### PR TITLE
Add orchestrator MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,14 @@ granular archaeology.
   skills via call arg or `HARN_REQUIRE_SIGNED_SKILLS=1`, and every load
   attempt emits a `skill.loaded` trust record into the transcript.
 
+- **`harn mcp serve` exposes orchestrators as MCP servers.**
+  Added a new orchestrator-backed MCP server command that serves over stdio and
+  HTTP, exposes trigger fire/list/replay, queue + DLQ inspection/retry,
+  dispatcher inspection, manifest/event/DLQ resources, and a placeholder trust
+  query surface. Tool calls now append `observability.action_graph` entries with
+  MCP client identity so external MCP clients can drive Harn without a custom
+  adapter layer.
+
 - **`harn orchestrator {inspect, fire, replay, dlq, queue}` CLI
   commands (#185).** Implemented the placeholder orchestrator
   subcommands that used to error with `not implemented`. `inspect`

--- a/conformance/helpers/mcp_stdio_tool.py
+++ b/conformance/helpers/mcp_stdio_tool.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+
+
+def send_request(proc, request):
+    proc.stdin.write(json.dumps(request) + "\n")
+    proc.stdin.flush()
+    line = proc.stdout.readline()
+    if not line:
+        raise RuntimeError("MCP server closed stdout")
+    return json.loads(line)
+
+
+def main():
+    if len(sys.argv) != 6:
+        raise SystemExit(
+            "usage: mcp_stdio_tool.py <harn_bin> <config_path> <state_dir> <tool_name> <arguments_json>"
+        )
+
+    harn_bin, config_path, state_dir, tool_name, arguments_json = sys.argv[1:6]
+    arguments = json.loads(arguments_json)
+    proc = subprocess.Popen(
+        [
+            harn_bin,
+            "mcp",
+            "serve",
+            "--config",
+            config_path,
+            "--state-dir",
+            state_dir,
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+
+    try:
+        init = send_request(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "conformance", "version": "1.0.0"},
+                },
+            },
+        )
+        if "error" in init:
+            raise RuntimeError(f"initialize failed: {init}")
+
+        response = send_request(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": tool_name,
+                    "arguments": arguments,
+                },
+            },
+        )
+        if response.get("result", {}).get("isError"):
+            raise RuntimeError(response["result"]["content"][0]["text"])
+        print(json.dumps(response["result"]["structuredContent"]))
+    finally:
+        if proc.stdin:
+            proc.stdin.close()
+        proc.wait(timeout=10)
+
+
+if __name__ == "__main__":
+    main()

--- a/conformance/tests/integration/mcp_server_fires_trigger.expected
+++ b/conformance/tests/integration/mcp_server_fires_trigger.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/conformance/tests/integration/mcp_server_fires_trigger.harn
+++ b/conformance/tests/integration/mcp_server_fires_trigger.harn
@@ -1,0 +1,47 @@
+fn resolve_harn_bin(repo_root) {
+  let cargo_config = path_join(repo_root, ".cargo/config.toml")
+  if file_exists(cargo_config) {
+    let config = exec("cat", cargo_config).stdout
+    let configured = first_group("target-dir = \\\"([^\\\"]+)\\\"", config)
+    if configured {
+      return path_join(configured, "debug/harn")
+    }
+  }
+  let target_dir = env("CARGO_TARGET_DIR") ?? path_join(repo_root, "target")
+  return path_join(target_dir, "debug/harn")
+}
+
+pipeline default() {
+  let root = path_join(temp_dir(), "harn-mcp-fire-" + uuid())
+  mkdir(root)
+  let log_path = path_join(root, "trigger.log")
+  write_file(
+    path_join(root, "harn.toml"),
+    "[package]\nname = \"fixture\"\n\n[exports]\nhandlers = \"lib.harn\"\n\n[[triggers]]\nid = \"cron-ok\"\nkind = \"cron\"\nprovider = \"cron\"\nschedule = \"* * * * *\"\nmatch = { events = [\"cron.tick\"] }\nhandler = \"handlers::on_ok\"\n",
+  )
+  write_file(
+    path_join(root, "lib.harn"),
+    "import \"std/triggers\"\n\nlet log_path = \""
+    + log_path
+    + "\"\n\npub fn on_ok(event: TriggerEvent) -> dict {\n  write_file(log_path, \"fired:\" + event.kind + \"\\n\")\n  return {kind: event.kind, event_id: event.id}\n}\n",
+  )
+
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let harn_bin = resolve_harn_bin(repo_root)
+  let helper = path_join(repo_root, "conformance/helpers/mcp_stdio_tool.py")
+  let result = exec(
+    "python3",
+    helper,
+    harn_bin,
+    path_join(root, "harn.toml"),
+    path_join(root, "state"),
+    "harn.trigger.fire",
+    "{\"trigger_id\":\"cron-ok\",\"payload\":{}}",
+  )
+  assert(result.success, "mcp helper failed")
+  let payload = json_parse(result.stdout.trim())
+  println(payload.status == "dispatched")
+  println(payload.binding_id == "cron-ok")
+  println(file_exists(log_path))
+  println(read_file(log_path).contains("fired:cron.tick"))
+}

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -39,7 +39,7 @@ harn-fmt = { path = "../harn-fmt", version = "0.7" }
 async-trait = "0.1"
 axum = "0.8"
 axum-server = { version = "0.7", features = ["tls-rustls"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "sync", "time"] }
 serde_json = "1"
 reedline = "0.47"
 nu-ansi-term = "0.50"

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -69,8 +69,9 @@ SCRIPTING
     Serve(ServeArgs),
     /// Start the ACP server on stdio.
     Acp(AcpArgs),
-    /// Expose a .harn tool bundle as an MCP server on stdio.
-    McpServe(McpServeArgs),
+    /// Legacy alias: expose a .harn tool bundle as an MCP server on stdio.
+    #[command(hide = true, name = "mcp-serve")]
+    McpServe(LegacyMcpServeArgs),
     /// Manage remote MCP OAuth credentials and status.
     Mcp(McpArgs),
     /// Watch a .harn file and re-run it on changes.
@@ -368,7 +369,7 @@ pub(crate) struct AcpArgs {
 }
 
 #[derive(Debug, Args)]
