### PR TITLE
[codex] Implement TriggerEvent schema and std/triggers typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ granular archaeology.
   session transcript + per-session agent-event sinks migrate onto
   the shared abstraction, `harn doctor` surfaces the active backend
   and on-disk footprint, and SQLite is the default when persisting.
+- **`TriggerEvent` schema and `std/triggers` stdlib types (#196,
+  closes #155).** New `harn_vm::triggers::event` module defines the
+  typed `TriggerEvent` envelope with a provider-payload union and
+  signature-status field, plus the `std/triggers` stdlib type
+  surface scripts use to construct and inspect trigger events.
+  Lays the type foundation that upcoming EventLog-backed trigger
+  registry, LLM predicate gate, and handler dispatcher work will
+  consume.
 
 ## v0.7.22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -887,6 +888,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "tempfile",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/crates/harn-cli/src/commands/bench.rs
+++ b/crates/harn-cli/src/commands/bench.rs
@@ -31,6 +31,9 @@ pub(crate) async fn run_bench(path: &str, iterations: usize) {
     if let Some(imported) = graph.imported_names_for_file(file_path) {
         checker = checker.with_imported_names(imported);
     }
+    if let Some(imported) = graph.imported_type_declarations_for_file(file_path) {
+        checker = checker.with_imported_type_decls(imported);
+    }
     let type_diagnostics = checker.check(&program);
     let mut had_type_error = false;
     for diag in &type_diagnostics {

--- a/crates/harn-cli/src/commands/check/check_cmd.rs
+++ b/crates/harn-cli/src/commands/check/check_cmd.rs
@@ -26,6 +26,9 @@ pub(crate) fn check_file_inner(
     if let Some(imported) = module_graph.imported_names_for_file(path) {
         checker = checker.with_imported_names(imported);
     }
+    if let Some(imported) = module_graph.imported_type_declarations_for_file(path) {
+        checker = checker.with_imported_type_decls(imported);
+    }
     let type_diagnostics = checker.check(&program);
     for diag in &type_diagnostics {
         let severity = match diag.severity {

--- a/crates/harn-cli/src/commands/check/lint.rs
+++ b/crates/harn-cli/src/commands/check/lint.rs
@@ -84,6 +84,9 @@ pub(crate) fn lint_fix_file(
     if let Some(imported) = module_graph.imported_names_for_file(path) {
         checker = checker.with_imported_names(imported);
     }
+    if let Some(imported) = module_graph.imported_type_declarations_for_file(path) {
+        checker = checker.with_imported_type_decls(imported);
+    }
     let type_diags = checker.check_with_source(&program, &source);
 
     let mut edits: Vec<&harn_lexer::FixEdit> = lint_diags

--- a/crates/harn-cli/src/commands/playground.rs
+++ b/crates/harn-cli/src/commands/playground.rs
@@ -272,6 +272,9 @@ fn typecheck_program(
     if !imported.is_empty() {
         checker = checker.with_imported_names(imported);
     }
+    if let Some(imported) = graph.imported_type_declarations_for_file(path) {
+        checker = checker.with_imported_type_decls(imported);
+    }
 
     let diagnostics = checker.check(program);
     let mut rendered = String::new();

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -84,6 +84,9 @@ fn typecheck_with_imports(
     if let Some(imported) = graph.imported_names_for_file(path) {
         checker = checker.with_imported_names(imported);
     }
+    if let Some(imported) = graph.imported_type_declarations_for_file(path) {
+        checker = checker.with_imported_type_decls(imported);
+    }
     checker.check(program)
 }
 

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -910,6 +910,9 @@ pub(crate) async fn execute(source: &str, source_path: Option<&Path>) -> Result<
         if let Some(imported) = graph.imported_names_for_file(path) {
             checker = checker.with_imported_names(imported);
         }
+        if let Some(imported) = graph.imported_type_declarations_for_file(path) {
+            checker = checker.with_imported_type_decls(imported);
+        }
     }
     let type_diagnostics = checker.check(&program);
     let mut warning_lines = Vec::new();

--- a/crates/harn-modules/src/lib.rs
+++ b/crates/harn-modules/src/lib.rs
@@ -69,6 +69,9 @@ struct ModuleInfo {
     fn_names: Vec<String>,
     /// True when at least one `pub fn` appeared at module scope.
     has_pub_fn: bool,
+    /// Top-level type-like declarations that can be imported into a caller's
+    /// static type environment.
+    type_declarations: Vec<SNode>,
 }
 
 #[derive(Debug, Clone)]
@@ -316,6 +319,47 @@ impl ModuleGraph {
         Some(names)
     }
 
+    /// Collect type / struct / enum / interface declarations made visible to
+    /// `file` by its imports. Returns `None` when any import is unresolved so
+    /// callers can fall back to conservative behavior.
+    pub fn imported_type_declarations_for_file(&self, file: &Path) -> Option<Vec<SNode>> {
+        let file = normalize_path(file);
+        let module = self.modules.get(&file)?;
+        if module.has_unresolved_wildcard_import || module.has_unresolved_selective_import {
+            return None;
+        }
+
+        let mut decls = Vec::new();
+        for import in &module.imports {
+            let import_path = import.path.as_ref()?;
+            let imported = self
+                .modules
+                .get(import_path)
+                .or_else(|| self.modules.get(&normalize_path(import_path)))?;
+            match &import.selective_names {
+                None => {
+                    for decl in &imported.type_declarations {
+                        if let Some(name) = type_decl_name(decl) {
+                            if imported.exports.contains(name) {
+                                decls.push(decl.clone());
+                            }
+                        }
+                    }
+                }
+                Some(selective) => {
+                    for decl in &imported.type_declarations {
+                        if let Some(name) = type_decl_name(decl) {
+                            if selective.contains(name) {
+                                decls.push(decl.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Some(decls)
+    }
+
     /// Find the definition of `name` visible from `file`.
     pub fn definition_of(&self, file: &Path, name: &str) -> Option<DefSite> {
         let file = normalize_path(file);
@@ -394,6 +438,7 @@ fn load_module(path: &Path) -> ModuleInfo {
     let mut module = ModuleInfo::default();
     for node in &program {
         collect_module_info(path, node, &mut module);
+        collect_type_declarations(node, &mut module.type_declarations);
     }
     // Fallback matching the VM loader: if the module declares no
     // `pub fn`, every fn is implicitly exported.
@@ -532,6 +577,27 @@ fn collect_module_info(file: &Path, snode: &SNode, module: &mut ModuleInfo) {
     }
 }
 
+fn collect_type_declarations(snode: &SNode, decls: &mut Vec<SNode>) {
+    match &snode.node {
+        Node::TypeDecl { .. }
+        | Node::StructDecl { .. }
+        | Node::EnumDecl { .. }
+        | Node::InterfaceDecl { .. } => decls.push(snode.clone()),
+        Node::AttributedDecl { inner, .. } => collect_type_declarations(inner, decls),
+        _ => {}
+    }
+}
+
+fn type_decl_name(snode: &SNode) -> Option<&str> {
+    match &snode.node {
+        Node::TypeDecl { name, .. }
+        | Node::StructDecl { name, .. }
+        | Node::EnumDecl { name, .. }
+        | Node::InterfaceDecl { name, .. } => Some(name.as_str()),
+        _ => None,
+    }
+}
+
 fn decl_site(file: &Path, span: Span, name: &str, kind: DefKind) -> DefSite {
     DefSite {
         name: name.to_string(),
@@ -637,6 +703,30 @@ mod tests {
             .expect("std/math should resolve");
         // `clamp` is defined in stdlib_math.harn as `pub fn clamp(...)`.
         assert!(imported.contains("clamp"));
+    }
+
+    #[test]
+    fn stdlib_imports_expose_type_declarations() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let entry = write_file(
+            root,
+            "entry.harn",
+            "import \"std/triggers\"\nlet provider = \"github\"\n",
+        );
+
+        let graph = build(std::slice::from_ref(&entry));
+        let decls = graph
+            .imported_type_declarations_for_file(&entry)
+            .expect("std/triggers type declarations should resolve");
+        let names: HashSet<String> = decls
+            .iter()
+            .filter_map(type_decl_name)
+            .map(ToString::to_string)
+            .collect();
+        assert!(names.contains("TriggerEvent"));
+        assert!(names.contains("ProviderPayload"));
+        assert!(names.contains("SignatureStatus"));
     }
 
     #[test]

--- a/crates/harn-modules/src/stdlib.rs
+++ b/crates/harn-modules/src/stdlib.rs
@@ -29,6 +29,7 @@ pub(crate) fn get_stdlib_source(module: &str) -> Option<&'static str> {
         "checkpoint" => Some(include_str!("../../harn-vm/src/stdlib_checkpoint.harn")),
         "worktree" => Some(include_str!("../../harn-vm/src/stdlib_worktree.harn")),
         "acp" => Some(include_str!("../../harn-vm/src/stdlib_acp.harn")),
+        "triggers" => Some(include_str!("../../harn-vm/src/stdlib_triggers.harn")),
         _ => None,
     }
 }

--- a/crates/harn-parser/src/typechecker/inference/entry.rs
+++ b/crates/harn-parser/src/typechecker/inference/entry.rs
@@ -19,6 +19,7 @@ impl TypeChecker {
         mut self,
         program: &[SNode],
     ) -> (Vec<TypeDiagnostic>, Vec<InlayHintInfo>) {
+        Self::register_declarations_into(&mut self.scope, &self.imported_type_decls);
         // First pass: collect declarations (type/enum/struct/interface) into scope
         // before type-checking bodies so forward references resolve.
         Self::register_declarations_into(&mut self.scope, program);

--- a/crates/harn-parser/src/typechecker/mod.rs
+++ b/crates/harn-parser/src/typechecker/mod.rs
@@ -90,6 +90,10 @@ pub struct TypeChecker {
     /// conservative pre-v0.7.12 behavior (no cross-module undefined-name
     /// diagnostics).
     imported_names: Option<HashSet<String>>,
+    /// Type-like declarations imported from other modules. These are registered
+    /// into the scope before local checking so imported type aliases and tagged
+    /// unions participate in normal field access and narrowing.
+    imported_type_decls: Vec<SNode>,
 }
 
 impl TypeChecker {
@@ -119,6 +123,7 @@ impl TypeChecker {
             fn_depth: 0,
             deprecated_fns: std::collections::HashMap::new(),
             imported_names: None,
+            imported_type_decls: Vec::new(),
         }
     }
 
@@ -134,6 +139,7 @@ impl TypeChecker {
             fn_depth: 0,
             deprecated_fns: std::collections::HashMap::new(),
             imported_names: None,
+            imported_type_decls: Vec::new(),
         }
     }
 
@@ -149,6 +155,14 @@ impl TypeChecker {
     /// — see `harn_modules::ModuleGraph::imported_names_for_file`.
     pub fn with_imported_names(mut self, imported: HashSet<String>) -> Self {
         self.imported_names = Some(imported);
+        self
+    }
+
+    /// Attach imported type / struct / enum / interface declarations. The
+    /// caller is responsible for resolving module imports and filtering the
+    /// visible declarations before passing them in.
+    pub fn with_imported_type_decls(mut self, imported: Vec<SNode>) -> Self {
+        self.imported_type_decls = imported;
         self
     }
 

--- a/crates/harn-parser/src/typechecker/tests/imports.rs
+++ b/crates/harn-parser/src/typechecker/tests/imports.rs
@@ -1,0 +1,105 @@
+use super::*;
+
+fn parse_program(source: &str) -> Vec<crate::SNode> {
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    parser.parse().unwrap()
+}
+
+#[test]
+fn imported_type_aliases_are_registered_into_scope() {
+    let imported = parse_program(
+        r#"
+type SignatureStatus = { state: "verified" } | { state: "failed", reason: string }
+
+type GitHubEventPayload = {
+  provider: "github",
+  action: string | nil,
+  raw: dict,
+}
+
+type SlackEventPayload = {
+  provider: "slack",
+  subtype: string | nil,
+  raw: dict,
+}
+
+type ProviderPayload = GitHubEventPayload | SlackEventPayload
+
+type TriggerEvent = {
+  provider_payload: ProviderPayload,
+  signature_status: SignatureStatus,
+}
+"#,
+    );
+    let program = parse_program(
+        r#"
+pipeline t(task) {
+  let event: TriggerEvent = {
+    provider_payload: {
+      provider: "github",
+      action: "opened",
+      raw: {},
+    },
+    signature_status: {
+      state: "failed",
+      reason: "bad signature",
+    },
+  }
+
+  let payload = event.provider_payload
+  if payload.provider == "github" {
+    let action: string | nil = payload.action
+  } else {
+    let subtype: string | nil = payload.subtype
+  }
+
+  let status = event.signature_status
+  if status.state == "failed" {
+    let reason: string = status.reason
+  }
+}
+"#,
+    );
+
+    let diagnostics = TypeChecker::new()
+        .with_imported_type_decls(imported)
+        .check(&program);
+    let errors: Vec<String> = diagnostics
+        .into_iter()
+        .filter(|diag| diag.severity == DiagnosticSeverity::Error)
+        .map(|diag| diag.message)
+        .collect();
+    assert!(errors.is_empty(), "got imported-type errors: {errors:?}");
+}
+
+#[test]
+fn imported_structs_allow_field_access() {
+    let imported = parse_program(
+        r#"
+struct HeaderRecord {
+  name: string,
+  value: string,
+}
+"#,
+    );
+    let program = parse_program(
+        r#"
+pipeline t(task) {
+  let header: HeaderRecord = HeaderRecord { name: "X-Test", value: "ok" }
+  let value: string = header.value
+}
+"#,
+    );
+
+    let diagnostics = TypeChecker::new()
+        .with_imported_type_decls(imported)
+        .check(&program);
+    let errors: Vec<String> = diagnostics
+        .into_iter()
+        .filter(|diag| diag.severity == DiagnosticSeverity::Error)
+        .map(|diag| diag.message)
+        .collect();
+    assert!(errors.is_empty(), "got imported-struct errors: {errors:?}");
+}

--- a/crates/harn-parser/src/typechecker/tests/mod.rs
+++ b/crates/harn-parser/src/typechecker/tests/mod.rs
@@ -11,6 +11,7 @@ use harn_lexer::Lexer;
 use super::{DiagnosticSeverity, TypeChecker, TypeDiagnostic};
 
 mod exhaustiveness;
+mod imports;
 mod interfaces;
 mod narrowing;
 mod reachability;

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -28,6 +28,7 @@ toml = "1.1"
 serde_yaml = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_path_to_error = "0.1"
+time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
 uuid = { version = "1", features = ["v4", "v7"] }
 tokio-util = { version = "0.7", features = ["io"] }
 futures = "0.3"

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -27,6 +27,7 @@ pub mod stdlib_modules;
 pub mod store;
 pub mod tool_annotations;
 pub mod tracing;
+pub mod triggers;
 pub mod value;
 pub mod visible_text;
 mod vm;
@@ -63,6 +64,11 @@ pub use stdlib::{
     register_agent_stdlib, register_core_stdlib, register_io_stdlib, register_vm_stdlib,
 };
 pub use store::register_store_builtins;
+pub use triggers::{
+    redact_headers, register_provider_schema, reset_provider_catalog, HeaderRedactionPolicy,
+    ProviderCatalog, ProviderCatalogError, ProviderId, ProviderPayload, ProviderSchema,
+    SignatureStatus, TenantId, TraceId, TriggerEvent, TriggerEventId,
+};
 pub use value::*;
 pub use vm::*;
 

--- a/crates/harn-vm/src/stdlib_modules.rs
+++ b/crates/harn-vm/src/stdlib_modules.rs
@@ -20,6 +20,7 @@ pub fn get_stdlib_source(module: &str) -> Option<&'static str> {
         "checkpoint" => Some(include_str!("stdlib_checkpoint.harn")),
         "worktree" => Some(include_str!("stdlib_worktree.harn")),
         "acp" => Some(include_str!("stdlib_acp.harn")),
+        "triggers" => Some(include_str!("stdlib_triggers.harn")),
         _ => None,
     }
 }

--- a/crates/harn-vm/src/stdlib_triggers.harn
+++ b/crates/harn-vm/src/stdlib_triggers.harn
@@ -1,0 +1,103 @@
+// std/triggers — typed trigger envelopes shared across inbound providers.
+//
+// Import with: `import "std/triggers"`.
+//
+// The runtime persists RFC3339 timestamps, typed signature status, and a
+// provider-tagged payload union. Connector-specific payloads intentionally
+// start with a small normalized surface plus `raw: dict`; provider tickets can
+// refine these aliases later without changing the top-level TriggerEvent shape.
+
+type ProviderId = "github" | "slack" | "linear" | "notion" | "cron" | "webhook" | "a2a-push" | string
+
+type SignatureVerified = {
+  state: "verified",
+}
+
+type SignatureUnsigned = {
+  state: "unsigned",
+}
+
+type SignatureFailed = {
+  state: "failed",
+  reason: string,
+}
+
+type SignatureStatus = SignatureVerified | SignatureUnsigned | SignatureFailed
+
+type GitHubEventPayload = {
+  provider: "github",
+  event: string,
+  action: string | nil,
+  delivery_id: string | nil,
+  installation_id: int | nil,
+  raw: dict,
+}
+
+type SlackEventPayload = {
+  provider: "slack",
+  event: string,
+  subtype: string | nil,
+  team_id: string | nil,
+  channel_id: string | nil,
+  raw: dict,
+}
+
+type LinearEventPayload = {
+  provider: "linear",
+  action: string | nil,
+  organization_id: string | nil,
+  webhook_timestamp: string | nil,
+  raw: dict,
+}
+
+type NotionEventPayload = {
+  provider: "notion",
+  event: string,
+  workspace_id: string | nil,
+  request_id: string | nil,
+  raw: dict,
+}
+
+type CronEventPayload = {
+  provider: "cron",
+  cron_id: string | nil,
+  schedule: string | nil,
+  tick_at: string,
+  raw: dict,
+}
+
+type GenericWebhookPayload = {
+  provider: "webhook",
+  source: string | nil,
+  content_type: string | nil,
+  raw: dict,
+}
+
+type A2aPushPayload = {
+  provider: "a2a-push",
+  task_id: string | nil,
+  sender: string | nil,
+  raw: dict,
+}
+
+type ExtensionProviderPayload = {
+  provider: string,
+  schema_name: string,
+  raw: dict,
+}
+
+type ProviderPayload = GitHubEventPayload | SlackEventPayload | LinearEventPayload | NotionEventPayload | CronEventPayload | GenericWebhookPayload | A2aPushPayload | ExtensionProviderPayload
+
+type TriggerEvent = {
+  id: string,
+  provider: ProviderId,
+  kind: string,
+  received_at: string,
+  occurred_at: string | nil,
+  dedupe_key: string,
+  trace_id: string,
+  tenant_id: string | nil,
+  headers: dict,
+  provider_payload: ProviderPayload,
+  signature_status: SignatureStatus,
+}

--- a/crates/harn-vm/src/triggers/event.rs
+++ b/crates/harn-vm/src/triggers/event.rs
@@ -1,0 +1,774 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, OnceLock, RwLock};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+const REDACTED_HEADER_VALUE: &str = "[redacted]";
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TriggerEventId(pub String);
+
+impl TriggerEventId {
+    pub fn new() -> Self {
+        Self(format!("trigger_evt_{}", Uuid::now_v7()))
+    }
+}
+
+impl Default for TriggerEventId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ProviderId(pub String);
+
+impl ProviderId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl From<&str> for ProviderId {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for ProviderId {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TraceId(pub String);
+
+impl TraceId {
+    pub fn new() -> Self {
+        Self(format!("trace_{}", Uuid::now_v7()))
+    }
+}
+
+impl Default for TraceId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TenantId(pub String);
+
+impl TenantId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum SignatureStatus {
+    Verified,
+    Unsigned,
+    Failed { reason: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GitHubEventPayload {
+    pub event: String,
+    pub action: Option<String>,
+    pub delivery_id: Option<String>,
+    pub installation_id: Option<i64>,
+    pub raw: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SlackEventPayload {
+    pub event: String,
+    pub subtype: Option<String>,
+    pub team_id: Option<String>,
+    pub channel_id: Option<String>,
+    pub raw: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LinearEventPayload {
+    pub action: Option<String>,
+    pub organization_id: Option<String>,
+    pub webhook_timestamp: Option<String>,
+    pub raw: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct NotionEventPayload {
+    pub event: String,
+    pub workspace_id: Option<String>,
+    pub request_id: Option<String>,
+    pub raw: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CronEventPayload {
+    pub cron_id: Option<String>,
+    pub schedule: Option<String>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub tick_at: OffsetDateTime,
+    pub raw: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GenericWebhookPayload {
+    pub source: Option<String>,
+    pub content_type: Option<String>,
+    pub raw: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct A2aPushPayload {
+    pub task_id: Option<String>,
+    pub sender: Option<String>,
+    pub raw: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExtensionProviderPayload {
+    pub provider: String,
+    pub schema_name: String,
+    pub raw: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ProviderPayload {
+    Known(KnownProviderPayload),
+    Extension(ExtensionProviderPayload),
+}
+
+impl ProviderPayload {
+    pub fn provider(&self) -> &str {
+        match self {
+            Self::Known(known) => known.provider(),
+            Self::Extension(payload) => payload.provider.as_str(),
+        }
+    }
+
+    pub fn normalize(
+        provider: &ProviderId,
+        kind: &str,
+        headers: &BTreeMap<String, String>,
+        raw: JsonValue,
+    ) -> Result<Self, ProviderCatalogError> {
+        provider_catalog()
+            .read()
+            .expect("provider catalog poisoned")
+            .normalize(provider, kind, headers, raw)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "provider")]
+pub enum KnownProviderPayload {
+    #[serde(rename = "github")]
+    GitHub(GitHubEventPayload),
+    #[serde(rename = "slack")]
+    Slack(SlackEventPayload),
+    #[serde(rename = "linear")]
+    Linear(LinearEventPayload),
+    #[serde(rename = "notion")]
+    Notion(NotionEventPayload),
+    #[serde(rename = "cron")]
+    Cron(CronEventPayload),
+    #[serde(rename = "webhook")]
+    Webhook(GenericWebhookPayload),
+    #[serde(rename = "a2a-push")]
+    A2aPush(A2aPushPayload),
+}
+
+impl KnownProviderPayload {
+    pub fn provider(&self) -> &str {
+        match self {
+            Self::GitHub(_) => "github",
+            Self::Slack(_) => "slack",
+            Self::Linear(_) => "linear",
+            Self::Notion(_) => "notion",
+            Self::Cron(_) => "cron",
+            Self::Webhook(_) => "webhook",
+            Self::A2aPush(_) => "a2a-push",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TriggerEvent {
+    pub id: TriggerEventId,
+    pub provider: ProviderId,
+    pub kind: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub received_at: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub occurred_at: Option<OffsetDateTime>,
+    pub dedupe_key: String,
+    pub trace_id: TraceId,
+    pub tenant_id: Option<TenantId>,
+    pub headers: BTreeMap<String, String>,
+    pub provider_payload: ProviderPayload,
+    pub signature_status: SignatureStatus,
+}
+
+impl TriggerEvent {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        provider: ProviderId,
+        kind: impl Into<String>,
+        occurred_at: Option<OffsetDateTime>,
+        dedupe_key: impl Into<String>,
+        tenant_id: Option<TenantId>,
+        headers: BTreeMap<String, String>,
+        provider_payload: ProviderPayload,
+        signature_status: SignatureStatus,
+    ) -> Self {
+        Self {
+            id: TriggerEventId::new(),
+            provider,
+            kind: kind.into(),
+            received_at: OffsetDateTime::now_utc(),
+            occurred_at,
+            dedupe_key: dedupe_key.into(),
+            trace_id: TraceId::new(),
+            tenant_id,
+            headers,
+            provider_payload,
+            signature_status,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HeaderRedactionPolicy {
+    safe_exact_names: BTreeSet<String>,
+}
+
+impl HeaderRedactionPolicy {
+    pub fn with_safe_header(mut self, name: impl Into<String>) -> Self {
+        self.safe_exact_names
+            .insert(name.into().to_ascii_lowercase());
+        self
+    }
+
+    fn should_keep(&self, name: &str) -> bool {
+        let lower = name.to_ascii_lowercase();
+        if self.safe_exact_names.contains(lower.as_str()) {
+            return true;
+        }
+        matches!(
+            lower.as_str(),
+            "user-agent"
+                | "request-id"
+                | "x-request-id"
+                | "x-correlation-id"
+                | "content-type"
+                | "content-length"
+                | "x-github-event"
+                | "x-github-delivery"
+                | "x-github-hook-id"
+                | "x-hub-signature-256"
+                | "x-slack-request-timestamp"
+                | "x-slack-signature"
+                | "x-linear-signature"
+                | "x-notion-signature"
+                | "x-a2a-signature"
+                | "x-a2a-delivery"
+        ) || lower.ends_with("-event")
+            || lower.ends_with("-delivery")
+            || lower.contains("timestamp")
+            || lower.contains("request-id")
+    }
+
+    fn should_redact(&self, name: &str) -> bool {
+        let lower = name.to_ascii_lowercase();
+        if self.should_keep(lower.as_str()) {
+            return false;
+        }
+        lower.contains("authorization")
+            || lower.contains("cookie")
+            || lower.contains("secret")
+            || lower.contains("token")
+            || lower.contains("key")
+    }
+}
+
+impl Default for HeaderRedactionPolicy {
+    fn default() -> Self {
+        Self {
+            safe_exact_names: BTreeSet::from([
+                "content-length".to_string(),
+                "content-type".to_string(),
+                "request-id".to_string(),
+                "user-agent".to_string(),
+                "x-a2a-delivery".to_string(),
+                "x-a2a-signature".to_string(),
+                "x-correlation-id".to_string(),
+                "x-github-delivery".to_string(),
+                "x-github-event".to_string(),
+                "x-github-hook-id".to_string(),
+                "x-hub-signature-256".to_string(),
+                "x-linear-signature".to_string(),
+                "x-notion-signature".to_string(),
+                "x-request-id".to_string(),
+                "x-slack-request-timestamp".to_string(),
+                "x-slack-signature".to_string(),
+            ]),
+        }
+    }
+}
+
+pub fn redact_headers(
+    headers: &BTreeMap<String, String>,
+    policy: &HeaderRedactionPolicy,
+) -> BTreeMap<String, String> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            if policy.should_redact(name) {
+                (name.clone(), REDACTED_HEADER_VALUE.to_string())
+            } else {
+                (name.clone(), value.clone())
+            }
+        })
+        .collect()
+}
+
+pub trait ProviderSchema: Send + Sync {
+    fn provider_id(&self) -> &'static str;
+    fn harn_schema_name(&self) -> &'static str;
+    fn normalize(
+        &self,
+        kind: &str,
+        headers: &BTreeMap<String, String>,
+        raw: JsonValue,
+    ) -> Result<ProviderPayload, ProviderCatalogError>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProviderCatalogError {
+    DuplicateProvider(String),
+    UnknownProvider(String),
+}
+
+impl std::fmt::Display for ProviderCatalogError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DuplicateProvider(provider) => {
+                write!(f, "provider `{provider}` is already registered")
+            }
+            Self::UnknownProvider(provider) => write!(f, "provider `{provider}` is not registered"),
+        }
+    }
+}
+
+impl std::error::Error for ProviderCatalogError {}
+
+#[derive(Clone, Default)]
+pub struct ProviderCatalog {
+    providers: BTreeMap<String, Arc<dyn ProviderSchema>>,
+}
+
+impl ProviderCatalog {
+    pub fn with_defaults() -> Self {
+        let mut catalog = Self::default();
+        for schema in default_provider_schemas() {
+            catalog
+                .register(schema)
+                .expect("default providers must register cleanly");
+        }
+        catalog
+    }
+
+    pub fn register(
+        &mut self,
+        schema: Arc<dyn ProviderSchema>,
+    ) -> Result<(), ProviderCatalogError> {
+        let provider = schema.provider_id().to_string();
+        if self.providers.contains_key(provider.as_str()) {
+            return Err(ProviderCatalogError::DuplicateProvider(provider));
+        }
+        self.providers.insert(provider, schema);
+        Ok(())
+    }
+
+    pub fn normalize(
+        &self,
+        provider: &ProviderId,
+        kind: &str,
+        headers: &BTreeMap<String, String>,
+        raw: JsonValue,
+    ) -> Result<ProviderPayload, ProviderCatalogError> {
+        let schema = self
+            .providers
+            .get(provider.as_str())
+            .ok_or_else(|| ProviderCatalogError::UnknownProvider(provider.0.clone()))?;
+        schema.normalize(kind, headers, raw)
+    }
+
+    pub fn schema_names(&self) -> BTreeMap<String, String> {
+        self.providers
+            .iter()
+            .map(|(provider, schema)| (provider.clone(), schema.harn_schema_name().to_string()))
+            .collect()
+    }
+}
+
+pub fn register_provider_schema(
+    schema: Arc<dyn ProviderSchema>,
+) -> Result<(), ProviderCatalogError> {
+    provider_catalog()
+        .write()
+        .expect("provider catalog poisoned")
+        .register(schema)
+}
+
+pub fn reset_provider_catalog() {
+    *provider_catalog()
+        .write()
+        .expect("provider catalog poisoned") = ProviderCatalog::with_defaults();
+}
+
+fn provider_catalog() -> &'static RwLock<ProviderCatalog> {
+    static PROVIDER_CATALOG: OnceLock<RwLock<ProviderCatalog>> = OnceLock::new();
+    PROVIDER_CATALOG.get_or_init(|| RwLock::new(ProviderCatalog::with_defaults()))
+}
+
+struct BuiltinProviderSchema {
+    provider_id: &'static str,
+    harn_schema_name: &'static str,
+    normalize: fn(&str, &BTreeMap<String, String>, JsonValue) -> ProviderPayload,
+}
+
+impl ProviderSchema for BuiltinProviderSchema {
+    fn provider_id(&self) -> &'static str {
+        self.provider_id
+    }
+
+    fn harn_schema_name(&self) -> &'static str {
+        self.harn_schema_name
+    }
+
+    fn normalize(
+        &self,
+        kind: &str,
+        headers: &BTreeMap<String, String>,
+        raw: JsonValue,
+    ) -> Result<ProviderPayload, ProviderCatalogError> {
+        Ok((self.normalize)(kind, headers, raw))
+    }
+}
+
+fn default_provider_schemas() -> Vec<Arc<dyn ProviderSchema>> {
+    vec![
+        Arc::new(BuiltinProviderSchema {
+            provider_id: "github",
+            harn_schema_name: "GitHubEventPayload",
+            normalize: github_payload,
+        }),
+        Arc::new(BuiltinProviderSchema {
+            provider_id: "slack",
+            harn_schema_name: "SlackEventPayload",
+            normalize: slack_payload,
+        }),
+        Arc::new(BuiltinProviderSchema {
+            provider_id: "linear",
+            harn_schema_name: "LinearEventPayload",
+            normalize: linear_payload,
+        }),
+        Arc::new(BuiltinProviderSchema {
+            provider_id: "notion",
+            harn_schema_name: "NotionEventPayload",
+            normalize: notion_payload,
+        }),
+        Arc::new(BuiltinProviderSchema {
+            provider_id: "cron",
+            harn_schema_name: "CronEventPayload",
+            normalize: cron_payload,
+        }),
+        Arc::new(BuiltinProviderSchema {
+            provider_id: "webhook",
+            harn_schema_name: "GenericWebhookPayload",
+            normalize: webhook_payload,
+        }),
+        Arc::new(BuiltinProviderSchema {
+            provider_id: "a2a-push",
+            harn_schema_name: "A2aPushPayload",
+            normalize: a2a_push_payload,
+        }),
+    ]
+}
+
+fn github_payload(
+    kind: &str,
+    headers: &BTreeMap<String, String>,
+    raw: JsonValue,
+) -> ProviderPayload {
+    let action = raw
+        .get("action")
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string);
+    let installation_id = raw
+        .get("installation")
+        .and_then(|value| value.get("id"))
+        .and_then(JsonValue::as_i64);
+    ProviderPayload::Known(KnownProviderPayload::GitHub(GitHubEventPayload {
+        event: kind.to_string(),
+        action,
+        delivery_id: headers.get("X-GitHub-Delivery").cloned(),
+        installation_id,
+        raw,
+    }))
+}
+
+fn slack_payload(
+    kind: &str,
+    _headers: &BTreeMap<String, String>,
+    raw: JsonValue,
+) -> ProviderPayload {
+    let subtype = raw
+        .get("event")
+        .and_then(|value| value.get("subtype"))
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string);
+    let team_id = raw
+        .get("team_id")
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string);
+    let channel_id = raw
+        .get("event")
+        .and_then(|value| value.get("channel"))
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string);
+    ProviderPayload::Known(KnownProviderPayload::Slack(SlackEventPayload {
+        event: kind.to_string(),
+        subtype,
+        team_id,
+        channel_id,
+        raw,
+    }))
+}
+
+fn linear_payload(
+    _kind: &str,
+    headers: &BTreeMap<String, String>,
+    raw: JsonValue,
+) -> ProviderPayload {
+    let action = raw
+        .get("action")
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string);
+    let organization_id = raw
+        .get("organizationId")
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string);
+    ProviderPayload::Known(KnownProviderPayload::Linear(LinearEventPayload {
+        action,
+        organization_id,
+        webhook_timestamp: headers.get("Linear-Request-Timestamp").cloned(),
+        raw,
+    }))
+}
+
+fn notion_payload(
+    kind: &str,
+    headers: &BTreeMap<String, String>,
+    raw: JsonValue,
+) -> ProviderPayload {
+    let workspace_id = raw
+        .get("workspace_id")
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string);
+    ProviderPayload::Known(KnownProviderPayload::Notion(NotionEventPayload {
+        event: kind.to_string(),
+        workspace_id,
+        request_id: headers
+            .get("request-id")
+            .cloned()
+            .or_else(|| headers.get("x-request-id").cloned()),
+        raw,
+    }))
+}
+
+fn cron_payload(
+    _kind: &str,
+    _headers: &BTreeMap<String, String>,
+    raw: JsonValue,
+) -> ProviderPayload {
+    let cron_id = raw
+        .get("cron_id")
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string);
+    let schedule = raw
+        .get("schedule")
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string);
+    let tick_at = raw
+        .get("tick_at")
+        .and_then(JsonValue::as_str)
+        .and_then(parse_rfc3339)
+        .unwrap_or_else(OffsetDateTime::now_utc);
+    ProviderPayload::Known(KnownProviderPayload::Cron(CronEventPayload {
+        cron_id,
+        schedule,
+        tick_at,
+        raw,
+    }))
+}
+
+fn webhook_payload(
+    _kind: &str,
+    headers: &BTreeMap<String, String>,
+    raw: JsonValue,
+) -> ProviderPayload {
+    ProviderPayload::Known(KnownProviderPayload::Webhook(GenericWebhookPayload {
+        source: headers.get("X-Webhook-Source").cloned(),
+        content_type: headers.get("Content-Type").cloned(),
+        raw,
+    }))
+}
+
+fn a2a_push_payload(
+    _kind: &str,
+    _headers: &BTreeMap<String, String>,
+    raw: JsonValue,
+) -> ProviderPayload {
+    let task_id = raw
+        .get("task_id")
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string);
+    let sender = raw
+        .get("sender")
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string);
+    ProviderPayload::Known(KnownProviderPayload::A2aPush(A2aPushPayload {
+        task_id,
+        sender,
+        raw,
+    }))
+}
+
+fn parse_rfc3339(text: &str) -> Option<OffsetDateTime> {
+    OffsetDateTime::parse(text, &time::format_description::well_known::Rfc3339).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_headers() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            ("Authorization".to_string(), "Bearer secret".to_string()),
+            ("Cookie".to_string(), "session=abc".to_string()),
+            ("User-Agent".to_string(), "GitHub-Hookshot/123".to_string()),
+            ("X-GitHub-Delivery".to_string(), "delivery-123".to_string()),
+            ("X-GitHub-Event".to_string(), "issues".to_string()),
+            ("X-Webhook-Token".to_string(), "token".to_string()),
+        ])
+    }
+
+    #[test]
+    fn default_redaction_policy_keeps_safe_headers() {
+        let redacted = redact_headers(&sample_headers(), &HeaderRedactionPolicy::default());
+        assert_eq!(redacted.get("User-Agent").unwrap(), "GitHub-Hookshot/123");
+        assert_eq!(redacted.get("X-GitHub-Delivery").unwrap(), "delivery-123");
+        assert_eq!(
+            redacted.get("Authorization").unwrap(),
+            REDACTED_HEADER_VALUE
+        );
+        assert_eq!(redacted.get("Cookie").unwrap(), REDACTED_HEADER_VALUE);
+        assert_eq!(
+            redacted.get("X-Webhook-Token").unwrap(),
+            REDACTED_HEADER_VALUE
+        );
+    }
+
+    #[test]
+    fn provider_catalog_rejects_duplicates() {
+        let mut catalog = ProviderCatalog::default();
+        catalog
+            .register(Arc::new(BuiltinProviderSchema {
+                provider_id: "github",
+                harn_schema_name: "GitHubEventPayload",
+                normalize: github_payload,
+            }))
+            .unwrap();
+        let error = catalog
+            .register(Arc::new(BuiltinProviderSchema {
+                provider_id: "github",
+                harn_schema_name: "GitHubEventPayload",
+                normalize: github_payload,
+            }))
+            .unwrap_err();
+        assert_eq!(
+            error,
+            ProviderCatalogError::DuplicateProvider("github".to_string())
+        );
+    }
+
+    #[test]
+    fn trigger_event_round_trip_is_stable() {
+        let provider = ProviderId::from("github");
+        let headers = redact_headers(&sample_headers(), &HeaderRedactionPolicy::default());
+        let payload = ProviderPayload::normalize(
+            &provider,
+            "issues",
+            &sample_headers(),
+            serde_json::json!({
+                "action": "opened",
+                "installation": {"id": 42},
+                "issue": {"number": 99}
+            }),
+        )
+        .unwrap();
+        let event = TriggerEvent {
+            id: TriggerEventId("trigger_evt_fixed".to_string()),
+            provider,
+            kind: "issues".to_string(),
+            received_at: parse_rfc3339("2026-04-19T07:00:00Z").unwrap(),
+            occurred_at: Some(parse_rfc3339("2026-04-19T06:59:59Z").unwrap()),
+            dedupe_key: "delivery-123".to_string(),
+            trace_id: TraceId("trace_fixed".to_string()),
+            tenant_id: Some(TenantId("tenant_1".to_string())),
+            headers,
+            provider_payload: payload,
+            signature_status: SignatureStatus::Verified,
+        };
+
+        let once = serde_json::to_value(&event).unwrap();
+        let decoded: TriggerEvent = serde_json::from_value(once.clone()).unwrap();
+        let twice = serde_json::to_value(&decoded).unwrap();
+        assert_eq!(decoded, event);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn unknown_provider_errors() {
+        let error = ProviderPayload::normalize(
+            &ProviderId::from("custom-provider"),
+            "thing.happened",
+            &BTreeMap::new(),
+            serde_json::json!({"ok": true}),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            ProviderCatalogError::UnknownProvider("custom-provider".to_string())
+        );
+    }
+}

--- a/crates/harn-vm/src/triggers/mod.rs
+++ b/crates/harn-vm/src/triggers/mod.rs
@@ -1,0 +1,9 @@
+pub mod event;
+
+pub use event::{
+    redact_headers, register_provider_schema, reset_provider_catalog, A2aPushPayload,
+    CronEventPayload, ExtensionProviderPayload, GenericWebhookPayload, GitHubEventPayload,
+    HeaderRedactionPolicy, LinearEventPayload, NotionEventPayload, ProviderCatalog,
+    ProviderCatalogError, ProviderId, ProviderPayload, ProviderSchema, SignatureStatus,
+    SlackEventPayload, TenantId, TraceId, TriggerEvent, TriggerEventId,
+};

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -24,6 +24,7 @@
 - [Agent state](./agent-state.md)
 - [Transcript architecture](./transcript-architecture.md)
 - [Workflow runtime](./workflow-runtime.md)
+- [Trigger event schema](./triggers/event-schema.md)
 - [Cookbook](./cookbook.md)
 - [Tutorial: code review agent](./tutorial-code-review-agent.md)
 - [Tutorial: MCP server](./tutorial-mcp-server.md)

--- a/docs/src/triggers/event-schema.md
+++ b/docs/src/triggers/event-schema.md
@@ -1,0 +1,74 @@
+# Trigger event schema
+
+`TriggerEvent` is the normalized envelope every inbound trigger provider
+converges on before dispatch. Connectors preserve provider-specific payload
+fidelity inside `provider_payload`, but the orchestration layer always sees the
+same outer shape:
+
+```harn
+import "std/triggers"
+
+fn on_event(event: TriggerEvent) {
+  let payload = event.provider_payload
+  if payload.provider == "github" {
+    println(payload.action ?? "unknown")
+  }
+
+  let signature = event.signature_status
+  if signature.state == "failed" {
+    println(signature.reason)
+  }
+}
+```
+
+## Envelope fields
+
+`TriggerEvent` carries:
+
+- `id`: runtime-assigned event id.
+- `provider`: provider identity such as `"github"`, `"slack"`, `"cron"`, or `"webhook"`.
+- `kind`: provider-specific event kind.
+- `received_at`: RFC3339 timestamp captured by the runtime.
+- `occurred_at`: provider-reported RFC3339 timestamp when available.
+- `dedupe_key`: delivery id or equivalent idempotency key.
+- `trace_id`: trace correlation id propagated through dispatch.
+- `tenant_id`: optional orchestrator-assigned tenant namespace.
+- `headers`: redacted provider headers retained for audit/debugging.
+- `provider_payload`: provider-tagged payload union.
+- `signature_status`: typed verification result.
+
+## Signature status
+
+`signature_status` is a discriminated union:
+
+- `{ state: "verified" }`
+- `{ state: "unsigned" }`
+- `{ state: "failed", reason: string }`
+
+Unsigned events are valid for synthetic sources such as cron. Failed events can
+still be logged for audit purposes even if the dispatcher rejects them.
+
+## Provider payloads
+
+The initial `std/triggers` payload aliases are intentionally small. Each
+provider variant exposes a stable normalized surface plus `raw: dict`:
+
+- `GitHubEventPayload`
+- `SlackEventPayload`
+- `LinearEventPayload`
+- `NotionEventPayload`
+- `CronEventPayload`
+- `GenericWebhookPayload`
+- `A2aPushPayload`
+- `ExtensionProviderPayload`
+
+The runtime registers these through a `ProviderCatalog`, so future connectors
+can contribute new payload schemas without rewriting the top-level
+`TriggerEvent` envelope.
+
+## Header redaction
+
+The runtime keeps delivery, event, timestamp, request-id, signature, and
+user-agent headers by default. It redacts sensitive headers such as
+`Authorization`, `Cookie`, and names containing `secret`, `token`, or `key`
+unless they are explicitly allow-listed as safe metadata.


### PR DESCRIPTION
## Summary
- add a runtime `TriggerEvent` schema with provider-specific payload variants, signature status modeling, header redaction, and provider schema registration
- add `std/triggers` so Harn programs can type imported trigger events and narrow on provider-specific payload shapes
- register imported type declarations in the static checker so stdlib modules expose usable aliases/structs across imports, which is required for `std/triggers` to work end-to-end
- document the trigger event schema for users

## Why
Issue #155 calls for a typed trigger envelope that can support built-in providers and extension providers without collapsing back to untyped JSON. During implementation it became clear that imported type declarations were not actually being registered into the checker, so a `std/triggers` module would parse but still not provide reliable field access or narrowing in user code.

## Validation
- `cargo fmt`
- `env CARGO_TARGET_DIR=/tmp/harn-e1c9-155-target cargo test -p harn-modules stdlib_imports_expose_type_declarations -- --nocapture`
- `env CARGO_TARGET_DIR=/tmp/harn-e1c9-155-target cargo test -p harn-parser imports:: --lib`
- `env CARGO_TARGET_DIR=/tmp/harn-e1c9-155-target cargo test -p harn-vm triggers::event::tests:: --lib`
- `env CARGO_TARGET_DIR=/tmp/harn-e1c9-155-target cargo run --quiet --bin harn -- run /tmp/harn_std_triggers_probe_run.harn`
- `env CARGO_TARGET_DIR=/tmp/harn-e1c9-155-target cargo run --quiet --bin harn -- check /tmp/harn_trigger_event_typecheck.harn`
- repo pre-push Rust/conformance checks passed before push; the only hook failure was an unrelated portal lint environment issue (`eslint` missing under `crates/harn-cli/portal`)

Closes #155