### PR TITLE
[codex] Avoid cloning VM compiled chunks on calls

### DIFF
--- a/crates/harn-cli/src/commands/orchestrator/inspect_data.rs
+++ b/crates/harn-cli/src/commands/orchestrator/inspect_data.rs
@@ -494,7 +494,7 @@ async fn evaluate_flow_key(
             .map_err(|error| format!("failed to encode trigger event: {error}"))?,
     );
     let value = vm
-        .call_closure_pub(&expr.closure, &[arg], &[])
+        .call_closure_pub(&expr.closure, &[arg])
         .await
         .map_err(|error| {
             format!(

--- a/crates/harn-serve/src/core.rs
+++ b/crates/harn-serve/src/core.rs
@@ -280,7 +280,7 @@ impl DispatchCore {
                     )));
                 };
                 let args = build_vm_args(&request.arguments, function)?;
-                let result = vm.call_closure_pub(closure, &args, &[]).await;
+                let result = vm.call_closure_pub(closure, &args).await;
 
                 match previous_log {
                     Some(log) => {

--- a/crates/harn-vm/src/bridge.rs
+++ b/crates/harn-vm/src/bridge.rs
@@ -114,7 +114,7 @@ impl InProcessHost {
         };
 
         let mut vm = self.vm.child_vm_for_host();
-        let result = vm.call_closure_pub(closure, args, &[]).await?;
+        let result = vm.call_closure_pub(closure, args).await?;
         Ok(crate::llm::vm_value_to_json(&result))
     }
 
@@ -165,7 +165,7 @@ impl InProcessHost {
         };
 
         let mut vm = self.vm.child_vm_for_host();
-        let result = vm.call_closure_pub(closure, &args, &[]).await?;
+        let result = vm.call_closure_pub(closure, &args).await?;
         let payload = match result {
             VmValue::Bool(granted) => serde_json::json!({ "granted": granted }),
             VmValue::String(reason) if !reason.is_empty() => {

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -330,7 +330,7 @@ pub struct Chunk {
     /// Current column to use when emitting instructions (set by compiler).
     current_col: u32,
     /// Compiled function bodies (for closures).
-    pub functions: Vec<CompiledFunction>,
+    pub functions: Vec<CompiledFunctionRef>,
     /// Instruction offset to inline-cache slot. Slots are assigned at emit time
     /// for cacheable instructions while bytecode bytes remain immutable.
     inline_cache_slots: BTreeMap<usize, usize>,
@@ -339,6 +339,9 @@ pub struct Chunk {
     inline_caches: Rc<RefCell<Vec<InlineCacheEntry>>>,
 }
 
+pub type ChunkRef = Rc<Chunk>;
+pub type CompiledFunctionRef = Rc<CompiledFunction>;
+
 /// A compiled function (closure body).
 #[derive(Debug, Clone)]
 pub struct CompiledFunction {
@@ -346,7 +349,7 @@ pub struct CompiledFunction {
     pub params: Vec<String>,
     /// Index of the first parameter with a default value, or None if all required.
     pub default_start: Option<usize>,
-    pub chunk: Chunk,
+    pub chunk: ChunkRef,
     /// True if the function body contains `yield` expressions (generator function).
     pub is_generator: bool,
     /// True if the last parameter is a rest parameter (`...name`).

--- a/crates/harn-vm/src/compiler/closures.rs
+++ b/crates/harn-vm/src/compiler/closures.rs
@@ -39,12 +39,12 @@ impl Compiler {
             name: name.to_string(),
             params: TypedParam::names(params),
             default_start: TypedParam::default_start(params),
-            chunk: fn_compiler.chunk,
+            chunk: Rc::new(fn_compiler.chunk),
             is_generator: is_gen,
             has_rest_param: params.last().is_some_and(|p| p.rest),
         };
         let fn_idx = self.chunk.functions.len();
-        self.chunk.functions.push(func);
+        self.chunk.functions.push(Rc::new(func));
 
         self.chunk.emit_u16(Op::Closure, fn_idx as u16, self.line);
         let name_idx = self.chunk.add_constant(Constant::String(name.to_string()));
@@ -80,12 +80,12 @@ impl Compiler {
             name: name.to_string(),
             params: TypedParam::names(params),
             default_start: TypedParam::default_start(params),
-            chunk: fn_compiler.chunk,
+            chunk: Rc::new(fn_compiler.chunk),
             is_generator: false,
             has_rest_param: params.last().is_some_and(|p| p.rest),
         };
         let fn_idx = self.chunk.functions.len();
-        self.chunk.functions.push(func);
+        self.chunk.functions.push(Rc::new(func));
 
         let define_name = self
             .chunk
@@ -269,12 +269,12 @@ impl Compiler {
             name: "<closure>".to_string(),
             params: TypedParam::names(params),
             default_start: TypedParam::default_start(params),
-            chunk: fn_compiler.chunk,
+            chunk: Rc::new(fn_compiler.chunk),
             is_generator: is_gen,
             has_rest_param: false,
         };
         let fn_idx = self.chunk.functions.len();
-        self.chunk.functions.push(func);
+        self.chunk.functions.push(Rc::new(func));
 
         self.chunk.emit_u16(Op::Closure, fn_idx as u16, self.line);
         Ok(())

--- a/crates/harn-vm/src/compiler/concurrency.rs
+++ b/crates/harn-vm/src/compiler/concurrency.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use harn_parser::{BindingPattern, ParallelMode, SNode, SelectCase, TypeExpr};
 
 use crate::chunk::{CompiledFunction, Constant, Op};
@@ -62,12 +64,12 @@ impl Compiler {
             name: fn_name.to_string(),
             params,
             default_start: None,
-            chunk: fn_compiler.chunk,
+            chunk: Rc::new(fn_compiler.chunk),
             is_generator: false,
             has_rest_param: false,
         };
         let fn_idx = self.chunk.functions.len();
-        self.chunk.functions.push(func);
+        self.chunk.functions.push(Rc::new(func));
         self.chunk.emit_u16(Op::Closure, fn_idx as u16, self.line);
         let op = match mode {
             ParallelMode::Count => Op::Parallel,
@@ -90,12 +92,12 @@ impl Compiler {
             name: "<spawn>".to_string(),
             params: vec![],
             default_start: None,
-            chunk: fn_compiler.chunk,
+            chunk: Rc::new(fn_compiler.chunk),
             is_generator: false,
             has_rest_param: false,
         };
         let fn_idx = self.chunk.functions.len();
-        self.chunk.functions.push(func);
+        self.chunk.functions.push(Rc::new(func));
         self.chunk.emit_u16(Op::Closure, fn_idx as u16, self.line);
         self.chunk.emit(Op::Spawn, self.line);
         Ok(())

--- a/crates/harn-vm/src/compiler/decls.rs
+++ b/crates/harn-vm/src/compiler/decls.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use harn_parser::{Attribute, DictEntry, Node, SNode, StructField, TypedParam};
 
 use crate::chunk::{CompiledFunction, Constant, Op};
@@ -105,12 +107,12 @@ impl Compiler {
                     name: format!("{}.{}", type_name, name),
                     params: TypedParam::names(params),
                     default_start: TypedParam::default_start(params),
-                    chunk: fn_compiler.chunk,
+                    chunk: Rc::new(fn_compiler.chunk),
                     is_generator: false,
                     has_rest_param: false,
                 };
                 let fn_idx = self.chunk.functions.len();
-                self.chunk.functions.push(func);
+                self.chunk.functions.push(Rc::new(func));
                 self.chunk.emit_u16(Op::Closure, fn_idx as u16, self.line);
             }
         }
@@ -167,12 +169,12 @@ impl Compiler {
             name: name.to_string(),
             params: TypedParam::names(&params),
             default_start: None,
-            chunk: fn_compiler.chunk,
+            chunk: Rc::new(fn_compiler.chunk),
             is_generator: false,
             has_rest_param: false,
         };
         let fn_idx = self.chunk.functions.len();
-        self.chunk.functions.push(func);
+        self.chunk.functions.push(Rc::new(func));
         self.chunk.emit_u16(Op::Closure, fn_idx as u16, self.line);
         let name_idx = self.chunk.add_constant(Constant::String(name.to_string()));
         self.chunk.emit_u16(Op::DefLet, name_idx, self.line);

--- a/crates/harn-vm/src/compiler/state.rs
+++ b/crates/harn-vm/src/compiler/state.rs
@@ -911,7 +911,7 @@ impl Compiler {
             name: String::new(),
             params: TypedParam::names(params),
             default_start: TypedParam::default_start(params),
-            chunk: fn_compiler.chunk,
+            chunk: Rc::new(fn_compiler.chunk),
             is_generator: is_gen,
             has_rest_param: false,
         })

--- a/crates/harn-vm/src/connectors/harn_module.rs
+++ b/crates/harn-vm/src/connectors/harn_module.rs
@@ -480,7 +480,7 @@ async fn required_export_call(
     };
     let mut child = base_vm.child_vm_for_host();
     child
-        .call_closure_pub(closure, args, &[])
+        .call_closure_pub(closure, args)
         .await
         .map_err(vm_error_to_connector)
 }
@@ -505,7 +505,7 @@ async fn call_provider_export(
         .into_iter()
         .map(|value| json_result_to_vm_value(&value))
         .collect::<Vec<_>>();
-    let result = child_vm.call_closure_pub(&closure, &vm_args, &[]).await;
+    let result = child_vm.call_closure_pub(&closure, &vm_args).await;
     ACTIVE_HARN_CONNECTOR_CTX.with(|slot| {
         slot.borrow_mut().pop();
     });

--- a/crates/harn-vm/src/llm/agent/mod.rs
+++ b/crates/harn-vm/src/llm/agent/mod.rs
@@ -62,7 +62,7 @@ pub(crate) async fn emit_agent_event(event: &AgentEvent) {
         let arg = crate::stdlib::json_to_vm_value(&payload);
         // Log but don't propagate: one broken subscriber must not tear
         // down the agent loop.
-        if let Err(err) = vm.call_closure_pub(&closure, &[arg], &[]).await {
+        if let Err(err) = vm.call_closure_pub(&closure, &[arg]).await {
             crate::events::log_warn(
                 "agent.subscriber",
                 &format!(

--- a/crates/harn-vm/src/llm/agent/post_turn.rs
+++ b/crates/harn-vm/src/llm/agent/post_turn.rs
@@ -198,7 +198,7 @@ pub(super) async fn run_post_turn(
                 )
             })?;
             let info_vm = crate::stdlib::json_to_vm_value(&turn_info);
-            let cb_result = cb_vm.call_closure_pub(closure, &[info_vm], &[]).await?;
+            let cb_result = cb_vm.call_closure_pub(closure, &[info_vm]).await?;
             let (message, stop) = interpret_post_turn_callback_result(&cb_result);
             if let Some(msg) = message {
                 if !msg.trim().is_empty() {

--- a/crates/harn-vm/src/llm/agent/skill_match.rs
+++ b/crates/harn-vm/src/llm/agent/skill_match.rs
@@ -350,7 +350,7 @@ async fn run_skill_hook(
     let Some(mut vm) = crate::vm::clone_async_builtin_child_vm() else {
         return Ok(());
     };
-    if let Err(err) = vm.call_closure_pub(&closure, &[], &[]).await {
+    if let Err(err) = vm.call_closure_pub(&closure, &[]).await {
         crate::events::log_warn(
             "agent.skill_hook",
             &format!("skill={skill_name} hook={hook_key} error: {err}"),

--- a/crates/harn-vm/src/llm/agent_tools.rs
+++ b/crates/harn-vm/src/llm/agent_tools.rs
@@ -271,7 +271,7 @@ pub(super) async fn dispatch_tool_execution(
             };
             let args_vm = crate::stdlib::json_to_vm_value(tool_args);
             let _trusted_bridge_guard = crate::orchestration::allow_trusted_bridge_calls();
-            match vm.call_closure_pub(&handler, &[args_vm], &[]).await {
+            match vm.call_closure_pub(&handler, &[args_vm]).await {
                 Ok(val) => Ok(serde_json::Value::String(val.display())),
                 Err(VmError::CategorizedError {
                     message,

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -552,7 +552,7 @@ pub fn register_llm_builtins(vm: &mut Vm) {
             let mut child_vm = crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
                 VmError::Runtime("with_rate_limit requires an async builtin VM context".to_string())
             })?;
-            match child_vm.call_closure_pub(&closure, &[], &[]).await {
+            match child_vm.call_closure_pub(&closure, &[]).await {
                 Ok(v) => return Ok(v),
                 Err(err) => {
                     let cat = crate::value::error_to_category(&err);

--- a/crates/harn-vm/src/llm/structural_experiments.rs
+++ b/crates/harn-vm/src/llm/structural_experiments.rs
@@ -327,7 +327,7 @@ pub(crate) async fn apply_structural_experiment(
             interpret_closure_result(
                 &current_messages,
                 current_system.as_deref(),
-                &vm.call_closure_pub(closure, &[VmValue::Dict(std::rc::Rc::new(ctx))], &[])
+                &vm.call_closure_pub(closure, &[VmValue::Dict(std::rc::Rc::new(ctx))])
                     .await?,
                 &config,
             )?

--- a/crates/harn-vm/src/mcp_server/server.rs
+++ b/crates/harn-vm/src/mcp_server/server.rs
@@ -221,7 +221,7 @@ impl McpServer {
             .unwrap_or(serde_json::json!({}));
         let args_vm = json_to_vm_value(&arguments);
 
-        let result = vm.call_closure_pub(&tool.handler, &[args_vm], &[]).await;
+        let result = vm.call_closure_pub(&tool.handler, &[args_vm]).await;
 
         match result {
             Ok(value) => {
@@ -388,7 +388,7 @@ impl McpServer {
         for tmpl in &self.resource_templates {
             if let Some(args) = match_uri_template(&tmpl.uri_template, uri) {
                 let args_vm = json_to_vm_value(&serde_json::json!(args));
-                let result = vm.call_closure_pub(&tmpl.handler, &[args_vm], &[]).await;
+                let result = vm.call_closure_pub(&tmpl.handler, &[args_vm]).await;
                 return match result {
                     Ok(value) => {
                         let mut content = serde_json::json!({
@@ -542,7 +542,7 @@ impl McpServer {
             .unwrap_or(serde_json::json!({}));
         let args_vm = json_to_vm_value(&arguments);
 
-        let result = vm.call_closure_pub(&prompt.handler, &[args_vm], &[]).await;
+        let result = vm.call_closure_pub(&prompt.handler, &[args_vm]).await;
 
         match result {
             Ok(value) => {

--- a/crates/harn-vm/src/orchestration/compaction.rs
+++ b/crates/harn-vm/src/orchestration/compaction.rs
@@ -223,7 +223,7 @@ pub(crate) async fn invoke_compress_callback(
         dict.insert("max_chars".to_string(), VmValue::Int(max_chars as i64));
         dict
     }));
-    match vm.call_closure_pub(&closure, &[args_dict], &[]).await {
+    match vm.call_closure_pub(&closure, &[args_dict]).await {
         Ok(VmValue::String(s)) if !s.is_empty() => s.to_string(),
         _ => microcompact_tool_output(output, max_chars),
     }
@@ -447,7 +447,7 @@ async fn custom_compaction_summary(
             .map(crate::stdlib::json_to_vm_value)
             .collect(),
     ));
-    let result = vm.call_closure_pub(&closure, &[messages_vm], &[]).await;
+    let result = vm.call_closure_pub(&closure, &[messages_vm]).await;
     let summary = compact_summary_text_from_value(&result?)?;
     if summary.trim().is_empty() {
         Ok(truncate_compaction_summary(old_messages, archived_count))
@@ -541,7 +541,7 @@ async fn invoke_mask_callback(
             .map(crate::stdlib::json_to_vm_value)
             .collect(),
     ));
-    let result = vm.call_closure_pub(&closure, &[messages_vm], &[]).await?;
+    let result = vm.call_closure_pub(&closure, &[messages_vm]).await?;
     let list = match result {
         VmValue::List(items) => items,
         _ => return Ok(vec![None; old_messages.len()]),

--- a/crates/harn-vm/src/orchestration/hooks.rs
+++ b/crates/harn-vm/src/orchestration/hooks.rs
@@ -309,7 +309,7 @@ async fn invoke_vm_hook(
         ));
     };
     let arg = crate::stdlib::json_to_vm_value(payload);
-    vm.call_closure_pub(closure, &[arg], &[]).await
+    vm.call_closure_pub(closure, &[arg]).await
 }
 
 fn parse_pre_tool_result(value: VmValue) -> Result<PreToolAction, VmError> {

--- a/crates/harn-vm/src/record_filter.rs
+++ b/crates/harn-vm/src/record_filter.rs
@@ -53,7 +53,7 @@ fn {FILTER_FN_NAME}(record) {{
         })?;
         let result = self
             .vm
-            .call_closure_pub(closure, &[json_to_vm_value(record)], &[])
+            .call_closure_pub(closure, &[json_to_vm_value(record)])
             .await?;
         Ok(result.is_truthy())
     }

--- a/crates/harn-vm/src/stdlib/hitl.rs
+++ b/crates/harn-vm/src/stdlib/hitl.rs
@@ -439,7 +439,7 @@ async fn dual_control_impl(args: &[VmValue]) -> Result<VmValue, VmError> {
             let mut vm = clone_async_builtin_child_vm().ok_or_else(|| {
                 VmError::Runtime("dual_control requires an async builtin VM context".to_string())
             })?;
-            let result = vm.call_closure_pub(&action, &[], &[]).await?;
+            let result = vm.call_closure_pub(&action, &[]).await?;
 
             append_named_event(
                 &log,

--- a/crates/harn-vm/src/stdlib/monitors.rs
+++ b/crates/harn-vm/src/stdlib/monitors.rs
@@ -478,7 +478,7 @@ async fn call_closure(
     closure: &Rc<VmClosure>,
     args: &[VmValue],
 ) -> Result<VmValue, VmError> {
-    vm.call_closure_pub(closure, args, &[]).await
+    vm.call_closure_pub(closure, args).await
 }
 
 async fn append_monitor_started(

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -2164,7 +2164,7 @@ impl Dispatcher {
         vm.install_cancel_token(cancel_token.clone());
         let arg = event_to_handler_value(event)?;
         let args = [arg];
-        let future = vm.call_closure_pub(closure, &args, &[]);
+        let future = vm.call_closure_pub(closure, &args);
         pin_mut!(future);
         let (binding_id, binding_version) = split_binding_key(binding_key);
         let prior_context = ACTIVE_DISPATCH_CONTEXT.with(|slot| {

--- a/crates/harn-vm/src/value/env.rs
+++ b/crates/harn-vm/src/value/env.rs
@@ -2,14 +2,14 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::{cell::RefCell, path::PathBuf};
 
-use crate::chunk::CompiledFunction;
+use crate::chunk::CompiledFunctionRef;
 
 use super::{VmError, VmValue};
 
 /// A compiled closure value.
 #[derive(Debug, Clone)]
 pub struct VmClosure {
-    pub func: CompiledFunction,
+    pub func: CompiledFunctionRef,
     pub env: VmEnv,
     /// Source directory for this closure's originating module.
     /// When set, `render()` and other source-relative builtins resolve

--- a/crates/harn-vm/src/vm/debug.rs
+++ b/crates/harn-vm/src/vm/debug.rs
@@ -536,7 +536,7 @@ impl Vm {
         self.stopped = false;
 
         self.frames.push(CallFrame {
-            chunk,
+            chunk: Rc::new(chunk),
             ip: 0,
             stack_base: saved_stack_len,
             saved_env,

--- a/crates/harn-vm/src/vm/dispatch.rs
+++ b/crates/harn-vm/src/vm/dispatch.rs
@@ -2,7 +2,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
 
-use crate::chunk::CompiledFunction;
 use crate::value::{ErrorCategory, VmClosure, VmError, VmValue};
 use crate::BuiltinId;
 
@@ -93,7 +92,6 @@ impl Vm {
         &'a mut self,
         closure: &'a VmClosure,
         args: &'a [VmValue],
-        _parent_functions: &'a [CompiledFunction],
     ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>> + 'a>> {
         Box::pin(async move {
             let saved_env = self.env.clone();
@@ -136,8 +134,8 @@ impl Vm {
                 None
             };
             let result = self
-                .run_chunk_entry(
-                    &closure.func.chunk,
+                .run_chunk_ref(
+                    Rc::clone(&closure.func.chunk),
                     argc,
                     saved_source_dir,
                     closure.module_functions.clone(),
@@ -159,29 +157,31 @@ impl Vm {
     /// `VmValue::BuiltinRef`, so builtin names passed by reference (e.g.
     /// `dict.rekey(snake_to_camel)`) dispatch through the same code path as
     /// user-defined closures.
-    pub(crate) async fn call_callable_value(
-        &mut self,
-        callable: &VmValue,
-        args: &[VmValue],
-        functions: &[CompiledFunction],
-    ) -> Result<VmValue, VmError> {
-        match callable {
-            VmValue::Closure(closure) => self.call_closure(closure, args, functions).await,
-            VmValue::BuiltinRef(name) => {
-                if let Some(result) = self.call_sync_builtin_by_ref(name, args) {
-                    result
-                } else {
-                    self.call_named_builtin(name, args.to_vec()).await
+    #[allow(clippy::manual_async_fn)]
+    pub(crate) fn call_callable_value<'a>(
+        &'a mut self,
+        callable: &'a VmValue,
+        args: &'a [VmValue],
+    ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>> + 'a>> {
+        Box::pin(async move {
+            match callable {
+                VmValue::Closure(closure) => self.call_closure(closure, args).await,
+                VmValue::BuiltinRef(name) => {
+                    if let Some(result) = self.call_sync_builtin_by_ref(name, args) {
+                        result
+                    } else {
+                        self.call_named_builtin(name, args.to_vec()).await
+                    }
                 }
+                VmValue::BuiltinRefId { id, name } => {
+                    self.call_builtin_id_or_name(*id, name, args.to_vec()).await
+                }
+                other => Err(VmError::TypeError(format!(
+                    "expected callable, got {}",
+                    other.type_name()
+                ))),
             }
-            VmValue::BuiltinRefId { id, name } => {
-                self.call_builtin_id_or_name(*id, name, args.to_vec()).await
-            }
-            other => Err(VmError::TypeError(format!(
-                "expected callable, got {}",
-                other.type_name()
-            ))),
-        }
+        })
     }
 
     fn call_sync_builtin_by_ref(
@@ -225,9 +225,8 @@ impl Vm {
         &mut self,
         closure: &VmClosure,
         args: &[VmValue],
-        functions: &[CompiledFunction],
     ) -> Result<VmValue, VmError> {
-        self.call_closure(closure, args, functions).await
+        self.call_closure(closure, args).await
     }
 
     /// Resolve a named builtin: sync builtins → async builtins → bridge → error.

--- a/crates/harn-vm/src/vm/execution.rs
+++ b/crates/harn-vm/src/vm/execution.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 use std::time::Instant;
 
-use crate::chunk::Chunk;
+use crate::chunk::{Chunk, ChunkRef};
 use crate::value::{ModuleFunctionRegistry, VmError, VmValue};
 
 use super::{CallFrame, Vm};
@@ -82,9 +82,27 @@ impl Vm {
         module_functions: Option<ModuleFunctionRegistry>,
         module_state: Option<crate::value::ModuleState>,
     ) -> Result<VmValue, VmError> {
+        self.run_chunk_ref(
+            Rc::new(chunk.clone()),
+            argc,
+            saved_source_dir,
+            module_functions,
+            module_state,
+        )
+        .await
+    }
+
+    pub(crate) async fn run_chunk_ref(
+        &mut self,
+        chunk: ChunkRef,
+        argc: usize,
+        saved_source_dir: Option<std::path::PathBuf>,
+        module_functions: Option<ModuleFunctionRegistry>,
+        module_state: Option<crate::value::ModuleState>,
+    ) -> Result<VmValue, VmError> {
         let initial_env = self.env.clone();
         self.frames.push(CallFrame {
-            chunk: chunk.clone(),
+            chunk,
             ip: 0,
             stack_base: self.stack.len(),
             saved_env: self.env.clone(),

--- a/crates/harn-vm/src/vm/iter.rs
+++ b/crates/harn-vm/src/vm/iter.rs
@@ -9,11 +9,8 @@
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
-use std::future::Future;
-use std::pin::Pin;
 use std::rc::Rc;
 
-use crate::chunk::CompiledFunction;
 use crate::value::{VmChannelHandle, VmError, VmGenerator, VmValue};
 
 /// Backing enum for `VmValue::Iter`. See module docs.
@@ -114,20 +111,16 @@ impl VmIter {
     /// Produce the next value, or `None` when exhausted.
     ///
     /// Combinator variants (`Map`, `Filter`, `FlatMap`) invoke user-provided
-    /// closures through the `vm` / `functions` parameters.
-    pub async fn next(
-        &mut self,
-        vm: &mut crate::vm::Vm,
-        functions: &[CompiledFunction],
-    ) -> Result<Option<VmValue>, VmError> {
-        self.next_impl(vm, functions).await
+    /// closures through the `vm` parameter.
+    pub fn next<'a>(
+        &'a mut self,
+        vm: &'a mut crate::vm::Vm,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Option<VmValue>, VmError>> + 'a>>
+    {
+        Box::pin(async move { self.next_impl(vm).await })
     }
 
-    async fn next_impl(
-        &mut self,
-        vm: &mut crate::vm::Vm,
-        functions: &[CompiledFunction],
-    ) -> Result<Option<VmValue>, VmError> {
+    async fn next_impl(&mut self, vm: &mut crate::vm::Vm) -> Result<Option<VmValue>, VmError> {
         match self {
             VmIter::Exhausted => Ok(None),
             VmIter::Range { next, stop } => {
@@ -197,14 +190,14 @@ impl VmIter {
             }
             VmIter::Map { inner, f } => {
                 let f = f.clone();
-                let item = next_handle_boxed(inner, vm, functions).await?;
+                let item = next_handle(inner, vm).await?;
                 match item {
                     None => {
                         *self = VmIter::Exhausted;
                         Ok(None)
                     }
                     Some(v) => {
-                        let out = vm.call_callable_value(&f, &[v], functions).await?;
+                        let out = vm.call_callable_value(&f, &[v]).await?;
                         Ok(Some(out))
                     }
                 }
@@ -212,14 +205,14 @@ impl VmIter {
             VmIter::Filter { inner, p } => {
                 let p = p.clone();
                 loop {
-                    let item = next_handle_boxed(inner, vm, functions).await?;
+                    let item = next_handle(inner, vm).await?;
                     match item {
                         None => {
                             *self = VmIter::Exhausted;
                             return Ok(None);
                         }
                         Some(v) => {
-                            let keep = vm.call_callable_value(&p, &[v.clone()], functions).await?;
+                            let keep = vm.call_callable_value(&p, &[v.clone()]).await?;
                             if keep.is_truthy() {
                                 return Ok(Some(v));
                             }
@@ -231,20 +224,20 @@ impl VmIter {
                 let f = f.clone();
                 loop {
                     if let Some(cur_iter) = cur.clone() {
-                        let item = next_handle_boxed(&cur_iter, vm, functions).await?;
+                        let item = next_handle(&cur_iter, vm).await?;
                         if let Some(v) = item {
                             return Ok(Some(v));
                         }
                         *cur = None;
                     }
-                    let item = next_handle_boxed(inner, vm, functions).await?;
+                    let item = next_handle(inner, vm).await?;
                     match item {
                         None => {
                             *self = VmIter::Exhausted;
                             return Ok(None);
                         }
                         Some(v) => {
-                            let result = vm.call_callable_value(&f, &[v], functions).await?;
+                            let result = vm.call_callable_value(&f, &[v]).await?;
                             let lifted = iter_from_value(result)?;
                             if let VmValue::Iter(h) = lifted {
                                 *cur = Some(h);
@@ -262,7 +255,7 @@ impl VmIter {
                     *self = VmIter::Exhausted;
                     return Ok(None);
                 }
-                let item = next_handle_boxed(inner, vm, functions).await?;
+                let item = next_handle(inner, vm).await?;
                 match item {
                     None => {
                         *self = VmIter::Exhausted;
@@ -279,7 +272,7 @@ impl VmIter {
             }
             VmIter::Skip { inner, remaining } => {
                 while *remaining > 0 {
-                    let item = next_handle_boxed(inner, vm, functions).await?;
+                    let item = next_handle(inner, vm).await?;
                     match item {
                         None => {
                             *self = VmIter::Exhausted;
@@ -290,7 +283,7 @@ impl VmIter {
                         }
                     }
                 }
-                let item = next_handle_boxed(inner, vm, functions).await?;
+                let item = next_handle(inner, vm).await?;
                 match item {
                     None => {
                         *self = VmIter::Exhausted;
@@ -304,14 +297,14 @@ impl VmIter {
                     return Ok(None);
                 }
                 let p = p.clone();
-                let item = next_handle_boxed(inner, vm, functions).await?;
+                let item = next_handle(inner, vm).await?;
                 match item {
                     None => {
                         *self = VmIter::Exhausted;
                         Ok(None)
                     }
                     Some(v) => {
-                        let keep = vm.call_callable_value(&p, &[v.clone()], functions).await?;
+                        let keep = vm.call_callable_value(&p, &[v.clone()]).await?;
                         if keep.is_truthy() {
                             Ok(Some(v))
                         } else {
@@ -323,7 +316,7 @@ impl VmIter {
             }
             VmIter::SkipWhile { inner, p, primed } => {
                 if *primed {
-                    let item = next_handle_boxed(inner, vm, functions).await?;
+                    let item = next_handle(inner, vm).await?;
                     return match item {
                         None => {
                             *self = VmIter::Exhausted;
@@ -334,15 +327,14 @@ impl VmIter {
                 }
                 let p = p.clone();
                 loop {
-                    let item = next_handle_boxed(inner, vm, functions).await?;
+                    let item = next_handle(inner, vm).await?;
                     match item {
                         None => {
                             *self = VmIter::Exhausted;
                             return Ok(None);
                         }
                         Some(v) => {
-                            let drop_it =
-                                vm.call_callable_value(&p, &[v.clone()], functions).await?;
+                            let drop_it = vm.call_callable_value(&p, &[v.clone()]).await?;
                             if !drop_it.is_truthy() {
                                 *primed = true;
                                 return Ok(Some(v));
@@ -352,7 +344,7 @@ impl VmIter {
                 }
             }
             VmIter::Zip { a, b } => {
-                let ia = next_handle_boxed(a, vm, functions).await?;
+                let ia = next_handle(a, vm).await?;
                 let x = match ia {
                     None => {
                         *self = VmIter::Exhausted;
@@ -360,7 +352,7 @@ impl VmIter {
                     }
                     Some(v) => v,
                 };
-                let ib = next_handle_boxed(b, vm, functions).await?;
+                let ib = next_handle(b, vm).await?;
                 let y = match ib {
                     None => {
                         *self = VmIter::Exhausted;
@@ -371,7 +363,7 @@ impl VmIter {
                 Ok(Some(VmValue::Pair(Rc::new((x, y)))))
             }
             VmIter::Enumerate { inner, i } => {
-                let item = next_handle_boxed(inner, vm, functions).await?;
+                let item = next_handle(inner, vm).await?;
                 match item {
                     None => {
                         *self = VmIter::Exhausted;
@@ -386,13 +378,13 @@ impl VmIter {
             }
             VmIter::Chain { a, b, on_a } => {
                 if *on_a {
-                    let item = next_handle_boxed(a, vm, functions).await?;
+                    let item = next_handle(a, vm).await?;
                     if let Some(v) = item {
                         return Ok(Some(v));
                     }
                     *on_a = false;
                 }
-                let item = next_handle_boxed(b, vm, functions).await?;
+                let item = next_handle(b, vm).await?;
                 match item {
                     None => {
                         *self = VmIter::Exhausted;
@@ -405,7 +397,7 @@ impl VmIter {
                 let n = *n;
                 let mut batch: Vec<VmValue> = Vec::with_capacity(n);
                 for _ in 0..n {
-                    let item = next_handle_boxed(inner, vm, functions).await?;
+                    let item = next_handle(inner, vm).await?;
                     match item {
                         Some(v) => batch.push(v),
                         None => break,
@@ -422,7 +414,7 @@ impl VmIter {
                 let n = *n;
                 if buf.is_empty() {
                     while buf.len() < n {
-                        let item = next_handle_boxed(inner, vm, functions).await?;
+                        let item = next_handle(inner, vm).await?;
                         match item {
                             Some(v) => buf.push_back(v),
                             None => {
@@ -432,7 +424,7 @@ impl VmIter {
                         }
                     }
                 } else {
-                    let item = next_handle_boxed(inner, vm, functions).await?;
+                    let item = next_handle(inner, vm).await?;
                     match item {
                         Some(v) => {
                             buf.pop_front();
@@ -480,32 +472,22 @@ impl VmIter {
 pub async fn next_handle(
     handle: &Rc<RefCell<VmIter>>,
     vm: &mut crate::vm::Vm,
-    functions: &[CompiledFunction],
 ) -> Result<Option<VmValue>, VmError> {
     let mut state = std::mem::replace(&mut *handle.borrow_mut(), VmIter::Exhausted);
-    let result = state.next(vm, functions).await;
+    let result = state.next(vm).await;
     // Restore state unless the inner call replaced it with Exhausted.
     *handle.borrow_mut() = state;
     result
-}
-
-fn next_handle_boxed<'a>(
-    handle: &'a Rc<RefCell<VmIter>>,
-    vm: &'a mut crate::vm::Vm,
-    functions: &'a [CompiledFunction],
-) -> Pin<Box<dyn Future<Output = Result<Option<VmValue>, VmError>> + 'a>> {
-    Box::pin(next_handle(handle, vm, functions))
 }
 
 /// Fully consume an iter handle into a Vec of values.
 pub async fn drain(
     handle: &Rc<RefCell<VmIter>>,
     vm: &mut crate::vm::Vm,
-    functions: &[CompiledFunction],
 ) -> Result<Vec<VmValue>, VmError> {
     let mut out = Vec::new();
     loop {
-        let v = next_handle(handle, vm, functions).await?;
+        let v = next_handle(handle, vm).await?;
         match v {
             Some(v) => out.push(v),
             None => break,

--- a/crates/harn-vm/src/vm/methods/dict.rs
+++ b/crates/harn-vm/src/vm/methods/dict.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
-use crate::chunk::CompiledFunction;
 use crate::value::{VmError, VmValue};
 
 impl crate::vm::Vm {
@@ -10,7 +9,6 @@ impl crate::vm::Vm {
         map: &Rc<BTreeMap<String, VmValue>>,
         method: &str,
         args: &[VmValue],
-        functions: &[CompiledFunction],
     ) -> Result<VmValue, VmError> {
         match method {
             "keys" => Ok(VmValue::List(Rc::new(
@@ -46,9 +44,7 @@ impl crate::vm::Vm {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     let mut result = BTreeMap::new();
                     for (k, v) in map.iter() {
-                        let mapped = self
-                            .call_callable_value(callable, &[v.clone()], functions)
-                            .await?;
+                        let mapped = self.call_callable_value(callable, &[v.clone()]).await?;
                         result.insert(k.clone(), mapped);
                     }
                     Ok(VmValue::Dict(Rc::new(result)))
@@ -61,11 +57,7 @@ impl crate::vm::Vm {
                     let mut result = BTreeMap::new();
                     for (k, v) in map.iter() {
                         let new_key = self
-                            .call_callable_value(
-                                callable,
-                                &[VmValue::String(Rc::from(k.as_str()))],
-                                functions,
-                            )
+                            .call_callable_value(callable, &[VmValue::String(Rc::from(k.as_str()))])
                             .await?;
                         let new_key_str = new_key.display();
                         result.insert(new_key_str, v.clone());
@@ -79,9 +71,7 @@ impl crate::vm::Vm {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     let mut result = BTreeMap::new();
                     for (k, v) in map.iter() {
-                        let keep = self
-                            .call_callable_value(callable, &[v.clone()], functions)
-                            .await?;
+                        let keep = self.call_callable_value(callable, &[v.clone()]).await?;
                         if keep.is_truthy() {
                             result.insert(k.clone(), v.clone());
                         }
@@ -104,7 +94,7 @@ impl crate::vm::Vm {
             }
             _ => {
                 if let Some(callable) = map.get(method).filter(|v| Self::is_callable_value(v)) {
-                    self.call_callable_value(callable, args, functions).await
+                    self.call_callable_value(callable, args).await
                 } else {
                     Ok(VmValue::Nil)
                 }

--- a/crates/harn-vm/src/vm/methods/dispatch.rs
+++ b/crates/harn-vm/src/vm/methods/dispatch.rs
@@ -1,47 +1,46 @@
-use crate::chunk::CompiledFunction;
+use std::future::Future;
+use std::pin::Pin;
+
 use crate::value::{VmError, VmValue};
 use crate::vm::iter::iter_from_value;
 
 impl crate::vm::Vm {
-    pub(in crate::vm) async fn call_method(
-        &mut self,
+    pub(in crate::vm) fn call_method<'a>(
+        &'a mut self,
         obj: VmValue,
-        method: &str,
-        args: &[VmValue],
-        functions: &[CompiledFunction],
-    ) -> Result<VmValue, VmError> {
-        if method == "iter"
-            && matches!(
-                &obj,
-                VmValue::List(_)
-                    | VmValue::Set(_)
-                    | VmValue::Dict(_)
-                    | VmValue::String(_)
-                    | VmValue::Generator(_)
-                    | VmValue::Channel(_)
-                    | VmValue::Iter(_)
-            )
-        {
-            return iter_from_value(obj);
-        }
+        method: &'a str,
+        args: &'a [VmValue],
+    ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>> + 'a>> {
+        Box::pin(async move {
+            if method == "iter"
+                && matches!(
+                    &obj,
+                    VmValue::List(_)
+                        | VmValue::Set(_)
+                        | VmValue::Dict(_)
+                        | VmValue::String(_)
+                        | VmValue::Generator(_)
+                        | VmValue::Channel(_)
+                        | VmValue::Iter(_)
+                )
+            {
+                return iter_from_value(obj);
+            }
 
-        match &obj {
-            VmValue::String(s) => self.call_string_method(s, method, args),
-            VmValue::List(items) => self.call_list_method(items, method, args, functions).await,
-            VmValue::Dict(map) => self.call_dict_method(map, method, args, functions).await,
-            VmValue::Set(items) => self.call_set_method(items, method, args, functions).await,
-            VmValue::Range(r) => {
-                self.call_range_method(&obj, r, method, args, functions)
-                    .await
+            match &obj {
+                VmValue::String(s) => self.call_string_method(s, method, args),
+                VmValue::List(items) => self.call_list_method(items, method, args).await,
+                VmValue::Dict(map) => self.call_dict_method(map, method, args).await,
+                VmValue::Set(items) => self.call_set_method(items, method, args).await,
+                VmValue::Range(r) => self.call_range_method(&obj, r, method, args).await,
+                VmValue::Int(_) | VmValue::Float(_) => self.call_number_method(&obj, method, args),
+                VmValue::StructInstance { .. } => {
+                    self.call_struct_instance_method(&obj, method, args).await
+                }
+                VmValue::Generator(gen) => self.call_generator_method(gen, method).await,
+                VmValue::Iter(handle) => self.call_iter_method(handle, method, args).await,
+                _ => Ok(VmValue::Nil),
             }
-            VmValue::Int(_) | VmValue::Float(_) => self.call_number_method(&obj, method, args),
-            VmValue::StructInstance { .. } => {
-                self.call_struct_instance_method(&obj, method, args, functions)
-                    .await
-            }
-            VmValue::Generator(gen) => self.call_generator_method(gen, method).await,
-            VmValue::Iter(handle) => self.call_iter_method(handle, method, args, functions).await,
-            _ => Ok(VmValue::Nil),
-        }
+        })
     }
 }

--- a/crates/harn-vm/src/vm/methods/iter.rs
+++ b/crates/harn-vm/src/vm/methods/iter.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
 use std::rc::Rc;
 
-use crate::chunk::CompiledFunction;
 use crate::value::{compare_values, values_equal, VmError, VmValue};
 use crate::vm::iter::{drain, iter_from_value, next_handle, VmIter};
 
@@ -12,7 +11,6 @@ impl crate::vm::Vm {
         handle: &Rc<RefCell<VmIter>>,
         method: &str,
         args: &[VmValue],
-        functions: &[CompiledFunction],
     ) -> Result<VmValue, VmError> {
         let handle = Rc::clone(handle);
         match method {
@@ -173,11 +171,11 @@ impl crate::vm::Vm {
                 }))))
             }
             "to_list" => {
-                let items = drain(&handle, self, functions).await?;
+                let items = drain(&handle, self).await?;
                 Ok(VmValue::List(Rc::new(items)))
             }
             "to_set" => {
-                let items = drain(&handle, self, functions).await?;
+                let items = drain(&handle, self).await?;
                 let mut out: Vec<VmValue> = Vec::new();
                 for v in items {
                     if !out.iter().any(|x| values_equal(x, &v)) {
@@ -187,7 +185,7 @@ impl crate::vm::Vm {
                 Ok(VmValue::Set(Rc::new(out)))
             }
             "to_dict" => {
-                let items = drain(&handle, self, functions).await?;
+                let items = drain(&handle, self).await?;
                 let mut map = BTreeMap::new();
                 for v in items {
                     match v {
@@ -217,7 +215,7 @@ impl crate::vm::Vm {
             "count" => {
                 let mut n: i64 = 0;
                 loop {
-                    let v = next_handle(&handle, self, functions).await?;
+                    let v = next_handle(&handle, self).await?;
                     if v.is_none() {
                         break;
                     }
@@ -226,7 +224,7 @@ impl crate::vm::Vm {
                 Ok(VmValue::Int(n))
             }
             "sum" => {
-                let items = drain(&handle, self, functions).await?;
+                let items = drain(&handle, self).await?;
                 let mut has_float = false;
                 let mut int_acc: i64 = 0;
                 let mut float_acc: f64 = 0.0;
@@ -255,7 +253,7 @@ impl crate::vm::Vm {
                 }
             }
             "min" => {
-                let items = drain(&handle, self, functions).await?;
+                let items = drain(&handle, self).await?;
                 let mut best: Option<VmValue> = None;
                 for v in items {
                     best = Some(match best {
@@ -272,7 +270,7 @@ impl crate::vm::Vm {
                 Ok(best.unwrap_or(VmValue::Nil))
             }
             "max" => {
-                let items = drain(&handle, self, functions).await?;
+                let items = drain(&handle, self).await?;
                 let mut best: Option<VmValue> = None;
                 for v in items {
                     best = Some(match best {
@@ -302,23 +300,23 @@ impl crate::vm::Vm {
                     ));
                 }
                 loop {
-                    let item = next_handle(&handle, self, functions).await?;
+                    let item = next_handle(&handle, self).await?;
                     match item {
                         None => return Ok(acc),
                         Some(v) => {
-                            acc = self.call_callable_value(&f, &[acc, v], functions).await?;
+                            acc = self.call_callable_value(&f, &[acc, v]).await?;
                         }
                     }
                 }
             }
             "first" => {
-                let v = next_handle(&handle, self, functions).await?;
+                let v = next_handle(&handle, self).await?;
                 Ok(v.unwrap_or(VmValue::Nil))
             }
             "last" => {
                 let mut last = VmValue::Nil;
                 loop {
-                    let v = next_handle(&handle, self, functions).await?;
+                    let v = next_handle(&handle, self).await?;
                     match v {
                         Some(v) => last = v,
                         None => return Ok(last),
@@ -332,11 +330,11 @@ impl crate::vm::Vm {
                     .cloned()
                     .ok_or_else(|| VmError::TypeError("iter.any: expected callable".to_string()))?;
                 loop {
-                    let item = next_handle(&handle, self, functions).await?;
+                    let item = next_handle(&handle, self).await?;
                     match item {
                         None => return Ok(VmValue::Bool(false)),
                         Some(v) => {
-                            let r = self.call_callable_value(&p, &[v], functions).await?;
+                            let r = self.call_callable_value(&p, &[v]).await?;
                             if r.is_truthy() {
                                 return Ok(VmValue::Bool(true));
                             }
@@ -351,11 +349,11 @@ impl crate::vm::Vm {
                     .cloned()
                     .ok_or_else(|| VmError::TypeError("iter.all: expected callable".to_string()))?;
                 loop {
-                    let item = next_handle(&handle, self, functions).await?;
+                    let item = next_handle(&handle, self).await?;
                     match item {
                         None => return Ok(VmValue::Bool(true)),
                         Some(v) => {
-                            let r = self.call_callable_value(&p, &[v], functions).await?;
+                            let r = self.call_callable_value(&p, &[v]).await?;
                             if !r.is_truthy() {
                                 return Ok(VmValue::Bool(false));
                             }
@@ -372,13 +370,11 @@ impl crate::vm::Vm {
                         VmError::TypeError("iter.find: expected callable".to_string())
                     })?;
                 loop {
-                    let item = next_handle(&handle, self, functions).await?;
+                    let item = next_handle(&handle, self).await?;
                     match item {
                         None => return Ok(VmValue::Nil),
                         Some(v) => {
-                            let r = self
-                                .call_callable_value(&p, &[v.clone()], functions)
-                                .await?;
+                            let r = self.call_callable_value(&p, &[v.clone()]).await?;
                             if r.is_truthy() {
                                 return Ok(v);
                             }
@@ -395,11 +391,11 @@ impl crate::vm::Vm {
                         VmError::TypeError("iter.for_each: expected callable".to_string())
                     })?;
                 loop {
-                    let item = next_handle(&handle, self, functions).await?;
+                    let item = next_handle(&handle, self).await?;
                     match item {
                         None => return Ok(VmValue::Nil),
                         Some(v) => {
-                            self.call_callable_value(&f, &[v], functions).await?;
+                            self.call_callable_value(&f, &[v]).await?;
                         }
                     }
                 }

--- a/crates/harn-vm/src/vm/methods/list.rs
+++ b/crates/harn-vm/src/vm/methods/list.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
-use crate::chunk::CompiledFunction;
 use crate::value::{compare_values, values_equal, VmError, VmValue};
 
 impl crate::vm::Vm {
@@ -10,7 +9,6 @@ impl crate::vm::Vm {
         items: &Rc<Vec<VmValue>>,
         method: &str,
         args: &[VmValue],
-        functions: &[CompiledFunction],
     ) -> Result<VmValue, VmError> {
         match method {
             "count" => Ok(VmValue::Int(items.len() as i64)),
@@ -19,10 +17,7 @@ impl crate::vm::Vm {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     let mut results = Vec::with_capacity(items.len());
                     for item in items.iter() {
-                        results.push(
-                            self.call_callable_value(callable, &[item.clone()], functions)
-                                .await?,
-                        );
+                        results.push(self.call_callable_value(callable, &[item.clone()]).await?);
                     }
                     Ok(VmValue::List(Rc::new(results)))
                 } else {
@@ -33,9 +28,7 @@ impl crate::vm::Vm {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     let mut results = Vec::with_capacity(items.len());
                     for item in items.iter() {
-                        let result = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
                         if result.is_truthy() {
                             results.push(item.clone());
                         }
@@ -51,7 +44,7 @@ impl crate::vm::Vm {
                     let mut acc = args[0].clone();
                     for item in items.iter() {
                         acc = self
-                            .call_callable_value(callable, &[acc, item.clone()], functions)
+                            .call_callable_value(callable, &[acc, item.clone()])
                             .await?;
                     }
                     return Ok(acc);
@@ -61,9 +54,7 @@ impl crate::vm::Vm {
             "find" => {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     for item in items.iter() {
-                        let result = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
                         if result.is_truthy() {
                             return Ok(item.clone());
                         }
@@ -74,9 +65,7 @@ impl crate::vm::Vm {
             "any" => {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     for item in items.iter() {
-                        let result = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
                         if result.is_truthy() {
                             return Ok(VmValue::Bool(true));
                         }
@@ -89,9 +78,7 @@ impl crate::vm::Vm {
             "all" | "every" | "all?" => {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     for item in items.iter() {
-                        let result = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
                         if !result.is_truthy() {
                             return Ok(VmValue::Bool(false));
                         }
@@ -105,9 +92,7 @@ impl crate::vm::Vm {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     let mut results = Vec::with_capacity(items.len());
                     for item in items.iter() {
-                        let result = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
                         if let VmValue::List(inner) = result {
                             results.extend(inner.iter().cloned());
                         } else {
@@ -128,9 +113,7 @@ impl crate::vm::Vm {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     let mut keyed: Vec<(VmValue, VmValue)> = Vec::new();
                     for item in items.iter() {
-                        let key = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let key = self.call_callable_value(callable, &[item.clone()]).await?;
                         keyed.push((item.clone(), key));
                     }
                     keyed.sort_by(|(_, ka), (_, kb)| compare_values(ka, kb).cmp(&0));
@@ -310,9 +293,7 @@ impl crate::vm::Vm {
             "none" | "none?" => {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     for item in items.iter() {
-                        let result = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
                         if result.is_truthy() {
                             return Ok(VmValue::Bool(false));
                         }
@@ -325,9 +306,7 @@ impl crate::vm::Vm {
             "find_index" => {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     for (i, item) in items.iter().enumerate() {
-                        let result = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
                         if result.is_truthy() {
                             return Ok(VmValue::Int(i as i64));
                         }
@@ -362,9 +341,7 @@ impl crate::vm::Vm {
                     let mut truthy = Vec::new();
                     let mut falsy = Vec::new();
                     for item in items.iter() {
-                        let result = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
                         if result.is_truthy() {
                             truthy.push(item.clone());
                         } else {
@@ -383,9 +360,7 @@ impl crate::vm::Vm {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     let mut groups: BTreeMap<String, Vec<VmValue>> = BTreeMap::new();
                     for item in items.iter() {
-                        let key = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let key = self.call_callable_value(callable, &[item.clone()]).await?;
                         let key_str = key.display();
                         groups.entry(key_str).or_default().push(item.clone());
                     }
@@ -412,13 +387,9 @@ impl crate::vm::Vm {
                 }
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     let mut best = items[0].clone();
-                    let mut best_key = self
-                        .call_callable_value(callable, &[best.clone()], functions)
-                        .await?;
+                    let mut best_key = self.call_callable_value(callable, &[best.clone()]).await?;
                     for item in &items[1..] {
-                        let key = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let key = self.call_callable_value(callable, &[item.clone()]).await?;
                         if compare_values(&key, &best_key) < 0 {
                             best = item.clone();
                             best_key = key;
@@ -435,13 +406,9 @@ impl crate::vm::Vm {
                 }
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     let mut best = items[0].clone();
-                    let mut best_key = self
-                        .call_callable_value(callable, &[best.clone()], functions)
-                        .await?;
+                    let mut best_key = self.call_callable_value(callable, &[best.clone()]).await?;
                     for item in &items[1..] {
-                        let key = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let key = self.call_callable_value(callable, &[item.clone()]).await?;
                         if compare_values(&key, &best_key) > 0 {
                             best = item.clone();
                             best_key = key;

--- a/crates/harn-vm/src/vm/methods/range.rs
+++ b/crates/harn-vm/src/vm/methods/range.rs
@@ -1,4 +1,3 @@
-use crate::chunk::CompiledFunction;
 use crate::value::{VmError, VmRange, VmValue};
 use crate::vm::iter::iter_from_value;
 
@@ -9,7 +8,6 @@ impl crate::vm::Vm {
         r: &VmRange,
         method: &str,
         args: &[VmValue],
-        functions: &[CompiledFunction],
     ) -> Result<VmValue, VmError> {
         match method {
             "len" | "count" => Ok(VmValue::Int(r.len())),
@@ -27,11 +25,7 @@ impl crate::vm::Vm {
             "to_string" => Ok(VmValue::String(std::rc::Rc::from(obj.display()))),
             _ => {
                 let lifted = iter_from_value(obj.clone())?;
-                let VmValue::Iter(handle) = lifted else {
-                    unreachable!("iter_from_value returns Iter for ranges")
-                };
-                self.call_iter_method(&handle, method, args, functions)
-                    .await
+                self.call_method(lifted, method, args).await
             }
         }
     }

--- a/crates/harn-vm/src/vm/methods/set.rs
+++ b/crates/harn-vm/src/vm/methods/set.rs
@@ -1,6 +1,5 @@
 use std::rc::Rc;
 
-use crate::chunk::CompiledFunction;
 use crate::value::{values_equal, VmError, VmValue};
 
 impl crate::vm::Vm {
@@ -9,7 +8,6 @@ impl crate::vm::Vm {
         items: &Rc<Vec<VmValue>>,
         method: &str,
         args: &[VmValue],
-        functions: &[CompiledFunction],
     ) -> Result<VmValue, VmError> {
         match method {
             "count" | "len" => Ok(VmValue::Int(items.len() as i64)),
@@ -127,9 +125,7 @@ impl crate::vm::Vm {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     let mut result = Vec::new();
                     for item in items.iter() {
-                        let mapped = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let mapped = self.call_callable_value(callable, &[item.clone()]).await?;
                         if !result.iter().any(|x| values_equal(x, &mapped)) {
                             result.push(mapped);
                         }
@@ -143,9 +139,7 @@ impl crate::vm::Vm {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     let mut result = Vec::new();
                     for item in items.iter() {
-                        let keep = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let keep = self.call_callable_value(callable, &[item.clone()]).await?;
                         if keep.is_truthy() {
                             result.push(item.clone());
                         }
@@ -158,9 +152,7 @@ impl crate::vm::Vm {
             "any" => {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     for item in items.iter() {
-                        let result = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
                         if result.is_truthy() {
                             return Ok(VmValue::Bool(true));
                         }
@@ -173,9 +165,7 @@ impl crate::vm::Vm {
             "all" | "every" => {
                 if let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) {
                     for item in items.iter() {
-                        let result = self
-                            .call_callable_value(callable, &[item.clone()], functions)
-                            .await?;
+                        let result = self.call_callable_value(callable, &[item.clone()]).await?;
                         if !result.is_truthy() {
                             return Ok(VmValue::Bool(false));
                         }

--- a/crates/harn-vm/src/vm/methods/struct_instance.rs
+++ b/crates/harn-vm/src/vm/methods/struct_instance.rs
@@ -1,4 +1,3 @@
-use crate::chunk::CompiledFunction;
 use crate::value::{VmError, VmValue};
 
 impl crate::vm::Vm {
@@ -7,7 +6,6 @@ impl crate::vm::Vm {
         obj: &VmValue,
         method: &str,
         args: &[VmValue],
-        functions: &[CompiledFunction],
     ) -> Result<VmValue, VmError> {
         let VmValue::StructInstance { layout, .. } = obj else {
             unreachable!("struct instance dispatch only calls struct instance handler");
@@ -18,7 +16,7 @@ impl crate::vm::Vm {
             if let Some(VmValue::Closure(closure)) = impl_dict.get(method) {
                 let mut full_args = vec![obj.clone()];
                 full_args.extend_from_slice(args);
-                return self.call_closure(closure, &full_args, functions).await;
+                return self.call_closure(closure, &full_args).await;
             }
         }
 

--- a/crates/harn-vm/src/vm/modules.rs
+++ b/crates/harn-vm/src/vm/modules.rs
@@ -330,7 +330,7 @@ impl Vm {
                     .compile_fn_body(params, body, module_source_file)
                     .map_err(|e| VmError::Runtime(format!("Import compile error: {e}")))?;
                 let closure = Rc::new(VmClosure {
-                    func: func_chunk,
+                    func: Rc::new(func_chunk),
                     env: module_env.clone(),
                     source_dir: source_dir.clone(),
                     module_functions: Some(Rc::clone(&registry)),

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -212,7 +212,6 @@ impl super::super::Vm {
         &mut self,
         name: &str,
         args: Vec<VmValue>,
-        functions: &[crate::chunk::CompiledFunction],
         direct_id: Option<BuiltinId>,
     ) -> Result<(), VmError> {
         if self.try_call_special_name(name, &args).await? {
@@ -223,7 +222,7 @@ impl super::super::Vm {
                 let gen = self.create_generator(&closure, &args);
                 self.stack.push(gen);
             } else {
-                self.push_closure_frame(&closure, &args, functions)?;
+                self.push_closure_frame(&closure, &args)?;
             }
         } else {
             let result = if let Some(id) = direct_id {
@@ -241,30 +240,27 @@ impl super::super::Vm {
             let frame = self.frames.last_mut().unwrap();
             let argc = frame.chunk.code[frame.ip] as usize;
             frame.ip += 1;
-            // Avoid borrowing frame across the call.
-            let functions = frame.chunk.functions.clone();
 
             let args: Vec<VmValue> = self.stack.split_off(self.stack.len().saturating_sub(argc));
             let callee = self.pop()?;
 
             match callee {
                 VmValue::String(name) => {
-                    self.call_named_value(&name, args, &functions, None).await?;
+                    self.call_named_value(&name, args, None).await?;
                 }
                 VmValue::Closure(closure) => {
                     if closure.func.is_generator {
                         let gen = self.create_generator(&closure, &args);
                         self.stack.push(gen);
                     } else {
-                        self.push_closure_frame(&closure, &args, &functions)?;
+                        self.push_closure_frame(&closure, &args)?;
                     }
                 }
                 VmValue::BuiltinRef(name) => {
-                    self.call_named_value(&name, args, &functions, None).await?;
+                    self.call_named_value(&name, args, None).await?;
                 }
                 VmValue::BuiltinRefId { id, name } => {
-                    self.call_named_value(&name, args, &functions, Some(id))
-                        .await?;
+                    self.call_named_value(&name, args, Some(id)).await?;
                 }
                 _ => {
                     return Err(VmError::TypeError(format!(
@@ -284,26 +280,23 @@ impl super::super::Vm {
                     ))
                 }
             };
-            let functions = self.frames.last().unwrap().chunk.functions.clone();
-
             match callee {
                 VmValue::String(name) => {
-                    self.call_named_value(&name, args, &functions, None).await?;
+                    self.call_named_value(&name, args, None).await?;
                 }
                 VmValue::Closure(closure) => {
                     if closure.func.is_generator {
                         let gen = self.create_generator(&closure, &args);
                         self.stack.push(gen);
                     } else {
-                        self.push_closure_frame(&closure, &args, &functions)?;
+                        self.push_closure_frame(&closure, &args)?;
                     }
                 }
                 VmValue::BuiltinRef(name) => {
-                    self.call_named_value(&name, args, &functions, None).await?;
+                    self.call_named_value(&name, args, None).await?;
                 }
                 VmValue::BuiltinRefId { id, name } => {
-                    self.call_named_value(&name, args, &functions, Some(id))
-                        .await?;
+                    self.call_named_value(&name, args, Some(id)).await?;
                 }
                 _ => {
                     return Err(VmError::TypeError(format!(
@@ -372,7 +365,7 @@ impl super::super::Vm {
 
                 let argc = args.len();
                 self.frames.push(CallFrame {
-                    chunk: closure.func.chunk.clone(),
+                    chunk: Rc::clone(&closure.func.chunk),
                     ip: 0,
                     stack_base,
                     saved_env: parent_env,
@@ -407,10 +400,8 @@ impl super::super::Vm {
             let argc = frame.chunk.code[frame.ip] as usize;
             frame.ip += 1;
             let name = Self::const_string(&frame.chunk.constants[name_idx])?;
-            let functions = frame.chunk.functions.clone();
             let args: Vec<VmValue> = self.stack.split_off(self.stack.len().saturating_sub(argc));
-            self.call_named_value(&name, args, &functions, Some(id))
-                .await?;
+            self.call_named_value(&name, args, Some(id)).await?;
         } else if op == Op::CallBuiltinSpread as u8 {
             let frame = self.frames.last_mut().unwrap();
             let id = BuiltinId::from_raw(frame.chunk.read_u64(frame.ip));
@@ -418,7 +409,6 @@ impl super::super::Vm {
             let name_idx = frame.chunk.read_u16(frame.ip) as usize;
             frame.ip += 2;
             let name = Self::const_string(&frame.chunk.constants[name_idx])?;
-            let functions = frame.chunk.functions.clone();
             let args_val = self.pop()?;
             let args = match args_val {
                 VmValue::List(items) => (*items).clone(),
@@ -428,8 +418,7 @@ impl super::super::Vm {
                     ))
                 }
             };
-            self.call_named_value(&name, args, &functions, Some(id))
-                .await?;
+            self.call_named_value(&name, args, Some(id)).await?;
         } else if op == Op::Return as u8 {
             let val = self.pop().unwrap_or(VmValue::Nil);
             return Err(VmError::Return(val));
@@ -437,7 +426,7 @@ impl super::super::Vm {
             let frame = self.frames.last_mut().unwrap();
             let fn_idx = frame.chunk.read_u16(frame.ip) as usize;
             frame.ip += 2;
-            let func = frame.chunk.functions[fn_idx].clone();
+            let func = Rc::clone(&frame.chunk.functions[fn_idx]);
             let closure = VmClosure {
                 func,
                 env: self.env.clone(),
@@ -482,8 +471,7 @@ impl super::super::Vm {
                     Self::const_string(&frame.chunk.constants[name_idx as usize])?
                 };
                 let cache_target = Self::method_cache_target(&obj, &method, args.len());
-                let functions = self.frames.last().unwrap().chunk.functions.clone();
-                let result = self.call_method(obj, &method, &args, &functions).await?;
+                let result = self.call_method(obj, &method, &args).await?;
                 if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
                     let frame = self.frames.last().unwrap();
                     frame.chunk.set_inline_cache_entry(
@@ -528,8 +516,7 @@ impl super::super::Vm {
                     Self::const_string(&frame.chunk.constants[name_idx as usize])?
                 };
                 let cache_target = Self::method_cache_target(&obj, &method, args.len());
-                let functions = self.frames.last().unwrap().chunk.functions.clone();
-                let result = self.call_method(obj, &method, &args, &functions).await?;
+                let result = self.call_method(obj, &method, &args).await?;
                 if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
                     let frame = self.frames.last().unwrap();
                     frame.chunk.set_inline_cache_entry(
@@ -546,22 +533,18 @@ impl super::super::Vm {
         } else if op == Op::Pipe as u8 {
             let callable = self.pop()?;
             let value = self.pop()?;
-            let functions = self.frames.last().unwrap().chunk.functions.clone();
             match callable {
                 VmValue::Closure(closure) => {
-                    self.push_closure_frame(&closure, &[value], &functions)?;
+                    self.push_closure_frame(&closure, &[value])?;
                 }
                 VmValue::String(name) => {
-                    self.call_named_value(&name, vec![value], &functions, None)
-                        .await?;
+                    self.call_named_value(&name, vec![value], None).await?;
                 }
                 VmValue::BuiltinRef(name) => {
-                    self.call_named_value(&name, vec![value], &functions, None)
-                        .await?;
+                    self.call_named_value(&name, vec![value], None).await?;
                 }
                 VmValue::BuiltinRefId { id, name } => {
-                    self.call_named_value(&name, vec![value], &functions, Some(id))
-                        .await?;
+                    self.call_named_value(&name, vec![value], Some(id)).await?;
                 }
                 _ => {
                     return Err(VmError::TypeError(format!(

--- a/crates/harn-vm/src/vm/ops/iter.rs
+++ b/crates/harn-vm/src/vm/ops/iter.rs
@@ -71,8 +71,7 @@ impl super::super::Vm {
             if let Some(handle) = vm_iter_handle {
                 // Safe for recursive VM reentry via closures as long as they
                 // don't re-enter the same iter handle.
-                let functions = self.frames.last().unwrap().chunk.functions.clone();
-                let next_val = crate::vm::iter::next_handle(&handle, self, &functions).await?;
+                let next_val = crate::vm::iter::next_handle(&handle, self).await?;
                 match next_val {
                     Some(v) => self.stack.push(v),
                     None => {

--- a/crates/harn-vm/src/vm/ops/parallel.rs
+++ b/crates/harn-vm/src/vm/ops/parallel.rs
@@ -93,7 +93,7 @@ impl super::super::Vm {
                     let closure = closure.clone();
                     futures.push(async move {
                         let result = child
-                            .call_closure(&closure, &[VmValue::Int(i as i64)], &[])
+                            .call_closure(&closure, &[VmValue::Int(i as i64)])
                             .await?;
                         Ok::<(VmValue, String), VmError>((
                             result,
@@ -126,7 +126,7 @@ impl super::super::Vm {
                         let closure = closure.clone();
                         let item = item.clone();
                         futures.push(async move {
-                            let result = child.call_closure(&closure, &[item], &[]).await?;
+                            let result = child.call_closure(&closure, &[item]).await?;
                             Ok::<(VmValue, String), VmError>((
                                 result,
                                 std::mem::take(&mut child.output),
@@ -158,7 +158,7 @@ impl super::super::Vm {
                         let closure = closure.clone();
                         let item = item.clone();
                         futures.push(async move {
-                            let result = child.call_closure(&closure, &[item], &[]).await;
+                            let result = child.call_closure(&closure, &[item]).await;
                             let output = std::mem::take(&mut child.output);
                             (result, output)
                         });
@@ -203,7 +203,7 @@ impl super::super::Vm {
                 let cancel_token = Arc::new(std::sync::atomic::AtomicBool::new(false));
                 child.cancel_token = Some(cancel_token.clone());
                 let handle = tokio::task::spawn_local(async move {
-                    let result = child.call_closure(&closure, &[], &[]).await?;
+                    let result = child.call_closure(&closure, &[]).await?;
                     Ok((result, std::mem::take(&mut child.output)))
                 });
                 self.spawned_tasks.insert(

--- a/crates/harn-vm/src/vm/scope.rs
+++ b/crates/harn-vm/src/vm/scope.rs
@@ -1,6 +1,5 @@
 use std::rc::Rc;
 
-use crate::chunk::CompiledFunction;
 use crate::value::{VmClosure, VmEnv, VmError, VmValue};
 
 use super::{CallFrame, Vm};
@@ -68,7 +67,6 @@ impl Vm {
         &mut self,
         closure: &VmClosure,
         args: &[VmValue],
-        _parent_functions: &[CompiledFunction],
     ) -> Result<(), VmError> {
         if self.frames.len() >= Self::MAX_FRAMES {
             return Err(VmError::StackOverflow);
@@ -127,7 +125,7 @@ impl Vm {
         }
 
         self.frames.push(CallFrame {
-            chunk: closure.func.chunk.clone(),
+            chunk: Rc::clone(&closure.func.chunk),
             ip: 0,
             stack_base: self.stack.len(),
             saved_env,
@@ -184,7 +182,7 @@ impl Vm {
         }
         child.env = call_env;
 
-        let chunk = closure.func.chunk.clone();
+        let chunk = Rc::clone(&closure.func.chunk);
         let saved_source_dir = if let Some(ref dir) = closure.source_dir {
             let prev = crate::stdlib::process::VM_SOURCE_DIR.with(|sd| sd.borrow().clone());
             crate::stdlib::set_thread_source_dir(dir);
@@ -199,8 +197,8 @@ impl Vm {
         // The task will execute until return, sending yielded values through the channel.
         tokio::task::spawn_local(async move {
             let _ = child
-                .run_chunk_entry(
-                    &chunk,
+                .run_chunk_ref(
+                    chunk,
                     argc,
                     saved_source_dir,
                     module_functions,

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::rc::Rc;
 use std::time::Instant;
 
-use crate::chunk::{Chunk, Constant};
+use crate::chunk::{Chunk, ChunkRef, Constant};
 use crate::value::{
     ModuleFunctionRegistry, VmAsyncBuiltinFn, VmBuiltinFn, VmEnv, VmError, VmTaskHandle, VmValue,
 };
@@ -28,7 +28,7 @@ impl Drop for ScopeSpan {
 
 /// Call frame for function execution.
 pub(crate) struct CallFrame {
-    pub(crate) chunk: Chunk,
+    pub(crate) chunk: ChunkRef,
     pub(crate) ip: usize,
     pub(crate) stack_base: usize,
     pub(crate) saved_env: VmEnv,
@@ -251,7 +251,7 @@ impl Vm {
     pub fn start(&mut self, chunk: &Chunk) {
         let initial_env = self.env.clone();
         self.frames.push(CallFrame {
-            chunk: chunk.clone(),
+            chunk: Rc::new(chunk.clone()),
             ip: 0,
             stack_base: self.stack.len(),
             saved_env: self.env.clone(),


### PR DESCRIPTION
Fixes #403.

## Summary
- Share compiled bytecode/function metadata with `Rc` handles (`ChunkRef` / `CompiledFunctionRef`) instead of cloning nested chunks into every closure frame.
- Store shared chunk/function handles in closures, call frames, and generated function tables.
- Add an internal `run_chunk_ref` path so closure/generator execution can reuse compiled chunks while preserving the public `&Chunk` entrypoint.
- Remove obsolete function-table plumbing through call/method/iterator dispatch that previously forced hot-path function-table clones.

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-issue-403-check cargo check -p harn-vm`
- `CARGO_TARGET_DIR=/tmp/harn-issue-403-check cargo test -p harn-vm vm::tests_runtime`
- `CARGO_TARGET_DIR=/tmp/harn-issue-403-check cargo test -p harn-vm vm::tests_debug`
- `CARGO_TARGET_DIR=/tmp/harn-issue-403-check cargo run --quiet --bin harn -- test conformance --filter function` (21 passed)
- `cargo run --quiet --bin harn -- test conformance` (621 passed)
- `make test` after rebasing onto current `origin/main` (1890 passed, 7 skipped)
- Commit hook: `cargo fmt`, clippy, generated highlight sync, markdown lint, portal lint
- Push hook: 1890 Rust tests, Harn formatting, markdown lint, portal lint

## Benchmark
Local `function_call_loop` fixture, 20 iterations, same machine before/after:
- Before on `origin/main`: avg 110.61 ms
- After on this branch: avg 82.00 ms
- Delta: -26.6% vs `perf/vm/BASELINE.md` baseline average, no regression observed
