### PR TITLE
[codex] Implement Slack Events API connector

### DIFF
--- a/conformance/helpers/slack_mock_server.py
+++ b/conformance/helpers/slack_mock_server.py
@@ -88,6 +88,22 @@ class SlackMockHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         parsed = urlparse(self.path)
+        if parsed.path == "/users.info":
+            self._record(
+                {
+                    key: values[0] if len(values) == 1 else values
+                    for key, values in parse_qs(parsed.query).items()
+                }
+            )
+            json_response(
+                self,
+                200,
+                {
+                    "ok": True,
+                    "user": {"id": "U123ABC456", "name": "roadrunner"},
+                },
+            )
+            return
         if parsed.path == "/__state":
             json_response(self, 200, self.state.snapshot())
             return
@@ -113,6 +129,19 @@ class SlackMockHandler(BaseHTTPRequestHandler):
                 },
             )
             return
+        if parsed.path == "/chat.update":
+            self._record(body)
+            json_response(
+                self,
+                200,
+                {
+                    "ok": True,
+                    "channel": body["channel"],
+                    "ts": body["ts"],
+                    "text": body["text"],
+                },
+            )
+            return
         if parsed.path == "/reactions.add":
             self._record(body)
             json_response(
@@ -131,6 +160,22 @@ class SlackMockHandler(BaseHTTPRequestHandler):
                         },
                     },
                 },
+            )
+            return
+        if parsed.path == "/views.open":
+            self._record(body)
+            json_response(
+                self,
+                200,
+                {"ok": True, "view": {"id": "V123ABC456", "type": "modal"}},
+            )
+            return
+        if parsed.path == "/auth.test":
+            self._record(body)
+            json_response(
+                self,
+                200,
+                {"ok": True, "team": "Example", "user": "bot"},
             )
             return
         json_response(self, 404, {"ok": False, "error": f"unhandled POST {parsed.path}"})

--- a/conformance/tests/agents/trigger_provider_catalog.harn
+++ b/conformance/tests/agents/trigger_provider_catalog.harn
@@ -101,6 +101,11 @@ pipeline test(task) {
   let slack_secret = slack_secrets[0]
   assert(slack_secret.name == "signing_secret", "slack should require signing_secret")
   assert(slack_secret.namespace == "slack", "slack secrets should stay namespaced to slack")
-  assert(len(slack?.outbound_methods ?? []) == 0, "slack should not publish outbound methods yet")
+  let slack_methods = slack?.outbound_methods ?? []
+  assert(len(slack_methods) == 7, "slack should publish its outbound method surface")
+  assert(slack_methods[0].name == "post_message", "slack should expose post_message")
+  assert(slack_methods[3].name == "open_view", "slack should expose open_view")
+  assert(slack_methods[4].name == "user_info", "slack should expose user_info")
+  assert(slack_methods[5].name == "api_call", "slack should expose api_call")
   log("trigger_provider_catalog tests passed")
 }

--- a/conformance/tests/integration/slack_connector_roundtrip.expected
+++ b/conformance/tests/integration/slack_connector_roundtrip.expected
@@ -1,7 +1,9 @@
 C123ABC456
-1715.000100
+updated from harn
 thumbsup
-C123ABC456
-2
-/chat.postMessage
-1715.000100
+V123ABC456
+U123ABC456
+Example
+6
+/views.open
+true

