### PR TITLE
Report unknown struct literals in `harn check`

### DIFF
--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -917,19 +917,33 @@ pub(crate) fn parse_source_file(path: &str) -> (String, Vec<harn_parser::SNode>)
     let mut parser = Parser::new(tokens);
     let program = match parser.parse() {
         Ok(p) => p,
-        Err(_) => {
-            for e in parser.all_errors() {
-                let span = error_span_from_parse(e);
+        Err(err) => {
+            if parser.all_errors().is_empty() {
+                let span = error_span_from_parse(&err);
                 let diagnostic = harn_parser::diagnostic::render_diagnostic(
                     &source,
                     path,
                     &span,
                     "error",
-                    &harn_parser::diagnostic::parser_error_message(e),
-                    Some(harn_parser::diagnostic::parser_error_label(e)),
-                    harn_parser::diagnostic::parser_error_help(e),
+                    &harn_parser::diagnostic::parser_error_message(&err),
+                    Some(harn_parser::diagnostic::parser_error_label(&err)),
+                    harn_parser::diagnostic::parser_error_help(&err),
                 );
                 eprint!("{diagnostic}");
+            } else {
+                for e in parser.all_errors() {
+                    let span = error_span_from_parse(e);
+                    let diagnostic = harn_parser::diagnostic::render_diagnostic(
+                        &source,
+                        path,
+                        &span,
+                        "error",
+                        &harn_parser::diagnostic::parser_error_message(e),
+                        Some(harn_parser::diagnostic::parser_error_label(e)),
+                        harn_parser::diagnostic::parser_error_help(e),
+                    );
+                    eprint!("{diagnostic}");
+                }
             }
             process::exit(1);
         }

--- a/crates/harn-cli/tests/check_cli.rs
+++ b/crates/harn-cli/tests/check_cli.rs
@@ -1,0 +1,34 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+#[test]
+fn check_reports_unknown_struct_type_in_stderr() {
+    let temp = TempDir::new().unwrap();
+    let script = temp.path().join("main.harn");
+    fs::write(&script, "let p = Point { x: 3, y: 4 }\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .args(["check", script.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected nonzero exit, stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown struct type `Point`"),
+        "missing unknown-struct diagnostic: {stderr}"
+    );
+    assert!(
+        stderr.contains(&format!("{}:1:9", script.display())),
+        "missing precise location in stderr: {stderr}"
+    );
+}

--- a/crates/harn-parser/src/parser/expressions.rs
+++ b/crates/harn-parser/src/parser/expressions.rs
@@ -421,14 +421,17 @@ impl Parser {
                         );
                     }
                 }
