### PR TITLE
[codex] Flatten VM opcode dispatch

### DIFF
--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -234,6 +234,112 @@ pub enum Op {
     Yield,
 }
 
+impl Op {
+    pub(crate) const ALL: &'static [Self] = &[
+        Op::Constant,
+        Op::Nil,
+        Op::True,
+        Op::False,
+        Op::GetVar,
+        Op::DefLet,
+        Op::DefVar,
+        Op::SetVar,
+        Op::PushScope,
+        Op::PopScope,
+        Op::Add,
+        Op::Sub,
+        Op::Mul,
+        Op::Div,
+        Op::Mod,
+        Op::Pow,
+        Op::Negate,
+        Op::Equal,
+        Op::NotEqual,
+        Op::Less,
+        Op::Greater,
+        Op::LessEqual,
+        Op::GreaterEqual,
+        Op::Not,
+        Op::Jump,
+        Op::JumpIfFalse,
+        Op::JumpIfTrue,
+        Op::Pop,
+        Op::Call,
+        Op::TailCall,
+        Op::Return,
+        Op::Closure,
+        Op::BuildList,
+        Op::BuildDict,
+        Op::Subscript,
+        Op::Slice,
+        Op::GetProperty,
+        Op::GetPropertyOpt,
+        Op::SetProperty,
+        Op::SetSubscript,
+        Op::MethodCall,
+        Op::MethodCallOpt,
+        Op::Concat,
+        Op::IterInit,
+        Op::IterNext,
+        Op::Pipe,
+        Op::Throw,
+        Op::TryCatchSetup,
+        Op::PopHandler,
+        Op::Parallel,
+        Op::ParallelMap,
+        Op::ParallelSettle,
+        Op::Spawn,
+        Op::Import,
+        Op::SelectiveImport,
+        Op::DeadlineSetup,
+        Op::DeadlineEnd,
+        Op::BuildEnum,
+        Op::MatchEnum,
+        Op::PopIterator,
+        Op::GetArgc,
+        Op::CheckType,
+        Op::TryUnwrap,
+        Op::CallSpread,
+        Op::CallBuiltin,
+        Op::CallBuiltinSpread,
+        Op::MethodCallSpread,
+        Op::Dup,
+        Op::Swap,
+        Op::Contains,
+        Op::AddInt,
+        Op::SubInt,
+        Op::MulInt,
+        Op::DivInt,
+        Op::ModInt,
+        Op::AddFloat,
+        Op::SubFloat,
+        Op::MulFloat,
+        Op::DivFloat,
+        Op::ModFloat,
+        Op::EqualInt,
+        Op::NotEqualInt,
+        Op::LessInt,
+        Op::GreaterInt,
+        Op::LessEqualInt,
+        Op::GreaterEqualInt,
+        Op::EqualFloat,
+        Op::NotEqualFloat,
+        Op::LessFloat,
+        Op::GreaterFloat,
+        Op::LessEqualFloat,
+        Op::GreaterEqualFloat,
+        Op::EqualBool,
+        Op::NotEqualBool,
+        Op::EqualString,
+        Op::NotEqualString,
+        Op::Yield,
+    ];
+
+    pub(crate) fn from_byte(byte: u8) -> Option<Self> {
+        Self::ALL.get(byte as usize).copied()
+    }
+}
+
 /// A constant value in the constant pool.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Constant {
@@ -887,5 +993,19 @@ impl Chunk {
 impl Default for Chunk {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Op;
+
+    #[test]
+    fn op_from_byte_matches_repr_order() {
+        for (byte, op) in Op::ALL.iter().copied().enumerate() {
+            assert_eq!(byte as u8, op as u8);
+            assert_eq!(Op::from_byte(byte as u8), Some(op));
+        }
+        assert_eq!(Op::from_byte(Op::ALL.len() as u8), None);
     }
 }

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -1,116 +1,145 @@
 use std::rc::Rc;
 
-use crate::chunk::Op;
 use crate::value::{VmError, VmValue};
 
 impl super::super::Vm {
-    pub(super) fn execute_typed_arithmetic_op(&mut self, op: u8) -> Result<(), VmError> {
-        if op == Op::AddInt as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_int_pair("add", a, b)?;
-            self.stack.push(VmValue::Int(x.wrapping_add(y)));
-        } else if op == Op::SubInt as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_int_pair("subtract", a, b)?;
-            self.stack.push(VmValue::Int(x.wrapping_sub(y)));
-        } else if op == Op::MulInt as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_int_pair("multiply", a, b)?;
-            self.stack.push(VmValue::Int(x.wrapping_mul(y)));
-        } else if op == Op::DivInt as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_int_pair("divide", a, b)?;
-            if y == 0 {
-                return Err(VmError::DivisionByZero);
-            }
-            self.stack.push(VmValue::Int(x / y));
-        } else if op == Op::ModInt as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_int_pair("modulo", a, b)?;
-            if y == 0 {
-                return Err(VmError::DivisionByZero);
-            }
-            self.stack.push(VmValue::Int(x % y));
-        } else if op == Op::AddFloat as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_float_pair("add", a, b)?;
-            self.stack.push(VmValue::Float(x + y));
-        } else if op == Op::SubFloat as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_float_pair("subtract", a, b)?;
-            self.stack.push(VmValue::Float(x - y));
-        } else if op == Op::MulFloat as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_float_pair("multiply", a, b)?;
-            self.stack.push(VmValue::Float(x * y));
-        } else if op == Op::DivFloat as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_float_pair("divide", a, b)?;
-            self.stack.push(VmValue::Float(x / y));
-        } else if op == Op::ModFloat as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_float_pair("modulo", a, b)?;
-            if y == 0.0 {
-                return Err(VmError::DivisionByZero);
-            }
-            self.stack.push(VmValue::Float(x % y));
-        } else {
-            return Err(VmError::InvalidInstruction(op));
-        }
+    fn push_binary_result(
+        &mut self,
+        f: impl FnOnce(&Self, VmValue, VmValue) -> Result<VmValue, VmError>,
+    ) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        let result = f(self, a, b)?;
+        self.stack.push(result);
         Ok(())
     }
 
-    pub(super) fn try_execute_arithmetic_op(&mut self, op: u8) -> Result<bool, VmError> {
-        if op == Op::Add as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            self.stack.push(self.add(a, b)?);
-        } else if op == Op::Sub as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            self.stack.push(self.sub(a, b)?);
-        } else if op == Op::Mul as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            self.stack.push(self.mul(a, b)?);
-        } else if op == Op::Div as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            self.stack.push(self.div(a, b)?);
-        } else if op == Op::Mod as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            self.stack.push(self.modulo(a, b)?);
-        } else if op == Op::Pow as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            self.stack.push(self.pow(a, b)?);
-        } else if op == Op::Negate as u8 {
-            let v = self.pop()?;
-            self.stack.push(match v {
-                VmValue::Int(n) => VmValue::Int(n.wrapping_neg()),
-                VmValue::Float(n) => VmValue::Float(-n),
-                _ => {
-                    return Err(VmError::Runtime(format!(
-                        "Cannot negate value of type {}",
-                        v.type_name()
-                    )))
-                }
-            });
-        } else {
-            return Ok(false);
+    pub(super) fn execute_add(&mut self) -> Result<(), VmError> {
+        self.push_binary_result(Self::add)
+    }
+
+    pub(super) fn execute_sub(&mut self) -> Result<(), VmError> {
+        self.push_binary_result(Self::sub)
+    }
+
+    pub(super) fn execute_mul(&mut self) -> Result<(), VmError> {
+        self.push_binary_result(Self::mul)
+    }
+
+    pub(super) fn execute_div(&mut self) -> Result<(), VmError> {
+        self.push_binary_result(Self::div)
+    }
+
+    pub(super) fn execute_mod(&mut self) -> Result<(), VmError> {
+        self.push_binary_result(Self::modulo)
+    }
+
+    pub(super) fn execute_pow(&mut self) -> Result<(), VmError> {
+        self.push_binary_result(Self::pow)
+    }
+
+    pub(super) fn execute_negate(&mut self) -> Result<(), VmError> {
+        let v = self.pop()?;
+        self.stack.push(match v {
+            VmValue::Int(n) => VmValue::Int(n.wrapping_neg()),
+            VmValue::Float(n) => VmValue::Float(-n),
+            _ => {
+                return Err(VmError::Runtime(format!(
+                    "Cannot negate value of type {}",
+                    v.type_name()
+                )))
+            }
+        });
+        Ok(())
+    }
+
+    pub(super) fn execute_add_int(&mut self) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        let (x, y) = typed_int_pair("add", a, b)?;
+        self.stack.push(VmValue::Int(x.wrapping_add(y)));
+        Ok(())
+    }
+
+    pub(super) fn execute_sub_int(&mut self) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        let (x, y) = typed_int_pair("subtract", a, b)?;
+        self.stack.push(VmValue::Int(x.wrapping_sub(y)));
+        Ok(())
+    }
+
+    pub(super) fn execute_mul_int(&mut self) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        let (x, y) = typed_int_pair("multiply", a, b)?;
+        self.stack.push(VmValue::Int(x.wrapping_mul(y)));
+        Ok(())
+    }
+
+    pub(super) fn execute_div_int(&mut self) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        let (x, y) = typed_int_pair("divide", a, b)?;
+        if y == 0 {
+            return Err(VmError::DivisionByZero);
         }
-        Ok(true)
+        self.stack.push(VmValue::Int(x / y));
+        Ok(())
+    }
+
+    pub(super) fn execute_mod_int(&mut self) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        let (x, y) = typed_int_pair("modulo", a, b)?;
+        if y == 0 {
+            return Err(VmError::DivisionByZero);
+        }
+        self.stack.push(VmValue::Int(x % y));
+        Ok(())
+    }
+
+    pub(super) fn execute_add_float(&mut self) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        let (x, y) = typed_float_pair("add", a, b)?;
+        self.stack.push(VmValue::Float(x + y));
+        Ok(())
+    }
+
+    pub(super) fn execute_sub_float(&mut self) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        let (x, y) = typed_float_pair("subtract", a, b)?;
+        self.stack.push(VmValue::Float(x - y));
+        Ok(())
+    }
+
+    pub(super) fn execute_mul_float(&mut self) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        let (x, y) = typed_float_pair("multiply", a, b)?;
+        self.stack.push(VmValue::Float(x * y));
+        Ok(())
+    }
+
+    pub(super) fn execute_div_float(&mut self) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        let (x, y) = typed_float_pair("divide", a, b)?;
+        self.stack.push(VmValue::Float(x / y));
+        Ok(())
+    }
+
+    pub(super) fn execute_mod_float(&mut self) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        let (x, y) = typed_float_pair("modulo", a, b)?;
+        if y == 0.0 {
+            return Err(VmError::DivisionByZero);
+        }
+        self.stack.push(VmValue::Float(x % y));
+        Ok(())
     }
 
     fn add(&self, a: VmValue, b: VmValue) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crate::chunk::{InlineCacheEntry, MethodCacheTarget, Op};
+use crate::chunk::{InlineCacheEntry, MethodCacheTarget};
 use crate::value::{VmClosure, VmError, VmValue};
 use crate::BuiltinId;
 
@@ -235,327 +235,343 @@ impl super::super::Vm {
         Ok(())
     }
 
