### PR TITLE
[codex] Preserve worker request provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ granular archaeology.
   under `.harn/metadata/<namespace>/entries.json` while legacy
   root-metadata reads remain backward-compatible. `harn doctor`
   surfaces metadata cache state.
+- **Worker request/provenance retention for delegated/background agents
+  (#124).** Worker handles, waited results, snapshots, child-run records,
+  and `worker_result` artifacts now preserve immutable original `request`
+  metadata plus normalized `provenance` fields. `std/agents` adds
+  `worker_request`, `worker_result`, `worker_provenance`,
+  `worker_research_questions`, `worker_action_items`,
+  `worker_workflow_stages`, and `worker_verification_steps` helpers so
+  parent orchestration can recover structured child metadata without
+  index-based rebinding.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ enforcement.
 - Delegated worker lifecycle builtins via `spawn_agent(...)`, `send_input(...)`,
   `resume_agent(...)`, `wait_agent(...)`, `close_agent(...)`, and `list_agents()`,
   with child run lineage, persisted worker snapshots, and host-visible worker
-  lifecycle events.
+  lifecycle events. Worker handles now retain immutable original `request`
+  metadata plus normalized `provenance` so parent orchestration can recover
+  research questions, action items, workflow stages, and verification steps
+  without positional rebinding.
 - Per-worker execution scoping on `spawn_agent(...)`: delegated workers inherit
   the current execution ceiling by default and can narrow it further with a
   `policy` dict or `tools: ["name", ...]` shorthand, with permission denials

--- a/conformance/tests/agents/worker_request_provenance.expected
+++ b/conformance/tests/agents/worker_request_provenance.expected
@@ -1,5 +1,6 @@
-completed
-subagent
+true
+true
+true
 true
 true
 true

--- a/conformance/tests/agents/worker_request_provenance.harn
+++ b/conformance/tests/agents/worker_request_provenance.harn
@@ -1,0 +1,29 @@
+import "std/agents"
+
+pipeline main() {
+  llm_mock({text: "background summary"})
+  let handle = sub_agent_run(
+    "Investigate worker provenance",
+    {
+    provider: "mock",
+    background: true,
+    request: {topic: "provenance", owner: "parent"},
+    research_questions: ["Which fields survive wait?"],
+    action_items: [{id: "action_1", title: "Read agents_workers"}],
+    workflow_stages: ["research", "implement"],
+    verification_steps: ["cargo test -p harn-vm agents_workers"],
+  },
+  )
+  println(worker_request(handle)?.payload?.topic == "provenance")
+  println(len(worker_research_questions(handle)) == 1)
+  println(worker_action_items(handle)[0]?.id == "action_1")
+  println(worker_workflow_stages(handle)[1] == "implement")
+  println(worker_verification_steps(handle)[0] == "cargo test -p harn-vm agents_workers")
+  let done = wait_agent(handle)
+  println(worker_request(done)?.task == "Investigate worker provenance")
+  println(worker_provenance(done)?.worker_id == done?.id)
+  println(contains(worker_result(done)?.summary ?? "", "background summary"))
+  let continued = send_input(done, "Follow up with implementation details")
+  println(continued?.task == "Follow up with implementation details")
+  println(worker_request(continued)?.task == "Investigate worker provenance")
+}

--- a/conformance/tests/agents/workflow_subagent_runtime.harn
+++ b/conformance/tests/agents/workflow_subagent_runtime.harn
@@ -9,7 +9,7 @@ pipeline main() {
     mode: "llm",
     model_policy: {provider: "mock"},
     output_contract: {output_kinds: ["summary"]},
-    metadata: {worker_name: "delegate-1"},
+    metadata: {worker_name: "delegate-1", request: {source: "workflow"}, workflow_stages: ["delegate"]},
   },
   },
     edges: [],
