### PR TITLE
Implement A2A push notification connector

### DIFF
--- a/conformance/tests/agents/trigger_provider_catalog.harn
+++ b/conformance/tests/agents/trigger_provider_catalog.harn
@@ -3,7 +3,7 @@ import "std/triggers"
 pipeline test(task) {
   let providers: list<ProviderCatalogEntry> = list_providers()
   let builtin = providers.filter({ provider -> provider.runtime.kind == "builtin" })
-  assert(len(builtin) == 6, "expected exactly six builtin trigger providers")
+  assert(len(builtin) == 7, "expected exactly seven builtin trigger providers")
   let stream_providers = providers.filter({ provider -> provider.kinds.any({ kind -> kind == "stream" }) })
   assert(len(stream_providers) == 6, "expected six stream trigger providers")
   assert(
@@ -60,6 +60,22 @@ pipeline test(task) {
   let webhook_secret = webhook_secrets[0]
   assert(webhook_secret.name == "signing_secret", "webhook should require signing_secret")
   assert(webhook_secret.namespace == "webhook", "webhook secrets should stay namespaced to webhook")
+  let a2a_push = builtin.find({ provider -> provider.provider == "a2a-push" })
+  assert(a2a_push?.schema_name == "A2aPushPayload", "a2a-push schema should be cataloged")
+  assert(a2a_push?.runtime?.connector == "a2a-push", "a2a-push should use the a2a-push connector")
+  assert(
+    a2a_push?.signature_verification?.kind == "none",
+    "a2a-push should not require catalog-level signature verification",
+  )
+  assert(len(a2a_push?.secret_requirements ?? []) == 0, "a2a-push should not require catalog secrets")
+  assert(
+    len(a2a_push?.outbound_methods ?? []) == 0,
+    "a2a-push should not publish outbound methods yet",
+  )
+  assert(
+    (a2a_push?.kinds ?? []).any({ kind -> kind == "a2a-push" }),
+    "a2a-push should publish its trigger kind",
+  )
   let github = builtin.find({ provider -> provider.provider == "github" })
   assert(github?.schema_name == "GitHubEventPayload", "github schema should be cataloged")
   assert(

--- a/conformance/tests/triggers/trigger_a2a_push_completed.expected
+++ b/conformance/tests/triggers/trigger_a2a_push_completed.expected
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+true

--- a/conformance/tests/triggers/trigger_a2a_push_completed.harn
+++ b/conformance/tests/triggers/trigger_a2a_push_completed.harn
@@ -1,0 +1,8 @@
+pipeline test(task) {
+  let result = trigger_test_harness("a2a_push_completed")
+  println(result.ok)
+  println(result.emitted[0].provider == "a2a-push")
+  println(result.emitted[0].kind == "a2a.task.completed")
+  println(result.details.task_id == "task-123")
+  println(result.details.task_state == "completed")
+}

--- a/conformance/tests/triggers/trigger_a2a_push_rejects_replay.expected
+++ b/conformance/tests/triggers/trigger_a2a_push_rejects_replay.expected
@@ -1,0 +1,3 @@
+true
+true
+true

--- a/conformance/tests/triggers/trigger_a2a_push_rejects_replay.harn
+++ b/conformance/tests/triggers/trigger_a2a_push_rejects_replay.harn
@@ -1,0 +1,6 @@
+pipeline test(task) {
+  let result = trigger_test_harness("a2a_push_rejects_replay")
+  println(result.ok)
+  println(result.details.jti == "a2a-jti-replay")
+  println(result.details.replay_rejected)
+}

--- a/crates/harn-cli/src/a2a/card.rs
+++ b/crates/harn-cli/src/a2a/card.rs
@@ -18,7 +18,7 @@ pub(super) fn agent_card(pipeline_name: &str, port: u16) -> serde_json::Value {
         "securitySchemes": [],
         "capabilities": {
             "streaming": true,
-            "pushNotifications": false,
+            "pushNotifications": true,
             "extendedAgentCard": false
         },
         "skills": [

--- a/crates/harn-cli/src/a2a/rpc.rs
+++ b/crates/harn-cli/src/a2a/rpc.rs
@@ -2,8 +2,8 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use uuid::Uuid;
 
 use super::task::{
-    cancel_task, complete_task, create_task, fail_task, is_task_cancelled, list_tasks,
-    mark_task_working, TaskStore,
+    add_push_config, cancel_task, complete_task, create_task, delete_push_config, fail_task,
+    is_task_cancelled, list_tasks, mark_task_working, task_snapshot, TaskStore,
 };
 use super::{execute_pipeline, write_http_response, write_sse_event, write_sse_header};
 
@@ -116,10 +116,47 @@ pub(super) async fn handle_jsonrpc(pipeline_path: &str, body: &str, store: &Task
                     "Invalid params: no text part found in message",
                 )
             } else {
-                let task_id = create_task(store, &task_text, context_id);
+                let push_config = parsed
+                    .pointer("/params/configuration/pushNotificationConfig")
+                    .cloned();
+                let return_immediately = parsed
+                    .pointer("/params/configuration/returnImmediately")
+                    .and_then(serde_json::Value::as_bool)
+                    .or_else(|| {
+                        parsed
+                            .pointer("/params/configuration/blocking")
+                            .and_then(serde_json::Value::as_bool)
+                            .map(|blocking| !blocking)
+                    })
+                    .unwrap_or(false);
+                let task_id = create_task(store, &task_text, context_id, push_config);
                 mark_task_working(store, &task_id);
 
                 if is_task_cancelled(store, &task_id) {
+                    let task_json = store.lock().unwrap().get(&task_id).unwrap().to_json();
+                    task_rpc_response(&rpc_id, task_json)
+                } else if return_immediately {
+                    let pipeline = pipeline_path.to_string();
+                    let task_text = task_text.clone();
+                    let task_id_for_thread = task_id.clone();
+                    let store_for_thread = store.clone();
+                    std::thread::spawn(move || {
+                        let runtime = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .expect("build A2A background runtime");
+                        let result = runtime.block_on(execute_pipeline(&pipeline, &task_text));
+                        match result {
+                            Ok(output) => {
+                                if !is_task_cancelled(&store_for_thread, &task_id_for_thread) {
+                                    complete_task(&store_for_thread, &task_id_for_thread, &output);
+                                }
+                            }
+                            Err(error) => {
+                                fail_task(&store_for_thread, &task_id_for_thread, &error);
+                            }
+                        }
+                    });
                     let task_json = store.lock().unwrap().get(&task_id).unwrap().to_json();
                     task_rpc_response(&rpc_id, task_json)
                 } else {
@@ -142,6 +179,81 @@ pub(super) async fn handle_jsonrpc(pipeline_path: &str, body: &str, store: &Task
                         }
                     }
                 }
+            }
+        }
+        "CreateTaskPushNotificationConfig" | "tasks/pushNotificationConfig/set" => {
+            let task_id = parsed
+                .pointer("/params/taskId")
+                .or_else(|| parsed.pointer("/params/task_id"))
+                .or_else(|| parsed.pointer("/params/id"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let config = parsed
+                .pointer("/params/pushNotificationConfig")
+                .or_else(|| parsed.pointer("/params/config"))
+                .cloned()
+                .unwrap_or(serde_json::Value::Null);
+            if task_id.is_empty() || !config.is_object() {
+                error_response(
+                    &rpc_id,
+                    -32602,
+                    "Invalid params: missing taskId or pushNotificationConfig",
+                )
+            } else {
+                match add_push_config(store, task_id, config) {
+                    Ok(config) => task_rpc_response(&rpc_id, config),
+                    Err(msg) => error_response(&rpc_id, A2A_TASK_NOT_FOUND, &msg),
+                }
+            }
+        }
+        "GetTaskPushNotificationConfig" => {
+            let task_id = parsed
+                .pointer("/params/taskId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let config_id = parsed
+                .pointer("/params/id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let config = task_snapshot(store, task_id).and_then(|task| {
+                task.push_configs.into_iter().find(|config| {
+                    config.get("id").and_then(serde_json::Value::as_str) == Some(config_id)
+                })
+            });
+            match config {
+                Some(config) => task_rpc_response(&rpc_id, config),
+                None => error_response(
+                    &rpc_id,
+                    A2A_TASK_NOT_FOUND,
+                    "Push notification config not found",
+                ),
+            }
+        }
+        "ListTaskPushNotificationConfigs" => {
+            let task_id = parsed
+                .pointer("/params/taskId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            match task_snapshot(store, task_id) {
+                Some(task) => task_rpc_response(
+                    &rpc_id,
+                    serde_json::json!({"configs": task.push_configs, "nextPageToken": ""}),
+                ),
+                None => error_response(&rpc_id, A2A_TASK_NOT_FOUND, "Task not found"),
+            }
+        }
+        "DeleteTaskPushNotificationConfig" => {
+            let task_id = parsed
+                .pointer("/params/taskId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let config_id = parsed
+                .pointer("/params/id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            match delete_push_config(store, task_id, config_id) {
+                Ok(()) => task_rpc_response(&rpc_id, serde_json::json!({})),
+                Err(msg) => error_response(&rpc_id, A2A_TASK_NOT_FOUND, &msg),
             }
         }
         "a2a.GetTask" => {
@@ -348,7 +460,7 @@ pub(super) async fn handle_streaming_request(
         return;
     }
 
-    let task_id = create_task(store, &task_text, context_id);
+    let task_id = create_task(store, &task_text, context_id, None);
 
     if write_sse_header(stream).await.is_err() {
         return;

--- a/crates/harn-cli/src/a2a/task.rs
+++ b/crates/harn-cli/src/a2a/task.rs
@@ -102,6 +102,7 @@ pub(super) struct TaskState {
     pub(super) status: TaskStatus,
     pub(super) history: Vec<TaskMessage>,
     pub(super) artifacts: Vec<Artifact>,
+    pub(super) push_configs: Vec<serde_json::Value>,
 }
 
 impl TaskState {
@@ -152,6 +153,7 @@ pub(super) fn create_task(
     store: &TaskStore,
     task_text: &str,
     context_id: Option<String>,
+    push_config: Option<serde_json::Value>,
 ) -> String {
     let task_id = Uuid::now_v7().to_string();
     let message_id = Uuid::now_v7().to_string();
@@ -165,9 +167,84 @@ pub(super) fn create_task(
             parts: vec![serde_json::json!({"type": "text", "text": task_text})],
         }],
         artifacts: Vec::new(),
+        push_configs: push_config.into_iter().collect(),
     };
     store.lock().unwrap().insert(task_id.clone(), task);
     task_id
+}
+
+pub(super) fn add_push_config(
+    store: &TaskStore,
+    task_id: &str,
+    mut config: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let mut map = store.lock().unwrap();
+    let task = map
+        .get_mut(task_id)
+        .ok_or_else(|| format!("TaskNotFoundError: {task_id}"))?;
+    if config.get("id").and_then(|value| value.as_str()).is_none() {
+        config["id"] = serde_json::Value::String(Uuid::now_v7().to_string());
+    }
+    config["taskId"] = serde_json::Value::String(task_id.to_string());
+    task.push_configs.push(config.clone());
+    Ok(config)
+}
+
+pub(super) fn delete_push_config(
+    store: &TaskStore,
+    task_id: &str,
+    config_id: &str,
+) -> Result<(), String> {
+    let mut map = store.lock().unwrap();
+    let task = map
+        .get_mut(task_id)
+        .ok_or_else(|| format!("TaskNotFoundError: {task_id}"))?;
+    task.push_configs
+        .retain(|config| config.get("id").and_then(serde_json::Value::as_str) != Some(config_id));
+    Ok(())
+}
+
+pub(super) fn task_snapshot(store: &TaskStore, task_id: &str) -> Option<TaskState> {
+    store.lock().unwrap().get(task_id).cloned()
+}
+
+pub(super) fn deliver_push_notifications(task: &TaskState) {
+    if task.push_configs.is_empty() {
+        return;
+    }
+    let payload = serde_json::json!({
+        "statusUpdate": {
+            "taskId": task.id,
+            "contextId": task.context_id.clone().unwrap_or_default(),
+            "status": {"state": task.status.as_str()},
+            "metadata": {"timestamp": time::OffsetDateTime::now_utc().format(&time::format_description::well_known::Rfc3339).unwrap_or_default()},
+        }
+    });
+    let client = reqwest::blocking::Client::new();
+    for config in &task.push_configs {
+        let Some(url) = config.get("url").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let mut request = client
+            .post(url)
+            .header(reqwest::header::CONTENT_TYPE, "application/a2a+json")
+            .json(&payload);
+        if let Some(auth) = config.get("authentication") {
+            if let Some(scheme) = auth.get("scheme").and_then(serde_json::Value::as_str) {
+                let credentials = auth
+                    .get("credentials")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default();
+                if !credentials.is_empty() {
+                    request = request.header(
+                        reqwest::header::AUTHORIZATION,
+                        format!("{scheme} {credentials}"),
+                    );
+                }
+            }
+        }
+        let _ = request.send();
+    }
 }
 
 /// Transition a task to `working`.
@@ -197,6 +274,9 @@ pub(super) fn complete_task(store: &TaskStore, task_id: &str, output: &str) {
             parts: vec![serde_json::json!({"type": "text", "text": output.trim_end()})],
         });
     }
+    if let Some(task) = task_snapshot(store, task_id) {
+        deliver_push_notifications(&task);
+    }
 }
 
 /// Mark a task as failed with an error message.
@@ -209,6 +289,9 @@ pub(super) fn fail_task(store: &TaskStore, task_id: &str, error: &str) {
             role: "agent".to_string(),
             parts: vec![serde_json::json!({"type": "text", "text": error})],
         });
+    }
+    if let Some(task) = task_snapshot(store, task_id) {
+        deliver_push_notifications(&task);
     }
 }
 

--- a/crates/harn-cli/src/a2a/tests.rs
+++ b/crates/harn-cli/src/a2a/tests.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use super::card::{agent_card, pipeline_name_from_path};
 use super::http::{check_version_header, parse_http_request};
@@ -24,7 +27,7 @@ fn test_agent_card_v1_fields() {
     assert!(card["securitySchemes"].is_array());
     assert_eq!(card["securitySchemes"].as_array().unwrap().len(), 0);
     assert_eq!(card["capabilities"]["streaming"], true);
-    assert_eq!(card["capabilities"]["pushNotifications"], false);
+    assert_eq!(card["capabilities"]["pushNotifications"], true);
     assert_eq!(card["capabilities"]["extendedAgentCard"], false);
     // v0.3 fields should not be present
     assert!(card.get("defaultInputModes").is_none());
@@ -63,7 +66,7 @@ fn test_task_status_terminal() {
 #[test]
 fn test_create_task_generates_uuid() {
     let store: TaskStore = Arc::new(Mutex::new(HashMap::new()));
-    let id = create_task(&store, "hello", None);
+    let id = create_task(&store, "hello", None, None);
     // UUID v7 format: 8-4-4-4-12 hex chars
     assert_eq!(id.len(), 36);
     assert!(id.contains('-'));
@@ -81,7 +84,7 @@ fn test_create_task_generates_uuid() {
 #[test]
 fn test_create_task_with_context_id() {
     let store: TaskStore = Arc::new(Mutex::new(HashMap::new()));
-    let id = create_task(&store, "hello", Some("ctx-123".to_string()));
+    let id = create_task(&store, "hello", Some("ctx-123".to_string()), None);
     let map = store.lock().unwrap();
     let task = map.get(&id).unwrap();
     assert_eq!(task.context_id, Some("ctx-123".to_string()));
@@ -95,6 +98,7 @@ fn test_task_to_json_includes_context_id() {
         status: TaskStatus::Submitted,
         history: vec![],
         artifacts: vec![],
+        push_configs: vec![],
     };
     let json = task.to_json();
     assert_eq!(json["contextId"], "ctx-abc");
@@ -108,6 +112,7 @@ fn test_task_to_json_without_context_id() {
         status: TaskStatus::Submitted,
         history: vec![],
         artifacts: vec![],
+        push_configs: vec![],
     };
     let json = task.to_json();
     assert!(json.get("contextId").is_none());
@@ -125,6 +130,7 @@ fn test_task_message_includes_id() {
             parts: vec![serde_json::json!({"type": "text", "text": "hi"})],
         }],
         artifacts: vec![],
+        push_configs: vec![],
     };
     let json = task.to_json();
     assert_eq!(json["history"][0]["id"], "msg-abc");
@@ -178,6 +184,7 @@ fn test_task_to_json_includes_artifacts() {
             mime_type: None,
             parts: vec![serde_json::json!({"type": "text", "text": "output"})],
         }],
+        push_configs: vec![],
     };
     let json = task.to_json();
     assert_eq!(json["artifacts"][0]["id"], "art-1");
@@ -187,7 +194,7 @@ fn test_task_to_json_includes_artifacts() {
 #[test]
 fn test_cancel_task_success() {
     let store: TaskStore = Arc::new(Mutex::new(HashMap::new()));
-    let id = create_task(&store, "hello", None);
+    let id = create_task(&store, "hello", None, None);
     mark_task_working(&store, &id);
     let result = cancel_task(&store, &id);
     assert!(result.is_ok());
@@ -198,7 +205,7 @@ fn test_cancel_task_success() {
 #[test]
 fn test_cancel_task_terminal_fails() {
     let store: TaskStore = Arc::new(Mutex::new(HashMap::new()));
-    let id = create_task(&store, "hello", None);
+    let id = create_task(&store, "hello", None, None);
     complete_task(&store, &id, "done");
     let result = cancel_task(&store, &id);
     assert!(result.is_err());
@@ -224,8 +231,8 @@ fn test_list_tasks_empty() {
 #[test]
 fn test_list_tasks_returns_summaries() {
     let store: TaskStore = Arc::new(Mutex::new(HashMap::new()));
-    create_task(&store, "task1", Some("ctx-1".to_string()));
-    create_task(&store, "task2", None);
+    create_task(&store, "task1", Some("ctx-1".to_string()), None);
+    create_task(&store, "task2", None, None);
     let result = list_tasks(&store, None, None);
     let tasks = result["tasks"].as_array().unwrap();
     assert_eq!(tasks.len(), 2);
@@ -242,7 +249,7 @@ fn test_list_tasks_pagination() {
     let store: TaskStore = Arc::new(Mutex::new(HashMap::new()));
     let mut ids = Vec::new();
     for i in 0..5 {
-        ids.push(create_task(&store, &format!("task{i}"), None));
+        ids.push(create_task(&store, &format!("task{i}"), None, None));
     }
     // Get first 2
     let result = list_tasks(&store, None, Some(2));
@@ -264,6 +271,7 @@ fn test_task_summary_json() {
             parts: vec![serde_json::json!({"type": "text", "text": "hello"})],
         }],
         artifacts: vec![],
+        push_configs: vec![],
     };
     let summary = task.to_summary_json();
     assert_eq!(summary["id"], "task-1");
@@ -414,8 +422,8 @@ async fn test_handle_jsonrpc_get_task_not_found() {
 #[tokio::test]
 async fn test_handle_jsonrpc_list_tasks() {
     let store: TaskStore = Arc::new(Mutex::new(HashMap::new()));
-    create_task(&store, "test1", None);
-    create_task(&store, "test2", Some("ctx".to_string()));
+    create_task(&store, "test1", None, None);
+    create_task(&store, "test2", Some("ctx".to_string()), None);
     let body = r#"{"jsonrpc":"2.0","id":1,"method":"a2a.ListTasks","params":{}}"#;
     let resp = handle_jsonrpc("/nonexistent.harn", body, &store).await;
     let parsed: serde_json::Value = serde_json::from_str(&resp).unwrap();
@@ -432,6 +440,91 @@ async fn test_handle_jsonrpc_send_message_empty() {
     let resp = handle_jsonrpc("/nonexistent.harn", body, &store).await;
     let parsed: serde_json::Value = serde_json::from_str(&resp).unwrap();
     assert_eq!(parsed["error"]["code"], -32602);
+}
+
+#[tokio::test]
+async fn test_handle_jsonrpc_async_push_notification_loop() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(false).unwrap();
+    let addr = listener.local_addr().unwrap();
+    let capture = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let mut request = Vec::new();
+        let mut buf = [0u8; 512];
+        loop {
+            let read = stream.read(&mut buf).unwrap_or(0);
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&buf[..read]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let text = String::from_utf8_lossy(&request);
+                let content_length = text
+                    .lines()
+                    .find_map(|line| {
+                        line.to_ascii_lowercase()
+                            .strip_prefix("content-length:")
+                            .and_then(|value| value.trim().parse::<usize>().ok())
+                    })
+                    .unwrap_or(0);
+                let header_end = request
+                    .windows(4)
+                    .position(|window| window == b"\r\n\r\n")
+                    .map(|pos| pos + 4)
+                    .unwrap();
+                if request.len() >= header_end + content_length {
+                    break;
+                }
+            }
+        }
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+            .unwrap();
+        String::from_utf8(request).unwrap()
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let pipeline = dir.path().join("server.harn");
+    std::fs::write(&pipeline, "pipeline default() {}\n").unwrap();
+    let store: TaskStore = Arc::new(Mutex::new(HashMap::new()));
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "a2a.SendMessage",
+        "params": {
+            "contextId": "ctx-push",
+            "message": {
+                "parts": [{"type": "text", "text": "run async"}]
+            },
+            "configuration": {
+                "returnImmediately": true,
+                "pushNotificationConfig": {
+                    "url": format!("http://{addr}/a2a/push"),
+                    "authentication": {
+                        "scheme": "Bearer",
+                        "credentials": "push-token"
+                    }
+                }
+            }
+        }
+    });
+    let resp = handle_jsonrpc(
+        pipeline.to_str().unwrap(),
+        &serde_json::to_string(&request).unwrap(),
+        &store,
+    )
+    .await;
+    let parsed: serde_json::Value = serde_json::from_str(&resp).unwrap();
+    assert_eq!(parsed["result"]["status"]["state"], "working");
+
+    let captured = capture.join().unwrap();
+    assert!(captured.starts_with("POST /a2a/push HTTP/1.1"));
+    assert!(captured.contains("authorization: Bearer push-token"));
+    assert!(captured.contains(r#""status":{"state":"completed"}"#));
+    assert!(captured.contains(r#""taskId":"#));
 }
 
 #[tokio::test]

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -217,6 +217,7 @@ pub(crate) struct RouteConfig {
     pub(crate) signing_secret: Option<SecretId>,
     pub(crate) dedupe_key_template: Option<String>,
     pub(crate) dedupe_retention_days: u32,
+    pub(crate) connector_ingress: bool,
     pub(crate) connector: Option<harn_vm::connectors::ConnectorHandle>,
 }
 
@@ -270,24 +271,57 @@ impl RouteConfig {
                     ),
                     dedupe_key_template: trigger.config.dedupe_key.clone(),
                     dedupe_retention_days: trigger.config.retry.retention_days,
+                    connector_ingress: false,
                     connector: None,
                 }))
             }
-            TriggerKind::A2aPush => Ok(Some(Self {
-                trigger_id: trigger.config.id.clone(),
-                binding_version,
-                provider: harn_vm::ProviderId::from("a2a-push"),
-                path: trigger_path(trigger)?,
-                auth_mode: AuthMode::BearerOrHmac,
-                signature_mode: SignatureMode::Unsigned,
-                signing_secret: None,
-                dedupe_key_template: trigger.config.dedupe_key.clone(),
-                dedupe_retention_days: trigger.config.retry.retention_days,
-                connector: None,
-            })),
+            TriggerKind::A2aPush => {
+                let connector_ingress = a2a_push_connector_configured(trigger);
+                Ok(Some(Self {
+                    trigger_id: trigger.config.id.clone(),
+                    binding_version,
+                    provider: harn_vm::ProviderId::from("a2a-push"),
+                    path: trigger_path(trigger)?,
+                    auth_mode: if connector_ingress {
+                        AuthMode::Public
+                    } else {
+                        AuthMode::BearerOrHmac
+                    },
+                    signature_mode: SignatureMode::Unsigned,
+                    signing_secret: None,
+                    dedupe_key_template: trigger.config.dedupe_key.clone(),
+                    dedupe_retention_days: trigger.config.retry.retention_days,
+                    connector_ingress,
+                    connector: None,
+                }))
+            }
             _ => Ok(None),
         }
     }
+}
+
+fn a2a_push_connector_configured(trigger: &CollectedManifestTrigger) -> bool {
+    if !matches!(trigger.config.kind, TriggerKind::A2aPush) {
+        return false;
+    }
+    let config = &trigger.config.kind_specific;
+    if config
+        .get("a2a_push")
+        .and_then(toml::Value::as_table)
+        .is_some_and(|table| !table.is_empty())
+    {
+        return true;
+    }
+    [
+        "expected_iss",
+        "expected_aud",
+        "jwks_url",
+        "auth_scheme",
+        "expected_token",
+        "token",
+    ]
+    .iter()
+    .any(|field| config.contains_key(*field))
 }
 
 #[derive(Clone)]
@@ -1402,6 +1436,7 @@ mod tests {
             signing_secret: None,
             dedupe_key_template: None,
             dedupe_retention_days: harn_vm::DEFAULT_INBOX_RETENTION_DAYS,
+            connector_ingress: false,
             connector: None,
         }
     }
@@ -1462,6 +1497,7 @@ mod tests {
             signing_secret: Some(SecretId::new("github", "test-signing-secret")),
             dedupe_key_template: Some("event.dedupe_key".to_string()),
             dedupe_retention_days: harn_vm::DEFAULT_INBOX_RETENTION_DAYS,
+            connector_ingress: false,
             connector: None,
         }
     }

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -501,10 +501,31 @@ fn connector_binding_config(config: &ResolvedTriggerConfig) -> Result<JsonValue,
             "stream": config.kind_specific,
             "window": config.window,
         })),
