### PR TITLE
Add structural prompt experiment framework

### DIFF
--- a/conformance/tests/integration/llm_structural_experiments.expected
+++ b/conformance/tests/integration/llm_structural_experiments.expected
@@ -1,0 +1,9 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/integration/llm_structural_experiments.harn
+++ b/conformance/tests/integration/llm_structural_experiments.harn
@@ -1,0 +1,56 @@
+import "std/experiments"
+
+pipeline main() {
+  llm_mock({text: "one"})
+  llm_mock({text: "two"})
+  llm_mock({text: "three"})
+  llm_mock({text: "four"})
+  llm_mock({text: "five"})
+
+  let custom_exp = custom(
+    "tail_echo",
+    { ctx ->
+      let latest = latest_string_user_message(ctx.messages)
+      let rewritten = replace_message(
+        ctx.messages,
+        latest.index,
+        message("user", latest.message.content + "\n\nTAIL"),
+      )
+      return {messages: rewritten, metadata: {kind: "tail_echo"}}
+    },
+  )
+
+  llm_call("alpha\n\nbeta\n\ngamma", nil, {
+    provider: "mock",
+    structural_experiment: "prompt_order_permutation(seed: 42)",
+  })
+  llm_call("hello", nil, {
+    provider: "mock",
+    structural_experiment: "doubled_prompt",
+  })
+  llm_call("user prompt", "system prompt", {
+    provider: "mock",
+    structural_experiment: "inverted_system",
+  })
+  llm_call("final answer", nil, {
+    provider: "mock",
+    structural_experiment: chain_of_draft(),
+  })
+  let custom_result = llm_call("custom body", nil, {
+    provider: "mock",
+    structural_experiment: custom_exp,
+  })
+
+  let calls = llm_mock_calls()
+  println(calls[0].messages[0].content != "alpha\n\nbeta\n\ngamma")
+  println(len(calls[1].messages) == 3)
+  println(calls[1].messages[0].content == "hello")
+  println(calls[1].messages[2].content == "hello")
+  println(calls[2].system == "user prompt")
+  println(calls[2].messages[0].content == "system prompt")
+  println(contains(calls[3].messages[0].content, "<draft>"))
+  println(contains(calls[4].messages[0].content, "TAIL"))
+
+  let provider_events = transcript_events_by_kind(custom_result.transcript, "provider_payload")
+  println(provider_events[0].metadata.structural_experiment.label == "tail_echo")
+}

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -1133,6 +1133,27 @@ pub(crate) struct EvalArgs {
     /// Optional baseline run record for diffing.
     #[arg(long)]
     pub compare: Option<String>,
+    /// Run a pipeline twice and compare the baseline against this structural experiment.
+    #[arg(long = "structural-experiment")]
+    pub structural_experiment: Option<String>,
+    /// Replay LLM responses from a JSONL fixture file when `path` is a `.harn` pipeline.
+    #[arg(
+        long = "llm-mock",
+        value_name = "PATH",
+        conflicts_with = "llm_mock_record"
+    )]
+    pub llm_mock: Option<String>,
+    /// Record executed LLM responses into a JSONL fixture file when `path` is a `.harn` pipeline.
+    #[arg(
+        long = "llm-mock-record",
+        value_name = "PATH",
+        conflicts_with = "llm_mock"
+    )]
+    pub llm_mock_record: Option<String>,
+    /// Positional arguments forwarded to `harn run <pipeline.harn> -- ...` when
+    /// `path` is a pipeline file and `--structural-experiment` is set.
+    #[arg(last = true)]
+    pub argv: Vec<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -424,7 +424,26 @@ async fn main() {
             }
         },
         Command::Replay(args) => replay_run_record(&args.path),
-        Command::Eval(args) => eval_run_record(&args.path, args.compare.as_deref()),
+        Command::Eval(args) => {
+            let llm_mock_mode = if let Some(path) = args.llm_mock.as_ref() {
+                commands::run::CliLlmMockMode::Replay {
+                    fixture_path: PathBuf::from(path),
+                }
+            } else if let Some(path) = args.llm_mock_record.as_ref() {
+                commands::run::CliLlmMockMode::Record {
+                    fixture_path: PathBuf::from(path),
+                }
+            } else {
+                commands::run::CliLlmMockMode::Off
+            };
+            eval_run_record(
+                &args.path,
+                args.compare.as_deref(),
+                args.structural_experiment.as_deref(),
+                &args.argv,
+                &llm_mock_mode,
+            )
+        }
         Command::Repl => commands::repl::run_repl().await,
         Command::Bench(args) => commands::bench::run_bench(&args.file, args.iterations).await,
         Command::Viz(args) => commands::viz::run_viz(&args.file, args.output.as_deref()),
@@ -796,7 +815,41 @@ fn replay_run_record(path: &str) {
     }
 }
 
