### PR TITLE
Fix trigger inbox shutdown race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,14 @@ granular archaeology.
   overlapping replays and tests that pre-set `HARN_REPLAY` no longer
   corrupt each other’s value restoration.
 
+- **Trigger inbox shutdown race could silently drop dequeued webhook
+  events (harn#241).** The dispatcher and orchestrator inbox pump no
+  longer detach `dispatch_inbox_envelope(...)` into fire-and-forget
+  local tasks during shutdown. Once an event is read from
+  `trigger.inbox`, drain now waits for that dispatch attempt to either
+  record its outbox outcome or observe cancellation instead of letting
+  SIGTERM exit with the envelope stranded between inbox and outbox.
+
 - **Flaky cwd-mutating test collisions (#204).** Added a shared-process
   cwd mutex so parallel `cargo test` no longer observes mid-test cwd
   swaps. `check_manifest_reports_loaded_triggers` and

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -601,9 +601,7 @@ fn spawn_inbox_pump(
             let envelope: harn_vm::triggers::dispatcher::InboxEnvelope =
                 serde_json::from_value(logged.payload)
                     .map_err(|error| format!("failed to decode dispatcher inbox event: {error}"))?;
-            tokio::task::spawn_local(async move {
-                let _ = dispatcher.dispatch_inbox_envelope(envelope).await;
-            });
+            let _ = dispatcher.dispatch_inbox_envelope(envelope).await;
             Ok(true)
         }
     })

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -41,6 +41,8 @@ pub use retry::{RetryPolicy, TriggerRetryConfig, DEFAULT_MAX_ATTEMPTS};
 thread_local! {
     static ACTIVE_DISPATCHER_STATE: RefCell<Option<Arc<DispatcherRuntimeState>>> = const { RefCell::new(None) };
     static ACTIVE_DISPATCH_CONTEXT: RefCell<Option<DispatchContext>> = const { RefCell::new(None) };
+    #[cfg(test)]
+    static TEST_INBOX_DEQUEUED_SIGNAL: RefCell<Option<tokio::sync::oneshot::Sender<()>>> = const { RefCell::new(None) };
 }
 
 tokio::task_local! {
@@ -327,10 +329,8 @@ impl Dispatcher {
                     }
                     let envelope: InboxEnvelope = serde_json::from_value(event.payload)
                         .map_err(|error| DispatchError::Serde(error.to_string()))?;
-                    let dispatcher = self.clone();
-                    tokio::task::spawn_local(async move {
-                        let _ = dispatcher.dispatch_inbox_envelope(envelope).await;
-                    });
+                    notify_test_inbox_dequeued();
+                    let _ = self.dispatch_inbox_envelope(envelope).await;
                 }
                 _ = recv_cancel(&mut cancel_rx) => break,
             }
@@ -1277,6 +1277,25 @@ fn decrement_retry_queue_depth(state: &DispatcherRuntimeState) {
     if previous == 1 && state.in_flight.load(Ordering::Relaxed) == 0 {
         state.idle_notify.notify_waiters();
     }
+}
+
+#[cfg(test)]
+fn install_test_inbox_dequeued_signal(tx: tokio::sync::oneshot::Sender<()>) {
+    TEST_INBOX_DEQUEUED_SIGNAL.with(|slot| {
+        *slot.borrow_mut() = Some(tx);
+    });
+}
+
+#[cfg(not(test))]
+fn notify_test_inbox_dequeued() {}
+
+#[cfg(test)]
+fn notify_test_inbox_dequeued() {
+    TEST_INBOX_DEQUEUED_SIGNAL.with(|slot| {
+        if let Some(tx) = slot.borrow_mut().take() {
+            let _ = tx.send(());
+        }
+    });
 }
 
 pub fn snapshot_dispatcher_stats() -> DispatcherStatsSnapshot {

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -11,6 +11,7 @@ use std::time::{Duration, Instant};
 use rcgen::generate_simple_self_signed;
 use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use rustls::{ServerConfig, ServerConnection, StreamOwned};
+use tokio::sync::oneshot;
 
 use crate::event_log::{install_default_for_base_dir, EventLog, Topic};
 use crate::register_vm_stdlib;
@@ -885,6 +886,66 @@ pub fn slow_handler(event: TriggerEvent) -> string {
             let outcomes = handle.await.expect("join local dispatch");
             assert_eq!(outcomes.len(), 1);
             assert_eq!(outcomes[0].status, DispatchStatus::Succeeded);
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn run_shutdown_does_not_silently_drop_dequeued_inbox_events() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (_dir, log, dispatcher) = dispatcher_fixture(
+                r#"
+import "std/triggers"
+
+pub fn wait_for_cancel(event: TriggerEvent) -> string {
+  while !is_cancelled() {
+    sleep(1)
+  }
+  return event.kind
+}
+"#,
+                "wait_for_cancel",
+                None,
+                TriggerRetryConfig::new(1, RetryPolicy::Linear { delay_ms: 0 }),
+            )
+            .await;
+
+            dispatcher
+                .enqueue(trigger_event("issues.opened", "delivery-run-shutdown"))
+                .await
+                .expect("enqueue succeeds");
+
+            let (dequeued_tx, dequeued_rx) = oneshot::channel();
+            super::install_test_inbox_dequeued_signal(dequeued_tx);
+
+            let run_dispatcher = dispatcher.clone();
+            let run_handle = tokio::task::spawn_local(async move {
+                run_dispatcher.run().await.expect("dispatcher run exits cleanly");
+            });
+
+            dequeued_rx.await.expect("run dequeued inbox event");
+            dispatcher.shutdown();
+            run_handle.await.expect("join dispatcher run");
+
+            let inbox = read_topic(log.clone(), "trigger.inbox").await;
+            assert_eq!(
+                inbox.iter()
+                    .filter(|(_, event)| event.kind == "event_ingested")
+                    .count(),
+                1
+            );
+
+            let outbox = read_topic(log.clone(), "trigger.outbox").await;
+            assert!(
+                outbox.iter().any(|(_, event)| event.kind == "dispatch_started"),
+                "dequeued inbox event must either stay queued or emit an explicit outbox outcome"
+            );
+            assert!(
+                outbox.iter().any(|(_, event)| event.kind == "dispatch_failed"),
+                "shutdown-triggered cancellation must be recorded instead of silently dropping the inbox event"
+            );
         })
         .await;
 }


### PR DESCRIPTION
## Summary
- stop detaching inbox envelope dispatches in the VM dispatcher loop and orchestrator inbox pump
- add a regression test that shuts the dispatcher down immediately after dequeueing an inbox event and asserts the event is recorded in outbox instead of disappearing
- document the harn#241 fix in the changelog

## Root cause
The inbox append path was already durable, but the inbox consumers were spawning fire-and-forget local tasks for `dispatch_inbox_envelope(...)`. During SIGTERM drain, the pump could treat the inbox event as handled and exit before that detached task ever wrote a `trigger.outbox` record. If the process exited in that window, the envelope was stranded between inbox and outbox.

## Behavior change
Once an event is dequeued from `trigger.inbox`, shutdown now waits for that dispatch attempt inline. The event either stays durably in inbox until it is processed, or it records an explicit dispatch outcome instead of being silently dropped.

## Validation
- `cargo test --package harn-vm --lib dispatcher`
- `cargo run --quiet --bin harn -- test conformance --filter trigger_harness`
- `make test`
