### PR TITLE
[codex] Implement orchestrator hot reload control plane

### DIFF
--- a/conformance/tests/integration/orchestrator_hot_reload_add.expected
+++ b/conformance/tests/integration/orchestrator_hot_reload_add.expected
@@ -1,0 +1,1 @@
+[harn] orchestrator hot reload add status: 200

--- a/conformance/tests/integration/orchestrator_hot_reload_add.harn
+++ b/conformance/tests/integration/orchestrator_hot_reload_add.harn
@@ -1,0 +1,147 @@
+import "../_common"
+
+pipeline default() {
+  let unique = uuid()
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let base = path_join(temp_dir(), "harn-orchestrator-hot-reload-add-" + unique)
+  let workspace = path_join(base, "workspace")
+  let state_dir = path_join(base, "state")
+  let binary = env_or("HARN_CONFORMANCE_HARN_BIN", resolve_harn_bin(repo_root))
+  assert(file_exists(binary), "missing built harn binary at " + binary)
+  let script = """
+    set -eu
+
+    base="${base}"
+    workspace="${workspace}"
+    state_dir="${state_dir}"
+    binary="${binary}"
+
+    mkdir -p "$workspace" "$state_dir"
+
+    cat > "$workspace/harn.toml" <<'EOF'
+    [package]
+    name = "orchestrator_hot_reload_add"
+    EOF
+
+    cat > "$workspace/harn.toml.next" <<'EOF'
+    [package]
+    name = "orchestrator_hot_reload_add"
+
+    [[triggers]]
+    id = "incoming-review-task"
+    kind = "a2a-push"
+    provider = "a2a-push"
+    path = "/a2a/v1"
+    match = { events = ["a2a.task.received"] }
+    handler = "worker://triage"
+    EOF
+
+    log_path="$base/orchestrator.log"
+    snapshot_path="$state_dir/orchestrator-state.json"
+    result_path="$base/result.json"
+
+    HARN_ORCHESTRATOR_API_KEYS="hot-reload-test-key" \
+    HARN_ORCHESTRATOR_HMAC_SECRET="hot-reload-test-hmac-secret" \
+      "$binary" orchestrator serve \
+        --config "$workspace/harn.toml" \
+        --state-dir "$state_dir" \
+        --bind 127.0.0.1:0 \
+        --role single-tenant \
+        >"$log_path" 2>&1 &
+    pid=$!
+
+    cleanup() {
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    }
+    trap cleanup EXIT
+
+    bind=$(python3 - "$snapshot_path" "$log_path" <<'PY'
+    import json, pathlib, sys, time
+    snapshot = pathlib.Path(sys.argv[1])
+    log = pathlib.Path(sys.argv[2])
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        if snapshot.exists():
+            data = json.loads(snapshot.read_text())
+            bind = data.get("bind")
+            if bind:
+                print(bind)
+                raise SystemExit(0)
+        time.sleep(0.05)
+    tail = log.read_text()[-4000:] if log.exists() else "(missing orchestrator log)"
+    raise SystemExit(f"timed out waiting for orchestrator snapshot; stderr:\\n{tail}")
+    PY
+    )
+
+    (
+      sleep 0.2
+      mv "$workspace/harn.toml.next" "$workspace/harn.toml"
+      kill -HUP "$pid"
+    ) &
+
+    python3 - "$snapshot_path" <<'PY'
+    import json, pathlib, sys, time
+    path = pathlib.Path(sys.argv[1])
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        if path.exists():
+            data = json.loads(path.read_text())
+            triggers = data.get("triggers") or []
+            if len(triggers) == 1 and triggers[0].get("version") == 1:
+                raise SystemExit(0)
+        time.sleep(0.05)
+    raise SystemExit("timed out waiting for add reload")
+    PY
+
+    python3 - "http://$bind/a2a/v1" "$result_path" <<'PY'
+    import json, pathlib, sys, urllib.request
+    url = sys.argv[1]
+    out = pathlib.Path(sys.argv[2])
+    payload = json.dumps({"task_id": "task-add", "sender": "alpha"}).encode()
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer hot-reload-test-key",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        out.write_text(json.dumps({"status": response.status, "body": json.loads(response.read().decode())}))
+    PY
+
+    python3 - "$state_dir" "$snapshot_path" "$result_path" <<'PY'
+    import glob
+    import json
+    import pathlib
+    import sqlite3
+    import sys
+
+    state_dir, snapshot_path, result_path = sys.argv[1:]
+    snapshot = json.loads(pathlib.Path(snapshot_path).read_text())
+    result = json.loads(pathlib.Path(result_path).read_text())
+    dbs = glob.glob(str(pathlib.Path(state_dir) / "**" / "*.sqlite"), recursive=True)
+    assert dbs, "missing sqlite event log"
+    conn = sqlite3.connect(dbs[0])
+    rows = conn.execute(
+        "SELECT payload FROM events WHERE topic = ? ORDER BY event_id",
+        ("orchestrator.triggers.pending",),
+    ).fetchall()
+    events = [json.loads(row[0]) for row in rows]
+    assert result["status"] == 200, result
+    assert len(snapshot["triggers"]) == 1, snapshot
+    assert snapshot["triggers"][0]["version"] == 1, snapshot
+    assert len(events) == 1, events
+    assert events[0]["binding_version"] == 1, events
+    print(json.dumps({"status": result["status"], "version": snapshot["triggers"][0]["version"]}))
+    PY
+    """
+  let result = shell(script)
+  assert(result?.success, result?.stderr)
+  let summary = json_parse(result?.stdout)
+  assert(summary.status == 200, "new route accepts after add reload")
+  assert(summary.version == 1, "added binding starts at version 1")
+  log("orchestrator hot reload add status: " + to_string(summary.status))
+}

--- a/conformance/tests/integration/orchestrator_hot_reload_remove.expected
+++ b/conformance/tests/integration/orchestrator_hot_reload_remove.expected
@@ -1,0 +1,1 @@
+[harn] orchestrator hot reload remove status: 404

