### PR TITLE
[codex] Harden orchestrator shutdown drain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "croner",
+ "futures",
  "harn-fmt",
  "harn-lexer",
  "harn-lint",

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -47,6 +47,7 @@ toml = "1.1"
 serde = { version = "1", features = ["derive"] }
 notify = "8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+futures = "0.3"
 sha2 = "0.11"
 subtle = "2.6"
 base64 = "0.22"

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -516,6 +516,9 @@ pub(crate) struct OrchestratorServeArgs {
     /// PEM-encoded private key for HTTPS termination.
     #[arg(long, env = "HARN_ORCHESTRATOR_KEY", value_name = "PATH")]
     pub key: Option<PathBuf>,
+    /// Seconds to wait for connector and dispatcher drain before forcing shutdown.
+    #[arg(long = "shutdown-timeout", default_value_t = 30, value_name = "SECS")]
+    pub shutdown_timeout: u64,
     /// Runtime role to boot. Multi-tenant is a stub for now.
     #[arg(
         long,
@@ -920,6 +923,8 @@ mod tests {
             "tls/cert.pem",
             "--key",
             "tls/key.pem",
+            "--shutdown-timeout",
+            "45",
             "--role",
             "single-tenant",
         ]);
@@ -935,6 +940,7 @@ mod tests {
         assert_eq!(serve.bind.to_string(), "0.0.0.0:8080");
         assert_eq!(serve.cert, Some(PathBuf::from("tls/cert.pem")));
         assert_eq!(serve.key, Some(PathBuf::from("tls/key.pem")));
+        assert_eq!(serve.shutdown_timeout, 45);
         assert_eq!(
             serve.role,
             crate::commands::orchestrator::role::OrchestratorRole::SingleTenant

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -128,9 +128,12 @@ impl ListenerRuntime {
         self.routes.reload(routes)
     }
 
-    pub(crate) async fn shutdown(self) -> Result<BTreeMap<String, TriggerMetricSnapshot>, String> {
+    pub(crate) async fn shutdown(
+        self,
+        timeout: Duration,
+    ) -> Result<BTreeMap<String, TriggerMetricSnapshot>, String> {
         let Self { server, routes } = self;
-        server.shutdown().await?;
+        server.shutdown(timeout).await?;
         Ok(routes.snapshot_metrics())
     }
 }

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -1056,7 +1056,10 @@ mod tests {
         assert_eq!(versions, vec![1, 2]);
         assert_eq!(task_ids, vec!["task-1".to_string(), "task-2".to_string()]);
 
-        listener.shutdown().await.expect("shutdown listener");
+        listener
+            .shutdown(Duration::from_secs(5))
+            .await
+            .expect("shutdown listener");
         std::env::remove_var(REQUEST_DELAY_ENV);
         reset_active_event_log();
         harn_vm::clear_trigger_registry();

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -2,12 +2,15 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
-use serde::Serialize;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
+use tokio::sync::watch;
 
 use harn_vm::event_log::EventLog;
 
@@ -23,9 +26,17 @@ use crate::package::{
 const LIFECYCLE_TOPIC: &str = "orchestrator.lifecycle";
 const MANIFEST_TOPIC: &str = "orchestrator.manifest";
 const STATE_SNAPSHOT_FILE: &str = "orchestrator-state.json";
+const PENDING_TOPIC: &str = "orchestrator.triggers.pending";
+const CRON_TICK_TOPIC: &str = "connectors.cron.tick";
 
 pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
+    let local = tokio::task::LocalSet::new();
+    local.run_until(async move { run_local(args).await }).await
+}
+
+async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
     harn_vm::reset_thread_local_state();
+    let shutdown_timeout = Duration::from_secs(args.shutdown_timeout.max(1));
 
     let tls = TlsFiles::from_args(args.cert.clone(), args.key.clone())?;
     let config_path = absolutize_from_cwd(&args.local.config)?;
@@ -115,6 +126,11 @@ pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
         format_activation_summary(&connector_runtime.activations)
     );
 
+    let dispatcher = harn_vm::Dispatcher::with_event_log(vm, event_log.clone());
+    let pending_pump = spawn_pending_pump(event_log.clone(), dispatcher.clone())?;
+    let cron_pump = spawn_cron_pump(event_log.clone(), dispatcher.clone())?;
+    let inbox_pump = spawn_inbox_pump(event_log.clone(), dispatcher.clone())?;
+
     let listener = ListenerRuntime::start(ListenerConfig {
         bind: args.bind,
         tls,
@@ -173,6 +189,7 @@ pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
             "trigger_count": live_triggers.len(),
             "connector_count": connector_runtime.providers.len(),
             "tls_enabled": listener.scheme() == "https",
+            "shutdown_timeout_secs": shutdown_timeout.as_secs(),
         }),
     )
     .await?;
@@ -205,14 +222,20 @@ pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
             secret_chain_display: &secret_chain_display,
             triggers: &live_triggers,
             connectors: &connector_runtime,
+            shutdown_timeout,
         },
         listener,
+        dispatcher,
+        pending_pump,
+        cron_pump,
+        inbox_pump,
     )
     .await
 }
 
 struct ConnectorRuntime {
     _registry: harn_vm::ConnectorRegistry,
+    handles: Vec<harn_vm::connectors::ConnectorHandle>,
     providers: Vec<String>,
     activations: Vec<harn_vm::ActivationHandle>,
 }
