### PR TITLE
Add Connector trait + registry + HMAC verify helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,18 @@ granular archaeology.
   Dispatch/A2A/worker/DLQ nodes deferred to the T-06 dispatcher
   milestone.
 - **Connector trait + registry + shared HMAC-signature verification
-  (PR pending, closes #167).** Foundation for upcoming MVP connectors
-  (cron, webhooks, GitHub, Slack, Linear, Notion, A2A push).
+  (#203, closes #167).** New `harn_vm::connectors` module defines
+  the async `Connector` + `ConnectorClient` traits,
+  `ConnectorRegistry` with activation fan-out, a provider-scoped
+  token-bucket rate limiter, and a shared `verify_hmac_signed(...)`
+  helper covering GitHub-style, Stripe-style, and Standard Webhooks
+  HMAC conventions. The HMAC helper operates on raw request-body
+  bytes, uses constant-time comparison, enforces timestamp-window
+  limits, and routes signature-verify failures through the
+  `audit.signature_verify` EventLog topic. Ships with authoring
+  docs at `docs/src/connectors/authoring.md`. Foundation for
+  upcoming MVP connectors (cron, webhooks, GitHub, Slack, Linear,
+  Notion, A2A push).
 - **Secret-provider primitives for reactive runtime work (#194,
   closes #154).** `harn_vm::secrets` now provides `SecretProvider`,
   `ChainSecretProvider`, zeroizing `SecretBytes`, and concrete env +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ granular archaeology.
   the shared `observability.action_graph` event-log topic.
   Dispatch/A2A/worker/DLQ nodes deferred to the T-06 dispatcher
   milestone.
+- **Connector trait + registry + shared HMAC-signature verification
+  (PR pending, closes #167).** Foundation for upcoming MVP connectors
+  (cron, webhooks, GitHub, Slack, Linear, Notion, A2A push).
 - **Secret-provider primitives for reactive runtime work (#194,
   closes #154).** `harn_vm::secrets` now provides `SecretProvider`,
   `ChainSecretProvider`, zeroizing `SecretBytes`, and concrete env +

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,7 @@ dependencies = [
  "futures",
  "harn-lexer",
  "harn-parser",
+ "hex",
  "httpdate",
  "ignore",
  "keyring",
@@ -991,6 +992,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_yaml",
  "sha2",
+ "subtle",
  "tempfile",
  "time",
  "tokio",
@@ -1039,6 +1041,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -22,12 +22,14 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 reqwest-eventsource = "0.6"
 tokio-stream = "0.1"
 base64 = "0.22"
+hex = "0.4"
 sha2 = "0.11"
 md-5 = "0.11"
 toml = "1.1"
 serde_yaml = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_path_to_error = "0.1"
+subtle = "2.6"
 time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
 uuid = { version = "1", features = ["v4", "v7"] }
 tokio-util = { version = "0.7", features = ["io"] }

--- a/crates/harn-vm/src/connectors/hmac.rs
+++ b/crates/harn-vm/src/connectors/hmac.rs
@@ -1,0 +1,856 @@
+use std::collections::BTreeMap;
+
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+use time::{Duration, OffsetDateTime};
+
+use crate::event_log::{EventLog, LogEvent, Topic};
+use crate::triggers::ProviderId;
+
+use super::ConnectorError;
+
+pub const SIGNATURE_VERIFY_AUDIT_TOPIC: &str = "audit.signature_verify";
+pub const DEFAULT_GITHUB_SIGNATURE_HEADER: &str = "x-hub-signature-256";
+pub const DEFAULT_STRIPE_SIGNATURE_HEADER: &str = "stripe-signature";
+pub const DEFAULT_STANDARD_WEBHOOKS_ID_HEADER: &str = "webhook-id";
+pub const DEFAULT_STANDARD_WEBHOOKS_SIGNATURE_HEADER: &str = "webhook-signature";
+pub const DEFAULT_STANDARD_WEBHOOKS_TIMESTAMP_HEADER: &str = "webhook-timestamp";
+
+/// Supported HMAC signature header conventions for inbound webhook providers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HmacSignatureStyle<'a> {
+    GitHub {
+        signature_header: &'a str,
+        prefix: &'a str,
+    },
+    Stripe {
+        signature_header: &'a str,
+        version: &'a str,
+    },
+    StandardWebhooks {
+        id_header: &'a str,
+        signature_header: &'a str,
+        timestamp_header: &'a str,
+        version: &'a str,
+    },
+}
+
+impl<'a> HmacSignatureStyle<'a> {
+    pub fn github() -> Self {
+        Self::GitHub {
+            signature_header: DEFAULT_GITHUB_SIGNATURE_HEADER,
+            prefix: "sha256=",
+        }
+    }
+
+    pub fn stripe() -> Self {
+        Self::Stripe {
+            signature_header: DEFAULT_STRIPE_SIGNATURE_HEADER,
+            version: "v1",
+        }
+    }
+
+    pub fn standard_webhooks() -> Self {
+        Self::StandardWebhooks {
+            id_header: DEFAULT_STANDARD_WEBHOOKS_ID_HEADER,
+            signature_header: DEFAULT_STANDARD_WEBHOOKS_SIGNATURE_HEADER,
+            timestamp_header: DEFAULT_STANDARD_WEBHOOKS_TIMESTAMP_HEADER,
+            version: "v1",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::GitHub { .. } => "github",
+            Self::Stripe { .. } => "stripe",
+            Self::StandardWebhooks { .. } => "standard_webhooks",
+        }
+    }
+}
+
+/// Verify an HMAC-signed raw request body against one of the supported webhook
+/// header conventions.
+pub async fn verify_hmac_signed<L: EventLog + ?Sized>(
+    event_log: &L,
+    provider: &ProviderId,
+    style: HmacSignatureStyle<'_>,
+    body: &[u8],
+    headers: &BTreeMap<String, String>,
+    secret: &str,
+    timestamp_window: Option<Duration>,
+    now: OffsetDateTime,
+) -> Result<(), ConnectorError> {
+    match style {
+        HmacSignatureStyle::GitHub {
+            signature_header,
+            prefix,
+        } => {
+            verify_github(
+                event_log,
+                provider,
+                style,
+                signature_header,
+                prefix,
+                body,
+                headers,
+                secret,
+                now,
+            )
+            .await
+        }
+        HmacSignatureStyle::Stripe {
+            signature_header,
+            version,
+        } => {
+            verify_stripe(
+                event_log,
+                provider,
+                style,
+                signature_header,
+                version,
+                body,
+                headers,
+                secret,
+                timestamp_window,
+                now,
+            )
+            .await
+        }
+        HmacSignatureStyle::StandardWebhooks {
+            id_header,
+            signature_header,
+            timestamp_header,
+            version,
+        } => {
+            verify_standard_webhooks(
+                event_log,
+                provider,
+                style,
+                id_header,
+                signature_header,
+                timestamp_header,
+                version,
+                body,
+                headers,
+                secret,
+                timestamp_window,
+                now,
+            )
+            .await
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn verify_github<L: EventLog + ?Sized>(
+    event_log: &L,
+    provider: &ProviderId,
+    style: HmacSignatureStyle<'_>,
+    signature_header: &str,
+    prefix: &str,
+    body: &[u8],
+    headers: &BTreeMap<String, String>,
+    secret: &str,
+    now: OffsetDateTime,
+) -> Result<(), ConnectorError> {
+    let header = required_header(headers, signature_header).map_err(|error| {
+        ConnectorError::MissingHeader(match error {
+            ConnectorError::MissingHeader(name) => name,
+            other => other.to_string(),
+        })
+    });
+    let header = match header {
+        Ok(value) => value,
+        Err(error) => return reject(event_log, provider, style, &error, now, None, None).await,
+    };
+
+    let encoded = match header.strip_prefix(prefix) {
+        Some(value) => value,
+        None => {
+            let error = ConnectorError::InvalidHeader {
+                name: signature_header.to_string(),
+                detail: format!("expected `{prefix}` prefix"),
+            };
+            return reject(event_log, provider, style, &error, now, None, None).await;
+        }
+    };
+    let provided = match hex::decode(encoded) {
+        Ok(value) => value,
+        Err(error) => {
+            let error = ConnectorError::InvalidHeader {
+                name: signature_header.to_string(),
+                detail: error.to_string(),
+            };
+            return reject(event_log, provider, style, &error, now, None, None).await;
+        }
+    };
+
+    let expected = hmac_sha256(secret.as_bytes(), body);
+    if secure_eq(&expected, &provided) {
+        Ok(())
+    } else {
+        let error =
+            ConnectorError::invalid_signature("signature did not match the raw request body");
+        reject(event_log, provider, style, &error, now, None, None).await
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn verify_stripe<L: EventLog + ?Sized>(
+    event_log: &L,
+    provider: &ProviderId,
+    style: HmacSignatureStyle<'_>,
+    signature_header: &str,
+    version: &str,
+    body: &[u8],
+    headers: &BTreeMap<String, String>,
+    secret: &str,
+    timestamp_window: Option<Duration>,
+    now: OffsetDateTime,
+) -> Result<(), ConnectorError> {
+    let window = match timestamp_window {
+        Some(window) => window,
+        None => {
+            let error = ConnectorError::Unsupported(
+                "stripe-style signature verification requires a timestamp window".to_string(),
+            );
+            return reject(event_log, provider, style, &error, now, None, None).await;
+        }
+    };
+
+    let header = match required_header(headers, signature_header) {
+        Ok(value) => value,
+        Err(error) => {
+            return reject(event_log, provider, style, &error, now, None, Some(window)).await
+        }
+    };
+
+    let mut timestamp = None;
+    let mut provided = Vec::new();
+    for part in header.split(',') {
+        let (key, value) = match part.split_once('=') {
+            Some(pair) => pair,
+            None => continue,
+        };
+        if key == "t" {
+            match value.parse::<i64>() {
+                Ok(raw) => match OffsetDateTime::from_unix_timestamp(raw) {
+                    Ok(parsed) => timestamp = Some(parsed),
+                    Err(error) => {
+                        let error = ConnectorError::InvalidHeader {
+                            name: signature_header.to_string(),
+                            detail: error.to_string(),
+                        };
+                        return reject(event_log, provider, style, &error, now, None, Some(window))
+                            .await;
+                    }
+                },
+                Err(error) => {
+                    let error = ConnectorError::InvalidHeader {
+                        name: signature_header.to_string(),
+                        detail: error.to_string(),
+                    };
+                    return reject(event_log, provider, style, &error, now, None, Some(window))
+                        .await;
+                }
+            }
+        } else if key == version {
+            match hex::decode(value) {
+                Ok(signature) => provided.push(signature),
+                Err(error) => {
+                    let error = ConnectorError::InvalidHeader {
+                        name: signature_header.to_string(),
+                        detail: error.to_string(),
+                    };
+                    return reject(event_log, provider, style, &error, now, None, Some(window))
+                        .await;
+                }
+            }
+        }
+    }
+
+    let timestamp = match timestamp {
+        Some(value) => value,
+        None => {
+            let error = ConnectorError::InvalidHeader {
+                name: signature_header.to_string(),
+                detail: "missing `t=` timestamp component".to_string(),
+            };
+            return reject(event_log, provider, style, &error, now, None, Some(window)).await;
+        }
+    };
+    ensure_timestamp_within_window(event_log, provider, style, timestamp, window, now).await?;
+
+    if provided.is_empty() {
+        let error = ConnectorError::InvalidHeader {
+            name: signature_header.to_string(),
+            detail: format!("missing `{version}=` signature component"),
+        };
+        return reject(
+            event_log,
+            provider,
+            style,
+            &error,
+            now,
+            Some(timestamp),
+            Some(window),
+        )
+        .await;
+    }
+
+    let mut signed = timestamp.unix_timestamp().to_string().into_bytes();
+    signed.push(b'.');
+    signed.extend_from_slice(body);
+    let expected = hmac_sha256(secret.as_bytes(), &signed);
+    if provided
+        .iter()
+        .any(|signature| secure_eq(&expected, signature))
+    {
+        Ok(())
+    } else {
+        let error =
+            ConnectorError::invalid_signature("no stripe signature matched the raw request body");
+        reject(
+            event_log,
+            provider,
+            style,
+            &error,
+            now,
+            Some(timestamp),
+            Some(window),
+        )
+        .await
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn verify_standard_webhooks<L: EventLog + ?Sized>(
+    event_log: &L,
+    provider: &ProviderId,
+    style: HmacSignatureStyle<'_>,
+    id_header: &str,
+    signature_header: &str,
+    timestamp_header: &str,
+    version: &str,
+    body: &[u8],
+    headers: &BTreeMap<String, String>,
+    secret: &str,
+    timestamp_window: Option<Duration>,
+    now: OffsetDateTime,
+) -> Result<(), ConnectorError> {
+    let window = match timestamp_window {
+        Some(window) => window,
+        None => {
+            let error = ConnectorError::Unsupported(
+                "standard-webhooks verification requires a timestamp window".to_string(),
+            );
+            return reject(event_log, provider, style, &error, now, None, None).await;
+        }
+    };
+
+    let message_id = match required_header(headers, id_header) {
+        Ok(value) => value,
+        Err(error) => {
+            return reject(event_log, provider, style, &error, now, None, Some(window)).await
+        }
+    };
+    let signature_header_value = match required_header(headers, signature_header) {
+        Ok(value) => value,
+        Err(error) => {
+            return reject(event_log, provider, style, &error, now, None, Some(window)).await
+        }
+    };
+    let timestamp_raw = match required_header(headers, timestamp_header) {
+        Ok(value) => value,
+        Err(error) => {
+            return reject(event_log, provider, style, &error, now, None, Some(window)).await
+        }
+    };
+
+    let timestamp = match timestamp_raw.parse::<i64>() {
+        Ok(raw) => match OffsetDateTime::from_unix_timestamp(raw) {
+            Ok(timestamp) => timestamp,
+            Err(error) => {
+                let error = ConnectorError::InvalidHeader {
+                    name: timestamp_header.to_string(),
+                    detail: error.to_string(),
+                };
+                return reject(event_log, provider, style, &error, now, None, Some(window)).await;
+            }
+        },
+        Err(error) => {
+            let error = ConnectorError::InvalidHeader {
+                name: timestamp_header.to_string(),
+                detail: error.to_string(),
+            };
+            return reject(event_log, provider, style, &error, now, None, Some(window)).await;
+        }
+    };
+    ensure_timestamp_within_window(event_log, provider, style, timestamp, window, now).await?;
+
+    let signing_key = match decode_standard_webhooks_secret(secret) {
+        Ok(secret) => secret,
+        Err(error) => {
+            return reject(
+                event_log,
+                provider,
+                style,
+                &error,
+                now,
+                Some(timestamp),
+                Some(window),
+            )
+            .await
+        }
+    };
+
+    let mut signed = message_id.as_bytes().to_vec();
+    signed.push(b'.');
+    signed.extend_from_slice(timestamp_raw.as_bytes());
+    signed.push(b'.');
+    signed.extend_from_slice(body);
+    let expected = hmac_sha256(&signing_key, &signed);
+
+    let mut any_v1 = false;
+    for versioned in signature_header_value.split_ascii_whitespace() {
+        let Some((current_version, encoded_signature)) = versioned.split_once(',') else {
+            continue;
+        };
+        if current_version != version {
+            continue;
+        }
+        any_v1 = true;
+        let provided = match BASE64_STANDARD.decode(encoded_signature) {
+            Ok(signature) => signature,
+            Err(error) => {
+                let error = ConnectorError::InvalidHeader {
+                    name: signature_header.to_string(),
+                    detail: error.to_string(),
+                };
+                return reject(
+                    event_log,
+                    provider,
+                    style,
+                    &error,
+                    now,
+                    Some(timestamp),
+                    Some(window),
+                )
+                .await;
+            }
+        };
+        if secure_eq(&expected, &provided) {
+            return Ok(());
+        }
+    }
+
+    let error = if any_v1 {
+        ConnectorError::invalid_signature(
+            "no standard-webhooks signature matched the raw request body",
+        )
+    } else {
+        ConnectorError::InvalidHeader {
+            name: signature_header.to_string(),
+            detail: format!("missing `{version},` signature entry"),
+        }
+    };
+    reject(
+        event_log,
+        provider,
+        style,
+        &error,
+        now,
+        Some(timestamp),
+        Some(window),
+    )
+    .await
+}
+
+async fn ensure_timestamp_within_window<L: EventLog + ?Sized>(
+    event_log: &L,
+    provider: &ProviderId,
+    style: HmacSignatureStyle<'_>,
+    timestamp: OffsetDateTime,
+    window: Duration,
+    now: OffsetDateTime,
+) -> Result<(), ConnectorError> {
+    if now - timestamp > window || timestamp - now > window {
+        let error = ConnectorError::TimestampOutOfWindow {
+            timestamp,
+            now,
+            window,
+        };
+        return reject(
+            event_log,
+            provider,
+            style,
+            &error,
+            now,
+            Some(timestamp),
+            Some(window),
+        )
+        .await;
+    }
+    Ok(())
+}
+
+fn required_header<'a>(
+    headers: &'a BTreeMap<String, String>,
+    name: &str,
+) -> Result<&'a str, ConnectorError> {
+    header_value(headers, name).ok_or_else(|| ConnectorError::MissingHeader(name.to_string()))
+}
+
+fn header_value<'a>(headers: &'a BTreeMap<String, String>, name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
+}
+
+fn decode_standard_webhooks_secret(secret: &str) -> Result<Vec<u8>, ConnectorError> {
+    let normalized = secret.strip_prefix("whsec_").unwrap_or(secret);
+    let mut padded = normalized.to_string();
+    let remainder = padded.len() % 4;
+    if remainder != 0 {
+        padded.push_str(&"=".repeat(4 - remainder));
+    }
+    BASE64_STANDARD
+        .decode(padded)
+        .map_err(|error| ConnectorError::InvalidHeader {
+            name: "webhook-secret".to_string(),
+            detail: error.to_string(),
+        })
+}
+
+fn hmac_sha256(secret: &[u8], data: &[u8]) -> Vec<u8> {
+    const BLOCK_SIZE: usize = 64;
+
+    let mut key = if secret.len() > BLOCK_SIZE {
+        Sha256::digest(secret).to_vec()
+    } else {
+        secret.to_vec()
+    };
+    key.resize(BLOCK_SIZE, 0);
+
+    let mut inner_pad = vec![0x36; BLOCK_SIZE];
+    let mut outer_pad = vec![0x5c; BLOCK_SIZE];
+    for (slot, key_byte) in inner_pad.iter_mut().zip(&key) {
+        *slot ^= key_byte;
+    }
+    for (slot, key_byte) in outer_pad.iter_mut().zip(&key) {
+        *slot ^= key_byte;
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(&inner_pad);
+    inner.update(data);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(&outer_pad);
+    outer.update(inner_digest);
+    outer.finalize().to_vec()
+}
+
+fn secure_eq(expected: &[u8], provided: &[u8]) -> bool {
+    expected.ct_eq(provided).into()
+}
+
+async fn reject<L: EventLog + ?Sized>(
+    event_log: &L,
+    provider: &ProviderId,
+    style: HmacSignatureStyle<'_>,
+    error: &ConnectorError,
+    now: OffsetDateTime,
+    signed_at: Option<OffsetDateTime>,
+    window: Option<Duration>,
+) -> Result<(), ConnectorError> {
+    audit_rejection(event_log, provider, style, error, now, signed_at, window).await;
+    Err(match error {
+        ConnectorError::DuplicateProvider(value) => {
+            ConnectorError::DuplicateProvider(value.clone())
+        }
+        ConnectorError::UnknownProvider(value) => ConnectorError::UnknownProvider(value.clone()),
+        ConnectorError::MissingHeader(value) => ConnectorError::MissingHeader(value.clone()),
+        ConnectorError::InvalidHeader { name, detail } => ConnectorError::InvalidHeader {
+            name: name.clone(),
+            detail: detail.clone(),
+        },
+        ConnectorError::InvalidSignature(value) => ConnectorError::InvalidSignature(value.clone()),
+        ConnectorError::TimestampOutOfWindow {
+            timestamp,
+            now,
+            window,
+        } => ConnectorError::TimestampOutOfWindow {
+            timestamp: *timestamp,
+            now: *now,
+            window: *window,
+        },
+        ConnectorError::Json(value) => ConnectorError::Json(value.clone()),
+        ConnectorError::Secret(value) => ConnectorError::Secret(value.clone()),
+        ConnectorError::EventLog(value) => ConnectorError::EventLog(value.clone()),
+        ConnectorError::Client(value) => ConnectorError::Client(value.clone()),
+        ConnectorError::Unsupported(value) => ConnectorError::Unsupported(value.clone()),
+        ConnectorError::Activation(value) => ConnectorError::Activation(value.clone()),
+    })
+}
+
+async fn audit_rejection<L: EventLog + ?Sized>(
+    event_log: &L,
+    provider: &ProviderId,
+    style: HmacSignatureStyle<'_>,
+    error: &ConnectorError,
+    now: OffsetDateTime,
+    signed_at: Option<OffsetDateTime>,
+    window: Option<Duration>,
+) {
+    let payload = json!({
+        "provider": provider.as_str(),
+        "style": style.label(),
+        "reason": error.to_string(),
+        "observed_at": now.format(&time::format_description::well_known::Rfc3339).ok(),
+        "signed_at": signed_at.and_then(|value| value.format(&time::format_description::well_known::Rfc3339).ok()),
+        "window_seconds": window.map(|value| value.whole_seconds()),
+    });
+    let topic = Topic::new(SIGNATURE_VERIFY_AUDIT_TOPIC).expect("audit topic is valid");
+    if let Err(error) = event_log
+        .append(&topic, LogEvent::new("signature_rejected", payload))
+        .await
+    {
+        crate::events::log_warn(
+            "connectors.signature_verify.audit",
+            &format!("failed to append signature verification audit event: {error}"),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::event_log::{EventLog, MemoryEventLog};
+
+    fn log() -> std::sync::Arc<MemoryEventLog> {
+        std::sync::Arc::new(MemoryEventLog::new(16))
+    }
+
+    async fn audit_events(
+        log: &std::sync::Arc<MemoryEventLog>,
+    ) -> Vec<(u64, crate::event_log::LogEvent)> {
+        let topic = Topic::new(SIGNATURE_VERIFY_AUDIT_TOPIC).unwrap();
+        log.read_range(&topic, None, 32).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn verifies_github_signature_using_official_docs_vector() {
+        let log = log();
+        let mut headers = BTreeMap::new();
+        headers.insert(
+            "X-Hub-Signature-256".to_string(),
+            "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17".to_string(),
+        );
+
+        verify_hmac_signed(
+            log.as_ref(),
+            &ProviderId::from("github"),
+            HmacSignatureStyle::github(),
+            b"Hello, World!",
+            &headers,
+            "It's a Secret to Everybody",
+            None,
+            OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(audit_events(&log).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn verifies_standard_webhooks_using_vendor_test_vector() {
+        let log = log();
+        let headers = BTreeMap::from([
+            (
+                "webhook-id".to_string(),
+                "msg_p5jXN8AQM9LWM0D4loKWxJek".to_string(),
+            ),
+            (
+                "webhook-signature".to_string(),
+                "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE=".to_string(),
+            ),
+            ("webhook-timestamp".to_string(), "1614265330".to_string()),
+        ]);
+        let now = OffsetDateTime::from_unix_timestamp(1_614_265_330).unwrap();
+
+        verify_hmac_signed(
+            log.as_ref(),
+            &ProviderId::from("webhook"),
+            HmacSignatureStyle::standard_webhooks(),
+            br#"{"test": 2432232314}"#,
+            &headers,
+            "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw",
+            Some(Duration::minutes(5)),
+            now,
+        )
+        .await
+        .unwrap();
+
+        assert!(audit_events(&log).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn verifies_stripe_signature_using_vendor_fixture_shape() {
+        let log = log();
+        let headers = BTreeMap::from([(
+            "Stripe-Signature".to_string(),
+            "t=12345,v1=2672d138c9a412830f3bfe2ecc5bfb3277cf6f5b49d0119d77dd6cb64da1257e"
+                .to_string(),
+        )]);
+        let body = b"{\n  \"id\": \"evt_test_webhook\",\n  \"object\": \"event\"\n}";
+
+        verify_hmac_signed(
+            log.as_ref(),
+            &ProviderId::from("stripe"),
+            HmacSignatureStyle::stripe(),
+            body,
+            &headers,
+            "whsec_test_secret",
+            Some(Duration::seconds(30)),
+            OffsetDateTime::from_unix_timestamp(12_350).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(audit_events(&log).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn rejects_bad_signature_and_audits_failure() {
+        let log = log();
+        let headers = BTreeMap::from([(
+            "X-Hub-Signature-256".to_string(),
+            "sha256=0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+        )]);
+
+        let error = verify_hmac_signed(
+            log.as_ref(),
+            &ProviderId::from("github"),
+            HmacSignatureStyle::github(),
+            b"Hello, World!",
+            &headers,
+            "It's a Secret to Everybody",
+            None,
+            OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, ConnectorError::InvalidSignature(_)));
+        assert_eq!(audit_events(&log).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn rejects_wrong_body_even_with_valid_github_header() {
+        let log = log();
+        let headers = BTreeMap::from([(
+            "X-Hub-Signature-256".to_string(),
+            "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17".to_string(),
+        )]);
+
+        let error = verify_hmac_signed(
+            log.as_ref(),
+            &ProviderId::from("github"),
+            HmacSignatureStyle::github(),
+            b"Hello, World?\n",
+            &headers,
+            "It's a Secret to Everybody",
+            None,
+            OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, ConnectorError::InvalidSignature(_)));
+        assert_eq!(audit_events(&log).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn rejects_tampered_timestamp_header() {
+        let log = log();
+        let headers = BTreeMap::from([(
+            "Stripe-Signature".to_string(),
+            "t=not-a-timestamp,v1=2672d138c9a412830f3bfe2ecc5bfb3277cf6f5b49d0119d77dd6cb64da1257e"
+                .to_string(),
+        )]);
+
+        let error = verify_hmac_signed(
+            log.as_ref(),
+            &ProviderId::from("stripe"),
+            HmacSignatureStyle::stripe(),
+            b"{\n  \"id\": \"evt_test_webhook\",\n  \"object\": \"event\"\n}",
+            &headers,
+            "whsec_test_secret",
+            Some(Duration::seconds(30)),
+            OffsetDateTime::from_unix_timestamp(12_350).unwrap(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, ConnectorError::InvalidHeader { .. }));
+        assert_eq!(audit_events(&log).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn rejects_expired_timestamp_window() {
+        let log = log();
+        let headers = BTreeMap::from([(
+            "Stripe-Signature".to_string(),
+            "t=12345,v1=2672d138c9a412830f3bfe2ecc5bfb3277cf6f5b49d0119d77dd6cb64da1257e"
+                .to_string(),
+        )]);
+
+        let error = verify_hmac_signed(
+            log.as_ref(),
+            &ProviderId::from("stripe"),
+            HmacSignatureStyle::stripe(),
+            b"{\n  \"id\": \"evt_test_webhook\",\n  \"object\": \"event\"\n}",
+            &headers,
+            "whsec_test_secret",
+            Some(Duration::seconds(10)),
+            OffsetDateTime::from_unix_timestamp(12_400).unwrap(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, ConnectorError::TimestampOutOfWindow { .. }));
+        assert_eq!(audit_events(&log).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_signature_header() {
+        let log = log();
+        let headers = BTreeMap::new();
+
+        let error = verify_hmac_signed(
+            log.as_ref(),
+            &ProviderId::from("github"),
+            HmacSignatureStyle::github(),
+            b"Hello, World!",
+            &headers,
+            "It's a Secret to Everybody",
+            None,
+            OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(error, ConnectorError::MissingHeader(header) if header == DEFAULT_GITHUB_SIGNATURE_HEADER)
+        );
+        assert_eq!(audit_events(&log).await.len(), 1);
+    }
+}

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -1,0 +1,672 @@
+//! Connector traits and shared helpers for inbound event-source providers.
+//!
+//! This lands in `harn-vm` for now because the current dependency surface
+//! (`EventLog`, `SecretProvider`, `TriggerEvent`) already lives here. If the
+//! connector ecosystem grows enough to justify extraction, the module can be
+//! split into a dedicated crate later without changing the high-level contract.
+
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration as StdDuration, Instant};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use time::OffsetDateTime;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::event_log::AnyEventLog;
+use crate::secrets::SecretProvider;
+use crate::triggers::{ProviderId, TenantId, TriggerEvent};
+
+pub mod hmac;
+
+pub use hmac::{
+    HmacSignatureStyle, DEFAULT_GITHUB_SIGNATURE_HEADER, DEFAULT_STANDARD_WEBHOOKS_ID_HEADER,
+    DEFAULT_STANDARD_WEBHOOKS_SIGNATURE_HEADER, DEFAULT_STANDARD_WEBHOOKS_TIMESTAMP_HEADER,
+    DEFAULT_STRIPE_SIGNATURE_HEADER, SIGNATURE_VERIFY_AUDIT_TOPIC,
+};
+
+/// Shared owned handle to a connector instance registered with the runtime.
+pub type ConnectorHandle = Arc<AsyncMutex<Box<dyn Connector>>>;
+
+/// Provider implementation contract for inbound connectors.
+#[async_trait]
+pub trait Connector: Send + Sync {
+    /// Stable provider id such as `github`, `slack`, or `webhook`.
+    fn provider_id(&self) -> &ProviderId;
+
+    /// Trigger kinds this connector supports (`webhook`, `poll`, `stream`, ...).
+    fn kinds(&self) -> &[TriggerKind];
+
+    /// Called once per connector instance at orchestrator startup.
+    async fn init(&mut self, ctx: ConnectorCtx) -> Result<(), ConnectorError>;
+
+    /// Activate the bindings relevant to this connector instance.
+    async fn activate(
+        &self,
+        bindings: &[TriggerBinding],
+    ) -> Result<ActivationHandle, ConnectorError>;
+
+    /// Verify + normalize a provider-native inbound request into `TriggerEvent`.
+    fn normalize_inbound(&self, raw: RawInbound) -> Result<TriggerEvent, ConnectorError>;
+
+    /// Payload schema surfaced to future trigger-type narrowing.
+    fn payload_schema(&self) -> ProviderPayloadSchema;
+
+    /// Outbound API wrapper exposed to handlers.
+    fn client(&self) -> Arc<dyn ConnectorClient>;
+}
+
+/// Outbound provider client interface used by connector-backed stdlib modules.
+#[async_trait]
+pub trait ConnectorClient: Send + Sync {
+    async fn call(&self, method: &str, args: JsonValue) -> Result<JsonValue, ClientError>;
+}
+
+/// Minimal outbound client errors shared by connector implementations.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ClientError {
+    MethodNotFound(String),
+    InvalidArgs(String),
+    RateLimited(String),
+    Transport(String),
+    Other(String),
+}
+
+impl fmt::Display for ClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MethodNotFound(message)
+            | Self::InvalidArgs(message)
+            | Self::RateLimited(message)
+            | Self::Transport(message)
+            | Self::Other(message) => message.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for ClientError {}
+
+/// Shared connector-layer errors.
+#[derive(Debug)]
+pub enum ConnectorError {
+    DuplicateProvider(String),
+    UnknownProvider(String),
+    MissingHeader(String),
+    InvalidHeader {
+        name: String,
+        detail: String,
+    },
+    InvalidSignature(String),
+    TimestampOutOfWindow {
+        timestamp: OffsetDateTime,
+        now: OffsetDateTime,
+        window: time::Duration,
+    },
+    Json(String),
+    Secret(String),
+    EventLog(String),
+    Client(ClientError),
+    Unsupported(String),
+    Activation(String),
+}
+
+impl ConnectorError {
+    pub fn invalid_signature(message: impl Into<String>) -> Self {
+        Self::InvalidSignature(message.into())
+    }
+}
+
+impl fmt::Display for ConnectorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateProvider(provider) => {
+                write!(f, "connector provider `{provider}` is already registered")
+            }
+            Self::UnknownProvider(provider) => {
+                write!(f, "connector provider `{provider}` is not registered")
+            }
+            Self::MissingHeader(header) => write!(f, "missing required header `{header}`"),
+            Self::InvalidHeader { name, detail } => {
+                write!(f, "invalid header `{name}`: {detail}")
+            }
+            Self::InvalidSignature(message)
+            | Self::Json(message)
+            | Self::Secret(message)
+            | Self::EventLog(message)
+            | Self::Unsupported(message)
+            | Self::Activation(message) => message.fmt(f),
+            Self::TimestampOutOfWindow {
+                timestamp,
+                now,
+                window,
+            } => write!(
+                f,
+                "timestamp {timestamp} is outside the allowed verification window of {window} around {now}"
+            ),
+            Self::Client(error) => error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for ConnectorError {}
+
+impl From<crate::event_log::LogError> for ConnectorError {
+    fn from(value: crate::event_log::LogError) -> Self {
+        Self::EventLog(value.to_string())
+    }
+}
+
+impl From<crate::secrets::SecretError> for ConnectorError {
+    fn from(value: crate::secrets::SecretError) -> Self {
+        Self::Secret(value.to_string())
+    }
+}
+
+impl From<serde_json::Error> for ConnectorError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Json(value.to_string())
+    }
+}
+
+impl From<ClientError> for ConnectorError {
+    fn from(value: ClientError) -> Self {
+        Self::Client(value)
+    }
+}
+
+/// Startup context shared with connector instances.
+#[derive(Clone)]
+pub struct ConnectorCtx {
+    pub event_log: Arc<AnyEventLog>,
+    pub secrets: Arc<dyn SecretProvider>,
+    pub inbox: Arc<InboxIndex>,
+    pub metrics: Arc<MetricsRegistry>,
+    pub rate_limiter: Arc<RateLimiterFactory>,
+}
+
+/// Placeholder inbox index until the durable trigger inbox lands.
+#[derive(Clone, Debug, Default)]
+pub struct InboxIndex;
+
+/// Placeholder metrics surface for connector-local counters and timings.
+#[derive(Clone, Debug, Default)]
+pub struct MetricsRegistry;
+
+/// Provider payload schema metadata exposed by a connector.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProviderPayloadSchema {
+    pub harn_schema_name: String,
+    #[serde(default)]
+    pub json_schema: JsonValue,
+}
+
+impl ProviderPayloadSchema {
+    pub fn new(harn_schema_name: impl Into<String>, json_schema: JsonValue) -> Self {
+        Self {
+            harn_schema_name: harn_schema_name.into(),
+            json_schema,
+        }
+    }
+
+    pub fn named(harn_schema_name: impl Into<String>) -> Self {
+        Self::new(harn_schema_name, JsonValue::Null)
+    }
+}
+
+impl Default for ProviderPayloadSchema {
+    fn default() -> Self {
+        Self::named("raw")
+    }
+}
+
+/// High-level transport kind a connector supports.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TriggerKind(String);
+
+impl TriggerKind {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl From<&str> for TriggerKind {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for TriggerKind {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+/// Future trigger manifest binding routed to a connector activation.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TriggerBinding {
+    pub provider: ProviderId,
+    pub kind: TriggerKind,
+    pub binding_id: String,
+    #[serde(default)]
+    pub config: JsonValue,
+}
+
+impl TriggerBinding {
+    pub fn new(
+        provider: ProviderId,
+        kind: impl Into<TriggerKind>,
+        binding_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider,
+            kind: kind.into(),
+            binding_id: binding_id.into(),
+            config: JsonValue::Null,
+        }
+    }
+}
+
+/// Small in-memory trigger-binding registry used to fan bindings into connectors.
+#[derive(Clone, Debug, Default)]
+pub struct TriggerRegistry {
+    bindings: BTreeMap<ProviderId, Vec<TriggerBinding>>,
+}
+
+impl TriggerRegistry {
+    pub fn register(&mut self, binding: TriggerBinding) {
+        self.bindings
+            .entry(binding.provider.clone())
+            .or_default()
+            .push(binding);
+    }
+
+    pub fn bindings_for(&self, provider: &ProviderId) -> &[TriggerBinding] {
+        self.bindings
+            .get(provider)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+}
+
+/// Metadata returned from connector activation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ActivationHandle {
+    pub provider: ProviderId,
+    pub binding_count: usize,
+}
+
+impl ActivationHandle {
+    pub fn new(provider: ProviderId, binding_count: usize) -> Self {
+        Self {
+            provider,
+            binding_count,
+        }
+    }
+}
+
+/// Provider-native inbound request payload preserved as raw bytes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RawInbound {
+    pub kind: String,
+    pub headers: BTreeMap<String, String>,
+    pub query: BTreeMap<String, String>,
+    pub body: Vec<u8>,
+    pub received_at: OffsetDateTime,
+    pub occurred_at: Option<OffsetDateTime>,
+    pub tenant_id: Option<TenantId>,
+    pub metadata: JsonValue,
+}
+
+impl RawInbound {
+    pub fn new(kind: impl Into<String>, headers: BTreeMap<String, String>, body: Vec<u8>) -> Self {
+        Self {
+            kind: kind.into(),
+            headers,
+            query: BTreeMap::new(),
+            body,
+            received_at: OffsetDateTime::now_utc(),
+            occurred_at: None,
+            tenant_id: None,
+            metadata: JsonValue::Null,
+        }
+    }
+
+    pub fn json_body(&self) -> Result<JsonValue, ConnectorError> {
+        Ok(serde_json::from_slice(&self.body)?)
+    }
+}
+
+/// Token-bucket configuration shared across connector clients.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RateLimitConfig {
+    pub capacity: u32,
+    pub refill_tokens: u32,
+    pub refill_interval: StdDuration,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            capacity: 60,
+            refill_tokens: 1,
+            refill_interval: StdDuration::from_secs(1),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TokenBucket {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn full(config: RateLimitConfig) -> Self {
+        Self {
+            tokens: config.capacity as f64,
+            last_refill: Instant::now(),
+        }
+    }
+
+    fn refill(&mut self, config: RateLimitConfig, now: Instant) {
+        let interval = config.refill_interval.as_secs_f64().max(f64::EPSILON);
+        let rate = config.refill_tokens.max(1) as f64 / interval;
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * rate).min(config.capacity.max(1) as f64);
+        self.last_refill = now;
+    }
+
+    fn try_acquire(&mut self, config: RateLimitConfig, now: Instant) -> bool {
+        self.refill(config, now);
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn wait_duration(&self, config: RateLimitConfig) -> StdDuration {
+        if self.tokens >= 1.0 {
+            return StdDuration::ZERO;
+        }
+        let interval = config.refill_interval.as_secs_f64().max(f64::EPSILON);
+        let rate = config.refill_tokens.max(1) as f64 / interval;
+        let missing = (1.0 - self.tokens).max(0.0);
+        StdDuration::from_secs_f64((missing / rate).max(0.001))
+    }
+}
+
+/// Shared per-provider, per-key token bucket factory for outbound connector clients.
+#[derive(Debug)]
+pub struct RateLimiterFactory {
+    config: RateLimitConfig,
+    buckets: Mutex<HashMap<(String, String), TokenBucket>>,
+}
+
+impl RateLimiterFactory {
+    pub fn new(config: RateLimitConfig) -> Self {
+        Self {
+            config,
+            buckets: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn config(&self) -> RateLimitConfig {
+        self.config
+    }
+
+    pub fn scoped(&self, provider: &ProviderId, key: impl Into<String>) -> ScopedRateLimiter<'_> {
+        ScopedRateLimiter {
+            factory: self,
+            provider: provider.clone(),
+            key: key.into(),
+        }
+    }
+
+    pub fn try_acquire(&self, provider: &ProviderId, key: &str) -> bool {
+        let mut buckets = self.buckets.lock().expect("rate limiter mutex poisoned");
+        let bucket = buckets
+            .entry((provider.as_str().to_string(), key.to_string()))
+            .or_insert_with(|| TokenBucket::full(self.config));
+        bucket.try_acquire(self.config, Instant::now())
+    }
+
+    pub async fn acquire(&self, provider: &ProviderId, key: &str) {
+        loop {
+            let wait = {
+                let mut buckets = self.buckets.lock().expect("rate limiter mutex poisoned");
+                let bucket = buckets
+                    .entry((provider.as_str().to_string(), key.to_string()))
+                    .or_insert_with(|| TokenBucket::full(self.config));
+                if bucket.try_acquire(self.config, Instant::now()) {
+                    return;
+                }
+                bucket.wait_duration(self.config)
+            };
+            tokio::time::sleep(wait).await;
+        }
+    }
+}
+
+impl Default for RateLimiterFactory {
+    fn default() -> Self {
+        Self::new(RateLimitConfig::default())
+    }
+}
+
+/// Borrowed view onto a single provider/key rate-limit scope.
+#[derive(Clone, Debug)]
+pub struct ScopedRateLimiter<'a> {
+    factory: &'a RateLimiterFactory,
+    provider: ProviderId,
+    key: String,
+}
+
+impl<'a> ScopedRateLimiter<'a> {
+    pub fn try_acquire(&self) -> bool {
+        self.factory.try_acquire(&self.provider, &self.key)
+    }
+
+    pub async fn acquire(&self) {
+        self.factory.acquire(&self.provider, &self.key).await;
+    }
+}
+
+/// Runtime connector registry keyed by provider id.
+#[derive(Default)]
+pub struct ConnectorRegistry {
+    connectors: BTreeMap<ProviderId, ConnectorHandle>,
+}
+
+impl ConnectorRegistry {
+    pub fn register(&mut self, connector: Box<dyn Connector>) -> Result<(), ConnectorError> {
+        let provider = connector.provider_id().clone();
+        if self.connectors.contains_key(&provider) {
+            return Err(ConnectorError::DuplicateProvider(provider.0));
+        }
+        self.connectors
+            .insert(provider, Arc::new(AsyncMutex::new(connector)));
+        Ok(())
+    }
+
+    pub fn get(&self, id: &ProviderId) -> Option<ConnectorHandle> {
+        self.connectors.get(id).cloned()
+    }
+
+    pub async fn activate_all(
+        &self,
+        registry: &TriggerRegistry,
+    ) -> Result<Vec<ActivationHandle>, ConnectorError> {
+        let mut handles = Vec::new();
+        for (provider, connector) in &self.connectors {
+            let bindings = registry.bindings_for(provider);
+            if bindings.is_empty() {
+                continue;
+            }
+            let connector = connector.lock().await;
+            handles.push(connector.activate(bindings).await?);
+        }
+        Ok(handles)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use serde_json::json;
+
+    struct NoopClient;
+
+    #[async_trait]
+    impl ConnectorClient for NoopClient {
+        async fn call(&self, method: &str, _args: JsonValue) -> Result<JsonValue, ClientError> {
+            Ok(json!({ "method": method }))
+        }
+    }
+
+    struct FakeConnector {
+        provider_id: ProviderId,
+        kinds: Vec<TriggerKind>,
+        activate_calls: Arc<AtomicUsize>,
+    }
+
+    impl FakeConnector {
+        fn new(provider_id: &str, activate_calls: Arc<AtomicUsize>) -> Self {
+            Self {
+                provider_id: ProviderId::from(provider_id),
+                kinds: vec![TriggerKind::from("webhook")],
+                activate_calls,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Connector for FakeConnector {
+        fn provider_id(&self) -> &ProviderId {
+            &self.provider_id
+        }
+
+        fn kinds(&self) -> &[TriggerKind] {
+            &self.kinds
+        }
+
+        async fn init(&mut self, _ctx: ConnectorCtx) -> Result<(), ConnectorError> {
+            Ok(())
+        }
+
+        async fn activate(
+            &self,
+            bindings: &[TriggerBinding],
+        ) -> Result<ActivationHandle, ConnectorError> {
+            self.activate_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ActivationHandle::new(
+                self.provider_id.clone(),
+                bindings.len(),
+            ))
+        }
+
+        fn normalize_inbound(&self, _raw: RawInbound) -> Result<TriggerEvent, ConnectorError> {
+            Err(ConnectorError::Unsupported(
+                "not needed for registry tests".to_string(),
+            ))
+        }
+
+        fn payload_schema(&self) -> ProviderPayloadSchema {
+            ProviderPayloadSchema::named("FakePayload")
+        }
+
+        fn client(&self) -> Arc<dyn ConnectorClient> {
+            Arc::new(NoopClient)
+        }
+    }
+
+    #[tokio::test]
+    async fn connector_registry_rejects_duplicate_providers() {
+        let activate_calls = Arc::new(AtomicUsize::new(0));
+        let mut registry = ConnectorRegistry::default();
+        registry
+            .register(Box::new(FakeConnector::new(
+                "github",
+                activate_calls.clone(),
+            )))
+            .unwrap();
+
+        let error = registry
+            .register(Box::new(FakeConnector::new("github", activate_calls)))
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            ConnectorError::DuplicateProvider(provider) if provider == "github"
+        ));
+    }
+
+    #[tokio::test]
+    async fn connector_registry_activates_only_bound_connectors() {
+        let github_calls = Arc::new(AtomicUsize::new(0));
+        let slack_calls = Arc::new(AtomicUsize::new(0));
+        let mut registry = ConnectorRegistry::default();
+        registry
+            .register(Box::new(FakeConnector::new("github", github_calls.clone())))
+            .unwrap();
+        registry
+            .register(Box::new(FakeConnector::new("slack", slack_calls.clone())))
+            .unwrap();
+
+        let mut trigger_registry = TriggerRegistry::default();
+        trigger_registry.register(TriggerBinding::new(
+            ProviderId::from("github"),
+            "webhook",
+            "github.push",
+        ));
+        trigger_registry.register(TriggerBinding::new(
+            ProviderId::from("github"),
+            "webhook",
+            "github.installation",
+        ));
+
+        let handles = registry.activate_all(&trigger_registry).await.unwrap();
+        assert_eq!(handles.len(), 1);
+        assert_eq!(handles[0].provider.as_str(), "github");
+        assert_eq!(handles[0].binding_count, 2);
+        assert_eq!(github_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(slack_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn rate_limiter_scopes_tokens_by_provider_and_key() {
+        let factory = RateLimiterFactory::new(RateLimitConfig {
+            capacity: 1,
+            refill_tokens: 1,
+            refill_interval: StdDuration::from_secs(60),
+        });
+
+        assert!(factory.try_acquire(&ProviderId::from("github"), "org:1"));
+        assert!(!factory.try_acquire(&ProviderId::from("github"), "org:1"));
+        assert!(factory.try_acquire(&ProviderId::from("github"), "org:2"));
+        assert!(factory.try_acquire(&ProviderId::from("slack"), "org:1"));
+    }
+
+    #[test]
+    fn raw_inbound_json_body_preserves_raw_bytes() {
+        let raw = RawInbound::new(
+            "push",
+            BTreeMap::from([("Content-Type".to_string(), "application/json".to_string())]),
+            br#"{"ok":true}"#.to_vec(),
+        );
+
+        assert_eq!(raw.json_body().unwrap(), json!({ "ok": true }));
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bridge;
 pub mod checkpoint;
 mod chunk;
 mod compiler;
+pub mod connectors;
 pub mod event_log;
 pub mod events;
 mod http;
@@ -36,6 +37,12 @@ pub mod workspace_path;
 pub use checkpoint::register_checkpoint_builtins;
 pub use chunk::*;
 pub use compiler::*;
+pub use connectors::{
+    hmac::verify_hmac_signed, ActivationHandle, ClientError, Connector, ConnectorClient,
+    ConnectorCtx, ConnectorError, ConnectorRegistry, InboxIndex, MetricsRegistry,
+    ProviderPayloadSchema, RateLimitConfig, RateLimiterFactory, RawInbound, TriggerBinding,
+    TriggerKind, TriggerRegistry,
+};
 pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;
 pub use mcp::{

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,6 +28,7 @@
 - [Trigger manifests](./triggers/manifest.md)
 - [Trigger event schema](./triggers/event-schema.md)
 - [Trigger observability in the action graph](./observability/triggers-in-action-graph.md)
+- [Connector authoring](./connectors/authoring.md)
 - [Cookbook](./cookbook.md)
 - [Tutorial: code review agent](./tutorial-code-review-agent.md)
 - [Tutorial: MCP server](./tutorial-mcp-server.md)

--- a/docs/src/connectors/authoring.md
+++ b/docs/src/connectors/authoring.md
@@ -1,0 +1,128 @@
+# Connector authoring
+
+Custom connectors implement the `harn_vm::connectors::Connector` trait and
+plug into a `ConnectorRegistry` at orchestrator startup. The initial surface
+lives in `crates/harn-vm/src/connectors/` because the supporting abstractions
+it depends on today already live in `harn-vm`:
+
+- `EventLog` for audit and durable event plumbing
+- `SecretProvider` for signing secrets and outbound tokens
+- `TriggerEvent` for the normalized inbound envelope
+
+If the connector ecosystem grows large enough, the module can be extracted into
+a dedicated crate later without changing the core trait contract.
+
+## Implementing a connector
+
+A connector implementation owns two concerns:
+
+- Inbound normalization: verify the provider request, preserve the raw bytes,
+  and normalize into `TriggerEvent`.
+- Outbound callbacks: expose provider APIs through a `ConnectorClient`.
+
+The runtime-facing surface is:
+
+```rust
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use harn_vm::connectors::{
+    Connector, ConnectorClient, ConnectorCtx, ConnectorError, ProviderPayloadSchema,
+    RawInbound, TriggerBinding, TriggerKind,
+};
+use harn_vm::{ProviderId, TriggerEvent};
+use serde_json::Value as JsonValue;
+
+struct ExampleConnector {
+    provider_id: ProviderId,
+    kinds: Vec<TriggerKind>,
+    client: Arc<ExampleClient>,
+}
+
+struct ExampleClient;
+
+#[async_trait]
+impl ConnectorClient for ExampleClient {
+    async fn call(
+        &self,
+        method: &str,
+        args: JsonValue,
+    ) -> Result<JsonValue, harn_vm::ClientError> {
+        let _ = (method, args);
+        Ok(JsonValue::Null)
+    }
+}
+
+#[async_trait]
+impl Connector for ExampleConnector {
+    fn provider_id(&self) -> &ProviderId {
+        &self.provider_id
+    }
+
+    fn kinds(&self) -> &[TriggerKind] {
+        &self.kinds
+    }
+
+    async fn init(&mut self, _ctx: ConnectorCtx) -> Result<(), ConnectorError> {
+        Ok(())
+    }
+
+    async fn activate(
+        &self,
+        _bindings: &[TriggerBinding],
+    ) -> Result<harn_vm::ActivationHandle, ConnectorError> {
+        Ok(harn_vm::ActivationHandle::new(self.provider_id.clone(), 0))
+    }
+
+    fn normalize_inbound(&self, raw: RawInbound) -> Result<TriggerEvent, ConnectorError> {
+        let _payload = raw.json_body()?;
+        todo!("map the provider request into TriggerEvent")
+    }
+
+    fn payload_schema(&self) -> ProviderPayloadSchema {
+        ProviderPayloadSchema::named("ExamplePayload")
+    }
+
+    fn client(&self) -> Arc<dyn ConnectorClient> {
+        self.client.clone()
+    }
+}
+```
+
+## HMAC verification helper
+
+Webhook-style connectors should reuse
+`harn_vm::connectors::verify_hmac_signed(...)` instead of open-coding HMAC
+checks. The helper enforces the non-negotiable rules from issue `#167`:
+
+- verification happens against the raw request body bytes
+- signature comparisons use constant-time equality
+- timestamped schemes reject outside a caller-provided window
+- rejection paths write an audit event to the `audit.signature_verify` topic
+
+The helper currently supports the three MVP HMAC header styles needed by the
+planned connector tickets:
+
+- GitHub: `X-Hub-Signature-256: sha256=<hex>`
+- Stripe: `Stripe-Signature: t=<unix>,v1=<hex>[,v1=<hex>...]`
+- Standard Webhooks: `webhook-id`, `webhook-timestamp`, and
+  `webhook-signature: v1,<base64>`
+
+## Rate limiting
+
+Connector clients should acquire outbound permits through the shared
+`RateLimiterFactory`. The current implementation is intentionally small: a
+process-local token bucket keyed by `(provider_id, scope_key)`. That keeps the
+first landing trait-pure while giving upcoming provider clients one place to
+enforce per-installation or per-tenant quotas.
+
+## What is deliberately not here yet
+
+This foundation PR does not define:
+
+- concrete provider connectors
+- stdlib bindings that expose connector clients to Harn code
+- third-party manifest ABI for external connector packages
+
+Those land in follow-up tickets once the shared trait, registry, audit, and
+verification primitives are in place.


### PR DESCRIPTION
## Summary
- add `harn_vm::connectors` with the async `Connector` / `ConnectorClient` traits, `ConnectorRegistry`, shared stub context types, and a small provider-scoped token-bucket rate limiter
- add a shared `verify_hmac_signed(...)` helper with audit logging for GitHub, Stripe-style, and Standard Webhooks HMAC conventions plus unit tests for positive and negative vectors
- document custom connector authoring and wire the new doc into the mdBook summary and changelog

## Architectural decision
Placed in `crates/harn-vm/src/connectors/` because the current concrete dependencies (`EventLog`, `SecretProvider`, `TriggerEvent`) already live in `harn-vm`; this can be extracted later if justified.

## In scope
- async trait surface for connector implementations
- registry + activation fanout scaffolding
- shared HMAC verification helper and audit topic (`audit.signature_verify`)
- authoring docs and changelog/docs index updates

## Out of scope
- any concrete provider connector
- stdlib bindings exposing connector clients to Harn code
- third-party connector manifest ABI

## Validation
- `cargo test -p harn-vm connectors:: -- --nocapture`
- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/harn-target cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target make test`
- `npx markdownlint-cli2 "**/*.md"`
- `./scripts/verify_language_spec.py`
- `cargo run --quiet --bin harn -- doctor --no-network`
- `CARGO_TARGET_DIR=/tmp/harn-target ./scripts/release_gate.sh audit` (hits the existing `verify_release_metadata.py` guard because workspace version `0.7.22` is already tagged while this non-release branch is ahead of that tag)
