### PR TITLE
[codex] Declarative runtime hooks via [hooks] manifest section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,30 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## Unreleased
+
+### Added
+
+- **Declarative runtime hooks via `[[hooks]]` manifests (#141, builds on
+  #138).** `harn.toml` can now register process-scoped `PreToolUse`,
+  `PostToolUse`, `PreAgentTurn`, `PostAgentTurn`, and worker lifecycle
+  hooks from exported Harn functions before execution starts. Tool hooks
+  support manifest-driven deny/argument-rewrite/result-rewrite behavior,
+  worker lifecycle moved off raw status strings onto a typed
+  `WorkerEvent` enum, and conformance now covers manifest registration,
+  pre-tool short-circuit, and post-tool rewrite behavior end-to-end.
+
 ## v0.7.21
 
 ### Added
+
+- **Daemon stdlib wrapper builtins for runtime-owned daemon mode (#143).**
+  `daemon_spawn`, `daemon_trigger`, `daemon_snapshot`, `daemon_stop`,
+  and `daemon_resume` now expose the existing agent-loop daemon
+  runtime through a first-class stdlib handle. The wrapper stores
+  daemon metadata alongside the persisted runtime snapshot so
+  resumable state dirs can be reopened ergonomically without changing
+  daemon semantics.
 
 - **Manifest-backed runtime extension ABI (#128).** `harn.toml` now
   supports `[exports]` for stable package module entry points and

--- a/conformance/tests/integration/manifest_hooks_runtime/harn.toml
+++ b/conformance/tests/integration/manifest_hooks_runtime/harn.toml
@@ -1,0 +1,13 @@
+[package]
+name = "manifest_hooks"
+version = "0.1.0"
+
+[[hooks]]
+event = "PreToolUse"
+pattern = "tool.name =~ \"write|edit\""
+handler = "manifest_hooks::deny_write_like_tools"
+
+[[hooks]]
+event = "PostToolUse"
+pattern = "tool.name =~ \"read\""
+handler = "manifest_hooks::rewrite_read_results"

--- a/conformance/tests/integration/manifest_hooks_runtime/lib.harn
+++ b/conformance/tests/integration/manifest_hooks_runtime/lib.harn
@@ -1,0 +1,11 @@
+pub fn deny_write_like_tools(event) {
+  let name = event?.tool?.name ?? ""
+  if contains(name, "write") || contains(name, "edit") {
+    return {deny: "manifest denied " + name}
+  }
+  return nil
+}
+
+pub fn rewrite_read_results(event) {
+  return "HOOKED:" + event?.result?.text ?? ""
+}

--- a/conformance/tests/integration/manifest_hooks_runtime/main.expected
+++ b/conformance/tests/integration/manifest_hooks_runtime/main.expected
@@ -1,0 +1,1 @@
+[harn] manifest_hooks_runtime tests passed

--- a/conformance/tests/integration/manifest_hooks_runtime/main.harn
+++ b/conformance/tests/integration/manifest_hooks_runtime/main.harn
@@ -1,0 +1,50 @@
+pipeline default() {
+  llm_mock_clear()
+  var registry = tool_registry()
+  registry = tool_define(
+    registry,
+    "write_note",
+    "Write a note to disk",
+    {parameters: {path: {type: "string"}}, handler: { args -> "SHOULD_NOT_RUN " + args.path }},
+  )
+  registry = tool_define(
+    registry,
+    "read_note",
+    "Read a note from disk",
+    {parameters: {path: {type: "string"}}, handler: { args -> "original result " + args.path }},
+  )
+  llm_mock({tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "notes.txt"}}]})
+  llm_mock({tool_calls: [{id: "read_1", name: "read_note", arguments: {path: "notes.txt"}}]})
+  llm_mock({text: "<done>##DONE##</done>"})
+  let result = agent_loop(
+    "Exercise manifest hooks",
+    nil,
+    {
+    provider: "mock",
+    tools: registry,
+    persistent: true,
+    max_iterations: 4,
+    session_id: "manifest-hooks-runtime",
+  },
+  )
+  assert(result?.status == "done", "loop completes")
+  let calls = llm_mock_calls()
+  assert(len(calls) == 3, "three model turns happened")
+  var saw_deny = false
+  for message in calls[1].messages {
+    let content = message?.content
+    if content != nil && contains(content, "manifest denied write_note") {
+      saw_deny = true
+    }
+  }
+  assert(saw_deny, "pre-tool hook denied write_note before execution")
+  var saw_post_hook = false
+  for message in calls[2].messages {
+    let content = message?.content
+    if content != nil && contains(content, "HOOKED:original result notes.txt") {
+      saw_post_hook = true
+    }
+  }
+  assert(saw_post_hook, "post-tool hook rewrote the successful result")
+  log("manifest_hooks_runtime tests passed")
+}

--- a/crates/harn-cli/src/acp/execute.rs
+++ b/crates/harn-cli/src/acp/execute.rs
@@ -53,6 +53,9 @@ pub(super) async fn execute_chunk(
     if let Some(path) = source_path {
         let extensions = package::load_runtime_extensions(path);
         package::install_runtime_extensions(&extensions);
+        package::install_manifest_hooks(&mut vm, &extensions)
+            .await
+            .map_err(|error| format!("failed to install manifest hooks: {error}"))?;
     }
 
     vm.set_global("prompt", harn_vm::VmValue::String(Rc::from(prompt_text)));

--- a/crates/harn-cli/src/commands/bench.rs
+++ b/crates/harn-cli/src/commands/bench.rs
@@ -115,6 +115,10 @@ pub(crate) async fn run_bench(path: &str, iterations: usize) {
                 connect_mcp_servers(&manifest.mcp, &mut vm).await;
             }
         }
+        if let Err(error) = package::install_manifest_hooks(&mut vm, &extensions).await {
+            eprintln!("error: failed to install manifest hooks: {error}");
+            process::exit(1);
+        }
 
         let started_at = Instant::now();
         let local = tokio::task::LocalSet::new();

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -546,6 +546,10 @@ pub(crate) async fn run_file_with_skill_dirs(
             connect_mcp_servers(&manifest.mcp, &mut vm).await;
         }
     }
+    if let Err(error) = package::install_manifest_hooks(&mut vm, &extensions).await {
+        eprintln!("error: failed to install manifest hooks: {error}");
+        process::exit(1);
+    }
 
     // Graceful shutdown: flush run records before exit on SIGINT/SIGTERM.
     let cancelled = Arc::new(AtomicBool::new(false));
@@ -806,6 +810,10 @@ pub(crate) async fn run_file_mcp_serve(path: &str, card_source: Option<&str>) {
         if !manifest.mcp.is_empty() {
             connect_mcp_servers(&manifest.mcp, &mut vm).await;
         }
+    }
+    if let Err(error) = package::install_manifest_hooks(&mut vm, &extensions).await {
+        eprintln!("error: failed to install manifest hooks: {error}");
+        process::exit(1);
     }
 
     let local = tokio::task::LocalSet::new();

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -980,6 +980,13 @@ pub(crate) async fn execute(source: &str, source_path: Option<&Path>) -> Result<
             });
             skill_loader::emit_loader_warnings(&loaded.loader_warnings);
             skill_loader::install_skills_global(&mut vm, &loaded);
