### PR TITLE
Migrate docs URLs from harn.burincode.com to harnlang.com [BLOCKED on domain live]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ granular archaeology.
 
 ## Unreleased
 
+### Changed
+
+- **Primary Harn docs site moved from `harn.burincode.com` to
+  `harnlang.com`.** The burin-code-subdomain was always a stopgap;
+  `harnlang.com` reflects Harn's identity as a standalone programming
+  language + runtime (precedent: `rust-lang.org`, `elixir-lang.org`).
+  `harn.burincode.com` continues to 301 → `harnlang.com` for 12+
+  months to preserve external links (crates.io metadata, blog posts,
+  cached search results). References in CLI help text, README, docs,
+  skill registry examples, CLAUDE.md, and conformance fixtures all
+  point at the new domain.
+
 ### Fixed
 
 - **Flaky cwd-mutating test collisions (#204).** Added a shared-process

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ table (including `schema_retries` + `provider: "auto"`), and the
 gotchas that repeatedly trip up first-time scripters.
 
 - In-repo: `docs/llm/harn-quickref.md`
-- Canonical URL: <https://harn.burincode.com/docs/llm/harn-quickref.md>
+- Canonical URL: <https://harnlang.com/docs/llm/harn-quickref.md>
 
 Claude Code users get this autoloaded via the `harn-scripting` skill
 at `.claude/skills/harn-scripting/SKILL.md`.

--- a/conformance/helpers/mcp_test_card.json
+++ b/conformance/helpers/mcp_test_card.json
@@ -14,6 +14,6 @@
   ],
   "publisher": {
     "name": "Harn conformance suite",
-    "url": "https://harn.burincode.com"
+    "url": "https://harnlang.com"
   }
 }

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -35,7 +35,7 @@ CONCURRENCY
       - parallel N            — N-way fan-out
       - with { max_concurrent: N }  — cap in-flight workers
       - channels, retry, select
-    https://harn.burincode.com/concurrency.html
+    https://harnlang.com/concurrency.html
 
 LLM THROTTLING
     Providers can be rate-limited via `rpm:` in harn.toml / providers.toml
@@ -43,9 +43,9 @@ LLM THROTTLING
     (RPM); `max_concurrent` on `parallel` caps simultaneous in-flight jobs.
 
 SCRIPTING
-    LLM-readable one-pager: https://harn.burincode.com/docs/llm/harn-quickref.md
-    Human cheatsheet:       https://harn.burincode.com/scripting-cheatsheet.html
-    Full docs:              https://harn.burincode.com/
+    LLM-readable one-pager: https://harnlang.com/docs/llm/harn-quickref.md
+    Human cheatsheet:       https://harnlang.com/scripting-cheatsheet.html
+    Full docs:              https://harnlang.com/
 ")]
     Run(RunArgs),
     /// Type-check .harn files or directories without executing them.

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -2091,7 +2091,7 @@ tag = "v1.2.0"
 
 [[skill.source]]
 type = "registry"
-url = "https://skills.harn.burincode.com"
+url = "https://skills.harnlang.com"
 name = "acme/ops"
 "#,
         )

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1,6 +1,6 @@
 # Harn Quick Reference (LLM-friendly)
 
-**Canonical URL:** <https://harn.burincode.com/docs/llm/harn-quickref.md>
+**Canonical URL:** <https://harnlang.com/docs/llm/harn-quickref.md>
 
 This file is a one-pass reference optimized for LLM consumption and
 grep. It covers the syntax, stdlib highlights, concurrency, and the

--- a/docs/src/scripting-cheatsheet.md
+++ b/docs/src/scripting-cheatsheet.md
@@ -2,7 +2,7 @@
 
 A compact, prose-friendly tour of everything you need to write real
 Harn scripts. The companion one-page LLM reference is at
-[`docs/llm/harn-quickref.md`](https://harn.burincode.com/docs/llm/harn-quickref.md)
+[`docs/llm/harn-quickref.md`](https://harnlang.com/docs/llm/harn-quickref.md)
 (outside the mdBook; served as raw Markdown) — they cover the same
 ground with different shapes, and should stay in lockstep. Agents that
 can fetch URLs should prefer the quickref.

--- a/docs/src/skills.md
+++ b/docs/src/skills.md
@@ -236,7 +236,7 @@ tag = "v1.2.0"
 
 [[skill.source]]
 type = "registry"   # reserved, inert until a marketplace exists
-url = "https://skills.harn.burincode.com"
+url = "https://skills.harnlang.com"
 name = "acme/ops"
 ```
 


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until harnlang.com is serving the docs site

This PR is pre-staged for the moment the domain migration human steps
(tracked in [burin-labs/harn-cloud#8](https://github.com/burin-labs/harn-cloud/issues/8))
complete. Merging before harnlang.com is live would break the links
published in any crate release (Cargo.toml homepage, CLI --help,
in-product docs).

**Merge checklist** (verify in order):
- [ ] harn-cloud#8 step 1: harnlang.com registered at Cloudflare
- [ ] harn-cloud#8 step 2: DNS zone active
- [ ] harn-cloud#8 step 3: Render custom-domain wired + TLS issued
- [ ] `curl -I https://harnlang.com/` returns 200
- [ ] `curl -I https://harn.burincode.com/docs/prompt-templating/` returns 301 to harnlang.com (Cloudflare Page Rule in step 4)
- [ ] Then this PR is safe to admin-squash-merge

## Summary

Swaps all 9 occurrences of `harn.burincode.com` to `harnlang.com` across 8 files:

- CHANGELOG.md — new Unreleased `### Changed` entry documenting the move + 12-month redirect commitment
- CLAUDE.md — canonical quickref URL in the "For agents writing Harn scripts" section
- conformance/helpers/mcp_test_card.json — publisher URL in the MCP test card fixture
- crates/harn-cli/src/cli.rs — 4 URLs in CLI `--help` text (concurrency docs, quickref, scripting-cheatsheet, full docs)
- crates/harn-cli/src/package.rs — skill registry URL in an inline example (doc-style code in tests)
- docs/llm/harn-quickref.md — canonical URL header
- docs/src/scripting-cheatsheet.md — companion-doc link to quickref
- docs/src/skills.md — skill registry URL in the `[[skill.source]]` example

`Cargo.toml` `homepage` is already pointing at `https://github.com/burin-labs/harn` — no change needed.

## Why harnlang.com

Precedent: `rust-lang.org`, `elixir-lang.org`, `haskell-lang.org`. Developers searching "harn programming language" expect `harn-lang.*` or `harnlang.*`. The `.burincode.com` subdomain was always a stopgap when Harn lived under the Burin Code umbrella — promoting it to a standalone domain reflects Harn's identity as a standalone typed language + runtime.

`harn.burincode.com` will 301 → `harnlang.com` for 12+ months minimum to preserve crates.io homepage metadata, external blog posts, cached search results, and any in-flight NPM/other metadata.

## Related

- Strategy doc: harn-cloud#8 (private) documents all human-required Cloudflare/Render/DNS steps
- Domain architecture: harnlang.com (OSS), harncloud.com (managed SaaS), harn.run (short-form), burincode.com (IDE, existing)