### PR TITLE
Stabilize stranded envelope crash test

### DIFF
--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -36,6 +36,7 @@ const PENDING_TOPIC: &str = "orchestrator.triggers.pending";
 const CRON_TICK_TOPIC: &str = "connectors.cron.tick";
 const TEST_PUMP_DELAY_ENV: &str = "HARN_TEST_ORCHESTRATOR_PUMP_DELAY_MS";
 const TEST_INBOX_TASK_DELAY_ENV: &str = "HARN_TEST_ORCHESTRATOR_INBOX_TASK_DELAY_MS";
+const TEST_INBOX_TASK_RELEASE_FILE_ENV: &str = "HARN_TEST_ORCHESTRATOR_INBOX_TASK_RELEASE_FILE";
 const TEST_FAIL_PENDING_PUMP_ENV: &str = "HARN_TEST_ORCHESTRATOR_FAIL_PENDING_PUMP";
 const WAITPOINT_SERVICE_INTERVAL: Duration = Duration::from_millis(250);
 
@@ -917,6 +918,7 @@ fn spawn_inbox_pump(
     let consumer = pump_consumer_id(&topic)?;
     let test_delay = pump_test_delay();
     let inbox_task_delay = inbox_task_test_delay();
+    let inbox_task_release_file = inbox_task_test_release_file();
     let (mode_tx, mut mode_rx) = watch::channel(PumpMode::Running);
     let join = tokio::task::spawn_local(async move {
         let start_from = event_log
@@ -1008,7 +1010,11 @@ fn spawn_inbox_pump(
                         serde_json::from_value(logged.payload)
                             .map_err(|error| format!("failed to decode dispatcher inbox event: {error}"))?;
                     let dispatcher = dispatcher.clone();
+                    let inbox_task_release_file = inbox_task_release_file.clone();
                     tasks.spawn_local(async move {
+                        if let Some(path) = inbox_task_release_file.as_ref() {
+                            wait_for_inbox_task_release_file(path).await;
+                        }
                         if let Some(delay) = inbox_task_delay {
                             tokio::time::sleep(delay).await;
                         }
@@ -1651,6 +1657,18 @@ fn inbox_task_test_delay() -> Option<Duration> {
         .and_then(|value| value.trim().parse::<u64>().ok())
         .map(Duration::from_millis)
         .filter(|delay| !delay.is_zero())
+}
+
+fn inbox_task_test_release_file() -> Option<PathBuf> {
+    std::env::var_os(TEST_INBOX_TASK_RELEASE_FILE_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+async fn wait_for_inbox_task_release_file(path: &Path) {
+    while tokio::fs::metadata(path).await.is_err() {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
 }
 
 fn pending_pump_test_should_fail() -> bool {

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -915,11 +915,17 @@ pub fn on_task(event: TriggerEvent) -> string {
 "#,
     );
 
+    let inbox_release_file = temp.path().join("release-inbox-dispatch");
+    let inbox_release_file = inbox_release_file.to_string_lossy().into_owned();
     let envs = [
         ("HARN_EVENT_LOG_BACKEND", "file"),
         ("HARN_ORCHESTRATOR_API_KEYS", "test-key"),
         ("HARN_ORCHESTRATOR_HMAC_SECRET", "unused-shared-secret"),
         ("HARN_TEST_DISPATCHER_FAIL_BEFORE_OUTBOX", "1"),
+        (
+            "HARN_TEST_ORCHESTRATOR_INBOX_TASK_RELEASE_FILE",
+            inbox_release_file.as_str(),
+        ),
     ];
     let (mut crashing_child, crashing_rx, crashing_handle) =
         spawn_orchestrator_with(&temp, &[], &envs);
@@ -931,8 +937,9 @@ pub fn on_task(event: TriggerEvent) -> string {
         .headers(bearer_headers())
         .body(body.to_vec())
         .send()
-        .await
-        .unwrap();
+        .await;
+    fs::write(&inbox_release_file, b"release").unwrap();
+    let response = response.unwrap();
     assert_eq!(response.status(), reqwest::StatusCode::OK);
 
     wait_for_exit_code(&mut crashing_child, 86);


### PR DESCRIPTION
## Summary
- add a test-only release-file gate for spawned inbox dispatch tasks
- use the gate in the stranded envelope crash/recovery test so the forced dispatcher exit cannot race the HTTP accept response

## Verification
- cargo test -p harn-cli --test orchestrator_cli restart_surfaces_stranded_envelopes_and_recover_replays_them_explicitly -- --nocapture
- 10x loop of the targeted stranded envelope test
- cargo test -p harn-cli --test orchestrator_cli -- --nocapture
- make test
- ./scripts/release_gate.sh audit
- pre-commit hook
- pre-push hook