--- a/conformance/tests/integration/slack_connector_roundtrip.harn
+++ b/conformance/tests/integration/slack_connector_roundtrip.harn
@@ -1,4 +1,13 @@
-import { add_reaction, configure, post_message, reset } from "std/connectors/slack"
+import {
+  add_reaction,
+  api_call,
+  configure,
+  open_view,
+  post_message,
+  reset,
+  update_message,
+  user_info,
+} from "std/connectors/slack"
 import { process_exec } from "std/runtime"
 
 fn wait_for_file(path, attempts) {
@@ -30,16 +39,30 @@ pipeline default() {
   let base = "http://127.0.0.1:" + read_file(port_path).trim()
   configure({api_base_url: base, bot_token: "xoxb-test-token"})
   let posted = post_message("C123ABC456", "hello from harn")
+  let updated = update_message("C123ABC456", posted.ts, "updated from harn")
   let reacted = add_reaction("C123ABC456", posted.ts, "thumbsup")
+  let opened = open_view(
+    "12345.98765.abcd2358fdea",
+    {
+      type: "modal",
+      title: {type: "plain_text", text: "Status"},
+      close: {type: "plain_text", text: "Close"},
+      blocks: [],
+    },
+  )
+  let user = user_info("U123ABC456", {include_locale: true})
+  let auth = api_call("auth.test")
   let state = json_parse(http_get(base + "/__state").body)
   let _stop = http_post(base + "/__shutdown", "")
   process_exec("kill $(cat \"" + pid_path + "\") >/dev/null 2>&1 || true")
   reset()
   println(posted.channel)
-  println(posted.ts)
+  println(updated.text)
   println(reacted.event.reaction)
-  println(reacted.event.item.channel)
+  println(opened.view.id)
+  println(user.user.id)
+  println(auth.team)
   println(len(state.requests))
-  println(state.requests[0].path)
-  println(state.requests[1].body.timestamp)
+  println(state.requests[3].path)
+  println(state.requests[4].body.include_locale)
 }

--- a/conformance/tests/integration/slack_connector_roundtrip.harn
+++ b/conformance/tests/integration/slack_connector_roundtrip.harn
@@ -44,11 +44,11 @@ pipeline default() {
   let opened = open_view(
     "12345.98765.abcd2358fdea",
     {
-      type: "modal",
-      title: {type: "plain_text", text: "Status"},
-      close: {type: "plain_text", text: "Close"},
-      blocks: [],
-    },
+    type: "modal",
+    title: {type: "plain_text", text: "Status"},
+    close: {type: "plain_text", text: "Close"},
+    blocks: [],
+  },
   )
   let user = user_info("U123ABC456", {include_locale: true})
   let auth = api_call("auth.test")

--- a/conformance/tests/triggers/trigger_webhook_slack_events_3s_ack.expected
+++ b/conformance/tests/triggers/trigger_webhook_slack_events_3s_ack.expected
@@ -1,0 +1,2 @@
+true
+true

--- a/conformance/tests/triggers/trigger_webhook_slack_events_3s_ack.harn
+++ b/conformance/tests/triggers/trigger_webhook_slack_events_3s_ack.harn
@@ -1,0 +1,5 @@
+pipeline test(task) {
+  let result = trigger_test_harness("slack_events_3s_ack")
+  println(result.ok)
+  println((result.details.elapsed_ms ?? 999999) < 200)
+}

--- a/conformance/tests/triggers/trigger_webhook_slack_events_3s_ack.harn
+++ b/conformance/tests/triggers/trigger_webhook_slack_events_3s_ack.harn
@@ -1,5 +1,5 @@
 pipeline test(task) {
   let result = trigger_test_harness("slack_events_3s_ack")
   println(result.ok)
-  println((result.details.elapsed_ms ?? 999999) < 200)
+  println(result.details.elapsed_ms ?? 999999 < 200)
 }

--- a/conformance/tests/triggers/trigger_webhook_slack_events_message.expected
+++ b/conformance/tests/triggers/trigger_webhook_slack_events_message.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/conformance/tests/triggers/trigger_webhook_slack_events_message.harn
+++ b/conformance/tests/triggers/trigger_webhook_slack_events_message.harn
@@ -1,0 +1,7 @@
+pipeline test(task) {
+  let result = trigger_test_harness("slack_events_message")
+  println(result.ok)
+  println(len(result.emitted) == 1)
+  println(result.emitted[0].provider == "slack")
+  println(result.emitted[0].kind == "message.channels")
+}

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -79,6 +79,7 @@ impl ListenerRuntime {
             config.event_log.clone(),
             inbox,
             config.secrets.clone(),
+            config.metrics_registry.clone(),
             auth.clone(),
             pending_topic.clone(),
             request_delay,
@@ -225,6 +226,7 @@ struct RouteContext {
     event_log: Arc<AnyEventLog>,
     inbox: Arc<harn_vm::InboxIndex>,
     secrets: Arc<dyn SecretProvider>,
+    metrics_registry: Arc<harn_vm::MetricsRegistry>,
     auth: Arc<ListenerAuth>,
     pending_topic: Topic,
     request_delay: Option<Duration>,
@@ -249,6 +251,7 @@ struct RouteRegistry {
     event_log: Arc<AnyEventLog>,
     inbox: Arc<harn_vm::InboxIndex>,
     secrets: Arc<dyn SecretProvider>,
+    metrics_registry: Arc<harn_vm::MetricsRegistry>,
     auth: Arc<ListenerAuth>,
     pending_topic: Topic,
     request_delay: Option<Duration>,
@@ -260,6 +263,7 @@ impl RouteRegistry {
         event_log: Arc<AnyEventLog>,
         inbox: Arc<harn_vm::InboxIndex>,
         secrets: Arc<dyn SecretProvider>,
+        metrics_registry: Arc<harn_vm::MetricsRegistry>,
         auth: Arc<ListenerAuth>,
         pending_topic: Topic,
         request_delay: Option<Duration>,
@@ -270,6 +274,7 @@ impl RouteRegistry {
             event_log,
             inbox,
             secrets,
+            metrics_registry,
             auth,
             pending_topic,
             request_delay,
@@ -297,6 +302,7 @@ impl RouteRegistry {
                     event_log: self.event_log.clone(),
                     inbox: self.inbox.clone(),
                     secrets: self.secrets.clone(),
+                    metrics_registry: self.metrics_registry.clone(),
                     auth: self.auth.clone(),
                     pending_topic: self.pending_topic.clone(),
                     request_delay: self.request_delay,
@@ -360,6 +366,25 @@ impl RouteRuntimeMetrics {
     }
 }
 
+fn finalize_response(context: &RouteContext, mut response: Response) -> Response {
+    if context.route.provider.as_str() == "slack" {
+        if response.status().is_success() {
+            context.metrics_registry.record_slack_delivery_success();
+        } else {
+            context.metrics_registry.record_slack_delivery_failure();
+            if response.status().is_client_error()
+                && response.status() != StatusCode::TOO_MANY_REQUESTS
+            {
+                response.headers_mut().insert(
+                    axum::http::header::HeaderName::from_static("x-slack-no-retry"),
+                    axum::http::HeaderValue::from_static("1"),
+                );
+            }
+        }
+    }
+    response
+}
+
 fn validate_unique_route_paths(routes: &[RouteConfig]) -> Result<(), String> {
     let mut seen_paths = BTreeSet::new();
     for route in routes {
@@ -415,7 +440,7 @@ async fn ingest_trigger(
         {
             context.metrics.failed.fetch_add(1, Ordering::Relaxed);
             context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
-            return error.into_response();
+            return finalize_response(&context, error.into_response());
         }
 
         if let Some(delay) = context.request_delay {
@@ -430,7 +455,7 @@ async fn ingest_trigger(
             trace_id,
         )
         .await;
-        match result {
+        let response = match result {
             Ok(NormalizedRequest::Event(event)) => {
                 let dedupe_ttl = Duration::from_secs(
                     u64::from(context.route.dedupe_retention_days.max(1)) * 24 * 60 * 60,
@@ -518,7 +543,8 @@ async fn ingest_trigger(
                 context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
                 error.into_response()
             }
-        }
+        };
+        finalize_response(&context, response)
     }
     .instrument(span)
     .await
@@ -974,11 +1000,13 @@ fn github_raw(payload: &harn_vm::triggers::event::GitHubEventPayload) -> &JsonVa
 
 fn slack_raw(payload: &harn_vm::triggers::event::SlackEventPayload) -> &JsonValue {
     match payload {
-        harn_vm::triggers::event::SlackEventPayload::MessageChannels(inner) => &inner.common.raw,
+        harn_vm::triggers::event::SlackEventPayload::Message(inner) => &inner.common.raw,
         harn_vm::triggers::event::SlackEventPayload::AppMention(inner) => &inner.common.raw,
         harn_vm::triggers::event::SlackEventPayload::ReactionAdded(inner) => &inner.common.raw,
-        harn_vm::triggers::event::SlackEventPayload::TeamJoin(inner) => &inner.common.raw,
-        harn_vm::triggers::event::SlackEventPayload::ChannelCreated(inner) => &inner.common.raw,
+        harn_vm::triggers::event::SlackEventPayload::AppHomeOpened(inner) => &inner.common.raw,
+        harn_vm::triggers::event::SlackEventPayload::AssistantThreadStarted(inner) => {
+            &inner.common.raw
+        }
         harn_vm::triggers::event::SlackEventPayload::Other(common) => &common.raw,
     }
 }

--- a/crates/harn-cli/src/commands/trigger/ops.rs
+++ b/crates/harn-cli/src/commands/trigger/ops.rs
@@ -765,7 +765,7 @@ fn normalized_event_payload(payload: &ProviderPayload) -> JsonValue {
         }
         ProviderPayload::Known(harn_vm::triggers::event::KnownProviderPayload::Slack(payload)) => {
             match payload.as_ref() {
-                harn_vm::triggers::event::SlackEventPayload::MessageChannels(value) => {
+                harn_vm::triggers::event::SlackEventPayload::Message(value) => {
                     value.common.raw.clone()
                 }
                 harn_vm::triggers::event::SlackEventPayload::AppMention(value) => {
@@ -774,10 +774,10 @@ fn normalized_event_payload(payload: &ProviderPayload) -> JsonValue {
                 harn_vm::triggers::event::SlackEventPayload::ReactionAdded(value) => {
                     value.common.raw.clone()
                 }
-                harn_vm::triggers::event::SlackEventPayload::TeamJoin(value) => {
+                harn_vm::triggers::event::SlackEventPayload::AppHomeOpened(value) => {
                     value.common.raw.clone()
                 }
-                harn_vm::triggers::event::SlackEventPayload::ChannelCreated(value) => {
+                harn_vm::triggers::event::SlackEventPayload::AssistantThreadStarted(value) => {
                     value.common.raw.clone()
                 }
                 harn_vm::triggers::event::SlackEventPayload::Other(value) => value.raw.clone(),

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -747,6 +747,100 @@ async fn slack_url_verification_returns_plaintext_challenge() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn slack_bad_requests_set_no_retry_header_and_export_delivery_metrics() {
+    let _lock = lock_orchestrator_tests();
+    let temp = TempDir::new().unwrap();
+    write_file(temp.path(), "harn.toml", &slack_manifest(None));
+    write_file(
+        temp.path(),
+        "lib.harn",
+        &slack_handler_module(&temp.path().join("unused-slack-marker.txt")),
+    );
+
+    let secret = "slack-signing-secret";
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_SECRET_SLACK_SIGNING_SECRET", secret),
+    ];
+    let mut process = spawn_orchestrator(&temp, &[], &envs);
+    let base_url = process.wait_for_listener_url();
+
+    let timestamp = OffsetDateTime::now_utc().unix_timestamp();
+    let body = serde_json::to_vec(&serde_json::json!({
+        "token": "ZZZZZZWSxiZZZ2yIvs3peJ",
+        "team_id": "T123ABC456",
+        "api_app_id": "A123ABC456",
+        "event": {
+            "type": "app_mention",
+            "user": "U123ABC456",
+            "text": "hello",
+            "ts": "1515449522.000016",
+            "channel": "C123ABC456",
+            "event_ts": "1515449522000016"
+        },
+        "type": "event_callback",
+        "event_id": "Ev123ABC456",
+        "event_time": 1515449522
+    }))
+    .unwrap();
+
+    let mut bad_headers = slack_headers(secret, timestamp, &body);
+    bad_headers.insert(
+        "X-Slack-Signature",
+        HeaderValue::from_static(
+            "v0=0000000000000000000000000000000000000000000000000000000000000000",
+        ),
+    );
+    let bad = reqwest::Client::new()
+        .post(format!("{base_url}/triggers/slack-mentions"))
+        .headers(bad_headers)
+        .body(body.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(bad.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        bad.headers()
+            .get("x-slack-no-retry")
+            .and_then(|v| v.to_str().ok()),
+        Some("1")
+    );
+
+    let ok = reqwest::Client::new()
+        .post(format!("{base_url}/triggers/slack-mentions"))
+        .headers(slack_headers(secret, timestamp, &body))
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ok.status(), StatusCode::OK);
+
+    let metrics = reqwest::Client::new()
+        .get(format!("{base_url}/metrics"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        metrics.contains("slack_events_delivery_success_total 1"),
+        "metrics={metrics}"
+    );
+    assert!(
+        metrics.contains("slack_events_delivery_failure_total 1"),
+        "metrics={metrics}"
+    );
+    assert!(
+        metrics.contains("slack_events_auto_disable_min_success_ratio 0.05"),
+        "metrics={metrics}"
+    );
+
+    send_sigterm(&process.child);
+    wait_for_exit(&mut process.child);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn a2a_push_route_requires_bearer_or_valid_hmac() {
     let _lock = lock_orchestrator_tests();
     let temp = TempDir::new().unwrap();

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -256,6 +256,8 @@ pub struct ConnectorMetricsSnapshot {
     pub dispatch_succeeded_total: u64,
     pub dispatch_failed_total: u64,
     pub retry_scheduled_total: u64,
+    pub slack_delivery_success_total: u64,
+    pub slack_delivery_failure_total: u64,
 }
 
 /// Shared metrics surface for connector-local counters and timings.
@@ -270,6 +272,8 @@ pub struct MetricsRegistry {
     dispatch_succeeded_total: AtomicU64,
     dispatch_failed_total: AtomicU64,
     retry_scheduled_total: AtomicU64,
+    slack_delivery_success_total: AtomicU64,
+    slack_delivery_failure_total: AtomicU64,
 }
 
 impl MetricsRegistry {
@@ -284,6 +288,8 @@ impl MetricsRegistry {
             dispatch_succeeded_total: self.dispatch_succeeded_total.load(Ordering::Relaxed),
             dispatch_failed_total: self.dispatch_failed_total.load(Ordering::Relaxed),
             retry_scheduled_total: self.retry_scheduled_total.load(Ordering::Relaxed),
+            slack_delivery_success_total: self.slack_delivery_success_total.load(Ordering::Relaxed),
+            slack_delivery_failure_total: self.slack_delivery_failure_total.load(Ordering::Relaxed),
         }
     }
 
@@ -328,6 +334,16 @@ impl MetricsRegistry {
         self.retry_scheduled_total.fetch_add(1, Ordering::Relaxed);
     }
 
+    pub fn record_slack_delivery_success(&self) {
+        self.slack_delivery_success_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_slack_delivery_failure(&self) {
+        self.slack_delivery_failure_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
     pub fn render_prometheus(&self) -> String {
         let snapshot = self.snapshot();
         let counters = [
@@ -338,6 +354,14 @@ impl MetricsRegistry {
             ("dispatch_failed_total", snapshot.dispatch_failed_total),
             ("inbox_duplicates_total", snapshot.inbox_duplicates_rejected),
             ("retry_scheduled_total", snapshot.retry_scheduled_total),
+            (
+                "slack_events_delivery_success_total",
+                snapshot.slack_delivery_success_total,
+            ),
+            (
+                "slack_events_delivery_failure_total",
+                snapshot.slack_delivery_failure_total,
+            ),
         ];
 
         let mut rendered = String::new();
@@ -350,6 +374,10 @@ impl MetricsRegistry {
             rendered.push_str(&value.to_string());
             rendered.push('\n');
         }
+        rendered.push_str("# TYPE slack_events_auto_disable_min_success_ratio gauge\n");
+        rendered.push_str("slack_events_auto_disable_min_success_ratio 0.05\n");
+        rendered.push_str("# TYPE slack_events_auto_disable_min_events_per_hour gauge\n");
+        rendered.push_str("slack_events_auto_disable_min_events_per_hour 1000\n");
         rendered
     }
 }

--- a/crates/harn-vm/src/connectors/slack/mod.rs
+++ b/crates/harn-vm/src/connectors/slack/mod.rs
@@ -54,17 +54,17 @@ struct SlackClient {
 #[allow(dead_code)]
 #[derive(Debug)]
 enum ParsedSlackEvent {
-    MessageChannels(MessageChannelsEvent),
+    Message(MessageEvent),
     AppMention(AppMentionEvent),
     ReactionAdded(ReactionAddedEvent),
-    TeamJoin(TeamJoinEvent),
-    ChannelCreated(ChannelCreatedEvent),
+    AppHomeOpened(AppHomeOpenedEvent),
+    AssistantThreadStarted(AssistantThreadStartedEvent),
     Other { kind: String, raw: JsonValue },
 }
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize)]
-struct MessageChannelsEvent {
+struct MessageEvent {
     channel: Option<String>,
     user: Option<String>,
     text: Option<String>,
@@ -94,14 +94,17 @@ struct ReactionAddedEvent {
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize)]
-struct TeamJoinEvent {
-    user: JsonValue,
+struct AppHomeOpenedEvent {
+    user: Option<String>,
+    channel: Option<String>,
+    tab: Option<String>,
+    view: Option<JsonValue>,
 }
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize)]
-struct ChannelCreatedEvent {
-    channel: JsonValue,
+struct AssistantThreadStartedEvent {
+    assistant_thread: JsonValue,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -174,6 +177,32 @@ struct AddReactionArgs {
     channel: String,
     ts: String,
     name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenViewArgs {
+    #[serde(flatten)]
+    config: SlackClientConfigArgs,
+    trigger_id: String,
+    view: JsonValue,
+}
+
+#[derive(Debug, Deserialize)]
+struct UserInfoArgs {
+    #[serde(flatten)]
+    config: SlackClientConfigArgs,
+    user_id: String,
+    #[serde(default)]
+    include_locale: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiCallArgs {
+    #[serde(flatten)]
+    config: SlackClientConfigArgs,
+    method: String,
+    #[serde(default)]
+    args: JsonValue,
 }
 
 #[derive(Debug, Deserialize)]
@@ -432,6 +461,45 @@ impl ConnectorClient for SlackClient {
                 )
                 .await
             }
+            "open_view" => {
+                let args: OpenViewArgs = parse_args(args)?;
+                let config = self.resolve_client_config(&args.config)?;
+                self.request_json(
+                    &config,
+                    "views.open",
+                    json!({
+                        "trigger_id": args.trigger_id,
+                        "view": args.view,
+                    }),
+                )
+                .await
+            }
+            "user_info" => {
+                let args: UserInfoArgs = parse_args(args)?;
+                let config = self.resolve_client_config(&args.config)?;
+                let mut query = vec![("user".to_string(), args.user_id)];
+                if let Some(include_locale) = args.include_locale {
+                    query.push((
+                        "include_locale".to_string(),
+                        if include_locale { "true" } else { "false" }.to_string(),
+                    ));
+                }
+                self.request_query_json(&config, "users.info", &query).await
+            }
+            "api_call" => {
+                let args: ApiCallArgs = parse_args(args)?;
+                let config = self.resolve_client_config(&args.config)?;
+                let body = match args.args {
+                    JsonValue::Null => JsonValue::Object(JsonMap::new()),
+                    JsonValue::Object(_) => args.args,
+                    _ => {
+                        return Err(ClientError::InvalidArgs(
+                            "slack api_call args must be a JSON object".to_string(),
+                        ));
+                    }
+                };
+                self.request_json(&config, &args.method, body).await
+            }
             "upload_file" => {
                 let args: UploadFileArgs = parse_args(args)?;
                 let config = self.resolve_client_config(&args.config)?;
@@ -487,7 +555,27 @@ impl SlackClient {
         method: &str,
         body: JsonValue,
     ) -> Result<JsonValue, ClientError> {
-        let response = self.request(method, config, Some(body)).await?;
+        let response = self
+            .request(Method::POST, method, config, Some(body))
+            .await?;
+        self.decode_api_response(method, response).await
+    }
+
+    async fn request_query_json(
+        &self,
+        config: &ResolvedSlackClientConfig,
+        method: &str,
+        query: &[(String, String)],
+    ) -> Result<JsonValue, ClientError> {
+        let response = self.request_query(method, config, query).await?;
+        self.decode_api_response(method, response).await
+    }
+
+    async fn decode_api_response(
+        &self,
+        method: &str,
+        response: reqwest::Response,
+    ) -> Result<JsonValue, ClientError> {
         let status = response.status();
         let payload = response
             .json::<SlackApiEnvelope>()
@@ -515,6 +603,7 @@ impl SlackClient {
 
     async fn request(
         &self,
+        http_method: Method,
         method: &str,
         config: &ResolvedSlackClientConfig,
         body: Option<JsonValue>,
@@ -532,12 +621,38 @@ impl SlackClient {
         );
         let mut request = self
             .http
-            .request(Method::POST, url)
+            .request(http_method, url)
             .header("Authorization", format!("Bearer {token}"));
         if let Some(body) = body {
             request = request.json(&body);
         }
         request
+            .send()
+            .await
+            .map_err(|error| ClientError::Transport(error.to_string()))
+    }
+
+    async fn request_query(
+        &self,
+        method: &str,
+        config: &ResolvedSlackClientConfig,
+        query: &[(String, String)],
+    ) -> Result<reqwest::Response, ClientError> {
+        let ctx = self.ctx()?;
+        ctx.rate_limiter
+            .scoped(&self.provider_id, "bot")
+            .acquire()
+            .await;
+        let token = self.bot_token(config).await?;
+        let url = format!(
+            "{}/{}",
+            config.api_base_url.trim_end_matches('/'),
+            method.trim_start_matches('/')
+        );
+        self.http
+            .request(Method::GET, url)
+            .header("Authorization", format!("Bearer {token}"))
+            .query(query)
             .send()
             .await
             .map_err(|error| ClientError::Transport(error.to_string()))
@@ -753,8 +868,16 @@ fn slack_event_kind(payload: &JsonValue, raw: &RawInbound) -> Result<String, Con
             .get("channel_type")
             .and_then(JsonValue::as_str)
             .unwrap_or_default();
-        if channel_type == "channel" {
-            return Ok("message.channels".to_string());
+        if !channel_type.is_empty() {
+            let kind = match channel_type {
+                "channel" => "message.channels",
+                "group" => "message.groups",
+                "im" => "message.im",
+                "mpim" => "message.mpim",
+                "app_home" => "message.app_home",
+                other => return Ok(format!("message.{other}")),
+            };
+            return Ok(kind.to_string());
         }
     }
     Ok(event_type.to_string())
@@ -769,8 +892,8 @@ fn parse_typed_event(kind: &str, payload: &JsonValue) -> Result<ParsedSlackEvent
     }
     let event = payload.get("event").cloned().unwrap_or(JsonValue::Null);
     match kind {
-        "message.channels" => serde_json::from_value(event)
-            .map(ParsedSlackEvent::MessageChannels)
+        kind if kind == "message" || kind.starts_with("message.") => serde_json::from_value(event)
+            .map(ParsedSlackEvent::Message)
             .map_err(|error| ConnectorError::Json(error.to_string())),
         "app_mention" => serde_json::from_value(event)
             .map(ParsedSlackEvent::AppMention)
@@ -778,11 +901,11 @@ fn parse_typed_event(kind: &str, payload: &JsonValue) -> Result<ParsedSlackEvent
         "reaction_added" => serde_json::from_value(event)
             .map(ParsedSlackEvent::ReactionAdded)
             .map_err(|error| ConnectorError::Json(error.to_string())),
-        "team_join" => serde_json::from_value(event)
-            .map(ParsedSlackEvent::TeamJoin)
+        "app_home_opened" => serde_json::from_value(event)
+            .map(ParsedSlackEvent::AppHomeOpened)
             .map_err(|error| ConnectorError::Json(error.to_string())),
-        "channel_created" => serde_json::from_value(event)
-            .map(ParsedSlackEvent::ChannelCreated)
+        "assistant_thread_started" => serde_json::from_value(event)
+            .map(ParsedSlackEvent::AssistantThreadStarted)
             .map_err(|error| ConnectorError::Json(error.to_string())),
         _ => Ok(ParsedSlackEvent::Other {
             kind: kind.to_string(),
@@ -812,11 +935,13 @@ fn infer_occurred_at(provider_payload: &ProviderPayload) -> Option<OffsetDateTim
 
 fn slack_raw(payload: &crate::triggers::event::SlackEventPayload) -> &JsonValue {
     match payload {
-        crate::triggers::event::SlackEventPayload::MessageChannels(inner) => &inner.common.raw,
+        crate::triggers::event::SlackEventPayload::Message(inner) => &inner.common.raw,
         crate::triggers::event::SlackEventPayload::AppMention(inner) => &inner.common.raw,
         crate::triggers::event::SlackEventPayload::ReactionAdded(inner) => &inner.common.raw,
-        crate::triggers::event::SlackEventPayload::TeamJoin(inner) => &inner.common.raw,
-        crate::triggers::event::SlackEventPayload::ChannelCreated(inner) => &inner.common.raw,
+        crate::triggers::event::SlackEventPayload::AppHomeOpened(inner) => &inner.common.raw,
+        crate::triggers::event::SlackEventPayload::AssistantThreadStarted(inner) => {
+            &inner.common.raw
+        }
         crate::triggers::event::SlackEventPayload::Other(common) => &common.raw,
     }
 }

--- a/crates/harn-vm/src/connectors/slack/tests.rs
+++ b/crates/harn-vm/src/connectors/slack/tests.rs
@@ -233,7 +233,7 @@ async fn slack_connector_normalizes_docs_fixtures_into_typed_payloads() {
                 },
                 "type": "event_callback",
                 "event_id": "Ev123ABC456",
-                "event_time": 1515449522000016i64
+                "event_time": 1515449522
             }),
         },
         FixtureCase {
@@ -257,50 +257,57 @@ async fn slack_connector_normalizes_docs_fixtures_into_typed_payloads() {
                 },
                 "type": "event_callback",
                 "event_id": "Ev123REACTION",
-                "event_time": 1234567890
+                "event_time": 1465244570
             }),
         },
         FixtureCase {
-            name: "team_join",
-            expected_kind: "team_join",
+            name: "app_home_opened",
+            expected_kind: "app_home_opened",
             body: json!({
                 "token": "z26uFbvR1xHJEdHE1OQiO6t8",
                 "team_id": "T123ABC456",
                 "api_app_id": "A123ABC456",
                 "event": {
-                    "type": "team_join",
-                    "user": {
-                        "id": "U024BE7LH",
-                        "name": "sam",
-                        "real_name": "Sam Example"
-                    },
-                    "event_ts": "1360782804.083113"
+                    "type": "app_home_opened",
+                    "user": "U123ABC456",
+                    "channel": "D123ABC456",
+                    "event_ts": "1515449522000016",
+                    "tab": "home",
+                    "view": {
+                        "id": "V123ABC456",
+                        "team_id": "T123ABC456",
+                        "type": "home"
+                    }
                 },
                 "type": "event_callback",
-                "event_id": "Ev123TEAMJOIN",
-                "event_time": 1360782804
+                "event_id": "Ev123HOME",
+                "event_time": 1515449522
             }),
         },
         FixtureCase {
-            name: "channel_created",
-            expected_kind: "channel_created",
+            name: "assistant_thread_started",
+            expected_kind: "assistant_thread_started",
             body: json!({
                 "token": "z26uFbvR1xHJEdHE1OQiO6t8",
-                "team_id": "T123ABC456",
+                "team_id": "T07XY8FPJ5C",
                 "api_app_id": "A123ABC456",
                 "event": {
-                    "type": "channel_created",
-                    "channel": {
-                        "id": "C024BE91L",
-                        "name": "fun",
-                        "created": 1360782804,
-                        "creator": "U024BE7LH"
+                    "type": "assistant_thread_started",
+                    "assistant_thread": {
+                        "user_id": "U123ABC456",
+                        "context": {
+                            "channel_id": "C123ABC456",
+                            "team_id": "T07XY8FPJ5C",
+                            "enterprise_id": "E480293PS82"
+                        },
+                        "channel_id": "D123ABC456",
+                        "thread_ts": "1729999327.187299"
                     },
-                    "event_ts": "1360782804.083113"
+                    "event_ts": "1715873754.429808"
                 },
                 "type": "event_callback",
-                "event_id": "Ev123CHANNEL",
-                "event_time": 1360782804
+                "event_id": "Ev123ASSISTANT",
+                "event_time": 1715873754
             }),
         },
     ];
@@ -317,8 +324,9 @@ async fn slack_connector_normalizes_docs_fixtures_into_typed_payloads() {
             other => panic!("expected slack payload, got {other:?}"),
         };
         match (case.expected_kind, payload.as_ref()) {
-            ("message.channels", SlackEventPayload::MessageChannels(inner)) => {
+            ("message.channels", SlackEventPayload::Message(inner)) => {
                 assert_eq!(inner.channel.as_deref(), Some("C123ABC456"));
+                assert_eq!(inner.channel_type.as_deref(), Some("channel"));
             }
             ("app_mention", SlackEventPayload::AppMention(inner)) => {
                 assert_eq!(inner.user.as_deref(), Some("U123ABC456"));
@@ -326,11 +334,14 @@ async fn slack_connector_normalizes_docs_fixtures_into_typed_payloads() {
             ("reaction_added", SlackEventPayload::ReactionAdded(inner)) => {
                 assert_eq!(inner.reaction.as_deref(), Some("slightly_smiling_face"));
             }
-            ("team_join", SlackEventPayload::TeamJoin(inner)) => {
-                assert_eq!(inner.common.user_id.as_deref(), Some("U024BE7LH"));
+            ("app_home_opened", SlackEventPayload::AppHomeOpened(inner)) => {
+                assert_eq!(inner.channel.as_deref(), Some("D123ABC456"));
+                assert_eq!(inner.tab.as_deref(), Some("home"));
             }
-            ("channel_created", SlackEventPayload::ChannelCreated(inner)) => {
-                assert_eq!(inner.common.channel_id.as_deref(), Some("C024BE91L"));
+            ("assistant_thread_started", SlackEventPayload::AssistantThreadStarted(inner)) => {
+                assert_eq!(inner.common.channel_id.as_deref(), Some("D123ABC456"));
+                assert_eq!(inner.common.user_id.as_deref(), Some("U123ABC456"));
+                assert_eq!(inner.thread_ts.as_deref(), Some("1729999327.187299"));
             }
             other => panic!("unexpected typed payload mapping: {other:?}"),
         }
@@ -544,6 +555,24 @@ fn spawn_mock_server(
                     &[("content-type", "application/json".to_string())],
                     r#"{"ok":true}"#,
                 ),
+                "/views.open" => write_response(
+                    &mut stream,
+                    200,
+                    &[("content-type", "application/json".to_string())],
+                    r#"{"ok":true,"view":{"id":"V123ABC456","type":"modal"}}"#,
+                ),
+                path if path.starts_with("/users.info") => write_response(
+                    &mut stream,
+                    200,
+                    &[("content-type", "application/json".to_string())],
+                    r#"{"ok":true,"user":{"id":"U123ABC456","name":"roadrunner"}}"#,
+                ),
+                "/auth.test" => write_response(
+                    &mut stream,
+                    200,
+                    &[("content-type", "application/json".to_string())],
+                    r#"{"ok":true,"url":"https://example.slack.com/","team":"Example","user":"bot"}"#,
+                ),
                 "/files.getUploadURLExternal" => write_response(
                     &mut stream,
                     200,
@@ -571,7 +600,7 @@ fn spawn_mock_server(
 async fn slack_outbound_helpers_hit_expected_api_methods() {
     let client = initialized_client().await;
     let scenario = Arc::new(Mutex::new(MockScenario::default()));
-    let (base_url, handle) = spawn_mock_server(6, scenario.clone());
+    let (base_url, handle) = spawn_mock_server(9, scenario.clone());
 
     let posted = client
         .call(
@@ -611,6 +640,47 @@ async fn slack_outbound_helpers_hit_expected_api_methods() {
         )
         .await
         .unwrap();
+    let opened = client
+        .call(
+            "open_view",
+            json!({
+                "api_base_url": base_url,
+                "bot_token": BOT_TOKEN,
+                "trigger_id": "12345.98765.abcd2358fdea",
+                "view": {
+                    "type": "modal",
+                    "title": {"type": "plain_text", "text": "Status"},
+                    "close": {"type": "plain_text", "text": "Close"},
+                    "blocks": []
+                }
+            }),
+        )
+        .await
+        .unwrap();
+    let user = client
+        .call(
+            "user_info",
+            json!({
+                "api_base_url": base_url,
+                "bot_token": BOT_TOKEN,
+                "user_id": "U123ABC456",
+                "include_locale": true,
+            }),
+        )
+        .await
+        .unwrap();
+    let auth = client
+        .call(
+            "api_call",
+            json!({
+                "api_base_url": base_url,
+                "bot_token": BOT_TOKEN,
+                "method": "auth.test",
+                "args": {}
+            }),
+        )
+        .await
+        .unwrap();
     let uploaded = client
         .call(
             "upload_file",
@@ -628,22 +698,33 @@ async fn slack_outbound_helpers_hit_expected_api_methods() {
 
     handle.join().expect("server thread");
     let requests = scenario.lock().expect("scenario lock").requests.clone();
-    assert_eq!(requests.len(), 6);
-    assert!(requests.iter().all(|request| request.method == "POST"));
+    assert_eq!(requests.len(), 9);
     assert_eq!(requests[0].path, "/chat.postMessage");
     assert_eq!(requests[1].path, "/chat.update");
     assert_eq!(requests[2].path, "/reactions.add");
-    assert_eq!(requests[3].path, "/files.getUploadURLExternal");
-    assert_eq!(requests[4].path, "/upload/F123");
-    assert_eq!(requests[5].path, "/files.completeUploadExternal");
+    assert_eq!(requests[3].path, "/views.open");
+    assert!(requests[4].path.starts_with("/users.info?"));
+    assert_eq!(requests[4].method, "GET");
+    assert!(requests[4].path.contains("user=U123ABC456"));
+    assert!(requests[4].path.contains("include_locale=true"));
+    assert_eq!(requests[5].path, "/auth.test");
+    assert_eq!(requests[6].path, "/files.getUploadURLExternal");
+    assert_eq!(requests[7].path, "/upload/F123");
+    assert_eq!(requests[8].path, "/files.completeUploadExternal");
     assert_eq!(
         requests[0].headers.get("authorization").map(String::as_str),
         Some("Bearer xoxb-test-token")
     );
-    assert!(requests[3].body.contains("filename=notes.txt"));
-    assert_eq!(requests[4].body, "hello upload");
-    assert!(requests[5].body.contains("\"channel_id\":\"C123ABC456\""));
+    assert!(requests[3]
+        .body
+        .contains("\"trigger_id\":\"12345.98765.abcd2358fdea\""));
+    assert!(requests[6].body.contains("filename=notes.txt"));
+    assert_eq!(requests[7].body, "hello upload");
+    assert!(requests[8].body.contains("\"channel_id\":\"C123ABC456\""));
     assert_eq!(posted["channel"], json!("C123ABC456"));
     assert_eq!(updated["text"], json!("updated"));
+    assert_eq!(opened["view"]["id"], json!("V123ABC456"));
+    assert_eq!(user["user"]["id"], json!("U123ABC456"));
+    assert_eq!(auth["team"], json!("Example"));
     assert_eq!(uploaded["file_id"], json!("F123"));
 }

--- a/crates/harn-vm/src/stdlib_connectors_slack.harn
+++ b/crates/harn-vm/src/stdlib_connectors_slack.harn
@@ -34,6 +34,18 @@ pub fn add_reaction(channel, ts, name, options = nil) {
   return __call("add_reaction", (options ?? {}) + {channel: channel, ts: ts, name: name})
 }
 
+pub fn open_view(trigger_id, view, options = nil) {
+  return __call("open_view", (options ?? {}) + {trigger_id: trigger_id, view: view})
+}
+
+pub fn user_info(user_id, options = nil) {
+  return __call("user_info", (options ?? {}) + {user_id: user_id})
+}
+
+pub fn api_call(method, args = nil, options = nil) {
+  return __call("api_call", filter_nil((options ?? {}) + {method: method, args: args ?? {}}))
+}
+
 pub fn upload_file(filename, content, options = nil) {
   return __call("upload_file", (options ?? {}) + {filename: filename, content: content})
 }

--- a/crates/harn-vm/src/stdlib_triggers.harn
+++ b/crates/harn-vm/src/stdlib_triggers.harn
@@ -34,19 +34,19 @@ type GitHubEventPayload = GitHubIssuesEventPayload | GitHubPullRequestEventPaylo
 
 type SlackEventCommon = {provider: "slack", event: string, event_id: string | nil, api_app_id: string | nil, team_id: string | nil, channel_id: string | nil, user_id: string | nil, event_ts: string | nil, raw: dict}
 
-type SlackMessageChannelsEventPayload = {provider: "slack", event: "message.channels", event_id: string | nil, api_app_id: string | nil, team_id: string | nil, channel_id: string | nil, user_id: string | nil, event_ts: string | nil, subtype: string | nil, channel: string | nil, user: string | nil, text: string | nil, ts: string | nil, thread_ts: string | nil, raw: dict}
+type SlackMessageEventPayload = {provider: "slack", event: string, event_id: string | nil, api_app_id: string | nil, team_id: string | nil, channel_id: string | nil, user_id: string | nil, event_ts: string | nil, subtype: string | nil, channel_type: string | nil, channel: string | nil, user: string | nil, text: string | nil, ts: string | nil, thread_ts: string | nil, raw: dict}
 
 type SlackAppMentionEventPayload = {provider: "slack", event: "app_mention", event_id: string | nil, api_app_id: string | nil, team_id: string | nil, channel_id: string | nil, user_id: string | nil, event_ts: string | nil, channel: string | nil, user: string | nil, text: string | nil, ts: string | nil, thread_ts: string | nil, raw: dict}
 
 type SlackReactionAddedEventPayload = {provider: "slack", event: "reaction_added", event_id: string | nil, api_app_id: string | nil, team_id: string | nil, channel_id: string | nil, user_id: string | nil, event_ts: string | nil, reaction: string | nil, item_user: string | nil, item: dict, raw: dict}
 
-type SlackTeamJoinEventPayload = {provider: "slack", event: "team_join", event_id: string | nil, api_app_id: string | nil, team_id: string | nil, channel_id: string | nil, user_id: string | nil, event_ts: string | nil, user: dict, raw: dict}
+type SlackAppHomeOpenedEventPayload = {provider: "slack", event: "app_home_opened", event_id: string | nil, api_app_id: string | nil, team_id: string | nil, channel_id: string | nil, user_id: string | nil, event_ts: string | nil, user: string | nil, channel: string | nil, tab: string | nil, view: dict, raw: dict}
 
-type SlackChannelCreatedEventPayload = {provider: "slack", event: "channel_created", event_id: string | nil, api_app_id: string | nil, team_id: string | nil, channel_id: string | nil, user_id: string | nil, event_ts: string | nil, channel: dict, raw: dict}
+type SlackAssistantThreadStartedEventPayload = {provider: "slack", event: "assistant_thread_started", event_id: string | nil, api_app_id: string | nil, team_id: string | nil, channel_id: string | nil, user_id: string | nil, event_ts: string | nil, assistant_thread: dict, thread_ts: string | nil, context: dict, raw: dict}
 
 type SlackOtherEventPayload = {provider: "slack", event: string, event_id: string | nil, api_app_id: string | nil, team_id: string | nil, channel_id: string | nil, user_id: string | nil, event_ts: string | nil, raw: dict}
 
-type SlackEventPayload = SlackMessageChannelsEventPayload | SlackAppMentionEventPayload | SlackReactionAddedEventPayload | SlackTeamJoinEventPayload | SlackChannelCreatedEventPayload | SlackOtherEventPayload
+type SlackEventPayload = SlackMessageEventPayload | SlackAppMentionEventPayload | SlackReactionAddedEventPayload | SlackAppHomeOpenedEventPayload | SlackAssistantThreadStartedEventPayload | SlackOtherEventPayload
 
 type LinearEventPayload = {provider: "linear", action: string | nil, organization_id: string | nil, webhook_timestamp: string | nil, raw: dict}
 

--- a/crates/harn-vm/src/triggers/event.rs
+++ b/crates/harn-vm/src/triggers/event.rs
@@ -166,10 +166,11 @@ pub struct SlackEventCommon {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct SlackMessageChannelsEventPayload {
+pub struct SlackMessageEventPayload {
     #[serde(flatten)]
     pub common: SlackEventCommon,
     pub subtype: Option<String>,
+    pub channel_type: Option<String>,
     pub channel: Option<String>,
     pub user: Option<String>,
     pub text: Option<String>,
@@ -198,27 +199,32 @@ pub struct SlackReactionAddedEventPayload {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct SlackTeamJoinEventPayload {
+pub struct SlackAppHomeOpenedEventPayload {
     #[serde(flatten)]
     pub common: SlackEventCommon,
-    pub user: JsonValue,
+    pub user: Option<String>,
+    pub channel: Option<String>,
+    pub tab: Option<String>,
+    pub view: JsonValue,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct SlackChannelCreatedEventPayload {
+pub struct SlackAssistantThreadStartedEventPayload {
     #[serde(flatten)]
     pub common: SlackEventCommon,
-    pub channel: JsonValue,
+    pub assistant_thread: JsonValue,
+    pub thread_ts: Option<String>,
+    pub context: JsonValue,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SlackEventPayload {
-    MessageChannels(SlackMessageChannelsEventPayload),
+    Message(SlackMessageEventPayload),
     AppMention(SlackAppMentionEventPayload),
     ReactionAdded(SlackReactionAddedEventPayload),
-    TeamJoin(SlackTeamJoinEventPayload),
-    ChannelCreated(SlackChannelCreatedEventPayload),
+    AppHomeOpened(SlackAppHomeOpenedEventPayload),
+    AssistantThreadStarted(SlackAssistantThreadStartedEventPayload),
     Other(SlackEventCommon),
 }
 
@@ -725,6 +731,7 @@ fn provider_metadata_entry(
     provider: &str,
     kinds: &[&str],
     schema_name: &str,
+    outbound_methods: &[&str],
     signature_verification: SignatureVerificationMetadata,
     secret_requirements: Vec<ProviderSecretRequirement>,
     runtime: ProviderRuntimeMetadata,
@@ -733,7 +740,12 @@ fn provider_metadata_entry(
         provider: provider.to_string(),
         kinds: kinds.iter().map(|kind| kind.to_string()).collect(),
         schema_name: schema_name.to_string(),
-        outbound_methods: Vec::new(),
+        outbound_methods: outbound_methods
+            .iter()
+            .map(|name| ProviderOutboundMethod {
+                name: (*name).to_string(),
+            })
+            .collect(),
         secret_requirements,
         signature_verification,
         runtime,
@@ -777,6 +789,7 @@ fn default_provider_schemas() -> Vec<Arc<dyn ProviderSchema>> {
                 "github",
                 &["webhook"],
                 "GitHubEventPayload",
+                &[],
                 hmac_signature_metadata(
                     "github",
                     "X-Hub-Signature-256",
@@ -800,6 +813,15 @@ fn default_provider_schemas() -> Vec<Arc<dyn ProviderSchema>> {
                 "slack",
                 &["webhook"],
                 "SlackEventPayload",
+                &[
+                    "post_message",
+                    "update_message",
+                    "add_reaction",
+                    "open_view",
+                    "user_info",
+                    "api_call",
+                    "upload_file",
+                ],
                 hmac_signature_metadata(
                     "slack",
                     "X-Slack-Signature",
@@ -823,6 +845,7 @@ fn default_provider_schemas() -> Vec<Arc<dyn ProviderSchema>> {
                 "linear",
                 &["webhook"],
                 "LinearEventPayload",
+                &[],
                 SignatureVerificationMetadata::None,
                 Vec::new(),
                 ProviderRuntimeMetadata::Placeholder,
@@ -836,6 +859,7 @@ fn default_provider_schemas() -> Vec<Arc<dyn ProviderSchema>> {
                 "notion",
                 &["webhook"],
                 "NotionEventPayload",
+                &[],
                 SignatureVerificationMetadata::None,
                 Vec::new(),
                 ProviderRuntimeMetadata::Placeholder,
@@ -849,6 +873,7 @@ fn default_provider_schemas() -> Vec<Arc<dyn ProviderSchema>> {
                 "cron",
                 &["cron"],
                 "CronEventPayload",
+                &[],
                 SignatureVerificationMetadata::None,
                 Vec::new(),
                 ProviderRuntimeMetadata::Builtin {
@@ -865,6 +890,7 @@ fn default_provider_schemas() -> Vec<Arc<dyn ProviderSchema>> {
                 "webhook",
                 &["webhook"],
                 "GenericWebhookPayload",
+                &[],
                 hmac_signature_metadata(
                     "standard",
                     "webhook-signature",
@@ -888,6 +914,7 @@ fn default_provider_schemas() -> Vec<Arc<dyn ProviderSchema>> {
                 "a2a-push",
                 &["a2a-push"],
                 "A2aPushPayload",
+                &[],
                 SignatureVerificationMetadata::None,
                 Vec::new(),
                 ProviderRuntimeMetadata::Placeholder,
@@ -983,10 +1010,14 @@ fn slack_payload(
         raw: raw.clone(),
     };
     let payload = match kind {
-        "message.channels" => {
-            SlackEventPayload::MessageChannels(SlackMessageChannelsEventPayload {
+        kind if kind == "message" || kind.starts_with("message.") => {
+            SlackEventPayload::Message(SlackMessageEventPayload {
                 subtype: event
                     .and_then(|value| value.get("subtype"))
+                    .and_then(JsonValue::as_str)
+                    .map(ToString::to_string),
+                channel_type: event
+                    .and_then(|value| value.get("channel_type"))
                     .and_then(JsonValue::as_str)
                     .map(ToString::to_string),
                 channel: event
@@ -1050,20 +1081,43 @@ fn slack_payload(
                 .unwrap_or(JsonValue::Null),
             common,
         }),
-        "team_join" => SlackEventPayload::TeamJoin(SlackTeamJoinEventPayload {
+        "app_home_opened" => SlackEventPayload::AppHomeOpened(SlackAppHomeOpenedEventPayload {
             user: event
                 .and_then(|value| value.get("user"))
-                .cloned()
-                .unwrap_or(JsonValue::Null),
-            common,
-        }),
-        "channel_created" => SlackEventPayload::ChannelCreated(SlackChannelCreatedEventPayload {
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string),
             channel: event
                 .and_then(|value| value.get("channel"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string),
+            tab: event
+                .and_then(|value| value.get("tab"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string),
+            view: event
+                .and_then(|value| value.get("view"))
                 .cloned()
                 .unwrap_or(JsonValue::Null),
             common,
         }),
+        "assistant_thread_started" => {
+            let assistant_thread = event
+                .and_then(|value| value.get("assistant_thread"))
+                .cloned()
+                .unwrap_or(JsonValue::Null);
+            SlackEventPayload::AssistantThreadStarted(SlackAssistantThreadStartedEventPayload {
+                thread_ts: assistant_thread
+                    .get("thread_ts")
+                    .and_then(JsonValue::as_str)
+                    .map(ToString::to_string),
+                context: assistant_thread
+                    .get("context")
+                    .cloned()
+                    .unwrap_or(JsonValue::Null),
+                assistant_thread,
+                common,
+            })
+        }
         _ => SlackEventPayload::Other(common),
     };
     ProviderPayload::Known(KnownProviderPayload::Slack(Box::new(payload)))
@@ -1088,6 +1142,13 @@ fn slack_channel_id(event: Option<&JsonValue>) -> Option<String> {
                 .and_then(JsonValue::as_str)
                 .map(ToString::to_string)
         })
+        .or_else(|| {
+            event
+                .and_then(|value| value.get("assistant_thread"))
+                .and_then(|value| value.get("channel_id"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string)
+        })
 }
 
 fn slack_user_id(event: Option<&JsonValue>) -> Option<String> {
@@ -1099,6 +1160,19 @@ fn slack_user_id(event: Option<&JsonValue>) -> Option<String> {
             event
                 .and_then(|value| value.get("user"))
                 .and_then(|value| value.get("id"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string)
+        })
+        .or_else(|| {
+            event
+                .and_then(|value| value.get("item_user"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string)
+        })
+        .or_else(|| {
+            event
+                .and_then(|value| value.get("assistant_thread"))
+                .and_then(|value| value.get("user_id"))
                 .and_then(JsonValue::as_str)
                 .map(ToString::to_string)
         })
@@ -1249,6 +1323,7 @@ mod tests {
                     "github",
                     &["webhook"],
                     "GitHubEventPayload",
+                    &[],
                     SignatureVerificationMetadata::None,
                     Vec::new(),
                     ProviderRuntimeMetadata::Placeholder,
@@ -1264,6 +1339,7 @@ mod tests {
                     "github",
                     &["webhook"],
                     "GitHubEventPayload",
+                    &[],
                     SignatureVerificationMetadata::None,
                     Vec::new(),
                     ProviderRuntimeMetadata::Placeholder,

--- a/crates/harn-vm/src/triggers/test_util/mod.rs
+++ b/crates/harn-vm/src/triggers/test_util/mod.rs
@@ -2,11 +2,12 @@ use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::time::Duration as StdDuration;
+use std::time::{Duration as StdDuration, Instant};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
+use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
 use tokio::sync::Notify;
 use uuid::Uuid;
@@ -17,7 +18,7 @@ use crate::connectors::webhook::{
 };
 use crate::connectors::{
     Connector, ConnectorCtx, ConnectorError, MetricsRegistry, RateLimitConfig, RateLimiterFactory,
-    RawInbound, TriggerBinding as ConnectorTriggerBinding,
+    RawInbound, SlackConnector, TriggerBinding as ConnectorTriggerBinding,
 };
 use crate::event_log::{
     install_memory_for_current_thread, AnyEventLog, EventLog, FileEventLog, LogEvent,
@@ -52,6 +53,8 @@ pub const TRIGGER_TEST_FIXTURES: &[&str] = &[
     "rate_limit_throttles",
     "replay_binding_gc_fallback",
     "replay_refires_from_dlq",
+    "slack_events_3s_ack",
+    "slack_events_message",
     "webhook_dedupe_blocks_duplicates",
     "webhook_verifies_hmac",
 ];
@@ -225,6 +228,8 @@ impl TriggerTestHarness {
             "rate_limit_throttles" => self.rate_limit_throttles().await,
             "replay_binding_gc_fallback" => self.replay_binding_gc_fallback().await,
             "replay_refires_from_dlq" => self.replay_refires_from_dlq().await,
+            "slack_events_3s_ack" => self.slack_events_3s_ack().await,
+            "slack_events_message" => self.slack_events_message().await,
             "webhook_dedupe_blocks_duplicates" => self.webhook_dedupe_blocks_duplicates().await,
             "webhook_verifies_hmac" => self.webhook_verifies_hmac().await,
             _ => Err(format!(
@@ -327,6 +332,131 @@ impl TriggerTestHarness {
             notes: Vec::new(),
             details: json!({
                 "provider": event.provider.as_str(),
+            }),
+        })
+    }
+
+    async fn slack_events_message(self) -> Result<TriggerHarnessResult, String> {
+        let _guard = clock::install_override(self.clock.clone());
+        let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(32)));
+        let inbox = build_inbox(&log).await;
+        let mut connector = SlackConnector::new();
+        connector
+            .init(connector_ctx(
+                log,
+                Arc::new(StaticSecretProvider::new(
+                    "slack",
+                    BTreeMap::from([(
+                        SecretId::new("slack", "test-signing-secret"),
+                        "8f742231b10e8888abcd99yyyzzz85a5".to_string(),
+                    )]),
+                )),
+                inbox,
+            ))
+            .await
+            .map_err(|error| error.to_string())?;
+        connector
+            .activate(&[slack_binding()])
+            .await
+            .map_err(|error| error.to_string())?;
+
+        let event = connector
+            .normalize_inbound(slack_raw_inbound())
+            .map_err(|error| error.to_string())?;
+        self.connector_registry
+            .record_event("slack.fixture", 1, &event, Some("verified"), None);
+        let emitted = self.connector_registry.emitted();
+        Ok(TriggerHarnessResult {
+            fixture: "slack_events_message".to_string(),
+            ok: emitted.len() == 1
+                && emitted[0].provider == "slack"
+                && emitted[0].kind == "message.channels"
+                && emitted[0].signature_state == "verified",
+            stub: false,
+            summary: "slack connector verifies the signature and emits a typed message event"
+                .to_string(),
+            emitted,
+            attempts: Vec::new(),
+            dlq: Vec::new(),
+            alerts: Vec::new(),
+            bindings: Vec::new(),
+            notes: Vec::new(),
+            details: json!({
+                "expected_kind": "message.channels",
+            }),
+        })
+    }
+
+    async fn slack_events_3s_ack(self) -> Result<TriggerHarnessResult, String> {
+        let _guard = clock::install_override(self.clock.clone());
+        let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(32)));
+        let inbox = build_inbox(&log).await;
+        let mut connector = SlackConnector::new();
+        connector
+            .init(connector_ctx(
+                log.clone(),
+                Arc::new(StaticSecretProvider::new(
+                    "slack",
+                    BTreeMap::from([(
+                        SecretId::new("slack", "test-signing-secret"),
+                        "8f742231b10e8888abcd99yyyzzz85a5".to_string(),
+                    )]),
+                )),
+                inbox.clone(),
+            ))
+            .await
+            .map_err(|error| error.to_string())?;
+        connector
+            .activate(&[slack_binding()])
+            .await
+            .map_err(|error| error.to_string())?;
+
+        let started = Instant::now();
+        let event = connector
+            .normalize_inbound(slack_raw_inbound())
+            .map_err(|error| error.to_string())?;
+        let processed = crate::connectors::postprocess_normalized_event(
+            inbox.as_ref(),
+            "slack.fixture",
+            false,
+            StdDuration::from_secs(60),
+            event,
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+        let crate::connectors::PostNormalizeOutcome::Ready(event) = processed else {
+            return Err("slack ack fixture unexpectedly dropped the event".to_string());
+        };
+        let pending_topic = Topic::new("triggers.harness.pending")
+            .expect("pending topic for slack ack fixture should be valid");
+        log.append(
+            &pending_topic,
+            LogEvent::new(
+                "trigger_event",
+                json!({
+                    "trigger_id": "slack.fixture",
+                    "binding_version": 1,
+                    "event": *event,
+                }),
+            ),
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+        let elapsed_ms = started.elapsed().as_millis() as u64;
+
+        Ok(TriggerHarnessResult {
+            fixture: "slack_events_3s_ack".to_string(),
+            ok: elapsed_ms < 200,
+            stub: false,
+            summary: "slack ack-first ingress path stays below 200ms before dispatch".to_string(),
+            emitted: Vec::new(),
+            attempts: Vec::new(),
+            dlq: Vec::new(),
+            alerts: Vec::new(),
+            bindings: Vec::new(),
+            notes: Vec::new(),
+            details: json!({
+                "elapsed_ms": elapsed_ms,
             }),
         })
     }
@@ -1226,6 +1356,94 @@ fn webhook_binding(
         }
     });
     binding
+}
+
+fn slack_binding() -> ConnectorTriggerBinding {
+    let mut binding =
+        ConnectorTriggerBinding::new(ProviderId::from("slack"), "webhook", "slack.fixture");
+    binding.config = json!({
+        "match": { "path": "/hooks/slack" },
+        "secrets": { "signing_secret": "slack/test-signing-secret" },
+    });
+    binding
+}
+
+fn slack_raw_inbound() -> RawInbound {
+    let payload = json!({
+        "team_id": "T123ABC456",
+        "api_app_id": "A123ABC456",
+        "event": {
+            "type": "message",
+            "user": "U123ABC456",
+            "text": "hello from slack",
+            "ts": "1715000000.000100",
+            "channel": "C123ABC456",
+            "channel_type": "channel",
+            "event_ts": "1715000000.000100"
+        },
+        "type": "event_callback",
+        "event_id": "Ev123MESSAGE",
+        "event_time": 1715000000
+    });
+    let body = serde_json::to_vec(&payload).expect("slack fixture body should serialize");
+    let timestamp = 1_715_000_000i64;
+    let mut raw = RawInbound::new(
+        "",
+        BTreeMap::from([
+            ("Content-Type".to_string(), "application/json".to_string()),
+            (
+                "X-Slack-Request-Timestamp".to_string(),
+                timestamp.to_string(),
+            ),
+            (
+                "X-Slack-Signature".to_string(),
+                slack_signature("8f742231b10e8888abcd99yyyzzz85a5", timestamp, &body),
+            ),
+        ]),
+        body,
+    );
+    raw.received_at = OffsetDateTime::from_unix_timestamp(timestamp).unwrap();
+    raw.metadata = json!({ "binding_id": "slack.fixture" });
+    raw
+}
+
+fn slack_signature(secret: &str, timestamp: i64, body: &[u8]) -> String {
+    let mut signed = format!("v0:{timestamp}:").into_bytes();
+    signed.extend_from_slice(body);
+    format!(
+        "v0={}",
+        hex::encode(hmac_sha256(secret.as_bytes(), &signed))
+    )
+}
+
+fn hmac_sha256(secret: &[u8], data: &[u8]) -> Vec<u8> {
+    const BLOCK_SIZE: usize = 64;
+
+    let mut key = if secret.len() > BLOCK_SIZE {
+        Sha256::digest(secret).to_vec()
+    } else {
+        secret.to_vec()
+    };
+    key.resize(BLOCK_SIZE, 0);
+
+    let mut inner_pad = vec![0x36; BLOCK_SIZE];
+    let mut outer_pad = vec![0x5c; BLOCK_SIZE];
+    for (slot, key_byte) in inner_pad.iter_mut().zip(&key) {
+        *slot ^= key_byte;
+    }
+    for (slot, key_byte) in outer_pad.iter_mut().zip(&key) {
+        *slot ^= key_byte;
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(&inner_pad);
+    inner.update(data);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(&outer_pad);
+    outer.update(inner_digest);
+    outer.finalize().to_vec()
 }
 
 fn standard_raw_inbound() -> RawInbound {

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -38,7 +38,7 @@
 - [Trigger registry](./triggers/registry.md)
 - [Cron connector](./connectors/cron.md)
 - [GitHub App connector](./connectors/github.md)
-- [Slack Events connector](./connectors/slack.md)
+- [Slack Events connector](./connectors/slack-events.md)
 - [Generic webhook connector](./connectors/webhook.md)
 - [Cookbook](./cookbook.md)
 - [Tutorial: code review agent](./tutorial-code-review-agent.md)

--- a/docs/src/connectors/slack-events.md
+++ b/docs/src/connectors/slack-events.md
@@ -1,9 +1,9 @@
 # Slack Events connector
 
 `SlackConnector` is Harn's built-in Slack Events API integration. It verifies
-Slack's signed webhook requests, narrows the most useful inbound event families
-into typed `SlackEventPayload` variants, and exposes a small outbound Web API
-client through `std/connectors/slack`.
+Slack's signed webhook requests, narrows the event families most useful for
+agent orchestration into typed `SlackEventPayload` variants, and exposes a
+small outbound Web API client through `std/connectors/slack`.
 
 This connector is for the HTTP Events API path, not Socket Mode.
 
@@ -13,7 +13,7 @@ Configure Slack as a `provider = "slack"` webhook trigger:
 
 ```toml
 [[triggers]]
-id = "slack-mentions"
+id = "slack-events"
 kind = "webhook"
 provider = "slack"
 match = { path = "/hooks/slack" }
@@ -39,15 +39,23 @@ so Harn treats inbound Slack deliveries as ack-first:
 `url_verification` is handled inline after signature verification and responds
 with the plaintext `challenge` value, as required by Slack.
 
+Retry metadata is preserved on the normalized headers:
+
+- `X-Slack-Retry-Num`
+- `X-Slack-Retry-Reason`
+
+Permanent client-side rejections return `x-slack-no-retry: 1` so Slack does not
+keep replaying bad requests.
+
 ## Typed inbound payloads
 
 `SlackEventPayload` is narrowed into these first-class variants:
 
-- `message.channels`
-- `app_mention`
-- `reaction_added`
-- `team_join`
-- `channel_created`
+- `Message` for `message.*` deliveries such as `message.channels`
+- `AppMention`
+- `ReactionAdded`
+- `AppHomeOpened`
+- `AssistantThreadStarted`
 
 Other Slack callback shapes still normalize into `SlackEventPayload::Other`
 with the full `raw` envelope preserved.
@@ -81,7 +89,13 @@ Available helpers:
 - `post_message(channel, text, blocks = nil, options = nil)`
 - `update_message(channel, ts, text, blocks = nil, options = nil)`
 - `add_reaction(channel, ts, name, options = nil)`
+- `open_view(trigger_id, view, options = nil)`
+- `user_info(user_id, options = nil)`
+- `api_call(method, args = nil, options = nil)`
 - `upload_file(filename, content, options = nil)`
+
+`api_call(...)` is a POST-based escape hatch for Slack methods that are not yet
+wrapped directly by the stdlib module.
 
 `upload_file(...)` uses Slack's external upload flow
 (`files.getUploadURLExternal` + upload URL + `files.completeUploadExternal`)
@@ -94,6 +108,7 @@ import {
   add_reaction,
   configure,
   post_message,
+  user_info,
 } from "std/connectors/slack"
 
 pipeline default() {
@@ -101,7 +116,8 @@ pipeline default() {
     bot_token_secret: "slack/bot-token",
   })
 
-  let posted = post_message("C123ABC456", "hello from harn")
+  let user = user_info("U123ABC456")
+  let posted = post_message("C123ABC456", "hello " + (user.user.name ?? "from harn"))
   add_reaction("C123ABC456", posted.ts, "thumbsup")
 }
 ```
@@ -114,8 +130,12 @@ Typical starting points:
 - `app_mentions:read` for `app_mention`
 - `channels:history` for `message.channels`
 - `reactions:read` for `reaction_added`
-- `users:read` for `team_join`
-- `channels:read` for `channel_created`
-- `chat:write` for message posting/updating
+- enable the App Home tab for `app_home_opened`
+- `assistant:write` for `assistant_thread_started` where Slack makes that scope available
+- `chat:write` for message posting and updates
 - `reactions:write` for reactions
+- `users:read` for `user_info`
+- `users:read.email` only if you need email fields from `users.info`
 - `files:write` for uploads
+
+See `examples/slack-app-manifest.yaml` for a pasteable starting manifest.

--- a/docs/src/triggers/event-schema.md
+++ b/docs/src/triggers/event-schema.md
@@ -56,9 +56,9 @@ payload is already narrowed into the six MVP event families (`issues`,
 `pull_request`, `issue_comment`, `pull_request_review`, `push`, and
 `workflow_run`) with event-specific top-level fields such as `issue`,
 `pull_request`, `comment`, `review`, `commits`, and `workflow_run`. Slack's
-payload is narrowed into `message.channels`, `app_mention`,
-`reaction_added`, `team_join`, and `channel_created`, while still preserving
-the full outer envelope in `raw`:
+payload is narrowed into `Message` (`message.*`), `AppMention`,
+`ReactionAdded`, `AppHomeOpened`, and `AssistantThreadStarted`, while still
+preserving the full outer envelope in `raw`:
 
 - `GitHubEventPayload`
 - `SlackEventPayload`

--- a/examples/slack-app-manifest.yaml
+++ b/examples/slack-app-manifest.yaml
@@ -1,0 +1,46 @@
+display_information:
+  name: Harn Events Connector
+  description: Slack Events API app manifest template for Harn
+  background_color: "#1d9bd1"
+
+features:
+  bot_user:
+    display_name: Harn
+    always_online: false
+  app_home:
+    home_tab_enabled: true
+    messages_tab_enabled: false
+    messages_tab_read_only_enabled: false
+
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - channels:history
+      - chat:write
+      - reactions:read
+      - reactions:write
+      - users:read
+      - files:write
+      # Add when you need channel_created-style metadata via Web API calls.
+      - channels:read
+      # Add only if you need email fields from users.info.
+      # - users:read.email
+      # Add only when Slack makes assistant apps available for your workspace.
+      # - assistant:write
+
+settings:
+  event_subscriptions:
+    request_url: https://example.com/hooks/slack
+    bot_events:
+      - app_mention
+      - message.channels
+      - reaction_added
+      - app_home_opened
+      # Enable only when assistant apps are available for your workspace.
+      # - assistant_thread_started
+  interactivity:
+    is_enabled: true
+    request_url: https://example.com/hooks/slack
+  org_deploy_enabled: false
+  socket_mode_enabled: false


### PR DESCRIPTION
## Summary

Implements comprehensive Slack Events API support for issue #171.

- expands inbound Slack event typing and normalization across the runtime, trigger schema, and stdlib
- adds outbound Slack helpers for `open_view`, `user_info`, and generic `api_call`
- adds listener-side Slack delivery metrics plus `x-slack-no-retry: 1` on permanent client errors
- updates docs and adds a sample Slack app manifest
- adds focused Rust tests and conformance coverage for inbound events and 3s acknowledgement behavior

## Why

Harn's Slack support was incomplete relative to the Events API surface described in #171. This change makes the connector usable for core Slack app workflows while tightening listener behavior around retries and delivery visibility.

## Validation

- `cargo fmt --all`
- `cargo test -p harn-vm slack_connector -- --nocapture`
- `cargo test -p harn-vm slack_outbound_helpers_hit_expected_api_methods -- --nocapture`
- `cargo test -p harn-cli slack_ -- --nocapture`
- `cargo run --quiet --bin harn -- test conformance --filter slack_connector_roundtrip`
- `cargo run --quiet --bin harn -- test conformance --filter trigger_provider_catalog`
- `cargo run --quiet --bin harn -- test conformance --filter trigger_webhook_slack_events_message`
- `cargo run --quiet --bin harn -- test conformance --filter trigger_webhook_slack_events_3s_ack`
- pre-push gate passed