+            if let Some(path) = source_path {
+                let extensions = package::load_runtime_extensions(path);
+                package::install_runtime_extensions(&extensions);
+                package::install_manifest_hooks(&mut vm, &extensions)
+                    .await
+                    .map_err(|error| format!("failed to install manifest hooks: {error}"))?;
+            }
             let execution_result = vm.execute(&chunk).await.map_err(|e| e.to_string());
             harn_vm::stdlib::process::set_thread_execution_context(None);
             execution_result?;

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -49,6 +49,24 @@ pub struct Manifest {
     /// instead of replacing the global config file.
     #[serde(default)]
     pub llm: harn_vm::llm_config::ProvidersConfig,
+    /// `[[hooks]]` array-of-tables — declarative runtime hooks installed
+    /// once per process/thread before execution starts. Matches the
+    /// manifest-extension ABI shape added by `[exports]` / `[llm]`, but
+    /// the handlers themselves live in Harn modules.
+    #[serde(default)]
+    pub hooks: Vec<HookConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HookConfig {
+    pub event: harn_vm::orchestration::HookEvent,
+    #[serde(default = "default_hook_pattern")]
+    pub pattern: String,
+    pub handler: String,
+}
+
+fn default_hook_pattern() -> String {
+    "*".to_string()
 }
 
 /// `[skills]` table body.
@@ -266,7 +284,26 @@ pub struct RuntimeExtensions {
     pub root_manifest: Option<Manifest>,
     pub llm: Option<harn_vm::llm_config::ProvidersConfig>,
     pub capabilities: Option<harn_vm::llm::capabilities::CapabilitiesFile>,
+    pub hooks: Vec<ResolvedHookConfig>,
 }
+
+#[derive(Debug, Clone)]
+pub struct ResolvedHookConfig {
+    pub event: harn_vm::orchestration::HookEvent,
+    pub pattern: String,
+    pub handler: String,
+    pub manifest_dir: PathBuf,
+    pub package_name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct LocatedManifest {
+    manifest: Manifest,
+    dir: PathBuf,
+}
+
+type HookModuleCacheKey = (PathBuf, Option<String>, String);
+type HookModuleExports = std::collections::BTreeMap<String, std::rc::Rc<harn_vm::VmClosure>>;
 
 #[derive(Debug, Default)]
 struct LockFile {
@@ -392,7 +429,7 @@ fn merge_capability_overrides(
         .extend(source.provider_family.clone());
 }
 
-fn collect_package_manifests(packages_dir: &Path) -> Vec<Manifest> {
+fn collect_package_manifests(packages_dir: &Path) -> Vec<LocatedManifest> {
     let mut manifests = Vec::new();
     let Ok(entries) = fs::read_dir(packages_dir) else {
         return manifests;
@@ -408,11 +445,28 @@ fn collect_package_manifests(packages_dir: &Path) -> Vec<Manifest> {
             continue;
         };
         match toml::from_str::<Manifest>(&content) {
-            Ok(manifest) => manifests.push(manifest),
+            Ok(manifest) => manifests.push(LocatedManifest { manifest, dir }),
             Err(e) => eprintln!("warning: failed to parse {}: {e}", manifest_path.display()),
         }
     }
     manifests
+}
+
+fn resolved_hooks_from_manifest(
+    manifest: &Manifest,
+    manifest_dir: &Path,
+) -> Vec<ResolvedHookConfig> {
+    manifest
+        .hooks
+        .iter()
+        .map(|hook| ResolvedHookConfig {
+            event: hook.event,
+            pattern: hook.pattern.clone(),
+            handler: hook.handler.clone(),
+            manifest_dir: manifest_dir.to_path_buf(),
+            package_name: manifest.package.as_ref().and_then(|pkg| pkg.name.clone()),
+        })
+        .collect()
 }
 
 fn manifest_capabilities(
@@ -435,23 +489,30 @@ pub fn load_runtime_extensions(anchor: &Path) -> RuntimeExtensions {
 
     let mut llm = harn_vm::llm_config::ProvidersConfig::default();
     let mut capabilities = harn_vm::llm::capabilities::CapabilitiesFile::default();
+    let mut hooks = Vec::new();
 
-    for manifest in collect_package_manifests(&manifest_dir.join(PKG_DIR)) {
-        llm.merge_from(&manifest.llm);
-        if let Some(file) = manifest_capabilities(&manifest) {
+    for located in collect_package_manifests(&manifest_dir.join(PKG_DIR)) {
+        llm.merge_from(&located.manifest.llm);
+        if let Some(file) = manifest_capabilities(&located.manifest) {
             merge_capability_overrides(&mut capabilities, file);
         }
+        hooks.extend(resolved_hooks_from_manifest(
+            &located.manifest,
+            &located.dir,
+        ));
     }
 
     llm.merge_from(&root_manifest.llm);
     if let Some(file) = manifest_capabilities(&root_manifest) {
         merge_capability_overrides(&mut capabilities, file);
     }
+    hooks.extend(resolved_hooks_from_manifest(&root_manifest, &manifest_dir));
 
     RuntimeExtensions {
         root_manifest: Some(root_manifest),
         llm: (!llm.is_empty()).then_some(llm),
         capabilities: (!is_empty_capabilities(&capabilities)).then_some(capabilities),
+        hooks,
     }
 }
 
@@ -459,6 +520,71 @@ pub fn load_runtime_extensions(anchor: &Path) -> RuntimeExtensions {
 pub fn install_runtime_extensions(extensions: &RuntimeExtensions) {
     harn_vm::llm_config::set_user_overrides(extensions.llm.clone());
     harn_vm::llm::capabilities::set_user_overrides(extensions.capabilities.clone());
+}
+
+async fn resolve_hook_exports(
+    vm: &mut harn_vm::Vm,
+    hook: &ResolvedHookConfig,
+    module_name: &str,
+) -> Result<HookModuleExports, String> {
+    let self_name_matches = hook
+        .package_name
+        .as_deref()
+        .is_some_and(|name| name == module_name);
+    if self_name_matches {
+        let lib_path = hook.manifest_dir.join("lib.harn");
+        if lib_path.exists() {
+            return vm
+                .load_module_exports(&lib_path)
+                .await
+                .map_err(|error| error.to_string());
+        }
+    }
+
+    vm.load_module_exports_from_import(module_name)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+pub async fn install_manifest_hooks(
+    vm: &mut harn_vm::Vm,
+    extensions: &RuntimeExtensions,
+) -> Result<(), String> {
+    harn_vm::orchestration::clear_runtime_hooks();
+    let mut loaded_exports: HashMap<HookModuleCacheKey, HookModuleExports> = HashMap::new();
+    for hook in &extensions.hooks {
+        let Some((module_name, function_name)) = hook.handler.rsplit_once("::") else {
+            return Err(format!(
+                "invalid hook handler '{}': expected <module>::<function>",
+                hook.handler
+            ));
+        };
+        let cache_key = (
+            hook.manifest_dir.clone(),
+            hook.package_name.clone(),
+            module_name.to_string(),
+        );
+        if !loaded_exports.contains_key(&cache_key) {
+            let exports = resolve_hook_exports(vm, hook, module_name).await?;
+            loaded_exports.insert(cache_key.clone(), exports);
+        }
+        let exports = loaded_exports
+            .get(&cache_key)
+            .expect("manifest hook exports cached");
+        let Some(closure) = exports.get(function_name) else {
+            return Err(format!(
+                "hook handler '{}' is not exported by module '{}'",
+                function_name, module_name
+            ));
+        };
+        harn_vm::orchestration::register_vm_hook(
+            hook.event,
+            hook.pattern.clone(),
+            hook.handler.clone(),
+            closure.clone(),
+        );
+    }
+    Ok(())
 }
 
 fn absolutize_check_config_paths(mut config: CheckConfig, manifest_dir: &Path) -> CheckConfig {
@@ -1163,5 +1289,46 @@ chat_endpoint = "/chat/completions"
         assert!(llm.providers.contains_key("project"));
         assert!(llm.aliases.contains_key("acme-fast"));
         assert!(llm.aliases.contains_key("project-fast"));
+    }
+
+    #[test]
+    fn load_runtime_extensions_collects_manifest_hooks_in_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::create_dir_all(root.join(".harn/packages/acme")).unwrap();
+        fs::write(
+            root.join(MANIFEST),
+            r#"
+[package]
+name = "workspace"
+
+[[hooks]]
+event = "PostToolUse"
+pattern = "tool.name =~ \"read\""
+handler = "workspace::after_read"
+"#,
+        )
+        .unwrap();
+        fs::write(
+            root.join(".harn/packages/acme/harn.toml"),
+            r#"
+[package]
+name = "acme"
+
+[[hooks]]
+event = "PreToolUse"
+pattern = "tool.name =~ \"edit|write\""
+handler = "acme::audit_edit"
+"#,
+        )
+        .unwrap();
+        let harn_file = root.join("main.harn");
+        fs::write(&harn_file, "pipeline main() {}\n").unwrap();
+
+        let extensions = load_runtime_extensions(&harn_file);
+        assert_eq!(extensions.hooks.len(), 2);
+        assert_eq!(extensions.hooks[0].handler, "acme::audit_edit");
+        assert_eq!(extensions.hooks[1].handler, "workspace::after_read");
     }
 }

--- a/crates/harn-cli/src/test_runner.rs
+++ b/crates/harn-cli/src/test_runner.rs
@@ -150,6 +150,11 @@ pub async fn run_test_file(
                     });
                 crate::skill_loader::emit_loader_warnings(&loaded.loader_warnings);
                 crate::skill_loader::install_skills_global(&mut vm, &loaded);
+                let extensions = crate::package::load_runtime_extensions(path);
+                crate::package::install_runtime_extensions(&extensions);
+                crate::package::install_manifest_hooks(&mut vm, &extensions)
+                    .await
+                    .map_err(|error| format!("failed to install manifest hooks: {error}"))?;
                 match vm.execute(&chunk).await {
                     Ok(val) => Ok(val),
                     Err(e) => {

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -25,6 +25,38 @@ use serde::{Deserialize, Serialize};
 
 use crate::tool_annotations::ToolKind;
 
+/// Typed worker lifecycle events emitted by delegated/background agent
+/// execution. Bridge-facing worker updates still derive a string status
+/// from these variants, but the runtime no longer passes raw status
+/// strings around internally.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum WorkerEvent {
+    WorkerSpawned,
+    WorkerCompleted,
+    WorkerFailed,
+    WorkerCancelled,
+}
+
+impl WorkerEvent {
+    pub fn as_status(self) -> &'static str {
+        match self {
+            Self::WorkerSpawned => "running",
+            Self::WorkerCompleted => "completed",
+            Self::WorkerFailed => "failed",
+            Self::WorkerCancelled => "cancelled",
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WorkerSpawned => "WorkerSpawned",
+            Self::WorkerCompleted => "WorkerCompleted",
+            Self::WorkerFailed => "WorkerFailed",
+            Self::WorkerCancelled => "WorkerCancelled",
+        }
+    }
+}
+
 /// Status of a tool call. Mirrors ACP's `toolCallStatus`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -79,6 +79,7 @@ pub fn reset_thread_local_state() {
     llm_config::clear_user_overrides();
     http::reset_http_state();
     stdlib::reset_stdlib_state();
+    orchestration::clear_runtime_hooks();
     events::reset_event_sinks();
     agent_events::reset_all_sinks();
     agent_sessions::reset_session_store();

--- a/crates/harn-vm/src/llm/agent/post_turn.rs
+++ b/crates/harn-vm/src/llm/agent/post_turn.rs
@@ -77,6 +77,24 @@ pub(super) struct PostTurnContext<'a> {
     pub iteration: usize,
 }
 
+async fn emit_post_agent_turn_hook(
+    session_id: &str,
+    _iteration: usize,
+    turn: serde_json::Value,
+) -> Result<(), VmError> {
+    crate::orchestration::run_lifecycle_hooks(
+        crate::orchestration::HookEvent::PostAgentTurn,
+        &serde_json::json!({
+            "event": crate::orchestration::HookEvent::PostAgentTurn.as_str(),
+            "session": {
+                "id": session_id,
+            },
+            "turn": turn,
+        }),
+    )
+    .await
+}
+
 pub(super) async fn run_post_turn(
     state: &mut AgentLoopState,
     opts: &mut super::super::api::LlmCallOptions,
@@ -146,10 +164,16 @@ pub(super) async fn run_post_turn(
             "successful_tool_names": successful_tool_names,
             "tool_count": call_result.tool_calls.len(),
             "iteration": iteration,
+            "failed": dispatch
+                .tool_results_this_iter
+                .iter()
+                .any(|result| result["status"].as_str() != Some("ok"))
+                || !call_result.tool_parse_errors.is_empty(),
             "consecutive_single_tool_turns": state.consecutive_single_tool_turns,
             "session_tools_used": state.all_tools_used,
             "session_successful_tools": state.successful_tools_used,
         });
+        emit_post_agent_turn_hook(ctx.session_id, iteration, turn_info.clone()).await?;
         super::emit_agent_event(&AgentEvent::TurnEnd {
             session_id: ctx.session_id.to_string(),
             iteration,
@@ -277,6 +301,17 @@ pub(super) async fn run_post_turn(
                 "content": assistant_content_for_history,
             }),
         );
+        emit_post_agent_turn_hook(
+            ctx.session_id,
+            iteration,
+            serde_json::json!({
+                "iteration": iteration,
+                "failed": false,
+                "sentinel_hit": true,
+                "text": call_result.text.clone(),
+            }),
+        )
+        .await?;
         return Ok(IterationOutcome::Break);
     }
 
@@ -291,6 +326,17 @@ pub(super) async fn run_post_turn(
         );
         call_result.tool_parse_errors.clear();
         state.consecutive_text_only = 0;
+        emit_post_agent_turn_hook(
+            ctx.session_id,
+            iteration,
+            serde_json::json!({
+                "iteration": iteration,
+                "failed": true,
+                "parse_error": true,
+                "text": call_result.text.clone(),
+            }),
+        )
+        .await?;
         return Ok(IterationOutcome::Continue);
     }
 
@@ -319,6 +365,17 @@ pub(super) async fn run_post_turn(
                 tail_excerpt,
             })
             .await;
+            emit_post_agent_turn_hook(
+                ctx.session_id,
+                iteration,
+                serde_json::json!({
+                    "iteration": iteration,
+                    "failed": true,
+                    "status": "stuck",
+                    "text": call_result.text.clone(),
+                }),
+            )
+            .await?;
             return Ok(IterationOutcome::Break);
         }
         let guidance =
@@ -336,6 +393,17 @@ pub(super) async fn run_post_turn(
                 ),
             ),
         );
