### PR TITLE
[codex] Add distroless orchestrator container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.claude
+.codex
+.burin
+.harn
+.harn-runs
+target
+docs/dist
+node_modules
+crates/harn-cli/portal/node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build:
@@ -65,9 +66,51 @@ jobs:
           name: harn-${{ matrix.target }}
           path: dist/harn-${{ matrix.target }}.tar.gz
 
+  container:
+    name: Publish Container
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ghcr.io/burin-labs/harn
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push container image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   release:
     name: Create Release
-    needs: build
+    needs: [build, container]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ granular archaeology.
 
 ### Added
 
+- **Distroless multi-arch orchestrator container (#186).** Added a root
+  `Dockerfile` for `harn orchestrator serve` with a Rust 1.95 builder,
+  distroless `cc` runtime, non-root UID `10001`, and a Docker healthcheck
+  that probes `GET /health`. `harn orchestrator serve` now accepts
+  container-friendly `--manifest` / `--listen` aliases plus
+  `HARN_ORCHESTRATOR_*` env defaults, `.dockerignore` prunes bulky build
+  outputs from the image context, and the release-tag workflow now builds
+  and pushes `linux/amd64` + `linux/arm64` images to
+  `ghcr.io/burin-labs/harn`.
+
 - **Trigger event replay now routes through the dispatcher (#166).**
   `trigger_replay(...)` no longer uses the local shallow stub. The
   stdlib now looks up historical events from `triggers.events`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,11 @@ granular archaeology.
   that probes `GET /health`. `harn orchestrator serve` now accepts
   container-friendly `--manifest` / `--listen` aliases plus
   `HARN_ORCHESTRATOR_*` env defaults, `.dockerignore` prunes bulky build
-  outputs from the image context, and the release-tag workflow now builds
-  and pushes `linux/amd64` + `linux/arm64` images to
-  `ghcr.io/burin-labs/harn`.
+  outputs from the image context, `a2a-push` listener routes can enforce
+  bearer API keys or canonical-request HMAC auth via
+  `HARN_ORCHESTRATOR_API_KEYS` and `HARN_ORCHESTRATOR_HMAC_SECRET`, and
+  the release-tag workflow now builds and pushes `linux/amd64` +
+  `linux/arm64` images to `ghcr.io/burin-labs/harn`.
 
 - **Trigger event replay now routes through the dispatcher (#166).**
   `trigger_replay(...)` no longer uses the local shallow stub. The

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,33 @@
 # syntax=docker/dockerfile:1.7
 
-FROM --platform=$BUILDPLATFORM rust:1.95 AS builder
+FROM --platform=$BUILDPLATFORM rust:1.95-bookworm AS builder
 
+ARG BUILDARCH
 ARG TARGETARCH
 
 WORKDIR /work
 
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true \
-    CARGO_TARGET_DIR=/tmp/harn-target
+    CARGO_TARGET_DIR=/tmp/harn-target \
+    RUSTC_WRAPPER= \
+    CARGO_BUILD_RUSTC_WRAPPER= \
+    SCCACHE_DISABLE=1
 
 RUN case "${TARGETARCH}" in \
         amd64) \
-            echo "x86_64-unknown-linux-gnu" > /tmp/rust-target \
+            if [ "${BUILDARCH}" != "amd64" ]; then \
+                apt-get update \
+                && apt-get install -y --no-install-recommends gcc-x86-64-linux-gnu libc6-dev-amd64-cross \
+                && rm -rf /var/lib/apt/lists/*; \
+            fi \
+            && echo "x86_64-unknown-linux-gnu" > /tmp/rust-target \
             ;; \
         arm64) \
-            apt-get update \
-            && apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
-            && rm -rf /var/lib/apt/lists/* \
+            if [ "${BUILDARCH}" != "arm64" ]; then \
+                apt-get update \
+                && apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
+                && rm -rf /var/lib/apt/lists/*; \
+            fi \
             && echo "aarch64-unknown-linux-gnu" > /tmp/rust-target \
             ;; \
         *) \
@@ -29,9 +40,9 @@ RUN case "${TARGETARCH}" in \
 COPY . .
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/tmp/harn-target \
     RUST_TARGET="$(cat /tmp/rust-target)" \
-    && if [ "${TARGETARCH}" = "arm64" ]; then export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc; fi \
+    && if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc; fi \
+    && if [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc; fi \
     && cargo build --locked --release -p harn-cli --bin harn --bin harn-container-probe --target "${RUST_TARGET}" \
     && install -d /out/usr/local/bin /out/etc/harn /out/var/lib/harn/state \
     && install -m 0755 "/tmp/harn-target/${RUST_TARGET}/release/harn" /out/usr/local/bin/harn \
@@ -43,10 +54,12 @@ FROM gcr.io/distroless/cc-debian12
 WORKDIR /var/lib/harn
 
 # Inject listener auth and provider secrets at runtime via
-# HARN_ORCHESTRATOR_API_KEYS, HARN_PROVIDER_*, HARN_SECRET_*,
+# HARN_ORCHESTRATOR_API_KEYS, HARN_ORCHESTRATOR_HMAC_SECRET,
+# HARN_PROVIDER_*, HARN_SECRET_*,
 # OPENAI_API_KEY, ANTHROPIC_API_KEY, or similar provider-specific env vars.
 ENV HARN_SECRET_PROVIDERS=env \
     HARN_ORCHESTRATOR_API_KEYS= \
+    HARN_ORCHESTRATOR_HMAC_SECRET= \
     HARN_ORCHESTRATOR_MANIFEST=/etc/harn/triggers.toml \
     HARN_ORCHESTRATOR_LISTEN=0.0.0.0:8080 \
     HARN_ORCHESTRATOR_STATE_DIR=/var/lib/harn/state \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1.7
+
+FROM --platform=$BUILDPLATFORM rust:1.95 AS builder
+
+ARG TARGETARCH
+
+WORKDIR /work
+
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true \
+    CARGO_TARGET_DIR=/tmp/harn-target
+
+RUN case "${TARGETARCH}" in \
+        amd64) \
+            echo "x86_64-unknown-linux-gnu" > /tmp/rust-target \
+            ;; \
+        arm64) \
+            apt-get update \
+            && apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
+            && rm -rf /var/lib/apt/lists/* \
+            && echo "aarch64-unknown-linux-gnu" > /tmp/rust-target \
+            ;; \
+        *) \
+            echo "unsupported TARGETARCH: ${TARGETARCH}" >&2 \
+            && exit 1 \
+            ;; \
+    esac \
+    && rustup target add "$(cat /tmp/rust-target)"
+
+COPY . .
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/tmp/harn-target \
+    RUST_TARGET="$(cat /tmp/rust-target)" \
+    && if [ "${TARGETARCH}" = "arm64" ]; then export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc; fi \
+    && cargo build --locked --release -p harn-cli --bin harn --bin harn-container-probe --target "${RUST_TARGET}" \
+    && install -d /out/usr/local/bin /out/etc/harn /out/var/lib/harn/state \
+    && install -m 0755 "/tmp/harn-target/${RUST_TARGET}/release/harn" /out/usr/local/bin/harn \
+    && install -m 0755 "/tmp/harn-target/${RUST_TARGET}/release/harn-container-probe" /out/usr/local/bin/harn-container-probe \
+    && printf "# Mount a Harn orchestrator manifest here.\n" > /out/etc/harn/triggers.toml
+
+FROM gcr.io/distroless/cc-debian12
+
+WORKDIR /var/lib/harn
+
+# Inject listener auth and provider secrets at runtime via
+# HARN_ORCHESTRATOR_API_KEYS, HARN_PROVIDER_*, HARN_SECRET_*,
+# OPENAI_API_KEY, ANTHROPIC_API_KEY, or similar provider-specific env vars.
+ENV HARN_SECRET_PROVIDERS=env \
+    HARN_ORCHESTRATOR_API_KEYS= \
+    HARN_ORCHESTRATOR_MANIFEST=/etc/harn/triggers.toml \
+    HARN_ORCHESTRATOR_LISTEN=0.0.0.0:8080 \
+    HARN_ORCHESTRATOR_STATE_DIR=/var/lib/harn/state \
+    RUST_LOG=info
+
+COPY --from=builder --chown=10001:10001 /out/ /
+
+EXPOSE 8080
+
+USER 10001:10001
+
+ENTRYPOINT ["/usr/local/bin/harn", "orchestrator", "serve"]
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 CMD ["/usr/local/bin/harn-container-probe"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ cd harn
 cargo install --path crates/harn-cli
 ```
 
+Container image:
+
+```bash
+docker run -p 8080:8080 -v $PWD/triggers.toml:/etc/harn/triggers.toml -e HARN_ORCHESTRATOR_API_KEYS=xxx ghcr.io/burin-labs/harn
+```
+
+Release tags publish multi-arch `linux/amd64` and `linux/arm64` images to
+GHCR. The container defaults to `harn orchestrator serve` with
+`HARN_ORCHESTRATOR_MANIFEST=/etc/harn/triggers.toml` and
+`HARN_ORCHESTRATOR_LISTEN=0.0.0.0:8080`; inject provider secrets with the
+usual environment variables such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+or your deployment's `HARN_PROVIDER_*` / `HARN_SECRET_*` values.
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ docker run -p 8080:8080 -v $PWD/triggers.toml:/etc/harn/triggers.toml -e HARN_OR
 Release tags publish multi-arch `linux/amd64` and `linux/arm64` images to
 GHCR. The container defaults to `harn orchestrator serve` with
 `HARN_ORCHESTRATOR_MANIFEST=/etc/harn/triggers.toml` and
-`HARN_ORCHESTRATOR_LISTEN=0.0.0.0:8080`; inject provider secrets with the
-usual environment variables such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
-or your deployment's `HARN_PROVIDER_*` / `HARN_SECRET_*` values.
+`HARN_ORCHESTRATOR_LISTEN=0.0.0.0:8080`; set
+`HARN_ORCHESTRATOR_API_KEYS` and `HARN_ORCHESTRATOR_HMAC_SECRET` when
+you expose authenticated `a2a-push` routes, and inject provider secrets
+with the usual environment variables such as `OPENAI_API_KEY`,
+`ANTHROPIC_API_KEY`, or your deployment's `HARN_PROVIDER_*` /
+`HARN_SECRET_*` values.
 
 ## Quick Start
 

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -6,6 +6,12 @@ license.workspace = true
 repository.workspace = true
 description = "CLI for the Harn programming language — run, test, REPL, format, and lint"
 build = "build.rs"
+# Two bins ship in this crate: `harn` (the main CLI) and
+# `harn-container-probe` (a tiny tool used by the Dockerfile healthcheck,
+# introduced in #186). `default-run` makes plain `cargo run -p harn-cli`
+# invoke the main CLI so hooks and release scripts don't need to spell
+# out `--bin harn` everywhere.
+default-run = "harn"
 # portal-dist/ is a gitignored build artifact produced by `npm run build` in
 # crates/harn-cli/portal. It is embedded at compile time via include_dir! in
 # src/commands/portal/assets.rs, so it must ship with the published crate.

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -48,7 +48,7 @@ url = "2"
 webbrowser = "1"
 rand = "0.10"
 regex = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 tower = { version = "0.5", features = ["util"] }
 time = { version = "0.3", features = ["formatting", "parsing"] }
 tempfile = "3"

--- a/crates/harn-cli/src/bin/harn-container-probe.rs
+++ b/crates/harn-cli/src/bin/harn-container-probe.rs
@@ -1,0 +1,106 @@
+use std::env;
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::process::ExitCode;
+use std::time::Duration;
+
+const DEFAULT_HEALTHCHECK_URL: &str = "http://127.0.0.1:8080/health";
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), String> {
+    let url = env::var("HARN_CONTAINER_HEALTHCHECK_URL").unwrap_or_else(|_| {
+        derive_healthcheck_url().unwrap_or_else(|| DEFAULT_HEALTHCHECK_URL.to_string())
+    });
+    let Some((authority, request_path)) = parse_http_url(&url) else {
+        return Err(format!(
+            "unsupported healthcheck URL '{url}'; expected http://host:port/path"
+        ));
+    };
+    let addr = authority
+        .to_socket_addrs()
+        .map_err(|error| format!("failed to resolve {authority}: {error}"))?
+        .next()
+        .ok_or_else(|| format!("no socket addresses resolved for {authority}"))?;
+
+    let mut stream = TcpStream::connect_timeout(&addr, Duration::from_secs(2))
+        .map_err(|error| format!("failed to connect to {addr}: {error}"))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .map_err(|error| format!("failed to set read timeout: {error}"))?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(2)))
+        .map_err(|error| format!("failed to set write timeout: {error}"))?;
+
+    let request =
+        format!("GET {request_path} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| format!("failed to write request: {error}"))?;
+
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .map_err(|error| format!("failed to read response: {error}"))?;
+
+    if response.starts_with("HTTP/1.1 200") || response.starts_with("HTTP/1.0 200") {
+        Ok(())
+    } else {
+        let status_line = response.lines().next().unwrap_or("<empty response>");
+        Err(format!("healthcheck failed: {status_line}"))
+    }
+}
+
+fn derive_healthcheck_url() -> Option<String> {
+    let bind = env::var("HARN_ORCHESTRATOR_LISTEN").ok()?;
+    let bind = bind.trim();
+    if bind.is_empty() {
+        return None;
+    }
+    let port = bind
+        .rsplit(':')
+        .next()
+        .filter(|segment| !segment.is_empty())?;
+    Some(format!("http://127.0.0.1:{port}/health"))
+}
+
+fn parse_http_url(url: &str) -> Option<(&str, &str)> {
+    let remainder = url.strip_prefix("http://")?;
+    let (authority, path) = match remainder.find('/') {
+        Some(index) => (&remainder[..index], &remainder[index..]),
+        None => (remainder, "/"),
+    };
+    if authority.is_empty() {
+        return None;
+    }
+    Some((authority, path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_http_url;
+
+    #[test]
+    fn parses_http_url_with_default_path() {
+        assert_eq!(
+            parse_http_url("http://127.0.0.1:8080"),
+            Some(("127.0.0.1:8080", "/"))
+        );
+    }
+
+    #[test]
+    fn parses_http_url_with_explicit_path() {
+        assert_eq!(
+            parse_http_url("http://localhost:9000/health"),
+            Some(("localhost:9000", "/health"))
+        );
+    }
+}

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -475,27 +475,46 @@ pub(crate) enum OrchestratorCommand {
 
 #[derive(Debug, Args)]
 pub(crate) struct OrchestratorServeArgs {
-    /// Path to the root `harn.toml` manifest to load.
-    #[arg(long, default_value = "harn.toml", value_name = "PATH")]
+    /// Path to the root manifest to load. Container deployments often mount
+    /// this as `/etc/harn/triggers.toml`.
+    #[arg(
+        long,
+        visible_alias = "manifest",
+        env = "HARN_ORCHESTRATOR_MANIFEST",
+        default_value = "harn.toml",
+        value_name = "PATH"
+    )]
     pub config: PathBuf,
     /// Directory used for EventLog data and orchestrator state snapshots.
     #[arg(
         long = "state-dir",
+        env = "HARN_ORCHESTRATOR_STATE_DIR",
         default_value = ".harn/orchestrator",
         value_name = "PATH"
     )]
     pub state_dir: PathBuf,
-    /// Socket address the future HTTP listener will bind to.
-    #[arg(long, default_value = "127.0.0.1:8080", value_name = "ADDR")]
+    /// Socket address the HTTP listener will bind to.
+    #[arg(
+        long,
+        visible_alias = "listen",
+        env = "HARN_ORCHESTRATOR_LISTEN",
+        default_value = "127.0.0.1:8080",
+        value_name = "ADDR"
+    )]
     pub bind: SocketAddr,
     /// PEM-encoded certificate chain for HTTPS termination.
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, env = "HARN_ORCHESTRATOR_CERT", value_name = "PATH")]
     pub cert: Option<PathBuf>,
     /// PEM-encoded private key for HTTPS termination.
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, env = "HARN_ORCHESTRATOR_KEY", value_name = "PATH")]
     pub key: Option<PathBuf>,
     /// Runtime role to boot. Multi-tenant is a stub for now.
-    #[arg(long, value_enum, default_value_t = crate::commands::orchestrator::role::OrchestratorRole::SingleTenant)]
+    #[arg(
+        long,
+        env = "HARN_ORCHESTRATOR_ROLE",
+        value_enum,
+        default_value_t = crate::commands::orchestrator::role::OrchestratorRole::SingleTenant
+    )]
     pub role: crate::commands::orchestrator::role::OrchestratorRole,
 }
 
@@ -864,6 +883,31 @@ mod tests {
             serve.role,
             crate::commands::orchestrator::role::OrchestratorRole::SingleTenant
         );
+    }
+
+    #[test]
+    fn test_parses_orchestrator_serve_container_aliases() {
+        let cli = Cli::parse_from([
+            "harn",
+            "orchestrator",
+            "serve",
+            "--manifest",
+            "/etc/harn/triggers.toml",
+            "--state-dir",
+            "/var/lib/harn/state",
+            "--listen",
+            "0.0.0.0:8080",
+        ]);
+
+        let Command::Orchestrator(args) = cli.command.unwrap() else {
+            panic!("expected orchestrator command");
+        };
+        let OrchestratorCommand::Serve(serve) = args.command else {
+            panic!("expected orchestrator serve");
+        };
+        assert_eq!(serve.config, PathBuf::from("/etc/harn/triggers.toml"));
+        assert_eq!(serve.state_dir, PathBuf::from("/var/lib/harn/state"));
+        assert_eq!(serve.bind.to_string(), "0.0.0.0:8080");
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -69,6 +69,10 @@ impl ListenerRuntime {
         let mut route_metrics = BTreeMap::new();
         let mut app = Router::new()
             .route(
+                "/health",
+                get(|| async move { (StatusCode::OK, "ok").into_response() }),
+            )
+            .route(
                 "/healthz",
                 get(|| async move { (StatusCode::OK, "ok").into_response() }),
             )

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -283,6 +283,9 @@ async fn github_webhook_delivery_is_accepted_and_persisted() {
     let mut process = spawn_orchestrator(&temp, &[], &envs);
     let base_url = process.wait_for_listener_url();
 
+    let health = reqwest::get(format!("{base_url}/health")).await.unwrap();
+    assert_status(health, StatusCode::OK).await;
+
     let body = br#"{"action":"opened","issue":{"number":1}}"#;
     let response = reqwest::Client::new()
         .post(format!("{base_url}/triggers/github-new-issue"))

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -1,10 +1,17 @@
 #![cfg(unix)]
+// Orchestrator HTTP tests serialize against a std::sync::Mutex to prevent
+// parallel binds of the same port. Each test holds the guard across .await
+// boundaries (spawn orchestrator, make requests, drain); that's the correct
+// pattern for this serialization. The clippy lint against await-holding-lock
+// is overly strict for this use case, so allow it at the module level.
+#![allow(clippy::await_holding_lock)]
 
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc::{self, Receiver};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -21,6 +28,15 @@ const STARTUP_PREFIX: &str = "[harn] HTTP listener ready on ";
 const SHUTDOWN_NEEDLE: &str = "graceful shutdown complete";
 
 type HmacSha256 = Hmac<Sha256>;
+
+static ORCHESTRATOR_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn lock_orchestrator_tests() -> MutexGuard<'static, ()> {
+    ORCHESTRATOR_TEST_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap()
+}
 
 fn write_file(dir: &Path, relative: &str, contents: &str) {
     let path = dir.join(relative);
@@ -271,6 +287,7 @@ fn json_headers() -> HeaderMap {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn github_webhook_delivery_is_accepted_and_persisted() {
+    let _lock = lock_orchestrator_tests();
     let temp = TempDir::new().unwrap();
     write_file(temp.path(), "harn.toml", &base_manifest(None));
     write_file(temp.path(), "lib.harn", handler_module());
@@ -315,6 +332,7 @@ async fn github_webhook_delivery_is_accepted_and_persisted() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn a2a_push_route_requires_bearer_or_valid_hmac() {
+    let _lock = lock_orchestrator_tests();
     let temp = TempDir::new().unwrap();
     write_file(temp.path(), "harn.toml", &a2a_manifest(None));
     write_file(temp.path(), "lib.harn", a2a_handler_module());
@@ -384,6 +402,7 @@ async fn a2a_push_route_requires_bearer_or_valid_hmac() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn tls_listener_serves_https_with_supplied_cert_and_key() {
+    let _lock = lock_orchestrator_tests();
     let temp = TempDir::new().unwrap();
     write_file(temp.path(), "harn.toml", &base_manifest(None));
     write_file(temp.path(), "lib.harn", handler_module());
@@ -426,6 +445,7 @@ async fn tls_listener_serves_https_with_supplied_cert_and_key() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn disallowed_origin_is_rejected() {
+    let _lock = lock_orchestrator_tests();
     let temp = TempDir::new().unwrap();
     write_file(
         temp.path(),
@@ -467,6 +487,7 @@ allowed_origins = ["https://allowed.example"]"#,
 
 #[tokio::test(flavor = "multi_thread")]
 async fn oversized_request_body_is_rejected() {
+    let _lock = lock_orchestrator_tests();
     let temp = TempDir::new().unwrap();
     write_file(temp.path(), "harn.toml", &base_manifest(None));
     write_file(temp.path(), "lib.harn", handler_module());
@@ -497,6 +518,7 @@ async fn oversized_request_body_is_rejected() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graceful_shutdown_waits_for_in_flight_request() {
+    let _lock = lock_orchestrator_tests();
     let temp = TempDir::new().unwrap();
     write_file(temp.path(), "harn.toml", &base_manifest(None));
     write_file(temp.path(), "lib.harn", handler_module());

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -62,37 +62,6 @@ Accepted deliveries are normalized into `TriggerEvent` records and
 appended to the shared `orchestrator.triggers.pending` queue in the
 event log for downstream dispatch.
 
-## Deployment
-
-Release tags publish a distroless container image to
-`ghcr.io/burin-labs/harn` for both `linux/amd64` and `linux/arm64`.
-
-```bash
-docker run \
-  -p 8080:8080 \
-  -v "$PWD/triggers.toml:/etc/harn/triggers.toml:ro" \
-  -e HARN_ORCHESTRATOR_API_KEYS=xxx \
-  -e RUST_LOG=info \
-  ghcr.io/burin-labs/harn
-```
-
-The image runs as UID `10001` and stores orchestrator state under
-`/var/lib/harn/state` by default. Override the startup contract with
-environment variables instead of replacing the entrypoint:
-
-- `HARN_ORCHESTRATOR_MANIFEST` defaults to `/etc/harn/triggers.toml`
-- `HARN_ORCHESTRATOR_LISTEN` defaults to `0.0.0.0:8080`
-- `HARN_ORCHESTRATOR_STATE_DIR` defaults to `/var/lib/harn/state`
-- `HARN_ORCHESTRATOR_API_KEYS` can inject listener auth keys when your
-  deployment enables them
-- `HARN_SECRET_*`, provider API-key env vars, and deployment-specific
-  `HARN_PROVIDER_*` values are passed through to connector/provider code
-- `RUST_LOG` controls runtime log verbosity
-
-The image healthcheck issues `GET /health` against the local listener, so
-it works with Docker, BuildKit smoke tests, and most container platforms
-without requiring curl inside the distroless runtime.
-
 ### Listener controls
 
 Listener-wide controls live under `[orchestrator]` in `harn.toml`.
@@ -113,14 +82,15 @@ max_body_bytes = 10485760
 
 Health probes stay public:
 
+- `GET /health`
 - `GET /healthz`
 - `GET /readyz`
 
 Webhook routes keep using their provider-specific signature checks.
-`a2a-push` routes now require either a bearer API key or a shared-secret
+`a2a-push` routes require either a bearer API key or a shared-secret
 HMAC authorization header.
 
-Configure the MVP auth material with environment variables:
+Configure the auth material with environment variables:
 
 ```bash
 export HARN_ORCHESTRATOR_API_KEYS="dev-key-1,dev-key-2"
@@ -152,6 +122,40 @@ SHA256(BODY)
 string, `TIMESTAMP` is a Unix epoch seconds value, and `SHA256(BODY)` is
 the lowercase hex digest of the raw request body. Timestamps outside the
 5-minute replay window are rejected with `401 Unauthorized`.
+
+## Deployment
+
+Release tags publish a distroless container image to
+`ghcr.io/burin-labs/harn` for both `linux/amd64` and `linux/arm64`.
+
+```bash
+docker run \
+  -p 8080:8080 \
+  -v "$PWD/triggers.toml:/etc/harn/triggers.toml:ro" \
+  -e HARN_ORCHESTRATOR_API_KEYS=xxx \
+  -e HARN_ORCHESTRATOR_HMAC_SECRET=replace-me \
+  -e RUST_LOG=info \
+  ghcr.io/burin-labs/harn
+```
+
+The image runs as UID `10001` and stores orchestrator state under
+`/var/lib/harn/state` by default. Override the startup contract with
+environment variables instead of replacing the entrypoint:
+
+- `HARN_ORCHESTRATOR_MANIFEST` defaults to `/etc/harn/triggers.toml`
+- `HARN_ORCHESTRATOR_LISTEN` defaults to `0.0.0.0:8080`
+- `HARN_ORCHESTRATOR_STATE_DIR` defaults to `/var/lib/harn/state`
+- `HARN_ORCHESTRATOR_API_KEYS` supplies bearer credentials for
+  authenticated `a2a-push` routes
+- `HARN_ORCHESTRATOR_HMAC_SECRET` supplies the shared secret for
+  canonical-request HMAC auth on `a2a-push` routes
+- `HARN_SECRET_*`, provider API-key env vars, and deployment-specific
+  `HARN_PROVIDER_*` values are passed through to connector/provider code
+- `RUST_LOG` controls runtime log verbosity
+
+The image healthcheck issues `GET /health` against the local listener, so
+it works with Docker, BuildKit smoke tests, and most container platforms
+without requiring curl inside the distroless runtime.
 
 ### Trigger examples
 

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -42,6 +42,12 @@ SIGTERM, it stops accepting new requests, lets in-flight requests drain,
 appends lifecycle events to the EventLog, and persists a final
 `orchestrator-state.json` snapshot under `--state-dir`.
 
+`--manifest` is an alias for `--config`, and `--listen` is an alias for
+`--bind`. Container deployments can also configure those through
+`HARN_ORCHESTRATOR_MANIFEST`, `HARN_ORCHESTRATOR_LISTEN`,
+`HARN_ORCHESTRATOR_STATE_DIR`, `HARN_ORCHESTRATOR_CERT`, and
+`HARN_ORCHESTRATOR_KEY`.
+
 ## HTTP Listener
 
 The orchestrator listener assembles routes from `[[triggers]]` entries
@@ -49,12 +55,43 @@ with `kind = "webhook"` or `kind = "a2a-push"`.
 
 - If a trigger declares `path = "/github/issues"`, that path is used.
 - Otherwise the route defaults to `/triggers/<id>`.
-- `/healthz` and `/readyz` are reserved listener endpoints; use
-  `GET /healthz` and `GET /readyz` for process health checks.
+- `/health`, `/healthz`, and `/readyz` are reserved listener endpoints;
+  use `GET /health` for container health checks.
 
 Accepted deliveries are normalized into `TriggerEvent` records and
 appended to the shared `orchestrator.triggers.pending` queue in the
 event log for downstream dispatch.
+
+## Deployment
+
+Release tags publish a distroless container image to
+`ghcr.io/burin-labs/harn` for both `linux/amd64` and `linux/arm64`.
+
+```bash
+docker run \
+  -p 8080:8080 \
+  -v "$PWD/triggers.toml:/etc/harn/triggers.toml:ro" \
+  -e HARN_ORCHESTRATOR_API_KEYS=xxx \
+  -e RUST_LOG=info \
+  ghcr.io/burin-labs/harn
+```
+
+The image runs as UID `10001` and stores orchestrator state under
+`/var/lib/harn/state` by default. Override the startup contract with
+environment variables instead of replacing the entrypoint:
+
+- `HARN_ORCHESTRATOR_MANIFEST` defaults to `/etc/harn/triggers.toml`
+- `HARN_ORCHESTRATOR_LISTEN` defaults to `0.0.0.0:8080`
+- `HARN_ORCHESTRATOR_STATE_DIR` defaults to `/var/lib/harn/state`
+- `HARN_ORCHESTRATOR_API_KEYS` can inject listener auth keys when your
+  deployment enables them
+- `HARN_SECRET_*`, provider API-key env vars, and deployment-specific
+  `HARN_PROVIDER_*` values are passed through to connector/provider code
+- `RUST_LOG` controls runtime log verbosity
+
+The image healthcheck issues `GET /health` against the local listener, so
+it works with Docker, BuildKit smoke tests, and most container platforms
+without requiring curl inside the distroless runtime.
 
 ### Listener controls
 


### PR DESCRIPTION
## What changed
- add a root multi-stage `Dockerfile` for `harn orchestrator serve` using a `rust:1.95-bookworm` builder and `gcr.io/distroless/cc-debian12` runtime as UID `10001`
- disable the repo-local `sccache` wrapper inside the container build and harden the build stage for both `linux/amd64` and `linux/arm64`, including cross-linker setup when `buildx` is targeting the non-host arch
- keep the distroless runtime probeable by shipping a tiny `harn-container-probe` binary and wiring Docker `HEALTHCHECK` to `GET /health`
- add container-friendly orchestrator aliases/env defaults (`--manifest`, `--listen`, `HARN_ORCHESTRATOR_*`) and expose `/health` alongside the existing listener probes
- require auth on `a2a-push` routes via `HARN_ORCHESTRATOR_API_KEYS` or canonical-request `HMAC-SHA256` auth backed by `HARN_ORCHESTRATOR_HMAC_SECRET`
- publish multi-arch `linux/amd64` + `linux/arm64` images to `ghcr.io/burin-labs/harn` from the release-tag workflow
- document deployment and listener auth in `README.md`, `docs/src/orchestrator.md`, and `CHANGELOG.md`

## Why
Issue #186 needs a production-ready container contract around the orchestrator listener so release tags ship a usable GHCR image instead of only tarball artifacts.

## Validation
- `cargo test -p harn-vm canonical_request_authorization -- --nocapture`
- `cargo test -p harn-cli --bin harn-container-probe -- --nocapture`
- `cargo test -p harn-cli --test orchestrator_http -- --nocapture`
- repo pre-push hook: workspace `nextest` + markdown + portal lint
- `docker build --no-cache -t harn-issue-186-smoke .`
- local arm64 smoke run: `docker run -d -p 18080:8080 ... harn-issue-186-smoke` then `curl http://127.0.0.1:18080/health` => `ok`
- `docker buildx build --platform linux/amd64 --load -t harn-issue-186-amd64 .`
- local amd64 smoke run under emulation: `docker run --platform linux/amd64 -d -p 18081:8080 ... harn-issue-186-amd64` then `curl http://127.0.0.1:18081/health` => `ok`

## Notes
- The Docker verification caught and fixed two real issues during implementation:
  1. the repo's `.cargo/config.toml` `sccache` wrapper broke container builds until it was explicitly disabled in the Docker builder environment
  2. `rust:1.95` was linking against a newer glibc than `distroless/cc-debian12`, so the builder was pinned to the Debian 12-compatible Rust image and the stale target-dir cache mount was removed