-fn eval_run_record(path: &str, compare: Option<&str>) {
+fn eval_run_record(
+    path: &str,
+    compare: Option<&str>,
+    structural_experiment: Option<&str>,
+    argv: &[String],
+    llm_mock_mode: &commands::run::CliLlmMockMode,
+) {
+    if let Some(experiment) = structural_experiment {
+        let path_buf = PathBuf::from(path);
+        if !path_buf.is_file() || path_buf.extension().and_then(|ext| ext.to_str()) != Some("harn")
+        {
+            eprintln!(
+                "--structural-experiment currently requires a .harn pipeline path, got {}",
+                path
+            );
+            process::exit(1);
+        }
+        if compare.is_some() {
+            eprintln!("--compare cannot be combined with --structural-experiment");
+            process::exit(1);
+        }
+        if matches!(llm_mock_mode, commands::run::CliLlmMockMode::Record { .. }) {
+            eprintln!("--llm-mock-record cannot be combined with --structural-experiment");
+            process::exit(1);
+        }
+        let path_buf = fs::canonicalize(&path_buf).unwrap_or_else(|error| {
+            command_error(&format!(
+                "failed to canonicalize structural eval pipeline {}: {error}",
+                path_buf.display()
+            ))
+        });
+        run_structural_experiment_eval(&path_buf, experiment, argv, llm_mock_mode);
+        return;
+    }
+
     let path_buf = PathBuf::from(path);
     if path_buf.is_file() && file_looks_like_eval_manifest(&path_buf) {
         if compare.is_some() {
@@ -911,6 +964,218 @@ fn eval_run_record(path: &str, compare: Option<&str>) {
     if !report.pass {
         process::exit(1);
     }
+}
+
+fn run_structural_experiment_eval(
+    path: &Path,
+    experiment: &str,
+    argv: &[String],
+    llm_mock_mode: &commands::run::CliLlmMockMode,
+) {
+    let baseline_dir = tempfile::Builder::new()
+        .prefix("harn-eval-baseline-")
+        .tempdir()
+        .unwrap_or_else(|error| {
+            command_error(&format!("failed to create baseline tempdir: {error}"))
+        });
+    let variant_dir = tempfile::Builder::new()
+        .prefix("harn-eval-variant-")
+        .tempdir()
+        .unwrap_or_else(|error| {
+            command_error(&format!("failed to create variant tempdir: {error}"))
+        });
+
+    let baseline = spawn_eval_pipeline_run(path, baseline_dir.path(), None, argv, llm_mock_mode);
+    if !baseline.status.success() {
+        relay_subprocess_failure("baseline", &baseline);
+    }
+
+    let variant = spawn_eval_pipeline_run(
+        path,
+        variant_dir.path(),
+        Some(experiment),
+        argv,
+        llm_mock_mode,
+    );
+    if !variant.status.success() {
+        relay_subprocess_failure("variant", &variant);
+    }
+
+    let baseline_runs = collect_structural_eval_runs(baseline_dir.path());
+    let variant_runs = collect_structural_eval_runs(variant_dir.path());
+    if baseline_runs.is_empty() || variant_runs.is_empty() {
+        eprintln!(
+            "structural eval expected workflow run records under {} and {}, but one side was empty",
+            baseline_dir.path().display(),
+            variant_dir.path().display()
+        );
+        process::exit(1);
+    }
+    if baseline_runs.len() != variant_runs.len() {
+        eprintln!(
+            "structural eval produced different run counts: baseline={} variant={}",
+            baseline_runs.len(),
+            variant_runs.len()
+        );
+        process::exit(1);
+    }
+
+    let mut baseline_ok = 0usize;
+    let mut variant_ok = 0usize;
+    let mut any_failures = false;
+
+    println!("Structural experiment: {}", experiment);
+    println!("Cases: {}", baseline_runs.len());
+    for (baseline_run, variant_run) in baseline_runs.iter().zip(variant_runs.iter()) {
+        let baseline_fixture = baseline_run
+            .replay_fixture
+            .clone()
+            .unwrap_or_else(|| harn_vm::orchestration::replay_fixture_from_run(baseline_run));
+        let variant_fixture = variant_run
+            .replay_fixture
+            .clone()
+            .unwrap_or_else(|| harn_vm::orchestration::replay_fixture_from_run(variant_run));
+        let baseline_report =
+            harn_vm::orchestration::evaluate_run_against_fixture(baseline_run, &baseline_fixture);
+        let variant_report =
+            harn_vm::orchestration::evaluate_run_against_fixture(variant_run, &variant_fixture);
+        let diff = harn_vm::orchestration::diff_run_records(baseline_run, variant_run);
+        if baseline_report.pass {
+            baseline_ok += 1;
+        }
+        if variant_report.pass {
+            variant_ok += 1;
+        }
+        any_failures |= !baseline_report.pass || !variant_report.pass;
+        println!(
+            "- {} [{}]",
+            variant_run
+                .workflow_name
+                .clone()
+                .unwrap_or_else(|| variant_run.workflow_id.clone()),
+            variant_run.task
+        );
+        println!(
+            "  baseline: {}",
+            if baseline_report.pass { "PASS" } else { "FAIL" }
+        );
+        for failure in &baseline_report.failures {
+            println!("    {}", failure);
+        }
+        println!(
+            "  variant: {}",
+            if variant_report.pass { "PASS" } else { "FAIL" }
+        );
+        for failure in &variant_report.failures {
+            println!("    {}", failure);
+        }
+        println!("  diff identical: {}", diff.identical);
+        println!("  stage diffs: {}", diff.stage_diffs.len());
+        println!("  tool diffs: {}", diff.tool_diffs.len());
+        println!("  observability diffs: {}", diff.observability_diffs.len());
+    }
+
+    println!("Baseline {} / {} passed", baseline_ok, baseline_runs.len());
+    println!("Variant {} / {} passed", variant_ok, variant_runs.len());
+
+    if any_failures {
+        process::exit(1);
+    }
+}
+
+fn spawn_eval_pipeline_run(
+    path: &Path,
+    run_dir: &Path,
+    structural_experiment: Option<&str>,
+    argv: &[String],
+    llm_mock_mode: &commands::run::CliLlmMockMode,
+) -> std::process::Output {
+    let exe = env::current_exe().unwrap_or_else(|error| {
+        command_error(&format!("failed to resolve current executable: {error}"))
+    });
+    let mut command = std::process::Command::new(exe);
+    command.current_dir(path.parent().unwrap_or_else(|| Path::new(".")));
+    command.arg("run");
+    match llm_mock_mode {
+        commands::run::CliLlmMockMode::Off => {}
+        commands::run::CliLlmMockMode::Replay { fixture_path } => {
+            command
+                .arg("--llm-mock")
+                .arg(absolute_cli_path(fixture_path));
+        }
+        commands::run::CliLlmMockMode::Record { fixture_path } => {
+            command
+                .arg("--llm-mock-record")
+                .arg(absolute_cli_path(fixture_path));
+        }
+    }
+    command.arg(path);
+    if !argv.is_empty() {
+        command.arg("--");
+        command.args(argv);
+    }
+    command.env(harn_vm::runtime_paths::HARN_RUN_DIR_ENV, run_dir);
+    if let Some(experiment) = structural_experiment {
+        command.env("HARN_STRUCTURAL_EXPERIMENT", experiment);
+    }
+    command.output().unwrap_or_else(|error| {
+        command_error(&format!(
+            "failed to spawn `harn run {}` for structural eval: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn absolute_cli_path(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(path)
+}
+
+fn relay_subprocess_failure(label: &str, output: &std::process::Output) -> ! {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stdout.trim().is_empty() {
+        eprintln!("[{label}] stdout:\n{stdout}");
+    }
+    if !stderr.trim().is_empty() {
+        eprintln!("[{label}] stderr:\n{stderr}");
+    }
+    process::exit(output.status.code().unwrap_or(1));
+}
+
+fn collect_structural_eval_runs(dir: &Path) -> Vec<harn_vm::orchestration::RunRecord> {
+    let mut paths: Vec<PathBuf> = fs::read_dir(dir)
+        .unwrap_or_else(|error| {
+            command_error(&format!(
+                "failed to read structural eval run dir {}: {error}",
+                dir.display()
+            ))
+        })
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|entry| entry.extension().and_then(|ext| ext.to_str()) == Some("json"))
+        .collect();
+    paths.sort();
+    let mut runs: Vec<_> = paths
+        .iter()
+        .map(|path| load_run_record_or_exit(path))
+        .collect();
+    runs.sort_by(|left, right| {
+        (
+            left.started_at.as_str(),
+            left.workflow_id.as_str(),
+            left.task.as_str(),
+        )
+            .cmp(&(
+                right.started_at.as_str(),
+                right.workflow_id.as_str(),
+                right.task.as_str(),
+            ))
+    });
+    runs
 }
 
 /// Parse a .harn file, returning (source, AST). Exits on error.

--- a/crates/harn-cli/tests/llm_mock_cli.rs
+++ b/crates/harn-cli/tests/llm_mock_cli.rs
@@ -617,3 +617,57 @@ pipeline default() {
     );
     assert!(stdout(&output).contains("matched summary"));
 }
+
+#[test]
+fn eval_runs_baseline_and_structural_variant_for_pipeline_file() {
+    let temp = TempDir::new().unwrap();
+    let script = write_file(
+        temp.path(),
+        "eval_structural.harn",
+        r#"
+import "std/agents"
+
+pipeline default() {
+  let flow = workflow({
+    name: "structural-eval",
+    persistent: false,
+    act: {mode: "llm"},
+  })
+  let result = task_run("alpha\n\nbeta", flow, {provider: env_or("TEST_PROVIDER", "mock")})
+  println(result?.status)
+}
+"#,
+    );
+    let fixtures = write_file(
+        temp.path(),
+        "fixtures.jsonl",
+        r#"{"text":"baseline","model":"fixture-model"}
+{"text":"variant","model":"fixture-model"}
+"#,
+    );
+
+    let output = run_harn(
+        &temp,
+        &[
+            "eval",
+            "--llm-mock",
+            &fixtures,
+            "--structural-experiment",
+            "doubled_prompt",
+            &script,
+        ],
+        &[("TEST_PROVIDER", "anthropic")],
+    );
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        stdout(&output),
+        stderr(&output)
+    );
+    let out = stdout(&output);
+    assert!(out.contains("Structural experiment: doubled_prompt"));
+    assert!(out.contains("Baseline 1 / 1 passed"));
+    assert!(out.contains("Variant 1 / 1 passed"));
+}

--- a/crates/harn-modules/src/stdlib.rs
+++ b/crates/harn-modules/src/stdlib.rs
@@ -24,6 +24,7 @@ pub(crate) fn get_stdlib_source(module: &str) -> Option<&'static str> {
         "context" => Some(include_str!("../../harn-vm/src/stdlib_context.harn")),
         "runtime" => Some(include_str!("../../harn-vm/src/stdlib_runtime.harn")),
         "review" => Some(include_str!("../../harn-vm/src/stdlib_review.harn")),
+        "experiments" => Some(include_str!("../../harn-vm/src/stdlib_experiments.harn")),
         "project" => Some(include_str!("../../harn-vm/src/stdlib_project.harn")),
         "async" => Some(include_str!("../../harn-vm/src/stdlib_async.harn")),
         "agents" => Some(include_str!("../../harn-vm/src/stdlib_agents.harn")),

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -121,6 +121,7 @@ pub(super) async fn run_llm_call(
             "output_tokens": result.output_tokens,
             "tool_calls": result.tool_calls,
             "tool_calling_mode": ctx.tool_format,
+            "structural_experiment": opts.applied_structural_experiment.as_ref(),
         })),
     ));
     if let Some(thinking) = result.thinking.clone() {

--- a/crates/harn-vm/src/llm/agent/tests/mod.rs
+++ b/crates/harn-vm/src/llm/agent/tests/mod.rs
@@ -70,6 +70,8 @@ pub(super) fn base_opts(messages: Vec<serde_json::Value>) -> LlmCallOptions {
         stream: true,
         provider_overrides: None,
         prefill: None,
+        structural_experiment: None,
+        applied_structural_experiment: None,
     }
 }
 

--- a/crates/harn-vm/src/llm/agent/turn_preflight.rs
+++ b/crates/harn-vm/src/llm/agent/turn_preflight.rs
@@ -184,6 +184,13 @@ pub(super) async fn run_turn_preflight(
         }));
     }
 
