### PR TITLE
[codex] Reduce boxed VM dispatch futures

### DIFF
--- a/crates/harn-vm/src/vm/dispatch.rs
+++ b/crates/harn-vm/src/vm/dispatch.rs
@@ -104,26 +104,53 @@ impl Vm {
     /// `VmValue::BuiltinRef`, so builtin names passed by reference (e.g.
     /// `dict.rekey(snake_to_camel)`) dispatch through the same code path as
     /// user-defined closures.
-    #[allow(clippy::manual_async_fn)]
-    pub(crate) fn call_callable_value<'a>(
-        &'a mut self,
-        callable: &'a VmValue,
-        args: &'a [VmValue],
-        functions: &'a [CompiledFunction],
-    ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>> + 'a>> {
-        Box::pin(async move {
-            match callable {
-                VmValue::Closure(closure) => self.call_closure(closure, args, functions).await,
-                VmValue::BuiltinRef(name) => {
-                    let name_owned = name.to_string();
-                    self.call_named_builtin(&name_owned, args.to_vec()).await
+    pub(crate) async fn call_callable_value(
+        &mut self,
+        callable: &VmValue,
+        args: &[VmValue],
+        functions: &[CompiledFunction],
+    ) -> Result<VmValue, VmError> {
+        match callable {
+            VmValue::Closure(closure) => self.call_closure(closure, args, functions).await,
+            VmValue::BuiltinRef(name) => {
+                if let Some(result) = self.call_sync_builtin_by_ref(name, args) {
+                    result
+                } else {
+                    self.call_named_builtin(name, args.to_vec()).await
                 }
-                other => Err(VmError::TypeError(format!(
-                    "expected callable, got {}",
-                    other.type_name()
-                ))),
             }
-        })
+            other => Err(VmError::TypeError(format!(
+                "expected callable, got {}",
+                other.type_name()
+            ))),
+        }
+    }
+
+    fn call_sync_builtin_by_ref(
+        &mut self,
+        name: &str,
+        args: &[VmValue],
+    ) -> Option<Result<VmValue, VmError>> {
+        let builtin = self.builtins.get(name).cloned()?;
+
+        let span_kind = match name {
+            "llm_call" | "llm_stream" | "agent_loop" => Some(crate::tracing::SpanKind::LlmCall),
+            "mcp_call" => Some(crate::tracing::SpanKind::ToolCall),
+            _ => None,
+        };
+        let _span = span_kind.map(|kind| ScopeSpan::new(kind, name.to_string()));
+
+        if self.denied_builtins.contains(name) {
+            return Some(Err(VmError::CategorizedError {
+                message: format!("Tool '{}' is not permitted.", name),
+                category: ErrorCategory::ToolRejected,
+            }));
+        }
+        if let Err(err) = crate::orchestration::enforce_current_policy_for_builtin(name, args) {
+            return Some(Err(err));
+        }
+
+        Some(builtin(args, &mut self.output))
     }
 
     /// Returns true if `v` is callable via `call_callable_value`.

--- a/crates/harn-vm/src/vm/iter.rs
+++ b/crates/harn-vm/src/vm/iter.rs
@@ -9,6 +9,8 @@
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
+use std::future::Future;
+use std::pin::Pin;
 use std::rc::Rc;
 
 use crate::chunk::CompiledFunction;
@@ -113,13 +115,12 @@ impl VmIter {
     ///
     /// Combinator variants (`Map`, `Filter`, `FlatMap`) invoke user-provided
     /// closures through the `vm` / `functions` parameters.
-    pub fn next<'a>(
-        &'a mut self,
-        vm: &'a mut crate::vm::Vm,
-        functions: &'a [CompiledFunction],
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Option<VmValue>, VmError>> + 'a>>
-    {
-        Box::pin(async move { self.next_impl(vm, functions).await })
+    pub async fn next(
+        &mut self,
+        vm: &mut crate::vm::Vm,
+        functions: &[CompiledFunction],
+    ) -> Result<Option<VmValue>, VmError> {
+        self.next_impl(vm, functions).await
     }
 
     async fn next_impl(
@@ -196,7 +197,7 @@ impl VmIter {
             }
             VmIter::Map { inner, f } => {
                 let f = f.clone();
-                let item = next_handle(inner, vm, functions).await?;
+                let item = next_handle_boxed(inner, vm, functions).await?;
                 match item {
                     None => {
                         *self = VmIter::Exhausted;
@@ -211,7 +212,7 @@ impl VmIter {
             VmIter::Filter { inner, p } => {
                 let p = p.clone();
                 loop {
-                    let item = next_handle(inner, vm, functions).await?;
+                    let item = next_handle_boxed(inner, vm, functions).await?;
                     match item {
                         None => {
                             *self = VmIter::Exhausted;
@@ -230,13 +231,13 @@ impl VmIter {
                 let f = f.clone();
                 loop {
                     if let Some(cur_iter) = cur.clone() {
-                        let item = next_handle(&cur_iter, vm, functions).await?;
+                        let item = next_handle_boxed(&cur_iter, vm, functions).await?;
                         if let Some(v) = item {
                             return Ok(Some(v));
                         }
                         *cur = None;
                     }
-                    let item = next_handle(inner, vm, functions).await?;
+                    let item = next_handle_boxed(inner, vm, functions).await?;
                     match item {
                         None => {
                             *self = VmIter::Exhausted;
@@ -261,7 +262,7 @@ impl VmIter {
                     *self = VmIter::Exhausted;
                     return Ok(None);
                 }
-                let item = next_handle(inner, vm, functions).await?;
+                let item = next_handle_boxed(inner, vm, functions).await?;
                 match item {
                     None => {
                         *self = VmIter::Exhausted;
@@ -278,7 +279,7 @@ impl VmIter {
             }
             VmIter::Skip { inner, remaining } => {
                 while *remaining > 0 {
-                    let item = next_handle(inner, vm, functions).await?;
+                    let item = next_handle_boxed(inner, vm, functions).await?;
                     match item {
                         None => {
                             *self = VmIter::Exhausted;
@@ -289,7 +290,7 @@ impl VmIter {
                         }
                     }
                 }
-                let item = next_handle(inner, vm, functions).await?;
+                let item = next_handle_boxed(inner, vm, functions).await?;
                 match item {
                     None => {
                         *self = VmIter::Exhausted;
@@ -303,7 +304,7 @@ impl VmIter {
                     return Ok(None);
                 }
                 let p = p.clone();
-                let item = next_handle(inner, vm, functions).await?;
+                let item = next_handle_boxed(inner, vm, functions).await?;
                 match item {
                     None => {
                         *self = VmIter::Exhausted;
@@ -322,7 +323,7 @@ impl VmIter {
             }
             VmIter::SkipWhile { inner, p, primed } => {
                 if *primed {
-                    let item = next_handle(inner, vm, functions).await?;
+                    let item = next_handle_boxed(inner, vm, functions).await?;
                     return match item {
                         None => {
                             *self = VmIter::Exhausted;
@@ -333,7 +334,7 @@ impl VmIter {
                 }
                 let p = p.clone();
                 loop {
-                    let item = next_handle(inner, vm, functions).await?;
+                    let item = next_handle_boxed(inner, vm, functions).await?;
                     match item {
                         None => {
                             *self = VmIter::Exhausted;
@@ -351,7 +352,7 @@ impl VmIter {
                 }
             }
             VmIter::Zip { a, b } => {
-                let ia = next_handle(a, vm, functions).await?;
+                let ia = next_handle_boxed(a, vm, functions).await?;
                 let x = match ia {
                     None => {
                         *self = VmIter::Exhausted;
@@ -359,7 +360,7 @@ impl VmIter {
                     }
                     Some(v) => v,
                 };
-                let ib = next_handle(b, vm, functions).await?;
+                let ib = next_handle_boxed(b, vm, functions).await?;
                 let y = match ib {
                     None => {
                         *self = VmIter::Exhausted;
@@ -370,7 +371,7 @@ impl VmIter {
                 Ok(Some(VmValue::Pair(Rc::new((x, y)))))
             }
             VmIter::Enumerate { inner, i } => {
-                let item = next_handle(inner, vm, functions).await?;
+                let item = next_handle_boxed(inner, vm, functions).await?;
                 match item {
                     None => {
                         *self = VmIter::Exhausted;
@@ -385,13 +386,13 @@ impl VmIter {
             }
             VmIter::Chain { a, b, on_a } => {
                 if *on_a {
-                    let item = next_handle(a, vm, functions).await?;
+                    let item = next_handle_boxed(a, vm, functions).await?;
                     if let Some(v) = item {
                         return Ok(Some(v));
                     }
                     *on_a = false;
                 }
-                let item = next_handle(b, vm, functions).await?;
+                let item = next_handle_boxed(b, vm, functions).await?;
                 match item {
                     None => {
                         *self = VmIter::Exhausted;
@@ -404,7 +405,7 @@ impl VmIter {
                 let n = *n;
                 let mut batch: Vec<VmValue> = Vec::with_capacity(n);
                 for _ in 0..n {
-                    let item = next_handle(inner, vm, functions).await?;
+                    let item = next_handle_boxed(inner, vm, functions).await?;
                     match item {
                         Some(v) => batch.push(v),
                         None => break,
@@ -421,7 +422,7 @@ impl VmIter {
                 let n = *n;
                 if buf.is_empty() {
                     while buf.len() < n {
-                        let item = next_handle(inner, vm, functions).await?;
+                        let item = next_handle_boxed(inner, vm, functions).await?;
                         match item {
                             Some(v) => buf.push_back(v),
                             None => {
@@ -431,7 +432,7 @@ impl VmIter {
                         }
                     }
                 } else {
-                    let item = next_handle(inner, vm, functions).await?;
+                    let item = next_handle_boxed(inner, vm, functions).await?;
                     match item {
                         Some(v) => {
                             buf.pop_front();
@@ -486,6 +487,14 @@ pub async fn next_handle(
     // Restore state unless the inner call replaced it with Exhausted.
     *handle.borrow_mut() = state;
     result
+}
+
+fn next_handle_boxed<'a>(
+    handle: &'a Rc<RefCell<VmIter>>,
+    vm: &'a mut crate::vm::Vm,
+    functions: &'a [CompiledFunction],
+) -> Pin<Box<dyn Future<Output = Result<Option<VmValue>, VmError>> + 'a>> {
+    Box::pin(next_handle(handle, vm, functions))
 }
 
 /// Fully consume an iter handle into a Vec of values.

--- a/crates/harn-vm/src/vm/methods/dispatch.rs
+++ b/crates/harn-vm/src/vm/methods/dispatch.rs
@@ -1,54 +1,47 @@
-use std::future::Future;
-use std::pin::Pin;
-
 use crate::chunk::CompiledFunction;
 use crate::value::{VmError, VmValue};
 use crate::vm::iter::iter_from_value;
 
 impl crate::vm::Vm {
-    pub(in crate::vm) fn call_method<'a>(
-        &'a mut self,
+    pub(in crate::vm) async fn call_method(
+        &mut self,
         obj: VmValue,
-        method: &'a str,
-        args: &'a [VmValue],
-        functions: &'a [CompiledFunction],
-    ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>> + 'a>> {
-        Box::pin(async move {
-            if method == "iter"
-                && matches!(
-                    &obj,
-                    VmValue::List(_)
-                        | VmValue::Set(_)
-                        | VmValue::Dict(_)
-                        | VmValue::String(_)
-                        | VmValue::Generator(_)
-                        | VmValue::Channel(_)
-                        | VmValue::Iter(_)
-                )
-            {
-                return iter_from_value(obj);
-            }
+        method: &str,
+        args: &[VmValue],
+        functions: &[CompiledFunction],
+    ) -> Result<VmValue, VmError> {
+        if method == "iter"
+            && matches!(
+                &obj,
+                VmValue::List(_)
+                    | VmValue::Set(_)
+                    | VmValue::Dict(_)
+                    | VmValue::String(_)
+                    | VmValue::Generator(_)
+                    | VmValue::Channel(_)
+                    | VmValue::Iter(_)
+            )
+        {
+            return iter_from_value(obj);
+        }
 
-            match &obj {
-                VmValue::String(s) => self.call_string_method(s, method, args),
-                VmValue::List(items) => self.call_list_method(items, method, args, functions).await,
-                VmValue::Dict(map) => self.call_dict_method(map, method, args, functions).await,
-                VmValue::Set(items) => self.call_set_method(items, method, args, functions).await,
-                VmValue::Range(r) => {
-                    self.call_range_method(&obj, r, method, args, functions)
-                        .await
-                }
-                VmValue::Int(_) | VmValue::Float(_) => self.call_number_method(&obj, method, args),
-                VmValue::StructInstance { .. } => {
-                    self.call_struct_instance_method(&obj, method, args, functions)
-                        .await
-                }
-                VmValue::Generator(gen) => self.call_generator_method(gen, method).await,
-                VmValue::Iter(handle) => {
-                    self.call_iter_method(handle, method, args, functions).await
-                }
-                _ => Ok(VmValue::Nil),
+        match &obj {
+            VmValue::String(s) => self.call_string_method(s, method, args),
+            VmValue::List(items) => self.call_list_method(items, method, args, functions).await,
+            VmValue::Dict(map) => self.call_dict_method(map, method, args, functions).await,
+            VmValue::Set(items) => self.call_set_method(items, method, args, functions).await,
+            VmValue::Range(r) => {
+                self.call_range_method(&obj, r, method, args, functions)
+                    .await
             }
-        })
+            VmValue::Int(_) | VmValue::Float(_) => self.call_number_method(&obj, method, args),
+            VmValue::StructInstance { .. } => {
+                self.call_struct_instance_method(&obj, method, args, functions)
+                    .await
+            }
+            VmValue::Generator(gen) => self.call_generator_method(gen, method).await,
+            VmValue::Iter(handle) => self.call_iter_method(handle, method, args, functions).await,
+            _ => Ok(VmValue::Nil),
+        }
     }
 }

--- a/crates/harn-vm/src/vm/methods/range.rs
+++ b/crates/harn-vm/src/vm/methods/range.rs
@@ -27,7 +27,11 @@ impl crate::vm::Vm {
             "to_string" => Ok(VmValue::String(std::rc::Rc::from(obj.display()))),
             _ => {
                 let lifted = iter_from_value(obj.clone())?;
-                self.call_method(lifted, method, args, functions).await
+                let VmValue::Iter(handle) = lifted else {
+                    unreachable!("iter_from_value returns Iter for ranges")
+                };
+                self.call_iter_method(&handle, method, args, functions)
+                    .await
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #412.

- Convert VM method dispatch and callable-value dispatch from manually boxed future wrappers to native `async fn` paths.
- Keep boxing isolated to recursive iterator-handle advancement, so top-level iterator stepping and method dispatch no longer allocate boxed wrapper futures.
- Add a sync builtin-reference fast path that preserves tracing, sandbox denial, and capability policy checks while avoiding the `Vec` clone for sync builtins.
- Route range fallback methods directly through iterator method dispatch to avoid reintroducing async recursion through `call_method`.

## Validation

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-412 cargo check -p harn-vm`
- `CARGO_TARGET_DIR=/tmp/harn-target-412 cargo test -p harn-vm vm::tests_runtime`
- `CARGO_TARGET_DIR=/tmp/harn-target-412 cargo run --quiet --bin harn -- test conformance --filter collections/iter`
- `cargo build --bin harn`
- `cargo run --quiet --bin harn -- test conformance` (620 passed, 0 failed)
- `cargo clippy -p harn-vm --all-targets -- -D warnings`
- Benchmark smoke runs:
  - `cargo run --quiet --bin harn -- bench conformance/tests/collections/list_map.harn --iterations 5`
  - `cargo run --quiet --bin harn -- bench conformance/tests/collections/iter_combinators_map_filter.harn --iterations 5`
  - `cargo run --quiet --bin harn -- bench conformance/tests/collections/range_iter_lazy.harn --iterations 5`

## Local Hook Note

The Rust/markdown/conformance portions of the local hooks passed, but `portal:lint` currently fails on existing `react-hooks/set-state-in-effect` findings in the portal frontend files. Those files are unrelated to this VM change and were not modified here.