+        crate::package::TriggerKind::A2aPush => Ok(serde_json::json!({
+            "match": config.match_,
+            "secrets": config.secrets,
+            "a2a_push": a2a_push_connector_config(&config.kind_specific)?,
+        })),
         _ => Ok(JsonValue::Null),
     }
     // Dedupe retention lives on the connector TriggerBinding rather than in
     // connector-specific JSON, so no retention_days insertion is needed here.
+}
+
+fn a2a_push_connector_config(
+    kind_specific: &BTreeMap<String, toml::Value>,
+) -> Result<JsonValue, String> {
+    if let Some(nested) = kind_specific.get("a2a_push") {
+        return serde_json::to_value(nested)
+            .map_err(|error| format!("failed to encode a2a_push trigger config: {error}"));
+    }
+    let filtered = kind_specific
+        .iter()
+        .filter(|(key, _)| key.as_str() != "path")
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect::<BTreeMap<_, _>>();
+    serde_json::to_value(filtered)
+        .map_err(|error| format!("failed to encode a2a_push trigger config: {error}"))
 }
 
 fn connector_for(
@@ -586,7 +607,9 @@ fn attach_route_connectors(
             // HTTP listener path. Webhook/github routes stay on the
             // signature-based `normalize_request` flow in the listener so
             // their existing Option-2 post-processing dedupe keeps working.
-            if connector_owns_ingress(route.provider.as_str(), provider_overrides) {
+            if route.connector_ingress
+                || connector_owns_ingress(route.provider.as_str(), provider_overrides)
+            {
                 route.connector = Some(registry.get(&route.provider).ok_or_else(|| {
                     format!(
                         "connector registry is missing provider '{}'",

--- a/crates/harn-modules/src/stdlib/stdlib_triggers.harn
+++ b/crates/harn-modules/src/stdlib/stdlib_triggers.harn
@@ -128,7 +128,7 @@ type CronEventPayload = {provider: "cron", cron_id: string | nil, schedule: stri
 
 type GenericWebhookPayload = {provider: "webhook", source: string | nil, content_type: string | nil, raw: dict}
 
-type A2aPushPayload = {provider: "a2a-push", task_id: string | nil, sender: string | nil, raw: dict}
+type A2aPushPayload = {provider: "a2a-push", task_id: string | nil, task_state: string | nil, artifact: any | nil, sender: string | nil, raw: dict, kind: string}
 
 type StreamEventPayload = {provider: "kafka" | "nats" | "pulsar" | "postgres-cdc" | "email" | "websocket", event: string, source: string | nil, stream: string | nil, partition: string | nil, offset: string | nil, key: string | nil, timestamp: string | nil, headers: dict, raw: dict}
 

--- a/crates/harn-vm/src/a2a/mod.rs
+++ b/crates/harn-vm/src/a2a/mod.rs
@@ -8,6 +8,8 @@ use crate::triggers::TriggerEvent;
 
 const A2A_AGENT_CARD_PATH: &str = ".well-known/a2a-agent";
 const A2A_PROTOCOL_VERSION: &str = "1.0.0";
+const A2A_PUSH_URL_ENV: &str = "HARN_A2A_PUSH_URL";
+const A2A_PUSH_TOKEN_ENV: &str = "HARN_A2A_PUSH_TOKEN";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolvedA2aEndpoint {
@@ -94,29 +96,34 @@ pub async fn dispatch_trigger_event(
     });
     let text = serde_json::to_string(&envelope)
         .map_err(|error| A2aClientError::Protocol(format!("serialize A2A envelope: {error}")))?;
-    let request = crate::jsonrpc::request(
-        message_id.clone(),
-        "a2a.SendMessage",
-        serde_json::json!({
-            "contextId": event.trace_id.0,
-            "message": {
-                "messageId": message_id,
-                "role": "user",
-                "parts": [{
-                    "type": "text",
-                    "text": text,
-                }],
-                "metadata": {
-                    "kind": "harn.trigger.dispatch",
-                    "trace_id": event.trace_id.0,
-                    "event_id": event.id.0,
-                    "trigger_id": binding_id,
-                    "binding_key": binding_key,
-                    "target_agent": endpoint.target_agent,
-                },
+    let push_config = push_notification_config();
+    let mut params = serde_json::json!({
+        "contextId": event.trace_id.0,
+        "message": {
+            "messageId": message_id,
+            "role": "user",
+            "parts": [{
+                "type": "text",
+                "text": text,
+            }],
+            "metadata": {
+                "kind": "harn.trigger.dispatch",
+                "trace_id": event.trace_id.0,
+                "event_id": event.id.0,
+                "trigger_id": binding_id,
+                "binding_key": binding_key,
+                "target_agent": endpoint.target_agent,
             },
-        }),
-    );
+        },
+    });
+    if let Some(config) = push_config.clone() {
+        params["configuration"] = serde_json::json!({
+            "blocking": false,
+            "returnImmediately": true,
+            "pushNotificationConfig": config,
+        });
+    }
+    let request = crate::jsonrpc::request(message_id.clone(), "a2a.SendMessage", params);
 
     let body = match send_jsonrpc(&endpoint.rpc_url, &request, &event.trace_id.0, cancel_rx).await {
         Ok(body) => body,
@@ -175,6 +182,19 @@ pub async fn dispatch_trigger_event(
         ));
     }
 
+    if let Some(config) = push_config {
+        register_push_notification_config(
+            &endpoint.rpc_url,
+            &task_id,
+            config,
+            &event.trace_id.0,
+            cancel_rx,
+        )
+        .await
+        .inspect_err(|_| {
+            record_a2a_metric(raw_target, "failed", started.elapsed());
+        })?;
+    }
     record_a2a_metric(raw_target, "succeeded", started.elapsed());
     Ok((
         endpoint.clone(),
@@ -192,6 +212,51 @@ pub async fn dispatch_trigger_event(
             }),
         },
     ))
+}
+
+fn push_notification_config() -> Option<Value> {
+    let url = std::env::var(A2A_PUSH_URL_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())?;
+    let token = std::env::var(A2A_PUSH_TOKEN_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let mut config = serde_json::json!({ "url": url });
+    if let Some(token) = token {
+        config["token"] = Value::String(token.clone());
+        config["authentication"] = serde_json::json!({
+            "scheme": "Bearer",
+            "credentials": token,
+        });
+    }
+    Some(config)
+}
+
+async fn register_push_notification_config(
+    rpc_url: &str,
+    task_id: &str,
+    config: Value,
+    trace_id: &str,
+    cancel_rx: &mut broadcast::Receiver<()>,
+) -> Result<(), A2aClientError> {
+    let request = crate::jsonrpc::request(
+        format!("{trace_id}.{task_id}.push-config"),
+        "CreateTaskPushNotificationConfig",
+        serde_json::json!({
+            "taskId": task_id,
+            "pushNotificationConfig": config,
+        }),
+    );
+    let response = send_jsonrpc(rpc_url, &request, trace_id, cancel_rx).await?;
+    if response.get("error").is_some() {
+        return Err(A2aClientError::Protocol(format!(
+            "A2A push notification registration failed: {}",
+            response["error"]
+        )));
+    }
+    Ok(())
 }
 
 fn record_a2a_metric(target: &str, outcome: &str, duration: std::time::Duration) {

--- a/crates/harn-vm/src/connectors/a2a_push/mod.rs
+++ b/crates/harn-vm/src/connectors/a2a_push/mod.rs
@@ -1,0 +1,789 @@
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration as StdDuration, Instant};
+
+use async_trait::async_trait;
+use jsonwebtoken::jwk::JwkSet;
+use jsonwebtoken::{decode, decode_header, DecodingKey, Validation};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use time::OffsetDateTime;
+
+use crate::connectors::{
+    ActivationHandle, ClientError, Connector, ConnectorClient, ConnectorCtx, ConnectorError,
+    ProviderPayloadSchema, RawInbound, TriggerBinding, TriggerKind,
+};
+use crate::triggers::event::KnownProviderPayload;
+use crate::triggers::{
+    redact_headers, A2aPushPayload, HeaderRedactionPolicy, ProviderId, ProviderPayload,
+    SignatureStatus, TraceId, TriggerEvent, TriggerEventId,
+};
+
+const PROVIDER_ID: &str = "a2a-push";
+const JWKS_REFRESH: StdDuration = StdDuration::from_secs(24 * 60 * 60);
+
+pub struct A2aPushConnector {
+    provider_id: ProviderId,
+    kinds: Vec<TriggerKind>,
+    client: Arc<A2aPushClient>,
+    state: RwLock<A2aPushState>,
+    http: reqwest::Client,
+}
+
+#[derive(Default)]
+struct A2aPushState {
+    ctx: Option<ConnectorCtx>,
+    bindings: HashMap<String, ActivatedA2aPushBinding>,
+}
+
+#[derive(Clone, Debug)]
+struct ActivatedA2aPushBinding {
+    binding_id: String,
+    expected_iss: Option<String>,
+    expected_aud: Option<String>,
+    expected_token: Option<String>,
+    jwks_url: Option<String>,
+    inline_jwks: Option<JwkSet>,
+    auth_scheme: A2aPushAuthScheme,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum A2aPushAuthScheme {
+    #[default]
+    Jwt,
+    BearerToken,
+    Unsigned,
+}
+
+#[derive(Default)]
+struct A2aPushClient;
+
+#[derive(Clone, Debug)]
+struct CachedJwks {
+    fetched_at: Instant,
+    jwks: JwkSet,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct A2aPushJwtClaims {
+    iss: String,
+    aud: AudienceClaim,
+    iat: i64,
+    exp: i64,
+    jti: String,
+    #[serde(default, rename = "taskId")]
+    task_id_camel: Option<String>,
+    #[serde(default)]
+    task_id: Option<String>,
+    #[serde(default)]
+    token: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+enum AudienceClaim {
+    One(String),
+    Many(Vec<String>),
+}
+
+#[async_trait]
+impl ConnectorClient for A2aPushClient {
+    async fn call(&self, method: &str, _args: JsonValue) -> Result<JsonValue, ClientError> {
+        Err(ClientError::MethodNotFound(format!(
+            "a2a-push connector has no outbound method `{method}`"
+        )))
+    }
+}
+
+impl A2aPushConnector {
+    pub fn new() -> Self {
+        Self {
+            provider_id: ProviderId::from(PROVIDER_ID),
+            kinds: vec![TriggerKind::from(PROVIDER_ID)],
+            client: Arc::new(A2aPushClient),
+            state: RwLock::new(A2aPushState::default()),
+            http: reqwest::Client::new(),
+        }
+    }
+
+    fn ctx(&self) -> Result<ConnectorCtx, ConnectorError> {
+        self.state
+            .read()
+            .expect("a2a-push connector state poisoned")
+            .ctx
+            .clone()
+            .ok_or_else(|| {
+                ConnectorError::Activation(
+                    "a2a-push connector must be initialized before use".to_string(),
+                )
+            })
+    }
+
+    fn binding_for_raw(&self, raw: &RawInbound) -> Result<ActivatedA2aPushBinding, ConnectorError> {
+        let state = self
+            .state
+            .read()
+            .expect("a2a-push connector state poisoned");
+        if let Some(binding_id) = raw.metadata.get("binding_id").and_then(JsonValue::as_str) {
+            return state.bindings.get(binding_id).cloned().ok_or_else(|| {
+                ConnectorError::Unsupported(format!(
+                    "a2a-push connector has no active binding `{binding_id}`"
+                ))
+            });
+        }
+        if state.bindings.len() == 1 {
+            return Ok(state
+                .bindings
+                .values()
+                .next()
+                .cloned()
+                .expect("checked single binding"));
+        }
+        Err(ConnectorError::Unsupported(
+            "a2a-push connector requires raw.metadata.binding_id when multiple bindings are active"
+                .to_string(),
+        ))
+    }
+
+    async fn verify(
+        &self,
+        ctx: &ConnectorCtx,
+        binding: &ActivatedA2aPushBinding,
+        raw: &RawInbound,
+        body: &JsonValue,
+    ) -> Result<(SignatureStatus, Option<A2aPushJwtClaims>, String), ConnectorError> {
+        match binding.auth_scheme {
+            A2aPushAuthScheme::Unsigned => Ok((
+                SignatureStatus::Unsigned,
+                None,
+                fallback_dedupe_key(&raw.body),
+            )),
+            A2aPushAuthScheme::BearerToken => {
+                let token = bearer_token(&raw.headers)?;
+                let expected = binding.expected_token.as_deref().ok_or_else(|| {
+                    ConnectorError::Activation(format!(
+                        "a2a-push binding `{}` requires token for bearer auth",
+                        binding.binding_id
+                    ))
+                })?;
+                if token != expected {
+                    return Err(ConnectorError::invalid_signature(
+                        "a2a-push bearer token did not match expected token",
+                    ));
+                }
+                Ok((
+                    SignatureStatus::Verified,
+                    None,
+                    fallback_dedupe_key(&raw.body),
+                ))
+            }
+            A2aPushAuthScheme::Jwt => {
+                let jwt = bearer_token(&raw.headers)?;
+                let claims = self.verify_jwt(binding, jwt).await?;
+                if let Some(expected_token) = binding.expected_token.as_deref() {
+                    let observed = claims
+                        .token
+                        .as_deref()
+                        .or_else(|| header_value(&raw.headers, "x-a2a-token"))
+                        .or_else(|| body.get("token").and_then(JsonValue::as_str));
+                    if observed != Some(expected_token) {
+                        return Err(ConnectorError::invalid_signature(
+                            "a2a-push JWT token claim/header did not match expected token",
+                        ));
+                    }
+                }
+                let now = OffsetDateTime::now_utc().unix_timestamp();
+                if claims.exp <= now {
+                    return Err(ConnectorError::invalid_signature(
+                        "a2a-push JWT exp is not in the future",
+                    ));
+                }
+                if claims.iat > now + 60 {
+                    return Err(ConnectorError::invalid_signature(
+                        "a2a-push JWT iat is in the future",
+                    ));
+                }
+                let ttl = StdDuration::from_secs((claims.exp - now).max(1) as u64);
+                if !ctx
+                    .inbox
+                    .insert_if_new(&binding.binding_id, &claims.jti, ttl)
+                    .await?
+                {
+                    return Err(ConnectorError::DuplicateDelivery(format!(
+                        "a2a-push JWT jti `{}` has already been accepted",
+                        claims.jti
+                    )));
+                }
+                Ok((SignatureStatus::Verified, Some(claims.clone()), claims.jti))
+            }
+        }
+    }
+
+    async fn verify_jwt(
+        &self,
+        binding: &ActivatedA2aPushBinding,
+        token: &str,
+    ) -> Result<A2aPushJwtClaims, ConnectorError> {
+        let header = decode_header(token)
+            .map_err(|error| ConnectorError::invalid_signature(error.to_string()))?;
+        let jwks = self.jwks(binding).await?;
+        let jwk = match header.kid.as_deref() {
+            Some(kid) => jwks.find(kid).ok_or_else(|| {
+                ConnectorError::invalid_signature(format!(
+                    "a2a-push JWT kid `{kid}` was not found in JWKS"
+                ))
+            })?,
+            None if jwks.keys.len() == 1 => &jwks.keys[0],
+            None => {
+                return Err(ConnectorError::invalid_signature(
+                    "a2a-push JWT missing kid and JWKS contains multiple keys",
+                ))
+            }
+        };
+        let key = DecodingKey::from_jwk(jwk)
+            .map_err(|error| ConnectorError::invalid_signature(error.to_string()))?;
+        let mut validation = Validation::new(header.alg);
+        validation.set_required_spec_claims(&["exp", "iss", "aud"]);
+        validation.set_issuer(&[required(binding.expected_iss.as_deref(), "expected_iss")?]);
+        validation.set_audience(&[required(binding.expected_aud.as_deref(), "expected_aud")?]);
+        let token = decode::<A2aPushJwtClaims>(token, &key, &validation)
+            .map_err(|error| ConnectorError::invalid_signature(error.to_string()))?;
+        if token.claims.jti.trim().is_empty() {
+            return Err(ConnectorError::invalid_signature(
+                "a2a-push JWT missing jti",
+            ));
+        }
+        Ok(token.claims)
+    }
+
+    async fn jwks(&self, binding: &ActivatedA2aPushBinding) -> Result<JwkSet, ConnectorError> {
+        if let Some(jwks) = &binding.inline_jwks {
+            return Ok(jwks.clone());
+        }
+        let Some(jwks_url) = binding.jwks_url.as_deref() else {
+            return Err(ConnectorError::Activation(format!(
+                "a2a-push binding `{}` requires jwks_url for JWT auth",
+                binding.binding_id
+            )));
+        };
+        if let Some(cached) = cached_jwks(jwks_url) {
+            return Ok(cached);
+        }
+        let jwks = self
+            .http
+            .get(jwks_url)
+            .send()
+            .await
+            .map_err(|error| ConnectorError::Activation(format!("fetch JWKS: {error}")))?
+            .error_for_status()
+            .map_err(|error| ConnectorError::Activation(format!("fetch JWKS: {error}")))?
+            .json::<JwkSet>()
+            .await
+            .map_err(|error| ConnectorError::Activation(format!("decode JWKS: {error}")))?;
+        store_cached_jwks(jwks_url, jwks.clone());
+        Ok(jwks)
+    }
+}
+
+impl Default for A2aPushConnector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Connector for A2aPushConnector {
+    fn provider_id(&self) -> &ProviderId {
+        &self.provider_id
+    }
+
+    fn kinds(&self) -> &[TriggerKind] {
+        &self.kinds
+    }
+
+    async fn init(&mut self, ctx: ConnectorCtx) -> Result<(), ConnectorError> {
+        self.state
+            .write()
+            .expect("a2a-push connector state poisoned")
+            .ctx = Some(ctx);
+        Ok(())
+    }
+
+    async fn activate(
+        &self,
+        bindings: &[TriggerBinding],
+    ) -> Result<ActivationHandle, ConnectorError> {
+        let mut configured = HashMap::new();
+        for binding in bindings {
+            configured.insert(
+                binding.binding_id.clone(),
+                ActivatedA2aPushBinding::from_binding(binding)?,
+            );
+        }
+        self.state
+            .write()
+            .expect("a2a-push connector state poisoned")
+            .bindings = configured;
+        Ok(ActivationHandle::new(
+            self.provider_id.clone(),
+            bindings.len(),
+        ))
+    }
+
+    async fn normalize_inbound(&self, raw: RawInbound) -> Result<TriggerEvent, ConnectorError> {
+        let ctx = self.ctx()?;
+        let binding = self.binding_for_raw(&raw)?;
+        let body = raw.json_body()?;
+        let (signature_status, claims, dedupe_key) =
+            self.verify(&ctx, &binding, &raw, &body).await?;
+        let normalized = normalize_a2a_push(&body, claims.as_ref());
+        let kind = normalized.kind.clone();
+        let mut event = TriggerEvent {
+            id: TriggerEventId::new(),
+            provider: self.provider_id.clone(),
+            kind,
+            received_at: raw.received_at,
+            occurred_at: raw.occurred_at.or_else(|| infer_occurred_at(&body)),
+            dedupe_key,
+            trace_id: TraceId::new(),
+            tenant_id: raw.tenant_id.clone(),
+            headers: redact_headers(&raw.headers, &HeaderRedactionPolicy::default()),
+            batch: None,
+            raw_body: Some(raw.body.clone()),
+            provider_payload: ProviderPayload::Known(KnownProviderPayload::A2aPush(normalized)),
+            signature_status,
+            dedupe_claimed: false,
+        };
+        if claims.is_some() {
+            event.mark_dedupe_claimed();
+        }
+        Ok(event)
+    }
+
+    fn payload_schema(&self) -> ProviderPayloadSchema {
+        ProviderPayloadSchema::named("A2aPushPayload")
+    }
+
+    fn client(&self) -> Arc<dyn ConnectorClient> {
+        self.client.clone()
+    }
+}
+
+impl ActivatedA2aPushBinding {
+    fn from_binding(binding: &TriggerBinding) -> Result<Self, ConnectorError> {
+        let config: A2aPushBindingConfig =
+            serde_json::from_value(binding.config.clone()).map_err(|error| {
+                ConnectorError::Activation(format!(
+                    "a2a-push binding `{}` has invalid config: {error}",
+                    binding.binding_id
+                ))
+            })?;
+        let push = config.a2a_push;
+        let auth_scheme = if push.auth_scheme.is_none() && push.is_empty() {
+            A2aPushAuthScheme::Unsigned
+        } else {
+            A2aPushAuthScheme::parse(push.auth_scheme.as_deref())?
+        };
+        let expected_token = push.expected_token.or(push.token);
+        if auth_scheme == A2aPushAuthScheme::Jwt {
+            if push.expected_iss.as_deref().is_none_or(str::is_empty) {
+                return Err(ConnectorError::Activation(format!(
+                    "a2a-push binding `{}` requires a2a_push.expected_iss for JWT auth",
+                    binding.binding_id
+                )));
+            }
+            if push.expected_aud.as_deref().is_none_or(str::is_empty) {
+                return Err(ConnectorError::Activation(format!(
+                    "a2a-push binding `{}` requires a2a_push.expected_aud for JWT auth",
+                    binding.binding_id
+                )));
+            }
+            if push.jwks_url.as_deref().is_none_or(str::is_empty) && push.inline_jwks.is_none() {
+                return Err(ConnectorError::Activation(format!(
+                    "a2a-push binding `{}` requires a2a_push.jwks_url for JWT auth",
+                    binding.binding_id
+                )));
+            }
+        }
+        if auth_scheme == A2aPushAuthScheme::BearerToken && expected_token.is_none() {
+            return Err(ConnectorError::Activation(format!(
+                "a2a-push binding `{}` requires a2a_push.expected_token for bearer-token auth",
+                binding.binding_id
+            )));
+        }
+        Ok(Self {
+            binding_id: binding.binding_id.clone(),
+            expected_iss: push.expected_iss,
+            expected_aud: push.expected_aud.or(push.audience),
+            expected_token,
+            jwks_url: push.jwks_url,
+            inline_jwks: push.inline_jwks,
+            auth_scheme,
+        })
+    }
+}
+
+#[derive(Default, Deserialize)]
+struct A2aPushBindingConfig {
+    #[serde(default)]
+    a2a_push: A2aPushConfig,
+}
+
+#[derive(Default, Deserialize)]
+struct A2aPushConfig {
+    expected_iss: Option<String>,
+    expected_aud: Option<String>,
+    audience: Option<String>,
+    jwks_url: Option<String>,
+    inline_jwks: Option<JwkSet>,
+    auth_scheme: Option<String>,
+    expected_token: Option<String>,
+    token: Option<String>,
+}
+
+impl A2aPushConfig {
+    fn is_empty(&self) -> bool {
+        self.expected_iss.is_none()
+            && self.expected_aud.is_none()
+            && self.audience.is_none()
+            && self.jwks_url.is_none()
+            && self.inline_jwks.is_none()
+            && self.expected_token.is_none()
+            && self.token.is_none()
+    }
+}
+
+impl A2aPushAuthScheme {
+    fn parse(raw: Option<&str>) -> Result<Self, ConnectorError> {
+        match raw.unwrap_or("jwt").trim().to_ascii_lowercase().as_str() {
+            "jwt" | "bearer-jwt" => Ok(Self::Jwt),
+            "bearer" | "bearer-token" | "api-key" => Ok(Self::BearerToken),
+            "none" | "unsigned" => Ok(Self::Unsigned),
+            other => Err(ConnectorError::Activation(format!(
+                "unsupported a2a-push auth_scheme `{other}`"
+            ))),
+        }
+    }
+}
+
+fn normalize_a2a_push(body: &JsonValue, claims: Option<&A2aPushJwtClaims>) -> A2aPushPayload {
+    let status_update = body.get("statusUpdate");
+    let artifact_update = body.get("artifactUpdate");
+    let task = body.get("task");
+    let message = body.get("message");
+    let task_id = status_update
+        .and_then(|value| value.get("taskId"))
+        .or_else(|| artifact_update.and_then(|value| value.get("taskId")))
+        .or_else(|| task.and_then(|value| value.get("id")))
+        .or_else(|| body.get("taskId"))
+        .or_else(|| body.get("task_id"))
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string)
+        .or_else(|| claims.and_then(|claims| claims.task_id()));
+    let task_state = status_update
+        .and_then(|value| value.pointer("/status/state"))
+        .or_else(|| task.and_then(|value| value.pointer("/status/state")))
+        .or_else(|| body.pointer("/status/state"))
+        .and_then(JsonValue::as_str)
+        .map(normalize_task_state);
+    let artifact = artifact_update
+        .and_then(|value| value.get("artifact"))
+        .or_else(|| task.and_then(|value| value.get("artifacts")))
+        .cloned();
+    let sender = body
+        .get("sender")
+        .or_else(|| body.get("fromAgentUrl"))
+        .or_else(|| body.get("from_agent_url"))
+        .and_then(JsonValue::as_str)
+        .map(ToString::to_string)
+        .or_else(|| claims.map(|claims| claims.iss.clone()));
+    let kind = if let Some(state) = task_state.as_deref() {
+        format!("a2a.task.{state}")
+    } else if artifact_update.is_some() {
+        "a2a.task.artifact".to_string()
+    } else if message.is_some() {
+        "a2a.task.message".to_string()
+    } else {
+        "a2a.task.update".to_string()
+    };
+
+    A2aPushPayload {
+        task_id,
+        task_state,
+        artifact,
+        sender,
+        raw: body.clone(),
+        kind,
+    }
+}
+
+impl A2aPushJwtClaims {
+    fn task_id(&self) -> Option<String> {
+        self.task_id.clone().or_else(|| self.task_id_camel.clone())
+    }
+}
+
+fn normalize_task_state(state: &str) -> String {
+    match state {
+        "cancelled" => "canceled".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn required<'a>(value: Option<&'a str>, name: &str) -> Result<&'a str, ConnectorError> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| ConnectorError::Activation(format!("a2a-push JWT auth requires {name}")))
+}
+
+fn bearer_token(headers: &BTreeMap<String, String>) -> Result<&str, ConnectorError> {
+    let authorization = header_value(headers, "authorization")
+        .ok_or_else(|| ConnectorError::MissingHeader("authorization".to_string()))?;
+    let Some((scheme, value)) = authorization.split_once(' ') else {
+        return Err(ConnectorError::InvalidHeader {
+            name: "authorization".to_string(),
+            detail: "expected `<scheme> <credentials>`".to_string(),
+        });
+    };
+    if !scheme.eq_ignore_ascii_case("bearer") {
+        return Err(ConnectorError::InvalidHeader {
+            name: "authorization".to_string(),
+            detail: "expected Bearer scheme".to_string(),
+        });
+    }
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(ConnectorError::InvalidHeader {
+            name: "authorization".to_string(),
+            detail: "bearer token is empty".to_string(),
+        });
+    }
+    Ok(value)
+}
+
+fn header_value<'a>(headers: &'a BTreeMap<String, String>, name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
+}
+
+fn infer_occurred_at(body: &JsonValue) -> Option<OffsetDateTime> {
+    body.get("timestamp")
+        .or_else(|| body.pointer("/statusUpdate/metadata/timestamp"))
+        .or_else(|| body.pointer("/artifactUpdate/metadata/timestamp"))
+        .and_then(JsonValue::as_str)
+        .and_then(|value| {
+            OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339).ok()
+        })
+}
+
+fn fallback_dedupe_key(raw_body: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(raw_body);
+    format!("sha256:{}", hex::encode(digest))
+}
+
+static JWKS_CACHE: std::sync::OnceLock<RwLock<HashMap<String, CachedJwks>>> =
+    std::sync::OnceLock::new();
+
+fn cached_jwks(url: &str) -> Option<JwkSet> {
+    let cache = JWKS_CACHE.get_or_init(|| RwLock::new(HashMap::new()));
+    let cache = cache.read().expect("a2a-push JWKS cache poisoned");
+    let cached = cache.get(url)?;
+    (cached.fetched_at.elapsed() < JWKS_REFRESH).then(|| cached.jwks.clone())
+}
+
+fn store_cached_jwks(url: &str, jwks: JwkSet) {
+    let cache = JWKS_CACHE.get_or_init(|| RwLock::new(HashMap::new()));
+    cache.write().expect("a2a-push JWKS cache poisoned").insert(
+        url.to_string(),
+        CachedJwks {
+            fetched_at: Instant::now(),
+            jwks,
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connectors::{Connector, ConnectorCtx};
+    use crate::event_log::{AnyEventLog, MemoryEventLog};
+    use crate::secrets::{
+        RotationHandle, SecretBytes, SecretError, SecretId, SecretMeta, SecretProvider,
+    };
+    use crate::triggers::InboxIndex;
+    use crate::{MetricsRegistry, RateLimiterFactory};
+    use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    struct EmptySecrets;
+
+    #[async_trait]
+    impl SecretProvider for EmptySecrets {
+        async fn get(&self, id: &SecretId) -> Result<SecretBytes, SecretError> {
+            Err(SecretError::NotFound {
+                provider: self.namespace().to_string(),
+                id: id.clone(),
+            })
+        }
+
+        async fn put(&self, id: &SecretId, _value: SecretBytes) -> Result<(), SecretError> {
+            Err(SecretError::NotFound {
+                provider: self.namespace().to_string(),
+                id: id.clone(),
+            })
+        }
+
+        async fn rotate(&self, id: &SecretId) -> Result<RotationHandle, SecretError> {
+            Err(SecretError::NotFound {
+                provider: self.namespace().to_string(),
+                id: id.clone(),
+            })
+        }
+
+        async fn list(&self, _prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError> {
+            Ok(Vec::new())
+        }
+
+        fn namespace(&self) -> &str {
+            "test"
+        }
+
+        fn supports_versions(&self) -> bool {
+            false
+        }
+    }
+
+    async fn connector_with_binding(
+        binding: TriggerBinding,
+    ) -> (A2aPushConnector, Arc<InboxIndex>) {
+        let event_log: Arc<AnyEventLog> = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(64)));
+        let metrics = Arc::new(MetricsRegistry::default());
+        let inbox = Arc::new(
+            InboxIndex::new(event_log.clone(), metrics.clone())
+                .await
+                .unwrap(),
+        );
+        let ctx = ConnectorCtx {
+            event_log,
+            secrets: Arc::new(EmptySecrets),
+            inbox: inbox.clone(),
+            metrics,
+            rate_limiter: Arc::new(RateLimiterFactory::default()),
+        };
+        let mut connector = A2aPushConnector::new();
+        connector.init(ctx).await.unwrap();
+        connector.activate(&[binding]).await.unwrap();
+        (connector, inbox)
+    }
+
+    fn hs_jwks() -> JwkSet {
+        serde_json::from_value(json!({
+            "keys": [{
+                "kty": "oct",
+                "kid": "test-key",
+                "alg": "HS256",
+                "k": "c2VjcmV0"
+            }]
+        }))
+        .unwrap()
+    }
+
+    fn jwt(jti: &str, token: &str) -> String {
+        let mut header = Header::new(Algorithm::HS256);
+        header.kid = Some("test-key".to_string());
+        encode(
+            &header,
+            &A2aPushJwtClaims {
+                iss: "reviewer.prod".to_string(),
+                aud: AudienceClaim::One("https://orchestrator.test/a2a/review".to_string()),
+                iat: OffsetDateTime::now_utc().unix_timestamp(),
+                exp: OffsetDateTime::now_utc().unix_timestamp() + 300,
+                jti: jti.to_string(),
+                task_id_camel: Some("task-123".to_string()),
+                task_id: None,
+                token: Some(token.to_string()),
+            },
+            &EncodingKey::from_secret(b"secret"),
+        )
+        .unwrap()
+    }
+
+    fn jwt_binding() -> TriggerBinding {
+        TriggerBinding {
+            provider: ProviderId::from(PROVIDER_ID),
+            kind: TriggerKind::from(PROVIDER_ID),
+            binding_id: "reviewer-task-update".to_string(),
+            dedupe_key: None,
+            dedupe_retention_days: 1,
+            config: json!({
+                "a2a_push": {
+                    "expected_iss": "reviewer.prod",
+                    "expected_aud": "https://orchestrator.test/a2a/review",
+                    "expected_token": "opaque-token",
+                    "inline_jwks": hs_jwks(),
+                }
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn normalizes_completed_status_update() {
+        let (connector, _inbox) = connector_with_binding(jwt_binding()).await;
+        let body = serde_json::to_vec(&json!({
+            "statusUpdate": {
+                "taskId": "task-123",
+                "contextId": "ctx-1",
+                "status": {"state": "completed"}
+            }
+        }))
+        .unwrap();
+        let mut headers = BTreeMap::new();
+        headers.insert(
+            "authorization".to_string(),
+            format!("Bearer {}", jwt("jti-1", "opaque-token")),
+        );
+        let mut raw = RawInbound::new("", headers, body);
+        raw.metadata = json!({"binding_id": "reviewer-task-update"});
+
+        let event = connector.normalize_inbound(raw).await.unwrap();
+        assert_eq!(event.kind, "a2a.task.completed");
+        assert_eq!(event.dedupe_key, "jti-1");
+        assert!(event.dedupe_claimed());
+        let ProviderPayload::Known(KnownProviderPayload::A2aPush(payload)) = event.provider_payload
+        else {
+            panic!("expected a2a payload");
+        };
+        assert_eq!(payload.task_id.as_deref(), Some("task-123"));
+        assert_eq!(payload.task_state.as_deref(), Some("completed"));
+    }
+
+    #[tokio::test]
+    async fn rejects_replayed_jti() {
+        let (connector, _inbox) = connector_with_binding(jwt_binding()).await;
+        let body = serde_json::to_vec(&json!({
+            "statusUpdate": {
+                "taskId": "task-123",
+                "contextId": "ctx-1",
+                "status": {"state": "completed"}
+            }
+        }))
+        .unwrap();
+        let mut headers = BTreeMap::new();
+        headers.insert(
+            "authorization".to_string(),
+            format!("Bearer {}", jwt("jti-replay", "opaque-token")),
+        );
+        let mut first = RawInbound::new("", headers.clone(), body.clone());
+        first.metadata = json!({"binding_id": "reviewer-task-update"});
+        connector.normalize_inbound(first).await.unwrap();
+        let mut second = RawInbound::new("", headers, body);
+        second.metadata = json!({"binding_id": "reviewer-task-update"});
+
+        let error = connector.normalize_inbound(second).await.unwrap_err();
+        assert!(matches!(error, ConnectorError::DuplicateDelivery(_)));
+    }
+}

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -26,6 +26,7 @@ use crate::triggers::{
     ProviderRuntimeMetadata, TenantId, TriggerEvent,
 };
 
+pub mod a2a_push;
 pub mod cron;
 pub mod github;
 pub mod harn_module;
@@ -37,6 +38,7 @@ pub mod slack;
 pub(crate) mod test_util;
 pub mod webhook;
 
+pub use a2a_push::A2aPushConnector;
 pub use cron::{CatchupMode, CronConnector};
 pub use github::GitHubConnector;
 pub use harn_module::{
@@ -1311,6 +1313,9 @@ fn default_connector_for_provider(provider: &ProviderMetadata) -> Box<dyn Connec
     }
     if provider.provider == "notion" {
         return Box::new(NotionConnector::new());
+    }
+    if provider.provider == "a2a-push" {
+        return Box::new(A2aPushConnector::new());
     }
     match &provider.runtime {
         ProviderRuntimeMetadata::Builtin {

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -1490,8 +1490,11 @@ fn default_provider_payload(
         "a2a-push" => serde_json::json!({
             "provider": "a2a-push",
             "task_id": serde_json::Value::Null,
+            "task_state": serde_json::Value::Null,
+            "artifact": serde_json::Value::Null,
             "sender": serde_json::Value::Null,
             "raw": raw_event,
+            "kind": "a2a.task.update",
         }),
         _ => serde_json::json!({
             "provider": provider,

--- a/crates/harn-vm/src/stdlib_triggers.harn
+++ b/crates/harn-vm/src/stdlib_triggers.harn
@@ -128,7 +128,7 @@ type CronEventPayload = {provider: "cron", cron_id: string | nil, schedule: stri
 
 type GenericWebhookPayload = {provider: "webhook", source: string | nil, content_type: string | nil, raw: dict}
 
-type A2aPushPayload = {provider: "a2a-push", task_id: string | nil, sender: string | nil, raw: dict}
+type A2aPushPayload = {provider: "a2a-push", task_id: string | nil, task_state: string | nil, artifact: any | nil, sender: string | nil, raw: dict, kind: string}
 
 type StreamEventPayload = {provider: "kafka" | "nats" | "pulsar" | "postgres-cdc" | "email" | "websocket", event: string, source: string | nil, stream: string | nil, partition: string | nil, offset: string | nil, key: string | nil, timestamp: string | nil, headers: dict, raw: dict}
 

--- a/crates/harn-vm/src/triggers/event.rs
+++ b/crates/harn-vm/src/triggers/event.rs
@@ -546,8 +546,11 @@ pub struct GenericWebhookPayload {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct A2aPushPayload {
     pub task_id: Option<String>,
+    pub task_state: Option<String>,
+    pub artifact: Option<JsonValue>,
     pub sender: Option<String>,
     pub raw: JsonValue,
+    pub kind: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1310,7 +1313,10 @@ fn default_provider_schemas() -> Vec<Arc<dyn ProviderSchema>> {
                 &[],
                 SignatureVerificationMetadata::None,
                 Vec::new(),
-                ProviderRuntimeMetadata::Placeholder,
+                ProviderRuntimeMetadata::Builtin {
+                    connector: "a2a-push".to_string(),
+                    default_signature_variant: None,
+                },
             ),
             normalize: a2a_push_payload,
         }),
@@ -1895,10 +1901,29 @@ fn a2a_push_payload(
         .get("sender")
         .and_then(JsonValue::as_str)
         .map(ToString::to_string);
+    let task_state = raw
+        .pointer("/status/state")
+        .or_else(|| raw.pointer("/statusUpdate/status/state"))
+        .and_then(JsonValue::as_str)
+        .map(|state| match state {
+            "cancelled" => "canceled".to_string(),
+            other => other.to_string(),
+        });
+    let artifact = raw
+        .pointer("/artifactUpdate/artifact")
+        .or_else(|| raw.get("artifact"))
+        .cloned();
+    let kind = task_state
+        .as_deref()
+        .map(|state| format!("a2a.task.{state}"))
+        .unwrap_or_else(|| "a2a.task.update".to_string());
     ProviderPayload::Known(KnownProviderPayload::A2aPush(A2aPushPayload {
         task_id,
+        task_state,
+        artifact,
         sender,
         raw,
+        kind,
     }))
 }
 
@@ -2074,7 +2099,8 @@ mod tests {
             .filter(|entry| matches!(entry.runtime, ProviderRuntimeMetadata::Builtin { .. }))
             .collect();
 
-        assert_eq!(builtin.len(), 6);
+        assert_eq!(builtin.len(), 7);
+        assert!(builtin.iter().any(|entry| entry.provider == "a2a-push"));
         assert!(builtin.iter().any(|entry| entry.provider == "cron"));
         assert!(builtin.iter().any(|entry| entry.provider == "github"));
         assert!(builtin.iter().any(|entry| entry.provider == "linear"));

--- a/crates/harn-vm/src/triggers/test_util/mod.rs
+++ b/crates/harn-vm/src/triggers/test_util/mod.rs
@@ -12,6 +12,7 @@ use time::OffsetDateTime;
 use tokio::sync::Notify;
 use uuid::Uuid;
 
+use crate::connectors::a2a_push::A2aPushConnector;
 use crate::connectors::cron::{CatchupMode, CronConnector, CronEventSink};
 use crate::connectors::linear::LinearConnector;
 use crate::connectors::webhook::{
@@ -49,6 +50,8 @@ pub const TRIGGER_TEST_FIXTURES: &[&str] = &[
     "dedupe_swallows_duplicate_key",
     "dispatcher_retries_with_exponential_backoff",
     "dlq_on_permanent_failure",
+    "a2a_push_completed",
+    "a2a_push_rejects_replay",
     "manifest_hot_reload_preserves_in_flight",
     "multi_tenant_isolation_stub",
     "rate_limit_throttles",
@@ -224,6 +227,8 @@ impl TriggerTestHarness {
                 self.dispatcher_retries_with_exponential_backoff().await
             }
             "dlq_on_permanent_failure" => self.dlq_on_permanent_failure().await,
+            "a2a_push_completed" => self.a2a_push_completed().await,
+            "a2a_push_rejects_replay" => self.a2a_push_rejects_replay().await,
             "manifest_hot_reload_preserves_in_flight" => {
                 self.manifest_hot_reload_preserves_in_flight().await
             }
@@ -978,6 +983,79 @@ impl TriggerTestHarness {
                 "delivery_id": "delivery-123",
                 "first_appended": first_appended,
                 "second_appended": second_appended,
+            }),
+        })
+    }
+
+    async fn a2a_push_completed(self) -> Result<TriggerHarnessResult, String> {
+        let _guard = clock::install_override(self.clock.clone());
+        let (connector, _inbox) = a2a_push_fixture_connector().await?;
+        let event = connector
+            .normalize_inbound(a2a_push_raw("a2a-jti-completed"))
+            .await
+            .map_err(|error| error.to_string())?;
+        self.connector_registry.record_event(
+            "a2a.push.fixture",
+            1,
+            &event,
+            Some("completed"),
+            None,
+        );
+        let emitted = self.connector_registry.emitted();
+        let payload = match &event.provider_payload {
+            ProviderPayload::Known(KnownProviderPayload::A2aPush(payload)) => payload,
+            _ => return Err("expected a2a-push payload".to_string()),
+        };
+        Ok(TriggerHarnessResult {
+            fixture: "a2a_push_completed".to_string(),
+            ok: event.kind == "a2a.task.completed"
+                && event.dedupe_key == "a2a-jti-completed"
+                && event.dedupe_claimed()
+                && payload.task_id.as_deref() == Some("task-123")
+                && payload.task_state.as_deref() == Some("completed")
+                && emitted.len() == 1,
+            stub: false,
+            summary: "A2A push status updates normalize into task-state trigger events".to_string(),
+            emitted,
+            attempts: Vec::new(),
+            dlq: Vec::new(),
+            alerts: Vec::new(),
+            bindings: Vec::new(),
+            notes: Vec::new(),
+            details: json!({
+                "task_id": payload.task_id,
+                "task_state": payload.task_state,
+                "kind": event.kind,
+                "dedupe_claimed": event.dedupe_claimed(),
+            }),
+        })
+    }
+
+    async fn a2a_push_rejects_replay(self) -> Result<TriggerHarnessResult, String> {
+        let _guard = clock::install_override(self.clock.clone());
+        let (connector, _inbox) = a2a_push_fixture_connector().await?;
+        connector
+            .normalize_inbound(a2a_push_raw("a2a-jti-replay"))
+            .await
+            .map_err(|error| error.to_string())?;
+        let replay = connector
+            .normalize_inbound(a2a_push_raw("a2a-jti-replay"))
+            .await;
+        let rejected = matches!(replay, Err(ConnectorError::DuplicateDelivery(_)));
+        Ok(TriggerHarnessResult {
+            fixture: "a2a_push_rejects_replay".to_string(),
+            ok: rejected,
+            stub: false,
+            summary: "A2A push JWT jti values are single-use through the trigger inbox".to_string(),
+            emitted: Vec::new(),
+            attempts: Vec::new(),
+            dlq: Vec::new(),
+            alerts: Vec::new(),
+            bindings: Vec::new(),
+            notes: Vec::new(),
+            details: json!({
+                "jti": "a2a-jti-replay",
+                "replay_rejected": rejected,
             }),
         })
     }
@@ -1776,6 +1854,103 @@ fn synthetic_event(binding_id: &str, dedupe_key: &str, tenant_id: Option<&str>) 
         })),
         SignatureStatus::Unsigned,
     )
+}
+
+async fn a2a_push_fixture_connector() -> Result<(A2aPushConnector, Arc<InboxIndex>), String> {
+    let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(32)));
+    let inbox = build_inbox(&log).await;
+    let mut connector = A2aPushConnector::new();
+    connector
+        .init(connector_ctx(
+            log,
+            Arc::new(EmptySecretProvider),
+            inbox.clone(),
+        ))
+        .await
+        .map_err(|error| error.to_string())?;
+    connector
+        .activate(&[ConnectorTriggerBinding {
+            provider: ProviderId::from("a2a-push"),
+            kind: crate::connectors::TriggerKind::from("a2a-push"),
+            binding_id: "a2a.push.fixture".to_string(),
+            dedupe_key: None,
+            dedupe_retention_days: DEFAULT_INBOX_RETENTION_DAYS,
+            config: json!({
+                "a2a_push": {
+                    "expected_iss": "reviewer.prod",
+                    "expected_aud": "https://orchestrator.test/a2a/review",
+                    "expected_token": "opaque-token",
+                    "inline_jwks": {
+                        "keys": [{
+                            "kty": "oct",
+                            "kid": "test-key",
+                            "alg": "HS256",
+                            "k": "c2VjcmV0"
+                        }]
+                    }
+                }
+            }),
+        }])
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok((connector, inbox))
+}
+
+fn a2a_push_raw(jti: &str) -> RawInbound {
+    let mut headers = BTreeMap::new();
+    headers.insert(
+        "authorization".to_string(),
+        format!("Bearer {}", a2a_push_fixture_jwt(jti)),
+    );
+    headers.insert(
+        "content-type".to_string(),
+        "application/a2a+json".to_string(),
+    );
+    let mut raw = RawInbound::new(
+        "",
+        headers,
+        serde_json::to_vec(&json!({
+            "statusUpdate": {
+                "taskId": "task-123",
+                "contextId": "ctx-123",
+                "status": {"state": "completed"}
+            }
+        }))
+        .expect("serialize a2a push fixture"),
+    );
+    raw.metadata = json!({"binding_id": "a2a.push.fixture"});
+    raw
+}
+
+#[derive(Serialize)]
+struct A2aFixtureClaims {
+    iss: String,
+    aud: String,
+    iat: i64,
+    exp: i64,
+    jti: String,
+    token: String,
+    #[serde(rename = "taskId")]
+    task_id: String,
+}
+
+fn a2a_push_fixture_jwt(jti: &str) -> String {
+    let mut header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256);
+    header.kid = Some("test-key".to_string());
+    jsonwebtoken::encode(
+        &header,
+        &A2aFixtureClaims {
+            iss: "reviewer.prod".to_string(),
+            aud: "https://orchestrator.test/a2a/review".to_string(),
+            iat: OffsetDateTime::now_utc().unix_timestamp(),
+            exp: OffsetDateTime::now_utc().unix_timestamp() + 300,
+            jti: jti.to_string(),
+            token: "opaque-token".to_string(),
+            task_id: "task-123".to_string(),
+        },
+        &jsonwebtoken::EncodingKey::from_secret(b"secret"),
+    )
+    .expect("encode fixture jwt")
 }
 
 fn parse_rfc3339(raw: &str) -> OffsetDateTime {

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -46,6 +46,7 @@
 - [Notion connector](./connectors/notion.md)
 - [Slack Events connector](./connectors/slack-events.md)
 - [Generic webhook connector](./connectors/webhook.md)
+- [A2A push connector](./connectors/a2a-push.md)
 - [Cookbook](./cookbook.md)
 - [Tutorial: code review agent](./tutorial-code-review-agent.md)
 - [Tutorial: MCP server](./tutorial-mcp-server.md)

--- a/docs/src/connectors/a2a-push.md
+++ b/docs/src/connectors/a2a-push.md
@@ -1,0 +1,88 @@
+# A2A push connector
+
+`a2a-push` receives Agent2Agent push-notification webhooks from remote
+A2A agents. It is for federated Harn orchestrators: one orchestrator can
+start long-running work on another and be woken when the remote task
+changes state.
+
+```text
+Orchestrator A  -- a2a://B/task -->  Orchestrator B
+     ^                                    |
+     |                                    |
+     +------- push POST task done --------+
+```
+
+## Manifest
+
+Use `kind = "a2a-push"` and add `[triggers.a2a_push]` to opt into the
+connector verifier:
+
+```toml
+[[triggers]]
+id = "reviewer-task-update"
+kind = "a2a-push"
+provider = "a2a-push"
+path = "/a2a/review"
+match = { events = ["a2a.task.completed", "a2a.task.failed"] }
+handler = "handlers::on_reviewer_update"
+
+[triggers.a2a_push]
+expected_iss = "reviewer.prod"
+expected_aud = "https://orchestrator.example.com/a2a/review"
+jwks_url = "https://reviewer.prod/.well-known/jwks.json"
+expected_token = "opaque-task-token"
+```
+
+JWT/JWKS is the default. The connector verifies:
+
+- `Authorization: Bearer <jwt>` is present.
+- The JWT signature matches the `kid` in the remote JWKS.
+- `iss` and `aud` match the manifest.
+- `exp` is still in the future and `iat` is not in the future.
+- `jti` is single-use through the trigger inbox.
+- `expected_token`, when set, matches the JWT `token` claim, the
+  `X-A2A-Token` header, or a `token` field in the JSON body.
+
+JWKS entries are cached for one day and refreshed after expiry.
+
+## Event Shape
+
+The connector accepts A2A stream-response push payloads:
+
+```json
+{
+  "statusUpdate": {
+    "taskId": "task-123",
+    "contextId": "ctx-123",
+    "status": {"state": "completed"}
+  }
+}
+```
+
+Task status updates map to `TriggerEvent.kind` values like
+`a2a.task.completed`, `a2a.task.failed`, and `a2a.task.canceled`.
+Artifact and message pushes map to `a2a.task.artifact` and
+`a2a.task.message`.
+
+Handlers receive `provider_payload` with:
+
+- `task_id`
+- `task_state`
+- `artifact`
+- `sender`
+- `kind`
+- `raw`
+
+## A2A Dispatch Registration
+
+When `HARN_A2A_PUSH_URL` is set, outbound `a2a://...` dispatches include
+and register a `pushNotificationConfig` for pending tasks. Set
+`HARN_A2A_PUSH_TOKEN` to include a bearer credential in that config.
+
+The built-in `harn serve a2a` adapter advertises push notification
+support, stores push configs, and posts `statusUpdate` payloads to each
+configured webhook when an asynchronous task completes or fails.
+
+Legacy `a2a-push` routes without `[triggers.a2a_push]` keep the older
+orchestrator listener auth: `HARN_ORCHESTRATOR_API_KEYS` plus
+`HARN_ORCHESTRATOR_HMAC_SECRET`.

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -284,5 +284,7 @@ handler = "a2a://reviewer.prod/triage"
 GitHub webhook triggers verify the `X-Hub-Signature-256` HMAC against
 `secrets.signing_secret` before enqueueing. Generic `provider = "webhook"`
 triggers use the shared Standard Webhooks verifier. `a2a-push` routes
-require either `Authorization: Bearer <api-key>` or a valid
-`Authorization: HMAC-SHA256 ...` header before enqueueing.
+without `[triggers.a2a_push]` require either
+`Authorization: Bearer <api-key>` or a valid
+`Authorization: HMAC-SHA256 ...` header before enqueueing. Routes with
+`[triggers.a2a_push]` use the A2A push connector's JWT/JWKS verifier.


### PR DESCRIPTION
## Summary

- adds the built-in `a2a-push` inbound connector with JWT/JWKS verification, `iss`/`aud` checks, `exp`/`iat` validation, and `jti` replay protection through the trigger inbox
- normalizes A2A task status, artifact, and message push payloads into trigger events with task state metadata
- wires outbound A2A dispatch to advertise and register push notification configs, and teaches the local A2A server to deliver completion pushes for async tasks
- adds conformance fixtures for completed pushes and replay rejection, plus an end-to-end A2A push loop test
- documents the connector manifest shape and operational behavior

Closes #175

## Verification

- `cargo test -p harn-vm connectors::a2a_push --lib`
- `cargo test -p harn-vm triggers::test_util --lib`
- `cargo test -p harn-cli --bin harn a2a`
- `cargo test -p harn-cli --bin harn a2a::tests::test_handle_jsonrpc_async_push_notification_loop`
- `cargo test -p harn-vm registered_provider_metadata_marks_builtin_connectors --lib`
- `cargo check -p harn-cli`
- `cargo run --quiet --bin harn -- test conformance --filter trigger_a2a_push_completed`
- `cargo run --quiet --bin harn -- test conformance --filter trigger_a2a_push_rejects_replay`
- pre-commit hook: clippy, highlight sync, markdown lint, Actions lint, portal lint
- pre-push hook: workspace nextest, Harn formatting, markdown lint, portal lint
