### PR TITLE
[codex] Fix webhook inbound dedupe bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ granular archaeology.
 
 ### Fixed
 
+- **Webhook inbound dedupe is back on for generic-webhook bindings
+  (#223).** `GenericWebhookConnector::normalize_inbound` now bridges
+  its sync trait surface to the async inbox index using the same
+  `block_on` pattern already used by the cron/GitHub connector layer,
+  so duplicate deliveries are rejected again by binding + delivery
+  key. Re-enabled the previously ignored webhook dedupe regression
+  test.
+
 - **Flaky cwd-mutating test collisions (#204).** Added a shared-process
   cwd mutex so parallel `cargo test` no longer observes mid-test cwd
   swaps. `check_manifest_reports_loaded_triggers` and

--- a/conformance/tests/triggers/trigger_harness_dedupe_swallows_duplicate_key.harn
+++ b/conformance/tests/triggers/trigger_harness_dedupe_swallows_duplicate_key.harn
@@ -3,5 +3,5 @@ pipeline test(task) {
   println(result.ok)
   println(len(result.emitted) == 1)
   println(result.emitted[0].note == "first_delivery")
-  println(result.details.first_claim && !result.details.second_claim)
+  println(contains(result.details.duplicate_error, "duplicate"))
 }

--- a/crates/harn-vm/src/connectors/webhook/mod.rs
+++ b/crates/harn-vm/src/connectors/webhook/mod.rs
@@ -16,7 +16,7 @@ use crate::connectors::{
 use crate::secrets::{SecretId, SecretVersion};
 use crate::triggers::{
     redact_headers, HeaderRedactionPolicy, ProviderId, ProviderPayload, SignatureStatus, TraceId,
-    TriggerEvent, TriggerEventId,
+    TriggerEvent, TriggerEventId, DEFAULT_INBOX_RETENTION_DAYS,
 };
 
 pub mod variants;
@@ -73,16 +73,13 @@ struct ConnectorState {
 
 #[derive(Clone, Debug)]
 struct ActivatedWebhookBinding {
-    // Retained for identification in future dedupe plumbing (harn#223) and
-    // for consistency with binding lookup; clippy's dead-code check doesn't
-    // see the external clone sites yet.
-    #[allow(dead_code)]
     binding_id: String,
     path: Option<String>,
     signing_secret: SecretId,
     signature_variant: WebhookSignatureVariant,
     timestamp_tolerance: Option<Duration>,
     dedupe_enabled: bool,
+    dedupe_ttl: std::time::Duration,
     source: Option<String>,
 }
 
@@ -231,16 +228,20 @@ impl Connector for GenericWebhookConnector {
             &normalized_body,
             &raw.body,
         );
-        // TODO(#220 fix-forward): webhook dedupe check was sync-calling
-        // the now-async InboxIndex::insert_if_new. `Connector::normalize_inbound`
-        // is a sync trait method (crates/harn-vm/src/connectors/mod.rs:60), so
-        // we can't simply `.await` here without either (a) promoting the trait
-        // to async, or (b) moving dedupe into an async wrapper layer in the
-        // webhook dispatch path. Filing follow-up: webhook dedupe is bypassed
-        // in this release; cron dedupe (the primary at-least-once use case)
-        // is fully wired.
-        let _ = dedupe_key; // silence unused-var warning until follow-up lands
-        let _ = &binding.dedupe_enabled;
+        if binding.dedupe_enabled {
+            let inserted = futures::executor::block_on(ctx.inbox.insert_if_new(
+                &binding.binding_id,
+                &dedupe_key,
+                binding.dedupe_ttl,
+            ))?;
+            if !inserted {
+                return Err(ConnectorError::DuplicateDelivery(format!(
+                    "duplicate {} delivery `{dedupe_key}` for binding `{}`",
+                    provider.as_str(),
+                    binding.binding_id
+                )));
+            }
+        }
 
         let provider_payload = ProviderPayload::normalize(
             &provider,
@@ -317,6 +318,9 @@ impl ActivatedWebhookBinding {
             signature_variant,
             timestamp_tolerance,
             dedupe_enabled: binding.dedupe_key.is_some(),
+            dedupe_ttl: std::time::Duration::from_secs(
+                u64::from(DEFAULT_INBOX_RETENTION_DAYS) * 24 * 60 * 60,
+            ),
             source: config.webhook.source,
         })
     }

--- a/crates/harn-vm/src/connectors/webhook/tests.rs
+++ b/crates/harn-vm/src/connectors/webhook/tests.rs
@@ -361,13 +361,7 @@ async fn webhook_variants_cover_valid_and_failure_cases() {
     }
 }
 
-// TODO(harn#223): webhook dedupe is temporarily disabled in this PR because
-// `Connector::normalize_inbound` is a sync trait method and cannot await the
-// now-async `InboxIndex::insert_if_new`. Re-enable this test once the async
-// bridge lands (harn#223). Cron dedupe (the primary at-least-once use case)
-// is already wired and covered by `orchestrator_inbox_dedupe.rs`.
-#[ignore = "webhook dedupe disabled until harn#223 bridges sync trait to async InboxIndex"]
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn normalize_inbound_dedupes_on_binding_delivery_key() {
     let harness = TestHarness::new(
         binding(WebhookSignatureVariant::Standard, Some("event.dedupe_key")),

--- a/crates/harn-vm/src/triggers/test_util/mod.rs
+++ b/crates/harn-vm/src/triggers/test_util/mod.rs
@@ -506,50 +506,18 @@ impl TriggerTestHarness {
         let first = connector
             .normalize_inbound(raw.clone())
             .map_err(|error| error.to_string())?;
-        let binding_id = "webhook.fixture";
-        let retention =
-            StdDuration::from_secs(u64::from(DEFAULT_INBOX_RETENTION_DAYS) * 24 * 60 * 60);
-        // Simulate the dispatch layer's inbox dedupe claim. The sync
-        // `Connector::normalize_inbound` intentionally no longer calls
-        // InboxIndex::insert_if_new inline (see #220 fix-forward comment in
-        // crates/harn-vm/src/connectors/webhook/mod.rs); dedupe is the
-        // responsibility of the async dispatch wrapper.
-        let first_claim = inbox
-            .insert_if_new(binding_id, &first.dedupe_key, retention)
-            .await
-            .map_err(|error| error.to_string())?;
-        if first_claim {
-            self.connector_registry.record_event(
-                binding_id,
-                1,
-                &first,
-                Some("first_delivery"),
-                None,
-            );
-        }
-        let second = connector
-            .normalize_inbound(raw)
-            .map_err(|error| error.to_string())?;
-        let second_claim = inbox
-            .insert_if_new(binding_id, &second.dedupe_key, retention)
-            .await
-            .map_err(|error| error.to_string())?;
-        if second_claim {
-            self.connector_registry.record_event(
-                binding_id,
-                1,
-                &second,
-                Some("duplicate_delivery"),
-                None,
-            );
-        }
+        self.connector_registry.record_event(
+            "webhook.fixture",
+            1,
+            &first,
+            Some("first_delivery"),
+            None,
+        );
+        let duplicate = connector.normalize_inbound(raw).unwrap_err();
         let emitted = self.connector_registry.emitted();
         Ok(TriggerHarnessResult {
             fixture: "dedupe_swallows_duplicate_key".to_string(),
-            ok: emitted.len() == 1
-                && first_claim
-                && !second_claim
-                && first.dedupe_key == second.dedupe_key,
+            ok: emitted.len() == 1 && matches!(duplicate, ConnectorError::DuplicateDelivery(_)),
             stub: false,
             summary: "duplicate inbound deliveries are swallowed by the dedupe guard".to_string(),
             emitted,
@@ -559,9 +527,8 @@ impl TriggerTestHarness {
             bindings: Vec::new(),
             notes: Vec::new(),
             details: json!({
-                "first_claim": first_claim,
-                "second_claim": second_claim,
                 "dedupe_key": first.dedupe_key,
+                "duplicate_error": duplicate.to_string(),
             }),
         })
     }


### PR DESCRIPTION
## Summary
- restore webhook inbound dedupe inside `GenericWebhookConnector::normalize_inbound` by bridging the sync connector trait to async inbox claims with `futures::executor::block_on`
- carry the binding id and default inbox retention TTL on activated webhook bindings so duplicate deliveries can be rejected consistently with the GitHub connector
- re-enable the webhook dedupe regression test and update the trigger harness fixture that had been written around the temporary bypass
- add an Unreleased changelog entry for harn#223

## Root Cause
`InboxIndex::insert_if_new` became async in #220 while `Connector::normalize_inbound` remained sync. Webhook dedupe was temporarily disabled during that rebase and the regression test was marked ignored.

## Impact
Webhook connectors once again reject duplicate deliveries by binding plus delivery key during normalization, matching the existing sync-to-async bridging pattern already used in the connector layer.

## Validation
- `cargo fmt --all`
- `env CARGO_TARGET_DIR=/tmp/harn-c5a4-target cargo clippy -p harn-vm -- -D warnings`
- `env CARGO_TARGET_DIR=/tmp/harn-c5a4-target cargo test -p harn-vm connectors::webhook`
- `env CARGO_TARGET_DIR=/tmp/harn-c5a4-target cargo test -p harn-vm every_trigger_harness_fixture_reports_success`
- repo pre-commit hooks (`cargo fmt`, clippy, markdownlint, portal lint)
- repo pre-push checks (`cargo nextest`, markdownlint, portal lint)
