### PR TITLE
[codex] Treat _ bindings as discards

### DIFF
--- a/conformance/errors/semantic/discard_binding_undefined.error
+++ b/conformance/errors/semantic/discard_binding_undefined.error
@@ -1,0 +1,1 @@
+Undefined variable: _

--- a/conformance/errors/semantic/discard_binding_undefined.harn
+++ b/conformance/errors/semantic/discard_binding_undefined.harn
@@ -1,0 +1,4 @@
+pipeline default(task) {
+  let _ = 1
+  log(_)
+}

--- a/conformance/tests/language/discard_binding.expected
+++ b/conformance/tests/language/discard_binding.expected
@@ -1,0 +1,7 @@
+simple
+30
+3
+a
+b
+dict
+pair

--- a/conformance/tests/language/discard_binding.harn
+++ b/conformance/tests/language/discard_binding.harn
@@ -1,0 +1,23 @@
+pipeline default() {
+  let _ = 1
+  let _ = 2
+  println("simple")
+
+  let [_, _, keep_list] = [10, 20, 30]
+  println(keep_list)
+
+  let {drop_a: _, drop_b: _, keep_dict} = {drop_a: 1, drop_b: 2, keep_dict: 3}
+  println(keep_dict)
+
+  for [_, value] in [[1, "a"], [2, "b"]] {
+    println(value)
+  }
+
+  for {drop: _, keep} in [{drop: "x", keep: "dict"}] {
+    println(keep)
+  }
+
+  for (_, right) in [pair("left", "pair")] {
+    println(right)
+  }
+}

