### PR TITLE
[codex] Split llm tools tests

### DIFF
--- a/crates/harn-vm/src/llm/tools/tests/bind.rs
+++ b/crates/harn-vm/src/llm/tools/tests/bind.rs
@@ -1,0 +1,120 @@
+use super::*;
+
+#[test]
+fn normalize_tool_args_rewrites_declared_aliases_from_active_policy() {
+    use crate::orchestration::{pop_execution_policy, push_execution_policy, CapabilityPolicy};
+    use crate::tool_annotations::{ToolAnnotations, ToolArgSchema, ToolKind};
+
+    let mut annotations = std::collections::BTreeMap::new();
+    let mut arg_aliases = std::collections::BTreeMap::new();
+    arg_aliases.insert("file".to_string(), "path".to_string());
+    arg_aliases.insert("mode".to_string(), "action".to_string());
+    annotations.insert(
+        "edit".to_string(),
+        ToolAnnotations {
+            kind: ToolKind::Edit,
+            arg_schema: ToolArgSchema {
+                arg_aliases,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+    let policy = CapabilityPolicy {
+        tool_annotations: annotations,
+        ..Default::default()
+    };
+    push_execution_policy(policy);
+
+    let out = normalize_tool_args(
+        "edit",
+        &json!({"file": "lib/foo.rs", "mode": "replace_range", "range_start": "3"}),
+    );
+    assert_eq!(out["path"], json!("lib/foo.rs"));
+    assert_eq!(out["action"], json!("replace_range"));
+    assert!(out.get("file").is_none());
+    assert!(out.get("mode").is_none());
+    assert_eq!(out["range_start"], json!(3));
+
+    pop_execution_policy();
+}
+
+#[test]
+fn normalize_tool_args_skips_unannotated_tool() {
+    let out = normalize_tool_args("mystery_tool", &json!({"file": "x.rs"}));
+    assert_eq!(out, json!({"file": "x.rs"}));
+}
+
+#[test]
+fn normalize_tool_args_coerces_integer_like_string_fields() {
+    let normalized = normalize_tool_args(
+        "edit",
+        &json!({
+            "action": "replace_range",
+            "path": "tests/unit/test_example.py",
+            "range_start": "1",
+            "range_end": "19",
+            "ops": [
+                {"op": "replace_range", "range_start": "3", "range_end": "5"}
+            ]
+        }),
+    );
+    assert_eq!(normalized["range_start"], json!(1));
+    assert_eq!(normalized["range_end"], json!(19));
+    assert_eq!(normalized["ops"][0]["range_start"], json!(3));
+    assert_eq!(normalized["ops"][0]["range_end"], json!(5));
+}
+
+#[test]
+fn validate_tool_args_reports_missing_required_params() {
+    let tools = sample_tool_registry();
+    let schemas = collect_tool_schemas(Some(&tools), None);
+    let args = json!({"action": "create"});
+    let result = validate_tool_args("edit", &args, &schemas);
+    assert!(result.is_err(), "should report missing required param");
+    let msg = result.unwrap_err();
+    assert!(msg.contains("path"), "error should mention 'path': {msg}");
+    assert!(
+        msg.contains("missing required parameter"),
+        "error should say missing required: {msg}"
+    );
+}
+
+#[test]
+fn validate_tool_args_passes_when_all_required_present() {
+    let tools = sample_tool_registry();
+    let schemas = collect_tool_schemas(Some(&tools), None);
+    let args = json!({"action": "create", "path": "test.go", "content": "pkg main"});
+    let result = validate_tool_args("edit", &args, &schemas);
+    assert!(result.is_ok(), "should pass with all required params");
+}
+
+#[test]
+fn validate_tool_args_skips_unknown_tool() {
+    let tools = sample_tool_registry();
+    let schemas = collect_tool_schemas(Some(&tools), None);
+    let args = json!({"foo": "bar"});
+    let result = validate_tool_args("nonexistent_tool", &args, &schemas);
+    assert!(
+        result.is_ok(),
+        "should pass for unknown tool (handled elsewhere)"
+    );
+}
+
+#[test]
+fn validate_tool_args_treats_null_as_missing() {
+    let tools = sample_tool_registry();
+    let schemas = collect_tool_schemas(Some(&tools), None);
+    let args = json!({"action": "create", "path": null});
+    let result = validate_tool_args("edit", &args, &schemas);
+    assert!(result.is_err(), "null should count as missing");
+    assert!(result.unwrap_err().contains("path"));
+}
+
+#[test]
+fn validate_tool_args_passes_with_empty_args_when_no_required() {
+    let tools = sample_tool_registry();
+    let schemas = collect_tool_schemas(Some(&tools), None);
+    let result = validate_tool_args("no_such_tool", &json!({}), &schemas);
+    assert!(result.is_ok());
+}

--- a/crates/harn-vm/src/llm/tools/tests/execute.rs
+++ b/crates/harn-vm/src/llm/tools/tests/execute.rs
@@ -1,0 +1,40 @@
+use super::*;
+use std::io::Write;
+
+#[test]
+fn read_file_offset_and_limit() {
+    let dir = std::env::temp_dir().join("harn_test_read_file_offset");
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("test_offset.txt");
+    {
+        let mut f = std::fs::File::create(&path).unwrap();
+        for i in 1..=20 {
+            writeln!(f, "line {i}").unwrap();
+        }
+    }
+    let path_str = path.to_str().unwrap();
+
+    let result = handle_tool_locally("read_file", &json!({"path": path_str})).unwrap();
+    assert!(result.contains("1\tline 1"), "first line numbered");
+    assert!(result.contains("20\tline 20"), "last line numbered");
+    assert!(!result.contains("more lines not shown"), "no truncation");
+
+    let result = handle_tool_locally(
+        "read_file",
+        &json!({"path": path_str, "offset": 5, "limit": 3}),
+    )
+    .unwrap();
+    assert!(result.contains("5\tline 5"), "starts at line 5");
+    assert!(result.contains("7\tline 7"), "ends at line 7");
+    assert!(!result.contains("4\tline 4"), "no line 4");
+    assert!(!result.contains("8\tline 8"), "no line 8");
+    assert!(result.contains("more lines not shown"), "truncation hint");
+    assert!(result.contains("offset=8"), "hint says offset=8");
+
+    let result =
+        handle_tool_locally("read_file", &json!({"path": path_str, "offset": 100})).unwrap();
+    assert!(!result.contains("line"), "no content past end");
+
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_dir(&dir);
+}

--- a/crates/harn-vm/src/llm/tools/tests/format.rs
+++ b/crates/harn-vm/src/llm/tools/tests/format.rs
@@ -1,0 +1,176 @@
+use super::*;
+
+#[test]
+fn contract_prompt_renders_edit_signature_with_enum_and_required_markers() {
+    let tools = sample_tool_registry();
+    let prompt = build_tool_calling_contract_prompt(Some(&tools), None, "text", true, None);
+    assert!(
+        prompt.contains("declare function edit(args:"),
+        "missing TS declaration: {prompt}"
+    );
+    assert!(
+        prompt.contains("\"create\" | \"patch\" | \"replace_body\""),
+        "enum should render as literal union: {prompt}"
+    );
+    let obj_start = prompt.find("args: {").unwrap();
+    let obj_end = prompt[obj_start..].find("})").unwrap() + obj_start;
+    let obj_body = &prompt[obj_start..obj_end];
+    let path_idx = obj_body.find("path:").unwrap();
+    let content_idx = obj_body.find("content?:").unwrap();
+    assert!(
+        path_idx < content_idx,
+        "required `path` should appear before optional `content?`: {obj_body}"
+    );
+    assert!(obj_body.contains("content?: string"));
+    assert!(obj_body.contains("new_body?: string"));
+    assert!(prompt.contains("path: string /* required"));
+    assert!(prompt.contains("content?: string /* optional"));
+    assert!(prompt.contains("\"internal/manifest/parser.go\""));
+    assert!(!prompt.contains("@param path"));
+    assert!(prompt.contains("declare function") || prompt.contains("Response protocol"));
+}
+
+#[test]
+fn contract_prompt_help_block_documents_tagged_protocol() {
+    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("Response protocol"));
+    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("<tool_call>"));
+    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("</tool_call>"));
+    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("<assistant_prose>"));
+    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("<done>##DONE##</done>"));
+    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("name({ key: value })"));
+    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("heredoc"));
+    assert!(!TEXT_RESPONSE_PROTOCOL_HELP.contains("contains no tool calls"));
+    assert!(!TEXT_RESPONSE_PROTOCOL_HELP.contains("```call"));
+}
+
+#[test]
+fn contract_prompt_native_mode_prefers_provider_channel_without_text_fallback() {
+    // Native mode should stay lean: the provider already receives the
+    // structured `tools` payload, so the system prompt must not inject
+    // the text-mode response grammar or duplicate `declare function`
+    // schemas that can confuse native-tool parsers.
+    let tools = sample_tool_registry();
+    let prompt = build_tool_calling_contract_prompt(Some(&tools), None, "native", true, None);
+    assert!(
+        prompt.contains("native tool-calling channel"),
+        "native preamble missing: {prompt}"
+    );
+    assert!(
+        prompt.contains("This turn is action-gated"),
+        "action gate missing: {prompt}"
+    );
+    assert!(prompt.contains("## Task ledger"));
+    assert!(!prompt.contains("## Response protocol"));
+    assert!(!prompt.contains("declare function edit(args:"));
+    assert!(!prompt.contains("## Available tools"));
+    assert!(!prompt.contains("<tool_call>"));
+}
+
+#[test]
+fn contract_prompt_text_mode_mentions_action_gate_before_examples() {
+    let tools = sample_tool_registry();
+    let prompt = build_tool_calling_contract_prompt(Some(&tools), None, "text", true, None);
+    assert!(prompt.contains("This turn is action-gated."));
+    assert!(prompt.contains("`<tool_call>...</tool_call>`"));
+    assert!(prompt.contains("Do not emit raw source code"));
+}
+
+#[test]
+fn contract_prompt_includes_tool_examples_before_schemas() {
+    let tools = sample_tool_registry();
+    let examples = "read({ path: \"src/main.rs\" })\n\nedit({ action: \"create\", path: \"test.rs\", content: <<EOF\nfn main() {}\nEOF\n})";
+    let prompt =
+        build_tool_calling_contract_prompt(Some(&tools), None, "text", true, Some(examples));
+    assert!(
+        prompt.contains("## Tool call examples"),
+        "missing examples header: {prompt}"
+    );
+    assert!(
+        prompt.contains("read({ path: \"src/main.rs\" })"),
+        "missing example content: {prompt}"
+    );
+    let examples_pos = prompt.find("Tool call examples").unwrap();
+    let schemas_pos = prompt.find("Available tools").unwrap();
+    assert!(
+        examples_pos < schemas_pos,
+        "examples ({examples_pos}) should appear before schemas ({schemas_pos})"
+    );
+}
+
+#[test]
+fn contract_prompt_omits_examples_section_when_none() {
+    let tools = sample_tool_registry();
+    let prompt = build_tool_calling_contract_prompt(Some(&tools), None, "text", true, None);
+    assert!(
+        !prompt.contains("Tool call examples"),
+        "should not have examples section when None"
+    );
+}
+
+#[test]
+fn assistant_tool_message_includes_empty_content_for_openai_style() {
+    let message = build_assistant_tool_message(
+        "",
+        &[json!({
+            "id": "call_001",
+            "name": "read",
+            "arguments": {"path": "main.rs"},
+        })],
+        "together",
+    );
+
+    assert_eq!(message["role"], "assistant");
+    assert_eq!(message["content"], "");
+    assert_eq!(message["tool_calls"][0]["id"], "call_001");
+}
+
+#[test]
+fn assistant_tool_message_uses_ollama_native_shape() {
+    let message = build_assistant_tool_message(
+        "",
+        &[json!({
+            "id": "call_001",
+            "name": "read",
+            "arguments": {"path": "main.rs"},
+        })],
+        "ollama",
+    );
+
+    assert_eq!(message["role"], "assistant");
+    assert!(message.get("content").is_none());
+    assert_eq!(message["tool_calls"][0]["type"], "function");
+    assert_eq!(message["tool_calls"][0]["function"]["name"], "read");
+    assert_eq!(
+        message["tool_calls"][0]["function"]["arguments"]["path"],
+        "main.rs"
+    );
+}
+
+#[test]
+fn tool_result_message_uses_ollama_tool_name() {
+    let message = build_tool_result_message("call_001", "read", "contents", "ollama");
+
+    assert_eq!(message["role"], "tool");
+    assert_eq!(message["tool_name"], "read");
+    assert_eq!(message["content"], "contents");
+    assert!(message.get("tool_call_id").is_none());
+}
+
+#[test]
+fn assistant_response_message_preserves_reasoning() {
+    let message = build_assistant_response_message(
+        "",
+        &[],
+        &[json!({
+            "id": "call_001",
+            "name": "read",
+            "arguments": {"path": "main.rs"},
+        })],
+        Some("inspect the file before editing"),
+        "together",
+    );
+
+    assert_eq!(message["reasoning"], "inspect the file before editing");
+    assert_eq!(message["content"], "");
+    assert_eq!(message["tool_calls"][0]["id"], "call_001");
+}