-    pub(super) async fn try_execute_call_op(&mut self, op: u8) -> Result<bool, VmError> {
-        if op == Op::Call as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let argc = frame.chunk.code[frame.ip] as usize;
-            frame.ip += 1;
+    pub(super) async fn execute_call(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let argc = frame.chunk.code[frame.ip] as usize;
+        frame.ip += 1;
 
-            let args: Vec<VmValue> = self.stack.split_off(self.stack.len().saturating_sub(argc));
-            let callee = self.pop()?;
+        let args: Vec<VmValue> = self.stack.split_off(self.stack.len().saturating_sub(argc));
+        let callee = self.pop()?;
 
-            match callee {
-                VmValue::String(name) => {
-                    self.call_named_value(&name, args, None).await?;
-                }
-                VmValue::Closure(closure) => {
-                    if closure.func.is_generator {
-                        let gen = self.create_generator(&closure, &args);
-                        self.stack.push(gen);
-                    } else {
-                        self.push_closure_frame(&closure, &args)?;
-                    }
-                }
-                VmValue::BuiltinRef(name) => {
-                    self.call_named_value(&name, args, None).await?;
-                }
-                VmValue::BuiltinRefId { id, name } => {
-                    self.call_named_value(&name, args, Some(id)).await?;
-                }
-                _ => {
-                    return Err(VmError::TypeError(format!(
-                        "Cannot call {}",
-                        callee.display()
-                    )));
-                }
+        match callee {
+            VmValue::String(name) => {
+                self.call_named_value(&name, args, None).await?;
             }
-        } else if op == Op::CallSpread as u8 {
-            let args_val = self.pop()?;
-            let callee = self.pop()?;
-            let args = match args_val {
-                VmValue::List(items) => (*items).clone(),
-                _ => {
-                    return Err(VmError::TypeError(
-                        "spread call requires list arguments".into(),
-                    ))
-                }
-            };
-            match callee {
-                VmValue::String(name) => {
-                    self.call_named_value(&name, args, None).await?;
-                }
-                VmValue::Closure(closure) => {
-                    if closure.func.is_generator {
-                        let gen = self.create_generator(&closure, &args);
-                        self.stack.push(gen);
-                    } else {
-                        self.push_closure_frame(&closure, &args)?;
-                    }
-                }
-                VmValue::BuiltinRef(name) => {
-                    self.call_named_value(&name, args, None).await?;
-                }
-                VmValue::BuiltinRefId { id, name } => {
-                    self.call_named_value(&name, args, Some(id)).await?;
-                }
-                _ => {
-                    return Err(VmError::TypeError(format!(
-                        "Cannot call {}",
-                        callee.display()
-                    )));
-                }
-            }
-        } else if op == Op::TailCall as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let argc = frame.chunk.code[frame.ip] as usize;
-            frame.ip += 1;
-
-            let args: Vec<VmValue> = self.stack.split_off(self.stack.len().saturating_sub(argc));
-            let callee = self.pop()?;
-
-            let resolved_closure = match &callee {
-                VmValue::Closure(cl) => Some(Rc::clone(cl)),
-                VmValue::String(name) => self.resolve_named_closure(name),
-                _ => None,
-            };
-
-            if let Some(closure) = resolved_closure {
+            VmValue::Closure(closure) => {
                 if closure.func.is_generator {
-                    // Generators cannot be tail-call optimized.
                     let gen = self.create_generator(&closure, &args);
-                    return Err(VmError::Return(gen));
-                }
-                // TCO: reuse the current frame's stack_base / saved_env.
-                let popped = self.frames.pop().unwrap();
-                let stack_base = popped.stack_base;
-                let parent_env = popped.saved_env;
-
-                if let Some(ref dir) = popped.saved_source_dir {
-                    crate::stdlib::set_thread_source_dir(dir);
-                }
-
-                self.stack.truncate(stack_base);
-
-                let saved_source_dir = if let Some(ref dir) = closure.source_dir {
-                    let prev = crate::stdlib::process::VM_SOURCE_DIR.with(|sd| sd.borrow().clone());
-                    crate::stdlib::set_thread_source_dir(dir);
-                    prev
+                    self.stack.push(gen);
                 } else {
-                    None
-                };
+                    self.push_closure_frame(&closure, &args)?;
+                }
+            }
+            VmValue::BuiltinRef(name) => {
+                self.call_named_value(&name, args, None).await?;
+            }
+            VmValue::BuiltinRefId { id, name } => {
+                self.call_named_value(&name, args, Some(id)).await?;
+            }
+            _ => {
+                return Err(VmError::TypeError(format!(
+                    "Cannot call {}",
+                    callee.display()
+                )))
+            }
+        }
+        Ok(())
+    }
 
-                // Pass parent env so closure_call_env merges locally-defined
-                // recursive fns.
-                let mut call_env = Self::closure_call_env(&parent_env, &closure);
-                call_env.push_scope();
-                let default_start = closure
-                    .func
-                    .default_start
-                    .unwrap_or(closure.func.params.len());
-                for (i, param) in closure.func.params.iter().enumerate() {
-                    if i < args.len() {
-                        call_env.define(param, args[i].clone(), false)?;
-                    } else if i < default_start {
-                        call_env.define(param, VmValue::Nil, false)?;
-                    }
-                    // else: has default, preamble will DefLet
+    pub(super) async fn execute_call_spread(&mut self) -> Result<(), VmError> {
+        let args_val = self.pop()?;
+        let callee = self.pop()?;
+        let args = match args_val {
+            VmValue::List(items) => (*items).clone(),
+            _ => {
+                return Err(VmError::TypeError(
+                    "spread call requires list arguments".into(),
+                ))
+            }
+        };
+        match callee {
+            VmValue::String(name) => {
+                self.call_named_value(&name, args, None).await?;
+            }
+            VmValue::Closure(closure) => {
+                if closure.func.is_generator {
+                    let gen = self.create_generator(&closure, &args);
+                    self.stack.push(gen);
+                } else {
+                    self.push_closure_frame(&closure, &args)?;
                 }
-                let initial_env = call_env.clone();
-                self.env = call_env;
+            }
+            VmValue::BuiltinRef(name) => {
+                self.call_named_value(&name, args, None).await?;
+            }
+            VmValue::BuiltinRefId { id, name } => {
+                self.call_named_value(&name, args, Some(id)).await?;
+            }
+            _ => {
+                return Err(VmError::TypeError(format!(
+                    "Cannot call {}",
+                    callee.display()
+                )))
+            }
+        }
+        Ok(())
+    }
 
-                let argc = args.len();
-                self.frames.push(CallFrame {
-                    chunk: Rc::clone(&closure.func.chunk),
-                    ip: 0,
-                    stack_base,
-                    saved_env: parent_env,
-                    initial_env: Some(initial_env),
-                    saved_iterator_depth: self.iterators.len(),
-                    fn_name: closure.func.name.clone(),
-                    argc,
-                    saved_source_dir,
-                    module_functions: closure.module_functions.clone(),
-                    module_state: closure.module_state.clone(),
-                });
-            } else {
-                match callee {
-                    VmValue::String(name) => {
-                        let result = self.call_named_builtin(&name, args).await?;
-                        self.stack.push(result);
-                    }
-                    _ => {
-                        return Err(VmError::TypeError(format!(
-                            "Cannot call {}",
-                            callee.display()
-                        )));
-                    }
-                }
+    pub(super) async fn execute_call_builtin(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let id = BuiltinId::from_raw(frame.chunk.read_u64(frame.ip));
+        frame.ip += 8;
+        let name_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let argc = frame.chunk.code[frame.ip] as usize;
+        frame.ip += 1;
+        let name = Self::const_string(&frame.chunk.constants[name_idx])?;
+        let args: Vec<VmValue> = self.stack.split_off(self.stack.len().saturating_sub(argc));
+        self.call_named_value(&name, args, Some(id)).await
+    }
+
+    pub(super) async fn execute_call_builtin_spread(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let id = BuiltinId::from_raw(frame.chunk.read_u64(frame.ip));
+        frame.ip += 8;
+        let name_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let name = Self::const_string(&frame.chunk.constants[name_idx])?;
+        let args_val = self.pop()?;
+        let args = match args_val {
+            VmValue::List(items) => (*items).clone(),
+            _ => {
+                return Err(VmError::TypeError(
+                    "spread call requires list arguments".into(),
+                ))
             }
-        } else if op == Op::CallBuiltin as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let id = BuiltinId::from_raw(frame.chunk.read_u64(frame.ip));
-            frame.ip += 8;
-            let name_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let argc = frame.chunk.code[frame.ip] as usize;
-            frame.ip += 1;
-            let name = Self::const_string(&frame.chunk.constants[name_idx])?;
-            let args: Vec<VmValue> = self.stack.split_off(self.stack.len().saturating_sub(argc));
-            self.call_named_value(&name, args, Some(id)).await?;
-        } else if op == Op::CallBuiltinSpread as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let id = BuiltinId::from_raw(frame.chunk.read_u64(frame.ip));
-            frame.ip += 8;
-            let name_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let name = Self::const_string(&frame.chunk.constants[name_idx])?;
-            let args_val = self.pop()?;
-            let args = match args_val {
-                VmValue::List(items) => (*items).clone(),
-                _ => {
-                    return Err(VmError::TypeError(
-                        "spread call requires list arguments".into(),
-                    ))
-                }
-            };
-            self.call_named_value(&name, args, Some(id)).await?;
-        } else if op == Op::Return as u8 {
-            let val = self.pop().unwrap_or(VmValue::Nil);
-            return Err(VmError::Return(val));
-        } else if op == Op::Closure as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let fn_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let func = Rc::clone(&frame.chunk.functions[fn_idx]);
-            let closure = VmClosure {
-                func,
-                env: self.env.clone(),
-                source_dir: None,
-                module_functions: self
-                    .frames
-                    .last()
-                    .and_then(|frame| frame.module_functions.clone()),
-                // Inherit module state so closures created inside a module
-                // function see and mutate the same module-level vars.
-                module_state: self
-                    .frames
-                    .last()
-                    .and_then(|frame| frame.module_state.clone()),
-            };
-            self.stack.push(VmValue::Closure(Rc::new(closure)));
-        } else if op == Op::MethodCall as u8 || op == Op::MethodCallOpt as u8 {
-            let optional = op == Op::MethodCallOpt as u8;
-            let (name_idx, argc, cache_slot, cache_entry) = {
-                let frame = self.frames.last_mut().unwrap();
-                let op_offset = frame.ip.saturating_sub(1);
-                let name_idx = frame.chunk.read_u16(frame.ip);
-                frame.ip += 2;
-                let argc = frame.chunk.code[frame.ip] as usize;
-                frame.ip += 1;
-                let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-                let cache_entry = cache_slot
-                    .map(|slot| frame.chunk.inline_cache_entry(slot))
-                    .unwrap_or(InlineCacheEntry::Empty);
-                (name_idx, argc, cache_slot, cache_entry)
-            };
-            let args: Vec<VmValue> = self.stack.split_off(self.stack.len().saturating_sub(argc));
-            let obj = self.pop()?;
-            if optional && matches!(obj, VmValue::Nil) {
-                self.stack.push(VmValue::Nil);
-            } else if let Some(result) = Self::try_cached_method(&cache_entry, name_idx, argc, &obj)
-            {
-                self.stack.push(result);
-            } else {
-                let method = {
-                    let frame = self.frames.last().unwrap();
-                    Self::const_string(&frame.chunk.constants[name_idx as usize])?
-                };
-                let cache_target = Self::method_cache_target(&obj, &method, args.len());
-                let result = self.call_method(obj, &method, &args).await?;
-                if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
-                    let frame = self.frames.last().unwrap();
-                    frame.chunk.set_inline_cache_entry(
-                        slot,
-                        InlineCacheEntry::Method {
-                            name_idx,
-                            argc,
-                            target,
-                        },
-                    );
-                }
-                self.stack.push(result);
+        };
+        self.call_named_value(&name, args, Some(id)).await
+    }
+
+    pub(super) async fn execute_tail_call(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let argc = frame.chunk.code[frame.ip] as usize;
+        frame.ip += 1;
+
+        let args: Vec<VmValue> = self.stack.split_off(self.stack.len().saturating_sub(argc));
+        let callee = self.pop()?;
+
+        let resolved_closure = match &callee {
+            VmValue::Closure(cl) => Some(Rc::clone(cl)),
+            VmValue::String(name) => self.resolve_named_closure(name),
+            _ => None,
+        };
+
+        if let Some(closure) = resolved_closure {
+            if closure.func.is_generator {
+                // Generators cannot be tail-call optimized.
+                let gen = self.create_generator(&closure, &args);
+                return Err(VmError::Return(gen));
             }
-        } else if op == Op::MethodCallSpread as u8 {
-            let (name_idx, cache_slot, cache_entry) = {
-                let frame = self.frames.last_mut().unwrap();
-                let op_offset = frame.ip.saturating_sub(1);
-                let name_idx = frame.chunk.read_u16(frame.ip);
-                frame.ip += 2;
-                let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-                let cache_entry = cache_slot
-                    .map(|slot| frame.chunk.inline_cache_entry(slot))
-                    .unwrap_or(InlineCacheEntry::Empty);
-                (name_idx, cache_slot, cache_entry)
-            };
-            let args_val = self.pop()?;
-            let obj = self.pop()?;
-            let args = match args_val {
-                VmValue::List(items) => (*items).clone(),
-                _ => {
-                    return Err(VmError::TypeError(
-                        "spread method call requires list arguments".into(),
-                    ))
-                }
-            };
-            if let Some(result) = Self::try_cached_method(&cache_entry, name_idx, args.len(), &obj)
-            {
-                self.stack.push(result);
-            } else {
-                let method = {
-                    let frame = self.frames.last().unwrap();
-                    Self::const_string(&frame.chunk.constants[name_idx as usize])?
-                };
-                let cache_target = Self::method_cache_target(&obj, &method, args.len());
-                let result = self.call_method(obj, &method, &args).await?;
-                if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
-                    let frame = self.frames.last().unwrap();
-                    frame.chunk.set_inline_cache_entry(
-                        slot,
-                        InlineCacheEntry::Method {
-                            name_idx,
-                            argc: args.len(),
-                            target,
-                        },
-                    );
-                }
-                self.stack.push(result);
+            // TCO: reuse the current frame's stack_base / saved_env.
+            let popped = self.frames.pop().unwrap();
+            let stack_base = popped.stack_base;
+            let parent_env = popped.saved_env;
+
+            if let Some(ref dir) = popped.saved_source_dir {
+                crate::stdlib::set_thread_source_dir(dir);
             }
-        } else if op == Op::Pipe as u8 {
-            let callable = self.pop()?;
-            let value = self.pop()?;
-            match callable {
-                VmValue::Closure(closure) => {
-                    self.push_closure_frame(&closure, &[value])?;
+
+            self.stack.truncate(stack_base);
+
+            let saved_source_dir = if let Some(ref dir) = closure.source_dir {
+                let prev = crate::stdlib::process::VM_SOURCE_DIR.with(|sd| sd.borrow().clone());
+                crate::stdlib::set_thread_source_dir(dir);
+                prev
+            } else {
+                None
+            };
+
+            // Pass parent env so closure_call_env merges locally-defined
+            // recursive fns.
+            let mut call_env = Self::closure_call_env(&parent_env, &closure);
+            call_env.push_scope();
+            let default_start = closure
+                .func
+                .default_start
+                .unwrap_or(closure.func.params.len());
+            for (i, param) in closure.func.params.iter().enumerate() {
+                if i < args.len() {
+                    call_env.define(param, args[i].clone(), false)?;
+                } else if i < default_start {
+                    call_env.define(param, VmValue::Nil, false)?;
                 }
+                // else: has default, preamble will DefLet
+            }
+            let initial_env = call_env.clone();
+            self.env = call_env;
+
+            let argc = args.len();
+            self.frames.push(CallFrame {
+                chunk: closure.func.chunk.clone(),
+                ip: 0,
+                stack_base,
+                saved_env: parent_env,
+                initial_env: Some(initial_env),
+                saved_iterator_depth: self.iterators.len(),
+                fn_name: closure.func.name.clone(),
+                argc,
+                saved_source_dir,
+                module_functions: closure.module_functions.clone(),
+                module_state: closure.module_state.clone(),
+            });
+        } else {
+            match callee {
                 VmValue::String(name) => {
-                    self.call_named_value(&name, vec![value], None).await?;
-                }
-                VmValue::BuiltinRef(name) => {
-                    self.call_named_value(&name, vec![value], None).await?;
-                }
-                VmValue::BuiltinRefId { id, name } => {
-                    self.call_named_value(&name, vec![value], Some(id)).await?;
+                    let result = self.call_named_builtin(&name, args).await?;
+                    self.stack.push(result);
                 }
                 _ => {
                     return Err(VmError::TypeError(format!(
-                        "cannot pipe into {}",
-                        callable.type_name()
-                    )));
+                        "Cannot call {}",
+                        callee.display()
+                    )))
                 }
             }
-        } else {
-            return Ok(false);
         }