+    opts.messages = call_messages;
+    opts.system = call_system;
+    let _ =
+        crate::llm::structural_experiments::apply_structural_experiment(opts, Some(ctx.iteration))
+            .await?;
+    call_messages = opts.messages.clone();
+
     crate::llm::api::debug_log_message_shapes(
         &format!("agent iteration={} preflight", ctx.iteration),
         &call_messages,
@@ -197,7 +204,6 @@ pub(super) async fn run_turn_preflight(
     state.rebuild_scoped_native_tools(opts);
 
     opts.messages = call_messages;
-    opts.system = call_system;
     Ok(())
 }
 

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -125,6 +125,7 @@ pub(crate) fn agent_loop_result_from_llm(
             "input_tokens": result.input_tokens,
             "output_tokens": result.output_tokens,
             "tool_calls": result.tool_calls.clone(),
+            "structural_experiment": opts.applied_structural_experiment.as_ref(),
         })),
     )];
     if let Some(thinking) = result.thinking.clone() {
@@ -185,6 +186,7 @@ pub(crate) fn build_llm_call_result(
             "input_tokens": result.input_tokens,
             "output_tokens": result.output_tokens,
             "tool_calls": result.tool_calls.clone(),
+            "structural_experiment": opts.applied_structural_experiment.as_ref(),
         })),
     )];
     if let Some(thinking) = result.thinking.clone() {
@@ -541,13 +543,16 @@ pub fn register_llm_call_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Host
     vm.register_async_builtin("llm_call", move |args| {
         let bridge = b.clone();
         async move {
-            let opts = extract_llm_options(&args)?;
+            let mut opts = extract_llm_options(&args)?;
             let options = args.get(2).and_then(|a| a.as_dict()).cloned();
             let user_visible = opt_bool(&options, "user_visible");
             let retry_config = LlmRetryConfig {
                 retries: opt_int(&options, "llm_retries").unwrap_or(0) as usize,
                 backoff_ms: opt_int(&options, "llm_backoff_ms").unwrap_or(2000) as u64,
             };
+            let _ =
+                crate::llm::structural_experiments::apply_structural_experiment(&mut opts, None)
+                    .await?;
 
             let result = observed_llm_call(
                 &opts,

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -347,6 +347,13 @@ pub(super) fn dump_llm_request(
         crate::llm::tools::collect_tool_schemas(opts.tools.as_ref(), opts.native_tools.as_deref());
     emit_tool_schemas_if_changed(&tool_schemas);
 
+    let structural_experiment = opts
+        .applied_structural_experiment
+        .as_ref()
+        .map(serde_json::to_value)
+        .transpose()
+        .unwrap_or(None)
+        .unwrap_or(serde_json::Value::Null);
     append_llm_transcript_entry(&serde_json::json!({
         "type": "provider_call_request",
         "iteration": iteration,
@@ -361,6 +368,7 @@ pub(super) fn dump_llm_request(
         "tool_format": tool_format,
         "native_tool_count": opts.native_tools.as_ref().map(|tools| tools.len()).unwrap_or(0),
         "message_count": opts.messages.len(),
+        "structural_experiment": structural_experiment,
     }));
 }
 
@@ -369,7 +377,13 @@ pub(super) fn dump_llm_response(
     call_id: &str,
     result: &super::api::LlmResult,
     response_ms: u64,
+    structural_experiment: Option<&crate::llm::structural_experiments::AppliedStructuralExperiment>,
 ) {
+    let structural_experiment = structural_experiment
+        .map(serde_json::to_value)
+        .transpose()
+        .unwrap_or(None)
+        .unwrap_or(serde_json::Value::Null);
     append_llm_transcript_entry(&serde_json::json!({
         "type": "provider_call_response",
         "iteration": iteration,
@@ -387,6 +401,7 @@ pub(super) fn dump_llm_response(
         "cache_hit": result.cache_read_tokens > 0,
         "thinking": result.thinking,
         "response_ms": response_ms,
+        "structural_experiment": structural_experiment,
     }));
 }
 
@@ -554,7 +569,22 @@ pub(crate) async fn observed_llm_call(
                     ("input_tokens", serde_json::json!(result.input_tokens)),
                     ("output_tokens", serde_json::json!(result.output_tokens)),
                 ]);
-                dump_llm_response(iteration.unwrap_or(0), &call_id, &result, duration_ms);
+                dump_llm_response(
+                    iteration.unwrap_or(0),
+                    &call_id,
+                    &result,
+                    duration_ms,
+                    opts.applied_structural_experiment.as_ref(),
+                );
+                annotate_current_span(&[(
+                    "structural_experiment",
+                    opts.applied_structural_experiment
+                        .as_ref()
+                        .map(serde_json::to_value)
+                        .transpose()
+                        .unwrap_or(None)
+                        .unwrap_or(serde_json::Value::Null),
+                )]);
                 if let Some(b) = bridge {
                     b.send_call_end(
                         &call_id,
@@ -567,6 +597,7 @@ pub(crate) async fn observed_llm_call(
                             "input_tokens": result.input_tokens,
                             "output_tokens": result.output_tokens,
                             "user_visible": user_visible,
+                            "structural_experiment": opts.applied_structural_experiment.as_ref(),
                         }),
                     );
                 }

--- a/crates/harn-vm/src/llm/api/options.rs
+++ b/crates/harn-vm/src/llm/api/options.rs
@@ -253,6 +253,13 @@ pub(crate) struct LlmCallOptions {
     /// See `llm::providers::anthropic` and `llm::providers::openai_compat`
     /// for provider-specific plumbing.
     pub prefill: Option<String>,
+    /// Optional prompt-structure transform applied immediately before
+    /// each provider call.
+    pub structural_experiment:
+        Option<crate::llm::structural_experiments::StructuralExperimentConfig>,
+    /// Metadata for the transform actually applied to this call.
+    pub applied_structural_experiment:
+        Option<crate::llm::structural_experiments::AppliedStructuralExperiment>,
 }
 
 /// Resolve effective request timeout: explicit value > `HARN_LLM_TIMEOUT` env > 120s default.
@@ -373,6 +380,8 @@ pub(super) fn base_opts(provider: &str) -> LlmCallOptions {
         idle_timeout: None,
         provider_overrides: Some(serde_json::json!({"custom_flag": true})),
         prefill: None,
+        structural_experiment: None,
+        applied_structural_experiment: None,
     }
 }
 

--- a/crates/harn-vm/src/llm/helpers/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/mod.rs
@@ -9,7 +9,9 @@ use std::collections::BTreeMap;
 
 use crate::value::VmValue;
 
-pub(crate) use messages::{vm_add_role_message, vm_message_value, vm_messages_to_json};
+pub(crate) use messages::{
+    json_messages_to_vm, vm_add_role_message, vm_message_value, vm_messages_to_json,
+};
 pub(crate) use opt_get::{opt_bool, opt_float, opt_int, opt_str};
 pub(crate) use options::{
     expects_structured_output, extract_json, extract_llm_options, opt_str_list,

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -398,6 +398,8 @@ pub(crate) fn extract_llm_options(
                 }
             }
         });
+    let structural_experiment =
+        crate::llm::structural_experiments::parse_structural_experiment_option(options.as_ref())?;
 
     let opts = LlmCallOptions {
         provider,
@@ -429,6 +431,8 @@ pub(crate) fn extract_llm_options(
         stream,
         provider_overrides,
         prefill,
+        structural_experiment,
+        applied_structural_experiment: None,
     };
 
     validate_options(&opts);

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod daemon;
 pub(crate) mod helpers;
 pub(crate) mod ledger;
 pub(crate) mod mock;
+pub(crate) mod structural_experiments;
 pub(crate) mod tool_search;
 mod transcript_stats;
 
@@ -382,6 +383,7 @@ pub(crate) async fn execute_llm_call(
     mut opts: api::LlmCallOptions,
     options: Option<std::collections::BTreeMap<String, VmValue>>,
 ) -> Result<VmValue, VmError> {
+    let _ = structural_experiments::apply_structural_experiment(&mut opts, None).await?;
     // Default `llm_retries` to 2 for resilience against transient
     // HTTP / provider failures. Pass `llm_retries: 0` to opt out.
     let retry_config = agent_observe::LlmRetryConfig {
@@ -1024,6 +1026,8 @@ mod tests {
             idle_timeout: None,
             provider_overrides: None,
             prefill: None,
+            structural_experiment: None,
+            applied_structural_experiment: None,
         }
     }
 

--- a/crates/harn-vm/src/llm/structural_experiments.rs
+++ b/crates/harn-vm/src/llm/structural_experiments.rs
@@ -1,0 +1,557 @@
+use std::collections::BTreeMap;
+
+use crate::value::{VmError, VmValue};
+
+#[derive(Clone, Debug)]
+pub(crate) enum StructuralExperimentHandler {
+    BuiltIn(BuiltInStructuralExperiment),
+    Closure(VmValue),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum BuiltInStructuralExperiment {
+    PromptOrderPermutation { seed: i64 },
+    DoubledPrompt,
+    ChainOfDraft,
+    InvertedSystem,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct StructuralExperimentConfig {
+    pub label: String,
+    pub name: String,
+    pub args: serde_json::Value,
+    pub handler: StructuralExperimentHandler,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub(crate) struct AppliedStructuralExperiment {
+    pub label: String,
+    pub name: String,
+    pub args: serde_json::Value,
+    pub metadata: serde_json::Value,
+}
+
+const STRUCTURAL_EXPERIMENT_ENV: &str = "HARN_STRUCTURAL_EXPERIMENT";
+
+pub(crate) fn parse_structural_experiment_option(
+    options: Option<&BTreeMap<String, VmValue>>,
+) -> Result<Option<StructuralExperimentConfig>, VmError> {
+    let explicit = options.and_then(|dict| dict.get("structural_experiment"));
+    match explicit {
+        Some(VmValue::Nil) | Some(VmValue::Bool(false)) => Ok(None),
+        Some(VmValue::String(spec)) => parse_structural_experiment_spec(spec.as_ref()),
+        Some(VmValue::Dict(dict)) => parse_structural_experiment_dict(dict),
+        Some(VmValue::Closure(closure)) => Ok(Some(StructuralExperimentConfig {
+            label: "custom".to_string(),
+            name: "custom".to_string(),
+            args: serde_json::json!({}),
+            handler: StructuralExperimentHandler::Closure(VmValue::Closure(closure.clone())),
+        })),
+        Some(other) => Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
+            format!(
+                "structural_experiment: expected string, dict, closure, nil, or false; got {}",
+                other.type_name()
+            ),
+        )))),
+        None => match std::env::var(STRUCTURAL_EXPERIMENT_ENV) {
+            Ok(spec) if !spec.trim().is_empty() => parse_structural_experiment_spec(spec.trim()),
+            _ => Ok(None),
+        },
+    }
+}
+
+fn parse_structural_experiment_dict(
+    dict: &BTreeMap<String, VmValue>,
+) -> Result<Option<StructuralExperimentConfig>, VmError> {
+    let label = dict
+        .get("label")
+        .map(|value| value.display())
+        .filter(|value| !value.trim().is_empty());
+    let name = dict
+        .get("name")
+        .or_else(|| dict.get("experiment"))
+        .map(|value| value.display())
+        .filter(|value| !value.trim().is_empty());
+    let args_value = dict
+        .get("args")
+        .map(crate::llm::helpers::vm_value_to_json)
+        .unwrap_or_else(|| {
+            let mut args = serde_json::Map::new();
+            for (key, value) in dict {
+                if matches!(
+                    key.as_str(),
+                    "label" | "name" | "experiment" | "transform" | "handler"
+                ) {
+                    continue;
+                }
+                args.insert(key.clone(), crate::llm::helpers::vm_value_to_json(value));
+            }
+            serde_json::Value::Object(args)
+        });
+
+    if let Some(transform) = dict
+        .get("transform")
+        .or_else(|| dict.get("handler"))
+        .filter(|value| matches!(value, VmValue::Closure(_)))
+    {
+        let resolved_name = name.unwrap_or_else(|| "custom".to_string());
+        let resolved_label = label.unwrap_or_else(|| resolved_name.clone());
+        return Ok(Some(StructuralExperimentConfig {
+            label: resolved_label,
+            name: resolved_name,
+            args: args_value,
+            handler: StructuralExperimentHandler::Closure(transform.clone()),
+        }));
+    }
+
+    let Some(name) = name else {
+        return Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
+            "structural_experiment: dict form requires `name` or `transform`",
+        ))));
+    };
+    build_builtin_experiment(&name, label, args_value)
+}
+
+fn parse_structural_experiment_spec(
+    spec: &str,
+) -> Result<Option<StructuralExperimentConfig>, VmError> {
+    let spec = spec.trim();
+    if spec.is_empty() {
+        return Ok(None);
+    }
+    let (name, args) = if let Some(open_idx) = spec.find('(') {
+        let close_idx = spec.rfind(')').ok_or_else(|| {
+            VmError::Thrown(VmValue::String(std::rc::Rc::from(
+                "structural_experiment: missing closing `)`",
+            )))
+        })?;
+        if close_idx < open_idx {
+            return Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
+                "structural_experiment: invalid argument list",
+            ))));
+        }
+        let name = spec[..open_idx].trim();
+        let args = parse_named_args(&spec[open_idx + 1..close_idx])?;
+        (name, serde_json::Value::Object(args))
+    } else {
+        (spec, serde_json::json!({}))
+    };
+    build_builtin_experiment(name, Some(spec.to_string()), args)
+}
+
+fn build_builtin_experiment(
+    raw_name: &str,
+    explicit_label: Option<String>,
+    args: serde_json::Value,
+) -> Result<Option<StructuralExperimentConfig>, VmError> {
+    let name = raw_name.trim();
+    if name.is_empty() {
+        return Ok(None);
+    }
+    let handler = match name {
+        "prompt_order_permutation" => {
+            let seed = args
+                .get("seed")
+                .and_then(|value| value.as_i64())
+                .unwrap_or(0);
+            StructuralExperimentHandler::BuiltIn(
+                BuiltInStructuralExperiment::PromptOrderPermutation { seed },
+            )
+        }
+        "doubled_prompt" => {
+            StructuralExperimentHandler::BuiltIn(BuiltInStructuralExperiment::DoubledPrompt)
+        }
+        "chain_of_draft" => {
+            StructuralExperimentHandler::BuiltIn(BuiltInStructuralExperiment::ChainOfDraft)
+        }
+        "inverted_system" => {
+            StructuralExperimentHandler::BuiltIn(BuiltInStructuralExperiment::InvertedSystem)
+        }
+        other => {
+            return Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
+                format!("unknown structural experiment `{other}`"),
+            ))))
+        }
+    };
+    Ok(Some(StructuralExperimentConfig {
+        label: explicit_label.unwrap_or_else(|| name.to_string()),
+        name: name.to_string(),
+        args,
+        handler,
+    }))
+}
+
+fn parse_named_args(input: &str) -> Result<serde_json::Map<String, serde_json::Value>, VmError> {
+    let mut out = serde_json::Map::new();
+    for part in split_top_level(input, ',') {
+        let item = part.trim();
+        if item.is_empty() {
+            continue;
+        }
+        let Some(colon_idx) = item.find(':') else {
+            return Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
+                format!("structural_experiment: expected `name: value`, got `{item}`"),
+            ))));
+        };
+        let key = item[..colon_idx].trim();
+        if key.is_empty() {
+            return Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
+                "structural_experiment: empty argument name",
+            ))));
+        }
+        let value = parse_scalar_value(item[colon_idx + 1..].trim())?;
+        out.insert(key.to_string(), value);
+    }
+    Ok(out)
+}
+
+fn split_top_level(input: &str, delimiter: char) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut in_string = false;
+    let mut escape = false;
+    for ch in input.chars() {
+        if escape {
+            current.push(ch);
+            escape = false;
+            continue;
+        }
+        match ch {
+            '\\' if in_string => {
+                current.push(ch);
+                escape = true;
+            }
+            '"' => {
+                in_string = !in_string;
+                current.push(ch);
+            }
+            _ if ch == delimiter && !in_string => {
+                out.push(current);
+                current = String::new();
+            }
+            _ => current.push(ch),
+        }
+    }
+    out.push(current);
+    out
+}
+
+fn parse_scalar_value(input: &str) -> Result<serde_json::Value, VmError> {
+    if input.eq_ignore_ascii_case("true") {
+        return Ok(serde_json::json!(true));
+    }
+    if input.eq_ignore_ascii_case("false") {
+        return Ok(serde_json::json!(false));
+    }
+    if input.eq_ignore_ascii_case("nil") || input.eq_ignore_ascii_case("null") {
+        return Ok(serde_json::Value::Null);
+    }
+    if let Ok(value) = input.parse::<i64>() {
+        return Ok(serde_json::json!(value));
+    }
+    if let Ok(value) = input.parse::<f64>() {
+        return Ok(serde_json::json!(value));
+    }
+    if input.starts_with('"') && input.ends_with('"') && input.len() >= 2 {
+        return serde_json::from_str(input).map_err(|error| {
+            VmError::Thrown(VmValue::String(std::rc::Rc::from(format!(
+                "structural_experiment: invalid string literal `{input}`: {error}"
+            ))))
+        });
+    }
+    Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
+        format!("structural_experiment: unsupported argument value `{input}`",),
+    ))))
+}
+
+pub(crate) async fn apply_structural_experiment(
+    opts: &mut crate::llm::api::LlmCallOptions,
+    iteration: Option<usize>,
+) -> Result<Option<AppliedStructuralExperiment>, VmError> {
+    let Some(config) = opts.structural_experiment.clone() else {
+        opts.applied_structural_experiment = None;
+        return Ok(None);
+    };
+    let current_messages = opts.messages.clone();
+    let current_system = opts.system.clone();
+    let (messages, system, metadata) = match config.handler {
+        StructuralExperimentHandler::BuiltIn(kind) => {
+            let (messages, system) =
+                apply_builtin_experiment(&kind, current_messages, current_system.clone());
+            (messages, system, config.args.clone())
+        }
+        StructuralExperimentHandler::Closure(ref closure) => {
+            let VmValue::Closure(closure) = closure else {
+                return Err(VmError::Runtime(
+                    "structural_experiment transform must be a closure".to_string(),
+                ));
+            };
+            let mut vm = crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
+                VmError::Runtime(
+                    "structural_experiment requires an async builtin VM context".to_string(),
+                )
+            })?;
+            let mut ctx = BTreeMap::new();
+            ctx.insert(
+                "messages".to_string(),
+                VmValue::List(std::rc::Rc::new(crate::llm::helpers::json_messages_to_vm(
+                    &current_messages,
+                ))),
+            );
+            ctx.insert(
+                "system".to_string(),
+                current_system
+                    .as_ref()
+                    .map(|value| VmValue::String(std::rc::Rc::from(value.as_str())))
+                    .unwrap_or(VmValue::Nil),
+            );
+            ctx.insert(
+                "iteration".to_string(),
+                iteration
+                    .map(|value| VmValue::Int(value as i64))
+                    .unwrap_or(VmValue::Nil),
+            );
+            ctx.insert(
+                "label".to_string(),
+                VmValue::String(std::rc::Rc::from(config.label.as_str())),
+            );
+            ctx.insert(
+                "name".to_string(),
+                VmValue::String(std::rc::Rc::from(config.name.as_str())),
+            );
+            ctx.insert(
+                "args".to_string(),
+                crate::stdlib::json_to_vm_value(&config.args),
+            );
+            interpret_closure_result(
+                &current_messages,
+                current_system.as_deref(),
+                &vm.call_closure_pub(closure, &[VmValue::Dict(std::rc::Rc::new(ctx))], &[])
+                    .await?,
+                &config,
+            )?
+        }
+    };
+    opts.messages = messages;
+    opts.system = system;
+    let applied = AppliedStructuralExperiment {
+        label: config.label.clone(),
+        name: config.name.clone(),
+        args: config.args,
+        metadata,
+    };
+    opts.applied_structural_experiment = Some(applied.clone());
+    Ok(Some(applied))
+}
+
+fn interpret_closure_result(
+    current_messages: &[serde_json::Value],
+    current_system: Option<&str>,
+    result: &VmValue,
+    config: &StructuralExperimentConfig,
+) -> Result<(Vec<serde_json::Value>, Option<String>, serde_json::Value), VmError> {
+    match result {
+        VmValue::Nil => Ok((
+            current_messages.to_vec(),
+            current_system.map(str::to_string),
+            serde_json::json!({}),
+        )),
+        VmValue::List(list) => Ok((
+            crate::llm::helpers::vm_messages_to_json(list)?,
+            current_system.map(str::to_string),
+            serde_json::json!({}),
+        )),
+        VmValue::Dict(dict) => {
+            let messages = match dict.get("messages") {
+                Some(VmValue::List(list)) => crate::llm::helpers::vm_messages_to_json(list)?,
+                Some(VmValue::Nil) | None => current_messages.to_vec(),
+                Some(_) => {
+                    return Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
+                        "structural_experiment transform: `messages` must be a list",
+                    ))))
+                }
+            };
+            let system = match dict.get("system") {
+                Some(VmValue::Nil) => None,
+                Some(value) => Some(value.display()),
+                None => current_system.map(str::to_string),
+            };
+            let label = dict
+                .get("label")
+                .map(|value| value.display())
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| config.label.clone());
+            let name = dict
+                .get("name")
+                .map(|value| value.display())
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| config.name.clone());
+            let mut metadata = serde_json::Map::new();
+            metadata.insert("label".to_string(), serde_json::json!(label));
+            metadata.insert("name".to_string(), serde_json::json!(name));
+            if let Some(value) = dict.get("metadata") {
+                metadata.insert(
+                    "details".to_string(),
+                    crate::llm::helpers::vm_value_to_json(value),
+                );
+            }
+            Ok((messages, system, serde_json::Value::Object(metadata)))
+        }
+        _ => Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
+            "structural_experiment transform must return nil, a message list, or a dict",
+        )))),
+    }
+}
+
+fn apply_builtin_experiment(
+    kind: &BuiltInStructuralExperiment,
+    mut messages: Vec<serde_json::Value>,
+    mut system: Option<String>,
+) -> (Vec<serde_json::Value>, Option<String>) {
+    match kind {
+        BuiltInStructuralExperiment::PromptOrderPermutation { seed } => {
+            if let Some(index) = latest_string_user_message_index(&messages) {
+                if let Some(content) = message_text(&messages[index]) {
+                    let sections = split_prompt_sections(content);
+                    if sections.len() > 1 {
+                        let mut ranked: Vec<(u64, usize, String)> = sections
+                            .into_iter()
+                            .enumerate()
+                            .map(|(idx, section)| (permute_score(*seed, idx), idx, section))
+                            .collect();
+                        ranked.sort_by_key(|entry| (entry.0, entry.1));
+                        let mut ordered: Vec<String> =
+                            ranked.into_iter().map(|entry| entry.2).collect();
+                        if ordered.join("\n\n") == content && ordered.len() > 1 {
+                            ordered.rotate_left(1);
+                        }
+                        set_message_text(&mut messages[index], ordered.join("\n\n"));
+                    }
+                }
+            }
+        }
+        BuiltInStructuralExperiment::DoubledPrompt => {
+            if let Some(index) = latest_string_user_message_index(&messages) {
+                if let Some(original) = messages.get(index).cloned() {
+                    messages.insert(0, original.clone());
+                    messages.push(original);
+                }
+            }
+        }
+        BuiltInStructuralExperiment::ChainOfDraft => {
+            if let Some(index) = latest_string_user_message_index(&messages) {
+                if let Some(content) = message_text(&messages[index]).map(str::to_string) {
+                    set_message_text(
+                        &mut messages[index],
+                        format!(
+                            "{content}\n\nBefore the final answer, emit a terse scratch draft inside <draft>...</draft>. After the draft block, provide the final answer outside those tags."
+                        ),
+                    );
+                }
+            }
+        }
+        BuiltInStructuralExperiment::InvertedSystem => {
+            if let Some(index) = latest_string_user_message_index(&messages) {
+                if let (Some(content), Some(current_system)) = (
+                    message_text(&messages[index]).map(str::to_string),
+                    system.clone(),
+                ) {
+                    set_message_text(&mut messages[index], current_system);
+                    system = Some(content);
+                }
+            }
+        }
+    }
+    (messages, system)
+}
+
+fn latest_string_user_message_index(messages: &[serde_json::Value]) -> Option<usize> {
+    messages
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(idx, message)| {
+            let is_user = message.get("role").and_then(|value| value.as_str()) == Some("user");
+            if is_user
+                && message
+                    .get("content")
+                    .and_then(|value| value.as_str())
+                    .is_some()
+            {
+                Some(idx)
+            } else {
+                None
+            }
+        })
+}
+
+fn message_text(message: &serde_json::Value) -> Option<&str> {
+    message.get("content").and_then(|value| value.as_str())
+}
+
+fn set_message_text(message: &mut serde_json::Value, content: String) {
+    if let Some(object) = message.as_object_mut() {
+        object.insert("content".to_string(), serde_json::json!(content));
+    }
+}
+
+fn split_prompt_sections(content: &str) -> Vec<String> {
+    content
+        .split("\n\n")
+        .map(str::trim)
+        .filter(|section| !section.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn permute_score(seed: i64, idx: usize) -> u64 {
+    let mut value = seed as u64 ^ (idx as u64 + 1).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    value = value.wrapping_mul(6364136223846793005).wrapping_add(1);
+    value ^ (value >> 33)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_string_spec_with_seed() {
+        let parsed = parse_structural_experiment_spec("prompt_order_permutation(seed: 42)")
+            .expect("parse")
+            .expect("config");
+        assert_eq!(parsed.name, "prompt_order_permutation");
+        assert_eq!(parsed.args["seed"], serde_json::json!(42));
+    }
+
+    #[test]
+    fn prompt_order_permutation_reorders_sections() {
+        let (messages, _system) = apply_builtin_experiment(
+            &BuiltInStructuralExperiment::PromptOrderPermutation { seed: 42 },
+            vec![serde_json::json!({
+                "role": "user",
+                "content": "alpha\n\nbeta\n\ngamma"
+            })],
+            None,
+        );
+        let content = messages[0]["content"].as_str().expect("content");
+        assert_ne!(content, "alpha\n\nbeta\n\ngamma");
+        assert!(content.contains("alpha"));
+        assert!(content.contains("beta"));
+        assert!(content.contains("gamma"));
+    }
+
+    #[test]
+    fn inverted_system_swaps_latest_user_and_system() {
+        let (messages, system) = apply_builtin_experiment(
+            &BuiltInStructuralExperiment::InvertedSystem,
+            vec![serde_json::json!({
+                "role": "user",
+                "content": "user prompt"
+            })],
+            Some("system prompt".to_string()),
+        );
+        assert_eq!(messages[0]["content"], serde_json::json!("system prompt"));
+        assert_eq!(system.as_deref(), Some("user prompt"));
+    }
+}

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -187,6 +187,7 @@ pub(crate) fn register_agent_builtins(vm: &mut Vm) {
             "tools",
             "max_iterations",
             "tool_format",
+            "structural_experiment",
             "context_callback",
             "context_filter",
             "tool_retries",

--- a/crates/harn-vm/src/stdlib/workflow/register.rs
+++ b/crates/harn-vm/src/stdlib/workflow/register.rs
@@ -129,7 +129,15 @@ pub(in crate::stdlib) async fn execute_workflow(
 
     let persist_path = optional_string_option(&options, "persist_path")
         .or_else(|| optional_string_option(&options, "resume_path"))
-        .unwrap_or_else(|| format!(".harn-runs/{}.json", uuid::Uuid::now_v7()));
+        .unwrap_or_else(|| {
+            match std::env::var(crate::runtime_paths::HARN_RUN_DIR_ENV) {
+                Ok(value) if !value.trim().is_empty() => crate::orchestration::default_run_dir(),
+                _ => std::path::PathBuf::from(".harn-runs"),
+            }
+            .join(format!("{}.json", uuid::Uuid::now_v7()))
+            .display()
+            .to_string()
+        });
     let execution = parse_execution_record(options.get("execution"))?;
     let parent_run_id = optional_string_option(&options, "parent_run_id");
     let root_run_id =

--- a/crates/harn-vm/src/stdlib_agents.harn
+++ b/crates/harn-vm/src/stdlib_agents.harn
@@ -33,6 +33,7 @@ pub fn workflow_options(config) {
     tool_choice: config?.tool_choice,
     cache: config?.cache,
     timeout: config?.timeout,
+    structural_experiment: config?.structural_experiment,
     persistent: config?.persistent,
     max_iterations: config?.max_iterations,
     max_nudges: config?.max_nudges,

--- a/crates/harn-vm/src/stdlib_experiments.harn
+++ b/crates/harn-vm/src/stdlib_experiments.harn
@@ -1,0 +1,73 @@
+/** message. */
+pub fn message(role, content) {
+  return {role: role, content: content}
+}
+
+/** prompt_order_permutation. */
+pub fn prompt_order_permutation(options = nil) {
+  let seed = options?.seed ?? 0
+  return {
+    name: "prompt_order_permutation",
+    label: "prompt_order_permutation(seed: " + to_string(seed) + ")",
+    seed: seed,
+  }
+}
+
+/** doubled_prompt. */
+pub fn doubled_prompt() {
+  return {name: "doubled_prompt", label: "doubled_prompt"}
+}
+
+/** chain_of_draft. */
+pub fn chain_of_draft() {
+  return {name: "chain_of_draft", label: "chain_of_draft"}
+}
+
+/** inverted_system. */
+pub fn inverted_system() {
+  return {name: "inverted_system", label: "inverted_system"}
+}
+
+/** custom. */
+pub fn custom(label, transform, args = nil) {
+  return {
+    name: label,
+    label: label,
+    args: args ?? {},
+    transform: transform,
+  }
+}
+
+/** latest_string_user_message. */
+pub fn latest_string_user_message(messages) {
+  var idx = len(messages)
+  while idx > 0 {
+    idx = idx - 1
+    let msg = messages[idx]
+    if msg?.role == "user" && type_of(msg?.content) == "string" {
+      return {index: idx, message: msg}
+    }
+  }
+  return nil
+}
+
+/** replace_message. */
+pub fn replace_message(messages, index, message) {
+  var out = []
+  var idx = 0
+  while idx < len(messages) {
+    out = out + [if idx == index { message } else { messages[idx] }]
+    idx = idx + 1
+  }
+  return out
+}
+
+/** prepend_message. */
+pub fn prepend_message(messages, msg) {
+  return [msg] + messages
+}
+
+/** append_message. */
+pub fn append_message(messages, msg) {
+  return messages + [msg]
+}

--- a/crates/harn-vm/src/stdlib_modules.rs
+++ b/crates/harn-vm/src/stdlib_modules.rs
@@ -15,6 +15,7 @@ pub fn get_stdlib_source(module: &str) -> Option<&'static str> {
         "context" => Some(include_str!("stdlib_context.harn")),
         "runtime" => Some(include_str!("stdlib_runtime.harn")),
         "review" => Some(include_str!("stdlib_review.harn")),
+        "experiments" => Some(include_str!("stdlib_experiments.harn")),
         "project" => Some(include_str!("stdlib_project.harn")),
         "async" => Some(include_str!("stdlib_async.harn")),
         "agents" => Some(include_str!("stdlib_agents.harn")),

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -459,6 +459,7 @@ harn eval .harn-runs/<run>.json
 harn eval .harn-runs/<run>.json --compare baseline.json
 harn eval .harn-runs/
 harn eval evals/regression.json
+harn eval --llm-mock fixtures.jsonl --structural-experiment doubled_prompt pipeline.harn
 ```
 
 `harn eval` accepts three inputs:
@@ -466,6 +467,12 @@ harn eval evals/regression.json
 - a single run record JSON file
 - a directory of run record JSON files
 - an eval suite manifest JSON file with grouped cases and optional baseline comparisons
+
+When `path` is a `.harn` pipeline file, `--structural-experiment <spec>` runs
+the pipeline twice in isolated temp run directories: once as the baseline and
+once with `HARN_STRUCTURAL_EXPERIMENT=<spec>`. The CLI then evaluates both run
+sets against their embedded replay fixtures and prints a paired A/B summary.
+Use `--llm-mock <fixture.jsonl>` to keep the two runs deterministic.
 
 ## harn orchestrator
 

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -115,6 +115,7 @@ println(result.text)
 | `stream` | bool | `true` | Use streaming SSE transport. Set `false` for synchronous request/response. Env: `HARN_LLM_STREAM` |
 | `timeout` | int | `120` | Request timeout in seconds |
 | `messages` | list | nil | Full message list (overrides prompt) |
+| `structural_experiment` | string/dict/closure | nil | Prompt-structure transform applied immediately before the provider call. Built-ins: `prompt_order_permutation(seed: N)`, `doubled_prompt`, `chain_of_draft`, `inverted_system`. Env: `HARN_STRUCTURAL_EXPERIMENT` |
 | `transcript` | dict | nil | Continue from a previous transcript; prompt is appended as the next user turn |
 | `model_tier` | string | nil | Resolve a configured tier alias such as `"small"`, `"mid"`, or `"frontier"` |
 
@@ -126,6 +127,19 @@ let result = llm_call("hello", nil, {
   ollama: {num_ctx: 32768}
 })
 ```
+
+Structural experiments can be enabled directly on a call:
+
+```harn
+let result = llm_call("Instruction\n\nContext block", nil, {
+  provider: "mock",
+  structural_experiment: "prompt_order_permutation(seed: 42)",
+})
+```
+
+For custom transforms, pass a closure (or a `std/experiments.custom(...)`
+spec) that rewrites `{messages, system}` and returns either `nil`, a new
+message list, or `{messages?, system?, metadata?}`.
 
 ## Tool Vault
 

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -80,8 +80,8 @@ code or inside any pipeline.
 `import "std/..."` is only needed for the Harn-written helper modules
 described below (`std/text`, `std/json`, `std/math`, `std/collections`,
 `std/path`, `std/vision`, `std/context`, `std/agent_state`, `std/agents`,
-`std/runtime`, `std/review`, `std/project`, `std/worktree`,
-`std/checkpoint`). These add layered
+`std/runtime`, `std/review`, `std/experiments`, `std/project`,
+`std/worktree`, `std/checkpoint`). These add layered
 utilities on top of the core builtins; the core builtins themselves are
 always available.
 
@@ -101,6 +101,7 @@ import "std/context"
 import "std/agent_state"
 import "std/agents"
 import "std/review"
+import "std/experiments"
 ```
 
 ### std/text
@@ -120,6 +121,21 @@ Text processing utilities for LLM output and code analysis:
 | `detect_compile_error(output)` | Check for compile error patterns (SyntaxError, etc.) |
 | `has_got_want(output)` | Check for got/want test failure patterns |
 | `format_test_errors(output)` | Extract error-relevant lines (max 20) |
+
+### std/experiments
+
+Helpers for structural prompt experiments:
+
+| Function | Description |
+|---|---|
+| `prompt_order_permutation({seed?})` | Built-in experiment spec that permutes blank-line-separated sections of the latest user prompt |
+| `doubled_prompt()` | Built-in experiment spec that duplicates the latest user prompt at the front and back of the message list |
+| `chain_of_draft()` | Built-in experiment spec that injects a lightweight `<draft>` / final-answer scaffold |
+| `inverted_system()` | Built-in experiment spec that swaps the latest user prompt with the system prompt |
+| `custom(label, transform, args?)` | Build a closure-backed experiment spec from Harn |
+| `latest_string_user_message(messages)` | Return `{index, message}` for the latest plain-string user message |
+| `replace_message(messages, index, message)` | Return a copy of `messages` with one entry replaced |
+| `prepend_message(messages, msg)` / `append_message(messages, msg)` | Convenience helpers for custom transforms |
 
 ### std/collections
 


### PR DESCRIPTION
Closes #312.

## Summary
- Add a structural experiment layer for `llm_call`, including string specs, dict specs, custom Harn closure transforms, and `HARN_STRUCTURAL_EXPERIMENT` fallback.
- Ship starter experiments: `prompt_order_permutation(seed)`, `doubled_prompt`, `chain_of_draft`, and `inverted_system`, plus a Harn stdlib helper module under `std/experiments`.
- Tag applied experiments in provider payloads, transcript request/response events, bridge metadata, and agent-loop calls.
- Add `harn eval --structural-experiment=...` to run paired baseline/variant pipeline evaluations with deterministic `--llm-mock` support.
- Document the LLM option, stdlib helpers, and CLI workflow.

## Validation
- `cargo fmt --all`
- `cargo test -p harn-vm structural_experiments --lib`
- `cargo test -p harn-cli --test llm_mock_cli eval_runs_baseline_and_structural_variant_for_pipeline_file`
- `cargo run --bin harn -- test conformance --filter llm_structural_experiments`