@@ -269,6 +292,7 @@ async fn initialize_connectors(
     // referenced by a trigger but *not* already in the catalog
     // (skip-if-already-registered).
     let mut providers = Vec::new();
+    let mut handles = Vec::new();
     for (provider, kinds) in grouped_kinds {
         let provider_name = provider.as_str().to_string();
         if registry.get(&provider).is_none() {
@@ -286,6 +310,7 @@ async fn initialize_connectors(
             .init(ctx.clone())
             .await
             .map_err(|error| error.to_string())?;
+        handles.push(handle.clone());
         providers.push(provider_name);
     }
 
@@ -296,6 +321,7 @@ async fn initialize_connectors(
 
     Ok(ConnectorRuntime {
         _registry: registry,
+        handles,
         providers,
         activations,
     })
@@ -473,6 +499,172 @@ fn handler_kind(handler: &CollectedTriggerHandler) -> &'static str {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PumpMode {
+    Running,
+    Draining { up_to: u64 },
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct PumpStats {
+    last_seen: u64,
+    processed: u64,
+}
+
+struct PumpHandle {
+    mode_tx: watch::Sender<PumpMode>,
+    join: tokio::task::JoinHandle<Result<PumpStats, String>>,
+}
+
+impl PumpHandle {
+    async fn drain(self, up_to: u64) -> Result<PumpStats, String> {
+        let _ = self.mode_tx.send(PumpMode::Draining { up_to });
+        match self.join.await {
+            Ok(result) => result,
+            Err(error) => Err(format!("pump task join failed: {error}")),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct PendingTriggerRecord {
+    trigger_id: String,
+    binding_version: u32,
+    event: harn_vm::TriggerEvent,
+}
+
+fn spawn_pending_pump(
+    event_log: Arc<harn_vm::event_log::AnyEventLog>,
+    dispatcher: harn_vm::Dispatcher,
+) -> Result<PumpHandle, String> {
+    let topic = harn_vm::event_log::Topic::new(PENDING_TOPIC).map_err(|error| error.to_string())?;
+    spawn_topic_pump(event_log, topic, move |logged| {
+        let dispatcher = dispatcher.clone();
+        async move {
+            if logged.kind != "trigger_event" {
+                return Ok(false);
+            }
+            let record: PendingTriggerRecord = serde_json::from_value(logged.payload)
+                .map_err(|error| format!("failed to decode pending trigger event: {error}"))?;
+            dispatcher
+                .enqueue_targeted(
+                    Some(record.trigger_id),
+                    Some(record.binding_version),
+                    record.event,
+                )
+                .await
+                .map_err(|error| format!("failed to enqueue pending trigger event: {error}"))?;
+            Ok(true)
+        }
+    })
+}
+
+fn spawn_cron_pump(
+    event_log: Arc<harn_vm::event_log::AnyEventLog>,
+    dispatcher: harn_vm::Dispatcher,
+) -> Result<PumpHandle, String> {
+    let topic =
+        harn_vm::event_log::Topic::new(CRON_TICK_TOPIC).map_err(|error| error.to_string())?;
+    spawn_topic_pump(event_log, topic, move |logged| {
+        let dispatcher = dispatcher.clone();
+        async move {
+            if logged.kind != "trigger_event" {
+                return Ok(false);
+            }
+            let event: harn_vm::TriggerEvent = serde_json::from_value(logged.payload)
+                .map_err(|error| format!("failed to decode cron trigger event: {error}"))?;
+            let trigger_id = match &event.provider_payload {
+                harn_vm::ProviderPayload::Known(
+                    harn_vm::triggers::event::KnownProviderPayload::Cron(payload),
+                ) => payload.cron_id.clone(),
+                _ => None,
+            };
+            dispatcher
+                .enqueue_targeted(trigger_id, None, event)
+                .await
+                .map_err(|error| format!("failed to enqueue cron trigger event: {error}"))?;
+            Ok(true)
+        }
+    })
+}
+
+fn spawn_inbox_pump(
+    event_log: Arc<harn_vm::event_log::AnyEventLog>,
+    dispatcher: harn_vm::Dispatcher,
+) -> Result<PumpHandle, String> {
+    let topic = harn_vm::event_log::Topic::new(harn_vm::TRIGGER_INBOX_TOPIC)
+        .map_err(|error| error.to_string())?;
+    spawn_topic_pump(event_log, topic, move |logged| {
+        let dispatcher = dispatcher.clone();
+        async move {
+            if logged.kind != "event_ingested" {
+                return Ok(false);
+            }
+            let envelope: harn_vm::triggers::dispatcher::InboxEnvelope =
+                serde_json::from_value(logged.payload)
+                    .map_err(|error| format!("failed to decode dispatcher inbox event: {error}"))?;
+            tokio::task::spawn_local(async move {
+                let _ = dispatcher.dispatch_inbox_envelope(envelope).await;
+            });
+            Ok(true)
+        }
+    })
+}
+
+fn spawn_topic_pump<F, Fut>(
+    event_log: Arc<harn_vm::event_log::AnyEventLog>,
+    topic: harn_vm::event_log::Topic,
+    process: F,
+) -> Result<PumpHandle, String>
+where
+    F: Fn(harn_vm::event_log::LogEvent) -> Fut + 'static,
+    Fut: std::future::Future<Output = Result<bool, String>> + 'static,
+{
+    let (mode_tx, mut mode_rx) = watch::channel(PumpMode::Running);
+    let join = tokio::task::spawn_local(async move {
+        let start_from = event_log
+            .latest(&topic)
+            .await
+            .map_err(|error| format!("failed to read topic head {topic}: {error}"))?;
+        let mut stream = event_log
+            .clone()
+            .subscribe(&topic, start_from)
+            .await
+            .map_err(|error| format!("failed to subscribe topic {topic}: {error}"))?;
+        let mut stats = PumpStats {
+            last_seen: start_from.unwrap_or(0),
+            processed: 0,
+        };
+        loop {
+            if matches!(*mode_rx.borrow(), PumpMode::Draining { up_to } if stats.last_seen >= up_to)
+            {
+                break;
+            }
+            tokio::select! {
+                changed = mode_rx.changed() => {
+                    if changed.is_err() {
+                        break;
+                    }
+                }
+                received = stream.next() => {
+                    let Some(received) = received else {
+                        break;
+                    };
+                    let (event_id, logged) = received
+                        .map_err(|error| format!("topic pump read failed for {topic}: {error}"))?;
+                    let handled = process(logged).await?;
+                    stats.last_seen = event_id;
+                    if handled {
+                        stats.processed += 1;
+                    }
+                }
+            }
+        }
+        Ok(stats)
+    });
+    Ok(PumpHandle { mode_tx, join })
+}
+
 fn trigger_kind_name(kind: crate::package::TriggerKind) -> &'static str {
     match kind {
         crate::package::TriggerKind::Webhook => "webhook",
@@ -487,29 +679,84 @@ fn trigger_kind_name(kind: crate::package::TriggerKind) -> &'static str {
 async fn graceful_shutdown(
     ctx: GracefulShutdownCtx<'_>,
     listener: ListenerRuntime,
+    dispatcher: harn_vm::Dispatcher,
+    pending_pump: PumpHandle,
+    cron_pump: PumpHandle,
+    inbox_pump: PumpHandle,
 ) -> Result<(), String> {
     eprintln!("[harn] signal received, starting graceful shutdown...");
-    // TODO(O-06): replace this listener-local scan with the shared
-    // orchestrator drain coordinator when that lands on the main branch.
-    let drained_events = listener
+    let listener_in_flight = listener
         .trigger_metrics()
         .into_values()
         .map(|metrics| metrics.in_flight)
         .sum::<u64>();
-    let listener_metrics = listener.shutdown().await?;
-
-    let stopped_at = now_rfc3339()?;
+    let dispatcher_before = dispatcher.snapshot();
     append_lifecycle_event(
         ctx.event_log,
-        "shutdown",
+        "draining",
         json!({
             "bind": ctx.bind.to_string(),
-            "drained_events": drained_events,
             "role": ctx.role.as_str(),
-            "status": "stopped",
+            "status": "draining",
+            "http_in_flight": listener_in_flight,
+            "dispatcher_in_flight": dispatcher_before.in_flight,
+            "dispatcher_retry_queue_depth": dispatcher_before.retry_queue_depth,
+            "dispatcher_dlq_depth": dispatcher_before.dlq_depth,
+            "shutdown_timeout_secs": ctx.shutdown_timeout.as_secs(),
         }),
     )
     .await?;
+
+    let deadline = tokio::time::Instant::now() + ctx.shutdown_timeout;
+    let listener_metrics = listener.shutdown(remaining_budget(deadline)).await?;
+    for handle in &ctx.connectors.handles {
+        let connector = handle.lock().await;
+        if let Err(error) = connector.shutdown(remaining_budget(deadline)).await {
+            eprintln!(
+                "[harn] connector {} shutdown warning: {error}",
+                connector.provider_id().as_str()
+            );
+        }
+    }
+
+    let pending_stats = pending_pump
+        .drain(topic_latest_id(ctx.event_log, PENDING_TOPIC).await?)
+        .await?;
+    let cron_stats = cron_pump
+        .drain(topic_latest_id(ctx.event_log, CRON_TICK_TOPIC).await?)
+        .await?;
+    let inbox_stats = inbox_pump
+        .drain(topic_latest_id(ctx.event_log, harn_vm::TRIGGER_INBOX_TOPIC).await?)
+        .await?;
+    let drain_report = dispatcher
+        .drain(remaining_budget(deadline))
+        .await
+        .map_err(|error| format!("failed to drain dispatcher: {error}"))?;
+
+    let stopped_at = now_rfc3339()?;
+    let timed_out = !drain_report.drained;
+    append_lifecycle_event(
+        ctx.event_log,
+        "stopped",
+        json!({
+            "bind": ctx.bind.to_string(),
+            "role": ctx.role.as_str(),
+            "status": "stopped",
+            "http_in_flight": listener_in_flight,
+            "dispatcher_in_flight": drain_report.in_flight,
+            "dispatcher_retry_queue_depth": drain_report.retry_queue_depth,
+            "dispatcher_dlq_depth": drain_report.dlq_depth,
+            "pending_events_drained": pending_stats.processed,
+            "cron_events_drained": cron_stats.processed,
+            "inbox_events_drained": inbox_stats.processed,
+            "timed_out": timed_out,
+        }),
+    )
+    .await?;
+    ctx.event_log
+        .flush()
+        .await
+        .map_err(|error| format!("failed to flush event log: {error}"))?;
 
     write_state_snapshot(
         &ctx.state_dir.join(STATE_SNAPSHOT_FILE),
@@ -542,6 +789,12 @@ async fn graceful_shutdown(
         },
     )?;
 
+    if timed_out {
+        eprintln!(
+            "[harn] graceful shutdown timed out with {} dispatches and {} retry waits remaining",
+            drain_report.in_flight, drain_report.retry_queue_depth
+        );
+    }
     eprintln!("[harn] graceful shutdown complete");
     Ok(())
 }
@@ -570,6 +823,21 @@ async fn append_manifest_event(
         .await
         .map(|_| ())
         .map_err(|error| format!("failed to append orchestrator manifest event: {error}"))
+}
+
+async fn topic_latest_id(
+    log: &Arc<harn_vm::event_log::AnyEventLog>,
+    topic_name: &str,
+) -> Result<u64, String> {
+    let topic = harn_vm::event_log::Topic::new(topic_name).map_err(|error| error.to_string())?;
+    log.latest(&topic)
+        .await
+        .map(|value| value.unwrap_or(0))
+        .map_err(|error| format!("failed to read topic head for {topic_name}: {error}"))
+}
+
+fn remaining_budget(deadline: tokio::time::Instant) -> Duration {
+    deadline.saturating_duration_since(tokio::time::Instant::now())
 }
 
 struct RuntimeSignalCtx<'a> {
@@ -834,6 +1102,7 @@ struct GracefulShutdownCtx<'a> {
     secret_chain_display: &'a str,
     triggers: &'a [CollectedManifestTrigger],
     connectors: &'a ConnectorRuntime,
+    shutdown_timeout: Duration,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/harn-cli/src/commands/orchestrator/tls.rs
+++ b/crates/harn-cli/src/commands/orchestrator/tls.rs
@@ -82,8 +82,8 @@ impl ServerRuntime {
         self.tls_enabled
     }
 
-    pub(crate) async fn shutdown(self) -> Result<(), String> {
-        self.handle.graceful_shutdown(Some(Duration::from_secs(30)));
+    pub(crate) async fn shutdown(self, timeout: Duration) -> Result<(), String> {
+        self.handle.graceful_shutdown(Some(timeout));
         match self.task.await {
             Ok(result) => result,
             Err(error) => Err(format!("listener task join failed: {error}")),

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -8,6 +8,8 @@ use std::sync::mpsc::{self, Receiver};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use harn_vm::event_log::{EventLog, EventLogBackendKind, EventLogConfig, Topic};
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use tempfile::TempDir;
 
 const STARTUP_NEEDLE: &str = "HTTP listener ready on";
@@ -22,7 +24,16 @@ fn write_file(dir: &Path, relative: &str, contents: &str) {
 }
 
 fn spawn_orchestrator(temp: &TempDir) -> (Child, Receiver<String>, thread::JoinHandle<String>) {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_harn"))
+    spawn_orchestrator_with(temp, &[], &[])
+}
+
+fn spawn_orchestrator_with(
+    temp: &TempDir,
+    extra_args: &[&str],
+    envs: &[(&str, &str)],
+) -> (Child, Receiver<String>, thread::JoinHandle<String>) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_harn"));
+    child
         .current_dir(temp.path())
         .arg("orchestrator")
         .arg("serve")
@@ -32,10 +43,17 @@ fn spawn_orchestrator(temp: &TempDir) -> (Child, Receiver<String>, thread::JoinH
         .arg("./state")
         .arg("--role")
         .arg("single-tenant")
+        .arg("--bind")
+        .arg("127.0.0.1:0")
         .stderr(Stdio::piped())
-        .stdout(Stdio::null())
-        .spawn()
-        .unwrap();
+        .stdout(Stdio::null());
+    for arg in extra_args {
+        child.arg(arg);
+    }
+    for (key, value) in envs {
+        child.env(key, value);
+    }
+    let mut child = child.spawn().unwrap();
 
     let stderr = child.stderr.take().expect("stderr pipe");
     let (tx, rx) = mpsc::channel();
@@ -72,6 +90,32 @@ fn wait_for_log_line(child: &mut Child, rx: &Receiver<String>, needle: &str) {
     panic!("timed out waiting for '{needle}'");
 }
 
+fn wait_for_listener_url(child: &mut Child, rx: &Receiver<String>) -> String {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(line) if line.contains(STARTUP_NEEDLE) => {
+                return line
+                    .split(STARTUP_NEEDLE)
+                    .nth(1)
+                    .expect("startup URL suffix")
+                    .trim()
+                    .to_string();
+            }
+            Ok(_) => continue,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if let Some(status) = child.try_wait().unwrap() {
+                    panic!("process exited before listener became ready: {status}");
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("stderr stream closed before listener became ready");
+            }
+        }
+    }
+    panic!("timed out waiting for listener URL");
+}
+
 fn send_sigterm(child: &Child) {
     let status = Command::new("kill")
         .arg("-TERM")
@@ -91,6 +135,47 @@ fn wait_for_exit(child: &mut Child) {
         thread::sleep(Duration::from_millis(100));
     }
     panic!("timed out waiting for orchestrator exit");
+}
+
+fn json_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers
+}
+
+fn bearer_headers() -> HeaderMap {
+    let mut headers = json_headers();
+    headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer test-key"));
+    headers
+}
+
+fn read_topic_events(
+    state_dir: &Path,
+    topic_name: &str,
+) -> Vec<(u64, harn_vm::event_log::LogEvent)> {
+    let mut config = EventLogConfig::for_base_dir(state_dir).unwrap();
+    let file_dir = state_dir.join("events");
+    if file_dir.join("topics").is_dir() {
+        config.backend = EventLogBackendKind::File;
+        config.file_dir = file_dir;
+    }
+    let log = harn_vm::event_log::open_event_log(&config).unwrap();
+    let topic = Topic::new(topic_name).unwrap();
+    futures::executor::block_on(log.read_range(&topic, None, usize::MAX)).unwrap()
+}
+
+fn wait_for_topic_kind(state_dir: &Path, topic_name: &str, kind: &str) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if read_topic_events(state_dir, topic_name)
+            .iter()
+            .any(|(_, event)| event.kind == kind)
+        {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!("timed out waiting for {topic_name}/{kind}");
 }
 
 #[test]
@@ -147,5 +232,95 @@ pub fn on_issue(event: TriggerEvent) {
     let snapshot = temp.path().join("state/orchestrator-state.json");
     let snapshot_contents = fs::read_to_string(&snapshot).unwrap();
     assert!(snapshot_contents.contains("\"status\": \"stopped\""));
-    assert!(snapshot_contents.contains("\"bind\": \"127.0.0.1:8080\""));
+    assert!(snapshot_contents.contains("\"bind\": \"127.0.0.1:"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn graceful_shutdown_drains_in_flight_dispatch_and_emits_lifecycle_events() {
+    let temp = TempDir::new().unwrap();
+    write_file(
+        temp.path(),
+        "harn.toml",
+        r#"
+[package]
+name = "fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "incoming-review-task"
+kind = "a2a-push"
+provider = "a2a-push"
+path = "/a2a/review"
+match = { events = ["a2a.task.received"] }
+handler = "handlers::on_task"
+"#,
+    );
+    write_file(
+        temp.path(),
+        "lib.harn",
+        r#"
+import "std/triggers"
+
+pub fn on_task(event: TriggerEvent) -> string {
+  sleep(1000)
+  return event.kind
+}
+"#,
+    );
+
+    let envs = [
+        ("HARN_EVENT_LOG_BACKEND", "file"),
+        ("HARN_ORCHESTRATOR_API_KEYS", "test-key"),
+        ("HARN_ORCHESTRATOR_HMAC_SECRET", "unused-shared-secret"),
+    ];
+    let (mut child, rx, handle) =
+        spawn_orchestrator_with(&temp, &["--shutdown-timeout", "5"], &envs);
+    let base_url = wait_for_listener_url(&mut child, &rx);
+    let state_dir = temp.path().join("state");
+
+    let body = br#"{"kind":"a2a.task.received","task":{"id":"task-123"}}"#;
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/a2a/review"))
+        .headers(bearer_headers())
+        .body(body.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    wait_for_topic_kind(&state_dir, "triggers.lifecycle", "DispatchStarted");
+    send_sigterm(&child);
+    wait_for_exit(&mut child);
+    let stderr = handle.join().expect("stderr collector thread");
+
+    assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
+
+    let lifecycle = read_topic_events(&state_dir, "orchestrator.lifecycle");
+    assert!(lifecycle.iter().any(|(_, event)| event.kind == "draining"));
+    assert!(lifecycle.iter().any(|(_, event)| {
+        event.kind == "stopped" && event.payload["timed_out"] == serde_json::json!(false)
+    }));
+
+    let inbox = read_topic_events(&state_dir, "trigger.inbox");
+    assert!(
+        inbox
+            .iter()
+            .any(|(_, event)| event.kind == "event_ingested"),
+        "inbox={inbox:?}"
+    );
+
+    let outbox = read_topic_events(&state_dir, "trigger.outbox");
+    assert!(outbox.iter().any(|(_, event)| {
+        event.kind == "dispatch_succeeded" && event.payload["result"] == serde_json::json!("push")
+    }));
+
+    let snapshot_contents =
+        fs::read_to_string(temp.path().join("state/orchestrator-state.json")).unwrap();
+    assert!(snapshot_contents.contains("\"status\": \"stopped\""));
+    assert!(
+        snapshot_contents.contains("\"in_flight\": 0"),
+        "snapshot={snapshot_contents}"
+    );
 }

--- a/crates/harn-vm/src/connectors/cron/mod.rs
+++ b/crates/harn-vm/src/connectors/cron/mod.rs
@@ -19,7 +19,7 @@ use crate::triggers::{
     DEFAULT_INBOX_RETENTION_DAYS,
 };
 
-use self::scheduler::{run_tick_loop, Clock, CronSchedule, RealClock, TickHandler};
+use self::scheduler::{run_tick_loop, Clock, CronSchedule, RealClock, ShutdownSignal, TickHandler};
 use self::state::{CronStateStore, PersistedCronState};
 
 pub(crate) mod scheduler;
@@ -48,6 +48,7 @@ pub struct CronConnector {
     clock: Arc<dyn Clock>,
     sink_override: Option<Arc<dyn CronEventSink>>,
     tasks: Mutex<Vec<JoinHandle<()>>>,
+    shutdown: Mutex<Arc<ShutdownSignal>>,
 }
 
 impl CronConnector {
@@ -64,6 +65,7 @@ impl CronConnector {
             clock,
             sink_override: None,
             tasks: Mutex::new(Vec::new()),
+            shutdown: Mutex::new(Arc::new(ShutdownSignal::default())),
         }
     }
 
@@ -84,6 +86,21 @@ impl CronConnector {
                 )
             })
     }
+
+    fn request_stop(&self) {
+        self.shutdown
+            .lock()
+            .expect("cron connector shutdown mutex poisoned")
+            .request_stop();
+    }
+
+    fn take_tasks(&self) -> Vec<JoinHandle<()>> {
+        self.tasks
+            .lock()
+            .expect("cron connector tasks mutex poisoned")
+            .drain(..)
+            .collect()
+    }
 }
 
 impl Default for CronConnector {
@@ -94,6 +111,7 @@ impl Default for CronConnector {
 
 impl Drop for CronConnector {
     fn drop(&mut self) {
+        self.request_stop();
         let mut tasks = self
             .tasks
             .lock()
@@ -127,6 +145,11 @@ impl Connector for CronConnector {
         bindings: &[TriggerBinding],
     ) -> Result<ActivationHandle, ConnectorError> {
         let ctx = self.context()?;
+        let shutdown = Arc::new(ShutdownSignal::default());
+        *self
+            .shutdown
+            .lock()
+            .expect("cron connector shutdown mutex poisoned") = shutdown.clone();
         let state_store = Arc::new(CronStateStore::new(ctx.event_log.clone()));
         let sink: Arc<dyn CronEventSink> = self.sink_override.clone().unwrap_or_else(|| {
             Arc::new(EventLogCronEventSink::new(
@@ -174,6 +197,7 @@ impl Connector for CronConnector {
                 sink,
                 state_store,
             });
+            let shutdown = shutdown.clone();
             let task = tokio::spawn(async move {
                 let _ = run_tick_loop(
                     handler.trigger.schedule.clone(),
@@ -181,6 +205,7 @@ impl Connector for CronConnector {
                     cursor,
                     catchup_ticks,
                     handler,
+                    shutdown,
                 )
                 .await;
             });
@@ -194,6 +219,30 @@ impl Connector for CronConnector {
             self.provider_id.clone(),
             bindings.len(),
         ))
+    }
+
+    async fn shutdown(&self, deadline: StdDuration) -> Result<(), ConnectorError> {
+        self.request_stop();
+        let pending = self.take_tasks();
+
+        if pending.is_empty() {
+            return Ok(());
+        }
+
+        let wait_all = async {
+            for task in pending {
+                let _ = task.await;
+            }
+        };
+        tokio::time::timeout(deadline, wait_all)
+            .await
+            .map_err(|_| {
+                ConnectorError::Activation(format!(
+                    "cron connector shutdown exceeded {}s",
+                    deadline.as_secs()
+                ))
+            })?;
+        Ok(())
     }
 
     fn normalize_inbound(&self, _raw: RawInbound) -> Result<TriggerEvent, ConnectorError> {

--- a/crates/harn-vm/src/connectors/cron/scheduler.rs
+++ b/crates/harn-vm/src/connectors/cron/scheduler.rs
@@ -1,10 +1,13 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
 use chrono_tz::Tz;
 use croner::Cron;
+use futures::pin_mut;
 use time::OffsetDateTime;
+use tokio::sync::Notify;
 
 use crate::connectors::ConnectorError;
 use crate::triggers::test_util::clock;
@@ -144,22 +147,58 @@ pub(crate) trait TickHandler: Send + Sync {
     async fn on_tick(&self, tick_at: OffsetDateTime, catchup: bool) -> Result<(), ConnectorError>;
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct ShutdownSignal {
+    stopped: AtomicBool,
+    notify: Notify,
+}
+
+impl ShutdownSignal {
+    pub(crate) fn request_stop(&self) {
+        self.stopped.store(true, Ordering::SeqCst);
+        self.notify.notify_waiters();
+    }
+
+    pub(crate) fn is_stopped(&self) -> bool {
+        self.stopped.load(Ordering::SeqCst)
+    }
+
+    pub(crate) async fn cancelled(&self) {
+        self.notify.notified().await;
+    }
+}
+
 pub(crate) async fn run_tick_loop(
     schedule: CronSchedule,
     clock: Arc<dyn Clock>,
     mut cursor: OffsetDateTime,
     catchup_ticks: Vec<OffsetDateTime>,
     handler: Arc<dyn TickHandler>,
+    shutdown: Arc<ShutdownSignal>,
 ) -> Result<(), ConnectorError> {
     for tick_at in catchup_ticks {
+        if shutdown.is_stopped() {
+            return Ok(());
+        }
         handler.on_tick(tick_at, true).await?;
         cursor = tick_at;
     }
 
     loop {
+        if shutdown.is_stopped() {
+            return Ok(());
+        }
         let next_tick = schedule.next_tick_after(cursor)?;
         if next_tick > clock.now() {
-            clock.sleep_until(next_tick).await;
+            let sleep = clock.sleep_until(next_tick);
+            pin_mut!(sleep);
+            tokio::select! {
+                _ = &mut sleep => {}
+                _ = shutdown.cancelled() => return Ok(()),
+            }
+        }
+        if shutdown.is_stopped() {
+            return Ok(());
         }
         let now = clock.now();
         let due = schedule.due_ticks_between(Some(cursor), now)?;
@@ -168,6 +207,9 @@ pub(crate) async fn run_tick_loop(
             continue;
         }
         for tick_at in due {
+            if shutdown.is_stopped() {
+                return Ok(());
+            }
             handler.on_tick(tick_at, false).await?;
             cursor = tick_at;
         }

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -71,6 +71,11 @@ pub trait Connector: Send + Sync {
         bindings: &[TriggerBinding],
     ) -> Result<ActivationHandle, ConnectorError>;
 
+    /// Stop connector-owned background work and flush any connector-local state.
+    async fn shutdown(&self, _deadline: StdDuration) -> Result<(), ConnectorError> {
+        Ok(())
+    }
+
     /// Verify + normalize a provider-native inbound request into `TriggerEvent`.
     fn normalize_inbound(&self, raw: RawInbound) -> Result<TriggerEvent, ConnectorError>;
 

--- a/crates/harn-vm/src/event_log/mod.rs
+++ b/crates/harn-vm/src/event_log/mod.rs
@@ -191,6 +191,8 @@ pub trait EventLog: Send + Sync {
 
     async fn append(&self, topic: &Topic, event: LogEvent) -> Result<EventId, LogError>;
 
+    async fn flush(&self) -> Result<(), LogError>;
+
     /// Read events strictly after `from`. `None` starts from the
     /// beginning of the topic.
     async fn read_range(
@@ -359,6 +361,14 @@ impl EventLog for AnyEventLog {
             Self::Memory(log) => log.append(topic, event).await,
             Self::File(log) => log.append(topic, event).await,
             Self::Sqlite(log) => log.append(topic, event).await,
+        }
+    }
+
+    async fn flush(&self) -> Result<(), LogError> {
+        match self {
+            Self::Memory(log) => log.flush().await,
+            Self::File(log) => log.flush().await,
+            Self::Sqlite(log) => log.flush().await,
         }
     }
 
@@ -553,6 +563,10 @@ impl EventLog for MemoryEventLog {
         self.broadcasts
             .publish(topic, self.queue_depth, (event_id, event));
         Ok(event_id)
+    }
+
+    async fn flush(&self) -> Result<(), LogError> {
+        Ok(())
     }
 
     async fn read_range(
@@ -778,6 +792,10 @@ impl EventLog for FileEventLog {
         Ok(next_id)
     }
 
+    async fn flush(&self) -> Result<(), LogError> {
+        sync_tree(&self.root)
+    }
+
     async fn read_range(
         &self,
         topic: &Topic,
@@ -991,6 +1009,17 @@ impl EventLog for SqliteEventLog {
         self.broadcasts
             .publish(topic, self.queue_depth, (event_id, event.clone()));
         Ok(event_id)
+    }
+
+    async fn flush(&self) -> Result<(), LogError> {
+        let connection = self
+            .connection
+            .lock()
+            .expect("sqlite event log connection poisoned");
+        connection
+            .execute_batch("PRAGMA wal_checkpoint(FULL);")
+            .map_err(|error| LogError::Sqlite(format!("event log checkpoint error: {error}")))?;
+        Ok(())
     }
 
     async fn read_range(
@@ -1213,6 +1242,26 @@ fn file_size(path: &Path) -> u64 {
     std::fs::metadata(path)
         .map(|metadata| metadata.len())
         .unwrap_or(0)
+}
+
+fn sync_tree(root: &Path) -> Result<(), LogError> {
+    if !root.exists() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(root)
+        .map_err(|error| LogError::Io(format!("event log read_dir error: {error}")))?
+    {
+        let entry = entry.map_err(|error| LogError::Io(format!("event log dir error: {error}")))?;
+        let path = entry.path();
+        if path.is_dir() {
+            sync_tree(&path)?;
+            continue;
+        }
+        std::fs::File::open(&path)
+            .and_then(|file| file.sync_all())
+            .map_err(|error| LogError::Io(format!("event log sync error: {error}")))?;
+    }
+    Ok(())
 }
 
 fn now_ms() -> i64 {

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -82,6 +82,7 @@ pub use triggers::{
     registered_provider_schema_names, reset_provider_catalog, resolve_live_trigger_binding,
     run_trigger_harness_fixture, snapshot_dispatcher_stats, snapshot_trigger_bindings,
     unpin_trigger_binding, DispatchError, DispatchOutcome, DispatchStatus, Dispatcher,
+    DispatcherDrainReport,
     DispatcherStatsSnapshot, HeaderRedactionPolicy, InboxIndex, ProviderCatalog,
     ProviderCatalogError, ProviderId, ProviderMetadata, ProviderOutboundMethod, ProviderPayload,
     ProviderRuntimeMetadata, ProviderSchema, ProviderSecretRequirement, RetryPolicy,

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -82,15 +82,14 @@ pub use triggers::{
     registered_provider_schema_names, reset_provider_catalog, resolve_live_trigger_binding,
     run_trigger_harness_fixture, snapshot_dispatcher_stats, snapshot_trigger_bindings,
     unpin_trigger_binding, DispatchError, DispatchOutcome, DispatchStatus, Dispatcher,
-    DispatcherDrainReport,
-    DispatcherStatsSnapshot, HeaderRedactionPolicy, InboxIndex, ProviderCatalog,
-    ProviderCatalogError, ProviderId, ProviderMetadata, ProviderOutboundMethod, ProviderPayload,
-    ProviderRuntimeMetadata, ProviderSchema, ProviderSecretRequirement, RetryPolicy,
-    SignatureStatus, SignatureVerificationMetadata, TenantId, TraceId, TriggerBindingSnapshot,
-    TriggerBindingSource, TriggerBindingSpec, TriggerDispatchOutcome, TriggerEvent, TriggerEventId,
-    TriggerHandlerSpec, TriggerHarnessResult, TriggerId, TriggerMetricsSnapshot,
-    TriggerPredicateSpec, TriggerRegistryError, TriggerRetryConfig, TriggerState,
-    DEFAULT_INBOX_RETENTION_DAYS, TRIGGER_INBOX_TOPIC, TRIGGER_TEST_FIXTURES,
+    DispatcherDrainReport, DispatcherStatsSnapshot, HeaderRedactionPolicy, InboxIndex,
+    ProviderCatalog, ProviderCatalogError, ProviderId, ProviderMetadata, ProviderOutboundMethod,
+    ProviderPayload, ProviderRuntimeMetadata, ProviderSchema, ProviderSecretRequirement,
+    RetryPolicy, SignatureStatus, SignatureVerificationMetadata, TenantId, TraceId,
+    TriggerBindingSnapshot, TriggerBindingSource, TriggerBindingSpec, TriggerDispatchOutcome,
+    TriggerEvent, TriggerEventId, TriggerHandlerSpec, TriggerHarnessResult, TriggerId,
+    TriggerMetricsSnapshot, TriggerPredicateSpec, TriggerRegistryError, TriggerRetryConfig,
+    TriggerState, DEFAULT_INBOX_RETENTION_DAYS, TRIGGER_INBOX_TOPIC, TRIGGER_TEST_FIXTURES,
 };
 pub use value::*;
 pub use vm::*;

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use futures::{pin_mut, StreamExt};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
+use tokio::sync::Notify;
 
 use crate::event_log::{active_event_log, AnyEventLog, EventLog, LogError, LogEvent, Topic};
 use crate::llm::vm_value_to_json;
@@ -68,6 +69,7 @@ struct DispatcherRuntimeState {
     dlq: Mutex<Vec<DlqEntry>>,
     cancel_tokens: Mutex<Vec<Arc<std::sync::atomic::AtomicBool>>>,
     shutting_down: std::sync::atomic::AtomicBool,
+    idle_notify: Notify,
 }
 
 impl Default for DispatcherRuntimeState {
@@ -78,6 +80,7 @@ impl Default for DispatcherRuntimeState {
             dlq: Mutex::new(Vec::new()),
             cancel_tokens: Mutex::new(Vec::new()),
             shutting_down: std::sync::atomic::AtomicBool::new(false),
+            idle_notify: Notify::new(),
         }
     }
 }
@@ -113,6 +116,22 @@ pub struct DispatchOutcome {
     pub replay_of_event_id: Option<String>,
     pub result: Option<serde_json::Value>,
     pub error: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct InboxEnvelope {
+    pub trigger_id: Option<String>,
+    pub binding_version: Option<u32>,
+    pub event: TriggerEvent,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DispatcherDrainReport {
+    pub drained: bool,
+    pub in_flight: u64,
+    pub retry_queue_depth: u64,
+    pub dlq_depth: u64,
 }
 
 impl Default for DispatchOutcome {
@@ -251,10 +270,23 @@ impl Dispatcher {
     }
 
     pub async fn enqueue(&self, event: TriggerEvent) -> Result<u64, DispatchError> {
+        self.enqueue_targeted(None, None, event).await
+    }
+
+    pub async fn enqueue_targeted(
+        &self,
+        trigger_id: Option<String>,
+        binding_version: Option<u32>,
+        event: TriggerEvent,
+    ) -> Result<u64, DispatchError> {
         let topic = Topic::new(TRIGGER_INBOX_TOPIC).expect("static trigger.inbox topic is valid");
         let headers = event_headers(&event, None, None, None);
-        let payload = serde_json::to_value(&event)
-            .map_err(|error| DispatchError::Serde(error.to_string()))?;
+        let payload = serde_json::to_value(InboxEnvelope {
+            trigger_id,
+            binding_version,
+            event,
+        })
+        .map_err(|error| DispatchError::Serde(error.to_string()))?;
         self.event_log
             .append(
                 &topic,
@@ -280,11 +312,11 @@ impl Dispatcher {
                     if event.kind != "event_ingested" {
                         continue;
                     }
-                    let trigger_event: TriggerEvent = serde_json::from_value(event.payload)
+                    let envelope: InboxEnvelope = serde_json::from_value(event.payload)
                         .map_err(|error| DispatchError::Serde(error.to_string()))?;
                     let dispatcher = self.clone();
                     tokio::task::spawn_local(async move {
-                        let _ = dispatcher.dispatch_event(trigger_event).await;
+                        let _ = dispatcher.dispatch_inbox_envelope(envelope).await;
                     });
                 }
                 _ = recv_cancel(&mut cancel_rx) => break,
@@ -292,6 +324,78 @@ impl Dispatcher {
         }
 
         Ok(())
+    }
+
+    pub async fn drain(&self, timeout: Duration) -> Result<DispatcherDrainReport, DispatchError> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let snapshot = self.snapshot();
+            if snapshot.in_flight == 0 && snapshot.retry_queue_depth == 0 {
+                return Ok(DispatcherDrainReport {
+                    drained: true,
+                    in_flight: snapshot.in_flight,
+                    retry_queue_depth: snapshot.retry_queue_depth,
+                    dlq_depth: snapshot.dlq_depth,
+                });
+            }
+
+            let notified = self.state.idle_notify.notified();
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Ok(DispatcherDrainReport {
+                    drained: false,
+                    in_flight: snapshot.in_flight,
+                    retry_queue_depth: snapshot.retry_queue_depth,
+                    dlq_depth: snapshot.dlq_depth,
+                });
+            }
+            if tokio::time::timeout(remaining, notified).await.is_err() {
+                let snapshot = self.snapshot();
+                return Ok(DispatcherDrainReport {
+                    drained: false,
+                    in_flight: snapshot.in_flight,
+                    retry_queue_depth: snapshot.retry_queue_depth,
+                    dlq_depth: snapshot.dlq_depth,
+                });
+            }
+        }
+    }
+
+    pub async fn dispatch_inbox_envelope(
+        &self,
+        envelope: InboxEnvelope,
+    ) -> Result<Vec<DispatchOutcome>, DispatchError> {
+        if let Some(trigger_id) = envelope.trigger_id {
+            let binding = super::registry::resolve_live_trigger_binding(
+                &trigger_id,
+                envelope.binding_version,
+            )
+            .map_err(|error| DispatchError::Registry(error.to_string()))?;
+            return Ok(vec![
+                self.dispatch_with_replay(&binding, envelope.event, None)
+                    .await?,
+            ]);
+        }
+
+        let cron_target = match &envelope.event.provider_payload {
+            crate::triggers::ProviderPayload::Known(
+                crate::triggers::event::KnownProviderPayload::Cron(payload),
+            ) => payload.cron_id.clone(),
+            _ => None,
+        };
+        if let Some(trigger_id) = cron_target {
+            let binding = super::registry::resolve_live_trigger_binding(
+                &trigger_id,
+                envelope.binding_version,
+            )
+            .map_err(|error| DispatchError::Registry(error.to_string()))?;
+            return Ok(vec![
+                self.dispatch_with_replay(&binding, envelope.event, None)
+                    .await?,
+            ]);
+        }
+
+        self.dispatch_event(envelope.event).await
     }
 
     pub async fn dispatch_event(
@@ -447,7 +551,7 @@ impl Dispatcher {
                 )
                 .await
                 .map_err(|error| DispatchError::Registry(error.to_string()))?;
-                self.state.in_flight.fetch_sub(1, Ordering::Relaxed);
+                decrement_in_flight(&self.state);
                 return Ok(DispatchOutcome {
                     trigger_id: binding.id.as_str().to_string(),
                     binding_key: binding.binding_key(),
@@ -623,7 +727,7 @@ impl Dispatcher {
                     )
                     .await
                     .map_err(|error| DispatchError::Registry(error.to_string()))?;
-                    self.state.in_flight.fetch_sub(1, Ordering::Relaxed);
+                    decrement_in_flight(&self.state);
                     return Ok(DispatchOutcome {
                         trigger_id: binding.id.as_str().to_string(),
                         binding_key: binding.binding_key(),
@@ -706,7 +810,7 @@ impl Dispatcher {
                         .map_err(|registry_error| {
                             DispatchError::Registry(registry_error.to_string())
                         })?;
-                        self.state.in_flight.fetch_sub(1, Ordering::Relaxed);
+                        decrement_in_flight(&self.state);
                         return Ok(DispatchOutcome {
                             trigger_id: binding.id.as_str().to_string(),
                             binding_key: binding.binding_key(),
@@ -795,7 +899,7 @@ impl Dispatcher {
                         self.state.retry_queue_depth.fetch_add(1, Ordering::Relaxed);
                         let sleep_result =
                             sleep_or_cancel(delay, &mut self.cancel_tx.subscribe()).await;
-                        self.state.retry_queue_depth.fetch_sub(1, Ordering::Relaxed);
+                        decrement_retry_queue_depth(&self.state);
                         if sleep_result.is_err() {
                             finish_in_flight(
                                 binding.id.as_str(),
@@ -806,7 +910,7 @@ impl Dispatcher {
                             .map_err(|registry_error| {
                                 DispatchError::Registry(registry_error.to_string())
                             })?;
-                            self.state.in_flight.fetch_sub(1, Ordering::Relaxed);
+                            decrement_in_flight(&self.state);
                             return Ok(DispatchOutcome {
                                 trigger_id: binding.id.as_str().to_string(),
                                 binding_key: binding.binding_key(),
@@ -902,7 +1006,7 @@ impl Dispatcher {
                     .map_err(|registry_error| {
                         DispatchError::Registry(registry_error.to_string())
                     })?;
-                    self.state.in_flight.fetch_sub(1, Ordering::Relaxed);
+                    decrement_in_flight(&self.state);
                     return Ok(DispatchOutcome {
                         trigger_id: binding.id.as_str().to_string(),
                         binding_key: binding.binding_key(),
@@ -926,7 +1030,7 @@ impl Dispatcher {
         )
         .await
         .map_err(|error| DispatchError::Registry(error.to_string()))?;
-        self.state.in_flight.fetch_sub(1, Ordering::Relaxed);
+        decrement_in_flight(&self.state);
         Ok(DispatchOutcome {
             trigger_id: binding.id.as_str().to_string(),
             binding_key: binding.binding_key(),
@@ -1108,6 +1212,20 @@ impl Dispatcher {
         )
         .await
         .map_err(DispatchError::from)
+    }
+}
+
+fn decrement_in_flight(state: &DispatcherRuntimeState) {
+    let previous = state.in_flight.fetch_sub(1, Ordering::Relaxed);
+    if previous == 1 && state.retry_queue_depth.load(Ordering::Relaxed) == 0 {
+        state.idle_notify.notify_waiters();
+    }
+}
+
+fn decrement_retry_queue_depth(state: &DispatcherRuntimeState) {
+    let previous = state.retry_queue_depth.fetch_sub(1, Ordering::Relaxed);
+    if previous == 1 && state.in_flight.load(Ordering::Relaxed) == 0 {
+        state.idle_notify.notify_waiters();
     }
 }
 

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -371,6 +371,50 @@ pub fn wait_for_cancel(event: TriggerEvent) -> string {
         .await;
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn drain_waits_for_in_flight_local_handlers_without_cancelling() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (_dir, _log, dispatcher) = dispatcher_fixture(
+                r#"
+import "std/triggers"
+
+pub fn slow_handler(event: TriggerEvent) -> string {
+  sleep(50)
+  return event.kind
+}
+"#,
+                "slow_handler",
+                None,
+                TriggerRetryConfig::default(),
+            )
+            .await;
+
+            let dispatcher_for_task = dispatcher.clone();
+            let handle = tokio::task::spawn_local(async move {
+                dispatcher_for_task
+                    .dispatch_event(trigger_event("issues.opened", "delivery-drain"))
+                    .await
+                    .expect("dispatch finishes")
+            });
+
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let report = dispatcher
+                .drain(Duration::from_secs(1))
+                .await
+                .expect("drain completes");
+            assert!(report.drained, "{report:?}");
+            assert_eq!(report.in_flight, 0);
+            assert_eq!(report.retry_queue_depth, 0);
+
+            let outcomes = handle.await.expect("join local dispatch");
+            assert_eq!(outcomes.len(), 1);
+            assert_eq!(outcomes[0].status, DispatchStatus::Succeeded);
+        })
+        .await;
+}
+
 #[test]
 fn uri_parser_rejects_invalid_and_unknown_handler_schemes() {
     assert_eq!(DispatchUri::parse("").unwrap_err(), DispatchUriError::Empty);

--- a/crates/harn-vm/src/triggers/mod.rs
+++ b/crates/harn-vm/src/triggers/mod.rs
@@ -6,7 +6,8 @@ pub mod test_util;
 
 pub use dispatcher::{
     clear_dispatcher_state, snapshot_dispatcher_stats, DispatchError, DispatchOutcome,
-    DispatchStatus, Dispatcher, DispatcherStatsSnapshot, RetryPolicy, TriggerRetryConfig,
+    DispatchStatus, Dispatcher, DispatcherDrainReport, DispatcherStatsSnapshot, RetryPolicy,
+    TriggerRetryConfig,
 };
 pub use event::{
     provider_metadata, redact_headers, register_provider_schema, registered_provider_metadata,


### PR DESCRIPTION
## Summary
- harden `harn orchestrator serve` shutdown so SIGTERM/SIGINT stops new HTTP traffic, drains pending/cron/inbox work, then waits for in-flight dispatcher tasks up to a configurable deadline
- add connector and event-log flush hooks so shutdown persists connector boundaries and durable event-log state before exit
- emit `orchestrator.lifecycle` draining/stopped events with drain counts and extend orchestrator integration coverage for mid-dispatch SIGTERM handling

## Why
The previous shutdown path only scaffolded graceful termination. That left a gap where the listener could stop but dispatcher/inbox work and persisted state might not be fully drained or flushed before process exit.

## Validation
- `cargo test -p harn-vm drain_waits_for_in_flight_local_handlers_without_cancelling -- --nocapture`
- `cargo test -p harn-cli --test orchestrator_cli graceful_shutdown_drains_in_flight_dispatch_and_emits_lifecycle_events -- --nocapture`
- `cargo test -p harn-cli --test orchestrator_cli orchestrator_serve_starts_and_shuts_down_cleanly -- --nocapture`
- `cargo test -p harn-cli --test orchestrator_http graceful_shutdown_waits_for_in_flight_request -- --nocapture`
- `git push -u origin ksinder/issue-183-orchestrator-shutdown` (pre-push gate passed)

## Issue
- harn#183 (O-06)
