### PR TITLE
[codex] Add harn-serve MCP adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ in Harn.
 
 ### Added
 
-<<<<<<< HEAD
 - **`project_fingerprint()` now returns a normalized repo profile for
   autonomous personas (#218).** The shallow detector now exposes stable
   primary tags for package manager, test runner, build tool, VCS, and CI
@@ -58,6 +57,13 @@ in Harn.
   matching workflow control methods so external callers can signal, query,
   update, pause, resume, and roll generations forward through the same durable
   runtime state.
+- **`harn serve mcp` workflow adapter for exported `pub fn` entrypoints
+  (#293).** The shared `harn-serve` core now ships its first transport
+  adapter: MCP. Any `.harn` module with exported `pub fn` entrypoints
+  can now be served directly as MCP tools with input/output schemas
+  derived from Harn types, cooperative cancellation, out-of-band
+  progress notifications, stdio + Streamable HTTP + legacy SSE
+  transports, and HTTP auth hooks for API-key / HMAC deployments.
 - **Git-backed package manager v0 (#345, #355).** Typed lockfile with
   content hashes, `harn add/install/update/remove/lock` commands, shared
   cache, ref resolution, frozen/refetch flows, and import resolution

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,7 @@ dependencies = [
  "harn-lint",
  "harn-modules",
  "harn-parser",
+ "harn-serve",
  "harn-vm",
  "hmac",
  "include_dir",
@@ -1263,7 +1264,9 @@ name = "harn-serve"
 version = "0.7.26"
 dependencies = [
  "async-trait",
+ "axum",
  "base64",
+ "futures",
  "harn-parser",
  "harn-vm",
  "hex",
@@ -1275,6 +1278,8 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -37,6 +37,7 @@ harn-vm = { path = "../harn-vm", version = "0.7", features = ["otel"] }
 harn-lint = { path = "../harn-lint", version = "0.7" }
 harn-modules = { path = "../harn-modules", version = "0.7" }
 harn-fmt = { path = "../harn-fmt", version = "0.7" }
+harn-serve = { path = "../harn-serve", version = "0.7" }
 async-trait = "0.1"
 axum = "0.8"
 axum-server = { version = "0.8", features = ["tls-rustls"] }

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -69,7 +69,7 @@ SCRIPTING
     Doctor(DoctorArgs),
     /// Register outbound connector resources with a provider.
     Connect(ConnectArgs),
-    /// Serve a .harn agent over HTTP using A2A.
+    /// Serve a Harn workflow over a transport adapter.
     Serve(ServeArgs),
     /// Start the ACP server on stdio.
     Acp(AcpArgs),
@@ -430,10 +430,60 @@ pub(crate) struct BenchArgs {
 
 #[derive(Debug, Args)]
 pub(crate) struct ServeArgs {
+    #[command(subcommand)]
+    pub command: ServeCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ServeCommand {
+    /// Serve a .harn agent over HTTP using A2A.
+    A2a(A2aServeArgs),
+    /// Serve exported `pub fn` entrypoints as MCP tools.
+    Mcp(ServeMcpArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct A2aServeArgs {
     /// Port to bind the A2A server to.
     #[arg(long, default_value_t = 8080)]
     pub port: u16,
     /// Path to the .harn file to serve.
+    pub file: String,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ServeMcpArgs {
+    /// Transport to expose for MCP clients.
+    #[arg(long, value_enum, default_value_t = McpServeTransport::Stdio)]
+    pub transport: McpServeTransport,
+    /// Socket address to bind when serving over HTTP.
+    #[arg(
+        long,
+        env = "HARN_SERVE_MCP_BIND",
+        default_value = "127.0.0.1:8765",
+        value_name = "ADDR"
+    )]
+    pub bind: SocketAddr,
+    /// Streamable HTTP endpoint path.
+    #[arg(long, default_value = "/mcp", value_name = "PATH")]
+    pub path: String,
+    /// Legacy SSE endpoint path for older MCP clients.
+    #[arg(long = "sse-path", default_value = "/sse", value_name = "PATH")]
+    pub sse_path: String,
+    /// Legacy SSE POST endpoint path for older MCP clients.
+    #[arg(
+        long = "messages-path",
+        default_value = "/messages",
+        value_name = "PATH"
+    )]
+    pub messages_path: String,
+    /// Static API keys accepted over HTTP via `Authorization: Bearer` or `X-API-Key`.
+    #[arg(long = "api-key", env = "HARN_SERVE_API_KEY", value_delimiter = ',')]
+    pub api_key: Vec<String>,
+    /// Shared secret for HMAC request signing on HTTP transports.
+    #[arg(long = "hmac-secret", env = "HARN_SERVE_HMAC_SECRET")]
+    pub hmac_secret: Option<String>,
+    /// Path to the `.harn` file whose exported `pub fn` entrypoints are served.
     pub file: String,
 }
 
@@ -1438,6 +1488,45 @@ mod tests {
         assert_eq!(serve.path, "/rpc");
         assert_eq!(serve.sse_path, "/events");
         assert_eq!(serve.messages_path, "/legacy/messages");
+    }
+
+    #[test]
+    fn test_parses_serve_mcp_flags() {
+        let cli = Cli::parse_from([
+            "harn",
+            "serve",
+            "mcp",
+            "--transport",
+            "http",
+            "--bind",
+            "127.0.0.1:9001",
+            "--path",
+            "/rpc",
+            "--sse-path",
+            "/events",
+            "--messages-path",
+            "/legacy/messages",
+            "--api-key",
+            "alpha,beta",
+            "--hmac-secret",
+            "shared",
+            "server.harn",
+        ]);
+
+        let Command::Serve(args) = cli.command.unwrap() else {
+            panic!("expected serve command");
+        };
+        let crate::cli::ServeCommand::Mcp(serve) = args.command else {
+            panic!("expected serve mcp");
+        };
+        assert_eq!(serve.transport, crate::cli::McpServeTransport::Http);
+        assert_eq!(serve.bind.to_string(), "127.0.0.1:9001");
+        assert_eq!(serve.path, "/rpc");
+        assert_eq!(serve.sse_path, "/events");
+        assert_eq!(serve.messages_path, "/legacy/messages");
+        assert_eq!(serve.api_key, vec!["alpha".to_string(), "beta".to_string()]);
+        assert_eq!(serve.hmac_secret.as_deref(), Some("shared"));
+        assert_eq!(serve.file, "server.harn");
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod playground;
 pub(crate) mod portal;
 pub(crate) mod repl;
 pub(crate) mod run;
+pub(crate) mod serve;
 pub(crate) mod skill;
 pub(crate) mod skills;
 pub(crate) mod test;

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -1159,6 +1159,7 @@ fn trigger_kind_name(kind: crate::package::TriggerKind) -> &'static str {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn graceful_shutdown(
     ctx: GracefulShutdownCtx<'_>,
     listener: ListenerRuntime,

--- a/crates/harn-cli/src/commands/serve.rs
+++ b/crates/harn-cli/src/commands/serve.rs
@@ -1,0 +1,54 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use harn_serve::{
+    ApiKeyAuthConfig, AuthMethodConfig, AuthPolicy, DispatchCore, DispatchCoreConfig,
+    HmacAuthConfig, McpHttpServeOptions, McpServer, McpServerConfig,
+};
+use time::Duration;
+
+use crate::cli::{McpServeTransport, ServeMcpArgs};
+
+pub(crate) async fn run_mcp_server(args: &ServeMcpArgs) -> Result<(), String> {
+    if args.transport == McpServeTransport::Stdio
+        && (!args.api_key.is_empty() || args.hmac_secret.is_some())
+    {
+        return Err("HTTP auth flags require `harn serve mcp --transport http`".to_string());
+    }
+
+    let mut config = DispatchCoreConfig::for_script(&args.file);
+    config.auth_policy = build_auth_policy(args);
+    let core = DispatchCore::new(config).map_err(|error| error.to_string())?;
+    let server = Arc::new(McpServer::new(McpServerConfig::new(core)));
+
+    match args.transport {
+        McpServeTransport::Stdio => server.run_stdio().await,
+        McpServeTransport::Http => {
+            server
+                .run_http(McpHttpServeOptions {
+                    bind: args.bind,
+                    path: args.path.clone(),
+                    sse_path: args.sse_path.clone(),
+                    messages_path: args.messages_path.clone(),
+                })
+                .await
+        }
+    }
+}
+
+fn build_auth_policy(args: &ServeMcpArgs) -> AuthPolicy {
+    let mut methods = Vec::new();
+    if !args.api_key.is_empty() {
+        methods.push(AuthMethodConfig::ApiKey(ApiKeyAuthConfig {
+            keys: args.api_key.iter().cloned().collect::<BTreeSet<_>>(),
+        }));
+    }
+    if let Some(secret) = args.hmac_secret.as_ref() {
+        methods.push(AuthMethodConfig::Hmac(HmacAuthConfig {
+            shared_secret: secret.clone(),
+            provider: "harn-serve".to_string(),
+            timestamp_window: Duration::seconds(300),
+        }));
+    }
+    AuthPolicy { methods }
+}

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -16,15 +16,15 @@ use std::sync::Arc;
 use std::{env, fs, process};
 
 use cli::{
-    Cli, Command, ConnectCommand, RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand,
-    SkillsCommand,
+    Cli, Command, ConnectCommand, RunsCommand, ServeCommand, SkillCommand, SkillKeyCommand,
+    SkillTrustCommand, SkillsCommand,
 };
 use harn_lexer::Lexer;
 use harn_parser::{DiagnosticSeverity, Parser, TypeChecker};
 
 #[tokio::main]
 async fn main() {
-    let raw_args: Vec<String> = env::args().collect();
+    let raw_args = normalize_serve_args(env::args().collect());
     if raw_args.len() == 2 && raw_args[1].ends_with(".harn") {
         commands::run::run_file(
             &raw_args[1],
@@ -362,7 +362,14 @@ async fn main() {
             commands::init::init_project(args.name.as_deref(), args.template)
         }
         Command::Doctor(args) => commands::doctor::run_doctor(!args.no_network).await,
-        Command::Serve(args) => a2a::run_a2a_server(&args.file, args.port).await,
+        Command::Serve(args) => match args.command {
+            ServeCommand::A2a(args) => a2a::run_a2a_server(&args.file, args.port).await,
+            ServeCommand::Mcp(args) => {
+                if let Err(error) = commands::serve::run_mcp_server(&args).await {
+                    command_error(&error);
+                }
+            }
+        },
         Command::Acp(args) => acp::run_acp_server(args.pipeline.as_deref()).await,
         Command::McpServe(args) => {
             commands::run::run_file_mcp_serve(&args.file, args.card.as_deref()).await
@@ -446,6 +453,19 @@ async fn main() {
             commands::dump_highlight_keywords::run(&args.output, args.check);
         }
     }
+}
+
+fn normalize_serve_args(mut raw_args: Vec<String>) -> Vec<String> {
+    if raw_args.len() > 2
+        && raw_args.get(1).is_some_and(|arg| arg == "serve")
+        && !matches!(
+            raw_args.get(2).map(String::as_str),
+            Some("a2a" | "mcp" | "-h" | "--help")
+        )
+    {
+        raw_args.insert(2, "a2a".to_string());
+    }
+    raw_args
 }
 
 fn print_version() {
@@ -1134,5 +1154,51 @@ fn connector_secret_namespace(base_dir: &Path) -> String {
                 .unwrap_or("workspace");
             format!("harn/{leaf}")
         }
+    }
+}
+
+#[cfg(test)]
+mod main_tests {
+    use super::normalize_serve_args;
+
+    #[test]
+    fn normalize_serve_args_inserts_a2a_for_legacy_shape() {
+        let args = normalize_serve_args(vec![
+            "harn".to_string(),
+            "serve".to_string(),
+            "--port".to_string(),
+            "3000".to_string(),
+            "agent.harn".to_string(),
+        ]);
+        assert_eq!(
+            args,
+            vec![
+                "harn".to_string(),
+                "serve".to_string(),
+                "a2a".to_string(),
+                "--port".to_string(),
+                "3000".to_string(),
+                "agent.harn".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn normalize_serve_args_preserves_explicit_subcommands() {
+        let args = normalize_serve_args(vec![
+            "harn".to_string(),
+            "serve".to_string(),
+            "mcp".to_string(),
+            "server.harn".to_string(),
+        ]);
+        assert_eq!(
+            args,
+            vec![
+                "harn".to_string(),
+                "serve".to_string(),
+                "mcp".to_string(),
+                "server.harn".to_string(),
+            ]
+        );
     }
 }

--- a/crates/harn-cli/tests/harn_serve_mcp_cli.rs
+++ b/crates/harn-cli/tests/harn_serve_mcp_cli.rs
@@ -1,0 +1,444 @@
+#![cfg(unix)]
+// These integration tests serialize process/port use with a synchronous guard.
+// Holding it across awaits is intentional so child-server lifetimes do not overlap.
+#![allow(clippy::await_holding_lock)]
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value as JsonValue};
+use tempfile::TempDir;
+
+static HARN_SERVE_MCP_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn lock_harn_serve_mcp_tests() -> MutexGuard<'static, ()> {
+    HARN_SERVE_MCP_TEST_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap()
+}
+
+fn write_fixture(temp: &TempDir) {
+    fs::write(
+        temp.path().join("server.harn"),
+        r#"
+pub fn greet(name: string, excited: bool = false) -> dict {
+  if excited {
+    return {message: "Hello, " + name + "!"}
+  }
+  return {message: "Hello, " + name}
+}
+
+pub fn fail(kind: string) -> string {
+  throw "boom:" + kind
+}
+
+pub fn spin(label: string) -> string {
+  while !is_cancelled() {}
+  return "cancelled:" + label
+}
+"#,
+    )
+    .unwrap();
+}
+
+fn spawn_stdout_reader(stdout: impl std::io::Read + Send + 'static) -> Receiver<JsonValue> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let line = line.unwrap();
+            if line.trim().is_empty() {
+                continue;
+            }
+            let value: JsonValue = serde_json::from_str(&line).unwrap();
+            let _ = tx.send(value);
+        }
+    });
+    rx
+}
+
+fn recv_until<F>(rx: &Receiver<JsonValue>, timeout: Duration, predicate: F) -> JsonValue
+where
+    F: Fn(&JsonValue) -> bool,
+{
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(message) if predicate(&message) => return message,
+            Ok(_) => continue,
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(error) => panic!("stdout reader disconnected: {error}"),
+        }
+    }
+    panic!("timed out waiting for matching JSON-RPC message");
+}
+
+fn wait_for_http_listener(child: &mut std::process::Child, rx: &Receiver<String>) -> String {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(line) if line.contains("MCP workflow server ready on ") => {
+                return line
+                    .split("MCP workflow server ready on ")
+                    .nth(1)
+                    .unwrap()
+                    .trim()
+                    .to_string();
+            }
+            Ok(_) => continue,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if let Some(status) = child.try_wait().unwrap() {
+                    panic!("HTTP MCP server exited early: {status}");
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("HTTP MCP stderr stream closed");
+            }
+        }
+    }
+    panic!("timed out waiting for HTTP listener");
+}
+
+fn parse_sse_messages(body: &str) -> Vec<JsonValue> {
+    body.lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect()
+}
+
+#[test]
+fn serve_mcp_stdio_lists_calls_and_cancels_exported_functions() {
+    let _guard = lock_harn_serve_mcp_tests();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .arg("serve")
+        .arg("mcp")
+        .arg("server.harn")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    let rx = spawn_stdout_reader(child.stdout.take().unwrap());
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "stdio-test", "version": "1.0.0" }
+            }
+        })
+    )
+    .unwrap();
+    let init = recv_until(&rx, Duration::from_secs(5), |message| message["id"] == 1);
+    assert_eq!(init["result"]["serverInfo"]["name"], "server");
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        })
+    )
+    .unwrap();
+    let tools = recv_until(&rx, Duration::from_secs(5), |message| message["id"] == 2);
+    let names = tools["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|tool| tool["name"].as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["fail", "greet", "spin"]);
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "greet",
+                "arguments": { "name": "alice", "excited": true }
+            }
+        })
+    )
+    .unwrap();
+    let greet = recv_until(&rx, Duration::from_secs(5), |message| message["id"] == 3);
+    assert_eq!(
+        greet["result"]["structuredContent"]["message"],
+        json!("Hello, alice!")
+    );
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "fail",
+                "arguments": { "kind": "stdio" }
+            }
+        })
+    )
+    .unwrap();
+    let fail = recv_until(&rx, Duration::from_secs(5), |message| message["id"] == 4);
+    assert_eq!(fail["result"]["isError"], json!(true));
+    assert!(fail.get("error").is_none());
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {
+                "name": "spin",
+                "arguments": { "label": "stdio" },
+                "_meta": { "progressToken": "spin-stdio" }
+            }
+        })
+    )
+    .unwrap();
+    let progress = recv_until(&rx, Duration::from_secs(5), |message| {
+        message["method"] == "notifications/progress"
+    });
+    assert_eq!(progress["params"]["progressToken"], json!("spin-stdio"));
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/cancelled",
+            "params": {
+                "requestId": 5,
+                "reason": "test cancel"
+            }
+        })
+    )
+    .unwrap();
+
+    writeln!(
+        stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "ping",
+            "params": {}
+        })
+    )
+    .unwrap();
+    let ping = recv_until(&rx, Duration::from_secs(5), |message| message["id"] == 6);
+    assert_eq!(ping["result"], json!({}));
+
+    drop(stdin);
+    let status = child.wait().unwrap();
+    assert!(status.success(), "status={status}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn serve_mcp_http_streams_progress_and_enforces_api_keys() {
+    let _guard = lock_harn_serve_mcp_tests();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .arg("serve")
+        .arg("mcp")
+        .arg("--transport")
+        .arg("http")
+        .arg("--bind")
+        .arg("127.0.0.1:0")
+        .arg("--api-key")
+        .arg("secret-token")
+        .arg("server.harn")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let stderr = child.stderr.take().unwrap();
+    let (tx, rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        for line in BufReader::new(stderr).lines() {
+            let line = line.unwrap();
+            let _ = tx.send(line);
+        }
+    });
+    let url = wait_for_http_listener(&mut child, &rx);
+    let client = reqwest::Client::new();
+
+    let init = client
+        .post(&url)
+        .header("Accept", "application/json, text/event-stream")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "http-test", "version": "1.0.0" }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(init.status().is_success());
+    let session_id = init
+        .headers()
+        .get("mcp-session-id")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let tools = client
+        .post(&url)
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }))
+        .send()
+        .await
+        .unwrap();
+    let tools_json: JsonValue = tools.json().await.unwrap();
+    assert_eq!(tools_json["result"]["tools"][1]["name"], "greet");
+
+    let unauthorized = client
+        .post(&url)
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "greet",
+                "arguments": { "name": "no-auth" }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    let unauthorized_body = unauthorized.text().await.unwrap();
+    let unauthorized_messages = parse_sse_messages(&unauthorized_body);
+    assert_eq!(unauthorized_messages[0]["error"]["code"], json!(-32001));
+
+    let call_task = tokio::spawn({
+        let client = client.clone();
+        let url = url.clone();
+        let session_id = session_id.clone();
+        async move {
+            client
+                .post(&url)
+                .header("Accept", "application/json, text/event-stream")
+                .header("mcp-session-id", &session_id)
+                .header("authorization", "Bearer secret-token")
+                .json(&json!({
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "spin",
+                        "arguments": { "label": "http" },
+                        "_meta": { "progressToken": "spin-http" }
+                    }
+                }))
+                .send()
+                .await
+                .unwrap()
+                .text()
+                .await
+                .unwrap()
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    let cancel = client
+        .post(&url)
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/cancelled",
+            "params": {
+                "requestId": 4,
+                "reason": "stop"
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(cancel.status(), reqwest::StatusCode::ACCEPTED);
+
+    let body = call_task.await.unwrap();
+    let messages = parse_sse_messages(&body);
+    assert!(messages
+        .iter()
+        .any(|message| message["method"] == "notifications/progress"));
+    assert!(!messages.iter().any(|message| message["id"] == 4));
+
+    let greet = client
+        .post(&url)
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .header("authorization", "Bearer secret-token")
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {
+                "name": "greet",
+                "arguments": { "name": "http", "excited": true }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    let greet_body = greet.text().await.unwrap();
+    let greet_messages = parse_sse_messages(&greet_body);
+    let final_response = greet_messages
+        .iter()
+        .find(|message| message["id"] == 5)
+        .unwrap();
+    assert_eq!(
+        final_response["result"]["structuredContent"]["message"],
+        json!("Hello, http!")
+    );
+
+    child.kill().unwrap();
+    child.wait().unwrap();
+    handle.join().unwrap();
+}

--- a/crates/harn-ir/src/lib.rs
+++ b/crates/harn-ir/src/lib.rs
@@ -327,22 +327,22 @@ impl Invariant for ApprovalReachability {
                     CallClassification::ApprovalGate => {
                         next_state.explicit_approval = true;
                     }
-                    CallClassification::FsWrite { .. } | CallClassification::SideEffect => {
-                        if !state.is_approved() && reported.insert(node_id) {
-                            diagnostics.push(InvariantDiagnostic {
-                                invariant: self.name().to_string(),
-                                handler: ir.name.clone(),
-                                message: format!(
-                                    "side-effecting call `{}` is reachable before any approval gate",
-                                    call.display_name
-                                ),
-                                span: node.span,
-                                help: Some(
-                                    "call `request_approval(...)` earlier on every path, or move the side effect into a `dual_control(...)` closure".to_string(),
-                                ),
-                                path: path.clone(),
-                            });
-                        }
+                    CallClassification::FsWrite { .. } | CallClassification::SideEffect
+                        if !state.is_approved() && reported.insert(node_id) =>
+                    {
+                        diagnostics.push(InvariantDiagnostic {
+                            invariant: self.name().to_string(),
+                            handler: ir.name.clone(),
+                            message: format!(
+                                "side-effecting call `{}` is reachable before any approval gate",
+                                call.display_name
+                            ),
+                            span: node.span,
+                            help: Some(
+                                "call `request_approval(...)` earlier on every path, or move the side effect into a `dual_control(...)` closure".to_string(),
+                            ),
+                            path: path.clone(),
+                        });
                     }
                     _ => {}
                 },
@@ -492,7 +492,7 @@ fn parse_invariant_specs(
             Ok(spec) => specs.push(spec),
             Err(mut diag) => {
                 diag.handler = handler_name.to_string();
-                diagnostics.push(diag);
+                diagnostics.push(*diag);
             }
         }
     }
@@ -500,20 +500,20 @@ fn parse_invariant_specs(
     (specs, diagnostics)
 }
 
-fn parse_invariant_spec(attribute: &Attribute) -> Result<InvariantSpec, InvariantDiagnostic> {
+fn parse_invariant_spec(attribute: &Attribute) -> Result<InvariantSpec, Box<InvariantDiagnostic>> {
     let mut named = BTreeMap::new();
     let mut positionals = Vec::new();
 
     for arg in &attribute.args {
         let Some(value) = attribute_arg_string(arg) else {
-            return Err(InvariantDiagnostic {
+            return Err(Box::new(InvariantDiagnostic {
                 invariant: "invariant".to_string(),
                 handler: String::new(),
                 message: "`@invariant(...)` arguments must be strings, identifiers, numbers, bools, or nil".to_string(),
                 span: arg.span,
                 help: Some("use strings for invariant names and configuration values".to_string()),
                 path: Vec::new(),
-            });
+            }));
         };
         if let Some(name) = &arg.name {
             named.insert(name.clone(), value);
@@ -525,7 +525,7 @@ fn parse_invariant_spec(attribute: &Attribute) -> Result<InvariantSpec, Invarian
     let raw_name = named
         .remove("name")
         .or_else(|| positionals.first().cloned())
-        .ok_or_else(|| InvariantDiagnostic {
+        .ok_or_else(|| Box::new(InvariantDiagnostic {
             invariant: "invariant".to_string(),
             handler: String::new(),
             message: "`@invariant(...)` requires an invariant name as the first positional argument or `name:`".to_string(),
@@ -534,17 +534,19 @@ fn parse_invariant_spec(attribute: &Attribute) -> Result<InvariantSpec, Invarian
                 "for example: `@invariant(\"fs.writes\", \"src/**\")`".to_string(),
             ),
             path: Vec::new(),
-        })?;
-    let name = normalize_invariant_name(&raw_name).ok_or_else(|| InvariantDiagnostic {
-        invariant: raw_name.clone(),
-        handler: String::new(),
-        message: format!("unknown invariant `{raw_name}`"),
-        span: attribute.span,
-        help: Some(
-            "known invariants are `fs.writes`, `budget.remaining`, and `approval.reachability`"
-                .to_string(),
-        ),
-        path: Vec::new(),
+        }))?;
+    let name = normalize_invariant_name(&raw_name).ok_or_else(|| {
+        Box::new(InvariantDiagnostic {
+            invariant: raw_name.clone(),
+            handler: String::new(),
+            message: format!("unknown invariant `{raw_name}`"),
+            span: attribute.span,
+            help: Some(
+                "known invariants are `fs.writes`, `budget.remaining`, and `approval.reachability`"
+                    .to_string(),
+            ),
+            path: Vec::new(),
+        })
     })?;
 
     let remaining_positionals = if named.contains_key("name") {

--- a/crates/harn-serve/Cargo.toml
+++ b/crates/harn-serve/Cargo.toml
@@ -8,13 +8,17 @@ description = "Shared outbound workflow server core for Harn adapters"
 
 [dependencies]
 async-trait = "0.1"
+axum = "0.8"
+futures = "0.3"
 harn-parser = { path = "../harn-parser", version = "0.7" }
 harn-vm = { path = "../harn-vm", version = "0.7" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["rt", "sync", "time"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "sync", "time"] }
 time = "0.3"
 tracing = "0.1"
+url = "2"
+uuid = { version = "1", features = ["v7"] }
 
 [dev-dependencies]
 base64 = "0.22"

--- a/crates/harn-serve/src/adapters/mcp.rs
+++ b/crates/harn-serve/src/adapters/mcp.rs
@@ -1,0 +1,1139 @@
+use std::collections::{BTreeMap, HashMap};
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::body::Bytes;
+use axum::extract::{Query, State};
+use axum::http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
+use futures::{stream, StreamExt};
+use serde_json::{json, Value as JsonValue};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::LocalSet;
+use uuid::Uuid;
+
+use crate::{
+    AdapterDescriptor, AuthRequest, CallArguments, CallRequest, CallResponse, DispatchCore,
+    DispatchError, ExportCatalog, TransportAdapter,
+};
+
+pub const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+
+const MCP_PROTOCOL_HEADER: &str = "mcp-protocol-version";
+const MCP_SESSION_HEADER: &str = "mcp-session-id";
+
+#[derive(Clone, Debug)]
+pub struct McpHttpServeOptions {
+    pub bind: SocketAddr,
+    pub path: String,
+    pub sse_path: String,
+    pub messages_path: String,
+}
+
+impl Default for McpHttpServeOptions {
+    fn default() -> Self {
+        Self {
+            bind: "127.0.0.1:8765".parse().expect("valid bind addr"),
+            path: "/mcp".to_string(),
+            sse_path: "/sse".to_string(),
+            messages_path: "/messages".to_string(),
+        }
+    }
+}
+
+pub struct McpServerConfig {
+    pub core: DispatchCore,
+    pub server_name: Option<String>,
+}
+
+impl McpServerConfig {
+    pub fn new(core: DispatchCore) -> Self {
+        Self {
+            server_name: Some(derived_server_name(core.catalog())),
+            core,
+        }
+    }
+}
+
+pub type McpStdioServer = McpServer;
+
+pub struct McpServer {
+    descriptor: AdapterDescriptor,
+    server_name: String,
+    catalog: ExportCatalog,
+    executor: ExecutionRuntime,
+}
+
+#[derive(Clone, Debug)]
+struct ConnectionState {
+    initialized: bool,
+    client_identity: String,
+}
+
+impl Default for ConnectionState {
+    fn default() -> Self {
+        Self {
+            initialized: false,
+            client_identity: "unknown".to_string(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ActiveCall {
+    cancel_token: Arc<AtomicBool>,
+    cancelled: Arc<AtomicBool>,
+}
+
+#[derive(Default)]
+struct SessionState {
+    connection: ConnectionState,
+    active_calls: HashMap<String, ActiveCall>,
+    stream_tx: Option<UnboundedSender<JsonValue>>,
+}
+
+#[derive(Clone)]
+struct SharedSession {
+    inner: Arc<Mutex<SessionState>>,
+}
+
+impl SharedSession {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(SessionState::default())),
+        }
+    }
+
+    fn connection(&self) -> ConnectionState {
+        self.inner
+            .lock()
+            .expect("session poisoned")
+            .connection
+            .clone()
+    }
+
+    fn update_connection(&self, connection: ConnectionState) {
+        self.inner.lock().expect("session poisoned").connection = connection;
+    }
+
+    fn insert_call(&self, request_id: String, active: ActiveCall) {
+        self.inner
+            .lock()
+            .expect("session poisoned")
+            .active_calls
+            .insert(request_id, active);
+    }
+
+    fn remove_call(&self, request_id: &str) -> Option<ActiveCall> {
+        self.inner
+            .lock()
+            .expect("session poisoned")
+            .active_calls
+            .remove(request_id)
+    }
+
+    fn cancel_call(&self, request_id: &str) -> bool {
+        let mut guard = self.inner.lock().expect("session poisoned");
+        let Some(active) = guard.active_calls.remove(request_id) else {
+            return false;
+        };
+        active.cancelled.store(true, Ordering::SeqCst);
+        active.cancel_token.store(true, Ordering::SeqCst);
+        true
+    }
+
+    fn set_stream_tx(&self, tx: Option<UnboundedSender<JsonValue>>) {
+        self.inner.lock().expect("session poisoned").stream_tx = tx;
+    }
+
+    fn stream_tx(&self) -> Option<UnboundedSender<JsonValue>> {
+        self.inner
+            .lock()
+            .expect("session poisoned")
+            .stream_tx
+            .as_ref()
+            .cloned()
+    }
+}
+
+struct ExecutionRuntime {
+    tx: mpsc::UnboundedSender<ExecutionJob>,
+}
+
+struct ExecutionJob {
+    request: CallRequest,
+    response_tx: oneshot::Sender<Result<CallResponse, DispatchError>>,
+}
+
+#[derive(Clone)]
+struct HttpState {
+    server: Arc<McpServer>,
+    options: McpHttpServeOptions,
+    sessions: Arc<Mutex<HashMap<String, SharedSession>>>,
+}
+
+#[derive(Clone)]
+struct RequestContext {
+    session: SharedSession,
+    connection: ConnectionState,
+    auth: AuthRequest,
+}
+
+enum ImmediateResult {
+    Response(JsonValue),
+    Accepted,
+    Stream(Box<StreamJob>),
+}
+
+struct StreamJob {
+    request_id: JsonValue,
+    request_key: String,
+    tool_name: String,
+    arguments: JsonValue,
+    progress_token: Option<JsonValue>,
+    context: RequestContext,
+}
+
+impl McpServer {
+    pub fn new(config: McpServerConfig) -> Self {
+        let server_name = config
+            .server_name
+            .unwrap_or_else(|| derived_server_name(config.core.catalog()));
+        let core = Arc::new(config.core);
+        let catalog = core.catalog().clone();
+        Self {
+            descriptor: AdapterDescriptor {
+                id: "mcp".to_string(),
+                caller_shape: "tool".to_string(),
+                supports_streaming: true,
+                supports_cancel: true,
+            },
+            server_name,
+            catalog,
+            executor: ExecutionRuntime::start(core.clone()),
+        }
+    }
+
+    pub async fn run_stdio(self: Arc<Self>) -> Result<(), String> {
+        let session = SharedSession::new();
+        let stdin = BufReader::new(tokio::io::stdin());
+        let mut lines = stdin.lines();
+        let mut stdout = tokio::io::stdout();
+        let (tx, mut rx) = mpsc::unbounded_channel::<JsonValue>();
+
+        let writer = tokio::spawn(async move {
+            while let Some(message) = rx.recv().await {
+                let mut encoded =
+                    serde_json::to_string(&message).map_err(|error| error.to_string())?;
+                encoded.push('\n');
+                stdout
+                    .write_all(encoded.as_bytes())
+                    .await
+                    .map_err(|error| error.to_string())?;
+                stdout.flush().await.map_err(|error| error.to_string())?;
+            }
+            Ok::<(), String>(())
+        });
+
+        eprintln!("[harn] MCP workflow server ready on stdio");
+
+        while let Ok(Some(line)) = lines.next_line().await {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let request = match serde_json::from_str::<JsonValue>(trimmed) {
+                Ok(value) => value,
+                Err(error) => {
+                    let _ = tx.send(parse_error_response(&error.to_string()));
+                    continue;
+                }
+            };
+            let auth = AuthRequest {
+                method: "STDIO".to_string(),
+                path: String::new(),
+                body: line.into_bytes(),
+                headers: BTreeMap::new(),
+                validated_oauth: None,
+            };
+            self.clone()
+                .handle_stdio_message(request, session.clone(), auth, tx.clone())
+                .await;
+        }
+
+        drop(tx);
+        writer
+            .await
+            .map_err(|error| format!("stdio writer task failed: {error}"))?
+    }
+
+    pub async fn run_http(self: Arc<Self>, options: McpHttpServeOptions) -> Result<(), String> {
+        let state = HttpState {
+            server: self,
+            options: options.clone(),
+            sessions: Arc::new(Mutex::new(HashMap::new())),
+        };
+        let router = Router::new()
+            .route(
+                &options.path,
+                post(http_post_request)
+                    .get(http_get_stream)
+                    .delete(http_delete_session),
+            )
+            .route(
+                &options.sse_path,
+                get(legacy_sse_stream).post(legacy_sse_message),
+            )
+            .route(&options.messages_path, post(legacy_sse_message))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind(options.bind)
+            .await
+            .map_err(|error| format!("failed to bind {}: {error}", options.bind))?;
+        let local_addr = listener
+            .local_addr()
+            .map_err(|error| format!("failed to read local addr: {error}"))?;
+        eprintln!(
+            "[harn] MCP workflow server ready on http://{local_addr}{}",
+            options.path
+        );
+        axum::serve(listener, router)
+            .await
+            .map_err(|error| format!("MCP HTTP server failed: {error}"))
+    }
+
+    async fn handle_stdio_message(
+        self: Arc<Self>,
+        request: JsonValue,
+        session: SharedSession,
+        auth: AuthRequest,
+        tx: mpsc::UnboundedSender<JsonValue>,
+    ) {
+        match self.process_message(request, session.clone(), auth).await {
+            ImmediateResult::Response(response) => {
+                let _ = tx.send(response);
+            }
+            ImmediateResult::Accepted => {}
+            ImmediateResult::Stream(job) => {
+                tokio::spawn(async move {
+                    let notifier = notify_channel(move |message| {
+                        let _ = tx.send(message);
+                    });
+                    self.execute_streaming_job(*job, notifier).await;
+                });
+            }
+        }
+    }
+
+    async fn process_message(
+        &self,
+        request: JsonValue,
+        session: SharedSession,
+        auth: AuthRequest,
+    ) -> ImmediateResult {
+        let id = request.get("id").cloned().unwrap_or(JsonValue::Null);
+        let method = request
+            .get("method")
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default();
+        let params = request.get("params").cloned().unwrap_or_else(|| json!({}));
+
+        if request.get("id").is_none() {
+            if method == "notifications/cancelled" {
+                self.handle_cancel_notification(&session, &params);
+            }
+            return ImmediateResult::Accepted;
+        }
+
+        if method == "initialize" {
+            return ImmediateResult::Response(self.handle_initialize(id, &session, &params));
+        }
+
+        let connection = session.connection();
+        if !connection.initialized && method != "ping" {
+            return ImmediateResult::Response(harn_vm::jsonrpc::error_response(
+                id,
+                -32002,
+                "server not initialized",
+            ));
+        }
+
+        match method {
+            "notifications/initialized" | "initialized" => ImmediateResult::Accepted,
+            "ping" => ImmediateResult::Response(harn_vm::jsonrpc::response(id, json!({}))),
+            "logging/setLevel" => {
+                ImmediateResult::Response(harn_vm::jsonrpc::response(id, json!({})))
+            }
+            "tools/list" => {
+                ImmediateResult::Response(harn_vm::jsonrpc::response(id, self.tools_list_result()))
+            }
+            "tools/call" => match self.prepare_stream_job(id, params, session, connection, auth) {
+                Ok(job) => ImmediateResult::Stream(Box::new(job)),
+                Err(response) => ImmediateResult::Response(response),
+            },
+            _ => ImmediateResult::Response(harn_vm::jsonrpc::error_response(
+                id,
+                -32601,
+                &format!("Method not found: {method}"),
+            )),
+        }
+    }
+
+    fn handle_initialize(
+        &self,
+        id: JsonValue,
+        session: &SharedSession,
+        params: &JsonValue,
+    ) -> JsonValue {
+        let requested = params
+            .get("protocolVersion")
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default();
+        if !requested.is_empty() && requested != MCP_PROTOCOL_VERSION {
+            return harn_vm::jsonrpc::error_response_with_data(
+                id,
+                -32602,
+                "Unsupported protocol version",
+                json!({
+                    "supported": [MCP_PROTOCOL_VERSION],
+                    "requested": requested,
+                }),
+            );
+        }
+
+        let client_name = params
+            .pointer("/clientInfo/name")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("unknown");
+        let client_version = params
+            .pointer("/clientInfo/version")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("unknown");
+        session.update_connection(ConnectionState {
+            initialized: true,
+            client_identity: format!("{client_name}/{client_version}"),
+        });
+
+        harn_vm::jsonrpc::response(
+            id,
+            json!({
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {
+                    "tools": {},
+                    "logging": {},
+                },
+                "serverInfo": {
+                    "name": self.server_name,
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            }),
+        )
+    }
+
+    fn handle_cancel_notification(&self, session: &SharedSession, params: &JsonValue) {
+        let Some(request_id) = params.get("requestId") else {
+            return;
+        };
+        let request_key = request_key(request_id);
+        let _ = session.cancel_call(&request_key);
+    }
+
+    fn prepare_stream_job(
+        &self,
+        request_id: JsonValue,
+        params: JsonValue,
+        session: SharedSession,
+        connection: ConnectionState,
+        auth: AuthRequest,
+    ) -> Result<StreamJob, JsonValue> {
+        let tool_name = params
+            .get("name")
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default()
+            .to_string();
+        if self.catalog.function(&tool_name).is_none() {
+            return Err(harn_vm::jsonrpc::error_response(
+                request_id,
+                -32602,
+                &format!("Unknown tool: {tool_name}"),
+            ));
+        }
+        let arguments = params
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        let progress_token = params
+            .pointer("/_meta/progressToken")
+            .cloned()
+            .filter(is_valid_progress_token);
+        let request_key = request_key(&request_id);
+        Ok(StreamJob {
+            request_id: request_id.clone(),
+            request_key,
+            tool_name,
+            arguments,
+            progress_token,
+            context: RequestContext {
+                session,
+                connection,
+                auth,
+            },
+        })
+    }
+
+    async fn execute_streaming_job(
+        &self,
+        job: StreamJob,
+        notify: Arc<dyn Fn(JsonValue) + Send + Sync>,
+    ) {
+        let cancel_token = Arc::new(AtomicBool::new(false));
+        let cancelled = Arc::new(AtomicBool::new(false));
+        job.context.session.insert_call(
+            job.request_key.clone(),
+            ActiveCall {
+                cancel_token: cancel_token.clone(),
+                cancelled: cancelled.clone(),
+            },
+        );
+
+        let progress_stop = if let Some(progress_token) = job.progress_token.clone() {
+            notify(progress_notification(
+                progress_token.clone(),
+                0.0,
+                format!("Starting {}", job.tool_name),
+            ));
+            Some(spawn_progress_notifier(
+                progress_token,
+                job.tool_name.clone(),
+                notify.clone(),
+            ))
+        } else {
+            None
+        };
+
+        let request = match build_call_request(
+            &self.descriptor.id,
+            &job.context.connection.client_identity,
+            &job.tool_name,
+            job.arguments,
+            job.context.auth,
+            cancel_token,
+        ) {
+            Ok(request) => request,
+            Err(error) => {
+                job.context.session.remove_call(&job.request_key);
+                if let Some(stop) = progress_stop {
+                    let _ = stop.send(());
+                }
+                notify(harn_vm::jsonrpc::error_response(
+                    job.request_id,
+                    -32602,
+                    &error,
+                ));
+                return;
+            }
+        };
+
+        let result = self.executor.call(request).await;
+        job.context.session.remove_call(&job.request_key);
+        if let Some(stop) = progress_stop {
+            let _ = stop.send(());
+        }
+        if cancelled.load(Ordering::SeqCst) {
+            return;
+        }
+
+        match result {
+            Ok(response) => notify(harn_vm::jsonrpc::response(
+                job.request_id,
+                tool_call_success(response),
+            )),
+            Err(DispatchError::Validation(message)) => notify(harn_vm::jsonrpc::error_response(
+                job.request_id,
+                -32602,
+                &message,
+            )),
+            Err(DispatchError::Unauthorized(message)) => notify(harn_vm::jsonrpc::error_response(
+                job.request_id,
+                -32001,
+                &message,
+            )),
+            Err(DispatchError::MissingExport(message)) => notify(harn_vm::jsonrpc::error_response(
+                job.request_id,
+                -32602,
+                &message,
+            )),
+            Err(DispatchError::Execution(message))
+            | Err(DispatchError::Cancelled(message))
+            | Err(DispatchError::Io(message))
+            | Err(DispatchError::Cache(message)) => notify(harn_vm::jsonrpc::response(
+                job.request_id,
+                tool_call_error(message),
+            )),
+        }
+    }
+
+    fn tools_list_result(&self) -> JsonValue {
+        let tools = self
+            .catalog
+            .functions
+            .values()
+            .map(tool_entry)
+            .collect::<Vec<_>>();
+        json!({ "tools": tools })
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl TransportAdapter for McpServer {
+    fn descriptor(&self) -> AdapterDescriptor {
+        self.descriptor.clone()
+    }
+}
+
+impl ExecutionRuntime {
+    fn start(core: Arc<DispatchCore>) -> Self {
+        let (tx, mut rx) = mpsc::unbounded_channel::<ExecutionJob>();
+        std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build MCP runtime");
+            let local = LocalSet::new();
+            local.block_on(&runtime, async move {
+                while let Some(job) = rx.recv().await {
+                    let core = core.clone();
+                    tokio::task::spawn_local(async move {
+                        let result = core.dispatch(job.request).await;
+                        let _ = job.response_tx.send(result);
+                    });
+                }
+            });
+        });
+        Self { tx }
+    }
+
+    async fn call(&self, request: CallRequest) -> Result<CallResponse, DispatchError> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.tx
+            .send(ExecutionJob {
+                request,
+                response_tx,
+            })
+            .map_err(|_| DispatchError::Execution("MCP executor is not running".to_string()))?;
+        response_rx
+            .await
+            .map_err(|_| DispatchError::Execution("MCP executor dropped response".to_string()))?
+    }
+}
+
+async fn http_post_request(
+    State(state): State<HttpState>,
+    method: Method,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if let Err(response) = validate_origin(&headers) {
+        return *response;
+    }
+    if let Err(response) = validate_protocol_header(&headers) {
+        return *response;
+    }
+
+    let request = match serde_json::from_slice::<JsonValue>(body.as_ref()) {
+        Ok(value) => value,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(parse_error_response(&error.to_string())),
+            )
+                .into_response()
+        }
+    };
+    let header_session = headers
+        .get(MCP_SESSION_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let (session_id, session, created) =
+        match lookup_or_create_session(&state, &request, header_session) {
+            Ok(value) => value,
+            Err(response) => return *response,
+        };
+    let auth = http_auth_request(method, &state.options.path, body.to_vec(), &headers);
+
+    match state.server.process_message(request, session, auth).await {
+        ImmediateResult::Accepted => StatusCode::ACCEPTED.into_response(),
+        ImmediateResult::Response(response) => {
+            let mut http = Json(response).into_response();
+            attach_http_headers(
+                &mut http,
+                created.then_some(session_id.as_str()),
+                MCP_PROTOCOL_VERSION,
+            );
+            http
+        }
+        ImmediateResult::Stream(job) => {
+            let stream = spawn_http_stream(state.server.clone(), *job);
+            let mut http = stream.into_response();
+            attach_http_headers(
+                &mut http,
+                created.then_some(session_id.as_str()),
+                MCP_PROTOCOL_VERSION,
+            );
+            http
+        }
+    }
+}
+
+async fn http_get_stream(State(state): State<HttpState>, headers: HeaderMap) -> Response {
+    if let Err(response) = validate_origin(&headers) {
+        return *response;
+    }
+    let Some(session_id) = headers
+        .get(MCP_SESSION_HEADER)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+    let Some(session) = state
+        .sessions
+        .lock()
+        .expect("sessions poisoned")
+        .get(session_id)
+        .cloned()
+    else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let (tx, rx) = unbounded::<JsonValue>();
+    session.set_stream_tx(Some(tx));
+    sse_response(rx).into_response()
+}
+
+async fn http_delete_session(State(state): State<HttpState>, headers: HeaderMap) -> Response {
+    let Some(session_id) = headers
+        .get(MCP_SESSION_HEADER)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+    let removed = state
+        .sessions
+        .lock()
+        .expect("sessions poisoned")
+        .remove(session_id);
+    if removed.is_some() {
+        StatusCode::NO_CONTENT.into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
+}
+
+async fn legacy_sse_stream(State(state): State<HttpState>, headers: HeaderMap) -> Response {
+    if let Err(response) = validate_origin(&headers) {
+        return *response;
+    }
+    let session_id = Uuid::now_v7().to_string();
+    let session = SharedSession::new();
+    let (tx, rx) = unbounded::<JsonValue>();
+    session.set_stream_tx(Some(tx));
+    state
+        .sessions
+        .lock()
+        .expect("sessions poisoned")
+        .insert(session_id.clone(), session);
+    let endpoint_event = Event::default().event("endpoint").data(format!(
+        "{}?session_id={session_id}",
+        state.options.messages_path
+    ));
+    let stream =
+        stream::once(async move { Ok::<Event, Infallible>(endpoint_event) }).chain(sse_events(rx));
+    Sse::new(stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
+async fn legacy_sse_message(
+    State(state): State<HttpState>,
+    Query(query): Query<BTreeMap<String, String>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if let Err(response) = validate_origin(&headers) {
+        return *response;
+    }
+    let Some(session_id) = query.get("session_id") else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+    let Some(session) = state
+        .sessions
+        .lock()
+        .expect("sessions poisoned")
+        .get(session_id)
+        .cloned()
+    else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let request = match serde_json::from_slice::<JsonValue>(body.as_ref()) {
+        Ok(value) => value,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(parse_error_response(&error.to_string())),
+            )
+                .into_response()
+        }
+    };
+    let auth = http_auth_request(
+        Method::POST,
+        &state.options.messages_path,
+        body.to_vec(),
+        &headers,
+    );
+    match state
+        .server
+        .process_message(request, session.clone(), auth)
+        .await
+    {
+        ImmediateResult::Accepted => StatusCode::ACCEPTED.into_response(),
+        ImmediateResult::Response(response) => {
+            if let Some(tx) = session.stream_tx() {
+                let _ = tx.unbounded_send(response);
+                StatusCode::ACCEPTED.into_response()
+            } else {
+                StatusCode::GONE.into_response()
+            }
+        }
+        ImmediateResult::Stream(job) => {
+            let Some(tx) = session.stream_tx() else {
+                return StatusCode::GONE.into_response();
+            };
+            tokio::spawn(async move {
+                let notifier = notify_channel(move |message| {
+                    let _ = tx.unbounded_send(message);
+                });
+                state.server.execute_streaming_job(*job, notifier).await;
+            });
+            StatusCode::ACCEPTED.into_response()
+        }
+    }
+}
+
+fn spawn_http_stream(
+    server: Arc<McpServer>,
+    job: StreamJob,
+) -> Sse<impl futures::Stream<Item = Result<Event, Infallible>>> {
+    let (tx, rx) = unbounded::<JsonValue>();
+    tokio::spawn(async move {
+        let notifier = notify_channel(move |message| {
+            let _ = tx.unbounded_send(message);
+        });
+        server.execute_streaming_job(job, notifier).await;
+    });
+    sse_response(rx)
+}
+
+fn sse_response(
+    rx: UnboundedReceiver<JsonValue>,
+) -> Sse<impl futures::Stream<Item = Result<Event, Infallible>>> {
+    let prime = Event::default().id(Uuid::now_v7().to_string()).data("");
+    let stream = stream::once(async move { Ok::<Event, Infallible>(prime) }).chain(sse_events(rx));
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+fn sse_events(
+    rx: UnboundedReceiver<JsonValue>,
+) -> impl futures::Stream<Item = Result<Event, Infallible>> {
+    rx.map(|message| {
+        Ok(Event::default()
+            .id(Uuid::now_v7().to_string())
+            .event("message")
+            .data(serde_json::to_string(&message).unwrap_or_else(|_| "{}".to_string())))
+    })
+}
+
+fn spawn_progress_notifier(
+    progress_token: JsonValue,
+    tool_name: String,
+    notify: Arc<dyn Fn(JsonValue) + Send + Sync>,
+) -> oneshot::Sender<()> {
+    let (stop_tx, mut stop_rx) = oneshot::channel();
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(Duration::from_secs(1));
+        let mut progress = 0.0;
+        loop {
+            tokio::select! {
+                _ = &mut stop_rx => break,
+                _ = ticker.tick() => {
+                    progress += 1.0;
+                    notify(progress_notification(
+                        progress_token.clone(),
+                        progress,
+                        format!("Running {tool_name}"),
+                    ));
+                }
+            }
+        }
+    });
+    stop_tx
+}
+
+fn notify_channel<F>(notify: F) -> Arc<dyn Fn(JsonValue) + Send + Sync>
+where
+    F: Fn(JsonValue) + Send + Sync + 'static,
+{
+    Arc::new(notify)
+}
+
+fn build_call_request(
+    adapter: &str,
+    caller: &str,
+    tool_name: &str,
+    arguments: JsonValue,
+    auth: AuthRequest,
+    cancel_token: Arc<AtomicBool>,
+) -> Result<CallRequest, String> {
+    let arguments = match arguments {
+        JsonValue::Null => CallArguments::Named(BTreeMap::new()),
+        JsonValue::Object(values) => CallArguments::Named(
+            values
+                .into_iter()
+                .collect::<BTreeMap<String, serde_json::Value>>(),
+        ),
+        JsonValue::Array(values) => CallArguments::Positional(values),
+        _ => {
+            return Err("tool arguments must be an object, array, or null".to_string());
+        }
+    };
+    Ok(CallRequest {
+        adapter: adapter.to_string(),
+        function: tool_name.to_string(),
+        arguments,
+        auth,
+        caller: caller.to_string(),
+        replay_key: None,
+        trace_id: None,
+        parent_span_id: None,
+        metadata: BTreeMap::new(),
+        cancel_token: Some(cancel_token),
+    })
+}
+
+fn tool_entry(function: &crate::ExportedFunction) -> JsonValue {
+    let mut entry = json!({
+        "name": function.name,
+        "description": format!("Invoke exported Harn function '{}'.", function.name),
+        "inputSchema": function.input_schema,
+    });
+    if let Some(output_schema) = function.output_schema.clone() {
+        entry["outputSchema"] = output_schema;
+    }
+    entry
+}
+
+fn tool_call_success(response: CallResponse) -> JsonValue {
+    let mut result = json!({
+        "content": content_blocks(&response.value),
+        "isError": false,
+    });
+    if let JsonValue::Object(map) = response.value {
+        result["structuredContent"] = JsonValue::Object(map);
+    }
+    result
+}
+
+fn tool_call_error(message: String) -> JsonValue {
+    json!({
+        "content": [{
+            "type": "text",
+            "text": message,
+        }],
+        "isError": true,
+    })
+}
+
+fn content_blocks(value: &JsonValue) -> JsonValue {
+    match value {
+        JsonValue::String(text) => json!([{ "type": "text", "text": text }]),
+        _ => json!([{
+            "type": "text",
+            "text": serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string()),
+        }]),
+    }
+}
+
+fn progress_notification(progress_token: JsonValue, progress: f64, message: String) -> JsonValue {
+    harn_vm::jsonrpc::notification(
+        "notifications/progress",
+        json!({
+            "progressToken": progress_token,
+            "progress": progress,
+            "message": message,
+        }),
+    )
+}
+
+fn request_key(id: &JsonValue) -> String {
+    serde_json::to_string(id).unwrap_or_else(|_| "null".to_string())
+}
+
+fn parse_error_response(message: &str) -> JsonValue {
+    harn_vm::jsonrpc::error_response(JsonValue::Null, -32700, &format!("Parse error: {message}"))
+}
+
+fn is_valid_progress_token(value: &JsonValue) -> bool {
+    matches!(value, JsonValue::String(_) | JsonValue::Number(_))
+}
+
+fn derived_server_name(catalog: &ExportCatalog) -> String {
+    catalog
+        .script_path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("harn-serve")
+        .to_string()
+}
+
+fn http_auth_request(
+    method: Method,
+    path: &str,
+    body: Vec<u8>,
+    headers: &HeaderMap,
+) -> AuthRequest {
+    AuthRequest {
+        method: method.as_str().to_string(),
+        path: path.to_string(),
+        body,
+        headers: normalized_headers(headers),
+        validated_oauth: None,
+    }
+}
+
+fn normalized_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+        })
+        .collect()
+}
+
+fn lookup_or_create_session(
+    state: &HttpState,
+    request: &JsonValue,
+    header_session: Option<String>,
+) -> Result<(String, SharedSession, bool), Box<Response>> {
+    let method = request
+        .get("method")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+    let mut sessions = state.sessions.lock().expect("sessions poisoned");
+    if let Some(session_id) = header_session {
+        if let Some(session) = sessions.get(&session_id).cloned() {
+            return Ok((session_id, session, false));
+        }
+        return Err(Box::new(StatusCode::NOT_FOUND.into_response()));
+    }
+    if method != "initialize" {
+        return Err(Box::new(StatusCode::BAD_REQUEST.into_response()));
+    }
+    let session_id = Uuid::now_v7().to_string();
+    let session = SharedSession::new();
+    sessions.insert(session_id.clone(), session.clone());
+    Ok((session_id, session, true))
+}
+
+fn attach_http_headers(response: &mut Response, session_id: Option<&str>, protocol: &str) {
+    if let Some(session_id) = session_id {
+        if let Ok(value) = HeaderValue::from_str(session_id) {
+            response
+                .headers_mut()
+                .insert(HeaderName::from_static(MCP_SESSION_HEADER), value);
+        }
+    }
+    if let Ok(value) = HeaderValue::from_str(protocol) {
+        response
+            .headers_mut()
+            .insert(HeaderName::from_static(MCP_PROTOCOL_HEADER), value);
+    }
+}
+
+fn validate_protocol_header(headers: &HeaderMap) -> Result<(), Box<Response>> {
+    let Some(value) = headers
+        .get(MCP_PROTOCOL_HEADER)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return Ok(());
+    };
+    if value == MCP_PROTOCOL_VERSION || value == "2025-03-26" {
+        Ok(())
+    } else {
+        Err(Box::new(StatusCode::BAD_REQUEST.into_response()))
+    }
+}
+
+fn validate_origin(headers: &HeaderMap) -> Result<(), Box<Response>> {
+    let Some(origin) = headers.get("origin").and_then(|value| value.to_str().ok()) else {
+        return Ok(());
+    };
+    let Ok(url) = url::Url::parse(origin) else {
+        return Err(Box::new(StatusCode::FORBIDDEN.into_response()));
+    };
+    match url.host_str() {
+        Some("127.0.0.1") | Some("localhost") | Some("[::1]") | Some("::1") => Ok(()),
+        _ => Err(Box::new(StatusCode::FORBIDDEN.into_response())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DispatchCoreConfig;
+
+    #[tokio::test]
+    async fn tools_list_exposes_public_functions() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(
+            &script,
+            r#"
+pub fn greet(name: string) -> string {
+  return name
+}
+"#,
+        )
+        .expect("write script");
+        let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+        let server = McpServer::new(McpServerConfig::new(core));
+        let tools = server.tools_list_result();
+        assert_eq!(tools["tools"][0]["name"], "greet");
+        assert_eq!(tools["tools"][0]["inputSchema"]["type"], "object");
+        assert_eq!(tools["tools"][0]["outputSchema"]["type"], "string");
+    }
+
+    #[test]
+    fn build_call_request_accepts_named_arguments() {
+        let request = build_call_request(
+            "mcp",
+            "tester",
+            "greet",
+            json!({"name": "alice"}),
+            AuthRequest::default(),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("call request");
+        match request.arguments {
+            CallArguments::Named(values) => assert_eq!(values["name"], json!("alice")),
+            other => panic!("expected named arguments, got {other:?}"),
+        }
+    }
+}

--- a/crates/harn-serve/src/adapters/mod.rs
+++ b/crates/harn-serve/src/adapters/mod.rs
@@ -1,0 +1,1 @@
+pub mod mcp;

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -1,4 +1,5 @@
 mod adapter;
+pub mod adapters;
 mod auth;
 mod core;
 mod error;
@@ -6,6 +7,9 @@ mod exports;
 mod replay;
 
 pub use adapter::{AdapterDescriptor, TransportAdapter};
+pub use adapters::mcp::{
+    McpHttpServeOptions, McpServer, McpServerConfig, McpStdioServer, MCP_PROTOCOL_VERSION,
+};
 pub use auth::{
     ApiKeyAuthConfig, AuthMethodConfig, AuthPolicy, AuthRequest, AuthenticatedPrincipal,
     AuthorizationDecision, HmacAuthConfig, OAuth21AuthConfig, OAuthClaims,

--- a/crates/harn-vm/src/stdlib/vision.rs
+++ b/crates/harn-vm/src/stdlib/vision.rs
@@ -897,6 +897,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn word(
         page: i64,
         block: i64,

--- a/crates/harn-vm/src/stdlib/waitpoint.rs
+++ b/crates/harn-vm/src/stdlib/waitpoint.rs
@@ -26,6 +26,8 @@ const WAITPOINT_WAITS_TOPIC: &str = "waitpoint.waits";
 pub const WAITPOINT_RESUME_TOPIC: &str = "waitpoint.resumes";
 const TRIGGER_EVENTS_TOPIC: &str = "triggers.events";
 
+type TerminalOptions = (Option<String>, Option<String>, Option<JsonValue>);
+
 thread_local! {
     static CREATE_SEQUENCE: RefCell<SequenceState> = RefCell::new(SequenceState::default());
     static WAIT_SEQUENCE: RefCell<SequenceState> = RefCell::new(SequenceState::default());
@@ -191,7 +193,7 @@ pub(crate) async fn create_waitpoint_on(
     metadata: Option<JsonValue>,
 ) -> Result<WaitpointRecord, VmError> {
     let id = explicit_id.unwrap_or_else(next_waitpoint_id);
-    if let Some(existing) = read_waitpoint_record(&log, &id).await? {
+    if let Some(existing) = read_waitpoint_record(log, &id).await? {
         return Ok(existing);
     }
     let record = WaitpointRecord {
@@ -201,7 +203,7 @@ pub(crate) async fn create_waitpoint_on(
         metadata,
         ..WaitpointRecord::default()
     };
-    append_waitpoint_record(&log, &record).await?;
+    append_waitpoint_record(log, &record).await?;
     Ok(record)
 }
 
@@ -313,7 +315,7 @@ pub(crate) async fn complete_waitpoint_on(
     reason: Option<String>,
     metadata: Option<JsonValue>,
 ) -> Result<WaitpointRecord, VmError> {
-    let mut record = read_waitpoint_record(&log, id)
+    let mut record = read_waitpoint_record(log, id)
         .await?
         .ok_or_else(|| VmError::Runtime(format!("waitpoint.complete: unknown waitpoint '{id}'")))?;
     if record.status == WaitpointStatus::Completed {
@@ -332,8 +334,8 @@ pub(crate) async fn complete_waitpoint_on(
     if metadata.is_some() {
         record.metadata = metadata;
     }
-    append_waitpoint_record(&log, &record).await?;
-    trigger_waitpoint_service(&log, Some(id.to_string())).await?;
+    append_waitpoint_record(log, &record).await?;
+    trigger_waitpoint_service(log, Some(id.to_string())).await?;
     Ok(record)
 }
 
@@ -354,7 +356,7 @@ pub(crate) async fn cancel_waitpoint_on(
     reason: Option<String>,
     metadata: Option<JsonValue>,
 ) -> Result<WaitpointRecord, VmError> {
-    let mut record = read_waitpoint_record(&log, id)
+    let mut record = read_waitpoint_record(log, id)
         .await?
         .ok_or_else(|| VmError::Runtime(format!("waitpoint.cancel: unknown waitpoint '{id}'")))?;
     if record.status == WaitpointStatus::Cancelled {
@@ -372,8 +374,8 @@ pub(crate) async fn cancel_waitpoint_on(
     if metadata.is_some() {
         record.metadata = metadata;
     }
-    append_waitpoint_record(&log, &record).await?;
-    trigger_waitpoint_service(&log, Some(id.to_string())).await?;
+    append_waitpoint_record(log, &record).await?;
+    trigger_waitpoint_service(log, Some(id.to_string())).await?;
     Ok(record)
 }
 
@@ -786,7 +788,7 @@ async fn read_waitpoint_record(
     Ok(events
         .into_iter()
         .filter_map(|(_, event)| serde_json::from_value::<WaitpointRecord>(event.payload).ok())
-        .last())
+        .next_back())
 }
 
 async fn read_waiter_record(
@@ -802,8 +804,7 @@ async fn read_waiter_record(
     Ok(events
         .into_iter()
         .filter_map(|(_, event)| serde_json::from_value::<WaiterRecord>(event.payload).ok())
-        .filter(|record| record.wait_id == wait_id)
-        .last())
+        .rfind(|record| record.wait_id == wait_id))
 }
 
 async fn load_waitpoint_states(
@@ -979,7 +980,7 @@ fn parse_wait_options(value: Option<&VmValue>) -> Result<WaitpointWaitOptions, V
 fn parse_terminal_options(
     value: Option<&VmValue>,
     builtin: &str,
-) -> Result<(Option<String>, Option<String>, Option<JsonValue>), VmError> {
+) -> Result<TerminalOptions, VmError> {
     let Some(value) = value else {
         return Ok((None, None, None));
     };

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -1016,7 +1016,7 @@ impl Dispatcher {
             source_node_id = predicate_node_id;
         }
 
-        let (event, mut acquired_flow) = match self
+        let (event, acquired_flow) = match self
             .apply_flow_control(binding, &event, replay_of_event_id.as_ref())
             .await?
         {
@@ -1373,7 +1373,7 @@ impl Dispatcher {
                         .map_err(|registry_error| {
                             DispatchError::Registry(registry_error.to_string())
                         })?;
-                        self.release_flow_control(&mut acquired_flow).await?;
+                        self.release_flow_control(&acquired_flow).await?;
                         decrement_in_flight(&self.state);
                         return Ok(DispatchOutcome {
                             trigger_id: binding.id.as_str().to_string(),

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -632,22 +632,41 @@ harn trust demote deploy-bot --to suggest --reason "needs tighter review gate"
 
 ## harn serve
 
-Start an A2A (Agent-to-Agent) HTTP server.
+Start a workflow server through one of the outbound transport adapters.
 
 ```bash
-harn serve agent.harn               # default port 8080
-harn serve --port 3000 agent.harn   # custom port
+harn serve a2a agent.harn                  # explicit A2A
+harn serve agent.harn                      # legacy A2A shorthand
+harn serve --port 3000 agent.harn          # legacy A2A shorthand with custom port
+harn serve mcp server.harn                 # exported pub fn -> MCP tools over stdio
+harn serve mcp --transport http server.harn
 ```
 
-See [MCP and ACP Integration](./mcp-and-acp.md) for protocol details.
+`harn serve mcp` uses the shared `harn-serve` dispatch core and maps each
+exported `pub fn` in the target module to one MCP tool. Tool schemas are
+derived from Harn type annotations. With `--transport http`, the server also
+supports Streamable HTTP on `--path` plus the legacy SSE compatibility
+endpoints `--sse-path` and `--messages-path`.
+
+`harn serve a2a` exposes the older A2A HTTP server. The legacy shorthand
+`harn serve <file>` is preserved and rewrites internally to `harn serve a2a
+<file>`.
+
+See [MCP and ACP Integration](./mcp-and-acp.md) and
+[Outbound workflow server](./harn-serve.md) for protocol details.
 
 ## harn mcp-serve
 
-Serve a Harn pipeline as an MCP server over stdio.
+Serve a Harn pipeline as an MCP server over stdio using the legacy
+tool-registry surface (`mcp_tools`, `mcp_resource`, `mcp_prompt`).
 
 ```bash
 harn mcp-serve agent.harn
 ```
+
+Use `harn serve mcp` when you want the newer `harn-serve` adapter that maps
+exported `pub fn` entrypoints automatically. Use `harn mcp-serve` when the
+server surface is authored explicitly through MCP registration builtins.
 
 See [MCP and ACP Integration](./mcp-and-acp.md) for details on defining
 tools, resources, and prompts.

--- a/docs/src/harn-serve.md
+++ b/docs/src/harn-serve.md
@@ -54,6 +54,25 @@ Mapping:
 - Harn type annotations become tool input/output schemas
 - replay keys map naturally to idempotent tool invocations
 
+Run it with:
+
+```bash
+harn serve mcp server.harn
+harn serve mcp --transport http server.harn
+```
+
+Behavior today:
+
+- stdio transport for local subprocess-style MCP clients
+- Streamable HTTP `POST` / `GET` endpoint at `--path`
+- legacy SSE compatibility endpoints at `--sse-path` and `--messages-path`
+- progress notifications when the caller provides `_meta.progressToken`
+- cooperative cancel propagation from `notifications/cancelled`
+- HTTP auth hooks built on the shared `AuthPolicy` surface:
+  API keys
+  HMAC canonical-request signatures
+  OAuth 2.1 claims injected by a hosting transport
+
 ### A2A
 
 Choose A2A when the caller wants a peer agent rather than a bag of tools.

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -576,8 +576,9 @@ interact with. The server implements A2A protocol version 1.0.0.
 ### Running the server
 
 ```bash
-harn serve agent.harn               # default port 8080
-harn serve --port 3000 agent.harn   # custom port
+harn serve a2a agent.harn             # explicit A2A
+harn serve agent.harn                 # legacy shorthand for A2A
+harn serve a2a --port 3000 agent.harn
 ```
 
 ### Agent card


### PR DESCRIPTION
## Summary

Implements #293 by adding the first transport adapter under `harn-serve`: an MCP server that exposes exported Harn `pub fn` entrypoints as MCP tools.

This PR adds:

- an MCP adapter module under `crates/harn-serve/src/adapters/mcp.rs`
- `harn serve mcp <file.harn>` with stdio and HTTP transports
- Streamable HTTP plus legacy SSE compatibility endpoints
- progress notifications and `notifications/cancelled` propagation for long-running tool calls
- shared auth wiring for API keys and HMAC on the HTTP serve path
- compatibility rewriting so legacy `harn serve <file>` still routes to A2A
- end-to-end CLI tests for stdio, HTTP, cancellation, progress, and auth
- docs + changelog updates covering the new surface and the distinction from `harn mcp-serve`

## Why

`harn-serve` already had the shared export catalog, auth policy, replay, and dispatch core from #301. #293 is the missing MCP transport layer on top of that core so MCP-aware clients can mount exported workflows directly as tools instead of going through the older `mcp_tools()` registry path.

## Validation

- `cargo fmt --all`
- `cargo test -p harn-serve`
- `cargo test -p harn-cli --test harn_serve_mcp_cli`
- `cargo test -p harn-cli --bin harn cli::tests::test_parses_serve_mcp_flags -- --exact`
- `cargo test -p harn-cli --bin harn main_tests::normalize_serve_args_inserts_a2a_for_legacy_shape -- --exact`
- `cargo test -p harn-cli --bin harn main_tests::normalize_serve_args_preserves_explicit_subcommands -- --exact`
- `npx markdownlint-cli2 CHANGELOG.md docs/src/cli-reference.md docs/src/harn-serve.md docs/src/mcp-and-acp.md`

Closes #293.