+        emit_post_agent_turn_hook(
+            ctx.session_id,
+            iteration,
+            serde_json::json!({
+                "iteration": iteration,
+                "failed": true,
+                "action_required": true,
+                "text": call_result.text.clone(),
+            }),
+        )
+        .await?;
         return Ok(IterationOutcome::Continue);
     }
 
@@ -355,6 +423,16 @@ pub(super) async fn run_post_turn(
     );
 
     if !ctx.persistent && !ctx.daemon {
+        emit_post_agent_turn_hook(
+            ctx.session_id,
+            iteration,
+            serde_json::json!({
+                "iteration": iteration,
+                "failed": false,
+                "text": call_result.text.clone(),
+            }),
+        )
+        .await?;
         return Ok(IterationOutcome::Break);
     }
 
@@ -391,6 +469,17 @@ pub(super) async fn run_post_turn(
                 .or(state.daemon_snapshot_path.take());
         if !ctx.daemon_config.has_wake_source(ctx.bridge.is_some()) {
             state.final_status = "idle";
+            emit_post_agent_turn_hook(
+                ctx.session_id,
+                iteration,
+                serde_json::json!({
+                    "iteration": iteration,
+                    "failed": false,
+                    "status": "idle",
+                    "text": call_result.text.clone(),
+                }),
+            )
+            .await?;
             return Ok(IterationOutcome::Break);
         }
         let watchdog_limit = ctx.daemon_config.idle_watchdog_attempts;
@@ -498,12 +587,34 @@ pub(super) async fn run_post_turn(
                     })
                     .await;
                     state.final_status = "watchdog";
+                    emit_post_agent_turn_hook(
+                        ctx.session_id,
+                        iteration,
+                        serde_json::json!({
+                            "iteration": iteration,
+                            "failed": true,
+                            "status": "watchdog",
+                            "text": call_result.text.clone(),
+                        }),
+                    )
+                    .await?;
                     return Ok(IterationOutcome::Break);
                 }
             }
             ctx.daemon_config
                 .update_idle_backoff(&mut state.idle_backoff_ms);
         }
+        emit_post_agent_turn_hook(
+            ctx.session_id,
+            iteration,
+            serde_json::json!({
+                "iteration": iteration,
+                "failed": false,
+                "status": "daemon_wake",
+                "text": call_result.text.clone(),
+            }),
+        )
+        .await?;
         return Ok(IterationOutcome::Continue);
     }
 
