### PR TITLE
Add preserve_thinking capability + Qwen3.6 provider rules

### DIFF
--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -68,6 +68,14 @@ pub struct ProviderRule {
     pub prompt_caching: Option<bool>,
     #[serde(default)]
     pub thinking: Option<bool>,
+    /// Carry `<think>...</think>` blocks in assistant history across turns.
+    /// Qwen3.6 exposes this as `chat_template_kwargs.preserve_thinking`;
+    /// Alibaba recommends enabling it for long-horizon coding agents so the
+    /// model doesn't re-derive context it already worked out in prior turns.
+    /// Anthropic's adaptive-thinking signature contract is stricter but plays
+    /// the same role there.
+    #[serde(default)]
+    pub preserve_thinking: Option<bool>,
 }
 
 /// Resolved capabilities for a `(provider, model)` pair. Unset rule
@@ -81,6 +89,7 @@ pub struct Capabilities {
     pub max_tools: Option<u32>,
     pub prompt_caching: bool,
     pub thinking: bool,
+    pub preserve_thinking: bool,
 }
 
 thread_local! {
@@ -234,6 +243,7 @@ fn rule_to_caps(rule: &ProviderRule) -> Capabilities {
         max_tools: rule.max_tools,
         prompt_caching: rule.prompt_caching.unwrap_or(false),
         thinking: rule.thinking.unwrap_or(false),
+        preserve_thinking: rule.preserve_thinking.unwrap_or(false),
     }
 }
 
