### PR TITLE
[codex] fix trigger replay binding fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,8 +99,11 @@ granular archaeology.
   resolution via trigger lifecycle history. Sets `HARN_REPLAY=1`
   during replay dispatch so runtime nondeterminism (e.g. `uuid()`,
   timestamps) can fall back to recorded values when handlers
-  cooperate. Complements the in-process `trigger_replay(...)` stdlib
-  and the orchestrator-scoped `harn orchestrator replay`.
+  cooperate. Replay now also falls back automatically to the binding
+  active at the recorded event timestamp when the recorded binding
+  version is no longer resolvable. Complements the in-process
+  `trigger_replay(...)` stdlib and the orchestrator-scoped `harn
+  orchestrator replay`.
 
 - **Hardened orchestrator shutdown drain (#183).** SIGTERM/SIGINT now
   stops new HTTP traffic, drains pending/cron/inbox work, and waits

--- a/crates/harn-cli/src/commands/trigger/replay.rs
+++ b/crates/harn-cli/src/commands/trigger/replay.rs
@@ -195,13 +195,39 @@ fn resolve_binding(
         );
     }
 
-    harn_vm::resolve_live_trigger_binding(&recorded.binding_id, Some(recorded.binding_version))
-        .map_err(|error| {
-            format!(
-                "failed to resolve recorded binding '{}@v{}': {}",
-                recorded.binding_id, recorded.binding_version, error
+    match harn_vm::resolve_live_trigger_binding(
+        &recorded.binding_id,
+        Some(recorded.binding_version),
+    ) {
+        Ok(binding) => Ok(binding),
+        Err(harn_vm::TriggerRegistryError::UnknownBindingVersion { .. }) => {
+            let fallback_as_of = recorded.event.received_at;
+            harn_vm::events::log_warn(
+                "trigger.replay",
+                &format!(
+                    "recorded binding '{}@v{}' is unavailable; replay is falling back to the binding active at {}",
+                    recorded.binding_id,
+                    recorded.binding_version,
+                    format_timestamp(fallback_as_of)
+                ),
+            );
+            harn_vm::resolve_trigger_binding_as_of(&recorded.binding_id, fallback_as_of).map_err(
+                |error| {
+                    format!(
+                        "failed to resolve recorded binding '{}@v{}' or fall back to {}: {}",
+                        recorded.binding_id,
+                        recorded.binding_version,
+                        format_timestamp(fallback_as_of),
+                        error
+                    )
+                },
             )
-        })
+        }
+        Err(error) => Err(format!(
+            "failed to resolve recorded binding '{}@v{}': {}",
+            recorded.binding_id, recorded.binding_version, error
+        )),
+    }
 }
 
 async fn append_replay_record(
@@ -468,5 +494,197 @@ fn diff_outcomes(
     DriftReport {
         changed: !fields.is_empty(),
         fields,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::path::Path;
+    use std::rc::Rc;
+    use std::sync::Arc;
+
+    use harn_vm::event_log::{
+        install_default_for_base_dir, AnyEventLog, EventLog, LogEvent, Topic,
+    };
+    use harn_vm::events::{add_event_sink, clear_event_sinks, CollectorSink, EventLevel};
+    use harn_vm::triggers::event::{CronEventPayload, KnownProviderPayload};
+    use time::OffsetDateTime;
+
+    use super::{
+        append_replay_record, build_replay_vm, load_recorded_event, resolve_binding,
+        summarize_dispatch_outcome, TriggerEventRecord, TRIGGER_EVENTS_TOPIC,
+    };
+    use crate::package;
+
+    const TEST_TRIGGER_ID: &str = "replay-cron";
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn replay_falls_back_to_recorded_timestamp_when_version_lookup_is_stale() {
+        harn_vm::reset_thread_local_state();
+        let sink = Rc::new(CollectorSink::new());
+        clear_event_sinks();
+        add_event_sink(sink.clone());
+
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let workspace_root = tempdir.path();
+        let event_log = install_default_for_base_dir(workspace_root).expect("install event log");
+
+        install_local_manifest(workspace_root, "on_tick_v1");
+        install_workspace_manifest(workspace_root).await;
+        install_local_manifest(workspace_root, "on_tick_v2");
+        install_workspace_manifest(workspace_root).await;
+        install_local_manifest(workspace_root, "on_tick_v3");
+        install_workspace_manifest(workspace_root).await;
+
+        let current = harn_vm::resolve_live_trigger_binding(TEST_TRIGGER_ID, None)
+            .expect("resolve active binding");
+        assert_eq!(current.version, 3);
+        assert!(matches!(
+            harn_vm::resolve_live_trigger_binding(TEST_TRIGGER_ID, Some(1)),
+            Err(harn_vm::TriggerRegistryError::UnknownBindingVersion { .. })
+        ));
+
+        append_trigger_event(
+            &event_log,
+            TriggerEventRecord {
+                binding_id: TEST_TRIGGER_ID.to_string(),
+                binding_version: 1,
+                replay_of_event_id: None,
+                event: recorded_cron_event("evt-stale", OffsetDateTime::now_utc()),
+            },
+        )
+        .await;
+
+        let recorded = load_recorded_event(&event_log, "evt-stale")
+            .await
+            .expect("load recorded event");
+        let binding = resolve_binding(&recorded, None).expect("resolve fallback binding");
+        append_replay_record(&event_log, &binding, &recorded.event)
+            .await
+            .expect("append replay record");
+
+        let dispatcher =
+            harn_vm::Dispatcher::with_event_log(build_replay_vm(workspace_root), event_log.clone());
+        let outcome = dispatcher
+            .dispatch_replay(
+                &binding,
+                recorded.event.clone(),
+                recorded.event.id.0.clone(),
+            )
+            .await
+            .expect("dispatch replay succeeds");
+        let replay = summarize_dispatch_outcome(&outcome);
+        assert_eq!(replay.status, "succeeded");
+
+        let topic = Topic::new(TRIGGER_EVENTS_TOPIC).expect("valid trigger events topic");
+        let records: Vec<TriggerEventRecord> = event_log
+            .read_range(&topic, None, usize::MAX)
+            .await
+            .expect("read trigger events")
+            .into_iter()
+            .map(|(_, event)| serde_json::from_value(event.payload).expect("decode trigger event"))
+            .collect();
+
+        assert!(records.iter().any(|record| {
+            record.replay_of_event_id.as_deref() == Some("evt-stale")
+                && record.binding_id == TEST_TRIGGER_ID
+                && record.binding_version == 3
+        }));
+        assert!(sink.logs.borrow().iter().any(|log| {
+            log.level == EventLevel::Warn
+                && log.category == "trigger.replay"
+                && log
+                    .message
+                    .contains("falling back to the binding active at")
+        }));
+
+        harn_vm::reset_thread_local_state();
+    }
+
+    fn install_local_manifest(root: &Path, handler_name: &str) {
+        std::fs::create_dir_all(root.join(".git")).expect("create .git");
+        fs::write(
+            root.join("harn.toml"),
+            format!(
+                r#"
+[package]
+name = "workspace"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "{TEST_TRIGGER_ID}"
+kind = "cron"
+provider = "cron"
+match = {{ events = ["cron.tick"] }}
+schedule = "* * * * *"
+timezone = "UTC"
+handler = "handlers::{handler_name}"
+"#
+            ),
+        )
+        .expect("write manifest");
+        fs::write(
+            root.join("lib.harn"),
+            format!(
+                r#"
+import "std/triggers"
+
+pub fn {handler_name}(event: TriggerEvent) -> string {{
+  return event.kind
+}}
+"#
+            ),
+        )
+        .expect("write lib");
+        fs::write(root.join("main.harn"), "pipeline main() {}\n").expect("write main");
+    }
+
+    async fn install_workspace_manifest(root: &Path) {
+        let mut vm = super::build_replay_vm(root);
+        let extensions = package::load_runtime_extensions(&root.join("main.harn"));
+        package::install_manifest_triggers(&mut vm, &extensions)
+            .await
+            .expect("install manifest triggers");
+    }
+
+    fn recorded_cron_event(event_id: &str, received_at: OffsetDateTime) -> harn_vm::TriggerEvent {
+        harn_vm::TriggerEvent {
+            id: harn_vm::TriggerEventId(event_id.to_string()),
+            provider: harn_vm::ProviderId::from("cron"),
+            kind: "cron.tick".to_string(),
+            received_at,
+            occurred_at: None,
+            dedupe_key: format!("delivery-{event_id}"),
+            trace_id: harn_vm::TraceId(format!("trace-{event_id}")),
+            tenant_id: None,
+            headers: BTreeMap::new(),
+            provider_payload: harn_vm::ProviderPayload::Known(KnownProviderPayload::Cron(
+                CronEventPayload {
+                    cron_id: Some("test-cron".to_string()),
+                    schedule: Some("* * * * *".to_string()),
+                    tick_at: received_at,
+                    raw: serde_json::json!({ "event_id": event_id }),
+                },
+            )),
+            signature_status: harn_vm::SignatureStatus::Verified,
+        }
+    }
+
+    async fn append_trigger_event(event_log: &Arc<AnyEventLog>, record: TriggerEventRecord) {
+        let topic = Topic::new(TRIGGER_EVENTS_TOPIC).expect("valid trigger events topic");
+        event_log
+            .append(
+                &topic,
+                LogEvent::new(
+                    "trigger_event",
+                    serde_json::to_value(record).expect("encode trigger event"),
+                ),
+            )
+            .await
+            .expect("append trigger event");
     }
 }

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use serde::{Deserialize, Serialize};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use uuid::Uuid;
 
 use crate::event_log::{
@@ -11,9 +12,9 @@ use crate::triggers::dispatcher::DEFAULT_MAX_ATTEMPTS;
 use crate::triggers::test_util::{clock, run_trigger_harness_fixture};
 use crate::triggers::{
     dynamic_register, registered_provider_metadata, resolve_live_trigger_binding,
-    snapshot_trigger_bindings, RetryPolicy, TriggerBindingSnapshot, TriggerBindingSource,
-    TriggerBindingSpec, TriggerEvent, TriggerEventId, TriggerHandlerSpec, TriggerPredicateSpec,
-    TriggerRetryConfig,
+    resolve_trigger_binding_as_of, snapshot_trigger_bindings, RetryPolicy, TriggerBindingSnapshot,
+    TriggerBindingSource, TriggerBindingSpec, TriggerEvent, TriggerEventId, TriggerHandlerSpec,
+    TriggerPredicateSpec, TriggerRegistryError, TriggerRetryConfig,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
@@ -105,7 +106,7 @@ pub(crate) fn register_trigger_builtins(vm: &mut Vm) {
             .get(1)
             .ok_or_else(|| VmError::Runtime("trigger_fire: missing trigger event".to_string()))?;
         let event = parse_trigger_event(raw_event)?;
-        dispatch_trigger_event(binding_id, binding_version, event, None).await
+        dispatch_trigger_event(binding_id, binding_version, event, None, None).await
     });
 
     vm.register_async_builtin("trigger_replay", |args| async move {
@@ -159,9 +160,10 @@ async fn dispatch_trigger_event(
     binding_version: Option<u32>,
     event: TriggerEvent,
     replay_of_event_id: Option<String>,
+    replay_received_at: Option<OffsetDateTime>,
 ) -> Result<VmValue, VmError> {
     let log = ensure_trigger_event_log();
-    let binding = resolve_live_trigger_binding(&binding_id, binding_version)
+    let binding = resolve_dispatch_binding(&binding_id, binding_version, replay_received_at)
         .map_err(trigger_registry_error)?;
     let version = binding.version;
     let event_id = event.id.0.clone();
@@ -200,13 +202,48 @@ async fn dispatch_trigger_event(
 
 async fn replay_trigger_event(event_id: &str) -> Result<VmValue, VmError> {
     let record = find_recorded_event(event_id).await?;
+    let received_at = record.event.received_at;
     dispatch_trigger_event(
         record.binding_id,
         Some(record.binding_version),
         record.event,
         Some(event_id.to_string()),
+        Some(received_at),
     )
     .await
+}
+
+fn resolve_dispatch_binding(
+    binding_id: &str,
+    binding_version: Option<u32>,
+    replay_received_at: Option<OffsetDateTime>,
+) -> Result<std::sync::Arc<crate::triggers::registry::TriggerBinding>, TriggerRegistryError> {
+    match resolve_live_trigger_binding(binding_id, binding_version) {
+        Ok(binding) => Ok(binding),
+        Err(TriggerRegistryError::UnknownBindingVersion { version, .. }) => {
+            let Some(fallback_as_of) = replay_received_at else {
+                return Err(TriggerRegistryError::UnknownBindingVersion {
+                    id: binding_id.to_string(),
+                    version,
+                });
+            };
+            crate::events::log_warn(
+                "trigger.replay",
+                &format!(
+                    "recorded binding '{}@v{}' is unavailable; replay is falling back to the binding active at {}",
+                    binding_id,
+                    version,
+                    format_timestamp(fallback_as_of)
+                ),
+            );
+            resolve_trigger_binding_as_of(binding_id, fallback_as_of)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn format_timestamp(value: OffsetDateTime) -> String {
+    value.format(&Rfc3339).unwrap_or_else(|_| value.to_string())
 }
 
 async fn dispatch_binding_via_dispatcher(


### PR DESCRIPTION
## Summary
- fall back to `resolve_trigger_binding_as_of(recorded.event.received_at)` when replay cannot resolve the recorded binding version directly
- apply the same WARN-logged fallback in both `harn trigger replay` and the `trigger_replay(...)` stdlib path
- add replay regression coverage for multi-reload stale version lookups and document the fallback in the #222 changelog entry

## Root Cause
Replay only attempted `resolve_live_trigger_binding(id, Some(recorded.binding_version))`. Once a recorded version was no longer directly resolvable, replay aborted instead of retrying against the binding active when the event was originally received.

## Impact
Older replay records now keep working when the stored binding version is unavailable but trigger lifecycle history can still resolve the binding that was active at the recorded event timestamp.

## Validation
- `env CARGO_TARGET_DIR=/tmp/harn-4d34-target cargo test -p harn-cli replay_falls_back_to_recorded_timestamp_when_version_lookup_is_stale`
- `env CARGO_TARGET_DIR=/tmp/harn-4d34-target cargo test -p harn-cli --test trigger_replay_cli`
- repo pre-push hook (`cargo nextest`, markdownlint, portal lint)
