### PR TITLE
Daemon lifecycle events in run observability (closes #143 part (c))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ granular archaeology.
   Lays the type foundation that upcoming EventLog-backed trigger
   registry, LLM predicate gate, and handler dispatcher work will
   consume.
+- **Daemon lifecycle events flow into run observability (#197,
+  closes #143 part (c)).** Persisted runs derive `daemon_events`
+  from daemon stdlib wrapper activity, `harn runs inspect` prints
+  the lifecycle timeline, and the portal run detail view exposes a
+  dedicated Daemons section alongside the rest of observability.
 
 ## v0.7.22
 

--- a/conformance/tests/stdlib/compact_transcript.harn
+++ b/conformance/tests/stdlib/compact_transcript.harn
@@ -77,7 +77,7 @@ pipeline test(task) {
   ],
   },
   )
-  println(run.observability?.schema_version == 2)
+  println(run.observability?.schema_version == 3)
   println(len(run.observability?.compaction_events) == 3)
   var saw_truncate = false
   var saw_mask = false

--- a/crates/harn-cli/portal/src/App.test.tsx
+++ b/crates/harn-cli/portal/src/App.test.tsx
@@ -103,7 +103,7 @@ const detailPayload = {
   story: [],
   child_runs: [],
   observability: {
-    schema_version: 1,
+    schema_version: 3,
     planner_rounds: [],
     research_fact_count: 0,
     action_graph_nodes: [],
@@ -111,6 +111,16 @@ const detailPayload = {
     worker_lineage: [],
     verification_outcomes: [],
     transcript_pointers: [],
+    daemon_events: [
+      {
+        daemon_id: "daemon-1",
+        name: "reviewer",
+        kind: "spawned",
+        timestamp: "1710000000.100",
+        persist_path: "/tmp/reviewer",
+        payload_summary: "always-on reviewer",
+      },
+    ],
   },
   skill_timeline: [],
   skill_match_events: [],
@@ -204,5 +214,6 @@ describe("App", () => {
       expect(screen.getByText("Inspect persisted run")).toBeInTheDocument()
     })
     expect(screen.getByText("harn replay .harn-runs/failed.json")).toBeInTheDocument()
+    expect(screen.getByText(/reviewer • Spawned • 1710000000.100/)).toBeInTheDocument()
   })
 })

