### PR TITLE
[codex] Add trigger lifecycle latency metrics

### DIFF
--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -556,6 +556,7 @@ async fn ingest_trigger(
         context.metrics.in_flight.load(Ordering::Relaxed),
     );
     let request_started = Instant::now();
+    let accepted_at_ms = current_unix_ms();
     let body_size_bytes = body.len();
 
     let trace_id = harn_vm::TraceId::new();
@@ -634,9 +635,21 @@ async fn ingest_trigger(
             trace_id,
         )
         .await;
+        let ingress_timing = IngressLifecycleTiming {
+            accepted_at_ms,
+            normalized_at_ms: current_unix_ms(),
+            accepted_to_normalized: request_started.elapsed(),
+        };
         let response = match result {
             Ok(NormalizedRequest::Events(events)) => {
-                match enqueue_normalized_events(&context, events, &span_context_headers).await {
+                match enqueue_normalized_events(
+                    &context,
+                    events,
+                    &span_context_headers,
+                    ingress_timing,
+                )
+                .await
+                {
                     Ok(summary) => {
                         context
                             .metrics
@@ -661,7 +674,14 @@ async fn ingest_trigger(
                 }
             }
             Ok(NormalizedRequest::Immediate { response, events }) => {
-                match enqueue_normalized_events(&context, events, &span_context_headers).await {
+                match enqueue_normalized_events(
+                    &context,
+                    events,
+                    &span_context_headers,
+                    ingress_timing,
+                )
+                .await
+                {
                     Ok(summary) => {
                         context.metrics.dispatched.fetch_add(
                             std::cmp::max(summary.accepted, 1) as u64,
@@ -914,6 +934,13 @@ struct EnqueueSummary {
     first_event_id: Option<String>,
 }
 
+#[derive(Clone, Copy)]
+struct IngressLifecycleTiming {
+    accepted_at_ms: i64,
+    normalized_at_ms: i64,
+    accepted_to_normalized: Duration,
+}
+
 fn connector_normalize_result_to_request(
     result: harn_vm::ConnectorNormalizeResult,
     trace_id: harn_vm::TraceId,
@@ -1026,6 +1053,7 @@ async fn enqueue_normalized_events(
     context: &RouteContext,
     events: Vec<harn_vm::TriggerEvent>,
     span_context_headers: &BTreeMap<String, String>,
+    timing: IngressLifecycleTiming,
 ) -> Result<EnqueueSummary, HttpError> {
     let mut summary = EnqueueSummary {
         accepted: 0,
@@ -1034,6 +1062,18 @@ async fn enqueue_normalized_events(
     };
 
     for event in events {
+        let binding_key =
+            listener_binding_key(&context.route.trigger_id, context.route.binding_version);
+        context
+            .metrics_registry
+            .record_trigger_accepted_to_normalized(
+                &context.route.trigger_id,
+                &binding_key,
+                event.provider.as_str(),
+                event.tenant_id.as_ref().map(|tenant| tenant.0.as_str()),
+                "normalized",
+                timing.accepted_to_normalized,
+            );
         let postprocess = harn_vm::postprocess_normalized_event(
             context.inbox.as_ref(),
             &context.route.trigger_id,
@@ -1057,19 +1097,54 @@ async fn enqueue_normalized_events(
                     "binding_version": context.route.binding_version,
                     "event": event,
                 });
+                let queue_span = tracing::info_span!(
+                    "queue_append",
+                    trigger_id = %context.route.trigger_id,
+                    binding_version = context.route.binding_version,
+                    event_id = %event.id.0,
+                    trace_id = %event.trace_id.0
+                );
+                let _ = harn_vm::observability::otel::set_span_parent_from_headers(
+                    &queue_span,
+                    span_context_headers,
+                    &event.trace_id,
+                    None,
+                );
                 let mut pending_headers = BTreeMap::new();
                 pending_headers.insert("trace_id".to_string(), event.trace_id.0.clone());
-                pending_headers.extend(span_context_headers.clone());
+                pending_headers.insert(
+                    harn_vm::triggers::dispatcher::TRIGGER_ACCEPTED_AT_MS_HEADER.to_string(),
+                    timing.accepted_at_ms.to_string(),
+                );
+                pending_headers.insert(
+                    harn_vm::triggers::dispatcher::TRIGGER_NORMALIZED_AT_MS_HEADER.to_string(),
+                    timing.normalized_at_ms.to_string(),
+                );
+                pending_headers.insert("trigger_id".to_string(), context.route.trigger_id.clone());
+                pending_headers.insert("binding_key".to_string(), binding_key.clone());
+                pending_headers.insert("provider".to_string(), event.provider.as_str().to_string());
+                if let Some(tenant_id) = event.tenant_id.as_ref() {
+                    pending_headers.insert("tenant_id".to_string(), tenant_id.0.clone());
+                }
+                let _ = harn_vm::observability::otel::inject_current_context_headers(
+                    &queue_span,
+                    &mut pending_headers,
+                );
                 let append_started = Instant::now();
                 let payload_size_bytes = serde_json::to_vec(&payload)
                     .map(|bytes| bytes.len())
                     .unwrap_or(0);
+                let mut log_event = LogEvent::new("trigger_event", payload);
+                let queue_appended_at_ms = log_event.occurred_at_ms;
+                pending_headers.insert(
+                    harn_vm::triggers::dispatcher::TRIGGER_QUEUE_APPENDED_AT_MS_HEADER.to_string(),
+                    queue_appended_at_ms.to_string(),
+                );
+                log_event.headers = pending_headers;
                 let event_id = context
                     .event_log
-                    .append(
-                        &context.pending_topic,
-                        LogEvent::new("trigger_event", payload).with_headers(pending_headers),
-                    )
+                    .append(&context.pending_topic, log_event)
+                    .instrument(queue_span)
                     .await
                     .map_err(|error| {
                         HttpError::internal(format!(
@@ -1080,6 +1155,25 @@ async fn enqueue_normalized_events(
                     context.pending_topic.as_str(),
                     append_started.elapsed(),
                     payload_size_bytes,
+                );
+                context
+                    .metrics_registry
+                    .record_trigger_accepted_to_queue_append(
+                        &context.route.trigger_id,
+                        &binding_key,
+                        event.provider.as_str(),
+                        event.tenant_id.as_ref().map(|tenant| tenant.0.as_str()),
+                        "queued",
+                        duration_between_ms(queue_appended_at_ms, timing.accepted_at_ms),
+                    );
+                context.metrics_registry.note_trigger_pending_event(
+                    event.id.0.as_str(),
+                    &context.route.trigger_id,
+                    &binding_key,
+                    event.provider.as_str(),
+                    event.tenant_id.as_ref().map(|tenant| tenant.0.as_str()),
+                    timing.accepted_at_ms,
+                    queue_appended_at_ms,
                 );
                 tracing::info!(
                     component = "listener",
@@ -1599,6 +1693,22 @@ async fn mark_test_file(path: &Path) -> Result<(), String> {
     tokio::fs::write(path, b"1")
         .await
         .map_err(|error| format!("failed to write {}: {error}", path.display()))
+}
+
+fn listener_binding_key(trigger_id: &str, binding_version: u32) -> String {
+    format!("{trigger_id}@v{binding_version}")
+}
+
+fn current_unix_ms() -> i64 {
+    unix_ms(OffsetDateTime::now_utc())
+}
+
+fn unix_ms(timestamp: OffsetDateTime) -> i64 {
+    (timestamp.unix_timestamp_nanos() / 1_000_000) as i64
+}
+
+fn duration_between_ms(later_ms: i64, earlier_ms: i64) -> Duration {
+    Duration::from_millis(later_ms.saturating_sub(earlier_ms).max(0) as u64)
 }
 
 #[cfg(test)]

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -916,10 +916,11 @@ fn spawn_pending_pump(
                 let record: PendingTriggerRecord = serde_json::from_value(logged.payload)
                     .map_err(|error| format!("failed to decode pending trigger event: {error}"))?;
                 dispatcher
-                    .enqueue_targeted(
+                    .enqueue_targeted_with_headers(
                         Some(record.trigger_id),
                         Some(record.binding_version),
                         record.event,
+                        Some(&logged.headers),
                     )
                     .await
                     .map_err(|error| format!("failed to enqueue pending trigger event: {error}"))?;
@@ -957,7 +958,7 @@ fn spawn_cron_pump(
                     _ => None,
                 };
                 dispatcher
-                    .enqueue_targeted(trigger_id, None, event)
+                    .enqueue_targeted_with_headers(trigger_id, None, event, Some(&logged.headers))
                     .await
                     .map_err(|error| format!("failed to enqueue cron trigger event: {error}"))?;
                 Ok(true)
@@ -1086,6 +1087,7 @@ fn spawn_inbox_pump(
                     let trigger_id = envelope.trigger_id.clone();
                     let binding_version = envelope.binding_version;
                     let trigger_event_id = envelope.event.id.0.clone();
+                    let parent_headers = logged.headers.clone();
                     append_pump_lifecycle_event(
                         &event_log,
                         "pump_eligible",
@@ -1136,7 +1138,12 @@ fn spawn_inbox_pump(
                             }),
                         )
                         .await;
-                        let result = dispatcher.dispatch_inbox_envelope(envelope).await;
+                        let result = dispatcher
+                            .dispatch_inbox_envelope_with_parent_headers(
+                                envelope,
+                                &parent_headers,
+                            )
+                            .await;
                         let (status, error_message) = match result {
                             Ok(_) => ("completed", None),
                             Err(error) => {

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -1951,9 +1951,9 @@ async fn json_log_format_writes_structured_rotating_file_with_trace_ids() {
     );
 }
 
-// Regression coverage for harn#327: ingest should inject W3C trace-context
-// headers, and dispatch should adopt that remote parent so both spans share a
-// trace ID with `dispatch.parent_span_id == ingest.span_id`.
+// Regression coverage for harn#327 and harn#479: ingest should inject W3C
+// trace-context headers, queue append should preserve the trace, and dispatch
+// should adopt the queue append span as its remote parent.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
     let _lock = lock_orchestrator_tests();
@@ -1998,8 +1998,9 @@ async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
     let spans = loop {
         let spans = collector.collected_spans();
         let has_ingest = spans.iter().any(|span| span.name == "ingest");
+        let has_queue_append = spans.iter().any(|span| span.name == "queue_append");
         let has_dispatch = spans.iter().any(|span| span.name == "dispatch");
-        if has_ingest && has_dispatch {
+        if has_ingest && has_queue_append && has_dispatch {
             break spans;
         }
         if Instant::now() >= deadline {
@@ -2016,12 +2017,19 @@ async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
     };
 
     let ingest = spans.iter().find(|span| span.name == "ingest").unwrap();
+    let queue_append = spans
+        .iter()
+        .find(|span| span.name == "queue_append")
+        .unwrap();
     let dispatch = spans.iter().find(|span| span.name == "dispatch").unwrap();
+    assert_eq!(ingest.trace_id, queue_append.trace_id);
     assert_eq!(ingest.trace_id, dispatch.trace_id);
+    assert_ne!(ingest.span_id, queue_append.span_id);
     assert_ne!(ingest.span_id, dispatch.span_id);
+    assert!(queue_append.parent_span_id.is_some());
     assert_eq!(
         dispatch.parent_span_id.as_deref(),
-        ingest.parent_span_id.as_deref()
+        Some(queue_append.span_id.as_str())
     );
 
     let ingest_trace_id = attribute_string(ingest, "trace_id").unwrap();

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -383,10 +383,14 @@ pub struct MetricsRegistry {
     counters: Mutex<BTreeMap<(String, MetricLabels), f64>>,
     gauges: Mutex<BTreeMap<(String, MetricLabels), f64>>,
     histograms: Mutex<BTreeMap<(String, MetricLabels), HistogramMetric>>,
+    pending_trigger_events: Mutex<BTreeMap<MetricLabels, BTreeMap<String, i64>>>,
 }
 
 impl MetricsRegistry {
     const DURATION_BUCKETS: [f64; 9] = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 5.0];
+    const TRIGGER_LATENCY_BUCKETS: [f64; 15] = [
+        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+    ];
     const SIZE_BUCKETS: [f64; 9] = [
         128.0, 512.0, 1024.0, 4096.0, 16384.0, 65536.0, 262144.0, 1048576.0, 10485760.0,
     ];
@@ -575,6 +579,174 @@ impl MetricsRegistry {
             labels([("trigger_id", trigger_id), ("reason", reason)]),
             1,
         );
+    }
+
+    pub fn record_trigger_accepted_to_normalized(
+        &self,
+        trigger_id: &str,
+        binding_key: &str,
+        provider: &str,
+        tenant_id: Option<&str>,
+        status: &str,
+        duration: StdDuration,
+    ) {
+        self.observe_histogram(
+            "harn_trigger_webhook_accepted_to_normalized_seconds",
+            trigger_lifecycle_labels(trigger_id, binding_key, provider, tenant_id, status),
+            duration.as_secs_f64(),
+            &Self::TRIGGER_LATENCY_BUCKETS,
+        );
+    }
+
+    pub fn record_trigger_accepted_to_queue_append(
+        &self,
+        trigger_id: &str,
+        binding_key: &str,
+        provider: &str,
+        tenant_id: Option<&str>,
+        status: &str,
+        duration: StdDuration,
+    ) {
+        self.observe_histogram(
+            "harn_trigger_webhook_accepted_to_queue_append_seconds",
+            trigger_lifecycle_labels(trigger_id, binding_key, provider, tenant_id, status),
+            duration.as_secs_f64(),
+            &Self::TRIGGER_LATENCY_BUCKETS,
+        );
+    }
+
+    pub fn record_trigger_queue_age_at_dispatch_admission(
+        &self,
+        trigger_id: &str,
+        binding_key: &str,
+        provider: &str,
+        tenant_id: Option<&str>,
+        status: &str,
+        age: StdDuration,
+    ) {
+        self.observe_histogram(
+            "harn_trigger_queue_age_at_dispatch_admission_seconds",
+            trigger_lifecycle_labels(trigger_id, binding_key, provider, tenant_id, status),
+            age.as_secs_f64(),
+            &Self::TRIGGER_LATENCY_BUCKETS,
+        );
+    }
+
+    pub fn record_trigger_queue_age_at_dispatch_start(
+        &self,
+        trigger_id: &str,
+        binding_key: &str,
+        provider: &str,
+        tenant_id: Option<&str>,
+        status: &str,
+        age: StdDuration,
+    ) {
+        self.observe_histogram(
+            "harn_trigger_queue_age_at_dispatch_start_seconds",
+            trigger_lifecycle_labels(trigger_id, binding_key, provider, tenant_id, status),
+            age.as_secs_f64(),
+            &Self::TRIGGER_LATENCY_BUCKETS,
+        );
+    }
+
+    pub fn record_trigger_dispatch_runtime(
+        &self,
+        trigger_id: &str,
+        binding_key: &str,
+        provider: &str,
+        tenant_id: Option<&str>,
+        status: &str,
+        duration: StdDuration,
+    ) {
+        self.observe_histogram(
+            "harn_trigger_dispatch_runtime_seconds",
+            trigger_lifecycle_labels(trigger_id, binding_key, provider, tenant_id, status),
+            duration.as_secs_f64(),
+            &Self::TRIGGER_LATENCY_BUCKETS,
+        );
+    }
+
+    pub fn record_trigger_retry_delay(
+        &self,
+        trigger_id: &str,
+        binding_key: &str,
+        provider: &str,
+        tenant_id: Option<&str>,
+        status: &str,
+        duration: StdDuration,
+    ) {
+        self.observe_histogram(
+            "harn_trigger_retry_delay_seconds",
+            trigger_lifecycle_labels(trigger_id, binding_key, provider, tenant_id, status),
+            duration.as_secs_f64(),
+            &Self::TRIGGER_LATENCY_BUCKETS,
+        );
+    }
+
+    pub fn record_trigger_accepted_to_dlq(
+        &self,
+        trigger_id: &str,
+        binding_key: &str,
+        provider: &str,
+        tenant_id: Option<&str>,
+        status: &str,
+        duration: StdDuration,
+    ) {
+        self.observe_histogram(
+            "harn_trigger_accepted_to_dlq_seconds",
+            trigger_lifecycle_labels(trigger_id, binding_key, provider, tenant_id, status),
+            duration.as_secs_f64(),
+            &Self::TRIGGER_LATENCY_BUCKETS,
+        );
+    }
+
+    pub fn note_trigger_pending_event(
+        &self,
+        event_id: &str,
+        trigger_id: &str,
+        binding_key: &str,
+        provider: &str,
+        tenant_id: Option<&str>,
+        accepted_at_ms: i64,
+        now_ms: i64,
+    ) {
+        let labels = trigger_pending_labels(trigger_id, binding_key, provider, tenant_id);
+        {
+            let mut pending = self
+                .pending_trigger_events
+                .lock()
+                .expect("pending trigger events poisoned");
+            pending
+                .entry(labels.clone())
+                .or_default()
+                .insert(event_id.to_string(), accepted_at_ms);
+        }
+        self.refresh_oldest_pending_gauge(labels, now_ms);
+    }
+
+    pub fn clear_trigger_pending_event(
+        &self,
+        event_id: &str,
+        trigger_id: &str,
+        binding_key: &str,
+        provider: &str,
+        tenant_id: Option<&str>,
+        now_ms: i64,
+    ) {
+        let labels = trigger_pending_labels(trigger_id, binding_key, provider, tenant_id);
+        {
+            let mut pending = self
+                .pending_trigger_events
+                .lock()
+                .expect("pending trigger events poisoned");
+            if let Some(events) = pending.get_mut(&labels) {
+                events.remove(event_id);
+                if events.is_empty() {
+                    pending.remove(&labels);
+                }
+            }
+        }
+        self.refresh_oldest_pending_gauge(labels, now_ms);
     }
 
     pub fn set_trigger_inflight(&self, trigger_id: &str, count: u64) {
@@ -833,6 +1005,23 @@ impl MetricsRegistry {
         *histogram.buckets.entry("+Inf".to_string()).or_default() += 1;
     }
 
+    fn refresh_oldest_pending_gauge(&self, labels: MetricLabels, now_ms: i64) {
+        let oldest_accepted_at_ms = self
+            .pending_trigger_events
+            .lock()
+            .expect("pending trigger events poisoned")
+            .get(&labels)
+            .and_then(|events| events.values().min().copied());
+        let age_seconds = oldest_accepted_at_ms
+            .map(|accepted_at_ms| millis_delta(now_ms, accepted_at_ms).as_secs_f64())
+            .unwrap_or(0.0);
+        self.set_gauge(
+            "harn_trigger_oldest_pending_age_seconds",
+            labels,
+            age_seconds,
+        );
+    }
+
     fn render_generic_metrics(&self, rendered: &mut String) {
         let counters = self
             .counters
@@ -927,6 +1116,7 @@ fn metric_family_names(kind: MetricKind) -> &'static [&'static str] {
             "harn_worker_queue_depth",
             "harn_orchestrator_pump_backlog",
             "harn_orchestrator_pump_outstanding",
+            "harn_trigger_oldest_pending_age_seconds",
         ],
         MetricKind::Histogram => &[
             "harn_http_request_duration_seconds",
@@ -936,6 +1126,13 @@ fn metric_family_names(kind: MetricKind) -> &'static [&'static str] {
             "harn_a2a_hop_duration_seconds",
             "harn_worker_queue_claim_age_seconds",
             "harn_orchestrator_pump_admission_delay_seconds",
+            "harn_trigger_webhook_accepted_to_normalized_seconds",
+            "harn_trigger_webhook_accepted_to_queue_append_seconds",
+            "harn_trigger_queue_age_at_dispatch_admission_seconds",
+            "harn_trigger_queue_age_at_dispatch_start_seconds",
+            "harn_trigger_dispatch_runtime_seconds",
+            "harn_trigger_retry_delay_seconds",
+            "harn_trigger_accepted_to_dlq_seconds",
         ],
     }
 }
@@ -945,6 +1142,47 @@ fn labels<const N: usize>(pairs: [(&str, &str); N]) -> MetricLabels {
         .into_iter()
         .map(|(name, value)| (name.to_string(), value.to_string()))
         .collect()
+}
+
+fn trigger_lifecycle_labels(
+    trigger_id: &str,
+    binding_key: &str,
+    provider: &str,
+    tenant_id: Option<&str>,
+    status: &str,
+) -> MetricLabels {
+    labels([
+        ("binding_key", binding_key),
+        ("provider", provider),
+        ("status", status),
+        ("tenant_id", tenant_label(tenant_id)),
+        ("trigger_id", trigger_id),
+    ])
+}
+
+fn trigger_pending_labels(
+    trigger_id: &str,
+    binding_key: &str,
+    provider: &str,
+    tenant_id: Option<&str>,
+) -> MetricLabels {
+    labels([
+        ("binding_key", binding_key),
+        ("provider", provider),
+        ("tenant_id", tenant_label(tenant_id)),
+        ("trigger_id", trigger_id),
+    ])
+}
+
+fn tenant_label(tenant_id: Option<&str>) -> &str {
+    tenant_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("none")
+}
+
+fn millis_delta(later_ms: i64, earlier_ms: i64) -> StdDuration {
+    StdDuration::from_millis(later_ms.saturating_sub(earlier_ms).max(0) as u64)
 }
 
 fn render_sample(rendered: &mut String, name: &str, labels: &MetricLabels, value: f64) {
@@ -1717,6 +1955,71 @@ mod tests {
             "trigger.inbox.envelopes",
             StdDuration::from_millis(50),
         );
+        metrics.record_trigger_accepted_to_normalized(
+            "github-new-issue",
+            "github-new-issue@v7",
+            "github",
+            Some("tenant-a"),
+            "normalized",
+            StdDuration::from_millis(25),
+        );
+        metrics.record_trigger_accepted_to_queue_append(
+            "github-new-issue",
+            "github-new-issue@v7",
+            "github",
+            Some("tenant-a"),
+            "queued",
+            StdDuration::from_millis(40),
+        );
+        metrics.record_trigger_queue_age_at_dispatch_admission(
+            "github-new-issue",
+            "github-new-issue@v7",
+            "github",
+            Some("tenant-a"),
+            "admitted",
+            StdDuration::from_millis(75),
+        );
+        metrics.record_trigger_queue_age_at_dispatch_start(
+            "github-new-issue",
+            "github-new-issue@v7",
+            "github",
+            Some("tenant-a"),
+            "started",
+            StdDuration::from_millis(125),
+        );
+        metrics.record_trigger_dispatch_runtime(
+            "github-new-issue",
+            "github-new-issue@v7",
+            "github",
+            Some("tenant-a"),
+            "succeeded",
+            StdDuration::from_millis(250),
+        );
+        metrics.record_trigger_retry_delay(
+            "github-new-issue",
+            "github-new-issue@v7",
+            "github",
+            Some("tenant-a"),
+            "scheduled",
+            StdDuration::from_secs(2),
+        );
+        metrics.record_trigger_accepted_to_dlq(
+            "github-new-issue",
+            "github-new-issue@v7",
+            "github",
+            Some("tenant-a"),
+            "retry_exhausted",
+            StdDuration::from_secs(45),
+        );
+        metrics.note_trigger_pending_event(
+            "evt-1",
+            "github-new-issue",
+            "github-new-issue@v7",
+            "github",
+            Some("tenant-a"),
+            1_000,
+            4_000,
+        );
         metrics.record_llm_call("mock", "mock", "succeeded", 0.01);
         metrics.record_llm_cache_hit("mock");
 
@@ -1745,6 +2048,14 @@ mod tests {
             "harn_orchestrator_pump_backlog{topic=\"trigger.inbox.envelopes\"} 2",
             "harn_orchestrator_pump_outstanding{topic=\"trigger.inbox.envelopes\"} 1",
             "harn_orchestrator_pump_admission_delay_seconds_bucket{le=\"0.05\",topic=\"trigger.inbox.envelopes\"} 1",
+            "harn_trigger_webhook_accepted_to_normalized_seconds_bucket{binding_key=\"github-new-issue@v7\",le=\"0.025\",provider=\"github\",status=\"normalized\",tenant_id=\"tenant-a\",trigger_id=\"github-new-issue\"} 1",
+            "harn_trigger_webhook_accepted_to_queue_append_seconds_bucket{binding_key=\"github-new-issue@v7\",le=\"0.05\",provider=\"github\",status=\"queued\",tenant_id=\"tenant-a\",trigger_id=\"github-new-issue\"} 1",
+            "harn_trigger_queue_age_at_dispatch_admission_seconds_bucket{binding_key=\"github-new-issue@v7\",le=\"0.1\",provider=\"github\",status=\"admitted\",tenant_id=\"tenant-a\",trigger_id=\"github-new-issue\"} 1",
+            "harn_trigger_queue_age_at_dispatch_start_seconds_bucket{binding_key=\"github-new-issue@v7\",le=\"0.25\",provider=\"github\",status=\"started\",tenant_id=\"tenant-a\",trigger_id=\"github-new-issue\"} 1",
+            "harn_trigger_dispatch_runtime_seconds_bucket{binding_key=\"github-new-issue@v7\",le=\"0.25\",provider=\"github\",status=\"succeeded\",tenant_id=\"tenant-a\",trigger_id=\"github-new-issue\"} 1",
+            "harn_trigger_retry_delay_seconds_bucket{binding_key=\"github-new-issue@v7\",le=\"2.5\",provider=\"github\",status=\"scheduled\",tenant_id=\"tenant-a\",trigger_id=\"github-new-issue\"} 1",
+            "harn_trigger_accepted_to_dlq_seconds_bucket{binding_key=\"github-new-issue@v7\",le=\"60\",provider=\"github\",status=\"retry_exhausted\",tenant_id=\"tenant-a\",trigger_id=\"github-new-issue\"} 1",
+            "harn_trigger_oldest_pending_age_seconds{binding_key=\"github-new-issue@v7\",provider=\"github\",tenant_id=\"tenant-a\",trigger_id=\"github-new-issue\"} 3",
             "harn_llm_calls_total{model=\"mock\",outcome=\"succeeded\",provider=\"mock\"} 1",
             "harn_llm_cost_usd_total{model=\"mock\",provider=\"mock\"} 0.01",
             "harn_llm_cache_hits_total{provider=\"mock\"} 1",

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -3,9 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
-#[cfg(feature = "otel")]
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use futures::{pin_mut, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -53,6 +51,10 @@ pub mod retry;
 pub mod uri;
 
 pub use retry::{RetryPolicy, TriggerRetryConfig, DEFAULT_MAX_ATTEMPTS};
+
+pub const TRIGGER_ACCEPTED_AT_MS_HEADER: &str = "harn_trigger_accepted_at_ms";
+pub const TRIGGER_NORMALIZED_AT_MS_HEADER: &str = "harn_trigger_normalized_at_ms";
+pub const TRIGGER_QUEUE_APPENDED_AT_MS_HEADER: &str = "harn_trigger_queue_appended_at_ms";
 
 thread_local! {
     static ACTIVE_DISPATCHER_STATE: RefCell<Option<Arc<DispatcherRuntimeState>>> = const { RefCell::new(None) };
@@ -571,20 +573,75 @@ impl Dispatcher {
         binding_version: Option<u32>,
         event: TriggerEvent,
     ) -> Result<u64, DispatchError> {
+        self.enqueue_targeted_with_headers(trigger_id, binding_version, event, None)
+            .await
+    }
+
+    pub async fn enqueue_targeted_with_headers(
+        &self,
+        trigger_id: Option<String>,
+        binding_version: Option<u32>,
+        event: TriggerEvent,
+        parent_headers: Option<&BTreeMap<String, String>>,
+    ) -> Result<u64, DispatchError> {
         let topic = Topic::new(TRIGGER_INBOX_ENVELOPES_TOPIC)
             .expect("static trigger inbox envelopes topic is valid");
-        let headers = event_headers(&event, None, None, None);
+        let trigger_id_for_metrics = trigger_id.clone();
+        let mut headers = parent_headers.cloned().unwrap_or_default();
+        headers.extend(event_headers(&event, None, None, None));
+        if let Some(trigger_id) = trigger_id_for_metrics.as_ref() {
+            headers.insert("trigger_id".to_string(), trigger_id.clone());
+            headers.insert(
+                "binding_key".to_string(),
+                binding_key_from_parts(trigger_id, binding_version),
+            );
+        }
+        headers
+            .entry(TRIGGER_ACCEPTED_AT_MS_HEADER.to_string())
+            .or_insert_with(|| unix_ms(event.received_at).to_string());
         let payload = serde_json::to_value(InboxEnvelope {
             trigger_id,
             binding_version,
-            event,
+            event: event.clone(),
         })
         .map_err(|error| DispatchError::Serde(error.to_string()))?;
+        let mut log_event = LogEvent::new("event_ingested", payload);
+        let had_queue_appended_at = headers.contains_key(TRIGGER_QUEUE_APPENDED_AT_MS_HEADER);
+        let queue_appended_at_ms = headers
+            .get(TRIGGER_QUEUE_APPENDED_AT_MS_HEADER)
+            .and_then(|value| value.parse::<i64>().ok())
+            .unwrap_or(log_event.occurred_at_ms);
+        headers
+            .entry(TRIGGER_QUEUE_APPENDED_AT_MS_HEADER.to_string())
+            .or_insert_with(|| log_event.occurred_at_ms.to_string());
+        if let (Some(metrics), Some(trigger_id)) =
+            (self.metrics.as_ref(), trigger_id_for_metrics.as_ref())
+        {
+            let binding_key = binding_key_from_parts(trigger_id, binding_version);
+            let accepted_at_ms = accepted_at_ms(Some(&headers), &event);
+            if !had_queue_appended_at {
+                metrics.record_trigger_accepted_to_queue_append(
+                    trigger_id,
+                    &binding_key,
+                    event.provider.as_str(),
+                    tenant_id(&event),
+                    "queued",
+                    duration_between_ms(queue_appended_at_ms, accepted_at_ms),
+                );
+            }
+            metrics.note_trigger_pending_event(
+                event.id.0.as_str(),
+                trigger_id,
+                &binding_key,
+                event.provider.as_str(),
+                tenant_id(&event),
+                accepted_at_ms,
+                queue_appended_at_ms,
+            );
+        }
+        log_event.headers = headers;
         self.event_log
-            .append(
-                &topic,
-                LogEvent::new("event_ingested", payload).with_headers(headers),
-            )
+            .append(&topic, log_event)
             .await
             .map_err(DispatchError::from)
     }
@@ -665,6 +722,15 @@ impl Dispatcher {
             .await
     }
 
+    pub async fn dispatch_inbox_envelope_with_parent_headers(
+        &self,
+        envelope: InboxEnvelope,
+        parent_headers: &BTreeMap<String, String>,
+    ) -> Result<Vec<DispatchOutcome>, DispatchError> {
+        self.dispatch_inbox_envelope_with_headers(envelope, Some(parent_headers))
+            .await
+    }
+
     async fn dispatch_inbox_envelope_with_headers(
         &self,
         envelope: InboxEnvelope,
@@ -700,17 +766,29 @@ impl Dispatcher {
             ]);
         }
 
-        self.dispatch_event(envelope.event).await
+        self.dispatch_event_with_headers(envelope.event, parent_headers)
+            .await
     }
 
     pub async fn dispatch_event(
         &self,
         event: TriggerEvent,
     ) -> Result<Vec<DispatchOutcome>, DispatchError> {
+        self.dispatch_event_with_headers(event, None).await
+    }
+
+    async fn dispatch_event_with_headers(
+        &self,
+        event: TriggerEvent,
+        parent_headers: Option<&BTreeMap<String, String>>,
+    ) -> Result<Vec<DispatchOutcome>, DispatchError> {
         let bindings = matching_bindings(&event);
         let mut outcomes = Vec::new();
         for binding in bindings {
-            outcomes.push(self.dispatch(&binding, event.clone()).await?);
+            outcomes.push(
+                self.dispatch_with_replay(&binding, event.clone(), None, None, parent_headers)
+                    .await?,
+            );
         }
         Ok(outcomes)
     }
@@ -752,6 +830,28 @@ impl Dispatcher {
         parent_span_id: Option<String>,
         parent_headers: Option<&BTreeMap<String, String>>,
     ) -> Result<DispatchOutcome, DispatchError> {
+        let parent_headers_for_metrics = parent_headers.cloned();
+        let admitted_at_ms = current_unix_ms();
+        if let Some(metrics) = self.metrics.as_ref() {
+            let binding_key = binding.binding_key();
+            let queue_appended_at_ms = queue_appended_at_ms(parent_headers, &event);
+            metrics.record_trigger_queue_age_at_dispatch_admission(
+                binding.id.as_str(),
+                &binding_key,
+                event.provider.as_str(),
+                tenant_id(&event),
+                "admitted",
+                duration_between_ms(admitted_at_ms, queue_appended_at_ms),
+            );
+            metrics.clear_trigger_pending_event(
+                event.id.0.as_str(),
+                binding.id.as_str(),
+                &binding_key,
+                event.provider.as_str(),
+                tenant_id(&event),
+                admitted_at_ms,
+            );
+        }
         let span = tracing::info_span!(
             "dispatch",
             trigger_id = %binding.id.as_str(),
@@ -780,8 +880,13 @@ impl Dispatcher {
         let outcome = ACTIVE_DISPATCH_IS_REPLAY
             .scope(
                 replay_of_event_id.is_some(),
-                self.dispatch_with_replay_inner(binding, event, replay_of_event_id)
-                    .instrument(span),
+                self.dispatch_with_replay_inner(
+                    binding,
+                    event,
+                    replay_of_event_id,
+                    parent_headers_for_metrics,
+                )
+                .instrument(span),
             )
             .await;
         if let Some(metrics) = metrics.as_ref() {
@@ -835,6 +940,7 @@ impl Dispatcher {
         binding: &TriggerBinding,
         event: TriggerEvent,
         replay_of_event_id: Option<String>,
+        parent_headers: Option<BTreeMap<String, String>>,
     ) -> Result<DispatchOutcome, DispatchError> {
         let autonomy_tier = crate::resolve_agent_autonomy_tier(
             &self.event_log,
@@ -1287,6 +1393,34 @@ impl Dispatcher {
                 ));
             }
             maybe_fail_before_outbox();
+            let attempt_started_instant = Instant::now();
+            let attempt_started_at_ms = current_unix_ms();
+            let queue_age_at_start = duration_between_ms(
+                attempt_started_at_ms,
+                queue_appended_at_ms(parent_headers.as_ref(), &event),
+            );
+            if attempt == 1 {
+                if let Some(metrics) = self.metrics.as_ref() {
+                    metrics.record_trigger_queue_age_at_dispatch_start(
+                        binding.id.as_str(),
+                        &binding_key,
+                        event.provider.as_str(),
+                        tenant_id(&event),
+                        "started",
+                        queue_age_at_start,
+                    );
+                }
+            }
+            tracing::info!(
+                component = "dispatcher",
+                lifecycle = "dispatch_started",
+                trigger_id = %binding.id.as_str(),
+                binding_key = %binding_key,
+                event_id = %event.id.0,
+                attempt,
+                queue_age_ms = queue_age_at_start.as_millis(),
+                trace_id = %event.trace_id.0
+            );
             let started_at = now_rfc3339();
             let attempt_node_id = dispatch_node_id(&route, &binding_key, &event.id.0, attempt);
             self.append_lifecycle_event(
@@ -1383,6 +1517,29 @@ impl Dispatcher {
                     &mut self.cancel_tx.subscribe(),
                 )
                 .await;
+            let attempt_runtime = attempt_started_instant.elapsed();
+            let attempt_status = dispatch_result_status(&result);
+            if let Some(metrics) = self.metrics.as_ref() {
+                metrics.record_trigger_dispatch_runtime(
+                    binding.id.as_str(),
+                    &binding_key,
+                    event.provider.as_str(),
+                    tenant_id(&event),
+                    attempt_status,
+                    attempt_runtime,
+                );
+            }
+            tracing::info!(
+                component = "dispatcher",
+                lifecycle = "handler_completed",
+                trigger_id = %binding.id.as_str(),
+                binding_key = %binding_key,
+                event_id = %event.id.0,
+                attempt,
+                status = attempt_status,
+                runtime_ms = attempt_runtime.as_millis(),
+                trace_id = %event.trace_id.0
+            );
             let completed_at = now_rfc3339();
 
             match result {
@@ -1716,7 +1873,25 @@ impl Dispatcher {
                         if let Some(metrics) = self.metrics.as_ref() {
                             metrics.record_retry_scheduled();
                             metrics.record_trigger_retry(binding.id.as_str(), attempt + 1);
+                            metrics.record_trigger_retry_delay(
+                                binding.id.as_str(),
+                                &binding_key,
+                                event.provider.as_str(),
+                                tenant_id(&event),
+                                "scheduled",
+                                delay,
+                            );
                         }
+                        tracing::info!(
+                            component = "dispatcher",
+                            lifecycle = "retry_scheduled",
+                            trigger_id = %binding.id.as_str(),
+                            binding_key = %binding_key,
+                            event_id = %event.id.0,
+                            attempt = attempt + 1,
+                            delay_ms = delay.as_millis(),
+                            trace_id = %event.trace_id.0
+                        );
                         let retry_node_id = format!("retry:{binding_key}:{}:{attempt}", event.id.0);
                         previous_retry_node = Some(retry_node_id.clone());
                         self.emit_action_graph(
@@ -1857,7 +2032,28 @@ impl Dispatcher {
                         .push(dlq_entry.clone());
                     if let Some(metrics) = self.metrics.as_ref() {
                         metrics.record_trigger_dlq(binding.id.as_str(), "retry_exhausted");
+                        metrics.record_trigger_accepted_to_dlq(
+                            binding.id.as_str(),
+                            &binding_key,
+                            event.provider.as_str(),
+                            tenant_id(&event),
+                            "retry_exhausted",
+                            duration_between_ms(
+                                current_unix_ms(),
+                                accepted_at_ms(parent_headers.as_ref(), &event),
+                            ),
+                        );
                     }
+                    tracing::info!(
+                        component = "dispatcher",
+                        lifecycle = "dlq_moved",
+                        trigger_id = %binding.id.as_str(),
+                        binding_key = %binding_key,
+                        event_id = %event.id.0,
+                        attempt_count = attempt,
+                        reason = "retry_exhausted",
+                        trace_id = %event.trace_id.0
+                    );
                     self.emit_action_graph(
                         &event,
                         vec![RunActionGraphNodeRecord {
@@ -3226,7 +3422,24 @@ impl Dispatcher {
             .push(dlq_entry.clone());
         if let Some(metrics) = self.metrics.as_ref() {
             metrics.record_trigger_dlq(binding.id.as_str(), "budget_exhausted");
+            metrics.record_trigger_accepted_to_dlq(
+                binding.id.as_str(),
+                &binding.binding_key(),
+                event.provider.as_str(),
+                tenant_id(event),
+                "budget_exhausted",
+                duration_between_ms(current_unix_ms(), accepted_at_ms(None, event)),
+            );
         }
+        tracing::info!(
+            component = "dispatcher",
+            lifecycle = "dlq_moved",
+            trigger_id = %binding.id.as_str(),
+            binding_key = %binding.binding_key(),
+            event_id = %event.id.0,
+            reason = "budget_exhausted",
+            trace_id = %event.trace_id.0
+        );
         self.emit_action_graph(
             event,
             vec![RunActionGraphNodeRecord {
@@ -3854,6 +4067,56 @@ fn split_binding_key(binding_key: &str) -> (String, u32) {
     };
     let version = suffix.parse::<u32>().unwrap_or(0);
     (binding_id.to_string(), version)
+}
+
+fn binding_key_from_parts(trigger_id: &str, binding_version: Option<u32>) -> String {
+    match binding_version {
+        Some(version) => format!("{trigger_id}@v{version}"),
+        None => trigger_id.to_string(),
+    }
+}
+
+fn tenant_id(event: &TriggerEvent) -> Option<&str> {
+    event.tenant_id.as_ref().map(|tenant| tenant.0.as_str())
+}
+
+fn current_unix_ms() -> i64 {
+    unix_ms(time::OffsetDateTime::now_utc())
+}
+
+fn unix_ms(timestamp: time::OffsetDateTime) -> i64 {
+    (timestamp.unix_timestamp_nanos() / 1_000_000) as i64
+}
+
+fn accepted_at_ms(headers: Option<&BTreeMap<String, String>>, event: &TriggerEvent) -> i64 {
+    lifecycle_header_ms(headers, TRIGGER_ACCEPTED_AT_MS_HEADER)
+        .unwrap_or_else(|| unix_ms(event.received_at))
+}
+
+fn queue_appended_at_ms(headers: Option<&BTreeMap<String, String>>, event: &TriggerEvent) -> i64 {
+    lifecycle_header_ms(headers, TRIGGER_QUEUE_APPENDED_AT_MS_HEADER)
+        .unwrap_or_else(|| accepted_at_ms(headers, event))
+}
+
+fn lifecycle_header_ms(headers: Option<&BTreeMap<String, String>>, name: &str) -> Option<i64> {
+    headers
+        .and_then(|headers| headers.get(name))
+        .and_then(|value| value.parse::<i64>().ok())
+}
+
+fn duration_between_ms(later_ms: i64, earlier_ms: i64) -> Duration {
+    Duration::from_millis(later_ms.saturating_sub(earlier_ms).max(0) as u64)
+}
+
+fn dispatch_result_status(result: &Result<serde_json::Value, DispatchError>) -> &'static str {
+    match result {
+        Ok(_) => "succeeded",
+        Err(DispatchError::Waiting(_)) => "waiting",
+        Err(DispatchError::Cancelled(_)) => "cancelled",
+        Err(DispatchError::Denied(_)) => "denied",
+        Err(DispatchError::Timeout(_)) => "timeout",
+        Err(_) => "failed",
+    }
 }
 
 fn is_cancelled_vm_error(error: &VmError) -> bool {

--- a/docs/src/orchestrator/observability.md
+++ b/docs/src/orchestrator/observability.md
@@ -17,6 +17,71 @@ metrics, EventLog append timings, budget gauges, A2A hop timings, worker queue
 depth and claim age, and LLM call/cache counters. Trigger labels use the
 manifest trigger id, provider, handler kind, and outcome where applicable.
 
+Webhook and trigger latency metrics use low-cardinality labels:
+`provider`, `trigger_id`, `binding_key`, `tenant_id`, and `status`. When an
+event has no tenant, `tenant_id` is `none`.
+
+Lifecycle histograms:
+
+- `harn_trigger_webhook_accepted_to_normalized_seconds`
+- `harn_trigger_webhook_accepted_to_queue_append_seconds`
+- `harn_trigger_queue_age_at_dispatch_admission_seconds`
+- `harn_trigger_queue_age_at_dispatch_start_seconds`
+- `harn_trigger_dispatch_runtime_seconds`
+- `harn_trigger_retry_delay_seconds`
+- `harn_trigger_accepted_to_dlq_seconds`
+
+Oldest pending age is exposed as `harn_trigger_oldest_pending_age_seconds` with
+the same trigger/provider/tenant labels, excluding `status`.
+
+Example webhook-to-dispatch latency SLO queries:
+
+```promql
+histogram_quantile(
+  0.50,
+  sum by (le, provider, trigger_id) (
+    rate(harn_trigger_queue_age_at_dispatch_start_seconds_bucket[5m])
+  )
+)
+```
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, provider, trigger_id) (
+    rate(harn_trigger_queue_age_at_dispatch_start_seconds_bucket[5m])
+  )
+)
+```
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (le, provider, trigger_id) (
+    rate(harn_trigger_queue_age_at_dispatch_start_seconds_bucket[5m])
+  )
+)
+```
+
+Example alert for queued work older than 30 seconds:
+
+```promql
+max by (provider, trigger_id, tenant_id) (
+  harn_trigger_oldest_pending_age_seconds
+) > 30
+```
+
+Example DLQ latency alert:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, provider, trigger_id) (
+    rate(harn_trigger_accepted_to_dlq_seconds_bucket[10m])
+  )
+) > 300
+```
+
 `harn orchestrator inspect` also surfaces the persisted trigger metric snapshot
 for local diagnosis:
 
@@ -55,9 +120,11 @@ HARN_OTEL_SERVICE_NAME=harn-orchestrator \
 harn orchestrator serve
 ```
 
-The orchestrator exports spans for webhook ingestion and dispatch, attaches the
-Harn `trace_id` as a span attribute, and propagates W3C trace context through
-the EventLog into dispatch spans. A2A dispatches also carry `A2A-Trace-Id` and
+The orchestrator exports spans for webhook ingestion, queue append, and
+dispatch, attaches the Harn `trace_id` as a span attribute, and propagates W3C
+trace context through pending and inbox EventLog topics into dispatch spans.
+Dispatcher span events mark dispatch start, handler completion, retry
+scheduling, and DLQ movement. A2A dispatches also carry `A2A-Trace-Id` and
 `traceparent` headers downstream.
 
 Optional OTLP request headers can be supplied as comma-, semicolon-, or


### PR DESCRIPTION
## Summary

- add trigger lifecycle Prometheus histograms for accepted-to-normalized, accepted-to-queue-append, queue age at dispatch admission/start, dispatch runtime, retry delay, and accepted-to-DLQ latency
- stamp lifecycle timestamps into trigger EventLog headers and preserve trace context through pending and inbox pumps
- add queue-append spans plus dispatch-start, handler-completion, retry, and DLQ trace events
- document PromQL SLO and alert examples for webhook-to-dispatch latency and oldest pending age

Closes #479.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-issue-479 cargo check -p harn-cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-479 cargo test -p harn-vm metrics_registry_exports_orchestrator_metric_families`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-479 cargo test -p harn-vm retry_exhaustion_moves_failed_dispatch_to_dlq`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-479 cargo test -p harn-cli --test orchestrator_http otel_exports_ingest_and_dispatch_spans_with_shared_trace_id`
- pre-commit hook: `cargo fmt`, workspace clippy, markdown lint passed

## Notes

The pre-push hook full test run was started before the final OTEL assertion update. It found the expected OTEL parent-chain assertion mismatch, which this PR fixes and reruns directly. It also reported two reproducible `harn_serve_mcp_cli` readiness timeouts that do not touch this trigger/observability path.