### PR TITLE
Forward raw auto_compact keys (keep_last, summarize_prompt) through workflow runtime

### DIFF
--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1116,6 +1116,101 @@ fn resolve_node_session_id(node: &WorkflowNode) -> String {
     format!("workflow_stage_{}", uuid::Uuid::now_v7())
 }
 
+fn raw_auto_compact_dict(
+    node: &WorkflowNode,
+) -> Option<&std::collections::BTreeMap<String, VmValue>> {
+    node.raw_auto_compact
+        .as_ref()
+        .and_then(|value| value.as_dict())
+}
+
+fn raw_auto_compact_int(node: &WorkflowNode, key: &str) -> Option<usize> {
+    raw_auto_compact_dict(node)
+        .and_then(|dict| dict.get(key))
+        .and_then(|value| value.as_int())
+        .filter(|value| *value >= 0)
+        .map(|value| value as usize)
+}
+
+fn raw_auto_compact_string(node: &WorkflowNode, key: &str) -> Option<String> {
+    raw_auto_compact_dict(node)
+        .and_then(|dict| dict.get(key))
+        .and_then(|value| match value {
+            VmValue::String(text) if !text.trim().is_empty() => Some(text.to_string()),
+            _ => None,
+        })
+}
+
+pub(crate) async fn resolve_stage_auto_compact(
+    node: &WorkflowNode,
+    opts: &crate::llm::api::LlmCallOptions,
+) -> Result<Option<crate::orchestration::AutoCompactConfig>, VmError> {
+    if !node.auto_compact.enabled {
+        return Ok(None);
+    }
+
+    let mut ac = crate::orchestration::AutoCompactConfig::default();
+    if let Some(v) = node.auto_compact.token_threshold {
+        ac.token_threshold = v;
+    }
+    if let Some(v) = node.auto_compact.tool_output_max_chars {
+        ac.tool_output_max_chars = v;
+    }
+    if let Some(ref strategy) = node.auto_compact.compact_strategy {
+        if let Ok(s) = crate::orchestration::parse_compact_strategy(strategy) {
+            ac.compact_strategy = s;
+        }
+    }
+    if let Some(v) = node.auto_compact.hard_limit_tokens {
+        ac.hard_limit_tokens = Some(v);
+    }
+    if let Some(ref strategy) = node.auto_compact.hard_limit_strategy {
+        if let Ok(s) = crate::orchestration::parse_compact_strategy(strategy) {
+            ac.hard_limit_strategy = s;
+        }
+    }
+
+    // Workflow nodes keep the richer agent-loop-only compaction knobs in the
+    // raw dict because the typed policy shape intentionally models only the
+    // common workflow fields.
+    if let Some(v) = raw_auto_compact_int(node, "compact_keep_last")
+        .or_else(|| raw_auto_compact_int(node, "keep_last"))
+    {
+        ac.keep_last = v;
+    }
+    if let Some(prompt) = raw_auto_compact_string(node, "summarize_prompt") {
+        ac.summarize_prompt = Some(prompt);
+    }
+
+    // Closure fields can't round-trip through serde, so extract them directly
+    // from the raw VmValue dict.
+    if let Some(dict) = raw_auto_compact_dict(node) {
+        if let Some(cb) = dict.get("compress_callback") {
+            ac.compress_callback = Some(cb.clone());
+        }
+        if let Some(cb) = dict.get("mask_callback") {
+            ac.mask_callback = Some(cb.clone());
+        }
+        if let Some(cb) = dict.get("custom_compactor") {
+            ac.custom_compactor = Some(cb.clone());
+        }
+    }
+
+    let user_specified_threshold = node.auto_compact.token_threshold.is_some();
+    let user_specified_hard_limit = node.auto_compact.hard_limit_tokens.is_some();
+    crate::llm::api::adapt_auto_compact_to_provider(
+        &mut ac,
+        user_specified_threshold,
+        user_specified_hard_limit,
+        &opts.provider,
+        &opts.model,
+        &opts.api_key,
+    )
+    .await;
+
+    Ok(Some(ac))
+}
+
 pub async fn execute_stage_node(
     node_id: &str,
     node: &WorkflowNode,
@@ -1290,65 +1385,13 @@ pub async fn execute_stage_node(
             VmValue::Dict(Rc::new(options)),
         ];
         let mut opts = extract_llm_options(&args)?;
+        let auto_compact = resolve_stage_auto_compact(node, &opts).await?;
 
         if node.mode.as_deref() == Some("agent") || !tool_names.is_empty() {
             let tool_policy = workflow_tool_policy_from_tools(&node.tools);
             let effective_policy = tool_policy
                 .intersect(&node.capability_policy)
                 .map_err(VmError::Runtime)?;
-            let auto_compact = if node.auto_compact.enabled {
-                let mut ac = crate::orchestration::AutoCompactConfig::default();
-                if let Some(v) = node.auto_compact.token_threshold {
-                    ac.token_threshold = v;
-                }
-                if let Some(v) = node.auto_compact.tool_output_max_chars {
-                    ac.tool_output_max_chars = v;
-                }
-                if let Some(ref strategy) = node.auto_compact.compact_strategy {
-                    if let Ok(s) = crate::orchestration::parse_compact_strategy(strategy) {
-                        ac.compact_strategy = s;
-                    }
-                }
-                if let Some(v) = node.auto_compact.hard_limit_tokens {
-                    ac.hard_limit_tokens = Some(v);
-                }
-                if let Some(ref strategy) = node.auto_compact.hard_limit_strategy {
-                    if let Ok(s) = crate::orchestration::parse_compact_strategy(strategy) {
-                        ac.hard_limit_strategy = s;
-                    }
-                }
-                // Closure fields can't round-trip through serde, so extract them
-                // directly from the raw VmValue dict.
-                if let Some(ref raw_ac) = node.raw_auto_compact {
-                    if let Some(dict) = raw_ac.as_dict() {
-                        if let Some(cb) = dict.get("compress_callback") {
-                            ac.compress_callback = Some(cb.clone());
-                        }
-                        if let Some(cb) = dict.get("mask_callback") {
-                            ac.mask_callback = Some(cb.clone());
-                        }
-                        if let Some(cb) = dict.get("custom_compactor") {
-                            ac.custom_compactor = Some(cb.clone());
-                        }
-                    }
-                }
-                {
-                    let user_specified_threshold = node.auto_compact.token_threshold.is_some();
-                    let user_specified_hard_limit = node.auto_compact.hard_limit_tokens.is_some();
-                    crate::llm::api::adapt_auto_compact_to_provider(
-                        &mut ac,
-                        user_specified_threshold,
-                        user_specified_hard_limit,
-                        &opts.provider,
-                        &opts.model,
-                        &opts.api_key,
-                    )
-                    .await;
-                }
-                Some(ac)
-            } else {
-                None
-            };
             crate::llm::run_agent_loop_internal(
                 &mut opts,
                 crate::llm::AgentLoopConfig {

--- a/crates/harn-vm/src/stdlib/workflow/tests.rs
+++ b/crates/harn-vm/src/stdlib/workflow/tests.rs
@@ -9,6 +9,7 @@ use crate::orchestration::{
     WorkflowNode,
 };
 use crate::tracing::{set_tracing_enabled, span_end, span_start, SpanKind};
+use crate::value::VmValue;
 use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::rc::Rc;
@@ -719,4 +720,155 @@ async fn stage_prompt_can_scope_verification_to_local_contract_only() {
     assert!(prompt.contains("src/current.ts"));
     assert!(!prompt.contains("src/future.ts"));
     assert!(!prompt.contains("futureOnly"));
+}
+
+fn base_workflow_node_with_raw_auto_compact(raw: BTreeMap<String, VmValue>) -> WorkflowNode {
+    WorkflowNode {
+        id: Some("edit".to_string()),
+        kind: "stage".to_string(),
+        mode: Some("agent".to_string()),
+        done_sentinel: Some("##DONE##".to_string()),
+        model_policy: crate::orchestration::ModelPolicy {
+            provider: Some("mock".to_string()),
+            max_iterations: Some(2),
+            ..Default::default()
+        },
+        auto_compact: crate::orchestration::AutoCompactPolicy {
+            enabled: true,
+            token_threshold: Some(1),
+            compact_strategy: Some("llm".to_string()),
+            ..Default::default()
+        },
+        raw_auto_compact: Some(VmValue::Dict(Rc::new(raw))),
+        ..Default::default()
+    }
+}
+
+fn mock_llm_opts() -> crate::llm::api::LlmCallOptions {
+    // The stage builder seeds the provider + model through options so
+    // extract_llm_options produces a shape the resolver expects.
+    let mut options = BTreeMap::new();
+    options.insert(
+        "provider".to_string(),
+        VmValue::String(Rc::from("mock".to_string())),
+    );
+    options.insert(
+        "model".to_string(),
+        VmValue::String(Rc::from("mock-model".to_string())),
+    );
+    let args = vec![
+        VmValue::String(Rc::from(String::new())),
+        VmValue::Nil,
+        VmValue::Dict(Rc::new(options)),
+    ];
+    crate::llm::extract_llm_options(&args).expect("mock LlmCallOptions")
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workflow_resolve_stage_auto_compact_forwards_raw_keep_last_and_summary_prompt() {
+    crate::reset_thread_local_state();
+    let opts = mock_llm_opts();
+
+    let prompt_path = std::env::temp_dir().join(format!(
+        "harn-workflow-compaction-summary-{}.harn.prompt",
+        uuid::Uuid::now_v7()
+    ));
+    std::fs::write(&prompt_path, "CUSTOM_WORKFLOW_SUMMARY_PROMPT\n")
+        .expect("summary prompt fixture");
+    let closure_marker = VmValue::String(Rc::from("compress-callback-sentinel".to_string()));
+
+    let raw = BTreeMap::from([
+        ("enabled".to_string(), VmValue::Bool(true)),
+        ("token_threshold".to_string(), VmValue::Int(1)),
+        (
+            "compact_strategy".to_string(),
+            VmValue::String(Rc::from("llm".to_string())),
+        ),
+        ("compact_keep_last".to_string(), VmValue::Int(5)),
+        (
+            "summarize_prompt".to_string(),
+            VmValue::String(Rc::from(prompt_path.to_string_lossy().into_owned())),
+        ),
+        ("compress_callback".to_string(), closure_marker.clone()),
+    ]);
+    let node = base_workflow_node_with_raw_auto_compact(raw);
+
+    let config = crate::orchestration::resolve_stage_auto_compact(&node, &opts)
+        .await
+        .expect("resolves")
+        .expect("auto_compact enabled");
+
+    assert_eq!(
+        config.keep_last, 5,
+        "compact_keep_last from raw dict should override the typed policy default"
+    );
+    assert_eq!(
+        config.summarize_prompt.as_deref(),
+        Some(prompt_path.to_string_lossy().as_ref()),
+        "summarize_prompt from raw dict should be forwarded verbatim"
+    );
+    // VmValue is not PartialEq; compare display forms as a sentinel that the
+    // same value the host wrote was threaded through to AutoCompactConfig.
+    assert_eq!(
+        config
+            .compress_callback
+            .as_ref()
+            .map(|v| v.display())
+            .as_deref(),
+        Some(closure_marker.display().as_str()),
+        "compress_callback VmValue should thread through to AutoCompactConfig"
+    );
+
+    let _ = std::fs::remove_file(&prompt_path);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workflow_resolve_stage_auto_compact_accepts_keep_last_alias_and_skips_empty_summary_prompt(
+) {
+    crate::reset_thread_local_state();
+    let opts = mock_llm_opts();
+
+    // `keep_last` is the legacy alias hosts still emit. Empty-string
+    // summarize_prompt must leave the default in place (not crash and not
+    // become Some("")).
+    let raw = BTreeMap::from([
+        ("enabled".to_string(), VmValue::Bool(true)),
+        ("keep_last".to_string(), VmValue::Int(7)),
+        (
+            "summarize_prompt".to_string(),
+            VmValue::String(Rc::from("   ".to_string())),
+        ),
+    ]);
+    let node = base_workflow_node_with_raw_auto_compact(raw);
+
+    let config = crate::orchestration::resolve_stage_auto_compact(&node, &opts)
+        .await
+        .expect("resolves")
+        .expect("auto_compact enabled");
+
+    assert_eq!(
+        config.keep_last, 7,
+        "keep_last alias should populate the AutoCompactConfig"
+    );
+    assert!(
+        config.summarize_prompt.is_none(),
+        "blank summarize_prompt must stay None rather than becoming an empty override"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workflow_resolve_stage_auto_compact_returns_none_when_disabled() {
+    crate::reset_thread_local_state();
+    let opts = mock_llm_opts();
+
+    let mut node = base_workflow_node_with_raw_auto_compact(BTreeMap::new());
+    node.auto_compact.enabled = false;
+
+    let config = crate::orchestration::resolve_stage_auto_compact(&node, &opts)
+        .await
+        .expect("resolves");
+    assert!(
+        config.is_none(),
+        "disabled auto_compact must return None so the agent loop skips compaction wiring"
+    );
 }


### PR DESCRIPTION
Fixes the harn-side runtime path flagged by the burin-code#188 review
at <https://github.com/burin-labs/burin-code/pull/188#issuecomment-4276138587>.

## What this does

The workflow runner now reads `compact_keep_last` / `keep_last` /
`summarize_prompt` / `compress_callback` / `mask_callback` /
`custom_compactor` from the raw per-node `auto_compact` dict
alongside the existing typed `AutoCompactPolicy` fields. The typed
policy intentionally models only the 6 common workflow fields; the
richer agent-loop-only knobs flow through via the raw dict so hosts
can keep configuring them without the struct having to grow.

Config-building moved into a new `resolve_stage_auto_compact()`
helper (`pub(crate)` so tests can drive it directly) plus three small
`raw_auto_compact_{dict,int,string}` accessors.

## Why

Before this change, burin-code's per-mode compaction config
(`keep_last: 5/10/20` + a dedicated `compaction-summary.harn.prompt`)
was silently dropped because the workflow-to-agent-loop mapping only
copied the 6 typed fields. Host scripts rendered correctly at config
time but the live `agent_loop` ran with the default `keep_last=12`
and harn's built-in summarize prompt.

## Tests

Three new unit tests in `crates/harn-vm/src/stdlib/workflow/tests.rs`
that drive `resolve_stage_auto_compact` directly:

- `workflow_resolve_stage_auto_compact_forwards_raw_keep_last_and_summary_prompt`
  asserts `compact_keep_last`, a file-path `summarize_prompt`, and a
  `compress_callback` VmValue all end up on the `AutoCompactConfig`.
- `workflow_resolve_stage_auto_compact_accepts_keep_last_alias_and_skips_empty_summary_prompt`
  pins the fallback to the legacy `keep_last` spelling and proves a
  whitespace-only `summarize_prompt` stays `None` instead of
  overriding the default.
- `workflow_resolve_stage_auto_compact_returns_none_when_disabled`
  pins the early-return when `auto_compact.enabled == false`.

The earlier WIP from the Codex session tried to drive this through a
full `execute_stage_attempts()` agent-loop mock, but without tool
dispatch the post-turn compaction hook never fires in the current
runtime (see `post_turn.rs:107`: compaction is inside the
`if let Some(dispatch) = dispatch` block, so a non-tool stage never
takes that path). Testing the resolver directly is a tighter fit for
what actually changed.

## Semantic note

The originally-stashed `max_iterations: Some(3)` tweak from the
pre-commit hook is moot now — with the unit-test refactor, no agent
loop runs in these tests.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo test -p harn-vm workflow` (32/32 pass, incl. 3 new)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [ ] burin-code's `.harn-version` pinned to this release once merged