-        Ok(true)
+        Ok(())
+    }
+
+    pub(super) fn execute_return(&mut self) -> VmError {
+        let val = self.pop().unwrap_or(VmValue::Nil);
+        VmError::Return(val)
+    }
+
+    pub(super) fn execute_closure(&mut self) {
+        let frame = self.frames.last_mut().unwrap();
+        let fn_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let func = frame.chunk.functions[fn_idx].clone();
+        let closure = VmClosure {
+            func,
+            env: self.env.clone(),
+            source_dir: None,
+            module_functions: self
+                .frames
+                .last()
+                .and_then(|frame| frame.module_functions.clone()),
+            // Inherit module state so closures created inside a module function
+            // see and mutate the same module-level vars.
+            module_state: self
+                .frames
+                .last()
+                .and_then(|frame| frame.module_state.clone()),
+        };
+        self.stack.push(VmValue::Closure(Rc::new(closure)));
+    }
+
+    pub(super) async fn execute_method_call(&mut self, optional: bool) -> Result<(), VmError> {
+        let (name_idx, argc, cache_slot, cache_entry) = {
+            let frame = self.frames.last_mut().unwrap();
+            let op_offset = frame.ip.saturating_sub(1);
+            let name_idx = frame.chunk.read_u16(frame.ip);
+            frame.ip += 2;
+            let argc = frame.chunk.code[frame.ip] as usize;
+            frame.ip += 1;
+            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
+            let cache_entry = cache_slot
+                .map(|slot| frame.chunk.inline_cache_entry(slot))
+                .unwrap_or(InlineCacheEntry::Empty);
+            (name_idx, argc, cache_slot, cache_entry)
+        };
+        let args: Vec<VmValue> = self.stack.split_off(self.stack.len().saturating_sub(argc));
+        let obj = self.pop()?;
+        if optional && matches!(obj, VmValue::Nil) {
+            self.stack.push(VmValue::Nil);
+        } else if let Some(result) = Self::try_cached_method(&cache_entry, name_idx, argc, &obj) {
+            self.stack.push(result);
+        } else {
+            let method = {
+                let frame = self.frames.last().unwrap();
+                Self::const_string(&frame.chunk.constants[name_idx as usize])?
+            };
+            let cache_target = Self::method_cache_target(&obj, &method, args.len());
+            let result = self.call_method(obj, &method, &args).await?;
+            if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
+                let frame = self.frames.last().unwrap();
+                frame.chunk.set_inline_cache_entry(
+                    slot,
+                    InlineCacheEntry::Method {
+                        name_idx,
+                        argc,
+                        target,
+                    },
+                );
+            }
+            self.stack.push(result);
+        }
+        Ok(())
+    }
+
+    pub(super) async fn execute_method_call_spread(&mut self) -> Result<(), VmError> {
+        let (name_idx, cache_slot, cache_entry) = {
+            let frame = self.frames.last_mut().unwrap();
+            let op_offset = frame.ip.saturating_sub(1);
+            let name_idx = frame.chunk.read_u16(frame.ip);
+            frame.ip += 2;
+            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
+            let cache_entry = cache_slot
+                .map(|slot| frame.chunk.inline_cache_entry(slot))
+                .unwrap_or(InlineCacheEntry::Empty);
+            (name_idx, cache_slot, cache_entry)
+        };
+        let args_val = self.pop()?;
+        let obj = self.pop()?;
+        let args = match args_val {
+            VmValue::List(items) => (*items).clone(),
+            _ => {
+                return Err(VmError::TypeError(
+                    "spread method call requires list arguments".into(),
+                ))
+            }
+        };
+        if let Some(result) = Self::try_cached_method(&cache_entry, name_idx, args.len(), &obj) {
+            self.stack.push(result);
+        } else {
+            let method = {
+                let frame = self.frames.last().unwrap();
+                Self::const_string(&frame.chunk.constants[name_idx as usize])?
+            };
+            let cache_target = Self::method_cache_target(&obj, &method, args.len());
+            let result = self.call_method(obj, &method, &args).await?;
+            if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
+                let frame = self.frames.last().unwrap();
+                frame.chunk.set_inline_cache_entry(
+                    slot,
+                    InlineCacheEntry::Method {
+                        name_idx,
+                        argc: args.len(),
+                        target,
+                    },
+                );
+            }
+            self.stack.push(result);
+        }
+        Ok(())
+    }
+
+    pub(super) async fn execute_pipe(&mut self) -> Result<(), VmError> {
+        let callable = self.pop()?;
+        let value = self.pop()?;
+        match callable {
+            VmValue::Closure(closure) => {
+                self.push_closure_frame(&closure, &[value])?;
+            }
+            VmValue::String(name) => {
+                self.call_named_value(&name, vec![value], None).await?;
+            }
+            VmValue::BuiltinRef(name) => {
+                self.call_named_value(&name, vec![value], None).await?;
+            }
+            VmValue::BuiltinRefId { id, name } => {
+                self.call_named_value(&name, vec![value], Some(id)).await?;
+            }
+            _ => {
+                return Err(VmError::TypeError(format!(
+                    "cannot pipe into {}",
+                    callable.type_name()
+                )));
+            }
+        }
+        Ok(())
     }
 }

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
-use crate::chunk::{InlineCacheEntry, Op, PropertyCacheTarget};
+use crate::chunk::{InlineCacheEntry, PropertyCacheTarget};
 use crate::value::{VmError, VmValue};
 
 impl super::super::Vm {
@@ -134,344 +134,362 @@ impl super::super::Vm {
         Ok(result)
     }
 
-    pub(super) fn try_execute_collections_op(&mut self, op: u8) -> Result<bool, VmError> {
-        if op == Op::BuildList as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let count = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let items = self.stack.split_off(self.stack.len().saturating_sub(count));
-            self.stack.push(VmValue::List(Rc::new(items)));
-        } else if op == Op::BuildDict as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let count = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let pairs = self
-                .stack
-                .split_off(self.stack.len().saturating_sub(count * 2));
-            let mut map = BTreeMap::new();
-            for pair in pairs.chunks(2) {
-                if pair.len() == 2 {
-                    let key = pair[0].display();
-                    map.insert(key, pair[1].clone());
+    pub(super) fn execute_build_list(&mut self) {
+        let frame = self.frames.last_mut().unwrap();
+        let count = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let items = self.stack.split_off(self.stack.len().saturating_sub(count));
+        self.stack.push(VmValue::List(Rc::new(items)));
+    }
+
+    pub(super) fn execute_build_dict(&mut self) {
+        let frame = self.frames.last_mut().unwrap();
+        let count = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let pairs = self
+            .stack
+            .split_off(self.stack.len().saturating_sub(count * 2));
+        let mut map = BTreeMap::new();
+        for pair in pairs.chunks(2) {
+            if pair.len() == 2 {
+                let key = pair[0].display();
+                map.insert(key, pair[1].clone());
+            }
+        }
+        self.stack.push(VmValue::Dict(Rc::new(map)));
+    }
+
+    pub(super) fn execute_subscript(&mut self) -> Result<(), VmError> {
+        let idx = self.pop()?;
+        let obj = self.pop()?;
+        let result = match (&obj, &idx) {
+            (VmValue::List(items), VmValue::Int(i)) => {
+                if *i < 0 {
+                    let pos = items.len() as i64 + *i;
+                    if pos < 0 {
+                        VmValue::Nil
+                    } else {
+                        items.get(pos as usize).cloned().unwrap_or(VmValue::Nil)
+                    }
+                } else {
+                    items.get(*i as usize).cloned().unwrap_or(VmValue::Nil)
                 }
             }
-            self.stack.push(VmValue::Dict(Rc::new(map)));
-        } else if op == Op::Subscript as u8 {
-            let idx = self.pop()?;
-            let obj = self.pop()?;
-            let result = match (&obj, &idx) {
-                (VmValue::List(items), VmValue::Int(i)) => {
-                    if *i < 0 {
-                        let pos = items.len() as i64 + *i;
-                        if pos < 0 {
-                            VmValue::Nil
-                        } else {
-                            items.get(pos as usize).cloned().unwrap_or(VmValue::Nil)
-                        }
-                    } else {
-                        items.get(*i as usize).cloned().unwrap_or(VmValue::Nil)
-                    }
-                }
-                (VmValue::Dict(map), _) => map.get(&idx.display()).cloned().unwrap_or(VmValue::Nil),
-                (VmValue::Range(r), VmValue::Int(i)) => {
-                    let len = r.len();
-                    let pos = if *i < 0 { len + *i } else { *i };
-                    match r.get(pos) {
-                        Some(v) => VmValue::Int(v),
-                        None => {
-                            return Err(VmError::Runtime(format!(
-                                "range index out of range: index {i} for range of length {len}",
-                            )));
-                        }
-                    }
-                }
-                (VmValue::String(s), VmValue::Int(i)) => {
-                    if *i < 0 {
-                        let count = s.chars().count() as i64;
-                        let pos = count + *i;
-                        if pos < 0 {
-                            VmValue::Nil
-                        } else {
-                            s.chars()
-                                .nth(pos as usize)
-                                .map(|c| VmValue::String(Rc::from(c.to_string())))
-                                .unwrap_or(VmValue::Nil)
-                        }
-                    } else {
-                        s.chars()
-                            .nth(*i as usize)
-                            .map(|c| VmValue::String(Rc::from(c.to_string())))
-                            .unwrap_or(VmValue::Nil)
-                    }
-                }
-                _ => {
-                    return Err(VmError::TypeError(format!(
-                        "cannot index into {} with {}",
-                        obj.type_name(),
-                        idx.type_name()
-                    )));
-                }
-            };
-            self.stack.push(result);
-        } else if op == Op::Slice as u8 {
-            let end_val = self.pop()?;
-            let start_val = self.pop()?;
-            let obj = self.pop()?;
-
-            let result = match &obj {
-                VmValue::List(items) => {
-                    let len = items.len() as i64;
-                    let start = match &start_val {
-                        VmValue::Nil => 0i64,
-                        VmValue::Int(i) => {
-                            if *i < 0 {
-                                (len + *i).max(0)
-                            } else {
-                                (*i).min(len)
-                            }
-                        }
-                        _ => {
-                            return Err(VmError::TypeError(format!(
-                                "slice start must be an integer, got {}",
-                                start_val.type_name()
-                            )));
-                        }
-                    };
-                    let end = match &end_val {
-                        VmValue::Nil => len,
-                        VmValue::Int(i) => {
-                            if *i < 0 {
-                                (len + *i).max(0)
-                            } else {
-                                (*i).min(len)
-                            }
-                        }
-                        _ => {
-                            return Err(VmError::TypeError(format!(
-                                "slice end must be an integer, got {}",
-                                end_val.type_name()
-                            )));
-                        }
-                    };
-                    if start >= end {
-                        VmValue::List(Rc::new(vec![]))
-                    } else {
-                        let sliced: Vec<VmValue> = items[start as usize..end as usize].to_vec();
-                        VmValue::List(Rc::new(sliced))
-                    }
-                }
-                VmValue::String(s) => {
-                    let char_count = s.chars().count() as i64;
-                    let start = match &start_val {
-                        VmValue::Nil => 0i64,
-                        VmValue::Int(i) => {
-                            if *i < 0 {
-                                (char_count + *i).max(0)
-                            } else {
-                                (*i).min(char_count)
-                            }
-                        }
-                        _ => {
-                            return Err(VmError::TypeError(format!(
-                                "slice start must be an integer, got {}",
-                                start_val.type_name()
-                            )));
-                        }
-                    };
-                    let end = match &end_val {
-                        VmValue::Nil => char_count,
-                        VmValue::Int(i) => {
-                            if *i < 0 {
-                                (char_count + *i).max(0)
-                            } else {
-                                (*i).min(char_count)
-                            }
-                        }
-                        _ => {
-                            return Err(VmError::TypeError(format!(
-                                "slice end must be an integer, got {}",
-                                end_val.type_name()
-                            )));
-                        }
-                    };
-                    if start >= end {
-                        VmValue::String(Rc::from(""))
-                    } else {
-                        let start_idx = start as usize;
-                        let end_idx = end as usize;
-                        let byte_start = s
-                            .char_indices()
-                            .nth(start_idx)
-                            .map(|(b, _)| b)
-                            .unwrap_or(s.len());
-                        let byte_end = s
-                            .char_indices()
-                            .nth(end_idx)
-                            .map(|(b, _)| b)
-                            .unwrap_or(s.len());
-                        VmValue::String(Rc::from(&s[byte_start..byte_end]))
-                    }
-                }
-                _ => {
-                    return Err(VmError::TypeError(format!(
-                        "cannot slice {}",
-                        obj.type_name()
-                    )));
-                }
-            };
-            self.stack.push(result);
-        } else if op == Op::GetProperty as u8 || op == Op::GetPropertyOpt as u8 {
-            let optional = op == Op::GetPropertyOpt as u8;
-            let (name_idx, cache_slot, cache_entry) = {
-                let frame = self.frames.last_mut().unwrap();
-                let op_offset = frame.ip.saturating_sub(1);
-                let name_idx = frame.chunk.read_u16(frame.ip);
-                frame.ip += 2;
-                let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-                let cache_entry = cache_slot
-                    .map(|slot| frame.chunk.inline_cache_entry(slot))
-                    .unwrap_or(InlineCacheEntry::Empty);
-                (name_idx, cache_slot, cache_entry)
-            };
-
-            let obj = self.pop()?;
-            if optional && matches!(obj, VmValue::Nil) {
-                self.stack.push(VmValue::Nil);
-            } else if let Some(result) = Self::try_cached_property(&cache_entry, name_idx, &obj) {
-                self.stack.push(result);
-            } else {
-                let name = {
-                    let frame = self.frames.last().unwrap();
-                    Self::const_string(&frame.chunk.constants[name_idx as usize])?
-                };
-                let result = Self::resolve_property(&obj, &name, optional)?;
-
-                if let (Some(slot), Some(target)) =
-                    (cache_slot, Self::property_cache_target(&obj, &name))
-                {
-                    let frame = self.frames.last().unwrap();
-                    frame.chunk.set_inline_cache_entry(
-                        slot,
-                        InlineCacheEntry::Property { name_idx, target },
-                    );
-                }
-                self.stack.push(result);
-            }
-        } else if op == Op::SetProperty as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let prop_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let var_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let prop_name = Self::const_string(&frame.chunk.constants[prop_idx])?;
-            let var_name = Self::const_string(&frame.chunk.constants[var_idx])?;
-            let new_value = self.pop()?;
-            if let Some(obj) = self.env.get(&var_name) {
-                match obj {
-                    VmValue::Dict(map) => {
-                        let mut new_map = (*map).clone();
-                        new_map.insert(prop_name, new_value);
-                        self.env
-                            .assign(&var_name, VmValue::Dict(Rc::new(new_map)))?;
-                    }
-                    VmValue::StructInstance { .. } => {
-                        let new_obj = obj
-                            .struct_instance_with_property(prop_name, new_value)
-                            .expect("struct instance matched above");
-                        self.env.assign(&var_name, new_obj)?;
-                    }
-                    _ => {
-                        return Err(VmError::TypeError(format!(
-                            "cannot set property `{prop_name}` on {}",
-                            obj.type_name()
+            (VmValue::Dict(map), _) => map.get(&idx.display()).cloned().unwrap_or(VmValue::Nil),
+            (VmValue::Range(r), VmValue::Int(i)) => {
+                let len = r.len();
+                let pos = if *i < 0 { len + *i } else { *i };
+                match r.get(pos) {
+                    Some(v) => VmValue::Int(v),
+                    None => {
+                        return Err(VmError::Runtime(format!(
+                            "range index out of range: index {i} for range of length {len}",
                         )));
                     }
                 }
             }
-        } else if op == Op::SetSubscript as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let var_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let var_name = Self::const_string(&frame.chunk.constants[var_idx])?;
-            let index = self.pop()?;
-            let new_value = self.pop()?;
-            if let Some(obj) = self.env.get(&var_name) {
-                match obj {
-                    VmValue::List(items) => {
-                        if let Some(i) = index.as_int() {
-                            let mut new_items = (*items).clone();
-                            let idx = if i < 0 {
-                                (new_items.len() as i64 + i).max(0) as usize
-                            } else {
-                                i as usize
-                            };
-                            if idx < new_items.len() {
-                                new_items[idx] = new_value;
-                                self.env
-                                    .assign(&var_name, VmValue::List(Rc::new(new_items)))?;
-                            } else {
-                                return Err(VmError::Runtime(format!(
-                                    "Index {} out of bounds for list of length {}",
-                                    i,
-                                    items.len()
-                                )));
-                            }
-                        }
+            (VmValue::String(s), VmValue::Int(i)) => {
+                if *i < 0 {
+                    let count = s.chars().count() as i64;
+                    let pos = count + *i;
+                    if pos < 0 {
+                        VmValue::Nil
+                    } else {
+                        s.chars()
+                            .nth(pos as usize)
+                            .map(|c| VmValue::String(Rc::from(c.to_string())))
+                            .unwrap_or(VmValue::Nil)
                     }
-                    VmValue::Dict(map) => {
-                        let key = index.display();
-                        let mut new_map = (*map).clone();
-                        new_map.insert(key, new_value);
-                        self.env
-                            .assign(&var_name, VmValue::Dict(Rc::new(new_map)))?;
-                    }
-                    _ => {}
+                } else {
+                    s.chars()
+                        .nth(*i as usize)
+                        .map(|c| VmValue::String(Rc::from(c.to_string())))
+                        .unwrap_or(VmValue::Nil)
                 }
             }
-        } else if op == Op::Concat as u8 {
+            _ => {
+                return Err(VmError::TypeError(format!(
+                    "cannot index into {} with {}",
+                    obj.type_name(),
+                    idx.type_name()
+                )));
+            }
+        };
+        self.stack.push(result);
+        Ok(())
+    }
+
+    pub(super) fn execute_slice(&mut self) -> Result<(), VmError> {
+        let end_val = self.pop()?;
+        let start_val = self.pop()?;
+        let obj = self.pop()?;
+
+        let result = match &obj {
+            VmValue::List(items) => {
+                let len = items.len() as i64;
+                let start = match &start_val {
+                    VmValue::Nil => 0i64,
+                    VmValue::Int(i) => {
+                        if *i < 0 {
+                            (len + *i).max(0)
+                        } else {
+                            (*i).min(len)
+                        }
+                    }
+                    _ => {
+                        return Err(VmError::TypeError(format!(
+                            "slice start must be an integer, got {}",
+                            start_val.type_name()
+                        )));
+                    }
+                };
+                let end = match &end_val {
+                    VmValue::Nil => len,
+                    VmValue::Int(i) => {
+                        if *i < 0 {
+                            (len + *i).max(0)
+                        } else {
+                            (*i).min(len)
+                        }
+                    }
+                    _ => {
+                        return Err(VmError::TypeError(format!(
+                            "slice end must be an integer, got {}",
+                            end_val.type_name()
+                        )));
+                    }
+                };
+                if start >= end {
+                    VmValue::List(Rc::new(vec![]))
+                } else {
+                    let sliced: Vec<VmValue> = items[start as usize..end as usize].to_vec();
+                    VmValue::List(Rc::new(sliced))
+                }
+            }
+            VmValue::String(s) => {
+                let char_count = s.chars().count() as i64;
+                let start = match &start_val {
+                    VmValue::Nil => 0i64,
+                    VmValue::Int(i) => {
+                        if *i < 0 {
+                            (char_count + *i).max(0)
+                        } else {
+                            (*i).min(char_count)
+                        }
+                    }
+                    _ => {
+                        return Err(VmError::TypeError(format!(
+                            "slice start must be an integer, got {}",
+                            start_val.type_name()
+                        )));
+                    }
+                };
+                let end = match &end_val {
+                    VmValue::Nil => char_count,
+                    VmValue::Int(i) => {
+                        if *i < 0 {
+                            (char_count + *i).max(0)
+                        } else {
+                            (*i).min(char_count)
+                        }
+                    }
+                    _ => {
+                        return Err(VmError::TypeError(format!(
+                            "slice end must be an integer, got {}",
+                            end_val.type_name()
+                        )));
+                    }
+                };
+                if start >= end {
+                    VmValue::String(Rc::from(""))
+                } else {
+                    let start_idx = start as usize;
+                    let end_idx = end as usize;
+                    let byte_start = s
+                        .char_indices()
+                        .nth(start_idx)
+                        .map(|(b, _)| b)
+                        .unwrap_or(s.len());
+                    let byte_end = s
+                        .char_indices()
+                        .nth(end_idx)
+                        .map(|(b, _)| b)
+                        .unwrap_or(s.len());
+                    VmValue::String(Rc::from(&s[byte_start..byte_end]))
+                }
+            }
+            _ => {
+                return Err(VmError::TypeError(format!(
+                    "cannot slice {}",
+                    obj.type_name()
+                )))
+            }
+        };
+        self.stack.push(result);
+        Ok(())
+    }
+
+    pub(super) fn execute_get_property(&mut self, optional: bool) -> Result<(), VmError> {
+        let (name_idx, cache_slot, cache_entry) = {
             let frame = self.frames.last_mut().unwrap();
-            let count = frame.chunk.read_u16(frame.ip) as usize;
+            let op_offset = frame.ip.saturating_sub(1);
+            let name_idx = frame.chunk.read_u16(frame.ip);
             frame.ip += 2;
-            let parts = self.stack.split_off(self.stack.len().saturating_sub(count));
-            let result: String = parts.iter().map(|p| p.display()).collect();
-            self.stack.push(VmValue::String(Rc::from(result)));
-        } else if op == Op::BuildEnum as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let enum_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let variant_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let field_count = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let enum_name = Self::const_string(&frame.chunk.constants[enum_idx])?;
-            let variant = Self::const_string(&frame.chunk.constants[variant_idx])?;
-            let fields = self
-                .stack
-                .split_off(self.stack.len().saturating_sub(field_count));
-            self.stack
-                .push(VmValue::enum_variant(enum_name, variant, fields));
-        } else if op == Op::MatchEnum as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let enum_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let variant_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let enum_name = Self::const_string(&frame.chunk.constants[enum_idx])?;
-            let variant_name = Self::const_string(&frame.chunk.constants[variant_idx])?;
-            let val = self.pop()?;
-            let matches = match &val {
-                VmValue::EnumVariant {
-                    enum_name: en,
-                    variant: vn,
-                    ..
-                } => en.as_ref() == enum_name && vn.as_ref() == variant_name,
-                _ => false,
-            };
-            self.stack.push(val);
-            self.stack.push(VmValue::Bool(matches));
+            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
+            let cache_entry = cache_slot
+                .map(|slot| frame.chunk.inline_cache_entry(slot))
+                .unwrap_or(InlineCacheEntry::Empty);
+            (name_idx, cache_slot, cache_entry)
+        };
+
+        let obj = self.pop()?;
+        if optional && matches!(obj, VmValue::Nil) {
+            self.stack.push(VmValue::Nil);
+        } else if let Some(result) = Self::try_cached_property(&cache_entry, name_idx, &obj) {
+            self.stack.push(result);
         } else {
-            return Ok(false);
+            let name = {
+                let frame = self.frames.last().unwrap();
+                Self::const_string(&frame.chunk.constants[name_idx as usize])?
+            };
+            let result = Self::resolve_property(&obj, &name, optional)?;
+
+            if let (Some(slot), Some(target)) =
+                (cache_slot, Self::property_cache_target(&obj, &name))
+            {
+                let frame = self.frames.last().unwrap();
+                frame
+                    .chunk
+                    .set_inline_cache_entry(slot, InlineCacheEntry::Property { name_idx, target });
+            }
+            self.stack.push(result);
         }
-        Ok(true)
+        Ok(())
+    }
+
+    pub(super) fn execute_set_property(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let prop_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let var_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let prop_name = Self::const_string(&frame.chunk.constants[prop_idx])?;
+        let var_name = Self::const_string(&frame.chunk.constants[var_idx])?;
+        let new_value = self.pop()?;
+        if let Some(obj) = self.env.get(&var_name) {
+            match obj {
+                VmValue::Dict(map) => {
+                    let mut new_map = (*map).clone();
+                    new_map.insert(prop_name, new_value);
+                    self.env
+                        .assign(&var_name, VmValue::Dict(Rc::new(new_map)))?;
+                }
+                VmValue::StructInstance { .. } => {
+                    let new_obj = obj
+                        .struct_instance_with_property(prop_name, new_value)
+                        .expect("struct instance matched above");
+                    self.env.assign(&var_name, new_obj)?;
+                }
+                _ => {
+                    return Err(VmError::TypeError(format!(
+                        "cannot set property `{prop_name}` on {}",
+                        obj.type_name()
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn execute_set_subscript(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let var_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let var_name = Self::const_string(&frame.chunk.constants[var_idx])?;
+        let index = self.pop()?;
+        let new_value = self.pop()?;
+        if let Some(obj) = self.env.get(&var_name) {
+            match obj {
+                VmValue::List(items) => {
+                    if let Some(i) = index.as_int() {
+                        let mut new_items = (*items).clone();
+                        let idx = if i < 0 {
+                            (new_items.len() as i64 + i).max(0) as usize
+                        } else {
+                            i as usize
+                        };
+                        if idx < new_items.len() {
+                            new_items[idx] = new_value;
+                            self.env
+                                .assign(&var_name, VmValue::List(Rc::new(new_items)))?;
+                        } else {
+                            return Err(VmError::Runtime(format!(
+                                "Index {} out of bounds for list of length {}",
+                                i,
+                                items.len()
+                            )));
+                        }
+                    }
+                }
+                VmValue::Dict(map) => {
+                    let key = index.display();
+                    let mut new_map = (*map).clone();
+                    new_map.insert(key, new_value);
+                    self.env
+                        .assign(&var_name, VmValue::Dict(Rc::new(new_map)))?;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn execute_concat(&mut self) {
+        let frame = self.frames.last_mut().unwrap();
+        let count = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let parts = self.stack.split_off(self.stack.len().saturating_sub(count));
+        let result: String = parts.iter().map(|p| p.display()).collect();
+        self.stack.push(VmValue::String(Rc::from(result)));
+    }
+
+    pub(super) fn execute_build_enum(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let enum_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let variant_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let field_count = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let enum_name = Self::const_string(&frame.chunk.constants[enum_idx])?;
+        let variant = Self::const_string(&frame.chunk.constants[variant_idx])?;
+        let fields = self
+            .stack
+            .split_off(self.stack.len().saturating_sub(field_count));
+        self.stack
+            .push(VmValue::enum_variant(enum_name, variant, fields));
+        Ok(())
+    }
+
+    pub(super) fn execute_match_enum(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let enum_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let variant_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let enum_name = Self::const_string(&frame.chunk.constants[enum_idx])?;
+        let variant_name = Self::const_string(&frame.chunk.constants[variant_idx])?;
+        let val = self.pop()?;
+        let matches = match &val {
+            VmValue::EnumVariant {
+                enum_name: en,
+                variant: vn,
+                ..
+            } => en.as_ref() == enum_name && vn.as_ref() == variant_name,
+            _ => false,
+        };
+        self.stack.push(val);
+        self.stack.push(VmValue::Bool(matches));
+        Ok(())
     }
 }

--- a/crates/harn-vm/src/vm/ops/comparison.rs
+++ b/crates/harn-vm/src/vm/ops/comparison.rs
@@ -1,150 +1,180 @@
 use std::rc::Rc;
 
-use crate::chunk::Op;
 use crate::value::{compare_values, values_equal, VmError, VmValue};
 
 impl super::super::Vm {
-    pub(super) fn execute_typed_comparison_op(&mut self, op: u8) -> Result<(), VmError> {
-        if op == Op::LessInt as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_int_pair("less-than", a, b)?;
-            self.stack.push(VmValue::Bool(x < y));
-        } else if op == Op::GreaterEqualInt as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_int_pair("greater-equal", a, b)?;
-            self.stack.push(VmValue::Bool(x >= y));
-        } else if op == Op::LessEqualInt as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_int_pair("less-equal", a, b)?;
-            self.stack.push(VmValue::Bool(x <= y));
-        } else if op == Op::EqualInt as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_int_pair("equal", a, b)?;
-            self.stack.push(VmValue::Bool(x == y));
-        } else if op == Op::NotEqualInt as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_int_pair("not-equal", a, b)?;
-            self.stack.push(VmValue::Bool(x != y));
-        } else if op == Op::GreaterInt as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_int_pair("greater-than", a, b)?;
-            self.stack.push(VmValue::Bool(x > y));
-        } else if op == Op::EqualFloat as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_float_pair("equal", a, b)?;
-            self.stack.push(VmValue::Bool(x == y));
-        } else if op == Op::NotEqualFloat as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_float_pair("not-equal", a, b)?;
-            self.stack.push(VmValue::Bool(x != y));
-        } else if op == Op::LessFloat as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_float_pair("less-than", a, b)?;
-            self.stack.push(VmValue::Bool(x < y));
-        } else if op == Op::GreaterFloat as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_float_pair("greater-than", a, b)?;
-            self.stack.push(VmValue::Bool(x > y));
-        } else if op == Op::LessEqualFloat as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_float_pair("less-equal", a, b)?;
-            self.stack.push(VmValue::Bool(x <= y));
-        } else if op == Op::GreaterEqualFloat as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_float_pair("greater-equal", a, b)?;
-            self.stack.push(VmValue::Bool(x >= y));
-        } else if op == Op::EqualBool as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_bool_pair("equal", a, b)?;
-            self.stack.push(VmValue::Bool(x == y));
-        } else if op == Op::NotEqualBool as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_bool_pair("not-equal", a, b)?;
-            self.stack.push(VmValue::Bool(x != y));
-        } else if op == Op::EqualString as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_string_pair("equal", a, b)?;
-            self.stack.push(VmValue::Bool(x == y));
-        } else if op == Op::NotEqualString as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            let (x, y) = typed_string_pair("not-equal", a, b)?;
-            self.stack.push(VmValue::Bool(x != y));
-        } else {
-            return Err(VmError::InvalidInstruction(op));
-        }
+    fn push_compare_result(
+        &mut self,
+        f: impl FnOnce(VmValue, VmValue) -> Result<bool, VmError>,
+    ) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        self.stack.push(VmValue::Bool(f(a, b)?));
         Ok(())
     }
 
-    pub(super) fn try_execute_comparison_op(&mut self, op: u8) -> Result<bool, VmError> {
-        if op == Op::Equal as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            self.stack.push(VmValue::Bool(values_equal(&a, &b)));
-        } else if op == Op::NotEqual as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            self.stack.push(VmValue::Bool(!values_equal(&a, &b)));
-        } else if op == Op::Less as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            self.stack.push(VmValue::Bool(compare_values(&a, &b) < 0));
-        } else if op == Op::Greater as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            self.stack.push(VmValue::Bool(compare_values(&a, &b) > 0));
-        } else if op == Op::LessEqual as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            self.stack.push(VmValue::Bool(compare_values(&a, &b) <= 0));
-        } else if op == Op::GreaterEqual as u8 {
-            let b = self.pop()?;
-            let a = self.pop()?;
-            self.stack.push(VmValue::Bool(compare_values(&a, &b) >= 0));
-        } else if op == Op::Contains as u8 {
-            let collection = self.pop()?;
-            let item = self.pop()?;
-            let result = match &collection {
-                VmValue::List(items) => items.iter().any(|v| values_equal(v, &item)),
-                VmValue::Dict(map) => {
-                    let key = item.display();
-                    map.contains_key(&key)
-                }
-                VmValue::Set(items) => items.iter().any(|v| values_equal(v, &item)),
-                VmValue::Range(r) => match &item {
-                    VmValue::Int(n) => r.contains(*n),
-                    _ => false,
-                },
-                VmValue::String(s) => {
-                    if let VmValue::String(substr) = &item {
-                        s.contains(&**substr)
-                    } else {
-                        let substr = item.display();
-                        s.contains(&substr)
-                    }
-                }
+    pub(super) fn execute_equal(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| Ok(values_equal(&a, &b)))
+    }
+
+    pub(super) fn execute_not_equal(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| Ok(!values_equal(&a, &b)))
+    }
+
+    pub(super) fn execute_less(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| Ok(compare_values(&a, &b) < 0))
+    }
+
+    pub(super) fn execute_greater(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| Ok(compare_values(&a, &b) > 0))
+    }
+
+    pub(super) fn execute_less_equal(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| Ok(compare_values(&a, &b) <= 0))
+    }
+
+    pub(super) fn execute_greater_equal(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| Ok(compare_values(&a, &b) >= 0))
+    }
+
+    pub(super) fn execute_contains(&mut self) -> Result<(), VmError> {
+        let collection = self.pop()?;
+        let item = self.pop()?;
+        let result = match &collection {
+            VmValue::List(items) => items.iter().any(|v| values_equal(v, &item)),
+            VmValue::Dict(map) => {
+                let key = item.display();
+                map.contains_key(&key)
+            }
+            VmValue::Set(items) => items.iter().any(|v| values_equal(v, &item)),
+            VmValue::Range(r) => match &item {
+                VmValue::Int(n) => r.contains(*n),
                 _ => false,
-            };
-            self.stack.push(VmValue::Bool(result));
-        } else {
-            return Ok(false);
-        }
-        Ok(true)
+            },
+            VmValue::String(s) => {
+                if let VmValue::String(substr) = &item {
+                    s.contains(&**substr)
+                } else {
+                    let substr = item.display();
+                    s.contains(&substr)
+                }
+            }
+            _ => false,
+        };
+        self.stack.push(VmValue::Bool(result));
+        Ok(())
+    }
+
+    pub(super) fn execute_equal_int(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_int_pair("equal", a, b)?;
+            Ok(x == y)
+        })
+    }
+
+    pub(super) fn execute_not_equal_int(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_int_pair("not-equal", a, b)?;
+            Ok(x != y)
+        })
+    }
+
+    pub(super) fn execute_less_int(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_int_pair("less-than", a, b)?;
+            Ok(x < y)
+        })
+    }
+
+    pub(super) fn execute_greater_int(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_int_pair("greater-than", a, b)?;
+            Ok(x > y)
+        })
+    }
+
+    pub(super) fn execute_less_equal_int(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_int_pair("less-equal", a, b)?;
+            Ok(x <= y)
+        })
+    }
+
+    pub(super) fn execute_greater_equal_int(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_int_pair("greater-equal", a, b)?;
+            Ok(x >= y)
+        })
+    }
+
+    pub(super) fn execute_equal_float(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_float_pair("equal", a, b)?;
+            Ok(x == y)
+        })
+    }
+
+    pub(super) fn execute_not_equal_float(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_float_pair("not-equal", a, b)?;
+            Ok(x != y)
+        })
+    }
+
+    pub(super) fn execute_less_float(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_float_pair("less-than", a, b)?;
+            Ok(x < y)
+        })
+    }
+
+    pub(super) fn execute_greater_float(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_float_pair("greater-than", a, b)?;
+            Ok(x > y)
+        })
+    }
+
+    pub(super) fn execute_less_equal_float(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_float_pair("less-equal", a, b)?;
+            Ok(x <= y)
+        })
+    }
+
+    pub(super) fn execute_greater_equal_float(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_float_pair("greater-equal", a, b)?;
+            Ok(x >= y)
+        })
+    }
+
+    pub(super) fn execute_equal_bool(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_bool_pair("equal", a, b)?;
+            Ok(x == y)
+        })
+    }
+
+    pub(super) fn execute_not_equal_bool(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_bool_pair("not-equal", a, b)?;
+            Ok(x != y)
+        })
+    }
+
+    pub(super) fn execute_equal_string(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_string_pair("equal", a, b)?;
+            Ok(x == y)
+        })
+    }
+
+    pub(super) fn execute_not_equal_string(&mut self) -> Result<(), VmError> {
+        self.push_compare_result(|a, b| {
+            let (x, y) = typed_string_pair("not-equal", a, b)?;
+            Ok(x != y)
+        })
     }
 }
 

