### PR TITLE
[codex] Add generic stream trigger ingress

### DIFF
--- a/conformance/tests/agents/trigger_provider_catalog.harn
+++ b/conformance/tests/agents/trigger_provider_catalog.harn
@@ -3,7 +3,7 @@ import "std/triggers"
 pipeline test(task) {
   let providers: list<ProviderCatalogEntry> = list_providers()
   let builtin = providers.filter({ provider -> provider.runtime.kind == "builtin" })
-  assert(len(builtin) == 7, "expected exactly seven builtin trigger providers")
+  assert(len(builtin) == 13, "expected thirteen builtin trigger providers")
   let stream_providers = providers.filter({ provider -> provider.kinds.any({ kind -> kind == "stream" }) })
   assert(len(stream_providers) == 6, "expected six stream trigger providers")
   assert(
@@ -11,8 +11,11 @@ pipeline test(task) {
     "stream providers should publish the shared stream payload schema",
   )
   assert(
-    stream_providers.all({ provider -> provider.runtime.kind == "placeholder" }),
-    "stream providers should be cataloged before concrete connector activation lands",
+    stream_providers
+    .all(
+    { provider -> provider.runtime.kind == "builtin" && provider.runtime.connector == "stream" },
+  ),
+    "stream providers should use the generic stream ingress connector",
   )
   assert(
     stream_providers.any({ provider -> provider.provider == "kafka" })

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -296,6 +296,24 @@ impl RouteConfig {
                     connector: None,
                 }))
             }
+            TriggerKind::Stream => {
+                if !trigger.config.kind_specific.contains_key("path") {
+                    return Ok(None);
+                }
+                Ok(Some(Self {
+                    trigger_id: trigger.config.id.clone(),
+                    binding_version,
+                    provider: trigger.config.provider.clone(),
+                    path: trigger_path(trigger)?,
+                    auth_mode: AuthMode::Public,
+                    signature_mode: SignatureMode::Unsigned,
+                    signing_secret: None,
+                    dedupe_key_template: trigger.config.dedupe_key.clone(),
+                    dedupe_retention_days: trigger.config.retry.retention_days,
+                    connector_ingress: true,
+                    connector: None,
+                }))
+            }
             _ => Ok(None),
         }
     }

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -180,6 +180,31 @@ handler = "handlers::on_echo"
     manifest
 }
 
