### PR TITLE
Add handler dispatcher with URI routing + retry policy (closes #159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,21 @@ granular archaeology.
 
 ### Added
 
+- **Handler dispatcher with URI routing, retries, cancellation, and
+  streaming trigger action-graph updates (#159).** Added
+  `harn_vm::triggers::Dispatcher` with EventLog-backed
+  `trigger.inbox` / `trigger.outbox` / `trigger.attempts` / `trigger.dlq`
+  topics, local handler execution against the live trigger registry,
+  manifest-driven retry policy normalization (`Svix`, `Linear`,
+  `Exponential`), cooperative shutdown propagation into in-flight local
+  handler VMs, and new dispatcher lifecycle records on
+  `triggers.lifecycle`. Closes the T-10 deferral for
+  `dispatch` / `retry` / `dlq` action-graph nodes and
+  `retry` / `dlq_move` edges on the local-handler path.
+  `a2a_hop` / `worker_enqueue` remain deferred to O-04 / O-05; the
+  current `a2a://...` and `worker://...` routes return explicit
+  `NotImplemented` errors that point at those tickets.
+
 - **`harn orchestrator serve` CLI scaffold (#209, closes #178).** Added
   a new `harn orchestrator` command family with a real `serve`
   subcommand plus placeholder `inspect`, `replay`, `dlq`, and

--- a/crates/harn-cli/src/commands/doctor.rs
+++ b/crates/harn-cli/src/commands/doctor.rs
@@ -285,6 +285,15 @@ async fn check_manifest() -> Vec<DoctorCheck> {
                         ),
                     });
                 }
