### PR TITLE
Prepare v0.7.30 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,62 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
-## v0.7.29
+## v0.7.30
 
 ### Added
 
-- **Trigger budget governance (#162).** Trigger predicates now support
-  per-call cost/token ceilings, hourly and daily trigger spend caps,
-  global orchestrator budget caps, budget exhaustion strategies
-  (`false`, `retry_later`, `fail`, `warn`), budget metrics, and
-  `harn orchestrator inspect` budget usage.
+- **Trigger budget governance and autonomy budgets (#162, #435,
+  #437).** Trigger predicates now support per-call cost/token ceilings,
+  hourly and daily trigger spend caps, global orchestrator budget caps,
+  budget exhaustion strategies (`false`, `retry_later`, `fail`,
+  `warn`), budget metrics, and `harn orchestrator inspect` budget usage.
+- **Trigger action graph observability (#434).** Dispatch records now
+  expose richer action graph node kinds and runtime metadata so trigger
+  execution can be inspected and audited after the fact.
+- **A2A push notification connector (#436).** Harn can now receive A2A
+  push completion callbacks through the trigger inbox, with replay
+  protections and conformance coverage for accepted and rejected flows.
+- **OpenTrustGraph chain support (#420).** Added trust graph chain
+  primitives, schemas, fixtures, stdlib APIs, CLI plumbing, and docs for
+  recording and validating provenance-linked decisions.
+- **HITL typed supervision receipts (#418).** Human-in-the-loop approval
+  records now include typed signed receipt data that replays
+  deterministically, with stricter lint and conformance coverage.
+- **Portal and orchestrator observability surfaces (#419).** The
+  portal and orchestrator inspection paths now expose richer run,
+  launch, trust, and observability data, including a starter dashboard
+  for operators.
+
+### Changed
+
+- **VM execution pipeline performance (#421-#431).** The compiler and VM
+  now use typed opcodes, builtin ids, inline caches, local slots,
+  indexed struct layouts, leaner value storage, and flatter opcode
+  dispatch to reduce cloning, allocation, and call overhead.
+- **Local and CI release workflow (#439, #440).** Local setup, hooks,
+  Makefile targets, CI, and the release scripts now prefer nextest where
+  available, lint GitHub Actions, support merge-queue-safe release
+  branches, and document the two-PR release flow.
+- **Conformance and test isolation (#438).** Conformance runs are
+  faster and test execution disables real LLM calls by default unless a
+  test explicitly opts in.
 
 ### Fixed
 
 - **Line-leading nil-coalescing continuations.** Expressions can now
   continue on a following line that starts with `??`, equality, or
   comparison operators, matching the formatter and tree-sitter grammar.
+- **HTTP mock call headers (#432).** Mocked HTTP calls now record
+  request headers, making replay and conformance assertions cover the
+  full call shape.
+- **Webhook dedupe retention coverage (#417).** Webhook dedupe handling
+  has stronger regression coverage for retained deliveries and duplicate
+  suppression.
+
+## v0.7.29
+
+### Fixed
+
 - **Stable script source directories.** `harn run` now stores source
   directories as absolute paths before exposing them through
   `source_dir()`. Scripts can safely derive sibling paths from

--- a/crates/harn-modules/src/stdlib/stdlib_hitl.harn
+++ b/crates/harn-modules/src/stdlib/stdlib_hitl.harn
@@ -36,11 +36,18 @@ type ApprovalOptions = {
   deadline?: duration,
 }
 
+type ApprovalSignature = {
+  reviewer: string,
+  signed_at: string,
+  signature: string,
+}
+
 type ApprovalRecord = {
   approved: bool,
   reviewers: list<string>,
   approved_at: string,
   reason: string | nil,
+  signatures: list<ApprovalSignature>,
 }
 
 type EscalationStatus = "pending" | "accepted"

--- a/crates/harn-modules/src/stdlib/stdlib_project.harn
+++ b/crates/harn-modules/src/stdlib/stdlib_project.harn
@@ -396,6 +396,7 @@ fn __project_deep_scan_enrichment_options(namespace, entry, evidence, options) {
     temperature: options?.temperature ?? nil,
     budget_tokens: options?.budget_tokens_per_dir ?? nil,
     cache_key: "${namespace}/${entry.path}",
+    include_operator_meta: options?.include_operator_meta ?? false,
   }
 }
 

--- a/crates/harn-modules/src/stdlib/stdlib_triggers.harn
+++ b/crates/harn-modules/src/stdlib/stdlib_triggers.harn
@@ -194,11 +194,19 @@ type DlqEntry = {id: string, event_id: string, binding_id: string, binding_versi
 
 type TriggerActionGraphEvent = {kind: string, headers: dict, payload: dict}
 
-type TrustRecord = {schema: string, record_id: string, agent: string, action: string, approver: string | nil, outcome: TrustOutcome, trace_id: string, autonomy_tier: AutonomyTier, timestamp: string, cost_usd: float | nil, metadata: dict}
+type TrustEntryId = string
+
+type CapabilityPolicy = {tools: list<string>, capabilities: dict, workspace_roots: list<string>, side_effect_level: string | nil, recursion_limit: int | nil, tool_arg_constraints: list<dict>, tool_annotations: dict}
+
+type TrustRecord = {schema: string, record_id: string, agent: string, action: string, approver: string | nil, outcome: TrustOutcome, trace_id: string, autonomy_tier: AutonomyTier, timestamp: string, cost_usd: float | nil, chain_index: int, previous_hash: string | nil, entry_hash: string, metadata: dict}
 
 type TrustTraceGroup = {trace_id: string, records: list<TrustRecord>}
 
 type TrustQueryFilters = {agent: string | nil, action: string | nil, since: string | nil, until: string | nil, tier: AutonomyTier | nil, outcome: TrustOutcome | nil, limit: int | nil, grouped_by_trace: bool | nil}
+
+type TrustScore = {agent: string, action: string | nil, total: int, successes: int, failures: int, denied: int, timeouts: int, success_rate: float, latest_outcome: TrustOutcome | nil, latest_timestamp: string | nil, effective_tier: AutonomyTier, policy: CapabilityPolicy}
+
+type TrustChainReport = {topic: string, total: int, verified: bool, root_hash: string | nil, broken_at_event_id: int | nil, errors: list<string>}
 
 type HandlerContext = {agent: string, action: string, trace_id: string, replay_of_event_id: string | nil, autonomy_tier: AutonomyTier, trigger_event: TriggerEvent}
 


### PR DESCRIPTION
## Summary

- add the v0.7.30 changelog entry for post-v0.7.29 release content
- keep v0.7.29 scoped to the already-published stable source-directory fix
- sync harn-modules stdlib mirrors for HITL approval signatures, project enrichment operator metadata, and trust graph chain types so package verification passes

## Verification

- python3 scripts/verify_release_metadata.py
- python3 scripts/render_release_notes.py --version 0.7.30
- cargo fmt --all
- make test
- cargo run --bin harn -- test conformance
- ./scripts/verify_crate_packages.sh
- ./scripts/release_gate.sh audit
- pre-commit hook
- pre-push hook

## Release Flow

After this lands through the merge queue, sync main and run:

```bash
./scripts/release_ship.sh --bump patch
```

That opens the separate `Bump version to 0.7.30` PR. Finalize only after the bump PR lands.