### PR TITLE
Fix webhook dedupe in async post-processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,13 +57,15 @@ granular archaeology.
   the trigger id, recorded version, event timestamp, and resolved
   version.
 
-- **Webhook inbound dedupe is back on for generic-webhook bindings
-  (#223).** `GenericWebhookConnector::normalize_inbound` now bridges
-  its sync trait surface to the async inbox index using the same
-  `block_on` pattern already used by the cron/GitHub connector layer,
-  so duplicate deliveries are rejected again by binding + delivery
-  key. Re-enabled the previously ignored webhook dedupe regression
-  test.
+- **Webhook inbox dedupe is active again (#223).** The async inbox-claim
+  step now runs after inbound webhook normalization but before the
+  event is appended to the pending log, so duplicate GitHub-style
+  deliveries are dropped instead of being enqueued twice. This
+  replaces the temporary `block_on` bridge inside
+  `GenericWebhookConnector::normalize_inbound` with a proper async
+  post-processing step on the dispatch path, keeping the connector
+  trait sync. The cron connector keeps its existing async dedupe path
+  and explicitly avoids double-claiming the same inbox key.
 
 - **Replay-scoped `HARN_REPLAY` no longer races across concurrent
   dispatches (harn#244).** Replay handlers still observe

--- a/conformance/tests/triggers/webhook_dedupe_blocks_duplicates.expected
+++ b/conformance/tests/triggers/webhook_dedupe_blocks_duplicates.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/conformance/tests/triggers/webhook_dedupe_blocks_duplicates.harn
+++ b/conformance/tests/triggers/webhook_dedupe_blocks_duplicates.harn
@@ -1,0 +1,7 @@
+pipeline test(task) {
+  let result = trigger_test_harness("webhook_dedupe_blocks_duplicates")
+  println(result.ok)
+  println(len(result.emitted) == 1)
+  println(result.emitted[0].dedupe_key == "delivery-123")
+  println(result.details.first_appended && !result.details.second_appended)
+}

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -55,6 +55,12 @@ impl ListenerRuntime {
     pub(crate) async fn start(config: ListenerConfig) -> Result<Self, String> {
         let pending_topic =
             Topic::new(PENDING_TOPIC).map_err(|error| format!("invalid pending topic: {error}"))?;
+        let inbox_metrics = Arc::new(harn_vm::MetricsRegistry::default());
+        let inbox = Arc::new(
+            harn_vm::InboxIndex::new(config.event_log.clone(), inbox_metrics)
+                .await
+                .map_err(|error| format!("failed to initialize inbox index: {error}"))?,
+        );
         let requires_auth = config
             .routes
             .iter()
@@ -69,6 +75,7 @@ impl ListenerRuntime {
         let routes = Arc::new(RouteRegistry::new(
             config.routes,
             config.event_log.clone(),
+            inbox,
             config.secrets.clone(),
             auth.clone(),
             pending_topic.clone(),
@@ -147,6 +154,8 @@ pub(crate) struct RouteConfig {
     pub(crate) auth_mode: AuthMode,
     pub(crate) signature_mode: SignatureMode,
     pub(crate) signing_secret: Option<SecretId>,
+    pub(crate) dedupe_key_template: Option<String>,
+    pub(crate) dedupe_retention_days: u32,
 }
 
 impl RouteConfig {
@@ -180,6 +189,8 @@ impl RouteConfig {
                             .get("signing_secret")
                             .map(String::as_str),
                     ),
+                    dedupe_key_template: trigger.config.dedupe_key.clone(),
+                    dedupe_retention_days: trigger.config.retry.retention_days,
                 }))
             }
             TriggerKind::A2aPush => Ok(Some(Self {
@@ -190,6 +201,8 @@ impl RouteConfig {
                 auth_mode: AuthMode::BearerOrHmac,
                 signature_mode: SignatureMode::Unsigned,
                 signing_secret: None,
+                dedupe_key_template: trigger.config.dedupe_key.clone(),
+                dedupe_retention_days: trigger.config.retry.retention_days,
             })),
             _ => Ok(None),
         }
@@ -200,6 +213,7 @@ impl RouteConfig {
 struct RouteContext {
     route: RouteConfig,
     event_log: Arc<AnyEventLog>,
+    inbox: Arc<harn_vm::InboxIndex>,
     secrets: Arc<dyn SecretProvider>,
     auth: Arc<ListenerAuth>,
     pending_topic: Topic,
@@ -223,6 +237,7 @@ struct RouteRegistry {
     routes_by_path: RwLock<BTreeMap<String, Arc<RouteContext>>>,
     metrics_by_trigger_id: Mutex<BTreeMap<String, Arc<RouteRuntimeMetrics>>>,
     event_log: Arc<AnyEventLog>,
+    inbox: Arc<harn_vm::InboxIndex>,
     secrets: Arc<dyn SecretProvider>,
     auth: Arc<ListenerAuth>,
     pending_topic: Topic,
@@ -233,6 +248,7 @@ impl RouteRegistry {
     fn new(
         routes: Vec<RouteConfig>,
         event_log: Arc<AnyEventLog>,
+        inbox: Arc<harn_vm::InboxIndex>,
         secrets: Arc<dyn SecretProvider>,
         auth: Arc<ListenerAuth>,
         pending_topic: Topic,
@@ -242,6 +258,7 @@ impl RouteRegistry {
             routes_by_path: RwLock::new(BTreeMap::new()),
             metrics_by_trigger_id: Mutex::new(BTreeMap::new()),
             event_log,
+            inbox,
             secrets,
             auth,
             pending_topic,
@@ -268,6 +285,7 @@ impl RouteRegistry {
                 Arc::new(RouteContext {
                     route,
                     event_log: self.event_log.clone(),
+                    inbox: self.inbox.clone(),
                     secrets: self.secrets.clone(),
                     auth: self.auth.clone(),
                     pending_topic: self.pending_topic.clone(),
@@ -382,40 +400,72 @@ async fn ingest_trigger(
     let result = normalize_request(&context, &normalized_headers, &query, body.as_ref()).await;
     let response = match result {
         Ok(event) => {
-            let payload = json!({
-                "trigger_id": context.route.trigger_id,
-                "binding_version": context.route.binding_version,
-                "event": event,
-            });
-            match context
-                .event_log
-                .append(
-                    &context.pending_topic,
-                    LogEvent::new("trigger_event", payload),
-                )
-                .await
-            {
-                Ok(event_id) => {
-                    context.metrics.dispatched.fetch_add(1, Ordering::Relaxed);
+            let dedupe_ttl = Duration::from_secs(
+                u64::from(context.route.dedupe_retention_days.max(1)) * 24 * 60 * 60,
+            );
+            let postprocess = harn_vm::postprocess_normalized_event(
+                context.inbox.as_ref(),
+                &context.route.trigger_id,
+                context.route.dedupe_key_template.is_some(),
+                dedupe_ttl,
+                event,
+            )
+            .await;
+            match postprocess {
+                Ok(harn_vm::PostNormalizeOutcome::DuplicateDropped) => {
                     context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
                     (
                         StatusCode::OK,
                         axum::Json(json!({
-                            "status": "accepted",
-                            "event_id": event_id,
+                            "status": "duplicate_dropped",
                             "trigger_id": context.route.trigger_id,
                         })),
                     )
                         .into_response()
                 }
+                Ok(harn_vm::PostNormalizeOutcome::Ready(event)) => {
+                    let event = *event;
+                    let payload = json!({
+                        "trigger_id": context.route.trigger_id,
+                        "binding_version": context.route.binding_version,
+                        "event": event,
+                    });
+                    match context
+                        .event_log
+                        .append(
+                            &context.pending_topic,
+                            LogEvent::new("trigger_event", payload),
+                        )
+                        .await
+                    {
+                        Ok(event_id) => {
+                            context.metrics.dispatched.fetch_add(1, Ordering::Relaxed);
+                            context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+                            (
+                                StatusCode::OK,
+                                axum::Json(json!({
+                                    "status": "accepted",
+                                    "event_id": event_id,
+                                    "trigger_id": context.route.trigger_id,
+                                })),
+                            )
+                                .into_response()
+                        }
+                        Err(error) => {
+                            context.metrics.failed.fetch_add(1, Ordering::Relaxed);
+                            context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+                            (
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                format!("failed to append trigger event to pending log: {error}"),
+                            )
+                                .into_response()
+                        }
+                    }
+                }
                 Err(error) => {
                     context.metrics.failed.fetch_add(1, Ordering::Relaxed);
                     context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("failed to append trigger event to pending log: {error}"),
-                    )
-                        .into_response()
+                    HttpError::from_connector(error).into_response()
                 }
             }
         }
@@ -523,6 +573,7 @@ async fn normalize_request(
         ),
         provider_payload,
         signature_status,
+        dedupe_claimed: false,
     })
 }
 
@@ -900,10 +951,14 @@ mod tests {
     use harn_vm::event_log::{
         install_default_for_base_dir, reset_active_event_log, EventLog, Topic,
     };
+    use harn_vm::secrets::{
+        RotationHandle, SecretBytes, SecretError, SecretId, SecretMeta, SecretProvider,
+    };
     use harn_vm::{
         ProviderId, TriggerBindingSource, TriggerBindingSpec, TriggerHandlerSpec,
         TriggerRetryConfig,
     };
+    use sha2::{Digest, Sha256};
     use tempfile::tempdir;
 
     static REQUEST_DELAY_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -940,7 +995,103 @@ mod tests {
             auth_mode: AuthMode::Public,
             signature_mode: SignatureMode::Unsigned,
             signing_secret: None,
+            dedupe_key_template: None,
+            dedupe_retention_days: harn_vm::DEFAULT_INBOX_RETENTION_DAYS,
         }
+    }
+
+    #[derive(Clone)]
+    struct StaticSecretProvider {
+        secret_id: SecretId,
+        secret: String,
+    }
+
+    #[async_trait::async_trait]
+    impl SecretProvider for StaticSecretProvider {
+        async fn get(&self, id: &SecretId) -> Result<SecretBytes, SecretError> {
+            if id == &self.secret_id {
+                Ok(SecretBytes::from(self.secret.clone()))
+            } else {
+                Err(SecretError::NotFound {
+                    provider: self.namespace().to_string(),
+                    id: id.clone(),
+                })
+            }
+        }
+
+        async fn put(&self, _id: &SecretId, _value: SecretBytes) -> Result<(), SecretError> {
+            Ok(())
+        }
+
+        async fn rotate(&self, id: &SecretId) -> Result<RotationHandle, SecretError> {
+            Ok(RotationHandle {
+                provider: self.namespace().to_string(),
+                id: id.clone(),
+                from_version: None,
+                to_version: None,
+            })
+        }
+
+        async fn list(&self, _prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError> {
+            Ok(Vec::new())
+        }
+
+        fn namespace(&self) -> &str {
+            "listener-test"
+        }
+
+        fn supports_versions(&self) -> bool {
+            false
+        }
+    }
+
+    fn webhook_route(path: &str) -> RouteConfig {
+        RouteConfig {
+            trigger_id: "github-webhook".to_string(),
+            binding_version: 1,
+            provider: ProviderId::from("github"),
+            path: path.to_string(),
+            auth_mode: AuthMode::Public,
+            signature_mode: SignatureMode::GitHub,
+            signing_secret: Some(SecretId::new("github", "test-signing-secret")),
+            dedupe_key_template: Some("event.dedupe_key".to_string()),
+            dedupe_retention_days: harn_vm::DEFAULT_INBOX_RETENTION_DAYS,
+        }
+    }
+
+    fn github_signature(secret: &str, body: &[u8]) -> String {
+        const BLOCK: usize = 64;
+        let mut key = secret.as_bytes().to_vec();
+        if key.len() > BLOCK {
+            key = Sha256::digest(&key).to_vec();
+        }
+        key.resize(BLOCK, 0);
+        let mut inner_pad = vec![0x36; BLOCK];
+        let mut outer_pad = vec![0x5c; BLOCK];
+        for i in 0..BLOCK {
+            inner_pad[i] ^= key[i];
+            outer_pad[i] ^= key[i];
+        }
+        let mut inner = Sha256::new();
+        inner.update(&inner_pad);
+        inner.update(body);
+        let inner_digest = inner.finalize();
+
+        let mut outer = Sha256::new();
+        outer.update(&outer_pad);
+        outer.update(inner_digest);
+        let digest = outer.finalize();
+        let encoded = digest
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        format!("sha256={encoded}")
+    }
+
+    async fn pending_events(log: &Arc<AnyEventLog>) -> Vec<(u64, harn_vm::event_log::LogEvent)> {
+        log.read_range(&Topic::new(PENDING_TOPIC).expect("pending topic"), None, 16)
+            .await
+            .expect("read pending events")
     }
 
     #[allow(clippy::await_holding_lock)]
@@ -1063,5 +1214,128 @@ mod tests {
         std::env::remove_var(REQUEST_DELAY_ENV);
         reset_active_event_log();
         harn_vm::clear_trigger_registry();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn webhook_first_delivery_is_appended() {
+        reset_active_event_log();
+        let dir = tempdir().expect("tempdir");
+        let log = install_default_for_base_dir(dir.path()).expect("install event log");
+        let listener = ListenerRuntime::start(ListenerConfig {
+            bind: "127.0.0.1:0".parse().expect("bind addr"),
+            tls: None,
+            event_log: log.clone(),
+            secrets: Arc::new(StaticSecretProvider {
+                secret_id: SecretId::new("github", "test-signing-secret"),
+                secret: "topsecret".to_string(),
+            }),
+            allowed_origins: OriginAllowList::wildcard(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            routes: vec![webhook_route("/hooks/github")],
+        })
+        .await
+        .expect("start listener");
+
+        let body = br#"{"action":"opened","issue":{"number":1}}"#;
+        let response = reqwest::Client::new()
+            .post(format!("http://{}/hooks/github", listener.local_addr()))
+            .header("X-GitHub-Event", "issues")
+            .header("X-GitHub-Delivery", "delivery-1")
+            .header("X-Hub-Signature-256", github_signature("topsecret", body))
+            .header("Content-Type", "application/json")
+            .body(body.to_vec())
+            .send()
+            .await
+            .expect("send webhook");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let payload: JsonValue = response.json().await.expect("response json");
+        assert_eq!(
+            payload.get("status"),
+            Some(&JsonValue::String("accepted".to_string()))
+        );
+
+        let events = pending_events(&log).await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0]
+                .1
+                .payload
+                .get("event")
+                .and_then(|value| value.get("dedupe_key"))
+                .and_then(JsonValue::as_str),
+            Some("delivery-1")
+        );
+
+        listener
+            .shutdown(Duration::from_secs(5))
+            .await
+            .expect("shutdown listener");
+        reset_active_event_log();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn webhook_duplicate_delivery_is_dropped() {
+        reset_active_event_log();
+        let dir = tempdir().expect("tempdir");
+        let log = install_default_for_base_dir(dir.path()).expect("install event log");
+        let listener = ListenerRuntime::start(ListenerConfig {
+            bind: "127.0.0.1:0".parse().expect("bind addr"),
+            tls: None,
+            event_log: log.clone(),
+            secrets: Arc::new(StaticSecretProvider {
+                secret_id: SecretId::new("github", "test-signing-secret"),
+                secret: "topsecret".to_string(),
+            }),
+            allowed_origins: OriginAllowList::wildcard(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            routes: vec![webhook_route("/hooks/github")],
+        })
+        .await
+        .expect("start listener");
+
+        let body = br#"{"action":"opened","issue":{"number":1}}"#;
+        let signature = github_signature("topsecret", body);
+        let client = reqwest::Client::new();
+        let url = format!("http://{}/hooks/github", listener.local_addr());
+
+        let first = client
+            .post(&url)
+            .header("X-GitHub-Event", "issues")
+            .header("X-GitHub-Delivery", "delivery-1")
+            .header("X-Hub-Signature-256", &signature)
+            .header("Content-Type", "application/json")
+            .body(body.to_vec())
+            .send()
+            .await
+            .expect("send first webhook");
+        assert_eq!(first.status(), StatusCode::OK);
+
+        let duplicate = client
+            .post(&url)
+            .header("X-GitHub-Event", "issues")
+            .header("X-GitHub-Delivery", "delivery-1")
+            .header("X-Hub-Signature-256", &signature)
+            .header("Content-Type", "application/json")
+            .body(body.to_vec())
+            .send()
+            .await
+            .expect("send duplicate webhook");
+
+        assert_eq!(duplicate.status(), StatusCode::OK);
+        let payload: JsonValue = duplicate.json().await.expect("duplicate response json");
+        assert_eq!(
+            payload.get("status"),
+            Some(&JsonValue::String("duplicate_dropped".to_string()))
+        );
+
+        let events = pending_events(&log).await;
+        assert_eq!(events.len(), 1);
+
+        listener
+            .shutdown(Duration::from_secs(5))
+            .await
+            .expect("shutdown listener");
+        reset_active_event_log();
     }
 }

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -333,6 +333,7 @@ fn trigger_binding_for(config: &ResolvedTriggerConfig) -> Result<harn_vm::Trigge
         kind: harn_vm::TriggerKind::from(trigger_kind_name(config.kind)),
         binding_id: config.id.clone(),
         dedupe_key: config.dedupe_key.clone(),
+        dedupe_retention_days: config.retry.retention_days,
         config: connector_binding_config(config)?,
     })
 }
@@ -354,11 +355,8 @@ fn connector_binding_config(config: &ResolvedTriggerConfig) -> Result<JsonValue,
         })),
         _ => Ok(JsonValue::Null),
     }
-    // Note: #220's earlier approach inserted `retention_days` into the JSON
-    // binding config. Post-#221, dedupe retention is carried on the
-    // TriggerBinding struct field `dedupe_retention_days` (see
-    // triggers/registry.rs) rather than in the connector-specific JSON,
-    // so no insertion is needed here.
+    // Dedupe retention lives on the connector TriggerBinding rather than in
+    // connector-specific JSON, so no retention_days insertion is needed here.
 }
 
 fn connector_for(

--- a/crates/harn-cli/src/commands/trigger/replay.rs
+++ b/crates/harn-cli/src/commands/trigger/replay.rs
@@ -651,6 +651,7 @@ pub fn {handler_name}(event: TriggerEvent) -> string {{
                 },
             )),
             signature_status: harn_vm::SignatureStatus::Verified,
+            dedupe_claimed: false,
         }
     }
 

--- a/crates/harn-vm/src/connectors/cron/mod.rs
+++ b/crates/harn-vm/src/connectors/cron/mod.rs
@@ -304,7 +304,7 @@ impl CronEventSink for EventLogCronEventSink {
         &self,
         binding_id: &str,
         retention: StdDuration,
-        event: TriggerEvent,
+        mut event: TriggerEvent,
     ) -> Result<(), ConnectorError> {
         if !self
             .inbox
@@ -313,6 +313,24 @@ impl CronEventSink for EventLogCronEventSink {
         {
             return Ok(());
         }
+        let dedupe_key = event.dedupe_key.clone();
+        event.mark_dedupe_claimed();
+        let event = match crate::connectors::postprocess_normalized_event(
+            self.inbox.as_ref(),
+            binding_id,
+            true,
+            retention,
+            event,
+        )
+        .await?
+        {
+            crate::connectors::PostNormalizeOutcome::Ready(event) => *event,
+            crate::connectors::PostNormalizeOutcome::DuplicateDropped => {
+                return Err(ConnectorError::Activation(format!(
+                    "cron event `{dedupe_key}` for binding `{binding_id}` was deduped twice"
+                )));
+            }
+        };
         let payload = serde_json::to_value(&event).map_err(ConnectorError::from)?;
         self.event_log
             .append(&self.topic, LogEvent::new("trigger_event", payload))

--- a/crates/harn-vm/src/connectors/cron/tests.rs
+++ b/crates/harn-vm/src/connectors/cron/tests.rs
@@ -55,6 +55,7 @@ fn binding(id: &str, schedule: &str, timezone: &str, catchup_mode: CatchupMode) 
         kind: TriggerKind::from("cron"),
         binding_id: id.to_string(),
         dedupe_key: None,
+        dedupe_retention_days: crate::triggers::DEFAULT_INBOX_RETENTION_DAYS,
         config: json!({
             "schedule": schedule,
             "timezone": timezone,
@@ -324,6 +325,36 @@ async fn default_sink_writes_trigger_events_to_event_log() {
     let topic = Topic::new(CRON_TICK_TOPIC).unwrap();
     let events = log.read_range(&topic, None, usize::MAX).await.unwrap();
     assert_eq!(events.len(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn default_sink_does_not_double_claim_dedupe() {
+    let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(32)));
+    let metrics = Arc::new(MetricsRegistry::default());
+    let inbox = Arc::new(InboxIndex::new(log.clone(), metrics.clone()).await.unwrap());
+    let sink = EventLogCronEventSink::new(log.clone(), inbox);
+    let trigger =
+        super::CronTrigger::from_binding(&binding("hourly", "* * * * *", "UTC", CatchupMode::Skip))
+            .unwrap();
+
+    sink.emit(
+        "hourly",
+        trigger.dedupe_retention,
+        trigger.to_event(parse("2026-04-19T00:01:00Z"), false),
+    )
+    .await
+    .unwrap();
+
+    let inbox_topic = Topic::new(crate::triggers::TRIGGER_INBOX_CLAIMS_TOPIC).unwrap();
+    let claims = log
+        .read_range(&inbox_topic, None, usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(
+        claims.len(),
+        1,
+        "cron post-processing should not re-claim inbox dedupe"
+    );
 }
 
 #[test]

--- a/crates/harn-vm/src/connectors/github/mod.rs
+++ b/crates/harn-vm/src/connectors/github/mod.rs
@@ -445,6 +445,7 @@ impl Connector for GitHubConnector {
             headers: redact_headers(&headers, &HeaderRedactionPolicy::default()),
             provider_payload,
             signature_status: SignatureStatus::Verified,
+            dedupe_claimed: false,
         })
     }
 

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -86,6 +86,32 @@ pub trait Connector: Send + Sync {
     fn client(&self) -> Arc<dyn ConnectorClient>;
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum PostNormalizeOutcome {
+    Ready(Box<TriggerEvent>),
+    DuplicateDropped,
+}
+
+pub async fn postprocess_normalized_event(
+    inbox: &InboxIndex,
+    binding_id: &str,
+    dedupe_enabled: bool,
+    dedupe_ttl: StdDuration,
+    mut event: TriggerEvent,
+) -> Result<PostNormalizeOutcome, ConnectorError> {
+    if dedupe_enabled && !event.dedupe_claimed() {
+        if !inbox
+            .insert_if_new(binding_id, &event.dedupe_key, dedupe_ttl)
+            .await?
+        {
+            return Ok(PostNormalizeOutcome::DuplicateDropped);
+        }
+        event.mark_dedupe_claimed();
+    }
+
+    Ok(PostNormalizeOutcome::Ready(Box::new(event)))
+}
+
 /// Outbound provider client interface used by connector-backed stdlib modules.
 #[async_trait]
 pub trait ConnectorClient: Send + Sync {
@@ -341,6 +367,8 @@ pub struct TriggerBinding {
     pub binding_id: String,
     #[serde(default)]
     pub dedupe_key: Option<String>,
+    #[serde(default = "default_dedupe_retention_days")]
+    pub dedupe_retention_days: u32,
     #[serde(default)]
     pub config: JsonValue,
 }
@@ -356,9 +384,14 @@ impl TriggerBinding {
             kind: kind.into(),
             binding_id: binding_id.into(),
             dedupe_key: None,
+            dedupe_retention_days: crate::triggers::DEFAULT_INBOX_RETENTION_DAYS,
             config: JsonValue::Null,
         }
     }
+}
+
+fn default_dedupe_retention_days() -> u32 {
+    crate::triggers::DEFAULT_INBOX_RETENTION_DAYS
 }
 
 /// Small in-memory trigger-binding registry used to fan bindings into connectors.

--- a/crates/harn-vm/src/connectors/webhook/mod.rs
+++ b/crates/harn-vm/src/connectors/webhook/mod.rs
@@ -16,7 +16,7 @@ use crate::connectors::{
 use crate::secrets::{SecretId, SecretVersion};
 use crate::triggers::{
     redact_headers, HeaderRedactionPolicy, ProviderId, ProviderPayload, SignatureStatus, TraceId,
-    TriggerEvent, TriggerEventId, DEFAULT_INBOX_RETENTION_DAYS,
+    TriggerEvent, TriggerEventId,
 };
 
 pub mod variants;
@@ -73,13 +73,12 @@ struct ConnectorState {
 
 #[derive(Clone, Debug)]
 struct ActivatedWebhookBinding {
+    #[allow(dead_code)]
     binding_id: String,
     path: Option<String>,
     signing_secret: SecretId,
     signature_variant: WebhookSignatureVariant,
     timestamp_tolerance: Option<Duration>,
-    dedupe_enabled: bool,
-    dedupe_ttl: std::time::Duration,
     source: Option<String>,
 }
 
@@ -228,20 +227,6 @@ impl Connector for GenericWebhookConnector {
             &normalized_body,
             &raw.body,
         );
-        if binding.dedupe_enabled {
-            let inserted = futures::executor::block_on(ctx.inbox.insert_if_new(
-                &binding.binding_id,
-                &dedupe_key,
-                binding.dedupe_ttl,
-            ))?;
-            if !inserted {
-                return Err(ConnectorError::DuplicateDelivery(format!(
-                    "duplicate {} delivery `{dedupe_key}` for binding `{}`",
-                    provider.as_str(),
-                    binding.binding_id
-                )));
-            }
-        }
 
         let provider_payload = ProviderPayload::normalize(
             &provider,
@@ -265,6 +250,7 @@ impl Connector for GenericWebhookConnector {
             headers: redact_headers(&effective_headers, &HeaderRedactionPolicy::default()),
             provider_payload,
             signature_status: SignatureStatus::Verified,
+            dedupe_claimed: false,
         })
     }
 
@@ -317,10 +303,6 @@ impl ActivatedWebhookBinding {
             signing_secret,
             signature_variant,
             timestamp_tolerance,
-            dedupe_enabled: binding.dedupe_key.is_some(),
-            dedupe_ttl: std::time::Duration::from_secs(
-                u64::from(DEFAULT_INBOX_RETENTION_DAYS) * 24 * 60 * 60,
-            ),
             source: config.webhook.source,
         })
     }

--- a/crates/harn-vm/src/connectors/webhook/tests.rs
+++ b/crates/harn-vm/src/connectors/webhook/tests.rs
@@ -361,8 +361,8 @@ async fn webhook_variants_cover_valid_and_failure_cases() {
     }
 }
 
-#[tokio::test(flavor = "current_thread")]
-async fn normalize_inbound_dedupes_on_binding_delivery_key() {
+#[tokio::test]
+async fn postprocess_drops_duplicate_delivery_key() {
     let harness = TestHarness::new(
         binding(WebhookSignatureVariant::Standard, Some("event.dedupe_key")),
         "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw",
@@ -388,9 +388,37 @@ async fn normalize_inbound_dedupes_on_binding_delivery_key() {
 
     let first = harness.connector.normalize_inbound(raw.clone()).unwrap();
     assert_eq!(first.dedupe_key, "msg_p5jXN8AQM9LWM0D4loKWxJek");
+    let first = crate::connectors::postprocess_normalized_event(
+        harness.connector.ctx().unwrap().inbox.as_ref(),
+        "webhook.test",
+        true,
+        std::time::Duration::from_secs(
+            u64::from(crate::DEFAULT_INBOX_RETENTION_DAYS) * 24 * 60 * 60,
+        ),
+        first,
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        first,
+        crate::connectors::PostNormalizeOutcome::Ready(_)
+    ));
 
-    let duplicate = harness.connector.normalize_inbound(raw).unwrap_err();
-    assert!(matches!(duplicate, ConnectorError::DuplicateDelivery(_)));
+    let duplicate = crate::connectors::postprocess_normalized_event(
+        harness.connector.ctx().unwrap().inbox.as_ref(),
+        "webhook.test",
+        true,
+        std::time::Duration::from_secs(
+            u64::from(crate::DEFAULT_INBOX_RETENTION_DAYS) * 24 * 60 * 60,
+        ),
+        harness.connector.normalize_inbound(raw).unwrap(),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        duplicate,
+        crate::connectors::PostNormalizeOutcome::DuplicateDropped
+    ));
 }
 
 #[tokio::test]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -42,11 +42,11 @@ pub use connectors::{
     active_connector_client, clear_active_connector_clients,
     cron::{CatchupMode, CronConnector},
     hmac::verify_hmac_signed,
-    install_active_connector_clients, ActivationHandle, ClientError, Connector, ConnectorClient,
-    ConnectorCtx, ConnectorError, ConnectorMetricsSnapshot, ConnectorRegistry,
-    GenericWebhookConnector, GitHubConnector, MetricsRegistry, ProviderPayloadSchema,
-    RateLimitConfig, RateLimiterFactory, RawInbound, TriggerBinding, TriggerKind, TriggerRegistry,
-    WebhookSignatureVariant,
+    install_active_connector_clients, postprocess_normalized_event, ActivationHandle, ClientError,
+    Connector, ConnectorClient, ConnectorCtx, ConnectorError, ConnectorMetricsSnapshot,
+    ConnectorRegistry, GenericWebhookConnector, GitHubConnector, MetricsRegistry,
+    PostNormalizeOutcome, ProviderPayloadSchema, RateLimitConfig, RateLimiterFactory, RawInbound,
+    TriggerBinding, TriggerKind, TriggerRegistry, WebhookSignatureVariant,
 };
 pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -485,6 +485,7 @@ fn derive_run_observability_adds_trigger_and_predicate_nodes_with_shared_trace_i
             }),
         ),
         signature_status: crate::triggers::SignatureStatus::Unsigned,
+        dedupe_claimed: false,
     };
     let run = RunRecord {
         id: "run_trigger_obs".to_string(),
@@ -579,6 +580,7 @@ fn derive_run_observability_adds_replay_chain_for_replayed_trigger_runs() {
             ),
         ),
         signature_status: crate::triggers::SignatureStatus::Verified,
+        dedupe_claimed: false,
     };
     let run = RunRecord {
         id: "run_replay_chain".to_string(),

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -937,6 +937,7 @@ mod tests {
                 },
             )),
             signature_status: crate::SignatureStatus::Verified,
+            dedupe_claimed: false,
         }
     }
 

