### PR TITLE
typechecker: distribute generic aliases over closed unions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## Unreleased
+
+### Added
+
+- **Distributive instantiation of generic type aliases.** Applying a
+  generic `type F<T> = ...` alias to a closed union now expands into a
+  union of per-variant instantiations rather than leaving the union in
+  a single `T` slot. Concretely, for
+
+  ```harn
+  type Action = "create" | "edit"
+  type ActionContainer<T> = { action: T, process_action: fn(T) -> nil }
+  ```
+
+  the type `ActionContainer<Action>` now resolves as
+  `ActionContainer<"create"> | ActionContainer<"edit">`, which lets a
+  `fn("create") -> nil` handler flow into the `"create"` branch without
+  running aground on the contravariance of the function parameter.
+  This is the pattern TypeScript rejects in the classic
+  `Array<ActionContainer<Action>>` playground example; Harn now handles
+  it soundly via distribution at alias-application time in
+  `crates/harn-parser/src/typechecker/inference/subtyping.rs`. No new
+  syntax or keyword required — distribution is an implementation of
+  existing alias-application semantics.
+
+### Fixed
+
+- **Bare function references now carry their full `fn(...)` type.**
+  Previously, a top-level (or nested) function used as a plain value
+  (e.g. inside a dict literal) inferred as `None`, which collapsed to
+  `nil` at the surrounding inference site. A subsequent assignment into
+  a typed slot then failed with a misleading "got nil" diagnostic. The
+  typechecker now falls back from `scope.get_var` to `scope.get_fn`
+  when resolving bare identifiers, projecting the function signature
+  into a proper `FnType { params, return_type }`.
+
 ## v0.7.16
 
 ### Fixed

--- a/conformance/tests/type_adt_distributive.expected
+++ b/conformance/tests/type_adt_distributive.expected
@@ -1,0 +1,4 @@
+create create
+edit edit
+create create
+edit edit

--- a/conformance/tests/type_adt_distributive.harn
+++ b/conformance/tests/type_adt_distributive.harn
@@ -1,0 +1,42 @@
+// Ports the motivating TypeScript playground:
+//   type Action = 'create' | 'edit'
+//   type ActionContainer<T extends Action> = { action: T, processAction: (t: T) => void }
+//   const xs: Array<ActionContainer<Action>> = [
+//     {action: 'create', processAction: processCreate},
+//     {action: 'edit',   processAction: processEdit},
+//   ]
+//
+// TS rejects this because `processCreate: (t: "create") => void` doesn't
+// fit `(t: "create" | "edit") => void` under contravariance. Harn fixes
+// it by distributing `ActionContainer<Action>` over the closed literal
+// union, so each instantiation self-consistently fixes `T`:
+//   ActionContainer<"create"> | ActionContainer<"edit">
+// which is exactly the shape each literal-tagged element inhabits.
+type Action = "create" | "edit"
+
+type ActionContainer<T> = {action: T, process_action: fn(T) -> nil}
+
+fn process_create(a: "create") {
+  println("create " + a)
+}
+
+fn process_edit(a: "edit") {
+  println("edit " + a)
+}
+
+pipeline test(task) {
+  // Scalar case: each annotation distributes `ActionContainer<Action>`
+  // into `ActionContainer<"create"> | ActionContainer<"edit">`; the
+  // literal-tagged shape on the RHS then fits one specific branch.
+  let c1: ActionContainer<Action> = {action: "create", process_action: process_create}
+  let c2: ActionContainer<Action> = {action: "edit", process_action: process_edit}
+  c1.process_action(c1.action)
+  c2.process_action(c2.action)
+  // List case: the TS playground example verbatim. A heterogeneous
+  // list of container instances assigns into `list<ActionContainer<Action>>`
+  // because the element type distributes.
+  let containers: list<ActionContainer<Action>> = [{action: "create", process_action: process_create}, {action: "edit", process_action: process_edit}]
+  for c in containers {
+    c.process_action(c.action)
+  }
+}

--- a/crates/harn-parser/src/typechecker/inference/entry.rs
+++ b/crates/harn-parser/src/typechecker/inference/entry.rs
@@ -9,7 +9,8 @@
 use crate::ast::*;
 
 use super::super::scope::{
-    EnumDeclInfo, FnSignature, ImplMethodSig, InterfaceDeclInfo, StructDeclInfo, TypeScope,
+    EnumDeclInfo, FnSignature, ImplMethodSig, InterfaceDeclInfo, StructDeclInfo, TypeAliasInfo,
+    TypeScope,
 };
 use super::super::{InlayHintInfo, TypeChecker, TypeDiagnostic};
 
