### PR TITLE
Add harn orchestrator serve CLI scaffold (closes #178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ granular archaeology.
 
 ### Added
 
+- **`harn orchestrator serve` CLI scaffold (#178).** Added a new
+  `harn orchestrator` command family with a real `serve`
+  subcommand plus placeholder `inspect`, `replay`, `dlq`, and
+  `queue` subcommands. `serve` now loads `harn.toml`, boots a
+  single-tenant orchestrator VM, installs the shared EventLog under
+  `--state-dir`, resolves the active secret-provider chain, collects
+  manifest triggers, activates placeholder connectors per manifest
+  provider, writes an orchestrator state snapshot, and idles until
+  SIGTERM for scaffolded graceful shutdown. Multi-tenant remains an
+  explicit `O-12 #190` stub; the HTTP listener remains deferred to
+  `O-02 #179`.
 - **Action-graph observability extended with `trigger` and `predicate`
   node kinds (#202, partial #163).** Persisted run records now
   synthesize a `trigger` node from `trigger_event` metadata, render

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ dependencies = [
 name = "harn-cli"
 version = "0.7.22"
 dependencies = [
+ "async-trait",
  "axum",
  "base64",
  "chrono-tz",

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -30,6 +30,7 @@ harn-vm = { path = "../harn-vm", version = "0.7" }
 harn-lint = { path = "../harn-lint", version = "0.7" }
 harn-modules = { path = "../harn-modules", version = "0.7" }
 harn-fmt = { path = "../harn-fmt", version = "0.7" }
+async-trait = "0.1"
 axum = "0.8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "time"] }
 serde_json = "1"

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -1,3 +1,6 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Debug, Parser)]
@@ -73,6 +76,8 @@ SCRIPTING
     Watch(WatchArgs),
     /// Launch the local Harn observability portal.
     Portal(PortalArgs),
+    /// Start the orchestrator process that hosts triggers and connector dispatch.
+    Orchestrator(OrchestratorArgs),
     /// Run a pipeline against a Harn-native host module for fast iteration.
     Playground(PlaygroundArgs),
     /// Inspect persisted workflow run records.
@@ -449,6 +454,46 @@ pub(crate) struct PortalArgs {
 }
 
 #[derive(Debug, Args)]
+pub(crate) struct OrchestratorArgs {
+    #[command(subcommand)]
+    pub command: OrchestratorCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum OrchestratorCommand {
+    /// Load manifests, initialize registries, and idle until shutdown.
+    Serve(OrchestratorServeArgs),
+    /// Inspect orchestrator state.
+    Inspect,
+    /// Replay orchestrator events.
+    Replay,
+    /// Inspect the dead-letter queue.
+    Dlq,
+    /// Inspect trigger and dispatch queues.
+    Queue,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorServeArgs {
+    /// Path to the root `harn.toml` manifest to load.
+    #[arg(long, default_value = "harn.toml", value_name = "PATH")]
+    pub config: PathBuf,
+    /// Directory used for EventLog data and orchestrator state snapshots.
+    #[arg(
+        long = "state-dir",
+        default_value = ".harn/orchestrator",
+        value_name = "PATH"
+    )]
+    pub state_dir: PathBuf,
+    /// Socket address the future HTTP listener will bind to.
+    #[arg(long, default_value = "127.0.0.1:8080", value_name = "ADDR")]
+    pub bind: SocketAddr,
+    /// Runtime role to boot. Multi-tenant is a stub for now.
+    #[arg(long, value_enum, default_value_t = crate::commands::orchestrator::role::OrchestratorRole::SingleTenant)]
+    pub role: crate::commands::orchestrator::role::OrchestratorRole,
+}
+
+#[derive(Debug, Args)]
 pub(crate) struct PlaygroundArgs {
     /// Host module exporting the capabilities the script expects.
     #[arg(long, default_value = "host.harn")]
@@ -656,7 +701,11 @@ pub(crate) struct SkillsNewArgs {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Command, McpCommand, ProjectTemplate, RunsCommand, SkillsCommand};
+    use std::path::PathBuf;
+
+    use super::{
+        Cli, Command, McpCommand, OrchestratorCommand, ProjectTemplate, RunsCommand, SkillsCommand,
+    };
     use clap::Parser;
 
     #[test]
@@ -772,6 +821,37 @@ mod tests {
         assert_eq!(args.host, "0.0.0.0");
         assert_eq!(args.port, 4900);
         assert!(!args.open);
+    }
+
+    #[test]
+    fn test_parses_orchestrator_serve_args() {
+        let cli = Cli::parse_from([
+            "harn",
+            "orchestrator",
+            "serve",
+            "--config",
+            "workspace/harn.toml",
+            "--state-dir",
+            "state/orchestrator",
+            "--bind",
+            "0.0.0.0:8080",
+            "--role",
+            "single-tenant",
+        ]);
+
+        let Command::Orchestrator(args) = cli.command.unwrap() else {
+            panic!("expected orchestrator command");
+        };
+        let OrchestratorCommand::Serve(serve) = args.command else {
+            panic!("expected orchestrator serve");
+        };
+        assert_eq!(serve.config, PathBuf::from("workspace/harn.toml"));
+        assert_eq!(serve.state_dir, PathBuf::from("state/orchestrator"));
+        assert_eq!(serve.bind.to_string(), "0.0.0.0:8080");
+        assert_eq!(
+            serve.role,
+            crate::commands::orchestrator::role::OrchestratorRole::SingleTenant
+        );
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod doctor;
 pub(crate) mod dump_highlight_keywords;
 pub(crate) mod init;
 pub(crate) mod mcp;
+pub(crate) mod orchestrator;
 pub(crate) mod playground;
 pub(crate) mod portal;
 pub(crate) mod repl;

--- a/crates/harn-cli/src/commands/orchestrator/mod.rs
+++ b/crates/harn-cli/src/commands/orchestrator/mod.rs
@@ -1,0 +1,24 @@
+pub(crate) mod role;
+mod serve;
+
+use crate::cli::{OrchestratorArgs, OrchestratorCommand};
+
+const O08_NOT_IMPLEMENTED: &str = "not yet implemented (see O-08 #185)";
+
+pub(crate) async fn handle(args: OrchestratorArgs) -> Result<(), String> {
+    match args.command {
+        OrchestratorCommand::Serve(serve_args) => serve::run(serve_args).await,
+        OrchestratorCommand::Inspect => Err(format!(
+            "`harn orchestrator inspect` is {O08_NOT_IMPLEMENTED}"
+        )),
+        OrchestratorCommand::Replay => Err(format!(
+            "`harn orchestrator replay` is {O08_NOT_IMPLEMENTED}"
+        )),
+        OrchestratorCommand::Dlq => {
+            Err(format!("`harn orchestrator dlq` is {O08_NOT_IMPLEMENTED}"))
+        }
+        OrchestratorCommand::Queue => Err(format!(
+            "`harn orchestrator queue` is {O08_NOT_IMPLEMENTED}"
+        )),
+    }
+}

--- a/crates/harn-cli/src/commands/orchestrator/role.rs
+++ b/crates/harn-cli/src/commands/orchestrator/role.rs
@@ -1,0 +1,53 @@
+use std::path::Path;
+
+use clap::ValueEnum;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub(crate) enum OrchestratorRole {
+    SingleTenant,
+    MultiTenant,
+}
+
+impl OrchestratorRole {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::SingleTenant => "single-tenant",
+            Self::MultiTenant => "multi-tenant",
+        }
+    }
+
+    pub(crate) fn registry_mode(self) -> &'static str {
+        match self {
+            Self::SingleTenant => "one shared trigger/connector registry",
+            Self::MultiTenant => "per-tenant registries",
+        }
+    }
+
+    pub(crate) fn build_vm(
+        self,
+        workspace_root: &Path,
+        source_dir: &Path,
+        state_dir: &Path,
+    ) -> Result<harn_vm::Vm, String> {
+        match self {
+            Self::SingleTenant => {
+                std::env::set_var(
+                    harn_vm::runtime_paths::HARN_STATE_DIR_ENV,
+                    state_dir.display().to_string(),
+                );
+                let mut vm = harn_vm::Vm::new();
+                harn_vm::register_vm_stdlib(&mut vm);
+                harn_vm::register_store_builtins(&mut vm, workspace_root);
+                harn_vm::register_metadata_builtins(&mut vm, workspace_root);
+                harn_vm::register_checkpoint_builtins(&mut vm, workspace_root, "orchestrator");
+                vm.set_project_root(workspace_root);
+                vm.set_source_dir(source_dir);
+                Ok(vm)
+            }
+            Self::MultiTenant => Err(
+                "multi-tenant orchestrator role is not yet implemented (see O-12 #190)".to_string(),
+            ),
+        }
+    }
+}

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -1,0 +1,592 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::Serialize;
+use serde_json::{json, Value as JsonValue};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use harn_vm::event_log::EventLog;
+
+use crate::cli::OrchestratorServeArgs;
+use crate::commands::orchestrator::role::OrchestratorRole;
+use crate::package::{
+    self, CollectedManifestTrigger, CollectedTriggerHandler, Manifest, ResolvedTriggerConfig,
+};
+
+const HTTP_LISTENER_STUB: &str = "HTTP listener not yet implemented (see O-02 #179)";
+const LIFECYCLE_TOPIC: &str = "orchestrator.lifecycle";
+const STATE_SNAPSHOT_FILE: &str = "orchestrator-state.json";
+
+pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
+    harn_vm::reset_thread_local_state();
+
+    let config_path = absolutize_from_cwd(&args.config)?;
+    let (manifest, manifest_dir) = load_manifest(&config_path)?;
+    let state_dir = absolutize_from_cwd(&args.state_dir)?;
+    std::fs::create_dir_all(&state_dir).map_err(|error| {
+        format!(
+            "failed to create state dir {}: {error}",
+            state_dir.display()
+        )
+    })?;
+
+    let workspace_root = manifest_dir.clone();
+    let startup_started_at = now_rfc3339()?;
+
+    eprintln!("[harn] orchestrator manifest: {}", config_path.display());
+    if let Some(name) = manifest
+        .package
+        .as_ref()
+        .and_then(|package| package.name.as_deref())
+    {
+        eprintln!("[harn] orchestrator package: {name}");
+    }
+    eprintln!(
+        "[harn] orchestrator role: {} ({})",
+        args.role.as_str(),
+        args.role.registry_mode()
+    );
+    eprintln!("[harn] orchestrator state dir: {}", state_dir.display());
+
+    let mut vm = args
+        .role
+        .build_vm(&workspace_root, &manifest_dir, &state_dir)?;
+
+    let event_log = harn_vm::event_log::active_event_log()
+        .ok_or_else(|| "event log was not installed during VM initialization".to_string())?;
+    let event_log_description = event_log.describe();
+    eprintln!(
+        "[harn] event log: {} {}",
+        event_log_description.backend,
+        event_log_description
+            .location
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "<memory>".to_string())
+    );
+
+    let secret_namespace = secret_namespace_for(&manifest_dir);
+    let secret_chain_display = configured_secret_chain_display();
+    let secret_chain = harn_vm::secrets::configured_default_chain(secret_namespace.clone())
+        .map_err(|error| format!("failed to configure secret providers: {error}"))?;
+    if secret_chain.providers().is_empty() {
+        return Err("secret provider chain resolved to zero providers".to_string());
+    }
+    eprintln!(
+        "[harn] secret providers: {} (namespace {})",
+        secret_chain_display, secret_namespace
+    );
+    let secret_provider: Arc<dyn harn_vm::secrets::SecretProvider> = Arc::new(secret_chain);
+
+    let extensions = package::load_runtime_extensions(&config_path);
+    let collected_triggers = package::collect_manifest_triggers(&mut vm, &extensions)
+        .await
+        .map_err(|error| format!("failed to collect manifest triggers: {error}"))?;
+    eprintln!(
+        "[harn] registered triggers ({}): {}",
+        collected_triggers.len(),
+        format_trigger_summary(&collected_triggers)
+    );
+
+    let connector_runtime = initialize_connectors(
+        &collected_triggers,
+        event_log.clone(),
+        secret_provider.clone(),
+    )
+    .await?;
+    eprintln!(
+        "[harn] registered connectors ({}): {}",
+        connector_runtime.providers.len(),
+        connector_runtime.providers.join(", ")
+    );
+    eprintln!(
+        "[harn] activated connectors: {}",
+        format_activation_summary(&connector_runtime.activations)
+    );
+
+    write_state_snapshot(
+        &state_dir.join(STATE_SNAPSHOT_FILE),
+        &ServeStateSnapshot {
+            status: "running".to_string(),
+            role: args.role.as_str().to_string(),
+            bind: args.bind.to_string(),
+            manifest_path: config_path.display().to_string(),
+            state_dir: state_dir.display().to_string(),
+            started_at: startup_started_at.clone(),
+            stopped_at: None,
+            secret_provider_chain: secret_chain_display.clone(),
+            event_log_backend: event_log_description.backend.to_string(),
+            event_log_location: event_log_description
+                .location
+                .as_ref()
+                .map(|path| path.display().to_string()),
+            triggers: collected_triggers
+                .iter()
+                .map(|trigger| TriggerStateSnapshot {
+                    id: trigger.config.id.clone(),
+                    provider: trigger.config.provider.as_str().to_string(),
+                    kind: trigger_kind_name(trigger.config.kind).to_string(),
+                    handler: handler_kind(&trigger.handler).to_string(),
+                })
+                .collect(),
+            connectors: connector_runtime.providers.clone(),
+            activations: connector_runtime
+                .activations
+                .iter()
+                .map(|activation| ConnectorActivationSnapshot {
+                    provider: activation.provider.as_str().to_string(),
+                    binding_count: activation.binding_count,
+                })
+                .collect(),
+        },
+    )?;
+
+    append_lifecycle_event(
+        &event_log,
+        "startup",
+        json!({
+            "bind": args.bind.to_string(),
+            "manifest": config_path.display().to_string(),
+            "role": args.role.as_str(),
+            "state_dir": state_dir.display().to_string(),
+            "trigger_count": collected_triggers.len(),
+            "connector_count": connector_runtime.providers.len(),
+        }),
+    )
+    .await?;
+
+    eprintln!("[harn] {HTTP_LISTENER_STUB}; requested bind {}", args.bind);
+    wait_for_termination_signal().await?;
+
+    graceful_shutdown(GracefulShutdownCtx {
+        role: args.role,
+        bind: args.bind,
+        config_path: &config_path,
+        state_dir: &state_dir,
+        startup_started_at: &startup_started_at,
+        event_log: &event_log,
+        event_log_description: &event_log_description,
+        secret_chain_display: &secret_chain_display,
+        triggers: &collected_triggers,
+        connectors: &connector_runtime,
+    })
+    .await
+}
+
+struct ConnectorRuntime {
+    _registry: harn_vm::ConnectorRegistry,
+    providers: Vec<String>,
+    activations: Vec<harn_vm::ActivationHandle>,
+}
+
+async fn initialize_connectors(
+    triggers: &[CollectedManifestTrigger],
+    event_log: Arc<harn_vm::event_log::AnyEventLog>,
+    secrets: Arc<dyn harn_vm::secrets::SecretProvider>,
+) -> Result<ConnectorRuntime, String> {
+    let mut registry = harn_vm::ConnectorRegistry::default();
+    let mut trigger_registry = harn_vm::TriggerRegistry::default();
+    let mut grouped_kinds: BTreeMap<harn_vm::ProviderId, BTreeSet<String>> = BTreeMap::new();
+
+    for trigger in triggers {
+        let binding = trigger_binding_for(&trigger.config);
+        grouped_kinds
+            .entry(binding.provider.clone())
+            .or_default()
+            .insert(binding.kind.as_str().to_string());
+        trigger_registry.register(binding);
+    }
+
+    let ctx = harn_vm::ConnectorCtx {
+        event_log,
+        secrets,
+        inbox: Arc::new(harn_vm::InboxIndex),
+        metrics: Arc::new(harn_vm::MetricsRegistry),
+        rate_limiter: Arc::new(harn_vm::RateLimiterFactory::default()),
+    };
+
+    let mut providers = Vec::new();
+    for (provider, kinds) in grouped_kinds {
+        let provider_name = provider.as_str().to_string();
+        let connector = PlaceholderConnector::new(provider.clone(), kinds);
+        registry
+            .register(Box::new(connector))
+            .map_err(|error| error.to_string())?;
+        let handle = registry
+            .get(&provider)
+            .ok_or_else(|| format!("connector registry lost provider '{}'", provider.as_str()))?;
+        handle
+            .lock()
+            .await
+            .init(ctx.clone())
+            .await
+            .map_err(|error| error.to_string())?;
+        providers.push(provider_name);
+    }
+
+    let activations = registry
+        .activate_all(&trigger_registry)
+        .await
+        .map_err(|error| error.to_string())?;
+
+    Ok(ConnectorRuntime {
+        _registry: registry,
+        providers,
+        activations,
+    })
+}
+
+fn trigger_binding_for(config: &ResolvedTriggerConfig) -> harn_vm::TriggerBinding {
+    harn_vm::TriggerBinding {
+        provider: config.provider.clone(),
+        kind: harn_vm::TriggerKind::from(trigger_kind_name(config.kind)),
+        binding_id: config.id.clone(),
+        config: JsonValue::Null,
+    }
+}
+
+fn format_trigger_summary(triggers: &[CollectedManifestTrigger]) -> String {
+    if triggers.is_empty() {
+        return "none".to_string();
+    }
+    triggers
+        .iter()
+        .map(|trigger| {
+            format!(
+                "{} [{}:{} -> {}]",
+                trigger.config.id,
+                trigger.config.provider.as_str(),
+                trigger_kind_name(trigger.config.kind),
+                handler_kind(&trigger.handler)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn format_activation_summary(activations: &[harn_vm::ActivationHandle]) -> String {
+    if activations.is_empty() {
+        return "none".to_string();
+    }
+    activations
+        .iter()
+        .map(|activation| {
+            format!(
+                "{}({})",
+                activation.provider.as_str(),
+                activation.binding_count
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn handler_kind(handler: &CollectedTriggerHandler) -> &'static str {
+    match handler {
+        CollectedTriggerHandler::Local { .. } => "local",
+        CollectedTriggerHandler::A2a { .. } => "a2a",
+        CollectedTriggerHandler::Worker { .. } => "worker",
+    }
+}
+
+fn trigger_kind_name(kind: crate::package::TriggerKind) -> &'static str {
+    match kind {
+        crate::package::TriggerKind::Webhook => "webhook",
+        crate::package::TriggerKind::Cron => "cron",
+        crate::package::TriggerKind::Poll => "poll",
+        crate::package::TriggerKind::Stream => "stream",
+        crate::package::TriggerKind::Predicate => "predicate",
+        crate::package::TriggerKind::A2aPush => "a2a-push",
+    }
+}
+
+async fn graceful_shutdown(ctx: GracefulShutdownCtx<'_>) -> Result<(), String> {
+    eprintln!("[harn] signal received, starting graceful shutdown...");
+    eprintln!("[harn] draining in-flight events (scaffold): 0");
+
+    let stopped_at = now_rfc3339()?;
+    append_lifecycle_event(
+        ctx.event_log,
+        "shutdown",
+        json!({
+            "bind": ctx.bind.to_string(),
+            "drained_events": 0,
+            "role": ctx.role.as_str(),
+            "status": "stopped",
+        }),
+    )
+    .await?;
+
+    write_state_snapshot(
+        &ctx.state_dir.join(STATE_SNAPSHOT_FILE),
+        &ServeStateSnapshot {
+            status: "stopped".to_string(),
+            role: ctx.role.as_str().to_string(),
+            bind: ctx.bind.to_string(),
+            manifest_path: ctx.config_path.display().to_string(),
+            state_dir: ctx.state_dir.display().to_string(),
+            started_at: ctx.startup_started_at.to_string(),
+            stopped_at: Some(stopped_at),
+            secret_provider_chain: ctx.secret_chain_display.to_string(),
+            event_log_backend: ctx.event_log_description.backend.to_string(),
+            event_log_location: ctx
+                .event_log_description
+                .location
+                .as_ref()
+                .map(|path| path.display().to_string()),
+            triggers: ctx
+                .triggers
+                .iter()
+                .map(|trigger| TriggerStateSnapshot {
+                    id: trigger.config.id.clone(),
+                    provider: trigger.config.provider.as_str().to_string(),
+                    kind: trigger_kind_name(trigger.config.kind).to_string(),
+                    handler: handler_kind(&trigger.handler).to_string(),
+                })
+                .collect(),
+            connectors: ctx.connectors.providers.clone(),
+            activations: ctx
+                .connectors
+                .activations
+                .iter()
+                .map(|activation| ConnectorActivationSnapshot {
+                    provider: activation.provider.as_str().to_string(),
+                    binding_count: activation.binding_count,
+                })
+                .collect(),
+        },
+    )?;
+
+    eprintln!("[harn] graceful shutdown complete");
+    Ok(())
+}
+
+async fn append_lifecycle_event(
+    log: &Arc<harn_vm::event_log::AnyEventLog>,
+    kind: &str,
+    payload: JsonValue,
+) -> Result<(), String> {
+    use harn_vm::event_log::EventLog;
+
+    let topic =
+        harn_vm::event_log::Topic::new(LIFECYCLE_TOPIC).map_err(|error| error.to_string())?;
+    log.append(&topic, harn_vm::event_log::LogEvent::new(kind, payload))
+        .await
+        .map(|_| ())
+        .map_err(|error| format!("failed to append orchestrator lifecycle event: {error}"))
+}
+
+async fn wait_for_termination_signal() -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+
+        let mut sigterm = signal(SignalKind::terminate())
+            .map_err(|error| format!("failed to register SIGTERM handler: {error}"))?;
+        let mut sigint = signal(SignalKind::interrupt())
+            .map_err(|error| format!("failed to register SIGINT handler: {error}"))?;
+        tokio::select! {
+            _ = sigterm.recv() => Ok(()),
+            _ = sigint.recv() => Ok(()),
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c()
+            .await
+            .map_err(|error| format!("failed to wait for Ctrl-C: {error}"))
+    }
+}
+
+fn load_manifest(config_path: &Path) -> Result<(Manifest, PathBuf), String> {
+    if !config_path.is_file() {
+        return Err(format!("manifest not found: {}", config_path.display()));
+    }
+    let content = std::fs::read_to_string(config_path)
+        .map_err(|error| format!("failed to read {}: {error}", config_path.display()))?;
+    let manifest = toml::from_str::<Manifest>(&content)
+        .map_err(|error| format!("failed to parse {}: {error}", config_path.display()))?;
+    let manifest_dir = config_path.parent().map(Path::to_path_buf).ok_or_else(|| {
+        format!(
+            "manifest has no parent directory: {}",
+            config_path.display()
+        )
+    })?;
+    Ok((manifest, manifest_dir))
+}
+
+fn absolutize_from_cwd(path: &Path) -> Result<PathBuf, String> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| format!("failed to read current directory: {error}"))?
+            .join(path)
+    };
+    Ok(candidate)
+}
+
+fn configured_secret_chain_display() -> String {
+    std::env::var(harn_vm::secrets::SECRET_PROVIDER_CHAIN_ENV)
+        .unwrap_or_else(|_| harn_vm::secrets::DEFAULT_SECRET_PROVIDER_CHAIN.to_string())
+        .split(',')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join(" -> ")
+}
+
+fn secret_namespace_for(manifest_dir: &Path) -> String {
+    match std::env::var("HARN_SECRET_NAMESPACE") {
+        Ok(namespace) if !namespace.trim().is_empty() => namespace,
+        _ => {
+            let leaf = manifest_dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .filter(|name| !name.is_empty())
+                .unwrap_or("workspace");
+            format!("harn/{leaf}")
+        }
+    }
+}
+
+fn now_rfc3339() -> Result<String, String> {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .map_err(|error| format!("failed to format timestamp: {error}"))
+}
+
+fn write_state_snapshot(path: &Path, snapshot: &ServeStateSnapshot) -> Result<(), String> {
+    let encoded = serde_json::to_vec_pretty(snapshot)
+        .map_err(|error| format!("failed to encode orchestrator state snapshot: {error}"))?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+    std::fs::write(path, encoded)
+        .map_err(|error| format!("failed to write {}: {error}", path.display()))
+}
+
+struct GracefulShutdownCtx<'a> {
+    role: OrchestratorRole,
+    bind: SocketAddr,
+    config_path: &'a Path,
+    state_dir: &'a Path,
+    startup_started_at: &'a str,
+    event_log: &'a Arc<harn_vm::event_log::AnyEventLog>,
+    event_log_description: &'a harn_vm::event_log::EventLogDescription,
+    secret_chain_display: &'a str,
+    triggers: &'a [CollectedManifestTrigger],
+    connectors: &'a ConnectorRuntime,
+}
+
+#[derive(Debug, Serialize)]
+struct ServeStateSnapshot {
+    status: String,
+    role: String,
+    bind: String,
+    manifest_path: String,
+    state_dir: String,
+    started_at: String,
+    stopped_at: Option<String>,
+    secret_provider_chain: String,
+    event_log_backend: String,
+    event_log_location: Option<String>,
+    triggers: Vec<TriggerStateSnapshot>,
+    connectors: Vec<String>,
+    activations: Vec<ConnectorActivationSnapshot>,
+}
+
+#[derive(Debug, Serialize)]
+struct TriggerStateSnapshot {
+    id: String,
+    provider: String,
+    kind: String,
+    handler: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ConnectorActivationSnapshot {
+    provider: String,
+    binding_count: usize,
+}
+
+struct PlaceholderConnector {
+    provider_id: harn_vm::ProviderId,
+    kinds: Vec<harn_vm::TriggerKind>,
+    _ctx: Option<harn_vm::ConnectorCtx>,
+}
+
+impl PlaceholderConnector {
+    fn new(provider_id: harn_vm::ProviderId, kinds: BTreeSet<String>) -> Self {
+        Self {
+            provider_id,
+            kinds: kinds.into_iter().map(harn_vm::TriggerKind::from).collect(),
+            _ctx: None,
+        }
+    }
+}
+
+struct PlaceholderClient;
+
+#[async_trait]
+impl harn_vm::ConnectorClient for PlaceholderClient {
+    async fn call(
+        &self,
+        method: &str,
+        _args: JsonValue,
+    ) -> Result<JsonValue, harn_vm::ClientError> {
+        Err(harn_vm::ClientError::Other(format!(
+            "connector client method '{method}' is not implemented in the orchestrator scaffold"
+        )))
+    }
+}
+
+#[async_trait]
+impl harn_vm::Connector for PlaceholderConnector {
+    fn provider_id(&self) -> &harn_vm::ProviderId {
+        &self.provider_id
+    }
+
+    fn kinds(&self) -> &[harn_vm::TriggerKind] {
+        &self.kinds
+    }
+
+    async fn init(&mut self, ctx: harn_vm::ConnectorCtx) -> Result<(), harn_vm::ConnectorError> {
+        self._ctx = Some(ctx);
+        Ok(())
+    }
+
+    async fn activate(
+        &self,
+        bindings: &[harn_vm::TriggerBinding],
+    ) -> Result<harn_vm::ActivationHandle, harn_vm::ConnectorError> {
+        Ok(harn_vm::ActivationHandle::new(
+            self.provider_id.clone(),
+            bindings.len(),
+        ))
+    }
+
+    fn normalize_inbound(
+        &self,
+        _raw: harn_vm::RawInbound,
+    ) -> Result<harn_vm::TriggerEvent, harn_vm::ConnectorError> {
+        Err(harn_vm::ConnectorError::Unsupported(format!(
+            "connector '{}' inbound normalization is not implemented yet",
+            self.provider_id.as_str()
+        )))
+    }
+
+    fn payload_schema(&self) -> harn_vm::ProviderPayloadSchema {
+        harn_vm::ProviderPayloadSchema::named("TriggerEvent")
+    }
+
+    fn client(&self) -> Arc<dyn harn_vm::ConnectorClient> {
+        Arc::new(PlaceholderClient)
+    }
+}

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -345,6 +345,12 @@ async fn main() {
         Command::Portal(args) => {
             commands::portal::run_portal(&args.dir, &args.host, args.port, args.open).await
         }
+        Command::Orchestrator(args) => {
+            if let Err(error) = commands::orchestrator::handle(args).await {
+                eprintln!("error: {error}");
+                process::exit(1);
+            }
+        }
         Command::Playground(args) => {
             let llm_mock_mode = if let Some(path) = args.llm_mock.as_ref() {
                 commands::run::CliLlmMockMode::Replay {

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -1,0 +1,151 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+const STARTUP_NEEDLE: &str = "HTTP listener not yet implemented (see O-02 #179)";
+const SHUTDOWN_NEEDLE: &str = "graceful shutdown complete";
+
+fn write_file(dir: &Path, relative: &str, contents: &str) {
+    let path = dir.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+fn spawn_orchestrator(temp: &TempDir) -> (Child, Receiver<String>, thread::JoinHandle<String>) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .arg("orchestrator")
+        .arg("serve")
+        .arg("--config")
+        .arg("harn.toml")
+        .arg("--state-dir")
+        .arg("./state")
+        .arg("--role")
+        .arg("single-tenant")
+        .stderr(Stdio::piped())
+        .stdout(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let stderr = child.stderr.take().expect("stderr pipe");
+    let (tx, rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let mut collected = String::new();
+        for line in BufReader::new(stderr).lines() {
+            let line = line.expect("stderr line");
+            collected.push_str(&line);
+            collected.push('\n');
+            let _ = tx.send(line);
+        }
+        collected
+    });
+
+    (child, rx, handle)
+}
+
+fn wait_for_log_line(child: &mut Child, rx: &Receiver<String>, needle: &str) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(line) if line.contains(needle) => return,
+            Ok(_) => continue,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if let Some(status) = child.try_wait().unwrap() {
+                    panic!("process exited before '{needle}' appeared: {status}");
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("stderr stream closed before '{needle}' appeared");
+            }
+        }
+    }
+    panic!("timed out waiting for '{needle}'");
+}
+
+fn send_sigterm(child: &Child) {
+    let status = Command::new("kill")
+        .arg("-TERM")
+        .arg(child.id().to_string())
+        .status()
+        .unwrap();
+    assert!(status.success(), "kill exited with {status}");
+}
+
+fn wait_for_exit(child: &mut Child) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if let Some(status) = child.try_wait().unwrap() {
+            assert!(status.success(), "child exited unsuccessfully: {status}");
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!("timed out waiting for orchestrator exit");
+}
+
+#[test]
+fn orchestrator_serve_starts_and_shuts_down_cleanly() {
+    let temp = TempDir::new().unwrap();
+    write_file(
+        temp.path(),
+        "harn.toml",
+        r#"
+[package]
+name = "fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "github-new-issue"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "handlers::on_issue"
+secrets = { signing_secret = "github/webhook-secret" }
+"#,
+    );
+    write_file(
+        temp.path(),
+        "lib.harn",
+        r#"
+import "std/triggers"
+
+pub fn on_issue(event: TriggerEvent) {
+  log(event.kind)
+}
+"#,
+    );
+
+    let (mut child, rx, handle) = spawn_orchestrator(&temp);
+    wait_for_log_line(&mut child, &rx, STARTUP_NEEDLE);
+    send_sigterm(&child);
+    wait_for_exit(&mut child);
+    let stderr = handle.join().expect("stderr collector thread");
+
+    assert!(stderr.contains("secret providers:"), "stderr={stderr}");
+    assert!(
+        stderr.contains("registered triggers (1):"),
+        "stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("registered connectors (1):"),
+        "stderr={stderr}"
+    );
+    assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
+
+    let snapshot = temp.path().join("state/orchestrator-state.json");
+    let snapshot_contents = fs::read_to_string(&snapshot).unwrap();
+    assert!(snapshot_contents.contains("\"status\": \"stopped\""));
+    assert!(snapshot_contents.contains("\"bind\": \"127.0.0.1:8080\""));
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -43,6 +43,7 @@
 - [Bridge protocol](./bridge-protocol.md)
 - [MCP and ACP integration](./mcp-and-acp.md)
 - [Harn portal](./portal.md)
+- [Orchestrator](./orchestrator.md)
 - [Orchestrator secrets](./orchestrator/secrets.md)
 
 # Reference

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -1,0 +1,39 @@
+# Orchestrator
+
+`harn orchestrator serve` is the long-running process entry point for
+manifest-driven trigger ingestion and connector activation.
+
+Today, the command establishes the startup and shutdown scaffold:
+
+- load `harn.toml` through the existing manifest loader
+- boot the selected orchestrator role
+- initialize the shared EventLog under `--state-dir`
+- initialize the configured secret-provider chain
+- resolve and register manifest triggers
+- register and activate placeholder connectors for each manifest provider
+- write a state snapshot and idle until shutdown
+
+Current limitations:
+
+- the HTTP listener is still a stub and logs
+  `HTTP listener not yet implemented (see O-02 #179)`
+- `multi-tenant` returns a clear not-implemented error that points at
+  `O-12 #190`
+- `inspect`, `replay`, `dlq`, and `queue` are placeholders for
+  `O-08 #185`
+
+## Command
+
+```bash
+harn orchestrator serve \
+  --config harn.toml \
+  --state-dir ./.harn/orchestrator \
+  --bind 0.0.0.0:8080 \
+  --role single-tenant
+```
+
+On startup, the command logs the active secret-provider chain, loaded
+triggers, registered connectors, and the requested bind address. On
+SIGTERM, it performs scaffolded graceful shutdown, appends lifecycle
+events to the EventLog, and persists a final
+`orchestrator-state.json` snapshot under `--state-dir`.


### PR DESCRIPTION
## Summary

Adds the `harn orchestrator` command family and scaffolds `harn orchestrator serve` as the orchestrator process entry point.

This change:
- adds the root `orchestrator` CLI surface with `serve`, `inspect`, `replay`, `dlq`, and `queue`
- implements the `serve` startup sequence for manifest loading, single-tenant VM boot, EventLog setup, secret-provider chain logging, trigger registration, connector activation scaffolding, and structured shutdown
- adds docs and changelog coverage plus an integration test that boots the subprocess, waits for startup, sends `SIGTERM`, and verifies clean shutdown

## Context

Builds on:
- #205 (T-04 trigger registry)
- #203 (C-01 connector trait)
- #194 (secret provider)
- #195 (EventLog)

Deferred follow-up work remains explicitly stubbed:
- HTTP listener: O-02 #179
- auth middleware: O-03 #180
- metrics export: O-07 #184
- multi-tenant runtime: O-12 #190
- `inspect` / `replay` / `dlq` subcommands: O-08 #185

## Validation

- `cargo fmt --all`
- `cargo run -p harn-cli -- orchestrator serve --help`
- `cargo test -p harn-cli orchestrator -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `make test`
