### PR TITLE
Wire orchestrator OTEL tracing and metrics (harn#184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,19 @@ granular archaeology.
   failures open a five-minute circuit breaker with operator-visible
   warnings.
 
+- **OpenTelemetry tracing and metrics for orchestrator dispatch flow (#184).**
+  Added orchestrator observability bootstrap in `harn orchestrator serve` with
+  `HARN_OTEL_ENDPOINT`, `HARN_OTEL_SERVICE_NAME`, and `HARN_OTEL_HEADERS`
+  propagation, plus OTel-enabled `ingest` and `dispatch` spans that share an
+  end-to-end trace id and include dispatch outcome attributes (`result.status`,
+  `result.duration_ms`). Listener ingest now records a `trace_id` on each pending
+  trigger payload and propagates ingest span context into dispatcher via
+  `otel_parent_span_id`, so pending work is linked end-to-end. Added Prometheus
+  counters (`dispatch_succeeded_total`, `dispatch_failed_total`, `inbox_duplicates_total`,
+  `retry_scheduled_total`) and `GET /metrics` on the listener. Added an
+  integration test asserting OTLP span emission with shared trace ids across ingress
+  and dispatch hops.
+
 - **`harn orchestrator {inspect, fire, replay, dlq, queue}` CLI
   commands (#185).** Implemented the placeholder orchestrator
   subcommands that used to error with `not implemented`. `inspect`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,8 +1146,10 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "tokio-stream",
  "toml",
  "tower 0.5.3",
+ "tracing",
  "url",
  "uuid",
  "webbrowser",
@@ -1248,6 +1262,9 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "uuid",
  "zeroize",
 ]
@@ -1392,6 +1409,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1806,6 +1824,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,6 +2084,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,8 +2129,8 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
+ "serde_json",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -2109,9 +2139,13 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
+ "base64",
+ "const-hex",
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
+ "serde",
+ "serde_json",
  "tonic",
  "tonic-prost",
 ]
@@ -2285,6 +2319,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2517,7 +2575,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -2532,6 +2589,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2640,6 +2698,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,6 +2759,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2858,6 +2937,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.2",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3112,6 +3200,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3426,6 +3523,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3439,6 +3578,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -3517,6 +3662,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -32,7 +32,7 @@ path = "src/main.rs"
 [dependencies]
 harn-lexer = { path = "../harn-lexer", version = "0.7" }
 harn-parser = { path = "../harn-parser", version = "0.7" }
-harn-vm = { path = "../harn-vm", version = "0.7" }
+harn-vm = { path = "../harn-vm", version = "0.7", features = ["otel"] }
 harn-lint = { path = "../harn-lint", version = "0.7" }
 harn-modules = { path = "../harn-modules", version = "0.7" }
 harn-fmt = { path = "../harn-fmt", version = "0.7" }
@@ -40,6 +40,7 @@ async-trait = "0.1"
 axum = "0.8"
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "sync", "time"] }
+tokio-stream = "0.1"
 serde_json = "1"
 reedline = "0.47"
 nu-ansi-term = "0.50"
@@ -67,6 +68,7 @@ croner = "3.0.1"
 jmespath = "0.5.0"
 rustls-pemfile = "2"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
+tracing = "0.1"
 
 [dev-dependencies]
 hmac = "0.12"

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -17,6 +17,7 @@ use time::OffsetDateTime;
 
 use harn_vm::event_log::{AnyEventLog, EventLog, LogEvent, Topic};
 use harn_vm::secrets::{SecretId, SecretProvider, SecretVersion};
+use tracing::Instrument as _;
 
 use crate::commands::orchestrator::origin_guard::{enforce_allowed_origin, OriginAllowList};
 use crate::commands::orchestrator::tls::{ServerRuntime, TlsFiles};
@@ -37,6 +38,7 @@ pub(crate) struct ListenerConfig {
     pub(crate) secrets: Arc<dyn SecretProvider>,
     pub(crate) allowed_origins: OriginAllowList,
     pub(crate) max_body_bytes: usize,
+    pub(crate) metrics_registry: Arc<harn_vm::MetricsRegistry>,
     pub(crate) routes: Vec<RouteConfig>,
 }
 
