### PR TITLE
Stabilize orchestrator timing tests

### DIFF
--- a/conformance/tests/integration/orchestrator_bounded_drain_resume.expected
+++ b/conformance/tests/integration/orchestrator_bounded_drain_resume.expected
@@ -2,4 +2,3 @@ true
 true
 true
 true
-true

--- a/conformance/tests/integration/orchestrator_bounded_drain_resume.harn
+++ b/conformance/tests/integration/orchestrator_bounded_drain_resume.harn
@@ -79,18 +79,41 @@ pipeline default() {
         "--shutdown-timeout",
         "5",
         "--drain-max-items",
-        "100",
+        "10",
         "--drain-deadline",
         "1",
     ]
 
-    def start(delay_ms, log_name):
+    pump_release_file = base / "release-pending-pump"
+    pump_waiting_file = base / "pending-pump-waiting"
+    pump_draining_file = base / "pending-pump-draining"
+
+    def reset_gate_files():
+        for path in (pump_release_file, pump_waiting_file, pump_draining_file):
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+
+    def touch(path):
+        path.write_text("release", encoding="utf-8")
+
+    def wait_path(path, label):
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            if path.exists():
+                return
+            time.sleep(0.05)
+        raise RuntimeError(f"timed out waiting for {label}: {path}")
+
+    def start(gated, log_name):
         env = os.environ.copy()
         env.update(common_env)