--- a/conformance/tests/language/discard_binding.harn
+++ b/conformance/tests/language/discard_binding.harn
@@ -2,21 +2,16 @@ pipeline default() {
   let _ = 1
   let _ = 2
   println("simple")
-
   let [_, _, keep_list] = [10, 20, 30]
   println(keep_list)
-
   let {drop_a: _, drop_b: _, keep_dict} = {drop_a: 1, drop_b: 2, keep_dict: 3}
   println(keep_dict)
-
   for [_, value] in [[1, "a"], [2, "b"]] {
     println(value)
   }
-
   for {drop: _, keep} in [{drop: "x", keep: "dict"}] {
     println(keep)
   }
-
   for (_, right) in [pair("left", "pair")] {
     println(right)
   }

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -49,6 +49,21 @@ fn test_roundtrip_for_in() {
 }
 
 #[test]
+fn test_roundtrip_discard_bindings() {
+    let source = r#"pipeline default(task) {
+  let _ = 1
+  let _ = 2
+  let [_, keep, _] = [10, 20, 30]
+  println(keep)
+}"#;
+    let formatted = format_source(source).unwrap();
+    assert!(formatted.contains("let _ = 1\n"));
+    assert!(formatted.contains("let _ = 2\n"));
+    assert!(formatted.contains("let [_, keep, _] = [10, 20, 30]\n"));
+    assert_roundtrip(source);
+}
+
+#[test]
 fn test_roundtrip_match() {
     assert_roundtrip(
         r#"pipeline default(task) { match x { "a" -> { log(1) } "b" -> { log(2) } } }"#,

--- a/crates/harn-parser/src/ast.rs
+++ b/crates/harn-parser/src/ast.rs
@@ -505,6 +505,11 @@ pub enum BindingPattern {
     Pair(String, String),
 }
 
+/// `_` is the discard binding name in `let`/`var`/destructuring positions.
+pub fn is_discard_name(name: &str) -> bool {
+    name == "_"
+}
+
 /// A field in a dict destructuring pattern.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DictPatternField {

--- a/crates/harn-parser/src/typechecker/inference/entry.rs
+++ b/crates/harn-parser/src/typechecker/inference/entry.rs
@@ -219,7 +219,9 @@ impl TypeChecker {
                     // patterns are checked as statements and define
                     // their vars as they are walked.
                     if let BindingPattern::Identifier(name) = pattern {
-                        scope.define_var(name, None);
+                        if !crate::ast::is_discard_name(name) {
+                            scope.define_var(name, None);
+                        }
                     }
                 }
                 _ => {}

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -129,7 +129,7 @@ impl TypeChecker {
                         }
                     }
                     // Collect inlay hint when type is inferred (no annotation)
-                    if type_ann.is_none() {
+                    if type_ann.is_none() && !is_discard_name(name) {
                         if let Some(ref ty) = inferred {
                             if !is_obvious_type(value, ty) {
                                 self.hints.push(InlayHintInfo {
@@ -183,7 +183,7 @@ impl TypeChecker {
                             }
                         }
                     }
-                    if type_ann.is_none() {
+                    if type_ann.is_none() && !is_discard_name(name) {
                         if let Some(ref ty) = inferred {
                             if !is_obvious_type(value, ty) {
                                 self.hints.push(InlayHintInfo {

--- a/crates/harn-parser/src/typechecker/scope.rs
+++ b/crates/harn-parser/src/typechecker/scope.rs
@@ -378,15 +378,24 @@ impl TypeScope {
     }
 
     pub(super) fn define_var(&mut self, name: &str, ty: InferredType) {
+        if is_discard_name(name) {
+            return;
+        }
         self.vars.insert(name.to_string(), ty);
     }
 
     pub(super) fn define_var_mutable(&mut self, name: &str, ty: InferredType) {
+        if is_discard_name(name) {
+            return;
+        }
         self.vars.insert(name.to_string(), ty);
         self.mutable_vars.insert(name.to_string());
     }
 
     pub(super) fn define_schema_binding(&mut self, name: &str, ty: InferredType) {
+        if is_discard_name(name) {
+            return;
+        }
         self.schema_bindings.insert(name.to_string(), ty);
     }
 
@@ -403,6 +412,9 @@ impl TypeScope {
     }
 
     pub(super) fn mark_untyped_source(&mut self, name: &str, source: &str) {
+        if is_discard_name(name) {
+            return;
+        }
         self.untyped_sources
             .insert(name.to_string(), source.to_string());
     }

--- a/crates/harn-vm/src/compiler/patterns.rs
+++ b/crates/harn-vm/src/compiler/patterns.rs
@@ -1,4 +1,4 @@
-use harn_parser::{BindingPattern, Node, SNode};
+use harn_parser::{is_discard_name, BindingPattern, Node, SNode};
 
 use crate::chunk::{Constant, Op};
 
@@ -6,6 +6,15 @@ use super::error::CompileError;
 use super::Compiler;
 
 impl Compiler {
+    fn emit_binding_target(&mut self, name: &str, def_op: Op) {
+        if is_discard_name(name) {
+            self.chunk.emit(Op::Pop, self.line);
+            return;
+        }
+        let idx = self.chunk.add_constant(Constant::String(name.to_string()));
+        self.chunk.emit_u16(def_op, idx, self.line);
+    }
+
     /// Compile a destructuring binding pattern.
     /// Expects the RHS value to already be on the stack.
     /// After this, the value is consumed (popped) and each binding is defined.
@@ -17,8 +26,7 @@ impl Compiler {
         let def_op = if is_mutable { Op::DefVar } else { Op::DefLet };
         match pattern {
             BindingPattern::Identifier(name) => {
-                let idx = self.chunk.add_constant(Constant::String(name.clone()));
-                self.chunk.emit_u16(def_op, idx, self.line);
+                self.emit_binding_target(name, def_op);
             }
             BindingPattern::Dict(fields) => {
                 // Runtime `__assert_dict(value)` type check on the RHS.
@@ -54,10 +62,7 @@ impl Compiler {
                         self.chunk.patch_jump(end);
                     }
                     let binding_name = field.alias.as_deref().unwrap_or(&field.key);
-                    let name_idx = self
-                        .chunk
-                        .add_constant(Constant::String(binding_name.to_string()));
-                    self.chunk.emit_u16(def_op, name_idx, self.line);
+                    self.emit_binding_target(binding_name, def_op);
                 }
 
                 if let Some(rest) = rest_field {
@@ -75,8 +80,7 @@ impl Compiler {
                         .emit_u16(Op::BuildList, non_rest.len() as u16, self.line);
                     self.chunk.emit_u8(Op::Call, 2, self.line);
                     let rest_name = &rest.key;
-                    let rest_idx = self.chunk.add_constant(Constant::String(rest_name.clone()));
-                    self.chunk.emit_u16(def_op, rest_idx, self.line);
+                    self.emit_binding_target(rest_name, def_op);
                 } else {
                     self.chunk.emit(Op::Pop, self.line);
                 }
@@ -88,20 +92,14 @@ impl Compiler {
                     .add_constant(Constant::String("first".to_string()));
                 self.chunk
                     .emit_u16(Op::GetProperty, first_key_idx, self.line);
-                let first_name_idx = self
-                    .chunk
-                    .add_constant(Constant::String(first_name.clone()));
-                self.chunk.emit_u16(def_op, first_name_idx, self.line);
+                self.emit_binding_target(first_name, def_op);
 
                 let second_key_idx = self
                     .chunk
                     .add_constant(Constant::String("second".to_string()));
                 self.chunk
                     .emit_u16(Op::GetProperty, second_key_idx, self.line);
-                let second_name_idx = self
-                    .chunk
-                    .add_constant(Constant::String(second_name.clone()));
-                self.chunk.emit_u16(def_op, second_name_idx, self.line);
+                self.emit_binding_target(second_name, def_op);
                 // No trailing Pop: GetProperty consumed the source pair.
             }
             BindingPattern::List(elements) => {
@@ -137,8 +135,7 @@ impl Compiler {
                         self.chunk.emit(Op::Pop, self.line);
                         self.chunk.patch_jump(end);
                     }
-                    let name_idx = self.chunk.add_constant(Constant::String(elem.name.clone()));
-                    self.chunk.emit_u16(def_op, name_idx, self.line);
+                    self.emit_binding_target(&elem.name, def_op);
                 }
 
                 if let Some(rest) = rest_elem {
@@ -150,9 +147,7 @@ impl Compiler {
                     self.chunk.emit_u16(Op::Constant, start_idx, self.line);
                     self.chunk.emit(Op::Nil, self.line);
                     self.chunk.emit(Op::Slice, self.line);
-                    let rest_name_idx =
-                        self.chunk.add_constant(Constant::String(rest.name.clone()));
-                    self.chunk.emit_u16(def_op, rest_name_idx, self.line);
+                    self.emit_binding_target(&rest.name, def_op);
                 } else {
                     self.chunk.emit(Op::Pop, self.line);
                 }
@@ -226,10 +221,7 @@ impl Compiler {
                             let idx_const = self.chunk.add_constant(Constant::Int(i as i64));
                             self.chunk.emit_u16(Op::Constant, idx_const, self.line);
                             self.chunk.emit(Op::Subscript, self.line);
-                            let name_idx = self
-                                .chunk
-                                .add_constant(Constant::String(binding_name.clone()));
-                            self.chunk.emit_u16(Op::DefLet, name_idx, self.line);
+                            self.emit_binding_target(binding_name, Op::DefLet);
                         }
                     }
 
@@ -336,10 +328,7 @@ impl Compiler {
                             let idx_const = self.chunk.add_constant(Constant::Int(i as i64));
                             self.chunk.emit_u16(Op::Constant, idx_const, self.line);
                             self.chunk.emit(Op::Subscript, self.line);
-                            let name_idx = self
-                                .chunk
-                                .add_constant(Constant::String(binding_name.clone()));
-                            self.chunk.emit_u16(Op::DefLet, name_idx, self.line);
+                            self.emit_binding_target(binding_name, Op::DefLet);
                         }
                     }
 
@@ -368,8 +357,7 @@ impl Compiler {
                 Node::Identifier(name) => {
                     self.begin_scope();
                     self.chunk.emit(Op::Dup, self.line);
-                    let name_idx = self.chunk.add_constant(Constant::String(name.clone()));
-                    self.chunk.emit_u16(Op::DefLet, name_idx, self.line);
+                    self.emit_binding_target(name, Op::DefLet);
                     // Optional guard
                     if let Some(ref guard) = arm.guard {
                         self.compile_node(guard)?;
@@ -453,8 +441,7 @@ impl Compiler {
                         let key_idx = self.chunk.add_constant(Constant::String(key.clone()));
                         self.chunk.emit_u16(Op::Constant, key_idx, self.line);
                         self.chunk.emit(Op::Subscript, self.line);
-                        let name_idx = self.chunk.add_constant(Constant::String(binding.clone()));
-                        self.chunk.emit_u16(Op::DefLet, name_idx, self.line);
+                        self.emit_binding_target(binding, Op::DefLet);
                     }
 
                     // Optional guard

--- a/crates/harn-vm/src/compiler/tests.rs
+++ b/crates/harn-vm/src/compiler/tests.rs
@@ -72,3 +72,27 @@ fn test_disassemble() {
     assert!(disasm.contains("ADD"));
     assert!(disasm.contains("CALL"));
 }
+
+#[test]
+fn test_compile_discard_bindings_do_not_define_underscore() {
+    let chunk = compile_source(
+        r#"
+pipeline test(task) {
+  let _ = 1
+  let [_, keep, _] = [10, 20, 30]
+  let {drop: _, keep_dict} = {drop: 1, keep_dict: 2}
+  for (_, value) in [pair("left", "right")] {
+    log(value)
+  }
+  log(keep)
+  log(keep_dict)
+}
+"#,
+    );
+
+    assert!(
+        !chunk.constants.contains(&Constant::String("_".to_string())),
+        "discard bindings should not emit a named `_` slot: {:?}",
+        chunk.constants
+    );
+}

--- a/docs/src/language-basics.md
+++ b/docs/src/language-basics.md
@@ -633,6 +633,8 @@ let long_value = some_function( \
 ## Destructuring
 
 Destructuring extracts values from dicts and lists into local variables.
+Use `_` when a position should be evaluated and ignored without creating a
+real variable.
 
 ### Dict destructuring
 
@@ -641,6 +643,9 @@ let person = {name: "Alice", age: 30}
 let {name, age} = person
 println(name)  // "Alice"
 println(age)   // 30
+
+let {name, debug: _} = {name: "Alice", debug: true}
+println(name)  // "Alice"
 ```
 
 ### List destructuring
@@ -650,6 +655,9 @@ let items = [1, 2, 3, 4, 5]
 let [first, ...rest] = items
 println(first)  // 1
 println(rest)   // [2, 3, 4, 5]
+
+let [_, second, _] = [10, 20, 30]
+println(second)  // 20
 ```
 
 ### Renaming
@@ -668,6 +676,10 @@ println(user_name)  // "Alice"
 let entries = [{key: "a", value: 1}, {key: "b", value: 2}]
 for {key, value} in entries {
   println("${key}: ${value}")
+}
+
+for [_, value] in [[0, "x"], [1, "y"]] {
+  println(value)
 }
 ```
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -626,6 +626,9 @@ Returns `nil` (which becomes `.nilValue`) if not found anywhere.
 
 - `let name = value` -- defines `name` as immutable in the current scope.
 - `var name = value` -- defines `name` as mutable in the current scope.
+- `let _ = value` / `var _ = value` -- evaluate `value` and discard it
+  without introducing a variable into scope. `_` can be reused any number
+  of times in the same scope.
 
 ### Variable assignment
 
@@ -661,6 +664,12 @@ let {name, age} = {name: "Alice", age: 30}
 
 Each field name in the pattern extracts the value for the matching key.
 If the key is missing from the dict, the variable is bound to `nil`.
+Use `_` as a discard binding when you want to ignore an extracted field:
+
+```harn
+let {name, debug: _} = {name: "Alice", debug: true}
+// name == "Alice"; `_` is not bound
+```
 
 ### Default values
 
@@ -698,6 +707,12 @@ let [first, second, third] = [10, 20, 30]
 Elements are bound positionally. If there are more bindings than elements
 in the list, the excess bindings receive `nil` (unless a default value is
 specified).
+Use `_` to discard positions without creating a binding:
+
+```harn
+let [_, second, _] = [10, 20, 30]
+// second == 20; `_` is not bound
+```
 
 ### Field renaming
 
@@ -740,6 +755,9 @@ for [a, b] in pairs {
 }
 ```
 
+`_` is also a discard binding in loop patterns, so `for [_, value] in ...`
+or `for (_, value) in ...` drops the ignored element instead of binding it.
+
 ### Var destructuring
 
 `var` destructuring creates mutable bindings that can be reassigned:
@@ -749,6 +767,9 @@ var {x, y} = {x: 1, y: 2}
 x = 10
 y = 20
 ```
+
+Discard bindings remain non-bindings under `var` as well: `var [_, value] =`
+still only introduces `value`.
 
 ### Type errors
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -624,6 +624,9 @@ Returns `nil` (which becomes `.nilValue`) if not found anywhere.
 
 - `let name = value` -- defines `name` as immutable in the current scope.
 - `var name = value` -- defines `name` as mutable in the current scope.
+- `let _ = value` / `var _ = value` -- evaluate `value` and discard it
+  without introducing a variable into scope. `_` can be reused any number
+  of times in the same scope.
 
 ### Variable assignment
 
@@ -659,6 +662,12 @@ let {name, age} = {name: "Alice", age: 30}
 
 Each field name in the pattern extracts the value for the matching key.
 If the key is missing from the dict, the variable is bound to `nil`.
+Use `_` as a discard binding when you want to ignore an extracted field:
+
+```harn
+let {name, debug: _} = {name: "Alice", debug: true}
+// name == "Alice"; `_` is not bound
+```
 
 ### Default values
 
@@ -696,6 +705,12 @@ let [first, second, third] = [10, 20, 30]
 Elements are bound positionally. If there are more bindings than elements
 in the list, the excess bindings receive `nil` (unless a default value is
 specified).
+Use `_` to discard positions without creating a binding:
+
+```harn
+let [_, second, _] = [10, 20, 30]
+// second == 20; `_` is not bound
+```
 
 ### Field renaming
 
@@ -738,6 +753,9 @@ for [a, b] in pairs {
 }
 ```
 
+`_` is also a discard binding in loop patterns, so `for [_, value] in ...`
+or `for (_, value) in ...` drops the ignored element instead of binding it.
+
 ### Var destructuring
 
 `var` destructuring creates mutable bindings that can be reassigned:
@@ -747,6 +765,9 @@ var {x, y} = {x: 1, y: 2}
 x = 10
 y = 20
 ```
+
+Discard bindings remain non-bindings under `var` as well: `var [_, value] =`
+still only introduces `value`.
 
 ### Type errors
 


### PR DESCRIPTION
## Summary
- treat `_` as a discard binding across `let`/`var`, destructuring, and match/loop lowering instead of creating a real variable slot
- add conformance coverage for repeated discard bindings and for `_` remaining undefined after a discard binding
- document discard-binding semantics and add formatter coverage for canonicalized discard-binding source

## Root cause
Harn already special-cased `_` in some contexts such as pipe placeholders and wildcard match arms, but ordinary binding lowering still emitted real variable definitions for `_`. That let `_` leak into scope as a usable variable and caused repeated `let _ = ...` bindings in the same scope to fail at runtime with an immutable redeclaration error.

## Impact
Discard bindings now behave consistently across parser/typechecker/compiler/runtime paths, so throwaway bindings can be repeated safely and `_` no longer becomes a real name in scope.

## Validation
- `cargo test -p harn-parser --lib`
- `cargo test -p harn-vm compiler::tests::test_compile_discard_bindings_do_not_define_underscore -- --exact`
- `cargo test -p harn-fmt discard_bindings`
- `cargo run --quiet --bin harn -- test conformance --filter discard_binding`
- `cargo run --quiet --bin harn -- test conformance --filter let_redeclare`
- pre-push fast release-quality checks (1606 tests, markdown, portal lint)