@@ -93,6 +95,10 @@ impl ListenerRuntime {
             .route(
                 "/readyz",
                 get(|| async move { (StatusCode::OK, "ready").into_response() }),
+            )
+            .route(
+                "/metrics",
+                get(metrics_endpoint).layer(Extension(config.metrics_registry.clone())),
             )
             .route(
                 "/{*path}",
@@ -382,110 +388,158 @@ async fn ingest_trigger(
     context.metrics.received.fetch_add(1, Ordering::Relaxed);
     context.metrics.in_flight.fetch_add(1, Ordering::Relaxed);
 
-    let normalized_headers = normalize_headers(&headers);
-    if let Err(error) = authorize_request(
-        &context,
-        method.as_str(),
-        uri.path(),
-        &normalized_headers,
-        body.as_ref(),
-    )
-    .await
-    {
-        context.metrics.failed.fetch_add(1, Ordering::Relaxed);
-        context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
-        return error.into_response();
-    }
+    let trace_id = harn_vm::TraceId::new();
+    let span = tracing::info_span!(
+        "ingest",
+        trigger_id = %context.route.trigger_id,
+        binding_version = context.route.binding_version,
+        trace_id = %trace_id.0
+    );
+    let _ = harn_vm::observability::otel::set_span_parent(&span, &trace_id, None);
 
-    if let Some(delay) = context.request_delay {
-        tokio::time::sleep(delay).await;
-    }
-
-    let result = normalize_request(&context, &normalized_headers, &query, body.as_ref()).await;
-    let response = match result {
-        Ok(NormalizedRequest::Event(event)) => {
-            let dedupe_ttl = Duration::from_secs(
-                u64::from(context.route.dedupe_retention_days.max(1)) * 24 * 60 * 60,
-            );
-            let postprocess = harn_vm::postprocess_normalized_event(
-                context.inbox.as_ref(),
-                &context.route.trigger_id,
-                context.route.dedupe_key_template.is_some(),
-                dedupe_ttl,
-                *event,
-            )
-            .await;
-            match postprocess {
-                Ok(harn_vm::PostNormalizeOutcome::DuplicateDropped) => {
-                    context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
-                    (
-                        StatusCode::OK,
-                        axum::Json(json!({
-                            "status": "duplicate_dropped",
-                            "trigger_id": context.route.trigger_id,
-                        })),
-                    )
-                        .into_response()
-                }
-                Ok(harn_vm::PostNormalizeOutcome::Ready(event)) => {
-                    let event = *event;
-                    let payload = json!({
-                        "trigger_id": context.route.trigger_id,
-                        "binding_version": context.route.binding_version,
-                        "event": event,
-                    });
-                    match context
-                        .event_log
-                        .append(
-                            &context.pending_topic,
-                            LogEvent::new("trigger_event", payload),
-                        )
-                        .await
-                    {
-                        Ok(event_id) => {
-                            context.metrics.dispatched.fetch_add(1, Ordering::Relaxed);
-                            context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
-                            (
-                                StatusCode::OK,
-                                axum::Json(json!({
-                                    "status": "accepted",
-                                    "event_id": event_id,
-                                    "trigger_id": context.route.trigger_id,
-                                })),
-                            )
-                                .into_response()
-                        }
-                        Err(error) => {
-                            context.metrics.failed.fetch_add(1, Ordering::Relaxed);
-                            context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
-                            (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                format!("failed to append trigger event to pending log: {error}"),
-                            )
-                                .into_response()
-                        }
-                    }
-                }
-                Err(error) => {
-                    context.metrics.failed.fetch_add(1, Ordering::Relaxed);
-                    context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
-                    HttpError::from_connector(error).into_response()
-                }
-            }
-        }
-        Ok(NormalizedRequest::Immediate(response)) => {
-            context.metrics.dispatched.fetch_add(1, Ordering::Relaxed);
-            context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
-            response
-        }
-        Err(error) => {
+    async move {
+        let normalized_headers = normalize_headers(&headers);
+        if let Err(error) = authorize_request(
+            &context,
+            method.as_str(),
+            uri.path(),
+            &normalized_headers,
+            body.as_ref(),
+        )
+        .await
+        {
             context.metrics.failed.fetch_add(1, Ordering::Relaxed);
             context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
-            error.into_response()
+            return error.into_response();
         }
-    };
 
-    response
+        if let Some(delay) = context.request_delay {
+            tokio::time::sleep(delay).await;
+        }
+
+        let result = normalize_request(
+            &context,
+            &normalized_headers,
+            &query,
+            body.as_ref(),
+            trace_id,
+        )
+        .await;
+        match result {
+            Ok(NormalizedRequest::Event(event)) => {
+                let dedupe_ttl = Duration::from_secs(
+                    u64::from(context.route.dedupe_retention_days.max(1)) * 24 * 60 * 60,
+                );
+                let postprocess = harn_vm::postprocess_normalized_event(
+                    context.inbox.as_ref(),
+                    &context.route.trigger_id,
+                    context.route.dedupe_key_template.is_some(),
+                    dedupe_ttl,
+                    *event,
+                )
+                .await;
+                match postprocess {
+                    Ok(harn_vm::PostNormalizeOutcome::DuplicateDropped) => {
+                        context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+                        (
+                            StatusCode::OK,
+                            axum::Json(json!({
+                                "status": "duplicate_dropped",
+                                "trigger_id": context.route.trigger_id,
+                            })),
+                        )
+                            .into_response()
+                    }
+                    Ok(harn_vm::PostNormalizeOutcome::Ready(event)) => {
+                        let event = *event;
+                        let payload = json!({
+                            "trigger_id": context.route.trigger_id,
+                            "binding_version": context.route.binding_version,
+                            "event": event,
+                        });
+                        let mut pending_headers = BTreeMap::new();
+                        pending_headers.insert("trace_id".to_string(), event.trace_id.0.clone());
+                        if let Some(parent_span_id) =
+                            harn_vm::observability::otel::current_span_id_hex(
+                                &tracing::Span::current(),
+                            )
+                        {
+                            pending_headers.insert(
+                                harn_vm::observability::otel::OTEL_PARENT_SPAN_ID_HEADER
+                                    .to_string(),
+                                parent_span_id,
+                            );
+                        }
+
+                        match context
+                            .event_log
+                            .append(
+                                &context.pending_topic,
+                                LogEvent::new("trigger_event", payload)
+                                    .with_headers(pending_headers),
+                            )
+                            .await
+                        {
+                            Ok(event_id) => {
+                                context.metrics.dispatched.fetch_add(1, Ordering::Relaxed);
+                                context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+                                (
+                                    StatusCode::OK,
+                                    axum::Json(json!({
+                                        "status": "accepted",
+                                        "event_id": event_id,
+                                        "trigger_id": context.route.trigger_id,
+                                    })),
+                                )
+                                    .into_response()
+                            }
+                            Err(error) => {
+                                context.metrics.failed.fetch_add(1, Ordering::Relaxed);
+                                context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+                                (
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                    format!(
+                                        "failed to append trigger event to pending log: {error}"
+                                    ),
+                                )
+                                    .into_response()
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        context.metrics.failed.fetch_add(1, Ordering::Relaxed);
+                        context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+                        HttpError::from_connector(error).into_response()
+                    }
+                }
+            }
+            Ok(NormalizedRequest::Immediate(response)) => {
+                context.metrics.dispatched.fetch_add(1, Ordering::Relaxed);
+                context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+                response
+            }
+            Err(error) => {
+                context.metrics.failed.fetch_add(1, Ordering::Relaxed);
+                context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+                error.into_response()
+            }
+        }
+    }
+    .instrument(span)
+    .await
+}
+
+async fn metrics_endpoint(
+    Extension(metrics): Extension<Arc<harn_vm::MetricsRegistry>>,
+) -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        metrics.render_prometheus(),
+    )
 }
 
 async fn authorize_request(
@@ -510,6 +564,7 @@ async fn normalize_request(
     normalized_headers: &BTreeMap<String, String>,
     query: &BTreeMap<String, String>,
     body: &[u8],
+    trace_id: harn_vm::TraceId,
 ) -> Result<NormalizedRequest, HttpError> {
     let received_at = OffsetDateTime::now_utc();
     if let Some(connector) = context.route.connector.as_ref() {
@@ -521,7 +576,7 @@ async fn normalize_request(
             "binding_version": context.route.binding_version,
             "path": context.route.path,
         });
-        let event = connector
+        let mut event = connector
             .lock()
             .await
             .normalize_inbound(raw)
@@ -536,6 +591,7 @@ async fn normalize_request(
                     .into_response(),
             ));
         }
+        event.trace_id = trace_id.clone();
         return Ok(NormalizedRequest::Event(Box::new(event)));
     }
 
@@ -596,7 +652,7 @@ async fn normalize_request(
         received_at,
         occurred_at: infer_occurred_at(&provider_payload),
         dedupe_key,
-        trace_id: harn_vm::TraceId::new(),
+        trace_id,
         tenant_id: None,
         headers: harn_vm::redact_headers(
             normalized_headers,

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -1370,6 +1370,7 @@ mod tests {
             }),
             allowed_origins: OriginAllowList::wildcard(),
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
             routes: vec![webhook_route("/hooks/github")],
         })
         .await
@@ -1428,6 +1429,7 @@ mod tests {
             }),
             allowed_origins: OriginAllowList::wildcard(),
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
             routes: vec![webhook_route("/hooks/github")],
         })
         .await

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -1258,6 +1258,7 @@ mod tests {
             )),
             allowed_origins: OriginAllowList::wildcard(),
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
             routes: vec![route("/a2a/v1", 1)],
         })
         .await

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -37,6 +37,9 @@ pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
 }
 
 async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
+    let _observability =
+        harn_vm::observability::otel::ObservabilityGuard::install_orchestrator_subscriber_from_env(
+        )?;
     harn_vm::reset_thread_local_state();
     let shutdown_timeout = Duration::from_secs(args.shutdown_timeout.max(1));
 
@@ -138,7 +141,12 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
         format_activation_summary(&connector_runtime.activations)
     );
 
-    let dispatcher = harn_vm::Dispatcher::with_event_log(vm, event_log.clone());
+    let metrics_registry = Arc::new(harn_vm::MetricsRegistry::default());
+    let dispatcher = harn_vm::Dispatcher::with_event_log_and_metrics(
+        vm,
+        event_log.clone(),
+        Some(metrics_registry.clone()),
+    );
     let pending_pump = spawn_pending_pump(event_log.clone(), dispatcher.clone())?;
     let cron_pump = spawn_cron_pump(event_log.clone(), dispatcher.clone())?;
     let inbox_pump = spawn_inbox_pump(event_log.clone(), dispatcher.clone())?;
