### PR TITLE
Forward-fix: spec also says 'nine' type_of variants

### DIFF
--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -2811,7 +2811,7 @@ fn handle(v: unknown) -> string {
 }
 ```
 
-Covering all eight `type_of` variants (`int`, `string`, `float`, `bool`,
+Covering all nine `type_of` variants (`int`, `string`, `float`, `bool`,
 `nil`, `list`, `dict`, `closure`, `bytes`) silences the warning. Suppression via
 an explicit fallthrough `return` is intentional: a plain `return`
 doesn't claim exhaustiveness, so partial narrowing followed by a normal


### PR DESCRIPTION
#368 flipped 'eight' → 'nine' in docs/src/language-spec.md but left spec/HARN_SPEC.md unchanged. sync_language_spec regenerates docs from spec, so every release re-introduced the drift. One-line fix.