### PR TITLE
feat(vm): OpenAI Responses-API native tool_search (harn#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,58 @@ granular archaeology.
   `skills/update` notification for host-driven hot-reload. See
   `docs/src/skills.md` for the full reference and
   `docs/src/bridge-protocol.md` for the wire format.
+- **Tool Vault phase 3: OpenAI Responses-API native `tool_search` (harn#71).**
+  `tool_search` now flows through OpenAI's native progressive-disclosure
+  mechanism on GPT 5.4+ with zero script changes: the capability gate
+  detects the model generation (via `gpt_generation()` — parses
+  `gpt-5.4-preview`, `gpt-5.4-turbo`, `gpt-5-4-20260115`, and
+  OpenRouter-style `openai/gpt-5.4` prefixes), prepends the meta-tool
+  `{"type": "tool_search", "mode": "hosted"}` to the tools array, and
+  emits `defer_loading: true` on each deferred user tool's wrapper.
+  Server-executed `tool_search_call` / `tool_search_output` entries in
+  the response get parsed into the same `tool_search_query` /
+  `tool_search_result` transcript events as the Anthropic path —
+  replays are indistinguishable across providers. OpenRouter, Together,
+  Groq, DeepSeek, Fireworks, HuggingFace, and `local` all inherit the
+  same capability check; when their routed model ID matches `gpt-5.4+`
+  they forward the payload unchanged.
+- **`namespace: "<label>"` on `tool_define(...)`** groups deferred tools
+  for OpenAI's `tool_search` meta-tool. Distinct namespaces are
+  collected into the meta-tool's `namespaces` field (sorted, deduped).
+  Anthropic ignores the label — harmless passthrough for replay
+  fidelity. Type-validated: non-string values error at `tool_define`
+  time so typos surface immediately.
+- **Escape hatch `<provider>: {force_native_tool_search: true}`** on
+  call options forces the hosted OpenAI path regardless of model
+  detection. Useful for self-hosted routers and enterprise gateways
+  whose model IDs Harn cannot parse but that forward `tool_search` +
+  `defer_loading` unchanged.
+- **Mock provider spoofs native capability by model generation.** When
+  a conformance test writes `provider: "mock", model: "gpt-5.4"` or
+  `"claude-sonnet-4-6"`, the capability gate reports native support so
+  the test can exercise the real native payload shape via
+  `llm_mock_calls()[0].tools`. Non-matching models still report no
+  native support (used by `tool_search_unsupported_provider.harn`).
+- **Response-parser coverage for OpenAI `tool_search_call` /
+  `tool_search_output`.** Both non-streaming and SSE streaming paths
+  now strip these blocks from the dispatchable `tool_calls` vector
+  (they're server-executed) and record them as transcript events with
+  the same shape Anthropic's `server_tool_use` /
+  `tool_search_tool_result` emits. The empty-response sanity check
+  exempts calls whose output consists entirely of these blocks.
+- **New `crates/harn-vm/src/llm/providers/openai_compat.rs` helpers.**
+  `gpt_generation(model)` parses major/minor from GPT model IDs;
+  `gpt_model_supports_tool_search(model)` gates on `(major, minor) >=
+  (5, 4)`. Unit-tested on dotted (`gpt-5.4`), dashed (`gpt-5-4`),
+  namespaced (`openai/gpt-5.4-turbo`), and dated
+  (`gpt-5-20260115` → `(5, 0)`, unsupported) forms.
+- **Conformance tests.** `tool_search_native_openai.{harn,expected}`
+  verifies the native injection + deferred-flag passthrough +
+  unsupported-model diagnostic. `tool_search_namespace.{harn,expected}`
+  verifies namespace passthrough through the registry, into the
+  OpenAI wrapper, and into the meta-tool's `namespaces` field.
+  `tool_search_provider_overrides.{harn,expected}` verifies the
+  escape hatch.
 - **Tool Vault phase 2: universal client-executed `tool_search` fallback (harn#70).**
   `tool_search` now works on every provider, not just the
   Anthropic-native path landed in phase 1. When the active provider
@@ -85,6 +137,15 @@ granular archaeology.
 
 ### Changed
 
+- **`tool_search_unsupported_provider.harn` pins `model: "gpt-4o"`**
+  (phase 3 / harn#71) so it continues to error on `mode: "native"`
+  after mock capability spoofing. The diagnostic still suggests
+  `mode: "client"` as the escape hatch; the error text is unchanged.
+- **Client-mode conformance tests now use `mode: "client"`
+  explicitly** (phase 3 / harn#71). With mock spoofing a Claude 4.0+
+  or GPT 5.4+ model, `mode: "auto"` would otherwise route through a
+  native path. The tests name themselves `tool_search_client_*`;
+  they now opt into the path they claim to cover.
 - Non-Anthropic providers no longer error when the user opts into
   `tool_search`. The phase-1 "no silent degradation" diagnostic that
   previously pointed at harn#70 is replaced by the actual fallback

--- a/conformance/tests/tool_search_client_bm25.harn
+++ b/conformance/tests/tool_search_client_bm25.harn
@@ -59,8 +59,18 @@ pipeline test(task) {
   let result = agent_loop(
     "Ship the release",
     nil,
-    {provider: "mock", tools: registry, tool_search: "bm25", persistent: true, max_iterations: 5},
+    {
+    provider: "mock",
+    tools: registry,
+    tool_search: {variant: "bm25", mode: "client"},
+    persistent: true,
+    max_iterations: 5,
+  },
   )
+  // Explicit `mode: "client"` — the mock provider now spoofs native
+  // tool_search when its (default) model looks like Claude 4.0+ or
+  // GPT 5.4+, which would otherwise route through the Anthropic
+  // native path. Client-mode tests must opt into the client path.
   let calls = llm_mock_calls()
   assert(len(calls) >= 2, "at least two LLM calls happened")
   // Turn 1 system prompt: synthetic tool visible, deferred tools hidden.

--- a/conformance/tests/tool_search_client_options.harn
+++ b/conformance/tests/tool_search_client_options.harn
@@ -101,11 +101,13 @@ pipeline test(task) {
     {
     provider: "mock",
     tools: big,
-    tool_search: {variant: "bm25", budget_tokens: 150},
+    tool_search: {variant: "bm25", mode: "client", budget_tokens: 150},
     persistent: true,
     max_iterations: 5,
   },
   )
+  // Explicit `mode: "client"` — mock now spoofs native tool_search
+  // for its default Claude model after harn#71.
   // After three turns: gamma promoted, alpha+beta evicted.
   let calls2 = llm_mock_calls()
   let last_system = calls2[len(calls2) - 1].system

--- a/conformance/tests/tool_search_client_regex.harn
+++ b/conformance/tests/tool_search_client_regex.harn
@@ -53,8 +53,17 @@ pipeline test(task) {
   let result = agent_loop(
     "Refactor the file",
     nil,
-    {provider: "mock", tools: registry, tool_search: "regex", persistent: true, max_iterations: 5},
+    {
+    provider: "mock",
+    tools: registry,
+    tool_search: {variant: "regex", mode: "client"},
+    persistent: true,
+    max_iterations: 5,
+  },
   )
+  // Explicit `mode: "client"` — mock spoofs native tool_search for
+  // Claude 4.0+ / GPT 5.4+ default models after harn#71, so
+  // client-mode tests must opt into the client path explicitly.
   let events = transcript_events(result?.transcript)
   var found_regex_strategy = false
   var promoted_edit = false

--- a/conformance/tests/tool_search_namespace.expected
+++ b/conformance/tests/tool_search_namespace.expected
@@ -1,0 +1,1 @@
+[harn] tool_search_namespace tests passed

--- a/conformance/tests/tool_search_namespace.harn
+++ b/conformance/tests/tool_search_namespace.harn
@@ -1,0 +1,111 @@
+// Tool Vault phase 3 (harn#71): `namespace` field on tool registry
+// entries groups deferred tools for OpenAI's `tool_search` meta-tool.
+// Anthropic ignores the field; Harn passes it through either way so
+// replays remain faithful and future versions can adopt the semantic
+// without another round of schema plumbing.
+pipeline test(task) {
+  llm_mock_clear()
+  var registry = tool_registry()
+  registry = tool_define(
+    registry,
+    "anchor",
+    "Always-on tool",
+    {parameters: {op: {type: "string"}}, handler: { _ -> "ok" }},
+  )
+  registry = tool_define(
+    registry,
+    "deploy_api",
+    "Deploy the API service",
+    {
+    parameters: {env: {type: "string"}},
+    defer_loading: true,
+    namespace: "ops",
+    handler: { args -> "deployed api to " + args.env },
+  },
+  )
+  registry = tool_define(
+    registry,
+    "deploy_web",
+    "Deploy the web frontend",
+    {
+    parameters: {env: {type: "string"}},
+    defer_loading: true,
+    namespace: "ops",
+    handler: { args -> "deployed web to " + args.env },
+  },
+  )
+  registry = tool_define(
+    registry,
+    "lookup_customer",
+    "Look up a customer record",
+    {
+    parameters: {id: {type: "string"}},
+    defer_loading: true,
+    namespace: "crm",
+    handler: { args -> "customer " + args.id },
+  },
+  )
+  // Registry inspection: namespace survives into tool_list metadata.
+  let tools = tool_list(registry)
+  var deploy_api_ns = nil
+  var lookup_ns = nil
+  for t in tools {
+    if t.name == "deploy_api" {
+      deploy_api_ns = t.namespace
+    }
+    if t.name == "lookup_customer" {
+      lookup_ns = t.namespace
+    }
+  }
+  assert(deploy_api_ns == "ops", "namespace preserved in registry")
+  assert(lookup_ns == "crm", "second namespace preserved")
+  // Payload emission: for a supported gpt-5.4+ model with
+  // `mode: "native"`, the OpenAI meta-tool collects distinct
+  // namespaces into its `namespaces` field.
+  llm_mock({text: "ack"})
+  llm_call(
+    "x",
+    nil,
+    {
+    provider: "mock",
+    model: "gpt-5.4-preview",
+    tools: registry,
+    tool_search: {variant: "bm25", mode: "native"},
+  },
+  )
+  let calls = llm_mock_calls()
+  let meta = calls[0].tools[0]
+  assert(meta.type == "tool_search", "meta-tool in slot 0")
+  let ns_list = meta.namespaces
+  assert(ns_list != nil, "meta-tool carries namespaces")
+  assert(len(ns_list) == 2, "two distinct namespaces")
+  // `namespaces` is sorted for determinism.
+  assert(ns_list[0] == "crm", "crm sorts first")
+  assert(ns_list[1] == "ops", "ops second")
+  // Individual user tools still carry their namespace.
+  var saw_deploy_api_ns = false
+  for t in calls[0].tools {
+    if t.type == "function" {
+      let fname = t.function?.name
+      if fname == "deploy_api" {
+        assert(t.namespace == "ops", "deploy_api.namespace reaches OpenAI wrapper")
+        saw_deploy_api_ns = true
+      }
+    }
+  }
+  assert(saw_deploy_api_ns, "deploy_api namespace passthrough confirmed")
+  // Type validation: a non-string namespace is rejected by tool_define.
+  let caught_bad_ns = try {
+    tool_define(
+    tool_registry(),
+    "busted",
+    "bad namespace",
+    {parameters: {}, namespace: 42, handler: { _ -> "ok" }},
+  )
+    false
+  } catch (e) {
+    true
+  }
+  assert(caught_bad_ns, "non-string namespace must be rejected")
+  log("tool_search_namespace tests passed")
+}

--- a/conformance/tests/tool_search_native_openai.expected
+++ b/conformance/tests/tool_search_native_openai.expected
@@ -1,0 +1,1 @@
+[harn] tool_search_native_openai tests passed

--- a/conformance/tests/tool_search_native_openai.harn
+++ b/conformance/tests/tool_search_native_openai.harn
@@ -1,0 +1,110 @@
+// Tool Vault phase 3 (harn#71): native OpenAI Responses-API
+// `tool_search` payload emission for GPT 5.4+. Verifies that:
+//   1. Opting into `tool_search` routes auto-resolution to native
+//      mode when the provider+model supports it.
+//   2. The payload prepends the OpenAI-shape meta-tool
+//      `{"type": "tool_search", "mode": "hosted"}` to the tools
+//      array (distinct from Anthropic's versioned
+//      `tool_search_tool_*_20251119`).
+//   3. `defer_loading: true` flows to the OpenAI-shape wrapper so
+//      the server knows which user tools to hide from the model
+//      until a `tool_search_call` surfaces them.
+//   4. `mode: "native"` against a pre-5.4 GPT model fires the same
+//      "does not expose native" diagnostic as other non-supporting
+//      providers.
+pipeline test(task) {
+  llm_mock_clear()
+  var registry = tool_registry()
+  registry = tool_define(
+    registry,
+    "lookup_account",
+    "Read an account record (always available)",
+    {parameters: {id: {type: "string"}}, handler: { args -> "acct " + args.id }},
+  )
+  registry = tool_define(
+    registry,
+    "deploy_service",
+    "Deploy the service stack",
+    {
+    parameters: {env: {type: "string"}},
+    defer_loading: true,
+    handler: { args -> "deployed to " + args.env },
+  },
+  )
+  registry = tool_define(
+    registry,
+    "query_metrics",
+    "Query observability metrics",
+    {
+    parameters: {query: {type: "string"}},
+    defer_loading: true,
+    handler: { args -> "metrics: " + args.query },
+  },
+  )
+  // One-shot llm_call: with mode:"native" + a supported gpt-5.4 model,
+  // options parsing must inject the OpenAI meta-tool and preserve the
+  // deferred flags. The mock provider won't actually call the tools —
+  // we just need a response that lets the call return so we can
+  // inspect `llm_mock_calls()`.
+  llm_mock({text: "ack"})
+  llm_call(
+    "do a thing",
+    nil,
+    {
+    provider: "mock",
+    model: "gpt-5.4-preview",
+    tools: registry,
+    tool_search: {variant: "bm25", mode: "native"},
+  },
+  )
+  let calls = llm_mock_calls()
+  assert(len(calls) >= 1, "at least one LLM call happened")
+  let tools = calls[0].tools
+  assert(tools != nil, "tools captured")
+  assert(len(tools) == 4, "meta-tool + 3 user tools = 4")
+  // First entry is the OpenAI-shape `tool_search` meta-tool.
+  let meta = tools[0]
+  assert(meta.type == "tool_search", "OpenAI meta-tool uses the `tool_search` type")
+  assert(meta.mode == "hosted", "native path defaults to hosted mode")
+  assert(meta.name == nil, "OpenAI meta-tool has no `name` field")
+  // User tools follow, preserving `defer_loading` on the wrapper.
+  var saw_deploy_deferred = false
+  var saw_metrics_deferred = false
+  var saw_lookup_eager = false
+  for t in tools {
+    if t.type == "function" {
+      let fname = t.function?.name
+      if fname == "deploy_service" {
+        assert(t.defer_loading == true, "deploy_service keeps defer_loading: true")
+        saw_deploy_deferred = true
+      }
+      if fname == "query_metrics" {
+        assert(t.defer_loading == true, "query_metrics keeps defer_loading: true")
+        saw_metrics_deferred = true
+      }
+      if fname == "lookup_account" {
+        assert(t.defer_loading == nil, "eager tool has no defer_loading flag")
+        saw_lookup_eager = true
+      }
+    }
+  }
+  assert(saw_deploy_deferred, "deploy_service present + deferred")
+  assert(saw_metrics_deferred, "query_metrics present + deferred")
+  assert(saw_lookup_eager, "lookup_account present + eager")
+  // Negative path: mode:"native" on a pre-5.4 GPT fires the same
+  // diagnostic the unsupported-provider test uses.
+  llm_mock_clear()
+  let pre54_err = try {
+    llm_call(
+    "x",
+    nil,
+    {provider: "mock", model: "gpt-4o", tools: registry, tool_search: {variant: "bm25", mode: "native"}},
+  )
+    nil
+  } catch (e) {
+    e
+  }
+  assert(pre54_err != nil, "pre-5.4 gpt rejects native")
+  assert(pre54_err.contains("does not expose native"), "diagnostic mentions missing native support")
+  log("tool_search_native_openai tests passed")
+}

--- a/conformance/tests/tool_search_provider_overrides.expected
+++ b/conformance/tests/tool_search_provider_overrides.expected
@@ -1,0 +1,1 @@
+[harn] tool_search_provider_overrides tests passed

--- a/conformance/tests/tool_search_provider_overrides.harn
+++ b/conformance/tests/tool_search_provider_overrides.harn
@@ -1,0 +1,66 @@
+// Tool Vault phase 3 (harn#71): `provider_overrides.<name>.force_native_tool_search`
+// escape hatch for proxied OpenAI-compat endpoints. A self-hosted router
+// or enterprise gateway may advertise a model ID Harn cannot parse
+// (`my-internal-gpt-clone-v2`), yet forward OpenAI's `tool_search` +
+// `defer_loading` fields unchanged. The override lets the user assert
+// that capability and opt into the native path.
+pipeline test(task) {
+  llm_mock_clear()
+  var registry = tool_registry()
+  registry = tool_define(
+    registry,
+    "anchor",
+    "Always-on tool",
+    {parameters: {op: {type: "string"}}, handler: { _ -> "ok" }},
+  )
+  registry = tool_define(
+    registry,
+    "deploy",
+    "Deploy the app",
+    {
+    parameters: {env: {type: "string"}},
+    defer_loading: true,
+    handler: { args -> "deployed to " + args.env },
+  },
+  )
+  // Without the override: Harn cannot parse "my-internal-model", so
+  // `mode: "native"` errors out.
+  let err_without = try {
+    llm_call(
+    "x",
+    nil,
+    {
+    provider: "mock",
+    model: "my-internal-model",
+    tools: registry,
+    tool_search: {variant: "bm25", mode: "native"},
+  },
+  )
+    nil
+  } catch (e) {
+    e
+  }
+  assert(err_without != nil, "unparsable model rejects native without override")
+  assert(err_without.contains("does not expose native"), "helpful diagnostic fired")
+  // With the override: the same config succeeds and emits the OpenAI
+  // meta-tool. `provider_overrides` is keyed by provider name so the
+  // same call can pass multiple provider-specific flags.
+  llm_mock_clear()
+  llm_mock({text: "ack"})
+  llm_call(
+    "x",
+    nil,
+    {
+    provider: "mock",
+    model: "my-internal-model",
+    tools: registry,
+    tool_search: {variant: "bm25", mode: "native"},
+    mock: {force_native_tool_search: true},
+  },
+  )
+  let calls = llm_mock_calls()
+  let meta = calls[0].tools[0]
+  assert(meta.type == "tool_search", "escape hatch emits OpenAI meta-tool")
+  assert(meta.mode == "hosted", "defaults to hosted mode")
+  log("tool_search_provider_overrides tests passed")
+}

--- a/conformance/tests/tool_search_unsupported_provider.harn
+++ b/conformance/tests/tool_search_unsupported_provider.harn
@@ -2,10 +2,11 @@
 //
 // Phase 1 (#69) added native tool_search on Anthropic Claude 4.0+
 // Opus/Sonnet and Haiku 4.5+. Phase 2 (#70) added the client-executed
-// fallback for everyone else, so `mode: "auto"` and `mode: "client"`
-// both succeed against the mock provider now. Only `mode: "native"`
-// still errors when the provider has no native support, pointing at
-// the client fallback as the fix.
+// fallback for everyone else. Phase 3 (#71) added OpenAI Responses-API
+// native support at GPT 5.4+. `mode: "auto"` and `mode: "client"` both
+// succeed against the mock provider; only `mode: "native"` on a
+// (provider, model) pair that exposes no native path still errors,
+// pointing at the client fallback as the fix.
 pipeline test(task) {
   var registry = tool_registry()
   registry = tool_define(
@@ -24,13 +25,17 @@ pipeline test(task) {
     handler: { args -> "deployed to " + args.env },
   },
   )
-  // mode: "native" against an unsupported provider → error with
-  // "does not expose native" text and a pointer to the client fallback.
+  // mode: "native" against an unsupported (provider, model) → error
+  // with "does not expose native" text and a pointer to the client
+  // fallback. Pin the model explicitly to `gpt-4o`: pre-harn#71 this
+  // path only gated on provider name, but mock now spoofs OpenAI
+  // capability by model generation. `gpt-4o` is below the 5.4 cutoff
+  // so the error still fires.
   let native_err = try {
     llm_call(
     "hello",
     nil,
-    {provider: "mock", tools: registry, tool_search: {variant: "bm25", mode: "native"}},
+    {provider: "mock", model: "gpt-4o", tools: registry, tool_search: {variant: "bm25", mode: "native"}},
   )
     nil
   } catch (e) {

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -1535,6 +1535,49 @@ fn parse_llm_response(
         let mut tool_calls = Vec::new();
         if let Some(calls) = message["tool_calls"].as_array() {
             for call in calls {
+                // OpenAI Responses-API tool_search (harn#71) emits
+                // `tool_search_call` blocks when the server-hosted
+                // search runs. These are NOT dispatchable tools — the
+                // server executes them for us — so we record the query
+                // as a transcript event and continue without touching
+                // tool_calls. `tool_search_output` blocks on the
+                // response carry server results and are recorded
+                // symmetrically.
+                let call_type = call["type"].as_str().unwrap_or("");
+                if call_type == "tool_search_call" {
+                    let id = call["id"].as_str().unwrap_or("").to_string();
+                    let query = call.get("query").cloned().unwrap_or_else(|| {
+                        call.get("input")
+                            .cloned()
+                            .unwrap_or(serde_json::Value::Null)
+                    });
+                    blocks.push(serde_json::json!({
+                        "type": "tool_search_query",
+                        "id": id,
+                        "name": "tool_search",
+                        "query": query,
+                        "visibility": "internal",
+                    }));
+                    continue;
+                }
+                if call_type == "tool_search_output" {
+                    let tool_use_id = call["call_id"]
+                        .as_str()
+                        .or_else(|| call["id"].as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let references = call["tool_references"]
+                        .as_array()
+                        .cloned()
+                        .unwrap_or_default();
+                    blocks.push(serde_json::json!({
+                        "type": "tool_search_result",
+                        "tool_use_id": tool_use_id,
+                        "tool_references": references,
+                        "visibility": "internal",
+                    }));
+                    continue;
+                }
                 let name = call["function"]["name"].as_str().unwrap_or("").to_string();
                 let args_str = call["function"]["arguments"].as_str().unwrap_or("{}");
                 let arguments: serde_json::Value = match serde_json::from_str(args_str) {
@@ -1573,10 +1616,24 @@ fn parse_llm_response(
             .as_str()
             .map(|s| s.to_string());
 
+        // OpenAI Responses-API `tool_search_call` / `tool_search_output`
+        // blocks (harn#71) are server-executed and get stripped from
+        // `tool_calls` during parsing; they show up only as transcript
+        // blocks. Count their presence as "did deliver something" so
+        // the empty-response error below doesn't trip when the
+        // server's response consisted entirely of a search
+        // query/result exchange.
+        let has_tool_search_block = blocks.iter().any(|b| {
+            matches!(
+                b.get("type").and_then(|v| v.as_str()),
+                Some("tool_search_query") | Some("tool_search_result")
+            )
+        });
         if text.is_empty()
             && extracted_thinking.is_empty()
             && output_tokens > 0
             && tool_calls.is_empty()
+            && !has_tool_search_block
         {
             return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
                 "openai-compatible model {model} reported completion_tokens={output_tokens} but delivered no content, reasoning, or tool calls"
@@ -1865,6 +1922,44 @@ async fn vm_call_llm_api_sse_from_response(
 
             if let Some(tcs) = delta["tool_calls"].as_array() {
                 for tc in tcs {
+                    // OpenAI Responses-API server-side tool_search
+                    // (harn#71) streams as `tool_search_call` /
+                    // `tool_search_output` entries in the tool_calls
+                    // array. Record them as transcript events, never
+                    // as dispatchable calls.
+                    let tc_type = tc["type"].as_str().unwrap_or("");
+                    if tc_type == "tool_search_call" {
+                        let id = tc["id"].as_str().unwrap_or("").to_string();
+                        let query = tc.get("query").cloned().unwrap_or_else(|| {
+                            tc.get("input").cloned().unwrap_or(serde_json::Value::Null)
+                        });
+                        blocks.push(serde_json::json!({
+                            "type": "tool_search_query",
+                            "id": id,
+                            "name": "tool_search",
+                            "query": query,
+                            "visibility": "internal",
+                        }));
+                        continue;
+                    }
+                    if tc_type == "tool_search_output" {
+                        let tool_use_id = tc["call_id"]
+                            .as_str()
+                            .or_else(|| tc["id"].as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let references = tc["tool_references"]
+                            .as_array()
+                            .cloned()
+                            .unwrap_or_default();
+                        blocks.push(serde_json::json!({
+                            "type": "tool_search_result",
+                            "tool_use_id": tool_use_id,
+                            "tool_references": references,
+                            "visibility": "internal",
+                        }));
+                        continue;
+                    }
                     let idx = tc["index"].as_u64().unwrap_or(0);
                     let entry = oai_tool_map.entry(idx).or_insert_with(|| {
                         let id = tc["id"].as_str().unwrap_or("").to_string();
@@ -1922,7 +2017,18 @@ async fn vm_call_llm_api_sse_from_response(
         blocks
             .push(serde_json::json!({"type": "output_text", "text": text, "visibility": "public"}));
     }
-    if text.is_empty() && thinking_text.is_empty() && output_tokens > 0 && tool_calls.is_empty() {
+    let has_tool_search_block = blocks.iter().any(|b| {
+        matches!(
+            b.get("type").and_then(|v| v.as_str()),
+            Some("tool_search_query") | Some("tool_search_result")
+        )
+    });
+    if text.is_empty()
+        && thinking_text.is_empty()
+        && output_tokens > 0
+        && tool_calls.is_empty()
+        && !has_tool_search_block
+    {
         return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
             "openai-compatible model {model} reported completion_tokens={output_tokens} but delivered no content, reasoning, or tool calls"
         )))));
@@ -3369,6 +3475,86 @@ mod tests {
             "expected tool_search_query block; got {:#?}",
             result.blocks
         );
+    }
+
+    #[test]
+    fn openai_parser_records_tool_search_call_as_query_event() {
+        // OpenAI's Responses API (harn#71) surfaces the server-hosted
+        // tool_search as a `tool_search_call` entry in the `tool_calls`
+        // array. The parser must NOT add it to the dispatchable
+        // `tool_calls` vector — OpenAI runs the search on their side —
+        // but must record a `tool_search_query` transcript block so
+        // replay lines up with the Anthropic path.
+        let resolved = super::super::helpers::ResolvedProvider::resolve("openai");
+        let response = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "searching",
+                    "tool_calls": [
+                        {
+                            "id": "tsc_01",
+                            "type": "tool_search_call",
+                            "query": {"q": "weather"}
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5}
+        });
+        let result = super::parse_llm_response(&response, "openai", "gpt-5.4-preview", &resolved)
+            .expect("parser succeeds");
+
+        assert!(
+            result.tool_calls.is_empty(),
+            "tool_search_call is server-executed; must not be dispatchable"
+        );
+        let query = result
+            .blocks
+            .iter()
+            .find(|b| b.get("type").and_then(|v| v.as_str()) == Some("tool_search_query"))
+            .expect("tool_search_query block present");
+        assert_eq!(query["id"].as_str(), Some("tsc_01"));
+        assert_eq!(query["query"]["q"].as_str(), Some("weather"));
+    }
+
+    #[test]
+    fn openai_parser_records_tool_search_output_as_result_event() {
+        let resolved = super::super::helpers::ResolvedProvider::resolve("openai");
+        let response = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tso_01",
+                            "type": "tool_search_output",
+                            "call_id": "tsc_01",
+                            "tool_references": [
+                                {"tool_name": "get_weather"}
+                            ]
+                        }
+                    ]
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1}
+        });
+        let result = super::parse_llm_response(&response, "openai", "gpt-5.4-preview", &resolved)
+            .expect("parser succeeds");
+
+        assert!(result.tool_calls.is_empty());
+        let result_block = result
+            .blocks
+            .iter()
+            .find(|b| b.get("type").and_then(|v| v.as_str()) == Some("tool_search_result"))
+            .expect("tool_search_result block present");
+        assert_eq!(result_block["tool_use_id"].as_str(), Some("tsc_01"));
+        let refs = result_block["tool_references"]
+            .as_array()
+            .expect("tool_references array");
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0]["tool_name"].as_str(), Some("get_weather"));
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -24,10 +24,51 @@ pub(crate) fn expects_structured_output(opts: &crate::llm::api::LlmCallOptions) 
 /// Three-way resolution of `tool_search.mode` against the provider's
 /// native capability. Kept as a private enum so the option-parse path
 /// reads linearly; the `Client` variant feeds the harn#70 fallback
-/// injection, the `Native` variant feeds the phase-1 Anthropic path.
+/// injection, the `Native` variant feeds the phase-1 Anthropic path
+/// (and phase-2 OpenAI path via harn#71).
 enum ToolSearchResolution {
     Native,
     Client,
+}
+
+/// Read the `provider_overrides.force_native_tool_search` escape hatch
+/// (bool). Set to true when a user is pointed at a proxied OpenAI-compat
+/// endpoint (self-hosted router, enterprise gateway) whose model ID
+/// Harn cannot parse but that is known to forward `tool_search` +
+/// `defer_loading` unchanged.
+fn provider_overrides_force_native(
+    options: Option<&BTreeMap<String, VmValue>>,
+    provider: &str,
+) -> bool {
+    let Some(options) = options else { return false };
+    let Some(VmValue::Dict(overrides)) = options.get(provider) else {
+        return false;
+    };
+    matches!(
+        overrides.get("force_native_tool_search"),
+        Some(VmValue::Bool(true))
+    )
+}
+
+/// Decide which wire shape this (provider, model) pair should emit for
+/// the native tool-search meta-tool. Anthropic + Claude → Anthropic
+/// shape; anything else → OpenAI shape. For `provider: "mock"` we
+/// inspect the model string so conformance tests can spoof either
+/// backend without HTTP.
+fn classify_native_shape(
+    provider: &str,
+    model: &str,
+) -> crate::llm::provider::NativeToolSearchShape {
+    use crate::llm::provider::NativeToolSearchShape;
+    if provider == "anthropic" {
+        return NativeToolSearchShape::Anthropic;
+    }
+    if provider == "mock"
+        && crate::llm::providers::anthropic::claude_model_supports_tool_search(model)
+    {
+        return NativeToolSearchShape::Anthropic;
+    }
+    NativeToolSearchShape::OpenAi
 }
 
 /// Extract all LLM call options from the standard (prompt, system, options) args.
@@ -36,9 +77,7 @@ pub(crate) fn extract_llm_options(
 ) -> Result<crate::llm::api::LlmCallOptions, VmError> {
     use crate::llm::api::{LlmCallOptions, ThinkingConfig, ToolSearchMode, ToolSearchVariant};
     use crate::llm::provider::{provider_supports_defer_loading, provider_tool_search_variants};
-    use crate::llm::tools::{
-        apply_tool_search_native_injection, extract_deferred_tool_names, vm_tools_to_native,
-    };
+    use crate::llm::tools::{extract_deferred_tool_names, vm_tools_to_native};
 
     let prompt = args.first().map(|a| a.display()).unwrap_or_default();
     let system = args.get(1).and_then(|a| {
@@ -151,15 +190,30 @@ pub(crate) fn extract_llm_options(
     if let Some(cfg) = tool_search.as_mut() {
         // Resolve tool_search against the active provider now. Three
         // possible outcomes:
-        //   - native: prepend the provider's meta-tool (Anthropic path).
+        //   - native: prepend the provider's meta-tool (Anthropic path
+        //     for Claude 4.0+; OpenAI Responses-API path for GPT 5.4+).
         //   - client: keep native_tools as-is so the agent loop can
         //     strip deferred tools per-turn and inject the synthetic
         //     `__harn_tool_search` dispatchable.
         //   - error: explicit native mode on a provider that cannot
         //     satisfy it.
         let native_variants = provider_tool_search_variants(&provider, &model);
-        let provider_has_native =
+        let model_based_native =
             provider_supports_defer_loading(&provider, &model) && !native_variants.is_empty();
+        // Escape hatch for proxied OpenAI-compat providers whose model
+        // ID Harn cannot parse. The override forces the OpenAI
+        // Responses-API shape; user asserts the endpoint forwards
+        // `tool_search` + `defer_loading` unchanged.
+        let forced = provider_overrides_force_native(options.as_ref(), &provider);
+        let provider_has_native = model_based_native || forced;
+        // If the forced path is active, use OpenAI's default variants
+        // so the injection below picks the right shape.
+        let forced_variants: &'static [&'static str] = &["hosted", "client"];
+        let effective_variants = if forced && native_variants.is_empty() {
+            forced_variants
+        } else {
+            native_variants
+        };
         let resolution = match cfg.mode {
             ToolSearchMode::Native => {
                 if !provider_has_native {
@@ -202,34 +256,66 @@ pub(crate) fn extract_llm_options(
 
         match resolution {
             ToolSearchResolution::Native => {
-                // Confirm the requested variant is actually supported;
-                // downgrade with a warning if not (future-proof for any
-                // future provider that only exposes one variant).
-                if !native_variants.contains(&cfg.variant.as_short()) {
-                    crate::events::log_warn(
-                        "llm.tool_search",
-                        &format!(
-                            "provider \"{provider}\" model \"{model}\" does not support \
-                             tool_search variant \"{}\"; falling back to \"{}\"",
-                            cfg.variant.as_short(),
-                            native_variants[0],
-                        ),
-                    );
-                }
-
-                let effective_variant = if native_variants.contains(&cfg.variant.as_short()) {
-                    cfg.variant
-                } else {
-                    match native_variants[0] {
-                        "regex" => ToolSearchVariant::Regex,
-                        _ => ToolSearchVariant::Bm25,
+                // Classify the native wire shape for this provider so
+                // the injection and response parser agree on what to
+                // emit / look for. Anthropic path emits the
+                // `tool_search_tool_*_20251119` meta-tool; OpenAI path
+                // emits `{"type": "tool_search"}`. For the "mock"
+                // provider we infer from the model string so
+                // conformance tests can exercise both paths without
+                // HTTP. See `provider_native_tool_search_shape`.
+                let shape = classify_native_shape(&provider, &model);
+                match shape {
+                    crate::llm::provider::NativeToolSearchShape::Anthropic => {
+                        // Anthropic exposes {bm25, regex}. Variant
+                        // names are documented in
+                        // `effective_variants`; fall back to element 0
+                        // with a warn if the user asked for something
+                        // this model doesn't support.
+                        if !effective_variants.contains(&cfg.variant.as_short()) {
+                            crate::events::log_warn(
+                                "llm.tool_search",
+                                &format!(
+                                    "provider \"{provider}\" model \"{model}\" does not support \
+                                     tool_search variant \"{}\"; falling back to \"{}\"",
+                                    cfg.variant.as_short(),
+                                    effective_variants[0],
+                                ),
+                            );
+                        }
+                        let effective_variant =
+                            if effective_variants.contains(&cfg.variant.as_short()) {
+                                cfg.variant
+                            } else {
+                                match effective_variants[0] {
+                                    "regex" => ToolSearchVariant::Regex,
+                                    _ => ToolSearchVariant::Bm25,
+                                }
+                            };
+                        crate::llm::tools::apply_tool_search_native_injection_typed(
+                            &mut native_tools,
+                            shape,
+                            effective_variant.as_short(),
+                            "hosted",
+                        );
                     }
-                };
-                apply_tool_search_native_injection(
-                    &mut native_tools,
-                    &provider,
-                    effective_variant.as_short(),
-                );
+                    crate::llm::provider::NativeToolSearchShape::OpenAi => {
+                        // OpenAI Responses API exposes hosted + client
+                        // modes. When the user picked `mode: "native"`
+                        // they meant "let OpenAI handle the search on
+                        // their side" — the hosted mode. Users who want
+                        // Harn to execute the search locally should
+                        // write `mode: "client"`, which flows through
+                        // the harn#70 synthetic-tool path below (same
+                        // ergonomics across every provider).
+                        crate::llm::tools::apply_tool_search_native_injection_typed(
+                            &mut native_tools,
+                            shape,
+                            cfg.variant.as_short(),
+                            "hosted",
+                        );
+                    }
+                }
             }
             ToolSearchResolution::Client => {
                 // Client mode: capture the deferred tool bodies into

--- a/crates/harn-vm/src/llm/provider.rs
+++ b/crates/harn-vm/src/llm/provider.rs
@@ -148,11 +148,38 @@ pub(crate) fn registered_provider_names() -> Vec<String> {
 /// capability logic in one place so callers don't reach into provider
 /// structs directly.
 pub(crate) fn provider_supports_defer_loading(provider: &str, model: &str) -> bool {
+    // `provider_overrides.force_native_tool_search = true` is the escape
+    // hatch for users pointed at a proxied OpenAI-compat endpoint (a
+    // self-hosted router, an enterprise gateway) whose model ID we
+    // cannot parse. The caller consults the override in `options.rs`
+    // before falling through here, so this function is the model-
+    // detection path only.
     match provider {
         "anthropic" => super::providers::AnthropicProvider.supports_defer_loading(model),
-        // OpenAI's native defer_loading support lands with the Responses
-        // API work in harn#71; stays `false` until then.
-        "openai" | "openrouter" => false,
+        // OpenAI's native `tool_search` + `defer_loading` land on the
+        // Responses API at GPT 5.4+. Every OpenAI-shape provider
+        // (OpenAI, OpenRouter, Together, Groq, DeepSeek, Fireworks,
+        // HuggingFace, local vLLM) delegates to the same capability
+        // check; whether the underlying backend actually forwards the
+        // payload is up to that backend. OpenRouter in particular
+        // forwards `tool_search` unchanged for upstream OpenAI routes.
+        "openai" | "openrouter" | "together" | "groq" | "deepseek" | "fireworks"
+        | "huggingface" | "local" => {
+            super::providers::OpenAiCompatibleProvider::new(provider.to_string())
+                .supports_defer_loading(model)
+        }
+        // Mock: spoof the real provider whose shape the model ID
+        // suggests. This lets conformance tests exercise the native
+        // Anthropic/OpenAI paths without making HTTP calls. The mock's
+        // tool-capture surface (llm_mock_calls) records the native
+        // payload so tests can assert on it directly.
+        "mock" => {
+            if super::providers::anthropic::claude_model_supports_tool_search(model) {
+                true
+            } else {
+                super::providers::openai_compat::gpt_model_supports_tool_search(model)
+            }
+        }
         // Everything else: no native support — use the client-executed
         // fallback tracked in harn#70.
         _ => false,
@@ -166,6 +193,32 @@ pub(crate) fn provider_tool_search_variants(
 ) -> &'static [&'static str] {
     match provider {
         "anthropic" => super::providers::AnthropicProvider.native_tool_search_variants(model),
+        "openai" | "openrouter" | "together" | "groq" | "deepseek" | "fireworks"
+        | "huggingface" | "local" => {
+            super::providers::OpenAiCompatibleProvider::new(provider.to_string())
+                .native_tool_search_variants(model)
+        }
+        "mock" => {
+            if super::providers::anthropic::claude_model_supports_tool_search(model) {
+                super::providers::AnthropicProvider.native_tool_search_variants(model)
+            } else {
+                super::providers::OpenAiCompatibleProvider::new("openai".to_string())
+                    .native_tool_search_variants(model)
+            }
+        }
         _ => &[],
     }
+}
+
+/// Which wire shape to emit for the native tool-search meta-tool. Kept
+/// in one place so the options layer, the tools builder, and the
+/// response parser all agree on who emits what. Anthropic emits
+/// `tool_search_tool_*_20251119` meta-tools; OpenAI-shape providers
+/// emit `{"type": "tool_search"}`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NativeToolSearchShape {
+    /// Anthropic's `{"type": "tool_search_tool_{bm25,regex}_20251119"}`.
+    Anthropic,
+    /// OpenAI Responses API's `{"type": "tool_search"}`.
+    OpenAi,
 }

--- a/crates/harn-vm/src/llm/providers/mod.rs
+++ b/crates/harn-vm/src/llm/providers/mod.rs
@@ -9,10 +9,10 @@
 //! - **Ollama** — local Ollama server with NDJSON streaming
 //! - **Mock** — deterministic test responses without any network I/O
 
-mod anthropic;
+pub(crate) mod anthropic;
 mod mock;
 mod ollama;
-mod openai_compat;
+pub(crate) mod openai_compat;
 
 pub(crate) use anthropic::AnthropicProvider;
 pub(crate) use mock::MockProvider;

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -6,6 +6,61 @@ use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult};
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
 use crate::value::VmError;
 
+/// Parse the (major, minor) version out of a GPT model ID. Handles dotted
+/// forms like `gpt-5.4`, `gpt-5.4-preview`, `gpt-5.4-turbo-20260115`, and
+/// dashed forms like `gpt-5-4`. Also strips OpenRouter-style prefixes
+/// (`openai/gpt-5.4`, `azure/gpt-5.4`) so the same parser can gate
+/// capabilities regardless of which OpenAI-compatible provider is routing.
+///
+/// Returns `None` for non-GPT shapes (`claude-opus-4-7`, `llama-3.1`, …).
+pub(crate) fn gpt_generation(model: &str) -> Option<(u32, u32)> {
+    let lower = model.to_lowercase();
+    // Strip any `namespace/` prefix (OpenRouter, Azure, vertex).
+    let stripped = match lower.rsplit_once('/') {
+        Some((_, tail)) => tail,
+        None => lower.as_str(),
+    };
+    let needle = "gpt-";
+    let idx = stripped.find(needle)?;
+    let tail = &stripped[idx + needle.len()..];
+    // Dotted: "5.4" / "5.4-preview" / "5.4-turbo".
+    if let Some((major, rest)) = tail.split_once('.') {
+        if let Ok(major) = major.parse::<u32>() {
+            let minor_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if let Ok(minor) = minor_str.parse::<u32>() {
+                return Some((major, minor));
+            }
+        }
+    }
+    // Dashed: "5-4" / "5-4-preview" / "5" (minor=0).
+    let mut parts = tail.split('-');
+    if let Some(major_str) = parts.next() {
+        if let Ok(major) = major_str.parse::<u32>() {
+            if let Some(minor_str) = parts.next() {
+                if let Ok(minor) = minor_str.parse::<u32>() {
+                    // Dates ≥ 1000 are stamps, not minor versions.
+                    let minor = if minor >= 1000 { 0 } else { minor };
+                    return Some((major, minor));
+                }
+            }
+            return Some((major, 0));
+        }
+    }
+    None
+}
+
+/// True for GPT models that expose OpenAI's Responses-API `tool_search` meta-tool
+/// and the `defer_loading: true` flag on user tool definitions. Per OpenAI's
+/// docs, the feature is gated on GPT 5.4+ (hosted + client-executed modes).
+/// We intentionally ignore legacy `gpt-4*`, `gpt-3.5*`, and any non-GPT model;
+/// those fall back to the client-executed path from harn#70.
+pub(crate) fn gpt_model_supports_tool_search(model: &str) -> bool {
+    match gpt_generation(model) {
+        Some((major, minor)) => (major, minor) >= (5, 4),
+        None => false,
+    }
+}
+
 /// OpenAI-compatible provider parameterized by name. A single struct handles
 /// all OpenAI-style backends — the provider name is used to resolve config
 /// (base URL, auth, etc.) from `llm_config`.
@@ -34,6 +89,23 @@ impl LlmProvider for OpenAiCompatibleProvider {
             if let Some(obj) = body.as_object_mut() {
                 obj.remove("chat_template_kwargs");
             }
+        }
+    }
+
+    fn supports_defer_loading(&self, model: &str) -> bool {
+        gpt_model_supports_tool_search(model)
+    }
+
+    fn native_tool_search_variants(&self, model: &str) -> &'static [&'static str] {
+        if gpt_model_supports_tool_search(model) {
+            // OpenAI Responses-API `tool_search` exposes two execution modes.
+            // `"hosted"` runs the search server-side (default — lowest token
+            // cost); `"client"` mirrors harn#70's client-executed fallback
+            // but keeps OpenAI's `call_id` round-trip semantics. Users who
+            // omit `mode` get `"hosted"` implicitly via the `Auto` resolver.
+            &["hosted", "client"]
+        } else {
+            &[]
         }
     }
 }
@@ -144,5 +216,75 @@ impl OpenAiCompatibleProvider {
             false, // is_ollama
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_search_supported_for_gpt_5_4_and_up() {
+        assert!(gpt_model_supports_tool_search("gpt-5.4"));
+        assert!(gpt_model_supports_tool_search("gpt-5.4-preview"));
+        assert!(gpt_model_supports_tool_search("gpt-5.4-turbo"));
+        assert!(gpt_model_supports_tool_search("gpt-5-4"));
+        assert!(gpt_model_supports_tool_search("gpt-5.5"));
+        assert!(gpt_model_supports_tool_search("gpt-6.0"));
+    }
+
+    #[test]
+    fn tool_search_unsupported_for_pre_5_4() {
+        assert!(!gpt_model_supports_tool_search("gpt-4o"));
+        assert!(!gpt_model_supports_tool_search("gpt-4.1"));
+        assert!(!gpt_model_supports_tool_search("gpt-4-turbo"));
+        assert!(!gpt_model_supports_tool_search("gpt-3.5-turbo"));
+        assert!(!gpt_model_supports_tool_search("gpt-5.0"));
+        assert!(!gpt_model_supports_tool_search("gpt-5.3-preview"));
+        assert!(!gpt_model_supports_tool_search("gpt-5"));
+    }
+
+    #[test]
+    fn tool_search_unsupported_for_non_gpt() {
+        assert!(!gpt_model_supports_tool_search("claude-opus-4-7"));
+        assert!(!gpt_model_supports_tool_search("llama-3.1-70b"));
+        assert!(!gpt_model_supports_tool_search(""));
+    }
+
+    #[test]
+    fn gpt_generation_handles_openrouter_prefix() {
+        // OpenRouter model IDs carry an `openai/` prefix. Same capability
+        // check must produce the same answer.
+        assert_eq!(gpt_generation("openai/gpt-5.4-preview"), Some((5, 4)));
+        assert_eq!(gpt_generation("azure/gpt-5.5-turbo"), Some((5, 5)));
+        assert!(gpt_model_supports_tool_search("openai/gpt-5.4"));
+        assert!(!gpt_model_supports_tool_search("openai/gpt-4o"));
+    }
+
+    #[test]
+    fn gpt_generation_ignores_date_suffix_as_minor() {
+        // `gpt-5-20260115` should parse as generation (5, 0), not (5, 20260115).
+        assert_eq!(gpt_generation("gpt-5-20260115"), Some((5, 0)));
+        assert!(!gpt_model_supports_tool_search("gpt-5-20260115"));
+    }
+
+    #[test]
+    fn native_tool_search_variants_lists_hosted_first() {
+        let provider = OpenAiCompatibleProvider::new("openai".to_string());
+        let variants = provider.native_tool_search_variants("gpt-5.4-preview");
+        assert_eq!(variants, &["hosted", "client"]);
+    }
+
+    #[test]
+    fn native_tool_search_variants_empty_for_old_model() {
+        let provider = OpenAiCompatibleProvider::new("openai".to_string());
+        assert!(provider.native_tool_search_variants("gpt-4o").is_empty());
+    }
+
+    #[test]
+    fn supports_defer_loading_matches_tool_search_gate() {
+        let provider = OpenAiCompatibleProvider::new("openai".to_string());
+        assert!(provider.supports_defer_loading("gpt-5.4"));
+        assert!(!provider.supports_defer_loading("gpt-4o"));
     }
 }

--- a/crates/harn-vm/src/llm/tools/mod.rs
+++ b/crates/harn-vm/src/llm/tools/mod.rs
@@ -1143,6 +1143,13 @@ pub(crate) fn vm_tools_to_native(
                 let params = entry.get("parameters").and_then(|v| v.as_dict());
                 let output_schema = entry.get("outputSchema").map(vm_value_to_json);
                 let defer_loading = matches!(entry.get("defer_loading"), Some(VmValue::Bool(true)));
+                // Optional `namespace: "crm"` groups deferred tools for
+                // OpenAI's `tool_search` meta-tool. Provider-agnostic at
+                // this layer; Anthropic simply ignores the field.
+                let namespace = entry.get("namespace").and_then(|v| match v {
+                    VmValue::String(s) if !s.is_empty() => Some(s.to_string()),
+                    _ => None,
+                });
 
                 let input_schema = vm_build_json_schema(params);
 
@@ -1169,6 +1176,13 @@ pub(crate) fn vm_tools_to_native(
                         // turns; we just pass the flag through.
                         tool_json["defer_loading"] = serde_json::Value::Bool(true);
                     }
+                    if let Some(ns) = namespace {
+                        // Anthropic ignores `namespace` today — harmless
+                        // passthrough keeps replay fidelity and lets a
+                        // future Anthropic release pick it up without
+                        // another round of schema plumbing.
+                        tool_json["namespace"] = serde_json::Value::String(ns);
+                    }
                     native_tools.push(tool_json);
                 } else {
                     let mut tool_json = serde_json::json!({
@@ -1187,12 +1201,20 @@ pub(crate) fn vm_tools_to_native(
                         // harn#71 (OpenAI Responses tool_search) and
                         // harn#70 (client-executed fallback) can read it
                         // without re-walking the VmValue tree. Non-
-                        // Anthropic providers that don't understand
-                        // `defer_loading` today will return an error when
-                        // the user explicitly requests tool_search — the
-                        // capability gate in options.rs catches that
-                        // before the payload ever reaches the provider.
+                        // OpenAI OpenAI-compat providers that don't
+                        // understand `defer_loading` today will return an
+                        // error when the user explicitly requests
+                        // tool_search — the capability gate in options.rs
+                        // catches that before the payload ever reaches
+                        // the provider.
                         tool_json["defer_loading"] = serde_json::Value::Bool(true);
+                    }
+                    if let Some(ns) = namespace {
+                        // OpenAI's `tool_search` meta-tool groups
+                        // deferred tools by namespace. Placed on the
+                        // wrapper (alongside `type: "function"`) so the
+                        // Responses API sees it next to `defer_loading`.
+                        tool_json["namespace"] = serde_json::Value::String(ns);
                     }
                     native_tools.push(tool_json);
                 }
@@ -1385,45 +1407,101 @@ pub(crate) fn build_client_search_tool_schema(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn apply_tool_search_native_injection(
     native_tools: &mut Option<Vec<serde_json::Value>>,
     provider: &str,
     variant: &str,
 ) {
-    let is_anthropic_style = super::helpers::ResolvedProvider::resolve(provider).is_anthropic_style;
-    if !is_anthropic_style {
-        // OpenAI's native tool_search lands in harn#71 with a different
-        // shape; the options.rs capability gate prevents non-Anthropic
-        // providers from reaching this call for now. This guard is just
-        // defense in depth.
-        return;
-    }
-
-    // Anthropic's documented versioned types. If/when Anthropic issues a
-    // newer dated variant, we'll bump these constants in lockstep; the
-    // short names (`bm25`/`regex`) stay stable for users.
-    let (type_name, tool_name) = match variant {
-        "regex" => ("tool_search_tool_regex_20251119", "tool_search_tool_regex"),
-        // "bm25" and anything else → default to bm25.
-        _ => ("tool_search_tool_bm25_20251119", "tool_search_tool_bm25"),
+    // Back-compat entry for existing unit tests: pick the shape by
+    // provider name alone. The canonical call site (options.rs) uses the
+    // model-aware helper below.
+    let shape = if provider == "anthropic" {
+        super::provider::NativeToolSearchShape::Anthropic
+    } else {
+        super::provider::NativeToolSearchShape::OpenAi
     };
+    apply_tool_search_native_injection_typed(native_tools, shape, variant, "hosted");
+}
 
-    let meta = serde_json::json!({
-        "type": type_name,
-        "name": tool_name,
-    });
+/// Native tool-search injection with an explicit wire shape + OpenAI
+/// execution mode. `mode` is `"hosted"` or `"client"`; it only affects
+/// the OpenAI Responses-API shape (Anthropic's server always runs the
+/// search). `"hosted"` is the OpenAI default.
+pub(crate) fn apply_tool_search_native_injection_typed(
+    native_tools: &mut Option<Vec<serde_json::Value>>,
+    shape: super::provider::NativeToolSearchShape,
+    variant: &str,
+    mode: &str,
+) {
+    use super::provider::NativeToolSearchShape;
 
-    match native_tools {
-        Some(list) => {
-            // Prepend so the search tool is the first thing the model
-            // sees. Cheap — tool lists are rarely longer than a few dozen
-            // entries.
-            list.insert(0, meta);
+    match shape {
+        NativeToolSearchShape::Anthropic => {
+            // Anthropic's documented versioned types. If/when Anthropic
+            // issues a newer dated variant, we'll bump these constants
+            // in lockstep; the short names (`bm25`/`regex`) stay stable
+            // for users.
+            let (type_name, tool_name) = match variant {
+                "regex" => ("tool_search_tool_regex_20251119", "tool_search_tool_regex"),
+                // "bm25" and anything else → default to bm25.
+                _ => ("tool_search_tool_bm25_20251119", "tool_search_tool_bm25"),
+            };
+            let meta = serde_json::json!({
+                "type": type_name,
+                "name": tool_name,
+            });
+            prepend_meta_tool(native_tools, meta);
         }
-        None => {
-            *native_tools = Some(vec![meta]);
+        NativeToolSearchShape::OpenAi => {
+            // OpenAI Responses-API shape (harn#71). The meta-tool goes
+            // at the front of the tools array and carries a `mode`
+            // field ("hosted"/"client"). Deferred tools get
+            // `defer_loading: true` set at the wrapper level in
+            // `vm_tools_to_native`; the model sees only stub schemas
+            // until a `tool_search_call` surfaces them. See
+            // <https://developers.openai.com/api/docs/guides/tools-tool-search>.
+            let resolved_mode = if mode == "client" { "client" } else { "hosted" };
+            let mut meta = serde_json::json!({
+                "type": "tool_search",
+                "mode": resolved_mode,
+            });
+            // Collect any `namespace` values declared on user tools so
+            // OpenAI can group deferred tools into searchable buckets.
+            // Omit the field when no tool declared a namespace — keeps
+            // the payload minimal for the common case.
+            if let Some(tools) = native_tools.as_ref() {
+                let mut namespaces: Vec<String> = tools.iter().filter_map(tool_namespace).collect();
+                namespaces.sort();
+                namespaces.dedup();
+                if !namespaces.is_empty() {
+                    meta["namespaces"] = serde_json::json!(namespaces);
+                }
+            }
+            prepend_meta_tool(native_tools, meta);
         }
     }
+}
+
+fn prepend_meta_tool(native_tools: &mut Option<Vec<serde_json::Value>>, meta: serde_json::Value) {
+    match native_tools {
+        Some(list) => list.insert(0, meta),
+        None => *native_tools = Some(vec![meta]),
+    }
+}
+
+/// Extract the user-declared namespace from a native tool JSON, if any.
+/// Anthropic shape keeps the field at the top level; OpenAI shape nests
+/// it inside `function`. Either location is honoured.
+pub(crate) fn tool_namespace(tool: &serde_json::Value) -> Option<String> {
+    tool.get("namespace")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            tool.get("function")
+                .and_then(|f| f.get("namespace"))
+                .and_then(|v| v.as_str())
+        })
+        .map(|s| s.to_string())
 }
 
 fn vm_build_json_schema(params: Option<&BTreeMap<String, VmValue>>) -> serde_json::Value {

--- a/crates/harn-vm/src/llm/tools/tests.rs
+++ b/crates/harn-vm/src/llm/tools/tests.rs
@@ -1881,6 +1881,35 @@ fn vm_tools_to_native_emits_defer_loading_for_anthropic() {
 }
 
 #[test]
+fn vm_tools_to_native_emits_namespace_for_openai_compat() {
+    // `namespace` on a tool entry (harn#71) flows through to the
+    // OpenAI-shape wrapper alongside `defer_loading`. Anthropic
+    // receives it too — the field is harmless there (ignored by the
+    // API) and keeps replay fidelity.
+    let mut deferred_params = BTreeMap::new();
+    deferred_params.insert("env".to_string(), vm_str("string"));
+    let deferred = vm_dict(&[
+        ("name", vm_str("deploy")),
+        ("description", vm_str("Deploy the app")),
+        ("parameters", VmValue::Dict(Rc::new(deferred_params))),
+        ("defer_loading", vm_bool(true)),
+        ("namespace", vm_str("ops")),
+    ]);
+    let registry = vm_list(vec![deferred]);
+
+    let openai = vm_tools_to_native(&registry, "openai").expect("openai native tools");
+    assert_eq!(openai[0]["namespace"].as_str(), Some("ops"));
+    assert_eq!(openai[0]["defer_loading"].as_bool(), Some(true));
+
+    let anthropic = vm_tools_to_native(&registry, "anthropic").expect("anthropic native tools");
+    assert_eq!(
+        anthropic[0]["namespace"].as_str(),
+        Some("ops"),
+        "namespace survives Anthropic passthrough (harmlessly ignored by API)"
+    );
+}
+
+#[test]
 fn vm_tools_to_native_emits_defer_loading_for_openai_compat() {
     // OpenAI-shape tools place the flag at the wrapper level (not inside
     // `function`) so harn#71's Responses-API path can read it uniformly
@@ -1957,15 +1986,51 @@ fn apply_tool_search_native_injection_regex_variant() {
 }
 
 #[test]
-fn apply_tool_search_native_injection_is_noop_for_non_anthropic() {
-    // OpenAI's native tool_search lands in harn#71 with a different
-    // shape. Until then this injection must not run — the options-layer
-    // capability gate is the single point that decides to skip it.
+fn apply_tool_search_native_injection_emits_openai_shape_for_non_anthropic() {
+    // OpenAI's native `tool_search` meta-tool (harn#71) uses a flat
+    // `{"type": "tool_search", "mode": "hosted"}` shape, distinct from
+    // Anthropic's versioned `tool_search_tool_*_20251119` block.
     let mut tools: Option<Vec<serde_json::Value>> = Some(vec![json!({"name": "look"})]);
     apply_tool_search_native_injection(&mut tools, "openai", "bm25");
     let tools = tools.unwrap();
-    assert_eq!(tools.len(), 1);
-    assert_eq!(tools[0]["name"].as_str(), Some("look"));
+    assert_eq!(tools.len(), 2, "OpenAI meta-tool prepended");
+    assert_eq!(tools[0]["type"].as_str(), Some("tool_search"));
+    assert_eq!(tools[0]["mode"].as_str(), Some("hosted"));
+    assert!(
+        tools[0].get("name").is_none(),
+        "OpenAI meta-tool has no `name` field (that's an Anthropic detail)"
+    );
+    assert_eq!(tools[1]["name"].as_str(), Some("look"));
+}
+
+#[test]
+fn apply_tool_search_native_injection_openai_collects_namespaces() {
+    // When deferred tools declare a `namespace`, OpenAI's meta-tool
+    // carries the distinct set so the server can group them.
+    let mut tools: Option<Vec<serde_json::Value>> = Some(vec![
+        json!({
+            "type": "function",
+            "function": {"name": "deploy_api"},
+            "namespace": "ops",
+        }),
+        json!({
+            "type": "function",
+            "function": {"name": "deploy_web"},
+            "namespace": "ops",
+        }),
+        json!({
+            "type": "function",
+            "function": {"name": "lookup_account"},
+            "namespace": "crm",
+        }),
+    ]);
+    apply_tool_search_native_injection(&mut tools, "openai", "bm25");
+    let tools = tools.unwrap();
+    let namespaces = tools[0]["namespaces"]
+        .as_array()
+        .expect("namespaces present");
+    let names: Vec<&str> = namespaces.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(names, vec!["crm", "ops"], "sorted + deduped");
 }
 
 #[test]

--- a/crates/harn-vm/src/stdlib/tools.rs
+++ b/crates/harn-vm/src/stdlib/tools.rs
@@ -402,9 +402,9 @@ pub(crate) fn register_tool_builtins(vm: &mut Vm) {
         }
 
         // `defer_loading` controls progressive-disclosure behavior on
-        // capable providers (Anthropic Claude 4.0+ today; OpenAI via
-        // harn#71). Gate the type here so typos don't silently fall back
-        // to the "no defer" default.
+        // capable providers (Anthropic Claude 4.0+ and OpenAI GPT 5.4+).
+        // Gate the type here so typos don't silently fall back to the
+        // "no defer" default.
         if let Some(v) = config.get("defer_loading") {
             if !matches!(v, VmValue::Bool(_)) {
                 return Err(VmError::Thrown(VmValue::String(Rc::from(
@@ -412,6 +412,23 @@ pub(crate) fn register_tool_builtins(vm: &mut Vm) {
                      (true → hold schema back until a tool_search call \
                      surfaces it; false or absent → ship eagerly)",
                 ))));
+            }
+        }
+
+        // `namespace` groups deferred tools for OpenAI's `tool_search`
+        // meta-tool (Anthropic ignores the field). Must be a non-empty
+        // string so typos don't silently flow through to the payload.
+        if let Some(v) = config.get("namespace") {
+            match v {
+                VmValue::String(s) if !s.is_empty() => {}
+                VmValue::Nil => {}
+                _ => {
+                    return Err(VmError::Thrown(VmValue::String(Rc::from(
+                        "tool_define: `namespace` must be a non-empty string \
+                         (groups deferred tools for OpenAI tool_search; \
+                         Anthropic ignores it)",
+                    ))));
+                }
             }
         }
 

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -521,27 +521,36 @@ Provider support matrix for `tool_search`:
 |---|---|---|
 | Anthropic — Opus/Sonnet 4.0+, Haiku 4.5+ | ✓ (`bm25`, `regex`) | ✓ |
 | Anthropic — pre-4.0 / other Claude | ✗ | ✓ |
-| OpenAI (native tracked in harn#71), Gemini, Ollama, others | ✗ | ✓ |
+| OpenAI — GPT 5.4+ (Responses API, hosted) | ✓ (`tool_search`) | ✓ |
+| OpenAI — pre-5.4 (`gpt-4o`, `gpt-4.1`, older) | ✗ | ✓ |
+| OpenRouter, Together, Groq, DeepSeek, Fireworks, HuggingFace, local vLLM | ✓ when model matches `gpt-5.4+` upstream | ✓ |
+| Gemini, Ollama, others | ✗ | ✓ |
 
 Semantics:
 
 - `defer_loading: true` on an individual tool keeps its schema out of
   the model's context until a tool-search call surfaces it. On
   capable Anthropic models the schema goes into the API prefix but not
-  the model's context, so prompt caching stays warm.
+  the model's context, so prompt caching stays warm. On OpenAI GPT
+  5.4+ the wrapper-level flag rides alongside the `{"type":
+  "tool_search"}` meta-tool in the tools array.
 - `tool_search: "bm25"` prepends the server-side
   `tool_search_tool_bm25_20251119` meta-tool on capable Anthropic
-  models. On any other provider, Harn falls back to a client-executed
-  equivalent: a synthetic `__harn_tool_search` tool whose handler runs
-  BM25/regex/semantic/host in-VM or through the bridge, then promotes
-  the matching deferred tools into subsequent turns' schema list.
+  models, or `{"type": "tool_search", "mode": "hosted"}` on GPT 5.4+
+  via the Responses API. On any other provider, Harn falls back to a
+  client-executed equivalent: a synthetic `__harn_tool_search` tool
+  whose handler runs BM25/regex/semantic/host in-VM or through the
+  bridge, then promotes the matching deferred tools into subsequent
+  turns' schema list.
 - `tool_search: "regex"` uses the Python-regex variant
   (`tool_search_tool_regex_20251119`) on Anthropic, or an
   in-VM case-insensitive Rust-regex search on everything else.
 - `tool_search: {mode: "native"}` refuses to silently downgrade —
   errors if the provider isn't natively capable.
 - `tool_search: {mode: "client"}` forces the client-executed path
-  even on providers with native support.
+  even on providers with native support (useful for debuggability on
+  GPT 5.4+, where the hosted path hides search deltas in the usage
+  accounting).
 - `tool_search: {strategy: "bm25" | "regex" | "semantic" | "host"}`
   (client mode only) picks the implementation. `"semantic"` and
   `"host"` delegate to the host via the `tool_search/query` bridge
@@ -554,13 +563,24 @@ Semantics:
   tool (default `__harn_tool_search`).
 - `tool_search: {include_stub_listing: true}` appends a short list
   of deferred tool names to the contract prompt.
+- `namespace: "ops"` on a `tool_define(...)` call groups deferred
+  tools for OpenAI's `tool_search` meta-tool. The distinct set of
+  namespaces is collected into the meta-tool's `namespaces` field;
+  Anthropic ignores the label (harmless passthrough).
+- Escape hatch for proxied OpenAI-compat endpoints whose model ID
+  Harn cannot parse: pass `{<provider_name>:
+  {force_native_tool_search: true}}` on the call options. Asserts
+  the endpoint forwards `tool_search` + `defer_loading` unchanged and
+  opts into the hosted path regardless of model detection.
 - Pre-flight: at least one user tool must be non-deferred, matching
   Anthropic's 400 on all-deferred tool lists.
 - Transcript events: `tool_search_query` and `tool_search_result`
   blocks appear in the run record so replay / eval can see which tools
   got promoted and when. Client-mode events carry a
   `metadata.mode: "client"` tag so replayers can distinguish the two
-  paths; otherwise the shapes are identical.
+  paths; otherwise the shapes are identical. OpenAI hosted mode emits
+  the same block shapes from the wire `tool_search_call` and
+  `tool_search_output` entries in the response.
 
 ### Skills (bundled tool + prompt + MCP metadata)
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1432,13 +1432,33 @@ falling back to eager loading.
 
 Deferred tools are only materialised on the wire when the call opts
 into `tool_search` (see the `llm_call` option of the same name and
-`docs/src/llm-and-agents.md`). On providers that support native
-progressive disclosure (Anthropic Claude Opus/Sonnet 4.0+ and
-Haiku 4.5+), Harn emits `defer_loading: true` in the native tool JSON
-and Anthropic keeps the schemas in the API prefix but out of the
-model's context (prompt caching stays warm). On providers without
-native support, Phase 1 refuses `tool_search` with a diagnostic error;
-client-executed fallback is tracked separately.
+`docs/src/llm-and-agents.md`). Harn supports two native backends plus a
+provider-agnostic client fallback:
+
+- **Anthropic Claude Opus/Sonnet 4.0+ and Haiku 4.5+** — Harn emits
+  `defer_loading: true` on each deferred tool and prepends the
+  `tool_search_tool_{bm25,regex}_20251119` meta-tool. Anthropic keeps
+  deferred schemas in the API prefix (prompt caching stays warm) but
+  out of the model's context.
+- **OpenAI GPT 5.4+ (Responses API)** — Harn emits
+  `defer_loading: true` on each deferred tool and prepends
+  `{"type": "tool_search", "mode": "hosted"}` to the tools array.
+  OpenRouter, Together, Groq, DeepSeek, Fireworks, HuggingFace, and
+  local vLLM inherit the capability when their routed model matches
+  `gpt-5.4+`.
+- **Everyone else (and any of the above on older models)** — Harn
+  injects a synthetic `__harn_tool_search` tool and runs the configured
+  strategy (BM25, regex, semantic, or host-delegated) in-VM, promoting
+  matching deferred tools into the next turn's schema list.
+
+Tool entries may also set `namespace: "<label>"` to group deferred tools
+for the OpenAI meta-tool's `namespaces` field. The field is a harmless
+passthrough on Anthropic — ignored by the API, preserved in replay.
+
+`mode: "native"` refuses to silently downgrade and errors when the
+active (provider, model) pair is not natively capable; `mode: "client"`
+forces the fallback everywhere; `mode: "auto"` (default) picks native
+when available.
 
 ### skill declarations
 

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -189,12 +189,56 @@ Accepted shapes:
 
 ### Provider support
 
-| Provider | Native `tool_search` | Variants |
+| Provider | Native `tool_search` | Variants / modes |
 |---|---|---|
 | Anthropic Claude Opus/Sonnet 4.0+, Haiku 4.5+ | ✓ | `bm25`, `regex` |
 | Anthropic 3.x or earlier 4.x Haiku | ✗ (uses client fallback) | — |
-| OpenAI Responses API (gpt-5.4+) | ✗ (tracked: [harn#71](https://github.com/burin-labs/harn/issues/71)) | client fallback works today |
-| Others (Gemini, Ollama, HuggingFace, Together, Fireworks, Groq, Deepseek, local, mock) | ✗ | client fallback works today |
+| OpenAI Responses API — GPT 5.4+ | ✓ | `hosted` (default), `client` |
+| OpenAI pre-5.4 (`gpt-4o`, `gpt-4.1`, …) | ✗ | client fallback works today |
+| OpenRouter / Together / Groq / DeepSeek / Fireworks / HuggingFace / local | ✓ when routed model matches `gpt-5.4+` upstream | hosted forwarded; escape hatch below for proxies |
+| Gemini, Ollama, mock (default model) | ✗ | client fallback works today |
+
+The OpenAI native path (harn#71) emits a flat `{"type": "tool_search",
+"mode": "hosted"}` meta-tool at the front of the tools array, alongside
+`defer_loading: true` on the wrapper of each user tool. The server runs
+the search and replies with `tool_search_call` / `tool_search_output`
+entries that Harn parses into the same transcript event shape as the
+Anthropic path (replays are indistinguishable across providers).
+
+#### Namespace grouping
+
+OpenAI's `tool_search` can group deferred tools into namespaces; pass
+`namespace: "<label>"` on `tool_define(...)` to tag a tool. Harn collects
+the distinct set into the meta-tool's `namespaces` field. Anthropic
+ignores the label — harmless passthrough for replay fidelity.
+
+```harn
+tool_define(registry, "deploy_api", "Deploy the API", {
+  parameters: {env: {type: "string"}},
+  defer_loading: true,
+  namespace: "ops",
+  handler: { args -> shell("deploy api " + args.env) },
+})
+```
+
+#### Escape hatch for proxied OpenAI-compat endpoints
+
+Self-hosted routers and enterprise gateways sometimes advertise a model
+ID Harn cannot parse (`my-internal-gpt-clone-v2`) yet forward the OpenAI
+Responses payload unchanged. Opt into the hosted path with:
+
+```harn
+llm_call(prompt, sys, {
+  provider: "openrouter",
+  model: "my-custom/gpt-forward",
+  tools: registry,
+  tool_search: {mode: "native"},
+  openrouter: {force_native_tool_search: true},
+})
+```
+
+The override is keyed by the provider name (the same dict you'd use for
+any provider-specific knob).
 
 ### Client-executed fallback
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1430,13 +1430,33 @@ falling back to eager loading.
 
 Deferred tools are only materialised on the wire when the call opts
 into `tool_search` (see the `llm_call` option of the same name and
-`docs/src/llm-and-agents.md`). On providers that support native
-progressive disclosure (Anthropic Claude Opus/Sonnet 4.0+ and
-Haiku 4.5+), Harn emits `defer_loading: true` in the native tool JSON
-and Anthropic keeps the schemas in the API prefix but out of the
-model's context (prompt caching stays warm). On providers without
-native support, Phase 1 refuses `tool_search` with a diagnostic error;
-client-executed fallback is tracked separately.
+`docs/src/llm-and-agents.md`). Harn supports two native backends plus a
+provider-agnostic client fallback:
+
+- **Anthropic Claude Opus/Sonnet 4.0+ and Haiku 4.5+** — Harn emits
+  `defer_loading: true` on each deferred tool and prepends the
+  `tool_search_tool_{bm25,regex}_20251119` meta-tool. Anthropic keeps
+  deferred schemas in the API prefix (prompt caching stays warm) but
+  out of the model's context.
+- **OpenAI GPT 5.4+ (Responses API)** — Harn emits
+  `defer_loading: true` on each deferred tool and prepends
+  `{"type": "tool_search", "mode": "hosted"}` to the tools array.
+  OpenRouter, Together, Groq, DeepSeek, Fireworks, HuggingFace, and
+  local vLLM inherit the capability when their routed model matches
+  `gpt-5.4+`.
+- **Everyone else (and any of the above on older models)** — Harn
+  injects a synthetic `__harn_tool_search` tool and runs the configured
+  strategy (BM25, regex, semantic, or host-delegated) in-VM, promoting
+  matching deferred tools into the next turn's schema list.
+
+Tool entries may also set `namespace: "<label>"` to group deferred tools
+for the OpenAI meta-tool's `namespaces` field. The field is a harmless
+passthrough on Anthropic — ignored by the API, preserved in replay.
+
+`mode: "native"` refuses to silently downgrade and errors when the
+active (provider, model) pair is not natively capable; `mode: "client"`
+forces the fallback everywhere; `mode: "auto"` (default) picks native
+when available.
 
 ### skill declarations
 


### PR DESCRIPTION
## Summary

Phase 3 of the Harn Tool Vault series. Closes [harn#71](https://github.com/burin-labs/harn/issues/71). Builds on phase 1 ([#69](https://github.com/burin-labs/harn/issues/69)) and phase 2 ([#70](https://github.com/burin-labs/harn/issues/70)).

GPT 5.4+ users now get the same zero-script-change progressive-tool-disclosure upgrade Anthropic users got in phase 1. When `tool_search` is engaged on a supported (provider, model) pair, Harn prepends `{"type": "tool_search", "mode": "hosted"}` to the tools array, emits `defer_loading: true` on each deferred user tool's wrapper, and parses server-executed `tool_search_call` / `tool_search_output` response blocks into the same `tool_search_query` / `tool_search_result` transcript events as the Anthropic path — replays are indistinguishable across providers.

## What changed

### Capability + payload
- New `gpt_generation()` parser in `openai_compat.rs` handles dotted (`gpt-5.4`), dashed (`gpt-5-4-preview`), namespaced (`openai/gpt-5.4-turbo`), and dated (`gpt-5-20260115` → `(5, 0)`) forms.
- `OpenAiCompatibleProvider` now overrides `supports_defer_loading` + `native_tool_search_variants` (returns `["hosted", "client"]` for `>= (5, 4)`).
- `provider.rs` dispatch helpers route the OpenAI-family names (`openai`, `openrouter`, `together`, `groq`, `deepseek`, `fireworks`, `huggingface`, `local`) through the same gate.
- New `NativeToolSearchShape` enum classifies Anthropic vs OpenAI wire shape in one place; `apply_tool_search_native_injection_typed(...)` keeps the options layer, tools builder, and response parser in agreement.

### Namespace grouping
- `namespace: "<label>"` on `tool_define(...)` flows through to the OpenAI tool wrapper. The meta-tool's `namespaces` field collects the distinct sorted set. Anthropic receives the field too (harmless — preserves replay fidelity). Type-validated at registration so typos error immediately.

### OpenRouter / proxied OpenAI-compat
- When the routed model ID matches `gpt-5.4+`, the capability check fires and the native payload is forwarded unchanged.
- Escape hatch: `<provider_name>: {force_native_tool_search: true}` on call options forces the hosted path regardless of model detection — for self-hosted routers / enterprise gateways whose model IDs Harn cannot parse.

### Response parsing
- Both non-streaming and SSE streaming paths in `api.rs` strip `tool_search_call` / `tool_search_output` entries out of the dispatchable `tool_calls` vector (OpenAI runs the search server-side) and record them as transcript blocks matching Anthropic's `server_tool_use` / `tool_search_tool_result` shape.
- Empty-response sanity check exempts calls whose output consists entirely of these blocks.

### Mock spoofing + conformance
- Mock provider now spoofs native capability based on the requested model so conformance tests can exercise both native paths without HTTP (`llm_mock_calls()[0].tools` captures the real payload).
- 3 new conformance tests: `tool_search_native_openai`, `tool_search_namespace`, `tool_search_provider_overrides`.
- `tool_search_unsupported_provider` pins `model: "gpt-4o"` (below the 5.4 cutoff); client-mode tests opt into `mode: "client"` explicitly to avoid auto-routing through the (now native-capable) mock Claude path.

### Docs
- Updated provider support matrix, semantics, and namespace / escape hatch guidance across `docs/llm/harn-quickref.md`, `docs/src/llm-and-agents.md`, and `spec/HARN_SPEC.md`. `docs/src/language-spec.md` regenerated.
- `CHANGELOG.md`: phase-3 added/changed bullets under Unreleased.

## Test plan

- [x] `cargo test -p harn-vm --lib` — 651/651 passing (new tests for `gpt_generation()`, OpenAI shape emission, namespace collection, `tool_search_call` / `tool_search_output` parsing)
- [x] `cargo nextest run --workspace` — 1284/1284 passing
- [x] `cargo run --bin harn -- test conformance` — 488/488 passing (7 tool_search tests: 4 existing + 3 new)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `make lint-harn`, `make fmt-harn`, `make check-docs-snippets`, `make gen-highlight` — all clean (no highlight drift)

## Reviewer notes

- The `NativeToolSearchShape` enum + `classify_native_shape(provider, model)` helper in `options.rs` is the single seam where shape selection happens. If OpenAI changes the meta-tool name or Anthropic ships a new versioned variant, it's a one-file update.
- The mock spoofing is deliberately scoped: it only reports native support when the model string explicitly parses as Claude 4.0+ or GPT 5.4+. Default mock behavior with a non-matching model still reports no native support (preserves the `tool_search_unsupported_provider` negative path).
- The `hosted` vs `client` distinction for OpenAI's meta-tool is separate from Harn's `mode: "auto" | "native" | "client"` resolver. `mode: "native"` on OpenAI emits `mode: "hosted"` (server runs the search); `mode: "client"` goes through the existing harn#70 synthetic-tool path regardless of provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)