### PR TITLE
[codex] Implement orchestrator CLI commands

### DIFF
--- a/conformance/tests/integration/orchestrator_cli_commands.expected
+++ b/conformance/tests/integration/orchestrator_cli_commands.expected
@@ -1,0 +1,11 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/integration/orchestrator_cli_commands.harn
+++ b/conformance/tests/integration/orchestrator_cli_commands.harn
@@ -62,19 +62,17 @@ pipeline test(task) {
   write_file(
     path_join(root, "lib.harn"),
     "import \"std/triggers\"\n\nlet replay_marker = \""
-      + replay_marker
-      + "\"\n\npub fn on_tick(event: TriggerEvent) {\n  log(event.kind)\n}\n\npub fn flaky_issue(event: TriggerEvent) -> dict {\n  if !file_exists(replay_marker) {\n    throw \"replay-me:\" + event.kind\n  }\n  return {kind: event.kind, event_id: event.id}\n}\n\npub fn always_fail(event: TriggerEvent) -> any {\n  throw \"discard-me:\" + event.kind\n}\n",
+    + replay_marker
+    + "\"\n\npub fn on_tick(event: TriggerEvent) {\n  log(event.kind)\n}\n\npub fn flaky_issue(event: TriggerEvent) -> dict {\n  if !file_exists(replay_marker) {\n    throw \"replay-me:\" + event.kind\n  }\n  return {kind: event.kind, event_id: event.id}\n}\n\npub fn always_fail(event: TriggerEvent) -> any {\n  throw \"discard-me:\" + event.kind\n}\n",
   )
-
   let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
   let harn_bin = resolve_harn_bin(repo_root)
   assert(file_exists(harn_bin), "missing built harn binary at " + harn_bin)
-
   let start = shell_at(
     root,
     "nohup env HARN_SECRET_PROVIDERS=env HARN_ORCHESTRATOR_API_KEYS=test-key HARN_ORCHESTRATOR_HMAC_SECRET=shared-secret "
-      + harn_bin
-      + " orchestrator serve --config harn.toml --state-dir ./state --role single-tenant --bind 127.0.0.1:0 >/dev/null 2>orchestrator.log </dev/null & echo $!",
+    + harn_bin
+    + " orchestrator serve --config harn.toml --state-dir ./state --role single-tenant --bind 127.0.0.1:0 >/dev/null 2>orchestrator.log </dev/null & echo $!",
   )
   let pid = start.stdout.trim()
   assert(start.success, "failed to start orchestrator")
@@ -84,27 +82,16 @@ pipeline test(task) {
   sleep(2500ms)
   let _ = shell("kill -TERM " + pid)
   assert(wait_for_exit(pid), "orchestrator did not exit")
-
   let state_dir = path_join(root, "state")
   let config_path = path_join(root, "harn.toml")
-
-  let inspect = exec(
-    harn_bin,
-    "orchestrator",
-    "inspect",
-    "--config",
-    config_path,
-    "--state-dir",
-    state_dir,
-  )
+  let inspect = exec(harn_bin, "orchestrator", "inspect", "--config", config_path, "--state-dir", state_dir)
   println(
     inspect.success
-      && inspect.stdout.contains("cron-heartbeat provider=cron kind=cron state=active version=1")
-      && inspect.stdout.contains("manual-replay provider=a2a-push kind=a2a-push state=active version=1")
-      && inspect.stdout.contains("cron bindings=1")
-      && inspect.stdout.contains("a2a-push bindings=2"),
+    && inspect.stdout.contains("cron-heartbeat provider=cron kind=cron state=active version=1")
+    && inspect.stdout.contains("manual-replay provider=a2a-push kind=a2a-push state=active version=1")
+    && inspect.stdout.contains("cron bindings=1")
+    && inspect.stdout.contains("a2a-push bindings=2"),
   )
-
   let fire_replay = exec(
     harn_bin,
     "orchestrator",
@@ -129,46 +116,26 @@ pipeline test(task) {
   assert(replay_event_id != nil, "missing replay event id")
   println(
     fire_replay.success
-      && fire_replay.stdout.contains("status=dlq")
-      && fire_discard.success
-      && fire_discard.stdout.contains("status=dlq"),
+    && fire_replay.stdout.contains("status=dlq")
+    && fire_discard.success
+    && fire_discard.stdout.contains("status=dlq"),
   )
-
-  let dlq_list = exec(
-    harn_bin,
-    "orchestrator",
-    "dlq",
-    "--list",
-    "--config",
-    config_path,
-    "--state-dir",
-    state_dir,
-  )
+  let dlq_list = exec(harn_bin, "orchestrator", "dlq", "--list", "--config", config_path, "--state-dir", state_dir)
   let replay_entry_id = first_group("(?m)^- (dlq_\\S+) binding=manual-replay", dlq_list.stdout)
   let discard_entry_id = first_group("(?m)^- (dlq_\\S+) binding=manual-discard", dlq_list.stdout)
   assert(replay_entry_id != nil, "missing replay dlq entry id")
   assert(discard_entry_id != nil, "missing discard dlq entry id")
   println(
     dlq_list.success
-      && dlq_list.stdout.contains("binding=manual-replay")
-      && dlq_list.stdout.contains("binding=manual-discard"),
+    && dlq_list.stdout.contains("binding=manual-replay")
+    && dlq_list.stdout.contains("binding=manual-discard"),
   )
-
-  let inspect_after = exec(
-    harn_bin,
-    "orchestrator",
-    "inspect",
-    "--config",
-    config_path,
-    "--state-dir",
-    state_dir,
-  )
+  let inspect_after = exec(harn_bin, "orchestrator", "inspect", "--config", config_path, "--state-dir", state_dir)
   println(
     inspect_after.success
-      && inspect_after.stdout.contains("dispatch_failed trigger=manual-replay")
-      && inspect_after.stdout.contains("dispatch_failed trigger=manual-discard"),
+    && inspect_after.stdout.contains("dispatch_failed trigger=manual-replay")
+    && inspect_after.stdout.contains("dispatch_failed trigger=manual-discard"),
   )
-
   write_file(replay_marker, "ready")
   let dlq_replay = exec(
     harn_bin,
@@ -182,7 +149,6 @@ pipeline test(task) {
     state_dir,
   )
   println(dlq_replay.success && dlq_replay.stdout.contains("status=dispatched"))
-
   let direct_replay = exec(
     harn_bin,
     "orchestrator",
@@ -195,10 +161,9 @@ pipeline test(task) {
   )
   println(
     direct_replay.success
-      && direct_replay.stdout.contains("status=dispatched")
-      && direct_replay.stdout.contains("replay_of_event_id=" + replay_event_id),
+    && direct_replay.stdout.contains("status=dispatched")
+    && direct_replay.stdout.contains("replay_of_event_id=" + replay_event_id),
   )
-
   let discard = exec(
     harn_bin,
     "orchestrator",
@@ -211,32 +176,13 @@ pipeline test(task) {
     state_dir,
   )
   println(discard.success && discard.stdout.contains("state=discarded"))
-
-  let dlq_after = exec(
-    harn_bin,
-    "orchestrator",
-    "dlq",
-    "--list",
-    "--config",
-    config_path,
-    "--state-dir",
-    state_dir,
-  )
+  let dlq_after = exec(harn_bin, "orchestrator", "dlq", "--list", "--config", config_path, "--state-dir", state_dir)
   println(dlq_after.success && dlq_after.stdout.contains("pending_entries=0"))
-
-  let queue = exec(
-    harn_bin,
-    "orchestrator",
-    "queue",
-    "--config",
-    config_path,
-    "--state-dir",
-    state_dir,
-  )
+  let queue = exec(harn_bin, "orchestrator", "queue", "--config", config_path, "--state-dir", state_dir)
   println(
     queue.success
-      && queue.stdout.contains("dispatcher_in_flight=0")
-      && queue.stdout.contains("inferred_pending_retries=0"),
+    && queue.stdout.contains("dispatcher_in_flight=0")
+    && queue.stdout.contains("inferred_pending_retries=0"),
   )
   println(len(regex_captures("inbox_claims_written=([1-9][0-9]*)", queue.stdout)) == 1)
   println(len(regex_captures("inbox_active_entries=([1-9][0-9]*)", queue.stdout)) == 1)

--- a/conformance/tests/integration/orchestrator_cli_commands.harn
+++ b/conformance/tests/integration/orchestrator_cli_commands.harn
@@ -1,0 +1,243 @@
+fn wait_for_listener_url(log_path) {
+  var attempts = 0
+  var url = nil
+  while attempts < 300 && !url {
+    if file_exists(log_path) {
+      let log = exec("cat", log_path).stdout
+      let matches = regex_captures("\\[harn\\] HTTP listener ready on (\\S+)", log)
+      if len(matches) > 0 {
+        url = matches[0].groups[0]
+      }
+    }
+    if !url {
+      sleep(50ms)
+      attempts = attempts + 1
+    }
+  }
+  return url
+}
+
+fn wait_for_exit(pid) {
+  var attempts = 0
+  while attempts < 200 {
+    let probe = shell("kill -0 " + pid + " >/dev/null 2>&1")
+    if !probe.success {
+      return true
+    }
+    sleep(50ms)
+    attempts = attempts + 1
+  }
+  return false
+}
+
+fn first_group(pattern, text) {
+  let matches = regex_captures(pattern, text)
+  if len(matches) == 0 {
+    return nil
+  }
+  return matches[0].groups[0]
+}
+
+fn resolve_harn_bin(repo_root) {
+  let cargo_config = path_join(repo_root, ".cargo/config.toml")
+  if file_exists(cargo_config) {
+    let config = exec("cat", cargo_config).stdout
+    let configured = first_group("target-dir = \\\"([^\\\"]+)\\\"", config)
+    if configured {
+      return path_join(configured, "debug/harn")
+    }
+  }
+  let target_dir = env("CARGO_TARGET_DIR") ?? path_join(repo_root, "target")
+  return path_join(target_dir, "debug/harn")
+}
+
+pipeline test(task) {
+  let root = path_join(temp_dir(), "harn-orchestrator-cli-" + uuid())
+  mkdir(root)
+  let replay_marker = path_join(root, "replay-ready.marker")
+  write_file(
+    path_join(root, "harn.toml"),
+    "[package]\nname = \"fixture\"\n\n[exports]\nhandlers = \"lib.harn\"\n\n[[triggers]]\nid = \"cron-heartbeat\"\nkind = \"cron\"\nprovider = \"cron\"\nmatch = { events = [\"cron.tick\"] }\nhandler = \"handlers::on_tick\"\nretry = { retention_days = 7 }\nschedule = \"*/2 * * * * *\"\ntimezone = \"UTC\"\ncatchup_mode = \"latest\"\n\n[[triggers]]\nid = \"manual-replay\"\nkind = \"a2a-push\"\nprovider = \"a2a-push\"\nmatch = { events = [\"manual.trigger\"] }\nhandler = \"handlers::flaky_issue\"\nretry = { max = 1, backoff = \"immediate\", retention_days = 7 }\n\n[[triggers]]\nid = \"manual-discard\"\nkind = \"a2a-push\"\nprovider = \"a2a-push\"\nmatch = { events = [\"manual.trigger\"] }\nhandler = \"handlers::always_fail\"\nretry = { max = 1, backoff = \"immediate\", retention_days = 7 }\n",
+  )
+  write_file(
+    path_join(root, "lib.harn"),
+    "import \"std/triggers\"\n\nlet replay_marker = \""
+      + replay_marker
+      + "\"\n\npub fn on_tick(event: TriggerEvent) {\n  log(event.kind)\n}\n\npub fn flaky_issue(event: TriggerEvent) -> dict {\n  if !file_exists(replay_marker) {\n    throw \"replay-me:\" + event.kind\n  }\n  return {kind: event.kind, event_id: event.id}\n}\n\npub fn always_fail(event: TriggerEvent) -> any {\n  throw \"discard-me:\" + event.kind\n}\n",
+  )
+
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let harn_bin = resolve_harn_bin(repo_root)
+  assert(file_exists(harn_bin), "missing built harn binary at " + harn_bin)
+
+  let start = shell_at(
+    root,
+    "nohup env HARN_SECRET_PROVIDERS=env HARN_ORCHESTRATOR_API_KEYS=test-key HARN_ORCHESTRATOR_HMAC_SECRET=shared-secret "
+      + harn_bin
+      + " orchestrator serve --config harn.toml --state-dir ./state --role single-tenant --bind 127.0.0.1:0 >/dev/null 2>orchestrator.log </dev/null & echo $!",
+  )
+  let pid = start.stdout.trim()
+  assert(start.success, "failed to start orchestrator")
+  assert(pid != "", "missing orchestrator pid")
+  let url = wait_for_listener_url(path_join(root, "orchestrator.log"))
+  assert(url != nil, "listener URL did not appear in log")
+  sleep(2500ms)
+  let _ = shell("kill -TERM " + pid)
+  assert(wait_for_exit(pid), "orchestrator did not exit")
+
+  let state_dir = path_join(root, "state")
+  let config_path = path_join(root, "harn.toml")
+
+  let inspect = exec(
+    harn_bin,
+    "orchestrator",
+    "inspect",
+    "--config",
+    config_path,
+    "--state-dir",
+    state_dir,
+  )
+  println(
+    inspect.success
+      && inspect.stdout.contains("cron-heartbeat provider=cron kind=cron state=active version=1")
+      && inspect.stdout.contains("manual-replay provider=a2a-push kind=a2a-push state=active version=1")
+      && inspect.stdout.contains("cron bindings=1")
+      && inspect.stdout.contains("a2a-push bindings=2"),
+  )
+
+  let fire_replay = exec(
+    harn_bin,
+    "orchestrator",
+    "fire",
+    "manual-replay",
+    "--config",
+    config_path,
+    "--state-dir",
+    state_dir,
+  )
+  let fire_discard = exec(
+    harn_bin,
+    "orchestrator",
+    "fire",
+    "manual-discard",
+    "--config",
+    config_path,
+    "--state-dir",
+    state_dir,
+  )
+  let replay_event_id = first_group("event_id=(\\S+)", fire_replay.stdout)
+  assert(replay_event_id != nil, "missing replay event id")
+  println(
+    fire_replay.success
+      && fire_replay.stdout.contains("status=dlq")
+      && fire_discard.success
+      && fire_discard.stdout.contains("status=dlq"),
+  )
+
+  let dlq_list = exec(
+    harn_bin,
+    "orchestrator",
+    "dlq",
+    "--list",
+    "--config",
+    config_path,
+    "--state-dir",
+    state_dir,
+  )
+  let replay_entry_id = first_group("(?m)^- (dlq_\\S+) binding=manual-replay", dlq_list.stdout)
+  let discard_entry_id = first_group("(?m)^- (dlq_\\S+) binding=manual-discard", dlq_list.stdout)
+  assert(replay_entry_id != nil, "missing replay dlq entry id")
+  assert(discard_entry_id != nil, "missing discard dlq entry id")
+  println(
+    dlq_list.success
+      && dlq_list.stdout.contains("binding=manual-replay")
+      && dlq_list.stdout.contains("binding=manual-discard"),
+  )
+
+  let inspect_after = exec(
+    harn_bin,
+    "orchestrator",
+    "inspect",
+    "--config",
+    config_path,
+    "--state-dir",
+    state_dir,
+  )
+  println(
+    inspect_after.success
+      && inspect_after.stdout.contains("dispatch_failed trigger=manual-replay")
+      && inspect_after.stdout.contains("dispatch_failed trigger=manual-discard"),
+  )
+
+  write_file(replay_marker, "ready")
+  let dlq_replay = exec(
+    harn_bin,
+    "orchestrator",
+    "dlq",
+    "--replay",
+    replay_entry_id,
+    "--config",
+    config_path,
+    "--state-dir",
+    state_dir,
+  )
+  println(dlq_replay.success && dlq_replay.stdout.contains("status=dispatched"))
+
+  let direct_replay = exec(
+    harn_bin,
+    "orchestrator",
+    "replay",
+    replay_event_id,
+    "--config",
+    config_path,
+    "--state-dir",
+    state_dir,
+  )
+  println(
+    direct_replay.success
+      && direct_replay.stdout.contains("status=dispatched")
+      && direct_replay.stdout.contains("replay_of_event_id=" + replay_event_id),
+  )
+
+  let discard = exec(
+    harn_bin,
+    "orchestrator",
+    "dlq",
+    "--discard",
+    discard_entry_id,
+    "--config",
+    config_path,
+    "--state-dir",
+    state_dir,
+  )
+  println(discard.success && discard.stdout.contains("state=discarded"))
+
+  let dlq_after = exec(
+    harn_bin,
+    "orchestrator",
+    "dlq",
+    "--list",
+    "--config",
+    config_path,
+    "--state-dir",
+    state_dir,
+  )
+  println(dlq_after.success && dlq_after.stdout.contains("pending_entries=0"))
+
+  let queue = exec(
+    harn_bin,
+    "orchestrator",
+    "queue",
+    "--config",
+    config_path,
+    "--state-dir",
+    state_dir,
+  )
+  println(
+    queue.success
+      && queue.stdout.contains("dispatcher_in_flight=0")
+      && queue.stdout.contains("inferred_pending_retries=0"),
+  )
+  println(len(regex_captures("inbox_claims_written=([1-9][0-9]*)", queue.stdout)) == 1)
+  println(len(regex_captures("inbox_active_entries=([1-9][0-9]*)", queue.stdout)) == 1)
+}

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -459,22 +459,8 @@ pub(crate) struct OrchestratorArgs {
     pub command: OrchestratorCommand,
 }
 
-#[derive(Debug, Subcommand)]
-pub(crate) enum OrchestratorCommand {
-    /// Load manifests, initialize registries, and idle until shutdown.
-    Serve(OrchestratorServeArgs),
-    /// Inspect orchestrator state.
-    Inspect,
-    /// Replay orchestrator events.
-    Replay,
-    /// Inspect the dead-letter queue.
-    Dlq,
-    /// Inspect trigger and dispatch queues.
-    Queue,
-}
-
-#[derive(Debug, Args)]
-pub(crate) struct OrchestratorServeArgs {
+#[derive(Debug, Args, Clone)]
+pub(crate) struct OrchestratorLocalArgs {
     /// Path to the root manifest to load. Container deployments often mount
     /// this as `/etc/harn/triggers.toml`.
     #[arg(
@@ -493,6 +479,28 @@ pub(crate) struct OrchestratorServeArgs {
         value_name = "PATH"
     )]
     pub state_dir: PathBuf,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum OrchestratorCommand {
+    /// Load manifests, initialize registries, and idle until shutdown.
+    Serve(OrchestratorServeArgs),
+    /// Inspect orchestrator state.
+    Inspect(OrchestratorInspectArgs),
+    /// Inject a synthetic event for a specific binding.
+    Fire(OrchestratorFireArgs),
+    /// Replay orchestrator events.
+    Replay(OrchestratorReplayArgs),
+    /// Inspect the dead-letter queue.
+    Dlq(OrchestratorDlqArgs),
+    /// Inspect trigger and dispatch queues.
+    Queue(OrchestratorQueueArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorServeArgs {
+    #[command(flatten)]
+    pub local: OrchestratorLocalArgs,
     /// Socket address the HTTP listener will bind to.
     #[arg(
         long,
@@ -516,6 +524,54 @@ pub(crate) struct OrchestratorServeArgs {
         default_value_t = crate::commands::orchestrator::role::OrchestratorRole::SingleTenant
     )]
     pub role: crate::commands::orchestrator::role::OrchestratorRole,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorInspectArgs {
+    #[command(flatten)]
+    pub local: OrchestratorLocalArgs,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorFireArgs {
+    #[command(flatten)]
+    pub local: OrchestratorLocalArgs,
+    /// Binding id to fire.
+    pub binding_id: String,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorReplayArgs {
+    #[command(flatten)]
+    pub local: OrchestratorLocalArgs,
+    /// Previously recorded event id to replay.
+    pub event_id: String,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorDlqArgs {
+    #[command(flatten)]
+    pub local: OrchestratorLocalArgs,
+    /// List pending DLQ entries.
+    #[arg(
+        long,
+        default_value_t = false,
+        action = ArgAction::SetTrue,
+        conflicts_with_all = ["replay", "discard"]
+    )]
+    pub list: bool,
+    /// Replay the DLQ entry identified by id.
+    #[arg(long, value_name = "ID", conflicts_with = "discard")]
+    pub replay: Option<String>,
+    /// Discard the DLQ entry identified by id.
+    #[arg(long, value_name = "ID", conflicts_with = "replay")]
+    pub discard: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorQueueArgs {
+    #[command(flatten)]
+    pub local: OrchestratorLocalArgs,
 }
 
 #[derive(Debug, Args)]
@@ -874,8 +930,8 @@ mod tests {
         let OrchestratorCommand::Serve(serve) = args.command else {
             panic!("expected orchestrator serve");
         };
-        assert_eq!(serve.config, PathBuf::from("workspace/harn.toml"));
-        assert_eq!(serve.state_dir, PathBuf::from("state/orchestrator"));
+        assert_eq!(serve.local.config, PathBuf::from("workspace/harn.toml"));
+        assert_eq!(serve.local.state_dir, PathBuf::from("state/orchestrator"));
         assert_eq!(serve.bind.to_string(), "0.0.0.0:8080");
         assert_eq!(serve.cert, Some(PathBuf::from("tls/cert.pem")));
         assert_eq!(serve.key, Some(PathBuf::from("tls/key.pem")));
@@ -905,9 +961,116 @@ mod tests {
         let OrchestratorCommand::Serve(serve) = args.command else {
             panic!("expected orchestrator serve");
         };
-        assert_eq!(serve.config, PathBuf::from("/etc/harn/triggers.toml"));
-        assert_eq!(serve.state_dir, PathBuf::from("/var/lib/harn/state"));
+        assert_eq!(serve.local.config, PathBuf::from("/etc/harn/triggers.toml"));
+        assert_eq!(serve.local.state_dir, PathBuf::from("/var/lib/harn/state"));
         assert_eq!(serve.bind.to_string(), "0.0.0.0:8080");
+    }
+
+    #[test]
+    fn test_parses_orchestrator_inspect_args() {
+        let cli = Cli::parse_from([
+            "harn",
+            "orchestrator",
+            "inspect",
+            "--config",
+            "workspace/harn.toml",
+            "--state-dir",
+            "state/orchestrator",
+        ]);
+
+        let Command::Orchestrator(args) = cli.command.unwrap() else {
+            panic!("expected orchestrator command");
+        };
+        let OrchestratorCommand::Inspect(inspect) = args.command else {
+            panic!("expected orchestrator inspect");
+        };
+        assert_eq!(inspect.local.config, PathBuf::from("workspace/harn.toml"));
+        assert_eq!(inspect.local.state_dir, PathBuf::from("state/orchestrator"));
+    }
+
+    #[test]
+    fn test_parses_orchestrator_fire_args() {
+        let cli = Cli::parse_from([
+            "harn",
+            "orchestrator",
+            "fire",
+            "github-new-issue",
+            "--config",
+            "workspace/harn.toml",
+        ]);
+
+        let Command::Orchestrator(args) = cli.command.unwrap() else {
+            panic!("expected orchestrator command");
+        };
+        let OrchestratorCommand::Fire(fire) = args.command else {
+            panic!("expected orchestrator fire");
+        };
+        assert_eq!(fire.binding_id, "github-new-issue");
+        assert_eq!(fire.local.config, PathBuf::from("workspace/harn.toml"));
+    }
+
+    #[test]
+    fn test_parses_orchestrator_replay_args() {
+        let cli = Cli::parse_from([
+            "harn",
+            "orchestrator",
+            "replay",
+            "trigger_evt_123",
+            "--state-dir",
+            "state/orchestrator",
+        ]);
+
+        let Command::Orchestrator(args) = cli.command.unwrap() else {
+            panic!("expected orchestrator command");
+        };
+        let OrchestratorCommand::Replay(replay) = args.command else {
+            panic!("expected orchestrator replay");
+        };
+        assert_eq!(replay.event_id, "trigger_evt_123");
+        assert_eq!(replay.local.state_dir, PathBuf::from("state/orchestrator"));
+    }
+
+    #[test]
+    fn test_parses_orchestrator_dlq_replay_args() {
+        let cli = Cli::parse_from([
+            "harn",
+            "orchestrator",
+            "dlq",
+            "--replay",
+            "dlq_123",
+            "--config",
+            "workspace/harn.toml",
+        ]);
+
+        let Command::Orchestrator(args) = cli.command.unwrap() else {
+            panic!("expected orchestrator command");
+        };
+        let OrchestratorCommand::Dlq(dlq) = args.command else {
+            panic!("expected orchestrator dlq");
+        };
+        assert_eq!(dlq.replay.as_deref(), Some("dlq_123"));
+        assert!(dlq.discard.is_none());
+        assert!(!dlq.list);
+        assert_eq!(dlq.local.config, PathBuf::from("workspace/harn.toml"));
+    }
+
+    #[test]
+    fn test_parses_orchestrator_queue_args() {
+        let cli = Cli::parse_from([
+            "harn",
+            "orchestrator",
+            "queue",
+            "--state-dir",
+            "state/orchestrator",
+        ]);
+
+        let Command::Orchestrator(args) = cli.command.unwrap() else {
+            panic!("expected orchestrator command");
+        };
+        let OrchestratorCommand::Queue(queue) = args.command else {
+            panic!("expected orchestrator queue");
+        };
+        assert_eq!(queue.local.state_dir, PathBuf::from("state/orchestrator"));
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/orchestrator/common.rs
+++ b/crates/harn-cli/src/commands/orchestrator/common.rs
@@ -1,0 +1,268 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use harn_vm::event_log::{AnyEventLog, EventLog, LogEvent, Topic};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::json;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use crate::cli::OrchestratorLocalArgs;
+use crate::package::{self, CollectedManifestTrigger, Manifest};
+
+use super::role::OrchestratorRole;
+
+pub(super) const STATE_SNAPSHOT_FILE: &str = "orchestrator-state.json";
+pub(super) const TRIGGER_INBOX_TOPIC: &str = "trigger.inbox";
+pub(super) const TRIGGER_OUTBOX_TOPIC: &str = "trigger.outbox";
+pub(super) const TRIGGER_ATTEMPTS_TOPIC: &str = "trigger.attempts";
+pub(super) const TRIGGER_DLQ_TOPIC: &str = "triggers.dlq";
+
+pub(super) struct LoadedOrchestratorContext {
+    pub vm: harn_vm::Vm,
+    pub event_log: Arc<AnyEventLog>,
+    pub collected_triggers: Vec<CollectedManifestTrigger>,
+    pub snapshot: Option<PersistedStateSnapshot>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct PersistedStateSnapshot {
+    pub status: String,
+    pub bind: String,
+    #[serde(default)]
+    pub connectors: Vec<String>,
+    #[serde(default)]
+    pub activations: Vec<ConnectorActivationSnapshot>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct ConnectorActivationSnapshot {
+    pub provider: String,
+    pub binding_count: usize,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct DispatchHandleRecord {
+    pub event_id: String,
+    pub binding_id: String,
+    pub binding_version: u32,
+    pub status: String,
+    pub replay_of_event_id: Option<String>,
+    pub dlq_entry_id: Option<String>,
+    pub error: Option<String>,
+    pub result: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(super) struct DlqAttemptRecord {
+    pub attempt: u32,
+    pub at: String,
+    pub status: String,
+    pub error: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(super) struct DlqEntryRecord {
+    pub id: String,
+    pub event_id: String,
+    pub binding_id: String,
+    pub binding_version: u32,
+    pub provider: String,
+    pub kind: String,
+    pub state: String,
+    pub error: String,
+    pub event: harn_vm::TriggerEvent,
+    pub retry_history: Vec<DlqAttemptRecord>,
+}
+
+pub(super) async fn load_local_runtime(
+    args: &OrchestratorLocalArgs,
+) -> Result<LoadedOrchestratorContext, String> {
+    harn_vm::reset_thread_local_state();
+
+    let config_path = absolutize_from_cwd(&args.config)?;
+    let (_manifest, manifest_dir) = load_manifest(&config_path)?;
+    let state_dir = absolutize_from_cwd(&args.state_dir)?;
+    std::fs::create_dir_all(&state_dir).map_err(|error| {
+        format!(
+            "failed to create state dir {}: {error}",
+            state_dir.display()
+        )
+    })?;
+
+    let mut vm =
+        OrchestratorRole::SingleTenant.build_vm(&manifest_dir, &manifest_dir, &state_dir)?;
+    let extensions = package::load_runtime_extensions(&config_path);
+    let collected_triggers = package::collect_manifest_triggers(&mut vm, &extensions)
+        .await
+        .map_err(|error| format!("failed to collect manifest triggers: {error}"))?;
+    package::install_collected_manifest_triggers(&collected_triggers).await?;
+
+    let event_log = harn_vm::event_log::active_event_log()
+        .ok_or_else(|| "event log was not installed during VM initialization".to_string())?;
+    let snapshot = read_state_snapshot(&state_dir.join(STATE_SNAPSHOT_FILE))?;
+
+    Ok(LoadedOrchestratorContext {
+        vm,
+        event_log,
+        collected_triggers,
+        snapshot,
+    })
+}
+
+pub(super) async fn trigger_list(
+    ctx: &mut LoadedOrchestratorContext,
+) -> Result<Vec<harn_vm::TriggerBindingSnapshot>, String> {
+    eval_json(&mut ctx.vm, "trigger_list()").await
+}
+
+pub(super) async fn trigger_replay(
+    ctx: &mut LoadedOrchestratorContext,
+    event_id: &str,
+) -> Result<DispatchHandleRecord, String> {
+    let event_id = serde_json::to_string(event_id).map_err(|error| error.to_string())?;
+    eval_json(&mut ctx.vm, &format!("trigger_replay({event_id})")).await
+}
+
+pub(super) async fn trigger_inspect_dlq(
+    ctx: &mut LoadedOrchestratorContext,
+) -> Result<Vec<DlqEntryRecord>, String> {
+    eval_json(&mut ctx.vm, "trigger_inspect_dlq()").await
+}
+
+pub(super) async fn trigger_fire(
+    ctx: &mut LoadedOrchestratorContext,
+    binding_id: &str,
+    event: serde_json::Value,
+) -> Result<DispatchHandleRecord, String> {
+    let binding_id = serde_json::to_string(binding_id).map_err(|error| error.to_string())?;
+    let event_json = serde_json::to_string(&event).map_err(|error| error.to_string())?;
+    let event_literal = serde_json::to_string(&event_json).map_err(|error| error.to_string())?;
+    eval_json(
+        &mut ctx.vm,
+        &format!("trigger_fire({binding_id}, json_parse({event_literal}))"),
+    )
+    .await
+}
+
+pub(super) fn synthetic_event_for_binding(
+    ctx: &LoadedOrchestratorContext,
+    binding_id: &str,
+) -> Result<serde_json::Value, String> {
+    let trigger = ctx
+        .collected_triggers
+        .iter()
+        .find(|trigger| trigger.config.id == binding_id)
+        .ok_or_else(|| format!("unknown manifest binding '{binding_id}'"))?;
+    let kind = trigger
+        .config
+        .match_
+        .events
+        .first()
+        .cloned()
+        .unwrap_or_else(|| match trigger.config.kind {
+            crate::package::TriggerKind::Webhook => "webhook".to_string(),
+            crate::package::TriggerKind::Cron => "cron.tick".to_string(),
+            crate::package::TriggerKind::Poll => "poll".to_string(),
+            crate::package::TriggerKind::Stream => "stream".to_string(),
+            crate::package::TriggerKind::Predicate => "predicate".to_string(),
+            crate::package::TriggerKind::A2aPush => "a2a.task.received".to_string(),
+        });
+    Ok(json!({
+        "provider": trigger.config.provider.as_str(),
+        "kind": kind,
+        "headers": {
+            "x-harn-binding-id": binding_id,
+            "x-harn-synthetic": "true",
+        }
+    }))
+}
+
+pub(super) async fn read_topic(
+    log: &Arc<AnyEventLog>,
+    topic_name: &str,
+) -> Result<Vec<(u64, LogEvent)>, String> {
+    let topic = Topic::new(topic_name).map_err(|error| error.to_string())?;
+    log.read_range(&topic, None, usize::MAX)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+pub(super) async fn append_dlq_entry(
+    log: &Arc<AnyEventLog>,
+    entry: &DlqEntryRecord,
+) -> Result<(), String> {
+    let topic = Topic::new(TRIGGER_DLQ_TOPIC).map_err(|error| error.to_string())?;
+    let payload = serde_json::to_value(entry).map_err(|error| error.to_string())?;
+    log.append(&topic, LogEvent::new("dlq_entry", payload))
+        .await
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+pub(super) fn discard_dlq_entry(entry: &DlqEntryRecord) -> Result<DlqEntryRecord, String> {
+    let mut next = entry.clone();
+    next.state = "discarded".to_string();
+    next.retry_history.push(DlqAttemptRecord {
+        attempt: (next.retry_history.len() + 1) as u32,
+        at: OffsetDateTime::now_utc()
+            .format(&Rfc3339)
+            .map_err(|error| error.to_string())?,
+        status: "discarded".to_string(),
+        error: None,
+    });
+    Ok(next)
+}
+
+fn read_state_snapshot(path: &Path) -> Result<Option<PersistedStateSnapshot>, String> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let snapshot = serde_json::from_str(&content)
+        .map_err(|error| format!("failed to parse {}: {error}", path.display()))?;
+    Ok(Some(snapshot))
+}
+
+async fn eval_json<T>(vm: &mut harn_vm::Vm, expr: &str) -> Result<T, String>
+where
+    T: DeserializeOwned,
+{
+    let source = format!("pipeline default() {{\n  return {expr}\n}}\n");
+    let chunk = harn_vm::compile_source(&source)?;
+    let value = vm
+        .execute(&chunk)
+        .await
+        .map_err(|error| error.to_string())?;
+    serde_json::from_value(harn_vm::llm::vm_value_to_json(&value))
+        .map_err(|error| format!("failed to decode builtin result: {error}"))
+}
+
+fn load_manifest(config_path: &Path) -> Result<(Manifest, PathBuf), String> {
+    if !config_path.is_file() {
+        return Err(format!("manifest not found: {}", config_path.display()));
+    }
+    let content = std::fs::read_to_string(config_path)
+        .map_err(|error| format!("failed to read {}: {error}", config_path.display()))?;
+    let manifest = toml::from_str::<Manifest>(&content)
+        .map_err(|error| format!("failed to parse {}: {error}", config_path.display()))?;
+    let manifest_dir = config_path.parent().map(Path::to_path_buf).ok_or_else(|| {
+        format!(
+            "manifest has no parent directory: {}",
+            config_path.display()
+        )
+    })?;
+    Ok((manifest, manifest_dir))
+}
+
+fn absolutize_from_cwd(path: &Path) -> Result<PathBuf, String> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| format!("failed to read current directory: {error}"))?
+            .join(path)
+    };
+    Ok(candidate)
+}

--- a/crates/harn-cli/src/commands/orchestrator/dlq.rs
+++ b/crates/harn-cli/src/commands/orchestrator/dlq.rs
@@ -1,0 +1,58 @@
+use crate::cli::OrchestratorDlqArgs;
+
+use super::common::{
+    append_dlq_entry, discard_dlq_entry, load_local_runtime, trigger_inspect_dlq, trigger_replay,
+};
+
+pub(super) async fn run(args: OrchestratorDlqArgs) -> Result<(), String> {
+    let mut ctx = load_local_runtime(&args.local).await?;
+    let entries = trigger_inspect_dlq(&mut ctx).await?;
+
+    if let Some(entry_id) = args.replay.as_deref() {
+        let entry = entries
+            .iter()
+            .find(|entry| entry.id == entry_id)
+            .ok_or_else(|| format!("unknown pending DLQ entry '{entry_id}'"))?;
+        let handle = trigger_replay(&mut ctx, &entry.event_id).await?;
+        println!("DLQ replay:");
+        println!("- entry_id={}", entry.id);
+        println!("- event_id={}", handle.event_id);
+        println!("- status={}", handle.status);
+        println!("- error={}", handle.error.as_deref().unwrap_or("-"));
+        println!(
+            "- replay_of_event_id={}",
+            handle.replay_of_event_id.as_deref().unwrap_or("-")
+        );
+        return Ok(());
+    }
+
+    if let Some(entry_id) = args.discard.as_deref() {
+        let entry = entries
+            .iter()
+            .find(|entry| entry.id == entry_id)
+            .ok_or_else(|| format!("unknown pending DLQ entry '{entry_id}'"))?;
+        let discarded = discard_dlq_entry(entry)?;
+        append_dlq_entry(&ctx.event_log, &discarded).await?;
+        println!("DLQ entry discarded:");
+        println!("- entry_id={}", discarded.id);
+        println!("- event_id={}", discarded.event_id);
+        println!("- state={}", discarded.state);
+        return Ok(());
+    }
+
+    let stats = harn_vm::snapshot_dispatcher_stats();
+    println!("DLQ:");
+    println!("- dispatcher_dlq_depth={}", stats.dlq_depth);
+    println!("- pending_entries={}", entries.len());
+    if entries.is_empty() {
+        println!("- none");
+        return Ok(());
+    }
+    for entry in entries {
+        println!(
+            "- {} binding={} event={} error={}",
+            entry.id, entry.binding_id, entry.event_id, entry.error
+        );
+    }
+    Ok(())
+}

--- a/crates/harn-cli/src/commands/orchestrator/fire.rs
+++ b/crates/harn-cli/src/commands/orchestrator/fire.rs
@@ -1,0 +1,32 @@
+use crate::cli::OrchestratorFireArgs;
+
+use super::common::{load_local_runtime, synthetic_event_for_binding, trigger_fire};
+
+pub(super) async fn run(args: OrchestratorFireArgs) -> Result<(), String> {
+    let mut ctx = load_local_runtime(&args.local).await?;
+    let event = synthetic_event_for_binding(&ctx, &args.binding_id)?;
+    let handle = trigger_fire(&mut ctx, &args.binding_id, event).await?;
+
+    println!("Synthetic event dispatched:");
+    println!("- binding_id={}", handle.binding_id);
+    println!("- binding_version={}", handle.binding_version);
+    println!("- event_id={}", handle.event_id);
+    println!("- status={}", handle.status);
+    println!(
+        "- replay_of_event_id={}",
+        handle.replay_of_event_id.as_deref().unwrap_or("-")
+    );
+    println!(
+        "- dlq_entry_id={}",
+        handle.dlq_entry_id.as_deref().unwrap_or("-")
+    );
+    println!("- error={}", handle.error.as_deref().unwrap_or("-"));
+    println!(
+        "- result={}",
+        handle
+            .result
+            .map(|result| result.to_string())
+            .unwrap_or_else(|| "-".to_string())
+    );
+    Ok(())
+}

--- a/crates/harn-cli/src/commands/orchestrator/inspect.rs
+++ b/crates/harn-cli/src/commands/orchestrator/inspect.rs
@@ -1,0 +1,100 @@
+use crate::cli::OrchestratorInspectArgs;
+
+use super::common::{load_local_runtime, read_topic, trigger_list, TRIGGER_OUTBOX_TOPIC};
+
+pub(super) async fn run(args: OrchestratorInspectArgs) -> Result<(), String> {
+    let mut ctx = load_local_runtime(&args.local).await?;
+    let bindings = trigger_list(&mut ctx).await?;
+    let dispatches = read_topic(&ctx.event_log, TRIGGER_OUTBOX_TOPIC).await?;
+
+    println!("Triggers:");
+    if bindings.is_empty() {
+        println!("- none");
+    } else {
+        for binding in bindings
+            .into_iter()
+            .filter(|binding| binding.source == harn_vm::TriggerBindingSource::Manifest)
+        {
+            println!(
+                "- {} provider={} kind={} state={} version={}",
+                binding.id,
+                binding.provider,
+                binding.kind,
+                binding.state.as_str(),
+                binding.version
+            );
+        }
+    }
+
+    println!();
+    println!("Connectors:");
+    match ctx.snapshot.as_ref() {
+        Some(snapshot) if !snapshot.activations.is_empty() => {
+            for activation in &snapshot.activations {
+                println!(
+                    "- {} bindings={}",
+                    activation.provider, activation.binding_count
+                );
+            }
+        }
+        Some(snapshot) if !snapshot.connectors.is_empty() => {
+            for connector in &snapshot.connectors {
+                println!("- {connector}");
+            }
+        }
+        Some(_) | None => println!("- none"),
+    }
+
+    if let Some(snapshot) = ctx.snapshot.as_ref() {
+        println!();
+        println!("Snapshot:");
+        println!("- status={}", snapshot.status);
+        println!("- bind={}", snapshot.bind);
+    }
+
+    println!();
+    println!("Recent dispatches:");
+    let mut recent: Vec<_> = dispatches
+        .into_iter()
+        .filter(|(_, event)| {
+            matches!(
+                event.kind.as_str(),
+                "dispatch_succeeded" | "dispatch_failed"
+            )
+        })
+        .collect();
+    if recent.is_empty() {
+        println!("- none");
+        return Ok(());
+    }
+    let keep_from = recent.len().saturating_sub(5);
+    recent.drain(0..keep_from);
+    for (_, event) in recent {
+        let trigger_id = event
+            .headers
+            .get("trigger_id")
+            .cloned()
+            .unwrap_or_else(|| "-".to_string());
+        let event_id = event
+            .headers
+            .get("event_id")
+            .cloned()
+            .unwrap_or_else(|| "-".to_string());
+        let attempt = event
+            .headers
+            .get("attempt")
+            .cloned()
+            .unwrap_or_else(|| "-".to_string());
+        let replay = event
+            .headers
+            .get("replay_of_event_id")
+            .cloned()
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "- {} trigger={} event={} attempt={} replay_of={}",
+            event.kind, trigger_id, event_id, attempt, replay
+        );
+    }
+
+    Ok(())
+}

--- a/crates/harn-cli/src/commands/orchestrator/mod.rs
+++ b/crates/harn-cli/src/commands/orchestrator/mod.rs
@@ -1,27 +1,24 @@
+mod common;
+mod dlq;
+mod fire;
+mod inspect;
 mod listener;
 mod origin_guard;
+mod queue;
+mod replay;
 pub(crate) mod role;
 mod serve;
 mod tls;
 
 use crate::cli::{OrchestratorArgs, OrchestratorCommand};
 
-const O08_NOT_IMPLEMENTED: &str = "not yet implemented (see O-08 #185)";
-
 pub(crate) async fn handle(args: OrchestratorArgs) -> Result<(), String> {
     match args.command {
         OrchestratorCommand::Serve(serve_args) => serve::run(serve_args).await,
-        OrchestratorCommand::Inspect => Err(format!(
-            "`harn orchestrator inspect` is {O08_NOT_IMPLEMENTED}"
-        )),
-        OrchestratorCommand::Replay => Err(format!(
-            "`harn orchestrator replay` is {O08_NOT_IMPLEMENTED}"
-        )),
-        OrchestratorCommand::Dlq => {
-            Err(format!("`harn orchestrator dlq` is {O08_NOT_IMPLEMENTED}"))
-        }
-        OrchestratorCommand::Queue => Err(format!(
-            "`harn orchestrator queue` is {O08_NOT_IMPLEMENTED}"
-        )),
+        OrchestratorCommand::Inspect(inspect_args) => inspect::run(inspect_args).await,
+        OrchestratorCommand::Fire(fire_args) => fire::run(fire_args).await,
+        OrchestratorCommand::Replay(replay_args) => replay::run(replay_args).await,
+        OrchestratorCommand::Dlq(dlq_args) => dlq::run(dlq_args).await,
+        OrchestratorCommand::Queue(queue_args) => queue::run(queue_args).await,
     }
 }

--- a/crates/harn-cli/src/commands/orchestrator/queue.rs
+++ b/crates/harn-cli/src/commands/orchestrator/queue.rs
@@ -1,0 +1,112 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use crate::cli::OrchestratorQueueArgs;
+
+use super::common::{
+    load_local_runtime, read_topic, TRIGGER_ATTEMPTS_TOPIC, TRIGGER_INBOX_TOPIC,
+    TRIGGER_OUTBOX_TOPIC,
+};
+
+pub(super) async fn run(args: OrchestratorQueueArgs) -> Result<(), String> {
+    let ctx = load_local_runtime(&args.local).await?;
+    let dispatcher = harn_vm::snapshot_dispatcher_stats();
+    let outbox = read_topic(&ctx.event_log, TRIGGER_OUTBOX_TOPIC).await?;
+    let attempts = read_topic(&ctx.event_log, TRIGGER_ATTEMPTS_TOPIC).await?;
+    let inbox_events = read_topic(&ctx.event_log, TRIGGER_INBOX_TOPIC).await?;
+
+    let mut started = BTreeSet::new();
+    let mut finished = BTreeSet::new();
+    for (_, event) in &outbox {
+        let Some(key) = dispatch_key(&event.headers) else {
+            continue;
+        };
+        match event.kind.as_str() {
+            "dispatch_started" => {
+                started.insert(key);
+            }
+            "dispatch_succeeded" | "dispatch_failed" => {
+                finished.insert(key);
+            }
+            _ => {}
+        }
+    }
+    let in_flight: Vec<_> = started.difference(&finished).cloned().collect();
+
+    let mut scheduled = BTreeSet::new();
+    for (_, event) in &attempts {
+        if event.kind != "retry_scheduled" {
+            continue;
+        }
+        if let Some(key) = dispatch_key(&event.headers) {
+            scheduled.insert(key);
+        }
+    }
+    let pending_retries: Vec<_> = scheduled.difference(&started).cloned().collect();
+
+    let inbox_metrics = Arc::new(harn_vm::MetricsRegistry::default());
+    let _inbox = harn_vm::triggers::InboxIndex::new(ctx.event_log.clone(), inbox_metrics.clone())
+        .await
+        .map_err(|error| error.to_string())?;
+    let inbox_snapshot = inbox_metrics.snapshot();
+    let inbox_claims_written = inbox_events
+        .iter()
+        .filter(|(_, event)| event.kind == "dedupe_claim")
+        .count();
+
+    println!("Queue:");
+    println!("- dispatcher_in_flight={}", dispatcher.in_flight);
+    println!(
+        "- dispatcher_retry_queue_depth={}",
+        dispatcher.retry_queue_depth
+    );
+    println!("- inferred_in_flight={}", in_flight.len());
+    println!("- inferred_pending_retries={}", pending_retries.len());
+    println!("- inbox_claims_written={}", inbox_claims_written);
+    println!(
+        "- inbox_duplicates_rejected={}",
+        inbox_snapshot.inbox_duplicates_rejected
+    );
+    println!(
+        "- inbox_fast_path_hits={}",
+        inbox_snapshot.inbox_fast_path_hits
+    );
+    println!("- inbox_durable_hits={}", inbox_snapshot.inbox_durable_hits);
+    println!(
+        "- inbox_expired_entries={}",
+        inbox_snapshot.inbox_expired_entries
+    );
+    println!(
+        "- inbox_active_entries={}",
+        inbox_snapshot.inbox_active_entries
+    );
+
+    println!();
+    println!("In-flight dispatches:");
+    if in_flight.is_empty() {
+        println!("- none");
+    } else {
+        for key in in_flight {
+            println!("- {key}");
+        }
+    }
+
+    println!();
+    println!("Pending retries:");
+    if pending_retries.is_empty() {
+        println!("- none");
+    } else {
+        for key in pending_retries {
+            println!("- {key}");
+        }
+    }
+
+    Ok(())
+}
+
+fn dispatch_key(headers: &std::collections::BTreeMap<String, String>) -> Option<String> {
+    let binding_key = headers.get("binding_key")?;
+    let event_id = headers.get("event_id")?;
+    let attempt = headers.get("attempt")?;
+    Some(format!("{binding_key}:{event_id}:{attempt}"))
+}

--- a/crates/harn-cli/src/commands/orchestrator/replay.rs
+++ b/crates/harn-cli/src/commands/orchestrator/replay.rs
@@ -1,0 +1,31 @@
+use crate::cli::OrchestratorReplayArgs;
+
+use super::common::{load_local_runtime, trigger_replay};
+
+pub(super) async fn run(args: OrchestratorReplayArgs) -> Result<(), String> {
+    let mut ctx = load_local_runtime(&args.local).await?;
+    let handle = trigger_replay(&mut ctx, &args.event_id).await?;
+
+    println!("Replay result:");
+    println!("- binding_id={}", handle.binding_id);
+    println!("- binding_version={}", handle.binding_version);
+    println!("- event_id={}", handle.event_id);
+    println!("- status={}", handle.status);
+    println!(
+        "- replay_of_event_id={}",
+        handle.replay_of_event_id.as_deref().unwrap_or("-")
+    );
+    println!(
+        "- dlq_entry_id={}",
+        handle.dlq_entry_id.as_deref().unwrap_or("-")
+    );
+    println!("- error={}", handle.error.as_deref().unwrap_or("-"));
+    println!(
+        "- result={}",
+        handle
+            .result
+            .map(|result| result.to_string())
+            .unwrap_or_else(|| "-".to_string())
+    );
+    Ok(())
+}

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -27,9 +27,9 @@ pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
     harn_vm::reset_thread_local_state();
 
     let tls = TlsFiles::from_args(args.cert.clone(), args.key.clone())?;
-    let config_path = absolutize_from_cwd(&args.config)?;
+    let config_path = absolutize_from_cwd(&args.local.config)?;
     let (manifest, manifest_dir) = load_manifest(&config_path)?;
-    let state_dir = absolutize_from_cwd(&args.state_dir)?;
+    let state_dir = absolutize_from_cwd(&args.local.state_dir)?;
     std::fs::create_dir_all(&state_dir).map_err(|error| {
         format!(
             "failed to create state dir {}: {error}",

--- a/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
+++ b/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
@@ -12,11 +12,11 @@ use std::time::{Duration, Instant};
 use harn_vm::event_log::{EventLog, SqliteEventLog, Topic};
 use tempfile::TempDir;
 
-// Since O-02 (#179/#215) landed, the orchestrator binds a real HTTP listener
-// and prints a ready line. This test predates that work; the startup needle is
-// updated to the post-#215 ready message so it keeps serving its real purpose
-// (waiting for startup to complete before asserting dedupe behaviour).
-const STARTUP_NEEDLE: &str = "HTTP listener ready on";
+// This fixture only exercises cron dispatch + inbox dedupe recovery. Waiting
+// for connector activation is sufficient and avoids a race where the
+// fail-after-emit test hook can terminate the process before the HTTP listener
+// readiness line is logged.
+const STARTUP_NEEDLE: &str = "activated connectors: cron(1)";
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
+++ b/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
@@ -57,6 +57,8 @@ fn spawn_orchestrator(
         .arg("harn.toml")
         .arg("--state-dir")
         .arg("./state")
+        .arg("--bind")
+        .arg("127.0.0.1:0")
         .arg("--role")
         .arg("single-tenant")
         .stderr(Stdio::piped())


### PR DESCRIPTION
## Summary
- implement the `harn orchestrator inspect`, `fire`, `replay`, `dlq`, and `queue` CLI commands using the existing trigger/event-log/snapshot primitives
- add shared orchestrator CLI runtime helpers plus conformance coverage for the new commands
- stabilize the orchestrator inbox dedupe test by avoiding fixed-port collisions and waiting for connector activation in the crash fixture

## Validation
- `cargo check -p harn-cli`
- `cargo test -p harn-cli test_parses_orchestrator -- --nocapture`
- `cargo test -p harn-cli --test orchestrator_cli -- --nocapture`
- `cargo nextest run -p harn-cli --test orchestrator_cli --test orchestrator_inbox_dedupe --test orchestrator_http`
- `cargo run --bin harn -- test conformance --filter orchestrator_cli_commands`
- repo pre-push gate (`nextest`, conformance format/lint, markdown, portal lint)