--- a/conformance/tests/integration/orchestrator_hot_reload_remove.harn
+++ b/conformance/tests/integration/orchestrator_hot_reload_remove.harn
@@ -1,0 +1,135 @@
+import "../_common"
+
+pipeline default() {
+  let unique = uuid()
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let base = path_join(temp_dir(), "harn-orchestrator-hot-reload-remove-" + unique)
+  let workspace = path_join(base, "workspace")
+  let state_dir = path_join(base, "state")
+  let binary = env_or("HARN_CONFORMANCE_HARN_BIN", resolve_harn_bin(repo_root))
+  assert(file_exists(binary), "missing built harn binary at " + binary)
+  let script = """
+    set -eu
+
+    base="${base}"
+    workspace="${workspace}"
+    state_dir="${state_dir}"
+    binary="${binary}"
+
+    mkdir -p "$workspace" "$state_dir"
+
+    cat > "$workspace/harn.toml" <<'EOF'
+    [package]
+    name = "orchestrator_hot_reload_remove"
+
+    [[triggers]]
+    id = "incoming-review-task"
+    kind = "a2a-push"
+    provider = "a2a-push"
+    path = "/a2a/v1"
+    match = { events = ["a2a.task.received"] }
+    handler = "worker://triage"
+    EOF
+
+    cat > "$workspace/harn.toml.next" <<'EOF'
+    [package]
+    name = "orchestrator_hot_reload_remove"
+    EOF
+
+    log_path="$base/orchestrator.log"
+    snapshot_path="$state_dir/orchestrator-state.json"
+    result_path="$base/result.json"
+
+    HARN_ORCHESTRATOR_API_KEYS="hot-reload-test-key" \
+    HARN_ORCHESTRATOR_HMAC_SECRET="hot-reload-test-hmac-secret" \
+      "$binary" orchestrator serve \
+        --config "$workspace/harn.toml" \
+        --state-dir "$state_dir" \
+        --bind 127.0.0.1:0 \
+        --role single-tenant \
+        >"$log_path" 2>&1 &
+    pid=$!
+
+    cleanup() {
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    }
+    trap cleanup EXIT
+
+    bind=$(python3 - "$snapshot_path" "$log_path" <<'PY'
+    import json, pathlib, sys, time
+    snapshot = pathlib.Path(sys.argv[1])
+    log = pathlib.Path(sys.argv[2])
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        if snapshot.exists():
+            data = json.loads(snapshot.read_text())
+            bind = data.get("bind")
+            if bind:
+                print(bind)
+                raise SystemExit(0)
+        time.sleep(0.05)
+    tail = log.read_text()[-4000:] if log.exists() else "(missing orchestrator log)"
+    raise SystemExit(f"timed out waiting for orchestrator snapshot; stderr:\\n{tail}")
+    PY
+    )
+
+    (
+      sleep 0.2
+      mv "$workspace/harn.toml.next" "$workspace/harn.toml"
+      kill -HUP "$pid"
+    ) &
+
+    python3 - "$snapshot_path" <<'PY'
+    import json, pathlib, sys, time
+    path = pathlib.Path(sys.argv[1])
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        if path.exists():
+            data = json.loads(path.read_text())
+            if len(data.get("triggers") or []) == 0:
+                raise SystemExit(0)
+        time.sleep(0.05)
+    raise SystemExit("timed out waiting for remove reload")
+    PY
+
+    python3 - "http://$bind/a2a/v1" "$result_path" <<'PY'
+    import json, pathlib, sys, urllib.error, urllib.request
+    url = sys.argv[1]
+    out = pathlib.Path(sys.argv[2])
+    payload = json.dumps({"task_id": "task-remove", "sender": "alpha"}).encode()
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer hot-reload-test-key",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            out.write_text(json.dumps({"status": response.status}))
+    except urllib.error.HTTPError as error:
+        out.write_text(json.dumps({"status": error.code}))
+    PY
+
+    python3 - "$snapshot_path" "$result_path" <<'PY'
+    import json
+    import pathlib
+    import sys
+
+    snapshot = json.loads(pathlib.Path(sys.argv[1]).read_text())
+    result = json.loads(pathlib.Path(sys.argv[2]).read_text())
+    assert len(snapshot.get("triggers") or []) == 0, snapshot
+    assert result["status"] == 404, result
+    print(json.dumps({"status": result["status"], "triggers": len(snapshot.get("triggers") or [])}))
+    PY
+    """
+  let result = shell(script)
+  assert(result?.success, result?.stderr)
+  let summary = json_parse(result?.stdout)
+  assert(summary.status == 404, "removed route returns 404 after reload")
+  assert(summary.triggers == 0, "state snapshot no longer lists removed trigger")
+  log("orchestrator hot reload remove status: " + to_string(summary.status))
+}

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -821,6 +821,8 @@ pub(crate) struct OrchestratorLocalArgs {
 pub(crate) enum OrchestratorCommand {
     /// Load manifests, initialize registries, and idle until shutdown.
     Serve(OrchestratorServeArgs),
+    /// Request a hot reload from a running orchestrator.
+    Reload(OrchestratorReloadArgs),
     /// Inspect orchestrator state.
     Inspect(OrchestratorInspectArgs),
     /// Inject a synthetic event for a specific binding.
@@ -865,6 +867,9 @@ pub(crate) struct OrchestratorServeArgs {
     /// Seconds to wait for each pump drain before truncating remaining backlog.
     #[arg(long = "drain-deadline", value_name = "SECS")]
     pub drain_deadline: Option<u64>,
+    /// Watch the manifest file and trigger reloads on changes.
+    #[arg(long)]
+    pub watch: bool,
     /// Runtime role to boot. Multi-tenant is a stub for now.
     #[arg(
         long,
@@ -873,6 +878,21 @@ pub(crate) struct OrchestratorServeArgs {
         default_value_t = crate::commands::orchestrator::role::OrchestratorRole::SingleTenant
     )]
     pub role: crate::commands::orchestrator::role::OrchestratorRole,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorReloadArgs {
+    #[command(flatten)]
+    pub local: OrchestratorLocalArgs,
+    /// Explicit admin base URL. Defaults to the running listener URL from the state snapshot.
+    #[arg(long = "admin-url", value_name = "URL")]
+    pub admin_url: Option<String>,
+    /// Request timeout in seconds.
+    #[arg(long, default_value_t = 10, value_name = "SECS")]
+    pub timeout: u64,
+    /// Emit JSON instead of human-readable output.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/harn-cli/src/commands/orchestrator/inspect_data.rs
+++ b/crates/harn-cli/src/commands/orchestrator/inspect_data.rs
@@ -788,8 +788,8 @@ pub fn on_ok(event: TriggerEvent) -> dict {
             trace_id: harn_vm::TraceId::new(),
             tenant_id: None,
             headers: BTreeMap::from([(String::from("tenant"), tenant.to_string())]),
-            batch: None,
             raw_body: None,
+            batch: None,
             provider_payload: harn_vm::ProviderPayload::Known(
                 harn_vm::triggers::event::KnownProviderPayload::Cron(
                     harn_vm::triggers::CronEventPayload {

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -14,6 +14,7 @@ use serde_json::{json, Value as JsonValue};
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 use time::OffsetDateTime;
+use tokio::sync::{mpsc, oneshot};
 
 use harn_vm::event_log::{AnyEventLog, EventLog, LogEvent, Topic};
 use harn_vm::secrets::{SecretId, SecretProvider, SecretVersion};
@@ -24,6 +25,7 @@ use crate::commands::orchestrator::tls::{ServerRuntime, TlsFiles};
 use crate::package::{CollectedManifestTrigger, TriggerKind};
 
 const DEFAULT_MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
+const ADMIN_RELOAD_PATH: &str = "/admin/reload";
 const PENDING_TOPIC: &str = "orchestrator.triggers.pending";
 const REQUEST_DELAY_ENV: &str = "HARN_ORCHESTRATOR_TEST_REQUEST_DELAY_MS";
 const API_KEYS_ENV: &str = "HARN_ORCHESTRATOR_API_KEYS";
@@ -39,6 +41,7 @@ pub(crate) struct ListenerConfig {
     pub(crate) allowed_origins: OriginAllowList,
     pub(crate) max_body_bytes: usize,
     pub(crate) metrics_registry: Arc<harn_vm::MetricsRegistry>,
+    pub(crate) admin_reload: Option<AdminReloadHandle>,
     pub(crate) routes: Vec<RouteConfig>,
 }
 
@@ -51,6 +54,44 @@ impl ListenerConfig {
 pub(crate) struct ListenerRuntime {
     server: ServerRuntime,
     routes: Arc<RouteRegistry>,
+}
+
+pub(crate) struct AdminReloadRequest {
+    pub(crate) source: String,
+    pub(crate) response_tx: Option<oneshot::Sender<Result<JsonValue, String>>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct AdminReloadHandle {
+    tx: mpsc::UnboundedSender<AdminReloadRequest>,
+}
+
+impl AdminReloadHandle {
+    pub(crate) fn channel() -> (Self, mpsc::UnboundedReceiver<AdminReloadRequest>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Self { tx }, rx)
+    }
+
+    pub(crate) fn trigger(&self, source: impl Into<String>) -> Result<(), String> {
+        self.tx
+            .send(AdminReloadRequest {
+                source: source.into(),
+                response_tx: None,
+            })
+            .map_err(|_| "reload channel is closed".to_string())
+    }
+
+    pub(crate) async fn request(&self, source: impl Into<String>) -> Result<JsonValue, String> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(AdminReloadRequest {
+                source: source.into(),
+                response_tx: Some(tx),
+            })
+            .map_err(|_| "reload channel is closed".to_string())?;
+        rx.await
+            .map_err(|_| "reload response channel closed".to_string())?
+    }
 }
 
 impl ListenerRuntime {
@@ -74,6 +115,13 @@ impl ListenerRuntime {
             .filter(|value| *value > 0)
             .map(Duration::from_millis);
         let origin_state = Arc::new(config.allowed_origins.clone());
+        let admin_state = config.admin_reload.clone().map(|reload| {
+            Arc::new(AdminReloadState {
+                event_log: config.event_log.clone(),
+                auth: auth.clone(),
+                reload,
+            })
+        });
         let routes = Arc::new(RouteRegistry::new(
             config.routes,
             config.event_log.clone(),
@@ -84,7 +132,7 @@ impl ListenerRuntime {
             pending_topic.clone(),
             request_delay,
         )?);
-        let app = Router::new()
+        let mut app = Router::new()
             .route(
                 "/health",
                 get(|| async move { (StatusCode::OK, "ok").into_response() }),
@@ -100,11 +148,17 @@ impl ListenerRuntime {
             .route(
                 "/metrics",
                 get(metrics_endpoint).layer(Extension(config.metrics_registry.clone())),
-            )
-            .route(
-                "/{*path}",
-                post(ingest_trigger).layer(Extension(routes.clone())),
             );
+        if let Some(admin_state) = admin_state {
+            app = app.route(
+                ADMIN_RELOAD_PATH,
+                post(admin_reload_endpoint).layer(Extension(admin_state)),
+            );
+        }
+        let app = app.route(
+            "/{*path}",
+            post(ingest_trigger).layer(Extension(routes.clone())),
+        );
 
         let app = app
             .layer(DefaultBodyLimit::max(config.max_body_bytes))
@@ -243,6 +297,13 @@ struct RouteContext {
     pending_topic: Topic,
     request_delay: Option<Duration>,
     metrics: Arc<RouteRuntimeMetrics>,
+}
+
+#[derive(Clone)]
+struct AdminReloadState {
+    event_log: Arc<AnyEventLog>,
+    auth: Arc<ListenerAuth>,
+    reload: AdminReloadHandle,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -573,6 +634,60 @@ async fn metrics_endpoint(
         )],
         metrics.render_prometheus(),
     )
+}
+
+async fn admin_reload_endpoint(
+    Extension(state): Extension<Arc<AdminReloadState>>,
+    method: Method,
+    OriginalUri(uri): OriginalUri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let normalized_headers = normalize_headers(&headers);
+    if state
+        .auth
+        .authorize(
+            state.event_log.as_ref(),
+            method.as_str(),
+            uri.path(),
+            &normalized_headers,
+            &body,
+        )
+        .await
+        .is_err()
+    {
+        return HttpError::unauthorized("auth failed").into_response();
+    }
+    let source = serde_json::from_slice::<JsonValue>(&body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("source")
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string)
+        })
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "admin_api".to_string());
+    match state.reload.request(source.clone()).await {
+        Ok(summary) => (
+            StatusCode::OK,
+            axum::Json(json!({
+                "status": "ok",
+                "source": source,
+                "summary": summary,
+            })),
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(json!({
+                "status": "error",
+                "source": source,
+                "error": error,
+            })),
+        )
+            .into_response(),
+    }
 }
 
 async fn authorize_request(
@@ -1336,6 +1451,7 @@ mod tests {
             allowed_origins: OriginAllowList::wildcard(),
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
             metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
+            admin_reload: None,
             routes: vec![route("/a2a/v1", 1)],
         })
         .await
@@ -1449,6 +1565,7 @@ mod tests {
             allowed_origins: OriginAllowList::wildcard(),
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
             metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
+            admin_reload: None,
             routes: vec![webhook_route("/hooks/github")],
         })
         .await
@@ -1509,6 +1626,7 @@ mod tests {
             allowed_origins: OriginAllowList::wildcard(),
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
             metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
+            admin_reload: None,
             routes: vec![webhook_route("/hooks/github")],
         })
         .await

--- a/crates/harn-cli/src/commands/orchestrator/mod.rs
+++ b/crates/harn-cli/src/commands/orchestrator/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod listener;
 mod origin_guard;
 mod queue;
 mod recover;
+mod reload;
 mod replay;
 mod resume;
 pub(crate) mod role;
@@ -18,6 +19,7 @@ use crate::cli::{OrchestratorArgs, OrchestratorCommand};
 pub(crate) async fn handle(args: OrchestratorArgs) -> Result<(), String> {
     match args.command {
         OrchestratorCommand::Serve(serve_args) => serve::run(serve_args).await,
+        OrchestratorCommand::Reload(reload_args) => reload::run(reload_args).await,
         OrchestratorCommand::Inspect(inspect_args) => inspect::run(inspect_args).await,
         OrchestratorCommand::Fire(fire_args) => fire::run(fire_args).await,
         OrchestratorCommand::Replay(replay_args) => replay::run(replay_args).await,

--- a/crates/harn-cli/src/commands/orchestrator/reload.rs
+++ b/crates/harn-cli/src/commands/orchestrator/reload.rs
@@ -1,0 +1,207 @@
+use std::env;
+use std::fs;
+use std::time::Duration;
+
+use base64::Engine;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
+use serde::Deserialize;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
+
+use crate::cli::OrchestratorReloadArgs;
+
+const STATE_SNAPSHOT_FILE: &str = "orchestrator-state.json";
+const ADMIN_RELOAD_PATH: &str = "/admin/reload";
+const API_KEYS_ENV: &str = "HARN_ORCHESTRATOR_API_KEYS";
+const HMAC_SECRET_ENV: &str = "HARN_ORCHESTRATOR_HMAC_SECRET";
+
+#[derive(Debug, Deserialize)]
+struct StateSnapshot {
+    bind: String,
+    #[serde(default)]
+    listener_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReloadResponse {
+    status: String,
+    source: String,
+    #[serde(default)]
+    summary: serde_json::Value,
+}
+
+pub(crate) async fn run(args: OrchestratorReloadArgs) -> Result<(), String> {
+    let base_url = resolve_admin_url(&args)?;
+    let url = format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        ADMIN_RELOAD_PATH.trim_start_matches('/')
+    );
+    let body = serde_json::to_vec(&json!({
+        "source": "cli",
+    }))
+    .map_err(|error| format!("failed to encode reload request: {error}"))?;
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(args.timeout.max(1)))
+        .build()
+        .map_err(|error| format!("failed to build HTTP client: {error}"))?;
+    let mut request = client
+        .post(&url)
+        .header(CONTENT_TYPE, "application/json")
+        .body(body.clone());
+    request = authorize_request(request, &url, &body)?;
+    let response = request
+        .send()
+        .await
+        .map_err(|error| format!("failed to request orchestrator reload at {url}: {error}"))?;
+    let status = response.status();
+    let text = response
+        .text()
+        .await
+        .map_err(|error| format!("failed to read orchestrator reload response: {error}"))?;
+    if !status.is_success() {
+        return Err(format!(
+            "orchestrator reload failed with HTTP {}: {}",
+            status.as_u16(),
+            text.trim()
+        ));
+    }
+    if args.json {
+        println!("{text}");
+        return Ok(());
+    }
+    let parsed: ReloadResponse = serde_json::from_str(&text)
+        .map_err(|error| format!("failed to decode orchestrator reload response: {error}"))?;
+    let summary = &parsed.summary;
+    let added = summary
+        .get("added")
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    let modified = summary
+        .get("modified")
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    let removed = summary
+        .get("removed")
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    println!(
+        "reload {} via {} (+{} ~{} -{})",
+        parsed.status, parsed.source, added, modified, removed
+    );
+    Ok(())
+}
+
+fn resolve_admin_url(args: &OrchestratorReloadArgs) -> Result<String, String> {
+    if let Some(url) = &args.admin_url {
+        return Ok(url.trim_end_matches('/').to_string());
+    }
+    let path = args.local.state_dir.join(STATE_SNAPSHOT_FILE);
+    let body = fs::read_to_string(&path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let snapshot: StateSnapshot = serde_json::from_str(&body)
+        .map_err(|error| format!("failed to parse {}: {error}", path.display()))?;
+    if let Some(url) = snapshot.listener_url {
+        return Ok(url.trim_end_matches('/').to_string());
+    }
+    Ok(format!("http://{}", snapshot.bind))
+}
+
+fn authorize_request(
+    request: reqwest::RequestBuilder,
+    url: &str,
+    body: &[u8],
+) -> Result<reqwest::RequestBuilder, String> {
+    if let Some(api_key) = env::var(API_KEYS_ENV).ok().and_then(|value| {
+        value
+            .split(',')
+            .map(str::trim)
+            .find(|segment| !segment.is_empty())
+            .map(ToString::to_string)
+    }) {
+        return Ok(request.header(AUTHORIZATION, format!("Bearer {api_key}")));
+    }
+
+    if let Some(secret) = env::var(HMAC_SECRET_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        let parsed = reqwest::Url::parse(url)
+            .map_err(|error| format!("invalid admin URL '{url}': {error}"))?;
+        let timestamp = OffsetDateTime::now_utc().unix_timestamp();
+        let authorization =
+            canonical_authorization(&secret, "POST", parsed.path(), timestamp, body);
+        return Ok(request.header(AUTHORIZATION, authorization));
+    }
+
+    Err(format!(
+        "set {API_KEYS_ENV} or {HMAC_SECRET_ENV} so the reload command can authenticate"
+    ))
+}
+
+fn canonical_authorization(
+    secret: &str,
+    method: &str,
+    path: &str,
+    timestamp: i64,
+    body: &[u8],
+) -> String {
+    let signed = canonical_request_message(method, path, &timestamp.to_string(), body);
+    let signature = hmac_sha256(secret.as_bytes(), signed.as_bytes());
+    format!(
+        "{} timestamp={},signature={}",
+        harn_vm::connectors::DEFAULT_CANONICAL_HMAC_SCHEME,
+        timestamp,
+        base64::engine::general_purpose::STANDARD.encode(signature)
+    )
+}
+
+fn canonical_request_message(method: &str, path: &str, timestamp: &str, body: &[u8]) -> String {
+    let body_hash = Sha256::digest(body);
+    let body_hex = body_hash
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!(
+        "{}\n{}\n{}\n{}",
+        method.to_uppercase(),
+        path,
+        timestamp,
+        body_hex
+    )
+}
+
+fn hmac_sha256(secret: &[u8], data: &[u8]) -> Vec<u8> {
+    const BLOCK_SIZE: usize = 64;
+
+    let mut key = if secret.len() > BLOCK_SIZE {
+        Sha256::digest(secret).to_vec()
+    } else {
+        secret.to_vec()
+    };
+    key.resize(BLOCK_SIZE, 0);
+
+    let mut inner_pad = vec![0x36; BLOCK_SIZE];
+    let mut outer_pad = vec![0x5c; BLOCK_SIZE];
+    for (pad, key_byte) in inner_pad.iter_mut().zip(key.iter()) {
+        *pad ^= *key_byte;
+    }
+    for (pad, key_byte) in outer_pad.iter_mut().zip(key.iter()) {
+        *pad ^= *key_byte;
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(&inner_pad);
+    inner.update(data);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(&outer_pad);
+    outer.update(inner_digest);
+    outer.finalize().to_vec()
+}

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -10,13 +10,16 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 use tokio::task::JoinSet;
 
 use harn_vm::event_log::{ConsumerId, EventLog};
 
 use super::common::stranded_envelopes;
-use super::listener::{ListenerConfig, ListenerRuntime, RouteConfig, TriggerMetricSnapshot};
+use super::listener::{
+    AdminReloadHandle, AdminReloadRequest, ListenerConfig, ListenerRuntime, RouteConfig,
+    TriggerMetricSnapshot,
+};
 use super::origin_guard::OriginAllowList;
 use super::role::OrchestratorRole;
 use super::tls::TlsFiles;
@@ -81,6 +84,7 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
 
     let workspace_root = manifest_dir.clone();
     let startup_started_at = now_rfc3339()?;
+    let (admin_reload, mut reload_rx) = AdminReloadHandle::channel();
 
     eprintln!("[harn] orchestrator manifest: {}", config_path.display());
     if let Some(name) = manifest
@@ -188,6 +192,7 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
             manifest.orchestrator.max_body_bytes,
         ),
         metrics_registry: metrics_registry.clone(),
+        admin_reload: Some(admin_reload.clone()),
         routes: route_configs,
     })
     .await?;
@@ -195,6 +200,14 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
     let listener_metrics = listener.trigger_metrics();
     let mut live_manifest = manifest;
     let mut live_triggers = collected_triggers;
+    let _manifest_watcher = if args.watch {
+        Some(spawn_manifest_watcher(
+            config_path.clone(),
+            admin_reload.clone(),
+        )?)
+    } else {
+        None
+    };
     eprintln!("[harn] HTTP listener ready on {}", listener.url());
 
     connector_runtime.activations = connector_runtime
@@ -213,6 +226,7 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
             status: "running".to_string(),
             role: args.role.as_str().to_string(),
             bind: local_bind.to_string(),
+            listener_url: listener.url(),
             manifest_path: config_path.display().to_string(),
             state_dir: state_dir.display().to_string(),
             started_at: startup_started_at.clone(),
@@ -281,9 +295,12 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
             event_log_description: &event_log_description,
             secret_chain_display: &secret_chain_display,
             listener: &listener,
-            connectors: &connector_runtime,
+            connectors: &mut connector_runtime,
             live_manifest: &mut live_manifest,
             live_triggers: &mut live_triggers,
+            secret_provider: &secret_provider,
+            metrics_registry: &metrics_registry,
+            reload_rx: &mut reload_rx,
         },
         #[cfg(unix)]
         signal_streams,
@@ -294,6 +311,7 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
         GracefulShutdownCtx {
             role: args.role,
             bind: local_bind,
+            listener_url: listener.url(),
             config_path: &config_path,
             state_dir: &state_dir,
             startup_started_at: &startup_started_at,
@@ -330,15 +348,10 @@ struct ConnectorRuntime {
     handles: Vec<harn_vm::connectors::ConnectorHandle>,
     providers: Vec<String>,
     activations: Vec<harn_vm::ActivationHandle>,
+    provider_overrides: Vec<ResolvedProviderConnectorConfig>,
 }
 
-struct PreparedManifestReload {
-    manifest: Manifest,
-    collected_triggers: Vec<CollectedManifestTrigger>,
-    summary: ManifestReloadSummary,
-}
-
-#[derive(Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 struct ManifestReloadSummary {
     added: Vec<String>,
     modified: Vec<String>,
@@ -419,6 +432,7 @@ async fn initialize_connectors(
         handles,
         providers,
         activations: Vec::new(),
+        provider_overrides: provider_overrides.to_vec(),
     })
 }
 
@@ -1317,6 +1331,7 @@ async fn graceful_shutdown(
             status: "stopped".to_string(),
             role: ctx.role.as_str().to_string(),
             bind: ctx.bind.to_string(),
+            listener_url: ctx.listener_url.clone(),
             manifest_path: ctx.config_path.display().to_string(),
             state_dir: ctx.state_dir.display().to_string(),
             started_at: ctx.startup_started_at.to_string(),
@@ -1576,6 +1591,67 @@ fn pending_pump_test_should_fail() -> bool {
         .is_some_and(|value| value != "0")
 }
 
+fn spawn_manifest_watcher(
+    config_path: PathBuf,
+    reload: AdminReloadHandle,
+) -> Result<notify::RecommendedWatcher, String> {
+    use notify::{Event, EventKind, RecursiveMode, Watcher};
+
+    let watch_dir = config_path.parent().ok_or_else(|| {
+        format!(
+            "manifest has no parent directory: {}",
+            config_path.display()
+        )
+    })?;
+    let target_name = config_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "manifest path is not valid UTF-8: {}",
+                config_path.display()
+            )
+        })?
+        .to_string();
+    let (tx, mut rx) = mpsc::unbounded_channel::<()>();
+    tokio::task::spawn_local(async move {
+        while rx.recv().await.is_some() {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            while rx.try_recv().is_ok() {}
+            let _ = reload.trigger("file_watch");
+        }
+    });
+    let mut watcher =
+        notify::recommended_watcher(move |res: Result<Event, notify::Error>| match res {
+            Ok(event)
+                if matches!(
+                    event.kind,
+                    EventKind::Modify(_)
+                        | EventKind::Create(_)
+                        | EventKind::Remove(_)
+                        | EventKind::Any
+                ) && event.paths.iter().any(|path| {
+                    path.file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(|name| name == target_name)
+                }) =>
+            {
+                let _ = tx.send(());
+            }
+            _ => {}
+        })
+        .map_err(|error| format!("failed to create manifest watcher: {error}"))?;
+    watcher
+        .watch(watch_dir, RecursiveMode::NonRecursive)
+        .map_err(|error| {
+            format!(
+                "failed to watch manifest directory {}: {error}",
+                watch_dir.display()
+            )
+        })?;
+    Ok(watcher)
+}
+
 struct RuntimeSignalCtx<'a> {
     role: OrchestratorRole,
     config_path: &'a Path,
@@ -1586,9 +1662,12 @@ struct RuntimeSignalCtx<'a> {
     event_log_description: &'a harn_vm::event_log::EventLogDescription,
     secret_chain_display: &'a str,
     listener: &'a ListenerRuntime,
-    connectors: &'a ConnectorRuntime,
+    connectors: &'a mut ConnectorRuntime,
     live_manifest: &'a mut Manifest,
     live_triggers: &'a mut Vec<CollectedManifestTrigger>,
+    secret_provider: &'a Arc<dyn harn_vm::secrets::SecretProvider>,
+    metrics_registry: &'a Arc<harn_vm::MetricsRegistry>,
+    reload_rx: &'a mut mpsc::UnboundedReceiver<AdminReloadRequest>,
 }
 
 #[cfg(unix)]
