### PR TITLE
skills: agent_loop lifecycle (match, activate, reassess, resume) (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ granular archaeology.
 
 ### Added
 
+- **Skills & Tool Vault phase 3: `agent_loop` skill lifecycle (harn#74).**
+  `agent_loop` now accepts a `skills:` option (a `skill_registry`
+  produced by the `skill { }` top-level form or `skill_define(...)`)
+  and runs a match-activate-reassess phase around every turn. The
+  default metadata matcher scores skills by BM25-ish keyword overlap
+  over `description` + `when_to_use`, name-in-prompt mentions, and
+  `paths:` glob matching against the host-supplied `working_files:`
+  list; opt into host-delegated ranking (embedding / LLM scorers /
+  whatever) via `skill_match: { strategy: "host" }` or `"embedding"`
+  — both route through a new `skill/match` JSON-RPC bridge method.
+  - Activation binds the skill's `prompt` body into the effective
+    system prompt, narrows the tool surface via its `allowed_tools`
+    whitelist (union when multiple skills are active), and calls
+    its `on_activate` hook. Deactivation (in `sticky: false` mode)
+    unwinds everything and calls `on_deactivate`.
+  - `disable-model-invocation: true` and `user-invocable: false`
+    SKILL.md frontmatter are honoured: the matcher skips disabled
+    skills entirely; `user-invocable` rides through for host UIs.
+  - Transcript events `skill_matched`, `skill_activated`,
+    `skill_deactivated`, `skill_scope_tools` emit with stable
+    schemas. The first three also emit as `AgentEvent` variants so
+    ACP hosts see live session updates (`harn-cli`'s ACP server
+    translates them into `session/update` notifications).
+  - Session-resume: when `session_id:` is set, the active skill set
+    at the end of one run is persisted in the session store and
+    rehydrated on the next `agent_loop` invocation, skipping
+    iteration-0 match so sticky re-entry stays hot.
+  - Conformance coverage under `conformance/tests/skill_lifecycle_*`.
 - **Skills phase 2: filesystem `SKILL.md` loader + layered discovery (harn#73).**
   `harn run` / `harn test` / `harn check` now pre-populate the `skills`
   VM global with every `SKILL.md` they find across eight priority

--- a/conformance/tests/skill_lifecycle_flags.expected
+++ b/conformance/tests/skill_lifecycle_flags.expected
@@ -1,0 +1,1 @@
+[harn] skill_lifecycle_flags tests passed

--- a/conformance/tests/skill_lifecycle_flags.harn
+++ b/conformance/tests/skill_lifecycle_flags.harn
@@ -1,0 +1,51 @@
+// Skills & Tool Vault phase 3 (harn#74): flag honouring.
+//
+// - `disable-model-invocation: true` excludes a skill from the
+//   matcher even when keywords would otherwise land it.
+// - An empty top-1 match produces `skill_matched` with no candidates
+//   and no activation.
+pipeline test(task) {
+  llm_mock_clear()
+  skill private_work {
+    description "Rotate database credentials"
+    when_to_use "User requests a credential rotation"
+    prompt "Never execute without manual approval."
+    allowed_tools ["rotate"]
+  }
+  // Flip the flag imperatively so the test still exercises the
+  // language form's metadata path.
+  let guarded = skill_define(
+    private_work,
+    "private_work",
+    {
+    description: "Rotate database credentials",
+    when_to_use: "User requests a credential rotation",
+    prompt: "Never execute without manual approval.",
+    allowed_tools: ["rotate"],
+    ["disable-model-invocation"]: true,
+  },
+  )
+  llm_mock({text: "Nothing to do."})
+  let result = agent_loop(
+    "Please rotate the staging credentials for me",
+    nil,
+    {provider: "mock", max_iterations: 1, skills: guarded},
+  )
+  let events = transcript_events(result?.transcript)
+  var activated = 0
+  var matched_events = 0
+  for ev in events {
+    if ev.kind == "skill_activated" {
+      activated = activated + 1
+    }
+    if ev.kind == "skill_matched" {
+      matched_events = matched_events + 1
+    }
+  }
+  assert(activated == 0, "disable-model-invocation hides the skill from the matcher")
+  assert(matched_events >= 1, "skill_matched event fires even with zero candidates")
+  // Active-skill section is omitted when no skill activated.
+  let calls = llm_mock_calls()
+  assert(!contains(calls[0].system, "## Active skills"), "no active-skill section when no match")
+  log("skill_lifecycle_flags tests passed")
+}

--- a/conformance/tests/skill_lifecycle_metadata.expected
+++ b/conformance/tests/skill_lifecycle_metadata.expected
@@ -1,0 +1,1 @@
+[harn] skill_lifecycle_metadata tests passed

--- a/conformance/tests/skill_lifecycle_metadata.harn
+++ b/conformance/tests/skill_lifecycle_metadata.harn
@@ -1,0 +1,100 @@
+// Skills & Tool Vault phase 3 (harn#74): agent_loop lifecycle
+// integration for the `skills:` option with the default "metadata"
+// matcher.
+//
+// Validates the full life cycle:
+//   1. Metadata ranking picks the skill whose description matches
+//      the prompt, activates it, and injects its body prompt into the
+//      effective system prompt.
+//   2. `allowed_tools` filters the schema list the model sees — the
+//      skill-scoped tool stays, out-of-scope tools disappear.
+//   3. Transcript events (`skill_matched`, `skill_activated`,
+//      `skill_scope_tools`) land with stable metadata.
+//   4. `paths:` auto-trigger still matches when the user prompt
+//      carries no keyword overlap.
+pipeline test(task) {
+  llm_mock_clear()
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "deploy_service",
+    "Deploy the production service stack",
+    {parameters: {env: {type: "string"}}, handler: { args -> "deployed to " + args.env }},
+  )
+  tools = tool_define(
+    tools,
+    "query_metrics",
+    "Query observability metrics",
+    {parameters: {query: {type: "string"}}, handler: { args -> "metrics: " + args.query }},
+  )
+  skill ship {
+    description "Ship a production release"
+    when_to_use "User says ship/release/deploy"
+    prompt "Follow the deploy runbook. One command at a time."
+    allowed_tools ["deploy_service"]
+  }
+  skill inspect {
+    description "Inspect observability signals"
+    when_to_use "User asks to check metrics or dashboards"
+    allowed_tools ["query_metrics"]
+  }
+  // Build a joined registry from both skill decls so both match
+  // candidates are visible to the ranker.
+  let registry = skill_define(ship, "inspect", skill_find(inspect, "inspect"))
+  // Single-turn mock so the loop completes naturally; we're only
+  // observing the system prompt + tool schema filtering on that turn.
+  llm_mock({text: "On it."})
+  let result = agent_loop(
+    "Ship the new release to production",
+    "You are a staff deploy engineer.",
+    {provider: "mock", tools: tools, tool_format: "native", max_iterations: 1, skills: registry},
+  )
+  assert(result?.status == "done", "agent loop completes")
+  // The system prompt on turn 1 carries the active-skill body.
+  let calls = llm_mock_calls()
+  assert(len(calls) >= 1, "at least one LLM call happened")
+  let first_system = calls[0].system
+  assert(contains(first_system, "## Active skills"), "system prompt includes active-skill section")
+  assert(contains(first_system, "ship"), "activated skill name surfaces in prompt")
+  assert(contains(first_system, "runbook"), "skill body prompt is woven in")
+  assert(contains(first_system, "Scoped tools: deploy_service"), "allowed_tools listed in prompt")
+  // Turn 1 tool schema list: query_metrics has been filtered out by
+  // the allowed_tools scope on the active skill.
+  let first_tools = calls[0].tools
+  var seen_deploy = false
+  var seen_metrics = false
+  if first_tools != nil {
+    for t in first_tools {
+      if t?.function?.name == "deploy_service" {
+        seen_deploy = true
+      }
+      if t?.function?.name == "query_metrics" {
+        seen_metrics = true
+      }
+    }
+  }
+  assert(seen_deploy, "scoped tool remained in the schema")
+  assert(!seen_metrics, "out-of-scope tool was filtered")
+  // Transcript events: skill_matched + skill_activated + skill_scope_tools
+  let events = transcript_events(result?.transcript)
+  var matched = 0
+  var activated = 0
+  var scoped = 0
+  for ev in events {
+    if ev.kind == "skill_matched" {
+      matched = matched + 1
+      assert(ev.metadata?.strategy == "metadata", "match phase records strategy")
+    }
+    if ev.kind == "skill_activated" {
+      activated = activated + 1
+      assert(ev.metadata?.name == "ship", "activated the expected skill")
+    }
+    if ev.kind == "skill_scope_tools" {
+      scoped = scoped + 1
+    }
+  }
+  assert(matched >= 1, "at least one skill_matched event fired")
+  assert(activated == 1, "one skill activated")
+  assert(scoped == 1, "tool-scope event fired for the active skill")
+  log("skill_lifecycle_metadata tests passed")
+}

--- a/conformance/tests/skill_lifecycle_paths.expected
+++ b/conformance/tests/skill_lifecycle_paths.expected
@@ -1,0 +1,1 @@
+[harn] skill_lifecycle_paths tests passed

--- a/conformance/tests/skill_lifecycle_paths.harn
+++ b/conformance/tests/skill_lifecycle_paths.harn
@@ -1,0 +1,52 @@
+// Skills & Tool Vault phase 3 (harn#74): `paths:` auto-trigger.
+//
+// When the user prompt contains no keyword overlap with any skill,
+// the `working_files:` option feeds the path-glob matcher — and a
+// path hit alone is enough to activate.
+pipeline test(task) {
+  llm_mock_clear()
+  skill infra_touch {
+    description "Infrastructure work"
+    paths ["infra/**", "Dockerfile"]
+    prompt "Keep changes minimal and reviewable."
+  }
+  skill docs_touch {
+    description "Documentation polish"
+    paths ["docs/**/*.md"]
+  }
+  let registry = skill_define(infra_touch, "docs_touch", skill_find(docs_touch, "docs_touch"))
+  llm_mock({text: "All done."})
+  let result = agent_loop(
+    "fix the edge case",
+    nil,
+    {
+    provider: "mock",
+    max_iterations: 1,
+    skills: registry,
+    working_files: ["infra/terraform/cluster.tf", "README.md"],
+  },
+  )
+  assert(result?.status == "done", "loop completes on path-only match")
+  // Exactly one skill should have activated — the infra one.
+  let events = transcript_events(result?.transcript)
+  var infra_activated = false
+  var docs_activated = false
+  for ev in events {
+    if ev.kind == "skill_activated" {
+      if ev.metadata?.name == "infra_touch" {
+        infra_activated = true
+      }
+      if ev.metadata?.name == "docs_touch" {
+        docs_activated = true
+      }
+    }
+  }
+  assert(infra_activated, "path-match alone activates infra_touch")
+  assert(!docs_activated, "non-matching skill stays inactive")
+  let calls = llm_mock_calls()
+  assert(
+    contains(calls[0].system, "infra_touch"),
+    "infra_touch prompt body weaves into system prompt",
+  )
+  log("skill_lifecycle_paths tests passed")
+}

--- a/conformance/tests/skill_lifecycle_reassess.expected
+++ b/conformance/tests/skill_lifecycle_reassess.expected
@@ -1,0 +1,1 @@
+[harn] skill_lifecycle_reassess tests passed

--- a/conformance/tests/skill_lifecycle_reassess.harn
+++ b/conformance/tests/skill_lifecycle_reassess.harn
@@ -1,0 +1,72 @@
+// Skills & Tool Vault phase 3 (harn#74): `sticky: false` triggers
+// the reassess phase before each turn, swapping skills when later
+// user context outgrows the earlier match.
+//
+// Flow:
+//   Turn 0: user prompt names a draft task → `draft` activates.
+//   Turn 0 response: text+tool call → post_turn_callback fires and
+//     injects a pivot user message ("review this instead").
+//   Turn 1: sticky=false, reassess re-reads visible_messages,
+//     scores the pivot, activates `review`, deactivates `draft`.
+pipeline test(task) {
+  llm_mock_clear()
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "noop",
+    "Noop that always succeeds",
+    {parameters: {}, handler: { _args -> "ok" }},
+  )
+  skill draft {
+    description "Draft a new document from scratch"
+    when_to_use "User asks to draft/write/compose"
+  }
+  skill review_skill {
+    description "Review existing code for correctness"
+    when_to_use "User asks to review/audit"
+  }
+  let registry = skill_define(draft, "review_skill", skill_find(review_skill, "review_skill"))
+  // Turn 0: a tool call forces post_turn_callback to fire, giving
+  // us a hook to inject a runtime user message that pivots intent.
+  llm_mock({text: "Drafting.", tool_calls: [{id: "t0", name: "noop", arguments: {}}]})
+  // Turn 1: acknowledge the pivot.
+  llm_mock({text: "Reviewing now."})
+  let result = agent_loop(
+    "Please draft the launch memo",
+    nil,
+    {
+    provider: "mock",
+    tools: tools,
+    tool_format: "native",
+    max_iterations: 2,
+    persistent: true,
+    skills: registry,
+    skill_match: {strategy: "metadata", top_n: 1, sticky: false},
+    post_turn_callback: { info ->
+    if info?.iteration == 0 {
+      return {message: "Actually, please review the existing launch memo."}
+    }
+    return ""
+  },
+  },
+  )
+  let events = transcript_events(result?.transcript)
+  var draft_activate = false
+  var review_activate = false
+  var draft_deactivate = false
+  for ev in events {
+    if ev.kind == "skill_activated" && ev.metadata?.name == "draft" {
+      draft_activate = true
+    }
+    if ev.kind == "skill_activated" && ev.metadata?.name == "review_skill" {
+      review_activate = true
+    }
+    if ev.kind == "skill_deactivated" && ev.metadata?.name == "draft" {
+      draft_deactivate = true
+    }
+  }
+  assert(draft_activate, "draft activated on turn 0")
+  assert(review_activate, "review activated after reassess on turn 1")
+  assert(draft_deactivate, "draft deactivated before review took over")
+  log("skill_lifecycle_reassess tests passed")
+}

--- a/conformance/tests/skill_lifecycle_session_resume.expected
+++ b/conformance/tests/skill_lifecycle_session_resume.expected
@@ -1,0 +1,1 @@
+[harn] skill_lifecycle_session_resume tests passed

--- a/conformance/tests/skill_lifecycle_session_resume.harn
+++ b/conformance/tests/skill_lifecycle_session_resume.harn
@@ -1,0 +1,39 @@
+// Skills & Tool Vault phase 3 (harn#74): session-resume restores
+// the last active skill when the user re-enters a named session.
+//
+// The resume path reads `agent_sessions::active_skills(session_id)`;
+// this test rides on the public `agent_session_*` builtins to bake
+// a durable session first, then re-enters it under a fresh
+// agent_loop invocation and checks the skill stayed hot without
+// re-matching.
+pipeline test(task) {
+  llm_mock_clear()
+  skill sticky_skill {
+    description "Handle every task"
+    prompt "Take a careful, confirmed approach."
+  }
+  llm_mock({text: "First turn done."})
+  let sid = "skill-resume-test"
+  let r1 = agent_loop(
+    "please handle this task carefully",
+    nil,
+    {provider: "mock", max_iterations: 1, skills: sticky_skill, session_id: sid},
+  )
+  assert(r1?.status == "done", "first run completes")
+  // Second invocation under the same session id: the matcher still
+  // runs (iteration 0 always re-matches) but the rehydration path
+  // seeded state.active_skills before it ran, so the transcript
+  // carries no extra skill_deactivated event (name didn't change).
+  llm_mock({text: "Resume done."})
+  let r2 = agent_loop(
+    "continue",
+    nil,
+    {provider: "mock", max_iterations: 1, skills: sticky_skill, session_id: sid},
+  )
+  assert(r2?.status == "done", "resume run completes")
+  // The second run's system prompt still mentions the skill body.
+  let calls = llm_mock_calls()
+  let last = calls[len(calls) - 1]
+  assert(contains(last.system, "sticky_skill"), "resume turn keeps skill active")
+  log("skill_lifecycle_session_resume tests passed")
+}

--- a/crates/harn-cli/src/acp/events.rs
+++ b/crates/harn-cli/src/acp/events.rs
@@ -138,6 +138,50 @@ impl AgentEventSink for AcpAgentEventSink {
                     },
                 }));
             }
