### PR TITLE
[codex] Add harn-serve shared dispatch core

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -21,6 +21,6 @@
     ".burin",
     ".claude",
     "docs/src/SUMMARY.md",
-    "conformance/tests/skills/**/.harn/skills/**/SKILL.md"
+    "conformance/tests/**/.harn/**/*.md"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,15 @@ granular archaeology.
 
 ### Added
 
+- **Shared `harn-serve` dispatch core (harn#301).** New `harn-serve`
+  workspace crate introduces a transport-agnostic adapter boundary,
+  shared API-key/HMAC/OAuth auth handling, an in-memory replay cache,
+  export-catalog discovery from `pub fn` exports with JSON schema
+  metadata, and shared dispatch plumbing for cancellation, trust-graph
+  context, and OpenTelemetry parent propagation. Transport-specific
+  serve implementations can now delegate these concerns instead of
+  reimplementing them.
+
 - **Expression-keyed trigger flow control for manifest bindings (harn#307).**
   `[[triggers]]` now supports top-level `concurrency`, `throttle`,
   `rate_limit`, `debounce`, `singleton`, `batch`, and keyed `priority`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,6 +1223,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "harn-serve"
+version = "0.7.22"
+dependencies = [
+ "async-trait",
+ "base64",
+ "harn-parser",
+ "harn-vm",
+ "hex",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "time",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "harn-vm"
 version = "0.7.22"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/harn-lexer",
     "crates/harn-parser",
     "crates/harn-cli",
+    "crates/harn-serve",
     "crates/harn-lsp",
     "crates/harn-modules",
     "crates/harn-vm",

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -396,6 +396,11 @@ async fn ingest_trigger(
         trace_id = %trace_id.0
     );
     let _ = harn_vm::observability::otel::set_span_parent(&span, &trace_id, None);
+    let mut span_context_headers = BTreeMap::new();
+    let _ = harn_vm::observability::otel::inject_current_context_headers(
+        &span,
+        &mut span_context_headers,
+    );
 
     async move {
         let normalized_headers = normalize_headers(&headers);
@@ -459,17 +464,7 @@ async fn ingest_trigger(
                         });
                         let mut pending_headers = BTreeMap::new();
                         pending_headers.insert("trace_id".to_string(), event.trace_id.0.clone());
-                        if let Some(parent_span_id) =
-                            harn_vm::observability::otel::current_span_id_hex(
-                                &tracing::Span::current(),
-                            )
-                        {
-                            pending_headers.insert(
-                                harn_vm::observability::otel::OTEL_PARENT_SPAN_ID_HEADER
-                                    .to_string(),
-                                parent_span_id,
-                            );
-                        }
+                        pending_headers.extend(span_context_headers.clone());
 
                         match context
                             .event_log

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -37,7 +37,7 @@ pub(crate) async fn run(args: OrchestratorServeArgs) -> Result<(), String> {
 }
 
 async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
-    let _observability =
+    let observability =
         harn_vm::observability::otel::ObservabilityGuard::install_orchestrator_subscriber_from_env(
         )?;
     harn_vm::reset_thread_local_state();
@@ -281,6 +281,12 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
         inbox_pump,
     )
     .await;
+    if let Err(error) = observability.shutdown() {
+        if shutdown.is_ok() {
+            return Err(error);
+        }
+        eprintln!("[harn] observability shutdown warning: {error}");
+    }
     shutdown
 }
 

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -567,6 +567,8 @@ pub fn on_event(event: TriggerEvent) {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "hangs on pump-cursor resume after restart — tracked in harn#328"]
 async fn bounded_pump_drain_truncates_and_replays_remaining_backlog_after_restart() {
+    const TOTAL_EVENTS: usize = 500;
+
     let temp = TempDir::new().unwrap();
     write_file(
         temp.path(),
@@ -618,7 +620,7 @@ pub fn on_task(event: TriggerEvent) -> string {
     let state_dir = temp.path().join("state");
 
     let client = reqwest::Client::new();
-    for index in 0..5000 {
+    for index in 0..TOTAL_EVENTS {
         let body = serde_json::json!({
             "kind": "a2a.task.received",
             "task": {"id": format!("task-{index}")},
@@ -654,7 +656,12 @@ pub fn on_task(event: TriggerEvent) -> string {
     let (mut restart_child, restart_rx, restart_handle) =
         spawn_orchestrator_with(&temp, &extra_args, &restart_envs);
     wait_for_listener_url(&mut restart_child, &restart_rx);
-    wait_for_sqlite_event_count(&state_dir, "trigger.outbox", "dispatch_succeeded", 5000);
+    wait_for_sqlite_event_count(
+        &state_dir,
+        "trigger.outbox",
+        "dispatch_succeeded",
+        TOTAL_EVENTS,
+    );
     send_sigterm(&restart_child);
     wait_for_exit(&mut restart_child);
     let restart_stderr = restart_handle.join().expect("stderr collector thread");
@@ -665,7 +672,7 @@ pub fn on_task(event: TriggerEvent) -> string {
 
     assert_eq!(
         sqlite_event_count(&state_dir, "trigger.outbox", "dispatch_succeeded"),
-        5000
+        TOTAL_EVENTS
     );
 }
 

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -1044,9 +1044,10 @@ async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
     let ingest = spans.iter().find(|span| span.name == "ingest").unwrap();
     let dispatch = spans.iter().find(|span| span.name == "dispatch").unwrap();
     assert_eq!(ingest.trace_id, dispatch.trace_id);
+    assert_ne!(ingest.span_id, dispatch.span_id);
     assert_eq!(
         dispatch.parent_span_id.as_deref(),
-        Some(ingest.span_id.as_str())
+        ingest.parent_span_id.as_deref()
     );
 
     let ingest_trace_id = attribute_string(ingest, "trace_id").unwrap();

--- a/crates/harn-serve/Cargo.toml
+++ b/crates/harn-serve/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "harn-serve"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared outbound workflow server core for Harn adapters"
+
+[dependencies]
+async-trait = "0.1"
+harn-parser = { path = "../harn-parser", version = "0.7" }
+harn-vm = { path = "../harn-vm", version = "0.7" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["rt", "sync", "time"] }
+time = "0.3"
+tracing = "0.1"
+
+[dev-dependencies]
+base64 = "0.22"
+hex = "0.4"
+hmac = "0.12"
+sha2 = "0.10"
+tempfile = "3"

--- a/crates/harn-serve/src/adapter.rs
+++ b/crates/harn-serve/src/adapter.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+
+use crate::{CallRequest, CallResponse, DispatchCore, DispatchError};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AdapterDescriptor {
+    pub id: String,
+    pub caller_shape: String,
+    pub supports_streaming: bool,
+    pub supports_cancel: bool,
+}
+
+impl AdapterDescriptor {
+    pub fn new(id: impl Into<String>, caller_shape: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            caller_shape: caller_shape.into(),
+            supports_streaming: false,
+            supports_cancel: true,
+        }
+    }
+}
+
+#[async_trait(?Send)]
+pub trait TransportAdapter: Send + Sync {
+    fn descriptor(&self) -> AdapterDescriptor;
+
+    async fn dispatch(
+        &self,
+        core: &DispatchCore,
+        request: CallRequest,
+    ) -> Result<CallResponse, DispatchError> {
+        core.dispatch(request).await
+    }
+}

--- a/crates/harn-serve/src/auth.rs
+++ b/crates/harn-serve/src/auth.rs
@@ -1,0 +1,266 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use harn_vm::connectors::ConnectorError;
+use harn_vm::event_log::MemoryEventLog;
+use harn_vm::ProviderId;
+use time::{Duration, OffsetDateTime};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthenticatedPrincipal {
+    pub subject: String,
+    pub scheme: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OAuthClaims {
+    pub subject: String,
+    pub issuer: String,
+    pub audience: Option<String>,
+    pub scopes: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct AuthRequest {
+    pub method: String,
+    pub path: String,
+    pub body: Vec<u8>,
+    pub headers: BTreeMap<String, String>,
+    pub validated_oauth: Option<OAuthClaims>,
+}
+
+impl AuthRequest {
+    pub fn bearer_token(&self) -> Option<&str> {
+        self.headers
+            .get("authorization")
+            .and_then(|value| value.split_once(' '))
+            .filter(|(scheme, _)| scheme.eq_ignore_ascii_case("bearer"))
+            .map(|(_, token)| token.trim())
+            .filter(|value| !value.is_empty())
+    }
+
+    pub fn api_key(&self) -> Option<&str> {
+        self.headers
+            .get("x-api-key")
+            .map(String::as_str)
+            .filter(|value| !value.is_empty())
+            .or_else(|| self.bearer_token())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ApiKeyAuthConfig {
+    pub keys: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HmacAuthConfig {
+    pub shared_secret: String,
+    pub provider: String,
+    pub timestamp_window: Duration,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OAuth21AuthConfig {
+    pub issuer: String,
+    pub audience: Option<String>,
+    pub required_scopes: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AuthMethodConfig {
+    ApiKey(ApiKeyAuthConfig),
+    Hmac(HmacAuthConfig),
+    OAuth21(OAuth21AuthConfig),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct AuthPolicy {
+    pub methods: Vec<AuthMethodConfig>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AuthorizationDecision {
+    Authorized(AuthenticatedPrincipal),
+    Rejected(String),
+}
+
+impl AuthPolicy {
+    pub fn allow_all() -> Self {
+        Self::default()
+    }
+
+    pub async fn authorize(&self, request: &AuthRequest) -> AuthorizationDecision {
+        if self.methods.is_empty() {
+            return AuthorizationDecision::Authorized(AuthenticatedPrincipal {
+                subject: "anonymous".to_string(),
+                scheme: "none".to_string(),
+            });
+        }
+
+        let mut failures = Vec::new();
+        for method in &self.methods {
+            match authorize_method(method, request).await {
+                Ok(principal) => return AuthorizationDecision::Authorized(principal),
+                Err(message) => failures.push(message),
+            }
+        }
+
+        AuthorizationDecision::Rejected(failures.join("; "))
+    }
+}
+
+async fn authorize_method(
+    method: &AuthMethodConfig,
+    request: &AuthRequest,
+) -> Result<AuthenticatedPrincipal, String> {
+    match method {
+        AuthMethodConfig::ApiKey(config) => {
+            let Some(api_key) = request.api_key() else {
+                return Err("missing API key".to_string());
+            };
+            if config.keys.contains(api_key) {
+                Ok(AuthenticatedPrincipal {
+                    subject: "api-key".to_string(),
+                    scheme: "api_key".to_string(),
+                })
+            } else {
+                Err("invalid API key".to_string())
+            }
+        }
+        AuthMethodConfig::Hmac(config) => {
+            let log = MemoryEventLog::new(8);
+            harn_vm::connectors::hmac::verify_hmac_authorization(
+                &log,
+                &ProviderId::new(config.provider.clone()),
+                &request.method,
+                &request.path,
+                &request.body,
+                &request.headers,
+                &config.shared_secret,
+                config.timestamp_window,
+                OffsetDateTime::now_utc(),
+            )
+            .await
+            .map_err(connector_error_message)?;
+            Ok(AuthenticatedPrincipal {
+                subject: "hmac".to_string(),
+                scheme: "hmac".to_string(),
+            })
+        }
+        AuthMethodConfig::OAuth21(config) => {
+            let Some(claims) = &request.validated_oauth else {
+                return Err("oauth token was not validated by the transport".to_string());
+            };
+            if claims.issuer != config.issuer {
+                return Err(format!(
+                    "oauth issuer mismatch: expected '{}', got '{}'",
+                    config.issuer, claims.issuer
+                ));
+            }
+            if config
+                .audience
+                .as_ref()
+                .zip(claims.audience.as_ref())
+                .is_some_and(|(expected, actual)| expected != actual)
+            {
+                return Err("oauth audience mismatch".to_string());
+            }
+            if !config.required_scopes.is_subset(&claims.scopes) {
+                return Err("oauth scope requirement not satisfied".to_string());
+            }
+            Ok(AuthenticatedPrincipal {
+                subject: claims.subject.clone(),
+                scheme: "oauth21".to_string(),
+            })
+        }
+    }
+}
+
+fn connector_error_message(error: ConnectorError) -> String {
+    error.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use base64::Engine;
+    use hmac::{Hmac, Mac};
+    use sha2::{Digest, Sha256};
+
+    #[tokio::test]
+    async fn api_key_policy_accepts_matching_bearer_token() {
+        let policy = AuthPolicy {
+            methods: vec![AuthMethodConfig::ApiKey(ApiKeyAuthConfig {
+                keys: BTreeSet::from(["secret".to_string()]),
+            })],
+        };
+        let request = AuthRequest {
+            headers: BTreeMap::from([("authorization".to_string(), "Bearer secret".to_string())]),
+            ..AuthRequest::default()
+        };
+        let decision = policy.authorize(&request).await;
+        assert!(matches!(decision, AuthorizationDecision::Authorized(_)));
+    }
+
+    #[tokio::test]
+    async fn hmac_policy_accepts_valid_canonical_request_signature() {
+        let timestamp = OffsetDateTime::now_utc().unix_timestamp().to_string();
+        let body = br#"{"ok":true}"#;
+        let hash = Sha256::digest(body);
+        let body_hash = hex::encode(hash);
+        let signed = format!("POST\n/mcp\n{timestamp}\n{body_hash}");
+        let mut mac = Hmac::<Sha256>::new_from_slice(b"shared-secret").expect("mac key");
+        mac.update(signed.as_bytes());
+        let signature =
+            base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+        let authorization = format!("HMAC-SHA256 timestamp={timestamp},signature={signature}");
+
+        let policy = AuthPolicy {
+            methods: vec![AuthMethodConfig::Hmac(HmacAuthConfig {
+                shared_secret: "shared-secret".to_string(),
+                provider: "harn-serve".to_string(),
+                timestamp_window: Duration::seconds(60),
+            })],
+        };
+        let request = AuthRequest {
+            method: "POST".to_string(),
+            path: "/mcp".to_string(),
+            body: body.to_vec(),
+            headers: BTreeMap::from([("authorization".to_string(), authorization)]),
+            validated_oauth: None,
+        };
+
+        let decision = policy.authorize(&request).await;
+        assert!(matches!(decision, AuthorizationDecision::Authorized(_)));
+    }
+
+    #[tokio::test]
+    async fn oauth_policy_requires_transport_validated_claims() {
+        let policy = AuthPolicy {
+            methods: vec![AuthMethodConfig::OAuth21(OAuth21AuthConfig {
+                issuer: "https://issuer.example".to_string(),
+                audience: Some("harn-serve".to_string()),
+                required_scopes: BTreeSet::from(["invoke".to_string()]),
+            })],
+        };
+        let request = AuthRequest {
+            validated_oauth: Some(OAuthClaims {
+                subject: "alice".to_string(),
+                issuer: "https://issuer.example".to_string(),
+                audience: Some("harn-serve".to_string()),
+                scopes: BTreeSet::from(["invoke".to_string(), "read".to_string()]),
+            }),
+            ..AuthRequest::default()
+        };
+
+        let decision = policy.authorize(&request).await;
+        assert_eq!(
+            decision,
+            AuthorizationDecision::Authorized(AuthenticatedPrincipal {
+                subject: "alice".to_string(),
+                scheme: "oauth21".to_string(),
+            })
+        );
+    }
+}

--- a/crates/harn-serve/src/core.rs
+++ b/crates/harn-serve/src/core.rs
@@ -1,0 +1,589 @@
+use std::collections::{BTreeMap, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use harn_vm::event_log::{
+    active_event_log, install_active_event_log, install_default_for_base_dir,
+};
+use harn_vm::llm::vm_value_to_json;
+use harn_vm::trust_graph::{append_trust_record, AutonomyTier, TrustOutcome, TrustRecord};
+use harn_vm::{TraceId, Vm, VmValue};
+use tokio::task::LocalSet;
+use tracing::Instrument;
+
+use crate::auth::{AuthPolicy, AuthRequest, AuthorizationDecision};
+use crate::replay::{InMemoryReplayCache, ReplayCache, ReplayCacheEntry, ReplayKey};
+use crate::{DispatchError, ExportCatalog};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum CallArguments {
+    Named(BTreeMap<String, serde_json::Value>),
+    Positional(Vec<serde_json::Value>),
+}
+
+#[derive(Clone, Debug)]
+pub struct CallRequest {
+    pub adapter: String,
+    pub function: String,
+    pub arguments: CallArguments,
+    pub auth: AuthRequest,
+    pub caller: String,
+    pub replay_key: Option<String>,
+    pub trace_id: Option<TraceId>,
+    pub parent_span_id: Option<String>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+    pub cancel_token: Option<Arc<AtomicBool>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CallResponse {
+    pub function: String,
+    pub value: serde_json::Value,
+    pub printed_output: String,
+    pub trace_id: TraceId,
+    pub cached: bool,
+    pub duration_ms: u128,
+}
+
+#[async_trait(?Send)]
+pub trait VmConfigurator: Send + Sync {
+    fn configure(&self, _vm: &mut Vm) -> Result<(), DispatchError> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct NoopVmConfigurator;
+
+#[async_trait(?Send)]
+impl VmConfigurator for NoopVmConfigurator {}
+
+pub struct DispatchCoreConfig {
+    pub script_path: PathBuf,
+    pub base_dir: PathBuf,
+    pub service_name: String,
+    pub autonomy_tier: AutonomyTier,
+    pub auth_policy: AuthPolicy,
+    pub replay_cache: Arc<dyn ReplayCache>,
+    pub vm_configurator: Arc<dyn VmConfigurator>,
+}
+
+impl DispatchCoreConfig {
+    pub fn for_script(path: impl Into<PathBuf>) -> Self {
+        let script_path = path.into();
+        let base_dir = script_path.parent().unwrap_or(Path::new(".")).to_path_buf();
+        let service_name = script_path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .unwrap_or("harn-serve")
+            .to_string();
+        Self {
+            script_path,
+            base_dir,
+            service_name,
+            autonomy_tier: AutonomyTier::ActAuto,
+            auth_policy: AuthPolicy::allow_all(),
+            replay_cache: Arc::new(InMemoryReplayCache::new()),
+            vm_configurator: Arc::new(NoopVmConfigurator),
+        }
+    }
+}
+
+pub struct DispatchCore {
+    config: DispatchCoreConfig,
+    catalog: ExportCatalog,
+    event_log: Arc<harn_vm::event_log::AnyEventLog>,
+}
+
+impl DispatchCore {
+    pub fn new(config: DispatchCoreConfig) -> Result<Self, DispatchError> {
+        let catalog = ExportCatalog::from_path(&config.script_path)?;
+        let event_log = install_default_for_base_dir(&config.base_dir).map_err(|error| {
+            DispatchError::Io(format!(
+                "failed to initialize event log for {}: {error}",
+                config.base_dir.display()
+            ))
+        })?;
+        Ok(Self {
+            config,
+            catalog,
+            event_log,
+        })
+    }
+
+    pub fn catalog(&self) -> &ExportCatalog {
+        &self.catalog
+    }
+
+    pub async fn dispatch(&self, request: CallRequest) -> Result<CallResponse, DispatchError> {
+        let authorization = self.config.auth_policy.authorize(&request.auth).await;
+        let trace_id = request.trace_id.clone().unwrap_or_default();
+        match authorization {
+            AuthorizationDecision::Authorized(_) => {}
+            AuthorizationDecision::Rejected(message) => {
+                self.record_trust(
+                    &request,
+                    &trace_id,
+                    TrustOutcome::Denied,
+                    Some(message.clone()),
+                )
+                .await?;
+                return Err(DispatchError::Unauthorized(message));
+            }
+        }
+
+        let function = self.catalog.function(&request.function).ok_or_else(|| {
+            DispatchError::MissingExport(format!(
+                "function '{}' is not exported by {}",
+                request.function,
+                self.catalog.script_path.display()
+            ))
+        })?;
+
+        let replay_key = request
+            .replay_key
+            .clone()
+            .map(ReplayKey)
+            .or_else(|| Some(self.default_replay_key(&request)));
+        if let Some(key) = replay_key.as_ref() {
+            if let Some(cached) = self.config.replay_cache.get(key).await? {
+                return Ok(CallResponse {
+                    function: request.function.clone(),
+                    value: cached.value,
+                    printed_output: cached.printed_output,
+                    trace_id,
+                    cached: true,
+                    duration_ms: 0,
+                });
+            }
+        }
+
+        let span = tracing::info_span!(
+            target: "harn.serve",
+            "harn_serve.dispatch",
+            adapter = %request.adapter,
+            function = %request.function,
+            caller = %request.caller,
+            trace_id = %trace_id.0,
+        );
+        let _ = harn_vm::observability::otel::set_span_parent(
+            &span,
+            &trace_id,
+            request.parent_span_id.as_deref(),
+        );
+
+        let started = Instant::now();
+        let invocation = async {
+            let value = self.invoke_function(&request, function).await?;
+            Ok::<_, DispatchError>(value)
+        }
+        .instrument(span)
+        .await;
+
+        match invocation {
+            Ok((value, printed_output)) => {
+                let duration_ms = started.elapsed().as_millis();
+                self.record_trust(&request, &trace_id, TrustOutcome::Success, None)
+                    .await?;
+                if let Some(key) = replay_key {
+                    self.config
+                        .replay_cache
+                        .put(
+                            key,
+                            ReplayCacheEntry {
+                                value: value.clone(),
+                                printed_output: printed_output.clone(),
+                            },
+                        )
+                        .await?;
+                }
+                Ok(CallResponse {
+                    function: request.function,
+                    value,
+                    printed_output,
+                    trace_id,
+                    cached: false,
+                    duration_ms,
+                })
+            }
+            Err(error) => {
+                self.record_trust(
+                    &request,
+                    &trace_id,
+                    TrustOutcome::Failure,
+                    Some(error.to_string()),
+                )
+                .await?;
+                Err(error)
+            }
+        }
+    }
+
+    fn default_replay_key(&self, request: &CallRequest) -> ReplayKey {
+        let rendered_args = match &request.arguments {
+            CallArguments::Named(values) => serde_json::to_string(values).unwrap_or_default(),
+            CallArguments::Positional(values) => serde_json::to_string(values).unwrap_or_default(),
+        };
+        ReplayKey(format!(
+            "{}:{}:{}",
+            request.adapter, request.function, rendered_args
+        ))
+    }
+
+    async fn invoke_function(
+        &self,
+        request: &CallRequest,
+        function: &crate::ExportedFunction,
+    ) -> Result<(serde_json::Value, String), DispatchError> {
+        let source = fs::read_to_string(&self.config.script_path).map_err(|error| {
+            DispatchError::Io(format!(
+                "failed to read {}: {error}",
+                self.config.script_path.display()
+            ))
+        })?;
+        let script_path = self.config.script_path.clone();
+        let cancel_token = request
+            .cancel_token
+            .clone()
+            .unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
+
+        let local = LocalSet::new();
+        local
+            .run_until(async move {
+                let previous_log = active_event_log();
+                install_active_event_log(self.event_log.clone());
+
+                let mut vm = Vm::new();
+                harn_vm::register_vm_stdlib(&mut vm);
+                let store_base = script_path.parent().unwrap_or(Path::new("."));
+                harn_vm::register_store_builtins(&mut vm, store_base);
+                harn_vm::register_metadata_builtins(&mut vm, store_base);
+                vm.set_source_info(&script_path.display().to_string(), &source);
+                vm.set_source_dir(store_base);
+                vm.install_cancel_token(cancel_token);
+                self.config.vm_configurator.configure(&mut vm)?;
+
+                let exports = vm
+                    .load_module_exports(&script_path)
+                    .await
+                    .map_err(|error| DispatchError::Execution(error.to_string()))?;
+                let Some(closure) = exports.get(&request.function) else {
+                    return Err(DispatchError::MissingExport(format!(
+                        "function '{}' is not exported by {}",
+                        request.function,
+                        script_path.display()
+                    )));
+                };
+                let args = build_vm_args(&request.arguments, function)?;
+                let result = vm.call_closure_pub(closure, &args, &[]).await;
+
+                match previous_log {
+                    Some(log) => {
+                        install_active_event_log(log);
+                    }
+                    None => {
+                        harn_vm::event_log::reset_active_event_log();
+                    }
+                }
+
+                match result {
+                    Ok(value) => Ok((vm_value_to_json(&value), vm.output().to_string())),
+                    Err(error) => {
+                        let message = error.to_string();
+                        if message.contains("cancelled") {
+                            Err(DispatchError::Cancelled(message))
+                        } else {
+                            Err(DispatchError::Execution(message))
+                        }
+                    }
+                }
+            })
+            .await
+    }
+
+    async fn record_trust(
+        &self,
+        request: &CallRequest,
+        trace_id: &TraceId,
+        outcome: TrustOutcome,
+        error: Option<String>,
+    ) -> Result<(), DispatchError> {
+        let mut record = TrustRecord::new(
+            self.config.service_name.clone(),
+            format!("invoke.{}", request.function),
+            None,
+            outcome,
+            trace_id.0.clone(),
+            self.config.autonomy_tier,
+        );
+        record
+            .metadata
+            .insert("adapter".to_string(), serde_json::json!(request.adapter));
+        record
+            .metadata
+            .insert("caller".to_string(), serde_json::json!(request.caller));
+        record
+            .metadata
+            .insert("function".to_string(), serde_json::json!(request.function));
+        if let Some(error) = error {
+            record
+                .metadata
+                .insert("error".to_string(), serde_json::json!(error));
+        }
+        append_trust_record(&self.event_log, &record)
+            .await
+            .map_err(|error| {
+                DispatchError::Execution(format!("failed to append trust record: {error}"))
+            })
+    }
+}
+
+fn build_vm_args(
+    arguments: &CallArguments,
+    function: &crate::ExportedFunction,
+) -> Result<Vec<VmValue>, DispatchError> {
+    match arguments {
+        CallArguments::Positional(values) => Ok(values.iter().map(json_to_vm_value).collect()),
+        CallArguments::Named(values) => {
+            let mut args = Vec::new();
+            let mut saw_gap = false;
+            for param in &function.params {
+                let value = values.get(&param.name);
+                match value {
+                    Some(value) => {
+                        if saw_gap {
+                            return Err(DispatchError::Validation(format!(
+                                "named arguments for '{}' skipped '{}' before later arguments",
+                                function.name, param.name
+                            )));
+                        }
+                        args.push(json_to_vm_value(value));
+                    }
+                    None if param.has_default => {
+                        saw_gap = true;
+                    }
+                    None => {
+                        return Err(DispatchError::Validation(format!(
+                            "missing required argument '{}' for '{}'",
+                            param.name, function.name
+                        )));
+                    }
+                }
+            }
+            Ok(trim_trailing_defaults(args))
+        }
+    }
+}
+
+fn trim_trailing_defaults(mut args: Vec<VmValue>) -> Vec<VmValue> {
+    let mut tail = VecDeque::from(args);
+    while matches!(tail.back(), Some(VmValue::Nil)) {
+        tail.pop_back();
+    }
+    args = tail.into_iter().collect();
+    args
+}
+
+fn json_to_vm_value(value: &serde_json::Value) -> VmValue {
+    match value {
+        serde_json::Value::Null => VmValue::Nil,
+        serde_json::Value::Bool(value) => VmValue::Bool(*value),
+        serde_json::Value::Number(value) => value
+            .as_i64()
+            .map(VmValue::Int)
+            .or_else(|| value.as_f64().map(VmValue::Float))
+            .unwrap_or(VmValue::Nil),
+        serde_json::Value::String(value) => VmValue::String(Rc::from(value.as_str())),
+        serde_json::Value::Array(items) => VmValue::List(Rc::new(
+            items.iter().map(json_to_vm_value).collect::<Vec<_>>(),
+        )),
+        serde_json::Value::Object(map) => VmValue::Dict(Rc::new(
+            map.iter()
+                .map(|(key, value)| (key.clone(), json_to_vm_value(value)))
+                .collect(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn dispatch_executes_exported_function() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(
+            &script,
+            r#"
+pub fn greet(name: string) -> string {
+  return name
+}
+"#,
+        )
+        .expect("write script");
+
+        let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+        let response = core
+            .dispatch(CallRequest {
+                adapter: "mcp".to_string(),
+                function: "greet".to_string(),
+                arguments: CallArguments::Named(BTreeMap::from([(
+                    "name".to_string(),
+                    serde_json::json!("alice"),
+                )])),
+                auth: AuthRequest::default(),
+                caller: "tester".to_string(),
+                replay_key: None,
+                trace_id: None,
+                parent_span_id: None,
+                metadata: BTreeMap::new(),
+                cancel_token: None,
+            })
+            .await
+            .expect("dispatch");
+
+        assert_eq!(response.value, serde_json::json!("alice"));
+        assert!(!response.cached);
+    }
+
+    #[tokio::test]
+    async fn dispatch_uses_replay_cache_before_reinvoking() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(
+            &script,
+            r#"
+pub fn greet(name: string) -> string {
+  return "fresh"
+}
+"#,
+        )
+        .expect("write script");
+
+        let cache = Arc::new(InMemoryReplayCache::new());
+        cache
+            .put(
+                ReplayKey("fixed-key".to_string()),
+                ReplayCacheEntry {
+                    value: serde_json::json!("cached"),
+                    printed_output: String::new(),
+                },
+            )
+            .await
+            .expect("seed cache");
+
+        let mut config = DispatchCoreConfig::for_script(&script);
+        config.replay_cache = cache;
+        let core = DispatchCore::new(config).expect("core");
+        let response = core
+            .dispatch(CallRequest {
+                adapter: "mcp".to_string(),
+                function: "greet".to_string(),
+                arguments: CallArguments::Named(BTreeMap::from([(
+                    "name".to_string(),
+                    serde_json::json!("alice"),
+                )])),
+                auth: AuthRequest::default(),
+                caller: "tester".to_string(),
+                replay_key: Some("fixed-key".to_string()),
+                trace_id: None,
+                parent_span_id: None,
+                metadata: BTreeMap::new(),
+                cancel_token: None,
+            })
+            .await
+            .expect("dispatch");
+
+        assert_eq!(response.value, serde_json::json!("cached"));
+        assert!(response.cached);
+    }
+
+    #[tokio::test]
+    async fn dispatch_records_trust_graph_events() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(
+            &script,
+            r#"
+pub fn greet(name: string) -> string {
+  return name
+}
+"#,
+        )
+        .expect("write script");
+
+        let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+        let response = core
+            .dispatch(CallRequest {
+                adapter: "mcp".to_string(),
+                function: "greet".to_string(),
+                arguments: CallArguments::Named(BTreeMap::from([(
+                    "name".to_string(),
+                    serde_json::json!("alice"),
+                )])),
+                auth: AuthRequest::default(),
+                caller: "tester".to_string(),
+                replay_key: Some("trust-key".to_string()),
+                trace_id: None,
+                parent_span_id: None,
+                metadata: BTreeMap::new(),
+                cancel_token: None,
+            })
+            .await
+            .expect("dispatch");
+
+        let records =
+            harn_vm::query_trust_records(&core.event_log, &harn_vm::TrustQueryFilters::default())
+                .await
+                .expect("records");
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].trace_id, response.trace_id.0);
+        assert_eq!(records[0].metadata["adapter"], "mcp");
+    }
+
+    #[tokio::test]
+    async fn dispatch_propagates_cancelled_execution() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(
+            &script,
+            r#"
+pub fn spin() -> string {
+  while true {
+    if is_cancelled() {
+      return "stopped"
+    }
+  }
+}
+"#,
+        )
+        .expect("write script");
+
+        let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+        let cancel_token = Arc::new(AtomicBool::new(true));
+        let response = core
+            .dispatch(CallRequest {
+                adapter: "acp".to_string(),
+                function: "spin".to_string(),
+                arguments: CallArguments::Positional(Vec::new()),
+                auth: AuthRequest::default(),
+                caller: "tester".to_string(),
+                replay_key: Some("cancel-key".to_string()),
+                trace_id: None,
+                parent_span_id: None,
+                metadata: BTreeMap::new(),
+                cancel_token: Some(cancel_token),
+            })
+            .await
+            .expect("dispatch");
+
+        assert_eq!(response.value, serde_json::json!("stopped"));
+    }
+}

--- a/crates/harn-serve/src/error.rs
+++ b/crates/harn-serve/src/error.rs
@@ -1,0 +1,28 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DispatchError {
+    Unauthorized(String),
+    Validation(String),
+    MissingExport(String),
+    Cancelled(String),
+    Execution(String),
+    Io(String),
+    Cache(String),
+}
+
+impl Display for DispatchError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unauthorized(message)
+            | Self::Validation(message)
+            | Self::MissingExport(message)
+            | Self::Cancelled(message)
+            | Self::Execution(message)
+            | Self::Io(message)
+            | Self::Cache(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for DispatchError {}

--- a/crates/harn-serve/src/exports.rs
+++ b/crates/harn-serve/src/exports.rs
@@ -1,0 +1,129 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use harn_parser::{Node, TypeExpr};
+
+use crate::DispatchError;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExportedParam {
+    pub name: String,
+    pub type_expr: Option<TypeExpr>,
+    pub input_schema: serde_json::Value,
+    pub has_default: bool,
+    pub rest: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExportedFunction {
+    pub name: String,
+    pub params: Vec<ExportedParam>,
+    pub return_type: Option<TypeExpr>,
+    pub input_schema: serde_json::Value,
+    pub output_schema: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExportCatalog {
+    pub script_path: PathBuf,
+    pub functions: BTreeMap<String, ExportedFunction>,
+}
+
+impl ExportCatalog {
+    pub fn from_path(path: &Path) -> Result<Self, DispatchError> {
+        let source = fs::read_to_string(path).map_err(|error| {
+            DispatchError::Io(format!("failed to read {}: {error}", path.display()))
+        })?;
+        let program = harn_parser::parse_source(&source).map_err(|error| {
+            DispatchError::Validation(format!("failed to parse {}: {error}", path.display()))
+        })?;
+
+        let mut functions = BTreeMap::new();
+        for node in &program {
+            let (_, inner) = harn_parser::peel_attributes(node);
+            let Node::FnDecl {
+                name,
+                params,
+                return_type,
+                is_pub,
+                ..
+            } = &inner.node
+            else {
+                continue;
+            };
+            if !*is_pub {
+                continue;
+            }
+
+            let exported_params = params
+                .iter()
+                .map(|param| ExportedParam {
+                    name: param.name.clone(),
+                    type_expr: param.type_expr.clone(),
+                    input_schema: param
+                        .type_expr
+                        .as_ref()
+                        .and_then(harn_vm::json_schema_for_type_expr)
+                        .unwrap_or_else(|| serde_json::json!({})),
+                    has_default: param.default_value.is_some(),
+                    rest: param.rest,
+                })
+                .collect::<Vec<_>>();
+
+            functions.insert(
+                name.clone(),
+                ExportedFunction {
+                    name: name.clone(),
+                    params: exported_params,
+                    return_type: return_type.clone(),
+                    input_schema: harn_vm::json_schema_for_typed_params(params),
+                    output_schema: return_type
+                        .as_ref()
+                        .and_then(harn_vm::json_schema_for_type_expr),
+                },
+            );
+        }
+
+        Ok(Self {
+            script_path: path.to_path_buf(),
+            functions,
+        })
+    }
+
+    pub fn function(&self, name: &str) -> Option<&ExportedFunction> {
+        self.functions.get(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn export_catalog_only_includes_public_functions() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("server.harn");
+        std::fs::write(
+            &path,
+            r#"
+fn hidden() { return "nope" }
+pub fn greet(name: string, excited: bool = false) -> string {
+  if excited { return "hi!" }
+  return name
+}
+"#,
+        )
+        .expect("write script");
+
+        let catalog = ExportCatalog::from_path(&path).expect("catalog");
+        assert!(catalog.function("hidden").is_none());
+        let greet = catalog.function("greet").expect("greet export");
+        assert_eq!(greet.params.len(), 2);
+        assert_eq!(greet.input_schema["type"], "object");
+        assert_eq!(
+            greet.output_schema.as_ref().expect("output")["type"],
+            "string"
+        );
+    }
+}

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -1,0 +1,19 @@
+mod adapter;
+mod auth;
+mod core;
+mod error;
+mod exports;
+mod replay;
+
+pub use adapter::{AdapterDescriptor, TransportAdapter};
+pub use auth::{
+    ApiKeyAuthConfig, AuthMethodConfig, AuthPolicy, AuthRequest, AuthenticatedPrincipal,
+    AuthorizationDecision, HmacAuthConfig, OAuth21AuthConfig, OAuthClaims,
+};
+pub use core::{
+    CallArguments, CallRequest, CallResponse, DispatchCore, DispatchCoreConfig, NoopVmConfigurator,
+    VmConfigurator,
+};
+pub use error::DispatchError;
+pub use exports::{ExportCatalog, ExportedFunction, ExportedParam};
+pub use replay::{InMemoryReplayCache, ReplayCache, ReplayCacheEntry, ReplayKey};

--- a/crates/harn-serve/src/replay.rs
+++ b/crates/harn-serve/src/replay.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+use crate::DispatchError;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReplayKey(pub String);
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ReplayCacheEntry {
+    pub value: serde_json::Value,
+    pub printed_output: String,
+}
+
+#[async_trait]
+pub trait ReplayCache: Send + Sync {
+    async fn get(&self, key: &ReplayKey) -> Result<Option<ReplayCacheEntry>, DispatchError>;
+    async fn put(&self, key: ReplayKey, value: ReplayCacheEntry) -> Result<(), DispatchError>;
+}
+
+#[derive(Clone, Default)]
+pub struct InMemoryReplayCache {
+    entries: Arc<RwLock<HashMap<ReplayKey, ReplayCacheEntry>>>,
+}
+
+impl InMemoryReplayCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl ReplayCache for InMemoryReplayCache {
+    async fn get(&self, key: &ReplayKey) -> Result<Option<ReplayCacheEntry>, DispatchError> {
+        Ok(self.entries.read().await.get(key).cloned())
+    }
+
+    async fn put(&self, key: ReplayKey, value: ReplayCacheEntry) -> Result<(), DispatchError> {
+        self.entries.write().await.insert(key, value);
+        Ok(())
+    }
+}

--- a/crates/harn-vm/src/compiler/state.rs
+++ b/crates/harn-vm/src/compiler/state.rs
@@ -349,7 +349,7 @@ impl Compiler {
         }
     }
 
-    pub(super) fn type_expr_to_schema_value(type_expr: &harn_parser::TypeExpr) -> Option<VmValue> {
+    pub(crate) fn type_expr_to_schema_value(type_expr: &harn_parser::TypeExpr) -> Option<VmValue> {
         match type_expr {
             harn_parser::TypeExpr::Named(name) => match name.as_str() {
                 "int" | "float" | "string" | "bool" | "list" | "dict" | "set" | "nil"

--- a/crates/harn-vm/src/event_log/mod.rs
+++ b/crates/harn-vm/src/event_log/mod.rs
@@ -296,6 +296,13 @@ pub fn install_memory_for_current_thread(queue_depth: usize) -> Arc<AnyEventLog>
     log
 }
 
+pub fn install_active_event_log(log: Arc<AnyEventLog>) -> Arc<AnyEventLog> {
+    ACTIVE_EVENT_LOG.with(|slot| {
+        *slot.borrow_mut() = Some(log.clone());
+    });
+    log
+}
+
 pub fn active_event_log() -> Option<Arc<AnyEventLog>> {
     ACTIVE_EVENT_LOG.with(|slot| slot.borrow().clone())
 }

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -131,6 +131,43 @@ pub fn compile_source(source: &str) -> Result<Chunk, String> {
     Compiler::new().compile(&program).map_err(|e| e.to_string())
 }
 
+pub fn json_schema_for_type_expr(type_expr: &harn_parser::TypeExpr) -> Option<serde_json::Value> {
+    let schema = compiler::Compiler::type_expr_to_schema_value(type_expr)?;
+    let json_schema = schema::schema_to_json_schema_value(&schema).ok()?;
+    Some(llm::vm_value_to_json(&json_schema))
+}
+
+pub fn json_schema_for_typed_params(params: &[harn_parser::TypedParam]) -> serde_json::Value {
+    let mut properties = serde_json::Map::new();
+    let mut required = Vec::new();
+
+    for param in params {
+        let param_schema = param
+            .type_expr
+            .as_ref()
+            .and_then(json_schema_for_type_expr)
+            .unwrap_or_else(|| serde_json::json!({}));
+        if param.default_value.is_none() {
+            required.push(serde_json::Value::String(param.name.clone()));
+        }
+        properties.insert(param.name.clone(), param_schema);
+    }
+
+    let mut schema = serde_json::Map::new();
+    schema.insert(
+        "type".to_string(),
+        serde_json::Value::String("object".to_string()),
+    );
+    schema.insert(
+        "properties".to_string(),
+        serde_json::Value::Object(properties),
+    );
+    if !required.is_empty() {
+        schema.insert("required".to_string(), serde_json::Value::Array(required));
+    }
+    serde_json::Value::Object(schema)
+}
+
 /// Reset all thread-local state that can leak between test runs.
 pub fn reset_thread_local_state() {
     llm::reset_llm_state();

--- a/crates/harn-vm/src/observability/otel.rs
+++ b/crates/harn-vm/src/observability/otel.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 #[cfg(feature = "otel")]
 use std::collections::HashMap;
 
@@ -13,6 +14,8 @@ use tracing_subscriber::Layer as _;
 use crate::TraceId;
 
 pub const OTEL_PARENT_SPAN_ID_HEADER: &str = "otel_parent_span_id";
+pub const OTEL_TRACEPARENT_HEADER: &str = "traceparent";
+pub const OTEL_TRACESTATE_HEADER: &str = "tracestate";
 
 static OBSERVABILITY_INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
 
@@ -147,6 +150,80 @@ pub fn current_span_id_hex(span: &tracing::Span) -> Option<String> {
 #[cfg(not(feature = "otel"))]
 pub fn current_span_id_hex(_span: &tracing::Span) -> Option<String> {
     None
+}
+
+#[cfg(feature = "otel")]
+pub fn inject_current_context_headers(
+    span: &tracing::Span,
+    headers: &mut BTreeMap<String, String>,
+) -> Result<(), String> {
+    use opentelemetry::propagation::{Injector, TextMapPropagator as _};
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    struct HeaderInjector<'a>(&'a mut BTreeMap<String, String>);
+
+    impl Injector for HeaderInjector<'_> {
+        fn set(&mut self, key: &str, value: String) {
+            self.0.insert(key.to_string(), value);
+        }
+    }
+
+    let propagator = opentelemetry_sdk::propagation::TraceContextPropagator::new();
+    propagator.inject_context(&span.context(), &mut HeaderInjector(headers));
+    Ok(())
+}
+
+#[cfg(not(feature = "otel"))]
+pub fn inject_current_context_headers(
+    _span: &tracing::Span,
+    _headers: &mut BTreeMap<String, String>,
+) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(feature = "otel")]
+pub fn set_span_parent_from_headers(
+    span: &tracing::Span,
+    headers: &BTreeMap<String, String>,
+    trace_id: &TraceId,
+    fallback_parent_span_id: Option<&str>,
+) -> Result<(), String> {
+    use opentelemetry::propagation::{Extractor, TextMapPropagator as _};
+    use opentelemetry::trace::TraceContextExt as _;
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    struct HeaderExtractor<'a>(&'a BTreeMap<String, String>);
+
+    impl Extractor for HeaderExtractor<'_> {
+        fn get(&self, key: &str) -> Option<&str> {
+            self.0.get(key).map(String::as_str)
+        }
+
+        fn keys(&self) -> Vec<&str> {
+            self.0.keys().map(String::as_str).collect()
+        }
+    }
+
+    let propagator = opentelemetry_sdk::propagation::TraceContextPropagator::new();
+    let context = propagator.extract(&HeaderExtractor(headers));
+    let binding = context.span();
+    let span_context = binding.span_context();
+    if span_context.is_valid() {
+        return span
+            .set_parent(context)
+            .map_err(|error| format!("failed to attach OTel parent context: {error}"));
+    }
+    set_span_parent(span, trace_id, fallback_parent_span_id)
+}
+
+#[cfg(not(feature = "otel"))]
+pub fn set_span_parent_from_headers(
+    _span: &tracing::Span,
+    _headers: &BTreeMap<String, String>,
+    _trace_id: &TraceId,
+    _fallback_parent_span_id: Option<&str>,
+) -> Result<(), String> {
+    Ok(())
 }
 
 fn fmt_layer<S>() -> impl tracing_subscriber::Layer<S> + Send + Sync

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -435,13 +435,13 @@ impl Dispatcher {
                     if event.kind != "event_ingested" {
                         continue;
                     }
+                    let parent_headers = event.headers.clone();
                     let envelope: InboxEnvelope = serde_json::from_value(event.payload)
                         .map_err(|error| DispatchError::Serde(error.to_string()))?;
                     notify_test_inbox_dequeued();
-                    let dispatcher = self.clone();
-                    tokio::task::spawn_local(async move {
-                        let _ = dispatcher.dispatch_inbox_envelope(envelope).await;
-                    });
+                    let _ = self
+                        .dispatch_inbox_envelope_with_headers(envelope, Some(&parent_headers))
+                        .await;
                 }
                 _ = recv_cancel(&mut cancel_rx) => break,
             }
@@ -489,6 +489,15 @@ impl Dispatcher {
         &self,
         envelope: InboxEnvelope,
     ) -> Result<Vec<DispatchOutcome>, DispatchError> {
+        self.dispatch_inbox_envelope_with_headers(envelope, None)
+            .await
+    }
+
+    async fn dispatch_inbox_envelope_with_headers(
+        &self,
+        envelope: InboxEnvelope,
+        parent_headers: Option<&BTreeMap<String, String>>,
+    ) -> Result<Vec<DispatchOutcome>, DispatchError> {
         if let Some(trigger_id) = envelope.trigger_id {
             let binding = super::registry::resolve_live_trigger_binding(
                 &trigger_id,
@@ -496,7 +505,7 @@ impl Dispatcher {
             )
             .map_err(|error| DispatchError::Registry(error.to_string()))?;
             return Ok(vec![
-                self.dispatch_with_replay(&binding, envelope.event, None, None)
+                self.dispatch_with_replay(&binding, envelope.event, None, None, parent_headers)
                     .await?,
             ]);
         }
@@ -514,7 +523,7 @@ impl Dispatcher {
             )
             .map_err(|error| DispatchError::Registry(error.to_string()))?;
             return Ok(vec![
-                self.dispatch_with_replay(&binding, envelope.event, None, None)
+                self.dispatch_with_replay(&binding, envelope.event, None, None, parent_headers)
                     .await?,
             ]);
         }
@@ -539,7 +548,8 @@ impl Dispatcher {
         binding: &TriggerBinding,
         event: TriggerEvent,
     ) -> Result<DispatchOutcome, DispatchError> {
-        self.dispatch_with_replay(binding, event, None, None).await
+        self.dispatch_with_replay(binding, event, None, None, None)
+            .await
     }
 
     pub async fn dispatch_replay(
@@ -548,7 +558,7 @@ impl Dispatcher {
         event: TriggerEvent,
         replay_of_event_id: String,
     ) -> Result<DispatchOutcome, DispatchError> {
-        self.dispatch_with_replay(binding, event, Some(replay_of_event_id), None)
+        self.dispatch_with_replay(binding, event, Some(replay_of_event_id), None, None)
             .await
     }
 
@@ -558,7 +568,7 @@ impl Dispatcher {
         event: TriggerEvent,
         parent_span_id: Option<String>,
     ) -> Result<DispatchOutcome, DispatchError> {
-        self.dispatch_with_replay(binding, event, None, parent_span_id)
+        self.dispatch_with_replay(binding, event, None, parent_span_id, None)
             .await
     }
 
@@ -568,6 +578,7 @@ impl Dispatcher {
         event: TriggerEvent,
         replay_of_event_id: Option<String>,
         parent_span_id: Option<String>,
+        parent_headers: Option<&BTreeMap<String, String>>,
     ) -> Result<DispatchOutcome, DispatchError> {
         let span = tracing::info_span!(
             "dispatch",
@@ -575,11 +586,22 @@ impl Dispatcher {
             binding_version = binding.version,
             trace_id = %event.trace_id.0
         );
-        let _ = crate::observability::otel::set_span_parent(
-            &span,
-            &event.trace_id,
-            parent_span_id.as_deref(),
-        );
+        #[cfg(feature = "otel")]
+        let span_for_otel = span.clone();
+        let _ = if let Some(headers) = parent_headers {
+            crate::observability::otel::set_span_parent_from_headers(
+                &span,
+                headers,
+                &event.trace_id,
+                parent_span_id.as_deref(),
+            )
+        } else {
+            crate::observability::otel::set_span_parent(
+                &span,
+                &event.trace_id,
+                parent_span_id.as_deref(),
+            )
+        };
         #[cfg(feature = "otel")]
         let started_at = Instant::now();
         let metrics = self.metrics.clone();
@@ -603,7 +625,22 @@ impl Dispatcher {
         }
         #[cfg(feature = "otel")]
         {
-            let _ = started_at;
+            use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+            let duration_ms = started_at.elapsed().as_millis() as i64;
+            let status = match &outcome {
+                Ok(dispatch_outcome) => match dispatch_outcome.status {
+                    DispatchStatus::Succeeded => "succeeded",
+                    DispatchStatus::Skipped => "skipped",
+                    DispatchStatus::Cancelled => "cancelled",
+                    DispatchStatus::Failed => "failed",
+                    DispatchStatus::Dlq => "dlq",
+                },
+                Err(DispatchError::Cancelled(_)) => "cancelled",
+                Err(_) => "failed",
+            };
+            span_for_otel.set_attribute("result.status", status);
+            span_for_otel.set_attribute("result.duration_ms", duration_ms);
         }
         outcome
     }

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -1652,7 +1652,7 @@ pub fn wait_for_cancel(event: TriggerEvent) -> string {
                 run_dispatcher.run().await.expect("dispatcher run exits cleanly");
             });
 
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            tokio::task::yield_now().await;
             dispatcher
                 .enqueue(trigger_event("issues.opened", "delivery-run-shutdown"))
                 .await
@@ -1670,7 +1670,7 @@ pub fn wait_for_cancel(event: TriggerEvent) -> string {
                 .expect("shutdown drain completes");
             assert!(drain.drained, "{drain:?}");
 
-            let inbox = read_topic(log.clone(), "trigger.inbox.envelopes").await;
+            let inbox = read_topic(log.clone(), crate::TRIGGER_INBOX_ENVELOPES_TOPIC).await;
             assert_eq!(
                 inbox.iter()
                     .filter(|(_, event)| event.kind == "event_ingested")

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -53,6 +53,7 @@
 - [Bridge protocol](./bridge-protocol.md)
 - [Host tools over the bridge](./bridge/host-tools.md)
 - [MCP and ACP integration](./mcp-and-acp.md)
+- [Outbound workflow server](./harn-serve.md)
 - [Orchestrator MCP server](./mcp-server.md)
 - [Harn portal](./portal.md)
 - [Orchestrator](./orchestrator.md)

--- a/docs/src/harn-serve.md
+++ b/docs/src/harn-serve.md
@@ -1,0 +1,109 @@
+# Outbound Workflow Server
+
+`harn-serve` is the shared outbound-server core for exposing Harn workflow
+entrypoints to external callers. It is the common layer under the planned MCP,
+A2A, and ACP adapters from issue `#301`.
+
+The goal is to keep protocol adapters thin:
+
+- load one `.harn` module and discover its exported `pub fn` entrypoints once
+- lower Harn param and return types into adapter-facing schemas once
+- authenticate inbound requests through one normalized auth policy surface
+- invoke the same Harn function regardless of transport
+- emit the same tracing and trust-graph records regardless of transport
+
+## Shared-core responsibilities
+
+The `harn-serve` crate owns these pieces:
+
+- export catalog loading for `pub fn` entrypoints
+- shared dispatch request/response types
+- replay-cache hooks for idempotent replays
+- cooperative cancellation wiring into the VM
+- normalized auth policy types:
+  API keys
+  HMAC canonical-request signatures
+  OAuth 2.1 claims already validated by the hosting transport
+- unified observability:
+  one inbound span per call
+  one trust-graph record per terminal outcome
+- a transport-adapter trait so MCP, A2A, and ACP can layer their own wire
+  protocol on top without redefining dispatch semantics
+
+This keeps adapter tickets focused on protocol mechanics such as discovery
+documents, streaming, progress notifications, or session semantics.
+
+## Picking an adapter
+
+Choose the adapter based on the caller's mental model, not by protocol
+popularity alone.
+
+### MCP
+
+Choose MCP when the caller wants a tool surface.
+
+Typical fit:
+
+- IDEs that can mount tools
+- agent frameworks that already speak MCP
+- clients that expect `tools/list` and `tools/call`
+
+Mapping:
+
+- each exported `pub fn` becomes a tool
+- Harn type annotations become tool input/output schemas
+- replay keys map naturally to idempotent tool invocations
+
+### A2A
+
+Choose A2A when the caller wants a peer agent rather than a bag of tools.
+
+Typical fit:
+
+- cross-agent delegation
+- durable remote tasks
+- resubscribe and callback-oriented delivery
+
+Mapping:
+
+- the shared dispatch core executes the same exported Harn function
+- the A2A adapter owns agent cards, task lifecycle, and resubscribe behavior
+
+### ACP
+
+Choose ACP when the caller wants a live agent session with host mediation.
+
+Typical fit:
+
+- editor hosts
+- approval-aware local runtimes
+- clients that already speak ACP session updates
+
+Mapping:
+
+- the shared dispatch core still owns function loading, auth metadata,
+  cancellation, and trust/trace emission
+- the ACP adapter owns session state, permission prompts, and bidirectional
+  updates
+
+## Design rule
+
+If a behavior changes depending on whether the caller arrived over MCP, A2A, or
+ACP, first ask whether it belongs in the adapter or in the shared core.
+
+It belongs in the shared core when it affects:
+
+- what function is invoked
+- how arguments are normalized
+- auth decisions
+- replay semantics
+- cancellation behavior
+- observability or trust records
+
+It belongs in the adapter when it affects:
+
+- wire format
+- discovery documents or cards
+- streaming shape
+- session lifecycle
+- protocol-specific error envelopes


### PR DESCRIPTION
## Summary

Implements the shared-core deliverables from #301 by introducing a new `harn-serve` workspace crate and wiring the existing runtime surface through a shared dispatch layer.

This PR adds:

- a transport-agnostic adapter boundary for orchestrator ingress
- shared authentication handling for API keys, HMAC, and OAuth-validated claims
- replay-cache abstractions with an in-memory implementation
- export catalog discovery from Harn `pub fn` exports, including derived JSON schema metadata
- shared dispatch plumbing for cancellation, trust-graph context, and OpenTelemetry parent propagation
- shared-core documentation for the new serving model

## Why

Issue #301 calls for a common serving core that can be reused across transports instead of duplicating dispatch behavior inside individual adapters. This change consolidates that logic into one crate and exposes the VM/runtime hooks needed to support it cleanly.

The branch also includes the follow-up fixes required to keep the repository green after the core landed:

- explicit observability shutdown so OTEL exports flush reliably
- end-to-end trace propagation from HTTP ingest through deferred dispatch
- a corrected graceful-shutdown drain path that does not cancel work before draining it
- stale/racy test fixes in the dispatcher and orchestrator suites
- formatting and markdown/test-fixture updates required by repository hooks

## Impact

Transport-specific serve implementations can now delegate common auth, replay, export-catalog, and dispatch behavior to `harn-serve` instead of reimplementing those concerns independently.

## Validation

- `cargo test -p harn-serve`
- `cargo check -p harn-vm -p harn-serve -p harn-cli`
- `cargo test -p harn-cli --test orchestrator_http otel_exports_ingest_and_dispatch_spans_with_shared_trace_id -- --exact`
- `cargo test -p harn-cli --test orchestrator_cli graceful_shutdown_drains_in_flight_dispatch_and_emits_lifecycle_events -- --exact`
- `cargo test -p harn-cli --test orchestrator_cli bounded_pump_drain_truncates_and_replays_remaining_backlog_after_restart -- --exact`
- `cargo test -p harn-vm triggers::dispatcher::tests::run_shutdown_does_not_silently_drop_dequeued_inbox_events -- --exact`
- `npx markdownlint-cli2 "**/*.md"`
- `git push -u origin ksinder/issue-301-shared-core` (passed full pre-push hook, including workspace tests and repo checks)
