### PR TITLE
[codex] Preserve triple-quoted string contents in harn fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,8 @@ lint-harn:
 	@echo "    Harn lint OK."
 
 # Check harn formatting on conformance tests (CI, not pre-commit).
-# Skip tests that exercise syntax the formatter intentionally normalizes
-# (triple-quoted multiline strings → single-line escaped strings).
-FMT_HARN_SKIP := multiline_strings.harn multiline_string_interpolation.harn semicolon_statements.harn semicolon_if_else_invalid.harn semicolon_try_catch_invalid.harn semicolon_empty_statement_invalid.harn
+# Skip syntax cases the formatter intentionally normalizes.
+FMT_HARN_SKIP := semicolon_statements.harn semicolon_if_else_invalid.harn semicolon_try_catch_invalid.harn semicolon_empty_statement_invalid.harn
 EXPERIMENT_HARN_CHECK := experiments/burin-mini/host.harn experiments/burin-mini/lib/common.harn experiments/burin-mini/lib/profiles.harn
 fmt-harn:
 	@echo "=== Checking Harn formatting ==="

--- a/conformance/tests/fmt/triple_quoted_preserve.harn
+++ b/conformance/tests/fmt/triple_quoted_preserve.harn
@@ -1,0 +1,17 @@
+pipeline test(task) {
+  let template = """
+// Auto-generated code - do not edit.
+pub fn {{ fn_name }}() -> dict {
+  return {}
+}
+"""
+  let name = "build"
+  let report = """
+root:
+  title: ${name}
+  nested:
+    keep: exact  
+"""
+  log(template)
+  log(report)
+}

--- a/crates/harn-fmt/src/formatter/comments.rs
+++ b/crates/harn-fmt/src/formatter/comments.rs
@@ -1,6 +1,6 @@
 use super::Formatter;
 
