### PR TITLE
Fix harn-cli unit-test isolation on event-log globals

### DIFF
--- a/crates/harn-cli/src/commands/doctor.rs
+++ b/crates/harn-cli/src/commands/doctor.rs
@@ -813,6 +813,7 @@ mod tests {
 
     #[test]
     fn event_log_check_reports_backend_and_location() {
+        let _state_guard = crate::tests::common::harn_state_lock::lock_harn_state();
         let _cwd_guard = crate::tests::common::cwd_lock::lock_cwd();
         let dir = tempfile::tempdir().expect("tempdir");
         let previous = std::env::current_dir().expect("cwd");

--- a/crates/harn-cli/src/commands/mcp/serve.rs
+++ b/crates/harn-cli/src/commands/mcp/serve.rs
@@ -1462,25 +1462,21 @@ fn auth_event_log(state_dir: &Path) -> Result<Arc<harn_vm::event_log::AnyEventLo
 }
 
 #[cfg(test)]
-// MCP_TEST_LOCK serializes tests that share a process-global harn state.
-// Swapping in a tokio::sync::Mutex would require threading it through every
-// test helper + the `init_session` future; the `std::sync::Mutex` guard is
-// dropped when each `#[tokio::test]` future resolves, so holding it across
+// Tests here mutate harn_vm process-global state (`HARN_STATE_DIR` env,
+// thread-local `ACTIVE_EVENT_LOG`, trigger registry) through the shared
+// `lock_harn_state` guard in `crate::tests::common::harn_state_lock`.
+// The guard is a `std::sync::Mutex` held across `.await` points; it is
+// dropped when each `#[tokio::test]` future resolves, so holding across
 // awaits is safe in practice despite the clippy lint.
 #[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
     use std::fs;
     use std::path::Path;
-    use std::sync::{Mutex, OnceLock};
 
     use tempfile::TempDir;
 
-    static MCP_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-    fn test_lock() -> std::sync::MutexGuard<'static, ()> {
-        MCP_TEST_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
-    }
+    use crate::tests::common::harn_state_lock::lock_harn_state;
 
     fn write_file(dir: &Path, relative: &str, contents: &str) {
         let path = dir.join(relative);
@@ -1622,7 +1618,7 @@ pub fn on_fail(event: TriggerEvent) -> any {
 
     #[tokio::test(flavor = "current_thread")]
     async fn trigger_list_tool_returns_manifest_bindings() {
-        let _guard = test_lock();
+        let _guard = lock_harn_state();
         let temp = TempDir::new().unwrap();
         write_fixture(&temp);
         let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
@@ -1641,7 +1637,7 @@ pub fn on_fail(event: TriggerEvent) -> any {
 
     #[tokio::test(flavor = "current_thread")]
     async fn secret_scan_tool_returns_findings_and_audits_them() {
-        let _guard = test_lock();
+        let _guard = lock_harn_state();
         let temp = TempDir::new().unwrap();
         write_fixture(&temp);
         let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
@@ -1671,7 +1667,7 @@ pub fn on_fail(event: TriggerEvent) -> any {
 
     #[tokio::test(flavor = "current_thread")]
     async fn trigger_fire_roundtrip_records_event_resource_and_action_graph() {
-        let _guard = test_lock();
+        let _guard = lock_harn_state();
         let temp = TempDir::new().unwrap();
         write_fixture(&temp);
         let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
@@ -1712,7 +1708,7 @@ pub fn on_fail(event: TriggerEvent) -> any {
 
     #[tokio::test(flavor = "current_thread")]
     async fn trigger_replay_tool_replays_event() {
-        let _guard = test_lock();
+        let _guard = lock_harn_state();
         let temp = TempDir::new().unwrap();
         write_fixture(&temp);
         let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
@@ -1737,7 +1733,7 @@ pub fn on_fail(event: TriggerEvent) -> any {
 
     #[tokio::test(flavor = "current_thread")]
     async fn dlq_tools_roundtrip_and_resource_read() {
-        let _guard = test_lock();
+        let _guard = lock_harn_state();
         let temp = TempDir::new().unwrap();
         write_fixture(&temp);
         let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
@@ -1775,7 +1771,7 @@ pub fn on_fail(event: TriggerEvent) -> any {
 
     #[tokio::test(flavor = "current_thread")]
     async fn queue_and_inspect_tools_return_snapshots() {
-        let _guard = test_lock();
+        let _guard = lock_harn_state();
         let temp = TempDir::new().unwrap();
         write_fixture(&temp);
         let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
@@ -1803,7 +1799,7 @@ pub fn on_fail(event: TriggerEvent) -> any {
 
     #[tokio::test(flavor = "current_thread")]
     async fn trust_query_returns_empty_results() {
-        let _guard = test_lock();
+        let _guard = lock_harn_state();
         let temp = TempDir::new().unwrap();
         write_fixture(&temp);
         let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
@@ -1822,7 +1818,7 @@ pub fn on_fail(event: TriggerEvent) -> any {
 
     #[tokio::test(flavor = "current_thread")]
     async fn manifest_resource_reads_raw_manifest() {
-        let _guard = test_lock();
+        let _guard = lock_harn_state();
         let temp = TempDir::new().unwrap();
         write_fixture(&temp);
         let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -1138,6 +1138,11 @@ impl IntoResponse for HttpError {
 }
 
 #[cfg(test)]
+// Tests below hold the shared `lock_harn_state` guard across `.await`
+// points; the guard is dropped when each `#[tokio::test]` future resolves
+// so this is safe in practice, matching the pattern already in
+// `mcp/serve.rs`.
+#[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
     use harn_vm::event_log::{
@@ -1153,7 +1158,7 @@ mod tests {
     use sha2::{Digest, Sha256};
     use tempfile::tempdir;
 
-    static REQUEST_DELAY_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    use crate::tests::common::harn_state_lock::lock_harn_state;
 
     fn manifest_binding_spec(id: &str, fingerprint: &str) -> TriggerBindingSpec {
         TriggerBindingSpec {
@@ -1295,7 +1300,7 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     #[tokio::test(flavor = "current_thread")]
     async fn reload_swaps_routes_without_losing_inflight_request() {
-        let _env_guard = REQUEST_DELAY_LOCK.lock().expect("request delay lock");
+        let _guard = lock_harn_state();
         reset_active_event_log();
         harn_vm::clear_trigger_registry();
 
@@ -1417,6 +1422,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn webhook_first_delivery_is_appended() {
+        let _guard = lock_harn_state();
         reset_active_event_log();
         let dir = tempdir().expect("tempdir");
         let log = install_default_for_base_dir(dir.path()).expect("install event log");
@@ -1476,6 +1482,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn webhook_duplicate_delivery_is_dropped() {
+        let _guard = lock_harn_state();
         reset_active_event_log();
         let dir = tempdir().expect("tempdir");
         let log = install_default_for_base_dir(dir.path()).expect("install event log");

--- a/crates/harn-cli/src/commands/trigger/replay.rs
+++ b/crates/harn-cli/src/commands/trigger/replay.rs
@@ -694,6 +694,11 @@ fn diff_outcomes(
 }
 
 #[cfg(test)]
+// Tests below hold the shared `lock_harn_state` guard across `.await`
+// points; the guard is dropped when each `#[tokio::test]` future resolves
+// so this is safe in practice, matching the pattern already in
+// `mcp/serve.rs`.
+#[allow(clippy::await_holding_lock)]
 mod tests {
     use std::collections::BTreeMap;
     use std::fs;
@@ -718,6 +723,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn replay_falls_back_to_recorded_timestamp_when_version_lookup_is_stale() {
+        let _guard = crate::tests::common::harn_state_lock::lock_harn_state();
         harn_vm::reset_thread_local_state();
         let sink = Rc::new(CollectorSink::new());
         clear_event_sinks();

--- a/crates/harn-cli/src/tests/common/harn_state_lock.rs
+++ b/crates/harn-cli/src/tests/common/harn_state_lock.rs
@@ -1,0 +1,51 @@
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+static HARN_STATE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Process-global env vars that point harn_vm at a specific state dir.
+/// Any test that leaves these set leaks its (now-deleted) `TempDir`
+/// path into subsequent tests' `install_default_for_base_dir(base_dir)`
+/// calls because `state_root()` / `event_log_*` resolvers honor an
+/// absolute env-var value over the supplied `base_dir`, silently
+/// pointing every test at the same stale SQLite file.
+const LEAKY_STATE_ENV_VARS: &[&str] = &[
+    harn_vm::runtime_paths::HARN_STATE_DIR_ENV,
+    harn_vm::runtime_paths::HARN_RUN_DIR_ENV,
+    harn_vm::runtime_paths::HARN_WORKTREE_DIR_ENV,
+    harn_vm::event_log::HARN_EVENT_LOG_BACKEND_ENV,
+    harn_vm::event_log::HARN_EVENT_LOG_DIR_ENV,
+    harn_vm::event_log::HARN_EVENT_LOG_SQLITE_PATH_ENV,
+    harn_vm::event_log::HARN_EVENT_LOG_QUEUE_DEPTH_ENV,
+];
+
+/// Serialize tests that mutate harn_vm process-global state.
+///
+/// Covers:
+/// - `HARN_STATE_DIR` and sibling env vars read by
+///   `harn_vm::runtime_paths::state_root()` / `event_log_*` and written
+///   by `OrchestratorRole::build_vm()`. The lock helper unsets them on
+///   entry so each test starts from a clean env instead of inheriting
+///   a previous test's absolute state path.
+/// - The thread-local `ACTIVE_EVENT_LOG`, which is reused across
+///   cargo test-thread handoffs.
+/// - The process-global `harn_vm` trigger registry mutated by
+///   `install_manifest_triggers` / `clear_trigger_registry`.
+///
+/// Tests grabbing this lock should not assume the global state is clean
+/// on entry — always call `reset_active_event_log()` +
+/// `harn_vm::clear_trigger_registry()` as applicable.
+///
+/// Poison recovery: a prior panic may poison the mutex. We recover the
+/// guard because each test resets the state on entry, so the mutex's
+/// `()` payload is irrelevant and propagating `PoisonError` would
+/// cascade a single legitimate failure across every downstream test.
+pub(crate) fn lock_harn_state() -> MutexGuard<'static, ()> {
+    let guard = HARN_STATE_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    for name in LEAKY_STATE_ENV_VARS {
+        std::env::remove_var(name);
+    }
+    guard
+}

--- a/crates/harn-cli/src/tests/common/mod.rs
+++ b/crates/harn-cli/src/tests/common/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod cwd_lock;
 pub(crate) mod env_lock;
+pub(crate) mod harn_state_lock;


### PR DESCRIPTION
## Summary

Unit tests in `crates/harn-cli` mutate `harn_vm` process-global state (the `HARN_STATE_DIR` env var set by `OrchestratorRole::SingleTenant::build_vm()`, the thread-local `ACTIVE_EVENT_LOG`, and the process-global trigger registry). Different test modules used different locks (`MCP_TEST_LOCK` in `mcp/serve.rs`, `REQUEST_DELAY_LOCK` in `orchestrator/listener.rs`) or no lock at all, so MCP tests and listener tests ran concurrently and collided on the SQLite event log.

- Introduce `crate::tests::common::harn_state_lock::lock_harn_state()` as a single shared, poison-recoverable guard.
- Replace the module-private locks in `mcp/serve.rs` and `orchestrator/listener.rs` with it.
- Add `lock_harn_state()` to listener tests that touch the event log without any prior lock (`webhook_first_delivery_is_appended`, `webhook_duplicate_delivery_is_dropped`) and to `trigger::replay::tests::replay_falls_back_to_recorded_timestamp_when_version_lookup_is_stale`.
- Keep the pattern of `#[allow(clippy::await_holding_lock)]` on the test modules; each test's guard is dropped when its future resolves.

## Why now

Post-v0.7.24 CI flaked in exactly this way on `main` for `ad1c66f` (Bump) and `12756111` (the PR #344 squash merge). The same test scheduling passes on PR builds because agent parallelism differs from the post-merge workload. Failures observed:

- `commands::mcp::serve::tests::dlq_tools_roundtrip_and_resource_read` first panic: "event log was not installed during VM initialization" (because `install_default_for_base_dir` silently failed with "database is locked" inside `register_store_builtins`).
- `MCP_TEST_LOCK` got poisoned, cascading `PoisonError { .. }` across 8 more MCP tests.
- `commands::orchestrator::listener::tests::reload_swaps_routes_…`, `webhook_first_delivery_is_appended`, `webhook_duplicate_delivery_is_dropped` tripped on "WAL pragma error: database is locked".

## Test plan

- [x] `cargo check -p harn-cli`
- [x] `cargo clippy -p harn-cli --tests` (clean)
- [x] `make test` (cargo nextest workspace): 1767/1767 passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)