### PR TITLE
[codex] Stop auto-replaying stranded inbox entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ granular archaeology.
   `load_skill({ name })` tool now hydrates those bodies on demand from
   the same registry.
 
+- **Orchestrator restart no longer auto-replays stranded inbox envelopes
+  (harn#242, backward-incompatible).** `harn orchestrator serve` used to
+  silently re-dispatch historical `trigger.inbox` entries that had no
+  matching `trigger.outbox` history, which could re-fire webhook/a2a
+  handlers users never intended to replay. Restart now leaves those
+  envelopes stranded, surfaces them via `harn orchestrator queue`, emits
+  `orchestrator.lifecycle/startup_stranded_envelopes` with a count, and
+  requires an explicit `harn orchestrator recover --envelope-age <duration>`
+  flow (`--dry-run` to inspect, `--yes` to actually replay).
+
 - **Primary Harn docs site moved from `harn.burincode.com` to
   `harnlang.com`.** The burin-code-subdomain was always a stopgap;
   `harnlang.com` reflects Harn's identity as a standalone programming

--- a/conformance/tests/integration/orchestrator_recover_stranded_envelopes.expected
+++ b/conformance/tests/integration/orchestrator_recover_stranded_envelopes.expected
@@ -1,0 +1,3 @@
+true
+true
+true

--- a/conformance/tests/integration/orchestrator_recover_stranded_envelopes.harn
+++ b/conformance/tests/integration/orchestrator_recover_stranded_envelopes.harn
@@ -62,11 +62,9 @@ pipeline test(task) {
     path_join(root, "lib.harn"),
     "import \"std/triggers\"\n\npub fn on_task(event: TriggerEvent) -> string {\n  return event.kind\n}\n",
   )
-
   let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
   let harn_bin = resolve_harn_bin(repo_root)
   assert(file_exists(harn_bin), "missing built harn binary at " + harn_bin)
-
   let crash_start = shell_at(
     root,
     "nohup env HARN_SECRET_PROVIDERS=env HARN_EVENT_LOG_BACKEND=file HARN_ORCHESTRATOR_API_KEYS=test-key HARN_ORCHESTRATOR_HMAC_SECRET=shared-secret HARN_TEST_DISPATCHER_FAIL_BEFORE_OUTBOX=1 "
@@ -86,7 +84,6 @@ pipeline test(task) {
   },
   )
   println(response.status == 200 && wait_for_exit(crash_pid))
-
   let restart = shell_at(
     root,
     "nohup env HARN_SECRET_PROVIDERS=env HARN_EVENT_LOG_BACKEND=file HARN_ORCHESTRATOR_API_KEYS=test-key HARN_ORCHESTRATOR_HMAC_SECRET=shared-secret "
@@ -98,7 +95,6 @@ pipeline test(task) {
   let restart_url = wait_for_listener_url(path_join(root, "orchestrator-restart.log"))
   assert(restart_url != nil, "restart listener URL did not appear in log")
   sleep(500ms)
-
   let state_dir = path_join(root, "state")
   let config_path = path_join(root, "harn.toml")
   let queue = shell_at(
@@ -116,7 +112,6 @@ pipeline test(task) {
     && queue.stdout.contains("Stranded envelopes:")
     && !queue.stdout.contains("dispatch_succeeded"),
   )
-
   let recover = shell_at(
     root,
     "env HARN_EVENT_LOG_BACKEND=file "
@@ -133,7 +128,6 @@ pipeline test(task) {
     && recover.stdout.contains("Candidates:")
     && recover.stdout.contains("event_id=trigger_evt_"),
   )
-
   let _ = shell("kill -TERM " + restart_pid)
   wait_for_exit(restart_pid)
   delete_file(root)

--- a/conformance/tests/integration/orchestrator_recover_stranded_envelopes.harn
+++ b/conformance/tests/integration/orchestrator_recover_stranded_envelopes.harn
@@ -1,0 +1,140 @@
+fn wait_for_listener_url(log_path) {
+  var attempts = 0
+  var url = nil
+  while attempts < 300 && !url {
+    if file_exists(log_path) {
+      let log = exec("cat", log_path).stdout
+      let matches = regex_captures("\\[harn\\] HTTP listener ready on (\\S+)", log)
+      if len(matches) > 0 {
+        url = matches[0].groups[0]
+      }
+    }
+    if !url {
+      sleep(50ms)
+      attempts = attempts + 1
+    }
+  }
+  return url
+}
+
+fn wait_for_exit(pid) {
+  var attempts = 0
+  while attempts < 200 {
+    let probe = shell("kill -0 " + pid + " >/dev/null 2>&1")
+    if !probe.success {
+      return true
+    }
+    sleep(50ms)
+    attempts = attempts + 1
+  }
+  return false
+}
+
+fn first_group(pattern, text) {
+  let matches = regex_captures(pattern, text)
+  if len(matches) == 0 {
+    return nil
+  }
+  return matches[0].groups[0]
+}
+
+fn resolve_harn_bin(repo_root) {
+  let cargo_config = path_join(repo_root, ".cargo/config.toml")
+  if file_exists(cargo_config) {
+    let config = exec("cat", cargo_config).stdout
+    let configured = first_group("target-dir = \\\"([^\\\"]+)\\\"", config)
+    if configured {
+      return path_join(configured, "debug/harn")
+    }
+  }
+  let target_dir = env("CARGO_TARGET_DIR") ?? path_join(repo_root, "target")
+  return path_join(target_dir, "debug/harn")
+}
+
+pipeline test(task) {
+  let root = path_join(temp_dir(), "harn-orchestrator-recover-" + uuid())
+  mkdir(root)
+  write_file(
+    path_join(root, "harn.toml"),
+    "[package]\nname = \"fixture\"\n\n[exports]\nhandlers = \"lib.harn\"\n\n[[triggers]]\nid = \"incoming-review-task\"\nkind = \"a2a-push\"\nprovider = \"a2a-push\"\npath = \"/a2a/review\"\nmatch = { events = [\"a2a.task.received\"] }\nhandler = \"handlers::on_task\"\n",
+  )
+  write_file(
+    path_join(root, "lib.harn"),
+    "import \"std/triggers\"\n\npub fn on_task(event: TriggerEvent) -> string {\n  return event.kind\n}\n",
+  )
+
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let harn_bin = resolve_harn_bin(repo_root)
+  assert(file_exists(harn_bin), "missing built harn binary at " + harn_bin)
+
+  let crash_start = shell_at(
+    root,
+    "nohup env HARN_SECRET_PROVIDERS=env HARN_EVENT_LOG_BACKEND=file HARN_ORCHESTRATOR_API_KEYS=test-key HARN_ORCHESTRATOR_HMAC_SECRET=shared-secret HARN_TEST_DISPATCHER_FAIL_BEFORE_OUTBOX=1 "
+    + harn_bin
+    + " orchestrator serve --config harn.toml --state-dir ./state --role single-tenant --bind 127.0.0.1:0 >/dev/null 2>orchestrator-crash.log </dev/null & echo $!",
+  )
+  let crash_pid = crash_start.stdout.trim()
+  assert(crash_start.success && crash_pid != "", "failed to start crashing orchestrator")
+  let crash_url = wait_for_listener_url(path_join(root, "orchestrator-crash.log"))
+  assert(crash_url != nil, "crashing listener URL did not appear in log")
+  let response = http_request(
+    "POST",
+    crash_url + "/a2a/review",
+    {
+    body: "{\"kind\":\"a2a.task.received\",\"task\":{\"id\":\"task-242\"}}",
+    headers: {["Content-Type"]: "application/json", Authorization: "Bearer test-key"},
+  },
+  )
+  println(response.status == 200 && wait_for_exit(crash_pid))
+
+  let restart = shell_at(
+    root,
+    "nohup env HARN_SECRET_PROVIDERS=env HARN_EVENT_LOG_BACKEND=file HARN_ORCHESTRATOR_API_KEYS=test-key HARN_ORCHESTRATOR_HMAC_SECRET=shared-secret "
+    + harn_bin
+    + " orchestrator serve --config harn.toml --state-dir ./state --role single-tenant --bind 127.0.0.1:0 >/dev/null 2>orchestrator-restart.log </dev/null & echo $!",
+  )
+  let restart_pid = restart.stdout.trim()
+  assert(restart.success && restart_pid != "", "failed to restart orchestrator")
+  let restart_url = wait_for_listener_url(path_join(root, "orchestrator-restart.log"))
+  assert(restart_url != nil, "restart listener URL did not appear in log")
+  sleep(500ms)
+
+  let state_dir = path_join(root, "state")
+  let config_path = path_join(root, "harn.toml")
+  let queue = shell_at(
+    root,
+    "env HARN_EVENT_LOG_BACKEND=file "
+    + harn_bin
+    + " orchestrator queue --config "
+    + config_path
+    + " --state-dir "
+    + state_dir,
+  )
+  println(
+    queue.success
+    && queue.stdout.contains("stranded_envelopes=1")
+    && queue.stdout.contains("Stranded envelopes:")
+    && !queue.stdout.contains("dispatch_succeeded"),
+  )
+
+  let recover = shell_at(
+    root,
+    "env HARN_EVENT_LOG_BACKEND=file "
+    + harn_bin
+    + " orchestrator recover --config "
+    + config_path
+    + " --state-dir "
+    + state_dir
+    + " --envelope-age 0s --dry-run",
+  )
+  println(
+    recover.success
+    && recover.stdout.contains("stranded_envelopes=1")
+    && recover.stdout.contains("Candidates:")
+    && recover.stdout.contains("event_id=trigger_evt_"),
+  )
+
+  let _ = shell("kill -TERM " + restart_pid)
+  wait_for_exit(restart_pid)
+  delete_file(root)
+}

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration as StdDuration;
 
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
@@ -521,6 +522,8 @@ pub(crate) enum OrchestratorCommand {
     Dlq(OrchestratorDlqArgs),
     /// Inspect trigger and dispatch queues.
     Queue(OrchestratorQueueArgs),
+    /// Replay stranded inbox envelopes explicitly.
+    Recover(OrchestratorRecoverArgs),
 }
 
 #[derive(Debug, Args)]
@@ -619,6 +622,21 @@ pub(crate) struct OrchestratorQueueArgs {
 }
 
 #[derive(Debug, Args)]
+pub(crate) struct OrchestratorRecoverArgs {
+    #[command(flatten)]
+    pub local: OrchestratorLocalArgs,
+    /// Minimum stranded-envelope age required before replay/listing.
+    #[arg(long = "envelope-age", value_name = "DURATION", value_parser = parse_duration_arg)]
+    pub envelope_age: StdDuration,
+    /// List stranded envelopes without replaying them.
+    #[arg(long, default_value_t = false, action = ArgAction::SetTrue)]
+    pub dry_run: bool,
+    /// Confirm that stranded envelopes should actually be replayed.
+    #[arg(long, default_value_t = false, action = ArgAction::SetTrue)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Args)]
 pub(crate) struct PlaygroundArgs {
     /// Host module exporting the capabilities the script expects.
     #[arg(long, default_value = "host.harn")]
@@ -650,6 +668,41 @@ pub(crate) struct PlaygroundArgs {
     /// Re-run when the script or host module changes.
     #[arg(long)]
     pub watch: bool,
+}
+
+fn parse_duration_arg(raw: &str) -> Result<StdDuration, String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err("duration cannot be empty".to_string());
+    }
+
+    let (digits, unit) = raw
+        .chars()
+        .position(|ch| !ch.is_ascii_digit())
+        .map(|index| raw.split_at(index))
+        .ok_or_else(|| {
+            "duration must include a unit suffix like ms, s, m, h, d, or w".to_string()
+        })?;
+    if digits.is_empty() || unit.is_empty() {
+        return Err("duration must be formatted like 30s, 5m, 2h, or 7d".to_string());
+    }
+
+    let value = digits
+        .parse::<u64>()
+        .map_err(|error| format!("invalid duration '{raw}': {error}"))?;
+    match unit {
+        "ms" => Ok(StdDuration::from_millis(value)),
+        "s" => Ok(StdDuration::from_secs(value)),
+        "m" => Ok(StdDuration::from_secs(value.saturating_mul(60))),
+        "h" => Ok(StdDuration::from_secs(value.saturating_mul(60 * 60))),
+        "d" => Ok(StdDuration::from_secs(value.saturating_mul(60 * 60 * 24))),
+        "w" => Ok(StdDuration::from_secs(
+            value.saturating_mul(60 * 60 * 24 * 7),
+        )),
+        _ => Err(format!(
+            "unsupported duration unit '{unit}'; expected ms, s, m, h, d, or w"
+        )),
+    }
 }
 
 #[derive(Debug, Args)]
@@ -827,6 +880,7 @@ pub(crate) struct SkillsNewArgs {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::time::Duration as StdDuration;
 
     use super::{
         Cli, Command, McpCommand, OrchestratorCommand, ProjectTemplate, RunsCommand, SkillsCommand,
@@ -1186,6 +1240,34 @@ mod tests {
             panic!("expected orchestrator queue");
         };
         assert_eq!(queue.local.state_dir, PathBuf::from("state/orchestrator"));
+    }
+
+    #[test]
+    fn test_parses_orchestrator_recover_args() {
+        let cli = Cli::parse_from([
+            "harn",
+            "orchestrator",
+            "recover",
+            "--config",
+            "workspace/harn.toml",
+            "--state-dir",
+            "state/orchestrator",
+            "--envelope-age",
+            "15m",
+            "--dry-run",
+        ]);
+
+        let Command::Orchestrator(args) = cli.command.unwrap() else {
+            panic!("expected orchestrator command");
+        };
+        let OrchestratorCommand::Recover(recover) = args.command else {
+            panic!("expected orchestrator recover");
+        };
+        assert_eq!(recover.local.config, PathBuf::from("workspace/harn.toml"));
+        assert_eq!(recover.local.state_dir, PathBuf::from("state/orchestrator"));
+        assert_eq!(recover.envelope_age, StdDuration::from_secs(15 * 60));
+        assert!(recover.dry_run);
+        assert!(!recover.yes);
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/orchestrator/common.rs
+++ b/crates/harn-cli/src/commands/orchestrator/common.rs
@@ -226,7 +226,7 @@ pub(super) async fn stranded_envelopes(
     }
 
     let mut stranded = Vec::new();
-    for (offset, event) in envelopes.into_iter().chain(legacy_inbox.into_iter()) {
+    for (offset, event) in envelopes.into_iter().chain(legacy_inbox) {
         if event.kind != "event_ingested" {
             continue;
         }

--- a/crates/harn-cli/src/commands/orchestrator/common.rs
+++ b/crates/harn-cli/src/commands/orchestrator/common.rs
@@ -1,5 +1,7 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration as StdDuration;
 
 use harn_vm::event_log::{AnyEventLog, EventLog, LogEvent, Topic};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -73,6 +75,18 @@ pub(super) struct DlqEntryRecord {
     pub error: String,
     pub event: harn_vm::TriggerEvent,
     pub retry_history: Vec<DlqAttemptRecord>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct StrandedEnvelopeRecord {
+    pub inbox_offset: u64,
+    pub event_id: String,
+    pub trigger_id: Option<String>,
+    pub binding_version: Option<u32>,
+    pub provider: String,
+    pub kind: String,
+    pub received_at: OffsetDateTime,
+    pub age: StdDuration,
 }
 
 pub(super) async fn load_local_runtime(
@@ -188,6 +202,74 @@ pub(super) async fn read_topic(
         .map_err(|error| error.to_string())
 }
 
+pub(super) async fn stranded_envelopes(
+    log: &Arc<AnyEventLog>,
+    min_age: StdDuration,
+) -> Result<Vec<StrandedEnvelopeRecord>, String> {
+    let envelopes = read_topic(log, TRIGGER_INBOX_ENVELOPES_TOPIC).await?;
+    let legacy_inbox = read_topic(log, TRIGGER_INBOX_LEGACY_TOPIC).await?;
+    let outbox = read_topic(log, TRIGGER_OUTBOX_TOPIC).await?;
+
+    let mut any_outbox_event_ids = BTreeSet::new();
+    let mut outbox_by_event_id = BTreeMap::<String, BTreeSet<String>>::new();
+    for (_, event) in outbox {
+        let Some(event_id) = event.headers.get("event_id").cloned() else {
+            continue;
+        };
+        any_outbox_event_ids.insert(event_id.clone());
+        if let Some(trigger_id) = event.headers.get("trigger_id").cloned() {
+            outbox_by_event_id
+                .entry(event_id)
+                .or_default()
+                .insert(trigger_id);
+        }
+    }
+
+    let mut stranded = Vec::new();
+    for (offset, event) in envelopes.into_iter().chain(legacy_inbox.into_iter()) {
+        if event.kind != "event_ingested" {
+            continue;
+        }
+        let envelope: harn_vm::triggers::dispatcher::InboxEnvelope =
+            serde_json::from_value(event.payload)
+                .map_err(|error| format!("failed to decode trigger inbox envelope: {error}"))?;
+        let age = age_since(envelope.event.received_at);
+        if age < min_age {
+            continue;
+        }
+
+        let event_id = envelope.event.id.0.clone();
+        let matched_outbox = if let Some(trigger_id) = envelope.trigger_id.as_ref() {
+            outbox_by_event_id
+                .get(&event_id)
+                .is_some_and(|trigger_ids| trigger_ids.contains(trigger_id))
+        } else {
+            any_outbox_event_ids.contains(&event_id)
+        };
+        if matched_outbox {
+            continue;
+        }
+
+        stranded.push(StrandedEnvelopeRecord {
+            inbox_offset: offset,
+            event_id,
+            trigger_id: envelope.trigger_id,
+            binding_version: envelope.binding_version,
+            provider: envelope.event.provider.as_str().to_string(),
+            kind: envelope.event.kind,
+            received_at: envelope.event.received_at,
+            age,
+        });
+    }
+
+    stranded.sort_by(|left, right| {
+        left.received_at
+            .cmp(&right.received_at)
+            .then(left.event_id.cmp(&right.event_id))
+    });
+    Ok(stranded)
+}
+
 pub(super) async fn append_dlq_entry(
     log: &Arc<AnyEventLog>,
     entry: &DlqEntryRecord,
@@ -274,4 +356,37 @@ fn absolutize_from_cwd(path: &Path) -> Result<PathBuf, String> {
             .join(path)
     };
     Ok(candidate)
+}
+
+pub(super) fn format_timestamp(value: OffsetDateTime) -> String {
+    value.format(&Rfc3339).unwrap_or_else(|_| value.to_string())
+}
+
+pub(super) fn format_duration(value: StdDuration) -> String {
+    if value.as_secs() == 0 {
+        return format!("{}ms", value.as_millis());
+    }
+    let seconds = value.as_secs();
+    if seconds < 60 {
+        return format!("{seconds}s");
+    }
+    if seconds < 60 * 60 {
+        return format!("{}m", seconds / 60);
+    }
+    if seconds < 60 * 60 * 24 {
+        return format!("{}h", seconds / (60 * 60));
+    }
+    format!("{}d", seconds / (60 * 60 * 24))
+}
+
+fn age_since(then: OffsetDateTime) -> StdDuration {
+    let now = OffsetDateTime::now_utc();
+    if now <= then {
+        return StdDuration::ZERO;
+    }
+    let delta = now - then;
+    StdDuration::new(
+        delta.whole_seconds() as u64,
+        delta.subsec_nanoseconds().try_into().unwrap_or_default(),
+    )
 }

--- a/crates/harn-cli/src/commands/orchestrator/mod.rs
+++ b/crates/harn-cli/src/commands/orchestrator/mod.rs
@@ -5,6 +5,7 @@ mod inspect;
 mod listener;
 mod origin_guard;
 mod queue;
+mod recover;
 mod replay;
 pub(crate) mod role;
 mod serve;
@@ -20,5 +21,6 @@ pub(crate) async fn handle(args: OrchestratorArgs) -> Result<(), String> {
         OrchestratorCommand::Replay(replay_args) => replay::run(replay_args).await,
         OrchestratorCommand::Dlq(dlq_args) => dlq::run(dlq_args).await,
         OrchestratorCommand::Queue(queue_args) => queue::run(queue_args).await,
+        OrchestratorCommand::Recover(recover_args) => recover::run(recover_args).await,
     }
 }

--- a/crates/harn-cli/src/commands/orchestrator/queue.rs
+++ b/crates/harn-cli/src/commands/orchestrator/queue.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 use crate::cli::OrchestratorQueueArgs;
 
 use super::common::{
-    load_local_runtime, read_topic, TRIGGER_ATTEMPTS_TOPIC, TRIGGER_INBOX_CLAIMS_TOPIC,
-    TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC, TRIGGER_OUTBOX_TOPIC,
+    format_duration, format_timestamp, load_local_runtime, read_topic, stranded_envelopes,
+    TRIGGER_ATTEMPTS_TOPIC, TRIGGER_INBOX_CLAIMS_TOPIC, TRIGGER_INBOX_ENVELOPES_TOPIC,
+    TRIGGER_INBOX_LEGACY_TOPIC, TRIGGER_OUTBOX_TOPIC,
 };
 
 pub(super) async fn run(args: OrchestratorQueueArgs) -> Result<(), String> {
@@ -16,6 +17,7 @@ pub(super) async fn run(args: OrchestratorQueueArgs) -> Result<(), String> {
     let claim_events = read_topic(&ctx.event_log, TRIGGER_INBOX_CLAIMS_TOPIC).await?;
     let envelope_events = read_topic(&ctx.event_log, TRIGGER_INBOX_ENVELOPES_TOPIC).await?;
     let legacy_inbox_events = read_topic(&ctx.event_log, TRIGGER_INBOX_LEGACY_TOPIC).await?;
+    let stranded = stranded_envelopes(&ctx.event_log, std::time::Duration::ZERO).await?;
 
     let mut started = BTreeSet::new();
     let mut finished = BTreeSet::new();
@@ -70,6 +72,7 @@ pub(super) async fn run(args: OrchestratorQueueArgs) -> Result<(), String> {
     );
     println!("- inferred_in_flight={}", in_flight.len());
     println!("- inferred_pending_retries={}", pending_retries.len());
+    println!("- stranded_envelopes={}", stranded.len());
     println!("- inbox_claims_written={}", inbox_claims_written);
     println!("- inbox_envelopes_written={}", inbox_envelopes_written);
     println!(
@@ -107,6 +110,29 @@ pub(super) async fn run(args: OrchestratorQueueArgs) -> Result<(), String> {
     } else {
         for key in pending_retries {
             println!("- {key}");
+        }
+    }
+
+    println!();
+    println!("Stranded envelopes:");
+    if stranded.is_empty() {
+        println!("- none");
+    } else {
+        for envelope in stranded {
+            println!(
+                "- event_id={} trigger_id={} binding_version={} provider={} kind={} age={} received_at={} inbox_offset={}",
+                envelope.event_id,
+                envelope.trigger_id.as_deref().unwrap_or("-"),
+                envelope
+                    .binding_version
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+                envelope.provider,
+                envelope.kind,
+                format_duration(envelope.age),
+                format_timestamp(envelope.received_at),
+                envelope.inbox_offset,
+            );
         }
     }
 

--- a/crates/harn-cli/src/commands/orchestrator/recover.rs
+++ b/crates/harn-cli/src/commands/orchestrator/recover.rs
@@ -1,0 +1,68 @@
+use crate::cli::OrchestratorRecoverArgs;
+
+use super::common::{
+    format_duration, format_timestamp, load_local_runtime, stranded_envelopes, trigger_replay,
+};
+
+pub(super) async fn run(args: OrchestratorRecoverArgs) -> Result<(), String> {
+    if !args.dry_run && !args.yes {
+        return Err(
+            "refusing to replay stranded envelopes without --yes; pass --dry-run to inspect first"
+                .to_string(),
+        );
+    }
+
+    let mut ctx = load_local_runtime(&args.local).await?;
+    let stranded = stranded_envelopes(&ctx.event_log, args.envelope_age).await?;
+
+    println!("Recovery:");
+    println!("- dry_run={}", args.dry_run);
+    println!("- min_envelope_age={}", format_duration(args.envelope_age));
+    println!("- stranded_envelopes={}", stranded.len());
+
+    println!();
+    println!("Candidates:");
+    if stranded.is_empty() {
+        println!("- none");
+        return Ok(());
+    }
+
+    for envelope in &stranded {
+        println!(
+            "- event_id={} trigger_id={} binding_version={} provider={} kind={} age={} received_at={} inbox_offset={}",
+            envelope.event_id,
+            envelope.trigger_id.as_deref().unwrap_or("-"),
+            envelope
+                .binding_version
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            envelope.provider,
+            envelope.kind,
+            format_duration(envelope.age),
+            format_timestamp(envelope.received_at),
+            envelope.inbox_offset,
+        );
+    }
+
+    if args.dry_run {
+        return Ok(());
+    }
+
+    println!();
+    println!("Replay results:");
+    for envelope in stranded {
+        let handle = trigger_replay(&mut ctx, &envelope.event_id).await?;
+        println!(
+            "- event_id={} status={} replay_of_event_id={} binding_id={} binding_version={} dlq_entry_id={} error={}",
+            handle.event_id,
+            handle.status,
+            handle.replay_of_event_id.as_deref().unwrap_or("-"),
+            handle.binding_id,
+            handle.binding_version,
+            handle.dlq_entry_id.as_deref().unwrap_or("-"),
+            handle.error.as_deref().unwrap_or("-"),
+        );
+    }
+
+    Ok(())
+}

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -14,6 +14,7 @@ use tokio::sync::watch;
 
 use harn_vm::event_log::{ConsumerId, EventLog};
 
+use super::common::stranded_envelopes;
 use super::listener::{ListenerConfig, ListenerRuntime, RouteConfig, TriggerMetricSnapshot};
 use super::origin_guard::OriginAllowList;
 use super::role::OrchestratorRole;
@@ -202,6 +203,22 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
             "shutdown_timeout_secs": shutdown_timeout.as_secs(),
             "drain_max_items": drain_config.max_items,
             "drain_deadline_secs": drain_config.deadline.as_secs(),
+        }),
+    )
+    .await?;
+
+    let stranded = stranded_envelopes(&event_log, Duration::ZERO).await?;
+    if !stranded.is_empty() {
+        eprintln!(
+            "[harn] startup found {} stranded inbox envelope(s); inspect with `harn orchestrator queue` and recover explicitly with `harn orchestrator recover --dry-run --envelope-age ...`",
+            stranded.len()
+        );
+    }
+    append_lifecycle_event(
+        &event_log,
+        "startup_stranded_envelopes",
+        json!({
+            "count": stranded.len(),
         }),
     )
     .await?;

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, Output, Stdio};
 use std::sync::mpsc::{self, Receiver};
 use std::sync::Arc;
 use std::thread;
@@ -127,6 +127,22 @@ fn send_sigterm(child: &Child) {
     assert!(status.success(), "kill exited with {status}");
 }
 
+fn wait_for_exit_code(child: &mut Child, expected: i32) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if let Some(status) = child.try_wait().unwrap() {
+            assert_eq!(
+                status.code(),
+                Some(expected),
+                "unexpected exit status: {status}"
+            );
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!("timed out waiting for orchestrator exit");
+}
+
 fn wait_for_exit(child: &mut Child) {
     let deadline = Instant::now() + Duration::from_secs(15);
     while Instant::now() < deadline {
@@ -160,6 +176,23 @@ fn bearer_headers() -> HeaderMap {
     let mut headers = json_headers();
     headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer test-key"));
     headers
+}
+
+fn run_harn_with_env(temp: &TempDir, args: &[&str], envs: &[(&str, &str)]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_harn"));
+    command.current_dir(temp.path()).args(args);
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    command.output().unwrap()
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
 }
 
 fn read_topic_events(
@@ -618,5 +651,199 @@ pub fn on_task(event: TriggerEvent) -> string {
     assert_eq!(
         sqlite_event_count(&state_dir, "trigger.outbox", "dispatch_succeeded"),
         5000
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restart_surfaces_stranded_envelopes_and_recover_replays_them_explicitly() {
+    let temp = TempDir::new().unwrap();
+    write_file(
+        temp.path(),
+        "harn.toml",
+        r#"
+[package]
+name = "fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "incoming-review-task"
+kind = "a2a-push"
+provider = "a2a-push"
+path = "/a2a/review"
+match = { events = ["a2a.task.received"] }
+handler = "handlers::on_task"
+"#,
+    );
+    write_file(
+        temp.path(),
+        "lib.harn",
+        r#"
+import "std/triggers"
+
+pub fn on_task(event: TriggerEvent) -> string {
+  return event.kind
+}
+"#,
+    );
+
+    let envs = [
+        ("HARN_EVENT_LOG_BACKEND", "file"),
+        ("HARN_ORCHESTRATOR_API_KEYS", "test-key"),
+        ("HARN_ORCHESTRATOR_HMAC_SECRET", "unused-shared-secret"),
+        ("HARN_TEST_DISPATCHER_FAIL_BEFORE_OUTBOX", "1"),
+    ];
+    let (mut crashing_child, crashing_rx, crashing_handle) =
+        spawn_orchestrator_with(&temp, &[], &envs);
+    let base_url = wait_for_listener_url(&mut crashing_child, &crashing_rx);
+
+    let body = br#"{"kind":"a2a.task.received","task":{"id":"task-242"}}"#;
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/a2a/review"))
+        .headers(bearer_headers())
+        .body(body.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    wait_for_exit_code(&mut crashing_child, 86);
+    let crashing_stderr = crashing_handle.join().expect("stderr collector thread");
+    assert!(
+        crashing_stderr.contains("registered connectors (1): a2a-push"),
+        "stderr={crashing_stderr}"
+    );
+
+    let restart_envs = [
+        ("HARN_EVENT_LOG_BACKEND", "file"),
+        ("HARN_ORCHESTRATOR_API_KEYS", "test-key"),
+        ("HARN_ORCHESTRATOR_HMAC_SECRET", "unused-shared-secret"),
+    ];
+    let (mut restarted_child, restarted_rx, restarted_handle) =
+        spawn_orchestrator_with(&temp, &[], &restart_envs);
+    wait_for_listener_url(&mut restarted_child, &restarted_rx);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let state_dir = temp.path().join("state");
+    let lifecycle = read_topic_events(&state_dir, "orchestrator.lifecycle");
+    assert!(lifecycle.iter().any(|(_, event)| {
+        event.kind == "startup_stranded_envelopes" && event.payload["count"] == serde_json::json!(1)
+    }));
+
+    let queue = run_harn_with_env(
+        &temp,
+        &[
+            "orchestrator",
+            "queue",
+            "--config",
+            "harn.toml",
+            "--state-dir",
+            "./state",
+        ],
+        &[("HARN_EVENT_LOG_BACKEND", "file")],
+    );
+    assert!(
+        queue.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        queue.status.code(),
+        stdout(&queue),
+        stderr(&queue)
+    );
+    assert!(stdout(&queue).contains("stranded_envelopes=1"));
+
+    let recover_without_yes = run_harn_with_env(
+        &temp,
+        &[
+            "orchestrator",
+            "recover",
+            "--config",
+            "harn.toml",
+            "--state-dir",
+            "./state",
+            "--envelope-age",
+            "0s",
+        ],
+        &[("HARN_EVENT_LOG_BACKEND", "file")],
+    );
+    assert!(!recover_without_yes.status.success());
+    assert!(stderr(&recover_without_yes).contains("without --yes"));
+
+    let dry_run = run_harn_with_env(
+        &temp,
+        &[
+            "orchestrator",
+            "recover",
+            "--config",
+            "harn.toml",
+            "--state-dir",
+            "./state",
+            "--envelope-age",
+            "0s",
+            "--dry-run",
+        ],
+        &[("HARN_EVENT_LOG_BACKEND", "file")],
+    );
+    assert!(
+        dry_run.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        dry_run.status.code(),
+        stdout(&dry_run),
+        stderr(&dry_run)
+    );
+    assert!(stdout(&dry_run).contains("stranded_envelopes=1"));
+    assert!(stdout(&dry_run).contains("event_id=trigger_evt_"));
+
+    let recover = run_harn_with_env(
+        &temp,
+        &[
+            "orchestrator",
+            "recover",
+            "--config",
+            "harn.toml",
+            "--state-dir",
+            "./state",
+            "--envelope-age",
+            "0s",
+            "--yes",
+        ],
+        &[("HARN_EVENT_LOG_BACKEND", "file")],
+    );
+    assert!(
+        recover.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        recover.status.code(),
+        stdout(&recover),
+        stderr(&recover)
+    );
+    assert!(stdout(&recover).contains("status=dispatched"));
+
+    let queue_after = run_harn_with_env(
+        &temp,
+        &[
+            "orchestrator",
+            "queue",
+            "--config",
+            "harn.toml",
+            "--state-dir",
+            "./state",
+        ],
+        &[("HARN_EVENT_LOG_BACKEND", "file")],
+    );
+    assert!(
+        queue_after.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        queue_after.status.code(),
+        stdout(&queue_after),
+        stderr(&queue_after)
+    );
+    assert!(stdout(&queue_after).contains("stranded_envelopes=0"));
+
+    send_sigterm(&restarted_child);
+    wait_for_exit(&mut restarted_child);
+    let restarted_stderr = restarted_handle.join().expect("stderr collector thread");
+    assert!(
+        restarted_stderr.contains(SHUTDOWN_NEEDLE),
+        "stderr={restarted_stderr}"
     );
 }

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -196,7 +196,7 @@ async fn dispatch_trigger_event(
 }
 
 async fn replay_trigger_event(event_id: &str) -> Result<VmValue, VmError> {
-    let record = find_recorded_event(event_id).await?;
+    let record = find_replayable_event(event_id).await?;
     let received_at = record.event.received_at;
     dispatch_trigger_event(
         record.binding_id,
@@ -323,7 +323,14 @@ async fn dispatch_handle_from_outcome(
     }
 }
 
-async fn find_recorded_event(event_id: &str) -> Result<TriggerEventRecord, VmError> {
+async fn find_replayable_event(event_id: &str) -> Result<TriggerEventRecord, VmError> {
+    if let Some(record) = find_recorded_event(event_id).await? {
+        return Ok(record);
+    }
+    find_ingested_event(event_id).await
+}
+
+async fn find_recorded_event(event_id: &str) -> Result<Option<TriggerEventRecord>, VmError> {
     let log = ensure_trigger_event_log();
     let topic = Topic::new(TRIGGER_EVENTS_TOPIC)
         .map_err(|error| VmError::Runtime(format!("trigger_replay: {error}")))?;
@@ -331,11 +338,47 @@ async fn find_recorded_event(event_id: &str) -> Result<TriggerEventRecord, VmErr
         .read_range(&topic, None, usize::MAX)
         .await
         .map_err(|error| VmError::Runtime(format!("trigger_replay: {error}")))?;
-    events
+    Ok(events
         .into_iter()
         .filter_map(|(_, event)| serde_json::from_value::<TriggerEventRecord>(event.payload).ok())
+        .find(|record| record.event.id.0 == event_id))
+}
+
+async fn find_ingested_event(event_id: &str) -> Result<TriggerEventRecord, VmError> {
+    let log = ensure_trigger_event_log();
+    let envelopes_topic = Topic::new(crate::triggers::TRIGGER_INBOX_ENVELOPES_TOPIC)
+        .map_err(|error| VmError::Runtime(format!("trigger_replay: {error}")))?;
+    let legacy_topic = Topic::new(crate::triggers::TRIGGER_INBOX_LEGACY_TOPIC)
+        .map_err(|error| VmError::Runtime(format!("trigger_replay: {error}")))?;
+    let mut events = log
+        .read_range(&envelopes_topic, None, usize::MAX)
+        .await
+        .map_err(|error| VmError::Runtime(format!("trigger_replay: {error}")))?;
+    let legacy_events = log
+        .read_range(&legacy_topic, None, usize::MAX)
+        .await
+        .map_err(|error| VmError::Runtime(format!("trigger_replay: {error}")))?;
+    events.extend(legacy_events);
+    events
+        .into_iter()
+        .filter_map(|(_, event)| {
+            if event.kind != "event_ingested" {
+                return None;
+            }
+            let envelope =
+                serde_json::from_value::<crate::triggers::dispatcher::InboxEnvelope>(event.payload)
+                    .ok()?;
+            let binding_id = envelope.trigger_id?;
+            let binding_version = envelope.binding_version?;
+            Some(TriggerEventRecord {
+                binding_id,
+                binding_version,
+                replay_of_event_id: None,
+                event: envelope.event,
+            })
+        })
         .find(|record| record.event.id.0 == event_id)
-        .ok_or_else(|| VmError::Runtime(format!("trigger_replay: unknown event id '{}'", event_id)))
+        .ok_or_else(|| VmError::Runtime(format!("trigger_replay: unknown event id '{event_id}'")))
 }
 
 async fn inspect_dlq_entries() -> Result<Vec<DlqEntryRecord>, VmError> {

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -313,7 +313,12 @@ impl Dispatcher {
     pub async fn run(&self) -> Result<(), DispatchError> {
         let topic = Topic::new(TRIGGER_INBOX_ENVELOPES_TOPIC)
             .expect("static trigger inbox envelopes topic is valid");
-        let stream = self.event_log.clone().subscribe(&topic, None).await?;
+        let start_from = self.event_log.latest(&topic).await?;
+        let stream = self
+            .event_log
+            .clone()
+            .subscribe(&topic, start_from)
+            .await?;
         pin_mut!(stream);
         let mut cancel_rx = self.cancel_tx.subscribe();
 
@@ -606,6 +611,7 @@ impl Dispatcher {
         let mut previous_retry_node = None;
         let max_attempts = binding.retry.max_attempts();
         for attempt in 1..=max_attempts {
+            maybe_fail_before_outbox();
             let started_at = now_rfc3339();
             let attempt_node_id = dispatch_node_id(&route, &binding_key, &event.id.0, attempt);
             self.append_lifecycle_event(
@@ -1412,6 +1418,14 @@ fn event_headers(
         headers.insert("attempt".to_string(), attempt.to_string());
     }
     headers
+}
+
+const TEST_FAIL_BEFORE_OUTBOX_ENV: &str = "HARN_TEST_DISPATCHER_FAIL_BEFORE_OUTBOX";
+
+fn maybe_fail_before_outbox() {
+    if std::env::var_os(TEST_FAIL_BEFORE_OUTBOX_ENV).is_some() {
+        std::process::exit(86);
+    }
 }
 
 fn now_rfc3339() -> String {

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -986,6 +986,83 @@ pub fn wait_for_cancel(event: TriggerEvent) -> string {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn run_skips_historical_inbox_entries_on_startup() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (_dir, log, dispatcher) = dispatcher_fixture(
+                r#"
+import "std/triggers"
+
+pub fn local_fn(event: TriggerEvent) -> string {
+  return event.kind
+}
+"#,
+                "local_fn",
+                None,
+                TriggerRetryConfig::default(),
+            )
+            .await;
+
+            let historical = trigger_event("issues.opened", "delivery-historical");
+            dispatcher
+                .enqueue_targeted(
+                    Some("github-new-issue".to_string()),
+                    Some(1),
+                    historical.clone(),
+                )
+                .await
+                .expect("enqueue historical inbox entry");
+
+            let dispatcher_for_task = dispatcher.clone();
+            let run_task = tokio::task::spawn_local(async move {
+                dispatcher_for_task
+                    .run()
+                    .await
+                    .expect("dispatcher run exits");
+            });
+
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            let outbox_before = read_topic(log.clone(), "trigger.outbox").await;
+            assert!(
+                outbox_before.is_empty(),
+                "startup should not auto-dispatch historical inbox entries: {outbox_before:?}"
+            );
+
+            let live = trigger_event("issues.opened", "delivery-live");
+            dispatcher
+                .enqueue_targeted(Some("github-new-issue".to_string()), Some(1), live.clone())
+                .await
+                .expect("enqueue live inbox entry");
+
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while Instant::now() < deadline {
+                let outbox = read_topic(log.clone(), "trigger.outbox").await;
+                if outbox.iter().any(|(_, event)| {
+                    event.headers.get("event_id").map(String::as_str) == Some(live.id.0.as_str())
+                        && event.kind == "dispatch_succeeded"
+                }) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+
+            dispatcher.shutdown();
+            run_task.await.expect("join dispatcher run task");
+
+            let outbox = read_topic(log.clone(), "trigger.outbox").await;
+            assert!(!outbox.iter().any(|(_, event)| {
+                event.headers.get("event_id").map(String::as_str) == Some(historical.id.0.as_str())
+            }));
+            assert!(outbox.iter().any(|(_, event)| {
+                event.headers.get("event_id").map(String::as_str) == Some(live.id.0.as_str())
+                    && event.kind == "dispatch_succeeded"
+            }));
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn drain_waits_for_in_flight_local_handlers_without_cancelling() {
     let local = tokio::task::LocalSet::new();
     local

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -18,8 +18,6 @@ Current limitations:
 
 - `multi-tenant` returns a clear not-implemented error that points at
   `O-12 #190`
-- `inspect`, `replay`, `dlq`, and `queue` are placeholders for
-  `O-08 #185`
 
 ## Command
 
@@ -42,6 +40,18 @@ SIGTERM, it stops accepting new requests, lets in-flight requests drain,
 appends lifecycle events to the EventLog, and persists a final
 `orchestrator-state.json` snapshot under `--state-dir`.
 
+Startup no longer replays old `trigger.inbox` entries automatically.
+If the previous process died after writing an inbox envelope but before
+writing any matching `trigger.outbox` record, the restarted orchestrator
+surfaces those envelopes instead of silently re-firing them:
+
+- `harn orchestrator queue` shows a `stranded_envelopes=<count>` summary
+  plus a `Stranded envelopes:` section with the event ids, bindings, and
+  ages.
+- `orchestrator.lifecycle` records a
+  `startup_stranded_envelopes` event with a `count` payload.
+- Recovery is explicit via `harn orchestrator recover`.
+
 `--manifest` is an alias for `--config`, and `--listen` is an alias for
 `--bind`. Container deployments can also configure those through
 `HARN_ORCHESTRATOR_MANIFEST`, `HARN_ORCHESTRATOR_LISTEN`,
@@ -61,6 +71,37 @@ binding version. The orchestrator records `reload_succeeded` /
 Current reload scope is intentionally narrow: listener-wide settings
 such as `--bind`, TLS files, `allowed_origins`, `max_body_bytes`, and
 connector-managed trigger changes still require a full restart.
+
+## Recovery
+
+Use `recover` to inspect or replay stranded inbox envelopes explicitly.
+
+```bash
+harn orchestrator recover \
+  --config harn.toml \
+  --state-dir ./.harn/orchestrator \
+  --envelope-age 5m \
+  --dry-run
+```
+
+`--envelope-age` is required so recovery stays scoped to envelopes older
+than the threshold you choose. Supported suffixes are `ms`, `s`, `m`,
+`h`, `d`, and `w`.
+
+`--dry-run` lists candidates only. To actually replay them, rerun the
+command without `--dry-run` and add `--yes`:
+
+```bash
+harn orchestrator recover \
+  --config harn.toml \
+  --state-dir ./.harn/orchestrator \
+  --envelope-age 5m \
+  --yes
+```
+
+Recovery reuses the normal `trigger_replay(...)` path, so replayed
+envelopes still flow through the dispatcher's retry policy and DLQ
+handling instead of using a special bypass path.
 
 ## HTTP Listener
 


### PR DESCRIPTION
## Summary
- stop startup from auto-replaying historical `trigger.inbox` entries and surface stranded envelopes via `harn orchestrator queue` plus `orchestrator.lifecycle/startup_stranded_envelopes`
- add explicit `harn orchestrator recover --envelope-age <duration> [--dry-run] [--yes]` recovery flow on top of `trigger_replay(...)`, including replay fallback for inbox-backed events
- document the backward-incompatible restart behavior change and cover it with dispatcher, CLI, and conformance tests

## Root Cause
The orchestrator previously treated inbox entries with no matching outbox history as implicit crash recovery work and silently re-fired them on restart. That replay path could re-trigger non-idempotent webhook handlers that users never intended to replay.

## Validation
- `cargo test --package harn-vm --lib dispatcher`
- `cargo test --package harn-cli`
- `cargo run --bin harn -- test conformance --filter orchestrator_recover_stranded_envelopes`