-impl Formatter {
+impl Formatter<'_> {
     /// Emit any comments on the given source line that haven't been emitted yet.
     ///
     /// Non-doc comments are emitted verbatim. Doc comments are coalesced with

--- a/crates/harn-fmt/src/formatter/decls.rs
+++ b/crates/harn-fmt/src/formatter/decls.rs
@@ -7,7 +7,7 @@ use crate::helpers::{
 
 use super::Formatter;
 
-impl Formatter {
+impl Formatter<'_> {
     pub(super) fn format_node(&mut self, node: &SNode) {
         let node_line = node.span.line;
         match &node.node {

--- a/crates/harn-fmt/src/formatter/expressions.rs
+++ b/crates/harn-fmt/src/formatter/expressions.rs
@@ -5,12 +5,12 @@ use crate::helpers::*;
 
 use super::Formatter;
 
-impl Formatter {
+impl Formatter<'_> {
     pub(crate) fn format_expr(&self, node: &SNode) -> String {
         match &node.node {
             Node::StringLiteral(s) => {
                 if node.span.line != node.span.end_line {
-                    format_multiline_triple_quoted(s, self.indent)
+                    self.source_slice(node).to_string()
                 } else {
                     let escaped = escape_string(s);
                     format!("\"{escaped}\"")
@@ -21,16 +21,7 @@ impl Formatter {
             }
             Node::InterpolatedString(segments) => {
                 if node.span.line != node.span.end_line {
-                    let mut body = String::new();
-                    for seg in segments {
-                        match seg {
-                            StringSegment::Literal(s) => body.push_str(s),
-                            StringSegment::Expression(e, _, _) => {
-                                body.push_str(&format!("${{{e}}}"));
-                            }
-                        }
-                    }
-                    return format_multiline_triple_quoted(&body, self.indent);
+                    return self.source_slice(node).to_string();
                 }
                 let mut result = String::from("\"");
                 for seg in segments {

--- a/crates/harn-fmt/src/formatter/mod.rs
+++ b/crates/harn-fmt/src/formatter/mod.rs
@@ -17,7 +17,8 @@ pub(crate) struct Comment {
     pub(crate) is_doc: bool,
 }
 
-pub(crate) struct Formatter {
+pub(crate) struct Formatter<'a> {
+    pub(crate) source: &'a str,
     pub(crate) output: String,
     pub(crate) indent: usize,
     pub(crate) line_width: usize,
@@ -28,13 +29,15 @@ pub(crate) struct Formatter {
     pub(crate) emitted_lines: HashSet<usize>,
 }
 
-impl Formatter {
+impl<'a> Formatter<'a> {
     pub(crate) fn new(
+        source: &'a str,
         comments: BTreeMap<usize, Vec<Comment>>,
         line_width: usize,
         separator_width: usize,
     ) -> Self {
         Self {
+            source,
             output: String::new(),
             indent: 0,
             line_width,
@@ -45,8 +48,6 @@ impl Formatter {
     }
 
     pub(crate) fn finish(mut self) -> String {
-        let trimmed: Vec<&str> = self.output.lines().map(|l| l.trim_end()).collect();
-        self.output = trimmed.join("\n");
         if !self.output.ends_with('\n') {
             self.output.push('\n');
         }
@@ -71,6 +72,10 @@ impl Formatter {
         self.write_indent();
         self.output.push_str(s);
         self.output.push('\n');
+    }
+
+    pub(crate) fn source_slice(&self, node: &SNode) -> &str {
+        &self.source[node.span.start..node.span.end]
     }
 
     /// Inner lines of a block — does NOT include opening/closing braces.

--- a/crates/harn-fmt/src/formatter/statements.rs
+++ b/crates/harn-fmt/src/formatter/statements.rs
@@ -6,7 +6,7 @@ use crate::helpers::{
 
 use super::Formatter;
 
-impl Formatter {
+impl Formatter<'_> {
     /// Hybrid context (closure / block bodies): only handles node types that
     /// need multi-line treatment different from `format_expr`.
     pub(super) fn format_expr_or_stmt(&self, node: &SNode, indent_level: usize) -> String {

--- a/crates/harn-fmt/src/helpers.rs
+++ b/crates/harn-fmt/src/helpers.rs
@@ -9,7 +9,7 @@ use crate::Formatter;
 
 /// Format a default-value expression in a destructuring pattern.
 fn format_default_expr(node: &SNode) -> String {
-    let fmt = Formatter::new(BTreeMap::new(), 100, 80);
+    let fmt = Formatter::new("", BTreeMap::new(), 100, 80);
     fmt.format_expr(node)
 }
 
@@ -179,28 +179,6 @@ pub(crate) fn escape_string(s: &str) -> String {
         .replace('\t', "\\t")
 }
 
-/// Render a multi-line `"""..."""` with body and closing delimiter indented
-/// one level deeper. The lexer strips common leading indent from the body, so
-/// re-indenting is purely aesthetic and round-trip safe.
-pub(crate) fn format_multiline_triple_quoted(body: &str, indent: usize) -> String {
-    let pad = "  ".repeat(indent + 1);
-    if body.is_empty() {
-        return format!("\"\"\"\n{pad}\"\"\"");
-    }
-    let indented: String = body
-        .split('\n')
-        .map(|l| {
-            if l.is_empty() {
-                String::new()
-            } else {
-                format!("{pad}{l}")
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    format!("\"\"\"\n{indented}\n{pad}\"\"\"")
-}
-
 /// Format the `(error_var: Type)` portion of a catch clause.
 pub(crate) fn format_catch_param(
     error_var: &Option<String>,
@@ -304,7 +282,7 @@ pub(crate) fn format_where_clauses(clauses: &[WhereClause]) -> String {
 
 /// Format an expression inline for use in parameter defaults.
 pub(crate) fn format_inline_expr(node: &SNode) -> String {
-    let fmt = Formatter::new(BTreeMap::new(), 100, 80);
+    let fmt = Formatter::new("", BTreeMap::new(), 100, 80);
     fmt.format_expr(node)
 }
 

--- a/crates/harn-fmt/src/lib.rs
+++ b/crates/harn-fmt/src/lib.rs
@@ -65,7 +65,7 @@ pub fn format_source_opts(source: &str, opts: &FmtOptions) -> Result<String, Str
     let mut parser = Parser::new(parser_tokens);
     let program = parser.parse().map_err(|e| e.to_string())?;
 
-    let mut fmt = Formatter::new(comments, opts.line_width, opts.separator_width);
+    let mut fmt = Formatter::new(source, comments, opts.line_width, opts.separator_width);
     fmt.format_program(&program);
     Ok(fmt.finish())
 }

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -1210,16 +1210,12 @@ fn test_section_header_respects_custom_separator_width() {
 }
 
 #[test]
-fn test_multiline_string_preserves_indent() {
-    let source = "pipeline test(task) {\n  let g = \"\"\"\n    hello world\n    second line\n    \"\"\"\n  log(g)\n}\n";
+fn test_multiline_string_preserves_verbatim_body() {
+    let source = "pipeline test(task) {\n  let template = \"\"\"\n// Auto-generated code - do not edit.\npub fn {{ fn_name }}() -> dict {\n  return {}\n}\n\"\"\"\n  log(template)\n}\n";
     let out = format_source(source).unwrap();
-    assert!(
-        out.contains("    hello world"),
-        "multiline string body should keep indent, got:\n{out}"
-    );
-    assert!(
-        out.contains("    \"\"\""),
-        "closing \"\"\" should be indented one level deeper than the let, got:\n{out}"
+    assert_eq!(
+        out, source,
+        "formatter should preserve triple-quoted strings verbatim"
     );
     let out2 = format_source(&out).unwrap();
     assert_eq!(
@@ -1229,12 +1225,12 @@ fn test_multiline_string_preserves_indent() {
 }
 
 #[test]
-fn test_multiline_interpolated_string_preserves_indent() {
-    let source = "pipeline test(task) {\n  let name = \"x\"\n  let g = \"\"\"\n    hi ${name}\n    \"\"\"\n  log(g)\n}\n";
+fn test_multiline_interpolated_string_preserves_verbatim_body() {
+    let source = "pipeline test(task) {\n  let name = \"x\"\n  let g = \"\"\"\n  root:\n    name: ${name}  \n    nested:\n      keep: exact\n\"\"\"\n  log(g)\n}\n";
     let out = format_source(source).unwrap();
-    assert!(
-        out.contains("    hi ${name}"),
-        "interpolated body should keep indent, got:\n{out}"
+    assert_eq!(
+        out, source,
+        "formatter should preserve interpolated triple-quoted strings verbatim"
     );
     let out2 = format_source(&out).unwrap();
     assert_eq!(out, out2, "formatter should be idempotent");


### PR DESCRIPTION
## Summary
- preserve triple-quoted string literals by emitting the original source slice for multiline string and interpolated string nodes
- stop trimming formatter output line endings in a way that mutates literal contents, and add verbatim regression coverage in `harn-fmt`
- add a `conformance/tests/fmt/triple_quoted_preserve.harn` fixture and bring the existing multiline string conformance files back under `fmt-harn`

## Why
Fixes #359. `harn fmt` was reconstructing triple-quoted literals from the parsed value, which had already been dedented by the lexer, and then re-indenting them as though they were code. That changed user-authored template/codegen content on every format run.

## Validation
- `cargo test -p harn-fmt`
- `cargo run --quiet --bin harn -- fmt --check conformance/tests/strings/multiline_strings.harn conformance/tests/strings/multiline_string_interpolation.harn conformance/tests/fmt/triple_quoted_preserve.harn`
- `target/debug/harn test conformance --filter 'strings/multiline_string'`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`, markdown lint, portal lint, highlight sync
- pre-push hook: workspace tests via nextest, `make fmt-harn`, markdown lint, portal lint

## Notes
- I attempted to spot-check the external `burin-labs/harn-openapi` repo mentioned in the issue, but the repository currently clones as empty from this environment, so that external verification was not possible here.
