### PR TITLE
[T-02] Add secret provider primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## Unreleased
+
+### Added
+
+- **Secret-provider primitives for reactive runtime work (#194,
+  closes #154).** `harn_vm::secrets` now provides `SecretProvider`,
+  `ChainSecretProvider`, zeroizing `SecretBytes`, and concrete env +
+  keyring providers. MCP OAuth token storage now routes through the
+  shared keyring provider, and `harn doctor` reports the active
+  secret-provider chain plus per-provider health for env/keyring
+  setups. Foundation for upcoming connector + orchestrator work.
+
 ## v0.7.22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,6 @@ dependencies = [
  "harn-parser",
  "harn-vm",
  "include_dir",
- "keyring",
  "notify",
  "nu-ansi-term",
  "rand 0.10.1",
@@ -841,12 +840,14 @@ dependencies = [
 name = "harn-vm"
 version = "0.7.22"
 dependencies = [
+ "async-trait",
  "base64",
  "futures",
  "harn-lexer",
  "harn-parser",
  "httpdate",
  "ignore",
+ "keyring",
  "md-5",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -866,6 +867,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -43,7 +43,6 @@ sha2 = "0.11"
 base64 = "0.22"
 url = "2"
 webbrowser = "1"
-keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 rand = "0.10"
 regex = "1"
 clap = { version = "4", features = ["derive"] }

--- a/crates/harn-cli/src/commands/doctor.rs
+++ b/crates/harn-cli/src/commands/doctor.rs
@@ -6,6 +6,10 @@ use std::time::Duration;
 
 use harn_vm::llm_config::{self, AuthEnv, ProviderDef};
 use harn_vm::runtime_paths;
+use harn_vm::secrets::{
+    configured_default_chain, EnvSecretProvider, KeyringSecretProvider, SecretId,
+    DEFAULT_SECRET_PROVIDER_CHAIN, SECRET_PROVIDER_CHAIN_ENV,
+};
 use reqwest::{header::CONTENT_TYPE, Method};
 
 use crate::package;
@@ -41,6 +45,7 @@ pub(crate) async fn run_doctor(network: bool) {
     checks.push(check_binary("rustc"));
     checks.push(check_binary("cargo"));
     checks.extend(check_provider_selection());
+    checks.extend(check_secret_providers());
     checks.extend(check_manifest());
     checks.extend(check_metadata_cache());
     checks.extend(check_skills());
@@ -118,6 +123,77 @@ fn check_provider_selection() -> Vec<DoctorCheck> {
             label: "selected provider".to_string(),
             detail: format!("HARN_LLM_PROVIDER={provider}"),
         });
+    }
+
+    checks
+}
+
+fn check_secret_providers() -> Vec<DoctorCheck> {
+    let namespace = default_secret_namespace();
+    let configured = std::env::var(SECRET_PROVIDER_CHAIN_ENV)
+        .unwrap_or_else(|_| DEFAULT_SECRET_PROVIDER_CHAIN.to_string());
+    let mut checks = Vec::new();
+
+    match configured_default_chain(namespace.clone()) {
+        Ok(chain) => checks.push(DoctorCheck {
+            status: if chain.providers().is_empty() {
+                DoctorStatus::Fail
+            } else {
+                DoctorStatus::Ok
+            },
+            label: "secret providers".to_string(),
+            detail: format!(
+                "{} (namespace {})",
+                configured.replace(',', " -> "),
+                namespace
+            ),
+        }),
+        Err(error) => {
+            checks.push(DoctorCheck {
+                status: DoctorStatus::Fail,
+                label: "secret providers".to_string(),
+                detail: error.to_string(),
+            });
+            return checks;
+        }
+    }
+
+    for provider in configured
+        .split(',')
+        .map(str::trim)
+        .filter(|provider| !provider.is_empty())
+    {
+        match provider {
+            "env" => {
+                let env_provider = EnvSecretProvider::new(namespace.clone());
+                let sample = env_provider.env_var_name(&SecretId::new("sample", "token"));
+                checks.push(DoctorCheck {
+                    status: DoctorStatus::Ok,
+                    label: "secret:env".to_string(),
+                    detail: format!("reads process env via {sample}"),
+                });
+            }
+            "keyring" => {
+                let keyring_provider = KeyringSecretProvider::new(namespace.clone());
+                match keyring_provider.healthcheck() {
+                    Ok(detail) => checks.push(DoctorCheck {
+                        status: DoctorStatus::Ok,
+                        label: "secret:keyring".to_string(),
+                        detail,
+                    }),
+                    Err(error) => checks.push(DoctorCheck {
+                        status: DoctorStatus::Fail,
+                        label: "secret:keyring".to_string(),
+                        detail: error.to_string(),
+                    }),
+                }
+            }
+            other => checks.push(DoctorCheck {
+                status: DoctorStatus::Fail,
+                label: format!("secret:{other}"),
+                detail: format!("unsupported provider '{other}'"),
+            }),
+        }
     }
 
     checks
@@ -511,6 +587,22 @@ fn find_nearest_manifest(start: &Path) -> Option<PathBuf> {
             return None;
         }
     }
+}
+
+fn default_secret_namespace() -> String {
+    if let Ok(namespace) = std::env::var("HARN_SECRET_NAMESPACE") {
+        if !namespace.trim().is_empty() {
+            return namespace;
+        }
+    }
+
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let leaf = cwd
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("workspace");
+    format!("harn/{leaf}")
 }
 
 fn read_manifest(path: &Path) -> Result<package::Manifest, String> {

--- a/crates/harn-cli/src/commands/mcp.rs
+++ b/crates/harn-cli/src/commands/mcp.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::{env, fs, process};
 
 use base64::Engine;
+use harn_vm::secrets::{KeyringSecretProvider, SecretBytes, SecretId, SecretProvider};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use url::Url;
@@ -92,10 +93,12 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
                 eprintln!("error: {error}");
                 process::exit(1);
             });