+            AgentEvent::SkillActivated {
+                session_id,
+                skill_name,
+                iteration,
+                reason,
+            } => {
+                self.write_notification(serde_json::json!({
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "skill_activated",
+                        "skillName": skill_name,
+                        "iteration": iteration,
+                        "reason": reason,
+                    },
+                }));
+            }
+            AgentEvent::SkillDeactivated {
+                session_id,
+                skill_name,
+                iteration,
+            } => {
+                self.write_notification(serde_json::json!({
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "skill_deactivated",
+                        "skillName": skill_name,
+                        "iteration": iteration,
+                    },
+                }));
+            }
+            AgentEvent::SkillScopeTools {
+                session_id,
+                skill_name,
+                allowed_tools,
+            } => {
+                self.write_notification(serde_json::json!({
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "skill_scope_tools",
+                        "skillName": skill_name,
+                        "allowedTools": allowed_tools,
+                    },
+                }));
+            }
             // Pipeline-loop milestones with no canonical ACP session/update
             // mapping; deliberately not forwarded.
             AgentEvent::TurnStart { .. }

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -111,6 +111,29 @@ pub enum AgentEvent {
         attempts: usize,
         elapsed_ms: u64,
     },
+    /// Emitted when a skill is activated. Carries the match reason so
+    /// replayers can reconstruct *why* a given skill took effect at
+    /// this iteration.
+    SkillActivated {
+        session_id: String,
+        skill_name: String,
+        iteration: usize,
+        reason: String,
+    },
+    /// Emitted when a previously-active skill is deactivated because
+    /// the reassess phase no longer matches it.
+    SkillDeactivated {
+        session_id: String,
+        skill_name: String,
+        iteration: usize,
+    },
+    /// Emitted once per activation when the skill's `allowed_tools` filter
+    /// narrows the effective tool surface exposed to the model.
+    SkillScopeTools {
+        session_id: String,
+        skill_name: String,
+        allowed_tools: Vec<String>,
+    },
 }
 
 impl AgentEvent {
@@ -126,7 +149,10 @@ impl AgentEvent {
             | Self::FeedbackInjected { session_id, .. }
             | Self::BudgetExhausted { session_id, .. }
             | Self::LoopStuck { session_id, .. }
-            | Self::DaemonWatchdogTripped { session_id, .. } => session_id,
+            | Self::DaemonWatchdogTripped { session_id, .. }
+            | Self::SkillActivated { session_id, .. }
+            | Self::SkillDeactivated { session_id, .. }
+            | Self::SkillScopeTools { session_id, .. } => session_id,
         }
     }
 }

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -34,6 +34,12 @@ pub struct SessionState {
     pub subscribers: Vec<VmValue>,
     pub created_at: Instant,
     pub last_accessed: Instant,
+    /// Names of skills that were active at the end of the most recent
+    /// `agent_loop` run on this session. Empty when no skills were
+    /// matched, when the skill system wasn't used, or when the
+    /// deactivation phase cleared them. Re-entering the session
+    /// restores these as the initial active set before matching runs.
+    pub active_skills: Vec<String>,
 }
 
 impl SessionState {
@@ -46,6 +52,7 @@ impl SessionState {
             subscribers: Vec::new(),
             created_at: now,
             last_accessed: now,
+            active_skills: Vec::new(),
         }
     }
 }
@@ -403,6 +410,30 @@ pub fn subscriber_count(id: &str) -> usize {
             .get(id)
             .map(|state| state.subscribers.len())
             .unwrap_or(0)
+    })
+}
+
+/// Persist the set of active skill names for session resume. Called at
+/// the end of an agent_loop run; the next `open_or_create` for this id
+/// reads them back via [`active_skills`].
+pub fn set_active_skills(id: &str, skills: Vec<String>) {
+    SESSIONS.with(|s| {
+        if let Some(state) = s.borrow_mut().get_mut(id) {
+            state.active_skills = skills;
+            state.last_accessed = Instant::now();
+        }
+    });
+}
+
+/// Skills that were active at the end of the previous agent_loop run
+/// against this session. Returns an empty vec when the session doesn't
+/// exist or nothing was persisted.
+pub fn active_skills(id: &str) -> Vec<String> {
+    SESSIONS.with(|s| {
+        s.borrow()
+            .get(id)
+            .map(|state| state.active_skills.clone())
+            .unwrap_or_default()
     })
 }
 

--- a/crates/harn-vm/src/llm/agent/finalize.rs
+++ b/crates/harn-vm/src/llm/agent/finalize.rs
@@ -120,6 +120,12 @@ pub(super) async fn run_finalize(
     );
     if !state.anonymous_session {
         crate::agent_sessions::store_transcript(&state.session_id, transcript_vm.clone());
+        // Persist the active-skill set so a re-entry of this session
+        // resumes the same scope without re-matching from scratch.
+        crate::agent_sessions::set_active_skills(
+            &state.session_id,
+            state.active_skills.iter().map(|s| s.name.clone()).collect(),
+        );
     }
     let transcript_json = crate::llm::helpers::vm_value_to_json(&transcript_vm);
 

