### PR TITLE
[codex] Add [[triggers]] manifest overlay validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,18 @@ granular archaeology.
   retriggerable workers until a real terminal state, and the
   persisted worker snapshot keeps the new lifecycle/carry-policy
   fields across resume.
+- **`[[triggers]]` manifest overlay parsing and validation (#199,
+  closes #156).** `harn.toml` can now declare `[[triggers]]` entries
+  alongside `[[hooks]]`, with typed parsing for trigger kinds
+  (`cron`, `webhook`, `a2a-push`, `poll`, `stream`, `predicate`),
+  retry/priority/budget config, and kind-specific fields. The loader
+  reuses the manifest-extension ABI from #138 + #141 to resolve
+  handler and `when` identifiers against exported Harn functions.
+  Validation covers id uniqueness, handler URI schemes, cron
+  schedules, JMESPath dedupe expressions, and secret-id namespaces.
+  `harn doctor` now surfaces loaded triggers with id, kind, provider,
+  handler kind, and budget. Ships with example manifests for
+  github-new-issue, cron-daily-digest, and a2a-reviewer-fanout.
 
 ## v0.7.22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,9 +272,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
 ]
 
 [[package]]
@@ -384,6 +396,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "croner"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "strum",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +469,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +527,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +578,12 @@ dependencies = [
  "rustc_version",
  "syn",
 ]