@@ -234,10 +235,16 @@ impl TypeChecker {
             match &snode.node {
                 Node::TypeDecl {
                     name,
-                    type_params: _,
+                    type_params,
                     type_expr,
                 } => {
-                    scope.type_aliases.insert(name.clone(), type_expr.clone());
+                    scope.type_aliases.insert(
+                        name.clone(),
+                        TypeAliasInfo {
+                            type_params: type_params.clone(),
+                            body: type_expr.clone(),
+                        },
+                    );
                 }
                 Node::EnumDecl {
                     name,

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -167,7 +167,29 @@ impl TypeChecker {
                 Some(TypeExpr::Named("closure".into()))
             }
 
-            Node::Identifier(name) => scope.get_var(name).cloned().flatten(),
+            Node::Identifier(name) => {
+                if let Some(ty) = scope.get_var(name).cloned().flatten() {
+                    return Some(ty);
+                }
+                // When a bare identifier names a top-level or nested function,
+                // treat the reference as an `fn(...) -> R` value. Prior to this,
+                // `Identifier` fell through to `None` for functions, which made
+                // function references in dict/list literals collapse to `nil`
+                // and silently break assignability against typed slots.
+                if let Some(sig) = scope.get_fn(name).cloned() {
+                    let params = sig
+                        .params
+                        .into_iter()
+                        .map(|(_, ty)| ty.unwrap_or_else(Self::wildcard_type))
+                        .collect();
+                    let return_type = sig.return_type.unwrap_or(TypeExpr::Named("nil".into()));
+                    return Some(TypeExpr::FnType {
+                        params,
+                        return_type: Box::new(return_type),
+                    });
+                }
+                None
+            }
 
             Node::FunctionCall { name, args } => {
                 // Struct constructor calls return the struct type

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -19,7 +19,8 @@ use super::super::exits::stmt_definitely_exits;
 use super::super::format::{format_type, is_obvious_type, shape_mismatch_detail};
 use super::super::schema_inference::schema_type_expr_from_node;
 use super::super::scope::{
-    EnumDeclInfo, FnSignature, ImplMethodSig, InterfaceDeclInfo, StructDeclInfo, TypeScope,
+    EnumDeclInfo, FnSignature, ImplMethodSig, InterfaceDeclInfo, StructDeclInfo, TypeAliasInfo,
+    TypeScope,
 };
 use super::super::union::narrow_to_single;
 use super::super::{InlayHintInfo, TypeChecker};
@@ -507,7 +508,13 @@ impl TypeChecker {
                 type_params,
                 type_expr,
             } => {
-                scope.type_aliases.insert(name.clone(), type_expr.clone());
+                scope.type_aliases.insert(
+                    name.clone(),
+                    TypeAliasInfo {
+                        type_params: type_params.clone(),
+                        body: type_expr.clone(),
+                    },
+                );
                 self.check_type_alias_decl_variance(type_params, type_expr, name, span);
             }
 

--- a/crates/harn-parser/src/typechecker/inference/subtyping.rs
+++ b/crates/harn-parser/src/typechecker/inference/subtyping.rs
@@ -434,16 +434,75 @@ impl TypeChecker {
                     .collect(),
                 return_type: Box::new(self.resolve_alias(return_type, scope)),
             },
-            TypeExpr::Applied { name, args } => TypeExpr::Applied {
-                name: name.clone(),
-                args: args
+            TypeExpr::Applied { name, args } => {
+                let resolved_args: Vec<TypeExpr> = args
                     .iter()
                     .map(|arg| self.resolve_alias(arg, scope))
-                    .collect(),
-            },
+                    .collect();
+                // If the constructor is a `type T<...> = ...` alias (as
+                // opposed to an enum/struct/interface), expand it by
+                // substituting the declared parameters with the supplied
+                // arguments. When an argument is a closed union, the
+                // instantiation distributes over the members to produce
+                // a union of substituted bodies. This is what lets
+                // `Container<A | B>` flow as `Container<A> | Container<B>`
+                // at use sites — each element self-consistently fixes
+                // its own `T`.
+                if let Some(info) = scope.resolve_type_alias(name) {
+                    if info.type_params.len() == resolved_args.len() {
+                        let names: Vec<String> =
+                            info.type_params.iter().map(|tp| tp.name.clone()).collect();
+                        let expanded =
+                            instantiate_alias_distributive(&info.body, &names, &resolved_args);
+                        return self.resolve_alias(&expanded, scope);
+                    }
+                }
+                TypeExpr::Applied {
+                    name: name.clone(),
+                    args: resolved_args,
+                }
+            }
             TypeExpr::Never => TypeExpr::Never,
             TypeExpr::LitString(s) => TypeExpr::LitString(s.clone()),
             TypeExpr::LitInt(v) => TypeExpr::LitInt(*v),
         }
+    }
+}
+
+/// Substitute `param_names[i] := args[i]` into `body`. When an argument is
+/// a `Union`, the body is cloned per union member and each result is
+/// unioned together — the "distributive" instantiation that makes
+/// `Container<A | B>` equal `Container<A> | Container<B>`.
+fn instantiate_alias_distributive(
+    body: &TypeExpr,
+    param_names: &[String],
+    args: &[TypeExpr],
+) -> TypeExpr {
+    debug_assert_eq!(param_names.len(), args.len());
+    let mut variants: Vec<std::collections::BTreeMap<String, TypeExpr>> =
+        vec![std::collections::BTreeMap::new()];
+    for (name, arg) in param_names.iter().zip(args.iter()) {
+        let members: Vec<TypeExpr> = match arg {
+            TypeExpr::Union(items) if !items.is_empty() => items.clone(),
+            other => vec![other.clone()],
+        };
+        let mut next = Vec::with_capacity(variants.len() * members.len());
+        for base in &variants {
+            for member in &members {
+                let mut extended = base.clone();
+                extended.insert(name.clone(), member.clone());
+                next.push(extended);
+            }
+        }
+        variants = next;
+    }
+    let mut results: Vec<TypeExpr> = variants
+        .into_iter()
+        .map(|bindings| TypeChecker::apply_type_bindings(body, &bindings))
+        .collect();
+    if results.len() == 1 {
+        results.pop().unwrap()
+    } else {
+        TypeExpr::Union(results)
     }
 }

--- a/crates/harn-parser/src/typechecker/scope.rs
+++ b/crates/harn-parser/src/typechecker/scope.rs
@@ -47,6 +47,16 @@ pub(super) struct EnumDeclInfo {
     pub(super) variants: Vec<EnumVariant>,
 }
 
+/// Full metadata for a `type T<...> = ...` alias. The type parameters are
+/// retained so that `Applied { name, args }` references can be expanded by
+/// substituting `type_params[i] := args[i]` into `body`, and closed-union
+/// arguments can be distributed into a union of instantiations.
+#[derive(Debug, Clone)]
+pub(super) struct TypeAliasInfo {
+    pub(super) type_params: Vec<TypeParam>,
+    pub(super) body: TypeExpr,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct StructDeclInfo {
     pub(super) type_params: Vec<TypeParam>,
@@ -67,8 +77,9 @@ pub(super) struct TypeScope {
     pub(super) vars: BTreeMap<String, InferredType>,
     /// Function name → (param types, return type).
     pub(super) functions: BTreeMap<String, FnSignature>,
-    /// Named type aliases.
-    pub(super) type_aliases: BTreeMap<String, TypeExpr>,
+    /// Named type aliases. Retains the declared type parameters so that
+    /// generic aliases can be expanded via substitution on `Applied`.
+    pub(super) type_aliases: BTreeMap<String, TypeAliasInfo>,
     /// Enum declarations with generic and variant metadata.
     pub(super) enums: BTreeMap<String, EnumDeclInfo>,
     /// Interface declarations with associated types and methods.
@@ -291,7 +302,17 @@ impl TypeScope {
     pub(super) fn resolve_type(&self, name: &str) -> Option<&TypeExpr> {
         self.type_aliases
             .get(name)
+            .map(|info| &info.body)
             .or_else(|| self.parent.as_ref()?.resolve_type(name))
+    }
+
+    /// Full alias metadata including declared type parameters. Used by
+    /// `resolve_alias` to expand `Applied { name, args }` references into
+    /// the alias body with substitutions applied.
+    pub(super) fn resolve_type_alias(&self, name: &str) -> Option<&TypeAliasInfo> {
+        self.type_aliases
+            .get(name)
+            .or_else(|| self.parent.as_ref()?.resolve_type_alias(name))
     }
 
     pub(super) fn is_generic_type_param(&self, name: &str) -> bool {

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -460,3 +460,77 @@ fn test_dict_invariant_int_to_float_rejected() {
         "expected dict<string, int> NOT to flow into dict<string, float>"
     );
 }
+
+#[test]
+fn test_generic_alias_distributes_over_closed_literal_union() {
+    // `ActionContainer<Action>` must distribute into
+    // `ActionContainer<"create"> | ActionContainer<"edit">`, which lets a
+    // `fn("create") -> nil` value flow into the `"create"` branch without
+    // running into contravariance grief (the TypeScript playground bug).
+    let errs = errors(
+        r#"
+type Action = "create" | "edit"
+type ActionContainer<T> = { action: T, process_action: fn(T) -> nil }
+
+fn process_create(a: "create") {}
+fn process_edit(a: "edit") {}
+
+pipeline t(task) {
+    let c: ActionContainer<Action> = {action: "create", process_action: process_create}
+    let d: ActionContainer<Action> = {action: "edit",   process_action: process_edit}
+}"#,
+    );
+    assert!(errs.is_empty(), "unexpected type errors: {errs:?}");
+}
+
+#[test]
+fn test_bare_function_reference_infers_fn_type() {
+    // Before the identifier-to-fn-type fallback, a bare function reference
+    // used as a value inferred to `None`, which meant it collapsed to
+    // `nil` when placed into a dict literal. That silently broke
+    // assignability against any typed `fn(...) -> R` slot.
+    let errs = errors(
+        r#"
+fn process(a: string) -> string { return a }
+
+pipeline t(task) {
+    let slot: fn(string) -> string = process
+    let d: { handler: fn(string) -> string } = { handler: process }
+}"#,
+    );
+    assert!(errs.is_empty(), "unexpected type errors: {errs:?}");
+}
+
+#[test]
+fn test_generic_alias_distribution_preserves_non_union_arg() {
+    // Non-union arguments still substitute plainly: `ActionContainer<int>`
+    // expands to `{ action: int, process_action: fn(int) -> nil }` with no
+    // distribution. A `fn(int) -> nil` handler fits; a `fn(string) -> nil`
+    // does not.
+    let ok_errs = errors(
+        r#"
+type ActionContainer<T> = { action: T, process_action: fn(T) -> nil }
+
+fn process_int(a: int) {}
+
+pipeline t(task) {
+    let c: ActionContainer<int> = {action: 7, process_action: process_int}
+}"#,
+    );
+    assert!(ok_errs.is_empty(), "expected no errors: {ok_errs:?}");
+
+    let bad_errs = errors(
+        r#"
+type ActionContainer<T> = { action: T, process_action: fn(T) -> nil }
+
+fn process_string(a: string) {}
+
+pipeline t(task) {
+    let c: ActionContainer<int> = {action: 7, process_action: process_string}
+}"#,
+    );
+    assert!(
+        !bad_errs.is_empty(),
+        "expected an error: `fn(string)` cannot fill an `fn(int)` slot"
+    );
+}


### PR DESCRIPTION
## Summary

- Generic `type F<T> = ...` aliases now distribute over closed-union arguments at use sites: `F<A | B>` resolves as `F<A> | F<B>`. This is the exact pattern TypeScript rejects in the classic `Array<ActionContainer<Action>>` playground — Harn now handles it soundly via distribution during alias expansion in [subtyping.rs](crates/harn-parser/src/typechecker/inference/subtyping.rs).
- Bare function references used as values (e.g. inside dict literals) now carry a proper `FnType` instead of collapsing to `nil`. [expressions.rs:170](crates/harn-parser/src/typechecker/inference/expressions.rs:170) falls back from `scope.get_var` to `scope.get_fn`.
- `type_aliases` scope bumps from `BTreeMap<String, TypeExpr>` to `BTreeMap<String, TypeAliasInfo>` so alias parameter lists reach the subtype checker.

Non-breaking (no surface syntax changes, only more-accepting subtype checks). No version bump — the bump + release is coordinated separately with the `burin-code` replatform.

This lands the headline slice of a larger type-system uplift. Follow-up work (discriminator narrowing on tagged shape unions, ADT unification, exhaustiveness-as-error, spec/docs/tree-sitter updates) is tracked for a separate breaking-change PR.

## Test plan

- [x] New motivating conformance test [type_adt_distributive.harn](conformance/tests/type_adt_distributive.harn) covers both the scalar `let c: ActionContainer<Action> = ...` and the list `list<ActionContainer<Action>>` forms from the TS playground.
- [x] Three new unit tests in [typing.rs](crates/harn-parser/src/typechecker/tests/typing.rs): distributive closed-union instantiation, non-union plain substitution, and the identifier-to-fn-type fallback.
- [x] `make test` — 1182/1182 nextest
- [x] `cargo run --bin harn -- test conformance` — 473/473
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `make lint-harn`, `make fmt-harn`, `make check-docs-snippets`
- [x] `(cd tree-sitter-harn && npm test)` — 16/16

🤖 Generated with [Claude Code](https://claude.com/claude-code)