### PR TITLE
Forward-fix: sync docs/src/language-spec.md after #369

### DIFF
--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1873,6 +1873,9 @@ Struct instances can be constructed with the struct name followed by
 a named-field body:
 
 ```harn
+struct Point { x: int, y: int }
+struct User { name: string, age: int }
+struct Pair<A, B> { first: A, second: B }
 let p = Point { x: 3, y: 4 }
 let u = User { name: "Alice", age: 30 }
 let pair: Pair<int, string> = Pair { first: 1, second: "two" }


### PR DESCRIPTION
Mirrors the inline struct decls from HARN_SPEC.md that #369 added; sync_language_spec was dirtying the tree at release time.