### PR TITLE
Fix orchestrator SIGTERM race on startup

### DIFF
--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -41,6 +41,17 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
         harn_vm::observability::otel::ObservabilityGuard::install_orchestrator_subscriber_from_env(
         )?;
     harn_vm::reset_thread_local_state();
+
+    // Install signal streams BEFORE any startup log a supervisor (test harness,
+    // systemd, launchd) might be watching for. Tokio's signal streams install
+    // the OS-level handler on their first call per SignalKind; any SIGTERM
+    // delivered before that call uses the default disposition (terminate),
+    // which caused orchestrator_serve_starts_and_shuts_down_cleanly to flake
+    // under parallel test load when the harness raced past the "HTTP listener
+    // ready" log.
+    #[cfg(unix)]
+    let signal_streams = install_signal_streams()?;
+
     let shutdown_timeout = Duration::from_secs(args.shutdown_timeout.max(1));
 
     let tls = TlsFiles::from_args(args.cert.clone(), args.key.clone())?;
@@ -243,20 +254,24 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
     )
     .await?;
 
-    wait_for_runtime_signal_loop(RuntimeSignalCtx {
-        role: args.role,
-        config_path: &config_path,
-        state_dir: &state_dir,
-        bind: local_bind,
-        startup_started_at: &startup_started_at,
-        event_log: &event_log,
-        event_log_description: &event_log_description,
-        secret_chain_display: &secret_chain_display,
-        listener: &listener,
-        connectors: &connector_runtime,
-        live_manifest: &mut live_manifest,
-        live_triggers: &mut live_triggers,
-    })
+    wait_for_runtime_signal_loop(
+        RuntimeSignalCtx {
+            role: args.role,
+            config_path: &config_path,
+            state_dir: &state_dir,
+            bind: local_bind,
+            startup_started_at: &startup_started_at,
+            event_log: &event_log,
+            event_log_description: &event_log_description,
+            secret_chain_display: &secret_chain_display,
+            listener: &listener,
+            connectors: &connector_runtime,
+            live_manifest: &mut live_manifest,
+            live_triggers: &mut live_triggers,
+        },
+        #[cfg(unix)]
+        signal_streams,
+    )
     .await?;
 
     let shutdown = graceful_shutdown(
@@ -1178,17 +1193,37 @@ struct RuntimeSignalCtx<'a> {
     live_triggers: &'a mut Vec<CollectedManifestTrigger>,
 }
 
-async fn wait_for_runtime_signal_loop(ctx: RuntimeSignalCtx<'_>) -> Result<(), String> {
+#[cfg(unix)]
+struct SignalStreams {
+    sigterm: tokio::signal::unix::Signal,
+    sigint: tokio::signal::unix::Signal,
+    sighup: tokio::signal::unix::Signal,
+}
+
+#[cfg(unix)]
+fn install_signal_streams() -> Result<SignalStreams, String> {
+    use tokio::signal::unix::{signal, SignalKind};
+    Ok(SignalStreams {
+        sigterm: signal(SignalKind::terminate())
+            .map_err(|error| format!("failed to register SIGTERM handler: {error}"))?,
+        sigint: signal(SignalKind::interrupt())
+            .map_err(|error| format!("failed to register SIGINT handler: {error}"))?,
+        sighup: signal(SignalKind::hangup())
+            .map_err(|error| format!("failed to register SIGHUP handler: {error}"))?,
+    })
+}
+
+async fn wait_for_runtime_signal_loop(
+    ctx: RuntimeSignalCtx<'_>,
+    #[cfg(unix)] mut signals: SignalStreams,
+) -> Result<(), String> {
     #[cfg(unix)]
     {
-        use tokio::signal::unix::{signal, SignalKind};
-
-        let mut sigterm = signal(SignalKind::terminate())
-            .map_err(|error| format!("failed to register SIGTERM handler: {error}"))?;
-        let mut sigint = signal(SignalKind::interrupt())
-            .map_err(|error| format!("failed to register SIGINT handler: {error}"))?;
-        let mut sighup = signal(SignalKind::hangup())
-            .map_err(|error| format!("failed to register SIGHUP handler: {error}"))?;
+        let SignalStreams {
+            sigterm,
+            sigint,
+            sighup,
+        } = &mut signals;
         loop {
             tokio::select! {
                 _ = sigterm.recv() => return Ok(()),


### PR DESCRIPTION
## Summary

- Install `tokio::signal::unix::signal(...)` streams for SIGTERM/SIGINT/SIGHUP at the top of `run_local` (right after `reset_thread_local_state`), before any `eprintln!` a supervisor or test harness can observe.
- Thread the pre-registered streams into `wait_for_runtime_signal_loop`, which now just drives the select loop instead of registering handlers itself.

## Root cause

`harn orchestrator serve` registered its Unix signal handlers inside `wait_for_runtime_signal_loop`, which ran only after the entire startup path (listener bind, `[harn] HTTP listener ready on …` log, post-listener connector activation, state snapshot write, startup lifecycle event). Tokio's `signal::unix::signal(SignalKind::…)` installs the OS handler on its first call per `SignalKind`; any SIGTERM delivered before that call uses the default disposition and terminates the process via signal 15.

Under heavy parallel test load, the integration test `orchestrator_serve_starts_and_shuts_down_cleanly` would observe the "HTTP listener ready on" needle, SIGTERM the child immediately, and beat the handler install. `wait_for_exit` then saw `signal: 15 (SIGTERM)` instead of exit code 0.

This is the flake that tripped the first `release_ship.sh` attempt for v0.7.24.

## Test plan

- [x] `cargo check -p harn-cli`
- [x] `cargo clippy -p harn-cli`
- [x] `cargo nextest run -p harn-cli --test orchestrator_cli orchestrator_serve_starts_and_shuts_down_cleanly` (isolated)
- [x] `cargo nextest run --workspace` — 1767/1767 passed under the same parallel load that reproduced the flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)