### PR TITLE
Add trigger + predicate action-graph node kinds (partial #163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ granular archaeology.
 ### Added
 
 - **Action-graph observability extended with `trigger` and `predicate`
-  node kinds (#PR-NUM, partial #163).** Persisted run records now
+  node kinds (#202, partial #163).** Persisted run records now
   synthesize a `trigger` node from `trigger_event` metadata, render
   workflow `condition` stages as `predicate` nodes, propagate
   `trace_id` across the derived action graph, and stream updates onto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ granular archaeology.
 
 ### Added
 
+- **Action-graph observability extended with `trigger` and `predicate`
+  node kinds (#PR-NUM, partial #163).** Persisted run records now
+  synthesize a `trigger` node from `trigger_event` metadata, render
+  workflow `condition` stages as `predicate` nodes, propagate
+  `trace_id` across the derived action graph, and stream updates onto
+  the shared `observability.action_graph` event-log topic.
+  Dispatch/A2A/worker/DLQ nodes deferred to the T-06 dispatcher
+  milestone.
 - **Secret-provider primitives for reactive runtime work (#194,
   closes #154).** `harn_vm::secrets` now provides `SecretProvider`,
   `ChainSecretProvider`, zeroizing `SecretBytes`, and concrete env +

--- a/conformance/tests/observability/action_graph_trigger_predicate_nodes.expected
+++ b/conformance/tests/observability/action_graph_trigger_predicate_nodes.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/conformance/tests/observability/action_graph_trigger_predicate_nodes.harn
+++ b/conformance/tests/observability/action_graph_trigger_predicate_nodes.harn
@@ -1,0 +1,73 @@
+pipeline main() {
+  let flow = workflow_graph(
+    {
+    name: "trigger_predicate_observability",
+    entry: "gate",
+    nodes: {
+    gate: {kind: "condition", context_policy: {include_kinds: ["plan"]}, metadata: {contains_text: "go"}},
+    act: {kind: "stage", mode: "llm", model_policy: {provider: "mock"}},
+    skip: {kind: "stage", mode: "llm", model_policy: {provider: "mock"}},
+  },
+    edges: [
+    {from: "gate", to: "act", branch: "true"},
+    {from: "gate", to: "skip", branch: "false"},
+  ],
+  },
+  )
+  let trigger = {
+    id: "trigger_evt_conformance",
+    provider: "cron",
+    kind: "tick",
+    received_at: "2026-04-19T16:00:00Z",
+    occurred_at: nil,
+    dedupe_key: "cron:conformance",
+    trace_id: "trace_conformance",
+    tenant_id: nil,
+    headers: {},
+    provider_payload: {
+      provider: "cron",
+      cron_id: "conformance",
+      schedule: "0 * * * *",
+      tick_at: "2026-04-19T16:00:00Z",
+      raw: {},
+    },
+    signature_status: {state: "unsigned"},
+  }
+  let result = workflow_execute(
+    "Handle a scheduled review",
+    flow,
+    [artifact({kind: "plan", text: "go inspect the repo"})],
+    {
+      max_steps: 4,
+      persist_path: "/tmp/harn-observability-trigger-predicate.json",
+      trigger_event: trigger,
+    },
+  )
+  let loaded = run_record_load(result?.path)
+  let nodes = loaded?.observability?.action_graph_nodes ?? []
+  let edges = loaded?.observability?.action_graph_edges ?? []
+  var trigger_trace = nil
+  var predicate_trace = nil
+  var saw_trigger_dispatch = false
+  var saw_predicate_gate = false
+  for node in nodes {
+    if node?.kind == "trigger" {
+      trigger_trace = node?.trace_id
+    }
+    if node?.kind == "predicate" {
+      predicate_trace = node?.trace_id
+    }
+  }
+  for edge in edges {
+    if edge?.kind == "trigger_dispatch" {
+      saw_trigger_dispatch = true
+    }
+    if edge?.kind == "predicate_gate" {
+      saw_predicate_gate = true
+    }
+  }
+  println(trigger_trace == "trace_conformance")
+  println(predicate_trace == "trace_conformance")
+  println(saw_trigger_dispatch)
+  println(saw_predicate_gate)
+}

--- a/conformance/tests/observability/action_graph_trigger_predicate_nodes.harn
+++ b/conformance/tests/observability/action_graph_trigger_predicate_nodes.harn
@@ -8,10 +8,7 @@ pipeline main() {
     act: {kind: "stage", mode: "llm", model_policy: {provider: "mock"}},
     skip: {kind: "stage", mode: "llm", model_policy: {provider: "mock"}},
   },
-    edges: [
-    {from: "gate", to: "act", branch: "true"},
-    {from: "gate", to: "skip", branch: "false"},
-  ],
+    edges: [{from: "gate", to: "act", branch: "true"}, {from: "gate", to: "skip", branch: "false"}],
   },
   )
   let trigger = {
@@ -25,12 +22,12 @@ pipeline main() {
     tenant_id: nil,
     headers: {},
     provider_payload: {
-      provider: "cron",
-      cron_id: "conformance",
-      schedule: "0 * * * *",
-      tick_at: "2026-04-19T16:00:00Z",
-      raw: {},
-    },
+    provider: "cron",
+    cron_id: "conformance",
+    schedule: "0 * * * *",
+    tick_at: "2026-04-19T16:00:00Z",
+    raw: {},
+  },
     signature_status: {state: "unsigned"},
   }
   let result = workflow_execute(
@@ -38,10 +35,10 @@ pipeline main() {
     flow,
     [artifact({kind: "plan", text: "go inspect the repo"})],
     {
-      max_steps: 4,
-      persist_path: "/tmp/harn-observability-trigger-predicate.json",
-      trigger_event: trigger,
-    },
+    max_steps: 4,
+    persist_path: "/tmp/harn-observability-trigger-predicate.json",
+    trigger_event: trigger,
+  },
   )
   let loaded = run_record_load(result?.path)
   let nodes = loaded?.observability?.action_graph_nodes ?? []

--- a/conformance/tests/stdlib/compact_transcript.harn
+++ b/conformance/tests/stdlib/compact_transcript.harn
@@ -77,7 +77,7 @@ pipeline test(task) {
   ],
   },
   )
-  println(run.observability?.schema_version == 3)
+  println(run.observability?.schema_version == 4)
   println(len(run.observability?.compaction_events) == 3)
   var saw_truncate = false
   var saw_mask = false

--- a/crates/harn-cli/portal/src/App.test.tsx
+++ b/crates/harn-cli/portal/src/App.test.tsx
@@ -103,7 +103,7 @@ const detailPayload = {
   story: [],
   child_runs: [],
   observability: {
-    schema_version: 3,
+    schema_version: 4,
     planner_rounds: [],
     research_fact_count: 0,
     action_graph_nodes: [],

--- a/crates/harn-vm/src/orchestration/records.rs
+++ b/crates/harn-vm/src/orchestration/records.rs
@@ -9,7 +9,9 @@ use super::{
     default_run_dir, new_id, now_rfc3339, parse_json_payload, parse_json_value, ArtifactRecord,
     CapabilityPolicy,
 };
+use crate::event_log::{active_event_log, EventLog, LogEvent as EventLogRecord, Topic};
 use crate::llm::vm_value_to_json;
+use crate::triggers::{SignatureStatus, TriggerEvent};
 use crate::value::{VmError, VmValue};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
@@ -202,6 +204,7 @@ pub struct RunActionGraphNodeRecord {
     pub kind: String,
     pub status: String,
     pub outcome: String,
+    pub trace_id: Option<String>,
     pub stage_id: Option<String>,
     pub node_id: Option<String>,
     pub worker_id: Option<String>,
@@ -465,6 +468,85 @@ fn compact_json_value(value: &serde_json::Value) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| value.to_string())
 }
 
+fn signature_status_label(status: &SignatureStatus) -> &'static str {
+    match status {
+        SignatureStatus::Verified => "verified",
+        SignatureStatus::Unsigned => "unsigned",
+        SignatureStatus::Failed { .. } => "failed",
+    }
+}
+
+fn trigger_event_from_run(run: &RunRecord) -> Option<TriggerEvent> {
+    run.metadata
+        .get("trigger_event")
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
+}
+
+fn run_trace_id(run: &RunRecord, trigger_event: Option<&TriggerEvent>) -> Option<String> {
+    trigger_event
+        .map(|event| event.trace_id.0.clone())
+        .or_else(|| {
+            run.metadata
+                .get("trace_id")
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        })
+}
+
+fn action_graph_kind_for_stage(stage: &RunStageRecord) -> &'static str {
+    if stage.kind == "condition" {
+        "predicate"
+    } else {
+        "stage"
+    }
+}
+
+fn append_action_graph_node(
+    nodes: &mut Vec<RunActionGraphNodeRecord>,
+    record: RunActionGraphNodeRecord,
+) {
+    nodes.push(record);
+}
+
+fn publish_action_graph_event(
+    run: &RunRecord,
+    observability: &RunObservabilityRecord,
+    path: &Path,
+) {
+    let Some(log) = active_event_log() else {
+        return;
+    };
+    let Ok(topic) = Topic::new("observability.action_graph") else {
+        return;
+    };
+    let trigger_event = trigger_event_from_run(run);
+    let mut headers = BTreeMap::new();
+    headers.insert("run_id".to_string(), run.id.clone());
+    headers.insert("workflow_id".to_string(), run.workflow_id.clone());
+    if let Some(trace_id) = run_trace_id(run, trigger_event.as_ref()) {
+        headers.insert("trace_id".to_string(), trace_id);
+    }
+    let record = EventLogRecord::new(
+        "action_graph_update",
+        serde_json::json!({
+            "run_id": run.id,
+            "workflow_id": run.workflow_id,
+            "persisted_path": path.to_string_lossy(),
+            "status": run.status,
+            "observability": observability,
+        }),
+    )
+    .with_headers(headers);
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        handle.spawn(async move {
+            let _ = log.append(&topic, record).await;
+        });
+    } else {
+        let _ = futures::executor::block_on(log.append(&topic, record));
+    }
+}
+
 fn llm_transcript_sidecar_path(run_path: &Path) -> Option<PathBuf> {
     let stem = run_path.file_stem()?.to_str()?;
     let parent = run_path.parent().unwrap_or_else(|| Path::new("."));
@@ -679,26 +761,64 @@ pub fn derive_run_observability(
     let mut research_fact_count = 0usize;
 
     let root_node_id = format!("run:{}", run.id);
-    action_graph_nodes.push(RunActionGraphNodeRecord {
-        id: root_node_id.clone(),
-        label: run
-            .workflow_name
-            .clone()
-            .unwrap_or_else(|| run.workflow_id.clone()),
-        kind: "run".to_string(),
-        status: run.status.clone(),
-        outcome: run.status.clone(),
-        stage_id: None,
-        node_id: None,
-        worker_id: None,
-        run_id: Some(run.id.clone()),
-        run_path: run.persisted_path.clone(),
-    });
+    let trigger_event = trigger_event_from_run(run);
+    let propagated_trace_id = run_trace_id(run, trigger_event.as_ref());
+    append_action_graph_node(
+        &mut action_graph_nodes,
+        RunActionGraphNodeRecord {
+            id: root_node_id.clone(),
+            label: run
+                .workflow_name
+                .clone()
+                .unwrap_or_else(|| run.workflow_id.clone()),
+            kind: "run".to_string(),
+            status: run.status.clone(),
+            outcome: run.status.clone(),
+            trace_id: propagated_trace_id.clone(),
+            stage_id: None,
+            node_id: None,
+            worker_id: None,
+            run_id: Some(run.id.clone()),
+            run_path: run.persisted_path.clone(),
+        },
+    );
+    let mut entry_node_id = root_node_id.clone();
+    if let Some(trigger_event) = trigger_event.as_ref() {
+        let trigger_node_id = format!("trigger:{}", trigger_event.id.0);
+        append_action_graph_node(
+            &mut action_graph_nodes,
+            RunActionGraphNodeRecord {
+                id: trigger_node_id.clone(),
+                label: format!("{}:{}", trigger_event.provider.as_str(), trigger_event.kind),
+                kind: "trigger".to_string(),
+                status: "received".to_string(),
+                outcome: signature_status_label(&trigger_event.signature_status).to_string(),
+                trace_id: Some(trigger_event.trace_id.0.clone()),
+                stage_id: None,
+                node_id: None,
+                worker_id: None,
+                run_id: Some(run.id.clone()),
+                run_path: run.persisted_path.clone(),
+            },
+        );
+        action_graph_edges.push(RunActionGraphEdgeRecord {
+            from_id: root_node_id.clone(),
+            to_id: trigger_node_id.clone(),
+            kind: "entry".to_string(),
+            label: Some(trigger_event.id.0.clone()),
+        });
+        entry_node_id = trigger_node_id;
+    }
 
     let stage_node_ids = run
         .stages
         .iter()
         .map(|stage| (stage.id.clone(), format!("stage:{}", stage.id)))
+        .collect::<BTreeMap<_, _>>();
+    let stage_by_id = run
+        .stages
+        .iter()
+        .map(|stage| (stage.id.as_str(), stage))
         .collect::<BTreeMap<_, _>>();
     let stage_by_node_id = run
         .stages
@@ -717,27 +837,35 @@ pub fn derive_run_observability(
             .get(&stage.id)
             .cloned()
             .unwrap_or_else(|| format!("stage:{}", stage.id));
-        action_graph_nodes.push(RunActionGraphNodeRecord {
-            id: graph_node_id.clone(),
-            label: stage.node_id.clone(),
-            kind: "stage".to_string(),
-            status: stage.status.clone(),
-            outcome: stage.outcome.clone(),
-            stage_id: Some(stage.id.clone()),
-            node_id: Some(stage.node_id.clone()),
-            worker_id: stage
-                .metadata
-                .get("worker_id")
-                .and_then(|value| value.as_str())
-                .map(str::to_string),
-            run_id: None,
-            run_path: None,
-        });
+        append_action_graph_node(
+            &mut action_graph_nodes,
+            RunActionGraphNodeRecord {
+                id: graph_node_id.clone(),
+                label: stage.node_id.clone(),
+                kind: action_graph_kind_for_stage(stage).to_string(),
+                status: stage.status.clone(),
+                outcome: stage.outcome.clone(),
+                trace_id: propagated_trace_id.clone(),
+                stage_id: Some(stage.id.clone()),
+                node_id: Some(stage.node_id.clone()),
+                worker_id: stage
+                    .metadata
+                    .get("worker_id")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string),
+                run_id: None,
+                run_path: None,
+            },
+        );
         if !incoming_nodes.contains(&stage.node_id) {
             action_graph_edges.push(RunActionGraphEdgeRecord {
-                from_id: root_node_id.clone(),
+                from_id: entry_node_id.clone(),
                 to_id: graph_node_id.clone(),
-                kind: "entry".to_string(),
+                kind: if trigger_event.is_some() {
+                    "trigger_dispatch".to_string()
+                } else {
+                    "entry".to_string()
+                },
                 label: None,
             });
         }
@@ -860,6 +988,10 @@ pub fn derive_run_observability(
         let Some(to_id) = stage_by_node_id.get(&transition.to_node_id).cloned() else {
             continue;
         };
+        let from_stage = transition
+            .from_stage_id
+            .as_deref()
+            .and_then(|stage_id| stage_by_id.get(stage_id).copied());
         let from_id = transition
             .from_stage_id
             .as_ref()
@@ -876,7 +1008,11 @@ pub fn derive_run_observability(
         action_graph_edges.push(RunActionGraphEdgeRecord {
             from_id,
             to_id,
-            kind: "transition".to_string(),
+            kind: if from_stage.is_some_and(|stage| stage.kind == "condition") {
+                "predicate_gate".to_string()
+            } else {
+                "transition".to_string()
+            },
             label: transition.branch.clone(),
         });
     }
@@ -886,18 +1022,22 @@ pub fn derive_run_observability(
         .iter()
         .map(|child| {
             let worker_node_id = format!("worker:{}", child.worker_id);
-            action_graph_nodes.push(RunActionGraphNodeRecord {
-                id: worker_node_id.clone(),
-                label: child.worker_name.clone(),
-                kind: "worker".to_string(),
-                status: child.status.clone(),
-                outcome: child.status.clone(),
-                stage_id: child.parent_stage_id.clone(),
-                node_id: None,
-                worker_id: Some(child.worker_id.clone()),
-                run_id: child.run_id.clone(),
-                run_path: child.run_path.clone(),
-            });
+            append_action_graph_node(
+                &mut action_graph_nodes,
+                RunActionGraphNodeRecord {
+                    id: worker_node_id.clone(),
+                    label: child.worker_name.clone(),
+                    kind: "worker".to_string(),
+                    status: child.status.clone(),
+                    outcome: child.status.clone(),
+                    trace_id: propagated_trace_id.clone(),
+                    stage_id: child.parent_stage_id.clone(),
+                    node_id: None,
+                    worker_id: Some(child.worker_id.clone()),
+                    run_id: child.run_id.clone(),
+                    run_path: child.run_path.clone(),
+                },
+            );
             if let Some(parent_stage_id) = child.parent_stage_id.as_ref() {
                 if let Some(stage_node_id) = stage_node_ids.get(parent_stage_id) {
                     action_graph_edges.push(RunActionGraphEdgeRecord {
@@ -958,7 +1098,7 @@ pub fn derive_run_observability(
     }
 
     RunObservabilityRecord {
-        schema_version: 3,
+        schema_version: 4,
         planner_rounds,
         research_fact_count,
         action_graph_nodes,
@@ -1226,6 +1366,9 @@ pub fn save_run_record(run: &RunRecord, path: Option<&str>) -> Result<String, Vm
         let _ = std::fs::write(&path, &json);
         VmError::Runtime(format!("failed to finalize run record: {e}"))
     })?;
+    if let Some(observability) = materialized.observability.as_ref() {
+        publish_action_graph_event(&materialized, observability, &path);
+    }
     Ok(path.to_string_lossy().into_owned())
 }
 

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -4,6 +4,8 @@ use super::*;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use crate::event_log::EventLog;
+
 #[test]
 fn capability_intersection_rejects_privilege_expansion() {
     let ceiling = CapabilityPolicy {
@@ -408,7 +410,7 @@ fn save_and_load_run_record_materializes_observability_summary() {
     save_run_record(&run, Some(run_path.to_str().unwrap())).unwrap();
     let loaded = load_run_record(&run_path).unwrap();
     let observability = loaded.observability.expect("observability summary");
-    assert_eq!(observability.schema_version, 3);
+    assert_eq!(observability.schema_version, 4);
     assert_eq!(observability.planner_rounds.len(), 1);
     assert_eq!(observability.research_fact_count, 1);
     assert_eq!(observability.worker_lineage.len(), 1);
@@ -460,6 +462,164 @@ fn save_and_load_run_record_materializes_daemon_events_from_sidecar() {
         observability.daemon_events[1].payload_summary.as_deref(),
         Some("new review requested")
     );
+}
+
+#[test]
+fn derive_run_observability_adds_trigger_and_predicate_nodes_with_shared_trace_id() {
+    let trigger_event = crate::triggers::TriggerEvent {
+        id: crate::triggers::TriggerEventId("trigger_evt_1".to_string()),
+        provider: crate::triggers::ProviderId("cron".to_string()),
+        kind: "tick".to_string(),
+        received_at: time::OffsetDateTime::from_unix_timestamp(1_710_000_000).unwrap(),
+        occurred_at: None,
+        dedupe_key: "cron:daily".to_string(),
+        trace_id: crate::triggers::TraceId("trace_123".to_string()),
+        tenant_id: None,
+        headers: BTreeMap::new(),
+        provider_payload: crate::triggers::ProviderPayload::Known(
+            crate::triggers::event::KnownProviderPayload::Cron(crate::triggers::CronEventPayload {
+                cron_id: Some("daily-review".to_string()),
+                schedule: Some("0 9 * * 1-5".to_string()),
+                tick_at: time::OffsetDateTime::from_unix_timestamp(1_710_000_000).unwrap(),
+                raw: serde_json::json!({"scheduled": true}),
+            }),
+        ),
+        signature_status: crate::triggers::SignatureStatus::Unsigned,
+    };
+    let run = RunRecord {
+        id: "run_trigger_obs".to_string(),
+        workflow_id: "wf".to_string(),
+        workflow_name: Some("triggered workflow".to_string()),
+        status: "completed".to_string(),
+        stages: vec![
+            RunStageRecord {
+                id: "stage_gate".to_string(),
+                node_id: "gate".to_string(),
+                kind: "condition".to_string(),
+                status: "completed".to_string(),
+                outcome: "condition_true".to_string(),
+                branch: Some("true".to_string()),
+                ..Default::default()
+            },
+            RunStageRecord {
+                id: "stage_act".to_string(),
+                node_id: "act".to_string(),
+                kind: "stage".to_string(),
+                status: "completed".to_string(),
+                outcome: "success".to_string(),
+                ..Default::default()
+            },
+        ],
+        transitions: vec![RunTransitionRecord {
+            id: "transition_gate_act".to_string(),
+            from_stage_id: Some("stage_gate".to_string()),
+            from_node_id: Some("gate".to_string()),
+            to_node_id: "act".to_string(),
+            branch: Some("true".to_string()),
+            timestamp: "transition".to_string(),
+            consumed_artifact_ids: Vec::new(),
+            produced_artifact_ids: Vec::new(),
+        }],
+        metadata: BTreeMap::from([(
+            "trigger_event".to_string(),
+            serde_json::to_value(&trigger_event).unwrap(),
+        )]),
+        ..Default::default()
+    };
+
+    let observability = derive_run_observability(&run, None);
+    let trigger_node = observability
+        .action_graph_nodes
+        .iter()
+        .find(|node| node.kind == "trigger")
+        .expect("trigger node");
+    let predicate_node = observability
+        .action_graph_nodes
+        .iter()
+        .find(|node| node.kind == "predicate")
+        .expect("predicate node");
+    assert_eq!(trigger_node.trace_id.as_deref(), Some("trace_123"));
+    assert_eq!(predicate_node.trace_id.as_deref(), Some("trace_123"));
+    assert!(observability
+        .action_graph_edges
+        .iter()
+        .any(|edge| edge.kind == "trigger_dispatch"));
+    assert!(observability
+        .action_graph_edges
+        .iter()
+        .any(|edge| edge.kind == "predicate_gate" && edge.label.as_deref() == Some("true")));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn save_run_record_publishes_action_graph_updates_to_event_log() {
+    crate::reset_thread_local_state();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let run_path = temp_dir.path().join("run.json");
+    crate::event_log::install_default_for_base_dir(temp_dir.path()).expect("install event log");
+
+    let mut run = RunRecord {
+        id: "run_event_log".to_string(),
+        workflow_id: "wf".to_string(),
+        workflow_name: Some("event-log workflow".to_string()),
+        status: "running".to_string(),
+        stages: vec![RunStageRecord {
+            id: "stage_gate".to_string(),
+            node_id: "gate".to_string(),
+            kind: "condition".to_string(),
+            status: "completed".to_string(),
+            outcome: "condition_true".to_string(),
+            branch: Some("true".to_string()),
+            ..Default::default()
+        }],
+        metadata: BTreeMap::from([(
+            "trigger_event".to_string(),
+            serde_json::json!({
+                "id": "trigger_evt_stream",
+                "provider": "cron",
+                "kind": "tick",
+                "received_at": "2026-04-19T16:00:00Z",
+                "occurred_at": null,
+                "dedupe_key": "cron:stream",
+                "trace_id": "trace_stream",
+                "tenant_id": null,
+                "headers": {},
+                "provider_payload": {
+                    "provider": "cron",
+                    "cron_id": "stream",
+                    "schedule": "0 * * * *",
+                    "tick_at": "2026-04-19T16:00:00Z",
+                    "raw": {}
+                },
+                "signature_status": {"state": "unsigned"}
+            }),
+        )]),
+        ..Default::default()
+    };
+
+    save_run_record(&run, Some(run_path.to_str().unwrap())).unwrap();
+    run.status = "completed".to_string();
+    save_run_record(&run, Some(run_path.to_str().unwrap())).unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+
+    let topic = crate::event_log::Topic::new("observability.action_graph").unwrap();
+    let log = crate::event_log::active_event_log().expect("active event log");
+    let events = log.read_range(&topic, None, usize::MAX).await.unwrap();
+    assert_eq!(events.len(), 2);
+    assert!(events
+        .iter()
+        .all(|(_, event)| event.kind == "action_graph_update"));
+    assert!(events.iter().all(|(_, event)| {
+        event.headers.get("trace_id").map(String::as_str) == Some("trace_stream")
+    }));
+    assert!(events.iter().any(|(_, event)| {
+        event.payload["observability"]["action_graph_nodes"]
+            .as_array()
+            .is_some_and(|nodes| {
+                nodes.iter().any(|node| {
+                    node.get("kind").and_then(|value| value.as_str()) == Some("trigger")
+                })
+            })
+    }));
 }
 
 #[test]

--- a/crates/harn-vm/src/stdlib/workflow/register.rs
+++ b/crates/harn-vm/src/stdlib/workflow/register.rs
@@ -29,6 +29,24 @@ use super::policy::{
 use super::stage::{execute_stage_attempts, replay_stage};
 use super::usage::{llm_usage_delta, llm_usage_snapshot};
 
+fn parse_trigger_event_option(
+    value: Option<&VmValue>,
+) -> Result<Option<crate::TriggerEvent>, VmError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if matches!(value, VmValue::Nil) {
+        return Ok(None);
+    }
+    serde_json::from_value(crate::llm::vm_value_to_json(value))
+        .map(Some)
+        .map_err(|error| {
+            VmError::Runtime(format!(
+                "workflow_execute: trigger_event parse error: {error}"
+            ))
+        })
+}
+
 /// Accept a skill registry dict on `workflow_execute(task, graph,
 /// artifacts, {skills: ...})`. Mirrors the agent-loop normalizer: a
 /// raw registry dict passes through, a list of skill entries is
@@ -250,6 +268,16 @@ pub(in crate::stdlib) async fn execute_workflow(
         run.metadata.insert(
             "workflow_metadata".to_string(),
             serde_json::to_value(&graph.metadata).unwrap_or_default(),
+        );
+    }
+    if let Some(trigger_event) = parse_trigger_event_option(options.get("trigger_event"))? {
+        run.metadata.insert(
+            "trigger_event".to_string(),
+            serde_json::to_value(&trigger_event).unwrap_or_default(),
+        );
+        run.metadata.insert(
+            "trace_id".to_string(),
+            serde_json::json!(trigger_event.trace_id.0),
         );
     }
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -26,6 +26,7 @@
 - [Workflow runtime](./workflow-runtime.md)
 - [Trigger manifests](./triggers/manifest.md)
 - [Trigger event schema](./triggers/event-schema.md)
+- [Trigger observability in the action graph](./observability/triggers-in-action-graph.md)
 - [Cookbook](./cookbook.md)
 - [Tutorial: code review agent](./tutorial-code-review-agent.md)
 - [Tutorial: MCP server](./tutorial-mcp-server.md)

--- a/docs/src/observability/triggers-in-action-graph.md
+++ b/docs/src/observability/triggers-in-action-graph.md
@@ -1,0 +1,66 @@
+# Trigger Observability In The Action Graph
+
+Harn now projects dispatcher-independent trigger activity into persisted run
+observability. This lands the first half of issue #163: `trigger` and
+`predicate` nodes, plus the matching `trigger_dispatch` and `predicate_gate`
+edges.
+
+## What lands in this change
+
+- A synthetic `trigger` node is added when a run carries a `trigger_event`
+  envelope in `run.metadata`.
+- Workflow `condition` stages render as `predicate` nodes in
+  `observability.action_graph_nodes`.
+- Entry edges from the trigger node into the workflow render as
+  `trigger_dispatch`.
+- Transitions leaving a predicate render as `predicate_gate`.
+- `trace_id` propagates from the `TriggerEvent` onto the synthetic trigger
+  node and every downstream action-graph node derived from that run.
+
+The runtime also streams the derived graph onto the shared event-log topic
+`observability.action_graph` whenever a run record is persisted. This reuses
+the generalized `EventLog` infrastructure instead of a parallel observability
+bus.
+
+## Current shape
+
+This scoped change is intentionally limited to the dispatcher-independent
+surface:
+
+- Landed here: `trigger` and `predicate` node kinds.
+- Deferred to T-06: `dispatch`, `a2a_hop`, `worker_enqueue`, and `dlq`.
+- Deferred to T-06: portal replay controls and dispatcher-coupled UI work.
+- Deferred to T-06: A2A `trace_id` header propagation.
+
+## Example
+
+When a workflow is started with a `trigger_event` option, the persisted run
+record will include observability nodes like:
+
+```json
+{
+  "kind": "trigger",
+  "label": "cron:tick",
+  "trace_id": "trace_123"
+}
+```
+
+and:
+
+```json
+{
+  "kind": "predicate",
+  "label": "gate",
+  "trace_id": "trace_123"
+}
+```
+
+with edges such as:
+
+```json
+{"kind": "trigger_dispatch", "from_id": "trigger:...", "to_id": "stage:..."}
+{"kind": "predicate_gate", "label": "true"}
+```
+
+The portal does not yet render specialized UI for these nodes in this PR; it
+will consume the shared event-log topic in the dispatcher follow-up.


### PR DESCRIPTION
## Summary

Implements the trigger + predicate node kinds from #163. Dispatch/a2a/worker_enqueue/dlq nodes deferred to T-06.

This PR lands the dispatcher-independent observability slice:

- add synthetic `trigger` action-graph nodes from persisted `trigger_event` metadata
- render workflow `condition` stages as `predicate` action-graph nodes
- add `trigger_dispatch` and `predicate_gate` edge kinds
- propagate `TriggerEvent.trace_id` through derived run observability nodes
- stream action-graph updates onto `observability.action_graph` via the shared `EventLog`
- add unit coverage, conformance coverage, and docs for the landed node kinds

## Deferred

- `dispatch`, `a2a_hop`, `worker_enqueue`, `dlq` node kinds
- portal replay button and specialized portal UI
- A2A `trace_id` header propagation

Portal follow-up work is tracked in #201.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `make test`
- `cargo run --bin harn -- test conformance`
