### PR TITLE
[T-10][Triggers] Finish action-graph observability

### DIFF
--- a/crates/harn-cli/portal/src/App.test.tsx
+++ b/crates/harn-cli/portal/src/App.test.tsx
@@ -107,8 +107,34 @@ const detailPayload = {
     planner_rounds: [],
     research_fact_count: 0,
     action_graph_nodes: [
-      { id: "trigger:original", label: "github:issue.opened (original trigger_evt_original)", kind: "trigger", status: "historical", outcome: "replayed_from", trace_id: "trace", stage_id: null, node_id: null, worker_id: null, run_id: null, run_path: null },
-      { id: "trigger:current", label: "github:issue.opened", kind: "trigger", status: "received", outcome: "received", trace_id: "trace", stage_id: null, node_id: null, worker_id: null, run_id: null, run_path: null },
+      {
+        id: "trigger:original",
+        label: "github:issue.opened (original trigger_evt_original)",
+        kind: "trigger",
+        status: "historical",
+        outcome: "replayed_from",
+        trace_id: "trace",
+        stage_id: null,
+        node_id: null,
+        worker_id: null,
+        run_id: null,
+        run_path: null,
+        metadata: { provider: "github", event_kind: "issue.opened", event_id: "trigger_evt_original" },
+      },
+      {
+        id: "trigger:current",
+        label: "github:issue.opened",
+        kind: "trigger",
+        status: "received",
+        outcome: "received",
+        trace_id: "trace",
+        stage_id: null,
+        node_id: null,
+        worker_id: null,
+        run_id: null,
+        run_path: null,
+        metadata: { provider: "github", event_kind: "issue.opened", event_id: "trigger_evt_current", signature_status: "verified" },
+      },
     ],
     action_graph_edges: [
       { from_id: "trigger:original", to_id: "trigger:current", kind: "replay_chain", label: "replay chain" },
@@ -176,6 +202,24 @@ describe("App", () => {
       if (input.startsWith("/api/run?path=failed.json")) {
         return { ok: true, json: async () => detailPayload }
       }
+      if (input === "/api/trigger/replay") {
+        return {
+          ok: true,
+          json: async () => ({
+            id: "job-1",
+            mode: "trigger_replay",
+            target_label: "trigger replay trigger_evt_current",
+            status: "running",
+            started_at: "2026-04-04T10:01:30Z",
+            finished_at: null,
+            exit_code: null,
+            logs: "",
+            discovered_run_paths: [],
+            workspace_dir: null,
+            transcript_path: null,
+          }),
+        }
+      }
       if (input === "/api/launch/targets") {
         return { ok: true, json: async () => ({ targets: [] }) }
       }
@@ -221,5 +265,10 @@ describe("App", () => {
     expect(screen.getByText("harn replay .harn-runs/failed.json")).toBeInTheDocument()
     expect(screen.getByText(/reviewer • Spawned • 1710000000.100/)).toBeInTheDocument()
     expect(screen.getByText(/github:issue\.opened \(original trigger_evt_original\) → github:issue\.opened • replay chain • replay_chain/)).toBeInTheDocument()
+    expect(screen.getAllByRole("button", { name: "Replay trigger" }).length).toBeGreaterThan(0)
+
+    const replayButtons = screen.getAllByRole("button", { name: "Replay trigger" })
+    await userEvent.click(replayButtons[replayButtons.length - 1])
+    expect(await screen.findByText("Queued trigger replay trigger_evt_current")).toBeInTheDocument()
   })
 })

--- a/crates/harn-cli/portal/src/components/RunDetail.tsx
+++ b/crates/harn-cli/portal/src/components/RunDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react"
 import { defineMessages, useIntl } from "react-intl"
 
-import { fetchRunCompare } from "../lib/api"
+import { fetchRunCompare, replayTriggerEvent } from "../lib/api"
 import { formatDuration, formatNumber, pct, statusClass } from "../lib/format"
 import type { PortalRunDetail, PortalRunDiff, RunSummary } from "../types"
 import { SkillObservability } from "./SkillObservability"
@@ -240,6 +240,210 @@ function daemonKindLabel(kind: PortalRunDetail["observability"]["daemon_events"]
   }
 }
 
+type ActionGraphNode = PortalRunDetail["observability"]["action_graph_nodes"][number]
+
+function nodeMeta(node: ActionGraphNode, key: string): unknown {
+  return node.metadata?.[key]
+}
+
+function nodeMetaString(node: ActionGraphNode, key: string) {
+  const value = nodeMeta(node, key)
+  return typeof value === "string" ? value : null
+}
+
+function nodeMetaNumber(node: ActionGraphNode, key: string) {
+  const value = nodeMeta(node, key)
+  return typeof value === "number" ? value : null
+}
+
+function nodeMetaBoolean(node: ActionGraphNode, key: string) {
+  const value = nodeMeta(node, key)
+  return typeof value === "boolean" ? value : null
+}
+
+function actionNodeAccent(kind: string) {
+  switch (kind) {
+    case "trigger":
+      return "action-node-trigger"
+    case "predicate":
+    case "trigger_predicate":
+      return "action-node-predicate"
+    case "a2a_hop":
+      return "action-node-a2a"
+    case "worker_enqueue":
+      return "action-node-worker"
+    case "dlq":
+      return "action-node-dlq"
+    case "retry":
+      return "action-node-retry"
+    default:
+      return "action-node-dispatch"
+  }
+}
+
+function actionNodeEyebrow(kind: string) {
+  switch (kind) {
+    case "trigger":
+      return "Inbound trigger"
+    case "predicate":
+    case "trigger_predicate":
+      return "Predicate gate"
+    case "dispatch":
+      return "Local dispatch"
+    case "a2a_hop":
+      return "A2A hop"
+    case "worker_enqueue":
+      return "Worker enqueue"
+    case "retry":
+      return "Retry"
+    case "dlq":
+      return "DLQ"
+    default:
+      return kind
+  }
+}
+
+function replayEventIdForNode(node: ActionGraphNode) {
+  return nodeMetaString(node, "event_id") ?? (node.kind === "trigger" ? node.id.replace(/^trigger:/, "") : null)
+}
+
+function actionNodeFacts(node: ActionGraphNode) {
+  const facts: string[] = []
+  switch (node.kind) {
+    case "trigger": {
+      const provider = nodeMetaString(node, "provider")
+      const eventKind = nodeMetaString(node, "event_kind")
+      const signature = nodeMetaString(node, "signature_status")
+      if (provider && eventKind) {
+        facts.push(`${provider}:${eventKind}`)
+      }
+      if (signature) {
+        facts.push(`signature ${signature}`)
+      }
+      break
+    }
+    case "predicate":
+    case "trigger_predicate": {
+      const result = nodeMetaBoolean(node, "result")
+      const costUsd = nodeMetaNumber(node, "cost_usd")
+      const latencyMs = nodeMetaNumber(node, "latency_ms")
+      if (result != null) {
+        facts.push(result ? "passed" : "blocked")
+      }
+      if (costUsd != null) {
+        facts.push(`$${costUsd.toFixed(4)}`)
+      }
+      if (latencyMs != null) {
+        facts.push(`${latencyMs} ms`)
+      }
+      break
+    }
+    case "dispatch":
+    case "a2a_hop":
+    case "worker_enqueue": {
+      const targetUri = nodeMetaString(node, "target_uri")
+      const targetAgent = nodeMetaString(node, "target_agent")
+      const queueName = nodeMetaString(node, "queue_name")
+      const taskId = nodeMetaString(node, "task_id")
+      const attempt = nodeMetaNumber(node, "attempt")
+      if (queueName) {
+        facts.push(`queue ${queueName}`)
+      } else if (targetAgent) {
+        facts.push(`agent ${targetAgent}`)
+      } else if (targetUri) {
+        facts.push(targetUri)
+      }
+      if (attempt != null) {
+        facts.push(`attempt ${attempt}`)
+      }
+      if (taskId) {
+        facts.push(`task ${taskId}`)
+      }
+      break
+    }
+    case "retry": {
+      const delayMs = nodeMetaNumber(node, "delay_ms")
+      if (delayMs != null) {
+        facts.push(`delay ${delayMs} ms`)
+      }
+      break
+    }
+    case "dlq": {
+      const attempts = nodeMetaNumber(node, "attempt_count")
+      if (attempts != null) {
+        facts.push(`${attempts} attempts`)
+      }
+      break
+    }
+    default:
+      break
+  }
+  if (node.trace_id) {
+    facts.push(`trace ${node.trace_id}`)
+  }
+  return facts
+}
+
+function actionNodeDetail(node: ActionGraphNode) {
+  switch (node.kind) {
+    case "predicate":
+    case "trigger_predicate":
+      return nodeMetaString(node, "reason") ?? nodeMetaString(node, "predicate")
+    case "a2a_hop":
+      return nodeMetaString(node, "target_uri")
+    case "worker_enqueue":
+      return nodeMetaString(node, "response_topic")
+    case "retry":
+    case "dlq":
+      return nodeMetaString(node, "error") ?? nodeMetaString(node, "final_error")
+    default:
+      return nodeMetaString(node, "dedupe_key")
+    }
+}
+
+function ActionGraphNodeCard({
+  node,
+  replayingEventId,
+  onReplay,
+}: {
+  node: ActionGraphNode
+  replayingEventId: string | null
+  onReplay: (eventId: string) => void
+}) {
+  const replayEventId = replayEventIdForNode(node)
+  const details = actionNodeDetail(node)
+  const facts = actionNodeFacts(node)
+
+  return (
+    <div className={`action-node-card ${actionNodeAccent(node.kind)}`} title={JSON.stringify(node.metadata ?? {}, null, 2)}>
+      <div className="row">
+        <div>
+          <div className="eyebrow">{actionNodeEyebrow(node.kind)}</div>
+          <strong>{node.label}</strong>
+        </div>
+        <span className={`pill ${statusClass(node.status)}`}>{node.status}</span>
+      </div>
+      <div className="meta">
+        {node.outcome}
+        {facts.length ? ` • ${facts.join(" • ")}` : ""}
+      </div>
+      {details ? <div className="meta">{details}</div> : null}
+      {replayEventId && (node.kind === "dlq" || node.kind === "trigger") ? (
+        <div className="action-node-actions">
+          <button
+            className="action-button action-button-inline"
+            disabled={replayingEventId === replayEventId}
+            onClick={() => onReplay(replayEventId)}
+            type="button"
+          >
+            {replayingEventId === replayEventId ? "Replaying…" : "Replay trigger"}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
 function StageDetail({ label, value, open = false }: { label: string; value: string | null; open?: boolean }) {
   if (!value) {return null}
   return (
@@ -253,6 +457,8 @@ function StageDetail({ label, value, open = false }: { label: string; value: str
 export function RunDetail({ detail, runs, onSelectRun }: RunDetailProps) {
   const intl = useIntl()
   const [compareBaselinePath, setCompareBaselinePath] = useState<string | null>(null)
+  const [replayingEventId, setReplayingEventId] = useState<string | null>(null)
+  const [replayStatus, setReplayStatus] = useState<string | null>(null)
   const [compareResult, setCompareResult] = useState<{
     requestKey: string
     diff: PortalRunDiff | null
@@ -365,6 +571,10 @@ export function RunDetail({ detail, runs, onSelectRun }: RunDetailProps) {
         ? intl.formatMessage(messages.validationPassed)
         : intl.formatMessage(messages.validationFailed)
   const graphNodeLabels = new Map(detail.observability.action_graph_nodes.map((node) => [node.id, node.label]))
+  const actionGraphNodes = [...detail.observability.action_graph_nodes].sort((left, right) => {
+    const order = ["trigger", "predicate", "trigger_predicate", "dispatch", "a2a_hop", "worker_enqueue", "retry", "dlq"]
+    return order.indexOf(left.kind) - order.indexOf(right.kind)
+  })
   const compareRows = compareDiff
     ? [
         ...compareDiff.stage_diffs.map((item) => (
@@ -641,6 +851,40 @@ export function RunDetail({ detail, runs, onSelectRun }: RunDetailProps) {
           </div>
         </div>
         <div className="flow-grid">
+          <div className="flow-item">
+            <div className="row">
+              <strong>Action graph nodes</strong>
+              <span className="turn-chip">{detail.observability.action_graph_nodes.length}</span>
+            </div>
+            {replayStatus ? <div className="meta">{replayStatus}</div> : null}
+            {actionGraphNodes.length ? (
+              <div className="action-node-grid">
+                {actionGraphNodes.map((node) => (
+                  <ActionGraphNodeCard
+                    key={`${node.id}-${node.status}-${node.outcome}`}
+                    node={node}
+                    replayingEventId={replayingEventId}
+                    onReplay={(eventId) => {
+                      setReplayingEventId(eventId)
+                      setReplayStatus(null)
+                      void replayTriggerEvent(eventId)
+                        .then((job) => {
+                          setReplayStatus(`Queued ${job.target_label}`)
+                        })
+                        .catch((error) => {
+                          setReplayStatus(error instanceof Error ? error.message : String(error))
+                        })
+                        .finally(() => {
+                          setReplayingEventId(null)
+                        })
+                    }}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="muted">{intl.formatMessage(messages.noTransitions)}</div>
+            )}
+          </div>
           <div className="flow-item">
             <div className="row">
               <strong>Graph edges</strong>

--- a/crates/harn-cli/portal/src/hooks/useRunDetailData.ts
+++ b/crates/harn-cli/portal/src/hooks/useRunDetailData.ts
@@ -12,6 +12,41 @@ function isCompleted(status: string) {
   return ["complete", "completed", "success", "verified"].includes(status)
 }
 
+function mergeActionGraphNodes(
+  current: PortalRunDetail["observability"]["action_graph_nodes"],
+  incoming: PortalRunDetail["observability"]["action_graph_nodes"],
+) {
+  const merged = new Map(current.map((node) => [node.id, node]))
+  for (const node of incoming) {
+    const previous = merged.get(node.id)
+    merged.set(node.id, {
+      ...previous,
+      ...node,
+      metadata: {
+        ...(previous?.metadata ?? {}),
+        ...(node.metadata ?? {}),
+      },
+    })
+  }
+  return [...merged.values()]
+}
+
+function mergeActionGraphEdges(
+  current: PortalRunDetail["observability"]["action_graph_edges"],
+  incoming: PortalRunDetail["observability"]["action_graph_edges"],
+) {
+  const merged = [...current]
+  const seen = new Set(current.map((edge) => `${edge.from_id}|${edge.to_id}|${edge.kind}|${edge.label ?? ""}`))
+  for (const edge of incoming) {
+    const key = `${edge.from_id}|${edge.to_id}|${edge.kind}|${edge.label ?? ""}`
+    if (!seen.has(key)) {
+      seen.add(key)
+      merged.push(edge)
+    }
+  }
+  return merged
+}
+
 export function useRunDetailData(path: string | null) {
   const [detail, setDetail] = useState<PortalRunDetail | null>(null)
   const [compareRuns, setCompareRuns] = useState<RunSummary[]>([])
@@ -81,6 +116,10 @@ export function useRunDetailData(path: string | null) {
     }
     return !isFailed(detail.summary.status) && !isCompleted(detail.summary.status)
   }, [detail])
+  const actionGraphTraceId = useMemo(
+    () => detail?.observability.action_graph_nodes.find((node) => node.trace_id != null)?.trace_id ?? null,
+    [detail],
+  )
 
   useEffect(() => {
     if (!needsPolling || !path) {
@@ -94,6 +133,55 @@ export function useRunDetailData(path: string | null) {
     }, 5000)
     return () => window.clearInterval(interval)
   }, [loadDetail, needsPolling, path])
+
+  useEffect(() => {
+    if (!path || !actionGraphTraceId || typeof EventSource === "undefined") {
+      return
+    }
+    const stream = new EventSource(`/api/run/action-graph/stream?path=${encodeURIComponent(path)}`)
+    const listener = (event: MessageEvent<string>) => {
+      try {
+        const payload = JSON.parse(event.data) as {
+          payload?: {
+            observability?: {
+              action_graph_nodes?: PortalRunDetail["observability"]["action_graph_nodes"]
+              action_graph_edges?: PortalRunDetail["observability"]["action_graph_edges"]
+            }
+          }
+        }
+        const nextObservability = payload.payload?.observability
+        if (!nextObservability) {
+          return
+        }
+        setDetail((current) => {
+          if (!current) {
+            return current
+          }
+          return {
+            ...current,
+            observability: {
+              ...current.observability,
+              action_graph_nodes: mergeActionGraphNodes(
+                current.observability.action_graph_nodes,
+                nextObservability.action_graph_nodes ?? [],
+              ),
+              action_graph_edges: mergeActionGraphEdges(
+                current.observability.action_graph_edges,
+                nextObservability.action_graph_edges ?? [],
+              ),
+            },
+          }
+        })
+      } catch {
+        // Ignore malformed live updates and keep the persisted snapshot.
+      }
+    }
+    stream.addEventListener("action_graph_update", listener as EventListener)
+    return () => {
+      stream.removeEventListener("action_graph_update", listener as EventListener)
+      stream.close()
+    }
+  }, [actionGraphTraceId, path])
 
   return {
     detail,

--- a/crates/harn-cli/portal/src/lib/api.ts
+++ b/crates/harn-cli/portal/src/lib/api.ts
@@ -123,3 +123,27 @@ export async function launchRun(payload: {
   }
   throw new Error(message)
 }
+
+export async function replayTriggerEvent(event_id: string): Promise<PortalLaunchJob> {
+  const response = await fetch("/api/trigger/replay", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ event_id }),
+  })
+  if (response.ok) {
+    return response.json() as Promise<PortalLaunchJob>
+  }
+
+  let message = `Request failed: ${response.status}`
+  try {
+    const payload = (await response.json()) as { error?: string }
+    if (payload.error) {
+      message = `${message} ${payload.error}`
+    }
+  } catch {
+    // Keep status-based fallback.
+  }
+  throw new Error(message)
+}

--- a/crates/harn-cli/portal/src/styles.css
+++ b/crates/harn-cli/portal/src/styles.css
@@ -743,6 +743,61 @@ textarea {
   color: var(--accent);
 }
 
+.action-node-grid {
+  display: grid;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.action-node-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01));
+}
+
+.action-node-card strong {
+  display: block;
+  margin-top: 2px;
+}
+
+.action-node-card .eyebrow {
+  margin-bottom: 2px;
+}
+
+.action-node-actions {
+  margin-top: 10px;
+}
+
+.action-node-trigger {
+  border-left: 4px solid var(--accent);
+}
+
+.action-node-predicate {
+  border-left: 4px solid var(--amber);
+}
+
+.action-node-dispatch {
+  border-left: 4px solid #6dd3ce;
+}
+
+.action-node-a2a {
+  border: 1px dashed #7dd3fc;
+  box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.18);
+}
+
+.action-node-worker {
+  border-left: 4px solid #7ee081;
+}
+
+.action-node-retry {
+  border-left: 4px solid #f59e0b;
+}
+
+.action-node-dlq {
+  border-left: 4px solid #ef4444;
+}
+
 .turn-message {
   border-left: 2px solid var(--accent);
   padding-left: 10px;

--- a/crates/harn-cli/portal/src/types.ts
+++ b/crates/harn-cli/portal/src/types.ts
@@ -294,11 +294,13 @@ export type RunActionGraphNode = {
   kind: string
   status: string
   outcome: string
+  trace_id: string | null
   stage_id: string | null
   node_id: string | null
   worker_id: string | null
   run_id: string | null
   run_path: string | null
+  metadata: Record<string, unknown>
 }
 
 export type RunActionGraphEdge = {

--- a/crates/harn-cli/src/commands/portal/dto.rs
+++ b/crates/harn-cli/src/commands/portal/dto.rs
@@ -356,6 +356,11 @@ pub(super) struct PortalLaunchRequest {
     pub(super) env: Option<BTreeMap<String, String>>,
 }
 
+#[derive(Debug, Deserialize)]
+pub(super) struct PortalTriggerReplayRequest {
+    pub(super) event_id: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct PortalRunDiff {
     pub(super) left_path: String,

--- a/crates/harn-cli/src/commands/portal/handlers/launch.rs
+++ b/crates/harn-cli/src/commands/portal/handlers/launch.rs
@@ -6,9 +6,12 @@ use axum::Json;
 
 use crate::commands::portal::dto::{
     PortalLaunchJob, PortalLaunchJobList, PortalLaunchRequest, PortalLaunchTargetList,
+    PortalTriggerReplayRequest,
 };
 use crate::commands::portal::errors::internal_error;
-use crate::commands::portal::launch::{create_launch_job, scan_launch_targets};
+use crate::commands::portal::launch::{
+    create_launch_job, create_trigger_replay_job, scan_launch_targets,
+};
 use crate::commands::portal::query::ErrorResponse;
 use crate::commands::portal::state::PortalState;
 
@@ -37,5 +40,13 @@ pub(crate) async fn launch_run_handler(
     ExtractJson(request): ExtractJson<PortalLaunchRequest>,
 ) -> Result<Json<PortalLaunchJob>, (StatusCode, Json<ErrorResponse>)> {
     let job = create_launch_job(&state, request).await?;
+    Ok(Json(job))
+}
+
+pub(crate) async fn trigger_replay_handler(
+    State(state): State<Arc<PortalState>>,
+    ExtractJson(request): ExtractJson<PortalTriggerReplayRequest>,
+) -> Result<Json<PortalLaunchJob>, (StatusCode, Json<ErrorResponse>)> {
+    let job = create_trigger_replay_job(&state, &request.event_id).await?;
     Ok(Json(job))
 }

--- a/crates/harn-cli/src/commands/portal/handlers/runs.rs
+++ b/crates/harn-cli/src/commands/portal/handlers/runs.rs
@@ -1,11 +1,16 @@
+use std::convert::Infallible;
 use std::sync::Arc;
 
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::Json;
+use futures::StreamExt;
+use harn_vm::event_log::{EventLog, Topic};
+use serde_json::json;
 
 use crate::commands::portal::dto::{PortalListResponse, PortalPagination, PortalRunDetail};
-use crate::commands::portal::errors::{internal_error, not_found_error};
+use crate::commands::portal::errors::{bad_request_error, internal_error, not_found_error};
 use crate::commands::portal::query::{ErrorResponse, ListRunsQuery, RunQuery};
 use crate::commands::portal::run_analysis::{
     build_run_detail, filter_and_sort_runs, resolve_run_path, scan_runs, summarize_runs,
@@ -59,4 +64,61 @@ pub(crate) async fn run_detail_handler(
         }
     })?;
     Ok(Json(build_run_detail(&state.run_dir, &query.path, &run)))
+}
+
+pub(crate) async fn action_graph_stream_handler(
+    State(state): State<Arc<PortalState>>,
+    Query(query): Query<RunQuery>,
+) -> Result<Sse<impl futures::Stream<Item = Result<Event, Infallible>>>, (StatusCode, Json<ErrorResponse>)>
+{
+    let path = resolve_run_path(&state.run_dir, &query.path)?;
+    let run = harn_vm::orchestration::load_run_record(&path).map_err(|error| {
+        if path.exists() {
+            internal_error(format!("failed to load run record: {error}"))
+        } else {
+            not_found_error(format!("run record not found: {}", query.path))
+        }
+    })?;
+    let observability = harn_vm::orchestration::derive_run_observability(&run, Some(&path));
+    let trace_id = observability
+        .action_graph_nodes
+        .iter()
+        .find_map(|node| node.trace_id.clone())
+        .ok_or_else(|| bad_request_error("run does not have an action-graph trace_id"))?;
+    let event_log = state
+        .event_log
+        .clone()
+        .ok_or_else(|| internal_error("portal event log is unavailable for streaming"))?;
+    let topic = Topic::new("observability.action_graph")
+        .map_err(|error| internal_error(format!("invalid action graph topic: {error}")))?;
+    let run_id = run.id.clone();
+    let stream = event_log
+        .subscribe(&topic, None)
+        .await
+        .map_err(|error| internal_error(format!("failed to subscribe to action graph: {error}")))?
+        .filter_map(move |item| {
+            let trace_id = trace_id.clone();
+            let run_id = run_id.clone();
+            async move {
+                let Ok((event_id, event)) = item else {
+                    return None;
+                };
+                let matches_trace = event.headers.get("trace_id") == Some(&trace_id)
+                    || event.headers.get("run_id") == Some(&run_id)
+                    || event.payload.get("trace_id").and_then(|value| value.as_str()) == Some(trace_id.as_str())
+                    || event.payload.get("run_id").and_then(|value| value.as_str()) == Some(run_id.as_str());
+                if !matches_trace {
+                    return None;
+                }
+                let payload = json!({
+                    "id": event_id,
+                    "kind": event.kind,
+                    "headers": event.headers,
+                    "payload": event.payload,
+                });
+                let encoded = serde_json::to_string(&payload).ok()?;
+                Some(Ok(Event::default().event("action_graph_update").data(encoded)))
+            }
+        });
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }

--- a/crates/harn-cli/src/commands/portal/launch.rs
+++ b/crates/harn-cli/src/commands/portal/launch.rs
@@ -109,6 +109,82 @@ pub(super) async fn create_launch_job(
     Ok(job)
 }
 
+pub(super) async fn create_trigger_replay_job(
+    state: &Arc<PortalState>,
+    event_id: &str,
+) -> Result<PortalLaunchJob, (StatusCode, Json<ErrorResponse>)> {
+    let event_id = event_id.trim();
+    if event_id.is_empty() {
+        return Err(bad_request_error("event_id is required"));
+    }
+
+    let job_id = portal_timestamp_id("job");
+    let started_at = portal_timestamp_id("started");
+    let job = PortalLaunchJob {
+        id: job_id.clone(),
+        mode: "trigger_replay".to_string(),
+        target_label: format!("trigger replay {event_id}"),
+        status: "running".to_string(),
+        started_at,
+        finished_at: None,
+        exit_code: None,
+        logs: String::new(),
+        discovered_run_paths: Vec::new(),
+        workspace_dir: None,
+        transcript_path: None,
+    };
+    state
+        .launch_jobs
+        .lock()
+        .await
+        .insert(job_id.clone(), job.clone());
+
+    let jobs = state.launch_jobs.clone();
+    let launch_program = state.launch_program.clone();
+    let workspace_root = state.workspace_root.clone();
+    let event_id = event_id.to_string();
+    tokio::spawn(async move {
+        let output = Command::new(&launch_program)
+            .arg("trigger")
+            .arg("replay")
+            .arg(&event_id)
+            .current_dir(&workspace_root)
+            .output()
+            .await;
+
+        let mut jobs = jobs.lock().await;
+        if let Some(job) = jobs.get_mut(&job_id) {
+            match output {
+                Ok(output) => {
+                    let mut logs = String::new();
+                    logs.push_str(&String::from_utf8_lossy(&output.stdout));
+                    if !output.stderr.is_empty() {
+                        if !logs.is_empty() {
+                            logs.push('\n');
+                        }
+                        logs.push_str(&String::from_utf8_lossy(&output.stderr));
+                    }
+                    job.logs = logs;
+                    job.exit_code = output.status.code();
+                    job.status = if output.status.success() {
+                        "completed".to_string()
+                    } else {
+                        "failed".to_string()
+                    };
+                    job.finished_at = Some(portal_timestamp_id("finished"));
+                }
+                Err(error) => {
+                    job.status = "failed".to_string();
+                    job.finished_at = Some(portal_timestamp_id("finished"));
+                    job.logs = format!("failed to start trigger replay: {error}");
+                }
+            }
+        }
+    });
+
+    Ok(job)
+}
+
 pub(super) fn validate_launch_request(
     request: &PortalLaunchRequest,
 ) -> Result<(), (StatusCode, Json<ErrorResponse>)> {

--- a/crates/harn-cli/src/commands/portal/mod.rs
+++ b/crates/harn-cli/src/commands/portal/mod.rs
@@ -26,6 +26,7 @@ use self::state::PortalState;
 pub(crate) async fn run_portal(dir: &str, host: &str, port: u16, open_browser: bool) {
     let run_dir = PathBuf::from(dir);
     let workspace_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let event_log = harn_vm::event_log::install_default_for_base_dir(&workspace_root).ok();
     let launch_program = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("harn"));
     let addr: SocketAddr = match format!("{host}:{port}").parse() {
         Ok(a) => a,
@@ -38,6 +39,7 @@ pub(crate) async fn run_portal(dir: &str, host: &str, port: u16, open_browser: b
     let state = Arc::new(PortalState {
         run_dir: run_dir.clone(),
         workspace_root,
+        event_log,
         launch_program,
         launch_jobs: Arc::new(Mutex::new(HashMap::new())),
     });

--- a/crates/harn-cli/src/commands/portal/router.rs
+++ b/crates/harn-cli/src/commands/portal/router.rs
@@ -7,9 +7,10 @@ use super::assets::{asset, index};
 use super::handlers::compare::compare_runs_handler;
 use super::handlers::launch::{
     launch_run_handler, list_launch_jobs_handler, list_launch_targets_handler,
+    trigger_replay_handler,
 };
 use super::handlers::meta::{highlight_keywords_handler, llm_options_handler, portal_meta_handler};
-use super::handlers::runs::{list_runs_handler, run_detail_handler};
+use super::handlers::runs::{action_graph_stream_handler, list_runs_handler, run_detail_handler};
 use super::state::PortalState;
 
 pub(super) fn build_router(state: Arc<PortalState>) -> Router {
@@ -21,10 +22,12 @@ pub(super) fn build_router(state: Arc<PortalState>) -> Router {
         .route("/api/llm/options", get(llm_options_handler))
         .route("/api/runs", get(list_runs_handler))
         .route("/api/run", get(run_detail_handler))
+        .route("/api/run/action-graph/stream", get(action_graph_stream_handler))
         .route("/api/compare", get(compare_runs_handler))
         .route("/api/launch/targets", get(list_launch_targets_handler))
         .route("/api/launch/jobs", get(list_launch_jobs_handler))
         .route("/api/launch", post(launch_run_handler))
+        .route("/api/trigger/replay", post(trigger_replay_handler))
         .route("/{*path}", get(index))
         .with_state(state)
 }

--- a/crates/harn-cli/src/commands/portal/state.rs
+++ b/crates/harn-cli/src/commands/portal/state.rs
@@ -5,11 +5,13 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use super::dto::PortalLaunchJob;
+use harn_vm::event_log::AnyEventLog;
 
 #[derive(Clone)]
 pub(super) struct PortalState {
     pub(super) run_dir: PathBuf,
     pub(super) workspace_root: PathBuf,
+    pub(super) event_log: Option<Arc<AnyEventLog>>,
     pub(super) launch_program: PathBuf,
     pub(super) launch_jobs: Arc<Mutex<HashMap<String, PortalLaunchJob>>>,
 }

--- a/crates/harn-cli/src/commands/portal/tests.rs
+++ b/crates/harn-cli/src/commands/portal/tests.rs
@@ -26,6 +26,7 @@ fn test_portal_state(run_dir: &Path) -> Arc<PortalState> {
     Arc::new(PortalState {
         run_dir: run_dir.to_path_buf(),
         workspace_root: run_dir.to_path_buf(),
+        event_log: None,
         launch_program: PathBuf::from("harn"),
         launch_jobs: Arc::new(Mutex::new(HashMap::new())),
     })

--- a/crates/harn-vm/src/a2a/mod.rs
+++ b/crates/harn-vm/src/a2a/mod.rs
@@ -105,7 +105,7 @@ pub async fn dispatch_trigger_event(
         }),
     );
 
-    let body = send_jsonrpc(&endpoint.rpc_url, &request, cancel_rx).await?;
+    let body = send_jsonrpc(&endpoint.rpc_url, &request, &event.trace_id.0, cancel_rx).await?;
     let result = body.get("result").cloned().ok_or_else(|| {
         if let Some(error) = body.get("error") {
             let message = error
@@ -470,6 +470,7 @@ fn url_authority(url: &Url) -> Result<String, A2aClientError> {
 async fn send_jsonrpc(
     rpc_url: &str,
     request: &Value,
+    trace_id: &str,
     cancel_rx: &mut broadcast::Receiver<()>,
 ) -> Result<Value, A2aClientError> {
     let response = send_http(
@@ -477,6 +478,7 @@ async fn send_jsonrpc(
             .post(rpc_url)
             .header(reqwest::header::CONTENT_TYPE, "application/json")
             .header("A2A-Version", A2A_PROTOCOL_VERSION)
+            .header("A2A-Trace-Id", trace_id)
             .json(request),
         cancel_rx,
         "A2A task dispatch cancelled",

--- a/crates/harn-vm/src/orchestration/records.rs
+++ b/crates/harn-vm/src/orchestration/records.rs
@@ -22,6 +22,7 @@ pub const ACTION_GRAPH_NODE_KIND_STAGE: &str = "stage";
 pub const ACTION_GRAPH_NODE_KIND_WORKER: &str = "worker";
 pub const ACTION_GRAPH_NODE_KIND_DISPATCH: &str = "dispatch";
 pub const ACTION_GRAPH_NODE_KIND_A2A_HOP: &str = "a2a_hop";
+pub const ACTION_GRAPH_NODE_KIND_WORKER_ENQUEUE: &str = "worker_enqueue";
 pub const ACTION_GRAPH_NODE_KIND_RETRY: &str = "retry";
 pub const ACTION_GRAPH_NODE_KIND_DLQ: &str = "dlq";
 
@@ -234,6 +235,7 @@ pub struct RunActionGraphNodeRecord {
     pub worker_id: Option<String>,
     pub run_id: Option<String>,
     pub run_path: Option<String>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -533,6 +535,43 @@ fn action_graph_kind_for_stage(stage: &RunStageRecord) -> &'static str {
     }
 }
 
+fn trigger_node_metadata(trigger_event: &TriggerEvent) -> BTreeMap<String, serde_json::Value> {
+    let mut metadata = BTreeMap::new();
+    metadata.insert(
+        "provider".to_string(),
+        serde_json::json!(trigger_event.provider.as_str()),
+    );
+    metadata.insert(
+        "event_kind".to_string(),
+        serde_json::json!(trigger_event.kind),
+    );
+    metadata.insert(
+        "dedupe_key".to_string(),
+        serde_json::json!(trigger_event.dedupe_key),
+    );
+    metadata.insert(
+        "signature_status".to_string(),
+        serde_json::json!(signature_status_label(&trigger_event.signature_status)),
+    );
+    metadata
+}
+
+fn stage_node_metadata(stage: &RunStageRecord) -> BTreeMap<String, serde_json::Value> {
+    let mut metadata = BTreeMap::new();
+    metadata.insert("stage_kind".to_string(), serde_json::json!(stage.kind));
+    if let Some(branch) = stage.branch.as_ref() {
+        metadata.insert("branch".to_string(), serde_json::json!(branch));
+    }
+    if let Some(worker_id) = stage
+        .metadata
+        .get("worker_id")
+        .and_then(|value| value.as_str())
+    {
+        metadata.insert("worker_id".to_string(), serde_json::json!(worker_id));
+    }
+    metadata
+}
+
 fn append_action_graph_node(
     nodes: &mut Vec<RunActionGraphNodeRecord>,
     record: RunActionGraphNodeRecord,
@@ -814,6 +853,10 @@ pub fn derive_run_observability(
             worker_id: None,
             run_id: Some(run.id.clone()),
             run_path: run.persisted_path.clone(),
+            metadata: BTreeMap::from([(
+                "workflow_id".to_string(),
+                serde_json::json!(run.workflow_id),
+            )]),
         },
     );
     let mut entry_node_id = root_node_id.clone();
@@ -839,6 +882,7 @@ pub fn derive_run_observability(
                     worker_id: None,
                     run_id: Some(run.id.clone()),
                     run_path: run.persisted_path.clone(),
+                    metadata: trigger_node_metadata(trigger_event),
                 },
             );
             action_graph_edges.push(RunActionGraphEdgeRecord {
@@ -863,6 +907,7 @@ pub fn derive_run_observability(
                 worker_id: None,
                 run_id: Some(run.id.clone()),
                 run_path: run.persisted_path.clone(),
+                metadata: trigger_node_metadata(trigger_event),
             },
         );
         action_graph_edges.push(RunActionGraphEdgeRecord {
@@ -919,6 +964,7 @@ pub fn derive_run_observability(
                     .map(str::to_string),
                 run_id: None,
                 run_path: None,
+                metadata: stage_node_metadata(stage),
             },
         );
         if !incoming_nodes.contains(&stage.node_id) {
@@ -1112,6 +1158,10 @@ pub fn derive_run_observability(
                     worker_id: Some(child.worker_id.clone()),
                     run_id: child.run_id.clone(),
                     run_path: child.run_path.clone(),
+                    metadata: BTreeMap::from([
+                        ("worker_name".to_string(), serde_json::json!(child.worker_name)),
+                        ("task".to_string(), serde_json::json!(child.task)),
+                    ]),
                 },
             );
             if let Some(parent_stage_id) = child.parent_stage_id.as_ref() {

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -23,7 +23,7 @@ use crate::orchestration::{
     ACTION_GRAPH_EDGE_KIND_RETRY, ACTION_GRAPH_EDGE_KIND_TRIGGER_DISPATCH,
     ACTION_GRAPH_NODE_KIND_A2A_HOP, ACTION_GRAPH_NODE_KIND_DISPATCH, ACTION_GRAPH_NODE_KIND_DLQ,
     ACTION_GRAPH_NODE_KIND_RETRY, ACTION_GRAPH_NODE_KIND_TRIGGER,
-    ACTION_GRAPH_NODE_KIND_TRIGGER_PREDICATE,
+    ACTION_GRAPH_NODE_KIND_TRIGGER_PREDICATE, ACTION_GRAPH_NODE_KIND_WORKER_ENQUEUE,
 };
 use crate::stdlib::json_to_vm_value;
 use crate::trust_graph::{append_trust_record, AutonomyTier, TrustOutcome, TrustRecord};
@@ -708,6 +708,7 @@ impl Dispatcher {
                 worker_id: None,
                 run_id: None,
                 run_path: None,
+                metadata: trigger_node_metadata(&event),
             });
             initial_edges.push(RunActionGraphEdgeRecord {
                 from_id: original_node_id,
@@ -728,6 +729,7 @@ impl Dispatcher {
             worker_id: None,
             run_id: None,
             run_path: None,
+            metadata: trigger_node_metadata(&event),
         });
         self.emit_action_graph(
             &event,
@@ -795,6 +797,7 @@ impl Dispatcher {
                     worker_id: None,
                     run_id: None,
                     run_path: None,
+                    metadata: predicate_node_metadata(binding, predicate, &event, &evaluation),
                 }],
                 vec![RunActionGraphEdgeRecord {
                     from_id: source_node_id.clone(),
@@ -1010,6 +1013,7 @@ impl Dispatcher {
                     worker_id: None,
                     run_id: None,
                     run_path: None,
+                    metadata: dispatch_node_metadata(&route, binding, &event, attempt),
                 }],
                 dispatch_edges,
                 serde_json::json!({
@@ -1090,6 +1094,42 @@ impl Dispatcher {
                             "replay_of_event_id": replay_of_event_id,
                         }),
                         replay_of_event_id.as_ref(),
+                    )
+                    .await?;
+                    self.emit_action_graph(
+                        &event,
+                        vec![RunActionGraphNodeRecord {
+                            id: attempt_node_id.clone(),
+                            label: dispatch_node_label(&route),
+                            kind: dispatch_node_kind(&route).to_string(),
+                            status: "completed".to_string(),
+                            outcome: dispatch_success_outcome(&route, &result).to_string(),
+                            trace_id: Some(event.trace_id.0.clone()),
+                            stage_id: None,
+                            node_id: None,
+                            worker_id: None,
+                            run_id: None,
+                            run_path: None,
+                            metadata: dispatch_success_metadata(
+                                &route,
+                                binding,
+                                &event,
+                                attempt,
+                                &result,
+                            ),
+                        }],
+                        Vec::new(),
+                        serde_json::json!({
+                            "source": "dispatcher",
+                            "trigger_id": binding.id.as_str(),
+                            "binding_key": binding.binding_key(),
+                            "event_id": event.id.0,
+                            "attempt": attempt,
+                            "handler_kind": route.kind(),
+                            "target_uri": route.target_uri(),
+                            "result": result,
+                            "replay_of_event_id": replay_of_event_id,
+                        }),
                     )
                     .await?;
                     finish_in_flight(
@@ -1180,6 +1220,46 @@ impl Dispatcher {
                         replay_of_event_id.as_ref(),
                     )
                     .await?;
+                    self.emit_action_graph(
+                        &event,
+                        vec![RunActionGraphNodeRecord {
+                            id: attempt_node_id.clone(),
+                            label: dispatch_node_label(&route),
+                            kind: dispatch_node_kind(&route).to_string(),
+                            status: if matches!(error, DispatchError::Cancelled(_)) {
+                                "cancelled".to_string()
+                            } else {
+                                "failed".to_string()
+                            },
+                            outcome: dispatch_error_label(&error).to_string(),
+                            trace_id: Some(event.trace_id.0.clone()),
+                            stage_id: None,
+                            node_id: None,
+                            worker_id: None,
+                            run_id: None,
+                            run_path: None,
+                            metadata: dispatch_error_metadata(
+                                &route,
+                                binding,
+                                &event,
+                                attempt,
+                                &error,
+                            ),
+                        }],
+                        Vec::new(),
+                        serde_json::json!({
+                            "source": "dispatcher",
+                            "trigger_id": binding.id.as_str(),
+                            "binding_key": binding.binding_key(),
+                            "event_id": event.id.0,
+                            "attempt": attempt,
+                            "handler_kind": route.kind(),
+                            "target_uri": route.target_uri(),
+                            "error": error.to_string(),
+                            "replay_of_event_id": replay_of_event_id,
+                        }),
+                    )
+                    .await?;
 
                     if !error.retryable() {
                         finish_in_flight(
@@ -1250,6 +1330,13 @@ impl Dispatcher {
                                 worker_id: None,
                                 run_id: None,
                                 run_path: None,
+                                metadata: retry_node_metadata(
+                                    binding,
+                                    &event,
+                                    attempt + 1,
+                                    delay,
+                                    &error,
+                                ),
                             }],
                             vec![RunActionGraphEdgeRecord {
                                 from_id: attempt_node_id,
@@ -1379,6 +1466,7 @@ impl Dispatcher {
                             worker_id: None,
                             run_id: None,
                             run_path: None,
+                            metadata: dlq_node_metadata(binding, &event, attempt, &final_error),
                         }],
                         vec![RunActionGraphEdgeRecord {
                             from_id: dispatch_node_id(&route, &binding_key, &event.id.0, attempt),
@@ -2641,6 +2729,19 @@ fn dispatch_error_label(error: &DispatchError) -> &'static str {
     }
 }
 
+fn dispatch_success_outcome(route: &DispatchUri, result: &serde_json::Value) -> &'static str {
+    match route {
+        DispatchUri::Worker { .. } => "enqueued",
+        DispatchUri::A2a { .. } if result.get("kind").and_then(|value| value.as_str())
+            == Some("a2a_task_handle") =>
+        {
+            "pending"
+        }
+        DispatchUri::A2a { .. } => "completed",
+        DispatchUri::Local { .. } => "success",
+    }
+}
+
 fn dispatch_node_id(
     route: &DispatchUri,
     binding_key: &str,
@@ -2657,6 +2758,7 @@ fn dispatch_node_id(
 fn dispatch_node_kind(route: &DispatchUri) -> &'static str {
     match route {
         DispatchUri::A2a { .. } => ACTION_GRAPH_NODE_KIND_A2A_HOP,
+        DispatchUri::Worker { .. } => ACTION_GRAPH_NODE_KIND_WORKER_ENQUEUE,
         _ => ACTION_GRAPH_NODE_KIND_DISPATCH,
     }
 }
@@ -2681,6 +2783,168 @@ fn dispatch_entry_edge_kind(route: &DispatchUri, has_predicate: bool) -> &'stati
         _ if has_predicate => ACTION_GRAPH_EDGE_KIND_PREDICATE_GATE,
         _ => ACTION_GRAPH_EDGE_KIND_TRIGGER_DISPATCH,
     }
+}
+
+fn signature_status_label(status: &crate::triggers::SignatureStatus) -> &'static str {
+    match status {
+        crate::triggers::SignatureStatus::Verified => "verified",
+        crate::triggers::SignatureStatus::Unsigned => "unsigned",
+        crate::triggers::SignatureStatus::Failed { .. } => "failed",
+    }
+}
+
+fn trigger_node_metadata(event: &TriggerEvent) -> BTreeMap<String, serde_json::Value> {
+    let mut metadata = BTreeMap::new();
+    metadata.insert("provider".to_string(), serde_json::json!(event.provider.as_str()));
+    metadata.insert("event_kind".to_string(), serde_json::json!(event.kind));
+    metadata.insert("dedupe_key".to_string(), serde_json::json!(event.dedupe_key));
+    metadata.insert(
+        "signature_status".to_string(),
+        serde_json::json!(signature_status_label(&event.signature_status)),
+    );
+    metadata
+}
+
+fn predicate_node_metadata(
+    binding: &TriggerBinding,
+    predicate: &super::registry::TriggerPredicateSpec,
+    event: &TriggerEvent,
+    evaluation: &PredicateEvaluationRecord,
+) -> BTreeMap<String, serde_json::Value> {
+    let mut metadata = BTreeMap::new();
+    metadata.insert(
+        "trigger_id".to_string(),
+        serde_json::json!(binding.id.as_str()),
+    );
+    metadata.insert("predicate".to_string(), serde_json::json!(predicate.raw));
+    metadata.insert("result".to_string(), serde_json::json!(evaluation.result));
+    metadata.insert("cost_usd".to_string(), serde_json::json!(evaluation.cost_usd));
+    metadata.insert("tokens".to_string(), serde_json::json!(evaluation.tokens));
+    metadata.insert(
+        "latency_ms".to_string(),
+        serde_json::json!(evaluation.latency_ms),
+    );
+    metadata.insert("cached".to_string(), serde_json::json!(evaluation.cached));
+    metadata.insert("event_id".to_string(), serde_json::json!(event.id.0));
+    if let Some(reason) = evaluation.reason.as_ref() {
+        metadata.insert("reason".to_string(), serde_json::json!(reason));
+    }
+    metadata
+}
+
+fn dispatch_node_metadata(
+    route: &DispatchUri,
+    binding: &TriggerBinding,
+    event: &TriggerEvent,
+    attempt: u32,
+) -> BTreeMap<String, serde_json::Value> {
+    let mut metadata = BTreeMap::new();
+    metadata.insert(
+        "handler_kind".to_string(),
+        serde_json::json!(route.kind()),
+    );
+    metadata.insert("target_uri".to_string(), serde_json::json!(route.target_uri()));
+    metadata.insert("attempt".to_string(), serde_json::json!(attempt));
+    metadata.insert(
+        "trigger_id".to_string(),
+        serde_json::json!(binding.id.as_str()),
+    );
+    metadata.insert("event_id".to_string(), serde_json::json!(event.id.0));
+    if let Some(target_agent) = dispatch_target_agent(route) {
+        metadata.insert("target_agent".to_string(), serde_json::json!(target_agent));
+    }
+    if let DispatchUri::Worker { queue } = route {
+        metadata.insert("queue_name".to_string(), serde_json::json!(queue));
+    }
+    metadata
+}
+
+fn dispatch_success_metadata(
+    route: &DispatchUri,
+    binding: &TriggerBinding,
+    event: &TriggerEvent,
+    attempt: u32,
+    result: &serde_json::Value,
+) -> BTreeMap<String, serde_json::Value> {
+    let mut metadata = dispatch_node_metadata(route, binding, event, attempt);
+    match route {
+        DispatchUri::A2a { .. } => {
+            if let Some(task_id) = result
+                .get("task_id")
+                .or_else(|| result.get("id"))
+                .and_then(|value| value.as_str())
+            {
+                metadata.insert("task_id".to_string(), serde_json::json!(task_id));
+            }
+            if let Some(state) = result.get("state").and_then(|value| value.as_str()) {
+                metadata.insert("state".to_string(), serde_json::json!(state));
+            }
+        }
+        DispatchUri::Worker { .. } => {
+            if let Some(job_event_id) = result.get("job_event_id").and_then(|value| value.as_u64()) {
+                metadata.insert("job_event_id".to_string(), serde_json::json!(job_event_id));
+            }
+            if let Some(response_topic) = result.get("response_topic").and_then(|value| value.as_str()) {
+                metadata.insert("response_topic".to_string(), serde_json::json!(response_topic));
+            }
+        }
+        DispatchUri::Local { .. } => {}
+    }
+    metadata
+}
+
+fn dispatch_error_metadata(
+    route: &DispatchUri,
+    binding: &TriggerBinding,
+    event: &TriggerEvent,
+    attempt: u32,
+    error: &DispatchError,
+) -> BTreeMap<String, serde_json::Value> {
+    let mut metadata = dispatch_node_metadata(route, binding, event, attempt);
+    metadata.insert("error".to_string(), serde_json::json!(error.to_string()));
+    metadata
+}
+
+fn retry_node_metadata(
+    binding: &TriggerBinding,
+    event: &TriggerEvent,
+    attempt: u32,
+    delay: Duration,
+    error: &DispatchError,
+) -> BTreeMap<String, serde_json::Value> {
+    let mut metadata = BTreeMap::new();
+    metadata.insert(
+        "trigger_id".to_string(),
+        serde_json::json!(binding.id.as_str()),
+    );
+    metadata.insert("event_id".to_string(), serde_json::json!(event.id.0));
+    metadata.insert("attempt".to_string(), serde_json::json!(attempt));
+    metadata.insert(
+        "delay_ms".to_string(),
+        serde_json::json!(delay.as_millis()),
+    );
+    metadata.insert("error".to_string(), serde_json::json!(error.to_string()));
+    metadata
+}
+
+fn dlq_node_metadata(
+    binding: &TriggerBinding,
+    event: &TriggerEvent,
+    attempt_count: u32,
+    final_error: &str,
+) -> BTreeMap<String, serde_json::Value> {
+    let mut metadata = BTreeMap::new();
+    metadata.insert(
+        "trigger_id".to_string(),
+        serde_json::json!(binding.id.as_str()),
+    );
+    metadata.insert("event_id".to_string(), serde_json::json!(event.id.0));
+    metadata.insert(
+        "attempt_count".to_string(),
+        serde_json::json!(attempt_count),
+    );
+    metadata.insert("final_error".to_string(), serde_json::json!(final_error));
+    metadata
 }
 
 fn predicate_value_as_bool(value: VmValue) -> Result<bool, String> {

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -332,18 +332,23 @@ fn lifecycle_payloads(
 
 struct MockA2aServer {
     authority: String,
-    requests: Receiver<serde_json::Value>,
+    requests: Receiver<MockA2aRequest>,
     stop: Arc<AtomicBool>,
     join: thread::JoinHandle<()>,
 }
 
+struct MockA2aRequest {
+    headers: BTreeMap<String, String>,
+    body: serde_json::Value,
+}
+
 impl MockA2aServer {
-    fn next_request(&self) -> serde_json::Value {
+    fn next_request(&self) -> MockA2aRequest {
         self.request_within(Duration::from_secs(5))
             .expect("mock A2A request")
     }
 
-    fn request_within(&self, timeout: Duration) -> Option<serde_json::Value> {
+    fn request_within(&self, timeout: Duration) -> Option<MockA2aRequest> {
         self.requests.recv_timeout(timeout).ok()
     }
 
@@ -453,10 +458,10 @@ fn handle_mock_a2a_connection<T: Read + Write>(
     stream: &mut T,
     card_scheme: &str,
     port: u16,
-    tx: &mpsc::Sender<serde_json::Value>,
+    tx: &mpsc::Sender<MockA2aRequest>,
     task_result: &serde_json::Value,
 ) {
-    let (request_line, body) = read_http_request(stream);
+    let (request_line, headers, body) = read_http_request(stream);
     if request_line.starts_with("GET /.well-known/a2a-agent ") {
         write_json_response(
             stream,
@@ -472,11 +477,13 @@ fn handle_mock_a2a_connection<T: Read + Write>(
         request_line.starts_with("POST /rpc "),
         "unexpected request line: {request_line}"
     );
-    tx.send(serde_json::from_slice::<serde_json::Value>(&body).expect("mock A2A request json"))
-        .expect("capture mock A2A request");
-    let rpc_id = serde_json::from_slice::<serde_json::Value>(&body).expect("mock A2A request json")
-        ["id"]
-        .clone();
+    let payload = serde_json::from_slice::<serde_json::Value>(&body).expect("mock A2A request json");
+    tx.send(MockA2aRequest {
+        headers,
+        body: payload.clone(),
+    })
+    .expect("capture mock A2A request");
+    let rpc_id = payload["id"].clone();
     write_json_response(
         stream,
         &crate::jsonrpc::response(rpc_id, task_result.clone()),
@@ -504,7 +511,7 @@ fn install_rustls_provider() {
     });
 }
 
-fn read_http_request<T: Read>(stream: &mut T) -> (String, Vec<u8>) {
+fn read_http_request<T: Read>(stream: &mut T) -> (String, BTreeMap<String, String>, Vec<u8>) {
     let mut buffer = Vec::new();
     let mut chunk = [0u8; 4096];
     let header_end;
@@ -526,8 +533,15 @@ fn read_http_request<T: Read>(stream: &mut T) -> (String, Vec<u8>) {
     }
     let headers = String::from_utf8_lossy(&buffer[..header_end]);
     let request_line = headers.lines().next().unwrap_or_default().to_string();
+    let mut parsed_headers = BTreeMap::new();
+    for line in headers.lines().skip(1) {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        parsed_headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+    }
     let body = buffer[header_end..header_end + content_length].to_vec();
-    (request_line, body)
+    (request_line, parsed_headers, body)
 }
 
 fn find_header_end(buffer: &[u8]) -> Option<usize> {
@@ -620,6 +634,17 @@ pub fn should_handle(event: TriggerEvent) -> bool {
             assert!(node_kinds.iter().any(|kind| kind == "dispatch"));
             assert!(edge_kinds.iter().any(|kind| kind == "trigger_dispatch"));
             assert!(edge_kinds.iter().any(|kind| kind == "predicate_gate"));
+            assert!(graph.iter().any(|(_, event)| {
+                event.payload["observability"]["action_graph_nodes"]
+                    .as_array()
+                    .is_some_and(|nodes| {
+                        nodes.iter().any(|node| {
+                            node["kind"] == serde_json::json!("dispatch")
+                                && node["status"] == serde_json::json!("completed")
+                                && node["metadata"]["handler_kind"] == serde_json::json!("local")
+                        })
+                    })
+            }));
         })
         .await;
 }
@@ -1049,8 +1074,12 @@ async fn a2a_handler_returns_inline_result_and_emits_a2a_action_graph() {
             );
 
             let request = server.next_request();
-            assert_eq!(request["method"], "a2a.SendMessage");
-            let envelope_text = request["params"]["message"]["parts"][0]["text"]
+            assert_eq!(request.body["method"], "a2a.SendMessage");
+            assert_eq!(
+                request.headers.get("a2a-trace-id").map(String::as_str),
+                Some("trace_inline")
+            );
+            let envelope_text = request.body["params"]["message"]["parts"][0]["text"]
                 .as_str()
                 .expect("A2A text part");
             let envelope: serde_json::Value =
@@ -1102,7 +1131,7 @@ async fn worker_handler_enqueues_job_and_returns_receipt() {
     );
     assert!(receipt["job_event_id"].as_u64().is_some());
 
-    let queue = crate::WorkerQueue::new(log);
+    let queue = crate::WorkerQueue::new(log.clone());
     let state = queue.queue_state("triage").await.expect("load queue state");
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -1112,6 +1141,19 @@ async fn worker_handler_enqueues_job_and_returns_receipt() {
     assert_eq!(state.jobs.len(), 1);
     assert_eq!(state.jobs[0].job.trigger_id, "github-worker-review");
     assert_eq!(state.jobs[0].job.priority, crate::WorkerQueuePriority::High);
+
+    let graph = read_topic(log.clone(), "observability.action_graph").await;
+    assert!(graph.iter().any(|(_, event)| {
+        event.payload["observability"]["action_graph_nodes"]
+            .as_array()
+            .is_some_and(|nodes| {
+                nodes.iter().any(|node| {
+                    node["kind"] == serde_json::json!("worker_enqueue")
+                        && node["metadata"]["queue_name"] == serde_json::json!("triage")
+                        && node["metadata"]["job_event_id"].as_u64().is_some()
+                })
+            })
+    }));
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -1154,7 +1196,7 @@ async fn a2a_handler_returns_pending_task_handle() {
             );
 
             let request = server.next_request();
-            assert_eq!(request["method"], "a2a.SendMessage");
+            assert_eq!(request.body["method"], "a2a.SendMessage");
             server.finish();
         })
         .await;
@@ -1288,7 +1330,11 @@ async fn a2a_handler_allows_cleartext_after_opt_in() {
             );
 
             let request = server.next_request();
-            assert_eq!(request["method"], "a2a.SendMessage");
+            assert_eq!(request.body["method"], "a2a.SendMessage");
+            assert_eq!(
+                request.headers.get("a2a-trace-id").map(String::as_str),
+                Some("trace_http")
+            );
 
             server.finish();
         })
@@ -1350,6 +1396,17 @@ pub fn local_fn(event: TriggerEvent) -> string {
             assert!(node_kinds.iter().any(|kind| kind == "dlq"));
             assert!(edge_kinds.iter().any(|kind| kind == "retry"));
             assert!(edge_kinds.iter().any(|kind| kind == "dlq_move"));
+            assert!(graph.iter().any(|(_, event)| {
+                event.payload["observability"]["action_graph_nodes"]
+                    .as_array()
+                    .is_some_and(|nodes| {
+                        nodes.iter().any(|node| {
+                            node["kind"] == serde_json::json!("dlq")
+                                && node["metadata"]["attempt_count"] == serde_json::json!(2)
+                                && node["metadata"]["final_error"] == serde_json::json!("boom")
+                        })
+                    })
+            }));
         })
         .await;
 }

--- a/docs/src/observability/assets/triggers-action-graph-sample.svg
+++ b/docs/src/observability/assets/triggers-action-graph-sample.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="540" viewBox="0 0 980 540" role="img" aria-labelledby="title desc">
+  <title id="title">Trigger action-graph portal sample</title>
+  <desc id="desc">A sample portal panel showing trigger, predicate, A2A hop, worker enqueue, retry, and DLQ cards.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#121820"/>
+      <stop offset="100%" stop-color="#0a0f15"/>
+    </linearGradient>
+  </defs>
+  <rect width="980" height="540" fill="url(#bg)"/>
+  <rect x="28" y="24" width="924" height="492" rx="18" fill="#141c25" stroke="#223142"/>
+  <text x="54" y="68" fill="#9fb4c8" font-family="Menlo, monospace" font-size="13">ACTION GRAPH</text>
+  <text x="54" y="98" fill="#f6fbff" font-family="Menlo, monospace" font-size="24">Trigger observability for trace trace_123</text>
+
+  <g font-family="Menlo, monospace">
+    <rect x="54" y="126" width="268" height="98" rx="12" fill="#17212c" stroke="#4da3ff" stroke-width="2"/>
+    <text x="72" y="152" fill="#7eb8ff" font-size="12">INBOUND TRIGGER</text>
+    <text x="72" y="178" fill="#f6fbff" font-size="18">github:issue.opened</text>
+    <text x="72" y="202" fill="#bcd0e2" font-size="12">signature verified • trace trace_123</text>
+
+    <rect x="344" y="126" width="268" height="98" rx="12" fill="#1f2117" stroke="#f3b13d" stroke-width="2"/>
+    <text x="362" y="152" fill="#f3b13d" font-size="12">PREDICATE GATE</text>
+    <text x="362" y="178" fill="#f6fbff" font-size="18">should_handle(event)</text>
+    <text x="362" y="202" fill="#d7d5bc" font-size="12">passed • $0.0021 • 184 ms</text>
+
+    <rect x="634" y="126" width="268" height="98" rx="12" fill="#17212c" stroke="#7dd3fc" stroke-width="2" stroke-dasharray="8 6"/>
+    <text x="652" y="152" fill="#7dd3fc" font-size="12">A2A HOP</text>
+    <text x="652" y="178" fill="#f6fbff" font-size="18">triage agent</text>
+    <text x="652" y="202" fill="#bcd0e2" font-size="12">task task-inline • A2A-Trace-Id trace_123</text>
+
+    <rect x="54" y="252" width="268" height="98" rx="12" fill="#152117" stroke="#63cf72" stroke-width="2"/>
+    <text x="72" y="278" fill="#63cf72" font-size="12">WORKER ENQUEUE</text>
+    <text x="72" y="304" fill="#f6fbff" font-size="18">worker://triage</text>
+    <text x="72" y="328" fill="#c4e2c8" font-size="12">queue triage • job_event_id 42</text>
+
+    <rect x="344" y="252" width="268" height="98" rx="12" fill="#241c14" stroke="#f59e0b" stroke-width="2"/>
+    <text x="362" y="278" fill="#f59e0b" font-size="12">RETRY</text>
+    <text x="362" y="304" fill="#f6fbff" font-size="18">retry in 250 ms</text>
+    <text x="362" y="328" fill="#e6d2bb" font-size="12">attempt 2 • timeout</text>
+
+    <rect x="634" y="252" width="268" height="98" rx="12" fill="#261415" stroke="#ef4444" stroke-width="2"/>
+    <text x="652" y="278" fill="#ef4444" font-size="12">DLQ</text>
+    <text x="652" y="304" fill="#f6fbff" font-size="18">github-a2a-review</text>
+    <text x="652" y="328" fill="#ebc4c4" font-size="12">2 attempts • final_error boom</text>
+
+    <rect x="634" y="366" width="160" height="40" rx="999" fill="#24374a" stroke="#7eb8ff"/>
+    <text x="682" y="391" fill="#f6fbff" font-size="13">Replay trigger</text>
+  </g>
+
+  <g stroke="#4f6478" stroke-width="2" fill="none">
+    <path d="M322 175 H344"/>
+    <path d="M612 175 H634"/>
+    <path d="M322 301 H344"/>
+    <path d="M612 301 H634"/>
+  </g>
+</svg>

--- a/docs/src/observability/triggers-in-action-graph.md
+++ b/docs/src/observability/triggers-in-action-graph.md
@@ -1,9 +1,10 @@
 # Trigger Observability In The Action Graph
 
-Harn now projects trigger activity into persisted run observability across both
-workflow-derived nodes and dispatcher hops. The current surface includes
-`trigger`, `predicate`, `dispatch`, and `a2a_hop` nodes, plus the matching
-`trigger_dispatch`, `predicate_gate`, and `a2a_dispatch` edges.
+Harn projects trigger activity into both persisted run observability and the
+live dispatcher event stream. The current surface includes `trigger`,
+`predicate`, `dispatch`, `a2a_hop`, `worker_enqueue`, `retry`, and `dlq`
+nodes, plus the matching `trigger_dispatch`, `predicate_gate`,
+`a2a_dispatch`, `retry`, `dlq_move`, and `replay_chain` edges.
 
 ## What lands in this change
 
@@ -14,38 +15,72 @@ workflow-derived nodes and dispatcher hops. The current surface includes
 - Local dispatch attempts render as `dispatch` nodes.
 - Remote A2A dispatch attempts render as `a2a_hop` nodes labelled with the
   resolved `target_agent`.
+- `worker://...` queue handoffs render as `worker_enqueue` nodes with queue
+  name, response topic, and job receipt metadata.
+- Retry scheduling emits `retry` nodes with delay/error metadata.
+- Exhausted deliveries emit `dlq` nodes with final-error metadata.
 - Entry edges from the trigger node into the workflow render as
   `trigger_dispatch`.
 - Trigger or predicate edges into a remote A2A hop render as `a2a_dispatch`.
 - Transitions leaving a predicate on the workflow path render as
   `predicate_gate`.
+- Replay-triggered dispatches add a visible `replay_chain` edge back to the
+  original trigger event.
 - `trace_id` propagates from the `TriggerEvent` onto the synthetic trigger
   node and every downstream action-graph node derived from that run,
-  including A2A hops.
+  including A2A hops and worker queue receipts.
+- A2A dispatches also send the same trace on the wire via the
+  `A2A-Trace-Id` HTTP header in addition to the JSON envelope metadata.
 
-The runtime also streams the derived graph onto the shared event-log topic
-`observability.action_graph` whenever a run record is persisted. This reuses
-the generalized `EventLog` infrastructure instead of a parallel observability
-bus.
+The runtime streams these updates onto the shared event-log topic
+`observability.action_graph`. The portal subscribes to that topic for traced
+runs and merges live node/edge updates into the detail view while still
+showing the persisted run snapshot.
 
-## Current shape
+## Portal view
 
-This scoped change still leaves some portal/runtime work deferred:
+The portal run detail now renders dedicated node cards instead of a plain edge
+dump:
 
-- Landed here: `trigger`, `predicate`, `dispatch`, and `a2a_hop` node kinds.
-- Deferred: `worker_enqueue` specialized nodes and richer DLQ/A2A UI.
-- Deferred: portal replay controls and dispatcher-coupled UI work.
+- trigger cards show provider, event kind, signature status, and trace id
+- predicate cards show pass/block state plus cost and latency
+- A2A cards render with a dashed trust-boundary style and task metadata
+- worker enqueue cards show queue and response-topic details
+- DLQ and trigger cards expose a replay button that invokes
+  `harn trigger replay <event-id>` through the portal backend
+
+![Portal sample](./assets/triggers-action-graph-sample.svg)
+
+## Node metadata
+
+Each `RunActionGraphNodeRecord` now carries a `metadata` map so the portal and
+CLI consumers can render node-specific details without inventing a second
+schema. Representative fields include:
+
+- `trigger`: `provider`, `event_kind`, `dedupe_key`, `signature_status`
+- `predicate`: `trigger_id`, `predicate`, `result`, `cost_usd`, `tokens`,
+  `latency_ms`, `reason`
+- `dispatch` / `a2a_hop` / `worker_enqueue`: `handler_kind`, `target_uri`,
+  `attempt`, plus route-specific fields like `target_agent`, `task_id`,
+  `queue_name`, `response_topic`, and `job_event_id`
+- `retry`: `delay_ms`, `error`
+- `dlq`: `attempt_count`, `final_error`
 
 ## Example
 
-When a workflow is started with a `trigger_event` option, the persisted run
-record will include observability nodes like:
+When a trigger is dispatched, the streamed action-graph updates now include
+records like:
 
 ```json
 {
   "kind": "trigger",
   "label": "cron:tick",
-  "trace_id": "trace_123"
+  "trace_id": "trace_123",
+  "metadata": {
+    "provider": "cron",
+    "event_kind": "cron.tick",
+    "signature_status": "unsigned"
+  }
 }
 ```
 
@@ -53,9 +88,14 @@ and:
 
 ```json
 {
-  "kind": "predicate",
-  "label": "gate",
-  "trace_id": "trace_123"
+  "kind": "worker_enqueue",
+  "label": "worker://triage",
+  "trace_id": "trace_123",
+  "metadata": {
+    "queue_name": "triage",
+    "response_topic": "worker.triage.responses",
+    "job_event_id": 42
+  }
 }
 ```
 
@@ -65,7 +105,6 @@ with edges such as:
 {"kind": "trigger_dispatch", "from_id": "trigger:...", "to_id": "stage:..."}
 {"kind": "predicate_gate", "label": "true"}
 {"kind": "a2a_dispatch", "from_id": "predicate:...", "to_id": "a2a:..."}
+{"kind": "retry", "from_id": "dispatch:...", "to_id": "retry:..."}
+{"kind": "dlq_move", "from_id": "dispatch:...", "to_id": "dlq:..."}
 ```
-
-The portal does not yet render specialized UI for these nodes in this PR; it
-will consume the shared event-log topic in the dispatcher follow-up.


### PR DESCRIPTION
## Summary

Finish the remaining action-graph observability work for trigger dispatches by wiring the runtime, portal, and docs together:

- extend `RunActionGraphNodeRecord` with per-node metadata and add the `worker_enqueue` node kind
- emit richer dispatcher node updates for trigger, predicate, dispatch, A2A hop, worker enqueue, retry, and DLQ transitions
- propagate trigger traces across the A2A HTTP boundary via `A2A-Trace-Id`
- add a portal action-graph stream endpoint backed by `observability.action_graph`
- render specialized portal node cards with replay controls for trigger/DLQ nodes
- document the final surface with an updated observability guide and screenshot-style SVG

## Why

`#163` was only partially landed earlier: the dispatcher-independent node kinds existed, but the portal still showed a generic edge dump, there was no replay action, and the live `observability.action_graph` topic was not consumed by the portal. This PR closes that gap and makes the trigger trace legible end-to-end.

## Validation

- `env CARGO_TARGET_DIR=/tmp/harn-b14d-target cargo check -p harn-vm -p harn-cli`
- `env CARGO_TARGET_DIR=/tmp/harn-b14d-target cargo test -p harn-vm dispatcher::tests -- --nocapture`
- `env CARGO_TARGET_DIR=/tmp/harn-b14d-target cargo test -p harn-cli portal::tests -- --nocapture`
- `npm --prefix crates/harn-cli/portal test`
- `npm --prefix crates/harn-cli/portal run build`

## Notes

- This PR covers the runtime + portal portions of `#163` and the portal follow-up tracked in `#201`.
- I did not add a new conformance fixture for the live `observability.action_graph` topic shape in this PR; validation is currently through targeted Rust and portal tests.

Refs #163
nRefs #201
