### PR TITLE
Expose flow-control state in orchestrator inspect

### DIFF
--- a/crates/harn-cli/src/commands/mcp/serve.rs
+++ b/crates/harn-cli/src/commands/mcp/serve.rs
@@ -24,9 +24,12 @@ use harn_vm::{append_secret_scan_audit, secret_scan_content, SecretFinding};
 use crate::cli::{McpServeArgs, McpServeTransport, OrchestratorLocalArgs};
 use crate::commands::orchestrator::common::{
     load_local_runtime, read_topic, synthetic_event_for_binding, trigger_fire, trigger_inspect_dlq,
-    trigger_list, trigger_replay, ConnectorActivationSnapshot, PersistedStateSnapshot,
-    TRIGGER_ATTEMPTS_TOPIC, TRIGGER_DLQ_TOPIC, TRIGGER_INBOX_CLAIMS_TOPIC,
-    TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC, TRIGGER_OUTBOX_TOPIC,
+    trigger_list, trigger_replay, TRIGGER_ATTEMPTS_TOPIC, TRIGGER_DLQ_TOPIC,
+    TRIGGER_INBOX_CLAIMS_TOPIC, TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC,
+    TRIGGER_OUTBOX_TOPIC,
+};
+use crate::commands::orchestrator::inspect_data::{
+    collect_orchestrator_inspect_data, OrchestratorInspectData,
 };
 use crate::commands::orchestrator::listener::ListenerAuth;
 use crate::package::CollectedTriggerHandler;
