### PR TITLE
Add trigger replay CLI command

### DIFF
--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -76,6 +76,8 @@ SCRIPTING
     Watch(WatchArgs),
     /// Launch the local Harn observability portal.
     Portal(PortalArgs),
+    /// Replay and inspect historical trigger dispatches from the event log.
+    Trigger(TriggerArgs),
     /// Start the orchestrator process that hosts triggers and connector dispatch.
     Orchestrator(OrchestratorArgs),
     /// Run a pipeline against a Harn-native host module for fast iteration.
@@ -454,6 +456,30 @@ pub(crate) struct PortalArgs {
 }
 
 #[derive(Debug, Args)]
+pub(crate) struct TriggerArgs {
+    #[command(subcommand)]
+    pub command: TriggerCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum TriggerCommand {
+    /// Replay a recorded trigger event from the event log.
+    Replay(TriggerReplayArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct TriggerReplayArgs {
+    /// Trigger event id to replay.
+    pub event_id: String,
+    /// Compare the replay outcome to the original stored outcome and emit drift JSON.
+    #[arg(long)]
+    pub diff: bool,
+    /// Resolve the binding version that was active at this historical timestamp.
+    #[arg(long = "as-of", value_name = "TIMESTAMP")]
+    pub as_of: Option<String>,
+}
+
+#[derive(Debug, Args)]
 pub(crate) struct OrchestratorArgs {
     #[command(subcommand)]
     pub command: OrchestratorCommand,
@@ -789,6 +815,7 @@ mod tests {
 
     use super::{
         Cli, Command, McpCommand, OrchestratorCommand, ProjectTemplate, RunsCommand, SkillsCommand,
+        TriggerCommand,
     };
     use clap::Parser;
 
@@ -889,6 +916,27 @@ mod tests {
         let RunsCommand::Inspect(inspect) = args.command;
         assert_eq!(inspect.path, "run.json");
         assert_eq!(inspect.compare.as_deref(), Some("baseline.json"));
+    }
+
+    #[test]
+    fn test_parses_trigger_replay_flags() {
+        let cli = Cli::parse_from([
+            "harn",
+            "trigger",
+            "replay",
+            "trigger_evt_123",
+            "--diff",
+            "--as-of",
+            "2026-04-19T18:00:00Z",
+        ]);
+
+        let Command::Trigger(args) = cli.command.unwrap() else {
+            panic!("expected trigger command");
+        };
+        let TriggerCommand::Replay(replay) = args.command;
+        assert_eq!(replay.event_id, "trigger_evt_123");
+        assert!(replay.diff);
+        assert_eq!(replay.as_of.as_deref(), Some("2026-04-19T18:00:00Z"));
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod repl;
 pub(crate) mod run;
 pub(crate) mod skills;
 pub(crate) mod test;
+pub(crate) mod trigger;
 pub(crate) mod viz;
 
 use std::path::{Path, PathBuf};

--- a/crates/harn-cli/src/commands/trigger/mod.rs
+++ b/crates/harn-cli/src/commands/trigger/mod.rs
@@ -1,0 +1,9 @@
+mod replay;
+
+use crate::cli::{TriggerArgs, TriggerCommand};
+
+pub(crate) async fn handle(args: TriggerArgs) -> Result<(), String> {
+    match args.command {
+        TriggerCommand::Replay(args) => replay::run(args).await,
+    }
+}

--- a/crates/harn-cli/src/commands/trigger/replay.rs
+++ b/crates/harn-cli/src/commands/trigger/replay.rs
@@ -1,0 +1,472 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use harn_vm::event_log::{AnyEventLog, EventLog, LogEvent, Topic};
+
+use crate::cli::TriggerReplayArgs;
+use crate::package;
+
+const TRIGGER_EVENTS_TOPIC: &str = "triggers.events";
+const TRIGGER_OUTBOX_TOPIC: &str = "trigger.outbox";
+const TRIGGER_DLQ_TOPIC: &str = "trigger.dlq";
+const ACTION_GRAPH_TOPIC: &str = "observability.action_graph";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct TriggerEventRecord {
+    binding_id: String,
+    binding_version: u32,
+    replay_of_event_id: Option<String>,
+    event: harn_vm::TriggerEvent,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct DispatchOutcomeSummary {
+    status: String,
+    attempt_count: u32,
+    handler_kind: String,
+    target_uri: Option<String>,
+    result: Option<JsonValue>,
+    error: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct DriftField {
+    original: JsonValue,
+    replayed: JsonValue,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct DriftReport {
+    changed: bool,
+    fields: BTreeMap<String, DriftField>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct TriggerReplayReport {
+    event_id: String,
+    binding_id: String,
+    binding_version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    as_of: Option<String>,
+    replay: DispatchOutcomeSummary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    original: Option<DispatchOutcomeSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    drift: Option<DriftReport>,
+}
+
+pub(crate) async fn run(args: TriggerReplayArgs) -> Result<(), String> {
+    harn_vm::reset_thread_local_state();
+
+    let cwd = std::env::current_dir().map_err(|error| format!("failed to read cwd: {error}"))?;
+    let workspace_root = harn_vm::stdlib::process::find_project_root(&cwd).unwrap_or(cwd.clone());
+    let event_log = harn_vm::event_log::install_default_for_base_dir(&workspace_root)
+        .map_err(|error| format!("failed to open event log snapshot: {error}"))?;
+
+    let mut vm = build_replay_vm(&workspace_root);
+    let extensions = package::load_runtime_extensions(&workspace_root);
+    package::install_runtime_extensions(&extensions);
+    package::install_manifest_triggers(&mut vm, &extensions)
+        .await
+        .map_err(|error| format!("failed to install manifest triggers: {error}"))?;
+
+    let recorded = load_recorded_event(&event_log, &args.event_id).await?;
+    let original = if args.diff {
+        Some(load_original_outcome(&event_log, &recorded).await?)
+    } else {
+        None
+    };
+    let as_of = args.as_of.as_deref().map(parse_timestamp).transpose()?;
+    let binding = resolve_binding(&recorded, as_of)?;
+
+    append_replay_record(&event_log, &binding, &recorded.event).await?;
+    let dispatcher = harn_vm::Dispatcher::with_event_log(vm, event_log);
+    let replay = dispatcher
+        .dispatch_replay(
+            &binding,
+            recorded.event.clone(),
+            recorded.event.id.0.clone(),
+        )
+        .await
+        .map_err(|error| format!("trigger replay failed: {error}"))?;
+    let replay_summary = summarize_dispatch_outcome(&replay);
+
+    let drift = original
+        .as_ref()
+        .map(|original| diff_outcomes(original, &replay_summary));
+    let report = TriggerReplayReport {
+        event_id: recorded.event.id.0,
+        binding_id: binding.id.as_str().to_string(),
+        binding_version: binding.version,
+        as_of: as_of.map(format_timestamp),
+        replay: replay_summary,
+        original,
+        drift,
+    };
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report)
+            .map_err(|error| format!("failed to encode replay report: {error}"))?
+    );
+    Ok(())
+}
+
+fn build_replay_vm(workspace_root: &Path) -> harn_vm::Vm {
+    let mut vm = harn_vm::Vm::new();
+    harn_vm::register_vm_stdlib(&mut vm);
+    harn_vm::register_store_builtins(&mut vm, workspace_root);
+    harn_vm::register_metadata_builtins(&mut vm, workspace_root);
+    harn_vm::register_checkpoint_builtins(&mut vm, workspace_root, "trigger-replay");
+    vm.set_project_root(workspace_root);
+    vm.set_source_dir(workspace_root);
+    vm
+}
+
+fn parse_timestamp(raw: &str) -> Result<OffsetDateTime, String> {
+    if let Ok(parsed) = OffsetDateTime::parse(raw, &Rfc3339) {
+        return Ok(parsed);
+    }
+    if let Ok(unix) = raw.parse::<i64>() {
+        let parsed = if raw.len() > 10 {
+            OffsetDateTime::from_unix_timestamp_nanos(unix as i128 * 1_000_000)
+        } else {
+            OffsetDateTime::from_unix_timestamp(unix)
+        };
+        return parsed.map_err(|error| format!("invalid --as-of timestamp '{raw}': {error}"));
+    }
+    Err(format!(
+        "invalid --as-of timestamp '{raw}': expected RFC3339 or unix seconds/milliseconds"
+    ))
+}
+
+fn format_timestamp(value: OffsetDateTime) -> String {
+    value.format(&Rfc3339).unwrap_or_else(|_| value.to_string())
+}
+
+async fn load_recorded_event(
+    event_log: &Arc<AnyEventLog>,
+    event_id: &str,
+) -> Result<TriggerEventRecord, String> {
+    let topic = Topic::new(TRIGGER_EVENTS_TOPIC)
+        .map_err(|error| format!("invalid trigger events topic: {error}"))?;
+    let events = event_log
+        .read_range(&topic, None, usize::MAX)
+        .await
+        .map_err(|error| format!("failed to read trigger events: {error}"))?;
+
+    let mut replay_match = None;
+    for (_, event) in events {
+        let Ok(record) = serde_json::from_value::<TriggerEventRecord>(event.payload) else {
+            continue;
+        };
+        if record.event.id.0 != event_id {
+            continue;
+        }
+        if record.replay_of_event_id.is_none() {
+            return Ok(record);
+        }
+        replay_match.get_or_insert(record);
+    }
+
+    replay_match.ok_or_else(|| format!("unknown trigger event id '{event_id}'"))
+}
+
+fn resolve_binding(
+    recorded: &TriggerEventRecord,
+    as_of: Option<OffsetDateTime>,
+) -> Result<Arc<harn_vm::triggers::registry::TriggerBinding>, String> {
+    if let Some(as_of) = as_of {
+        return harn_vm::resolve_trigger_binding_as_of(&recorded.binding_id, as_of).map_err(
+            |error| {
+                format!(
+                    "failed to resolve binding '{}' as of {}: {}",
+                    recorded.binding_id,
+                    format_timestamp(as_of),
+                    error
+                )
+            },
+        );
+    }
+
+    harn_vm::resolve_live_trigger_binding(&recorded.binding_id, Some(recorded.binding_version))
+        .map_err(|error| {
+            format!(
+                "failed to resolve recorded binding '{}@v{}': {}",
+                recorded.binding_id, recorded.binding_version, error
+            )
+        })
+}
+
+async fn append_replay_record(
+    event_log: &Arc<AnyEventLog>,
+    binding: &harn_vm::triggers::registry::TriggerBinding,
+    event: &harn_vm::TriggerEvent,
+) -> Result<(), String> {
+    let topic = Topic::new(TRIGGER_EVENTS_TOPIC)
+        .map_err(|error| format!("invalid trigger events topic: {error}"))?;
+    event_log
+        .append(
+            &topic,
+            LogEvent::new(
+                "trigger_event",
+                serde_json::to_value(TriggerEventRecord {
+                    binding_id: binding.id.as_str().to_string(),
+                    binding_version: binding.version,
+                    replay_of_event_id: Some(event.id.0.clone()),
+                    event: event.clone(),
+                })
+                .unwrap_or(JsonValue::Null),
+            ),
+        )
+        .await
+        .map(|_| ())
+        .map_err(|error| format!("failed to append replay record: {error}"))
+}
+
+async fn load_original_outcome(
+    event_log: &Arc<AnyEventLog>,
+    recorded: &TriggerEventRecord,
+) -> Result<DispatchOutcomeSummary, String> {
+    let binding_key = format!("{}@v{}", recorded.binding_id, recorded.binding_version);
+    if let Some(outcome) =
+        load_original_terminal_outcome(event_log, &recorded.event.id.0, &binding_key).await?
+    {
+        return Ok(outcome);
+    }
+
+    load_skipped_outcome(event_log, &recorded.event.id.0, &binding_key)
+        .await?
+        .ok_or_else(|| {
+            format!(
+                "no stored original outcome found for '{}@v{}' event '{}'",
+                recorded.binding_id, recorded.binding_version, recorded.event.id.0
+            )
+        })
+}
+
+async fn load_original_terminal_outcome(
+    event_log: &Arc<AnyEventLog>,
+    event_id: &str,
+    binding_key: &str,
+) -> Result<Option<DispatchOutcomeSummary>, String> {
+    let outbox_topic = Topic::new(TRIGGER_OUTBOX_TOPIC)
+        .map_err(|error| format!("invalid trigger outbox topic: {error}"))?;
+    let dlq_topic = Topic::new(TRIGGER_DLQ_TOPIC)
+        .map_err(|error| format!("invalid trigger dlq topic: {error}"))?;
+
+    let outbox_events = event_log
+        .read_range(&outbox_topic, None, usize::MAX)
+        .await
+        .map_err(|error| format!("failed to read trigger outbox: {error}"))?;
+    let dlq_events = event_log
+        .read_range(&dlq_topic, None, usize::MAX)
+        .await
+        .map_err(|error| format!("failed to read trigger dlq: {error}"))?;
+
+    let mut success = None;
+    let mut failure = None;
+    for (_, event) in outbox_events {
+        if !matches_original_dispatch(&event, event_id, binding_key) {
+            continue;
+        }
+        let attempt = header_u32(&event, "attempt").unwrap_or(0);
+        let handler_kind = header_text(&event, "handler_kind").unwrap_or_default();
+        let target_uri = event
+            .payload
+            .get("target_uri")
+            .cloned()
+            .and_then(|value| value.as_str().map(str::to_string));
+        match event.kind.as_str() {
+            "dispatch_succeeded" => {
+                success = Some(DispatchOutcomeSummary {
+                    status: "succeeded".to_string(),
+                    attempt_count: attempt,
+                    handler_kind,
+                    target_uri,
+                    result: event.payload.get("result").cloned(),
+                    error: None,
+                });
+            }
+            "dispatch_failed" => {
+                let error = event
+                    .payload
+                    .get("error")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string);
+                failure = Some(DispatchOutcomeSummary {
+                    status: failure_status(error.as_deref()),
+                    attempt_count: attempt,
+                    handler_kind,
+                    target_uri,
+                    result: None,
+                    error,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    for (_, event) in dlq_events {
+        if !matches_original_dispatch(&event, event_id, binding_key) || event.kind != "dlq_moved" {
+            continue;
+        }
+        let attempt_count = event
+            .payload
+            .get("attempt_count")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0) as u32;
+        return Ok(Some(DispatchOutcomeSummary {
+            status: "dlq".to_string(),
+            attempt_count,
+            handler_kind: header_text(&event, "handler_kind").unwrap_or_default(),
+            target_uri: None,
+            result: None,
+            error: event
+                .payload
+                .get("final_error")
+                .and_then(|value| value.as_str())
+                .map(str::to_string),
+        }));
+    }
+
+    Ok(success.or(failure))
+}
+
+async fn load_skipped_outcome(
+    event_log: &Arc<AnyEventLog>,
+    event_id: &str,
+    binding_key: &str,
+) -> Result<Option<DispatchOutcomeSummary>, String> {
+    let topic = Topic::new(ACTION_GRAPH_TOPIC)
+        .map_err(|error| format!("invalid action graph topic: {error}"))?;
+    let events = event_log
+        .read_range(&topic, None, usize::MAX)
+        .await
+        .map_err(|error| format!("failed to read action graph updates: {error}"))?;
+
+    for (_, event) in events {
+        let Some(context) = event.payload.get("context") else {
+            continue;
+        };
+        if context.get("event_id").and_then(|value| value.as_str()) != Some(event_id) {
+            continue;
+        }
+        if context.get("binding_key").and_then(|value| value.as_str()) != Some(binding_key) {
+            continue;
+        }
+        if context
+            .get("replay_of_event_id")
+            .and_then(|value| value.as_str())
+            .is_some()
+        {
+            continue;
+        }
+        let Some(nodes) = event.payload["observability"]["action_graph_nodes"].as_array() else {
+            continue;
+        };
+        let predicate = nodes.iter().find(|node| {
+            node.get("kind").and_then(|value| value.as_str()) == Some("predicate")
+                && node.get("outcome").and_then(|value| value.as_str()) == Some("false")
+        });
+        if let Some(predicate) = predicate {
+            return Ok(Some(DispatchOutcomeSummary {
+                status: "skipped".to_string(),
+                attempt_count: 0,
+                handler_kind: String::new(),
+                target_uri: None,
+                result: Some(json!({
+                    "skipped": true,
+                    "predicate": predicate.get("label").cloned().unwrap_or(JsonValue::Null),
+                })),
+                error: None,
+            }));
+        }
+    }
+
+    Ok(None)
+}
+
+fn matches_original_dispatch(event: &LogEvent, event_id: &str, binding_key: &str) -> bool {
+    header_text(event, "event_id") == Some(event_id.to_string())
+        && header_text(event, "binding_key") == Some(binding_key.to_string())
+        && header_text(event, "replay_of_event_id").is_none()
+}
+
+fn header_text(event: &LogEvent, key: &str) -> Option<String> {
+    event.headers.get(key).cloned()
+}
+
+fn header_u32(event: &LogEvent, key: &str) -> Option<u32> {
+    event.headers.get(key).and_then(|value| value.parse().ok())
+}
+
+fn failure_status(error: Option<&str>) -> String {
+    if error.is_some_and(|error| error.contains("cancelled")) {
+        "cancelled".to_string()
+    } else {
+        "failed".to_string()
+    }
+}
+
+fn summarize_dispatch_outcome(outcome: &harn_vm::DispatchOutcome) -> DispatchOutcomeSummary {
+    DispatchOutcomeSummary {
+        status: match outcome.status {
+            harn_vm::DispatchStatus::Succeeded => "succeeded".to_string(),
+            harn_vm::DispatchStatus::Failed => "failed".to_string(),
+            harn_vm::DispatchStatus::Dlq => "dlq".to_string(),
+            harn_vm::DispatchStatus::Skipped => "skipped".to_string(),
+            harn_vm::DispatchStatus::Cancelled => "cancelled".to_string(),
+        },
+        attempt_count: outcome.attempt_count,
+        handler_kind: outcome.handler_kind.clone(),
+        target_uri: Some(outcome.target_uri.clone()),
+        result: outcome.result.clone(),
+        error: outcome.error.clone(),
+    }
+}
+
+fn diff_outcomes(
+    original: &DispatchOutcomeSummary,
+    replayed: &DispatchOutcomeSummary,
+) -> DriftReport {
+    let original = serde_json::to_value(original).unwrap_or(JsonValue::Null);
+    let replayed = serde_json::to_value(replayed).unwrap_or(JsonValue::Null);
+    let mut fields = BTreeMap::new();
+
+    let original = original.as_object().cloned().unwrap_or_default();
+    let replayed = replayed.as_object().cloned().unwrap_or_default();
+    let mut keys = original.keys().cloned().collect::<Vec<_>>();
+    for key in replayed.keys() {
+        if !keys.iter().any(|existing| existing == key) {
+            keys.push(key.clone());
+        }
+    }
+    keys.sort();
+    keys.dedup();
+
+    for key in keys {
+        let left = original.get(&key).cloned().unwrap_or(JsonValue::Null);
+        let right = replayed.get(&key).cloned().unwrap_or(JsonValue::Null);
+        if left != right {
+            fields.insert(
+                key,
+                DriftField {
+                    original: left,
+                    replayed: right,
+                },
+            );
+        }
+    }
+
+    DriftReport {
+        changed: !fields.is_empty(),
+        fields,
+    }
+}

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -348,6 +348,12 @@ async fn main() {
         Command::Portal(args) => {
             commands::portal::run_portal(&args.dir, &args.host, args.port, args.open).await
         }
+        Command::Trigger(args) => {
+            if let Err(error) = commands::trigger::handle(args).await {
+                eprintln!("error: {error}");
+                process::exit(1);
+            }
+        }
         Command::Orchestrator(args) => {
             if let Err(error) = commands::orchestrator::handle(args).await {
                 eprintln!("error: {error}");

--- a/crates/harn-cli/tests/trigger_replay_cli.rs
+++ b/crates/harn-cli/tests/trigger_replay_cli.rs
@@ -31,6 +31,7 @@ kind = "webhook"
 provider = "github"
 match = { events = ["issues.opened"] }
 handler = "handlers::on_issue"
+secrets = { signing_secret = "github/webhook-secret" }
 "#,
     );
 }

--- a/crates/harn-cli/tests/trigger_replay_cli.rs
+++ b/crates/harn-cli/tests/trigger_replay_cli.rs
@@ -1,0 +1,202 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+fn write_file(dir: &Path, relative: &str, contents: &str) {
+    let path = dir.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+fn write_manifest(dir: &Path) {
+    write_file(
+        dir,
+        "harn.toml",
+        r#"
+[package]
+name = "fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "github-new-issue"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "handlers::on_issue"
+"#,
+    );
+}
+
+fn write_seed_script(dir: &Path, dedupe_key: &str) {
+    write_file(
+        dir,
+        "seed.harn",
+        &format!(
+            r#"
+import "std/triggers"
+
+pipeline default() {{
+  println(json_stringify(trigger_fire("github-new-issue", {{
+    provider: "github",
+    kind: "issues.opened",
+    dedupe_key: "{dedupe_key}",
+    provider_payload: {{
+      provider: "github",
+      event: "issues",
+      action: "opened",
+      delivery_id: "{dedupe_key}",
+      installation_id: 42,
+      raw: {{ action: "opened" }},
+    }},
+    signature_status: {{ state: "verified" }},
+  }})))
+}}
+"#
+        ),
+    );
+}
+
+fn run_harn(temp: &TempDir, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn seed_event(temp: &TempDir, dedupe_key: &str) -> serde_json::Value {
+    write_seed_script(temp.path(), dedupe_key);
+    let output = run_harn(temp, &["run", "seed.harn"]);
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        stdout(&output),
+        stderr(&output)
+    );
+    serde_json::from_str(stdout(&output).trim()).unwrap()
+}
+
+#[test]
+fn trigger_replay_diff_reports_structured_drift() {
+    let temp = TempDir::new().unwrap();
+    write_manifest(temp.path());
+    write_file(
+        temp.path(),
+        "lib.harn",
+        r#"
+import "std/triggers"
+
+pub fn on_issue(event: TriggerEvent) -> dict {
+  return {
+    event_id: event.id,
+    replay_env: env("HARN_REPLAY"),
+  }
+}
+"#,
+    );
+
+    let seeded = seed_event(&temp, "delivery-diff");
+    let event_id = seeded["event_id"].as_str().unwrap().to_string();
+
+    let output = run_harn(&temp, &["trigger", "replay", &event_id, "--diff"]);
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        stdout(&output),
+        stderr(&output)
+    );
+
+    let report: serde_json::Value = serde_json::from_str(&stdout(&output)).unwrap();
+    assert_eq!(report["event_id"].as_str(), Some(event_id.as_str()));
+    assert_eq!(report["replay"]["status"].as_str(), Some("succeeded"));
+    assert_eq!(report["original"]["status"].as_str(), Some("succeeded"));
+    assert_eq!(report["drift"]["changed"].as_bool(), Some(true));
+    assert_eq!(
+        report["drift"]["fields"]["result"]["original"]["replay_env"],
+        serde_json::Value::Null
+    );
+    assert_eq!(
+        report["drift"]["fields"]["result"]["replayed"]["replay_env"],
+        serde_json::json!("1")
+    );
+}
+
+#[test]
+fn trigger_replay_as_of_uses_historical_binding_version() {
+    let temp = TempDir::new().unwrap();
+    write_manifest(temp.path());
+    write_file(
+        temp.path(),
+        "lib.harn",
+        r#"
+import "std/triggers"
+
+pub fn on_issue(event: TriggerEvent) -> dict {
+  return { version: "v1" }
+}
+"#,
+    );
+
+    let seeded = seed_event(&temp, "delivery-as-of-v1");
+    let event_id = seeded["event_id"].as_str().unwrap().to_string();
+    let as_of = OffsetDateTime::now_utc();
+    std::thread::sleep(std::time::Duration::from_millis(10));
+
+    write_file(
+        temp.path(),
+        "lib.harn",
+        r#"
+import "std/triggers"
+
+pub fn on_issue(event: TriggerEvent) -> dict {
+  return { version: "v2" }
+}
+"#,
+    );
+    let _ = seed_event(&temp, "delivery-as-of-v2");
+
+    write_file(
+        temp.path(),
+        "lib.harn",
+        r#"
+import "std/triggers"
+
+pub fn on_issue(event: TriggerEvent) -> dict {
+  return { version: "v1" }
+}
+"#,
+    );
+
+    let as_of = as_of.format(&Rfc3339).unwrap();
+    let output = run_harn(&temp, &["trigger", "replay", &event_id, "--as-of", &as_of]);
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        stdout(&output),
+        stderr(&output)
+    );
+
+    let report: serde_json::Value = serde_json::from_str(&stdout(&output)).unwrap();
+    assert_eq!(report["binding_version"].as_u64(), Some(1));
+    assert_eq!(report["replay"]["result"]["version"].as_str(), Some("v1"));
+    assert_eq!(report["as_of"].as_str(), Some(as_of.as_str()));
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -77,20 +77,21 @@ pub use stdlib::{
 };
 pub use store::register_store_builtins;
 pub use triggers::{
-    begin_in_flight, clear_dispatcher_state, clear_trigger_registry, drain, dynamic_deregister,
-    dynamic_register, finish_in_flight, install_manifest_triggers, pin_trigger_binding,
-    provider_metadata, redact_headers, register_provider_schema, registered_provider_metadata,
-    registered_provider_schema_names, reset_provider_catalog, resolve_live_trigger_binding,
-    run_trigger_harness_fixture, snapshot_dispatcher_stats, snapshot_trigger_bindings,
-    unpin_trigger_binding, DispatchError, DispatchOutcome, DispatchStatus, Dispatcher,
-    DispatcherDrainReport, DispatcherStatsSnapshot, HeaderRedactionPolicy, InboxIndex,
-    ProviderCatalog, ProviderCatalogError, ProviderId, ProviderMetadata, ProviderOutboundMethod,
-    ProviderPayload, ProviderRuntimeMetadata, ProviderSchema, ProviderSecretRequirement,
-    RetryPolicy, SignatureStatus, SignatureVerificationMetadata, TenantId, TraceId,
-    TriggerBindingSnapshot, TriggerBindingSource, TriggerBindingSpec, TriggerDispatchOutcome,
-    TriggerEvent, TriggerEventId, TriggerHandlerSpec, TriggerHarnessResult, TriggerId,
-    TriggerMetricsSnapshot, TriggerPredicateSpec, TriggerRegistryError, TriggerRetryConfig,
-    TriggerState, DEFAULT_INBOX_RETENTION_DAYS, TRIGGER_INBOX_TOPIC, TRIGGER_TEST_FIXTURES,
+    begin_in_flight, binding_version_as_of, clear_dispatcher_state, clear_trigger_registry, drain,
+    dynamic_deregister, dynamic_register, finish_in_flight, install_manifest_triggers,
+    pin_trigger_binding, provider_metadata, redact_headers, register_provider_schema,
+    registered_provider_metadata, registered_provider_schema_names, reset_provider_catalog,
+    resolve_live_trigger_binding, resolve_trigger_binding_as_of, run_trigger_harness_fixture,
+    snapshot_dispatcher_stats, snapshot_trigger_bindings, unpin_trigger_binding, DispatchError,
+    DispatchOutcome, DispatchStatus, Dispatcher, DispatcherDrainReport, DispatcherStatsSnapshot,
+    HeaderRedactionPolicy, InboxIndex, ProviderCatalog, ProviderCatalogError, ProviderId,
+    ProviderMetadata, ProviderOutboundMethod, ProviderPayload, ProviderRuntimeMetadata,
+    ProviderSchema, ProviderSecretRequirement, RetryPolicy, SignatureStatus,
+    SignatureVerificationMetadata, TenantId, TraceId, TriggerBindingSnapshot, TriggerBindingSource,
+    TriggerBindingSpec, TriggerDispatchOutcome, TriggerEvent, TriggerEventId, TriggerHandlerSpec,
+    TriggerHarnessResult, TriggerId, TriggerMetricsSnapshot, TriggerPredicateSpec,
+    TriggerRegistryError, TriggerRetryConfig, TriggerState, DEFAULT_INBOX_RETENTION_DAYS,
+    TRIGGER_INBOX_TOPIC, TRIGGER_TEST_FIXTURES,
 };
 pub use value::*;
 pub use vm::*;

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -1,7 +1,9 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -39,6 +41,7 @@ const TRIGGER_OUTBOX_TOPIC: &str = "trigger.outbox";
 const TRIGGER_ATTEMPTS_TOPIC: &str = "trigger.attempts";
 const TRIGGER_DLQ_TOPIC: &str = "trigger.dlq";
 const TRIGGERS_LIFECYCLE_TOPIC: &str = "triggers.lifecycle";
+const HARN_REPLAY_ENV: &str = "HARN_REPLAY";
 
 thread_local! {
     static ACTIVE_DISPATCHER_STATE: RefCell<Option<Arc<DispatcherRuntimeState>>> = const { RefCell::new(None) };
@@ -432,6 +435,17 @@ impl Dispatcher {
     }
 
     async fn dispatch_with_replay(
+        &self,
+        binding: &TriggerBinding,
+        event: TriggerEvent,
+        replay_of_event_id: Option<String>,
+    ) -> Result<DispatchOutcome, DispatchError> {
+        let _replay_guard = ReplayEnvGuard::enter(replay_of_event_id.is_some());
+        self.dispatch_with_replay_inner(binding, event, replay_of_event_id)
+            .await
+    }
+
+    async fn dispatch_with_replay_inner(
         &self,
         binding: &TriggerBinding,
         event: TriggerEvent,
@@ -1362,6 +1376,65 @@ fn now_rfc3339() -> String {
     time::OffsetDateTime::now_utc()
         .format(&time::format_description::well_known::Rfc3339)
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+#[derive(Default)]
+struct ReplayEnvState {
+    depth: usize,
+    previous: Option<OsString>,
+}
+
+struct ReplayEnvGuard {
+    active: bool,
+}
+
+impl ReplayEnvGuard {
+    fn enter(active: bool) -> Self {
+        if !active {
+            return Self { active: false };
+        }
+
+        let lock = replay_env_state()
+            .lock()
+            .expect("replay env state mutex poisoned");
+        let mut state = lock;
+        if state.depth == 0 {
+            state.previous = std::env::var_os(HARN_REPLAY_ENV);
+            std::env::set_var(HARN_REPLAY_ENV, "1");
+        }
+        state.depth += 1;
+        drop(state);
+
+        Self { active: true }
+    }
+}
+
+impl Drop for ReplayEnvGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+
+        let lock = replay_env_state()
+            .lock()
+            .expect("replay env state mutex poisoned");
+        let mut state = lock;
+        if state.depth > 0 {
+            state.depth -= 1;
+        }
+        if state.depth == 0 {
+            if let Some(previous) = state.previous.take() {
+                std::env::set_var(HARN_REPLAY_ENV, previous);
+            } else {
+                std::env::remove_var(HARN_REPLAY_ENV);
+            }
+        }
+    }
+}
+
+fn replay_env_state() -> &'static Mutex<ReplayEnvState> {
+    static STATE: OnceLock<Mutex<ReplayEnvState>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(ReplayEnvState::default()))
 }
 
 async fn sleep_or_cancel(

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -3,6 +3,7 @@ use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::mpsc::{self, Receiver};
 use std::sync::Arc;
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -309,6 +310,11 @@ fn write_json_response(stream: &mut TcpStream, body: &serde_json::Value) {
     stream.flush().expect("flush mock A2A response");
 }
 
+fn replay_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn local_handler_round_trip_logs_outbox_lifecycle_and_action_graph() {
     let local = tokio::task::LocalSet::new();
@@ -590,6 +596,47 @@ pub fn local_fn(event: TriggerEvent) -> dict {
             }));
         })
         .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn replay_dispatch_sets_harn_replay_env_and_restores_previous_value() {
+    let _env_guard = replay_env_lock().lock().expect("env lock poisoned");
+    std::env::set_var("HARN_REPLAY", "outer");
+
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (_dir, _log, dispatcher) = dispatcher_fixture(
+                r#"
+import "std/triggers"
+
+pub fn local_fn(event: TriggerEvent) -> string {
+  return env_or("HARN_REPLAY", "missing")
+}
+"#,
+                "local_fn",
+                None,
+                TriggerRetryConfig::default(),
+            )
+            .await;
+
+            let binding =
+                resolve_live_trigger_binding("github-new-issue", None).expect("resolve binding");
+            let outcome = dispatcher
+                .dispatch_replay(
+                    &binding,
+                    trigger_event("issues.opened", "delivery-env"),
+                    "event-original".to_string(),
+                )
+                .await
+                .expect("replay succeeds");
+
+            assert_eq!(outcome.result, Some(serde_json::json!("1")));
+            assert_eq!(std::env::var("HARN_REPLAY").ok().as_deref(), Some("outer"));
+        })
+        .await;
+
+    std::env::remove_var("HARN_REPLAY");
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -1,3 +1,10 @@
+// Replay tests serialize HARN_REPLAY env-var manipulation with a `Mutex<()>`
+// so parallel test runs don't race. That guard is intentionally held across
+// `.await` points while driving the dispatcher; silence clippy rather than
+// introduce an async-aware mutex whose only purpose is to guard env state.
+// Same pattern as `crates/harn-cli/tests/orchestrator_http.rs`.
+#![allow(clippy::await_holding_lock)]
+
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};

--- a/crates/harn-vm/src/triggers/mod.rs
+++ b/crates/harn-vm/src/triggers/mod.rs
@@ -20,10 +20,11 @@ pub use event::{
 };
 pub use inbox::{InboxIndex, DEFAULT_INBOX_RETENTION_DAYS, TRIGGER_INBOX_TOPIC};
 pub use registry::{
-    begin_in_flight, clear_trigger_registry, drain, dynamic_deregister, dynamic_register,
-    finish_in_flight, install_manifest_triggers, pin_trigger_binding, resolve_live_trigger_binding,
-    snapshot_trigger_bindings, unpin_trigger_binding, TriggerBindingSnapshot, TriggerBindingSource,
-    TriggerBindingSpec, TriggerDispatchOutcome, TriggerHandlerSpec, TriggerId,
-    TriggerMetricsSnapshot, TriggerPredicateSpec, TriggerRegistryError, TriggerState,
+    begin_in_flight, binding_version_as_of, clear_trigger_registry, drain, dynamic_deregister,
+    dynamic_register, finish_in_flight, install_manifest_triggers, pin_trigger_binding,
+    resolve_live_trigger_binding, resolve_trigger_binding_as_of, snapshot_trigger_bindings,
+    unpin_trigger_binding, TriggerBindingSnapshot, TriggerBindingSource, TriggerBindingSpec,
+    TriggerDispatchOutcome, TriggerHandlerSpec, TriggerId, TriggerMetricsSnapshot,
+    TriggerPredicateSpec, TriggerRegistryError, TriggerState,
 };
 pub use test_util::{run_trigger_harness_fixture, TriggerHarnessResult, TRIGGER_TEST_FIXTURES};

--- a/crates/harn-vm/src/triggers/registry.rs
+++ b/crates/harn-vm/src/triggers/registry.rs
@@ -5,6 +5,8 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+
+use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::event_log::{active_event_log, AnyEventLog, EventLog, LogEvent, Topic};
@@ -329,6 +331,29 @@ thread_local! {
 
 const TERMINATED_VERSION_RETENTION_LIMIT: usize = 2;
 
+const TRIGGERS_LIFECYCLE_TOPIC: &str = "triggers.lifecycle";
+
+#[derive(Clone, Debug, Deserialize)]
+struct LifecycleStateTransitionRecord {
+    id: String,
+    version: u32,
+    #[serde(default)]
+    definition_fingerprint: Option<String>,
+    to_state: TriggerState,
+}
+
+#[derive(Clone, Debug)]
+struct HistoricalLifecycleRecord {
+    occurred_at_ms: i64,
+    transition: LifecycleStateTransitionRecord,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct HistoricalVersionLookup {
+    matching_version: Option<u32>,
+    max_version: Option<u32>,
+}
+
 pub fn clear_trigger_registry() {
     TRIGGER_REGISTRY.with(|slot| {
         *slot.borrow_mut() = TriggerRegistry::default();
@@ -351,6 +376,22 @@ pub fn snapshot_trigger_bindings() -> Vec<TriggerBindingSnapshot> {
                 .then(left.state.as_str().cmp(right.state.as_str()))
         });
         snapshots
+    })
+}
+
+#[allow(clippy::arc_with_non_send_sync)]
+pub fn resolve_trigger_binding_as_of(
+    id: &str,
+    as_of: OffsetDateTime,
+) -> Result<Arc<TriggerBinding>, TriggerRegistryError> {
+    let version = binding_version_as_of(id, as_of)?;
+    resolve_live_trigger_binding(id, Some(version))
+}
+
+pub fn binding_version_as_of(id: &str, as_of: OffsetDateTime) -> Result<u32, TriggerRegistryError> {
+    TRIGGER_REGISTRY.with(|slot| {
+        let registry = slot.borrow();
+        registry.binding_version_as_of(id, as_of)
     })
 }
 
@@ -485,14 +526,14 @@ pub async fn install_manifest_triggers(
                 registry.transition_binding_to_draining(&binding, &mut lifecycle);
             }
 
-            let version = registry.next_version_for_id(&id);
+            let version = registry.next_version_for_spec(&spec);
             registry.register_binding(spec, version, &mut lifecycle);
             touched_ids.insert(id.clone());
         }
 
         for spec in incoming.into_values() {
             touched_ids.insert(spec.id.clone());
-            let version = registry.next_version_for_id(&spec.id);
+            let version = registry.next_version_for_spec(&spec);
             registry.register_binding(spec, version, &mut lifecycle);
         }
 
@@ -523,7 +564,8 @@ pub async fn dynamic_register(
         }
 
         let mut lifecycle = Vec::new();
-        registry.register_binding(spec, 1, &mut lifecycle);
+        let version = registry.next_version_for_spec(&spec);
+        registry.register_binding(spec, version, &mut lifecycle);
         Ok((registry.event_log.clone(), lifecycle))
     })?;
 
@@ -712,12 +754,30 @@ impl TriggerRegistry {
             .collect()
     }
 
-    fn next_version_for_id(&self, id: &str) -> u32 {
+    fn next_version_for_spec(&self, spec: &TriggerBindingSpec) -> u32 {
+        if let Some(version) = self
+            .bindings
+            .get(spec.id.as_str())
+            .into_iter()
+            .flat_map(|bindings| bindings.iter())
+            .find(|binding| binding.definition_fingerprint == spec.definition_fingerprint)
+            .map(|binding| binding.version)
+        {
+            return version;
+        }
+
+        let historical =
+            self.historical_versions_for(spec.id.as_str(), spec.definition_fingerprint.as_str());
+        if let Some(version) = historical.matching_version {
+            return version;
+        }
+
         self.bindings
-            .get(id)
+            .get(spec.id.as_str())
             .into_iter()
             .flat_map(|bindings| bindings.iter())
             .map(|binding| binding.version)
+            .chain(historical.max_version)
             .max()
             .unwrap_or(0)
             + 1
@@ -742,6 +802,76 @@ impl TriggerRegistry {
         if bindings.is_empty() {
             self.bindings.remove(id);
         }
+    }
+
+    fn historical_versions_for(&self, id: &str, fingerprint: &str) -> HistoricalVersionLookup {
+        let mut lookup = HistoricalVersionLookup::default();
+        for record in self.lifecycle_records_for(id) {
+            lookup.max_version = Some(
+                lookup
+                    .max_version
+                    .unwrap_or(0)
+                    .max(record.transition.version),
+            );
+            if record.transition.definition_fingerprint.as_deref() == Some(fingerprint) {
+                lookup.matching_version = Some(record.transition.version);
+            }
+        }
+        lookup
+    }
+
+    fn binding_version_as_of(
+        &self,
+        id: &str,
+        as_of: OffsetDateTime,
+    ) -> Result<u32, TriggerRegistryError> {
+        let cutoff_ms = (as_of.unix_timestamp_nanos() / 1_000_000) as i64;
+        let mut active_version = None;
+        for record in self.lifecycle_records_for(id) {
+            if record.occurred_at_ms > cutoff_ms {
+                break;
+            }
+            match record.transition.to_state {
+                TriggerState::Active => active_version = Some(record.transition.version),
+                TriggerState::Draining | TriggerState::Terminated => {
+                    if active_version == Some(record.transition.version) {
+                        active_version = None;
+                    }
+                }
+                TriggerState::Registering => {}
+            }
+        }
+
+        active_version.ok_or_else(|| {
+            TriggerRegistryError::InvalidSpec(format!(
+                "no active trigger binding '{}' at {}",
+                id,
+                as_of
+                    .format(&time::format_description::well_known::Rfc3339)
+                    .unwrap_or_else(|_| as_of.to_string())
+            ))
+        })
+    }
+
+    fn lifecycle_records_for(&self, id: &str) -> Vec<HistoricalLifecycleRecord> {
+        let Some(event_log) = self.event_log.as_ref() else {
+            return Vec::new();
+        };
+        let topic = Topic::new(TRIGGERS_LIFECYCLE_TOPIC)
+            .expect("static triggers.lifecycle topic should always be valid");
+        futures::executor::block_on(event_log.read_range(&topic, None, usize::MAX))
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|(_, event)| {
+                let occurred_at_ms = event.occurred_at_ms;
+                let transition: LifecycleStateTransitionRecord =
+                    serde_json::from_value(event.payload).ok()?;
+                (transition.id == id).then_some(HistoricalLifecycleRecord {
+                    occurred_at_ms,
+                    transition,
+                })
+            })
+            .collect()
     }
 
     #[allow(clippy::arc_with_non_send_sync)]
@@ -821,6 +951,7 @@ fn lifecycle_event(
             "kind": &binding.kind,
             "source": binding.source.as_str(),
             "handler_kind": binding.handler.kind(),
+            "definition_fingerprint": &binding.definition_fingerprint,
             "from_state": from_state.map(TriggerState::as_str),
             "to_state": to_state.as_str(),
         }),
@@ -838,7 +969,7 @@ async fn append_lifecycle_events(
         return Ok(());
     }
 
-    let topic = Topic::new("triggers.lifecycle")
+    let topic = Topic::new(TRIGGERS_LIFECYCLE_TOPIC)
         .expect("static triggers.lifecycle topic should always be valid");
     for event in events {
         event_log
@@ -879,6 +1010,7 @@ fn now_ms() -> i64 {
 mod tests {
     use super::*;
     use crate::event_log::{install_default_for_base_dir, reset_active_event_log};
+    use time::OffsetDateTime;
 
     fn manifest_spec(id: &str, fingerprint: &str) -> TriggerBindingSpec {
         TriggerBindingSpec {
@@ -1103,6 +1235,70 @@ mod tests {
                 "draining".to_string(),
                 "terminated".to_string(),
             ]
+        );
+
+        reset_active_event_log();
+        clear_trigger_registry();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn version_history_reuses_historical_version_after_restart() {
+        clear_trigger_registry();
+        reset_active_event_log();
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        install_default_for_base_dir(tempdir.path()).expect("install event log");
+
+        install_manifest_triggers(vec![manifest_spec("github-new-issue", "v1")])
+            .await
+            .expect("initial manifest trigger installs");
+        install_manifest_triggers(vec![manifest_spec("github-new-issue", "v2")])
+            .await
+            .expect("updated manifest trigger installs");
+
+        clear_trigger_registry();
+        reset_active_event_log();
+        install_default_for_base_dir(tempdir.path()).expect("reopen event log");
+
+        install_manifest_triggers(vec![manifest_spec("github-new-issue", "v2")])
+            .await
+            .expect("manifest reload reuses historical version");
+
+        let binding = snapshot_trigger_bindings()
+            .into_iter()
+            .find(|binding| binding.id == "github-new-issue")
+            .expect("binding snapshot");
+        assert_eq!(binding.version, 2);
+
+        reset_active_event_log();
+        clear_trigger_registry();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn binding_version_as_of_reports_historical_active_version() {
+        clear_trigger_registry();
+        reset_active_event_log();
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        install_default_for_base_dir(tempdir.path()).expect("install event log");
+
+        install_manifest_triggers(vec![manifest_spec("github-new-issue", "v1")])
+            .await
+            .expect("initial manifest trigger installs");
+        let before_reload = OffsetDateTime::now_utc();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        install_manifest_triggers(vec![manifest_spec("github-new-issue", "v2")])
+            .await
+            .expect("updated manifest trigger installs");
+        let after_reload = OffsetDateTime::now_utc();
+
+        assert_eq!(
+            binding_version_as_of("github-new-issue", before_reload)
+                .expect("version before reload"),
+            1
+        );
+        assert_eq!(
+            binding_version_as_of("github-new-issue", after_reload).expect("version after reload"),
+            2
         );
 
         reset_active_event_log();


### PR DESCRIPTION
## Summary
- add a top-level `harn trigger replay <event-id>` command for replaying any recorded trigger event from an EventLog snapshot
- add `--diff` drift reporting and `--as-of <timestamp>` historical binding resolution via trigger lifecycle history
- set `HARN_REPLAY=1` during replay dispatch so runtime nondeterminism can fall back to recorded values

## Testing
- cargo fmt --all
- env CARGO_TARGET_DIR=/tmp/harn-issue-222-trigger-replay-vm cargo test -p harn-vm version_history_reuses_historical_version_after_restart -- --nocapture
- env CARGO_TARGET_DIR=/tmp/harn-issue-222-trigger-replay-vm cargo test -p harn-vm binding_version_as_of_reports_historical_active_version -- --nocapture
- env CARGO_TARGET_DIR=/tmp/harn-issue-222-trigger-replay-vm cargo test -p harn-vm replay_dispatch_emits_replay_chain_edge_and_headers -- --nocapture
- env CARGO_TARGET_DIR=/tmp/harn-issue-222-trigger-replay-vm cargo test -p harn-vm replay_dispatch_sets_harn_replay_env_and_restores_previous_value -- --nocapture
- env CARGO_TARGET_DIR=/tmp/harn-issue-222-trigger-replay-cli cargo test -p harn-cli --test trigger_replay_cli -- --nocapture