### PR TITLE
[codex] Gate cleartext A2A behind explicit opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,8 +186,10 @@ granular archaeology.
   either the inline remote result or a pending task handle payload.
   A2A card discovery now prefers HTTPS, only falls back to cleartext
   after an HTTPS connect-refused failure, and rejects agent cards whose
-  declared URL authority does not match the requested target. The
-  broader host-allowlist follow-up remains deferred.
+  declared URL authority does not match the requested target. Cleartext
+  A2A discovery / dispatch now also requires explicit
+  `allow_cleartext = true` on the trigger binding. The broader
+  host-allowlist follow-up remains deferred.
   Dispatcher retries / DLQ behavior now apply to remote A2A attempts the
   same way they already applied to local handlers. Persisted
   observability adds `a2a_hop` nodes and `a2a_dispatch` edges with

--- a/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
+++ b/conformance/tests/integration/orchestrator_a2a_dispatch_sync.harn
@@ -39,7 +39,7 @@ pipeline test(task) {
     "pipeline default(task) {\n  let envelope = json_parse(task)\n  println(json_stringify({trace_id: envelope.event.trace_id, target_agent: envelope.target_agent}))\n}\n",
   )
   let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
-  let harn_bin = resolve_harn_bin(repo_root)
+  let harn_bin = env_or("HARN_CONFORMANCE_HARN_BIN", resolve_harn_bin(repo_root))
   assert(file_exists(harn_bin), "missing built harn binary at " + harn_bin)
   let start = shell_at(
     root,
@@ -64,6 +64,7 @@ pipeline test(task) {
     kind: "issue.opened",
     provider: "github",
     handler: "a2a://127.0.0.1:" + to_string(port) + "/triage",
+    allow_cleartext: true,
     when: nil,
     retry: {max: 1, backoff: "immediate"},
     match: {events: ["issue.opened"]},

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -188,8 +188,13 @@ pub struct TriggerBudgetSpec {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TriggerHandlerUri {
     Local(TriggerFunctionRef),
-    A2a { target: String },
-    Worker { queue: String },
+    A2a {
+        target: String,
+        allow_cleartext: bool,
+    },
+    Worker {
+        queue: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -468,6 +473,7 @@ pub enum CollectedTriggerHandler {
     },
     A2a {
         target: String,
+        allow_cleartext: bool,
     },
     Worker {
         queue: String,
@@ -774,8 +780,13 @@ fn parse_trigger_handler_uri(trigger: &ResolvedTriggerConfig) -> Result<TriggerH
                 "handler a2a:// target cannot be empty",
             ));
         }
+        let allow_cleartext = extract_kind_field(trigger, "allow_cleartext")
+            .map(parse_trigger_allow_cleartext)
+            .transpose()?
+            .unwrap_or(false);
         return Ok(TriggerHandlerUri::A2a {
             target: target.to_string(),
+            allow_cleartext,
         });
     }
     if let Some(queue) = raw.strip_prefix("worker://") {
@@ -897,6 +908,15 @@ fn validate_static_trigger_config(trigger: &ResolvedTriggerConfig) -> Result<(),
     if let Some(filter) = &trigger.filter {
         parse_jmespath_expression(trigger, "filter", filter)?;
     }
+    if let Some(value) = extract_kind_field(trigger, "allow_cleartext") {
+        let _ = parse_trigger_allow_cleartext(value)?;
+        if !trigger.handler.trim().starts_with("a2a://") {
+            return Err(trigger_error(
+                trigger,
+                "`allow_cleartext` is only valid for `a2a://...` handlers",
+            ));
+        }
+    }
     if let Some(daily_cost_usd) = trigger.budget.daily_cost_usd {
         if daily_cost_usd.is_sign_negative() {
             return Err(trigger_error(
@@ -986,6 +1006,12 @@ fn validate_static_trigger_configs(triggers: &[ResolvedTriggerConfig]) -> Result
         }
     }
     Ok(())
+}
+
+fn parse_trigger_allow_cleartext(value: &toml::Value) -> Result<bool, String> {
+    value
+        .as_bool()
+        .ok_or_else(|| "`allow_cleartext` must be a boolean".to_string())
 }
 
 fn manifest_module_source_path(
@@ -1285,7 +1311,13 @@ pub async fn collect_manifest_triggers(
                     closure: closure.clone(),
                 }
             }
-            TriggerHandlerUri::A2a { target } => CollectedTriggerHandler::A2a { target },
+            TriggerHandlerUri::A2a {
+                target,
+                allow_cleartext,
+            } => CollectedTriggerHandler::A2a {
+                target,
+                allow_cleartext,
+            },
             TriggerHandlerUri::Worker { queue } => CollectedTriggerHandler::Worker { queue },
         };
 
@@ -1416,13 +1448,18 @@ pub fn manifest_trigger_binding_spec(
                 "raw": reference.raw,
             }),
         ),
-        CollectedTriggerHandler::A2a { target } => (
+        CollectedTriggerHandler::A2a {
+            target,
+            allow_cleartext,
+        } => (
             harn_vm::TriggerHandlerSpec::A2a {
                 target: target.clone(),
+                allow_cleartext,
             },
             serde_json::json!({
                 "kind": "a2a",
                 "target": target,
+                "allow_cleartext": allow_cleartext,
             }),
         ),
         CollectedTriggerHandler::Worker { queue } => (
@@ -2426,6 +2463,37 @@ pub fn should_handle(event: TriggerEvent) -> bool {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn collect_manifest_triggers_accepts_a2a_allow_cleartext() {
+        let tmp = tempfile::tempdir().unwrap();
+        let harn_file = write_trigger_project(
+            tmp.path(),
+            r#"
+[[triggers]]
+id = "local-a2a"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "a2a://127.0.0.1:8787/triage"
+allow_cleartext = true
+secrets = { signing_secret = "github/webhook-secret" }
+"#,
+            None,
+        );
+        let mut vm = test_vm();
+        let collected = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+            .await
+            .expect("trigger collection succeeds");
+        assert_eq!(collected.len(), 1);
+        assert!(matches!(
+            &collected[0].handler,
+            CollectedTriggerHandler::A2a {
+                target,
+                allow_cleartext: true,
+            } if target == "127.0.0.1:8787/triage"
+        ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn collect_manifest_triggers_rejects_duplicate_ids() {
         let tmp = tempfile::tempdir().unwrap();
         let harn_file = write_trigger_project(
@@ -2476,6 +2544,54 @@ handler = "worker://queue"
             .await
             .unwrap_err();
         assert!(error.contains("provider 'made-up' is not registered"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_manifest_triggers_rejects_non_bool_allow_cleartext() {
+        let tmp = tempfile::tempdir().unwrap();
+        let harn_file = write_trigger_project(
+            tmp.path(),
+            r#"
+[[triggers]]
+id = "bad-allow-cleartext-type"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "a2a://127.0.0.1:8787/triage"
+allow_cleartext = "yes"
+secrets = { signing_secret = "github/webhook-secret" }
+"#,
+            None,
+        );
+        let mut vm = test_vm();
+        let error = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+            .await
+            .unwrap_err();
+        assert!(error.contains("`allow_cleartext` must be a boolean"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_manifest_triggers_rejects_allow_cleartext_on_non_a2a_handler() {
+        let tmp = tempfile::tempdir().unwrap();
+        let harn_file = write_trigger_project(
+            tmp.path(),
+            r#"
+[[triggers]]
+id = "bad-allow-cleartext-target"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues.opened"] }
+handler = "worker://queue"
+allow_cleartext = true
+secrets = { signing_secret = "github/webhook-secret" }
+"#,
+            None,
+        );
+        let mut vm = test_vm();
+        let error = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+            .await
+            .unwrap_err();
+        assert!(error.contains("only valid for `a2a://...` handlers"));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-vm/src/a2a/mod.rs
+++ b/crates/harn-vm/src/a2a/mod.rs
@@ -60,13 +60,14 @@ enum AgentCardFetchError {
 
 pub async fn dispatch_trigger_event(
     raw_target: &str,
+    allow_cleartext: bool,
     binding_id: &str,
     binding_key: &str,
     event: &TriggerEvent,
     cancel_rx: &mut broadcast::Receiver<()>,
 ) -> Result<(ResolvedA2aEndpoint, DispatchAck), A2aClientError> {
     let target = parse_target(raw_target)?;
-    let endpoint = resolve_endpoint(&target, cancel_rx).await?;
+    let endpoint = resolve_endpoint(&target, allow_cleartext, cancel_rx).await?;
     let message_id = format!("{}.{}", event.trace_id.0, event.id.0);
     let envelope = serde_json::json!({
         "kind": "harn.trigger.dispatch",
@@ -200,15 +201,17 @@ fn parse_target(raw_target: &str) -> Result<ParsedTarget, A2aClientError> {
 
 async fn resolve_endpoint(
     target: &ParsedTarget,
+    allow_cleartext: bool,
     cancel_rx: &mut broadcast::Receiver<()>,
 ) -> Result<ResolvedA2aEndpoint, A2aClientError> {
     let mut last_error = None;
-    for scheme in card_resolution_schemes() {
+    for scheme in card_resolution_schemes(allow_cleartext) {
         let card_url = format!("{scheme}://{}/{A2A_AGENT_CARD_PATH}", target.authority);
         match fetch_agent_card(&card_url, cancel_rx).await {
             Ok(card) => {
                 return endpoint_from_card(
                     card_url,
+                    allow_cleartext,
                     &target.authority,
                     target.target_agent.clone(),
                     &card,
@@ -220,7 +223,8 @@ async fn resolve_endpoint(
             Err(error) => {
                 let message = agent_card_fetch_error_message(&error);
                 last_error = Some(message);
-                if should_try_cleartext_fallback(scheme, &error, &target.authority) {
+                if should_try_cleartext_fallback(scheme, allow_cleartext, &error, &target.authority)
+                {
                     continue;
                 }
                 break;
@@ -268,6 +272,7 @@ async fn fetch_agent_card(
 
 fn endpoint_from_card(
     card_url: String,
+    allow_cleartext: bool,
     requested_authority: &str,
     target_agent: String,
     card: &Value,
@@ -279,6 +284,7 @@ fn endpoint_from_card(
     let base_url = Url::parse(base_url).map_err(|error| {
         A2aClientError::Discovery(format!("invalid A2A card url '{base_url}': {error}"))
     })?;
+    ensure_cleartext_allowed(&base_url, allow_cleartext, "agent card")?;
     let card_authority = url_authority(&base_url)?;
     if !authorities_equivalent(&card_authority, requested_authority) {
         return Err(A2aClientError::Discovery(format!(
@@ -312,6 +318,7 @@ fn endpoint_from_card(
             "invalid A2A interface url '{interface_url}': {error}"
         ))
     })?;
+    ensure_cleartext_allowed(&rpc_url, allow_cleartext, "jsonrpc interface")?;
     Ok(ResolvedA2aEndpoint {
         card_url,
         rpc_url: rpc_url.to_string(),
@@ -320,13 +327,12 @@ fn endpoint_from_card(
     })
 }
 
-fn card_resolution_schemes() -> [&'static str; 2] {
-    [
-        "https",
-        // Cleartext fallback exists for dev-mode only; production should use TLS.
-        // TODO(harn#250): Require an explicit opt-in gate before trying cleartext A2A discovery.
-        "http",
-    ]
+fn card_resolution_schemes(allow_cleartext: bool) -> &'static [&'static str] {
+    if allow_cleartext {
+        &["https", "http"]
+    } else {
+        &["https"]
+    }
 }
 
 /// Decide whether an HTTPS discovery failure should fall through to cleartext.
@@ -343,10 +349,11 @@ fn card_resolution_schemes() -> [&'static str; 2] {
 /// local loopback already has code execution on the box.
 fn should_try_cleartext_fallback(
     scheme: &str,
+    allow_cleartext: bool,
     error: &AgentCardFetchError,
     authority: &str,
 ) -> bool {
-    if scheme != "https" {
+    if !allow_cleartext || scheme != "https" {
         return false;
     }
     match error {
@@ -354,6 +361,19 @@ fn should_try_cleartext_fallback(
         AgentCardFetchError::ConnectRefused(_) => true,
         AgentCardFetchError::Discovery(_) => is_loopback_authority(authority),
     }
+}
+
+fn ensure_cleartext_allowed(
+    url: &Url,
+    allow_cleartext: bool,
+    label: &str,
+) -> Result<(), A2aClientError> {
+    if allow_cleartext || url.scheme() != "http" {
+        return Ok(());
+    }
+    Err(A2aClientError::Discovery(format!(
+        "cleartext A2A {label} '{url}' requires `allow_cleartext = true` on the trigger binding"
+    )))
 }
 
 fn is_loopback_authority(authority: &str) -> bool {
@@ -557,30 +577,54 @@ mod tests {
 
     #[test]
     fn discovery_prefers_https_before_http() {
-        assert_eq!(card_resolution_schemes(), ["https", "http"]);
+        assert_eq!(card_resolution_schemes(false), ["https"]);
+        assert_eq!(card_resolution_schemes(true), ["https", "http"]);
     }
 
     #[test]
     fn cleartext_fallback_only_after_https_connect_refused() {
         assert!(should_try_cleartext_fallback(
             "https",
+            true,
             &AgentCardFetchError::ConnectRefused("connect refused".to_string()),
             "reviewer.example:443",
         ));
         assert!(!should_try_cleartext_fallback(
             "http",
+            true,
             &AgentCardFetchError::ConnectRefused("connect refused".to_string()),
             "reviewer.example:443",
         ));
         assert!(!should_try_cleartext_fallback(
             "https",
+            true,
             &AgentCardFetchError::Discovery("tls handshake failed".to_string()),
             "reviewer.example:443",
         ));
     }
 
     #[test]
-    fn cleartext_fallback_auto_allowed_for_loopback_authorities() {
+    fn cleartext_fallback_requires_opt_in_even_for_loopback_authorities() {
+        for authority in [
+            "127.0.0.1:8080",
+            "localhost:8080",
+            "[::1]:8080",
+            "127.1.2.3:9000",
+        ] {
+            assert!(
+                !should_try_cleartext_fallback(
+                    "https",
+                    false,
+                    &AgentCardFetchError::Discovery("tls handshake failed".to_string()),
+                    authority,
+                ),
+                "cleartext fallback must stay disabled without opt-in for '{authority}'"
+            );
+        }
+    }
+
+    #[test]
+    fn cleartext_fallback_allows_loopback_after_opt_in() {
         // Local dev: harn serve is HTTP-only, so TLS handshake fails but we
         // still need the HTTP fallback to succeed.
         for authority in [
@@ -592,6 +636,7 @@ mod tests {
             assert!(
                 should_try_cleartext_fallback(
                     "https",
+                    true,
                     &AgentCardFetchError::Discovery("tls handshake failed".to_string()),
                     authority,
                 ),
@@ -613,6 +658,7 @@ mod tests {
             assert!(
                 !should_try_cleartext_fallback(
                     "https",
+                    true,
                     &AgentCardFetchError::Discovery("tls handshake failed".to_string()),
                     authority,
                 ),
@@ -638,6 +684,7 @@ mod tests {
     fn endpoint_from_card_rejects_card_url_authority_mismatch() {
         let error = endpoint_from_card(
             "https://trusted.example/.well-known/a2a-agent".to_string(),
+            false,
             "trusted.example",
             "triage".to_string(),
             &serde_json::json!({
@@ -653,7 +700,25 @@ mod tests {
     }
 
     #[test]
-    fn endpoint_from_card_accepts_loopback_alias_pairs() {
+    fn endpoint_from_card_rejects_cleartext_without_opt_in() {
+        let error = endpoint_from_card(
+            "https://127.0.0.1:8080/.well-known/a2a-agent".to_string(),
+            false,
+            "127.0.0.1:8080",
+            "triage".to_string(),
+            &serde_json::json!({
+                "url": "http://localhost:8080",
+                "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
+            }),
+        )
+        .expect_err("cleartext card should require explicit opt-in");
+        assert!(error
+            .to_string()
+            .contains("requires `allow_cleartext = true`"));
+    }
+
+    #[test]
+    fn endpoint_from_card_accepts_loopback_alias_pairs_when_cleartext_opted_in() {
         // harn serve reports `http://localhost:PORT` in its card, but clients
         // commonly dial `127.0.0.1:PORT`. Both refer to the same socket, so
         // the authority check must not spuriously reject the pair.
@@ -663,6 +728,7 @@ mod tests {
         });
         let endpoint = endpoint_from_card(
             "http://127.0.0.1:8080/.well-known/a2a-agent".to_string(),
+            true,
             "127.0.0.1:8080",
             "triage".to_string(),
             &card,
@@ -677,6 +743,7 @@ mod tests {
         });
         let endpoint_v6 = endpoint_from_card(
             "http://localhost:8080/.well-known/a2a-agent".to_string(),
+            true,
             "localhost:8080",
             "triage".to_string(),
             &card_v6,
@@ -691,6 +758,7 @@ mod tests {
         });
         let error = endpoint_from_card(
             "http://127.0.0.1:8080/.well-known/a2a-agent".to_string(),
+            true,
             "127.0.0.1:8080",
             "triage".to_string(),
             &card_wrong_port,

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -505,17 +505,20 @@ fn parse_trigger_config(config: &BTreeMap<String, VmValue>) -> Result<TriggerBin
     let kind = required_string(config, "kind", "trigger_register")?;
     let provider =
         crate::ProviderId::from(required_string(config, "provider", "trigger_register")?);
+    let allow_cleartext =
+        optional_bool(config, "allow_cleartext", "trigger_register")?.unwrap_or(false);
     let (handler, handler_descriptor) = parse_handler_value(
         config
             .get("handler")
             .ok_or_else(|| VmError::Runtime("trigger_register: missing `handler`".to_string()))?,
         "trigger_register",
         "handler",
+        allow_cleartext,
     )?;
     let when = match config.get("when") {
         Some(VmValue::Nil) | None => None,
         Some(value) => {
-            let (handler, _) = parse_handler_value(value, "trigger_register", "when")?;
+            let (handler, _) = parse_handler_value(value, "trigger_register", "when", false)?;
             match handler {
                 TriggerHandlerSpec::Local { raw, closure } => {
                     Some(TriggerPredicateSpec { raw, closure })
@@ -572,6 +575,7 @@ fn parse_trigger_config(config: &BTreeMap<String, VmValue>) -> Result<TriggerBin
         "match_events": match_events,
         "dedupe_key": dedupe_key,
         "filter": filter,
+        "allow_cleartext": allow_cleartext,
         "daily_cost_usd": daily_cost_usd,
         "max_concurrent": max_concurrent,
         "manifest_path": manifest_path.as_ref().map(|path| path.display().to_string()),
@@ -627,6 +631,7 @@ fn parse_handler_value(
     value: &VmValue,
     builtin: &str,
     field_name: &str,
+    allow_cleartext: bool,
 ) -> Result<(TriggerHandlerSpec, serde_json::Value), VmError> {
     match value {
         VmValue::Closure(closure) => {
@@ -647,10 +652,12 @@ fn parse_handler_value(
                 return Ok((
                     TriggerHandlerSpec::A2a {
                         target: target.to_string(),
+                        allow_cleartext,
                     },
                     serde_json::json!({
                         "kind": "a2a",
                         "target": target,
+                        "allow_cleartext": allow_cleartext,
                     }),
                 ));
             }
@@ -776,6 +783,20 @@ fn optional_string(map: &BTreeMap<String, VmValue>, key: &str) -> Option<String>
         VmValue::String(text) => Some(text.to_string()),
         _ => None,
     })
+}
+
+fn optional_bool(
+    map: &BTreeMap<String, VmValue>,
+    key: &str,
+    builtin: &str,
+) -> Result<Option<bool>, VmError> {
+    match map.get(key) {
+        Some(VmValue::Bool(value)) => Ok(Some(*value)),
+        Some(VmValue::Nil) | None => Ok(None),
+        Some(_) => Err(VmError::Runtime(format!(
+            "{builtin}: field `{key}` must be a bool"
+        ))),
+    }
 }
 
 fn parse_string_list(value: &VmValue) -> Result<Vec<String>, VmError> {

--- a/crates/harn-vm/src/stdlib_triggers.harn
+++ b/crates/harn-vm/src/stdlib_triggers.harn
@@ -252,6 +252,7 @@ type TriggerConfig = {
   events: list<string> | nil,
   dedupe_key: string | nil,
   filter: string | nil,
+  allow_cleartext: bool | nil,
   budget: TriggerBudget | nil,
   manifest_path: string | nil,
   package_name: string | nil,

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -1093,7 +1093,10 @@ impl Dispatcher {
                     .await?;
                 Ok(vm_value_to_json(&value))
             }
-            DispatchUri::A2a { target } => {
+            DispatchUri::A2a {
+                target,
+                allow_cleartext,
+            } => {
                 if self.state.shutting_down.load(Ordering::SeqCst) {
                     return Err(DispatchError::Cancelled(
                         "dispatcher shutdown cancelled A2A dispatch".to_string(),
@@ -1101,6 +1104,7 @@ impl Dispatcher {
                 }
                 let (_endpoint, ack) = crate::a2a::dispatch_trigger_event(
                     target,
+                    *allow_cleartext,
                     binding.id.as_str(),
                     &binding.binding_key(),
                     event,
@@ -1354,14 +1358,14 @@ fn dispatch_node_kind(route: &DispatchUri) -> &'static str {
 
 fn dispatch_node_label(route: &DispatchUri) -> String {
     match route {
-        DispatchUri::A2a { target } => crate::a2a::target_agent_label(target),
+        DispatchUri::A2a { target, .. } => crate::a2a::target_agent_label(target),
         _ => route.target_uri(),
     }
 }
 
 fn dispatch_target_agent(route: &DispatchUri) -> Option<String> {
     match route {
-        DispatchUri::A2a { target } => Some(crate::a2a::target_agent_label(target)),
+        DispatchUri::A2a { target, .. } => Some(crate::a2a::target_agent_label(target)),
         _ => None,
     }
 }

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -117,6 +117,7 @@ async fn dispatcher_fixture(
 async fn a2a_dispatcher_fixture(
     target: String,
     retry: TriggerRetryConfig,
+    allow_cleartext: bool,
 ) -> (
     tempfile::TempDir,
     Arc<crate::event_log::AnyEventLog>,
@@ -137,6 +138,7 @@ async fn a2a_dispatcher_fixture(
         provider: ProviderId::from("github"),
         handler: TriggerHandlerSpec::A2a {
             target: target.clone(),
+            allow_cleartext,
         },
         when: None,
         retry,
@@ -215,6 +217,25 @@ impl MockA2aServer {
 }
 
 fn spawn_mock_a2a_server(task_result: serde_json::Value) -> MockA2aServer {
+    spawn_mock_a2a_server_with_schemes(task_result, "https", "https")
+}
+
+fn spawn_mock_https_a2a_server_with_card_scheme(
+    task_result: serde_json::Value,
+    card_scheme: &'static str,
+) -> MockA2aServer {
+    spawn_mock_a2a_server_with_schemes(task_result, "https", card_scheme)
+}
+
+fn spawn_mock_http_a2a_server(task_result: serde_json::Value) -> MockA2aServer {
+    spawn_mock_a2a_server_with_schemes(task_result, "http", "http")
+}
+
+fn spawn_mock_a2a_server_with_schemes(
+    task_result: serde_json::Value,
+    listener_scheme: &'static str,
+    card_scheme: &'static str,
+) -> MockA2aServer {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock A2A listener");
     listener
         .set_nonblocking(true)
@@ -224,10 +245,15 @@ fn spawn_mock_a2a_server(task_result: serde_json::Value) -> MockA2aServer {
     let (tx, rx) = mpsc::channel();
     let stop = Arc::new(AtomicBool::new(false));
     let stop_thread = stop.clone();
-    let tls_config = mock_a2a_tls_config();
+    let tls_config = (listener_scheme == "https").then(mock_a2a_tls_config);
+    let max_connections = if listener_scheme == "http" && card_scheme == "http" {
+        3
+    } else {
+        2
+    };
     let join = thread::spawn(move || {
         let mut handled_requests = 0;
-        while handled_requests < 2 {
+        while handled_requests < max_connections {
             if stop_thread.load(Ordering::SeqCst) {
                 break;
             }
@@ -248,10 +274,33 @@ fn spawn_mock_a2a_server(task_result: serde_json::Value) -> MockA2aServer {
             stream
                 .set_write_timeout(Some(Duration::from_secs(5)))
                 .expect("set write timeout");
-            let connection = ServerConnection::new(tls_config.clone())
-                .expect("construct mock A2A TLS connection");
-            let mut stream = StreamOwned::new(connection, stream);
-            handle_mock_a2a_connection(&mut stream, addr.port(), &tx, &task_result);
+            if let Some(tls_config) = &tls_config {
+                let connection = ServerConnection::new(tls_config.clone())
+                    .expect("construct mock A2A TLS connection");
+                let mut stream = StreamOwned::new(connection, stream);
+                handle_mock_a2a_connection(
+                    &mut stream,
+                    card_scheme,
+                    addr.port(),
+                    &tx,
+                    &task_result,
+                );
+            } else {
+                let mut stream = stream;
+                let mut first = [0u8; 1];
+                let read = stream.peek(&mut first).expect("peek mock A2A stream");
+                if read == 0 || !matches!(first[0], b'G' | b'P') {
+                    handled_requests += 1;
+                    continue;
+                }
+                handle_mock_a2a_connection(
+                    &mut stream,
+                    card_scheme,
+                    addr.port(),
+                    &tx,
+                    &task_result,
+                );
+            }
             handled_requests += 1;
         }
     });
@@ -265,6 +314,7 @@ fn spawn_mock_a2a_server(task_result: serde_json::Value) -> MockA2aServer {
 
 fn handle_mock_a2a_connection<T: Read + Write>(
     stream: &mut T,
+    card_scheme: &str,
     port: u16,
     tx: &mpsc::Sender<serde_json::Value>,
     task_result: &serde_json::Value,
@@ -275,7 +325,7 @@ fn handle_mock_a2a_connection<T: Read + Write>(
             stream,
             &serde_json::json!({
                 "id": "mock-a2a",
-                "url": format!("https://127.0.0.1:{port}"),
+                "url": format!("{card_scheme}://127.0.0.1:{port}"),
                 "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
             }),
         );
@@ -454,6 +504,7 @@ async fn a2a_handler_returns_inline_result_and_emits_a2a_action_graph() {
             let (_dir, log, dispatcher) = a2a_dispatcher_fixture(
                 format!("{}/triage", server.authority),
                 TriggerRetryConfig::default(),
+                false,
             )
             .await;
 
@@ -515,6 +566,7 @@ async fn a2a_handler_returns_pending_task_handle() {
             let (_dir, _log, dispatcher) = a2a_dispatcher_fixture(
                 format!("{}/triage", server.authority),
                 TriggerRetryConfig::default(),
+                false,
             )
             .await;
 
@@ -561,6 +613,7 @@ async fn shutdown_cancels_a2a_dispatch_started_after_shutdown() {
             let (_dir, _log, dispatcher) = a2a_dispatcher_fixture(
                 format!("{}/triage", server.authority),
                 TriggerRetryConfig::default(),
+                false,
             )
             .await;
 
@@ -586,6 +639,92 @@ async fn shutdown_cancels_a2a_dispatch_started_after_shutdown() {
                 server.request_within(Duration::from_millis(100)).is_none(),
                 "A2A dispatch should not reach the remote after shutdown"
             );
+
+            server.finish();
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn a2a_handler_rejects_cleartext_by_default() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let server = spawn_mock_https_a2a_server_with_card_scheme(serde_json::json!({
+                "id": "task-inline",
+                "status": {"state": "completed"},
+                "history": [
+                    {"id": "msg-agent", "role": "agent", "parts": [{"type": "text", "text": "\"unexpected\""}]},
+                ],
+                "artifacts": [],
+            }), "http");
+            let (_dir, _log, dispatcher) = a2a_dispatcher_fixture(
+                format!("{}/triage", server.authority),
+                TriggerRetryConfig::new(1, RetryPolicy::Linear { delay_ms: 0 }),
+                false,
+            )
+            .await;
+
+            let outcomes = dispatcher
+                .dispatch_event(trigger_event("issues.opened", "delivery-a2a-http-denied"))
+                .await
+                .expect("cleartext denial returns terminal outcome");
+            assert_eq!(outcomes.len(), 1);
+            assert_eq!(outcomes[0].status, DispatchStatus::Dlq);
+            assert!(outcomes[0]
+                .error
+                .as_deref()
+                .is_some_and(|message| message.contains("allow_cleartext = true")));
+            assert!(
+                server.request_within(Duration::from_millis(100)).is_none(),
+                "cleartext A2A dispatch should not reach the HTTP rpc endpoint without opt-in"
+            );
+
+            server.finish();
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn a2a_handler_allows_cleartext_after_opt_in() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let server = spawn_mock_http_a2a_server(serde_json::json!({
+                "id": "task-inline",
+                "status": {"state": "completed"},
+                "history": [
+                    {"id": "msg-user", "role": "user", "parts": [{"type": "text", "text": "ignored"}]},
+                    {"id": "msg-agent", "role": "agent", "parts": [{"type": "text", "text": "{\"trace_id\":\"trace_http\",\"target_agent\":\"triage\"}"}]},
+                ],
+                "artifacts": [],
+            }));
+            let (_dir, _log, dispatcher) = a2a_dispatcher_fixture(
+                format!("{}/triage", server.authority),
+                TriggerRetryConfig::default(),
+                true,
+            )
+            .await;
+
+            let mut event = trigger_event("issues.opened", "delivery-a2a-http-allowed");
+            event.trace_id = TraceId("trace_http".to_string());
+
+            let outcomes = dispatcher
+                .dispatch_event(event)
+                .await
+                .expect("cleartext A2A dispatch succeeds after opt-in");
+            assert_eq!(outcomes.len(), 1);
+            assert_eq!(outcomes[0].status, DispatchStatus::Succeeded);
+            assert_eq!(
+                outcomes[0].result,
+                Some(serde_json::json!({
+                    "trace_id": "trace_http",
+                    "target_agent": "triage",
+                }))
+            );
+
+            let request = server.next_request();
+            assert_eq!(request["method"], "a2a.SendMessage");
 
             server.finish();
         })

--- a/crates/harn-vm/src/triggers/dispatcher/uri.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/uri.rs
@@ -23,9 +23,16 @@ impl std::error::Error for DispatchUriError {}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DispatchUri {
-    Local { raw: String },
-    A2a { target: String },
-    Worker { queue: String },
+    Local {
+        raw: String,
+    },
+    A2a {
+        target: String,
+        allow_cleartext: bool,
+    },
+    Worker {
+        queue: String,
+    },
 }
 
 impl DispatchUri {
@@ -42,6 +49,7 @@ impl DispatchUri {
             }
             return Ok(Self::A2a {
                 target: target.to_string(),
+                allow_cleartext: false,
             });
         }
         if let Some(queue) = raw.strip_prefix("worker://") {
@@ -73,7 +81,7 @@ impl DispatchUri {
     pub fn target_uri(&self) -> String {
         match self {
             Self::Local { raw } => raw.clone(),
-            Self::A2a { target } => format!("a2a://{target}"),
+            Self::A2a { target, .. } => format!("a2a://{target}"),
             Self::Worker { queue } => format!("worker://{queue}"),
         }
     }
@@ -83,8 +91,12 @@ impl From<&TriggerHandlerSpec> for DispatchUri {
     fn from(value: &TriggerHandlerSpec) -> Self {
         match value {
             TriggerHandlerSpec::Local { raw, .. } => Self::Local { raw: raw.clone() },
-            TriggerHandlerSpec::A2a { target } => Self::A2a {
+            TriggerHandlerSpec::A2a {
+                target,
+                allow_cleartext,
+            } => Self::A2a {
                 target: target.clone(),
+                allow_cleartext: *allow_cleartext,
             },
             TriggerHandlerSpec::Worker { queue } => Self::Worker {
                 queue: queue.clone(),

--- a/crates/harn-vm/src/triggers/registry.rs
+++ b/crates/harn-vm/src/triggers/registry.rs
@@ -74,16 +74,31 @@ impl TriggerBindingSource {
 
 #[derive(Clone)]
 pub enum TriggerHandlerSpec {
-    Local { raw: String, closure: Rc<VmClosure> },
-    A2a { target: String },
-    Worker { queue: String },
+    Local {
+        raw: String,
+        closure: Rc<VmClosure>,
+    },
+    A2a {
+        target: String,
+        allow_cleartext: bool,
+    },
+    Worker {
+        queue: String,
+    },
 }
 
 impl std::fmt::Debug for TriggerHandlerSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Local { raw, .. } => f.debug_struct("Local").field("raw", raw).finish(),
-            Self::A2a { target } => f.debug_struct("A2a").field("target", target).finish(),
+            Self::A2a {
+                target,
+                allow_cleartext,
+            } => f
+                .debug_struct("A2a")
+                .field("target", target)
+                .field("allow_cleartext", allow_cleartext)
+                .finish(),
             Self::Worker { queue } => f.debug_struct("Worker").field("queue", queue).finish(),
         }
     }

--- a/docs/src/stdlib/triggers.md
+++ b/docs/src/stdlib/triggers.md
@@ -47,6 +47,7 @@ Register a trigger dynamically and return its `TriggerHandle`.
 - `match` or `events`
 - `dedupe_key`
 - `filter`
+- `allow_cleartext`
 - `budget`
 - `manifest_path`
 - `package_name`
@@ -55,6 +56,10 @@ The runtime currently accepts two handler forms:
 
 - Local Harn closures / function references
 - Remote URI strings with `a2a://...` or `worker://...`
+
+`allow_cleartext` is optional and only applies to `a2a://...` handlers. Set it
+to `true` when you intentionally want HTTP A2A discovery / dispatch, for
+example when talking to a local `harn serve` process during development.
 
 `retry` is optional. The current stdlib surface accepts:
 
@@ -75,6 +80,7 @@ let handle: TriggerHandle = trigger_register({
   kind: "issue.opened",
   provider: "github",
   handler: handle_issue,
+  allow_cleartext: nil,
   when: nil,
   match: {events: ["issue.opened"]},
   events: nil,
@@ -177,6 +183,8 @@ println(replay.replay_of_event_id)     // original event id
 
 - Dynamic registrations are runtime-local. `trigger_register(...)` updates the
   live registry in the current process; it does not rewrite `harn.toml`.
+- `a2a://...` bindings default to HTTPS-only. Use `allow_cleartext: true` only
+  for intentional local or otherwise trusted HTTP peers.
 - `trigger_fire(...)` and `trigger_replay(...)` need an active EventLog to
   persist `triggers.events` and `triggers.dlq`. If the runtime did not already
   install one, the stdlib wrapper falls back to an in-memory log for the

--- a/docs/src/triggers/dispatcher.md
+++ b/docs/src/triggers/dispatcher.md
@@ -51,6 +51,8 @@ stable handler kind and target URI in lifecycle logs and action-graph nodes.
 For `a2a://host[:port]/path` routes, the dispatcher:
 
 - fetches `/.well-known/a2a-agent` from the target host
+- defaults to HTTPS-only discovery + dispatch; cleartext HTTP is rejected unless
+  the trigger binding explicitly sets `allow_cleartext = true`
 - requires exactly one JSON-RPC interface in the agent card before it will
   dispatch
 - treats the URI path as the `target_agent` label that propagates into the
@@ -58,6 +60,10 @@ For `a2a://host[:port]/path` routes, the dispatcher:
 - sends the `TriggerEvent` envelope over `a2a.SendMessage`
 - returns either the inline agent result (when the peer completes
   synchronously) or a pending task handle payload for the caller
+
+For local-dev receivers started with `harn serve`, add `allow_cleartext = true`
+on the trigger binding. `harn serve` is HTTP-only today, so the dispatcher will
+otherwise stop after the HTTPS probe instead of silently downgrading.
 
 ## Retry policy
 

--- a/docs/src/triggers/manifest.md
+++ b/docs/src/triggers/manifest.md
@@ -42,6 +42,14 @@ Harn currently accepts three handler forms:
 
 Unsupported URI schemes fail fast at load time.
 
+`a2a://...` handlers accept one extra opt-in field:
+
+- `allow_cleartext = true` permits HTTP A2A card discovery / JSON-RPC dispatch
+  for that binding
+
+Leave it unset for normal remote targets. It exists for bounded local-dev cases
+such as dispatching into `harn serve`, which currently listens on HTTP only.
+
 Local handlers and predicates resolve through the same module-export plumbing as
 the manifest hook loader:
 
@@ -56,6 +64,8 @@ The manifest loader rejects invalid trigger declarations before execution:
 - trigger ids must be unique across the loaded root manifest plus installed package manifests
 - `provider` must exist in the registered trigger provider catalog
 - `handler` must be a supported URI, and local handlers must resolve to exported functions
+- `allow_cleartext`, when present, must be a boolean and is only valid for
+  `a2a://...` handlers
 - `when` must resolve to a function with signature `fn(TriggerEvent) -> bool`
 - `dedupe_key` and `filter` must parse as JMESPath expressions
 - `retry.max` must be `<= 100`


### PR DESCRIPTION
## Summary
- gate cleartext A2A discovery and JSON-RPC dispatch behind an explicit `allow_cleartext` opt-in on `a2a://...` trigger bindings
- thread that flag through manifest loading, dynamic `trigger_register(...)`, dispatcher routing, runtime endpoint resolution, and docs/conformance coverage
- add focused tests for the accepted and rejected cleartext paths, including loopback/local-dev fallback behavior

## Why
Issue #250 follows the HTTPS-first A2A hardening work by removing the remaining silent downgrade path. Local HTTP peers like `harn serve` should still work for intentional dev/test flows, but only when the binding opts in explicitly.

## Root cause
The runtime still treated cleartext fallback as an implicit behavior of A2A discovery, especially for loopback targets. That meant an `a2a://...` binding could reach HTTP endpoints without any explicit acknowledgement in the trigger config.

## Impact
- default A2A trigger bindings are now HTTPS-only
- local/dev HTTP receivers require `allow_cleartext = true` in the manifest or `allow_cleartext: true` in `trigger_register(...)`
- invalid `allow_cleartext` usage now fails early during manifest validation

## Validation
- `env CARGO_TARGET_DIR=/tmp/harn-3927-a2a cargo test -p harn-vm a2a -- --nocapture`
- `env CARGO_TARGET_DIR=/tmp/harn-3927-a2a cargo test -p harn-cli collect_manifest_triggers -- --nocapture`
- `env CARGO_TARGET_DIR=/tmp/harn-3927-a2a HARN_CONFORMANCE_HARN_BIN=/tmp/harn-3927-a2a/debug/harn cargo run --quiet --bin harn -- test conformance --filter orchestrator_a2a_dispatch_sync`
- repo pre-commit hook (`cargo fmt`, clippy, markdownlint, portal lint, highlight sync)
- repo pre-push hook (`cargo nextest`, markdownlint, portal lint)`