--- a/crates/harn-vm/src/llm/tools/tests/mock_fixtures.rs
+++ b/crates/harn-vm/src/llm/tools/tests/mock_fixtures.rs
@@ -1,0 +1,146 @@
+use super::*;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+pub(crate) fn vm_dict(pairs: &[(&str, VmValue)]) -> VmValue {
+    let mut map = BTreeMap::new();
+    for (k, v) in pairs {
+        map.insert((*k).to_string(), v.clone());
+    }
+    VmValue::Dict(Rc::new(map))
+}
+
+pub(crate) fn vm_str(s: &str) -> VmValue {
+    VmValue::String(Rc::from(s))
+}
+
+pub(crate) fn vm_bool(b: bool) -> VmValue {
+    VmValue::Bool(b)
+}
+
+pub(crate) fn vm_list(items: Vec<VmValue>) -> VmValue {
+    VmValue::List(Rc::new(items))
+}
+
+/// Build a small tool registry containing an `edit` tool with rich schema
+/// (enum action, required path, multiple fields). Returned as a VmValue so it
+/// can be passed to `parse_text_tool_calls_with_tools`.
+pub(crate) fn sample_tool_registry() -> VmValue {
+    let mut params = BTreeMap::new();
+    params.insert(
+        "action".to_string(),
+        vm_dict(&[
+            ("type", vm_str("string")),
+            (
+                "enum",
+                vm_list(vec![
+                    vm_str("create"),
+                    vm_str("patch"),
+                    vm_str("replace_body"),
+                ]),
+            ),
+            ("description", vm_str("Kind of edit.")),
+        ]),
+    );
+    params.insert(
+        "path".to_string(),
+        vm_dict(&[
+            ("type", vm_str("string")),
+            ("description", vm_str("Repo-relative path.")),
+            (
+                "examples",
+                vm_list(vec![vm_str("internal/manifest/parser.go")]),
+            ),
+        ]),
+    );
+    params.insert(
+        "content".to_string(),
+        vm_dict(&[
+            ("type", vm_str("string")),
+            ("required", vm_bool(false)),
+            ("description", vm_str("File contents for create.")),
+        ]),
+    );
+    params.insert(
+        "new_body".to_string(),
+        vm_dict(&[
+            ("type", vm_str("string")),
+            ("required", vm_bool(false)),
+            ("description", vm_str("Replacement body for replace_body.")),
+        ]),
+    );
+    params.insert(
+        "function_name".to_string(),
+        vm_dict(&[
+            ("type", vm_str("string")),
+            ("required", vm_bool(false)),
+            ("description", vm_str("Existing function name.")),
+        ]),
+    );
+    params.insert(
+        "import_statement".to_string(),
+        vm_dict(&[
+            ("type", vm_str("string")),
+            ("required", vm_bool(false)),
+            ("description", vm_str("Import line for add_import.")),
+        ]),
+    );
+    params.insert(
+        "ops".to_string(),
+        vm_dict(&[
+            ("type", vm_str("list")),
+            ("required", vm_bool(false)),
+            ("description", vm_str("Atomic same-file batch edit ops.")),
+        ]),
+    );
+
+    let edit_tool = vm_dict(&[
+        ("name", vm_str("edit")),
+        ("description", vm_str("Precise code edit.")),
+        ("parameters", VmValue::Dict(Rc::new(params))),
+    ]);
+
+    let mut run_params = BTreeMap::new();
+    run_params.insert(
+        "command".to_string(),
+        vm_dict(&[
+            ("type", vm_str("string")),
+            ("description", vm_str("Shell command to execute.")),
+        ]),
+    );
+    let run_tool = vm_dict(&[
+        ("name", vm_str("run")),
+        ("description", vm_str("Run a shell command.")),
+        ("parameters", VmValue::Dict(Rc::new(run_params))),
+    ]);
+
+    vm_dict(&[("tools", vm_list(vec![edit_tool, run_tool]))])
+}
+
+pub(crate) fn known_tools_set() -> std::collections::BTreeSet<String> {
+    ["edit", "read", "run", "lookup", "scaffold"]
+        .into_iter()
+        .map(String::from)
+        .collect()
+}
+
+pub(crate) fn defer_loading_registry() -> VmValue {
+    let mut eager_params = BTreeMap::new();
+    eager_params.insert("path".to_string(), vm_str("string"));
+    let eager = vm_dict(&[
+        ("name", vm_str("look")),
+        ("description", vm_str("Read file contents")),
+        ("parameters", VmValue::Dict(Rc::new(eager_params))),
+    ]);
+
+    let mut deferred_params = BTreeMap::new();
+    deferred_params.insert("env".to_string(), vm_str("string"));
+    let deferred = vm_dict(&[
+        ("name", vm_str("deploy")),
+        ("description", vm_str("Deploy the app")),
+        ("parameters", VmValue::Dict(Rc::new(deferred_params))),
+        ("defer_loading", vm_bool(true)),
+    ]);
+
+    vm_list(vec![eager, deferred])
+}