+
+[[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
@@ -588,6 +683,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -767,7 +868,9 @@ version = "0.7.22"
 dependencies = [
  "axum",
  "base64",
+ "chrono-tz",
  "clap",
+ "croner",
  "harn-fmt",
  "harn-lexer",
  "harn-lint",
@@ -775,6 +878,7 @@ dependencies = [
  "harn-parser",
  "harn-vm",
  "include_dir",
+ "jmespath",
  "notify",
  "nu-ansi-term",
  "rand 0.10.1",
@@ -1163,6 +1267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1405,17 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jmespath"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "094f2a852a5b9d2fa1a37e9295b3e65ce181b3abf1b16445467b101ca1c4c6e2"
+dependencies = [
+ "serde",
+ "serde_json",
+ "slug",
+]
 
 [[package]]
 name = "jni"
@@ -1729,6 +1850,24 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -2390,10 +2529,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slug"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "smallvec"

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -51,3 +51,6 @@ time = { version = "0.3", features = ["formatting", "parsing"] }
 tempfile = "3"
 include_dir = "0.7"
 uuid = { version = "1", features = ["v4", "v7"] }
+chrono-tz = "0.10.4"
+croner = "3.0.1"
+jmespath = "0.5.0"

--- a/crates/harn-cli/src/acp/execute.rs
+++ b/crates/harn-cli/src/acp/execute.rs
@@ -53,6 +53,9 @@ pub(super) async fn execute_chunk(
     if let Some(path) = source_path {
         let extensions = package::load_runtime_extensions(path);
         package::install_runtime_extensions(&extensions);
+        package::collect_manifest_triggers(&mut vm, &extensions)
+            .await
+            .map_err(|error| format!("failed to validate manifest triggers: {error}"))?;
         package::install_manifest_hooks(&mut vm, &extensions)
             .await
             .map_err(|error| format!("failed to install manifest hooks: {error}"))?;

--- a/crates/harn-cli/src/commands/bench.rs
+++ b/crates/harn-cli/src/commands/bench.rs
@@ -118,6 +118,10 @@ pub(crate) async fn run_bench(path: &str, iterations: usize) {
                 connect_mcp_servers(&manifest.mcp, &mut vm).await;
             }
         }
+        if let Err(error) = package::collect_manifest_triggers(&mut vm, &extensions).await {
+            eprintln!("error: failed to validate manifest triggers: {error}");
+            process::exit(1);
+        }
         if let Err(error) = package::install_manifest_hooks(&mut vm, &extensions).await {
             eprintln!("error: failed to install manifest hooks: {error}");
             process::exit(1);

--- a/crates/harn-cli/src/commands/doctor.rs
+++ b/crates/harn-cli/src/commands/doctor.rs
@@ -46,7 +46,7 @@ pub(crate) async fn run_doctor(network: bool) {
     checks.push(check_binary("cargo"));
     checks.extend(check_provider_selection());
     checks.extend(check_secret_providers());
-    checks.extend(check_manifest());
+    checks.extend(check_manifest().await);
     checks.extend(check_event_log());
     checks.extend(check_metadata_cache());
     checks.extend(check_skills());
@@ -200,7 +200,7 @@ fn check_secret_providers() -> Vec<DoctorCheck> {
     checks
 }
 
-fn check_manifest() -> Vec<DoctorCheck> {
+async fn check_manifest() -> Vec<DoctorCheck> {
     let Some(path) = find_nearest_manifest(&std::env::current_dir().unwrap_or_default()) else {
         return vec![DoctorCheck {
             status: DoctorStatus::Warn,
@@ -263,7 +263,66 @@ fn check_manifest() -> Vec<DoctorCheck> {
         }
     }
 
+    let extensions = package::load_runtime_extensions(&path);
+    if !extensions.triggers.is_empty() {
+        let mut vm = harn_vm::Vm::new();
+        harn_vm::register_vm_stdlib(&mut vm);
+        match package::collect_manifest_triggers(&mut vm, &extensions).await {
+            Ok(triggers) => {
+                for trigger in triggers {
+                    checks.push(DoctorCheck {
+                        status: DoctorStatus::Ok,
+                        label: format!("trigger:{}", trigger.config.id),
+                        detail: format!(
+                            "{} via {} handler={} budget={}",
+                            trigger_kind_label(trigger.config.kind),
+                            trigger.config.provider.as_str(),
+                            collected_handler_kind(&trigger.handler),
+                            format_trigger_budget(&trigger.config.budget),
+                        ),
+                    });
+                }
+            }
+            Err(error) => checks.push(DoctorCheck {
+                status: DoctorStatus::Fail,
+                label: "triggers".to_string(),
+                detail: error,
+            }),
+        }
+    }
+
     checks
+}
+
+fn trigger_kind_label(kind: package::TriggerKind) -> &'static str {
+    match kind {
+        package::TriggerKind::Webhook => "webhook",
+        package::TriggerKind::Cron => "cron",
+        package::TriggerKind::Poll => "poll",
+        package::TriggerKind::Stream => "stream",
+        package::TriggerKind::Predicate => "predicate",
+        package::TriggerKind::A2aPush => "a2a-push",
+    }
+}
+
+fn collected_handler_kind(handler: &package::CollectedTriggerHandler) -> &'static str {
+    match handler {
+        package::CollectedTriggerHandler::Local { .. } => "local",
+        package::CollectedTriggerHandler::A2a { .. } => "a2a",
+        package::CollectedTriggerHandler::Worker { .. } => "worker",
+    }
+}
+
+fn format_trigger_budget(budget: &package::TriggerBudgetSpec) -> String {
+    let daily = budget
+        .daily_cost_usd
+        .map(|value| format!("${value:.2}/day"))
+        .unwrap_or_else(|| "unbounded".to_string());
+    let concurrency = budget
+        .max_concurrent
+        .map(|value| format!("max {value} concurrent"))
+        .unwrap_or_else(|| "default concurrency".to_string());
+    format!("{daily}, {concurrency}")
 }
 
 fn check_skills() -> Vec<DoctorCheck> {
@@ -642,7 +701,10 @@ fn read_manifest(path: &Path) -> Result<package::Manifest, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_healthcheck_url, check_event_log, find_nearest_manifest, read_manifest};
+    use super::{
+        build_healthcheck_url, check_event_log, check_manifest, find_nearest_manifest,
+        format_trigger_budget, read_manifest, DoctorStatus,
+    };
     use harn_vm::llm_config::{AuthEnv, HealthcheckDef, ProviderDef};
 
     #[test]
@@ -712,5 +774,64 @@ mod tests {
         assert_eq!(checks[0].status, super::DoctorStatus::Ok);
         assert!(checks[0].detail.contains("sqlite"));
         assert!(checks[0].detail.contains(".harn/events.sqlite"));
+    }
+
+    #[test]
+    fn format_trigger_budget_renders_limits() {
+        let rendered = format_trigger_budget(&crate::package::TriggerBudgetSpec {
+            daily_cost_usd: Some(5.0),
+            max_concurrent: Some(10),
+        });
+        assert_eq!(rendered, "$5.00/day, max 10 concurrent");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn check_manifest_reports_loaded_triggers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join(".git")).expect("git dir");
+        std::fs::write(
+            dir.path().join("harn.toml"),
+            r#"
+[package]
+name = "workspace"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "github-new-issue"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "handlers::on_new_issue"
+budget = { daily_cost_usd = 5.0, max_concurrent = 10 }
+"#,
+        )
+        .expect("write manifest");
+        std::fs::write(
+            dir.path().join("lib.harn"),
+            r#"
+import "std/triggers"
+
+pub fn on_new_issue(event: TriggerEvent) {
+  log(event.kind)
+}
+"#,
+        )
+        .expect("write lib");
+
+        let previous = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(dir.path()).expect("set cwd");
+        let checks = check_manifest().await;
+        std::env::set_current_dir(previous).expect("restore cwd");
+
+        let trigger = checks
+            .iter()
+            .find(|check| check.label == "trigger:github-new-issue")
+            .expect("trigger check");
+        assert_eq!(trigger.status, DoctorStatus::Ok);
+        assert!(trigger.detail.contains("webhook via github"));
+        assert!(trigger.detail.contains("handler=local"));
+        assert!(trigger.detail.contains("$5.00/day"));
     }
 }

--- a/crates/harn-cli/src/commands/playground.rs
+++ b/crates/harn-cli/src/commands/playground.rs
@@ -255,6 +255,9 @@ async fn configured_vm(
             connect_mcp_servers(&manifest.mcp, &mut vm).await;
         }
     }
+    package::collect_manifest_triggers(&mut vm, &extensions)
+        .await
+        .map_err(|error| format!("failed to validate manifest triggers: {error}"))?;
 
     Ok(vm)
 }

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -549,6 +549,10 @@ pub(crate) async fn run_file_with_skill_dirs(
             connect_mcp_servers(&manifest.mcp, &mut vm).await;
         }
     }
+    if let Err(error) = package::collect_manifest_triggers(&mut vm, &extensions).await {
+        eprintln!("error: failed to validate manifest triggers: {error}");
+        process::exit(1);
+    }
     if let Err(error) = package::install_manifest_hooks(&mut vm, &extensions).await {
         eprintln!("error: failed to install manifest hooks: {error}");
         process::exit(1);
@@ -813,6 +817,10 @@ pub(crate) async fn run_file_mcp_serve(path: &str, card_source: Option<&str>) {
         if !manifest.mcp.is_empty() {
             connect_mcp_servers(&manifest.mcp, &mut vm).await;
         }
+    }
+    if let Err(error) = package::collect_manifest_triggers(&mut vm, &extensions).await {
+        eprintln!("error: failed to validate manifest triggers: {error}");
+        process::exit(1);
     }
     if let Err(error) = package::install_manifest_hooks(&mut vm, &extensions).await {
         eprintln!("error: failed to install manifest hooks: {error}");

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -998,6 +998,9 @@ pub(crate) async fn execute(source: &str, source_path: Option<&Path>) -> Result<
             if let Some(path) = source_path {
                 let extensions = package::load_runtime_extensions(path);
                 package::install_runtime_extensions(&extensions);
+                package::collect_manifest_triggers(&mut vm, &extensions)
+                    .await
+                    .map_err(|error| format!("failed to validate manifest triggers: {error}"))?;
                 package::install_manifest_hooks(&mut vm, &extensions)
                     .await
                     .map_err(|error| format!("failed to install manifest hooks: {error}"))?;

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -1,12 +1,16 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 use std::{fs, process};
 
-use serde::Deserialize;
+use chrono_tz::Tz;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 const PKG_DIR: &str = ".harn/packages";
 const MANIFEST: &str = "harn.toml";
 const LOCK_FILE: &str = "harn.lock";
+const TRIGGER_RETRY_MAX_LIMIT: u32 = 100;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Manifest {
@@ -55,6 +59,12 @@ pub struct Manifest {
     /// the handlers themselves live in Harn modules.
     #[serde(default)]
     pub hooks: Vec<HookConfig>,
+    /// `[[triggers]]` array-of-tables — declarative event-driven trigger
+    /// registrations that resolve local handlers and predicates from Harn
+    /// modules at load time and preserve remote URI schemes for later
+    /// dispatcher work.
+    #[serde(default)]
+    pub triggers: Vec<TriggerManifestEntry>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -67,6 +77,98 @@ pub struct HookConfig {
 
 fn default_hook_pattern() -> String {
     "*".to_string()
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TriggerManifestEntry {
+    pub id: String,
+    pub kind: TriggerKind,
+    pub provider: harn_vm::ProviderId,
+    #[serde(rename = "match")]
+    pub match_: TriggerMatchExpr,
+    #[serde(default)]
+    pub when: Option<String>,
+    pub handler: String,
+    #[serde(default)]
+    pub dedupe_key: Option<String>,
+    #[serde(default)]
+    pub retry: TriggerRetrySpec,
+    #[serde(default)]
+    pub priority: TriggerPriority,
+    #[serde(default)]
+    pub budget: TriggerBudgetSpec,
+    #[serde(default)]
+    pub secrets: BTreeMap<String, String>,
+    #[serde(default)]
+    pub filter: Option<String>,
+    #[serde(flatten, default)]
+    pub kind_specific: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TriggerKind {
+    Webhook,
+    Cron,
+    Poll,
+    Stream,
+    Predicate,
+    A2aPush,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct TriggerMatchExpr {
+    #[serde(default)]
+    pub events: Vec<String>,
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TriggerRetrySpec {
+    #[serde(default)]
+    pub max: u32,
+    #[serde(default)]
+    pub backoff: TriggerRetryBackoff,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TriggerRetryBackoff {
+    #[default]
+    Immediate,
+    Svix,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TriggerPriority {
+    High,
+    #[default]
+    Normal,
+    Low,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TriggerBudgetSpec {
+    #[serde(default)]
+    pub daily_cost_usd: Option<f64>,
+    #[serde(default)]
+    pub max_concurrent: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TriggerHandlerUri {
+    Local(TriggerFunctionRef),
+    A2a { target: String },
+    Worker { queue: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TriggerFunctionRef {
+    pub raw: String,
+    pub module_name: Option<String>,
+    pub function_name: String,
 }
 
 /// `[skills]` table body.
@@ -285,6 +387,7 @@ pub struct RuntimeExtensions {
     pub llm: Option<harn_vm::llm_config::ProvidersConfig>,
     pub capabilities: Option<harn_vm::llm::capabilities::CapabilitiesFile>,
     pub hooks: Vec<ResolvedHookConfig>,
+    pub triggers: Vec<ResolvedTriggerConfig>,
 }
 
 #[derive(Debug, Clone)]
@@ -294,6 +397,60 @@ pub struct ResolvedHookConfig {
     pub handler: String,
     pub manifest_dir: PathBuf,
     pub package_name: Option<String>,
+    pub exports: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Trigger metadata is carried forward for doctor output and downstream dispatcher work.
+pub struct ResolvedTriggerConfig {
+    pub id: String,
+    pub kind: TriggerKind,
+    pub provider: harn_vm::ProviderId,
+    pub match_: TriggerMatchExpr,
+    pub when: Option<String>,
+    pub handler: String,
+    pub dedupe_key: Option<String>,
+    pub retry: TriggerRetrySpec,
+    pub priority: TriggerPriority,
+    pub budget: TriggerBudgetSpec,
+    pub secrets: BTreeMap<String, String>,
+    pub filter: Option<String>,
+    pub kind_specific: BTreeMap<String, toml::Value>,
+    pub manifest_dir: PathBuf,
+    pub manifest_path: PathBuf,
+    pub package_name: Option<String>,
+    pub exports: HashMap<String, String>,
+    pub table_index: usize,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Collected trigger bindings are validated now and consumed by follow-up trigger dispatcher work.
+pub struct CollectedManifestTrigger {
+    pub config: ResolvedTriggerConfig,
+    pub handler: CollectedTriggerHandler,
+    pub when: Option<CollectedTriggerPredicate>,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Remote handler targets and resolved closures are retained for downstream trigger execution.
+pub enum CollectedTriggerHandler {
+    Local {
+        reference: TriggerFunctionRef,
+        closure: Rc<harn_vm::VmClosure>,
+    },
+    A2a {
+        target: String,
+    },
+    Worker {
+        queue: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Predicate closures are validated now and reused by later trigger dispatch work.
+pub struct CollectedTriggerPredicate {
+    pub reference: TriggerFunctionRef,
+    pub closure: Rc<harn_vm::VmClosure>,
 }
 
 #[derive(Debug, Clone)]
@@ -302,8 +459,8 @@ struct LocatedManifest {
     dir: PathBuf,
 }
 
-type HookModuleCacheKey = (PathBuf, Option<String>, String);
-type HookModuleExports = std::collections::BTreeMap<String, std::rc::Rc<harn_vm::VmClosure>>;
+type ManifestModuleCacheKey = (PathBuf, Option<String>, Option<String>);
+type ManifestModuleExports = BTreeMap<String, Rc<harn_vm::VmClosure>>;
 
 #[derive(Debug, Default)]
 struct LockFile {
@@ -465,8 +622,425 @@ fn resolved_hooks_from_manifest(
             handler: hook.handler.clone(),
             manifest_dir: manifest_dir.to_path_buf(),
             package_name: manifest.package.as_ref().and_then(|pkg| pkg.name.clone()),
+            exports: manifest.exports.clone(),
         })
         .collect()
+}
+
+fn resolved_triggers_from_manifest(
+    manifest: &Manifest,
+    manifest_dir: &Path,
+) -> Vec<ResolvedTriggerConfig> {
+    let manifest_path = manifest_dir.join(MANIFEST);
+    let package_name = manifest.package.as_ref().and_then(|pkg| pkg.name.clone());
+    manifest
+        .triggers
+        .iter()
+        .enumerate()
+        .map(|(table_index, trigger)| ResolvedTriggerConfig {
+            id: trigger.id.clone(),
+            kind: trigger.kind,
+            provider: trigger.provider.clone(),
+            match_: trigger.match_.clone(),
+            when: trigger.when.clone(),
+            handler: trigger.handler.clone(),
+            dedupe_key: trigger.dedupe_key.clone(),
+            retry: trigger.retry.clone(),
+            priority: trigger.priority,
+            budget: trigger.budget.clone(),
+            secrets: trigger.secrets.clone(),
+            filter: trigger.filter.clone(),
+            kind_specific: trigger.kind_specific.clone(),
+            manifest_dir: manifest_dir.to_path_buf(),
+            manifest_path: manifest_path.clone(),
+            package_name: package_name.clone(),
+            exports: manifest.exports.clone(),
+            table_index,
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone)]
+struct TriggerFunctionSignature {
+    params: Vec<Option<harn_parser::TypeExpr>>,
+    return_type: Option<harn_parser::TypeExpr>,
+}
+
+fn manifest_trigger_location(trigger: &ResolvedTriggerConfig) -> String {
+    format!(
+        "{} [[triggers]] table #{} (id = {})",
+        trigger.manifest_path.display(),
+        trigger.table_index + 1,
+        trigger.id
+    )
+}
+
+fn trigger_error(trigger: &ResolvedTriggerConfig, message: impl Into<String>) -> String {
+    format!("{}: {}", manifest_trigger_location(trigger), message.into())
+}
+
+fn valid_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(ch) if ch == '_' || ch.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn parse_local_trigger_ref(
+    raw: &str,
+    field_name: &str,
+    trigger: &ResolvedTriggerConfig,
+) -> Result<TriggerFunctionRef, String> {
+    if raw.trim().is_empty() {
+        return Err(trigger_error(
+            trigger,
+            format!("{field_name} cannot be empty"),
+        ));
+    }
+    if raw.contains("://") {
+        return Err(trigger_error(
+            trigger,
+            format!("{field_name} must reference a local function, not a URI"),
+        ));
+    }
+    if let Some((module_name, function_name)) = raw.rsplit_once("::") {
+        if module_name.trim().is_empty() || function_name.trim().is_empty() {
+            return Err(trigger_error(
+                trigger,
+                format!("{field_name} must use <module>::<function> when module-qualified"),
+            ));
+        }
+        if !valid_identifier(function_name) {
+            return Err(trigger_error(
+                trigger,
+                format!("{field_name} function name '{function_name}' is not a valid identifier"),
+            ));
+        }
+        return Ok(TriggerFunctionRef {
+            raw: raw.to_string(),
+            module_name: Some(module_name.to_string()),
+            function_name: function_name.to_string(),
+        });
+    }
+    if !valid_identifier(raw) {
+        return Err(trigger_error(
+            trigger,
+            format!("{field_name} '{raw}' is not a valid bare function identifier"),
+        ));
+    }
+    Ok(TriggerFunctionRef {
+        raw: raw.to_string(),
+        module_name: None,
+        function_name: raw.to_string(),
+    })
+}
+
+fn parse_trigger_handler_uri(trigger: &ResolvedTriggerConfig) -> Result<TriggerHandlerUri, String> {
+    let raw = trigger.handler.trim();
+    if let Some(target) = raw.strip_prefix("a2a://") {
+        if target.is_empty() {
+            return Err(trigger_error(
+                trigger,
+                "handler a2a:// target cannot be empty",
+            ));
+        }
+        return Ok(TriggerHandlerUri::A2a {
+            target: target.to_string(),
+        });
+    }
+    if let Some(queue) = raw.strip_prefix("worker://") {
+        if queue.is_empty() {
+            return Err(trigger_error(
+                trigger,
+                "handler worker:// queue cannot be empty",
+            ));
+        }
+        return Ok(TriggerHandlerUri::Worker {
+            queue: queue.to_string(),
+        });
+    }
+    if raw.contains("://") {
+        return Err(trigger_error(
+            trigger,
+            format!("handler URI scheme in '{raw}' is not implemented"),
+        ));
+    }
+    Ok(TriggerHandlerUri::Local(parse_local_trigger_ref(
+        raw, "handler", trigger,
+    )?))
+}
+
+fn parse_secret_id(raw: &str) -> Option<harn_vm::secrets::SecretId> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let (base, version) = match trimmed.rsplit_once('@') {
+        Some((base, version_text)) => {
+            let version = version_text.parse::<u64>().ok()?;
+            (base, harn_vm::secrets::SecretVersion::Exact(version))
+        }
+        None => (trimmed, harn_vm::secrets::SecretVersion::Latest),
+    };
+    let (namespace, name) = base.split_once('/')?;
+    if namespace.is_empty() || name.is_empty() {
+        return None;
+    }
+    Some(harn_vm::secrets::SecretId::new(namespace, name).with_version(version))
+}
+
+fn extract_kind_field<'a>(
+    trigger: &'a ResolvedTriggerConfig,
+    field: &str,
+) -> Option<&'a toml::Value> {
+    trigger.kind_specific.get(field)
+}
+
+fn parse_jmespath_expression(
+    trigger: &ResolvedTriggerConfig,
+    field_name: &str,
+    expr: &str,
+) -> Result<(), String> {
+    jmespath::compile(expr).map(|_| ()).map_err(|error| {
+        trigger_error(
+            trigger,
+            format!("{field_name} '{expr}' is invalid: {error}"),
+        )
+    })
+}
+
+fn validate_static_trigger_config(trigger: &ResolvedTriggerConfig) -> Result<(), String> {
+    if trigger.id.trim().is_empty() {
+        return Err(trigger_error(trigger, "id cannot be empty"));
+    }
+    let provider_schemas = harn_vm::registered_provider_schema_names();
+    if !provider_schemas.contains_key(trigger.provider.as_str()) {
+        return Err(trigger_error(
+            trigger,
+            format!("provider '{}' is not registered", trigger.provider.as_str()),
+        ));
+    }
+    if let Some(dedupe_key) = &trigger.dedupe_key {
+        parse_jmespath_expression(trigger, "dedupe_key", dedupe_key)?;
+    }
+    if let Some(filter) = &trigger.filter {
+        parse_jmespath_expression(trigger, "filter", filter)?;
+    }
+    if let Some(daily_cost_usd) = trigger.budget.daily_cost_usd {
+        if daily_cost_usd.is_sign_negative() {
+            return Err(trigger_error(
+                trigger,
+                "budget.daily_cost_usd must be greater than or equal to 0",
+            ));
+        }
+    }
+    if trigger.retry.max > TRIGGER_RETRY_MAX_LIMIT {
+        return Err(trigger_error(
+            trigger,
+            format!("retry.max must be less than or equal to {TRIGGER_RETRY_MAX_LIMIT}"),
+        ));
+    }
+    for (name, secret_ref) in &trigger.secrets {
+        let Some(secret_id) = parse_secret_id(secret_ref) else {
+            return Err(trigger_error(
+                trigger,
+                format!("secret '{name}' must use <namespace>/<name> syntax"),
+            ));
+        };
+        if secret_id.namespace != trigger.provider.as_str() {
+            return Err(trigger_error(
+                trigger,
+                format!(
+                    "secret '{name}' uses namespace '{}' but provider is '{}'",
+                    secret_id.namespace,
+                    trigger.provider.as_str()
+                ),
+            ));
+        }
+    }
+    if matches!(trigger.kind, TriggerKind::Cron) {
+        let Some(schedule) = extract_kind_field(trigger, "schedule").and_then(toml::Value::as_str)
+        else {
+            return Err(trigger_error(
+                trigger,
+                "cron triggers require a string schedule field",
+            ));
+        };
+        croner::Cron::from_str(schedule).map_err(|error| {
+            trigger_error(
+                trigger,
+                format!("invalid cron schedule '{schedule}': {error}"),
+            )
+        })?;
+        if let Some(timezone) =
+            extract_kind_field(trigger, "timezone").and_then(toml::Value::as_str)
+        {
+            timezone.parse::<Tz>().map_err(|error| {
+                trigger_error(
+                    trigger,
+                    format!("invalid cron timezone '{timezone}': {error}"),
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_static_trigger_configs(triggers: &[ResolvedTriggerConfig]) -> Result<(), String> {
+    let mut seen_ids = HashSet::new();
+    for trigger in triggers {
+        validate_static_trigger_config(trigger)?;
+        if !seen_ids.insert(trigger.id.clone()) {
+            return Err(trigger_error(
+                trigger,
+                format!(
+                    "duplicate trigger id '{}' across loaded manifests",
+                    trigger.id
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn manifest_module_source_path(
+    manifest_dir: &Path,
+    package_name: Option<&str>,
+    exports: &HashMap<String, String>,
+    module_name: Option<&str>,
+) -> Result<PathBuf, String> {
+    match module_name {
+        None => {
+            let path = manifest_dir.join("lib.harn");
+            if path.exists() {
+                Ok(path)
+            } else {
+                Err(format!(
+                    "no lib.harn found next to manifest in {}",
+                    manifest_dir.display()
+                ))
+            }
+        }
+        Some(module_name) if package_name.is_some_and(|pkg| pkg == module_name) => {
+            let path = manifest_dir.join("lib.harn");
+            if path.exists() {
+                Ok(path)
+            } else {
+                Err(format!(
+                    "module '{}' resolves to local lib.harn, but {} is missing",
+                    module_name,
+                    path.display()
+                ))
+            }
+        }
+        Some(module_name) if exports.contains_key(module_name) => {
+            let rel_path = exports.get(module_name).expect("checked export key exists");
+            let path = manifest_dir.join(rel_path);
+            if path.exists() {
+                Ok(path)
+            } else {
+                Err(format!(
+                    "export '{}' resolves to {}, but that path does not exist",
+                    module_name,
+                    path.display()
+                ))
+            }
+        }
+        Some(module_name) => {
+            let path = harn_vm::resolve_module_import_path(manifest_dir, module_name);
+            if path.exists() {
+                Ok(path)
+            } else {
+                Err(format!(
+                    "module '{}' could not be resolved from {}",
+                    module_name,
+                    manifest_dir.display()
+                ))
+            }
+        }
+    }
+}
+
+fn load_trigger_function_signatures(
+    path: &Path,
+) -> Result<BTreeMap<String, TriggerFunctionSignature>, String> {
+    let source = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let program = harn_parser::parse_source(&source)
+        .map_err(|error| format!("failed to parse {}: {error}", path.display()))?;
+    let mut signatures = BTreeMap::new();
+    for node in &program {
+        let (_, inner) = harn_parser::peel_attributes(node);
+        if let harn_parser::Node::FnDecl {
+            name,
+            params,
+            return_type,
+            ..
+        } = &inner.node
+        {
+            signatures.insert(
+                name.clone(),
+                TriggerFunctionSignature {
+                    params: params.iter().map(|param| param.type_expr.clone()).collect(),
+                    return_type: return_type.clone(),
+                },
+            );
+        }
+    }
+    Ok(signatures)
+}
+
+async fn resolve_manifest_exports(
+    vm: &mut harn_vm::Vm,
+    manifest_dir: &Path,
+    package_name: Option<&str>,
+    exports: &HashMap<String, String>,
+    module_name: Option<&str>,
+) -> Result<ManifestModuleExports, String> {
+    match module_name {
+        None => {
+            let lib_path = manifest_module_source_path(manifest_dir, package_name, exports, None)?;
+            vm.load_module_exports(&lib_path)
+                .await
+                .map_err(|error| error.to_string())
+        }
+        Some(module_name) if package_name.is_some_and(|name| name == module_name) => {
+            let lib_path = manifest_module_source_path(
+                manifest_dir,
+                package_name,
+                exports,
+                Some(module_name),
+            )?;
+            vm.load_module_exports(&lib_path)
+                .await
+                .map_err(|error| error.to_string())
+        }
+        Some(module_name) if exports.contains_key(module_name) => {
+            let lib_path = manifest_module_source_path(
+                manifest_dir,
+                package_name,
+                exports,
+                Some(module_name),
+            )?;
+            vm.load_module_exports(&lib_path)
+                .await
+                .map_err(|error| error.to_string())
+        }
+        Some(module_name) => vm
+            .load_module_exports_from_import(module_name)
+            .await
+            .map_err(|error| error.to_string()),
+    }
+}
+
+fn is_trigger_event_type(ty: &harn_parser::TypeExpr) -> bool {
+    matches!(ty, harn_parser::TypeExpr::Named(name) if name == "TriggerEvent")
+}
+
+fn is_bool_type(ty: &harn_parser::TypeExpr) -> bool {
+    matches!(ty, harn_parser::TypeExpr::Named(name) if name == "bool")
 }
 
 fn manifest_capabilities(
@@ -490,6 +1064,7 @@ pub fn load_runtime_extensions(anchor: &Path) -> RuntimeExtensions {
     let mut llm = harn_vm::llm_config::ProvidersConfig::default();
     let mut capabilities = harn_vm::llm::capabilities::CapabilitiesFile::default();
     let mut hooks = Vec::new();
+    let mut triggers = Vec::new();
 
     for located in collect_package_manifests(&manifest_dir.join(PKG_DIR)) {
         llm.merge_from(&located.manifest.llm);
@@ -500,6 +1075,10 @@ pub fn load_runtime_extensions(anchor: &Path) -> RuntimeExtensions {
             &located.manifest,
             &located.dir,
         ));
+        triggers.extend(resolved_triggers_from_manifest(
+            &located.manifest,
+            &located.dir,
+        ));
     }
 
     llm.merge_from(&root_manifest.llm);
@@ -507,12 +1086,17 @@ pub fn load_runtime_extensions(anchor: &Path) -> RuntimeExtensions {
         merge_capability_overrides(&mut capabilities, file);
     }
     hooks.extend(resolved_hooks_from_manifest(&root_manifest, &manifest_dir));
+    triggers.extend(resolved_triggers_from_manifest(
+        &root_manifest,
+        &manifest_dir,
+    ));
 
     RuntimeExtensions {
         root_manifest: Some(root_manifest),
         llm: (!llm.is_empty()).then_some(llm),
         capabilities: (!is_empty_capabilities(&capabilities)).then_some(capabilities),
         hooks,
+        triggers,
     }
 }
 
@@ -522,36 +1106,12 @@ pub fn install_runtime_extensions(extensions: &RuntimeExtensions) {
     harn_vm::llm::capabilities::set_user_overrides(extensions.capabilities.clone());
 }
 
-async fn resolve_hook_exports(
-    vm: &mut harn_vm::Vm,
-    hook: &ResolvedHookConfig,
-    module_name: &str,
-) -> Result<HookModuleExports, String> {
-    let self_name_matches = hook
-        .package_name
-        .as_deref()
-        .is_some_and(|name| name == module_name);
-    if self_name_matches {
-        let lib_path = hook.manifest_dir.join("lib.harn");
-        if lib_path.exists() {
-            return vm
-                .load_module_exports(&lib_path)
-                .await
-                .map_err(|error| error.to_string());
-        }
-    }
-
-    vm.load_module_exports_from_import(module_name)
-        .await
-        .map_err(|error| error.to_string())
-}
-
 pub async fn install_manifest_hooks(
     vm: &mut harn_vm::Vm,
     extensions: &RuntimeExtensions,
 ) -> Result<(), String> {
     harn_vm::orchestration::clear_runtime_hooks();
-    let mut loaded_exports: HashMap<HookModuleCacheKey, HookModuleExports> = HashMap::new();
+    let mut loaded_exports: HashMap<ManifestModuleCacheKey, ManifestModuleExports> = HashMap::new();
     for hook in &extensions.hooks {
         let Some((module_name, function_name)) = hook.handler.rsplit_once("::") else {
             return Err(format!(
@@ -562,10 +1122,17 @@ pub async fn install_manifest_hooks(
         let cache_key = (
             hook.manifest_dir.clone(),
             hook.package_name.clone(),
-            module_name.to_string(),
+            Some(module_name.to_string()),
         );
         if !loaded_exports.contains_key(&cache_key) {
-            let exports = resolve_hook_exports(vm, hook, module_name).await?;
+            let exports = resolve_manifest_exports(
+                vm,
+                &hook.manifest_dir,
+                hook.package_name.as_deref(),
+                &hook.exports,
+                Some(module_name),
+            )
+            .await?;
             loaded_exports.insert(cache_key.clone(), exports);
         }
         let exports = loaded_exports
@@ -585,6 +1152,159 @@ pub async fn install_manifest_hooks(
         );
     }
     Ok(())
+}
+
+pub async fn collect_manifest_triggers(
+    vm: &mut harn_vm::Vm,
+    extensions: &RuntimeExtensions,
+) -> Result<Vec<CollectedManifestTrigger>, String> {
+    validate_static_trigger_configs(&extensions.triggers)?;
+    let mut loaded_exports: HashMap<ManifestModuleCacheKey, ManifestModuleExports> = HashMap::new();
+    let mut module_signatures: HashMap<PathBuf, BTreeMap<String, TriggerFunctionSignature>> =
+        HashMap::new();
+    let mut collected = Vec::new();
+
+    for trigger in &extensions.triggers {
+        let handler = parse_trigger_handler_uri(trigger)?;
+        let collected_handler = match handler {
+            TriggerHandlerUri::Local(reference) => {
+                let cache_key = (
+                    trigger.manifest_dir.clone(),
+                    trigger.package_name.clone(),
+                    reference.module_name.clone(),
+                );
+                if !loaded_exports.contains_key(&cache_key) {
+                    let exports = resolve_manifest_exports(
+                        vm,
+                        &trigger.manifest_dir,
+                        trigger.package_name.as_deref(),
+                        &trigger.exports,
+                        reference.module_name.as_deref(),
+                    )
+                    .await
+                    .map_err(|error| trigger_error(trigger, error))?;
+                    loaded_exports.insert(cache_key.clone(), exports);
+                }
+                let exports = loaded_exports
+                    .get(&cache_key)
+                    .expect("manifest trigger exports cached");
+                let Some(closure) = exports.get(&reference.function_name) else {
+                    return Err(trigger_error(
+                        trigger,
+                        format!(
+                            "handler '{}' is not exported by the resolved module",
+                            reference.raw
+                        ),
+                    ));
+                };
+                CollectedTriggerHandler::Local {
+                    reference,
+                    closure: closure.clone(),
+                }
+            }
+            TriggerHandlerUri::A2a { target } => CollectedTriggerHandler::A2a { target },
+            TriggerHandlerUri::Worker { queue } => CollectedTriggerHandler::Worker { queue },
+        };
+
+        let collected_when = if let Some(when_raw) = &trigger.when {
+            let reference = parse_local_trigger_ref(when_raw, "when", trigger)?;
+            let cache_key = (
+                trigger.manifest_dir.clone(),
+                trigger.package_name.clone(),
+                reference.module_name.clone(),
+            );
+            if !loaded_exports.contains_key(&cache_key) {
+                let exports = resolve_manifest_exports(
+                    vm,
+                    &trigger.manifest_dir,
+                    trigger.package_name.as_deref(),
+                    &trigger.exports,
+                    reference.module_name.as_deref(),
+                )
+                .await
+                .map_err(|error| trigger_error(trigger, error))?;
+                loaded_exports.insert(cache_key.clone(), exports);
+            }
+            let exports = loaded_exports
+                .get(&cache_key)
+                .expect("manifest trigger predicate exports cached");
+            let Some(closure) = exports.get(&reference.function_name) else {
+                return Err(trigger_error(
+                    trigger,
+                    format!(
+                        "when predicate '{}' is not exported by the resolved module",
+                        reference.raw
+                    ),
+                ));
+            };
+
+            let source_path = manifest_module_source_path(
+                &trigger.manifest_dir,
+                trigger.package_name.as_deref(),
+                &trigger.exports,
+                reference.module_name.as_deref(),
+            )
+            .map_err(|error| trigger_error(trigger, error))?;
+            if !module_signatures.contains_key(&source_path) {
+                let signatures = load_trigger_function_signatures(&source_path)
+                    .map_err(|error| trigger_error(trigger, error))?;
+                module_signatures.insert(source_path.clone(), signatures);
+            }
+            let signatures = module_signatures
+                .get(&source_path)
+                .expect("module signatures cached");
+            let Some(signature) = signatures.get(&reference.function_name) else {
+                return Err(trigger_error(
+                    trigger,
+                    format!(
+                        "when predicate '{}' must resolve to a function declaration",
+                        reference.raw
+                    ),
+                ));
+            };
+            if signature.params.len() != 1
+                || signature.params[0]
+                    .as_ref()
+                    .is_none_or(|param| !is_trigger_event_type(param))
+            {
+                return Err(trigger_error(
+                    trigger,
+                    format!(
+                        "when predicate '{}' must have signature fn(TriggerEvent) -> bool",
+                        reference.raw
+                    ),
+                ));
+            }
+            if signature
+                .return_type
+                .as_ref()
+                .is_none_or(|return_type| !is_bool_type(return_type))
+            {
+                return Err(trigger_error(
+                    trigger,
+                    format!(
+                        "when predicate '{}' must have signature fn(TriggerEvent) -> bool",
+                        reference.raw
+                    ),
+                ));
+            }
+
+            Some(CollectedTriggerPredicate {
+                reference,
+                closure: closure.clone(),
+            })
+        } else {
+            None
+        };
+
+        collected.push(CollectedManifestTrigger {
+            config: trigger.clone(),
+            handler: collected_handler,
+            when: collected_when,
+        });
+    }
+
+    Ok(collected)
 }
 
 fn absolutize_check_config_paths(mut config: CheckConfig, manifest_dir: &Path) -> CheckConfig {
@@ -1077,6 +1797,30 @@ fn expand_single_star_glob(path: &Path) -> Vec<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct TriggerTables {
+        #[serde(default)]
+        triggers: Vec<TriggerManifestEntry>,
+    }
+
+    fn test_vm() -> harn_vm::Vm {
+        let mut vm = harn_vm::Vm::new();
+        harn_vm::register_vm_stdlib(&mut vm);
+        vm
+    }
+
+    fn write_trigger_project(root: &Path, manifest: &str, lib_source: Option<&str>) -> PathBuf {
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join(MANIFEST), manifest).unwrap();
+        if let Some(source) = lib_source {
+            fs::write(root.join("lib.harn"), source).unwrap();
+        }
+        let harn_file = root.join("main.harn");
+        fs::write(&harn_file, "pipeline main() {}\n").unwrap();
+        harn_file
+    }
 
     #[test]
     fn preflight_severity_parsing_accepts_synonyms() {
@@ -1330,5 +2074,332 @@ handler = "acme::audit_edit"
         assert_eq!(extensions.hooks.len(), 2);
         assert_eq!(extensions.hooks[0].handler, "acme::audit_edit");
         assert_eq!(extensions.hooks[1].handler, "workspace::after_read");
+    }
+
+    #[test]
+    fn trigger_manifest_entries_round_trip_through_toml() {
+        let source = r#"
+[[triggers]]
+id = "github-new-issue"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+when = "handlers::should_handle"
+handler = "handlers::on_new_issue"
+dedupe_key = "event.dedupe_key"
+retry = { max = 7, backoff = "svix" }
+priority = "high"
+budget = { daily_cost_usd = 5.0, max_concurrent = 10 }
+secrets = { signing_secret = "github/webhook-secret" }
+filter = "event.kind"
+
+[[triggers]]
+id = "daily-digest"
+kind = "cron"
+provider = "cron"
+match = { events = ["cron.tick"] }
+handler = "worker://digest-queue"
+schedule = "0 9 * * *"
+timezone = "America/Los_Angeles"
+"#;
+        let parsed: TriggerTables = toml::from_str(source).expect("trigger tables parse");
+        let encoded = toml::to_string(&parsed).expect("trigger tables encode");
+        let reparsed: TriggerTables = toml::from_str(&encoded).expect("trigger tables reparse");
+        assert_eq!(reparsed, parsed);
+    }
+
+    #[test]
+    fn load_runtime_extensions_collects_manifest_triggers_in_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::create_dir_all(root.join(".harn/packages/acme")).unwrap();
+        fs::write(
+            root.join(MANIFEST),
+            r#"
+[package]
+name = "workspace"
+
+[[triggers]]
+id = "workspace-trigger"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "worker://workspace-queue"
+"#,
+        )
+        .unwrap();
+        fs::write(
+            root.join(".harn/packages/acme/harn.toml"),
+            r#"
+[package]
+name = "acme"
+
+[[triggers]]
+id = "acme-trigger"
+kind = "cron"
+provider = "cron"
+match = { events = ["cron.tick"] }
+handler = "worker://acme-queue"
+schedule = "0 9 * * *"
+timezone = "UTC"
+"#,
+        )
+        .unwrap();
+        let harn_file = root.join("main.harn");
+        fs::write(&harn_file, "pipeline main() {}\n").unwrap();
+
+        let extensions = load_runtime_extensions(&harn_file);
+        assert_eq!(extensions.triggers.len(), 2);
+        assert_eq!(extensions.triggers[0].id, "acme-trigger");
+        assert_eq!(extensions.triggers[1].id, "workspace-trigger");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_manifest_triggers_accepts_local_handler_and_when() {
+        let tmp = tempfile::tempdir().unwrap();
+        let harn_file = write_trigger_project(
+            tmp.path(),
+            r#"
+[package]
+name = "workspace"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "github-new-issue"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+when = "handlers::should_handle"
+handler = "handlers::on_new_issue"
+dedupe_key = "event.dedupe_key"
+retry = { max = 7, backoff = "svix" }
+priority = "normal"
+budget = { daily_cost_usd = 5.0, max_concurrent = 10 }
+secrets = { signing_secret = "github/webhook-secret" }
+filter = "event.kind"
+"#,
+            Some(
+                r#"
+import "std/triggers"
+
+pub fn on_new_issue(event: TriggerEvent) {
+  log(event.kind)
+}
+
+pub fn should_handle(event: TriggerEvent) -> bool {
+  return event.provider == "github"
+}
+"#,
+            ),
+        );
+        let extensions = load_runtime_extensions(&harn_file);
+        let mut vm = test_vm();
+        let collected = collect_manifest_triggers(&mut vm, &extensions)
+            .await
+            .expect("trigger collection succeeds");
+        assert_eq!(collected.len(), 1);
+        assert!(matches!(
+            &collected[0].handler,
+            CollectedTriggerHandler::Local { reference, .. } if reference.raw == "handlers::on_new_issue"
+        ));
+        assert_eq!(collected[0].config.priority, TriggerPriority::Normal);
+        assert!(collected[0].when.is_some());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_manifest_triggers_rejects_duplicate_ids() {
+        let tmp = tempfile::tempdir().unwrap();
+        let harn_file = write_trigger_project(
+            tmp.path(),
+            r#"
+[[triggers]]
+id = "duplicate"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "worker://queue-a"
+
+[[triggers]]
+id = "duplicate"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.edited"] }
+handler = "worker://queue-b"
+"#,
+            None,
+        );
+        let mut vm = test_vm();
+        let error = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+            .await
+            .unwrap_err();
+        assert!(error.contains("duplicate trigger id 'duplicate'"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_manifest_triggers_rejects_unknown_provider() {
+        let tmp = tempfile::tempdir().unwrap();
+        let harn_file = write_trigger_project(
+            tmp.path(),
+            r#"
+[[triggers]]
+id = "unknown-provider"
+kind = "webhook"
+provider = "made-up"
+match = { events = ["issues.opened"] }
+handler = "worker://queue"
+"#,
+            None,
+        );
+        let mut vm = test_vm();
+        let error = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+            .await
+            .unwrap_err();
+        assert!(error.contains("provider 'made-up' is not registered"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_manifest_triggers_rejects_unresolved_handler() {
+        let tmp = tempfile::tempdir().unwrap();
+        let harn_file = write_trigger_project(
+            tmp.path(),
+            r#"
+[package]
+name = "workspace"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "missing-handler"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "handlers::missing"
+"#,
+            Some(
+                r#"
+import "std/triggers"
+
+pub fn on_new_issue(event: TriggerEvent) {
+  log(event.kind)
+}
+"#,
+            ),
+        );
+        let mut vm = test_vm();
+        let error = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+            .await
+            .unwrap_err();
+        assert!(error.contains("handler 'handlers::missing' is not exported"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_manifest_triggers_rejects_malformed_cron() {
+        let tmp = tempfile::tempdir().unwrap();
+        let harn_file = write_trigger_project(
+            tmp.path(),
+            r#"
+[[triggers]]
+id = "bad-cron"
+kind = "cron"
+provider = "cron"
+match = { events = ["cron.tick"] }
+handler = "worker://queue"
+schedule = "not a cron"
+timezone = "America/Los_Angeles"
+"#,
+            None,
+        );
+        let mut vm = test_vm();
+        let error = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+            .await
+            .unwrap_err();
+        assert!(error.contains("invalid cron schedule"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_manifest_triggers_rejects_invalid_dedupe_expression() {
+        let tmp = tempfile::tempdir().unwrap();
+        let harn_file = write_trigger_project(
+            tmp.path(),
+            r#"
+[[triggers]]
+id = "bad-dedupe"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "worker://queue"
+dedupe_key = "["
+"#,
+            None,
+        );
+        let mut vm = test_vm();
+        let error = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+            .await
+            .unwrap_err();
+        assert!(error.contains("dedupe_key"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_manifest_triggers_rejects_secret_namespace_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let harn_file = write_trigger_project(
+            tmp.path(),
+            r#"
+[[triggers]]
+id = "bad-secret"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "worker://queue"
+secrets = { signing_secret = "slack/webhook-secret" }
+"#,
+            None,
+        );
+        let mut vm = test_vm();
+        let error = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+            .await
+            .unwrap_err();
+        assert!(error.contains("uses namespace 'slack'"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_manifest_triggers_rejects_invalid_when_signature() {
+        let tmp = tempfile::tempdir().unwrap();
+        let harn_file = write_trigger_project(
+            tmp.path(),
+            r#"
+[package]
+name = "workspace"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "bad-when"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+when = "handlers::should_handle"
+handler = "worker://queue"
+"#,
+            Some(
+                r#"
+import "std/triggers"
+
+pub fn should_handle(event: TriggerEvent) -> string {
+  return event.kind
+}
+"#,
+            ),
+        );
+        let mut vm = test_vm();
+        let error = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+            .await
+            .unwrap_err();
+        assert!(error.contains("must have signature fn(TriggerEvent) -> bool"));
     }
 }

--- a/crates/harn-cli/src/test_runner.rs
+++ b/crates/harn-cli/src/test_runner.rs
@@ -152,6 +152,9 @@ pub async fn run_test_file(
                 crate::skill_loader::install_skills_global(&mut vm, &loaded);
                 let extensions = crate::package::load_runtime_extensions(path);
                 crate::package::install_runtime_extensions(&extensions);
+                crate::package::collect_manifest_triggers(&mut vm, &extensions)
+                    .await
+                    .map_err(|error| format!("failed to validate manifest triggers: {error}"))?;
                 crate::package::install_manifest_hooks(&mut vm, &extensions)
                     .await
                     .map_err(|error| format!("failed to install manifest hooks: {error}"))?;

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -65,9 +65,10 @@ pub use stdlib::{
 };
 pub use store::register_store_builtins;
 pub use triggers::{
-    redact_headers, register_provider_schema, reset_provider_catalog, HeaderRedactionPolicy,
-    ProviderCatalog, ProviderCatalogError, ProviderId, ProviderPayload, ProviderSchema,
-    SignatureStatus, TenantId, TraceId, TriggerEvent, TriggerEventId,
+    redact_headers, register_provider_schema, registered_provider_schema_names,
+    reset_provider_catalog, HeaderRedactionPolicy, ProviderCatalog, ProviderCatalogError,
+    ProviderId, ProviderPayload, ProviderSchema, SignatureStatus, TenantId, TraceId, TriggerEvent,
+    TriggerEventId,
 };
 pub use value::*;
 pub use vm::*;

--- a/crates/harn-vm/src/triggers/event.rs
+++ b/crates/harn-vm/src/triggers/event.rs
@@ -444,6 +444,13 @@ pub fn reset_provider_catalog() {
         .expect("provider catalog poisoned") = ProviderCatalog::with_defaults();
 }
 
+pub fn registered_provider_schema_names() -> BTreeMap<String, String> {
+    provider_catalog()
+        .read()
+        .expect("provider catalog poisoned")
+        .schema_names()
+}
+
 fn provider_catalog() -> &'static RwLock<ProviderCatalog> {
     static PROVIDER_CATALOG: OnceLock<RwLock<ProviderCatalog>> = OnceLock::new();
     PROVIDER_CATALOG.get_or_init(|| RwLock::new(ProviderCatalog::with_defaults()))

--- a/crates/harn-vm/src/triggers/mod.rs
+++ b/crates/harn-vm/src/triggers/mod.rs
@@ -1,9 +1,10 @@
 pub mod event;
 
 pub use event::{
-    redact_headers, register_provider_schema, reset_provider_catalog, A2aPushPayload,
-    CronEventPayload, ExtensionProviderPayload, GenericWebhookPayload, GitHubEventPayload,
-    HeaderRedactionPolicy, LinearEventPayload, NotionEventPayload, ProviderCatalog,
-    ProviderCatalogError, ProviderId, ProviderPayload, ProviderSchema, SignatureStatus,
-    SlackEventPayload, TenantId, TraceId, TriggerEvent, TriggerEventId,
+    redact_headers, register_provider_schema, registered_provider_schema_names,
+    reset_provider_catalog, A2aPushPayload, CronEventPayload, ExtensionProviderPayload,
+    GenericWebhookPayload, GitHubEventPayload, HeaderRedactionPolicy, LinearEventPayload,
+    NotionEventPayload, ProviderCatalog, ProviderCatalogError, ProviderId, ProviderPayload,
+    ProviderSchema, SignatureStatus, SlackEventPayload, TenantId, TraceId, TriggerEvent,
+    TriggerEventId,
 };

--- a/crates/harn-vm/src/vm/mod.rs
+++ b/crates/harn-vm/src/vm/mod.rs
@@ -21,6 +21,7 @@ pub use async_builtin::{
     take_async_builtin_child_vm, AsyncBuiltinChildVmGuard,
 };
 pub use debug::{DebugAction, DebugState};
+pub use modules::resolve_module_import_path;
 pub use state::Vm;
 
 pub(crate) use state::{CallFrame, ExceptionHandler, IterState, ScopeSpan};

--- a/crates/harn-vm/src/vm/modules.rs
+++ b/crates/harn-vm/src/vm/modules.rs
@@ -81,7 +81,7 @@ fn finalize_package_target(path: &Path) -> Option<PathBuf> {
     None
 }
 
-fn resolve_import_target(base: &Path, path: &str) -> PathBuf {
+pub fn resolve_module_import_path(base: &Path, path: &str) -> PathBuf {
     let mut file_path = base.join(path);
 
     if !file_path.exists() && file_path.extension().is_none() {
@@ -175,7 +175,7 @@ impl Vm {
                 .source_dir
                 .clone()
                 .unwrap_or_else(|| PathBuf::from("."));
-            let file_path = resolve_import_target(&base, path);
+            let file_path = resolve_module_import_path(&base, path);
 
             let canonical = file_path
                 .canonicalize()
@@ -444,7 +444,7 @@ impl Vm {
             .source_dir
             .clone()
             .unwrap_or_else(|| PathBuf::from("."));
-        let file_path = resolve_import_target(&base, import_path);
+        let file_path = resolve_module_import_path(&base, import_path);
         self.load_module_exports(&file_path).await
     }
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -24,6 +24,7 @@
 - [Agent state](./agent-state.md)
 - [Transcript architecture](./transcript-architecture.md)
 - [Workflow runtime](./workflow-runtime.md)
+- [Trigger manifests](./triggers/manifest.md)
 - [Trigger event schema](./triggers/event-schema.md)
 - [Cookbook](./cookbook.md)
 - [Tutorial: code review agent](./tutorial-code-review-agent.md)

--- a/docs/src/triggers/manifest.md
+++ b/docs/src/triggers/manifest.md
@@ -1,0 +1,87 @@
+# Trigger manifests
+
+`[[triggers]]` extends `harn.toml` with declarative trigger registrations in the
+same manifest-overlay family as `[exports]`, `[llm]`, and `[[hooks]]`.
+
+Each entry declares:
+
+- a stable trigger `id`
+- a trigger `kind` such as `webhook`, `cron`, or `a2a-push`
+- a `provider` from the registered trigger provider catalog
+- a delivery `handler`
+- optional dedupe, retry, budget, secret, and predicate settings
+
+## Shape
+
+```toml
+[[triggers]]
+id = "github-new-issue"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+when = "handlers::should_handle"
+handler = "handlers::on_new_issue"
+dedupe_key = "event.dedupe_key"
+retry = { max = 7, backoff = "svix" }
+priority = "normal"
+budget = { daily_cost_usd = 5.00, max_concurrent = 10 }
+secrets = { signing_secret = "github/webhook-secret" }
+filter = "event.kind"
+```
+
+## Handler URI schemes
+
+Harn currently accepts three handler forms:
+
+- local function:
+  `handler = "on_event"` or `handler = "handlers::on_event"`
+- A2A dispatch:
+  `handler = "a2a://reviewer.prod/triage"`
+- worker queue dispatch:
+  `handler = "worker://triage-queue"`
+
+Unsupported URI schemes fail fast at load time.
+
+Local handlers and predicates resolve through the same module-export plumbing as
+the manifest hook loader:
+
+- bare names resolve against `lib.harn` next to the manifest
+- `module::function` resolves either through the current manifest's `[exports]`
+  table or through package imports under `.harn/packages`
+
+## Validation
+
+The manifest loader rejects invalid trigger declarations before execution:
+
+- trigger ids must be unique across the loaded root manifest plus installed package manifests
+- `provider` must exist in the registered trigger provider catalog
+- `handler` must be a supported URI, and local handlers must resolve to exported functions
+- `when` must resolve to a function with signature `fn(TriggerEvent) -> bool`
+- `dedupe_key` and `filter` must parse as JMESPath expressions
+- `retry.max` must be `<= 100`
+- `budget.daily_cost_usd` must be `>= 0`
+- cron triggers must declare a parseable `schedule`
+- cron `timezone` must be a valid IANA timezone name
+- secret references must use `<namespace>/<name>` syntax and the namespace must
+  match the trigger provider
+
+Errors include the manifest path plus the `[[triggers]]` table index so the bad
+entry is easy to locate.
+
+## Doctor output
+
+`harn doctor` now lists loaded triggers with:
+
+- trigger id
+- trigger kind
+- provider
+- handler kind (`local`, `a2a`, or `worker`)
+- budget summary
+
+## Examples
+
+See the example manifests under [`examples/triggers`](../../../examples/triggers):
+
+- [`cron-daily-digest`](../../../examples/triggers/cron-daily-digest/harn.toml)
+- [`github-new-issue`](../../../examples/triggers/github-new-issue/harn.toml)
+- [`a2a-reviewer-fanout`](../../../examples/triggers/a2a-reviewer-fanout/harn.toml)

--- a/examples/triggers/README.md
+++ b/examples/triggers/README.md
@@ -1,0 +1,7 @@
+# Trigger manifest examples
+
+These examples show the currently validated `[[triggers]]` shapes:
+
+- `cron-daily-digest/`: cron schedule + local handler
+- `github-new-issue/`: webhook trigger + local predicate + local handler
+- `a2a-reviewer-fanout/`: a2a-push trigger + remote A2A handler

--- a/examples/triggers/a2a-reviewer-fanout/harn.toml
+++ b/examples/triggers/a2a-reviewer-fanout/harn.toml
@@ -1,0 +1,15 @@
+[package]
+name = "a2a-reviewer-fanout"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "incoming-review-task"
+kind = "a2a-push"
+provider = "a2a-push"
+match = { events = ["a2a.task.received"] }
+when = "handlers::should_forward"
+handler = "a2a://reviewer.prod/triage"
+dedupe_key = "event.dedupe_key"
+budget = { max_concurrent = 8 }

--- a/examples/triggers/a2a-reviewer-fanout/lib.harn
+++ b/examples/triggers/a2a-reviewer-fanout/lib.harn
@@ -1,0 +1,5 @@
+import "std/triggers"
+
+pub fn should_forward(event: TriggerEvent) -> bool {
+  return event.provider == "a2a-push"
+}

--- a/examples/triggers/cron-daily-digest/harn.toml
+++ b/examples/triggers/cron-daily-digest/harn.toml
@@ -1,0 +1,12 @@
+[package]
+name = "cron-daily-digest"
+
+[[triggers]]
+id = "daily-digest"
+kind = "cron"
+provider = "cron"
+match = { events = ["cron.tick"] }
+handler = "send_daily_digest"
+schedule = "0 9 * * 1-5"
+timezone = "America/Los_Angeles"
+budget = { daily_cost_usd = 1.50, max_concurrent = 1 }

--- a/examples/triggers/cron-daily-digest/lib.harn
+++ b/examples/triggers/cron-daily-digest/lib.harn
@@ -1,0 +1,5 @@
+import "std/triggers"
+
+pub fn send_daily_digest(event: TriggerEvent) {
+  log("running digest for ${event.kind}")
+}

--- a/examples/triggers/github-new-issue/harn.toml
+++ b/examples/triggers/github-new-issue/harn.toml
@@ -1,0 +1,18 @@
+[package]
+name = "github-new-issue"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "github-new-issue"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+when = "handlers::should_handle"
+handler = "handlers::on_new_issue"
+dedupe_key = "event.dedupe_key"
+retry = { max = 7, backoff = "svix" }
+budget = { daily_cost_usd = 5.00, max_concurrent = 4 }
+secrets = { signing_secret = "github/webhook-secret" }
+filter = "event.kind"

--- a/examples/triggers/github-new-issue/lib.harn
+++ b/examples/triggers/github-new-issue/lib.harn
@@ -1,0 +1,9 @@
+import "std/triggers"
+
+pub fn should_handle(event: TriggerEvent) -> bool {
+  return event.provider == "github"
+}
+
+pub fn on_new_issue(event: TriggerEvent) {
+  log("triaging ${event.kind}")
+}


### PR DESCRIPTION
## Summary

Implements #156 by adding a `[[triggers]]` manifest overlay to the existing runtime-extension plumbing.

This change:
- adds typed manifest parsing for trigger entries, kinds, retry/priority/budget config, and trigger-specific fields
- validates trigger ids, providers, handler URI schemes, local handler exports, `when` predicate signatures, JMESPath expressions, cron schedules/timezones, and provider-scoped secret ids
- surfaces loaded triggers in `harn doctor` with id, kind, provider, handler kind, and budget
- ships trigger manifest docs and example manifests for cron, webhook, and a2a-push flows
- threads trigger validation through the CLI execution paths that already install manifest hooks

## Why

Issue #156 called for the trigger manifest overlay to reuse the manifest ABI and hook-resolution plumbing from #138 and #141 rather than inventing a parallel loader. This PR keeps the implementation narrow around that existing machinery while making the loader fail fast on invalid trigger declarations.

## Developer impact

Projects can now declare `[[triggers]]` in `harn.toml` and get load-time validation before execution. `harn doctor` also exposes trigger registrations so operators can audit what a manifest is loading.

## Validation

- `cargo fmt --all`
- `env CARGO_TARGET_DIR=/tmp/harn-issue156-target cargo test -p harn-cli`
- `env CARGO_TARGET_DIR=/tmp/harn-issue156-target cargo run -p harn-cli --bin harn -- doctor --no-network` in:
  - `examples/triggers/github-new-issue`
  - `examples/triggers/cron-daily-digest`
  - `examples/triggers/a2a-reviewer-fanout`
- repo pre-commit and pre-push hooks passed, including clippy, markdown lint, portal lint, and the fast release-quality test gate

Closes #156.