### PR TITLE
[codex] Add llm mock run flags

### DIFF
--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -124,6 +124,21 @@ pub(crate) struct RunArgs {
     /// wins ties against every other layer. See `docs/src/skills.md`.
     #[arg(long = "skill-dir", value_name = "PATH")]
     pub skill_dir: Vec<String>,
+    /// Replay LLM responses from a JSONL fixture file instead of
+    /// calling the configured provider.
+    #[arg(
+        long = "llm-mock",
+        value_name = "PATH",
+        conflicts_with = "llm_mock_record"
+    )]
+    pub llm_mock: Option<String>,
+    /// Record executed LLM responses into a JSONL fixture file.
+    #[arg(
+        long = "llm-mock-record",
+        value_name = "PATH",
+        conflicts_with = "llm_mock"
+    )]
+    pub llm_mock_record: Option<String>,
     /// Path to the .harn file to execute.
     pub file: Option<String>,
     /// Positional arguments passed to the pipeline as the global `argv`
@@ -641,6 +656,25 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn test_parses_run_llm_mock_flags() {
+        let cli = Cli::parse_from(["harn", "run", "--llm-mock", "fixtures.jsonl", "main.harn"]);
+
+        let Command::Run(args) = cli.command.unwrap() else {
+            panic!("expected run command");
+        };
+        assert_eq!(args.llm_mock.as_deref(), Some("fixtures.jsonl"));
+        assert_eq!(args.llm_mock_record, None);
+
+        let cli = Cli::parse_from(["harn", "run", "--llm-mock-record", "out.jsonl", "main.harn"]);
+
+        let Command::Run(args) = cli.command.unwrap() else {
+            panic!("expected run command");
+        };
+        assert_eq!(args.llm_mock_record.as_deref(), Some("out.jsonl"));
+        assert_eq!(args.llm_mock, None);
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
+use std::fs;
 use std::io::{self, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -86,13 +87,332 @@ fn typecheck_with_imports(
     checker.check(program)
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) enum CliLlmMockMode {
+    #[default]
+    Off,
+    Replay {
+        fixture_path: PathBuf,
+    },
+    Record {
+        fixture_path: PathBuf,
+    },
+}
+
+fn load_cli_llm_mocks(path: &Path) -> Result<Vec<harn_vm::llm::LlmMock>, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let mut mocks = Vec::new();
+    for (idx, raw_line) in content.lines().enumerate() {
+        let line_no = idx + 1;
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = serde_json::from_str(line).map_err(|error| {
+            format!(
+                "invalid JSON in {} line {}: {error}",
+                path.display(),
+                line_no
+            )
+        })?;
+        mocks.push(parse_cli_llm_mock_value(&value).map_err(|error| {
+            format!(
+                "invalid --llm-mock fixture in {} line {}: {error}",
+                path.display(),
+                line_no
+            )
+        })?);
+    }
+    Ok(mocks)
+}
+
+fn parse_cli_llm_mock_value(value: &serde_json::Value) -> Result<harn_vm::llm::LlmMock, String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| "fixture line must be a JSON object".to_string())?;
+
+    let match_pattern = optional_string_field(object, "match")?;
+    let text = optional_string_field(object, "text")?.unwrap_or_default();
+    let input_tokens = optional_i64_field(object, "input_tokens")?;
+    let output_tokens = optional_i64_field(object, "output_tokens")?;
+    let cache_read_tokens = optional_i64_field(object, "cache_read_tokens")?;
+    let cache_write_tokens = optional_i64_field(object, "cache_write_tokens")?;
+    let thinking = optional_string_field(object, "thinking")?;
+    let stop_reason = optional_string_field(object, "stop_reason")?;
+    let model = optional_string_field(object, "model")?.unwrap_or_else(|| "mock".to_string());
+    let provider = optional_string_field(object, "provider")?;
+    let blocks = optional_vec_field(object, "blocks")?;
+    let tool_calls = parse_cli_llm_tool_calls(object.get("tool_calls"))?;
+    let error = parse_cli_llm_mock_error(object.get("error"))?;
+
+    Ok(harn_vm::llm::LlmMock {
+        text,
+        tool_calls,
+        match_pattern,
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_write_tokens,
+        thinking,
+        stop_reason,
+        model,
+        provider,
+        blocks,
+        error,
+    })
+}
+
+fn parse_cli_llm_tool_calls(
+    value: Option<&serde_json::Value>,
+) -> Result<Vec<serde_json::Value>, String> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let items = value
+        .as_array()
+        .ok_or_else(|| "tool_calls must be an array".to_string())?;
+    items
+        .iter()
+        .enumerate()
+        .map(|(idx, item)| {
+            normalize_cli_llm_tool_call(item).map_err(|error| format!("tool_calls[{idx}] {error}"))
+        })
+        .collect()
+}
+
+fn normalize_cli_llm_tool_call(value: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| "must be a JSON object".to_string())?;
+    let name = object
+        .get("name")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| "is missing string field `name`".to_string())?;
+    let arguments = object
+        .get("arguments")
+        .cloned()
+        .or_else(|| object.get("args").cloned())
+        .unwrap_or_else(|| serde_json::json!({}));
+    Ok(serde_json::json!({
+        "name": name,
+        "arguments": arguments,
+    }))
+}
+
+fn parse_cli_llm_mock_error(
+    value: Option<&serde_json::Value>,
+) -> Result<Option<harn_vm::llm::MockError>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let object = value
+        .as_object()
+        .ok_or_else(|| "error must be an object {category, message}".to_string())?;
+    let category_str = object
+        .get("category")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| "error.category is required".to_string())?;
+    let category = harn_vm::ErrorCategory::parse(category_str);
+    if category.as_str() != category_str {
+        return Err(format!("unknown error category `{category_str}`"));
+    }
+    let message = object
+        .get("message")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string();
+    Ok(Some(harn_vm::llm::MockError { category, message }))
+}
+
+fn optional_string_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<Option<String>, String> {
+    match object.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(value)) => Ok(Some(value.clone())),
+        Some(_) => Err(format!("`{key}` must be a string")),
+    }
+}
+
+fn optional_i64_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<Option<i64>, String> {
+    match object.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(value) => value
+            .as_i64()
+            .map(Some)
+            .ok_or_else(|| format!("`{key}` must be an integer")),
+    }
+}
+
+fn optional_vec_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<Option<Vec<serde_json::Value>>, String> {
+    match object.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::Array(items)) => Ok(Some(items.clone())),
+        Some(_) => Err(format!("`{key}` must be an array")),
+    }
+}
+
+fn install_cli_llm_mock_mode(mode: &CliLlmMockMode) -> Result<(), String> {
+    harn_vm::llm::clear_cli_llm_mock_mode();
+    match mode {
+        CliLlmMockMode::Off => Ok(()),
+        CliLlmMockMode::Replay { fixture_path } => {
+            let mocks = load_cli_llm_mocks(fixture_path)?;
+            harn_vm::llm::install_cli_llm_mocks(mocks);
+            Ok(())
+        }
+        CliLlmMockMode::Record { .. } => {
+            harn_vm::llm::enable_cli_llm_mock_recording();
+            Ok(())
+        }
+    }
+}
+
+fn persist_cli_llm_mock_recording(mode: &CliLlmMockMode) -> Result<(), String> {
+    let CliLlmMockMode::Record { fixture_path } = mode else {
+        return Ok(());
+    };
+    if let Some(parent) = fixture_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "failed to create fixture directory {}: {error}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+
+    let lines = harn_vm::llm::take_cli_llm_recordings()
+        .into_iter()
+        .map(serialize_cli_llm_mock)
+        .collect::<Result<Vec<_>, _>>()?;
+    let body = if lines.is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", lines.join("\n"))
+    };
+    fs::write(fixture_path, body)
+        .map_err(|error| format!("failed to write {}: {error}", fixture_path.display()))
+}
+
+fn serialize_cli_llm_mock(mock: harn_vm::llm::LlmMock) -> Result<String, String> {
+    let mut object = serde_json::Map::new();
+    if let Some(match_pattern) = mock.match_pattern {
+        object.insert(
+            "match".to_string(),
+            serde_json::Value::String(match_pattern),
+        );
+    }
+    if !mock.text.is_empty() {
+        object.insert("text".to_string(), serde_json::Value::String(mock.text));
+    }
+    if !mock.tool_calls.is_empty() {
+        let tool_calls = mock
+            .tool_calls
+            .into_iter()
+            .map(|tool_call| {
+                let object = tool_call
+                    .as_object()
+                    .ok_or_else(|| "recorded tool call must be an object".to_string())?;
+                let name = object
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .ok_or_else(|| "recorded tool call is missing `name`".to_string())?;
+                Ok(serde_json::json!({
+                    "name": name,
+                    "args": object
+                        .get("arguments")
+                        .cloned()
+                        .unwrap_or_else(|| serde_json::json!({})),
+                }))
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        object.insert(
+            "tool_calls".to_string(),
+            serde_json::Value::Array(tool_calls),
+        );
+    }
+    if let Some(input_tokens) = mock.input_tokens {
+        object.insert(
+            "input_tokens".to_string(),
+            serde_json::Value::Number(input_tokens.into()),
+        );
+    }
+    if let Some(output_tokens) = mock.output_tokens {
+        object.insert(
+            "output_tokens".to_string(),
+            serde_json::Value::Number(output_tokens.into()),
+        );
+    }
+    if let Some(cache_read_tokens) = mock.cache_read_tokens {
+        object.insert(
+            "cache_read_tokens".to_string(),
+            serde_json::Value::Number(cache_read_tokens.into()),
+        );
+    }
+    if let Some(cache_write_tokens) = mock.cache_write_tokens {
+        object.insert(
+            "cache_write_tokens".to_string(),
+            serde_json::Value::Number(cache_write_tokens.into()),
+        );
+    }
+    if let Some(thinking) = mock.thinking {
+        object.insert("thinking".to_string(), serde_json::Value::String(thinking));
+    }
+    if let Some(stop_reason) = mock.stop_reason {
+        object.insert(
+            "stop_reason".to_string(),
+            serde_json::Value::String(stop_reason),
+        );
+    }
+    object.insert("model".to_string(), serde_json::Value::String(mock.model));
+    if let Some(provider) = mock.provider {
+        object.insert("provider".to_string(), serde_json::Value::String(provider));
+    }
+    if let Some(blocks) = mock.blocks {
+        object.insert("blocks".to_string(), serde_json::Value::Array(blocks));
+    }
+    if let Some(error) = mock.error {
+        object.insert(
+            "error".to_string(),
+            serde_json::json!({
+                "category": error.category.as_str(),
+                "message": error.message,
+            }),
+        );
+    }
+    serde_json::to_string(&serde_json::Value::Object(object))
+        .map_err(|error| format!("failed to serialize recorded fixture: {error}"))
+}
+
 pub(crate) async fn run_file(
     path: &str,
     trace: bool,
     denied_builtins: HashSet<String>,
     script_argv: Vec<String>,
+    llm_mock_mode: CliLlmMockMode,
 ) {
-    run_file_with_skill_dirs(path, trace, denied_builtins, script_argv, Vec::new()).await;
+    run_file_with_skill_dirs(
+        path,
+        trace,
+        denied_builtins,
+        script_argv,
+        Vec::new(),
+        llm_mock_mode,
+    )
+    .await;
 }
 
 pub(crate) async fn run_file_with_skill_dirs(
@@ -101,6 +421,7 @@ pub(crate) async fn run_file_with_skill_dirs(
     denied_builtins: HashSet<String>,
     script_argv: Vec<String>,
     skill_dirs_raw: Vec<String>,
+    llm_mock_mode: CliLlmMockMode,
 ) {
     let (source, program) = parse_source_file(path);
 
@@ -157,6 +478,10 @@ pub(crate) async fn run_file_with_skill_dirs(
 
     if trace {
         harn_vm::llm::enable_tracing();
+    }
+    if let Err(error) = install_cli_llm_mock_mode(&llm_mock_mode) {
+        eprintln!("error: {error}");
+        process::exit(1);
     }
 
     let mut vm = harn_vm::Vm::new();
@@ -245,25 +570,33 @@ pub(crate) async fn run_file_with_skill_dirs(
 
     // Run inside a LocalSet so spawn_local works for concurrency builtins.
     let local = tokio::task::LocalSet::new();
-    local
+    let execution = local
         .run_until(async {
             match vm.execute(&chunk).await {
-                Ok(_) => {
-                    let output = vm.output();
-                    if !output.is_empty() {
-                        io::stdout().write_all(output.as_bytes()).ok();
-                    }
-                }
-                Err(e) => {
-                    eprint!("{}", vm.format_runtime_error(&e));
-                    if cancelled.load(Ordering::SeqCst) {
-                        process::exit(124);
-                    }
-                    process::exit(1);
-                }
+                Ok(_) => Ok(vm.output()),
+                Err(e) => Err(vm.format_runtime_error(&e)),
             }
         })
         .await;
+    if let Err(error) = persist_cli_llm_mock_recording(&llm_mock_mode) {
+        eprintln!("error: {error}");
+        process::exit(1);
+    }
+
+    match execution {
+        Ok(output) => {
+            if !output.is_empty() {
+                io::stdout().write_all(output.as_bytes()).ok();
+            }
+        }
+        Err(rendered_error) => {
+            eprint!("{rendered_error}");
+            if cancelled.load(Ordering::SeqCst) {
+                process::exit(124);
+            }
+            process::exit(1);
+        }
+    }
 
     if trace {
         print_trace_summary();
@@ -581,7 +914,14 @@ pub(crate) async fn run_watch(path: &str, denied_builtins: HashSet<String>) {
     let watch_dir = abs_path.parent().unwrap_or(Path::new("."));
 
     eprintln!("\x1b[2m[watch] running {path}...\x1b[0m");
-    run_file(path, false, denied_builtins.clone(), Vec::new()).await;
+    run_file(
+        path,
+        false,
+        denied_builtins.clone(),
+        Vec::new(),
+        CliLlmMockMode::Off,
+    )
+    .await;
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(1);
     let _watcher = {
@@ -628,6 +968,13 @@ pub(crate) async fn run_watch(path: &str, denied_builtins: HashSet<String>) {
 
         eprintln!();
         eprintln!("\x1b[2m[watch] change detected, re-running {path}...\x1b[0m");
-        run_file(path, false, denied_builtins.clone(), Vec::new()).await;
+        run_file(
+            path,
+            false,
+            denied_builtins.clone(),
+            Vec::new(),
+            CliLlmMockMode::Off,
+        )
+        .await;
     }
 }

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -24,6 +24,7 @@ async fn main() {
             false,
             std::collections::HashSet::new(),
             Vec::new(),
+            commands::run::CliLlmMockMode::Off,
         )
         .await;
         return;
@@ -47,6 +48,17 @@ async fn main() {
         Command::Run(args) => {
             let denied =
                 commands::run::build_denied_builtins(args.deny.as_deref(), args.allow.as_deref());
+            let llm_mock_mode = if let Some(path) = args.llm_mock.as_ref() {
+                commands::run::CliLlmMockMode::Replay {
+                    fixture_path: PathBuf::from(path),
+                }
+            } else if let Some(path) = args.llm_mock_record.as_ref() {
+                commands::run::CliLlmMockMode::Record {
+                    fixture_path: PathBuf::from(path),
+                }
+            } else {
+                commands::run::CliLlmMockMode::Off
+            };
 
             match (args.eval.as_deref(), args.file.as_deref()) {
                 (Some(code), None) => {
@@ -73,6 +85,7 @@ async fn main() {
                         denied,
                         args.argv.clone(),
                         args.skill_dir.clone(),
+                        llm_mock_mode.clone(),
                     )
                     .await;
                     drop(tmp);
@@ -84,6 +97,7 @@ async fn main() {
                         denied,
                         args.argv.clone(),
                         args.skill_dir.clone(),
+                        llm_mock_mode,
                     )
                     .await
                 }

--- a/crates/harn-cli/tests/llm_mock_cli.rs
+++ b/crates/harn-cli/tests/llm_mock_cli.rs
@@ -1,0 +1,185 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+fn write_file(dir: &Path, relative: &str, contents: &str) -> String {
+    let path = dir.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&path, contents).unwrap();
+    path.to_string_lossy().into_owned()
+}
+
+fn run_harn(temp: &TempDir, args: &[&str], envs: &[(&str, &str)]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_harn"));
+    command.current_dir(temp.path());
+    command.args(args);
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    command.output().unwrap()
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn llm_mock_replays_fifo_fixtures_for_non_mock_provider() {
+    let temp = TempDir::new().unwrap();
+    let script = write_file(
+        temp.path(),
+        "script.harn",
+        r#"
+pipeline default() {
+  println(llm_call("same prompt", nil, {provider: env_or("TEST_PROVIDER", "mock")}).text)
+  println(llm_call("same prompt", nil, {provider: env_or("TEST_PROVIDER", "mock")}).text)
+}
+"#,
+    );
+    let fixtures = write_file(
+        temp.path(),
+        "fixtures.jsonl",
+        r#"{"text":"first","model":"fixture-model"}
+{"text":"second","model":"fixture-model"}
+"#,
+    );
+
+    let output = run_harn(
+        &temp,
+        &["run", "--llm-mock", &fixtures, &script],
+        &[("TEST_PROVIDER", "anthropic")],
+    );
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstderr={}",
+        output.status.code(),
+        stderr(&output)
+    );
+    assert_eq!(stdout(&output), "first\nsecond\n");
+}
+
+#[test]
+fn llm_mock_reuses_glob_matches() {
+    let temp = TempDir::new().unwrap();
+    let script = write_file(
+        temp.path(),
+        "script.harn",
+        r#"
+pipeline default() {
+  println(llm_call("say hello please", nil, {provider: env_or("TEST_PROVIDER", "mock")}).text)
+  println(llm_call("say hello again", nil, {provider: env_or("TEST_PROVIDER", "mock")}).text)
+}
+"#,
+    );
+    let fixtures = write_file(
+        temp.path(),
+        "fixtures.jsonl",
+        r#"{"match":"*hello*","text":"matched","model":"fixture-model"}
+"#,
+    );
+
+    let output = run_harn(
+        &temp,
+        &["run", "--llm-mock", &fixtures, &script],
+        &[("TEST_PROVIDER", "anthropic")],
+    );
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstderr={}",
+        output.status.code(),
+        stderr(&output)
+    );
+    assert_eq!(stdout(&output), "matched\nmatched\n");
+}
+
+#[test]
+fn llm_mock_reports_unmatched_prompt_snippet() {
+    let temp = TempDir::new().unwrap();
+    let script = write_file(
+        temp.path(),
+        "script.harn",
+        r#"
+pipeline default() {
+  println(llm_call("this prompt is intentionally unmatched for fixture coverage", nil, {provider: env_or("TEST_PROVIDER", "mock")}).text)
+}
+"#,
+    );
+    let fixtures = write_file(
+        temp.path(),
+        "fixtures.jsonl",
+        r#"{"match":"*different*","text":"nope","model":"fixture-model"}
+"#,
+    );
+
+    let output = run_harn(
+        &temp,
+        &["run", "--llm-mock", &fixtures, &script],
+        &[("TEST_PROVIDER", "anthropic")],
+    );
+
+    assert!(!output.status.success(), "stdout={}", stdout(&output));
+    let stderr = stderr(&output);
+    assert!(stderr.contains("No --llm-mock fixture matched prompt:"));
+    assert!(stderr.contains("this prompt is intentionally unmatched"));
+}
+
+#[test]
+fn llm_mock_record_replays_identical_output() {
+    let temp = TempDir::new().unwrap();
+    let script = write_file(
+        temp.path(),
+        "script.harn",
+        r#"
+pipeline default() {
+  let provider = env_or("TEST_PROVIDER", "mock")
+  let result = llm_call("hello world", nil, {provider: provider})
+  println(transcript_render_full(result.transcript))
+}
+"#,
+    );
+    let fixtures = temp.path().join("recorded.jsonl");
+
+    let recorded = run_harn(
+        &temp,
+        &[
+            "run",
+            "--llm-mock-record",
+            &fixtures.to_string_lossy(),
+            &script,
+        ],
+        &[("TEST_PROVIDER", "mock")],
+    );
+    assert!(
+        recorded.status.success(),
+        "status={:?}\nstderr={}",
+        recorded.status.code(),
+        stderr(&recorded)
+    );
+
+    let recorded_fixture = fs::read_to_string(&fixtures).unwrap();
+    assert_eq!(recorded_fixture.lines().count(), 1);
+
+    let replayed = run_harn(
+        &temp,
+        &["run", "--llm-mock", &fixtures.to_string_lossy(), &script],
+        &[("TEST_PROVIDER", "anthropic")],
+    );
+    assert!(
+        replayed.status.success(),
+        "status={:?}\nstderr={}",
+        replayed.status.code(),
+        stderr(&replayed)
+    );
+
+    assert_eq!(stdout(&recorded), stdout(&replayed));
+}

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -21,7 +21,8 @@ use std::rc::Rc;
 use crate::value::{VmError, VmValue};
 
 use super::mock::{
-    fixture_hash, get_replay_mode, load_fixture, mock_llm_response, save_fixture, LlmReplayMode,
+    fixture_hash, get_replay_mode, load_fixture, mock_llm_response, record_cli_llm_result,
+    save_fixture, LlmReplayMode,
 };
 
 // ─── Public surface (crate-wide) ────────────────────────────────────────
@@ -90,12 +91,13 @@ async fn vm_call_llm_full_inner_request(
     request: &LlmRequestPayload,
     delta_tx: Option<DeltaSender>,
 ) -> Result<LlmResult, VmError> {
-    if request.provider == "mock" {
+    if crate::llm::providers::MockProvider::should_intercept(&request.provider) {
         let result = mock_llm_response(
             &request.messages,
             request.system.as_deref(),
             request.native_tools.as_deref(),
         )?;
+        record_cli_llm_result(&result);
         if let Some(tx) = delta_tx {
             if !result.text.is_empty() {
                 let _ = tx.send(result.text.clone());
@@ -131,6 +133,7 @@ async fn vm_call_llm_full_inner_request(
     if replay_mode == LlmReplayMode::Record {
         save_fixture(&hash, &result);
     }
+    record_cli_llm_result(&result);
 
     super::cost::accumulate_cost(&result.model, result.input_tokens, result.output_tokens)?;
 
@@ -141,13 +144,15 @@ async fn vm_call_llm_full_inner_offthread(
     request: &LlmRequestPayload,
     delta_tx: Option<DeltaSender>,
 ) -> Result<LlmResult, String> {
-    if request.provider == "mock" {
-        return mock_llm_response(
+    if crate::llm::providers::MockProvider::should_intercept(&request.provider) {
+        let result = mock_llm_response(
             &request.messages,
             request.system.as_deref(),
             request.native_tools.as_deref(),
         )
-        .map_err(|e| e.to_string());
+        .map_err(|e| e.to_string())?;
+        record_cli_llm_result(&result);
+        return Ok(result);
     }
 
     let replay_mode = get_replay_mode();
@@ -170,6 +175,7 @@ async fn vm_call_llm_full_inner_offthread(
     if replay_mode == LlmReplayMode::Record {
         save_fixture(&hash, &result);
     }
+    record_cli_llm_result(&result);
 
     super::cost::accumulate_cost(&result.model, result.input_tokens, result.output_tokens)
         .map_err(|err| err.to_string())?;

--- a/crates/harn-vm/src/llm/helpers/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/mod.rs
@@ -331,7 +331,7 @@ pub(crate) fn vm_resolve_model(
 
 pub fn resolve_api_key(provider: &str) -> Result<String, VmError> {
     use crate::llm_config;
-    if provider == "mock" {
+    if provider == "mock" || crate::llm::mock::cli_llm_mock_replay_active() {
         return Ok(String::new());
     }
 

--- a/crates/harn-vm/src/llm/mock.rs
+++ b/crates/harn-vm/src/llm/mock.rs
@@ -20,25 +20,37 @@ pub enum ToolRecordingMode {
     Replay,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CliLlmMockMode {
+    Off,
+    Replay,
+    Record,
+}
+
 /// Categorized error injected by a mock. When present, the mock
 /// short-circuits the provider call and surfaces as
 /// `VmError::CategorizedError`, so `llm_call` throws and
 /// `llm_call_safe` populates its `error` envelope.
 #[derive(Clone)]
-pub(crate) struct MockError {
+pub struct MockError {
     pub category: ErrorCategory,
     pub message: String,
 }
 
-pub(crate) struct LlmMock {
+#[derive(Clone)]
+pub struct LlmMock {
     pub text: String,
     pub tool_calls: Vec<serde_json::Value>,
     pub match_pattern: Option<String>, // None = FIFO (consumed), Some = glob (reusable)
     pub input_tokens: Option<i64>,
     pub output_tokens: Option<i64>,
+    pub cache_read_tokens: Option<i64>,
+    pub cache_write_tokens: Option<i64>,
     pub thinking: Option<String>,
     pub stop_reason: Option<String>,
     pub model: String,
+    pub provider: Option<String>,
+    pub blocks: Option<Vec<serde_json::Value>>,
     /// When `Some`, this mock synthesizes an error instead of an
     /// `LlmResult`. `text`/`tool_calls` are ignored for error mocks.
     pub error: Option<MockError>,
@@ -58,6 +70,9 @@ thread_local! {
     static TOOL_RECORDINGS: RefCell<Vec<ToolCallRecord>> = const { RefCell::new(Vec::new()) };
     static TOOL_REPLAY_FIXTURES: RefCell<Vec<ToolCallRecord>> = const { RefCell::new(Vec::new()) };
     static LLM_MOCKS: RefCell<Vec<LlmMock>> = const { RefCell::new(Vec::new()) };
+    static CLI_LLM_MOCK_MODE: RefCell<CliLlmMockMode> = const { RefCell::new(CliLlmMockMode::Off) };
+    static CLI_LLM_MOCKS: RefCell<Vec<LlmMock>> = const { RefCell::new(Vec::new()) };
+    static CLI_LLM_RECORDINGS: RefCell<Vec<LlmMock>> = const { RefCell::new(Vec::new()) };
     static LLM_MOCK_CALLS: RefCell<Vec<LlmMockCall>> = const { RefCell::new(Vec::new()) };
 }
 
@@ -71,7 +86,36 @@ pub(crate) fn get_llm_mock_calls() -> Vec<LlmMockCall> {
 
 pub(crate) fn reset_llm_mock_state() {
     LLM_MOCKS.with(|v| v.borrow_mut().clear());
+    CLI_LLM_MOCK_MODE.with(|v| *v.borrow_mut() = CliLlmMockMode::Off);
+    CLI_LLM_MOCKS.with(|v| v.borrow_mut().clear());
+    CLI_LLM_RECORDINGS.with(|v| v.borrow_mut().clear());
     LLM_MOCK_CALLS.with(|v| v.borrow_mut().clear());
+}
+
+pub fn clear_cli_llm_mock_mode() {
+    CLI_LLM_MOCK_MODE.with(|v| *v.borrow_mut() = CliLlmMockMode::Off);
+    CLI_LLM_MOCKS.with(|v| v.borrow_mut().clear());
+    CLI_LLM_RECORDINGS.with(|v| v.borrow_mut().clear());
+}
+
+pub fn install_cli_llm_mocks(mocks: Vec<LlmMock>) {
+    CLI_LLM_MOCK_MODE.with(|v| *v.borrow_mut() = CliLlmMockMode::Replay);
+    CLI_LLM_MOCKS.with(|v| *v.borrow_mut() = mocks);
+    CLI_LLM_RECORDINGS.with(|v| v.borrow_mut().clear());
+}
+
+pub fn enable_cli_llm_mock_recording() {
+    CLI_LLM_MOCK_MODE.with(|v| *v.borrow_mut() = CliLlmMockMode::Record);
+    CLI_LLM_MOCKS.with(|v| v.borrow_mut().clear());
+    CLI_LLM_RECORDINGS.with(|v| v.borrow_mut().clear());
+}
+
+pub fn take_cli_llm_recordings() -> Vec<LlmMock> {
+    CLI_LLM_RECORDINGS.with(|v| std::mem::take(&mut *v.borrow_mut()))
+}
+
+pub(crate) fn cli_llm_mock_replay_active() -> bool {
+    CLI_LLM_MOCK_MODE.with(|v| *v.borrow() == CliLlmMockMode::Replay)
 }
 
 fn record_llm_mock_call(
@@ -90,48 +134,54 @@ fn record_llm_mock_call(
 
 /// Build an LlmResult from a matched mock.
 fn build_mock_result(mock: &LlmMock, last_msg_len: usize) -> LlmResult {
-    let mut blocks = Vec::new();
+    let (tool_calls, blocks) = if let Some(blocks) = &mock.blocks {
+        (mock.tool_calls.clone(), blocks.clone())
+    } else {
+        let mut blocks = Vec::new();
 
-    if !mock.text.is_empty() {
-        blocks.push(serde_json::json!({
-            "type": "output_text",
-            "text": mock.text,
-            "visibility": "public",
-        }));
-    }
+        if !mock.text.is_empty() {
+            blocks.push(serde_json::json!({
+                "type": "output_text",
+                "text": mock.text,
+                "visibility": "public",
+            }));
+        }
 
-    let mut tool_calls = Vec::new();
-    for (i, tc) in mock.tool_calls.iter().enumerate() {
-        let id = format!("mock_call_{}", i + 1);
-        let name = tc.get("name").and_then(|n| n.as_str()).unwrap_or("unknown");
-        let arguments = tc
-            .get("arguments")
-            .cloned()
-            .unwrap_or(serde_json::json!({}));
-        tool_calls.push(serde_json::json!({
-            "id": id,
-            "type": "tool_call",
-            "name": name,
-            "arguments": arguments,
-        }));
-        blocks.push(serde_json::json!({
-            "type": "tool_call",
-            "id": id,
-            "name": name,
-            "arguments": arguments,
-            "visibility": "internal",
-        }));
-    }
+        let mut tool_calls = Vec::new();
+        for (i, tc) in mock.tool_calls.iter().enumerate() {
+            let id = format!("mock_call_{}", i + 1);
+            let name = tc.get("name").and_then(|n| n.as_str()).unwrap_or("unknown");
+            let arguments = tc
+                .get("arguments")
+                .cloned()
+                .unwrap_or(serde_json::json!({}));
+            tool_calls.push(serde_json::json!({
+                "id": id,
+                "type": "tool_call",
+                "name": name,
+                "arguments": arguments,
+            }));
+            blocks.push(serde_json::json!({
+                "type": "tool_call",
+                "id": id,
+                "name": name,
+                "arguments": arguments,
+                "visibility": "internal",
+            }));
+        }
+
+        (tool_calls, blocks)
+    };
 
     LlmResult {
         text: mock.text.clone(),
         tool_calls,
         input_tokens: mock.input_tokens.unwrap_or(last_msg_len as i64),
         output_tokens: mock.output_tokens.unwrap_or(30),
-        cache_read_tokens: 0,
-        cache_write_tokens: 0,
+        cache_read_tokens: mock.cache_read_tokens.unwrap_or(0),
+        cache_write_tokens: mock.cache_write_tokens.unwrap_or(0),
         model: mock.model.clone(),
-        provider: "mock".to_string(),
+        provider: mock.provider.clone().unwrap_or_else(|| "mock".to_string()),
         thinking: mock.thinking.clone(),
         stop_reason: mock.stop_reason.clone(),
         blocks,
@@ -186,33 +236,69 @@ fn mock_error_to_vm_error(err: &MockError) -> VmError {
 /// Try to find and return a matching mock response. Returns
 /// `Some(Ok(LlmResult))` on a text/tool_call match, `Some(Err(VmError))`
 /// on an error-mock match, and `None` to fall through to default.
-fn try_match_mock(last_msg: &str) -> Option<Result<LlmResult, VmError>> {
-    LLM_MOCKS.with(|mocks| {
-        let mut mocks = mocks.borrow_mut();
+fn try_match_mock_queue(
+    mocks: &mut Vec<LlmMock>,
+    last_msg: &str,
+) -> Option<Result<LlmResult, VmError>> {
+    if let Some(idx) = mocks.iter().position(|m| m.match_pattern.is_none()) {
+        let mock = mocks.remove(idx);
+        return Some(match &mock.error {
+            Some(err) => Err(mock_error_to_vm_error(err)),
+            None => Ok(build_mock_result(&mock, last_msg.len())),
+        });
+    }
 
-        // FIFO: first mock without a match pattern (consumed on use).
-        if let Some(idx) = mocks.iter().position(|m| m.match_pattern.is_none()) {
-            let mock = mocks.remove(idx);
-            return Some(match &mock.error {
-                Some(err) => Err(mock_error_to_vm_error(err)),
-                None => Ok(build_mock_result(&mock, last_msg.len())),
-            });
-        }
-
-        // Pattern match (last registered wins).
-        for mock in mocks.iter().rev() {
-            if let Some(ref pattern) = mock.match_pattern {
-                if mock_glob_match(pattern, last_msg) {
-                    return Some(match &mock.error {
-                        Some(err) => Err(mock_error_to_vm_error(err)),
-                        None => Ok(build_mock_result(mock, last_msg.len())),
-                    });
-                }
+    for mock in mocks.iter().rev() {
+        if let Some(ref pattern) = mock.match_pattern {
+            if mock_glob_match(pattern, last_msg) {
+                return Some(match &mock.error {
+                    Some(err) => Err(mock_error_to_vm_error(err)),
+                    None => Ok(build_mock_result(mock, last_msg.len())),
+                });
             }
         }
+    }
 
-        None
-    })
+    None
+}
+
+fn try_match_builtin_mock(last_msg: &str) -> Option<Result<LlmResult, VmError>> {
+    LLM_MOCKS.with(|mocks| try_match_mock_queue(&mut mocks.borrow_mut(), last_msg))
+}
+
+fn try_match_cli_mock(last_msg: &str) -> Option<Result<LlmResult, VmError>> {
+    CLI_LLM_MOCKS.with(|mocks| try_match_mock_queue(&mut mocks.borrow_mut(), last_msg))
+}
+
+pub(crate) fn record_cli_llm_result(result: &LlmResult) {
+    if !CLI_LLM_MOCK_MODE.with(|mode| *mode.borrow() == CliLlmMockMode::Record) {
+        return;
+    }
+    CLI_LLM_RECORDINGS.with(|recordings| {
+        recordings.borrow_mut().push(LlmMock {
+            text: result.text.clone(),
+            tool_calls: result.tool_calls.clone(),
+            match_pattern: None,
+            input_tokens: Some(result.input_tokens),
+            output_tokens: Some(result.output_tokens),
+            cache_read_tokens: Some(result.cache_read_tokens),
+            cache_write_tokens: Some(result.cache_write_tokens),
+            thinking: result.thinking.clone(),
+            stop_reason: result.stop_reason.clone(),
+            model: result.model.clone(),
+            provider: Some(result.provider.clone()),
+            blocks: Some(result.blocks.clone()),
+            error: None,
+        });
+    });
+}
+
+fn unmatched_cli_prompt_error(last_msg: &str) -> VmError {
+    let mut snippet: String = last_msg.chars().take(200).collect();
+    if last_msg.chars().count() > 200 {
+        snippet.push_str("...");
+    }
+    VmError::Runtime(format!("No --llm-mock fixture matched prompt: {snippet:?}"))
 }
 
 /// Set LLM replay mode (record/replay) and fixture directory.
@@ -360,8 +446,16 @@ pub(crate) fn mock_llm_response(
         .and_then(|c| c.as_str())
         .unwrap_or("");
 
-    if let Some(matched) = try_match_mock(last_msg) {
+    if let Some(matched) = try_match_cli_mock(last_msg) {
         return matched;
+    }
+
+    if let Some(matched) = try_match_builtin_mock(last_msg) {
+        return matched;
+    }
+
+    if cli_llm_mock_replay_active() {
+        return Err(unmatched_cli_prompt_error(last_msg));
     }
 
     // Generate a mock tool call for the first tool, filling required

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -283,7 +283,10 @@ pub use self::cost::peek_total_cost;
 pub(crate) use self::helpers::extract_llm_options;
 pub use self::helpers::resolve_api_key;
 pub use self::helpers::vm_value_to_json;
-pub use self::mock::{set_replay_mode, LlmReplayMode};
+pub use self::mock::{
+    clear_cli_llm_mock_mode, enable_cli_llm_mock_recording, install_cli_llm_mocks, set_replay_mode,
+    take_cli_llm_recordings, LlmMock, LlmReplayMode, MockError,
+};
 pub use self::trace::{
     agent_trace_summary, enable_tracing, peek_agent_trace, peek_trace, peek_trace_summary,
     take_agent_trace, take_trace, AgentTraceEvent, LlmTraceEntry,
@@ -800,9 +803,13 @@ fn register_llm_mock_builtins(vm: &mut Vm) {
             match_pattern,
             input_tokens,
             output_tokens,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
             thinking,
             stop_reason,
             model,
+            provider: None,
+            blocks: None,
             error,
         });
         Ok(VmValue::Nil)

--- a/crates/harn-vm/src/llm/providers/mock.rs
+++ b/crates/harn-vm/src/llm/providers/mock.rs
@@ -33,6 +33,10 @@ impl LlmProviderChat for MockProvider {
 }
 
 impl MockProvider {
+    pub(crate) fn should_intercept(provider: &str) -> bool {
+        provider == "mock" || crate::llm::mock::cli_llm_mock_replay_active()
+    }
+
     pub(crate) async fn chat_impl(
         &self,
         request: &LlmRequestPayload,

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -128,6 +128,32 @@ log(result)
 
 This queues a canned response that the next LLM call consumes.
 
+For end-to-end CLI runs, `harn run` can preload the same mock
+infrastructure from a JSONL fixture file:
+
+```jsonl
+{"text":"PLAN: find the middleware module first","model":"fixture-model"}
+{"match":"*hello*","text":"matched","model":"fixture-model"}
+{"match":"*","error":{"category":"rate_limit","message":"fake rate limit"}}
+```
+
+```bash
+harn run script.harn --llm-mock fixtures.jsonl
+```
+
+- A line without `match` is FIFO and is consumed on use.
+- A line with `match` is a reusable glob against the prompt text.
+- When no fixture matches, `harn run --llm-mock ...` fails with the
+  first prompt snippet so you can add the missing case directly.
+
+To capture a replayable fixture from a run, record once and then replay
+the saved JSONL:
+
+```bash
+harn run script.harn --llm-mock-record fixtures.jsonl
+harn run script.harn --llm-mock fixtures.jsonl
+```
+
 ## Built-in assertions
 
 Harn provides `assert`, `assert_eq`, and `assert_ne` builtins for test pipelines:


### PR DESCRIPTION
## Summary

Adds first-class `harn run` support for LLM fixture replay and recording via `--llm-mock` and `--llm-mock-record`.

Closes #100.

## What changed

- add `--llm-mock <fixtures.jsonl>` and `--llm-mock-record <fixtures.jsonl>` to the `run` CLI
- load and persist JSONL fixtures from the run command path
- wire the existing VM mock machinery into CLI replay and record modes
- intercept replay for non-`mock` providers so fixture replay avoids real provider calls
- surface unmatched prompt errors with a prompt snippet
- add CLI integration tests for replay, glob reuse, unmatched prompts, and record-to-replay round-tripping
- document the new run flags in the testing docs

## Why

The runtime already had mock infrastructure, but it was not exposed as a first-class `harn run` workflow. This change makes local iteration simpler by letting users record fixtures from a real run and replay them deterministically without live LLM traffic.

## Impact

Users can now:

- replay LLM calls for `harn run` from JSONL fixtures with `--llm-mock`
- record successful LLM calls into JSONL fixtures with `--llm-mock-record`
- get a direct error when no replay fixture matches the current prompt

## Validation

Passed:

- `cargo fmt --all`
- `env CARGO_BUILD_JOBS=2 CARGO_INCREMENTAL=0 cargo check -p harn-cli --tests`
- `env CARGO_BUILD_JOBS=2 CARGO_INCREMENTAL=0 cargo test -p harn-cli --test llm_mock_cli`
- pre-push Rust test suite: `cargo nextest run --workspace`
- pre-push markdown lint
- `env CARGO_BUILD_JOBS=2 CARGO_INCREMENTAL=0 make all` through Rust/clippy/conformance/docs checks

Environment blocker:

- portal lint in local hooks and `make all` stops with `sh: eslint: command not found` because the portal eslint binary is not installed in this checkout