### PR TITLE
[codex] expand transcript_compact to wrap AutoCompactConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ granular archaeology.
   handle. The wrapper stores daemon metadata alongside the persisted
   runtime snapshot so resumable state dirs can be reopened
   ergonomically without changing daemon semantics.
+- **`transcript_compact(...)` now wraps the runtime-owned transcript
+  compaction engine (#142 part (a)).** The manual transcript
+  compaction surface now reuses `AutoCompactConfig` with `llm`,
+  `truncate`, and `observation_mask` strategies, supports prompt-
+  template overrides for LLM summaries, preserves pre-compaction
+  transcripts as durable embedded artifacts, and exposes compaction
+  events through both transcript observability and the live
+  `agent_subscribe` stream.
 
 ## v0.7.21
 

--- a/conformance/tests/stdlib/compact_transcript.expected
+++ b/conformance/tests/stdlib/compact_transcript.expected
@@ -1,0 +1,15 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/stdlib/compact_transcript.harn
+++ b/conformance/tests/stdlib/compact_transcript.harn
@@ -1,0 +1,99 @@
+pipeline test(task) {
+  let base = transcript_from_messages(
+    [
+    {role: "user", content: "Investigate parser drift."},
+    {role: "assistant", content: "I inspected the lexer and parser entrypoints."},
+    {role: "user", content: "Focus on diagnostics next."},
+    {role: "assistant", content: "I found three likely hotspots."},
+  ],
+  )
+  let truncated = transcript_compact(base, {strategy: "truncate", keep_last: 1, target_tokens: 1})
+  println(transcript_summary(truncated).contains("auto-compacted"))
+  println(transcript_events_by_kind(truncated, "compaction")[0].metadata?.strategy == "truncate")
+  let truncate_assets = transcript_assets(truncated)
+  println(len(truncate_assets) == 1)
+  println(len(transcript_messages(truncate_assets[0].data)) == 4)
+  var verbose_lines = ""
+  for i in range(0, 40) {
+    verbose_lines = verbose_lines + "verbose line " + to_string(i) + "\n"
+  }
+  let masked_base = transcript_from_messages(
+    [
+    {role: "assistant", content: "I ran the generator."},
+    {role: "user", content: "error: compile failed\n" + verbose_lines},
+    {role: "assistant", content: "I will inspect the failure."},
+    {role: "user", content: "All right."},
+  ],
+  )
+  let masked = transcript_compact(masked_base, {strategy: "observation_mask", keep_last: 1, target_tokens: 1})
+  println(transcript_summary(masked).contains("masked"))
+  println(transcript_events_by_kind(masked, "compaction")[0].metadata?.strategy == "observation_mask")
+  llm_mock_clear()
+  llm_mock({text: "LLM compact summary"})
+  let llm_compacted = transcript_compact(
+    base,
+    {
+    provider: "mock",
+    strategy: "llm",
+    keep_last: 1,
+    summarize_prompt: "compact_transcript_summary.harn.prompt",
+  },
+  )
+  println(transcript_summary(llm_compacted).contains("LLM compact summary"))
+  let llm_calls = llm_mock_calls()
+  let prompt = llm_calls[0].messages[0].content
+  println(prompt.contains("Compact prompt from asset."))
+  println(prompt.contains("Archived count: 2"))
+  let stream_session = agent_session_open("compact-stream-session")
+  agent_session_inject(stream_session, {role: "user", content: "one"})
+  agent_session_inject(stream_session, {role: "assistant", content: "two"})
+  agent_session_inject(stream_session, {role: "user", content: "three"})
+  agent_subscribe(
+    stream_session,
+    { ev ->
+    if ev?.type == "transcript_compacted" {
+      agent_session_inject(stream_session, {role: "assistant", content: "LIVE_COMPACTION_EVENT"})
+    }
+  },
+  )
+  let session_snapshot = agent_session_snapshot(stream_session)
+  let _ = transcript_compact(session_snapshot, {strategy: "truncate", keep_last: 1, target_tokens: 1})
+  println(
+    json_stringify(transcript_messages(agent_session_snapshot(stream_session)))
+    .contains(
+    "LIVE_COMPACTION_EVENT",
+  ),
+  )
+  let run = run_record(
+    {
+    _type: "run_record",
+    id: "compact-run",
+    workflow_id: "wf",
+    status: "completed",
+    stages: [
+    {id: "stage-truncate", node_id: "truncate", transcript: truncated},
+    {id: "stage-mask", node_id: "mask", transcript: masked},
+    {id: "stage-llm", node_id: "llm", transcript: llm_compacted},
+  ],
+  },
+  )
+  println(run.observability?.schema_version == 2)
+  println(len(run.observability?.compaction_events) == 3)
+  var saw_truncate = false
+  var saw_mask = false
+  var saw_llm = false
+  for ev in run.observability?.compaction_events {
+    if ev.stage_id == "stage-truncate" && ev.strategy == "truncate" && ev.available {
+      saw_truncate = true
+    }
+    if ev.stage_id == "stage-mask" && ev.strategy == "observation_mask" && ev.available {
+      saw_mask = true
+    }
+    if ev.stage_id == "stage-llm" && ev.strategy == "llm" && ev.available {
+      saw_llm = true
+    }
+  }
+  println(saw_truncate)
+  println(saw_mask)
+  println(saw_llm)
+}

--- a/conformance/tests/stdlib/compact_transcript_summary.harn.prompt
+++ b/conformance/tests/stdlib/compact_transcript_summary.harn.prompt
@@ -1,0 +1,5 @@
+Compact prompt from asset.
+Archived count: {{ archived_count }}
+
+Conversation:
+{{ formatted_messages }}

--- a/crates/harn-cli/src/acp/events.rs
+++ b/crates/harn-cli/src/acp/events.rs
@@ -220,6 +220,28 @@ impl AgentEventSink for AcpAgentEventSink {
                     },
                 }));
             }