+fn stream_manifest(orchestrator_block: Option<&str>) -> String {
+    let mut manifest = r#"
+[package]
+name = "fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "ws-stream"
+kind = "stream"
+provider = "websocket"
+path = "/streams/ws"
+match = { events = ["quote.tick"] }
+handler = "handlers::on_stream"
+"#
+    .to_string();
+    if let Some(block) = orchestrator_block {
+        manifest.push('\n');
+        manifest.push_str(block);
+        manifest.push('\n');
+    }
+    manifest
+}
+
 fn slack_handler_module(marker_path: &Path) -> String {
     format!(
         r#"
@@ -221,6 +246,25 @@ pub fn on_echo(event: TriggerEvent) {{
     binding_id: event.provider_payload.raw.binding_id,
     echoed: ping.message,
     ping_token: ping.token,
+  }}))
+}}
+"#,
+        marker = marker_path.display().to_string()
+    )
+}
+
+fn stream_handler_module(marker_path: &Path) -> String {
+    format!(
+        r#"
+import "std/triggers"
+
+pub fn on_stream(event: TriggerEvent) {{
+  write_file({marker:?}, json_stringify({{
+    provider: event.provider,
+    kind: event.kind,
+    key: event.provider_payload.key,
+    stream: event.provider_payload.stream,
+    amount: event.provider_payload.raw.value.amount,
   }}))
 }}
 "#,
@@ -1304,6 +1348,65 @@ async fn harn_connector_module_round_trips_inbound_and_client_calls() {
             .get("message")
             .and_then(JsonValue::as_str),
         Some("hello from echo")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_trigger_route_uses_generic_stream_connector() {
+    let _lock = lock_orchestrator_tests();
+    let temp = TempDir::new().unwrap();
+    let marker_path = temp.path().join("stream-handler.json");
+    write_file(temp.path(), "harn.toml", &stream_manifest(None));
+    write_file(
+        temp.path(),
+        "lib.harn",
+        &stream_handler_module(&marker_path),
+    );
+
+    let mut process = spawn_orchestrator(&temp, &[], &[("HARN_SECRET_PROVIDERS", "env")]);
+    let base_url = process.wait_for_listener_url();
+
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/streams/ws"))
+        .header(CONTENT_TYPE, "application/json")
+        .json(&serde_json::json!({
+            "key": "acct-1",
+            "stream": "quotes",
+            "value": {"amount": 10}
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_status(response, StatusCode::OK).await;
+
+    wait_for_path(&marker_path, EVENT_FAIL_FAST_TIMEOUT);
+    let marker: JsonValue =
+        serde_json::from_str(&fs::read_to_string(&marker_path).unwrap()).unwrap();
+    assert_eq!(
+        marker.get("provider").and_then(JsonValue::as_str),
+        Some("websocket")
+    );
+    assert_eq!(
+        marker.get("kind").and_then(JsonValue::as_str),
+        Some("quote.tick")
+    );
+    assert_eq!(
+        marker.get("key").and_then(JsonValue::as_str),
+        Some("acct-1")
+    );
+    assert_eq!(
+        marker.get("stream").and_then(JsonValue::as_str),
+        Some("quotes")
+    );
+    assert_eq!(marker.get("amount").and_then(JsonValue::as_i64), Some(10));
+
+    send_sigterm(&process.child);
+    let status = wait_for_exit_async(&mut process.child).await;
+    let stderr = process.join_stderr();
+    assert!(status.success(), "status={status} stderr={stderr}");
+    assert!(
+        stderr.contains("activated connectors: websocket(1)"),
+        "stderr={stderr}"
     );
 }
 

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -34,6 +34,7 @@ pub mod hmac;
 pub mod linear;
 pub mod notion;
 pub mod slack;
+pub mod stream;
 #[cfg(test)]
 pub(crate) mod test_util;
 pub mod webhook;
@@ -58,6 +59,7 @@ pub use notion::{
     load_pending_webhook_handshakes, NotionConnector, PersistedNotionWebhookHandshake,
 };
 pub use slack::SlackConnector;
+pub use stream::StreamConnector;
 use webhook::WebhookProviderProfile;
 pub use webhook::{GenericWebhookConnector, WebhookSignatureVariant};
 
@@ -1323,6 +1325,10 @@ fn default_connector_for_provider(provider: &ProviderMetadata) -> Box<dyn Connec
             default_signature_variant,
         } => match connector.as_str() {
             "cron" => Box::new(CronConnector::new()),
+            "stream" => Box::new(StreamConnector::new(
+                ProviderId::from(provider.provider.clone()),
+                provider.schema_name.clone(),
+            )),
             "webhook" => {
                 let variant = WebhookSignatureVariant::parse(default_signature_variant.as_deref())
                     .expect("catalog webhook signature variant must be valid");

--- a/crates/harn-vm/src/connectors/stream.rs
+++ b/crates/harn-vm/src/connectors/stream.rs
@@ -1,0 +1,415 @@
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, RwLock};
+
+use async_trait::async_trait;
+use serde_json::{json, Value as JsonValue};
+use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
+
+use crate::connectors::{
+    ActivationHandle, ClientError, Connector, ConnectorClient, ConnectorCtx, ConnectorError,
+    ProviderPayloadSchema, RawInbound, TriggerBinding, TriggerKind,
+};
+use crate::triggers::{
+    redact_headers, HeaderRedactionPolicy, ProviderId, ProviderPayload, SignatureStatus, TraceId,
+    TriggerEvent, TriggerEventId,
+};
+
+pub struct StreamConnector {
+    provider_id: ProviderId,
+    kinds: Vec<TriggerKind>,
+    schema_name: String,
+    client: Arc<StreamClient>,
+    state: RwLock<ConnectorState>,
+}
+
+#[derive(Default)]
+struct ConnectorState {
+    ctx: Option<ConnectorCtx>,
+    bindings: HashMap<String, ActivatedStreamBinding>,
+}
+
+#[derive(Clone, Debug)]
+struct ActivatedStreamBinding {
+    match_events: Vec<String>,
+    stream: JsonValue,
+}
+
+#[derive(Default)]
+struct StreamClient;
+
+#[async_trait]
+impl ConnectorClient for StreamClient {
+    async fn call(&self, method: &str, _args: JsonValue) -> Result<JsonValue, ClientError> {
+        Err(ClientError::MethodNotFound(format!(
+            "stream connector has no outbound method `{method}`"
+        )))
+    }
+}
+
+impl StreamConnector {
+    pub fn new(provider_id: ProviderId, schema_name: impl Into<String>) -> Self {
+        Self {
+            provider_id,
+            kinds: vec![TriggerKind::from("stream")],
+            schema_name: schema_name.into(),
+            client: Arc::new(StreamClient),
+            state: RwLock::new(ConnectorState::default()),
+        }
+    }
+
+    fn binding_for_raw(&self, raw: &RawInbound) -> Result<ActivatedStreamBinding, ConnectorError> {
+        let state = self.state.read().expect("stream connector state poisoned");
+        let binding = if let Some(binding_id) =
+            raw.metadata.get("binding_id").and_then(JsonValue::as_str)
+        {
+            state.bindings.get(binding_id).cloned().ok_or_else(|| {
+                ConnectorError::Unsupported(format!(
+                    "stream connector has no active binding `{binding_id}`"
+                ))
+            })?
+        } else if state.bindings.len() == 1 {
+            state
+                .bindings
+                .values()
+                .next()
+                .cloned()
+                .expect("checked single binding")
+        } else {
+            return Err(ConnectorError::Unsupported(
+                "stream connector requires raw.metadata.binding_id when multiple bindings are active"
+                    .to_string(),
+            ));
+        };
+        Ok(binding)
+    }
+
+    fn ctx(&self) -> Result<ConnectorCtx, ConnectorError> {
+        self.state
+            .read()
+            .expect("stream connector state poisoned")
+            .ctx
+            .clone()
+            .ok_or_else(|| {
+                ConnectorError::Activation(
+                    "stream connector must be initialized before use".to_string(),
+                )
+            })
+    }
+}
+
+#[async_trait]
+impl Connector for StreamConnector {
+    fn provider_id(&self) -> &ProviderId {
+        &self.provider_id
+    }
+
+    fn kinds(&self) -> &[TriggerKind] {
+        &self.kinds
+    }
+
+    async fn init(&mut self, ctx: ConnectorCtx) -> Result<(), ConnectorError> {
+        self.state
+            .write()
+            .expect("stream connector state poisoned")
+            .ctx = Some(ctx);
+        Ok(())
+    }
+
+    async fn activate(
+        &self,
+        bindings: &[TriggerBinding],
+    ) -> Result<ActivationHandle, ConnectorError> {
+        let mut configured = HashMap::new();
+        for binding in bindings {
+            let activated = ActivatedStreamBinding::from_binding(binding)?;
+            configured.insert(binding.binding_id.clone(), activated);
+        }
+
+        self.state
+            .write()
+            .expect("stream connector state poisoned")
+            .bindings = configured;
+        Ok(ActivationHandle::new(
+            self.provider_id().clone(),
+            bindings.len(),
+        ))
+    }
+
+    async fn normalize_inbound(&self, raw: RawInbound) -> Result<TriggerEvent, ConnectorError> {
+        let _ctx = self.ctx()?;
+        let binding = self.binding_for_raw(&raw)?;
+        let body = normalized_body(&raw)?;
+        let kind = stream_event_kind(&binding, &body);
+        let dedupe_key = stream_dedupe_key(&binding, &raw, &body);
+        let provider_payload =
+            ProviderPayload::normalize(&self.provider_id, &kind, &raw.headers, body)
+                .map_err(|error| ConnectorError::Unsupported(error.to_string()))?;
+        let occurred_at = raw
+            .occurred_at
+            .or_else(|| infer_occurred_at(&provider_payload));
+
+        Ok(TriggerEvent {
+            id: TriggerEventId::new(),
+            provider: self.provider_id.clone(),
+            kind,
+            received_at: raw.received_at,
+            occurred_at,
+            dedupe_key,
+            trace_id: TraceId::new(),
+            tenant_id: raw.tenant_id,
+            headers: redact_headers(&raw.headers, &HeaderRedactionPolicy::default()),
+            batch: None,
+            raw_body: Some(raw.body),
+            provider_payload,
+            signature_status: SignatureStatus::Unsigned,
+            dedupe_claimed: false,
+        })
+    }
+
+    fn payload_schema(&self) -> ProviderPayloadSchema {
+        ProviderPayloadSchema::named(self.schema_name.clone())
+    }
+
+    fn client(&self) -> Arc<dyn ConnectorClient> {
+        self.client.clone()
+    }
+}
+
+impl ActivatedStreamBinding {
+    fn from_binding(binding: &TriggerBinding) -> Result<Self, ConnectorError> {
+        let config = binding.config.as_object().ok_or_else(|| {
+            ConnectorError::Activation(format!(
+                "stream binding '{}' config must be an object",
+                binding.binding_id
+            ))
+        })?;
+        let match_events = config
+            .get("match")
+            .and_then(|value| value.get("events"))
+            .and_then(JsonValue::as_array)
+            .map(|events| {
+                events
+                    .iter()
+                    .filter_map(JsonValue::as_str)
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let stream = config.get("stream").cloned().unwrap_or(JsonValue::Null);
+
+        Ok(Self {
+            match_events,
+            stream,
+        })
+    }
+}
+
+fn normalized_body(raw: &RawInbound) -> Result<JsonValue, ConnectorError> {
+    let content_type = header_value(&raw.headers, "content-type").unwrap_or_default();
+    if content_type.contains("json") {
+        return raw.json_body();
+    }
+    if let Ok(value) = serde_json::from_slice(&raw.body) {
+        return Ok(value);
+    }
+    use base64::Engine;
+    Ok(json!({
+        "raw_base64": base64::engine::general_purpose::STANDARD.encode(&raw.body),
+        "raw_utf8": std::str::from_utf8(&raw.body).ok(),
+    }))
+}
+
+fn stream_event_kind(binding: &ActivatedStreamBinding, body: &JsonValue) -> String {
+    body.get("kind")
+        .and_then(JsonValue::as_str)
+        .or_else(|| body.get("event").and_then(JsonValue::as_str))
+        .or_else(|| body.get("type").and_then(JsonValue::as_str))
+        .map(ToString::to_string)
+        .or_else(|| binding.match_events.first().cloned())
+        .unwrap_or_else(|| "stream.message".to_string())
+}
+
+fn stream_dedupe_key(
+    binding: &ActivatedStreamBinding,
+    raw: &RawInbound,
+    body: &JsonValue,
+) -> String {
+    header_value(&raw.headers, "x-harn-stream-id")
+        .map(ToString::to_string)
+        .or_else(|| stringish(body, &["dedupe_key", "event_id", "id", "key", "message_id"]))
+        .or_else(|| {
+            let stream_name = stringish(body, &["stream", "topic", "subject", "channel", "slot"])
+                .or_else(|| {
+                    stringish(
+                        &binding.stream,
+                        &["stream", "topic", "subject", "channel", "slot"],
+                    )
+                });
+            let offset = stringish(body, &["offset", "sequence", "lsn"]);
+            match (stream_name, offset) {
+                (Some(stream), Some(offset)) => Some(format!("{stream}:{offset}")),
+                _ => None,
+            }
+        })
+        .unwrap_or_else(|| fallback_body_digest(&raw.body))
+}
+
+fn infer_occurred_at(payload: &ProviderPayload) -> Option<OffsetDateTime> {
+    let ProviderPayload::Known(known) = payload else {
+        return None;
+    };
+    let payload = match known {
+        crate::triggers::event::KnownProviderPayload::Kafka(payload)
+        | crate::triggers::event::KnownProviderPayload::Nats(payload)
+        | crate::triggers::event::KnownProviderPayload::Pulsar(payload)
+        | crate::triggers::event::KnownProviderPayload::PostgresCdc(payload)
+        | crate::triggers::event::KnownProviderPayload::Email(payload)
+        | crate::triggers::event::KnownProviderPayload::Websocket(payload) => payload,
+        _ => return None,
+    };
+    payload.timestamp.as_deref().and_then(|timestamp| {
+        OffsetDateTime::parse(timestamp, &time::format_description::well_known::Rfc3339).ok()
+    })
+}
+
+fn stringish(raw: &JsonValue, fields: &[&str]) -> Option<String> {
+    fields.iter().find_map(|field| {
+        let value = raw.get(*field)?;
+        value
+            .as_str()
+            .map(ToString::to_string)
+            .or_else(|| value.as_i64().map(|number| number.to_string()))
+            .or_else(|| value.as_u64().map(|number| number.to_string()))
+    })
+}
+
+fn header_value<'a>(headers: &'a BTreeMap<String, String>, name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
+}
+
+fn fallback_body_digest(body: &[u8]) -> String {
+    let digest = Sha256::digest(body);
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        encoded.push_str(&format!("{byte:02x}"));
+    }
+    format!("sha256:{encoded}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connectors::{RateLimiterFactory, TriggerBinding};
+    use crate::event_log::{install_memory_for_current_thread, reset_active_event_log};
+    use crate::secrets::{
+        RotationHandle, SecretBytes, SecretError, SecretId, SecretMeta, SecretProvider,
+    };
+    use crate::triggers::InboxIndex;
+
+    struct EmptySecretProvider;
+
+    #[async_trait::async_trait]
+    impl SecretProvider for EmptySecretProvider {
+        async fn get(&self, id: &SecretId) -> Result<SecretBytes, SecretError> {
+            Err(SecretError::NotFound {
+                provider: self.namespace().to_string(),
+                id: id.clone(),
+            })
+        }
+
+        async fn put(&self, _id: &SecretId, _value: SecretBytes) -> Result<(), SecretError> {
+            Ok(())
+        }
+
+        async fn rotate(&self, id: &SecretId) -> Result<RotationHandle, SecretError> {
+            Ok(RotationHandle {
+                provider: self.namespace().to_string(),
+                id: id.clone(),
+                from_version: None,
+                to_version: None,
+            })
+        }
+
+        async fn list(&self, _prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError> {
+            Ok(Vec::new())
+        }
+
+        fn namespace(&self) -> &str {
+            "empty"
+        }
+
+        fn supports_versions(&self) -> bool {
+            false
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_connector_normalizes_json_inbound() {
+        install_memory_for_current_thread(128);
+        let event_log = crate::event_log::active_event_log().expect("event log");
+        let inbox = Arc::new(
+            InboxIndex::new(
+                event_log.clone(),
+                Arc::new(crate::connectors::MetricsRegistry::default()),
+            )
+            .await
+            .expect("inbox"),
+        );
+        let mut connector = StreamConnector::new(ProviderId::from("kafka"), "StreamEventPayload");
+        connector
+            .init(ConnectorCtx {
+                event_log,
+                secrets: Arc::new(EmptySecretProvider),
+                inbox,
+                metrics: Arc::new(crate::connectors::MetricsRegistry::default()),
+                rate_limiter: Arc::new(RateLimiterFactory::default()),
+            })
+            .await
+            .expect("init");
+        connector
+            .activate(&[TriggerBinding {
+                provider: ProviderId::from("kafka"),
+                kind: TriggerKind::from("stream"),
+                binding_id: "quotes".to_string(),
+                dedupe_key: None,
+                dedupe_retention_days: 7,
+                config: json!({
+                    "match": {"events": ["quote.tick"]},
+                    "stream": {"topic": "quotes"}
+                }),
+            }])
+            .await
+            .expect("activate");
+
+        let mut headers = BTreeMap::new();
+        headers.insert("content-type".to_string(), "application/json".to_string());
+        let mut raw = RawInbound::new(
+            "",
+            headers,
+            serde_json::to_vec(&json!({
+                "key": "acct-1",
+                "offset": 42,
+                "value": {"amount": 10}
+            }))
+            .unwrap(),
+        );
+        raw.metadata = json!({"binding_id": "quotes"});
+
+        let event = connector.normalize_inbound(raw).await.expect("event");
+        assert_eq!(event.provider.as_str(), "kafka");
+        assert_eq!(event.kind, "quote.tick");
+        assert_eq!(event.dedupe_key, "acct-1");
+        let ProviderPayload::Known(crate::triggers::event::KnownProviderPayload::Kafka(payload)) =
+            event.provider_payload
+        else {
+            panic!("expected kafka stream payload");
+        };
+        assert_eq!(payload.stream.as_deref(), None);
+        assert_eq!(payload.key.as_deref(), Some("acct-1"));
+        reset_active_event_log();
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -57,8 +57,8 @@ pub use connectors::{
     Connector, ConnectorClient, ConnectorCtx, ConnectorError, ConnectorMetricsSnapshot,
     ConnectorRegistry, GenericWebhookConnector, GitHubConnector, LinearConnector, MetricsRegistry,
     NotionConnector, PersistedNotionWebhookHandshake, PostNormalizeOutcome, ProviderPayloadSchema,
-    RateLimitConfig, RateLimiterFactory, RawInbound, SlackConnector, TriggerBinding, TriggerKind,
-    TriggerRegistry, WebhookSignatureVariant,
+    RateLimitConfig, RateLimiterFactory, RawInbound, SlackConnector, StreamConnector,
+    TriggerBinding, TriggerKind, TriggerRegistry, WebhookSignatureVariant,
 };
 pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;

--- a/crates/harn-vm/src/triggers/event.rs
+++ b/crates/harn-vm/src/triggers/event.rs
@@ -1343,7 +1343,10 @@ fn stream_provider_schema(
             &[],
             SignatureVerificationMetadata::None,
             Vec::new(),
-            ProviderRuntimeMetadata::Placeholder,
+            ProviderRuntimeMetadata::Builtin {
+                connector: "stream".to_string(),
+                default_signature_variant: None,
+            },
         ),
         normalize,
     }
@@ -2099,7 +2102,7 @@ mod tests {
             .filter(|entry| matches!(entry.runtime, ProviderRuntimeMetadata::Builtin { .. }))
             .collect();
 
-        assert_eq!(builtin.len(), 7);
+        assert_eq!(builtin.len(), 13);
         assert!(builtin.iter().any(|entry| entry.provider == "a2a-push"));
         assert!(builtin.iter().any(|entry| entry.provider == "cron"));
         assert!(builtin.iter().any(|entry| entry.provider == "github"));
@@ -2115,7 +2118,10 @@ mod tests {
         assert_eq!(kafka.schema_name, "StreamEventPayload");
         assert!(matches!(
             kafka.runtime,
-            ProviderRuntimeMetadata::Placeholder
+            ProviderRuntimeMetadata::Builtin {
+                ref connector,
+                default_signature_variant: None
+            } if connector == "stream"
         ));
     }
 

--- a/docs/src/triggers/manifest.md
+++ b/docs/src/triggers/manifest.md
@@ -165,9 +165,10 @@ catalog currently recognizes these STREAM-01 providers:
 - `websocket`
 
 Stream providers are cataloged with a shared `StreamEventPayload` typed payload.
-Concrete broker/email/WebSocket connector loops are represented as placeholder
-connectors until a deployment supplies a Harn connector override or a future
-native connector lands.
+The built-in `stream` connector normalizes unsigned HTTP ingress for stream
+triggers that declare `path = "/..."`. Native long-running broker/email
+consumer loops are still supplied through Harn connector overrides until
+provider-specific Rust consumers land.
 
 Windowing is declared with `window = { ... }`:
 


### PR DESCRIPTION
## Summary
- Adds a built-in generic `stream` connector for STREAM-01 providers that normalizes unsigned HTTP ingress into stream trigger events.
- Wires stream triggers that declare `path = "..."` into the orchestrator listener via connector-owned ingress.
- Updates provider catalog metadata, docs, conformance, and HTTP coverage so Kafka/NATS/Pulsar/Postgres CDC/email/WebSocket advertise the generic stream ingress connector.

## Scope
Refs #280. This lands the generic ingress/runtime plumbing for stream triggers. Native long-running broker/email consumer loops remain future work via provider-specific connectors or Harn connector overrides.

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-280 cargo check -p harn-vm -p harn-cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-280 cargo test -p harn-vm stream_connector_normalizes_json_inbound -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-280 cargo test -p harn-cli stream_trigger_route_uses_generic_stream_connector -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-280 cargo test -p harn-cli trigger_manifest_entries_round_trip_stream_sources -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-280 cargo test -p harn-cli trigger_manifest_entries_parse_inline_sources -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-280 cargo test -p harn-cli collect_manifest_triggers_expands_stream_sources -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-280 cargo run --quiet --bin harn -- test conformance --filter trigger_provider_catalog`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-280 cargo run --quiet --bin harn -- test conformance --filter trigger_stream_combinators`
- pre-commit hook passed
- pre-push hook completed full nextest once before failing Harn formatting; after formatting, a rerun hit a listener URL timeout in `bounded_pump_drain_truncates_and_replays_remaining_backlog_after_restart`, and that test passed when rerun in isolation.