### PR TITLE
[codex] Implement trigger registry runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,16 @@ granular archaeology.
   quickref coverage. Daemon lifecycle events (Triggered, Snapshotted,
   Stopped, Resumed) continue to flow into run observability at
   enqueue/snapshot/stop/resume boundaries.
+- **Runtime-owned `TriggerRegistry` with lifecycle + versioning (#205,
+  closes #158).** Thread-local registry in `harn_vm::triggers::registry`
+  tracks per-binding state (`active`, `draining`, `removed`),
+  per-binding metrics, and in-flight event counts. Every lifecycle
+  transition logs to the shared `triggers.lifecycle` EventLog topic.
+  `run`, `bench`, ACP, playground, and test execution paths now install
+  manifest triggers into this live registry rather than only validating
+  them. `harn doctor` surfaces the live binding view including
+  provider, state, version, and metrics snapshot. Foundation for
+  hot-reload (T-13) and the handler dispatcher (T-06).
 
 ## v0.7.22
 

--- a/crates/harn-cli/src/acp/execute.rs
+++ b/crates/harn-cli/src/acp/execute.rs
@@ -53,9 +53,9 @@ pub(super) async fn execute_chunk(
     if let Some(path) = source_path {
         let extensions = package::load_runtime_extensions(path);
         package::install_runtime_extensions(&extensions);
-        package::collect_manifest_triggers(&mut vm, &extensions)
+        package::install_manifest_triggers(&mut vm, &extensions)
             .await
-            .map_err(|error| format!("failed to validate manifest triggers: {error}"))?;
+            .map_err(|error| format!("failed to install manifest triggers: {error}"))?;
         package::install_manifest_hooks(&mut vm, &extensions)
             .await
             .map_err(|error| format!("failed to install manifest hooks: {error}"))?;

--- a/crates/harn-cli/src/commands/bench.rs
+++ b/crates/harn-cli/src/commands/bench.rs
@@ -118,8 +118,8 @@ pub(crate) async fn run_bench(path: &str, iterations: usize) {
                 connect_mcp_servers(&manifest.mcp, &mut vm).await;
             }
         }
-        if let Err(error) = package::collect_manifest_triggers(&mut vm, &extensions).await {
-            eprintln!("error: failed to validate manifest triggers: {error}");
+        if let Err(error) = package::install_manifest_triggers(&mut vm, &extensions).await {
+            eprintln!("error: failed to install manifest triggers: {error}");
             process::exit(1);
         }
         if let Err(error) = package::install_manifest_hooks(&mut vm, &extensions).await {

--- a/crates/harn-cli/src/commands/doctor.rs
+++ b/crates/harn-cli/src/commands/doctor.rs
@@ -267,21 +267,25 @@ async fn check_manifest() -> Vec<DoctorCheck> {
     if !extensions.triggers.is_empty() {
         let mut vm = harn_vm::Vm::new();
         harn_vm::register_vm_stdlib(&mut vm);
-        match package::collect_manifest_triggers(&mut vm, &extensions).await {
-            Ok(triggers) => {
-                for trigger in triggers {
+        harn_vm::clear_trigger_registry();
+        match package::install_manifest_triggers(&mut vm, &extensions).await {
+            Ok(()) => {
+                for trigger in harn_vm::snapshot_trigger_bindings() {
                     checks.push(DoctorCheck {
                         status: DoctorStatus::Ok,
-                        label: format!("trigger:{}", trigger.config.id),
+                        label: format!("trigger:{}", trigger.id),
                         detail: format!(
-                            "{} via {} handler={} budget={}",
-                            trigger_kind_label(trigger.config.kind),
-                            trigger.config.provider.as_str(),
-                            collected_handler_kind(&trigger.handler),
-                            format_trigger_budget(&trigger.config.budget),
+                            "{} via {} handler={} state={} version={} metrics={}",
+                            trigger.kind,
+                            trigger.provider,
+                            trigger.handler_kind,
+                            trigger.state.as_str(),
+                            trigger.version,
+                            format_trigger_metrics(&trigger.metrics),
                         ),
                     });
                 }
+                harn_vm::clear_trigger_registry();
             }
             Err(error) => checks.push(DoctorCheck {
                 status: DoctorStatus::Fail,
@@ -294,35 +298,11 @@ async fn check_manifest() -> Vec<DoctorCheck> {
     checks
 }
 
-fn trigger_kind_label(kind: package::TriggerKind) -> &'static str {
-    match kind {
-        package::TriggerKind::Webhook => "webhook",
-        package::TriggerKind::Cron => "cron",
-        package::TriggerKind::Poll => "poll",
-        package::TriggerKind::Stream => "stream",
-        package::TriggerKind::Predicate => "predicate",
-        package::TriggerKind::A2aPush => "a2a-push",
-    }
-}
-
-fn collected_handler_kind(handler: &package::CollectedTriggerHandler) -> &'static str {
-    match handler {
-        package::CollectedTriggerHandler::Local { .. } => "local",
-        package::CollectedTriggerHandler::A2a { .. } => "a2a",
-        package::CollectedTriggerHandler::Worker { .. } => "worker",
-    }
-}
-
-fn format_trigger_budget(budget: &package::TriggerBudgetSpec) -> String {
-    let daily = budget
-        .daily_cost_usd
-        .map(|value| format!("${value:.2}/day"))
-        .unwrap_or_else(|| "unbounded".to_string());
-    let concurrency = budget
-        .max_concurrent
-        .map(|value| format!("max {value} concurrent"))
-        .unwrap_or_else(|| "default concurrency".to_string());
-    format!("{daily}, {concurrency}")
+fn format_trigger_metrics(metrics: &harn_vm::TriggerMetricsSnapshot) -> String {
+    format!(
+        "received={} dispatched={} failed={} dlq={} in_flight={}",
+        metrics.received, metrics.dispatched, metrics.failed, metrics.dlq, metrics.in_flight
+    )
 }
 
 fn check_skills() -> Vec<DoctorCheck> {
@@ -703,7 +683,7 @@ fn read_manifest(path: &Path) -> Result<package::Manifest, String> {
 mod tests {
     use super::{
         build_healthcheck_url, check_event_log, check_manifest, find_nearest_manifest,
-        format_trigger_budget, read_manifest, DoctorStatus,
+        format_trigger_metrics, read_manifest, DoctorStatus,
     };
     use harn_vm::llm_config::{AuthEnv, HealthcheckDef, ProviderDef};
 
@@ -777,12 +757,21 @@ mod tests {
     }
 
     #[test]
-    fn format_trigger_budget_renders_limits() {
-        let rendered = format_trigger_budget(&crate::package::TriggerBudgetSpec {
-            daily_cost_usd: Some(5.0),
-            max_concurrent: Some(10),
+    fn format_trigger_metrics_renders_snapshot() {
+        let rendered = format_trigger_metrics(&harn_vm::TriggerMetricsSnapshot {
+            received: 1,
+            dispatched: 2,
+            failed: 3,
+            dlq: 4,
+            in_flight: 5,
+            last_received_ms: None,
+            cost_total_usd_micros: 0,
+            cost_today_usd_micros: 0,
         });
-        assert_eq!(rendered, "$5.00/day, max 10 concurrent");
+        assert_eq!(
+            rendered,
+            "received=1 dispatched=2 failed=3 dlq=4 in_flight=5"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -832,6 +821,8 @@ pub fn on_new_issue(event: TriggerEvent) {
         assert_eq!(trigger.status, DoctorStatus::Ok);
         assert!(trigger.detail.contains("webhook via github"));
         assert!(trigger.detail.contains("handler=local"));
-        assert!(trigger.detail.contains("$5.00/day"));
+        assert!(trigger.detail.contains("state=active"));
+        assert!(trigger.detail.contains("version=1"));
+        assert!(trigger.detail.contains("metrics=received=0"));
     }
 }

--- a/crates/harn-cli/src/commands/playground.rs
+++ b/crates/harn-cli/src/commands/playground.rs
@@ -255,9 +255,9 @@ async fn configured_vm(
             connect_mcp_servers(&manifest.mcp, &mut vm).await;
         }
     }
-    package::collect_manifest_triggers(&mut vm, &extensions)
+    package::install_manifest_triggers(&mut vm, &extensions)
         .await
-        .map_err(|error| format!("failed to validate manifest triggers: {error}"))?;
+        .map_err(|error| format!("failed to install manifest triggers: {error}"))?;
 
     Ok(vm)
 }

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -549,8 +549,8 @@ pub(crate) async fn run_file_with_skill_dirs(
             connect_mcp_servers(&manifest.mcp, &mut vm).await;
         }
     }
-    if let Err(error) = package::collect_manifest_triggers(&mut vm, &extensions).await {
-        eprintln!("error: failed to validate manifest triggers: {error}");
+    if let Err(error) = package::install_manifest_triggers(&mut vm, &extensions).await {
+        eprintln!("error: failed to install manifest triggers: {error}");
         process::exit(1);
     }
     if let Err(error) = package::install_manifest_hooks(&mut vm, &extensions).await {
@@ -818,8 +818,8 @@ pub(crate) async fn run_file_mcp_serve(path: &str, card_source: Option<&str>) {
             connect_mcp_servers(&manifest.mcp, &mut vm).await;
         }
     }
-    if let Err(error) = package::collect_manifest_triggers(&mut vm, &extensions).await {
-        eprintln!("error: failed to validate manifest triggers: {error}");
+    if let Err(error) = package::install_manifest_triggers(&mut vm, &extensions).await {
+        eprintln!("error: failed to install manifest triggers: {error}");
         process::exit(1);
     }
     if let Err(error) = package::install_manifest_hooks(&mut vm, &extensions).await {

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -998,9 +998,9 @@ pub(crate) async fn execute(source: &str, source_path: Option<&Path>) -> Result<
             if let Some(path) = source_path {
                 let extensions = package::load_runtime_extensions(path);
                 package::install_runtime_extensions(&extensions);
-                package::collect_manifest_triggers(&mut vm, &extensions)
+                package::install_manifest_triggers(&mut vm, &extensions)
                     .await
-                    .map_err(|error| format!("failed to validate manifest triggers: {error}"))?;
+                    .map_err(|error| format!("failed to install manifest triggers: {error}"))?;
                 package::install_manifest_hooks(&mut vm, &extensions)
                     .await
                     .map_err(|error| format!("failed to install manifest hooks: {error}"))?;

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -1307,6 +1307,120 @@ pub async fn collect_manifest_triggers(
     Ok(collected)
 }
 
+fn trigger_kind_label(kind: TriggerKind) -> &'static str {
+    match kind {
+        TriggerKind::Webhook => "webhook",
+        TriggerKind::Cron => "cron",
+        TriggerKind::Poll => "poll",
+        TriggerKind::Stream => "stream",
+        TriggerKind::Predicate => "predicate",
+        TriggerKind::A2aPush => "a2a-push",
+    }
+}
+
+fn manifest_trigger_binding_spec(trigger: CollectedManifestTrigger) -> harn_vm::TriggerBindingSpec {
+    let config = trigger.config;
+    let (handler, handler_descriptor) = match trigger.handler {
+        CollectedTriggerHandler::Local { reference, closure } => (
+            harn_vm::TriggerHandlerSpec::Local {
+                raw: reference.raw.clone(),
+                closure,
+            },
+            serde_json::json!({
+                "kind": "local",
+                "raw": reference.raw,
+            }),
+        ),
+        CollectedTriggerHandler::A2a { target } => (
+            harn_vm::TriggerHandlerSpec::A2a {
+                target: target.clone(),
+            },
+            serde_json::json!({
+                "kind": "a2a",
+                "target": target,
+            }),
+        ),
+        CollectedTriggerHandler::Worker { queue } => (
+            harn_vm::TriggerHandlerSpec::Worker {
+                queue: queue.clone(),
+            },
+            serde_json::json!({
+                "kind": "worker",
+                "queue": queue,
+            }),
+        ),
+    };
+
+    let when_raw = trigger
+        .when
+        .as_ref()
+        .map(|predicate| predicate.reference.raw.clone());
+    let when = trigger.when.map(|predicate| harn_vm::TriggerPredicateSpec {
+        raw: predicate.reference.raw,
+        closure: predicate.closure,
+    });
+    let id = config.id.clone();
+    let kind = trigger_kind_label(config.kind).to_string();
+    let provider = config.provider.clone();
+    let match_events = config.match_.events.clone();
+    let dedupe_key = config.dedupe_key.clone();
+    let filter = config.filter.clone();
+    let daily_cost_usd = config.budget.daily_cost_usd;
+    let max_concurrent = config.budget.max_concurrent;
+    let manifest_path = Some(config.manifest_path.clone());
+    let package_name = config.package_name.clone();
+
+    let fingerprint = serde_json::to_string(&serde_json::json!({
+        "id": &id,
+        "kind": &kind,
+        "provider": provider.as_str(),
+        "match": config.match_,
+        "when": when_raw,
+        "handler": handler_descriptor,
+        "dedupe_key": &dedupe_key,
+        "retry": config.retry,
+        "priority": config.priority,
+        "budget": config.budget,
+        "secrets": config.secrets,
+        "filter": &filter,
+        "kind_specific": config.kind_specific,
+        "manifest_path": &manifest_path,
+        "package_name": &package_name,
+    }))
+    .unwrap_or_else(|_| format!("{}:{}:{}", id, kind, provider.as_str()));
+
+    harn_vm::TriggerBindingSpec {
+        id,
+        source: harn_vm::TriggerBindingSource::Manifest,
+        kind,
+        provider,
+        handler,
+        when,
+        match_events,
+        dedupe_key,
+        filter,
+        daily_cost_usd,
+        max_concurrent,
+        manifest_path,
+        package_name,
+        definition_fingerprint: fingerprint,
+    }
+}
+
+pub async fn install_manifest_triggers(
+    vm: &mut harn_vm::Vm,
+    extensions: &RuntimeExtensions,
+) -> Result<(), String> {
+    let collected = collect_manifest_triggers(vm, extensions).await?;
+    let bindings = collected
+        .into_iter()
+        .map(manifest_trigger_binding_spec)
+        .collect();
+    harn_vm::install_manifest_triggers(bindings)
+        .await
+        .map_err(|error| error.to_string())
+}
+
 fn absolutize_check_config_paths(mut config: CheckConfig, manifest_dir: &Path) -> CheckConfig {
     if let Some(path) = config.host_capabilities_path.clone() {
         let candidate = PathBuf::from(&path);

--- a/crates/harn-cli/src/test_runner.rs
+++ b/crates/harn-cli/src/test_runner.rs
@@ -152,9 +152,9 @@ pub async fn run_test_file(
                 crate::skill_loader::install_skills_global(&mut vm, &loaded);
                 let extensions = crate::package::load_runtime_extensions(path);
                 crate::package::install_runtime_extensions(&extensions);
-                crate::package::collect_manifest_triggers(&mut vm, &extensions)
+                crate::package::install_manifest_triggers(&mut vm, &extensions)
                     .await
-                    .map_err(|error| format!("failed to validate manifest triggers: {error}"))?;
+                    .map_err(|error| format!("failed to install manifest triggers: {error}"))?;
                 crate::package::install_manifest_hooks(&mut vm, &extensions)
                     .await
                     .map_err(|error| format!("failed to install manifest hooks: {error}"))?;

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -72,10 +72,14 @@ pub use stdlib::{
 };
 pub use store::register_store_builtins;
 pub use triggers::{
-    redact_headers, register_provider_schema, registered_provider_schema_names,
-    reset_provider_catalog, HeaderRedactionPolicy, ProviderCatalog, ProviderCatalogError,
-    ProviderId, ProviderPayload, ProviderSchema, SignatureStatus, TenantId, TraceId, TriggerEvent,
-    TriggerEventId,
+    begin_in_flight, clear_trigger_registry, drain, dynamic_deregister, dynamic_register,
+    finish_in_flight, install_manifest_triggers, redact_headers, register_provider_schema,
+    registered_provider_schema_names, reset_provider_catalog, snapshot_trigger_bindings,
+    HeaderRedactionPolicy, ProviderCatalog, ProviderCatalogError, ProviderId, ProviderPayload,
+    ProviderSchema, SignatureStatus, TenantId, TraceId, TriggerBindingSnapshot,
+    TriggerBindingSource, TriggerBindingSpec, TriggerDispatchOutcome, TriggerEvent, TriggerEventId,
+    TriggerHandlerSpec, TriggerId, TriggerMetricsSnapshot, TriggerPredicateSpec,
+    TriggerRegistryError, TriggerState,
 };
 pub use value::*;
 pub use vm::*;
@@ -97,6 +101,7 @@ pub fn reset_thread_local_state() {
     event_log::reset_active_event_log();
     stdlib::reset_stdlib_state();
     orchestration::clear_runtime_hooks();
+    triggers::clear_trigger_registry();
     events::reset_event_sinks();
     agent_events::reset_all_sinks();
     agent_sessions::reset_session_store();

--- a/crates/harn-vm/src/triggers/mod.rs
+++ b/crates/harn-vm/src/triggers/mod.rs
@@ -1,4 +1,5 @@
 pub mod event;
+pub mod registry;
 
 pub use event::{
     redact_headers, register_provider_schema, registered_provider_schema_names,
@@ -7,4 +8,10 @@ pub use event::{
     NotionEventPayload, ProviderCatalog, ProviderCatalogError, ProviderId, ProviderPayload,
     ProviderSchema, SignatureStatus, SlackEventPayload, TenantId, TraceId, TriggerEvent,
     TriggerEventId,
+};
+pub use registry::{
+    begin_in_flight, clear_trigger_registry, drain, dynamic_deregister, dynamic_register,
+    finish_in_flight, install_manifest_triggers, snapshot_trigger_bindings, TriggerBindingSnapshot,
+    TriggerBindingSource, TriggerBindingSpec, TriggerDispatchOutcome, TriggerHandlerSpec,
+    TriggerId, TriggerMetricsSnapshot, TriggerPredicateSpec, TriggerRegistryError, TriggerState,
 };

--- a/crates/harn-vm/src/triggers/registry.rs
+++ b/crates/harn-vm/src/triggers/registry.rs
@@ -1,0 +1,935 @@
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::event_log::{active_event_log, AnyEventLog, EventLog, LogEvent, Topic};
+use crate::secrets::{configured_default_chain, SecretProvider};
+use crate::value::VmClosure;
+
+use super::ProviderId;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TriggerId(String);
+
+impl TriggerId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for TriggerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerState {
+    Registering,
+    Active,
+    Draining,
+    Terminated,
+}
+
+impl TriggerState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Registering => "registering",
+            Self::Active => "active",
+            Self::Draining => "draining",
+            Self::Terminated => "terminated",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerBindingSource {
+    Manifest,
+    Dynamic,
+}
+
+impl TriggerBindingSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Manifest => "manifest",
+            Self::Dynamic => "dynamic",
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum TriggerHandlerSpec {
+    Local { raw: String, closure: Rc<VmClosure> },
+    A2a { target: String },
+    Worker { queue: String },
+}
+
+impl std::fmt::Debug for TriggerHandlerSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Local { raw, .. } => f.debug_struct("Local").field("raw", raw).finish(),
+            Self::A2a { target } => f.debug_struct("A2a").field("target", target).finish(),
+            Self::Worker { queue } => f.debug_struct("Worker").field("queue", queue).finish(),
+        }
+    }
+}
+
+impl TriggerHandlerSpec {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Local { .. } => "local",
+            Self::A2a { .. } => "a2a",
+            Self::Worker { .. } => "worker",
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct TriggerPredicateSpec {
+    pub raw: String,
+    pub closure: Rc<VmClosure>,
+}
+
+impl std::fmt::Debug for TriggerPredicateSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TriggerPredicateSpec")
+            .field("raw", &self.raw)
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TriggerBindingSpec {
+    pub id: String,
+    pub source: TriggerBindingSource,
+    pub kind: String,
+    pub provider: ProviderId,
+    pub handler: TriggerHandlerSpec,
+    pub when: Option<TriggerPredicateSpec>,
+    pub match_events: Vec<String>,
+    pub dedupe_key: Option<String>,
+    pub filter: Option<String>,
+    pub daily_cost_usd: Option<f64>,
+    pub max_concurrent: Option<u32>,
+    pub manifest_path: Option<PathBuf>,
+    pub package_name: Option<String>,
+    pub definition_fingerprint: String,
+}
+
+#[derive(Debug)]
+pub struct TriggerMetrics {
+    pub received: AtomicU64,
+    pub dispatched: AtomicU64,
+    pub failed: AtomicU64,
+    pub dlq: AtomicU64,
+    pub last_received_ms: Mutex<Option<i64>>,
+    pub cost_total_usd_micros: AtomicU64,
+    pub cost_today_usd_micros: AtomicU64,
+}
+
+impl Default for TriggerMetrics {
+    fn default() -> Self {
+        Self {
+            received: AtomicU64::new(0),
+            dispatched: AtomicU64::new(0),
+            failed: AtomicU64::new(0),
+            dlq: AtomicU64::new(0),
+            last_received_ms: Mutex::new(None),
+            cost_total_usd_micros: AtomicU64::new(0),
+            cost_today_usd_micros: AtomicU64::new(0),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TriggerMetricsSnapshot {
+    pub received: u64,
+    pub dispatched: u64,
+    pub failed: u64,
+    pub dlq: u64,
+    pub in_flight: u64,
+    pub last_received_ms: Option<i64>,
+    pub cost_total_usd_micros: u64,
+    pub cost_today_usd_micros: u64,
+}
+
+pub struct TriggerBinding {
+    pub id: TriggerId,
+    pub version: u32,
+    pub source: TriggerBindingSource,
+    pub kind: String,
+    pub provider: ProviderId,
+    pub handler: TriggerHandlerSpec,
+    pub when: Option<TriggerPredicateSpec>,
+    pub match_events: Vec<String>,
+    pub dedupe_key: Option<String>,
+    pub filter: Option<String>,
+    pub daily_cost_usd: Option<f64>,
+    pub max_concurrent: Option<u32>,
+    pub manifest_path: Option<PathBuf>,
+    pub package_name: Option<String>,
+    pub definition_fingerprint: String,
+    pub state: Mutex<TriggerState>,
+    pub metrics: TriggerMetrics,
+    pub in_flight: AtomicU64,
+    pub cancel_token: Arc<AtomicBool>,
+}
+
+impl std::fmt::Debug for TriggerBinding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TriggerBinding")
+            .field("id", &self.id)
+            .field("version", &self.version)
+            .field("source", &self.source)
+            .field("kind", &self.kind)
+            .field("provider", &self.provider)
+            .field("handler_kind", &self.handler.kind())
+            .field("state", &self.state_snapshot())
+            .finish()
+    }
+}
+
+impl TriggerBinding {
+    fn new(spec: TriggerBindingSpec, version: u32) -> Self {
+        Self {
+            id: TriggerId::new(spec.id),
+            version,
+            source: spec.source,
+            kind: spec.kind,
+            provider: spec.provider,
+            handler: spec.handler,
+            when: spec.when,
+            match_events: spec.match_events,
+            dedupe_key: spec.dedupe_key,
+            filter: spec.filter,
+            daily_cost_usd: spec.daily_cost_usd,
+            max_concurrent: spec.max_concurrent,
+            manifest_path: spec.manifest_path,
+            package_name: spec.package_name,
+            definition_fingerprint: spec.definition_fingerprint,
+            state: Mutex::new(TriggerState::Registering),
+            metrics: TriggerMetrics::default(),
+            in_flight: AtomicU64::new(0),
+            cancel_token: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn binding_key(&self) -> String {
+        format!("{}@v{}", self.id.as_str(), self.version)
+    }
+
+    pub fn state_snapshot(&self) -> TriggerState {
+        *self.state.lock().expect("trigger state poisoned")
+    }
+
+    pub fn metrics_snapshot(&self) -> TriggerMetricsSnapshot {
+        TriggerMetricsSnapshot {
+            received: self.metrics.received.load(Ordering::Relaxed),
+            dispatched: self.metrics.dispatched.load(Ordering::Relaxed),
+            failed: self.metrics.failed.load(Ordering::Relaxed),
+            dlq: self.metrics.dlq.load(Ordering::Relaxed),
+            in_flight: self.in_flight.load(Ordering::Relaxed),
+            last_received_ms: *self
+                .metrics
+                .last_received_ms
+                .lock()
+                .expect("trigger metrics poisoned"),
+            cost_total_usd_micros: self.metrics.cost_total_usd_micros.load(Ordering::Relaxed),
+            cost_today_usd_micros: self.metrics.cost_today_usd_micros.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TriggerBindingSnapshot {
+    pub id: String,
+    pub version: u32,
+    pub source: TriggerBindingSource,
+    pub kind: String,
+    pub provider: String,
+    pub handler_kind: String,
+    pub state: TriggerState,
+    pub metrics: TriggerMetricsSnapshot,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TriggerDispatchOutcome {
+    Dispatched,
+    Failed,
+    Dlq,
+}
+
+#[derive(Debug)]
+pub enum TriggerRegistryError {
+    DuplicateId(String),
+    InvalidSpec(String),
+    UnknownId(String),
+    UnknownBindingVersion { id: String, version: u32 },
+    EventLog(String),
+}
+
+impl std::fmt::Display for TriggerRegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DuplicateId(id) => write!(f, "duplicate trigger id '{id}'"),
+            Self::InvalidSpec(message) | Self::EventLog(message) => f.write_str(message),
+            Self::UnknownId(id) => write!(f, "unknown trigger id '{id}'"),
+            Self::UnknownBindingVersion { id, version } => {
+                write!(f, "unknown trigger binding '{id}' version {version}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TriggerRegistryError {}
+
+#[derive(Default)]
+pub struct TriggerRegistry {
+    bindings: BTreeMap<String, Vec<Arc<TriggerBinding>>>,
+    by_provider: BTreeMap<String, BTreeSet<String>>,
+    event_log: Option<Arc<AnyEventLog>>,
+    secret_provider: Option<Arc<dyn SecretProvider>>,
+}
+
+thread_local! {
+    static TRIGGER_REGISTRY: RefCell<TriggerRegistry> = RefCell::new(TriggerRegistry::default());
+}
+
+pub fn clear_trigger_registry() {
+    TRIGGER_REGISTRY.with(|slot| {
+        *slot.borrow_mut() = TriggerRegistry::default();
+    });
+}
+
+pub fn snapshot_trigger_bindings() -> Vec<TriggerBindingSnapshot> {
+    TRIGGER_REGISTRY.with(|slot| {
+        let registry = slot.borrow();
+        let mut snapshots = Vec::new();
+        for bindings in registry.bindings.values() {
+            for binding in bindings {
+                snapshots.push(TriggerBindingSnapshot {
+                    id: binding.id.as_str().to_string(),
+                    version: binding.version,
+                    source: binding.source,
+                    kind: binding.kind.clone(),
+                    provider: binding.provider.as_str().to_string(),
+                    handler_kind: binding.handler.kind().to_string(),
+                    state: binding.state_snapshot(),
+                    metrics: binding.metrics_snapshot(),
+                });
+            }
+        }
+        snapshots.sort_by(|left, right| {
+            left.id
+                .cmp(&right.id)
+                .then(left.version.cmp(&right.version))
+                .then(left.state.as_str().cmp(right.state.as_str()))
+        });
+        snapshots
+    })
+}
+
+pub async fn install_manifest_triggers(
+    specs: Vec<TriggerBindingSpec>,
+) -> Result<(), TriggerRegistryError> {
+    let (event_log, events) = TRIGGER_REGISTRY.with(|slot| {
+        let registry = &mut *slot.borrow_mut();
+        registry.refresh_runtime_context();
+
+        let mut incoming = BTreeMap::new();
+        for spec in specs {
+            let spec_id = spec.id.clone();
+            if spec.source != TriggerBindingSource::Manifest {
+                return Err(TriggerRegistryError::InvalidSpec(format!(
+                    "manifest install received non-manifest trigger '{}'",
+                    spec_id
+                )));
+            }
+            if spec_id.trim().is_empty() {
+                return Err(TriggerRegistryError::InvalidSpec(
+                    "manifest trigger id cannot be empty".to_string(),
+                ));
+            }
+            if incoming.insert(spec_id.clone(), spec).is_some() {
+                return Err(TriggerRegistryError::DuplicateId(spec_id));
+            }
+        }
+
+        let mut lifecycle = Vec::new();
+        let existing_ids: Vec<String> = registry
+            .bindings
+            .iter()
+            .filter(|(_, bindings)| {
+                bindings.iter().any(|binding| {
+                    binding.source == TriggerBindingSource::Manifest
+                        && binding.state_snapshot() != TriggerState::Terminated
+                })
+            })
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        for id in existing_ids {
+            let live_manifest = registry.live_bindings(&id, TriggerBindingSource::Manifest);
+            let Some(spec) = incoming.remove(&id) else {
+                for binding in live_manifest {
+                    registry.transition_binding_to_draining(&binding, &mut lifecycle);
+                }
+                continue;
+            };
+
+            let has_matching_active = live_manifest.iter().any(|binding| {
+                binding.definition_fingerprint == spec.definition_fingerprint
+                    && matches!(
+                        binding.state_snapshot(),
+                        TriggerState::Registering | TriggerState::Active
+                    )
+            });
+            if has_matching_active {
+                continue;
+            }
+
+            for binding in live_manifest {
+                registry.transition_binding_to_draining(&binding, &mut lifecycle);
+            }
+
+            let version = registry.next_version_for_id(&id);
+            registry.register_binding(spec, version, &mut lifecycle);
+        }
+
+        for spec in incoming.into_values() {
+            let version = registry.next_version_for_id(&spec.id);
+            registry.register_binding(spec, version, &mut lifecycle);
+        }
+
+        Ok((registry.event_log.clone(), lifecycle))
+    })?;
+
+    append_lifecycle_events(event_log, events).await
+}
+
+pub async fn dynamic_register(
+    mut spec: TriggerBindingSpec,
+) -> Result<TriggerId, TriggerRegistryError> {
+    if spec.id.trim().is_empty() {
+        spec.id = format!("dynamic_trigger_{}", Uuid::now_v7());
+    }
+    spec.source = TriggerBindingSource::Dynamic;
+    let id = spec.id.clone();
+    let (event_log, events) = TRIGGER_REGISTRY.with(|slot| {
+        let registry = &mut *slot.borrow_mut();
+        registry.refresh_runtime_context();
+
+        if registry.bindings.contains_key(id.as_str()) {
+            return Err(TriggerRegistryError::DuplicateId(id.clone()));
+        }
+
+        let mut lifecycle = Vec::new();
+        registry.register_binding(spec, 1, &mut lifecycle);
+        Ok((registry.event_log.clone(), lifecycle))
+    })?;
+
+    append_lifecycle_events(event_log, events).await?;
+    Ok(TriggerId::new(id))
+}
+
+pub async fn dynamic_deregister(id: &str) -> Result<(), TriggerRegistryError> {
+    let (event_log, events) = TRIGGER_REGISTRY.with(|slot| {
+        let registry = &mut *slot.borrow_mut();
+        let live_dynamic = registry.live_bindings(id, TriggerBindingSource::Dynamic);
+        if live_dynamic.is_empty() {
+            return Err(TriggerRegistryError::UnknownId(id.to_string()));
+        }
+
+        let mut lifecycle = Vec::new();
+        for binding in live_dynamic {
+            registry.transition_binding_to_draining(&binding, &mut lifecycle);
+        }
+        Ok((registry.event_log.clone(), lifecycle))
+    })?;
+
+    append_lifecycle_events(event_log, events).await
+}
+
+pub async fn drain(id: &str) -> Result<(), TriggerRegistryError> {
+    let (event_log, events) = TRIGGER_REGISTRY.with(|slot| {
+        let registry = &mut *slot.borrow_mut();
+        let live = registry.live_bindings_any_source(id);
+        if live.is_empty() {
+            return Err(TriggerRegistryError::UnknownId(id.to_string()));
+        }
+
+        let mut lifecycle = Vec::new();
+        for binding in live {
+            registry.transition_binding_to_draining(&binding, &mut lifecycle);
+        }
+        Ok((registry.event_log.clone(), lifecycle))
+    })?;
+
+    append_lifecycle_events(event_log, events).await
+}
+
+pub fn begin_in_flight(id: &str, version: u32) -> Result<(), TriggerRegistryError> {
+    TRIGGER_REGISTRY.with(|slot| {
+        let registry = slot.borrow();
+        let binding = registry.binding(id, version).ok_or_else(|| {
+            TriggerRegistryError::UnknownBindingVersion {
+                id: id.to_string(),
+                version,
+            }
+        })?;
+        match binding.state_snapshot() {
+            TriggerState::Terminated => Err(TriggerRegistryError::InvalidSpec(format!(
+                "trigger binding '{}' version {} is terminated",
+                id, version
+            ))),
+            _ => {
+                binding.in_flight.fetch_add(1, Ordering::Relaxed);
+                binding.metrics.received.fetch_add(1, Ordering::Relaxed);
+                *binding
+                    .metrics
+                    .last_received_ms
+                    .lock()
+                    .expect("trigger metrics poisoned") = Some(now_ms());
+                Ok(())
+            }
+        }
+    })
+}
+
+pub async fn finish_in_flight(
+    id: &str,
+    version: u32,
+    outcome: TriggerDispatchOutcome,
+) -> Result<(), TriggerRegistryError> {
+    let (event_log, events) = TRIGGER_REGISTRY.with(|slot| {
+        let registry = &mut *slot.borrow_mut();
+        let binding = registry.binding(id, version).ok_or_else(|| {
+            TriggerRegistryError::UnknownBindingVersion {
+                id: id.to_string(),
+                version,
+            }
+        })?;
+        let current = binding.in_flight.load(Ordering::Relaxed);
+        if current == 0 {
+            return Err(TriggerRegistryError::InvalidSpec(format!(
+                "trigger binding '{}' version {} has no in-flight events",
+                id, version
+            )));
+        }
+        binding.in_flight.fetch_sub(1, Ordering::Relaxed);
+        match outcome {
+            TriggerDispatchOutcome::Dispatched => {
+                binding.metrics.dispatched.fetch_add(1, Ordering::Relaxed);
+            }
+            TriggerDispatchOutcome::Failed => {
+                binding.metrics.failed.fetch_add(1, Ordering::Relaxed);
+            }
+            TriggerDispatchOutcome::Dlq => {
+                binding.metrics.dlq.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let mut lifecycle = Vec::new();
+        registry.maybe_finalize_draining(&binding, &mut lifecycle);
+        Ok((registry.event_log.clone(), lifecycle))
+    })?;
+
+    append_lifecycle_events(event_log, events).await
+}
+
+impl TriggerRegistry {
+    fn refresh_runtime_context(&mut self) {
+        if self.event_log.is_none() {
+            self.event_log = active_event_log();
+        }
+        if self.secret_provider.is_none() {
+            self.secret_provider = default_secret_provider();
+        }
+    }
+
+    fn binding(&self, id: &str, version: u32) -> Option<Arc<TriggerBinding>> {
+        self.bindings
+            .get(id)
+            .and_then(|bindings| bindings.iter().find(|binding| binding.version == version))
+            .cloned()
+    }
+
+    fn live_bindings(&self, id: &str, source: TriggerBindingSource) -> Vec<Arc<TriggerBinding>> {
+        self.bindings
+            .get(id)
+            .into_iter()
+            .flat_map(|bindings| bindings.iter())
+            .filter(|binding| {
+                binding.source == source && binding.state_snapshot() != TriggerState::Terminated
+            })
+            .cloned()
+            .collect()
+    }
+
+    fn live_bindings_any_source(&self, id: &str) -> Vec<Arc<TriggerBinding>> {
+        self.bindings
+            .get(id)
+            .into_iter()
+            .flat_map(|bindings| bindings.iter())
+            .filter(|binding| binding.state_snapshot() != TriggerState::Terminated)
+            .cloned()
+            .collect()
+    }
+
+    fn next_version_for_id(&self, id: &str) -> u32 {
+        self.bindings
+            .get(id)
+            .into_iter()
+            .flat_map(|bindings| bindings.iter())
+            .map(|binding| binding.version)
+            .max()
+            .unwrap_or(0)
+            + 1
+    }
+
+    #[allow(clippy::arc_with_non_send_sync)]
+    fn register_binding(
+        &mut self,
+        spec: TriggerBindingSpec,
+        version: u32,
+        lifecycle: &mut Vec<LogEvent>,
+    ) -> Arc<TriggerBinding> {
+        let binding = Arc::new(TriggerBinding::new(spec, version));
+        self.by_provider
+            .entry(binding.provider.as_str().to_string())
+            .or_default()
+            .insert(binding.id.as_str().to_string());
+        self.bindings
+            .entry(binding.id.as_str().to_string())
+            .or_default()
+            .push(binding.clone());
+        lifecycle.push(lifecycle_event(&binding, None, TriggerState::Registering));
+        self.transition_binding_state(&binding, TriggerState::Active, lifecycle);
+        binding
+    }
+
+    fn transition_binding_to_draining(
+        &self,
+        binding: &Arc<TriggerBinding>,
+        lifecycle: &mut Vec<LogEvent>,
+    ) {
+        if matches!(binding.state_snapshot(), TriggerState::Terminated) {
+            return;
+        }
+        self.transition_binding_state(binding, TriggerState::Draining, lifecycle);
+        self.maybe_finalize_draining(binding, lifecycle);
+    }
+
+    fn maybe_finalize_draining(
+        &self,
+        binding: &Arc<TriggerBinding>,
+        lifecycle: &mut Vec<LogEvent>,
+    ) {
+        if binding.state_snapshot() == TriggerState::Draining
+            && binding.in_flight.load(Ordering::Relaxed) == 0
+        {
+            self.transition_binding_state(binding, TriggerState::Terminated, lifecycle);
+        }
+    }
+
+    fn transition_binding_state(
+        &self,
+        binding: &Arc<TriggerBinding>,
+        next: TriggerState,
+        lifecycle: &mut Vec<LogEvent>,
+    ) {
+        let mut state = binding.state.lock().expect("trigger state poisoned");
+        let previous = *state;
+        if previous == next {
+            return;
+        }
+        *state = next;
+        drop(state);
+        lifecycle.push(lifecycle_event(binding, Some(previous), next));
+    }
+}
+
+fn lifecycle_event(
+    binding: &TriggerBinding,
+    from_state: Option<TriggerState>,
+    to_state: TriggerState,
+) -> LogEvent {
+    LogEvent::new(
+        "state_transition",
+        serde_json::json!({
+            "id": binding.id.as_str(),
+            "binding_key": binding.binding_key(),
+            "version": binding.version,
+            "provider": binding.provider.as_str(),
+            "kind": &binding.kind,
+            "source": binding.source.as_str(),
+            "handler_kind": binding.handler.kind(),
+            "from_state": from_state.map(TriggerState::as_str),
+            "to_state": to_state.as_str(),
+        }),
+    )
+}
+
+async fn append_lifecycle_events(
+    event_log: Option<Arc<AnyEventLog>>,
+    events: Vec<LogEvent>,
+) -> Result<(), TriggerRegistryError> {
+    let Some(event_log) = event_log else {
+        return Ok(());
+    };
+    if events.is_empty() {
+        return Ok(());
+    }
+
+    let topic = Topic::new("triggers.lifecycle")
+        .expect("static triggers.lifecycle topic should always be valid");
+    for event in events {
+        event_log
+            .append(&topic, event)
+            .await
+            .map_err(|error| TriggerRegistryError::EventLog(error.to_string()))?;
+    }
+    Ok(())
+}
+
+fn default_secret_provider() -> Option<Arc<dyn SecretProvider>> {
+    configured_default_chain(default_secret_namespace())
+        .ok()
+        .map(|provider| Arc::new(provider) as Arc<dyn SecretProvider>)
+}
+
+fn default_secret_namespace() -> String {
+    if let Ok(namespace) = std::env::var("HARN_SECRET_NAMESPACE") {
+        if !namespace.trim().is_empty() {
+            return namespace;
+        }
+    }
+
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let leaf = cwd
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("workspace");
+    format!("harn/{leaf}")
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event_log::{install_default_for_base_dir, reset_active_event_log};
+
+    fn manifest_spec(id: &str, fingerprint: &str) -> TriggerBindingSpec {
+        TriggerBindingSpec {
+            id: id.to_string(),
+            source: TriggerBindingSource::Manifest,
+            kind: "webhook".to_string(),
+            provider: ProviderId::from("github"),
+            handler: TriggerHandlerSpec::Worker {
+                queue: format!("{id}-queue"),
+            },
+            when: None,
+            match_events: vec!["issues.opened".to_string()],
+            dedupe_key: Some("event.dedupe_key".to_string()),
+            filter: Some("event.kind".to_string()),
+            daily_cost_usd: Some(5.0),
+            max_concurrent: Some(10),
+            manifest_path: None,
+            package_name: Some("workspace".to_string()),
+            definition_fingerprint: fingerprint.to_string(),
+        }
+    }
+
+    fn dynamic_spec(id: &str) -> TriggerBindingSpec {
+        TriggerBindingSpec {
+            id: id.to_string(),
+            source: TriggerBindingSource::Dynamic,
+            kind: "webhook".to_string(),
+            provider: ProviderId::from("github"),
+            handler: TriggerHandlerSpec::Worker {
+                queue: format!("{id}-queue"),
+            },
+            when: None,
+            match_events: vec!["issues.opened".to_string()],
+            dedupe_key: None,
+            filter: None,
+            daily_cost_usd: None,
+            max_concurrent: None,
+            manifest_path: None,
+            package_name: None,
+            definition_fingerprint: format!("dynamic:{id}"),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn manifest_loaded_trigger_registers_with_zeroed_metrics() {
+        clear_trigger_registry();
+
+        install_manifest_triggers(vec![manifest_spec("github-new-issue", "v1")])
+            .await
+            .expect("manifest trigger installs");
+
+        let snapshots = snapshot_trigger_bindings();
+        assert_eq!(snapshots.len(), 1);
+        let binding = &snapshots[0];
+        assert_eq!(binding.id, "github-new-issue");
+        assert_eq!(binding.version, 1);
+        assert_eq!(binding.state, TriggerState::Active);
+        assert_eq!(binding.metrics, TriggerMetricsSnapshot::default());
+
+        clear_trigger_registry();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dynamic_register_assigns_unique_ids_and_rejects_duplicates() {
+        clear_trigger_registry();
+
+        let first = dynamic_register(dynamic_spec("dynamic-a"))
+            .await
+            .expect("first dynamic trigger");
+        let second = dynamic_register(dynamic_spec("dynamic-b"))
+            .await
+            .expect("second dynamic trigger");
+        assert_ne!(first, second);
+
+        let error = dynamic_register(dynamic_spec("dynamic-a"))
+            .await
+            .expect_err("duplicate id should fail");
+        assert!(matches!(error, TriggerRegistryError::DuplicateId(_)));
+
+        clear_trigger_registry();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn drain_waits_for_in_flight_events_before_terminating() {
+        clear_trigger_registry();
+
+        install_manifest_triggers(vec![manifest_spec("github-new-issue", "v1")])
+            .await
+            .expect("manifest trigger installs");
+        begin_in_flight("github-new-issue", 1).expect("start in-flight event");
+
+        drain("github-new-issue").await.expect("drain succeeds");
+        let binding = snapshot_trigger_bindings()
+            .into_iter()
+            .find(|binding| binding.id == "github-new-issue" && binding.version == 1)
+            .expect("binding snapshot");
+        assert_eq!(binding.state, TriggerState::Draining);
+        assert_eq!(binding.metrics.in_flight, 1);
+
+        finish_in_flight("github-new-issue", 1, TriggerDispatchOutcome::Dispatched)
+            .await
+            .expect("finish in-flight event");
+        let binding = snapshot_trigger_bindings()
+            .into_iter()
+            .find(|binding| binding.id == "github-new-issue" && binding.version == 1)
+            .expect("binding snapshot");
+        assert_eq!(binding.state, TriggerState::Terminated);
+        assert_eq!(binding.metrics.in_flight, 0);
+
+        clear_trigger_registry();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn hot_reload_registers_new_version_while_old_binding_drains() {
+        clear_trigger_registry();
+
+        install_manifest_triggers(vec![manifest_spec("github-new-issue", "v1")])
+            .await
+            .expect("initial manifest trigger installs");
+        begin_in_flight("github-new-issue", 1).expect("start in-flight event");
+
+        install_manifest_triggers(vec![manifest_spec("github-new-issue", "v2")])
+            .await
+            .expect("updated manifest trigger installs");
+
+        let snapshots = snapshot_trigger_bindings();
+        assert_eq!(snapshots.len(), 2);
+        let old = snapshots
+            .iter()
+            .find(|binding| binding.id == "github-new-issue" && binding.version == 1)
+            .expect("old binding");
+        let new = snapshots
+            .iter()
+            .find(|binding| binding.id == "github-new-issue" && binding.version == 2)
+            .expect("new binding");
+        assert_eq!(old.state, TriggerState::Draining);
+        assert_eq!(new.state, TriggerState::Active);
+
+        finish_in_flight("github-new-issue", 1, TriggerDispatchOutcome::Dispatched)
+            .await
+            .expect("finish old in-flight event");
+        let old = snapshot_trigger_bindings()
+            .into_iter()
+            .find(|binding| binding.id == "github-new-issue" && binding.version == 1)
+            .expect("old binding");
+        assert_eq!(old.state, TriggerState::Terminated);
+
+        clear_trigger_registry();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn lifecycle_transitions_append_to_event_log() {
+        clear_trigger_registry();
+        reset_active_event_log();
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let log = install_default_for_base_dir(tempdir.path()).expect("install event log");
+
+        install_manifest_triggers(vec![manifest_spec("github-new-issue", "v1")])
+            .await
+            .expect("manifest trigger installs");
+        begin_in_flight("github-new-issue", 1).expect("start in-flight event");
+        drain("github-new-issue").await.expect("drain succeeds");
+        finish_in_flight("github-new-issue", 1, TriggerDispatchOutcome::Dispatched)
+            .await
+            .expect("finish event");
+
+        let topic = Topic::new("triggers.lifecycle").expect("valid lifecycle topic");
+        let events = log
+            .read_range(&topic, None, 32)
+            .await
+            .expect("read lifecycle events");
+        let states: Vec<String> = events
+            .into_iter()
+            .filter_map(|(_, event)| {
+                event
+                    .payload
+                    .get("to_state")
+                    .and_then(|value| value.as_str())
+                    .map(|value| value.to_string())
+            })
+            .collect();
+        assert_eq!(
+            states,
+            vec![
+                "registering".to_string(),
+                "active".to_string(),
+                "draining".to_string(),
+                "terminated".to_string(),
+            ]
+        );
+
+        reset_active_event_log();
+        clear_trigger_registry();
+    }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -29,6 +29,7 @@
 - [Trigger event schema](./triggers/event-schema.md)
 - [Trigger observability in the action graph](./observability/triggers-in-action-graph.md)
 - [Connector authoring](./connectors/authoring.md)
+- [Trigger registry](./triggers/registry.md)
 - [Cookbook](./cookbook.md)
 - [Tutorial: code review agent](./tutorial-code-review-agent.md)
 - [Tutorial: MCP server](./tutorial-mcp-server.md)

--- a/docs/src/triggers/registry.md
+++ b/docs/src/triggers/registry.md
@@ -1,0 +1,81 @@
+# Trigger registry
+
+The trigger registry is the runtime-owned binding table that turns
+validated `[[triggers]]` manifest entries into live, versioned trigger
+bindings inside a VM thread.
+
+## Ownership model
+
+- The registry is thread-local, following the same pattern as the
+  runtime hook table. Each VM thread owns its own bindings and does not
+  share `Rc<VmClosure>` values across threads.
+- Cross-thread coordination is pushed down to the event-log layer. The
+  trigger registry only tracks the bindings that the current VM can
+  execute.
+- Manifest parsing and validation still live in `harn-cli`. Once
+  handlers and predicates resolve, the CLI passes a compact binding spec
+  into `harn-vm`, which owns lifecycle and metrics.
+
+## Binding shape
+
+Each live binding stores:
+
+- logical trigger id
+- monotonically increasing version
+- provider and trigger kind
+- resolved handler target (`local`, `a2a`, or `worker`)
+- optional resolved `when` predicate
+- lifecycle state: `registering`, `active`, `draining`, `terminated`
+- metrics snapshot: `received`, `dispatched`, `failed`, `dlq`,
+  `in_flight`, and last-received timestamp
+- manifest provenance for diagnostics
+
+Hot reload keeps the logical id stable and bumps the binding version
+whenever the manifest definition fingerprint changes.
+
+## Lifecycle
+
+Manifest install performs a reconcile step against the current
+thread-local registry:
+
+1. New trigger id: register version `1`, emit `registering`, then
+   `active`.
+2. Existing trigger id with unchanged definition: keep the current
+   active binding.
+3. Existing trigger id with changed definition: mark the old binding
+   `draining`, register a new active version, and keep both bindings
+   visible until the old version reaches `in_flight == 0`.
+4. Removed manifest trigger: mark the live binding `draining`. Once
+   `in_flight == 0`, it transitions to `terminated`.
+
+Dynamic registrations follow the same state machine, but they are not
+reconciled by manifest reload.
+
+## Metrics and draining
+
+- `begin_in_flight(id, version)` increments `received` and `in_flight`
+  and updates `last_received_ms`.
+- `finish_in_flight(id, version, outcome)` decrements `in_flight` and
+  increments one of `dispatched`, `failed`, or `dlq`.
+- A draining binding becomes terminated only after the in-flight count
+  returns to zero.
+
+This keeps hot reload safe: events that started under version `N`
+complete under version `N`, while new events route to version `N+1`.
+
+## Event-log integration
+
+When an active event log is installed for the VM thread, every lifecycle
+transition appends a record to the `triggers.lifecycle` topic. The event
+payload includes:
+
+- logical trigger id
+- `id@vN` binding key
+- provider
+- trigger kind
+- handler kind
+- transition `from_state` and `to_state`
+
+`harn doctor` uses the installed registry snapshot to report the live
+bindings it sees after manifest load, including state, version, and
+zeroed metrics for newly installed triggers.


### PR DESCRIPTION
## Summary

Implements #158 by adding a thread-local `TriggerRegistry` to `harn-vm` and wiring manifest-backed trigger installation through the existing package loader paths.

This change:
- adds a versioned runtime trigger registry with lifecycle state, per-binding metrics, and in-flight tracking
- logs every registry lifecycle transition to the shared `triggers.lifecycle` event-log topic when a runtime event log is active
- installs manifest triggers at startup across `run`, `bench`, ACP, playground, and test execution instead of only validating them
- updates `harn doctor` to report live trigger bindings with provider, state, version, and metrics snapshots
- documents the registry architecture in `docs/src/triggers/registry.md`

## Why

`#158` is the runtime half of the trigger substrate: once `[[triggers]]` declarations can be parsed and resolved, the VM still needs a runtime-owned binding table that can hot-reload safely, preserve in-flight work under old versions, and expose observable lifecycle state.

This branch also folds in the `#156` manifest-overlay dependency from `main` so the registry can be wired end-to-end without stacking on an unmerged branch.

## Developer impact

Trigger manifests now install into a real VM registry rather than stopping at validation. Runtime code can inspect trigger bindings through the exported registry APIs, dynamic registrations can be added and drained programmatically, and `harn doctor` now shows the live binding view the VM sees after manifest load.

## Validation

- `env CARGO_TARGET_DIR=/tmp/harn-issue158-target cargo test -p harn-vm triggers::registry -- --nocapture`
- `env CARGO_TARGET_DIR=/tmp/harn-issue158-target cargo test -p harn-cli`
- `env CARGO_TARGET_DIR=/tmp/harn-issue158-target cargo run -p harn-cli --bin harn -- doctor --no-network` in `examples/triggers/github-new-issue`
- repo pre-commit and pre-push hooks passed, including clippy, markdown lint, portal lint, and the fast release-quality gate

Closes #158.
Closes #156.