+                let dispatcher = harn_vm::snapshot_dispatcher_stats();
+                checks.push(DoctorCheck {
+                    status: DoctorStatus::Ok,
+                    label: "dispatcher".to_string(),
+                    detail: format!(
+                        "in_flight={} retry_queue_depth={} dlq_depth={}",
+                        dispatcher.in_flight, dispatcher.retry_queue_depth, dispatcher.dlq_depth,
+                    ),
+                });
                 harn_vm::clear_trigger_registry();
             }
             Err(error) => checks.push(DoctorCheck {
@@ -826,5 +835,15 @@ pub fn on_new_issue(event: TriggerEvent) {
         assert!(trigger.detail.contains("state=active"));
         assert!(trigger.detail.contains("version=1"));
         assert!(trigger.detail.contains("metrics=received=0"));
+
+        let dispatcher = checks
+            .iter()
+            .find(|check| check.label == "dispatcher")
+            .expect("dispatcher check");
+        assert_eq!(dispatcher.status, DoctorStatus::Ok);
+        assert_eq!(
+            dispatcher.detail,
+            "in_flight=0 retry_queue_depth=0 dlq_depth=0"
+        );
     }
 }

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -1391,6 +1391,13 @@ fn manifest_trigger_binding_spec(trigger: CollectedManifestTrigger) -> harn_vm::
     let provider = config.provider.clone();
     let match_events = config.match_.events.clone();
     let dedupe_key = config.dedupe_key.clone();
+    let retry = harn_vm::TriggerRetryConfig::new(
+        config.retry.max,
+        match config.retry.backoff {
+            TriggerRetryBackoff::Immediate => harn_vm::RetryPolicy::Linear { delay_ms: 0 },
+            TriggerRetryBackoff::Svix => harn_vm::RetryPolicy::Svix,
+        },
+    );
     let filter = config.filter.clone();
     let daily_cost_usd = config.budget.daily_cost_usd;
     let max_concurrent = config.budget.max_concurrent;
@@ -1423,6 +1430,7 @@ fn manifest_trigger_binding_spec(trigger: CollectedManifestTrigger) -> harn_vm::
         provider,
         handler,
         when,
+        retry,
         match_events,
         dedupe_key,
         filter,

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -74,14 +74,16 @@ pub use stdlib::{
 };
 pub use store::register_store_builtins;
 pub use triggers::{
-    begin_in_flight, clear_trigger_registry, drain, dynamic_deregister, dynamic_register,
-    finish_in_flight, install_manifest_triggers, redact_headers, register_provider_schema,
-    registered_provider_schema_names, reset_provider_catalog, resolve_live_trigger_binding,
-    snapshot_trigger_bindings, HeaderRedactionPolicy, ProviderCatalog, ProviderCatalogError,
-    ProviderId, ProviderPayload, ProviderSchema, SignatureStatus, TenantId, TraceId,
-    TriggerBindingSnapshot, TriggerBindingSource, TriggerBindingSpec, TriggerDispatchOutcome,
-    TriggerEvent, TriggerEventId, TriggerHandlerSpec, TriggerId, TriggerMetricsSnapshot,
-    TriggerPredicateSpec, TriggerRegistryError, TriggerState,
+    begin_in_flight, clear_dispatcher_state, clear_trigger_registry, drain, dynamic_deregister,
+    dynamic_register, finish_in_flight, install_manifest_triggers, redact_headers,
+    register_provider_schema, registered_provider_schema_names, reset_provider_catalog,
+    resolve_live_trigger_binding, snapshot_dispatcher_stats, snapshot_trigger_bindings,
+    DispatchError, DispatchOutcome, DispatchStatus, Dispatcher, DispatcherStatsSnapshot,
+    HeaderRedactionPolicy, ProviderCatalog, ProviderCatalogError, ProviderId, ProviderPayload,
+    ProviderSchema, RetryPolicy, SignatureStatus, TenantId, TraceId, TriggerBindingSnapshot,
+    TriggerBindingSource, TriggerBindingSpec, TriggerDispatchOutcome, TriggerEvent, TriggerEventId,
+    TriggerHandlerSpec, TriggerId, TriggerMetricsSnapshot, TriggerPredicateSpec,
+    TriggerRegistryError, TriggerRetryConfig, TriggerState,
 };
 pub use value::*;
 pub use vm::*;
@@ -103,6 +105,7 @@ pub fn reset_thread_local_state() {
     event_log::reset_active_event_log();
     stdlib::reset_stdlib_state();
     orchestration::clear_runtime_hooks();
+    triggers::clear_dispatcher_state();
     triggers::clear_trigger_registry();
     events::reset_event_sinks();
     agent_events::reset_all_sinks();

--- a/crates/harn-vm/src/orchestration/records.rs
+++ b/crates/harn-vm/src/orchestration/records.rs
@@ -14,6 +14,23 @@ use crate::llm::vm_value_to_json;
 use crate::triggers::{SignatureStatus, TriggerEvent};
 use crate::value::{VmError, VmValue};
 
+pub const ACTION_GRAPH_NODE_KIND_RUN: &str = "run";
+pub const ACTION_GRAPH_NODE_KIND_TRIGGER: &str = "trigger";
+pub const ACTION_GRAPH_NODE_KIND_PREDICATE: &str = "predicate";
+pub const ACTION_GRAPH_NODE_KIND_STAGE: &str = "stage";
+pub const ACTION_GRAPH_NODE_KIND_WORKER: &str = "worker";
+pub const ACTION_GRAPH_NODE_KIND_DISPATCH: &str = "dispatch";
+pub const ACTION_GRAPH_NODE_KIND_RETRY: &str = "retry";
+pub const ACTION_GRAPH_NODE_KIND_DLQ: &str = "dlq";
+
+pub const ACTION_GRAPH_EDGE_KIND_ENTRY: &str = "entry";
+pub const ACTION_GRAPH_EDGE_KIND_TRIGGER_DISPATCH: &str = "trigger_dispatch";
+pub const ACTION_GRAPH_EDGE_KIND_PREDICATE_GATE: &str = "predicate_gate";
+pub const ACTION_GRAPH_EDGE_KIND_TRANSITION: &str = "transition";
+pub const ACTION_GRAPH_EDGE_KIND_DELEGATES: &str = "delegates";
+pub const ACTION_GRAPH_EDGE_KIND_RETRY: &str = "retry";
+pub const ACTION_GRAPH_EDGE_KIND_DLQ_MOVE: &str = "dlq_move";
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct LlmUsageRecord {
@@ -496,9 +513,9 @@ fn run_trace_id(run: &RunRecord, trigger_event: Option<&TriggerEvent>) -> Option
 
 fn action_graph_kind_for_stage(stage: &RunStageRecord) -> &'static str {
     if stage.kind == "condition" {
-        "predicate"
+        ACTION_GRAPH_NODE_KIND_PREDICATE
     } else {
-        "stage"
+        ACTION_GRAPH_NODE_KIND_STAGE
     }
 }
 
@@ -509,17 +526,24 @@ fn append_action_graph_node(
     nodes.push(record);
 }
 
+pub async fn append_action_graph_update(
+    headers: BTreeMap<String, String>,
+    payload: serde_json::Value,
+) -> Result<(), crate::event_log::LogError> {
+    let Some(log) = active_event_log() else {
+        return Ok(());
+    };
+    let topic = Topic::new("observability.action_graph")
+        .expect("static observability.action_graph topic should always be valid");
+    let record = EventLogRecord::new("action_graph_update", payload).with_headers(headers);
+    log.append(&topic, record).await.map(|_| ())
+}
+
 fn publish_action_graph_event(
     run: &RunRecord,
     observability: &RunObservabilityRecord,
     path: &Path,
 ) {
-    let Some(log) = active_event_log() else {
-        return;
-    };
-    let Ok(topic) = Topic::new("observability.action_graph") else {
-        return;
-    };
     let trigger_event = trigger_event_from_run(run);
     let mut headers = BTreeMap::new();
     headers.insert("run_id".to_string(), run.id.clone());
@@ -527,23 +551,19 @@ fn publish_action_graph_event(
     if let Some(trace_id) = run_trace_id(run, trigger_event.as_ref()) {
         headers.insert("trace_id".to_string(), trace_id);
     }
-    let record = EventLogRecord::new(
-        "action_graph_update",
-        serde_json::json!({
-            "run_id": run.id,
-            "workflow_id": run.workflow_id,
-            "persisted_path": path.to_string_lossy(),
-            "status": run.status,
-            "observability": observability,
-        }),
-    )
-    .with_headers(headers);
+    let payload = serde_json::json!({
+        "run_id": run.id,
+        "workflow_id": run.workflow_id,
+        "persisted_path": path.to_string_lossy(),
+        "status": run.status,
+        "observability": observability,
+    });
     if let Ok(handle) = tokio::runtime::Handle::try_current() {
         handle.spawn(async move {
-            let _ = log.append(&topic, record).await;
+            let _ = append_action_graph_update(headers, payload).await;
         });
     } else {
-        let _ = futures::executor::block_on(log.append(&topic, record));
+        let _ = futures::executor::block_on(append_action_graph_update(headers, payload));
     }
 }
 
@@ -771,7 +791,7 @@ pub fn derive_run_observability(
                 .workflow_name
                 .clone()
                 .unwrap_or_else(|| run.workflow_id.clone()),
-            kind: "run".to_string(),
+            kind: ACTION_GRAPH_NODE_KIND_RUN.to_string(),
             status: run.status.clone(),
             outcome: run.status.clone(),
             trace_id: propagated_trace_id.clone(),
@@ -790,7 +810,7 @@ pub fn derive_run_observability(
             RunActionGraphNodeRecord {
                 id: trigger_node_id.clone(),
                 label: format!("{}:{}", trigger_event.provider.as_str(), trigger_event.kind),
-                kind: "trigger".to_string(),
+                kind: ACTION_GRAPH_NODE_KIND_TRIGGER.to_string(),
                 status: "received".to_string(),
                 outcome: signature_status_label(&trigger_event.signature_status).to_string(),
                 trace_id: Some(trigger_event.trace_id.0.clone()),
@@ -804,7 +824,7 @@ pub fn derive_run_observability(
         action_graph_edges.push(RunActionGraphEdgeRecord {
             from_id: root_node_id.clone(),
             to_id: trigger_node_id.clone(),
-            kind: "entry".to_string(),
+            kind: ACTION_GRAPH_EDGE_KIND_ENTRY.to_string(),
             label: Some(trigger_event.id.0.clone()),
         });
         entry_node_id = trigger_node_id;
@@ -862,9 +882,9 @@ pub fn derive_run_observability(
                 from_id: entry_node_id.clone(),
                 to_id: graph_node_id.clone(),
                 kind: if trigger_event.is_some() {
-                    "trigger_dispatch".to_string()
+                    ACTION_GRAPH_EDGE_KIND_TRIGGER_DISPATCH.to_string()
                 } else {
-                    "entry".to_string()
+                    ACTION_GRAPH_EDGE_KIND_ENTRY.to_string()
                 },
                 label: None,
             });
@@ -1009,9 +1029,9 @@ pub fn derive_run_observability(
             from_id,
             to_id,
             kind: if from_stage.is_some_and(|stage| stage.kind == "condition") {
-                "predicate_gate".to_string()
+                ACTION_GRAPH_EDGE_KIND_PREDICATE_GATE.to_string()
             } else {
-                "transition".to_string()
+                ACTION_GRAPH_EDGE_KIND_TRANSITION.to_string()
             },
             label: transition.branch.clone(),
         });
@@ -1027,7 +1047,7 @@ pub fn derive_run_observability(
                 RunActionGraphNodeRecord {
                     id: worker_node_id.clone(),
                     label: child.worker_name.clone(),
-                    kind: "worker".to_string(),
+                    kind: ACTION_GRAPH_NODE_KIND_WORKER.to_string(),
                     status: child.status.clone(),
                     outcome: child.status.clone(),
                     trace_id: propagated_trace_id.clone(),
@@ -1043,7 +1063,7 @@ pub fn derive_run_observability(
                     action_graph_edges.push(RunActionGraphEdgeRecord {
                         from_id: stage_node_id.clone(),
                         to_id: worker_node_id,
-                        kind: "delegates".to_string(),
+                        kind: ACTION_GRAPH_EDGE_KIND_DELEGATES.to_string(),
                         label: Some(child.worker_name.clone()),
                     });
                 }

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -12,6 +12,7 @@ use crate::triggers::{
     begin_in_flight, dynamic_register, finish_in_flight, resolve_live_trigger_binding,
     snapshot_trigger_bindings, TriggerBindingSnapshot, TriggerBindingSource, TriggerBindingSpec,
     TriggerDispatchOutcome, TriggerEvent, TriggerEventId, TriggerHandlerSpec, TriggerPredicateSpec,
+    TriggerRetryConfig,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
@@ -487,6 +488,7 @@ fn parse_trigger_config(config: &BTreeMap<String, VmValue>) -> Result<TriggerBin
         provider,
         handler,
         when,
+        retry: TriggerRetryConfig::default(),
         match_events,
         dedupe_key,
         filter,

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -1,0 +1,1077 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use futures::{pin_mut, StreamExt};
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+use crate::event_log::{active_event_log, AnyEventLog, EventLog, LogError, LogEvent, Topic};
+use crate::llm::vm_value_to_json;
+use crate::orchestration::{
+    append_action_graph_update, RunActionGraphEdgeRecord, RunActionGraphNodeRecord,
+    RunObservabilityRecord, ACTION_GRAPH_EDGE_KIND_DLQ_MOVE, ACTION_GRAPH_EDGE_KIND_PREDICATE_GATE,
+    ACTION_GRAPH_EDGE_KIND_RETRY, ACTION_GRAPH_EDGE_KIND_TRIGGER_DISPATCH,
+    ACTION_GRAPH_NODE_KIND_DISPATCH, ACTION_GRAPH_NODE_KIND_DLQ, ACTION_GRAPH_NODE_KIND_RETRY,
+    ACTION_GRAPH_NODE_KIND_TRIGGER,
+};
+use crate::stdlib::json_to_vm_value;
+use crate::value::{error_to_category, ErrorCategory, VmError, VmValue};
+use crate::vm::Vm;
+
+use self::uri::DispatchUri;
+use super::registry::matching_bindings;
+use super::registry::{TriggerBinding, TriggerHandlerSpec};
+use super::{begin_in_flight, finish_in_flight, TriggerDispatchOutcome, TriggerEvent};
+
+pub mod retry;
+pub mod uri;
+
+pub use retry::{RetryPolicy, TriggerRetryConfig, DEFAULT_MAX_ATTEMPTS};
+
+const TRIGGER_INBOX_TOPIC: &str = "trigger.inbox";
+const TRIGGER_OUTBOX_TOPIC: &str = "trigger.outbox";
+const TRIGGER_ATTEMPTS_TOPIC: &str = "trigger.attempts";
+const TRIGGER_DLQ_TOPIC: &str = "trigger.dlq";
+const TRIGGERS_LIFECYCLE_TOPIC: &str = "triggers.lifecycle";
+
+thread_local! {
+    static ACTIVE_DISPATCHER_STATE: RefCell<Option<Arc<DispatcherRuntimeState>>> = const { RefCell::new(None) };
+}
+
+#[derive(Clone)]
+pub struct Dispatcher {
+    base_vm: Rc<Vm>,
+    event_log: Arc<AnyEventLog>,
+    cancel_tx: broadcast::Sender<()>,
+    state: Arc<DispatcherRuntimeState>,
+}
+
+#[derive(Debug)]
+struct DispatcherRuntimeState {
+    in_flight: AtomicU64,
+    retry_queue_depth: AtomicU64,
+    dlq: Mutex<Vec<DlqEntry>>,
+    cancel_tokens: Mutex<Vec<Arc<std::sync::atomic::AtomicBool>>>,
+    shutting_down: std::sync::atomic::AtomicBool,
+}
+
+impl Default for DispatcherRuntimeState {
+    fn default() -> Self {
+        Self {
+            in_flight: AtomicU64::new(0),
+            retry_queue_depth: AtomicU64::new(0),
+            dlq: Mutex::new(Vec::new()),
+            cancel_tokens: Mutex::new(Vec::new()),
+            shutting_down: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DispatcherStatsSnapshot {
+    pub in_flight: u64,
+    pub retry_queue_depth: u64,
+    pub dlq_depth: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DispatchStatus {
+    Succeeded,
+    Failed,
+    Dlq,
+    Skipped,
+    Cancelled,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DispatchOutcome {
+    pub trigger_id: String,
+    pub binding_key: String,
+    pub event_id: String,
+    pub attempt_count: u32,
+    pub status: DispatchStatus,
+    pub handler_kind: String,
+    pub target_uri: String,
+    pub result: Option<serde_json::Value>,
+    pub error: Option<String>,
+}
+
+impl Default for DispatchOutcome {
+    fn default() -> Self {
+        Self {
+            trigger_id: String::new(),
+            binding_key: String::new(),
+            event_id: String::new(),
+            attempt_count: 0,
+            status: DispatchStatus::Failed,
+            handler_kind: String::new(),
+            target_uri: String::new(),
+            result: None,
+            error: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DispatchAttemptRecord {
+    pub trigger_id: String,
+    pub binding_key: String,
+    pub event_id: String,
+    pub attempt: u32,
+    pub handler_kind: String,
+    pub started_at: String,
+    pub completed_at: String,
+    pub outcome: String,
+    pub error_msg: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DlqEntry {
+    pub trigger_id: String,
+    pub binding_key: String,
+    pub event: TriggerEvent,
+    pub attempt_count: u32,
+    pub final_error: String,
+    pub attempts: Vec<DispatchAttemptRecord>,
+}
+
+#[derive(Debug)]
+pub enum DispatchError {
+    EventLog(String),
+    Registry(String),
+    Serde(String),
+    Local(String),
+    Cancelled(String),
+    NotImplemented(String),
+}
+
+impl std::fmt::Display for DispatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EventLog(message)
+            | Self::Registry(message)
+            | Self::Serde(message)
+            | Self::Local(message)
+            | Self::Cancelled(message)
+            | Self::NotImplemented(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for DispatchError {}
+
+impl DispatchError {
+    fn retryable(&self) -> bool {
+        !matches!(self, Self::Cancelled(_) | Self::NotImplemented(_))
+    }
+}
+
+impl From<LogError> for DispatchError {
+    fn from(value: LogError) -> Self {
+        Self::EventLog(value.to_string())
+    }
+}
+
+impl Dispatcher {
+    pub fn new(base_vm: Vm) -> Result<Self, DispatchError> {
+        let event_log = active_event_log().ok_or_else(|| {
+            DispatchError::EventLog("dispatcher requires an active event log".to_string())
+        })?;
+        Ok(Self::with_event_log(base_vm, event_log))
+    }
+
+    pub fn with_event_log(base_vm: Vm, event_log: Arc<AnyEventLog>) -> Self {
+        let state = Arc::new(DispatcherRuntimeState::default());
+        ACTIVE_DISPATCHER_STATE.with(|slot| {
+            *slot.borrow_mut() = Some(state.clone());
+        });
+        let (cancel_tx, _) = broadcast::channel(32);
+        Self {
+            base_vm: Rc::new(base_vm),
+            event_log,
+            cancel_tx,
+            state,
+        }
+    }
+
+    pub fn snapshot(&self) -> DispatcherStatsSnapshot {
+        DispatcherStatsSnapshot {
+            in_flight: self.state.in_flight.load(Ordering::Relaxed),
+            retry_queue_depth: self.state.retry_queue_depth.load(Ordering::Relaxed),
+            dlq_depth: self
+                .state
+                .dlq
+                .lock()
+                .expect("dispatcher dlq poisoned")
+                .len() as u64,
+        }
+    }
+
+    pub fn dlq_entries(&self) -> Vec<DlqEntry> {
+        self.state
+            .dlq
+            .lock()
+            .expect("dispatcher dlq poisoned")
+            .clone()
+    }
+
+    pub fn shutdown(&self) {
+        self.state.shutting_down.store(true, Ordering::SeqCst);
+        for token in self
+            .state
+            .cancel_tokens
+            .lock()
+            .expect("dispatcher cancel tokens poisoned")
+            .iter()
+        {
+            token.store(true, Ordering::SeqCst);
+        }
+        let _ = self.cancel_tx.send(());
+    }
+
+    pub async fn enqueue(&self, event: TriggerEvent) -> Result<u64, DispatchError> {
+        let topic = Topic::new(TRIGGER_INBOX_TOPIC).expect("static trigger.inbox topic is valid");
+        let headers = event_headers(&event, None, None);
+        let payload = serde_json::to_value(&event)
+            .map_err(|error| DispatchError::Serde(error.to_string()))?;
+        self.event_log
+            .append(
+                &topic,
+                LogEvent::new("event_ingested", payload).with_headers(headers),
+            )
+            .await
+            .map_err(DispatchError::from)
+    }
+
+    pub async fn run(&self) -> Result<(), DispatchError> {
+        let topic = Topic::new(TRIGGER_INBOX_TOPIC).expect("static trigger.inbox topic is valid");
+        let stream = self.event_log.clone().subscribe(&topic, None).await?;
+        pin_mut!(stream);
+        let mut cancel_rx = self.cancel_tx.subscribe();
+
+        loop {
+            tokio::select! {
+                received = stream.next() => {
+                    let Some(received) = received else {
+                        break;
+                    };
+                    let (_, event) = received.map_err(DispatchError::from)?;
+                    if event.kind != "event_ingested" {
+                        continue;
+                    }
+                    let trigger_event: TriggerEvent = serde_json::from_value(event.payload)
+                        .map_err(|error| DispatchError::Serde(error.to_string()))?;
+                    let dispatcher = self.clone();
+                    tokio::task::spawn_local(async move {
+                        let _ = dispatcher.dispatch_event(trigger_event).await;
+                    });
+                }
+                _ = recv_cancel(&mut cancel_rx) => break,
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn dispatch_event(
+        &self,
+        event: TriggerEvent,
+    ) -> Result<Vec<DispatchOutcome>, DispatchError> {
+        let bindings = matching_bindings(&event);
+        let mut outcomes = Vec::new();
+        for binding in bindings {
+            outcomes.push(self.dispatch(&binding, event.clone()).await?);
+        }
+        Ok(outcomes)
+    }
+
+    pub async fn dispatch(
+        &self,
+        binding: &TriggerBinding,
+        event: TriggerEvent,
+    ) -> Result<DispatchOutcome, DispatchError> {
+        let binding_key = binding.binding_key();
+        let route = DispatchUri::from(&binding.handler);
+        let trigger_id = binding.id.as_str().to_string();
+        let event_id = event.id.0.clone();
+        self.state.in_flight.fetch_add(1, Ordering::Relaxed);
+        begin_in_flight(binding.id.as_str(), binding.version)
+            .map_err(|error| DispatchError::Registry(error.to_string()))?;
+
+        let mut attempts = Vec::new();
+        let mut source_node_id = format!("trigger:{}", event.id.0);
+        self.emit_action_graph(
+            &event,
+            vec![RunActionGraphNodeRecord {
+                id: source_node_id.clone(),
+                label: format!("{}:{}", event.provider.as_str(), event.kind),
+                kind: ACTION_GRAPH_NODE_KIND_TRIGGER.to_string(),
+                status: "received".to_string(),
+                outcome: "received".to_string(),
+                trace_id: Some(event.trace_id.0.clone()),
+                stage_id: None,
+                node_id: None,
+                worker_id: None,
+                run_id: None,
+                run_path: None,
+            }],
+            Vec::new(),
+            serde_json::json!({
+                "source": "dispatcher",
+                "trigger_id": trigger_id,
+                "binding_key": binding_key,
+                "event_id": event_id,
+            }),
+        )
+        .await?;
+
+        if let Some(predicate) = binding.when.as_ref() {
+            let predicate_node_id = format!("predicate:{binding_key}:{}", event.id.0);
+            let predicate_result = self
+                .invoke_vm_callable(&predicate.closure, &event, &mut self.cancel_tx.subscribe())
+                .await?;
+            let passed = matches!(predicate_result, VmValue::Bool(true));
+            self.emit_action_graph(
+                &event,
+                vec![RunActionGraphNodeRecord {
+                    id: predicate_node_id.clone(),
+                    label: predicate.raw.clone(),
+                    kind: crate::orchestration::ACTION_GRAPH_NODE_KIND_PREDICATE.to_string(),
+                    status: "completed".to_string(),
+                    outcome: passed.to_string(),
+                    trace_id: Some(event.trace_id.0.clone()),
+                    stage_id: None,
+                    node_id: None,
+                    worker_id: None,
+                    run_id: None,
+                    run_path: None,
+                }],
+                vec![RunActionGraphEdgeRecord {
+                    from_id: source_node_id.clone(),
+                    to_id: predicate_node_id.clone(),
+                    kind: ACTION_GRAPH_EDGE_KIND_TRIGGER_DISPATCH.to_string(),
+                    label: None,
+                }],
+                serde_json::json!({
+                    "source": "dispatcher",
+                    "trigger_id": binding.id.as_str(),
+                    "binding_key": binding.binding_key(),
+                    "event_id": event.id.0,
+                    "predicate": predicate.raw,
+                }),
+            )
+            .await?;
+
+            if !passed {
+                finish_in_flight(
+                    binding.id.as_str(),
+                    binding.version,
+                    TriggerDispatchOutcome::Dispatched,
+                )
+                .await
+                .map_err(|error| DispatchError::Registry(error.to_string()))?;
+                self.state.in_flight.fetch_sub(1, Ordering::Relaxed);
+                return Ok(DispatchOutcome {
+                    trigger_id: binding.id.as_str().to_string(),
+                    binding_key: binding.binding_key(),
+                    event_id: event.id.0,
+                    attempt_count: 0,
+                    status: DispatchStatus::Skipped,
+                    handler_kind: route.kind().to_string(),
+                    target_uri: route.target_uri(),
+                    result: None,
+                    error: None,
+                });
+            }
+
+            source_node_id = predicate_node_id;
+        }
+
+        let mut previous_retry_node = None;
+        let max_attempts = binding.retry.max_attempts();
+        for attempt in 1..=max_attempts {
+            let started_at = now_rfc3339();
+            let dispatch_node_id = format!("dispatch:{binding_key}:{}:{attempt}", event.id.0);
+            self.append_lifecycle_event(
+                "DispatchStarted",
+                &event,
+                binding,
+                serde_json::json!({
+                    "event_id": event.id.0,
+                    "attempt": attempt,
+                    "handler_kind": route.kind(),
+                    "target_uri": route.target_uri(),
+                }),
+            )
+            .await?;
+            self.append_topic_event(
+                TRIGGER_OUTBOX_TOPIC,
+                "dispatch_started",
+                &event,
+                Some(binding),
+                Some(attempt),
+                serde_json::json!({
+                    "event_id": event.id.0,
+                    "attempt": attempt,
+                    "trigger_id": binding.id.as_str(),
+                    "binding_key": binding.binding_key(),
+                    "handler_kind": route.kind(),
+                    "target_uri": route.target_uri(),
+                }),
+            )
+            .await?;
+
+            let mut dispatch_edges = Vec::new();
+            if attempt == 1 {
+                dispatch_edges.push(RunActionGraphEdgeRecord {
+                    from_id: source_node_id.clone(),
+                    to_id: dispatch_node_id.clone(),
+                    kind: if binding.when.is_some() {
+                        ACTION_GRAPH_EDGE_KIND_PREDICATE_GATE.to_string()
+                    } else {
+                        ACTION_GRAPH_EDGE_KIND_TRIGGER_DISPATCH.to_string()
+                    },
+                    label: binding.when.as_ref().map(|_| "true".to_string()),
+                });
+            } else if let Some(retry_node_id) = previous_retry_node.take() {
+                dispatch_edges.push(RunActionGraphEdgeRecord {
+                    from_id: retry_node_id,
+                    to_id: dispatch_node_id.clone(),
+                    kind: ACTION_GRAPH_EDGE_KIND_RETRY.to_string(),
+                    label: Some(format!("attempt {attempt}")),
+                });
+            }
+
+            self.emit_action_graph(
+                &event,
+                vec![RunActionGraphNodeRecord {
+                    id: dispatch_node_id.clone(),
+                    label: route.target_uri(),
+                    kind: ACTION_GRAPH_NODE_KIND_DISPATCH.to_string(),
+                    status: "running".to_string(),
+                    outcome: format!("attempt_{attempt}"),
+                    trace_id: Some(event.trace_id.0.clone()),
+                    stage_id: None,
+                    node_id: None,
+                    worker_id: None,
+                    run_id: None,
+                    run_path: None,
+                }],
+                dispatch_edges,
+                serde_json::json!({
+                    "source": "dispatcher",
+                    "trigger_id": binding.id.as_str(),
+                    "binding_key": binding.binding_key(),
+                    "event_id": event.id.0,
+                    "attempt": attempt,
+                    "handler_kind": route.kind(),
+                    "target_uri": route.target_uri(),
+                }),
+            )
+            .await?;
+
+            let result = self
+                .dispatch_once(binding, &route, &event, &mut self.cancel_tx.subscribe())
+                .await;
+            let completed_at = now_rfc3339();
+
+            match result {
+                Ok(result) => {
+                    let attempt_record = DispatchAttemptRecord {
+                        trigger_id: binding.id.as_str().to_string(),
+                        binding_key: binding.binding_key(),
+                        event_id: event.id.0.clone(),
+                        attempt,
+                        handler_kind: route.kind().to_string(),
+                        started_at,
+                        completed_at,
+                        outcome: "success".to_string(),
+                        error_msg: None,
+                    };
+                    attempts.push(attempt_record.clone());
+                    self.append_attempt_record(&event, binding, &attempt_record)
+                        .await?;
+                    self.append_lifecycle_event(
+                        "DispatchSucceeded",
+                        &event,
+                        binding,
+                        serde_json::json!({
+                            "event_id": event.id.0,
+                            "attempt": attempt,
+                            "handler_kind": route.kind(),
+                            "target_uri": route.target_uri(),
+                            "result": result,
+                        }),
+                    )
+                    .await?;
+                    self.append_topic_event(
+                        TRIGGER_OUTBOX_TOPIC,
+                        "dispatch_succeeded",
+                        &event,
+                        Some(binding),
+                        Some(attempt),
+                        serde_json::json!({
+                            "event_id": event.id.0,
+                            "attempt": attempt,
+                            "trigger_id": binding.id.as_str(),
+                            "binding_key": binding.binding_key(),
+                            "handler_kind": route.kind(),
+                            "target_uri": route.target_uri(),
+                            "result": result,
+                        }),
+                    )
+                    .await?;
+                    finish_in_flight(
+                        binding.id.as_str(),
+                        binding.version,
+                        TriggerDispatchOutcome::Dispatched,
+                    )
+                    .await
+                    .map_err(|error| DispatchError::Registry(error.to_string()))?;
+                    self.state.in_flight.fetch_sub(1, Ordering::Relaxed);
+                    return Ok(DispatchOutcome {
+                        trigger_id: binding.id.as_str().to_string(),
+                        binding_key: binding.binding_key(),
+                        event_id: event.id.0,
+                        attempt_count: attempt,
+                        status: DispatchStatus::Succeeded,
+                        handler_kind: route.kind().to_string(),
+                        target_uri: route.target_uri(),
+                        result: Some(result),
+                        error: None,
+                    });
+                }
+                Err(error) => {
+                    let attempt_record = DispatchAttemptRecord {
+                        trigger_id: binding.id.as_str().to_string(),
+                        binding_key: binding.binding_key(),
+                        event_id: event.id.0.clone(),
+                        attempt,
+                        handler_kind: route.kind().to_string(),
+                        started_at,
+                        completed_at,
+                        outcome: if matches!(error, DispatchError::Cancelled(_)) {
+                            "cancelled".to_string()
+                        } else {
+                            "failed".to_string()
+                        },
+                        error_msg: Some(error.to_string()),
+                    };
+                    attempts.push(attempt_record.clone());
+                    self.append_attempt_record(&event, binding, &attempt_record)
+                        .await?;
+                    self.append_lifecycle_event(
+                        "DispatchFailed",
+                        &event,
+                        binding,
+                        serde_json::json!({
+                            "event_id": event.id.0,
+                            "attempt": attempt,
+                            "handler_kind": route.kind(),
+                            "target_uri": route.target_uri(),
+                            "error": error.to_string(),
+                        }),
+                    )
+                    .await?;
+                    self.append_topic_event(
+                        TRIGGER_OUTBOX_TOPIC,
+                        "dispatch_failed",
+                        &event,
+                        Some(binding),
+                        Some(attempt),
+                        serde_json::json!({
+                            "event_id": event.id.0,
+                            "attempt": attempt,
+                            "trigger_id": binding.id.as_str(),
+                            "binding_key": binding.binding_key(),
+                            "handler_kind": route.kind(),
+                            "target_uri": route.target_uri(),
+                            "error": error.to_string(),
+                        }),
+                    )
+                    .await?;
+
+                    if !error.retryable() {
+                        finish_in_flight(
+                            binding.id.as_str(),
+                            binding.version,
+                            TriggerDispatchOutcome::Failed,
+                        )
+                        .await
+                        .map_err(|registry_error| {
+                            DispatchError::Registry(registry_error.to_string())
+                        })?;
+                        self.state.in_flight.fetch_sub(1, Ordering::Relaxed);
+                        return Ok(DispatchOutcome {
+                            trigger_id: binding.id.as_str().to_string(),
+                            binding_key: binding.binding_key(),
+                            event_id: event.id.0,
+                            attempt_count: attempt,
+                            status: if matches!(error, DispatchError::Cancelled(_)) {
+                                DispatchStatus::Cancelled
+                            } else {
+                                DispatchStatus::Failed
+                            },
+                            handler_kind: route.kind().to_string(),
+                            target_uri: route.target_uri(),
+                            result: None,
+                            error: Some(error.to_string()),
+                        });
+                    }
+
+                    if let Some(delay) = binding.retry.next_retry_delay(attempt) {
+                        let retry_node_id = format!("retry:{binding_key}:{}:{attempt}", event.id.0);
+                        previous_retry_node = Some(retry_node_id.clone());
+                        self.emit_action_graph(
+                            &event,
+                            vec![RunActionGraphNodeRecord {
+                                id: retry_node_id.clone(),
+                                label: format!("retry in {}ms", delay.as_millis()),
+                                kind: ACTION_GRAPH_NODE_KIND_RETRY.to_string(),
+                                status: "scheduled".to_string(),
+                                outcome: format!("attempt_{}", attempt + 1),
+                                trace_id: Some(event.trace_id.0.clone()),
+                                stage_id: None,
+                                node_id: None,
+                                worker_id: None,
+                                run_id: None,
+                                run_path: None,
+                            }],
+                            vec![RunActionGraphEdgeRecord {
+                                from_id: dispatch_node_id,
+                                to_id: retry_node_id.clone(),
+                                kind: ACTION_GRAPH_EDGE_KIND_RETRY.to_string(),
+                                label: Some(format!("attempt {}", attempt + 1)),
+                            }],
+                            serde_json::json!({
+                                "source": "dispatcher",
+                                "trigger_id": binding.id.as_str(),
+                                "binding_key": binding.binding_key(),
+                                "event_id": event.id.0,
+                                "attempt": attempt + 1,
+                                "delay_ms": delay.as_millis(),
+                            }),
+                        )
+                        .await?;
+                        self.append_lifecycle_event(
+                            "RetryScheduled",
+                            &event,
+                            binding,
+                            serde_json::json!({
+                                "event_id": event.id.0,
+                                "attempt": attempt + 1,
+                                "delay_ms": delay.as_millis(),
+                                "error": error.to_string(),
+                            }),
+                        )
+                        .await?;
+                        self.append_topic_event(
+                            TRIGGER_ATTEMPTS_TOPIC,
+                            "retry_scheduled",
+                            &event,
+                            Some(binding),
+                            Some(attempt + 1),
+                            serde_json::json!({
+                                "event_id": event.id.0,
+                                "attempt": attempt + 1,
+                                "trigger_id": binding.id.as_str(),
+                                "binding_key": binding.binding_key(),
+                                "delay_ms": delay.as_millis(),
+                                "error": error.to_string(),
+                            }),
+                        )
+                        .await?;
+                        self.state.retry_queue_depth.fetch_add(1, Ordering::Relaxed);
+                        let sleep_result =
+                            sleep_or_cancel(delay, &mut self.cancel_tx.subscribe()).await;
+                        self.state.retry_queue_depth.fetch_sub(1, Ordering::Relaxed);
+                        if sleep_result.is_err() {
+                            finish_in_flight(
+                                binding.id.as_str(),
+                                binding.version,
+                                TriggerDispatchOutcome::Failed,
+                            )
+                            .await
+                            .map_err(|registry_error| {
+                                DispatchError::Registry(registry_error.to_string())
+                            })?;
+                            self.state.in_flight.fetch_sub(1, Ordering::Relaxed);
+                            return Ok(DispatchOutcome {
+                                trigger_id: binding.id.as_str().to_string(),
+                                binding_key: binding.binding_key(),
+                                event_id: event.id.0,
+                                attempt_count: attempt,
+                                status: DispatchStatus::Cancelled,
+                                handler_kind: route.kind().to_string(),
+                                target_uri: route.target_uri(),
+                                result: None,
+                                error: Some("dispatcher shutdown cancelled retry wait".to_string()),
+                            });
+                        }
+                        continue;
+                    }
+
+                    let final_error = error.to_string();
+                    let dlq_entry = DlqEntry {
+                        trigger_id: binding.id.as_str().to_string(),
+                        binding_key: binding.binding_key(),
+                        event: event.clone(),
+                        attempt_count: attempt,
+                        final_error: final_error.clone(),
+                        attempts: attempts.clone(),
+                    };
+                    self.state
+                        .dlq
+                        .lock()
+                        .expect("dispatcher dlq poisoned")
+                        .push(dlq_entry.clone());
+                    self.emit_action_graph(
+                        &event,
+                        vec![RunActionGraphNodeRecord {
+                            id: format!("dlq:{binding_key}:{}", event.id.0),
+                            label: binding.id.as_str().to_string(),
+                            kind: ACTION_GRAPH_NODE_KIND_DLQ.to_string(),
+                            status: "queued".to_string(),
+                            outcome: "retry_exhausted".to_string(),
+                            trace_id: Some(event.trace_id.0.clone()),
+                            stage_id: None,
+                            node_id: None,
+                            worker_id: None,
+                            run_id: None,
+                            run_path: None,
+                        }],
+                        vec![RunActionGraphEdgeRecord {
+                            from_id: format!("dispatch:{binding_key}:{}:{attempt}", event.id.0),
+                            to_id: format!("dlq:{binding_key}:{}", event.id.0),
+                            kind: ACTION_GRAPH_EDGE_KIND_DLQ_MOVE.to_string(),
+                            label: Some(format!("{attempt} attempts")),
+                        }],
+                        serde_json::json!({
+                            "source": "dispatcher",
+                            "trigger_id": binding.id.as_str(),
+                            "binding_key": binding.binding_key(),
+                            "event_id": event.id.0,
+                            "attempt_count": attempt,
+                            "final_error": final_error,
+                        }),
+                    )
+                    .await?;
+                    self.append_lifecycle_event(
+                        "DlqMoved",
+                        &event,
+                        binding,
+                        serde_json::json!({
+                            "event_id": event.id.0,
+                            "attempt_count": attempt,
+                            "final_error": dlq_entry.final_error,
+                        }),
+                    )
+                    .await?;
+                    self.append_topic_event(
+                        TRIGGER_DLQ_TOPIC,
+                        "dlq_moved",
+                        &event,
+                        Some(binding),
+                        Some(attempt),
+                        serde_json::to_value(&dlq_entry)
+                            .map_err(|serde_error| DispatchError::Serde(serde_error.to_string()))?,
+                    )
+                    .await?;
+                    finish_in_flight(
+                        binding.id.as_str(),
+                        binding.version,
+                        TriggerDispatchOutcome::Dlq,
+                    )
+                    .await
+                    .map_err(|registry_error| {
+                        DispatchError::Registry(registry_error.to_string())
+                    })?;
+                    self.state.in_flight.fetch_sub(1, Ordering::Relaxed);
+                    return Ok(DispatchOutcome {
+                        trigger_id: binding.id.as_str().to_string(),
+                        binding_key: binding.binding_key(),
+                        event_id: event.id.0,
+                        attempt_count: attempt,
+                        status: DispatchStatus::Dlq,
+                        handler_kind: route.kind().to_string(),
+                        target_uri: route.target_uri(),
+                        result: None,
+                        error: Some(error.to_string()),
+                    });
+                }
+            }
+        }
+
+        finish_in_flight(
+            binding.id.as_str(),
+            binding.version,
+            TriggerDispatchOutcome::Failed,
+        )
+        .await
+        .map_err(|error| DispatchError::Registry(error.to_string()))?;
+        self.state.in_flight.fetch_sub(1, Ordering::Relaxed);
+        Ok(DispatchOutcome {
+            trigger_id: binding.id.as_str().to_string(),
+            binding_key: binding.binding_key(),
+            event_id: event.id.0,
+            attempt_count: max_attempts,
+            status: DispatchStatus::Failed,
+            handler_kind: route.kind().to_string(),
+            target_uri: route.target_uri(),
+            result: None,
+            error: Some("dispatch exhausted without terminal outcome".to_string()),
+        })
+    }
+
+    async fn dispatch_once(
+        &self,
+        binding: &TriggerBinding,
+        route: &DispatchUri,
+        event: &TriggerEvent,
+        cancel_rx: &mut broadcast::Receiver<()>,
+    ) -> Result<serde_json::Value, DispatchError> {
+        match route {
+            DispatchUri::Local { .. } => {
+                let TriggerHandlerSpec::Local { closure, .. } = &binding.handler else {
+                    return Err(DispatchError::Local(format!(
+                        "trigger '{}' resolved to a local dispatch URI but does not carry a local closure",
+                        binding.id.as_str()
+                    )));
+                };
+                let value = self.invoke_vm_callable(closure, event, cancel_rx).await?;
+                Ok(vm_value_to_json(&value))
+            }
+            DispatchUri::A2a { target } => Err(DispatchError::NotImplemented(format!(
+                "a2a:// dispatch to '{target}' is not implemented yet; see O-04 #181"
+            ))),
+            DispatchUri::Worker { queue } => Err(DispatchError::NotImplemented(format!(
+                "worker:// dispatch to '{queue}' is not implemented yet; see O-05 #182"
+            ))),
+        }
+    }
+
+    async fn invoke_vm_callable(
+        &self,
+        closure: &crate::value::VmClosure,
+        event: &TriggerEvent,
+        _cancel_rx: &mut broadcast::Receiver<()>,
+    ) -> Result<VmValue, DispatchError> {
+        let mut vm = self.base_vm.child_vm();
+        let cancel_token = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        if self.state.shutting_down.load(Ordering::SeqCst) {
+            cancel_token.store(true, Ordering::SeqCst);
+        }
+        self.state
+            .cancel_tokens
+            .lock()
+            .expect("dispatcher cancel tokens poisoned")
+            .push(cancel_token.clone());
+        vm.install_cancel_token(cancel_token.clone());
+        let arg = json_to_vm_value(
+            &serde_json::to_value(event)
+                .map_err(|error| DispatchError::Serde(error.to_string()))?,
+        );
+        let args = [arg];
+        let future = vm.call_closure_pub(closure, &args, &[]);
+        pin_mut!(future);
+        let result = future.await;
+        let mut tokens = self
+            .state
+            .cancel_tokens
+            .lock()
+            .expect("dispatcher cancel tokens poisoned");
+        tokens.retain(|token| !Arc::ptr_eq(token, &cancel_token));
+        if cancel_token.load(Ordering::SeqCst) {
+            Err(DispatchError::Cancelled(
+                "dispatcher shutdown cancelled local handler".to_string(),
+            ))
+        } else {
+            result.map_err(dispatch_error_from_vm_error)
+        }
+    }
+
+    async fn append_attempt_record(
+        &self,
+        event: &TriggerEvent,
+        binding: &TriggerBinding,
+        attempt: &DispatchAttemptRecord,
+    ) -> Result<(), DispatchError> {
+        self.append_topic_event(
+            TRIGGER_ATTEMPTS_TOPIC,
+            "attempt_recorded",
+            event,
+            Some(binding),
+            Some(attempt.attempt),
+            serde_json::to_value(attempt)
+                .map_err(|error| DispatchError::Serde(error.to_string()))?,
+        )
+        .await
+    }
+
+    async fn append_lifecycle_event(
+        &self,
+        kind: &str,
+        event: &TriggerEvent,
+        binding: &TriggerBinding,
+        payload: serde_json::Value,
+    ) -> Result<(), DispatchError> {
+        self.append_topic_event(
+            TRIGGERS_LIFECYCLE_TOPIC,
+            kind,
+            event,
+            Some(binding),
+            None,
+            payload,
+        )
+        .await
+    }
+
+    async fn append_topic_event(
+        &self,
+        topic_name: &str,
+        kind: &str,
+        event: &TriggerEvent,
+        binding: Option<&TriggerBinding>,
+        attempt: Option<u32>,
+        payload: serde_json::Value,
+    ) -> Result<(), DispatchError> {
+        let topic = Topic::new(topic_name)
+            .expect("static trigger dispatcher topic names should always be valid");
+        let headers = event_headers(event, binding, attempt);
+        self.event_log
+            .append(&topic, LogEvent::new(kind, payload).with_headers(headers))
+            .await
+            .map_err(DispatchError::from)
+            .map(|_| ())
+    }
+
+    async fn emit_action_graph(
+        &self,
+        event: &TriggerEvent,
+        nodes: Vec<RunActionGraphNodeRecord>,
+        edges: Vec<RunActionGraphEdgeRecord>,
+        extra: serde_json::Value,
+    ) -> Result<(), DispatchError> {
+        let mut headers = BTreeMap::new();
+        headers.insert("trace_id".to_string(), event.trace_id.0.clone());
+        headers.insert("event_id".to_string(), event.id.0.clone());
+        let observability = RunObservabilityRecord {
+            schema_version: 1,
+            action_graph_nodes: nodes,
+            action_graph_edges: edges,
+            ..Default::default()
+        };
+        append_action_graph_update(
+            headers,
+            serde_json::json!({
+                "source": "dispatcher",
+                "trace_id": event.trace_id.0,
+                "event_id": event.id.0,
+                "observability": observability,
+                "context": extra,
+            }),
+        )
+        .await
+        .map_err(DispatchError::from)
+    }
+}
+
+pub fn snapshot_dispatcher_stats() -> DispatcherStatsSnapshot {
+    ACTIVE_DISPATCHER_STATE.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .map(|state| DispatcherStatsSnapshot {
+                in_flight: state.in_flight.load(Ordering::Relaxed),
+                retry_queue_depth: state.retry_queue_depth.load(Ordering::Relaxed),
+                dlq_depth: state.dlq.lock().expect("dispatcher dlq poisoned").len() as u64,
+            })
+            .unwrap_or_default()
+    })
+}
+
+pub fn clear_dispatcher_state() {
+    ACTIVE_DISPATCHER_STATE.with(|slot| {
+        *slot.borrow_mut() = None;
+    });
+}
+
+fn dispatch_error_from_vm_error(error: VmError) -> DispatchError {
+    if is_cancelled_vm_error(&error) {
+        return DispatchError::Cancelled("dispatcher shutdown cancelled local handler".to_string());
+    }
+    if let VmError::Thrown(VmValue::String(message)) = &error {
+        return DispatchError::Local(message.to_string());
+    }
+    match error_to_category(&error) {
+        ErrorCategory::Cancelled => {
+            DispatchError::Cancelled("dispatcher shutdown cancelled local handler".to_string())
+        }
+        _ => DispatchError::Local(error.to_string()),
+    }
+}
+
+fn is_cancelled_vm_error(error: &VmError) -> bool {
+    matches!(
+        error,
+        VmError::Thrown(VmValue::String(message))
+            if message.starts_with("kind:cancelled:")
+    ) || matches!(error_to_category(error), ErrorCategory::Cancelled)
+}
+
+fn event_headers(
+    event: &TriggerEvent,
+    binding: Option<&TriggerBinding>,
+    attempt: Option<u32>,
+) -> BTreeMap<String, String> {
+    let mut headers = BTreeMap::new();
+    headers.insert("event_id".to_string(), event.id.0.clone());
+    headers.insert("trace_id".to_string(), event.trace_id.0.clone());
+    headers.insert("provider".to_string(), event.provider.as_str().to_string());
+    headers.insert("kind".to_string(), event.kind.clone());
+    if let Some(binding) = binding {
+        headers.insert("trigger_id".to_string(), binding.id.as_str().to_string());
+        headers.insert("binding_key".to_string(), binding.binding_key());
+        headers.insert(
+            "handler_kind".to_string(),
+            DispatchUri::from(&binding.handler).kind().to_string(),
+        );
+    }
+    if let Some(attempt) = attempt {
+        headers.insert("attempt".to_string(), attempt.to_string());
+    }
+    headers
+}
+
+fn now_rfc3339() -> String {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+async fn sleep_or_cancel(
+    duration: Duration,
+    cancel_rx: &mut broadcast::Receiver<()>,
+) -> Result<(), DispatchError> {
+    if duration.is_zero() {
+        return Ok(());
+    }
+    tokio::select! {
+        _ = tokio::time::sleep(duration) => Ok(()),
+        _ = recv_cancel(cancel_rx) => Err(DispatchError::Cancelled("dispatcher shutdown cancelled retry wait".to_string())),
+    }
+}
+
+async fn recv_cancel(cancel_rx: &mut broadcast::Receiver<()>) {
+    let _ = cancel_rx.recv().await;
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/harn-vm/src/triggers/dispatcher/retry.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/retry.rs
@@ -1,0 +1,151 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_MAX_ATTEMPTS: u32 = 7;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RetryPolicy {
+    #[default]
+    Svix,
+    Linear {
+        delay_ms: u64,
+    },
+    Exponential {
+        base_ms: u64,
+        cap_ms: u64,
+    },
+}
+
+impl RetryPolicy {
+    pub fn delay_for_attempt(&self, attempt: u32) -> Duration {
+        let attempt = attempt.max(1);
+        match self {
+            Self::Svix => {
+                const SCHEDULE_MS: [u64; 8] = [
+                    0,
+                    5_000,
+                    5 * 60_000,
+                    30 * 60_000,
+                    2 * 60 * 60_000,
+                    5 * 60 * 60_000,
+                    10 * 60 * 60_000,
+                    10 * 60 * 60_000,
+                ];
+                let index = (attempt.saturating_sub(1) as usize).min(SCHEDULE_MS.len() - 1);
+                Duration::from_millis(SCHEDULE_MS[index])
+            }
+            Self::Linear { delay_ms } => {
+                if attempt == 1 {
+                    Duration::ZERO
+                } else {
+                    Duration::from_millis(*delay_ms)
+                }
+            }
+            Self::Exponential { base_ms, cap_ms } => {
+                if attempt == 1 {
+                    return Duration::ZERO;
+                }
+                let exponent = attempt.saturating_sub(2).min(63);
+                let multiplier = 1u64.checked_shl(exponent).unwrap_or(u64::MAX);
+                Duration::from_millis(base_ms.saturating_mul(multiplier).min(*cap_ms))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct TriggerRetryConfig {
+    pub max_attempts: u32,
+    pub policy: RetryPolicy,
+}
+
+impl Default for TriggerRetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            policy: RetryPolicy::default(),
+        }
+    }
+}
+
+impl TriggerRetryConfig {
+    pub fn new(max_attempts: u32, policy: RetryPolicy) -> Self {
+        Self {
+            max_attempts,
+            policy,
+        }
+    }
+
+    pub fn max_attempts(&self) -> u32 {
+        match self.max_attempts {
+            0 => DEFAULT_MAX_ATTEMPTS,
+            attempts => attempts,
+        }
+    }
+
+    pub fn next_retry_delay(&self, completed_attempt: u32) -> Option<Duration> {
+        let next_attempt = completed_attempt.saturating_add(1);
+        if next_attempt > self.max_attempts() {
+            None
+        } else {
+            Some(self.policy.delay_for_attempt(next_attempt))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RetryPolicy, TriggerRetryConfig};
+
+    #[test]
+    fn svix_schedule_matches_expected_vector() {
+        let policy = RetryPolicy::Svix;
+        let delays: Vec<u64> = (1..=8)
+            .map(|attempt| policy.delay_for_attempt(attempt).as_millis() as u64)
+            .collect();
+        assert_eq!(
+            delays,
+            vec![
+                0,
+                5_000,
+                5 * 60_000,
+                30 * 60_000,
+                2 * 60 * 60_000,
+                5 * 60 * 60_000,
+                10 * 60 * 60_000,
+                10 * 60 * 60_000,
+            ]
+        );
+    }
+
+    #[test]
+    fn linear_backoff_is_immediate_then_fixed() {
+        let policy = RetryPolicy::Linear { delay_ms: 2_500 };
+        let delays: Vec<u64> = (1..=4)
+            .map(|attempt| policy.delay_for_attempt(attempt).as_millis() as u64)
+            .collect();
+        assert_eq!(delays, vec![0, 2_500, 2_500, 2_500]);
+    }
+
+    #[test]
+    fn exponential_backoff_caps_at_the_configured_ceiling() {
+        let policy = RetryPolicy::Exponential {
+            base_ms: 1_000,
+            cap_ms: 5_000,
+        };
+        let delays: Vec<u64> = (1..=6)
+            .map(|attempt| policy.delay_for_attempt(attempt).as_millis() as u64)
+            .collect();
+        assert_eq!(delays, vec![0, 1_000, 2_000, 4_000, 5_000, 5_000]);
+    }
+
+    #[test]
+    fn zero_max_attempts_defaults_to_seven_total_attempts() {
+        let config = TriggerRetryConfig::new(0, RetryPolicy::Svix);
+        assert_eq!(config.max_attempts(), 7);
+        assert!(config.next_retry_delay(7).is_none());
+    }
+}

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -1,0 +1,330 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::event_log::{install_default_for_base_dir, EventLog, Topic};
+use crate::register_vm_stdlib;
+use crate::triggers::event::{GitHubEventPayload, KnownProviderPayload};
+use crate::triggers::registry::{
+    install_manifest_triggers, TriggerBindingSource, TriggerBindingSpec, TriggerHandlerSpec,
+    TriggerPredicateSpec,
+};
+use crate::triggers::{ProviderId, ProviderPayload, SignatureStatus, TriggerEvent};
+use crate::Vm;
+
+use super::retry::TriggerRetryConfig;
+use super::uri::{DispatchUri, DispatchUriError};
+use super::{DispatchStatus, Dispatcher, RetryPolicy};
+
+fn trigger_event(kind: &str, dedupe_key: &str) -> TriggerEvent {
+    TriggerEvent::new(
+        ProviderId::from("github"),
+        kind,
+        None,
+        dedupe_key,
+        None,
+        BTreeMap::new(),
+        ProviderPayload::Known(KnownProviderPayload::GitHub(GitHubEventPayload {
+            event: "issues".to_string(),
+            action: Some("opened".to_string()),
+            delivery_id: Some(dedupe_key.to_string()),
+            installation_id: Some(42),
+            raw: serde_json::json!({"action":"opened"}),
+        })),
+        SignatureStatus::Verified,
+    )
+}
+
+async fn dispatcher_fixture(
+    source: &str,
+    handler_name: &str,
+    when_name: Option<&str>,
+    retry: TriggerRetryConfig,
+) -> (
+    tempfile::TempDir,
+    Arc<crate::event_log::AnyEventLog>,
+    Dispatcher,
+) {
+    crate::reset_thread_local_state();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let log = install_default_for_base_dir(dir.path()).expect("install event log");
+    let lib_path = dir.path().join("lib.harn");
+    std::fs::write(&lib_path, source).expect("write module source");
+
+    let mut vm = Vm::new();
+    register_vm_stdlib(&mut vm);
+    vm.set_source_dir(dir.path());
+    let exports = vm
+        .load_module_exports(&lib_path)
+        .await
+        .expect("load handler exports");
+
+    let handler = exports
+        .get(handler_name)
+        .unwrap_or_else(|| panic!("missing handler export {handler_name}"))
+        .clone();
+    let when = when_name.map(|name| TriggerPredicateSpec {
+        raw: name.to_string(),
+        closure: exports
+            .get(name)
+            .unwrap_or_else(|| panic!("missing predicate export {name}"))
+            .clone(),
+    });
+
+    install_manifest_triggers(vec![TriggerBindingSpec {
+        id: "github-new-issue".to_string(),
+        source: TriggerBindingSource::Manifest,
+        kind: "webhook".to_string(),
+        provider: ProviderId::from("github"),
+        handler: TriggerHandlerSpec::Local {
+            raw: handler_name.to_string(),
+            closure: handler,
+        },
+        when,
+        retry,
+        match_events: vec!["issues.opened".to_string()],
+        dedupe_key: Some("event.dedupe_key".to_string()),
+        filter: None,
+        daily_cost_usd: None,
+        max_concurrent: None,
+        manifest_path: None,
+        package_name: Some("workspace".to_string()),
+        definition_fingerprint: format!("fp:{handler_name}"),
+    }])
+    .await
+    .expect("install test trigger binding");
+
+    (dir, log.clone(), Dispatcher::with_event_log(vm, log))
+}
+
+async fn read_topic(
+    log: Arc<crate::event_log::AnyEventLog>,
+    topic: &str,
+) -> Vec<(u64, crate::event_log::LogEvent)> {
+    let topic = Topic::new(topic).expect("valid topic");
+    log.read_range(&topic, None, usize::MAX)
+        .await
+        .expect("read topic events")
+}
+
+fn flatten_action_graph(
+    events: &[(u64, crate::event_log::LogEvent)],
+) -> (Vec<String>, Vec<String>) {
+    let mut node_kinds = Vec::new();
+    let mut edge_kinds = Vec::new();
+    for (_, event) in events {
+        let observability = &event.payload["observability"];
+        if let Some(nodes) = observability["action_graph_nodes"].as_array() {
+            node_kinds.extend(nodes.iter().filter_map(|node| {
+                node.get("kind")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string)
+            }));
+        }
+        if let Some(edges) = observability["action_graph_edges"].as_array() {
+            edge_kinds.extend(edges.iter().filter_map(|edge| {
+                edge.get("kind")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string)
+            }));
+        }
+    }
+    (node_kinds, edge_kinds)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn local_handler_round_trip_logs_outbox_lifecycle_and_action_graph() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (_dir, log, dispatcher) = dispatcher_fixture(
+                r#"
+import "std/triggers"
+
+pub fn local_fn(event: TriggerEvent) -> string {
+  return event.kind
+}
+
+pub fn should_handle(event: TriggerEvent) -> bool {
+  return event.kind == "issues.opened"
+}
+"#,
+                "local_fn",
+                Some("should_handle"),
+                TriggerRetryConfig::default(),
+            )
+            .await;
+
+            let event = trigger_event("issues.opened", "delivery-roundtrip");
+            let outcomes = dispatcher
+                .dispatch_event(event.clone())
+                .await
+                .expect("dispatch succeeds");
+            assert_eq!(outcomes.len(), 1);
+            assert_eq!(outcomes[0].status, DispatchStatus::Succeeded);
+            assert_eq!(outcomes[0].result, Some(serde_json::json!("issues.opened")));
+
+            let outbox = read_topic(log.clone(), "trigger.outbox").await;
+            assert!(outbox
+                .iter()
+                .any(|(_, event)| event.kind == "dispatch_started"));
+            assert!(outbox.iter().any(|(_, event)| {
+                event.kind == "dispatch_succeeded"
+                    && event.payload["result"] == serde_json::json!("issues.opened")
+            }));
+
+            let lifecycle = read_topic(log.clone(), "triggers.lifecycle").await;
+            assert!(lifecycle
+                .iter()
+                .any(|(_, event)| event.kind == "DispatchStarted"));
+            assert!(lifecycle
+                .iter()
+                .any(|(_, event)| event.kind == "DispatchSucceeded"));
+
+            let graph = read_topic(log.clone(), "observability.action_graph").await;
+            let (node_kinds, edge_kinds) = flatten_action_graph(&graph);
+            assert!(node_kinds.iter().any(|kind| kind == "trigger"));
+            assert!(node_kinds.iter().any(|kind| kind == "predicate"));
+            assert!(node_kinds.iter().any(|kind| kind == "dispatch"));
+            assert!(edge_kinds.iter().any(|kind| kind == "trigger_dispatch"));
+            assert!(edge_kinds.iter().any(|kind| kind == "predicate_gate"));
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn retry_exhaustion_moves_failed_dispatch_to_dlq() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (_dir, log, dispatcher) = dispatcher_fixture(
+                r#"
+import "std/triggers"
+
+pub fn local_fn(event: TriggerEvent) -> string {
+  throw "boom"
+}
+"#,
+                "local_fn",
+                None,
+                TriggerRetryConfig::new(2, RetryPolicy::Linear { delay_ms: 0 }),
+            )
+            .await;
+
+            let event = trigger_event("issues.opened", "delivery-dlq");
+            let outcomes = dispatcher
+                .dispatch_event(event.clone())
+                .await
+                .expect("dispatch returns terminal outcome");
+            assert_eq!(outcomes.len(), 1);
+            assert_eq!(outcomes[0].status, DispatchStatus::Dlq);
+            assert_eq!(outcomes[0].attempt_count, 2);
+
+            let dlq = dispatcher.dlq_entries();
+            assert_eq!(dlq.len(), 1);
+            assert_eq!(dlq[0].attempt_count, 2);
+            assert_eq!(dlq[0].final_error, "boom");
+
+            let dlq_topic = read_topic(log.clone(), "trigger.dlq").await;
+            assert_eq!(dlq_topic.len(), 1);
+            assert_eq!(dlq_topic[0].1.kind, "dlq_moved");
+
+            let attempts = read_topic(log.clone(), "trigger.attempts").await;
+            assert_eq!(
+                attempts
+                    .iter()
+                    .filter(|(_, event)| event.kind == "attempt_recorded")
+                    .count(),
+                2
+            );
+            assert!(attempts
+                .iter()
+                .any(|(_, event)| event.kind == "retry_scheduled"));
+
+            let graph = read_topic(log.clone(), "observability.action_graph").await;
+            let (node_kinds, edge_kinds) = flatten_action_graph(&graph);
+            assert!(node_kinds.iter().any(|kind| kind == "retry"));
+            assert!(node_kinds.iter().any(|kind| kind == "dlq"));
+            assert!(edge_kinds.iter().any(|kind| kind == "retry"));
+            assert!(edge_kinds.iter().any(|kind| kind == "dlq_move"));
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn shutdown_propagates_cancel_to_all_in_flight_local_handlers() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (_dir, _log, dispatcher) = dispatcher_fixture(
+                r#"
+import "std/triggers"
+
+pub fn wait_for_cancel(event: TriggerEvent) -> string {
+  while !is_cancelled() {
+    sleep(1)
+  }
+  return event.kind
+}
+"#,
+                "wait_for_cancel",
+                None,
+                TriggerRetryConfig::new(1, RetryPolicy::Linear { delay_ms: 0 }),
+            )
+            .await;
+
+            let start = Instant::now();
+            let mut handles = Vec::new();
+            for index in 0..3 {
+                let dispatcher = dispatcher.clone();
+                handles.push(tokio::task::spawn_local(async move {
+                    dispatcher
+                        .dispatch_event(trigger_event(
+                            "issues.opened",
+                            &format!("delivery-cancel-{index}"),
+                        ))
+                        .await
+                        .expect("dispatch finishes")
+                }));
+            }
+
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            dispatcher.shutdown();
+
+            let mut cancelled = 0;
+            for handle in handles {
+                let outcomes = handle.await.expect("join local dispatch");
+                assert_eq!(outcomes.len(), 1);
+                if outcomes[0].status == DispatchStatus::Cancelled {
+                    cancelled += 1;
+                }
+            }
+            assert_eq!(cancelled, 3);
+            assert!(
+                start.elapsed() <= Duration::from_millis(100),
+                "all in-flight dispatches must observe cancellation within 100ms"
+            );
+        })
+        .await;
+}
+
+#[test]
+fn uri_parser_rejects_invalid_and_unknown_handler_schemes() {
+    assert_eq!(DispatchUri::parse("").unwrap_err(), DispatchUriError::Empty);
+    assert_eq!(
+        DispatchUri::parse("a2a://").unwrap_err(),
+        DispatchUriError::MissingTarget {
+            scheme: "a2a".to_string()
+        }
+    );
+    assert_eq!(
+        DispatchUri::parse("worker://").unwrap_err(),
+        DispatchUriError::MissingTarget {
+            scheme: "worker".to_string()
+        }
+    );
+    assert_eq!(
+        DispatchUri::parse("smtp://relay").unwrap_err(),
+        DispatchUriError::UnknownScheme("smtp".to_string())
+    );
+}

--- a/crates/harn-vm/src/triggers/dispatcher/uri.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/uri.rs
@@ -1,0 +1,94 @@
+use crate::triggers::TriggerHandlerSpec;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DispatchUriError {
+    Empty,
+    MissingTarget { scheme: String },
+    UnknownScheme(String),
+}
+
+impl std::fmt::Display for DispatchUriError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => f.write_str("handler URI cannot be empty"),
+            Self::MissingTarget { scheme } => {
+                write!(f, "{scheme} handler URI target cannot be empty")
+            }
+            Self::UnknownScheme(scheme) => write!(f, "unsupported handler URI scheme '{scheme}'"),
+        }
+    }
+}
+
+impl std::error::Error for DispatchUriError {}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DispatchUri {
+    Local { raw: String },
+    A2a { target: String },
+    Worker { queue: String },
+}
+
+impl DispatchUri {
+    pub fn parse(raw: &str) -> Result<Self, DispatchUriError> {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Err(DispatchUriError::Empty);
+        }
+        if let Some(target) = raw.strip_prefix("a2a://") {
+            if target.is_empty() {
+                return Err(DispatchUriError::MissingTarget {
+                    scheme: "a2a".to_string(),
+                });
+            }
+            return Ok(Self::A2a {
+                target: target.to_string(),
+            });
+        }
+        if let Some(queue) = raw.strip_prefix("worker://") {
+            if queue.is_empty() {
+                return Err(DispatchUriError::MissingTarget {
+                    scheme: "worker".to_string(),
+                });
+            }
+            return Ok(Self::Worker {
+                queue: queue.to_string(),
+            });
+        }
+        if let Some((scheme, _)) = raw.split_once("://") {
+            return Err(DispatchUriError::UnknownScheme(scheme.to_string()));
+        }
+        Ok(Self::Local {
+            raw: raw.to_string(),
+        })
+    }
+
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Local { .. } => "local",
+            Self::A2a { .. } => "a2a",
+            Self::Worker { .. } => "worker",
+        }
+    }
+
+    pub fn target_uri(&self) -> String {
+        match self {
+            Self::Local { raw } => raw.clone(),
+            Self::A2a { target } => format!("a2a://{target}"),
+            Self::Worker { queue } => format!("worker://{queue}"),
+        }
+    }
+}
+
+impl From<&TriggerHandlerSpec> for DispatchUri {
+    fn from(value: &TriggerHandlerSpec) -> Self {
+        match value {
+            TriggerHandlerSpec::Local { raw, .. } => Self::Local { raw: raw.clone() },
+            TriggerHandlerSpec::A2a { target } => Self::A2a {
+                target: target.clone(),
+            },
+            TriggerHandlerSpec::Worker { queue } => Self::Worker {
+                queue: queue.clone(),
+            },
+        }
+    }
+}

--- a/crates/harn-vm/src/triggers/mod.rs
+++ b/crates/harn-vm/src/triggers/mod.rs
@@ -1,6 +1,11 @@
+pub mod dispatcher;
 pub mod event;
 pub mod registry;
 
+pub use dispatcher::{
+    clear_dispatcher_state, snapshot_dispatcher_stats, DispatchError, DispatchOutcome,
+    DispatchStatus, Dispatcher, DispatcherStatsSnapshot, RetryPolicy, TriggerRetryConfig,
+};
 pub use event::{
     redact_headers, register_provider_schema, registered_provider_schema_names,
     reset_provider_catalog, A2aPushPayload, CronEventPayload, ExtensionProviderPayload,

--- a/crates/harn-vm/src/triggers/registry.rs
+++ b/crates/harn-vm/src/triggers/registry.rs
@@ -13,6 +13,7 @@ use crate::event_log::{active_event_log, AnyEventLog, EventLog, LogEvent, Topic}
 use crate::secrets::{configured_default_chain, SecretProvider};
 use crate::value::VmClosure;
 
+use super::dispatcher::TriggerRetryConfig;
 use super::ProviderId;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -119,6 +120,7 @@ pub struct TriggerBindingSpec {
     pub provider: ProviderId,
     pub handler: TriggerHandlerSpec,
     pub when: Option<TriggerPredicateSpec>,
+    pub retry: TriggerRetryConfig,
     pub match_events: Vec<String>,
     pub dedupe_key: Option<String>,
     pub filter: Option<String>,
@@ -174,6 +176,7 @@ pub struct TriggerBinding {
     pub provider: ProviderId,
     pub handler: TriggerHandlerSpec,
     pub when: Option<TriggerPredicateSpec>,
+    pub retry: TriggerRetryConfig,
     pub match_events: Vec<String>,
     pub dedupe_key: Option<String>,
     pub filter: Option<String>,
@@ -225,6 +228,7 @@ impl TriggerBinding {
             provider: spec.provider,
             handler: spec.handler,
             when: spec.when,
+            retry: spec.retry,
             match_events: spec.match_events,
             dedupe_key: spec.dedupe_key,
             filter: spec.filter,
@@ -374,6 +378,41 @@ pub fn resolve_live_trigger_binding(
             .into_iter()
             .max_by_key(|binding| binding.version)
             .ok_or_else(|| TriggerRegistryError::UnknownId(id.to_string()))
+    })
+}
+
+pub(crate) fn matching_bindings(event: &super::TriggerEvent) -> Vec<Arc<TriggerBinding>> {
+    TRIGGER_REGISTRY.with(|slot| {
+        let registry = slot.borrow();
+        let Some(binding_ids) = registry.by_provider.get(event.provider.as_str()) else {
+            return Vec::new();
+        };
+
+        let mut bindings = Vec::new();
+        for id in binding_ids {
+            let Some(versions) = registry.bindings.get(id) else {
+                continue;
+            };
+            for binding in versions {
+                if binding.state_snapshot() != TriggerState::Active {
+                    continue;
+                }
+                if !binding.match_events.is_empty()
+                    && !binding.match_events.iter().any(|kind| kind == &event.kind)
+                {
+                    continue;
+                }
+                bindings.push(binding.clone());
+            }
+        }
+
+        bindings.sort_by(|left, right| {
+            left.id
+                .as_str()
+                .cmp(right.id.as_str())
+                .then(left.version.cmp(&right.version))
+        });
+        bindings
     })
 }
 
@@ -784,6 +823,7 @@ mod tests {
                 queue: format!("{id}-queue"),
             },
             when: None,
+            retry: TriggerRetryConfig::default(),
             match_events: vec!["issues.opened".to_string()],
             dedupe_key: Some("event.dedupe_key".to_string()),
             filter: Some("event.kind".to_string()),
@@ -805,6 +845,7 @@ mod tests {
                 queue: format!("{id}-queue"),
             },
             when: None,
+            retry: TriggerRetryConfig::default(),
             match_events: vec!["issues.opened".to_string()],
             dedupe_key: None,
             filter: None,

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,6 +28,7 @@
 - [Workflow runtime](./workflow-runtime.md)
 - [Trigger manifests](./triggers/manifest.md)
 - [Trigger event schema](./triggers/event-schema.md)
+- [Trigger dispatcher](./triggers/dispatcher.md)
 - [Trigger observability in the action graph](./observability/triggers-in-action-graph.md)
 - [Connector authoring](./connectors/authoring.md)
 - [Trigger registry](./triggers/registry.md)

--- a/docs/src/triggers/dispatcher.md
+++ b/docs/src/triggers/dispatcher.md
@@ -1,0 +1,114 @@
+# Trigger Dispatcher
+
+The trigger dispatcher is the runtime path that turns a normalized
+`TriggerEvent` plus a live registry binding into actual handler work.
+
+At MVP, the dispatcher fully wires the local-function path and keeps the
+remote handler schemes (`a2a://...`, `worker://...`) as explicit stubs with
+clear error messages pointing at their follow-up tickets.
+
+## Dispatch shape
+
+Each dispatch goes through the same sequence:
+
+1. Append the inbound event to `trigger.inbox`.
+2. Match the event against active registry bindings for the provider +
+   event kind.
+3. Evaluate the optional `when` predicate in the same VM/runtime surface as
+   the handler.
+4. Invoke the resolved handler target.
+5. Record each attempt on `trigger.attempts`.
+6. Record successful handler results on `trigger.outbox`.
+7. Schedule retries from the manifest retry policy.
+8. Move exhausted deliveries into the in-memory DLQ and append a copy to
+   `trigger.dlq`.
+
+The dispatcher keeps per-thread stats for:
+
+- in-flight dispatch count
+- retry queue depth
+- DLQ depth
+
+`harn doctor` surfaces that snapshot next to the trigger registry view.
+
+## Handler URI resolution
+
+Manifest handler URIs support three forms:
+
+- bare/local function name: `handler = "on_issue"` or `handler = "handlers::on_issue"`
+- remote A2A target: `handler = "a2a://reviewer.prod/triage"`
+- worker queue target: `handler = "worker://triage-queue"`
+
+By the time the dispatcher sees a manifest-installed binding, local function
+handlers have already been resolved to concrete `VmClosure` values through the
+same export-loading path used by manifest hooks and trigger predicates.
+
+The dispatcher still re-normalizes those shapes internally so it can emit a
+stable handler kind and target URI in lifecycle logs and action-graph nodes.
+
+## Retry policy
+
+Bindings carry a normalized `TriggerRetryConfig`:
+
+- `Svix`
+- `Linear { delay_ms }`
+- `Exponential { base_ms, cap_ms }`
+
+The default retry budget is 7 total attempts.
+
+The Svix schedule is:
+
+`immediate -> 5s -> 5m -> 30m -> 2h -> 5h -> 10h -> 10h`
+
+The last slot saturates, so attempts beyond the published vector continue to
+wait 10 hours unless a future manifest surface narrows that policy.
+
+## Cancellation
+
+Dispatcher shutdown is cooperative:
+
+- a shutdown signal flips the active per-dispatch VM cancel tokens immediately
+- sleeping retry waits listen for the shared shutdown broadcast and abort early
+- local handlers observe cancellation through the existing VM
+  `install_cancel_token(...)` path and exit on the next instruction boundary
+
+This keeps the trigger runtime aligned with the orchestrator shutdown model
+without inventing a second cancellation mechanism.
+
+## Event-log topics
+
+The dispatcher uses the shared `EventLog` instead of a parallel queue layer:
+
+- `trigger.inbox`
+- `trigger.outbox`
+- `trigger.attempts`
+- `trigger.dlq`
+- `triggers.lifecycle`
+- `observability.action_graph`
+
+`triggers.lifecycle` now includes dispatcher-specific lifecycle records:
+
+- `DispatchStarted`
+- `DispatchSucceeded`
+- `DispatchFailed`
+- `RetryScheduled`
+- `DlqMoved`
+
+## Action-graph updates
+
+Dispatcher streaming closes the local-handler portion of the trigger
+action-graph deferral:
+
+- node kinds: `trigger`, `predicate`, `dispatch`, `retry`, `dlq`
+- edge kinds: `trigger_dispatch`, `predicate_gate`, `retry`, `dlq_move`
+
+Each update is appended to `observability.action_graph` using the shared
+`RunActionGraphNodeRecord` / `RunActionGraphEdgeRecord` schema so the portal
+and any other subscriber can consume dispatcher traces without special-casing a
+separate payload format.
+
+## Current MVP limits
+
+- `a2a://...` returns `DispatchError::NotImplemented` and points at `O-04 #181`
+- `worker://...` returns `DispatchError::NotImplemented` and points at `O-05 #182`
+- DLQ storage is in-memory plus event-log append; durable replay remains follow-up work


### PR DESCRIPTION
## Summary
- add a trigger dispatcher for local handler dispatch with URI parsing, retry policy, cancellation propagation, lifecycle logging, and in-memory DLQ handling
- emit action-graph `dispatch`, `retry`, and `dlq` nodes plus `retry` and `dlq_move` edges for the local-handler dispatch path
- surface dispatcher stats in `harn doctor` and document dispatcher authoring/reference behavior

## Why
Trigger bindings and registry bookkeeping were in place, but the runtime still did not actually dispatch ingested trigger events to handlers. This wires the MVP dispatcher against the T-04 registry so local handlers run end to end, with retry/cancel observability and DLQ behavior.

This closes the T-10 deferral for dispatch/retry/dlq nodes (local-handler path); `a2a_hop` / `worker_enqueue` nodes remain deferred to O-04 / O-05.

## Deferred paths
- `a2a://...` currently returns a clear `NotImplemented` error pointing at O-04 #181
- `worker://queue-name` currently returns a clear `NotImplemented` error pointing at O-05 #182

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p harn-vm triggers::dispatcher -- --nocapture`
- `cargo test -p harn-vm triggers:: -- --nocapture`
- `cargo test -p harn-cli check_manifest_reports_loaded_triggers -- --nocapture`
- `cargo run --bin harn -- test conformance`
- repo pre-push checks (`cargo nextest`, markdown lint, portal lint)
