### PR TITLE
Support line-leading coalescing operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ granular archaeology.
 
 ### Fixed
 
+- **Line-leading nil-coalescing continuations.** Expressions can now
+  continue on a following line that starts with `??`, equality, or
+  comparison operators, matching the formatter and tree-sitter grammar.
 - **Stable script source directories.** `harn run` now stores source
   directories as absolute paths before exposing them through
   `source_dir()`. Scripts can safely derive sibling paths from

--- a/conformance/tests/language/multiline_continuation_operators.expected
+++ b/conformance/tests/language/multiline_continuation_operators.expected
@@ -1,0 +1,5 @@
+fallback
+true
+true
+true
+true

--- a/conformance/tests/language/multiline_continuation_operators.harn
+++ b/conformance/tests/language/multiline_continuation_operators.harn
@@ -1,0 +1,17 @@
+pipeline default() {
+  let fallback = nil
+    ?? "fallback"
+  println(fallback)
+  let same = 1
+    == 1
+  println(same)
+  let different = 1
+    != 2
+  println(different)
+  let smaller = 1
+    < 2
+  println(smaller)
+  let larger_or_equal = 2
+    >= 2
+  println(larger_or_equal)
+}

--- a/crates/harn-fmt/src/helpers.rs
+++ b/crates/harn-fmt/src/helpers.rs
@@ -120,10 +120,26 @@ pub(crate) fn child_needs_parens(parent_op: &str, child: &Node, is_right: bool) 
     false
 }
 
-/// Operators for which the Harn lexer/parser uses `check_skip_newlines`;
-/// a line break before them is safe without a backslash continuation.
+/// Operators for which the Harn parser accepts a line break before the
+/// operator without a backslash continuation.
 pub(crate) fn op_safe_after_newline(op: &str) -> bool {
-    matches!(op, "|>" | "||" | "&&" | "+" | "*" | "/" | "%" | "**")
+    matches!(
+        op,
+        "|>" | "||"
+            | "&&"
+            | "=="
+            | "!="
+            | "<"
+            | ">"
+            | "<="
+            | ">="
+            | "??"
+            | "+"
+            | "*"
+            | "/"
+            | "%"
+            | "**"
+    )
 }
 
 /// Format a binding pattern to a string.

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -419,6 +419,33 @@ fn test_subtraction_uses_backslash_continuation() {
 }
 
 #[test]
