### PR TITLE
Auto-finalize release via GitHub Actions

### DIFF
--- a/.claude/commands/release-harn.md
+++ b/.claude/commands/release-harn.md
@@ -9,9 +9,12 @@ Run the merge-queue-safe Harn release workflow from the repo source of truth.
 
 `release_ship.sh --bump patch` handles audit, dry-run publish, version bump,
 branch push, and automated bump PR creation. After that PR lands through the
-merge queue, run `./scripts/release_ship.sh --finalize` from updated `main` to
-tag, publish to crates.io, and create/update the GitHub release. Do not
-re-invent the sequence manually unless the script cannot do what you need.
+merge queue, **the `Finalize Release` GitHub Action (`.github/workflows/finalize-release.yml`) runs `release_ship.sh --finalize` automatically** — it
+audits, tags, publishes to crates.io, and creates/updates the GitHub release.
+The human release path ends at opening the bump PR; the tag + publish are
+automated. Only run `./scripts/release_ship.sh --finalize` locally to recover
+from a failed workflow run, or manually re-trigger the workflow via "Run
+workflow" on the `Finalize Release` GitHub Actions page.
 
 ## Default workflow
 
@@ -58,10 +61,14 @@ re-invent the sequence manually unless the script cannot do what you need.
    run `./scripts/release_ship.sh --bump patch` (or `minor`/`major`). The
    script audits, dry-run publishes, bumps `Cargo.toml`, commits the bump,
    pushes `release/vX.Y.Z`, and opens the bump PR.
-10. After the bump PR lands through the merge queue, sync `main` and run
-    `./scripts/release_ship.sh --finalize`. The script audits, dry-run
-    publishes, creates/pushes the tag, publishes to crates.io, and
-    creates/updates the GitHub release.
+10. After the bump PR lands through the merge queue, the `Finalize Release`
+    GitHub Action runs `./scripts/release_ship.sh --finalize` automatically
+    against updated `main`. It audits, dry-run publishes, creates/pushes the
+    tag, publishes to crates.io, and creates/updates the GitHub release. Do
+    not run `--finalize` locally as a default step; only do so if the
+    workflow fails and the tree needs to be recovered manually. The
+    workflow also exposes a `workflow_dispatch` trigger for manual
+    re-runs from the GitHub Actions UI.
 11. For an all-in-one dry run that stops before any destructive action,
     use `./scripts/release_gate.sh full --bump patch --dry-run`.
 12. Only drop down to the piecewise `release_gate.sh prepare` / `publish` /
