### PR TITLE
[codex] Avoid eager collection cloning in for loops

### DIFF
--- a/conformance/tests/collections/dict_iteration.expected
+++ b/conformance/tests/collections/dict_iteration.expected
@@ -1,2 +1,4 @@
 [harn] a
 [harn] b
+[harn] a=1
+[harn] b=2

--- a/conformance/tests/collections/dict_iteration.harn
+++ b/conformance/tests/collections/dict_iteration.harn
@@ -3,4 +3,7 @@ pipeline test(task) {
   for entry in d {
     log(entry.key)
   }
+  for {key: k, value: v} in d {
+    log("${k}=${v}")
+  }
 }

--- a/crates/harn-vm/src/vm/ops/iter.rs
+++ b/crates/harn-vm/src/vm/ops/iter.rs
@@ -10,29 +10,20 @@ impl super::super::Vm {
             let iterable = self.pop()?;
             match iterable {
                 VmValue::List(items) => {
-                    self.iterators.push(super::super::IterState::Vec {
-                        items: (*items).clone(),
-                        idx: 0,
-                    });
-                }
-                VmValue::Dict(map) => {
-                    let items: Vec<VmValue> = map
-                        .iter()
-                        .map(|(k, v)| {
-                            VmValue::Dict(Rc::new(BTreeMap::from([
-                                ("key".to_string(), VmValue::String(Rc::from(k.as_str()))),
-                                ("value".to_string(), v.clone()),
-                            ])))
-                        })
-                        .collect();
                     self.iterators
                         .push(super::super::IterState::Vec { items, idx: 0 });
                 }
-                VmValue::Set(items) => {
-                    self.iterators.push(super::super::IterState::Vec {
-                        items: (*items).clone(),
+                VmValue::Dict(map) => {
+                    let keys = map.keys().cloned().collect();
+                    self.iterators.push(super::super::IterState::Dict {
+                        entries: map,
+                        keys,
                         idx: 0,
                     });
+                }
+                VmValue::Set(items) => {
+                    self.iterators
+                        .push(super::super::IterState::Vec { items, idx: 0 });
                 }
                 VmValue::Channel(ch) => {
                     self.iterators.push(super::super::IterState::Channel {
@@ -62,7 +53,7 @@ impl super::super::Vm {
                 }
                 _ => {
                     self.iterators.push(super::super::IterState::Vec {
-                        items: Vec::new(),
+                        items: Rc::new(Vec::new()),
                         idx: 0,
                     });
                 }
@@ -97,6 +88,21 @@ impl super::super::Vm {
                             let item = items[*idx].clone();
                             *idx += 1;
                             self.stack.push(item);
+                        } else {
+                            self.iterators.pop();
+                            let frame = self.frames.last_mut().unwrap();
+                            frame.ip = target;
+                        }
+                    }
+                    super::super::IterState::Dict { entries, keys, idx } => {
+                        if *idx < keys.len() {
+                            let key = &keys[*idx];
+                            let value = entries.get(key).cloned().unwrap_or(VmValue::Nil);
+                            *idx += 1;
+                            self.stack.push(VmValue::Dict(Rc::new(BTreeMap::from([
+                                ("key".to_string(), VmValue::String(Rc::from(key.as_str()))),
+                                ("value".to_string(), value),
+                            ]))));
                         } else {
                             self.iterators.pop();
                             let frame = self.frames.last_mut().unwrap();
@@ -172,5 +178,90 @@ impl super::super::Vm {
             return Ok(false);
         }
         Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vm::{IterState, Vm};
+
+    fn run_iter_init_test(test: impl std::future::Future<Output = ()>) {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(test);
+    }
+
+    #[test]
+    fn iter_init_list_keeps_shared_backing_store() {
+        run_iter_init_test(async {
+            let items = Rc::new(vec![VmValue::Int(1), VmValue::Int(2)]);
+            let mut vm = Vm::new();
+            vm.stack.push(VmValue::List(items.clone()));
+
+            vm.try_execute_iter_op(Op::IterInit as u8).await.unwrap();
+
+            match vm.iterators.last().unwrap() {
+                IterState::Vec {
+                    items: iter_items,
+                    idx,
+                } => {
+                    assert!(Rc::ptr_eq(&items, iter_items));
+                    assert_eq!(*idx, 0);
+                }
+                _ => panic!("expected vec iterator state"),
+            }
+        });
+    }
+
+    #[test]
+    fn iter_init_set_keeps_shared_backing_store() {
+        run_iter_init_test(async {
+            let items = Rc::new(vec![VmValue::Int(1), VmValue::Int(2)]);
+            let mut vm = Vm::new();
+            vm.stack.push(VmValue::Set(items.clone()));
+
+            vm.try_execute_iter_op(Op::IterInit as u8).await.unwrap();
+
+            match vm.iterators.last().unwrap() {
+                IterState::Vec {
+                    items: iter_items,
+                    idx,
+                } => {
+                    assert!(Rc::ptr_eq(&items, iter_items));
+                    assert_eq!(*idx, 0);
+                }
+                _ => panic!("expected vec iterator state"),
+            }
+        });
+    }
+
+    #[test]
+    fn iter_init_dict_keeps_shared_entries_and_snapshots_keys() {
+        run_iter_init_test(async {
+            let entries = Rc::new(BTreeMap::from([
+                ("a".to_string(), VmValue::Int(1)),
+                ("b".to_string(), VmValue::Int(2)),
+            ]));
+            let mut vm = Vm::new();
+            vm.stack.push(VmValue::Dict(entries.clone()));
+
+            vm.try_execute_iter_op(Op::IterInit as u8).await.unwrap();
+
+            match vm.iterators.last().unwrap() {
+                IterState::Dict {
+                    entries: iter_entries,
+                    keys,
+                    idx,
+                } => {
+                    assert!(Rc::ptr_eq(&entries, iter_entries));
+                    assert_eq!(keys.as_slice(), ["a".to_string(), "b".to_string()]);
+                    assert_eq!(*idx, 0);
+                }
+                _ => panic!("expected dict iterator state"),
+            }
+        });
     }
 }

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -68,10 +68,15 @@ pub(crate) struct ExceptionHandler {
     pub(crate) error_type: String,
 }
 
-/// Iterator state for for-in loops: either a pre-collected vec, an async channel, or a generator.
+/// Iterator state for for-in loops.
 pub(crate) enum IterState {
     Vec {
-        items: Vec<VmValue>,
+        items: Rc<Vec<VmValue>>,
+        idx: usize,
+    },
+    Dict {
+        entries: Rc<BTreeMap<String, VmValue>>,
+        keys: Vec<String>,
         idx: usize,
     },
     Channel {


### PR DESCRIPTION
## Summary

- Change VM `for` loop list/set iterator state to keep the existing shared `Rc<Vec<VmValue>>` backing store instead of cloning the whole collection at loop setup.
- Add a lazy direct-dict `IterState` that keeps the shared `Rc<BTreeMap<_, _>>`, snapshots keys, and builds the existing `{key, value}` entry shape one item at a time.
- Add iterator-state unit coverage and extend dict iteration conformance coverage for destructuring `{key, value}` entries.

Fixes #407.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-issue407-test-target cargo test -p harn-vm vm::ops::iter::tests::iter_init_ -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-issue407-test-target cargo test -p harn-vm vm::tests_runtime::test_for_in -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-issue407-test-target cargo test -p harn-vm vm::tests_runtime -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-issue407-test-target cargo run --quiet --bin harn -- test conformance --filter dict_iteration`
- `CARGO_TARGET_DIR=/tmp/harn-issue407-test-target cargo run --quiet --bin harn -- test conformance --filter iter`
- Full conformance initially reported `608 passed, 12 failed`; the failures were process-spawning fixtures looking for the repo `.cargo/config.toml` debug binary while I had built with a custom `CARGO_TARGET_DIR`. After copying the built debug binary to that expected temp target path, rerunning the failing subset passed: `5 passed, 0 failed`.
- Pre-push Rust gate ran through nextest successfully: `1887 tests run: 1887 passed, 7 skipped`; Harn formatting and markdown also passed. The hook then failed on existing portal ESLint `react-hooks/set-state-in-effect` violations in `crates/harn-cli/portal`, unrelated to this VM change.

## Benchmarks

Ran `CARGO_TARGET_DIR=/tmp/harn-issue407-target scripts/bench_vm.sh --iterations 5` before and after. This machine had concurrent build/benchmark load, so treat wall-clock numbers as noisy, but the iterator fixtures improved materially:

- `list_iteration`: `84.52 ms` avg before -> `25.51 ms` avg after
- `list_map_filter`: `961.19 ms` avg before -> `343.70 ms` avg after