### PR TITLE
[codex] Fix unknown struct construction diagnostics

### DIFF
--- a/crates/harn-parser/src/parser/decls.rs
+++ b/crates/harn-parser/src/parser/decls.rs
@@ -454,7 +454,6 @@ impl Parser {
         let start = self.current_span();
         self.consume(&TokenKind::Struct, "struct")?;
         let name = self.consume_identifier("struct name")?;
-        self.struct_names.insert(name.clone());
         let type_params = if self.check(&TokenKind::Lt) {
             self.advance();
             self.parse_type_param_list()?

--- a/crates/harn-parser/src/parser/expressions.rs
+++ b/crates/harn-parser/src/parser/expressions.rs
@@ -5,6 +5,92 @@ use super::error::ParserError;
 use super::state::Parser;
 
 impl Parser {
+    fn kind_at_non_newline_offset(&self, mut offset: usize) -> Option<&TokenKind> {
+        while matches!(
+            self.tokens.get(offset).map(|token| &token.kind),
+            Some(TokenKind::Newline)
+        ) {
+            offset += 1;
+        }
+        self.tokens.get(offset).map(|token| &token.kind)
+    }
+
+    fn token_starts_dict_key(kind: &TokenKind) -> bool {
+        matches!(
+            kind,
+            TokenKind::Identifier(_)
+                | TokenKind::Pipeline
+                | TokenKind::Extends
+                | TokenKind::Override
+                | TokenKind::Let
+                | TokenKind::Var
+                | TokenKind::If
+                | TokenKind::Else
+                | TokenKind::For
+                | TokenKind::In
+                | TokenKind::Match
+                | TokenKind::Retry
+                | TokenKind::Parallel
+                | TokenKind::Return
+                | TokenKind::Import
+                | TokenKind::True
+                | TokenKind::False
+                | TokenKind::Nil
+                | TokenKind::Try
+                | TokenKind::Catch
+                | TokenKind::Throw
+                | TokenKind::Fn
+                | TokenKind::Spawn
+                | TokenKind::While
+                | TokenKind::TypeKw
+                | TokenKind::Enum
+                | TokenKind::Struct
+                | TokenKind::Interface
+                | TokenKind::Pub
+                | TokenKind::From
+                | TokenKind::To
+                | TokenKind::Tool
+                | TokenKind::Exclusive
+                | TokenKind::Guard
+                | TokenKind::Deadline
+                | TokenKind::Defer
+                | TokenKind::Yield
+                | TokenKind::Mutex
+                | TokenKind::Break
+                | TokenKind::Continue
+                | TokenKind::Impl
+        )
+    }
+
+    fn looks_like_struct_construct(&self) -> bool {
+        let Some(first_kind) = self.kind_at_non_newline_offset(self.pos + 1) else {
+            return false;
+        };
+        match first_kind {
+            TokenKind::RBrace => true,
+            TokenKind::Dot => matches!(
+                (
+                    self.kind_at_non_newline_offset(self.pos + 2),
+                    self.kind_at_non_newline_offset(self.pos + 3),
+                ),
+                (Some(TokenKind::Dot), Some(TokenKind::Dot))
+            ),
+            TokenKind::StringLiteral(_) => {
+                matches!(
+                    self.kind_at_non_newline_offset(self.pos + 2),
+                    Some(TokenKind::Colon)
+                )
+            }
+            other if Self::token_starts_dict_key(other) => {
+                matches!(
+                    self.kind_at_non_newline_offset(self.pos + 2),
+                    Some(TokenKind::Colon)
+                )
+            }
+            _ => false,
+        }
+    }
+
     /// Parse a single expression (for string interpolation).
     pub fn parse_single_expression(&mut self) -> Result<SNode, ParserError> {
         self.skip_newlines();

--- a/crates/harn-parser/src/parser/state.rs
+++ b/crates/harn-parser/src/parser/state.rs
@@ -1,6 +1,5 @@
 use crate::ast::*;
 use harn_lexer::{Span, Token, TokenKind};
-use std::collections::HashSet;
 
 use super::error::ParserError;
 
@@ -9,7 +8,6 @@ pub struct Parser {
     pub(super) tokens: Vec<Token>,
     pub(super) pos: usize,
     pub(super) errors: Vec<ParserError>,
-    pub(super) struct_names: HashSet<String>,
 }
 
 impl Parser {
@@ -18,7 +16,6 @@ impl Parser {
             tokens,
             pos: 0,
             errors: Vec::new(),
-            struct_names: HashSet::new(),
         }
     }
 

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -634,8 +634,7 @@ impl TypeChecker {
                 fields,
             } => scope
                 .get_struct(struct_name)
-                .map(|struct_info| self.infer_struct_type(struct_name, struct_info, fields, scope))
-                .or_else(|| Some(TypeExpr::Named(struct_name.clone()))),
+                .map(|struct_info| self.infer_struct_type(struct_name, struct_info, fields, scope)),
 
             _ => None,
         }


### PR DESCRIPTION
## Summary
- parse `Identifier { ... }` as struct construction even when the struct name is unresolved, using a dict-literal lookahead so `match x { ... }` and similar grammar stays intact
- report `unknown type \`Name\`` for unresolved struct construction instead of inferring a phantom named type and exiting silently
- add parser and typechecker regressions for unknown struct literals

## Root cause
`harn check` only validated binary operators for `let`/`var` initializers, so a top-level struct-construction initializer never reached the `StructConstruct` checker path. On top of that, struct construction inference fell back to `TypeExpr::Named(struct_name)` when the struct was unresolved, which suppressed any diagnostic.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-018b-target cargo test -p harn-parser unknown_struct -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-018b-target cargo test -p harn-parser` (one unrelated pre-existing failure remains: `typechecker::tests::narrowing::test_or_falsy_narrowing`)
- `CARGO_TARGET_DIR=/tmp/harn-018b-target cargo run --quiet --bin harn -- check /tmp/t.harn` with `let p = Point { x: 3, y: 4 }`, which now prints `error: unknown type \`Point\`` at `/tmp/t.harn:1:9` and exits 1

Fixes #370.
