### PR TITLE
[codex] Fix llm schema contract for OpenRouter Gemini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ granular archaeology.
 
 ## Unreleased
 
+### Fixed
+
+- **Structured-output schema contract for OpenRouter Gemini (#208,
+  closes #206).** Schema-mode `llm_call(...)` no longer returns a
+  success envelope with `data == nil` after prose-only or
+  non-parseable responses. Missing parseable JSON now counts as a
+  schema failure and feeds `schema_retries`. Preserves bare retries
+  when `schema_retry_nudge: false`. Broadens JSON extraction to
+  recover structured output from tagged prose and canonical public
+  output blocks. Maps Harn's `thinking` option onto OpenRouter's
+  `reasoning` request surface (no more "thinking unsupported"
+  warnings there).
+
 ### Added
 
 - **Action-graph observability extended with `trigger` and `predicate`

--- a/conformance/tests/integration/llm_schema_retry.expected
+++ b/conformance/tests/integration/llm_schema_retry.expected
@@ -3,3 +3,7 @@ YES
 true
 true
 1
+YES
+2
+assistant
+true

--- a/conformance/tests/integration/llm_schema_retry.harn
+++ b/conformance/tests/integration/llm_schema_retry.harn
@@ -46,4 +46,46 @@ pipeline default() {
   }
   println(contains(unwrap_err(err), "schema"))
   println(len(llm_mock_calls()))
+
+  // `schema_retry_nudge: false` still retries; it just omits the
+  // corrective user message.
+  llm_mock_clear()
+  llm_mock({text: "Analyzing the task carefully"})
+  llm_mock({text: "{\"verdict\": \"YES\", \"improvement\": \"\"}"})
+  let bare = llm_call(
+    "Grade with bare retry",
+    nil,
+    {
+    provider: "mock",
+    output_schema: schema,
+    output_validation: "error",
+    schema_retries: 1,
+    schema_retry_nudge: false,
+    response_format: "json",
+  },
+  )
+  println(bare.data.verdict)
+  let bare_calls = llm_mock_calls()
+  println(len(bare_calls))
+  let bare_second = bare_calls[1].messages
+  println(bare_second[len(bare_second) - 1].role)
+
+  // Exhausted prose-only retries surface as hard schema failures.
+  llm_mock_clear()
+  llm_mock({text: "Analyzing the user task"})
+  llm_mock({text: "Examining the failed run"})
+  let prose_err = try {
+    llm_call(
+    "Grade prose-only output",
+    nil,
+    {
+    provider: "mock",
+    output_schema: schema,
+    output_validation: "error",
+    schema_retries: 1,
+    response_format: "json",
+  },
+  )
+  }
+  println(contains(unwrap_err(prose_err), "parseable JSON"))
 }

--- a/conformance/tests/integration/llm_schema_retry.harn
+++ b/conformance/tests/integration/llm_schema_retry.harn
@@ -46,7 +46,6 @@ pipeline default() {
   }
   println(contains(unwrap_err(err), "schema"))
   println(len(llm_mock_calls()))
-
   // `schema_retry_nudge: false` still retries; it just omits the
   // corrective user message.
   llm_mock_clear()
@@ -69,7 +68,6 @@ pipeline default() {
   println(len(bare_calls))
   let bare_second = bare_calls[1].messages
   println(bare_second[len(bare_second) - 1].role)
-
   // Exhausted prose-only retries surface as hard schema failures.
   llm_mock_clear()
   llm_mock({text: "Analyzing the user task"})

--- a/crates/harn-vm/src/llm/agent/tests/result_build.rs
+++ b/crates/harn-vm/src/llm/agent/tests/result_build.rs
@@ -69,3 +69,38 @@ fn build_llm_call_result_uses_output_schema_without_response_format_flag() {
         "structured output should populate data"
     );
 }
+
+#[test]
+fn build_llm_call_result_extracts_json_from_tagged_prose() {
+    let mut opts = base_opts(vec![json!({"role": "user", "content": "Return JSON"})]);
+    opts.output_schema = Some(json!({
+        "type": "object",
+        "properties": {
+            "frameworks": {
+                "type": "array",
+                "items": {"type": "string"}
+            }
+        }
+    }));
+
+    let result = LlmResult {
+        text: "<assistant_prose>{\"frameworks\":[\"cargo nextest\"]}</assistant_prose>".to_string(),
+        tool_calls: Vec::new(),
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        model: "mock".to_string(),
+        provider: "mock".to_string(),
+        thinking: None,
+        stop_reason: None,
+        blocks: Vec::new(),
+    };
+
+    let vm_result = build_llm_call_result(&result, &opts);
+    let dict = vm_result.as_dict().expect("dict");
+    assert!(
+        dict.get("data").is_some(),
+        "tagged prose should still populate structured data"
+    );
+}

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -208,14 +208,54 @@ pub(crate) fn build_llm_call_result(
     );
 
     if expects_structured_output(opts) {
-        let json_str = extract_json(&result.text);
-        let parsed = serde_json::from_str::<serde_json::Value>(&json_str)
-            .ok()
-            .map(|jv| json_to_vm_value(&jv));
+        let parsed = structured_output_candidates(result, opts.tools.as_ref())
+            .into_iter()
+            .find_map(|candidate| {
+                let json_str = extract_json(&candidate);
+                serde_json::from_str::<serde_json::Value>(&json_str)
+                    .ok()
+                    .map(|jv| json_to_vm_value(&jv))
+            });
         return vm_build_llm_result(result, parsed, Some(transcript), opts.tools.as_ref());
     }
 
     vm_build_llm_result(result, None, Some(transcript), opts.tools.as_ref())