-            delete_stored_token(&server.url).unwrap_or_else(|error| {
-                eprintln!("error: {error}");
-                process::exit(1);
-            });
+            delete_stored_token(&server.url)
+                .await
+                .unwrap_or_else(|error| {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                });
             println!(
                 "Removed stored OAuth token for {} ({})",
                 server.name, server.url
@@ -106,7 +109,7 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
                 eprintln!("error: {error}");
                 process::exit(1);
             });
-            match load_stored_token(&server.url) {
+            match load_stored_token(&server.url).await {
                 Ok(Some(token)) => {
                     println!("Server: {}", server.name);
                     println!("URL: {}", server.url);
@@ -153,13 +156,13 @@ pub(crate) async fn resolve_auth_for_server(
         return Ok(AuthResolution::None);
     }
 
-    let Some(mut stored) = load_stored_token(&server.url)? else {
+    let Some(mut stored) = load_stored_token(&server.url).await? else {
         return Ok(AuthResolution::None);
     };
 
     if token_needs_refresh(&stored) {
         stored = refresh_token_if_needed(&stored).await?;
-        save_stored_token(&stored)?;
+        save_stored_token(&stored).await?;
     }
 
     Ok(AuthResolution::Bearer(stored.access_token))
@@ -266,7 +269,7 @@ async fn login(options: &McpLoginArgs) -> Result<(), String> {
         resource: server.url.clone(),
         scopes: options.scope.clone().or(server.scopes),
     };
-    save_stored_token(&stored)?;
+    save_stored_token(&stored).await?;
     println!("OAuth token stored for {}.", server.name);
     Ok(())
 }
@@ -756,38 +759,35 @@ fn current_unix_timestamp() -> i64 {
         .unwrap_or_default()
 }
 
-fn save_stored_token(token: &StoredOAuthToken) -> Result<(), String> {
-    let entry = keyring::Entry::new(KEYRING_SERVICE, &token_store_account(&token.resource))
-        .map_err(|error| format!("Failed to open keyring entry: {error}"))?;
+async fn save_stored_token(token: &StoredOAuthToken) -> Result<(), String> {
     let payload = serde_json::to_string(token)
         .map_err(|error| format!("Failed to serialize OAuth token: {error}"))?;
-    entry
-        .set_password(&payload)
+    oauth_token_provider()
+        .put(
+            &token_secret_id(&token.resource),
+            SecretBytes::from(payload.into_bytes()),
+        )
+        .await
         .map_err(|error| format!("Failed to store OAuth token in keyring: {error}"))
 }
 
-fn load_stored_token(resource: &str) -> Result<Option<StoredOAuthToken>, String> {
-    let entry = keyring::Entry::new(KEYRING_SERVICE, &token_store_account(resource))
-        .map_err(|error| format!("Failed to open keyring entry: {error}"))?;
-    let payload = match entry.get_password() {
-        Ok(value) => value,
-        Err(keyring::Error::NoEntry) => return Ok(None),
+async fn load_stored_token(resource: &str) -> Result<Option<StoredOAuthToken>, String> {
+    let payload = match oauth_token_provider().get(&token_secret_id(resource)).await {
+        Ok(secret) => secret,
+        Err(harn_vm::secrets::SecretError::NotFound { .. }) => return Ok(None),
         Err(error) => return Err(format!("Failed to read OAuth token from keyring: {error}")),
     };
-    let token = serde_json::from_str::<StoredOAuthToken>(&payload)
+    let token = payload
+        .with_exposed(|bytes| serde_json::from_slice::<StoredOAuthToken>(bytes))
         .map_err(|error| format!("Stored OAuth token was invalid JSON: {error}"))?;
     Ok(Some(token))
 }
 
-fn delete_stored_token(resource: &str) -> Result<(), String> {
-    let entry = keyring::Entry::new(KEYRING_SERVICE, &token_store_account(resource))
-        .map_err(|error| format!("Failed to open keyring entry: {error}"))?;
-    match entry.delete_credential() {
-        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-        Err(error) => Err(format!(
-            "Failed to delete OAuth token from keyring: {error}"
-        )),
-    }
+async fn delete_stored_token(resource: &str) -> Result<(), String> {
+    oauth_token_provider()
+        .delete(&token_secret_id(resource))
+        .await
+        .map_err(|error| format!("Failed to delete OAuth token from keyring: {error}"))
 }
 
 fn token_store_account(resource: &str) -> String {
@@ -796,6 +796,14 @@ fn token_store_account(resource: &str) -> String {
         "mcp-{}",
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
     )
+}
+
+fn oauth_token_provider() -> KeyringSecretProvider {
+    KeyringSecretProvider::new(KEYRING_SERVICE)
+}
+
+fn token_secret_id(resource: &str) -> SecretId {
+    SecretId::new("", token_store_account(resource))
 }
 
 fn format_expiry(unix: i64) -> String {

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -13,6 +13,7 @@ otel = ["opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp"]
 [dependencies]
 harn-lexer = { path = "../harn-lexer", version = "0.7" }
 harn-parser = { path = "../harn-parser", version = "0.7" }
+async-trait = "0.1"
 regex = "1"
 serde_json = "1"
 rand = "0.10"
@@ -32,9 +33,11 @@ tokio-util = { version = "0.7", features = ["io"] }
 futures = "0.3"
 httpdate = "1"
 ignore = "0.4"
+keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 opentelemetry = { version = "0.31", optional = true }
 opentelemetry_sdk = { version = "0.31", optional = true, features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.31", optional = true }
+zeroize = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -19,6 +19,7 @@ pub mod metadata;
 pub mod orchestration;
 pub mod runtime_paths;
 pub mod schema;
+pub mod secrets;
 pub mod skills;
 pub mod stdlib;
 pub mod stdlib_modules;

--- a/crates/harn-vm/src/secrets/env.rs
+++ b/crates/harn-vm/src/secrets/env.rs
@@ -1,0 +1,144 @@
+use async_trait::async_trait;
+
+use super::{
+    emit_secret_access_event, RotationHandle, SecretBytes, SecretError, SecretId, SecretMeta,
+    SecretProvider, SecretVersion,
+};
+
+#[derive(Debug, Clone)]
+pub struct EnvSecretProvider {
+    namespace: String,
+}
+
+impl EnvSecretProvider {
+    pub fn new(namespace: impl Into<String>) -> Self {
+        Self {
+            namespace: namespace.into(),
+        }
+    }
+
+    pub fn env_var_name(&self, id: &SecretId) -> String {
+        let namespace = normalize_env_component(&id.namespace);
+        let name = normalize_env_component(&id.name);
+        match id.version {
+            SecretVersion::Latest => format!("HARN_SECRET_{namespace}_{name}"),
+            SecretVersion::Exact(version) => format!("HARN_SECRET_{namespace}_{name}_V{version}"),
+        }
+    }
+}
+
+#[async_trait]
+impl SecretProvider for EnvSecretProvider {
+    async fn get(&self, id: &SecretId) -> Result<SecretBytes, SecretError> {
+        let env_name = self.env_var_name(id);
+        match std::env::var(&env_name) {
+            Ok(value) if !value.is_empty() => {
+                emit_secret_access_event("env", id);
+                Ok(SecretBytes::from(value))
+            }
+            _ => Err(SecretError::NotFound {
+                provider: "env".to_string(),
+                id: id.clone(),
+            }),
+        }
+    }
+
+    async fn put(&self, id: &SecretId, value: SecretBytes) -> Result<(), SecretError> {
+        let env_name = self.env_var_name(id);
+        let rendered = value.with_exposed(|bytes| {
+            std::str::from_utf8(bytes)
+                .map(|text| text.to_string())
+                .map_err(|error| SecretError::Backend {
+                    provider: "env".to_string(),
+                    message: format!("env secrets must be valid UTF-8: {error}"),
+                })
+        })?;
+        std::env::set_var(&env_name, rendered);
+        Ok(())
+    }
+
+    async fn rotate(&self, _id: &SecretId) -> Result<RotationHandle, SecretError> {
+        Err(SecretError::Unsupported {
+            provider: "env".to_string(),
+            operation: "rotate",
+        })
+    }
+
+    async fn list(&self, prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError> {
+        let env_prefix = if prefix.name.is_empty() {
+            format!(
+                "HARN_SECRET_{}_",
+                normalize_env_component(&prefix.namespace)
+            )
+        } else {
+            self.env_var_name(prefix)
+        };
+
+        let items = std::env::vars()
+            .filter_map(|(name, _)| {
+                if !name.starts_with(&env_prefix) {
+                    return None;
+                }
+                let suffix = name
+                    .strip_prefix(&format!(
+                        "HARN_SECRET_{}_",
+                        normalize_env_component(&prefix.namespace)
+                    ))
+                    .unwrap_or_default()
+                    .trim_start_matches('_')
+                    .to_ascii_lowercase();
+                Some(SecretMeta {
+                    id: SecretId::new(prefix.namespace.clone(), suffix),
+                    provider: "env".to_string(),
+                })
+            })
+            .collect::<Vec<_>>();
+        Ok(items)
+    }
+
+    fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    fn supports_versions(&self) -> bool {
+        false
+    }
+}
+
+fn normalize_env_component(value: &str) -> String {
+    let mut normalized = String::with_capacity(value.len());
+    let mut last_was_underscore = false;
+    for ch in value.chars() {
+        let mapped = if ch.is_ascii_alphanumeric() {
+            ch.to_ascii_uppercase()
+        } else {
+            '_'
+        };
+        if mapped == '_' {
+            if !last_was_underscore {
+                normalized.push(mapped);
+            }
+            last_was_underscore = true;
+        } else {
+            normalized.push(mapped);
+            last_was_underscore = false;
+        }
+    }
+
+    normalized.trim_matches('_').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_provider_uses_expected_variable_name() {
+        let provider = EnvSecretProvider::new("harn/test");
+        let id = SecretId::new("harn.orchestrator.github", "installation-12345/private-key");
+        assert_eq!(
+            provider.env_var_name(&id),
+            "HARN_SECRET_HARN_ORCHESTRATOR_GITHUB_INSTALLATION_12345_PRIVATE_KEY"
+        );
+    }
+}

--- a/crates/harn-vm/src/secrets/keyring.rs
+++ b/crates/harn-vm/src/secrets/keyring.rs
@@ -1,0 +1,163 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+
+use super::{
+    emit_secret_access_event, RotationHandle, SecretBytes, SecretError, SecretId, SecretMeta,
+    SecretProvider,
+};
+
+#[derive(Debug)]
+pub struct KeyringSecretProvider {
+    namespace: String,
+    entries: Mutex<HashMap<String, Arc<::keyring::Entry>>>,
+}
+
+impl KeyringSecretProvider {
+    pub fn new(namespace: impl Into<String>) -> Self {
+        Self {
+            namespace: namespace.into(),
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn service(&self) -> &str {
+        &self.namespace
+    }
+
+    pub async fn delete(&self, id: &SecretId) -> Result<(), SecretError> {
+        let entry = self.entry(id)?;
+        match entry.delete_credential() {
+            Ok(()) | Err(::keyring::Error::NoEntry) => Ok(()),
+            Err(error) => Err(SecretError::Backend {
+                provider: "keyring".to_string(),
+                message: format!("failed to delete keyring credential: {error}"),
+            }),
+        }
+    }
+
+    pub fn healthcheck(&self) -> Result<String, SecretError> {
+        let probe = SecretId::new("", "__harn_probe__");
+        let entry = self.entry(&probe)?;
+        match entry.get_secret() {
+            Ok(_) | Err(::keyring::Error::NoEntry) => {
+                Ok(format!("service '{}' reachable", self.namespace))
+            }
+            Err(error) => Err(SecretError::Backend {
+                provider: "keyring".to_string(),
+                message: format!("failed to access keyring backend: {error}"),
+            }),
+        }
+    }
+
+    fn entry(&self, id: &SecretId) -> Result<Arc<::keyring::Entry>, SecretError> {
+        let account = account_name(id);
+        let mut entries = self.entries.lock().expect("keyring cache poisoned");
+        if let Some(entry) = entries.get(&account) {
+            return Ok(entry.clone());
+        }
+
+        let entry = Arc::new(
+            ::keyring::Entry::new(self.service(), &account).map_err(|error| {
+                SecretError::Backend {
+                    provider: "keyring".to_string(),
+                    message: format!("failed to create keyring entry: {error}"),
+                }
+            })?,
+        );
+        entries.insert(account, entry.clone());
+        Ok(entry)
+    }
+}
+
+#[async_trait]
+impl SecretProvider for KeyringSecretProvider {
+    async fn get(&self, id: &SecretId) -> Result<SecretBytes, SecretError> {
+        let entry = self.entry(id)?;
+        match entry.get_secret() {
+            Ok(bytes) => {
+                emit_secret_access_event("keyring", id);
+                Ok(SecretBytes::from(bytes))
+            }
+            Err(::keyring::Error::NoEntry) => Err(SecretError::NotFound {
+                provider: "keyring".to_string(),
+                id: id.clone(),
+            }),
+            Err(error) => Err(SecretError::Backend {
+                provider: "keyring".to_string(),
+                message: format!("failed to read keyring secret: {error}"),
+            }),
+        }
+    }
+
+    async fn put(&self, id: &SecretId, value: SecretBytes) -> Result<(), SecretError> {
+        let entry = self.entry(id)?;
+        value.with_exposed(|bytes| {
+            entry
+                .set_secret(bytes)
+                .map_err(|error| SecretError::Backend {
+                    provider: "keyring".to_string(),
+                    message: format!("failed to store keyring secret: {error}"),
+                })
+        })
+    }
+
+    async fn rotate(&self, _id: &SecretId) -> Result<RotationHandle, SecretError> {
+        Err(SecretError::Unsupported {
+            provider: "keyring".to_string(),
+            operation: "rotate",
+        })
+    }
+
+    async fn list(&self, _prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError> {
+        Err(SecretError::Unsupported {
+            provider: "keyring".to_string(),
+            operation: "list",
+        })
+    }
+
+    fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    fn supports_versions(&self) -> bool {
+        false
+    }
+}
+
+fn account_name(id: &SecretId) -> String {
+    let mut account = String::new();
+    if !id.namespace.is_empty() {
+        account.push_str(&sanitize_component(&id.namespace));
+        account.push('/');
+    }
+    account.push_str(&sanitize_component(&id.name));
+    match id.version {
+        super::SecretVersion::Latest => {}
+        super::SecretVersion::Exact(version) => {
+            account.push('#');
+            account.push('v');
+            account.push_str(&version.to_string());
+        }
+    }
+    account
+}
+
+fn sanitize_component(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | ':' | '/') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if normalized.is_empty() {
+        "_".to_string()
+    } else {
+        normalized
+    }
+}

--- a/crates/harn-vm/src/secrets/mod.rs
+++ b/crates/harn-vm/src/secrets/mod.rs
@@ -1,0 +1,616 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, Zeroizing};
+
+mod env;
+mod keyring;
+
+pub use env::EnvSecretProvider;
+pub use keyring::KeyringSecretProvider;
+
+pub const DEFAULT_SECRET_PROVIDER_CHAIN: &str = "env,keyring";
+pub const SECRET_PROVIDER_CHAIN_ENV: &str = "HARN_SECRET_PROVIDERS";
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+pub enum SecretVersion {
+    #[default]
+    Latest,
+    Exact(u64),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct SecretId {
+    pub namespace: String,
+    pub name: String,
+    #[serde(default)]
+    pub version: SecretVersion,
+}
+
+impl SecretId {
+    pub fn new(namespace: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            namespace: namespace.into(),
+            name: name.into(),
+            version: SecretVersion::Latest,
+        }
+    }
+
+    pub fn with_version(mut self, version: SecretVersion) -> Self {
+        self.version = version;
+        self
+    }
+}
+
+impl fmt::Display for SecretId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.namespace.is_empty() {
+            write!(f, "{}", self.name)?;
+        } else {
+            write!(f, "{}/{}", self.namespace, self.name)?;
+        }
+        match self.version {
+            SecretVersion::Latest => Ok(()),
+            SecretVersion::Exact(version) => write!(f, "@{version}"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SecretMeta {
+    pub id: SecretId,
+    pub provider: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RotationHandle {
+    pub provider: String,
+    pub id: SecretId,
+    pub from_version: Option<u64>,
+    pub to_version: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SecretError {
+    NotFound {
+        provider: String,
+        id: SecretId,
+    },
+    Unsupported {
+        provider: String,
+        operation: &'static str,
+    },
+    Backend {
+        provider: String,
+        message: String,
+    },
+    InvalidConfig(String),
+    NoProviders {
+        namespace: String,
+    },
+    All(Vec<SecretError>),
+}
+
+impl fmt::Display for SecretError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound { provider, id } => {
+                write!(f, "{provider}: secret '{id}' not found")
+            }
+            Self::Unsupported {
+                provider,
+                operation,
+            } => write!(f, "{provider}: operation '{operation}' is unsupported"),
+            Self::Backend { provider, message } => write!(f, "{provider}: {message}"),
+            Self::InvalidConfig(message) => write!(f, "{message}"),
+            Self::NoProviders { namespace } => {
+                write!(
+                    f,
+                    "no secret providers configured for namespace '{namespace}'"
+                )
+            }
+            Self::All(errors) => {
+                let rendered = errors
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                write!(f, "all secret providers failed: {rendered}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SecretError {}
+
+#[derive(Default)]
+struct SecretBuffer {
+    bytes: Vec<u8>,
+    #[cfg(test)]
+    drop_probe: Option<std::sync::Arc<std::sync::Mutex<Option<Vec<u8>>>>>,
+}
+
+impl SecretBuffer {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self {
+            bytes,
+            #[cfg(test)]
+            drop_probe: None,
+        }
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    #[cfg(test)]
+    fn attach_drop_probe(&mut self, probe: std::sync::Arc<std::sync::Mutex<Option<Vec<u8>>>>) {
+        self.drop_probe = Some(probe);
+    }
+}
+
+impl std::ops::Deref for SecretBuffer {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl Zeroize for SecretBuffer {
+    fn zeroize(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+impl Drop for SecretBuffer {
+    fn drop(&mut self) {
+        #[cfg(test)]
+        if let Some(probe) = &self.drop_probe {
+            *probe.lock().expect("drop probe poisoned") = Some(self.bytes.clone());
+        }
+    }
+}
+
+pub struct SecretBytes(Zeroizing<SecretBuffer>);
+
+impl SecretBytes {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(Zeroizing::new(SecretBuffer::new(bytes)))
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.as_slice().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.as_slice().is_empty()
+    }
+
+    pub fn with_exposed<R>(&self, f: impl FnOnce(&[u8]) -> R) -> R {
+        f(self.0.as_slice())
+    }
+
+    pub fn reborrow(&self) -> Self {
+        self.with_exposed(|bytes| Self::new(bytes.to_vec()))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn attach_drop_probe(
+        &mut self,
+        probe: std::sync::Arc<std::sync::Mutex<Option<Vec<u8>>>>,
+    ) {
+        self.0.attach_drop_probe(probe);
+    }
+}
+
+impl fmt::Debug for SecretBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SecretBytes {{ redacted: {} bytes }}", self.len())
+    }
+}
+
+impl Serialize for SecretBytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("<redacted:{} bytes>", self.len()))
+    }
+}
+
+impl From<Vec<u8>> for SecretBytes {
+    fn from(value: Vec<u8>) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for SecretBytes {
+    fn from(value: String) -> Self {
+        Self::new(value.into_bytes())
+    }
+}
+
+impl From<&str> for SecretBytes {
+    fn from(value: &str) -> Self {
+        Self::new(value.as_bytes().to_vec())
+    }
+}
+
+impl From<&[u8]> for SecretBytes {
+    fn from(value: &[u8]) -> Self {
+        Self::new(value.to_vec())
+    }
+}
+
+#[async_trait]
+pub trait SecretProvider: Send + Sync {
+    async fn get(&self, id: &SecretId) -> Result<SecretBytes, SecretError>;
+    async fn put(&self, id: &SecretId, value: SecretBytes) -> Result<(), SecretError>;
+    async fn rotate(&self, id: &SecretId) -> Result<RotationHandle, SecretError>;
+    async fn list(&self, prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError>;
+
+    fn namespace(&self) -> &str;
+    fn supports_versions(&self) -> bool;
+}
+
+pub struct ChainSecretProvider {
+    namespace: String,
+    providers: Vec<Arc<dyn SecretProvider>>,
+}
+
+impl ChainSecretProvider {
+    pub fn new(namespace: impl Into<String>, providers: Vec<Arc<dyn SecretProvider>>) -> Self {
+        Self {
+            namespace: namespace.into(),
+            providers,
+        }
+    }
+
+    pub fn providers(&self) -> &[Arc<dyn SecretProvider>] {
+        &self.providers
+    }
+}
+
+#[async_trait]
+impl SecretProvider for ChainSecretProvider {
+    async fn get(&self, id: &SecretId) -> Result<SecretBytes, SecretError> {
+        if self.providers.is_empty() {
+            return Err(SecretError::NoProviders {
+                namespace: self.namespace.clone(),
+            });
+        }
+
+        let mut errors = Vec::new();
+        for provider in &self.providers {
+            match provider.get(id).await {
+                Ok(secret) => return Ok(secret),
+                Err(error) => errors.push(error),
+            }
+        }
+
+        Err(SecretError::All(errors))
+    }
+
+    async fn put(&self, id: &SecretId, value: SecretBytes) -> Result<(), SecretError> {
+        if self.providers.is_empty() {
+            return Err(SecretError::NoProviders {
+                namespace: self.namespace.clone(),
+            });
+        }
+
+        let mut last_value = Some(value);
+        let mut errors = Vec::new();
+        for (index, provider) in self.providers.iter().enumerate() {
+            let attempt_value = if index + 1 == self.providers.len() {
+                last_value
+                    .take()
+                    .expect("final secret write attempt missing value")
+            } else {
+                last_value
+                    .as_ref()
+                    .expect("intermediate secret write attempt missing value")
+                    .reborrow()
+            };
+            match provider.put(id, attempt_value).await {
+                Ok(()) => return Ok(()),
+                Err(error) => errors.push(error),
+            }
+        }
+
+        Err(SecretError::All(errors))
+    }
+
+    async fn rotate(&self, id: &SecretId) -> Result<RotationHandle, SecretError> {
+        if self.providers.is_empty() {
+            return Err(SecretError::NoProviders {
+                namespace: self.namespace.clone(),
+            });
+        }
+
+        let mut errors = Vec::new();
+        for provider in &self.providers {
+            match provider.rotate(id).await {
+                Ok(handle) => return Ok(handle),
+                Err(error) => errors.push(error),
+            }
+        }
+
+        Err(SecretError::All(errors))
+    }
+
+    async fn list(&self, prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError> {
+        if self.providers.is_empty() {
+            return Err(SecretError::NoProviders {
+                namespace: self.namespace.clone(),
+            });
+        }
+
+        let mut errors = Vec::new();
+        let mut merged = BTreeMap::<SecretId, SecretMeta>::new();
+        for provider in &self.providers {
+            match provider.list(prefix).await {
+                Ok(items) => {
+                    for item in items {
+                        merged.entry(item.id.clone()).or_insert(item);
+                    }
+                }
+                Err(error) => errors.push(error),
+            }
+        }
+
+        if merged.is_empty() && !errors.is_empty() {
+            return Err(SecretError::All(errors));
+        }
+
+        Ok(merged.into_values().collect())
+    }
+
+    fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    fn supports_versions(&self) -> bool {
+        self.providers
+            .iter()
+            .any(|provider| provider.supports_versions())
+    }
+}
+
+pub fn configured_default_chain(
+    namespace: impl Into<String>,
+) -> Result<ChainSecretProvider, SecretError> {
+    let namespace = namespace.into();
+    let configured = std::env::var(SECRET_PROVIDER_CHAIN_ENV)
+        .unwrap_or_else(|_| DEFAULT_SECRET_PROVIDER_CHAIN.to_string());
+    let mut providers: Vec<Arc<dyn SecretProvider>> = Vec::new();
+
+    for raw_name in configured.split(',') {
+        let provider_name = raw_name.trim();
+        if provider_name.is_empty() {
+            continue;
+        }
+        match provider_name {
+            "env" => providers.push(Arc::new(EnvSecretProvider::new(namespace.clone()))),
+            "keyring" => providers.push(Arc::new(KeyringSecretProvider::new(namespace.clone()))),
+            other => {
+                return Err(SecretError::InvalidConfig(format!(
+                    "unsupported secret provider '{other}' in {SECRET_PROVIDER_CHAIN_ENV}; expected a comma-separated list of env,keyring"
+                )))
+            }
+        }
+    }
+
+    Ok(ChainSecretProvider::new(namespace, providers))
+}
+
+pub(crate) fn emit_secret_access_event(provider: &str, id: &SecretId) {
+    #[derive(Serialize)]
+    struct SecretAccessEvent<'a> {
+        topic: &'a str,
+        provider: &'a str,
+        id: &'a SecretId,
+        caller_span_id: Option<u64>,
+        mutation_session_id: Option<String>,
+        timestamp: String,
+    }
+
+    let event = SecretAccessEvent {
+        topic: "audit.secret_access",
+        provider,
+        id,
+        caller_span_id: crate::tracing::current_span_id(),
+        mutation_session_id: crate::orchestration::current_mutation_session()
+            .map(|session| session.session_id),
+        timestamp: crate::orchestration::now_rfc3339(),
+    };
+    let metadata = serde_json::to_value(event)
+        .ok()
+        .and_then(|value| value.as_object().cloned())
+        .map(|object| object.into_iter().collect::<BTreeMap<_, _>>())
+        .unwrap_or_default();
+    crate::events::log_info_meta("secret.audit", "secret accessed", metadata);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex, Once};
+
+    use async_trait::async_trait;
+
+    use super::*;
+
+    fn install_mock_keyring() {
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            ::keyring::set_default_credential_builder(::keyring::mock::default_credential_builder());
+        });
+    }
+
+    struct FakeProvider {
+        namespace: String,
+        result: Mutex<Vec<Result<SecretBytes, SecretError>>>,
+    }
+
+    impl FakeProvider {
+        fn new(
+            namespace: impl Into<String>,
+            result: Vec<Result<SecretBytes, SecretError>>,
+        ) -> Self {
+            Self {
+                namespace: namespace.into(),
+                result: Mutex::new(result),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SecretProvider for FakeProvider {
+        async fn get(&self, _id: &SecretId) -> Result<SecretBytes, SecretError> {
+            self.result
+                .lock()
+                .expect("fake provider poisoned")
+                .remove(0)
+        }
+
+        async fn put(&self, _id: &SecretId, _value: SecretBytes) -> Result<(), SecretError> {
+            Err(SecretError::Unsupported {
+                provider: self.namespace.clone(),
+                operation: "put",
+            })
+        }
+
+        async fn rotate(&self, _id: &SecretId) -> Result<RotationHandle, SecretError> {
+            Err(SecretError::Unsupported {
+                provider: self.namespace.clone(),
+                operation: "rotate",
+            })
+        }
+
+        async fn list(&self, _prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError> {
+            Err(SecretError::Unsupported {
+                provider: self.namespace.clone(),
+                operation: "list",
+            })
+        }
+
+        fn namespace(&self) -> &str {
+            &self.namespace
+        }
+
+        fn supports_versions(&self) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn secret_bytes_debug_is_redacted() {
+        let secret = SecretBytes::from("abcd");
+        assert_eq!(format!("{secret:?}"), "SecretBytes { redacted: 4 bytes }");
+    }
+
+    #[test]
+    fn secret_bytes_zeroes_on_drop() {
+        let probe = Arc::new(Mutex::new(None));
+        let mut secret = SecretBytes::from("super-secret");
+        secret.attach_drop_probe(probe.clone());
+        drop(secret);
+
+        let dropped = probe
+            .lock()
+            .expect("drop probe poisoned")
+            .clone()
+            .expect("probe should capture bytes");
+        assert!(dropped.iter().all(|byte| *byte == 0));
+    }
+
+    #[tokio::test]
+    async fn chain_secret_provider_falls_through_to_next_hit() {
+        let id = SecretId::new("harn.test", "api-key");
+        let first = Arc::new(FakeProvider::new(
+            "first",
+            vec![Err(SecretError::NotFound {
+                provider: "first".to_string(),
+                id: id.clone(),
+            })],
+        ));
+        let second = Arc::new(FakeProvider::new(
+            "second",
+            vec![Ok(SecretBytes::from("value"))],
+        ));
+        let chain = ChainSecretProvider::new("harn/test", vec![first, second]);
+
+        let secret = chain.get(&id).await.expect("chain should resolve");
+        let exposed = secret.with_exposed(|bytes| bytes.to_vec());
+        assert_eq!(exposed, b"value");
+    }
+
+    #[tokio::test]
+    async fn chain_secret_provider_returns_all_errors_when_everything_fails() {
+        let id = SecretId::new("harn.test", "missing");
+        let first = Arc::new(FakeProvider::new(
+            "first",
+            vec![Err(SecretError::NotFound {
+                provider: "first".to_string(),
+                id: id.clone(),
+            })],
+        ));
+        let second = Arc::new(FakeProvider::new(
+            "second",
+            vec![Err(SecretError::Backend {
+                provider: "second".to_string(),
+                message: "boom".to_string(),
+            })],
+        ));
+        let chain = ChainSecretProvider::new("harn/test", vec![first, second]);
+
+        let error = chain.get(&id).await.expect_err("chain should fail");
+        match error {
+            SecretError::All(errors) => {
+                assert_eq!(errors.len(), 2);
+                assert!(matches!(errors[0], SecretError::NotFound { .. }));
+                assert!(matches!(errors[1], SecretError::Backend { .. }));
+            }
+            other => panic!("expected aggregated errors, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn keyring_provider_round_trips_and_zeroes_on_drop() {
+        install_mock_keyring();
+
+        let provider = KeyringSecretProvider::new("harn.test");
+        let id = SecretId::new("", format!("mock-{}", uuid::Uuid::now_v7()));
+        provider
+            .put(&id, SecretBytes::from("round-trip-secret"))
+            .await
+            .expect("mock keyring write should succeed");
+
+        let probe = Arc::new(Mutex::new(None));
+        let mut secret = provider
+            .get(&id)
+            .await
+            .expect("mock keyring read should succeed");
+        assert_eq!(
+            secret.with_exposed(|bytes| bytes.to_vec()),
+            b"round-trip-secret"
+        );
+        secret.attach_drop_probe(probe.clone());
+        drop(secret);
+
+        let dropped = probe
+            .lock()
+            .expect("drop probe poisoned")
+            .clone()
+            .expect("probe should capture bytes");
+        assert!(dropped.iter().all(|byte| *byte == 0));
+
+        provider
+            .delete(&id)
+            .await
+            .expect("mock keyring delete should succeed");
+    }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -37,6 +37,7 @@
 - [Bridge protocol](./bridge-protocol.md)
 - [MCP and ACP integration](./mcp-and-acp.md)
 - [Harn portal](./portal.md)
+- [Orchestrator secrets](./orchestrator/secrets.md)
 
 # Reference
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -332,7 +332,8 @@ explicit.
 
 ## harn doctor
 
-Inspect the local environment and report the current Harn setup.
+Inspect the local environment and report the current Harn setup,
+including the resolved secret-provider chain and keyring health.
 
 ```bash
 harn doctor

--- a/docs/src/orchestrator/secrets.md
+++ b/docs/src/orchestrator/secrets.md
@@ -1,0 +1,113 @@
+# Orchestrator Secrets
+
+Reactive Harn features need a single way to fetch secrets without
+sprinkling provider-specific code across connectors, OAuth flows, and
+future orchestrator runtime surfaces. The secret layer lives in
+`harn_vm::secrets` and currently ships with two concrete providers:
+
+- `EnvSecretProvider`
+- `KeyringSecretProvider`
+
+The default chain is:
+
+```text
+env -> keyring
+```
+
+Use `harn doctor --no-network` to inspect the active chain and to verify
+that the keyring backend is reachable on the current machine.
+
+## Secret model
+
+Secrets are addressed by a structured `SecretId`:
+
+```rust
+use harn_vm::secrets::{SecretId, SecretVersion};
+
+let id = SecretId::new(
+    "harn.orchestrator.github",
+    "installation-12345/private-key",
+)
+.with_version(SecretVersion::Latest);
+```
+
+Secret values are held in `SecretBytes`:
+
+- bytes are zeroized on drop
+- `Debug` is redacted
+- `Display` is intentionally absent
+- explicit duplication requires `reborrow()`
+- callers expose bytes via `with_exposed(|bytes| ...)`
+
+Successful `get()` calls also emit a structured audit event through the
+existing VM event sink with the secret id, provider name, caller span,
+mutation session id when present, and a timestamp. The event payload never
+contains the secret bytes.
+
+## Provider chain configuration
+
+The provider order is controlled with `HARN_SECRET_PROVIDERS`:
+
+```bash
+export HARN_SECRET_PROVIDERS=env,keyring
+```
+
+The doctor output also reports a namespace used for backend grouping. By
+default Harn derives it as `harn/<current-directory-name>`. Override it
+with:
+
+```bash
+export HARN_SECRET_NAMESPACE="harn/my-workspace"
+```
+
+## Environment provider
+
+`EnvSecretProvider` is first in the chain so CI, local shells, and
+containers can override secrets without touching the OS credential store.
+
+Environment variable names use:
+
+```text
+HARN_SECRET_<NAMESPACE>_<NAME>
+```
+
+For example:
+
+```bash
+export HARN_SECRET_HARN_ORCHESTRATOR_GITHUB_INSTALLATION_12345_PRIVATE_KEY="$(cat github-app.pem)"
+```
+
+Non-alphanumeric characters are normalized to underscores and multiple
+separators collapse.
+
+## Keyring provider
+
+`KeyringSecretProvider` uses the [`keyring`](https://crates.io/crates/keyring)
+crate so the same code path works against:
+
+- macOS Keychain
+- Linux native keyring / Secret Service backends supported by `keyring`
+- Windows Credential Manager
+
+This is the default local-first provider. The CLI already uses it for MCP
+OAuth token storage, and `harn doctor` probes it directly.
+
+## Recommended setups
+
+Laptop development:
+
+```bash
+export HARN_SECRET_PROVIDERS=env,keyring
+```
+
+CI or containers:
+
+```bash
+export HARN_SECRET_PROVIDERS=env
+```
+
+Cloud deployments:
+
+Today, use `env` for injected platform secrets. The `SecretProvider`
+surface is intentionally ready for Vault / AWS / GCP implementations, but
+those provider backends are not wired in yet.


### PR DESCRIPTION
## Summary
- add a new `harn_vm::secrets` module with `SecretProvider`, `ChainSecretProvider`, zeroizing `SecretBytes`, and env/keyring implementations
- route MCP OAuth token persistence through the shared keyring provider instead of a one-off keyring code path
- extend `harn doctor` and the docs/changelog to surface the active secret-provider chain and backend health

## Why
Issue #154 calls for a foundational secret abstraction that connectors and the future orchestrator runtime can share. The repo already had ad hoc keyring handling in MCP OAuth, but no reusable secret model, no chain composition, and no visibility in `harn doctor`.

This change lands the core primitives with the smallest coherent implementation that fits the current codebase:
- env-first overrides for CI and containers
- keyring-backed local storage for laptops
- audit events on successful secret reads
- an immediate in-tree consumer via MCP OAuth token storage

## Validation
- `cargo test -p harn-vm secrets --lib`
- `cargo test -p harn-cli token_store_account_is_stable`
- `cargo test -p harn-cli test_parses_doctor_flags`
- `cargo run --bin harn -- doctor --no-network`
- repo pre-commit hook: `cargo fmt`, clippy, markdown lint, portal lint
- repo pre-push hook: fast release-quality checks / workspace tests

Closes #154.
