### PR TITLE
Add first-class Slack Events connector

### DIFF
--- a/conformance/helpers/slack_mock_server.py
+++ b/conformance/helpers/slack_mock_server.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+
+def json_response(handler, status, body, headers=None):
+    encoded = json.dumps(body).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(encoded)))
+    handler.send_header("Connection", "close")
+    if headers:
+        for name, value in headers.items():
+            handler.send_header(name, value)
+    handler.end_headers()
+    handler.wfile.write(encoded)
+
+
+class SlackMockState:
+    def __init__(self, root: Path):
+        self.root = root
+        self.path = root / "state.json"
+        self.requests = []
+        self.lock = threading.Lock()
+
+    def snapshot(self):
+        with self.lock:
+            return {"requests": list(self.requests)}
+
+    def write(self):
+        self.path.write_text(json.dumps(self.snapshot(), indent=2), encoding="utf-8")
+
+    def record_request(self, method: str, path: str, headers: dict, body):
+        with self.lock:
+            self.requests.append(
+                {
+                    "method": method,
+                    "path": path,
+                    "headers": headers,
+                    "body": body,
+                }
+            )
+        self.write()
+
+
+class SlackMockHandler(BaseHTTPRequestHandler):
+    server_version = "HarnSlackMock/1.0"
+
+    def log_message(self, format, *args):
+        return
+
+    @property
+    def state(self) -> SlackMockState:
+        return self.server.state
+
+    def _read_body(self):
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        if length <= 0:
+            return b""
+        return self.rfile.read(length)
+
+    def _parsed_body(self):
+        body = self._read_body()
+        if not body:
+            return None
+        content_type = self.headers.get("Content-Type", "")
+        if "application/json" in content_type:
+            return json.loads(body.decode("utf-8"))
+        if "application/x-www-form-urlencoded" in content_type:
+            parsed = parse_qs(body.decode("utf-8"))
+            return {
+                key: values[0] if len(values) == 1 else values
+                for key, values in parsed.items()
+            }
+        return body.decode("utf-8", errors="replace")
+
+    def _request_headers(self):
+        return {name.lower(): value for name, value in self.headers.items()}
+
+    def _record(self, body):
+        parsed = urlparse(self.path)
+        self.state.record_request(self.command, parsed.path, self._request_headers(), body)
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/__state":
+            json_response(self, 200, self.state.snapshot())
+            return
+        json_response(self, 404, {"ok": False, "error": f"unhandled GET {parsed.path}"})
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        body = self._parsed_body()
+        if parsed.path == "/__shutdown":
+            json_response(self, 202, {"ok": True})
+            threading.Thread(target=self.server.shutdown, daemon=True).start()
+            return
+        if parsed.path == "/chat.postMessage":
+            self._record(body)
+            json_response(
+                self,
+                200,
+                {
+                    "ok": True,
+                    "channel": body["channel"],
+                    "ts": "1715.000100",
+                    "message": {"text": body["text"]},
+                },
+            )
+            return
+        if parsed.path == "/reactions.add":
+            self._record(body)
+            json_response(
+                self,
+                200,
+                {
+                    "ok": True,
+                    "type": "event_callback",
+                    "event": {
+                        "type": "reaction_added",
+                        "reaction": body["name"],
+                        "item": {
+                            "type": "message",
+                            "channel": body["channel"],
+                            "ts": body["timestamp"],
+                        },
+                    },
+                },
+            )
+            return
+        json_response(self, 404, {"ok": False, "error": f"unhandled POST {parsed.path}"})
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: slack_mock_server.py <state-dir>", file=sys.stderr)
+        return 2
+    state_dir = Path(sys.argv[1]).resolve()
+    state_dir.mkdir(parents=True, exist_ok=True)
+    state = SlackMockState(state_dir)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), SlackMockHandler)
+    server.state = state
+    port = server.server_address[1]
+    (state_dir / "port").write_text(str(port), encoding="utf-8")
+    state.write()
+    try:
+        server.serve_forever()
+    finally:
+        state.write()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conformance/tests/agents/trigger_provider_catalog.harn
+++ b/conformance/tests/agents/trigger_provider_catalog.harn
@@ -3,7 +3,7 @@ import "std/triggers"
 pipeline test(task) {
   let providers: list<ProviderCatalogEntry> = list_providers()
   let builtin = providers.filter({ provider -> provider.runtime.kind == "builtin" })
-  assert(len(builtin) == 3, "expected exactly three builtin trigger providers")
+  assert(len(builtin) == 4, "expected exactly four builtin trigger providers")
   let cron = builtin.find({ provider -> provider.provider == "cron" })
   assert(cron?.schema_name == "CronEventPayload", "cron schema should be cataloged")
   assert(cron?.runtime?.connector == "cron", "cron should use the cron connector")
@@ -73,5 +73,34 @@ pipeline test(task) {
   assert(github_secret.name == "signing_secret", "github should require signing_secret")
   assert(github_secret.namespace == "github", "github secrets should stay namespaced to github")
   assert(len(github?.outbound_methods ?? []) == 0, "github should not publish outbound methods yet")
+  let slack = builtin.find({ provider -> provider.provider == "slack" })
+  assert(slack?.schema_name == "SlackEventPayload", "slack schema should be cataloged")
+  assert(slack?.runtime?.connector == "slack", "slack should use the slack connector")
+  assert(
+    slack?.runtime?.default_signature_variant == "slack",
+    "slack should default to slack signatures",
+  )
+  assert(
+    slack?.signature_verification?.kind == "hmac",
+    "slack should publish HMAC verification metadata",
+  )
+  assert(
+    slack?.signature_verification?.variant == "slack",
+    "slack should publish the slack signature variant",
+  )
+  assert(
+    slack?.signature_verification?.signature_header == "X-Slack-Signature",
+    "slack should expose the signature header",
+  )
+  assert(
+    slack?.signature_verification?.timestamp_header == "X-Slack-Request-Timestamp",
+    "slack should expose the timestamp header",
+  )
+  let slack_secrets = slack?.secret_requirements ?? []
+  assert(len(slack_secrets) == 1, "slack should require one secret")
+  let slack_secret = slack_secrets[0]
+  assert(slack_secret.name == "signing_secret", "slack should require signing_secret")
+  assert(slack_secret.namespace == "slack", "slack secrets should stay namespaced to slack")
+  assert(len(slack?.outbound_methods ?? []) == 0, "slack should not publish outbound methods yet")
   log("trigger_provider_catalog tests passed")
 }

--- a/conformance/tests/integration/slack_connector_roundtrip.expected
+++ b/conformance/tests/integration/slack_connector_roundtrip.expected
@@ -1,0 +1,7 @@
+C123ABC456
+1715.000100
+thumbsup
+C123ABC456
+2
+/chat.postMessage
+1715.000100

--- a/conformance/tests/integration/slack_connector_roundtrip.harn
+++ b/conformance/tests/integration/slack_connector_roundtrip.harn
@@ -1,0 +1,52 @@
+import {
+  add_reaction,
+  configure,
+  post_message,
+  reset,
+} from "std/connectors/slack"
+import { process_exec } from "std/runtime"
+
+fn wait_for_file(path, attempts) {
+  var remaining = attempts
+  while !file_exists(path) && remaining > 0 {
+    sleep(50ms)
+    remaining = remaining - 1
+  }
+  assert(file_exists(path), "timed out waiting for " + path)
+}
+
+pipeline default() {
+  let root = project_root() ?? cwd()
+  let helper_dir = path_join(root, "conformance/helpers")
+  let server_script = path_join(helper_dir, "slack_mock_server.py")
+  let state_dir = path_join(temp_dir(), "harn-slack-connector-" + uuid())
+  let port_path = path_join(state_dir, "port")
+  let pid_path = path_join(state_dir, "server.pid")
+  let log_path = path_join(state_dir, "server.log")
+  mkdir(state_dir)
+  let start = process_exec(
+    "python3 \"" + server_script + "\" \"" + state_dir + "\" >\"" + log_path
+    + "\" 2>&1 & echo $! > \""
+    + pid_path
+    + "\"",
+  )
+  assert(start?.success, "slack mock server started")
+  wait_for_file(port_path, 100)
+  let base = "http://127.0.0.1:" + read_file(port_path).trim()
+  configure(
+    {api_base_url: base, bot_token: "xoxb-test-token"},
+  )
+  let posted = post_message("C123ABC456", "hello from harn")
+  let reacted = add_reaction("C123ABC456", posted.ts, "thumbsup")
+  let state = json_parse(http_get(base + "/__state").body)
+  let _stop = http_post(base + "/__shutdown", "")
+  process_exec("kill $(cat \"" + pid_path + "\") >/dev/null 2>&1 || true")
+  reset()
+  println(posted.channel)
+  println(posted.ts)
+  println(reacted.event.reaction)
+  println(reacted.event.item.channel)
+  println(len(state.requests))
+  println(state.requests[0].path)
+  println(state.requests[1].body.timestamp)
+}

--- a/conformance/tests/integration/slack_connector_roundtrip.harn
+++ b/conformance/tests/integration/slack_connector_roundtrip.harn
@@ -1,9 +1,4 @@
-import {
-  add_reaction,
-  configure,
-  post_message,
-  reset,
-} from "std/connectors/slack"
+import { add_reaction, configure, post_message, reset } from "std/connectors/slack"
 import { process_exec } from "std/runtime"
 
 fn wait_for_file(path, attempts) {
@@ -33,9 +28,7 @@ pipeline default() {
   assert(start?.success, "slack mock server started")
   wait_for_file(port_path, 100)
   let base = "http://127.0.0.1:" + read_file(port_path).trim()
-  configure(
-    {api_base_url: base, bot_token: "xoxb-test-token"},
-  )
+  configure({api_base_url: base, bot_token: "xoxb-test-token"})
   let posted = post_message("C123ABC456", "hello from harn")
   let reacted = add_reaction("C123ABC456", posted.ts, "thumbsup")
   let state = json_parse(http_get(base + "/__state").body)

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -320,7 +320,7 @@ impl RouteRegistry {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SignatureMode {
     GitHub,
     Standard,
@@ -628,6 +628,52 @@ fn trigger_path(trigger: &CollectedManifestTrigger) -> Result<String, String> {
         ));
     }
     Ok(path)
+}
+
+async fn load_secret(
+    context: &RouteContext,
+    secret_id: Option<&SecretId>,
+) -> Result<String, HttpError> {
+    let secret_id = secret_id.ok_or_else(|| {
+        HttpError::internal(format!(
+            "trigger '{}' requires a signing secret",
+            context.route.trigger_id
+        ))
+    })?;
+    let secret = context
+        .secrets
+        .get(secret_id)
+        .await
+        .map_err(|error| HttpError::internal(error.to_string()))?;
+    secret.with_exposed(|bytes| {
+        std::str::from_utf8(bytes)
+            .map(|value| value.to_string())
+            .map_err(|error| {
+                HttpError::internal(format!(
+                    "secret '{}' is not valid UTF-8: {error}",
+                    secret_id
+                ))
+            })
+    })
+}
+
+fn parse_secret_id(raw: Option<&str>) -> Option<SecretId> {
+    let trimmed = raw?.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let (base, version) = match trimmed.rsplit_once('@') {
+        Some((base, version_text)) => {
+            let version = version_text.parse::<u64>().ok()?;
+            (base, SecretVersion::Exact(version))
+        }
+        None => (trimmed, SecretVersion::Latest),
+    };
+    let (namespace, name) = base.split_once('/')?;
+    if namespace.is_empty() || name.is_empty() {
+        return None;
+    }
+    Some(SecretId::new(namespace, name).with_version(version))
 }
 
 #[derive(Clone, Default)]
@@ -1030,6 +1076,7 @@ mod tests {
             signing_secret: None,
             dedupe_key_template: None,
             dedupe_retention_days: harn_vm::DEFAULT_INBOX_RETENTION_DAYS,
+            connector: None,
         }
     }
 

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -7,7 +7,7 @@ use axum::body::Bytes;
 use axum::extract::{DefaultBodyLimit, Extension, OriginalUri, Query};
 use axum::http::{HeaderMap, Method, StatusCode};
 use axum::middleware;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Router;
 use serde_json::{json, Value as JsonValue};
@@ -15,15 +15,13 @@ use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 use time::OffsetDateTime;
 
-use harn_vm::event_log::{AnyEventLog, EventLog, LogEvent, Topic};
-use harn_vm::secrets::{SecretId, SecretProvider, SecretVersion};
+use harn_vm::event_log::AnyEventLog;
 
 use crate::commands::orchestrator::origin_guard::{enforce_allowed_origin, OriginAllowList};
 use crate::commands::orchestrator::tls::{ServerRuntime, TlsFiles};
 use crate::package::{CollectedManifestTrigger, TriggerKind};
 
 const DEFAULT_MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
-const PENDING_TOPIC: &str = "orchestrator.triggers.pending";
 const REQUEST_DELAY_ENV: &str = "HARN_ORCHESTRATOR_TEST_REQUEST_DELAY_MS";
 const API_KEYS_ENV: &str = "HARN_ORCHESTRATOR_API_KEYS";
 const HMAC_SECRET_ENV: &str = "HARN_ORCHESTRATOR_HMAC_SECRET";
@@ -156,6 +154,7 @@ pub(crate) struct RouteConfig {
     pub(crate) signing_secret: Option<SecretId>,
     pub(crate) dedupe_key_template: Option<String>,
     pub(crate) dedupe_retention_days: u32,
+    pub(crate) connector: Option<harn_vm::connectors::ConnectorHandle>,
 }
 
 impl RouteConfig {
@@ -169,6 +168,7 @@ impl RouteConfig {
                 let signature_mode = match provider.as_str() {
                     "github" => SignatureMode::GitHub,
                     "webhook" => SignatureMode::Standard,
+                    "slack" => SignatureMode::Unsigned,
                     other => {
                         return Err(format!(
                             "HTTP listener does not yet support webhook provider '{other}' on this branch"
@@ -191,6 +191,7 @@ impl RouteConfig {
                     ),
                     dedupe_key_template: trigger.config.dedupe_key.clone(),
                     dedupe_retention_days: trigger.config.retry.retention_days,
+                    connector: None,
                 }))
             }
             TriggerKind::A2aPush => Ok(Some(Self {
@@ -203,6 +204,7 @@ impl RouteConfig {
                 signing_secret: None,
                 dedupe_key_template: trigger.config.dedupe_key.clone(),
                 dedupe_retention_days: trigger.config.retry.retention_days,
+                connector: None,
             })),
             _ => Ok(None),
         }
@@ -216,7 +218,6 @@ struct RouteContext {
     inbox: Arc<harn_vm::InboxIndex>,
     secrets: Arc<dyn SecretProvider>,
     auth: Arc<ListenerAuth>,
-    pending_topic: Topic,
     request_delay: Option<Duration>,
     metrics: Arc<RouteRuntimeMetrics>,
 }
@@ -399,7 +400,7 @@ async fn ingest_trigger(
 
     let result = normalize_request(&context, &normalized_headers, &query, body.as_ref()).await;
     let response = match result {
-        Ok(event) => {
+        Ok(NormalizedRequest::Event(event)) => {
             let dedupe_ttl = Duration::from_secs(
                 u64::from(context.route.dedupe_retention_days.max(1)) * 24 * 60 * 60,
             );
@@ -408,7 +409,7 @@ async fn ingest_trigger(
                 &context.route.trigger_id,
                 context.route.dedupe_key_template.is_some(),
                 dedupe_ttl,
-                event,
+                *event,
             )
             .await;
             match postprocess {
@@ -469,6 +470,11 @@ async fn ingest_trigger(
                 }
             }
         }
+        Ok(NormalizedRequest::Immediate(response)) => {
+            context.metrics.dispatched.fetch_add(1, Ordering::Relaxed);
+            context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+            response
+        }
         Err(error) => {
             context.metrics.failed.fetch_add(1, Ordering::Relaxed);
             context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
@@ -499,10 +505,37 @@ async fn authorize_request(
 async fn normalize_request(
     context: &RouteContext,
     normalized_headers: &BTreeMap<String, String>,
-    _query: &BTreeMap<String, String>,
+    query: &BTreeMap<String, String>,
     body: &[u8],
-) -> Result<harn_vm::TriggerEvent, HttpError> {
+) -> Result<NormalizedRequest, HttpError> {
     let received_at = OffsetDateTime::now_utc();
+    if let Some(connector) = context.route.connector.as_ref() {
+        let mut raw = harn_vm::RawInbound::new("", normalized_headers.clone(), body.to_vec());
+        raw.query = query.clone();
+        raw.received_at = received_at;
+        raw.metadata = json!({
+            "binding_id": context.route.trigger_id,
+            "binding_version": context.route.binding_version,
+            "path": context.route.path,
+        });
+        let event = connector
+            .lock()
+            .await
+            .normalize_inbound(raw)
+            .map_err(HttpError::from_connector)?;
+        if let Some(challenge) = slack_url_verification_challenge(&event) {
+            return Ok(NormalizedRequest::Immediate(
+                (
+                    StatusCode::OK,
+                    [("content-type", "text/plain; charset=utf-8")],
+                    challenge,
+                )
+                    .into_response(),
+            ));
+        }
+        return Ok(NormalizedRequest::Event(Box::new(event)));
+    }
+
     let normalized_body = normalize_body(body, normalized_headers);
     let provider = context.route.provider.clone();
 
@@ -544,12 +577,7 @@ async fn normalize_request(
 
     let provider_kind = provider_event_kind(&provider, normalized_headers, &normalized_body);
     let trigger_kind = trigger_event_kind(&provider, normalized_headers, &normalized_body);
-    let dedupe_key = dedupe_key(
-        context.route.signature_mode,
-        normalized_headers,
-        &normalized_body,
-        body,
-    );
+    let dedupe_key = dedupe_key(&provider, normalized_headers, &normalized_body, body);
     let provider_payload = harn_vm::ProviderPayload::normalize(
         &provider,
         &provider_kind,
@@ -558,7 +586,7 @@ async fn normalize_request(
     )
     .map_err(|error| HttpError::unprocessable(error.to_string()))?;
 
-    Ok(harn_vm::TriggerEvent {
+    Ok(NormalizedRequest::Event(Box::new(harn_vm::TriggerEvent {
         id: harn_vm::TriggerEventId::new(),
         provider,
         kind: trigger_kind,
@@ -574,7 +602,12 @@ async fn normalize_request(
         provider_payload,
         signature_status,
         dedupe_claimed: false,
-    })
+    })))
+}
+
+enum NormalizedRequest {
+    Event(Box<harn_vm::TriggerEvent>),
+    Immediate(Response),
 }
 
 fn trigger_path(trigger: &CollectedManifestTrigger) -> Result<String, String> {
@@ -592,52 +625,6 @@ fn trigger_path(trigger: &CollectedManifestTrigger) -> Result<String, String> {
         ));
     }
     Ok(path)
-}
-
-async fn load_secret(
-    context: &RouteContext,
-    secret_id: Option<&SecretId>,
-) -> Result<String, HttpError> {
-    let secret_id = secret_id.ok_or_else(|| {
-        HttpError::internal(format!(
-            "trigger '{}' requires a signing secret",
-            context.route.trigger_id
-        ))
-    })?;
-    let secret = context
-        .secrets
-        .get(secret_id)
-        .await
-        .map_err(|error| HttpError::internal(error.to_string()))?;
-    secret.with_exposed(|bytes| {
-        std::str::from_utf8(bytes)
-            .map(|value| value.to_string())
-            .map_err(|error| {
-                HttpError::internal(format!(
-                    "secret '{}' is not valid UTF-8: {error}",
-                    secret_id
-                ))
-            })
-    })
-}
-
-fn parse_secret_id(raw: Option<&str>) -> Option<SecretId> {
-    let trimmed = raw?.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    let (base, version) = match trimmed.rsplit_once('@') {
-        Some((base, version_text)) => {
-            let version = version_text.parse::<u64>().ok()?;
-            (base, SecretVersion::Exact(version))
-        }
-        None => (trimmed, SecretVersion::Latest),
-    };
-    let (namespace, name) = base.split_once('/')?;
-    if namespace.is_empty() || name.is_empty() {
-        return None;
-    }
-    Some(SecretId::new(namespace, name).with_version(version))
 }
 
 #[derive(Clone, Default)]
@@ -760,6 +747,10 @@ fn normalize_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
         ("x-github-event", "X-GitHub-Event"),
         ("x-github-delivery", "X-GitHub-Delivery"),
         ("x-hub-signature-256", "X-Hub-Signature-256"),
+        ("x-slack-signature", "X-Slack-Signature"),
+        ("x-slack-request-timestamp", "X-Slack-Request-Timestamp"),
+        ("x-slack-retry-num", "X-Slack-Retry-Num"),
+        ("x-slack-retry-reason", "X-Slack-Retry-Reason"),
         ("webhook-id", "webhook-id"),
         ("webhook-signature", "webhook-signature"),
         ("webhook-timestamp", "webhook-timestamp"),
@@ -827,16 +818,16 @@ fn trigger_event_kind(
 }
 
 fn dedupe_key(
-    signature_mode: SignatureMode,
+    provider: &harn_vm::ProviderId,
     headers: &BTreeMap<String, String>,
     body: &JsonValue,
     raw_body: &[u8],
 ) -> String {
-    match signature_mode {
-        SignatureMode::GitHub => header_value(headers, "x-github-delivery")
+    match provider.as_str() {
+        "github" => header_value(headers, "x-github-delivery")
             .map(ToString::to_string)
             .unwrap_or_else(|| fallback_body_digest(raw_body)),
-        SignatureMode::Standard => header_value(headers, "webhook-id")
+        "webhook" => header_value(headers, "webhook-id")
             .map(ToString::to_string)
             .or_else(|| {
                 body.get("id")
@@ -844,7 +835,7 @@ fn dedupe_key(
                     .map(ToString::to_string)
             })
             .unwrap_or_else(|| fallback_body_digest(raw_body)),
-        SignatureMode::Unsigned => header_value(headers, "x-a2a-delivery")
+        _ => header_value(headers, "x-a2a-delivery")
             .map(ToString::to_string)
             .unwrap_or_else(|| fallback_body_digest(raw_body)),
     }
@@ -856,6 +847,7 @@ fn infer_occurred_at(payload: &harn_vm::ProviderPayload) -> Option<OffsetDateTim
     };
     let raw = match payload {
         harn_vm::triggers::event::KnownProviderPayload::GitHub(payload) => github_raw(payload),
+        harn_vm::triggers::event::KnownProviderPayload::Slack(payload) => slack_raw(payload),
         harn_vm::triggers::event::KnownProviderPayload::Webhook(payload) => &payload.raw,
         harn_vm::triggers::event::KnownProviderPayload::A2aPush(payload) => &payload.raw,
         _ => return None,
@@ -877,6 +869,33 @@ fn github_raw(payload: &harn_vm::triggers::event::GitHubEventPayload) -> &JsonVa
         harn_vm::triggers::event::GitHubEventPayload::WorkflowRun(inner) => &inner.common.raw,
         harn_vm::triggers::event::GitHubEventPayload::Other(common) => &common.raw,
     }
+}
+
+fn slack_raw(payload: &harn_vm::triggers::event::SlackEventPayload) -> &JsonValue {
+    match payload {
+        harn_vm::triggers::event::SlackEventPayload::MessageChannels(inner) => &inner.common.raw,
+        harn_vm::triggers::event::SlackEventPayload::AppMention(inner) => &inner.common.raw,
+        harn_vm::triggers::event::SlackEventPayload::ReactionAdded(inner) => &inner.common.raw,
+        harn_vm::triggers::event::SlackEventPayload::TeamJoin(inner) => &inner.common.raw,
+        harn_vm::triggers::event::SlackEventPayload::ChannelCreated(inner) => &inner.common.raw,
+        harn_vm::triggers::event::SlackEventPayload::Other(common) => &common.raw,
+    }
+}
+
+fn slack_url_verification_challenge(event: &harn_vm::TriggerEvent) -> Option<String> {
+    let harn_vm::ProviderPayload::Known(harn_vm::triggers::event::KnownProviderPayload::Slack(
+        payload,
+    )) = &event.provider_payload
+    else {
+        return None;
+    };
+    if event.kind != "url_verification" {
+        return None;
+    }
+    slack_raw(payload)
+        .get("challenge")
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string)
 }
 
 fn header_value<'a>(headers: &'a BTreeMap<String, String>, name: &str) -> Option<&'a str> {

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -320,7 +320,7 @@ impl RouteRegistry {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 pub(crate) enum SignatureMode {
     GitHub,
     Standard,
@@ -1136,6 +1136,7 @@ mod tests {
             signing_secret: Some(SecretId::new("github", "test-signing-secret")),
             dedupe_key_template: Some("event.dedupe_key".to_string()),
             dedupe_retention_days: harn_vm::DEFAULT_INBOX_RETENTION_DAYS,
+            connector: None,
         }
     }
 

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -15,13 +15,15 @@ use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 use time::OffsetDateTime;
 
-use harn_vm::event_log::AnyEventLog;
+use harn_vm::event_log::{AnyEventLog, EventLog, LogEvent, Topic};
+use harn_vm::secrets::{SecretId, SecretProvider, SecretVersion};
 
 use crate::commands::orchestrator::origin_guard::{enforce_allowed_origin, OriginAllowList};
 use crate::commands::orchestrator::tls::{ServerRuntime, TlsFiles};
 use crate::package::{CollectedManifestTrigger, TriggerKind};
 
 const DEFAULT_MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
+const PENDING_TOPIC: &str = "orchestrator.triggers.pending";
 const REQUEST_DELAY_ENV: &str = "HARN_ORCHESTRATOR_TEST_REQUEST_DELAY_MS";
 const API_KEYS_ENV: &str = "HARN_ORCHESTRATOR_API_KEYS";
 const HMAC_SECRET_ENV: &str = "HARN_ORCHESTRATOR_HMAC_SECRET";
@@ -218,6 +220,7 @@ struct RouteContext {
     inbox: Arc<harn_vm::InboxIndex>,
     secrets: Arc<dyn SecretProvider>,
     auth: Arc<ListenerAuth>,
+    pending_topic: Topic,
     request_delay: Option<Duration>,
     metrics: Arc<RouteRuntimeMetrics>,
 }

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -171,12 +171,6 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
         format_activation_summary(&connector_runtime.activations)
     );
 
-    let dispatcher = harn_vm::Dispatcher::with_event_log(vm, event_log.clone());
-    let dispatcher_task = {
-        let dispatcher = dispatcher.clone();
-        tokio::task::spawn_local(async move { dispatcher.run().await })
-    };
-
     write_state_snapshot(
         &state_dir.join(STATE_SNAPSHOT_FILE),
         &ServeStateSnapshot {
@@ -279,12 +273,7 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
         inbox_pump,
     )
     .await;
-    let dispatcher_result = dispatcher_task
-        .await
-        .map_err(|error| format!("dispatcher task join failed: {error}"))?
-        .map_err(|error| format!("dispatcher failed during shutdown: {error}"));
-    shutdown?;
-    dispatcher_result
+    shutdown
 }
 
 struct ConnectorRuntime {

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -121,7 +121,7 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
 
     let binding_versions = live_manifest_binding_versions();
     let route_configs = build_route_configs(&collected_triggers, &binding_versions)?;
-    let connector_runtime = initialize_connectors(
+    let mut connector_runtime = initialize_connectors(
         &collected_triggers,
         event_log.clone(),
         secret_provider.clone(),
@@ -160,6 +160,22 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
     let mut live_manifest = manifest;
     let mut live_triggers = collected_triggers;
     eprintln!("[harn] HTTP listener ready on {}", listener.url());
+
+    connector_runtime.activations = connector_runtime
+        .registry
+        .activate_all(&connector_runtime.trigger_registry)
+        .await
+        .map_err(|error| error.to_string())?;
+    eprintln!(
+        "[harn] activated connectors: {}",
+        format_activation_summary(&connector_runtime.activations)
+    );
+
+    let dispatcher = harn_vm::Dispatcher::with_event_log(vm, event_log.clone());
+    let dispatcher_task = {
+        let dispatcher = dispatcher.clone();
+        tokio::task::spawn_local(async move { dispatcher.run().await })
+    };
 
     write_state_snapshot(
         &state_dir.join(STATE_SNAPSHOT_FILE),
@@ -272,7 +288,8 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
 }
 
 struct ConnectorRuntime {
-    _registry: harn_vm::ConnectorRegistry,
+    registry: harn_vm::ConnectorRegistry,
+    trigger_registry: harn_vm::TriggerRegistry,
     handles: Vec<harn_vm::connectors::ConnectorHandle>,
     providers: Vec<String>,
     activations: Vec<harn_vm::ActivationHandle>,
@@ -352,16 +369,12 @@ async fn initialize_connectors(
         providers.push(provider_name);
     }
 
-    let activations = registry
-        .activate_all(&trigger_registry)
-        .await
-        .map_err(|error| error.to_string())?;
-
     Ok(ConnectorRuntime {
-        _registry: registry,
+        registry,
+        trigger_registry,
         handles,
         providers,
-        activations,
+        activations: Vec::new(),
     })
 }
 

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -127,6 +127,7 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
         secret_provider.clone(),
     )
     .await?;
+    let route_configs = attach_route_connectors(route_configs, &connector_runtime.registry)?;
     eprintln!(
         "[harn] registered connectors ({}): {}",
         connector_runtime.providers.len(),
@@ -239,7 +240,8 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
     })
     .await?;
 
-    graceful_shutdown(
+    dispatcher.shutdown();
+    let shutdown = graceful_shutdown(
         GracefulShutdownCtx {
             role: args.role,
             bind: local_bind,
@@ -260,7 +262,13 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
         cron_pump,
         inbox_pump,
     )
-    .await
+    .await;
+    let dispatcher_result = dispatcher_task
+        .await
+        .map_err(|error| format!("dispatcher task join failed: {error}"))?
+        .map_err(|error| format!("dispatcher failed during shutdown: {error}"));
+    shutdown?;
+    dispatcher_result
 }
 
 struct ConnectorRuntime {
@@ -423,6 +431,35 @@ fn build_route_configs(
         }
     }
     Ok(routes)
+}
+
+fn attach_route_connectors(
+    routes: Vec<RouteConfig>,
+    registry: &harn_vm::ConnectorRegistry,
+) -> Result<Vec<RouteConfig>, String> {
+    routes
+        .into_iter()
+        .map(|mut route| {
+            // Only providers whose `normalize_inbound` owns HMAC verification
+            // and URL-challenge handling need the connector handle on the
+            // HTTP listener path. Webhook/github routes stay on the
+            // signature-based `normalize_request` flow in the listener so
+            // their existing Option-2 post-processing dedupe keeps working.
+            if connector_owns_ingress(route.provider.as_str()) {
+                route.connector = Some(registry.get(&route.provider).ok_or_else(|| {
+                    format!(
+                        "connector registry is missing provider '{}'",
+                        route.provider.as_str()
+                    )
+                })?);
+            }
+            Ok(route)
+        })
+        .collect()
+}
+
+fn connector_owns_ingress(provider: &str) -> bool {
+    matches!(provider, "slack")
 }
 
 fn live_manifest_binding_versions() -> BTreeMap<String, u32> {

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -89,6 +89,45 @@ pub fn on_issue(event: TriggerEvent) {
 "#
 }
 
+fn slack_manifest(orchestrator_block: Option<&str>) -> String {
+    let mut manifest = r#"
+[package]
+name = "fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "slack-mentions"
+kind = "webhook"
+provider = "slack"
+match = { events = ["app_mention"] }
+handler = "handlers::on_slack"
+secrets = { signing_secret = "slack/signing-secret" }
+"#
+    .to_string();
+    if let Some(block) = orchestrator_block {
+        manifest.push('\n');
+        manifest.push_str(block);
+        manifest.push('\n');
+    }
+    manifest
+}
+
+fn slack_handler_module(marker_path: &Path) -> String {
+    format!(
+        r#"
+import "std/triggers"
+
+pub fn on_slack(event: TriggerEvent) {{
+  sleep(4100ms)
+  write_file({marker:?}, event.kind)
+}}
+"#,
+        marker = marker_path.display().to_string()
+    )
+}
+
 fn a2a_manifest(orchestrator_block: Option<&str>) -> String {
     let mut manifest = r#"
 [package]
@@ -251,6 +290,17 @@ fn github_signature(secret: &str, body: &[u8]) -> String {
     format!("sha256={encoded}")
 }
 
+fn slack_signature(secret: &str, timestamp: i64, body: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+    mac.update(format!("v0:{timestamp}:").as_bytes());
+    mac.update(body);
+    let mut encoded = String::new();
+    for byte in mac.finalize().into_bytes() {
+        encoded.push_str(&format!("{byte:02x}"));
+    }
+    format!("v0={encoded}")
+}
+
 fn github_headers(secret: &str, body: &[u8], origin: Option<&str>) -> HeaderMap {
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
@@ -269,6 +319,20 @@ fn github_headers(secret: &str, body: &[u8], origin: Option<&str>) -> HeaderMap 
     headers
 }
 
+fn slack_headers(secret: &str, timestamp: i64, body: &[u8]) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert(
+        "X-Slack-Request-Timestamp",
+        HeaderValue::from_str(&timestamp.to_string()).unwrap(),
+    );
+    headers.insert(
+        "X-Slack-Signature",
+        HeaderValue::from_str(&slack_signature(secret, timestamp, body)).unwrap(),
+    );
+    headers
+}
+
 fn state_snapshot(temp: &TempDir) -> String {
     fs::read_to_string(temp.path().join("state/orchestrator-state.json")).unwrap()
 }
@@ -283,6 +347,17 @@ fn json_headers() -> HeaderMap {
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
     headers
+}
+
+fn wait_for_path(path: &Path, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!("timed out waiting for {}", path.display());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -328,6 +403,111 @@ async fn github_webhook_delivery_is_accepted_and_persisted() {
         snapshot.contains("\"dispatched\": 1"),
         "snapshot={snapshot}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn slack_webhook_acknowledges_before_handler_finishes() {
+    let _lock = lock_orchestrator_tests();
+    let temp = TempDir::new().unwrap();
+    let marker_path = temp.path().join("slack-handler.txt");
+    write_file(temp.path(), "harn.toml", &slack_manifest(None));
+    write_file(temp.path(), "lib.harn", &slack_handler_module(&marker_path));
+
+    let secret = "slack-signing-secret";
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_SECRET_SLACK_SIGNING_SECRET", secret),
+    ];
+    let mut process = spawn_orchestrator(&temp, &[], &envs);
+    let base_url = process.wait_for_listener_url();
+
+    let timestamp = OffsetDateTime::now_utc().unix_timestamp();
+    let body = serde_json::to_vec(&serde_json::json!({
+        "token": "ZZZZZZWSxiZZZ2yIvs3peJ",
+        "team_id": "T123ABC456",
+        "api_app_id": "A123ABC456",
+        "event": {
+            "type": "app_mention",
+            "user": "U123ABC456",
+            "text": "What is the hour of the pearl, <@U0LAN0Z89>?",
+            "ts": "1515449522.000016",
+            "channel": "C123ABC456",
+            "event_ts": "1515449522000016"
+        },
+        "type": "event_callback",
+        "event_id": "Ev123ABC456",
+        "event_time": 1515449522000016i64
+    }))
+    .unwrap();
+
+    let started = Instant::now();
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/triggers/slack-mentions"))
+        .headers(slack_headers(secret, timestamp, &body))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_status(response, StatusCode::OK).await;
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "slack ack path took too long: {:?}",
+        started.elapsed()
+    );
+    assert!(
+        !marker_path.exists(),
+        "handler should not have completed before the HTTP ack"
+    );
+    wait_for_path(&marker_path, Duration::from_secs(10));
+    let marker = fs::read_to_string(&marker_path).unwrap();
+    assert_eq!(marker, "app_mention");
+
+    send_sigterm(&process.child);
+    wait_for_exit(&mut process.child);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn slack_url_verification_returns_plaintext_challenge() {
+    let _lock = lock_orchestrator_tests();
+    let temp = TempDir::new().unwrap();
+    write_file(temp.path(), "harn.toml", &slack_manifest(None));
+    write_file(
+        temp.path(),
+        "lib.harn",
+        &slack_handler_module(&temp.path().join("unused-slack-marker.txt")),
+    );
+
+    let secret = "slack-signing-secret";
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_SECRET_SLACK_SIGNING_SECRET", secret),
+    ];
+    let mut process = spawn_orchestrator(&temp, &[], &envs);
+    let base_url = process.wait_for_listener_url();
+
+    let timestamp = OffsetDateTime::now_utc().unix_timestamp();
+    let body = serde_json::to_vec(&serde_json::json!({
+        "token": "legacy-token",
+        "challenge": "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P",
+        "type": "url_verification"
+    }))
+    .unwrap();
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/triggers/slack-mentions"))
+        .headers(slack_headers(secret, timestamp, &body))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_body = response.text().await.unwrap();
+    assert_eq!(
+        response_body,
+        "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P"
+    );
+
+    send_sigterm(&process.child);
+    wait_for_exit(&mut process.child);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/harn-vm/src/connectors/hmac.rs
+++ b/crates/harn-vm/src/connectors/hmac.rs
@@ -14,6 +14,8 @@ use super::ConnectorError;
 
 pub const SIGNATURE_VERIFY_AUDIT_TOPIC: &str = "audit.signature_verify";
 pub const DEFAULT_GITHUB_SIGNATURE_HEADER: &str = "x-hub-signature-256";
+pub const DEFAULT_SLACK_SIGNATURE_HEADER: &str = "x-slack-signature";
+pub const DEFAULT_SLACK_TIMESTAMP_HEADER: &str = "x-slack-request-timestamp";
 pub const DEFAULT_STRIPE_SIGNATURE_HEADER: &str = "stripe-signature";
 pub const DEFAULT_STANDARD_WEBHOOKS_ID_HEADER: &str = "webhook-id";
 pub const DEFAULT_STANDARD_WEBHOOKS_SIGNATURE_HEADER: &str = "webhook-signature";
@@ -27,6 +29,11 @@ pub enum HmacSignatureStyle<'a> {
     GitHub {
         signature_header: &'a str,
         prefix: &'a str,
+    },
+    Slack {
+        signature_header: &'a str,
+        timestamp_header: &'a str,
+        version: &'a str,
     },
     Stripe {
         signature_header: &'a str,
@@ -59,6 +66,14 @@ impl<'a> HmacSignatureStyle<'a> {
         }
     }
 
+    pub fn slack() -> Self {
+        Self::Slack {
+            signature_header: DEFAULT_SLACK_SIGNATURE_HEADER,
+            timestamp_header: DEFAULT_SLACK_TIMESTAMP_HEADER,
+            version: "v0",
+        }
+    }
+
     pub fn standard_webhooks() -> Self {
         Self::StandardWebhooks {
             id_header: DEFAULT_STANDARD_WEBHOOKS_ID_HEADER,
@@ -78,6 +93,7 @@ impl<'a> HmacSignatureStyle<'a> {
     fn label(self) -> &'static str {
         match self {
             Self::GitHub { .. } => "github",
+            Self::Slack { .. } => "slack",
             Self::Stripe { .. } => "stripe",
             Self::StandardWebhooks { .. } => "standard_webhooks",
             Self::CanonicalRequest { .. } => "canonical_request",
@@ -111,6 +127,26 @@ pub async fn verify_hmac_signed<L: EventLog + ?Sized>(
                 body,
                 headers,
                 secret,
+                now,
+            )
+            .await
+        }
+        HmacSignatureStyle::Slack {
+            signature_header,
+            timestamp_header,
+            version,
+        } => {
+            verify_slack(
+                event_log,
+                provider,
+                style,
+                signature_header,
+                timestamp_header,
+                version,
+                body,
+                headers,
+                secret,
+                timestamp_window,
                 now,
             )
             .await
@@ -263,6 +299,136 @@ async fn verify_github<L: EventLog + ?Sized>(
         let error =
             ConnectorError::invalid_signature("signature did not match the raw request body");
         reject(event_log, provider, style, &error, now, None, None).await
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn verify_slack<L: EventLog + ?Sized>(
+    event_log: &L,
+    provider: &ProviderId,
+    style: HmacSignatureStyle<'_>,
+    signature_header: &str,
+    timestamp_header: &str,
+    version: &str,
+    body: &[u8],
+    headers: &BTreeMap<String, String>,
+    secret: &str,
+    timestamp_window: Option<Duration>,
+    now: OffsetDateTime,
+) -> Result<(), ConnectorError> {
+    let window = match timestamp_window {
+        Some(window) => window,
+        None => {
+            let error = ConnectorError::Unsupported(
+                "slack-style signature verification requires a timestamp window".to_string(),
+            );
+            return reject(event_log, provider, style, &error, now, None, None).await;
+        }
+    };
+
+    let timestamp_raw = match required_header(headers, timestamp_header) {
+        Ok(value) => value,
+        Err(error) => {
+            return reject(event_log, provider, style, &error, now, None, Some(window)).await;
+        }
+    };
+    let timestamp = match timestamp_raw.parse::<i64>() {
+        Ok(raw) => match OffsetDateTime::from_unix_timestamp(raw) {
+            Ok(timestamp) => timestamp,
+            Err(error) => {
+                let error = ConnectorError::InvalidHeader {
+                    name: timestamp_header.to_string(),
+                    detail: error.to_string(),
+                };
+                return reject(event_log, provider, style, &error, now, None, Some(window)).await;
+            }
+        },
+        Err(error) => {
+            let error = ConnectorError::InvalidHeader {
+                name: timestamp_header.to_string(),
+                detail: error.to_string(),
+            };
+            return reject(event_log, provider, style, &error, now, None, Some(window)).await;
+        }
+    };
+    ensure_timestamp_within_window(event_log, provider, style, timestamp, window, now).await?;
+
+    let header = match required_header(headers, signature_header) {
+        Ok(value) => value,
+        Err(error) => {
+            return reject(
+                event_log,
+                provider,
+                style,
+                &error,
+                now,
+                Some(timestamp),
+                Some(window),
+            )
+            .await;
+        }
+    };
+    let prefix = format!("{version}=");
+    let encoded = match header.strip_prefix(prefix.as_str()) {
+        Some(value) => value,
+        None => {
+            let error = ConnectorError::InvalidHeader {
+                name: signature_header.to_string(),
+                detail: format!("expected `{prefix}` prefix"),
+            };
+            return reject(
+                event_log,
+                provider,
+                style,
+                &error,
+                now,
+                Some(timestamp),
+                Some(window),
+            )
+            .await;
+        }
+    };
+    let provided = match hex::decode(encoded) {
+        Ok(value) => value,
+        Err(error) => {
+            let error = ConnectorError::InvalidHeader {
+                name: signature_header.to_string(),
+                detail: error.to_string(),
+            };
+            return reject(
+                event_log,
+                provider,
+                style,
+                &error,
+                now,
+                Some(timestamp),
+                Some(window),
+            )
+            .await;
+        }
+    };
+
+    let mut signed = Vec::with_capacity(version.len() + timestamp_raw.len() + body.len() + 2);
+    signed.extend_from_slice(version.as_bytes());
+    signed.push(b':');
+    signed.extend_from_slice(timestamp_raw.as_bytes());
+    signed.push(b':');
+    signed.extend_from_slice(body);
+    let expected = hmac_sha256(secret.as_bytes(), &signed);
+    if secure_eq(&expected, &provided) {
+        Ok(())
+    } else {
+        let error = ConnectorError::invalid_signature("slack signature mismatch");
+        reject(
+            event_log,
+            provider,
+            style,
+            &error,
+            now,
+            Some(timestamp),
+            Some(window),
+        )
+        .await
     }
 }
 
@@ -973,6 +1139,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn verifies_slack_signature_using_official_docs_vector() {
+        let log = log();
+        let headers = BTreeMap::from([
+            (
+                "X-Slack-Signature".to_string(),
+                "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503".to_string(),
+            ),
+            (
+                "X-Slack-Request-Timestamp".to_string(),
+                "1531420618".to_string(),
+            ),
+        ]);
+        let body = b"token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
+
+        verify_hmac_signed(
+            log.as_ref(),
+            &ProviderId::from("slack"),
+            HmacSignatureStyle::slack(),
+            body,
+            &headers,
+            "8f742231b10e8888abcd99yyyzzz85a5",
+            Some(Duration::minutes(5)),
+            OffsetDateTime::from_unix_timestamp(1_531_420_618).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(audit_events(&log).await.is_empty());
+    }
+
+    #[tokio::test]
     async fn verifies_standard_webhooks_using_vendor_test_vector() {
         let log = log();
         let headers = BTreeMap::from([
@@ -1124,6 +1321,38 @@ mod tests {
             "whsec_test_secret",
             Some(Duration::seconds(10)),
             OffsetDateTime::from_unix_timestamp(12_400).unwrap(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, ConnectorError::TimestampOutOfWindow { .. }));
+        assert_eq!(audit_events(&log).await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn rejects_expired_slack_timestamp_window() {
+        let log = log();
+        let headers = BTreeMap::from([
+            (
+                "X-Slack-Signature".to_string(),
+                "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503".to_string(),
+            ),
+            (
+                "X-Slack-Request-Timestamp".to_string(),
+                "1531420618".to_string(),
+            ),
+        ]);
+        let body = b"token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
+
+        let error = verify_hmac_signed(
+            log.as_ref(),
+            &ProviderId::from("slack"),
+            HmacSignatureStyle::slack(),
+            body,
+            &headers,
+            "8f742231b10e8888abcd99yyyzzz85a5",
+            Some(Duration::minutes(5)),
+            OffsetDateTime::from_unix_timestamp(1_531_421_000).unwrap(),
         )
         .await
         .unwrap_err();

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -29,6 +29,7 @@ use crate::triggers::{
 pub mod cron;
 pub mod github;
 pub mod hmac;
+pub mod slack;
 #[cfg(test)]
 pub(crate) mod test_util;
 pub mod webhook;
@@ -37,11 +38,12 @@ pub use cron::{CatchupMode, CronConnector};
 pub use github::GitHubConnector;
 pub use hmac::{
     verify_hmac_authorization, HmacSignatureStyle, DEFAULT_CANONICAL_AUTHORIZATION_HEADER,
-    DEFAULT_CANONICAL_HMAC_SCHEME, DEFAULT_GITHUB_SIGNATURE_HEADER,
-    DEFAULT_STANDARD_WEBHOOKS_ID_HEADER, DEFAULT_STANDARD_WEBHOOKS_SIGNATURE_HEADER,
-    DEFAULT_STANDARD_WEBHOOKS_TIMESTAMP_HEADER, DEFAULT_STRIPE_SIGNATURE_HEADER,
-    SIGNATURE_VERIFY_AUDIT_TOPIC,
+    DEFAULT_CANONICAL_HMAC_SCHEME, DEFAULT_GITHUB_SIGNATURE_HEADER, DEFAULT_SLACK_SIGNATURE_HEADER,
+    DEFAULT_SLACK_TIMESTAMP_HEADER, DEFAULT_STANDARD_WEBHOOKS_ID_HEADER,
+    DEFAULT_STANDARD_WEBHOOKS_SIGNATURE_HEADER, DEFAULT_STANDARD_WEBHOOKS_TIMESTAMP_HEADER,
+    DEFAULT_STRIPE_SIGNATURE_HEADER, SIGNATURE_VERIFY_AUDIT_TOPIC,
 };
+pub use slack::SlackConnector;
 use webhook::WebhookProviderProfile;
 pub use webhook::{GenericWebhookConnector, WebhookSignatureVariant};
 
@@ -696,6 +698,9 @@ fn default_connector_for_provider(provider: &ProviderMetadata) -> Box<dyn Connec
     // users to switch to a distinct provider_id.
     if provider.provider == "github" {
         return Box::new(GitHubConnector::new());
+    }
+    if provider.provider == "slack" {
+        return Box::new(SlackConnector::new());
     }
     match &provider.runtime {
         ProviderRuntimeMetadata::Builtin {

--- a/crates/harn-vm/src/connectors/slack/mod.rs
+++ b/crates/harn-vm/src/connectors/slack/mod.rs
@@ -1,0 +1,860 @@
+use std::collections::{BTreeSet, HashMap};
+use std::sync::{Arc, RwLock};
+
+use async_trait::async_trait;
+use reqwest::Method;
+use serde::Deserialize;
+use serde_json::{json, Map as JsonMap, Value as JsonValue};
+use sha2::Digest;
+use time::{Duration, OffsetDateTime};
+
+use crate::connectors::{
+    ActivationHandle, ClientError, Connector, ConnectorClient, ConnectorCtx, ConnectorError,
+    HmacSignatureStyle, ProviderPayloadSchema, RawInbound, TriggerBinding, TriggerKind,
+};
+use crate::secrets::{SecretId, SecretVersion};
+use crate::triggers::{
+    redact_headers, HeaderRedactionPolicy, ProviderId, ProviderPayload, SignatureStatus, TraceId,
+    TriggerEvent, TriggerEventId,
+};
+
+#[cfg(test)]
+mod tests;
+
+pub const SLACK_PROVIDER_ID: &str = "slack";
+const DEFAULT_API_BASE_URL: &str = "https://slack.com/api";
+
+pub struct SlackConnector {
+    provider_id: ProviderId,
+    kinds: Vec<TriggerKind>,
+    state: Arc<SlackConnectorState>,
+    client: Arc<SlackClient>,
+}
+
+#[derive(Default)]
+struct SlackConnectorState {
+    ctx: RwLock<Option<ConnectorCtx>>,
+    bindings: RwLock<HashMap<String, ActivatedSlackBinding>>,
+}
+
+#[derive(Clone, Debug)]
+struct ActivatedSlackBinding {
+    #[allow(dead_code)]
+    binding_id: String,
+    path: Option<String>,
+    signing_secret: SecretId,
+}
+
+struct SlackClient {
+    provider_id: ProviderId,
+    state: Arc<SlackConnectorState>,
+    http: reqwest::Client,
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+enum ParsedSlackEvent {
+    MessageChannels(MessageChannelsEvent),
+    AppMention(AppMentionEvent),
+    ReactionAdded(ReactionAddedEvent),
+    TeamJoin(TeamJoinEvent),
+    ChannelCreated(ChannelCreatedEvent),
+    Other { kind: String, raw: JsonValue },
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct MessageChannelsEvent {
+    channel: Option<String>,
+    user: Option<String>,
+    text: Option<String>,
+    ts: Option<String>,
+    thread_ts: Option<String>,
+    subtype: Option<String>,
+    channel_type: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct AppMentionEvent {
+    channel: Option<String>,
+    user: Option<String>,
+    text: Option<String>,
+    ts: Option<String>,
+    thread_ts: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct ReactionAddedEvent {
+    reaction: Option<String>,
+    item_user: Option<String>,
+    item: JsonValue,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct TeamJoinEvent {
+    user: JsonValue,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct ChannelCreatedEvent {
+    channel: JsonValue,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SlackBindingConfig {
+    #[serde(default, rename = "match")]
+    match_config: SlackMatchConfig,
+    #[serde(default)]
+    secrets: SlackSecretsConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SlackMatchConfig {
+    path: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SlackSecretsConfig {
+    signing_secret: Option<String>,
+    bot_token: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SlackClientConfigArgs {
+    api_base_url: Option<String>,
+    bot_token: Option<String>,
+    bot_token_secret: Option<String>,
+    #[serde(default)]
+    secrets: SlackSecretsConfig,
+}
+
+#[derive(Clone, Debug)]
+struct ResolvedSlackClientConfig {
+    api_base_url: String,
+    bot_token: BotTokenSource,
+}
+
+#[derive(Clone, Debug)]
+enum BotTokenSource {
+    Inline(String),
+    Secret(SecretId),
+}
+
+#[derive(Debug, Deserialize)]
+struct PostMessageArgs {
+    #[serde(flatten)]
+    config: SlackClientConfigArgs,
+    channel: String,
+    text: String,
+    #[serde(default)]
+    blocks: Option<JsonValue>,
+    #[serde(default)]
+    thread_ts: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UpdateMessageArgs {
+    #[serde(flatten)]
+    config: SlackClientConfigArgs,
+    channel: String,
+    ts: String,
+    text: String,
+    #[serde(default)]
+    blocks: Option<JsonValue>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AddReactionArgs {
+    #[serde(flatten)]
+    config: SlackClientConfigArgs,
+    channel: String,
+    ts: String,
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct UploadFileArgs {
+    #[serde(flatten)]
+    config: SlackClientConfigArgs,
+    filename: String,
+    content: String,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    channel_id: Option<String>,
+    #[serde(default)]
+    initial_comment: Option<String>,
+    #[serde(default)]
+    thread_ts: Option<String>,
+    #[serde(default)]
+    alt_txt: Option<String>,
+    #[serde(default)]
+    snippet_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackApiEnvelope {
+    ok: bool,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(flatten)]
+    rest: JsonMap<String, JsonValue>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackUploadUrlResponse {
+    ok: bool,
+    #[serde(default)]
+    error: Option<String>,
+    upload_url: Option<String>,
+    file_id: Option<String>,
+    #[allow(dead_code)]
+    #[serde(flatten)]
+    rest: JsonMap<String, JsonValue>,
+}
+
+impl SlackConnector {
+    pub fn new() -> Self {
+        let state = Arc::new(SlackConnectorState::default());
+        let client = Arc::new(SlackClient {
+            provider_id: ProviderId::from(SLACK_PROVIDER_ID),
+            state: state.clone(),
+            http: reqwest::Client::builder()
+                .user_agent("harn-slack-connector")
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+        });
+        Self {
+            provider_id: ProviderId::from(SLACK_PROVIDER_ID),
+            kinds: vec![TriggerKind::from("webhook")],
+            state,
+            client,
+        }
+    }
+
+    fn binding_for_raw(&self, raw: &RawInbound) -> Result<ActivatedSlackBinding, ConnectorError> {
+        let bindings = self
+            .state
+            .bindings
+            .read()
+            .expect("slack connector bindings poisoned");
+        if let Some(binding_id) = raw.metadata.get("binding_id").and_then(JsonValue::as_str) {
+            return bindings.get(binding_id).cloned().ok_or_else(|| {
+                ConnectorError::Unsupported(format!(
+                    "slack connector has no active binding `{binding_id}`"
+                ))
+            });
+        }
+        if bindings.len() == 1 {
+            return bindings
+                .values()
+                .next()
+                .cloned()
+                .ok_or_else(|| ConnectorError::Activation("slack bindings missing".to_string()));
+        }
+        Err(ConnectorError::Unsupported(
+            "slack connector requires raw.metadata.binding_id when multiple bindings are active"
+                .to_string(),
+        ))
+    }
+
+    fn ctx(&self) -> Result<ConnectorCtx, ConnectorError> {
+        self.state
+            .ctx
+            .read()
+            .expect("slack connector ctx poisoned")
+            .clone()
+            .ok_or_else(|| {
+                ConnectorError::Activation(
+                    "slack connector must be initialized before use".to_string(),
+                )
+            })
+    }
+}
+
+impl Default for SlackConnector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Connector for SlackConnector {
+    fn provider_id(&self) -> &ProviderId {
+        &self.provider_id
+    }
+
+    fn kinds(&self) -> &[TriggerKind] {
+        &self.kinds
+    }
+
+    async fn init(&mut self, ctx: ConnectorCtx) -> Result<(), ConnectorError> {
+        *self
+            .state
+            .ctx
+            .write()
+            .expect("slack connector ctx poisoned") = Some(ctx);
+        Ok(())
+    }
+
+    async fn activate(
+        &self,
+        bindings: &[TriggerBinding],
+    ) -> Result<ActivationHandle, ConnectorError> {
+        let mut configured = HashMap::new();
+        let mut paths = BTreeSet::new();
+        for binding in bindings {
+            let activated = ActivatedSlackBinding::from_binding(binding)?;
+            if let Some(path) = &activated.path {
+                if !paths.insert(path.clone()) {
+                    return Err(ConnectorError::Activation(format!(
+                        "slack connector path `{path}` is configured by multiple bindings"
+                    )));
+                }
+            }
+            configured.insert(binding.binding_id.clone(), activated);
+        }
+        *self
+            .state
+            .bindings
+            .write()
+            .expect("slack connector bindings poisoned") = configured;
+        Ok(ActivationHandle::new(
+            self.provider_id.clone(),
+            bindings.len(),
+        ))
+    }
+
+    fn normalize_inbound(&self, raw: RawInbound) -> Result<TriggerEvent, ConnectorError> {
+        let ctx = self.ctx()?;
+        let binding = self.binding_for_raw(&raw)?;
+        let provider = self.provider_id.clone();
+        let received_at = raw.received_at;
+        let headers = effective_headers(&raw.headers);
+        let secret = load_secret_text_blocking(&ctx, &binding.signing_secret)?;
+        futures::executor::block_on(crate::connectors::hmac::verify_hmac_signed(
+            ctx.event_log.as_ref(),
+            &provider,
+            HmacSignatureStyle::slack(),
+            &raw.body,
+            &headers,
+            secret.as_str(),
+            Some(Duration::minutes(5)),
+            received_at,
+        ))?;
+
+        let payload = raw.json_body()?;
+        let event_kind = slack_event_kind(&payload, &raw)?;
+        let _typed = parse_typed_event(&event_kind, &payload)?;
+        let dedupe_key = payload
+            .get("event_id")
+            .and_then(JsonValue::as_str)
+            .map(ToString::to_string)
+            .unwrap_or_else(|| fallback_body_digest(&raw.body));
+        let provider_payload =
+            ProviderPayload::normalize(&provider, &event_kind, &headers, payload)
+                .map_err(|error| ConnectorError::Unsupported(error.to_string()))?;
+        Ok(TriggerEvent {
+            id: TriggerEventId::new(),
+            provider,
+            kind: event_kind,
+            received_at,
+            occurred_at: raw
+                .occurred_at
+                .or_else(|| infer_occurred_at(&provider_payload)),
+            dedupe_key,
+            trace_id: TraceId::new(),
+            tenant_id: raw.tenant_id.clone(),
+            headers: redact_headers(&headers, &HeaderRedactionPolicy::default()),
+            provider_payload,
+            signature_status: SignatureStatus::Verified,
+            dedupe_claimed: false,
+        })
+    }
+
+    fn payload_schema(&self) -> ProviderPayloadSchema {
+        ProviderPayloadSchema::named("SlackEventPayload")
+    }
+
+    fn client(&self) -> Arc<dyn ConnectorClient> {
+        self.client.clone()
+    }
+}
+
+#[async_trait]
+impl ConnectorClient for SlackClient {
+    async fn call(&self, method: &str, args: JsonValue) -> Result<JsonValue, ClientError> {
+        match method {
+            "post_message" => {
+                let args: PostMessageArgs = parse_args(args)?;
+                let config = self.resolve_client_config(&args.config)?;
+                let mut body = JsonMap::new();
+                body.insert("channel".to_string(), JsonValue::String(args.channel));
+                body.insert("text".to_string(), JsonValue::String(args.text));
+                if let Some(blocks) = args.blocks {
+                    body.insert("blocks".to_string(), blocks);
+                }
+                if let Some(thread_ts) = args.thread_ts {
+                    body.insert("thread_ts".to_string(), JsonValue::String(thread_ts));
+                }
+                self.request_json(&config, "chat.postMessage", JsonValue::Object(body))
+                    .await
+            }
+            "update_message" => {
+                let args: UpdateMessageArgs = parse_args(args)?;
+                let config = self.resolve_client_config(&args.config)?;
+                let mut body = JsonMap::new();
+                body.insert("channel".to_string(), JsonValue::String(args.channel));
+                body.insert("ts".to_string(), JsonValue::String(args.ts));
+                body.insert("text".to_string(), JsonValue::String(args.text));
+                if let Some(blocks) = args.blocks {
+                    body.insert("blocks".to_string(), blocks);
+                }
+                self.request_json(&config, "chat.update", JsonValue::Object(body))
+                    .await
+            }
+            "add_reaction" => {
+                let args: AddReactionArgs = parse_args(args)?;
+                let config = self.resolve_client_config(&args.config)?;
+                self.request_json(
+                    &config,
+                    "reactions.add",
+                    json!({
+                        "channel": args.channel,
+                        "timestamp": args.ts,
+                        "name": args.name,
+                    }),
+                )
+                .await
+            }
+            "upload_file" => {
+                let args: UploadFileArgs = parse_args(args)?;
+                let config = self.resolve_client_config(&args.config)?;
+                self.upload_file(&config, args).await
+            }
+            other => Err(ClientError::MethodNotFound(format!(
+                "slack connector does not implement outbound method `{other}`"
+            ))),
+        }
+    }
+}
+
+impl SlackClient {
+    fn resolve_client_config(
+        &self,
+        args: &SlackClientConfigArgs,
+    ) -> Result<ResolvedSlackClientConfig, ClientError> {
+        let bot_token = if let Some(secret_id) = args
+            .bot_token_secret
+            .as_deref()
+            .or(args.secrets.bot_token.as_deref())
+            .and_then(|value| parse_secret_id(Some(value)))
+        {
+            BotTokenSource::Secret(secret_id)
+        } else if let Some(token) = args.bot_token.clone() {
+            BotTokenSource::Inline(token)
+        } else {
+            return Err(ClientError::InvalidArgs(
+                "slack connector requires bot_token or bot_token_secret".to_string(),
+            ));
+        };
+        Ok(ResolvedSlackClientConfig {
+            api_base_url: args
+                .api_base_url
+                .clone()
+                .unwrap_or_else(|| DEFAULT_API_BASE_URL.to_string()),
+            bot_token,
+        })
+    }
+
+    fn ctx(&self) -> Result<ConnectorCtx, ClientError> {
+        self.state
+            .ctx
+            .read()
+            .expect("slack connector ctx poisoned")
+            .clone()
+            .ok_or_else(|| ClientError::Other("slack connector must be initialized".to_string()))
+    }
+
+    async fn request_json(
+        &self,
+        config: &ResolvedSlackClientConfig,
+        method: &str,
+        body: JsonValue,
+    ) -> Result<JsonValue, ClientError> {
+        let response = self.request(method, config, Some(body)).await?;
+        let status = response.status();
+        let payload = response
+            .json::<SlackApiEnvelope>()
+            .await
+            .map_err(|error| ClientError::Transport(error.to_string()))?;
+        if !status.is_success() {
+            let message = payload
+                .error
+                .unwrap_or_else(|| format!("Slack API request failed with status {status}"));
+            return Err(ClientError::Transport(message));
+        }
+        if !payload.ok {
+            return Err(ClientError::Transport(
+                payload
+                    .error
+                    .unwrap_or_else(|| format!("Slack API method `{method}` failed")),
+            ));
+        }
+        let mut body = JsonValue::Object(payload.rest);
+        if let Some(object) = body.as_object_mut() {
+            object.insert("ok".to_string(), JsonValue::Bool(true));
+        }
+        Ok(body)
+    }
+
+    async fn request(
+        &self,
+        method: &str,
+        config: &ResolvedSlackClientConfig,
+        body: Option<JsonValue>,
+    ) -> Result<reqwest::Response, ClientError> {
+        let ctx = self.ctx()?;
+        ctx.rate_limiter
+            .scoped(&self.provider_id, "bot")
+            .acquire()
+            .await;
+        let token = self.bot_token(config).await?;
+        let url = format!(
+            "{}/{}",
+            config.api_base_url.trim_end_matches('/'),
+            method.trim_start_matches('/')
+        );
+        let mut request = self
+            .http
+            .request(Method::POST, url)
+            .header("Authorization", format!("Bearer {token}"));
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+        request
+            .send()
+            .await
+            .map_err(|error| ClientError::Transport(error.to_string()))
+    }
+
+    async fn bot_token(&self, config: &ResolvedSlackClientConfig) -> Result<String, ClientError> {
+        match &config.bot_token {
+            BotTokenSource::Inline(token) => Ok(token.clone()),
+            BotTokenSource::Secret(secret_id) => {
+                let ctx = self.ctx()?;
+                let secret = ctx
+                    .secrets
+                    .get(secret_id)
+                    .await
+                    .map_err(|error| ClientError::Other(error.to_string()))?;
+                Ok(secret.with_exposed(|bytes| String::from_utf8_lossy(bytes).to_string()))
+            }
+        }
+    }
+
+    async fn upload_file(
+        &self,
+        config: &ResolvedSlackClientConfig,
+        args: UploadFileArgs,
+    ) -> Result<JsonValue, ClientError> {
+        let token = self.bot_token(config).await?;
+        let ctx = self.ctx()?;
+        ctx.rate_limiter
+            .scoped(&self.provider_id, "bot")
+            .acquire()
+            .await;
+
+        let start_url = format!(
+            "{}/files.getUploadURLExternal",
+            config.api_base_url.trim_end_matches('/')
+        );
+        let mut form = vec![
+            ("filename".to_string(), args.filename.clone()),
+            ("length".to_string(), args.content.len().to_string()),
+        ];
+        if let Some(alt_txt) = args.alt_txt.clone() {
+            form.push(("alt_txt".to_string(), alt_txt));
+        }
+        if let Some(snippet_type) = args.snippet_type.clone() {
+            form.push(("snippet_type".to_string(), snippet_type));
+        }
+        let start = self
+            .http
+            .request(Method::POST, start_url)
+            .header("Authorization", format!("Bearer {token}"))
+            .form(&form);
+        let start_response = start
+            .send()
+            .await
+            .map_err(|error| ClientError::Transport(error.to_string()))?;
+        let start_status = start_response.status();
+        let start_payload = start_response
+            .json::<SlackUploadUrlResponse>()
+            .await
+            .map_err(|error| ClientError::Transport(error.to_string()))?;
+        if !start_status.is_success() || !start_payload.ok {
+            return Err(ClientError::Transport(start_payload.error.unwrap_or_else(
+                || "Slack API method `files.getUploadURLExternal` failed".to_string(),
+            )));
+        }
+        let upload_url = start_payload.upload_url.ok_or_else(|| {
+            ClientError::Transport(
+                "Slack API response missing upload_url for files.getUploadURLExternal".to_string(),
+            )
+        })?;
+        let file_id = start_payload.file_id.ok_or_else(|| {
+            ClientError::Transport(
+                "Slack API response missing file_id for files.getUploadURLExternal".to_string(),
+            )
+        })?;
+        self.http
+            .request(Method::POST, upload_url)
+            .header("Content-Type", "application/octet-stream")
+            .body(args.content.into_bytes())
+            .send()
+            .await
+            .map_err(|error| ClientError::Transport(error.to_string()))?
+            .error_for_status()
+            .map_err(|error| ClientError::Transport(error.to_string()))?;
+
+        let mut files = JsonMap::new();
+        files.insert("id".to_string(), JsonValue::String(file_id.clone()));
+        files.insert(
+            "title".to_string(),
+            JsonValue::String(args.title.unwrap_or_else(|| args.filename.clone())),
+        );
+        let mut body = JsonMap::new();
+        body.insert(
+            "files".to_string(),
+            JsonValue::Array(vec![JsonValue::Object(files)]),
+        );
+        if let Some(channel_id) = args.channel_id {
+            body.insert("channel_id".to_string(), JsonValue::String(channel_id));
+        }
+        if let Some(initial_comment) = args.initial_comment {
+            body.insert(
+                "initial_comment".to_string(),
+                JsonValue::String(initial_comment),
+            );
+        }
+        if let Some(thread_ts) = args.thread_ts {
+            body.insert("thread_ts".to_string(), JsonValue::String(thread_ts));
+        }
+        self.request_json(
+            config,
+            "files.completeUploadExternal",
+            JsonValue::Object(body),
+        )
+        .await
+        .map(|mut value| {
+            if let Some(object) = value.as_object_mut() {
+                object.insert("file_id".to_string(), JsonValue::String(file_id));
+            }
+            value
+        })
+    }
+}
+
+impl ActivatedSlackBinding {
+    fn from_binding(binding: &TriggerBinding) -> Result<Self, ConnectorError> {
+        let config: SlackBindingConfig =
+            serde_json::from_value(binding.config.clone()).map_err(|error| {
+                ConnectorError::Activation(format!(
+                    "slack binding `{}` has invalid config: {error}",
+                    binding.binding_id
+                ))
+            })?;
+        let signing_secret =
+            parse_secret_id(config.secrets.signing_secret.as_deref()).ok_or_else(|| {
+                ConnectorError::Activation(format!(
+                    "slack binding `{}` requires secrets.signing_secret",
+                    binding.binding_id
+                ))
+            })?;
+        Ok(Self {
+            binding_id: binding.binding_id.clone(),
+            path: config.match_config.path,
+            signing_secret,
+        })
+    }
+}
+
+fn effective_headers(
+    headers: &std::collections::BTreeMap<String, String>,
+) -> std::collections::BTreeMap<String, String> {
+    let mut effective = headers.clone();
+    for (raw, canonical) in [
+        ("content-type", "Content-Type"),
+        ("x-slack-signature", "X-Slack-Signature"),
+        ("x-slack-request-timestamp", "X-Slack-Request-Timestamp"),
+        ("x-slack-retry-num", "X-Slack-Retry-Num"),
+        ("x-slack-retry-reason", "X-Slack-Retry-Reason"),
+    ] {
+        if let Some(value) = header_value(headers, raw) {
+            effective
+                .entry(canonical.to_string())
+                .or_insert_with(|| value.to_string());
+        }
+    }
+    effective
+}
+
+fn parse_args<T: for<'de> Deserialize<'de>>(args: JsonValue) -> Result<T, ClientError> {
+    serde_json::from_value(args).map_err(|error| ClientError::InvalidArgs(error.to_string()))
+}
+
+fn load_secret_text_blocking(
+    ctx: &ConnectorCtx,
+    secret_id: &SecretId,
+) -> Result<String, ConnectorError> {
+    let secret = futures::executor::block_on(ctx.secrets.get(secret_id))?;
+    secret.with_exposed(|bytes| {
+        std::str::from_utf8(bytes)
+            .map(|value| value.to_string())
+            .map_err(|error| {
+                ConnectorError::Secret(format!(
+                    "slack signing secret `{secret_id}` is not valid UTF-8: {error}"
+                ))
+            })
+    })
+}
+
+fn slack_event_kind(payload: &JsonValue, raw: &RawInbound) -> Result<String, ConnectorError> {
+    if !raw.kind.trim().is_empty() {
+        return Ok(raw.kind.clone());
+    }
+    let kind = payload
+        .get("type")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| {
+            ConnectorError::Unsupported("slack payload missing top-level type".to_string())
+        })?;
+    if kind == "url_verification" {
+        return Ok("url_verification".to_string());
+    }
+    if kind != "event_callback" {
+        return Ok(kind.to_string());
+    }
+    let event = payload.get("event").ok_or_else(|| {
+        ConnectorError::Unsupported("slack event_callback missing event".to_string())
+    })?;
+    let event_type = event
+        .get("type")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| ConnectorError::Unsupported("slack event missing type".to_string()))?;
+    if event_type == "message" {
+        let channel_type = event
+            .get("channel_type")
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default();
+        if channel_type == "channel" {
+            return Ok("message.channels".to_string());
+        }
+    }
+    Ok(event_type.to_string())
+}
+
+fn parse_typed_event(kind: &str, payload: &JsonValue) -> Result<ParsedSlackEvent, ConnectorError> {
+    if kind == "url_verification" {
+        return Ok(ParsedSlackEvent::Other {
+            kind: kind.to_string(),
+            raw: payload.clone(),
+        });
+    }
+    let event = payload.get("event").cloned().unwrap_or(JsonValue::Null);
+    match kind {
+        "message.channels" => serde_json::from_value(event)
+            .map(ParsedSlackEvent::MessageChannels)
+            .map_err(|error| ConnectorError::Json(error.to_string())),
+        "app_mention" => serde_json::from_value(event)
+            .map(ParsedSlackEvent::AppMention)
+            .map_err(|error| ConnectorError::Json(error.to_string())),
+        "reaction_added" => serde_json::from_value(event)
+            .map(ParsedSlackEvent::ReactionAdded)
+            .map_err(|error| ConnectorError::Json(error.to_string())),
+        "team_join" => serde_json::from_value(event)
+            .map(ParsedSlackEvent::TeamJoin)
+            .map_err(|error| ConnectorError::Json(error.to_string())),
+        "channel_created" => serde_json::from_value(event)
+            .map(ParsedSlackEvent::ChannelCreated)
+            .map_err(|error| ConnectorError::Json(error.to_string())),
+        _ => Ok(ParsedSlackEvent::Other {
+            kind: kind.to_string(),
+            raw: payload.clone(),
+        }),
+    }
+}
+
+fn infer_occurred_at(provider_payload: &ProviderPayload) -> Option<OffsetDateTime> {
+    let ProviderPayload::Known(payload) = provider_payload else {
+        return None;
+    };
+    let raw = match payload {
+        crate::triggers::event::KnownProviderPayload::Slack(payload) => slack_raw(payload),
+        _ => return None,
+    };
+    raw.get("event")
+        .and_then(|event| event.get("event_ts"))
+        .and_then(JsonValue::as_str)
+        .and_then(parse_slack_timestamp)
+        .or_else(|| {
+            raw.get("event_time")
+                .and_then(JsonValue::as_i64)
+                .and_then(|secs| OffsetDateTime::from_unix_timestamp(secs).ok())
+        })
+}
+
+fn slack_raw(payload: &crate::triggers::event::SlackEventPayload) -> &JsonValue {
+    match payload {
+        crate::triggers::event::SlackEventPayload::MessageChannels(inner) => &inner.common.raw,
+        crate::triggers::event::SlackEventPayload::AppMention(inner) => &inner.common.raw,
+        crate::triggers::event::SlackEventPayload::ReactionAdded(inner) => &inner.common.raw,
+        crate::triggers::event::SlackEventPayload::TeamJoin(inner) => &inner.common.raw,
+        crate::triggers::event::SlackEventPayload::ChannelCreated(inner) => &inner.common.raw,
+        crate::triggers::event::SlackEventPayload::Other(common) => &common.raw,
+    }
+}
+
+fn parse_slack_timestamp(raw: &str) -> Option<OffsetDateTime> {
+    let seconds = raw.split('.').next()?.parse::<i64>().ok()?;
+    OffsetDateTime::from_unix_timestamp(seconds).ok()
+}
+
+fn header_value<'a>(
+    headers: &'a std::collections::BTreeMap<String, String>,
+    name: &str,
+) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
+}
+
+fn parse_secret_id(raw: Option<&str>) -> Option<SecretId> {
+    let trimmed = raw?.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let (base, version) = match trimmed.rsplit_once('@') {
+        Some((base, version_text)) => {
+            let version = version_text.parse::<u64>().ok()?;
+            (base, SecretVersion::Exact(version))
+        }
+        None => (trimmed, SecretVersion::Latest),
+    };
+    let (namespace, name) = base.split_once('/')?;
+    if namespace.is_empty() || name.is_empty() {
+        return None;
+    }
+    Some(SecretId::new(namespace, name).with_version(version))
+}
+
+fn fallback_body_digest(body: &[u8]) -> String {
+    let digest = sha2::Sha256::digest(body);
+    format!("sha256:{}", hex::encode(digest))
+}

--- a/crates/harn-vm/src/connectors/slack/tests.rs
+++ b/crates/harn-vm/src/connectors/slack/tests.rs
@@ -1,0 +1,648 @@
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+
+use async_trait::async_trait;
+use serde_json::{json, Value as JsonValue};
+use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
+
+use super::*;
+use crate::connectors::{
+    Connector, ConnectorClient, ConnectorCtx, InboxIndex, MetricsRegistry, RateLimiterFactory,
+    RawInbound, TriggerBinding,
+};
+use crate::event_log::{AnyEventLog, MemoryEventLog};
+use crate::secrets::{SecretBytes, SecretError, SecretId, SecretMeta, SecretProvider};
+use crate::triggers::event::KnownProviderPayload;
+use crate::triggers::{ProviderId, SlackEventPayload};
+
+const SIGNING_SECRET: &str = "8f742231b10e8888abcd99yyyzzz85a5";
+const BOT_TOKEN: &str = "xoxb-test-token";
+
+struct StaticSecretProvider {
+    namespace: String,
+    secrets: BTreeMap<SecretId, String>,
+}
+
+impl StaticSecretProvider {
+    fn new(namespace: &str, secrets: BTreeMap<SecretId, String>) -> Self {
+        Self {
+            namespace: namespace.to_string(),
+            secrets,
+        }
+    }
+}
+
+#[async_trait]
+impl SecretProvider for StaticSecretProvider {
+    async fn get(&self, id: &SecretId) -> Result<SecretBytes, SecretError> {
+        self.secrets
+            .get(id)
+            .cloned()
+            .map(SecretBytes::from)
+            .ok_or_else(|| SecretError::NotFound {
+                provider: self.namespace.clone(),
+                id: id.clone(),
+            })
+    }
+
+    async fn put(&self, _id: &SecretId, _value: SecretBytes) -> Result<(), SecretError> {
+        Err(SecretError::Unsupported {
+            provider: self.namespace.clone(),
+            operation: "put",
+        })
+    }
+
+    async fn rotate(&self, _id: &SecretId) -> Result<crate::secrets::RotationHandle, SecretError> {
+        Err(SecretError::Unsupported {
+            provider: self.namespace.clone(),
+            operation: "rotate",
+        })
+    }
+
+    async fn list(&self, _prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError> {
+        Ok(Vec::new())
+    }
+
+    fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    fn supports_versions(&self) -> bool {
+        false
+    }
+}
+
+async fn test_ctx(secrets: Arc<dyn SecretProvider>) -> ConnectorCtx {
+    let event_log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(64)));
+    let metrics = Arc::new(MetricsRegistry::default());
+    let inbox = Arc::new(
+        InboxIndex::new(event_log.clone(), metrics.clone())
+            .await
+            .expect("inbox init"),
+    );
+    ConnectorCtx {
+        event_log,
+        secrets,
+        inbox,
+        metrics,
+        rate_limiter: Arc::new(RateLimiterFactory::default()),
+    }
+}
+
+async fn connector() -> SlackConnector {
+    let secrets = Arc::new(StaticSecretProvider::new(
+        "slack",
+        BTreeMap::from([
+            (
+                SecretId::new("slack", "test-signing-secret"),
+                SIGNING_SECRET.to_string(),
+            ),
+            (SecretId::new("slack", "bot-token"), BOT_TOKEN.to_string()),
+        ]),
+    ));
+    let mut connector = SlackConnector::new();
+    connector.init(test_ctx(secrets).await).await.unwrap();
+    connector.activate(&[binding()]).await.unwrap();
+    connector
+}
+
+async fn initialized_client() -> Arc<dyn ConnectorClient> {
+    Arc::new(connector().await).client()
+}
+
+fn binding() -> TriggerBinding {
+    let mut binding = TriggerBinding::new(ProviderId::from("slack"), "webhook", "slack.test");
+    binding.config = json!({
+        "match": { "path": "/hooks/slack" },
+        "secrets": { "signing_secret": "slack/test-signing-secret" },
+    });
+    binding
+}
+
+fn raw_inbound(body: &JsonValue, timestamp: i64) -> RawInbound {
+    let encoded = serde_json::to_vec(body).unwrap();
+    let headers = slack_headers(&encoded, timestamp);
+    let mut raw = RawInbound::new("", headers, encoded);
+    raw.received_at = OffsetDateTime::from_unix_timestamp(timestamp).unwrap();
+    raw.metadata = json!({ "binding_id": "slack.test" });
+    raw
+}
+
+fn slack_headers(body: &[u8], timestamp: i64) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        ("Content-Type".to_string(), "application/json".to_string()),
+        (
+            "X-Slack-Request-Timestamp".to_string(),
+            timestamp.to_string(),
+        ),
+        (
+            "X-Slack-Signature".to_string(),
+            slack_signature(SIGNING_SECRET, timestamp, body),
+        ),
+    ])
+}
+
+fn slack_signature(secret: &str, timestamp: i64, body: &[u8]) -> String {
+    let mut signed = format!("v0:{timestamp}:").into_bytes();
+    signed.extend_from_slice(body);
+    let digest = hmac_sha256(secret.as_bytes(), &signed);
+    format!("v0={}", hex::encode(digest))
+}
+
+fn hmac_sha256(secret: &[u8], data: &[u8]) -> Vec<u8> {
+    const BLOCK_SIZE: usize = 64;
+
+    let mut key = if secret.len() > BLOCK_SIZE {
+        Sha256::digest(secret).to_vec()
+    } else {
+        secret.to_vec()
+    };
+    key.resize(BLOCK_SIZE, 0);
+
+    let mut inner_pad = vec![0x36; BLOCK_SIZE];
+    let mut outer_pad = vec![0x5c; BLOCK_SIZE];
+    for (slot, key_byte) in inner_pad.iter_mut().zip(&key) {
+        *slot ^= key_byte;
+    }
+    for (slot, key_byte) in outer_pad.iter_mut().zip(&key) {
+        *slot ^= key_byte;
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(&inner_pad);
+    inner.update(data);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(&outer_pad);
+    outer.update(inner_digest);
+    outer.finalize().to_vec()
+}
+
+#[derive(Clone)]
+struct FixtureCase {
+    name: &'static str,
+    body: JsonValue,
+    expected_kind: &'static str,
+}
+
+#[tokio::test]
+async fn slack_connector_normalizes_docs_fixtures_into_typed_payloads() {
+    let connector = connector().await;
+    let timestamp = 1_715_000_000;
+    let cases = vec![
+        FixtureCase {
+            name: "message.channels",
+            expected_kind: "message.channels",
+            body: json!({
+                "token": "z26uFbvR1xHJEdHE1OQiO6t8",
+                "team_id": "T123ABC456",
+                "api_app_id": "A123ABC456",
+                "event": {
+                    "type": "message",
+                    "user": "U123ABC456",
+                    "text": "hello from a channel",
+                    "ts": "1715000000.000100",
+                    "channel": "C123ABC456",
+                    "channel_type": "channel",
+                    "event_ts": "1715000000.000100"
+                },
+                "type": "event_callback",
+                "event_id": "Ev123MESSAGE",
+                "event_time": 1715000000
+            }),
+        },
+        FixtureCase {
+            name: "app_mention",
+            expected_kind: "app_mention",
+            body: json!({
+                "token": "ZZZZZZWSxiZZZ2yIvs3peJ",
+                "team_id": "T123ABC456",
+                "api_app_id": "A123ABC456",
+                "event": {
+                    "type": "app_mention",
+                    "user": "U123ABC456",
+                    "text": "What is the hour of the pearl, <@U0LAN0Z89>?",
+                    "ts": "1515449522.000016",
+                    "channel": "C123ABC456",
+                    "event_ts": "1515449522000016"
+                },
+                "type": "event_callback",
+                "event_id": "Ev123ABC456",
+                "event_time": 1515449522000016i64
+            }),
+        },
+        FixtureCase {
+            name: "reaction_added",
+            expected_kind: "reaction_added",
+            body: json!({
+                "token": "z26uFbvR1xHJEdHE1OQiO6t8",
+                "team_id": "T123ABC456",
+                "api_app_id": "A123ABC456",
+                "event": {
+                    "type": "reaction_added",
+                    "user": "U123ABC456",
+                    "item": {
+                        "type": "message",
+                        "channel": "C123ABC456",
+                        "ts": "1464196127.000002"
+                    },
+                    "reaction": "slightly_smiling_face",
+                    "item_user": "U222222222",
+                    "event_ts": "1465244570.336841"
+                },
+                "type": "event_callback",
+                "event_id": "Ev123REACTION",
+                "event_time": 1234567890
+            }),
+        },
+        FixtureCase {
+            name: "team_join",
+            expected_kind: "team_join",
+            body: json!({
+                "token": "z26uFbvR1xHJEdHE1OQiO6t8",
+                "team_id": "T123ABC456",
+                "api_app_id": "A123ABC456",
+                "event": {
+                    "type": "team_join",
+                    "user": {
+                        "id": "U024BE7LH",
+                        "name": "sam",
+                        "real_name": "Sam Example"
+                    },
+                    "event_ts": "1360782804.083113"
+                },
+                "type": "event_callback",
+                "event_id": "Ev123TEAMJOIN",
+                "event_time": 1360782804
+            }),
+        },
+        FixtureCase {
+            name: "channel_created",
+            expected_kind: "channel_created",
+            body: json!({
+                "token": "z26uFbvR1xHJEdHE1OQiO6t8",
+                "team_id": "T123ABC456",
+                "api_app_id": "A123ABC456",
+                "event": {
+                    "type": "channel_created",
+                    "channel": {
+                        "id": "C024BE91L",
+                        "name": "fun",
+                        "created": 1360782804,
+                        "creator": "U024BE7LH"
+                    },
+                    "event_ts": "1360782804.083113"
+                },
+                "type": "event_callback",
+                "event_id": "Ev123CHANNEL",
+                "event_time": 1360782804
+            }),
+        },
+    ];
+
+    for case in cases {
+        let event = connector
+            .normalize_inbound(raw_inbound(&case.body, timestamp))
+            .unwrap();
+        assert_eq!(event.kind, case.expected_kind, "case {}", case.name);
+        let payload = match &event.provider_payload {
+            crate::triggers::ProviderPayload::Known(KnownProviderPayload::Slack(payload)) => {
+                payload
+            }
+            other => panic!("expected slack payload, got {other:?}"),
+        };
+        match (case.expected_kind, payload) {
+            ("message.channels", SlackEventPayload::MessageChannels(inner)) => {
+                assert_eq!(inner.channel.as_deref(), Some("C123ABC456"));
+            }
+            ("app_mention", SlackEventPayload::AppMention(inner)) => {
+                assert_eq!(inner.user.as_deref(), Some("U123ABC456"));
+            }
+            ("reaction_added", SlackEventPayload::ReactionAdded(inner)) => {
+                assert_eq!(inner.reaction.as_deref(), Some("slightly_smiling_face"));
+            }
+            ("team_join", SlackEventPayload::TeamJoin(inner)) => {
+                assert_eq!(inner.common.user_id.as_deref(), Some("U024BE7LH"));
+            }
+            ("channel_created", SlackEventPayload::ChannelCreated(inner)) => {
+                assert_eq!(inner.common.channel_id.as_deref(), Some("C024BE91L"));
+            }
+            other => panic!("unexpected typed payload mapping: {other:?}"),
+        }
+        assert_eq!(
+            event.signature_status,
+            crate::triggers::SignatureStatus::Verified
+        );
+    }
+}
+
+#[tokio::test]
+async fn slack_connector_accepts_url_verification_payloads() {
+    let connector = connector().await;
+    let payload = json!({
+        "token": "legacy-token",
+        "challenge": "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P",
+        "type": "url_verification"
+    });
+    let event = connector
+        .normalize_inbound(raw_inbound(&payload, 1_715_000_000))
+        .unwrap();
+    assert_eq!(event.kind, "url_verification");
+    match event.provider_payload {
+        crate::triggers::ProviderPayload::Known(KnownProviderPayload::Slack(
+            SlackEventPayload::Other(common),
+        )) => {
+            assert_eq!(
+                common.raw.get("challenge").and_then(JsonValue::as_str),
+                Some("3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P")
+            );
+        }
+        other => panic!("expected slack other payload, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn slack_connector_rejects_tampered_signature() {
+    let connector = connector().await;
+    let payload = json!({
+        "team_id": "T123ABC456",
+        "type": "event_callback",
+        "event_id": "EvBad",
+        "event": {
+            "type": "app_mention",
+            "user": "U123ABC456",
+            "channel": "C123ABC456",
+            "text": "hello",
+            "ts": "1515449522.000016",
+            "event_ts": "1515449522000016"
+        }
+    });
+    let mut raw = raw_inbound(&payload, 1_715_000_000);
+    raw.headers.insert(
+        "X-Slack-Signature".to_string(),
+        "v0=0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+    );
+    let error = connector.normalize_inbound(raw).unwrap_err();
+    assert!(matches!(
+        error,
+        crate::connectors::ConnectorError::InvalidSignature(_)
+    ));
+}
+
+#[derive(Clone, Debug)]
+struct CapturedRequest {
+    method: String,
+    path: String,
+    headers: BTreeMap<String, String>,
+    body: String,
+}
+
+#[derive(Default)]
+struct MockScenario {
+    requests: Vec<CapturedRequest>,
+}
+
+fn accept_with_deadline(listener: &TcpListener, label: &str) -> std::net::TcpStream {
+    listener.set_nonblocking(true).expect("set nonblocking");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                stream
+                    .set_nonblocking(false)
+                    .expect("restore blocking mode");
+                stream
+                    .set_read_timeout(Some(std::time::Duration::from_secs(3)))
+                    .ok();
+                stream
+                    .set_write_timeout(Some(std::time::Duration::from_secs(3)))
+                    .ok();
+                return stream;
+            }
+            Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                if std::time::Instant::now() >= deadline {
+                    panic!("{label}: no client within 3s");
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(error) => panic!("{label}: accept failed: {error}"),
+        }
+    }
+}
+
+fn read_request(stream: &mut std::net::TcpStream) -> CapturedRequest {
+    let mut buffer = Vec::new();
+    let mut temp = [0u8; 4096];
+    let header_end;
+    loop {
+        let n = stream.read(&mut temp).expect("read request");
+        assert!(n > 0, "request ended before headers");
+        buffer.extend_from_slice(&temp[..n]);
+        if let Some(idx) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
+            header_end = idx + 4;
+            break;
+        }
+    }
+    let header_text = String::from_utf8_lossy(&buffer[..header_end]).to_string();
+    let mut lines = header_text.split("\r\n").filter(|line| !line.is_empty());
+    let request_line = lines.next().expect("request line");
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts.next().unwrap_or_default().to_string();
+    let path = request_parts.next().unwrap_or_default().to_string();
+    let mut headers = BTreeMap::new();
+    for line in lines {
+        if let Some((name, value)) = line.split_once(':') {
+            headers.insert(name.to_ascii_lowercase(), value.trim().to_string());
+        }
+    }
+    let content_length = headers
+        .get("content-length")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
+    while buffer.len() < header_end + content_length {
+        let n = stream.read(&mut temp).expect("read body");
+        assert!(n > 0, "request ended before body");
+        buffer.extend_from_slice(&temp[..n]);
+    }
+    let body =
+        String::from_utf8_lossy(&buffer[header_end..header_end + content_length]).to_string();
+    CapturedRequest {
+        method,
+        path,
+        headers,
+        body,
+    }
+}
+
+fn write_response(
+    stream: &mut std::net::TcpStream,
+    status: u16,
+    headers: &[(&str, String)],
+    body: &str,
+) {
+    let status_text = match status {
+        200 => "OK",
+        201 => "Created",
+        _ => "OK",
+    };
+    let mut response = format!(
+        "HTTP/1.1 {} {}\r\ncontent-length: {}\r\nconnection: close\r\n",
+        status,
+        status_text,
+        body.len()
+    );
+    for (name, value) in headers {
+        response.push_str(name);
+        response.push_str(": ");
+        response.push_str(value);
+        response.push_str("\r\n");
+    }
+    response.push_str("\r\n");
+    response.push_str(body);
+    stream
+        .write_all(response.as_bytes())
+        .expect("write response");
+}
+
+fn spawn_mock_server(
+    expected_requests: usize,
+    scenario: Arc<Mutex<MockScenario>>,
+) -> (String, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+    let addr = listener.local_addr().expect("mock addr");
+    let handle = std::thread::spawn(move || {
+        for _ in 0..expected_requests {
+            let mut stream = accept_with_deadline(&listener, "slack mock server");
+            let request = read_request(&mut stream);
+            scenario
+                .lock()
+                .expect("scenario lock")
+                .requests
+                .push(request.clone());
+            match request.path.as_str() {
+                "/chat.postMessage" => write_response(
+                    &mut stream,
+                    200,
+                    &[("content-type", "application/json".to_string())],
+                    r#"{"ok":true,"channel":"C123ABC456","ts":"1715.000100","message":{"text":"hello from harn"}}"#,
+                ),
+                "/chat.update" => write_response(
+                    &mut stream,
+                    200,
+                    &[("content-type", "application/json".to_string())],
+                    r#"{"ok":true,"channel":"C123ABC456","ts":"1715.000100","text":"updated"}"#,
+                ),
+                "/reactions.add" => write_response(
+                    &mut stream,
+                    200,
+                    &[("content-type", "application/json".to_string())],
+                    r#"{"ok":true}"#,
+                ),
+                "/files.getUploadURLExternal" => write_response(
+                    &mut stream,
+                    200,
+                    &[("content-type", "application/json".to_string())],
+                    &format!(
+                        "{{\"ok\":true,\"upload_url\":\"http://{}/upload/F123\",\"file_id\":\"F123\"}}",
+                        addr
+                    ),
+                ),
+                "/upload/F123" => write_response(&mut stream, 200, &[], ""),
+                "/files.completeUploadExternal" => write_response(
+                    &mut stream,
+                    200,
+                    &[("content-type", "application/json".to_string())],
+                    r#"{"ok":true,"files":[{"id":"F123","title":"notes.txt"}]}"#,
+                ),
+                other => panic!("unexpected path {other}"),
+            }
+        }
+    });
+    (format!("http://{addr}"), handle)
+}
+
+#[tokio::test]
+async fn slack_outbound_helpers_hit_expected_api_methods() {
+    let client = initialized_client().await;
+    let scenario = Arc::new(Mutex::new(MockScenario::default()));
+    let (base_url, handle) = spawn_mock_server(6, scenario.clone());
+
+    let posted = client
+        .call(
+            "post_message",
+            json!({
+                "api_base_url": base_url,
+                "bot_token_secret": "slack/bot-token",
+                "channel": "C123ABC456",
+                "text": "hello from harn",
+            }),
+        )
+        .await
+        .unwrap();
+    let updated = client
+        .call(
+            "update_message",
+            json!({
+                "api_base_url": base_url,
+                "bot_token": BOT_TOKEN,
+                "channel": "C123ABC456",
+                "ts": "1715.000100",
+                "text": "updated",
+            }),
+        )
+        .await
+        .unwrap();
+    client
+        .call(
+            "add_reaction",
+            json!({
+                "api_base_url": base_url,
+                "bot_token": BOT_TOKEN,
+                "channel": "C123ABC456",
+                "ts": "1715.000100",
+                "name": "thumbsup",
+            }),
+        )
+        .await
+        .unwrap();
+    let uploaded = client
+        .call(
+            "upload_file",
+            json!({
+                "api_base_url": base_url,
+                "bot_token": BOT_TOKEN,
+                "filename": "notes.txt",
+                "content": "hello upload",
+                "title": "notes.txt",
+                "channel_id": "C123ABC456",
+            }),
+        )
+        .await
+        .unwrap();
+
+    handle.join().expect("server thread");
+    let requests = scenario.lock().expect("scenario lock").requests.clone();
+    assert_eq!(requests.len(), 6);
+    assert!(requests.iter().all(|request| request.method == "POST"));
+    assert_eq!(requests[0].path, "/chat.postMessage");
+    assert_eq!(requests[1].path, "/chat.update");
+    assert_eq!(requests[2].path, "/reactions.add");
+    assert_eq!(requests[3].path, "/files.getUploadURLExternal");
+    assert_eq!(requests[4].path, "/upload/F123");
+    assert_eq!(requests[5].path, "/files.completeUploadExternal");
+    assert_eq!(
+        requests[0].headers.get("authorization").map(String::as_str),
+        Some("Bearer xoxb-test-token")
+    );
+    assert!(requests[3].body.contains("filename=notes.txt"));
+    assert_eq!(requests[4].body, "hello upload");
+    assert!(requests[5].body.contains("\"channel_id\":\"C123ABC456\""));
+    assert_eq!(posted["channel"], json!("C123ABC456"));
+    assert_eq!(updated["text"], json!("updated"));
+    assert_eq!(uploaded["file_id"], json!("F123"));
+}

--- a/crates/harn-vm/src/connectors/slack/tests.rs
+++ b/crates/harn-vm/src/connectors/slack/tests.rs
@@ -316,7 +316,7 @@ async fn slack_connector_normalizes_docs_fixtures_into_typed_payloads() {
             }
             other => panic!("expected slack payload, got {other:?}"),
         };
-        match (case.expected_kind, payload) {
+        match (case.expected_kind, payload.as_ref()) {
             ("message.channels", SlackEventPayload::MessageChannels(inner)) => {
                 assert_eq!(inner.channel.as_deref(), Some("C123ABC456"));
             }
@@ -354,9 +354,10 @@ async fn slack_connector_accepts_url_verification_payloads() {
         .unwrap();
     assert_eq!(event.kind, "url_verification");
     match event.provider_payload {
-        crate::triggers::ProviderPayload::Known(KnownProviderPayload::Slack(
-            SlackEventPayload::Other(common),
-        )) => {
+        crate::triggers::ProviderPayload::Known(KnownProviderPayload::Slack(payload)) => {
+            let SlackEventPayload::Other(common) = *payload else {
+                panic!("expected slack other payload");
+            };
             assert_eq!(
                 common.raw.get("challenge").and_then(JsonValue::as_str),
                 Some("3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P")

--- a/crates/harn-vm/src/connectors/webhook/mod.rs
+++ b/crates/harn-vm/src/connectors/webhook/mod.rs
@@ -428,6 +428,11 @@ fn derive_dedupe_key(
         WebhookSignatureVariant::GitHub => header_value(headers, "x-github-delivery")
             .map(ToString::to_string)
             .unwrap_or_else(|| fallback_body_digest(raw_body)),
+        WebhookSignatureVariant::Slack => body
+            .get("event_id")
+            .and_then(JsonValue::as_str)
+            .map(ToString::to_string)
+            .unwrap_or_else(|| fallback_body_digest(raw_body)),
     }
 }
 

--- a/crates/harn-vm/src/connectors/webhook/tests.rs
+++ b/crates/harn-vm/src/connectors/webhook/tests.rs
@@ -150,6 +150,7 @@ fn binding(variant: WebhookSignatureVariant, dedupe_key: Option<&str>) -> Trigge
                 WebhookSignatureVariant::Standard => "standard",
                 WebhookSignatureVariant::Stripe => "stripe",
                 WebhookSignatureVariant::GitHub => "github",
+                WebhookSignatureVariant::Slack => "slack",
             },
             "source": "fixtures",
         }
@@ -465,12 +466,15 @@ async fn github_profile_normalizes_events_under_the_github_provider() {
 }
 
 #[test]
-fn connector_registry_default_lists_github_and_webhook_connectors() {
+fn connector_registry_default_lists_github_slack_and_webhook_connectors() {
     let registry = ConnectorRegistry::default();
     let providers = registry.list();
     assert!(providers
         .iter()
         .any(|provider| provider.as_str() == "github"));
+    assert!(providers
+        .iter()
+        .any(|provider| provider.as_str() == "slack"));
     assert!(providers
         .iter()
         .any(|provider| provider.as_str() == "webhook"));

--- a/crates/harn-vm/src/connectors/webhook/variants.rs
+++ b/crates/harn-vm/src/connectors/webhook/variants.rs
@@ -15,6 +15,7 @@ pub enum WebhookSignatureVariant {
     Standard,
     Stripe,
     GitHub,
+    Slack,
 }
 
 impl WebhookSignatureVariant {
@@ -23,15 +24,16 @@ impl WebhookSignatureVariant {
             "standard" => Ok(Self::Standard),
             "stripe" => Ok(Self::Stripe),
             "github" => Ok(Self::GitHub),
+            "slack" => Ok(Self::Slack),
             other => Err(ConnectorError::Unsupported(format!(
-                "unsupported generic webhook signature scheme `{other}`; expected one of standard, stripe, github"
+                "unsupported generic webhook signature scheme `{other}`; expected one of standard, stripe, github, slack"
             ))),
         }
     }
 
     pub fn default_timestamp_window(self) -> Option<Duration> {
         match self {
-            Self::Standard | Self::Stripe => Some(Duration::minutes(5)),
+            Self::Standard | Self::Stripe | Self::Slack => Some(Duration::minutes(5)),
             Self::GitHub => None,
         }
     }
@@ -50,6 +52,7 @@ impl WebhookSignatureVariant {
             Self::Standard => HmacSignatureStyle::standard_webhooks(),
             Self::Stripe => HmacSignatureStyle::stripe(),
             Self::GitHub => HmacSignatureStyle::github(),
+            Self::Slack => HmacSignatureStyle::slack(),
         };
         block_on(verify_hmac_signed(
             event_log,

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -46,7 +46,7 @@ pub use connectors::{
     Connector, ConnectorClient, ConnectorCtx, ConnectorError, ConnectorMetricsSnapshot,
     ConnectorRegistry, GenericWebhookConnector, GitHubConnector, MetricsRegistry,
     PostNormalizeOutcome, ProviderPayloadSchema, RateLimitConfig, RateLimiterFactory, RawInbound,
-    TriggerBinding, TriggerKind, TriggerRegistry, WebhookSignatureVariant,
+    SlackConnector, TriggerBinding, TriggerKind, TriggerRegistry, WebhookSignatureVariant,
 };
 pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -893,9 +893,12 @@ fn default_provider_payload(
         "slack" => serde_json::json!({
             "provider": "slack",
             "event": kind,
-            "subtype": serde_json::Value::Null,
+            "event_id": serde_json::Value::Null,
+            "api_app_id": serde_json::Value::Null,
             "team_id": serde_json::Value::Null,
             "channel_id": serde_json::Value::Null,
+            "user_id": serde_json::Value::Null,
+            "event_ts": serde_json::Value::Null,
             "raw": raw_event,
         }),
         "linear" => serde_json::json!({

--- a/crates/harn-vm/src/stdlib_connectors_slack.harn
+++ b/crates/harn-vm/src/stdlib_connectors_slack.harn
@@ -1,0 +1,39 @@
+import { filter_nil } from "std/collections"
+import { merge } from "std/json"
+
+var slack_connector_config = {}
+
+pub fn configure(config) {
+  slack_connector_config = filter_nil(config ?? {})
+  return slack_connector_config
+}
+
+pub fn reset() {
+  slack_connector_config = {}
+}
+
+fn __call(method, params = {}) {
+  return connector_call("slack", method, filter_nil(merge(slack_connector_config, params ?? {})))
+}
+
+pub fn post_message(channel, text, blocks = nil, options = nil) {
+  return __call(
+    "post_message",
+    filter_nil((options ?? {}) + {channel: channel, text: text, blocks: blocks}),
+  )
+}
+
+pub fn update_message(channel, ts, text, blocks = nil, options = nil) {
+  return __call(
+    "update_message",
+    filter_nil((options ?? {}) + {channel: channel, ts: ts, text: text, blocks: blocks}),
+  )
+}
+
+pub fn add_reaction(channel, ts, name, options = nil) {
+  return __call("add_reaction", (options ?? {}) + {channel: channel, ts: ts, name: name})
+}
+
+pub fn upload_file(filename, content, options = nil) {
+  return __call("upload_file", (options ?? {}) + {filename: filename, content: content})
+}

--- a/crates/harn-vm/src/stdlib_modules.rs
+++ b/crates/harn-vm/src/stdlib_modules.rs
@@ -23,6 +23,7 @@ pub fn get_stdlib_source(module: &str) -> Option<&'static str> {
         "acp" => Some(include_str!("stdlib_acp.harn")),
         "triggers" => Some(include_str!("stdlib_triggers.harn")),
         "connectors/github" => Some(include_str!("stdlib_connectors_github.harn")),
+        "connectors/slack" => Some(include_str!("stdlib_connectors_slack.harn")),
         _ => None,
     }
 }

--- a/crates/harn-vm/src/stdlib_triggers.harn
+++ b/crates/harn-vm/src/stdlib_triggers.harn
@@ -98,14 +98,107 @@ type GitHubOtherEventPayload = {
 
 type GitHubEventPayload = GitHubIssuesEventPayload | GitHubPullRequestEventPayload | GitHubIssueCommentEventPayload | GitHubPullRequestReviewEventPayload | GitHubPushEventPayload | GitHubWorkflowRunEventPayload | GitHubOtherEventPayload
 
-type SlackEventPayload = {
+type SlackEventCommon = {
   provider: "slack",
   event: string,
-  subtype: string | nil,
+  event_id: string | nil,
+  api_app_id: string | nil,
   team_id: string | nil,
   channel_id: string | nil,
+  user_id: string | nil,
+  event_ts: string | nil,
   raw: dict,
 }
+
+type SlackMessageChannelsEventPayload = {
+  provider: "slack",
+  event: "message.channels",
+  event_id: string | nil,
+  api_app_id: string | nil,
+  team_id: string | nil,
+  channel_id: string | nil,
+  user_id: string | nil,
+  event_ts: string | nil,
+  subtype: string | nil,
+  channel: string | nil,
+  user: string | nil,
+  text: string | nil,
+  ts: string | nil,
+  thread_ts: string | nil,
+  raw: dict,
+}
+
+type SlackAppMentionEventPayload = {
+  provider: "slack",
+  event: "app_mention",
+  event_id: string | nil,
+  api_app_id: string | nil,
+  team_id: string | nil,
+  channel_id: string | nil,
+  user_id: string | nil,
+  event_ts: string | nil,
+  channel: string | nil,
+  user: string | nil,
+  text: string | nil,
+  ts: string | nil,
+  thread_ts: string | nil,
+  raw: dict,
+}
+
+type SlackReactionAddedEventPayload = {
+  provider: "slack",
+  event: "reaction_added",
+  event_id: string | nil,
+  api_app_id: string | nil,
+  team_id: string | nil,
+  channel_id: string | nil,
+  user_id: string | nil,
+  event_ts: string | nil,
+  reaction: string | nil,
+  item_user: string | nil,
+  item: dict,
+  raw: dict,
+}
+
+type SlackTeamJoinEventPayload = {
+  provider: "slack",
+  event: "team_join",
+  event_id: string | nil,
+  api_app_id: string | nil,
+  team_id: string | nil,
+  channel_id: string | nil,
+  user_id: string | nil,
+  event_ts: string | nil,
+  user: dict,
+  raw: dict,
+}
+
+type SlackChannelCreatedEventPayload = {
+  provider: "slack",
+  event: "channel_created",
+  event_id: string | nil,
+  api_app_id: string | nil,
+  team_id: string | nil,
+  channel_id: string | nil,
+  user_id: string | nil,
+  event_ts: string | nil,
+  channel: dict,
+  raw: dict,
+}
+
+type SlackOtherEventPayload = {
+  provider: "slack",
+  event: string,
+  event_id: string | nil,
+  api_app_id: string | nil,
+  team_id: string | nil,
+  channel_id: string | nil,
+  user_id: string | nil,
+  event_ts: string | nil,
+  raw: dict,
+}
+
+type SlackEventPayload = SlackMessageChannelsEventPayload | SlackAppMentionEventPayload | SlackReactionAddedEventPayload | SlackTeamJoinEventPayload | SlackChannelCreatedEventPayload | SlackOtherEventPayload
 
 type LinearEventPayload = {
   provider: "linear",

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -1308,6 +1308,23 @@ fn notify_test_inbox_dequeued() {
     });
 }
 
+pub async fn enqueue_trigger_event<L: EventLog + ?Sized>(
+    event_log: &L,
+    event: &TriggerEvent,
+) -> Result<u64, DispatchError> {
+    let topic = Topic::new(TRIGGER_INBOX_ENVELOPES_TOPIC)
+        .expect("static trigger.inbox.envelopes topic is valid");
+    let headers = event_headers(event, None, None, None);
+    let payload =
+        serde_json::to_value(event).map_err(|error| DispatchError::Serde(error.to_string()))?;
+    event_log
+        .append(
+            &topic,
+            LogEvent::new("event_ingested", payload).with_headers(headers),
+        )
+        .await
+        .map_err(DispatchError::from)
+
 pub fn snapshot_dispatcher_stats() -> DispatcherStatsSnapshot {
     ACTIVE_DISPATCHER_STATE.with(|slot| {
         slot.borrow()

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -1324,6 +1324,7 @@ pub async fn enqueue_trigger_event<L: EventLog + ?Sized>(
         )
         .await
         .map_err(DispatchError::from)
+}
 
 pub fn snapshot_dispatcher_stats() -> DispatcherStatsSnapshot {
     ACTIVE_DISPATCHER_STATE.with(|slot| {

--- a/crates/harn-vm/src/triggers/event.rs
+++ b/crates/harn-vm/src/triggers/event.rs
@@ -154,12 +154,72 @@ pub enum GitHubEventPayload {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct SlackEventPayload {
+pub struct SlackEventCommon {
     pub event: String,
-    pub subtype: Option<String>,
+    pub event_id: Option<String>,
+    pub api_app_id: Option<String>,
     pub team_id: Option<String>,
     pub channel_id: Option<String>,
+    pub user_id: Option<String>,
+    pub event_ts: Option<String>,
     pub raw: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SlackMessageChannelsEventPayload {
+    #[serde(flatten)]
+    pub common: SlackEventCommon,
+    pub subtype: Option<String>,
+    pub channel: Option<String>,
+    pub user: Option<String>,
+    pub text: Option<String>,
+    pub ts: Option<String>,
+    pub thread_ts: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SlackAppMentionEventPayload {
+    #[serde(flatten)]
+    pub common: SlackEventCommon,
+    pub channel: Option<String>,
+    pub user: Option<String>,
+    pub text: Option<String>,
+    pub ts: Option<String>,
+    pub thread_ts: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SlackReactionAddedEventPayload {
+    #[serde(flatten)]
+    pub common: SlackEventCommon,
+    pub reaction: Option<String>,
+    pub item_user: Option<String>,
+    pub item: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SlackTeamJoinEventPayload {
+    #[serde(flatten)]
+    pub common: SlackEventCommon,
+    pub user: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SlackChannelCreatedEventPayload {
+    #[serde(flatten)]
+    pub common: SlackEventCommon,
+    pub channel: JsonValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SlackEventPayload {
+    MessageChannels(SlackMessageChannelsEventPayload),
+    AppMention(SlackAppMentionEventPayload),
+    ReactionAdded(SlackReactionAddedEventPayload),
+    TeamJoin(SlackTeamJoinEventPayload),
+    ChannelCreated(SlackChannelCreatedEventPayload),
+    Other(SlackEventCommon),
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -242,7 +302,7 @@ pub enum KnownProviderPayload {
     #[serde(rename = "github")]
     GitHub(GitHubEventPayload),
     #[serde(rename = "slack")]
-    Slack(SlackEventPayload),
+    Slack(Box<SlackEventPayload>),
     #[serde(rename = "linear")]
     Linear(LinearEventPayload),
     #[serde(rename = "notion")]
@@ -737,9 +797,19 @@ fn default_provider_schemas() -> Vec<Arc<dyn ProviderSchema>> {
                 "slack",
                 &["webhook"],
                 "SlackEventPayload",
-                SignatureVerificationMetadata::None,
-                Vec::new(),
-                ProviderRuntimeMetadata::Placeholder,
+                hmac_signature_metadata(
+                    "slack",
+                    "X-Slack-Signature",
+                    Some("X-Slack-Request-Timestamp"),
+                    None,
+                    Some(300),
+                    "hex",
+                ),
+                vec![required_secret("signing_secret", "slack")],
+                ProviderRuntimeMetadata::Builtin {
+                    connector: "slack".to_string(),
+                    default_signature_variant: Some("slack".to_string()),
+                },
             ),
             normalize: slack_payload,
         }),
@@ -886,27 +956,149 @@ fn slack_payload(
     _headers: &BTreeMap<String, String>,
     raw: JsonValue,
 ) -> ProviderPayload {
-    let subtype = raw
-        .get("event")
-        .and_then(|value| value.get("subtype"))
-        .and_then(JsonValue::as_str)
-        .map(ToString::to_string);
-    let team_id = raw
-        .get("team_id")
-        .and_then(JsonValue::as_str)
-        .map(ToString::to_string);
-    let channel_id = raw
-        .get("event")
+    let event = raw.get("event");
+    let common = SlackEventCommon {
+        event: kind.to_string(),
+        event_id: raw
+            .get("event_id")
+            .and_then(JsonValue::as_str)
+            .map(ToString::to_string),
+        api_app_id: raw
+            .get("api_app_id")
+            .and_then(JsonValue::as_str)
+            .map(ToString::to_string),
+        team_id: raw
+            .get("team_id")
+            .and_then(JsonValue::as_str)
+            .map(ToString::to_string),
+        channel_id: slack_channel_id(event),
+        user_id: slack_user_id(event),
+        event_ts: event
+            .and_then(|value| value.get("event_ts"))
+            .and_then(JsonValue::as_str)
+            .map(ToString::to_string),
+        raw: raw.clone(),
+    };
+    let payload = match kind {
+        "message.channels" => {
+            SlackEventPayload::MessageChannels(SlackMessageChannelsEventPayload {
+                subtype: event
+                    .and_then(|value| value.get("subtype"))
+                    .and_then(JsonValue::as_str)
+                    .map(ToString::to_string),
+                channel: event
+                    .and_then(|value| value.get("channel"))
+                    .and_then(JsonValue::as_str)
+                    .map(ToString::to_string),
+                user: event
+                    .and_then(|value| value.get("user"))
+                    .and_then(JsonValue::as_str)
+                    .map(ToString::to_string),
+                text: event
+                    .and_then(|value| value.get("text"))
+                    .and_then(JsonValue::as_str)
+                    .map(ToString::to_string),
+                ts: event
+                    .and_then(|value| value.get("ts"))
+                    .and_then(JsonValue::as_str)
+                    .map(ToString::to_string),
+                thread_ts: event
+                    .and_then(|value| value.get("thread_ts"))
+                    .and_then(JsonValue::as_str)
+                    .map(ToString::to_string),
+                common,
+            })
+        }
+        "app_mention" => SlackEventPayload::AppMention(SlackAppMentionEventPayload {
+            channel: event
+                .and_then(|value| value.get("channel"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string),
+            user: event
+                .and_then(|value| value.get("user"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string),
+            text: event
+                .and_then(|value| value.get("text"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string),
+            ts: event
+                .and_then(|value| value.get("ts"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string),
+            thread_ts: event
+                .and_then(|value| value.get("thread_ts"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string),
+            common,
+        }),
+        "reaction_added" => SlackEventPayload::ReactionAdded(SlackReactionAddedEventPayload {
+            reaction: event
+                .and_then(|value| value.get("reaction"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string),
+            item_user: event
+                .and_then(|value| value.get("item_user"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string),
+            item: event
+                .and_then(|value| value.get("item"))
+                .cloned()
+                .unwrap_or(JsonValue::Null),
+            common,
+        }),
+        "team_join" => SlackEventPayload::TeamJoin(SlackTeamJoinEventPayload {
+            user: event
+                .and_then(|value| value.get("user"))
+                .cloned()
+                .unwrap_or(JsonValue::Null),
+            common,
+        }),
+        "channel_created" => SlackEventPayload::ChannelCreated(SlackChannelCreatedEventPayload {
+            channel: event
+                .and_then(|value| value.get("channel"))
+                .cloned()
+                .unwrap_or(JsonValue::Null),
+            common,
+        }),
+        _ => SlackEventPayload::Other(common),
+    };
+    ProviderPayload::Known(KnownProviderPayload::Slack(Box::new(payload)))
+}
+
+fn slack_channel_id(event: Option<&JsonValue>) -> Option<String> {
+    event
         .and_then(|value| value.get("channel"))
         .and_then(JsonValue::as_str)
-        .map(ToString::to_string);
-    ProviderPayload::Known(KnownProviderPayload::Slack(SlackEventPayload {
-        event: kind.to_string(),
-        subtype,
-        team_id,
-        channel_id,
-        raw,
-    }))
+        .map(ToString::to_string)
+        .or_else(|| {
+            event
+                .and_then(|value| value.get("item"))
+                .and_then(|value| value.get("channel"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string)
+        })
+        .or_else(|| {
+            event
+                .and_then(|value| value.get("channel"))
+                .and_then(|value| value.get("id"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string)
+        })
+}
+
+fn slack_user_id(event: Option<&JsonValue>) -> Option<String> {
+    event
+        .and_then(|value| value.get("user"))
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string)
+        .or_else(|| {
+            event
+                .and_then(|value| value.get("user"))
+                .and_then(|value| value.get("id"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string)
+        })
 }
 
 fn linear_payload(

--- a/crates/harn-vm/src/triggers/event.rs
+++ b/crates/harn-vm/src/triggers/event.rs
@@ -1282,9 +1282,10 @@ mod tests {
             .filter(|entry| matches!(entry.runtime, ProviderRuntimeMetadata::Builtin { .. }))
             .collect();
 
-        assert_eq!(builtin.len(), 3);
+        assert_eq!(builtin.len(), 4);
         assert!(builtin.iter().any(|entry| entry.provider == "cron"));
         assert!(builtin.iter().any(|entry| entry.provider == "github"));
+        assert!(builtin.iter().any(|entry| entry.provider == "slack"));
         assert!(builtin.iter().any(|entry| entry.provider == "webhook"));
     }
 

--- a/crates/harn-vm/src/triggers/test_util/mod.rs
+++ b/crates/harn-vm/src/triggers/test_util/mod.rs
@@ -1220,6 +1220,7 @@ fn webhook_binding(
                 WebhookSignatureVariant::Standard => "standard",
                 WebhookSignatureVariant::Stripe => "stripe",
                 WebhookSignatureVariant::GitHub => "github",
+                WebhookSignatureVariant::Slack => "slack",
             },
             "source": "fixtures",
         }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -35,6 +35,7 @@
 - [Trigger registry](./triggers/registry.md)
 - [Cron connector](./connectors/cron.md)
 - [GitHub App connector](./connectors/github.md)
+- [Slack Events connector](./connectors/slack.md)
 - [Generic webhook connector](./connectors/webhook.md)
 - [Cookbook](./cookbook.md)
 - [Tutorial: code review agent](./tutorial-code-review-agent.md)

--- a/docs/src/connectors/slack.md
+++ b/docs/src/connectors/slack.md
@@ -1,0 +1,121 @@
+# Slack Events connector
+
+`SlackConnector` is Harn's built-in Slack Events API integration. It verifies
+Slack's signed webhook requests, narrows the most useful inbound event families
+into typed `SlackEventPayload` variants, and exposes a small outbound Web API
+client through `std/connectors/slack`.
+
+This connector is for the HTTP Events API path, not Socket Mode.
+
+## Inbound webhook bindings
+
+Configure Slack as a `provider = "slack"` webhook trigger:
+
+```toml
+[[triggers]]
+id = "slack-mentions"
+kind = "webhook"
+provider = "slack"
+match = { path = "/hooks/slack" }
+handler = "handlers::on_slack"
+secrets = { signing_secret = "slack/signing-secret" }
+```
+
+The connector verifies:
+
+- `X-Slack-Request-Timestamp`
+- `X-Slack-Signature`
+- the raw request body, using `v0:{timestamp}:{body}` and HMAC-SHA256
+
+Slack retries aggressively if a listener does not answer within three seconds,
+so Harn treats inbound Slack deliveries as ack-first:
+
+1. verify the signature
+2. normalize into `TriggerEvent`
+3. append to `trigger.inbox`
+4. return HTTP 200
+5. let the dispatcher run handlers asynchronously after the response
+
+`url_verification` is handled inline after signature verification and responds
+with the plaintext `challenge` value, as required by Slack.
+
+## Typed inbound payloads
+
+`SlackEventPayload` is narrowed into these first-class variants:
+
+- `message.channels`
+- `app_mention`
+- `reaction_added`
+- `team_join`
+- `channel_created`
+
+Other Slack callback shapes still normalize into `SlackEventPayload::Other`
+with the full `raw` envelope preserved.
+
+## Outbound configuration
+
+Import from `std/connectors/slack`:
+
+```harn
+import { configure } from "std/connectors/slack"
+
+configure({
+  bot_token_secret: "slack/bot-token",
+})
+```
+
+Required config:
+
+- `bot_token` or `bot_token_secret`
+
+Optional config:
+
+- `api_base_url` for tests or local mocks; defaults to `https://slack.com/api`
+
+The connector uses bearer auth for every outbound request.
+
+## Outbound helpers
+
+Available helpers:
+
+- `post_message(channel, text, blocks = nil, options = nil)`
+- `update_message(channel, ts, text, blocks = nil, options = nil)`
+- `add_reaction(channel, ts, name, options = nil)`
+- `upload_file(filename, content, options = nil)`
+
+`upload_file(...)` uses Slack's external upload flow
+(`files.getUploadURLExternal` + upload URL + `files.completeUploadExternal`)
+instead of the older legacy `files.upload` path.
+
+Example:
+
+```harn
+import {
+  add_reaction,
+  configure,
+  post_message,
+} from "std/connectors/slack"
+
+pipeline default() {
+  configure({
+    bot_token_secret: "slack/bot-token",
+  })
+
+  let posted = post_message("C123ABC456", "hello from harn")
+  add_reaction("C123ABC456", posted.ts, "thumbsup")
+}
+```
+
+## Recommended scopes
+
+The minimal Slack scopes depend on which events and outbound methods you use.
+Typical starting points:
+
+- `app_mentions:read` for `app_mention`
+- `channels:history` for `message.channels`
+- `reactions:read` for `reaction_added`
+- `users:read` for `team_join`
+- `channels:read` for `channel_created`
+- `chat:write` for message posting/updating
+- `reactions:write` for reactions
+- `files:write` for uploads

--- a/docs/src/triggers/event-schema.md
+++ b/docs/src/triggers/event-schema.md
@@ -55,7 +55,10 @@ provider variant exposes a stable normalized surface plus `raw: dict`. GitHub's
 payload is already narrowed into the six MVP event families (`issues`,
 `pull_request`, `issue_comment`, `pull_request_review`, `push`, and
 `workflow_run`) with event-specific top-level fields such as `issue`,
-`pull_request`, `comment`, `review`, `commits`, and `workflow_run`:
+`pull_request`, `comment`, `review`, `commits`, and `workflow_run`. Slack's
+payload is narrowed into `message.channels`, `app_mention`,
+`reaction_added`, `team_join`, and `channel_created`, while still preserving
+the full outer envelope in `raw`:
 
 - `GitHubEventPayload`
 - `SlackEventPayload`


### PR DESCRIPTION
## Summary
- add a native Slack connector with shared Slack HMAC verification, typed inbound event payloads, and outbound API helpers
- route webhook ingress through the existing `trigger.inbox` dispatcher path so listeners ack quickly and handlers run asynchronously after the HTTP response
- add Slack provider catalog/stdlib/docs/conformance coverage, plus targeted orchestrator and connector tests

## Details
- implements first-class `slack` provider handling, including `message.channels`, `app_mention`, `reaction_added`, `team_join`, and `channel_created`
- adds `post_message`, `update_message`, `add_reaction`, and `upload_file` helpers on the Slack connector client
- adds a fixture-based Slack mock server and a round-trip conformance case covering message -> reaction flow
- adjusts orchestrator startup ordering so the HTTP listener announces readiness before background connector activation begins

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-b602-target cargo test -p harn-vm slack -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-b602-target cargo test -p harn-cli slack_ -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-b602-target cargo run --bin harn -- test conformance --filter slack_connector_roundtrip`
- `CARGO_TARGET_DIR=/tmp/harn-b602-target cargo run --bin harn -- test conformance --filter trigger_provider_catalog`
- `git push -u origin ksinder/slack-events-connector` (includes repo pre-push suite: 1587 tests, markdown, portal lint)