+}
+
+fn structured_output_candidates(
+    result: &super::api::LlmResult,
+    tools: Option<&crate::value::VmValue>,
+) -> Vec<String> {
+    let mut candidates = Vec::new();
+    push_structured_output_candidate(&mut candidates, result.text.trim().to_string());
+
+    let public_blocks = result
+        .blocks
+        .iter()
+        .filter(|block| {
+            block.get("type").and_then(|value| value.as_str()) == Some("output_text")
+                && block.get("visibility").and_then(|value| value.as_str()) != Some("private")
+        })
+        .filter_map(|block| block.get("text").and_then(|value| value.as_str()))
+        .collect::<String>();
+    push_structured_output_candidate(&mut candidates, public_blocks.trim().to_string());
+
+    let derived = candidates.clone();
+    for candidate in derived {
+        let parsed = crate::llm::tools::parse_text_tool_calls_with_tools(&candidate, tools);
+        if !parsed.prose.is_empty() {
+            push_structured_output_candidate(&mut candidates, parsed.prose.trim().to_string());
+        }
+    }
+
+    candidates
+}
+
+fn push_structured_output_candidate(candidates: &mut Vec<String>, candidate: String) {
+    if candidate.is_empty() || candidates.iter().any(|existing| existing == &candidate) {
+        return;
+    }
+    candidates.push(candidate);
 }
 
 pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::HostBridge>) {

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -632,12 +632,20 @@ fn validate_options(opts: &crate::llm::api::LlmCallOptions) {
                 warn("presence_penalty");
             }
         }