@@ -388,6 +398,63 @@ mod tests {
         let caps = lookup("mock", "gpt-5.4-preview");
         assert!(caps.defer_loading);
         assert_eq!(caps.tool_search, vec!["hosted", "client"]);
+    }
+
+    #[test]
+    fn qwen36_ollama_preserves_thinking() {
+        reset();
+        let caps = lookup("ollama", "qwen3.6:35b-a3b-coding-nvfp4");
+        assert!(caps.native_tools);
+        assert!(caps.thinking);
+        assert!(
+            caps.preserve_thinking,
+            "Qwen3.6 should enable preserve_thinking by default for coding agents"
+        );
+    }
+
+    #[test]
+    fn qwen35_ollama_does_not_preserve_thinking() {
+        reset();
+        let caps = lookup("ollama", "qwen3.5:35b-a3b-coding-nvfp4");
+        assert!(caps.native_tools);
+        assert!(caps.thinking);
+        assert!(
+            !caps.preserve_thinking,
+            "Qwen3.5 lacks the preserve_thinking kwarg — rely on the chat template's rolling checkpoint instead"
+        );
+    }
+
+    #[test]
+    fn qwen36_routed_providers_all_preserve_thinking() {
+        reset();
+        for (provider, model) in [
+            ("openrouter", "qwen/qwen3.6-plus"),
+            ("together", "Qwen/Qwen3.6-35B-A3B"),
+            ("huggingface", "Qwen/Qwen3.6-35B-A3B"),
+            ("fireworks", "accounts/fireworks/models/qwen3p6-plus"),
+            ("dashscope", "qwen3.6-plus"),
+            ("llamacpp", "unsloth/Qwen3.6-35B-A3B-GGUF"),
+            ("local", "Qwen3.6-35B-A3B"),
+        ] {
+            let caps = lookup(provider, model);
+            assert!(caps.thinking, "{provider}/{model}: thinking");
+            assert!(
+                caps.preserve_thinking,
+                "{provider}/{model}: preserve_thinking must be on for Qwen3.6"
+            );
+            assert!(caps.native_tools, "{provider}/{model}: native_tools");
+        }
+    }
+
+    #[test]
+    fn dashscope_and_llamacpp_resolve_capabilities() {
+        reset();
+        // New sibling providers should fall through to `openai` for
+        // gpt-*  models even without dedicated rules.
+        let caps = lookup("dashscope", "gpt-5.4-preview");
+        assert!(caps.defer_loading);
+        let caps = lookup("llamacpp", "gpt-5.4-preview");
+        assert!(caps.defer_loading);
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -155,12 +155,176 @@ native_tools = true
 # Local providers don't advertise native tool_search or prompt caching.
 # Native-tools coverage depends on the specific model. Qwen 3 / 3.5
 # packages on Ollama expose native tool calling and thinking on the
-# official docs + model pages.
+# official docs + model pages. Qwen 3.6 adds `preserve_thinking` which
+# Alibaba recommends for multi-turn agentic / coding workflows (the
+# flagship use case we're building for) — keep it on by default.
+
+[[provider.ollama]]
+model_match = "qwen3.6*"
+native_tools = true
+thinking = true
+preserve_thinking = true
 
 [[provider.ollama]]
 model_match = "qwen3*"
 native_tools = true
 thinking = true
+
+# llama.cpp / llama-server speaks OpenAI-compat but is a separate surface
+# in Burin's providers.toml. Give it the same Qwen3.6 wiring so the local
+# GGUF path gets `preserve_thinking` by default too.
+[[provider.llamacpp]]
+model_match = "*qwen3.6*"
+native_tools = true
+thinking = true
+preserve_thinking = true
+
+[[provider.llamacpp]]
+model_match = "*qwen3*"
+native_tools = true
+thinking = true
+
+# Local vLLM / SGLang — same story. The capability rules here gate
+# chat_template_kwargs emission in openai_compat; the actual model has
+# to have been launched with the matching --chat-template.
+[[provider.local]]
+model_match = "*qwen3.6*"
+native_tools = true
+thinking = true
+preserve_thinking = true
+
+[[provider.local]]
+model_match = "*qwen3*"
+native_tools = true
+thinking = true
+
+# ---------- Qwen3.6 family (routed providers) --------------------------------
+#
+# DashScope is the authoritative Qwen host; Fireworks and OpenRouter
+# carry the closed Plus variant. They all speak OpenAI-compat + honour
+# the Qwen `chat_template_kwargs`, so the wiring is identical to local
+# vLLM. The sibling fallthrough to `[[provider.openai]]` would match the
+# gpt-* rules (which don't apply) so we declare Qwen explicitly here to
+# prevent a silent fallthrough to empty capabilities.
+
+[[provider.dashscope]]
+model_match = "qwen3.6*"
+native_tools = true
+thinking = true
+preserve_thinking = true
+
+[[provider.dashscope]]
+model_match = "qwen*"
+native_tools = true
+thinking = true
+
+[[provider.fireworks]]
+model_match = "*qwen3.6*"
+native_tools = true
+thinking = true
+preserve_thinking = true
+
+# Fireworks's own model IDs squash dots to `p` (`qwen3p6`, `qwen3p5`),
+# so we need a second rule to catch their canonical naming.
+[[provider.fireworks]]
+model_match = "*qwen3p6*"
+native_tools = true
+thinking = true
+preserve_thinking = true
+
+[[provider.fireworks]]
+model_match = "*qwen*"
+native_tools = true
+thinking = true
+
+# OpenRouter: forwards Qwen thinking via its `reasoning` field (not
+# chat_template_kwargs — transform_request strips that). Preservation
+# works transparently since thinking blocks round-trip as assistant
+# content; the reasoning enablement lives in `openrouter_reasoning_config`.
+[[provider.openrouter]]
+model_match = "qwen/qwen3.6*"
+native_tools = true
+thinking = true
+preserve_thinking = true
+
+[[provider.openrouter]]
+model_match = "qwen/*"
+native_tools = true
+thinking = true
+
+# HuggingFace router + Together pass Qwen chat_template_kwargs through
+# unchanged. Match the qwen3.6 model card shape (`Qwen/Qwen3.6-*`).
+[[provider.huggingface]]
+model_match = "qwen/qwen3.6*"
+native_tools = true
+thinking = true
+preserve_thinking = true
+
+[[provider.huggingface]]
+model_match = "qwen/*"
+native_tools = true
+thinking = true
+
+[[provider.together]]
+model_match = "qwen/qwen3.6*"
+native_tools = true
+thinking = true
+preserve_thinking = true
+
+[[provider.together]]
+model_match = "qwen/*"
+native_tools = true
+thinking = true
+
+# ---------- DeepSeek reasoning (across host providers) -----------------------
+#
+# DeepSeek V3.1+ exposes reasoning via `chat_template_kwargs.enable_thinking`
+# when routed through vLLM-style hosts (HuggingFace router, Together). On
+# OpenRouter it surfaces as the `reasoning` field like other models on
+# that platform. Prompt caching is DeepSeek-native (automatic, billed as
+# cache_read tokens) so declare it wherever the host forwards the usage.
+
+[[provider.together]]
+model_match = "deepseek-ai/deepseek-v3*"
+native_tools = true
+thinking = true
+prompt_caching = true
+
+[[provider.huggingface]]
+model_match = "deepseek-ai/deepseek-v3*"
+native_tools = true
+thinking = true
+prompt_caching = true
+
+[[provider.openrouter]]
+model_match = "deepseek/deepseek-v3*"
+native_tools = true
+thinking = true
+prompt_caching = true
+
+# ---------- Google Gemini + Gemma 4 (via OpenRouter) -------------------------
+#
+# Gemini 2.5 exposes thinking budgets through OpenRouter's `reasoning`
+# field. Gemma 4 does not; it's a plain instruction-tuned dense / MoE
+# model with native tool calling.
+
+[[provider.openrouter]]
+model_match = "google/gemini-2.5*"
+native_tools = true
+thinking = true
+prompt_caching = true
+
+[[provider.openrouter]]
+model_match = "google/gemma-4*"
+native_tools = true
+
+# ---------- Moonshot Kimi K2.5 (via Together) --------------------------------
+#
+# Kimi K2.5 does OpenAI-compatible native tool calls; no thinking surface.
+
+[[provider.together]]
+model_match = "moonshotai/*"
+native_tools = true
 
 # ---------- Mock --------------------------------------------------------------
 #
@@ -179,3 +343,6 @@ deepseek = "openai"
 fireworks = "openai"
 huggingface = "openai"
 local = "openai"
+# New April 2026 routes for Qwen3.6:
+dashscope = "openai"
+llamacpp = "openai"

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -199,6 +199,16 @@ impl OpenAiCompatibleProvider {
             chat_template_kwargs["add_generation_prompt"] = serde_json::json!(false);
             chat_template_kwargs["continue_final_message"] = serde_json::json!(true);
         }
+        // Qwen3.6 introduced `preserve_thinking`. When the capability
+        // matrix says the current (provider, model) pair honours it,
+        // emit the flag so the chat template carries `<think>` blocks
+        // across turns. Alibaba recommends it for agentic workloads
+        // (coding agents, long-horizon tool loops — our primary use
+        // case). Providers that don't understand the kwarg ignore it.
+        let caps = crate::llm::capabilities::lookup(&opts.provider, &opts.model);
+        if caps.preserve_thinking {
+            chat_template_kwargs["preserve_thinking"] = serde_json::json!(true);
+        }
         body["chat_template_kwargs"] = chat_template_kwargs;
         body
     }