--- a/crates/harn-vm/src/triggers/event.rs
+++ b/crates/harn-vm/src/triggers/event.rs
@@ -284,6 +284,8 @@ pub struct TriggerEvent {
     pub headers: BTreeMap<String, String>,
     pub provider_payload: ProviderPayload,
     pub signature_status: SignatureStatus,
+    #[serde(skip)]
+    pub dedupe_claimed: bool,
 }
 
 impl TriggerEvent {
@@ -310,7 +312,16 @@ impl TriggerEvent {
             headers,
             provider_payload,
             signature_status,
+            dedupe_claimed: false,
         }
+    }
+
+    pub fn dedupe_claimed(&self) -> bool {
+        self.dedupe_claimed
+    }
+
+    pub fn mark_dedupe_claimed(&mut self) {
+        self.dedupe_claimed = true;
     }
 }
 
@@ -1112,6 +1123,7 @@ mod tests {
             headers,
             provider_payload: payload,
             signature_status: SignatureStatus::Verified,
+            dedupe_claimed: false,
         };
 
         let once = serde_json::to_value(&event).unwrap();

--- a/crates/harn-vm/src/triggers/test_util/mod.rs
+++ b/crates/harn-vm/src/triggers/test_util/mod.rs
@@ -12,7 +12,9 @@ use tokio::sync::Notify;
 use uuid::Uuid;
 
 use crate::connectors::cron::{CatchupMode, CronConnector, CronEventSink};