--- a/crates/harn-vm/src/llm/tools/tests/mod.rs
+++ b/crates/harn-vm/src/llm/tools/tests/mod.rs
@@ -1,0 +1,28 @@
+//! Unit tests for `crate::llm::tools`, split by subject.
+//!
+//! Shared imports and fixtures live here so each submodule can stay on
+//! `use super::*;` while `tools/mod.rs` continues to declare only
+//! `#[cfg(test)] mod tests;`.
+
+pub(super) use super::{
+    apply_tool_search_native_injection, build_assistant_response_message,
+    build_assistant_tool_message, build_tool_calling_contract_prompt, build_tool_result_message,
+    collect_tool_schemas, collect_tool_schemas_with_registry, extract_deferred_tool_names,
+    handle_tool_locally, json_schema_to_type_expr, normalize_tool_args, parse_bare_calls_in_body,
+    parse_native_json_tool_calls, parse_text_tool_calls_with_tools, validate_tool_args,
+    vm_tools_to_native, ComponentRegistry, TEXT_RESPONSE_PROTOCOL_HELP,
+};
+pub(super) use crate::value::VmValue;
+pub(super) use serde_json::json;
+
+mod bind;
+mod execute;
+mod format;
+mod mock_fixtures;
+mod parse;
+mod registry;
+
+pub(super) use mock_fixtures::{
+    defer_loading_registry, known_tools_set, sample_tool_registry, vm_bool, vm_dict, vm_list,
+    vm_str,
+};