@@ -526,6 +637,17 @@ pub(super) async fn run_post_turn(
     if !finish_step_messages.is_empty() {
         state.consecutive_text_only = 0;
         state.idle_backoff_ms = 100;
+        emit_post_agent_turn_hook(
+            ctx.session_id,
+            iteration,
+            serde_json::json!({
+                "iteration": iteration,
+                "failed": false,
+                "status": "host_input",
+                "text": call_result.text.clone(),
+            }),
+        )
+        .await?;
         return Ok(IterationOutcome::Continue);
     }
 
@@ -548,6 +670,17 @@ pub(super) async fn run_post_turn(
             tail_excerpt,
         })
         .await;
+        emit_post_agent_turn_hook(
+            ctx.session_id,
+            iteration,
+            serde_json::json!({
+                "iteration": iteration,
+                "failed": true,
+                "status": "stuck",
+                "text": call_result.text.clone(),
+            }),
+        )
+        .await?;
         return Ok(IterationOutcome::Break);
     }
 
@@ -559,5 +692,16 @@ pub(super) async fn run_post_turn(
         &mut state.recorded_messages,
         runtime_feedback_message("nudge", nudge),
     );
+    emit_post_agent_turn_hook(
+        ctx.session_id,
+        iteration,
+        serde_json::json!({
+            "iteration": iteration,
+            "failed": false,
+            "status": "continue",
+            "text": call_result.text.clone(),
+        }),
+    )
+    .await?;
     Ok(IterationOutcome::Continue)
 }

--- a/crates/harn-vm/src/llm/agent/tool_dispatch.rs
+++ b/crates/harn-vm/src/llm/agent/tool_dispatch.rs
@@ -578,7 +578,7 @@ pub(super) async fn run_tool_dispatch(
         }
 
         // PreToolUse hooks: in-process hooks first, then bridge gate