--- a/crates/harn-cli/portal/src/components/RunDetail.tsx
+++ b/crates/harn-cli/portal/src/components/RunDetail.tsx
@@ -148,6 +148,10 @@ const messages = defineMessages({
     id: "portal.detail.noWorkerLineage",
     defaultMessage: "No delegated worker lineage was captured for this run.",
   },
+  noDaemonEvents: {
+    id: "portal.detail.noDaemonEvents",
+    defaultMessage: "No daemon lifecycle events were captured for this run.",
+  },
   noActivity: {
     id: "portal.detail.noActivity",
     defaultMessage: "No span activity captured for this run.",
@@ -217,6 +221,23 @@ function compareCandidates(current: RunSummary, runs: RunSummary[]) {
 
 function findBaselineRun(current: RunSummary, runs: RunSummary[]) {
   return compareCandidates(current, runs).find((run) => run.started_at <= current.started_at) ?? null
+}
+
+function daemonKindLabel(kind: PortalRunDetail["observability"]["daemon_events"][number]["kind"]) {
+  switch (kind) {
+    case "spawned":
+      return "Spawned"
+    case "triggered":
+      return "Triggered"
+    case "snapshotted":
+      return "Snapshotted"
+    case "resumed":
+      return "Resumed"
+    case "stopped":
+      return "Stopped"
+    default:
+      return kind
+  }
 }
 
 function StageDetail({ label, value, open = false }: { label: string; value: string | null; open?: boolean }) {
@@ -534,6 +555,7 @@ export function RunDetail({ detail, runs, onSelectRun }: RunDetailProps) {
               </div>
               <div className="meta">{detail.observability.worker_lineage.length} workers</div>
               <div className="meta">{detail.observability.transcript_pointers.length} transcript pointers</div>
+              <div className="meta">{detail.observability.daemon_events.length} daemon events</div>
             </div>
           </div>
           <div className="policy-item">
@@ -595,6 +617,25 @@ export function RunDetail({ detail, runs, onSelectRun }: RunDetailProps) {
                 ))
               ) : (
                 <div className="muted">{intl.formatMessage(messages.noTranscriptPointers)}</div>
+              )}
+            </div>
+          </div>
+          <div className="policy-item">
+            <div className="row">
+              <strong>Daemons</strong>
+              <span className="turn-chip">{detail.observability.daemon_events.length}</span>
+            </div>
+            <div className="policy-list">
+              {detail.observability.daemon_events.length ? (
+                detail.observability.daemon_events.map((event, index) => (
+                  <div className="meta" key={`${event.daemon_id}-${event.kind}-${event.timestamp}-${index}`}>
+                    {event.name} • {daemonKindLabel(event.kind)} • {event.timestamp}
+                    {event.persist_path ? ` • ${event.persist_path}` : ""}
+                    {event.payload_summary ? ` • ${event.payload_summary}` : ""}
+                  </div>
+                ))
+              ) : (
+                <div className="muted">{intl.formatMessage(messages.noDaemonEvents)}</div>
               )}
             </div>
           </div>

--- a/crates/harn-cli/portal/src/types.ts
+++ b/crates/harn-cli/portal/src/types.ts
@@ -325,6 +325,15 @@ export type RunTranscriptPointer = {
   available: boolean
 }
 
+export type DaemonEvent = {
+  daemon_id: string
+  name: string
+  kind: "spawned" | "triggered" | "snapshotted" | "resumed" | "stopped"
+  timestamp: string
+  persist_path: string
+  payload_summary: string | null
+}
+
 export type RunObservability = {
   schema_version: number
   planner_rounds: RunPlannerRound[]
@@ -334,6 +343,7 @@ export type RunObservability = {
   worker_lineage: RunWorkerLineage[]
   verification_outcomes: RunVerificationOutcome[]
   transcript_pointers: RunTranscriptPointer[]
+  daemon_events: DaemonEvent[]
 }
 
 export type PortalExecutionSummary = {

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -556,6 +556,7 @@ fn inspect_run_record(path: &str, compare: Option<&str>) {
             "Transcript pointers: {}",
             observability.transcript_pointers.len()
         );
+        println!("Daemon events: {}", observability.daemon_events.len());
     }
     if let Some(parent_worker_id) = run
         .metadata
@@ -649,6 +650,17 @@ fn inspect_run_record(path: &str, compare: Option<&str>) {
                     .clone()
                     .unwrap_or_else(|| pointer.location.clone())
             );
+        }
+        for event in &observability.daemon_events {
+            println!(
+                "- daemon {} [{:?}] at {}",
+                event.name, event.kind, event.timestamp
+            );
+            println!("  id: {}", event.daemon_id);
+            println!("  persist_path: {}", event.persist_path);
+            if let Some(summary) = &event.payload_summary {
+                println!("  payload: {}", summary);
+            }
         }
     }
     if let Some(compare_path) = compare {

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -229,6 +229,20 @@ fn append_llm_transcript_event_log(entry: &serde_json::Value) {
     }
 }
 
+pub(crate) fn append_llm_observability_entry(
+    event_type: &str,
+    mut fields: serde_json::Map<String, serde_json::Value>,
+) {
+    fields.insert("type".to_string(), serde_json::json!(event_type));
+    fields
+        .entry("timestamp".to_string())
+        .or_insert_with(|| serde_json::json!(chrono_now()));
+    fields
+        .entry("span_id".to_string())
+        .or_insert_with(|| serde_json::json!(crate::tracing::current_span_id()));
+    append_llm_transcript_entry(&serde_json::Value::Object(fields));
+}
+
 /// Emit a `message` event for an assistant/user/tool message that was just
 /// appended to the visible transcript. One row per message keeps the log
 /// append-only: reconstructing the prompt at turn N is a replay, not a

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -116,6 +116,13 @@ pub fn clear_current_host_bridge() {
     agent::clear_current_host_bridge();
 }
 
+pub(crate) fn append_observability_sidecar_entry(
+    event_type: &str,
+    fields: serde_json::Map<String, serde_json::Value>,
+) {
+    agent_observe::append_llm_observability_entry(event_type, fields);
+}
+
 fn output_validation_mode(opts: &api::LlmCallOptions) -> &str {
     opts.output_validation.as_deref().unwrap_or("off")
 }

--- a/crates/harn-vm/src/orchestration/records.rs
+++ b/crates/harn-vm/src/orchestration/records.rs
@@ -257,6 +257,28 @@ pub struct CompactionEventRecord {
     pub available: bool,
 }
 
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum DaemonEventKindRecord {
+    #[default]
+    Spawned,
+    Triggered,
+    Snapshotted,
+    Resumed,
+    Stopped,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct DaemonEventRecord {
+    pub daemon_id: String,
+    pub name: String,
+    pub kind: DaemonEventKindRecord,
+    pub timestamp: String,
+    pub persist_path: String,
+    pub payload_summary: Option<String>,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct RunObservabilityRecord {
@@ -269,6 +291,7 @@ pub struct RunObservabilityRecord {
     pub verification_outcomes: Vec<RunVerificationOutcomeRecord>,
     pub transcript_pointers: Vec<RunTranscriptPointerRecord>,
     pub compaction_events: Vec<CompactionEventRecord>,
+    pub daemon_events: Vec<DaemonEventRecord>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -440,6 +463,12 @@ pub struct RunExecutionRecord {
 
 fn compact_json_value(value: &serde_json::Value) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| value.to_string())
+}
+
+fn llm_transcript_sidecar_path(run_path: &Path) -> Option<PathBuf> {
+    let stem = run_path.file_stem()?.to_str()?;
+    let parent = run_path.parent().unwrap_or_else(|| Path::new("."));
+    Some(parent.join(format!("{stem}-llm/llm_transcript.jsonl")))
 }
 
 fn json_string_array(value: Option<&serde_json::Value>) -> Vec<String> {
@@ -619,6 +648,23 @@ fn compaction_events_from_transcript(
         .unwrap_or_default()
 }
 
+fn daemon_events_from_sidecar(run_path: &Path) -> Vec<DaemonEventRecord> {
+    let Some(sidecar_path) = llm_transcript_sidecar_path(run_path) else {
+        return Vec::new();
+    };
+    let Ok(content) = std::fs::read_to_string(sidecar_path) else {
+        return Vec::new();
+    };
+
+    content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|event| event.get("type").and_then(|value| value.as_str()) == Some("daemon_event"))
+        .filter_map(|event| serde_json::from_value::<DaemonEventRecord>(event).ok())
+        .collect()
+}
+
 pub fn derive_run_observability(
     run: &RunRecord,
     persisted_path: Option<&Path>,
@@ -629,6 +675,7 @@ pub fn derive_run_observability(
     let mut planner_rounds = Vec::new();
     let mut transcript_pointers = Vec::new();
     let mut compaction_events = Vec::new();
+    let mut daemon_events = Vec::new();
     let mut research_fact_count = 0usize;
 
     let root_node_id = format!("run:{}", run.id);
@@ -897,15 +944,7 @@ pub fn derive_run_observability(
     }
 
     if let Some(path) = persisted_path {
-        let stem = path
-            .file_stem()
-            .and_then(|value| value.to_str())
-            .unwrap_or_default();
-        if !stem.is_empty() {
-            let sidecar_path = path
-                .parent()
-                .unwrap_or_else(|| Path::new("."))
-                .join(format!("{stem}-llm/llm_transcript.jsonl"));
+        if let Some(sidecar_path) = llm_transcript_sidecar_path(path) {
             transcript_pointers.push(RunTranscriptPointerRecord {
                 id: "run:llm_transcript".to_string(),
                 label: "LLM transcript sidecar".to_string(),
@@ -915,10 +954,11 @@ pub fn derive_run_observability(
                 available: sidecar_path.exists(),
             });
         }
+        daemon_events.extend(daemon_events_from_sidecar(path));
     }
 
     RunObservabilityRecord {
-        schema_version: 2,
+        schema_version: 3,
         planner_rounds,
         research_fact_count,
         action_graph_nodes,
@@ -927,6 +967,7 @@ pub fn derive_run_observability(
         verification_outcomes,
         transcript_pointers,
         compaction_events,
+        daemon_events,
     }
 }
 
@@ -1726,6 +1767,66 @@ pub fn diff_run_records(left: &RunRecord, right: &RunRecord) -> RunDiffReport {
                 observability_diffs.push(RunObservabilityDiffRecord {
                     section: "compaction_events".to_string(),
                     label: compaction_id,
+                    details: vec![format!("event: {:?} -> {:?}", left_event, right_event)],
+                });
+            }
+            _ => {}
+        }
+    }
+
+    let left_daemons = left_observability
+        .daemon_events
+        .iter()
+        .map(|event| {
+            (
+                (event.daemon_id.clone(), event.kind, event.timestamp.clone()),
+                (
+                    event.name.clone(),
+                    event.persist_path.clone(),
+                    event.payload_summary.clone(),
+                ),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let right_daemons = right_observability
+        .daemon_events
+        .iter()
+        .map(|event| {
+            (
+                (event.daemon_id.clone(), event.kind, event.timestamp.clone()),
+                (
+                    event.name.clone(),
+                    event.persist_path.clone(),
+                    event.payload_summary.clone(),
+                ),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let daemon_keys = left_daemons
+        .keys()
+        .chain(right_daemons.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    for daemon_key in daemon_keys {
+        let label = format!("{}:{:?}:{}", daemon_key.0, daemon_key.1, daemon_key.2);
+        match (
+            left_daemons.get(&daemon_key),
+            right_daemons.get(&daemon_key),
+        ) {
+            (Some(_), None) => observability_diffs.push(RunObservabilityDiffRecord {
+                section: "daemon_events".to_string(),
+                label,
+                details: vec!["daemon event missing from right run".to_string()],
+            }),
+            (None, Some(_)) => observability_diffs.push(RunObservabilityDiffRecord {
+                section: "daemon_events".to_string(),
+                label,
+                details: vec!["daemon event missing from left run".to_string()],
+            }),
+            (Some(left_event), Some(right_event)) if left_event != right_event => {
+                observability_diffs.push(RunObservabilityDiffRecord {
+                    section: "daemon_events".to_string(),
+                    label,
                     details: vec![format!("event: {:?} -> {:?}", left_event, right_event)],
                 });
             }

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -408,7 +408,7 @@ fn save_and_load_run_record_materializes_observability_summary() {
     save_run_record(&run, Some(run_path.to_str().unwrap())).unwrap();
     let loaded = load_run_record(&run_path).unwrap();
     let observability = loaded.observability.expect("observability summary");
-    assert_eq!(observability.schema_version, 2);
+    assert_eq!(observability.schema_version, 3);
     assert_eq!(observability.planner_rounds.len(), 1);
     assert_eq!(observability.research_fact_count, 1);
     assert_eq!(observability.worker_lineage.len(), 1);
@@ -421,6 +421,44 @@ fn save_and_load_run_record_materializes_observability_summary() {
     assert_eq!(
         observability.planner_rounds[0].research_facts,
         vec!["verify stage failed after read".to_string()]
+    );
+}
+
+#[test]
+fn save_and_load_run_record_materializes_daemon_events_from_sidecar() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let run_path = temp_dir.path().join("run.json");
+    let sidecar_dir = temp_dir.path().join("run-llm");
+    std::fs::create_dir_all(&sidecar_dir).unwrap();
+    std::fs::write(
+        sidecar_dir.join("llm_transcript.jsonl"),
+        concat!(
+            "{\"type\":\"daemon_event\",\"timestamp\":\"1710000000.100\",\"daemon_id\":\"daemon-1\",\"name\":\"reviewer\",\"kind\":\"spawned\",\"persist_path\":\"/tmp/reviewer\",\"payload_summary\":\"always-on reviewer\"}\n",
+            "{\"type\":\"daemon_event\",\"timestamp\":\"1710000001.200\",\"daemon_id\":\"daemon-1\",\"name\":\"reviewer\",\"kind\":\"triggered\",\"persist_path\":\"/tmp/reviewer\",\"payload_summary\":\"new review requested\"}\n"
+        ),
+    )
+    .unwrap();
+
+    let run = RunRecord {
+        id: "run_daemon_obs".to_string(),
+        workflow_id: "wf".to_string(),
+        status: "completed".to_string(),
+        ..Default::default()
+    };
+
+    save_run_record(&run, Some(run_path.to_str().unwrap())).unwrap();
+    let loaded = load_run_record(&run_path).unwrap();
+    let observability = loaded.observability.expect("observability summary");
+    assert_eq!(observability.daemon_events.len(), 2);
+    assert_eq!(observability.daemon_events[0].daemon_id, "daemon-1");
+    assert_eq!(observability.daemon_events[0].name, "reviewer");
+    assert_eq!(
+        observability.daemon_events[0].kind,
+        super::DaemonEventKindRecord::Spawned
+    );
+    assert_eq!(
+        observability.daemon_events[1].payload_summary.as_deref(),
+        Some("new review requested")
     );
 }
 

--- a/crates/harn-vm/src/stdlib/agents_daemon.rs
+++ b/crates/harn-vm/src/stdlib/agents_daemon.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use crate::bridge::HostBridge;
 use crate::llm::daemon::{load_snapshot, DaemonSnapshot};
+use crate::orchestration::DaemonEventKindRecord;
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
@@ -97,6 +98,13 @@ pub fn register_daemon_builtins(vm: &mut Vm) {
         register_daemon(state.clone());
         spawn_daemon_task(state.clone(), child_vm);
         wait_for_snapshot(state.clone(), None, 500).await;
+        record_daemon_event(
+            &spec.id,
+            &spec.name,
+            DaemonEventKindRecord::Spawned,
+            &spec.persist_root,
+            summarize_text(&spec.prompt),
+        );
         let summary = {
             let daemon = state.borrow();
             daemon_summary(&daemon)?
@@ -123,11 +131,22 @@ pub fn register_daemon_builtins(vm: &mut Vm) {
             }
         }
         let message = trigger_payload_text(payload);
+        let payload_summary = summarize_text(&message);
         let bridge = state.borrow().bridge.clone();
         bridge
             .push_queued_user_message(message, "finish_step")
             .await;
         bridge.signal_resume();
+        {
+            let daemon = state.borrow();
+            record_daemon_event(
+                &daemon.id,
+                &daemon.name,
+                DaemonEventKindRecord::Triggered,
+                &daemon.persist_root,
+                payload_summary.clone(),
+            );
+        }
         let summary = {
             let daemon = state.borrow();
             daemon_summary(&daemon)?
@@ -143,6 +162,13 @@ pub fn register_daemon_builtins(vm: &mut Vm) {
         with_daemon_state(&daemon_id, |state| {
             let mut daemon = state.borrow_mut();
             let snapshot = refresh_snapshot(&mut daemon)?;
+            record_daemon_event(
+                &daemon.id,
+                &daemon.name,
+                DaemonEventKindRecord::Snapshotted,
+                &daemon.persist_root,
+                summarize_snapshot(snapshot.as_ref()),
+            );
             Ok(snapshot_to_vm(&snapshot.unwrap_or_default()))
         })
     });
@@ -163,6 +189,13 @@ pub fn register_daemon_builtins(vm: &mut Vm) {
             }
             daemon.status = "stopped".to_string();
             daemon.last_error = None;
+            record_daemon_event(
+                &daemon.id,
+                &daemon.name,
+                DaemonEventKindRecord::Stopped,
+                &daemon.persist_root,
+                summarize_snapshot(daemon.last_snapshot.as_ref()),
+            );
             daemon_summary(&daemon)
         })
     });
@@ -199,6 +232,16 @@ pub fn register_daemon_builtins(vm: &mut Vm) {
             }
             spawn_daemon_task(state.clone(), child_vm);
             wait_for_snapshot(state.clone(), Some(snapshot.saved_at.clone()), 500).await;
+            {
+                let daemon = state.borrow();
+                record_daemon_event(
+                    &daemon.id,
+                    &daemon.name,
+                    DaemonEventKindRecord::Resumed,
+                    &daemon.persist_root,
+                    summarize_snapshot(Some(&snapshot)),
+                );
+            }
             return daemon_summary(&state.borrow());
         }
 
@@ -275,7 +318,14 @@ pub fn register_daemon_builtins(vm: &mut Vm) {
         }));
         register_daemon(state.clone());
         spawn_daemon_task(state.clone(), child_vm);
-        wait_for_snapshot(state.clone(), Some(snapshot.saved_at), 500).await;
+        wait_for_snapshot(state.clone(), Some(snapshot.saved_at.clone()), 500).await;
+        record_daemon_event(
+            &spec.id,
+            &spec.name,
+            DaemonEventKindRecord::Resumed,
+            &spec.persist_root,
+            summarize_snapshot(Some(&snapshot)),
+        );
         let summary = {
             let daemon = state.borrow();
             daemon_summary(&daemon)?
@@ -509,6 +559,47 @@ fn trigger_payload_text(payload: &VmValue) -> String {
         _ => serde_json::to_string(&crate::llm::vm_value_to_json(payload))
             .unwrap_or_else(|_| payload.display()),
     }
+}
+
+fn summarize_text(text: &str) -> Option<String> {
+    let compact = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.is_empty() {
+        return None;
+    }
+    const MAX_LEN: usize = 160;
+    if compact.len() <= MAX_LEN {
+        Some(compact)
+    } else {
+        Some(format!("{}...", &compact[..MAX_LEN]))
+    }
+}
+
+fn summarize_snapshot(snapshot: Option<&DaemonSnapshot>) -> Option<String> {
+    snapshot.map(|snapshot| {
+        format!(
+            "state={} saved_at={}",
+            snapshot.daemon_state, snapshot.saved_at
+        )
+    })
+}
+
+fn record_daemon_event(
+    daemon_id: &str,
+    name: &str,
+    kind: DaemonEventKindRecord,
+    persist_path: &str,
+    payload_summary: Option<String>,
+) {
+    let mut fields = serde_json::Map::new();
+    fields.insert("daemon_id".to_string(), serde_json::json!(daemon_id));
+    fields.insert("name".to_string(), serde_json::json!(name));
+    fields.insert("kind".to_string(), serde_json::json!(kind));
+    fields.insert("persist_path".to_string(), serde_json::json!(persist_path));
+    fields.insert(
+        "payload_summary".to_string(),
+        payload_summary.map_or(serde_json::Value::Null, serde_json::Value::String),
+    );
+    crate::llm::append_observability_sidecar_entry("daemon_event", fields);
 }
 
 fn write_meta(spec: &DaemonSpawnSpec) -> Result<(), VmError> {


### PR DESCRIPTION
## Summary
- add daemon lifecycle events to run observability and derive them from the LLM sidecar into persisted run records
- emit daemon spawn/trigger/snapshot/resume/stop events from the daemon stdlib wrappers and surface them in `harn runs inspect`
- add a Daemons section to the portal run detail view, update tests, and document the change in `CHANGELOG.md`

## Why
P5 will rely on always-on daemon sessions, and operators need those lifecycle transitions visible in persisted run records, CLI inspection, and the portal.

## Validation
- `make all`
- `npm --prefix crates/harn-cli/portal run test`
- `npm --prefix crates/harn-cli/portal run build`
