### PR TITLE
[codex] Add VM inline caches

### DIFF
--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -1,4 +1,7 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::fmt;
+use std::rc::Rc;
 
 /// Bytecode opcodes for the Harn VM.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -208,6 +211,58 @@ pub enum Constant {
     Duration(u64),
 }
 
+/// Monomorphic inline-cache state for bytecode instructions that repeatedly
+/// resolve the same property or builtin method. Cache guards are intentionally
+/// conservative: each entry is tied to the instruction's name constant index
+/// and a single receiver variant. Harn collection values are immutable or
+/// copy-on-write at the VM level, so list/string/pair/range/set/dict receiver
+/// kind caches do not need invalidation; dynamic dict fields and struct fields
+/// are left on the generic path until they have stable layout metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum InlineCacheEntry {
+    Empty,
+    Property {
+        name_idx: u16,
+        target: PropertyCacheTarget,
+    },
+    Method {
+        name_idx: u16,
+        argc: usize,
+        target: MethodCacheTarget,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PropertyCacheTarget {
+    ListCount,
+    ListEmpty,
+    ListFirst,
+    ListLast,
+    StringCount,
+    StringEmpty,
+    PairFirst,
+    PairSecond,
+    EnumVariant,
+    EnumFields,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MethodCacheTarget {
+    ListCount,
+    ListEmpty,
+    StringCount,
+    StringEmpty,
+    DictCount,
+    RangeCount,
+    RangeLen,
+    RangeEmpty,
+    RangeFirst,
+    RangeLast,
+    SetCount,
+    SetLen,
+    SetEmpty,
+}
+
 impl fmt::Display for Constant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -242,6 +297,12 @@ pub struct Chunk {
     current_col: u32,
     /// Compiled function bodies (for closures).
     pub functions: Vec<CompiledFunction>,
+    /// Instruction offset to inline-cache slot. Slots are assigned at emit time
+    /// for cacheable instructions while bytecode bytes remain immutable.
+    inline_cache_slots: BTreeMap<usize, usize>,
+    /// Shared cache entries so cloned chunks in call frames warm the same side
+    /// table as the compiled chunk used by tests/debugging.
+    inline_caches: Rc<RefCell<Vec<InlineCacheEntry>>>,
 }
 
 /// A compiled function (closure body).
@@ -268,6 +329,8 @@ impl Chunk {
             source_file: None,
             current_col: 0,
             functions: Vec::new(),
+            inline_cache_slots: BTreeMap::new(),
+            inline_caches: Rc::new(RefCell::new(Vec::new())),
         }
     }
 
@@ -299,6 +362,7 @@ impl Chunk {
     /// Emit an instruction with a u16 argument.
     pub fn emit_u16(&mut self, op: Op, arg: u16, line: u32) {
         let col = self.current_col;
+        let op_offset = self.code.len();
         self.code.push(op as u8);
         self.code.push((arg >> 8) as u8);
         self.code.push((arg & 0xFF) as u8);
@@ -308,6 +372,12 @@ impl Chunk {
         self.columns.push(col);
         self.columns.push(col);
         self.columns.push(col);
+        if matches!(
+            op,
+            Op::GetProperty | Op::GetPropertyOpt | Op::MethodCallSpread
+        ) {
+            self.register_inline_cache(op_offset);
+        }
     }
 
     /// Emit an instruction with a u8 argument.
@@ -333,6 +403,7 @@ impl Chunk {
 
     fn emit_method_call_inner(&mut self, op: Op, name_idx: u16, arg_count: u8, line: u32) {
         let col = self.current_col;
+        let op_offset = self.code.len();
         self.code.push(op as u8);
         self.code.push((name_idx >> 8) as u8);
         self.code.push((name_idx & 0xFF) as u8);
@@ -345,6 +416,7 @@ impl Chunk {
         self.columns.push(col);
         self.columns.push(col);
         self.columns.push(col);
+        self.register_inline_cache(op_offset);
     }
 
     /// Current code offset (for jump patching).
@@ -385,6 +457,39 @@ impl Chunk {
     /// Read a u16 argument at the given position.
     pub fn read_u16(&self, pos: usize) -> u16 {
         ((self.code[pos] as u16) << 8) | (self.code[pos + 1] as u16)
+    }
+
+    fn register_inline_cache(&mut self, op_offset: usize) {
+        if self.inline_cache_slots.contains_key(&op_offset) {
+            return;
+        }
+        let mut entries = self.inline_caches.borrow_mut();
+        let slot = entries.len();
+        entries.push(InlineCacheEntry::Empty);
+        self.inline_cache_slots.insert(op_offset, slot);
+    }
+
+    pub(crate) fn inline_cache_slot(&self, op_offset: usize) -> Option<usize> {
+        self.inline_cache_slots.get(&op_offset).copied()
+    }
+
+    pub(crate) fn inline_cache_entry(&self, slot: usize) -> InlineCacheEntry {
+        self.inline_caches
+            .borrow()
+            .get(slot)
+            .cloned()
+            .unwrap_or(InlineCacheEntry::Empty)
+    }
+
+    pub(crate) fn set_inline_cache_entry(&self, slot: usize, entry: InlineCacheEntry) {
+        if let Some(existing) = self.inline_caches.borrow_mut().get_mut(slot) {
+            *existing = entry;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inline_cache_entries(&self) -> Vec<InlineCacheEntry> {
+        self.inline_caches.borrow().clone()
     }
 
     /// Disassemble for debugging.

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -1,11 +1,102 @@
 use std::rc::Rc;
 
-use crate::chunk::Op;
+use crate::chunk::{InlineCacheEntry, MethodCacheTarget, Op};
 use crate::value::{VmClosure, VmError, VmValue};
 
 use super::super::CallFrame;
 
 impl super::super::Vm {
+    fn try_cached_method(
+        cache: &InlineCacheEntry,
+        name_idx: u16,
+        argc: usize,
+        obj: &VmValue,
+    ) -> Option<VmValue> {
+        let InlineCacheEntry::Method {
+            name_idx: cached_name_idx,
+            argc: cached_argc,
+            target,
+        } = cache
+        else {
+            return None;
+        };
+        if *cached_name_idx != name_idx || *cached_argc != argc {
+            return None;
+        }
+
+        match (target, obj) {
+            (MethodCacheTarget::ListCount, VmValue::List(items)) => {
+                Some(VmValue::Int(items.len() as i64))
+            }
+            (MethodCacheTarget::ListEmpty, VmValue::List(items)) => {
+                Some(VmValue::Bool(items.is_empty()))
+            }
+            (MethodCacheTarget::StringCount, VmValue::String(s)) => {
+                Some(VmValue::Int(s.chars().count() as i64))
+            }
+            (MethodCacheTarget::StringEmpty, VmValue::String(s)) => {
+                Some(VmValue::Bool(s.is_empty()))
+            }
+            (MethodCacheTarget::DictCount, VmValue::Dict(map)) => {
+                Some(VmValue::Int(map.len() as i64))
+            }
+            (MethodCacheTarget::RangeCount | MethodCacheTarget::RangeLen, VmValue::Range(r)) => {
+                Some(VmValue::Int(r.len()))
+            }
+            (MethodCacheTarget::RangeEmpty, VmValue::Range(r)) => Some(VmValue::Bool(r.is_empty())),
+            (MethodCacheTarget::RangeFirst, VmValue::Range(r)) => {
+                Some(r.first().map(VmValue::Int).unwrap_or(VmValue::Nil))
+            }
+            (MethodCacheTarget::RangeLast, VmValue::Range(r)) => {
+                Some(r.last().map(VmValue::Int).unwrap_or(VmValue::Nil))
+            }
+            (MethodCacheTarget::SetCount | MethodCacheTarget::SetLen, VmValue::Set(items)) => {
+                Some(VmValue::Int(items.len() as i64))
+            }
+            (MethodCacheTarget::SetEmpty, VmValue::Set(items)) => {
+                Some(VmValue::Bool(items.is_empty()))
+            }
+            _ => None,
+        }
+    }
+
+    fn method_cache_target(obj: &VmValue, method: &str, argc: usize) -> Option<MethodCacheTarget> {
+        if argc != 0 {
+            return None;
+        }
+        match obj {
+            VmValue::List(_) => match method {
+                "count" => Some(MethodCacheTarget::ListCount),
+                "empty" => Some(MethodCacheTarget::ListEmpty),
+                _ => None,
+            },
+            VmValue::String(_) => match method {
+                "count" | "len" => Some(MethodCacheTarget::StringCount),
+                "empty" => Some(MethodCacheTarget::StringEmpty),
+                _ => None,
+            },
+            VmValue::Dict(_) => match method {
+                "count" => Some(MethodCacheTarget::DictCount),
+                _ => None,
+            },
+            VmValue::Range(_) => match method {
+                "count" => Some(MethodCacheTarget::RangeCount),
+                "len" => Some(MethodCacheTarget::RangeLen),
+                "empty" => Some(MethodCacheTarget::RangeEmpty),
+                "first" => Some(MethodCacheTarget::RangeFirst),
+                "last" => Some(MethodCacheTarget::RangeLast),
+                _ => None,
+            },
+            VmValue::Set(_) => match method {
+                "count" => Some(MethodCacheTarget::SetCount),
+                "len" => Some(MethodCacheTarget::SetLen),
+                "empty" => Some(MethodCacheTarget::SetEmpty),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     pub(super) async fn try_execute_call_op(&mut self, op: u8) -> Result<bool, VmError> {
         if op == Op::Call as u8 {
             let frame = self.frames.last_mut().unwrap();
@@ -325,27 +416,59 @@ impl super::super::Vm {
             self.stack.push(VmValue::Closure(Rc::new(closure)));
         } else if op == Op::MethodCall as u8 || op == Op::MethodCallOpt as u8 {
             let optional = op == Op::MethodCallOpt as u8;
-            let frame = self.frames.last_mut().unwrap();
-            let name_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let argc = frame.chunk.code[frame.ip] as usize;
-            frame.ip += 1;
-            let method = Self::const_string(&frame.chunk.constants[name_idx])?;
-            let functions = frame.chunk.functions.clone();
+            let (name_idx, argc, cache_slot, cache_entry) = {
+                let frame = self.frames.last_mut().unwrap();
+                let op_offset = frame.ip.saturating_sub(1);
+                let name_idx = frame.chunk.read_u16(frame.ip);
+                frame.ip += 2;
+                let argc = frame.chunk.code[frame.ip] as usize;
+                frame.ip += 1;
+                let cache_slot = frame.chunk.inline_cache_slot(op_offset);
+                let cache_entry = cache_slot
+                    .map(|slot| frame.chunk.inline_cache_entry(slot))
+                    .unwrap_or(InlineCacheEntry::Empty);
+                (name_idx, argc, cache_slot, cache_entry)
+            };
             let args: Vec<VmValue> = self.stack.split_off(self.stack.len().saturating_sub(argc));
             let obj = self.pop()?;
             if optional && matches!(obj, VmValue::Nil) {
                 self.stack.push(VmValue::Nil);
+            } else if let Some(result) = Self::try_cached_method(&cache_entry, name_idx, argc, &obj)
+            {
+                self.stack.push(result);
             } else {
+                let method = {
+                    let frame = self.frames.last().unwrap();
+                    Self::const_string(&frame.chunk.constants[name_idx as usize])?
+                };
+                let cache_target = Self::method_cache_target(&obj, &method, args.len());
+                let functions = self.frames.last().unwrap().chunk.functions.clone();
                 let result = self.call_method(obj, &method, &args, &functions).await?;
+                if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
+                    let frame = self.frames.last().unwrap();
+                    frame.chunk.set_inline_cache_entry(
+                        slot,
+                        InlineCacheEntry::Method {
+                            name_idx,
+                            argc,
+                            target,
+                        },
+                    );
+                }
                 self.stack.push(result);
             }
         } else if op == Op::MethodCallSpread as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let name_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let method = Self::const_string(&frame.chunk.constants[name_idx])?;
-            let functions = frame.chunk.functions.clone();
+            let (name_idx, cache_slot, cache_entry) = {
+                let frame = self.frames.last_mut().unwrap();
+                let op_offset = frame.ip.saturating_sub(1);
+                let name_idx = frame.chunk.read_u16(frame.ip);
+                frame.ip += 2;
+                let cache_slot = frame.chunk.inline_cache_slot(op_offset);
+                let cache_entry = cache_slot
+                    .map(|slot| frame.chunk.inline_cache_entry(slot))
+                    .unwrap_or(InlineCacheEntry::Empty);
+                (name_idx, cache_slot, cache_entry)
+            };
             let args_val = self.pop()?;
             let obj = self.pop()?;
             let args = match args_val {
@@ -356,8 +479,30 @@ impl super::super::Vm {
                     ))
                 }
             };
-            let result = self.call_method(obj, &method, &args, &functions).await?;
-            self.stack.push(result);
+            if let Some(result) = Self::try_cached_method(&cache_entry, name_idx, args.len(), &obj)
+            {
+                self.stack.push(result);
+            } else {
+                let method = {
+                    let frame = self.frames.last().unwrap();
+                    Self::const_string(&frame.chunk.constants[name_idx as usize])?
+                };
+                let cache_target = Self::method_cache_target(&obj, &method, args.len());
+                let functions = self.frames.last().unwrap().chunk.functions.clone();
+                let result = self.call_method(obj, &method, &args, &functions).await?;
+                if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
+                    let frame = self.frames.last().unwrap();
+                    frame.chunk.set_inline_cache_entry(
+                        slot,
+                        InlineCacheEntry::Method {
+                            name_idx,
+                            argc: args.len(),
+                            target,
+                        },
+                    );
+                }
+                self.stack.push(result);
+            }
         } else if op == Op::Pipe as u8 {
             let callable = self.pop()?;
             let value = self.pop()?;

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -1,10 +1,137 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
-use crate::chunk::Op;
+use crate::chunk::{InlineCacheEntry, Op, PropertyCacheTarget};
 use crate::value::{VmError, VmValue};
 
 impl super::super::Vm {
+    fn try_cached_property(
+        cache: &InlineCacheEntry,
+        name_idx: u16,
+        obj: &VmValue,
+    ) -> Option<VmValue> {
+        let InlineCacheEntry::Property {
+            name_idx: cached_name_idx,
+            target,
+        } = cache
+        else {
+            return None;
+        };
+        if *cached_name_idx != name_idx {
+            return None;
+        }
+
+        match (target, obj) {
+            (PropertyCacheTarget::ListCount, VmValue::List(items)) => {
+                Some(VmValue::Int(items.len() as i64))
+            }
+            (PropertyCacheTarget::ListEmpty, VmValue::List(items)) => {
+                Some(VmValue::Bool(items.is_empty()))
+            }
+            (PropertyCacheTarget::ListFirst, VmValue::List(items)) => {
+                Some(items.first().cloned().unwrap_or(VmValue::Nil))
+            }
+            (PropertyCacheTarget::ListLast, VmValue::List(items)) => {
+                Some(items.last().cloned().unwrap_or(VmValue::Nil))
+            }
+            (PropertyCacheTarget::StringCount, VmValue::String(s)) => {
+                Some(VmValue::Int(s.chars().count() as i64))
+            }
+            (PropertyCacheTarget::StringEmpty, VmValue::String(s)) => {
+                Some(VmValue::Bool(s.is_empty()))
+            }
+            (PropertyCacheTarget::PairFirst, VmValue::Pair(p)) => Some(p.0.clone()),
+            (PropertyCacheTarget::PairSecond, VmValue::Pair(p)) => Some(p.1.clone()),
+            (PropertyCacheTarget::EnumVariant, VmValue::EnumVariant { variant, .. }) => {
+                Some(VmValue::String(Rc::from(variant.as_str())))
+            }
+            (PropertyCacheTarget::EnumFields, VmValue::EnumVariant { fields, .. }) => {
+                Some(VmValue::List(Rc::new(fields.clone())))
+            }
+            _ => None,
+        }
+    }
+
+    fn property_cache_target(obj: &VmValue, name: &str) -> Option<PropertyCacheTarget> {
+        match obj {
+            VmValue::List(_) => match name {
+                "count" => Some(PropertyCacheTarget::ListCount),
+                "empty" => Some(PropertyCacheTarget::ListEmpty),
+                "first" => Some(PropertyCacheTarget::ListFirst),
+                "last" => Some(PropertyCacheTarget::ListLast),
+                _ => None,
+            },
+            VmValue::String(_) => match name {
+                "count" => Some(PropertyCacheTarget::StringCount),
+                "empty" => Some(PropertyCacheTarget::StringEmpty),
+                _ => None,
+            },
+            VmValue::Pair(_) => match name {
+                "first" => Some(PropertyCacheTarget::PairFirst),
+                "second" => Some(PropertyCacheTarget::PairSecond),
+                _ => None,
+            },
+            VmValue::EnumVariant { .. } => match name {
+                "variant" => Some(PropertyCacheTarget::EnumVariant),
+                "fields" => Some(PropertyCacheTarget::EnumFields),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn resolve_property(obj: &VmValue, name: &str, optional: bool) -> Result<VmValue, VmError> {
+        let result = match obj {
+            VmValue::Nil if optional => VmValue::Nil,
+            VmValue::Dict(map) => map.get(name).cloned().unwrap_or(VmValue::Nil),
+            VmValue::List(items) => match name {
+                "count" => VmValue::Int(items.len() as i64),
+                "empty" => VmValue::Bool(items.is_empty()),
+                "first" => items.first().cloned().unwrap_or(VmValue::Nil),
+                "last" => items.last().cloned().unwrap_or(VmValue::Nil),
+                _ => VmValue::Nil,
+            },
+            VmValue::String(s) => match name {
+                "count" => VmValue::Int(s.chars().count() as i64),
+                "empty" => VmValue::Bool(s.is_empty()),
+                _ => VmValue::Nil,
+            },
+            VmValue::EnumVariant {
+                variant, fields, ..
+            } => match name {
+                "variant" => VmValue::String(Rc::from(variant.as_str())),
+                "fields" => VmValue::List(Rc::new(fields.clone())),
+                _ => VmValue::Nil,
+            },
+            VmValue::StructInstance { fields, .. } => {
+                fields.get(name).cloned().unwrap_or(VmValue::Nil)
+            }
+            VmValue::Pair(p) => match name {
+                "first" => p.0.clone(),
+                "second" => p.1.clone(),
+                _ if optional => VmValue::Nil,
+                _ => {
+                    return Err(VmError::TypeError(format!(
+                        "cannot access property `{name}` on pair (expected `first` or `second`)"
+                    )));
+                }
+            },
+            VmValue::Nil => {
+                return Err(VmError::TypeError(format!(
+                    "cannot access property `{name}` on nil"
+                )));
+            }
+            _ if optional => VmValue::Nil,
+            _ => {
+                return Err(VmError::TypeError(format!(
+                    "cannot access property `{name}` on {}",
+                    obj.type_name()
+                )));
+            }
+        };
+        Ok(result)
+    }
+
     pub(super) fn try_execute_collections_op(&mut self, op: u8) -> Result<bool, VmError> {
         if op == Op::BuildList as u8 {
             let frame = self.frames.last_mut().unwrap();
@@ -191,97 +318,43 @@ impl super::super::Vm {
                 }
             };
             self.stack.push(result);
-        } else if op == Op::GetProperty as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let name = Self::const_string(&frame.chunk.constants[idx])?;
-            let obj = self.pop()?;
-            let result = match &obj {
-                VmValue::Dict(map) => map.get(&name).cloned().unwrap_or(VmValue::Nil),
-                VmValue::List(items) => match name.as_str() {
-                    "count" => VmValue::Int(items.len() as i64),
-                    "empty" => VmValue::Bool(items.is_empty()),
-                    "first" => items.first().cloned().unwrap_or(VmValue::Nil),
-                    "last" => items.last().cloned().unwrap_or(VmValue::Nil),
-                    _ => VmValue::Nil,
-                },
-                VmValue::String(s) => match name.as_str() {
-                    "count" => VmValue::Int(s.chars().count() as i64),
-                    "empty" => VmValue::Bool(s.is_empty()),
-                    _ => VmValue::Nil,
-                },
-                VmValue::EnumVariant {
-                    variant, fields, ..
-                } => match name.as_str() {
-                    "variant" => VmValue::String(Rc::from(variant.as_str())),
-                    "fields" => VmValue::List(Rc::new(fields.clone())),
-                    _ => VmValue::Nil,
-                },
-                VmValue::StructInstance { fields, .. } => {
-                    fields.get(&name).cloned().unwrap_or(VmValue::Nil)
-                }
-                VmValue::Pair(p) => match name.as_str() {
-                    "first" => p.0.clone(),
-                    "second" => p.1.clone(),
-                    _ => {
-                        return Err(VmError::TypeError(format!(
-                            "cannot access property `{name}` on pair (expected `first` or `second`)"
-                        )));
-                    }
-                },
-                VmValue::Nil => {
-                    return Err(VmError::TypeError(format!(
-                        "cannot access property `{name}` on nil"
-                    )));
-                }
-                _ => {
-                    return Err(VmError::TypeError(format!(
-                        "cannot access property `{name}` on {}",
-                        obj.type_name()
-                    )));
-                }
+        } else if op == Op::GetProperty as u8 || op == Op::GetPropertyOpt as u8 {
+            let optional = op == Op::GetPropertyOpt as u8;
+            let (name_idx, cache_slot, cache_entry) = {
+                let frame = self.frames.last_mut().unwrap();
+                let op_offset = frame.ip.saturating_sub(1);
+                let name_idx = frame.chunk.read_u16(frame.ip);
+                frame.ip += 2;
+                let cache_slot = frame.chunk.inline_cache_slot(op_offset);
+                let cache_entry = cache_slot
+                    .map(|slot| frame.chunk.inline_cache_entry(slot))
+                    .unwrap_or(InlineCacheEntry::Empty);
+                (name_idx, cache_slot, cache_entry)
             };
-            self.stack.push(result);
-        } else if op == Op::GetPropertyOpt as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let name = Self::const_string(&frame.chunk.constants[idx])?;
+
             let obj = self.pop()?;
-            let result = match &obj {
-                VmValue::Nil => VmValue::Nil,
-                VmValue::Dict(map) => map.get(&name).cloned().unwrap_or(VmValue::Nil),
-                VmValue::List(items) => match name.as_str() {
-                    "count" => VmValue::Int(items.len() as i64),
-                    "empty" => VmValue::Bool(items.is_empty()),
-                    "first" => items.first().cloned().unwrap_or(VmValue::Nil),
-                    "last" => items.last().cloned().unwrap_or(VmValue::Nil),
-                    _ => VmValue::Nil,
-                },
-                VmValue::String(s) => match name.as_str() {
-                    "count" => VmValue::Int(s.chars().count() as i64),
-                    "empty" => VmValue::Bool(s.is_empty()),
-                    _ => VmValue::Nil,
-                },
-                VmValue::EnumVariant {
-                    variant, fields, ..
-                } => match name.as_str() {
-                    "variant" => VmValue::String(Rc::from(variant.as_str())),
-                    "fields" => VmValue::List(Rc::new(fields.clone())),
-                    _ => VmValue::Nil,
-                },
-                VmValue::StructInstance { fields, .. } => {
-                    fields.get(&name).cloned().unwrap_or(VmValue::Nil)
+            if optional && matches!(obj, VmValue::Nil) {
+                self.stack.push(VmValue::Nil);
+            } else if let Some(result) = Self::try_cached_property(&cache_entry, name_idx, &obj) {
+                self.stack.push(result);
+            } else {
+                let name = {
+                    let frame = self.frames.last().unwrap();
+                    Self::const_string(&frame.chunk.constants[name_idx as usize])?
+                };
+                let result = Self::resolve_property(&obj, &name, optional)?;
+
+                if let (Some(slot), Some(target)) =
+                    (cache_slot, Self::property_cache_target(&obj, &name))
+                {
+                    let frame = self.frames.last().unwrap();
+                    frame.chunk.set_inline_cache_entry(
+                        slot,
+                        InlineCacheEntry::Property { name_idx, target },
+                    );
                 }
-                VmValue::Pair(p) => match name.as_str() {
-                    "first" => p.0.clone(),
-                    "second" => p.1.clone(),
-                    _ => VmValue::Nil,
-                },
-                _ => VmValue::Nil,
-            };
-            self.stack.push(result);
+                self.stack.push(result);
+            }
         } else if op == Op::SetProperty as u8 {
             let frame = self.frames.last_mut().unwrap();
             let prop_idx = frame.chunk.read_u16(frame.ip) as usize;

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use crate::compiler::Compiler;
 use crate::stdlib::register_vm_stdlib;
-use crate::{VmError, VmValue};
+use crate::{Chunk, InlineCacheEntry, MethodCacheTarget, PropertyCacheTarget, VmError, VmValue};
 use harn_lexer::Lexer;
 use harn_parser::Parser;
 
@@ -28,6 +28,30 @@ fn run_harn(source: &str) -> (String, VmValue) {
                 register_vm_stdlib(&mut vm);
                 let result = vm.execute(&chunk).await.unwrap();
                 (vm.output().to_string(), result)
+            })
+            .await
+    })
+}
+
+fn run_harn_with_chunk(source: &str) -> (Chunk, String, VmValue) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let mut lexer = Lexer::new(source);
+                let tokens = lexer.tokenize().unwrap();
+                let mut parser = Parser::new(tokens);
+                let program = parser.parse().unwrap();
+                let chunk = Compiler::new().compile(&program).unwrap();
+
+                let mut vm = Vm::new();
+                register_vm_stdlib(&mut vm);
+                let result = vm.execute(&chunk).await.unwrap();
+                (chunk, vm.output().to_string(), result)
             })
             .await
     })
@@ -360,6 +384,161 @@ fn test_list_properties() {
         "pipeline t(task) { let list = [1, 2, 3]\nlog(list.count)\nlog(list.empty)\nlog(list.first)\nlog(list.last) }",
     );
     assert_eq!(out, "[harn] 3\n[harn] false\n[harn] 1\n[harn] 3");
+}
+
+#[test]
+fn test_inline_cache_warms_property_sites() {
+    let (chunk, out, _) = run_harn_with_chunk(
+        r#"pipeline t(task) {
+let list = [1, 2, 3]
+let text = ""
+let p = pair("left", "right")
+var i = 0
+var total = 0
+while i < 3 {
+  total = total + list.count
+  if text.empty {
+    total = total + 1
+  }
+  log(p.second)
+  i = i + 1
+}
+log(total)
+}"#,
+    );
+
+    assert_eq!(
+        out.trim_end(),
+        "[harn] right\n[harn] right\n[harn] right\n[harn] 12"
+    );
+    let entries = chunk.inline_cache_entries();
+    assert!(
+        entries.iter().any(|entry| matches!(
+            entry,
+            InlineCacheEntry::Property {
+                target: PropertyCacheTarget::ListCount,
+                ..
+            }
+        )),
+        "{entries:?}"
+    );
+    assert!(
+        entries.iter().any(|entry| matches!(
+            entry,
+            InlineCacheEntry::Property {
+                target: PropertyCacheTarget::StringEmpty,
+                ..
+            }
+        )),
+        "{entries:?}"
+    );
+    assert!(
+        entries.iter().any(|entry| matches!(
+            entry,
+            InlineCacheEntry::Property {
+                target: PropertyCacheTarget::PairSecond,
+                ..
+            }
+        )),
+        "{entries:?}"
+    );
+}
+
+#[test]
+fn test_inline_cache_replaces_polymorphic_property_site() {
+    let (chunk, out, _) = run_harn_with_chunk(
+        r#"pipeline t(task) {
+for value in [[1, 2], "ab"] {
+  log(value.count)
+}
+}"#,
+    );
+
+    assert_eq!(out.trim_end(), "[harn] 2\n[harn] 2");
+    let entries = chunk.inline_cache_entries();
+    assert!(
+        entries.iter().any(|entry| matches!(
+            entry,
+            InlineCacheEntry::Property {
+                target: PropertyCacheTarget::StringCount,
+                ..
+            }
+        )),
+        "{entries:?}"
+    );
+}
+
+#[test]
+fn test_inline_cache_warms_method_sites() {
+    let (chunk, out, _) = run_harn_with_chunk(
+        r#"pipeline t(task) {
+let list = [1, 2, 3]
+let text = "abc"
+let dict = {a: 1, b: 2}
+let range = 1 to 3
+let values = set(1, 2)
+var i = 0
+var total = 0
+while i < 3 {
+  total = total + list.count()
+  total = total + text.count()
+  total = total + dict.count()
+  total = total + range.first()
+  total = total + values.count()
+  i = i + 1
+}
+log(total)
+}"#,
+    );
+
+    assert_eq!(out.trim_end(), "[harn] 33");
+    let entries = chunk.inline_cache_entries();
+    for target in [
+        MethodCacheTarget::ListCount,
+        MethodCacheTarget::StringCount,
+        MethodCacheTarget::DictCount,
+        MethodCacheTarget::RangeFirst,
+        MethodCacheTarget::SetCount,
+    ] {
+        assert!(
+            entries.iter().any(|entry| matches!(
+                entry,
+                InlineCacheEntry::Method {
+                    target: cached_target,
+                    ..
+                } if *cached_target == target
+            )),
+            "missing {target:?} in {entries:?}"
+        );
+    }
+}
+
+#[test]
+fn test_inline_cache_warms_spread_method_site() {
+    let (chunk, out, _) = run_harn_with_chunk(
+        r#"pipeline t(task) {
+let list = [1, 2, 3]
+let args = []
+var i = 0
+while i < 3 {
+  log(list.count(...args))
+  i = i + 1
+}
+}"#,
+    );
+
+    assert_eq!(out.trim_end(), "[harn] 3\n[harn] 3\n[harn] 3");
+    let entries = chunk.inline_cache_entries();
+    assert!(
+        entries.iter().any(|entry| matches!(
+            entry,
+            InlineCacheEntry::Method {
+                target: MethodCacheTarget::ListCount,
+                ..
+            }
+        )),
+        "{entries:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #413.

Adds conservative monomorphic inline caches for repeated VM property access and builtin method call sites without mutating bytecode bytes.

- adds per-instruction cache slots to `Chunk`, with cache entries shared across cloned chunks/frames for observability and warm reuse
- caches common property fast paths for list, string, pair, and enum variant access while leaving dict fields and struct fields on the existing dynamic path
- caches conservative zero-argument builtin method fast paths for list/string/dict/range/set receivers, including spread method calls when the spread list is empty
- preserves optional access, nil handling, missing-property behavior, and all existing fallback dispatch paths
- adds targeted runtime tests that verify cache warming, polymorphic replacement, spread method cache warming, and unchanged output

## Verification

- `cargo test -p harn-vm inline_cache -- --nocapture`
- `cargo test -p harn-vm vm::tests_runtime`
- `cargo test -p harn-vm compiler`
- `cargo run --quiet --bin harn -- test conformance`
  - initial full run: 608 passed, 12 failed because the conformance fixtures expected a built debug `harn` binary at the configured target path
  - after `cargo build --bin harn`, reran failed filters:
    - `cargo run --quiet --bin harn -- test conformance --filter orchestrator`: 10 passed
    - `cargo run --quiet --bin harn -- test conformance --filter mcp_server_fires_trigger`: 1 passed
    - `cargo run --quiet --bin harn -- test conformance --filter agent_state_resume_process`: 1 passed
- `make test`: 1888 passed, 7 skipped
- pre-commit/pre-push hooks:
  - Rust fmt, Harn fmt, clippy, markdown, highlight sync, and workspace Rust tests passed
  - portal lint currently fails on unrelated `react-hooks/set-state-in-effect` findings in existing portal files outside this PR

## Benchmarks

Release-mode `harn bench`, 20 iterations each, using temporary fixtures with 200k repeated accesses per run:

| fixture | base avg | branch avg | change |
| --- | ---: | ---: | ---: |
| property loop (`list.count`, `string.count`, `pair.second`) | 267.88 ms | 181.03 ms | 32.4% faster |
| method loop (`count()`/`first()` on list/string/dict/range/set) | 390.76 ms | 318.78 ms | 18.4% faster |

Base was an unmodified worktree at `2e55806b`; branch commit is `ef2f6667`.
