### PR TITLE
[codex] Fix conformance harn binary resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,48 @@ granular archaeology.
 
 ### Added
 
+- **`harn orchestrator {inspect, fire, replay, dlq, queue}` CLI
+  commands (#185).** Implemented the placeholder orchestrator
+  subcommands that used to error with `not implemented`. `inspect`
+  dumps the orchestrator state snapshot + trigger bindings, `fire`
+  enqueues a synthetic `TriggerEvent` for a given trigger id, `replay`
+  re-dispatches a historical event through the trigger dispatcher
+  (complementary to `harn trigger replay`, which works against a
+  standalone EventLog), `dlq` lists dead-letter entries, and `queue`
+  shows the pending-queue head. Orchestrator run fixtures cover each
+  command against a live `harn orchestrator serve`. Also stabilized
+  `orchestrator_inbox_dedupe` by awaiting `activated connectors:
+  cron(1)` instead of the HTTP listener ready line (closes harn#230
+  flake).
+
+- **Bridge-backed host tool discovery (#216).** Bridge sessions now
+  expose `host_tool_list()`, `host_tool_describe(name)`, and
+  `host_tool_call(name, args)` stdlib entry points plus matching
+  parser signatures. Harn programs running inside burin-code can
+  enumerate the host's editor tools, read their schemas, and invoke
+  them through the bridge without the host needing to pre-inject a
+  static catalog.
+
+- **`harn trigger replay <event-id>` CLI command (#222).** Added a
+  top-level replay CLI that works directly against an EventLog
+  snapshot without requiring an orchestrator to be running. Supports
+  `--diff` drift reporting (structured JSON comparing original vs.
+  replay result) and `--as-of <timestamp>` historical binding
+  resolution via trigger lifecycle history. Sets `HARN_REPLAY=1`
+  during replay dispatch so runtime nondeterminism (e.g. `uuid()`,
+  timestamps) can fall back to recorded values when handlers
+  cooperate. Complements the in-process `trigger_replay(...)` stdlib
+  and the orchestrator-scoped `harn orchestrator replay`.
+
+- **Hardened orchestrator shutdown drain (#183).** SIGTERM/SIGINT now
+  stops new HTTP traffic, drains pending/cron/inbox work, and waits
+  for in-flight dispatcher tasks up to a configurable deadline. Added
+  connector + event-log flush hooks so persisted connector boundaries
+  and durable event-log state land before exit, plus
+  `orchestrator.lifecycle` `draining` / `stopped` events with drain
+  counts. Extends orchestrator integration coverage for mid-dispatch
+  SIGTERM handling.
+
 - **Distroless multi-arch orchestrator container (#186).** Added a root
   `Dockerfile` for `harn orchestrator serve` with a Rust 1.95 builder,
   distroless `cc` runtime, non-root UID `10001`, and a Docker healthcheck

--- a/conformance/tests/_common.harn
+++ b/conformance/tests/_common.harn
@@ -1,0 +1,21 @@
+// Shared conformance helper for fixtures that exec the built `harn` binary.
+fn first_group(pattern, text) {
+  let matches = regex_captures(pattern, text)
+  if len(matches) == 0 {
+    return nil
+  }
+  return matches[0].groups[0]
+}
+
+pub fn resolve_harn_bin(repo_root) {
+  let cargo_config = path_join(repo_root, ".cargo/config.toml")
+  if file_exists(cargo_config) {
+    let config = exec("cat", cargo_config).stdout
+    let configured = first_group("(?m)^target-dir\\s*=\\s*\\\"([^\\\"]+)\\\"", config)
+    if configured {
+      return path_join(configured, "debug/harn")
+    }
+  }
+  let target_dir = env("CARGO_TARGET_DIR") ?? path_join(repo_root, "target")
+  return path_join(target_dir, "debug/harn")
+}

--- a/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
+++ b/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
@@ -1,3 +1,4 @@
+import "../_common"
 import "std/triggers"
 
 fn wait_for_log_line(log_path, needle) {
@@ -38,8 +39,7 @@ pipeline test(task) {
     "pipeline default(task) {\n  let envelope = json_parse(task)\n  println(json_stringify({trace_id: envelope.event.trace_id, target_agent: envelope.target_agent}))\n}\n",
   )
   let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
-  let target_dir = env("CARGO_TARGET_DIR") ?? path_join(repo_root, "target")
-  let harn_bin = path_join(target_dir, "debug/harn")
+  let harn_bin = resolve_harn_bin(repo_root)
   assert(file_exists(harn_bin), "missing built harn binary at " + harn_bin)
   let start = shell_at(
     root,

--- a/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
+++ b/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
@@ -1,5 +1,5 @@
-import "../_common"
 import "std/triggers"
+import "../_common"
 
 fn wait_for_log_line(log_path, needle) {
   var attempts = 0

--- a/conformance/tests/integration/orchestrator_auth_middleware.harn
+++ b/conformance/tests/integration/orchestrator_auth_middleware.harn
@@ -1,3 +1,5 @@
+import "../_common"
+
 fn wait_for_listener_url(log_path) {
   var attempts = 0
   var url = nil
@@ -42,8 +44,7 @@ pipeline test(task) {
     "import \"std/triggers\"\n\npub fn on_task(event: TriggerEvent) {\n  log(event.kind)\n}\n",
   )
   let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
-  let target_dir = env("CARGO_TARGET_DIR") ?? path_join(repo_root, "target")
-  let harn_bin = path_join(target_dir, "debug/harn")
+  let harn_bin = resolve_harn_bin(repo_root)
   assert(file_exists(harn_bin), "missing built harn binary at " + harn_bin)
   let start = shell_at(
     root,

--- a/conformance/tests/integration/orchestrator_hot_reload_modify_inflight.harn
+++ b/conformance/tests/integration/orchestrator_hot_reload_modify_inflight.harn
@@ -1,11 +1,12 @@
+import "../_common"
+
 pipeline default() {
   let unique = uuid()
   let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
-  let target_dir = env("CARGO_TARGET_DIR") ?? path_join(repo_root, "target")
   let base = path_join(temp_dir(), "harn-orchestrator-hot-reload-" + unique)
   let workspace = path_join(base, "workspace")
   let state_dir = path_join(base, "state")
-  let binary = env_or("HARN_CONFORMANCE_HARN_BIN", path_join(target_dir, "debug/harn"))
+  let binary = env_or("HARN_CONFORMANCE_HARN_BIN", resolve_harn_bin(repo_root))
   assert(file_exists(binary), "missing built harn binary at " + binary)
   let script = """
     set -eu

--- a/conformance/tests/stdlib/agent_state_resume_process.harn
+++ b/conformance/tests/stdlib/agent_state_resume_process.harn
@@ -1,3 +1,5 @@
+import "../_common"
+
 pipeline default() {
   let root = path_join(temp_dir(), "harn-agent-state-process-" + uuid())
   let script_dir = path_join(root, "scripts")
@@ -13,8 +15,7 @@ pipeline default() {
     "import \"std/agent_state\"\n\npipeline default() {\n  let root = argv[0]\n  let handle = agent_state_resume(root, \"resume-session\", nil)\n  println(agent_state_read(handle, \"plan.md\"))\n  let handoff = json_parse(agent_state_read(handle, agent_state_handoff_key()))\n  println(handoff.summary.status)\n  println(handoff.session_id)\n}\n",
   )
   let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
-  let target_dir = env("CARGO_TARGET_DIR") ?? path_join(repo_root, "target")
-  let harn_bin = path_join(target_dir, "debug/harn")
+  let harn_bin = resolve_harn_bin(repo_root)
   let first = exec(harn_bin, "run", writer, "--", root)
   println(first.success)
   println(first.stdout.contains("persisted plan"))


### PR DESCRIPTION
## Summary
- add `conformance/tests/_common.harn` with a shared `resolve_harn_bin(repo_root)` helper for conformance fixtures that exec the built `harn` binary
- switch the affected orchestrator/agent-state fixtures to use the shared helper so they honor `.cargo/config.toml` `target-dir` before falling back to `CARGO_TARGET_DIR` and then `target/debug/harn`
- preserve the existing `HARN_CONFORMANCE_HARN_BIN` override in `orchestrator_hot_reload_modify_inflight.harn`

## Root Cause
Several conformance fixtures resolved `harn` from `CARGO_TARGET_DIR ?? <repo>/target`, which misses the repo-local `.cargo/config.toml` `target-dir` used by the dev setup and worktree builds. That made those fixtures fail when the built binary lived under the configured temp target directory instead of `target/debug/harn`.

## Validation
- `cargo run --bin harn -- test conformance --filter orchestrator_auth_middleware`
- `cargo run --bin harn -- test conformance --filter orchestrator_hot_reload_modify_inflight`
- `cargo run --bin harn -- test conformance --filter orchestrator_a2a_dispatch_sync`
- `cargo run --bin harn -- test conformance --filter agent_state_resume_process`
- pre-push gate: `cargo nextest run`, markdown lint, portal lint

Fixes #247.
