### PR TITLE
Fix HARN_REPLAY replay races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ granular archaeology.
   key. Re-enabled the previously ignored webhook dedupe regression
   test.
 
+- **Replay-scoped `HARN_REPLAY` no longer races across concurrent
+  dispatches (harn#244).** Replay handlers still observe
+  `env_or("HARN_REPLAY", ...) == "1"` and replay-spawned subprocesses
+  still inherit `HARN_REPLAY=1`, but the runtime no longer flips the
+  process-global env var for the full async dispatch lifetime. Replay
+  detection is now scoped to the specific in-flight dispatch, so
+  overlapping replays and tests that pre-set `HARN_REPLAY` no longer
+  corrupt each other’s value restoration.
+
 - **Flaky cwd-mutating test collisions (#204).** Added a shared-process
   cwd mutex so parallel `cargo test` no longer observes mid-test cwd
   swaps. `check_manifest_reports_loaded_triggers` and

--- a/crates/harn-cli/tests/trigger_replay_cli.rs
+++ b/crates/harn-cli/tests/trigger_replay_cli.rs
@@ -108,6 +108,7 @@ pub fn on_issue(event: TriggerEvent) -> dict {
   return {
     event_id: event.id,
     replay_env: env("HARN_REPLAY"),
+    child_replay_env: shell("printf '%s' \"$HARN_REPLAY\"").stdout,
   }
 }
 "#,
@@ -136,6 +137,14 @@ pub fn on_issue(event: TriggerEvent) -> dict {
     );
     assert_eq!(
         report["drift"]["fields"]["result"]["replayed"]["replay_env"],
+        serde_json::json!("1")
+    );
+    assert_eq!(
+        report["drift"]["fields"]["result"]["original"]["child_replay_env"],
+        serde_json::Value::String(String::new())
+    );
+    assert_eq!(
+        report["drift"]["fields"]["result"]["replayed"]["child_replay_env"],
         serde_json::json!("1")
     );
 }

--- a/crates/harn-vm/src/stdlib/process.rs
+++ b/crates/harn-vm/src/stdlib/process.rs
@@ -7,6 +7,8 @@ use crate::orchestration::RunExecutionRecord;
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
+const HARN_REPLAY_ENV: &str = "HARN_REPLAY";
+
 thread_local! {
     pub(crate) static VM_SOURCE_DIR: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
     static VM_EXECUTION_CONTEXT: RefCell<Option<RunExecutionRecord>> = const { RefCell::new(None) };
@@ -53,6 +55,17 @@ pub fn asset_root_path() -> PathBuf {
     source_root_path()
 }
 
+fn env_override(name: &str) -> Option<String> {
+    (name == HARN_REPLAY_ENV && crate::triggers::dispatcher::current_dispatch_is_replay())
+        .then(|| "1".to_string())
+}
+
+fn read_env_value(name: &str) -> Option<String> {
+    env_override(name)
+        .or_else(|| current_execution_context().and_then(|context| context.env.get(name).cloned()))
+        .or_else(|| std::env::var(name).ok())
+}
+
 pub fn runtime_root_base() -> PathBuf {
     find_project_root(&execution_root_path())
         .or_else(|| find_project_root(&source_root_path()))
@@ -78,29 +91,19 @@ pub fn resolve_source_asset_path(path: &str) -> PathBuf {
 pub(crate) fn register_process_builtins(vm: &mut Vm) {
     vm.register_builtin("env", |args, _out| {
         let name = args.first().map(|a| a.display()).unwrap_or_default();
-        if let Some(value) =
-            current_execution_context().and_then(|context| context.env.get(&name).cloned())
-        {
+        if let Some(value) = read_env_value(&name) {
             return Ok(VmValue::String(Rc::from(value)));
         }
-        match std::env::var(&name) {
-            Ok(val) => Ok(VmValue::String(Rc::from(val))),
-            Err(_) => Ok(VmValue::Nil),
-        }
+        Ok(VmValue::Nil)
     });
 
     vm.register_builtin("env_or", |args, _out| {
         let name = args.first().map(|a| a.display()).unwrap_or_default();
         let default = args.get(1).cloned().unwrap_or(VmValue::Nil);
-        if let Some(value) =
-            current_execution_context().and_then(|context| context.env.get(&name).cloned())
-        {
+        if let Some(value) = read_env_value(&name) {
             return Ok(VmValue::String(Rc::from(value)));
         }
-        match std::env::var(&name) {
-            Ok(val) => Ok(VmValue::String(Rc::from(val))),
-            Err(_) => Ok(default),
-        }
+        Ok(default)
     });
 
     vm.register_builtin("timestamp", |_args, _out| {
@@ -428,6 +431,9 @@ fn apply_execution_context(command: &mut std::process::Command, dir: Option<&str
         if !context.env.is_empty() {
             command.envs(context.env);
         }
+    }
+    if let Some(value) = env_override(HARN_REPLAY_ENV) {
+        command.env(HARN_REPLAY_ENV, value);
     }
 }
 

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -1,9 +1,7 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::ffi::OsString;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::OnceLock;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -40,11 +38,13 @@ pub mod uri;
 
 pub use retry::{RetryPolicy, TriggerRetryConfig, DEFAULT_MAX_ATTEMPTS};
 
-const HARN_REPLAY_ENV: &str = "HARN_REPLAY";
-
 thread_local! {
     static ACTIVE_DISPATCHER_STATE: RefCell<Option<Arc<DispatcherRuntimeState>>> = const { RefCell::new(None) };
     static ACTIVE_DISPATCH_CONTEXT: RefCell<Option<DispatchContext>> = const { RefCell::new(None) };
+}
+
+tokio::task_local! {
+    static ACTIVE_DISPATCH_IS_REPLAY: bool;
 }
 
 #[derive(Clone, Debug)]
@@ -55,6 +55,12 @@ pub(crate) struct DispatchContext {
 
 pub(crate) fn current_dispatch_context() -> Option<DispatchContext> {
     ACTIVE_DISPATCH_CONTEXT.with(|slot| slot.borrow().clone())
+}
+
+pub(crate) fn current_dispatch_is_replay() -> bool {
+    ACTIVE_DISPATCH_IS_REPLAY
+        .try_with(|is_replay| *is_replay)
+        .unwrap_or(false)
 }
 
 #[derive(Clone)]
@@ -441,8 +447,11 @@ impl Dispatcher {
         event: TriggerEvent,
         replay_of_event_id: Option<String>,
     ) -> Result<DispatchOutcome, DispatchError> {
-        let _replay_guard = ReplayEnvGuard::enter(replay_of_event_id.is_some());
-        self.dispatch_with_replay_inner(binding, event, replay_of_event_id)
+        ACTIVE_DISPATCH_IS_REPLAY
+            .scope(
+                replay_of_event_id.is_some(),
+                self.dispatch_with_replay_inner(binding, event, replay_of_event_id),
+            )
             .await
     }
 
@@ -1382,65 +1391,6 @@ fn now_rfc3339() -> String {
     time::OffsetDateTime::now_utc()
         .format(&time::format_description::well_known::Rfc3339)
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
-}
-
-#[derive(Default)]
-struct ReplayEnvState {
-    depth: usize,
-    previous: Option<OsString>,
-}
-
-struct ReplayEnvGuard {
-    active: bool,
-}
-
-impl ReplayEnvGuard {
-    fn enter(active: bool) -> Self {
-        if !active {
-            return Self { active: false };
-        }
-
-        let lock = replay_env_state()
-            .lock()
-            .expect("replay env state mutex poisoned");
-        let mut state = lock;
-        if state.depth == 0 {
-            state.previous = std::env::var_os(HARN_REPLAY_ENV);
-            std::env::set_var(HARN_REPLAY_ENV, "1");
-        }
-        state.depth += 1;
-        drop(state);
-
-        Self { active: true }
-    }
-}
-
-impl Drop for ReplayEnvGuard {
-    fn drop(&mut self) {
-        if !self.active {
-            return;
-        }
-
-        let lock = replay_env_state()
-            .lock()
-            .expect("replay env state mutex poisoned");
-        let mut state = lock;
-        if state.depth > 0 {
-            state.depth -= 1;
-        }
-        if state.depth == 0 {
-            if let Some(previous) = state.previous.take() {
-                std::env::set_var(HARN_REPLAY_ENV, previous);
-            } else {
-                std::env::remove_var(HARN_REPLAY_ENV);
-            }
-        }
-    }
-}
-
-fn replay_env_state() -> &'static Mutex<ReplayEnvState> {
-    static STATE: OnceLock<Mutex<ReplayEnvState>> = OnceLock::new();
-    STATE.get_or_init(|| Mutex::new(ReplayEnvState::default()))
 }
 
 async fn sleep_or_cancel(

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -1,17 +1,10 @@
-// Replay tests serialize HARN_REPLAY env-var manipulation with a `Mutex<()>`
-// so parallel test runs don't race. That guard is intentionally held across
-// `.await` points while driving the dispatcher; silence clippy rather than
-// introduce an async-aware mutex whose only purpose is to guard env state.
-// Same pattern as `crates/harn-cli/tests/orchestrator_http.rs`.
-#![allow(clippy::await_holding_lock)]
-
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver};
 use std::sync::Arc;
-use std::sync::{Mutex, Once, OnceLock};
+use std::sync::Once;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -383,11 +376,6 @@ fn write_json_response<T: Write>(stream: &mut T, body: &serde_json::Value) {
     stream.flush().expect("flush mock A2A response");
 }
 
-fn replay_env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-}
-
 #[tokio::test(flavor = "current_thread")]
 async fn local_handler_round_trip_logs_outbox_lifecycle_and_action_graph() {
     let local = tokio::task::LocalSet::new();
@@ -664,15 +652,6 @@ pub fn local_fn(event: TriggerEvent) -> string {
 
 #[tokio::test(flavor = "current_thread")]
 async fn replay_dispatch_emits_replay_chain_edge_and_headers() {
-    // Every `dispatch_replay` call enters `ReplayEnvGuard`, which mutates the
-    // process-wide HARN_REPLAY env var. If two replay tests overlap, the
-    // guard's save/restore depth counter mishandles nested enters made
-    // concurrently by independent tests and the env var ends up set to
-    // whichever test dropped last rather than each test's own "previous"
-    // value. Hold the same `replay_env_lock` as
-    // `replay_dispatch_sets_harn_replay_env_and_restores_previous_value` to
-    // serialize every test that drives the replay path. See harn#244.
-    let _env_guard = replay_env_lock().lock().expect("env lock poisoned");
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
@@ -729,8 +708,7 @@ pub fn local_fn(event: TriggerEvent) -> dict {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn replay_dispatch_sets_harn_replay_env_and_restores_previous_value() {
-    let _env_guard = replay_env_lock().lock().expect("env lock poisoned");
+async fn replay_dispatch_scopes_harn_replay_per_dispatch_and_child_process() {
     std::env::set_var("HARN_REPLAY", "outer");
 
     let local = tokio::task::LocalSet::new();
@@ -740,8 +718,13 @@ async fn replay_dispatch_sets_harn_replay_env_and_restores_previous_value() {
                 r#"
 import "std/triggers"
 
-pub fn local_fn(event: TriggerEvent) -> string {
-  return env_or("HARN_REPLAY", "missing")
+pub fn local_fn(event: TriggerEvent) -> dict {
+  let child = shell("printf '%s' \"$HARN_REPLAY\"")
+  return {
+    replay_env: env_or("HARN_REPLAY", "missing"),
+    child_replay_env: child.stdout,
+    dedupe_key: event.dedupe_key,
+  }
 }
 "#,
                 "local_fn",
@@ -752,16 +735,52 @@ pub fn local_fn(event: TriggerEvent) -> string {
 
             let binding =
                 resolve_live_trigger_binding("github-new-issue", None).expect("resolve binding");
-            let outcome = dispatcher
-                .dispatch_replay(
-                    &binding,
-                    trigger_event("issues.opened", "delivery-env"),
-                    "event-original".to_string(),
-                )
-                .await
-                .expect("replay succeeds");
 
-            assert_eq!(outcome.result, Some(serde_json::json!("1")));
+            let first_dispatcher = dispatcher.clone();
+            let first_binding = binding.clone();
+            let first = tokio::task::spawn_local(async move {
+                first_dispatcher
+                    .dispatch_replay(
+                        &first_binding,
+                        trigger_event("issues.opened", "delivery-env-a"),
+                        "event-original-a".to_string(),
+                    )
+                    .await
+                    .expect("first replay succeeds")
+            });
+
+            let second_dispatcher = dispatcher.clone();
+            let second_binding = binding.clone();
+            let second = tokio::task::spawn_local(async move {
+                second_dispatcher
+                    .dispatch_replay(
+                        &second_binding,
+                        trigger_event("issues.opened", "delivery-env-b"),
+                        "event-original-b".to_string(),
+                    )
+                    .await
+                    .expect("second replay succeeds")
+            });
+
+            let first = first.await.expect("join first replay");
+            let second = second.await.expect("join second replay");
+
+            let mut dedupe_keys = Vec::new();
+            for outcome in [first, second] {
+                assert_eq!(outcome.status, DispatchStatus::Succeeded);
+                let result = outcome.result.expect("replay result");
+                assert_eq!(result["replay_env"], serde_json::json!("1"));
+                assert_eq!(result["child_replay_env"], serde_json::json!("1"));
+                dedupe_keys.push(
+                    result["dedupe_key"]
+                        .as_str()
+                        .expect("dedupe key")
+                        .to_string(),
+                );
+            }
+            dedupe_keys.sort();
+            assert_eq!(dedupe_keys, vec!["delivery-env-a", "delivery-env-b"]);
+
             assert_eq!(std::env::var("HARN_REPLAY").ok().as_deref(), Some("outer"));
         })
         .await;


### PR DESCRIPTION
## Summary

This fixes harn#244 by removing the process-global `HARN_REPLAY` guard from in-process replay dispatches.

The replay signal is now dispatch-scoped instead of process-scoped:

- replay dispatches run inside a Tokio task-local `is_replay` scope
- `env(...)` / `env_or(...)` return `"1"` for `HARN_REPLAY` when that scope is active
- `exec(...)` / `shell(...)` explicitly inject `HARN_REPLAY=1` into spawned child processes during replay dispatches
- the old `ReplayEnvGuard`, replay env depth tracking, `replay_env_lock()` test mutex, and the `#![allow(clippy::await_holding_lock)]` band-aid are gone

## Design Note

Picked **option 1: Tokio task-local + VM stdlib override**.

Why this option:

- It makes the in-process race structurally impossible by removing replay detection from shared process-global state.
- It preserves the public contract: handlers still see `env_or("HARN_REPLAY", ...) == "1"` during replay.
- It keeps subprocess semantics intact by setting `HARN_REPLAY=1` only at child-process spawn points, which is the part that actually depends on `envp` inheritance.
- It has a small enough surface area to land safely in this fix window without a broad VM plumbing refactor.

Why not the others in this change:

- **Option 2 (`serial_test`)** only hides test flakes and leaves production replays racy.
- **Option 3 (shared mutex guard)** still keeps `HARN_REPLAY` as process-global transport, so any out-of-band `std::env::set_var("HARN_REPLAY", ...)` can still corrupt behavior.
- **Option 4 (full dispatch context plumbing)** is attractive long-term, but it touches more runtime surface than was necessary to remove the race safely here.

## Root Cause

`dispatch_replay(...)` used an RAII `ReplayEnvGuard` that called `std::env::set_var` / `remove_var` around the full async dispatch lifetime. Because process env is global, overlapping replays and tests that manually pre-set `HARN_REPLAY` could interleave their save/restore bookkeeping and leave the env var in the wrong state.

## Validation

- `cargo test --package harn-vm --lib replay_dispatch` passed
- `cargo test --package harn-vm --lib replay_dispatch` looped 20x with default test thread count and passed 20/20
- `cargo test --package harn-cli --test trigger_replay_cli` passed
- `cargo run --bin harn -- test conformance --filter trigger_harness_replay` passed
- `make test` passed
- `cargo clippy --workspace --all-targets -- -D warnings` passed
- manual orchestrator check: fired two events into one temp state dir, replayed both concurrently, and both replay outputs showed `replay_env="1"` and `child_replay_env="1"`

## Checklist

- [x] Short design note explains the chosen option and why the others were not used here
- [x] `CHANGELOG.md` includes a `### Fixed` entry for harn#244
- [x] Band-aid removed: `replay_env_lock()` and its call sites are gone
- [x] `#![allow(clippy::await_holding_lock)]` removed from `dispatcher/tests.rs`
- [x] Replay-focused test loop passed 20x locally
- [x] `harn test conformance --filter trigger_harness_replay` stayed green
- [x] Subprocess inheritance verified via `crates/harn-cli/tests/trigger_replay_cli.rs`
