### PR TITLE
fix(tree-sitter): accept backslash line continuation

### DIFF
--- a/examples/backslash_line_continuation.harn
+++ b/examples/backslash_line_continuation.harn
@@ -1,0 +1,9 @@
+pipeline main() {
+  let same_worker = "delegate" \
+    == "delegate"
+  println(same_worker)
+  println(
+    "workflow" \
+      == "workflow",
+  )
+}

--- a/tree-sitter-harn/grammar.js
+++ b/tree-sitter-harn/grammar.js
@@ -5,7 +5,7 @@ const KEYWORD_IDENTIFIERS = require("./grammar/keywords");
 module.exports = grammar({
   name: "harn",
 
-  extras: ($) => [/[ \t\r]/, $.comment],
+  extras: ($) => [/[ \t\r]/, /\\\r?\n[ \t]*/, $.comment],
 
   externals: ($) => [$._block_sep, $._line_sep],
 

--- a/tree-sitter-harn/src/grammar.json
+++ b/tree-sitter-harn/src/grammar.json
@@ -6712,6 +6712,10 @@
       "value": "[ \\t\\r]"
     },
     {
+      "type": "PATTERN",
+      "value": "\\\\\\r?\\n[ \\t]*"
+    },
+    {
       "type": "SYMBOL",
       "name": "comment"
     }

--- a/tree-sitter-harn/test/corpus/expressions.txt
+++ b/tree-sitter-harn/test/corpus/expressions.txt
@@ -31,3 +31,27 @@ pipeline test(task) {
               (identifier)
               (identifier)))
           (identifier))))))
+
+==================
+Backslash Continued Expression
+==================
+
+pipeline test(task) {
+  let ok = left \
+    == right
+}
+
+---
+
+(source_file
+  (pipeline_declaration
+    name: (identifier)
+    (parameter_list
+      (typed_parameter
+        name: (identifier)))
+    (block
+      (let_binding
+        name: (identifier)
+        value: (binary_expression
+          (identifier)
+          (identifier))))))

--- a/tree-sitter-harn/test/corpus/layout_and_methods.txt
+++ b/tree-sitter-harn/test/corpus/layout_and_methods.txt
@@ -25,6 +25,33 @@ fn collect() {
             (identifier)))))))
 
 ==================
+Backslash Continued Argument Expression
+==================
+
+fn collect() {
+  capture(
+    first \
+      == second,
+    third,
+  )
+}
+
+---
+
+(source_file
+  (fn_declaration
+    name: (identifier)
+    body: (block
+      (expression_statement
+        (call_expression
+          function: (identifier)
+          (argument_list
+            (binary_expression
+              (identifier)
+              (identifier))
+            (identifier)))))))
+
+==================
 Property Call Chains
 ==================
 


### PR DESCRIPTION
## Summary
- treat backslash-newline continuation as ignorable whitespace in the tree-sitter grammar
- add corpus coverage for continued expressions and continued argument expressions
- add a small positive example so `scripts/verify_tree_sitter_parse.py --strict` exercises this syntax during release audits

Fixes #144.

## Verification
- `cd tree-sitter-harn && npm test`
- `python3 scripts/verify_tree_sitter_parse.py --strict`
- `git push -u origin ksinder/issue-144-tree-sitter-backslash` (pre-push checks passed)

## Notes
- `./scripts/release_gate.sh full --bump patch --dry-run` now clears the grammar lane, but it still fails in `verify_release_metadata` on current `main` because the repo is past the `v0.7.21` tag while `Cargo.toml` still reports `0.7.21`. I confirmed the same metadata guard fails in a clean `origin/main` worktree, so that blocker is pre-existing and separate from this grammar fix.