### PR TITLE
[codex] Bound orchestrator pump drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,16 @@ granular archaeology.
   record its outbox outcome or observe cancellation instead of letting
   SIGTERM exit with the envelope stranded between inbox and outbox.
 
+- **Bounded orchestrator pump drain on shutdown (harn#240).** The
+  orchestrator no longer tries to drain an unbounded pending/cron/inbox
+  backlog during SIGTERM/SIGINT. `harn orchestrator serve` now applies a
+  configurable per-pump shutdown bound from
+  `[orchestrator].drain.{max_items,deadline_seconds}` or
+  `--drain-max-items` / `--drain-deadline`, emits
+  `orchestrator.lifecycle` `drain_truncated` when backlog remains, and
+  resumes truncated pump backlog on the next start from a durable pump
+  cursor instead of skipping pre-existing source-topic events.
+
 - **Flaky cwd-mutating test collisions (#204).** Added a shared-process
   cwd mutex so parallel `cargo test` no longer observes mid-test cwd
   swaps. `check_manifest_reports_loaded_triggers` and

--- a/conformance/tests/integration/orchestrator_bounded_drain_resume.expected
+++ b/conformance/tests/integration/orchestrator_bounded_drain_resume.expected
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+true

--- a/conformance/tests/integration/orchestrator_bounded_drain_resume.harn
+++ b/conformance/tests/integration/orchestrator_bounded_drain_resume.harn
@@ -1,0 +1,208 @@
+import "../_common"
+
+pipeline default() {
+  let unique = uuid()
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let base = path_join(temp_dir(), "harn-orchestrator-bounded-drain-" + unique)
+  let workspace = path_join(base, "workspace")
+  let state_dir = path_join(base, "state")
+  let binary = env_or("HARN_CONFORMANCE_HARN_BIN", resolve_harn_bin(repo_root))
+  assert(file_exists(binary), "missing built harn binary at " + binary)
+  let script = """
+    set -eu
+
+    base="${base}"
+    workspace="${workspace}"
+    state_dir="${state_dir}"
+    binary="${binary}"
+
+    mkdir -p "$workspace" "$state_dir"
+
+    cat > "$workspace/harn.toml" <<'EOF'
+    [package]
+    name = "orchestrator_bounded_drain_resume"
+
+    [exports]
+    handlers = "lib.harn"
+
+    [[triggers]]
+    id = "incoming-review-task"
+    kind = "a2a-push"
+    provider = "a2a-push"
+    path = "/a2a/review"
+    match = { events = ["a2a.task.received"] }
+    handler = "handlers::on_task"
+    EOF
+
+    cat > "$workspace/lib.harn" <<'EOF'
+    import "std/triggers"
+
+    pub fn on_task(event: TriggerEvent) -> string {
+      return event.kind
+    }
+    EOF
+
+    python3 - "$workspace" "$state_dir" "$binary" <<'PY'
+    import glob
+    import http.client
+    import json
+    import os
+    import pathlib
+    import signal
+    import sqlite3
+    import subprocess
+    import sys
+    import time
+
+    workspace, state_dir, binary = sys.argv[1:]
+    base = pathlib.Path(workspace).parent
+    snapshot_path = pathlib.Path(state_dir) / "orchestrator-state.json"
+    sqlite_candidates = glob.glob(str(pathlib.Path(state_dir) / "**" / "*.sqlite"), recursive=True)
+    sqlite_path = pathlib.Path(sqlite_candidates[0]) if sqlite_candidates else pathlib.Path(state_dir) / "events.sqlite"
+
+    common_env = {
+        "HARN_ORCHESTRATOR_API_KEYS": "test-key",
+        "HARN_ORCHESTRATOR_HMAC_SECRET": "bounded-drain-secret",
+        "HARN_EVENT_LOG_QUEUE_DEPTH": "8192",
+    }
+    extra_args = [
+        "orchestrator",
+        "serve",
+        "--config",
+        "harn.toml",
+        "--state-dir",
+        str(pathlib.Path(state_dir)),
+        "--bind",
+        "127.0.0.1:0",
+        "--role",
+        "single-tenant",
+        "--shutdown-timeout",
+        "5",
+        "--drain-max-items",
+        "100",
+        "--drain-deadline",
+        "1",
+    ]
+
+    def start(delay_ms, log_name):
+        env = os.environ.copy()
+        env.update(common_env)
+        if delay_ms is not None:
+            env["HARN_TEST_ORCHESTRATOR_PUMP_DELAY_MS"] = str(delay_ms)
+        else:
+            env.pop("HARN_TEST_ORCHESTRATOR_PUMP_DELAY_MS", None)
+        log = open(base / log_name, "w", encoding="utf-8")
+        proc = subprocess.Popen(
+            [binary, *extra_args],
+            cwd=workspace,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=log,
+        )
+        return proc, log
+
+    def wait_ready(log_name):
+        deadline = time.time() + 30
+        log_path = base / log_name
+        while time.time() < deadline:
+            if snapshot_path.exists():
+                data = json.loads(snapshot_path.read_text())
+                bind = data.get("bind")
+                if bind:
+                    return bind
+            time.sleep(0.05)
+        tail = log_path.read_text()[-4000:] if log_path.exists() else "(missing log)"
+        raise RuntimeError(f"timed out waiting for orchestrator readiness\\n{tail}")
+
+    def sqlite_conn():
+        return sqlite3.connect(sqlite_path)
+
+    def wait_outbox(expected):
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            with sqlite_conn() as conn:
+                count = conn.execute(
+                    "SELECT COUNT(*) FROM events WHERE topic = ? AND kind = ?",
+                    ("trigger.outbox", "dispatch_succeeded"),
+                ).fetchone()[0]
+            if count >= expected:
+                return count
+            time.sleep(0.1)
+        raise RuntimeError(f"timed out waiting for {expected} dispatch_succeeded rows")
+
+    first_proc, first_log = start(50, "orchestrator-first.log")
+    try:
+        bind = wait_ready("orchestrator-first.log")
+        host, port = bind.split(":")
+        conn = http.client.HTTPConnection(host, int(port), timeout=10)
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer test-key",
+        }
+        for index in range(5000):
+            body = json.dumps(
+                {
+                    "kind": "a2a.task.received",
+                    "task": {"id": f"task-{index}"},
+                }
+            )
+            conn.request("POST", "/a2a/review", body=body, headers=headers)
+            response = conn.getresponse()
+            payload = response.read()
+            if response.status != 200:
+                raise RuntimeError(f"flood request {index} failed: {response.status} {payload!r}")
+        conn.close()
+
+        shutdown_start = time.monotonic()
+        first_proc.send_signal(signal.SIGTERM)
+        first_proc.wait(timeout=10)
+        shutdown_ms = int((time.monotonic() - shutdown_start) * 1000)
+        if first_proc.returncode != 0:
+            raise RuntimeError(f"first orchestrator exited with {first_proc.returncode}")
+    finally:
+        first_log.close()
+
+    with sqlite_conn() as conn:
+        row = conn.execute(
+            "SELECT payload FROM events WHERE topic = ? AND kind = ? ORDER BY event_id DESC LIMIT 1",
+            ("orchestrator.lifecycle", "drain_truncated"),
+        ).fetchone()
+    if row is None:
+        raise RuntimeError("missing drain_truncated lifecycle event")
+    truncated = json.loads(row[0])
+
+    second_proc, second_log = start(None, "orchestrator-second.log")
+    try:
+        wait_ready("orchestrator-second.log")
+        outbox_count = wait_outbox(5000)
+        second_proc.send_signal(signal.SIGTERM)
+        second_proc.wait(timeout=10)
+        if second_proc.returncode != 0:
+            raise RuntimeError(f"second orchestrator exited with {second_proc.returncode}")
+    finally:
+        second_log.close()
+
+    print(
+        json.dumps(
+            {
+                "shutdown_ms": shutdown_ms,
+                "truncated": True,
+                "remaining_queued": truncated.get("remaining_queued", 0),
+                "outbox_count": outbox_count,
+                "topic": truncated.get("topic"),
+            }
+        )
+    )
+    PY
+  """
+  let result = shell(script)
+  println(result.success)
+  if !result.success {
+    return
+  }
+  let summary = json_parse(result.stdout.trim())
+  println(summary.shutdown_ms <= 4000)
+  println(summary.truncated == true)
+  println(summary.remaining_queued > 0)
+  println(summary.outbox_count == 5000)
+}

--- a/conformance/tests/integration/orchestrator_bounded_drain_resume.harn
+++ b/conformance/tests/integration/orchestrator_bounded_drain_resume.harn
@@ -194,7 +194,7 @@ pipeline default() {
         )
     )
     PY
-  """
+    """
   let result = shell(script)
   println(result.success)
   if !result.success {

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -545,6 +545,12 @@ pub(crate) struct OrchestratorServeArgs {
     /// Seconds to wait for connector and dispatcher drain before forcing shutdown.
     #[arg(long = "shutdown-timeout", default_value_t = 30, value_name = "SECS")]
     pub shutdown_timeout: u64,
+    /// Maximum number of pump items to process during graceful shutdown.
+    #[arg(long = "drain-max-items", value_name = "COUNT")]
+    pub drain_max_items: Option<usize>,
+    /// Seconds to wait for each pump drain before truncating remaining backlog.
+    #[arg(long = "drain-deadline", value_name = "SECS")]
+    pub drain_deadline: Option<u64>,
     /// Runtime role to boot. Multi-tenant is a stub for now.
     #[arg(
         long,
@@ -982,6 +988,10 @@ mod tests {
             "tls/key.pem",
             "--shutdown-timeout",
             "45",
+            "--drain-max-items",
+            "256",
+            "--drain-deadline",
+            "9",
             "--role",
             "single-tenant",
         ]);
@@ -998,6 +1008,8 @@ mod tests {
         assert_eq!(serve.cert, Some(PathBuf::from("tls/cert.pem")));
         assert_eq!(serve.key, Some(PathBuf::from("tls/key.pem")));
         assert_eq!(serve.shutdown_timeout, 45);
+        assert_eq!(serve.drain_max_items, Some(256));
+        assert_eq!(serve.drain_deadline, Some(9));
         assert_eq!(
             serve.role,
             crate::commands::orchestrator::role::OrchestratorRole::SingleTenant

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -12,7 +12,7 @@ use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use tokio::sync::watch;
 
-use harn_vm::event_log::EventLog;
+use harn_vm::event_log::{ConsumerId, EventLog};
 
 use super::listener::{ListenerConfig, ListenerRuntime, RouteConfig, TriggerMetricSnapshot};
 use super::origin_guard::OriginAllowList;
@@ -28,6 +28,7 @@ const MANIFEST_TOPIC: &str = "orchestrator.manifest";
 const STATE_SNAPSHOT_FILE: &str = "orchestrator-state.json";
 const PENDING_TOPIC: &str = "orchestrator.triggers.pending";
 const CRON_TICK_TOPIC: &str = "connectors.cron.tick";
+const TEST_PUMP_DELAY_ENV: &str = "HARN_TEST_ORCHESTRATOR_PUMP_DELAY_MS";
 
 pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
     let local = tokio::task::LocalSet::new();
@@ -41,6 +42,15 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
     let tls = TlsFiles::from_args(args.cert.clone(), args.key.clone())?;
     let config_path = absolutize_from_cwd(&args.local.config)?;
     let (manifest, manifest_dir) = load_manifest(&config_path)?;
+    let drain_config = DrainConfig {
+        max_items: args
+            .drain_max_items
+            .unwrap_or(manifest.orchestrator.drain.max_items),
+        deadline: Duration::from_secs(
+            args.drain_deadline
+                .unwrap_or(manifest.orchestrator.drain.deadline_seconds),
+        ),
+    };
     let state_dir = absolutize_from_cwd(&args.local.state_dir)?;
     std::fs::create_dir_all(&state_dir).map_err(|error| {
         format!(
@@ -190,6 +200,8 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
             "connector_count": connector_runtime.providers.len(),
             "tls_enabled": listener.scheme() == "https",
             "shutdown_timeout_secs": shutdown_timeout.as_secs(),
+            "drain_max_items": drain_config.max_items,
+            "drain_deadline_secs": drain_config.deadline.as_secs(),
         }),
     )
     .await?;
@@ -223,6 +235,7 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
             triggers: &live_triggers,
             connectors: &connector_runtime,
             shutdown_timeout,
+            drain_config,
         },
         listener,
         dispatcher,
@@ -500,7 +513,37 @@ fn handler_kind(handler: &CollectedTriggerHandler) -> &'static str {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PumpMode {
     Running,
-    Draining { up_to: u64 },
+    Draining(PumpDrainRequest),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DrainConfig {
+    max_items: usize,
+    deadline: Duration,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PumpDrainRequest {
+    up_to: u64,
+    config: DrainConfig,
+    deadline: tokio::time::Instant,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PumpDrainStopReason {
+    Drained,
+    MaxItems,
+    Deadline,
+}
+
+impl PumpDrainStopReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Drained => "drained",
+            Self::MaxItems => "max_items",
+            Self::Deadline => "deadline",
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -509,14 +552,47 @@ struct PumpStats {
     processed: u64,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct PumpDrainProgress {
+    request: PumpDrainRequest,
+    start_seen: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PumpDrainReport {
+    stats: PumpStats,
+    drain_items: u64,
+    remaining_queued: u64,
+    stop_reason: PumpDrainStopReason,
+}
+
+impl PumpDrainReport {
+    fn truncated(self) -> bool {
+        self.remaining_queued > 0
+    }
+}
+
 struct PumpHandle {
     mode_tx: watch::Sender<PumpMode>,
-    join: tokio::task::JoinHandle<Result<PumpStats, String>>,
+    join: tokio::task::JoinHandle<Result<PumpDrainReport, String>>,
 }
 
 impl PumpHandle {
-    async fn drain(self, up_to: u64) -> Result<PumpStats, String> {
-        let _ = self.mode_tx.send(PumpMode::Draining { up_to });
+    async fn drain(
+        self,
+        up_to: u64,
+        config: DrainConfig,
+        overall_deadline: tokio::time::Instant,
+    ) -> Result<PumpDrainReport, String> {
+        let drain_deadline = std::cmp::min(
+            tokio::time::Instant::now() + config.deadline,
+            overall_deadline,
+        );
+        let _ = self.mode_tx.send(PumpMode::Draining(PumpDrainRequest {
+            up_to,
+            config,
+            deadline: drain_deadline,
+        }));
         match self.join.await {
             Ok(result) => result,
             Err(error) => Err(format!("pump task join failed: {error}")),
@@ -616,12 +692,18 @@ where
     F: Fn(harn_vm::event_log::LogEvent) -> Fut + 'static,
     Fut: std::future::Future<Output = Result<bool, String>> + 'static,
 {
+    let consumer = pump_consumer_id(&topic)?;
+    let test_delay = pump_test_delay();
     let (mode_tx, mut mode_rx) = watch::channel(PumpMode::Running);
     let join = tokio::task::spawn_local(async move {
         let start_from = event_log
-            .latest(&topic)
+            .consumer_cursor(&topic, &consumer)
             .await
-            .map_err(|error| format!("failed to read topic head {topic}: {error}"))?;
+            .map_err(|error| format!("failed to read consumer cursor for {topic}: {error}"))?
+            .or(event_log
+                .latest(&topic)
+                .await
+                .map_err(|error| format!("failed to read topic head {topic}: {error}"))?);
         let mut stream = event_log
             .clone()
             .subscribe(&topic, start_from)
@@ -631,15 +713,41 @@ where
             last_seen: start_from.unwrap_or(0),
             processed: 0,
         };
+        let mut drain_progress = None;
         loop {
-            if matches!(*mode_rx.borrow(), PumpMode::Draining { up_to } if stats.last_seen >= up_to)
-            {
-                break;
+            if let Some(progress) = drain_progress {
+                if let Some(report) = maybe_finish_pump_drain(stats, progress) {
+                    return Ok(report);
+                }
             }
+            let deadline = drain_progress.map(|progress| progress.request.deadline);
+            let mut deadline_wait = Box::pin(async move {
+                if let Some(deadline) = deadline {
+                    tokio::time::sleep_until(deadline).await;
+                } else {
+                    std::future::pending::<()>().await;
+                }
+            });
             tokio::select! {
                 changed = mode_rx.changed() => {
                     if changed.is_err() {
                         break;
+                    }
+                    if let PumpMode::Draining(request) = *mode_rx.borrow() {
+                        drain_progress.get_or_insert(PumpDrainProgress {
+                            request,
+                            start_seen: stats.last_seen,
+                        });
+                    }
+                }
+                _ = &mut deadline_wait => {
+                    if let Some(progress) = drain_progress {
+                        return Ok(pump_drain_report(
+                            stats,
+                            progress.start_seen,
+                            progress.request.up_to,
+                            PumpDrainStopReason::Deadline,
+                        ));
                     }
                 }
                 received = stream.next() => {
@@ -648,15 +756,36 @@ where
                     };
                     let (event_id, logged) = received
                         .map_err(|error| format!("topic pump read failed for {topic}: {error}"))?;
+                    if let Some(delay) = test_delay {
+                        tokio::time::sleep(delay).await;
+                    }
                     let handled = process(logged).await?;
                     stats.last_seen = event_id;
                     if handled {
                         stats.processed += 1;
                     }
+                    event_log
+                        .ack(&topic, &consumer, event_id)
+                        .await
+                        .map_err(|error| format!("failed to ack topic pump cursor for {topic}: {error}"))?;
                 }
             }
         }
-        Ok(stats)
+        Ok(drain_progress
+            .map(|progress| {
+                pump_drain_report(
+                    stats,
+                    progress.start_seen,
+                    progress.request.up_to,
+                    PumpDrainStopReason::Drained,
+                )
+            })
+            .unwrap_or_else(|| PumpDrainReport {
+                stats,
+                drain_items: 0,
+                remaining_queued: 0,
+                stop_reason: PumpDrainStopReason::Drained,
+            }))
     });
     Ok(PumpHandle { mode_tx, join })
 }
@@ -699,6 +828,8 @@ async fn graceful_shutdown(
             "dispatcher_retry_queue_depth": dispatcher_before.retry_queue_depth,
             "dispatcher_dlq_depth": dispatcher_before.dlq_depth,
             "shutdown_timeout_secs": ctx.shutdown_timeout.as_secs(),
+            "drain_max_items": ctx.drain_config.max_items,
+            "drain_deadline_secs": ctx.drain_config.deadline.as_secs(),
         }),
     )
     .await?;
@@ -716,14 +847,41 @@ async fn graceful_shutdown(
     }
 
     let pending_stats = pending_pump
-        .drain(topic_latest_id(ctx.event_log, PENDING_TOPIC).await?)
+        .drain(
+            topic_latest_id(ctx.event_log, PENDING_TOPIC).await?,
+            ctx.drain_config,
+            deadline,
+        )
         .await?;
+    emit_drain_truncated(
+        ctx.event_log,
+        PENDING_TOPIC,
+        pending_stats,
+        ctx.drain_config,
+    )
+    .await?;
     let cron_stats = cron_pump
-        .drain(topic_latest_id(ctx.event_log, CRON_TICK_TOPIC).await?)
+        .drain(
+            topic_latest_id(ctx.event_log, CRON_TICK_TOPIC).await?,
+            ctx.drain_config,
+            deadline,
+        )
         .await?;
+    emit_drain_truncated(ctx.event_log, CRON_TICK_TOPIC, cron_stats, ctx.drain_config).await?;
     let inbox_stats = inbox_pump
-        .drain(topic_latest_id(ctx.event_log, harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC).await?)
+        .drain(
+            topic_latest_id(ctx.event_log, harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC).await?,
+            ctx.drain_config,
+            deadline,
+        )
         .await?;
+    emit_drain_truncated(
+        ctx.event_log,
+        harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC,
+        inbox_stats,
+        ctx.drain_config,
+    )
+    .await?;
     let drain_report = dispatcher
         .drain(remaining_budget(deadline))
         .await
@@ -742,9 +900,9 @@ async fn graceful_shutdown(
             "dispatcher_in_flight": drain_report.in_flight,
             "dispatcher_retry_queue_depth": drain_report.retry_queue_depth,
             "dispatcher_dlq_depth": drain_report.dlq_depth,
-            "pending_events_drained": pending_stats.processed,
-            "cron_events_drained": cron_stats.processed,
-            "inbox_events_drained": inbox_stats.processed,
+            "pending_events_drained": pending_stats.stats.processed,
+            "cron_events_drained": cron_stats.stats.processed,
+            "inbox_events_drained": inbox_stats.stats.processed,
             "timed_out": timed_out,
         }),
     )
@@ -821,6 +979,36 @@ async fn append_manifest_event(
         .map_err(|error| format!("failed to append orchestrator manifest event: {error}"))
 }
 
+async fn emit_drain_truncated(
+    log: &Arc<harn_vm::event_log::AnyEventLog>,
+    topic_name: &str,
+    report: PumpDrainReport,
+    config: DrainConfig,
+) -> Result<(), String> {
+    if !report.truncated() {
+        return Ok(());
+    }
+    eprintln!(
+        "[harn] warning: pump drain truncated for {topic_name}: remaining_queued={} drain_items={} reason={}",
+        report.remaining_queued,
+        report.drain_items,
+        report.stop_reason.as_str()
+    );
+    append_lifecycle_event(
+        log,
+        "drain_truncated",
+        json!({
+            "topic": topic_name,
+            "remaining_queued": report.remaining_queued,
+            "drain_items": report.drain_items,
+            "max_items": config.max_items,
+            "deadline_secs": config.deadline.as_secs(),
+            "reason": report.stop_reason.as_str(),
+        }),
+    )
+    .await
+}
+
 async fn topic_latest_id(
     log: &Arc<harn_vm::event_log::AnyEventLog>,
     topic_name: &str,
@@ -834,6 +1022,65 @@ async fn topic_latest_id(
 
 fn remaining_budget(deadline: tokio::time::Instant) -> Duration {
     deadline.saturating_duration_since(tokio::time::Instant::now())
+}
+
+fn maybe_finish_pump_drain(
+    stats: PumpStats,
+    progress: PumpDrainProgress,
+) -> Option<PumpDrainReport> {
+    if stats.last_seen >= progress.request.up_to {
+        return Some(pump_drain_report(
+            stats,
+            progress.start_seen,
+            progress.request.up_to,
+            PumpDrainStopReason::Drained,
+        ));
+    }
+    let drain_items = stats.last_seen.saturating_sub(progress.start_seen);
+    if drain_items >= progress.request.config.max_items as u64 {
+        return Some(pump_drain_report(
+            stats,
+            progress.start_seen,
+            progress.request.up_to,
+            PumpDrainStopReason::MaxItems,
+        ));
+    }
+    if tokio::time::Instant::now() >= progress.request.deadline {
+        return Some(pump_drain_report(
+            stats,
+            progress.start_seen,
+            progress.request.up_to,
+            PumpDrainStopReason::Deadline,
+        ));
+    }
+    None
+}
+
+fn pump_drain_report(
+    stats: PumpStats,
+    start_seen: u64,
+    up_to: u64,
+    stop_reason: PumpDrainStopReason,
+) -> PumpDrainReport {
+    PumpDrainReport {
+        stats,
+        drain_items: stats.last_seen.saturating_sub(start_seen),
+        remaining_queued: up_to.saturating_sub(stats.last_seen),
+        stop_reason,
+    }
+}
+
+fn pump_consumer_id(topic: &harn_vm::event_log::Topic) -> Result<ConsumerId, String> {
+    ConsumerId::new(format!("orchestrator-pump.{}", topic.as_str()))
+        .map_err(|error| format!("failed to create consumer id for {topic}: {error}"))
+}
+
+fn pump_test_delay() -> Option<Duration> {
+    std::env::var(TEST_PUMP_DELAY_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .filter(|delay| !delay.is_zero())
 }
 
 struct RuntimeSignalCtx<'a> {
@@ -1099,6 +1346,7 @@ struct GracefulShutdownCtx<'a> {
     triggers: &'a [CollectedManifestTrigger],
     connectors: &'a ConnectorRuntime,
     shutdown_timeout: Duration,
+    drain_config: DrainConfig,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -77,6 +77,36 @@ pub struct OrchestratorConfig {
     pub allowed_origins: Vec<String>,
     #[serde(default, alias = "max-body-bytes")]
     pub max_body_bytes: Option<usize>,
+    #[serde(default)]
+    pub drain: OrchestratorDrainConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OrchestratorDrainConfig {
+    #[serde(default = "default_orchestrator_drain_max_items", alias = "max-items")]
+    pub max_items: usize,
+    #[serde(
+        default = "default_orchestrator_drain_deadline_seconds",
+        alias = "deadline-seconds"
+    )]
+    pub deadline_seconds: u64,
+}
+
+impl Default for OrchestratorDrainConfig {
+    fn default() -> Self {
+        Self {
+            max_items: default_orchestrator_drain_max_items(),
+            deadline_seconds: default_orchestrator_drain_deadline_seconds(),
+        }
+    }
+}
+
+fn default_orchestrator_drain_max_items() -> usize {
+    1024
+}
+
+fn default_orchestrator_drain_deadline_seconds() -> u64 {
+    30
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -2144,6 +2174,33 @@ pipelines = ["pipelines", "scripts"]
         assert_eq!(workspace.pipelines, vec!["pipelines", "scripts"]);
         // Walk-up lands on the directory containing the harn.toml.
         assert_eq!(manifest_dir, root);
+    }
+
+    #[test]
+    fn orchestrator_drain_config_parses_defaults_and_overrides() {
+        let default_manifest: Manifest = toml::from_str(
+            r#"
+[package]
+name = "fixture"
+"#,
+        )
+        .unwrap();
+        assert_eq!(default_manifest.orchestrator.drain.max_items, 1024);
+        assert_eq!(default_manifest.orchestrator.drain.deadline_seconds, 30);
+
+        let configured: Manifest = toml::from_str(
+            r#"
+[package]
+name = "fixture"
+
+[orchestrator]
+drain.max_items = 77
+drain.deadline_seconds = 12
+"#,
+        )
+        .unwrap();
+        assert_eq!(configured.orchestrator.drain.max_items, 77);
+        assert_eq!(configured.orchestrator.drain.deadline_seconds, 12);
     }
 
     #[test]

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -250,6 +250,51 @@ fn wait_for_topic_kind(state_dir: &Path, topic_name: &str, kind: &str) {
     panic!("timed out waiting for {topic_name}/{kind}");
 }
 
+fn sqlite_event_count(state_dir: &Path, topic_name: &str, kind: &str) -> usize {
+    let output = Command::new("python3")
+        .arg("-c")
+        .arg(
+            r#"
+import pathlib
+import sqlite3
+import sys
+
+state_dir, topic, kind = sys.argv[1:]
+conn = sqlite3.connect(str(pathlib.Path(state_dir) / "events.sqlite"))
+count = conn.execute(
+    "SELECT COUNT(*) FROM events WHERE topic = ? AND kind = ?",
+    (topic, kind),
+).fetchone()[0]
+print(count)
+"#,
+        )
+        .arg(state_dir)
+        .arg(topic_name)
+        .arg(kind)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "python stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .unwrap()
+}
+
+fn wait_for_sqlite_event_count(state_dir: &Path, topic_name: &str, kind: &str, expected: usize) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if sqlite_event_count(state_dir, topic_name, kind) >= expected {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!("timed out waiting for {topic_name}/{kind} count {expected}");
+}
+
 #[test]
 fn orchestrator_serve_starts_and_shuts_down_cleanly() {
     let temp = TempDir::new().unwrap();
@@ -470,4 +515,108 @@ pub fn on_event(event: TriggerEvent) {
         Duration::from_secs(60),
     ))
     .unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bounded_pump_drain_truncates_and_replays_remaining_backlog_after_restart() {
+    let temp = TempDir::new().unwrap();
+    write_file(
+        temp.path(),
+        "harn.toml",
+        r#"
+[package]
+name = "fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "incoming-review-task"
+kind = "a2a-push"
+provider = "a2a-push"
+path = "/a2a/review"
+match = { events = ["a2a.task.received"] }
+handler = "handlers::on_task"
+"#,
+    );
+    write_file(
+        temp.path(),
+        "lib.harn",
+        r#"
+import "std/triggers"
+
+pub fn on_task(event: TriggerEvent) -> string {
+  return event.kind
+}
+"#,
+    );
+
+    let envs = [
+        ("HARN_ORCHESTRATOR_API_KEYS", "test-key"),
+        ("HARN_ORCHESTRATOR_HMAC_SECRET", "unused-shared-secret"),
+        ("HARN_EVENT_LOG_QUEUE_DEPTH", "8192"),
+        ("HARN_TEST_ORCHESTRATOR_PUMP_DELAY_MS", "50"),
+    ];
+    let extra_args = [
+        "--shutdown-timeout",
+        "5",
+        "--drain-max-items",
+        "100",
+        "--drain-deadline",
+        "1",
+    ];
+    let (mut child, rx, handle) = spawn_orchestrator_with(&temp, &extra_args, &envs);
+    let base_url = wait_for_listener_url(&mut child, &rx);
+    let state_dir = temp.path().join("state");
+
+    let client = reqwest::Client::new();
+    for index in 0..5000 {
+        let body = serde_json::json!({
+            "kind": "a2a.task.received",
+            "task": {"id": format!("task-{index}")},
+        });
+        let response = client
+            .post(format!("{base_url}/a2a/review"))
+            .headers(bearer_headers())
+            .body(body.to_string())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+    }
+
+    let shutdown_started = Instant::now();
+    send_sigterm(&child);
+    wait_for_exit(&mut child);
+    let shutdown_elapsed = shutdown_started.elapsed();
+    let stderr = handle.join().expect("stderr collector thread");
+
+    assert!(
+        shutdown_elapsed < Duration::from_secs(4),
+        "shutdown should finish within bounded drain budget: {shutdown_elapsed:?}"
+    );
+    assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
+    assert!(stderr.contains("pump drain truncated"), "stderr={stderr}");
+
+    let restart_envs = [
+        ("HARN_ORCHESTRATOR_API_KEYS", "test-key"),
+        ("HARN_ORCHESTRATOR_HMAC_SECRET", "unused-shared-secret"),
+        ("HARN_EVENT_LOG_QUEUE_DEPTH", "8192"),
+    ];
+    let (mut restart_child, restart_rx, restart_handle) =
+        spawn_orchestrator_with(&temp, &extra_args, &restart_envs);
+    wait_for_listener_url(&mut restart_child, &restart_rx);
+    wait_for_sqlite_event_count(&state_dir, "trigger.outbox", "dispatch_succeeded", 5000);
+    send_sigterm(&restart_child);
+    wait_for_exit(&mut restart_child);
+    let restart_stderr = restart_handle.join().expect("stderr collector thread");
+    assert!(
+        restart_stderr.contains(SHUTDOWN_NEEDLE),
+        "stderr={restart_stderr}"
+    );
+
+    assert_eq!(
+        sqlite_event_count(&state_dir, "trigger.outbox", "dispatch_succeeded"),
+        5000
+    );
 }

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -285,7 +285,7 @@ print(count)
 }
 
 fn wait_for_sqlite_event_count(state_dir: &Path, topic_name: &str, kind: &str, expected: usize) {
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + Duration::from_secs(90);
     while Instant::now() < deadline {
         if sqlite_event_count(state_dir, topic_name, kind) >= expected {
             return;

--- a/crates/harn-vm/src/event_log/mod.rs
+++ b/crates/harn-vm/src/event_log/mod.rs
@@ -217,6 +217,12 @@ pub trait EventLog: Send + Sync {
         up_to: EventId,
     ) -> Result<(), LogError>;
 
+    async fn consumer_cursor(
+        &self,
+        topic: &Topic,
+        consumer: &ConsumerId,
+    ) -> Result<Option<EventId>, LogError>;
+
     async fn latest(&self, topic: &Topic) -> Result<Option<EventId>, LogError>;
 
     async fn compact(&self, topic: &Topic, before: EventId) -> Result<CompactReport, LogError>;
@@ -426,6 +432,18 @@ impl EventLog for AnyEventLog {
         }
     }
 
+    async fn consumer_cursor(
+        &self,
+        topic: &Topic,
+        consumer: &ConsumerId,
+    ) -> Result<Option<EventId>, LogError> {
+        match self {
+            Self::Memory(log) => log.consumer_cursor(topic, consumer).await,
+            Self::File(log) => log.consumer_cursor(topic, consumer).await,
+            Self::Sqlite(log) => log.consumer_cursor(topic, consumer).await,
+        }
+    }
+
     async fn latest(&self, topic: &Topic) -> Result<Option<EventId>, LogError> {
         match self {
             Self::Memory(log) => log.latest(topic).await,
@@ -616,6 +634,18 @@ impl EventLog for MemoryEventLog {
             up_to,
         );
         Ok(())
+    }
+
+    async fn consumer_cursor(
+        &self,
+        topic: &Topic,
+        consumer: &ConsumerId,
+    ) -> Result<Option<EventId>, LogError> {
+        let state = self.state.lock().await;
+        Ok(state
+            .consumers
+            .get(&(topic.as_str().to_string(), consumer.as_str().to_string()))
+            .copied())
     }
 
     async fn latest(&self, topic: &Topic) -> Result<Option<EventId>, LogError> {
@@ -834,6 +864,28 @@ impl EventLog for FileEventLog {
             "updated_at_ms": now_ms(),
         });
         write_json_atomically(&path, &payload)
+    }
+
+    async fn consumer_cursor(
+        &self,
+        topic: &Topic,
+        consumer: &ConsumerId,
+    ) -> Result<Option<EventId>, LogError> {
+        let path = self.consumer_path(topic, consumer);
+        if !path.is_file() {
+            return Ok(None);
+        }
+        let raw = std::fs::read_to_string(&path)
+            .map_err(|error| LogError::Io(format!("event log consumer read error: {error}")))?;
+        let payload: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|error| LogError::Serde(format!("event log consumer parse error: {error}")))?;
+        let cursor = payload
+            .get("cursor")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| {
+                LogError::Serde("event log consumer record missing numeric cursor".to_string())
+            })?;
+        Ok(Some(cursor))
     }
 
     async fn latest(&self, topic: &Topic) -> Result<Option<EventId>, LogError> {
@@ -1115,6 +1167,25 @@ impl EventLog for SqliteEventLog {
             )
             .map_err(|error| LogError::Sqlite(format!("event log ack error: {error}")))?;
         Ok(())
+    }
+
+    async fn consumer_cursor(
+        &self,
+        topic: &Topic,
+        consumer: &ConsumerId,
+    ) -> Result<Option<EventId>, LogError> {
+        let connection = self
+            .connection
+            .lock()
+            .expect("sqlite event log connection poisoned");
+        connection
+            .query_row(
+                "SELECT cursor FROM consumers WHERE topic = ?1 AND consumer_id = ?2",
+                params![topic.as_str(), consumer.as_str()],
+                |row| row.get::<_, EventId>(0),
+            )
+            .optional()
+            .map_err(|error| LogError::Sqlite(format!("event log consumer cursor error: {error}")))
     }
 
     async fn latest(&self, topic: &Topic) -> Result<Option<EventId>, LogError> {


### PR DESCRIPTION
## Summary
- bound orchestrator pump draining on shutdown with configurable `max_items` and per-pump deadline
- persist pump consumer cursors so truncated pending/inbox backlog is resumed on the next orchestrator start
- add lifecycle/logging coverage plus a restart conformance case for the bounded-drain path

## Root cause
`harn orchestrator serve` drained the pending/cron/inbox pumps to the topic head with no item cap. Under backlog spikes during SIGTERM, shutdown time could grow without bound and a container runtime could kill the process before the drain finished, leaving work half-processed.

## What changed
- added `[orchestrator].drain.max_items` and `[orchestrator].drain.deadline_seconds` manifest config plus `--drain-max-items` / `--drain-deadline` CLI overrides
- taught the orchestrator pumps to stop on either the configured item cap or deadline, emit `orchestrator.lifecycle` `drain_truncated`, and warn in stderr when backlog remains
- added durable pump consumer cursors in the event log so truncated source-topic backlog is resumed after restart instead of being skipped
- added package/integration coverage and a conformance case that floods 5000 events, truncates drain at shutdown, and proves the remaining backlog drains after restart
- updated `CHANGELOG.md` for harn#240

## Validation
- `cargo test --package harn-cli`
- `cargo run --bin harn -- test conformance --filter orchestrator_bounded_drain_resume`