-            } else if self.check(&TokenKind::LBrace)
-                && matches!(&expr.node, Node::Identifier(name) if self.struct_names.contains(name))
-            {
-                let start = expr.span;
-                let struct_name = match expr.node {
-                    Node::Identifier(name) => name,
-                    _ => unreachable!("checked above"),
+            } else if self.check(&TokenKind::LBrace) {
+                let struct_name = match &expr.node {
+                    Node::Identifier(name) if self.is_struct_construct_lookahead(name) => {
+                        Some(name.clone())
+                    }
+                    _ => None,
                 };
+                let Some(struct_name) = struct_name else {
+                    break;
+                };
+                let start = expr.span;
                 self.advance();
                 let dict = self.parse_dict_literal(start)?;
                 let fields = match dict.node {
@@ -710,6 +713,28 @@ impl Parser {
         }
         self.pos = saved;
         self.parse_dict_literal(start)
+    }
+
+    /// After seeing `Identifier {`, decide whether the brace block is a
+    /// struct-construction field list rather than a control-flow block.
+    /// Struct fields always start with `name:` / `"name":` or `}`.
+    pub(super) fn is_struct_construct_lookahead(&self, struct_name: &str) -> bool {
+        let mut offset = 1;
+        while matches!(self.peek_kind_at(offset), Some(TokenKind::Newline)) {
+            offset += 1;
+        }
+
+        match self.peek_kind_at(offset) {
+            Some(TokenKind::RBrace) => self.struct_names.contains(struct_name),
+            Some(TokenKind::Identifier(_)) | Some(TokenKind::StringLiteral(_)) => {
+                offset += 1;
+                while matches!(self.peek_kind_at(offset), Some(TokenKind::Newline)) {
+                    offset += 1;
+                }
+                matches!(self.peek_kind_at(offset), Some(TokenKind::Colon))
+            }
+            _ => false,
+        }
     }
 
     /// Caller must save/restore `pos`; this advances while scanning.

--- a/crates/harn-parser/src/parser/mod.rs
+++ b/crates/harn-parser/src/parser/mod.rs
@@ -162,6 +162,34 @@ pipeline test(task) {
     }
 
     #[test]
+    fn parses_struct_literal_syntax_without_prior_struct_decl() {
+        let source = r#"
+pipeline test(task) {
+  let point = Point { x: 3, y: 4 }
+}
+"#;
+
+        let program = parse_source(source).expect("should parse");
+        let pipeline = program
+            .iter()
+            .find(|node| matches!(node.node, Node::Pipeline { .. }))
+            .expect("pipeline node");
+        let body = match &pipeline.node {
+            Node::Pipeline { body, .. } => body,
+            _ => unreachable!(),
+        };
+        assert!(matches!(
+            &body[0].node,
+            Node::LetBinding { value, .. }
+                if matches!(
+                    value.node,
+                    Node::StructConstruct { ref struct_name, ref fields }
+                        if struct_name == "Point" && fields.len() == 2
+                )
+        ));
+    }
+
+    #[test]
     fn parses_exponentiation_as_right_associative() {
         let mut lexer = Lexer::new("a ** b ** c");
         let tokens = lexer.tokenize().expect("tokens");

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -109,7 +109,7 @@ impl TypeChecker {
                 type_ann,
                 value,
             } => {
-                self.check_binops(value, scope);
+                self.check_node(value, scope);
                 let inferred = self.infer_type(value, scope);
                 if let BindingPattern::Identifier(name) = pattern {
                     if let Some(expected) = type_ann {
@@ -164,7 +164,7 @@ impl TypeChecker {
                 type_ann,
                 value,
             } => {
-                self.check_binops(value, scope);
+                self.check_node(value, scope);
                 let inferred = self.infer_type(value, scope);
                 if let BindingPattern::Identifier(name) = pattern {
                     if let Some(expected) = type_ann {
@@ -1176,6 +1176,33 @@ impl TypeChecker {
                                 entry.value.span,
                             );
                         }
+                    }
+                } else {
+                    let suggestion = crate::diagnostic::find_closest_match(
+                        struct_name,
+                        scope.all_struct_names().iter().map(|name| name.as_str()),
+                        2,
+                    )
+                    .map(|candidate| candidate.to_string());
+                    let message = match &suggestion {
+                        Some(candidate) => format!(
+                            "unknown struct type `{struct_name}` — did you mean `{candidate}`?"
+                        ),
+                        None => format!("unknown struct type `{struct_name}`"),
+                    };
+                    match suggestion {
+                        Some(candidate) => self.error_at_with_help(
+                            message,
+                            span,
+                            format!("declare `struct {candidate} {{ ... }}` or fix the type name"),
+                        ),
+                        None => self.error_at_with_help(
+                            message,
+                            span,
+                            format!(
+                                "declare `struct {struct_name} {{ ... }}` before constructing it"
+                            ),
+                        ),
                     }
                 }
             }

--- a/crates/harn-parser/src/typechecker/scope.rs
+++ b/crates/harn-parser/src/typechecker/scope.rs
@@ -287,6 +287,16 @@ impl TypeScope {
         names
     }
 
+    /// Collect every struct name visible through this scope chain.
+    /// Used for typo suggestions on struct construction sites.
+    pub(super) fn all_struct_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.structs.keys().cloned().collect();
+        if let Some(parent) = &self.parent {
+            names.extend(parent.all_struct_names());
+        }
+        names
+    }
+
     pub(super) fn get_fn(&self, name: &str) -> Option<&FnSignature> {
         self.functions
             .get(name)

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -137,6 +137,48 @@ second: B
 }
 
 #[test]
+fn test_unknown_struct_literal_reports_error() {
+    let diagnostics = check_source(
+        r#"pipeline t(task) {
+  let p = Point {x: 3, y: 4}
+}"#,
+    );
+    let errors: Vec<_> = diagnostics
+        .into_iter()
+        .filter(|diag| diag.severity == DiagnosticSeverity::Error)
+        .collect();
+    assert_eq!(errors.len(), 1, "expected one error, got: {errors:?}");
+    assert_eq!(errors[0].message, "unknown struct type `Point`");
+}
+
+#[test]
+fn test_unknown_struct_literal_suggests_close_match() {
+    let diagnostics = check_source(
+        r#"pipeline t(task) {
+  struct Point {
+    x: int
+    y: int
+  }
+
+  let p = Piont {x: 3, y: 4}
+}"#,
+    );
+    let errors: Vec<_> = diagnostics
+        .into_iter()
+        .filter(|diag| diag.severity == DiagnosticSeverity::Error)
+        .collect();
+    assert_eq!(errors.len(), 1, "expected one error, got: {errors:?}");
+    assert_eq!(
+        errors[0].message,
+        "unknown struct type `Piont` — did you mean `Point`?"
+    );
+    assert_eq!(
+        errors[0].help.as_deref(),
+        Some("declare `struct Point { ... }` or fix the type name")
+    );
+}
+
+#[test]
 fn test_generic_enum_construct_instantiates_type_arguments() {
     let errs = errors(
         r#"pipeline t(task) {


### PR DESCRIPTION
## Summary
- parse `Identifier { field: ... }` struct literals even when the struct name has not been declared yet, while preserving existing block parsing behavior
- surface an explicit `unknown struct type` type-checker error with an optional typo suggestion for unresolved struct literals
- harden CLI parse-error reporting and add parser/type-checker/CLI regressions for the original `harn check` reproducer

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-370 cargo test -p harn-parser --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-370 cargo test -p harn-cli --test check_cli`
- reproduced `cargo run --quiet --bin harn -- check` on `let p = Point { x: 3, y: 4 }` and confirmed it now prints the diagnostic at `1:9`

Closes #370