### PR TITLE
[codex] Make Harn release flow merge-queue safe

### DIFF
--- a/.claude/commands/release-harn.md
+++ b/.claude/commands/release-harn.md
@@ -1,16 +1,17 @@
-Run the full Harn release workflow from the repo source of truth.
+Run the merge-queue-safe Harn release workflow from the repo source of truth.
 
 ## TL;DR
 
 ```bash
-# From a clean checkout, with release content + CHANGELOG entry already in HEAD:
+# From updated main, after the release-content PR has landed:
 ./scripts/release_ship.sh --bump patch
 ```
 
-`release_ship.sh` handles audit, dry-run publish, bump, tag, push, crates.io
-publish, and GitHub release creation in the right order. Run it once the
-release content commit is in place; do not re-invent the sequence manually
-unless the script cannot do what you need.
+`release_ship.sh --bump patch` handles audit, dry-run publish, version bump,
+branch push, and automated bump PR creation. After that PR lands through the
+merge queue, run `./scripts/release_ship.sh --finalize` from updated `main` to
+tag, publish to crates.io, and create/update the GitHub release. Do not
+re-invent the sequence manually unless the script cannot do what you need.
 
 ## Default workflow
 
@@ -46,22 +47,24 @@ unless the script cannot do what you need.
    truth.
 6. Update `CHANGELOG.md` before bumping the version. The new top entry must
    describe the actual pending code changes that will ship.
-7. Run `cargo fmt --all` once so the upcoming release content commit is
+7. Run `cargo fmt --all` once so the upcoming release content PR is
    formatting-clean. `release_gate.sh audit` runs `cargo fmt -- --check` and
    will reject drift later; catching it here avoids re-doing commits.
-8. Stage and commit the release content:
-   `git commit -m "Prepare vX.Y.Z release"`. Include every file that ships in
-   this version, including `CHANGELOG.md` and doc updates. Do **not** include
-   `Cargo.toml` / `Cargo.lock` version bumps in this commit — the ship script
-   produces those in a separate "Bump version to X.Y.Z" commit.
-9. With the release content committed and the worktree clean, run
-   `./scripts/release_ship.sh --bump patch` (or `minor`/`major`). The script
-   audits, dry-run publishes, bumps `Cargo.toml`, commits the bump, tags,
-   pushes branch + tag, publishes to crates.io, and creates the GitHub
-   release in that order.
-10. For an all-in-one dry run that stops before any destructive action,
+8. Stage, commit, push, and open a "Prepare vX.Y.Z release" PR. Include every
+   file that ships in this version, including `CHANGELOG.md` and doc updates.
+   Do **not** include `Cargo.toml` / `Cargo.lock` version bumps in this PR —
+   the ship script produces those in a separate "Bump version to X.Y.Z" PR.
+9. After the release-content PR lands through the merge queue, sync `main` and
+   run `./scripts/release_ship.sh --bump patch` (or `minor`/`major`). The
+   script audits, dry-run publishes, bumps `Cargo.toml`, commits the bump,
+   pushes `release/vX.Y.Z`, and opens the bump PR.
+10. After the bump PR lands through the merge queue, sync `main` and run
+    `./scripts/release_ship.sh --finalize`. The script audits, dry-run
+    publishes, creates/pushes the tag, publishes to crates.io, and
+    creates/updates the GitHub release.
+11. For an all-in-one dry run that stops before any destructive action,
     use `./scripts/release_gate.sh full --bump patch --dry-run`.
-11. Only drop down to the piecewise `release_gate.sh prepare` / `publish` /
+12. Only drop down to the piecewise `release_gate.sh prepare` / `publish` /
     `notes` commands when `release_ship.sh` cannot do what you need
     (e.g. recovering a partial release).
 
@@ -72,20 +75,21 @@ Always prefer the repo scripts:
 ```bash
 ./scripts/release_gate.sh <audit|prepare|publish|notes|full> ...
 ./scripts/release_ship.sh --bump patch
+./scripts/release_ship.sh --finalize
 ```
 
 Do not re-invent the release ritual from memory if the script can do it.
 Use normal git commands for the parts that the release gate intentionally does
-not automate, such as analyzing pending local work, making release commits, and
-pushing `main` and tags. Once the release content is committed and the tree is
-clean, prefer `./scripts/release_ship.sh` for the deterministic release
-mechanics.
+not automate, such as analyzing pending local work and opening the
+"Prepare vX.Y.Z release" PR. Once that PR lands and the tree is clean, prefer
+`./scripts/release_ship.sh --bump patch` for the bump PR and
+`./scripts/release_ship.sh --finalize` for tag/publish mechanics.
 
 ## Rules
 
 - Report failures clearly and stop on the first failed gate.
-- Summarize the resulting version, publish status, release notes, and required
-  tag/release follow-up.
+- Summarize the resulting version, bump PR or publish status, release notes,
+  and required tag/release follow-up.
 - If `mdbook` is not installed, mention that the docs audit skipped mdBook build.
 - If the tree is dirty, do not work around it silently for `prepare`; either
   stop or commit the intended release content first.
@@ -107,24 +111,24 @@ mechanics.
 - The grammar/spec audit also includes `scripts/verify_tree_sitter_parse.py`,
   which sweeps positive `.harn` programs through the executable tree-sitter
   grammar. Treat failures there as parser/grammar divergence.
-- A real release has exactly two commits on top of the previous release:
-  `Prepare vX.Y.Z release` (code + docs + `CHANGELOG.md`) followed by
-  `Bump version to X.Y.Z` (Cargo.toml + Cargo.lock only). `release_ship.sh`
-  creates the second commit automatically; the human/agent creates the
-  first.
-- `scripts/release_ship.sh` assumes the real release content, including docs
-  consistency updates, has already been committed and the tree is clean before
-  it starts.
+- A real release has exactly two release commits on `main`, both landed via
+  PR/merge queue: `Prepare vX.Y.Z release` (code + docs + `CHANGELOG.md`)
+  followed by `Bump version to X.Y.Z` (Cargo.toml + Cargo.lock only).
+  `release_ship.sh --bump patch` creates and opens the second PR
+  automatically; the human/agent creates the first.
+- `scripts/release_ship.sh --bump patch` assumes the real release content,
+  including docs consistency updates, has already landed through the merge
+  queue and the local `main` tree is clean before it starts.
 - `verify_release_metadata.py` accepts the pre-bump state — it passes when
   the top `CHANGELOG.md` entry is exactly one patch/minor/major step ahead