@@ -1612,7 +1691,7 @@ fn install_signal_streams() -> Result<SignalStreams, String> {
 }
 
 async fn wait_for_runtime_signal_loop(
-    ctx: RuntimeSignalCtx<'_>,
+    mut ctx: RuntimeSignalCtx<'_>,
     #[cfg(unix)] mut signals: SignalStreams,
 ) -> Result<(), String> {
     #[cfg(unix)]
@@ -1626,68 +1705,11 @@ async fn wait_for_runtime_signal_loop(
             tokio::select! {
                 _ = sigterm.recv() => return Ok(()),
                 _ = sigint.recv() => return Ok(()),
-                _ = sighup.recv() => {
-                    match reload_manifest(&ctx).await {
-                        Ok(reload) => {
-                            *ctx.live_manifest = reload.manifest;
-                            *ctx.live_triggers = reload.collected_triggers;
-                            let listener_metrics = ctx.listener.trigger_metrics();
-                            write_state_snapshot(
-                                &ctx.state_dir.join(STATE_SNAPSHOT_FILE),
-                                &ServeStateSnapshot {
-                                    status: "running".to_string(),
-                                    role: ctx.role.as_str().to_string(),
-                                    bind: ctx.bind.to_string(),
-                                    manifest_path: ctx.config_path.display().to_string(),
-                                    state_dir: ctx.state_dir.display().to_string(),
-                                    started_at: ctx.startup_started_at.to_string(),
-                                    stopped_at: None,
-                                    secret_provider_chain: ctx.secret_chain_display.to_string(),
-                                    event_log_backend: ctx.event_log_description.backend.to_string(),
-                                    event_log_location: ctx
-                                        .event_log_description
-                                        .location
-                                        .as_ref()
-                                        .map(|path| path.display().to_string()),
-                                    triggers: trigger_state_snapshots(ctx.live_triggers, &listener_metrics),
-                                    connectors: ctx.connectors.providers.clone(),
-                                    activations: ctx
-                                        .connectors
-                                        .activations
-                                        .iter()
-                                        .map(|activation| ConnectorActivationSnapshot {
-                                            provider: activation.provider.as_str().to_string(),
-                                            binding_count: activation.binding_count,
-                                        })
-                                        .collect(),
-                                },
-                            )?;
-                            append_manifest_event(
-                                ctx.event_log,
-                                "reload_succeeded",
-                                serde_json::to_value(&reload.summary).unwrap_or_default(),
-                            )
-                            .await?;
-                            eprintln!(
-                                "[harn] manifest reload applied: +{} ~{} -{}",
-                                reload.summary.added.len(),
-                                reload.summary.modified.len(),
-                                reload.summary.removed.len()
-                            );
-                        }
-                        Err(error) => {
-                            eprintln!("[harn] manifest reload failed: {error}");
-                            append_manifest_event(
-                                ctx.event_log,
-                                "reload_failed",
-                                json!({
-                                    "error": error,
-                                }),
-                            )
-                            .await?;
-                        }
-                    }
-                }
+                _ = sighup.recv() => handle_reload_request(&mut ctx, AdminReloadRequest {
+                    source: "signal".to_string(),
+                    response_tx: None,
+                }).await?,
+                Some(request) = ctx.reload_rx.recv() => handle_reload_request(&mut ctx, request).await?,
             }
         }
     }