--- a/crates/harn-vm/src/llm/tools/tests/parse.rs
+++ b/crates/harn-vm/src/llm/tools/tests/parse.rs
@@ -1,146 +1,4 @@
-//! Unit tests for `crate::llm::tools`: the fenceless TypeScript tool-call
-//! parser, the schema → TypeScript renderer (TypeExpr + ComponentRegistry),
-//! and the argument-normalizer compatibility shims.
-//!
-//! Declared as `#[cfg(test)] mod tests;` in `tools/mod.rs`, so `super::`
-//! names either items defined directly in `mod.rs` or parser symbols
-//! that `mod.rs` re-exports (`pub(crate) use parse::…`,
-//! `pub(crate) use handle_local::…`) for callers outside the tools
-//! module. Either way the flat `use super::{…}` below is accurate.
-
-use super::{
-    apply_tool_search_native_injection, build_assistant_response_message,
-    build_assistant_tool_message, build_tool_calling_contract_prompt, build_tool_result_message,
-    collect_tool_schemas, collect_tool_schemas_with_registry, extract_deferred_tool_names,
-    normalize_tool_args, parse_bare_calls_in_body, parse_native_json_tool_calls,
-    parse_text_tool_calls_with_tools, validate_tool_args, vm_tools_to_native, ComponentRegistry,
-    TEXT_RESPONSE_PROTOCOL_HELP,
-};
-use crate::value::VmValue;
-use serde_json::json;
-use std::collections::BTreeMap;
-use std::rc::Rc;
-
-// ─── Helpers ────────────────────────────────────────────────────────────────
-
-fn vm_dict(pairs: &[(&str, VmValue)]) -> VmValue {
-    let mut map = BTreeMap::new();
-    for (k, v) in pairs {
-        map.insert((*k).to_string(), v.clone());
-    }
-    VmValue::Dict(Rc::new(map))
-}
-
-fn vm_str(s: &str) -> VmValue {
-    VmValue::String(Rc::from(s))
-}
-
-fn vm_bool(b: bool) -> VmValue {
-    VmValue::Bool(b)
-}
-
-fn vm_list(items: Vec<VmValue>) -> VmValue {
-    VmValue::List(Rc::new(items))
-}
-
-/// Build a small tool registry containing an `edit` tool with rich schema
-/// (enum action, required path, multiple fields). Returned as a VmValue so it
-/// can be passed to `parse_text_tool_calls_with_tools`.
-fn sample_tool_registry() -> VmValue {
-    // parameters dict
-    let mut params = BTreeMap::new();
-    params.insert(
-        "action".to_string(),
-        vm_dict(&[
-            ("type", vm_str("string")),
-            (
-                "enum",
-                vm_list(vec![
-                    vm_str("create"),
-                    vm_str("patch"),
-                    vm_str("replace_body"),
-                ]),
-            ),
-            ("description", vm_str("Kind of edit.")),
-        ]),
-    );
-    params.insert(
-        "path".to_string(),
-        vm_dict(&[
-            ("type", vm_str("string")),
-            ("description", vm_str("Repo-relative path.")),
-            (
-                "examples",
-                vm_list(vec![vm_str("internal/manifest/parser.go")]),
-            ),
-        ]),
-    );
-    params.insert(
-        "content".to_string(),
-        vm_dict(&[
-            ("type", vm_str("string")),
-            ("required", vm_bool(false)),
-            ("description", vm_str("File contents for create.")),
-        ]),
-    );
-    params.insert(
-        "new_body".to_string(),
-        vm_dict(&[
-            ("type", vm_str("string")),
-            ("required", vm_bool(false)),
-            ("description", vm_str("Replacement body for replace_body.")),
-        ]),
-    );
-    params.insert(
-        "function_name".to_string(),
-        vm_dict(&[
-            ("type", vm_str("string")),
-            ("required", vm_bool(false)),
-            ("description", vm_str("Existing function name.")),
-        ]),
-    );
-    params.insert(
-        "import_statement".to_string(),
-        vm_dict(&[
-            ("type", vm_str("string")),
-            ("required", vm_bool(false)),
-            ("description", vm_str("Import line for add_import.")),
-        ]),
-    );
-    params.insert(
-        "ops".to_string(),
-        vm_dict(&[
-            ("type", vm_str("list")),
-            ("required", vm_bool(false)),
-            ("description", vm_str("Atomic same-file batch edit ops.")),
-        ]),
-    );
-
-    let edit_tool = vm_dict(&[
-        ("name", vm_str("edit")),
-        ("description", vm_str("Precise code edit.")),
-        ("parameters", VmValue::Dict(Rc::new(params))),
-    ]);
-
-    // run tool
-    let mut run_params = BTreeMap::new();
-    run_params.insert(
-        "command".to_string(),
-        vm_dict(&[
-            ("type", vm_str("string")),
-            ("description", vm_str("Shell command to execute.")),
-        ]),
-    );
-    let run_tool = vm_dict(&[
-        ("name", vm_str("run")),
-        ("description", vm_str("Run a shell command.")),
-        ("parameters", VmValue::Dict(Rc::new(run_params))),
-    ]);
-
-    vm_dict(&[("tools", vm_list(vec![edit_tool, run_tool]))])
-}
-
-// ─── Fenceless TS parser ───────────────────────────────────────────────────
+use super::*;
 
 #[test]
 fn parses_a_simple_object_literal_call() {
@@ -179,7 +37,6 @@ fn parses_a_template_literal_multiline_body() {
 #[test]
 fn escapes_inside_template_literals_are_honored() {
     let tools = sample_tool_registry();
-    // \` must be passed through as a literal backtick; \\ as a backslash.
     let text = "edit({ action: \"create\", path: \"a.md\", content: `line with a \\` backtick` })";
     let result = parse_bare_calls_in_body(text, Some(&tools));
     assert!(result.errors.is_empty());
@@ -202,7 +59,6 @@ fn parses_tool_calls_inside_markdown_code_fences() {
     );
     assert_eq!(result.calls[0]["arguments"]["path"], json!("fenced.go"));
     assert_eq!(result.calls[1]["arguments"]["path"], json!("bare.go"));
-    // Fence lines should be stripped from prose when they bracket tool calls
     assert!(
         !result.prose.contains("```"),
         "fence markers should be stripped from prose: {:?}",
@@ -306,9 +162,6 @@ EOF
 #[test]
 fn reports_unknown_tool_names() {
     let tools = sample_tool_registry();
-    // `fictitious_tool(...)` looks like a call but the name is not in the
-    // registry, so the scanner should report an error and still parse the
-    // valid `edit` call.
     let text = "fictitious_tool({ x: 1 })\nedit({ action: \"create\", path: \"a.go\" })";
     let result = parse_bare_calls_in_body(text, Some(&tools));
     assert_eq!(result.errors.len(), 1, "should report unknown tool");
@@ -328,9 +181,6 @@ fn reports_unknown_tool_names() {
 
 #[test]
 fn strips_gemma_tool_code_prefix_so_native_format_parses() {
-    // Gemma 3/4 are RL-trained to emit `tool_code: fn(args)` as their
-    // native inline tool-call form. In text mode we want that to parse
-    // cleanly instead of silently drifting into prose.
     let tools = sample_tool_registry();
     let text = "tool_code: run({ command: \"ls\" })";
     let result = parse_bare_calls_in_body(text, Some(&tools));
@@ -369,11 +219,6 @@ fn strips_assorted_language_and_wrapper_prefixes() {
 
 #[test]
 fn explicit_parse_error_for_unknown_label_prefix_on_known_tool() {
-    // When the line looks like `SomeLabel: known_tool(...)` and the label
-    // isn't in our strip allowlist, we should surface a parse error so
-    // the model gets a self-correction signal instead of a silent drop.
-    // The guard is on the second identifier being a known tool, which
-    // keeps us from false-positive'ing on arbitrary prose.
     let tools = sample_tool_registry();
     let text = "Hint: run({ command: \"ls\" })";
     let result = parse_bare_calls_in_body(text, Some(&tools));
@@ -402,8 +247,6 @@ fn explicit_parse_error_for_unknown_label_prefix_on_known_tool() {
 
 #[test]
 fn parses_gemma_fenced_tool_code_block() {
-    // The full-response `unwrap_exact_code_wrapper` path handles Gemma's
-    // other native form: ```tool_code\nrun({...})\n```
     let tools = sample_tool_registry();
     let text = "```tool_code\nrun({ command: \"ls\" })\n```";
     let result = parse_bare_calls_in_body(text, Some(&tools));
@@ -413,18 +256,10 @@ fn parses_gemma_fenced_tool_code_block() {
 
 #[test]
 fn unknown_label_prefix_with_unknown_identifier_stays_prose() {
-    // `note: make_coffee(...)` must NOT fire the near-miss diagnostic
-    // because `make_coffee` isn't a known tool. This is the guardrail
-    // against false positives on arbitrary prose containing colons.
     let tools = sample_tool_registry();
     let text = "Note: make_coffee({ strength: \"strong\" })";
     let result = parse_bare_calls_in_body(text, Some(&tools));
     assert_eq!(result.calls.len(), 0);
-    // `make_coffee` followed by `(` with an object-literal arg WILL hit
-    // the existing unknown-tool error path, but only because the line
-    // starts with `Note: ` — our near-miss path must be a no-op here.
-    // The existing unknown-tool error is fine; we just check we didn't
-    // add a duplicate.
     let near_miss_errors: Vec<&String> = result
         .errors
         .iter()
@@ -457,8 +292,6 @@ fn parses_nested_object_and_array_literals() {
     new_body: { "nested": [1, 2, "three"], "flag": true }
 })"#;
     let result = parse_bare_calls_in_body(text, Some(&tools));
-    // new_body is a string in the schema, but the parser is structural and
-    // returns whatever shape the model writes; the tool handler will coerce.
     assert!(result.errors.is_empty());
     assert_eq!(result.calls.len(), 1);
     let new_body = &result.calls[0]["arguments"]["new_body"];
@@ -470,7 +303,6 @@ fn parses_nested_object_and_array_literals() {
 #[test]
 fn reports_unclosed_object_literal_with_precise_diagnostic() {
     let tools = sample_tool_registry();
-    // Truncated mid-object: model hit token limit before closing brace.
     let text = "edit({ action: \"create\", path: \"a.go\", content: `hello";
     let result = parse_bare_calls_in_body(text, Some(&tools));
     assert!(result.calls.is_empty());
@@ -561,256 +393,6 @@ fn ignores_non_tool_function_calls_inside_code_examples() {
         result.errors
     );
 }
-
-// ─── Tool-calling contract prompt ───────────────────────────────────────────
-
-#[test]
-fn contract_prompt_renders_edit_signature_with_enum_and_required_markers() {
-    let tools = sample_tool_registry();
-    let prompt = build_tool_calling_contract_prompt(Some(&tools), None, "text", true, None);
-    // TypeScript declaration header.
-    assert!(
-        prompt.contains("declare function edit(args:"),
-        "missing TS declaration: {prompt}"
-    );
-    // Enum rendered as literal union.
-    assert!(
-        prompt.contains("\"create\" | \"patch\" | \"replace_body\""),
-        "enum should render as literal union: {prompt}"
-    );
-    // Required `path` comes before optional fields in the object type.
-    let obj_start = prompt.find("args: {").unwrap();
-    let obj_end = prompt[obj_start..].find("})").unwrap() + obj_start;
-    let obj_body = &prompt[obj_start..obj_end];
-    let path_idx = obj_body.find("path:").unwrap();
-    let content_idx = obj_body.find("content?:").unwrap();
-    assert!(
-        path_idx < content_idx,
-        "required `path` should appear before optional `content?`: {obj_body}"
-    );
-    // Optional fields carry a trailing `?` in the declaration.
-    assert!(obj_body.contains("content?: string"));
-    assert!(obj_body.contains("new_body?: string"));
-    // Field comments carry required/optional markers and examples inline.
-    assert!(prompt.contains("path: string /* required"));
-    assert!(prompt.contains("content?: string /* optional"));
-    assert!(prompt.contains("\"internal/manifest/parser.go\""));
-    assert!(!prompt.contains("@param path"));
-    // Tagged response protocol contract is included in text mode.
-    assert!(prompt.contains("declare function") || prompt.contains("Response protocol"));
-}
-
-#[test]
-fn contract_prompt_help_block_documents_tagged_protocol() {
-    // The help constant teaches the three top-level tags, the call shape
-    // inside <tool_call>, and the done-block grammar.
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("Response protocol"));
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("<tool_call>"));
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("</tool_call>"));
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("<assistant_prose>"));
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("<done>##DONE##</done>"));
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("name({ key: value })"));
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("heredoc"));
-    // Legacy bare-call phrasing must not regress.
-    assert!(!TEXT_RESPONSE_PROTOCOL_HELP.contains("contains no tool calls"));
-    assert!(!TEXT_RESPONSE_PROTOCOL_HELP.contains("```call"));
-}
-
-#[test]
-fn contract_prompt_native_mode_prefers_provider_channel_without_text_fallback() {
-    // Native mode should stay lean: the provider already receives the
-    // structured `tools` payload, so the system prompt must not inject
-    // the text-mode response grammar or duplicate `declare function`
-    // schemas that can confuse native-tool parsers.
-    let tools = sample_tool_registry();
-    let prompt = build_tool_calling_contract_prompt(Some(&tools), None, "native", true, None);
-    assert!(
-        prompt.contains("native tool-calling channel"),
-        "native preamble missing: {prompt}"
-    );
-    assert!(
-        prompt.contains("This turn is action-gated"),
-        "action gate missing: {prompt}"
-    );
-    assert!(prompt.contains("## Task ledger"));
-    assert!(!prompt.contains("## Response protocol"));
-    assert!(!prompt.contains("declare function edit(args:"));
-    assert!(!prompt.contains("## Available tools"));
-    assert!(!prompt.contains("<tool_call>"));
-}
-
-#[test]
-fn contract_prompt_text_mode_mentions_action_gate_before_examples() {
-    let tools = sample_tool_registry();
-    let prompt = build_tool_calling_contract_prompt(Some(&tools), None, "text", true, None);
-    assert!(prompt.contains("This turn is action-gated."));
-    assert!(prompt.contains("`<tool_call>...</tool_call>`"));
-    assert!(prompt.contains("Do not emit raw source code"));
-}
-
-#[test]
-fn contract_prompt_includes_tool_examples_before_schemas() {
-    let tools = sample_tool_registry();
-    let examples = "read({ path: \"src/main.rs\" })\n\nedit({ action: \"create\", path: \"test.rs\", content: <<EOF\nfn main() {}\nEOF\n})";
-    let prompt =
-        build_tool_calling_contract_prompt(Some(&tools), None, "text", true, Some(examples));
-    // Examples section is present.
-    assert!(
-        prompt.contains("## Tool call examples"),
-        "missing examples header: {prompt}"
-    );
-    assert!(
-        prompt.contains("read({ path: \"src/main.rs\" })"),
-        "missing example content: {prompt}"
-    );
-    // Examples appear BEFORE the tool schemas.
-    let examples_pos = prompt.find("Tool call examples").unwrap();
-    let schemas_pos = prompt.find("Available tools").unwrap();
-    assert!(
-        examples_pos < schemas_pos,
-        "examples ({examples_pos}) should appear before schemas ({schemas_pos})"
-    );
-}
-
-#[test]
-fn contract_prompt_omits_examples_section_when_none() {
-    let tools = sample_tool_registry();
-    let prompt = build_tool_calling_contract_prompt(Some(&tools), None, "text", true, None);
-    assert!(
-        !prompt.contains("Tool call examples"),
-        "should not have examples section when None"
-    );
-}
-
-// ─── $ref / ComponentRegistry ───────────────────────────────────────────────
-
-#[test]
-fn native_schema_ref_resolves_to_component_alias() {
-    let native_tools = vec![json!({
-        "type": "function",
-        "function": {
-            "name": "touch",
-            "description": "Touch a file path.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "path": { "$ref": "#/components/schemas/FilePath" }
-                },
-                "required": ["path"]
-            }
-        },
-        "components": {
-            "schemas": {
-                "FilePath": {
-                    "type": "string",
-                    "description": "Repo-relative path"
-                }
-            }
-        }
-    })];
-    let (schemas, registry) = collect_tool_schemas_with_registry(None, Some(&native_tools));
-    assert_eq!(schemas.len(), 1);
-    let aliases = registry.render_aliases();
-    assert!(
-        aliases.contains("type FilePath = string;"),
-        "expected type alias for FilePath: {aliases}"
-    );
-    // The signature for `touch` should reference `FilePath` by name.
-    let prompt = build_tool_calling_contract_prompt(None, Some(&native_tools), "text", false, None);
-    assert!(
-        prompt.contains("type FilePath = string;"),
-        "prompt missing alias: {prompt}"
-    );
-    assert!(
-        prompt.contains("path: FilePath"),
-        "signature should reference alias: {prompt}"
-    );
-}
-
-#[test]
-fn component_registry_handles_recursive_refs_without_looping() {
-    let mut registry = ComponentRegistry::default();
-    // A root schema where `Node` refers to itself via its children. We just
-    // need to prove resolution terminates.
-    let root = json!({
-        "components": {
-            "schemas": {
-                "Node": {
-                    "type": "object",
-                    "properties": {
-                        "children": {
-                            "type": "array",
-                            "items": { "$ref": "#/components/schemas/Node" }
-                        }
-                    }
-                }
-            }
-        }
-    });
-    let node_schema = root["components"]["schemas"]["Node"].clone();
-    let _ty = super::json_schema_to_type_expr(&node_schema, &root, &mut registry);
-    // Alias rendering must not panic or infinite-loop.
-    let _ = registry.render_aliases();
-}
-
-// ─── normalize_tool_args alias rewriting ───────────────────────────────────
-//
-// The VM consults the active policy's tool_annotations registry for the
-// arg_aliases table; no tool-name branches live in harn. Tool-specific
-// command shaping (e.g. joining argv arrays into shell strings) now lives
-// in the pipeline's tool handler, not the VM.
-
-#[test]
-fn normalize_tool_args_rewrites_declared_aliases_from_active_policy() {
-    use crate::orchestration::{pop_execution_policy, push_execution_policy, CapabilityPolicy};
-    use crate::tool_annotations::{ToolAnnotations, ToolArgSchema, ToolKind};
-
-    let mut annotations = std::collections::BTreeMap::new();
-    let mut arg_aliases = std::collections::BTreeMap::new();
-    arg_aliases.insert("file".to_string(), "path".to_string());
-    arg_aliases.insert("mode".to_string(), "action".to_string());
-    annotations.insert(
-        "edit".to_string(),
-        ToolAnnotations {
-            kind: ToolKind::Edit,
-            arg_schema: ToolArgSchema {
-                arg_aliases,
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-    );
-    let policy = CapabilityPolicy {
-        tool_annotations: annotations,
-        ..Default::default()
-    };
-    push_execution_policy(policy);
-
-    // Aliases get rewritten to their canonical keys; non-aliased fields
-    // pass through untouched; canonical key already present wins over alias.
-    let out = normalize_tool_args(
-        "edit",
-        &json!({"file": "lib/foo.rs", "mode": "replace_range", "range_start": "3"}),
-    );
-    assert_eq!(out["path"], json!("lib/foo.rs"));
-    assert_eq!(out["action"], json!("replace_range"));
-    assert!(out.get("file").is_none());
-    assert!(out.get("mode").is_none());
-    // range_start still coerces string-numerics to integers.
-    assert_eq!(out["range_start"], json!(3));
-
-    pop_execution_policy();
-}
-
-#[test]
-fn normalize_tool_args_skips_unannotated_tool() {
-    // Unannotated tools get no alias rewriting — harn has no
-    // hardcoded tool-name knowledge.
-    let out = normalize_tool_args("mystery_tool", &json!({"file": "x.rs"}));
-    assert_eq!(out, json!({"file": "x.rs"}));
-}
-
-// ─── Heredoc parser tests ──────────────────────────────────────────────────
 
 #[test]
 fn heredoc_simple() {
@@ -948,10 +530,6 @@ NEW
 
 #[test]
 fn heredoc_close_with_brace_and_comma_on_same_line() {
-    // Cheap models (e.g. Together Gemma 3n) frequently collapse the closing
-    // dict/array tail onto the heredoc's closing line: `EOF },`. The parser
-    // must accept that — anything after the tag on the close line is handed
-    // back to the outer parser verbatim.
     let tools = sample_tool_registry();
     let text = r#"edit({ path: "internal/manifest/parser_extra_test.go", ops: [
   { op: "replace_body", function_name: "TestInvalidYaml", new_body: <<EOF
@@ -988,9 +566,6 @@ EOF }
 
 #[test]
 fn heredoc_close_with_multiple_closers_on_same_line() {
-    // Tightly-collapsed tool calls sometimes end with `EOF } ] })` all on
-    // one line. The word-boundary closing rule should absorb any punctuation
-    // after the tag and hand control back to the outer parser.
     let tools = sample_tool_registry();
     let text = r#"edit({ path: "a.go", ops: [ { op: "replace_body", function_name: "F", new_body: <<EOF
 body
@@ -1009,9 +584,6 @@ EOF } ] })"#;
 
 #[test]
 fn heredoc_word_boundary_rejects_tag_prefix_of_identifier() {
-    // The close line must hit a word boundary after the tag. `EOFunction`
-    // should NOT terminate the heredoc — otherwise any identifier that
-    // happens to begin with the tag would corrupt content parsing.
     let tools = sample_tool_registry();
     let text = r#"edit({
     action: "create",
@@ -1281,15 +853,6 @@ run({ command: "go build" })"#;
     );
 }
 
-// ─── Native JSON fallback parser ──────────────────────────────────────────
-
-fn known_tools_set() -> std::collections::BTreeSet<String> {
-    ["edit", "read", "run", "lookup", "scaffold"]
-        .into_iter()
-        .map(String::from)
-        .collect()
-}
-
 #[test]
 fn native_json_fallback_parses_openai_array_format() {
     let known = known_tools_set();
@@ -1303,26 +866,6 @@ fn native_json_fallback_parses_openai_array_format() {
     assert_eq!(calls[0]["arguments"]["action"], json!("create"));
     assert_eq!(calls[0]["arguments"]["path"], json!("test.go"));
     assert_eq!(calls[0]["arguments"]["content"], json!("package main"));
-}
-
-#[test]
-fn normalize_tool_args_coerces_integer_like_string_fields() {
-    let normalized = normalize_tool_args(
-        "edit",
-        &json!({
-            "action": "replace_range",
-            "path": "tests/unit/test_example.py",
-            "range_start": "1",
-            "range_end": "19",
-            "ops": [
-                {"op": "replace_range", "range_start": "3", "range_end": "5"}
-            ]
-        }),
-    );
-    assert_eq!(normalized["range_start"], json!(1));
-    assert_eq!(normalized["range_end"], json!(19));
-    assert_eq!(normalized["ops"][0]["range_start"], json!(3));
-    assert_eq!(normalized["ops"][0]["range_end"], json!(5));
 }
 
 #[test]
@@ -1382,7 +925,6 @@ fn native_json_fallback_returns_empty_for_no_json() {
 #[test]
 fn native_json_fallback_handles_object_arguments() {
     let known = known_tools_set();
-    // Some models emit arguments as an object instead of a JSON string
     let text = r#"[{"id":"call_001","type":"function","function":{"name":"read","arguments":{"path":"main.go"}}}]"#;
     let (calls, errors) = parse_native_json_tool_calls(text, &known);
     assert!(errors.is_empty());
@@ -1408,8 +950,6 @@ Now I'll create the test:
 
 #[test]
 fn text_parser_falls_through_to_native_json_fallback() {
-    // End-to-end: the main parse_text_tool_calls_with_tools should fall
-    // through to the native JSON parser when text parsing finds nothing
     let tools = sample_tool_registry();
     let text = r#"I'll create the file.
 
@@ -1431,198 +971,17 @@ fn text_parser_falls_through_to_native_json_fallback() {
 
 #[test]
 fn text_parser_prefers_text_format_over_native_json() {
-    // If both text-format and native JSON are present, text format wins
     let tools = sample_tool_registry();
     let text = r#"edit({ action: "create", path: "a.go", content: "pkg a" })
 
 [{"id":"call_001","type":"function","function":{"name":"run","arguments":"{\"command\":\"go test\"}"}}]"#;
     let result = parse_bare_calls_in_body(text, Some(&tools));
-    // Text parser should find the edit call and NOT fall through to native
     assert_eq!(result.calls.len(), 1, "text format should take priority");
     assert_eq!(result.calls[0]["name"], json!("edit"));
 }
 
 #[test]
-fn assistant_tool_message_includes_empty_content_for_openai_style() {
-    let message = build_assistant_tool_message(
-        "",
-        &[json!({
-            "id": "call_001",
-            "name": "read",
-            "arguments": {"path": "main.rs"},
-        })],
-        "together",
-    );
-
-    assert_eq!(message["role"], "assistant");
-    assert_eq!(message["content"], "");
-    assert_eq!(message["tool_calls"][0]["id"], "call_001");
-}
-
-#[test]
-fn assistant_tool_message_uses_ollama_native_shape() {
-    let message = build_assistant_tool_message(
-        "",
-        &[json!({
-            "id": "call_001",
-            "name": "read",
-            "arguments": {"path": "main.rs"},
-        })],
-        "ollama",
-    );
-
-    assert_eq!(message["role"], "assistant");
-    assert!(message.get("content").is_none());
-    assert_eq!(message["tool_calls"][0]["type"], "function");
-    assert_eq!(message["tool_calls"][0]["function"]["name"], "read");
-    assert_eq!(
-        message["tool_calls"][0]["function"]["arguments"]["path"],
-        "main.rs"
-    );
-}
-
-#[test]
-fn tool_result_message_uses_ollama_tool_name() {
-    let message = build_tool_result_message("call_001", "read", "contents", "ollama");
-
-    assert_eq!(message["role"], "tool");
-    assert_eq!(message["tool_name"], "read");
-    assert_eq!(message["content"], "contents");
-    assert!(message.get("tool_call_id").is_none());
-}
-
-#[test]
-fn assistant_response_message_preserves_reasoning() {
-    let message = build_assistant_response_message(
-        "",
-        &[],
-        &[json!({
-            "id": "call_001",
-            "name": "read",
-            "arguments": {"path": "main.rs"},
-        })],
-        Some("inspect the file before editing"),
-        "together",
-    );
-
-    assert_eq!(message["reasoning"], "inspect the file before editing");
-    assert_eq!(message["content"], "");
-    assert_eq!(message["tool_calls"][0]["id"], "call_001");
-}
-
-// ─── handle_tool_locally: read_file offset/limit ───────────────────────────
-
-#[test]
-fn read_file_offset_and_limit() {
-    use super::handle_tool_locally;
-    use std::io::Write;
-
-    // Create a temp file with numbered lines.
-    let dir = std::env::temp_dir().join("harn_test_read_file_offset");
-    let _ = std::fs::create_dir_all(&dir);
-    let path = dir.join("test_offset.txt");
-    {
-        let mut f = std::fs::File::create(&path).unwrap();
-        for i in 1..=20 {
-            writeln!(f, "line {i}").unwrap();
-        }
-    }
-    let path_str = path.to_str().unwrap();
-
-    // Full read — should get all 20 lines.
-    let result = handle_tool_locally("read_file", &json!({"path": path_str})).unwrap();
-    assert!(result.contains("1\tline 1"), "first line numbered");
-    assert!(result.contains("20\tline 20"), "last line numbered");
-    assert!(!result.contains("more lines not shown"), "no truncation");
-
-    // Offset 5, limit 3 — lines 5, 6, 7.
-    let result = handle_tool_locally(
-        "read_file",
-        &json!({"path": path_str, "offset": 5, "limit": 3}),
-    )
-    .unwrap();
-    assert!(result.contains("5\tline 5"), "starts at line 5");
-    assert!(result.contains("7\tline 7"), "ends at line 7");
-    assert!(!result.contains("4\tline 4"), "no line 4");
-    assert!(!result.contains("8\tline 8"), "no line 8");
-    assert!(result.contains("more lines not shown"), "truncation hint");
-    assert!(result.contains("offset=8"), "hint says offset=8");
-
-    // Offset past end — empty result, no panic.
-    let result =
-        handle_tool_locally("read_file", &json!({"path": path_str, "offset": 100})).unwrap();
-    assert!(!result.contains("line"), "no content past end");
-
-    // Clean up.
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_dir(&dir);
-}
-
-// ── validate_tool_args ─────────────────────────────────────────────────────
-
-#[test]
-fn validate_tool_args_reports_missing_required_params() {
-    let tools = sample_tool_registry();
-    let schemas = collect_tool_schemas(Some(&tools), None);
-    // edit requires "action" and "path" — omit "path"
-    let args = json!({"action": "create"});
-    let result = validate_tool_args("edit", &args, &schemas);
-    assert!(result.is_err(), "should report missing required param");
-    let msg = result.unwrap_err();
-    assert!(msg.contains("path"), "error should mention 'path': {msg}");
-    assert!(
-        msg.contains("missing required parameter"),
-        "error should say missing required: {msg}"
-    );
-}
-
-#[test]
-fn validate_tool_args_passes_when_all_required_present() {
-    let tools = sample_tool_registry();
-    let schemas = collect_tool_schemas(Some(&tools), None);
-    let args = json!({"action": "create", "path": "test.go", "content": "pkg main"});
-    let result = validate_tool_args("edit", &args, &schemas);
-    assert!(result.is_ok(), "should pass with all required params");
-}
-
-#[test]
-fn validate_tool_args_skips_unknown_tool() {
-    let tools = sample_tool_registry();
-    let schemas = collect_tool_schemas(Some(&tools), None);
-    let args = json!({"foo": "bar"});
-    let result = validate_tool_args("nonexistent_tool", &args, &schemas);
-    assert!(
-        result.is_ok(),
-        "should pass for unknown tool (handled elsewhere)"
-    );
-}
-
-#[test]
-fn validate_tool_args_treats_null_as_missing() {
-    let tools = sample_tool_registry();
-    let schemas = collect_tool_schemas(Some(&tools), None);
-    let args = json!({"action": "create", "path": null});
-    let result = validate_tool_args("edit", &args, &schemas);
-    assert!(result.is_err(), "null should count as missing");
-    assert!(result.unwrap_err().contains("path"));
-}
-
-#[test]
-fn validate_tool_args_passes_with_empty_args_when_no_required() {
-    let tools = sample_tool_registry();
-    let schemas = collect_tool_schemas(Some(&tools), None);
-    // "run" tool requires "command" — but let's test with a tool that has
-    // no required params. Since sample_tool_registry tools all have required
-    // params, just verify an unknown tool passes.
-    let result = validate_tool_args("no_such_tool", &json!({}), &schemas);
-    assert!(result.is_ok());
-}
-
-#[test]
 fn text_parser_reports_unknown_tool_in_native_json_fallback() {
-    // End-to-end through parse_text_tool_calls_with_tools: when a native
-    // JSON fallback call references an unknown tool, it should surface as
-    // an error in the TextToolParseResult.
     let tools = sample_tool_registry();
     let text = r#"[{"id":"call_001","type":"function","function":{"name":"nonexistent","arguments":"{}"}}]"#;
     let result = parse_bare_calls_in_body(text, Some(&tools));
@@ -1638,12 +997,6 @@ fn text_parser_reports_unknown_tool_in_native_json_fallback() {
         result.errors[0]
     );
 }
-
-// ─── Tagged response protocol ──────────────────────────────────────────────
-//
-// These tests exercise the top-level `parse_text_tool_calls_with_tools`
-// grammar: responses must be composed only of <tool_call>, <assistant_prose>,
-// and <done> blocks at the top level, with whitespace between them.
 
 #[test]
 fn tagged_parser_accepts_well_formed_response() {
@@ -1681,18 +1034,11 @@ fn tagged_parser_flags_stray_prose_outside_tags() {
         !result.violations.is_empty(),
         "stray prose before <tool_call> must be flagged"
     );
-    // The inside-tag call still parses; the model sees the violation on the
-    // next turn but the runtime doesn't lose the action.
     assert_eq!(result.calls.len(), 1);
 }
 
 #[test]
 fn tagged_parser_executes_bare_tool_call_with_soft_violation() {
-    // Pre-v0.5.82 bare calls without `<tool_call>` wrappers were flagged
-    // AND dropped, which stranded weaker locally-hosted models that kept
-    // emitting the same right-shape-wrong-wrapper response. Now we
-    // execute the call and surface a soft violation so the model still
-    // learns the canonical wrapping next turn.
     let tools = sample_tool_registry();
     let text = "edit({ action: \"create\", path: \"a.rs\", content: \"x\" })";
     let result = parse_text_tool_calls_with_tools(text, Some(&tools));
@@ -1723,12 +1069,6 @@ fn tagged_parser_executes_bare_tool_call_with_soft_violation() {
 
 #[test]
 fn tagged_parser_executes_bare_tool_call_with_heredoc_body() {
-    // Regression: the top-level scanner's stray-bytes chunker scanned to
-    // the next `<` byte, which truncated bare `name({ key: <<EOF\n...\nEOF })`
-    // calls at the heredoc opener and left the salvage path with a fragment
-    // that couldn't parse. qwen2.5-coder hits this on every py-test edit
-    // because it emits the entire test body as a heredoc value without
-    // wrapping the call in `<tool_call>` tags.
     let tools = sample_tool_registry();
     let text = "edit({ action: \"replace_range\", path: \"tests/test.py\", \
                 range_start: 1, range_end: 4, content: <<EOF\n\
@@ -1840,7 +1180,6 @@ fn tagged_parser_canonical_omits_raw_stray_text() {
     let tools = sample_tool_registry();
     let text = "leading garbage\n<assistant_prose>Narration.</assistant_prose>";
     let result = parse_text_tool_calls_with_tools(text, Some(&tools));
-    // Canonical reflects only the well-formed tagged content.
     assert_eq!(
         result.canonical.trim(),
         "<assistant_prose>\nNarration.\n</assistant_prose>"
@@ -1850,226 +1189,9 @@ fn tagged_parser_canonical_omits_raw_stray_text() {
 
 #[test]
 fn tagged_parser_accepts_configured_done_body() {
-    // The parser captures the body verbatim; the agent compares it to the
-    // pipeline's configured `done_sentinel` value. Non-default sentinels
-    // like "PLAN_READY" must round-trip through the grammar.
     let tools = sample_tool_registry();
     let text = "<done>PLAN_READY</done>";
     let result = parse_text_tool_calls_with_tools(text, Some(&tools));
     assert_eq!(result.done_marker.as_deref(), Some("PLAN_READY"));
     assert!(result.violations.is_empty());
-}
-
-// ─── Tool Vault: defer_loading + tool_search ────────────────────────────────
-//
-// These exercise the pieces of the progressive-disclosure surface that can't
-// easily be reached from a `.harn` conformance test without a live provider:
-// payload shape for the Anthropic-style native path, the deferred-tool name
-// extractor, and the synthetic `tool_search_tool_*` meta-tool injection.
-
-fn defer_loading_registry() -> VmValue {
-    let mut eager_params = BTreeMap::new();
-    eager_params.insert("path".to_string(), vm_str("string"));
-    let eager = vm_dict(&[
-        ("name", vm_str("look")),
-        ("description", vm_str("Read file contents")),
-        ("parameters", VmValue::Dict(Rc::new(eager_params))),
-    ]);
-
-    let mut deferred_params = BTreeMap::new();
-    deferred_params.insert("env".to_string(), vm_str("string"));
-    let deferred = vm_dict(&[
-        ("name", vm_str("deploy")),
-        ("description", vm_str("Deploy the app")),
-        ("parameters", VmValue::Dict(Rc::new(deferred_params))),
-        ("defer_loading", vm_bool(true)),
-    ]);
-
-    vm_list(vec![eager, deferred])
-}
-
-#[test]
-fn vm_tools_to_native_emits_defer_loading_for_anthropic() {
-    let registry = defer_loading_registry();
-    let tools = vm_tools_to_native(&registry, "anthropic").expect("anthropic native tools");
-    // Eager `look` tool has no defer_loading key.
-    let look = tools
-        .iter()
-        .find(|t| t.get("name").and_then(|v| v.as_str()) == Some("look"))
-        .expect("look tool present");
-    assert!(look.get("defer_loading").is_none());
-    // Deferred `deploy` tool carries `defer_loading: true`.
-    let deploy = tools
-        .iter()
-        .find(|t| t.get("name").and_then(|v| v.as_str()) == Some("deploy"))
-        .expect("deploy tool present");
-    assert_eq!(
-        deploy.get("defer_loading").and_then(|v| v.as_bool()),
-        Some(true)
-    );
-}
-
-#[test]
-fn vm_tools_to_native_emits_namespace_for_openai_compat() {
-    // `namespace` on a tool entry (harn#71) flows through to the
-    // OpenAI-shape wrapper alongside `defer_loading`. Anthropic
-    // receives it too — the field is harmless there (ignored by the
-    // API) and keeps replay fidelity.
-    let mut deferred_params = BTreeMap::new();
-    deferred_params.insert("env".to_string(), vm_str("string"));
-    let deferred = vm_dict(&[
-        ("name", vm_str("deploy")),
-        ("description", vm_str("Deploy the app")),
-        ("parameters", VmValue::Dict(Rc::new(deferred_params))),
-        ("defer_loading", vm_bool(true)),
-        ("namespace", vm_str("ops")),
-    ]);
-    let registry = vm_list(vec![deferred]);
-
-    let openai = vm_tools_to_native(&registry, "openai").expect("openai native tools");
-    assert_eq!(openai[0]["namespace"].as_str(), Some("ops"));
-    assert_eq!(openai[0]["defer_loading"].as_bool(), Some(true));
-
-    let anthropic = vm_tools_to_native(&registry, "anthropic").expect("anthropic native tools");
-    assert_eq!(
-        anthropic[0]["namespace"].as_str(),
-        Some("ops"),
-        "namespace survives Anthropic passthrough (harmlessly ignored by API)"
-    );
-}
-
-#[test]
-fn vm_tools_to_native_emits_defer_loading_for_openai_compat() {
-    // OpenAI-shape tools place the flag at the wrapper level (not inside
-    // `function`) so harn#71's Responses-API path can read it uniformly
-    // without re-walking. Non-Anthropic providers that don't understand
-    // the flag will never actually see it — the capability gate in
-    // options.rs blocks them before the request leaves the VM.
-    let registry = defer_loading_registry();
-    let tools = vm_tools_to_native(&registry, "openai").expect("openai native tools");
-    let deploy = tools
-        .iter()
-        .find(|t| {
-            t.get("function")
-                .and_then(|f| f.get("name"))
-                .and_then(|v| v.as_str())
-                == Some("deploy")
-        })
-        .expect("deploy tool present");
-    assert_eq!(
-        deploy.get("defer_loading").and_then(|v| v.as_bool()),
-        Some(true)
-    );
-}
-
-#[test]
-fn extract_deferred_tool_names_walks_both_wire_shapes() {
-    let anthropic = vec![
-        json!({"name": "look"}),
-        json!({"name": "deploy", "defer_loading": true}),
-    ];
-    assert_eq!(
-        extract_deferred_tool_names(&anthropic),
-        vec!["deploy".to_string()]
-    );
-
-    let openai = vec![
-        json!({"type": "function", "function": {"name": "look"}}),
-        json!({
-            "type": "function",
-            "function": {"name": "deploy"},
-            "defer_loading": true,
-        }),
-    ];
-    assert_eq!(
-        extract_deferred_tool_names(&openai),
-        vec!["deploy".to_string()]
-    );
-}
-
-#[test]
-fn apply_tool_search_native_injection_prepends_meta_tool() {
-    let mut tools: Option<Vec<serde_json::Value>> =
-        Some(vec![json!({"name": "look"}), json!({"name": "deploy"})]);
-    apply_tool_search_native_injection(&mut tools, "anthropic", "bm25");
-    let tools = tools.expect("tools still set");
-    assert_eq!(tools.len(), 3, "search tool prepended");
-    assert_eq!(
-        tools[0]["type"].as_str(),
-        Some("tool_search_tool_bm25_20251119"),
-        "bm25 variant uses the documented type string"
-    );
-    assert_eq!(tools[0]["name"].as_str(), Some("tool_search_tool_bm25"));
-}
-
-#[test]
-fn apply_tool_search_native_injection_regex_variant() {
-    let mut tools: Option<Vec<serde_json::Value>> = Some(vec![json!({"name": "look"})]);
-    apply_tool_search_native_injection(&mut tools, "anthropic", "regex");
-    let tools = tools.unwrap();
-    assert_eq!(
-        tools[0]["type"].as_str(),
-        Some("tool_search_tool_regex_20251119")
-    );
-    assert_eq!(tools[0]["name"].as_str(), Some("tool_search_tool_regex"));
-}
-
-#[test]
-fn apply_tool_search_native_injection_emits_openai_shape_for_non_anthropic() {
-    // OpenAI's native `tool_search` meta-tool (harn#71) uses a flat
-    // `{"type": "tool_search", "mode": "hosted"}` shape, distinct from
-    // Anthropic's versioned `tool_search_tool_*_20251119` block.
-    let mut tools: Option<Vec<serde_json::Value>> = Some(vec![json!({"name": "look"})]);
-    apply_tool_search_native_injection(&mut tools, "openai", "bm25");
-    let tools = tools.unwrap();
-    assert_eq!(tools.len(), 2, "OpenAI meta-tool prepended");
-    assert_eq!(tools[0]["type"].as_str(), Some("tool_search"));
-    assert_eq!(tools[0]["mode"].as_str(), Some("hosted"));
-    assert!(
-        tools[0].get("name").is_none(),
-        "OpenAI meta-tool has no `name` field (that's an Anthropic detail)"
-    );
-    assert_eq!(tools[1]["name"].as_str(), Some("look"));
-}
-
-#[test]
-fn apply_tool_search_native_injection_openai_collects_namespaces() {
-    // When deferred tools declare a `namespace`, OpenAI's meta-tool
-    // carries the distinct set so the server can group them.
-    let mut tools: Option<Vec<serde_json::Value>> = Some(vec![
-        json!({
-            "type": "function",
-            "function": {"name": "deploy_api"},
-            "namespace": "ops",
-        }),
-        json!({
-            "type": "function",
-            "function": {"name": "deploy_web"},
-            "namespace": "ops",
-        }),
-        json!({
-            "type": "function",
-            "function": {"name": "lookup_account"},
-            "namespace": "crm",
-        }),
-    ]);
-    apply_tool_search_native_injection(&mut tools, "openai", "bm25");
-    let tools = tools.unwrap();
-    let namespaces = tools[0]["namespaces"]
-        .as_array()
-        .expect("namespaces present");
-    let names: Vec<&str> = namespaces.iter().filter_map(|v| v.as_str()).collect();
-    assert_eq!(names, vec!["crm", "ops"], "sorted + deduped");
-}
-
-#[test]
-fn apply_tool_search_native_injection_creates_list_when_empty() {
-    let mut tools: Option<Vec<serde_json::Value>> = None;
-    apply_tool_search_native_injection(&mut tools, "anthropic", "bm25");
-    let tools = tools.expect("tools populated");
-    assert_eq!(tools.len(), 1);
-    assert_eq!(
-        tools[0]["type"].as_str(),
-        Some("tool_search_tool_bm25_20251119")
-    );
 }

--- a/crates/harn-vm/src/llm/tools/tests/registry.rs
+++ b/crates/harn-vm/src/llm/tools/tests/registry.rs
@@ -1,0 +1,238 @@
+use super::*;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+#[test]
+fn native_schema_ref_resolves_to_component_alias() {
+    let native_tools = vec![json!({
+        "type": "function",
+        "function": {
+            "name": "touch",
+            "description": "Touch a file path.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": { "$ref": "#/components/schemas/FilePath" }
+                },
+                "required": ["path"]
+            }
+        },
+        "components": {
+            "schemas": {
+                "FilePath": {
+                    "type": "string",
+                    "description": "Repo-relative path"
+                }
+            }
+        }
+    })];
+    let (schemas, registry) = collect_tool_schemas_with_registry(None, Some(&native_tools));
+    assert_eq!(schemas.len(), 1);
+    let aliases = registry.render_aliases();
+    assert!(
+        aliases.contains("type FilePath = string;"),
+        "expected type alias for FilePath: {aliases}"
+    );
+    let prompt = build_tool_calling_contract_prompt(None, Some(&native_tools), "text", false, None);
+    assert!(
+        prompt.contains("type FilePath = string;"),
+        "prompt missing alias: {prompt}"
+    );
+    assert!(
+        prompt.contains("path: FilePath"),
+        "signature should reference alias: {prompt}"
+    );
+}
+
+#[test]
+fn component_registry_handles_recursive_refs_without_looping() {
+    let mut registry = ComponentRegistry::default();
+    let root = json!({
+        "components": {
+            "schemas": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "children": {
+                            "type": "array",
+                            "items": { "$ref": "#/components/schemas/Node" }
+                        }
+                    }
+                }
+            }
+        }
+    });
+    let node_schema = root["components"]["schemas"]["Node"].clone();
+    let _ty = json_schema_to_type_expr(&node_schema, &root, &mut registry);
+    let _ = registry.render_aliases();
+}
+
+#[test]
+fn vm_tools_to_native_emits_defer_loading_for_anthropic() {
+    let registry = defer_loading_registry();
+    let tools = vm_tools_to_native(&registry, "anthropic").expect("anthropic native tools");
+    let look = tools
+        .iter()
+        .find(|t| t.get("name").and_then(|v| v.as_str()) == Some("look"))
+        .expect("look tool present");
+    assert!(look.get("defer_loading").is_none());
+    let deploy = tools
+        .iter()
+        .find(|t| t.get("name").and_then(|v| v.as_str()) == Some("deploy"))
+        .expect("deploy tool present");
+    assert_eq!(
+        deploy.get("defer_loading").and_then(|v| v.as_bool()),
+        Some(true)
+    );
+}
+
+#[test]
+fn vm_tools_to_native_emits_namespace_for_openai_compat() {
+    let mut deferred_params = BTreeMap::new();
+    deferred_params.insert("env".to_string(), vm_str("string"));
+    let deferred = vm_dict(&[
+        ("name", vm_str("deploy")),
+        ("description", vm_str("Deploy the app")),
+        ("parameters", VmValue::Dict(Rc::new(deferred_params))),
+        ("defer_loading", vm_bool(true)),
+        ("namespace", vm_str("ops")),
+    ]);
+    let registry = vm_list(vec![deferred]);
+
+    let openai = vm_tools_to_native(&registry, "openai").expect("openai native tools");
+    assert_eq!(openai[0]["namespace"].as_str(), Some("ops"));
+    assert_eq!(openai[0]["defer_loading"].as_bool(), Some(true));
+
+    let anthropic = vm_tools_to_native(&registry, "anthropic").expect("anthropic native tools");
+    assert_eq!(
+        anthropic[0]["namespace"].as_str(),
+        Some("ops"),
+        "namespace survives Anthropic passthrough (harmlessly ignored by API)"
+    );
+}
+
+#[test]
+fn vm_tools_to_native_emits_defer_loading_for_openai_compat() {
+    let registry = defer_loading_registry();
+    let tools = vm_tools_to_native(&registry, "openai").expect("openai native tools");
+    let deploy = tools
+        .iter()
+        .find(|t| {
+            t.get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|v| v.as_str())
+                == Some("deploy")
+        })
+        .expect("deploy tool present");
+    assert_eq!(
+        deploy.get("defer_loading").and_then(|v| v.as_bool()),
+        Some(true)
+    );
+}
+
+#[test]
+fn extract_deferred_tool_names_walks_both_wire_shapes() {
+    let anthropic = vec![
+        json!({"name": "look"}),
+        json!({"name": "deploy", "defer_loading": true}),
+    ];
+    assert_eq!(
+        extract_deferred_tool_names(&anthropic),
+        vec!["deploy".to_string()]
+    );
+
+    let openai = vec![
+        json!({"type": "function", "function": {"name": "look"}}),
+        json!({
+            "type": "function",
+            "function": {"name": "deploy"},
+            "defer_loading": true,
+        }),
+    ];
+    assert_eq!(
+        extract_deferred_tool_names(&openai),
+        vec!["deploy".to_string()]
+    );
+}
+
+#[test]
+fn apply_tool_search_native_injection_prepends_meta_tool() {
+    let mut tools: Option<Vec<serde_json::Value>> =
+        Some(vec![json!({"name": "look"}), json!({"name": "deploy"})]);
+    apply_tool_search_native_injection(&mut tools, "anthropic", "bm25");
+    let tools = tools.expect("tools still set");
+    assert_eq!(tools.len(), 3, "search tool prepended");
+    assert_eq!(
+        tools[0]["type"].as_str(),
+        Some("tool_search_tool_bm25_20251119"),
+        "bm25 variant uses the documented type string"
+    );
+    assert_eq!(tools[0]["name"].as_str(), Some("tool_search_tool_bm25"));
+}
+
+#[test]
+fn apply_tool_search_native_injection_regex_variant() {
+    let mut tools: Option<Vec<serde_json::Value>> = Some(vec![json!({"name": "look"})]);
+    apply_tool_search_native_injection(&mut tools, "anthropic", "regex");
+    let tools = tools.unwrap();
+    assert_eq!(
+        tools[0]["type"].as_str(),
+        Some("tool_search_tool_regex_20251119")
+    );
+    assert_eq!(tools[0]["name"].as_str(), Some("tool_search_tool_regex"));
+}
+
+#[test]
+fn apply_tool_search_native_injection_emits_openai_shape_for_non_anthropic() {
+    let mut tools: Option<Vec<serde_json::Value>> = Some(vec![json!({"name": "look"})]);
+    apply_tool_search_native_injection(&mut tools, "openai", "bm25");
+    let tools = tools.unwrap();
+    assert_eq!(tools.len(), 2, "OpenAI meta-tool prepended");
+    assert_eq!(tools[0]["type"].as_str(), Some("tool_search"));
+    assert_eq!(tools[0]["mode"].as_str(), Some("hosted"));
+    assert!(
+        tools[0].get("name").is_none(),
+        "OpenAI meta-tool has no `name` field (that's an Anthropic detail)"
+    );
+    assert_eq!(tools[1]["name"].as_str(), Some("look"));
+}
+
+#[test]
+fn apply_tool_search_native_injection_openai_collects_namespaces() {
+    let mut tools: Option<Vec<serde_json::Value>> = Some(vec![
+        json!({
+            "type": "function",
+            "function": {"name": "deploy_api"},
+            "namespace": "ops",
+        }),
+        json!({
+            "type": "function",
+            "function": {"name": "deploy_web"},
+            "namespace": "ops",
+        }),
+        json!({
+            "type": "function",
+            "function": {"name": "lookup_account"},
+            "namespace": "crm",
+        }),
+    ]);
+    apply_tool_search_native_injection(&mut tools, "openai", "bm25");
+    let tools = tools.unwrap();
+    let namespaces = tools[0]["namespaces"]
+        .as_array()
+        .expect("namespaces present");
+    let names: Vec<&str> = namespaces.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(names, vec!["crm", "ops"], "sorted + deduped");
+}
+
+#[test]
+fn apply_tool_search_native_injection_creates_list_when_empty() {
+    let mut tools: Option<Vec<serde_json::Value>> = None;
+    apply_tool_search_native_injection(&mut tools, "anthropic", "bm25");
+    let tools = tools.expect("tools populated");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(
+        tools[0]["type"].as_str(),
+        Some("tool_search_tool_bm25_20251119")
+    );
+}


### PR DESCRIPTION
## Summary
- split `crates/harn-vm/src/llm/tools/tests.rs` into subject-focused test modules
- moved shared imports and reusable fixtures into `tests/mod.rs` and `tests/mock_fixtures.rs`
- kept the existing `#[cfg(test)] mod tests;` entry point and test behavior unchanged

## Why
- reduce the size of the monolithic `llm::tools` test file
- make parser, binding, execution, formatting, and registry coverage easier to navigate and extend

## Impact
- no runtime behavior changes
- `cargo test` discovery stays under `llm::tools::tests::*`, now grouped by subject

## Validation
- `env CARGO_TARGET_DIR=/tmp/harn-target-2116 cargo test -p harn-vm llm::tools::tests`
- pre-commit hook: format, clippy, markdown lint, portal lint
- pre-push hook: fast release-quality checks, markdown lint, portal lint
