### PR TITLE
[codex] Make verifier contracts first-class workflow inputs

### DIFF
--- a/crates/harn-vm/src/orchestration/artifacts.rs
+++ b/crates/harn-vm/src/orchestration/artifacts.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-use super::{microcompact_tool_output, new_id, now_rfc3339, ContextPolicy};
+use super::{microcompact_tool_output, new_id, now_rfc3339, ContextPolicy, VerificationContract};
 
 /// Snip an artifact's text to fit within a token budget.
 pub fn microcompact_artifact(artifact: &mut ArtifactRecord, max_tokens: usize) {
@@ -303,6 +303,7 @@ pub fn render_artifacts_context(artifacts: &[ArtifactRecord], policy: &ContextPo
 pub fn render_workflow_prompt(
     task: &str,
     task_label: Option<&str>,
+    rendered_verification: &str,
     rendered_context: &str,
 ) -> String {
     let label = task_label
@@ -314,6 +315,12 @@ pub fn render_workflow_prompt(
         escape_prompt_text(label),
         task.trim(),
     );
+    let verification = rendered_verification.trim();
+    if !verification.is_empty() {
+        prompt.push_str("\n\n<workflow_verification>\n");
+        prompt.push_str(verification);
+        prompt.push_str("\n</workflow_verification>");
+    }
     let context = rendered_context.trim();
     if !context.is_empty() {
         prompt.push_str("\n\n<workflow_context>\n");
@@ -327,6 +334,105 @@ Keep commentary minimal and use the active tool-calling contract for concrete pr
 </workflow_response_contract>",
     );
     prompt
+}
+
+pub fn render_verification_context(contracts: &[VerificationContract]) -> String {
+    if contracts.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::from(
+        "Treat this verifier contract as the source of truth for exact identifiers, file paths, and required wiring. Prefer the exact strings below over guessed synonyms.\n",
+    );
+
+    for contract in contracts {
+        out.push_str("\n<contract>\n");
+        if let Some(source_node) = contract.source_node.as_deref() {
+            out.push_str("<source_node>");
+            out.push_str(&escape_prompt_text(source_node));
+            out.push_str("</source_node>\n");
+        }
+        if let Some(summary) = contract.summary.as_deref() {
+            out.push_str("<summary>");
+            out.push_str(&escape_prompt_text(summary));
+            out.push_str("</summary>\n");
+        }
+        if let Some(command) = contract.command.as_deref() {
+            out.push_str("<command>");
+            out.push_str(&escape_prompt_text(command));
+            out.push_str("</command>\n");
+        }
+        if let Some(expect_status) = contract.expect_status {
+            out.push_str("<expect_status>");
+            out.push_str(&expect_status.to_string());
+            out.push_str("</expect_status>\n");
+        }
+        if let Some(assert_text) = contract.assert_text.as_deref() {
+            out.push_str("<assert_text>");
+            out.push_str(&escape_prompt_text(assert_text));
+            out.push_str("</assert_text>\n");
+        }
+        if let Some(expect_text) = contract.expect_text.as_deref() {
+            out.push_str("<expect_text>");
+            out.push_str(&escape_prompt_text(expect_text));
+            out.push_str("</expect_text>\n");
+        }
+        if !contract.required_identifiers.is_empty() {
+            out.push_str("<required_identifiers>\n");
+            for value in &contract.required_identifiers {
+                out.push_str("- ");
+                out.push_str(&escape_prompt_text(value));
+                out.push('\n');
+            }
+            out.push_str("</required_identifiers>\n");
+        }
+        if !contract.required_paths.is_empty() {
+            out.push_str("<required_paths>\n");
+            for value in &contract.required_paths {
+                out.push_str("- ");
+                out.push_str(&escape_prompt_text(value));
+                out.push('\n');
+            }
+            out.push_str("</required_paths>\n");
+        }
+        if !contract.required_text.is_empty() {
+            out.push_str("<required_text>\n");
+            for value in &contract.required_text {
+                out.push_str("- ");
+                out.push_str(&escape_prompt_text(value));
+                out.push('\n');
+            }
+            out.push_str("</required_text>\n");
+        }
+        if !contract.checks.is_empty() {
+            out.push_str("<checks>\n");
+            for check in &contract.checks {
+                out.push_str("- ");
+                out.push_str(&escape_prompt_text(&check.kind));
+                out.push_str(": ");
+                out.push_str(&escape_prompt_text(&check.value));
+                if let Some(note) = check.note.as_deref() {
+                    out.push_str(" (");
+                    out.push_str(&escape_prompt_text(note));
+                    out.push(')');
+                }
+                out.push('\n');
+            }
+            out.push_str("</checks>\n");
+        }
+        if !contract.notes.is_empty() {
+            out.push_str("<notes>\n");
+            for note in &contract.notes {
+                out.push_str("- ");
+                out.push_str(&escape_prompt_text(note));
+                out.push('\n');
+            }
+            out.push_str("</notes>\n");
+        }
+        out.push_str("</contract>");
+    }
+
+    out
 }
 
 fn escape_prompt_text(text: &str) -> String {

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -14,6 +14,8 @@ use crate::llm::{extract_llm_options, vm_call_llm_full, vm_value_to_json};
 use crate::tool_annotations::{SideEffectLevel, ToolAnnotations, ToolArgSchema, ToolKind};
 use crate::value::{VmError, VmValue};
 
+pub const WORKFLOW_VERIFICATION_CONTRACTS_METADATA_KEY: &str = "workflow_verification_contracts";
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct WorkflowNode {
@@ -73,6 +75,367 @@ impl PartialEq for WorkflowNode {
     fn eq(&self, other: &Self) -> bool {
         serde_json::to_value(self).ok() == serde_json::to_value(other).ok()
     }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct VerificationRequirement {
+    pub kind: String,
+    pub value: String,
+    pub note: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct VerificationContract {
+    pub source_node: Option<String>,
+    pub summary: Option<String>,
+    pub command: Option<String>,
+    pub expect_status: Option<i64>,
+    pub assert_text: Option<String>,
+    pub expect_text: Option<String>,
+    pub required_identifiers: Vec<String>,
+    pub required_paths: Vec<String>,
+    pub required_text: Vec<String>,
+    pub notes: Vec<String>,
+    pub checks: Vec<VerificationRequirement>,
+}
+
+impl VerificationContract {
+    fn is_empty(&self) -> bool {
+        self.summary.is_none()
+            && self.command.is_none()
+            && self.expect_status.is_none()
+            && self.assert_text.is_none()
+            && self.expect_text.is_none()
+            && self.required_identifiers.is_empty()
+            && self.required_paths.is_empty()
+            && self.required_text.is_empty()
+            && self.notes.is_empty()
+            && self.checks.is_empty()
+    }
+}
+
+fn push_unique_string(values: &mut Vec<String>, value: &str) {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    if !values.iter().any(|existing| existing == trimmed) {
+        values.push(trimmed.to_string());
+    }
+}
+
+fn push_unique_requirement(
+    values: &mut Vec<VerificationRequirement>,
+    kind: &str,
+    value: &str,
+    note: Option<&str>,
+) {
+    let trimmed_kind = kind.trim();
+    let trimmed_value = value.trim();
+    let trimmed_note = note
+        .map(str::trim)
+        .filter(|candidate| !candidate.is_empty())
+        .map(|candidate| candidate.to_string());
+    if trimmed_kind.is_empty() || trimmed_value.is_empty() {
+        return;
+    }
+    let candidate = VerificationRequirement {
+        kind: trimmed_kind.to_string(),
+        value: trimmed_value.to_string(),
+        note: trimmed_note,
+    };
+    if !values.iter().any(|existing| existing == &candidate) {
+        values.push(candidate);
+    }
+}
+
+fn json_string_list(value: Option<&serde_json::Value>) -> Vec<String> {
+    match value {
+        Some(serde_json::Value::String(text)) => {
+            let mut values = Vec::new();
+            push_unique_string(&mut values, text);
+            values
+        }
+        Some(serde_json::Value::Array(items)) => {
+            let mut values = Vec::new();
+            for item in items {
+                if let Some(text) = item.as_str() {
+                    push_unique_string(&mut values, text);
+                }
+            }
+            values
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn merge_verification_requirement_list(
+    target: &mut Vec<VerificationRequirement>,
+    value: Option<&serde_json::Value>,
+) {
+    let Some(items) = value.and_then(|raw| raw.as_array()) else {
+        return;
+    };
+    for item in items {
+        let Some(object) = item.as_object() else {
+            continue;
+        };
+        let kind = object
+            .get("kind")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default();
+        let value = object
+            .get("value")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default();
+        let note = object
+            .get("note")
+            .or_else(|| object.get("description"))
+            .or_else(|| object.get("reason"))
+            .and_then(|value| value.as_str());
+        push_unique_requirement(target, kind, value, note);
+    }
+}
+
+fn merge_verification_contract_fields(
+    target: &mut VerificationContract,
+    object: &serde_json::Map<String, serde_json::Value>,
+) {
+    if target.summary.is_none() {
+        target.summary = object
+            .get("summary")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_string());
+    }
+    if target.command.is_none() {
+        target.command = object
+            .get("command")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_string());
+    }
+    if target.expect_status.is_none() {
+        target.expect_status = object.get("expect_status").and_then(|value| value.as_i64());
+    }
+    if target.assert_text.is_none() {
+        target.assert_text = object
+            .get("assert_text")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_string());
+    }
+    if target.expect_text.is_none() {
+        target.expect_text = object
+            .get("expect_text")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_string());
+    }
+
+    for value in json_string_list(
+        object
+            .get("required_identifiers")
+            .or_else(|| object.get("identifiers")),
+    ) {
+        push_unique_string(&mut target.required_identifiers, &value);
+    }
+    for value in json_string_list(object.get("required_paths").or_else(|| object.get("paths"))) {
+        push_unique_string(&mut target.required_paths, &value);
+    }
+    for value in json_string_list(
+        object
+            .get("required_text")
+            .or_else(|| object.get("exact_text"))
+            .or_else(|| object.get("required_strings")),
+    ) {
+        push_unique_string(&mut target.required_text, &value);
+    }
+    for value in json_string_list(object.get("notes")) {
+        push_unique_string(&mut target.notes, &value);
+    }
+    merge_verification_requirement_list(&mut target.checks, object.get("checks"));
+}
+
+fn load_verification_contract_file(path: &str) -> Result<serde_json::Value, VmError> {
+    let resolved = crate::stdlib::process::resolve_source_asset_path(path);
+    let contents = std::fs::read_to_string(&resolved).map_err(|error| {
+        VmError::Runtime(format!(
+            "workflow verification contract read failed for {}: {error}",
+            resolved.display()
+        ))
+    })?;
+    serde_json::from_str(&contents).map_err(|error| {
+        VmError::Runtime(format!(
+            "workflow verification contract parse failed for {}: {error}",
+            resolved.display()
+        ))
+    })
+}
+
+fn resolve_verification_contract_path(
+    verify: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Option<serde_json::Value>, VmError> {
+    let Some(path) = verify
+        .get("contract_path")
+        .or_else(|| verify.get("verification_contract_path"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+    Ok(Some(load_verification_contract_file(path)?))
+}
+
+pub fn verification_contract_from_verify(
+    node_id: &str,
+    verify: Option<&serde_json::Value>,
+) -> Result<Option<VerificationContract>, VmError> {
+    let Some(verify_object) = verify.and_then(|value| value.as_object()) else {
+        return Ok(None);
+    };
+
+    let mut contract = VerificationContract {
+        source_node: Some(node_id.to_string()),
+        ..Default::default()
+    };
+
+    if let Some(file_contract) = resolve_verification_contract_path(verify_object)? {
+        let Some(object) = file_contract.as_object() else {
+            return Err(VmError::Runtime(
+                "workflow verification contract file must parse to a JSON object".to_string(),
+            ));
+        };
+        merge_verification_contract_fields(&mut contract, object);
+    }
+
+    if let Some(inline_contract) = verify_object.get("contract") {
+        let Some(object) = inline_contract.as_object() else {
+            return Err(VmError::Runtime(
+                "workflow verify.contract must be an object".to_string(),
+            ));
+        };
+        merge_verification_contract_fields(&mut contract, object);
+    }
+
+    merge_verification_contract_fields(&mut contract, verify_object);
+
+    if let Some(assert_text) = contract.assert_text.clone() {
+        push_unique_requirement(
+            &mut contract.checks,
+            "visible_text_contains",
+            &assert_text,
+            Some("verify stage requires visible output to contain this text"),
+        );
+    }
+    if let Some(expect_text) = contract.expect_text.clone() {
+        push_unique_requirement(
+            &mut contract.checks,
+            "combined_output_contains",
+            &expect_text,
+            Some("verify command requires combined stdout/stderr to contain this text"),
+        );
+    }
+    if let Some(expect_status) = contract.expect_status {
+        push_unique_requirement(
+            &mut contract.checks,
+            "expect_status",
+            &expect_status.to_string(),
+            Some("verify command exit status must match exactly"),
+        );
+    }
+    for identifier in contract.required_identifiers.clone() {
+        push_unique_requirement(
+            &mut contract.checks,
+            "identifier",
+            &identifier,
+            Some("use this exact identifier spelling"),
+        );
+    }
+    for path in contract.required_paths.clone() {
+        push_unique_requirement(
+            &mut contract.checks,
+            "path",
+            &path,
+            Some("preserve this exact path"),
+        );
+    }
+    for text in contract.required_text.clone() {
+        push_unique_requirement(
+            &mut contract.checks,
+            "text",
+            &text,
+            Some("required exact text or wiring snippet"),
+        );
+    }
+
+    if contract.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(contract))
+}
+
+fn push_unique_contract(values: &mut Vec<VerificationContract>, candidate: VerificationContract) {
+    if !values.iter().any(|existing| existing == &candidate) {
+        values.push(candidate);
+    }
+}
+
+pub fn workflow_verification_contracts(
+    graph: &WorkflowGraph,
+) -> Result<Vec<VerificationContract>, VmError> {
+    let mut contracts = Vec::new();
+    for (node_id, node) in &graph.nodes {
+        if let Some(contract) = verification_contract_from_verify(node_id, node.verify.as_ref())? {
+            push_unique_contract(&mut contracts, contract);
+        }
+    }
+    Ok(contracts)
+}
+
+pub fn inject_workflow_verification_contracts(
+    node: &mut WorkflowNode,
+    contracts: &[VerificationContract],
+) {
+    if contracts.is_empty() {
+        return;
+    }
+    node.metadata.insert(
+        WORKFLOW_VERIFICATION_CONTRACTS_METADATA_KEY.to_string(),
+        serde_json::to_value(contracts).unwrap_or_default(),
+    );
+}
+
+pub fn stage_verification_contracts(
+    node_id: &str,
+    node: &WorkflowNode,
+) -> Result<Vec<VerificationContract>, VmError> {
+    let mut contracts = node
+        .metadata
+        .get(WORKFLOW_VERIFICATION_CONTRACTS_METADATA_KEY)
+        .cloned()
+        .map(|value| {
+            serde_json::from_value::<Vec<VerificationContract>>(value).map_err(|error| {
+                VmError::Runtime(format!(
+                    "workflow stage {node_id} verification contract metadata parse failed: {error}"
+                ))
+            })
+        })
+        .transpose()?
+        .unwrap_or_default();
+
+    if let Some(local_contract) = verification_contract_from_verify(node_id, node.verify.as_ref())?
+    {
+        push_unique_contract(&mut contracts, local_contract);
+    }
+    Ok(contracts)
 }
 
 pub fn workflow_tool_names(value: &serde_json::Value) -> Vec<String> {
@@ -746,6 +1109,8 @@ pub async fn execute_stage_node(
     }
     let selected = super::select_artifacts_adaptive(artifacts.to_vec(), &selection_policy);
     let rendered_context = super::render_artifacts_context(&selected, &node.context_policy);
+    let verification_contracts = super::stage_verification_contracts(node_id, node)?;
+    let rendered_verification = super::render_verification_context(&verification_contracts);
     let stage_session_id = resolve_node_session_id(node);
     if node.input_contract.require_transcript && !crate::agent_sessions::exists(&stage_session_id) {
         return Err(VmError::Runtime(format!(
@@ -768,7 +1133,12 @@ pub async fn execute_stage_node(
             )));
         }
     }
-    let prompt = super::render_workflow_prompt(task, node.task_label.as_deref(), &rendered_context);
+    let prompt = super::render_workflow_prompt(
+        task,
+        node.task_label.as_deref(),
+        &rendered_verification,
+        &rendered_context,
+    );
 
     // Precedence for the tool-calling contract format:
     //   1. explicit `model_policy.tool_format` on the node
@@ -1041,6 +1411,16 @@ pub async fn execute_stage_node(
             "rendered_context".to_string(),
             serde_json::json!(rendered_context),
         );
+        if !verification_contracts.is_empty() {
+            payload.insert(
+                "verification_contracts".to_string(),
+                serde_json::to_value(&verification_contracts).unwrap_or_default(),
+            );
+            payload.insert(
+                "rendered_verification_context".to_string(),
+                serde_json::json!(rendered_verification),
+            );
+        }
         payload.insert(
             "selected_artifact_ids".to_string(),
             serde_json::json!(selected

--- a/crates/harn-vm/src/stdlib/workflow/register.rs
+++ b/crates/harn-vm/src/stdlib/workflow/register.rs
@@ -7,8 +7,9 @@ use crate::orchestration::{
     append_audit_entry, builtin_ceiling, install_current_mutation_session,
     install_workflow_skill_context, load_run_record, next_nodes_for, normalize_run_record,
     normalize_workflow_value, pop_execution_policy, push_execution_policy, validate_workflow,
-    ArtifactRecord, MutationSessionRecord, RunRecord, RunStageRecord, RunTransitionRecord,
-    WorkflowEdge, WorkflowGraph, WorkflowSkillContext, WorkflowSkillContextGuard,
+    workflow_verification_contracts, ArtifactRecord, MutationSessionRecord, RunRecord,
+    RunStageRecord, RunTransitionRecord, WorkflowEdge, WorkflowGraph, WorkflowSkillContext,
+    WorkflowSkillContextGuard,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
@@ -80,6 +81,7 @@ pub(in crate::stdlib) async fn execute_workflow(
             report.errors.join("; ")
         )));
     }
+    let workflow_verification_contracts = workflow_verification_contracts(&graph)?;
 
     let resumed_run = match optional_string_option(&options, "resume_path") {
         Some(path) if !path.is_empty() => Some(load_run_record(std::path::Path::new(&path))?),
@@ -365,7 +367,11 @@ pub(in crate::stdlib) async fn execute_workflow(
                 continue;
             }
         }
-        let node = apply_runtime_node_overrides(node, &options);
+        let mut node = apply_runtime_node_overrides(node, &options);
+        crate::orchestration::inject_workflow_verification_contracts(
+            &mut node,
+            &workflow_verification_contracts,
+        );
         let stage_policy = effective_node_policy(&graph, &node)?;
         let stage_approval = effective_node_approval_policy(&graph, &node);
 
@@ -449,6 +455,20 @@ pub(in crate::stdlib) async fn execute_workflow(
         }
         if let Some(rendered_context) = executed.result.get("rendered_context") {
             stage_metadata.insert("rendered_context".to_string(), rendered_context.clone());
+        }
+        if let Some(verification_contracts) = executed.result.get("verification_contracts") {
+            stage_metadata.insert(
+                "verification_contracts".to_string(),
+                verification_contracts.clone(),
+            );
+        }
+        if let Some(rendered_verification_context) =
+            executed.result.get("rendered_verification_context")
+        {
+            stage_metadata.insert(
+                "rendered_verification_context".to_string(),
+                rendered_verification_context.clone(),
+            );
         }
         if let Some(selected_artifact_ids) = executed.result.get("selected_artifact_ids") {
             stage_metadata.insert(

--- a/crates/harn-vm/src/stdlib/workflow/tests.rs
+++ b/crates/harn-vm/src/stdlib/workflow/tests.rs
@@ -1,10 +1,16 @@
 use super::artifact::{load_run_tree, snapshot_trace_spans};
 use super::map::{execute_join_policy, LocalTask};
+use super::register::execute_workflow;
 use super::stage::{classify_stage_outcome, execute_stage_attempts};
-use crate::orchestration::{render_artifacts_context, render_workflow_prompt};
-use crate::orchestration::{save_run_record, RunChildRecord, RunRecord};
+use crate::orchestration::{
+    inject_workflow_verification_contracts, render_artifacts_context, render_workflow_prompt,
+    save_run_record, workflow_verification_contracts, RunChildRecord, RunExecutionRecord,
+    RunRecord, VerificationContract, VerificationRequirement, WorkflowEdge, WorkflowGraph,
+    WorkflowNode,
+};
 use crate::tracing::{set_tracing_enabled, span_end, span_start, SpanKind};
 use std::cell::Cell;
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 #[test]
@@ -101,6 +107,7 @@ fn render_workflow_prompt_puts_task_before_context() {
     let prompt = render_workflow_prompt(
         "Create the missing test file with one edit call.",
         Some("Create Required Outputs"),
+        "",
         "<artifact>\n<title>tests/unit/test_example.py</title>\n<body>\npass\n</body>\n</artifact>",
     );
     let task_index = prompt
@@ -120,6 +127,28 @@ fn render_workflow_prompt_puts_task_before_context() {
         prompt.trim_end().ends_with("</workflow_response_contract>"),
         "prompt should end on the response contract instead of artifact text"
     );
+}
+
+#[test]
+fn render_workflow_prompt_places_verification_before_context() {
+    let prompt = render_workflow_prompt(
+        "Implement the verifier-exact wiring.",
+        Some("Implement"),
+        "<contract>\n<required_identifiers>\n- rateLimit\n</required_identifiers>\n</contract>",
+        "<artifact>\n<title>src/server.ts</title>\n<body>\nexisting code\n</body>\n</artifact>",
+    );
+
+    let verification_index = prompt
+        .find("<workflow_verification>")
+        .expect("verification block should exist");
+    let context_index = prompt
+        .find("<workflow_context>")
+        .expect("context block should exist");
+    assert!(
+        verification_index < context_index,
+        "verification block should precede artifact context"
+    );
+    assert!(prompt.contains("rateLimit"));
 }
 
 #[test]
@@ -383,4 +412,234 @@ async fn stage_task_reaches_execution_verbatim() {
             .expect("stage executes");
 
     assert_eq!(executed.attempts.len(), 1);
+}
+
+#[test]
+fn workflow_verification_contracts_collect_exact_requirements() {
+    let graph = WorkflowGraph {
+        entry: "act".to_string(),
+        nodes: BTreeMap::from([(
+            "verify".to_string(),
+            WorkflowNode {
+                id: Some("verify".to_string()),
+                kind: "verify".to_string(),
+                verify: Some(serde_json::json!({
+                    "command": "python verify.py",
+                    "expect_status": 0,
+                    "required_identifiers": ["rateLimit"],
+                    "required_paths": ["src/middleware/rateLimit.ts"],
+                    "required_text": ["app.use(rateLimit)"],
+                    "notes": ["Do not rename the middleware export."],
+                })),
+                ..Default::default()
+            },
+        )]),
+        ..Default::default()
+    };
+
+    let contracts = workflow_verification_contracts(&graph).expect("verification contracts");
+    assert_eq!(contracts.len(), 1);
+    assert_eq!(
+        contracts[0].required_identifiers,
+        vec!["rateLimit".to_string()]
+    );
+    assert_eq!(
+        contracts[0].required_paths,
+        vec!["src/middleware/rateLimit.ts".to_string()]
+    );
+    assert_eq!(
+        contracts[0].required_text,
+        vec!["app.use(rateLimit)".to_string()]
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workflow_execute_injects_verify_contract_into_act_prompt() {
+    crate::reset_thread_local_state();
+    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
+        text: "done".to_string(),
+        tool_calls: Vec::new(),
+        match_pattern: None,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: None,
+        stop_reason: None,
+        model: "mock-model".to_string(),
+        provider: Some("mock".to_string()),
+        blocks: None,
+        error: None,
+    });
+
+    let temp_dir = std::env::temp_dir().join(format!("harn-issue-126-{}", uuid::Uuid::now_v7()));
+    std::fs::create_dir_all(&temp_dir).expect("temp dir");
+    let persist_path = temp_dir.join("run.json");
+
+    let graph = WorkflowGraph {
+        type_name: "workflow_graph".to_string(),
+        id: "wf".to_string(),
+        entry: "act".to_string(),
+        nodes: BTreeMap::from([
+            (
+                "act".to_string(),
+                WorkflowNode {
+                    id: Some("act".to_string()),
+                    kind: "stage".to_string(),
+                    mode: Some("llm".to_string()),
+                    model_policy: crate::orchestration::ModelPolicy {
+                        provider: Some("mock".to_string()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            ),
+            (
+                "verify".to_string(),
+                WorkflowNode {
+                    id: Some("verify".to_string()),
+                    kind: "verify".to_string(),
+                    verify: Some(serde_json::json!({
+                        "command": "echo ok",
+                        "expect_status": 0,
+                        "required_identifiers": ["rateLimit"],
+                        "required_text": ["app.use(rateLimit)"],
+                    })),
+                    output_contract: crate::orchestration::StageContract {
+                        output_kinds: vec!["verification_result".to_string()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            ),
+        ]),
+        edges: vec![WorkflowEdge {
+            from: "act".to_string(),
+            to: "verify".to_string(),
+            branch: None,
+            label: None,
+        }],
+        ..Default::default()
+    };
+
+    let result = execute_workflow(
+        "Implement the verifier-exact middleware.".to_string(),
+        graph,
+        Vec::new(),
+        BTreeMap::from([
+            (
+                "persist_path".to_string(),
+                crate::value::VmValue::String(Rc::from(
+                    persist_path.to_string_lossy().into_owned(),
+                )),
+            ),
+            ("max_steps".to_string(), crate::value::VmValue::Int(2)),
+        ]),
+    )
+    .await
+    .expect("workflow executes");
+
+    let run_value = result
+        .as_dict()
+        .and_then(|value| value.get("run"))
+        .cloned()
+        .expect("workflow envelope run");
+    let run = crate::orchestration::normalize_run_record(&run_value).expect("run record");
+    let act_stage = run
+        .stages
+        .iter()
+        .find(|stage| stage.node_id == "act")
+        .expect("act stage");
+    let prompt = act_stage
+        .metadata
+        .get("prompt")
+        .and_then(|value| value.as_str())
+        .expect("prompt metadata");
+    assert!(prompt.contains("<workflow_verification>"));
+    assert!(prompt.contains("rateLimit"));
+    assert!(prompt.contains("app.use(rateLimit)"));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn stage_prompt_loads_contract_file_relative_to_execution_context() {
+    crate::reset_thread_local_state();
+    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
+        text: "done".to_string(),
+        tool_calls: Vec::new(),
+        match_pattern: None,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: None,
+        stop_reason: None,
+        model: "mock-model".to_string(),
+        provider: Some("mock".to_string()),
+        blocks: None,
+        error: None,
+    });
+
+    let temp_dir =
+        std::env::temp_dir().join(format!("harn-issue-126-file-{}", uuid::Uuid::now_v7()));
+    std::fs::create_dir_all(&temp_dir).expect("temp dir");
+    let contract_path = temp_dir.join("verify.contract.json");
+    std::fs::write(
+        &contract_path,
+        serde_json::json!({
+            "summary": "Verifier expects the exact middleware symbol.",
+            "required_identifiers": ["rateLimit"],
+            "required_paths": ["src/middleware/rateLimit.ts"],
+            "required_text": ["app.use(rateLimit)"],
+        })
+        .to_string(),
+    )
+    .expect("contract file");
+
+    crate::stdlib::process::set_thread_execution_context(Some(RunExecutionRecord {
+        cwd: Some(temp_dir.to_string_lossy().into_owned()),
+        ..Default::default()
+    }));
+
+    let mut node = WorkflowNode {
+        id: Some("act".to_string()),
+        kind: "stage".to_string(),
+        mode: Some("llm".to_string()),
+        model_policy: crate::orchestration::ModelPolicy {
+            provider: Some("mock".to_string()),
+            ..Default::default()
+        },
+        verify: Some(serde_json::json!({
+            "contract_path": "verify.contract.json",
+        })),
+        ..Default::default()
+    };
+    inject_workflow_verification_contracts(
+        &mut node,
+        &[VerificationContract {
+            source_node: Some("verify".to_string()),
+            checks: vec![VerificationRequirement {
+                kind: "identifier".to_string(),
+                value: "rateLimit".to_string(),
+                note: Some("Use the exact exported name.".to_string()),
+            }],
+            ..Default::default()
+        }],
+    );
+
+    let executed = execute_stage_attempts("Implement the middleware.", "act", &node, &[], None)
+        .await
+        .expect("stage executes");
+    let prompt = executed
+        .result
+        .get("prompt")
+        .and_then(|value| value.as_str())
+        .expect("prompt");
+    assert!(prompt.contains("rateLimit"));
+    assert!(prompt.contains("src/middleware/rateLimit.ts"));
+    assert!(prompt.contains("app.use(rateLimit)"));
+
+    crate::reset_thread_local_state();
+    let _ = std::fs::remove_dir_all(&temp_dir);
 }

--- a/docs/src/workflow-runtime.md
+++ b/docs/src/workflow-runtime.md
@@ -174,6 +174,39 @@ Command-based verification records `stdout`, `stderr`, `exit_status`, and a
 derived success flag on the stage result while still flowing through the same
 workflow branch/outcome machinery as LLM-backed verification.
 
+Verifier requirements can also be published as structured contract inputs for
+earlier planning and execution stages. Harn injects these contracts into the
+stage prompt automatically so the model sees exact verifier-owned identifiers,
+paths, and wiring text before it starts editing:
+
+```harn,ignore
+verify: {
+  kind: "verify",
+  verify: {
+    command: "python scripts/verify_rate_limit.py",
+    expect_status: 0,
+    required_identifiers: ["rateLimit"],
+    required_paths: ["src/middleware/rateLimit.ts"],
+    required_text: ["app.use(rateLimit)"],
+    notes: ["Use the verifier-exact symbol names. Do not rename them."]
+  }
+}
+```
+
+When the verifier contract lives outside the workflow file, point `contract_path`
+at a JSON file relative to the workflow execution context:
+
+```harn,ignore
+verify: {
+  kind: "verify",
+  verify: {
+    command: "python scripts/verify_rate_limit.py",
+    contract_path: "scripts/verify_rate_limit.contract.json",
+    expect_status: 0
+  }
+}
+```
+
 Options currently include:
 
 - `max_steps`


### PR DESCRIPTION
## Summary
- normalize workflow verifier metadata into structured verification contracts that can carry exact identifiers, paths, required text, and optional sidecar JSON contract files
- inject those contracts into stage prompts and run metadata automatically so planning/execution stages see verifier-exact requirements before editing
- cover the new behavior with workflow/orchestration tests and document the contract fields in the workflow runtime docs

## Why
Issue #126 called out Burin Mini failures where the planner/executor had to rediscover verifier-owned naming and wiring details from scratch, leading to drift like `rateLimiter` instead of `rateLimit`. This change makes verifier constraints first-class workflow inputs instead of leaving them implicit in ad hoc prompts.

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-target-9030 cargo test -p harn-vm workflow::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-9030 cargo test -p harn-vm orchestration::tests -- --nocapture`
- repo pre-commit hook during `git commit`
- repo pre-push hook during `git push -u origin ksinder/issue-126-verification-contracts`

Closes #126.
