### PR TITLE
[codex] Implement NormalizeResult v1 for Harn connectors

### DIFF
--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
-use axum::body::Bytes;
+use axum::body::{Body, Bytes};
 use axum::extract::{DefaultBodyLimit, Extension, OriginalUri, Query};
 use axum::http::{HeaderMap, Method, StatusCode};
 use axum::middleware;
@@ -635,103 +635,19 @@ async fn ingest_trigger(
         )
         .await;
         let response = match result {
-            Ok(NormalizedRequest::Event(event)) => {
-                let postprocess = harn_vm::postprocess_normalized_event(
-                    context.inbox.as_ref(),
-                    &context.route.trigger_id,
-                    context.route.dedupe_key_template.is_some(),
-                    context.route.dedupe_ttl(),
-                    *event,
-                )
-                .await;
-                match postprocess {
-                    Ok(harn_vm::PostNormalizeOutcome::DuplicateDropped) => {
-                        context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+            Ok(NormalizedRequest::Events(events)) => {
+                match enqueue_normalized_events(&context, events, &span_context_headers).await {
+                    Ok(summary) => {
                         context
-                            .metrics_registry
-                            .record_trigger_deduped(&context.route.trigger_id, "inbox_duplicate");
+                            .metrics
+                            .dispatched
+                            .fetch_add(summary.accepted as u64, Ordering::Relaxed);
+                        context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
                         context.metrics_registry.set_trigger_inflight(
                             &context.route.trigger_id,
                             context.metrics.in_flight.load(Ordering::Relaxed),
                         );
-                        (
-                            StatusCode::OK,
-                            axum::Json(json!({
-                                "status": "duplicate_dropped",
-                                "trigger_id": context.route.trigger_id,
-                            })),
-                        )
-                            .into_response()
-                    }
-                    Ok(harn_vm::PostNormalizeOutcome::Ready(event)) => {
-                        let event = *event;
-                        let payload = json!({
-                            "trigger_id": context.route.trigger_id,
-                            "binding_version": context.route.binding_version,
-                            "event": event,
-                        });
-                        let mut pending_headers = BTreeMap::new();
-                        pending_headers.insert("trace_id".to_string(), event.trace_id.0.clone());
-                        pending_headers.extend(span_context_headers.clone());
-                        let append_started = Instant::now();
-                        let payload_size_bytes = serde_json::to_vec(&payload)
-                            .map(|bytes| bytes.len())
-                            .unwrap_or(0);
-
-                        match context
-                            .event_log
-                            .append(
-                                &context.pending_topic,
-                                LogEvent::new("trigger_event", payload)
-                                    .with_headers(pending_headers),
-                            )
-                            .await
-                        {
-                            Ok(event_id) => {
-                                context.metrics_registry.record_event_log_append(
-                                    context.pending_topic.as_str(),
-                                    append_started.elapsed(),
-                                    payload_size_bytes,
-                                );
-                                tracing::info!(
-                                    component = "listener",
-                                    trace_id = %event.trace_id.0,
-                                    trigger_id = %context.route.trigger_id,
-                                    event_id = %event_id,
-                                    "trigger event accepted"
-                                );
-                                context.metrics.dispatched.fetch_add(1, Ordering::Relaxed);
-                                context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
-                                context.metrics_registry.set_trigger_inflight(
-                                    &context.route.trigger_id,
-                                    context.metrics.in_flight.load(Ordering::Relaxed),
-                                );
-                                (
-                                    StatusCode::OK,
-                                    axum::Json(json!({
-                                        "status": "accepted",
-                                        "event_id": event_id,
-                                        "trigger_id": context.route.trigger_id,
-                                    })),
-                                )
-                                    .into_response()
-                            }
-                            Err(error) => {
-                                context.metrics.failed.fetch_add(1, Ordering::Relaxed);
-                                context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
-                                context.metrics_registry.set_trigger_inflight(
-                                    &context.route.trigger_id,
-                                    context.metrics.in_flight.load(Ordering::Relaxed),
-                                );
-                                (
-                                    StatusCode::INTERNAL_SERVER_ERROR,
-                                    format!(
-                                        "failed to append trigger event to pending log: {error}"
-                                    ),
-                                )
-                                    .into_response()
-                            }
-                        }
+                        enqueue_summary_response(&context, summary)
                     }
                     Err(error) => {
                         context.metrics.failed.fetch_add(1, Ordering::Relaxed);
@@ -740,12 +656,37 @@ async fn ingest_trigger(
                             &context.route.trigger_id,
                             context.metrics.in_flight.load(Ordering::Relaxed),
                         );
-                        HttpError::from_connector(error).into_response()
+                        error.into_response()
                     }
                 }
             }
-            Ok(NormalizedRequest::Immediate(response)) => {
-                context.metrics.dispatched.fetch_add(1, Ordering::Relaxed);
+            Ok(NormalizedRequest::Immediate { response, events }) => {
+                match enqueue_normalized_events(&context, events, &span_context_headers).await {
+                    Ok(summary) => {
+                        context.metrics.dispatched.fetch_add(
+                            std::cmp::max(summary.accepted, 1) as u64,
+                            Ordering::Relaxed,
+                        );
+                        context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+                        context.metrics_registry.set_trigger_inflight(
+                            &context.route.trigger_id,
+                            context.metrics.in_flight.load(Ordering::Relaxed),
+                        );
+                        response
+                    }
+                    Err(error) => {
+                        context.metrics.failed.fetch_add(1, Ordering::Relaxed);
+                        context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+                        context.metrics_registry.set_trigger_inflight(
+                            &context.route.trigger_id,
+                            context.metrics.in_flight.load(Ordering::Relaxed),
+                        );
+                        error.into_response()
+                    }
+                }
+            }
+            Ok(NormalizedRequest::Rejected(response)) => {
+                context.metrics.failed.fetch_add(1, Ordering::Relaxed);
                 context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
                 context.metrics_registry.set_trigger_inflight(
                     &context.route.trigger_id,
@@ -878,27 +819,13 @@ async fn normalize_request(
             "binding_version": context.route.binding_version,
             "path": context.route.path,
         });
-        let mut event = connector
+        let result = connector
             .lock()
             .await
-            .normalize_inbound(raw)
+            .normalize_inbound_result(raw)
             .await
             .map_err(HttpError::from_connector)?;
-        if let Some(challenge) = slack_url_verification_challenge(&event) {
-            return Ok(NormalizedRequest::Immediate(
-                (
-                    StatusCode::OK,
-                    [("content-type", "text/plain; charset=utf-8")],
-                    challenge,
-                )
-                    .into_response(),
-            ));
-        }
-        if let Some(response) = notion_subscription_verification_response(&event) {
-            return Ok(NormalizedRequest::Immediate(response));
-        }
-        event.trace_id = trace_id.clone();
-        return Ok(NormalizedRequest::Event(Box::new(event)));
+        return connector_normalize_result_to_request(result, trace_id);
     }
 
     let normalized_body = normalize_body(body, normalized_headers);
@@ -951,7 +878,7 @@ async fn normalize_request(
     )
     .map_err(|error| HttpError::unprocessable(error.to_string()))?;
 
-    Ok(NormalizedRequest::Event(Box::new(harn_vm::TriggerEvent {
+    Ok(NormalizedRequest::Events(vec![harn_vm::TriggerEvent {
         id: harn_vm::TriggerEventId::new(),
         provider,
         kind: trigger_kind,
@@ -969,12 +896,243 @@ async fn normalize_request(
         provider_payload,
         signature_status,
         dedupe_claimed: false,
-    })))
+    }]))
 }
 
 enum NormalizedRequest {
-    Event(Box<harn_vm::TriggerEvent>),
-    Immediate(Response),
+    Events(Vec<harn_vm::TriggerEvent>),
+    Immediate {
+        response: Response,
+        events: Vec<harn_vm::TriggerEvent>,
+    },
+    Rejected(Response),
+}
+
+struct EnqueueSummary {
+    accepted: usize,
+    duplicates: usize,
+    first_event_id: Option<String>,
+}
+
+fn connector_normalize_result_to_request(
+    result: harn_vm::ConnectorNormalizeResult,
+    trace_id: harn_vm::TraceId,
+) -> Result<NormalizedRequest, HttpError> {
+    match result {
+        harn_vm::ConnectorNormalizeResult::Event(event) => {
+            let mut event = *event;
+            if let Some(challenge) = slack_url_verification_challenge(&event) {
+                return Ok(NormalizedRequest::Immediate {
+                    response: (
+                        StatusCode::OK,
+                        [("content-type", "text/plain; charset=utf-8")],
+                        challenge,
+                    )
+                        .into_response(),
+                    events: Vec::new(),
+                });
+            }
+            if let Some(response) = notion_subscription_verification_response(&event) {
+                return Ok(NormalizedRequest::Immediate {
+                    response,
+                    events: Vec::new(),
+                });
+            }
+            event.trace_id = trace_id;
+            Ok(NormalizedRequest::Events(vec![event]))
+        }
+        harn_vm::ConnectorNormalizeResult::Batch(mut events) => {
+            set_trace_id(&mut events, trace_id);
+            Ok(NormalizedRequest::Events(events))
+        }
+        harn_vm::ConnectorNormalizeResult::ImmediateResponse {
+            response,
+            mut events,
+        } => {
+            set_trace_id(&mut events, trace_id);
+            Ok(NormalizedRequest::Immediate {
+                response: connector_http_response_to_response(response)?,
+                events,
+            })
+        }
+        harn_vm::ConnectorNormalizeResult::Reject(response) => Ok(NormalizedRequest::Rejected(
+            connector_http_response_to_response(response)?,
+        )),
+    }
+}
+
+fn set_trace_id(events: &mut [harn_vm::TriggerEvent], trace_id: harn_vm::TraceId) {
+    for event in events {
+        event.trace_id = trace_id.clone();
+    }
+}
+
+fn connector_http_response_to_response(
+    response: harn_vm::ConnectorHttpResponse,
+) -> Result<Response, HttpError> {
+    let status = StatusCode::from_u16(response.status).map_err(|error| {
+        HttpError::internal(format!(
+            "connector returned invalid HTTP status {}: {error}",
+            response.status
+        ))
+    })?;
+    let mut builder = Response::builder().status(status);
+    let has_content_type = response
+        .headers
+        .keys()
+        .any(|key| key.eq_ignore_ascii_case("content-type"));
+    for (name, value) in response.headers {
+        let name = axum::http::HeaderName::from_bytes(name.as_bytes()).map_err(|error| {
+            HttpError::internal(format!(
+                "connector returned invalid response header name: {error}"
+            ))
+        })?;
+        let value = axum::http::HeaderValue::from_str(&value).map_err(|error| {
+            HttpError::internal(format!(
+                "connector returned invalid response header value for '{}': {error}",
+                name.as_str()
+            ))
+        })?;
+        builder = builder.header(name, value);
+    }
+
+    let body = match response.body {
+        JsonValue::Null => Body::empty(),
+        JsonValue::String(value) => {
+            if !has_content_type {
+                builder = builder.header(
+                    axum::http::header::CONTENT_TYPE,
+                    "text/plain; charset=utf-8",
+                );
+            }
+            Body::from(value)
+        }
+        value => {
+            if !has_content_type {
+                builder = builder.header(axum::http::header::CONTENT_TYPE, "application/json");
+            }
+            let bytes = serde_json::to_vec(&value)
+                .map_err(|error| HttpError::internal(error.to_string()))?;
+            Body::from(bytes)
+        }
+    };
+
+    builder
+        .body(body)
+        .map_err(|error| HttpError::internal(error.to_string()))
+}
+
+async fn enqueue_normalized_events(
+    context: &RouteContext,
+    events: Vec<harn_vm::TriggerEvent>,
+    span_context_headers: &BTreeMap<String, String>,
+) -> Result<EnqueueSummary, HttpError> {
+    let mut summary = EnqueueSummary {
+        accepted: 0,
+        duplicates: 0,
+        first_event_id: None,
+    };
+
+    for event in events {
+        let postprocess = harn_vm::postprocess_normalized_event(
+            context.inbox.as_ref(),
+            &context.route.trigger_id,
+            context.route.dedupe_key_template.is_some(),
+            context.route.dedupe_ttl(),
+            event,
+        )
+        .await
+        .map_err(HttpError::from_connector)?;
+        match postprocess {
+            harn_vm::PostNormalizeOutcome::DuplicateDropped => {
+                summary.duplicates += 1;
+                context
+                    .metrics_registry
+                    .record_trigger_deduped(&context.route.trigger_id, "inbox_duplicate");
+            }
+            harn_vm::PostNormalizeOutcome::Ready(event) => {
+                let event = *event;
+                let payload = json!({
+                    "trigger_id": context.route.trigger_id,
+                    "binding_version": context.route.binding_version,
+                    "event": event,
+                });
+                let mut pending_headers = BTreeMap::new();
+                pending_headers.insert("trace_id".to_string(), event.trace_id.0.clone());
+                pending_headers.extend(span_context_headers.clone());
+                let append_started = Instant::now();
+                let payload_size_bytes = serde_json::to_vec(&payload)
+                    .map(|bytes| bytes.len())
+                    .unwrap_or(0);
+                let event_id = context
+                    .event_log
+                    .append(
+                        &context.pending_topic,
+                        LogEvent::new("trigger_event", payload).with_headers(pending_headers),
+                    )
+                    .await
+                    .map_err(|error| {
+                        HttpError::internal(format!(
+                            "failed to append trigger event to pending log: {error}"
+                        ))
+                    })?;
+                context.metrics_registry.record_event_log_append(
+                    context.pending_topic.as_str(),
+                    append_started.elapsed(),
+                    payload_size_bytes,
+                );
+                tracing::info!(
+                    component = "listener",
+                    trace_id = %event.trace_id.0,
+                    trigger_id = %context.route.trigger_id,
+                    event_id = %event_id,
+                    "trigger event accepted"
+                );
+                summary.accepted += 1;
+                if summary.first_event_id.is_none() {
+                    summary.first_event_id = Some(event_id.to_string());
+                }
+            }
+        }
+    }
+
+    Ok(summary)
+}
+
+fn enqueue_summary_response(context: &RouteContext, summary: EnqueueSummary) -> Response {
+    if summary.accepted == 0 && summary.duplicates > 0 {
+        return (
+            StatusCode::OK,
+            axum::Json(json!({
+                "status": "duplicate_dropped",
+                "trigger_id": context.route.trigger_id,
+            })),
+        )
+            .into_response();
+    }
+
+    if summary.accepted == 1 && summary.duplicates == 0 {
+        return (
+            StatusCode::OK,
+            axum::Json(json!({
+                "status": "accepted",
+                "event_id": summary.first_event_id,
+                "trigger_id": context.route.trigger_id,
+            })),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::OK,
+        axum::Json(json!({
+            "status": "accepted",
+            "events_accepted": summary.accepted,
+            "duplicates_dropped": summary.duplicates,
+            "trigger_id": context.route.trigger_id,
+        })),
+    )
+        .into_response()
 }
 
 fn trigger_path(trigger: &CollectedManifestTrigger) -> Result<String, String> {

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -318,13 +318,16 @@ pub fn normalize_inbound(raw) {
     message: body.message,
   })
   return {
-    kind: "echo.received",
-    occurred_at: raw.received_at,
-    dedupe_key: "echo:" + body.id,
-    payload: {
-      body: body,
-      token: token,
-      binding_id: raw.binding_id,
+    type: "event",
+    event: {
+      kind: "echo.received",
+      occurred_at: raw.received_at,
+      dedupe_key: "echo:" + body.id,
+      payload: {
+        body: body,
+        token: token,
+        binding_id: raw.binding_id,
+      },
     },
   }
 }

--- a/crates/harn-vm/src/connectors/harn_module.rs
+++ b/crates/harn-vm/src/connectors/harn_module.rs
@@ -21,8 +21,9 @@ use crate::value::{VmClosure, VmError, VmValue};
 use crate::vm::Vm;
 use crate::{
     redact_headers, ClientError, Connector, ConnectorClient, ConnectorCtx, ConnectorError,
-    HeaderRedactionPolicy, ProviderId, ProviderPayload, ProviderPayloadSchema, SignatureStatus,
-    TenantId, TraceId, TriggerBinding, TriggerEvent, TriggerEventId, TriggerKind,
+    ConnectorHttpResponse, ConnectorNormalizeResult, HeaderRedactionPolicy, ProviderId,
+    ProviderPayload, ProviderPayloadSchema, SignatureStatus, TenantId, TraceId, TriggerBinding,
+    TriggerEvent, TriggerEventId, TriggerKind,
 };
 
 thread_local! {
@@ -97,6 +98,16 @@ struct HarnNormalizeResult {
     headers: Option<BTreeMap<String, String>>,
     #[serde(default)]
     batch: Option<Vec<JsonValue>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HarnHttpResponse {
+    #[serde(default = "default_ok_status")]
+    status: u16,
+    #[serde(default)]
+    headers: BTreeMap<String, String>,
+    #[serde(default)]
+    body: JsonValue,
 }
 
 impl HarnConnector {
@@ -362,50 +373,52 @@ impl Connector for HarnConnector {
         &self,
         raw: crate::RawInbound,
     ) -> Result<TriggerEvent, ConnectorError> {
+        let result = self.normalize_inbound_result(raw).await?;
+        match result {
+            ConnectorNormalizeResult::Event(event) => Ok(*event),
+            ConnectorNormalizeResult::Batch(events) => {
+                Err(ConnectorError::HarnRuntime(format!(
+                    "connector '{}' returned a NormalizeResult batch where a single event was expected ({} events)",
+                    self.provider_id.as_str(),
+                    events.len()
+                )))
+            }
+            ConnectorNormalizeResult::ImmediateResponse { events, .. } => {
+                let mut events = events.into_iter();
+                let Some(event) = events.next() else {
+                    return Err(ConnectorError::HarnRuntime(format!(
+                        "connector '{}' returned an immediate_response without an event where a single event was expected",
+                        self.provider_id.as_str()
+                    )));
+                };
+                if events.next().is_some() {
+                    return Err(ConnectorError::HarnRuntime(format!(
+                        "connector '{}' returned an immediate_response with multiple events where a single event was expected",
+                        self.provider_id.as_str()
+                    )));
+                }
+                Ok(event)
+            }
+            ConnectorNormalizeResult::Reject(response) => Err(ConnectorError::Unsupported(format!(
+                "connector '{}' rejected inbound request with HTTP {}",
+                self.provider_id.as_str(),
+                response.status
+            ))),
+        }
+    }
+
+    async fn normalize_inbound_result(
+        &self,
+        raw: crate::RawInbound,
+    ) -> Result<ConnectorNormalizeResult, ConnectorError> {
         let raw_json = raw_inbound_to_json(&raw);
-        let event = self
+        let value = self
             .shared
             .worker()?
             .call_export("normalize_inbound", vec![raw_json], true)
             .await?
             .expect("required export returns a value");
-        let normalized: HarnNormalizeResult = serde_json::from_value(event)
-            .map_err(|error| ConnectorError::HarnRuntime(error.to_string()))?;
-        let occurred_at = normalized
-            .occurred_at
-            .as_deref()
-            .map(parse_rfc3339)
-            .transpose()?;
-        let tenant_id = normalized.tenant_id.map(TenantId::new);
-        let headers = redact_headers(
-            &normalized.headers.unwrap_or_else(|| raw.headers.clone()),
-            &HeaderRedactionPolicy::default(),
-        );
-        let provider_payload = ProviderPayload::normalize(
-            &self.provider_id,
-            &normalized.kind,
-            &raw.headers,
-            normalized.payload,
-        )
-        .map_err(|error| ConnectorError::HarnRuntime(error.to_string()))?;
-        Ok(TriggerEvent {
-            id: TriggerEventId::new(),
-            provider: self.provider_id.clone(),
-            kind: normalized.kind,
-            received_at: raw.received_at,
-            occurred_at,
-            dedupe_key: normalized.dedupe_key,
-            trace_id: TraceId::new(),
-            tenant_id: tenant_id.or_else(|| raw.tenant_id.clone()),
-            headers,
-            batch: normalized.batch,
-            provider_payload,
-            raw_body: Some(raw.body.clone()),
-            signature_status: normalized
-                .signature_status
-                .unwrap_or(SignatureStatus::Unsigned),
-            dedupe_claimed: false,
-        })
+        parse_normalize_result(&self.provider_id, &raw, value)
     }
 
     fn payload_schema(&self) -> ProviderPayloadSchema {
@@ -437,6 +450,179 @@ impl ConnectorClient for HarnConnectorClient {
         };
         Ok(result)
     }
+}
+
+fn parse_normalize_result(
+    provider_id: &ProviderId,
+    raw: &crate::RawInbound,
+    value: JsonValue,
+) -> Result<ConnectorNormalizeResult, ConnectorError> {
+    let result_type = value
+        .get("type")
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    match result_type {
+        Some("event") => {
+            let event_value = value.get("event").cloned().unwrap_or(value);
+            parse_harn_normalized_event(provider_id, raw, event_value)
+                .map(ConnectorNormalizeResult::event)
+        }
+        Some("batch") => {
+            let events = parse_events_field(provider_id, raw, &value, "events")?;
+            if events.is_empty() {
+                return Err(ConnectorError::HarnRuntime(
+                    "NormalizeResult batch must contain at least one event".to_string(),
+                ));
+            }
+            Ok(ConnectorNormalizeResult::Batch(events))
+        }
+        Some("immediate_response") => {
+            let response = parse_http_response(&value, "immediate_response", 200)?;
+            let events = parse_optional_embedded_events(provider_id, raw, &value)?;
+            Ok(ConnectorNormalizeResult::ImmediateResponse { response, events })
+        }
+        Some("reject") => {
+            parse_http_response(&value, "reject", 400).map(ConnectorNormalizeResult::Reject)
+        }
+        Some(other) => Err(ConnectorError::HarnRuntime(format!(
+            "unsupported NormalizeResult type '{other}'"
+        ))),
+        None => {
+            tracing::warn!(
+                provider = provider_id.as_str(),
+                "Harn connector normalize_inbound returned a legacy direct event shape; return NormalizeResult v1 instead"
+            );
+            parse_harn_normalized_event(provider_id, raw, value)
+                .map(ConnectorNormalizeResult::event)
+        }
+    }
+}
+
+fn parse_optional_embedded_events(
+    provider_id: &ProviderId,
+    raw: &crate::RawInbound,
+    value: &JsonValue,
+) -> Result<Vec<TriggerEvent>, ConnectorError> {
+    let has_event = value.get("event").is_some();
+    let has_events = value.get("events").is_some();
+    if has_event && has_events {
+        return Err(ConnectorError::HarnRuntime(
+            "NormalizeResult immediate_response must use either 'event' or 'events', not both"
+                .to_string(),
+        ));
+    }
+    if has_event {
+        let event = value
+            .get("event")
+            .cloned()
+            .expect("checked immediate_response event field");
+        return parse_harn_normalized_event(provider_id, raw, event).map(|event| vec![event]);
+    }
+    if has_events {
+        return parse_events_field(provider_id, raw, value, "events");
+    }
+    Ok(Vec::new())
+}
+
+fn parse_events_field(
+    provider_id: &ProviderId,
+    raw: &crate::RawInbound,
+    value: &JsonValue,
+    field: &str,
+) -> Result<Vec<TriggerEvent>, ConnectorError> {
+    let events = value
+        .get(field)
+        .and_then(JsonValue::as_array)
+        .ok_or_else(|| {
+            ConnectorError::HarnRuntime(format!("NormalizeResult missing array field '{field}'"))
+        })?;
+    events
+        .iter()
+        .cloned()
+        .map(|event| parse_harn_normalized_event(provider_id, raw, event))
+        .collect()
+}
+
+fn parse_harn_normalized_event(
+    provider_id: &ProviderId,
+    raw: &crate::RawInbound,
+    value: JsonValue,
+) -> Result<TriggerEvent, ConnectorError> {
+    let normalized: HarnNormalizeResult = serde_json::from_value(value)
+        .map_err(|error| ConnectorError::HarnRuntime(error.to_string()))?;
+    let occurred_at = normalized
+        .occurred_at
+        .as_deref()
+        .map(parse_rfc3339)
+        .transpose()?;
+    let tenant_id = normalized.tenant_id.map(TenantId::new);
+    let headers = redact_headers(
+        &normalized.headers.unwrap_or_else(|| raw.headers.clone()),
+        &HeaderRedactionPolicy::default(),
+    );
+    let provider_payload = ProviderPayload::normalize(
+        provider_id,
+        &normalized.kind,
+        &raw.headers,
+        normalized.payload,
+    )
+    .map_err(|error| ConnectorError::HarnRuntime(error.to_string()))?;
+    Ok(TriggerEvent {
+        id: TriggerEventId::new(),
+        provider: provider_id.clone(),
+        kind: normalized.kind,
+        received_at: raw.received_at,
+        occurred_at,
+        dedupe_key: normalized.dedupe_key,
+        trace_id: TraceId::new(),
+        tenant_id: tenant_id.or_else(|| raw.tenant_id.clone()),
+        headers,
+        batch: normalized.batch,
+        provider_payload,
+        raw_body: Some(raw.body.clone()),
+        signature_status: normalized
+            .signature_status
+            .unwrap_or(SignatureStatus::Unsigned),
+        dedupe_claimed: false,
+    })
+}
+
+fn parse_http_response(
+    value: &JsonValue,
+    nested_field: &str,
+    default_status: u16,
+) -> Result<ConnectorHttpResponse, ConnectorError> {
+    let response_value = value
+        .get(nested_field)
+        .or_else(|| value.get("response"))
+        .unwrap_or(value);
+    let source_has_status = response_value.get("status").is_some();
+    let mut response: HarnHttpResponse = serde_json::from_value(response_value.clone())
+        .map_err(|error| ConnectorError::HarnRuntime(error.to_string()))?;
+    if !source_has_status {
+        response.status = default_status;
+    }
+    validate_http_status(response.status)?;
+    Ok(ConnectorHttpResponse::new(
+        response.status,
+        response.headers,
+        response.body,
+    ))
+}
+
+fn validate_http_status(status: u16) -> Result<(), ConnectorError> {
+    if (100..=599).contains(&status) {
+        return Ok(());
+    }
+    Err(ConnectorError::HarnRuntime(format!(
+        "NormalizeResult HTTP status {status} is outside 100..=599"
+    )))
+}
+
+fn default_ok_status() -> u16 {
+    200
 }
 
 async fn load_module_runtime(
@@ -654,4 +840,165 @@ fn raw_inbound_to_json(raw: &crate::RawInbound) -> JsonValue {
         }
     }
     payload
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw_inbound(body: JsonValue) -> crate::RawInbound {
+        let mut headers = BTreeMap::new();
+        headers.insert("content-type".to_string(), "application/json".to_string());
+        let mut raw = crate::RawInbound::new(
+            "",
+            headers,
+            serde_json::to_vec(&body).expect("json body serializes"),
+        );
+        raw.received_at = OffsetDateTime::parse("2026-04-22T12:34:56Z", &Rfc3339).unwrap();
+        raw
+    }
+
+    fn event_value(kind: &str, dedupe_key: &str, id: &str) -> JsonValue {
+        json!({
+            "kind": kind,
+            "occurred_at": "2026-04-22T12:30:00Z",
+            "dedupe_key": dedupe_key,
+            "payload": {
+                "id": id,
+                "type": kind,
+            },
+            "signature_status": {
+                "state": "verified",
+            },
+        })
+    }
+
+    #[test]
+    fn normalize_result_v1_event_parses_normal_event() {
+        let provider = ProviderId::new("webhook");
+        let raw = raw_inbound(json!({"id": "evt-1"}));
+        let result = parse_normalize_result(
+            &provider,
+            &raw,
+            json!({
+                "type": "event",
+                "event": event_value("webhook.received", "webhook:evt-1", "evt-1"),
+            }),
+        )
+        .unwrap();
+
+        let ConnectorNormalizeResult::Event(event) = result else {
+            panic!("expected event result");
+        };
+        assert_eq!(event.provider, provider);
+        assert_eq!(event.kind, "webhook.received");
+        assert_eq!(event.dedupe_key, "webhook:evt-1");
+        assert_eq!(event.signature_status, SignatureStatus::Verified);
+        assert!(event.raw_body.is_some());
+    }
+
+    #[test]
+    fn normalize_result_v1_batch_parses_multiple_events() {
+        let provider = ProviderId::new("webhook");
+        let raw = raw_inbound(json!({"items": [{"id": "a"}, {"id": "b"}]}));
+        let result = parse_normalize_result(
+            &provider,
+            &raw,
+            json!({
+                "type": "batch",
+                "events": [
+                    event_value("webhook.received", "webhook:a", "a"),
+                    event_value("webhook.received", "webhook:b", "b"),
+                ],
+            }),
+        )
+        .unwrap();
+
+        let ConnectorNormalizeResult::Batch(events) = result else {
+            panic!("expected batch result");
+        };
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].dedupe_key, "webhook:a");
+        assert_eq!(events[1].dedupe_key, "webhook:b");
+    }
+
+    #[test]
+    fn normalize_result_v1_immediate_response_covers_slack_url_verification_fixture() {
+        let provider = ProviderId::new("slack");
+        let raw = raw_inbound(json!({
+            "type": "url_verification",
+            "challenge": "challenge-token",
+        }));
+        let result = parse_normalize_result(
+            &provider,
+            &raw,
+            json!({
+                "type": "immediate_response",
+                "immediate_response": {
+                    "status": 200,
+                    "headers": {
+                        "content-type": "text/plain; charset=utf-8",
+                    },
+                    "body": "challenge-token",
+                },
+            }),
+        )
+        .unwrap();
+
+        let ConnectorNormalizeResult::ImmediateResponse { response, events } = result else {
+            panic!("expected immediate_response result");
+        };
+        assert_eq!(response.status, 200);
+        assert_eq!(
+            response.headers.get("content-type").map(String::as_str),
+            Some("text/plain; charset=utf-8")
+        );
+        assert_eq!(
+            response.body,
+            JsonValue::String("challenge-token".to_string())
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn normalize_result_v1_reject_parses_http_rejection() {
+        let provider = ProviderId::new("webhook");
+        let raw = raw_inbound(json!({"id": "evt-1"}));
+        let result = parse_normalize_result(
+            &provider,
+            &raw,
+            json!({
+                "type": "reject",
+                "status": 403,
+                "body": {
+                    "error": "verification_failed",
+                },
+            }),
+        )
+        .unwrap();
+
+        let ConnectorNormalizeResult::Reject(response) = result else {
+            panic!("expected reject result");
+        };
+        assert_eq!(response.status, 403);
+        assert_eq!(response.body["error"], "verification_failed");
+    }
+
+    #[test]
+    fn legacy_direct_normalize_result_still_parses_during_transition() {
+        let provider = ProviderId::new("webhook");
+        let raw = raw_inbound(json!({"id": "legacy"}));
+        let result = parse_normalize_result(
+            &provider,
+            &raw,
+            event_value("webhook.received", "webhook:legacy", "legacy"),
+        )
+        .unwrap();
+
+        let ConnectorNormalizeResult::Event(event) = result else {
+            panic!("expected legacy event result");
+        };
+        assert_eq!(event.kind, "webhook.received");
+        assert_eq!(event.dedupe_key, "webhook:legacy");
+    }
 }

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -97,11 +97,66 @@ pub trait Connector: Send + Sync {
     /// Verify + normalize a provider-native inbound request into `TriggerEvent`.
     async fn normalize_inbound(&self, raw: RawInbound) -> Result<TriggerEvent, ConnectorError>;
 
+    /// Verify + normalize a provider-native inbound request into the richer
+    /// connector result contract used by ack-first webhook adapters.
+    async fn normalize_inbound_result(
+        &self,
+        raw: RawInbound,
+    ) -> Result<ConnectorNormalizeResult, ConnectorError> {
+        self.normalize_inbound(raw)
+            .await
+            .map(ConnectorNormalizeResult::event)
+    }
+
     /// Payload schema surfaced to future trigger-type narrowing.
     fn payload_schema(&self) -> ProviderPayloadSchema;
 
     /// Outbound API wrapper exposed to handlers.
     fn client(&self) -> Arc<dyn ConnectorClient>;
+}
+
+/// Provider-supplied HTTP response returned before or instead of trigger dispatch.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConnectorHttpResponse {
+    pub status: u16,
+    pub headers: BTreeMap<String, String>,
+    pub body: JsonValue,
+}
+
+impl ConnectorHttpResponse {
+    pub fn new(status: u16, headers: BTreeMap<String, String>, body: JsonValue) -> Self {
+        Self {
+            status,
+            headers,
+            body,
+        }
+    }
+}
+
+/// Normalized inbound result accepted by the runtime connector adapter.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConnectorNormalizeResult {
+    Event(Box<TriggerEvent>),
+    Batch(Vec<TriggerEvent>),
+    ImmediateResponse {
+        response: ConnectorHttpResponse,
+        events: Vec<TriggerEvent>,
+    },
+    Reject(ConnectorHttpResponse),
+}
+
+impl ConnectorNormalizeResult {
+    pub fn event(event: TriggerEvent) -> Self {
+        Self::Event(Box::new(event))
+    }
+
+    pub fn into_events(self) -> Vec<TriggerEvent> {
+        match self {
+            Self::Event(event) => vec![*event],
+            Self::Batch(events) | Self::ImmediateResponse { events, .. } => events,
+            Self::Reject(_) => Vec::new(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -54,11 +54,12 @@ pub use connectors::{
     hmac::verify_hmac_signed,
     install_active_connector_clients, install_active_metrics_registry,
     load_pending_webhook_handshakes, postprocess_normalized_event, ActivationHandle, ClientError,
-    Connector, ConnectorClient, ConnectorCtx, ConnectorError, ConnectorMetricsSnapshot,
-    ConnectorRegistry, GenericWebhookConnector, GitHubConnector, LinearConnector, MetricsRegistry,
-    NotionConnector, PersistedNotionWebhookHandshake, PostNormalizeOutcome, ProviderPayloadSchema,
-    RateLimitConfig, RateLimiterFactory, RawInbound, SlackConnector, StreamConnector,
-    TriggerBinding, TriggerKind, TriggerRegistry, WebhookSignatureVariant,
+    Connector, ConnectorClient, ConnectorCtx, ConnectorError, ConnectorHttpResponse,
+    ConnectorMetricsSnapshot, ConnectorNormalizeResult, ConnectorRegistry, GenericWebhookConnector,
+    GitHubConnector, LinearConnector, MetricsRegistry, NotionConnector,
+    PersistedNotionWebhookHandshake, PostNormalizeOutcome, ProviderPayloadSchema, RateLimitConfig,
+    RateLimiterFactory, RawInbound, SlackConnector, StreamConnector, TriggerBinding, TriggerKind,
+    TriggerRegistry, WebhookSignatureVariant,
 };
 pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;

--- a/docs/src/connectors/authoring.md
+++ b/docs/src/connectors/authoring.md
@@ -75,6 +75,69 @@ pub fn normalize_inbound(raw) -> dict
 
 `normalize_inbound(raw)` returns a dict with:
 
+- `type`: one of `"event"`, `"batch"`, `"immediate_response"`, or `"reject"`
+
+For a single event, return:
+
+```harn
+{
+  type: "event",
+  event: {
+    kind: "echo.received",
+    occurred_at: raw.received_at,
+    dedupe_key: "echo:" + body.id,
+    payload: body,
+  },
+}
+```
+
+For multiple events, return:
+
+```harn
+{
+  type: "batch",
+  events: [
+    {
+      kind: "echo.received",
+      dedupe_key: "echo:" + first.id,
+      payload: first,
+    },
+    {
+      kind: "echo.received",
+      dedupe_key: "echo:" + second.id,
+      payload: second,
+    },
+  ],
+}
+```
+
+For ack-first webhooks such as URL verification handshakes, return an
+immediate HTTP response and optionally include `event` or `events` to enqueue
+after normalization:
+
+```harn
+{
+  type: "immediate_response",
+  immediate_response: {
+    status: 200,
+    headers: {"content-type": "text/plain; charset=utf-8"},
+    body: body.challenge,
+  },
+}
+```
+
+For unsupported or failed verification inputs, return:
+
+```harn
+{
+  type: "reject",
+  status: 403,
+  body: {error: "verification_failed"},
+}
+```
+
+Each event dict contains:
+
 - `kind`: normalized trigger kind
 - `dedupe_key`: stable delivery key
 - `payload`: provider payload dict preserved as `event.provider_payload.raw`
@@ -117,13 +180,16 @@ pub fn normalize_inbound(raw) {
     binding_id: raw.binding_id,
   })
   return {
-    kind: "echo.received",
-    occurred_at: raw.received_at,
-    dedupe_key: "echo:" + body.id,
-    payload: {
-      body: body,
-      token: token,
-      binding_id: raw.binding_id,
+    type: "event",
+    event: {
+      kind: "echo.received",
+      occurred_at: raw.received_at,
+      dedupe_key: "echo:" + body.id,
+      payload: {
+        body: body,
+        token: token,
+        binding_id: raw.binding_id,
+      },
     },
   }
 }

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -3108,9 +3108,23 @@ provider integrations.
 
 Harn-backed connector modules are loaded through manifest `[[providers]]`
 entries and must export `provider_id()`, `kinds()`, and `payload_schema()`.
-Inbound providers also export `normalize_inbound(raw)`, which returns a dict
-with `kind`, `dedupe_key`, and `payload` plus optional metadata such as
-`occurred_at`, `tenant_id`, `headers`, `batch`, and `signature_status`.
+Inbound providers also export `normalize_inbound(raw)`, which returns a
+`NormalizeResult` v1 dict. The top-level `type` field is one of:
+
+- `"event"` with `event: {kind, dedupe_key, payload, ...}` for one normalized
+  event.
+- `"batch"` with `events: [{kind, dedupe_key, payload, ...}, ...]` for multiple
+  normalized events.
+- `"immediate_response"` with `immediate_response: {status, headers?, body?}`
+  and optional `event` or `events` fields for ack-first webhook responses that
+  may still enqueue normalized events.
+- `"reject"` with `status`, `headers?`, and `body?` for explicit verification
+  or unsupported-input rejection.
+
+Each normalized event includes `kind`, `dedupe_key`, and `payload` plus optional
+metadata such as `occurred_at`, `tenant_id`, `headers`, `batch`, and
+`signature_status`. During the transition to NormalizeResult v1, runtimes also
+accept the legacy direct event dict shape.
 
 ## Iterator protocol
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -3106,9 +3106,23 @@ provider integrations.
 
 Harn-backed connector modules are loaded through manifest `[[providers]]`
 entries and must export `provider_id()`, `kinds()`, and `payload_schema()`.
-Inbound providers also export `normalize_inbound(raw)`, which returns a dict
-with `kind`, `dedupe_key`, and `payload` plus optional metadata such as
-`occurred_at`, `tenant_id`, `headers`, `batch`, and `signature_status`.
+Inbound providers also export `normalize_inbound(raw)`, which returns a
+`NormalizeResult` v1 dict. The top-level `type` field is one of:
+
+- `"event"` with `event: {kind, dedupe_key, payload, ...}` for one normalized
+  event.
+- `"batch"` with `events: [{kind, dedupe_key, payload, ...}, ...]` for multiple
+  normalized events.
+- `"immediate_response"` with `immediate_response: {status, headers?, body?}`
+  and optional `event` or `events` fields for ack-first webhook responses that
+  may still enqueue normalized events.
+- `"reject"` with `status`, `headers?`, and `body?` for explicit verification
+  or unsupported-input rejection.
+
+Each normalized event includes `kind`, `dedupe_key`, and `payload` plus optional
+metadata such as `occurred_at`, `tenant_id`, `headers`, `batch`, and
+`signature_status`. During the transition to NormalizeResult v1, runtimes also
+accept the legacy direct event dict shape.
 
 ## Iterator protocol
 


### PR DESCRIPTION
## Summary

- Add a `ConnectorNormalizeResult` contract that supports `event`, `batch`, `immediate_response`, and `reject` outcomes for connector normalization.
- Teach the Harn-module connector adapter to parse NormalizeResult v1 while preserving the legacy direct event dict shape with a transition warning.
- Update the orchestrator listener to enqueue zero, one, or many normalized events and return connector-specified HTTP responses for ack-first or reject paths.
- Document the v1 shape in connector authoring docs and the canonical language spec.

Closes #464.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-464 cargo test -p harn-vm connectors::harn_module --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-464-cli cargo check -p harn-cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-464-cli cargo test -p harn-cli --test orchestrator_http harn_connector_module_round_trips_inbound_and_client_calls -- --nocapture`
- Pre-commit hook: formatting, clippy, highlight sync, markdownlint, actionlint, portal lint
- Pre-push hook: full nextest run (`1963 passed, 7 skipped`), Harn formatting, markdownlint, portal lint