-        match crate::orchestration::run_pre_tool_hooks(tool_name, &tool_args) {
+        match crate::orchestration::run_pre_tool_hooks(tool_name, &tool_args).await? {
             crate::orchestration::PreToolAction::Allow => {}
             crate::orchestration::PreToolAction::Deny(reason) => {
                 let result_text = render_tool_result(&denied_tool_result(tool_name, reason));
@@ -849,7 +849,8 @@ pub(super) async fn run_tool_dispatch(
             serde_json::json!(result_text.len()),
         );
 
-        let result_text = crate::orchestration::run_post_tool_hooks(tool_name, &result_text);
+        let result_text =
+            crate::orchestration::run_post_tool_hooks(tool_name, &tool_args, &result_text).await?;
 
         super::emit_agent_event(&AgentEvent::ToolCallUpdate {
             session_id: ctx.session_id.to_string(),

--- a/crates/harn-vm/src/llm/agent/turn_preflight.rs
+++ b/crates/harn-vm/src/llm/agent/turn_preflight.rs
@@ -122,6 +122,21 @@ pub(super) async fn run_turn_preflight(
     let mut call_messages = state.visible_messages.clone();
     let call_system = default_system;
 
+    crate::orchestration::run_lifecycle_hooks(
+        crate::orchestration::HookEvent::PreAgentTurn,
+        &serde_json::json!({
+            "event": crate::orchestration::HookEvent::PreAgentTurn.as_str(),
+            "session": {
+                "id": ctx.session_id,
+            },
+            "turn": {
+                "iteration": ctx.iteration,
+                "total_iterations": state.total_iterations,
+            },
+        }),
+    )
+    .await?;
+
     // Emit TurnStart before draining pending feedback so subscribers
     // see the boundary before any drain-generated injections land.
     emit_agent_event(&AgentEvent::TurnStart {

--- a/crates/harn-vm/src/orchestration/hooks.rs
+++ b/crates/harn-vm/src/orchestration/hooks.rs
@@ -1,7 +1,58 @@
-//! Tool lifecycle hooks — pre/post-execution interception.
+//! Runtime lifecycle hooks — tool, agent-turn, and worker interception.
 
 use std::cell::RefCell;
 use std::rc::Rc;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::agent_events::WorkerEvent;
+use crate::value::{VmClosure, VmError, VmValue};
+
+/// Manifest / runtime hook event names.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum HookEvent {
+    #[serde(rename = "PreToolUse")]
+    PreToolUse,
+    #[serde(rename = "PostToolUse")]
+    PostToolUse,
+    #[serde(rename = "PreAgentTurn")]
+    PreAgentTurn,
+    #[serde(rename = "PostAgentTurn")]
+    PostAgentTurn,
+    #[serde(rename = "WorkerSpawned")]
+    WorkerSpawned,
+    #[serde(rename = "WorkerCompleted")]
+    WorkerCompleted,
+    #[serde(rename = "WorkerFailed")]
+    WorkerFailed,
+    #[serde(rename = "WorkerCancelled")]
+    WorkerCancelled,
+}
+
+impl HookEvent {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PreToolUse => "PreToolUse",
+            Self::PostToolUse => "PostToolUse",
+            Self::PreAgentTurn => "PreAgentTurn",
+            Self::PostAgentTurn => "PostAgentTurn",
+            Self::WorkerSpawned => "WorkerSpawned",
+            Self::WorkerCompleted => "WorkerCompleted",
+            Self::WorkerFailed => "WorkerFailed",
+            Self::WorkerCancelled => "WorkerCancelled",
+        }
+    }
+
+    pub fn from_worker_event(event: WorkerEvent) -> Self {
+        match event {
+            WorkerEvent::WorkerSpawned => Self::WorkerSpawned,
+            WorkerEvent::WorkerCompleted => Self::WorkerCompleted,
+            WorkerEvent::WorkerFailed => Self::WorkerFailed,
+            WorkerEvent::WorkerCancelled => Self::WorkerCancelled,
+        }
+    }
+}
 
 /// Action returned by a PreToolUse hook.
 #[derive(Clone, Debug)]
@@ -23,7 +74,7 @@ pub enum PostToolAction {
     Modify(String),
 }
 
-/// Callback types for tool lifecycle hooks.
+/// Callback types for legacy tool lifecycle hooks.
 pub type PreToolHookFn = Rc<dyn Fn(&str, &serde_json::Value) -> PreToolAction>;
 pub type PostToolHookFn = Rc<dyn Fn(&str, &str) -> PostToolAction>;
 
@@ -48,8 +99,55 @@ impl std::fmt::Debug for ToolHook {
     }
 }
 
+#[derive(Clone)]
+enum PatternMatcher {
+    ToolNameGlob(String),
+    EventExpression(String),
+}
+
+impl std::fmt::Debug for PatternMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ToolNameGlob(pattern) => f.debug_tuple("ToolNameGlob").field(pattern).finish(),
+            Self::EventExpression(pattern) => {
+                f.debug_tuple("EventExpression").field(pattern).finish()
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+enum RuntimeHookHandler {
+    NativePreTool(PreToolHookFn),
+    NativePostTool(PostToolHookFn),
+    Vm {
+        handler_name: String,
+        closure: Rc<VmClosure>,
+    },
+}
+
+impl std::fmt::Debug for RuntimeHookHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NativePreTool(_) => f.write_str("NativePreTool(..)"),
+            Self::NativePostTool(_) => f.write_str("NativePostTool(..)"),
+            Self::Vm { handler_name, .. } => f
+                .debug_struct("Vm")
+                .field("handler_name", handler_name)
+                .finish(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RuntimeHook {
+    event: HookEvent,
+    matcher: PatternMatcher,
+    handler: RuntimeHookHandler,
+}
+
 thread_local! {
-    pub(super) static TOOL_HOOKS: RefCell<Vec<ToolHook>> = const { RefCell::new(Vec::new()) };
+    static RUNTIME_HOOKS: RefCell<Vec<RuntimeHook>> = const { RefCell::new(Vec::new()) };
 }
 
 pub(crate) fn glob_match(pattern: &str, name: &str) -> bool {
@@ -66,58 +164,287 @@ pub(crate) fn glob_match(pattern: &str, name: &str) -> bool {
 }
 
 pub fn register_tool_hook(hook: ToolHook) {
-    TOOL_HOOKS.with(|hooks| hooks.borrow_mut().push(hook));
+    if let Some(pre) = hook.pre {
+        RUNTIME_HOOKS.with(|hooks| {
+            hooks.borrow_mut().push(RuntimeHook {
+                event: HookEvent::PreToolUse,
+                matcher: PatternMatcher::ToolNameGlob(hook.pattern.clone()),
+                handler: RuntimeHookHandler::NativePreTool(pre),
+            });
+        });
+    }
+    if let Some(post) = hook.post {
+        RUNTIME_HOOKS.with(|hooks| {
+            hooks.borrow_mut().push(RuntimeHook {
+                event: HookEvent::PostToolUse,
+                matcher: PatternMatcher::ToolNameGlob(hook.pattern),
+                handler: RuntimeHookHandler::NativePostTool(post),
+            });
+        });
+    }
+}
+
+pub fn register_vm_hook(
+    event: HookEvent,
+    pattern: impl Into<String>,
+    handler_name: impl Into<String>,
+    closure: Rc<VmClosure>,
+) {
+    RUNTIME_HOOKS.with(|hooks| {
+        hooks.borrow_mut().push(RuntimeHook {
+            event,
+            matcher: PatternMatcher::EventExpression(pattern.into()),
+            handler: RuntimeHookHandler::Vm {
+                handler_name: handler_name.into(),
+                closure,
+            },
+        });
+    });
 }
 
 pub fn clear_tool_hooks() {
-    TOOL_HOOKS.with(|hooks| hooks.borrow_mut().clear());
+    RUNTIME_HOOKS.with(|hooks| {
+        hooks
+            .borrow_mut()
+            .retain(|hook| !matches!(hook.event, HookEvent::PreToolUse | HookEvent::PostToolUse));
+    });
+}
+
+pub fn clear_runtime_hooks() {
+    RUNTIME_HOOKS.with(|hooks| hooks.borrow_mut().clear());
+}
+
+fn value_at_path<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for segment in path.split('.') {
+        let serde_json::Value::Object(map) = current else {
+            return None;
+        };
+        current = map.get(segment)?;
+    }
+    Some(current)
+}
+
+fn value_truthy(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Null => false,
+        serde_json::Value::Bool(value) => *value,
+        serde_json::Value::Number(value) => value
+            .as_i64()
+            .map(|number| number != 0)
+            .or_else(|| value.as_u64().map(|number| number != 0))
+            .or_else(|| value.as_f64().map(|number| number != 0.0))
+            .unwrap_or(false),
+        serde_json::Value::String(value) => !value.is_empty(),
+        serde_json::Value::Array(values) => !values.is_empty(),
+        serde_json::Value::Object(values) => !values.is_empty(),
+    }
+}
+
+fn value_to_pattern_string(value: Option<&serde_json::Value>) -> String {
+    match value {
+        Some(serde_json::Value::String(text)) => text.clone(),
+        Some(other) => other.to_string(),
+        None => String::new(),
+    }
+}
+
+fn strip_quoted(value: &str) -> &str {
+    value
+        .trim()
+        .strip_prefix('"')
+        .and_then(|text| text.strip_suffix('"'))
+        .or_else(|| {
+            value
+                .trim()
+                .strip_prefix('\'')
+                .and_then(|text| text.strip_suffix('\''))
+        })
+        .unwrap_or(value.trim())
+}
+
+fn expression_matches(pattern: &str, payload: &serde_json::Value) -> bool {
+    let pattern = pattern.trim();
+    if pattern.is_empty() || pattern == "*" {
+        return true;
+    }
+    if let Some((lhs, rhs)) = pattern.split_once("=~") {
+        let value = value_to_pattern_string(value_at_path(payload, lhs.trim()));
+        let regex = strip_quoted(rhs);
+        return Regex::new(regex).is_ok_and(|compiled| compiled.is_match(&value));
+    }
+    if let Some((lhs, rhs)) = pattern.split_once("==") {
+        let value = value_to_pattern_string(value_at_path(payload, lhs.trim()));
+        return value == strip_quoted(rhs);
+    }
+    if let Some((lhs, rhs)) = pattern.split_once("!=") {
+        let value = value_to_pattern_string(value_at_path(payload, lhs.trim()));
+        return value != strip_quoted(rhs);
+    }
+    if pattern.contains('.') {
+        return value_at_path(payload, pattern).is_some_and(value_truthy);
+    }
+    glob_match(
+        pattern,
+        &value_to_pattern_string(value_at_path(payload, "tool.name")),
+    )
+}
+
+fn hook_matches(hook: &RuntimeHook, tool_name: Option<&str>, payload: &serde_json::Value) -> bool {
+    match &hook.matcher {
+        PatternMatcher::ToolNameGlob(pattern) => {
+            tool_name.is_some_and(|candidate| glob_match(pattern, candidate))
+        }
+        PatternMatcher::EventExpression(pattern) => expression_matches(pattern, payload),
+    }
+}
+
+async fn invoke_vm_hook(
+    closure: &Rc<VmClosure>,
+    payload: &serde_json::Value,
+) -> Result<VmValue, VmError> {
+    let Some(mut vm) = crate::vm::clone_async_builtin_child_vm() else {
+        return Err(VmError::Runtime(
+            "runtime hook requires an async builtin VM context".to_string(),
+        ));
+    };
+    let arg = crate::stdlib::json_to_vm_value(payload);
+    vm.call_closure_pub(closure, &[arg], &[]).await
+}
+
+fn parse_pre_tool_result(value: VmValue) -> Result<PreToolAction, VmError> {
+    match value {
+        VmValue::Nil => Ok(PreToolAction::Allow),
+        VmValue::Dict(map) => {
+            if let Some(reason) = map.get("deny") {
+                return Ok(PreToolAction::Deny(reason.display()));
+            }
+            if let Some(args) = map.get("args") {
+                return Ok(PreToolAction::Modify(crate::llm::vm_value_to_json(args)));
+            }
+            Ok(PreToolAction::Allow)
+        }
+        other => Err(VmError::Runtime(format!(
+            "PreToolUse hook must return nil or {{deny, args}}, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_post_tool_result(value: VmValue) -> Result<PostToolAction, VmError> {
+    match value {
+        VmValue::Nil => Ok(PostToolAction::Pass),
+        VmValue::String(text) => Ok(PostToolAction::Modify(text.to_string())),
+        VmValue::Dict(map) => {
+            if let Some(result) = map.get("result") {
+                return Ok(PostToolAction::Modify(result.display()));
+            }
+            Ok(PostToolAction::Pass)
+        }
+        other => Err(VmError::Runtime(format!(
+            "PostToolUse hook must return nil, string, or {{result}}, got {}",
+            other.type_name()
+        ))),
+    }
 }
 
 /// Run all matching PreToolUse hooks. Returns the final action.
-pub fn run_pre_tool_hooks(tool_name: &str, args: &serde_json::Value) -> PreToolAction {
-    TOOL_HOOKS.with(|hooks| {
-        let hooks = hooks.borrow();
-        let mut current_args = args.clone();
-        for hook in hooks.iter() {
-            if !glob_match(&hook.pattern, tool_name) {
-                continue;
+pub async fn run_pre_tool_hooks(
+    tool_name: &str,
+    args: &serde_json::Value,
+) -> Result<PreToolAction, VmError> {
+    let hooks = RUNTIME_HOOKS.with(|hooks| hooks.borrow().clone());
+    let mut current_args = args.clone();
+    for hook in hooks
+        .iter()
+        .filter(|hook| hook.event == HookEvent::PreToolUse)
+    {
+        let payload = serde_json::json!({
+            "event": HookEvent::PreToolUse.as_str(),
+            "tool": {
+                "name": tool_name,
+                "args": current_args.clone(),
+            },
+        });
+        if !hook_matches(hook, Some(tool_name), &payload) {
+            continue;
+        }
+        let action = match &hook.handler {
+            RuntimeHookHandler::NativePreTool(pre) => pre(tool_name, &current_args),
+            RuntimeHookHandler::Vm { closure, .. } => {
+                parse_pre_tool_result(invoke_vm_hook(closure, &payload).await?)?
             }
-            if let Some(ref pre) = hook.pre {
-                match pre(tool_name, &current_args) {
-                    PreToolAction::Allow => {}
-                    PreToolAction::Deny(reason) => return PreToolAction::Deny(reason),
-                    PreToolAction::Modify(new_args) => {
-                        current_args = new_args;
-                    }
-                }
+            RuntimeHookHandler::NativePostTool(_) => continue,
+        };
+        match action {
+            PreToolAction::Allow => {}
+            PreToolAction::Deny(reason) => return Ok(PreToolAction::Deny(reason)),
+            PreToolAction::Modify(new_args) => {
+                current_args = new_args;
             }
         }
-        if current_args != *args {
-            PreToolAction::Modify(current_args)
-        } else {
-            PreToolAction::Allow
-        }
-    })
+    }
+    if current_args != *args {
+        Ok(PreToolAction::Modify(current_args))
+    } else {
+        Ok(PreToolAction::Allow)
+    }
 }
 
 /// Run all matching PostToolUse hooks. Returns the (possibly modified) result.
-pub fn run_post_tool_hooks(tool_name: &str, result: &str) -> String {
-    TOOL_HOOKS.with(|hooks| {
-        let hooks = hooks.borrow();
-        let mut current = result.to_string();
-        for hook in hooks.iter() {
-            if !glob_match(&hook.pattern, tool_name) {
-                continue;
+pub async fn run_post_tool_hooks(
+    tool_name: &str,
+    args: &serde_json::Value,
+    result: &str,
+) -> Result<String, VmError> {
+    let hooks = RUNTIME_HOOKS.with(|hooks| hooks.borrow().clone());
+    let mut current = result.to_string();
+    for hook in hooks
+        .iter()
+        .filter(|hook| hook.event == HookEvent::PostToolUse)
+    {
+        let payload = serde_json::json!({
+            "event": HookEvent::PostToolUse.as_str(),
+            "tool": {
+                "name": tool_name,
+                "args": args,
+            },
+            "result": {
+                "text": current.clone(),
+            },
+        });
+        if !hook_matches(hook, Some(tool_name), &payload) {
+            continue;
+        }
+        let action = match &hook.handler {
+            RuntimeHookHandler::NativePostTool(post) => post(tool_name, &current),
+            RuntimeHookHandler::Vm { closure, .. } => {
+                parse_post_tool_result(invoke_vm_hook(closure, &payload).await?)?
             }
-            if let Some(ref post) = hook.post {
-                match post(tool_name, &current) {
-                    PostToolAction::Pass => {}
-                    PostToolAction::Modify(new_result) => {
-                        current = new_result;
-                    }
-                }
+            RuntimeHookHandler::NativePreTool(_) => continue,
+        };
+        match action {
+            PostToolAction::Pass => {}
+            PostToolAction::Modify(new_result) => {
+                current = new_result;
             }
         }
-        current
-    })
+    }
+    Ok(current)
+}
+
+pub async fn run_lifecycle_hooks(
+    event: HookEvent,
+    payload: &serde_json::Value,
+) -> Result<(), VmError> {
+    let hooks = RUNTIME_HOOKS.with(|hooks| hooks.borrow().clone());
+    for hook in hooks.iter().filter(|hook| hook.event == event) {
+        if !hook_matches(hook, None, payload) {
+            continue;
+        }
+        if let RuntimeHookHandler::Vm { closure, .. } = &hook.handler {
+            let _ = invoke_vm_hook(closure, payload).await?;
+        }
+    }
+    Ok(())
 }

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -661,8 +661,8 @@ fn normalize_run_record_preserves_trace_spans() {
     );
 }
 
-#[test]
-fn pre_tool_hook_deny_blocks_execution() {
+#[tokio::test(flavor = "current_thread")]
+async fn pre_tool_hook_deny_blocks_execution() {
     clear_tool_hooks();
     register_tool_hook(ToolHook {
         pattern: "dangerous_*".to_string(),
@@ -671,26 +671,30 @@ fn pre_tool_hook_deny_blocks_execution() {
         })),
         post: None,
     });
-    let result = run_pre_tool_hooks("dangerous_delete", &serde_json::json!({}));
+    let result = run_pre_tool_hooks("dangerous_delete", &serde_json::json!({}))
+        .await
+        .expect("hook result");
     clear_tool_hooks();
     assert!(matches!(result, PreToolAction::Deny(_)));
 }
 
-#[test]
-fn pre_tool_hook_allow_passes_through() {
+#[tokio::test(flavor = "current_thread")]
+async fn pre_tool_hook_allow_passes_through() {
     clear_tool_hooks();
     register_tool_hook(ToolHook {
         pattern: "safe_*".to_string(),
         pre: Some(Rc::new(|_name, _args| PreToolAction::Allow)),
         post: None,
     });
-    let result = run_pre_tool_hooks("safe_read", &serde_json::json!({}));
+    let result = run_pre_tool_hooks("safe_read", &serde_json::json!({}))
+        .await
+        .expect("hook result");
     clear_tool_hooks();
     assert!(matches!(result, PreToolAction::Allow));
 }
 
-#[test]
-fn pre_tool_hook_modify_rewrites_args() {
+#[tokio::test(flavor = "current_thread")]
+async fn pre_tool_hook_modify_rewrites_args() {
     clear_tool_hooks();
     register_tool_hook(ToolHook {
         pattern: "*".to_string(),
@@ -699,7 +703,9 @@ fn pre_tool_hook_modify_rewrites_args() {
         })),
         post: None,
     });
-    let result = run_pre_tool_hooks("read_file", &serde_json::json!({"path": "/etc/passwd"}));
+    let result = run_pre_tool_hooks("read_file", &serde_json::json!({"path": "/etc/passwd"}))
+        .await
+        .expect("hook result");
     clear_tool_hooks();
     match result {
         PreToolAction::Modify(args) => assert_eq!(args["path"], "/sanitized"),
@@ -707,8 +713,8 @@ fn pre_tool_hook_modify_rewrites_args() {
     }
 }
 
-#[test]
-fn post_tool_hook_modifies_result() {
+#[tokio::test(flavor = "current_thread")]
+async fn post_tool_hook_modifies_result() {
     clear_tool_hooks();
     register_tool_hook(ToolHook {
         pattern: "exec".to_string(),
@@ -721,15 +727,19 @@ fn post_tool_hook_modifies_result() {
             }
         })),
     });
-    let result = run_post_tool_hooks("exec", "output with SECRET data");
-    let clean = run_post_tool_hooks("exec", "clean output");
+    let result = run_post_tool_hooks("exec", &serde_json::json!({}), "output with SECRET data")
+        .await
+        .expect("hook result");
+    let clean = run_post_tool_hooks("exec", &serde_json::json!({}), "clean output")
+        .await
+        .expect("hook result");
     clear_tool_hooks();
     assert_eq!(result, "[REDACTED]");
     assert_eq!(clean, "clean output");
 }
 
-#[test]
-fn unmatched_hook_pattern_does_not_fire() {
+#[tokio::test(flavor = "current_thread")]
+async fn unmatched_hook_pattern_does_not_fire() {
     clear_tool_hooks();
     register_tool_hook(ToolHook {
         pattern: "exec".to_string(),
@@ -738,7 +748,9 @@ fn unmatched_hook_pattern_does_not_fire() {
         })),
         post: None,
     });
-    let result = run_pre_tool_hooks("read_file", &serde_json::json!({}));
+    let result = run_pre_tool_hooks("read_file", &serde_json::json!({}))
+        .await
+        .expect("hook result");
     clear_tool_hooks();
     assert!(matches!(result, PreToolAction::Allow));
 }

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -22,8 +22,8 @@ use std::sync::Arc;
 use self::agents_workers::{
     apply_worker_artifact_policy, emit_worker_event, load_worker_state_snapshot, next_worker_id,
     parse_worker_config, persist_worker_state_snapshot, spawn_worker_task, with_worker_state,
-    worker_id_from_value, worker_request_for_config, worker_snapshot_path, worker_summary,
-    WorkerConfig, WorkerState, WORKER_REGISTRY,
+    worker_event_snapshot, worker_id_from_value, worker_request_for_config, worker_snapshot_path,
+    worker_summary, WorkerConfig, WorkerState, WORKER_REGISTRY,
 };
 use self::sub_agent::{execute_sub_agent, parse_sub_agent_request};
 use crate::orchestration::{
@@ -413,12 +413,13 @@ pub(crate) fn register_agent_builtins(vm: &mut Vm) {
         Ok(summary)
     });
 
-    vm.register_builtin("close_agent", |args, _out| {
+    vm.register_async_builtin("close_agent", |args| async move {
         let target = args
             .first()
             .ok_or_else(|| VmError::Runtime("close_agent: missing worker handle".to_string()))?;
         let worker_id = worker_id_from_value(target)?;
-        with_worker_state(&worker_id, |state| {
+        let state = with_worker_state(&worker_id, |state| Ok(state.clone()))?;
+        let (snapshot, summary) = {
             let mut worker = state.borrow_mut();
             worker.cancel_token.store(true, Ordering::SeqCst);
             if let Some(handle) = worker.handle.take() {
@@ -430,10 +431,12 @@ pub(crate) fn register_agent_builtins(vm: &mut Vm) {
             if worker.carry_policy.persist_state {
                 persist_worker_state_snapshot(&worker)?;
             }
-            emit_worker_event(&worker, "cancelled");
+            let snapshot = worker_event_snapshot(&worker);
             let summary = worker_summary(&worker)?;
-            Ok(summary)
-        })
+            (snapshot, summary)
+        };
+        emit_worker_event(&snapshot, crate::agent_events::WorkerEvent::WorkerCancelled).await?;
+        Ok(summary)
     });
 
     vm.register_builtin("list_agents", |_args, _out| {

--- a/crates/harn-vm/src/stdlib/agents_workers/bridge.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/bridge.rs
@@ -1,5 +1,8 @@
 use std::path::PathBuf;
 
+use crate::agent_events::WorkerEvent;
+use crate::orchestration::MutationSessionRecord;
+
 use super::{worker_provenance, WorkerState};
 
 fn worker_bridge_metadata(state: &WorkerState) -> serde_json::Value {
@@ -24,28 +27,67 @@ fn worker_bridge_metadata(state: &WorkerState) -> serde_json::Value {
     })
 }
 
-pub(in super::super) fn emit_worker_event(state: &WorkerState, status: &str) {
+pub(in super::super) struct WorkerEventSnapshot {
+    pub(in super::super) worker_id: String,
+    pub(in super::super) worker_name: String,
+    pub(in super::super) worker_task: String,
+    pub(in super::super) worker_mode: String,
+    pub(in super::super) metadata: serde_json::Value,
+    pub(in super::super) audit: MutationSessionRecord,
+}
+
+pub(in super::super) async fn emit_worker_event(
+    snapshot: &WorkerEventSnapshot,
+    event: WorkerEvent,
+) -> Result<(), crate::value::VmError> {
+    let status = event.as_status();
+    crate::orchestration::run_lifecycle_hooks(
+        crate::orchestration::HookEvent::from_worker_event(event),
+        &serde_json::json!({
+            "event": event.as_str(),
+            "worker": {
+                "id": snapshot.worker_id,
+                "name": snapshot.worker_name,
+                "task": snapshot.worker_task,
+                "mode": snapshot.worker_mode,
+                "status": status,
+                "metadata": snapshot.metadata.clone(),
+            },
+        }),
+    )
+    .await?;
     if let Some(bridge) = crate::llm::current_host_bridge() {
-        let metadata = worker_bridge_metadata(state);
         bridge.send_worker_update(
-            &state.id,
-            &state.name,
+            &snapshot.worker_id,
+            &snapshot.worker_name,
             status,
-            metadata.clone(),
-            Some(&state.audit),
+            snapshot.metadata.clone(),
+            Some(&snapshot.audit),
         );
         bridge.send_progress(
             "worker",
-            &format!("{} {}", state.name, status),
+            &format!("{} {}", snapshot.worker_name, status),
             None,
             None,
             Some(serde_json::json!({
-                "worker_id": state.id,
-                "worker_name": state.name,
+                "worker_id": snapshot.worker_id,
+                "worker_name": snapshot.worker_name,
                 "status": status,
-                "metadata": metadata,
+                "metadata": snapshot.metadata,
             })),
         );
+    }
+    Ok(())
+}
+
+pub(in super::super) fn worker_event_snapshot(state: &WorkerState) -> WorkerEventSnapshot {
+    WorkerEventSnapshot {
+        worker_id: state.id.clone(),
+        worker_name: state.name.clone(),
+        worker_task: state.task.clone(),
+        worker_mode: state.mode.clone(),
+        metadata: worker_bridge_metadata(state),
+        audit: state.audit.clone(),
     }
 }
 

--- a/crates/harn-vm/src/stdlib/agents_workers/execution.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/execution.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use super::bridge::{emit_worker_event, worker_snapshot_path};
+use super::bridge::{emit_worker_event, worker_event_snapshot, worker_snapshot_path};
 use super::config::{parse_execution_profile_json, persist_worker_state_snapshot};
 use super::worktree::{
     cleanup_worker_execution, ensure_worker_worktree, WorkerMutationSessionResetGuard,
@@ -14,6 +14,7 @@ use super::{
     WorkerCarryPolicy, WorkerConfig, WorkerExecutionProfile, WorkerExecutionResult, WorkerState,
     WORKER_REGISTRY,
 };
+use crate::agent_events::WorkerEvent;
 use crate::orchestration::{
     current_approval_policy, current_execution_policy, pop_execution_policy, push_execution_policy,
     ArtifactRecord, ContextPolicy, MutationSessionRecord,
@@ -155,7 +156,6 @@ pub(in super::super) fn spawn_worker_task(state: Rc<RefCell<WorkerState>>) {
         if worker.carry_policy.persist_state {
             persist_worker_state_snapshot(&worker).ok();
         }
-        emit_worker_event(&worker, "running");
         (
             worker.id.clone(),
             worker.task.clone(),
@@ -176,6 +176,11 @@ pub(in super::super) fn spawn_worker_task(state: Rc<RefCell<WorkerState>>) {
                 category: crate::value::ErrorCategory::Cancelled,
             });
         }
+        let spawned_snapshot = {
+            let worker = state_for_task.borrow();
+            worker_event_snapshot(&worker)
+        };
+        emit_worker_event(&spawned_snapshot, WorkerEvent::WorkerSpawned).await?;
 
         if let Some(ref policy) = worker_policy {
             push_execution_policy(policy.clone());
@@ -192,54 +197,64 @@ pub(in super::super) fn spawn_worker_task(state: Rc<RefCell<WorkerState>>) {
             pop_execution_policy();
         }
         {
-            let mut worker = state_for_task.borrow_mut();
-            worker.finished_at = Some(uuid::Uuid::now_v7().to_string());
-            match &result {
-                Ok(executed) => {
-                    worker.status = "completed".to_string();
-                    worker.latest_payload = Some(executed.payload.clone());
-                    worker.latest_error = None;
-                    worker.transcript = executed.transcript.clone();
-                    worker.artifacts = executed.artifacts.clone();
-                    worker.execution = executed.execution.clone();
-                    worker.child_run_id = executed
-                        .payload
-                        .get("run")
-                        .and_then(|run| run.get("id"))
-                        .and_then(|value| value.as_str())
-                        .map(|value| value.to_string());
-                    worker.child_run_path = executed
-                        .payload
-                        .get("path")
-                        .and_then(|value| value.as_str())
-                        .map(|value| value.to_string());
-                    if let Some(run_id) = &worker.child_run_id {
-                        worker.audit.run_id = Some(run_id.clone());
-                    }
-                    if worker.carry_policy.persist_state {
-                        persist_worker_state_snapshot(&worker).ok();
-                    }
-                    emit_worker_event(&worker, "completed");
-                }
-                Err(error) => {
-                    if matches!(
-                        error,
-                        VmError::CategorizedError {
-                            category: crate::value::ErrorCategory::Cancelled,
-                            ..
+            let completion_snapshot = {
+                let mut worker = state_for_task.borrow_mut();
+                worker.finished_at = Some(uuid::Uuid::now_v7().to_string());
+                match &result {
+                    Ok(executed) => {
+                        worker.status = "completed".to_string();
+                        worker.latest_payload = Some(executed.payload.clone());
+                        worker.latest_error = None;
+                        worker.transcript = executed.transcript.clone();
+                        worker.artifacts = executed.artifacts.clone();
+                        worker.execution = executed.execution.clone();
+                        worker.child_run_id = executed
+                            .payload
+                            .get("run")
+                            .and_then(|run| run.get("id"))
+                            .and_then(|value| value.as_str())
+                            .map(|value| value.to_string());
+                        worker.child_run_path = executed
+                            .payload
+                            .get("path")
+                            .and_then(|value| value.as_str())
+                            .map(|value| value.to_string());
+                        if let Some(run_id) = &worker.child_run_id {
+                            worker.audit.run_id = Some(run_id.clone());
                         }
-                    ) {
-                        worker.status = "cancelled".to_string();
-                    } else {
-                        worker.status = "failed".to_string();
+                        if worker.carry_policy.persist_state {
+                            persist_worker_state_snapshot(&worker).ok();
+                        }
                     }
-                    worker.latest_error = Some(error.to_string());
-                    if worker.carry_policy.persist_state {
-                        persist_worker_state_snapshot(&worker).ok();
+                    Err(error) => {
+                        if matches!(
+                            error,
+                            VmError::CategorizedError {
+                                category: crate::value::ErrorCategory::Cancelled,
+                                ..
+                            }
+                        ) {
+                            worker.status = "cancelled".to_string();
+                        } else {
+                            worker.status = "failed".to_string();
+                        }
+                        worker.latest_error = Some(error.to_string());
+                        if worker.carry_policy.persist_state {
+                            persist_worker_state_snapshot(&worker).ok();
+                        }
                     }
-                    emit_worker_event(&worker, &worker.status.clone());
                 }
-            }
+                worker_event_snapshot(&worker)
+            };
+            let event = match &result {
+                Ok(_) => WorkerEvent::WorkerCompleted,
+                Err(VmError::CategorizedError {
+                    category: crate::value::ErrorCategory::Cancelled,
+                    ..
+                }) => WorkerEvent::WorkerCancelled,
+                Err(_) => WorkerEvent::WorkerFailed,
+            };
+            emit_worker_event(&completion_snapshot, event).await?;
         }
         result
     });

--- a/crates/harn-vm/src/stdlib/agents_workers/mod.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/mod.rs
@@ -13,7 +13,7 @@ mod policy;
 mod worktree;
 
 pub(super) use audit::inherited_worker_audit;
-pub(super) use bridge::{emit_worker_event, worker_snapshot_path};
+pub(super) use bridge::{emit_worker_event, worker_event_snapshot, worker_snapshot_path};
 pub(super) use config::{
     load_worker_state_snapshot, parse_worker_config, parse_worker_execution_profile,
     persist_worker_state_snapshot,

--- a/crates/harn-vm/src/vm/modules.rs
+++ b/crates/harn-vm/src/vm/modules.rs
@@ -81,6 +81,22 @@ fn finalize_package_target(path: &Path) -> Option<PathBuf> {
     None
 }
 
+fn resolve_import_target(base: &Path, path: &str) -> PathBuf {
+    let mut file_path = base.join(path);
+
+    if !file_path.exists() && file_path.extension().is_none() {
+        file_path.set_extension("harn");
+    }
+
+    if !file_path.exists() {
+        if let Some(resolved) = resolve_package_import(base, path) {
+            file_path = resolved;
+        }
+    }
+
+    file_path
+}
+
 impl Vm {
     fn export_loaded_module(
         &mut self,
@@ -159,17 +175,7 @@ impl Vm {
                 .source_dir
                 .clone()
                 .unwrap_or_else(|| PathBuf::from("."));
-            let mut file_path = base.join(path);
-
-            if !file_path.exists() && file_path.extension().is_none() {
-                file_path.set_extension("harn");
-            }
-
-            if !file_path.exists() {
-                if let Some(resolved) = resolve_package_import(&base, path) {
-                    file_path = resolved;
-                }
-            }
+            let file_path = resolve_import_target(&base, path);
 
             let canonical = file_path
                 .canonicalize()
@@ -397,5 +403,48 @@ impl Vm {
         }
 
         Ok(exports)
+    }
+
+    /// Load a module by import path (`std/foo`, relative module path, or
+    /// package import) and return the exported function closures that a
+    /// wildcard import would expose.
+    pub async fn load_module_exports_from_import(
+        &mut self,
+        import_path: &str,
+    ) -> Result<BTreeMap<String, Rc<VmClosure>>, VmError> {
+        self.execute_import(import_path, None).await?;
+
+        if let Some(module) = import_path.strip_prefix("std/") {
+            let synthetic = PathBuf::from(format!("<stdlib>/{module}.harn"));
+            let loaded = self.module_cache.get(&synthetic).cloned().ok_or_else(|| {
+                VmError::Runtime(format!(
+                    "Import error: failed to cache loaded module '{}'",
+                    synthetic.display()
+                ))
+            })?;
+            let mut exports = BTreeMap::new();
+            let export_names: Vec<String> = if loaded.public_names.is_empty() {
+                loaded.functions.keys().cloned().collect()
+            } else {
+                loaded.public_names.iter().cloned().collect()
+            };
+            for name in export_names {
+                let Some(closure) = loaded.functions.get(&name) else {
+                    return Err(VmError::Runtime(format!(
+                        "Import error: exported function '{name}' is missing from {}",
+                        synthetic.display()
+                    )));
+                };
+                exports.insert(name, Rc::clone(closure));
+            }
+            return Ok(exports);
+        }
+
+        let base = self
+            .source_dir
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("."));
+        let file_path = resolve_import_target(&base, import_path);
+        self.load_module_exports(&file_path).await
     }
 }

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -3295,6 +3295,62 @@ When Harn starts from a file inside a workspace, it merges:
 Later layers win on key collisions; rule lists are prepended so package
 and project inference/tier overrides run before the built-in defaults.
 
+### `[[hooks]]` — declarative runtime hooks
+
+```toml
+[[hooks]]
+event = "PreToolUse"
+pattern = "tool.name =~ \"edit|write\""
+handler = "my_package::audit_edit"
+
+[[hooks]]
+event = "PostToolUse"
+pattern = "tool.name =~ \"read\""
+handler = "my_package::rewrite_read_result"
+```
+
+`[[hooks]]` installs runtime-owned lifecycle hooks from `harn.toml`
+before execution starts. Supported events today are:
+
+- `PreToolUse`
+- `PostToolUse`
+- `PreAgentTurn`
+- `PostAgentTurn`
+- `WorkerSpawned`
+- `WorkerCompleted`
+- `WorkerFailed`
+- `WorkerCancelled`
+
+The `handler` string uses `"<module>::<function>"`. For package-style
+handlers such as `my_package::audit_edit`, Harn resolves `my_package`
+to that manifest's `lib.harn`. Other module import paths may also be
+used when they resolve from the current source root.
+
+Pattern matching is payload-based:
+
+- `tool.name =~ "edit|write"` regex-matches a dotted field path
+- `turn.failed` checks the truthiness of a dotted field path
+- plain glob strings keep the legacy tool-name behavior (`"read_*"`)
+
+Handler payloads are dictionaries shaped by the event. Tool hooks always
+receive a `tool` object; post-tool hooks also receive `result.text`;
+agent-turn hooks receive `session.id` plus `turn`; worker hooks receive
+`worker`.
+
+Hook return values are event-specific:
+
+- `PreToolUse`: return `nil` / `{}` to allow, `{deny: "reason"}` to
+  reject, or `{args: <json>}` to replace tool arguments
+- `PostToolUse`: return `nil` to pass through, a string to replace the
+  result text, or `{result: "..."}` for the same replacement
+- other events: return value is ignored; handlers are for side effects
+
+Manifest-declared hooks are **process-scoped** on the current execution
+thread. Harn installs them once before the run starts, shares them
+across all agent sessions in that process, and clears them when the
+process/thread-local runtime state resets. They do not hot-reload in the
+middle of a session.
+
 ### `[lint]` — lint configuration
 
 ```toml


### PR DESCRIPTION
## Summary
- add declarative `[[hooks]]` manifest support and register those handlers before runtime execution starts
- extend runtime hooks beyond tool dispatch to agent-turn and typed worker lifecycle events, replacing the old stringly worker event reporting
- add conformance coverage for manifest hook registration, deny short-circuiting, and post-tool success behavior; document process scoping and note the work in CHANGELOG

## Validation
- make all
- pre-push hook (`make test`, conformance fmt check, markdown lint, portal lint)

closes #141