-  of `Cargo.toml`. That means running `release_ship.sh` on a "Prepare
-  vX.Y.Z release" commit is fine even though Cargo.toml still points at the
-  previous version.
-- `release_ship.sh` pushes the branch and tag **before** calling
-  `cargo publish`, so GitHub release binary workflows and downstream
-  fetchers (e.g. `burin-code`'s `fetch-harn`) start working in parallel
-  with crates.io publication. The GitHub release body is created last so
-  it can reference the final crates.io state.
+  of `Cargo.toml`. That means running `release_ship.sh --bump patch` on a
+  "Prepare vX.Y.Z release" commit is fine even though Cargo.toml still points
+  at the previous version.
+- `release_ship.sh --finalize` pushes the tag **before** calling
+  `cargo publish`, so GitHub release binary workflows and downstream fetchers
+  (e.g. `burin-code`'s `fetch-harn`) start working in parallel with crates.io
+  publication. The GitHub release body is created last so it can reference the
+  final crates.io state.
 - `CHANGELOG.md` is the release-language source of truth. Use
   `scripts/render_release_notes.py` or `./scripts/release_gate.sh notes` to
   produce the exact GitHub release body from it.
@@ -148,6 +152,7 @@ phase stretch to ~12 min while fighting `rust-audit`'s clippy+nextest for
 
 ```bash
 ./scripts/release_ship.sh --bump patch
+./scripts/release_ship.sh --finalize
 ./scripts/release_gate.sh full --bump patch --dry-run
 ./scripts/release_gate.sh notes
 ```

--- a/.codex/commands/harn-release.md
+++ b/.codex/commands/harn-release.md
@@ -1,6 +1,6 @@
 # Harn Release Command
 
-Run the full Harn release workflow from the repo source of truth.
+Run the merge-queue-safe Harn release workflow from the repo source of truth.
 
 Default assumptions:
 
@@ -17,35 +17,45 @@ Default assumptions:
   `docs/src/`, `spec/HARN_SPEC.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, and
   developer setup surfaces such as `scripts/dev_setup.sh`, `Makefile`,
   `.githooks/`, and `docs/src/portal.md`.
-- Run `cargo fmt --all` once so the upcoming release content commit is
+- Run `cargo fmt --all` once so the upcoming release content PR is
   formatting-clean — `release_gate.sh audit` runs `cargo fmt -- --check` and
   will reject drift later.
-- Commit the release content with `git commit -m "Prepare vX.Y.Z release"`.
-  Include every file that ships in this version (code + docs + `CHANGELOG.md`)
-  but **not** `Cargo.toml` / `Cargo.lock` — `release_ship.sh` creates the
-  "Bump version to X.Y.Z" commit separately.
-- Then run the deterministic ship script:
+- Open and land a "Prepare vX.Y.Z release" PR. Include every file that ships
+  in this version (code + docs + `CHANGELOG.md`) but **not** `Cargo.toml` /
+  `Cargo.lock` — `release_ship.sh` creates the "Bump version to X.Y.Z" PR
+  separately.
+- After that PR lands through the merge queue, sync `main` and run:
 
 ```bash
 ./scripts/release_ship.sh --bump patch
 ```
 
-- Adjust `patch` to `minor` or `major` if requested.
+- Adjust `patch` to `minor` or `major` if requested. This opens the automated
+  version-bump PR.
+- After the version-bump PR lands through the merge queue, sync `main` and
+  finalize:
+
+```bash
+./scripts/release_ship.sh --finalize
+```
 
 Rules:
 
-- `./scripts/release_ship.sh` is the default mechanical entry point once the
-  release content and docs are consistent and committed. It runs audit,
-  dry-run publish, bump, commit, tag, push branch + tag, `cargo publish`,
-  and GitHub release creation in that order. The push happens **before**
-  `cargo publish` so GitHub release-binary workflows and downstream
-  fetchers (e.g. `burin-code`'s `fetch-harn`) start in parallel with
-  crates.io. The GitHub release body is created last.
+- `./scripts/release_ship.sh --bump patch` is the default mechanical entry
+  point once the release content and docs are consistent and landed on `main`.
+  It runs audit, dry-run publish, bump, commit, pushes `release/vX.Y.Z`, and
+  opens the version-bump PR. It does not tag, publish, or push to `main`.
+- `./scripts/release_ship.sh --finalize` runs only after the bump PR lands on
+  `main`. It runs audit, dry-run publish, creates/pushes the tag, publishes to
+  crates.io, and creates/updates the GitHub release. The tag push happens
+  **before** `cargo publish` so GitHub release-binary workflows and downstream
+  fetchers (e.g. `burin-code`'s `fetch-harn`) start in parallel with crates.io.
+  The GitHub release body is created last.
 - `verify_release_metadata.py` accepts the pre-bump state — it passes when
   `CHANGELOG.md` top is exactly one patch/minor/major step ahead of
-  `Cargo.toml`. That is why running `release_ship.sh` on a "Prepare vX.Y.Z
-  release" commit is fine even though Cargo.toml still points at the
-  previous version.
+  `Cargo.toml`. That is why running `release_ship.sh --bump patch` on a
+  "Prepare vX.Y.Z release" commit is fine even though Cargo.toml still points
+  at the previous version.
 - Prefer `./scripts/release_gate.sh <audit|prepare|publish|notes|full>` over
   ad hoc release commands only when working below the ship script (e.g.
   recovering from a partial release).
@@ -57,7 +67,7 @@ Rules:
   `README.md`, `CLAUDE.md`, `CONTRIBUTING.md`, and mdBook pages that describe
   the changed surface.
 - Treat `CHANGELOG.md` as the source of truth for GitHub release notes.
-- Summarize the shipped version, the release-content commit, the bump commit,
+- Summarize the shipped version, the release-content PR, the bump PR/commit,
   publish status, and the exact notes body or compare link.
 - `release_gate.sh audit` begins with a serial `cargo build --workspace
   --all-targets` warm prebuild before spawning the five parallel lanes, so
@@ -69,6 +79,7 @@ Useful shortcuts:
 
 ```bash
 ./scripts/release_ship.sh --bump patch
+./scripts/release_ship.sh --finalize
 ./scripts/release_gate.sh full --bump patch --dry-run
 ./scripts/release_gate.sh notes
 ```

--- a/.codex/skills/harn-release/SKILL.md
+++ b/.codex/skills/harn-release/SKILL.md
@@ -1,39 +1,52 @@
 ---
 name: harn-release
-description: Use this skill when asked to analyze pending Harn release work, fold dirty or untracked changes into a release, update CHANGELOG.md, bump the version, publish crates, tag, push, or prepare GitHub release notes for this repository.
+description: Use this skill for Harn release prep, bump PRs, publishing, tagging, and release notes.
 ---
 
 # Harn Release Gate
 
 Use this skill when asked to run the final Harn release workflow, including
 analysis of pending local changes, repo-wide consistency updates, changelog
-prep, version bumping, crates.io publication, tagging, and release-note
-rendering.
+prep, version-bump PR creation, crates.io publication, tagging, and
+release-note rendering.
 
 ## Source of truth
 
 Always prefer the repo scripts:
 
 ```bash
-./scripts/release_ship.sh --bump patch                     # full release
+./scripts/release_ship.sh --bump patch                     # open bump PR
+./scripts/release_ship.sh --finalize                       # tag/publish after merge
 ./scripts/release_gate.sh <audit|prepare|publish|notes|full> ...  # piecewise
 ```
 
 Do not re-invent the release ritual from memory if `release_ship.sh` can do
 it. Use normal git commands only for the parts that the release gate
 intentionally does not automate: analyzing pending local work and producing
-the "Prepare vX.Y.Z release" commit. Once that commit is in place and the
-tree is clean, `release_ship.sh` handles audit, bump, tag, push, publish,
-and GitHub release creation.
+the "Prepare vX.Y.Z release" PR. Once that PR lands through the merge queue,
+`release_ship.sh --bump patch` handles audit, dry-run publish, bump-branch
+creation, version-bump commit, branch push, and PR creation. After the bump PR
+lands through the merge queue, `release_ship.sh --finalize` tags `main`,
+publishes crates, renders notes, and creates/updates the GitHub release.
 
-## Fire-and-forget mode
+## Merge-queue mode
 
-Once the "Prepare vX.Y.Z release" commit is in place and the tree is clean,
-`./scripts/release_ship.sh --bump patch` is a **fire-and-forget** command:
-it performs audit → dry-run publish → bump → commit → tag → push branch+tag
-→ `cargo publish` → release notes → GitHub release, then exits. Check the
-exit code when it returns; if non-zero, the step names in its stdout tell
-you which gate tripped.
+Direct pushes to `main` are not part of the release flow. The release has two
+merge-queue-reviewed PRs:
+
+1. `Prepare vX.Y.Z release` — code + docs + `CHANGELOG.md`, no Cargo version
+   bump.
+2. `Bump version to X.Y.Z` — `Cargo.toml` + `Cargo.lock` only, opened by
+   `./scripts/release_ship.sh --bump patch`.
+
+Only after the bump PR lands should you run `./scripts/release_ship.sh
+--finalize` from an up-to-date `main`. Finalize creates/pushes the tag before
+`cargo publish` so release-binary workflows and downstream fetchers can still
+start in parallel with crates.io publication.
+
+Both script phases run the release audit and stop on the first failed gate.
+Check the exit code when they return; if non-zero, the step names in stdout
+tell you which gate tripped.
 
 Typical wall-clock: ~6–10 min cold, ~2–4 min warm (sccache hot). Do not
 babysit it. Start the command and work on other things. Failure modes,
@@ -43,26 +56,29 @@ roughly in frequency order:
   into the same "Prepare vX.Y.Z release" commit (amend), re-run.
 - `publish --dry-run` failure → usually a missing `include = [...]` file
   in a crate manifest; fix and re-commit.
-- `cargo publish` rate-limit / transient network → re-run; it's idempotent
-  once the tag exists.
-- `gh release create` failure → the release is already on crates.io and
-  tagged; finish manually with
+- bump PR creation failure → the release bump branch has usually already been
+  pushed; create the PR manually from `release/vX.Y.Z` into `main`.
+- `cargo publish` rate-limit / transient network during finalize → re-run
+  `release_ship.sh --finalize`; it is idempotent once the tag exists at HEAD.
+- `gh release create` failure during finalize → the release is already on
+  crates.io and tagged; finish manually with
   `gh release create <tag> --title <tag> --notes-file <rendered>`.
 
 ## Batching multiple tickets in one release
 
 When several unrelated tickets are ready to ship together:
 
-1. Merge each ticket's PR to `main` individually (each may carry a
+1. Merge each ticket's PR to `main` through the merge queue (each may carry a
    one-line CHANGELOG addition under an "Unreleased" heading — that is
    fine).
 2. Immediately before releasing, consolidate the CHANGELOG: promote the
    "Unreleased" section to `## [vX.Y.Z] - YYYY-MM-DD` with the grouped
    entries and reference each closed ticket by number.
-3. Commit that consolidation as the "Prepare vX.Y.Z release" commit
+3. Open and land a "Prepare vX.Y.Z release" PR with that consolidation
    (docs/spec edits ride along if needed).
-4. Run `release_ship.sh --bump patch` once. The release covers all the
-   batched tickets.
+4. From updated `main`, run `release_ship.sh --bump patch` once to open the
+   version-bump PR. The release covers all the batched tickets.
+5. After the bump PR lands, run `release_ship.sh --finalize`.
 
 Prefer larger batches over many small releases when the tickets are
 topically related (e.g. the "iteration unblocker" pair, the "evidence
@@ -104,26 +120,29 @@ installs the binaries directly. Release batching exists to control the
 7. Run `cargo fmt --all` once so the upcoming release content commit is
    formatting-clean. `release_gate.sh audit` runs `cargo fmt -- --check` and
    will reject drift later; catching it here avoids re-doing commits.
-8. Stage and commit the release content with
-   `git commit -m "Prepare vX.Y.Z release"`. Include every file that ships in
-   this version, including `CHANGELOG.md` and docs updates. Do **not** touch
-   `Cargo.toml` / `Cargo.lock` version strings — `release_ship.sh` produces
-   the "Bump version to X.Y.Z" commit separately.
-9. With the release content committed and the tree clean, run
-   `./scripts/release_ship.sh --bump patch` (or `minor`/`major`). The script
-   runs audit, dry-run publish, bump, commit, tag, push branch + tag,
-   `cargo publish`, and GitHub release creation in that order.
-10. For an all-in-one dry run that stops before any destructive action, use
+8. Stage, commit, push, and open a "Prepare vX.Y.Z release" PR. Include every
+   file that ships in this version, including `CHANGELOG.md` and docs updates.
+   Do **not** touch `Cargo.toml` / `Cargo.lock` version strings — the bump PR
+   is separate.
+9. After the release-content PR lands through the merge queue, sync `main` and
+   run `./scripts/release_ship.sh --bump patch` (or `minor`/`major`). The
+   script runs audit, dry-run publish, creates `release/vX.Y.Z`, commits the
+   Cargo version bump, pushes that branch, and opens the bump PR.
+10. After the bump PR lands through the merge queue, sync `main` and run
+    `./scripts/release_ship.sh --finalize`. The script runs audit, dry-run
+    publish, creates/pushes the tag, publishes to crates.io, renders notes,
+    and creates/updates the GitHub release.
+11. For an all-in-one dry run that stops before any destructive action, use
     `./scripts/release_gate.sh full --bump patch --dry-run`.
-11. Only fall back to the piecewise `release_gate.sh prepare` / `publish` /
+12. Only fall back to the piecewise `release_gate.sh prepare` / `publish` /
     `notes` commands when `release_ship.sh` cannot do what you need
     (e.g. recovering a partial release).
 
 ## Expectations
 
 - Report failures clearly and stop on the first failed gate.
-- Summarize the resulting version, publish status, release notes, and required
-  tag/release follow-up.
+- Summarize the resulting version, bump PR or publish status, release notes,
+  and required tag/release follow-up.
 - If `mdbook` is not installed, mention that the docs audit skipped mdBook build.
 - If the tree is dirty, do not work around it silently for `prepare`; either
   stop or commit the intended release content first.
@@ -153,20 +172,21 @@ installs the binaries directly. Release batching exists to control the
   `scripts/render_release_notes.py` or `./scripts/release_gate.sh notes` to
   produce the exact GitHub release body from it.
 - GitHub release artifacts are produced by the existing release workflow once
-  the tag is pushed.
-- `release_ship.sh` pushes the branch and tag **before** running
+  the tag is pushed during finalize.
+- `release_ship.sh --finalize` pushes the tag **before** running
   `cargo publish`, so the GitHub release-binary workflow and downstream
   fetchers (e.g. `burin-code`'s `fetch-harn`) can start working in parallel
   with crates.io publication. The GitHub release body is created last so it
   reflects the final crates.io + git state.
-- A real release has exactly two commits on top of the previous release:
-  `Prepare vX.Y.Z release` (code + docs + `CHANGELOG.md`) followed by
-  `Bump version to X.Y.Z` (Cargo.toml + Cargo.lock only). `release_ship.sh`
-  creates the second commit automatically; the human/agent creates the
-  first.
-- `scripts/release_ship.sh` assumes the real release content, including docs
-  consistency updates, has already been committed and the tree is clean
-  before it starts.
+- A real release has exactly two release commits on `main`, both landed via
+  PR/merge queue: `Prepare vX.Y.Z release` (code + docs + `CHANGELOG.md`)
+  followed by `Bump version to X.Y.Z` (Cargo.toml + Cargo.lock only).
+  `release_ship.sh --bump patch` creates and opens the second PR
+  automatically; the human/agent creates the first.
+- `scripts/release_ship.sh --bump patch` assumes the real release content,
+  including docs consistency updates, has already landed through the merge
+  queue and the local `main` tree is clean before it starts. `--finalize`
+  assumes the automated bump PR has landed through the merge queue.
 - `verify_release_metadata.py` (run from `release_gate.sh audit`) accepts the
   pre-bump state: it passes when the top `CHANGELOG.md` entry is exactly one
   patch/minor/major step ahead of `Cargo.toml`. Running audit on a "Prepare

--- a/.codex/skills/release-harn/SKILL.md
+++ b/.codex/skills/release-harn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-harn
-description: Alias for the Harn release workflow skill. Use this when asked to prepare, audit, publish, tag, or document a Harn release.
+description: Alias for the Harn release workflow skill.
 ---
 
 # Release Harn
@@ -11,19 +11,24 @@ The repo source of truth remains:
 
 ```bash
 ./scripts/dev_setup.sh
-./scripts/release_ship.sh --bump patch                     # full release
+./scripts/release_ship.sh --bump patch                     # open bump PR
+./scripts/release_ship.sh --finalize                       # tag/publish after merge
 ./scripts/release_gate.sh <audit|prepare|publish|notes|full> ...  # piecewise
 ```
 
-`release_ship.sh` runs audit → dry-run publish → bump → commit → tag →
-push branch + tag → `cargo publish` → render notes → create GitHub
-release. The push happens before `cargo publish` so downstream
-consumers (e.g. `burin-code`'s `fetch-harn`, GitHub release-binary
-workflows) can start working in parallel with crates.io.
+Direct pushes to `main` are not part of the release flow. After the release
+content PR lands through the merge queue, `release_ship.sh --bump patch` runs
+audit → dry-run publish → bump → commit → push `release/vX.Y.Z` → open a bump
+PR. After the bump PR lands, `release_ship.sh --finalize` runs audit → dry-run
+publish → tag → push tag → `cargo publish` → render notes → create/update the
+GitHub release. The tag push happens before `cargo publish` so downstream
+consumers (e.g. `burin-code`'s `fetch-harn`, GitHub release-binary workflows)
+can start working in parallel with crates.io.
 
-**Fire-and-forget:** once the "Prepare vX.Y.Z release" commit lands and
-the tree is clean, `release_ship.sh` is safe to invoke and walk away
-from. Check the exit code when it returns; otherwise do not babysit.
+**Merge-queue flow:** land a "Prepare vX.Y.Z release" PR first, run
+`release_ship.sh --bump patch` from updated `main` to open the automated bump
+PR, then run `release_ship.sh --finalize` from updated `main` after the bump PR
+lands. Check each exit code when it returns; otherwise do not babysit.
 
 **Cross-repo consumers do not wait on releases.** `burin-code`'s
 `scripts/fetch-harn.sh --local` builds Harn from `~/projects/harn` and
@@ -43,5 +48,7 @@ surface are documented coherently:
 
 Commit pattern for a real release:
 
-1. `Prepare vX.Y.Z release` — code + docs + `CHANGELOG.md`, no Cargo.toml.
-2. `Bump version to X.Y.Z` — created automatically by `release_ship.sh`.
+1. `Prepare vX.Y.Z release` — code + docs + `CHANGELOG.md`, no Cargo.toml,
+   landed through PR/merge queue.
+2. `Bump version to X.Y.Z` — created automatically by `release_ship.sh --bump
+   patch`, landed through PR/merge queue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,10 +106,12 @@ This repository implements Harn, a programming language and runtime for orchestr
 
 ## Release Workflow
 
-- Full release from a clean content commit: `./scripts/release_ship.sh --bump patch`
-- Audit: `./scripts/release_gate.sh audit` (uses `make test`, so `cargo-nextest` accelerates Rust tests when installed)
-- Dry-run full release: `./scripts/release_gate.sh full --bump patch --dry-run`
+- Open version-bump PR after release content lands: `./scripts/release_ship.sh --bump patch`
+- Finalize after bump PR lands: `./scripts/release_ship.sh --finalize`
+- Audit: `./scripts/release_gate.sh audit` (uses `make test`, so `cargo-nextest`
+  accelerates Rust tests when installed)
+- Dry-run release gate: `./scripts/release_gate.sh full --bump patch --dry-run`
 - Crate publishing helper: `./scripts/publish.sh --dry-run`
-- `release_ship.sh` pushes branch + tag before `cargo publish` so
+- `release_ship.sh --finalize` pushes the tag before `cargo publish` so
   downstream consumers (e.g. `burin-code`'s `fetch-harn`, GitHub release
   binary workflows) run in parallel with crates.io publication.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,10 +136,12 @@ at `.claude/skills/harn-scripting/SKILL.md`.
 
 ## Release Workflow
 
-- Full release from a clean content commit: `./scripts/release_ship.sh --bump patch`
-- Audit: `./scripts/release_gate.sh audit` (uses `make test`, so `cargo-nextest` accelerates Rust tests when installed)
-- Dry-run full release: `./scripts/release_gate.sh full --bump patch --dry-run`
+- Open version-bump PR after release content lands: `./scripts/release_ship.sh --bump patch`
+- Finalize after bump PR lands: `./scripts/release_ship.sh --finalize`
+- Audit: `./scripts/release_gate.sh audit` (uses `make test`, so `cargo-nextest`
+  accelerates Rust tests when installed)
+- Dry-run release gate: `./scripts/release_gate.sh full --bump patch --dry-run`
 - Crate publishing helper: `./scripts/publish.sh --dry-run`
-- `release_ship.sh` pushes branch + tag before `cargo publish` so
+- `release_ship.sh --finalize` pushes the tag before `cargo publish` so
   downstream consumers (e.g. `burin-code`'s `fetch-harn`, GitHub release
   binary workflows) run in parallel with crates.io publication.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,6 @@ dependencies = [
  "regex",
  "reqwest",
  "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1174,7 +1173,6 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
- "tokio-stream",
  "toml",
  "tower 0.5.3",
  "tracing",
@@ -1187,8 +1185,6 @@ dependencies = [
 name = "harn-dap"
 version = "0.7.29"
 dependencies = [
- "harn-lexer",
- "harn-parser",
  "harn-vm",
  "serde",
  "serde_json",
@@ -1235,7 +1231,6 @@ dependencies = [
  "harn-lint",
  "harn-modules",
  "harn-parser",
- "serde_json",
  "tokio",
  "tower-lsp",
 ]
@@ -1271,7 +1266,6 @@ dependencies = [
  "harn-vm",
  "hex",
  "hmac",
- "serde",
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
@@ -2795,15 +2789,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.7.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -281,15 +281,23 @@ execution plus explicit host approval for destructive operations.
 ## Release Workflow
 
 Once the release content (code + docs + `CHANGELOG.md` entry for the next
-version) is committed and the tree is clean, maintainers run the full
-release ritual through:
+version) lands on `main` through the merge queue, maintainers open the
+automated version-bump PR with:
 
 ```bash
 ./scripts/release_ship.sh --bump patch
 ```
 
-This runs audit → dry-run publish → bump → commit → tag → push branch and
-tag → `cargo publish` → GitHub release creation in that order. The push
+After that PR lands through the merge queue, finalize the release from an
+up-to-date `main`:
+
+```bash
+./scripts/release_ship.sh --finalize
+```
+
+The first command runs audit → dry-run publish → bump → commit → push
+`release/vX.Y.Z` → open PR. The finalize command runs audit → dry-run publish
+→ tag → push tag → `cargo publish` → GitHub release creation. The tag push
 happens **before** `cargo publish` so downstream consumers and GitHub
 release-binary workflows can start working in parallel with crates.io.
 

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -42,7 +42,6 @@ async-trait = "0.1"
 axum = "0.8"
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "sync", "time"] }
-tokio-stream = "0.1"
 serde_json = "1"
 reedline = "0.47"
 nu-ansi-term = "0.50"
@@ -68,7 +67,6 @@ uuid = { version = "1", features = ["v4", "v7"] }
 chrono-tz = "0.10.4"
 croner = "3.0.1"
 jmespath = "0.5.0"
-rustls-pemfile = "2"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 tracing = "0.1"
 fs2 = "0.4"

--- a/crates/harn-dap/Cargo.toml
+++ b/crates/harn-dap/Cargo.toml
@@ -11,8 +11,6 @@ name = "harn-dap"
 path = "src/main.rs"
 
 [dependencies]
-harn-lexer = { path = "../harn-lexer", version = "0.7" }
-harn-parser = { path = "../harn-parser", version = "0.7" }
 harn-vm = { path = "../harn-vm", version = "0.7" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/harn-lsp/Cargo.toml
+++ b/crates/harn-lsp/Cargo.toml
@@ -19,4 +19,3 @@ harn-modules = { path = "../harn-modules", version = "0.7" }
 harn-fmt = { path = "../harn-fmt", version = "0.7" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std"] }
-serde_json = "1"

--- a/crates/harn-serve/Cargo.toml
+++ b/crates/harn-serve/Cargo.toml
@@ -12,7 +12,6 @@ axum = "0.8"
 futures = "0.3"
 harn-parser = { path = "../harn-parser", version = "0.7" }
 harn-vm = { path = "../harn-vm", version = "0.7" }
-serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "sync", "time"] }
 time = "0.3"

--- a/crates/harn-wasm/Cargo.toml
+++ b/crates/harn-wasm/Cargo.toml
@@ -14,5 +14,4 @@ harn-lexer = { path = "../harn-lexer", version = "0.7" }
 harn-parser = { path = "../harn-parser", version = "0.7" }
 harn-fmt = { path = "../harn-fmt", version = "0.7" }
 wasm-bindgen = "0.2"
-serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -743,16 +743,25 @@ Security guidance:
 
 ## Release gate
 
-For repo maintainers, the deterministic full-release path is:
+For repo maintainers, the merge-queue-safe release path opens the automated
+version-bump PR after the release-content PR lands on `main`:
 
 ```bash
 ./scripts/release_ship.sh --bump patch
 ```
 
-This runs audit → dry-run publish → bump → commit → tag → push → `cargo publish`
-→ GitHub release in that order. Pushing happens before `cargo publish` so
-downstream consumers (GitHub release binary workflows, `burin-code`'s
-`fetch-harn`) start in parallel with crates.io.
+After that bump PR lands through the merge queue, finalize from an up-to-date
+`main`:
+
+```bash
+./scripts/release_ship.sh --finalize
+```
+
+The first command runs audit → dry-run publish → bump → commit → push
+`release/vX.Y.Z` → open PR. Finalize runs audit → dry-run publish → tag → push
+tag → `cargo publish` → GitHub release. The tag push happens before
+`cargo publish` so downstream consumers (GitHub release binary workflows,
+`burin-code`'s `fetch-harn`) start in parallel with crates.io.
 
 For piecewise work, the docs audit, verification gate, bump flow, and publish
 sequence are exposed individually:

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -292,8 +292,9 @@ cmd_prepare() {
   echo "Version updated: $current -> $next"
   echo "Next steps:"
   echo "  1. Review docs/release notes diff"
-  echo "  2. Commit: git commit -am 'Bump version to $next'"
-  echo "  3. Tag after merge or final verification: git tag v$next"
+  echo "  2. Commit on a release/v$next branch: git commit -am 'Bump version to $next'"
+  echo "  3. Open a PR into main and let it land through the merge queue"
+  echo "  4. Finalize after merge: ./scripts/release_ship.sh --finalize"
 }
 
 cmd_publish() {
@@ -317,10 +318,13 @@ cmd_publish() {
   ./scripts/publish.sh ${dry_run}
   local version
   version="$(current_version)"
+  if [[ -n "$dry_run" ]]; then
+    echo "Publish dry run complete for v$version"
+    return
+  fi
   echo "Publish phase complete for v$version"
   echo "Follow-up:"
-  echo "  git tag v$version"
-  echo "  git push origin v$version"
+  echo "  Ensure tag v$version has been pushed from the merge-queue-approved main commit"
   echo "  Review changelog-backed GitHub release notes"
 }
 

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -59,36 +59,46 @@ log_step() {
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/release_ship.sh [--bump patch|minor|major] [--skip-dry-run] [--notes-output path] [--no-push]
+  ./scripts/release_ship.sh [--bump patch|minor|major] [--skip-dry-run] [--base main]
+  ./scripts/release_ship.sh --finalize [--skip-dry-run] [--notes-output path] [--base main]
 
-Deterministic release sequence for a prepared Harn release.
+Merge-queue-safe release sequence for a prepared Harn release.
 
 Assumptions:
   - Codex or a human has already reviewed pending tracked/untracked work.
   - README.md, CLAUDE.md, docs/, spec/, and CHANGELOG.md were updated as needed.
-  - The intended release content has already been committed.
+  - The intended release content has already landed on main through the merge queue.
   - The current worktree is clean before this script starts.
 
-This script then:
+Default mode then:
   1. Runs ./scripts/release_gate.sh audit
   2. Optionally runs ./scripts/release_gate.sh publish --dry-run
-  3. Runs ./scripts/release_gate.sh prepare --bump ...
-  4. Commits the version bump
-  5. Creates tag vX.Y.Z
-  6. Pushes the current branch and tag first (unless --no-push) so GitHub
-     release-binary workflows and downstream fetchers (e.g. burin-code's
-     fetch-harn) can start working in parallel with crates.io publication.
-  7. Runs ./scripts/release_gate.sh publish to upload crates to crates.io.
-  8. Renders changelog-backed release notes.
-  9. Creates/updates a GitHub release with the rendered notes (requires gh
-     CLI) as the final step, so the release body reflects crates.io state.
+  3. Creates release/vX.Y.Z
+  4. Runs ./scripts/release_gate.sh prepare --bump ...
+  5. Commits the version bump
+  6. Pushes release/vX.Y.Z and opens a "Bump version to X.Y.Z" PR.
+
+After that PR lands through the merge queue, run:
+
+  ./scripts/release_ship.sh --finalize
+
+Finalize mode:
+  1. Runs ./scripts/release_gate.sh audit
+  2. Optionally runs ./scripts/release_gate.sh publish --dry-run
+  3. Creates/pushes tag vX.Y.Z from main
+  4. Runs ./scripts/release_gate.sh publish to upload crates to crates.io
+  5. Renders changelog-backed release notes
+  6. Creates/updates a GitHub release with the rendered notes
 EOF
 }
 
 require_clean_tree() {
-  if ! git diff --quiet --ignore-submodules HEAD --; then
+  local status
+  status="$(git status --porcelain --untracked-files=normal)"
+  if [[ -n "$status" ]]; then
     echo "error: working tree is dirty"
-    echo "hint: commit README/docs/spec/changelog/release-content changes before running release_ship.sh"
+    printf '%s\n' "$status"
+    echo "hint: commit, stash, or discard changes before running release_ship.sh from main"
     exit 1
   fi
 }
@@ -103,15 +113,181 @@ print(m.group(1) if m else "")
 PY
 }
 
+next_version() {
+  local bump="$1"
+  python3 - "$bump" <<'PY'
+from pathlib import Path
+import re, sys
+bump = sys.argv[1]
+text = Path("Cargo.toml").read_text()
+m = re.search(r'^version = "([^"]+)"', text, re.M)
+if not m:
+    raise SystemExit("missing workspace version")
+major, minor, patch = map(int, m.group(1).split("."))
+if bump == "major":
+    major, minor, patch = major + 1, 0, 0
+elif bump == "minor":
+    minor, patch = minor + 1, 0
+elif bump == "patch":
+    patch += 1
+else:
+    raise SystemExit(f"unsupported bump: {bump}")
+print(f"{major}.{minor}.{patch}")
+PY
+}
+
+require_base_branch() {
+  local base="$1"
+  local branch
+  branch="$(git branch --show-current)"
+  if [[ "$branch" != "$base" ]]; then
+    echo "error: release_ship.sh must run from $base; current branch is ${branch:-detached}"
+    echo "hint: wait for release-content/version-bump PRs to land, then sync $base"
+    exit 1
+  fi
+  git fetch origin "$base" --quiet
+  local local_head remote_head
+  local_head="$(git rev-parse HEAD)"
+  remote_head="$(git rev-parse "origin/$base")"
+  if [[ "$local_head" != "$remote_head" ]]; then
+    echo "error: local $base is not up to date with origin/$base"
+    echo "hint: git pull --ff-only origin $base"
+    exit 1
+  fi
+}
+
+run_common_gates() {
+  # Build the portal frontend up front so `portal-dist/` exists for every
+  # downstream step. The `harn-cli` crate embeds portal-dist via `include_dir!`
+  # at compile time and ships it via the crate's `include = [...]` field, so
+  # both the audit (clippy + tests) and the subsequent cargo publish need the
+  # real bundle on disk. portal-dist/ is gitignored — a fresh clone or CI run
+  # would otherwise get the build.rs placeholder.
+  log_step "Build portal frontend"
+  make portal-check
+
+  log_step "Release audit"
+  ./scripts/release_gate.sh audit
+
+  if [[ "$SKIP_DRY_RUN" -eq 0 ]]; then
+    log_step "Publish dry run"
+    ./scripts/release_gate.sh publish --dry-run
+  fi
+}
+
+open_bump_pr() {
+  local base="$1"
+  local previous="$2"
+  local next="$3"
+  local branch="release/v$next"
+  local tag="v$next"
+
+  if git show-ref --verify --quiet "refs/heads/$branch"; then
+    echo "error: local branch already exists: $branch"
+    exit 1
+  fi
+
+  log_step "Create bump branch"
+  git switch -c "$branch"
+
+  log_step "Version bump"
+  ./scripts/release_gate.sh prepare --bump "$BUMP"
+  local actual_next
+  actual_next="$(current_version)"
+  if [[ "$actual_next" != "$next" ]]; then
+    echo "error: expected version $next, got $actual_next"
+    exit 1
+  fi
+
+  log_step "Commit version bump"
+  git add Cargo.toml Cargo.lock crates/*/Cargo.toml
+  git commit -m "Bump version to $next"
+
+  log_step "Push bump branch"
+  git push -u origin "$branch"
+
+  local body_file
+  body_file="$(mktemp)"
+  cat >"$body_file" <<EOF
+Automated version-bump PR for $tag.
+
+Release gates completed before opening this PR:
+
+- ./scripts/release_gate.sh audit
+- ./scripts/release_gate.sh publish --dry-run, unless --skip-dry-run was passed
+
+After this PR lands through the merge queue, finalize from an up-to-date $base:
+
+\`\`\`bash
+./scripts/release_ship.sh --finalize
+\`\`\`
+EOF
+
+  if command -v gh &>/dev/null; then
+    log_step "Open bump PR"
+    gh pr create \
+      --base "$base" \
+      --head "$branch" \
+      --title "Bump version to $next" \
+      --body-file "$body_file"
+  else
+    echo "warning: gh CLI not found — skipping PR creation"
+    echo "hint: open a PR from $branch into $base titled 'Bump version to $next'"
+  fi
+  rm -f "$body_file"
+
+  log_step "Bump PR ready"
+  TOTAL_NS=$(( $(_ship_now_ns) - SHIP_START_NS ))
+  echo ""
+  echo "Release bump PR ready:"
+  echo "  Previous version: $previous"
+  echo "  Next version:     $next"
+  echo "  Base branch:      $base"
+  echo "  Bump branch:      $branch"
+  echo "  Tag after merge:  $tag"
+  echo "  Total wall time:  $(_ship_fmt_ns "$TOTAL_NS")"
+  echo "  Finalize after merge queue lands it: ./scripts/release_ship.sh --finalize"
+}
+
+tag_exists() {
+  local tag="$1"
+  git rev-parse -q --verify "refs/tags/$tag" >/dev/null
+}
+
+ensure_tag_at_head() {
+  local tag="$1"
+  if tag_exists "$tag"; then
+    local tag_commit head_commit
+    tag_commit="$(git rev-list -n 1 "$tag")"
+    head_commit="$(git rev-parse HEAD)"
+    if [[ "$tag_commit" != "$head_commit" ]]; then
+      echo "error: $tag already exists at $tag_commit, but HEAD is $head_commit"
+      exit 1
+    fi
+    echo "Tag already exists at HEAD: $tag"
+  else
+    git tag "$tag"
+  fi
+}
+
 BUMP="patch"
 SKIP_DRY_RUN=0
-NO_PUSH=0
+MODE="bump-pr"
+BASE_BRANCH="main"
 NOTES_OUTPUT=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --bump)
       BUMP="${2:-}"
+      shift 2
+      ;;
+    --finalize)
+      MODE="finalize"
+      shift
+      ;;
+    --base)
+      BASE_BRANCH="${2:-}"
       shift 2
       ;;
     --skip-dry-run)
@@ -123,8 +299,9 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --no-push)
-      NO_PUSH=1
-      shift
+      echo "error: --no-push was removed from release_ship.sh"
+      echo "hint: use ./scripts/release_gate.sh prepare/publish/notes for manual piecewise work"
+      exit 1
       ;;
     -h|--help)
       usage
@@ -147,6 +324,7 @@ case "$BUMP" in
 esac
 
 require_clean_tree
+require_base_branch "$BASE_BRANCH"
 
 PREVIOUS_VERSION="$(current_version)"
 if [[ -z "$PREVIOUS_VERSION" ]]; then
@@ -154,51 +332,30 @@ if [[ -z "$PREVIOUS_VERSION" ]]; then
   exit 1
 fi
 
-# Build the portal frontend up front so `portal-dist/` exists for every
-# downstream step. The `harn-cli` crate embeds portal-dist via `include_dir!`
-# at compile time and ships it via the crate's `include = [...]` field, so
-# both the audit (clippy + tests) and the subsequent cargo publish need the
-# real bundle on disk. portal-dist/ is gitignored — a fresh clone or CI run
-# would otherwise get the build.rs placeholder.
-log_step "Build portal frontend"
-make portal-check
-
-log_step "Release audit"
-./scripts/release_gate.sh audit
-
-if [[ "$SKIP_DRY_RUN" -eq 0 ]]; then
-  log_step "Publish dry run"
-  ./scripts/release_gate.sh publish --dry-run
+if [[ "$MODE" == "bump-pr" ]]; then
+  NEXT_VERSION="$(next_version "$BUMP")"
+  if [[ "$NEXT_VERSION" == "$PREVIOUS_VERSION" ]]; then
+    echo "error: version did not change"
+    exit 1
+  fi
+  run_common_gates
+  open_bump_pr "$BASE_BRANCH" "$PREVIOUS_VERSION" "$NEXT_VERSION"
+  exit 0
 fi
 
-log_step "Version bump"
-./scripts/release_gate.sh prepare --bump "$BUMP"
-NEXT_VERSION="$(current_version)"
-
-if [[ "$NEXT_VERSION" == "$PREVIOUS_VERSION" ]]; then
-  echo "error: version did not change"
-  exit 1
-fi
-
-log_step "Commit version bump"
-git add Cargo.toml Cargo.lock crates/*/Cargo.toml
-git commit -m "Bump version to $NEXT_VERSION"
-
+NEXT_VERSION="$PREVIOUS_VERSION"
 TAG="v$NEXT_VERSION"
 BRANCH="$(git branch --show-current)"
 
-log_step "Tag"
-git tag "$TAG"
+run_common_gates
 
-# Push branch + tag before cargo publish so downstream consumers (e.g.
-# burin-code's fetch-harn script, GitHub release-binary workflows) can start
-# working in parallel with crates.io publication. crates.io is slower than
-# GitHub, and this ordering overlaps the two latencies.
-if [[ "$NO_PUSH" -eq 0 ]]; then
-  log_step "Push branch + tag"
-  git push origin "$BRANCH"
-  git push origin "$TAG"
-fi
+log_step "Tag"
+ensure_tag_at_head "$TAG"
+
+# Push the tag before cargo publish so GitHub release-binary workflows and
+# downstream fetchers can start working in parallel with crates.io publication.
+log_step "Push tag"
+git push origin "$TAG"
 
 log_step "Publish"
 ./scripts/release_gate.sh publish
@@ -219,7 +376,7 @@ cat "$NOTES_OUTPUT"
 # was slow, the upstream tag is already live — downstream CI will have
 # kicked off minutes ago.
 GH_RELEASE_URL=""
-if [[ "$NO_PUSH" -eq 0 ]] && command -v gh &>/dev/null; then
+if command -v gh &>/dev/null; then
   log_step "GitHub release"
   if gh release view "$TAG" &>/dev/null; then
     GH_RELEASE_URL="$(gh release edit "$TAG" --notes-file "$NOTES_OUTPUT" 2>&1)"
@@ -228,7 +385,7 @@ if [[ "$NO_PUSH" -eq 0 ]] && command -v gh &>/dev/null; then
     GH_RELEASE_URL="$(gh release create "$TAG" --title "$TAG" --notes-file "$NOTES_OUTPUT" 2>&1)"
     echo "Created release: $GH_RELEASE_URL"
   fi
-elif [[ "$NO_PUSH" -eq 0 ]]; then
+else
   echo "warning: gh CLI not found — skipping GitHub release creation"
   echo "hint: run 'gh release create $TAG --title \"$TAG\" --notes-file \"$NOTES_OUTPUT\"' manually"
 fi
@@ -243,11 +400,7 @@ echo "  Branch:           $BRANCH"
 echo "  Tag:              $TAG"
 echo "  Notes file:       $NOTES_OUTPUT"
 echo "  Total wall time:  $(_ship_fmt_ns "$TOTAL_NS")"
-if [[ "$NO_PUSH" -eq 1 ]]; then
-  echo "  Push status:      skipped (--no-push)"
-else
-  echo "  Push status:      pushed branch and tag"
-fi
+echo "  Push status:      pushed tag"
 if [[ -n "$GH_RELEASE_URL" ]]; then
   echo "  GitHub release:   $GH_RELEASE_URL"
 fi


### PR DESCRIPTION
## Summary

- Change `release_ship.sh` into a merge-queue-safe two-phase flow: default mode opens an automated version-bump PR, and `--finalize` tags/publishes only after that PR lands on `main`.
- Update Codex and Claude release skills/slash commands, README, CLI docs, and repo agent guidance to stop describing direct pushes to `main`.
- Keep the valid `cargo machete --fix` cleanup for unused manifest dependencies; restored `md-5` because `harn-vm` still uses it.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-codex-target-release-flow cargo check --workspace --all-targets`
- `bash -n scripts/release_ship.sh scripts/release_gate.sh`
- `shellcheck scripts/release_ship.sh scripts/release_gate.sh`
- `npx markdownlint-cli2 README.md AGENTS.md CLAUDE.md .codex/commands/harn-release.md .codex/skills/harn-release/SKILL.md .codex/skills/release-harn/SKILL.md .claude/commands/release-harn.md docs/src/cli-reference.md`
- pre-commit hook: formatting, clippy, highlight generation check, markdown, actionlint, portal lint
- pre-push hook: workspace tests, Harn formatting, markdown, portal lint
