### PR TITLE
Fix release workflow: skip dockerbuild artifact in download step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,7 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
+          pattern: harn-*
           merge-multiple: true
 
       - name: Render release notes from changelog


### PR DESCRIPTION
## Summary

- `v0.7.23` release ran all four platform builds + container publish cleanly, but the `Create Release` job failed twice on `actions/download-artifact@v8` after ~30s — it tries to download all 5 artifacts, and the `burin-labs~harn~<tag>.dockerbuild` buildx cache artifact (~187 KB) hangs and retries-out.
- The release job only uploads `artifacts/*.tar.gz` via `softprops/action-gh-release`, so the dockerbuild artifact is dead weight. Scope the download to `pattern: harn-*`.
- The docker image is already published to ghcr.io by the container job; nothing downstream depends on the dockerbuild cache artifact.

## Test plan

- [x] Workflow diff is a single `pattern: harn-*` line under the existing `download-artifact@v8` call.
- [ ] After merge, rerun the failed Create Release job for v0.7.23 and confirm it downloads 4 artifacts + creates the release.
- [ ] The follow-up release (next patch bump) runs clean end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)