@@ -152,6 +160,7 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
         max_body_bytes: ListenerConfig::max_body_bytes_or_default(
             manifest.orchestrator.max_body_bytes,
         ),
+        metrics_registry: metrics_registry.clone(),
         routes: route_configs,
     })
     .await?;

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -368,7 +368,7 @@ pub fn on_issue(event: TriggerEvent) {
     wait_for_exit(&mut child);
     let stderr = handle.join().expect("stderr collector thread");
 
-    assert!(stderr.contains("secret providers:"), "stderr={stderr}");
+    assert!(stderr.contains("secret providers"), "stderr={stderr}");
     assert!(
         stderr.contains("registered triggers (1):"),
         "stderr={stderr}"

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -29,6 +29,7 @@ use sha2::Sha256;
 use tempfile::TempDir;
 use time::OffsetDateTime;
 use tokio::net::TcpListener;
+use tokio::sync::oneshot;
 
 const STARTUP_PREFIX: &str = "[harn] HTTP listener ready on ";
 const STARTUP_NEEDLE: &str = "HTTP listener ready";
@@ -244,13 +245,19 @@ impl OrchestratorProcess {
                     }
                 }
                 Err(mpsc::RecvTimeoutError::Disconnected) => {
-                    let stderr = self.join_stderr();
+                    let stderr = self.shutdown_and_join_stderr();
                     panic!("stderr stream closed before listener became ready\nstderr={stderr}");
                 }
             }
         }
-        let stderr = self.join_stderr();
+        let stderr = self.shutdown_and_join_stderr();
         panic!("timed out waiting for listener startup\nstderr={stderr}");
+    }
+
+    fn shutdown_and_join_stderr(&mut self) -> String {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        self.join_stderr()
     }
 
     fn join_stderr(&mut self) -> String {
@@ -298,6 +305,17 @@ fn wait_for_exit(child: &mut Child) {
             return;
         }
         thread::sleep(Duration::from_millis(100));
+    }
+    panic!("timed out waiting for orchestrator exit");
+}
+
+async fn wait_for_exit_async(child: &mut Child) -> std::process::ExitStatus {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if let Some(status) = child.try_wait().unwrap() {
+            return status;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
     }
     panic!("timed out waiting for orchestrator exit");
 }
