### PR TITLE
Expose \ stdlib builtin (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ granular archaeology.
   `hitl.approvals`, `hitl.dual_control`, and `hitl.escalations` through the
   event log without reaching into SQLite directly.
 
+- **Expose `agent_session_current_id()` as a public stdlib builtin
+  (#318).** Handlers and subscribers can now read the innermost active
+  agent session id directly, which makes it easier to compose
+  `agent_session_snapshot`, `agent_session_fork`, and
+  `agent_session_trim` against the currently executing session without
+  threading the id through every call.
+
 ## v0.7.23
 
 ### Changed

--- a/conformance/tests/agents/agent_session_current_id.expected
+++ b/conformance/tests/agents/agent_session_current_id.expected
@@ -1,0 +1,1 @@
+[harn] agent_session_current_id tests passed

--- a/conformance/tests/agents/agent_session_current_id.harn
+++ b/conformance/tests/agents/agent_session_current_id.harn
@@ -1,0 +1,54 @@
+pipeline main(task) {
+  assert(
+    agent_session_current_id() == nil,
+    "top-level current session lookup returns nil outside any active session",
+  )
+  let session = "current-id-session"
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "read_current_id",
+    "Return the current session id",
+    {
+    handler: { _args ->
+    let current = agent_session_current_id()
+    assert(current == session, "tool handler sees the session it is running under")
+    return current
+  },
+    parameters: {},
+    returns: {type: "string"},
+  },
+  )
+  llm_mock(
+    {text: "Checking the session.", tool_calls: [{id: "sid1", name: "read_current_id", arguments: {}}]},
+  )
+  llm_mock({text: "<done>##DONE##</done>"})
+  let result = agent_loop(
+    "Report the current session id",
+    nil,
+    {
+    provider: "mock",
+    tools: tools,
+    tool_format: "native",
+    persistent: true,
+    max_iterations: 4,
+    session_id: session,
+  },
+  )
+  assert(result?.status == "done", "loop completes")
+  let calls = llm_mock_calls()
+  assert(len(calls) >= 2, "tool call produces a second turn")
+  let turn2_messages = calls[1].messages
+  var saw_session_feedback = false
+  for m in turn2_messages {
+    let content = m?.content
+    if content != nil && contains(content, session) {
+      saw_session_feedback = true
+    }
+  }
+  assert(
+    saw_session_feedback,
+    "next turn includes the tool result returned by agent_session_current_id()",
+  )
+  log("agent_session_current_id tests passed")
+}

--- a/crates/harn-parser/src/builtin_signatures/signatures/agents.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/agents.rs
@@ -56,6 +56,10 @@ pub(crate) const SIGNATURES: &[BuiltinSig] = &[
         return_type: Some(BuiltinReturn::Named("int")),
     },
     BuiltinSig {
+        name: "agent_session_current_id",
+        return_type: Some(BuiltinReturn::Union(UNION_STRING_NIL)),
+    },
+    BuiltinSig {
         name: "agent_session_exists",
         return_type: Some(BuiltinReturn::Named("bool")),
     },

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -106,7 +106,7 @@ pub(crate) fn pop_current_session() {
     });
 }
 
-pub(crate) fn current_session_id() -> Option<String> {
+pub fn current_session_id() -> Option<String> {
     CURRENT_SESSION_STACK.with(|stack| stack.borrow().last().cloned())
 }
 

--- a/crates/harn-vm/src/stdlib/agent_sessions.rs
+++ b/crates/harn-vm/src/stdlib/agent_sessions.rs
@@ -18,6 +18,7 @@ pub fn register_agent_session_builtins(vm: &mut Vm) {
     register_length(vm);
     register_snapshot(vm);
     register_ancestry(vm);
+    register_current_id(vm);
     register_reset(vm);
     register_fork(vm);
     register_fork_at(vm);
@@ -132,6 +133,16 @@ fn register_ancestry(vm: &mut Vm) {
                 VmValue::String(Rc::from(ancestry.root_id)),
             ),
         ]))))
+    });
+}
+
+/// Return the innermost active agent session id for the currently
+/// executing thread, or `nil` when no session is active.
+fn register_current_id(vm: &mut Vm) {
+    vm.register_builtin("agent_session_current_id", |_args, _out| {
+        Ok(agent_sessions::current_session_id()
+            .map(|id| VmValue::String(Rc::from(id)))
+            .unwrap_or(VmValue::Nil))
     });
 }
 
@@ -330,4 +341,43 @@ fn build_compact_config(
         cfg.compress_callback = Some(v);
     }
     Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::value::VmValue;
+
+    fn call_current_id_builtin() -> VmValue {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        rt.block_on(async {
+            let local = tokio::task::LocalSet::new();
+            local
+                .run_until(async {
+                    let mut vm = crate::Vm::new();
+                    crate::register_vm_stdlib(&mut vm);
+                    vm.call_named_builtin("agent_session_current_id", Vec::new())
+                        .await
+                        .expect("builtin call")
+                })
+                .await
+        })
+    }
+
+    #[test]
+    fn current_id_returns_nil_outside_active_session() {
+        crate::reset_thread_local_state();
+        assert!(matches!(call_current_id_builtin(), VmValue::Nil));
+    }
+
+    #[test]
+    fn current_id_returns_active_session_id() {
+        crate::reset_thread_local_state();
+        crate::agent_sessions::push_current_session("unit-test-session".to_string());
+        let current = call_current_id_builtin();
+        crate::agent_sessions::pop_current_session();
+        assert!(matches!(current, VmValue::String(value) if value.as_ref() == "unit-test-session"));
+    }
 }

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -787,6 +787,7 @@ Lifecycle builtins (all hard-error on unknown ids except `exists`,
 `open`, `snapshot`, `ancestry`):
 
 - `agent_session_open(id?)` / `_close(id)` / `_exists(id)`
