### PR TITLE
[codex] Widen nil-initialized vars on first assignment

### DIFF
--- a/conformance/tests/types/var_nil_widening.expected
+++ b/conformance/tests/types/var_nil_widening.expected
@@ -1,0 +1,3 @@
+b:2
+ready
+true

--- a/conformance/tests/types/var_nil_widening.harn
+++ b/conformance/tests/types/var_nil_widening.harn
@@ -1,7 +1,6 @@
 // `var x = nil` should widen on the first concrete assignment instead of
 // pinning `x` to `nil` forever. Explicit `T | nil` annotations remain the
 // precise escape hatch when callers want to say so up front.
-
 fn first_hit() -> {name: string, score: int} | nil {
   var hit = nil
   for entry in {a: 1, b: 2}.entries() {

--- a/conformance/tests/types/var_nil_widening.harn
+++ b/conformance/tests/types/var_nil_widening.harn
@@ -1,0 +1,41 @@
+// `var x = nil` should widen on the first concrete assignment instead of
+// pinning `x` to `nil` forever. Explicit `T | nil` annotations remain the
+// precise escape hatch when callers want to say so up front.
+
+fn first_hit() -> {name: string, score: int} | nil {
+  var hit = nil
+  for entry in {a: 1, b: 2}.entries() {
+    if hit == nil && entry.value > 1 {
+      hit = {name: entry.key, score: entry.value}
+    }
+  }
+  return hit
+}
+
+fn render_hit(hit: {name: string, score: int} | nil) -> string {
+  if hit == nil {
+    return "missing"
+  }
+  return hit.name + ":" + to_string(hit.score)
+}
+
+fn widen_direct() -> string {
+  var label = nil
+  label = "ready"
+  let current: string | nil = label
+  label = nil
+  return current ?? "none"
+}
+
+fn annotated_roundtrip() -> bool {
+  var label: string | nil = nil
+  label = "set"
+  label = nil
+  return label == nil
+}
+
+pipeline default(task) {
+  println(render_hit(first_hit()))
+  println(widen_direct())
+  println(annotated_roundtrip())
+}

--- a/crates/harn-parser/src/typechecker/inference/decls.rs
+++ b/crates/harn-parser/src/typechecker/inference/decls.rs
@@ -48,6 +48,7 @@ impl TypeChecker {
         }
         for param in params {
             fn_scope.define_var(&param.name, param.type_expr.clone());
+            fn_scope.clear_nil_widenable(&param.name);
             if let Some(default) = &param.default_value {
                 self.check_node(default, &mut fn_scope);
             }

--- a/crates/harn-parser/src/typechecker/inference/entry.rs
+++ b/crates/harn-parser/src/typechecker/inference/entry.rs
@@ -82,6 +82,7 @@ impl TypeChecker {
                     let mut child = self.scope.child();
                     for p in params {
                         child.define_var(p, None);
+                        child.clear_nil_widenable(p);
                     }
                     self.fn_depth += 1;
                     let ret_scope_base = return_type.as_ref().map(|_| child.child());
@@ -132,6 +133,9 @@ impl TypeChecker {
                     }
                     for name in scope.mutable_vars {
                         self.scope.mutable_vars.insert(name);
+                    }
+                    for (name, enabled) in scope.nil_widenable_vars {
+                        self.scope.nil_widenable_vars.insert(name, enabled);
                     }
                 }
             }
@@ -212,6 +216,7 @@ impl TypeChecker {
                 }
                 Node::SkillDecl { name, .. } => {
                     scope.define_var(name, None);
+                    scope.clear_nil_widenable(name);
                 }
                 Node::LetBinding { pattern, .. } | Node::VarBinding { pattern, .. } => {
                     // Only bare-identifier patterns at module scope
@@ -221,6 +226,7 @@ impl TypeChecker {
                     if let BindingPattern::Identifier(name) = pattern {
                         if !crate::ast::is_discard_name(name) {
                             scope.define_var(name, None);
+                            scope.clear_nil_widenable(name);
                         }
                     }
                 }

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -56,6 +56,7 @@ impl TypeChecker {
             } else {
                 scope.define_var(name, None);
             }
+            scope.clear_nil_widenable(name);
         };
         match pattern {
             BindingPattern::Identifier(name) => {
@@ -101,6 +102,25 @@ impl TypeChecker {
         }
     }
 
+    fn is_nil_type(ty: &TypeExpr) -> bool {
+        matches!(ty, TypeExpr::Named(name) if name == "nil")
+    }
+
+    fn union_with_nil(ty: &TypeExpr) -> TypeExpr {
+        if Self::is_nil_type(ty) {
+            return ty.clone();
+        }
+        match ty {
+            TypeExpr::Union(members) if members.iter().any(Self::is_nil_type) => ty.clone(),
+            TypeExpr::Union(members) => {
+                let mut widened = members.clone();
+                widened.push(TypeExpr::Named("nil".into()));
+                TypeExpr::Union(widened)
+            }
+            other => TypeExpr::Union(vec![other.clone(), TypeExpr::Named("nil".into())]),
+        }
+    }
+
     pub(in crate::typechecker) fn check_node(&mut self, snode: &SNode, scope: &mut TypeScope) {
         let span = snode.span;
         match &snode.node {
@@ -142,6 +162,7 @@ impl TypeChecker {
                     }
                     let ty = type_ann.clone().or(inferred);
                     scope.define_var(name, ty);
+                    scope.clear_nil_widenable(name);
                     scope.define_schema_binding(name, schema_type_expr_from_node(value, scope));
                     // Strict types: mark variables assigned from boundary APIs
                     if self.strict_types {
@@ -194,8 +215,15 @@ impl TypeChecker {
                             }
                         }
                     }
+                    let inferred_is_nil =
+                        type_ann.is_none() && inferred.as_ref().is_some_and(Self::is_nil_type);
                     let ty = type_ann.clone().or(inferred);
                     scope.define_var_mutable(name, ty);
+                    if inferred_is_nil {
+                        scope.mark_nil_widenable(name);
+                    } else {
+                        scope.clear_nil_widenable(name);
+                    }
                     scope.define_schema_binding(name, schema_type_expr_from_node(value, scope));
                     // Strict types: mark variables assigned from boundary APIs
                     if self.strict_types {
@@ -239,6 +267,7 @@ impl TypeChecker {
                 };
                 scope.define_fn(name, sig.clone());
                 scope.define_var(name, None);
+                scope.clear_nil_widenable(name);
                 self.check_fn_decl_variance(type_params, params, return_type.as_ref(), name, span);
                 self.check_fn_body(type_params, params, return_type, body, where_clauses);
             }
@@ -265,6 +294,7 @@ impl TypeChecker {
                 };
                 scope.define_fn(name, sig);
                 scope.define_var(name, None);
+                scope.clear_nil_widenable(name);
                 self.check_fn_body(&[], params, return_type, body, &[]);
             }
 
@@ -277,6 +307,7 @@ impl TypeChecker {
                     self.check_node(value, scope);
                 }
                 scope.define_var(name, None);
+                scope.clear_nil_widenable(name);
             }
 
             Node::FunctionCall { name, args } => {
@@ -367,6 +398,7 @@ impl TypeChecker {
                         _ => None,
                     };
                     loop_scope.define_var(variable, elem_type);
+                    loop_scope.clear_nil_widenable(variable);
                 } else if let BindingPattern::Pair(a, b) = pattern {
                     // Pair destructuring: `for (k, v) in iter` — extract K, V
                     // from the yielded Pair<K, V>.
@@ -399,6 +431,8 @@ impl TypeChecker {
                     };
                     loop_scope.define_var(a, ka);
                     loop_scope.define_var(b, vb);
+                    loop_scope.clear_nil_widenable(a);
+                    loop_scope.clear_nil_widenable(b);
                 } else {
                     self.check_pattern_defaults(pattern, &mut loop_scope);
                     Self::define_pattern_vars(pattern, &mut loop_scope, false);
@@ -434,6 +468,7 @@ impl TypeChecker {
                 let mut catch_scope = scope.child();
                 if let Some(var) = error_var {
                     catch_scope.define_var(var, error_type.clone());
+                    catch_scope.clear_nil_widenable(var);
                 }
                 self.check_block(catch_body, &mut catch_scope);
                 if let Some(fb) = finally_body {
@@ -468,6 +503,7 @@ impl TypeChecker {
             } => {
                 self.check_node(value, scope);
                 if let Node::Identifier(name) = &target.node {
+                    let mut widened_slot_type: Option<TypeExpr> = None;
                     // Compile-time immutability check
                     if scope.get_var(name).is_some() && !scope.is_mutable(name) {
                         self.warning_at(
@@ -495,22 +531,38 @@ impl TypeChecker {
                                 .and_then(|t| t.as_ref())
                                 .unwrap_or(var_type);
                             if !self.types_compatible(check_type, actual, scope) {
-                                self.error_at(
-                                    format!(
-                                        "can't assign {} to '{}' (declared as {})",
-                                        format_type(actual),
-                                        name,
-                                        format_type(check_type)
-                                    ),
-                                    span,
-                                );
+                                if scope.is_mutable(name)
+                                    && scope.is_nil_widenable(name)
+                                    && Self::is_nil_type(check_type)
+                                    && !Self::is_nil_type(actual)
+                                {
+                                    widened_slot_type = Some(Self::union_with_nil(actual));
+                                } else {
+                                    self.error_at(
+                                        format!(
+                                            "can't assign {} to '{}' (declared as {})",
+                                            format_type(actual),
+                                            name,
+                                            format_type(check_type)
+                                        ),
+                                        span,
+                                    );
+                                }
                             }
                         }
                     }
 
                     // Invalidate narrowing on reassignment: restore original type
                     if let Some(original) = scope.narrowed_vars.remove(name) {
-                        scope.define_var(name, original);
+                        if let Some(widened) = widened_slot_type.as_ref() {
+                            scope.define_var(name, Some(widened.clone()));
+                        } else {
+                            scope.define_var(name, original);
+                        }
+                    }
+                    if let Some(widened) = widened_slot_type {
+                        scope.define_var(name, Some(widened));
+                        scope.clear_nil_widenable(name);
                     }
                     scope.define_schema_binding(name, None);
                     scope.clear_unknown_ruled_out(name);
@@ -1025,6 +1077,7 @@ impl TypeChecker {
                         }
                     };
                     par_scope.define_var(var, var_type);
+                    par_scope.clear_nil_widenable(var);
                 }
                 self.check_block(body, &mut par_scope);
             }
@@ -1038,6 +1091,7 @@ impl TypeChecker {
                     self.check_node(&case.channel, scope);
                     let mut case_scope = scope.child();
                     case_scope.define_var(&case.variable, None);
+                    case_scope.clear_nil_widenable(&case.variable);
                     self.check_block(&case.body, &mut case_scope);
                 }
                 if let Some((dur, body)) = timeout {
@@ -1072,6 +1126,7 @@ impl TypeChecker {
                 let mut closure_scope = scope.child();
                 for p in params {
                     closure_scope.define_var(&p.name, p.type_expr.clone());
+                    closure_scope.clear_nil_widenable(&p.name);
                 }
                 self.fn_depth += 1;
                 self.check_block(body, &mut closure_scope);

--- a/crates/harn-parser/src/typechecker/scope.rs
+++ b/crates/harn-parser/src/typechecker/scope.rs
@@ -99,6 +99,10 @@ pub(super) struct TypeScope {
     /// Variables that have been narrowed by flow-sensitive refinement.
     /// Maps var name → pre-narrowing type (used to restore on reassignment).
     pub(super) narrowed_vars: BTreeMap<String, InferredType>,
+    /// Mutable vars declared as unannotated `var x = nil`. A local `false`
+    /// entry shadows a parent widenable marker after a new declaration or
+    /// after the first successful widening assignment.
+    pub(super) nil_widenable_vars: BTreeMap<String, bool>,
     /// Schema literals bound to variables, reduced to a TypeExpr subset so
     /// `schema_is(x, some_schema)` can participate in flow refinement.
     pub(super) schema_bindings: BTreeMap<String, InferredType>,
@@ -153,6 +157,7 @@ impl TypeScope {
             where_constraints: BTreeMap::new(),
             mutable_vars: std::collections::BTreeSet::new(),
             narrowed_vars: BTreeMap::new(),
+            nil_widenable_vars: BTreeMap::new(),
             schema_bindings: BTreeMap::new(),
             untyped_sources: BTreeMap::new(),
             unknown_ruled_out: BTreeMap::new(),
@@ -209,6 +214,7 @@ impl TypeScope {
             where_constraints: BTreeMap::new(),
             mutable_vars: std::collections::BTreeSet::new(),
             narrowed_vars: BTreeMap::new(),
+            nil_widenable_vars: BTreeMap::new(),
             schema_bindings: BTreeMap::new(),
             untyped_sources: BTreeMap::new(),
             unknown_ruled_out: BTreeMap::new(),
@@ -390,6 +396,29 @@ impl TypeScope {
         }
         self.vars.insert(name.to_string(), ty);
         self.mutable_vars.insert(name.to_string());
+    }
+
+    pub(super) fn mark_nil_widenable(&mut self, name: &str) {
+        if is_discard_name(name) {
+            return;
+        }
+        self.nil_widenable_vars.insert(name.to_string(), true);
+    }
+
+    pub(super) fn clear_nil_widenable(&mut self, name: &str) {
+        if is_discard_name(name) {
+            return;
+        }
+        self.nil_widenable_vars.insert(name.to_string(), false);
+    }
+
+    pub(super) fn is_nil_widenable(&self, name: &str) -> bool {
+        if let Some(enabled) = self.nil_widenable_vars.get(name) {
+            return *enabled;
+        }
+        self.parent
+            .as_ref()
+            .is_some_and(|p| p.is_nil_widenable(name))
     }
 
     pub(super) fn define_schema_binding(&mut self, name: &str, ty: InferredType) {

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -61,6 +61,56 @@ fn test_union_type_mismatch() {
 }
 
 #[test]
+fn test_var_nil_widens_on_first_concrete_assignment() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  var hit = nil
+  hit = {name: "b", score: 2}
+  let widened: {name: string, score: int} | nil = hit
+  hit = nil
+}"#,
+    );
+    assert!(errs.is_empty(), "unexpected type errors: {errs:?}");
+}
+
+#[test]
+fn test_var_nil_widens_inside_nil_guard() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  var hit = nil
+  if hit == nil {
+    hit = {name: "b", score: 2}
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "unexpected type errors: {errs:?}");
+}
+
+#[test]
+fn test_explicit_nullable_var_annotation_still_accepts_nil_and_concrete() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  var hit: {name: string, score: int} | nil = nil
+  hit = {name: "b", score: 2}
+  hit = nil
+}"#,
+    );
+    assert!(errs.is_empty(), "unexpected type errors: {errs:?}");
+}
+
+#[test]
+fn test_explicit_nil_var_does_not_widen() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  var hit: nil = nil
+  hit = {name: "b", score: 2}
+}"#,
+    );
+    assert_eq!(errs.len(), 1, "expected 1 error, got: {errs:?}");
+    assert!(errs[0].contains("declared as nil"), "got: {}", errs[0]);
+}
+
+#[test]
 fn test_type_inference_propagation() {
     let errs = errors(
         r#"pipeline t(task) {

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -634,6 +634,10 @@ Returns `nil` (which becomes `.nilValue`) if not found anywhere.
 
 - `let name = value` -- defines `name` as immutable in the current scope.
 - `var name = value` -- defines `name` as mutable in the current scope.
+- `var name = nil` -- leaves `name` widenable until the first non-`nil`
+  assignment, which fixes the slot to `T | nil`. The explicit form
+  `var name: T | nil = nil` remains valid when you want to pin `T`
+  up front.
 - `let _ = value` / `var _ = value` -- evaluate `value` and discard it
   without introducing a variable into scope. `_` can be reused any number
   of times in the same scope.

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -632,6 +632,10 @@ Returns `nil` (which becomes `.nilValue`) if not found anywhere.
 
 - `let name = value` -- defines `name` as immutable in the current scope.
 - `var name = value` -- defines `name` as mutable in the current scope.
+- `var name = nil` -- leaves `name` widenable until the first non-`nil`
+  assignment, which fixes the slot to `T | nil`. The explicit form
+  `var name: T | nil = nil` remains valid when you want to pin `T`
+  up front.
 - `let _ = value` / `var _ = value` -- evaluate `value` and discard it
   without introducing a variable into scope. `_` can be reused any number
   of times in the same scope.


### PR DESCRIPTION
## Summary
- widen unannotated `var x = nil` slots on the first non-nil assignment to `T | nil`
- preserve explicit `T | nil` annotations and keep explicit `nil`-typed vars fixed to `nil`
- add parser/unit/conformance coverage and document the behavior in the language spec

## Why
Fixes #358. The typechecker previously pinned `var x = nil` to `nil`, which broke common "find the first matching item" loops.

## Validation
- env CARGO_TARGET_DIR=/tmp/harn-2762-target cargo test -p harn-parser
- env CARGO_TARGET_DIR=/tmp/harn-2762-target cargo run --quiet --bin harn -- test conformance --filter var_nil_widening
- pre-push hook (workspace tests via nextest, Harn fmt, markdown lint, portal lint)
