### PR TITLE
[codex] Implement a2a trigger dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,19 @@ granular archaeology.
   the release-tag workflow now builds and pushes `linux/amd64` +
   `linux/arm64` images to `ghcr.io/burin-labs/harn`.
 
+- **Real `a2a://...` trigger dispatch in the runtime (#181).** The
+  dispatcher now resolves `a2a://host[:port]/path` handlers through the
+  target agent card, requires a confirmed-unique JSON-RPC endpoint,
+  posts the `TriggerEvent` envelope over `a2a.SendMessage`, and returns
+  either the inline remote result or a pending task handle payload.
+  Dispatcher retries / DLQ behavior now apply to remote A2A attempts the
+  same way they already applied to local handlers. Persisted
+  observability adds `a2a_hop` nodes and `a2a_dispatch` edges with
+  propagated `trace_id` and `target_agent` context. Adds dispatcher unit
+  coverage for inline + pending A2A responses and a conformance fixture
+  that exercises `trigger_register(...)` / `trigger_fire(...)` against a
+  live `harn serve` receiver.
+
 - **Trigger event replay now routes through the dispatcher (#166).**
   `trigger_replay(...)` no longer uses the local shallow stub. The
   stdlib now looks up historical events from `triggers.events`,
@@ -75,10 +88,9 @@ granular archaeology.
   handler VMs, and new dispatcher lifecycle records on
   `triggers.lifecycle`. Closes the T-10 deferral for
   `dispatch` / `retry` / `dlq` action-graph nodes and
-  `retry` / `dlq_move` edges on the local-handler path.
-  `a2a_hop` / `worker_enqueue` remain deferred to O-04 / O-05; the
-  current `a2a://...` and `worker://...` routes return explicit
-  `NotImplemented` errors that point at those tickets.
+  `retry` / `dlq_move` edges on the local-handler path. Follow-up work
+  since extended the remote side with `a2a_hop` / `a2a_dispatch`; only
+  `worker://...` remains deferred to O-05.
 
 - **Durable trigger inbox dedupe on top of the shared EventLog (#160).**
   `harn_vm::triggers::InboxIndex` now persists dedupe claims on the

--- a/conformance/tests/integration/orchestrator_a2a_dispatch_sync.expected
+++ b/conformance/tests/integration/orchestrator_a2a_dispatch_sync.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
+++ b/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
@@ -1,0 +1,95 @@
+import "std/triggers"
+
+fn wait_for_log_line(log_path, needle) {
+  var attempts = 0
+  while attempts < 200 {
+    if file_exists(log_path) {
+      let log = exec("cat", log_path).stdout
+      if contains(log, needle) {
+        return true
+      }
+    }
+    sleep(50ms)
+    attempts = attempts + 1
+  }
+  return false
+}
+
+fn wait_for_exit(pid) {
+  var attempts = 0
+  while attempts < 100 {
+    let probe = shell("kill -0 " + pid + " >/dev/null 2>&1")
+    if !probe.success {
+      return true
+    }
+    sleep(50ms)
+    attempts = attempts + 1
+  }
+  return false
+}
+
+pipeline test(task) {
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let root = path_join(temp_dir(), "harn-a2a-dispatch-" + unique)
+  mkdir(root)
+
+  let port = random_int(20000, 45000)
+  write_file(
+    path_join(root, "receiver.harn"),
+    "pipeline default(task) {\n  let envelope = json_parse(task)\n  println(json_stringify({trace_id: envelope.event.trace_id, target_agent: envelope.target_agent}))\n}\n",
+  )
+
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let target_dir = env("CARGO_TARGET_DIR") ?? path_join(repo_root, "target")
+  let harn_bin = path_join(target_dir, "debug/harn")
+  assert(file_exists(harn_bin), "missing built harn binary at " + harn_bin)
+
+  let start = shell_at(
+    root,
+    "nohup " + harn_bin + " serve --port " + to_string(port) + " receiver.harn >receiver.log 2>&1 </dev/null & echo $!",
+  )
+  let pid = start.stdout.trim()
+  assert(start.success, "failed to start A2A receiver")
+  assert(pid != "", "missing A2A receiver pid")
+  assert(
+    wait_for_log_line(path_join(root, "receiver.log"), "Harn A2A server listening on http://localhost:" + to_string(port)),
+    "A2A receiver did not start",
+  )
+
+  let trigger_id = "github-a2a-review-" + unique
+  let trace_id = "trace-a2a-" + unique
+  let handle: TriggerHandle = trigger_register({
+    id: trigger_id,
+    kind: "issue.opened",
+    provider: "github",
+    handler: "a2a://127.0.0.1:" + to_string(port) + "/triage",
+    when: nil,
+    retry: {max: 1, backoff: "immediate"},
+    match: {events: ["issue.opened"]},
+    events: nil,
+    budget: nil,
+    dedupe_key: nil,
+    filter: nil,
+    manifest_path: nil,
+    package_name: "conformance",
+  })
+  println(handle.id == trigger_id && handle.handler_kind == "a2a")
+
+  let fire: DispatchHandle = trigger_fire(
+    handle,
+    {
+    id: "evt-" + unique,
+    provider: "github",
+    kind: "issue.opened",
+    trace_id: trace_id,
+    headers: {x_delivery: "evt-" + unique},
+  },
+  )
+  println(fire.status == "dispatched" && fire.error == nil)
+  println(fire.result?.trace_id == trace_id)
+  println(fire.result?.target_agent == "triage")
+
+  let _ = shell("kill -TERM " + pid)
+  wait_for_exit(pid)
+  delete_file(root)
+}

--- a/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
+++ b/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
@@ -32,33 +32,34 @@ pipeline test(task) {
   let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
   let root = path_join(temp_dir(), "harn-a2a-dispatch-" + unique)
   mkdir(root)
-
   let port = random_int(20000, 45000)
   write_file(
     path_join(root, "receiver.harn"),
     "pipeline default(task) {\n  let envelope = json_parse(task)\n  println(json_stringify({trace_id: envelope.event.trace_id, target_agent: envelope.target_agent}))\n}\n",
   )
-
   let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
   let target_dir = env("CARGO_TARGET_DIR") ?? path_join(repo_root, "target")
   let harn_bin = path_join(target_dir, "debug/harn")
   assert(file_exists(harn_bin), "missing built harn binary at " + harn_bin)
-
   let start = shell_at(
     root,
-    "nohup " + harn_bin + " serve --port " + to_string(port) + " receiver.harn >receiver.log 2>&1 </dev/null & echo $!",
+    "nohup " + harn_bin + " serve --port " + to_string(port)
+    + " receiver.harn >receiver.log 2>&1 </dev/null & echo $!",
   )
   let pid = start.stdout.trim()
   assert(start.success, "failed to start A2A receiver")
   assert(pid != "", "missing A2A receiver pid")
   assert(
-    wait_for_log_line(path_join(root, "receiver.log"), "Harn A2A server listening on http://localhost:" + to_string(port)),
+    wait_for_log_line(
+    path_join(root, "receiver.log"),
+    "Harn A2A server listening on http://localhost:" + to_string(port),
+  ),
     "A2A receiver did not start",
   )
-
   let trigger_id = "github-a2a-review-" + unique
   let trace_id = "trace-a2a-" + unique
-  let handle: TriggerHandle = trigger_register({
+  let handle: TriggerHandle = trigger_register(
+    {
     id: trigger_id,
     kind: "issue.opened",
     provider: "github",
@@ -72,9 +73,9 @@ pipeline test(task) {
     filter: nil,
     manifest_path: nil,
     package_name: "conformance",
-  })
+  },
+  )
   println(handle.id == trigger_id && handle.handler_kind == "a2a")
-
   let fire: DispatchHandle = trigger_fire(
     handle,
     {
@@ -88,7 +89,6 @@ pipeline test(task) {
   println(fire.status == "dispatched" && fire.error == nil)
   println(fire.result?.trace_id == trace_id)
   println(fire.result?.target_agent == "triage")
-
   let _ = shell("kill -TERM " + pid)
   wait_for_exit(pid)
   delete_file(root)

--- a/crates/harn-vm/src/a2a/mod.rs
+++ b/crates/harn-vm/src/a2a/mod.rs
@@ -1,0 +1,390 @@
+use reqwest::Url;
+use serde_json::Value;
+use tokio::sync::broadcast;
+
+use crate::triggers::TriggerEvent;
+
+const A2A_AGENT_CARD_PATH: &str = ".well-known/a2a-agent";
+const A2A_PROTOCOL_VERSION: &str = "1.0.0";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedA2aEndpoint {
+    pub card_url: String,
+    pub rpc_url: String,
+    pub agent_id: Option<String>,
+    pub target_agent: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum DispatchAck {
+    InlineResult {
+        task_id: String,
+        result: Value,
+    },
+    PendingTask {
+        task_id: String,
+        state: String,
+        handle: Value,
+    },
+}
+
+#[derive(Debug)]
+pub enum A2aClientError {
+    InvalidTarget(String),
+    Discovery(String),
+    Protocol(String),
+    Cancelled(String),
+}
+
+impl std::fmt::Display for A2aClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidTarget(message)
+            | Self::Discovery(message)
+            | Self::Protocol(message)
+            | Self::Cancelled(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for A2aClientError {}
+
+pub async fn dispatch_trigger_event(
+    raw_target: &str,
+    binding_id: &str,
+    binding_key: &str,
+    event: &TriggerEvent,
+    cancel_rx: &mut broadcast::Receiver<()>,
+) -> Result<(ResolvedA2aEndpoint, DispatchAck), A2aClientError> {
+    let target = parse_target(raw_target)?;
+    let endpoint = resolve_endpoint(&target, cancel_rx).await?;
+    let message_id = format!("{}.{}", event.trace_id.0, event.id.0);
+    let envelope = serde_json::json!({
+        "kind": "harn.trigger.dispatch",
+        "message_id": message_id,
+        "trace_id": event.trace_id.0,
+        "event_id": event.id.0,
+        "trigger_id": binding_id,
+        "binding_key": binding_key,
+        "target_agent": endpoint.target_agent,
+        "event": event,
+    });
+    let text = serde_json::to_string(&envelope)
+        .map_err(|error| A2aClientError::Protocol(format!("serialize A2A envelope: {error}")))?;
+    let request = crate::jsonrpc::request(
+        message_id.clone(),
+        "a2a.SendMessage",
+        serde_json::json!({
+            "contextId": event.trace_id.0,
+            "message": {
+                "messageId": message_id,
+                "role": "user",
+                "parts": [{
+                    "type": "text",
+                    "text": text,
+                }],
+                "metadata": {
+                    "kind": "harn.trigger.dispatch",
+                    "trace_id": event.trace_id.0,
+                    "event_id": event.id.0,
+                    "trigger_id": binding_id,
+                    "binding_key": binding_key,
+                    "target_agent": endpoint.target_agent,
+                },
+            },
+        }),
+    );
+
+    let body = send_jsonrpc(&endpoint.rpc_url, &request, cancel_rx).await?;
+    let result = body.get("result").cloned().ok_or_else(|| {
+        if let Some(error) = body.get("error") {
+            let message = error
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown A2A error");
+            A2aClientError::Protocol(format!("A2A task dispatch failed: {message}"))
+        } else {
+            A2aClientError::Protocol("A2A task dispatch response missing result".to_string())
+        }
+    })?;
+
+    let task_id = result
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| A2aClientError::Protocol("A2A task response missing result.id".to_string()))?
+        .to_string();
+    let state = task_state(&result)?.to_string();
+
+    if state == "completed" {
+        let inline = extract_inline_result(&result);
+        return Ok((
+            endpoint,
+            DispatchAck::InlineResult {
+                task_id,
+                result: inline,
+            },
+        ));
+    }
+
+    Ok((
+        endpoint.clone(),
+        DispatchAck::PendingTask {
+            task_id: task_id.clone(),
+            state: state.clone(),
+            handle: serde_json::json!({
+                "kind": "a2a_task_handle",
+                "task_id": task_id,
+                "state": state,
+                "target_agent": endpoint.target_agent,
+                "rpc_url": endpoint.rpc_url,
+                "card_url": endpoint.card_url,
+                "agent_id": endpoint.agent_id,
+            }),
+        },
+    ))
+}
+
+pub fn target_agent_label(raw_target: &str) -> String {
+    parse_target(raw_target)
+        .map(|target| target.target_agent_label())
+        .unwrap_or_else(|_| raw_target.to_string())
+}
+
+#[derive(Clone, Debug)]
+struct ParsedTarget {
+    authority: String,
+    target_agent: String,
+}
+
+impl ParsedTarget {
+    fn target_agent_label(&self) -> String {
+        if self.target_agent.is_empty() {
+            self.authority.clone()
+        } else {
+            self.target_agent.clone()
+        }
+    }
+}
+
+fn parse_target(raw_target: &str) -> Result<ParsedTarget, A2aClientError> {
+    let parsed = Url::parse(&format!("http://{raw_target}")).map_err(|error| {
+        A2aClientError::InvalidTarget(format!(
+            "invalid a2a dispatch target '{raw_target}': {error}"
+        ))
+    })?;
+    let host = parsed.host_str().ok_or_else(|| {
+        A2aClientError::InvalidTarget(format!(
+            "invalid a2a dispatch target '{raw_target}': missing host"
+        ))
+    })?;
+    let authority = if let Some(port) = parsed.port() {
+        format!("{host}:{port}")
+    } else {
+        host.to_string()
+    };
+    Ok(ParsedTarget {
+        authority,
+        target_agent: parsed.path().trim_start_matches('/').to_string(),
+    })
+}
+
+async fn resolve_endpoint(
+    target: &ParsedTarget,
+    cancel_rx: &mut broadcast::Receiver<()>,
+) -> Result<ResolvedA2aEndpoint, A2aClientError> {
+    let mut last_error = None;
+    for scheme in ["http", "https"] {
+        let card_url = format!("{scheme}://{}/{A2A_AGENT_CARD_PATH}", target.authority);
+        match fetch_agent_card(&card_url, cancel_rx).await {
+            Ok(card) => return endpoint_from_card(card_url, target.target_agent.clone(), &card),
+            Err(A2aClientError::Cancelled(message)) => {
+                return Err(A2aClientError::Cancelled(message));
+            }
+            Err(error) => last_error = Some(error.to_string()),
+        }
+    }
+    Err(A2aClientError::Discovery(format!(
+        "could not resolve A2A agent card for '{}': {}",
+        target.authority,
+        last_error.unwrap_or_else(|| "unknown discovery error".to_string())
+    )))
+}
+
+async fn fetch_agent_card(
+    card_url: &str,
+    cancel_rx: &mut broadcast::Receiver<()>,
+) -> Result<Value, A2aClientError> {
+    let response = send_http(
+        crate::llm::shared_utility_client().get(card_url),
+        cancel_rx,
+        "A2A agent-card fetch cancelled",
+    )
+    .await?;
+    if !response.status().is_success() {
+        return Err(A2aClientError::Discovery(format!(
+            "GET {card_url} returned HTTP {}",
+            response.status()
+        )));
+    }
+    response
+        .json::<Value>()
+        .await
+        .map_err(|error| A2aClientError::Discovery(format!("parse {card_url}: {error}")))
+}
+
+fn endpoint_from_card(
+    card_url: String,
+    target_agent: String,
+    card: &Value,
+) -> Result<ResolvedA2aEndpoint, A2aClientError> {
+    let base_url = card
+        .get("url")
+        .and_then(Value::as_str)
+        .ok_or_else(|| A2aClientError::Discovery("A2A agent card missing url".to_string()))?;
+    let base_url = Url::parse(base_url).map_err(|error| {
+        A2aClientError::Discovery(format!("invalid A2A card url '{base_url}': {error}"))
+    })?;
+    let interfaces = card
+        .get("interfaces")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            A2aClientError::Discovery("A2A agent card missing interfaces".to_string())
+        })?;
+    let jsonrpc_interfaces: Vec<&Value> = interfaces
+        .iter()
+        .filter(|entry| entry.get("protocol").and_then(Value::as_str) == Some("jsonrpc"))
+        .collect();
+    if jsonrpc_interfaces.len() != 1 {
+        return Err(A2aClientError::Discovery(format!(
+            "A2A agent card must expose exactly one jsonrpc interface, found {}",
+            jsonrpc_interfaces.len()
+        )));
+    }
+    let interface_url = jsonrpc_interfaces[0]
+        .get("url")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            A2aClientError::Discovery("A2A jsonrpc interface missing url".to_string())
+        })?;
+    let rpc_url = base_url.join(interface_url).map_err(|error| {
+        A2aClientError::Discovery(format!(
+            "invalid A2A interface url '{interface_url}': {error}"
+        ))
+    })?;
+    Ok(ResolvedA2aEndpoint {
+        card_url,
+        rpc_url: rpc_url.to_string(),
+        agent_id: card.get("id").and_then(Value::as_str).map(str::to_string),
+        target_agent,
+    })
+}
+
+async fn send_jsonrpc(
+    rpc_url: &str,
+    request: &Value,
+    cancel_rx: &mut broadcast::Receiver<()>,
+) -> Result<Value, A2aClientError> {
+    let response = send_http(
+        crate::llm::shared_blocking_client()
+            .post(rpc_url)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header("A2A-Version", A2A_PROTOCOL_VERSION)
+            .json(request),
+        cancel_rx,
+        "A2A task dispatch cancelled",
+    )
+    .await?;
+    if !response.status().is_success() {
+        return Err(A2aClientError::Protocol(format!(
+            "A2A task dispatch returned HTTP {}",
+            response.status()
+        )));
+    }
+    response
+        .json::<Value>()
+        .await
+        .map_err(|error| A2aClientError::Protocol(format!("parse A2A dispatch response: {error}")))
+}
+
+async fn send_http(
+    request: reqwest::RequestBuilder,
+    cancel_rx: &mut broadcast::Receiver<()>,
+    cancelled_message: &'static str,
+) -> Result<reqwest::Response, A2aClientError> {
+    tokio::select! {
+        response = request.send() => response
+            .map_err(|error| A2aClientError::Protocol(format!("A2A HTTP request failed: {error}"))),
+        _ = recv_cancel(cancel_rx) => Err(A2aClientError::Cancelled(cancelled_message.to_string())),
+    }
+}
+
+fn task_state(task: &Value) -> Result<&str, A2aClientError> {
+    task.pointer("/status/state")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            A2aClientError::Protocol("A2A task response missing result.status.state".to_string())
+        })
+}
+
+fn extract_inline_result(task: &Value) -> Value {
+    let text = task
+        .get("history")
+        .and_then(Value::as_array)
+        .and_then(|history| {
+            history.iter().rev().find_map(|message| {
+                let role = message.get("role").and_then(Value::as_str)?;
+                if role != "agent" {
+                    return None;
+                }
+                message
+                    .get("parts")
+                    .and_then(Value::as_array)
+                    .and_then(|parts| {
+                        parts.iter().find_map(|part| {
+                            if part.get("type").and_then(Value::as_str) == Some("text") {
+                                part.get("text").and_then(Value::as_str).map(str::trim_end)
+                            } else {
+                                None
+                            }
+                        })
+                    })
+            })
+        });
+    match text {
+        Some(text) if !text.is_empty() => {
+            serde_json::from_str(text).unwrap_or_else(|_| Value::String(text.to_string()))
+        }
+        _ => task.clone(),
+    }
+}
+
+async fn recv_cancel(cancel_rx: &mut broadcast::Receiver<()>) {
+    let _ = cancel_rx.recv().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_agent_label_prefers_path() {
+        assert_eq!(target_agent_label("reviewer.prod/triage"), "triage");
+        assert_eq!(target_agent_label("reviewer.prod"), "reviewer.prod");
+    }
+
+    #[test]
+    fn extract_inline_result_parses_json_text() {
+        let task = serde_json::json!({
+            "history": [
+                {"role": "user", "parts": [{"type": "text", "text": "ignored"}]},
+                {"role": "agent", "parts": [{"type": "text", "text": "{\"trace_id\":\"trace_123\"}\n"}]},
+            ]
+        });
+        assert_eq!(
+            extract_inline_result(&task),
+            serde_json::json!({"trace_id": "trace_123"})
+        );
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::result_large_err, clippy::cloned_ref_to_slice_refs)]
 
+pub mod a2a;
 pub mod agent_events;
 pub mod agent_sessions;
 pub mod bridge;

--- a/crates/harn-vm/src/orchestration/records.rs
+++ b/crates/harn-vm/src/orchestration/records.rs
@@ -20,11 +20,13 @@ pub const ACTION_GRAPH_NODE_KIND_PREDICATE: &str = "predicate";
 pub const ACTION_GRAPH_NODE_KIND_STAGE: &str = "stage";
 pub const ACTION_GRAPH_NODE_KIND_WORKER: &str = "worker";
 pub const ACTION_GRAPH_NODE_KIND_DISPATCH: &str = "dispatch";
+pub const ACTION_GRAPH_NODE_KIND_A2A_HOP: &str = "a2a_hop";
 pub const ACTION_GRAPH_NODE_KIND_RETRY: &str = "retry";
 pub const ACTION_GRAPH_NODE_KIND_DLQ: &str = "dlq";
 
 pub const ACTION_GRAPH_EDGE_KIND_ENTRY: &str = "entry";
 pub const ACTION_GRAPH_EDGE_KIND_TRIGGER_DISPATCH: &str = "trigger_dispatch";
+pub const ACTION_GRAPH_EDGE_KIND_A2A_DISPATCH: &str = "a2a_dispatch";
 pub const ACTION_GRAPH_EDGE_KIND_PREDICATE_GATE: &str = "predicate_gate";
 pub const ACTION_GRAPH_EDGE_KIND_REPLAY_CHAIN: &str = "replay_chain";
 pub const ACTION_GRAPH_EDGE_KIND_TRANSITION: &str = "transition";

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -13,10 +13,11 @@ use crate::event_log::{active_event_log, AnyEventLog, EventLog, LogError, LogEve
 use crate::llm::vm_value_to_json;
 use crate::orchestration::{
     append_action_graph_update, RunActionGraphEdgeRecord, RunActionGraphNodeRecord,
-    RunObservabilityRecord, ACTION_GRAPH_EDGE_KIND_DLQ_MOVE, ACTION_GRAPH_EDGE_KIND_PREDICATE_GATE,
-    ACTION_GRAPH_EDGE_KIND_REPLAY_CHAIN, ACTION_GRAPH_EDGE_KIND_RETRY,
-    ACTION_GRAPH_EDGE_KIND_TRIGGER_DISPATCH, ACTION_GRAPH_NODE_KIND_DISPATCH,
-    ACTION_GRAPH_NODE_KIND_DLQ, ACTION_GRAPH_NODE_KIND_RETRY, ACTION_GRAPH_NODE_KIND_TRIGGER,
+    RunObservabilityRecord, ACTION_GRAPH_EDGE_KIND_A2A_DISPATCH, ACTION_GRAPH_EDGE_KIND_DLQ_MOVE,
+    ACTION_GRAPH_EDGE_KIND_PREDICATE_GATE, ACTION_GRAPH_EDGE_KIND_REPLAY_CHAIN,
+    ACTION_GRAPH_EDGE_KIND_RETRY, ACTION_GRAPH_EDGE_KIND_TRIGGER_DISPATCH,
+    ACTION_GRAPH_NODE_KIND_A2A_HOP, ACTION_GRAPH_NODE_KIND_DISPATCH, ACTION_GRAPH_NODE_KIND_DLQ,
+    ACTION_GRAPH_NODE_KIND_RETRY, ACTION_GRAPH_NODE_KIND_TRIGGER,
 };
 use crate::stdlib::json_to_vm_value;
 use crate::value::{error_to_category, ErrorCategory, VmError, VmValue};
@@ -162,6 +163,7 @@ pub enum DispatchError {
     Registry(String),
     Serde(String),
     Local(String),
+    A2a(String),
     Cancelled(String),
     NotImplemented(String),
 }
@@ -173,6 +175,7 @@ impl std::fmt::Display for DispatchError {
             | Self::Registry(message)
             | Self::Serde(message)
             | Self::Local(message)
+            | Self::A2a(message)
             | Self::Cancelled(message)
             | Self::NotImplemented(message) => f.write_str(message),
         }
@@ -472,7 +475,7 @@ impl Dispatcher {
         let max_attempts = binding.retry.max_attempts();
         for attempt in 1..=max_attempts {
             let started_at = now_rfc3339();
-            let dispatch_node_id = format!("dispatch:{binding_key}:{}:{attempt}", event.id.0);
+            let attempt_node_id = dispatch_node_id(&route, &binding_key, &event.id.0, attempt);
             self.append_lifecycle_event(
                 "DispatchStarted",
                 &event,
@@ -510,18 +513,14 @@ impl Dispatcher {
             if attempt == 1 {
                 dispatch_edges.push(RunActionGraphEdgeRecord {
                     from_id: source_node_id.clone(),
-                    to_id: dispatch_node_id.clone(),
-                    kind: if binding.when.is_some() {
-                        ACTION_GRAPH_EDGE_KIND_PREDICATE_GATE.to_string()
-                    } else {
-                        ACTION_GRAPH_EDGE_KIND_TRIGGER_DISPATCH.to_string()
-                    },
+                    to_id: attempt_node_id.clone(),
+                    kind: dispatch_entry_edge_kind(&route, binding.when.is_some()).to_string(),
                     label: binding.when.as_ref().map(|_| "true".to_string()),
                 });
             } else if let Some(retry_node_id) = previous_retry_node.take() {
                 dispatch_edges.push(RunActionGraphEdgeRecord {
                     from_id: retry_node_id,
-                    to_id: dispatch_node_id.clone(),
+                    to_id: attempt_node_id.clone(),
                     kind: ACTION_GRAPH_EDGE_KIND_RETRY.to_string(),
                     label: Some(format!("attempt {attempt}")),
                 });
@@ -530,9 +529,9 @@ impl Dispatcher {
             self.emit_action_graph(
                 &event,
                 vec![RunActionGraphNodeRecord {
-                    id: dispatch_node_id.clone(),
-                    label: route.target_uri(),
-                    kind: ACTION_GRAPH_NODE_KIND_DISPATCH.to_string(),
+                    id: attempt_node_id.clone(),
+                    label: dispatch_node_label(&route),
+                    kind: dispatch_node_kind(&route).to_string(),
                     status: "running".to_string(),
                     outcome: format!("attempt_{attempt}"),
                     trace_id: Some(event.trace_id.0.clone()),
@@ -551,6 +550,7 @@ impl Dispatcher {
                     "attempt": attempt,
                     "handler_kind": route.kind(),
                     "target_uri": route.target_uri(),
+                    "target_agent": dispatch_target_agent(&route),
                     "replay_of_event_id": replay_of_event_id,
                 }),
             )
@@ -744,7 +744,7 @@ impl Dispatcher {
                                 run_path: None,
                             }],
                             vec![RunActionGraphEdgeRecord {
-                                from_id: dispatch_node_id,
+                                from_id: attempt_node_id,
                                 to_id: retry_node_id.clone(),
                                 kind: ACTION_GRAPH_EDGE_KIND_RETRY.to_string(),
                                 label: Some(format!("attempt {}", attempt + 1)),
@@ -853,7 +853,7 @@ impl Dispatcher {
                             run_path: None,
                         }],
                         vec![RunActionGraphEdgeRecord {
-                            from_id: format!("dispatch:{binding_key}:{}:{attempt}", event.id.0),
+                            from_id: dispatch_node_id(&route, &binding_key, &event.id.0, attempt),
                             to_id: format!("dlq:{binding_key}:{}", event.id.0),
                             kind: ACTION_GRAPH_EDGE_KIND_DLQ_MOVE.to_string(),
                             label: Some(format!("{attempt} attempts")),
@@ -961,9 +961,26 @@ impl Dispatcher {
                     .await?;
                 Ok(vm_value_to_json(&value))
             }
-            DispatchUri::A2a { target } => Err(DispatchError::NotImplemented(format!(
-                "a2a:// dispatch to '{target}' is not implemented yet; see O-04 #181"
-            ))),
+            DispatchUri::A2a { target } => {
+                let (_endpoint, ack) = crate::a2a::dispatch_trigger_event(
+                    target,
+                    binding.id.as_str(),
+                    &binding.binding_key(),
+                    event,
+                    cancel_rx,
+                )
+                .await
+                .map_err(|error| match error {
+                    crate::a2a::A2aClientError::Cancelled(message) => {
+                        DispatchError::Cancelled(message)
+                    }
+                    other => DispatchError::A2a(other.to_string()),
+                })?;
+                match ack {
+                    crate::a2a::DispatchAck::InlineResult { result, .. } => Ok(result),
+                    crate::a2a::DispatchAck::PendingTask { handle, .. } => Ok(handle),
+                }
+            }
             DispatchUri::Worker { queue } => Err(DispatchError::NotImplemented(format!(
                 "worker:// dispatch to '{queue}' is not implemented yet; see O-05 #182"
             ))),
@@ -1142,6 +1159,48 @@ fn dispatch_error_from_vm_error(error: VmError) -> DispatchError {
             DispatchError::Cancelled("dispatcher shutdown cancelled local handler".to_string())
         }
         _ => DispatchError::Local(error.to_string()),
+    }
+}
+
+fn dispatch_node_id(
+    route: &DispatchUri,
+    binding_key: &str,
+    event_id: &str,
+    attempt: u32,
+) -> String {
+    let prefix = match route {
+        DispatchUri::A2a { .. } => "a2a",
+        _ => "dispatch",
+    };
+    format!("{prefix}:{binding_key}:{event_id}:{attempt}")
+}
+
+fn dispatch_node_kind(route: &DispatchUri) -> &'static str {
+    match route {
+        DispatchUri::A2a { .. } => ACTION_GRAPH_NODE_KIND_A2A_HOP,
+        _ => ACTION_GRAPH_NODE_KIND_DISPATCH,
+    }
+}
+
+fn dispatch_node_label(route: &DispatchUri) -> String {
+    match route {
+        DispatchUri::A2a { target } => crate::a2a::target_agent_label(target),
+        _ => route.target_uri(),
+    }
+}
+
+fn dispatch_target_agent(route: &DispatchUri) -> Option<String> {
+    match route {
+        DispatchUri::A2a { target } => Some(crate::a2a::target_agent_label(target)),
+        _ => None,
+    }
+}
+
+fn dispatch_entry_edge_kind(route: &DispatchUri, has_predicate: bool) -> &'static str {
+    match route {
+        DispatchUri::A2a { .. } => ACTION_GRAPH_EDGE_KIND_A2A_DISPATCH,
+        _ if has_predicate => ACTION_GRAPH_EDGE_KIND_PREDICATE_GATE,
+        _ => ACTION_GRAPH_EDGE_KIND_TRIGGER_DISPATCH,
     }
 }
 

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -1,5 +1,9 @@
 use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc::{self, Receiver};
 use std::sync::Arc;
+use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::event_log::{install_default_for_base_dir, EventLog, Topic};
@@ -9,7 +13,7 @@ use crate::triggers::registry::{
     install_manifest_triggers, resolve_live_trigger_binding, TriggerBindingSource,
     TriggerBindingSpec, TriggerHandlerSpec, TriggerPredicateSpec,
 };
-use crate::triggers::{ProviderId, ProviderPayload, SignatureStatus, TriggerEvent};
+use crate::triggers::{ProviderId, ProviderPayload, SignatureStatus, TraceId, TriggerEvent};
 use crate::Vm;
 
 use super::retry::TriggerRetryConfig;
@@ -103,6 +107,48 @@ async fn dispatcher_fixture(
     (dir, log.clone(), Dispatcher::with_event_log(vm, log))
 }
 
+async fn a2a_dispatcher_fixture(
+    target: String,
+    retry: TriggerRetryConfig,
+) -> (
+    tempfile::TempDir,
+    Arc<crate::event_log::AnyEventLog>,
+    Dispatcher,
+) {
+    crate::reset_thread_local_state();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let log = install_default_for_base_dir(dir.path()).expect("install event log");
+
+    let mut vm = Vm::new();
+    register_vm_stdlib(&mut vm);
+    vm.set_source_dir(dir.path());
+
+    install_manifest_triggers(vec![TriggerBindingSpec {
+        id: "github-a2a-review".to_string(),
+        source: TriggerBindingSource::Manifest,
+        kind: "webhook".to_string(),
+        provider: ProviderId::from("github"),
+        handler: TriggerHandlerSpec::A2a {
+            target: target.clone(),
+        },
+        when: None,
+        retry,
+        match_events: vec!["issues.opened".to_string()],
+        dedupe_key: Some("event.dedupe_key".to_string()),
+        dedupe_retention_days: crate::triggers::DEFAULT_INBOX_RETENTION_DAYS,
+        filter: None,
+        daily_cost_usd: None,
+        max_concurrent: None,
+        manifest_path: None,
+        package_name: Some("workspace".to_string()),
+        definition_fingerprint: format!("fp:{target}"),
+    }])
+    .await
+    .expect("install test trigger binding");
+
+    (dir, log.clone(), Dispatcher::with_event_log(vm, log))
+}
+
 async fn read_topic(
     log: Arc<crate::event_log::AnyEventLog>,
     topic: &str,
@@ -136,6 +182,131 @@ fn flatten_action_graph(
         }
     }
     (node_kinds, edge_kinds)
+}
+
+struct MockA2aServer {
+    authority: String,
+    requests: Receiver<serde_json::Value>,
+    join: thread::JoinHandle<()>,
+}
+
+impl MockA2aServer {
+    fn next_request(&self) -> serde_json::Value {
+        self.requests
+            .recv_timeout(Duration::from_secs(5))
+            .expect("mock A2A request")
+    }
+
+    fn finish(self) {
+        self.join.join().expect("mock A2A thread");
+    }
+}
+
+fn spawn_mock_a2a_server(task_result: serde_json::Value) -> MockA2aServer {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock A2A listener");
+    let addr = listener.local_addr().expect("mock A2A addr");
+    let authority = format!("127.0.0.1:{}", addr.port());
+    let (tx, rx) = mpsc::channel();
+    let join = thread::spawn(move || {
+        for _ in 0..2 {
+            let (mut stream, _) = listener.accept().expect("accept mock A2A request");
+            let (request_line, body) = read_http_request(&mut stream);
+            if request_line.starts_with("GET /.well-known/a2a-agent ") {
+                write_json_response(
+                    &mut stream,
+                    &serde_json::json!({
+                        "id": "mock-a2a",
+                        "url": format!("http://127.0.0.1:{}", addr.port()),
+                        "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
+                    }),
+                );
+                continue;
+            }
+            assert!(
+                request_line.starts_with("POST /rpc "),
+                "unexpected request line: {request_line}"
+            );
+            tx.send(
+                serde_json::from_slice::<serde_json::Value>(&body).expect("mock A2A request json"),
+            )
+            .expect("capture mock A2A request");
+            let rpc_id = serde_json::from_slice::<serde_json::Value>(&body)
+                .expect("mock A2A request json")["id"]
+                .clone();
+            write_json_response(
+                &mut stream,
+                &crate::jsonrpc::response(rpc_id, task_result.clone()),
+            );
+        }
+    });
+    MockA2aServer {
+        authority,
+        requests: rx,
+        join,
+    }
+}
+
+fn read_http_request(stream: &mut TcpStream) -> (String, Vec<u8>) {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set read timeout");
+    let mut buffer = Vec::new();
+    let mut chunk = [0u8; 4096];
+    let header_end;
+    let content_length;
+    loop {
+        let read = stream.read(&mut chunk).expect("read mock A2A request");
+        assert!(read > 0, "mock A2A request closed before headers");
+        buffer.extend_from_slice(&chunk[..read]);
+        if let Some(end) = find_header_end(&buffer) {
+            header_end = end;
+            content_length = parse_content_length(&buffer[..header_end]);
+            break;
+        }
+    }
+    while buffer.len() < header_end + content_length {
+        let read = stream.read(&mut chunk).expect("read mock A2A body");
+        assert!(read > 0, "mock A2A request closed before body");
+        buffer.extend_from_slice(&chunk[..read]);
+    }
+    let headers = String::from_utf8_lossy(&buffer[..header_end]);
+    let request_line = headers.lines().next().unwrap_or_default().to_string();
+    let body = buffer[header_end..header_end + content_length].to_vec();
+    (request_line, body)
+}
+
+fn find_header_end(buffer: &[u8]) -> Option<usize> {
+    buffer
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map(|index| index + 4)
+}
+
+fn parse_content_length(headers: &[u8]) -> usize {
+    let text = String::from_utf8_lossy(headers);
+    text.lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.eq_ignore_ascii_case("content-length") {
+                value.trim().parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0)
+}
+
+fn write_json_response(stream: &mut TcpStream, body: &serde_json::Value) {
+    let payload = serde_json::to_vec(body).expect("serialize mock A2A response");
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
+        payload.len()
+    );
+    stream
+        .write_all(response.as_bytes())
+        .expect("write mock A2A headers");
+    stream.write_all(&payload).expect("write mock A2A body");
+    stream.flush().expect("flush mock A2A response");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -194,6 +365,113 @@ pub fn should_handle(event: TriggerEvent) -> bool {
             assert!(node_kinds.iter().any(|kind| kind == "dispatch"));
             assert!(edge_kinds.iter().any(|kind| kind == "trigger_dispatch"));
             assert!(edge_kinds.iter().any(|kind| kind == "predicate_gate"));
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn a2a_handler_returns_inline_result_and_emits_a2a_action_graph() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let server = spawn_mock_a2a_server(serde_json::json!({
+                "id": "task-inline",
+                "status": {"state": "completed"},
+                "history": [
+                    {"id": "msg-user", "role": "user", "parts": [{"type": "text", "text": "ignored"}]},
+                    {"id": "msg-agent", "role": "agent", "parts": [{"type": "text", "text": "{\"trace_id\":\"trace_inline\",\"target_agent\":\"triage\"}"}]},
+                ],
+                "artifacts": [],
+            }));
+            let (_dir, log, dispatcher) = a2a_dispatcher_fixture(
+                format!("{}/triage", server.authority),
+                TriggerRetryConfig::default(),
+            )
+            .await;
+
+            let mut event = trigger_event("issues.opened", "delivery-a2a-inline");
+            event.trace_id = TraceId("trace_inline".to_string());
+
+            let outcomes = dispatcher
+                .dispatch_event(event.clone())
+                .await
+                .expect("A2A dispatch succeeds");
+            assert_eq!(outcomes.len(), 1);
+            assert_eq!(outcomes[0].status, DispatchStatus::Succeeded);
+            assert_eq!(
+                outcomes[0].result,
+                Some(serde_json::json!({
+                    "trace_id": "trace_inline",
+                    "target_agent": "triage",
+                }))
+            );
+
+            let request = server.next_request();
+            assert_eq!(request["method"], "a2a.SendMessage");
+            let envelope_text = request["params"]["message"]["parts"][0]["text"]
+                .as_str()
+                .expect("A2A text part");
+            let envelope: serde_json::Value =
+                serde_json::from_str(envelope_text).expect("A2A envelope JSON");
+            assert_eq!(envelope["trace_id"], "trace_inline");
+            assert_eq!(envelope["target_agent"], "triage");
+            assert_eq!(envelope["event"]["trace_id"], "trace_inline");
+
+            let graph = read_topic(log.clone(), "observability.action_graph").await;
+            let (node_kinds, edge_kinds) = flatten_action_graph(&graph);
+            assert!(node_kinds.iter().any(|kind| kind == "a2a_hop"));
+            assert!(edge_kinds.iter().any(|kind| kind == "a2a_dispatch"));
+            assert!(graph.iter().any(|(_, logged)| {
+                logged.headers.get("trace_id").map(String::as_str) == Some("trace_inline")
+                    && logged.payload["context"]["target_agent"] == serde_json::json!("triage")
+            }));
+
+            server.finish();
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn a2a_handler_returns_pending_task_handle() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let server = spawn_mock_a2a_server(serde_json::json!({
+                "id": "task-pending",
+                "status": {"state": "working"},
+                "history": [
+                    {"id": "msg-user", "role": "user", "parts": [{"type": "text", "text": "ignored"}]},
+                ],
+                "artifacts": [],
+            }));
+            let (_dir, _log, dispatcher) = a2a_dispatcher_fixture(
+                format!("{}/triage", server.authority),
+                TriggerRetryConfig::default(),
+            )
+            .await;
+
+            let outcomes = dispatcher
+                .dispatch_event(trigger_event("issues.opened", "delivery-a2a-pending"))
+                .await
+                .expect("A2A dispatch returns pending handle");
+            assert_eq!(outcomes.len(), 1);
+            assert_eq!(outcomes[0].status, DispatchStatus::Succeeded);
+            assert_eq!(
+                outcomes[0].result,
+                Some(serde_json::json!({
+                    "kind": "a2a_task_handle",
+                    "task_id": "task-pending",
+                    "state": "working",
+                    "target_agent": "triage",
+                    "rpc_url": format!("http://{}/rpc", server.authority),
+                    "card_url": format!("http://{}/.well-known/a2a-agent", server.authority),
+                    "agent_id": "mock-a2a",
+                }))
+            );
+
+            let request = server.next_request();
+            assert_eq!(request["method"], "a2a.SendMessage");
+            server.finish();
         })
         .await;
 }

--- a/docs/src/observability/triggers-in-action-graph.md
+++ b/docs/src/observability/triggers-in-action-graph.md
@@ -1,9 +1,9 @@
 # Trigger Observability In The Action Graph
 
-Harn now projects dispatcher-independent trigger activity into persisted run
-observability. This lands the first half of issue #163: `trigger` and
-`predicate` nodes, plus the matching `trigger_dispatch` and `predicate_gate`
-edges.
+Harn now projects trigger activity into persisted run observability across both
+workflow-derived nodes and dispatcher hops. The current surface includes
+`trigger`, `predicate`, `dispatch`, and `a2a_hop` nodes, plus the matching
+`trigger_dispatch`, `predicate_gate`, and `a2a_dispatch` edges.
 
 ## What lands in this change
 
@@ -11,11 +11,17 @@ edges.
   envelope in `run.metadata`.
 - Workflow `condition` stages render as `predicate` nodes in
   `observability.action_graph_nodes`.
+- Local dispatch attempts render as `dispatch` nodes.
+- Remote A2A dispatch attempts render as `a2a_hop` nodes labelled with the
+  resolved `target_agent`.
 - Entry edges from the trigger node into the workflow render as
   `trigger_dispatch`.
-- Transitions leaving a predicate render as `predicate_gate`.
+- Trigger or predicate edges into a remote A2A hop render as `a2a_dispatch`.
+- Transitions leaving a predicate on the workflow path render as
+  `predicate_gate`.
 - `trace_id` propagates from the `TriggerEvent` onto the synthetic trigger
-  node and every downstream action-graph node derived from that run.
+  node and every downstream action-graph node derived from that run,
+  including A2A hops.
 
 The runtime also streams the derived graph onto the shared event-log topic
 `observability.action_graph` whenever a run record is persisted. This reuses
@@ -24,13 +30,11 @@ bus.
 
 ## Current shape
 
-This scoped change is intentionally limited to the dispatcher-independent
-surface:
+This scoped change still leaves some portal/runtime work deferred:
 
-- Landed here: `trigger` and `predicate` node kinds.
-- Deferred to T-06: `dispatch`, `a2a_hop`, `worker_enqueue`, and `dlq`.
-- Deferred to T-06: portal replay controls and dispatcher-coupled UI work.
-- Deferred to T-06: A2A `trace_id` header propagation.
+- Landed here: `trigger`, `predicate`, `dispatch`, and `a2a_hop` node kinds.
+- Deferred: `worker_enqueue` specialized nodes and richer DLQ/A2A UI.
+- Deferred: portal replay controls and dispatcher-coupled UI work.
 
 ## Example
 
@@ -60,6 +64,7 @@ with edges such as:
 ```json
 {"kind": "trigger_dispatch", "from_id": "trigger:...", "to_id": "stage:..."}
 {"kind": "predicate_gate", "label": "true"}
+{"kind": "a2a_dispatch", "from_id": "predicate:...", "to_id": "a2a:..."}
 ```
 
 The portal does not yet render specialized UI for these nodes in this PR; it

--- a/docs/src/triggers/dispatcher.md
+++ b/docs/src/triggers/dispatcher.md
@@ -3,9 +3,9 @@
 The trigger dispatcher is the runtime path that turns a normalized
 `TriggerEvent` plus a live registry binding into actual handler work.
 
-At MVP, the dispatcher fully wires the local-function path and keeps the
-remote handler schemes (`a2a://...`, `worker://...`) as explicit stubs with
-clear error messages pointing at their follow-up tickets.
+At MVP, the dispatcher fully wires the local-function path plus synchronous
+and pending-handle `a2a://...` dispatch. The `worker://...` scheme remains an
+explicit stub with a clear follow-up ticket.
 
 ## Dispatch shape
 
@@ -47,6 +47,17 @@ same export-loading path used by manifest hooks and trigger predicates.
 
 The dispatcher still re-normalizes those shapes internally so it can emit a
 stable handler kind and target URI in lifecycle logs and action-graph nodes.
+
+For `a2a://host[:port]/path` routes, the dispatcher:
+
+- fetches `/.well-known/a2a-agent` from the target host
+- requires exactly one JSON-RPC interface in the agent card before it will
+  dispatch
+- treats the URI path as the `target_agent` label that propagates into the
+  outbound envelope and the action graph
+- sends the `TriggerEvent` envelope over `a2a.SendMessage`
+- returns either the inline agent result (when the peer completes
+  synchronously) or a pending task handle payload for the caller
 
 ## Retry policy
 
@@ -98,11 +109,11 @@ The dispatcher uses the shared `EventLog` instead of a parallel queue layer:
 
 ## Action-graph updates
 
-Dispatcher streaming closes the local-handler portion of the trigger
-action-graph deferral:
+Dispatcher streaming now covers the local-handler path plus the first A2A hop:
 
-- node kinds: `trigger`, `predicate`, `dispatch`, `retry`, `dlq`
-- edge kinds: `trigger_dispatch`, `predicate_gate`, `retry`, `dlq_move`
+- node kinds: `trigger`, `predicate`, `dispatch`, `a2a_hop`, `retry`, `dlq`
+- edge kinds: `trigger_dispatch`, `a2a_dispatch`, `predicate_gate`, `retry`,
+  `dlq_move`
 
 Each update is appended to `observability.action_graph` using the shared
 `RunActionGraphNodeRecord` / `RunActionGraphEdgeRecord` schema so the portal
@@ -118,6 +129,10 @@ event back to the original event id.
 
 ## Current MVP limits
 
-- `a2a://...` returns `DispatchError::NotImplemented` and points at `O-04 #181`
-- `worker://...` returns `DispatchError::NotImplemented` and points at `O-05 #182`
-- DLQ storage is in-memory plus event-log append; durable replay remains follow-up work
+- `a2a://...` currently uses the single-shot `a2a.SendMessage` path only; push
+  callbacks, streaming chunk accumulation, and remote cancel/resubscribe stay
+  deferred
+- `worker://...` still returns `DispatchError::NotImplemented` and points at
+  `O-05 #182`
+- DLQ storage is in-memory plus event-log append; durable replay remains
+  follow-up work


### PR DESCRIPTION
## Summary
- implement real `a2a://...` trigger dispatch in `harn-vm` using A2A agent-card discovery plus `a2a.SendMessage`
- return either the inline remote result or a pending task handle, while preserving existing dispatcher retry/DLQ/cancellation behavior
- add `a2a_hop` / `a2a_dispatch` action-graph observability plus unit and conformance coverage for trace propagation

## Why
The dispatcher introduced in #213 intentionally left `a2a://` targets as a `NotImplemented` stub. This change fills in the O-04 runtime slice so manifest and stdlib trigger dispatch can federate to a remote A2A receiver instead of failing immediately.

## Validation
- `cargo test -p harn-vm triggers::dispatcher -- --nocapture`
- `cargo test -p harn-vm a2a::tests -- --nocapture`
- `cargo run --bin harn -- test conformance conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn`
- `cargo run --bin harn -- test conformance conformance/tests/agents/trigger_stdlib_wrappers.harn`
- repo pre-commit hook (`cargo clippy --workspace -- -D warnings`, markdown lint, portal lint)
- repo pre-push suite was re-run during `git push` but hit an unrelated flaky failure in `harn-cli::orchestrator_inbox_dedupe::restart_after_emit_does_not_duplicate_cron_dispatch`; the test passed when re-run directly via `cargo test -p harn-cli --test orchestrator_inbox_dedupe restart_after_emit_does_not_duplicate_cron_dispatch -- --nocapture`
