### PR TITLE
[codex] Serialize cwd-mutating tests via shared mutex (closes #204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ granular archaeology.
 
 ### Fixed
 
+- **Flaky cwd-mutating test collisions (#204).** Added a shared-process
+  cwd mutex so parallel `cargo test` no longer observes mid-test cwd
+  swaps. `check_manifest_reports_loaded_triggers` and
+  `run_tests_uses_file_parent_as_execution_cwd_and_restores_shell_cwd`
+  no longer flake on CI.
+
 - **Structured-output schema contract for OpenRouter Gemini (#208,
   closes #206).** Schema-mode `llm_call(...)` no longer returns a
   success envelope with `data == nil` after prose-only or

--- a/crates/harn-cli/src/commands/doctor.rs
+++ b/crates/harn-cli/src/commands/doctor.rs
@@ -745,6 +745,7 @@ mod tests {
 
     #[test]
     fn event_log_check_reports_backend_and_location() {
+        let _cwd_guard = crate::tests::common::cwd_lock::lock_cwd();
         let dir = tempfile::tempdir().expect("tempdir");
         let previous = std::env::current_dir().expect("cwd");
         std::env::set_current_dir(dir.path()).expect("set current dir");
@@ -776,6 +777,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn check_manifest_reports_loaded_triggers() {
+        let _cwd_guard = crate::tests::common::cwd_lock::lock_cwd_async().await;
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::create_dir_all(dir.path().join(".git")).expect("git dir");
         std::fs::write(

--- a/crates/harn-cli/src/commands/playground.rs
+++ b/crates/harn-cli/src/commands/playground.rs
@@ -415,20 +415,6 @@ impl Drop for ScopedEnv {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::OnceLock;
-    use tokio::sync::Mutex;
-
-    /// Serialize `execute_playground` tests so the process-wide env vars
-    /// `HARN_LLM_PROVIDER` / `HARN_LLM_MODEL` / `HARN_TASK` written by
-    /// `ScopedEnv::apply` don't race between parallel test threads — the
-    /// symptom was `playground_executes_host_backed_script` seeing an
-    /// anthropic default instead of the per-test `mock` override. Uses
-    /// `tokio::sync::Mutex` so the guard can be held across `.await`
-    /// without tripping clippy's `await_holding_lock` check.
-    fn playground_env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
 
     fn write_file(path: &Path, contents: &str) {
         if let Some(parent) = path.parent() {
@@ -463,7 +449,7 @@ pub fn request_permission(tool_name, request_args) { return true }
 
     #[tokio::test(flavor = "current_thread")]
     async fn playground_executes_host_backed_script() {
-        let _guard = playground_env_lock().lock().await;
+        let _guard = crate::tests::common::env_lock::lock_env().lock().await;
         let temp = tempfile::tempdir().unwrap();
         let host = temp.path().join("host.harn");
         let script = temp.path().join("pipeline.harn");
@@ -504,7 +490,7 @@ pipeline default(task) {
 
     #[tokio::test(flavor = "current_thread")]
     async fn playground_reports_missing_capability_with_caller_context() {
-        let _guard = playground_env_lock().lock().await;
+        let _guard = crate::tests::common::env_lock::lock_env().lock().await;
         let temp = tempfile::tempdir().unwrap();
         let host = temp.path().join("host.harn");
         let script = temp.path().join("pipeline.harn");
@@ -541,7 +527,7 @@ pipeline default(task) {
 
     #[tokio::test(flavor = "current_thread")]
     async fn playground_replays_cli_llm_mock_fixtures() {
-        let _guard = playground_env_lock().lock().await;
+        let _guard = crate::tests::common::env_lock::lock_env().lock().await;
         let temp = tempfile::tempdir().unwrap();
         let host = temp.path().join("host.harn");
         let script = temp.path().join("pipeline.harn");

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -6,6 +6,8 @@ mod config;
 mod package;
 mod skill_loader;
 mod test_runner;
+#[cfg(test)]
+mod tests;
 
 use clap::{error::ErrorKind, CommandFactory, Parser as ClapParser};
 use std::path::{Path, PathBuf};

--- a/crates/harn-cli/src/test_runner.rs
+++ b/crates/harn-cli/src/test_runner.rs
@@ -393,6 +393,8 @@ mod tests {
 
     #[tokio::test]
     async fn run_tests_uses_file_parent_as_execution_cwd_and_restores_shell_cwd() {
+        let _cwd_guard = crate::tests::common::cwd_lock::lock_cwd_async().await;
+        let _env_guard = crate::tests::common::env_lock::lock_env().lock().await;
         let temp = TempTestDir::new();
         temp.write(
             "suite/test_cwd.harn",

--- a/crates/harn-cli/src/tests/common/cwd_lock.rs
+++ b/crates/harn-cli/src/tests/common/cwd_lock.rs
@@ -1,0 +1,15 @@
+use std::sync::OnceLock;
+
+use tokio::sync::{Mutex, MutexGuard};
+
+static CWD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Serialize tests that mutate the process-wide current directory.
+pub(crate) fn lock_cwd() -> MutexGuard<'static, ()> {
+    CWD_LOCK.get_or_init(|| Mutex::new(())).blocking_lock()
+}
+
+/// Async variant for tests that hold the cwd lock across `.await`.
+pub(crate) async fn lock_cwd_async() -> MutexGuard<'static, ()> {
+    CWD_LOCK.get_or_init(|| Mutex::new(())).lock().await
+}

--- a/crates/harn-cli/src/tests/common/env_lock.rs
+++ b/crates/harn-cli/src/tests/common/env_lock.rs
@@ -1,0 +1,10 @@
+use std::sync::OnceLock;
+
+use tokio::sync::Mutex;
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Serialize tests that mutate process-wide environment variables.
+pub(crate) fn lock_env() -> &'static Mutex<()> {
+    ENV_LOCK.get_or_init(|| Mutex::new(()))
+}

--- a/crates/harn-cli/src/tests/common/mod.rs
+++ b/crates/harn-cli/src/tests/common/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod cwd_lock;
+pub(crate) mod env_lock;

--- a/crates/harn-cli/src/tests/mod.rs
+++ b/crates/harn-cli/src/tests/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod common;


### PR DESCRIPTION
## Summary
- add shared test-only process locks under `crates/harn-cli/src/tests/common` and use the cwd lock in every `harn-cli` unit test that mutates process cwd
- cover the flaking `check_manifest_reports_loaded_triggers` and `run_tests_uses_file_parent_as_execution_cwd_and_restores_shell_cwd` paths, plus the other audited cwd-mutating `doctor` unit test
- add the Unreleased changelog entry for the cwd collision fix

## Root Cause
`commands::doctor::tests::check_manifest_reports_loaded_triggers` and `test_runner::tests::run_tests_uses_file_parent_as_execution_cwd_and_restores_shell_cwd` were both mutating process-wide cwd under parallel `cargo test`, so one test could observe the other test's cwd swap mid-assertion and fail with `NotFound` or incorrect results.

This PR takes option A from #204: serialize the cwd-mutating tests with a shared mutex rather than widening production API surface. While validating the fix, I also moved the existing playground env lock into the same shared test-helper area so the default-parallel `harn-cli` suite no longer trips on a separate `HARN_LLM_PROVIDER` race.

This should unblock the admin-merge-through pain on the connector series / wave-3 sweep.

## Validation
- `cargo fmt --all`
- `cargo test -p harn-cli` (4 consecutive green runs under default parallelism)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `make test`