-        "openai" | "openrouter" | "huggingface" | "local" => {
+        "openai" | "huggingface" | "local" => {
             if opts.top_k.is_some() {
                 warn("top_k");
             }
             if opts.thinking.is_some() {
                 warn("thinking");
+            }
+            if opts.cache {
+                warn("cache");
+            }
+        }
+        "openrouter" => {
+            if opts.top_k.is_some() {
+                warn("top_k");
             }
             if opts.cache {
                 warn("cache");

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -201,6 +201,33 @@ fn compute_validation_errors(data: &VmValue, opts: &api::LlmCallOptions) -> Vec<
     schema_validation_errors(&validation)
 }
 
+fn structured_output_errors(result: &VmValue, opts: &api::LlmCallOptions) -> Vec<String> {
+    let Some(dict) = result.as_dict() else {
+        return vec!["structured output result was not a dict".to_string()];
+    };
+    if let Some(data) = dict.get("data") {
+        return compute_validation_errors(data, opts);
+    }
+
+    let mut errors = vec!["response did not contain parseable JSON".to_string()];
+    if let Some(VmValue::List(violations)) = dict.get("protocol_violations") {
+        let joined = violations
+            .iter()
+            .map(VmValue::display)
+            .collect::<Vec<_>>()
+            .join("; ");
+        if !joined.is_empty() {
+            errors.push(format!("protocol violations: {joined}"));
+        }
+    }
+    if let Some(stop_reason) = dict.get("stop_reason").map(VmValue::display) {
+        if matches!(stop_reason.as_str(), "length" | "max_tokens") {
+            errors.push("response hit the token limit before producing complete JSON".to_string());
+        }
+    }
+    errors
+}
+
 /// How `llm_call` should nudge the model when `output_schema` validation
 /// fails and `schema_retries > 0`.
 #[derive(Debug, Clone)]
@@ -366,26 +393,17 @@ pub(crate) async fn execute_llm_call(
 
         // Non-bridge path runs schema validation; bridge path
         // delegates validation to the host.
-        let mut vm_result = agent_config::build_llm_call_result(&result, &opts);
+        let vm_result = agent_config::build_llm_call_result(&result, &opts);
         if !helpers::expects_structured_output(&opts) {
             return Ok(vm_result);
         }
-        let VmValue::Dict(ref dict) = vm_result else {
-            return Ok(vm_result);
-        };
-        let Some(data) = dict.get("data") else {
-            return Ok(vm_result);
-        };
-        let errors = compute_validation_errors(data, &opts);
+        let errors = structured_output_errors(&vm_result, &opts);
         if errors.is_empty() {
-            let mut d = dict.as_ref().clone();
-            d.insert("data".to_string(), data.clone());
-            vm_result = VmValue::Dict(Rc::new(d));
             return Ok(vm_result);
         }
 
         let more_attempts = attempt < schema_retries;
-        let should_retry = more_attempts && !matches!(nudge_mode, SchemaNudge::Disabled);
+        let should_retry = more_attempts;
         if should_retry {
             let nudge = build_schema_nudge(&errors, opts.output_schema.as_ref(), &nudge_mode);
             emit_agent_event(AgentTraceEvent::SchemaRetry {
@@ -934,7 +952,10 @@ fn register_llm_stream(vm: &mut Vm) {
 #[cfg(test)]
 mod tests {
     use super::api::LlmCallOptions;
-    use super::compute_validation_errors;
+    use super::{
+        compute_validation_errors, execute_llm_call, reset_llm_state, structured_output_errors,
+    };
+    use crate::llm::mock;
     use crate::value::VmValue;
     use std::rc::Rc;
 
@@ -996,5 +1017,81 @@ mod tests {
         let errors = compute_validation_errors(&data, &opts);
         assert!(!errors.is_empty(), "schema should fail");
         assert!(errors.join(" ").contains("string"));
+    }
+
+    #[test]
+    fn structured_output_errors_report_missing_json() {
+        let result = VmValue::Dict(Rc::new(std::collections::BTreeMap::from([
+            (
+                "text".to_string(),
+                VmValue::String(Rc::from("Analyzing the task")),
+            ),
+            (
+                "protocol_violations".to_string(),
+                VmValue::List(Rc::new(vec![VmValue::String(Rc::from(
+                    "stray text outside response tags",
+                ))])),
+            ),
+            (
+                "stop_reason".to_string(),
+                VmValue::String(Rc::from("length")),
+            ),
+        ])));
+
+        let errors = structured_output_errors(&result, &base_opts());
+        assert!(errors.iter().any(|err| err.contains("parseable JSON")));
+        assert!(errors.iter().any(|err| err.contains("protocol violations")));
+        assert!(errors.iter().any(|err| err.contains("token limit")));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_llm_call_retries_when_response_has_no_json_data() {
+        reset_llm_state();
+        mock::push_llm_mock(mock::LlmMock {
+            text: "Analyzing the task carefully".to_string(),
+            tool_calls: Vec::new(),
+            match_pattern: None,
+            consume_on_match: false,
+            input_tokens: None,
+            output_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+            thinking: None,
+            stop_reason: None,
+            model: "mock".to_string(),
+            provider: Some("mock".to_string()),
+            blocks: None,
+            error: None,
+        });
+        mock::push_llm_mock(mock::LlmMock {
+            text: "{\"name\":\"Ada\"}".to_string(),
+            tool_calls: Vec::new(),
+            match_pattern: None,
+            consume_on_match: false,
+            input_tokens: None,
+            output_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+            thinking: None,
+            stop_reason: None,
+            model: "mock".to_string(),
+            provider: Some("mock".to_string()),
+            blocks: None,
+            error: None,
+        });
+
+        let response = execute_llm_call(base_opts(), None)
+            .await
+            .expect("structured retry should recover");
+        let dict = response.as_dict().expect("dict response");
+        let data = dict
+            .get("data")
+            .and_then(VmValue::as_dict)
+            .expect("parsed data");
+        assert_eq!(
+            data.get("name").map(VmValue::display).as_deref(),
+            Some("Ada")
+        );
+        assert_eq!(mock::get_llm_mock_calls().len(), 2);
     }
 }

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -2,7 +2,7 @@
 //! DeepSeek, Fireworks, HuggingFace, local vLLM/SGLang, and any server that
 //! speaks the `/v1/chat/completions` protocol.
 
-use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult};
+use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult, ThinkingConfig};
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
 use crate::value::VmError;
 
@@ -159,6 +159,11 @@ impl OpenAiCompatibleProvider {
         if let Some(pp) = opts.presence_penalty {
             body["presence_penalty"] = serde_json::json!(pp);
         }
+        if opts.provider == "openrouter" {
+            if let Some(reasoning) = openrouter_reasoning_config(opts.thinking.as_ref()) {
+                body["reasoning"] = reasoning;
+            }
+        }
         if opts.response_format.as_deref() == Some("json") {
             if let Some(ref schema) = opts.json_schema {
                 body["response_format"] = serde_json::json!({
@@ -214,9 +219,24 @@ impl OpenAiCompatibleProvider {
     }
 }
 
+fn openrouter_reasoning_config(thinking: Option<&ThinkingConfig>) -> Option<serde_json::Value> {
+    match thinking {
+        Some(ThinkingConfig::Enabled) => Some(serde_json::json!({
+            "enabled": true
+        })),
+        Some(ThinkingConfig::WithBudget(max_tokens)) => Some(serde_json::json!({
+            "max_tokens": max_tokens
+        })),
+        None => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::llm::api::LlmRequestPayload;
+    use crate::llm::api::ThinkingConfig;
+    use serde_json::json;
 
     #[test]
     fn tool_search_supported_for_gpt_5_4_and_up() {
@@ -281,5 +301,57 @@ mod tests {
         let provider = OpenAiCompatibleProvider::new("openai".to_string());
         assert!(provider.supports_defer_loading("gpt-5.4"));
         assert!(!provider.supports_defer_loading("gpt-4o"));
+    }
+
+    #[test]
+    fn openrouter_thinking_enabled_maps_to_reasoning_enabled() {
+        let provider = OpenAiCompatibleProvider::new("openrouter".to_string());
+        let mut payload = base_request_payload();
+        payload.thinking = Some(ThinkingConfig::Enabled);
+        let mut body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        provider.transform_request(&mut body);
+
+        assert_eq!(body["reasoning"]["enabled"], true);
+        assert!(body.get("chat_template_kwargs").is_none());
+    }
+
+    #[test]
+    fn openrouter_thinking_budget_maps_to_reasoning_max_tokens() {
+        let provider = OpenAiCompatibleProvider::new("openrouter".to_string());
+        let mut payload = base_request_payload();
+        payload.thinking = Some(ThinkingConfig::WithBudget(2048));
+        let mut body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        provider.transform_request(&mut body);
+
+        assert_eq!(body["reasoning"]["max_tokens"], 2048);
+        assert!(body.get("chat_template_kwargs").is_none());
+    }
+
+    fn base_request_payload() -> LlmRequestPayload {
+        LlmRequestPayload {
+            provider: "openrouter".to_string(),
+            model: "google/gemini-2.5-pro".to_string(),
+            api_key: String::new(),
+            messages: vec![json!({"role": "user", "content": "hello"})],
+            system: None,
+            max_tokens: 64,
+            temperature: Some(0.0),
+            top_p: None,
+            top_k: None,
+            stop: None,
+            seed: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            response_format: None,
+            json_schema: None,
+            thinking: None,
+            native_tools: None,
+            tool_choice: None,
+            cache: false,
+            timeout: None,
+            stream: false,
+            provider_overrides: None,
+            prefill: None,
+        }
     }
 }

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -107,7 +107,7 @@ println(result.text)
 | `presence_penalty` | float | nil | Presence penalty (OpenAI only) |
 | `response_format` | string | `"text"` | `"text"` or `"json"` |
 | `schema` | dict | nil | JSON Schema, OpenAPI Schema Object, or canonical Harn schema dict for structured output |
-| `thinking` | bool/dict | nil | Enable extended reasoning. `true` or `{budget_tokens: N}` |
+| `thinking` | bool/dict | nil | Enable provider reasoning. `true` or `{budget_tokens: N}`. Anthropic maps this to thinking/adaptive thinking, OpenRouter maps it to `reasoning`, and Ollama maps it to `think`. |
 | `tools` | list | nil | Tool definitions |
 | `tool_choice` | string/dict | `"auto"` | `"auto"`, `"none"`, `"required"`, or `{name: "tool"}` |
 | `tool_search` | bool/string/dict | nil | Progressive tool disclosure. See [Tool Vault](#tool-vault) |


### PR DESCRIPTION
## Summary
Fixes #206.

This tightens Harn's structured-output contract so schema-mode `llm_call()` no longer returns a nominal success envelope with `data == nil` after prose-only or non-parseable responses.

## What changed
- Treat missing parseable JSON as a schema failure, so `schema_retries` now retries prose-only / malformed structured responses instead of returning success with `data == nil`.
- Preserve bare retries for `schema_retry_nudge: false` instead of accidentally disabling retries entirely.
- Broaden structured-output extraction to recover JSON from tagged prose and canonical public output blocks before giving up.
- Map Harn's `thinking` option onto OpenRouter's `reasoning` request surface and stop warning that `thinking` is unsupported there.
- Add regression coverage in both Rust unit tests and Harn conformance tests.

## Root cause
The schema retry loop only validated responses when the built result already contained a `data` field. If parsing failed entirely, Harn returned early with a success payload and left it to callers to salvage `visible_text` or fail manually.

## Validation
- `cargo test -p harn-vm llm:: -- --nocapture`
- `cargo run --quiet --bin harn -- test conformance --filter llm_schema_retry`
- repo pre-push hook: nextest + markdown lint + portal lint
