### PR TITLE
fix(modules): canonicalize import paths before seen-set dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## Unreleased
+
+### Fixed
+
+- **Module graph path-spelling explosion (harn-modules).**
+  `harn_modules::build()` deduped discovered imports on the raw path
+  returned by `resolve_import_path`, which preserves `..` segments
+  (`base.join(import)` without collapsing). Two files in sibling
+  directories that imported each other (e.g. `lib/context/a.harn`
+  importing `../runtime/b.harn` and vice versa) produced a fresh path
+  spelling on every round-trip — `.../context/../runtime/`,
+  `.../context/../runtime/../context/`, `.../context/../runtime/../context/../runtime/`,
+  and so on. Because each spelling was treated as a new module, the
+  walk only terminated when `path.exists()` started failing at the
+  filesystem's `PATH_MAX`. macOS's effective `PATH_MAX` of 1024
+  masked the blow-up; Linux's `PATH_MAX` of 4096 let the walk run
+  ~4× longer, re-parsing the same pair tens of thousands of times —
+  RSS ballooned to 7+ GB and GitHub Actions runners SIGTERM'd or
+  SIGKILL'd the process. Symptom was a `harn lint <dir>` or
+  `harn check --workspace` that looked like a hang at 0% CPU
+  (actually thrashing and eventually OOM-killed). `build()` now
+  canonicalizes each import path through `normalize_path` before
+  inserting into the `seen` set, so the graph size is bounded by the
+  number of underlying files rather than path-spelling cycles. On a
+  representative 88-file pipeline tree, Linux lint dropped from
+  OOM-killed-at-48s (7.7 GB RSS) to 0.22s / 16 MB; macOS dropped
+  from 6.7s / 1.2 GB to 0.09s / 14 MB.
+
 ## v0.7.19
 
 ### Fixed