--- a/crates/harn-vm/src/llm/agent/mod.rs
+++ b/crates/harn-vm/src/llm/agent/mod.rs
@@ -9,10 +9,16 @@ mod finalize;
 mod helpers;
 mod llm_call;
 mod post_turn;
+mod skill_match;
 mod state;
 mod tool_dispatch;
 mod tool_search_client;
 mod turn_preflight;
+
+pub use skill_match::parse_skill_config;
+pub use state::SkillMatchConfig;
+#[allow(unused_imports)]
+pub use state::{ActiveSkill, SkillMatchStrategy};
 
 thread_local! {
     static CURRENT_HOST_BRIDGE: std::cell::RefCell<Option<Rc<crate::bridge::HostBridge>>> = const { std::cell::RefCell::new(None) };
@@ -196,6 +202,40 @@ pub async fn run_agent_loop_internal(
 
     let mut iteration_exited_via_break = false;
     for iteration in 0..max_iterations {
+        // Skill matching runs at the head of iteration 0 (always) and,
+        // when sticky=false, again before each subsequent iteration.
+        // Reassess-in-place keeps the active skill when nothing
+        // changed, so sticky=true + a still-applicable skill stays hot
+        // for the rest of the loop.
+        //
+        // Exception: if this loop resumed a persisted session whose
+        // previous run left skills active, iteration 0 preserves that
+        // set instead of re-matching from a cold prompt. sticky=false
+        // still lets the post-turn reassess run after turn 1.
+        let skip_initial_match =
+            iteration == 0 && state.rehydrated_from_session && state.skill_match.sticky;
+        let should_match = (iteration == 0 || !state.skill_match.sticky) && !skip_initial_match;
+        if should_match {
+            skill_match::run_skill_match(
+                &mut state,
+                opts,
+                &bridge,
+                &session_id,
+                iteration,
+                iteration > 0,
+            )
+            .await?;
+        }
+
+        // If any active skill narrows the tool surface via
+        // `allowed_tools`, compute the scoped registry for this turn.
+        // Downstream phases see the narrowed view; the original
+        // `tools_owned` stays intact so deactivation restores the full
+        // surface on a later iteration.
+        let scoped_tools = state.skill_scoped_tools_val(tools_val);
+        let effective_tools_val: Option<&crate::value::VmValue> =
+            scoped_tools.as_ref().or(tools_val);
+
         turn_preflight::run_turn_preflight(
             &mut state,
             opts,
@@ -207,6 +247,7 @@ pub async fn run_agent_loop_internal(
                 base_system: base_system.as_deref(),
                 tool_contract_prompt: tool_contract_prompt.as_deref(),
                 persistent_system_prompt: persistent_system_prompt.as_deref(),
+                scoped_tools_val: scoped_tools.as_ref(),
             },
         )
         .await?;
@@ -225,7 +266,7 @@ pub async fn run_agent_loop_internal(
                 turn_policy: turn_policy.as_ref(),
                 llm_retries,
                 llm_backoff_ms,
-                tools_val,
+                tools_val: effective_tools_val,
             },
             iteration,
         )
@@ -239,7 +280,7 @@ pub async fn run_agent_loop_internal(
                     &tool_dispatch::ToolDispatchContext {
                         bridge: &bridge,
                         tool_format: &tool_format,
-                        tools_val,
+                        tools_val: effective_tools_val,
                         tool_retries,
                         tool_backoff_ms,
                         loop_detect_enabled,

--- a/crates/harn-vm/src/llm/agent/skill_match.rs
+++ b/crates/harn-vm/src/llm/agent/skill_match.rs
@@ -1,0 +1,738 @@
+//! Skill-matching phase.
+//!
+//! Resolves a concrete set of skills to activate for an agent_loop turn
+//! from a skill registry (created with `skill_registry()` / `skill { }`
+//! decls), the user's latest prompt, and the host-supplied working file
+//! set. The phase runs once on iteration 0 and again (reassess) after
+//! every turn when `sticky: false`. Activation binds a skill's
+//! `prompt`, `allowed_tools`, and metadata onto `AgentLoopState` so the
+//! preflight + tool-dispatch phases can react.
+//!
+//! Three strategies are supported:
+//!
+//! - `"metadata"` (default): BM25-ish term scoring over
+//!   `description` + `when_to_use` plus glob matching on `paths`
+//!   against the working file set. All in-VM, no host round-trip.
+//! - `"host"`: delegates scoring to the host via the `skill/match`
+//!   bridge RPC. Useful for embedding-based matchers.
+//! - `"embedding"`: alias for `"host"` today; kept separate so the
+//!   language accepts Anthropic's canonical term.
+//!
+//! Matching is deliberately permissive: unknown strategies fall back
+//! to `"metadata"` with a warning, and bridge errors surface as an
+//! empty match set (loop proceeds without an active skill).
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use crate::agent_events::AgentEvent;
+use crate::bridge::HostBridge;
+use crate::value::{VmError, VmValue};
+
+use super::super::helpers::transcript_event;
+use super::state::{ActiveSkill, AgentLoopState, SkillMatchConfig, SkillMatchStrategy};
+
+/// Per-skill score with optional diagnostic string.
+#[derive(Clone, Debug)]
+pub(super) struct SkillCandidate {
+    pub name: String,
+    pub score: f64,
+    pub reason: String,
+}
+
+/// Public entry: decide which skills (if any) to activate this turn.
+/// Called from the agent loop before `turn_preflight`:
+/// - on iteration 0 (always)
+/// - on every iteration when `sticky: false`
+///
+/// Safe to call when no skill registry is configured — returns early.
+pub(super) async fn run_skill_match(
+    state: &mut AgentLoopState,
+    opts: &crate::llm::api::LlmCallOptions,
+    bridge: &Option<Rc<HostBridge>>,
+    session_id: &str,
+    iteration: usize,
+    is_reassess: bool,
+) -> Result<(), VmError> {
+    let Some(registry) = state.skill_registry.clone() else {
+        return Ok(());
+    };
+    let match_config = state.skill_match.clone();
+    let skills = extract_skills(&registry);
+    if skills.is_empty() {
+        return Ok(());
+    }
+    // Read the most recent user-role message from state, not opts:
+    // opts.messages reflects the previous turn's preflight snapshot,
+    // while state.visible_messages carries every post-turn injection
+    // that happened after that snapshot (runtime feedback, host
+    // messages, inject_feedback calls).
+    let prompt_text =
+        latest_user_prompt_from_state(state).unwrap_or_else(|| latest_user_prompt(opts));
+    let working_files = state.working_files.clone();
+
+    let candidates = match match_config.strategy {
+        SkillMatchStrategy::Metadata => score_metadata(&skills, &prompt_text, &working_files),
+        SkillMatchStrategy::Host | SkillMatchStrategy::Embedding => {
+            match score_via_bridge(
+                bridge.as_deref(),
+                &skills,
+                &prompt_text,
+                &working_files,
+                &match_config.strategy,
+            )
+            .await
+            {
+                Ok(c) => c,
+                Err(err) => {
+                    crate::events::log_warn(
+                        "agent.skill_match",
+                        &format!("host strategy failed: {err}; falling back to metadata scoring"),
+                    );
+                    score_metadata(&skills, &prompt_text, &working_files)
+                }
+            }
+        }
+    };
+
+    let mut ranked = candidates;
+    ranked.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    // Emit a `skill_matched` transcript + agent event regardless of whether
+    // anything activated — replayers need to see the zero-match case too.
+    let candidates_json: Vec<serde_json::Value> = ranked
+        .iter()
+        .map(|c| {
+            serde_json::json!({
+                "name": c.name,
+                "score": c.score,
+                "reason": c.reason,
+            })
+        })
+        .collect();
+    state.transcript_events.push(transcript_event(
+        "skill_matched",
+        "system",
+        "internal",
+        "",
+        Some(serde_json::json!({
+            "strategy": match_config.strategy.as_str(),
+            "iteration": iteration,
+            "reassess": is_reassess,
+            "candidates": candidates_json,
+            "working_files": working_files,
+        })),
+    ));
+
+    // Filter out sub-threshold scores so the top-N pick doesn't
+    // activate a skill that didn't actually match anything.
+    let top: Vec<&SkillCandidate> = ranked
+        .iter()
+        .filter(|c| {
+            c.score > 0.0
+                || matches!(
+                    match_config.strategy,
+                    SkillMatchStrategy::Host | SkillMatchStrategy::Embedding
+                )
+        })
+        .take(match_config.top_n.max(1))
+        .collect();
+
+    let current_names: Vec<String> = state.active_skills.iter().map(|s| s.name.clone()).collect();
+    let new_names: Vec<String> = top.iter().map(|c| c.name.to_string()).collect();
+
+    if current_names == new_names {
+        // No change — nothing to activate / deactivate.
+        return Ok(());
+    }
+
+    // Deactivate previously-active skills that aren't in the new set.
+    let keep: std::collections::BTreeSet<&str> = new_names.iter().map(|s| s.as_str()).collect();
+    let deactivated: Vec<ActiveSkill> = state
+        .active_skills
+        .iter()
+        .filter(|s| !keep.contains(s.name.as_str()))
+        .cloned()
+        .collect();
+    for skill in &deactivated {
+        super::emit_agent_event(&AgentEvent::SkillDeactivated {
+            session_id: session_id.to_string(),
+            skill_name: skill.name.clone(),
+            iteration,
+        })
+        .await;
+        state.transcript_events.push(transcript_event(
+            "skill_deactivated",
+            "system",
+            "internal",
+            &skill.name,
+            Some(serde_json::json!({
+                "name": skill.name,
+                "iteration": iteration,
+            })),
+        ));
+        run_skill_hook(&registry, &skill.name, "on_deactivate").await?;
+    }
+
+    // Activate newly-matched skills.
+    state
+        .active_skills
+        .retain(|s| keep.contains(s.name.as_str()));
+    let existing: std::collections::BTreeSet<String> =
+        state.active_skills.iter().map(|s| s.name.clone()).collect();
+    for cand in &top {
+        if existing.contains(&cand.name) {
+            continue;
+        }
+        let Some(skill_entry) = find_skill_entry(&registry, &cand.name) else {
+            continue;
+        };
+        let active = ActiveSkill::from_entry(&skill_entry);
+        super::emit_agent_event(&AgentEvent::SkillActivated {
+            session_id: session_id.to_string(),
+            skill_name: active.name.clone(),
+            iteration,
+            reason: cand.reason.clone(),
+        })
+        .await;
+        state.transcript_events.push(transcript_event(
+            "skill_activated",
+            "system",
+            "internal",
+            &active.name,
+            Some(serde_json::json!({
+                "name": active.name,
+                "description": active.description,
+                "iteration": iteration,
+                "score": cand.score,
+                "reason": cand.reason,
+                "allowed_tools": active.allowed_tools,
+            })),
+        ));
+        if !active.allowed_tools.is_empty() {
+            super::emit_agent_event(&AgentEvent::SkillScopeTools {
+                session_id: session_id.to_string(),
+                skill_name: active.name.clone(),
+                allowed_tools: active.allowed_tools.clone(),
+            })
+            .await;
+            state.transcript_events.push(transcript_event(
+                "skill_scope_tools",
+                "system",
+                "internal",
+                &active.name,
+                Some(serde_json::json!({
+                    "name": active.name,
+                    "allowed_tools": active.allowed_tools,
+                })),
+            ));
+        }
+        run_skill_hook(&registry, &active.name, "on_activate").await?;
+        state.active_skills.push(active);
+    }
+
+    Ok(())
+}
+
+/// Flatten a skill registry (validated `skill_registry` dict) into a
+/// `Vec<VmValue::Dict>` skill-entry list. Returns empty when the input
+/// isn't recognisable as a registry.
+fn extract_skills(registry: &VmValue) -> Vec<VmValue> {
+    let Some(dict) = registry.as_dict() else {
+        return Vec::new();
+    };
+    match dict.get("skills") {
+        Some(VmValue::List(list)) => list.iter().cloned().collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Find the raw skill entry (`VmValue::Dict`) by name.
+fn find_skill_entry(registry: &VmValue, name: &str) -> Option<VmValue> {
+    for skill in extract_skills(registry) {
+        if let VmValue::Dict(dict) = &skill {
+            if dict
+                .get("name")
+                .map(|v| v.display() == name)
+                .unwrap_or(false)
+            {
+                return Some(skill);
+            }
+        }
+    }
+    None
+}
+
+/// Execute an `on_activate` / `on_deactivate` closure if it's present
+/// on the skill entry. Hook errors log-and-continue — a broken hook
+/// must not tear down the loop.
+async fn run_skill_hook(
+    registry: &VmValue,
+    skill_name: &str,
+    hook_key: &str,
+) -> Result<(), VmError> {
+    let Some(skill) = find_skill_entry(registry, skill_name) else {
+        return Ok(());
+    };
+    let Some(dict) = skill.as_dict() else {
+        return Ok(());
+    };
+    let Some(VmValue::Closure(closure)) = dict.get(hook_key).cloned() else {
+        return Ok(());
+    };
+    let Some(mut vm) = crate::vm::clone_async_builtin_child_vm() else {
+        return Ok(());
+    };
+    if let Err(err) = vm.call_closure_pub(&closure, &[], &[]).await {
+        crate::events::log_warn(
+            "agent.skill_hook",
+            &format!("skill={skill_name} hook={hook_key} error: {err}"),
+        );
+    }
+    Ok(())
+}
+
+fn list_of_strings(value: Option<&VmValue>) -> Vec<String> {
+    match value {
+        Some(VmValue::List(list)) => list.iter().map(|v| v.display()).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Extract the most recent user-role message content from the outgoing
+/// payload. Used as the "query" for metadata scoring and as the
+/// `prompt` param for bridge-based matchers.
+fn latest_user_prompt(opts: &crate::llm::api::LlmCallOptions) -> String {
+    for message in opts.messages.iter().rev() {
+        if message.get("role").and_then(|v| v.as_str()) == Some("user") {
+            if let Some(content) = message.get("content").and_then(|v| v.as_str()) {
+                return content.to_string();
+            }
+        }
+    }
+    String::new()
+}
+
+/// Search `state.visible_messages` for the most recent user message.
+/// Preferred over `opts.messages` because visible_messages carries
+/// every post-turn injection from the previous iteration, while
+/// `opts.messages` only refreshes in `turn_preflight`. Returns `None`
+/// when no user message is present (callers fall back to opts).
+fn latest_user_prompt_from_state(state: &AgentLoopState) -> Option<String> {
+    for message in state.visible_messages.iter().rev() {
+        if message.get("role").and_then(|v| v.as_str()) == Some("user") {
+            if let Some(content) = message.get("content").and_then(|v| v.as_str()) {
+                return Some(content.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// BM25-ish scorer over `description` + `when_to_use`, combined with
+/// `paths:` glob matching. A path hit dominates — if the user is
+/// editing a file the skill claims to own, that's a stronger signal
+/// than any keyword overlap.
+fn score_metadata(
+    skills: &[VmValue],
+    prompt: &str,
+    working_files: &[String],
+) -> Vec<SkillCandidate> {
+    let tokens = tokenize_lower(prompt);
+    let mut candidates = Vec::new();
+    for skill in skills {
+        // Skip skills the author marked off-limits to the model.
+        if ActiveSkill::is_disabled_for_model(skill) {
+            continue;
+        }
+        let Some(dict) = skill.as_dict() else {
+            continue;
+        };
+        let name = dict.get("name").map(|v| v.display()).unwrap_or_default();
+        let description = dict
+            .get("description")
+            .map(|v| v.display())
+            .unwrap_or_default();
+        let when_to_use = dict
+            .get("when_to_use")
+            .map(|v| v.display())
+            .unwrap_or_default();
+        let paths = list_of_strings(dict.get("paths"));
+
+        let mut score = 0.0_f64;
+        let mut reasons: Vec<String> = Vec::new();
+
+        let keyword_hits =
+            count_term_hits(&tokens, &description) + count_term_hits(&tokens, &when_to_use);
+        if keyword_hits > 0 {
+            // Normalize by (token count + BM25-ish saturation) so a
+            // skill with a short, high-overlap description doesn't lose
+            // to a long verbose one.
+            let bm25 = (keyword_hits as f64) / (keyword_hits as f64 + 1.5);
+            score += bm25;
+            reasons.push(format!("{keyword_hits} keyword hit(s)"));
+        }
+
+        // Name-in-prompt is a very strong signal (explicit skill name
+        // mention). Boost even above path hits.
+        if !name.is_empty() && prompt.to_lowercase().contains(&name.to_lowercase()) {
+            score += 2.0;
+            reasons.push(format!("prompt mentions '{name}'"));
+        }
+
+        let path_hits = count_path_hits(&paths, working_files);
+        if path_hits > 0 {
+            score += 1.5 * (path_hits as f64);
+            reasons.push(format!("{path_hits} path glob(s) matched"));
+        }
+
+        if score > 0.0 {
+            let reason = if reasons.is_empty() {
+                String::new()
+            } else {
+                reasons.join("; ")
+            };
+            candidates.push(SkillCandidate {
+                name,
+                score,
+                reason,
+            });
+        }
+    }
+    candidates
+}
+
+fn tokenize_lower(text: &str) -> Vec<String> {
+    text.split(|c: char| !c.is_alphanumeric())
+        .filter(|t| t.len() > 2)
+        .map(|t| t.to_lowercase())
+        .collect()
+}
+
+fn count_term_hits(terms: &[String], haystack: &str) -> usize {
+    if terms.is_empty() || haystack.is_empty() {
+        return 0;
+    }
+    let lower = haystack.to_lowercase();
+    terms
+        .iter()
+        .filter(|term| lower.contains(term.as_str()))
+        .count()
+}
+
+/// Count working files matched by any path glob on the skill. Globs
+/// support `*` (single segment) and `**` (multi-segment) with the
+/// semantics of ordinary shell globbing. Absolute or workspace-relative
+/// paths are both accepted — matching is string-based.
+fn count_path_hits(patterns: &[String], working_files: &[String]) -> usize {
+    let mut hits = 0;
+    for pattern in patterns {
+        for file in working_files {
+            if glob_match(pattern, file) {
+                hits += 1;
+                break;
+            }
+        }
+    }
+    hits
+}
+
+/// Simple glob matcher supporting `*` (non-separator) and `**`
+/// (cross-separator). Intentionally self-contained — the existing
+/// workspace had two other glob matchers but both were tightly coupled
+/// to their callers.
+fn glob_match(pattern: &str, path: &str) -> bool {
+    let pat_bytes = pattern.as_bytes();
+    let path_bytes = path.as_bytes();
+    glob_match_inner(pat_bytes, 0, path_bytes, 0)
+}
+
+fn glob_match_inner(pat: &[u8], mut pi: usize, path: &[u8], mut si: usize) -> bool {
+    while pi < pat.len() {
+        match pat[pi] {
+            b'*' => {
+                let double = pi + 1 < pat.len() && pat[pi + 1] == b'*';
+                let next_pi = if double { pi + 2 } else { pi + 1 };
+                // Skip trailing slash after `**/`
+                let (next_pi, _after_double_slash) =
+                    if double && next_pi < pat.len() && pat[next_pi] == b'/' {
+                        (next_pi + 1, true)
+                    } else {
+                        (next_pi, false)
+                    };
+                if next_pi >= pat.len() {
+                    // Trailing `*` or `**` matches the rest.
+                    if double {
+                        return true;
+                    }
+                    // Single-`*` does not cross `/`.
+                    return !path[si..].contains(&b'/');
+                }
+                // Try every suffix of `path[si..]`.
+                for try_si in si..=path.len() {
+                    if !double {
+                        // `*` does not cross `/`: abort as soon as we see a slash.
+                        if path[si..try_si].contains(&b'/') {
+                            break;
+                        }
+                    }
+                    if glob_match_inner(pat, next_pi, path, try_si) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            b'?' => {
+                if si >= path.len() || path[si] == b'/' {
+                    return false;
+                }
+                pi += 1;
+                si += 1;
+            }
+            c => {
+                if si >= path.len() || path[si] != c {
+                    return false;
+                }
+                pi += 1;
+                si += 1;
+            }
+        }
+    }
+    si == path.len()
+}
+
+async fn score_via_bridge(
+    bridge: Option<&HostBridge>,
+    skills: &[VmValue],
+    prompt: &str,
+    working_files: &[String],
+    strategy: &SkillMatchStrategy,
+) -> Result<Vec<SkillCandidate>, VmError> {
+    let Some(bridge) = bridge else {
+        return Err(VmError::Runtime(
+            "skill_match strategy=\"host\" requires a host bridge".to_string(),
+        ));
+    };
+    let candidate_meta: Vec<serde_json::Value> = skills
+        .iter()
+        .filter_map(|s| s.as_dict())
+        .map(|d| {
+            serde_json::json!({
+                "name": d.get("name").map(|v| v.display()).unwrap_or_default(),
+                "description": d.get("description").map(|v| v.display()).unwrap_or_default(),
+                "when_to_use": d.get("when_to_use").map(|v| v.display()).unwrap_or_default(),
+                "paths": list_of_strings(d.get("paths")),
+            })
+        })
+        .collect();
+    let params = serde_json::json!({
+        "strategy": strategy.as_str(),
+        "prompt": prompt,
+        "working_files": working_files,
+        "candidates": candidate_meta,
+    });
+    let response = bridge.call("skill/match", params).await?;
+    let list = response
+        .get("matches")
+        .or_else(|| response.get("skills"))
+        .or_else(|| response.get("result").and_then(|r| r.get("matches")))
+        .cloned()
+        .or_else(|| {
+            if response.is_array() {
+                Some(response)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(serde_json::Value::Array(Vec::new()));
+    let arr = list.as_array().cloned().unwrap_or_default();
+    let mut out = Vec::new();
+    for entry in arr {
+        let name = entry
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if name.is_empty() {
+            continue;
+        }
+        let score = entry.get("score").and_then(|v| v.as_f64()).unwrap_or(1.0);
+        let reason = entry
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .unwrap_or("host match")
+            .to_string();
+        out.push(SkillCandidate {
+            name,
+            score,
+            reason,
+        });
+    }
+    Ok(out)
+}
+
+/// Parse the `skills:` / `skill_match:` / `working_files:` options off
+/// the agent_loop options dict into concrete typed state. Called from
+/// `AgentLoopConfig` parsing.
+pub fn parse_skill_config(
+    options: &Option<BTreeMap<String, VmValue>>,
+) -> (Option<VmValue>, SkillMatchConfig, Vec<String>) {
+    let Some(opts) = options else {
+        return (None, SkillMatchConfig::default(), Vec::new());
+    };
+    let skill_registry = opts.get("skills").and_then(normalize_skill_registry);
+    let skill_match = opts
+        .get("skill_match")
+        .and_then(|v| v.as_dict())
+        .map(parse_skill_match_config)
+        .unwrap_or_default();
+    let working_files = match opts.get("working_files") {
+        Some(VmValue::List(list)) => list.iter().map(|v| v.display()).collect(),
+        Some(VmValue::String(s)) => vec![s.to_string()],
+        _ => Vec::new(),
+    };
+    (skill_registry, skill_match, working_files)
+}
+
+/// Accept a registry dict, a list of skill entries, or a list of
+/// skill-name strings. The last form requires the registry to be
+/// supplied separately, so it falls through to `None` today — the
+/// issue spec names it as a future shape.
+fn normalize_skill_registry(value: &VmValue) -> Option<VmValue> {
+    match value {
+        VmValue::Dict(d)
+            if d.get("_type")
+                .map(|v| v.display() == "skill_registry")
+                .unwrap_or(false) =>
+        {
+            Some(value.clone())
+        }
+        VmValue::List(list) => {
+            // Wrap a list of skill entries into a synthetic registry.
+            let mut dict = BTreeMap::new();
+            dict.insert(
+                "_type".to_string(),
+                VmValue::String(Rc::from("skill_registry")),
+            );
+            dict.insert("skills".to_string(), VmValue::List(list.clone()));
+            Some(VmValue::Dict(Rc::new(dict)))
+        }
+        _ => None,
+    }
+}
+
+fn parse_skill_match_config(dict: &BTreeMap<String, VmValue>) -> SkillMatchConfig {
+    let strategy = dict
+        .get("strategy")
+        .map(|v| v.display())
+        .map(|s| SkillMatchStrategy::parse(&s))
+        .unwrap_or_default();
+    let top_n = dict
+        .get("top_n")
+        .and_then(|v| v.as_int())
+        .map(|n| n.max(1) as usize)
+        .unwrap_or(1);
+    let sticky = dict
+        .get("sticky")
+        .map(|v| matches!(v, VmValue::Bool(true)))
+        .unwrap_or(true);
+    SkillMatchConfig {
+        strategy,
+        top_n,
+        sticky,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_basic_match() {
+        assert!(glob_match("src/*.rs", "src/main.rs"));
+        assert!(!glob_match("src/*.rs", "src/sub/main.rs"));
+        assert!(glob_match("src/**/*.rs", "src/sub/dir/main.rs"));
+        assert!(glob_match("Dockerfile", "Dockerfile"));
+        assert!(!glob_match("Dockerfile", "Dockerfile.dev"));
+        assert!(glob_match("infra/**", "infra/terraform/main.tf"));
+    }
+
+    #[test]
+    fn tokenize_skips_short_and_punct() {
+        let tokens = tokenize_lower("Deploy the AI service (to prod)!");
+        assert!(tokens.contains(&"deploy".to_string()));
+        assert!(tokens.contains(&"service".to_string()));
+        assert!(tokens.contains(&"prod".to_string()));
+        assert!(!tokens.contains(&"ai".to_string())); // too short (len 2)
+        assert!(!tokens.contains(&"to".to_string())); // too short
+    }
+
+    #[test]
+    fn score_metadata_ranks_prompt_mentions_highest() {
+        use std::rc::Rc;
+        let skill_a = VmValue::Dict(Rc::new(BTreeMap::from([
+            ("name".to_string(), VmValue::String(Rc::from("deploy"))),
+            (
+                "description".to_string(),
+                VmValue::String(Rc::from("Deploy the application to production")),
+            ),
+            (
+                "when_to_use".to_string(),
+                VmValue::String(Rc::from("User says deploy/ship/release")),
+            ),
+        ])));
+        let skill_b = VmValue::Dict(Rc::new(BTreeMap::from([
+            ("name".to_string(), VmValue::String(Rc::from("test"))),
+            (
+                "description".to_string(),
+                VmValue::String(Rc::from("Run unit tests")),
+            ),
+        ])));
+        let skills = vec![skill_a, skill_b];
+        let ranked = score_metadata(&skills, "Please deploy the staging service", &[]);
+        assert_eq!(ranked[0].name, "deploy");
+    }
+
+    #[test]
+    fn score_metadata_path_hit_beats_nothing() {
+        use std::rc::Rc;
+        let skill = VmValue::Dict(Rc::new(BTreeMap::from([
+            ("name".to_string(), VmValue::String(Rc::from("infra"))),
+            (
+                "description".to_string(),
+                VmValue::String(Rc::from("Infrastructure work")),
+            ),
+            (
+                "paths".to_string(),
+                VmValue::List(Rc::new(vec![
+                    VmValue::String(Rc::from("infra/**")),
+                    VmValue::String(Rc::from("Dockerfile")),
+                ])),
+            ),
+        ])));
+        let working = vec!["infra/terraform/main.tf".to_string()];
+        let ranked = score_metadata(&[skill], "unrelated prompt", &working);
+        assert_eq!(ranked.len(), 1);
+        assert!(ranked[0].score >= 1.5);
+        assert!(ranked[0].reason.contains("path"));
+    }
+
+    #[test]
+    fn disable_model_invocation_filters_out() {
+        use std::rc::Rc;
+        let skill = VmValue::Dict(Rc::new(BTreeMap::from([
+            ("name".to_string(), VmValue::String(Rc::from("secret"))),
+            (
+                "description".to_string(),
+                VmValue::String(Rc::from("Private skill")),
+            ),
+            ("disable-model-invocation".to_string(), VmValue::Bool(true)),
+        ])));
+        let ranked = score_metadata(&[skill], "private secret thing", &[]);
+        assert!(ranked.is_empty());
+    }
+}

--- a/crates/harn-vm/src/llm/agent/state.rs
+++ b/crates/harn-vm/src/llm/agent/state.rs
@@ -8,7 +8,7 @@
 use std::rc::Rc;
 
 use crate::llm::daemon::{watch_state, DaemonLoopConfig};
-use crate::value::VmError;
+use crate::value::{VmError, VmValue};
 
 use super::super::agent_config::AgentLoopConfig;
 use super::super::agent_tools::{
@@ -174,6 +174,200 @@ impl Drop for SessionSinkGuard {
     }
 }
 
+/// Strategy for picking a skill from the registry. `Metadata` runs
+/// entirely inside the VM; `Host` / `Embedding` delegate to the host via
+/// the `skill/match` bridge RPC.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum SkillMatchStrategy {
+    #[default]
+    Metadata,
+    Host,
+    Embedding,
+}
+
+impl SkillMatchStrategy {
+    pub fn parse(s: &str) -> Self {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "host" => Self::Host,
+            "embedding" => Self::Embedding,
+            "metadata" | "" => Self::Metadata,
+            other => {
+                crate::events::log_warn(
+                    "agent.skill_match",
+                    &format!("unknown strategy '{other}', falling back to 'metadata'"),
+                );
+                Self::Metadata
+            }
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Metadata => "metadata",
+            Self::Host => "host",
+            Self::Embedding => "embedding",
+        }
+    }
+}
+
+/// User-facing `skill_match:` config dict parsed off the agent_loop
+/// options dict.
+#[derive(Clone, Debug)]
+pub struct SkillMatchConfig {
+    pub strategy: SkillMatchStrategy,
+    pub top_n: usize,
+    /// When `true`, once a skill activates it stays active for the rest
+    /// of the loop. When `false`, the reassess phase re-runs after each
+    /// turn and may swap it out.
+    pub sticky: bool,
+}
+
+impl Default for SkillMatchConfig {
+    fn default() -> Self {
+        Self {
+            strategy: SkillMatchStrategy::Metadata,
+            top_n: 1,
+            sticky: true,
+        }
+    }
+}
+
+/// Concrete per-skill metadata after activation. Derived from the raw
+/// skill-registry entry once on activation so downstream phases don't
+/// re-walk VM dicts every turn.
+#[derive(Clone, Debug, Default)]
+#[allow(dead_code)]
+pub struct ActiveSkill {
+    pub name: String,
+    pub description: String,
+    pub prompt: Option<String>,
+    pub when_to_use: String,
+    pub paths: Vec<String>,
+    pub allowed_tools: Vec<String>,
+    pub mcp_servers: Vec<String>,
+    pub model: Option<String>,
+    pub effort: Option<String>,
+    pub invocation: String,
+    pub disable_model_invocation: bool,
+    pub user_invocable: bool,
+}
+
+impl ActiveSkill {
+    /// Project a raw skill-registry entry (a `VmValue::Dict`) into the
+    /// strongly-typed activation view. Tolerates missing fields with
+    /// defaults matching Anthropic's SKILL.md frontmatter semantics
+    /// (`user-invocable` defaults to `true`, `disable-model-invocation`
+    /// to `false`).
+    ///
+    /// Single source of truth for ActiveSkill construction — the
+    /// matching phase and the session-rehydration path both route
+    /// through here so the two can't drift.
+    pub(crate) fn from_entry(entry: &VmValue) -> Self {
+        let Some(dict) = entry.as_dict() else {
+            return Self::default();
+        };
+        let list_strings = |v: Option<&VmValue>| -> Vec<String> {
+            match v {
+                Some(VmValue::List(list)) => list.iter().map(|x| x.display()).collect(),
+                _ => Vec::new(),
+            }
+        };
+        let non_empty = |v: Option<&VmValue>| -> Option<String> {
+            v.map(|value| value.display()).filter(|s| !s.is_empty())
+        };
+        let bool_with = |keys: &[&str], default: bool| -> bool {
+            keys.iter()
+                .find_map(|key| dict.get(*key))
+                .map(|v| matches!(v, VmValue::Bool(true)))
+                .unwrap_or(default)
+        };
+        Self {
+            name: dict.get("name").map(|v| v.display()).unwrap_or_default(),
+            description: dict
+                .get("description")
+                .map(|v| v.display())
+                .unwrap_or_default(),
+            prompt: non_empty(dict.get("prompt")),
+            when_to_use: dict
+                .get("when_to_use")
+                .map(|v| v.display())
+                .unwrap_or_default(),
+            paths: list_strings(dict.get("paths")),
+            allowed_tools: list_strings(dict.get("allowed_tools")),
+            mcp_servers: list_strings(dict.get("mcp")),
+            model: non_empty(dict.get("model")),
+            effort: non_empty(dict.get("effort")),
+            invocation: dict
+                .get("invocation")
+                .map(|v| v.display())
+                .unwrap_or_default(),
+            disable_model_invocation: bool_with(
+                &["disable-model-invocation", "disable_model_invocation"],
+                false,
+            ),
+            user_invocable: bool_with(&["user-invocable", "user_invocable"], true),
+        }
+    }
+
+    /// True when the skill's `disable-model-invocation` frontmatter is
+    /// set. Used by the metadata matcher to filter candidates.
+    pub(crate) fn is_disabled_for_model(entry: &VmValue) -> bool {
+        let Some(dict) = entry.as_dict() else {
+            return false;
+        };
+        matches!(
+            dict.get("disable-model-invocation")
+                .or_else(|| dict.get("disable_model_invocation")),
+            Some(VmValue::Bool(true))
+        )
+    }
+}
+
+/// Restore previously-active skills for a session when the caller
+/// re-enters it. Anonymous (caller-less session_id) loops always start
+/// empty — their transcript doesn't persist either.
+///
+/// Rehydration runs against the *current* skill registry, so a skill
+/// that was active on the last run but has since been removed just
+/// quietly drops off the active set — it won't block the match phase
+/// from re-running.
+fn rehydrate_active_skills(
+    anonymous: bool,
+    session_id: &str,
+    registry: Option<&crate::value::VmValue>,
+) -> Vec<ActiveSkill> {
+    if anonymous {
+        return Vec::new();
+    }
+    let Some(registry) = registry else {
+        return Vec::new();
+    };
+    let Some(dict) = registry.as_dict() else {
+        return Vec::new();
+    };
+    let skills: Vec<crate::value::VmValue> = match dict.get("skills") {
+        Some(crate::value::VmValue::List(list)) => list.iter().cloned().collect(),
+        _ => Vec::new(),
+    };
+    let names = crate::agent_sessions::active_skills(session_id);
+    if names.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    for name in names {
+        let Some(entry) = skills.iter().find(|s| {
+            s.as_dict()
+                .and_then(|d| d.get("name"))
+                .map(|v| v.display() == name)
+                .unwrap_or(false)
+        }) else {
+            continue;
+        };
+        out.push(ActiveSkill::from_entry(entry));
+    }
+    out
+}
+
 /// Every long-lived local the agent loop carried in
 /// `run_agent_loop_internal`, gathered onto a single owned struct so
 /// phase methods can take `&mut self` and mutate state in place.
@@ -263,6 +457,32 @@ pub(super) struct AgentLoopState {
     /// `ToolSearchMode::Client` resolved for this loop (harn#70).
     pub(super) tool_search_client: Option<ClientToolSearchState>,
 
+    /// Skill registry (validated `{_type: "skill_registry", skills: [...]}`)
+    /// passed in via `agent_loop(…, {skills: …})`. `None` when no
+    /// skill system is configured for this loop.
+    pub(crate) skill_registry: Option<VmValue>,
+    /// Match configuration — strategy, top_n, sticky flag.
+    pub(crate) skill_match: SkillMatchConfig,
+    /// Host-supplied working file set. Feeds `paths:` auto-trigger
+    /// scoring in the metadata matcher and rides along as a hint to
+    /// host-based matchers.
+    pub(crate) working_files: Vec<String>,
+    /// Currently-active skills after the most recent match / reassess
+    /// phase. Empty when no skill activated. Preserves insertion order
+    /// so deterministic top_n selection stays stable across turns.
+    pub(crate) active_skills: Vec<ActiveSkill>,
+    /// Snapshot of `opts.native_tools` taken in `new()` before any
+    /// skill-scope narrowing. Used to restore the full tool list when
+    /// an active skill deactivates. `None` when no native tools were
+    /// configured.
+    pub(super) native_tools_snapshot: Option<Vec<serde_json::Value>>,
+    /// True when `active_skills` was populated from a persisted
+    /// session. Signals the matching phase to preserve the restored
+    /// set on iteration 0 instead of re-matching from scratch — that
+    /// keeps session-resume semantics stable across agent_loop
+    /// invocations under the same `session_id`.
+    pub(crate) rehydrated_from_session: bool,
+
     // Drop guards: see "Drop ordering" on the struct docs.
     pub(super) _approval_guard: ApprovalPolicyGuard,
     pub(super) _policy_guard: ExecutionPolicyGuard,
@@ -271,6 +491,103 @@ pub(super) struct AgentLoopState {
 }
 
 impl AgentLoopState {
+    /// Union of `allowed_tools` across every active skill. Empty when
+    /// no skill narrows the tool surface — callers should fall through
+    /// to the unfiltered registry and native_tools list.
+    pub(crate) fn skill_allowed_tools(&self) -> std::collections::BTreeSet<String> {
+        self.active_skills
+            .iter()
+            .filter(|s| !s.allowed_tools.is_empty())
+            .flat_map(|s| s.allowed_tools.iter().cloned())
+            .collect()
+    }
+
+    /// Produce a skill-scoped view of the original `tools_val` registry.
+    /// When any active skill carries a non-empty `allowed_tools` list,
+    /// the union of those names is the whitelist for the upcoming turn.
+    /// Tools outside the whitelist are filtered out of the registry so
+    /// the provider schema, contract prompt, and dispatch all see the
+    /// narrower surface.
+    ///
+    /// Returns `None` when there's no active scope to apply — callers
+    /// should fall through to the original registry.
+    pub(crate) fn skill_scoped_tools_val(
+        &self,
+        tools_val: Option<&crate::value::VmValue>,
+    ) -> Option<crate::value::VmValue> {
+        use crate::value::VmValue;
+        use std::rc::Rc;
+
+        let tools_val = tools_val?;
+        let dict = tools_val.as_dict()?;
+        let allowed = self.skill_allowed_tools();
+        if allowed.is_empty() {
+            return None;
+        }
+        let tools_list = match dict.get("tools") {
+            Some(VmValue::List(list)) => list,
+            _ => return None,
+        };
+        let mut kept: Vec<VmValue> = Vec::with_capacity(tools_list.len());
+        for entry in tools_list.iter() {
+            let keep = match entry {
+                VmValue::Dict(d) => d
+                    .get("name")
+                    .map(|v| v.display())
+                    .map(|name| allowed.contains(&name))
+                    .unwrap_or(false),
+                _ => false,
+            };
+            if keep {
+                kept.push(entry.clone());
+            }
+        }
+        let mut new_dict = dict.clone();
+        new_dict.insert("tools".to_string(), VmValue::List(Rc::new(kept)));
+        Some(VmValue::Dict(Rc::new(new_dict)))
+    }
+
+    /// Rebuild `opts.native_tools` from the canonical snapshot, then
+    /// apply the skill-scope whitelist. Single source of truth for
+    /// "what the provider sees this turn": activate narrows, deactivate
+    /// restores, and the rebuild is idempotent.
+    ///
+    /// No-op when `native_tools_snapshot` is `None` (text-mode contract
+    /// prompt without a native channel).
+    pub(super) fn rebuild_scoped_native_tools(&self, opts: &mut crate::llm::api::LlmCallOptions) {
+        let Some(snapshot) = self.native_tools_snapshot.as_ref() else {
+            return;
+        };
+        let allowed = self.skill_allowed_tools();
+        if allowed.is_empty() {
+            opts.native_tools = Some(snapshot.clone());
+            return;
+        }
+        let filtered: Vec<serde_json::Value> = snapshot
+            .iter()
+            .filter(|entry| {
+                let name = entry
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| {
+                        entry
+                            .get("function")
+                            .and_then(|f| f.get("name"))
+                            .and_then(|v| v.as_str())
+                    })
+                    .unwrap_or("");
+                // Always keep the synthetic `__harn_tool_search` tool —
+                // a skill's `allowed_tools` gates the user-declared
+                // surface, not the runtime's own scaffolding. Without
+                // this, activating a skill while `tool_search` is
+                // configured silently kills progressive disclosure.
+                name.starts_with("__harn_") || allowed.contains(name)
+            })
+            .cloned()
+            .collect();
+        opts.native_tools = Some(filtered);
+    }
+
     /// Rebuild the tool-calling contract prompt for a turn with the
     /// current promoted-tool set factored in. Returns `None` when the
     /// loop isn't running in client-mode tool_search (use the baked-in
@@ -424,6 +741,9 @@ impl AgentLoopState {
         let max_iterations = config.max_iterations;
         let persistent = config.persistent;
         let max_nudges = config.max_nudges;
+        let config_skill_registry = config.skill_registry.clone();
+        let config_skill_match = config.skill_match.clone();
+        let config_working_files = config.working_files.clone();
         let custom_nudge = config.nudge.clone();
         let done_sentinel = config
             .done_sentinel
@@ -522,6 +842,11 @@ impl AgentLoopState {
         let native_tools_for_prompt = opts.native_tools.clone();
         opts.native_tools =
             normalize_native_tools_for_format(&tool_format, opts.native_tools.clone());
+        // Capture the post-normalization native_tools list as the
+        // canonical full set. Subsequent turn_preflights use this to
+        // rebuild `opts.native_tools` from scratch — activate narrows,
+        // deactivate restores the full surface.
+        let native_tools_snapshot = opts.native_tools.clone();
         opts.tool_choice = normalize_tool_choice_for_format(
             &opts.provider,
             &tool_format,
@@ -712,6 +1037,12 @@ impl AgentLoopState {
             }
         }
 
+        let rehydrated_active_skills = rehydrate_active_skills(
+            anonymous_session,
+            &session_id,
+            config_skill_registry.as_ref(),
+        );
+
         Ok(Self {
             config,
             session_id,
@@ -760,6 +1091,12 @@ impl AgentLoopState {
             daemon_config,
             custom_nudge,
             tool_search_client,
+            rehydrated_from_session: !rehydrated_active_skills.is_empty(),
+            active_skills: rehydrated_active_skills,
+            skill_registry: config_skill_registry,
+            skill_match: config_skill_match,
+            working_files: config_working_files,
+            native_tools_snapshot,
             _approval_guard,
             _policy_guard,
             _sink_guard,

--- a/crates/harn-vm/src/llm/agent/tests.rs
+++ b/crates/harn-vm/src/llm/agent/tests.rs
@@ -89,6 +89,9 @@ fn base_agent_config() -> AgentLoopConfig {
         event_sink: None,
         task_ledger: Default::default(),
         post_turn_callback: None,
+        skill_registry: None,
+        skill_match: Default::default(),
+        working_files: Vec::new(),
     }
 }
 

--- a/crates/harn-vm/src/llm/agent/turn_preflight.rs
+++ b/crates/harn-vm/src/llm/agent/turn_preflight.rs
@@ -43,6 +43,10 @@ pub(super) struct PreflightContext<'a> {
     pub base_system: Option<&'a str>,
     pub tool_contract_prompt: Option<&'a str>,
     pub persistent_system_prompt: Option<&'a str>,
+    /// Skill-scoped tool registry for this turn, when skill activation
+    /// narrowed `tools_val`. `None` when the full registry is in
+    /// effect — the preflight then uses the baked-in `tool_contract_prompt`.
+    pub scoped_tools_val: Option<&'a crate::value::VmValue>,
 }
 
 pub(super) async fn run_turn_preflight(
@@ -81,11 +85,36 @@ pub(super) async fn run_turn_preflight(
     // tools) would be reused for turn N, and the model wouldn't see
     // the schemas the search tool just surfaced.
     let dynamic_contract_prompt = state.rebuild_tool_contract_prompt(opts);
-    let tool_prompt_override = dynamic_contract_prompt.as_deref();
-    let tool_prompt_slot = tool_prompt_override.or(ctx.tool_contract_prompt);
+    // Skill-scoped tool prompt: when an active skill narrows the tool
+    // surface, rebuild the contract prompt against the scoped view so
+    // the model's schema list matches the dispatch allowlist. Takes
+    // priority over the baked-in snapshot but not over the dynamic
+    // tool_search prompt.
+    let scoped_contract_prompt = ctx
+        .scoped_tools_val
+        .filter(|_| dynamic_contract_prompt.is_none() && state.has_tools)
+        .map(|tv| {
+            crate::llm::tools::build_tool_calling_contract_prompt(
+                Some(tv),
+                opts.native_tools.as_deref(),
+                &state.tool_format,
+                state
+                    .config
+                    .turn_policy
+                    .as_ref()
+                    .is_some_and(|policy| policy.require_action_or_yield),
+                state.config.tool_examples.as_deref(),
+            )
+        });
+    let tool_prompt_slot = dynamic_contract_prompt
+        .as_deref()
+        .or(scoped_contract_prompt.as_deref())
+        .or(ctx.tool_contract_prompt);
 
+    let skill_prompt = render_active_skill_prompt(&state.active_skills);
+    let base_with_skill = merge_optional(ctx.base_system, skill_prompt.as_deref());
     let default_system = build_agent_system_prompt(
-        ctx.base_system,
+        base_with_skill.as_deref(),
         tool_prompt_slot,
         ctx.persistent_system_prompt,
     );
@@ -140,7 +169,62 @@ pub(super) async fn run_turn_preflight(
         &call_messages,
     );
 
+    // Rebuild opts.native_tools from the baseline snapshot and apply
+    // the active skill's allowed_tools whitelist. Idempotent across
+    // turns — activation narrows, deactivation restores. Works whether
+    // or not a scoped view currently applies (the helper handles both
+    // paths).
+    state.rebuild_scoped_native_tools(opts);
+
     opts.messages = call_messages;
     opts.system = call_system;
     Ok(())
+}
+
+/// Render the active-skill block that gets appended to the base system
+/// prompt. Each skill contributes its description (always) and body
+/// prompt (when non-empty) under a `## Active skill: <name>` heading.
+/// Returns `None` when no skills are active — callers fall back to the
+/// unmodified base prompt.
+fn render_active_skill_prompt(active: &[super::state::ActiveSkill]) -> Option<String> {
+    if active.is_empty() {
+        return None;
+    }
+    let mut out = String::from("\n\n## Active skills\n");
+    for skill in active {
+        out.push_str(&format!("\n### {}\n", skill.name));
+        if !skill.description.is_empty() {
+            out.push_str(&format!("{}\n", skill.description.trim()));
+        }
+        if !skill.when_to_use.is_empty() {
+            out.push_str(&format!("When to use: {}\n", skill.when_to_use.trim()));
+        }
+        if !skill.allowed_tools.is_empty() {
+            out.push_str(&format!(
+                "Scoped tools: {}\n",
+                skill.allowed_tools.join(", ")
+            ));
+        }
+        if let Some(prompt) = skill.prompt.as_deref() {
+            let trimmed = prompt.trim();
+            if !trimmed.is_empty() {
+                out.push('\n');
+                out.push_str(trimmed);
+                out.push('\n');
+            }
+        }
+    }
+    Some(out)
+}
+
+fn merge_optional(base: Option<&str>, extra: Option<&str>) -> Option<String> {
+    match (base, extra) {
+        (Some(b), Some(e)) => {
+            let trimmed_b = b.trim_end();
+            Some(format!("{trimmed_b}{e}"))
+        }
+        (Some(b), None) => Some(b.to_string()),
+        (None, Some(e)) => Some(e.trim_start().to_string()),
+        (None, None) => None,
+    }
 }

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -77,6 +77,14 @@ pub struct AgentLoopConfig {
     /// - `true`: stop the stage immediately
     /// - `{message, stop}` dict: both (optional `message`, optional `stop`)
     pub post_turn_callback: Option<crate::value::VmValue>,
+    /// Skill registry (from `skill_registry()` / `skill { }` decls)
+    /// exposed to the skill-matching phase. `None` disables skills for
+    /// this loop.
+    pub skill_registry: Option<VmValue>,
+    /// Skill matching configuration (strategy, top_n, sticky).
+    pub skill_match: super::agent::SkillMatchConfig,
+    /// Working file set fed into `paths:` auto-trigger scoring.
+    pub working_files: Vec<String>,
 }
 
 impl std::fmt::Debug for AgentLoopConfig {
@@ -309,6 +317,8 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                     serde_json::from_value::<crate::orchestration::TurnPolicy>(json)
                         .unwrap_or_default()
                 });
+            let (skill_registry, skill_match, working_files) =
+                super::agent::parse_skill_config(&options);
             let mut opts = extract_llm_options(&args)?;
             let result = run_agent_loop_internal(
                 &mut opts,
@@ -351,6 +361,9 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                         .and_then(|o| o.get("post_turn_callback"))
                         .filter(|v| matches!(v, crate::value::VmValue::Closure(_)))
                         .cloned(),
+                    skill_registry,
+                    skill_match,
+                    working_files,
                 },
             )
             .await?;

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -630,6 +630,8 @@ pub fn register_llm_builtins(vm: &mut Vm) {
         let break_unless_phase = opt_str(&options, "break_unless_phase");
         let exit_when_verified = opt_bool(&options, "exit_when_verified");
         let daemon_config = parse_daemon_loop_config(options.as_ref());
+        let (skill_registry, skill_match, working_files) =
+            crate::llm::agent::parse_skill_config(&options);
         let mut opts = extract_llm_options(&args)?;
         let result = run_agent_loop_internal(
             &mut opts,
@@ -666,6 +668,9 @@ pub fn register_llm_builtins(vm: &mut Vm) {
                     .and_then(|o| o.get("post_turn_callback"))
                     .filter(|v| matches!(v, crate::value::VmValue::Closure(_)))
                     .cloned(),
+                skill_registry,
+                skill_match,
+                working_files,
             },
         )
         .await?;

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -931,6 +931,9 @@ pub async fn execute_stage_node(
                         .and_then(|d| d.get("post_turn_callback"))
                         .filter(|v| matches!(v, crate::value::VmValue::Closure(_)))
                         .cloned(),
+                    skill_registry: None,
+                    skill_match: Default::default(),
+                    working_files: Vec::new(),
                 },
             )
             .await?

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -200,3 +200,77 @@ skill catalog; the CLI re-runs layered discovery (including another
 `skills/list` call) on the next iteration boundary — for `harn watch`,
 between file changes; for long-running agents, between turns. A VM
 without an active bridge simply ignores the notification.
+
+## Host-delegated skill matching
+
+Harn agents that opt into
+`skill_match: { strategy: "host" }` (or the alias `"embedding"`)
+delegate skill ranking to the host via a single JSON-RPC request. The
+host response is purely advisory — unknown skill names are ignored,
+and an RPC error falls back to the in-VM metadata ranker with a
+warning logged against `agent.skill_match`.
+
+### `skill/match`
+
+Request payload (harn-issued, host response required):
+
+```json
+{
+  "strategy": "host",
+  "prompt": "Ship the new release to production",
+  "working_files": ["infra/terraform/cluster.tf"],
+  "candidates": [
+    {
+      "name": "ship",
+      "description": "Ship a production release",
+      "when_to_use": "User says ship/release/deploy",
+      "paths": ["infra/**", "Dockerfile"]
+    },
+    {
+      "name": "review",
+      "description": "Review existing code for correctness",
+      "when_to_use": "User asks to review/audit",
+      "paths": []
+    }
+  ]
+}
+```
+
+Response payload (host-issued):
+
+```json
+{
+  "matches": [
+    {"name": "ship", "score": 0.92, "reason": "matched by embedding similarity"}
+  ]
+}
+```
+
+- `matches[*].name` (required): the candidate's skill name. Names
+  absent from the original `candidates` list are ignored.
+- `matches[*].score` (optional): non-negative float; higher scores
+  rank earlier. Defaults to `1.0` when omitted.
+- `matches[*].reason` (optional): short diagnostic stored on the
+  `skill_matched` / `skill_activated` transcript events. Defaults
+  to `"host match"`.
+
+Alternative shapes accepted for host convenience:
+
+- Top-level array: `[{"name": ..., "score": ...}, ...]`
+- `{"skills": [...]}` wrapping
+- `{"result": {"matches": [...]}}` ACP envelope
+
+### Skill lifecycle session updates
+
+Agents emit ACP `session/update` notifications for skill lifecycle
+transitions so hosts can surface active-skill state in real time.
+`harn-cli`'s ACP server translates the canonical `AgentEvent`
+variants into:
+
+- `sessionUpdate: "skill_activated"` — `{skillName, iteration, reason}`
+- `sessionUpdate: "skill_deactivated"` — `{skillName, iteration}`
+- `sessionUpdate: "skill_scope_tools"` — `{skillName, allowedTools}`
+
+`skill_matched` stays internal to the VM transcript — the candidate
+list can be large and host UIs typically only care about activation
+transitions, not every ranking pass.

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -388,6 +388,9 @@ Same as `llm_call`, plus additional options:
 | `loop_detect_warn` | int | `2` | Consecutive identical tool calls before appending a redirection hint |
 | `loop_detect_block` | int | `3` | Consecutive identical tool calls before replacing the result with a hard redirect |
 | `loop_detect_skip` | int | `4` | Consecutive identical tool calls before skipping execution entirely |
+| `skills` | skill_registry or list | nil | Skill registry exposed to the match-and-activate lifecycle phase. See [Skills lifecycle](#skills-lifecycle) |
+| `skill_match` | dict | `{strategy: "metadata", top_n: 1, sticky: true}` | Match configuration — `strategy` (`"metadata"` \| `"host"` \| `"embedding"`), `top_n`, `sticky` |
+| `working_files` | list\|string | `[]` | Paths that feed `paths:` glob auto-trigger in the metadata matcher and ride along as a hint to host-delegated matchers |
 
 When `daemon: true`, the loop transitions `active -> idle -> active` instead of
 terminating on a text-only turn. Idle daemons can be woken by queued human
@@ -527,6 +530,104 @@ retry 3 {
   println(result.text)
 }
 ```
+
+## Skills lifecycle
+
+Skills bundle metadata, a system-prompt fragment, scoped tools, and
+lifecycle hooks into a typed unit. Declare them with the top-level
+`skill NAME { ... }` language form (see [the Harn spec](./language-spec.md))
+or the imperative `skill_define(...)` builtin, then pass the resulting
+`skill_registry` to `agent_loop` via the `skills:` option. The agent
+loop matches, activates, and (optionally) deactivates skills across
+turns automatically.
+
+### Matching strategies
+
+`skill_match: { strategy: ..., top_n: 1, sticky: true }` controls how
+the loop picks which skill(s) to activate:
+
+- `"metadata"` (default) — in-VM BM25-ish scoring over
+  `description` + `when_to_use` combined with glob matching against
+  the `paths:` list. Name-in-prompt mentions count as a strong
+  boost. No host round-trip, so matching is fast and deterministic.
+- `"host"` — delegates scoring to the host via the `skill/match`
+  bridge RPC (see [bridge-protocol.md](./bridge-protocol.md)).
+  Useful for embedding-based or LLM-driven matchers. Failing RPC
+  falls back to metadata scoring with a warning.
+- `"embedding"` — alias for `"host"`; accepted so the language
+  matches Anthropic's canonical terminology.
+
+### Activation lifecycle
+
+- **Match** runs at the head of iteration 0 (always) and, when
+  `sticky: false`, before every subsequent iteration (reassess).
+- **Activate**: the skill's `on_activate` closure (if any) is
+  called, its `prompt` body is woven into the effective system
+  prompt, and `allowed_tools` narrows the tool surface for the
+  next LLM call. Each activation emits
+  `AgentEvent::SkillActivated` + a `skill_activated` transcript
+  event with the match score and reason.
+- **Deactivate** (only in `sticky: false` mode) — when reassess
+  picks a different top-N, the previously-active skill's
+  `on_deactivate` runs and the scoped tool filter is dropped.
+  Emits `AgentEvent::SkillDeactivated` + a `skill_deactivated`
+  transcript event.
+- **Session resume**: when `session_id:` is set, the set of active
+  skills at the end of one run is persisted in the session store.
+  The next `agent_loop` call on the same session rehydrates them
+  before iteration-0 matching runs, so sticky re-entry stays hot
+  without re-matching from a cold prompt.
+
+### Scoped tools
+
+A skill's `allowed_tools` list is the union across all active
+skills; any tool outside that union is filtered out of both the
+contract prompt and the native tool schemas the provider sees.
+Runtime-internal tools like `__harn_tool_search` are never filtered
+— scoping gates the user-declared surface, not the runtime's own
+scaffolding.
+
+### Frontmatter honoured by the runtime
+
+| Field | Type | Effect |
+|---|---|---|
+| `description` | string | Primary ranking signal for metadata matching |
+| `when_to_use` | string | Secondary ranking signal |
+| `paths` | `list<string>` | Glob patterns for `paths:` auto-trigger |
+| `allowed_tools` | `list<string>` | Whitelist applied to the tool surface on activation |
+| `prompt` | string | Body woven into the active-skill system-prompt block |
+| `disable-model-invocation` | bool | When `true`, the matcher skips the skill entirely |
+| `user-invocable` | bool | Placeholder for host UI (not consumed by the runtime today) |
+| `mcp` | `list<string>` | MCP servers the skill wants booted (consumed by host integrations) |
+| `on_activate` / `on_deactivate` | fn | Closures invoked on transition |
+
+### Example
+
+```harn
+skill ship {
+  description "Ship a production release"
+  when_to_use "User says ship/release/deploy"
+  paths ["infra/**", "Dockerfile"]
+  allowed_tools ["deploy_service"]
+  prompt "Follow the deploy runbook. One command at a time."
+}
+
+let result = agent_loop(
+  "Ship the new release to production",
+  "You are a staff deploy engineer.",
+  {
+    provider: "anthropic",
+    tools: tools(),
+    skills: ship,
+    working_files: ["infra/terraform/cluster.tf"],
+  }
+)
+```
+
+The loop emits one `skill_matched` event per match pass (including
+zero-candidate passes so replayers see the boundary), one
+`skill_activated` per activated skill, and one `skill_scope_tools`
+event per activation whose `allowed_tools` narrowed the surface.
 
 ## Streaming responses
 


### PR DESCRIPTION
## Summary

Wires skills into the `agent_loop` turn cycle as described in [issue #74](https://github.com/burin-labs/harn/issues/74). Skills now drive the turn loop automatically: matching, activation, prompt composition, tool-scope narrowing, reassess, session-resume — all with stable transcript + ACP event surfaces.

## What's new

**New `agent_loop` options:**

- `skills:` — a `skill_registry` (from `skill { }` decls or `skill_define`)
- `skill_match: { strategy, top_n, sticky }` — `"metadata"` (default, BM25 + paths globs), `"host"` / `"embedding"` (host RPC), `top_n` (default 1), `sticky` (default `true`)
- `working_files: [...]` — feeds `paths:` auto-trigger in the metadata matcher

**Lifecycle phases added to the agent loop:**

1. Match runs on iteration 0 (always) and before every iteration when `sticky: false`. Emits `skill_matched` with candidates + scores even when empty (replayers need the boundary).
2. Activation calls `on_activate`, weaves the skill's `prompt` body into the effective system prompt, narrows `opts.native_tools` + `tools_val` to the skill's `allowed_tools` whitelist (union when multiple skills are active). Emits `skill_activated` + `skill_scope_tools`.
3. Deactivation (only in `sticky: false`) runs `on_deactivate`, restores the full tool surface, emits `skill_deactivated`.
4. Session resume: at finalize the active-skill name set is persisted on `SessionState`; on the next `agent_loop` with the same `session_id`, rehydration seeds `state.active_skills` and the iteration-0 match is skipped (sticky re-entry stays hot).

**Bridge protocol additions:**

- `skill/match` JSON-RPC request for host-delegated ranking
- `AgentEvent::SkillActivated` / `SkillDeactivated` / `SkillScopeTools` → translated by `harn-cli`'s ACP server into `session/update` notifications

**Frontmatter honoured:**

- `disable-model-invocation: true` excludes a skill from the matcher entirely
- `user-invocable: false` rides through for host UIs (not consumed by runtime)
- `description`, `when_to_use`, `paths`, `allowed_tools`, `prompt`, `model`, `effort`, `mcp`, `invocation`, `on_activate`, `on_deactivate` all flow into the typed `ActiveSkill` projection

**DRY:**

- Single `ActiveSkill::from_entry(&VmValue)` builder is the only path that projects a raw skill-registry entry to the typed activation view; matching and session rehydration both route through it.
- Single `state.rebuild_scoped_native_tools(opts)` rebuilds `opts.native_tools` each turn from an immutable snapshot taken in `new()` so activation narrows and deactivation restores idempotently.

## Acceptance criteria

- [x] New phases in agent loop with transcript emission
- [x] Metadata ranker (BM25-ish over description + when_to_use, `paths:` glob matching)
- [x] Bridge RPC `skill/match`
- [x] Skill activation runs `on_activate`, binds tool subset, composes prompt
- [x] Skill-scoped prompt fragments via the base system prompt
- [x] `paths:` auto-trigger with host-supplied `working_files:`
- [x] Stable transcript events (`skill_matched`, `skill_activated`, `skill_deactivated`, `skill_scope_tools`) + matching `AgentEvent` variants
- [x] Session-resume semantics
- [x] `disable-model-invocation: true` and `user-invocable: false` honoured
- [x] Conformance fixtures under `conformance/tests/skill_lifecycle_*` (metadata, paths, flags, reassess, session_resume)

## Test plan

- [x] `make test` — 1293/1293 workspace tests pass (including 5 new `skill_match` unit tests)
- [x] `make conformance` — 500/500 conformance tests pass (5 new lifecycle fixtures)
- [x] `make all` — lint, fmt, tests, conformance, docs, portal all green
- [x] Manual smoke under `cargo run --bin harn -- run <file>` validated lifecycle events emitting and prompt composition working

## Files touched

- `crates/harn-vm/src/llm/agent/skill_match.rs` (new — matcher, bridge call, option parsing)
- `crates/harn-vm/src/llm/agent/{mod,state,turn_preflight,finalize}.rs` (phases, state, prompt composition)
- `crates/harn-vm/src/agent_events.rs` (three new `AgentEvent` variants)
- `crates/harn-vm/src/agent_sessions.rs` (active-skill persistence)
- `crates/harn-vm/src/llm/{agent_config,mod}.rs` and `crates/harn-vm/src/orchestration/workflow.rs` (option parsing + new `AgentLoopConfig` fields)
- `crates/harn-cli/src/acp/events.rs` (ACP session/update translation)
- `docs/src/{llm-and-agents,bridge-protocol}.md`, `CHANGELOG.md`
- `conformance/tests/skill_lifecycle_*.{harn,expected}` (5 fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)