### PR TITLE
Fix stale OpenRouter fallback model

### DIFF
--- a/crates/harn-vm/src/llm/helpers/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/mod.rs
@@ -335,4 +335,42 @@ mod tests {
         }
         reset_provider_key_cache();
     }
+
+    #[test]
+    fn openrouter_provider_fallback_uses_current_valid_model_id() {
+        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
+        let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
+        let prev_local_model = std::env::var("LOCAL_LLM_MODEL").ok();
+        let prev_local_base = std::env::var("LOCAL_LLM_BASE_URL").ok();
+        unsafe {
+            std::env::remove_var("HARN_LLM_MODEL");
+            std::env::remove_var("HARN_LLM_PROVIDER");
+            std::env::remove_var("LOCAL_LLM_MODEL");
+            std::env::remove_var("LOCAL_LLM_BASE_URL");
+        }
+
+        let resolved = vm_resolve_model(&None, "openrouter");
+
+        unsafe {
+            match prev_harn_model {
+                Some(value) => std::env::set_var("HARN_LLM_MODEL", value),
+                None => std::env::remove_var("HARN_LLM_MODEL"),
+            }
+            match prev_harn_provider {
+                Some(value) => std::env::set_var("HARN_LLM_PROVIDER", value),
+                None => std::env::remove_var("HARN_LLM_PROVIDER"),
+            }
+            match prev_local_model {
+                Some(value) => std::env::set_var("LOCAL_LLM_MODEL", value),
+                None => std::env::remove_var("LOCAL_LLM_MODEL"),
+            }
+            match prev_local_base {
+                Some(value) => std::env::set_var("LOCAL_LLM_BASE_URL", value),
+                None => std::env::remove_var("LOCAL_LLM_BASE_URL"),
+            }
+        }
+
+        assert_eq!(resolved, "anthropic/claude-sonnet-4.6");
+    }
 }

--- a/crates/harn-vm/src/llm/helpers/provider.rs
+++ b/crates/harn-vm/src/llm/helpers/provider.rs
@@ -292,7 +292,7 @@ pub(crate) fn vm_resolve_model(
             .unwrap_or_else(|_| "gpt-4o".to_string()),
         "openai" => "gpt-4o".to_string(),
         "ollama" => "llama3.2".to_string(),
-        "openrouter" => "anthropic/claude-sonnet-4-20250514".to_string(),
+        "openrouter" => "anthropic/claude-sonnet-4.6".to_string(),
         _ => "claude-sonnet-4-20250514".to_string(),
     }
 }

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -12,7 +12,7 @@ environment variable to authenticate or point Harn at a local endpoint:
 |---|---|---|
 | Anthropic (default) | `ANTHROPIC_API_KEY` | `claude-sonnet-4-20250514` |
 | OpenAI | `OPENAI_API_KEY` | `gpt-4o` |
-| OpenRouter | `OPENROUTER_API_KEY` | `anthropic/claude-sonnet-4-20250514` |
+| OpenRouter | `OPENROUTER_API_KEY` | `anthropic/claude-sonnet-4.6` |
 | HuggingFace | `HF_TOKEN` or `HUGGINGFACE_API_KEY` | explicit `model` |
 | Ollama | `OLLAMA_HOST` (optional) | `llama3.2` |
 | Local server | `LOCAL_LLM_BASE_URL` | `LOCAL_LLM_MODEL` or explicit `model` |


### PR DESCRIPTION
## Summary
- replace Harn's provider-only OpenRouter fallback model with a current valid model id
- add a regression test covering provider-only OpenRouter resolution with no env/model override
- update the LLM docs table to match the runtime default

## Testing
- cargo test -p harn-vm llm::helpers::tests
- cargo fmt --check --all