-use crate::connectors::webhook::{GenericWebhookConnector, WebhookSignatureVariant};
+use crate::connectors::webhook::{
+    GenericWebhookConnector, WebhookProviderProfile, WebhookSignatureVariant,
+};
 use crate::connectors::{
     Connector, ConnectorCtx, ConnectorError, MetricsRegistry, RateLimitConfig, RateLimiterFactory,
     RawInbound, TriggerBinding as ConnectorTriggerBinding,
@@ -50,6 +52,7 @@ pub const TRIGGER_TEST_FIXTURES: &[&str] = &[
     "rate_limit_throttles",
     "replay_binding_gc_fallback",
     "replay_refires_from_dlq",
+    "webhook_dedupe_blocks_duplicates",
     "webhook_verifies_hmac",
 ];
 
@@ -222,6 +225,7 @@ impl TriggerTestHarness {
             "rate_limit_throttles" => self.rate_limit_throttles().await,
             "replay_binding_gc_fallback" => self.replay_binding_gc_fallback().await,
             "replay_refires_from_dlq" => self.replay_refires_from_dlq().await,
+            "webhook_dedupe_blocks_duplicates" => self.webhook_dedupe_blocks_duplicates().await,
             "webhook_verifies_hmac" => self.webhook_verifies_hmac().await,
             _ => Err(format!(
                 "unknown trigger harness fixture '{fixture}' (known: {})",
@@ -508,21 +512,61 @@ impl TriggerTestHarness {
             .map_err(|error| error.to_string())?;
 
         let raw = standard_raw_inbound();
+        let binding_id = "webhook.fixture";
+        let retention =
+            StdDuration::from_secs(u64::from(DEFAULT_INBOX_RETENTION_DAYS) * 24 * 60 * 60);
         let first = connector
             .normalize_inbound(raw.clone())
             .map_err(|error| error.to_string())?;
-        self.connector_registry.record_event(
-            "webhook.fixture",
-            1,
-            &first,
-            Some("first_delivery"),
-            None,
+        let first_claim = matches!(
+            crate::connectors::postprocess_normalized_event(
+                inbox.as_ref(),
+                binding_id,
+                true,
+                retention,
+                first.clone(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+            crate::connectors::PostNormalizeOutcome::Ready(_)
         );
-        let duplicate = connector.normalize_inbound(raw).unwrap_err();
+        if first_claim {
+            self.connector_registry.record_event(
+                binding_id,
+                1,
+                &first,
+                Some("first_delivery"),
+                None,
+            );
+        }
+        let second = connector
+            .normalize_inbound(raw)
+            .map_err(|error| error.to_string())?;
+        let second_claim = matches!(
+            crate::connectors::postprocess_normalized_event(
+                inbox.as_ref(),
+                binding_id,
+                true,
+                retention,
+                second.clone(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+            crate::connectors::PostNormalizeOutcome::Ready(_)
+        );
+        if second_claim {
+            self.connector_registry.record_event(
+                binding_id,
+                1,
+                &second,
+                Some("duplicate_delivery"),
+                None,
+            );
+        }
         let emitted = self.connector_registry.emitted();
         Ok(TriggerHarnessResult {
             fixture: "dedupe_swallows_duplicate_key".to_string(),
-            ok: emitted.len() == 1 && matches!(duplicate, ConnectorError::DuplicateDelivery(_)),
+            ok: first_claim && !second_claim && emitted.len() == 1,
             stub: false,
             summary: "duplicate inbound deliveries are swallowed by the dedupe guard".to_string(),
             emitted,
@@ -533,7 +577,135 @@ impl TriggerTestHarness {
             notes: Vec::new(),
             details: json!({
                 "dedupe_key": first.dedupe_key,
-                "duplicate_error": duplicate.to_string(),
+                "first_claim": first_claim,
+                "second_claim": second_claim,
+                "duplicate_error": if !second_claim {
+                    format!(
+                        "duplicate delivery `{}` for binding `{}` dropped by post-normalize dedupe",
+                        second.dedupe_key, binding_id
+                    )
+                } else {
+                    String::new()
+                },
+            }),
+        })
+    }
+
+    async fn webhook_dedupe_blocks_duplicates(self) -> Result<TriggerHarnessResult, String> {
+        let _guard = clock::install_override(self.clock.clone());
+        let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(32)));
+        let inbox = build_inbox(&log).await;
+        let mut connector = GenericWebhookConnector::with_profile(WebhookProviderProfile::new(
+            ProviderId::from("github"),
+            "GitHubEventPayload",
+            WebhookSignatureVariant::GitHub,
+        ));
+        connector
+            .init(connector_ctx(
+                log,
+                Arc::new(StaticSecretProvider::new(
+                    "github",
+                    BTreeMap::from([(
+                        SecretId::new("github", "test-signing-secret"),
+                        "It's a Secret to Everybody".to_string(),
+                    )]),
+                )),
+                inbox.clone(),
+            ))
+            .await
+            .map_err(|error| error.to_string())?;
+        let mut binding =
+            webhook_binding(WebhookSignatureVariant::GitHub, Some("event.dedupe_key"));
+        binding.provider = ProviderId::from("github");
+        binding.binding_id = "github.webhook.fixture".to_string();
+        binding.config = json!({
+            "match": { "path": "/hooks/github" },
+            "secrets": { "signing_secret": "github/test-signing-secret" },
+            "webhook": {
+                "signature_scheme": "github",
+                "source": "fixtures",
+            }
+        });
+        connector
+            .activate(&[binding])
+            .await
+            .map_err(|error| error.to_string())?;
+
+        let raw = github_raw_inbound();
+        let binding_id = "github.webhook.fixture";
+        let retention =
+            StdDuration::from_secs(u64::from(DEFAULT_INBOX_RETENTION_DAYS) * 24 * 60 * 60);
+
+        let first = connector
+            .normalize_inbound(raw.clone())
+            .map_err(|error| error.to_string())?;
+        let first_appended = matches!(
+            crate::connectors::postprocess_normalized_event(
+                inbox.as_ref(),
+                binding_id,
+                true,
+                retention,
+                first.clone(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+            crate::connectors::PostNormalizeOutcome::Ready(_)
+        );
+        if first_appended {
+            self.connector_registry.record_event(
+                binding_id,
+                1,
+                &first,
+                Some("first_delivery"),
+                None,
+            );
+        }
+
+        let second = connector
+            .normalize_inbound(raw)
+            .map_err(|error| error.to_string())?;
+        let second_appended = matches!(
+            crate::connectors::postprocess_normalized_event(
+                inbox.as_ref(),
+                binding_id,
+                true,
+                retention,
+                second.clone(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+            crate::connectors::PostNormalizeOutcome::Ready(_)
+        );
+        if second_appended {
+            self.connector_registry.record_event(
+                binding_id,
+                1,
+                &second,
+                Some("duplicate_delivery"),
+                None,
+            );
+        }
+
+        let emitted = self.connector_registry.emitted();
+        Ok(TriggerHarnessResult {
+            fixture: "webhook_dedupe_blocks_duplicates".to_string(),
+            ok: first_appended
+                && !second_appended
+                && emitted.len() == 1
+                && emitted[0].dedupe_key == "delivery-123",
+            stub: false,
+            summary: "duplicate GitHub-style webhook deliveries are dropped before append"
+                .to_string(),
+            emitted,
+            attempts: Vec::new(),
+            dlq: Vec::new(),
+            alerts: Vec::new(),
+            bindings: Vec::new(),
+            notes: Vec::new(),
+            details: json!({
+                "delivery_id": "delivery-123",
+                "first_appended": first_appended,
+                "second_appended": second_appended,
             }),
         })
     }


### PR DESCRIPTION
## Summary\n- move inbound webhook dedupe into async post-processing before pending-log append\n- preserve cron's existing async dedupe path and assert it does not double-claim\n- add listener, webhook, cron, trigger-harness, conformance, and changelog coverage for webhook dedupe\n\nCloses #223.\n\n## Verification\n- make test\n- cargo run --bin harn -- test conformance --filter webhook_dedupe