### PR TITLE
Add axum-based HTTP listener for orchestrator serve (closes #179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,16 @@ granular archaeology.
   manifest triggers, activates placeholder connectors per manifest
   provider, writes an orchestrator state snapshot, and idles until
   SIGTERM for scaffolded graceful shutdown. Multi-tenant remains an
-  explicit `O-12 #190` stub; the HTTP listener remains deferred to
-  `O-02 #179`.
+  explicit `O-12 #190` stub.
+- **Axum-based orchestrator HTTP listener with TLS, origin guards,
+  and body limits (#179).** `harn orchestrator serve` now binds a
+  real Axum listener on `--bind`, optionally serves HTTPS with
+  `--cert` + `--key`, enforces `[orchestrator].allowed_origins`
+  and `[orchestrator].max_body_bytes`, registers HTTP routes for
+  manifest `webhook` and `a2a-push` triggers, normalizes inbound
+  deliveries into `TriggerEvent` envelopes, appends accepted
+  payloads onto `orchestrator.triggers.pending`, and drains
+  in-flight requests during shutdown.
 - **DST-safe cron connector with durable tick state and catch-up modes
   (#210, closes #169).** `harn_vm::connectors::CronConnector` now schedules
   named IANA time zones through `croner` + `chrono-tz`, persists the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +130,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -175,6 +206,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -239,6 +301,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -261,7 +325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -330,6 +394,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +458,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -457,6 +539,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -587,13 +679,24 @@ checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.0",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -615,6 +718,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -704,6 +813,22 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -809,6 +934,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,11 +998,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "harn-cli"
 version = "0.7.22"
 dependencies = [
  "async-trait",
  "axum",
+ "axum-server",
  "base64",
  "chrono-tz",
  "clap",
@@ -878,17 +1033,22 @@ dependencies = [
  "harn-modules",
  "harn-parser",
  "harn-vm",
+ "hmac",
  "include_dir",
  "jmespath",
  "notify",
  "nu-ansi-term",
  "rand 0.10.1",
+ "rcgen",
  "reedline",
  "regex",
  "reqwest",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
+ "sha2 0.11.0",
  "tempfile",
  "time",
  "tokio",
@@ -995,7 +1155,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "tempfile",
  "time",
@@ -1051,6 +1211,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"
@@ -1116,6 +1285,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1479,6 +1649,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,7 +1803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1855,6 +2035,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -2102,6 +2292,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,12 +2482,23 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2303,6 +2517,7 @@ version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2478,13 +2693,24 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3685,6 +3911,15 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -32,6 +32,7 @@ harn-modules = { path = "../harn-modules", version = "0.7" }
 harn-fmt = { path = "../harn-fmt", version = "0.7" }
 async-trait = "0.1"
 axum = "0.8"
+axum-server = { version = "0.7", features = ["tls-rustls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "time"] }
 serde_json = "1"
 reedline = "0.47"
@@ -55,3 +56,10 @@ uuid = { version = "1", features = ["v4", "v7"] }
 chrono-tz = "0.10.4"
 croner = "3.0.1"
 jmespath = "0.5.0"
+rustls-pemfile = "2"
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
+
+[dev-dependencies]
+hmac = "0.12"
+rcgen = "0.13"
+sha2_10 = { package = "sha2", version = "0.10" }

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -488,6 +488,12 @@ pub(crate) struct OrchestratorServeArgs {
     /// Socket address the future HTTP listener will bind to.
     #[arg(long, default_value = "127.0.0.1:8080", value_name = "ADDR")]
     pub bind: SocketAddr,
+    /// PEM-encoded certificate chain for HTTPS termination.
+    #[arg(long, value_name = "PATH")]
+    pub cert: Option<PathBuf>,
+    /// PEM-encoded private key for HTTPS termination.
+    #[arg(long, value_name = "PATH")]
+    pub key: Option<PathBuf>,
     /// Runtime role to boot. Multi-tenant is a stub for now.
     #[arg(long, value_enum, default_value_t = crate::commands::orchestrator::role::OrchestratorRole::SingleTenant)]
     pub role: crate::commands::orchestrator::role::OrchestratorRole,
@@ -835,6 +841,10 @@ mod tests {
             "state/orchestrator",
             "--bind",
             "0.0.0.0:8080",
+            "--cert",
+            "tls/cert.pem",
+            "--key",
+            "tls/key.pem",
             "--role",
             "single-tenant",
         ]);
@@ -848,6 +858,8 @@ mod tests {
         assert_eq!(serve.config, PathBuf::from("workspace/harn.toml"));
         assert_eq!(serve.state_dir, PathBuf::from("state/orchestrator"));
         assert_eq!(serve.bind.to_string(), "0.0.0.0:8080");
+        assert_eq!(serve.cert, Some(PathBuf::from("tls/cert.pem")));
+        assert_eq!(serve.key, Some(PathBuf::from("tls/key.pem")));
         assert_eq!(
             serve.role,
             crate::commands::orchestrator::role::OrchestratorRole::SingleTenant

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -1,0 +1,640 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Bytes;
+use axum::extract::{DefaultBodyLimit, Extension, Query};
+use axum::http::{HeaderMap, StatusCode};
+use axum::middleware;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::Router;
+use serde_json::{json, Value as JsonValue};
+use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
+
+use harn_vm::event_log::{AnyEventLog, EventLog, LogEvent, Topic};
+use harn_vm::secrets::{SecretId, SecretProvider, SecretVersion};
+
+use crate::commands::orchestrator::origin_guard::{enforce_allowed_origin, OriginAllowList};
+use crate::commands::orchestrator::tls::{ServerRuntime, TlsFiles};
+use crate::package::{CollectedManifestTrigger, TriggerKind};
+
+const DEFAULT_MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
+const PENDING_TOPIC: &str = "orchestrator.triggers.pending";
+const REQUEST_DELAY_ENV: &str = "HARN_ORCHESTRATOR_TEST_REQUEST_DELAY_MS";
+
+#[derive(Clone)]
+pub(crate) struct ListenerConfig {
+    pub(crate) bind: std::net::SocketAddr,
+    pub(crate) tls: Option<TlsFiles>,
+    pub(crate) event_log: Arc<AnyEventLog>,
+    pub(crate) secrets: Arc<dyn SecretProvider>,
+    pub(crate) allowed_origins: OriginAllowList,
+    pub(crate) max_body_bytes: usize,
+    pub(crate) routes: Vec<RouteConfig>,
+}
+
+impl ListenerConfig {
+    pub(crate) fn max_body_bytes_or_default(max_body_bytes: Option<usize>) -> usize {
+        max_body_bytes.unwrap_or(DEFAULT_MAX_BODY_BYTES)
+    }
+}
+
+pub(crate) struct ListenerRuntime {
+    server: ServerRuntime,
+    metrics: Arc<BTreeMap<String, Arc<RouteRuntimeMetrics>>>,
+}
+
+impl ListenerRuntime {
+    pub(crate) async fn start(config: ListenerConfig) -> Result<Self, String> {
+        let pending_topic =
+            Topic::new(PENDING_TOPIC).map_err(|error| format!("invalid pending topic: {error}"))?;
+        let request_delay = std::env::var(REQUEST_DELAY_ENV)
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .map(Duration::from_millis);
+        let origin_state = Arc::new(config.allowed_origins.clone());
+        let mut route_metrics = BTreeMap::new();
+        let mut app = Router::new()
+            .route(
+                "/healthz",
+                get(|| async move { (StatusCode::OK, "ok").into_response() }),
+            )
+            .route(
+                "/readyz",
+                get(|| async move { (StatusCode::OK, "ready").into_response() }),
+            );
+
+        let mut seen_paths = BTreeSet::new();
+        for route in &config.routes {
+            if !seen_paths.insert(route.path.clone()) {
+                return Err(format!(
+                    "trigger route '{}' is configured more than once",
+                    route.path
+                ));
+            }
+            let context = Arc::new(RouteContext {
+                route: route.clone(),
+                event_log: config.event_log.clone(),
+                secrets: config.secrets.clone(),
+                pending_topic: pending_topic.clone(),
+                request_delay,
+                metrics: Arc::new(RouteRuntimeMetrics::default()),
+            });
+            route_metrics.insert(route.trigger_id.clone(), context.metrics.clone());
+            app = app.route(
+                &route.path,
+                post(ingest_trigger).layer(Extension(context.clone())),
+            );
+        }
+
+        let app = app
+            .layer(DefaultBodyLimit::max(config.max_body_bytes))
+            .layer(middleware::from_fn_with_state(
+                origin_state.clone(),
+                enforce_allowed_origin,
+            ))
+            .with_state(origin_state);
+
+        let server = ServerRuntime::start(config.bind, app, config.tls.as_ref()).await?;
+        Ok(Self {
+            server,
+            metrics: Arc::new(route_metrics),
+        })
+    }
+
+    pub(crate) fn local_addr(&self) -> std::net::SocketAddr {
+        self.server.local_addr()
+    }
+
+    pub(crate) fn scheme(&self) -> &'static str {
+        if self.server.tls_enabled() {
+            "https"
+        } else {
+            "http"
+        }
+    }
+
+    pub(crate) fn url(&self) -> String {
+        format!("{}://{}", self.scheme(), self.local_addr())
+    }
+
+    pub(crate) fn trigger_metrics(&self) -> BTreeMap<String, TriggerMetricSnapshot> {
+        snapshot_metrics(self.metrics.as_ref())
+    }
+
+    pub(crate) async fn shutdown(self) -> Result<BTreeMap<String, TriggerMetricSnapshot>, String> {
+        let Self { server, metrics } = self;
+        server.shutdown().await?;
+        Ok(snapshot_metrics(metrics.as_ref()))
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct RouteConfig {
+    pub(crate) trigger_id: String,
+    pub(crate) binding_version: u32,
+    pub(crate) provider: harn_vm::ProviderId,
+    pub(crate) path: String,
+    pub(crate) signature_mode: SignatureMode,
+    pub(crate) signing_secret: Option<SecretId>,
+}
+
+impl RouteConfig {
+    pub(crate) fn from_trigger(
+        trigger: &CollectedManifestTrigger,
+        binding_version: u32,
+    ) -> Result<Option<Self>, String> {
+        match trigger.config.kind {
+            TriggerKind::Webhook => {
+                let provider = trigger.config.provider.clone();
+                let signature_mode = match provider.as_str() {
+                    "github" => SignatureMode::GitHub,
+                    "webhook" => SignatureMode::Standard,
+                    other => {
+                        return Err(format!(
+                            "HTTP listener does not yet support webhook provider '{other}' on this branch"
+                        ))
+                    }
+                };
+                Ok(Some(Self {
+                    trigger_id: trigger.config.id.clone(),
+                    binding_version,
+                    provider,
+                    path: trigger_path(trigger)?,
+                    signature_mode,
+                    signing_secret: parse_secret_id(
+                        trigger
+                            .config
+                            .secrets
+                            .get("signing_secret")
+                            .map(String::as_str),
+                    ),
+                }))
+            }
+            TriggerKind::A2aPush => Ok(Some(Self {
+                trigger_id: trigger.config.id.clone(),
+                binding_version,
+                provider: harn_vm::ProviderId::from("a2a-push"),
+                path: trigger_path(trigger)?,
+                signature_mode: SignatureMode::Unsigned,
+                signing_secret: None,
+            })),
+            _ => Ok(None),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct RouteContext {
+    route: RouteConfig,
+    event_log: Arc<AnyEventLog>,
+    secrets: Arc<dyn SecretProvider>,
+    pending_topic: Topic,
+    request_delay: Option<Duration>,
+    metrics: Arc<RouteRuntimeMetrics>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum SignatureMode {
+    GitHub,
+    Standard,
+    Unsigned,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TriggerMetricSnapshot {
+    pub(crate) received: u64,
+    pub(crate) dispatched: u64,
+    pub(crate) failed: u64,
+    pub(crate) in_flight: u64,
+}
+
+#[derive(Default)]
+struct RouteRuntimeMetrics {
+    received: AtomicU64,
+    dispatched: AtomicU64,
+    failed: AtomicU64,
+    in_flight: AtomicU64,
+}
+
+impl RouteRuntimeMetrics {
+    fn snapshot(&self) -> TriggerMetricSnapshot {
+        TriggerMetricSnapshot {
+            received: self.received.load(Ordering::Relaxed),
+            dispatched: self.dispatched.load(Ordering::Relaxed),
+            failed: self.failed.load(Ordering::Relaxed),
+            in_flight: self.in_flight.load(Ordering::Relaxed),
+        }
+    }
+}
+
+fn snapshot_metrics(
+    metrics: &BTreeMap<String, Arc<RouteRuntimeMetrics>>,
+) -> BTreeMap<String, TriggerMetricSnapshot> {
+    metrics
+        .iter()
+        .map(|(trigger_id, metrics)| (trigger_id.clone(), metrics.snapshot()))
+        .collect()
+}
+
+async fn ingest_trigger(
+    Extension(context): Extension<Arc<RouteContext>>,
+    headers: HeaderMap,
+    Query(query): Query<BTreeMap<String, String>>,
+    body: Bytes,
+) -> impl IntoResponse {
+    context.metrics.received.fetch_add(1, Ordering::Relaxed);
+    context.metrics.in_flight.fetch_add(1, Ordering::Relaxed);
+
+    if let Some(delay) = context.request_delay {
+        tokio::time::sleep(delay).await;
+    }
+
+    let result = normalize_request(&context, &headers, &query, body.as_ref()).await;
+
+    match result {
+        Ok(event) => {
+            let payload = json!({
+                "trigger_id": context.route.trigger_id,
+                "binding_version": context.route.binding_version,
+                "event": event,
+            });
+            match context
+                .event_log
+                .append(
+                    &context.pending_topic,
+                    LogEvent::new("trigger_event", payload),
+                )
+                .await
+            {
+                Ok(event_id) => {
+                    context.metrics.dispatched.fetch_add(1, Ordering::Relaxed);
+                    context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+                    (
+                        StatusCode::OK,
+                        axum::Json(json!({
+                            "status": "accepted",
+                            "event_id": event_id,
+                            "trigger_id": context.route.trigger_id,
+                        })),
+                    )
+                        .into_response()
+                }
+                Err(error) => {
+                    context.metrics.failed.fetch_add(1, Ordering::Relaxed);
+                    context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("failed to append trigger event to pending log: {error}"),
+                    )
+                        .into_response()
+                }
+            }
+        }
+        Err(error) => {
+            context.metrics.failed.fetch_add(1, Ordering::Relaxed);
+            context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+            error.into_response()
+        }
+    }
+}
+
+async fn normalize_request(
+    context: &RouteContext,
+    headers: &HeaderMap,
+    _query: &BTreeMap<String, String>,
+    body: &[u8],
+) -> Result<harn_vm::TriggerEvent, HttpError> {
+    let received_at = OffsetDateTime::now_utc();
+    let normalized_headers = normalize_headers(headers);
+    let normalized_body = normalize_body(body, &normalized_headers);
+    let provider = context.route.provider.clone();
+
+    let signature_status = match context.route.signature_mode {
+        SignatureMode::Unsigned => harn_vm::SignatureStatus::Unsigned,
+        SignatureMode::GitHub => {
+            let secret = load_secret(context, context.route.signing_secret.as_ref()).await?;
+            harn_vm::connectors::hmac::verify_hmac_signed(
+                context.event_log.as_ref(),
+                &provider,
+                harn_vm::connectors::HmacSignatureStyle::github(),
+                body,
+                &normalized_headers,
+                &secret,
+                None,
+                received_at,
+            )
+            .await
+            .map_err(HttpError::from_connector)?;
+            harn_vm::SignatureStatus::Verified
+        }
+        SignatureMode::Standard => {
+            let secret = load_secret(context, context.route.signing_secret.as_ref()).await?;
+            harn_vm::connectors::hmac::verify_hmac_signed(
+                context.event_log.as_ref(),
+                &provider,
+                harn_vm::connectors::HmacSignatureStyle::standard_webhooks(),
+                body,
+                &normalized_headers,
+                &secret,
+                Some(time::Duration::minutes(5)),
+                received_at,
+            )
+            .await
+            .map_err(HttpError::from_connector)?;
+            harn_vm::SignatureStatus::Verified
+        }
+    };
+
+    let provider_kind = provider_event_kind(&provider, &normalized_headers, &normalized_body);
+    let trigger_kind = trigger_event_kind(&provider, &normalized_headers, &normalized_body);
+    let dedupe_key = dedupe_key(
+        context.route.signature_mode,
+        &normalized_headers,
+        &normalized_body,
+        body,
+    );
+    let provider_payload = harn_vm::ProviderPayload::normalize(
+        &provider,
+        &provider_kind,
+        &normalized_headers,
+        normalized_body,
+    )
+    .map_err(|error| HttpError::unprocessable(error.to_string()))?;
+
+    Ok(harn_vm::TriggerEvent {
+        id: harn_vm::TriggerEventId::new(),
+        provider,
+        kind: trigger_kind,
+        received_at,
+        occurred_at: infer_occurred_at(&provider_payload),
+        dedupe_key,
+        trace_id: harn_vm::TraceId::new(),
+        tenant_id: None,
+        headers: harn_vm::redact_headers(
+            &normalized_headers,
+            &harn_vm::HeaderRedactionPolicy::default(),
+        ),
+        provider_payload,
+        signature_status,
+    })
+}
+
+fn trigger_path(trigger: &CollectedManifestTrigger) -> Result<String, String> {
+    let path = trigger
+        .config
+        .kind_specific
+        .get("path")
+        .and_then(JsonValueExt::as_toml_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("/triggers/{}", trigger.config.id));
+    if !path.starts_with('/') {
+        return Err(format!(
+            "trigger '{}' path must start with '/'",
+            trigger.config.id
+        ));
+    }
+    Ok(path)
+}
+
+async fn load_secret(
+    context: &RouteContext,
+    secret_id: Option<&SecretId>,
+) -> Result<String, HttpError> {
+    let secret_id = secret_id.ok_or_else(|| {
+        HttpError::internal(format!(
+            "trigger '{}' requires a signing secret",
+            context.route.trigger_id
+        ))
+    })?;
+    let secret = context
+        .secrets
+        .get(secret_id)
+        .await
+        .map_err(|error| HttpError::internal(error.to_string()))?;
+    secret.with_exposed(|bytes| {
+        std::str::from_utf8(bytes)
+            .map(|value| value.to_string())
+            .map_err(|error| {
+                HttpError::internal(format!(
+                    "secret '{}' is not valid UTF-8: {error}",
+                    secret_id
+                ))
+            })
+    })
+}
+
+fn parse_secret_id(raw: Option<&str>) -> Option<SecretId> {
+    let trimmed = raw?.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let (base, version) = match trimmed.rsplit_once('@') {
+        Some((base, version_text)) => {
+            let version = version_text.parse::<u64>().ok()?;
+            (base, SecretVersion::Exact(version))
+        }
+        None => (trimmed, SecretVersion::Latest),
+    };
+    let (namespace, name) = base.split_once('/')?;
+    if namespace.is_empty() || name.is_empty() {
+        return None;
+    }
+    Some(SecretId::new(namespace, name).with_version(version))
+}
+
+fn normalize_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
+    let mut normalized = BTreeMap::new();
+    for (name, value) in headers {
+        if let Ok(value) = value.to_str() {
+            normalized.insert(name.as_str().to_string(), value.to_string());
+        }
+    }
+
+    for (raw, canonical) in [
+        ("content-type", "Content-Type"),
+        ("content-length", "Content-Length"),
+        ("origin", "Origin"),
+        ("x-github-event", "X-GitHub-Event"),
+        ("x-github-delivery", "X-GitHub-Delivery"),
+        ("x-hub-signature-256", "X-Hub-Signature-256"),
+        ("webhook-id", "webhook-id"),
+        ("webhook-signature", "webhook-signature"),
+        ("webhook-timestamp", "webhook-timestamp"),
+        ("x-a2a-delivery", "X-A2A-Delivery"),
+    ] {
+        if let Some(value) = header_value(&normalized, raw) {
+            let value = value.to_string();
+            normalized.entry(canonical.to_string()).or_insert(value);
+        }
+    }
+
+    normalized
+}
+
+fn normalize_body(body: &[u8], headers: &BTreeMap<String, String>) -> JsonValue {
+    let content_type = header_value(headers, "content-type").unwrap_or_default();
+    if content_type.contains("json") {
+        if let Ok(value) = serde_json::from_slice(body) {
+            return value;
+        }
+    }
+    use base64::Engine;
+
+    let raw_base64 = base64::engine::general_purpose::STANDARD.encode(body);
+    serde_json::from_slice(body).unwrap_or_else(|_| {
+        json!({
+            "raw_base64": raw_base64,
+            "raw_utf8": std::str::from_utf8(body).ok(),
+        })
+    })
+}
+
+fn provider_event_kind(
+    provider: &harn_vm::ProviderId,
+    headers: &BTreeMap<String, String>,
+    body: &JsonValue,
+) -> String {
+    match provider.as_str() {
+        "github" => header_value(headers, "x-github-event")
+            .map(ToString::to_string)
+            .unwrap_or_else(|| "webhook".to_string()),
+        "a2a-push" => "push".to_string(),
+        _ => body
+            .get("type")
+            .and_then(JsonValue::as_str)
+            .or_else(|| body.get("event").and_then(JsonValue::as_str))
+            .unwrap_or("webhook")
+            .to_string(),
+    }
+}
+
+fn trigger_event_kind(
+    provider: &harn_vm::ProviderId,
+    headers: &BTreeMap<String, String>,
+    body: &JsonValue,
+) -> String {
+    if provider.as_str() == "github" {
+        let event = header_value(headers, "x-github-event").unwrap_or("webhook");
+        if let Some(action) = body.get("action").and_then(JsonValue::as_str) {
+            return format!("{event}.{action}");
+        }
+        return event.to_string();
+    }
+    provider_event_kind(provider, headers, body)
+}
+
+fn dedupe_key(
+    signature_mode: SignatureMode,
+    headers: &BTreeMap<String, String>,
+    body: &JsonValue,
+    raw_body: &[u8],
+) -> String {
+    match signature_mode {
+        SignatureMode::GitHub => header_value(headers, "x-github-delivery")
+            .map(ToString::to_string)
+            .unwrap_or_else(|| fallback_body_digest(raw_body)),
+        SignatureMode::Standard => header_value(headers, "webhook-id")
+            .map(ToString::to_string)
+            .or_else(|| {
+                body.get("id")
+                    .and_then(JsonValue::as_str)
+                    .map(ToString::to_string)
+            })
+            .unwrap_or_else(|| fallback_body_digest(raw_body)),
+        SignatureMode::Unsigned => header_value(headers, "x-a2a-delivery")
+            .map(ToString::to_string)
+            .unwrap_or_else(|| fallback_body_digest(raw_body)),
+    }
+}
+
+fn infer_occurred_at(payload: &harn_vm::ProviderPayload) -> Option<OffsetDateTime> {
+    let harn_vm::ProviderPayload::Known(payload) = payload else {
+        return None;
+    };
+    let raw = match payload {
+        harn_vm::triggers::event::KnownProviderPayload::GitHub(payload) => &payload.raw,
+        harn_vm::triggers::event::KnownProviderPayload::Webhook(payload) => &payload.raw,
+        harn_vm::triggers::event::KnownProviderPayload::A2aPush(payload) => &payload.raw,
+        _ => return None,
+    };
+    raw.get("timestamp")
+        .and_then(JsonValue::as_str)
+        .and_then(|value| {
+            OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339).ok()
+        })
+}
+
+fn header_value<'a>(headers: &'a BTreeMap<String, String>, name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
+}
+
+fn fallback_body_digest(body: &[u8]) -> String {
+    let digest = Sha256::digest(body);
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        encoded.push_str(&format!("{byte:02x}"));
+    }
+    format!("sha256:{encoded}")
+}
+
+trait JsonValueExt {
+    fn as_toml_str(&self) -> Option<&str>;
+}
+
+impl JsonValueExt for toml::Value {
+    fn as_toml_str(&self) -> Option<&str> {
+        self.as_str()
+    }
+}
+
+struct HttpError {
+    status: StatusCode,
+    message: String,
+}
+
+impl HttpError {
+    fn internal(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: message.into(),
+        }
+    }
+
+    fn unprocessable(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            message: message.into(),
+        }
+    }
+
+    fn from_connector(error: harn_vm::ConnectorError) -> Self {
+        match error {
+            harn_vm::ConnectorError::MissingHeader(_)
+            | harn_vm::ConnectorError::InvalidHeader { .. }
+            | harn_vm::ConnectorError::InvalidSignature(_)
+            | harn_vm::ConnectorError::TimestampOutOfWindow { .. } => Self {
+                status: StatusCode::BAD_REQUEST,
+                message: error.to_string(),
+            },
+            harn_vm::ConnectorError::Unsupported(_) => Self {
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                message: error.to_string(),
+            },
+            _ => Self::internal(error.to_string()),
+        }
+    }
+}
+
+impl IntoResponse for HttpError {
+    fn into_response(self) -> axum::response::Response {
+        (self.status, self.message).into_response()
+    }
+}

--- a/crates/harn-cli/src/commands/orchestrator/mod.rs
+++ b/crates/harn-cli/src/commands/orchestrator/mod.rs
@@ -1,5 +1,8 @@
+mod listener;
+mod origin_guard;
 pub(crate) mod role;
 mod serve;
+mod tls;
 
 use crate::cli::{OrchestratorArgs, OrchestratorCommand};
 

--- a/crates/harn-cli/src/commands/orchestrator/origin_guard.rs
+++ b/crates/harn-cli/src/commands/orchestrator/origin_guard.rs
@@ -1,0 +1,97 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct OriginAllowList {
+    wildcard: bool,
+    exact: BTreeSet<String>,
+}
+
+impl OriginAllowList {
+    pub(crate) fn from_manifest(origins: &[String]) -> Self {
+        if origins.is_empty() {
+            return Self::wildcard();
+        }
+
+        let mut wildcard = false;
+        let mut exact = BTreeSet::new();
+        for origin in origins {
+            let trimmed = origin.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if trimmed == "*" {
+                wildcard = true;
+                continue;
+            }
+            exact.insert(trimmed.to_string());
+        }
+
+        if wildcard || exact.is_empty() {
+            Self::wildcard()
+        } else {
+            Self {
+                wildcard: false,
+                exact,
+            }
+        }
+    }
+
+    pub(crate) fn wildcard() -> Self {
+        Self {
+            wildcard: true,
+            exact: BTreeSet::new(),
+        }
+    }
+
+    pub(crate) fn allows(&self, origin: &str) -> bool {
+        self.wildcard || self.exact.contains(origin)
+    }
+}
+
+pub(crate) async fn enforce_allowed_origin(
+    State(allow_list): State<Arc<OriginAllowList>>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let origin = request
+        .headers()
+        .get(axum::http::header::ORIGIN)
+        .and_then(|value| value.to_str().ok());
+
+    match origin {
+        Some(origin) if !allow_list.allows(origin) => (
+            StatusCode::FORBIDDEN,
+            format!("origin '{origin}' is not allowed"),
+        )
+            .into_response(),
+        _ => next.run(request).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OriginAllowList;
+
+    #[test]
+    fn empty_manifest_defaults_to_wildcard() {
+        let allow_list = OriginAllowList::from_manifest(&[]);
+        assert!(allow_list.allows("https://example.com"));
+    }
+
+    #[test]
+    fn explicit_allow_list_restricts_origins() {
+        let allow_list = OriginAllowList::from_manifest(&[
+            "https://allowed.example".to_string(),
+            "https://other.example".to_string(),
+        ]);
+        assert!(allow_list.allows("https://allowed.example"));
+        assert!(!allow_list.allows("https://blocked.example"));
+    }
+}

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -11,19 +11,22 @@ use time::OffsetDateTime;
 
 use harn_vm::event_log::EventLog;
 
+use super::listener::{ListenerConfig, ListenerRuntime, RouteConfig, TriggerMetricSnapshot};
+use super::origin_guard::OriginAllowList;
+use super::role::OrchestratorRole;
+use super::tls::TlsFiles;
 use crate::cli::OrchestratorServeArgs;
-use crate::commands::orchestrator::role::OrchestratorRole;
 use crate::package::{
     self, CollectedManifestTrigger, CollectedTriggerHandler, Manifest, ResolvedTriggerConfig,
 };
 
-const HTTP_LISTENER_STUB: &str = "HTTP listener not yet implemented (see O-02 #179)";
 const LIFECYCLE_TOPIC: &str = "orchestrator.lifecycle";
 const STATE_SNAPSHOT_FILE: &str = "orchestrator-state.json";
 
 pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
     harn_vm::reset_thread_local_state();
 
+    let tls = TlsFiles::from_args(args.cert.clone(), args.key.clone())?;
     let config_path = absolutize_from_cwd(&args.config)?;
     let (manifest, manifest_dir) = load_manifest(&config_path)?;
     let state_dir = absolutize_from_cwd(&args.state_dir)?;
@@ -86,12 +89,15 @@ pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
     let collected_triggers = package::collect_manifest_triggers(&mut vm, &extensions)
         .await
         .map_err(|error| format!("failed to collect manifest triggers: {error}"))?;
+    package::install_collected_manifest_triggers(&collected_triggers).await?;
     eprintln!(
         "[harn] registered triggers ({}): {}",
         collected_triggers.len(),
         format_trigger_summary(&collected_triggers)
     );
 
+    let binding_versions = live_manifest_binding_versions();
+    let route_configs = build_route_configs(&collected_triggers, &binding_versions)?;
     let connector_runtime = initialize_connectors(
         &collected_triggers,
         event_log.clone(),
@@ -108,12 +114,28 @@ pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
         format_activation_summary(&connector_runtime.activations)
     );
 
+    let listener = ListenerRuntime::start(ListenerConfig {
+        bind: args.bind,
+        tls,
+        event_log: event_log.clone(),
+        secrets: secret_provider.clone(),
+        allowed_origins: OriginAllowList::from_manifest(&manifest.orchestrator.allowed_origins),
+        max_body_bytes: ListenerConfig::max_body_bytes_or_default(
+            manifest.orchestrator.max_body_bytes,
+        ),
+        routes: route_configs,
+    })
+    .await?;
+    let local_bind = listener.local_addr();
+    let listener_metrics = listener.trigger_metrics();
+    eprintln!("[harn] HTTP listener ready on {}", listener.url());
+
     write_state_snapshot(
         &state_dir.join(STATE_SNAPSHOT_FILE),
         &ServeStateSnapshot {
             status: "running".to_string(),
             role: args.role.as_str().to_string(),
-            bind: args.bind.to_string(),
+            bind: local_bind.to_string(),
             manifest_path: config_path.display().to_string(),
             state_dir: state_dir.display().to_string(),
             started_at: startup_started_at.clone(),
@@ -124,15 +146,7 @@ pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
                 .location
                 .as_ref()
                 .map(|path| path.display().to_string()),
-            triggers: collected_triggers
-                .iter()
-                .map(|trigger| TriggerStateSnapshot {
-                    id: trigger.config.id.clone(),
-                    provider: trigger.config.provider.as_str().to_string(),
-                    kind: trigger_kind_name(trigger.config.kind).to_string(),
-                    handler: handler_kind(&trigger.handler).to_string(),
-                })
-                .collect(),
+            triggers: trigger_state_snapshots(&collected_triggers, &listener_metrics),
             connectors: connector_runtime.providers.clone(),
             activations: connector_runtime
                 .activations
@@ -149,31 +163,34 @@ pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
         &event_log,
         "startup",
         json!({
-            "bind": args.bind.to_string(),
+            "bind": local_bind.to_string(),
             "manifest": config_path.display().to_string(),
             "role": args.role.as_str(),
             "state_dir": state_dir.display().to_string(),
             "trigger_count": collected_triggers.len(),
             "connector_count": connector_runtime.providers.len(),
+            "tls_enabled": listener.scheme() == "https",
         }),
     )
     .await?;
 
-    eprintln!("[harn] {HTTP_LISTENER_STUB}; requested bind {}", args.bind);
     wait_for_termination_signal().await?;
 
-    graceful_shutdown(GracefulShutdownCtx {
-        role: args.role,
-        bind: args.bind,
-        config_path: &config_path,
-        state_dir: &state_dir,
-        startup_started_at: &startup_started_at,
-        event_log: &event_log,
-        event_log_description: &event_log_description,
-        secret_chain_display: &secret_chain_display,
-        triggers: &collected_triggers,
-        connectors: &connector_runtime,
-    })
+    graceful_shutdown(
+        GracefulShutdownCtx {
+            role: args.role,
+            bind: local_bind,
+            config_path: &config_path,
+            state_dir: &state_dir,
+            startup_started_at: &startup_started_at,
+            event_log: &event_log,
+            event_log_description: &event_log_description,
+            secret_chain_display: &secret_chain_display,
+            triggers: &collected_triggers,
+            connectors: &connector_runtime,
+        },
+        listener,
+    )
     .await
 }
 
@@ -212,9 +229,13 @@ async fn initialize_connectors(
     let mut providers = Vec::new();
     for (provider, kinds) in grouped_kinds {
         let provider_name = provider.as_str().to_string();
-        let connector = PlaceholderConnector::new(provider.clone(), kinds);
+        let connector: Box<dyn harn_vm::Connector> = if provider.as_str() == "cron" {
+            Box::new(harn_vm::CronConnector::new())
+        } else {
+            Box::new(PlaceholderConnector::new(provider.clone(), kinds))
+        };
         registry
-            .register(Box::new(connector))
+            .register(connector)
             .map_err(|error| error.to_string())?;
         let handle = registry
             .get(&provider)
@@ -241,13 +262,105 @@ async fn initialize_connectors(
 }
 
 fn trigger_binding_for(config: &ResolvedTriggerConfig) -> harn_vm::TriggerBinding {
-    harn_vm::TriggerBinding {
-        provider: config.provider.clone(),
-        kind: harn_vm::TriggerKind::from(trigger_kind_name(config.kind)),
-        binding_id: config.id.clone(),
-        dedupe_key: None,
-        config: JsonValue::Null,
+    let mut binding = harn_vm::TriggerBinding::new(
+        config.provider.clone(),
+        trigger_kind_name(config.kind),
+        config.id.clone(),
+    );
+    let mut binding_config = serde_json::Map::new();
+    binding_config.insert(
+        "match".to_string(),
+        serde_json::to_value(&config.match_).unwrap_or(JsonValue::Null),
+    );
+    binding_config.insert(
+        "secrets".to_string(),
+        serde_json::to_value(&config.secrets).unwrap_or(JsonValue::Null),
+    );
+    for (key, value) in &config.kind_specific {
+        binding_config.insert(
+            key.clone(),
+            serde_json::to_value(value).unwrap_or(JsonValue::Null),
+        );
     }
+    binding.config = JsonValue::Object(binding_config);
+    binding
+}
+
+fn build_route_configs(
+    triggers: &[CollectedManifestTrigger],
+    binding_versions: &BTreeMap<String, u32>,
+) -> Result<Vec<RouteConfig>, String> {
+    let mut routes = Vec::new();
+    for trigger in triggers {
+        let Some(binding_version) = binding_versions.get(&trigger.config.id).copied() else {
+            return Err(format!(
+                "trigger registry is missing active manifest binding '{}'",
+                trigger.config.id
+            ));
+        };
+        if let Some(route) = RouteConfig::from_trigger(trigger, binding_version)? {
+            routes.push(route);
+        }
+    }
+    Ok(routes)
+}
+
+fn live_manifest_binding_versions() -> BTreeMap<String, u32> {
+    let mut versions = BTreeMap::new();
+    for binding in harn_vm::snapshot_trigger_bindings() {
+        if binding.source != harn_vm::TriggerBindingSource::Manifest {
+            continue;
+        }
+        if binding.state == harn_vm::TriggerState::Terminated {
+            continue;
+        }
+        versions
+            .entry(binding.id)
+            .and_modify(|current: &mut u32| *current = (*current).max(binding.version))
+            .or_insert(binding.version);
+    }
+    versions
+}
+
+fn trigger_state_snapshots(
+    triggers: &[CollectedManifestTrigger],
+    listener_metrics: &BTreeMap<String, TriggerMetricSnapshot>,
+) -> Vec<TriggerStateSnapshot> {
+    let bindings_by_id = harn_vm::snapshot_trigger_bindings()
+        .into_iter()
+        .filter(|binding| binding.source == harn_vm::TriggerBindingSource::Manifest)
+        .fold(
+            BTreeMap::<String, harn_vm::TriggerBindingSnapshot>::new(),
+            |mut acc, binding| {
+                match acc.get(&binding.id) {
+                    Some(current) if current.version >= binding.version => {}
+                    _ => {
+                        acc.insert(binding.id.clone(), binding);
+                    }
+                }
+                acc
+            },
+        );
+
+    triggers
+        .iter()
+        .map(|trigger| {
+            let runtime = bindings_by_id.get(&trigger.config.id);
+            let metrics = listener_metrics.get(&trigger.config.id);
+            TriggerStateSnapshot {
+                id: trigger.config.id.clone(),
+                provider: trigger.config.provider.as_str().to_string(),
+                kind: trigger_kind_name(trigger.config.kind).to_string(),
+                handler: handler_kind(&trigger.handler).to_string(),
+                version: runtime.map(|binding| binding.version),
+                state: runtime.map(|binding| binding.state.as_str().to_string()),
+                received: metrics.map(|value| value.received).unwrap_or(0),
+                dispatched: metrics.map(|value| value.dispatched).unwrap_or(0),
+                failed: metrics.map(|value| value.failed).unwrap_or(0),
+                in_flight: metrics.map(|value| value.in_flight).unwrap_or(0),
+            }
+        })
+        .collect()
 }
 
 fn format_trigger_summary(triggers: &[CollectedManifestTrigger]) -> String {
@@ -305,9 +418,19 @@ fn trigger_kind_name(kind: crate::package::TriggerKind) -> &'static str {
     }
 }
 
-async fn graceful_shutdown(ctx: GracefulShutdownCtx<'_>) -> Result<(), String> {
+async fn graceful_shutdown(
+    ctx: GracefulShutdownCtx<'_>,
+    listener: ListenerRuntime,
+) -> Result<(), String> {
     eprintln!("[harn] signal received, starting graceful shutdown...");
-    eprintln!("[harn] draining in-flight events (scaffold): 0");
+    // TODO(O-06): replace this listener-local scan with the shared
+    // orchestrator drain coordinator when that lands on the main branch.
+    let drained_events = listener
+        .trigger_metrics()
+        .into_values()
+        .map(|metrics| metrics.in_flight)
+        .sum::<u64>();
+    let listener_metrics = listener.shutdown().await?;
 
     let stopped_at = now_rfc3339()?;
     append_lifecycle_event(
@@ -315,7 +438,7 @@ async fn graceful_shutdown(ctx: GracefulShutdownCtx<'_>) -> Result<(), String> {
         "shutdown",
         json!({
             "bind": ctx.bind.to_string(),
-            "drained_events": 0,
+            "drained_events": drained_events,
             "role": ctx.role.as_str(),
             "status": "stopped",
         }),
@@ -339,16 +462,7 @@ async fn graceful_shutdown(ctx: GracefulShutdownCtx<'_>) -> Result<(), String> {
                 .location
                 .as_ref()
                 .map(|path| path.display().to_string()),
-            triggers: ctx
-                .triggers
-                .iter()
-                .map(|trigger| TriggerStateSnapshot {
-                    id: trigger.config.id.clone(),
-                    provider: trigger.config.provider.as_str().to_string(),
-                    kind: trigger_kind_name(trigger.config.kind).to_string(),
-                    handler: handler_kind(&trigger.handler).to_string(),
-                })
-                .collect(),
+            triggers: trigger_state_snapshots(ctx.triggers, &listener_metrics),
             connectors: ctx.connectors.providers.clone(),
             activations: ctx
                 .connectors
@@ -371,8 +485,6 @@ async fn append_lifecycle_event(
     kind: &str,
     payload: JsonValue,
 ) -> Result<(), String> {
-    use harn_vm::event_log::EventLog;
-
     let topic =
         harn_vm::event_log::Topic::new(LIFECYCLE_TOPIC).map_err(|error| error.to_string())?;
     log.append(&topic, harn_vm::event_log::LogEvent::new(kind, payload))
@@ -509,6 +621,12 @@ struct TriggerStateSnapshot {
     provider: String,
     kind: String,
     handler: String,
+    version: Option<u32>,
+    state: Option<String>,
+    received: u64,
+    dispatched: u64,
+    failed: u64,
+    in_flight: u64,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/harn-cli/src/commands/orchestrator/tls.rs
+++ b/crates/harn-cli/src/commands/orchestrator/tls.rs
@@ -1,0 +1,128 @@
+use std::net::{SocketAddr, TcpListener};
+use std::path::{Path, PathBuf};
+use std::sync::Once;
+use std::time::Duration;
+
+use axum::Router;
+use axum_server::tls_rustls::RustlsConfig;
+use axum_server::Handle;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TlsFiles {
+    pub(crate) cert: PathBuf,
+    pub(crate) key: PathBuf,
+}
+
+impl TlsFiles {
+    pub(crate) fn from_args(
+        cert: Option<PathBuf>,
+        key: Option<PathBuf>,
+    ) -> Result<Option<Self>, String> {
+        match (cert, key) {
+            (None, None) => Ok(None),
+            (Some(cert), Some(key)) => Ok(Some(Self { cert, key })),
+            (Some(_), None) => Err("`--cert` requires `--key`".to_string()),
+            (None, Some(_)) => Err("`--key` requires `--cert`".to_string()),
+        }
+    }
+}
+
+pub(crate) struct ServerRuntime {
+    local_addr: SocketAddr,
+    handle: Handle,
+    task: tokio::task::JoinHandle<Result<(), String>>,
+    tls_enabled: bool,
+}
+
+impl ServerRuntime {
+    pub(crate) async fn start(
+        bind: SocketAddr,
+        app: Router,
+        tls: Option<&TlsFiles>,
+    ) -> Result<Self, String> {
+        let listener = bind_listener(bind)?;
+        let local_addr = listener
+            .local_addr()
+            .map_err(|error| format!("failed to inspect listener address: {error}"))?;
+        let handle = Handle::new();
+        let handle_for_task = handle.clone();
+
+        let task = if let Some(tls) = tls {
+            let rustls = load_rustls_config(&tls.cert, &tls.key).await?;
+            tokio::spawn(async move {
+                axum_server::from_tcp_rustls(listener, rustls)
+                    .handle(handle_for_task)
+                    .serve(app.into_make_service())
+                    .await
+                    .map_err(|error| format!("HTTPS listener failed: {error}"))
+            })
+        } else {
+            tokio::spawn(async move {
+                axum_server::from_tcp(listener)
+                    .handle(handle_for_task)
+                    .serve(app.into_make_service())
+                    .await
+                    .map_err(|error| format!("HTTP listener failed: {error}"))
+            })
+        };
+
+        Ok(Self {
+            local_addr,
+            handle,
+            task,
+            tls_enabled: tls.is_some(),
+        })
+    }
+
+    pub(crate) fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    pub(crate) fn tls_enabled(&self) -> bool {
+        self.tls_enabled
+    }
+
+    pub(crate) async fn shutdown(self) -> Result<(), String> {
+        self.handle.graceful_shutdown(Some(Duration::from_secs(30)));
+        match self.task.await {
+            Ok(result) => result,
+            Err(error) => Err(format!("listener task join failed: {error}")),
+        }
+    }
+}
+
+async fn load_rustls_config(cert: &Path, key: &Path) -> Result<RustlsConfig, String> {
+    install_crypto_provider();
+    if !cert.is_file() {
+        return Err(format!("TLS certificate not found: {}", cert.display()));
+    }
+    if !key.is_file() {
+        return Err(format!("TLS private key not found: {}", key.display()));
+    }
+
+    RustlsConfig::from_pem_file(cert.to_path_buf(), key.to_path_buf())
+        .await
+        .map_err(|error| {
+            format!(
+                "failed to load TLS certificate {} and key {}: {error}",
+                cert.display(),
+                key.display()
+            )
+        })
+}
+
+fn install_crypto_provider() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    });
+}
+
+fn bind_listener(bind: SocketAddr) -> Result<TcpListener, String> {
+    let listener = TcpListener::bind(bind)
+        .map_err(|error| format!("failed to bind listener on {bind}: {error}"))?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|error| format!("failed to enable nonblocking listener mode: {error}"))?;
+    Ok(listener)
+}

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -65,6 +65,18 @@ pub struct Manifest {
     /// dispatcher work.
     #[serde(default)]
     pub triggers: Vec<TriggerManifestEntry>,
+    /// `[orchestrator]` table — listener-level controls shared by
+    /// manifest-driven ingress surfaces.
+    #[serde(default)]
+    pub orchestrator: OrchestratorConfig,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct OrchestratorConfig {
+    #[serde(default, alias = "allowed-origins")]
+    pub allowed_origins: Vec<String>,
+    #[serde(default, alias = "max-body-bytes")]
+    pub max_body_bytes: Option<usize>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1345,7 +1357,9 @@ fn trigger_kind_label(kind: TriggerKind) -> &'static str {
     }
 }
 
-fn manifest_trigger_binding_spec(trigger: CollectedManifestTrigger) -> harn_vm::TriggerBindingSpec {
+pub fn manifest_trigger_binding_spec(
+    trigger: CollectedManifestTrigger,
+) -> harn_vm::TriggerBindingSpec {
     let config = trigger.config;
     let (handler, handler_descriptor) = match trigger.handler {
         CollectedTriggerHandler::Local { reference, closure } => (
@@ -1439,8 +1453,15 @@ pub async fn install_manifest_triggers(
     extensions: &RuntimeExtensions,
 ) -> Result<(), String> {
     let collected = collect_manifest_triggers(vm, extensions).await?;
+    install_collected_manifest_triggers(&collected).await
+}
+
+pub async fn install_collected_manifest_triggers(
+    collected: &[CollectedManifestTrigger],
+) -> Result<(), String> {
     let bindings = collected
-        .into_iter()
+        .iter()
+        .cloned()
         .map(manifest_trigger_binding_spec)
         .collect();
     harn_vm::install_manifest_triggers(bindings)

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 
-const STARTUP_NEEDLE: &str = "HTTP listener not yet implemented (see O-02 #179)";
+const STARTUP_NEEDLE: &str = "HTTP listener ready on";
 const SHUTDOWN_NEEDLE: &str = "graceful shutdown complete";
 
 fn write_file(dir: &Path, relative: &str, contents: &str) {

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -1,0 +1,422 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use hmac::{Hmac, Mac};
+use rcgen::generate_simple_self_signed;
+use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE, ORIGIN};
+use reqwest::Certificate;
+use reqwest::StatusCode;
+use sha2_10::Sha256;
+use tempfile::TempDir;
+
+const STARTUP_PREFIX: &str = "[harn] HTTP listener ready on ";
+const SHUTDOWN_NEEDLE: &str = "graceful shutdown complete";
+
+type HmacSha256 = Hmac<Sha256>;
+
+fn write_file(dir: &Path, relative: &str, contents: &str) {
+    let path = dir.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+fn write_bytes(dir: &Path, relative: &str, bytes: &[u8]) {
+    let path = dir.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, bytes).unwrap();
+}
+
+fn base_manifest(orchestrator_block: Option<&str>) -> String {
+    let mut manifest = r#"
+[package]
+name = "fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "github-new-issue"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "handlers::on_issue"
+secrets = { signing_secret = "github/webhook-secret" }
+"#
+    .to_string();
+    if let Some(block) = orchestrator_block {
+        manifest.push('\n');
+        manifest.push_str(block);
+        manifest.push('\n');
+    }
+    manifest
+}
+
+fn handler_module() -> &'static str {
+    r#"
+import "std/triggers"
+
+pub fn on_issue(event: TriggerEvent) {
+  log(event.kind)
+}
+"#
+}
+
+fn spawn_orchestrator(
+    temp: &TempDir,
+    extra_args: &[&str],
+    envs: &[(&str, &str)],
+) -> OrchestratorProcess {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_harn"));
+    command
+        .current_dir(temp.path())
+        .arg("orchestrator")
+        .arg("serve")
+        .arg("--config")
+        .arg("harn.toml")
+        .arg("--state-dir")
+        .arg("./state")
+        .arg("--role")
+        .arg("single-tenant")
+        .arg("--bind")
+        .arg("127.0.0.1:0")
+        .stderr(Stdio::piped())
+        .stdout(Stdio::null());
+    for arg in extra_args {
+        command.arg(arg);
+    }
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+
+    let mut child = command.spawn().unwrap();
+    let stderr = child.stderr.take().expect("stderr pipe");
+    let (tx, rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let mut collected = String::new();
+        for line in BufReader::new(stderr).lines() {
+            let line = line.expect("stderr line");
+            collected.push_str(&line);
+            collected.push('\n');
+            let _ = tx.send(line);
+        }
+        collected
+    });
+
+    OrchestratorProcess {
+        child,
+        rx,
+        handle: Some(handle),
+    }
+}
+
+struct OrchestratorProcess {
+    child: Child,
+    rx: Receiver<String>,
+    handle: Option<thread::JoinHandle<String>>,
+}
+
+impl OrchestratorProcess {
+    fn wait_for_listener_url(&mut self) -> String {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while Instant::now() < deadline {
+            match self.rx.recv_timeout(Duration::from_millis(100)) {
+                Ok(line) if line.contains(STARTUP_PREFIX) => {
+                    return line
+                        .split(STARTUP_PREFIX)
+                        .nth(1)
+                        .expect("startup line has URL")
+                        .trim()
+                        .to_string();
+                }
+                Ok(_) => continue,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    if let Some(status) = self.child.try_wait().unwrap() {
+                        let stderr = self.join_stderr();
+                        panic!(
+                            "process exited before listener became ready: {status}\nstderr={stderr}"
+                        );
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    let stderr = self.join_stderr();
+                    panic!("stderr stream closed before listener became ready\nstderr={stderr}");
+                }
+            }
+        }
+        let stderr = self.join_stderr();
+        panic!("timed out waiting for listener startup\nstderr={stderr}");
+    }
+
+    fn join_stderr(&mut self) -> String {
+        self.handle
+            .take()
+            .expect("stderr collector thread")
+            .join()
+            .expect("stderr collector result")
+    }
+}
+
+fn send_sigterm(child: &Child) {
+    let status = Command::new("kill")
+        .arg("-TERM")
+        .arg(child.id().to_string())
+        .status()
+        .unwrap();
+    assert!(status.success(), "kill exited with {status}");
+}
+
+fn wait_for_exit(child: &mut Child) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if let Some(status) = child.try_wait().unwrap() {
+            assert!(status.success(), "child exited unsuccessfully: {status}");
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!("timed out waiting for orchestrator exit");
+}
+
+fn github_signature(secret: &str, body: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+    mac.update(body);
+    let bytes = mac.finalize().into_bytes();
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push_str(&format!("{byte:02x}"));
+    }
+    format!("sha256={encoded}")
+}
+
+fn github_headers(secret: &str, body: &[u8], origin: Option<&str>) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert("X-GitHub-Event", HeaderValue::from_static("issues"));
+    headers.insert(
+        "X-GitHub-Delivery",
+        HeaderValue::from_static("delivery-123"),
+    );
+    headers.insert(
+        "X-Hub-Signature-256",
+        HeaderValue::from_str(&github_signature(secret, body)).unwrap(),
+    );
+    if let Some(origin) = origin {
+        headers.insert(ORIGIN, HeaderValue::from_str(origin).unwrap());
+    }
+    headers
+}
+
+fn state_snapshot(temp: &TempDir) -> String {
+    fs::read_to_string(temp.path().join("state/orchestrator-state.json")).unwrap()
+}
+
+async fn assert_status(response: reqwest::Response, expected: StatusCode) {
+    let status = response.status();
+    let body = response.text().await.unwrap();
+    assert_eq!(status, expected, "status={status} body={body}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn github_webhook_delivery_is_accepted_and_persisted() {
+    let temp = TempDir::new().unwrap();
+    write_file(temp.path(), "harn.toml", &base_manifest(None));
+    write_file(temp.path(), "lib.harn", handler_module());
+
+    let secret = "integration-test-secret";
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_SECRET_GITHUB_WEBHOOK_SECRET", secret),
+    ];
+    let mut process = spawn_orchestrator(&temp, &[], &envs);
+    let base_url = process.wait_for_listener_url();
+
+    let body = br#"{"action":"opened","issue":{"number":1}}"#;
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/triggers/github-new-issue"))
+        .headers(github_headers(secret, body, None))
+        .body(body.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_status(response, StatusCode::OK).await;
+
+    send_sigterm(&process.child);
+    wait_for_exit(&mut process.child);
+    let stderr = process.join_stderr();
+    assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
+
+    let snapshot = state_snapshot(&temp);
+    assert!(
+        snapshot.contains("\"status\": \"stopped\""),
+        "snapshot={snapshot}"
+    );
+    assert!(snapshot.contains("\"received\": 1"), "snapshot={snapshot}");
+    assert!(
+        snapshot.contains("\"dispatched\": 1"),
+        "snapshot={snapshot}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tls_listener_serves_https_with_supplied_cert_and_key() {
+    let temp = TempDir::new().unwrap();
+    write_file(temp.path(), "harn.toml", &base_manifest(None));
+    write_file(temp.path(), "lib.harn", handler_module());
+
+    let cert = generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+        .unwrap();
+    let cert_pem = cert.cert.pem();
+    let key_pem = cert.key_pair.serialize_pem();
+    write_bytes(temp.path(), "tls/cert.pem", cert_pem.as_bytes());
+    write_bytes(temp.path(), "tls/key.pem", key_pem.as_bytes());
+
+    let secret = "tls-secret";
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_SECRET_GITHUB_WEBHOOK_SECRET", secret),
+    ];
+    let args = ["--cert", "tls/cert.pem", "--key", "tls/key.pem"];
+    let mut process = spawn_orchestrator(&temp, &args, &envs);
+    let base_url = process.wait_for_listener_url();
+    assert!(base_url.starts_with("https://"), "{base_url}");
+
+    let body = br#"{"action":"opened","issue":{"number":2}}"#;
+    let response = reqwest::Client::builder()
+        .add_root_certificate(Certificate::from_pem(cert_pem.as_bytes()).unwrap())
+        .build()
+        .unwrap()
+        .post(format!("{base_url}/triggers/github-new-issue"))
+        .headers(github_headers(secret, body, None))
+        .body(body.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_status(response, StatusCode::OK).await;
+
+    send_sigterm(&process.child);
+    wait_for_exit(&mut process.child);
+    let stderr = process.join_stderr();
+    assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn disallowed_origin_is_rejected() {
+    let temp = TempDir::new().unwrap();
+    write_file(
+        temp.path(),
+        "harn.toml",
+        &base_manifest(Some(
+            r#"[orchestrator]
+allowed_origins = ["https://allowed.example"]"#,
+        )),
+    );
+    write_file(temp.path(), "lib.harn", handler_module());
+
+    let secret = "origin-secret";
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_SECRET_GITHUB_WEBHOOK_SECRET", secret),
+    ];
+    let mut process = spawn_orchestrator(&temp, &[], &envs);
+    let base_url = process.wait_for_listener_url();
+
+    let body = br#"{"action":"opened","issue":{"number":3}}"#;
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/triggers/github-new-issue"))
+        .headers(github_headers(
+            secret,
+            body,
+            Some("https://blocked.example"),
+        ))
+        .body(body.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_status(response, StatusCode::FORBIDDEN).await;
+
+    send_sigterm(&process.child);
+    wait_for_exit(&mut process.child);
+    let stderr = process.join_stderr();
+    assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn oversized_request_body_is_rejected() {
+    let temp = TempDir::new().unwrap();
+    write_file(temp.path(), "harn.toml", &base_manifest(None));
+    write_file(temp.path(), "lib.harn", handler_module());
+
+    let secret = "body-limit-secret";
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_SECRET_GITHUB_WEBHOOK_SECRET", secret),
+    ];
+    let mut process = spawn_orchestrator(&temp, &[], &envs);
+    let base_url = process.wait_for_listener_url();
+
+    let body = vec![b'a'; (10 * 1024 * 1024) + 1];
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/triggers/github-new-issue"))
+        .headers(github_headers(secret, &body, None))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_status(response, StatusCode::PAYLOAD_TOO_LARGE).await;
+
+    send_sigterm(&process.child);
+    wait_for_exit(&mut process.child);
+    let stderr = process.join_stderr();
+    assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn graceful_shutdown_waits_for_in_flight_request() {
+    let temp = TempDir::new().unwrap();
+    write_file(temp.path(), "harn.toml", &base_manifest(None));
+    write_file(temp.path(), "lib.harn", handler_module());
+
+    let secret = "shutdown-secret";
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_SECRET_GITHUB_WEBHOOK_SECRET", secret),
+        ("HARN_ORCHESTRATOR_TEST_REQUEST_DELAY_MS", "500"),
+    ];
+    let mut process = spawn_orchestrator(&temp, &[], &envs);
+    let base_url = process.wait_for_listener_url();
+
+    let body = br#"{"action":"opened","issue":{"number":4}}"#.to_vec();
+    let request = tokio::spawn({
+        let client = reqwest::Client::new();
+        let url = format!("{base_url}/triggers/github-new-issue");
+        let headers = github_headers(secret, &body, None);
+        async move { client.post(url).headers(headers).body(body).send().await }
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    send_sigterm(&process.child);
+    let response = request.await.unwrap().unwrap();
+    assert_status(response, StatusCode::OK).await;
+
+    wait_for_exit(&mut process.child);
+    let stderr = process.join_stderr();
+    assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
+
+    let snapshot = state_snapshot(&temp);
+    assert!(
+        snapshot.contains("\"dispatched\": 1"),
+        "snapshot={snapshot}"
+    );
+    assert!(snapshot.contains("\"in_flight\": 0"), "snapshot={snapshot}");
+}

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -3,20 +3,19 @@
 `harn orchestrator serve` is the long-running process entry point for
 manifest-driven trigger ingestion and connector activation.
 
-Today, the command establishes the startup and shutdown scaffold:
+Today, the command:
 
 - load `harn.toml` through the existing manifest loader
 - boot the selected orchestrator role
 - initialize the shared EventLog under `--state-dir`
 - initialize the configured secret-provider chain
 - resolve and register manifest triggers
-- register and activate placeholder connectors for each manifest provider
-- write a state snapshot and idle until shutdown
+- activate connectors for the manifest's providers
+- bind an HTTP listener for `webhook` and `a2a-push` triggers
+- write a state snapshot and stay up until shutdown
 
 Current limitations:
 
-- the HTTP listener is still a stub and logs
-  `HTTP listener not yet implemented (see O-02 #179)`
 - `multi-tenant` returns a clear not-implemented error that points at
   `O-12 #190`
 - `inspect`, `replay`, `dlq`, and `queue` are placeholders for
@@ -29,11 +28,72 @@ harn orchestrator serve \
   --config harn.toml \
   --state-dir ./.harn/orchestrator \
   --bind 0.0.0.0:8080 \
+  --cert certs/dev.pem \
+  --key certs/dev-key.pem \
   --role single-tenant
 ```
 
+Omit `--cert` and `--key` to serve plain HTTP. When both are present,
+the listener serves HTTPS and terminates TLS with `rustls`.
+
 On startup, the command logs the active secret-provider chain, loaded
-triggers, registered connectors, and the requested bind address. On
-SIGTERM, it performs scaffolded graceful shutdown, appends lifecycle
-events to the EventLog, and persists a final
+triggers, registered connectors, and the actual bound listener URL. On
+SIGTERM, it stops accepting new requests, lets in-flight requests drain,
+appends lifecycle events to the EventLog, and persists a final
 `orchestrator-state.json` snapshot under `--state-dir`.
+
+## HTTP Listener
+
+The orchestrator listener assembles routes from `[[triggers]]` entries
+with `kind = "webhook"` or `kind = "a2a-push"`.
+
+- If a trigger declares `path = "/github/issues"`, that path is used.
+- Otherwise the route defaults to `/triggers/<id>`.
+- `/healthz` and `/readyz` are reserved listener endpoints; use
+  `GET /healthz` and `GET /readyz` for process health checks.
+
+Accepted deliveries are normalized into `TriggerEvent` records and
+appended to the shared `orchestrator.triggers.pending` queue in the
+event log for downstream dispatch.
+
+### Listener controls
+
+Listener-wide controls live under `[orchestrator]` in `harn.toml`.
+
+```toml
+[orchestrator]
+allowed_origins = ["https://app.example.com"]
+max_body_bytes = 10485760
+```
+
+- `allowed_origins` defaults to `["*"]` semantics when omitted or empty.
+  Requests with an `Origin` header outside the allowlist are rejected
+  with `403 Forbidden`.
+- `max_body_bytes` defaults to `10485760` bytes (10 MiB). Larger
+  requests are rejected with `413 Payload Too Large`.
+
+### Trigger examples
+
+```toml
+[[triggers]]
+id = "github-new-issue"
+kind = "webhook"
+provider = "github"
+path = "/triggers/github-new-issue"
+match = { events = ["issues.opened"] }
+handler = "handlers::on_new_issue"
+secrets = { signing_secret = "github/webhook-secret" }
+
+[[triggers]]
+id = "incoming-review-task"
+kind = "a2a-push"
+provider = "a2a-push"
+path = "/a2a/review"
+match = { events = ["a2a.task.received"] }
+handler = "a2a://reviewer.prod/triage"
+```
+
+GitHub webhook triggers verify the `X-Hub-Signature-256` HMAC against
+`secrets.signing_secret` before enqueueing. Generic `provider = "webhook"`
+triggers use the shared Standard Webhooks verifier. `a2a-push` routes
+currently accept unsigned deliveries.


### PR DESCRIPTION
## Summary

This PR wires a real Axum-based HTTP listener into `harn orchestrator serve`.

It replaces the O-01 scaffold's listener stub with a bound HTTP/HTTPS server that:
- listens on `--bind`
- optionally terminates TLS with `--cert` + `--key`
- enforces origin allowlists from `[orchestrator].allowed_origins`
- enforces body-size limits from `[orchestrator].max_body_bytes`
- registers `webhook` and `a2a-push` trigger routes from the manifest
- normalizes accepted deliveries into `TriggerEvent` envelopes and appends them to `orchestrator.triggers.pending`
- drains in-flight requests during graceful shutdown

This also adds subprocess end-to-end coverage for plain HTTP, TLS, origin rejection, body-limit rejection, and graceful shutdown, and updates the orchestrator docs/changelog to describe the real listener behavior.

## Context

Builds on the orchestrator serve scaffold from #209 and the connector / trigger runtime primitives from #203.

`origin/main` does not yet expose the richer route-registration contract described in #211, so this PR consumes the manifest trigger metadata available on mainline and wires the listener directly from those registrations.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p harn-cli orchestrator -- --nocapture`
- `cargo test -p harn-cli --test orchestrator_http -- --nocapture`
- `make test`
