### PR TITLE
[codex] Add orchestrator cloud deploy helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ granular archaeology.
   log, supports push-driven wakeups from the trigger inbox with
   poll-interval fallback, and replays recorded terminal results during
   dispatch replays for deterministic reruns.
+- **`harn orchestrator deploy` helper (#188, #414).** Generate and run
+  manifest-driven orchestrator deploys against Fly, Railway, or Render
+  from the CLI, with provider-specific starter configs shipped under
+  `deploy/` for quick onboarding.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ with the usual environment variables such as `OPENAI_API_KEY`,
 `ANTHROPIC_API_KEY`, or your deployment's `HARN_PROVIDER_*` /
 `HARN_SECRET_*` values.
 
+Cloud deploy templates for Render, Fly.io, and Railway live under
+`deploy/`. To generate a project-local bundle and run the provider CLI:
+
+```bash
+harn orchestrator deploy --provider fly --manifest ./harn.toml --build
+```
+
 ## Quick Start
 
 ```bash

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -821,6 +821,8 @@ pub(crate) struct OrchestratorLocalArgs {
 pub(crate) enum OrchestratorCommand {
     /// Load manifests, initialize registries, and idle until shutdown.
     Serve(OrchestratorServeArgs),
+    /// Generate and run a cloud deploy for a manifest-driven orchestrator.
+    Deploy(OrchestratorDeployArgs),
     /// Request a hot reload from a running orchestrator.
     Reload(OrchestratorReloadArgs),
     /// Inspect orchestrator state.
@@ -878,6 +880,100 @@ pub(crate) struct OrchestratorServeArgs {
         default_value_t = crate::commands::orchestrator::role::OrchestratorRole::SingleTenant
     )]
     pub role: crate::commands::orchestrator::role::OrchestratorRole,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorDeployArgs {
+    /// Cloud provider target.
+    #[arg(long, value_enum)]
+    pub provider: OrchestratorDeployProvider,
+    /// Path to the root manifest to validate and deploy.
+    #[arg(
+        long,
+        visible_alias = "config",
+        env = "HARN_ORCHESTRATOR_MANIFEST",
+        default_value = "harn.toml",
+        value_name = "PATH"
+    )]
+    pub manifest: PathBuf,
+    /// Service/app name used in generated provider templates.
+    #[arg(long, default_value = "harn-orchestrator", value_name = "NAME")]
+    pub name: String,
+    /// Container image to deploy, or the tag to build/push when --build is set.
+    #[arg(
+        long,
+        default_value = "ghcr.io/burin-labs/harn:latest",
+        value_name = "IMAGE"
+    )]
+    pub image: String,
+    /// Directory where provider deploy bundles are written.
+    #[arg(long = "deploy-dir", default_value = "deploy", value_name = "DIR")]
+    pub deploy_dir: PathBuf,
+    /// Internal HTTP port the orchestrator listens on in the container.
+    #[arg(long, default_value_t = 8080, value_name = "PORT")]
+    pub port: u16,
+    /// Persistent data mount path inside the container.
+    #[arg(long = "data-dir", default_value = "/data", value_name = "PATH")]
+    pub data_dir: String,
+    /// Persistent disk or volume size in GiB where the provider supports it.
+    #[arg(long = "disk-size-gb", default_value_t = 10, value_name = "GB")]
+    pub disk_size_gb: u16,
+    /// Graceful shutdown timeout, passed through to orchestrator serve.
+    #[arg(long = "shutdown-timeout", default_value_t = 30, value_name = "SECS")]
+    pub shutdown_timeout: u64,
+    /// Optional provider region for templates and deploy commands that support it.
+    #[arg(long, value_name = "REGION")]
+    pub region: Option<String>,
+    /// Render service id/name to redeploy with `render deploys create`.
+    #[arg(long = "render-service", value_name = "SERVICE")]
+    pub render_service: Option<String>,
+    /// Railway service id/name for variable sync and deploy targeting.
+    #[arg(long = "railway-service", value_name = "SERVICE")]
+    pub railway_service: Option<String>,
+    /// Railway environment id/name for variable sync and deploy targeting.
+    #[arg(long = "railway-environment", value_name = "ENV")]
+    pub railway_environment: Option<String>,
+    /// Build and push the deploy image before running the provider deploy.
+    #[arg(long)]
+    pub build: bool,
+    /// Build locally without pushing when --build is set.
+    #[arg(long = "no-push")]
+    pub no_push: bool,
+    /// Extra runtime environment variable to include and sync, as KEY=VALUE.
+    #[arg(long = "env", value_name = "KEY=VALUE")]
+    pub env: Vec<String>,
+    /// Extra runtime secret to sync through the provider CLI, as KEY=VALUE.
+    #[arg(long = "secret", value_name = "KEY=VALUE")]
+    pub secret: Vec<String>,
+    /// Skip provider CLI secret synchronization.
+    #[arg(long = "no-secret-sync")]
+    pub no_secret_sync: bool,
+    /// Generate files and print commands without invoking provider CLIs.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Print the generated provider spec to stdout.
+    #[arg(long)]
+    pub print: bool,
+    /// Health URL to probe after the deploy command completes.
+    #[arg(long = "health-url", value_name = "URL")]
+    pub health_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum OrchestratorDeployProvider {
+    Render,
+    Fly,
+    Railway,
+}
+
+impl OrchestratorDeployProvider {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Render => "render",
+            Self::Fly => "fly",
+            Self::Railway => "railway",
+        }
+    }
 }
 
 #[derive(Debug, Args)]
@@ -1408,9 +1504,10 @@ mod tests {
     use std::time::Duration as StdDuration;
 
     use super::{
-        Cli, Command, McpCommand, OrchestratorCommand, OrchestratorQueueCommand, ProjectTemplate,
-        RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand,
-        TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
+        Cli, Command, McpCommand, OrchestratorCommand, OrchestratorDeployProvider,
+        OrchestratorQueueCommand, ProjectTemplate, RunsCommand, SkillCommand, SkillKeyCommand,
+        SkillTrustCommand, SkillsCommand, TriggerCommand, TrustCommand, TrustOutcomeArg,
+        TrustTierArg,
     };
     use clap::Parser;
 
@@ -1795,6 +1892,62 @@ mod tests {
         assert_eq!(serve.local.config, PathBuf::from("/etc/harn/triggers.toml"));
         assert_eq!(serve.local.state_dir, PathBuf::from("/var/lib/harn/state"));
         assert_eq!(serve.bind.to_string(), "0.0.0.0:8080");
+    }
+
+    #[test]
+    fn test_parses_orchestrator_deploy_args() {
+        let cli = Cli::parse_from([
+            "harn",
+            "orchestrator",
+            "deploy",
+            "--provider",
+            "fly",
+            "--manifest",
+            "workspace/harn.toml",
+            "--name",
+            "harn-prod",
+            "--image",
+            "ghcr.io/acme/harn-prod:latest",
+            "--deploy-dir",
+            "ops/deploy",
+            "--port",
+            "8443",
+            "--data-dir",
+            "/data",
+            "--disk-size-gb",
+            "20",
+            "--shutdown-timeout",
+            "60",
+            "--region",
+            "sjc",
+            "--build",
+            "--env",
+            "RUST_LOG=debug",
+            "--secret",
+            "OPENAI_API_KEY=sk-test",
+            "--dry-run",
+        ]);
+
+        let Command::Orchestrator(args) = cli.command.unwrap() else {
+            panic!("expected orchestrator command");
+        };
+        let OrchestratorCommand::Deploy(deploy) = args.command else {
+            panic!("expected orchestrator deploy");
+        };
+        assert_eq!(deploy.provider, OrchestratorDeployProvider::Fly);
+        assert_eq!(deploy.manifest, PathBuf::from("workspace/harn.toml"));
+        assert_eq!(deploy.name, "harn-prod");
+        assert_eq!(deploy.image, "ghcr.io/acme/harn-prod:latest");
+        assert_eq!(deploy.deploy_dir, PathBuf::from("ops/deploy"));
+        assert_eq!(deploy.port, 8443);
+        assert_eq!(deploy.data_dir, "/data");
+        assert_eq!(deploy.disk_size_gb, 20);
+        assert_eq!(deploy.shutdown_timeout, 60);
+        assert_eq!(deploy.region.as_deref(), Some("sjc"));
+        assert!(deploy.build);
+        assert_eq!(deploy.env, vec!["RUST_LOG=debug".to_string()]);
+        assert_eq!(deploy.secret, vec!["OPENAI_API_KEY=sk-test".to_string()]);
+        assert!(deploy.dry_run);
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/orchestrator/deploy.rs
+++ b/crates/harn-cli/src/commands/orchestrator/deploy.rs
@@ -1,0 +1,891 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use crate::cli::{OrchestratorDeployArgs, OrchestratorDeployProvider, OrchestratorLocalArgs};
+use crate::package::{Manifest, TriggerKind};
+
+use super::common;
+
+const CONTAINER_MANIFEST_PATH: &str = "/app/harn.toml";
+
+#[derive(Debug)]
+struct ValidatedManifest {
+    manifest: Manifest,
+    manifest_path: PathBuf,
+    manifest_dir: PathBuf,
+    trigger_count: usize,
+    http_trigger_count: usize,
+}
+
+#[derive(Debug)]
+struct DeployBundle {
+    provider_dir: PathBuf,
+    context_dir: PathBuf,
+    dockerfile_path: PathBuf,
+    spec_path: PathBuf,
+    spec_contents: String,
+}
+
+#[derive(Debug)]
+struct DeployEnv {
+    public: BTreeMap<String, String>,
+    secrets: BTreeMap<String, String>,
+    missing_secret_env: Vec<String>,
+}
+
+pub(crate) async fn run(args: OrchestratorDeployArgs) -> Result<(), String> {
+    let validated = validate_manifest(&args).await?;
+    let env = collect_deploy_env(&args, &validated.manifest)?;
+    let bundle = write_bundle(&args, &validated, &env.public)?;
+
+    println!(
+        "validated {} trigger(s) from {} ({} HTTP-managed)",
+        validated.trigger_count,
+        validated.manifest_path.display(),
+        validated.http_trigger_count
+    );
+    println!("wrote deploy bundle: {}", bundle.provider_dir.display());
+
+    if !env.missing_secret_env.is_empty() {
+        eprintln!(
+            "warning: {} manifest secret env var(s) were not set locally and were not synced: {}",
+            env.missing_secret_env.len(),
+            env.missing_secret_env.join(", ")
+        );
+    }
+
+    if args.print {
+        println!("{}", bundle.spec_contents);
+    }
+
+    let mut plan = Vec::new();
+    if args.build {
+        plan.push(build_image_command(&args, &bundle));
+    }
+    plan.extend(public_env_sync_commands(&args, &env.public));
+    if !args.no_secret_sync && !env.secrets.is_empty() {
+        plan.extend(secret_sync_commands(&args, &env.secrets));
+    }
+    plan.push(provider_deploy_command(&args, &bundle));
+
+    if args.dry_run {
+        println!("dry run; commands not executed:");
+        for command in &plan {
+            println!("  {}", command.display());
+        }
+        return Ok(());
+    }
+
+    for command in plan {
+        run_checked(command)?;
+    }
+
+    if let Some(url) = args
+        .health_url
+        .clone()
+        .or_else(|| default_health_url(&args.provider, &args.name))
+    {
+        probe_health(&url)?;
+    }
+
+    Ok(())
+}
+
+async fn validate_manifest(args: &OrchestratorDeployArgs) -> Result<ValidatedManifest, String> {
+    let manifest_path = absolutize_from_cwd(&args.manifest)?;
+    let manifest_dir = manifest_path
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| {
+            format!(
+                "manifest has no parent directory: {}",
+                manifest_path.display()
+            )
+        })?;
+    let manifest = read_manifest(&manifest_path)?;
+    let validation_state = tempfile::Builder::new()
+        .prefix("harn-deploy-validate-")
+        .tempdir()
+        .map_err(|error| {
+            format!("failed to create temporary deploy validation state dir: {error}")
+        })?;
+    let local = OrchestratorLocalArgs {
+        config: manifest_path.clone(),
+        state_dir: validation_state.path().to_path_buf(),
+    };
+    let ctx = common::load_local_runtime(&local).await?;
+    let trigger_count = ctx.collected_triggers.len();
+    let http_trigger_count = ctx
+        .collected_triggers
+        .iter()
+        .filter(|trigger| {
+            matches!(
+                trigger.config.kind,
+                TriggerKind::Webhook | TriggerKind::A2aPush
+            )
+        })
+        .count();
+    Ok(ValidatedManifest {
+        manifest,
+        manifest_path,
+        manifest_dir,
+        trigger_count,
+        http_trigger_count,
+    })
+}
+
+fn write_bundle(
+    args: &OrchestratorDeployArgs,
+    validated: &ValidatedManifest,
+    public_env: &BTreeMap<String, String>,
+) -> Result<DeployBundle, String> {
+    let provider_dir = validated
+        .manifest_dir
+        .join(&args.deploy_dir)
+        .join(args.provider.as_str());
+    fs::create_dir_all(&provider_dir)
+        .map_err(|error| format!("failed to create {}: {error}", provider_dir.display()))?;
+
+    let dockerfile_path = provider_dir.join("Dockerfile");
+    let dockerfile = render_dockerfile();
+    write_if_changed(&dockerfile_path, &dockerfile)?;
+
+    let spec_contents = match args.provider {
+        OrchestratorDeployProvider::Render => render_render_yaml(args, public_env),
+        OrchestratorDeployProvider::Fly => render_fly_toml(args, public_env),
+        OrchestratorDeployProvider::Railway => render_railway_json(args, public_env)?,
+    };
+    let spec_path = provider_dir.join(provider_spec_file(args.provider));
+    write_if_changed(&spec_path, &spec_contents)?;
+
+    Ok(DeployBundle {
+        provider_dir,
+        context_dir: validated.manifest_dir.clone(),
+        dockerfile_path,
+        spec_path,
+        spec_contents,
+    })
+}
+
+fn collect_deploy_env(
+    args: &OrchestratorDeployArgs,
+    manifest: &Manifest,
+) -> Result<DeployEnv, String> {
+    let state_dir = format!("{}/state", args.data_dir.trim_end_matches('/'));
+    let sqlite_path = format!("{}/events.sqlite", args.data_dir.trim_end_matches('/'));
+    let mut public = BTreeMap::from([
+        (
+            "HARN_ORCHESTRATOR_MANIFEST".to_string(),
+            CONTAINER_MANIFEST_PATH.to_string(),
+        ),
+        (
+            "HARN_ORCHESTRATOR_LISTEN".to_string(),
+            format!("0.0.0.0:{}", args.port),
+        ),
+        ("HARN_ORCHESTRATOR_STATE_DIR".to_string(), state_dir),
+        ("HARN_EVENT_LOG_BACKEND".to_string(), "sqlite".to_string()),
+        ("HARN_EVENT_LOG_SQLITE_PATH".to_string(), sqlite_path),
+        ("HARN_SECRET_PROVIDERS".to_string(), "env".to_string()),
+        ("RUST_LOG".to_string(), "info".to_string()),
+    ]);
+
+    let mut secrets = BTreeMap::new();
+    let mut missing_secret_env = Vec::new();
+
+    for pair in &args.env {
+        let (key, value) = parse_key_value(pair)?;
+        public.insert(key, value);
+    }
+    for pair in &args.secret {
+        let (key, value) = parse_key_value(pair)?;
+        secrets.insert(key, value);
+    }
+
+    for key in [
+        "HARN_ORCHESTRATOR_API_KEYS",
+        "HARN_ORCHESTRATOR_HMAC_SECRET",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENROUTER_API_KEY",
+        "HF_TOKEN",
+        "HUGGINGFACE_API_KEY",
+        "TOGETHER_AI_API_KEY",
+    ] {
+        if secrets.contains_key(key) {
+            continue;
+        }
+        if let Ok(value) = std::env::var(key) {
+            if !value.is_empty() {
+                secrets.insert(key.to_string(), value);
+            }
+        }
+    }
+
+    for trigger in &manifest.triggers {
+        for secret_ref in trigger.secrets.values() {
+            let Some(env_name) = secret_ref_env_name(secret_ref) else {
+                continue;
+            };
+            if secrets.contains_key(&env_name) {
+                continue;
+            }
+            match std::env::var(&env_name) {
+                Ok(value) if !value.is_empty() => {
+                    secrets.insert(env_name, value);
+                }
+                _ => missing_secret_env.push(env_name),
+            }
+        }
+    }
+    missing_secret_env.sort();
+    missing_secret_env.dedup();
+
+    Ok(DeployEnv {
+        public,
+        secrets,
+        missing_secret_env,
+    })
+}
+
+fn render_dockerfile() -> String {
+    r#"FROM ghcr.io/burin-labs/harn:latest
+
+WORKDIR /app
+COPY . /app
+
+ENV HARN_ORCHESTRATOR_MANIFEST=/app/harn.toml
+
+ENTRYPOINT ["/usr/local/bin/harn", "orchestrator", "serve"]
+"#
+    .to_string()
+}
+
+fn render_render_yaml(
+    args: &OrchestratorDeployArgs,
+    public_env: &BTreeMap<String, String>,
+) -> String {
+    let env_vars = public_env
+        .iter()
+        .map(|(key, value)| {
+            format!(
+                "      - key: {}\n        value: {}\n",
+                yaml_plain(key),
+                serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
+            )
+        })
+        .collect::<String>();
+    format!(
+        r#"services:
+  - type: web
+    name: {name}
+    runtime: image
+    image:
+      url: {image}
+    disk:
+      name: harn-data
+      mountPath: {data_dir}
+      sizeGB: {disk_size_gb}
+    envVars:
+{env_vars}      - fromGroup: harn-secrets
+    healthCheckPath: /healthz
+"#,
+        name = yaml_plain(&args.name),
+        image = yaml_plain(&args.image),
+        data_dir = yaml_plain(&args.data_dir),
+        disk_size_gb = args.disk_size_gb,
+        env_vars = env_vars,
+    )
+}
+
+fn render_fly_toml(args: &OrchestratorDeployArgs, public_env: &BTreeMap<String, String>) -> String {
+    let region = args
+        .region
+        .as_ref()
+        .map(|region| format!("primary_region = {}\n", toml_string(region)))
+        .unwrap_or_default();
+    let env_vars = public_env
+        .iter()
+        .map(|(key, value)| format!("  {key} = {}\n", toml_string(value)))
+        .collect::<String>();
+    format!(
+        r#"app = {name}
+{region}kill_signal = "SIGTERM"
+kill_timeout = "{shutdown_timeout}s"
+
+[build]
+  image = {image}
+
+[env]
+{env_vars}
+
+[mounts]
+  source = "harn_data"
+  destination = {data_dir}
+
+[http_service]
+  internal_port = {port}
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    path = "/healthz"
+    timeout = "5s"
+
+[metrics]
+  port = {port}
+  path = "/metrics"
+"#,
+        name = toml_string(&args.name),
+        region = region,
+        shutdown_timeout = args.shutdown_timeout,
+        image = toml_string(&args.image),
+        port = args.port,
+        env_vars = env_vars,
+        data_dir = toml_string(&args.data_dir),
+    )
+}
+
+fn render_railway_json(
+    args: &OrchestratorDeployArgs,
+    public_env: &BTreeMap<String, String>,
+) -> Result<String, String> {
+    let value = serde_json::json!({
+        "$schema": "https://railway.app/railway.schema.json",
+        "build": {
+            "builder": "DOCKERFILE",
+            "dockerfilePath": "deploy/railway/Dockerfile"
+        },
+        "deploy": {
+            "startCommand": format!("harn orchestrator serve --shutdown-timeout {}", args.shutdown_timeout),
+            "healthcheckPath": "/healthz",
+            "healthcheckTimeout": 30,
+            "restartPolicyType": "ON_FAILURE",
+            "restartPolicyMaxRetries": 10
+        },
+        "environments": {
+            "production": {
+                "variables": public_env
+            }
+        }
+    });
+    serde_json::to_string_pretty(&value)
+        .map(|json| format!("{json}\n"))
+        .map_err(|error| format!("failed to render railway.json: {error}"))
+}
+
+fn build_image_command(args: &OrchestratorDeployArgs, bundle: &DeployBundle) -> PlannedCommand {
+    let mut command = PlannedCommand::new("docker");
+    if args.no_push {
+        command.args(["build", "-f"]);
+        command.arg(bundle.dockerfile_path.as_os_str());
+        command.args(["-t", args.image.as_str(), "."]);
+    } else {
+        command.args([
+            "buildx",
+            "build",
+            "--platform",
+            "linux/amd64,linux/arm64",
+            "-f",
+        ]);
+        command.arg(bundle.dockerfile_path.as_os_str());
+        command.args(["-t", args.image.as_str(), "--push", "."]);
+    }
+    command.cwd = Some(bundle.context_dir.clone());
+    command
+}
+
+fn secret_sync_commands(
+    args: &OrchestratorDeployArgs,
+    secrets: &BTreeMap<String, String>,
+) -> Vec<PlannedCommand> {
+    match args.provider {
+        OrchestratorDeployProvider::Fly => {
+            let mut command = PlannedCommand::new("fly");
+            command.args(["secrets", "set"]);
+            for (key, value) in secrets {
+                command.arg_sensitive(format!("{key}={value}"));
+            }
+            command.args(["--app", args.name.as_str()]);
+            vec![command]
+        }
+        OrchestratorDeployProvider::Railway => secrets
+            .iter()
+            .map(|(key, value)| {
+                let mut command = PlannedCommand::new("railway");
+                command.args(["variable", "set"]);
+                command.arg_sensitive(format!("{key}={value}"));
+                command.arg("--skip-deploys");
+                if let Some(service) = &args.railway_service {
+                    command.args(["--service", service.as_str()]);
+                }
+                if let Some(environment) = &args.railway_environment {
+                    command.args(["--environment", environment.as_str()]);
+                }
+                command
+            })
+            .collect(),
+        OrchestratorDeployProvider::Render => {
+            let Some(service) = &args.render_service else {
+                return Vec::new();
+            };
+            secrets
+                .iter()
+                .map(|(key, value)| {
+                    let mut command = PlannedCommand::new("render");
+                    command.args(["services", "update", service.as_str()]);
+                    command.arg("--env-var");
+                    command.arg_sensitive(format!("{key}={value}"));
+                    command.arg("--confirm");
+                    command
+                })
+                .collect()
+        }
+    }
+}
+
+fn public_env_sync_commands(
+    args: &OrchestratorDeployArgs,
+    public_env: &BTreeMap<String, String>,
+) -> Vec<PlannedCommand> {
+    if args.provider != OrchestratorDeployProvider::Railway {
+        return Vec::new();
+    }
+
+    let mut vars = public_env.clone();
+    vars.insert(
+        "RAILWAY_DOCKERFILE_PATH".to_string(),
+        "deploy/railway/Dockerfile".to_string(),
+    );
+
+    vars.iter()
+        .map(|(key, value)| {
+            let mut command = PlannedCommand::new("railway");
+            command.args(["variable", "set"]);
+            command.arg(format!("{key}={value}"));
+            command.arg("--skip-deploys");
+            if let Some(service) = &args.railway_service {
+                command.args(["--service", service.as_str()]);
+            }
+            if let Some(environment) = &args.railway_environment {
+                command.args(["--environment", environment.as_str()]);
+            }
+            command
+        })
+        .collect()
+}
+
+fn provider_deploy_command(args: &OrchestratorDeployArgs, bundle: &DeployBundle) -> PlannedCommand {
+    match args.provider {
+        OrchestratorDeployProvider::Render => {
+            if let Some(service) = &args.render_service {
+                let mut command = PlannedCommand::new("render");
+                command.args(["deploys", "create", service.as_str()]);
+                command.args(["--image", args.image.as_str(), "--wait", "--confirm"]);
+                command
+            } else {
+                let mut command = PlannedCommand::new("render");
+                command.args(["blueprints", "validate"]);
+                command.arg(bundle.spec_path.as_os_str());
+                command
+            }
+        }
+        OrchestratorDeployProvider::Fly => {
+            let mut command = PlannedCommand::new("fly");
+            command.args(["deploy", "--config"]);
+            command.arg(bundle.spec_path.as_os_str());
+            command.args(["--app", args.name.as_str()]);
+            command
+        }
+        OrchestratorDeployProvider::Railway => {
+            let mut command = PlannedCommand::new("railway");
+            command.args(["up", "--yes"]);
+            if let Some(service) = &args.railway_service {
+                command.args(["--service", service.as_str()]);
+            }
+            if let Some(environment) = &args.railway_environment {
+                command.args(["--environment", environment.as_str()]);
+            }
+            command.cwd = Some(bundle.context_dir.clone());
+            command
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PlannedCommand {
+    program: String,
+    args: Vec<String>,
+    sensitive_args: BTreeSet<usize>,
+    cwd: Option<PathBuf>,
+}
+
+impl PlannedCommand {
+    fn new(program: impl Into<String>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            sensitive_args: BTreeSet::new(),
+            cwd: None,
+        }
+    }
+
+    fn arg(&mut self, arg: impl AsRef<OsStr>) -> &mut Self {
+        self.args.push(arg.as_ref().to_string_lossy().into_owned());
+        self
+    }
+
+    fn arg_sensitive(&mut self, arg: impl AsRef<OsStr>) -> &mut Self {
+        let index = self.args.len();
+        self.arg(arg);
+        self.sensitive_args.insert(index);
+        self
+    }
+
+    fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        for arg in args {
+            self.arg(arg);
+        }
+        self
+    }
+
+    fn display(&self) -> String {
+        let mut rendered = shell_quote(&self.program);
+        for (index, arg) in self.args.iter().enumerate() {
+            rendered.push(' ');
+            let display_arg = if self.sensitive_args.contains(&index) {
+                redact_arg(arg)
+            } else {
+                arg.to_string()
+            };
+            rendered.push_str(&shell_quote(&display_arg));
+        }
+        if let Some(cwd) = &self.cwd {
+            format!(
+                "(cd {} && {rendered})",
+                shell_quote(&cwd.display().to_string())
+            )
+        } else {
+            rendered
+        }
+    }
+}
+
+fn run_checked(command: PlannedCommand) -> Result<(), String> {
+    println!("running: {}", command.display());
+    let mut process = Command::new(&command.program);
+    process.args(&command.args);
+    if let Some(cwd) = &command.cwd {
+        process.current_dir(cwd);
+    }
+    let status = process
+        .status()
+        .map_err(|error| format!("failed to run {}: {error}", command.program))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "command failed with {status}: {}",
+            command.display()
+        ))
+    }
+}
+
+fn probe_health(url: &str) -> Result<(), String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(20))
+        .build()
+        .map_err(|error| format!("failed to create health probe client: {error}"))?;
+    let response = client
+        .get(url)
+        .send()
+        .map_err(|error| format!("health probe failed for {url}: {error}"))?;
+    if response.status().is_success() {
+        println!("health check passed: {url}");
+        Ok(())
+    } else {
+        Err(format!(
+            "health probe failed for {url}: HTTP {}",
+            response.status()
+        ))
+    }
+}
+
+fn default_health_url(provider: &OrchestratorDeployProvider, name: &str) -> Option<String> {
+    match provider {
+        OrchestratorDeployProvider::Fly => Some(format!("https://{name}.fly.dev/healthz")),
+        OrchestratorDeployProvider::Render | OrchestratorDeployProvider::Railway => None,
+    }
+}
+
+fn provider_spec_file(provider: OrchestratorDeployProvider) -> &'static str {
+    match provider {
+        OrchestratorDeployProvider::Render => "render.yaml",
+        OrchestratorDeployProvider::Fly => "fly.toml",
+        OrchestratorDeployProvider::Railway => "railway.json",
+    }
+}
+
+fn read_manifest(path: &Path) -> Result<Manifest, String> {
+    if !path.is_file() {
+        return Err(format!("manifest not found: {}", path.display()));
+    }
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    toml::from_str(&content).map_err(|error| format!("failed to parse {}: {error}", path.display()))
+}
+
+fn absolutize_from_cwd(path: &Path) -> Result<PathBuf, String> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    std::env::current_dir()
+        .map(|cwd| cwd.join(path))
+        .map_err(|error| format!("failed to read current directory: {error}"))
+}
+
+fn write_if_changed(path: &Path, content: &str) -> Result<(), String> {
+    if fs::read_to_string(path).is_ok_and(|existing| existing == content) {
+        return Ok(());
+    }
+    fs::write(path, content).map_err(|error| format!("failed to write {}: {error}", path.display()))
+}
+
+fn parse_key_value(raw: &str) -> Result<(String, String), String> {
+    let Some((key, value)) = raw.split_once('=') else {
+        return Err(format!("expected KEY=VALUE, got '{raw}'"));
+    };
+    let key = key.trim();
+    if key.is_empty() {
+        return Err(format!("expected non-empty KEY in '{raw}'"));
+    }
+    Ok((key.to_string(), value.to_string()))
+}
+
+fn secret_ref_env_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let (base, version) = match trimmed.rsplit_once('@') {
+        Some((base, version_text)) => Some((base, version_text.parse::<u64>().ok()?)),
+        None => None,
+    }
+    .unwrap_or((trimmed, 0));
+    let (namespace, name) = base.split_once('/')?;
+    if namespace.is_empty() || name.is_empty() {
+        return None;
+    }
+    let prefix = format!(
+        "HARN_SECRET_{}_{}",
+        normalize_env_component(namespace),
+        normalize_env_component(name)
+    );
+    if version == 0 {
+        Some(prefix)
+    } else {
+        Some(format!("{prefix}_V{version}"))
+    }
+}
+
+fn normalize_env_component(value: &str) -> String {
+    let mut normalized = String::new();
+    let mut last_was_underscore = false;
+    for ch in value.chars() {
+        let mapped = if ch.is_ascii_alphanumeric() {
+            ch.to_ascii_uppercase()
+        } else {
+            '_'
+        };
+        if mapped == '_' {
+            if !last_was_underscore {
+                normalized.push(mapped);
+            }
+            last_was_underscore = true;
+        } else {
+            normalized.push(mapped);
+            last_was_underscore = false;
+        }
+    }
+    normalized.trim_matches('_').to_string()
+}
+
+fn toml_string(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
+}
+
+fn yaml_plain(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | ':' | '/'))
+    {
+        value.to_string()
+    } else {
+        serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '-' | '_' | ':' | '='))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn redact_arg(value: &str) -> String {
+    match value.split_once('=') {
+        Some((key, _)) => format!("{key}=***"),
+        None => "***".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(provider: OrchestratorDeployProvider) -> OrchestratorDeployArgs {
+        OrchestratorDeployArgs {
+            provider,
+            manifest: PathBuf::from("harn.toml"),
+            name: "harn-prod".to_string(),
+            image: "ghcr.io/acme/harn-prod:latest".to_string(),
+            deploy_dir: PathBuf::from("deploy"),
+            port: 8080,
+            data_dir: "/data".to_string(),
+            disk_size_gb: 10,
+            shutdown_timeout: 45,
+            region: Some("sjc".to_string()),
+            render_service: Some("srv-123".to_string()),
+            railway_service: Some("harn-prod".to_string()),
+            railway_environment: Some("production".to_string()),
+            build: false,
+            no_push: false,
+            env: vec![],
+            secret: vec![],
+            no_secret_sync: false,
+            dry_run: true,
+            print: false,
+            health_url: None,
+        }
+    }
+
+    fn env() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            (
+                "HARN_ORCHESTRATOR_MANIFEST".to_string(),
+                CONTAINER_MANIFEST_PATH.to_string(),
+            ),
+            (
+                "HARN_ORCHESTRATOR_LISTEN".to_string(),
+                "0.0.0.0:8080".to_string(),
+            ),
+            (
+                "HARN_ORCHESTRATOR_STATE_DIR".to_string(),
+                "/data/state".to_string(),
+            ),
+            ("HARN_EVENT_LOG_BACKEND".to_string(), "sqlite".to_string()),
+            (
+                "HARN_EVENT_LOG_SQLITE_PATH".to_string(),
+                "/data/events.sqlite".to_string(),
+            ),
+            ("HARN_SECRET_PROVIDERS".to_string(), "env".to_string()),
+            ("RUST_LOG".to_string(), "info".to_string()),
+        ])
+    }
+
+    #[test]
+    fn render_template_uses_current_orchestrator_env_names() {
+        let rendered = render_render_yaml(&args(OrchestratorDeployProvider::Render), &env());
+        assert!(rendered.contains("HARN_ORCHESTRATOR_LISTEN"));
+        assert!(rendered.contains("HARN_EVENT_LOG_BACKEND"));
+        assert!(rendered.contains("healthCheckPath: /healthz"));
+    }
+
+    #[test]
+    fn fly_template_keeps_one_instance_for_cron_and_metrics() {
+        let rendered = render_fly_toml(&args(OrchestratorDeployProvider::Fly), &env());
+        assert!(rendered.contains("min_machines_running = 1"));
+        assert!(rendered.contains("[metrics]"));
+        assert!(rendered.contains("kill_timeout = \"45s\""));
+    }
+
+    #[test]
+    fn railway_template_is_valid_json() {
+        let rendered =
+            render_railway_json(&args(OrchestratorDeployProvider::Railway), &env()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(parsed["deploy"]["healthcheckPath"], "/healthz");
+        assert_eq!(
+            parsed["environments"]["production"]["variables"]["HARN_SECRET_PROVIDERS"],
+            "env"
+        );
+    }
+
+    #[test]
+    fn manifest_secret_refs_map_to_env_vars() {
+        assert_eq!(
+            secret_ref_env_name("github/installation-123/private-key"),
+            Some("HARN_SECRET_GITHUB_INSTALLATION_123_PRIVATE_KEY".to_string())
+        );
+        assert_eq!(
+            secret_ref_env_name("slack/signing-secret@7"),
+            Some("HARN_SECRET_SLACK_SIGNING_SECRET_V7".to_string())
+        );
+    }
+
+    #[test]
+    fn provider_commands_are_rendered_without_secrets_in_specs() {
+        let mut secrets = BTreeMap::new();
+        secrets.insert("OPENAI_API_KEY".to_string(), "sk-test".to_string());
+        let commands = secret_sync_commands(&args(OrchestratorDeployProvider::Fly), &secrets);
+        assert_eq!(commands.len(), 1);
+        assert!(commands[0].display().contains("fly secrets set"));
+        assert!(commands[0].display().contains("OPENAI_API_KEY=***"));
+        assert!(!commands[0].display().contains("sk-test"));
+    }
+
+    #[test]
+    fn railway_syncs_public_env_and_custom_dockerfile_path() {
+        let commands = public_env_sync_commands(&args(OrchestratorDeployProvider::Railway), &env());
+        assert!(commands
+            .iter()
+            .any(|command| command.display().contains("RAILWAY_DOCKERFILE_PATH")));
+        assert!(commands
+            .iter()
+            .any(|command| command.display().contains("HARN_ORCHESTRATOR_LISTEN")));
+    }
+
+    #[test]
+    fn build_command_uses_manifest_context_even_with_nested_deploy_dir() {
+        let mut args = args(OrchestratorDeployProvider::Fly);
+        args.deploy_dir = PathBuf::from("ops/deploy");
+        args.build = true;
+        let bundle = DeployBundle {
+            provider_dir: PathBuf::from("/repo/ops/deploy/fly"),
+            context_dir: PathBuf::from("/repo"),
+            dockerfile_path: PathBuf::from("/repo/ops/deploy/fly/Dockerfile"),
+            spec_path: PathBuf::from("/repo/ops/deploy/fly/fly.toml"),
+            spec_contents: String::new(),
+        };
+        let command = build_image_command(&args, &bundle);
+        assert_eq!(command.cwd.as_deref(), Some(Path::new("/repo")));
+        assert!(command
+            .display()
+            .contains("/repo/ops/deploy/fly/Dockerfile"));
+    }
+}

--- a/crates/harn-cli/src/commands/orchestrator/mod.rs
+++ b/crates/harn-cli/src/commands/orchestrator/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod common;
+mod deploy;
 mod dlq;
 mod fire;
 mod inspect;
@@ -19,6 +20,7 @@ use crate::cli::{OrchestratorArgs, OrchestratorCommand};
 pub(crate) async fn handle(args: OrchestratorArgs) -> Result<(), String> {
     match args.command {
         OrchestratorCommand::Serve(serve_args) => serve::run(serve_args).await,
+        OrchestratorCommand::Deploy(deploy_args) => deploy::run(deploy_args).await,
         OrchestratorCommand::Reload(reload_args) => reload::run(reload_args).await,
         OrchestratorCommand::Inspect(inspect_args) => inspect::run(inspect_args).await,
         OrchestratorCommand::Fire(fire_args) => fire::run(fire_args).await,

--- a/deploy/fly/fly.toml
+++ b/deploy/fly/fly.toml
@@ -1,0 +1,37 @@
+app = "harn-orchestrator"
+kill_signal = "SIGTERM"
+kill_timeout = "30s"
+
+[build]
+  image = "ghcr.io/burin-labs/harn:latest"
+
+[env]
+  HARN_ORCHESTRATOR_MANIFEST = "/app/harn.toml"
+  HARN_ORCHESTRATOR_LISTEN = "0.0.0.0:8080"
+  HARN_ORCHESTRATOR_STATE_DIR = "/data/state"
+  HARN_EVENT_LOG_BACKEND = "sqlite"
+  HARN_EVENT_LOG_SQLITE_PATH = "/data/events.sqlite"
+  HARN_SECRET_PROVIDERS = "env"
+  RUST_LOG = "info"
+
+[mounts]
+  source = "harn_data"
+  destination = "/data"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    path = "/healthz"
+    timeout = "5s"
+
+[metrics]
+  port = 8080
+  path = "/metrics"

--- a/deploy/railway/railway.json
+++ b/deploy/railway/railway.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "deploy/railway/Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "harn orchestrator serve --shutdown-timeout 30",
+    "healthcheckPath": "/healthz",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  },
+  "environments": {
+    "production": {
+      "variables": {
+        "HARN_ORCHESTRATOR_MANIFEST": "/app/harn.toml",
+        "HARN_ORCHESTRATOR_LISTEN": "0.0.0.0:8080",
+        "HARN_ORCHESTRATOR_STATE_DIR": "/data/state",
+        "HARN_EVENT_LOG_BACKEND": "sqlite",
+        "HARN_EVENT_LOG_SQLITE_PATH": "/data/events.sqlite",
+        "HARN_SECRET_PROVIDERS": "env",
+        "RUST_LOG": "info"
+      }
+    }
+  }
+}

--- a/deploy/render/render.yaml
+++ b/deploy/render/render.yaml
@@ -1,0 +1,27 @@
+services:
+  - type: web
+    name: harn-orchestrator
+    runtime: image
+    image:
+      url: ghcr.io/burin-labs/harn:latest
+    disk:
+      name: harn-data
+      mountPath: /data
+      sizeGB: 10
+    envVars:
+      - key: HARN_ORCHESTRATOR_MANIFEST
+        value: "/app/harn.toml"
+      - key: HARN_ORCHESTRATOR_LISTEN
+        value: "0.0.0.0:8080"
+      - key: HARN_ORCHESTRATOR_STATE_DIR
+        value: "/data/state"
+      - key: HARN_EVENT_LOG_BACKEND
+        value: sqlite
+      - key: HARN_EVENT_LOG_SQLITE_PATH
+        value: "/data/events.sqlite"
+      - key: HARN_SECRET_PROVIDERS
+        value: env
+      - key: RUST_LOG
+        value: info
+      - fromGroup: harn-secrets
+    healthCheckPath: /healthz

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -65,6 +65,9 @@
 - [Hot reload](./orchestrator/hot-reload.md)
 - [Worker dispatch](./orchestrator/worker-dispatch.md)
 - [Orchestrator secrets](./orchestrator/secrets.md)
+- [Deploy to Render](./deploy/render.md)
+- [Deploy to Fly.io](./deploy/fly.md)
+- [Deploy to Railway](./deploy/railway.md)
 
 # Reference
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -514,6 +514,9 @@ harn orchestrator queue --config harn.toml --state-dir ./.harn/orchestrator drai
 
 # Drop ready jobs from a worker queue.
 harn orchestrator queue --config harn.toml --state-dir ./.harn/orchestrator purge <queue> --confirm
+
+# Generate and run a cloud deploy bundle.
+harn orchestrator deploy --provider fly --manifest ./harn.toml --build --dry-run
 ```
 
 `harn orchestrator inspect/fire/replay/dlq/queue` are offline
@@ -523,6 +526,11 @@ directory. Environment variables `HARN_ORCHESTRATOR_MANIFEST`,
 `HARN_ORCHESTRATOR_LISTEN`, `HARN_ORCHESTRATOR_STATE_DIR`,
 `HARN_ORCHESTRATOR_API_KEYS`, and `HARN_ORCHESTRATOR_HMAC_SECRET`
 configure the serve entry point for container deployments.
+`harn orchestrator deploy` accepts `--provider render|fly|railway`,
+validates the manifest with the orchestrator runtime, writes provider files
+under `deploy/<provider>/`, optionally builds/pushes `--image` with
+`--build`, and syncs locally available secrets unless `--no-secret-sync` is
+set.
 
 ## harn trigger replay
 

--- a/docs/src/deploy/fly.md
+++ b/docs/src/deploy/fly.md
@@ -1,0 +1,34 @@
+# Deploy to Fly.io
+
+Harn ships a Fly template at `deploy/fly/fly.toml` and the deploy helper can
+generate a project-local app config:
+
+```bash
+harn orchestrator deploy \
+  --provider fly \
+  --manifest ./harn.toml \
+  --name harn-prod \
+  --region sjc \
+  --image ghcr.io/acme/harn-prod:latest \
+  --build
+```
+
+Before the first deploy, create the app and its persistent volume:
+
+```bash
+fly apps create harn-prod
+fly volumes create harn_data --app harn-prod --size 10 --region sjc
+```
+
+The generated `fly.toml` keeps one machine running by default so cron-heavy
+workloads do not miss scheduled fires during scale-to-zero cold starts. It
+uses `/healthz` for HTTP checks and exposes Harn's Prometheus metrics from
+`/metrics` on the same internal listener port.
+
+Secret sync uses `fly secrets set`. The deploy helper syncs values supplied
+with `--secret KEY=VALUE`, common provider keys such as `OPENAI_API_KEY`, and
+env-backed manifest secrets like `HARN_SECRET_GITHUB_WEBHOOK_SECRET` when
+those variables are already present locally.
+
+Fly provides automatic TLS on the public hostname. Keep the orchestrator
+container on plain HTTP with `HARN_ORCHESTRATOR_LISTEN=0.0.0.0:8080`.

--- a/docs/src/deploy/railway.md
+++ b/docs/src/deploy/railway.md
@@ -1,0 +1,29 @@
+# Deploy to Railway
+
+Harn ships a Railway config at `deploy/railway/railway.json`. The deploy
+helper can generate it and run the Railway CLI:
+
+```bash
+harn orchestrator deploy \
+  --provider railway \
+  --manifest ./harn.toml \
+  --railway-service harn-prod \
+  --railway-environment production
+```
+
+Railway reads `railway.json` for build and deploy settings. The generated
+config uses the Dockerfile builder, starts `harn orchestrator serve`, checks
+`/healthz`, and sets the runtime variables needed for a SQLite-backed
+orchestrator EventLog.
+
+Secret sync uses `railway variable set`. The helper syncs `--secret KEY=VALUE`
+values, common provider API keys from the local environment, and
+`HARN_SECRET_*` variables referenced by manifest trigger secrets when they are
+set locally. It also stages the public Harn runtime variables and
+`RAILWAY_DOCKERFILE_PATH=deploy/railway/Dockerfile` so `railway up` builds the
+same deploy bundle it generated. Railway applies variable changes as staged
+service changes; review and deploy them in the Railway UI if your project
+requires manual approvals.
+
+Railway provides TLS for public domains. Keep Harn listening on plain HTTP in
+the container and let Railway terminate HTTPS.

--- a/docs/src/deploy/render.md
+++ b/docs/src/deploy/render.md
@@ -1,0 +1,36 @@
+# Deploy to Render
+
+Harn ships a Render Blueprint at `deploy/render/render.yaml` and the
+`harn orchestrator deploy` helper can generate a project-local variant for
+your manifest.
+
+```bash
+harn orchestrator deploy \
+  --provider render \
+  --manifest ./harn.toml \
+  --image ghcr.io/acme/harn-orchestrator:latest \
+  --build \
+  --render-service srv-xxxxxxxx
+```
+
+The helper validates the manifest by booting the single-tenant orchestrator
+runtime in a temporary state directory, writes `deploy/render/render.yaml`,
+and writes `deploy/render/Dockerfile`. The Dockerfile packages the current
+project on top of the published Harn runtime image so local handlers and
+prompt assets are available at `/app` in the container.
+
+Render secrets should live in the `harn-secrets` environment group referenced
+by the Blueprint. When `--render-service` is supplied, `--secret KEY=VALUE`
+values and locally set Harn secret env vars are also pushed through the Render
+CLI before the deploy command runs.
+
+The generated service uses:
+
+- `GET /healthz` for Render health checks.
+- `/data` for persistent orchestrator state and the SQLite EventLog.
+- `HARN_ORCHESTRATOR_LISTEN=0.0.0.0:8080`.
+- `HARN_SECRET_PROVIDERS=env`.
+
+Render provides TLS at the edge, so the orchestrator should run plain HTTP in
+the container unless you have a provider-specific reason to terminate TLS
+inside Harn.

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -235,6 +235,22 @@ The image healthcheck issues `GET /health` against the local listener, so
 it works with Docker, BuildKit smoke tests, and most container platforms
 without requiring curl inside the distroless runtime.
 
+For managed cloud deploys, use `harn orchestrator deploy` to validate the
+manifest, generate a provider deploy bundle, optionally build/push an image,
+sync locally available secrets, and run the provider CLI:
+
+```bash
+harn orchestrator deploy --provider fly --manifest ./harn.toml --build
+harn orchestrator deploy --provider render --manifest ./harn.toml --render-service srv-...
+harn orchestrator deploy --provider railway --manifest ./harn.toml
+```
+
+Provider-specific templates and notes live under:
+
+- [Render](./deploy/render.md)
+- [Fly.io](./deploy/fly.md)
+- [Railway](./deploy/railway.md)
+
 ### Trigger examples
 
 ```toml


### PR DESCRIPTION
## Summary

Implements #188 by adding cloud deploy templates and a new `harn orchestrator deploy` helper for Render, Fly.io, and Railway.

- Adds checked-in provider templates under `deploy/render`, `deploy/fly`, and `deploy/railway`.
- Adds `harn orchestrator deploy --provider render|fly|railway`, including manifest validation through the orchestrator runtime, provider bundle generation, optional Docker build/push, provider CLI execution, secret/env sync, dry-run output, and optional health probing.
- Documents provider-specific flows and adds README / orchestrator / CLI reference links.

## Notes

- The deploy helper packages the project on top of the published Harn runtime image via a generated provider Dockerfile so local handlers and assets are available inside the container.
- Secret values are redacted in dry-run command output.
- Railway deploys sync public runtime variables plus `RAILWAY_DOCKERFILE_PATH=deploy/railway/Dockerfile` before `railway up`, matching Railway's CLI/custom-Dockerfile model.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-issue-188 cargo test -p harn-cli deploy`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-188 cargo clippy -p harn-cli --all-targets -- -D warnings`
- `npx markdownlint-cli2 README.md docs/src/orchestrator.md docs/src/cli-reference.md docs/src/deploy/*.md`
- Dry-run smoke: `/tmp/harn-target-issue-188/debug/harn orchestrator deploy --provider fly --manifest harn.toml --deploy-dir ops/deploy --build --no-push --dry-run --no-secret-sync`
- Dry-run smoke: `/tmp/harn-target-issue-188/debug/harn orchestrator deploy --provider railway --manifest harn.toml --secret OPENAI_API_KEY=sk-test --dry-run`

Local pre-commit was attempted. Its Rust clippy, highlight keyword sync, and markdown phases passed, but the hook failed in `portal:lint` on existing React hook lint errors in portal files that this PR does not touch.
