### PR TITLE
[codex] Split trigger inbox claim and envelope topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ granular archaeology.
 
 ### Changed
 
+- **Split trigger inbox envelopes from durable dedupe claims (#243).**
+  Dispatcher envelopes now append to `trigger.inbox.envelopes` while
+  `InboxIndex` persists TTL-bound claim records under
+  `trigger.inbox.claims`, which removes the steady-state startup scan
+  over all historical envelopes. Harn v0.7.23 soft-reads legacy
+  `trigger.inbox` records on startup so existing orchestrator event
+  logs keep working while new writes land only on the split topics.
+
 - **Primary Harn docs site moved from `harn.burincode.com` to
   `harnlang.com`.** The burin-code-subdomain was always a stopgap;
   `harnlang.com` reflects Harn's identity as a standalone programming

--- a/crates/harn-cli/src/commands/orchestrator/common.rs
+++ b/crates/harn-cli/src/commands/orchestrator/common.rs
@@ -13,14 +13,10 @@ use crate::package::{self, CollectedManifestTrigger, Manifest};
 use super::role::OrchestratorRole;
 
 pub(super) const STATE_SNAPSHOT_FILE: &str = "orchestrator-state.json";
-pub(super) const TRIGGER_INBOX_TOPIC: &str = "trigger.inbox";
-pub(super) const TRIGGER_OUTBOX_TOPIC: &str = "trigger.outbox";
-pub(super) const TRIGGER_ATTEMPTS_TOPIC: &str = "trigger.attempts";
-// Must match `harn_vm::triggers::dispatcher::TRIGGER_DLQ_TOPIC`. Previous
-// value "triggers.dlq" silently diverged and made `harn orchestrator dlq`
-// return zero results even when the dispatcher was actively writing DLQ
-// entries.
-pub(super) const TRIGGER_DLQ_TOPIC: &str = "trigger.dlq";
+pub(super) use harn_vm::{
+    TRIGGER_ATTEMPTS_TOPIC, TRIGGER_DLQ_TOPIC, TRIGGER_INBOX_CLAIMS_TOPIC,
+    TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC, TRIGGER_OUTBOX_TOPIC,
+};
 
 pub(super) struct LoadedOrchestratorContext {
     pub vm: harn_vm::Vm,

--- a/crates/harn-cli/src/commands/orchestrator/queue.rs
+++ b/crates/harn-cli/src/commands/orchestrator/queue.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use crate::cli::OrchestratorQueueArgs;
 
 use super::common::{
-    load_local_runtime, read_topic, TRIGGER_ATTEMPTS_TOPIC, TRIGGER_INBOX_TOPIC,
-    TRIGGER_OUTBOX_TOPIC,
+    load_local_runtime, read_topic, TRIGGER_ATTEMPTS_TOPIC, TRIGGER_INBOX_CLAIMS_TOPIC,
+    TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC, TRIGGER_OUTBOX_TOPIC,
 };
 
 pub(super) async fn run(args: OrchestratorQueueArgs) -> Result<(), String> {
@@ -13,7 +13,9 @@ pub(super) async fn run(args: OrchestratorQueueArgs) -> Result<(), String> {
     let dispatcher = harn_vm::snapshot_dispatcher_stats();
     let outbox = read_topic(&ctx.event_log, TRIGGER_OUTBOX_TOPIC).await?;
     let attempts = read_topic(&ctx.event_log, TRIGGER_ATTEMPTS_TOPIC).await?;
-    let inbox_events = read_topic(&ctx.event_log, TRIGGER_INBOX_TOPIC).await?;
+    let claim_events = read_topic(&ctx.event_log, TRIGGER_INBOX_CLAIMS_TOPIC).await?;
+    let envelope_events = read_topic(&ctx.event_log, TRIGGER_INBOX_ENVELOPES_TOPIC).await?;
+    let legacy_inbox_events = read_topic(&ctx.event_log, TRIGGER_INBOX_LEGACY_TOPIC).await?;
 
     let mut started = BTreeSet::new();
     let mut finished = BTreeSet::new();
@@ -49,9 +51,15 @@ pub(super) async fn run(args: OrchestratorQueueArgs) -> Result<(), String> {
         .await
         .map_err(|error| error.to_string())?;
     let inbox_snapshot = inbox_metrics.snapshot();
-    let inbox_claims_written = inbox_events
+    let inbox_claims_written = claim_events
         .iter()
+        .chain(legacy_inbox_events.iter())
         .filter(|(_, event)| event.kind == "dedupe_claim")
+        .count();
+    let inbox_envelopes_written = envelope_events
+        .iter()
+        .chain(legacy_inbox_events.iter())
+        .filter(|(_, event)| event.kind == "event_ingested")
         .count();
 
     println!("Queue:");
@@ -63,6 +71,7 @@ pub(super) async fn run(args: OrchestratorQueueArgs) -> Result<(), String> {
     println!("- inferred_in_flight={}", in_flight.len());
     println!("- inferred_pending_retries={}", pending_retries.len());
     println!("- inbox_claims_written={}", inbox_claims_written);
+    println!("- inbox_envelopes_written={}", inbox_envelopes_written);
     println!(
         "- inbox_duplicates_rejected={}",
         inbox_snapshot.inbox_duplicates_rejected

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -592,7 +592,7 @@ fn spawn_inbox_pump(
     event_log: Arc<harn_vm::event_log::AnyEventLog>,
     dispatcher: harn_vm::Dispatcher,
 ) -> Result<PumpHandle, String> {
-    let topic = harn_vm::event_log::Topic::new(harn_vm::TRIGGER_INBOX_TOPIC)
+    let topic = harn_vm::event_log::Topic::new(harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC)
         .map_err(|error| error.to_string())?;
     spawn_topic_pump(event_log, topic, move |logged| {
         let dispatcher = dispatcher.clone();
@@ -726,7 +726,7 @@ async fn graceful_shutdown(
         .drain(topic_latest_id(ctx.event_log, CRON_TICK_TOPIC).await?)
         .await?;
     let inbox_stats = inbox_pump
-        .drain(topic_latest_id(ctx.event_log, harn_vm::TRIGGER_INBOX_TOPIC).await?)
+        .drain(topic_latest_id(ctx.event_log, harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC).await?)
         .await?;
     let drain_report = dispatcher
         .drain(remaining_budget(deadline))

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -1,14 +1,16 @@
 #![cfg(unix)]
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc::{self, Receiver};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use harn_vm::event_log::{EventLog, EventLogBackendKind, EventLogConfig, Topic};
+use harn_vm::event_log::{EventLog, EventLogBackendKind, EventLogConfig, LogEvent, Topic};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use tempfile::TempDir;
 
@@ -164,6 +166,65 @@ fn read_topic_events(
     futures::executor::block_on(log.read_range(&topic, None, usize::MAX)).unwrap()
 }
 
+fn seed_legacy_inbox_records(temp: &TempDir) {
+    let state_dir = temp.path().join("state");
+    fs::create_dir_all(&state_dir).unwrap();
+    let config = EventLogConfig::for_base_dir(&state_dir).unwrap();
+    let log = harn_vm::event_log::open_event_log(&config).unwrap();
+
+    let legacy_topic = Topic::new(harn_vm::TRIGGER_INBOX_LEGACY_TOPIC).unwrap();
+    let future_expiry_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64
+        + 60_000;
+    futures::executor::block_on(log.append(
+        &legacy_topic,
+        LogEvent::new(
+            "dedupe_claim",
+            serde_json::json!({
+                "binding_id": "github-new-issue",
+                "dedupe_key": "delivery-123",
+                "expires_at_ms": future_expiry_ms,
+            }),
+        ),
+    ))
+    .unwrap();
+
+    let event = harn_vm::TriggerEvent::new(
+        harn_vm::ProviderId::from("webhook"),
+        "webhook.received",
+        None,
+        "delivery-123",
+        None,
+        BTreeMap::new(),
+        harn_vm::ProviderPayload::Known(harn_vm::triggers::event::KnownProviderPayload::Webhook(
+            harn_vm::triggers::GenericWebhookPayload {
+                source: Some("legacy-fixture".to_string()),
+                content_type: Some("application/json".to_string()),
+                raw: serde_json::json!({"legacy": true}),
+            },
+        )),
+        harn_vm::SignatureStatus::Unsigned,
+    );
+    futures::executor::block_on(
+        log.append(
+            &legacy_topic,
+            LogEvent::new(
+                "event_ingested",
+                serde_json::to_value(harn_vm::triggers::dispatcher::InboxEnvelope {
+                    trigger_id: Some("github-new-issue".to_string()),
+                    binding_version: Some(1),
+                    event,
+                })
+                .unwrap(),
+            ),
+        ),
+    )
+    .unwrap();
+    futures::executor::block_on(log.flush()).unwrap();
+}
+
 fn wait_for_topic_kind(state_dir: &Path, topic_name: &str, kind: &str) {
     let deadline = Instant::now() + Duration::from_secs(30);
     while Instant::now() < deadline {
@@ -303,13 +364,15 @@ pub fn on_task(event: TriggerEvent) -> string {
         event.kind == "stopped" && event.payload["timed_out"] == serde_json::json!(false)
     }));
 
-    let inbox = read_topic_events(&state_dir, "trigger.inbox");
+    let inbox = read_topic_events(&state_dir, harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC);
     assert!(
         inbox
             .iter()
             .any(|(_, event)| event.kind == "event_ingested"),
         "inbox={inbox:?}"
     );
+    let legacy_inbox = read_topic_events(&state_dir, harn_vm::TRIGGER_INBOX_LEGACY_TOPIC);
+    assert!(legacy_inbox.is_empty(), "legacy_inbox={legacy_inbox:?}");
 
     let outbox = read_topic_events(&state_dir, "trigger.outbox");
     assert!(outbox.iter().any(|(_, event)| {
@@ -323,4 +386,78 @@ pub fn on_task(event: TriggerEvent) -> string {
         snapshot_contents.contains("\"in_flight\": 0"),
         "snapshot={snapshot_contents}"
     );
+}
+
+#[test]
+fn orchestrator_queue_soft_migrates_legacy_inbox_topics() {
+    let temp = TempDir::new().unwrap();
+    write_file(
+        temp.path(),
+        "harn.toml",
+        r#"
+[package]
+name = "fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "github-new-issue"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "handlers::on_event"
+secrets = { signing_secret = "github/webhook-secret" }
+"#,
+    );
+    write_file(
+        temp.path(),
+        "lib.harn",
+        r#"
+import "std/triggers"
+
+pub fn on_event(event: TriggerEvent) {
+  log(event.kind)
+}
+"#,
+    );
+    seed_legacy_inbox_records(&temp);
+    let state_dir = temp.path().join("state");
+    let legacy_before = read_topic_events(&state_dir, harn_vm::TRIGGER_INBOX_LEGACY_TOPIC);
+    assert_eq!(legacy_before.len(), 2, "legacy_before={legacy_before:?}");
+
+    let (mut child, rx, handle) = spawn_orchestrator(&temp);
+    wait_for_log_line(&mut child, &rx, STARTUP_NEEDLE);
+    send_sigterm(&child);
+    wait_for_exit(&mut child);
+    let stderr = handle.join().expect("stderr collector thread");
+    assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
+    let legacy_after = read_topic_events(&state_dir, harn_vm::TRIGGER_INBOX_LEGACY_TOPIC);
+    assert_eq!(legacy_after.len(), 2, "legacy_after={legacy_after:?}");
+    assert_eq!(
+        legacy_after
+            .iter()
+            .filter(|(_, event)| event.kind == "dedupe_claim")
+            .count(),
+        1,
+        "legacy_after={legacy_after:?}"
+    );
+    assert!(
+        legacy_after
+            .iter()
+            .any(|(_, event)| event.kind == "event_ingested"),
+        "legacy_after={legacy_after:?}"
+    );
+
+    let config = EventLogConfig::for_base_dir(&state_dir).unwrap();
+    let log = harn_vm::event_log::open_event_log(&config).unwrap();
+    let metrics = Arc::new(harn_vm::MetricsRegistry::default());
+    let inbox =
+        futures::executor::block_on(harn_vm::InboxIndex::new(log.clone(), metrics)).unwrap();
+    assert!(!futures::executor::block_on(inbox.insert_if_new(
+        "github-new-issue",
+        "delivery-123",
+        Duration::from_secs(60),
+    ))
+    .unwrap());
 }

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -139,6 +139,17 @@ fn wait_for_exit(child: &mut Child) {
     panic!("timed out waiting for orchestrator exit");
 }
 
+fn wait_for_any_exit(child: &mut Child) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if child.try_wait().unwrap().is_some() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!("timed out waiting for orchestrator exit");
+}
+
 fn json_headers() -> HeaderMap {
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
@@ -428,10 +439,9 @@ pub fn on_event(event: TriggerEvent) {
 
     let (mut child, rx, handle) = spawn_orchestrator(&temp);
     wait_for_log_line(&mut child, &rx, STARTUP_NEEDLE);
-    send_sigterm(&child);
-    wait_for_exit(&mut child);
-    let stderr = handle.join().expect("stderr collector thread");
-    assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
+    child.kill().unwrap();
+    wait_for_any_exit(&mut child);
+    let _stderr = handle.join().expect("stderr collector thread");
     let legacy_after = read_topic_events(&state_dir, harn_vm::TRIGGER_INBOX_LEGACY_TOPIC);
     assert_eq!(legacy_after.len(), 2, "legacy_after={legacy_after:?}");
     assert_eq!(

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -91,7 +91,9 @@ pub use triggers::{
     TriggerBindingSpec, TriggerDispatchOutcome, TriggerEvent, TriggerEventId, TriggerHandlerSpec,
     TriggerHarnessResult, TriggerId, TriggerMetricsSnapshot, TriggerPredicateSpec,
     TriggerRegistryError, TriggerRetryConfig, TriggerState, DEFAULT_INBOX_RETENTION_DAYS,
-    TRIGGER_INBOX_TOPIC, TRIGGER_TEST_FIXTURES,
+    TRIGGERS_LIFECYCLE_TOPIC, TRIGGER_ATTEMPTS_TOPIC, TRIGGER_DLQ_TOPIC,
+    TRIGGER_INBOX_CLAIMS_TOPIC, TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC,
+    TRIGGER_OUTBOX_TOPIC, TRIGGER_TEST_FIXTURES,
 };
 pub use value::*;
 pub use vm::*;

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -14,18 +14,12 @@ use crate::triggers::{
     dynamic_register, registered_provider_metadata, resolve_live_trigger_binding,
     resolve_trigger_binding_as_of, snapshot_trigger_bindings, RetryPolicy, TriggerBindingSnapshot,
     TriggerBindingSource, TriggerBindingSpec, TriggerEvent, TriggerEventId, TriggerHandlerSpec,
-    TriggerPredicateSpec, TriggerRegistryError, TriggerRetryConfig,
+    TriggerPredicateSpec, TriggerRegistryError, TriggerRetryConfig, TRIGGER_DLQ_TOPIC,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
 const TRIGGER_EVENTS_TOPIC: &str = "triggers.events";
-// Must match `crate::triggers::dispatcher::TRIGGER_DLQ_TOPIC` so that
-// `trigger_inspect_dlq()` sees entries appended by the dispatcher.
-// Previous value "triggers.dlq" silently diverged from the dispatcher's
-// "trigger.dlq" (plural vs singular family convention) and hid every
-// DLQ entry from stdlib inspectors.
-const TRIGGER_DLQ_TOPIC: &str = "trigger.dlq";
 const TRIGGER_EVENT_LOG_QUEUE_DEPTH: usize = 128;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -29,18 +29,17 @@ use crate::vm::Vm;
 use self::uri::DispatchUri;
 use super::registry::matching_bindings;
 use super::registry::{TriggerBinding, TriggerHandlerSpec};
-use super::{begin_in_flight, finish_in_flight, TriggerDispatchOutcome, TriggerEvent};
+use super::{
+    begin_in_flight, finish_in_flight, TriggerDispatchOutcome, TriggerEvent,
+    TRIGGERS_LIFECYCLE_TOPIC, TRIGGER_ATTEMPTS_TOPIC, TRIGGER_DLQ_TOPIC,
+    TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_OUTBOX_TOPIC,
+};
 
 pub mod retry;
 pub mod uri;
 
 pub use retry::{RetryPolicy, TriggerRetryConfig, DEFAULT_MAX_ATTEMPTS};
 
-const TRIGGER_INBOX_TOPIC: &str = "trigger.inbox";
-const TRIGGER_OUTBOX_TOPIC: &str = "trigger.outbox";
-const TRIGGER_ATTEMPTS_TOPIC: &str = "trigger.attempts";
-const TRIGGER_DLQ_TOPIC: &str = "trigger.dlq";
-const TRIGGERS_LIFECYCLE_TOPIC: &str = "triggers.lifecycle";
 const HARN_REPLAY_ENV: &str = "HARN_REPLAY";
 
 thread_local! {
@@ -285,7 +284,8 @@ impl Dispatcher {
         binding_version: Option<u32>,
         event: TriggerEvent,
     ) -> Result<u64, DispatchError> {
-        let topic = Topic::new(TRIGGER_INBOX_TOPIC).expect("static trigger.inbox topic is valid");
+        let topic = Topic::new(TRIGGER_INBOX_ENVELOPES_TOPIC)
+            .expect("static trigger inbox envelopes topic is valid");
         let headers = event_headers(&event, None, None, None);
         let payload = serde_json::to_value(InboxEnvelope {
             trigger_id,
@@ -303,7 +303,8 @@ impl Dispatcher {
     }
 
     pub async fn run(&self) -> Result<(), DispatchError> {
-        let topic = Topic::new(TRIGGER_INBOX_TOPIC).expect("static trigger.inbox topic is valid");
+        let topic = Topic::new(TRIGGER_INBOX_ENVELOPES_TOPIC)
+            .expect("static trigger inbox envelopes topic is valid");
         let stream = self.event_log.clone().subscribe(&topic, None).await?;
         pin_mut!(stream);
         let mut cancel_rx = self.cancel_tx.subscribe();

--- a/crates/harn-vm/src/triggers/inbox.rs
+++ b/crates/harn-vm/src/triggers/inbox.rs
@@ -7,9 +7,10 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex as AsyncMutex;
 
 use crate::connectors::{ConnectorError, MetricsRegistry};
-use crate::event_log::{AnyEventLog, EventLog, Topic};
+use crate::event_log::{AnyEventLog, EventLog, LogEvent, Topic};
 
-pub const TRIGGER_INBOX_TOPIC: &str = "trigger.inbox";
+use super::{TRIGGER_INBOX_CLAIMS_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC};
+
 pub const DEFAULT_INBOX_RETENTION_DAYS: u32 = 7;
 const CLAIM_EVENT_KIND: &str = "dedupe_claim";
 const HOT_CACHE_LIMIT: usize = 4096;
@@ -29,32 +30,25 @@ impl InboxIndex {
         event_log: Arc<AnyEventLog>,
         metrics: Arc<MetricsRegistry>,
     ) -> Result<Self, ConnectorError> {
-        let topic = Topic::new(TRIGGER_INBOX_TOPIC).expect("trigger inbox topic is valid");
+        let topic =
+            Topic::new(TRIGGER_INBOX_CLAIMS_TOPIC).expect("trigger inbox claims topic is valid");
         let records = event_log
             .read_range(&topic, None, usize::MAX)
+            .await
+            .map_err(ConnectorError::from)?;
+        let legacy_topic =
+            Topic::new(TRIGGER_INBOX_LEGACY_TOPIC).expect("legacy trigger inbox topic is valid");
+        let legacy_records = event_log
+            .read_range(&legacy_topic, None, usize::MAX)
             .await
             .map_err(ConnectorError::from)?;
         let now_ms = now_ms();
         let mut entries = HashMap::new();
         let mut expired = 0u64;
-        for (_, record) in records {
-            if record.kind != CLAIM_EVENT_KIND {
-                continue;
-            }
-            let claim: InboxClaimRecord =
-                serde_json::from_value(record.payload).map_err(ConnectorError::from)?;
-            let key = InboxKey::new(claim.binding_id, claim.dedupe_key);
-            if claim.expires_at_ms <= now_ms {
-                expired += 1;
-                continue;
-            }
-            entries.insert(
-                key,
-                InboxEntry {
-                    expires_at_ms: claim.expires_at_ms,
-                },
-            );
-        }
+        rehydrate_claims(records, now_ms, &mut entries, &mut expired)?;
+        // Soft migration for pre-split logs that still hold claim records in
+        // the legacy mixed inbox topic.
+        rehydrate_claims(legacy_records, now_ms, &mut entries, &mut expired)?;
         metrics.record_inbox_expired_entries(expired);
         metrics.set_inbox_active_entries(entries.len());
         Ok(Self {
@@ -163,6 +157,33 @@ impl InboxIndex {
             .retain_active(now_ms);
         self.metrics.record_inbox_expired_entries(expired);
     }
+}
+
+fn rehydrate_claims(
+    records: Vec<(u64, LogEvent)>,
+    now_ms: i64,
+    entries: &mut HashMap<InboxKey, InboxEntry>,
+    expired: &mut u64,
+) -> Result<(), ConnectorError> {
+    for (_, record) in records {
+        if record.kind != CLAIM_EVENT_KIND {
+            continue;
+        }
+        let claim: InboxClaimRecord =
+            serde_json::from_value(record.payload).map_err(ConnectorError::from)?;
+        let key = InboxKey::new(claim.binding_id, claim.dedupe_key);
+        if claim.expires_at_ms <= now_ms {
+            *expired += 1;
+            continue;
+        }
+        entries.insert(
+            key,
+            InboxEntry {
+                expires_at_ms: claim.expires_at_ms,
+            },
+        );
+    }
+    Ok(())
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -314,9 +335,44 @@ mod tests {
             .await
             .unwrap());
 
-        let topic = Topic::new(TRIGGER_INBOX_TOPIC).unwrap();
+        let topic = Topic::new(TRIGGER_INBOX_CLAIMS_TOPIC).unwrap();
         let events = log.read_range(&topic, None, usize::MAX).await.unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(metrics.snapshot().inbox_fast_path_hits, 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn restart_rehydrates_legacy_claims_from_mixed_topic() {
+        let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(32)));
+        let metrics = Arc::new(MetricsRegistry::default());
+        let legacy_topic = Topic::new(TRIGGER_INBOX_LEGACY_TOPIC).unwrap();
+        let now_ms = now_ms();
+        log.append(
+            &legacy_topic,
+            LogEvent::new(
+                CLAIM_EVENT_KIND,
+                serde_json::json!({
+                    "binding_id": "binding",
+                    "dedupe_key": "delivery-1",
+                    "expires_at_ms": now_ms + 60_000,
+                }),
+            ),
+        )
+        .await
+        .unwrap();
+
+        let index = InboxIndex::new(log.clone(), metrics.clone()).await.unwrap();
+        assert!(!index
+            .insert_if_new("binding", "delivery-1", StdDuration::from_secs(60))
+            .await
+            .unwrap());
+
+        let new_claims_topic = Topic::new(TRIGGER_INBOX_CLAIMS_TOPIC).unwrap();
+        let new_claims = log
+            .read_range(&new_claims_topic, None, usize::MAX)
+            .await
+            .unwrap();
+        assert!(new_claims.is_empty());
+        assert_eq!(metrics.snapshot().inbox_duplicates_rejected, 1);
     }
 }

--- a/crates/harn-vm/src/triggers/mod.rs
+++ b/crates/harn-vm/src/triggers/mod.rs
@@ -3,6 +3,7 @@ pub mod event;
 pub mod inbox;
 pub mod registry;
 pub mod test_util;
+pub mod topics;
 
 pub use dispatcher::{
     clear_dispatcher_state, snapshot_dispatcher_stats, DispatchError, DispatchOutcome,
@@ -18,7 +19,7 @@ pub use event::{
     ProviderSchema, ProviderSecretRequirement, SignatureStatus, SignatureVerificationMetadata,
     SlackEventPayload, TenantId, TraceId, TriggerEvent, TriggerEventId,
 };
-pub use inbox::{InboxIndex, DEFAULT_INBOX_RETENTION_DAYS, TRIGGER_INBOX_TOPIC};
+pub use inbox::{InboxIndex, DEFAULT_INBOX_RETENTION_DAYS};
 pub use registry::{
     begin_in_flight, binding_version_as_of, clear_trigger_registry, drain, dynamic_deregister,
     dynamic_register, finish_in_flight, install_manifest_triggers, pin_trigger_binding,
@@ -28,3 +29,8 @@ pub use registry::{
     TriggerPredicateSpec, TriggerRegistryError, TriggerState,
 };
 pub use test_util::{run_trigger_harness_fixture, TriggerHarnessResult, TRIGGER_TEST_FIXTURES};
+pub use topics::{
+    TRIGGERS_LIFECYCLE_TOPIC, TRIGGER_ATTEMPTS_TOPIC, TRIGGER_DLQ_TOPIC,
+    TRIGGER_INBOX_CLAIMS_TOPIC, TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC,
+    TRIGGER_OUTBOX_TOPIC,
+};

--- a/crates/harn-vm/src/triggers/topics.rs
+++ b/crates/harn-vm/src/triggers/topics.rs
@@ -1,0 +1,7 @@
+pub const TRIGGER_INBOX_LEGACY_TOPIC: &str = "trigger.inbox";
+pub const TRIGGER_INBOX_CLAIMS_TOPIC: &str = "trigger.inbox.claims";
+pub const TRIGGER_INBOX_ENVELOPES_TOPIC: &str = "trigger.inbox.envelopes";
+pub const TRIGGER_OUTBOX_TOPIC: &str = "trigger.outbox";
+pub const TRIGGER_ATTEMPTS_TOPIC: &str = "trigger.attempts";
+pub const TRIGGER_DLQ_TOPIC: &str = "trigger.dlq";
+pub const TRIGGERS_LIFECYCLE_TOPIC: &str = "triggers.lifecycle";

--- a/docs/src/triggers/dispatcher.md
+++ b/docs/src/triggers/dispatcher.md
@@ -11,7 +11,7 @@ explicit stub with a clear follow-up ticket.
 
 Each dispatch goes through the same sequence:
 
-1. Append the inbound event to `trigger.inbox`.
+1. Append the inbound event to `trigger.inbox.envelopes`.
 2. Match the event against active registry bindings for the provider +
    event kind.
 3. Evaluate the optional `when` predicate in the same VM/runtime surface as
@@ -92,12 +92,19 @@ without inventing a second cancellation mechanism.
 
 The dispatcher uses the shared `EventLog` instead of a parallel queue layer:
 
-- `trigger.inbox`
+- `trigger.inbox.envelopes`
+- `trigger.inbox.claims`
 - `trigger.outbox`
 - `trigger.attempts`
 - `trigger.dlq`
 - `triggers.lifecycle`
 - `observability.action_graph`
+
+`trigger.inbox.envelopes` is the dispatcher's durable ingress stream.
+`trigger.inbox.claims` stores TTL-bound dedupe claims for `InboxIndex`.
+Harn v0.7.23 also soft-reads the legacy mixed `trigger.inbox` topic on
+startup so older event logs keep working while new writes go only to the
+split topics.
 
 `triggers.lifecycle` now includes dispatcher-specific lifecycle records:
 

--- a/docs/src/triggers/manifest.md
+++ b/docs/src/triggers/manifest.md
@@ -72,7 +72,7 @@ entry is easy to locate.
 ## Durable dedupe retention
 
 Trigger dedupe now uses a durable inbox index backed by the shared EventLog
-topic `trigger.inbox`. Each successful claim stores the binding id plus the
+topic `trigger.inbox.claims`. Each successful claim stores the binding id plus the
 resolved `dedupe_key`, and duplicate deliveries are rejected until the claim's
 TTL expires.
 
@@ -85,6 +85,10 @@ TTL expires.
 Use a retention window at least as long as the provider's maximum retry window.
 If a provider can redeliver for longer than your configured TTL, Harn may
 dispatch that late retry again once the durable claim has expired.
+
+Harn v0.7.23 still soft-reads legacy claim records from the old mixed
+`trigger.inbox` topic on startup, but all new claim writes land under
+`trigger.inbox.claims`.
 
 ## Doctor output
 


### PR DESCRIPTION
## What changed
- split the mixed `trigger.inbox` stream into shared trigger topic constants under `harn_vm::triggers`
- write durable dedupe claims to `trigger.inbox.claims` and dispatcher envelopes to `trigger.inbox.envelopes`
- keep a soft migration path by rehydrating legacy claim records from the old `trigger.inbox` topic on startup
- update orchestrator wiring, docs, and changelog to reflect the new topic semantics
- add coverage for legacy mixed-topic startup behavior and stabilize the new orchestrator migration fixture under the full test gate

## Why
`InboxIndex::new` was rebuilding durable claim state by scanning the old mixed `trigger.inbox` topic, which also held never-expiring dispatcher envelopes. That made orchestrator startup cost grow with all historical deliveries instead of just the bounded claim-retention window.

## Impact
Startup rehydration for inbox dedupe now scales with retained claim records rather than all-time envelope traffic, while existing event logs continue to work without a manual migration in v0.7.23.

## Root cause
Both `InboxClaimRecord` and `InboxEnvelope` were using the same topic string, so the inbox index had no bounded claim-only stream to replay.

## Validation
- `cargo test -p harn-vm triggers::inbox::tests --lib`
- `cargo test -p harn-cli --test orchestrator_cli`
- `cargo test -p harn-cli --test orchestrator_inbox_dedupe`
- repo pre-push hook: workspace nextest run, markdown lint, portal lint