+fn test_line_leading_safe_operators_do_not_use_backslash_continuation() {
+    let source = r#"pipeline default(task) {
+  let fallback = first_really_long_variable_name ?? second_really_long_variable_name
+  let same = first_really_long_variable_name == second_really_long_variable_name
+}"#;
+    let result = fmt_opts(source, 40);
+    assert!(
+        result.contains("\n    ?? ") && result.contains("\n    == "),
+        "Expected line-leading ?? and == operators, got:\n{result}"
+    );
+    assert!(
+        !result.contains("\\\n"),
+        "Expected no backslash continuation for newline-safe operators, got:\n{result}"
+    );
+
+    let mut lexer = Lexer::new(&result);
+    let tokens = lexer
+        .tokenize()
+        .unwrap_or_else(|e| panic!("Formatted output failed to lex:\n{result}\nError: {e}"));
+    let mut parser = Parser::new(tokens);
+    parser
+        .parse()
+        .unwrap_or_else(|e| panic!("Formatted output failed to parse:\n{result}\nError: {e}"));
+    assert_eq!(result, fmt_opts(&result, 40));
+}
+
+#[test]
 fn test_nested_function_call_wrapping() {
     let source = r#"pipeline default(task) {
   let x = outer_function(inner_function(very_long_argument_name_one, very_long_argument_name_two, very_long_argument_name_three), another_really_long_argument_name)

--- a/crates/harn-parser/src/parser/expressions.rs
+++ b/crates/harn-parser/src/parser/expressions.rs
@@ -82,7 +82,7 @@ impl Parser {
     // so `xs?.count ?? 0 > 0` parses as `(xs?.count ?? 0) > 0`.
     pub(super) fn parse_nil_coalescing(&mut self) -> Result<SNode, ParserError> {
         let mut left = self.parse_multiplicative()?;
-        while self.check(&TokenKind::NilCoal) {
+        while self.check_skip_newlines(&TokenKind::NilCoal) {
             let start = left.span;
             self.advance();
             let right = self.parse_multiplicative()?;
@@ -136,7 +136,8 @@ impl Parser {
 
     pub(super) fn parse_equality(&mut self) -> Result<SNode, ParserError> {
         let mut left = self.parse_comparison()?;
-        while self.check(&TokenKind::Eq) || self.check(&TokenKind::Neq) {
+        while self.check_skip_newlines(&TokenKind::Eq) || self.check_skip_newlines(&TokenKind::Neq)
+        {
             let start = left.span;
             let op = if self.check(&TokenKind::Eq) {
                 "=="
@@ -160,10 +161,10 @@ impl Parser {
     pub(super) fn parse_comparison(&mut self) -> Result<SNode, ParserError> {
         let mut left = self.parse_additive()?;
         loop {
-            if self.check(&TokenKind::Lt)
-                || self.check(&TokenKind::Gt)
-                || self.check(&TokenKind::Lte)
-                || self.check(&TokenKind::Gte)
+            if self.check_skip_newlines(&TokenKind::Lt)
+                || self.check_skip_newlines(&TokenKind::Gt)
+                || self.check_skip_newlines(&TokenKind::Lte)
+                || self.check_skip_newlines(&TokenKind::Gte)
             {
                 let start = left.span;
                 let op = match self.current().map(|t| &t.kind) {

--- a/crates/harn-parser/src/parser/mod.rs
+++ b/crates/harn-parser/src/parser/mod.rs
@@ -40,6 +40,22 @@ pipeline p() {
     }
 
     #[test]
+    fn parses_line_leading_infix_continuation_operators() {
+        let source = r#"
+pipeline p() {
+  let fallback = nil
+    ?? "fallback"
+  let same = 1
+    == 1
+  let smaller = 1
+    < 2
+}
+"#;
+
+        assert!(parse_source(source).is_ok());
+    }
+
+    #[test]
     fn parses_public_declarations_and_generic_interfaces() {
         let source = r#"
 pub pipeline build(task) extends base {

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -163,9 +163,9 @@ contexts, but they are not preserved in formatter output.
   trailing commas.
 - **Binary operator chains** — long expressions like `a + b + c + d` break
   before the operator. Operators that the parser cannot resume across a bare
-  newline (`-`, `==`, `!=`, `<`, `>`, `<=`, `>=`, `in`, `not in`, `??`)
-  get an automatic backslash continuation (`\`); other operators (`+`, `*`,
-  `/`, `%`, `||`, `&&`, `|>`) break without one.
+  newline (`-`, `in`, `not in`) get an automatic backslash continuation (`\`);
+  other operators (`+`, `*`, `/`, `%`, `||`, `&&`, `|>`, `==`, `!=`, `<`,
+  `>`, `<=`, `>=`, `??`) break without one.
 - **Operator precedence parentheses** — the formatter inserts parentheses
   to preserve semantics when the AST drops them (e.g. `a * (b + c)` stays
   parenthesised) and for clarity when mixing `&&` / `||`

--- a/docs/src/language-basics.md
+++ b/docs/src/language-basics.md
@@ -616,10 +616,17 @@ let result = items
 let valid = check_a()
   && check_b()
   || fallback()
+
+let name = nil
+  ?? "unknown"
+
+let same = 1
+  == 1
 ```
 
 Note: `-` does not continue across lines because it doubles as unary
-negation.
+negation. Keyword operators `in`, `not in`, and `to` also require an explicit
+backslash continuation.
 
 A backslash at the end of a line forces the next line to continue the
 current expression, even when no operator is present:

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -576,14 +576,15 @@ From lowest to highest binding:
 
 ### Multiline expressions
 
-Binary operators `||`, `&&`, `+`, `*`, `/`, `%`, `**`, `|>` and the `.`
-member
-access operator can span multiple lines. The operator at the start of a
-continuation line causes the parser to treat it as a continuation of the
-previous expression rather than a new statement.
+Binary operators `|>`, `||`, `&&`, `==`, `!=`, `<`, `>`, `<=`, `>=`, `??`,
+`+`, `*`, `/`, `%`, `**`, and the `.` / `?.` member access operators can span
+multiple lines. The operator at the start of a continuation line causes the
+parser to treat it as a continuation of the previous expression rather than a
+new statement.
 
-Note: `-` does not support multiline continuation because it is also a
-unary negation prefix.
+Note: `-` does not support multiline continuation because it is also a unary
+negation prefix. Keyword operators `in`, `not in`, and `to` also require an
+explicit backslash continuation.
 
 ```harn
 let result = items

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -574,14 +574,15 @@ From lowest to highest binding:
 
 ### Multiline expressions
 
-Binary operators `||`, `&&`, `+`, `*`, `/`, `%`, `**`, `|>` and the `.`
-member
-access operator can span multiple lines. The operator at the start of a
-continuation line causes the parser to treat it as a continuation of the
-previous expression rather than a new statement.
+Binary operators `|>`, `||`, `&&`, `==`, `!=`, `<`, `>`, `<=`, `>=`, `??`,
+`+`, `*`, `/`, `%`, `**`, and the `.` / `?.` member access operators can span
+multiple lines. The operator at the start of a continuation line causes the
+parser to treat it as a continuation of the previous expression rather than a
+new statement.
 
-Note: `-` does not support multiline continuation because it is also a
-unary negation prefix.
+Note: `-` does not support multiline continuation because it is also a unary
+negation prefix. Keyword operators `in`, `not in`, and `to` also require an
+explicit backslash continuation.
 
 ```harn
 let result = items

--- a/tree-sitter-harn/grammar.js
+++ b/tree-sitter-harn/grammar.js
@@ -29,11 +29,15 @@ module.exports = grammar({
     [$.interface_declaration],
     [$.match_statement],
     [$.skill_declaration, $.pipe_expression, $.binary_expression, $.method_call, $.property_access],
+    [$.skill_declaration, $.pipe_expression, $.nil_coalescing_expression, $.binary_expression, $.method_call, $.property_access],
     [$.pipe_expression, $.binary_expression, $.unary_expression, $.method_call, $.property_access],
     [$.pipe_expression, $.binary_expression, $.method_call, $.property_access],
     [$.pipe_expression, $.nil_coalescing_expression, $.binary_expression, $.method_call, $.property_access],
     [$.pipe_expression, $.ternary_expression, $.binary_expression, $.method_call, $.property_access],
     [$.pipe_expression, $.range_expression, $.binary_expression, $.method_call, $.property_access],
+    [$.pipe_expression, $.nil_coalescing_expression, $.binary_expression, $.range_expression, $.method_call, $.property_access],
+    [$.pipe_expression, $.ternary_expression, $.nil_coalescing_expression, $.binary_expression, $.method_call, $.property_access],
+    [$.pipe_expression, $.nil_coalescing_expression, $.binary_expression, $.unary_expression, $.method_call, $.property_access],
   ],
 
   word: ($) => $.identifier,
@@ -564,14 +568,14 @@ module.exports = grammar({
       prec.right(2, seq($._expression, "?", $._expression, ":", $._expression)),
 
     nil_coalescing_expression: ($) =>
-      prec.left(3, seq($._expression, "??", $._expression)),
+      prec.left(3, seq($._expression, repeat($._newline), "??", repeat($._newline), $._expression)),
 
     binary_expression: ($) =>
       choice(
         prec.left(4, seq($._expression, repeat($._newline), "||", repeat($._newline), $._expression)),
         prec.left(5, seq($._expression, repeat($._newline), "&&", repeat($._newline), $._expression)),
-        prec.left(6, seq($._expression, choice("==", "!="), $._expression)),
-        prec.left(7, seq($._expression, choice("<", ">", "<=", ">="), $._expression)),
+        prec.left(6, seq($._expression, repeat($._newline), choice("==", "!="), repeat($._newline), $._expression)),
+        prec.left(7, seq($._expression, repeat($._newline), choice("<", ">", "<=", ">="), repeat($._newline), $._expression)),
         prec.left(7, seq($._expression, "in", $._expression)),
         prec.left(7, seq($._expression, "not", "in", $._expression)),
         prec.left(8, seq($._expression, repeat($._newline), "+", repeat($._newline), $._expression)),

--- a/tree-sitter-harn/src/grammar.json
+++ b/tree-sitter-harn/src/grammar.json
@@ -3844,8 +3844,22 @@
             "name": "_expression"
           },
           {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_newline"
+            }
+          },
+          {
             "type": "STRING",
             "value": "??"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_newline"
+            }
           },
           {
             "type": "SYMBOL",
@@ -3938,6 +3952,13 @@
                 "name": "_expression"
               },
               {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_newline"
+                }
+              },
+              {
                 "type": "CHOICE",
                 "members": [
                   {
@@ -3949,6 +3970,13 @@
                     "value": "!="
                   }
                 ]
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_newline"
+                }
               },
               {
                 "type": "SYMBOL",
@@ -3966,6 +3994,13 @@
               {
                 "type": "SYMBOL",
                 "name": "_expression"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_newline"
+                }
               },
               {
                 "type": "CHOICE",
@@ -3987,6 +4022,13 @@
                     "value": ">="
                   }
                 ]
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_newline"
+                }
               },
               {
                 "type": "SYMBOL",
@@ -7502,6 +7544,14 @@
       "property_access"
     ],
     [
+      "skill_declaration",
+      "pipe_expression",
+      "nil_coalescing_expression",
+      "binary_expression",
+      "method_call",
+      "property_access"
+    ],
+    [
       "pipe_expression",
       "binary_expression",
       "unary_expression",
@@ -7532,6 +7582,30 @@
       "pipe_expression",
       "range_expression",
       "binary_expression",
+      "method_call",
+      "property_access"
+    ],
+    [
+      "pipe_expression",
+      "nil_coalescing_expression",
+      "binary_expression",
+      "range_expression",
+      "method_call",
+      "property_access"
+    ],
+    [
+      "pipe_expression",
+      "ternary_expression",
+      "nil_coalescing_expression",
+      "binary_expression",
+      "method_call",
+      "property_access"
+    ],
+    [
+      "pipe_expression",
+      "nil_coalescing_expression",
+      "binary_expression",
+      "unary_expression",
       "method_call",
       "property_access"
     ]

--- a/tree-sitter-harn/src/scanner.c
+++ b/tree-sitter-harn/src/scanner.c
@@ -18,6 +18,10 @@ typedef struct {
 static bool is_ignored_separator_target(int32_t lookahead) {
   switch (lookahead) {
     case '.':
+    case '!':
+    case '=':
+    case '<':
+    case '>':
     case '|':
     case '&':
     case '+':

--- a/tree-sitter-harn/test/corpus/expressions.txt
+++ b/tree-sitter-harn/test/corpus/expressions.txt
@@ -55,3 +55,48 @@ pipeline test(task) {
         value: (binary_expression
           (identifier)
           (identifier))))))
+
+==================
+Line Leading Infix Operators
+==================
+
+pipeline test(task) {
+  let fallback = nil
+    ?? "fallback"
+  let same = 1
+    == 1
+  let different = 1
+    != 2
+  let larger = 2
+    >= 1
+}
+
+---
+
+(source_file
+  (pipeline_declaration
+    name: (identifier)
+    (parameter_list
+      (typed_parameter
+        name: (identifier)))
+    (block
+      (let_binding
+        name: (identifier)
+        value: (nil_coalescing_expression
+          (nil)
+          (string_literal)))
+      (let_binding
+        name: (identifier)
+        value: (binary_expression
+          (integer_literal)
+          (integer_literal)))
+      (let_binding
+        name: (identifier)
+        value: (binary_expression
+          (integer_literal)
+          (integer_literal)))
+      (let_binding
+        name: (identifier)
+        value: (binary_expression
+          (integer_literal)
+          (integer_literal))))))


### PR DESCRIPTION
## Summary
- Allow line-leading symbolic continuation operators for nil coalescing, equality, and comparisons.
- Update formatter wrapping so those operators no longer need backslash continuations.
- Sync spec/docs, conformance coverage, and tree-sitter grammar/scanner/generated parser support.

## Verification
- CARGO_TARGET_DIR=/tmp/harn-target-line-leading-operators cargo test -p harn-parser -p harn-fmt
- CARGO_TARGET_DIR=/tmp/harn-target-line-leading-operators cargo run --quiet --bin harn -- test conformance --filter multiline_continuation_operators
- CARGO_TARGET_DIR=/tmp/harn-target-line-leading-operators cargo run --quiet --bin harn -- fmt --check conformance/tests/language/multiline_continuation_operators.harn
- cd tree-sitter-harn && npm test
- git diff --check
- Pre-commit hook passed: cargo fmt, Harn fmt, clippy, highlight sync, markdown lint, actionlint, portal lint.
- Pre-push hook passed: nextest workspace run, Harn fmt, markdown lint, portal lint.

## Note
- make check-docs-snippets needs HARN_BIN when using an isolated CARGO_TARGET_DIR; with that set it still fails on existing docs snippets with undefined placeholder helpers/fragments unrelated to this parser change.