+            AgentEvent::TranscriptCompacted {
+                session_id,
+                mode,
+                strategy,
+                archived_messages,
+                estimated_tokens_before,
+                estimated_tokens_after,
+                snapshot_asset_id,
+            } => {
+                self.write_notification(serde_json::json!({
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "transcript_compacted",
+                        "mode": mode,
+                        "strategy": strategy,
+                        "archivedMessages": archived_messages,
+                        "estimatedTokensBefore": estimated_tokens_before,
+                        "estimatedTokensAfter": estimated_tokens_after,
+                        "snapshotAssetId": snapshot_asset_id,
+                    },
+                }));
+            }
             // Pipeline-loop milestones with no canonical ACP session/update
             // mapping; deliberately not forwarded.
             AgentEvent::TurnStart { .. }

--- a/crates/harn-lsp/src/constants.rs
+++ b/crates/harn-lsp/src/constants.rs
@@ -681,7 +681,7 @@ pub(crate) fn builtin_doc(name: &str) -> Option<String> {
         "llm_config" => "**llm_config(provider?)** → dict — Get provider configuration",
         "llm_healthcheck" => "**llm_healthcheck(provider?)** → dict — Check provider health and connectivity",
         "transcript" => "**transcript(metadata?)** → dict — Create a new transcript",
-        "transcript_compact" => "**transcript_compact(transcript, options?)** → dict — Compact a transcript locally",
+        "transcript_compact" => "**transcript_compact(transcript, options?)** → dict — Compact a transcript with the runtime compaction engine",
         "transcript_summarize" => "**transcript_summarize(transcript, options?)** → dict — Summarize and compact a transcript with an LLM",
         "transcript_auto_compact" => "**transcript_auto_compact(messages, options?)** → list — Apply the agent-loop compaction pipeline to a message list",
         "schema_check" => "**schema_check(data, schema)** → Result — Validate data against an extended Harn schema without applying defaults",

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -191,6 +191,15 @@ pub enum AgentEvent {
         strategy: String,
         mode: String,
     },
+    TranscriptCompacted {
+        session_id: String,
+        mode: String,
+        strategy: String,
+        archived_messages: usize,
+        estimated_tokens_before: usize,
+        estimated_tokens_after: usize,
+        snapshot_asset_id: Option<String>,
+    },
 }
 
 impl AgentEvent {
@@ -211,7 +220,8 @@ impl AgentEvent {
             | Self::SkillDeactivated { session_id, .. }
             | Self::SkillScopeTools { session_id, .. }
             | Self::ToolSearchQuery { session_id, .. }
-            | Self::ToolSearchResult { session_id, .. } => session_id,
+            | Self::ToolSearchResult { session_id, .. }
+            | Self::TranscriptCompacted { session_id, .. } => session_id,
         }
     }
 }