@@ -138,26 +141,8 @@ struct TopicPreview {
 #[derive(Clone, Debug, Serialize)]
 struct InspectPayload {
     dispatcher: harn_vm::DispatcherStatsSnapshot,
-    bindings: Vec<harn_vm::TriggerBindingSnapshot>,
-    connectors: Vec<String>,
-    activations: Vec<ConnectorActivationSnapshot>,
-    snapshot: Option<PersistedStateSnapshot>,
-    recent_dispatches: Vec<RecentDispatchRecord>,
-}
-
-#[derive(Clone, Debug, Serialize)]
-struct RecentDispatchRecord {
-    kind: String,
-    status: String,
-    occurred_at_ms: i64,
-    trigger_id: Option<String>,
-    event_id: Option<String>,
-    attempt: Option<u32>,
-    replay_of_event_id: Option<String>,
-    handler_kind: Option<String>,
-    target_uri: Option<String>,
-    error: Option<String>,
-    result: Option<JsonValue>,
+    #[serde(flatten)]
+    inspect: OrchestratorInspectData,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -442,7 +427,7 @@ impl McpOrchestratorService {
                     ),
                     tool_def(
                         "harn.orchestrator.inspect",
-                        "Snapshot dispatcher state, bindings, metrics, and recent dispatches.",
+                        "Snapshot dispatcher state, triggers, flow-control state, and recent dispatches.",
                         json!({
                             "type": "object",
                             "properties": {},
@@ -715,23 +700,10 @@ impl McpOrchestratorService {
 
     async fn tool_orchestrator_inspect(&self, _arguments: JsonValue) -> Result<JsonValue, String> {
         let mut ctx = load_local_runtime(&self.local_args()).await?;
-        let bindings = trigger_list(&mut ctx).await?;
-        let dispatches = read_topic(&ctx.event_log, TRIGGER_OUTBOX_TOPIC).await?;
+        let inspect = collect_orchestrator_inspect_data(&mut ctx).await?;
         let payload = InspectPayload {
             dispatcher: harn_vm::snapshot_dispatcher_stats(),
-            bindings,
-            connectors: ctx
-                .snapshot
-                .as_ref()
-                .map(|snapshot| snapshot.connectors.clone())
-                .unwrap_or_default(),
-            activations: ctx
-                .snapshot
-                .as_ref()
-                .map(|snapshot| snapshot.activations.clone())
-                .unwrap_or_default(),
-            snapshot: ctx.snapshot.clone(),
-            recent_dispatches: recent_dispatch_records(dispatches, 20),
+            inspect,
         };
         serde_json::to_value(payload).map_err(|error| error.to_string())
     }
@@ -1350,55 +1322,6 @@ fn preview_events(events: Vec<(u64, LogEvent)>) -> Vec<QueuePreviewEntry> {
         .collect()
 }
 
-fn recent_dispatch_records(
-    dispatches: Vec<(u64, LogEvent)>,
-    limit: usize,
-) -> Vec<RecentDispatchRecord> {
-    let mut recent: Vec<_> = dispatches
-        .into_iter()
-        .filter_map(|(_, event)| {
-            if !matches!(
-                event.kind.as_str(),
-                "dispatch_succeeded" | "dispatch_failed"
-            ) {
-                return None;
-            }
-            let payload = event.payload.as_object();
-            Some(RecentDispatchRecord {
-                status: event.kind.trim_start_matches("dispatch_").to_string(),
-                kind: event.kind,
-                occurred_at_ms: event.occurred_at_ms,
-                trigger_id: event.headers.get("trigger_id").cloned(),
-                event_id: event.headers.get("event_id").cloned(),
-                attempt: event
-                    .headers
-                    .get("attempt")
-                    .and_then(|attempt| attempt.parse::<u32>().ok()),
-                replay_of_event_id: event.headers.get("replay_of_event_id").cloned(),
-                handler_kind: event.headers.get("handler_kind").cloned(),
-                target_uri: payload.and_then(|payload| {
-                    payload
-                        .get("target_uri")
-                        .and_then(JsonValue::as_str)
-                        .map(ToOwned::to_owned)
-                }),
-                error: payload.and_then(|payload| {
-                    payload
-                        .get("error")
-                        .and_then(JsonValue::as_str)
-                        .map(ToOwned::to_owned)
-                }),
-                result: payload.and_then(|payload| payload.get("result").cloned()),
-            })
-        })
-        .collect();
-    recent.sort_by_key(|dispatch| dispatch.occurred_at_ms);
-    if recent.len() > limit {
-        recent.drain(0..recent.len() - limit);
-    }
-    recent
-}
-
 fn filter_related_events(
     events: Vec<(u64, LogEvent)>,
     event_id: &str,
@@ -1794,7 +1717,7 @@ pub fn on_fail(event: TriggerEvent) -> any {
             json!({}),
         )
         .await;
-        assert_eq!(inspect["bindings"].as_array().unwrap().len(), 2);
+        assert_eq!(inspect["triggers"].as_array().unwrap().len(), 2);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-cli/src/commands/orchestrator/common.rs
+++ b/crates/harn-cli/src/commands/orchestrator/common.rs
@@ -16,8 +16,9 @@ use super::role::OrchestratorRole;
 
 pub(crate) const STATE_SNAPSHOT_FILE: &str = "orchestrator-state.json";
 pub(crate) use harn_vm::{
-    TRIGGER_ATTEMPTS_TOPIC, TRIGGER_DLQ_TOPIC, TRIGGER_INBOX_CLAIMS_TOPIC,
-    TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC, TRIGGER_OUTBOX_TOPIC,
+    TRIGGERS_LIFECYCLE_TOPIC, TRIGGER_ATTEMPTS_TOPIC, TRIGGER_DLQ_TOPIC,
+    TRIGGER_INBOX_CLAIMS_TOPIC, TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC,
+    TRIGGER_OUTBOX_TOPIC,
 };
 
 pub(crate) struct LoadedOrchestratorContext {
@@ -32,9 +33,29 @@ pub(crate) struct PersistedStateSnapshot {
     pub status: String,
     pub bind: String,
     #[serde(default)]
+    pub triggers: Vec<PersistedTriggerStateSnapshot>,
+    #[serde(default)]
     pub connectors: Vec<String>,
     #[serde(default)]
     pub activations: Vec<ConnectorActivationSnapshot>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub(crate) struct PersistedTriggerStateSnapshot {
+    pub id: String,
+    pub provider: String,
+    pub kind: String,
+    pub handler: String,
+    pub version: Option<u32>,
+    pub state: Option<String>,
+    #[serde(default)]
+    pub received: u64,
+    #[serde(default)]
+    pub dispatched: u64,
+    #[serde(default)]
+    pub failed: u64,
+    #[serde(default)]
+    pub in_flight: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/harn-cli/src/commands/orchestrator/inspect.rs
+++ b/crates/harn-cli/src/commands/orchestrator/inspect.rs
@@ -1,100 +1,53 @@
 use crate::cli::OrchestratorInspectArgs;
 
-use serde::Serialize;
-
-use super::common::{
-    load_local_runtime, print_json, read_topic, trigger_list, ConnectorActivationSnapshot,
-    PersistedStateSnapshot, TRIGGER_OUTBOX_TOPIC,
-};
-
-#[derive(Debug, Serialize)]
-struct InspectPayload {
-    bindings: Vec<harn_vm::TriggerBindingSnapshot>,
-    connectors: Vec<String>,
-    activations: Vec<ConnectorActivationSnapshot>,
-    snapshot: Option<PersistedStateSnapshot>,
-    recent_dispatches: Vec<RecentDispatchRecord>,
-}
-
-#[derive(Debug, Serialize)]
-struct RecentDispatchRecord {
-    kind: String,
-    status: String,
-    occurred_at_ms: i64,
-    trigger_id: Option<String>,
-    event_id: Option<String>,
-    attempt: Option<u32>,
-    replay_of_event_id: Option<String>,
-    handler_kind: Option<String>,
-    target_uri: Option<String>,
-    error: Option<String>,
-    result: Option<serde_json::Value>,
-}
+use super::common::{load_local_runtime, print_json};
+use super::inspect_data::collect_orchestrator_inspect_data;
 
 pub(super) async fn run(args: OrchestratorInspectArgs) -> Result<(), String> {
     let mut ctx = load_local_runtime(&args.local).await?;
-    let bindings: Vec<_> = trigger_list(&mut ctx)
-        .await?
-        .into_iter()
-        .filter(|binding| binding.source == harn_vm::TriggerBindingSource::Manifest)
-        .collect();
-    let dispatches = read_topic(&ctx.event_log, TRIGGER_OUTBOX_TOPIC).await?;
-    let recent_dispatches = recent_dispatch_records(dispatches, 20);
+    let payload = collect_orchestrator_inspect_data(&mut ctx).await?;
 
     if args.json {
-        return print_json(&InspectPayload {
-            bindings,
-            connectors: ctx
-                .snapshot
-                .as_ref()
-                .map(|snapshot| snapshot.connectors.clone())
-                .unwrap_or_default(),
-            activations: ctx
-                .snapshot
-                .as_ref()
-                .map(|snapshot| snapshot.activations.clone())
-                .unwrap_or_default(),
-            snapshot: ctx.snapshot.clone(),
-            recent_dispatches,
-        });
+        return print_json(&payload);
     }
 
     println!("Triggers:");
-    if bindings.is_empty() {
+    if payload.triggers.is_empty() {
         println!("- none");
     } else {
-        for binding in bindings {
+        for trigger in &payload.triggers {
             println!(
                 "- {} provider={} kind={} state={} version={}",
-                binding.id,
-                binding.provider,
-                binding.kind,
-                binding.state.as_str(),
-                binding.version
+                trigger.id,
+                trigger.provider,
+                trigger.kind,
+                trigger.state.as_deref().unwrap_or("-"),
+                trigger
+                    .version
+                    .map(|version| version.to_string())
+                    .unwrap_or_else(|| "-".to_string())
             );
         }
     }
 
     println!();
     println!("Connectors:");
-    match ctx.snapshot.as_ref() {
-        Some(snapshot) if !snapshot.activations.is_empty() => {
-            for activation in &snapshot.activations {
-                println!(
-                    "- {} bindings={}",
-                    activation.provider, activation.binding_count
-                );
-            }
+    if !payload.activations.is_empty() {
+        for activation in &payload.activations {
+            println!(
+                "- {} bindings={}",
+                activation.provider, activation.binding_count
+            );
         }
-        Some(snapshot) if !snapshot.connectors.is_empty() => {
-            for connector in &snapshot.connectors {
-                println!("- {connector}");
-            }
+    } else if !payload.connectors.is_empty() {
+        for connector in &payload.connectors {
+            println!("- {connector}");
         }
-        Some(_) | None => println!("- none"),
+    } else {
+        println!("- none");
     }
 
-    if let Some(snapshot) = ctx.snapshot.as_ref() {
+    if let Some(snapshot) = payload.snapshot.as_ref() {
         println!();
         println!("Snapshot:");
         println!("- status={}", snapshot.status);
@@ -103,11 +56,11 @@ pub(super) async fn run(args: OrchestratorInspectArgs) -> Result<(), String> {
 
     println!();
     println!("Recent dispatches:");
-    if recent_dispatches.is_empty() {
+    if payload.recent_dispatches.is_empty() {
         println!("- none");
         return Ok(());
     }
-    for dispatch in recent_dispatches.into_iter().rev().take(5).rev() {
+    for dispatch in payload.recent_dispatches.iter().rev().take(5).rev() {
         println!(
             "- {} trigger={} event={} attempt={} replay_of={}",
             dispatch.kind,
@@ -123,58 +76,4 @@ pub(super) async fn run(args: OrchestratorInspectArgs) -> Result<(), String> {
     }
 
     Ok(())
-}
-
-fn recent_dispatch_records(
-    dispatches: Vec<(u64, harn_vm::event_log::LogEvent)>,
-    limit: usize,
-) -> Vec<RecentDispatchRecord> {
-    let mut recent: Vec<_> = dispatches
-        .into_iter()
-        .filter_map(|(_, event)| {
-            if !matches!(
-                event.kind.as_str(),
-                "dispatch_succeeded" | "dispatch_failed"
-            ) {
-                return None;
-            }
-
-            let kind = event.kind;
-            let occurred_at_ms = event.occurred_at_ms;
-            let headers = event.headers;
-            let payload = event.payload;
-            let payload = payload.as_object();
-            Some(RecentDispatchRecord {
-                status: kind.trim_start_matches("dispatch_").to_string(),
-                kind,
-                occurred_at_ms,
-                trigger_id: headers.get("trigger_id").cloned(),
-                event_id: headers.get("event_id").cloned(),
-                attempt: headers
-                    .get("attempt")
-                    .and_then(|attempt| attempt.parse::<u32>().ok()),
-                replay_of_event_id: headers.get("replay_of_event_id").cloned(),
-                handler_kind: headers.get("handler_kind").cloned(),
-                target_uri: payload.and_then(|payload| {
-                    payload
-                        .get("target_uri")
-                        .and_then(|value| value.as_str())
-                        .map(ToOwned::to_owned)
-                }),
-                error: payload.and_then(|payload| {
-                    payload
-                        .get("error")
-                        .and_then(|value| value.as_str())
-                        .map(ToOwned::to_owned)
-                }),
-                result: payload.and_then(|payload| payload.get("result").cloned()),
-            })
-        })
-        .collect();
-
-    recent.sort_by_key(|dispatch| dispatch.occurred_at_ms);
-    if recent.len() > limit {
-        recent.drain(0..recent.len() - limit);
-    }
-    recent
 }

--- a/crates/harn-cli/src/commands/orchestrator/inspect_data.rs
+++ b/crates/harn-cli/src/commands/orchestrator/inspect_data.rs
@@ -1,0 +1,935 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+use time::OffsetDateTime;
+
+use crate::package::{CollectedManifestTrigger, CollectedTriggerHandler, TriggerKind};
+
+use super::common::{
+    read_topic, trigger_list, ConnectorActivationSnapshot, LoadedOrchestratorContext,
+    PersistedStateSnapshot, PersistedTriggerStateSnapshot, TRIGGERS_LIFECYCLE_TOPIC,
+    TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC, TRIGGER_OUTBOX_TOPIC,
+};
+
+const GLOBAL_FLOW_KEY: &str = "_global";
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct OrchestratorInspectData {
+    pub triggers: Vec<TriggerInspectRecord>,
+    pub connectors: Vec<String>,
+    pub activations: Vec<ConnectorActivationSnapshot>,
+    pub snapshot: Option<PersistedStateSnapshot>,
+    pub recent_dispatches: Vec<RecentDispatchRecord>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct TriggerInspectRecord {
+    pub id: String,
+    pub provider: String,
+    pub kind: String,
+    pub handler: String,
+    pub version: Option<u32>,
+    pub state: Option<String>,
+    pub metrics: TriggerInspectMetrics,
+    pub flow_control: TriggerFlowControlInspect,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct TriggerInspectMetrics {
+    pub received: u64,
+    pub dispatched: u64,
+    pub failed: u64,
+    pub in_flight: u64,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct TriggerFlowControlInspect {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<QueueFlowControlInspect>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub throttle: Option<ThrottleInspect>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limit: Option<RateLimitInspect>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub debounce: Option<DebounceInspect>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub singleton: Option<QueueFlowControlInspect>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch: Option<BatchInspect>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<PriorityInspect>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_budget: Option<CostBudgetInspect>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct QueueFlowControlInspect {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_expr: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max: Option<u32>,
+    pub queue_depth_by_key: BTreeMap<String, u64>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct ThrottleInspect {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_expr: Option<String>,
+    pub window_sec: u64,
+    pub limit: u32,
+    pub queue_depth_by_key: BTreeMap<String, u64>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct RateLimitInspect {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_expr: Option<String>,
+    pub window_sec: u64,
+    pub limit: u32,
+    pub util_by_key: BTreeMap<String, RateLimitUtilInspect>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct RateLimitUtilInspect {
+    pub window_sec: u64,
+    pub count: u64,
+    pub limit: u32,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct DebounceInspect {
+    pub key_expr: String,
+    pub window_sec: u64,
+    pub queue_depth_by_key: BTreeMap<String, u64>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct BatchInspect {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_expr: Option<String>,
+    pub size: u32,
+    pub timeout_sec: u64,
+    pub queue_depth_by_key: BTreeMap<String, u64>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct PriorityInspect {
+    pub key_expr: String,
+    pub order: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct CostBudgetInspect {
+    pub limit_usd: f64,
+    pub used_usd: f64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct RecentDispatchRecord {
+    pub kind: String,
+    pub status: String,
+    pub occurred_at_ms: i64,
+    pub trigger_id: Option<String>,
+    pub event_id: Option<String>,
+    pub attempt: Option<u32>,
+    pub replay_of_event_id: Option<String>,
+    pub handler_kind: Option<String>,
+    pub target_uri: Option<String>,
+    pub error: Option<String>,
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skip_stage: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct SkipDisposition {
+    stage: Option<String>,
+    flow_control: Option<String>,
+}
+
+pub(crate) async fn collect_orchestrator_inspect_data(
+    ctx: &mut LoadedOrchestratorContext,
+) -> Result<OrchestratorInspectData, String> {
+    let runtime_bindings = trigger_list(ctx).await?;
+    let snapshot = ctx.snapshot.clone();
+    let snapshot_by_id = snapshot_trigger_map(snapshot.as_ref());
+    let runtime_by_id = runtime_trigger_map(&runtime_bindings);
+    let current_binding_keys =
+        current_binding_keys(&ctx.collected_triggers, &snapshot_by_id, &runtime_by_id);
+
+    let envelopes = read_topic(&ctx.event_log, TRIGGER_INBOX_ENVELOPES_TOPIC).await?;
+    let legacy_inbox = read_topic(&ctx.event_log, TRIGGER_INBOX_LEGACY_TOPIC).await?;
+    let outbox = read_topic(&ctx.event_log, TRIGGER_OUTBOX_TOPIC).await?;
+    let lifecycle = read_topic(&ctx.event_log, TRIGGERS_LIFECYCLE_TOPIC).await?;
+
+    let recent_dispatches = recent_dispatch_records(&outbox, 20);
+    let terminal = terminal_dispatches(&outbox);
+    let skipped = skipped_dispatches(&outbox);
+
+    let mut pending_by_binding_key = BTreeMap::<String, Vec<harn_vm::TriggerEvent>>::new();
+    let mut ingested_by_binding_key = BTreeMap::<String, Vec<harn_vm::TriggerEvent>>::new();
+
+    for (_, record) in envelopes.into_iter().chain(legacy_inbox) {
+        if record.kind != "event_ingested" {
+            continue;
+        }
+        let envelope: harn_vm::triggers::dispatcher::InboxEnvelope =
+            serde_json::from_value(record.payload)
+                .map_err(|error| format!("failed to decode trigger inbox envelope: {error}"))?;
+        let binding_keys =
+            binding_keys_for_envelope(&envelope, &ctx.collected_triggers, &current_binding_keys);
+        for binding_key in binding_keys {
+            ingested_by_binding_key
+                .entry(binding_key.clone())
+                .or_default()
+                .push(envelope.event.clone());
+            if !terminal.contains(&(binding_key.clone(), envelope.event.id.0.clone())) {
+                pending_by_binding_key
+                    .entry(binding_key)
+                    .or_default()
+                    .push(envelope.event.clone());
+            }
+        }
+    }
+
+    let today_start = utc_day_start();
+    let mut cost_by_binding_key = BTreeMap::<String, f64>::new();
+    for (_, event) in lifecycle {
+        if event.kind != "predicate.evaluated"
+            || event.occurred_at_ms < today_start.unix_timestamp() * 1000
+        {
+            continue;
+        }
+        let Some(binding_key) = event.headers.get("binding_key").cloned() else {
+            continue;
+        };
+        let cost = event
+            .payload
+            .get("cost_usd")
+            .and_then(|value| value.as_f64())
+            .unwrap_or_default();
+        if cost > 0.0 {
+            *cost_by_binding_key.entry(binding_key).or_default() += cost;
+        }
+    }
+
+    let mut triggers = Vec::new();
+    for trigger in ctx.collected_triggers.clone() {
+        let snapshot_state = snapshot_by_id.get(&trigger.config.id);
+        let runtime_state = runtime_by_id.get(&trigger.config.id);
+        let version = snapshot_state
+            .and_then(|state| state.version)
+            .or_else(|| runtime_state.map(|binding| binding.version));
+        let binding_key = version.map(|version| format!("{}@v{}", trigger.config.id, version));
+        let pending_events = binding_key
+            .as_ref()
+            .and_then(|binding_key| pending_by_binding_key.get(binding_key))
+            .cloned()
+            .unwrap_or_default();
+        let ingested_events = binding_key
+            .as_ref()
+            .and_then(|binding_key| ingested_by_binding_key.get(binding_key))
+            .cloned()
+            .unwrap_or_default();
+        let trigger_metrics = snapshot_state
+            .map(trigger_metrics_from_snapshot)
+            .or_else(|| runtime_state.map(trigger_metrics_from_runtime))
+            .unwrap_or_default();
+
+        let flow_control = build_flow_control_inspect(
+            ctx,
+            &trigger,
+            binding_key.as_deref(),
+            &pending_events,
+            &ingested_events,
+            &skipped,
+            &cost_by_binding_key,
+        )
+        .await?;
+
+        triggers.push(TriggerInspectRecord {
+            id: trigger.config.id.clone(),
+            provider: trigger.config.provider.as_str().to_string(),
+            kind: trigger_kind_name(trigger.config.kind).to_string(),
+            handler: handler_kind(&trigger.handler).to_string(),
+            version,
+            state: snapshot_state
+                .and_then(|state| state.state.clone())
+                .or_else(|| runtime_state.map(|binding| binding.state.as_str().to_string())),
+            metrics: trigger_metrics,
+            flow_control,
+        });
+    }
+
+    Ok(OrchestratorInspectData {
+        triggers,
+        connectors: snapshot
+            .as_ref()
+            .map(|state| state.connectors.clone())
+            .unwrap_or_default(),
+        activations: snapshot
+            .as_ref()
+            .map(|state| state.activations.clone())
+            .unwrap_or_default(),
+        snapshot,
+        recent_dispatches,
+    })
+}
+
+pub(crate) fn recent_dispatch_records(
+    dispatches: &[(u64, harn_vm::event_log::LogEvent)],
+    limit: usize,
+) -> Vec<RecentDispatchRecord> {
+    let mut recent: Vec<_> = dispatches
+        .iter()
+        .filter_map(|(_, event)| {
+            if !matches!(
+                event.kind.as_str(),
+                "dispatch_succeeded" | "dispatch_failed" | "dispatch_skipped"
+            ) {
+                return None;
+            }
+
+            let payload = event.payload.as_object();
+            Some(RecentDispatchRecord {
+                status: event.kind.trim_start_matches("dispatch_").to_string(),
+                kind: event.kind.clone(),
+                occurred_at_ms: event.occurred_at_ms,
+                trigger_id: event.headers.get("trigger_id").cloned(),
+                event_id: event.headers.get("event_id").cloned(),
+                attempt: event
+                    .headers
+                    .get("attempt")
+                    .and_then(|attempt| attempt.parse::<u32>().ok()),
+                replay_of_event_id: event.headers.get("replay_of_event_id").cloned(),
+                handler_kind: payload.and_then(|payload| {
+                    payload
+                        .get("handler_kind")
+                        .and_then(|value| value.as_str())
+                        .map(ToOwned::to_owned)
+                }),
+                target_uri: payload.and_then(|payload| {
+                    payload
+                        .get("target_uri")
+                        .and_then(|value| value.as_str())
+                        .map(ToOwned::to_owned)
+                }),
+                error: payload.and_then(|payload| {
+                    payload
+                        .get("error")
+                        .and_then(|value| value.as_str())
+                        .map(ToOwned::to_owned)
+                }),
+                result: payload.and_then(|payload| payload.get("result").cloned()),
+                skip_stage: payload.and_then(|payload| {
+                    payload
+                        .get("skip_stage")
+                        .and_then(|value| value.as_str())
+                        .map(ToOwned::to_owned)
+                }),
+                detail: payload.and_then(|payload| payload.get("detail").cloned()),
+            })
+        })
+        .collect();
+
+    recent.sort_by_key(|dispatch| dispatch.occurred_at_ms);
+    if recent.len() > limit {
+        recent.drain(0..recent.len() - limit);
+    }
+    recent
+}
+
+async fn build_flow_control_inspect(
+    ctx: &mut LoadedOrchestratorContext,
+    trigger: &CollectedManifestTrigger,
+    binding_key: Option<&str>,
+    pending_events: &[harn_vm::TriggerEvent],
+    ingested_events: &[harn_vm::TriggerEvent],
+    skipped: &BTreeMap<(String, String), SkipDisposition>,
+    cost_by_binding_key: &BTreeMap<String, f64>,
+) -> Result<TriggerFlowControlInspect, String> {
+    let flow = &trigger.flow_control;
+    let mut inspect = TriggerFlowControlInspect::default();
+
+    if let Some(concurrency) = &flow.concurrency {
+        inspect.concurrency = Some(QueueFlowControlInspect {
+            key_expr: concurrency.key.as_ref().map(|expr| expr.raw.clone()),
+            max: Some(concurrency.max),
+            queue_depth_by_key: queue_depth_by_key(ctx, concurrency.key.as_ref(), pending_events)
+                .await?,
+        });
+    }
+    if let Some(throttle) = &flow.throttle {
+        inspect.throttle = Some(ThrottleInspect {
+            key_expr: throttle.key.as_ref().map(|expr| expr.raw.clone()),
+            window_sec: throttle.period.as_secs(),
+            limit: throttle.max,
+            queue_depth_by_key: queue_depth_by_key(ctx, throttle.key.as_ref(), pending_events)
+                .await?,
+        });
+    }
+    if let Some(rate_limit) = &flow.rate_limit {
+        inspect.rate_limit = Some(RateLimitInspect {
+            key_expr: rate_limit.key.as_ref().map(|expr| expr.raw.clone()),
+            window_sec: rate_limit.period.as_secs(),
+            limit: rate_limit.max,
+            util_by_key: rate_limit_util_by_key(
+                ctx,
+                binding_key,
+                rate_limit.key.as_ref(),
+                ingested_events,
+                skipped,
+                rate_limit.period,
+                rate_limit.max,
+            )
+            .await?,
+        });
+    }
+    if let Some(debounce) = &flow.debounce {
+        inspect.debounce = Some(DebounceInspect {
+            key_expr: debounce.key.raw.clone(),
+            window_sec: debounce.period.as_secs(),
+            queue_depth_by_key: queue_depth_by_key(ctx, Some(&debounce.key), pending_events)
+                .await?,
+        });
+    }
+    if let Some(singleton) = &flow.singleton {
+        inspect.singleton = Some(QueueFlowControlInspect {
+            key_expr: singleton.key.as_ref().map(|expr| expr.raw.clone()),
+            max: None,
+            queue_depth_by_key: queue_depth_by_key(ctx, singleton.key.as_ref(), pending_events)
+                .await?,
+        });
+    }
+    if let Some(batch) = &flow.batch {
+        inspect.batch = Some(BatchInspect {
+            key_expr: batch.key.as_ref().map(|expr| expr.raw.clone()),
+            size: batch.size,
+            timeout_sec: batch.timeout.as_secs(),
+            queue_depth_by_key: queue_depth_by_key(ctx, batch.key.as_ref(), pending_events).await?,
+        });
+    }
+    if let Some(priority) = &flow.priority {
+        inspect.priority = Some(PriorityInspect {
+            key_expr: priority.key.raw.clone(),
+            order: priority.order.clone(),
+        });
+    }
+    if let (Some(binding_key), Some(limit_usd)) =
+        (binding_key, trigger.config.budget.daily_cost_usd)
+    {
+        inspect.cost_budget = Some(CostBudgetInspect {
+            limit_usd,
+            used_usd: cost_by_binding_key
+                .get(binding_key)
+                .copied()
+                .unwrap_or_default(),
+        });
+    }
+
+    Ok(inspect)
+}
+
+async fn queue_depth_by_key(
+    ctx: &mut LoadedOrchestratorContext,
+    expr: Option<&harn_vm::TriggerExpressionSpec>,
+    events: &[harn_vm::TriggerEvent],
+) -> Result<BTreeMap<String, u64>, String> {
+    let mut counts = BTreeMap::new();
+    for event in events {
+        let key = evaluate_flow_key(&mut ctx.vm, expr, event).await?;
+        *counts.entry(key).or_insert(0) += 1;
+    }
+    Ok(counts)
+}
+
+async fn rate_limit_util_by_key(
+    ctx: &mut LoadedOrchestratorContext,
+    binding_key: Option<&str>,
+    expr: Option<&harn_vm::TriggerExpressionSpec>,
+    events: &[harn_vm::TriggerEvent],
+    skipped: &BTreeMap<(String, String), SkipDisposition>,
+    period: std::time::Duration,
+    limit: u32,
+) -> Result<BTreeMap<String, RateLimitUtilInspect>, String> {
+    let mut util = BTreeMap::new();
+    let Some(window_start) =
+        OffsetDateTime::now_utc().checked_sub(period.try_into().unwrap_or_default())
+    else {
+        return Ok(util);
+    };
+    for event in events {
+        if event.received_at < window_start {
+            continue;
+        }
+        if binding_key
+            .and_then(|binding_key| skipped.get(&(binding_key.to_string(), event.id.0.clone())))
+            .is_some_and(skip_consumed_before_rate_limit)
+        {
+            continue;
+        }
+        let key = evaluate_flow_key(&mut ctx.vm, expr, event).await?;
+        let entry = util.entry(key).or_insert(RateLimitUtilInspect {
+            window_sec: period.as_secs(),
+            count: 0,
+            limit,
+        });
+        entry.count += 1;
+    }
+    Ok(util)
+}
+
+async fn evaluate_flow_key(
+    vm: &mut harn_vm::Vm,
+    expr: Option<&harn_vm::TriggerExpressionSpec>,
+    event: &harn_vm::TriggerEvent,
+) -> Result<String, String> {
+    let Some(expr) = expr else {
+        return Ok(GLOBAL_FLOW_KEY.to_string());
+    };
+    let arg = harn_vm::json_to_vm_value(
+        &serde_json::to_value(event)
+            .map_err(|error| format!("failed to encode trigger event: {error}"))?,
+    );
+    let value = vm
+        .call_closure_pub(&expr.closure, &[arg], &[])
+        .await
+        .map_err(|error| {
+            format!(
+                "failed to evaluate flow-control expression '{}': {error}",
+                expr.raw
+            )
+        })?;
+    Ok(json_value_to_gate(&harn_vm::llm::vm_value_to_json(&value)))
+}
+
+fn current_binding_keys(
+    triggers: &[CollectedManifestTrigger],
+    snapshot_by_id: &BTreeMap<String, PersistedTriggerStateSnapshot>,
+    runtime_by_id: &BTreeMap<String, harn_vm::TriggerBindingSnapshot>,
+) -> BTreeMap<String, String> {
+    triggers
+        .iter()
+        .filter_map(|trigger| {
+            let version = snapshot_by_id
+                .get(&trigger.config.id)
+                .and_then(|state| state.version)
+                .or_else(|| {
+                    runtime_by_id
+                        .get(&trigger.config.id)
+                        .map(|binding| binding.version)
+                })?;
+            Some((
+                trigger.config.id.clone(),
+                format!("{}@v{}", trigger.config.id, version),
+            ))
+        })
+        .collect()
+}
+
+fn binding_keys_for_envelope(
+    envelope: &harn_vm::triggers::dispatcher::InboxEnvelope,
+    triggers: &[CollectedManifestTrigger],
+    current_binding_keys: &BTreeMap<String, String>,
+) -> Vec<String> {
+    if let Some(trigger_id) = envelope.trigger_id.as_ref() {
+        if let Some(version) = envelope.binding_version {
+            return vec![format!("{trigger_id}@v{version}")];
+        }
+        return current_binding_keys
+            .get(trigger_id)
+            .cloned()
+            .into_iter()
+            .collect();
+    }
+
+    if let harn_vm::ProviderPayload::Known(harn_vm::triggers::event::KnownProviderPayload::Cron(
+        payload,
+    )) = &envelope.event.provider_payload
+    {
+        if let Some(cron_id) = payload.cron_id.as_ref() {
+            return current_binding_keys
+                .get(cron_id)
+                .cloned()
+                .into_iter()
+                .collect();
+        }
+    }
+
+    triggers
+        .iter()
+        .filter(|trigger| {
+            trigger.config.provider == envelope.event.provider
+                && trigger
+                    .config
+                    .match_
+                    .events
+                    .iter()
+                    .any(|event| event == &envelope.event.kind)
+        })
+        .filter_map(|trigger| current_binding_keys.get(&trigger.config.id).cloned())
+        .collect()
+}
+
+fn terminal_dispatches(
+    outbox: &[(u64, harn_vm::event_log::LogEvent)],
+) -> BTreeSet<(String, String)> {
+    outbox
+        .iter()
+        .filter(|(_, event)| {
+            matches!(
+                event.kind.as_str(),
+                "dispatch_succeeded" | "dispatch_failed" | "dispatch_skipped"
+            )
+        })
+        .filter_map(|(_, event)| {
+            Some((
+                event.headers.get("binding_key")?.clone(),
+                event.headers.get("event_id")?.clone(),
+            ))
+        })
+        .collect()
+}
+
+fn skipped_dispatches(
+    outbox: &[(u64, harn_vm::event_log::LogEvent)],
+) -> BTreeMap<(String, String), SkipDisposition> {
+    outbox
+        .iter()
+        .filter(|(_, event)| event.kind == "dispatch_skipped")
+        .filter_map(|(_, event)| {
+            let binding_key = event.headers.get("binding_key")?.clone();
+            let event_id = event.headers.get("event_id")?.clone();
+            let disposition = SkipDisposition {
+                stage: event
+                    .payload
+                    .get("skip_stage")
+                    .and_then(|value| value.as_str())
+                    .map(ToOwned::to_owned),
+                flow_control: event
+                    .payload
+                    .get("detail")
+                    .and_then(|detail| detail.get("flow_control"))
+                    .and_then(|value| value.as_str())
+                    .map(ToOwned::to_owned),
+            };
+            Some(((binding_key, event_id), disposition))
+        })
+        .collect()
+}
+
+fn skip_consumed_before_rate_limit(skip: &SkipDisposition) -> bool {
+    match skip.stage.as_deref() {
+        Some("predicate") => true,
+        Some("flow_control") => matches!(
+            skip.flow_control.as_deref(),
+            Some("batch_merged") | Some("debounced") | Some("rate_limited")
+        ),
+        _ => false,
+    }
+}
+
+fn snapshot_trigger_map(
+    snapshot: Option<&PersistedStateSnapshot>,
+) -> BTreeMap<String, PersistedTriggerStateSnapshot> {
+    snapshot
+        .map(|snapshot| {
+            snapshot
+                .triggers
+                .iter()
+                .cloned()
+                .map(|trigger| (trigger.id.clone(), trigger))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn runtime_trigger_map(
+    bindings: &[harn_vm::TriggerBindingSnapshot],
+) -> BTreeMap<String, harn_vm::TriggerBindingSnapshot> {
+    bindings
+        .iter()
+        .filter(|binding| binding.source == harn_vm::TriggerBindingSource::Manifest)
+        .cloned()
+        .map(|binding| (binding.id.clone(), binding))
+        .collect()
+}
+
+fn trigger_metrics_from_snapshot(
+    snapshot: &PersistedTriggerStateSnapshot,
+) -> TriggerInspectMetrics {
+    TriggerInspectMetrics {
+        received: snapshot.received,
+        dispatched: snapshot.dispatched,
+        failed: snapshot.failed,
+        in_flight: snapshot.in_flight,
+    }
+}
+
+fn trigger_metrics_from_runtime(
+    binding: &harn_vm::TriggerBindingSnapshot,
+) -> TriggerInspectMetrics {
+    TriggerInspectMetrics {
+        received: binding.metrics.received,
+        dispatched: binding.metrics.dispatched,
+        failed: binding.metrics.failed,
+        in_flight: binding.metrics.in_flight,
+    }
+}
+
+fn handler_kind(handler: &CollectedTriggerHandler) -> &'static str {
+    match handler {
+        CollectedTriggerHandler::Local { .. } => "local",
+        CollectedTriggerHandler::A2a { .. } => "a2a",
+        CollectedTriggerHandler::Worker { .. } => "worker",
+    }
+}
+
+fn trigger_kind_name(kind: TriggerKind) -> &'static str {
+    match kind {
+        TriggerKind::Webhook => "webhook",
+        TriggerKind::Cron => "cron",
+        TriggerKind::Poll => "poll",
+        TriggerKind::Stream => "stream",
+        TriggerKind::Predicate => "predicate",
+        TriggerKind::A2aPush => "a2a-push",
+    }
+}
+
+fn json_value_to_gate(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::String(text) => text.clone(),
+        serde_json::Value::Bool(value) => value.to_string(),
+        serde_json::Value::Number(value) => value.to_string(),
+        other => serde_json::to_string(other).unwrap_or_else(|_| "unserializable".to_string()),
+    }
+}
+
+fn utc_day_start() -> OffsetDateTime {
+    let now = OffsetDateTime::now_utc();
+    now.replace_hour(0)
+        .and_then(|value| value.replace_minute(0))
+        .and_then(|value| value.replace_second(0))
+        .and_then(|value| value.replace_millisecond(0))
+        .and_then(|value| value.replace_microsecond(0))
+        .and_then(|value| value.replace_nanosecond(0))
+        .unwrap_or(now)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::path::Path;
+
+    use harn_vm::event_log::{EventLog, LogEvent, Topic};
+    use tempfile::TempDir;
+
+    use crate::cli::OrchestratorLocalArgs;
+
+    use super::super::common::load_local_runtime;
+    use super::*;
+
+    fn write_file(dir: &Path, relative: &str, contents: &str) {
+        let path = dir.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    fn write_fixture(temp: &TempDir) {
+        write_file(
+            temp.path(),
+            "harn.toml",
+            r#"
+[package]
+name = "inspect-fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "cron-flow"
+kind = "cron"
+provider = "cron"
+schedule = "* * * * *"
+match = { events = ["cron.tick"] }
+handler = "handlers::on_ok"
+rate_limit = { key = "event.headers.tenant", period = "1h", max = 1 }
+singleton = { key = "event.headers.tenant" }
+budget = { daily_cost_usd = 1.0 }
+"#,
+        );
+        write_file(
+            temp.path(),
+            "lib.harn",
+            r#"
+import "std/triggers"
+
+pub fn on_ok(event: TriggerEvent) -> dict {
+  return {tenant: event.headers.tenant}
+}
+"#,
+        );
+    }
+
+    fn trigger_event(event_id: &str, tenant: &str) -> harn_vm::TriggerEvent {
+        harn_vm::TriggerEvent {
+            id: harn_vm::TriggerEventId(event_id.to_string()),
+            provider: harn_vm::ProviderId::new("cron"),
+            kind: "cron.tick".to_string(),
+            received_at: OffsetDateTime::now_utc(),
+            occurred_at: None,
+            dedupe_key: event_id.to_string(),
+            trace_id: harn_vm::TraceId::new(),
+            tenant_id: None,
+            headers: BTreeMap::from([(String::from("tenant"), tenant.to_string())]),
+            batch: None,
+            provider_payload: harn_vm::ProviderPayload::Known(
+                harn_vm::triggers::event::KnownProviderPayload::Cron(
+                    harn_vm::triggers::CronEventPayload {
+                        cron_id: Some("cron-flow".to_string()),
+                        schedule: Some("* * * * *".to_string()),
+                        tick_at: OffsetDateTime::now_utc(),
+                        raw: serde_json::json!({}),
+                    },
+                ),
+            ),
+            signature_status: harn_vm::SignatureStatus::Verified,
+            dedupe_claimed: false,
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn collect_orchestrator_inspect_data_reports_flow_control_state() {
+        let temp = TempDir::new().unwrap();
+        write_fixture(&temp);
+
+        let mut ctx = load_local_runtime(&OrchestratorLocalArgs {
+            config: temp.path().join("harn.toml"),
+            state_dir: temp.path().join("state"),
+        })
+        .await
+        .expect("load local runtime");
+
+        let inbox_topic = Topic::new(TRIGGER_INBOX_ENVELOPES_TOPIC).unwrap();
+        let outbox_topic = Topic::new(TRIGGER_OUTBOX_TOPIC).unwrap();
+        let lifecycle_topic = Topic::new(TRIGGERS_LIFECYCLE_TOPIC).unwrap();
+
+        let event_one = trigger_event("evt-1", "acme");
+        let event_two = trigger_event("evt-2", "acme");
+
+        let envelope_one = harn_vm::triggers::dispatcher::InboxEnvelope {
+            trigger_id: Some("cron-flow".to_string()),
+            binding_version: Some(1),
+            event: event_one.clone(),
+        };
+        let envelope_two = harn_vm::triggers::dispatcher::InboxEnvelope {
+            trigger_id: Some("cron-flow".to_string()),
+            binding_version: Some(1),
+            event: event_two.clone(),
+        };
+
+        ctx.event_log
+            .append(
+                &inbox_topic,
+                LogEvent::new(
+                    "event_ingested",
+                    serde_json::to_value(&envelope_one).unwrap(),
+                ),
+            )
+            .await
+            .unwrap();
+        ctx.event_log
+            .append(
+                &inbox_topic,
+                LogEvent::new(
+                    "event_ingested",
+                    serde_json::to_value(&envelope_two).unwrap(),
+                ),
+            )
+            .await
+            .unwrap();
+        ctx.event_log
+            .append(
+                &outbox_topic,
+                LogEvent::new(
+                    "dispatch_skipped",
+                    serde_json::json!({
+                        "event_id": "evt-2",
+                        "trigger_id": "cron-flow",
+                        "binding_key": "cron-flow@v1",
+                        "handler_kind": "local",
+                        "target_uri": "local://cron-flow",
+                        "skip_stage": "flow_control",
+                        "detail": {
+                            "flow_control": "rate_limited",
+                        },
+                    }),
+                )
+                .with_headers(BTreeMap::from([
+                    (String::from("event_id"), String::from("evt-2")),
+                    (String::from("trigger_id"), String::from("cron-flow")),
+                    (String::from("binding_key"), String::from("cron-flow@v1")),
+                ])),
+            )
+            .await
+            .unwrap();
+        ctx.event_log
+            .append(
+                &lifecycle_topic,
+                LogEvent::new(
+                    "predicate.evaluated",
+                    serde_json::json!({
+                        "cost_usd": 0.42,
+                    }),
+                )
+                .with_headers(BTreeMap::from([(
+                    String::from("binding_key"),
+                    String::from("cron-flow@v1"),
+                )])),
+            )
+            .await
+            .unwrap();
+
+        let inspect = collect_orchestrator_inspect_data(&mut ctx)
+            .await
+            .expect("collect inspect data");
+        let trigger = inspect
+            .triggers
+            .iter()
+            .find(|trigger| trigger.id == "cron-flow")
+            .expect("cron-flow trigger in inspect payload");
+
+        assert_eq!(
+            trigger
+                .flow_control
+                .singleton
+                .as_ref()
+                .and_then(|singleton| singleton.queue_depth_by_key.get("acme"))
+                .copied(),
+            Some(1)
+        );
+        assert_eq!(
+            trigger
+                .flow_control
+                .rate_limit
+                .as_ref()
+                .and_then(|rate_limit| rate_limit.util_by_key.get("acme"))
+                .map(|util| util.count),
+            Some(1)
+        );
+        assert_eq!(
+            trigger
+                .flow_control
+                .cost_budget
+                .as_ref()
+                .map(|budget| budget.used_usd),
+            Some(0.42)
+        );
+    }
+}

--- a/crates/harn-cli/src/commands/orchestrator/mod.rs
+++ b/crates/harn-cli/src/commands/orchestrator/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod common;
 mod dlq;
 mod fire;
 mod inspect;
+pub(crate) mod inspect_data;
 pub(crate) mod listener;
 mod origin_guard;
 mod queue;

--- a/crates/harn-cli/tests/mcp_server_cli.rs
+++ b/crates/harn-cli/tests/mcp_server_cli.rs
@@ -331,7 +331,7 @@ fn mcp_server_stdio_roundtrips_tools_and_resources() {
         }),
     );
     assert_eq!(
-        inspect["result"]["structuredContent"]["bindings"]
+        inspect["result"]["structuredContent"]["triggers"]
             .as_array()
             .unwrap()
             .len(),

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -74,6 +74,7 @@ pub use mcp_server::{
 };
 pub use metadata::{register_metadata_builtins, register_scan_builtins};
 pub use record_filter::{normalize_record_filter_expression, CompiledRecordFilter};
+pub use schema::json_to_vm_value;
 pub use stdlib::hitl::{
     append_hitl_response, HitlHostResponse, HITL_APPROVALS_TOPIC, HITL_DUAL_CONTROL_TOPIC,
     HITL_ESCALATIONS_TOPIC, HITL_QUESTIONS_TOPIC,

--- a/crates/harn-vm/src/schema/canonicalize.rs
+++ b/crates/harn-vm/src/schema/canonicalize.rs
@@ -480,7 +480,7 @@ fn json_type_for_harn(type_name: &str) -> serde_json::Value {
     serde_json::Value::String(json_type.to_string())
 }
 
-pub(crate) fn json_to_vm_value(jv: &serde_json::Value) -> VmValue {
+pub fn json_to_vm_value(jv: &serde_json::Value) -> VmValue {
     match jv {
         serde_json::Value::Null => VmValue::Nil,
         serde_json::Value::Bool(b) => VmValue::Bool(*b),

--- a/crates/harn-vm/src/schema/mod.rs
+++ b/crates/harn-vm/src/schema/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use api::{
     schema_pick_value, schema_result_value, schema_to_json_schema_value,
     schema_to_openapi_schema_value,
 };
-pub(crate) use canonicalize::json_to_vm_value;
+pub use canonicalize::json_to_vm_value;
 
 fn vm_value_to_serde_json(value: &VmValue) -> serde_json::Value {
     match value {

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -258,6 +258,12 @@ enum FlowControlOutcome {
     },
 }
 
+#[derive(Clone, Debug)]
+enum DispatchSkipStage {
+    Predicate,
+    FlowControl,
+}
+
 #[derive(Debug)]
 pub enum DispatchError {
     EventLog(String),
@@ -295,6 +301,15 @@ impl DispatchError {
             self,
             Self::Cancelled(_) | Self::Denied(_) | Self::NotImplemented(_)
         )
+    }
+}
+
+impl DispatchSkipStage {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Predicate => "predicate",
+            Self::FlowControl => "flow_control",
+        }
     }
 }
 
@@ -804,6 +819,18 @@ impl Dispatcher {
             .await?;
 
             if !passed {
+                self.append_skipped_outbox_event(
+                    binding,
+                    &route,
+                    &event,
+                    replay_of_event_id.as_ref(),
+                    DispatchSkipStage::Predicate,
+                    serde_json::json!({
+                        "predicate": predicate.raw,
+                        "reason": evaluation.reason,
+                    }),
+                )
+                .await?;
                 finish_in_flight(
                     binding.id.as_str(),
                     binding.version,
@@ -851,6 +878,17 @@ impl Dispatcher {
         {
             FlowControlOutcome::Dispatch { event, acquired } => (*event, acquired),
             FlowControlOutcome::Skip { reason } => {
+                self.append_skipped_outbox_event(
+                    binding,
+                    &route,
+                    &event,
+                    replay_of_event_id.as_ref(),
+                    DispatchSkipStage::FlowControl,
+                    serde_json::json!({
+                        "flow_control": reason,
+                    }),
+                )
+                .await?;
                 finish_in_flight(
                     binding.id.as_str(),
                     binding.version,
@@ -2322,6 +2360,36 @@ impl Dispatcher {
             Some(binding),
             None,
             payload,
+            replay_of_event_id,
+        )
+        .await
+    }
+
+    async fn append_skipped_outbox_event(
+        &self,
+        binding: &TriggerBinding,
+        route: &DispatchUri,
+        event: &TriggerEvent,
+        replay_of_event_id: Option<&String>,
+        stage: DispatchSkipStage,
+        detail: serde_json::Value,
+    ) -> Result<(), DispatchError> {
+        self.append_topic_event(
+            TRIGGER_OUTBOX_TOPIC,
+            "dispatch_skipped",
+            event,
+            Some(binding),
+            None,
+            serde_json::json!({
+                "event_id": event.id.0,
+                "trigger_id": binding.id.as_str(),
+                "binding_key": binding.binding_key(),
+                "handler_kind": route.kind(),
+                "target_uri": route.target_uri(),
+                "skip_stage": stage.as_str(),
+                "detail": detail,
+                "replay_of_event_id": replay_of_event_id,
+            }),
             replay_of_event_id,
         )
         .await

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -1834,6 +1834,20 @@ pub fn local_fn(event: TriggerEvent) -> string {
             assert!(events
                 .iter()
                 .any(|(_, event)| event.kind == "rate_limit_blocked"));
+
+            let outbox = read_topic(log.clone(), "trigger.outbox").await;
+            let skipped = outbox
+                .iter()
+                .find(|(_, event)| event.kind == "dispatch_skipped")
+                .expect("rate-limited dispatch emits skipped outbox record");
+            assert_eq!(
+                skipped.1.payload["skip_stage"],
+                serde_json::json!("flow_control")
+            );
+            assert_eq!(
+                skipped.1.payload["detail"]["flow_control"],
+                serde_json::json!("rate_limited")
+            );
         })
         .await;
 }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -457,7 +457,7 @@ harn orchestrator serve \
   --bind 0.0.0.0:8080 \
   --role single-tenant
 
-# Inspect the running orchestrator state snapshot + bindings.
+# Inspect the running orchestrator state, trigger flow-control state, and recent dispatches.
 harn orchestrator inspect --state-dir .harn/orchestrator
 
 # Inject a synthetic TriggerEvent to exercise a specific binding.

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -186,8 +186,8 @@ Retries one DLQ entry by id.
 
 ### `harn.orchestrator.inspect`
 
-Returns the dispatcher snapshot, bindings, persisted orchestrator snapshot, and
-recent dispatch records.
+Returns the dispatcher snapshot, trigger-centric inspect data, persisted
+orchestrator snapshot, flow-control state, and recent dispatch records.
 
 ### `harn.trust.query`
 


### PR DESCRIPTION
## Summary
- replace orchestrator inspect's binding snapshot with a trigger-centric payload that includes per-primitive flow-control state, rate-limit utilization, queue depth by key, and cost-budget consumption
- emit durable `dispatch_skipped` outbox records so offline inspect can treat skips as terminal outcomes when reconstructing queue and rate-limit state
- align the MCP inspect tool, docs, and tests with the new `triggers` payload

## Testing
- env CARGO_TARGET_DIR=/tmp/harn-aa90-target cargo test -p harn-vm flow_control_rate_limit_skips_excess_dispatches -- --nocapture
- env CARGO_TARGET_DIR=/tmp/harn-aa90-target cargo test -p harn-cli collect_orchestrator_inspect_data_reports_flow_control_state -- --nocapture
- env CARGO_TARGET_DIR=/tmp/harn-aa90-target cargo test -p harn-cli queue_and_inspect_tools_return_snapshots -- --nocapture
- env CARGO_TARGET_DIR=/tmp/harn-aa90-target cargo test -p harn-cli --test mcp_server_cli -- --nocapture