--- a/crates/harn-vm/src/vm/ops/control_flow.rs
+++ b/crates/harn-vm/src/vm/ops/control_flow.rs
@@ -1,33 +1,33 @@
-use crate::chunk::Op;
 use crate::value::VmError;
 
 impl super::super::Vm {
-    pub(super) fn try_execute_control_flow_op(&mut self, op: u8) -> Result<bool, VmError> {
-        if op == Op::Jump as u8 {
+    pub(super) fn execute_jump(&mut self) {
+        let frame = self.frames.last_mut().unwrap();
+        let target = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip = target;
+    }
+
+    pub(super) fn execute_jump_if_false(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let target = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let val = self.peek()?;
+        if !val.is_truthy() {
             let frame = self.frames.last_mut().unwrap();
-            let target = frame.chunk.read_u16(frame.ip) as usize;
             frame.ip = target;
-        } else if op == Op::JumpIfFalse as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let target = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let val = self.peek()?;
-            if !val.is_truthy() {
-                let frame = self.frames.last_mut().unwrap();
-                frame.ip = target;
-            }
-        } else if op == Op::JumpIfTrue as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let target = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let val = self.peek()?;
-            if val.is_truthy() {
-                let frame = self.frames.last_mut().unwrap();
-                frame.ip = target;
-            }
-        } else {
-            return Ok(false);
         }
-        Ok(true)
+        Ok(())
+    }
+
+    pub(super) fn execute_jump_if_true(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let target = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let val = self.peek()?;
+        if val.is_truthy() {
+            let frame = self.frames.last_mut().unwrap();
+            frame.ip = target;
+        }
+        Ok(())
     }
 }

