### PR TITLE
Fix harn fmt drift on hitl_pending conformance test (follow-up to #341)

### DIFF
--- a/conformance/tests/stdlib/hitl_pending.harn
+++ b/conformance/tests/stdlib/hitl_pending.harn
@@ -6,9 +6,8 @@ pipeline test(task) {
     ask_user(prompt, {timeout: 5m})
   }
   sleep(10ms)
-  let rows: list<HitlPendingRequest> = hitl_pending({}).filter({row ->
-    row.prompt == prompt
-  })
+  let rows: list<HitlPendingRequest> = hitl_pending({})
+    .filter({ row -> row.prompt == prompt })
   println(len(rows))
   println(rows[0].request_kind)
   println(starts_with(rows[0].prompt, "Need a human "))


### PR DESCRIPTION
## Summary
- `#341` added `conformance/tests/stdlib/hitl_pending.harn` but didn't run `harn fmt` on it, so the post-merge main-CI `make fmt-harn` check failed.
- This applies the 2-line fmt fix to unblock main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)