### PR TITLE
Forward-fix: cover bytes in exhaustive-narrowing conformance + spec

### DIFF
--- a/conformance/tests/types/unknown_exhaustive_narrowing.expected
+++ b/conformance/tests/types/unknown_exhaustive_narrowing.expected
@@ -4,6 +4,7 @@
 [harn] list:3
 [harn] dict:1
 [harn] bool:true
+[harn] bytes:2
 [harn] str
 [harn] int
 [harn] other

--- a/conformance/tests/types/unknown_exhaustive_narrowing.harn
+++ b/conformance/tests/types/unknown_exhaustive_narrowing.harn
@@ -1,4 +1,4 @@
-// Exhaustive narrowing on `unknown`: when all eight concrete `type_of`
+// Exhaustive narrowing on `unknown`: when all nine concrete `type_of`
 // variants are covered before an `unreachable()` fallback, the type
 // checker emits no warning and the program runs end-to-end.
 pipeline test(task) {
@@ -27,6 +27,9 @@ pipeline test(task) {
     if type_of(v) == "closure" {
       return "closure"
     }
+    if type_of(v) == "bytes" {
+      return "bytes:${bytes_len(v)}"
+    }
     unreachable("unknown type_of variant")
   }
   log(describe("hi"))
@@ -35,6 +38,7 @@ pipeline test(task) {
   log(describe([1, 2, 3]))
   log(describe({a: 1}))
   log(describe(true))
+  log(describe(bytes_from_string("ab")))
   // Partial narrowing with a plain `return` fallback is NOT an
   // exhaustiveness claim — it compiles silently and runs fine.
   fn categorize(v: unknown) -> string {
@@ -77,6 +81,9 @@ pipeline test(task) {
     }
     if type_of(v) == "closure" {
       return "c"
+    }
+    if type_of(v) == "bytes" {
+      return "bytes"
     }
     unreachable("unknown type_of variant")
   }

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -848,7 +848,9 @@ though this is mostly relevant for closures and parallel bodies.
 1. If path starts with `std/`, loads embedded stdlib module (e.g. `std/text`)
 2. Relative to current file's directory; auto-adds `.harn` extension
 3. `.harn/packages/<path>` directories rooted at the nearest ancestor
-   package root (the search walks upward and stops at a `.git` boundary)
+   package root (the search walks upward and stops at a `.git` boundary).
+   Harn materializes this tree from `harn.lock` before import-aware
+   commands run.
 4. Package manifest `[exports]` mappings under
    `.harn/packages/<package>/harn.toml`
 5. Package directories with `lib.harn` entry point
@@ -901,6 +903,7 @@ unresolved import itself still surfaces via the runtime loader.
 | Type | Syntax | Description |
 |---|---|---|
 | `string` | `"text"` | UTF-8 string |
+| `bytes` | builtin-produced | Immutable byte buffer |
 | `int` | `42` | Platform-width integer |
 | `float` | `3.14` | Double-precision float |
 | `bool` | `true` / `false` | Boolean |
@@ -924,6 +927,7 @@ unresolved import itself still surfaces via the runtime loader.
 | `int(0)` | No |
 | `float(0)` | No |
 | `string("")` | No |
+| `bytes(b"")` | No |
 | `list([])` | No |
 | `dict([:])` | No |
 | `set()` (empty) | No |
@@ -2290,7 +2294,7 @@ Narrowing rules for `unknown`:
 
 - `type_of(x) == "T"` narrows `x` to `T` on the truthy branch (where
   `T` is one of the type-of protocol names: `string`, `int`, `float`,
-  `bool`, `nil`, `list`, `dict`, `closure`).
+  `bool`, `nil`, `list`, `dict`, `closure`, `bytes`).
 - `schema_is(x, Shape)` narrows `x` to `Shape` on the truthy branch.
 - `guard type_of(x) == "T" else { ... }` narrows `x` to `T` in the
   surrounding scope after the guard.
@@ -2802,12 +2806,12 @@ fn handle(v: unknown) -> string {
   unreachable("unknown type_of variant")
   // warning: `unreachable()` reached but `v: unknown` was not fully
   // narrowed — uncovered concrete type(s): float, bool, nil, list,
-  // dict, closure
+  // dict, closure, bytes
 }
 ```
 
-Covering all eight `type_of` variants (`int`, `string`, `float`, `bool`,
-`nil`, `list`, `dict`, `closure`) silences the warning. Suppression via
+Covering all nine `type_of` variants (`int`, `string`, `float`, `bool`,
+`nil`, `list`, `dict`, `closure`, `bytes`) silences the warning. Suppression via
 an explicit fallthrough `return` is intentional: a plain `return`
 doesn't claim exhaustiveness, so partial narrowing followed by a normal
 return stays silent. Reaching `throw` or `unreachable()` with no prior
@@ -2852,8 +2856,8 @@ If the types do not match, a `TypeError` is thrown:
 TypeError: parameter 'name' expected string, got int (42)
 ```
 
-The following types are enforced at runtime: `int`, `float`, `string`, `bool`,
-`list`, `dict`, `set`, `nil`, and `closure`. `int` and `float` are mutually
+The following types are enforced at runtime: `int`, `float`, `string`, `bytes`,
+`bool`, `list`, `dict`, `set`, `nil`, and `closure`. `int` and `float` are mutually
 compatible (passing an `int` to a `float` parameter is allowed, and vice versa).
 Union types, `list<T>`, `dict<string, V>`, and nested shapes are also checked at
 runtime when the parameter annotation can be lowered into a runtime schema.
@@ -2961,6 +2965,17 @@ Sets are iterable with `for ... in` and support `len()`.
 | `base32_decode(str)` | Returns the decoded string from a base32-encoded `str` |
 | `hex_encode(str)` | Returns the lowercase hex encoding of `str` |
 | `hex_decode(str)` | Returns the decoded string from a hex-encoded `str` |
+| `bytes_from_string(str)` | UTF-8 encodes `str` into `bytes` |
+| `bytes_to_string(bytes)` | UTF-8 decodes `bytes` into `string` |
+| `bytes_to_string_lossy(bytes)` | Lossy UTF-8 decode of `bytes` |
+| `bytes_from_hex(str)` | Parses lowercase/uppercase hex into `bytes` |
+| `bytes_to_hex(bytes)` | Hex-encodes `bytes` |
+| `bytes_from_base64(str)` | Decodes base64 into `bytes` |
+| `bytes_to_base64(bytes)` | Encodes `bytes` as base64 |
+| `bytes_len(bytes)` | Returns the length in octets |
+| `bytes_concat(a, b)` | Concatenates two byte buffers |
+| `bytes_slice(bytes, start, end)` | Returns a clamped slice of a byte buffer |
+| `bytes_eq(a, b)` | Constant-time byte equality check |
 | `sha256(str)` | Returns the hex-encoded SHA-256 hash of `str` |
 | `md5(str)` | Returns the hex-encoded MD5 hash of `str` |
 
@@ -3355,6 +3370,43 @@ each. Positional targets remain additive. The manifest is discovered by
 walking upward from the first positional target (or the current working
 directory when none is supplied).
 
+### `[dependencies]` and `harn.lock` — git-backed package installs
+
+```toml
+[dependencies]
+notion-sdk-harn = { git = "https://github.com/burin-labs/notion-sdk-harn", rev = "v1.2.3" }
+notion = { git = "https://github.com/burin-labs/notion-sdk-harn", rev = "v1.2.3", package = "notion-sdk-harn" }
+openapi = { git = "https://github.com/burin-labs/harn-openapi", branch = "main" }
+local-fixture = { path = "../fixture-lib" }
+```
+
+`[dependencies]` installs package sources into `.harn/packages/` so
+imports like `import "notion-sdk-harn"` or `import "notion/providers"`
+resolve without filesystem-relative hacks.
+
+- The table key is the local import alias.
+- `git` accepts HTTPS, SSH, `file://`, local-repo paths, and GitHub-style
+  shorthand URLs.
+- `rev` pins a tag, symbolic ref, or full commit SHA in the manifest.
+- `branch` records a moving ref in the manifest, but `harn.lock` still
+  pins one resolved commit for reproducible installs.
+- `package` documents the upstream package name when the local alias
+  differs from the repository name.
+- `path` installs a local directory or `.harn` file without using the
+  shared git cache.
+
+`harn.lock` is a typed TOML file with `version = 1` and one `[[package]]`
+entry per dependency. Each git entry records:
+
+- `source`
+- `rev_request`
+- `commit`
+- `content_hash`
+
+`content_hash` is a SHA-256 over the cached package tree. Harn verifies
+that hash whenever it reuses a cached package or re-materializes
+`.harn/packages/<alias>/`.
+
 ### `[exports]` — stable package module entry points
 
 ```toml
@@ -3394,11 +3446,12 @@ When Harn starts from a file inside a workspace, it merges:
 1. built-in defaults,
 2. the global provider file (`HARN_PROVIDERS_CONFIG` or
    `~/.config/harn/providers.toml`),
-3. installed package `[llm]` tables from `.harn/packages/*/harn.toml`,
-4. the root project's `[llm]` table.
+3. the root project's `[llm]` table.
 
-Later layers win on key collisions; rule lists are prepended so package
-and project inference/tier overrides run before the built-in defaults.
+Installed package manifests do not auto-merge runtime extensions such as
+`[llm]`, `[capabilities]`, `[[hooks]]`, or `[[triggers]]` into the host
+project. Package code is importable; host runtime configuration remains
+root-manifest-owned by default.
 
 ### `[lint]` — lint configuration
 


### PR DESCRIPTION
PR #354 added `bytes` as a 9th concrete `type_of` variant but the `unknown_exhaustive_narrowing` conformance test only covered the original 8. The release audit's conformance gate now correctly warns about uncovered `bytes` and fails. Adds `bytes` branches to `describe()` and `shape()`, updates `.expected`, and revises language-spec.md "eight" → "nine".