@@ -386,7 +404,7 @@ fn wait_for_path(path: &Path, timeout: Duration) {
 #[derive(Clone, Debug)]
 struct OtlpRequest {
     headers: Vec<(String, String)>,
-    body: JsonValue,
+    body: Vec<u8>,
 }
 
 #[derive(Clone)]
@@ -397,28 +415,44 @@ struct MockOtelCollectorState {
 struct MockOtelCollector {
     url: String,
     requests: Arc<Mutex<Vec<OtlpRequest>>>,
-    task: tokio::task::JoinHandle<()>,
+    shutdown: Option<oneshot::Sender<()>>,
+    thread: Option<thread::JoinHandle<()>>,
 }
 
 impl MockOtelCollector {
-    async fn start() -> Self {
+    fn start() -> Self {
         let requests = Arc::new(Mutex::new(Vec::new()));
         let state = MockOtelCollectorState {
             requests: requests.clone(),
         };
-        let app = Router::new()
-            .route("/v1/traces", post(record_otlp_traces))
-            .with_state(state);
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let task = tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
+        let (url_tx, url_rx) = mpsc::channel();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let thread = thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            runtime.block_on(async move {
+                let app = Router::new()
+                    .route("/v1/traces", post(record_otlp_traces))
+                    .with_state(state);
+                let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let addr = listener.local_addr().unwrap();
+                url_tx.send(format!("http://{addr}")).unwrap();
+                axum::serve(listener, app)
+                    .with_graceful_shutdown(async {
+                        let _ = shutdown_rx.await;
+                    })
+                    .await
+                    .unwrap();
+            });
         });
 
         Self {
-            url: format!("http://{addr}"),
+            url: url_rx.recv().unwrap(),
             requests,
-            task,
+            shutdown: Some(shutdown_tx),
+            thread: Some(thread),
         }
     }
 
@@ -426,14 +460,23 @@ impl MockOtelCollector {
         let requests = self.requests.lock().unwrap().clone();
         requests
             .into_iter()
-            .flat_map(|request| collect_spans_from_body(&request.body))
+            .flat_map(|request| {
+                serde_json::from_slice::<JsonValue>(&request.body)
+                    .map(|body| collect_spans_from_body(&body))
+                    .unwrap_or_default()
+            })
             .collect()
     }
 }
 
 impl Drop for MockOtelCollector {
     fn drop(&mut self) {
-        self.task.abort();
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
     }
 }
 
@@ -451,7 +494,6 @@ async fn record_otlp_traces(
     headers: HeaderMap,
     body: Bytes,
 ) -> StatusCode {
-    let json: JsonValue = serde_json::from_slice(&body).unwrap();
     let captured_headers = headers
         .iter()
         .filter_map(|(name, value)| {
@@ -463,7 +505,7 @@ async fn record_otlp_traces(
         .collect::<Vec<_>>();
     state.requests.lock().unwrap().push(OtlpRequest {
         headers: captured_headers,
-        body: json,
+        body: body.to_vec(),
     });
     StatusCode::OK
 }
@@ -582,7 +624,7 @@ async fn github_webhook_delivery_is_accepted_and_persisted() {
     assert_status(response, StatusCode::OK).await;
 
     send_sigterm(&process.child);
-    let status = process.child.wait().unwrap();
+    let status = wait_for_exit_async(&mut process.child).await;
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
@@ -761,7 +803,7 @@ async fn a2a_push_route_requires_bearer_or_valid_hmac() {
     assert_status(response, StatusCode::OK).await;
 
     send_sigterm(&process.child);
-    let status = process.child.wait().unwrap();
+    let status = wait_for_exit_async(&mut process.child).await;
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
@@ -933,14 +975,14 @@ async fn graceful_shutdown_waits_for_in_flight_request() {
     assert!(snapshot.contains("\"in_flight\": 0"), "snapshot={snapshot}");
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
     let _lock = lock_orchestrator_tests();
     let temp = TempDir::new().unwrap();
     write_file(temp.path(), "harn.toml", &base_manifest(None));
     write_file(temp.path(), "lib.harn", handler_module());
 
-    let collector = MockOtelCollector::start().await;
+    let collector = MockOtelCollector::start();
     let secret = "otel-secret";
     let envs = [
         ("HARN_SECRET_PROVIDERS", "env"),
@@ -956,17 +998,18 @@ async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
     let base_url = process.wait_for_listener_url();
 
     let body = br#"{"action":"opened","issue":{"number":5}}"#;
-    let response = reqwest::Client::new()
+    let client = reqwest::Client::new();
+    let request = client
         .post(format!("{base_url}/triggers/github-new-issue"))
         .headers(github_headers(secret, body, None))
         .body(body.to_vec())
-        .send()
-        .await
+        .build()
         .unwrap();
+    let response = client.execute(request).await.unwrap();
     assert_status(response, StatusCode::OK).await;
 
     send_sigterm(&process.child);
-    let status = process.child.wait().unwrap();
+    let status = wait_for_exit_async(&mut process.child).await;
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
@@ -979,10 +1022,16 @@ async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
         if has_ingest && has_dispatch {
             break spans;
         }
-        assert!(
-            Instant::now() < deadline,
-            "timed out waiting for OTel spans"
-        );
+        if Instant::now() >= deadline {
+            let requests = collector.requests.lock().unwrap().clone();
+            panic!(
+                "timed out waiting for OTel spans\ncollector_headers={:#?}",
+                requests
+                    .iter()
+                    .map(|request| request.headers.clone())
+                    .collect::<Vec<_>>()
+            );
+        }
         tokio::time::sleep(Duration::from_millis(100)).await;
     };
 

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -11,20 +11,27 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc::{self, Receiver};
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::routing::post;
+use axum::Router;
 use hmac::{Hmac, Mac};
 use rcgen::generate_simple_self_signed;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, ORIGIN};
 use reqwest::Certificate;
 use reqwest::StatusCode;
+use serde_json::Value as JsonValue;
 use sha2::Sha256;
 use tempfile::TempDir;
 use time::OffsetDateTime;
+use tokio::net::TcpListener;
 
 const STARTUP_PREFIX: &str = "[harn] HTTP listener ready on ";
+const STARTUP_NEEDLE: &str = "HTTP listener ready";
 const SHUTDOWN_NEEDLE: &str = "graceful shutdown complete";
 
 type HmacSha256 = Hmac<Sha256>;
@@ -222,13 +229,10 @@ impl OrchestratorProcess {
         let deadline = Instant::now() + Duration::from_secs(30);
         while Instant::now() < deadline {
             match self.rx.recv_timeout(Duration::from_millis(100)) {
-                Ok(line) if line.contains(STARTUP_PREFIX) => {
-                    return line
-                        .split(STARTUP_PREFIX)
-                        .nth(1)
-                        .expect("startup line has URL")
-                        .trim()
-                        .to_string();
+                Ok(line) if line.contains(STARTUP_NEEDLE) => {
+                    if let Some(url) = listener_url_from_line(&line) {
+                        return url;
+                    }
                 }
                 Ok(_) => continue,
                 Err(mpsc::RecvTimeoutError::Timeout) => {
@@ -256,6 +260,25 @@ impl OrchestratorProcess {
             .join()
             .expect("stderr collector result")
     }
+}
+
+fn listener_url_from_line(line: &str) -> Option<String> {
+    if let Some(url) = line.split(STARTUP_PREFIX).nth(1) {
+        return url
+            .split_whitespace()
+            .next()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string);
+    }
+    let field = "listener_url=";
+    let start = line.find(field)? + field.len();
+    let url = line[start..]
+        .split_whitespace()
+        .next()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    Some(url.to_string())
 }
 
 fn send_sigterm(child: &Child) {
@@ -360,6 +383,176 @@ fn wait_for_path(path: &Path, timeout: Duration) {
     panic!("timed out waiting for {}", path.display());
 }
 
+#[derive(Clone, Debug)]
+struct OtlpRequest {
+    headers: Vec<(String, String)>,
+    body: JsonValue,
+}
+
+#[derive(Clone)]
+struct MockOtelCollectorState {
+    requests: Arc<Mutex<Vec<OtlpRequest>>>,
+}
+
+struct MockOtelCollector {
+    url: String,
+    requests: Arc<Mutex<Vec<OtlpRequest>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl MockOtelCollector {
+    async fn start() -> Self {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let state = MockOtelCollectorState {
+            requests: requests.clone(),
+        };
+        let app = Router::new()
+            .route("/v1/traces", post(record_otlp_traces))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        Self {
+            url: format!("http://{addr}"),
+            requests,
+            task,
+        }
+    }
+
+    fn collected_spans(&self) -> Vec<CollectedSpan> {
+        let requests = self.requests.lock().unwrap().clone();
+        requests
+            .into_iter()
+            .flat_map(|request| collect_spans_from_body(&request.body))
+            .collect()
+    }
+}
+
+impl Drop for MockOtelCollector {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+#[derive(Debug)]
+struct CollectedSpan {
+    name: String,
+    trace_id: String,
+    span_id: String,
+    parent_span_id: Option<String>,
+    attributes: Vec<(String, JsonValue)>,
+}
+
+async fn record_otlp_traces(
+    State(state): State<MockOtelCollectorState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> StatusCode {
+    let json: JsonValue = serde_json::from_slice(&body).unwrap();
+    let captured_headers = headers
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+        })
+        .collect::<Vec<_>>();
+    state.requests.lock().unwrap().push(OtlpRequest {
+        headers: captured_headers,
+        body: json,
+    });
+    StatusCode::OK
+}
+
+fn collect_spans_from_body(body: &JsonValue) -> Vec<CollectedSpan> {
+    let mut spans = Vec::new();
+    let Some(resource_spans) = body.get("resourceSpans").and_then(JsonValue::as_array) else {
+        return spans;
+    };
+
+    for resource_span in resource_spans {
+        let Some(scope_spans) = resource_span
+            .get("scopeSpans")
+            .and_then(JsonValue::as_array)
+        else {
+            continue;
+        };
+        for scope_span in scope_spans {
+            let Some(otel_spans) = scope_span.get("spans").and_then(JsonValue::as_array) else {
+                continue;
+            };
+            for span in otel_spans {
+                spans.push(CollectedSpan {
+                    name: span
+                        .get("name")
+                        .and_then(JsonValue::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    trace_id: span
+                        .get("traceId")
+                        .and_then(JsonValue::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    span_id: span
+                        .get("spanId")
+                        .and_then(JsonValue::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    parent_span_id: span
+                        .get("parentSpanId")
+                        .and_then(JsonValue::as_str)
+                        .map(ToString::to_string)
+                        .filter(|value| !value.is_empty()),
+                    attributes: span
+                        .get("attributes")
+                        .and_then(JsonValue::as_array)
+                        .map(|attributes| {
+                            attributes
+                                .iter()
+                                .filter_map(|attribute| {
+                                    Some((
+                                        attribute.get("key")?.as_str()?.to_string(),
+                                        attribute.get("value")?.clone(),
+                                    ))
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default(),
+                });
+            }
+        }
+    }
+
+    spans
+}
+
+fn attribute_string(span: &CollectedSpan, key: &str) -> Option<String> {
+    span.attributes
+        .iter()
+        .find(|(name, _)| name == key)
+        .and_then(|(_, value)| {
+            value
+                .get("stringValue")
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string)
+                .or_else(|| {
+                    value
+                        .get("intValue")
+                        .map(|value| {
+                            value
+                                .as_str()
+                                .map(ToString::to_string)
+                                .or_else(|| value.as_i64().map(|value| value.to_string()))
+                        })
+                        .and_then(|value| value)
+                })
+        })
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn github_webhook_delivery_is_accepted_and_persisted() {
     let _lock = lock_orchestrator_tests();
@@ -389,8 +582,9 @@ async fn github_webhook_delivery_is_accepted_and_persisted() {
     assert_status(response, StatusCode::OK).await;
 
     send_sigterm(&process.child);
-    wait_for_exit(&mut process.child);
+    let status = process.child.wait().unwrap();
     let stderr = process.join_stderr();
+    assert!(status.success(), "status={status} stderr={stderr}");
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
 
     let snapshot = state_snapshot(&temp);
@@ -567,8 +761,9 @@ async fn a2a_push_route_requires_bearer_or_valid_hmac() {
     assert_status(response, StatusCode::OK).await;
 
     send_sigterm(&process.child);
-    wait_for_exit(&mut process.child);
+    let status = process.child.wait().unwrap();
     let stderr = process.join_stderr();
+    assert!(status.success(), "status={status} stderr={stderr}");
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
 
     let snapshot = state_snapshot(&temp);
@@ -618,8 +813,9 @@ async fn tls_listener_serves_https_with_supplied_cert_and_key() {
     assert_status(response, StatusCode::OK).await;
 
     send_sigterm(&process.child);
-    wait_for_exit(&mut process.child);
+    let status = process.child.wait().unwrap();
     let stderr = process.join_stderr();
+    assert!(status.success(), "status={status} stderr={stderr}");
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
 }
 
@@ -735,4 +931,98 @@ async fn graceful_shutdown_waits_for_in_flight_request() {
         "snapshot={snapshot}"
     );
     assert!(snapshot.contains("\"in_flight\": 0"), "snapshot={snapshot}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
+    let _lock = lock_orchestrator_tests();
+    let temp = TempDir::new().unwrap();
+    write_file(temp.path(), "harn.toml", &base_manifest(None));
+    write_file(temp.path(), "lib.harn", handler_module());
+
+    let collector = MockOtelCollector::start().await;
+    let secret = "otel-secret";
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_SECRET_GITHUB_WEBHOOK_SECRET", secret),
+        ("HARN_OTEL_ENDPOINT", collector.url.as_str()),
+        ("HARN_OTEL_SERVICE_NAME", "harn-orchestrator-test"),
+        (
+            "HARN_OTEL_HEADERS",
+            "authorization=Bearer otel-token,x-tenant-id=tenant-abc",
+        ),
+    ];
+    let mut process = spawn_orchestrator(&temp, &[], &envs);
+    let base_url = process.wait_for_listener_url();
+
+    let body = br#"{"action":"opened","issue":{"number":5}}"#;
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/triggers/github-new-issue"))
+        .headers(github_headers(secret, body, None))
+        .body(body.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_status(response, StatusCode::OK).await;
+
+    send_sigterm(&process.child);
+    let status = process.child.wait().unwrap();
+    let stderr = process.join_stderr();
+    assert!(status.success(), "status={status} stderr={stderr}");
+    assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let spans = loop {
+        let spans = collector.collected_spans();
+        let has_ingest = spans.iter().any(|span| span.name == "ingest");
+        let has_dispatch = spans.iter().any(|span| span.name == "dispatch");
+        if has_ingest && has_dispatch {
+            break spans;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for OTel spans"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+
+    let ingest = spans.iter().find(|span| span.name == "ingest").unwrap();
+    let dispatch = spans.iter().find(|span| span.name == "dispatch").unwrap();
+    assert_eq!(ingest.trace_id, dispatch.trace_id);
+    assert_eq!(
+        dispatch.parent_span_id.as_deref(),
+        Some(ingest.span_id.as_str())
+    );
+
+    let ingest_trace_id = attribute_string(ingest, "trace_id").unwrap();
+    let dispatch_trace_id = attribute_string(dispatch, "trace_id").unwrap();
+    assert_eq!(ingest_trace_id, dispatch_trace_id);
+    assert_eq!(
+        attribute_string(dispatch, "result.status").as_deref(),
+        Some("succeeded")
+    );
+    assert!(
+        attribute_string(dispatch, "result.duration_ms").is_some(),
+        "dispatch span was missing duration attribute: {dispatch:?}"
+    );
+
+    let requests = collector.requests.lock().unwrap().clone();
+    assert!(
+        requests.iter().any(|request| {
+            request
+                .headers
+                .iter()
+                .any(|(name, value)| name == "authorization" && value == "Bearer otel-token")
+        }),
+        "collector never saw Authorization header: {requests:?}"
+    );
+    assert!(
+        requests.iter().any(|request| {
+            request
+                .headers
+                .iter()
+                .any(|(name, value)| name == "x-tenant-id" && value == "tenant-abc")
+        }),
+        "collector never saw tenant header: {requests:?}"
+    );
 }

--- a/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
+++ b/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
@@ -178,7 +178,7 @@ async fn restart_after_emit_does_not_duplicate_cron_dispatch() {
         .clone();
 
     let (mut second_child, second_rx, second_handle) = spawn_orchestrator(&temp, &[]);
-    wait_for_log_line(&mut second_child, &second_rx, "HTTP listener ready on");
+    wait_for_log_line(&mut second_child, &second_rx, STARTUP_NEEDLE);
     thread::sleep(Duration::from_secs(3));
     send_sigterm(&second_child);
     wait_for_successful_exit(&mut second_child);

--- a/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
+++ b/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
@@ -164,7 +164,7 @@ async fn restart_after_emit_does_not_duplicate_cron_dispatch() {
 
     let (mut crashing_child, crashing_rx, crashing_handle) =
         spawn_orchestrator(&temp, &[("HARN_TEST_CRON_FAIL_AFTER_EMIT", "1")]);
-    wait_for_log_line(&mut crashing_child, &crashing_rx, STARTUP_NEEDLE);
+    drop(crashing_rx);
     wait_for_exit_code(&mut crashing_child, 86);
     let crashing_stderr = crashing_handle.join().expect("stderr collector thread");
     assert!(crashing_stderr.contains("registered connectors (1): cron"));
@@ -178,7 +178,7 @@ async fn restart_after_emit_does_not_duplicate_cron_dispatch() {
         .clone();
 
     let (mut second_child, second_rx, second_handle) = spawn_orchestrator(&temp, &[]);
-    wait_for_log_line(&mut second_child, &second_rx, STARTUP_NEEDLE);
+    wait_for_log_line(&mut second_child, &second_rx, "HTTP listener ready on");
     thread::sleep(Duration::from_secs(3));
     send_sigterm(&second_child);
     wait_for_successful_exit(&mut second_child);

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -8,7 +8,12 @@ description = "Async bytecode virtual machine for the Harn programming language"
 
 [features]
 default = []
-otel = ["opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp"]
+otel = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:tracing-opentelemetry",
+]
 
 [dependencies]
 harn-lexer = { path = "../harn-lexer", version = "0.7" }
@@ -42,9 +47,12 @@ httpdate = "1"
 ignore = "0.4"
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "registry"] }
 opentelemetry = { version = "0.31", optional = true }
 opentelemetry_sdk = { version = "0.31", optional = true, features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.31", optional = true }
+opentelemetry-otlp = { version = "0.31", default-features = false, features = ["http-json", "reqwest-rustls"], optional = true }
+tracing-opentelemetry = { version = "0.32", optional = true }
 zeroize = "1"
 
 [dev-dependencies]

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -50,7 +50,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "registry"] }
 opentelemetry = { version = "0.31", optional = true }
-opentelemetry_sdk = { version = "0.31", optional = true, features = ["rt-tokio"] }
+opentelemetry_sdk = { version = "0.31", optional = true, features = ["rt-tokio", "experimental_trace_batch_span_processor_with_async_runtime"] }
 opentelemetry-otlp = { version = "0.31", default-features = false, features = ["http-json", "reqwest-rustls"], optional = true }
 tracing-opentelemetry = { version = "0.32", optional = true }
 zeroize = "1"

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -253,6 +253,9 @@ pub struct ConnectorMetricsSnapshot {
     pub inbox_durable_hits: u64,
     pub inbox_expired_entries: u64,
     pub inbox_active_entries: u64,
+    pub dispatch_succeeded_total: u64,
+    pub dispatch_failed_total: u64,
+    pub retry_scheduled_total: u64,
 }
 
 /// Shared metrics surface for connector-local counters and timings.
@@ -264,6 +267,9 @@ pub struct MetricsRegistry {
     inbox_durable_hits: AtomicU64,
     inbox_expired_entries: AtomicU64,
     inbox_active_entries: AtomicU64,
+    dispatch_succeeded_total: AtomicU64,
+    dispatch_failed_total: AtomicU64,
+    retry_scheduled_total: AtomicU64,
 }
 
 impl MetricsRegistry {
@@ -275,6 +281,9 @@ impl MetricsRegistry {
             inbox_durable_hits: self.inbox_durable_hits.load(Ordering::Relaxed),
             inbox_expired_entries: self.inbox_expired_entries.load(Ordering::Relaxed),
             inbox_active_entries: self.inbox_active_entries.load(Ordering::Relaxed),
+            dispatch_succeeded_total: self.dispatch_succeeded_total.load(Ordering::Relaxed),
+            dispatch_failed_total: self.dispatch_failed_total.load(Ordering::Relaxed),
+            retry_scheduled_total: self.retry_scheduled_total.load(Ordering::Relaxed),
         }
     }
 
@@ -304,6 +313,44 @@ impl MetricsRegistry {
     pub(crate) fn set_inbox_active_entries(&self, count: usize) {
         self.inbox_active_entries
             .store(count as u64, Ordering::Relaxed);
+    }
+
+    pub fn record_dispatch_succeeded(&self) {
+        self.dispatch_succeeded_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_dispatch_failed(&self) {
+        self.dispatch_failed_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_retry_scheduled(&self) {
+        self.retry_scheduled_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn render_prometheus(&self) -> String {
+        let snapshot = self.snapshot();
+        let counters = [
+            (
+                "dispatch_succeeded_total",
+                snapshot.dispatch_succeeded_total,
+            ),
+            ("dispatch_failed_total", snapshot.dispatch_failed_total),
+            ("inbox_duplicates_total", snapshot.inbox_duplicates_rejected),
+            ("retry_scheduled_total", snapshot.retry_scheduled_total),
+        ];
+
+        let mut rendered = String::new();
+        for (name, value) in counters {
+            rendered.push_str("# TYPE ");
+            rendered.push_str(name);
+            rendered.push_str(" counter\n");
+            rendered.push_str(name);
+            rendered.push(' ');
+            rendered.push_str(&value.to_string());
+            rendered.push('\n');
+        }
+        rendered
     }
 }
 

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -19,6 +19,7 @@ pub mod mcp_card;
 pub mod mcp_registry;
 pub mod mcp_server;
 pub mod metadata;
+pub mod observability;
 pub mod orchestration;
 pub mod runtime_paths;
 pub mod schema;

--- a/crates/harn-vm/src/observability/mod.rs
+++ b/crates/harn-vm/src/observability/mod.rs
@@ -1,0 +1,1 @@
+pub mod otel;

--- a/crates/harn-vm/src/observability/otel.rs
+++ b/crates/harn-vm/src/observability/otel.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 #[cfg(feature = "otel")]
 use sha2::{Digest, Sha256};
 use tracing::level_filters::LevelFilter;
+use tracing_subscriber::filter::filter_fn;
 use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::Layer as _;
 
 use crate::TraceId;
 
@@ -32,7 +34,11 @@ impl ObservabilityGuard {
                 use opentelemetry::trace::TracerProvider as _;
 
                 let tracer = provider.tracer("harn.orchestrator");
-                let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+                let telemetry = tracing_opentelemetry::layer()
+                    .with_tracer(tracer)
+                    .with_filter(filter_fn(|metadata| {
+                        metadata.is_span() && metadata.target().starts_with("harn")
+                    }));
                 let subscriber = tracing_subscriber::registry()
                     .with(LevelFilter::INFO)
                     .with(fmt_layer())
@@ -144,6 +150,8 @@ fn build_tracer_provider_from_env(
 ) -> Result<Option<opentelemetry_sdk::trace::SdkTracerProvider>, String> {
     use opentelemetry::global;
     use opentelemetry_otlp::{Protocol, WithExportConfig as _, WithHttpConfig as _};
+    use opentelemetry_sdk::runtime;
+    use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
     use opentelemetry_sdk::Resource;
 
     let Some(raw_endpoint) = std::env::var("HARN_OTEL_ENDPOINT")
@@ -175,9 +183,10 @@ fn build_tracer_provider_from_env(
         .build()
         .map_err(|error| format!("failed to build OTel span exporter: {error}"))?;
 
+    let batch = BatchSpanProcessor::builder(exporter, runtime::Tokio).build();
     let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
         .with_resource(Resource::builder().with_service_name(service_name).build())
-        .with_simple_exporter(exporter)
+        .with_span_processor(batch)
         .build();
     global::set_tracer_provider(provider.clone());
     Ok(Some(provider))

--- a/crates/harn-vm/src/observability/otel.rs
+++ b/crates/harn-vm/src/observability/otel.rs
@@ -1,0 +1,299 @@
+#[cfg(feature = "otel")]
+use std::collections::HashMap;
+
+#[cfg(feature = "otel")]
+use sha2::{Digest, Sha256};
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::layer::SubscriberExt;
+
+use crate::TraceId;
+
+pub const OTEL_PARENT_SPAN_ID_HEADER: &str = "otel_parent_span_id";
+
+static OBSERVABILITY_INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+
+pub struct ObservabilityGuard {
+    #[cfg(feature = "otel")]
+    tracer_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+}
+
+impl ObservabilityGuard {
+    pub fn install_orchestrator_subscriber_from_env() -> Result<Self, String> {
+        if OBSERVABILITY_INIT.get().is_some() {
+            return Ok(Self {
+                #[cfg(feature = "otel")]
+                tracer_provider: None,
+            });
+        }
+
+        #[cfg(feature = "otel")]
+        {
+            if let Some(provider) = build_tracer_provider_from_env()? {
+                use opentelemetry::trace::TracerProvider as _;
+
+                let tracer = provider.tracer("harn.orchestrator");
+                let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+                let subscriber = tracing_subscriber::registry()
+                    .with(LevelFilter::INFO)
+                    .with(fmt_layer())
+                    .with(telemetry);
+                tracing::subscriber::set_global_default(subscriber).map_err(|error| {
+                    format!("failed to install global tracing subscriber: {error}")
+                })?;
+                let _ = OBSERVABILITY_INIT.set(());
+                return Ok(Self {
+                    tracer_provider: Some(provider),
+                });
+            }
+        }
+
+        #[cfg(not(feature = "otel"))]
+        if std::env::var("HARN_OTEL_ENDPOINT")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .is_some()
+        {
+            return Err(
+                "HARN_OTEL_ENDPOINT is set, but this build was compiled without the `otel` feature"
+                    .to_string(),
+            );
+        }
+
+        let subscriber = tracing_subscriber::registry()
+            .with(LevelFilter::INFO)
+            .with(fmt_layer());
+        tracing::subscriber::set_global_default(subscriber)
+            .map_err(|error| format!("failed to install global tracing subscriber: {error}"))?;
+        let _ = OBSERVABILITY_INIT.set(());
+        Ok(Self {
+            #[cfg(feature = "otel")]
+            tracer_provider: None,
+        })
+    }
+
+    pub fn shutdown(self) -> Result<(), String> {
+        #[cfg(feature = "otel")]
+        if let Some(provider) = self.tracer_provider {
+            provider
+                .force_flush()
+                .map_err(|error| format!("failed to flush OTel spans: {error}"))?;
+            provider
+                .shutdown()
+                .map_err(|error| format!("failed to shut down OTel tracer provider: {error}"))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "otel")]
+pub fn set_span_parent(
+    span: &tracing::Span,
+    trace_id: &TraceId,
+    parent_span_id: Option<&str>,
+) -> Result<(), String> {
+    use opentelemetry::trace::TraceContextExt as _;
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    let context = opentelemetry::Context::current()
+        .with_remote_span_context(span_context(trace_id, parent_span_id));
+    span.set_parent(context)
+        .map_err(|error| format!("failed to attach OTel parent context: {error}"))
+}
+
+#[cfg(not(feature = "otel"))]
+pub fn set_span_parent(
+    _span: &tracing::Span,
+    _trace_id: &TraceId,
+    _parent_span_id: Option<&str>,
+) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(feature = "otel")]
+pub fn current_span_id_hex(span: &tracing::Span) -> Option<String> {
+    use opentelemetry::trace::TraceContextExt as _;
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    let context = span.context();
+    let binding = context.span();
+    let span_context = binding.span_context();
+    span_context
+        .is_valid()
+        .then(|| span_context.span_id().to_string())
+}
+
+#[cfg(not(feature = "otel"))]
+pub fn current_span_id_hex(_span: &tracing::Span) -> Option<String> {
+    None
+}
+
+fn fmt_layer<S>() -> impl tracing_subscriber::Layer<S> + Send + Sync
+where
+    S: tracing::Subscriber,
+    for<'span> S: tracing_subscriber::registry::LookupSpan<'span>,
+{
+    tracing_subscriber::fmt::layer()
+        .with_target(false)
+        .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stderr()))
+        .with_writer(std::io::stderr)
+        .compact()
+}
+
+#[cfg(feature = "otel")]
+fn build_tracer_provider_from_env(
+) -> Result<Option<opentelemetry_sdk::trace::SdkTracerProvider>, String> {
+    use opentelemetry::global;
+    use opentelemetry_otlp::{Protocol, WithExportConfig as _, WithHttpConfig as _};
+    use opentelemetry_sdk::Resource;
+
+    let Some(raw_endpoint) = std::env::var("HARN_OTEL_ENDPOINT")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+
+    let endpoint = normalize_otlp_traces_endpoint(&raw_endpoint);
+    let service_name = std::env::var("HARN_OTEL_SERVICE_NAME")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "harn-orchestrator".to_string());
+    let headers = parse_headers(&std::env::var("HARN_OTEL_HEADERS").unwrap_or_default());
+
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_http_client(
+            reqwest::Client::builder()
+                .build()
+                .map_err(|error| format!("failed to build OTLP HTTP client: {error}"))?,
+        )
+        .with_protocol(Protocol::HttpJson)
+        .with_endpoint(endpoint)
+        .with_headers(headers)
+        .build()
+        .map_err(|error| format!("failed to build OTel span exporter: {error}"))?;
+
+    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_resource(Resource::builder().with_service_name(service_name).build())
+        .with_simple_exporter(exporter)
+        .build();
+    global::set_tracer_provider(provider.clone());
+    Ok(Some(provider))
+}
+
+#[cfg(feature = "otel")]
+fn span_context(
+    trace_id: &TraceId,
+    parent_span_id: Option<&str>,
+) -> opentelemetry::trace::SpanContext {
+    use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceState};
+
+    let trace_id = otel_trace_id(trace_id);
+    let span_id = parent_span_id
+        .and_then(|value| SpanId::from_hex(value).ok())
+        .filter(|value| *value != SpanId::INVALID)
+        .unwrap_or_else(|| hashed_span_id(trace_id.to_string().as_bytes()));
+
+    SpanContext::new(
+        trace_id,
+        span_id,
+        TraceFlags::SAMPLED,
+        true,
+        TraceState::default(),
+    )
+}
+
+#[cfg(feature = "otel")]
+fn otel_trace_id(trace_id: &TraceId) -> opentelemetry::trace::TraceId {
+    use opentelemetry::trace::TraceId as OtelTraceId;
+
+    let normalized = trace_id
+        .0
+        .strip_prefix("trace_")
+        .unwrap_or(trace_id.0.as_str())
+        .replace('-', "");
+    if let Ok(trace_id) = OtelTraceId::from_hex(&normalized) {
+        if trace_id != OtelTraceId::INVALID {
+            return trace_id;
+        }
+    }
+    hashed_trace_id(trace_id.0.as_bytes())
+}
+
+#[cfg(feature = "otel")]
+fn hashed_trace_id(input: &[u8]) -> opentelemetry::trace::TraceId {
+    let digest = Sha256::digest(input);
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    opentelemetry::trace::TraceId::from_bytes(bytes)
+}
+
+#[cfg(feature = "otel")]
+fn hashed_span_id(input: &[u8]) -> opentelemetry::trace::SpanId {
+    let digest = Sha256::digest(input);
+    let mut bytes = [0_u8; 8];
+    bytes.copy_from_slice(&digest[..8]);
+    if bytes.iter().all(|byte| *byte == 0) {
+        bytes[7] = 1;
+    }
+    opentelemetry::trace::SpanId::from_bytes(bytes)
+}
+
+#[cfg(feature = "otel")]
+fn normalize_otlp_traces_endpoint(endpoint: &str) -> String {
+    let trimmed = endpoint.trim_end_matches('/');
+    if trimmed.ends_with("/v1/traces") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}/v1/traces")
+    }
+}
+
+#[cfg(feature = "otel")]
+fn parse_headers(raw: &str) -> HashMap<String, String> {
+    raw.split([',', '\n', ';'])
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .filter_map(|segment| {
+            let (name, value) = segment
+                .split_once('=')
+                .or_else(|| segment.split_once(':'))?;
+            let name = name.trim();
+            let value = value.trim();
+            if name.is_empty() || value.is_empty() {
+                return None;
+            }
+            Some((name.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+#[cfg(all(test, feature = "otel"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_trace_endpoint_suffix() {
+        assert_eq!(
+            normalize_otlp_traces_endpoint("http://127.0.0.1:4318"),
+            "http://127.0.0.1:4318/v1/traces"
+        );
+        assert_eq!(
+            normalize_otlp_traces_endpoint("http://127.0.0.1:4318/v1/traces"),
+            "http://127.0.0.1:4318/v1/traces"
+        );
+    }
+
+    #[test]
+    fn parses_header_lists() {
+        let headers = parse_headers("authorization=Bearer token,x-tenant-id=tenant-123;trace=true");
+        assert_eq!(
+            headers.get("authorization"),
+            Some(&"Bearer token".to_string())
+        );
+        assert_eq!(headers.get("x-tenant-id"), Some(&"tenant-123".to_string()));
+        assert_eq!(headers.get("trace"), Some(&"true".to_string()));
+    }
+}

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -4,11 +4,14 @@ use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+#[cfg(feature = "otel")]
+use std::time::Instant;
 
 use futures::{pin_mut, StreamExt};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 use tokio::sync::Notify;
+use tracing::Instrument as _;
 
 use crate::event_log::{active_event_log, AnyEventLog, EventLog, LogError, LogEvent, Topic};
 use crate::llm::trigger_predicate::{start_predicate_evaluation, PredicateCacheEntry};
@@ -90,6 +93,7 @@ pub struct Dispatcher {
     event_log: Arc<AnyEventLog>,
     cancel_tx: broadcast::Sender<()>,
     state: Arc<DispatcherRuntimeState>,
+    metrics: Option<Arc<crate::MetricsRegistry>>,
 }
 
 #[derive(Debug)]
@@ -131,6 +135,18 @@ pub enum DispatchStatus {
     Dlq,
     Skipped,
     Cancelled,
+}
+
+impl DispatchStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Dlq => "dlq",
+            Self::Skipped => "skipped",
+            Self::Cancelled => "cancelled",
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -253,6 +269,14 @@ impl Dispatcher {
     }
 
     pub fn with_event_log(base_vm: Vm, event_log: Arc<AnyEventLog>) -> Self {
+        Self::with_event_log_and_metrics(base_vm, event_log, None)
+    }
+
+    pub fn with_event_log_and_metrics(
+        base_vm: Vm,
+        event_log: Arc<AnyEventLog>,
+        metrics: Option<Arc<crate::MetricsRegistry>>,
+    ) -> Self {
         let state = Arc::new(DispatcherRuntimeState::default());
         ACTIVE_DISPATCHER_STATE.with(|slot| {
             *slot.borrow_mut() = Some(state.clone());
@@ -263,6 +287,7 @@ impl Dispatcher {
             event_log,
             cancel_tx,
             state,
+            metrics,
         }
     }
 
@@ -409,7 +434,7 @@ impl Dispatcher {
             )
             .map_err(|error| DispatchError::Registry(error.to_string()))?;
             return Ok(vec![
-                self.dispatch_with_replay(&binding, envelope.event, None)
+                self.dispatch_with_replay(&binding, envelope.event, None, None)
                     .await?,
             ]);
         }
@@ -427,7 +452,7 @@ impl Dispatcher {
             )
             .map_err(|error| DispatchError::Registry(error.to_string()))?;
             return Ok(vec![
-                self.dispatch_with_replay(&binding, envelope.event, None)
+                self.dispatch_with_replay(&binding, envelope.event, None, None)
                     .await?,
             ]);
         }
@@ -452,7 +477,7 @@ impl Dispatcher {
         binding: &TriggerBinding,
         event: TriggerEvent,
     ) -> Result<DispatchOutcome, DispatchError> {
-        self.dispatch_with_replay(binding, event, None).await
+        self.dispatch_with_replay(binding, event, None, None).await
     }
 
     pub async fn dispatch_replay(
@@ -461,7 +486,17 @@ impl Dispatcher {
         event: TriggerEvent,
         replay_of_event_id: String,
     ) -> Result<DispatchOutcome, DispatchError> {
-        self.dispatch_with_replay(binding, event, Some(replay_of_event_id))
+        self.dispatch_with_replay(binding, event, Some(replay_of_event_id), None)
+            .await
+    }
+
+    pub async fn dispatch_with_parent_span_id(
+        &self,
+        binding: &TriggerBinding,
+        event: TriggerEvent,
+        parent_span_id: Option<String>,
+    ) -> Result<DispatchOutcome, DispatchError> {
+        self.dispatch_with_replay(binding, event, None, parent_span_id)
             .await
     }
 
@@ -470,13 +505,45 @@ impl Dispatcher {
         binding: &TriggerBinding,
         event: TriggerEvent,
         replay_of_event_id: Option<String>,
+        parent_span_id: Option<String>,
     ) -> Result<DispatchOutcome, DispatchError> {
-        ACTIVE_DISPATCH_IS_REPLAY
+        let span = tracing::info_span!(
+            "dispatch",
+            trigger_id = %binding.id.as_str(),
+            binding_version = binding.version,
+            trace_id = %event.trace_id.0
+        );
+        let _ = crate::observability::otel::set_span_parent(
+            &span,
+            &event.trace_id,
+            parent_span_id.as_deref(),
+        );
+        #[cfg(feature = "otel")]
+        let started_at = Instant::now();
+        let metrics = self.metrics.clone();
+        let outcome = ACTIVE_DISPATCH_IS_REPLAY
             .scope(
                 replay_of_event_id.is_some(),
-                self.dispatch_with_replay_inner(binding, event, replay_of_event_id),
+                self.dispatch_with_replay_inner(binding, event, replay_of_event_id)
+                    .instrument(span),
             )
-            .await
+            .await;
+        if let Some(metrics) = metrics.as_ref() {
+            match &outcome {
+                Ok(dispatch_outcome) => match dispatch_outcome.status {
+                    DispatchStatus::Succeeded | DispatchStatus::Skipped => {
+                        metrics.record_dispatch_succeeded();
+                    }
+                    _ => metrics.record_dispatch_failed(),
+                },
+                Err(_) => metrics.record_dispatch_failed(),
+            }
+        }
+        #[cfg(feature = "otel")]
+        {
+            let _ = started_at;
+        }
+        outcome
     }
 
     async fn dispatch_with_replay_inner(


### PR DESCRIPTION
## What changed

This wires OpenTelemetry tracing and Prometheus-style metrics through the orchestrator dispatch path so each dispatch keeps a stable end-to-end `trace_id` from inbound webhook ingestion through dispatcher execution.

It adds:
- OTLP exporter bootstrap from `HARN_OTEL_ENDPOINT`, `HARN_OTEL_SERVICE_NAME`, and `HARN_OTEL_HEADERS`
- inbound `ingest` spans in the listener and `dispatch` spans around handler execution
- dispatcher/result span attributes for status and duration
- structured `tracing::info!` logs in orchestrator serve output
- Prometheus-compatible counters on the existing listener via `GET /metrics`
- an integration test covering OTEL export with matching trace IDs across ingest and dispatch spans

## Why

Issue `harn#184` requires trace continuity across the orchestrator pipeline so webhook receipt, dispatch, and handler execution can be correlated in one trace, while also exposing dispatch and dedupe counters through the existing listener.

## Notes

A follow-up fix on this branch stabilizes the new OTEL integration path by:
- exporting only Harn spans instead of third-party library spans
- using the Tokio-backed batch span processor so request handling is not blocked by synchronous OTLP export
- hardening the orchestrator integration tests around startup/shutdown and OTEL collection

## Validation

- `cargo test -p harn-cli --test orchestrator_cli orchestrator_serve_starts_and_shuts_down_cleanly -- --nocapture`
- `cargo test -p harn-cli --test orchestrator_inbox_dedupe restart_after_emit_does_not_duplicate_cron_dispatch -- --nocapture`
- `cargo test -p harn-cli --test orchestrator_http -- --nocapture`
- `git push -u origin ksinder/otel-orchestrator-tracing-184` pre-push hook
  - `1582` tests passed
  - markdown lint passed
  - portal lint passed