+- `agent_session_current_id()` returns the innermost active session id or `nil`.
 - `agent_session_reset(id)` / `_fork(src, dst?)` / `_fork_at(src, keep_first, dst?)` / `_trim(id, keep_last)`
 - `agent_session_inject(id, {role, content, …})` — missing `role` errors.
 - `agent_session_compact(id, opts)` — unknown keys in `opts` error.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -20,6 +20,7 @@
 
 - [LLM calls and agent loops](./llm-and-agents.md)
 - [Daemon stdlib](./stdlib/daemon.md)
+- [Current session builtin](./stdlib/agent_session_current_id.md)
 - [Triggers](./triggers.md)
 - [Trigger stdlib](./stdlib/triggers.md)
 - [Human in the loop](./hitl.md)

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1495,6 +1495,7 @@ See the [Sessions](./sessions.md) chapter for the full model.
 |---|---|---|---|
 | `agent_session_open(id?)` | id: string or nil | string | Idempotent open; `nil` mints a UUIDv7 |
 | `agent_session_exists(id)` | id | bool | Safe on unknown ids |
+| `agent_session_current_id()` | none | string or nil | Returns the innermost active session id, or `nil` outside any active session |
 | `agent_session_length(id)` | id | int | Message count; errors on unknown id |
 | `agent_session_snapshot(id)` | id | dict or nil | Read-only transcript snapshot plus `parent_id`, `child_ids`, `branched_at_event_index` |
 | `agent_session_ancestry(id)` | id | dict or nil | Returns `{parent_id, child_ids, root_id}` for the current in-VM lineage |

--- a/docs/src/sessions.md
+++ b/docs/src/sessions.md
@@ -62,6 +62,7 @@ the "one-shot" call shape.
 |---|---|---|
 | `agent_session_open(id?: string)` | `string` | Idempotent. `nil` mints a UUIDv7. |
 | `agent_session_exists(id)` | `bool` | Safe on unknown ids. |
+| `agent_session_current_id()` | `string` or `nil` | Returns the innermost active session id for the current thread, or `nil` outside any active session. |
 | `agent_session_length(id)` | `int` | Message count. Errors if `id` doesn't exist. |
 | `agent_session_snapshot(id)` | `dict` or `nil` | Read-only transcript snapshot plus `parent_id`, `child_ids`, and `branched_at_event_index`. |
 | `agent_session_ancestry(id)` | `dict` or `nil` | Returns `{parent_id, child_ids, root_id}` for the in-VM session graph. |
@@ -104,6 +105,10 @@ accessed session when a new one is opened over the cap.
 events through every subscriber for that session id. Subscribers are
 not copied by `agent_session_fork` — a fork is a conversation branch,
 not an event fanout.
+
+Inside those callbacks, `agent_session_current_id()` resolves to the
+session currently being driven by the agent loop. Outside any active
+session, it returns `nil`.
 
 ## Lineage
 

--- a/docs/src/stdlib/agent_session_current_id.md
+++ b/docs/src/stdlib/agent_session_current_id.md
@@ -1,0 +1,44 @@
+# `agent_session_current_id()`
+
+Return the innermost active agent session id for the currently executing
+VM thread.
+
+## Signature
+
+```harn
+agent_session_current_id() -> string | nil
+```
+
+The builtin returns:
+
+- the active `session_id` while code is running inside an `agent_loop(...)`
+  turn, subscriber callback, or other session-scoped callback
+- `nil` when no agent session is active
+
+## Why it exists
+
+Session management builtins like `agent_session_snapshot(id)`,
+`agent_session_fork(id, dst?)`, and `agent_session_trim(id, keep_last)`
+operate on explicit ids. `agent_session_current_id()` lets nested handlers
+discover "the session I am currently executing under" without threading that
+id through every layer manually.
+
+## Example
+
+```harn
+let session = "support-thread"
+
+agent_subscribe(
+  session,
+  { ev ->
+  if ev?.type == "turn_end" {
+    let current = agent_session_current_id()
+    if current != nil {
+      agent_inject_feedback(current, "turn_marker", "just finished a turn")
+    }
+  }
+},
+)
+```
+
+Use [Sessions](../sessions.md) for the broader storage and lifecycle model.


### PR DESCRIPTION
## Summary
- Promotes the internal `current_session_id()` helper to a public
  stdlib builtin `agent_session_current_id() -> string | nil`.
- Returns the innermost active session id, or nil outside any session.
- Enables handlers to compose `agent_session_snapshot` /
  `agent_session_fork` / `agent_session_trim` against themselves
  without threading the id through the call chain.

Closes #318.

## Test plan
- [ ] `cargo nextest run -p harn-vm` green
- [ ] `cargo run --bin harn -- test conformance` green (includes new
      agent_session_current_id conformance test)
- [ ] Clippy clean
- [ ] Stdlib docs + quickref updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)