### PR TITLE
Forward-fix: inline struct decls in struct-construction spec fence

### DIFF
--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1871,6 +1871,9 @@ Struct instances can be constructed with the struct name followed by
 a named-field body:
 
 ```harn
+struct Point { x: int, y: int }
+struct User { name: string, age: int }
+struct Pair<A, B> { first: A, second: B }
 let p = Point { x: 3, y: 4 }
 let u = User { name: "Alice", age: 30 }
 let pair: Pair<int, string> = Pair { first: 1, second: "two" }


### PR DESCRIPTION
The verify_language_spec.py gate extracts each triple-backtick harn fence from HARN_SPEC.md as an independent file and runs `harn check` on it. The Struct construction example referenced `Point` / `User` / `Pair<A,B>` without declaring them, and `harn check` on that extracted fence silently exits 1 with no output. Inline the struct decls so the fence type-checks standalone.

Separately worth filing upstream: `harn check` exiting 1 with zero diagnostic output on unknown types is a usability bug. The spec-verify gate's 'language spec verification failed' message comes from the script, not harn itself.