@@ -129,6 +136,15 @@ not automate, such as analyzing pending local work and opening the
   (e.g. `burin-code`'s `fetch-harn`) start working in parallel with crates.io
   publication. The GitHub release body is created last so it can reference the
   final crates.io state.
+- Finalize runs inside GitHub Actions via
+  `.github/workflows/finalize-release.yml`. The workflow fires on push to
+  `main` when the head commit starts with the prefix `Bump version to` (the
+  convention `release_ship.sh --bump` writes), and also exposes
+  `workflow_dispatch` for manual re-runs. It uses the repo secret
+  `CARGO_REGISTRY_TOKEN` for crates.io and the default `GITHUB_TOKEN` for
+  tag push + release creation. Running `release_ship.sh --finalize`
+  locally is only needed when the workflow fails and a human has to
+  recover — it is idempotent once the tag exists at HEAD.
 - `CHANGELOG.md` is the release-language source of truth. Use
   `scripts/render_release_notes.py` or `./scripts/release_gate.sh notes` to
   produce the exact GitHub release body from it.
@@ -151,8 +167,11 @@ phase stretch to ~12 min while fighting `rust-audit`'s clippy+nextest for
 ## Useful shortcuts
 
 ```bash
-./scripts/release_ship.sh --bump patch
-./scripts/release_ship.sh --finalize
+./scripts/release_ship.sh --bump patch               # open the bump PR
+./scripts/release_ship.sh --finalize                 # recovery only
 ./scripts/release_gate.sh full --bump patch --dry-run
 ./scripts/release_gate.sh notes
+
+# Manual re-trigger of the finalize workflow:
+gh workflow run finalize-release.yml --ref main
 ```

--- a/.codex/commands/harn-release.md
+++ b/.codex/commands/harn-release.md
@@ -32,11 +32,20 @@ Default assumptions:
 
 - Adjust `patch` to `minor` or `major` if requested. This opens the automated
   version-bump PR.
-- After the version-bump PR lands through the merge queue, sync `main` and
-  finalize:
+- After the version-bump PR lands through the merge queue, the
+  `Finalize Release` GitHub Action
+  (`.github/workflows/finalize-release.yml`) runs `release_ship.sh --finalize`
+  automatically against updated `main`. Do not run the local `--finalize`
+  command as a default step. Only fall back to running it locally if the
+  workflow fails and a human has to recover, or re-trigger the workflow
+  via the GitHub Actions UI (it exposes a `workflow_dispatch` input):
 
 ```bash
+# Recovery path only — normally, the workflow does this for you.
 ./scripts/release_ship.sh --finalize
+
+# Or re-trigger the workflow manually:
+gh workflow run finalize-release.yml --ref main
 ```
 
 Rules:
@@ -51,6 +60,14 @@ Rules:
   **before** `cargo publish` so GitHub release-binary workflows and downstream
   fetchers (e.g. `burin-code`'s `fetch-harn`) start in parallel with crates.io.
   The GitHub release body is created last.
+- Finalize runs inside GitHub Actions via
+  `.github/workflows/finalize-release.yml`. The workflow fires on push to
+  `main` when the head commit starts with the prefix `Bump version to` (the convention
+  `release_ship.sh --bump` writes), and also exposes `workflow_dispatch` for
+  manual re-runs. It uses repo secret `CARGO_REGISTRY_TOKEN` for crates.io
+  and the default `GITHUB_TOKEN` for tag push + release creation. Local
+  `release_ship.sh --finalize` remains the recovery path and is idempotent
+  once the tag exists at HEAD.
 - `verify_release_metadata.py` accepts the pre-bump state — it passes when
   `CHANGELOG.md` top is exactly one patch/minor/major step ahead of
   `Cargo.toml`. That is why running `release_ship.sh --bump patch` on a

--- a/.codex/skills/harn-release/SKILL.md
+++ b/.codex/skills/harn-release/SKILL.md
@@ -26,8 +26,11 @@ intentionally does not automate: analyzing pending local work and producing
 the "Prepare vX.Y.Z release" PR. Once that PR lands through the merge queue,
 `release_ship.sh --bump patch` handles audit, dry-run publish, bump-branch
 creation, version-bump commit, branch push, and PR creation. After the bump PR
-lands through the merge queue, `release_ship.sh --finalize` tags `main`,
-publishes crates, renders notes, and creates/updates the GitHub release.
+lands through the merge queue, the `Finalize Release` GitHub Action
+(`.github/workflows/finalize-release.yml`) runs `release_ship.sh --finalize`
+automatically, which tags `main`, publishes crates, renders notes, and
+creates/updates the GitHub release. Local `release_ship.sh --finalize` remains
+the recovery path when the workflow fails.
 
 ## Merge-queue mode
 
@@ -39,14 +42,20 @@ merge-queue-reviewed PRs:
 2. `Bump version to X.Y.Z` — `Cargo.toml` + `Cargo.lock` only, opened by
    `./scripts/release_ship.sh --bump patch`.
 
-Only after the bump PR lands should you run `./scripts/release_ship.sh
---finalize` from an up-to-date `main`. Finalize creates/pushes the tag before
-`cargo publish` so release-binary workflows and downstream fetchers can still
-start in parallel with crates.io publication.
+Once the bump PR lands, the `Finalize Release` GitHub Action runs
+`./scripts/release_ship.sh --finalize` against updated `main` automatically.
+It fires on `push` to `main` when the head commit starts with
+the prefix `Bump version to` (which is exactly what `release_ship.sh --bump patch`
+writes), and also exposes `workflow_dispatch` for manual re-runs. Finalize
+creates/pushes the tag before `cargo publish` so release-binary workflows
+and downstream fetchers can still start in parallel with crates.io
+publication. Only run `--finalize` locally when the workflow fails and a
+human has to recover — the script is idempotent once the tag exists at HEAD.
 
 Both script phases run the release audit and stop on the first failed gate.
-Check the exit code when they return; if non-zero, the step names in stdout
-tell you which gate tripped.
+Check the exit code when the bump script returns locally; for the finalize
+workflow, check the job status on the `Finalize Release` Actions page.
+If non-zero, the step names in stdout tell you which gate tripped.
 
 Typical wall-clock: ~6–10 min cold, ~2–4 min warm (sccache hot). Do not
 babysit it. Start the command and work on other things. Failure modes,
@@ -59,7 +68,10 @@ roughly in frequency order:
 - bump PR creation failure → the release bump branch has usually already been
   pushed; create the PR manually from `release/vX.Y.Z` into `main`.
 - `cargo publish` rate-limit / transient network during finalize → re-run
-  `release_ship.sh --finalize`; it is idempotent once the tag exists at HEAD.
+  the `Finalize Release` workflow via
+  `gh workflow run finalize-release.yml --ref main` (or run
+  `./scripts/release_ship.sh --finalize` locally); both are idempotent once
+  the tag exists at HEAD.
 - `gh release create` failure during finalize → the release is already on
   crates.io and tagged; finish manually with
   `gh release create <tag> --title <tag> --notes-file <rendered>`.
@@ -128,10 +140,13 @@ installs the binaries directly. Release batching exists to control the
    run `./scripts/release_ship.sh --bump patch` (or `minor`/`major`). The
    script runs audit, dry-run publish, creates `release/vX.Y.Z`, commits the
    Cargo version bump, pushes that branch, and opens the bump PR.
-10. After the bump PR lands through the merge queue, sync `main` and run
-    `./scripts/release_ship.sh --finalize`. The script runs audit, dry-run
-    publish, creates/pushes the tag, publishes to crates.io, renders notes,
-    and creates/updates the GitHub release.
+10. After the bump PR lands through the merge queue, the `Finalize Release`
+    GitHub Action runs `./scripts/release_ship.sh --finalize` automatically
+    against updated `main`. The workflow runs audit, dry-run publish,
+    creates/pushes the tag, publishes to crates.io, renders notes, and
+    creates/updates the GitHub release. Watch the run on the Actions page;
+    only run `--finalize` locally as a recovery step if the workflow
+    fails (it is idempotent once the tag exists at HEAD).
 11. For an all-in-one dry run that stops before any destructive action, use
     `./scripts/release_gate.sh full --bump patch --dry-run`.
 12. Only fall back to the piecewise `release_gate.sh prepare` / `publish` /
@@ -178,6 +193,14 @@ installs the binaries directly. Release batching exists to control the
   fetchers (e.g. `burin-code`'s `fetch-harn`) can start working in parallel
   with crates.io publication. The GitHub release body is created last so it
   reflects the final crates.io + git state.
+- The `Finalize Release` workflow
+  (`.github/workflows/finalize-release.yml`) runs `--finalize` inside
+  GitHub Actions whenever a `Bump version to X.Y.Z` commit lands on
+  `main`. It authenticates to crates.io with repo secret
+  `CARGO_REGISTRY_TOKEN` and to GitHub with the default `GITHUB_TOKEN`.
+  `workflow_dispatch` is the manual re-trigger. Running `--finalize`
+  locally is still supported for recovery but is not the default
+  post-bump step.
 - A real release has exactly two release commits on `main`, both landed via
   PR/merge queue: `Prepare vX.Y.Z release` (code + docs + `CHANGELOG.md`)
   followed by `Bump version to X.Y.Z` (Cargo.toml + Cargo.lock only).

--- a/.codex/skills/release-harn/SKILL.md
+++ b/.codex/skills/release-harn/SKILL.md
@@ -12,23 +12,27 @@ The repo source of truth remains:
 ```bash
 ./scripts/dev_setup.sh
 ./scripts/release_ship.sh --bump patch                     # open bump PR
-./scripts/release_ship.sh --finalize                       # tag/publish after merge
+./scripts/release_ship.sh --finalize                       # recovery only — normally automated
 ./scripts/release_gate.sh <audit|prepare|publish|notes|full> ...  # piecewise
 ```
 
 Direct pushes to `main` are not part of the release flow. After the release
 content PR lands through the merge queue, `release_ship.sh --bump patch` runs
 audit → dry-run publish → bump → commit → push `release/vX.Y.Z` → open a bump
-PR. After the bump PR lands, `release_ship.sh --finalize` runs audit → dry-run
-publish → tag → push tag → `cargo publish` → render notes → create/update the
-GitHub release. The tag push happens before `cargo publish` so downstream
-consumers (e.g. `burin-code`'s `fetch-harn`, GitHub release-binary workflows)
-can start working in parallel with crates.io.
+PR. After the bump PR lands, the `Finalize Release` GitHub Action
+(`.github/workflows/finalize-release.yml`) runs `release_ship.sh --finalize`
+automatically: audit → dry-run publish → tag → push tag → `cargo publish` →
+render notes → create/update the GitHub release. The tag push happens before
+`cargo publish` so downstream consumers (e.g. `burin-code`'s `fetch-harn`,
+GitHub release-binary workflows) can start working in parallel with crates.io.
 
 **Merge-queue flow:** land a "Prepare vX.Y.Z release" PR first, run
 `release_ship.sh --bump patch` from updated `main` to open the automated bump
-PR, then run `release_ship.sh --finalize` from updated `main` after the bump PR
-lands. Check each exit code when it returns; otherwise do not babysit.
+PR, then wait for the bump PR to land through the merge queue — the
+`Finalize Release` workflow fires automatically and completes the release.
+Watch the Actions run on the `Finalize Release` page; `workflow_dispatch`
+is available for manual re-triggers. Only run `release_ship.sh --finalize`
+locally if the workflow fails and a human has to recover.
 
 **Cross-repo consumers do not wait on releases.** `burin-code`'s
 `scripts/fetch-harn.sh --local` builds Harn from `~/projects/harn` and
@@ -51,4 +55,6 @@ Commit pattern for a real release:
 1. `Prepare vX.Y.Z release` — code + docs + `CHANGELOG.md`, no Cargo.toml,
    landed through PR/merge queue.
 2. `Bump version to X.Y.Z` — created automatically by `release_ship.sh --bump
-   patch`, landed through PR/merge queue.
+   patch`, landed through PR/merge queue. This commit landing on `main`
+   triggers the `Finalize Release` workflow, which produces the tag and
+   crates.io + GitHub release without further human action.

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -1,0 +1,77 @@
+name: Finalize Release
+
+# Fires when a "Bump version to X.Y.Z" commit lands on main through the merge
+# queue. Runs ./scripts/release_ship.sh --finalize, which audits, dry-run
+# publishes, tags, publishes to crates.io, and creates/updates the GitHub
+# release. The tag push cascades to .github/workflows/release.yml for binary
+# artifacts.
+#
+# workflow_dispatch is kept as a manual recovery path — if this workflow
+# fails mid-run (e.g. crates.io rate limit), re-run it; release_ship.sh is
+# idempotent once the tag exists at HEAD.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: finalize-release
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  finalize:
+    name: Finalize release
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.head_commit.message, 'Bump version to ')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.9.1
+        with:
+          shared-key: workspace
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
+        continue-on-error: true
+        with:
+          tool: nextest@0.9.133
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: crates/harn-cli/portal/package-lock.json
+
+      - name: Install portal dependencies
+        working-directory: crates/harn-cli/portal
+        run: npm ci
+
+      - name: Configure git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Finalize release
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/release_ship.sh --finalize


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/finalize-release.yml`, which fires on push to
  `main` when the head commit starts with `Bump version to` (the exact
  convention `release_ship.sh --bump patch` writes) and also exposes
  `workflow_dispatch` for manual re-runs.
- The workflow runs `./scripts/release_ship.sh --finalize` end-to-end:
  audit → dry-run publish → tag HEAD → push tag (cascades to
  `release.yml` for binaries) → `cargo publish` via
  `CARGO_REGISTRY_TOKEN` → render notes → create/update GitHub release.
- A `concurrency:` group serializes overlapping finalize runs so
  back-to-back bump commits can't race. Local
  `release_ship.sh --finalize` stays as the recovery path (idempotent
  once the tag exists at HEAD).
- Updates the release-harn skill/command for Claude and Codex so
  future agents stop at "open the bump PR" and let the workflow
  finalize, rather than running `--finalize` themselves.

## Why reuse `release_ship.sh` instead of reimplementing inline

The script encodes the ordering invariants we care about (tag push
before `cargo publish` so downstream fetchers kick off in parallel;
audit before tag; GitHub release body created last so it reflects
final crates.io state). Rewriting that sequence inline in YAML would
fork the source of truth. The workflow is therefore just: install
toolchain + portal deps + secrets, then invoke the script.

## Prerequisites

- Repo secret `CARGO_REGISTRY_TOKEN` (set).
- Default `GITHUB_TOKEN` with `contents: write` permission on the job
  (granted inline).

## Test plan

- [x] `actionlint .github/workflows/finalize-release.yml` — clean
      (with `pyflakes` and `shellcheck` both installed and invoked).
- [x] Pre-commit + pre-push hooks pass (markdown lint + GitHub Actions
      lint).
- [ ] Smoke test via `workflow_dispatch` from the Actions UI after
      this PR lands — from a tree that is already tagged, `--finalize`
      will be a no-op beyond re-publishing unchanged crates (will fail
      at crates.io for duplicates — that is the expected idempotent
      behavior).
- [ ] Real first fire: next release cycle after v0.7.31.

Note: v0.7.31 itself will be shipped one last time via the local
`release_ship.sh --bump patch` + `release_ship.sh --finalize` path
so this workflow and v0.7.31 don't race each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)