@@ -1700,7 +1722,91 @@ async fn wait_for_runtime_signal_loop(
     }
 }
 
-async fn reload_manifest(ctx: &RuntimeSignalCtx<'_>) -> Result<PreparedManifestReload, String> {
+async fn handle_reload_request(
+    ctx: &mut RuntimeSignalCtx<'_>,
+    request: AdminReloadRequest,
+) -> Result<(), String> {
+    let source = request.source.clone();
+    match reload_manifest(ctx).await {
+        Ok(summary) => {
+            write_running_state_snapshot(ctx)?;
+            append_manifest_event(
+                ctx.event_log,
+                "reload_succeeded",
+                json!({
+                    "source": source,
+                    "summary": summary,
+                }),
+            )
+            .await?;
+            eprintln!(
+                "[harn] manifest reload ({source}) applied: +{} ~{} -{}",
+                summary.added.len(),
+                summary.modified.len(),
+                summary.removed.len()
+            );
+            if let Some(response_tx) = request.response_tx {
+                let _ = response_tx.send(
+                    serde_json::to_value(&summary)
+                        .map_err(|error| format!("failed to encode reload summary: {error}")),
+                );
+            }
+        }
+        Err(error) => {
+            eprintln!("[harn] manifest reload ({source}) failed: {error}");
+            append_manifest_event(
+                ctx.event_log,
+                "reload_failed",
+                json!({
+                    "source": source,
+                    "error": error,
+                }),
+            )
+            .await?;
+            if let Some(response_tx) = request.response_tx {
+                let _ = response_tx.send(Err(error));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_running_state_snapshot(ctx: &RuntimeSignalCtx<'_>) -> Result<(), String> {
+    let listener_metrics = ctx.listener.trigger_metrics();
+    write_state_snapshot(
+        &ctx.state_dir.join(STATE_SNAPSHOT_FILE),
+        &ServeStateSnapshot {
+            status: "running".to_string(),
+            role: ctx.role.as_str().to_string(),
+            bind: ctx.bind.to_string(),
+            listener_url: ctx.listener.url(),
+            manifest_path: ctx.config_path.display().to_string(),
+            state_dir: ctx.state_dir.display().to_string(),
+            started_at: ctx.startup_started_at.to_string(),
+            stopped_at: None,
+            secret_provider_chain: ctx.secret_chain_display.to_string(),
+            event_log_backend: ctx.event_log_description.backend.to_string(),
+            event_log_location: ctx
+                .event_log_description
+                .location
+                .as_ref()
+                .map(|path| path.display().to_string()),
+            triggers: trigger_state_snapshots(ctx.live_triggers, &listener_metrics),
+            connectors: ctx.connectors.providers.clone(),
+            activations: ctx
+                .connectors
+                .activations
+                .iter()
+                .map(|activation| ConnectorActivationSnapshot {
+                    provider: activation.provider.as_str().to_string(),
+                    binding_count: activation.binding_count,
+                })
+                .collect(),
+        },
+    )
+}
+
+async fn reload_manifest(ctx: &mut RuntimeSignalCtx<'_>) -> Result<ManifestReloadSummary, String> {
     let (manifest, manifest_dir) = load_manifest(ctx.config_path)?;
     let mut vm = ctx
         .role
@@ -1709,31 +1815,96 @@ async fn reload_manifest(ctx: &RuntimeSignalCtx<'_>) -> Result<PreparedManifestR
     let collected_triggers = package::collect_manifest_triggers(&mut vm, &extensions)
         .await
         .map_err(|error| format!("failed to collect manifest triggers: {error}"))?;
-    ensure_reloadable_trigger_changes(ctx.live_triggers, &collected_triggers)?;
     let summary = summarize_manifest_reload(ctx.live_triggers, &collected_triggers);
+    let connector_reload =
+        connector_reload_fingerprint_map(ctx.live_triggers, &ctx.connectors.provider_overrides)
+            != connector_reload_fingerprint_map(
+                &collected_triggers,
+                &extensions.provider_connectors,
+            );
+    let next_connector_runtime = if connector_reload {
+        let mut runtime = initialize_connectors(
+            &collected_triggers,
+            ctx.event_log.clone(),
+            ctx.secret_provider.clone(),
+            ctx.metrics_registry.clone(),
+            &extensions.provider_connectors,
+        )
+        .await?;
+        runtime.activations = runtime
+            .registry
+            .activate_all(&runtime.trigger_registry)
+            .await
+            .map_err(|error| error.to_string())?;
+        Some(runtime)
+    } else {
+        None
+    };
+    let previous_manifest = ctx.live_manifest.clone();
+    let previous_triggers = ctx.live_triggers.clone();
     package::install_collected_manifest_triggers(&collected_triggers).await?;
     let binding_versions = live_manifest_binding_versions();
-    let route_configs = build_route_configs(&collected_triggers, &binding_versions)?;
-    ctx.listener.reload_routes(route_configs)?;
-    Ok(PreparedManifestReload {
-        manifest,
-        collected_triggers,
-        summary,
-    })
+    let route_registry = next_connector_runtime
+        .as_ref()
+        .map(|runtime| &runtime.registry)
+        .unwrap_or(&ctx.connectors.registry);
+    let route_overrides = next_connector_runtime
+        .as_ref()
+        .map(|runtime| runtime.provider_overrides.as_slice())
+        .unwrap_or(ctx.connectors.provider_overrides.as_slice());
+    let route_configs = match build_route_configs(&collected_triggers, &binding_versions)
+        .and_then(|routes| attach_route_connectors(routes, route_registry, route_overrides))
+    {
+        Ok(routes) => routes,
+        Err(error) => {
+            rollback_manifest_reload(ctx, &previous_manifest, &previous_triggers)
+                .await
+                .map_err(|rollback| format!("{error}; rollback failed: {rollback}"))?;
+            return Err(error);
+        }
+    };
+    if let Err(error) = ctx.listener.reload_routes(route_configs) {
+        rollback_manifest_reload(ctx, &previous_manifest, &previous_triggers)
+            .await
+            .map_err(|rollback| format!("{error}; rollback failed: {rollback}"))?;
+        return Err(error);
+    }
+    if let Some(runtime) = next_connector_runtime {
+        let previous_handles = ctx.connectors.handles.clone();
+        let connector_clients = runtime.registry.client_map().await;
+        harn_vm::install_active_connector_clients(connector_clients);
+        *ctx.connectors = runtime;
+        for handle in previous_handles {
+            let connector = handle.lock().await;
+            if let Err(error) = connector.shutdown(Duration::from_secs(5)).await {
+                eprintln!(
+                    "[harn] connector {} reload shutdown warning: {error}",
+                    connector.provider_id().as_str()
+                );
+            }
+        }
+    }
+    *ctx.live_manifest = manifest;
+    *ctx.live_triggers = collected_triggers;
+    Ok(summary)
 }
 
-fn ensure_reloadable_trigger_changes(
-    current: &[CollectedManifestTrigger],
-    next: &[CollectedManifestTrigger],
+async fn rollback_manifest_reload(
+    ctx: &mut RuntimeSignalCtx<'_>,
+    previous_manifest: &Manifest,
+    previous_triggers: &[CollectedManifestTrigger],
 ) -> Result<(), String> {
-    let current_non_http = trigger_fingerprint_map(current, false);
-    let next_non_http = trigger_fingerprint_map(next, false);
-    if current_non_http != next_non_http {
-        return Err(
-            "SIGHUP reload currently supports manifest-backed HTTP triggers only; connector-managed trigger changes still require restart"
-                .to_string(),
-        );
-    }
+    package::install_collected_manifest_triggers(previous_triggers).await?;
+    let binding_versions = live_manifest_binding_versions();
+    let route_configs = build_route_configs(previous_triggers, &binding_versions)?;
+    let route_configs = attach_route_connectors(
+        route_configs,
+        &ctx.connectors.registry,
+        &ctx.connectors.provider_overrides,
+    )?;
+    ctx.listener.reload_routes(route_configs)?;
+    *ctx.live_manifest = previous_manifest.clone();
+    *ctx.live_triggers = previous_triggers.to_vec();
     Ok(())
 }
 
@@ -1769,6 +1940,61 @@ fn trigger_fingerprint_map(
             (trigger.config.id.clone(), spec.definition_fingerprint)
         })
         .collect()
+}
+
+fn connector_reload_fingerprint_map(
+    triggers: &[CollectedManifestTrigger],
+    provider_overrides: &[ResolvedProviderConnectorConfig],
+) -> BTreeMap<String, Vec<String>> {
+    let mut by_provider = BTreeMap::<String, Vec<String>>::new();
+    for trigger in triggers {
+        let provider = trigger.config.provider.as_str().to_string();
+        if !connector_owns_ingress(&provider, provider_overrides)
+            && matches!(
+                trigger.config.kind,
+                crate::package::TriggerKind::Webhook | crate::package::TriggerKind::A2aPush
+            )
+        {
+            continue;
+        }
+        let spec = package::manifest_trigger_binding_spec(trigger.clone());
+        by_provider
+            .entry(provider)
+            .or_default()
+            .push(spec.definition_fingerprint);
+    }
+    for override_config in provider_overrides {
+        by_provider
+            .entry(override_config.id.as_str().to_string())
+            .or_default()
+            .push(provider_connector_fingerprint(override_config));
+    }
+    for fingerprints in by_provider.values_mut() {
+        fingerprints.sort();
+    }
+    by_provider
+}
+
+fn provider_connector_fingerprint(config: &ResolvedProviderConnectorConfig) -> String {
+    match &config.connector {
+        ResolvedProviderConnectorKind::RustBuiltin => format!(
+            "{}::builtin@{}",
+            config.id.as_str(),
+            config.manifest_dir.display()
+        ),
+        ResolvedProviderConnectorKind::Harn { module } => format!(
+            "{}::harn:{}@{}",
+            config.id.as_str(),
+            module,
+            config.manifest_dir.display()
+        ),
+        ResolvedProviderConnectorKind::Invalid(message) => format!(
+            "{}::invalid:{}@{}",
+            config.id.as_str(),
+            message,
+            config.manifest_dir.display()
+        ),
+    }
 }
 
 fn is_http_managed_trigger(trigger: &CollectedManifestTrigger) -> bool {
@@ -1850,6 +2076,7 @@ fn write_state_snapshot(path: &Path, snapshot: &ServeStateSnapshot) -> Result<()
 struct GracefulShutdownCtx<'a> {
     role: OrchestratorRole,
     bind: SocketAddr,
+    listener_url: String,
     config_path: &'a Path,
     state_dir: &'a Path,
     startup_started_at: &'a str,
@@ -1867,6 +2094,7 @@ struct ServeStateSnapshot {
     status: String,
     role: String,
     bind: String,
+    listener_url: String,
     manifest_path: String,
     state_dir: String,
     started_at: String,

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -1354,6 +1354,246 @@ async fn a2a_push_route_requires_bearer_or_valid_hmac() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn admin_reload_endpoint_applies_manifest_changes() {
+    let _lock = lock_orchestrator_tests();
+    let temp = TempDir::new().unwrap();
+    write_file(temp.path(), "harn.toml", &a2a_manifest(None));
+    write_file(temp.path(), "lib.harn", a2a_handler_module());
+
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_ORCHESTRATOR_API_KEYS", "reload-key"),
+        ("HARN_ORCHESTRATOR_HMAC_SECRET", "shared-secret"),
+    ];
+    let mut process = spawn_orchestrator(&temp, &[], &envs);
+    let base_url = process.wait_for_listener_url();
+
+    let client = reqwest::Client::new();
+    let mut auth_headers = json_headers();
+    auth_headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer reload-key"));
+
+    let original = client
+        .post(format!("{base_url}/a2a/review"))
+        .headers(auth_headers.clone())
+        .body(br#"{"kind":"a2a.task.received","task":{"id":"task-before"}}"#.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_status(original, StatusCode::OK).await;
+
+    write_file(
+        temp.path(),
+        "harn.toml",
+        &a2a_manifest(None).replace("/a2a/review", "/a2a/review-v2"),
+    );
+
+    let reload = client
+        .post(format!("{base_url}/admin/reload"))
+        .headers(auth_headers.clone())
+        .json(&serde_json::json!({"source": "http_test"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(reload.status(), StatusCode::OK);
+    let reload_body: JsonValue = reload.json().await.unwrap();
+    assert_eq!(reload_body["status"], serde_json::json!("ok"));
+    assert_eq!(reload_body["source"], serde_json::json!("http_test"));
+    assert_eq!(
+        reload_body["summary"]["modified"][0],
+        serde_json::json!("incoming-review-task")
+    );
+
+    let updated = client
+        .post(format!("{base_url}/a2a/review-v2"))
+        .headers(auth_headers.clone())
+        .body(br#"{"kind":"a2a.task.received","task":{"id":"task-after"}}"#.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_status(updated, StatusCode::OK).await;
+
+    let retired = client
+        .post(format!("{base_url}/a2a/review"))
+        .headers(auth_headers)
+        .body(br#"{"kind":"a2a.task.received","task":{"id":"task-old"}}"#.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_status(retired, StatusCode::NOT_FOUND).await;
+
+    send_sigterm(&process.child);
+    wait_for_exit(&mut process.child);
+    let snapshot = state_snapshot(&temp);
+    assert!(snapshot.contains("\"listener_url\""), "snapshot={snapshot}");
+    assert!(snapshot.contains("\"version\": 2"), "snapshot={snapshot}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn admin_reload_invalid_manifest_keeps_existing_routes_live() {
+    let _lock = lock_orchestrator_tests();
+    let temp = TempDir::new().unwrap();
+    write_file(temp.path(), "harn.toml", &a2a_manifest(None));
+    write_file(temp.path(), "lib.harn", a2a_handler_module());
+
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_ORCHESTRATOR_API_KEYS", "reload-key"),
+        ("HARN_ORCHESTRATOR_HMAC_SECRET", "shared-secret"),
+    ];
+    let mut process = spawn_orchestrator(&temp, &[], &envs);
+    let base_url = process.wait_for_listener_url();
+
+    let client = reqwest::Client::new();
+    let mut auth_headers = json_headers();
+    auth_headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer reload-key"));
+
+    write_file(
+        temp.path(),
+        "harn.toml",
+        "[package]\nname = \"broken\"\n[[triggers]]\nid = ",
+    );
+
+    let reload = client
+        .post(format!("{base_url}/admin/reload"))
+        .headers(auth_headers.clone())
+        .json(&serde_json::json!({"source": "http_test_invalid"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(reload.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body = reload.text().await.unwrap();
+    assert!(body.contains("error"), "{body}");
+
+    let still_live = client
+        .post(format!("{base_url}/a2a/review"))
+        .headers(auth_headers)
+        .body(br#"{"kind":"a2a.task.received","task":{"id":"task-still-live"}}"#.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_status(still_live, StatusCode::OK).await;
+
+    send_sigterm(&process.child);
+    wait_for_exit(&mut process.child);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn watch_mode_reloads_manifest_changes() {
+    let _lock = lock_orchestrator_tests();
+    let temp = TempDir::new().unwrap();
+    write_file(temp.path(), "harn.toml", &a2a_manifest(None));
+    write_file(temp.path(), "lib.harn", a2a_handler_module());
+
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_ORCHESTRATOR_API_KEYS", "reload-key"),
+        ("HARN_ORCHESTRATOR_HMAC_SECRET", "shared-secret"),
+    ];
+    let mut process = spawn_orchestrator(&temp, &["--watch"], &envs);
+    let base_url = process.wait_for_listener_url();
+
+    write_file(
+        temp.path(),
+        "harn.toml",
+        &a2a_manifest(None).replace("/a2a/review", "/a2a/review-watch"),
+    );
+
+    let client = reqwest::Client::new();
+    let mut auth_headers = json_headers();
+    auth_headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer reload-key"));
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let response = client
+            .post(format!("{base_url}/a2a/review-watch"))
+            .headers(auth_headers.clone())
+            .body(br#"{"kind":"a2a.task.received","task":{"id":"task-watch"}}"#.to_vec())
+            .send()
+            .await
+            .unwrap();
+        if response.status() == StatusCode::OK {
+            break;
+        }
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert!(Instant::now() < deadline, "watch reload never applied");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let retired = client
+        .post(format!("{base_url}/a2a/review"))
+        .headers(auth_headers)
+        .body(br#"{"kind":"a2a.task.received","task":{"id":"task-old"}}"#.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_status(retired, StatusCode::NOT_FOUND).await;
+
+    send_sigterm(&process.child);
+    wait_for_exit(&mut process.child);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reload_cli_uses_admin_endpoint() {
+    let _lock = lock_orchestrator_tests();
+    let temp = TempDir::new().unwrap();
+    write_file(temp.path(), "harn.toml", &a2a_manifest(None));
+    write_file(temp.path(), "lib.harn", a2a_handler_module());
+
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_ORCHESTRATOR_API_KEYS", "reload-key"),
+        ("HARN_ORCHESTRATOR_HMAC_SECRET", "shared-secret"),
+    ];
+    let mut process = spawn_orchestrator(&temp, &[], &envs);
+    let base_url = process.wait_for_listener_url();
+
+    write_file(
+        temp.path(),
+        "harn.toml",
+        &a2a_manifest(None).replace("/a2a/review", "/a2a/review-cli"),
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .arg("orchestrator")
+        .arg("reload")
+        .arg("--config")
+        .arg("harn.toml")
+        .arg("--state-dir")
+        .arg("./state")
+        .envs(envs)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "status={:?} stdout={} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("reload ok"),
+        "stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let client = reqwest::Client::new();
+    let mut auth_headers = json_headers();
+    auth_headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer reload-key"));
+    let updated = client
+        .post(format!("{base_url}/a2a/review-cli"))
+        .headers(auth_headers)
+        .body(br#"{"kind":"a2a.task.received","task":{"id":"task-cli"}}"#.to_vec())
+        .send()
+        .await
+        .unwrap();
+    assert_status(updated, StatusCode::OK).await;
+
+    send_sigterm(&process.child);
+    wait_for_exit(&mut process.child);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn tls_listener_serves_https_with_supplied_cert_and_key() {
     let _lock = lock_orchestrator_tests();
     let temp = TempDir::new().unwrap();

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -61,6 +61,7 @@
 - [Orchestrator MCP server](./mcp-server.md)
 - [Harn portal](./portal.md)
 - [Orchestrator](./orchestrator.md)
+- [Hot reload](./orchestrator/hot-reload.md)
 - [Worker dispatch](./orchestrator/worker-dispatch.md)
 - [Orchestrator secrets](./orchestrator/secrets.md)
 

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -67,19 +67,27 @@ the queue with `harn orchestrator queue drain triage`. See
 `HARN_ORCHESTRATOR_STATE_DIR`, `HARN_ORCHESTRATOR_CERT`, and
 `HARN_ORCHESTRATOR_KEY`.
 
-On Unix, `SIGHUP` reloads manifest-backed HTTP trigger bindings without
-rebinding the socket. The orchestrator reparses `harn.toml`,
-re-collects manifest triggers, installs a new manifest binding version
-for changed `webhook` / `a2a-push` entries, and swaps the live listener
-route table in place. Requests already in flight keep the binding
-version they started with; new requests route to the newest active
-binding version. The orchestrator records `reload_succeeded` /
-`reload_failed` events on `orchestrator.manifest` and refreshes
-`orchestrator-state.json` after a successful reload.
+Hot reload now supports four equivalent entrypoints:
 
-Current reload scope is intentionally narrow: listener-wide settings
-such as `--bind`, TLS files, `allowed_origins`, `max_body_bytes`, and
-connector-managed trigger changes still require a full restart.
+- `SIGHUP` on Unix
+- `harn orchestrator reload`
+- authenticated `POST /admin/reload`
+- `harn orchestrator serve --watch` for manifest file changes
+
+Each path reparses `harn.toml`, re-collects manifest triggers, prepares
+connector changes off to the side, then swaps the live binding set in
+place. Requests already in flight keep the binding version they started
+with; new requests route to the newest active binding version. If the
+new manifest is invalid, a handler export no longer resolves, or a
+connector cannot initialize/activate, the reload is rejected and the
+existing bindings stay live.
+
+The orchestrator records `reload_succeeded` / `reload_failed` events on
+`orchestrator.manifest`, refreshes `orchestrator-state.json` after a
+successful reload, and now includes `listener_url` in that snapshot so
+local tooling can target the running admin API. See
+[Hot reload](./orchestrator/hot-reload.md) for the full workflow and
+operator-facing details.
 
 ## Recovery
 

--- a/docs/src/orchestrator/hot-reload.md
+++ b/docs/src/orchestrator/hot-reload.md
@@ -1,0 +1,65 @@
+# Hot reload
+
+Hot reload lets a running orchestrator adopt a new `harn.toml` without
+dropping in-flight trigger deliveries.
+
+## Entry points
+
+Use any of these:
+
+- send `SIGHUP` to the orchestrator process
+- run `harn orchestrator reload --config harn.toml --state-dir ./.harn/orchestrator`
+- `POST /admin/reload` with the same bearer/HMAC auth used by `a2a-push`
+- start the orchestrator with `--watch` to reload automatically when the
+  manifest file changes
+
+`harn orchestrator reload` discovers the running listener URL from
+`orchestrator-state.json` by default. Pass `--admin-url` to target a
+different instance explicitly.
+
+## What reload does
+
+Each reload path runs the same sequence:
+
+1. Parse and validate the new manifest.
+2. Resolve handlers and predicates in a fresh VM.
+3. Prepare connector replacements before touching live bindings.
+4. Reconcile manifest trigger ids into added, removed, modified, and
+   unchanged bindings.
+5. Drain old binding versions, activate new ones, and swap listener
+   routes in place.
+6. Publish `reload_succeeded` or `reload_failed` on
+   `orchestrator.manifest`.
+
+If any step before the final swap fails, the running orchestrator keeps
+serving the old manifest.
+
+## Safety model
+
+- In-flight requests keep the binding version they started with.
+- New requests route to the newest active binding version.
+- Removed bindings stop accepting new work and drain until their
+  in-flight count reaches zero.
+- Connector reload is staged: the orchestrator initializes and activates
+  replacement connectors before swapping them into the live runtime.
+- If connector activation or route replacement fails, the orchestrator
+  rolls back to the previous manifest/runtime view.
+
+## Auth
+
+`POST /admin/reload` uses the same auth helpers as `a2a-push` routes:
+
+- `Authorization: Bearer <api-key>` where the key comes from
+  `HARN_ORCHESTRATOR_API_KEYS`
+- `Authorization: HMAC-SHA256 ...` using
+  `HARN_ORCHESTRATOR_HMAC_SECRET`
+
+The CLI wrapper prefers the first configured API key and falls back to
+the shared HMAC secret when no API key is present.
+
+## Watch mode
+
+`harn orchestrator serve --watch` watches the manifest directory and
+debounces reload requests for short bursts of file events. It is useful
+for local development and test harnesses; production deployments usually
+prefer explicit `SIGHUP` or the admin API.


### PR DESCRIPTION
## Summary
- add a shared orchestrator hot-reload pipeline that serves SIGHUP, `harn orchestrator reload`, authenticated `POST /admin/reload`, and `serve --watch`
- support connector-aware staged reload with rollback, plus new conformance and HTTP coverage for add/remove/modify and invalid-manifest safety
- document the operator workflow in a dedicated hot-reload page and update the main orchestrator guide

## Testing
- `CARGO_TARGET_DIR=/tmp/harn-target-2d0f cargo check -p harn-cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-2d0f cargo test -p harn-cli --test orchestrator_http -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2d0f cargo test -p harn-cli reload_swaps_routes_without_losing_inflight_request -- --nocapture`
- `HARN_CONFORMANCE_HARN_BIN=/tmp/harn-target-2d0f/debug/harn CARGO_TARGET_DIR=/tmp/harn-target-2d0f cargo run --bin harn -- test conformance --filter orchestrator_hot_reload_`

Fixes #187.
