### PR TITLE
Add generic webhook receiver connector (closes #168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,17 @@ granular archaeology.
   docs at `docs/src/connectors/authoring.md`. Foundation for
   upcoming MVP connectors (cron, webhooks, GitHub, Slack, Linear,
   Notion, A2A push).
+- **Generic webhook receiver connector (#168).** `harn_vm::connectors`
+  now ships a built-in `GenericWebhookConnector` for inbound HTTP
+  webhook deliveries. The connector verifies Standard Webhooks,
+  Stripe-style, and GitHub-style HMAC signatures through the shared
+  C-01 helper, normalizes verified payloads into `TriggerEvent`
+  using `GenericWebhookPayload`, records verification failures on
+  `audit.signature_verify`, exposes the built-in provider through
+  `ConnectorRegistry::list()`, and adds authoring docs at
+  `docs/src/connectors/webhook.md`. Listener routing/TLS integration
+  remains deferred to O-02, and durable inbox-backed dedupe remains
+  deferred to T-09.
 - **Secret-provider primitives for reactive runtime work (#194,
   closes #154).** `harn_vm::secrets` now provides `SecretProvider`,
   `ChainSecretProvider`, zeroizing `SecretBytes`, and concrete env +

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -204,7 +204,7 @@ async fn initialize_connectors(
     let ctx = harn_vm::ConnectorCtx {
         event_log,
         secrets,
-        inbox: Arc::new(harn_vm::InboxIndex),
+        inbox: Arc::new(harn_vm::InboxIndex::default()),
         metrics: Arc::new(harn_vm::MetricsRegistry),
         rate_limiter: Arc::new(harn_vm::RateLimiterFactory::default()),
     };
@@ -245,6 +245,7 @@ fn trigger_binding_for(config: &ResolvedTriggerConfig) -> harn_vm::TriggerBindin
         provider: config.provider.clone(),
         kind: harn_vm::TriggerKind::from(trigger_kind_name(config.kind)),
         binding_id: config.id.clone(),
+        dedupe_key: None,
         config: JsonValue::Null,
     }
 }

--- a/crates/harn-vm/src/connectors/cron/tests.rs
+++ b/crates/harn-vm/src/connectors/cron/tests.rs
@@ -47,6 +47,7 @@ fn binding(id: &str, schedule: &str, timezone: &str, catchup_mode: CatchupMode) 
         provider: ProviderId::from("cron"),
         kind: TriggerKind::from("cron"),
         binding_id: id.to_string(),
+        dedupe_key: None,
         config: json!({
             "schedule": schedule,
             "timezone": timezone,
@@ -59,7 +60,7 @@ fn ctx(event_log: Arc<AnyEventLog>) -> ConnectorCtx {
     ConnectorCtx {
         event_log,
         secrets: Arc::new(FakeSecretProvider),
-        inbox: Arc::new(InboxIndex),
+        inbox: Arc::new(InboxIndex::default()),
         metrics: Arc::new(MetricsRegistry),
         rate_limiter: Arc::new(RateLimiterFactory::default()),
     }

--- a/crates/harn-vm/src/connectors/hmac.rs
+++ b/crates/harn-vm/src/connectors/hmac.rs
@@ -574,6 +574,9 @@ async fn reject<L: EventLog + ?Sized>(
         ConnectorError::DuplicateProvider(value) => {
             ConnectorError::DuplicateProvider(value.clone())
         }
+        ConnectorError::DuplicateDelivery(value) => {
+            ConnectorError::DuplicateDelivery(value.clone())
+        }
         ConnectorError::UnknownProvider(value) => ConnectorError::UnknownProvider(value.clone()),
         ConnectorError::MissingHeader(value) => ConnectorError::MissingHeader(value.clone()),
         ConnectorError::InvalidHeader { name, detail } => ConnectorError::InvalidHeader {

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -5,7 +5,7 @@
 //! connector ecosystem grows enough to justify extraction, the module can be
 //! split into a dedicated crate later without changing the high-level contract.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration as StdDuration, Instant};
@@ -24,6 +24,7 @@ pub mod cron;
 pub mod hmac;
 #[cfg(test)]
 pub(crate) mod test_util;
+pub mod webhook;
 
 pub use cron::{CatchupMode, CronConnector};
 pub use hmac::{
@@ -31,6 +32,7 @@ pub use hmac::{
     DEFAULT_STANDARD_WEBHOOKS_SIGNATURE_HEADER, DEFAULT_STANDARD_WEBHOOKS_TIMESTAMP_HEADER,
     DEFAULT_STRIPE_SIGNATURE_HEADER, SIGNATURE_VERIFY_AUDIT_TOPIC,
 };
+pub use webhook::{GenericWebhookConnector, WebhookSignatureVariant};
 
 /// Shared owned handle to a connector instance registered with the runtime.
 pub type ConnectorHandle = Arc<AsyncMutex<Box<dyn Connector>>>;
@@ -97,6 +99,7 @@ impl std::error::Error for ClientError {}
 #[derive(Debug)]
 pub enum ConnectorError {
     DuplicateProvider(String),
+    DuplicateDelivery(String),
     UnknownProvider(String),
     MissingHeader(String),
     InvalidHeader {
@@ -129,6 +132,7 @@ impl fmt::Display for ConnectorError {
             Self::DuplicateProvider(provider) => {
                 write!(f, "connector provider `{provider}` is already registered")
             }
+            Self::DuplicateDelivery(message) => message.fmt(f),
             Self::UnknownProvider(provider) => {
                 write!(f, "connector provider `{provider}` is not registered")
             }
@@ -192,8 +196,19 @@ pub struct ConnectorCtx {
 }
 
 /// Placeholder inbox index until the durable trigger inbox lands.
-#[derive(Clone, Debug, Default)]
-pub struct InboxIndex;
+#[derive(Debug, Default)]
+pub struct InboxIndex {
+    seen: Mutex<HashSet<(String, String)>>,
+}
+
+impl InboxIndex {
+    pub fn insert_if_new(&self, binding_id: &str, dedupe_key: &str) -> bool {
+        // TODO(T-09): replace this process-local stub with the durable trigger
+        // inbox dedupe index once the inbox lands.
+        let mut seen = self.seen.lock().expect("inbox index mutex poisoned");
+        seen.insert((binding_id.to_string(), dedupe_key.to_string()))
+    }
+}
 
 /// Placeholder metrics surface for connector-local counters and timings.
 #[derive(Clone, Debug, Default)]
@@ -260,6 +275,8 @@ pub struct TriggerBinding {
     pub kind: TriggerKind,
     pub binding_id: String,
     #[serde(default)]
+    pub dedupe_key: Option<String>,
+    #[serde(default)]
     pub config: JsonValue,
 }
 
@@ -273,6 +290,7 @@ impl TriggerBinding {
             provider,
             kind: kind.into(),
             binding_id: binding_id.into(),
+            dedupe_key: None,
             config: JsonValue::Null,
         }
     }
@@ -486,12 +504,25 @@ impl<'a> ScopedRateLimiter<'a> {
 }
 
 /// Runtime connector registry keyed by provider id.
-#[derive(Default)]
 pub struct ConnectorRegistry {
     connectors: BTreeMap<ProviderId, ConnectorHandle>,
 }
 
 impl ConnectorRegistry {
+    pub fn empty() -> Self {
+        Self {
+            connectors: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_defaults() -> Self {
+        let mut registry = Self::empty();
+        registry
+            .register(Box::new(GenericWebhookConnector::new()))
+            .expect("default connector registration should not fail");
+        registry
+    }
+
     pub fn register(&mut self, connector: Box<dyn Connector>) -> Result<(), ConnectorError> {
         let provider = connector.provider_id().clone();
         if self.connectors.contains_key(&provider) {
@@ -504,6 +535,10 @@ impl ConnectorRegistry {
 
     pub fn get(&self, id: &ProviderId) -> Option<ConnectorHandle> {
         self.connectors.get(id).cloned()
+    }
+
+    pub fn list(&self) -> Vec<ProviderId> {
+        self.connectors.keys().cloned().collect()
     }
 
     pub async fn activate_all(
@@ -520,6 +555,12 @@ impl ConnectorRegistry {
             handles.push(connector.activate(bindings).await?);
         }
         Ok(handles)
+    }
+}
+
+impl Default for ConnectorRegistry {
+    fn default() -> Self {
+        Self::with_defaults()
     }
 }
 
@@ -600,7 +641,7 @@ mod tests {
     #[tokio::test]
     async fn connector_registry_rejects_duplicate_providers() {
         let activate_calls = Arc::new(AtomicUsize::new(0));
-        let mut registry = ConnectorRegistry::default();
+        let mut registry = ConnectorRegistry::empty();
         registry
             .register(Box::new(FakeConnector::new(
                 "github",
@@ -621,7 +662,7 @@ mod tests {
     async fn connector_registry_activates_only_bound_connectors() {
         let github_calls = Arc::new(AtomicUsize::new(0));
         let slack_calls = Arc::new(AtomicUsize::new(0));
-        let mut registry = ConnectorRegistry::default();
+        let mut registry = ConnectorRegistry::empty();
         registry
             .register(Box::new(FakeConnector::new("github", github_calls.clone())))
             .unwrap();
@@ -672,5 +713,11 @@ mod tests {
         );
 
         assert_eq!(raw.json_body().unwrap(), json!({ "ok": true }));
+    }
+
+    #[test]
+    fn connector_registry_lists_builtin_webhook_connector() {
+        let registry = ConnectorRegistry::default();
+        assert_eq!(registry.list(), vec![ProviderId::from("webhook")]);
     }
 }

--- a/crates/harn-vm/src/connectors/webhook/mod.rs
+++ b/crates/harn-vm/src/connectors/webhook/mod.rs
@@ -1,0 +1,443 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::{Arc, RwLock};
+
+use async_trait::async_trait;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use serde::Deserialize;
+use serde_json::{json, Value as JsonValue};
+use sha2::{Digest, Sha256};
+use time::Duration;
+
+use crate::connectors::{
+    ActivationHandle, ClientError, Connector, ConnectorClient, ConnectorCtx, ConnectorError,
+    ProviderPayloadSchema, RawInbound, TriggerBinding, TriggerKind,
+};
+use crate::secrets::{SecretId, SecretVersion};
+use crate::triggers::{
+    redact_headers, HeaderRedactionPolicy, ProviderId, ProviderPayload, SignatureStatus, TraceId,
+    TriggerEvent, TriggerEventId,
+};
+
+pub mod variants;
+
+pub use variants::WebhookSignatureVariant;
+
+#[cfg(test)]
+mod tests;
+
+pub const WEBHOOK_PROVIDER_ID: &str = "webhook";
+const DEFAULT_EVENT_KIND: &str = "webhook";
+
+pub struct GenericWebhookConnector {
+    provider_id: ProviderId,
+    kinds: Vec<TriggerKind>,
+    client: Arc<GenericWebhookClient>,
+    state: RwLock<ConnectorState>,
+}
+
+#[derive(Default)]
+struct ConnectorState {
+    ctx: Option<ConnectorCtx>,
+    bindings: HashMap<String, ActivatedWebhookBinding>,
+}
+
+#[derive(Clone, Debug)]
+struct ActivatedWebhookBinding {
+    binding_id: String,
+    path: Option<String>,
+    signing_secret: SecretId,
+    signature_variant: WebhookSignatureVariant,
+    timestamp_tolerance: Option<Duration>,
+    dedupe_enabled: bool,
+    source: Option<String>,
+}
+
+#[derive(Default)]
+struct GenericWebhookClient;
+
+#[async_trait]
+impl ConnectorClient for GenericWebhookClient {
+    async fn call(&self, method: &str, _args: JsonValue) -> Result<JsonValue, ClientError> {
+        Err(ClientError::MethodNotFound(format!(
+            "generic webhook connector has no outbound method `{method}`"
+        )))
+    }
+}
+
+impl GenericWebhookConnector {
+    pub fn new() -> Self {
+        Self {
+            provider_id: ProviderId::from(WEBHOOK_PROVIDER_ID),
+            kinds: vec![TriggerKind::from("webhook")],
+            client: Arc::new(GenericWebhookClient),
+            state: RwLock::new(ConnectorState::default()),
+        }
+    }
+
+    fn binding_for_raw(&self, raw: &RawInbound) -> Result<ActivatedWebhookBinding, ConnectorError> {
+        let state = self.state.read().expect("webhook connector state poisoned");
+        let binding = if let Some(binding_id) =
+            raw.metadata.get("binding_id").and_then(JsonValue::as_str)
+        {
+            state.bindings.get(binding_id).cloned().ok_or_else(|| {
+                ConnectorError::Unsupported(format!(
+                    "generic webhook connector has no active binding `{binding_id}`"
+                ))
+            })?
+        } else if state.bindings.len() == 1 {
+            state
+                .bindings
+                .values()
+                .next()
+                .cloned()
+                .expect("checked single binding")
+        } else {
+            return Err(ConnectorError::Unsupported(
+                "generic webhook connector requires raw.metadata.binding_id when multiple bindings are active".to_string(),
+            ));
+        };
+        Ok(binding)
+    }
+
+    fn ctx(&self) -> Result<ConnectorCtx, ConnectorError> {
+        self.state
+            .read()
+            .expect("webhook connector state poisoned")
+            .ctx
+            .clone()
+            .ok_or_else(|| {
+                ConnectorError::Activation(
+                    "generic webhook connector must be initialized before use".to_string(),
+                )
+            })
+    }
+}
+
+impl Default for GenericWebhookConnector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Connector for GenericWebhookConnector {
+    fn provider_id(&self) -> &ProviderId {
+        &self.provider_id
+    }
+
+    fn kinds(&self) -> &[TriggerKind] {
+        &self.kinds
+    }
+
+    async fn init(&mut self, ctx: ConnectorCtx) -> Result<(), ConnectorError> {
+        self.state
+            .write()
+            .expect("webhook connector state poisoned")
+            .ctx = Some(ctx);
+        Ok(())
+    }
+
+    async fn activate(
+        &self,
+        bindings: &[TriggerBinding],
+    ) -> Result<ActivationHandle, ConnectorError> {
+        let mut configured = HashMap::new();
+        let mut paths = BTreeSet::new();
+        for binding in bindings {
+            let activated = ActivatedWebhookBinding::from_binding(binding)?;
+            if let Some(path) = &activated.path {
+                if !paths.insert(path.clone()) {
+                    return Err(ConnectorError::Activation(format!(
+                        "generic webhook connector path `{path}` is configured by multiple bindings"
+                    )));
+                }
+            }
+            configured.insert(binding.binding_id.clone(), activated);
+        }
+
+        self.state
+            .write()
+            .expect("webhook connector state poisoned")
+            .bindings = configured;
+        Ok(ActivationHandle::new(
+            self.provider_id.clone(),
+            bindings.len(),
+        ))
+    }
+
+    fn normalize_inbound(&self, raw: RawInbound) -> Result<TriggerEvent, ConnectorError> {
+        let ctx = self.ctx()?;
+        let binding = self.binding_for_raw(&raw)?;
+        let provider = self.provider_id.clone();
+        let received_at = raw.received_at;
+        let effective_headers = effective_headers(&raw.headers, binding.source.as_deref());
+        let secret = load_secret(&ctx, &binding.signing_secret)?;
+        binding.signature_variant.verify(
+            ctx.event_log.as_ref(),
+            &provider,
+            &raw.body,
+            &effective_headers,
+            secret.as_str(),
+            binding.timestamp_tolerance,
+            received_at,
+        )?;
+
+        let normalized_body = normalize_body(&raw.body, &effective_headers);
+        let kind = derive_kind(&raw, &effective_headers, &normalized_body);
+        let dedupe_key = derive_dedupe_key(
+            binding.signature_variant,
+            &effective_headers,
+            &normalized_body,
+            &raw.body,
+        );
+        if binding.dedupe_enabled && !ctx.inbox.insert_if_new(&binding.binding_id, &dedupe_key) {
+            return Err(ConnectorError::DuplicateDelivery(format!(
+                "duplicate webhook delivery `{dedupe_key}` for binding `{}`",
+                binding.binding_id
+            )));
+        }
+
+        let provider_payload = ProviderPayload::normalize(
+            &provider,
+            kind.as_str(),
+            &effective_headers,
+            normalized_body,
+        )
+        .map_err(|error| ConnectorError::Unsupported(error.to_string()))?;
+
+        Ok(TriggerEvent {
+            id: TriggerEventId::new(),
+            provider,
+            kind,
+            received_at,
+            occurred_at: raw
+                .occurred_at
+                .or_else(|| infer_occurred_at(&provider_payload)),
+            dedupe_key,
+            trace_id: TraceId::new(),
+            tenant_id: raw.tenant_id.clone(),
+            headers: redact_headers(&effective_headers, &HeaderRedactionPolicy::default()),
+            provider_payload,
+            signature_status: SignatureStatus::Verified,
+        })
+    }
+
+    fn payload_schema(&self) -> ProviderPayloadSchema {
+        ProviderPayloadSchema::named("GenericWebhookPayload")
+    }
+
+    fn client(&self) -> Arc<dyn ConnectorClient> {
+        self.client.clone()
+    }
+}
+
+impl ActivatedWebhookBinding {
+    fn from_binding(binding: &TriggerBinding) -> Result<Self, ConnectorError> {
+        let config: WebhookBindingConfig =
+            serde_json::from_value(binding.config.clone()).map_err(|error| {
+                ConnectorError::Activation(format!(
+                    "generic webhook binding `{}` has invalid config: {error}",
+                    binding.binding_id
+                ))
+            })?;
+        let signing_secret =
+            parse_secret_id(config.secrets.signing_secret.as_deref()).ok_or_else(|| {
+                ConnectorError::Activation(format!(
+                    "generic webhook binding `{}` requires secrets.signing_secret",
+                    binding.binding_id
+                ))
+            })?;
+        let signature_variant =
+            WebhookSignatureVariant::parse(config.webhook.signature_scheme.as_deref())?;
+        let timestamp_tolerance = match config.webhook.timestamp_tolerance_secs {
+            Some(seconds) if seconds < 0 => {
+                return Err(ConnectorError::Activation(format!(
+                    "generic webhook binding `{}` has a negative timestamp_tolerance_secs",
+                    binding.binding_id
+                )))
+            }
+            Some(seconds) => Some(Duration::seconds(seconds)),
+            None => signature_variant.default_timestamp_window(),
+        };
+
+        Ok(Self {
+            binding_id: binding.binding_id.clone(),
+            path: config.match_config.path,
+            signing_secret,
+            signature_variant,
+            timestamp_tolerance,
+            dedupe_enabled: binding.dedupe_key.is_some(),
+            source: config.webhook.source,
+        })
+    }
+}
+
+#[derive(Default, Deserialize)]
+struct WebhookBindingConfig {
+    #[serde(default, rename = "match")]
+    match_config: WebhookMatchConfig,
+    #[serde(default)]
+    secrets: WebhookSecretsConfig,
+    #[serde(default)]
+    webhook: WebhookConnectorConfig,
+}
+
+#[derive(Default, Deserialize)]
+struct WebhookMatchConfig {
+    path: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+struct WebhookSecretsConfig {
+    signing_secret: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+struct WebhookConnectorConfig {
+    signature_scheme: Option<String>,
+    timestamp_tolerance_secs: Option<i64>,
+    source: Option<String>,
+}
+
+fn effective_headers(
+    headers: &BTreeMap<String, String>,
+    source: Option<&str>,
+) -> BTreeMap<String, String> {
+    let mut effective = headers.clone();
+    if let Some(content_type) = header_value(headers, "content-type") {
+        effective
+            .entry("Content-Type".to_string())
+            .or_insert_with(|| content_type.to_string());
+    }
+    if let Some(source) = source.or_else(|| header_value(headers, "x-webhook-source")) {
+        effective
+            .entry("X-Webhook-Source".to_string())
+            .or_insert_with(|| source.to_string());
+    }
+    if let Some(event) = header_value(headers, "x-github-event") {
+        effective
+            .entry("X-GitHub-Event".to_string())
+            .or_insert_with(|| event.to_string());
+    }
+    if let Some(delivery) = header_value(headers, "x-github-delivery") {
+        effective
+            .entry("X-GitHub-Delivery".to_string())
+            .or_insert_with(|| delivery.to_string());
+    }
+    effective
+}
+
+fn load_secret(ctx: &ConnectorCtx, secret_id: &SecretId) -> Result<String, ConnectorError> {
+    let secret = futures::executor::block_on(ctx.secrets.get(secret_id))?;
+    secret.with_exposed(|bytes| {
+        std::str::from_utf8(bytes)
+            .map(|value| value.to_string())
+            .map_err(|error| {
+                ConnectorError::Secret(format!(
+                    "generic webhook signing secret `{secret_id}` is not valid UTF-8: {error}"
+                ))
+            })
+    })
+}
+
+fn normalize_body(body: &[u8], headers: &BTreeMap<String, String>) -> JsonValue {
+    let content_type = header_value(headers, "content-type").unwrap_or_default();
+    if content_type.contains("json") {
+        if let Ok(value) = serde_json::from_slice(body) {
+            return value;
+        }
+    }
+    serde_json::from_slice(body).unwrap_or_else(|_| {
+        json!({
+            "raw_base64": BASE64_STANDARD.encode(body),
+            "raw_utf8": std::str::from_utf8(body).ok(),
+        })
+    })
+}
+
+fn derive_kind(raw: &RawInbound, headers: &BTreeMap<String, String>, body: &JsonValue) -> String {
+    if !raw.kind.trim().is_empty() {
+        return raw.kind.clone();
+    }
+    header_value(headers, "x-github-event")
+        .map(ToString::to_string)
+        .or_else(|| {
+            body.get("type")
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string)
+        })
+        .or_else(|| {
+            body.get("event")
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string)
+        })
+        .unwrap_or_else(|| DEFAULT_EVENT_KIND.to_string())
+}
+
+fn derive_dedupe_key(
+    variant: WebhookSignatureVariant,
+    headers: &BTreeMap<String, String>,
+    body: &JsonValue,
+    raw_body: &[u8],
+) -> String {
+    match variant {
+        WebhookSignatureVariant::Standard => header_value(headers, "webhook-id")
+            .map(ToString::to_string)
+            .unwrap_or_else(|| fallback_body_digest(raw_body)),
+        WebhookSignatureVariant::Stripe => body
+            .get("id")
+            .and_then(JsonValue::as_str)
+            .map(ToString::to_string)
+            .unwrap_or_else(|| fallback_body_digest(raw_body)),
+        WebhookSignatureVariant::GitHub => header_value(headers, "x-github-delivery")
+            .map(ToString::to_string)
+            .unwrap_or_else(|| fallback_body_digest(raw_body)),
+    }
+}
+
+fn infer_occurred_at(provider_payload: &ProviderPayload) -> Option<time::OffsetDateTime> {
+    let ProviderPayload::Known(payload) = provider_payload else {
+        return None;
+    };
+    let raw = match payload {
+        crate::triggers::event::KnownProviderPayload::Webhook(payload) => &payload.raw,
+        _ => return None,
+    };
+    raw.get("timestamp")
+        .and_then(JsonValue::as_str)
+        .and_then(|value| {
+            time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339).ok()
+        })
+}
+
+fn header_value<'a>(headers: &'a BTreeMap<String, String>, name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
+}
+
+fn parse_secret_id(raw: Option<&str>) -> Option<SecretId> {
+    let trimmed = raw?.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let (base, version) = match trimmed.rsplit_once('@') {
+        Some((base, version_text)) => {
+            let version = version_text.parse::<u64>().ok()?;
+            (base, SecretVersion::Exact(version))
+        }
+        None => (trimmed, SecretVersion::Latest),
+    };
+    let (namespace, name) = base.split_once('/')?;
+    if namespace.is_empty() || name.is_empty() {
+        return None;
+    }
+    Some(SecretId::new(namespace, name).with_version(version))
+}
+
+fn fallback_body_digest(body: &[u8]) -> String {
+    let digest = Sha256::digest(body);
+    format!("sha256:{}", hex::encode(digest))
+}

--- a/crates/harn-vm/src/connectors/webhook/tests.rs
+++ b/crates/harn-vm/src/connectors/webhook/tests.rs
@@ -1,0 +1,389 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::json;
+use time::OffsetDateTime;
+
+use super::{GenericWebhookConnector, WebhookSignatureVariant};
+use crate::connectors::{
+    Connector, ConnectorCtx, ConnectorError, ConnectorRegistry, InboxIndex, MetricsRegistry,
+    RateLimiterFactory, RawInbound, TriggerBinding,
+};
+use crate::event_log::{AnyEventLog, EventLog, MemoryEventLog, Topic};
+use crate::secrets::{SecretBytes, SecretError, SecretId, SecretMeta, SecretProvider};
+use crate::triggers::{ProviderId, SignatureStatus};
+
+struct StaticSecretProvider {
+    namespace: String,
+    secrets: BTreeMap<SecretId, String>,
+}
+
+impl StaticSecretProvider {
+    fn new(namespace: &str, secrets: BTreeMap<SecretId, String>) -> Self {
+        Self {
+            namespace: namespace.to_string(),
+            secrets,
+        }
+    }
+}
+
+#[async_trait]
+impl SecretProvider for StaticSecretProvider {
+    async fn get(&self, id: &SecretId) -> Result<SecretBytes, SecretError> {
+        self.secrets
+            .get(id)
+            .cloned()
+            .map(SecretBytes::from)
+            .ok_or_else(|| SecretError::NotFound {
+                provider: self.namespace.clone(),
+                id: id.clone(),
+            })
+    }
+
+    async fn put(&self, _id: &SecretId, _value: SecretBytes) -> Result<(), SecretError> {
+        Err(SecretError::Unsupported {
+            provider: self.namespace.clone(),
+            operation: "put",
+        })
+    }
+
+    async fn rotate(&self, _id: &SecretId) -> Result<crate::secrets::RotationHandle, SecretError> {
+        Err(SecretError::Unsupported {
+            provider: self.namespace.clone(),
+            operation: "rotate",
+        })
+    }
+
+    async fn list(&self, _prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError> {
+        Ok(Vec::new())
+    }
+
+    fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    fn supports_versions(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Clone)]
+struct TestHarness {
+    log: Arc<AnyEventLog>,
+    connector: Arc<GenericWebhookConnector>,
+}
+
+impl TestHarness {
+    async fn new(binding: TriggerBinding, secret: &str) -> Self {
+        let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(32)));
+        let secrets = Arc::new(StaticSecretProvider::new(
+            "webhook",
+            BTreeMap::from([(
+                SecretId::new("webhook", "test-signing-secret"),
+                secret.to_string(),
+            )]),
+        ));
+        let ctx = ConnectorCtx {
+            event_log: log.clone(),
+            secrets,
+            inbox: Arc::new(InboxIndex::default()),
+            metrics: Arc::new(MetricsRegistry),
+            rate_limiter: Arc::new(RateLimiterFactory::default()),
+        };
+
+        let mut connector = GenericWebhookConnector::new();
+        connector.init(ctx).await.unwrap();
+        connector.activate(&[binding]).await.unwrap();
+
+        Self {
+            log,
+            connector: Arc::new(connector),
+        }
+    }
+
+    async fn audit_events(&self) -> Vec<(u64, crate::event_log::LogEvent)> {
+        self.log
+            .read_range(
+                &Topic::new(crate::connectors::SIGNATURE_VERIFY_AUDIT_TOPIC).unwrap(),
+                None,
+                32,
+            )
+            .await
+            .unwrap()
+    }
+}
+
+#[derive(Clone)]
+struct Case {
+    name: &'static str,
+    variant: WebhookSignatureVariant,
+    secret: &'static str,
+    headers: BTreeMap<String, String>,
+    body: Vec<u8>,
+    received_at: OffsetDateTime,
+    expect_ok: bool,
+}
+
+fn binding(variant: WebhookSignatureVariant, dedupe_key: Option<&str>) -> TriggerBinding {
+    let mut binding = TriggerBinding::new(ProviderId::from("webhook"), "webhook", "webhook.test");
+    binding.dedupe_key = dedupe_key.map(ToString::to_string);
+    binding.config = json!({
+        "match": { "path": "/hooks/test" },
+        "secrets": { "signing_secret": "webhook/test-signing-secret" },
+        "webhook": {
+            "signature_scheme": match variant {
+                WebhookSignatureVariant::Standard => "standard",
+                WebhookSignatureVariant::Stripe => "stripe",
+                WebhookSignatureVariant::GitHub => "github",
+            },
+            "source": "fixtures",
+        }
+    });
+    binding
+}
+
+fn raw_inbound(
+    headers: BTreeMap<String, String>,
+    body: &[u8],
+    received_at: OffsetDateTime,
+) -> RawInbound {
+    let mut raw = RawInbound::new("", headers, body.to_vec());
+    raw.received_at = received_at;
+    raw
+}
+
+#[tokio::test]
+async fn webhook_variants_cover_valid_and_failure_cases() {
+    // Standard Webhooks vector from the public reference fixtures / spec examples:
+    // https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries
+    // https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md
+    let standard_valid = Case {
+        name: "standard_valid",
+        variant: WebhookSignatureVariant::Standard,
+        secret: "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw",
+        headers: BTreeMap::from([
+            (
+                "webhook-id".to_string(),
+                "msg_p5jXN8AQM9LWM0D4loKWxJek".to_string(),
+            ),
+            (
+                "webhook-signature".to_string(),
+                "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE=".to_string(),
+            ),
+            ("webhook-timestamp".to_string(), "1614265330".to_string()),
+            ("Content-Type".to_string(), "application/json".to_string()),
+        ]),
+        body: br#"{"test": 2432232314}"#.to_vec(),
+        received_at: OffsetDateTime::from_unix_timestamp(1_614_265_330).unwrap(),
+        expect_ok: true,
+    };
+    let standard_tampered = Case {
+        name: "standard_tampered_body",
+        body: br#"{"test": 2432232315}"#.to_vec(),
+        expect_ok: false,
+        ..standard_valid.clone()
+    };
+    let standard_bad_timestamp = Case {
+        name: "standard_bad_timestamp",
+        received_at: OffsetDateTime::from_unix_timestamp(1_614_265_700).unwrap(),
+        expect_ok: false,
+        ..standard_valid.clone()
+    };
+    let standard_bad_sig = Case {
+        name: "standard_bad_sig",
+        headers: BTreeMap::from([
+            (
+                "webhook-id".to_string(),
+                "msg_p5jXN8AQM9LWM0D4loKWxJek".to_string(),
+            ),
+            (
+                "webhook-signature".to_string(),
+                "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".to_string(),
+            ),
+            ("webhook-timestamp".to_string(), "1614265330".to_string()),
+            ("Content-Type".to_string(), "application/json".to_string()),
+        ]),
+        expect_ok: false,
+        ..standard_valid.clone()
+    };
+
+    // Stripe signature shape and webhook payload fixture based on the official docs:
+    // https://docs.stripe.com/webhooks#signatures
+    let stripe_valid = Case {
+        name: "stripe_valid",
+        variant: WebhookSignatureVariant::Stripe,
+        secret: "whsec_test_secret",
+        headers: BTreeMap::from([(
+            "Stripe-Signature".to_string(),
+            "t=12345,v1=2672d138c9a412830f3bfe2ecc5bfb3277cf6f5b49d0119d77dd6cb64da1257e"
+                .to_string(),
+        )]),
+        body: b"{\n  \"id\": \"evt_test_webhook\",\n  \"object\": \"event\"\n}".to_vec(),
+        received_at: OffsetDateTime::from_unix_timestamp(12_350).unwrap(),
+        expect_ok: true,
+    };
+    let stripe_tampered = Case {
+        name: "stripe_tampered_body",
+        body: b"{\n  \"id\": \"evt_test_webhook_tampered\",\n  \"object\": \"event\"\n}".to_vec(),
+        expect_ok: false,
+        ..stripe_valid.clone()
+    };
+    let stripe_bad_timestamp = Case {
+        name: "stripe_bad_timestamp",
+        received_at: OffsetDateTime::from_unix_timestamp(13_000).unwrap(),
+        expect_ok: false,
+        ..stripe_valid.clone()
+    };
+    let stripe_bad_sig = Case {
+        name: "stripe_bad_sig",
+        headers: BTreeMap::from([(
+            "Stripe-Signature".to_string(),
+            "t=12345,v1=0000000000000000000000000000000000000000000000000000000000000000"
+                .to_string(),
+        )]),
+        expect_ok: false,
+        ..stripe_valid.clone()
+    };
+
+    // GitHub vector from the official validating-webhook-deliveries docs:
+    // https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+    let github_valid = Case {
+        name: "github_valid",
+        variant: WebhookSignatureVariant::GitHub,
+        secret: "It's a Secret to Everybody",
+        headers: BTreeMap::from([
+            (
+                "X-Hub-Signature-256".to_string(),
+                "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17"
+                    .to_string(),
+            ),
+            ("X-GitHub-Delivery".to_string(), "delivery-123".to_string()),
+            ("X-GitHub-Event".to_string(), "ping".to_string()),
+            ("Content-Type".to_string(), "application/json".to_string()),
+        ]),
+        body: b"Hello, World!".to_vec(),
+        received_at: OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap(),
+        expect_ok: true,
+    };
+    let github_tampered = Case {
+        name: "github_tampered_body",
+        body: b"Hello, World?\n".to_vec(),
+        expect_ok: false,
+        ..github_valid.clone()
+    };
+    let github_bad_timestamp = Case {
+        name: "github_bad_timestamp_ignored",
+        // GitHub's webhook signature scheme is untimestamped, so skewed receive
+        // times should not change verification behavior.
+        received_at: OffsetDateTime::from_unix_timestamp(1_800_000_000).unwrap(),
+        expect_ok: true,
+        ..github_valid.clone()
+    };
+    let github_bad_sig = Case {
+        name: "github_bad_sig",
+        headers: BTreeMap::from([
+            (
+                "X-Hub-Signature-256".to_string(),
+                "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+                    .to_string(),
+            ),
+            ("X-GitHub-Delivery".to_string(), "delivery-123".to_string()),
+            ("X-GitHub-Event".to_string(), "ping".to_string()),
+            ("Content-Type".to_string(), "application/json".to_string()),
+        ]),
+        expect_ok: false,
+        ..github_valid.clone()
+    };
+
+    let cases = vec![
+        standard_valid,
+        standard_tampered,
+        standard_bad_timestamp,
+        standard_bad_sig,
+        stripe_valid,
+        stripe_tampered,
+        stripe_bad_timestamp,
+        stripe_bad_sig,
+        github_valid,
+        github_tampered,
+        github_bad_timestamp,
+        github_bad_sig,
+    ];
+
+    for case in cases {
+        let harness = TestHarness::new(binding(case.variant, None), case.secret).await;
+        let result = harness.connector.normalize_inbound(raw_inbound(
+            case.headers.clone(),
+            &case.body,
+            case.received_at,
+        ));
+        let audit_events = harness.audit_events().await;
+
+        if case.expect_ok {
+            let event =
+                result.unwrap_or_else(|error| panic!("{} should succeed: {error}", case.name));
+            assert_eq!(event.provider.as_str(), "webhook", "{}", case.name);
+            assert!(
+                matches!(event.signature_status, SignatureStatus::Verified),
+                "{}",
+                case.name
+            );
+            assert_eq!(audit_events.len(), 0, "{}", case.name);
+        } else {
+            let error = result.unwrap_err();
+            assert!(
+                matches!(
+                    error,
+                    ConnectorError::InvalidSignature(_)
+                        | ConnectorError::TimestampOutOfWindow { .. }
+                        | ConnectorError::InvalidHeader { .. }
+                ),
+                "{} produced unexpected error: {error:?}",
+                case.name
+            );
+            assert_eq!(audit_events.len(), 1, "{}", case.name);
+        }
+    }
+}
+
+#[tokio::test]
+async fn normalize_inbound_dedupes_on_binding_delivery_key() {
+    let harness = TestHarness::new(
+        binding(WebhookSignatureVariant::Standard, Some("event.dedupe_key")),
+        "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw",
+    )
+    .await;
+    let headers = BTreeMap::from([
+        (
+            "webhook-id".to_string(),
+            "msg_p5jXN8AQM9LWM0D4loKWxJek".to_string(),
+        ),
+        (
+            "webhook-signature".to_string(),
+            "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE=".to_string(),
+        ),
+        ("webhook-timestamp".to_string(), "1614265330".to_string()),
+        ("Content-Type".to_string(), "application/json".to_string()),
+    ]);
+    let raw = raw_inbound(
+        headers,
+        br#"{"test": 2432232314}"#,
+        OffsetDateTime::from_unix_timestamp(1_614_265_330).unwrap(),
+    );
+
+    let first = harness.connector.normalize_inbound(raw.clone()).unwrap();
+    assert_eq!(first.dedupe_key, "msg_p5jXN8AQM9LWM0D4loKWxJek");
+
+    let duplicate = harness.connector.normalize_inbound(raw).unwrap_err();
+    assert!(matches!(duplicate, ConnectorError::DuplicateDelivery(_)));
+}
+
+#[test]
+fn connector_registry_default_lists_generic_webhook_connector() {
+    let registry = ConnectorRegistry::default();
+    assert!(registry
+        .list()
+        .iter()
+        .any(|provider| provider.as_str() == "webhook"));
+}

--- a/crates/harn-vm/src/connectors/webhook/variants.rs
+++ b/crates/harn-vm/src/connectors/webhook/variants.rs
@@ -1,0 +1,65 @@
+use std::collections::BTreeMap;
+
+use futures::executor::block_on;
+use serde::{Deserialize, Serialize};
+use time::{Duration, OffsetDateTime};
+
+use crate::connectors::hmac::{verify_hmac_signed, HmacSignatureStyle};
+use crate::connectors::ConnectorError;
+use crate::event_log::AnyEventLog;
+use crate::triggers::ProviderId;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebhookSignatureVariant {
+    Standard,
+    Stripe,
+    GitHub,
+}
+
+impl WebhookSignatureVariant {
+    pub fn parse(raw: Option<&str>) -> Result<Self, ConnectorError> {
+        match raw.unwrap_or("standard") {
+            "standard" => Ok(Self::Standard),
+            "stripe" => Ok(Self::Stripe),
+            "github" => Ok(Self::GitHub),
+            other => Err(ConnectorError::Unsupported(format!(
+                "unsupported generic webhook signature scheme `{other}`; expected one of standard, stripe, github"
+            ))),
+        }
+    }
+
+    pub fn default_timestamp_window(self) -> Option<Duration> {
+        match self {
+            Self::Standard | Self::Stripe => Some(Duration::minutes(5)),
+            Self::GitHub => None,
+        }
+    }
+
+    pub fn verify(
+        self,
+        event_log: &AnyEventLog,
+        provider: &ProviderId,
+        body: &[u8],
+        headers: &BTreeMap<String, String>,
+        secret: &str,
+        timestamp_window: Option<Duration>,
+        now: OffsetDateTime,
+    ) -> Result<(), ConnectorError> {
+        let style = match self {
+            Self::Standard => HmacSignatureStyle::standard_webhooks(),
+            Self::Stripe => HmacSignatureStyle::stripe(),
+            Self::GitHub => HmacSignatureStyle::github(),
+        };
+        block_on(verify_hmac_signed(
+            event_log,
+            provider,
+            style,
+            body,
+            headers,
+            secret,
+            timestamp_window.or_else(|| self.default_timestamp_window()),
+            now,
+        ))
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -41,9 +41,9 @@ pub use connectors::{
     cron::{CatchupMode, CronConnector},
     hmac::verify_hmac_signed,
     ActivationHandle, ClientError, Connector, ConnectorClient, ConnectorCtx, ConnectorError,
-    ConnectorRegistry, GenericWebhookConnector, InboxIndex, MetricsRegistry,
-    ProviderPayloadSchema, RateLimitConfig, RateLimiterFactory, RawInbound, TriggerBinding,
-    TriggerKind, TriggerRegistry, WebhookSignatureVariant,
+    ConnectorRegistry, GenericWebhookConnector, InboxIndex, MetricsRegistry, ProviderPayloadSchema,
+    RateLimitConfig, RateLimiterFactory, RawInbound, TriggerBinding, TriggerKind, TriggerRegistry,
+    WebhookSignatureVariant,
 };
 pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -41,8 +41,9 @@ pub use connectors::{
     cron::{CatchupMode, CronConnector},
     hmac::verify_hmac_signed,
     ActivationHandle, ClientError, Connector, ConnectorClient, ConnectorCtx, ConnectorError,
-    ConnectorRegistry, InboxIndex, MetricsRegistry, ProviderPayloadSchema, RateLimitConfig,
-    RateLimiterFactory, RawInbound, TriggerBinding, TriggerKind, TriggerRegistry,
+    ConnectorRegistry, GenericWebhookConnector, InboxIndex, MetricsRegistry,
+    ProviderPayloadSchema, RateLimitConfig, RateLimiterFactory, RawInbound, TriggerBinding,
+    TriggerKind, TriggerRegistry, WebhookSignatureVariant,
 };
 pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -31,6 +31,7 @@
 - [Connector authoring](./connectors/authoring.md)
 - [Trigger registry](./triggers/registry.md)
 - [Cron connector](./connectors/cron.md)
+- [Generic webhook connector](./connectors/webhook.md)
 - [Cookbook](./cookbook.md)
 - [Tutorial: code review agent](./tutorial-code-review-agent.md)
 - [Tutorial: MCP server](./tutorial-mcp-server.md)

--- a/docs/src/connectors/webhook.md
+++ b/docs/src/connectors/webhook.md
@@ -1,0 +1,107 @@
+# Generic webhook connector
+
+`GenericWebhookConnector` is the first concrete inbound connector built on top
+of the C-01 `Connector` trait. It accepts generic HTTP webhook deliveries,
+verifies supported HMAC signature conventions against the raw request body, and
+normalizes the delivery into a `TriggerEvent` with the built-in
+`GenericWebhookPayload` shape.
+
+The current implementation is intentionally small:
+
+- activation-only; the O-02 HTTP listener still wires request routing later
+- raw-body verification for Standard Webhooks, Stripe-style, and GitHub-style
+  signatures
+- `TriggerEvent` normalization with header redaction and provider payload
+  preservation
+- process-local dedupe stub keyed by the manifest `dedupe_key` opt-in until the
+  durable trigger inbox lands
+
+## Manifest shape
+
+```toml
+[[triggers]]
+id = "incoming-webhook"
+kind = "webhook"
+provider = "webhook"
+match = { path = "/hooks/incoming" }
+handler = "handlers::on_webhook"
+dedupe_key = "event.dedupe_key"
+secrets = { signing_secret = "webhook/incoming" }
+
+[triggers.webhook]
+signature_scheme = "standard"  # "standard" | "stripe" | "github"
+timestamp_tolerance_secs = 300
+source = "incoming"
+```
+
+`signature_scheme` defaults to `"standard"` when omitted. Standard Webhooks and
+Stripe-style signatures default to a 5-minute timestamp tolerance. GitHub-style
+signatures are untimestamped and therefore ignore timestamp skew.
+
+## Supported signature conventions
+
+The connector delegates signature checks to
+`harn_vm::connectors::verify_hmac_signed(...)`, so it inherits the shared
+verification rules from C-01:
+
+- verify against the raw inbound bytes, not a reparsed body
+- compare signatures in constant time
+- enforce a timestamp window for timestamped schemes
+- append signature failures to the `audit.signature_verify` event-log topic
+
+Supported variants:
+
+- Standard Webhooks:
+  `webhook-id`, `webhook-timestamp`, `webhook-signature: v1,<base64>`
+- Stripe-style:
+  `Stripe-Signature: t=<unix>,v1=<hex>[,v1=<hex>...]`
+- GitHub-style:
+  `X-Hub-Signature-256: sha256=<hex>`
+
+## Normalized event fields
+
+For successful deliveries the connector produces:
+
+- `provider = "webhook"`
+- `kind` from `RawInbound.kind`, then `X-GitHub-Event`, then payload `type` /
+  `event`, else `"webhook"`
+- `dedupe_key` from the provider-native delivery identifier:
+  `webhook-id`, Stripe event `id`, or `X-GitHub-Delivery`
+- `signature_status = { state: "verified" }`
+- `provider_payload = GenericWebhookPayload`
+
+`GenericWebhookPayload.raw` keeps parsed JSON when the body is JSON. When the
+payload is not valid JSON, the connector preserves the bytes as:
+
+```json
+{
+  "raw_base64": "<base64-encoded body>",
+  "raw_utf8": "optional utf-8 view"
+}
+```
+
+`GenericWebhookPayload.source` comes from `X-Webhook-Source` when present, or
+from the binding's optional `webhook.source` override.
+
+## Dedupe
+
+If the trigger manifest declares `dedupe_key`, the connector records the
+normalized `event.dedupe_key` in the current inbox dedupe stub and rejects
+replays for the same binding. This is process-local today; durable inbox-backed
+dedupe is still deferred to T-09.
+
+## Activation and listener integration
+
+The connector's `activate()` hook validates the binding config and reserves
+unique `match.path` values across active bindings. Because O-02 is still
+outstanding, request routing is not implemented here. Until the listener lands:
+
+- a single active binding can call `normalize_inbound(...)` directly
+- multiple active bindings must pass the selected `binding_id` in
+  `RawInbound.metadata.binding_id`
+
+## Notes and follow-up
+
+- Signature failures are audited even when normalization returns an error.
+- Production TLS handling is owned by the eventual listener, not this connector.
+- Streaming request bodies larger than 10 MiB is still a follow-up item.


### PR DESCRIPTION
## Summary
- add a built-in `GenericWebhookConnector` on top of the C-01 connector trait from #203
- verify Standard Webhooks, Stripe-style, and GitHub-style HMAC deliveries and normalize them into `TriggerEvent`
- add registry/list exposure, dedupe stub wiring, focused tests, docs, and a changelog entry

## Notes
- built on #203 (C-01)
- depends on the `audit.signature_verify` event-log topic from #200, which is already merged
- HTTP listener integration is deferred to O-02
- durable inbox-backed dedupe is still deferred to T-09

## Validation
- `cargo fmt --all`
- `cargo clippy -p harn-vm --lib --tests -- -D warnings`
- `cargo test -p harn-vm connectors::webhook -- --nocapture`
- repository pre-push checks (`make test` path, markdown lint, portal lint)
