### PR TITLE
Add DST-safe cron connector with catch-up modes (closes #169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ granular archaeology.
 
 ### Added
 
-- **`harn orchestrator serve` CLI scaffold (#178).** Added a new
-  `harn orchestrator` command family with a real `serve`
+- **`harn orchestrator serve` CLI scaffold (#209, closes #178).** Added
+  a new `harn orchestrator` command family with a real `serve`
   subcommand plus placeholder `inspect`, `replay`, `dlq`, and
   `queue` subcommands. `serve` now loads `harn.toml`, boots a
   single-tenant orchestrator VM, installs the shared EventLog under
@@ -35,6 +35,16 @@ granular archaeology.
   SIGTERM for scaffolded graceful shutdown. Multi-tenant remains an
   explicit `O-12 #190` stub; the HTTP listener remains deferred to
   `O-02 #179`.
+- **DST-safe cron connector with durable tick state and catch-up modes
+  (#210, closes #169).** `harn_vm::connectors::CronConnector` now schedules
+  named IANA time zones through `croner` + `chrono-tz`, persists the
+  latest scheduled boundary per trigger on the `connectors.cron.state`
+  EventLog topic, and supports `catchup_mode = "skip" | "all" |
+  "latest"` when an orchestrator resumes after downtime. The scheduler
+  fires repeated fall-back hours once, skips missing spring-forward
+  hours instead of inventing wall-clock times, writes normalized cron
+  `TriggerEvent` envelopes to `connectors.cron.tick`, and ships with
+  docs at `docs/src/connectors/cron.md`.
 - **Action-graph observability extended with `trigger` and `predicate`
   node kinds (#202, partial #163).** Persisted run records now
   synthesize a `trigger` node from `trigger_event` metadata, render

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,9 @@ version = "0.7.22"
 dependencies = [
  "async-trait",
  "base64",
+ "chrono",
+ "chrono-tz",
+ "croner",
  "futures",
  "harn-lexer",
  "harn-parser",

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -798,6 +798,25 @@ fn extract_kind_field<'a>(
     trigger.kind_specific.get(field)
 }
 
+fn looks_like_utc_offset_timezone(raw: &str) -> bool {
+    let value = raw.trim();
+    if let Some(rest) = value
+        .strip_prefix("UTC")
+        .or_else(|| value.strip_prefix("utc"))
+        .or_else(|| value.strip_prefix("GMT"))
+        .or_else(|| value.strip_prefix("gmt"))
+    {
+        return rest.starts_with('+') || rest.starts_with('-');
+    }
+    let chars: Vec<char> = value.chars().collect();
+    if chars.len() < 3 || !matches!(chars[0], '+' | '-') {
+        return false;
+    }
+    chars[1..]
+        .iter()
+        .all(|ch| ch.is_ascii_digit() || *ch == ':')
+}
+
 fn parse_jmespath_expression(
     trigger: &ResolvedTriggerConfig,
     field_name: &str,
@@ -877,6 +896,14 @@ fn validate_static_trigger_config(trigger: &ResolvedTriggerConfig) -> Result<(),
         if let Some(timezone) =
             extract_kind_field(trigger, "timezone").and_then(toml::Value::as_str)
         {
+            if looks_like_utc_offset_timezone(timezone) {
+                return Err(trigger_error(
+                    trigger,
+                    format!(
+                        "invalid cron timezone '{timezone}': use an IANA timezone name like 'America/New_York', not a UTC offset"
+                    ),
+                ));
+            }
             timezone.parse::<Tz>().map_err(|error| {
                 trigger_error(
                     trigger,
@@ -2432,6 +2459,30 @@ timezone = "America/Los_Angeles"
             .await
             .unwrap_err();
         assert!(error.contains("invalid cron schedule"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_manifest_triggers_rejects_utc_offset_timezone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let harn_file = write_trigger_project(
+            tmp.path(),
+            r#"
+[[triggers]]
+id = "bad-cron-timezone"
+kind = "cron"
+provider = "cron"
+match = { events = ["cron.tick"] }
+handler = "worker://queue"
+schedule = "0 9 * * *"
+timezone = "+02:00"
+"#,
+            None,
+        );
+        let mut vm = test_vm();
+        let error = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+            .await
+            .unwrap_err();
+        assert!(error.contains("use an IANA timezone name"));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -14,6 +14,9 @@ otel = ["opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp"]
 harn-lexer = { path = "../harn-lexer", version = "0.7" }
 harn-parser = { path = "../harn-parser", version = "0.7" }
 async-trait = "0.1"
+chrono = "0.4"
+chrono-tz = "0.10.4"
+croner = "3.0.1"
 regex = "1"
 serde_json = "1"
 rand = "0.10"

--- a/crates/harn-vm/src/connectors/cron/mod.rs
+++ b/crates/harn-vm/src/connectors/cron/mod.rs
@@ -1,0 +1,357 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+use time::OffsetDateTime;
+use tokio::task::JoinHandle;
+
+use crate::connectors::{
+    ActivationHandle, ClientError, Connector, ConnectorClient, ConnectorCtx, ConnectorError,
+    ProviderPayloadSchema, RawInbound, TriggerBinding, TriggerKind,
+};
+use crate::event_log::{AnyEventLog, EventLog, LogEvent, Topic};
+use crate::triggers::event::KnownProviderPayload;
+use crate::triggers::{
+    CronEventPayload, ProviderId, ProviderPayload, SignatureStatus, TriggerEvent,
+};
+
+use self::scheduler::{run_tick_loop, Clock, CronSchedule, RealClock, TickHandler};
+use self::state::{CronStateStore, PersistedCronState};
+
+pub(crate) mod scheduler;
+pub(crate) mod state;
+
+#[cfg(test)]
+mod tests;
+
+pub const CRON_TICK_TOPIC: &str = "connectors.cron.tick";
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CatchupMode {
+    #[default]
+    Skip,
+    All,
+    Latest,
+}
+
+pub struct CronConnector {
+    provider_id: ProviderId,
+    kinds: Vec<TriggerKind>,
+    client: Arc<CronClient>,
+    ctx: Mutex<Option<ConnectorCtx>>,
+    clock: Arc<dyn Clock>,
+    sink_override: Option<Arc<dyn CronEventSink>>,
+    tasks: Mutex<Vec<JoinHandle<()>>>,
+}
+
+impl CronConnector {
+    pub fn new() -> Self {
+        Self::with_clock(Arc::new(RealClock))
+    }
+
+    pub(crate) fn with_clock(clock: Arc<dyn Clock>) -> Self {
+        Self {
+            provider_id: ProviderId::from("cron"),
+            kinds: vec![TriggerKind::from("cron")],
+            client: Arc::new(CronClient),
+            ctx: Mutex::new(None),
+            clock,
+            sink_override: None,
+            tasks: Mutex::new(Vec::new()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_clock_and_sink(clock: Arc<dyn Clock>, sink: Arc<dyn CronEventSink>) -> Self {
+        let mut connector = Self::with_clock(clock);
+        connector.sink_override = Some(sink);
+        connector
+    }
+
+    fn context(&self) -> Result<ConnectorCtx, ConnectorError> {
+        self.ctx
+            .lock()
+            .expect("cron connector context mutex poisoned")
+            .clone()
+            .ok_or_else(|| {
+                ConnectorError::Activation(
+                    "cron connector must be initialized before activation".to_string(),
+                )
+            })
+    }
+}
+
+impl Default for CronConnector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for CronConnector {
+    fn drop(&mut self) {
+        let mut tasks = self
+            .tasks
+            .lock()
+            .expect("cron connector tasks mutex poisoned");
+        for task in tasks.drain(..) {
+            task.abort();
+        }
+    }
+}
+
+#[async_trait]
+impl Connector for CronConnector {
+    fn provider_id(&self) -> &ProviderId {
+        &self.provider_id
+    }
+
+    fn kinds(&self) -> &[TriggerKind] {
+        &self.kinds
+    }
+
+    async fn init(&mut self, ctx: ConnectorCtx) -> Result<(), ConnectorError> {
+        *self
+            .ctx
+            .lock()
+            .expect("cron connector context mutex poisoned") = Some(ctx);
+        Ok(())
+    }
+
+    async fn activate(
+        &self,
+        bindings: &[TriggerBinding],
+    ) -> Result<ActivationHandle, ConnectorError> {
+        let ctx = self.context()?;
+        let state_store = Arc::new(CronStateStore::new(ctx.event_log.clone()));
+        let sink: Arc<dyn CronEventSink> = self
+            .sink_override
+            .clone()
+            .unwrap_or_else(|| Arc::new(EventLogCronEventSink::new(ctx.event_log.clone())));
+        {
+            let mut tasks = self
+                .tasks
+                .lock()
+                .expect("cron connector tasks mutex poisoned");
+            for task in tasks.drain(..) {
+                task.abort();
+            }
+        }
+
+        for binding in bindings {
+            let trigger = CronTrigger::from_binding(binding)?;
+            let clock = self.clock.clone();
+            let sink = sink.clone();
+            let state_store = state_store.clone();
+            let last_fired = state_store
+                .load(&trigger.trigger_id)
+                .await?
+                .map(|state| state.last_fired_at);
+            let now = clock.now();
+            let catchup_ticks = match trigger.catchup_mode {
+                CatchupMode::Skip => Vec::new(),
+                CatchupMode::All => trigger.schedule.due_ticks_between(last_fired, now)?,
+                CatchupMode::Latest => trigger
+                    .schedule
+                    .due_ticks_between(last_fired, now)?
+                    .into_iter()
+                    .last()
+                    .into_iter()
+                    .collect(),
+            };
+            let cursor = match trigger.catchup_mode {
+                CatchupMode::Skip => now,
+                _ => last_fired.unwrap_or(now),
+            };
+            let handler = Arc::new(CronTaskHandler {
+                trigger,
+                sink,
+                state_store,
+            });
+            let task = tokio::spawn(async move {
+                let _ = run_tick_loop(
+                    handler.trigger.schedule.clone(),
+                    clock,
+                    cursor,
+                    catchup_ticks,
+                    handler,
+                )
+                .await;
+            });
+            self.tasks
+                .lock()
+                .expect("cron connector tasks mutex poisoned")
+                .push(task);
+        }
+
+        Ok(ActivationHandle::new(
+            self.provider_id.clone(),
+            bindings.len(),
+        ))
+    }
+
+    fn normalize_inbound(&self, _raw: RawInbound) -> Result<TriggerEvent, ConnectorError> {
+        Err(ConnectorError::Unsupported(
+            "cron is an in-process scheduler and does not accept inbound payloads".to_string(),
+        ))
+    }
+
+    fn payload_schema(&self) -> ProviderPayloadSchema {
+        ProviderPayloadSchema::named("CronEventPayload")
+    }
+
+    fn client(&self) -> Arc<dyn ConnectorClient> {
+        self.client.clone()
+    }
+}
+
+#[derive(Debug)]
+struct CronClient;
+
+#[async_trait]
+impl ConnectorClient for CronClient {
+    async fn call(&self, method: &str, _args: JsonValue) -> Result<JsonValue, ClientError> {
+        Err(ClientError::MethodNotFound(format!(
+            "cron connector does not implement outbound method '{method}'"
+        )))
+    }
+}
+
+#[async_trait]
+pub(crate) trait CronEventSink: Send + Sync {
+    async fn emit(&self, event: TriggerEvent) -> Result<(), ConnectorError>;
+}
+
+struct EventLogCronEventSink {
+    event_log: Arc<AnyEventLog>,
+    topic: Topic,
+}
+
+impl EventLogCronEventSink {
+    fn new(event_log: Arc<AnyEventLog>) -> Self {
+        Self {
+            event_log,
+            topic: Topic::new(CRON_TICK_TOPIC).expect("cron tick topic is valid"),
+        }
+    }
+}
+
+#[async_trait]
+impl CronEventSink for EventLogCronEventSink {
+    async fn emit(&self, event: TriggerEvent) -> Result<(), ConnectorError> {
+        let payload = serde_json::to_value(&event).map_err(ConnectorError::from)?;
+        self.event_log
+            .append(&self.topic, LogEvent::new("trigger_event", payload))
+            .await
+            .map_err(ConnectorError::from)?;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct CronTaskHandler {
+    trigger: CronTrigger,
+    sink: Arc<dyn CronEventSink>,
+    state_store: Arc<CronStateStore>,
+}
+
+#[async_trait]
+impl TickHandler for CronTaskHandler {
+    async fn on_tick(&self, tick_at: OffsetDateTime, catchup: bool) -> Result<(), ConnectorError> {
+        let event = self.trigger.to_event(tick_at, catchup);
+        self.sink.emit(event).await?;
+        self.state_store
+            .persist(PersistedCronState {
+                trigger_id: self.trigger.trigger_id.clone(),
+                last_fired_at: tick_at,
+            })
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct CronTrigger {
+    trigger_id: String,
+    schedule_raw: String,
+    timezone_raw: String,
+    schedule: CronSchedule,
+    catchup_mode: CatchupMode,
+}
+
+impl CronTrigger {
+    fn from_binding(binding: &TriggerBinding) -> Result<Self, ConnectorError> {
+        let config: CronBindingConfig =
+            serde_json::from_value(binding.config.clone()).map_err(ConnectorError::from)?;
+        let timezone = parse_iana_timezone(&config.timezone)?;
+        Ok(Self {
+            trigger_id: binding.binding_id.clone(),
+            schedule_raw: config.schedule.clone(),
+            timezone_raw: config.timezone.clone(),
+            schedule: CronSchedule::parse(config.schedule, timezone)?,
+            catchup_mode: config.catchup_mode,
+        })
+    }
+
+    fn to_event(&self, tick_at: OffsetDateTime, catchup: bool) -> TriggerEvent {
+        let payload = ProviderPayload::Known(KnownProviderPayload::Cron(CronEventPayload {
+            cron_id: Some(self.trigger_id.clone()),
+            schedule: Some(self.schedule_raw.clone()),
+            tick_at,
+            raw: json!({
+                "catchup": catchup,
+                "timezone": self.timezone_raw,
+            }),
+        }));
+        TriggerEvent::new(
+            ProviderId::from("cron"),
+            "tick",
+            Some(tick_at),
+            format!("cron:{}:{}", self.trigger_id, tick_at.unix_timestamp()),
+            None,
+            BTreeMap::new(),
+            payload,
+            SignatureStatus::Unsigned,
+        )
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct CronBindingConfig {
+    schedule: String,
+    timezone: String,
+    #[serde(default, alias = "catch_up", alias = "catchup")]
+    catchup_mode: CatchupMode,
+}
+
+fn parse_iana_timezone(raw: &str) -> Result<chrono_tz::Tz, ConnectorError> {
+    if looks_like_utc_offset(raw) {
+        return Err(ConnectorError::Activation(format!(
+            "invalid cron timezone '{raw}': use an IANA timezone name like 'America/New_York', not a UTC offset"
+        )));
+    }
+    raw.parse::<chrono_tz::Tz>().map_err(|error| {
+        ConnectorError::Activation(format!("invalid cron timezone '{raw}': {error}"))
+    })
+}
+
+pub(crate) fn looks_like_utc_offset(raw: &str) -> bool {
+    let value = raw.trim();
+    if let Some(rest) = value
+        .strip_prefix("UTC")
+        .or_else(|| value.strip_prefix("utc"))
+        .or_else(|| value.strip_prefix("GMT"))
+        .or_else(|| value.strip_prefix("gmt"))
+    {
+        return rest.starts_with('+') || rest.starts_with('-');
+    }
+    let chars: Vec<char> = value.chars().collect();
+    if chars.len() < 3 || !matches!(chars[0], '+' | '-') {
+        return false;
+    }
+    chars[1..]
+        .iter()
+        .all(|ch| ch.is_ascii_digit() || *ch == ':')
+}

--- a/crates/harn-vm/src/connectors/cron/scheduler.rs
+++ b/crates/harn-vm/src/connectors/cron/scheduler.rs
@@ -1,0 +1,174 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
+use chrono_tz::Tz;
+use croner::Cron;
+use time::OffsetDateTime;
+
+use crate::connectors::ConnectorError;
+
+#[derive(Clone, Debug)]
+pub(crate) struct CronSchedule {
+    timezone: Tz,
+    cron: Cron,
+}
+
+impl CronSchedule {
+    pub(crate) fn parse(raw: impl Into<String>, timezone: Tz) -> Result<Self, ConnectorError> {
+        let raw = raw.into();
+        let cron = raw.parse::<Cron>().map_err(|error| {
+            ConnectorError::Activation(format!("invalid cron schedule '{raw}': {error}"))
+        })?;
+        Ok(Self { timezone, cron })
+    }
+
+    pub(crate) fn next_tick_after(
+        &self,
+        after: OffsetDateTime,
+    ) -> Result<OffsetDateTime, ConnectorError> {
+        let mut cursor = self.to_local(after);
+        let last_local = None;
+        loop {
+            let candidate = self
+                .cron
+                .find_next_occurrence(&cursor, false)
+                .map_err(schedule_error)?;
+            cursor = candidate + ChronoDuration::seconds(1);
+            if !self
+                .cron
+                .is_time_matching(&candidate)
+                .map_err(schedule_error)?
+            {
+                continue;
+            }
+            let candidate_local = candidate.naive_local();
+            if last_local == Some(candidate_local) {
+                continue;
+            }
+            return chrono_to_offset(candidate).map_err(schedule_error);
+        }
+    }
+
+    pub(crate) fn due_ticks_between(
+        &self,
+        after: Option<OffsetDateTime>,
+        until: OffsetDateTime,
+    ) -> Result<Vec<OffsetDateTime>, ConnectorError> {
+        let mut cursor = self.to_local(after.unwrap_or(until - time::Duration::minutes(1)));
+        let mut last_local = after.map(|ts| self.to_local(ts).naive_local());
+        let mut ticks = Vec::new();
+        loop {
+            let candidate = self
+                .cron
+                .find_next_occurrence(&cursor, false)
+                .map_err(schedule_error)?;
+            let candidate_offset = chrono_to_offset(candidate).map_err(schedule_error)?;
+            if candidate_offset > until {
+                break;
+            }
+            cursor = candidate + ChronoDuration::seconds(1);
+            if !self
+                .cron
+                .is_time_matching(&candidate)
+                .map_err(schedule_error)?
+            {
+                continue;
+            }
+            let candidate_local = candidate.naive_local();
+            if last_local == Some(candidate_local) {
+                continue;
+            }
+            last_local = Some(candidate_local);
+            ticks.push(candidate_offset);
+        }
+        Ok(ticks)
+    }
+
+    fn to_local(&self, ts: OffsetDateTime) -> DateTime<Tz> {
+        offset_to_utc(ts).with_timezone(&self.timezone)
+    }
+}
+
+fn schedule_error(error: impl std::fmt::Display) -> ConnectorError {
+    ConnectorError::Activation(format!("cron scheduler error: {error}"))
+}
+
+fn offset_to_utc(ts: OffsetDateTime) -> DateTime<Utc> {
+    Utc.timestamp_opt(ts.unix_timestamp(), ts.nanosecond())
+        .single()
+        .expect("offset timestamp is representable in chrono")
+}
+
+fn chrono_to_offset<TzImpl: TimeZone>(
+    value: DateTime<TzImpl>,
+) -> Result<OffsetDateTime, time::error::ComponentRange> {
+    OffsetDateTime::from_unix_timestamp_nanos(i128::from(
+        value
+            .timestamp_nanos_opt()
+            .expect("chrono timestamp fits in i64"),
+    ))
+}
+
+#[async_trait]
+pub(crate) trait Clock: Send + Sync {
+    fn now(&self) -> OffsetDateTime;
+    async fn sleep_until(&self, deadline: OffsetDateTime);
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct RealClock;
+
+#[async_trait]
+impl Clock for RealClock {
+    fn now(&self) -> OffsetDateTime {
+        OffsetDateTime::now_utc()
+    }
+
+    async fn sleep_until(&self, deadline: OffsetDateTime) {
+        let now = self.now();
+        if deadline <= now {
+            return;
+        }
+        let wait = deadline - now;
+        let Ok(wait) = wait.try_into() else {
+            return;
+        };
+        tokio::time::sleep(wait).await;
+    }
+}
+
+#[async_trait]
+pub(crate) trait TickHandler: Send + Sync {
+    async fn on_tick(&self, tick_at: OffsetDateTime, catchup: bool) -> Result<(), ConnectorError>;
+}
+
+pub(crate) async fn run_tick_loop(
+    schedule: CronSchedule,
+    clock: Arc<dyn Clock>,
+    mut cursor: OffsetDateTime,
+    catchup_ticks: Vec<OffsetDateTime>,
+    handler: Arc<dyn TickHandler>,
+) -> Result<(), ConnectorError> {
+    for tick_at in catchup_ticks {
+        handler.on_tick(tick_at, true).await?;
+        cursor = tick_at;
+    }
+
+    loop {
+        let next_tick = schedule.next_tick_after(cursor)?;
+        if next_tick > clock.now() {
+            clock.sleep_until(next_tick).await;
+        }
+        let now = clock.now();
+        let due = schedule.due_ticks_between(Some(cursor), now)?;
+        if due.is_empty() {
+            cursor = now;
+            continue;
+        }
+        for tick_at in due {
+            handler.on_tick(tick_at, false).await?;
+            cursor = tick_at;
+        }
+    }
+}

--- a/crates/harn-vm/src/connectors/cron/state.rs
+++ b/crates/harn-vm/src/connectors/cron/state.rs
@@ -1,0 +1,69 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+use crate::connectors::ConnectorError;
+use crate::event_log::{AnyEventLog, EventLog, LogEvent, Topic};
+
+pub(crate) const CRON_STATE_TOPIC: &str = "connectors.cron.state";
+const STATE_EVENT_KIND: &str = "cron_trigger_state";
+
+#[derive(Clone)]
+pub(crate) struct CronStateStore {
+    event_log: Arc<AnyEventLog>,
+    topic: Topic,
+}
+
+impl CronStateStore {
+    pub(crate) fn new(event_log: Arc<AnyEventLog>) -> Self {
+        Self {
+            event_log,
+            topic: Topic::new(CRON_STATE_TOPIC).expect("cron state topic is valid"),
+        }
+    }
+
+    pub(crate) async fn load_all(
+        &self,
+    ) -> Result<BTreeMap<String, PersistedCronState>, ConnectorError> {
+        let mut state = BTreeMap::new();
+        let events = self
+            .event_log
+            .read_range(&self.topic, None, usize::MAX)
+            .await
+            .map_err(ConnectorError::from)?;
+        for (_, record) in events {
+            if record.kind != STATE_EVENT_KIND {
+                continue;
+            }
+            let payload: PersistedCronState =
+                serde_json::from_value(record.payload).map_err(ConnectorError::from)?;
+            state.insert(payload.trigger_id.clone(), payload);
+        }
+        Ok(state)
+    }
+
+    pub(crate) async fn load(
+        &self,
+        trigger_id: &str,
+    ) -> Result<Option<PersistedCronState>, ConnectorError> {
+        Ok(self.load_all().await?.remove(trigger_id))
+    }
+
+    pub(crate) async fn persist(&self, state: PersistedCronState) -> Result<(), ConnectorError> {
+        let payload = serde_json::to_value(&state).map_err(ConnectorError::from)?;
+        self.event_log
+            .append(&self.topic, LogEvent::new(STATE_EVENT_KIND, payload))
+            .await
+            .map_err(ConnectorError::from)?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PersistedCronState {
+    pub trigger_id: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub last_fired_at: OffsetDateTime,
+}

--- a/crates/harn-vm/src/connectors/cron/tests.rs
+++ b/crates/harn-vm/src/connectors/cron/tests.rs
@@ -1,0 +1,321 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::json;
+use time::{Duration, OffsetDateTime};
+use tokio::sync::Mutex;
+
+use crate::connectors::cron::scheduler::CronSchedule;
+use crate::connectors::cron::state::{CronStateStore, PersistedCronState};
+use crate::connectors::cron::{looks_like_utc_offset, CatchupMode, CronConnector, CronEventSink};
+use crate::connectors::{Connector, ConnectorCtx, TriggerBinding};
+use crate::event_log::{AnyEventLog, EventLog, FileEventLog, MemoryEventLog, Topic};
+use crate::secrets::{
+    RotationHandle, SecretBytes, SecretError, SecretId, SecretMeta, SecretProvider,
+};
+use crate::triggers::TriggerEvent;
+use crate::{InboxIndex, MetricsRegistry, ProviderId, RateLimiterFactory, TriggerKind};
+
+use super::CRON_TICK_TOPIC;
+
+struct RecordingSink {
+    events: Mutex<Vec<TriggerEvent>>,
+}
+
+impl RecordingSink {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            events: Mutex::new(Vec::new()),
+        })
+    }
+
+    async fn take(&self) -> Vec<TriggerEvent> {
+        self.events.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl CronEventSink for RecordingSink {
+    async fn emit(&self, event: TriggerEvent) -> Result<(), crate::connectors::ConnectorError> {
+        self.events.lock().await.push(event);
+        Ok(())
+    }
+}
+
+fn binding(id: &str, schedule: &str, timezone: &str, catchup_mode: CatchupMode) -> TriggerBinding {
+    TriggerBinding {
+        provider: ProviderId::from("cron"),
+        kind: TriggerKind::from("cron"),
+        binding_id: id.to_string(),
+        config: json!({
+            "schedule": schedule,
+            "timezone": timezone,
+            "catchup_mode": catchup_mode,
+        }),
+    }
+}
+
+fn ctx(event_log: Arc<AnyEventLog>) -> ConnectorCtx {
+    ConnectorCtx {
+        event_log,
+        secrets: Arc::new(FakeSecretProvider),
+        inbox: Arc::new(InboxIndex),
+        metrics: Arc::new(MetricsRegistry),
+        rate_limiter: Arc::new(RateLimiterFactory::default()),
+    }
+}
+
+fn parse(ts: &str) -> OffsetDateTime {
+    OffsetDateTime::parse(ts, &time::format_description::well_known::Rfc3339).unwrap()
+}
+
+struct FakeSecretProvider;
+
+#[async_trait]
+impl SecretProvider for FakeSecretProvider {
+    async fn get(&self, id: &SecretId) -> Result<SecretBytes, SecretError> {
+        Err(SecretError::NotFound {
+            provider: self.namespace().to_string(),
+            id: id.clone(),
+        })
+    }
+
+    async fn put(&self, _id: &SecretId, _value: SecretBytes) -> Result<(), SecretError> {
+        Ok(())
+    }
+
+    async fn rotate(&self, id: &SecretId) -> Result<RotationHandle, SecretError> {
+        Ok(RotationHandle {
+            provider: self.namespace().to_string(),
+            id: id.clone(),
+            from_version: None,
+            to_version: None,
+        })
+    }
+
+    async fn list(&self, _prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError> {
+        Ok(Vec::new())
+    }
+
+    fn namespace(&self) -> &str {
+        "cron"
+    }
+
+    fn supports_versions(&self) -> bool {
+        false
+    }
+}
+
+#[test]
+fn midnight_schedule_tracks_new_york_local_midnight_in_dst_and_standard_time() {
+    let schedule = CronSchedule::parse("0 0 * * *", "America/New_York".parse().unwrap()).unwrap();
+
+    let january = schedule
+        .next_tick_after(parse("2026-01-15T04:59:00Z"))
+        .unwrap();
+    let july = schedule
+        .next_tick_after(parse("2026-07-15T03:59:00Z"))
+        .unwrap();
+
+    assert_eq!(january, parse("2026-01-15T05:00:00Z"));
+    assert_eq!(july, parse("2026-07-15T04:00:00Z"));
+}
+
+#[test]
+fn fallback_hour_fires_only_once() {
+    let schedule = CronSchedule::parse("0 1 * * *", "America/New_York".parse().unwrap()).unwrap();
+    let due = schedule
+        .due_ticks_between(
+            Some(parse("2026-11-01T04:59:00Z")),
+            parse("2026-11-01T07:01:00Z"),
+        )
+        .unwrap();
+
+    assert_eq!(due, vec![parse("2026-11-01T05:00:00Z")]);
+}
+
+#[test]
+fn spring_forward_gap_does_not_fire_missing_hour() {
+    let schedule = CronSchedule::parse("0 2 * * *", "America/New_York".parse().unwrap()).unwrap();
+    let due = schedule
+        .due_ticks_between(
+            Some(parse("2026-03-08T06:59:00Z")),
+            parse("2026-03-08T08:01:00Z"),
+        )
+        .unwrap();
+
+    assert!(due.is_empty());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn durable_state_round_trips_through_event_log() {
+    let tmp = tempfile::tempdir().unwrap();
+    let first = Arc::new(AnyEventLog::File(
+        FileEventLog::open(tmp.path().to_path_buf(), 32).unwrap(),
+    ));
+    let store = CronStateStore::new(first);
+    store
+        .persist(PersistedCronState {
+            trigger_id: "nightly".to_string(),
+            last_fired_at: parse("2026-04-19T00:10:00Z"),
+        })
+        .await
+        .unwrap();
+
+    let reopened = Arc::new(AnyEventLog::File(
+        FileEventLog::open(tmp.path().to_path_buf(), 32).unwrap(),
+    ));
+    let restored = CronStateStore::new(reopened)
+        .load("nightly")
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(restored.last_fired_at, parse("2026-04-19T00:10:00Z"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn catchup_skip_drops_missed_ticks() {
+    let clock = crate::connectors::test_util::MockClock::new(parse("2026-04-19T00:10:00Z"));
+    let sink = RecordingSink::new();
+    let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(32)));
+    let store = CronStateStore::new(log.clone());
+    store
+        .persist(PersistedCronState {
+            trigger_id: "hourly".to_string(),
+            last_fired_at: parse("2026-04-19T00:00:00Z"),
+        })
+        .await
+        .unwrap();
+
+    let mut connector = CronConnector::with_clock_and_sink(clock.clone(), sink.clone());
+    connector.init(ctx(log)).await.unwrap();
+    connector
+        .activate(&[binding("hourly", "* * * * *", "UTC", CatchupMode::Skip)])
+        .await
+        .unwrap();
+    tokio::task::yield_now().await;
+
+    assert!(sink.take().await.is_empty());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn catchup_all_replays_every_missed_tick_in_order() {
+    let clock = crate::connectors::test_util::MockClock::new(parse("2026-04-19T00:10:00Z"));
+    let sink = RecordingSink::new();
+    let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(32)));
+    let store = CronStateStore::new(log.clone());
+    store
+        .persist(PersistedCronState {
+            trigger_id: "hourly".to_string(),
+            last_fired_at: parse("2026-04-19T00:00:00Z"),
+        })
+        .await
+        .unwrap();
+
+    let mut connector = CronConnector::with_clock_and_sink(clock.clone(), sink.clone());
+    connector.init(ctx(log)).await.unwrap();
+    connector
+        .activate(&[binding("hourly", "* * * * *", "UTC", CatchupMode::All)])
+        .await
+        .unwrap();
+    tokio::task::yield_now().await;
+
+    let events = sink.take().await;
+    assert_eq!(events.len(), 10);
+    assert_eq!(events[0].occurred_at, Some(parse("2026-04-19T00:01:00Z")));
+    assert_eq!(events[9].occurred_at, Some(parse("2026-04-19T00:10:00Z")));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn catchup_latest_replays_only_the_most_recent_tick() {
+    let clock = crate::connectors::test_util::MockClock::new(parse("2026-04-19T00:10:00Z"));
+    let sink = RecordingSink::new();
+    let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(32)));
+    let store = CronStateStore::new(log.clone());
+    store
+        .persist(PersistedCronState {
+            trigger_id: "hourly".to_string(),
+            last_fired_at: parse("2026-04-19T00:00:00Z"),
+        })
+        .await
+        .unwrap();
+
+    let mut connector = CronConnector::with_clock_and_sink(clock.clone(), sink.clone());
+    connector.init(ctx(log)).await.unwrap();
+    connector
+        .activate(&[binding("hourly", "* * * * *", "UTC", CatchupMode::Latest)])
+        .await
+        .unwrap();
+    tokio::task::yield_now().await;
+
+    let events = sink.take().await;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].occurred_at, Some(parse("2026-04-19T00:10:00Z")));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn restart_uses_durable_state_to_avoid_duplicate_tick() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_path_buf();
+    let sink_one = RecordingSink::new();
+    let clock_one = crate::connectors::test_util::MockClock::new(parse("2026-04-19T00:00:30Z"));
+    let log_one = Arc::new(AnyEventLog::File(
+        FileEventLog::open(path.clone(), 32).unwrap(),
+    ));
+
+    let mut first = CronConnector::with_clock_and_sink(clock_one.clone(), sink_one.clone());
+    first.init(ctx(log_one)).await.unwrap();
+    first
+        .activate(&[binding("hourly", "* * * * *", "UTC", CatchupMode::Skip)])
+        .await
+        .unwrap();
+    clock_one.advance(Duration::seconds(30)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(sink_one.take().await.len(), 1);
+    drop(first);
+
+    let sink_two = RecordingSink::new();
+    let clock_two = crate::connectors::test_util::MockClock::new(parse("2026-04-19T00:01:30Z"));
+    let log_two = Arc::new(AnyEventLog::File(FileEventLog::open(path, 32).unwrap()));
+    let mut second = CronConnector::with_clock_and_sink(clock_two.clone(), sink_two.clone());
+    second.init(ctx(log_two)).await.unwrap();
+    second
+        .activate(&[binding("hourly", "* * * * *", "UTC", CatchupMode::Skip)])
+        .await
+        .unwrap();
+    tokio::task::yield_now().await;
+    assert!(sink_two.take().await.is_empty());
+    clock_two.advance(Duration::seconds(30)).await;
+    tokio::task::yield_now().await;
+
+    let events = sink_two.take().await;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].occurred_at, Some(parse("2026-04-19T00:02:00Z")));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn default_sink_writes_trigger_events_to_event_log() {
+    let clock = crate::connectors::test_util::MockClock::new(parse("2026-04-19T00:00:30Z"));
+    let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(32)));
+    let mut connector = CronConnector::with_clock(clock.clone());
+    connector.init(ctx(log.clone())).await.unwrap();
+    connector
+        .activate(&[binding("hourly", "* * * * *", "UTC", CatchupMode::Skip)])
+        .await
+        .unwrap();
+    clock.advance(Duration::seconds(30)).await;
+    tokio::task::yield_now().await;
+
+    let topic = Topic::new(CRON_TICK_TOPIC).unwrap();
+    let events = log.read_range(&topic, None, usize::MAX).await.unwrap();
+    assert_eq!(events.len(), 1);
+}
+
+#[test]
+fn utc_offset_detection_rejects_offset_style_timezones() {
+    assert!(looks_like_utc_offset("+02:00"));
+    assert!(looks_like_utc_offset("UTC-5"));
+    assert!(!looks_like_utc_offset("UTC"));
+    assert!(!looks_like_utc_offset("America/New_York"));
+}

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -20,8 +20,12 @@ use crate::event_log::AnyEventLog;
 use crate::secrets::SecretProvider;
 use crate::triggers::{ProviderId, TenantId, TriggerEvent};
 
+pub mod cron;
 pub mod hmac;
+#[cfg(test)]
+pub(crate) mod test_util;
 
+pub use cron::{CatchupMode, CronConnector};
 pub use hmac::{
     HmacSignatureStyle, DEFAULT_GITHUB_SIGNATURE_HEADER, DEFAULT_STANDARD_WEBHOOKS_ID_HEADER,
     DEFAULT_STANDARD_WEBHOOKS_SIGNATURE_HEADER, DEFAULT_STANDARD_WEBHOOKS_TIMESTAMP_HEADER,

--- a/crates/harn-vm/src/connectors/test_util.rs
+++ b/crates/harn-vm/src/connectors/test_util.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use time::OffsetDateTime;
+use tokio::sync::Notify;
+
+use super::cron::scheduler::Clock;
+
+#[derive(Debug)]
+pub(crate) struct MockClock {
+    now: Mutex<OffsetDateTime>,
+    notify: Notify,
+}
+
+impl MockClock {
+    pub(crate) fn new(now: OffsetDateTime) -> Arc<Self> {
+        Arc::new(Self {
+            now: Mutex::new(now),
+            notify: Notify::new(),
+        })
+    }
+
+    pub(crate) async fn set(&self, now: OffsetDateTime) {
+        *self.now.lock().expect("mock clock mutex poisoned") = now;
+        self.notify.notify_waiters();
+    }
+
+    pub(crate) async fn advance(&self, duration: time::Duration) {
+        let next = *self.now.lock().expect("mock clock mutex poisoned") + duration;
+        self.set(next).await;
+    }
+}
+
+#[async_trait]
+impl Clock for MockClock {
+    fn now(&self) -> OffsetDateTime {
+        *self.now.lock().expect("mock clock mutex poisoned")
+    }
+
+    async fn sleep_until(&self, deadline: OffsetDateTime) {
+        loop {
+            if *self.now.lock().expect("mock clock mutex poisoned") >= deadline {
+                return;
+            }
+            self.notify.notified().await;
+        }
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -38,10 +38,11 @@ pub use checkpoint::register_checkpoint_builtins;
 pub use chunk::*;
 pub use compiler::*;
 pub use connectors::{
-    hmac::verify_hmac_signed, ActivationHandle, ClientError, Connector, ConnectorClient,
-    ConnectorCtx, ConnectorError, ConnectorRegistry, InboxIndex, MetricsRegistry,
-    ProviderPayloadSchema, RateLimitConfig, RateLimiterFactory, RawInbound, TriggerBinding,
-    TriggerKind, TriggerRegistry,
+    cron::{CatchupMode, CronConnector},
+    hmac::verify_hmac_signed,
+    ActivationHandle, ClientError, Connector, ConnectorClient, ConnectorCtx, ConnectorError,
+    ConnectorRegistry, InboxIndex, MetricsRegistry, ProviderPayloadSchema, RateLimitConfig,
+    RateLimiterFactory, RawInbound, TriggerBinding, TriggerKind, TriggerRegistry,
 };
 pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -30,6 +30,7 @@
 - [Trigger observability in the action graph](./observability/triggers-in-action-graph.md)
 - [Connector authoring](./connectors/authoring.md)
 - [Trigger registry](./triggers/registry.md)
+- [Cron connector](./connectors/cron.md)
 - [Cookbook](./cookbook.md)
 - [Tutorial: code review agent](./tutorial-code-review-agent.md)
 - [Tutorial: MCP server](./tutorial-mcp-server.md)

--- a/docs/src/connectors/cron.md
+++ b/docs/src/connectors/cron.md
@@ -1,0 +1,89 @@
+# Cron connector
+
+The cron connector is Harn's in-process scheduler for time-triggered work. It
+implements the shared `Connector` trait, evaluates cron expressions in an IANA
+time zone, and persists the last-fired boundary for each trigger in the shared
+EventLog.
+
+## Manifest shape
+
+Cron triggers live under `[[triggers]]` and keep their schedule-specific
+settings inline with the rest of the trigger manifest entry:
+
+```toml
+[[triggers]]
+id = "daily-digest"
+kind = "cron"
+provider = "cron"
+match = { events = ["cron.tick"] }
+handler = "worker://digest-queue"
+schedule = "0 9 * * *"
+timezone = "America/New_York"
+catchup_mode = "skip"
+```
+
+Supported fields:
+
+- `schedule`: five-field cron expression parsed by `croner`
+- `timezone`: IANA time zone name such as `America/New_York`
+- `catchup_mode`: `skip` (default), `all`, or `latest`
+
+Offset literals such as `+02:00` and `UTC-5` are rejected at manifest-load
+time. Use a named zone instead so DST transitions can be evaluated correctly.
+
+## DST semantics
+
+The cron connector intentionally favors stable wall-clock semantics over trying
+to synthesize impossible local times:
+
+- Fall-back overlaps fire a matching wall-clock slot once, even though the local
+  hour appears twice.
+- Spring-forward gaps do not invent a firing for a missing local time. A
+  schedule like `0 2 * * *` simply does not fire on the DST transition day when
+  `02:00` is skipped.
+- Named zones continue to track the intended local wall time across standard and
+  daylight time. Midnight in `America/New_York` fires at `05:00Z` in winter and
+  `04:00Z` in summer.
+
+## Durable state
+
+Every successful firing appends the latest scheduled boundary for that trigger
+to the EventLog topic `connectors.cron.state`. On restart, the connector reloads
+the latest entry for each `trigger_id` and uses it to determine whether any
+ticks were missed while the orchestrator was down.
+
+The current implementation persists:
+
+- `trigger_id`
+- `last_fired_at`
+
+This keeps recovery append-only and backend-agnostic across the memory, file,
+and SQLite EventLog implementations.
+
+## Catch-up modes
+
+Catch-up behavior is evaluated from the persisted `last_fired_at` boundary to
+the connector's current clock on activation.
+
+- `skip`: drop missed ticks and resume from "now"
+- `all`: replay every missed scheduled tick in chronological order
+- `latest`: replay only the most recent missed scheduled tick
+
+Catch-up reuses the original scheduled boundary as `occurred_at`, so downstream
+consumers can distinguish between when a job was due and when the process
+actually resumed.
+
+## Event output
+
+Until the broader trigger dispatcher lands, cron firings are emitted as
+serialized `TriggerEvent` envelopes on the EventLog topic `connectors.cron.tick`
+with provider `cron`, kind `tick`, and a `CronEventPayload` that includes:
+
+- `cron_id`
+- `schedule`
+- `tick_at`
+- `raw.catchup`
+- `raw.timezone`
+
+This keeps the connector testable today and preserves a normalized event shape
+for the follow-up dispatcher work.


### PR DESCRIPTION
## Summary

- add `CronConnector` with DST-safe scheduling in named IANA time zones
- persist per-trigger last-fired state on `connectors.cron.state` and apply `skip`/`all`/`latest` catch-up on activation
- reject UTC-offset cron timezones at manifest-load time and document the connector/runtime behavior

## Context

Built on #203 (C-01 connector trait) and #195 (EventLog durable state).

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p harn-vm connectors::cron -- --nocapture`
- `make test`