--- a/crates/harn-modules/src/lib.rs
+++ b/crates/harn-modules/src/lib.rs
@@ -98,10 +98,25 @@ pub fn build(files: &[PathBuf]) -> ModuleGraph {
         let module = load_module(&path);
         // Enqueue resolved import targets so the whole reachable graph is
         // discovered without the caller having to pre-walk imports.
+        //
+        // `resolve_import_path` returns paths as `base.join(import)` —
+        // i.e. with `..` segments preserved rather than collapsed. If we
+        // dedupe on those raw forms, two files that import each other
+        // across sibling dirs (`lib/context/` ↔ `lib/runtime/`) produce a
+        // different path spelling on every cycle — `.../context/../runtime/`,
+        // then `.../context/../runtime/../context/`, and so on — each of
+        // which is treated as a new file. The walk only terminates when
+        // `path.exists()` starts failing at the filesystem's `PATH_MAX`,
+        // which is 1024 on macOS but 4096 on Linux. Linux therefore
+        // re-parses the same handful of files thousands of times, balloons
+        // RSS into the multi-GB range, and gets SIGKILL'd by CI runners.
+        // Canonicalize once here so `seen` dedupes by the underlying file,
+        // not by its path spelling.
         for import in &module.imports {
             if let Some(import_path) = &import.path {
-                if seen.insert(import_path.clone()) {
-                    queue.push_back(import_path.clone());
+                let canonical = normalize_path(import_path);
+                if seen.insert(canonical.clone()) {
+                    queue.push_back(canonical);
                 }
             }
         }
@@ -595,6 +610,48 @@ mod tests {
 
         // Just ensuring this terminates and yields sensible names.
         let graph = build(std::slice::from_ref(&entry));
+        let imported = graph
+            .imported_names_for_file(&entry)
+            .expect("cyclic imports still resolve to known exports");
+        assert!(imported.contains("b_fn"));
+    }
+
+    #[test]
+    fn cross_directory_cycle_does_not_explode_module_count() {
+        // Regression: two files in sibling directories that import each
+        // other produced a fresh path spelling on every round-trip
+        // (`../runtime/../context/../runtime/...`), and `build()`'s
+        // `seen` set deduped on the raw spelling rather than the
+        // canonical path. The walk only terminated when `PATH_MAX` was
+        // hit — 1024 on macOS, 4096 on Linux — so Linux re-parsed the
+        // same pair thousands of times until it ran out of memory.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let context = root.join("context");
+        let runtime = root.join("runtime");
+        fs::create_dir_all(&context).unwrap();
+        fs::create_dir_all(&runtime).unwrap();
+        write_file(
+            &context,
+            "a.harn",
+            "import \"../runtime/b\"\npub fn a_fn() { 1 }\n",
+        );
+        write_file(
+            &runtime,
+            "b.harn",
+            "import \"../context/a\"\npub fn b_fn() { 1 }\n",
+        );
+        let entry = context.join("a.harn");
+
+        let graph = build(std::slice::from_ref(&entry));
+        // The graph should contain exactly the two real files, keyed by
+        // their canonical paths. Pre-fix this was thousands of entries.
+        assert_eq!(
+            graph.modules.len(),
+            2,
+            "cross-directory cycle loaded {} modules, expected 2",
+            graph.modules.len()
+        );
         let imported = graph
             .imported_names_for_file(&entry)
             .expect("cyclic imports still resolve to known exports");


### PR DESCRIPTION
## Summary

- Fixes a path-spelling explosion in `harn_modules::build()` that made `harn lint <dir>` and `harn check --workspace` appear to hang (0% CPU, eventually SIGTERM'd) on Linux CI — the process is actually thrashing allocation and getting OOM-killed.
- Root cause: `build()` deduped discovered imports on the raw path from `resolve_import_path`, which preserves `..` segments (`base.join(import)`). Two files in sibling dirs importing each other generate a fresh path spelling on every round-trip (`.../context/../runtime/`, `.../context/../runtime/../context/`, …) and each was treated as a new module. The walk only terminated when `path.exists()` started failing at the filesystem's `PATH_MAX`. macOS's effective `PATH_MAX` of 1024 masked the blow-up; Linux's 4096 let it run ~4× longer, re-parsing the same pair tens of thousands of times.
- Fix: canonicalize each import path through `normalize_path` before inserting into `seen`. Graph size is now bounded by the number of underlying files instead of path-spelling cycles. Safe because `imported_names_for_file` / `wildcard_exports_for` already fall back to `normalize_path` on lookup.

## Measured impact

Representative 88-file pipeline tree (burin-code `Sources/BurinCore/Resources/pipelines/`):

| | macOS (before) | macOS (after) | Linux (before) | Linux (after) |
|---|---|---|---|---|
| `harn lint <dir>` wall | 6.7s | **0.09s** | OOM-killed @ 48s | **0.22s** |
| Peak RSS | 1.2 GB | **14 MB** | 7.7 GB | **16 MB** |

Linux data captured inside a `rust:1.95` container built from this branch (same image Docker uses on GHA ubuntu runners). Pre-fix, strace showed **30,451 unique `.harn` paths** `openat`'d for a single-file lint of a 13-line source file with only 52 transitive imports — paths grew to the full 4097-char `PATH_MAX` (`.../mode/../lib/runtime/../context/../runtime/...` repeated).

## Changes

- `crates/harn-modules/src/lib.rs` — canonicalize import paths in `build()` before inserting into `seen` / queuing. Adds a regression test (`cross_directory_cycle_does_not_explode_module_count`) that reproduces the sibling-dir cyclic import pattern and asserts `graph.modules.len() == 2` (pre-fix: thousands).
- `CHANGELOG.md` — `Unreleased` entry.

## Test plan

- [x] `cargo test -p harn-modules` — 7/7 pass including new regression test
- [x] `make test` — 1375/1375 workspace tests pass
- [x] `make lint-md` — clean
- [x] `cargo clippy -p harn-modules --all-targets -- -D warnings` — clean
- [x] Manual repro: macOS lint of burin-code pipelines drops from 6.7s/1.2 GB → 0.09s/14 MB
- [x] Manual repro: Linux arm64 (Docker) lint of burin-code pipelines drops from OOM-at-48s/7.7 GB → 0.22s/16 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)