### PR TITLE
[codex] Add native tool fallback controls and observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ encoding helpers, and first-class `bytes` + raw inbound bodies now
 ship together so external connector repos can be written entirely
 in Harn.
 
+### Fixed
+
+- **Native-tool stages can now fail closed or one-shot text fallback,
+  and they expose structured fallback/retry metadata (#229).**
+  `agent_loop`, `sub_agent_run`, and workflow `model_policy` now accept
+  `native_tool_fallback: "allow" | "allow_once" | "reject"` for
+  native-tool stages. Harn also records
+  `native_text_tool_fallbacks`,
+  `native_text_tool_fallback_rejections`, and
+  `empty_completion_retries` in stage trace summaries / observability so
+  eval tooling can distinguish tolerated provider recovery from the
+  intended native-tool contract.
+
 ### Added
 
 - **Git-backed package manager v0 (#345, #355).** Typed lockfile with

--- a/conformance/tests/integration/native_tool_fallback_observability.expected
+++ b/conformance/tests/integration/native_tool_fallback_observability.expected
@@ -1,0 +1,6 @@
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/integration/native_tool_fallback_observability.harn
+++ b/conformance/tests/integration/native_tool_fallback_observability.harn
@@ -1,0 +1,53 @@
+fn tools() {
+  var registry = tool_registry()
+  registry = tool_define(
+    registry,
+    "read",
+    "Read a file",
+    {
+    handler: { args -> "read:" + args.path },
+    parameters: {path: {type: "string", description: "Path to read"}},
+    returns: {type: "string"},
+  },
+  )
+  return registry
+}
+
+pipeline default() {
+  llm_mock_clear()
+  llm_mock({text: "<tool_call>\nread({ path: \"src/lib.rs\" })\n</tool_call>"})
+  llm_mock({text: "<tool_call>\nread({ path: \"src/lib.rs\" })\n</tool_call>"})
+  let fallback = agent_loop(
+    "Inspect the repo",
+    "You are helpful",
+    {
+    provider: "mock",
+    tools: tools(),
+    tool_format: "native",
+    native_tool_fallback: "allow_once",
+    persistent: true,
+    max_iterations: 2,
+  },
+  )
+  println(fallback?.trace?.native_text_tool_fallbacks == 2)
+  println(fallback?.trace?.native_text_tool_fallback_rejections == 1)
+  let fallback_events = transcript_events_by_kind(fallback?.transcript, "native_tool_fallback")
+  println(len(fallback_events) == 2)
+  println(fallback_events[0]?.metadata?.accepted == true)
+  println(fallback_events[1]?.metadata?.accepted == false)
+
+  llm_mock_clear()
+  llm_mock({
+    error: {
+      category: "server_error",
+      message: "openai-compatible model mock reported completion_tokens=1 but delivered no content, reasoning, or tool calls",
+    },
+  })
+  llm_mock({text: "<done>##DONE##</done>"})
+  let retried = agent_loop(
+    "Finish the task",
+    "You are helpful",
+    {provider: "mock", persistent: true, max_iterations: 1},
+  )
+  println(retried?.trace?.empty_completion_retries == 1)
+}

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -52,6 +52,7 @@ use super::state::AgentLoopState;
 pub(super) struct LlmCallContext<'a> {
     pub bridge: &'a Option<Rc<HostBridge>>,
     pub tool_format: &'a str,
+    pub native_tool_fallback: crate::orchestration::NativeToolFallbackPolicy,
     pub done_sentinel: &'a str,
     pub break_unless_phase: Option<&'a str>,
     pub exit_when_verified: bool,
@@ -270,14 +271,70 @@ pub(super) async fn run_llm_call(
         // a native `tools` channel (the model's chat template doesn't
         // actually route through the native function-call surface).
         // Discarding them would strand a legitimate call mid-loop.
-        if ctx.tool_format == "native" && !parse_result.calls.is_empty() {
-            crate::events::log_info(
-                "llm.tool",
-                "native-mode stage accepted text-mode tool calls (model fell back to text)",
-            );
-        }
         {
-            let calls = parse_result.calls;
+            let mut calls = parse_result.calls;
+            let parsed_call_count = calls.len();
+            if ctx.tool_format == "native" && !calls.is_empty() {
+                state.native_text_tool_fallbacks += 1;
+                let fallback_index = state.native_text_tool_fallbacks;
+                let accepted = match ctx.native_tool_fallback {
+                    crate::orchestration::NativeToolFallbackPolicy::Allow => true,
+                    crate::orchestration::NativeToolFallbackPolicy::AllowOnce => {
+                        fallback_index == 1
+                    }
+                    crate::orchestration::NativeToolFallbackPolicy::Reject => false,
+                };
+                if accepted {
+                    crate::events::log_info(
+                        "llm.tool",
+                        "native-mode stage accepted text-mode tool calls (model fell back to text)",
+                    );
+                } else {
+                    state.native_text_tool_fallback_rejections += 1;
+                    crate::events::log_warn(
+                        "llm.tool",
+                        &format!(
+                            "native-mode stage rejected text-mode tool calls (policy={}, fallback_index={fallback_index})",
+                            ctx.native_tool_fallback.as_str(),
+                        ),
+                    );
+                    let feedback = format!(
+                        "This stage is running in native tool mode. Your last response emitted text-mode tool calls instead of provider-native tool calls.\n\n\
+                         Re-issue the same action using ONLY the native tool channel. Do not write `<tool_call>` tags, bare `name({{ ... }})` calls, Markdown fences, or JSON tool-call envelopes in assistant text.\n\n\
+                         Policy: `{}`. Observed fallback turn: {}.",
+                        ctx.native_tool_fallback.as_str(),
+                        fallback_index,
+                    );
+                    append_message_to_contexts(
+                        &mut state.visible_messages,
+                        &mut state.recorded_messages,
+                        runtime_feedback_message("native_tool_contract", feedback),
+                    );
+                    calls.clear();
+                }
+                state.transcript_events.push(transcript_event(
+                    "native_tool_fallback",
+                    "assistant",
+                    "internal",
+                    "",
+                    Some(serde_json::json!({
+                        "accepted": accepted,
+                        "policy": ctx.native_tool_fallback.as_str(),
+                        "fallback_index": fallback_index,
+                        "tool_call_count": parsed_call_count,
+                        "tool_parse_error_count": tool_parse_errors.len(),
+                    })),
+                ));
+                super::super::trace::emit_agent_event(
+                    super::super::trace::AgentTraceEvent::NativeToolFallback {
+                        iteration,
+                        accepted,
+                        policy: ctx.native_tool_fallback.as_str().to_string(),
+                        fallback_index,
+                        tool_call_count: parsed_call_count,
+                    },
+                );
+            }
 
             // Emit feedback on ANY parse error so mixed-batch cases
             // (some calls parsed, some didn't) still signal the model.

--- a/crates/harn-vm/src/llm/agent/mod.rs
+++ b/crates/harn-vm/src/llm/agent/mod.rs
@@ -198,6 +198,7 @@ pub async fn run_agent_loop_internal(
     let loop_detect_enabled = state.loop_detect_enabled;
     let resumed_iterations = state.resumed_iterations;
     let tool_format = state.tool_format.clone();
+    let native_tool_fallback = state.config.native_tool_fallback;
     let done_sentinel = state.done_sentinel.clone();
     let break_unless_phase = state.break_unless_phase.clone();
     let loop_start = state.loop_start;
@@ -292,6 +293,7 @@ pub async fn run_agent_loop_internal(
             &llm_call::LlmCallContext {
                 bridge: &bridge,
                 tool_format: &tool_format,
+                native_tool_fallback,
                 done_sentinel: &done_sentinel,
                 break_unless_phase: break_unless_phase.as_deref(),
                 exit_when_verified,

--- a/crates/harn-vm/src/llm/agent/state.rs
+++ b/crates/harn-vm/src/llm/agent/state.rs
@@ -486,6 +486,8 @@ pub(super) struct AgentLoopState {
     pub(super) daemon_state: String,
     pub(super) daemon_snapshot_path: Option<String>,
     pub(super) daemon_watch_state: std::collections::BTreeMap<String, u64>,
+    pub(super) native_text_tool_fallbacks: usize,
+    pub(super) native_text_tool_fallback_rejections: usize,
 
     /// Set only by the finalize phase.
     pub(super) final_status: &'static str,
@@ -1175,6 +1177,8 @@ impl AgentLoopState {
         };
         let mut daemon_snapshot_path: Option<String> = None;
         let mut daemon_watch_state = watch_state(&daemon_config.watch_paths);
+        let native_text_tool_fallbacks = 0usize;
+        let native_text_tool_fallback_rejections = 0usize;
         let mut resumed_iterations = 0usize;
         let mut last_run_exit_code = last_run_exit_code;
 
@@ -1247,6 +1251,8 @@ impl AgentLoopState {
             daemon_state,
             daemon_snapshot_path,
             daemon_watch_state,
+            native_text_tool_fallbacks,
+            native_text_tool_fallback_rejections,
             final_status,
             loop_start,
             bridge,

--- a/crates/harn-vm/src/llm/agent/tests/mod.rs
+++ b/crates/harn-vm/src/llm/agent/tests/mod.rs
@@ -29,6 +29,7 @@ pub(super) use std::rc::Rc;
 pub(super) use std::sync::atomic::AtomicBool;
 pub(super) use std::sync::{Arc, Mutex};
 
+mod native_tool_fallback;
 mod phase_history;
 mod policy;
 mod prompts;
@@ -83,6 +84,7 @@ pub(super) fn base_agent_config() -> AgentLoopConfig {
         tool_retries: 0,
         tool_backoff_ms: 1,
         tool_format: "text".to_string(),
+        native_tool_fallback: crate::orchestration::NativeToolFallbackPolicy::Allow,
         auto_compact: None,
         policy: None,
         approval_policy: None,

--- a/crates/harn-vm/src/llm/agent/tests/native_tool_fallback.rs
+++ b/crates/harn-vm/src/llm/agent/tests/native_tool_fallback.rs
@@ -1,0 +1,209 @@
+use super::*;
+
+fn read_tool_registry() -> VmValue {
+    let mut tool_params = std::collections::BTreeMap::new();
+    tool_params.insert(
+        "path".to_string(),
+        VmValue::Dict(Rc::new(std::collections::BTreeMap::from([(
+            "type".to_string(),
+            VmValue::String(Rc::from("string")),
+        )]))),
+    );
+    let tool = VmValue::Dict(Rc::new(std::collections::BTreeMap::from([
+        ("name".to_string(), VmValue::String(Rc::from("read"))),
+        (
+            "description".to_string(),
+            VmValue::String(Rc::from("Read a file.")),
+        ),
+        (
+            "parameters".to_string(),
+            VmValue::Dict(Rc::new(tool_params)),
+        ),
+    ])));
+    VmValue::Dict(Rc::new(std::collections::BTreeMap::from([(
+        "tools".to_string(),
+        VmValue::List(Rc::new(vec![tool])),
+    )])))
+}
+
+fn text_tool_call_response() -> String {
+    "<tool_call>\nread({ path: \"src/lib.rs\" })\n</tool_call>".to_string()
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn allow_once_accepts_first_native_text_fallback_and_rejects_second() {
+    reset_llm_mock_state();
+    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
+        text: text_tool_call_response(),
+        tool_calls: Vec::new(),
+        match_pattern: None,
+        consume_on_match: true,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: None,
+        stop_reason: None,
+        model: "mock".to_string(),
+        provider: None,
+        blocks: None,
+        error: None,
+    });
+    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
+        text: text_tool_call_response(),
+        tool_calls: Vec::new(),
+        match_pattern: None,
+        consume_on_match: true,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: None,
+        stop_reason: None,
+        model: "mock".to_string(),
+        provider: None,
+        blocks: None,
+        error: None,
+    });
+
+    let mut opts = base_opts(vec![json!({
+        "role": "user",
+        "content": "inspect the source tree",
+    })]);
+    opts.tools = Some(read_tool_registry());
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 2;
+    config.tool_format = "native".to_string();
+    config.native_tool_fallback = crate::orchestration::NativeToolFallbackPolicy::AllowOnce;
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_eq!(result["trace"]["native_text_tool_fallbacks"], json!(2));
+    assert_eq!(
+        result["trace"]["native_text_tool_fallback_rejections"],
+        json!(1)
+    );
+
+    let events = result["transcript"]["events"]
+        .as_array()
+        .expect("transcript events array");
+    let fallback_events = events
+        .iter()
+        .filter(|event| event["kind"] == "native_tool_fallback")
+        .collect::<Vec<_>>();
+    assert_eq!(fallback_events.len(), 2);
+    assert_eq!(fallback_events[0]["metadata"]["accepted"], json!(true));
+    assert_eq!(fallback_events[1]["metadata"]["accepted"], json!(false));
+    assert!(events.iter().any(|event| {
+        event["kind"] == "message"
+            && event["text"]
+                .as_str()
+                .unwrap_or("")
+                .contains("native tool mode")
+    }));
+
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn reject_policy_blocks_first_native_text_fallback() {
+    reset_llm_mock_state();
+    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
+        text: text_tool_call_response(),
+        tool_calls: Vec::new(),
+        match_pattern: None,
+        consume_on_match: true,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: None,
+        stop_reason: None,
+        model: "mock".to_string(),
+        provider: None,
+        blocks: None,
+        error: None,
+    });
+
+    let mut opts = base_opts(vec![json!({
+        "role": "user",
+        "content": "inspect the source tree",
+    })]);
+    opts.tools = Some(read_tool_registry());
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 1;
+    config.tool_format = "native".to_string();
+    config.native_tool_fallback = crate::orchestration::NativeToolFallbackPolicy::Reject;
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_eq!(result["trace"]["native_text_tool_fallbacks"], json!(1));
+    assert_eq!(
+        result["trace"]["native_text_tool_fallback_rejections"],
+        json!(1)
+    );
+    let events = result["transcript"]["events"]
+        .as_array()
+        .expect("transcript events array");
+    let fallback_event = events
+        .iter()
+        .find(|event| event["kind"] == "native_tool_fallback")
+        .expect("native_tool_fallback event");
+    assert_eq!(fallback_event["metadata"]["accepted"], json!(false));
+
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn empty_completion_retry_is_counted_in_trace_summary() {
+    reset_llm_mock_state();
+    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
+        text: String::new(),
+        tool_calls: Vec::new(),
+        match_pattern: None,
+        consume_on_match: true,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: None,
+        stop_reason: None,
+        model: "mock".to_string(),
+        provider: None,
+        blocks: None,
+        error: Some(crate::llm::mock::MockError {
+            category: crate::value::ErrorCategory::ServerError,
+            message: "openai-compatible model mock reported completion_tokens=1 but delivered no content, reasoning, or tool calls".to_string(),
+        }),
+    });
+    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
+        text: "<done>##DONE##</done>".to_string(),
+        tool_calls: Vec::new(),
+        match_pattern: None,
+        consume_on_match: true,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: None,
+        stop_reason: None,
+        model: "mock".to_string(),
+        provider: None,
+        blocks: None,
+        error: None,
+    });
+
+    let mut opts = base_opts(vec![json!({
+        "role": "user",
+        "content": "finish this task",
+    })]);
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 1;
+    config.llm_retries = 1;
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_eq!(result["trace"]["empty_completion_retries"], json!(1));
+
+    reset_llm_mock_state();
+}

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -27,6 +27,7 @@ pub struct AgentLoopConfig {
     pub tool_retries: usize,
     pub tool_backoff_ms: u64,
     pub tool_format: String,
+    pub native_tool_fallback: crate::orchestration::NativeToolFallbackPolicy,
     /// Auto-compaction config.
     pub auto_compact: Option<crate::orchestration::AutoCompactConfig>,
     /// Capability policy scoped to this agent loop.
@@ -278,6 +279,18 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                 let provider = opts.as_ref().map(|o| o.provider.as_str()).unwrap_or("");
                 crate::llm_config::default_tool_format(model, provider)
             });
+            let native_tool_fallback = opt_str(&options, "native_tool_fallback")
+                .map(|value| {
+                    crate::orchestration::NativeToolFallbackPolicy::parse(&value).ok_or_else(
+                        || {
+                            crate::value::VmError::Runtime(format!(
+                                "agent_loop: native_tool_fallback must be one of allow, allow_once, reject; got `{value}`"
+                            ))
+                        },
+                    )
+                })
+                .transpose()?
+                .unwrap_or_default();
             let done_sentinel = opt_str(&options, "done_sentinel");
             let break_unless_phase = opt_str(&options, "break_unless_phase");
             let session_id = opt_str(&options, "session_id")
@@ -376,6 +389,7 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                     tool_retries,
                     tool_backoff_ms,
                     tool_format,
+                    native_tool_fallback,
                     auto_compact,
                     policy,
                     approval_policy,

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -127,6 +127,17 @@ pub(super) fn is_retryable_llm_error(err: &VmError) -> bool {
         || lower.contains("eof")
 }
 
+fn is_empty_completion_retry_error(err: &VmError) -> bool {
+    let msg = match err {
+        VmError::Thrown(crate::value::VmValue::String(s)) => s.as_ref(),
+        VmError::CategorizedError { message, .. } => message.as_str(),
+        VmError::Runtime(s) => s.as_str(),
+        _ => return false,
+    };
+    let lower = msg.to_lowercase();
+    lower.contains("completion_tokens=") && lower.contains("delivered no content")
+}
+
 /// Extract retry-after delay from an error message if present.
 ///
 /// Supports both forms defined by RFC 7231 §7.1.3:
@@ -609,6 +620,28 @@ pub(crate) async fn observed_llm_call(
                 }
                 if !can_retry {
                     return Err(error);
+                }
+                if is_empty_completion_retry_error(&error) {
+                    append_llm_observability_entry(
+                        "empty_completion_retry",
+                        serde_json::Map::from_iter([
+                            (
+                                "iteration".to_string(),
+                                serde_json::json!(iteration.unwrap_or(0)),
+                            ),
+                            ("attempt".to_string(), serde_json::json!(attempt + 1)),
+                            ("provider".to_string(), serde_json::json!(opts.provider)),
+                            ("model".to_string(), serde_json::json!(opts.model)),
+                            ("error".to_string(), serde_json::json!(error.to_string())),
+                        ]),
+                    );
+                    super::trace::emit_agent_event(
+                        super::trace::AgentTraceEvent::EmptyCompletionRetry {
+                            iteration: iteration.unwrap_or(0),
+                            attempt: attempt + 1,
+                            error: error.to_string(),
+                        },
+                    );
                 }
                 attempt += 1;
                 let backoff = extract_retry_after_ms(&error)

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -639,6 +639,16 @@ pub fn register_llm_builtins(vm: &mut Vm) {
         let tool_retries = opt_int(&options, "tool_retries").unwrap_or(0) as usize;
         let tool_backoff_ms = opt_int(&options, "tool_backoff_ms").unwrap_or(1000) as u64;
         let tool_format = opt_str(&options, "tool_format").unwrap_or_else(|| "text".to_string());
+        let native_tool_fallback = opt_str(&options, "native_tool_fallback")
+            .map(|value| {
+                crate::orchestration::NativeToolFallbackPolicy::parse(&value).ok_or_else(|| {
+                    crate::value::VmError::Runtime(format!(
+                        "agent_loop: native_tool_fallback must be one of allow, allow_once, reject; got `{value}`"
+                    ))
+                })
+            })
+            .transpose()?
+            .unwrap_or_default();
         let daemon = opt_bool(&options, "daemon");
         // Empty string means "mint an anonymous session" (state.rs handles
         // this path and does not persist). A caller-provided id flows
@@ -713,6 +723,7 @@ pub fn register_llm_builtins(vm: &mut Vm) {
                 tool_retries,
                 tool_backoff_ms,
                 tool_format,
+                native_tool_fallback,
                 auto_compact,
                 policy,
                 approval_policy,

--- a/crates/harn-vm/src/llm/trace.rs
+++ b/crates/harn-vm/src/llm/trace.rs
@@ -121,6 +121,18 @@ pub enum AgentTraceEvent {
         errors: Vec<String>,
         nudge_used: bool,
     },
+    NativeToolFallback {
+        iteration: usize,
+        accepted: bool,
+        policy: String,
+        fallback_index: usize,
+        tool_call_count: usize,
+    },
+    EmptyCompletionRetry {
+        iteration: usize,
+        attempt: usize,
+        error: String,
+    },
 }
 
 thread_local! {
@@ -151,6 +163,9 @@ pub fn agent_trace_summary() -> serde_json::Value {
         let mut tool_rejections = 0usize;
         let mut interventions = 0usize;
         let mut compactions = 0usize;
+        let mut native_text_tool_fallbacks = 0usize;
+        let mut native_text_tool_fallback_rejections = 0usize;
+        let mut empty_completion_retries = 0usize;
         let mut total_input_tokens = 0i64;
         let mut total_output_tokens = 0i64;
         let mut total_llm_duration_ms = 0u64;
@@ -205,6 +220,15 @@ pub fn agent_trace_summary() -> serde_json::Value {
                     total_duration_ms = *d;
                 }
                 AgentTraceEvent::SchemaRetry { .. } => {}
+                AgentTraceEvent::NativeToolFallback { accepted, .. } => {
+                    native_text_tool_fallbacks += 1;
+                    if !accepted {
+                        native_text_tool_fallback_rejections += 1;
+                    }
+                }
+                AgentTraceEvent::EmptyCompletionRetry { .. } => {
+                    empty_completion_retries += 1;
+                }
             }
         }
 
@@ -217,6 +241,9 @@ pub fn agent_trace_summary() -> serde_json::Value {
             "tool_rejections": tool_rejections,
             "interventions": interventions,
             "compactions": compactions,
+            "native_text_tool_fallbacks": native_text_tool_fallbacks,
+            "native_text_tool_fallback_rejections": native_text_tool_fallback_rejections,
+            "empty_completion_retries": empty_completion_retries,
             "total_input_tokens": total_input_tokens,
             "total_output_tokens": total_output_tokens,
             "total_llm_duration_ms": total_llm_duration_ms,

--- a/crates/harn-vm/src/orchestration/policy/mod.rs
+++ b/crates/harn-vm/src/orchestration/policy/mod.rs
@@ -20,8 +20,9 @@ use crate::workspace_path::{classify_workspace_path, WorkspacePathInfo};
 pub use crate::tool_annotations::{ToolArgSchema, ToolKind};
 pub use types::{
     enforce_tool_arg_constraints, AutoCompactPolicy, BranchSemantics, CapabilityPolicy,
-    ContextPolicy, EqIgnored, EscalationPolicy, JoinPolicy, MapPolicy, ModelPolicy, ReducePolicy,
-    RetryPolicy, StageContract, ToolArgConstraint, TurnPolicy,
+    ContextPolicy, EqIgnored, EscalationPolicy, JoinPolicy, MapPolicy, ModelPolicy,
+    NativeToolFallbackPolicy, ReducePolicy, RetryPolicy, StageContract, ToolArgConstraint,
+    TurnPolicy,
 };
 
 thread_local! {

--- a/crates/harn-vm/src/orchestration/policy/types.rs
+++ b/crates/harn-vm/src/orchestration/policy/types.rs
@@ -304,6 +304,34 @@ impl Default for TurnPolicy {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeToolFallbackPolicy {
+    #[default]
+    Allow,
+    AllowOnce,
+    Reject,
+}
+
+impl NativeToolFallbackPolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::AllowOnce => "allow_once",
+            Self::Reject => "reject",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "allow" => Some(Self::Allow),
+            "allow_once" => Some(Self::AllowOnce),
+            "reject" => Some(Self::Reject),
+            _ => None,
+        }
+    }
+}
+
 fn default_true() -> bool {
     true
 }
@@ -351,6 +379,9 @@ pub struct ModelPolicy {
     /// option. When `None`, the workflow falls back to `HARN_AGENT_TOOL_FORMAT`
     /// env / the provider-model default.
     pub tool_format: Option<String>,
+    /// Policy for native-tool stages when a provider emits text-mode
+    /// `<tool_call>` output instead of native tool calls.
+    pub native_tool_fallback: NativeToolFallbackPolicy,
 }
 
 /// Wrapper that always compares equal, allowing non-Eq types in derived PartialEq structs.

--- a/crates/harn-vm/src/orchestration/records.rs
+++ b/crates/harn-vm/src/orchestration/records.rs
@@ -195,6 +195,9 @@ pub struct RunPlannerRoundRecord {
     pub tool_rejection_count: usize,
     pub intervention_count: usize,
     pub compaction_count: usize,
+    pub native_text_tool_fallback_count: usize,
+    pub native_text_tool_fallback_rejection_count: usize,
+    pub empty_completion_retry_count: usize,
     pub tools_used: Vec<String>,
     pub successful_tools: Vec<String>,
     pub ledger_done_rejections: usize,
@@ -1026,6 +1029,15 @@ pub fn derive_run_observability(
                 ),
                 intervention_count: json_usize(trace.and_then(|trace| trace.get("interventions"))),
                 compaction_count: json_usize(trace.and_then(|trace| trace.get("compactions"))),
+                native_text_tool_fallback_count: json_usize(
+                    trace.and_then(|trace| trace.get("native_text_tool_fallbacks")),
+                ),
+                native_text_tool_fallback_rejection_count: json_usize(
+                    trace.and_then(|trace| trace.get("native_text_tool_fallback_rejections")),
+                ),
+                empty_completion_retry_count: json_usize(
+                    trace.and_then(|trace| trace.get("empty_completion_retries")),
+                ),
                 tools_used,
                 successful_tools,
                 ledger_done_rejections: json_usize(payload.get("ledger_done_rejections")),
@@ -1035,6 +1047,9 @@ pub fn derive_run_observability(
             let has_agentic_detail = planner_round.iteration_count > 0
                 || planner_round.llm_call_count > 0
                 || planner_round.tool_execution_count > 0
+                || planner_round.native_text_tool_fallback_count > 0
+                || planner_round.native_text_tool_fallback_rejection_count > 0
+                || planner_round.empty_completion_retry_count > 0
                 || planner_round.ledger_done_rejections > 0
                 || planner_round.task_ledger.is_some()
                 || !planner_round.tools_used.is_empty()
@@ -1801,6 +1816,33 @@ pub fn diff_run_records(left: &RunRecord, right: &RunRecord) -> RunDiffReport {
                     details.push(format!(
                         "tool_executions: {} -> {}",
                         left_round.tool_execution_count, right_round.tool_execution_count
+                    ));
+                }
+                if left_round.native_text_tool_fallback_count
+                    != right_round.native_text_tool_fallback_count
+                {
+                    details.push(format!(
+                        "native_text_tool_fallbacks: {} -> {}",
+                        left_round.native_text_tool_fallback_count,
+                        right_round.native_text_tool_fallback_count
+                    ));
+                }
+                if left_round.native_text_tool_fallback_rejection_count
+                    != right_round.native_text_tool_fallback_rejection_count
+                {
+                    details.push(format!(
+                        "native_text_tool_fallback_rejections: {} -> {}",
+                        left_round.native_text_tool_fallback_rejection_count,
+                        right_round.native_text_tool_fallback_rejection_count
+                    ));
+                }
+                if left_round.empty_completion_retry_count
+                    != right_round.empty_completion_retry_count
+                {
+                    details.push(format!(
+                        "empty_completion_retries: {} -> {}",
+                        left_round.empty_completion_retry_count,
+                        right_round.empty_completion_retry_count
                     ));
                 }
                 if left_round.research_facts != right_round.research_facts {

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1404,6 +1404,7 @@ pub async fn execute_stage_node(
                     tool_retries: 0,
                     tool_backoff_ms: 1000,
                     tool_format: tool_format.clone(),
+                    native_tool_fallback: node.model_policy.native_tool_fallback,
                     auto_compact,
                     policy: Some(effective_policy),
                     approval_policy: Some(node.approval_policy.clone()),

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -634,6 +634,16 @@ fn sub_agent_loop_options(spec: &SubAgentRunSpec) -> Result<crate::llm::AgentLoo
             )
             .unwrap_or_default()
         });
+    let native_tool_fallback = crate::llm::helpers::opt_str(&options, "native_tool_fallback")
+        .map(|value| {
+            crate::orchestration::NativeToolFallbackPolicy::parse(&value).ok_or_else(|| {
+                VmError::Runtime(format!(
+                    "sub_agent_run: native_tool_fallback must be one of allow, allow_once, reject; got `{value}`"
+                ))
+            })
+        })
+        .transpose()?
+        .unwrap_or_default();
     let (skill_registry, skill_match, working_files) = crate::llm::parse_skill_config(&options);
     Ok(crate::llm::AgentLoopConfig {
         persistent: crate::llm::helpers::opt_bool(&options, "persistent"),
@@ -645,6 +655,7 @@ fn sub_agent_loop_options(spec: &SubAgentRunSpec) -> Result<crate::llm::AgentLoo
         tool_retries: tool_retries as usize,
         tool_backoff_ms: tool_backoff_ms as u64,
         tool_format: tool_format.unwrap_or_default(),
+        native_tool_fallback,
         auto_compact: None,
         policy,
         approval_policy,

--- a/crates/harn-vm/src/stdlib_agents.harn
+++ b/crates/harn-vm/src/stdlib_agents.harn
@@ -43,6 +43,7 @@ pub fn workflow_options(config) {
     tool_retries: config?.tool_retries,
     tool_backoff_ms: config?.tool_backoff_ms,
     tool_format: config?.tool_format,
+    native_tool_fallback: config?.native_tool_fallback,
     context_callback: config?.context_callback ?? config?.context_filter,
     transcript: config?.transcript,
   },

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -762,7 +762,9 @@ Returns a dict with `status`, `text`, `visible_text` (last iteration's
 prose with tool calls stripped), `iterations`, `duration_ms`,
 `tools_used`, `task_ledger`, `transcript`, and more. Respects the same
 `llm_retries` / `llm_backoff_ms` options plus its own `tool_retries`,
-`max_iterations`, `max_nudges`.
+`max_iterations`, `max_nudges`, and `native_tool_fallback`
+(`"allow"`, `"allow_once"`, or `"reject"` for native-tool stages that
+receive text-mode `<tool_call>` fallback output).
 
 ### Sessions (persistent conversations)
 

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -492,6 +492,7 @@ Same as `llm_call`, plus additional options:
 | `context_filter` | closure | nil | Alias for `context_callback` |
 | `post_turn_callback` | closure | nil | Hook called after each tool turn. Receives turn metadata and may inject a message, request an immediate stage stop, or both |
 | `turn_policy` | dict | nil | Turn-shape policy for action stages. Supports `require_action_or_yield: bool`, `allow_done_sentinel: bool` (default `true`; set to `false` in workflow-owned action stages so nudges stop advertising the done sentinel), and `max_prose_chars: int` |
+| `native_tool_fallback` | string | `"allow"` | Native-tool-stage policy when the provider emits text-mode `<tool_call>` content instead of native tool calls. `"allow"` preserves the current recovery path, `"allow_once"` accepts the first fallback turn then rejects later repeats with corrective feedback, and `"reject"` fails closed on the first text fallback |
 | `stop_after_successful_tools` | `list<string>` | nil | Stop after a tool-calling turn whose successful results include one of these tool names. Useful for workflow-owned verify loops such as `["edit", "scaffold"]` |
 | `require_successful_tools` | `list<string>` | nil | Mark the loop `status = "failed"` unless at least one of these tool names succeeds at some point during the interaction. Keeps action stages honest when every attempted effect was rejected or errored |
 | `loop_detect_warn` | int | `2` | Consecutive identical tool calls before appending a redirection hint |
@@ -505,6 +506,11 @@ When `daemon: true`, the loop transitions `active -> idle -> active` instead of
 terminating on a text-only turn. Idle daemons can be woken by queued human
 messages, `agent/resume` bridge notifications, `wake_interval_ms`, or watched
 file changes from `watch_paths`.
+
+Native-tool stages also expose structured fallback / retry metadata in the
+result `trace` summary. Look for `native_text_tool_fallbacks`,
+`native_text_tool_fallback_rejections`, and `empty_completion_retries` when
+debugging provider contract drift or OpenAI-compatible empty completions.
 
 Default nudge message:
 


### PR DESCRIPTION
## Summary
Fixes #229.

This adds explicit policy controls and structured observability for native-tool stages when providers fall back to text-mode `<tool_call>` output, and it records empty-completion retries as trace metadata instead of leaving them as warning-only behavior.

## What changed
- added `native_tool_fallback: "allow" | "allow_once" | "reject"` to `agent_loop`, `sub_agent_run`, and workflow `model_policy`
- recorded `native_tool_fallback` transcript events plus trace counters for accepted/rejected native-text fallback turns
- added `empty_completion_retry` observability entries and `empty_completion_retries` trace counters for retryable OpenAI-compatible empty completions
- rolled the new counters into workflow/run observability summaries
- added Rust regression tests and a conformance test for fallback policy and retry metadata
- documented the new option and trace fields, and updated the changelog

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-fb1c-target cargo test -p harn-vm native_tool_fallback`
- `CARGO_TARGET_DIR=/tmp/harn-fb1c-target cargo run --quiet --bin harn -- test conformance --filter native_tool_fallback_observability`
- `CARGO_TARGET_DIR=/tmp/harn-fb1c-target cargo test -p harn-vm save_and_load_run_record_materializes_observability_summary`
- `cargo fmt --all --check`
