### PR TITLE
[codex] Enable nextest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,13 @@ jobs:
       - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.9.1
         with:
           shared-key: workspace
+      - uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
+        with:
+          tool: cargo-nextest
       - run: make lint
       - run: make test
+        env:
+          NEXTEST_PROFILE: ci
       - run: make conformance
       - run: make lint-harn
       - run: make fmt-harn


### PR DESCRIPTION
## Summary

- Install `cargo-nextest` in the Rust CI job using pinned `taiki-e/install-action`.
- Run `make test` with `NEXTEST_PROFILE=ci` so the existing nextest CI profile is selected on GitHub Actions.

## Why

`make test` already prefers `cargo nextest run --workspace`, but GitHub-hosted runners did not have `cargo-nextest` installed. CI therefore fell back to `cargo test --workspace`, which loses nextest's workspace scheduling and bounded test behavior.

## Validation

- `make lint-actions`
- `git diff --check`
- pre-commit hook: format, clippy, generated highlight check, markdown lint, Actions lint, portal lint
- pre-push hook: `make test` via nextest, Harn formatting check, markdown lint, portal lint