--- a/crates/harn-vm/src/vm/ops/exception.rs
+++ b/crates/harn-vm/src/vm/ops/exception.rs
@@ -1,57 +1,57 @@
-use crate::chunk::{Constant, Op};
+use crate::chunk::Constant;
 use crate::value::{VmError, VmValue};
 
 use super::super::ExceptionHandler;
 
 impl super::super::Vm {
-    pub(super) fn try_execute_exception_op(&mut self, op: u8) -> Result<bool, VmError> {
-        if op == Op::Throw as u8 {
-            let val = self.pop()?;
-            return Err(VmError::Thrown(val));
-        } else if op == Op::TryCatchSetup as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let catch_offset = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let type_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let error_type = match &frame.chunk.constants[type_idx] {
-                Constant::String(s) => s.clone(),
-                _ => String::new(),
-            };
-            self.exception_handlers.push(ExceptionHandler {
-                catch_ip: catch_offset,
-                stack_depth: self.stack.len(),
-                frame_depth: self.frames.len(),
-                env_scope_depth: self.env.scope_depth(),
-                error_type,
-            });
-        } else if op == Op::PopHandler as u8 {
-            self.exception_handlers.pop();
-        } else if op == Op::TryUnwrap as u8 {
-            let val = self.pop()?;
-            match &val {
-                VmValue::EnumVariant {
-                    enum_name,
-                    variant,
-                    fields,
-                } if enum_name.as_ref() == "Result" => {
-                    if variant.as_ref() == "Ok" {
-                        self.stack
-                            .push(fields.first().cloned().unwrap_or(VmValue::Nil));
-                    } else {
-                        return Err(VmError::Return(val));
-                    }
-                }
-                other => {
-                    return Err(VmError::TypeError(format!(
-                        "? operator requires a Result value, got {}",
-                        other.type_name()
-                    )));
+    pub(super) fn execute_throw(&mut self) -> Result<(), VmError> {
+        let val = self.pop()?;
+        Err(VmError::Thrown(val))
+    }
+
+    pub(super) fn execute_try_catch_setup(&mut self) {
+        let frame = self.frames.last_mut().unwrap();
+        let catch_offset = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let type_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let error_type = match &frame.chunk.constants[type_idx] {
+            Constant::String(s) => s.clone(),
+            _ => String::new(),
+        };
+        self.exception_handlers.push(ExceptionHandler {
+            catch_ip: catch_offset,
+            stack_depth: self.stack.len(),
+            frame_depth: self.frames.len(),
+            env_scope_depth: self.env.scope_depth(),
+            error_type,
+        });
+    }
+
+    pub(super) fn execute_pop_handler(&mut self) {
+        self.exception_handlers.pop();
+    }
+
+    pub(super) fn execute_try_unwrap(&mut self) -> Result<(), VmError> {
+        let val = self.pop()?;
+        match &val {
+            VmValue::EnumVariant {
+                enum_name,
+                variant,
+                fields,
+            } if enum_name.as_ref() == "Result" => {
+                if variant.as_ref() == "Ok" {
+                    self.stack
+                        .push(fields.first().cloned().unwrap_or(VmValue::Nil));
+                    Ok(())
+                } else {
+                    Err(VmError::Return(val))
                 }
             }
-        } else {
-            return Ok(false);
+            other => Err(VmError::TypeError(format!(
+                "? operator requires a Result value, got {}",
+                other.type_name()
+            ))),
         }
-        Ok(true)
     }
 }

--- a/crates/harn-vm/src/vm/ops/imports.rs
+++ b/crates/harn-vm/src/vm/ops/imports.rs
@@ -1,27 +1,23 @@
-use crate::chunk::Op;
 use crate::value::VmError;
 
 impl super::super::Vm {
-    pub(super) async fn try_execute_imports_op(&mut self, op: u8) -> Result<bool, VmError> {
-        if op == Op::Import as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let path_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let import_path = Self::const_string(&frame.chunk.constants[path_idx])?;
-            self.execute_import(&import_path, None).await?;
-        } else if op == Op::SelectiveImport as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let path_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let names_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let import_path = Self::const_string(&frame.chunk.constants[path_idx])?;
-            let names_str = Self::const_string(&frame.chunk.constants[names_idx])?;
-            let names: Vec<String> = names_str.split(',').map(|s| s.to_string()).collect();
-            self.execute_import(&import_path, Some(&names)).await?;
-        } else {
-            return Ok(false);
-        }
-        Ok(true)
+    pub(super) async fn execute_import_op(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let path_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let import_path = Self::const_string(&frame.chunk.constants[path_idx])?;
+        self.execute_import(&import_path, None).await
+    }
+
+    pub(super) async fn execute_selective_import(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let path_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let names_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let import_path = Self::const_string(&frame.chunk.constants[path_idx])?;
+        let names_str = Self::const_string(&frame.chunk.constants[names_idx])?;
+        let names: Vec<String> = names_str.split(',').map(|s| s.to_string()).collect();
+        self.execute_import(&import_path, Some(&names)).await
     }
 }

--- a/crates/harn-vm/src/vm/ops/iter.rs
+++ b/crates/harn-vm/src/vm/ops/iter.rs
@@ -1,128 +1,161 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
-use crate::chunk::Op;
 use crate::value::{VmError, VmValue};
 
 impl super::super::Vm {
-    pub(super) async fn try_execute_iter_op(&mut self, op: u8) -> Result<bool, VmError> {
-        if op == Op::IterInit as u8 {
-            let iterable = self.pop()?;
-            match iterable {
-                VmValue::List(items) => {
-                    self.iterators
-                        .push(super::super::IterState::Vec { items, idx: 0 });
-                }
-                VmValue::Dict(map) => {
-                    let keys = map.keys().cloned().collect();
-                    self.iterators.push(super::super::IterState::Dict {
-                        entries: map,
-                        keys,
-                        idx: 0,
-                    });
-                }
-                VmValue::Set(items) => {
-                    self.iterators
-                        .push(super::super::IterState::Vec { items, idx: 0 });
-                }
-                VmValue::Channel(ch) => {
-                    self.iterators.push(super::super::IterState::Channel {
-                        receiver: ch.receiver.clone(),
-                        closed: ch.closed.clone(),
-                    });
-                }
-                VmValue::Generator(gen) => {
-                    self.iterators
-                        .push(super::super::IterState::Generator { gen });
-                }
-                VmValue::Range(r) => {
-                    let stop = if r.inclusive {
-                        // Saturate to avoid i64 overflow on `i64::MAX to i64::MAX`.
-                        r.end.saturating_add(1)
-                    } else {
-                        r.end
-                    };
-                    // `5 to 1` is simply empty — no reverse iteration.
-                    let next = r.start;
-                    self.iterators
-                        .push(super::super::IterState::Range { next, stop });
-                }
-                VmValue::Iter(handle) => {
-                    self.iterators
-                        .push(super::super::IterState::VmIter { handle });
-                }
-                _ => {
-                    self.iterators.push(super::super::IterState::Vec {
-                        items: Rc::new(Vec::new()),
-                        idx: 0,
-                    });
+    pub(super) fn execute_iter_init(&mut self) -> Result<(), VmError> {
+        let iterable = self.pop()?;
+        match iterable {
+            VmValue::List(items) => {
+                self.iterators
+                    .push(super::super::IterState::Vec { items, idx: 0 });
+            }
+            VmValue::Dict(map) => {
+                let keys = map.keys().cloned().collect();
+                self.iterators.push(super::super::IterState::Dict {
+                    entries: map,
+                    keys,
+                    idx: 0,
+                });
+            }
+            VmValue::Set(items) => {
+                self.iterators
+                    .push(super::super::IterState::Vec { items, idx: 0 });
+            }
+            VmValue::Channel(ch) => {
+                self.iterators.push(super::super::IterState::Channel {
+                    receiver: ch.receiver.clone(),
+                    closed: ch.closed.clone(),
+                });
+            }
+            VmValue::Generator(gen) => {
+                self.iterators
+                    .push(super::super::IterState::Generator { gen });
+            }
+            VmValue::Range(r) => {
+                let stop = if r.inclusive {
+                    // Saturate to avoid i64 overflow on `i64::MAX to i64::MAX`.
+                    r.end.saturating_add(1)
+                } else {
+                    r.end
+                };
+                // `5 to 1` is simply empty: no reverse iteration.
+                let next = r.start;
+                self.iterators
+                    .push(super::super::IterState::Range { next, stop });
+            }
+            VmValue::Iter(handle) => {
+                self.iterators
+                    .push(super::super::IterState::VmIter { handle });
+            }
+            _ => {
+                self.iterators.push(super::super::IterState::Vec {
+                    items: Rc::new(Vec::new()),
+                    idx: 0,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) async fn execute_iter_next(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let target = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        // Clone the handle so we don't hold a borrow on self.iterators across
+        // the async next() call.
+        let vm_iter_handle = match self.iterators.last() {
+            Some(super::super::IterState::VmIter { handle }) => Some(handle.clone()),
+            _ => None,
+        };
+        if let Some(handle) = vm_iter_handle {
+            // Safe for recursive VM reentry via closures as long as they don't
+            // re-enter the same iter handle.
+            let next_val = crate::vm::iter::next_handle(&handle, self).await?;
+            match next_val {
+                Some(v) => self.stack.push(v),
+                None => {
+                    self.iterators.pop();
+                    let frame = self.frames.last_mut().unwrap();
+                    frame.ip = target;
                 }
             }
-        } else if op == Op::IterNext as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let target = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            // Clone the handle so we don't hold a borrow on self.iterators
-            // across the async next() call.
-            let vm_iter_handle = match self.iterators.last() {
-                Some(super::super::IterState::VmIter { handle }) => Some(handle.clone()),
-                _ => None,
-            };
-            if let Some(handle) = vm_iter_handle {
-                // Safe for recursive VM reentry via closures as long as they
-                // don't re-enter the same iter handle.
-                let next_val = crate::vm::iter::next_handle(&handle, self).await?;
-                match next_val {
-                    Some(v) => self.stack.push(v),
-                    None => {
+        } else if let Some(state) = self.iterators.last_mut() {
+            match state {
+                super::super::IterState::Vec { items, idx } => {
+                    if *idx < items.len() {
+                        let item = items[*idx].clone();
+                        *idx += 1;
+                        self.stack.push(item);
+                    } else {
                         self.iterators.pop();
                         let frame = self.frames.last_mut().unwrap();
                         frame.ip = target;
                     }
                 }
-            } else if let Some(state) = self.iterators.last_mut() {
-                match state {
-                    super::super::IterState::Vec { items, idx } => {
-                        if *idx < items.len() {
-                            let item = items[*idx].clone();
-                            *idx += 1;
-                            self.stack.push(item);
-                        } else {
+                super::super::IterState::Dict { entries, keys, idx } => {
+                    if *idx < keys.len() {
+                        let key = &keys[*idx];
+                        let value = entries.get(key).cloned().unwrap_or(VmValue::Nil);
+                        *idx += 1;
+                        self.stack.push(VmValue::Dict(Rc::new(BTreeMap::from([
+                            ("key".to_string(), VmValue::String(Rc::from(key.as_str()))),
+                            ("value".to_string(), value),
+                        ]))));
+                    } else {
+                        self.iterators.pop();
+                        let frame = self.frames.last_mut().unwrap();
+                        frame.ip = target;
+                    }
+                }
+                super::super::IterState::Channel { receiver, closed } => {
+                    let rx = receiver.clone();
+                    let is_closed = closed.load(std::sync::atomic::Ordering::Relaxed);
+                    let mut guard = rx.lock().await;
+                    // Closed sender: drain without blocking.
+                    let item = if is_closed {
+                        guard.try_recv().ok()
+                    } else {
+                        guard.recv().await
+                    };
+                    match item {
+                        Some(val) => {
+                            self.stack.push(val);
+                        }
+                        None => {
+                            drop(guard);
                             self.iterators.pop();
                             let frame = self.frames.last_mut().unwrap();
                             frame.ip = target;
                         }
                     }
-                    super::super::IterState::Dict { entries, keys, idx } => {
-                        if *idx < keys.len() {
-                            let key = &keys[*idx];
-                            let value = entries.get(key).cloned().unwrap_or(VmValue::Nil);
-                            *idx += 1;
-                            self.stack.push(VmValue::Dict(Rc::new(BTreeMap::from([
-                                ("key".to_string(), VmValue::String(Rc::from(key.as_str()))),
-                                ("value".to_string(), value),
-                            ]))));
-                        } else {
-                            self.iterators.pop();
-                            let frame = self.frames.last_mut().unwrap();
-                            frame.ip = target;
-                        }
+                }
+                super::super::IterState::Range { next, stop } => {
+                    if *next < *stop {
+                        let v = *next;
+                        *next += 1;
+                        self.stack.push(VmValue::Int(v));
+                    } else {
+                        self.iterators.pop();
+                        let frame = self.frames.last_mut().unwrap();
+                        frame.ip = target;
                     }
-                    super::super::IterState::Channel { receiver, closed } => {
-                        let rx = receiver.clone();
-                        let is_closed = closed.load(std::sync::atomic::Ordering::Relaxed);
+                }
+                super::super::IterState::Generator { gen } => {
+                    if gen.done.get() {
+                        self.iterators.pop();
+                        let frame = self.frames.last_mut().unwrap();
+                        frame.ip = target;
+                    } else {
+                        let rx = gen.receiver.clone();
                         let mut guard = rx.lock().await;
-                        // Closed sender: drain without blocking.
-                        let item = if is_closed {
-                            guard.try_recv().ok()
-                        } else {
-                            guard.recv().await
-                        };
-                        match item {
+                        match guard.recv().await {
                             Some(val) => {
                                 self.stack.push(val);
                             }
                             None => {
+                                gen.done.set(true);
                                 drop(guard);
                                 self.iterators.pop();
                                 let frame = self.frames.last_mut().unwrap();
@@ -130,53 +163,20 @@ impl super::super::Vm {
                             }
                         }
                     }
-                    super::super::IterState::Range { next, stop } => {
-                        if *next < *stop {
-                            let v = *next;
-                            *next += 1;
-                            self.stack.push(VmValue::Int(v));
-                        } else {
-                            self.iterators.pop();
-                            let frame = self.frames.last_mut().unwrap();
-                            frame.ip = target;
-                        }
-                    }
-                    super::super::IterState::Generator { gen } => {
-                        if gen.done.get() {
-                            self.iterators.pop();
-                            let frame = self.frames.last_mut().unwrap();
-                            frame.ip = target;
-                        } else {
-                            let rx = gen.receiver.clone();
-                            let mut guard = rx.lock().await;
-                            match guard.recv().await {
-                                Some(val) => {
-                                    self.stack.push(val);
-                                }
-                                None => {
-                                    gen.done.set(true);
-                                    drop(guard);
-                                    self.iterators.pop();
-                                    let frame = self.frames.last_mut().unwrap();
-                                    frame.ip = target;
-                                }
-                            }
-                        }
-                    }
-                    super::super::IterState::VmIter { .. } => {
-                        unreachable!("VmIter state handled before this match");
-                    }
                 }
-            } else {
-                let frame = self.frames.last_mut().unwrap();
-                frame.ip = target;
+                super::super::IterState::VmIter { .. } => {
+                    unreachable!("VmIter state handled before this match");
+                }
             }
-        } else if op == Op::PopIterator as u8 {
-            self.iterators.pop();
         } else {
-            return Ok(false);
+            let frame = self.frames.last_mut().unwrap();
+            frame.ip = target;
         }
-        Ok(true)
+        Ok(())
+    }
+
+    pub(super) fn execute_pop_iterator(&mut self) {
+        self.iterators.pop();
     }
 }
 
@@ -200,7 +200,7 @@ mod tests {
             let mut vm = Vm::new();
             vm.stack.push(VmValue::List(items.clone()));
 
-            vm.try_execute_iter_op(Op::IterInit as u8).await.unwrap();
+            vm.execute_iter_init().unwrap();
 
             match vm.iterators.last().unwrap() {
                 IterState::Vec {
@@ -222,7 +222,7 @@ mod tests {
             let mut vm = Vm::new();
             vm.stack.push(VmValue::Set(items.clone()));
 
-            vm.try_execute_iter_op(Op::IterInit as u8).await.unwrap();
+            vm.execute_iter_init().unwrap();
 
             match vm.iterators.last().unwrap() {
                 IterState::Vec {
@@ -247,7 +247,7 @@ mod tests {
             let mut vm = Vm::new();
             vm.stack.push(VmValue::Dict(entries.clone()));
 
-            vm.try_execute_iter_op(Op::IterInit as u8).await.unwrap();
+            vm.execute_iter_init().unwrap();
 
             match vm.iterators.last().unwrap() {
                 IterState::Dict {

--- a/crates/harn-vm/src/vm/ops/logical.rs
+++ b/crates/harn-vm/src/vm/ops/logical.rs
@@ -1,14 +1,9 @@
-use crate::chunk::Op;
 use crate::value::{VmError, VmValue};
 
 impl super::super::Vm {
-    pub(super) fn try_execute_logical_op(&mut self, op: u8) -> Result<bool, VmError> {
-        if op == Op::Not as u8 {
-            let v = self.pop()?;
-            self.stack.push(VmValue::Bool(!v.is_truthy()));
-        } else {
-            return Ok(false);
-        }
-        Ok(true)
+    pub(super) fn execute_not(&mut self) -> Result<(), VmError> {
+        let v = self.pop()?;
+        self.stack.push(VmValue::Bool(!v.is_truthy()));
+        Ok(())
     }
 }

--- a/crates/harn-vm/src/vm/ops/misc.rs
+++ b/crates/harn-vm/src/vm/ops/misc.rs
@@ -1,49 +1,48 @@
-use crate::chunk::{Constant, Op};
+use crate::chunk::Constant;
 use crate::value::{VmError, VmValue};
 
 impl super::super::Vm {
-    pub(super) async fn try_execute_misc_op(&mut self, op: u8) -> Result<bool, VmError> {
-        if op == Op::CheckType as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let var_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let type_idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let var_name = match &frame.chunk.constants[var_idx] {
-                Constant::String(s) => s.clone(),
-                _ => return Err(VmError::TypeError("expected string constant".into())),
-            };
-            let expected_type = match &frame.chunk.constants[type_idx] {
-                Constant::String(s) => s.clone(),
-                _ => return Err(VmError::TypeError("expected string constant".into())),
-            };
-            if let Some(val) = self.env.get(&var_name) {
-                let actual_type = val.type_name();
-                let compatible = actual_type == expected_type
-                    || (expected_type == "float" && actual_type == "int")
-                    || (expected_type == "int" && actual_type == "float");
-                if !compatible {
-                    return Err(VmError::Runtime(format!(
-                        "TypeError: parameter '{}' expected {}, got {} ({})",
-                        var_name,
-                        expected_type,
-                        actual_type,
-                        val.display()
-                    )));
-                }
+    pub(super) fn execute_check_type(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let var_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let type_idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let var_name = match &frame.chunk.constants[var_idx] {
+            Constant::String(s) => s.clone(),
+            _ => return Err(VmError::TypeError("expected string constant".into())),
+        };
+        let expected_type = match &frame.chunk.constants[type_idx] {
+            Constant::String(s) => s.clone(),
+            _ => return Err(VmError::TypeError("expected string constant".into())),
+        };
+        if let Some(val) = self.env.get(&var_name) {
+            let actual_type = val.type_name();
+            let compatible = actual_type == expected_type
+                || (expected_type == "float" && actual_type == "int")
+                || (expected_type == "int" && actual_type == "float");
+            if !compatible {
+                return Err(VmError::Runtime(format!(
+                    "TypeError: parameter '{}' expected {}, got {} ({})",
+                    var_name,
+                    expected_type,
+                    actual_type,
+                    val.display()
+                )));
             }
-        } else if op == Op::Yield as u8 {
-            let val = self.pop()?;
-            if let Some(sender) = &self.yield_sender {
-                // Dropped receiver = generator was abandoned; ignore send error.
-                let _ = sender.send(val).await;
-                // Let the consumer pull this value before we produce the next.
-                tokio::task::yield_now().await;
-            }
-            self.stack.push(VmValue::Nil);
-        } else {
-            return Ok(false);
         }
-        Ok(true)
+        Ok(())
+    }
+
+    pub(super) async fn execute_yield(&mut self) -> Result<(), VmError> {
+        let val = self.pop()?;
+        if let Some(sender) = &self.yield_sender {
+            // Dropped receiver = generator was abandoned; ignore send error.
+            let _ = sender.send(val).await;
+            // Let the consumer pull this value before we produce the next.
+            tokio::task::yield_now().await;
+        }
+        self.stack.push(VmValue::Nil);
+        Ok(())
     }
 }

--- a/crates/harn-vm/src/vm/ops/mod.rs
+++ b/crates/harn-vm/src/vm/ops/mod.rs
@@ -19,54 +19,109 @@ impl super::Vm {
     /// - Ok(None): continue execution
     /// - Ok(Some(val)): return this value (top-level exit)
     /// - Err(e): error occurred
-    pub(super) async fn execute_op(&mut self, op: u8) -> Result<Option<VmValue>, VmError> {
-        if self.try_execute_stack_op(op)? {
-            return Ok(None);
-        }
-        if op >= Op::AddInt as u8 {
-            if op <= Op::ModFloat as u8 {
-                self.execute_typed_arithmetic_op(op)?;
-                return Ok(None);
-            }
-            if op <= Op::NotEqualString as u8 {
-                self.execute_typed_comparison_op(op)?;
-                return Ok(None);
-            }
+    pub(super) async fn execute_op(&mut self, op_byte: u8) -> Result<Option<VmValue>, VmError> {
+        let op = Op::from_byte(op_byte).ok_or(VmError::InvalidInstruction(op_byte))?;
+
+        match op {
+            Op::Constant => self.execute_constant()?,
+            Op::Nil => self.execute_nil(),
+            Op::True => self.execute_true(),
+            Op::False => self.execute_false(),
+            Op::GetVar => self.execute_get_var()?,
+            Op::DefLet => self.execute_def_let()?,
+            Op::DefVar => self.execute_def_var()?,
+            Op::SetVar => self.execute_set_var()?,
+            Op::PushScope => self.execute_push_scope(),
+            Op::PopScope => self.execute_pop_scope(),
+            Op::Add => self.execute_add()?,
+            Op::Sub => self.execute_sub()?,
+            Op::Mul => self.execute_mul()?,
+            Op::Div => self.execute_div()?,
+            Op::Mod => self.execute_mod()?,
+            Op::Pow => self.execute_pow()?,
+            Op::Negate => self.execute_negate()?,
+            Op::Equal => self.execute_equal()?,
+            Op::NotEqual => self.execute_not_equal()?,
+            Op::Less => self.execute_less()?,
+            Op::Greater => self.execute_greater()?,
+            Op::LessEqual => self.execute_less_equal()?,
+            Op::GreaterEqual => self.execute_greater_equal()?,
+            Op::Not => self.execute_not()?,
+            Op::Jump => self.execute_jump(),
+            Op::JumpIfFalse => self.execute_jump_if_false()?,
+            Op::JumpIfTrue => self.execute_jump_if_true()?,
+            Op::Pop => self.execute_pop()?,
+            Op::Call => self.execute_call().await?,
+            Op::CallBuiltin => self.execute_call_builtin().await?,
+            Op::CallBuiltinSpread => self.execute_call_builtin_spread().await?,
+            Op::TailCall => self.execute_tail_call().await?,
+            Op::Return => return Err(self.execute_return()),
+            Op::Closure => self.execute_closure(),
+            Op::BuildList => self.execute_build_list(),
+            Op::BuildDict => self.execute_build_dict(),
+            Op::Subscript => self.execute_subscript()?,
+            Op::Slice => self.execute_slice()?,
+            Op::GetProperty => self.execute_get_property(false)?,
+            Op::GetPropertyOpt => self.execute_get_property(true)?,
+            Op::SetProperty => self.execute_set_property()?,
+            Op::SetSubscript => self.execute_set_subscript()?,
+            Op::MethodCall => self.execute_method_call(false).await?,
+            Op::MethodCallOpt => self.execute_method_call(true).await?,
+            Op::Concat => self.execute_concat(),
+            Op::IterInit => self.execute_iter_init()?,
+            Op::IterNext => self.execute_iter_next().await?,
+            Op::Pipe => self.execute_pipe().await?,
+            Op::Throw => self.execute_throw()?,
+            Op::TryCatchSetup => self.execute_try_catch_setup(),
+            Op::PopHandler => self.execute_pop_handler(),
+            Op::Parallel => self.execute_parallel().await?,
+            Op::ParallelMap => self.execute_parallel_map().await?,
+            Op::ParallelSettle => self.execute_parallel_settle().await?,
+            Op::Spawn => self.execute_spawn()?,
+            Op::Import => self.execute_import_op().await?,
+            Op::SelectiveImport => self.execute_selective_import().await?,
+            Op::DeadlineSetup => self.execute_deadline_setup()?,
+            Op::DeadlineEnd => self.execute_deadline_end(),
+            Op::BuildEnum => self.execute_build_enum()?,
+            Op::MatchEnum => self.execute_match_enum()?,
+            Op::PopIterator => self.execute_pop_iterator(),
+            Op::GetArgc => self.execute_get_argc(),
+            Op::CheckType => self.execute_check_type()?,
+            Op::TryUnwrap => self.execute_try_unwrap()?,
+            Op::CallSpread => self.execute_call_spread().await?,
+            Op::MethodCallSpread => self.execute_method_call_spread().await?,
+            Op::Dup => self.execute_dup()?,
+            Op::Swap => self.execute_swap(),
+            Op::Contains => self.execute_contains()?,
+            Op::AddInt => self.execute_add_int()?,
+            Op::SubInt => self.execute_sub_int()?,
+            Op::MulInt => self.execute_mul_int()?,
+            Op::DivInt => self.execute_div_int()?,
+            Op::ModInt => self.execute_mod_int()?,
+            Op::AddFloat => self.execute_add_float()?,
+            Op::SubFloat => self.execute_sub_float()?,
+            Op::MulFloat => self.execute_mul_float()?,
+            Op::DivFloat => self.execute_div_float()?,
+            Op::ModFloat => self.execute_mod_float()?,
+            Op::EqualInt => self.execute_equal_int()?,
+            Op::NotEqualInt => self.execute_not_equal_int()?,
+            Op::LessInt => self.execute_less_int()?,
+            Op::GreaterInt => self.execute_greater_int()?,
+            Op::LessEqualInt => self.execute_less_equal_int()?,
+            Op::GreaterEqualInt => self.execute_greater_equal_int()?,
+            Op::EqualFloat => self.execute_equal_float()?,
+            Op::NotEqualFloat => self.execute_not_equal_float()?,
+            Op::LessFloat => self.execute_less_float()?,
+            Op::GreaterFloat => self.execute_greater_float()?,
+            Op::LessEqualFloat => self.execute_less_equal_float()?,
+            Op::GreaterEqualFloat => self.execute_greater_equal_float()?,
+            Op::EqualBool => self.execute_equal_bool()?,
+            Op::NotEqualBool => self.execute_not_equal_bool()?,
+            Op::EqualString => self.execute_equal_string()?,
+            Op::NotEqualString => self.execute_not_equal_string()?,
+            Op::Yield => self.execute_yield().await?,
         }
 
-        if self.try_execute_arithmetic_op(op)? {
-            return Ok(None);
-        }
-        if self.try_execute_comparison_op(op)? {
-            return Ok(None);
-        }
-        if self.try_execute_logical_op(op)? {
-            return Ok(None);
-        }
-        if self.try_execute_control_flow_op(op)? {
-            return Ok(None);
-        }
-        if self.try_execute_call_op(op).await? {
-            return Ok(None);
-        }
-        if self.try_execute_collections_op(op)? {
-            return Ok(None);
-        }
-        if self.try_execute_iter_op(op).await? {
-            return Ok(None);
-        }
-        if self.try_execute_parallel_op(op).await? {
-            return Ok(None);
-        }
-        if self.try_execute_exception_op(op)? {
-            return Ok(None);
-        }
-        if self.try_execute_imports_op(op).await? {
-            return Ok(None);
-        }
-        if self.try_execute_misc_op(op).await? {
-            return Ok(None);
-        }
-        Err(VmError::InvalidInstruction(op))
+        Ok(None)
     }
 }

--- a/crates/harn-vm/src/vm/ops/parallel.rs
+++ b/crates/harn-vm/src/vm/ops/parallel.rs
@@ -3,7 +3,6 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::chunk::Op;
 use crate::value::{VmError, VmTaskHandle, VmValue};
 
 /// Decode the `cap_val` stack operand pushed by `parallel ... with
@@ -74,163 +73,170 @@ where
 }
 
 impl super::super::Vm {
-    pub(super) async fn try_execute_parallel_op(&mut self, op: u8) -> Result<bool, VmError> {
-        if op == Op::Parallel as u8 {
-            let _par_span =
-                super::super::ScopeSpan::new(crate::tracing::SpanKind::Parallel, "parallel".into());
-            let closure = self.pop()?;
-            let count_val = self.pop()?;
-            let cap_val = self.pop()?;
-            let count = match &count_val {
-                VmValue::Int(n) => (*n).max(0) as usize,
-                _ => 0,
-            };
-            let cap = parallel_cap_from_value(&cap_val, count)?;
-            if let VmValue::Closure(closure) = closure {
-                let mut futures: Vec<_> = Vec::with_capacity(count);
-                for i in 0..count {
+    pub(super) async fn execute_parallel(&mut self) -> Result<(), VmError> {
+        let _par_span =
+            super::super::ScopeSpan::new(crate::tracing::SpanKind::Parallel, "parallel".into());
+        let closure = self.pop()?;
+        let count_val = self.pop()?;
+        let cap_val = self.pop()?;
+        let count = match &count_val {
+            VmValue::Int(n) => (*n).max(0) as usize,
+            _ => 0,
+        };
+        let cap = parallel_cap_from_value(&cap_val, count)?;
+        if let VmValue::Closure(closure) = closure {
+            let mut futures: Vec<_> = Vec::with_capacity(count);
+            for i in 0..count {
+                let mut child = self.child_vm();
+                let closure = closure.clone();
+                futures.push(async move {
+                    let result = child
+                        .call_closure(&closure, &[VmValue::Int(i as i64)])
+                        .await?;
+                    Ok::<(VmValue, String), VmError>((result, std::mem::take(&mut child.output)))
+                });
+            }
+            let joined = run_capped_ordered(futures, cap, "Parallel task error").await?;
+            let mut results = Vec::with_capacity(count);
+            for entry in joined {
+                let (val, task_output) = entry?;
+                self.output.push_str(&task_output);
+                results.push(val);
+            }
+            self.stack.push(VmValue::List(Rc::new(results)));
+        } else {
+            self.stack.push(VmValue::Nil);
+        }
+        Ok(())
+    }
+
+    pub(super) async fn execute_parallel_map(&mut self) -> Result<(), VmError> {
+        let closure = self.pop()?;
+        let list_val = self.pop()?;
+        let cap_val = self.pop()?;
+        match (&list_val, &closure) {
+            (VmValue::List(items), VmValue::Closure(closure)) => {
+                let len = items.len();
+                let cap = parallel_cap_from_value(&cap_val, len)?;
+                let mut futures = Vec::with_capacity(len);
+                for item in items.iter() {
                     let mut child = self.child_vm();
                     let closure = closure.clone();
+                    let item = item.clone();
                     futures.push(async move {
-                        let result = child
-                            .call_closure(&closure, &[VmValue::Int(i as i64)])
-                            .await?;
+                        let result = child.call_closure(&closure, &[item]).await?;
                         Ok::<(VmValue, String), VmError>((
                             result,
                             std::mem::take(&mut child.output),
                         ))
                     });
                 }
-                let joined = run_capped_ordered(futures, cap, "Parallel task error").await?;
-                let mut results = Vec::with_capacity(count);
+                let joined = run_capped_ordered(futures, cap, "Parallel map error").await?;
+                let mut results = Vec::with_capacity(len);
                 for entry in joined {
                     let (val, task_output) = entry?;
                     self.output.push_str(&task_output);
                     results.push(val);
                 }
                 self.stack.push(VmValue::List(Rc::new(results)));
-            } else {
-                self.stack.push(VmValue::Nil);
             }
-        } else if op == Op::ParallelMap as u8 {
-            let closure = self.pop()?;
-            let list_val = self.pop()?;
-            let cap_val = self.pop()?;
-            match (&list_val, &closure) {
-                (VmValue::List(items), VmValue::Closure(closure)) => {
-                    let len = items.len();
-                    let cap = parallel_cap_from_value(&cap_val, len)?;
-                    let mut futures = Vec::with_capacity(len);
-                    for item in items.iter() {
-                        let mut child = self.child_vm();
-                        let closure = closure.clone();
-                        let item = item.clone();
-                        futures.push(async move {
-                            let result = child.call_closure(&closure, &[item]).await?;
-                            Ok::<(VmValue, String), VmError>((
-                                result,
-                                std::mem::take(&mut child.output),
-                            ))
-                        });
-                    }
-                    let joined = run_capped_ordered(futures, cap, "Parallel map error").await?;
-                    let mut results = Vec::with_capacity(len);
-                    for entry in joined {
-                        let (val, task_output) = entry?;
-                        self.output.push_str(&task_output);
-                        results.push(val);
-                    }
-                    self.stack.push(VmValue::List(Rc::new(results)));
+            _ => self.stack.push(VmValue::Nil),
+        }
+        Ok(())
+    }
+
+    pub(super) async fn execute_parallel_settle(&mut self) -> Result<(), VmError> {
+        let closure = self.pop()?;
+        let list_val = self.pop()?;
+        let cap_val = self.pop()?;
+        match (&list_val, &closure) {
+            (VmValue::List(items), VmValue::Closure(closure)) => {
+                let len = items.len();
+                let cap = parallel_cap_from_value(&cap_val, len)?;
+                let mut futures = Vec::with_capacity(len);
+                for item in items.iter() {
+                    let mut child = self.child_vm();
+                    let closure = closure.clone();
+                    let item = item.clone();
+                    futures.push(async move {
+                        let result = child.call_closure(&closure, &[item]).await;
+                        let output = std::mem::take(&mut child.output);
+                        (result, output)
+                    });
                 }
-                _ => self.stack.push(VmValue::Nil),
-            }
-        } else if op == Op::ParallelSettle as u8 {
-            let closure = self.pop()?;
-            let list_val = self.pop()?;
-            let cap_val = self.pop()?;
-            match (&list_val, &closure) {
-                (VmValue::List(items), VmValue::Closure(closure)) => {
-                    let len = items.len();
-                    let cap = parallel_cap_from_value(&cap_val, len)?;
-                    let mut futures = Vec::with_capacity(len);
-                    for item in items.iter() {
-                        let mut child = self.child_vm();
-                        let closure = closure.clone();
-                        let item = item.clone();
-                        futures.push(async move {
-                            let result = child.call_closure(&closure, &[item]).await;
-                            let output = std::mem::take(&mut child.output);
-                            (result, output)
-                        });
-                    }
-                    let joined = run_capped_ordered(futures, cap, "Parallel settle error").await?;
-                    let mut results = Vec::with_capacity(len);
-                    let mut succeeded = 0i64;
-                    let mut failed = 0i64;
-                    for (result, task_output) in joined {
-                        self.output.push_str(&task_output);
-                        match result {
-                            Ok(val) => {
-                                succeeded += 1;
-                                results.push(VmValue::enum_variant("Result", "Ok", vec![val]));
-                            }
-                            Err(e) => {
-                                failed += 1;
-                                results.push(VmValue::enum_variant(
-                                    "Result",
-                                    "Err",
-                                    vec![VmValue::String(Rc::from(e.to_string()))],
-                                ));
-                            }
+                let joined = run_capped_ordered(futures, cap, "Parallel settle error").await?;
+                let mut results = Vec::with_capacity(len);
+                let mut succeeded = 0i64;
+                let mut failed = 0i64;
+                for (result, task_output) in joined {
+                    self.output.push_str(&task_output);
+                    match result {
+                        Ok(val) => {
+                            succeeded += 1;
+                            results.push(VmValue::enum_variant("Result", "Ok", vec![val]));
+                        }
+                        Err(e) => {
+                            failed += 1;
+                            results.push(VmValue::enum_variant(
+                                "Result",
+                                "Err",
+                                vec![VmValue::String(Rc::from(e.to_string()))],
+                            ));
                         }
                     }
-                    let mut dict = BTreeMap::new();
-                    dict.insert("results".to_string(), VmValue::List(Rc::new(results)));
-                    dict.insert("succeeded".to_string(), VmValue::Int(succeeded));
-                    dict.insert("failed".to_string(), VmValue::Int(failed));
-                    self.stack.push(VmValue::Dict(Rc::new(dict)));
                 }
-                _ => self.stack.push(VmValue::Nil),
+                let mut dict = BTreeMap::new();
+                dict.insert("results".to_string(), VmValue::List(Rc::new(results)));
+                dict.insert("succeeded".to_string(), VmValue::Int(succeeded));
+                dict.insert("failed".to_string(), VmValue::Int(failed));
+                self.stack.push(VmValue::Dict(Rc::new(dict)));
             }
-        } else if op == Op::Spawn as u8 {
-            let _spawn_span =
-                super::super::ScopeSpan::new(crate::tracing::SpanKind::Spawn, "spawn".into());
-            let closure = self.pop()?;
-            if let VmValue::Closure(closure) = closure {
-                self.task_counter += 1;
-                let task_id = format!("vm_task_{}", self.task_counter);
-                let mut child = self.child_vm();
-                let cancel_token = Arc::new(std::sync::atomic::AtomicBool::new(false));
-                child.cancel_token = Some(cancel_token.clone());
-                let handle = tokio::task::spawn_local(async move {
-                    let result = child.call_closure(&closure, &[]).await?;
-                    Ok((result, std::mem::take(&mut child.output)))
-                });
-                self.spawned_tasks.insert(
-                    task_id.clone(),
-                    VmTaskHandle {
-                        handle,
-                        cancel_token,
-                    },
-                );
-                self.stack.push(VmValue::TaskHandle(task_id));
-            } else {
-                self.stack.push(VmValue::Nil);
-            }
-        } else if op == Op::DeadlineSetup as u8 {
-            let dur_val = self.pop()?;
-            let ms = match &dur_val {
-                VmValue::Duration(ms) => *ms,
-                VmValue::Int(n) => (*n).max(0) as u64,
-                _ => 30_000,
-            };
-            let deadline = Instant::now() + std::time::Duration::from_millis(ms);
-            self.deadlines.push((deadline, self.frames.len()));
-        } else if op == Op::DeadlineEnd as u8 {
-            self.deadlines.pop();
-        } else {
-            return Ok(false);
+            _ => self.stack.push(VmValue::Nil),
         }
-        Ok(true)
+        Ok(())
+    }
+
+    pub(super) fn execute_spawn(&mut self) -> Result<(), VmError> {
+        let _spawn_span =
+            super::super::ScopeSpan::new(crate::tracing::SpanKind::Spawn, "spawn".into());
+        let closure = self.pop()?;
+        if let VmValue::Closure(closure) = closure {
+            self.task_counter += 1;
+            let task_id = format!("vm_task_{}", self.task_counter);
+            let mut child = self.child_vm();
+            let cancel_token = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            child.cancel_token = Some(cancel_token.clone());
+            let handle = tokio::task::spawn_local(async move {
+                let result = child.call_closure(&closure, &[]).await?;
+                Ok((result, std::mem::take(&mut child.output)))
+            });
+            self.spawned_tasks.insert(
+                task_id.clone(),
+                VmTaskHandle {
+                    handle,
+                    cancel_token,
+                },
+            );
+            self.stack.push(VmValue::TaskHandle(task_id));
+        } else {
+            self.stack.push(VmValue::Nil);
+        }
+        Ok(())
+    }
+
+    pub(super) fn execute_deadline_setup(&mut self) -> Result<(), VmError> {
+        let dur_val = self.pop()?;
+        let ms = match &dur_val {
+            VmValue::Duration(ms) => *ms,
+            VmValue::Int(n) => (*n).max(0) as u64,
+            _ => 30_000,
+        };
+        let deadline = Instant::now() + std::time::Duration::from_millis(ms);
+        self.deadlines.push((deadline, self.frames.len()));
+        Ok(())
+    }
+
+    pub(super) fn execute_deadline_end(&mut self) {
+        self.deadlines.pop();
     }
 }

--- a/crates/harn-vm/src/vm/ops/stack.rs
+++ b/crates/harn-vm/src/vm/ops/stack.rs
@@ -1,137 +1,162 @@
 use std::rc::Rc;
 
-use crate::chunk::{Constant, Op};
+use crate::chunk::Constant;
 use crate::value::{VmError, VmValue};
 
 impl super::super::Vm {
-    pub(super) fn try_execute_stack_op(&mut self, op: u8) -> Result<bool, VmError> {
-        if op == Op::Constant as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let val = match &frame.chunk.constants[idx] {
-                Constant::Int(n) => VmValue::Int(*n),
-                Constant::Float(n) => VmValue::Float(*n),
-                Constant::String(s) => VmValue::String(Rc::from(s.as_str())),
-                Constant::Bool(b) => VmValue::Bool(*b),
-                Constant::Nil => VmValue::Nil,
-                Constant::Duration(ms) => VmValue::Duration(*ms),
-            };
+    pub(super) fn execute_constant(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let val = match &frame.chunk.constants[idx] {
+            Constant::Int(n) => VmValue::Int(*n),
+            Constant::Float(n) => VmValue::Float(*n),
+            Constant::String(s) => VmValue::String(Rc::from(s.as_str())),
+            Constant::Bool(b) => VmValue::Bool(*b),
+            Constant::Nil => VmValue::Nil,
+            Constant::Duration(ms) => VmValue::Duration(*ms),
+        };
+        self.stack.push(val);
+        Ok(())
+    }
+
+    pub(super) fn execute_nil(&mut self) {
+        self.stack.push(VmValue::Nil);
+    }
+
+    pub(super) fn execute_true(&mut self) {
+        self.stack.push(VmValue::Bool(true));
+    }
+
+    pub(super) fn execute_false(&mut self) {
+        self.stack.push(VmValue::Bool(false));
+    }
+
+    pub(super) fn execute_get_var(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let name = match &frame.chunk.constants[idx] {
+            Constant::String(s) => s.clone(),
+            _ => return Err(VmError::TypeError("expected string constant".into())),
+        };
+        if let Some(val) = self.env.get(&name) {
             self.stack.push(val);
-        } else if op == Op::Nil as u8 {
-            self.stack.push(VmValue::Nil);
-        } else if op == Op::True as u8 {
-            self.stack.push(VmValue::Bool(true));
-        } else if op == Op::False as u8 {
-            self.stack.push(VmValue::Bool(false));
-        } else if op == Op::GetVar as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let name = match &frame.chunk.constants[idx] {
-                Constant::String(s) => s.clone(),
-                _ => return Err(VmError::TypeError("expected string constant".into())),
-            };
-            if let Some(val) = self.env.get(&name) {
-                self.stack.push(val);
-            } else if let Some(val) = self
-                .frames
-                .last()
-                .and_then(|f| f.module_state.as_ref())
-                .and_then(|ms| ms.borrow().get(&name))
-            {
-                // Module-level var from the closure's originating module.
-                self.stack.push(val);
-            } else if let Some(val) = self.globals.get(&name) {
-                self.stack.push(val.clone());
-            } else if let Some(id) = self.registered_builtin_id(&name) {
-                // Allow bare builtin references so they can be passed as callbacks.
-                self.stack.push(VmValue::BuiltinRefId {
-                    id,
-                    name: Rc::from(name.as_str()),
-                });
-            } else if self.builtins.contains_key(&name) || self.async_builtins.contains_key(&name) {
-                // Collided IDs cannot use the direct index, but remain valid callbacks.
-                self.stack
-                    .push(VmValue::BuiltinRef(Rc::from(name.as_str())));
-            } else {
-                let mut all_vars = self.env.all_variables();
-                for (k, v) in &self.globals {
-                    all_vars.entry(k.clone()).or_insert_with(|| v.clone());
-                }
-                // Include builtin names so typos on builtin refs get suggestions.
-                let mut candidates: Vec<String> = all_vars.keys().cloned().collect();
-                candidates.extend(self.builtins.keys().cloned());
-                candidates.extend(self.async_builtins.keys().cloned());
-                if let Some(suggestion) =
-                    crate::value::closest_match(&name, candidates.iter().map(|s| s.as_str()))
-                {
-                    return Err(VmError::Runtime(format!(
-                        "Undefined variable: {name} (did you mean `{suggestion}`?)"
-                    )));
-                }
-                return Err(VmError::UndefinedVariable(name));
-            }
-        } else if op == Op::DefLet as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let name = Self::const_string(&frame.chunk.constants[idx])?;
-            let val = self.pop()?;
-            self.env.define(&name, val, false)?;
-        } else if op == Op::DefVar as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let name = Self::const_string(&frame.chunk.constants[idx])?;
-            let val = self.pop()?;
-            self.env.define(&name, val, true)?;
-        } else if op == Op::PushScope as u8 {
-            self.env.push_scope();
-        } else if op == Op::PopScope as u8 {
-            self.env.pop_scope();
-        } else if op == Op::SetVar as u8 {
-            let frame = self.frames.last_mut().unwrap();
-            let idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            let name = Self::const_string(&frame.chunk.constants[idx])?;
-            let val = self.pop()?;
-            // Local scope wins; otherwise route to the closure's shared
-            // module_state. Fall through to env.assign only when neither
-            // has it, so UndefinedVariable / ImmutableAssignment surface.
-            if self.env.get(&name).is_some() {
-                self.env.assign(&name, val)?;
-            } else if let Some(ms) = self
-                .frames
-                .last()
-                .and_then(|f| f.module_state.as_ref())
-                .cloned()
-            {
-                if ms.borrow().get(&name).is_some() {
-                    ms.borrow_mut().assign(&name, val)?;
-                } else {
-                    // Neither has it — let env.assign produce the diagnostic.
-                    self.env.assign(&name, val)?;
-                }
-            } else {
-                self.env.assign(&name, val)?;
-            }
-        } else if op == Op::Pop as u8 {
-            self.pop()?;
-        } else if op == Op::Dup as u8 {
-            let val = self.peek()?.clone();
+        } else if let Some(val) = self
+            .frames
+            .last()
+            .and_then(|f| f.module_state.as_ref())
+            .and_then(|ms| ms.borrow().get(&name))
+        {
+            // Module-level var from the closure's originating module.
             self.stack.push(val);
-        } else if op == Op::Swap as u8 {
-            let len = self.stack.len();
-            if len >= 2 {
-                self.stack.swap(len - 1, len - 2);
-            }
-        } else if op == Op::GetArgc as u8 {
-            let argc = self.frames.last().map(|f| f.argc).unwrap_or(0);
-            self.stack.push(VmValue::Int(argc as i64));
+        } else if let Some(val) = self.globals.get(&name) {
+            self.stack.push(val.clone());
+        } else if let Some(id) = self.registered_builtin_id(&name) {
+            // Allow bare builtin references so they can be passed as callbacks.
+            self.stack.push(VmValue::BuiltinRefId {
+                id,
+                name: Rc::from(name.as_str()),
+            });
+        } else if self.builtins.contains_key(&name) || self.async_builtins.contains_key(&name) {
+            // Collided IDs cannot use the direct index, but remain valid callbacks.
+            self.stack
+                .push(VmValue::BuiltinRef(Rc::from(name.as_str())));
         } else {
-            return Ok(false);
+            let mut all_vars = self.env.all_variables();
+            for (k, v) in &self.globals {
+                all_vars.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+            // Include builtin names so typos on builtin refs get suggestions.
+            let mut candidates: Vec<String> = all_vars.keys().cloned().collect();
+            candidates.extend(self.builtins.keys().cloned());
+            candidates.extend(self.async_builtins.keys().cloned());
+            if let Some(suggestion) =
+                crate::value::closest_match(&name, candidates.iter().map(|s| s.as_str()))
+            {
+                return Err(VmError::Runtime(format!(
+                    "Undefined variable: {name} (did you mean `{suggestion}`?)"
+                )));
+            }
+            return Err(VmError::UndefinedVariable(name));
         }
-        Ok(true)
+        Ok(())
+    }
+
+    pub(super) fn execute_def_let(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let name = Self::const_string(&frame.chunk.constants[idx])?;
+        let val = self.pop()?;
+        self.env.define(&name, val, false)
+    }
+
+    pub(super) fn execute_def_var(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let name = Self::const_string(&frame.chunk.constants[idx])?;
+        let val = self.pop()?;
+        self.env.define(&name, val, true)
+    }
+
+    pub(super) fn execute_push_scope(&mut self) {
+        self.env.push_scope();
+    }
+
+    pub(super) fn execute_pop_scope(&mut self) {
+        self.env.pop_scope();
+    }
+
+    pub(super) fn execute_set_var(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().unwrap();
+        let idx = frame.chunk.read_u16(frame.ip) as usize;
+        frame.ip += 2;
+        let name = Self::const_string(&frame.chunk.constants[idx])?;
+        let val = self.pop()?;
+        // Local scope wins; otherwise route to the closure's shared
+        // module_state. Fall through to env.assign only when neither
+        // has it, so UndefinedVariable / ImmutableAssignment surface.
+        if self.env.get(&name).is_some() {
+            self.env.assign(&name, val)?;
+        } else if let Some(ms) = self
+            .frames
+            .last()
+            .and_then(|f| f.module_state.as_ref())
+            .cloned()
+        {
+            if ms.borrow().get(&name).is_some() {
+                ms.borrow_mut().assign(&name, val)?;
+            } else {
+                // Neither has it: let env.assign produce the diagnostic.
+                self.env.assign(&name, val)?;
+            }
+        } else {
+            self.env.assign(&name, val)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn execute_pop(&mut self) -> Result<(), VmError> {
+        self.pop().map(drop)
+    }
+
+    pub(super) fn execute_dup(&mut self) -> Result<(), VmError> {
+        let val = self.peek()?.clone();
+        self.stack.push(val);
+        Ok(())
+    }
+
+    pub(super) fn execute_swap(&mut self) {
+        let len = self.stack.len();
+        if len >= 2 {
+            self.stack.swap(len - 1, len - 2);
+        }
+    }
+
+    pub(super) fn execute_get_argc(&mut self) {
+        let argc = self.frames.last().map(|f| f.argc).unwrap_or(0);
+        self.stack.push(VmValue::Int(argc as i64));
     }
 }


### PR DESCRIPTION
Closes #406.

## Summary
- Replaced the VM's category-probe opcode dispatch chain with one central exhaustive `match Op` in `execute_op`.
- Added table-backed `Op::from_byte` plus an invariant test that keeps byte decoding aligned with opcode repr order.
- Split the old `try_execute_*` handlers into concrete opcode helpers while preserving the existing per-category files and operand decoding behavior.

## Verification
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-issue-406-target-check cargo test -p harn-vm vm::tests_runtime`
- `CARGO_TARGET_DIR=/tmp/harn-issue-406-target-check-debug cargo test -p harn-vm vm::tests_debug`
- `CARGO_TARGET_DIR=/tmp/harn-issue-406-target-check cargo test -p harn-vm`
- `cargo build --bin harn`
- `cargo run --quiet --bin harn -- test conformance` (622 passed)
- `make test` (1914 passed, 7 skipped)
- Push hook release-quality gate (1914 passed, Harn formatting, markdownlint, portal lint)
- `scripts/bench_vm.sh --iterations 10` before/after in release mode

## Benchmarks

| Benchmark | Before avg ms | After avg ms | Delta |
| --- | ---: | ---: | ---: |
| arithmetic_loop | 111.79 | 101.82 | -8.9% |
| comparison_loop | 179.84 | 133.01 | -26.0% |
| dict_property_read | 182.11 | 85.18 | -53.2% |
| function_call_loop | 225.61 | 110.66 | -51.0% |
| list_iteration | 37.31 | 22.49 | -39.7% |
| list_map_filter | 364.17 | 285.62 | -21.6% |
| local_variable_lookup | 188.14 | 198.17 | +5.3% |
| method_call_dispatch | 58.61 | 56.57 | -3.5% |
| recursive_countdown | 24.72 | 23.52 | -4.9% |
| string_interpolation_loop | 8.37 | 7.08 | -15.4% |
| struct_field_read | 167.45 | 139.75 | -16.5% |