### PR TITLE
Fix project_fingerprint conformance leak (#330)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,11 +28,6 @@ conformance/tests/**/.harn/metadata/
 # private harn-cloud repo + business goals); it lives in burin-code's
 # local `.claude/commands/` only, never in the public harn repo.
 .claude/commands/merge-captain.md
-# conformance/tests/stdlib/project_fingerprint.harn leaks a
-# `project_fingerprint_repo/` fixture into cwd (repo root) because
-# it uses relative mkdir instead of temp_dir(). Tracked as a test
-# hygiene issue; until the test is fixed, don't commit the leak.
-/project_fingerprint_repo/
 meta_scratch/
 .remember/
 .serena/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## Unreleased
+
+### Fixed
+
+- **`project_fingerprint` no longer leaks its fixture tree into the repo
+  root (#330).** The conformance test now builds its synthetic repo under
+  a temp directory and cleans it up automatically, so documented
+  `harn test conformance` runs stop leaving a stray
+  `project_fingerprint_repo/` behind.
+
 ## v0.7.23
 
 ### Changed

--- a/conformance/tests/stdlib/project_fingerprint.harn
+++ b/conformance/tests/stdlib/project_fingerprint.harn
@@ -1,22 +1,27 @@
 import "std/project"
 
 pipeline test(task) {
-  mkdir("project_fingerprint_repo/backend")
-  mkdir("project_fingerprint_repo/frontend/tests")
-  mkdir("project_fingerprint_repo/.github/workflows")
+  let root = path_join(temp_dir(), "project-fingerprint-" + uuid())
+  mkdir(root)
+  defer {
+    delete_file(root)
+  }
+  mkdir(path_join(root, "backend"))
+  mkdir(path_join(root, "frontend/tests"))
+  mkdir(path_join(root, ".github/workflows"))
   write_file(
-    "project_fingerprint_repo/backend/Cargo.toml",
+    path_join(root, "backend/Cargo.toml"),
     "[package]\nname = \"backend\"\nversion = \"0.1.0\"\n[dependencies]\naxum = \"0.8\"\n",
   )
-  write_file("project_fingerprint_repo/backend/Cargo.lock", "# lock\n")
+  write_file(path_join(root, "backend/Cargo.lock"), "# lock\n")
   write_file(
-    "project_fingerprint_repo/frontend/package.json",
+    path_join(root, "frontend/package.json"),
     "{\n  \"name\": \"frontend\",\n  \"packageManager\": \"pnpm@9.0.0\",\n  \"dependencies\": {\n    \"next\": \"15.0.0\",\n    \"react\": \"19.0.0\"\n  }\n}\n",
   )
-  write_file("project_fingerprint_repo/frontend/next.config.ts", "export default {}\n")
-  write_file("project_fingerprint_repo/frontend/pnpm-lock.yaml", "lockfileVersion: '9.0'\n")
-  write_file("project_fingerprint_repo/.github/workflows/ci.yml", "name: ci\non: push\n")
-  let fingerprint: ProjectFingerprint = project_fingerprint("project_fingerprint_repo")
+  write_file(path_join(root, "frontend/next.config.ts"), "export default {}\n")
+  write_file(path_join(root, "frontend/pnpm-lock.yaml"), "lockfileVersion: '9.0'\n")
+  write_file(path_join(root, ".github/workflows/ci.yml"), "name: ci\non: push\n")
+  let fingerprint: ProjectFingerprint = project_fingerprint(root)
   println(fingerprint.primary_language == "mixed")
   println(fingerprint.languages[0] == "rust")
   println(fingerprint.languages[1] == "typescript")


### PR DESCRIPTION
## Summary
- Scopes the `project_fingerprint.harn` conformance fixture into a tempdir + cleans up after itself, so running the suite no longer trashes the repo root with a `project_fingerprint_repo/` directory.
- Removes the stale `.gitignore` entry.

Closes #330.

## Test plan
- [x] `cargo run --bin harn -- test conformance --filter project_fingerprint`
- [x] `ls project_fingerprint_repo/` at the repo root returns `No such file or directory` after the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