--- a/crates/harn-vm/src/llm/agent/helpers.rs
+++ b/crates/harn-vm/src/llm/agent/helpers.rs
@@ -297,6 +297,7 @@ pub(crate) async fn maybe_auto_compact_agent_messages(
         if approx_tokens >= ac.token_threshold {
             let mut compact_opts = opts.clone();
             compact_opts.messages = visible_messages.clone();
+            let original_message_count = visible_messages.len();
             if let Some(summary) = crate::orchestration::auto_compact_messages(
                 visible_messages,
                 ac,
@@ -304,6 +305,28 @@ pub(crate) async fn maybe_auto_compact_agent_messages(
             )
             .await?
             {
+                let estimated_tokens_after =
+                    crate::orchestration::estimate_message_tokens(visible_messages);
+                let archived_messages = original_message_count
+                    .saturating_sub(visible_messages.len())
+                    .saturating_add(1);
+                if let Some(session_id) = super::current_agent_session_id() {
+                    super::emit_agent_event(
+                        &crate::agent_events::AgentEvent::TranscriptCompacted {
+                            session_id,
+                            mode: "auto".to_string(),
+                            strategy: crate::orchestration::compact_strategy_name(
+                                &ac.compact_strategy,
+                            )
+                            .to_string(),
+                            archived_messages,
+                            estimated_tokens_before: approx_tokens,
+                            estimated_tokens_after,
+                            snapshot_asset_id: None,
+                        },
+                    )
+                    .await;
+                }
                 let merged = match transcript_summary.take() {
                     Some(existing) if !existing.is_empty() => {
                         format!("{existing}\n\n{summary}")

--- a/crates/harn-vm/src/llm/agent/mod.rs
+++ b/crates/harn-vm/src/llm/agent/mod.rs
@@ -44,7 +44,7 @@ thread_local! {
 /// future VM embedder runs the loop from a multi-thread runtime
 /// without a `LocalSet`, closure subscribers will silently decouple
 /// from their emit site.
-async fn emit_agent_event(event: &AgentEvent) {
+pub(crate) async fn emit_agent_event(event: &AgentEvent) {
     agent_events::emit_event(event);
 
     let subscribers = crate::agent_sessions::subscribers_for(event.session_id());

--- a/crates/harn-vm/src/llm/agent/post_turn.rs
+++ b/crates/harn-vm/src/llm/agent/post_turn.rs
@@ -229,6 +229,7 @@ pub(super) async fn run_post_turn(
             if est > ac.token_threshold {
                 let mut compact_opts = opts.clone();
                 compact_opts.messages = state.visible_messages.clone();
+                let original_message_count = state.visible_messages.len();
                 if let Some(summary) = crate::orchestration::auto_compact_messages(
                     &mut state.visible_messages,
                     ac,
@@ -236,17 +237,46 @@ pub(super) async fn run_post_turn(
                 )
                 .await?
                 {
+                    let estimated_tokens_after =
+                        crate::orchestration::estimate_message_tokens(&state.visible_messages);
+                    let archived_messages = original_message_count
+                        .saturating_sub(state.visible_messages.len())
+                        .saturating_add(1);
                     super::super::trace::emit_agent_event(
                         super::super::trace::AgentTraceEvent::ContextCompaction {
-                            archived_messages: est.saturating_sub(
-                                crate::orchestration::estimate_message_tokens(
-                                    &state.visible_messages,
-                                ),
-                            ),
+                            archived_messages,
                             new_summary_len: summary.len(),
                             iteration,
                         },
                     );
+                    state.transcript_events.push(crate::llm::helpers::transcript_event(
+                        "compaction",
+                        "system",
+                        "internal",
+                        "Transcript compacted during agent loop",
+                        Some(serde_json::json!({
+                            "mode": "auto",
+                            "strategy": crate::orchestration::compact_strategy_name(&ac.compact_strategy),
+                            "archived_messages": archived_messages,
+                            "estimated_tokens_before": est,
+                            "estimated_tokens_after": estimated_tokens_after,
+                        })),
+                    ));
+                    super::emit_agent_event(
+                        &crate::agent_events::AgentEvent::TranscriptCompacted {
+                            session_id: ctx.session_id.to_string(),
+                            mode: "auto".to_string(),
+                            strategy: crate::orchestration::compact_strategy_name(
+                                &ac.compact_strategy,
+                            )
+                            .to_string(),
+                            archived_messages,
+                            estimated_tokens_before: est,
+                            estimated_tokens_after,
+                            snapshot_asset_id: None,
+                        },
+                    )
+                    .await;
                     let merged = match state.transcript_summary.take() {
                         Some(existing)
                             if !existing.trim().is_empty() && existing.trim() != summary.trim() =>

--- a/crates/harn-vm/src/llm/conversation.rs
+++ b/crates/harn-vm/src/llm/conversation.rs
@@ -382,51 +382,6 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
         Ok(VmValue::Dict(Rc::new(compacted)))
     });
 
-    vm.register_builtin("transcript_compact", |args, _out| {
-        let transcript = require_transcript(args, "transcript_compact")?;
-        let keep_last = args
-            .get(1)
-            .and_then(|v| v.as_dict())
-            .and_then(|d| d.get("keep_last"))
-            .and_then(|v| v.as_int())
-            .unwrap_or(6)
-            .max(0) as usize;
-        let messages = transcript_message_list(transcript)?;
-        let retained = messages
-            .into_iter()
-            .rev()
-            .take(keep_last)
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
-            .collect::<Vec<_>>();
-        let archived_count = transcript_message_list(transcript)?
-            .len()
-            .saturating_sub(retained.len());
-        let summary = args
-            .get(1)
-            .and_then(|v| v.as_dict())
-            .and_then(|d| d.get("summary"))
-            .map(|v| v.display())
-            .or_else(|| transcript_summary_text(transcript));
-        let mut compacted = match rebuild_transcript(
-            transcript,
-            retained,
-            summary,
-            transcript_asset_list(transcript)?,
-            Vec::new(),
-            transcript_state(transcript),
-        ) {
-            VmValue::Dict(d) => (*d).clone(),
-            _ => BTreeMap::new(),
-        };
-        compacted.insert(
-            "archived_messages".to_string(),
-            VmValue::Int(archived_count as i64),
-        );
-        Ok(VmValue::Dict(Rc::new(compacted)))
-    });
-
     vm.register_builtin("add_message", |args, _out| match args.first() {
         Some(VmValue::List(list)) => {
             let role = args.get(1).map(|a| a.display()).unwrap_or_default();

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -285,7 +285,8 @@ fn build_schema_nudge(
 pub(crate) use self::agent::parse_skill_match_config_public as parse_skill_match_config_dict;
 pub(crate) use self::agent::SkillMatchConfig;
 pub(crate) use self::agent::{
-    current_agent_session_id, current_host_bridge, parse_skill_config, run_agent_loop_internal,
+    current_agent_session_id, current_host_bridge, emit_agent_event as emit_live_agent_event,
+    parse_skill_config, run_agent_loop_internal,
 };
 pub(crate) use self::agent_config::{agent_loop_result_from_llm, AgentLoopConfig};
 pub use self::agent_config::{register_agent_loop_with_bridge, register_llm_call_with_bridge};

--- a/crates/harn-vm/src/orchestration/compaction.rs
+++ b/crates/harn-vm/src/orchestration/compaction.rs
@@ -1,5 +1,6 @@
 //! Auto-compaction — transcript size management strategies.
 
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use crate::llm::{vm_call_llm_full, vm_value_to_json};
@@ -22,6 +23,15 @@ pub fn parse_compact_strategy(value: &str) -> Result<CompactStrategy, VmError> {
         other => Err(VmError::Runtime(format!(
             "unknown compact_strategy '{other}' (expected 'llm', 'truncate', 'custom', or 'observation_mask')"
         ))),
+    }
+}
+
+pub fn compact_strategy_name(strategy: &CompactStrategy) -> &'static str {
+    match strategy {
+        CompactStrategy::Llm => "llm",
+        CompactStrategy::Truncate => "truncate",
+        CompactStrategy::Custom => "custom",
+        CompactStrategy::ObservationMask => "observation_mask",
     }
 }
 
@@ -65,6 +75,10 @@ pub struct AutoCompactConfig {
     /// This allows the pipeline to use LLM-based compression rather than
     /// keyword heuristics.
     pub compress_callback: Option<VmValue>,
+    /// Optional prompt-template asset path used when LLM compaction is
+    /// selected. The rendered template becomes the user message sent to
+    /// the summarizer.
+    pub summarize_prompt: Option<String>,
 }
 
 impl Default for AutoCompactConfig {
@@ -79,6 +93,7 @@ impl Default for AutoCompactConfig {
             custom_compactor: None,
             mask_callback: None,
             compress_callback: None,
+            summarize_prompt: None,
         }
     }
 }
@@ -341,6 +356,7 @@ async fn llm_compaction_summary(
     old_messages: &[serde_json::Value],
     archived_count: usize,
     llm_opts: &crate::llm::api::LlmCallOptions,
+    summarize_prompt: Option<&str>,
 ) -> Result<String, VmError> {
     let mut compact_opts = llm_opts.clone();
     let formatted = format_compaction_messages(old_messages);
@@ -350,11 +366,10 @@ async fn llm_compaction_summary(
     compact_opts.tool_choice = None;
     compact_opts.response_format = None;
     compact_opts.json_schema = None;
+    let prompt = render_llm_compaction_prompt(summarize_prompt, &formatted, archived_count)?;
     compact_opts.messages = vec![serde_json::json!({
         "role": "user",
-        "content": format!(
-            "Summarize these archived conversation messages for a follow-on coding agent. Preserve goals, constraints, decisions, completed tool work, unresolved issues, and next actions. Output only the summary text.\n\nArchived message count: {archived_count}\n\nConversation:\n{formatted}"
-        ),
+        "content": prompt,
     })];
     let result = vm_call_llm_full(&compact_opts).await?;
     let summary = result.text.trim();
@@ -369,6 +384,46 @@ async fn llm_compaction_summary(
             "[auto-compacted {archived_count} older messages]\n{summary}"
         ))
     }
+}
+
+fn render_llm_compaction_prompt(
+    summarize_prompt: Option<&str>,
+    formatted: &str,
+    archived_count: usize,
+) -> Result<String, VmError> {
+    let Some(path) = summarize_prompt.filter(|path| !path.trim().is_empty()) else {
+        return Ok(format!(
+            "Summarize these archived conversation messages for a follow-on coding agent. Preserve goals, constraints, decisions, completed tool work, unresolved issues, and next actions. Output only the summary text.\n\nArchived message count: {archived_count}\n\nConversation:\n{formatted}"
+        ));
+    };
+
+    let resolved = crate::stdlib::process::resolve_source_asset_path(path);
+    let template = std::fs::read_to_string(&resolved).map_err(|error| {
+        VmError::Runtime(format!(
+            "failed to read compaction summarize_prompt {}: {error}",
+            resolved.display()
+        ))
+    })?;
+    let mut bindings = BTreeMap::new();
+    bindings.insert(
+        "formatted_messages".to_string(),
+        VmValue::String(Rc::from(formatted.to_string())),
+    );
+    bindings.insert(
+        "archived_count".to_string(),
+        VmValue::Int(archived_count as i64),
+    );
+    crate::stdlib::template::render_template_result(
+        &template,
+        Some(&bindings),
+        resolved.parent(),
+        Some(&resolved),
+    )
+    .map_err(|error| {
+        VmError::Runtime(format!(
+            "compaction summarize_prompt render error: {error:?}"
+        ))
+    })
 }
 
 async fn custom_compaction_summary(
@@ -509,6 +564,7 @@ async fn apply_compaction_strategy(
     llm_opts: Option<&crate::llm::api::LlmCallOptions>,
     custom_compactor: Option<&VmValue>,
     mask_callback: Option<&VmValue>,
+    summarize_prompt: Option<&str>,
 ) -> Result<String, VmError> {
     match strategy {
         CompactStrategy::Truncate => Ok(truncate_compaction_summary(old_messages, archived_count)),
@@ -521,6 +577,7 @@ async fn apply_compaction_strategy(
                         "LLM transcript compaction requires active LLM call options".to_string(),
                     )
                 })?,
+                summarize_prompt,
             )
             .await
         }
@@ -605,6 +662,7 @@ pub(crate) async fn auto_compact_messages(
         llm_opts,
         config.custom_compactor.as_ref(),
         config.mask_callback.as_ref(),
+        config.summarize_prompt.as_deref(),
     )
     .await?;
 
@@ -625,6 +683,7 @@ pub(crate) async fn auto_compact_messages(
                 llm_opts,
                 config.custom_compactor.as_ref(),
                 None,
+                config.summarize_prompt.as_deref(),
             )
             .await?;
         }

--- a/crates/harn-vm/src/orchestration/records.rs
+++ b/crates/harn-vm/src/orchestration/records.rs
@@ -241,6 +241,24 @@ pub struct RunTranscriptPointerRecord {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
+pub struct CompactionEventRecord {
+    pub id: String,
+    pub transcript_id: Option<String>,
+    pub stage_id: Option<String>,
+    pub node_id: Option<String>,
+    pub mode: String,
+    pub strategy: String,
+    pub archived_messages: usize,
+    pub estimated_tokens_before: usize,
+    pub estimated_tokens_after: usize,
+    pub snapshot_asset_id: Option<String>,
+    pub snapshot_location: String,
+    pub snapshot_path: Option<String>,
+    pub available: bool,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct RunObservabilityRecord {
     pub schema_version: usize,
     pub planner_rounds: Vec<RunPlannerRoundRecord>,
@@ -250,6 +268,7 @@ pub struct RunObservabilityRecord {
     pub worker_lineage: Vec<RunWorkerLineageRecord>,
     pub verification_outcomes: Vec<RunVerificationOutcomeRecord>,
     pub transcript_pointers: Vec<RunTranscriptPointerRecord>,
+    pub compaction_events: Vec<CompactionEventRecord>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -512,6 +531,94 @@ fn task_ledger_summary_from_value(value: &serde_json::Value) -> Option<RunTaskLe
     })
 }
 
+fn compaction_events_from_transcript(
+    transcript: &serde_json::Value,
+    stage_id: Option<&str>,
+    node_id: Option<&str>,
+    location_prefix: &str,
+    persisted_path: Option<&Path>,
+) -> Vec<CompactionEventRecord> {
+    let transcript_id = transcript
+        .get("id")
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    let asset_ids = transcript
+        .get("assets")
+        .and_then(|value| value.as_array())
+        .map(|assets| {
+            assets
+                .iter()
+                .filter_map(|asset| {
+                    asset
+                        .get("id")
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string)
+                })
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+    transcript
+        .get("events")
+        .and_then(|value| value.as_array())
+        .map(|events| {
+            events
+                .iter()
+                .filter(|event| {
+                    event.get("kind").and_then(|value| value.as_str()) == Some("compaction")
+                })
+                .map(|event| {
+                    let metadata = event.get("metadata");
+                    let snapshot_asset_id = metadata
+                        .and_then(|value| value.get("snapshot_asset_id"))
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string);
+                    let available = snapshot_asset_id
+                        .as_ref()
+                        .is_some_and(|asset_id| asset_ids.contains(asset_id));
+                    let snapshot_location = snapshot_asset_id
+                        .as_ref()
+                        .map(|asset_id| format!("{location_prefix}.assets[{asset_id}]"))
+                        .unwrap_or_else(|| location_prefix.to_string());
+                    CompactionEventRecord {
+                        id: event
+                            .get("id")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        transcript_id: transcript_id.clone(),
+                        stage_id: stage_id.map(str::to_string),
+                        node_id: node_id.map(str::to_string),
+                        mode: metadata
+                            .and_then(|value| value.get("mode"))
+                            .and_then(|value| value.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        strategy: metadata
+                            .and_then(|value| value.get("strategy"))
+                            .and_then(|value| value.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        archived_messages: json_usize(
+                            metadata.and_then(|value| value.get("archived_messages")),
+                        ),
+                        estimated_tokens_before: json_usize(
+                            metadata.and_then(|value| value.get("estimated_tokens_before")),
+                        ),
+                        estimated_tokens_after: json_usize(
+                            metadata.and_then(|value| value.get("estimated_tokens_after")),
+                        ),
+                        snapshot_asset_id,
+                        snapshot_location,
+                        snapshot_path: persisted_path
+                            .map(|path| path.to_string_lossy().into_owned()),
+                        available,
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 pub fn derive_run_observability(
     run: &RunRecord,
     persisted_path: Option<&Path>,
@@ -521,6 +628,7 @@ pub fn derive_run_observability(
     let mut verification_outcomes = Vec::new();
     let mut planner_rounds = Vec::new();
     let mut transcript_pointers = Vec::new();
+    let mut compaction_events = Vec::new();
     let mut research_fact_count = 0usize;
 
     let root_node_id = format!("run:{}", run.id);
@@ -639,6 +747,15 @@ pub fn derive_run_observability(
                 path: run.persisted_path.clone(),
                 available: true,
             });
+            if let Some(transcript) = stage.transcript.as_ref() {
+                compaction_events.extend(compaction_events_from_transcript(
+                    transcript,
+                    Some(&stage.id),
+                    Some(&stage.node_id),
+                    &format!("run.stages[{}].transcript", stage.node_id),
+                    persisted_path,
+                ));
+            }
         }
 
         if let Some(payload) = stage_result_payload(stage) {
@@ -768,6 +885,15 @@ pub fn derive_run_observability(
             path: run.persisted_path.clone(),
             available: true,
         });
+        if let Some(transcript) = run.transcript.as_ref() {
+            compaction_events.extend(compaction_events_from_transcript(
+                transcript,
+                None,
+                None,
+                "run.transcript",
+                persisted_path,
+            ));
+        }
     }
 
     if let Some(path) = persisted_path {
@@ -792,7 +918,7 @@ pub fn derive_run_observability(
     }
 
     RunObservabilityRecord {
-        schema_version: 1,
+        schema_version: 2,
         planner_rounds,
         research_fact_count,
         action_graph_nodes,
@@ -800,6 +926,7 @@ pub fn derive_run_observability(
         worker_lineage,
         verification_outcomes,
         transcript_pointers,
+        compaction_events,
     }
 }
 
@@ -1539,6 +1666,67 @@ pub fn diff_run_records(left: &RunRecord, right: &RunRecord) -> RunDiffReport {
                         "pointer: {:?} -> {:?}",
                         left_pointer, right_pointer
                     )],
+                });
+            }
+            _ => {}
+        }
+    }
+
+    let left_compactions = left_observability
+        .compaction_events
+        .iter()
+        .map(|event| {
+            (
+                event.id.clone(),
+                (
+                    event.strategy.clone(),
+                    event.archived_messages,
+                    event.snapshot_asset_id.clone(),
+                    event.available,
+                ),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let right_compactions = right_observability
+        .compaction_events
+        .iter()
+        .map(|event| {
+            (
+                event.id.clone(),
+                (
+                    event.strategy.clone(),
+                    event.archived_messages,
+                    event.snapshot_asset_id.clone(),
+                    event.available,
+                ),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let compaction_ids = left_compactions
+        .keys()
+        .chain(right_compactions.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    for compaction_id in compaction_ids {
+        match (
+            left_compactions.get(&compaction_id),
+            right_compactions.get(&compaction_id),
+        ) {
+            (Some(_), None) => observability_diffs.push(RunObservabilityDiffRecord {
+                section: "compaction_events".to_string(),
+                label: compaction_id,
+                details: vec!["compaction event missing from right run".to_string()],
+            }),
+            (None, Some(_)) => observability_diffs.push(RunObservabilityDiffRecord {
+                section: "compaction_events".to_string(),
+                label: compaction_id,
+                details: vec!["compaction event missing from left run".to_string()],
+            }),
+            (Some(left_event), Some(right_event)) if left_event != right_event => {
+                observability_diffs.push(RunObservabilityDiffRecord {
+                    section: "compaction_events".to_string(),
+                    label: compaction_id,
+                    details: vec![format!("event: {:?} -> {:?}", left_event, right_event)],
                 });
             }
             _ => {}

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -408,11 +408,12 @@ fn save_and_load_run_record_materializes_observability_summary() {
     save_run_record(&run, Some(run_path.to_str().unwrap())).unwrap();
     let loaded = load_run_record(&run_path).unwrap();
     let observability = loaded.observability.expect("observability summary");
-    assert_eq!(observability.schema_version, 1);
+    assert_eq!(observability.schema_version, 2);
     assert_eq!(observability.planner_rounds.len(), 1);
     assert_eq!(observability.research_fact_count, 1);
     assert_eq!(observability.worker_lineage.len(), 1);
     assert_eq!(observability.verification_outcomes.len(), 1);
+    assert!(observability.compaction_events.is_empty());
     assert!(observability
         .transcript_pointers
         .iter()
@@ -421,6 +422,71 @@ fn save_and_load_run_record_materializes_observability_summary() {
         observability.planner_rounds[0].research_facts,
         vec!["verify stage failed after read".to_string()]
     );
+}
+
+#[test]
+fn derive_run_observability_collects_compaction_events() {
+    let transcript = serde_json::json!({
+        "_type": "transcript",
+        "id": "session-compaction",
+        "messages": [
+            {"role": "user", "content": "summary"}
+        ],
+        "events": [
+            {
+                "id": "compaction-event-1",
+                "kind": "compaction",
+                "role": "system",
+                "visibility": "internal",
+                "text": "Transcript compacted via truncate",
+                "metadata": {
+                    "mode": "manual",
+                    "strategy": "truncate",
+                    "archived_messages": 3,
+                    "estimated_tokens_before": 120,
+                    "estimated_tokens_after": 48,
+                    "snapshot_asset_id": "snapshot-1"
+                }
+            }
+        ],
+        "assets": [
+            {
+                "id": "snapshot-1",
+                "kind": "compaction_source_transcript",
+                "visibility": "internal",
+                "data": {
+                    "_type": "transcript",
+                    "id": "session-compaction",
+                    "messages": [
+                        {"role": "user", "content": "first"},
+                        {"role": "assistant", "content": "second"},
+                        {"role": "user", "content": "third"},
+                        {"role": "assistant", "content": "fourth"}
+                    ]
+                }
+            }
+        ]
+    });
+    let run = RunRecord {
+        id: "run_compaction".to_string(),
+        workflow_id: "wf".to_string(),
+        status: "completed".to_string(),
+        transcript: Some(transcript),
+        ..Default::default()
+    };
+
+    let observability = derive_run_observability(&run, None);
+    assert_eq!(observability.compaction_events.len(), 1);
+    let event = &observability.compaction_events[0];
+    assert_eq!(event.id, "compaction-event-1");
+    assert_eq!(event.mode, "manual");
+    assert_eq!(event.strategy, "truncate");
+    assert_eq!(event.archived_messages, 3);
+    assert_eq!(event.estimated_tokens_before, 120);
+    assert_eq!(event.estimated_tokens_after, 48);
+    assert_eq!(event.snapshot_asset_id.as_deref(), Some("snapshot-1"));
+    assert_eq!(event.snapshot_location, "run.transcript.assets[snapshot-1]");
+    assert!(event.available);
 }
 
 #[test]

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -28,6 +28,7 @@ pub mod template;
 mod testing;
 pub(crate) mod tools;
 pub mod tracing;
+mod transcript_compact;
 mod types;
 
 use crate::http::register_http_builtins;
@@ -77,6 +78,7 @@ pub fn register_agent_stdlib(vm: &mut Vm) {
     agents_daemon::register_daemon_builtins(vm);
     agents::register_agent_builtins(vm);
     agent_sessions::register_agent_session_builtins(vm);
+    transcript_compact::register_transcript_compaction_builtins(vm);
     register_http_builtins(vm);
     register_llm_builtins(vm);
     register_mcp_builtins(vm);

--- a/crates/harn-vm/src/stdlib/transcript_compact.rs
+++ b/crates/harn-vm/src/stdlib/transcript_compact.rs
@@ -1,0 +1,320 @@
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use crate::agent_events::AgentEvent;
+use crate::llm::helpers::{
+    extract_llm_options, is_transcript_value, new_transcript_with_events,
+    normalize_transcript_asset, transcript_asset_list, transcript_event, transcript_id,
+    transcript_message_list, transcript_summary_text, vm_value_to_json,
+};
+use crate::orchestration::{
+    auto_compact_messages, compact_strategy_name, estimate_message_tokens, AutoCompactConfig,
+    CompactStrategy,
+};
+use crate::stdlib::json_to_vm_value;
+use crate::value::{VmError, VmValue};
+use crate::vm::Vm;
+
+pub(crate) fn register_transcript_compaction_builtins(vm: &mut Vm) {
+    vm.register_async_builtin("transcript_compact", |args| async move {
+        let transcript = args
+            .first()
+            .and_then(|value| value.as_dict())
+            .filter(|_| args.first().is_some_and(is_transcript_value))
+            .ok_or_else(|| {
+                VmError::Runtime("transcript_compact: first argument must be a transcript".into())
+            })?;
+        let options = args.get(1).and_then(|value| value.as_dict());
+        compact_transcript_impl(transcript, options, args.get(1).cloned()).await
+    });
+}
+
+#[derive(Clone)]
+struct TranscriptCompactOptions {
+    strategy: CompactStrategy,
+    keep_last: usize,
+    target_tokens: Option<usize>,
+    summarize_prompt: Option<String>,
+    summary: Option<String>,
+}
+
+async fn compact_transcript_impl(
+    transcript: &BTreeMap<String, VmValue>,
+    options: Option<&BTreeMap<String, VmValue>>,
+    raw_options: Option<VmValue>,
+) -> Result<VmValue, VmError> {
+    let options = parse_options(options)?;
+    let mut config = AutoCompactConfig {
+        keep_last: options.keep_last,
+        compact_strategy: options.strategy.clone(),
+        hard_limit_strategy: options.strategy.clone(),
+        summarize_prompt: options.summarize_prompt.clone(),
+        ..Default::default()
+    };
+    if let Some(target_tokens) = options.target_tokens {
+        config.token_threshold = target_tokens;
+        config.hard_limit_tokens = Some(target_tokens);
+    } else {
+        config.token_threshold = 0;
+    }
+
+    let original_transcript = VmValue::Dict(Rc::new(transcript.clone()));
+    let mut messages: Vec<serde_json::Value> = transcript_message_list(transcript)?
+        .iter()
+        .map(vm_value_to_json)
+        .collect();
+    let estimated_tokens_before = estimate_message_tokens(&messages);
+    if options
+        .target_tokens
+        .is_some_and(|target_tokens| estimated_tokens_before <= target_tokens)
+    {
+        return Ok(original_transcript);
+    }
+
+    let llm_opts = if config.compact_strategy == CompactStrategy::Llm {
+        Some(extract_llm_options(&[
+            VmValue::String(Rc::from("")),
+            VmValue::Nil,
+            raw_options.unwrap_or(VmValue::Nil),
+        ])?)
+    } else {
+        None
+    };
+
+    let original_message_count = messages.len();
+    let Some(summary) = auto_compact_messages(&mut messages, &config, llm_opts.as_ref()).await?
+    else {
+        return Ok(original_transcript);
+    };
+    let summary = options.summary.clone().unwrap_or(summary);
+    let estimated_tokens_after = estimate_message_tokens(&messages);
+    let archived_messages = original_message_count
+        .saturating_sub(messages.len())
+        .saturating_add(1);
+    let snapshot_asset = build_snapshot_asset(
+        &original_transcript,
+        &options,
+        archived_messages,
+        estimated_tokens_before,
+        estimated_tokens_after,
+    );
+    let snapshot_asset_id = snapshot_asset
+        .as_dict()
+        .and_then(|dict| dict.get("id"))
+        .map(|value| value.display())
+        .unwrap_or_default();
+    let mut assets = transcript_asset_list(transcript)?;
+    assets.push(snapshot_asset);
+
+    let metadata = serde_json::json!({
+        "mode": "manual",
+        "strategy": compact_strategy_name(&options.strategy),
+        "keep_last": options.keep_last,
+        "target_tokens": options.target_tokens,
+        "archived_messages": archived_messages,
+        "estimated_tokens_before": estimated_tokens_before,
+        "estimated_tokens_after": estimated_tokens_after,
+        "snapshot_asset_id": snapshot_asset_id,
+    });
+    let mut extra_events = transcript_extra_events(transcript);
+    extra_events.push(transcript_event(
+        "compaction",
+        "system",
+        "internal",
+        &format!(
+            "Transcript compacted via {}",
+            compact_strategy_name(&options.strategy)
+        ),
+        Some(metadata.clone()),
+    ));
+
+    if let Some(session_id) =
+        transcript_id(transcript).or_else(crate::llm::current_agent_session_id)
+    {
+        crate::llm::emit_live_agent_event(&AgentEvent::TranscriptCompacted {
+            session_id,
+            mode: "manual".to_string(),
+            strategy: compact_strategy_name(&options.strategy).to_string(),
+            archived_messages,
+            estimated_tokens_before,
+            estimated_tokens_after,
+            snapshot_asset_id: Some(snapshot_asset_id.clone()),
+        })
+        .await;
+    }
+
+    let compacted = new_transcript_with_events(
+        transcript_id(transcript),
+        messages.iter().map(json_to_vm_value).collect(),
+        merge_summary(transcript_summary_text(transcript), &summary),
+        transcript.get("metadata").cloned(),
+        extra_events,
+        assets,
+        transcript_state(transcript),
+    );
+    Ok(compacted)
+}
+
+fn parse_options(
+    options: Option<&BTreeMap<String, VmValue>>,
+) -> Result<TranscriptCompactOptions, VmError> {
+    let mut parsed = TranscriptCompactOptions {
+        strategy: CompactStrategy::ObservationMask,
+        keep_last: AutoCompactConfig::default().keep_last,
+        target_tokens: None,
+        summarize_prompt: None,
+        summary: None,
+    };
+    if let Some(value) = options
+        .and_then(|dict| {
+            dict.get("strategy")
+                .or_else(|| dict.get("compact_strategy"))
+        })
+        .and_then(|value| match value {
+            VmValue::String(text) => Some(text.as_ref()),
+            _ => None,
+        })
+    {
+        parsed.strategy = crate::orchestration::parse_compact_strategy(value)?;
+    }
+    if parsed.strategy == CompactStrategy::Custom {
+        return Err(VmError::Runtime(
+            "transcript_compact: strategy 'custom' is not supported; use 'llm', 'truncate', or 'observation_mask'"
+                .into(),
+        ));
+    }
+    if let Some(value) = options
+        .and_then(|dict| dict.get("keep_last"))
+        .and_then(|value| value.as_int())
+    {
+        if value < 0 {
+            return Err(VmError::Runtime(
+                "transcript_compact: keep_last must be >= 0".into(),
+            ));
+        }
+        parsed.keep_last = value as usize;
+    }
+    if let Some(value) = options
+        .and_then(|dict| dict.get("target_tokens"))
+        .and_then(|value| value.as_int())
+    {
+        if value < 0 {
+            return Err(VmError::Runtime(
+                "transcript_compact: target_tokens must be >= 0".into(),
+            ));
+        }
+        parsed.target_tokens = Some(value as usize);
+    }
+    parsed.summarize_prompt = options
+        .and_then(|dict| dict.get("summarize_prompt"))
+        .and_then(|value| match value {
+            VmValue::String(text) if !text.trim().is_empty() => Some(text.to_string()),
+            _ => None,
+        });
+    parsed.summary = options
+        .and_then(|dict| dict.get("summary"))
+        .and_then(|value| match value {
+            VmValue::String(text) if !text.trim().is_empty() => Some(text.to_string()),
+            _ => None,
+        });
+    if parsed.summarize_prompt.is_some() && parsed.strategy != CompactStrategy::Llm {
+        return Err(VmError::Runtime(
+            "transcript_compact: summarize_prompt is only supported with strategy 'llm'".into(),
+        ));
+    }
+    Ok(parsed)
+}
+
+fn build_snapshot_asset(
+    transcript: &VmValue,
+    options: &TranscriptCompactOptions,
+    archived_messages: usize,
+    estimated_tokens_before: usize,
+    estimated_tokens_after: usize,
+) -> VmValue {
+    let asset = VmValue::Dict(Rc::new(BTreeMap::from([
+        (
+            "id".to_string(),
+            VmValue::String(Rc::from(format!(
+                "compaction-source-{}",
+                uuid::Uuid::now_v7()
+            ))),
+        ),
+        (
+            "kind".to_string(),
+            VmValue::String(Rc::from("compaction_source_transcript")),
+        ),
+        (
+            "title".to_string(),
+            VmValue::String(Rc::from("Pre-compaction transcript")),
+        ),
+        (
+            "visibility".to_string(),
+            VmValue::String(Rc::from("internal")),
+        ),
+        ("data".to_string(), transcript.clone()),
+        (
+            "metadata".to_string(),
+            VmValue::Dict(Rc::new(BTreeMap::from([
+                (
+                    "strategy".to_string(),
+                    VmValue::String(Rc::from(compact_strategy_name(&options.strategy))),
+                ),
+                (
+                    "archived_messages".to_string(),
+                    VmValue::Int(archived_messages as i64),
+                ),
+                (
+                    "estimated_tokens_before".to_string(),
+                    VmValue::Int(estimated_tokens_before as i64),
+                ),
+                (
+                    "estimated_tokens_after".to_string(),
+                    VmValue::Int(estimated_tokens_after as i64),
+                ),
+            ]))),
+        ),
+    ])));
+    normalize_transcript_asset(&asset)
+}
+
+fn merge_summary(existing: Option<String>, next: &str) -> Option<String> {
+    if next.trim().is_empty() {
+        return existing;
+    }
+    match existing {
+        Some(existing) if !existing.trim().is_empty() && existing.trim() != next.trim() => {
+            Some(format!("{existing}\n\n{next}"))
+        }
+        Some(existing) if !existing.trim().is_empty() => Some(existing),
+        _ => Some(next.to_string()),
+    }
+}
+
+fn transcript_extra_events(transcript: &BTreeMap<String, VmValue>) -> Vec<VmValue> {
+    transcript
+        .get("events")
+        .and_then(|events| match events {
+            VmValue::List(list) => Some(
+                list.iter()
+                    .filter(|event| {
+                        event
+                            .as_dict()
+                            .and_then(|dict| dict.get("kind"))
+                            .map(|value| value.display())
+                            .is_some_and(|kind| kind != "message" && kind != "tool_result")
+                    })
+                    .cloned()
+                    .collect(),
+            ),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+fn transcript_state(transcript: &BTreeMap<String, VmValue>) -> Option<&str> {
+    transcript.get("state").and_then(|value| match value {
+        VmValue::String(text) if !text.is_empty() => Some(text.as_ref()),
+        _ => None,
+    })
+}

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -784,7 +784,7 @@ llm_mock_clear()
 | `transcript_import(json_text)` | json_text: string | dict | Import transcript JSON |
 | `transcript_fork(transcript, options?)` | transcript: dict, options: dict | dict | Fork transcript, optionally dropping messages or summary |
 | `transcript_summarize(transcript, options?)` | transcript: dict, options: dict | dict | Summarize and compact a transcript via `llm_call` |
-| `transcript_compact(transcript, options?)` | transcript: dict, options: dict | dict | Compact a transcript locally, preserving summary and recent turns |
+| `transcript_compact(transcript, options?)` | transcript: dict, options: dict | dict | Compact a transcript with the runtime compaction engine, preserving durable artifacts and compaction events |
 | `transcript_auto_compact(messages, options?)` | messages: list, options: dict | list | Apply the agent-loop compaction pipeline to a message list using `llm`, `truncate`, or `custom` strategy |
 
 ### Provider configuration
@@ -1464,7 +1464,7 @@ and offline analysis.
 | `transcript_archive(transcript)` | transcript | transcript | Mark transcript archived and append an internal lifecycle event |
 | `transcript_abandon(transcript)` | transcript | transcript | Mark transcript abandoned and append an internal lifecycle event |
 | `transcript_resume(transcript)` | transcript | transcript | Mark transcript active again and append an internal lifecycle event |
-| `transcript_compact(transcript, options?)` | transcript, options | transcript | Locally compact transcript messages |
+| `transcript_compact(transcript, options?)` | transcript, options | transcript | Compact a transcript with the runtime compaction engine |
 | `transcript_summarize(transcript, options?)` | transcript, options | transcript | Compact via LLM-generated summary |
 | `transcript_auto_compact(messages, options?)` | messages, options | list | Apply the agent-loop compaction pipeline to a message list |
 | `transcript_render_visible(transcript)` | transcript | string | Render only public/human-visible messages |

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -911,7 +911,8 @@ let compacted = transcript_compact(second.transcript, {
 ```
 
 Use `transcript_summarize()` when you want Harn to create a fresh summary with
-an LLM, or `transcript_compact()` when you want a local compaction step.
+an LLM, or `transcript_compact()` when you want the runtime compaction engine
+outside the `agent_loop` path.
 
 Transcript helpers also expose the canonical event model:
 


### PR DESCRIPTION
## Summary
- expand the existing `transcript_compact(...)` builtin to wrap `AutoCompactConfig` for on-demand transcript compaction outside `agent_loop`
- preserve pre-compaction transcripts as durable transcript assets, derive first-class compaction events in run observability, and emit live `transcript_compacted` events to subscribers/hosts
- add conformance coverage for `truncate`, `observation_mask`, and `llm` strategies plus the observability record shape, and update docs/changelog to reflect the expanded builtin contract

## Why
Issue #142 part (a) needs a runtime-owned manual compaction surface. The repo already had `transcript_compact(...)`, so this PR keeps the language surface DRY by expanding that builtin instead of adding a second synonymous `compact_transcript(...)` entry point.

`#142b` remains out of scope.

## Validation
- `cargo test -p harn-vm derive_run_observability_collects_compaction_events`
- `cargo run --quiet --bin harn -- test conformance --filter compact_transcript`
- `cargo run --quiet --bin harn -- test conformance --filter llm_transcripts`
- `make all` using an isolated temp `CARGO_TARGET_DIR` and the Makefile's documented `cargo test` fallback, to avoid unrelated `cargo nextest` timeouts from slow pre-existing CLI tests on this host
