### PR TITLE
[codex] Add trust_query limit and trace grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ granular archaeology.
   leaking byte positions through timing. Covered by RFC 4231 and
   GitHub's documented webhook test vectors.
 
+- **`trust_query(filters)` now supports `limit` and `grouped_by_trace`
+  (#338).** Trust-graph queries can now cap results to the newest N
+  matching records server-side and optionally return
+  `{trace_id, records}` buckets for timeline UIs that need bounded
+  polling without regrouping the full history client-side. The same
+  filters are now wired through the stdlib builtin, `harn trust query`,
+  and `harn mcp serve`'s `harn.trust.query` tool.
+
 ### Fixed
 
 - **Orchestrator no longer SIGTERM-races under parallel test load

--- a/conformance/tests/trust_graph/trust_query_limit_and_group_by_trace.expected
+++ b/conformance/tests/trust_graph/trust_query_limit_and_group_by_trace.expected
@@ -1,0 +1,9 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/trust_graph/trust_query_limit_and_group_by_trace.harn
+++ b/conformance/tests/trust_graph/trust_query_limit_and_group_by_trace.harn
@@ -1,0 +1,50 @@
+import "std/triggers"
+
+pipeline test(task) {
+  let unique = to_string(to_int(timestamp())) + "-" + to_string(random_int(100000, 999999))
+  let agent_id = "trust-grouped-" + unique
+  let handle: TriggerHandle = trigger_register(
+    {
+      id: agent_id,
+      kind: "issue.opened",
+      provider: "github",
+      autonomy_tier: "act_auto",
+      handler: { event ->
+        let _ = trust_record(agent_id, "audit.note", nil, "success", "suggest")
+        return handler_context()
+      },
+      when: nil,
+      retry: nil,
+      match: {events: ["issue.opened"]},
+      events: nil,
+      dedupe_key: nil,
+      filter: nil,
+      budget: nil,
+      manifest_path: "runtime://trust-graph",
+      package_name: "conformance",
+    },
+  )
+
+  let first: DispatchHandle = trigger_fire(
+    handle,
+    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-a-" + unique}},
+  )
+  let second: DispatchHandle = trigger_fire(
+    handle,
+    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-b-" + unique}},
+  )
+
+  let flat: list<TrustRecord> = trust_query({agent: agent_id, limit: 2})
+  let grouped: list<TrustTraceGroup> =
+    trust_query({agent: agent_id, limit: 2, grouped_by_trace: true})
+
+  println(first.status == "dispatched")
+  println(second.status == "dispatched")
+  println(len(flat) == 2)
+  println(flat[0].action == "audit.note")
+  println(flat[1].action == "github.issue.opened")
+  println(len(grouped) == 1)
+  println(grouped[0].trace_id == second.result?.trace_id)
+  println(len(grouped[0].records) == 2)
+  println(grouped[0].records[0].trace_id == grouped[0].records[1].trace_id)
+}

--- a/conformance/tests/trust_graph/trust_query_limit_and_group_by_trace.harn
+++ b/conformance/tests/trust_graph/trust_query_limit_and_group_by_trace.harn
@@ -5,26 +5,25 @@ pipeline test(task) {
   let agent_id = "trust-grouped-" + unique
   let handle: TriggerHandle = trigger_register(
     {
-      id: agent_id,
-      kind: "issue.opened",
-      provider: "github",
-      autonomy_tier: "act_auto",
-      handler: { event ->
-        let _ = trust_record(agent_id, "audit.note", nil, "success", "suggest")
-        return handler_context()
-      },
-      when: nil,
-      retry: nil,
-      match: {events: ["issue.opened"]},
-      events: nil,
-      dedupe_key: nil,
-      filter: nil,
-      budget: nil,
-      manifest_path: "runtime://trust-graph",
-      package_name: "conformance",
-    },
+    id: agent_id,
+    kind: "issue.opened",
+    provider: "github",
+    autonomy_tier: "act_auto",
+    handler: { event ->
+    let _ = trust_record(agent_id, "audit.note", nil, "success", "suggest")
+    return handler_context()
+  },
+    when: nil,
+    retry: nil,
+    match: {events: ["issue.opened"]},
+    events: nil,
+    dedupe_key: nil,
+    filter: nil,
+    budget: nil,
+    manifest_path: "runtime://trust-graph",
+    package_name: "conformance",
+  },
   )
-
   let first: DispatchHandle = trigger_fire(
     handle,
     {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-a-" + unique}},
@@ -33,11 +32,8 @@ pipeline test(task) {
     handle,
     {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-b-" + unique}},
   )
-
   let flat: list<TrustRecord> = trust_query({agent: agent_id, limit: 2})
-  let grouped: list<TrustTraceGroup> =
-    trust_query({agent: agent_id, limit: 2, grouped_by_trace: true})
-
+  let grouped: list<TrustTraceGroup> = trust_query({agent: agent_id, limit: 2, grouped_by_trace: true})
   println(first.status == "dispatched")
   println(second.status == "dispatched")
   println(len(flat) == 2)

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -682,6 +682,12 @@ pub(crate) struct TrustQueryArgs {
     /// Filter by trust outcome.
     #[arg(long, value_enum)]
     pub outcome: Option<TrustOutcomeArg>,
+    /// Limit results to the newest N matching records.
+    #[arg(long)]
+    pub limit: Option<usize>,
+    /// Group results into trace buckets instead of returning a flat list.
+    #[arg(long)]
+    pub grouped_by_trace: bool,
     /// Emit JSON instead of human-readable output.
     #[arg(long)]
     pub json: bool,
@@ -1469,6 +1475,9 @@ mod tests {
             "act-auto",
             "--outcome",
             "success",
+            "--limit",
+            "500",
+            "--grouped-by-trace",
             "--json",
             "--summary",
         ]);
@@ -1485,6 +1494,8 @@ mod tests {
         assert_eq!(query.until.as_deref(), Some("2026-04-19T19:00:00Z"));
         assert!(matches!(query.tier, Some(TrustTierArg::ActAuto)));
         assert!(matches!(query.outcome, Some(TrustOutcomeArg::Success)));
+        assert_eq!(query.limit, Some(500));
+        assert!(query.grouped_by_trace);
         assert!(query.json);
         assert!(query.summary);
     }

--- a/crates/harn-cli/src/commands/mcp/serve.rs
+++ b/crates/harn-cli/src/commands/mcp/serve.rs
@@ -14,6 +14,7 @@ use futures::channel::mpsc::{unbounded, UnboundedSender};
 use futures::{stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
+use time::OffsetDateTime;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
@@ -195,7 +196,21 @@ struct SecretScanRequest {
 #[derive(Clone, Debug, Deserialize)]
 struct TrustQueryRequest {
     #[serde(default)]
-    query: Option<String>,
+    agent: Option<String>,
+    #[serde(default)]
+    action: Option<String>,
+    #[serde(default)]
+    since: Option<String>,
+    #[serde(default)]
+    until: Option<String>,
+    #[serde(default)]
+    tier: Option<harn_vm::AutonomyTier>,
+    #[serde(default)]
+    outcome: Option<harn_vm::TrustOutcome>,
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    grouped_by_trace: bool,
 }
 
 pub(crate) async fn run(args: &McpServeArgs) -> Result<(), String> {
@@ -452,18 +467,32 @@ impl McpOrchestratorService {
                     ),
                     tool_def(
                         "harn.trust.query",
-                        "Reserved trust-graph query surface. Returns an empty result set for now.",
+                        "Query trust-graph records with the same filters exposed by trust_query(filters).",
                         json!({
                             "type": "object",
                             "properties": {
-                                "query": { "type": "string" }
+                                "agent": { "type": "string" },
+                                "action": { "type": "string" },
+                                "since": { "type": "string" },
+                                "until": { "type": "string" },
+                                "tier": {
+                                    "type": "string",
+                                    "enum": ["shadow", "suggest", "act_with_approval", "act_auto"]
+                                },
+                                "outcome": {
+                                    "type": "string",
+                                    "enum": ["success", "failure", "denied", "timeout"]
+                                },
+                                "limit": { "type": "integer", "minimum": 0 },
+                                "grouped_by_trace": { "type": "boolean" }
                             },
                             "additionalProperties": false,
                         }),
                         Some(json!({
                             "type": "object",
-                            "required": ["results"],
+                            "required": ["grouped_by_trace", "results"],
                             "properties": {
+                                "grouped_by_trace": { "type": "boolean" },
                                 "results": { "type": "array" },
                             },
                         })),
@@ -738,8 +767,39 @@ impl McpOrchestratorService {
 
     async fn tool_trust_query(&self, arguments: JsonValue) -> Result<JsonValue, String> {
         let request: TrustQueryRequest =
-            serde_json::from_value(arguments).unwrap_or(TrustQueryRequest { query: None });
-        Ok(json!({ "query": request.query, "results": [] }))
+            serde_json::from_value(arguments).map_err(|error| error.to_string())?;
+        let filters = harn_vm::TrustQueryFilters {
+            agent: request.agent,
+            action: request.action,
+            since: request
+                .since
+                .as_deref()
+                .map(parse_trust_query_timestamp)
+                .transpose()?,
+            until: request
+                .until
+                .as_deref()
+                .map(parse_trust_query_timestamp)
+                .transpose()?,
+            tier: request.tier,
+            outcome: request.outcome,
+            limit: request.limit,
+            grouped_by_trace: request.grouped_by_trace,
+        };
+        let ctx = load_local_runtime(&self.local_args()).await?;
+        let records = harn_vm::query_trust_records(&ctx.event_log, &filters)
+            .await
+            .map_err(|error| error.to_string())?;
+        let results = if filters.grouped_by_trace {
+            serde_json::to_value(harn_vm::group_trust_records_by_trace(&records))
+                .map_err(|error| error.to_string())?
+        } else {
+            serde_json::to_value(records).map_err(|error| error.to_string())?
+        };
+        Ok(json!({
+            "grouped_by_trace": filters.grouped_by_trace,
+            "results": results,
+        }))
     }
 
     async fn list_resources(&self) -> Result<Vec<JsonValue>, String> {
@@ -917,6 +977,23 @@ impl McpOrchestratorService {
             .map(|_| ())
             .map_err(|error| error.to_string())
     }
+}
+
+fn parse_trust_query_timestamp(raw: &str) -> Result<OffsetDateTime, String> {
+    if let Ok(parsed) = OffsetDateTime::parse(raw, &time::format_description::well_known::Rfc3339) {
+        return Ok(parsed);
+    }
+    if let Ok(unix) = raw.parse::<i64>() {
+        let parsed = if raw.len() > 10 {
+            OffsetDateTime::from_unix_timestamp_nanos(unix as i128 * 1_000_000)
+        } else {
+            OffsetDateTime::from_unix_timestamp(unix)
+        };
+        return parsed.map_err(|error| format!("invalid timestamp '{raw}': {error}"));
+    }
+    Err(format!(
+        "invalid timestamp '{raw}': expected RFC3339 or unix seconds/milliseconds"
+    ))
 }
 
 async fn run_stdio(service: Arc<McpOrchestratorService>) -> Result<(), String> {
@@ -1798,22 +1875,69 @@ pub fn on_fail(event: TriggerEvent) -> any {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn trust_query_returns_empty_results() {
+    async fn trust_query_returns_filtered_trace_groups() {
         let _guard = lock_harn_state();
         let temp = TempDir::new().unwrap();
         write_fixture(&temp);
         let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
         let mut session = init_session(&service).await;
 
+        let ctx = load_local_runtime(&service.local_args()).await.unwrap();
+        harn_vm::append_trust_record(
+            &ctx.event_log,
+            &harn_vm::TrustRecord::new(
+                "ide-bot",
+                "issue.opened",
+                None,
+                harn_vm::TrustOutcome::Success,
+                "trace-1",
+                harn_vm::AutonomyTier::ActAuto,
+            ),
+        )
+        .await
+        .unwrap();
+        harn_vm::append_trust_record(
+            &ctx.event_log,
+            &harn_vm::TrustRecord::new(
+                "ide-bot",
+                "issue.closed",
+                None,
+                harn_vm::TrustOutcome::Success,
+                "trace-2",
+                harn_vm::AutonomyTier::ActAuto,
+            ),
+        )
+        .await
+        .unwrap();
+        harn_vm::append_trust_record(
+            &ctx.event_log,
+            &harn_vm::TrustRecord::new(
+                "ide-bot",
+                "issue.commented",
+                None,
+                harn_vm::TrustOutcome::Failure,
+                "trace-2",
+                harn_vm::AutonomyTier::ActAuto,
+            ),
+        )
+        .await
+        .unwrap();
+
         let result = call_tool(
             &service,
             &mut session,
             "harn.trust.query",
-            json!({ "query": "anything" }),
+            json!({
+                "agent": "ide-bot",
+                "grouped_by_trace": true,
+                "limit": 2
+            }),
         )
         .await;
-        assert_eq!(result["results"], json!([]));
-        assert_eq!(result["query"], "anything");
+        assert_eq!(result["grouped_by_trace"], json!(true));
+        assert_eq!(result["results"].as_array().unwrap().len(), 1);
+        assert_eq!(result["results"][0]["trace_id"], "trace-2");
+        assert_eq!(result["results"][0]["records"].as_array().unwrap().len(), 2);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-cli/src/commands/trust.rs
+++ b/crates/harn-cli/src/commands/trust.rs
@@ -17,6 +17,9 @@ pub(crate) async fn handle(args: TrustArgs) -> Result<(), String> {
 }
 
 async fn run_query(args: TrustQueryArgs) -> Result<(), String> {
+    if args.summary && args.grouped_by_trace {
+        return Err("--grouped-by-trace cannot be combined with --summary".to_string());
+    }
     let log = open_trust_log()?;
     let filters = harn_vm::TrustQueryFilters {
         agent: args.agent,
@@ -25,6 +28,8 @@ async fn run_query(args: TrustQueryArgs) -> Result<(), String> {
         until: args.until.as_deref().map(parse_timestamp).transpose()?,
         tier: args.tier.map(Into::into),
         outcome: args.outcome.map(Into::into),
+        limit: args.limit,
+        grouped_by_trace: args.grouped_by_trace,
     };
     let records = harn_vm::query_trust_records(&log, &filters)
         .await
@@ -58,10 +63,36 @@ async fn run_query(args: TrustQueryArgs) -> Result<(), String> {
     }
 
     if args.json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&records).map_err(|error| error.to_string())?
-        );
+        if args.grouped_by_trace {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&harn_vm::group_trust_records_by_trace(&records))
+                    .map_err(|error| error.to_string())?
+            );
+        } else {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&records).map_err(|error| error.to_string())?
+            );
+        }
+        return Ok(());
+    }
+
+    if args.grouped_by_trace {
+        for group in harn_vm::group_trust_records_by_trace(&records) {
+            println!("trace_id={} count={}", group.trace_id, group.records.len());
+            for record in group.records {
+                println!(
+                    "  {} agent={} action={} outcome={} tier={} approver={}",
+                    format_timestamp(record.timestamp),
+                    record.agent,
+                    record.action,
+                    record.outcome.as_str(),
+                    record.autonomy_tier.as_str(),
+                    record.approver.unwrap_or_else(|| "-".to_string()),
+                );
+            }
+        }
         return Ok(());
     }
 

--- a/crates/harn-cli/tests/mcp_server_cli.rs
+++ b/crates/harn-cli/tests/mcp_server_cli.rs
@@ -347,11 +347,21 @@ fn mcp_server_stdio_roundtrips_tools_and_resources() {
             "method": "tools/call",
             "params": {
                 "name": "harn.trust.query",
-                "arguments": { "query": "test" }
+                "arguments": { "agent": "cron-ok", "limit": 2 }
             }
         }),
     );
-    assert_eq!(trust["result"]["structuredContent"]["results"], json!([]));
+    assert_eq!(
+        trust["result"]["structuredContent"]["grouped_by_trace"],
+        json!(false)
+    );
+    let trust_results = trust["result"]["structuredContent"]["results"]
+        .as_array()
+        .unwrap();
+    assert_eq!(trust_results.len(), 2);
+    assert!(trust_results
+        .iter()
+        .all(|record| record["agent"] == json!("cron-ok")));
 
     let manifest = send_request(
         &mut stdin,

--- a/crates/harn-parser/src/builtin_signatures/generics.rs
+++ b/crates/harn-parser/src/builtin_signatures/generics.rs
@@ -417,7 +417,7 @@ fn trust_query_builtin_sig() -> BuiltinGenericSig {
             TypeExpr::Named("TrustQueryFilters".into()),
             TypeExpr::Named("nil".into()),
         ])],
-        return_type: TypeExpr::List(Box::new(TypeExpr::Named("TrustRecord".into()))),
+        return_type: TypeExpr::Named("list".into()),
     }
 }
 

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -120,10 +120,10 @@ pub use triggers::{
     TRIGGER_TEST_FIXTURES, WORKER_QUEUE_CATALOG_TOPIC,
 };
 pub use trust_graph::{
-    append_active_trust_record, append_trust_record, query_trust_records,
-    resolve_agent_autonomy_tier, summarize_trust_records, topic_for_agent, AutonomyTier,
-    TrustAgentSummary, TrustOutcome, TrustQueryFilters, TrustRecord, OPENTRUSTGRAPH_SCHEMA_V0,
-    TRUST_GRAPH_GLOBAL_TOPIC, TRUST_GRAPH_TOPIC_PREFIX,
+    append_active_trust_record, append_trust_record, group_trust_records_by_trace,
+    query_trust_records, resolve_agent_autonomy_tier, summarize_trust_records, topic_for_agent,
+    AutonomyTier, TrustAgentSummary, TrustOutcome, TrustQueryFilters, TrustRecord, TrustTraceGroup,
+    OPENTRUSTGRAPH_SCHEMA_V0, TRUST_GRAPH_GLOBAL_TOPIC, TRUST_GRAPH_TOPIC_PREFIX,
 };
 pub use value::*;
 pub use vm::*;

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -19,7 +19,8 @@ use crate::triggers::{
     TRIGGERS_LIFECYCLE_TOPIC, TRIGGER_DLQ_TOPIC,
 };
 use crate::trust_graph::{
-    query_trust_records, AutonomyTier, TrustOutcome, TrustQueryFilters, TrustRecord,
+    group_trust_records_by_trace, query_trust_records, AutonomyTier, TrustOutcome,
+    TrustQueryFilters, TrustRecord,
 };
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
@@ -219,6 +220,9 @@ pub(crate) fn register_trigger_builtins(vm: &mut Vm) {
         let records = query_trust_records(&log, &filters)
             .await
             .map_err(|error| VmError::Runtime(format!("trust_query: {error}")))?;
+        if filters.grouped_by_trace {
+            return Ok(value_from_serde(&group_trust_records_by_trace(&records)));
+        }
         Ok(VmValue::List(Rc::new(
             records
                 .into_iter()
@@ -900,7 +904,37 @@ fn parse_trust_query_filters(value: &VmValue) -> Result<TrustQueryFilters, VmErr
             .transpose()?,
         tier: map.get("tier").map(parse_autonomy_tier).transpose()?,
         outcome: map.get("outcome").map(parse_trust_outcome).transpose()?,
+        limit: map.get("limit").map(parse_trust_query_limit).transpose()?,
+        grouped_by_trace: map
+            .get("grouped_by_trace")
+            .map(parse_trust_query_grouped_flag)
+            .transpose()?
+            .unwrap_or(false),
     })
+}
+
+fn parse_trust_query_limit(value: &VmValue) -> Result<usize, VmError> {
+    let limit = value.as_int().ok_or_else(|| {
+        VmError::Runtime(format!(
+            "trust_query: limit must be an int, got {}",
+            value.type_name()
+        ))
+    })?;
+    usize::try_from(limit).map_err(|_| {
+        VmError::Runtime(format!(
+            "trust_query: limit must be non-negative, got {limit}"
+        ))
+    })
+}
+
+fn parse_trust_query_grouped_flag(value: &VmValue) -> Result<bool, VmError> {
+    match value {
+        VmValue::Bool(flag) => Ok(*flag),
+        other => Err(VmError::Runtime(format!(
+            "trust_query: grouped_by_trace must be a bool, got {}",
+            other.type_name()
+        ))),
+    }
 }
 
 fn parse_query_timestamp(builtin: &str, field: &str, raw: &str) -> Result<OffsetDateTime, VmError> {

--- a/crates/harn-vm/src/stdlib_triggers.harn
+++ b/crates/harn-vm/src/stdlib_triggers.harn
@@ -173,7 +173,9 @@ type DlqEntry = {id: string, event_id: string, binding_id: string, binding_versi
 
 type TrustRecord = {schema: string, record_id: string, agent: string, action: string, approver: string | nil, outcome: TrustOutcome, trace_id: string, autonomy_tier: AutonomyTier, timestamp: string, cost_usd: float | nil, metadata: dict}
 
-type TrustQueryFilters = {agent: string | nil, action: string | nil, since: string | nil, until: string | nil, tier: AutonomyTier | nil, outcome: TrustOutcome | nil}
+type TrustTraceGroup = {trace_id: string, records: list<TrustRecord>}
+
+type TrustQueryFilters = {agent: string | nil, action: string | nil, since: string | nil, until: string | nil, tier: AutonomyTier | nil, outcome: TrustOutcome | nil, limit: int | nil, grouped_by_trace: bool | nil}
 
 type HandlerContext = {agent: string, action: string, trace_id: string, replay_of_event_id: string | nil, autonomy_tier: AutonomyTier, trigger_event: TriggerEvent}
 

--- a/crates/harn-vm/src/trust_graph.rs
+++ b/crates/harn-vm/src/trust_graph.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -107,6 +107,15 @@ pub struct TrustQueryFilters {
     pub until: Option<OffsetDateTime>,
     pub tier: Option<AutonomyTier>,
     pub outcome: Option<TrustOutcome>,
+    pub limit: Option<usize>,
+    pub grouped_by_trace: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TrustTraceGroup {
+    pub trace_id: String,
+    pub records: Vec<TrustRecord>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -162,7 +171,8 @@ pub async fn query_trust_records(
     log: &Arc<AnyEventLog>,
     filters: &TrustQueryFilters,
 ) -> Result<Vec<TrustRecord>, LogError> {
-    let events = log.read_range(&global_topic()?, None, usize::MAX).await?;
+    let topic = query_topic(filters)?;
+    let events = log.read_range(&topic, None, usize::MAX).await?;
     let mut records = Vec::new();
     for (_, event) in events {
         if event.kind != "trust_recorded" {
@@ -182,7 +192,25 @@ pub async fn query_trust_records(
             .then(left.agent.cmp(&right.agent))
             .then(left.record_id.cmp(&right.record_id))
     });
+    apply_record_limit(&mut records, filters.limit);
     Ok(records)
+}
+
+pub fn group_trust_records_by_trace(records: &[TrustRecord]) -> Vec<TrustTraceGroup> {
+    let mut groups: Vec<TrustTraceGroup> = Vec::new();
+    let mut positions: HashMap<String, usize> = HashMap::new();
+    for record in records {
+        if let Some(index) = positions.get(record.trace_id.as_str()).copied() {
+            groups[index].records.push(record.clone());
+            continue;
+        }
+        positions.insert(record.trace_id.clone(), groups.len());
+        groups.push(TrustTraceGroup {
+            trace_id: record.trace_id.clone(),
+            records: vec![record.clone()],
+        });
+    }
+    groups
 }
 
 pub fn summarize_trust_records(records: &[TrustRecord]) -> Vec<TrustAgentSummary> {
@@ -293,10 +321,29 @@ fn matches_filters(record: &TrustRecord, filters: &TrustQueryFilters) -> bool {
     true
 }
 
+fn query_topic(filters: &TrustQueryFilters) -> Result<Topic, LogError> {
+    match filters.agent.as_deref() {
+        Some(agent) => topic_for_agent(agent),
+        None => global_topic(),
+    }
+}
+
+fn apply_record_limit(records: &mut Vec<TrustRecord>, limit: Option<usize>) {
+    let Some(limit) = limit else {
+        return;
+    };
+    if records.len() <= limit {
+        return;
+    }
+    let keep_from = records.len() - limit;
+    records.drain(0..keep_from);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::event_log::MemoryEventLog;
+    use time::Duration;
 
     #[tokio::test]
     async fn append_and_query_round_trip() {
@@ -361,5 +408,65 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(tier, AutonomyTier::Shadow);
+    }
+
+    #[tokio::test]
+    async fn query_limit_keeps_newest_matching_records() {
+        let log: Arc<AnyEventLog> = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(16)));
+        let base = OffsetDateTime::now_utc();
+        for (offset, action) in ["first", "second", "third"].into_iter().enumerate() {
+            let mut record = TrustRecord::new(
+                "bot",
+                action,
+                None,
+                TrustOutcome::Success,
+                format!("trace-{action}"),
+                AutonomyTier::ActAuto,
+            );
+            record.timestamp = base + Duration::seconds(offset as i64);
+            append_trust_record(&log, &record).await.unwrap();
+        }
+
+        let records = query_trust_records(
+            &log,
+            &TrustQueryFilters {
+                agent: Some("bot".to_string()),
+                limit: Some(2),
+                ..TrustQueryFilters::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].action, "second");
+        assert_eq!(records[1].action, "third");
+    }
+
+    #[test]
+    fn group_by_trace_preserves_chronological_group_order() {
+        let make_record = |trace_id: &str, action: &str| TrustRecord {
+            trace_id: trace_id.to_string(),
+            action: action.to_string(),
+            ..TrustRecord::new(
+                "bot",
+                action,
+                None,
+                TrustOutcome::Success,
+                trace_id,
+                AutonomyTier::ActAuto,
+            )
+        };
+        let grouped = group_trust_records_by_trace(&[
+            make_record("trace-1", "first"),
+            make_record("trace-2", "second"),
+            make_record("trace-1", "third"),
+        ]);
+
+        assert_eq!(grouped.len(), 2);
+        assert_eq!(grouped[0].trace_id, "trace-1");
+        assert_eq!(grouped[0].records.len(), 2);
+        assert_eq!(grouped[0].records[1].action, "third");
+        assert_eq!(grouped[1].trace_id, "trace-2");
     }
 }

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -878,7 +878,8 @@ Trust-graph helpers also live in `std/triggers`:
 - `handler_context()` returns the active trigger dispatch context or `nil`.
 - `trust_record(agent, action, approver, outcome, tier)` appends a manual
   trust record.
-- `trust_query(filters)` queries historical trust records.
+- `trust_query(filters)` queries historical trust records, including
+  `limit` and `grouped_by_trace`.
 - `TriggerConfig.autonomy_tier` and manifest `[[triggers]].autonomy_tier`
   accept `shadow | suggest | act_with_approval | act_auto`.
 - `harn trust query`, `harn trust promote`, and `harn trust demote` expose the

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -761,7 +761,7 @@ See [LLM calls and agent loops](llm-and-agents.md) for full documentation.
 | `trigger_test_harness(fixture)` | fixture: string or `{fixture: string}` | dict | Run a named trigger-system harness fixture and return a structured report. Intended for Rust/unit/conformance coverage of cron, webhook, retry, DLQ, dedupe, rate-limit, cost-guard, recovery, and dead-man-switch scenarios |
 | `handler_context()` | — | dict or nil | Return the active trigger dispatch context (`agent`, `action`, `trace_id`, `replay_of_event_id`, `autonomy_tier`, `trigger_event`) or `nil` outside dispatch |
 | `trust_record(agent, action, approver, outcome, tier)` | agent: string, action: string, approver: string or nil, outcome: string, tier: string | dict | Append a manual `TrustRecord` to `trust.graph` and `trust.graph.<agent>` |
-| `trust_query(filters)` | filters: dict | list | Query trust-graph records by `agent`, `action`, `since`, `until`, `tier`, and/or `outcome` |
+| `trust_query(filters)` | filters: dict | list | Query trust-graph records by `agent`, `action`, `since`, `until`, `tier`, `outcome`, `limit`, and/or `grouped_by_trace` |
 | `llm_info()` | — | dict | Current LLM config: `{provider, model, api_key_set}` |
 | `llm_usage()` | — | dict | Cumulative usage: `{input_tokens, output_tokens, total_duration_ms, call_count, total_calls}` |
 | `llm_resolve_model(alias)` | alias: string | dict | Resolve model alias to `{id, provider}` via providers.toml |

--- a/docs/src/stdlib/triggers.md
+++ b/docs/src/stdlib/triggers.md
@@ -201,6 +201,12 @@ Supported filter keys:
 - `until`
 - `tier`
 - `outcome`
+- `limit`
+- `grouped_by_trace`
+
+`limit` keeps only the newest N matching records. When `grouped_by_trace` is
+`true`, the builtin returns `list<{trace_id, records}>` trace buckets instead of
+the default flat `list<TrustRecord>`.
 
 ## Example
 

--- a/docs/src/trust-graph.md
+++ b/docs/src/trust-graph.md
@@ -73,7 +73,8 @@ Import `std/triggers` and use:
   `agent`, `action`, `trace_id`, and `autonomy_tier`
 - `trust_record(agent, action, approver, outcome, tier)` to append a manual
   trust record
-- `trust_query(filters)` to query historical records from Harn code
+- `trust_query(filters)` to query historical records from Harn code, including
+  server-side `limit` and `grouped_by_trace` options
 
 Example:
 
@@ -84,5 +85,18 @@ let records = trust_query({
   agent: "github-triage-bot",
   outcome: "success",
   tier: "act_auto",
+  limit: 100,
+})
+```
+
+Grouped queries return trace buckets:
+
+```harn
+import "std/triggers"
+
+let grouped = trust_query({
+  since: "2026-04-19T18:00:00Z",
+  limit: 500,
+  grouped_by_trace: true,
 })
 ```


### PR DESCRIPTION
## Summary
- add `limit` and `grouped_by_trace` support to trust-graph queries, including grouped trace buckets and newest-N limiting in `harn-vm`
- wire the new filters through `trust_query(filters)`, `harn trust query`, and the `harn.trust.query` MCP tool
- add Rust tests, trust-graph conformance coverage, and docs/changelog updates for the new query surface

## Why
The Burin IDE timeline needs bounded trust-graph polling and server-side trace grouping. Before this change, `trust_query` only returned the full flat history, so consumers had to fetch everything and clip/group client-side on every refresh.

## Validation
- `env CARGO_TARGET_DIR=/tmp/harn-636f-target cargo test -p harn-vm trust_graph::tests -- --nocapture`
- `env CARGO_TARGET_DIR=/tmp/harn-636f-target cargo test -p harn-cli trust_query -- --nocapture`
- `env CARGO_TARGET_DIR=/tmp/harn-636f-target cargo test -p harn-cli --test mcp_server_cli mcp_server_stdio_roundtrips_tools_and_resources -- --nocapture`
- `env CARGO_TARGET_DIR=/tmp/harn-636f-target cargo run --quiet --bin harn -- test conformance --filter trust_graph`
- repo pre-push gate (`nextest`, Harn format, markdown, portal lint)

Closes #338.