@@ -325,6 +335,36 @@ mod tests {
 
         assert_eq!(body["reasoning"]["max_tokens"], 2048);
         assert!(body.get("chat_template_kwargs").is_none());
+    }
+
+    #[test]
+    fn qwen36_emits_preserve_thinking_in_chat_template_kwargs() {
+        let mut payload = base_request_payload();
+        payload.provider = "local".to_string();
+        payload.model = "Qwen/Qwen3.6-35B-A3B".to_string();
+        payload.thinking = Some(ThinkingConfig::Enabled);
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert_eq!(
+            body["chat_template_kwargs"]["preserve_thinking"], true,
+            "Qwen3.6 should request preserve_thinking so <think> blocks survive across agentic turns"
+        );
+        assert_eq!(body["chat_template_kwargs"]["enable_thinking"], true);
+    }
+
+    #[test]
+    fn qwen35_does_not_emit_preserve_thinking() {
+        let mut payload = base_request_payload();
+        payload.provider = "ollama".to_string();
+        payload.model = "qwen3.5:35b-a3b-coding-nvfp4".to_string();
+        payload.thinking = Some(ThinkingConfig::Enabled);
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert!(
+            body["chat_template_kwargs"]
+                .get("preserve_thinking")
+                .is_none(),
+            "Qwen3.5 lacks the kwarg — we shouldn't send it"
+        );
+        assert_eq!(body["chat_template_kwargs"]["enable_thinking"], true);
     }
 
     fn base_request_payload() -> LlmRequestPayload {


### PR DESCRIPTION
## Summary

- Adds `preserve_thinking` to the provider capability matrix and emits it through the OpenAI-compat request builder. Alibaba explicitly recommends this for multi-turn agentic / coding workloads (the Burin use case), so Qwen3.6 rules turn it on by default.
- Declares capability rules for every route that will host Qwen3.6 — Ollama, local vLLM, local llama.cpp (new \`llamacpp\` sibling), DashScope (new \`dashscope\` sibling), Fireworks, OpenRouter, Together, HuggingFace.
- Fills gaps the audit surfaced: DeepSeek V3+ reasoning + prompt caching across Together/HuggingFace/OpenRouter, Gemini 2.5 reasoning via OpenRouter, Kimi K2.5 native tools via Together.

## How it works

\`\`\`toml
[[provider.ollama]]
model_match = "qwen3.6*"
native_tools = true
thinking = true
preserve_thinking = true    # NEW
\`\`\`

When \`capabilities::lookup(provider, model).preserve_thinking\` is true, \`openai_compat::build_request_body\` adds \`chat_template_kwargs.preserve_thinking: true\` next to the existing \`enable_thinking\` kwarg. Providers that don't understand it ignore it. The Qwen3.5 rules deliberately do NOT set it — 3.5 lacks the template flag; rely on the chat template's rolling-checkpoint semantics instead.

## Test plan

- [x] \`cargo test --package harn-vm --lib llm::capabilities\` — 21 pass
- [x] \`cargo test --package harn-vm --lib llm::providers::openai_compat\` — 12 pass (2 new: qwen3.6 emits preserve_thinking; qwen3.5 does not)
- [x] \`cargo test --package harn-vm --lib llm::\` — 299 pass, 0 fail
- [x] End-to-end: launched \`llama-server\` with Unsloth Qwen3.6-35B-A3B-GGUF and verified the chat template acknowledges \`preserve_thinking\` (reasoning_content surfaces \<think\> blocks). 38.8 tok/s on M5 Pro 48 GB.
- [ ] CI: let it run

🤖 Generated with [Claude Code](https://claude.com/claude-code)