-        if delay_ms is not None:
-            env["HARN_TEST_ORCHESTRATOR_PUMP_DELAY_MS"] = str(delay_ms)
-        else:
-            env.pop("HARN_TEST_ORCHESTRATOR_PUMP_DELAY_MS", None)
+        if gated:
+            reset_gate_files()
+            env["HARN_TEST_ORCHESTRATOR_PUMP_RELEASE_FILE"] = str(pump_release_file)
+            env["HARN_TEST_ORCHESTRATOR_PUMP_WAITING_FILE"] = str(pump_waiting_file)
+            env["HARN_TEST_ORCHESTRATOR_PUMP_DRAINING_FILE"] = str(pump_draining_file)
         log = open(base / log_name, "w", encoding="utf-8")
         proc = subprocess.Popen(
             [binary, *extra_args],
@@ -130,7 +153,7 @@ pipeline default() {
             time.sleep(0.1)
         raise RuntimeError(f"timed out waiting for {expected} dispatch_succeeded rows")
 
-    first_proc, first_log = start(50, "orchestrator-first.log")
+    first_proc, first_log = start(True, "orchestrator-first.log")
     try:
         bind = wait_ready("orchestrator-first.log")
         host, port = bind.split(":")
@@ -153,10 +176,11 @@ pipeline default() {
                 raise RuntimeError(f"flood request {index} failed: {response.status} {payload!r}")
         conn.close()
 
-        shutdown_start = time.monotonic()
+        wait_path(pump_waiting_file, "pending pump to pause")
         first_proc.send_signal(signal.SIGTERM)
+        wait_path(pump_draining_file, "pending pump drain to start")
+        touch(pump_release_file)
         first_proc.wait(timeout=10)
-        shutdown_ms = int((time.monotonic() - shutdown_start) * 1000)
         if first_proc.returncode != 0:
             raise RuntimeError(f"first orchestrator exited with {first_proc.returncode}")
     finally:
@@ -171,7 +195,7 @@ pipeline default() {
         raise RuntimeError("missing drain_truncated lifecycle event")
     truncated = json.loads(row[0])
 
-    second_proc, second_log = start(None, "orchestrator-second.log")
+    second_proc, second_log = start(False, "orchestrator-second.log")
     try:
         wait_ready("orchestrator-second.log")
         outbox_count = wait_outbox(40)
@@ -185,7 +209,6 @@ pipeline default() {
     print(
         json.dumps(
             {
-                "shutdown_ms": shutdown_ms,
                 "truncated": True,
                 "remaining_queued": truncated.get("remaining_queued", 0),
                 "outbox_count": outbox_count,
@@ -201,7 +224,6 @@ pipeline default() {
     return
   }
   let summary = json_parse(result.stdout.trim())
-  println(summary.shutdown_ms <= 4000)
   println(summary.truncated == true)
   println(summary.remaining_queued > 0)
   println(summary.outbox_count == 40)

--- a/conformance/tests/integration/orchestrator_hot_reload_modify_inflight.harn
+++ b/conformance/tests/integration/orchestrator_hot_reload_modify_inflight.harn
@@ -36,13 +36,17 @@ pipeline default() {
     first_path="$base/first.json"
     second_path="$base/second.json"
     old_path="$base/old.json"
+    request_entered_path="$base/request-entered"
+    request_release_path="$base/request-release"
+    rm -f "$request_entered_path" "$request_release_path"
 
     # #224 made a2a-push routes require bearer+HMAC auth at startup; supply
     # dummy credentials so the orchestrator can finish booting. This test
     # doesn't exercise auth — the bearer credential just has to exist and
     # the HMAC secret just has to be non-empty (the test uses the bearer
     # path for all POSTs).
-    HARN_ORCHESTRATOR_TEST_REQUEST_DELAY_MS=250 \
+    HARN_ORCHESTRATOR_TEST_REQUEST_ENTERED_FILE="$request_entered_path" \
+    HARN_ORCHESTRATOR_TEST_REQUEST_RELEASE_FILE="$request_release_path" \
     HARN_ORCHESTRATOR_API_KEYS="hot-reload-test-key" \
     HARN_ORCHESTRATOR_HMAC_SECRET="hot-reload-test-hmac-secret" \
       "$binary" orchestrator serve \
@@ -92,24 +96,7 @@ pipeline default() {
 
     base_url="http://$bind"
 
-    (
-      sleep 0.12
-      cat > "$workspace/harn.toml" <<'EOF'
-    [package]
-    name = "orchestrator_hot_reload"
-
-    [[triggers]]
-    id = "incoming-review-task"
-    kind = "a2a-push"
-    provider = "a2a-push"
-    path = "/a2a/v2"
-    match = { events = ["a2a.task.received"] }
-    handler = "worker://triage"
-    EOF
-      kill -HUP "$pid"
-    ) &
-
-    python3 - "$base_url/a2a/v1" "$first_path" <<'PY'
+    python3 - "$base_url/a2a/v1" "$first_path" <<'PY' &
     import json, pathlib, sys, urllib.error, urllib.request
     url = sys.argv[1]
     out = pathlib.Path(sys.argv[2])
@@ -131,6 +118,34 @@ pipeline default() {
         body = error.read().decode()
         out.write_text(json.dumps({"status": error.code, "body": body}))
     PY
+    first_request_pid=$!
+
+    python3 - "$request_entered_path" "$log_path" <<'PY'
+    import pathlib, sys, time
+    marker = pathlib.Path(sys.argv[1])
+    log = pathlib.Path(sys.argv[2])
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        if marker.exists():
+            raise SystemExit(0)
+        time.sleep(0.05)
+    tail = log.read_text()[-4000:] if log.exists() else "(missing log)"
+    raise SystemExit(f"timed out waiting for first request to enter listener\n{tail}")
+    PY
+
+    cat > "$workspace/harn.toml" <<'EOF'
+    [package]
+    name = "orchestrator_hot_reload"
+
+    [[triggers]]
+    id = "incoming-review-task"
+    kind = "a2a-push"
+    provider = "a2a-push"
+    path = "/a2a/v2"
+    match = { events = ["a2a.task.received"] }
+    handler = "worker://triage"
+    EOF
+    kill -HUP "$pid"
 
     python3 - "$snapshot_path" <<'PY'
     import json, pathlib, sys, time
@@ -145,6 +160,9 @@ pipeline default() {
         time.sleep(0.05)
     raise SystemExit("timed out waiting for manifest reload")
     PY
+
+    : > "$request_release_path"
+    wait "$first_request_pid"
 
     python3 - "$base_url/a2a/v2" "$second_path" <<'PY'
     import json, pathlib, sys, urllib.error, urllib.request

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
@@ -27,7 +28,8 @@ use crate::package::{CollectedManifestTrigger, TriggerKind};
 const DEFAULT_MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
 const ADMIN_RELOAD_PATH: &str = "/admin/reload";
 const PENDING_TOPIC: &str = "orchestrator.triggers.pending";
-const REQUEST_DELAY_ENV: &str = "HARN_ORCHESTRATOR_TEST_REQUEST_DELAY_MS";
+const REQUEST_ENTERED_FILE_ENV: &str = "HARN_ORCHESTRATOR_TEST_REQUEST_ENTERED_FILE";
+const REQUEST_RELEASE_FILE_ENV: &str = "HARN_ORCHESTRATOR_TEST_REQUEST_RELEASE_FILE";
 const API_KEYS_ENV: &str = "HARN_ORCHESTRATOR_API_KEYS";
 const HMAC_SECRET_ENV: &str = "HARN_ORCHESTRATOR_HMAC_SECRET";
 const AUTH_TIMESTAMP_WINDOW_SECS: i64 = 5 * 60;
@@ -109,11 +111,10 @@ impl ListenerRuntime {
             .iter()
             .any(|route| route.auth_mode.requires_credentials());
         let auth = Arc::new(ListenerAuth::from_env(requires_auth)?);
-        let request_delay = std::env::var(REQUEST_DELAY_ENV)
-            .ok()
-            .and_then(|value| value.parse::<u64>().ok())
-            .filter(|value| *value > 0)
-            .map(Duration::from_millis);
+        let request_gate = TestRequestGate {
+            entered_file: test_file_from_env(REQUEST_ENTERED_FILE_ENV),
+            release_file: test_file_from_env(REQUEST_RELEASE_FILE_ENV),
+        };
         let origin_state = Arc::new(config.allowed_origins.clone());
         let admin_state = config.admin_reload.clone().map(|reload| {
             Arc::new(AdminReloadState {
@@ -130,7 +131,7 @@ impl ListenerRuntime {
             config.metrics_registry.clone(),
             auth.clone(),
             pending_topic.clone(),
-            request_delay,
+            request_gate,
         )?);
         let mut app = Router::new()
             .route(
@@ -333,8 +334,14 @@ struct RouteContext {
     metrics_registry: Arc<harn_vm::MetricsRegistry>,
     auth: Arc<ListenerAuth>,
     pending_topic: Topic,
-    request_delay: Option<Duration>,
+    request_gate: TestRequestGate,
     metrics: Arc<RouteRuntimeMetrics>,
+}
+
+#[derive(Clone, Default)]
+struct TestRequestGate {
+    entered_file: Option<PathBuf>,
+    release_file: Option<PathBuf>,
 }
 
 #[derive(Clone)]
@@ -365,7 +372,7 @@ struct RouteRegistry {
     metrics_registry: Arc<harn_vm::MetricsRegistry>,
     auth: Arc<ListenerAuth>,
     pending_topic: Topic,
-    request_delay: Option<Duration>,
+    request_gate: TestRequestGate,
 }
 
 impl RouteRegistry {
@@ -377,7 +384,7 @@ impl RouteRegistry {
         metrics_registry: Arc<harn_vm::MetricsRegistry>,
         auth: Arc<ListenerAuth>,
         pending_topic: Topic,
-        request_delay: Option<Duration>,
+        request_gate: TestRequestGate,
     ) -> Result<Self, String> {
         let registry = Self {
             routes_by_path: RwLock::new(BTreeMap::new()),
@@ -388,7 +395,7 @@ impl RouteRegistry {
             metrics_registry,
             auth,
             pending_topic,
-            request_delay,
+            request_gate,
         };
         registry.reload(routes)?;
         Ok(registry)
@@ -416,7 +423,7 @@ impl RouteRegistry {
                     metrics_registry: self.metrics_registry.clone(),
                     auth: self.auth.clone(),
                     pending_topic: self.pending_topic.clone(),
-                    request_delay: self.request_delay,
+                    request_gate: self.request_gate.clone(),
                     metrics,
                 }),
             );
@@ -575,8 +582,30 @@ async fn ingest_trigger(
             return response;
         }
 
-        if let Some(delay) = context.request_delay {
-            tokio::time::sleep(delay).await;
+        if let Some(path) = context.request_gate.entered_file.as_ref() {
+            if let Err(error) = mark_test_file(path).await {
+                context.metrics.failed.fetch_add(1, Ordering::Relaxed);
+                context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+                context.metrics_registry.set_trigger_inflight(
+                    &context.route.trigger_id,
+                    context.metrics.in_flight.load(Ordering::Relaxed),
+                );
+                let response = finalize_response(
+                    &context,
+                    (StatusCode::INTERNAL_SERVER_ERROR, error).into_response(),
+                );
+                context.metrics_registry.record_http_request(
+                    &context.route.path,
+                    method.as_str(),
+                    response.status().as_u16(),
+                    request_started.elapsed(),
+                    body_size_bytes,
+                );
+                return response;
+            }
+        }
+        if let Some(path) = context.request_gate.release_file.as_ref() {
+            wait_for_test_release_file(path).await;
         }
 
         let result = normalize_request(
@@ -1373,6 +1402,29 @@ impl IntoResponse for HttpError {
     }
 }
 
+fn test_file_from_env(key: &str) -> Option<PathBuf> {
+    std::env::var_os(key)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+async fn wait_for_test_release_file(path: &Path) {
+    while tokio::fs::metadata(path).await.is_err() {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn mark_test_file(path: &Path) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+    tokio::fs::write(path, b"1")
+        .await
+        .map_err(|error| format!("failed to write {}: {error}", path.display()))
+}
+
 #[cfg(test)]
 // Tests below hold the shared `lock_harn_state` guard across `.await`
 // points; the guard is dropped when each `#[tokio::test]` future resolves
@@ -1572,7 +1624,10 @@ mod tests {
         .await
         .expect("install v1 binding");
 
-        std::env::set_var(REQUEST_DELAY_ENV, "200");
+        let request_entered_path = dir.path().join("request-entered");
+        let request_release_path = dir.path().join("request-release");
+        std::env::set_var(REQUEST_ENTERED_FILE_ENV, &request_entered_path);
+        std::env::set_var(REQUEST_RELEASE_FILE_ENV, &request_release_path);
         let listener = ListenerRuntime::start(ListenerConfig {
             bind: "127.0.0.1:0".parse().expect("bind addr"),
             tls: None,
@@ -1606,7 +1661,7 @@ mod tests {
             })
         };
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        wait_for_test_release_file(&request_entered_path).await;
         harn_vm::install_manifest_triggers(vec![manifest_binding_spec(
             "incoming-review-task",
             "v2",
@@ -1616,6 +1671,9 @@ mod tests {
         listener
             .reload_routes(vec![route("/a2a/v2", 2)])
             .expect("reload listener routes");
+        tokio::fs::write(&request_release_path, b"release")
+            .await
+            .expect("release first request");
 
         assert_eq!(
             first_request.await.expect("join first request"),
@@ -1675,7 +1733,8 @@ mod tests {
             .shutdown(Duration::from_secs(5))
             .await
             .expect("shutdown listener");
-        std::env::remove_var(REQUEST_DELAY_ENV);
+        std::env::remove_var(REQUEST_ENTERED_FILE_ENV);
+        std::env::remove_var(REQUEST_RELEASE_FILE_ENV);
         reset_active_event_log();
         harn_vm::clear_trigger_registry();
     }

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -34,8 +34,9 @@ const MANIFEST_TOPIC: &str = "orchestrator.manifest";
 const STATE_SNAPSHOT_FILE: &str = "orchestrator-state.json";
 const PENDING_TOPIC: &str = "orchestrator.triggers.pending";
 const CRON_TICK_TOPIC: &str = "connectors.cron.tick";
-const TEST_PUMP_DELAY_ENV: &str = "HARN_TEST_ORCHESTRATOR_PUMP_DELAY_MS";
-const TEST_INBOX_TASK_DELAY_ENV: &str = "HARN_TEST_ORCHESTRATOR_INBOX_TASK_DELAY_MS";
+const TEST_PUMP_RELEASE_FILE_ENV: &str = "HARN_TEST_ORCHESTRATOR_PUMP_RELEASE_FILE";
+const TEST_PUMP_WAITING_FILE_ENV: &str = "HARN_TEST_ORCHESTRATOR_PUMP_WAITING_FILE";
+const TEST_PUMP_DRAINING_FILE_ENV: &str = "HARN_TEST_ORCHESTRATOR_PUMP_DRAINING_FILE";
 const TEST_INBOX_TASK_RELEASE_FILE_ENV: &str = "HARN_TEST_ORCHESTRATOR_INBOX_TASK_RELEASE_FILE";
 const TEST_FAIL_PENDING_PUMP_ENV: &str = "HARN_TEST_ORCHESTRATOR_FAIL_PENDING_PUMP";
 const WAITPOINT_SERVICE_INTERVAL: Duration = Duration::from_millis(250);
@@ -822,6 +823,9 @@ impl PumpHandle {
             config,
             deadline: drain_deadline,
         }));
+        if let Some(path) = pump_test_draining_file() {
+            mark_test_file(&path).await?;
+        }
         match self.join.await {
             Ok(result) => result,
             Err(error) => Err(format!("pump task join failed: {error}")),
@@ -916,8 +920,6 @@ fn spawn_inbox_pump(
     let topic = harn_vm::event_log::Topic::new(harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC)
         .map_err(|error| error.to_string())?;
     let consumer = pump_consumer_id(&topic)?;
-    let test_delay = pump_test_delay();
-    let inbox_task_delay = inbox_task_test_delay();
     let inbox_task_release_file = inbox_task_test_release_file();
     let (mode_tx, mut mode_rx) = watch::channel(PumpMode::Running);
     let join = tokio::task::spawn_local(async move {
@@ -995,9 +997,6 @@ fn spawn_inbox_pump(
                     };
                     let (event_id, logged) = received
                         .map_err(|error| format!("topic pump read failed for {topic}: {error}"))?;
-                    if let Some(delay) = test_delay {
-                        tokio::time::sleep(delay).await;
-                    }
                     if logged.kind != "event_ingested" {
                         stats.last_seen = event_id;
                         event_log
@@ -1013,10 +1012,7 @@ fn spawn_inbox_pump(
                     let inbox_task_release_file = inbox_task_release_file.clone();
                     tasks.spawn_local(async move {
                         if let Some(path) = inbox_task_release_file.as_ref() {
-                            wait_for_inbox_task_release_file(path).await;
-                        }
-                        if let Some(delay) = inbox_task_delay {
-                            tokio::time::sleep(delay).await;
+                            wait_for_test_release_file(path).await;
                         }
                         if let Err(error) = dispatcher.dispatch_inbox_envelope(envelope).await {
                             eprintln!("[harn] inbox dispatch warning: {error}");
@@ -1125,7 +1121,8 @@ where
     Fut: std::future::Future<Output = Result<bool, String>> + 'static,
 {
     let consumer = pump_consumer_id(&topic)?;
-    let test_delay = pump_test_delay();
+    let test_release_file = pump_test_release_file();
+    let test_waiting_file = pump_test_waiting_file();
     let (mode_tx, mut mode_rx) = watch::channel(PumpMode::Running);
     let join = tokio::task::spawn_local(async move {
         let start_from = event_log
@@ -1189,8 +1186,11 @@ where
                     };
                     let (event_id, logged) = received
                         .map_err(|error| format!("topic pump read failed for {topic}: {error}"))?;
-                    if let Some(delay) = test_delay {
-                        tokio::time::sleep(delay).await;
+                    if let Some(path) = test_release_file.as_ref() {
+                        if let Some(waiting_path) = test_waiting_file.as_ref() {
+                            mark_test_file(waiting_path).await?;
+                        }
+                        wait_for_test_release_file(path).await;
                     }
                     let handled = process(logged).await?;
                     stats.last_seen = event_id;
@@ -1643,32 +1643,43 @@ fn pump_consumer_id(topic: &harn_vm::event_log::Topic) -> Result<ConsumerId, Str
         .map_err(|error| format!("failed to create consumer id for {topic}: {error}"))
 }
 
-fn pump_test_delay() -> Option<Duration> {
-    std::env::var(TEST_PUMP_DELAY_ENV)
-        .ok()
-        .and_then(|value| value.trim().parse::<u64>().ok())
-        .map(Duration::from_millis)
-        .filter(|delay| !delay.is_zero())
+fn pump_test_release_file() -> Option<PathBuf> {
+    test_file_from_env(TEST_PUMP_RELEASE_FILE_ENV)
 }
 
-fn inbox_task_test_delay() -> Option<Duration> {
-    std::env::var(TEST_INBOX_TASK_DELAY_ENV)
-        .ok()
-        .and_then(|value| value.trim().parse::<u64>().ok())
-        .map(Duration::from_millis)
-        .filter(|delay| !delay.is_zero())
+fn pump_test_waiting_file() -> Option<PathBuf> {
+    test_file_from_env(TEST_PUMP_WAITING_FILE_ENV)
+}
+
+fn pump_test_draining_file() -> Option<PathBuf> {
+    test_file_from_env(TEST_PUMP_DRAINING_FILE_ENV)
 }
 
 fn inbox_task_test_release_file() -> Option<PathBuf> {
-    std::env::var_os(TEST_INBOX_TASK_RELEASE_FILE_ENV)
+    test_file_from_env(TEST_INBOX_TASK_RELEASE_FILE_ENV)
+}
+
+fn test_file_from_env(key: &str) -> Option<PathBuf> {
+    std::env::var_os(key)
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
 }
 
-async fn wait_for_inbox_task_release_file(path: &Path) {
+async fn wait_for_test_release_file(path: &Path) {
     while tokio::fs::metadata(path).await.is_err() {
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
+}
+
+async fn mark_test_file(path: &Path) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+    tokio::fs::write(path, b"1")
+        .await
+        .map_err(|error| format!("failed to write {}: {error}", path.display()))
 }
 
 fn pending_pump_test_should_fail() -> bool {

--- a/crates/harn-cli/tests/harn_serve_mcp_cli.rs
+++ b/crates/harn-cli/tests/harn_serve_mcp_cli.rs
@@ -13,9 +13,10 @@ use std::time::{Duration, Instant};
 
 use serde_json::{json, Value as JsonValue};
 use tempfile::TempDir;
+use tokio::sync::oneshot;
 
 static HARN_SERVE_MCP_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-const JSON_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+const TEST_TIMEOUT: Duration = Duration::from_secs(2);
 
 fn lock_harn_serve_mcp_tests() -> MutexGuard<'static, ()> {
     HARN_SERVE_MCP_TEST_LOCK
@@ -82,9 +83,9 @@ where
 }
 
 fn wait_for_http_listener(child: &mut std::process::Child, rx: &Receiver<String>) -> String {
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + TEST_TIMEOUT;
     while Instant::now() < deadline {
-        match rx.recv_timeout(Duration::from_millis(100)) {
+        match rx.recv_timeout(Duration::from_millis(25)) {
             Ok(line) if line.contains("MCP workflow server ready on ") => {
                 return line
                     .split("MCP workflow server ready on ")
@@ -113,6 +114,25 @@ fn parse_sse_messages(body: &str) -> Vec<JsonValue> {
         .filter(|line| !line.is_empty())
         .filter_map(|line| serde_json::from_str(line).ok())
         .collect()
+}
+
+async fn collect_sse_body_after_progress(
+    mut response: reqwest::Response,
+    mut progress_seen: Option<oneshot::Sender<()>>,
+) -> String {
+    let mut body = String::new();
+    while let Some(chunk) = response.chunk().await.unwrap() {
+        let chunk = std::str::from_utf8(&chunk).unwrap();
+        body.push_str(chunk);
+        if progress_seen.is_some()
+            && parse_sse_messages(&body)
+                .iter()
+                .any(|message| message["method"] == "notifications/progress")
+        {
+            let _ = progress_seen.take().unwrap().send(());
+        }
+    }
+    body
 }
 
 #[test]
@@ -150,7 +170,7 @@ fn serve_mcp_stdio_lists_calls_and_cancels_exported_functions() {
         })
     )
     .unwrap();
-    let init = recv_until(&rx, JSON_RPC_TIMEOUT, |message| message["id"] == 1);
+    let init = recv_until(&rx, TEST_TIMEOUT, |message| message["id"] == 1);
     assert_eq!(init["result"]["serverInfo"]["name"], "server");
 
     writeln!(
@@ -164,7 +184,7 @@ fn serve_mcp_stdio_lists_calls_and_cancels_exported_functions() {
         })
     )
     .unwrap();
-    let tools = recv_until(&rx, JSON_RPC_TIMEOUT, |message| message["id"] == 2);
+    let tools = recv_until(&rx, TEST_TIMEOUT, |message| message["id"] == 2);
     let names = tools["result"]["tools"]
         .as_array()
         .unwrap()
@@ -187,7 +207,7 @@ fn serve_mcp_stdio_lists_calls_and_cancels_exported_functions() {
         })
     )
     .unwrap();
-    let greet = recv_until(&rx, JSON_RPC_TIMEOUT, |message| message["id"] == 3);
+    let greet = recv_until(&rx, TEST_TIMEOUT, |message| message["id"] == 3);
     assert_eq!(
         greet["result"]["structuredContent"]["message"],
         json!("Hello, alice!")
@@ -207,7 +227,7 @@ fn serve_mcp_stdio_lists_calls_and_cancels_exported_functions() {
         })
     )
     .unwrap();
-    let fail = recv_until(&rx, JSON_RPC_TIMEOUT, |message| message["id"] == 4);
+    let fail = recv_until(&rx, TEST_TIMEOUT, |message| message["id"] == 4);
     assert_eq!(fail["result"]["isError"], json!(true));
     assert!(fail.get("error").is_none());
 
@@ -226,7 +246,7 @@ fn serve_mcp_stdio_lists_calls_and_cancels_exported_functions() {
         })
     )
     .unwrap();
-    let progress = recv_until(&rx, JSON_RPC_TIMEOUT, |message| {
+    let progress = recv_until(&rx, TEST_TIMEOUT, |message| {
         message["method"] == "notifications/progress"
     });
     assert_eq!(progress["params"]["progressToken"], json!("spin-stdio"));
@@ -256,7 +276,7 @@ fn serve_mcp_stdio_lists_calls_and_cancels_exported_functions() {
         })
     )
     .unwrap();
-    let ping = recv_until(&rx, JSON_RPC_TIMEOUT, |message| message["id"] == 6);
+    let ping = recv_until(&rx, TEST_TIMEOUT, |message| message["id"] == 6);
     assert_eq!(ping["result"], json!({}));
 
     drop(stdin);
@@ -360,12 +380,13 @@ async fn serve_mcp_http_streams_progress_and_enforces_api_keys() {
     let unauthorized_messages = parse_sse_messages(&unauthorized_body);
     assert_eq!(unauthorized_messages[0]["error"]["code"], json!(-32001));
 
+    let (progress_tx, progress_rx) = oneshot::channel();
     let call_task = tokio::spawn({
         let client = client.clone();
         let url = url.clone();
         let session_id = session_id.clone();
         async move {
-            client
+            let response = client
                 .post(&url)
                 .header("Accept", "application/json, text/event-stream")
                 .header("mcp-session-id", &session_id)
@@ -382,14 +403,15 @@ async fn serve_mcp_http_streams_progress_and_enforces_api_keys() {
                 }))
                 .send()
                 .await
-                .unwrap()
-                .text()
-                .await
-                .unwrap()
+                .unwrap();
+            collect_sse_body_after_progress(response, Some(progress_tx)).await
         }
     });
 
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    tokio::time::timeout(TEST_TIMEOUT, progress_rx)
+        .await
+        .expect("timed out waiting for streamed MCP progress notification")
+        .expect("streaming MCP request ended before emitting progress");
     let cancel = client
         .post(&url)
         .header("Accept", "application/json, text/event-stream")
@@ -407,7 +429,10 @@ async fn serve_mcp_http_streams_progress_and_enforces_api_keys() {
         .unwrap();
     assert_eq!(cancel.status(), reqwest::StatusCode::ACCEPTED);
 
-    let body = call_task.await.unwrap();
+    let body = tokio::time::timeout(TEST_TIMEOUT, call_task)
+        .await
+        .expect("timed out waiting for cancelled MCP stream to close")
+        .unwrap();
     let messages = parse_sse_messages(&body);
     assert!(messages
         .iter()

--- a/crates/harn-cli/tests/mcp_server_cli.rs
+++ b/crates/harn-cli/tests/mcp_server_cli.rs
@@ -18,6 +18,7 @@ use serde_json::{json, Value as JsonValue};
 use tempfile::TempDir;
 
 static MCP_CLI_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+const TEST_TIMEOUT: Duration = Duration::from_secs(2);
 
 fn lock_mcp_cli_tests() -> MutexGuard<'static, ()> {
     MCP_CLI_TEST_LOCK
@@ -94,9 +95,9 @@ fn send_request(
 }
 
 fn wait_for_http_listener(child: &mut std::process::Child, rx: &Receiver<String>) -> String {
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + TEST_TIMEOUT;
     while Instant::now() < deadline {
-        match rx.recv_timeout(Duration::from_millis(100)) {
+        match rx.recv_timeout(Duration::from_millis(25)) {
             Ok(line) if line.contains("MCP HTTP listener ready on ") => {
                 return line
                     .split("MCP HTTP listener ready on ")

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -18,6 +18,8 @@ use tempfile::TempDir;
 
 const STARTUP_NEEDLE: &str = "HTTP listener ready on";
 const SHUTDOWN_NEEDLE: &str = "graceful shutdown complete";
+const PROCESS_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(5);
+const EVENT_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(2);
 
 fn write_file(dir: &Path, relative: &str, contents: &str) {
     let path = dir.join(relative);
@@ -25,6 +27,22 @@ fn write_file(dir: &Path, relative: &str, contents: &str) {
         fs::create_dir_all(parent).unwrap();
     }
     fs::write(path, contents).unwrap();
+}
+
+fn gated_task_handler_module(release_path: &Path) -> String {
+    format!(
+        r#"
+import "std/triggers"
+
+pub fn on_task(event: TriggerEvent) -> string {{
+  while !file_exists({release:?}) {{
+    sleep(1ms)
+  }}
+  return event.kind
+}}
+"#,
+        release = release_path.display().to_string()
+    )
 }
 
 fn spawn_orchestrator(temp: &TempDir) -> (Child, Receiver<String>, thread::JoinHandle<String>) {
@@ -76,9 +94,9 @@ fn spawn_orchestrator_with(
 }
 
 fn wait_for_log_line(child: &mut Child, rx: &Receiver<String>, needle: &str) {
-    let deadline = Instant::now() + Duration::from_secs(15);
+    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
-        match rx.recv_timeout(Duration::from_millis(100)) {
+        match rx.recv_timeout(Duration::from_millis(25)) {
             Ok(line) if line.contains(needle) => return,
             Ok(_) => continue,
             Err(mpsc::RecvTimeoutError::Timeout) => {
@@ -95,9 +113,9 @@ fn wait_for_log_line(child: &mut Child, rx: &Receiver<String>, needle: &str) {
 }
 
 fn wait_for_listener_url(child: &mut Child, rx: &Receiver<String>) -> String {
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
-        match rx.recv_timeout(Duration::from_millis(100)) {
+        match rx.recv_timeout(Duration::from_millis(25)) {
             Ok(line) if line.contains(STARTUP_NEEDLE) => {
                 return line
                     .split(STARTUP_NEEDLE)
@@ -130,7 +148,7 @@ fn send_sigterm(child: &Child) {
 }
 
 fn wait_for_exit_code(child: &mut Child, expected: i32) {
-    let deadline = Instant::now() + Duration::from_secs(15);
+    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
         if let Some(status) = child.try_wait().unwrap() {
             assert_eq!(
@@ -146,7 +164,7 @@ fn wait_for_exit_code(child: &mut Child, expected: i32) {
 }
 
 fn wait_for_exit(child: &mut Child) {
-    let deadline = Instant::now() + Duration::from_secs(15);
+    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
         if let Some(status) = child.try_wait().unwrap() {
             assert!(status.success(), "child exited unsuccessfully: {status}");
@@ -158,14 +176,25 @@ fn wait_for_exit(child: &mut Child) {
 }
 
 fn wait_for_any_exit(child: &mut Child) {
-    let deadline = Instant::now() + Duration::from_secs(15);
+    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
         if child.try_wait().unwrap().is_some() {
             return;
         }
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(25));
     }
     panic!("timed out waiting for orchestrator exit");
+}
+
+fn wait_for_path(path: &Path, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    panic!("timed out waiting for {}", path.display());
 }
 
 fn json_headers() -> HeaderMap {
@@ -228,7 +257,7 @@ async fn wait_for_consumer_cursor(
     consumer: &str,
     at_least: u64,
 ) {
-    let deadline = Instant::now() + Duration::from_secs(15);
+    let deadline = Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
     let log = open_state_event_log(state_dir);
     let topic = Topic::new(topic_name).unwrap();
     let consumer = ConsumerId::new(consumer).unwrap();
@@ -306,7 +335,7 @@ fn seed_legacy_inbox_records(temp: &TempDir) {
 }
 
 fn wait_for_topic_kind(state_dir: &Path, topic_name: &str, kind: &str) {
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
         if read_topic_events(state_dir, topic_name)
             .iter()
@@ -314,13 +343,13 @@ fn wait_for_topic_kind(state_dir: &Path, topic_name: &str, kind: &str) {
         {
             return;
         }
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(25));
     }
     panic!("timed out waiting for {topic_name}/{kind}");
 }
 
 fn wait_for_topic_event(state_dir: &Path, topic_name: &str, predicate: impl Fn(&LogEvent) -> bool) {
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
         if read_topic_events(state_dir, topic_name)
             .iter()
@@ -368,12 +397,12 @@ print(count)
 }
 
 fn wait_for_sqlite_event_count(state_dir: &Path, topic_name: &str, kind: &str, expected: usize) {
-    let deadline = Instant::now() + Duration::from_secs(90);
+    let deadline = Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
         if sqlite_event_count(state_dir, topic_name, kind) >= expected {
             return;
         }
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(25));
     }
     panic!("timed out waiting for {topic_name}/{kind} count {expected}");
 }
@@ -441,6 +470,7 @@ pub fn on_issue(event: TriggerEvent) {
 #[tokio::test(flavor = "multi_thread")]
 async fn graceful_shutdown_drains_in_flight_dispatch_and_emits_lifecycle_events() {
     let temp = TempDir::new().unwrap();
+    let handler_release_path = temp.path().join("release-handler");
     write_file(
         temp.path(),
         "harn.toml",
@@ -463,14 +493,7 @@ handler = "handlers::on_task"
     write_file(
         temp.path(),
         "lib.harn",
-        r#"
-import "std/triggers"
-
-pub fn on_task(event: TriggerEvent) -> string {
-  sleep(100ms)
-  return event.kind
-}
-"#,
+        &gated_task_handler_module(&handler_release_path),
     );
 
     let envs = [
@@ -495,6 +518,7 @@ pub fn on_task(event: TriggerEvent) -> string {
 
     wait_for_topic_kind(&state_dir, "triggers.lifecycle", "DispatchStarted");
     send_sigterm(&child);
+    fs::write(&handler_release_path, b"release").unwrap();
     wait_for_exit(&mut child);
     let stderr = handle.join().expect("stderr collector thread");
 
@@ -585,7 +609,6 @@ pub fn on_task(event: TriggerEvent) -> string {
         .unwrap();
     assert_eq!(response.status(), reqwest::StatusCode::OK);
 
-    tokio::time::sleep(Duration::from_millis(25)).await;
     send_sigterm(&child);
     wait_for_exit(&mut child);
     let stderr = handle.join().expect("stderr collector thread");
@@ -610,6 +633,8 @@ pub fn on_task(event: TriggerEvent) -> string {
 #[tokio::test(flavor = "multi_thread")]
 async fn graceful_shutdown_waits_for_spawned_inbox_dispatch_tasks() {
     let temp = TempDir::new().unwrap();
+    let inbox_release_file = temp.path().join("release-inbox-dispatch");
+    let inbox_release_value = inbox_release_file.to_string_lossy().into_owned();
     write_file(
         temp.path(),
         "harn.toml",
@@ -645,7 +670,10 @@ pub fn on_task(event: TriggerEvent) -> string {
         ("HARN_EVENT_LOG_BACKEND", "file"),
         ("HARN_ORCHESTRATOR_API_KEYS", "test-key"),
         ("HARN_ORCHESTRATOR_HMAC_SECRET", "unused-shared-secret"),
-        ("HARN_TEST_ORCHESTRATOR_INBOX_TASK_DELAY_MS", "1000"),
+        (
+            "HARN_TEST_ORCHESTRATOR_INBOX_TASK_RELEASE_FILE",
+            inbox_release_value.as_str(),
+        ),
     ];
     let (mut child, rx, handle) =
         spawn_orchestrator_with(&temp, &["--shutdown-timeout", "5"], &envs);
@@ -674,6 +702,7 @@ pub fn on_task(event: TriggerEvent) -> string {
     .await;
 
     send_sigterm(&child);
+    fs::write(&inbox_release_file, b"release").unwrap();
     wait_for_exit(&mut child);
     let stderr = handle.join().expect("stderr collector thread");
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
@@ -775,6 +804,12 @@ async fn bounded_pump_drain_truncates_and_replays_remaining_backlog_after_restar
     const TOTAL_EVENTS: usize = 60;
 
     let temp = TempDir::new().unwrap();
+    let pump_release_file = temp.path().join("release-pending-pump");
+    let pump_waiting_file = temp.path().join("pending-pump-waiting");
+    let pump_draining_file = temp.path().join("pending-pump-draining");
+    let pump_release_value = pump_release_file.to_string_lossy().into_owned();
+    let pump_waiting_value = pump_waiting_file.to_string_lossy().into_owned();
+    let pump_draining_value = pump_draining_file.to_string_lossy().into_owned();
     write_file(
         temp.path(),
         "harn.toml",
@@ -810,7 +845,18 @@ pub fn on_task(event: TriggerEvent) -> string {
         ("HARN_ORCHESTRATOR_API_KEYS", "test-key"),
         ("HARN_ORCHESTRATOR_HMAC_SECRET", "unused-shared-secret"),
         ("HARN_EVENT_LOG_QUEUE_DEPTH", "8192"),
-        ("HARN_TEST_ORCHESTRATOR_PUMP_DELAY_MS", "10"),
+        (
+            "HARN_TEST_ORCHESTRATOR_PUMP_RELEASE_FILE",
+            pump_release_value.as_str(),
+        ),
+        (
+            "HARN_TEST_ORCHESTRATOR_PUMP_WAITING_FILE",
+            pump_waiting_value.as_str(),
+        ),
+        (
+            "HARN_TEST_ORCHESTRATOR_PUMP_DRAINING_FILE",
+            pump_draining_value.as_str(),
+        ),
     ];
     let extra_args = [
         "--shutdown-timeout",
@@ -840,16 +886,13 @@ pub fn on_task(event: TriggerEvent) -> string {
         assert_eq!(response.status(), reqwest::StatusCode::OK);
     }
 
-    let shutdown_started = Instant::now();
+    wait_for_path(&pump_waiting_file, EVENT_FAIL_FAST_TIMEOUT);
     send_sigterm(&child);
+    wait_for_path(&pump_draining_file, EVENT_FAIL_FAST_TIMEOUT);
+    fs::write(&pump_release_file, b"release").unwrap();
     wait_for_exit(&mut child);
-    let shutdown_elapsed = shutdown_started.elapsed();
     let stderr = handle.join().expect("stderr collector thread");
 
-    assert!(
-        shutdown_elapsed < Duration::from_secs(4),
-        "shutdown should finish within bounded drain budget: {shutdown_elapsed:?}"
-    );
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
     assert!(stderr.contains("pump drain truncated"), "stderr={stderr}");
 

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -35,6 +35,8 @@ use tokio::sync::oneshot;
 const STARTUP_PREFIX: &str = "[harn] HTTP listener ready on ";
 const STARTUP_NEEDLE: &str = "HTTP listener ready";
 const SHUTDOWN_NEEDLE: &str = "graceful shutdown complete";
+const PROCESS_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(5);
+const EVENT_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(2);
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -184,7 +186,6 @@ fn slack_handler_module(marker_path: &Path) -> String {
 import "std/triggers"
 
 pub fn on_slack(event: TriggerEvent) {{
-  sleep(100ms)
   write_file({marker:?}, event.kind)
 }}
 "#,
@@ -395,9 +396,9 @@ struct OrchestratorProcess {
 
 impl OrchestratorProcess {
     fn wait_for_listener_url(&mut self) -> String {
-        let deadline = Instant::now() + Duration::from_secs(30);
+        let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
         while Instant::now() < deadline {
-            match self.rx.recv_timeout(Duration::from_millis(100)) {
+            match self.rx.recv_timeout(Duration::from_millis(25)) {
                 Ok(line) if line.contains(STARTUP_NEEDLE) => {
                     if let Some(url) = listener_url_from_line(&line) {
                         return url;
@@ -466,24 +467,24 @@ fn send_sigterm(child: &Child) {
 }
 
 fn wait_for_exit(child: &mut Child) {
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
         if let Some(status) = child.try_wait().unwrap() {
             assert!(status.success(), "child exited unsuccessfully: {status}");
             return;
         }
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(25));
     }
     panic!("timed out waiting for orchestrator exit");
 }
 
 async fn wait_for_exit_async(child: &mut Child) -> std::process::ExitStatus {
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
         if let Some(status) = child.try_wait().unwrap() {
             return status;
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(25)).await;
     }
     panic!("timed out waiting for orchestrator exit");
 }
@@ -835,6 +836,8 @@ async fn slack_webhook_acknowledges_before_handler_finishes() {
     let _lock = lock_orchestrator_tests();
     let temp = TempDir::new().unwrap();
     let marker_path = temp.path().join("slack-handler.txt");
+    let release_path = temp.path().join("release-slack-dispatch");
+    let release_path_value = release_path.to_string_lossy().into_owned();
     write_file(temp.path(), "harn.toml", &slack_manifest(None));
     write_file(temp.path(), "lib.harn", &slack_handler_module(&marker_path));
 
@@ -842,6 +845,10 @@ async fn slack_webhook_acknowledges_before_handler_finishes() {
     let envs = [
         ("HARN_SECRET_PROVIDERS", "env"),
         ("HARN_SECRET_SLACK_SIGNING_SECRET", secret),
+        (
+            "HARN_TEST_ORCHESTRATOR_INBOX_TASK_RELEASE_FILE",
+            release_path_value.as_str(),
+        ),
     ];
     let mut process = spawn_orchestrator(&temp, &[], &envs);
     let base_url = process.wait_for_listener_url();
@@ -881,9 +888,10 @@ async fn slack_webhook_acknowledges_before_handler_finishes() {
     );
     assert!(
         !marker_path.exists(),
-        "handler should not have completed before the HTTP ack"
+        "dispatch should not have completed before the HTTP ack"
     );
-    wait_for_path(&marker_path, Duration::from_secs(10));
+    fs::write(&release_path, b"release").unwrap();
+    wait_for_path(&marker_path, EVENT_FAIL_FAST_TIMEOUT);
     let marker = fs::read_to_string(&marker_path).unwrap();
     assert_eq!(marker, "app_mention");
 
@@ -1157,7 +1165,7 @@ async fn notion_webhook_signed_delivery_is_dispatched() {
         .unwrap();
     assert_status(response, StatusCode::OK).await;
 
-    wait_for_path(&marker_path, Duration::from_secs(10));
+    wait_for_path(&marker_path, EVENT_FAIL_FAST_TIMEOUT);
     let marker = fs::read_to_string(&marker_path).unwrap();
     assert_eq!(marker, "page.content_updated");
 
@@ -1205,7 +1213,7 @@ async fn harn_connector_module_round_trips_inbound_and_client_calls() {
         .unwrap();
     assert_status(response, StatusCode::OK).await;
 
-    wait_for_path(&marker_path, Duration::from_secs(10));
+    wait_for_path(&marker_path, EVENT_FAIL_FAST_TIMEOUT);
     let marker: JsonValue =
         serde_json::from_str(&fs::read_to_string(&marker_path).unwrap()).unwrap();
     assert_eq!(
@@ -1519,7 +1527,7 @@ async fn watch_mode_reloads_manifest_changes() {
     let mut auth_headers = json_headers();
     auth_headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer reload-key"));
 
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
     loop {
         let response = client
             .post(format!("{base_url}/a2a/review-watch"))
@@ -1533,7 +1541,7 @@ async fn watch_mode_reloads_manifest_changes() {
         }
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
         assert!(Instant::now() < deadline, "watch reload never applied");
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(25)).await;
     }
 
     let retired = client
@@ -1732,6 +1740,10 @@ async fn oversized_request_body_is_rejected() {
 async fn graceful_shutdown_waits_for_in_flight_request() {
     let _lock = lock_orchestrator_tests();
     let temp = TempDir::new().unwrap();
+    let request_entered_path = temp.path().join("request-entered");
+    let request_release_path = temp.path().join("request-release");
+    let request_entered_value = request_entered_path.to_string_lossy().into_owned();
+    let request_release_value = request_release_path.to_string_lossy().into_owned();
     write_file(temp.path(), "harn.toml", &base_manifest(None));
     write_file(temp.path(), "lib.harn", handler_module());
 
@@ -1739,7 +1751,14 @@ async fn graceful_shutdown_waits_for_in_flight_request() {
     let envs = [
         ("HARN_SECRET_PROVIDERS", "env"),
         ("HARN_SECRET_GITHUB_WEBHOOK_SECRET", secret),
-        ("HARN_ORCHESTRATOR_TEST_REQUEST_DELAY_MS", "500"),
+        (
+            "HARN_ORCHESTRATOR_TEST_REQUEST_ENTERED_FILE",
+            request_entered_value.as_str(),
+        ),
+        (
+            "HARN_ORCHESTRATOR_TEST_REQUEST_RELEASE_FILE",
+            request_release_value.as_str(),
+        ),
     ];
     let mut process = spawn_orchestrator(&temp, &[], &envs);
     let base_url = process.wait_for_listener_url();
@@ -1752,8 +1771,9 @@ async fn graceful_shutdown_waits_for_in_flight_request() {
         async move { client.post(url).headers(headers).body(body).send().await }
     });
 
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    wait_for_path(&request_entered_path, EVENT_FAIL_FAST_TIMEOUT);
     send_sigterm(&process.child);
+    fs::write(&request_release_path, b"release").unwrap();
     let response = request.await.unwrap().unwrap();
     assert_status(response, StatusCode::OK).await;
 
@@ -1868,7 +1888,7 @@ async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
     assert!(status.success(), "status={status} stderr={stderr}");
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
 
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
     let spans = loop {
         let spans = collector.collected_spans();
         let has_ingest = spans.iter().any(|span| span.name == "ingest");
@@ -1886,7 +1906,7 @@ async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
                     .collect::<Vec<_>>()
             );
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(25)).await;
     };
 
     let ingest = spans.iter().find(|span| span.name == "ingest").unwrap();

--- a/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
+++ b/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
@@ -17,6 +17,8 @@ use tempfile::TempDir;
 // fail-after-emit test hook can terminate the process before the HTTP listener
 // readiness line is logged.
 const STARTUP_NEEDLE: &str = "activated connectors: cron(1)";
+const PROCESS_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(5);
+const EVENT_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(2);
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -42,13 +44,6 @@ fn copy_dir_recursive(source: &Path, destination: &Path) {
 fn seed_fixture(temp: &TempDir) {
     let fixture = repo_root().join("conformance/fixtures/triggers/inbox_dedupe_restart");
     copy_dir_recursive(&fixture, temp.path());
-    let manifest = temp.path().join("harn.toml");
-    let contents = fs::read_to_string(&manifest).unwrap();
-    fs::write(
-        &manifest,
-        contents.replace("*/2 * * * * *", "*/1 * * * * *"),
-    )
-    .unwrap();
 }
 
 fn spawn_orchestrator(
@@ -92,9 +87,9 @@ fn spawn_orchestrator(
 }
 
 fn wait_for_log_line(child: &mut Child, rx: &Receiver<String>, needle: &str) {
-    let deadline = Instant::now() + Duration::from_secs(15);
+    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
-        match rx.recv_timeout(Duration::from_millis(100)) {
+        match rx.recv_timeout(Duration::from_millis(25)) {
             Ok(line) if line.contains(needle) => return,
             Ok(_) => continue,
             Err(mpsc::RecvTimeoutError::Timeout) => {
@@ -111,7 +106,7 @@ fn wait_for_log_line(child: &mut Child, rx: &Receiver<String>, needle: &str) {
 }
 
 fn wait_for_exit_code(child: &mut Child, expected: i32) {
-    let deadline = Instant::now() + Duration::from_secs(15);
+    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
         if let Some(status) = child.try_wait().unwrap() {
             assert_eq!(
@@ -121,7 +116,7 @@ fn wait_for_exit_code(child: &mut Child, expected: i32) {
             );
             return;
         }
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(25));
     }
     panic!("timed out waiting for orchestrator exit");
 }
@@ -136,13 +131,13 @@ fn send_sigterm(child: &Child) {
 }
 
 fn wait_for_successful_exit(child: &mut Child) {
-    let deadline = Instant::now() + Duration::from_secs(15);
+    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
         if let Some(status) = child.try_wait().unwrap() {
             assert!(status.success(), "child exited unsuccessfully: {status}");
             return;
         }
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(25));
     }
     panic!("timed out waiting for orchestrator exit");
 }
@@ -165,7 +160,7 @@ async fn read_tick_dedupe_counts(temp: &TempDir) -> HashMap<String, usize> {
 }
 
 async fn wait_for_tick_count(temp: &TempDir, min_count: usize) -> HashMap<String, usize> {
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let deadline = Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
     loop {
         let counts = read_tick_dedupe_counts(temp).await;
         if counts.len() >= min_count {
@@ -184,8 +179,13 @@ async fn restart_after_emit_does_not_duplicate_cron_dispatch() {
     let temp = TempDir::new().unwrap();
     seed_fixture(&temp);
 
-    let (mut crashing_child, crashing_rx, crashing_handle) =
-        spawn_orchestrator(&temp, &[("HARN_TEST_CRON_FAIL_AFTER_EMIT", "1")]);
+    let (mut crashing_child, crashing_rx, crashing_handle) = spawn_orchestrator(
+        &temp,
+        &[
+            ("HARN_TEST_CRON_SINGLE_TICK_AT", "1800000000"),
+            ("HARN_TEST_CRON_FAIL_AFTER_EMIT", "1"),
+        ],
+    );
     drop(crashing_rx);
     wait_for_exit_code(&mut crashing_child, 86);
     let crashing_stderr = crashing_handle.join().expect("stderr collector thread");
@@ -199,7 +199,8 @@ async fn restart_after_emit_does_not_duplicate_cron_dispatch() {
         .expect("first crashed tick")
         .clone();
 
-    let (mut second_child, second_rx, second_handle) = spawn_orchestrator(&temp, &[]);
+    let (mut second_child, second_rx, second_handle) =
+        spawn_orchestrator(&temp, &[("HARN_TEST_CRON_SINGLE_TICK_AT", "1800000001")]);
     wait_for_log_line(&mut second_child, &second_rx, STARTUP_NEEDLE);
     let counts = wait_for_tick_count(&temp, 2).await;
     send_sigterm(&second_child);

--- a/crates/harn-vm/src/connectors/cron/mod.rs
+++ b/crates/harn-vm/src/connectors/cron/mod.rs
@@ -30,6 +30,7 @@ mod tests;
 
 pub const CRON_TICK_TOPIC: &str = "connectors.cron.tick";
 const TEST_FAIL_AFTER_EMIT_ENV: &str = "HARN_TEST_CRON_FAIL_AFTER_EMIT";
+const TEST_SINGLE_TICK_AT_ENV: &str = "HARN_TEST_CRON_SINGLE_TICK_AT";
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -197,6 +198,16 @@ impl Connector for CronConnector {
                 sink,
                 state_store,
             });
+            if let Some(tick_at) = test_single_tick_at()? {
+                let task = tokio::spawn(async move {
+                    let _ = handler.on_tick(tick_at, false).await;
+                });
+                self.tasks
+                    .lock()
+                    .expect("cron connector tasks mutex poisoned")
+                    .push(task);
+                continue;
+            }
             let shutdown = shutdown.clone();
             let task = tokio::spawn(async move {
                 let _ = run_tick_loop(
@@ -467,4 +478,23 @@ fn maybe_fail_after_emit() {
     if std::env::var_os(TEST_FAIL_AFTER_EMIT_ENV).is_some() {
         std::process::exit(86);
     }
+}
+
+fn test_single_tick_at() -> Result<Option<OffsetDateTime>, ConnectorError> {
+    let Some(raw) = std::env::var_os(TEST_SINGLE_TICK_AT_ENV) else {
+        return Ok(None);
+    };
+    let raw = raw.to_string_lossy();
+    let timestamp = raw.parse::<i64>().map_err(|error| {
+        ConnectorError::Activation(format!(
+            "invalid {TEST_SINGLE_TICK_AT_ENV} unix timestamp '{raw}': {error}"
+        ))
+    })?;
+    OffsetDateTime::from_unix_timestamp(timestamp)
+        .map(Some)
+        .map_err(|error| {
+            ConnectorError::Activation(format!(
+                "invalid {TEST_SINGLE_TICK_AT_ENV} unix timestamp '{raw}': {error}"
+            ))
+        })
 }

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -739,10 +739,8 @@ mod tests {
             .set_nonblocking(true)
             .expect("set listener nonblocking");
         let handle = std::thread::spawn(move || {
-            // 15s accept window: shorter windows were flaky under parallel
-            // CI load (listener exiting before reqwest connects caused
-            // transport errors instead of the tested HTTP 500 payload).
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+            // Fail fast if the client never reaches the stub listener.
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
             let (mut stream, _) = loop {
                 match listener.accept() {
                     Ok(pair) => break pair,
@@ -811,8 +809,8 @@ mod tests {
                     opts.output_schema = None;
                     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
                     let call = tokio::time::timeout(
-                        // Must stay under the stub's 15s accept window.
-                        std::time::Duration::from_secs(12),
+                        // Must stay inside the stub's fail-fast accept window.
+                        std::time::Duration::from_secs(2),
                         vm_call_llm_full_streaming_offthread(&opts, tx),
                     )
                     .await;

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -337,6 +337,37 @@ async fn read_topic(
         .expect("read topic events")
 }
 
+async fn wait_for_dispatcher_in_flight(dispatcher: &Dispatcher, expected: u64) {
+    for _ in 0..1_000 {
+        if dispatcher.snapshot().in_flight >= expected {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!(
+        "timed out waiting for {expected} in-flight dispatches; snapshot={:?}",
+        dispatcher.snapshot()
+    );
+}
+
+async fn wait_for_topic_event(
+    log: Arc<crate::event_log::AnyEventLog>,
+    topic: &str,
+    predicate: impl Fn(&crate::event_log::LogEvent) -> bool,
+) {
+    for _ in 0..1_000 {
+        if read_topic(log.clone(), topic)
+            .await
+            .iter()
+            .any(|(_, event)| predicate(event))
+        {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("timed out waiting for matching {topic} event");
+}
+
 fn flatten_action_graph(
     events: &[(u64, crate::event_log::LogEvent)],
 ) -> (Vec<String>, Vec<String>) {
@@ -1765,7 +1796,6 @@ pub fn wait_for_cancel(event: TriggerEvent) -> string {
             )
             .await;
 
-            let start = Instant::now();
             let mut handles = Vec::new();
             for index in 0..3 {
                 let dispatcher = dispatcher.clone();
@@ -1780,7 +1810,7 @@ pub fn wait_for_cancel(event: TriggerEvent) -> string {
                 }));
             }
 
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            wait_for_dispatcher_in_flight(&dispatcher, 3).await;
             dispatcher.shutdown();
 
             let mut cancelled = 0;
@@ -1792,10 +1822,6 @@ pub fn wait_for_cancel(event: TriggerEvent) -> string {
                 }
             }
             assert_eq!(cancelled, 3);
-            assert!(
-                start.elapsed() <= Duration::from_millis(100),
-                "all in-flight dispatches must observe cancellation within 100ms"
-            );
         })
         .await;
 }
@@ -1836,7 +1862,7 @@ pub fn wait_for_cancel(event: TriggerEvent) -> string {
                     .expect("dispatch completes")
             });
 
-            tokio::time::sleep(Duration::from_millis(25)).await;
+            wait_for_dispatcher_in_flight(&dispatcher, 1).await;
             append_dispatch_cancel_request(
                 &log,
                 &DispatchCancelRequest {
@@ -1909,7 +1935,15 @@ pub fn wait_for_signal(event: TriggerEvent) -> string {
                     .expect("dispatch completes")
             });
 
-            tokio::time::sleep(Duration::from_millis(25)).await;
+            wait_for_topic_event(
+                log.clone(),
+                crate::waitpoints::WAITPOINT_WAITS_TOPIC,
+                |event| {
+                    event.kind == "waitpoint_wait_started"
+                        && event.headers.get("wait_id").map(String::as_str) == Some("wait-cancel")
+                },
+            )
+            .await;
             append_dispatch_cancel_request(
                 &log,
                 &DispatchCancelRequest {
@@ -2048,7 +2082,7 @@ pub fn slow_handler(event: TriggerEvent) -> string {
                     .expect("dispatch finishes")
             });
 
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            wait_for_dispatcher_in_flight(&dispatcher, 1).await;
             let report = dispatcher
                 .drain(Duration::from_secs(1))
                 .await
@@ -2322,7 +2356,7 @@ pub fn slow_handler(event: TriggerEvent) -> string {
                     .expect("first dispatch succeeds")
             });
 
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            wait_for_dispatcher_in_flight(&dispatcher, 1).await;
 
             let second = dispatcher
                 .dispatch_event(trigger_event("issues.opened", "delivery-singleton-2"))
@@ -2829,7 +2863,7 @@ pub fn slow_handler(event: TriggerEvent) -> string {
                     .expect("leader dispatch succeeds")
             });
 
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            wait_for_dispatcher_in_flight(&dispatcher, 1).await;
 
             let bronze_dispatcher = dispatcher.clone();
             let bronze_waiter = tokio::task::spawn_local(async move {

--- a/crates/harn-vm/src/triggers/inbox.rs
+++ b/crates/harn-vm/src/triggers/inbox.rs
@@ -307,12 +307,11 @@ mod tests {
         let metrics = Arc::new(MetricsRegistry::default());
         let index = InboxIndex::new(log.clone(), metrics.clone()).await.unwrap();
         assert!(index
-            .insert_if_new("binding", "delivery-1", StdDuration::from_millis(10))
+            .insert_if_new("binding", "delivery-1", StdDuration::ZERO)
             .await
             .unwrap());
-        tokio::time::sleep(StdDuration::from_millis(25)).await;
         assert!(index
-            .insert_if_new("binding", "delivery-1", StdDuration::from_millis(10))
+            .insert_if_new("binding", "delivery-1", StdDuration::ZERO)
             .await
             .unwrap());
 

--- a/crates/harn-vm/src/triggers/worker_queue.rs
+++ b/crates/harn-vm/src/triggers/worker_queue.rs
@@ -858,8 +858,8 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn expired_claim_allows_reclaim() {
         let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(32)));
-        let queue = WorkerQueue::new(log);
-        queue
+        let queue = WorkerQueue::new(log.clone());
+        let receipt = queue
             .enqueue(&test_job(
                 "triage",
                 "incoming-review-task",
@@ -868,19 +868,26 @@ mod tests {
             ))
             .await
             .unwrap();
-        let first = queue
-            .claim_next("triage", "consumer-a", StdDuration::from_millis(15))
-            .await
-            .unwrap()
-            .unwrap();
-        tokio::time::sleep(StdDuration::from_millis(30)).await;
+        let expired_claim = WorkerQueueClaimRecord {
+            job_event_id: receipt.job_event_id,
+            claim_id: "expired-claim".to_string(),
+            consumer_id: "consumer-a".to_string(),
+            claimed_at_ms: now_ms().saturating_sub(2),
+            expires_at_ms: now_ms().saturating_sub(1),
+        };
+        log.append(
+            &claims_topic("triage").unwrap(),
+            LogEvent::new("job_claimed", serde_json::to_value(&expired_claim).unwrap()),
+        )
+        .await
+        .unwrap();
         let second = queue
             .claim_next("triage", "consumer-b", StdDuration::from_secs(60))
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(first.job.event.id.0, second.job.event.id.0);
-        assert_ne!(first.handle.claim_id, second.handle.claim_id);
+        assert_eq!(second.job.event.id.0, "evt-1");
+        assert_ne!(second.handle.claim_id, expired_claim.claim_id);
         assert_eq!(second.handle.consumer_id, "consumer-b");
     }
 


### PR DESCRIPTION
## Summary
- replace orchestrator test sleep/delay hooks with deterministic file gates
- remove wall-clock assertions from shutdown, pump drain, and reclaim tests
- update HTTP, CLI, VM trigger, and conformance coverage to use readiness/release markers

## Verification
- cargo test -p harn-cli --test orchestrator_http -- --nocapture
- cargo test -p harn-cli --test orchestrator_cli -- --nocapture
- cargo test -p harn-vm triggers::dispatcher::tests:: -- --nocapture
- cargo test -p harn-vm triggers::inbox::tests:: -- --nocapture
- cargo test -p harn-vm triggers::worker_queue::tests:: -- --nocapture
- cargo run --quiet --bin harn -- test conformance --filter orchestrator_bounded_drain_resume
- cargo run --quiet --bin harn -- test conformance --filter orchestrator_hot_reload_modify_inflight
- cargo clippy -p harn-cli --all-targets -- -D warnings
- make test
- ./scripts/release_gate.sh audit