@@ -19,7 +19,13 @@ pipeline main() {
   println(result?.status)
   println(result?.run?.stages[0]?.kind)
   println(result?.run?.stages[0]?.metadata?.worker?.name == "delegate-1")
+  println(result?.run?.stages[0]?.metadata?.worker?.request?.payload?.source == "workflow")
   println(result?.run?.stages[0]?.artifacts[0]?.metadata?.delegated)
   println(result?.run?.stages[0]?.artifacts[1]?.kind == "worker_result")
+  println(result?.run?.stages[0]?.artifacts[1]?.data?.request?.workflow_stages[0] == "delegate")
+  println(
+    result?.run?.stages[0]?.artifacts[1]?.data?.provenance?.worker_id \
+    == result?.run?.stages[0]?.metadata?.worker?.id,
+  )
   println(result?.run?.stages[0]?.metadata?.worker_id != nil)
 }

--- a/crates/harn-vm/src/orchestration/records.rs
+++ b/crates/harn-vm/src/orchestration/records.rs
@@ -271,6 +271,8 @@ pub struct RunChildRecord {
     pub mutation_scope: Option<String>,
     pub approval_policy: Option<super::ToolApprovalPolicy>,
     pub task: String,
+    pub request: Option<serde_json::Value>,
+    pub provenance: Option<serde_json::Value>,
     pub status: String,
     pub started_at: String,
     pub finished_at: Option<String>,

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -22,8 +22,8 @@ use std::sync::Arc;
 use self::agents_workers::{
     apply_worker_artifact_policy, emit_worker_event, load_worker_state_snapshot, next_worker_id,
     parse_worker_config, persist_worker_state_snapshot, spawn_worker_task, with_worker_state,
-    worker_id_from_value, worker_snapshot_path, worker_summary, WorkerConfig, WorkerState,
-    WORKER_REGISTRY,
+    worker_id_from_value, worker_request_for_config, worker_snapshot_path, worker_summary,
+    WorkerConfig, WorkerState, WORKER_REGISTRY,
 };
 use self::sub_agent::{execute_sub_agent, parse_sub_agent_request};
 use crate::orchestration::{
@@ -151,21 +151,29 @@ pub(crate) fn register_agent_builtins(vm: &mut Vm) {
         let created_at = uuid::Uuid::now_v7().to_string();
         let mut audit = agents_workers::inherited_worker_audit("sub_agent");
         audit.worker_id = Some(worker_id.clone());
+        let execution = request.execution;
+        let worker_policy = request.worker_policy;
+        let spec = request.spec;
+        let worker_name = spec.name.clone();
+        let worker_task = spec.task.clone();
+        let config = WorkerConfig::SubAgent {
+            spec: Box::new(spec),
+        };
+        let original_request = worker_request_for_config(&worker_task, &config);
         let state = Rc::new(RefCell::new(WorkerState {
             id: worker_id.clone(),
-            name: request.spec.name.clone(),
-            task: request.spec.task.clone(),
+            name: worker_name,
+            task: worker_task.clone(),
             status: "running".to_string(),
             created_at: created_at.clone(),
             started_at: created_at,
             finished_at: None,
             mode: "sub_agent".to_string(),
-            history: vec![request.spec.task.clone()],
-            config: WorkerConfig::SubAgent {
-                spec: Box::new(request.spec),
-            },
+            history: vec![worker_task],
+            config,
             handle: None,
             cancel_token: Arc::new(AtomicBool::new(false)),
+            request: original_request,
             latest_payload: None,
             latest_error: None,
             transcript: None,
@@ -179,9 +187,9 @@ pub(crate) fn register_agent_builtins(vm: &mut Vm) {
                 context_policy: ContextPolicy::default(),
                 resume_workflow: false,
                 persist_state: true,
-                policy: request.worker_policy,
+                policy: worker_policy,
             },
-            execution: request.execution,
+            execution,
             snapshot_path: worker_snapshot_path(&worker_id),
             audit,
         }));
@@ -217,6 +225,7 @@ pub(crate) fn register_agent_builtins(vm: &mut Vm) {
         let mut audit = init.audit.clone().normalize();
         audit.worker_id = Some(worker_id.clone());
         audit.execution_kind = Some(mode.clone());
+        let original_request = worker_request_for_config(&init.task, &init.config);
         let state = Rc::new(RefCell::new(WorkerState {
             id: worker_id.clone(),
             name: init.name,
@@ -230,6 +239,7 @@ pub(crate) fn register_agent_builtins(vm: &mut Vm) {
             config: init.config,
             handle: None,
             cancel_token: Arc::new(AtomicBool::new(false)),
+            request: original_request,
             latest_payload: None,
             latest_error: None,
             transcript: None,

--- a/crates/harn-vm/src/stdlib/agents_workers/bridge.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/bridge.rs
@@ -1,11 +1,13 @@
 use std::path::PathBuf;
 
-use super::WorkerState;
+use super::{worker_provenance, WorkerState};
 
 fn worker_bridge_metadata(state: &WorkerState) -> serde_json::Value {
     serde_json::json!({
         "task": state.task,
         "mode": state.mode,
+        "request": state.request,
+        "provenance": worker_provenance(state),
         "created_at": state.created_at,
         "started_at": state.started_at,
         "finished_at": state.finished_at,

--- a/crates/harn-vm/src/stdlib/agents_workers/config.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/config.rs
@@ -10,7 +10,10 @@ use super::policy::{
     parse_worker_carry_policy, parse_worker_policy_value, resolve_worker_policy,
     worker_policy_value,
 };
-use super::{WorkerCarryPolicy, WorkerConfig, WorkerExecutionProfile, WorkerInit, WorkerState};
+use super::{
+    WorkerCarryPolicy, WorkerConfig, WorkerExecutionProfile, WorkerInit, WorkerRequestRecord,
+    WorkerState,
+};
 use crate::orchestration::{ArtifactRecord, MutationSessionRecord, WorkflowGraph};
 use crate::value::{VmError, VmValue};
 
@@ -185,6 +188,7 @@ pub(in super::super) fn persist_worker_state_snapshot(state: &WorkerState) -> Re
         "mode": state.mode,
         "history": state.history,
         "config": worker_config_to_json(&state.config),
+        "request": state.request,
         "latest_payload": state.latest_payload,
         "latest_error": state.latest_error,
         "transcript": state.transcript.as_ref().map(crate::llm::vm_value_to_json),
@@ -254,6 +258,9 @@ pub(in super::super) fn load_worker_state_snapshot(target: &str) -> Result<Worke
     let execution: WorkerExecutionProfile =
         serde_json::from_value(payload.get("execution").cloned().unwrap_or_default())
             .map_err(|e| VmError::Runtime(format!("worker snapshot execution parse error: {e}")))?;
+    let request: WorkerRequestRecord =
+        serde_json::from_value(payload.get("request").cloned().unwrap_or_default())
+            .unwrap_or_else(|_| WorkerRequestRecord::default());
     let status = payload
         .get("status")
         .and_then(|value| value.as_str())
@@ -312,6 +319,7 @@ pub(in super::super) fn load_worker_state_snapshot(target: &str) -> Result<Worke
         config,
         handle: None,
         cancel_token: Arc::new(AtomicBool::new(false)),
+        request,
         latest_payload: payload.get("latest_payload").cloned(),
         latest_error: payload
             .get("latest_error")

--- a/crates/harn-vm/src/stdlib/agents_workers/execution.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/execution.rs
@@ -10,8 +10,9 @@ use super::worktree::{
     cleanup_worker_execution, ensure_worker_worktree, WorkerMutationSessionResetGuard,
 };
 use super::{
-    clone_worker_state, next_worker_id, WorkerCarryPolicy, WorkerConfig, WorkerExecutionProfile,
-    WorkerExecutionResult, WorkerState, WORKER_REGISTRY,
+    clone_worker_state, next_worker_id, worker_provenance, worker_request_for_config,
+    WorkerCarryPolicy, WorkerConfig, WorkerExecutionProfile, WorkerExecutionResult, WorkerState,
+    WORKER_REGISTRY,
 };
 use crate::orchestration::{
     current_approval_policy, current_execution_policy, pop_execution_policy, push_execution_policy,
@@ -267,6 +268,8 @@ fn worker_result_artifact(
         data: Some(serde_json::json!({
             "worker_id": state.id,
             "worker_name": state.name,
+            "request": state.request,
+            "provenance": worker_provenance(state),
             "execution": state.execution,
             "payload": payload,
             "produced_artifact_ids": produced.iter().map(|artifact| artifact.id.clone()).collect::<Vec<_>>(),
@@ -305,6 +308,12 @@ pub(in super::super) async fn execute_delegated_stage(
     let mut stage_node = node.clone();
     stage_node.kind = "stage".to_string();
     let execution = parse_execution_profile_json(node.metadata.get("execution"))?;
+    let config = WorkerConfig::Stage {
+        node: Box::new(stage_node),
+        artifacts: artifacts.to_vec(),
+        transcript,
+    };
+    let original_request = worker_request_for_config(task, &config);
     let state = Rc::new(RefCell::new(WorkerState {
         id: worker_id.clone(),
         name: worker_name.clone(),
@@ -315,13 +324,10 @@ pub(in super::super) async fn execute_delegated_stage(
         finished_at: None,
         mode: "delegated_stage".to_string(),
         history: vec![task.to_string()],
-        config: WorkerConfig::Stage {
-            node: Box::new(stage_node),
-            artifacts: artifacts.to_vec(),
-            transcript,
-        },
+        config,
         handle: None,
         cancel_token: Arc::new(AtomicBool::new(false)),
+        request: original_request,
         latest_payload: None,
         latest_error: None,
         transcript: None,

--- a/crates/harn-vm/src/stdlib/agents_workers/mod.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/mod.rs
@@ -75,6 +75,33 @@ pub(super) struct WorkerExecutionProfile {
     pub(super) worktree: Option<WorkerWorktreeSpec>,
 }
 
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub(super) struct WorkerRequestRecord {
+    pub(super) task: String,
+    pub(super) system: Option<String>,
+    pub(super) payload: Option<serde_json::Value>,
+    pub(super) research_questions: Vec<serde_json::Value>,
+    pub(super) action_items: Vec<serde_json::Value>,
+    pub(super) workflow_stages: Vec<serde_json::Value>,
+    pub(super) verification_steps: Vec<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub(super) struct WorkerProvenanceRecord {
+    pub(super) worker_id: String,
+    pub(super) worker_name: String,
+    pub(super) mode: String,
+    pub(super) parent_worker_id: Option<String>,
+    pub(super) parent_stage_id: Option<String>,
+    pub(super) session_id: Option<String>,
+    pub(super) parent_session_id: Option<String>,
+    pub(super) snapshot_path: String,
+    pub(super) run_id: Option<String>,
+    pub(super) run_path: Option<String>,
+}
+
 pub(super) struct WorkerInit {
     pub(super) name: String,
     pub(super) task: String,
@@ -98,6 +125,7 @@ pub(super) struct WorkerState {
     pub(super) config: WorkerConfig,
     pub(super) handle: Option<tokio::task::JoinHandle<Result<WorkerExecutionResult, VmError>>>,
     pub(super) cancel_token: Arc<AtomicBool>,
+    pub(super) request: WorkerRequestRecord,
     pub(super) latest_payload: Option<serde_json::Value>,
     pub(super) latest_error: Option<String>,
     pub(super) transcript: Option<VmValue>,
@@ -142,6 +170,183 @@ pub(super) fn worker_id_from_value(value: &VmValue) -> Result<String, VmError> {
     }
 }
 
+fn request_items_from_json(value: Option<&serde_json::Value>) -> Vec<serde_json::Value> {
+    match value {
+        Some(serde_json::Value::Array(items)) => items.clone(),
+        Some(serde_json::Value::Null) | None => Vec::new(),
+        Some(value) => vec![value.clone()],
+    }
+}
+
+fn request_items_from_vm_value(value: Option<&VmValue>) -> Vec<serde_json::Value> {
+    value
+        .map(crate::llm::vm_value_to_json)
+        .map(|json| request_items_from_json(Some(&json)))
+        .unwrap_or_default()
+}
+
+fn request_items_from_vm_dict(
+    dict: &BTreeMap<String, VmValue>,
+    keys: &[&str],
+) -> Vec<serde_json::Value> {
+    keys.iter()
+        .find_map(|key| {
+            let items = request_items_from_vm_value(dict.get(*key));
+            (!items.is_empty()).then_some(items)
+        })
+        .unwrap_or_default()
+}
+
+fn request_items_from_json_dict(
+    dict: &BTreeMap<String, serde_json::Value>,
+    keys: &[&str],
+) -> Vec<serde_json::Value> {
+    keys.iter()
+        .find_map(|key| {
+            let items = request_items_from_json(dict.get(*key));
+            (!items.is_empty()).then_some(items)
+        })
+        .unwrap_or_default()
+}
+
+fn canonical_request_payload(
+    research_questions: &[serde_json::Value],
+    action_items: &[serde_json::Value],
+    workflow_stages: &[serde_json::Value],
+    verification_steps: &[serde_json::Value],
+) -> Option<serde_json::Value> {
+    let mut payload = serde_json::Map::new();
+    if !research_questions.is_empty() {
+        payload.insert(
+            "research_questions".to_string(),
+            serde_json::Value::Array(research_questions.to_vec()),
+        );
+    }
+    if !action_items.is_empty() {
+        payload.insert(
+            "action_items".to_string(),
+            serde_json::Value::Array(action_items.to_vec()),
+        );
+    }
+    if !workflow_stages.is_empty() {
+        payload.insert(
+            "workflow_stages".to_string(),
+            serde_json::Value::Array(workflow_stages.to_vec()),
+        );
+    }
+    if !verification_steps.is_empty() {
+        payload.insert(
+            "verification_steps".to_string(),
+            serde_json::Value::Array(verification_steps.to_vec()),
+        );
+    }
+    (!payload.is_empty()).then_some(serde_json::Value::Object(payload))
+}
+
+fn worker_request_from_vm_dict(
+    task: &str,
+    system: Option<String>,
+    dict: &BTreeMap<String, VmValue>,
+) -> WorkerRequestRecord {
+    let research_questions = request_items_from_vm_dict(dict, &["research_questions", "questions"]);
+    let action_items = request_items_from_vm_dict(dict, &["action_items", "actions"]);
+    let workflow_stages = request_items_from_vm_dict(dict, &["workflow_stages", "stages"]);
+    let verification_steps =
+        request_items_from_vm_dict(dict, &["verification_steps", "verification"]);
+    let payload = dict
+        .get("request")
+        .map(crate::llm::vm_value_to_json)
+        .or_else(|| {
+            canonical_request_payload(
+                &research_questions,
+                &action_items,
+                &workflow_stages,
+                &verification_steps,
+            )
+        });
+    WorkerRequestRecord {
+        task: task.to_string(),
+        system,
+        payload,
+        research_questions,
+        action_items,
+        workflow_stages,
+        verification_steps,
+    }
+}
+
+fn worker_request_from_json_dict(
+    task: &str,
+    system: Option<String>,
+    dict: &BTreeMap<String, serde_json::Value>,
+) -> WorkerRequestRecord {
+    let research_questions =
+        request_items_from_json_dict(dict, &["research_questions", "questions"]);
+    let action_items = request_items_from_json_dict(dict, &["action_items", "actions"]);
+    let workflow_stages = request_items_from_json_dict(dict, &["workflow_stages", "stages"]);
+    let verification_steps =
+        request_items_from_json_dict(dict, &["verification_steps", "verification"]);
+    let payload = dict.get("request").cloned().or_else(|| {
+        canonical_request_payload(
+            &research_questions,
+            &action_items,
+            &workflow_stages,
+            &verification_steps,
+        )
+    });
+    WorkerRequestRecord {
+        task: task.to_string(),
+        system,
+        payload,
+        research_questions,
+        action_items,
+        workflow_stages,
+        verification_steps,
+    }
+}
+
+pub(super) fn worker_request_for_config(task: &str, config: &WorkerConfig) -> WorkerRequestRecord {
+    match config {
+        WorkerConfig::Workflow { graph, options, .. } => {
+            let options_request = worker_request_from_vm_dict(task, None, options);
+            if options_request.payload.is_some()
+                || !options_request.research_questions.is_empty()
+                || !options_request.action_items.is_empty()
+                || !options_request.workflow_stages.is_empty()
+                || !options_request.verification_steps.is_empty()
+            {
+                return options_request;
+            }
+            worker_request_from_json_dict(task, None, &graph.metadata)
+        }
+        WorkerConfig::Stage { node, .. } => {
+            worker_request_from_json_dict(task, node.system.clone(), &node.metadata)
+        }
+        WorkerConfig::SubAgent { spec } => {
+            worker_request_from_vm_dict(task, spec.system.clone(), &spec.options)
+        }
+    }
+}
+
+pub(super) fn worker_provenance(state: &WorkerState) -> WorkerProvenanceRecord {
+    WorkerProvenanceRecord {
+        worker_id: state.id.clone(),
+        worker_name: state.name.clone(),
+        mode: state.mode.clone(),
+        parent_worker_id: state.parent_worker_id.clone(),
+        parent_stage_id: state.parent_stage_id.clone(),
+        session_id: if state.audit.session_id.is_empty() {
+            None
+        } else {
+            Some(state.audit.session_id.clone())
+        },
+        parent_session_id: state.audit.parent_session_id.clone(),
+        snapshot_path: state.snapshot_path.clone(),
+        run_id: state.child_run_id.clone(),
+        run_path: state.child_run_path.clone(),
+    }
+}
+
 pub(super) fn clone_worker_state(state: &WorkerState) -> serde_json::Value {
     serde_json::json!({
         "_type": "agent_handle",
@@ -154,6 +359,8 @@ pub(super) fn clone_worker_state(state: &WorkerState) -> serde_json::Value {
         "started_at": state.started_at,
         "finished_at": state.finished_at,
         "history": state.history,
+        "request": state.request,
+        "provenance": worker_provenance(state),
         "result": state.latest_payload,
         "error": state.latest_error,
         "artifact_count": state.artifacts.len(),

--- a/crates/harn-vm/src/stdlib/agents_workers/tests.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/tests.rs
@@ -35,6 +35,23 @@ fn worker_snapshot_round_trip_preserves_resume_fields() {
         },
         handle: None,
         cancel_token: Arc::new(AtomicBool::new(false)),
+        request: WorkerRequestRecord {
+            task: "task".to_string(),
+            system: Some("system".to_string()),
+            payload: Some(serde_json::json!({
+                "research_questions": ["question one"],
+                "action_items": [{"id": "action_1", "title": "do the thing"}],
+                "workflow_stages": ["research", "implement"],
+                "verification_steps": ["cargo test -p harn-vm"],
+            })),
+            research_questions: vec![serde_json::json!("question one")],
+            action_items: vec![serde_json::json!({"id": "action_1", "title": "do the thing"})],
+            workflow_stages: vec![
+                serde_json::json!("research"),
+                serde_json::json!("implement"),
+            ],
+            verification_steps: vec![serde_json::json!("cargo test -p harn-vm")],
+        },
         latest_payload: Some(serde_json::json!({"status": "completed"})),
         latest_error: None,
         transcript: Some(VmValue::Dict(Rc::new(BTreeMap::from([(
@@ -98,6 +115,19 @@ fn worker_snapshot_round_trip_preserves_resume_fields() {
     assert_eq!(loaded.carry_policy.artifact_mode, "none");
     assert!(!loaded.carry_policy.resume_workflow);
     assert_eq!(
+        loaded.request.payload,
+        Some(serde_json::json!({
+            "research_questions": ["question one"],
+            "action_items": [{"id": "action_1", "title": "do the thing"}],
+            "workflow_stages": ["research", "implement"],
+            "verification_steps": ["cargo test -p harn-vm"],
+        }))
+    );
+    assert_eq!(
+        loaded.request.action_items,
+        vec![serde_json::json!({"id": "action_1", "title": "do the thing"})]
+    );
+    assert_eq!(
         loaded.carry_policy.policy,
         Some(CapabilityPolicy {
             tools: vec!["read".to_string()],
@@ -110,6 +140,81 @@ fn worker_snapshot_round_trip_preserves_resume_fields() {
 
     let _ = std::fs::remove_dir_all(&dir);
     unsafe { std::env::remove_var("HARN_WORKER_STATE_DIR") };
+}
+
+#[test]
+fn worker_summary_exposes_request_and_provenance() {
+    let state = WorkerState {
+        id: "worker_123".to_string(),
+        name: "worker".to_string(),
+        task: "latest task".to_string(),
+        status: "completed".to_string(),
+        created_at: "created".to_string(),
+        started_at: "started".to_string(),
+        finished_at: Some("finished".to_string()),
+        mode: "sub_agent".to_string(),
+        history: vec!["original task".to_string(), "latest task".to_string()],
+        config: WorkerConfig::SubAgent {
+            spec: Box::new(SubAgentRunSpec {
+                name: "worker".to_string(),
+                task: "latest task".to_string(),
+                system: Some("system".to_string()),
+                options: BTreeMap::new(),
+                returns_schema: None,
+                session_id: "session_worker".to_string(),
+                parent_session_id: Some("session_parent".to_string()),
+            }),
+        },
+        handle: None,
+        cancel_token: Arc::new(AtomicBool::new(false)),
+        request: WorkerRequestRecord {
+            task: "original task".to_string(),
+            system: Some("system".to_string()),
+            payload: Some(serde_json::json!({
+                "research_questions": ["What changed?"],
+            })),
+            research_questions: vec![serde_json::json!("What changed?")],
+            action_items: Vec::new(),
+            workflow_stages: Vec::new(),
+            verification_steps: Vec::new(),
+        },
+        latest_payload: Some(serde_json::json!({"ok": true})),
+        latest_error: None,
+        transcript: None,
+        artifacts: Vec::new(),
+        parent_worker_id: Some("parent_worker".to_string()),
+        parent_stage_id: Some("stage_1".to_string()),
+        child_run_id: Some("run_123".to_string()),
+        child_run_path: Some(".harn-runs/run_123.json".to_string()),
+        carry_policy: WorkerCarryPolicy::default(),
+        execution: WorkerExecutionProfile::default(),
+        snapshot_path: ".harn/workers/worker_123.json".to_string(),
+        audit: MutationSessionRecord {
+            session_id: "session_worker".to_string(),
+            parent_session_id: Some("session_parent".to_string()),
+            ..Default::default()
+        }
+        .normalize(),
+    };
+
+    let summary = clone_worker_state(&state);
+    assert_eq!(
+        summary["request"]["task"],
+        serde_json::json!("original task")
+    );
+    assert_eq!(
+        summary["request"]["research_questions"][0],
+        serde_json::json!("What changed?")
+    );
+    assert_eq!(
+        summary["provenance"]["worker_id"],
+        serde_json::json!("worker_123")
+    );
+    assert_eq!(
+        summary["provenance"]["parent_session_id"],
+        serde_json::json!("session_parent")
+    );
+    assert_eq!(summary["task"], serde_json::json!("latest task"));
 }
 
 #[test]

--- a/crates/harn-vm/src/stdlib/workflow/artifact.rs
+++ b/crates/harn-vm/src/stdlib/workflow/artifact.rs
@@ -175,6 +175,8 @@ pub(super) fn append_child_run_record(
             .and_then(|value| value.as_str())
             .unwrap_or_default()
             .to_string(),
+        request: worker.get("request").cloned(),
+        provenance: worker.get("provenance").cloned(),
         status: worker
             .get("status")
             .and_then(|value| value.as_str())

--- a/crates/harn-vm/src/stdlib_agents.harn
+++ b/crates/harn-vm/src/stdlib_agents.harn
@@ -496,3 +496,38 @@ pub fn workflow_session_persist(prev, path) {
     },
   )
 }
+
+/** worker_request. */
+pub fn worker_request(worker) {
+  return worker?.request ?? worker?.worker?.request ?? worker?.data?.request
+}
+
+/** worker_result. */
+pub fn worker_result(worker) {
+  return worker?.result ?? worker?.data?.payload ?? worker?.worker?.result
+}
+
+/** worker_provenance. */
+pub fn worker_provenance(worker) {
+  return worker?.provenance ?? worker?.worker?.provenance ?? worker?.data?.provenance
+}
+
+/** worker_research_questions. */
+pub fn worker_research_questions(worker) {
+  return worker_request(worker)?.research_questions ?? []
+}
+
+/** worker_action_items. */
+pub fn worker_action_items(worker) {
+  return worker_request(worker)?.action_items ?? []
+}
+
+/** worker_workflow_stages. */
+pub fn worker_workflow_stages(worker) {
+  return worker_request(worker)?.workflow_stages ?? []
+}
+
+/** worker_verification_steps. */
+pub fn worker_verification_steps(worker) {
+  return worker_request(worker)?.verification_steps ?? []
+}

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1356,7 +1356,11 @@ the call if you want a fresh run with the same id.
 
 Workers return handle dicts with an `id`, lifecycle timestamps, `status`,
 `mode`, result/error fields, transcript presence, produced artifact count,
-snapshot/child-run paths, and `audit` mutation-session metadata when available.
+snapshot/child-run paths, immutable original `request` metadata, normalized
+`provenance`, and `audit` mutation-session metadata when available.
+The `request` object preserves canonical `research_questions`,
+`action_items`, `workflow_stages`, and `verification_steps` arrays when the
+caller supplied them.
 When a worker-scoped policy denies a tool call, the agent receives a structured
 tool result payload: `{error: "permission_denied", tool: "...", reason: "..."}`.
 

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -838,6 +838,9 @@ lineage metadata.
 Set `background: true` to get a normal worker handle back instead of waiting
 inline. The resulting worker uses `mode: "sub_agent"` and can be resumed with
 `wait_agent(...)`, `send_input(...)`, and `close_agent(...)`.
+Background handles retain the original structured `request` plus a normalized
+`provenance` object, so parent pipelines can recover child questions, actions,
+workflow stages, and verification steps directly from the handle/result.
 
 Workers can persist state and child run paths between sessions. Use `carry`
 inside `spawn_agent(...)` when you want continuation to reset transcript state,
@@ -916,6 +919,11 @@ println(session?.usage?.output_tokens)
 println(session?.usage?.total_duration_ms)
 println(session?.usage?.call_count)
 ```
+
+`std/agents` also exposes worker helpers for delegated/background orchestration:
+`worker_request(worker)`, `worker_result(worker)`, `worker_provenance(worker)`,
+`worker_research_questions(worker)`, `worker_action_items(worker)`,
+`worker_workflow_stages(worker)`, and `worker_verification_steps(worker)`.
 
 This is the intended host integration boundary:
 

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -328,6 +328,13 @@ Workflow helpers built on transcripts and `agent_loop`:
 | `workflow_continue(prev, task, flow, overrides?)` | Continue from an existing transcript |
 | `workflow_compact(prev, options?)` | Summarize and compact a transcript |
 | `workflow_reset(prev, carry_summary)` | Reset or summarize-then-reset a workflow transcript |
+| `worker_request(worker)` | Return a worker handle's immutable original request payload |
+| `worker_result(worker)` | Return a worker handle/result payload or worker-result artifact payload |
+| `worker_provenance(worker)` | Return normalized worker provenance fields |
+| `worker_research_questions(worker)` | Return the worker's canonical `research_questions` list |
+| `worker_action_items(worker)` | Return the worker's canonical `action_items` list |
+| `worker_workflow_stages(worker)` | Return the worker's canonical `workflow_stages` list |
+| `worker_verification_steps(worker)` | Return the worker's canonical `verification_steps` list |
 
 `workflow_session(...)` returns a normalized session dict that includes the
 current transcript, message count, summary, persisted run metadata, and a
@@ -336,7 +343,8 @@ current transcript, message count, summary, persisted run metadata, and a
 
 For background or delegated execution, use the worker lifecycle builtins
 (`spawn_agent`, `send_input`, `resume_agent`, `wait_agent`, `close_agent`, `list_agents`)
-directly from the runtime.
+directly from the runtime, or the `worker_*` helpers above when you need the
+normalized request/provenance views.
 
 ### std/worktree
 


### PR DESCRIPTION
## Summary
- preserve immutable original worker `request` metadata plus normalized `provenance` on worker handles, waited results, snapshots, child-run records, bridge events, and `worker_result` artifacts
- add `std/agents` worker helper APIs for extracting request/result/provenance plus canonical research/action/stage/verification lists
- add Rust + conformance coverage and update docs/changelog for the new delegated-worker provenance contract

## Root cause
Worker state only surfaced a narrow lifecycle summary. The original structured child request lived transiently inside mutable config/options, so parent orchestration had to rebind worker outputs externally to recover questions, action items, and verification context.

## Validation
- `cargo test -p harn-vm agents_workers`
- `cargo run --quiet --bin harn -- test conformance --filter worker_request_provenance`
- `cargo run --quiet --bin harn -- test conformance --filter workflow_subagent_runtime`
- `cargo run --quiet --bin harn -- test conformance --filter agent_workers`
- `cargo run --quiet --bin harn -- test conformance --filter sub_agent_run_budget_and_background`
- repo pre-commit + pre-push hooks

Closes #124.