-pub(crate) struct McpServeArgs {
+pub(crate) struct LegacyMcpServeArgs {
     /// Path to the .harn file that defines the MCP surface.
     pub file: String,
     /// Optional Server Card JSON to advertise (MCP v2.1). Path to a
@@ -379,6 +380,12 @@ pub(crate) struct McpServeArgs {
     pub card: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum McpServeTransport {
+    Stdio,
+    Http,
+}
+
 #[derive(Debug, Args)]
 pub(crate) struct McpArgs {
     #[command(subcommand)]
@@ -387,6 +394,8 @@ pub(crate) struct McpArgs {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum McpCommand {
+    /// Expose a running orchestrator as an MCP server.
+    Serve(McpServeArgs),
     /// Log in to a remote MCP server via OAuth.
     Login(McpLoginArgs),
     /// Remove a stored OAuth token.
@@ -395,6 +404,36 @@ pub(crate) enum McpCommand {
     Status(McpServerRefArgs),
     /// Print the default OAuth redirect URI.
     RedirectUri,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct McpServeArgs {
+    #[command(flatten)]
+    pub local: OrchestratorLocalArgs,
+    /// Transport to expose for MCP clients.
+    #[arg(long, value_enum, default_value_t = McpServeTransport::Stdio)]
+    pub transport: McpServeTransport,
+    /// Socket address to bind when serving over HTTP.
+    #[arg(
+        long,
+        env = "HARN_MCP_SERVE_BIND",
+        default_value = "127.0.0.1:8765",
+        value_name = "ADDR"
+    )]
+    pub bind: SocketAddr,
+    /// Streamable HTTP endpoint path.
+    #[arg(long, default_value = "/mcp", value_name = "PATH")]
+    pub path: String,
+    /// Legacy SSE endpoint path for older MCP clients.
+    #[arg(long = "sse-path", default_value = "/sse", value_name = "PATH")]
+    pub sse_path: String,
+    /// Legacy SSE POST endpoint path for older MCP clients.
+    #[arg(
+        long = "messages-path",
+        default_value = "/messages",
+        value_name = "PATH"
+    )]
+    pub messages_path: String,
 }
 
 #[derive(Debug, Args)]
@@ -1044,6 +1083,43 @@ mod tests {
         assert_eq!(login.target.as_deref(), Some("notion"));
         assert_eq!(login.url.as_deref(), Some("https://example.com/mcp"));
         assert_eq!(login.client_id.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn test_parses_mcp_serve_flags() {
+        let cli = Cli::parse_from([
+            "harn",
+            "mcp",
+            "serve",
+            "--config",
+            "workspace/harn.toml",
+            "--state-dir",
+            "state/orchestrator",
+            "--transport",
+            "http",
+            "--bind",
+            "127.0.0.1:9000",
+            "--path",
+            "/rpc",
+            "--sse-path",
+            "/events",
+            "--messages-path",
+            "/legacy/messages",
+        ]);
+
+        let Command::Mcp(args) = cli.command.unwrap() else {
+            panic!("expected mcp command");
+        };
+        let McpCommand::Serve(serve) = args.command else {
+            panic!("expected mcp serve");
+        };
+        assert_eq!(serve.local.config, PathBuf::from("workspace/harn.toml"));
+        assert_eq!(serve.local.state_dir, PathBuf::from("state/orchestrator"));
+        assert_eq!(serve.transport, crate::cli::McpServeTransport::Http);
+        assert_eq!(serve.bind.to_string(), "127.0.0.1:9000");
+        assert_eq!(serve.path, "/rpc");
+        assert_eq!(serve.sse_path, "/events");
+        assert_eq!(serve.messages_path, "/legacy/messages");
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/mcp/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/mod.rs
@@ -12,6 +12,8 @@ use url::Url;
 use crate::cli::{McpCommand, McpLoginArgs, McpServerRefArgs};
 use crate::package::{self, McpServerConfig};
 
+mod serve;
+
 const DEFAULT_REDIRECT_URI: &str = "http://127.0.0.1:9783/oauth/callback";
 const KEYRING_SERVICE: &str = "dev.harn.mcp";
 const TOKEN_REFRESH_SKEW_SECS: i64 = 60;
@@ -82,6 +84,12 @@ pub(crate) enum AuthResolution {
 
 pub(crate) async fn handle_mcp_command(command: &McpCommand) {
     match command {
+        McpCommand::Serve(args) => {
+            if let Err(error) = serve::run(args).await {
+                eprintln!("error: {error}");
+                process::exit(1);
+            }
+        }
         McpCommand::Login(options) => {
             if let Err(error) = login(options).await {
                 eprintln!("error: {error}");

--- a/crates/harn-cli/src/commands/mcp/serve.rs
+++ b/crates/harn-cli/src/commands/mcp/serve.rs
@@ -1,0 +1,1734 @@
+use std::collections::{BTreeMap, HashMap};
+use std::convert::Infallible;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use axum::body::Bytes;
+use axum::extract::{Query, State};
+use axum::http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use futures::channel::mpsc::{unbounded, UnboundedSender};
+use futures::{stream, StreamExt};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::{mpsc, oneshot};
+use uuid::Uuid;
+
+use harn_vm::event_log::{EventLog, LogEvent, Topic};
+
+use crate::cli::{McpServeArgs, McpServeTransport, OrchestratorLocalArgs};
+use crate::commands::orchestrator::common::{
+    load_local_runtime, read_topic, synthetic_event_for_binding, trigger_fire, trigger_inspect_dlq,
+    trigger_list, trigger_replay, ConnectorActivationSnapshot, PersistedStateSnapshot,
+    TRIGGER_ATTEMPTS_TOPIC, TRIGGER_DLQ_TOPIC, TRIGGER_INBOX_CLAIMS_TOPIC,
+    TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC, TRIGGER_OUTBOX_TOPIC,
+};
+use crate::commands::orchestrator::listener::ListenerAuth;
+use crate::package::CollectedTriggerHandler;
+
+const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+const MCP_SESSION_HEADER: &str = "mcp-session-id";
+const MCP_PROTOCOL_HEADER: &str = "mcp-protocol-version";
+const ACTION_GRAPH_TOPIC: &str = "observability.action_graph";
+const TRIGGER_EVENTS_TOPIC: &str = "triggers.events";
+const DEFAULT_RESOURCE_LIMIT: usize = 200;
+
+#[derive(Clone)]
+pub(crate) struct McpOrchestratorService {
+    config_path: PathBuf,
+    state_dir: PathBuf,
+    manifest_source: Arc<String>,
+    auth: ListenerAuth,
+}
+
+#[derive(Clone, Debug)]
+struct ConnectionState {
+    initialized: bool,
+    authenticated: bool,
+    client_identity: String,
+    protocol_version: String,
+}
+
+impl Default for ConnectionState {
+    fn default() -> Self {
+        Self {
+            initialized: false,
+            authenticated: false,
+            client_identity: "unknown".to_string(),
+            protocol_version: MCP_PROTOCOL_VERSION.to_string(),
+        }
+    }
+}
+
+struct HttpSession {
+    state: Mutex<ConnectionState>,
+    sse_tx: Mutex<Option<UnboundedSender<JsonValue>>>,
+}
+
+impl Default for HttpSession {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(ConnectionState::default()),
+            sse_tx: Mutex::new(None),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct RpcBridge {
+    tx: mpsc::UnboundedSender<RpcRequest>,
+}
+
+struct RpcRequest {
+    session: ConnectionState,
+    request: JsonValue,
+    response_tx: oneshot::Sender<(ConnectionState, JsonValue)>,
+}
+
+#[derive(Clone)]
+struct HttpState {
+    service: Arc<McpOrchestratorService>,
+    rpc: RpcBridge,
+    sessions: Arc<Mutex<HashMap<String, Arc<HttpSession>>>>,
+    mcp_path: String,
+    messages_path: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct TriggerListEntry {
+    trigger_id: String,
+    kind: String,
+    provider: String,
+    when: Option<String>,
+    handler: JsonValue,
+    version: u32,
+    state: String,
+    metrics: harn_vm::TriggerMetricsSnapshot,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct QueuePreviewEntry {
+    event_id: u64,
+    kind: String,
+    occurred_at_ms: i64,
+    headers: BTreeMap<String, String>,
+    payload: JsonValue,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct QueueSnapshot {
+    dispatcher: harn_vm::DispatcherStatsSnapshot,
+    inbox: TopicPreview,
+    outbox: TopicPreview,
+    attempts: TopicPreview,
+    dlq: TopicPreview,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct TopicPreview {
+    count: usize,
+    head: Vec<QueuePreviewEntry>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct InspectPayload {
+    dispatcher: harn_vm::DispatcherStatsSnapshot,
+    bindings: Vec<harn_vm::TriggerBindingSnapshot>,
+    connectors: Vec<String>,
+    activations: Vec<ConnectorActivationSnapshot>,
+    snapshot: Option<PersistedStateSnapshot>,
+    recent_dispatches: Vec<RecentDispatchRecord>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct RecentDispatchRecord {
+    kind: String,
+    status: String,
+    occurred_at_ms: i64,
+    trigger_id: Option<String>,
+    event_id: Option<String>,
+    attempt: Option<u32>,
+    replay_of_event_id: Option<String>,
+    handler_kind: Option<String>,
+    target_uri: Option<String>,
+    error: Option<String>,
+    result: Option<JsonValue>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct RecordedTriggerEvent {
+    binding_id: String,
+    binding_version: u32,
+    replay_of_event_id: Option<String>,
+    event: harn_vm::TriggerEvent,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct TriggerFireRequest {
+    trigger_id: String,
+    #[serde(default)]
+    payload: JsonValue,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct TriggerReplayRequest {
+    event_id: String,
+    #[serde(default)]
+    as_of: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct DlqRetryRequest {
+    entry_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct TrustQueryRequest {
+    #[serde(default)]
+    query: Option<String>,
+}
+
+pub(crate) async fn run(args: &McpServeArgs) -> Result<(), String> {
+    let service = Arc::new(McpOrchestratorService::new(args)?);
+    match args.transport {
+        McpServeTransport::Stdio => run_stdio(service).await,
+        McpServeTransport::Http => run_http(service, args).await,
+    }
+}
+
+impl McpOrchestratorService {
+    fn new(args: &McpServeArgs) -> Result<Self, String> {
+        let manifest_source = std::fs::read_to_string(&args.local.config).map_err(|error| {
+            format!(
+                "failed to read manifest {}: {error}",
+                args.local.config.display()
+            )
+        })?;
+        let auth = ListenerAuth::from_env(false)?;
+        Ok(Self {
+            config_path: args.local.config.clone(),
+            state_dir: args.local.state_dir.clone(),
+            manifest_source: Arc::new(manifest_source),
+            auth,
+        })
+    }
+
+    fn local_args(&self) -> OrchestratorLocalArgs {
+        OrchestratorLocalArgs {
+            config: self.config_path.clone(),
+            state_dir: self.state_dir.clone(),
+        }
+    }
+
+    async fn handle_request(&self, session: &mut ConnectionState, request: JsonValue) -> JsonValue {
+        let id = request.get("id").cloned().unwrap_or(JsonValue::Null);
+        let method = request
+            .get("method")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default();
+        let params = request.get("params").cloned().unwrap_or_else(|| json!({}));
+
+        if method == "initialize" {
+            return self.handle_initialize(id, session, &params);
+        }
+
+        if request.get("id").is_none() {
+            return JsonValue::Null;
+        }
+
+        if !session.initialized && method != "ping" {
+            return harn_vm::jsonrpc::error_response(id, -32002, "server not initialized");
+        }
+
+        match method {
+            "initialized" => JsonValue::Null,
+            "ping" => harn_vm::jsonrpc::response(id, json!({})),
+            "logging/setLevel" => harn_vm::jsonrpc::response(id, json!({})),
+            "tools/list" => self.handle_tools_list(id),
+            "tools/call" => self.handle_tools_call(id, session, &params).await,
+            "resources/list" => self.handle_resources_list(id).await,
+            "resources/read" => self.handle_resources_read(id, &params).await,
+            _ => {
+                harn_vm::jsonrpc::error_response(id, -32601, &format!("Method not found: {method}"))
+            }
+        }
+    }
+
+    fn handle_initialize(
+        &self,
+        id: JsonValue,
+        session: &mut ConnectionState,
+        params: &JsonValue,
+    ) -> JsonValue {
+        let client_name = params
+            .pointer("/clientInfo/name")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("unknown");
+        let client_version = params
+            .pointer("/clientInfo/version")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("unknown");
+        session.client_identity = format!("{client_name}/{client_version}");
+        session.protocol_version = params
+            .get("protocolVersion")
+            .and_then(JsonValue::as_str)
+            .unwrap_or(MCP_PROTOCOL_VERSION)
+            .to_string();
+
+        if self.auth.has_api_keys() {
+            let api_key = initialize_api_key(params);
+            if api_key.is_none_or(|value| !self.auth.matches_api_key(value)) {
+                return harn_vm::jsonrpc::error_response(id, -32001, "unauthorized");
+            }
+            session.authenticated = true;
+        } else {
+            session.authenticated = true;
+        }
+        session.initialized = true;
+
+        harn_vm::jsonrpc::response(
+            id,
+            json!({
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {
+                    "tools": { "listChanged": false },
+                    "resources": { "listChanged": false },
+                    "logging": {},
+                },
+                "serverInfo": {
+                    "name": "harn-orchestrator",
+                    "title": "Harn Orchestrator MCP",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+                "instructions": "Expose Harn trigger and orchestrator controls over MCP."
+            }),
+        )
+    }
+
+    fn handle_tools_list(&self, id: JsonValue) -> JsonValue {
+        harn_vm::jsonrpc::response(
+            id,
+            json!({
+                "tools": [
+                    tool_def(
+                        "harn.trigger.fire",
+                        "Dispatch a trigger inline and return its event id plus terminal status.",
+                        json!({
+                            "type": "object",
+                            "required": ["trigger_id", "payload"],
+                            "properties": {
+                                "trigger_id": { "type": "string" },
+                                "payload": {},
+                            },
+                            "additionalProperties": false,
+                        }),
+                        Some(json!({
+                            "type": "object",
+                            "required": ["event_id", "status"],
+                            "properties": {
+                                "event_id": { "type": "string" },
+                                "status": { "type": "string" },
+                            },
+                        })),
+                    ),
+                    tool_def(
+                        "harn.trigger.list",
+                        "List registered triggers and their kind/provider/when/handler metadata.",
+                        json!({
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false,
+                        }),
+                        None,
+                    ),
+                    tool_def(
+                        "harn.trigger.replay",
+                        "Replay an existing trigger event, optionally resolving bindings as of a historical timestamp.",
+                        json!({
+                            "type": "object",
+                            "required": ["event_id"],
+                            "properties": {
+                                "event_id": { "type": "string" },
+                                "as_of": { "type": "string" },
+                            },
+                            "additionalProperties": false,
+                        }),
+                        None,
+                    ),
+                    tool_def(
+                        "harn.orchestrator.queue",
+                        "Return inbox/outbox/attempt/DLQ counts plus recent previews.",
+                        json!({
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false,
+                        }),
+                        None,
+                    ),
+                    tool_def(
+                        "harn.orchestrator.dlq.list",
+                        "List pending dead-letter queue entries.",
+                        json!({
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false,
+                        }),
+                        None,
+                    ),
+                    tool_def(
+                        "harn.orchestrator.dlq.retry",
+                        "Replay a pending dead-letter queue entry.",
+                        json!({
+                            "type": "object",
+                            "required": ["entry_id"],
+                            "properties": {
+                                "entry_id": { "type": "string" },
+                            },
+                            "additionalProperties": false,
+                        }),
+                        None,
+                    ),
+                    tool_def(
+                        "harn.orchestrator.inspect",
+                        "Snapshot dispatcher state, bindings, metrics, and recent dispatches.",
+                        json!({
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false,
+                        }),
+                        None,
+                    ),
+                    tool_def(
+                        "harn.trust.query",
+                        "Reserved trust-graph query surface. Returns an empty result set for now.",
+                        json!({
+                            "type": "object",
+                            "properties": {
+                                "query": { "type": "string" }
+                            },
+                            "additionalProperties": false,
+                        }),
+                        Some(json!({
+                            "type": "object",
+                            "required": ["results"],
+                            "properties": {
+                                "results": { "type": "array" },
+                            },
+                        })),
+                    ),
+                ]
+            }),
+        )
+    }
+
+    async fn handle_tools_call(
+        &self,
+        id: JsonValue,
+        session: &ConnectionState,
+        params: &JsonValue,
+    ) -> JsonValue {
+        if !session.authenticated {
+            return harn_vm::jsonrpc::error_response(id, -32001, "unauthorized");
+        }
+
+        let name = params
+            .get("name")
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default();
+        let arguments = params
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        let trace_id = format!("mcp_{}", Uuid::now_v7().simple());
+
+        let result = match name {
+            "harn.trigger.fire" => self.tool_trigger_fire(session, &trace_id, arguments).await,
+            "harn.trigger.list" => self.tool_trigger_list(arguments).await,
+            "harn.trigger.replay" => self.tool_trigger_replay(arguments).await,
+            "harn.orchestrator.queue" => self.tool_orchestrator_queue(arguments).await,
+            "harn.orchestrator.dlq.list" => self.tool_orchestrator_dlq_list(arguments).await,
+            "harn.orchestrator.dlq.retry" => self.tool_orchestrator_dlq_retry(arguments).await,
+            "harn.orchestrator.inspect" => self.tool_orchestrator_inspect(arguments).await,
+            "harn.trust.query" => self.tool_trust_query(arguments).await,
+            _ => Err(format!("unknown tool '{name}'")),
+        };
+
+        let _ = self
+            .record_tool_call(name, &trace_id, &session.client_identity, &result)
+            .await;
+
+        match result {
+            Ok(value) => harn_vm::jsonrpc::response(
+                id,
+                json!({
+                    "content": [{
+                        "type": "text",
+                        "text": serde_json::to_string_pretty(&value)
+                            .unwrap_or_else(|_| value.to_string()),
+                    }],
+                    "structuredContent": value,
+                    "isError": false,
+                }),
+            ),
+            Err(error) => harn_vm::jsonrpc::response(
+                id,
+                json!({
+                    "content": [{ "type": "text", "text": error }],
+                    "isError": true,
+                }),
+            ),
+        }
+    }
+
+    async fn handle_resources_list(&self, id: JsonValue) -> JsonValue {
+        match self.list_resources().await {
+            Ok(resources) => harn_vm::jsonrpc::response(id, json!({ "resources": resources })),
+            Err(error) => harn_vm::jsonrpc::error_response(id, -32603, &error),
+        }
+    }
+
+    async fn handle_resources_read(&self, id: JsonValue, params: &JsonValue) -> JsonValue {
+        let uri = params
+            .get("uri")
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default();
+        match self.read_resource(uri).await {
+            Ok((text, mime_type)) => harn_vm::jsonrpc::response(
+                id,
+                json!({
+                    "contents": [{
+                        "uri": uri,
+                        "text": text,
+                        "mimeType": mime_type,
+                    }],
+                }),
+            ),
+            Err(error) => harn_vm::jsonrpc::error_response(id, -32002, &error),
+        }
+    }
+
+    async fn tool_trigger_fire(
+        &self,
+        session: &ConnectionState,
+        trace_id: &str,
+        arguments: JsonValue,
+    ) -> Result<JsonValue, String> {
+        let request: TriggerFireRequest =
+            serde_json::from_value(arguments).map_err(|error| error.to_string())?;
+        let mut ctx = load_local_runtime(&self.local_args()).await?;
+        let mut event = synthetic_event_for_binding(&ctx, &request.trigger_id)?;
+        merge_json_object(&mut event, request.payload);
+        inject_trace_headers(&mut event, &session.client_identity, trace_id);
+        let handle = trigger_fire(&mut ctx, &request.trigger_id, event).await?;
+        Ok(json!({
+            "event_id": handle.event_id,
+            "status": handle.status,
+            "binding_id": handle.binding_id,
+            "binding_version": handle.binding_version,
+            "dlq_entry_id": handle.dlq_entry_id,
+            "error": handle.error,
+            "result": handle.result,
+        }))
+    }
+
+    async fn tool_trigger_list(&self, _arguments: JsonValue) -> Result<JsonValue, String> {
+        let mut ctx = load_local_runtime(&self.local_args()).await?;
+        let snapshots = trigger_list(&mut ctx).await?;
+        let mut snapshots_by_id = BTreeMap::new();
+        for snapshot in snapshots {
+            snapshots_by_id.insert(snapshot.id.clone(), snapshot);
+        }
+
+        let mut triggers = Vec::new();
+        for trigger in &ctx.collected_triggers {
+            let Some(snapshot) = snapshots_by_id.get(&trigger.config.id) else {
+                continue;
+            };
+            triggers.push(TriggerListEntry {
+                trigger_id: trigger.config.id.clone(),
+                kind: trigger_kind_name(trigger.config.kind).to_string(),
+                provider: trigger.config.provider.as_str().to_string(),
+                when: trigger.when.as_ref().map(|when| when.reference.raw.clone()),
+                handler: handler_json(&trigger.handler),
+                version: snapshot.version,
+                state: snapshot.state.as_str().to_string(),
+                metrics: snapshot.metrics.clone(),
+            });
+        }
+        Ok(json!({ "triggers": triggers }))
+    }
+
+    async fn tool_trigger_replay(&self, arguments: JsonValue) -> Result<JsonValue, String> {
+        let request: TriggerReplayRequest =
+            serde_json::from_value(arguments).map_err(|error| error.to_string())?;
+        if let Some(as_of) = request.as_of.as_deref() {
+            let workspace_root = self
+                .config_path
+                .parent()
+                .unwrap_or(Path::new("."))
+                .to_path_buf();
+            let ctx = load_local_runtime(&self.local_args()).await?;
+            let report = crate::commands::trigger::replay::replay_report_for_event_log(
+                ctx.event_log.clone(),
+                &workspace_root,
+                &request.event_id,
+                Some(as_of),
+                false,
+            )
+            .await?;
+            return Ok(serde_json::to_value(report).map_err(|error| error.to_string())?);
+        }
+
+        let mut ctx = load_local_runtime(&self.local_args()).await?;
+        let handle = trigger_replay(&mut ctx, &request.event_id).await?;
+        Ok(serde_json::to_value(handle).map_err(|error| error.to_string())?)
+    }
+
+    async fn tool_orchestrator_queue(&self, _arguments: JsonValue) -> Result<JsonValue, String> {
+        let ctx = load_local_runtime(&self.local_args()).await?;
+        let dispatcher = harn_vm::snapshot_dispatcher_stats();
+        let inbox_claims = read_topic(&ctx.event_log, TRIGGER_INBOX_CLAIMS_TOPIC).await?;
+        let inbox_envelopes = read_topic(&ctx.event_log, TRIGGER_INBOX_ENVELOPES_TOPIC).await?;
+        let inbox_legacy = read_topic(&ctx.event_log, TRIGGER_INBOX_LEGACY_TOPIC).await?;
+        let outbox = read_topic(&ctx.event_log, TRIGGER_OUTBOX_TOPIC).await?;
+        let attempts = read_topic(&ctx.event_log, TRIGGER_ATTEMPTS_TOPIC).await?;
+        let dlq = read_topic(&ctx.event_log, TRIGGER_DLQ_TOPIC).await?;
+
+        let queue = QueueSnapshot {
+            dispatcher,
+            inbox: TopicPreview {
+                count: inbox_claims.len() + inbox_envelopes.len() + inbox_legacy.len(),
+                head: preview_events(
+                    inbox_claims
+                        .into_iter()
+                        .chain(inbox_envelopes.into_iter())
+                        .chain(inbox_legacy.into_iter())
+                        .collect(),
+                ),
+            },
+            outbox: TopicPreview {
+                count: outbox.len(),
+                head: preview_events(outbox),
+            },
+            attempts: TopicPreview {
+                count: attempts.len(),
+                head: preview_events(attempts),
+            },
+            dlq: TopicPreview {
+                count: dlq.len(),
+                head: preview_events(dlq),
+            },
+        };
+        Ok(serde_json::to_value(queue).map_err(|error| error.to_string())?)
+    }
+
+    async fn tool_orchestrator_dlq_list(&self, _arguments: JsonValue) -> Result<JsonValue, String> {
+        let mut ctx = load_local_runtime(&self.local_args()).await?;
+        let entries = trigger_inspect_dlq(&mut ctx).await?;
+        Ok(json!({ "entries": entries }))
+    }
+
+    async fn tool_orchestrator_dlq_retry(&self, arguments: JsonValue) -> Result<JsonValue, String> {
+        let request: DlqRetryRequest =
+            serde_json::from_value(arguments).map_err(|error| error.to_string())?;
+        let mut ctx = load_local_runtime(&self.local_args()).await?;
+        let entries = trigger_inspect_dlq(&mut ctx).await?;
+        let entry = entries
+            .iter()
+            .find(|entry| entry.id == request.entry_id)
+            .ok_or_else(|| format!("unknown pending DLQ entry '{}'", request.entry_id))?;
+        let handle = trigger_replay(&mut ctx, &entry.event_id).await?;
+        Ok(json!({
+            "entry_id": entry.id,
+            "handle": handle,
+        }))
+    }
+
+    async fn tool_orchestrator_inspect(&self, _arguments: JsonValue) -> Result<JsonValue, String> {
+        let mut ctx = load_local_runtime(&self.local_args()).await?;
+        let bindings = trigger_list(&mut ctx).await?;
+        let dispatches = read_topic(&ctx.event_log, TRIGGER_OUTBOX_TOPIC).await?;
+        let payload = InspectPayload {
+            dispatcher: harn_vm::snapshot_dispatcher_stats(),
+            bindings,
+            connectors: ctx
+                .snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.connectors.clone())
+                .unwrap_or_default(),
+            activations: ctx
+                .snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.activations.clone())
+                .unwrap_or_default(),
+            snapshot: ctx.snapshot.clone(),
+            recent_dispatches: recent_dispatch_records(dispatches, 20),
+        };
+        Ok(serde_json::to_value(payload).map_err(|error| error.to_string())?)
+    }
+
+    async fn tool_trust_query(&self, arguments: JsonValue) -> Result<JsonValue, String> {
+        let request: TrustQueryRequest =
+            serde_json::from_value(arguments).unwrap_or(TrustQueryRequest { query: None });
+        Ok(json!({ "query": request.query, "results": [] }))
+    }
+
+    async fn list_resources(&self) -> Result<Vec<JsonValue>, String> {
+        let mut resources = vec![json!({
+            "uri": "harn://manifest",
+            "name": "Manifest",
+            "description": "The running orchestrator manifest",
+            "mimeType": "application/toml",
+        })];
+
+        let ctx = load_local_runtime(&self.local_args()).await?;
+        let recorded = read_topic(&ctx.event_log, TRIGGER_EVENTS_TOPIC).await?;
+        for (event_id, event) in recorded.into_iter().take(DEFAULT_RESOURCE_LIMIT) {
+            let Ok(record) = serde_json::from_value::<RecordedTriggerEvent>(event.payload) else {
+                continue;
+            };
+            resources.push(json!({
+                "uri": format!("harn://event/{}", record.event.id.0),
+                "name": format!("Event {}", record.event.id.0),
+                "description": format!("Trigger event log record #{event_id}"),
+                "mimeType": "application/json",
+            }));
+        }
+
+        let mut ctx = load_local_runtime(&self.local_args()).await?;
+        for entry in trigger_inspect_dlq(&mut ctx).await? {
+            resources.push(json!({
+                "uri": format!("harn://dlq/{}", entry.id),
+                "name": format!("DLQ {}", entry.id),
+                "description": format!("Pending DLQ entry for event {}", entry.event_id),
+                "mimeType": "application/json",
+            }));
+        }
+
+        Ok(resources)
+    }
+
+    async fn read_resource(&self, uri: &str) -> Result<(String, &'static str), String> {
+        if uri == "harn://manifest" {
+            return Ok(((*self.manifest_source).clone(), "application/toml"));
+        }
+        if let Some(event_id) = uri.strip_prefix("harn://event/") {
+            let detail = self.event_resource(event_id).await?;
+            return Ok((
+                serde_json::to_string_pretty(&detail).map_err(|error| error.to_string())?,
+                "application/json",
+            ));
+        }
+        if let Some(entry_id) = uri.strip_prefix("harn://dlq/") {
+            let detail = self.dlq_resource(entry_id).await?;
+            return Ok((
+                serde_json::to_string_pretty(&detail).map_err(|error| error.to_string())?,
+                "application/json",
+            ));
+        }
+        Err(format!("resource not found: {uri}"))
+    }
+
+    async fn event_resource(&self, event_id: &str) -> Result<JsonValue, String> {
+        let ctx = load_local_runtime(&self.local_args()).await?;
+        let recorded = read_topic(&ctx.event_log, TRIGGER_EVENTS_TOPIC).await?;
+        let record = recorded
+            .into_iter()
+            .find_map(|(log_id, event)| {
+                let parsed = serde_json::from_value::<RecordedTriggerEvent>(event.payload).ok()?;
+                (parsed.event.id.0 == event_id).then_some((log_id, parsed))
+            })
+            .ok_or_else(|| format!("unknown trigger event id '{event_id}'"))?;
+        let trace_id = record.1.event.trace_id.0.clone();
+        let related_outbox = filter_related_events(
+            read_topic(&ctx.event_log, TRIGGER_OUTBOX_TOPIC).await?,
+            event_id,
+            &trace_id,
+        );
+        let related_attempts = filter_related_events(
+            read_topic(&ctx.event_log, TRIGGER_ATTEMPTS_TOPIC).await?,
+            event_id,
+            &trace_id,
+        );
+        let related_dlq = filter_related_events(
+            read_topic(&ctx.event_log, TRIGGER_DLQ_TOPIC).await?,
+            event_id,
+            &trace_id,
+        );
+        let related_graph = filter_related_events(
+            read_topic(&ctx.event_log, ACTION_GRAPH_TOPIC).await?,
+            event_id,
+            &trace_id,
+        );
+        Ok(json!({
+            "log_event_id": record.0,
+            "binding_id": record.1.binding_id,
+            "binding_version": record.1.binding_version,
+            "replay_of_event_id": record.1.replay_of_event_id,
+            "event": record.1.event,
+            "trace": {
+                "trace_id": trace_id,
+                "outbox": related_outbox,
+                "attempts": related_attempts,
+                "dlq": related_dlq,
+                "action_graph": related_graph,
+            },
+        }))
+    }
+
+    async fn dlq_resource(&self, entry_id: &str) -> Result<JsonValue, String> {
+        let mut ctx = load_local_runtime(&self.local_args()).await?;
+        let entry = trigger_inspect_dlq(&mut ctx)
+            .await?
+            .into_iter()
+            .find(|entry| entry.id == entry_id)
+            .ok_or_else(|| format!("unknown DLQ entry '{entry_id}'"))?;
+        Ok(serde_json::to_value(entry).map_err(|error| error.to_string())?)
+    }
+
+    async fn record_tool_call(
+        &self,
+        tool_name: &str,
+        trace_id: &str,
+        client_identity: &str,
+        result: &Result<JsonValue, String>,
+    ) -> Result<(), String> {
+        let status = if result.is_ok() {
+            "completed"
+        } else {
+            "failed"
+        };
+        let outcome = if result.is_ok() { "success" } else { "error" };
+
+        eprintln!(
+            "[harn] mcp: client={} tool={} status={} trace_id={}",
+            client_identity, tool_name, status, trace_id
+        );
+
+        let ctx = load_local_runtime(&self.local_args()).await?;
+        let topic = Topic::new(ACTION_GRAPH_TOPIC).map_err(|error| error.to_string())?;
+        let mut headers = BTreeMap::new();
+        headers.insert("trace_id".to_string(), trace_id.to_string());
+        headers.insert("mcp_client".to_string(), client_identity.to_string());
+        headers.insert("tool_name".to_string(), tool_name.to_string());
+        let payload = json!({
+            "context": {
+                "tool_name": tool_name,
+                "client_identity": client_identity,
+                "trace_id": trace_id,
+            },
+            "observability": {
+                "schema_version": 1,
+                "planner_rounds": [],
+                "research_fact_count": 0,
+                "action_graph_nodes": [{
+                    "id": format!("mcp/{trace_id}"),
+                    "label": tool_name,
+                    "kind": "mcp_tool_call",
+                    "status": status,
+                    "outcome": outcome,
+                    "trace_id": trace_id,
+                }],
+                "action_graph_edges": [],
+                "worker_lineage": [],
+                "verification_outcomes": [],
+                "transcript_pointers": [],
+                "compaction_events": [],
+                "daemon_events": [],
+            },
+            "result": result.as_ref().ok(),
+            "error": result.as_ref().err(),
+        });
+        ctx.event_log
+            .append(
+                &topic,
+                LogEvent::new("action_graph_update", payload).with_headers(headers),
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+}
+
+async fn run_stdio(service: Arc<McpOrchestratorService>) -> Result<(), String> {
+    let stdin = BufReader::new(tokio::io::stdin());
+    let mut stdout = tokio::io::stdout();
+    let mut lines = stdin.lines();
+    let mut session = ConnectionState::default();
+
+    eprintln!("[harn] MCP stdio server ready");
+
+    while let Ok(Some(line)) = lines.next_line().await {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let request: JsonValue = match serde_json::from_str(trimmed) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        let response = service.handle_request(&mut session, request).await;
+        if response.is_null() {
+            continue;
+        }
+        let mut encoded = serde_json::to_string(&response)
+            .map_err(|error| format!("serialize error: {error}"))?;
+        encoded.push('\n');
+        stdout
+            .write_all(encoded.as_bytes())
+            .await
+            .map_err(|error| format!("stdout write failed: {error}"))?;
+        stdout
+            .flush()
+            .await
+            .map_err(|error| format!("stdout flush failed: {error}"))?;
+    }
+
+    Ok(())
+}
+
+async fn run_http(service: Arc<McpOrchestratorService>, args: &McpServeArgs) -> Result<(), String> {
+    let rpc = RpcBridge::start(service.clone());
+    let state = HttpState {
+        service,
+        rpc,
+        sessions: Arc::new(Mutex::new(HashMap::new())),
+        mcp_path: args.path.clone(),
+        messages_path: args.messages_path.clone(),
+    };
+    let router = Router::new()
+        .route(
+            &args.path,
+            post(http_post_request).delete(http_delete_session),
+        )
+        .route(&args.sse_path, get(legacy_sse_stream))
+        .route(&args.messages_path, post(legacy_sse_message))
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind(args.bind)
+        .await
+        .map_err(|error| format!("failed to bind {}: {error}", args.bind))?;
+    let local_addr = listener
+        .local_addr()
+        .map_err(|error| format!("failed to read local addr: {error}"))?;
+    eprintln!(
+        "[harn] MCP HTTP listener ready on http://{local_addr}{}",
+        args.path
+    );
+    axum::serve(listener, router)
+        .await
+        .map_err(|error| format!("MCP HTTP server failed: {error}"))
+}
+
+async fn http_post_request(
+    State(state): State<HttpState>,
+    method: Method,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let normalized = normalized_headers(&headers);
+    if state.service.auth.has_api_keys() {
+        let auth_log = match auth_event_log(&state.service.state_dir) {
+            Ok(log) => log,
+            Err(error) => return (StatusCode::INTERNAL_SERVER_ERROR, error).into_response(),
+        };
+        if let Err(()) = state
+            .service
+            .auth
+            .authorize(
+                auth_log.as_ref(),
+                method.as_str(),
+                &state.mcp_path,
+                &normalized,
+                body.as_ref(),
+            )
+            .await
+        {
+            return (StatusCode::UNAUTHORIZED, "auth failed").into_response();
+        }
+    }
+
+    let request: JsonValue = match serde_json::from_slice(body.as_ref()) {
+        Ok(value) => value,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("invalid JSON-RPC request body: {error}"),
+            )
+                .into_response()
+        }
+    };
+
+    let header_session = headers
+        .get(MCP_SESSION_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let (session_id, session, created) =
+        match lookup_or_create_session(&state, &request, header_session) {
+            Ok(value) => value,
+            Err(response) => return response,
+        };
+
+    let current = session.state.lock().expect("HTTP session poisoned").clone();
+    let (updated, response_json) = match state.rpc.call(current, request).await {
+        Ok(result) => result,
+        Err(error) => return (StatusCode::INTERNAL_SERVER_ERROR, error).into_response(),
+    };
+    *session.state.lock().expect("HTTP session poisoned") = updated;
+    let mut response = Json(response_json).into_response();
+    if created {
+        response.headers_mut().insert(
+            HeaderName::from_static(MCP_SESSION_HEADER),
+            HeaderValue::from_str(&session_id)
+                .unwrap_or_else(|_| HeaderValue::from_static("invalid")),
+        );
+    }
+    response.headers_mut().insert(
+        HeaderName::from_static(MCP_PROTOCOL_HEADER),
+        HeaderValue::from_static(MCP_PROTOCOL_VERSION),
+    );
+    response
+}
+
+async fn http_delete_session(State(state): State<HttpState>, headers: HeaderMap) -> Response {
+    let Some(session_id) = headers
+        .get(MCP_SESSION_HEADER)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+    let removed = state
+        .sessions
+        .lock()
+        .expect("MCP sessions poisoned")
+        .remove(session_id);
+    if removed.is_some() {
+        StatusCode::NO_CONTENT.into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
+}
+
+async fn legacy_sse_stream(State(state): State<HttpState>, headers: HeaderMap) -> Response {
+    let normalized = normalized_headers(&headers);
+    if state.service.auth.has_api_keys() {
+        let auth_log =
+            match harn_vm::event_log::EventLogConfig::for_base_dir(&state.service.state_dir)
+                .ok()
+                .and_then(|config| harn_vm::event_log::open_event_log(&config).ok())
+            {
+                Some(log) => log,
+                None => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to open event log",
+                    )
+                        .into_response()
+                }
+            };
+        if let Err(()) = state
+            .service
+            .auth
+            .authorize(
+                auth_log.as_ref(),
+                "GET",
+                &state.messages_path,
+                &normalized,
+                &[],
+            )
+            .await
+        {
+            return (StatusCode::UNAUTHORIZED, "auth failed").into_response();
+        }
+    }
+
+    let session_id = Uuid::now_v7().to_string();
+    let session = Arc::new(HttpSession::default());
+    let (tx, rx) = unbounded::<JsonValue>();
+    *session.sse_tx.lock().expect("SSE sender poisoned") = Some(tx);
+    state
+        .sessions
+        .lock()
+        .expect("MCP sessions poisoned")
+        .insert(session_id.clone(), session);
+    let endpoint = format!("{}?session_id={session_id}", state.messages_path);
+    let endpoint_event = Event::default().event("endpoint").data(endpoint);
+    let stream = stream::once(async move { Ok::<Event, Infallible>(endpoint_event) }).chain(
+        rx.map(|message| {
+            Ok(Event::default()
+                .event("message")
+                .data(serde_json::to_string(&message).unwrap_or_else(|_| "{}".to_string())))
+        }),
+    );
+    Sse::new(stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
+async fn legacy_sse_message(
+    State(state): State<HttpState>,
+    Query(query): Query<BTreeMap<String, String>>,
+    body: Bytes,
+) -> Response {
+    let Some(session_id) = query.get("session_id") else {
+        return (StatusCode::BAD_REQUEST, "missing session_id").into_response();
+    };
+    let Some(session) = state
+        .sessions
+        .lock()
+        .expect("MCP sessions poisoned")
+        .get(session_id)
+        .cloned()
+    else {
+        return (StatusCode::NOT_FOUND, "unknown session").into_response();
+    };
+    let request: JsonValue = match serde_json::from_slice(body.as_ref()) {
+        Ok(value) => value,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("invalid JSON-RPC request body: {error}"),
+            )
+                .into_response()
+        }
+    };
+    let current = session
+        .state
+        .lock()
+        .expect("legacy SSE session poisoned")
+        .clone();
+    let (updated, response) = match state.rpc.call(current, request).await {
+        Ok(result) => result,
+        Err(error) => return (StatusCode::INTERNAL_SERVER_ERROR, error).into_response(),
+    };
+    *session.state.lock().expect("legacy SSE session poisoned") = updated;
+    if response.is_null() {
+        return StatusCode::ACCEPTED.into_response();
+    }
+    let Some(sender) = session
+        .sse_tx
+        .lock()
+        .expect("legacy SSE sender poisoned")
+        .as_ref()
+        .cloned()
+    else {
+        return (StatusCode::GONE, "session stream closed").into_response();
+    };
+    if sender.unbounded_send(response).is_err() {
+        return (StatusCode::GONE, "session stream closed").into_response();
+    }
+    StatusCode::ACCEPTED.into_response()
+}
+
+fn lookup_or_create_session(
+    state: &HttpState,
+    request: &JsonValue,
+    header_session: Option<String>,
+) -> Result<(String, Arc<HttpSession>, bool), Response> {
+    let method = request
+        .get("method")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+    let mut sessions = state.sessions.lock().expect("MCP sessions poisoned");
+    if let Some(session_id) = header_session {
+        if let Some(session) = sessions.get(&session_id).cloned() {
+            return Ok((session_id, session, false));
+        }
+        return Err((StatusCode::NOT_FOUND, "unknown MCP session").into_response());
+    }
+    if method != "initialize" {
+        return Err((StatusCode::BAD_REQUEST, "missing MCP session").into_response());
+    }
+    let session_id = Uuid::now_v7().to_string();
+    let session = Arc::new(HttpSession::default());
+    sessions.insert(session_id.clone(), session.clone());
+    Ok((session_id, session, true))
+}
+
+impl RpcBridge {
+    fn start(service: Arc<McpOrchestratorService>) -> Self {
+        let (tx, mut rx) = mpsc::unbounded_channel::<RpcRequest>();
+        std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build MCP worker runtime");
+            runtime.block_on(async move {
+                while let Some(request) = rx.recv().await {
+                    let mut session = request.session;
+                    let response = service.handle_request(&mut session, request.request).await;
+                    let _ = request.response_tx.send((session, response));
+                }
+            });
+        });
+        Self { tx }
+    }
+
+    async fn call(
+        &self,
+        session: ConnectionState,
+        request: JsonValue,
+    ) -> Result<(ConnectionState, JsonValue), String> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.tx
+            .send(RpcRequest {
+                session,
+                request,
+                response_tx,
+            })
+            .map_err(|_| "MCP worker is not running".to_string())?;
+        response_rx
+            .await
+            .map_err(|_| "MCP worker dropped the response channel".to_string())
+    }
+}
+
+fn initialize_api_key(params: &JsonValue) -> Option<&str> {
+    params
+        .pointer("/capabilities/harn/apiKey")
+        .and_then(JsonValue::as_str)
+        .or_else(|| {
+            params
+                .pointer("/_meta/harn/apiKey")
+                .and_then(JsonValue::as_str)
+        })
+        .or_else(|| {
+            params
+                .pointer("/capabilities/experimental/harn/apiKey")
+                .and_then(JsonValue::as_str)
+        })
+}
+
+fn tool_def(
+    name: &str,
+    description: &str,
+    input_schema: JsonValue,
+    output_schema: Option<JsonValue>,
+) -> JsonValue {
+    let mut value = json!({
+        "name": name,
+        "description": description,
+        "inputSchema": input_schema,
+    });
+    if let Some(output_schema) = output_schema {
+        value["outputSchema"] = output_schema;
+    }
+    value
+}
+
+fn handler_json(handler: &CollectedTriggerHandler) -> JsonValue {
+    match handler {
+        CollectedTriggerHandler::Local { reference, .. } => json!({
+            "kind": "local",
+            "reference": reference.raw,
+        }),
+        CollectedTriggerHandler::A2a { target, .. } => json!({
+            "kind": "a2a",
+            "target": target,
+        }),
+        CollectedTriggerHandler::Worker { queue } => json!({
+            "kind": "worker",
+            "queue": queue,
+        }),
+    }
+}
+
+fn inject_trace_headers(event: &mut JsonValue, client_identity: &str, trace_id: &str) {
+    let Some(object) = event.as_object_mut() else {
+        return;
+    };
+    object.insert("trace_id".to_string(), json!(trace_id));
+    let headers = object
+        .entry("headers")
+        .or_insert_with(|| json!({}))
+        .as_object_mut();
+    if let Some(headers) = headers {
+        headers.insert("x-harn-mcp-client".to_string(), json!(client_identity));
+        headers.insert("x-harn-mcp-trace-id".to_string(), json!(trace_id));
+    }
+}
+
+fn merge_json_object(target: &mut JsonValue, patch: JsonValue) {
+    let Some(target) = target.as_object_mut() else {
+        return;
+    };
+    if let Some(patch) = patch.as_object() {
+        for (key, value) in patch {
+            target.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+fn preview_events(events: Vec<(u64, LogEvent)>) -> Vec<QueuePreviewEntry> {
+    let mut preview = events
+        .into_iter()
+        .map(|(event_id, event)| QueuePreviewEntry {
+            event_id,
+            kind: event.kind,
+            occurred_at_ms: event.occurred_at_ms,
+            headers: event.headers,
+            payload: event.payload,
+        })
+        .collect::<Vec<_>>();
+    preview.sort_by_key(|entry| entry.event_id);
+    preview
+        .into_iter()
+        .rev()
+        .take(5)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect()
+}
+
+fn recent_dispatch_records(
+    dispatches: Vec<(u64, LogEvent)>,
+    limit: usize,
+) -> Vec<RecentDispatchRecord> {
+    let mut recent: Vec<_> = dispatches
+        .into_iter()
+        .filter_map(|(_, event)| {
+            if !matches!(
+                event.kind.as_str(),
+                "dispatch_succeeded" | "dispatch_failed"
+            ) {
+                return None;
+            }
+            let payload = event.payload.as_object();
+            Some(RecentDispatchRecord {
+                status: event.kind.trim_start_matches("dispatch_").to_string(),
+                kind: event.kind,
+                occurred_at_ms: event.occurred_at_ms,
+                trigger_id: event.headers.get("trigger_id").cloned(),
+                event_id: event.headers.get("event_id").cloned(),
+                attempt: event
+                    .headers
+                    .get("attempt")
+                    .and_then(|attempt| attempt.parse::<u32>().ok()),
+                replay_of_event_id: event.headers.get("replay_of_event_id").cloned(),
+                handler_kind: event.headers.get("handler_kind").cloned(),
+                target_uri: payload.and_then(|payload| {
+                    payload
+                        .get("target_uri")
+                        .and_then(JsonValue::as_str)
+                        .map(ToOwned::to_owned)
+                }),
+                error: payload.and_then(|payload| {
+                    payload
+                        .get("error")
+                        .and_then(JsonValue::as_str)
+                        .map(ToOwned::to_owned)
+                }),
+                result: payload.and_then(|payload| payload.get("result").cloned()),
+            })
+        })
+        .collect();
+    recent.sort_by_key(|dispatch| dispatch.occurred_at_ms);
+    if recent.len() > limit {
+        recent.drain(0..recent.len() - limit);
+    }
+    recent
+}
+
+fn filter_related_events(
+    events: Vec<(u64, LogEvent)>,
+    event_id: &str,
+    trace_id: &str,
+) -> Vec<JsonValue> {
+    events
+        .into_iter()
+        .filter_map(|(id, event)| {
+            let matches_event = event
+                .headers
+                .get("event_id")
+                .is_some_and(|value| value == event_id)
+                || event
+                    .headers
+                    .get("trace_id")
+                    .is_some_and(|value| value == trace_id)
+                || event
+                    .payload
+                    .pointer("/context/event_id")
+                    .and_then(JsonValue::as_str)
+                    == Some(event_id);
+            matches_event.then_some(json!({
+                "id": id,
+                "kind": event.kind,
+                "occurred_at_ms": event.occurred_at_ms,
+                "headers": event.headers,
+                "payload": event.payload,
+            }))
+        })
+        .collect()
+}
+
+fn normalized_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+        })
+        .collect()
+}
+
+fn trigger_kind_name(kind: crate::package::TriggerKind) -> &'static str {
+    match kind {
+        crate::package::TriggerKind::Webhook => "webhook",
+        crate::package::TriggerKind::Cron => "cron",
+        crate::package::TriggerKind::Poll => "poll",
+        crate::package::TriggerKind::Stream => "stream",
+        crate::package::TriggerKind::Predicate => "predicate",
+        crate::package::TriggerKind::A2aPush => "a2a-push",
+    }
+}
+
+fn auth_event_log(state_dir: &Path) -> Result<Arc<harn_vm::event_log::AnyEventLog>, String> {
+    let config = harn_vm::event_log::EventLogConfig::for_base_dir(state_dir)
+        .map_err(|error| format!("failed to build auth event log config: {error}"))?;
+    harn_vm::event_log::open_event_log(&config)
+        .map_err(|error| format!("failed to open auth event log: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use std::sync::{Mutex, OnceLock};
+
+    use tempfile::TempDir;
+
+    static MCP_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+        MCP_TEST_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    fn write_file(dir: &Path, relative: &str, contents: &str) {
+        let path = dir.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    fn fixture_args(temp: &TempDir) -> McpServeArgs {
+        let state_dir = temp.path().join("state");
+        fs::create_dir_all(&state_dir).unwrap();
+        McpServeArgs {
+            local: OrchestratorLocalArgs {
+                config: temp.path().join("harn.toml"),
+                state_dir,
+            },
+            transport: McpServeTransport::Stdio,
+            bind: "127.0.0.1:0".parse().unwrap(),
+            path: "/mcp".to_string(),
+            sse_path: "/sse".to_string(),
+            messages_path: "/messages".to_string(),
+        }
+    }
+
+    fn write_fixture(temp: &TempDir) {
+        write_file(
+            temp.path(),
+            "harn.toml",
+            r#"
+[package]
+name = "fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "cron-ok"
+kind = "cron"
+provider = "cron"
+schedule = "* * * * *"
+match = { events = ["cron.tick"] }
+handler = "handlers::on_ok"
+
+[[triggers]]
+id = "cron-fail"
+kind = "cron"
+provider = "cron"
+schedule = "* * * * *"
+match = { events = ["cron.tick"] }
+handler = "handlers::on_fail"
+retry = { max = 1, backoff = "immediate", retention_days = 7 }
+"#,
+        );
+        write_file(
+            temp.path(),
+            "lib.harn",
+            r#"
+import "std/triggers"
+
+pub fn on_ok(event: TriggerEvent) -> dict {
+  log("ok:" + event.kind)
+  return {kind: event.kind, event_id: event.id, trace_id: event.trace_id}
+}
+
+pub fn on_fail(event: TriggerEvent) -> any {
+  throw "boom:" + event.kind
+}
+"#,
+        );
+    }
+
+    async fn init_session(service: &McpOrchestratorService) -> ConnectionState {
+        let mut session = ConnectionState::default();
+        let response = service
+            .handle_request(
+                &mut session,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": MCP_PROTOCOL_VERSION,
+                        "capabilities": {},
+                        "clientInfo": { "name": "test-client", "version": "1.0.0" }
+                    }
+                }),
+            )
+            .await;
+        assert_eq!(response["result"]["protocolVersion"], MCP_PROTOCOL_VERSION);
+        session
+    }
+
+    async fn call_tool(
+        service: &McpOrchestratorService,
+        session: &mut ConnectionState,
+        name: &str,
+        arguments: JsonValue,
+    ) -> JsonValue {
+        let response = service
+            .handle_request(
+                session,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {
+                        "name": name,
+                        "arguments": arguments,
+                    }
+                }),
+            )
+            .await;
+        assert_eq!(response["result"]["isError"], false, "response={response}");
+        response["result"]["structuredContent"].clone()
+    }
+
+    async fn read_resource(
+        service: &McpOrchestratorService,
+        session: &mut ConnectionState,
+        uri: &str,
+    ) -> JsonValue {
+        let response = service
+            .handle_request(
+                session,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "resources/read",
+                    "params": { "uri": uri }
+                }),
+            )
+            .await;
+        let text = response["result"]["contents"][0]["text"]
+            .as_str()
+            .expect("resource text");
+        serde_json::from_str(text).unwrap_or_else(|_| json!(text))
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn trigger_list_tool_returns_manifest_bindings() {
+        let _guard = test_lock();
+        let temp = TempDir::new().unwrap();
+        write_fixture(&temp);
+        let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
+        let mut session = init_session(&service).await;
+
+        let result = call_tool(&service, &mut session, "harn.trigger.list", json!({})).await;
+        let triggers = result["triggers"].as_array().unwrap();
+        assert_eq!(triggers.len(), 2);
+        assert!(triggers
+            .iter()
+            .any(|trigger| trigger["trigger_id"] == "cron-ok"));
+        assert!(triggers
+            .iter()
+            .any(|trigger| trigger["trigger_id"] == "cron-fail"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn trigger_fire_roundtrip_records_event_resource_and_action_graph() {
+        let _guard = test_lock();
+        let temp = TempDir::new().unwrap();
+        write_fixture(&temp);
+        let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
+        let mut session = init_session(&service).await;
+
+        let fire = call_tool(
+            &service,
+            &mut session,
+            "harn.trigger.fire",
+            json!({
+                "trigger_id": "cron-ok",
+                "payload": {
+                    "headers": { "x-test": "1" }
+                }
+            }),
+        )
+        .await;
+        assert_eq!(fire["status"], "dispatched");
+        let event_id = fire["event_id"].as_str().unwrap();
+        let event =
+            read_resource(&service, &mut session, &format!("harn://event/{event_id}")).await;
+        assert_eq!(
+            event["event"]["headers"]["x-harn-mcp-client"],
+            "test-client/1.0.0"
+        );
+
+        let ctx = load_local_runtime(&service.local_args()).await.unwrap();
+        let action_graph = read_topic(&ctx.event_log, ACTION_GRAPH_TOPIC)
+            .await
+            .unwrap();
+        assert!(
+            action_graph.iter().any(|(_, event)| {
+                event.payload["context"]["tool_name"] == json!("harn.trigger.fire")
+            }),
+            "action_graph={action_graph:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn trigger_replay_tool_replays_event() {
+        let _guard = test_lock();
+        let temp = TempDir::new().unwrap();
+        write_fixture(&temp);
+        let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
+        let mut session = init_session(&service).await;
+        let fire = call_tool(
+            &service,
+            &mut session,
+            "harn.trigger.fire",
+            json!({ "trigger_id": "cron-ok", "payload": {} }),
+        )
+        .await;
+        let replay = call_tool(
+            &service,
+            &mut session,
+            "harn.trigger.replay",
+            json!({ "event_id": fire["event_id"] }),
+        )
+        .await;
+        assert_eq!(replay["status"], "dispatched");
+        assert_eq!(replay["replay_of_event_id"], fire["event_id"]);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dlq_tools_roundtrip_and_resource_read() {
+        let _guard = test_lock();
+        let temp = TempDir::new().unwrap();
+        write_fixture(&temp);
+        let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
+        let mut session = init_session(&service).await;
+
+        let fire = call_tool(
+            &service,
+            &mut session,
+            "harn.trigger.fire",
+            json!({ "trigger_id": "cron-fail", "payload": {} }),
+        )
+        .await;
+        assert_eq!(fire["status"], "dlq");
+        let entries = call_tool(
+            &service,
+            &mut session,
+            "harn.orchestrator.dlq.list",
+            json!({}),
+        )
+        .await;
+        let entry_id = entries["entries"][0]["id"].as_str().unwrap();
+        let detail = read_resource(&service, &mut session, &format!("harn://dlq/{entry_id}")).await;
+        assert_eq!(detail["id"], entry_id);
+
+        let retry = call_tool(
+            &service,
+            &mut session,
+            "harn.orchestrator.dlq.retry",
+            json!({ "entry_id": entry_id }),
+        )
+        .await;
+        assert_eq!(retry["entry_id"], entry_id);
+        assert_eq!(retry["handle"]["replay_of_event_id"], fire["event_id"]);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn queue_and_inspect_tools_return_snapshots() {
+        let _guard = test_lock();
+        let temp = TempDir::new().unwrap();
+        write_fixture(&temp);
+        let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
+        let mut session = init_session(&service).await;
+
+        let _ = call_tool(
+            &service,
+            &mut session,
+            "harn.trigger.fire",
+            json!({ "trigger_id": "cron-ok", "payload": {} }),
+        )
+        .await;
+        let queue = call_tool(&service, &mut session, "harn.orchestrator.queue", json!({})).await;
+        assert!(queue["outbox"]["count"].as_u64().unwrap() >= 1);
+
+        let inspect = call_tool(
+            &service,
+            &mut session,
+            "harn.orchestrator.inspect",
+            json!({}),
+        )
+        .await;
+        assert_eq!(inspect["bindings"].as_array().unwrap().len(), 2);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn trust_query_returns_empty_results() {
+        let _guard = test_lock();
+        let temp = TempDir::new().unwrap();
+        write_fixture(&temp);
+        let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
+        let mut session = init_session(&service).await;
+
+        let result = call_tool(
+            &service,
+            &mut session,
+            "harn.trust.query",
+            json!({ "query": "anything" }),
+        )
+        .await;
+        assert_eq!(result["results"], json!([]));
+        assert_eq!(result["query"], "anything");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn manifest_resource_reads_raw_manifest() {
+        let _guard = test_lock();
+        let temp = TempDir::new().unwrap();
+        write_fixture(&temp);
+        let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
+        let mut session = init_session(&service).await;
+
+        let manifest = read_resource(&service, &mut session, "harn://manifest").await;
+        let manifest = manifest.as_str().unwrap();
+        assert!(manifest.contains("[[triggers]]"));
+        assert!(manifest.contains("cron-ok"));
+    }
+}

--- a/crates/harn-cli/src/commands/orchestrator/common.rs
+++ b/crates/harn-cli/src/commands/orchestrator/common.rs
@@ -14,13 +14,13 @@ use crate::package::{self, CollectedManifestTrigger, Manifest};
 
 use super::role::OrchestratorRole;
 
-pub(super) const STATE_SNAPSHOT_FILE: &str = "orchestrator-state.json";
-pub(super) use harn_vm::{
+pub(crate) const STATE_SNAPSHOT_FILE: &str = "orchestrator-state.json";
+pub(crate) use harn_vm::{
     TRIGGER_ATTEMPTS_TOPIC, TRIGGER_DLQ_TOPIC, TRIGGER_INBOX_CLAIMS_TOPIC,
     TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC, TRIGGER_OUTBOX_TOPIC,
 };
 
-pub(super) struct LoadedOrchestratorContext {
+pub(crate) struct LoadedOrchestratorContext {
     pub vm: harn_vm::Vm,
     pub event_log: Arc<AnyEventLog>,
     pub collected_triggers: Vec<CollectedManifestTrigger>,
@@ -28,7 +28,7 @@ pub(super) struct LoadedOrchestratorContext {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(super) struct PersistedStateSnapshot {
+pub(crate) struct PersistedStateSnapshot {
     pub status: String,
     pub bind: String,
     #[serde(default)]
@@ -38,13 +38,13 @@ pub(super) struct PersistedStateSnapshot {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(super) struct ConnectorActivationSnapshot {
+pub(crate) struct ConnectorActivationSnapshot {
     pub provider: String,
     pub binding_count: usize,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(super) struct DispatchHandleRecord {
+pub(crate) struct DispatchHandleRecord {
     pub event_id: String,
     pub binding_id: String,
     pub binding_version: u32,
@@ -56,7 +56,7 @@ pub(super) struct DispatchHandleRecord {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(super) struct DlqAttemptRecord {
+pub(crate) struct DlqAttemptRecord {
     pub attempt: u32,
     pub at: String,
     pub status: String,
@@ -64,7 +64,7 @@ pub(super) struct DlqAttemptRecord {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(super) struct DlqEntryRecord {
+pub(crate) struct DlqEntryRecord {
     pub id: String,
     pub event_id: String,
     pub binding_id: String,
@@ -78,7 +78,7 @@ pub(super) struct DlqEntryRecord {
 }
 
 #[derive(Clone, Debug)]
-pub(super) struct StrandedEnvelopeRecord {
+pub(crate) struct StrandedEnvelopeRecord {
     pub inbox_offset: u64,
     pub event_id: String,
     pub trigger_id: Option<String>,
@@ -89,7 +89,7 @@ pub(super) struct StrandedEnvelopeRecord {
     pub age: StdDuration,
 }
 
-pub(super) async fn load_local_runtime(
+pub(crate) async fn load_local_runtime(
     args: &OrchestratorLocalArgs,
 ) -> Result<LoadedOrchestratorContext, String> {
     harn_vm::reset_thread_local_state();
@@ -124,13 +124,13 @@ pub(super) async fn load_local_runtime(
     })
 }
 
-pub(super) async fn trigger_list(
+pub(crate) async fn trigger_list(
     ctx: &mut LoadedOrchestratorContext,
 ) -> Result<Vec<harn_vm::TriggerBindingSnapshot>, String> {
     eval_json(&mut ctx.vm, "trigger_list()").await
 }
 
-pub(super) async fn trigger_replay(
+pub(crate) async fn trigger_replay(
     ctx: &mut LoadedOrchestratorContext,
     event_id: &str,
 ) -> Result<DispatchHandleRecord, String> {
@@ -138,13 +138,13 @@ pub(super) async fn trigger_replay(
     eval_json(&mut ctx.vm, &format!("trigger_replay({event_id})")).await
 }
 
-pub(super) async fn trigger_inspect_dlq(
+pub(crate) async fn trigger_inspect_dlq(
     ctx: &mut LoadedOrchestratorContext,
 ) -> Result<Vec<DlqEntryRecord>, String> {
     eval_json(&mut ctx.vm, "trigger_inspect_dlq()").await
 }
 
-pub(super) async fn trigger_fire(
+pub(crate) async fn trigger_fire(
     ctx: &mut LoadedOrchestratorContext,
     binding_id: &str,
     event: serde_json::Value,
@@ -159,7 +159,7 @@ pub(super) async fn trigger_fire(
     .await
 }
 
-pub(super) fn synthetic_event_for_binding(
+pub(crate) fn synthetic_event_for_binding(
     ctx: &LoadedOrchestratorContext,
     binding_id: &str,
 ) -> Result<serde_json::Value, String> {
@@ -192,7 +192,7 @@ pub(super) fn synthetic_event_for_binding(
     }))
 }
 
-pub(super) async fn read_topic(
+pub(crate) async fn read_topic(
     log: &Arc<AnyEventLog>,
     topic_name: &str,
 ) -> Result<Vec<(u64, LogEvent)>, String> {
@@ -202,7 +202,7 @@ pub(super) async fn read_topic(
         .map_err(|error| error.to_string())
 }
 
-pub(super) async fn stranded_envelopes(
+pub(crate) async fn stranded_envelopes(
     log: &Arc<AnyEventLog>,
     min_age: StdDuration,
 ) -> Result<Vec<StrandedEnvelopeRecord>, String> {
@@ -270,7 +270,7 @@ pub(super) async fn stranded_envelopes(
     Ok(stranded)
 }
 
-pub(super) async fn append_dlq_entry(
+pub(crate) async fn append_dlq_entry(
     log: &Arc<AnyEventLog>,
     entry: &DlqEntryRecord,
 ) -> Result<(), String> {
@@ -282,7 +282,7 @@ pub(super) async fn append_dlq_entry(
         .map_err(|error| error.to_string())
 }
 
-pub(super) fn discard_dlq_entry(entry: &DlqEntryRecord) -> Result<DlqEntryRecord, String> {
+pub(crate) fn discard_dlq_entry(entry: &DlqEntryRecord) -> Result<DlqEntryRecord, String> {
     let mut next = entry.clone();
     next.state = "discarded".to_string();
     next.retry_history.push(DlqAttemptRecord {
@@ -296,7 +296,7 @@ pub(super) fn discard_dlq_entry(entry: &DlqEntryRecord) -> Result<DlqEntryRecord
     Ok(next)
 }
 
-pub(super) fn print_json<T>(value: &T) -> Result<(), String>
+pub(crate) fn print_json<T>(value: &T) -> Result<(), String>
 where
     T: Serialize,
 {

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -641,13 +641,13 @@ fn parse_secret_id(raw: Option<&str>) -> Option<SecretId> {
 }
 
 #[derive(Clone, Default)]
-struct ListenerAuth {
+pub(crate) struct ListenerAuth {
     api_keys: Vec<String>,
     hmac_secret: Option<String>,
 }
 
 impl ListenerAuth {
-    fn from_env(required: bool) -> Result<Self, String> {
+    pub(crate) fn from_env(required: bool) -> Result<Self, String> {
         let api_keys = std::env::var(API_KEYS_ENV)
             .ok()
             .map(|value| {
@@ -681,7 +681,11 @@ impl ListenerAuth {
         })
     }
 
-    async fn authorize(
+    pub(crate) fn has_api_keys(&self) -> bool {
+        !self.api_keys.is_empty()
+    }
+
+    pub(crate) async fn authorize(
         &self,
         event_log: &AnyEventLog,
         method: &str,
@@ -689,6 +693,13 @@ impl ListenerAuth {
         headers: &BTreeMap<String, String>,
         body: &[u8],
     ) -> Result<(), ()> {
+        if let Some(api_key) = header_value(headers, "x-api-key") {
+            if self.matches_api_key(api_key.trim()) {
+                return Ok(());
+            }
+            return Err(());
+        }
+
         let authorization = header_value(headers, "authorization").ok_or(())?;
         let Some((scheme, value)) = authorization.split_once(' ') else {
             return Err(());
@@ -727,7 +738,7 @@ impl ListenerAuth {
         Err(())
     }
 
-    fn matches_api_key(&self, candidate: &str) -> bool {
+    pub(crate) fn matches_api_key(&self, candidate: &str) -> bool {
         self.api_keys
             .iter()
             .any(|key| key.as_bytes().ct_eq(candidate.as_bytes()).into())

--- a/crates/harn-cli/src/commands/orchestrator/mod.rs
+++ b/crates/harn-cli/src/commands/orchestrator/mod.rs
@@ -1,8 +1,8 @@
-mod common;
+pub(crate) mod common;
 mod dlq;
 mod fire;
 mod inspect;
-mod listener;
+pub(crate) mod listener;
 mod origin_guard;
 mod queue;
 mod recover;

--- a/crates/harn-cli/src/commands/trigger/mod.rs
+++ b/crates/harn-cli/src/commands/trigger/mod.rs
@@ -1,4 +1,4 @@
-mod replay;
+pub(crate) mod replay;
 
 use crate::cli::{TriggerArgs, TriggerCommand};
 

--- a/crates/harn-cli/src/commands/trigger/replay.rs
+++ b/crates/harn-cli/src/commands/trigger/replay.rs
@@ -26,7 +26,7 @@ struct TriggerEventRecord {
 }
 
 #[derive(Clone, Debug, Serialize)]
-struct DispatchOutcomeSummary {
+pub(crate) struct DispatchOutcomeSummary {
     status: String,
     attempt_count: u32,
     handler_kind: String,
@@ -36,19 +36,19 @@ struct DispatchOutcomeSummary {
 }
 
 #[derive(Clone, Debug, Serialize)]
-struct DriftField {
+pub(crate) struct DriftField {
     original: JsonValue,
     replayed: JsonValue,
 }
 
 #[derive(Clone, Debug, Serialize)]
-struct DriftReport {
+pub(crate) struct DriftReport {
     changed: bool,
     fields: BTreeMap<String, DriftField>,
 }
 
 #[derive(Clone, Debug, Serialize)]
-struct TriggerReplayReport {
+pub(crate) struct TriggerReplayReport {
     event_id: String,
     binding_id: String,
     binding_version: u32,
@@ -68,7 +68,30 @@ pub(crate) async fn run(args: TriggerReplayArgs) -> Result<(), String> {
     let workspace_root = harn_vm::stdlib::process::find_project_root(&cwd).unwrap_or(cwd.clone());
     let event_log = harn_vm::event_log::install_default_for_base_dir(&workspace_root)
         .map_err(|error| format!("failed to open event log snapshot: {error}"))?;
+    let report = replay_report_for_event_log(
+        event_log,
+        &workspace_root,
+        &args.event_id,
+        args.as_of.as_deref(),
+        args.diff,
+    )
+    .await?;
 
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report)
+            .map_err(|error| format!("failed to encode replay report: {error}"))?
+    );
+    Ok(())
+}
+
+pub(crate) async fn replay_report_for_event_log(
+    event_log: Arc<AnyEventLog>,
+    workspace_root: &Path,
+    event_id: &str,
+    as_of: Option<&str>,
+    diff: bool,
+) -> Result<TriggerReplayReport, String> {
     let mut vm = build_replay_vm(&workspace_root);
     let extensions = package::load_runtime_extensions(&workspace_root);
     package::install_runtime_extensions(&extensions);
@@ -76,13 +99,13 @@ pub(crate) async fn run(args: TriggerReplayArgs) -> Result<(), String> {
         .await
         .map_err(|error| format!("failed to install manifest triggers: {error}"))?;
 
-    let recorded = load_recorded_event(&event_log, &args.event_id).await?;
-    let original = if args.diff {
+    let recorded = load_recorded_event(&event_log, event_id).await?;
+    let original = if diff {
         Some(load_original_outcome(&event_log, &recorded).await?)
     } else {
         None
     };
-    let as_of = args.as_of.as_deref().map(parse_timestamp).transpose()?;
+    let as_of = as_of.map(parse_timestamp).transpose()?;
     let binding = resolve_binding(&recorded, as_of)?;
 
     append_replay_record(&event_log, &binding, &recorded.event).await?;
@@ -100,7 +123,7 @@ pub(crate) async fn run(args: TriggerReplayArgs) -> Result<(), String> {
     let drift = original
         .as_ref()
         .map(|original| diff_outcomes(original, &replay_summary));
-    let report = TriggerReplayReport {
+    Ok(TriggerReplayReport {
         event_id: recorded.event.id.0,
         binding_id: binding.id.as_str().to_string(),
         binding_version: binding.version,
@@ -108,14 +131,7 @@ pub(crate) async fn run(args: TriggerReplayArgs) -> Result<(), String> {
         replay: replay_summary,
         original,
         drift,
-    };
-
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&report)
-            .map_err(|error| format!("failed to encode replay report: {error}"))?
-    );
-    Ok(())
+    })
 }
 
 fn build_replay_vm(workspace_root: &Path) -> harn_vm::Vm {

--- a/crates/harn-cli/tests/mcp_server_cli.rs
+++ b/crates/harn-cli/tests/mcp_server_cli.rs
@@ -1,0 +1,437 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value as JsonValue};
+use tempfile::TempDir;
+
+static MCP_CLI_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn lock_mcp_cli_tests() -> MutexGuard<'static, ()> {
+    MCP_CLI_TEST_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap()
+}
+
+fn write_file(dir: &Path, relative: &str, contents: &str) {
+    let path = dir.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+fn write_fixture(temp: &TempDir) {
+    write_file(
+        temp.path(),
+        "harn.toml",
+        r#"
+[package]
+name = "fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "cron-ok"
+kind = "cron"
+provider = "cron"
+schedule = "* * * * *"
+match = { events = ["cron.tick"] }
+handler = "handlers::on_ok"
+
+[[triggers]]
+id = "cron-fail"
+kind = "cron"
+provider = "cron"
+schedule = "* * * * *"
+match = { events = ["cron.tick"] }
+handler = "handlers::on_fail"
+retry = { max = 1, backoff = "immediate", retention_days = 7 }
+"#,
+    );
+    write_file(
+        temp.path(),
+        "lib.harn",
+        r#"
+import "std/triggers"
+
+pub fn on_ok(event: TriggerEvent) -> dict {
+  log("ok:" + event.kind)
+  return {kind: event.kind, event_id: event.id, trace_id: event.trace_id}
+}
+
+pub fn on_fail(event: TriggerEvent) -> any {
+  throw "boom:" + event.kind
+}
+"#,
+    );
+}
+
+fn send_request(
+    stdin: &mut impl Write,
+    stdout: &mut BufReader<impl std::io::Read>,
+    request: JsonValue,
+) -> JsonValue {
+    writeln!(stdin, "{}", serde_json::to_string(&request).unwrap()).unwrap();
+    stdin.flush().unwrap();
+    let mut line = String::new();
+    stdout.read_line(&mut line).unwrap();
+    serde_json::from_str(line.trim()).unwrap()
+}
+
+fn wait_for_http_listener(child: &mut std::process::Child, rx: &Receiver<String>) -> String {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(line) if line.contains("MCP HTTP listener ready on ") => {
+                return line
+                    .split("MCP HTTP listener ready on ")
+                    .nth(1)
+                    .unwrap()
+                    .trim()
+                    .to_string();
+            }
+            Ok(_) => continue,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if let Some(status) = child.try_wait().unwrap() {
+                    panic!("HTTP MCP server exited early: {status}");
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("HTTP MCP stderr stream closed");
+            }
+        }
+    }
+    panic!("timed out waiting for HTTP MCP listener");
+}
+
+#[test]
+fn mcp_server_stdio_roundtrips_tools_and_resources() {
+    let _guard = lock_mcp_cli_tests();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .arg("mcp")
+        .arg("serve")
+        .arg("--config")
+        .arg("harn.toml")
+        .arg("--state-dir")
+        .arg("./state")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    let init = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "integration", "version": "1.0.0" }
+            }
+        }),
+    );
+    assert_eq!(init["result"]["serverInfo"]["name"], "harn-orchestrator");
+
+    let tools = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }),
+    );
+    assert!(tools["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|tool| tool["name"] == "harn.trigger.fire"));
+
+    let dlq_fire = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "harn.trigger.fire",
+                "arguments": { "trigger_id": "cron-fail", "payload": {} }
+            }
+        }),
+    );
+    assert_eq!(
+        dlq_fire["result"]["structuredContent"]["status"],
+        json!("dlq")
+    );
+    let dlq_entry_id = dlq_fire["result"]["structuredContent"]["dlq_entry_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let dlq_list = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "harn.orchestrator.dlq.list",
+                "arguments": {}
+            }
+        }),
+    );
+    assert_eq!(
+        dlq_list["result"]["structuredContent"]["entries"][0]["id"],
+        dlq_entry_id
+    );
+
+    let dlq_retry = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {
+                "name": "harn.orchestrator.dlq.retry",
+                "arguments": { "entry_id": dlq_entry_id }
+            }
+        }),
+    );
+    assert_eq!(
+        dlq_retry["result"]["structuredContent"]["entry_id"],
+        json!(dlq_entry_id)
+    );
+
+    let ok_fire = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {
+                "name": "harn.trigger.fire",
+                "arguments": { "trigger_id": "cron-ok", "payload": {} }
+            }
+        }),
+    );
+    assert_eq!(
+        ok_fire["result"]["structuredContent"]["status"],
+        json!("dispatched")
+    );
+    let ok_event_id = ok_fire["result"]["structuredContent"]["event_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let replay = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": {
+                "name": "harn.trigger.replay",
+                "arguments": { "event_id": ok_event_id }
+            }
+        }),
+    );
+    assert_eq!(
+        replay["result"]["structuredContent"]["status"],
+        json!("dispatched")
+    );
+
+    let queue = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": {
+                "name": "harn.orchestrator.queue",
+                "arguments": {}
+            }
+        }),
+    );
+    assert!(
+        queue["result"]["structuredContent"]["outbox"]["count"]
+            .as_u64()
+            .unwrap()
+            >= 1
+    );
+
+    let inspect = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {
+                "name": "harn.orchestrator.inspect",
+                "arguments": {}
+            }
+        }),
+    );
+    assert_eq!(
+        inspect["result"]["structuredContent"]["bindings"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2
+    );
+
+    let trust = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "tools/call",
+            "params": {
+                "name": "harn.trust.query",
+                "arguments": { "query": "test" }
+            }
+        }),
+    );
+    assert_eq!(trust["result"]["structuredContent"]["results"], json!([]));
+
+    let manifest = send_request(
+        &mut stdin,
+        &mut stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "resources/read",
+            "params": { "uri": "harn://manifest" }
+        }),
+    );
+    assert!(manifest["result"]["contents"][0]["text"]
+        .as_str()
+        .unwrap()
+        .contains("cron-ok"));
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "status={status}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_server_http_roundtrips_initialize_and_fire() {
+    let _guard = lock_mcp_cli_tests();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .arg("mcp")
+        .arg("serve")
+        .arg("--config")
+        .arg("harn.toml")
+        .arg("--state-dir")
+        .arg("./state")
+        .arg("--transport")
+        .arg("http")
+        .arg("--bind")
+        .arg("127.0.0.1:0")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let stderr = child.stderr.take().unwrap();
+    let (tx, rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        for line in BufReader::new(stderr).lines() {
+            let line = line.unwrap();
+            let _ = tx.send(line);
+        }
+    });
+    let url = wait_for_http_listener(&mut child, &rx);
+    let client = reqwest::Client::new();
+
+    let init = client
+        .post(&url)
+        .header("Accept", "application/json, text/event-stream")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "http-test", "version": "1.0.0" }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(init.status().is_success());
+    let session_id = init
+        .headers()
+        .get("mcp-session-id")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let init_json: JsonValue = init.json().await.unwrap();
+    assert_eq!(
+        init_json["result"]["serverInfo"]["name"],
+        "harn-orchestrator"
+    );
+
+    let fire = client
+        .post(&url)
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "harn.trigger.fire",
+                "arguments": { "trigger_id": "cron-ok", "payload": {} }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(fire.status().is_success());
+    let fire_json: JsonValue = fire.json().await.unwrap();
+    assert_eq!(
+        fire_json["result"]["structuredContent"]["status"],
+        json!("dispatched")
+    );
+
+    child.kill().unwrap();
+    child.wait().unwrap();
+    handle.join().unwrap();
+}

--- a/crates/harn-vm/src/llm/agent/tool_dispatch.rs
+++ b/crates/harn-vm/src/llm/agent/tool_dispatch.rs
@@ -209,15 +209,18 @@ fn execute_runtime_load_skill(
     require_signature: bool,
     session_id: &str,
 ) -> String {
-    let Some(registry) = state.skill_registry.as_ref() else {
-        return runtime_tool_error(
-            "skill_registry_unavailable",
-            requested,
-            "load_skill requires agent_loop to receive a `skills:` registry",
-        );
+    let registry = match state.skill_registry.as_ref() {
+        Some(registry) => registry.clone(),
+        None => {
+            return runtime_tool_error(
+                "skill_registry_unavailable",
+                requested,
+                "load_skill requires agent_loop to receive a `skills:` registry",
+            )
+        }
     };
 
-    let entry = match crate::skills::resolve_skill_entry(registry, requested, "load_skill") {
+    let entry = match crate::skills::resolve_skill_entry(&registry, requested, "load_skill") {
         Ok(entry) => entry,
         Err(message) => return runtime_tool_error("skill_not_found", requested, message),
     };
@@ -262,7 +265,7 @@ fn execute_runtime_load_skill(
 
     let binding = crate::skills::current_skill_registry();
     let loaded = match crate::skills::load_skill_from_registry(
-        registry,
+        &registry,
         binding.as_ref().map(|bound| &bound.fetcher),
         requested,
         Some(session_id),

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -49,6 +49,7 @@
 - [Bridge protocol](./bridge-protocol.md)
 - [Host tools over the bridge](./bridge/host-tools.md)
 - [MCP and ACP integration](./mcp-and-acp.md)
+- [Orchestrator MCP server](./mcp-server.md)
 - [Harn portal](./portal.md)
 - [Orchestrator](./orchestrator.md)
 - [Orchestrator secrets](./orchestrator/secrets.md)

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -1,0 +1,197 @@
+# Orchestrator MCP Server
+
+`harn mcp serve` exposes a local Harn orchestrator as an MCP server so any MCP
+client can fire triggers, inspect queues, replay events, and read runtime state
+without a Harn-specific adapter.
+
+The server is aimed at closed-loop agent clients that already know how to speak
+MCP, including:
+
+- Cursor Composer
+- Claude Desktop
+- Claude Code
+- LangChain MCP adapters
+
+## Quickstart
+
+Hook Harn into Cursor Composer in 3 steps:
+
+1. Start the server from the workspace that owns your orchestrator manifest.
+
+```bash
+harn mcp serve --config ./harn.toml --state-dir ./.harn/orchestrator
+```
+
+2. Point Cursor at the command as a stdio MCP server.
+
+```json
+{
+  "mcpServers": {
+    "harn": {
+      "command": "harn",
+      "args": ["mcp", "serve", "--config", "/absolute/path/to/harn.toml", "--state-dir", "/absolute/path/to/.harn/orchestrator"]
+    }
+  }
+}
+```
+
+3. Ask the client to call Harn tools such as `harn.trigger.list` or
+   `harn.orchestrator.inspect`.
+
+Example prompts:
+
+- "List the Harn triggers in this workspace."
+- "Fire the `cron-ok` trigger with an empty payload."
+- "Show the Harn DLQ and retry the newest entry."
+
+## Transports
+
+`harn mcp serve` supports:
+
+- `stdio` for local spawned clients. This is the default.
+- `http` for remote MCP clients.
+
+HTTP mode exposes:
+
+- Streamable HTTP POST at `--path` (default `/mcp`)
+- Legacy SSE GET at `--sse-path` (default `/sse`)
+- Legacy SSE POST at `--messages-path` (default `/messages`)
+
+Example:
+
+```bash
+harn mcp serve \
+  --config ./harn.toml \
+  --state-dir ./.harn/orchestrator \
+  --transport http \
+  --bind 127.0.0.1:8765
+```
+
+## Auth
+
+Set `HARN_ORCHESTRATOR_API_KEYS` to a comma-separated key list to require API
+keys.
+
+HTTP clients can authenticate with either:
+
+- `Authorization: Bearer <key>`
+- `x-api-key: <key>`
+
+Stdio clients authenticate during `initialize` using a Harn extension field:
+
+```json
+{
+  "capabilities": {
+    "harn": {
+      "apiKey": "test-key"
+    }
+  }
+}
+```
+
+If `HARN_ORCHESTRATOR_API_KEYS` is unset, the MCP server runs without auth.
+
+## Tool Catalog
+
+### `harn.trigger.fire`
+
+Dispatch a trigger inline.
+
+Input:
+
+```json
+{
+  "trigger_id": "cron-ok",
+  "payload": {}
+}
+```
+
+Returns the dispatch handle summary including `event_id` and `status`.
+
+### `harn.trigger.list`
+
+Lists manifest-backed triggers with:
+
+- `trigger_id`
+- `kind`
+- `provider`
+- `when`
+- `handler`
+- `version`
+- `state`
+- `metrics`
+
+### `harn.trigger.replay`
+
+Replays a historical event. Supports `as_of` to resolve bindings against a
+historical timestamp when needed.
+
+```json
+{
+  "event_id": "trigger_evt_123",
+  "as_of": "2026-04-19T18:00:00Z"
+}
+```
+
+### `harn.orchestrator.queue`
+
+Returns queue counts plus recent head previews for:
+
+- inbox
+- outbox
+- attempts
+- DLQ
+
+### `harn.orchestrator.dlq.list`
+
+Lists pending dead-letter entries.
+
+### `harn.orchestrator.dlq.retry`
+
+Retries one DLQ entry by id.
+
+```json
+{
+  "entry_id": "dlq_123"
+}
+```
+
+### `harn.orchestrator.inspect`
+
+Returns the dispatcher snapshot, bindings, persisted orchestrator snapshot, and
+recent dispatch records.
+
+### `harn.trust.query`
+
+Placeholder trust-graph surface. Today it returns:
+
+```json
+{
+  "results": []
+}
+```
+
+## Resources
+
+The server exposes these MCP resources:
+
+- `harn://manifest`
+- `harn://event/<event_id>`
+- `harn://dlq/<entry_id>`
+
+`harn://event/<event_id>` includes the recorded trigger event plus related
+outbox/attempt/DLQ/action-graph trace entries.
+
+## Observability
+
+Every MCP tool call appends an `observability.action_graph` event and emits a
+stderr log line with:
+
+- MCP client identity
+- tool name
+- status
+- trace id
+
+`harn.trigger.fire` also injects MCP client identity and trace metadata into the
+synthetic event headers so downstream dispatch traces can be tied back to the
+calling MCP client.


### PR DESCRIPTION
## Summary
- add `harn mcp serve` to expose a running orchestrator as an MCP server over stdio and HTTP/SSE
- expose trigger, queue, DLQ, inspect, and trust-query MCP tools plus manifest, event, and DLQ MCP resources
- record MCP tool calls in `observability.action_graph`, thread MCP client identity through trace headers, and cover the surface with unit, CLI integration, and conformance tests

## Why
This lets standard MCP clients drive Harn orchestrators directly without a Harn-specific adapter layer, making Harn the neutral outer-loop runtime for existing coding-agent control planes.

## Validation
- `cargo fmt --all`
- `env CARGO_TARGET_DIR=/tmp/harn-mcp-server-target cargo check -p harn-cli`
- `env CARGO_TARGET_DIR=/tmp/harn-mcp-server-target cargo test -p harn-cli commands::mcp::serve::tests -- --nocapture`
- `env CARGO_TARGET_DIR=/tmp/harn-mcp-server-target cargo test -p harn-cli --test mcp_server_cli -- --nocapture`
- `env CARGO_TARGET_DIR=/tmp/harn-mcp-server-target cargo run --bin harn -- test conformance --filter mcp`
- `env CARGO_TARGET_DIR=/tmp/harn-mcp-server-target make test`
