### PR TITLE
[codex] Bound orchestrator topic pumps

### DIFF
--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -1017,6 +1017,13 @@ pub(crate) struct OrchestratorServeArgs {
     /// Seconds to wait for each pump drain before truncating remaining backlog.
     #[arg(long = "drain-deadline", value_name = "SECS")]
     pub drain_deadline: Option<u64>,
+    /// Maximum outstanding items admitted by each topic pump.
+    #[arg(
+        long = "pump-max-outstanding",
+        env = "HARN_ORCHESTRATOR_PUMP_MAX_OUTSTANDING",
+        value_name = "COUNT"
+    )]
+    pub pump_max_outstanding: Option<usize>,
     /// Watch the manifest file and trigger reloads on changes.
     #[arg(long)]
     pub watch: bool,
@@ -2108,6 +2115,8 @@ mod tests {
             "256",
             "--drain-deadline",
             "9",
+            "--pump-max-outstanding",
+            "4",
             "--log-format",
             "json",
             "--role",
@@ -2128,6 +2137,7 @@ mod tests {
         assert_eq!(serve.shutdown_timeout, 45);
         assert_eq!(serve.drain_max_items, Some(256));
         assert_eq!(serve.drain_deadline, Some(9));
+        assert_eq!(serve.pump_max_outstanding, Some(4));
         assert_eq!(serve.log_format, OrchestratorLogFormat::Json);
         assert_eq!(
             serve.role,

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -73,6 +73,12 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
                 .unwrap_or(manifest.orchestrator.drain.deadline_seconds),
         ),
     };
+    let pump_config = PumpConfig {
+        max_outstanding: args
+            .pump_max_outstanding
+            .unwrap_or(manifest.orchestrator.pumps.max_outstanding)
+            .max(1),
+    };
     let state_dir = absolutize_from_cwd(&args.local.state_dir)?;
     std::fs::create_dir_all(&state_dir).map_err(|error| {
         format!(
@@ -190,11 +196,36 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
         event_log.clone(),
         Some(metrics_registry.clone()),
     );
-    let pending_pump = spawn_pending_pump(event_log.clone(), dispatcher.clone())?;
-    let cron_pump = spawn_cron_pump(event_log.clone(), dispatcher.clone())?;
-    let inbox_pump = spawn_inbox_pump(event_log.clone(), dispatcher.clone())?;
-    let waitpoint_pump = spawn_waitpoint_resume_pump(event_log.clone(), dispatcher.clone())?;
-    let waitpoint_cancel_pump = spawn_waitpoint_cancel_pump(event_log.clone(), dispatcher.clone())?;
+    let pending_pump = spawn_pending_pump(
+        event_log.clone(),
+        dispatcher.clone(),
+        pump_config,
+        metrics_registry.clone(),
+    )?;
+    let cron_pump = spawn_cron_pump(
+        event_log.clone(),
+        dispatcher.clone(),
+        pump_config,
+        metrics_registry.clone(),
+    )?;
+    let inbox_pump = spawn_inbox_pump(
+        event_log.clone(),
+        dispatcher.clone(),
+        pump_config,
+        metrics_registry.clone(),
+    )?;
+    let waitpoint_pump = spawn_waitpoint_resume_pump(
+        event_log.clone(),
+        dispatcher.clone(),
+        pump_config,
+        metrics_registry.clone(),
+    )?;
+    let waitpoint_cancel_pump = spawn_waitpoint_cancel_pump(
+        event_log.clone(),
+        dispatcher.clone(),
+        pump_config,
+        metrics_registry.clone(),
+    )?;
     let waitpoint_sweeper = spawn_waitpoint_sweeper(dispatcher.clone());
 
     let listener = ListenerRuntime::start(ListenerConfig {
@@ -285,6 +316,7 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
             "shutdown_timeout_secs": shutdown_timeout.as_secs(),
             "drain_max_items": drain_config.max_items,
             "drain_deadline_secs": drain_config.deadline.as_secs(),
+            "pump_max_outstanding": pump_config.max_outstanding,
         }),
     )
     .await?;
@@ -750,6 +782,11 @@ struct DrainConfig {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PumpConfig {
+    max_outstanding: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct PumpDrainRequest {
     up_to: u64,
     config: DrainConfig,
@@ -858,64 +895,82 @@ struct PendingTriggerRecord {
 fn spawn_pending_pump(
     event_log: Arc<harn_vm::event_log::AnyEventLog>,
     dispatcher: harn_vm::Dispatcher,
+    pump_config: PumpConfig,
+    metrics_registry: Arc<harn_vm::MetricsRegistry>,
 ) -> Result<PumpHandle, String> {
     let topic = harn_vm::event_log::Topic::new(PENDING_TOPIC).map_err(|error| error.to_string())?;
-    spawn_topic_pump(event_log, topic, move |logged| {
-        let dispatcher = dispatcher.clone();
-        async move {
-            if pending_pump_test_should_fail() {
-                return Err("test pending pump failure".to_string());
+    spawn_topic_pump(
+        event_log,
+        topic,
+        pump_config,
+        metrics_registry,
+        move |logged| {
+            let dispatcher = dispatcher.clone();
+            async move {
+                if pending_pump_test_should_fail() {
+                    return Err("test pending pump failure".to_string());
+                }
+                if logged.kind != "trigger_event" {
+                    return Ok(false);
+                }
+                let record: PendingTriggerRecord = serde_json::from_value(logged.payload)
+                    .map_err(|error| format!("failed to decode pending trigger event: {error}"))?;
+                dispatcher
+                    .enqueue_targeted(
+                        Some(record.trigger_id),
+                        Some(record.binding_version),
+                        record.event,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to enqueue pending trigger event: {error}"))?;
+                Ok(true)
             }
-            if logged.kind != "trigger_event" {
-                return Ok(false);
-            }
-            let record: PendingTriggerRecord = serde_json::from_value(logged.payload)
-                .map_err(|error| format!("failed to decode pending trigger event: {error}"))?;
-            dispatcher
-                .enqueue_targeted(
-                    Some(record.trigger_id),
-                    Some(record.binding_version),
-                    record.event,
-                )
-                .await
-                .map_err(|error| format!("failed to enqueue pending trigger event: {error}"))?;
-            Ok(true)
-        }
-    })
+        },
+    )
 }
 
 fn spawn_cron_pump(
     event_log: Arc<harn_vm::event_log::AnyEventLog>,
     dispatcher: harn_vm::Dispatcher,
+    pump_config: PumpConfig,
+    metrics_registry: Arc<harn_vm::MetricsRegistry>,
 ) -> Result<PumpHandle, String> {
     let topic =
         harn_vm::event_log::Topic::new(CRON_TICK_TOPIC).map_err(|error| error.to_string())?;
-    spawn_topic_pump(event_log, topic, move |logged| {
-        let dispatcher = dispatcher.clone();
-        async move {
-            if logged.kind != "trigger_event" {
-                return Ok(false);
+    spawn_topic_pump(
+        event_log,
+        topic,
+        pump_config,
+        metrics_registry,
+        move |logged| {
+            let dispatcher = dispatcher.clone();
+            async move {
+                if logged.kind != "trigger_event" {
+                    return Ok(false);
+                }
+                let event: harn_vm::TriggerEvent = serde_json::from_value(logged.payload)
+                    .map_err(|error| format!("failed to decode cron trigger event: {error}"))?;
+                let trigger_id = match &event.provider_payload {
+                    harn_vm::ProviderPayload::Known(
+                        harn_vm::triggers::event::KnownProviderPayload::Cron(payload),
+                    ) => payload.cron_id.clone(),
+                    _ => None,
+                };
+                dispatcher
+                    .enqueue_targeted(trigger_id, None, event)
+                    .await
+                    .map_err(|error| format!("failed to enqueue cron trigger event: {error}"))?;
+                Ok(true)
             }
-            let event: harn_vm::TriggerEvent = serde_json::from_value(logged.payload)
-                .map_err(|error| format!("failed to decode cron trigger event: {error}"))?;
-            let trigger_id = match &event.provider_payload {
-                harn_vm::ProviderPayload::Known(
-                    harn_vm::triggers::event::KnownProviderPayload::Cron(payload),
-                ) => payload.cron_id.clone(),
-                _ => None,
-            };
-            dispatcher
-                .enqueue_targeted(trigger_id, None, event)
-                .await
-                .map_err(|error| format!("failed to enqueue cron trigger event: {error}"))?;
-            Ok(true)
-        }
-    })
+        },
+    )
 }
 
 fn spawn_inbox_pump(
     event_log: Arc<harn_vm::event_log::AnyEventLog>,
     dispatcher: harn_vm::Dispatcher,
+    pump_config: PumpConfig,
+    metrics_registry: Arc<harn_vm::MetricsRegistry>,
 ) -> Result<PumpHandle, String> {
     let topic = harn_vm::event_log::Topic::new(harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC)
         .map_err(|error| error.to_string())?;
@@ -923,6 +978,7 @@ fn spawn_inbox_pump(
     let inbox_task_release_file = inbox_task_test_release_file();
     let (mode_tx, mut mode_rx) = watch::channel(PumpMode::Running);
     let join = tokio::task::spawn_local(async move {
+        metrics_registry.set_orchestrator_pump_outstanding(topic.as_str(), 0);
         let start_from = event_log
             .consumer_cursor(&topic, &consumer)
             .await
@@ -940,6 +996,7 @@ fn spawn_inbox_pump(
             last_seen: start_from.unwrap_or(0),
             processed: 0,
         };
+        record_pump_backlog(&metrics_registry, &event_log, &topic, stats.last_seen).await;
         let mut drain_progress = None;
         let mut tasks = JoinSet::new();
 
@@ -984,14 +1041,20 @@ fn spawn_inbox_pump(
                 }
                 joined = tasks.join_next(), if !tasks.is_empty() => {
                     match joined {
-                        Some(Ok(())) => {}
+                        Some(Ok(())) => {
+                            metrics_registry
+                                .set_orchestrator_pump_outstanding(topic.as_str(), tasks.len());
+                        }
                         Some(Err(error)) => {
                             return Err(format!("inbox dispatch task join failed: {error}"));
                         }
                         None => {}
                     }
                 }
-                received = stream.next() => {
+                _ = tokio::time::sleep(Duration::from_millis(25)), if tasks.len() >= pump_config.max_outstanding => {
+                    record_pump_backlog(&metrics_registry, &event_log, &topic, stats.last_seen).await;
+                }
+                received = stream.next(), if tasks.len() < pump_config.max_outstanding => {
                     let Some(received) = received else {
                         break;
                     };
@@ -1003,20 +1066,96 @@ fn spawn_inbox_pump(
                             .ack(&topic, &consumer, event_id)
                             .await
                             .map_err(|error| format!("failed to ack topic pump cursor for {topic}: {error}"))?;
+                        record_pump_backlog(&metrics_registry, &event_log, &topic, stats.last_seen).await;
                         continue;
                     }
+                    append_pump_lifecycle_event(
+                        &event_log,
+                        "pump_received",
+                        json!({
+                            "topic": topic.as_str(),
+                            "event_log_id": event_id,
+                            "outstanding": tasks.len(),
+                            "max_outstanding": pump_config.max_outstanding,
+                        }),
+                    )
+                    .await?;
                     let envelope: harn_vm::triggers::dispatcher::InboxEnvelope =
                         serde_json::from_value(logged.payload)
                             .map_err(|error| format!("failed to decode dispatcher inbox event: {error}"))?;
+                    let trigger_id = envelope.trigger_id.clone();
+                    let binding_version = envelope.binding_version;
+                    let trigger_event_id = envelope.event.id.0.clone();
+                    append_pump_lifecycle_event(
+                        &event_log,
+                        "pump_eligible",
+                        json!({
+                            "topic": topic.as_str(),
+                            "event_log_id": event_id,
+                            "trigger_id": trigger_id.clone(),
+                            "binding_version": binding_version,
+                            "trigger_event_id": trigger_event_id,
+                        }),
+                    )
+                    .await?;
+                    metrics_registry.record_orchestrator_pump_admission_delay(
+                        topic.as_str(),
+                        admission_delay(logged.occurred_at_ms),
+                    );
+                    append_pump_lifecycle_event(
+                        &event_log,
+                        "pump_admitted",
+                        json!({
+                            "topic": topic.as_str(),
+                            "event_log_id": event_id,
+                            "outstanding_after_admit": tasks.len() + 1,
+                            "max_outstanding": pump_config.max_outstanding,
+                            "trigger_id": trigger_id.clone(),
+                            "binding_version": binding_version,
+                            "trigger_event_id": trigger_event_id,
+                        }),
+                    )
+                    .await?;
                     let dispatcher = dispatcher.clone();
+                    let task_event_log = event_log.clone();
+                    let task_topic = topic.as_str().to_string();
                     let inbox_task_release_file = inbox_task_release_file.clone();
                     tasks.spawn_local(async move {
                         if let Some(path) = inbox_task_release_file.as_ref() {
                             wait_for_test_release_file(path).await;
                         }
-                        if let Err(error) = dispatcher.dispatch_inbox_envelope(envelope).await {
-                            eprintln!("[harn] inbox dispatch warning: {error}");
-                        }
+                        let _ = append_pump_lifecycle_event(
+                            &task_event_log,
+                            "pump_dispatch_started",
+                            json!({
+                                "topic": task_topic.clone(),
+                                "event_log_id": event_id,
+                                "trigger_id": trigger_id,
+                                "binding_version": binding_version,
+                                "trigger_event_id": trigger_event_id,
+                            }),
+                        )
+                        .await;
+                        let result = dispatcher.dispatch_inbox_envelope(envelope).await;
+                        let (status, error_message) = match result {
+                            Ok(_) => ("completed", None),
+                            Err(error) => {
+                                let message = error.to_string();
+                                eprintln!("[harn] inbox dispatch warning: {message}");
+                                ("failed", Some(message))
+                            }
+                        };
+                        let _ = append_pump_lifecycle_event(
+                            &task_event_log,
+                            "pump_dispatch_completed",
+                            json!({
+                                "topic": task_topic,
+                                "event_log_id": event_id,
+                                "status": status,
+                                "error": error_message,
+                            }),
+                        )
+                        .await;
                     });
                     stats.last_seen = event_id;
                     stats.processed += 1;
@@ -1024,12 +1163,25 @@ fn spawn_inbox_pump(
                         .ack(&topic, &consumer, event_id)
                         .await
                         .map_err(|error| format!("failed to ack topic pump cursor for {topic}: {error}"))?;
+                    append_pump_lifecycle_event(
+                        &event_log,
+                        "pump_acked",
+                        json!({
+                            "topic": topic.as_str(),
+                            "event_log_id": event_id,
+                            "cursor": event_id,
+                        }),
+                    )
+                    .await?;
+                    metrics_registry.set_orchestrator_pump_outstanding(topic.as_str(), tasks.len());
+                    record_pump_backlog(&metrics_registry, &event_log, &topic, stats.last_seen).await;
                 }
             }
         }
 
         while let Some(joined) = tasks.join_next().await {
             joined.map_err(|error| format!("inbox dispatch task join failed: {error}"))?;
+            metrics_registry.set_orchestrator_pump_outstanding(topic.as_str(), tasks.len());
         }
 
         Ok(drain_progress
@@ -1056,35 +1208,51 @@ fn spawn_inbox_pump(
 fn spawn_waitpoint_resume_pump(
     event_log: Arc<harn_vm::event_log::AnyEventLog>,
     dispatcher: harn_vm::Dispatcher,
+    pump_config: PumpConfig,
+    metrics_registry: Arc<harn_vm::MetricsRegistry>,
 ) -> Result<PumpHandle, String> {
     let topic = harn_vm::event_log::Topic::new(harn_vm::WAITPOINT_RESUME_TOPIC)
         .map_err(|error| error.to_string())?;
-    spawn_topic_pump(event_log, topic, move |logged| {
-        let dispatcher = dispatcher.clone();
-        async move { harn_vm::process_waitpoint_resume_event(&dispatcher, logged).await }
-    })
+    spawn_topic_pump(
+        event_log,
+        topic,
+        pump_config,
+        metrics_registry,
+        move |logged| {
+            let dispatcher = dispatcher.clone();
+            async move { harn_vm::process_waitpoint_resume_event(&dispatcher, logged).await }
+        },
+    )
 }
 
 fn spawn_waitpoint_cancel_pump(
     event_log: Arc<harn_vm::event_log::AnyEventLog>,
     dispatcher: harn_vm::Dispatcher,
+    pump_config: PumpConfig,
+    metrics_registry: Arc<harn_vm::MetricsRegistry>,
 ) -> Result<PumpHandle, String> {
     let topic = harn_vm::event_log::Topic::new(harn_vm::TRIGGER_CANCEL_REQUESTS_TOPIC)
         .map_err(|error| error.to_string())?;
-    spawn_topic_pump(event_log, topic, move |logged| {
-        let dispatcher = dispatcher.clone();
-        async move {
-            if logged.kind != "dispatch_cancel_requested" {
-                return Ok(false);
+    spawn_topic_pump(
+        event_log,
+        topic,
+        pump_config,
+        metrics_registry,
+        move |logged| {
+            let dispatcher = dispatcher.clone();
+            async move {
+                if logged.kind != "dispatch_cancel_requested" {
+                    return Ok(false);
+                }
+                harn_vm::service_waitpoints_once(&dispatcher, None)
+                    .await
+                    .map_err(|error| {
+                        format!("failed to service waitpoints after cancel request: {error}")
+                    })?;
+                Ok(true)
             }
-            harn_vm::service_waitpoints_once(&dispatcher, None)
-                .await
-                .map_err(|error| {
-                    format!("failed to service waitpoints after cancel request: {error}")
-                })?;
-            Ok(true)
-        }
-    })
+        },
+    )
 }
 
 fn spawn_waitpoint_sweeper(dispatcher: harn_vm::Dispatcher) -> WaitpointSweepHandle {
@@ -1114,6 +1282,8 @@ fn spawn_waitpoint_sweeper(dispatcher: harn_vm::Dispatcher) -> WaitpointSweepHan
 fn spawn_topic_pump<F, Fut>(
     event_log: Arc<harn_vm::event_log::AnyEventLog>,
     topic: harn_vm::event_log::Topic,
+    _pump_config: PumpConfig,
+    metrics_registry: Arc<harn_vm::MetricsRegistry>,
     process: F,
 ) -> Result<PumpHandle, String>
 where
@@ -1125,6 +1295,7 @@ where
     let test_waiting_file = pump_test_waiting_file();
     let (mode_tx, mut mode_rx) = watch::channel(PumpMode::Running);
     let join = tokio::task::spawn_local(async move {
+        metrics_registry.set_orchestrator_pump_outstanding(topic.as_str(), 0);
         let start_from = event_log
             .consumer_cursor(&topic, &consumer)
             .await
@@ -1142,6 +1313,7 @@ where
             last_seen: start_from.unwrap_or(0),
             processed: 0,
         };
+        record_pump_backlog(&metrics_registry, &event_log, &topic, stats.last_seen).await;
         let mut drain_progress = None;
         loop {
             if let Some(progress) = drain_progress {
@@ -1186,6 +1358,11 @@ where
                     };
                     let (event_id, logged) = received
                         .map_err(|error| format!("topic pump read failed for {topic}: {error}"))?;
+                    metrics_registry.set_orchestrator_pump_outstanding(topic.as_str(), 1);
+                    metrics_registry.record_orchestrator_pump_admission_delay(
+                        topic.as_str(),
+                        admission_delay(logged.occurred_at_ms),
+                    );
                     if let Some(path) = test_release_file.as_ref() {
                         if let Some(waiting_path) = test_waiting_file.as_ref() {
                             mark_test_file(waiting_path).await?;
@@ -1201,6 +1378,8 @@ where
                         .ack(&topic, &consumer, event_id)
                         .await
                         .map_err(|error| format!("failed to ack topic pump cursor for {topic}: {error}"))?;
+                    metrics_registry.set_orchestrator_pump_outstanding(topic.as_str(), 0);
+                    record_pump_backlog(&metrics_registry, &event_log, &topic, stats.last_seen).await;
                 }
             }
         }
@@ -1454,6 +1633,32 @@ async fn append_lifecycle_event(
         .map_err(|error| format!("failed to append orchestrator lifecycle event: {error}"))
 }
 
+async fn append_pump_lifecycle_event(
+    log: &Arc<harn_vm::event_log::AnyEventLog>,
+    kind: &str,
+    payload: JsonValue,
+) -> Result<(), String> {
+    append_lifecycle_event(log, kind, payload).await
+}
+
+async fn record_pump_backlog(
+    metrics: &harn_vm::MetricsRegistry,
+    log: &Arc<harn_vm::event_log::AnyEventLog>,
+    topic: &harn_vm::event_log::Topic,
+    last_seen: u64,
+) {
+    let latest = log.latest(topic).await.ok().flatten().unwrap_or(last_seen);
+    metrics.set_orchestrator_pump_backlog(topic.as_str(), latest.saturating_sub(last_seen));
+}
+
+fn admission_delay(occurred_at_ms: i64) -> Duration {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+    Duration::from_millis(now.saturating_sub(occurred_at_ms).max(0) as u64)
+}
+
 async fn append_manifest_event(
     log: &Arc<harn_vm::event_log::AnyEventLog>,
     kind: &str,
@@ -1599,6 +1804,18 @@ fn maybe_finish_pump_drain(
             outstanding_tasks,
             PumpDrainStopReason::Drained,
         ));
+    }
+    if outstanding_tasks > 0 {
+        if tokio::time::Instant::now() >= progress.request.deadline {
+            return Some(pump_drain_report(
+                stats,
+                progress.start_seen,
+                progress.request.up_to,
+                outstanding_tasks,
+                PumpDrainStopReason::Deadline,
+            ));
+        }
+        return None;
     }
     let drain_items = stats.last_seen.saturating_sub(progress.start_seen);
     if drain_items >= progress.request.config.max_items as u64 {

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -96,6 +96,8 @@ pub struct OrchestratorConfig {
     pub budget: OrchestratorBudgetSpec,
     #[serde(default)]
     pub drain: OrchestratorDrainConfig,
+    #[serde(default)]
+    pub pumps: OrchestratorPumpConfig,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -132,6 +134,27 @@ fn default_orchestrator_drain_max_items() -> usize {
 
 fn default_orchestrator_drain_deadline_seconds() -> u64 {
     30
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OrchestratorPumpConfig {
+    #[serde(
+        default = "default_orchestrator_pump_max_outstanding",
+        alias = "max-outstanding"
+    )]
+    pub max_outstanding: usize,
+}
+
+impl Default for OrchestratorPumpConfig {
+    fn default() -> Self {
+        Self {
+            max_outstanding: default_orchestrator_pump_max_outstanding(),
+        }
+    }
+}
+
+fn default_orchestrator_pump_max_outstanding() -> usize {
+    64
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -4400,6 +4423,7 @@ name = "fixture"
         .unwrap();
         assert_eq!(default_manifest.orchestrator.drain.max_items, 1024);
         assert_eq!(default_manifest.orchestrator.drain.deadline_seconds, 30);
+        assert_eq!(default_manifest.orchestrator.pumps.max_outstanding, 64);
 
         let configured: Manifest = toml::from_str(
             r#"
@@ -4409,11 +4433,13 @@ name = "fixture"
 [orchestrator]
 drain.max_items = 77
 drain.deadline_seconds = 12
+pumps.max_outstanding = 3
 "#,
         )
         .unwrap();
         assert_eq!(configured.orchestrator.drain.max_items, 77);
         assert_eq!(configured.orchestrator.drain.deadline_seconds, 12);
+        assert_eq!(configured.orchestrator.pumps.max_outstanding, 3);
     }
 
     #[test]

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -216,6 +216,30 @@ fn bearer_headers() -> HeaderMap {
     headers
 }
 
+async fn wait_for_metrics_contains(
+    client: &reqwest::Client,
+    base_url: &str,
+    needles: &[&str],
+) -> String {
+    let deadline = Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
+    let mut last = String::new();
+    while Instant::now() < deadline {
+        last = client
+            .get(format!("{base_url}/metrics"))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        if needles.iter().all(|needle| last.contains(needle)) {
+            return last;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("timed out waiting for metrics samples {needles:?}; last={last}");
+}
+
 fn run_harn_with_env(temp: &TempDir, args: &[&str], envs: &[(&str, &str)]) -> Output {
     let mut command = Command::new(env!("CARGO_BIN_EXE_harn"));
     command.current_dir(temp.path()).args(args);
@@ -367,6 +391,21 @@ fn wait_for_topic_event(state_dir: &Path, topic_name: &str, predicate: impl Fn(&
         thread::sleep(Duration::from_millis(25));
     }
     panic!("timed out waiting for matching {topic_name} event");
+}
+
+fn wait_for_topic_event_count(state_dir: &Path, topic_name: &str, kind: &str, expected: usize) {
+    let deadline = Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
+    while Instant::now() < deadline {
+        let count = read_topic_events(state_dir, topic_name)
+            .iter()
+            .filter(|(_, event)| event.kind == kind)
+            .count();
+        if count >= expected {
+            return;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    panic!("timed out waiting for {topic_name}/{kind} count {expected}");
 }
 
 fn sqlite_event_count(state_dir: &Path, topic_name: &str, kind: &str) -> usize {
@@ -732,6 +771,148 @@ pub fn on_task(event: TriggerEvent) -> string {
         snapshot_contents.contains("\"in_flight\": 0"),
         "snapshot={snapshot_contents}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn inbox_pump_backpressures_before_ack_when_outstanding_limit_is_full() {
+    let _lock = support::lock_orchestrator_process_tests();
+    let temp = TempDir::new().unwrap();
+    let inbox_release_file = temp.path().join("release-inbox-dispatch");
+    let inbox_release_value = inbox_release_file.to_string_lossy().into_owned();
+    write_file(
+        temp.path(),
+        "harn.toml",
+        r#"
+[package]
+name = "fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[triggers]]
+id = "incoming-review-task"
+kind = "a2a-push"
+provider = "a2a-push"
+path = "/a2a/review"
+match = { events = ["a2a.task.received"] }
+handler = "handlers::on_task"
+"#,
+    );
+    write_file(
+        temp.path(),
+        "lib.harn",
+        r#"
+import "std/triggers"
+
+pub fn on_task(event: TriggerEvent) -> string {
+  return event.kind
+}
+"#,
+    );
+
+    let envs = [
+        ("HARN_EVENT_LOG_BACKEND", "file"),
+        ("HARN_ORCHESTRATOR_API_KEYS", "test-key"),
+        ("HARN_ORCHESTRATOR_HMAC_SECRET", "unused-shared-secret"),
+        (
+            "HARN_TEST_ORCHESTRATOR_INBOX_TASK_RELEASE_FILE",
+            inbox_release_value.as_str(),
+        ),
+    ];
+    let extra_args = ["--shutdown-timeout", "5", "--pump-max-outstanding", "1"];
+    let (mut child, rx, handle) = spawn_orchestrator_with(&temp, &extra_args, &envs);
+    let base_url = wait_for_listener_url(&mut child, &rx);
+    let state_dir = temp.path().join("state");
+    let client = reqwest::Client::new();
+
+    for id in ["task-478-a", "task-478-b"] {
+        let body = serde_json::json!({
+            "kind": "a2a.task.received",
+            "task": {"id": id},
+        });
+        let response = client
+            .post(format!("{base_url}/a2a/review"))
+            .headers(bearer_headers())
+            .body(body.to_string())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+    }
+
+    wait_for_consumer_cursor(
+        &state_dir,
+        harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC,
+        &format!(
+            "orchestrator-pump.{}",
+            harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC
+        ),
+        1,
+    )
+    .await;
+    wait_for_topic_event(&state_dir, "orchestrator.lifecycle", |event| {
+        event.kind == "pump_admitted" && event.payload["event_log_id"] == serde_json::json!(1)
+    });
+    wait_for_topic_event_count(
+        &state_dir,
+        harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC,
+        "event_ingested",
+        2,
+    );
+
+    let log = open_state_event_log(&state_dir);
+    let topic = Topic::new(harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC).unwrap();
+    let consumer = ConsumerId::new(format!(
+        "orchestrator-pump.{}",
+        harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC
+    ))
+    .unwrap();
+    let cursor = log.consumer_cursor(&topic, &consumer).await.unwrap();
+    assert_eq!(
+        cursor,
+        Some(1),
+        "second inbox event was acked before admission"
+    );
+
+    let _metrics = wait_for_metrics_contains(
+        &client,
+        &base_url,
+        &[
+            "harn_orchestrator_pump_outstanding{topic=\"trigger.inbox.envelopes\"} 1",
+            "harn_orchestrator_pump_backlog{topic=\"trigger.inbox.envelopes\"} 1",
+        ],
+    )
+    .await;
+
+    send_sigterm(&child);
+    fs::write(&inbox_release_file, b"release").unwrap();
+    wait_for_exit(&mut child);
+    let stderr = handle.join().expect("stderr collector thread");
+    assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
+
+    let outbox = read_topic_events(&state_dir, "trigger.outbox");
+    assert_eq!(
+        outbox
+            .iter()
+            .filter(|(_, event)| event.kind == "dispatch_succeeded")
+            .count(),
+        2,
+        "outbox={outbox:?}"
+    );
+    let lifecycle = read_topic_events(&state_dir, "orchestrator.lifecycle");
+    for kind in [
+        "pump_received",
+        "pump_eligible",
+        "pump_admitted",
+        "pump_dispatch_started",
+        "pump_dispatch_completed",
+        "pump_acked",
+    ] {
+        assert!(
+            lifecycle.iter().any(|(_, event)| event.kind == kind),
+            "missing {kind}: lifecycle={lifecycle:?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -604,6 +604,31 @@ impl MetricsRegistry {
         );
     }
 
+    pub fn set_orchestrator_pump_backlog(&self, topic: &str, count: u64) {
+        self.set_gauge(
+            "harn_orchestrator_pump_backlog",
+            labels([("topic", topic)]),
+            count as f64,
+        );
+    }
+
+    pub fn set_orchestrator_pump_outstanding(&self, topic: &str, count: usize) {
+        self.set_gauge(
+            "harn_orchestrator_pump_outstanding",
+            labels([("topic", topic)]),
+            count as f64,
+        );
+    }
+
+    pub fn record_orchestrator_pump_admission_delay(&self, topic: &str, duration: StdDuration) {
+        self.observe_histogram(
+            "harn_orchestrator_pump_admission_delay_seconds",
+            labels([("topic", topic)]),
+            duration.as_secs_f64(),
+            &Self::DURATION_BUCKETS,
+        );
+    }
+
     pub fn record_llm_call(&self, provider: &str, model: &str, outcome: &str, cost_usd: f64) {
         self.increment_counter(
             "harn_llm_calls_total",
@@ -845,6 +870,8 @@ fn metric_family_names(kind: MetricKind) -> &'static [&'static str] {
             "harn_event_log_consumer_lag",
             "harn_trigger_budget_cost_today_usd",
             "harn_worker_queue_depth",
+            "harn_orchestrator_pump_backlog",
+            "harn_orchestrator_pump_outstanding",
         ],
         MetricKind::Histogram => &[
             "harn_http_request_duration_seconds",
@@ -853,6 +880,7 @@ fn metric_family_names(kind: MetricKind) -> &'static [&'static str] {
             "harn_event_log_append_duration_seconds",
             "harn_a2a_hop_duration_seconds",
             "harn_worker_queue_claim_age_seconds",
+            "harn_orchestrator_pump_admission_delay_seconds",
         ],
     }
 }
@@ -1628,6 +1656,12 @@ mod tests {
         metrics.record_a2a_hop("agent.example", "succeeded", StdDuration::from_millis(10));
         metrics.set_worker_queue_depth("triage", 1);
         metrics.record_worker_queue_claim_age("triage", 3.0);
+        metrics.set_orchestrator_pump_backlog("trigger.inbox.envelopes", 2);
+        metrics.set_orchestrator_pump_outstanding("trigger.inbox.envelopes", 1);
+        metrics.record_orchestrator_pump_admission_delay(
+            "trigger.inbox.envelopes",
+            StdDuration::from_millis(50),
+        );
         metrics.record_llm_call("mock", "mock", "succeeded", 0.01);
         metrics.record_llm_cache_hit("mock");
 
@@ -1653,6 +1687,9 @@ mod tests {
             "harn_a2a_hop_duration_seconds_bucket{le=\"0.01\",target=\"agent.example\"} 1",
             "harn_worker_queue_depth{queue=\"triage\"} 1",
             "harn_worker_queue_claim_age_seconds_bucket{le=\"5\",queue=\"triage\"} 1",
+            "harn_orchestrator_pump_backlog{topic=\"trigger.inbox.envelopes\"} 2",
+            "harn_orchestrator_pump_outstanding{topic=\"trigger.inbox.envelopes\"} 1",
+            "harn_orchestrator_pump_admission_delay_seconds_bucket{le=\"0.05\",topic=\"trigger.inbox.envelopes\"} 1",
             "harn_llm_calls_total{model=\"mock\",outcome=\"succeeded\",provider=\"mock\"} 1",
             "harn_llm_cost_usd_total{model=\"mock\",provider=\"mock\"} 0.01",
             "harn_llm_cache_hits_total{provider=\"mock\"} 1",

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -553,6 +553,7 @@ harn orchestrator serve \
   --config harn.toml \
   --state-dir .harn/orchestrator \
   --bind 0.0.0.0:8080 \
+  --pump-max-outstanding 64 \
   --log-format json \
   --role single-tenant
 

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -29,6 +29,7 @@ harn orchestrator serve \
   --bind 0.0.0.0:8080 \
   --cert certs/dev.pem \
   --key certs/dev-key.pem \
+  --pump-max-outstanding 64 \
   --log-format json \
   --role single-tenant
 ```
@@ -41,6 +42,20 @@ triggers, registered connectors, and the actual bound listener URL. On
 SIGTERM, it stops accepting new requests, lets in-flight requests drain,
 appends lifecycle events to the EventLog, and persists a final
 `orchestrator-state.json` snapshot under `--state-dir`.
+
+Topic pumps are bounded. `--pump-max-outstanding` controls how many
+items each pump may admit at once; the same value can be configured in
+`harn.toml` as:
+
+```toml
+[orchestrator]
+pumps.max_outstanding = 64
+```
+
+When the inbox pump reaches that limit, it stops reading more
+`trigger.inbox.envelopes` records until an admitted dispatch finishes.
+The source cursor is advanced only after a record is admitted, and
+shutdown waits for admitted work before reporting a truncated drain.
 
 Startup no longer replays old `trigger.inbox` entries automatically.
 If the previous process died after writing an inbox envelope but before

--- a/docs/src/triggers/dispatcher.md
+++ b/docs/src/triggers/dispatcher.md
@@ -131,6 +131,14 @@ Harn v0.7.23 also soft-reads the legacy mixed `trigger.inbox` topic on
 startup so older event logs keep working while new writes go only to the
 split topics.
 
+The long-running orchestrator inbox pump admits a bounded number of
+outstanding dispatch tasks. A full pump stops reading new inbox envelopes
+and leaves their source cursor unacked until capacity is available. Pump
+state is visible through `orchestrator.lifecycle` events such as
+`pump_received`, `pump_eligible`, `pump_admitted`, `pump_dispatch_started`,
+`pump_dispatch_completed`, and `pump_acked`, plus Prometheus metrics for
+backlog, outstanding count, and admission delay.
+
 Flow-control topics record per-gate admission decisions and waits. For example,
 `concurrency = { key = "event.headers.tenant", max = 2 }` writes records under
 `trigger.concurrency.<binding-and-gate>`, while `debounce` and `batch` emit the


### PR DESCRIPTION
## Summary
- add configurable orchestrator pump outstanding limits via `--pump-max-outstanding` and `[orchestrator] pumps.max_outstanding`
- bound the inbox pump so it stops reading and acking event-log work while admitted dispatch tasks are at capacity
- add pump lifecycle events plus backlog, outstanding, and admission-delay Prometheus metrics

Fixes #478

## Validation
- `cargo check -p harn-cli`
- `cargo fmt --check`
- `cargo test -p harn-vm metrics_registry_exports_orchestrator_metric_families`
- `cargo test -p harn-cli test_parses_orchestrator_serve_args`
- `cargo test -p harn-cli orchestrator_drain_config_parses_defaults_and_overrides`
- `cargo test -p harn-cli --test orchestrator_cli inbox_pump_backpressures_before_ack_when_outstanding_limit_is_full -- --nocapture`
- `cargo test -p harn-cli --test orchestrator_cli graceful_shutdown_waits_for_spawned_inbox_dispatch_tasks -- --nocapture`
- pre-push hook: workspace nextest, Harn formatting, markdownlint, actionlint, portal lint
