### PR TITLE
[codex] Add manifest-backed runtime extension ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ granular archaeology.
 
 ### Added
 
+- **Manifest-backed runtime extension ABI (#128).** `harn.toml` now
+  supports `[exports]` for stable package module entry points and
+  `[llm]` for packaged provider definitions, aliases, inference rules,
+  and model defaults. Runtime imports and the static module graph both
+  resolve package exports and search the nearest ancestor
+  `.harn/packages/` root, so packages can ship capability modules and
+  provider adapters without Rust-side registration edits.
 - **`project_enrich` L2 enrichment primitive (#110, closes #102).** New
   native-backed stdlib fn that layers a caller-owned LLM enrichment
   pass on top of deterministic `project_scan` evidence. Caller supplies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,9 @@ version = "0.7.20"
 dependencies = [
  "harn-lexer",
  "harn-parser",
+ "serde",
  "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ enforcement.
   `schema_parse(...)`, `schema_is(...)`, JSON Schema/OpenAPI conversion, and
   schema composition helpers, plus a lazy `std/schema` builder module for
   ergonomic schema authoring when imported.
+- Manifest-backed extension ABI: packages can publish stable module entry
+  points via `[exports]` and ship provider/alias adapters declaratively via
+  `[llm]` in `harn.toml`, without editing core runtime registration code.
 - Design-by-contract and project/runtime helpers: `require ...`,
   metadata/scanner runtime builtins, `import "std/project"` for
   freshness-aware metadata and scan state, and `import "std/runtime"` for

--- a/crates/harn-cli/src/acp/execute.rs
+++ b/crates/harn-cli/src/acp/execute.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 use std::time::Instant;
 
 use super::{builtins, AcpBridge};
+use crate::package;
 
 /// Execute a compiled chunk with ACP bridge builtins.
 pub(super) async fn execute_chunk(
@@ -47,6 +48,11 @@ pub(super) async fn execute_chunk(
         }
     } else {
         vm.set_source_dir(cwd);
+    }
+
+    if let Some(path) = source_path {
+        let extensions = package::load_runtime_extensions(path);
+        package::install_runtime_extensions(&extensions);
     }
 
     vm.set_global("prompt", harn_vm::VmValue::String(Rc::from(prompt_text)));

--- a/crates/harn-cli/src/commands/bench.rs
+++ b/crates/harn-cli/src/commands/bench.rs
@@ -89,10 +89,8 @@ pub(crate) async fn run_bench(path: &str, iterations: usize) {
         .file_stem()
         .and_then(|segment| segment.to_str())
         .unwrap_or("default");
-    let manifest = package::try_read_manifest_for(Path::new(path));
-    if let Some(m) = manifest.as_ref() {
-        package::install_capability_overrides(m);
-    }
+    let extensions = package::load_runtime_extensions(Path::new(path));
+    package::install_runtime_extensions(&extensions);
 
     let mut runs = Vec::with_capacity(iterations);
     for iteration in 0..iterations {
@@ -112,7 +110,7 @@ pub(crate) async fn run_bench(path: &str, iterations: usize) {
             vm.set_source_dir(source_parent);
         }
 
-        if let Some(manifest) = manifest.as_ref() {
+        if let Some(manifest) = extensions.root_manifest.as_ref() {
             if !manifest.mcp.is_empty() {
                 connect_mcp_servers(&manifest.mcp, &mut vm).await;
             }

--- a/crates/harn-cli/src/commands/doctor.rs
+++ b/crates/harn-cli/src/commands/doctor.rs
@@ -371,7 +371,7 @@ async fn check_provider_health(network: bool) -> Vec<DoctorCheck> {
             continue;
         };
 
-        checks.push(run_healthcheck(&client, &provider_name, def, &auth, healthcheck).await);
+        checks.push(run_healthcheck(&client, &provider_name, &def, &auth, healthcheck).await);
     }
     checks
 }

--- a/crates/harn-cli/src/commands/playground.rs
+++ b/crates/harn-cli/src/commands/playground.rs
@@ -248,8 +248,9 @@ async fn configured_vm(
     emit_loader_warnings(&loaded.loader_warnings);
     install_skills_global(&mut vm, &loaded);
 
-    if let Some(manifest) = package::try_read_manifest_for(path) {
-        package::install_capability_overrides(&manifest);
+    let extensions = package::load_runtime_extensions(path);
+    package::install_runtime_extensions(&extensions);
+    if let Some(manifest) = extensions.root_manifest.as_ref() {
         if !manifest.mcp.is_empty() {
             connect_mcp_servers(&manifest.mcp, &mut vm).await;
         }

--- a/crates/harn-cli/src/commands/portal/llm.rs
+++ b/crates/harn-cli/src/commands/portal/llm.rs
@@ -28,7 +28,7 @@ pub(super) async fn build_llm_options() -> PortalLlmOptions {
         let Some(def) = llm_config::provider_config(&name) else {
             continue;
         };
-        let base_url = llm_config::resolve_base_url(def);
+        let base_url = llm_config::resolve_base_url(&def);
         let auth_envs = auth_env_names(&def.auth_env);
         let auth_configured = auth_envs.iter().any(|env_name| {
             std::env::var(env_name)
@@ -44,7 +44,7 @@ pub(super) async fn build_llm_options() -> PortalLlmOptions {
             .map(|(alias_name, _)| alias_name.clone())
             .collect::<Vec<_>>();
         let mut models = if local {
-            discover_provider_models(&name, &base_url, def)
+            discover_provider_models(&name, &base_url, &def)
                 .await
                 .unwrap_or_default()
         } else {

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -539,8 +539,9 @@ pub(crate) async fn run_file_with_skill_dirs(
         harn_vm::VmValue::List(std::rc::Rc::new(argv_values)),
     );
 
-    if let Some(manifest) = package::try_read_manifest_for(Path::new(path)) {
-        package::install_capability_overrides(&manifest);
+    let extensions = package::load_runtime_extensions(Path::new(path));
+    package::install_runtime_extensions(&extensions);
+    if let Some(manifest) = extensions.root_manifest.as_ref() {
         if !manifest.mcp.is_empty() {
             connect_mcp_servers(&manifest.mcp, &mut vm).await;
         }
@@ -799,8 +800,9 @@ pub(crate) async fn run_file_mcp_serve(path: &str, card_source: Option<&str>) {
     emit_loader_warnings(&loaded.loader_warnings);
     install_skills_global(&mut vm, &loaded);
 
-    if let Some(manifest) = package::try_read_manifest_for(Path::new(path)) {
-        package::install_capability_overrides(&manifest);
+    let extensions = package::load_runtime_extensions(Path::new(path));
+    package::install_runtime_extensions(&extensions);
+    if let Some(manifest) = extensions.root_manifest.as_ref() {
         if !manifest.mcp.is_empty() {
             connect_mcp_servers(&manifest.mcp, &mut vm).await;
         }

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -8,7 +8,7 @@ const PKG_DIR: &str = ".harn/packages";
 const MANIFEST: &str = "harn.toml";
 const LOCK_FILE: &str = "harn.lock";
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Manifest {
     #[allow(dead_code)]
     pub package: Option<PackageInfo>,
@@ -37,6 +37,18 @@ pub struct Manifest {
     /// `harn_vm::llm::capabilities` for the rule schema.
     #[serde(default)]
     pub capabilities: Option<harn_vm::llm::capabilities::CapabilitiesFile>,
+    /// Stable exported package modules. Keys are the logical import
+    /// suffixes (e.g. `providers/openai`) and values are package-root-
+    /// relative file paths. Consumers import them via `<package>/<key>`.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub exports: HashMap<String, String>,
+    /// `[llm]` section — packaged provider definitions, aliases,
+    /// inference rules, tier rules, and model defaults. Uses the same
+    /// schema as `providers.toml`, but merges into the current run
+    /// instead of replacing the global config file.
+    #[serde(default)]
+    pub llm: harn_vm::llm_config::ProvidersConfig,
 }
 
 /// `[skills]` table body.
@@ -205,7 +217,7 @@ pub struct McpServerConfig {
     pub keep_alive_ms: Option<u64>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[allow(dead_code)]
 pub struct PackageInfo {
     pub name: Option<String>,
@@ -247,6 +259,13 @@ impl Dependency {
             Dependency::Path(p) => Some(p.as_str()),
         }
     }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RuntimeExtensions {
+    pub root_manifest: Option<Manifest>,
+    pub llm: Option<harn_vm::llm_config::ProvidersConfig>,
+    pub capabilities: Option<harn_vm::llm::capabilities::CapabilitiesFile>,
 }
 
 #[derive(Debug, Default)]
@@ -357,30 +376,89 @@ pub fn read_manifest() -> Manifest {
     }
 }
 
-/// Try to read `harn.toml` from the directory containing the given file.
-/// Returns `None` if the file doesn't exist. Prints a warning and returns
-/// `None` on parse errors.
-pub fn try_read_manifest_for(harn_file: &std::path::Path) -> Option<Manifest> {
-    let dir = harn_file.parent().unwrap_or(std::path::Path::new("."));
-    let manifest_path = dir.join(MANIFEST);
-    let content = fs::read_to_string(&manifest_path).ok()?;
-    match toml::from_str::<Manifest>(&content) {
-        Ok(m) => Some(m),
-        Err(e) => {
-            eprintln!("warning: failed to parse {}: {e}", manifest_path.display());
-            None
+fn merge_capability_overrides(
+    target: &mut harn_vm::llm::capabilities::CapabilitiesFile,
+    source: &harn_vm::llm::capabilities::CapabilitiesFile,
+) {
+    for (provider, rules) in &source.provider {
+        target
+            .provider
+            .entry(provider.clone())
+            .or_default()
+            .extend(rules.clone());
+    }
+    target
+        .provider_family
+        .extend(source.provider_family.clone());
+}
+
+fn collect_package_manifests(packages_dir: &Path) -> Vec<Manifest> {
+    let mut manifests = Vec::new();
+    let Ok(entries) = fs::read_dir(packages_dir) else {
+        return manifests;
+    };
+    let mut dirs: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.is_dir())
+        .collect();
+    dirs.sort();
+    for dir in dirs {
+        let manifest_path = dir.join(MANIFEST);
+        let Ok(content) = fs::read_to_string(&manifest_path) else {
+            continue;
+        };
+        match toml::from_str::<Manifest>(&content) {
+            Ok(manifest) => manifests.push(manifest),
+            Err(e) => eprintln!("warning: failed to parse {}: {e}", manifest_path.display()),
         }
+    }
+    manifests
+}
+
+fn manifest_capabilities(
+    manifest: &Manifest,
+) -> Option<&harn_vm::llm::capabilities::CapabilitiesFile> {
+    manifest.capabilities.as_ref()
+}
+
+fn is_empty_capabilities(file: &harn_vm::llm::capabilities::CapabilitiesFile) -> bool {
+    file.provider.is_empty() && file.provider_family.is_empty()
+}
+
+/// Load the nearest project manifest plus any installed package manifests and
+/// merge their runtime extensions. Installed packages load first; the root
+/// project manifest wins on conflicts.
+pub fn load_runtime_extensions(anchor: &Path) -> RuntimeExtensions {
+    let Some((root_manifest, manifest_dir)) = find_nearest_manifest(anchor) else {
+        return RuntimeExtensions::default();
+    };
+
+    let mut llm = harn_vm::llm_config::ProvidersConfig::default();
+    let mut capabilities = harn_vm::llm::capabilities::CapabilitiesFile::default();
+
+    for manifest in collect_package_manifests(&manifest_dir.join(PKG_DIR)) {
+        llm.merge_from(&manifest.llm);
+        if let Some(file) = manifest_capabilities(&manifest) {
+            merge_capability_overrides(&mut capabilities, file);
+        }
+    }
+
+    llm.merge_from(&root_manifest.llm);
+    if let Some(file) = manifest_capabilities(&root_manifest) {
+        merge_capability_overrides(&mut capabilities, file);
+    }
+
+    RuntimeExtensions {
+        root_manifest: Some(root_manifest),
+        llm: (!llm.is_empty()).then_some(llm),
+        capabilities: (!is_empty_capabilities(&capabilities)).then_some(capabilities),
     }
 }
 
-/// Install this manifest's `[[capabilities.provider.<name>]]` overrides
-/// on the current thread so the VM's `capabilities::lookup` picks them
-/// up for the duration of the run. Called by each CLI entry point that
-/// constructs a VM after reading harn.toml. Safe to call with a
-/// manifest that omits the section — clears any prior override so the
-/// built-in rules apply cleanly.
-pub fn install_capability_overrides(manifest: &Manifest) {
-    harn_vm::llm::capabilities::set_user_overrides(manifest.capabilities.clone());
+/// Install merged runtime extensions on the current thread.
+pub fn install_runtime_extensions(extensions: &RuntimeExtensions) {
+    harn_vm::llm_config::set_user_overrides(extensions.llm.clone());
+    harn_vm::llm::capabilities::set_user_overrides(extensions.capabilities.clone());
 }
 
 fn absolutize_check_config_paths(mut config: CheckConfig, manifest_dir: &Path) -> CheckConfig {
@@ -1044,5 +1122,46 @@ name = "acme/ops"
             cfg.preflight_severity.is_none(),
             "must not inherit harn.toml from outside the .git boundary"
         );
+    }
+
+    #[test]
+    fn load_runtime_extensions_merges_package_and_root_llm_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::create_dir_all(root.join(".harn/packages/acme")).unwrap();
+        fs::write(
+            root.join(MANIFEST),
+            r#"
+[llm.aliases]
+project-fast = { id = "project/model", provider = "project" }
+
+[llm.providers.project]
+base_url = "https://project.test/v1"
+chat_endpoint = "/chat/completions"
+"#,
+        )
+        .unwrap();
+        fs::write(
+            root.join(".harn/packages/acme/harn.toml"),
+            r#"
+[llm.aliases]
+acme-fast = { id = "acme/model", provider = "acme" }
+
+[llm.providers.acme]
+base_url = "https://acme.test/v1"
+chat_endpoint = "/chat/completions"
+"#,
+        )
+        .unwrap();
+        let harn_file = root.join("main.harn");
+        fs::write(&harn_file, "pipeline main() {}\n").unwrap();
+
+        let extensions = load_runtime_extensions(&harn_file);
+        let llm = extensions.llm.expect("merged llm config");
+        assert!(llm.providers.contains_key("acme"));
+        assert!(llm.providers.contains_key("project"));
+        assert!(llm.aliases.contains_key("acme-fast"));
+        assert!(llm.aliases.contains_key("project-fast"));
     }
 }

--- a/crates/harn-modules/Cargo.toml
+++ b/crates/harn-modules/Cargo.toml
@@ -9,6 +9,8 @@ description = "Cross-file module graph and import resolution utilities for Harn"
 [dependencies]
 harn-lexer = { path = "../harn-lexer", version = "0.7" }
 harn-parser = { path = "../harn-parser", version = "0.7" }
+serde = { version = "1", features = ["derive"] }
+toml = "1.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/harn-modules/src/lib.rs
+++ b/crates/harn-modules/src/lib.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use harn_lexer::Span;
 use harn_parser::{BindingPattern, Node, Parser, SNode};
+use serde::Deserialize;
 
 mod stdlib;
 
@@ -74,6 +75,12 @@ struct ModuleInfo {
 struct ImportRef {
     path: Option<PathBuf>,
     selective_names: Option<HashSet<String>>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PackageManifest {
+    #[serde(default)]
+    exports: HashMap<String, String>,
 }
 
 /// Build a module graph from a set of files.
@@ -154,23 +161,68 @@ pub fn resolve_import_path(current_file: &Path, import_path: &str) -> Option<Pat
         return Some(file_path);
     }
 
-    let pkg_path = base.join(".harn/packages").join(import_path);
-    if pkg_path.exists() {
-        if pkg_path.is_dir() {
-            let lib = pkg_path.join("lib.harn");
-            if lib.exists() {
-                return Some(lib);
+    if let Some(path) = resolve_package_import(base, import_path) {
+        return Some(path);
+    }
+
+    None
+}
+
+fn resolve_package_import(base: &Path, import_path: &str) -> Option<PathBuf> {
+    for anchor in base.ancestors() {
+        let packages_root = anchor.join(".harn/packages");
+        if !packages_root.is_dir() {
+            if anchor.join(".git").exists() {
+                break;
             }
+            continue;
         }
-        return Some(pkg_path);
+        if let Some(path) = resolve_from_packages_root(&packages_root, import_path) {
+            return Some(path);
+        }
+        if anchor.join(".git").exists() {
+            break;
+        }
+    }
+    None
+}
+
+fn resolve_from_packages_root(packages_root: &Path, import_path: &str) -> Option<PathBuf> {
+    let pkg_path = packages_root.join(import_path);
+    if let Some(path) = finalize_package_target(&pkg_path) {
+        return Some(path);
     }
 
-    let mut pkg_harn = pkg_path;
-    pkg_harn.set_extension("harn");
-    if pkg_harn.exists() {
-        return Some(pkg_harn);
-    }
+    let (package_name, export_name) = import_path.split_once('/')?;
+    let manifest_path = packages_root.join(package_name).join("harn.toml");
+    let manifest = read_package_manifest(&manifest_path)?;
+    let rel_path = manifest.exports.get(export_name)?;
+    finalize_package_target(&packages_root.join(package_name).join(rel_path))
+}
 
+fn read_package_manifest(path: &Path) -> Option<PackageManifest> {
+    let content = std::fs::read_to_string(path).ok()?;
+    toml::from_str::<PackageManifest>(&content).ok()
+}
+
+fn finalize_package_target(path: &Path) -> Option<PathBuf> {
+    if path.is_dir() {
+        let lib = path.join("lib.harn");
+        if lib.exists() {
+            return Some(lib);
+        }
+        return Some(path.to_path_buf());
+    }
+    if path.exists() {
+        return Some(path.to_path_buf());
+    }
+    if path.extension().is_none() {
+        let mut with_ext = path.to_path_buf();
+        with_ext.set_extension("harn");
+        if with_ext.exists() {
+            return Some(with_ext);
+        }
+    }
     None
 }
 
@@ -585,6 +637,66 @@ mod tests {
             .expect("std/math should resolve");
         // `clamp` is defined in stdlib_math.harn as `pub fn clamp(...)`.
         assert!(imported.contains("clamp"));
+    }
+
+    #[test]
+    fn package_export_map_resolves_declared_module() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let packages = root.join(".harn/packages/acme/runtime");
+        fs::create_dir_all(&packages).unwrap();
+        fs::write(
+            root.join(".harn/packages/acme/harn.toml"),
+            "[exports]\ncapabilities = \"runtime/capabilities.harn\"\n",
+        )
+        .unwrap();
+        fs::write(
+            packages.join("capabilities.harn"),
+            "pub fn exported_capability() { 1 }\n",
+        )
+        .unwrap();
+        let entry = write_file(
+            root,
+            "entry.harn",
+            "import \"acme/capabilities\"\nexported_capability()\n",
+        );
+
+        let graph = build(std::slice::from_ref(&entry));
+        let imported = graph
+            .imported_names_for_file(&entry)
+            .expect("package export should resolve");
+        assert!(imported.contains("exported_capability"));
+    }
+
+    #[test]
+    fn package_imports_resolve_from_nested_package_module() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::create_dir_all(root.join(".harn/packages/acme")).unwrap();
+        fs::create_dir_all(root.join(".harn/packages/shared")).unwrap();
+        fs::write(
+            root.join(".harn/packages/shared/lib.harn"),
+            "pub fn shared_helper() { 1 }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join(".harn/packages/acme/lib.harn"),
+            "import \"shared\"\npub fn use_shared() { shared_helper() }\n",
+        )
+        .unwrap();
+        let entry = write_file(root, "entry.harn", "import \"acme\"\nuse_shared()\n");
+
+        let graph = build(std::slice::from_ref(&entry));
+        let imported = graph
+            .imported_names_for_file(&entry)
+            .expect("nested package import should resolve");
+        assert!(imported.contains("use_shared"));
+        let acme_path = root.join(".harn/packages/acme/lib.harn");
+        let acme_imports = graph
+            .imported_names_for_file(&acme_path)
+            .expect("package module imports should resolve");
+        assert!(acme_imports.contains("shared_helper"));
     }
 
     #[test]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -76,6 +76,7 @@ pub fn compile_source(source: &str) -> Result<Chunk, String> {
 /// Reset all thread-local state that can leak between test runs.
 pub fn reset_thread_local_state() {
     llm::reset_llm_state();
+    llm_config::clear_user_overrides();
     http::reset_http_state();
     stdlib::reset_stdlib_state();
     events::reset_event_sinks();

--- a/crates/harn-vm/src/llm/api/completion.rs
+++ b/crates/harn-vm/src/llm/api/completion.rs
@@ -24,9 +24,9 @@ pub(crate) async fn vm_call_completion_full(
     }
 
     let resolved = crate::llm_config::provider_config(&opts.provider);
-    let completion_endpoint = resolved.and_then(|p| p.completion_endpoint.as_deref());
+    let completion_endpoint = resolved.and_then(|p| p.completion_endpoint);
 
-    match completion_endpoint {
+    match completion_endpoint.as_deref() {
         Some("/api/generate") => vm_call_completion_ollama(opts, prefix, suffix).await,
         Some(_) => vm_call_completion_openai_style(opts, prefix, suffix).await,
         None => vm_call_completion_fallback(opts, prefix, suffix).await,
@@ -43,9 +43,11 @@ async fn vm_call_completion_openai_style(
 
     let pdef = crate::llm_config::provider_config(&opts.provider);
     let base_url = pdef
+        .as_ref()
         .map(crate::llm_config::resolve_base_url)
         .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
     let endpoint = pdef
+        .as_ref()
         .and_then(|p| p.completion_endpoint.as_deref())
         .unwrap_or("/completions");
 
@@ -82,7 +84,7 @@ async fn vm_call_completion_openai_style(
         .header("Content-Type", "application/json")
         .timeout(std::time::Duration::from_secs(llm_timeout))
         .json(&body);
-    let req = apply_auth_headers(req, &opts.api_key, pdef);
+    let req = apply_auth_headers(req, &opts.api_key, pdef.as_ref());
 
     let response = req.send().await.map_err(|e| {
         VmError::Thrown(VmValue::String(Rc::from(format!(
@@ -138,9 +140,11 @@ async fn vm_call_completion_ollama(
     let client = crate::llm::shared_blocking_client().clone();
     let pdef = crate::llm_config::provider_config(&opts.provider);
     let base_url = pdef
+        .as_ref()
         .map(crate::llm_config::resolve_base_url)
         .unwrap_or_else(|| "http://localhost:11434".to_string());
     let endpoint = pdef
+        .as_ref()
         .and_then(|p| p.completion_endpoint.as_deref())
         .unwrap_or("/api/generate");
 
@@ -197,7 +201,7 @@ async fn vm_call_completion_ollama(
         .header("Content-Type", "application/json")
         .timeout(std::time::Duration::from_secs(llm_timeout))
         .json(&body);
-    let req = apply_auth_headers(req, &opts.api_key, pdef);
+    let req = apply_auth_headers(req, &opts.api_key, pdef.as_ref());
 
     let response = req.send().await.map_err(|e| {
         VmError::Thrown(VmValue::String(Rc::from(format!(

--- a/crates/harn-vm/src/llm/api/context_window.rs
+++ b/crates/harn-vm/src/llm/api/context_window.rs
@@ -33,6 +33,7 @@ pub async fn fetch_provider_max_context(
 ) -> Option<usize> {
     let pdef = crate::llm_config::provider_config(provider);
     let base_url = pdef
+        .as_ref()
         .map(crate::llm_config::resolve_base_url)
         .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
     let cache_key = (base_url.clone(), model.to_string());
@@ -137,7 +138,7 @@ async fn fetch_openai_compatible_context_window(
         .get(&url)
         .header("Content-Type", "application/json")
         .timeout(std::time::Duration::from_secs(10));
-    let req = apply_auth_headers(req, api_key, pdef);
+    let req = apply_auth_headers(req, api_key, pdef.as_ref());
     let response = req.send().await.ok()?;
     if !response.status().is_success() {
         return None;

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -14,7 +14,7 @@ pub(super) fn parse_llm_response(
     json: &serde_json::Value,
     provider: &str,
     model: &str,
-    resolved: &crate::llm::helpers::ResolvedProvider<'_>,
+    resolved: &crate::llm::helpers::ResolvedProvider,
 ) -> Result<LlmResult, VmError> {
     if resolved.is_anthropic_style {
         let mut text = String::new();
@@ -321,7 +321,7 @@ mod tests {
     // Build a ResolvedProvider for the Anthropic path without going through
     // the thread-local provider registry — these parser tests only need the
     // is_anthropic_style flag set.
-    fn anthropic_resolved() -> crate::llm::helpers::ResolvedProvider<'static> {
+    fn anthropic_resolved() -> crate::llm::helpers::ResolvedProvider {
         crate::llm::helpers::ResolvedProvider::resolve("anthropic")
     }
 

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -305,7 +305,7 @@ pub(crate) async fn vm_call_llm_api_with_body(
 async fn vm_call_llm_api_sse_from_response(
     response: reqwest::Response,
     model: &str,
-    resolved: &crate::llm::helpers::ResolvedProvider<'_>,
+    resolved: &crate::llm::helpers::ResolvedProvider,
     delta_tx: DeltaSender,
 ) -> Result<LlmResult, VmError> {
     use tokio::io::AsyncBufReadExt;

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -182,7 +182,7 @@ pub(crate) fn register_config_builtins(vm: &mut Vm) {
         match provider_name {
             Some(name) => {
                 if let Some(pdef) = llm_config::provider_config(&name) {
-                    Ok(provider_def_to_vm_value(pdef))
+                    Ok(provider_def_to_vm_value(&pdef))
                 } else {
                     Ok(VmValue::Nil)
                 }
@@ -192,7 +192,7 @@ pub(crate) fn register_config_builtins(vm: &mut Vm) {
                 let mut dict = BTreeMap::new();
                 for name in llm_config::provider_names() {
                     if let Some(pdef) = llm_config::provider_config(&name) {
-                        dict.insert(name, provider_def_to_vm_value(pdef));
+                        dict.insert(name, provider_def_to_vm_value(&pdef));
                     }
                 }
                 Ok(VmValue::Dict(Rc::new(dict)))
@@ -267,7 +267,7 @@ pub(crate) fn register_config_builtins(vm: &mut Vm) {
         let url = if let Some(absolute_url) = &hc.url {
             absolute_url.clone()
         } else {
-            let base = llm_config::resolve_base_url(pdef);
+            let base = llm_config::resolve_base_url(&pdef);
             let path = hc.path.as_deref().unwrap_or("");
             format!("{base}{path}")
         };
@@ -286,7 +286,7 @@ pub(crate) fn register_config_builtins(vm: &mut Vm) {
         };
 
         // Apply auth
-        req = apply_auth_headers(req, &api_key, Some(pdef));
+        req = apply_auth_headers(req, &api_key, Some(&pdef));
         if let Some(p) = llm_config::provider_config(&provider_name) {
             for (k, v) in &p.extra_headers {
                 req = req.header(k.as_str(), v.as_str());

--- a/crates/harn-vm/src/llm/helpers/provider.rs
+++ b/crates/harn-vm/src/llm/helpers/provider.rs
@@ -350,17 +350,18 @@ pub fn resolve_api_key(provider: &str) -> Result<String, VmError> {
     })
 }
 
-pub(crate) struct ResolvedProvider<'a> {
-    pub pdef: Option<&'a crate::llm_config::ProviderDef>,
+pub(crate) struct ResolvedProvider {
+    pub pdef: Option<crate::llm_config::ProviderDef>,
     pub is_anthropic_style: bool,
     pub base_url: String,
-    pub endpoint: &'a str,
+    pub endpoint: String,
 }
 
-impl<'a> ResolvedProvider<'a> {
-    pub fn resolve(provider: &str) -> ResolvedProvider<'static> {
+impl ResolvedProvider {
+    pub fn resolve(provider: &str) -> ResolvedProvider {
         let pdef = crate::llm_config::provider_config(provider);
         let is_anthropic_style = pdef
+            .as_ref()
             .map(|p| p.chat_endpoint.contains("/messages"))
             .unwrap_or(provider == "anthropic");
         let (default_base, default_endpoint) = if is_anthropic_style {
@@ -369,11 +370,13 @@ impl<'a> ResolvedProvider<'a> {
             ("https://api.openai.com/v1", "/chat/completions")
         };
         let base_url = pdef
+            .as_ref()
             .map(crate::llm_config::resolve_base_url)
             .unwrap_or_else(|| default_base.to_string());
         let endpoint = pdef
-            .map(|p| p.chat_endpoint.as_str())
-            .unwrap_or(default_endpoint);
+            .as_ref()
+            .map(|p| p.chat_endpoint.clone())
+            .unwrap_or_else(|| default_endpoint.to_string());
         ResolvedProvider {
             pdef,
             is_anthropic_style,
@@ -391,8 +394,8 @@ impl<'a> ResolvedProvider<'a> {
         mut req: reqwest::RequestBuilder,
         api_key: &str,
     ) -> reqwest::RequestBuilder {
-        req = crate::llm::api::apply_auth_headers(req, api_key, self.pdef);
-        if let Some(p) = self.pdef {
+        req = crate::llm::api::apply_auth_headers(req, api_key, self.pdef.as_ref());
+        if let Some(p) = self.pdef.as_ref() {
             for (k, v) in &p.extra_headers {
                 req = req.header(k.as_str(), v.as_str());
             }

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -1,9 +1,18 @@
 use serde::Deserialize;
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
 static CONFIG: OnceLock<ProvidersConfig> = OnceLock::new();
 static CONFIG_PATH: OnceLock<String> = OnceLock::new();
+
+thread_local! {
+    /// Thread-local provider config overlays installed by the CLI after it
+    /// reads the nearest `harn.toml` plus any installed package manifests.
+    /// Kept thread-local so tests and multi-VM hosts can scope extensions to
+    /// the current run without mutating the process-wide default config.
+    static USER_OVERRIDES: RefCell<Option<ProvidersConfig>> = const { RefCell::new(None) };
+}
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct ProvidersConfig {
@@ -19,6 +28,45 @@ pub struct ProvidersConfig {
     pub tier_defaults: TierDefaults,
     #[serde(default)]
     pub model_defaults: BTreeMap<String, BTreeMap<String, toml::Value>>,
+}
+
+impl ProvidersConfig {
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+            && self.aliases.is_empty()
+            && self.inference_rules.is_empty()
+            && self.tier_rules.is_empty()
+            && self.model_defaults.is_empty()
+            && self.tier_defaults.default == default_mid()
+    }
+
+    pub fn merge_from(&mut self, overlay: &ProvidersConfig) {
+        self.providers.extend(overlay.providers.clone());
+        self.aliases.extend(overlay.aliases.clone());
+
+        if !overlay.inference_rules.is_empty() {
+            let mut merged = overlay.inference_rules.clone();
+            merged.extend(self.inference_rules.clone());
+            self.inference_rules = merged;
+        }
+
+        if !overlay.tier_rules.is_empty() {
+            let mut merged = overlay.tier_rules.clone();
+            merged.extend(self.tier_rules.clone());
+            self.tier_rules = merged;
+        }
+
+        if overlay.tier_defaults.default != default_mid() {
+            self.tier_defaults = overlay.tier_defaults.clone();
+        }
+
+        for (pattern, defaults) in &overlay.model_defaults {
+            self.model_defaults
+                .entry(pattern.clone())
+                .or_default()
+                .extend(defaults.clone());
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -206,9 +254,31 @@ pub fn loaded_config_path() -> Option<std::path::PathBuf> {
     CONFIG_PATH.get().map(std::path::PathBuf::from)
 }
 
+/// Install per-run provider config overlays. The overlay uses the same shape as
+/// `providers.toml`, but lives under `[llm]` in `harn.toml` and package
+/// manifests. Passing `None` clears the overlay.
+pub fn set_user_overrides(config: Option<ProvidersConfig>) {
+    USER_OVERRIDES.with(|cell| *cell.borrow_mut() = config);
+}
+
+/// Clear per-run provider config overlays.
+pub fn clear_user_overrides() {
+    set_user_overrides(None);
+}
+
+fn effective_config() -> ProvidersConfig {
+    let mut merged = load_config().clone();
+    USER_OVERRIDES.with(|cell| {
+        if let Some(overlay) = cell.borrow().as_ref() {
+            merged.merge_from(overlay);
+        }
+    });
+    merged
+}
+
 /// Resolve a model alias to (model_id, provider_name).
 pub fn resolve_model(alias: &str) -> (String, Option<String>) {
-    let config = load_config();
+    let config = effective_config();
     if let Some(a) = config.aliases.get(alias) {
         return (a.id.clone(), Some(a.provider.clone()));
     }
@@ -217,7 +287,7 @@ pub fn resolve_model(alias: &str) -> (String, Option<String>) {
 
 /// Infer provider from a model ID using inference rules.
 pub fn infer_provider(model_id: &str) -> String {
-    let config = load_config();
+    let config = effective_config();
     for rule in &config.inference_rules {
         if let Some(exact) = &rule.exact {
             if model_id == exact {
@@ -259,7 +329,7 @@ pub fn infer_provider(model_id: &str) -> String {
 
 /// Get model tier ("small", "mid", "frontier").
 pub fn model_tier(model_id: &str) -> String {
-    let config = load_config();
+    let config = effective_config();
     for rule in &config.tier_rules {
         if let Some(exact) = &rule.exact {
             if model_id == exact {
@@ -288,14 +358,14 @@ pub fn model_tier(model_id: &str) -> String {
 }
 
 /// Get provider config for resolving base_url, auth, etc.
-pub fn provider_config(name: &str) -> Option<&'static ProviderDef> {
-    load_config().providers.get(name)
+pub fn provider_config(name: &str) -> Option<ProviderDef> {
+    effective_config().providers.get(name).cloned()
 }
 
 /// Get model-specific default parameters (temperature, etc.).
 /// Matches glob patterns in model_defaults keys.
 pub fn model_params(model_id: &str) -> BTreeMap<String, toml::Value> {
-    let config = load_config();
+    let config = effective_config();
     let mut params = BTreeMap::new();
     for (pattern, defaults) in &config.model_defaults {
         if glob_match(pattern, model_id) {
@@ -309,7 +379,7 @@ pub fn model_params(model_id: &str) -> BTreeMap<String, toml::Value> {
 
 /// Get list of configured provider names.
 pub fn provider_names() -> Vec<String> {
-    load_config().providers.keys().cloned().collect()
+    effective_config().providers.keys().cloned().collect()
 }
 
 /// Check if a provider advertises a feature (e.g., "native_tools").
@@ -322,7 +392,7 @@ pub fn provider_has_feature(provider: &str, feature: &str) -> bool {
 /// Resolve the default tool format for a model+provider combination.
 /// Priority: alias `tool_format` (matched by model ID) > provider feature > "text".
 pub fn default_tool_format(model: &str, provider: &str) -> String {
-    let config = load_config();
+    let config = effective_config();
     // Aliases match by model ID + provider, or by alias name.
     for (name, alias) in &config.aliases {
         let matches = (alias.id == model && alias.provider == provider) || name == model;
@@ -344,7 +414,7 @@ pub fn resolve_tier_model(
     target: &str,
     preferred_provider: Option<&str>,
 ) -> Option<(String, String)> {
-    let config = load_config();
+    let config = effective_config();
 
     if let Some(alias) = config.aliases.get(target) {
         return Some((alias.id.clone(), alias.provider.clone()));
@@ -374,7 +444,7 @@ pub fn resolve_tier_model(
 /// model falls into the requested capability tier. The result is de-duplicated
 /// and sorted deterministically by provider then model id.
 pub fn tier_candidates(target: &str) -> Vec<(String, String)> {
-    let config = load_config();
+    let config = effective_config();
     let mut seen = std::collections::BTreeSet::new();
     let mut candidates = Vec::new();
 
@@ -799,6 +869,10 @@ fn default_config() -> ProvidersConfig {
 mod tests {
     use super::*;
 
+    fn reset_overrides() {
+        clear_user_overrides();
+    }
+
     #[test]
     fn test_glob_match_prefix() {
         assert!(glob_match("claude-*", "claude-sonnet-4-20250514"));
@@ -918,5 +992,56 @@ mod tests {
     fn test_model_params_empty() {
         let params = model_params("claude-sonnet-4-20250514");
         assert!(params.is_empty());
+    }
+
+    #[test]
+    fn test_user_overrides_add_provider_and_alias() {
+        reset_overrides();
+        let mut overlay = ProvidersConfig::default();
+        overlay.providers.insert(
+            "acme".to_string(),
+            ProviderDef {
+                base_url: "https://llm.acme.test/v1".to_string(),
+                chat_endpoint: "/chat/completions".to_string(),
+                ..Default::default()
+            },
+        );
+        overlay.aliases.insert(
+            "acme-fast".to_string(),
+            AliasDef {
+                id: "acme/model-fast".to_string(),
+                provider: "acme".to_string(),
+                tool_format: Some("native".to_string()),
+            },
+        );
+        set_user_overrides(Some(overlay));
+
+        let (model, provider) = resolve_model("acme-fast");
+        assert_eq!(model, "acme/model-fast");
+        assert_eq!(provider.as_deref(), Some("acme"));
+        assert!(provider_names().contains(&"acme".to_string()));
+        assert_eq!(
+            provider_config("acme").map(|provider| provider.base_url),
+            Some("https://llm.acme.test/v1".to_string())
+        );
+
+        reset_overrides();
+    }
+
+    #[test]
+    fn test_user_overrides_prepend_inference_rules() {
+        reset_overrides();
+        let mut overlay = ProvidersConfig::default();
+        overlay.inference_rules.push(InferenceRule {
+            pattern: Some("internal-*".to_string()),
+            contains: None,
+            exact: None,
+            provider: "openai".to_string(),
+        });
+        set_user_overrides(Some(overlay));
+
+        assert_eq!(infer_provider("internal-foo"), "openai");
+
+        reset_overrides();
     }
 }

--- a/crates/harn-vm/src/vm/modules.rs
+++ b/crates/harn-vm/src/vm/modules.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::rc::Rc;
 
+use serde::Deserialize;
+
 use crate::value::{ModuleFunctionRegistry, VmClosure, VmEnv, VmError, VmValue};
 
 use super::{ScopeSpan, Vm};
@@ -13,6 +15,70 @@ use super::{ScopeSpan, Vm};
 pub(crate) struct LoadedModule {
     pub(crate) functions: BTreeMap<String, Rc<VmClosure>>,
     pub(crate) public_names: HashSet<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PackageManifest {
+    #[serde(default)]
+    exports: BTreeMap<String, String>,
+}
+
+fn resolve_package_import(base: &Path, import_path: &str) -> Option<PathBuf> {
+    for anchor in base.ancestors() {
+        let packages_root = anchor.join(".harn/packages");
+        if !packages_root.is_dir() {
+            if anchor.join(".git").exists() {
+                break;
+            }
+            continue;
+        }
+        if let Some(path) = resolve_from_packages_root(&packages_root, import_path) {
+            return Some(path);
+        }
+        if anchor.join(".git").exists() {
+            break;
+        }
+    }
+    None
+}
+
+fn resolve_from_packages_root(packages_root: &Path, import_path: &str) -> Option<PathBuf> {
+    let pkg_path = packages_root.join(import_path);
+    if let Some(path) = finalize_package_target(&pkg_path) {
+        return Some(path);
+    }
+
+    let (package_name, export_name) = import_path.split_once('/')?;
+    let manifest_path = packages_root.join(package_name).join("harn.toml");
+    let manifest = read_package_manifest(&manifest_path)?;
+    let rel_path = manifest.exports.get(export_name)?;
+    finalize_package_target(&packages_root.join(package_name).join(rel_path))
+}
+
+fn read_package_manifest(path: &Path) -> Option<PackageManifest> {
+    let content = std::fs::read_to_string(path).ok()?;
+    toml::from_str::<PackageManifest>(&content).ok()
+}
+
+fn finalize_package_target(path: &Path) -> Option<PathBuf> {
+    if path.is_dir() {
+        let lib = path.join("lib.harn");
+        if lib.exists() {
+            return Some(lib);
+        }
+        return Some(path.to_path_buf());
+    }
+    if path.exists() {
+        return Some(path.to_path_buf());
+    }
+    if path.extension().is_none() {
+        let mut with_ext = path.to_path_buf();
+        with_ext.set_extension("harn");
+        if with_ext.exists() {
+            return Some(with_ext);
+        }
+    }
+    None
 }
 
 impl Vm {
@@ -100,24 +166,8 @@ impl Vm {
             }
 
             if !file_path.exists() {
-                let pkg_path = base.join(".harn/packages").join(path);
-                if pkg_path.exists() {
-                    file_path = if pkg_path.is_dir() {
-                        let lib = pkg_path.join("lib.harn");
-                        if lib.exists() {
-                            lib
-                        } else {
-                            pkg_path
-                        }
-                    } else {
-                        pkg_path
-                    };
-                } else {
-                    let mut pkg_harn = pkg_path.clone();
-                    pkg_harn.set_extension("harn");
-                    if pkg_harn.exists() {
-                        file_path = pkg_harn;
-                    }
+                if let Some(resolved) = resolve_package_import(&base, path) {
+                    file_path = resolved;
                 }
             }
 

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::path::Path;
 
 use crate::compiler::Compiler;
 use crate::stdlib::register_vm_stdlib;
@@ -34,6 +35,34 @@ fn run_harn(source: &str) -> (String, VmValue) {
 
 fn run_output(source: &str) -> String {
     run_harn(source).0.trim_end().to_string()
+}
+
+fn run_harn_at(path: &Path, source: &str) -> Result<(String, VmValue), VmError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let mut lexer = Lexer::new(source);
+                let tokens = lexer.tokenize().unwrap();
+                let mut parser = Parser::new(tokens);
+                let program = parser.parse().unwrap();
+                let chunk = Compiler::new().compile(&program).unwrap();
+
+                let mut vm = Vm::new();
+                register_vm_stdlib(&mut vm);
+                vm.set_source_info(&path.display().to_string(), source);
+                if let Some(parent) = path.parent() {
+                    vm.set_source_dir(parent);
+                }
+                let result = vm.execute(&chunk).await?;
+                Ok((vm.output().to_string(), result))
+            })
+            .await
+    })
 }
 
 fn run_harn_result(source: &str) -> Result<(String, VmValue), VmError> {
@@ -835,4 +864,33 @@ log(label)
         out,
         "[harn] loop 1\n[harn] loop 2\n[harn] boom\n[harn] outer"
     );
+}
+
+#[test]
+fn package_export_import_executes_through_manifest_alias() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join(".git")).unwrap();
+    std::fs::create_dir_all(root.join(".harn/packages/acme/runtime")).unwrap();
+    std::fs::write(
+        root.join(".harn/packages/acme/harn.toml"),
+        "[exports]\ncapabilities = \"runtime/capabilities.harn\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join(".harn/packages/acme/runtime/capabilities.harn"),
+        "pub fn exported_capability() { return 41 + 1 }\n",
+    )
+    .unwrap();
+    let entry = root.join("main.harn");
+    let source = r#"
+import "acme/capabilities"
+
+pipeline main(task) {
+  println(exported_capability())
+}
+"#;
+
+    let (out, _) = run_harn_at(&entry, source).unwrap();
+    assert_eq!(out.trim(), "42");
 }

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -792,39 +792,41 @@ llm_mock_clear()
 LLM provider endpoints, model aliases, inference rules, and default parameters
 are configured via a TOML file. The VM searches for config in this order:
 
-1. `HARN_PROVIDERS_CONFIG` env var (explicit path)
-2. `~/.config/harn/providers.toml`
-3. Built-in defaults (Anthropic, OpenAI, OpenRouter, HuggingFace, Ollama, Local)
+1. Built-in defaults (Anthropic, OpenAI, OpenRouter, HuggingFace, Ollama, Local)
+2. `HARN_PROVIDERS_CONFIG` if set, otherwise `~/.config/harn/providers.toml`
+3. Installed package `[llm]` tables in `.harn/packages/*/harn.toml`
+4. The nearest project `harn.toml` `[llm]` table
 
-See `harn init` to generate a default config file, or create one manually:
+The `[llm]` section uses the same schema as `providers.toml`, so project and
+package manifests can ship provider adapters declaratively:
 
 ```toml
-[providers.anthropic]
+[llm.providers.anthropic]
 base_url = "https://api.anthropic.com/v1"
 auth_style = "header"
 auth_header = "x-api-key"
 auth_env = "ANTHROPIC_API_KEY"
 chat_endpoint = "/messages"
 
-[providers.local]
+[llm.providers.local]
 base_url = "http://localhost:8000"
 base_url_env = "LOCAL_LLM_BASE_URL"
 auth_style = "none"
 chat_endpoint = "/v1/chat/completions"
 completion_endpoint = "/v1/completions"
 
-[aliases]
+[llm.aliases]
 sonnet = { id = "claude-sonnet-4-20250514", provider = "anthropic" }
 
-[[inference_rules]]
+[[llm.inference_rules]]
 pattern = "claude-*"
 provider = "anthropic"
 
-[[tier_rules]]
+[[llm.tier_rules]]
 pattern = "claude-*"
 tier = "frontier"
 
-[model_defaults."qwen/*"]
+[llm.model_defaults."qwen/*"]
 temperature = 0.3
 ```
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -818,8 +818,23 @@ though this is mostly relevant for closures and parallel bodies.
 
 1. If path starts with `std/`, loads embedded stdlib module (e.g. `std/text`)
 2. Relative to current file's directory; auto-adds `.harn` extension
-3. `.harn/packages/<path>` directories
-4. Package directories with `lib.harn` entry point
+3. `.harn/packages/<path>` directories rooted at the nearest ancestor
+   package root (the search walks upward and stops at a `.git` boundary)
+4. Package manifest `[exports]` mappings under
+   `.harn/packages/<package>/harn.toml`
+5. Package directories with `lib.harn` entry point
+
+Package manifests can publish stable module entry points without forcing
+consumers to import the on-disk file layout directly:
+
+```toml
+[exports]
+capabilities = "runtime/capabilities.harn"
+providers = "runtime/providers.harn"
+```
+
+With the example above, `import "acme/capabilities"` resolves to the
+declared file inside the installed `acme` package.
 
 Selective imports: `import { name1, name2 } from "module"` imports only
 the specified functions. Functions marked `pub` are exported by default;
@@ -3234,6 +3249,51 @@ the manifest directory and recursively checks every `.harn` file under
 each. Positional targets remain additive. The manifest is discovered by
 walking upward from the first positional target (or the current working
 directory when none is supplied).
+
+### `[exports]` — stable package module entry points
+
+```toml
+[exports]
+capabilities = "runtime/capabilities.harn"
+providers = "runtime/providers.harn"
+```
+
+`[exports]` maps logical import suffixes to package-root-relative module
+paths. After `harn install`, consumers import them as
+`"<package>/<export>"` instead of coupling to the package's internal
+directory layout.
+
+Exports are resolved after the direct `.harn/packages/<path>` lookup, so
+packages can still expose raw file trees when they want that behavior.
+
+### `[llm]` — packaged provider extensions
+
+```toml
+[llm.providers.my_proxy]
+base_url = "https://llm.example.com/v1"
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+auth_style = "bearer"
+auth_env = "MY_PROXY_API_KEY"
+
+[llm.aliases]
+my-fast = { id = "vendor/model-fast", provider = "my_proxy" }
+```
+
+The `[llm]` table accepts the same schema as `providers.toml`
+(`providers`, `aliases`, `inference_rules`, `tier_rules`,
+`tier_defaults`, `model_defaults`) but scopes it to the current run.
+
+When Harn starts from a file inside a workspace, it merges:
+
+1. built-in defaults,
+2. the global provider file (`HARN_PROVIDERS_CONFIG` or
+   `~/.config/harn/providers.toml`),
+3. installed package `[llm]` tables from `.harn/packages/*/harn.toml`,
+4. the root project's `[llm]` table.
+
+Later layers win on key collisions; rule lists are prepended so package
+and project inference/tier overrides run before the built-in defaults.
 
 ### `[lint]` — lint configuration
 

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -320,6 +320,35 @@ editing the manifest is awkward:
   script detects a proxied endpoint at runtime.
 - `provider_capabilities_clear()` — revert to shipped defaults.
 
+### Packaged provider adapters via `[llm]`
+
+Projects and installed packages can also contribute provider definitions,
+aliases, inference rules, and model defaults directly from `harn.toml`
+under `[llm]`. The schema matches `providers.toml`, but the merge is
+scoped to the current run:
+
+```toml
+[llm.providers.my_proxy]
+base_url = "https://llm.example.com/v1"
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+auth_style = "bearer"
+auth_env = "MY_PROXY_API_KEY"
+
+[llm.aliases]
+my-fast = { id = "vendor/model-fast", provider = "my_proxy" }
+```
+
+Load order is:
+
+1. built-in defaults
+2. `HARN_PROVIDERS_CONFIG` when set, otherwise `~/.config/harn/providers.toml`
+3. installed package `[llm]` tables from `.harn/packages/*/harn.toml`
+4. the root project's `[llm]` table
+
+That gives packages a stable, declarative way to ship provider adapters
+and model aliases without editing Rust-side registration code.
+
 ### Client-executed fallback
 
 On providers without native `defer_loading`, Harn falls back to an

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -378,6 +378,27 @@ import { extract_paths, parse_cells } from "std/text"
 
 ## Import behavior
 
+Import paths resolve in this order:
+
+1. `std/<module>` from the embedded stdlib
+2. Relative to the importing file, with implicit `.harn`
+3. Installed packages under the nearest ancestor `.harn/packages/`
+4. Package manifest `[exports]` aliases
+5. Package directories with `lib.harn`
+
+Packages can publish stable module entry points in `harn.toml`:
+
+```toml
+[exports]
+capabilities = "runtime/capabilities.harn"
+providers = "runtime/providers.harn"
+```
+
+With that manifest, `import "acme/capabilities"` resolves to the
+declared file inside `.harn/packages/acme/`, and nested package modules
+can import sibling packages through the workspace-level `.harn/packages`
+root instead of relying on brittle relative paths.
+
 1. The imported file is parsed and executed
 2. Pipelines in the imported file are registered by name
 3. Non-pipeline top-level statements (fn declarations, let bindings) are executed, making their values available

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -816,8 +816,23 @@ though this is mostly relevant for closures and parallel bodies.
 
 1. If path starts with `std/`, loads embedded stdlib module (e.g. `std/text`)
 2. Relative to current file's directory; auto-adds `.harn` extension
-3. `.harn/packages/<path>` directories
-4. Package directories with `lib.harn` entry point
+3. `.harn/packages/<path>` directories rooted at the nearest ancestor
+   package root (the search walks upward and stops at a `.git` boundary)
+4. Package manifest `[exports]` mappings under
+   `.harn/packages/<package>/harn.toml`
+5. Package directories with `lib.harn` entry point
+
+Package manifests can publish stable module entry points without forcing
+consumers to import the on-disk file layout directly:
+
+```toml
+[exports]
+capabilities = "runtime/capabilities.harn"
+providers = "runtime/providers.harn"
+```
+
+With the example above, `import "acme/capabilities"` resolves to the
+declared file inside the installed `acme` package.
 
 Selective imports: `import { name1, name2 } from "module"` imports only
 the specified functions. Functions marked `pub` are exported by default;
@@ -3232,6 +3247,51 @@ the manifest directory and recursively checks every `.harn` file under
 each. Positional targets remain additive. The manifest is discovered by
 walking upward from the first positional target (or the current working
 directory when none is supplied).
+
+### `[exports]` — stable package module entry points
+
+```toml
+[exports]
+capabilities = "runtime/capabilities.harn"
+providers = "runtime/providers.harn"
+```
+
+`[exports]` maps logical import suffixes to package-root-relative module
+paths. After `harn install`, consumers import them as
+`"<package>/<export>"` instead of coupling to the package's internal
+directory layout.
+
+Exports are resolved after the direct `.harn/packages/<path>` lookup, so
+packages can still expose raw file trees when they want that behavior.
+
+### `[llm]` — packaged provider extensions
+
+```toml
+[llm.providers.my_proxy]
+base_url = "https://llm.example.com/v1"
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+auth_style = "bearer"
+auth_env = "MY_PROXY_API_KEY"
+
+[llm.aliases]
+my-fast = { id = "vendor/model-fast", provider = "my_proxy" }
+```
+
+The `[llm]` table accepts the same schema as `providers.toml`
+(`providers`, `aliases`, `inference_rules`, `tier_rules`,
+`tier_defaults`, `model_defaults`) but scopes it to the current run.
+
+When Harn starts from a file inside a workspace, it merges:
+
+1. built-in defaults,
+2. the global provider file (`HARN_PROVIDERS_CONFIG` or
+   `~/.config/harn/providers.toml`),
+3. installed package `[llm]` tables from `.harn/packages/*/harn.toml`,
+4. the root project's `[llm]` table.
+
+Later layers win on key collisions; rule lists are prepended so package
+and project inference/tier overrides run before the built-in defaults.
 
 ### `[lint]` — lint configuration
 


### PR DESCRIPTION
## Summary
Adds a manifest-backed extension ABI for runtime-owned capabilities and provider integrations.

- add `[exports]` package entry points so modules can publish stable import surfaces without core runtime edits
- add `[llm]` manifest overlays so packages and projects can register provider aliases, inference rules, tiers, and model defaults declaratively
- teach runtime and static import resolution to consult ancestor `.harn/packages` roots plus package export maps, while preserving existing `lib.harn` fallback behavior
- load package and root manifest overlays at runtime so approval policy, transcripts, replay, and eval tooling still execute through the existing runtime trust boundary

## Why
Issue #128 calls for a stable extension model that lets new runtime-owned capabilities and provider/tool adapters be authored and packaged without invasive Rust-side registration changes. This keeps the runtime authoritative while moving extension definition into package manifests.

## Validation
- `cargo fmt`
- `git diff --check`
- `env CARGO_TARGET_DIR=/tmp/harn-issue128-target cargo test -p harn-modules --lib`
- `env CARGO_TARGET_DIR=/tmp/harn-issue128-target cargo test -p harn-vm --lib`
- `env CARGO_TARGET_DIR=/tmp/harn-issue128-target cargo test -p harn-cli load_runtime_extensions_merges_package_and_root_llm_config`
- pre-push checks passed, including the repo fast test gate (`1434 passed, 0 failed`)

Closes #128.
