### PR TITLE
Stabilize serve mcp stdio readiness wait

### DIFF
--- a/crates/harn-cli/tests/harn_serve_mcp_cli.rs
+++ b/crates/harn-cli/tests/harn_serve_mcp_cli.rs
@@ -19,6 +19,14 @@ use serde_json::{json, Value as JsonValue};
 use tempfile::TempDir;
 use tokio::sync::oneshot;
 
+// Two-tier timeout convention shared with the orchestrator integration
+// tests: cold-start of the debug `harn` binary is process-bound and can
+// take a few hundred milliseconds (link, parse, set up the stdio loop),
+// while in-flight JSON-RPC roundtrips against an already-ready server
+// are event-bound and finish in milliseconds. Use a 5s budget when
+// waiting for the readiness log on stderr, and the tighter 2s budget
+// for every subsequent message-level recv.
+const PROCESS_READY_TIMEOUT: Duration = Duration::from_secs(5);
 const TEST_TIMEOUT: Duration = Duration::from_secs(2);
 
 fn lock_harn_serve_mcp_tests() -> mcp_support::HarnProcessTestLock {
@@ -71,15 +79,33 @@ where
     F: Fn(&JsonValue) -> bool,
 {
     let deadline = Instant::now() + timeout;
+    let mut observed: Vec<JsonValue> = Vec::new();
     while Instant::now() < deadline {
         match rx.recv_timeout(Duration::from_millis(25)) {
             Ok(message) if predicate(&message) => return message,
-            Ok(_) => continue,
+            Ok(message) => {
+                observed.push(message);
+                continue;
+            }
             Err(mpsc::RecvTimeoutError::Timeout) => continue,
             Err(error) => panic!("stdout reader disconnected: {error}"),
         }
     }
-    panic!("timed out waiting for matching JSON-RPC message");
+    panic!(
+        "timed out waiting for matching JSON-RPC message; observed {} non-matching message(s): {:?}",
+        observed.len(),
+        observed
+    );
+}
+
+fn wait_for_stdio_ready(child: &mut std::process::Child, rx: &Receiver<String>) {
+    mcp_support::wait_for_child_log_suffix(
+        child,
+        rx,
+        "MCP workflow server ready on ",
+        PROCESS_READY_TIMEOUT,
+        "stdio MCP server",
+    );
 }
 
 fn wait_for_http_listener(child: &mut std::process::Child, rx: &Receiver<String>) -> String {
@@ -87,7 +113,7 @@ fn wait_for_http_listener(child: &mut std::process::Child, rx: &Receiver<String>
         child,
         rx,
         "MCP workflow server ready on ",
-        TEST_TIMEOUT,
+        PROCESS_READY_TIMEOUT,
         "HTTP MCP server",
     )
 }
@@ -132,12 +158,15 @@ fn serve_mcp_stdio_lists_calls_and_cancels_exported_functions() {
         .arg("server.harn")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()
         .unwrap();
 
     let mut stdin = child.stdin.take().unwrap();
     let (rx, stdout_handle) = spawn_stdout_reader(child.stdout.take().unwrap());
+    let (stderr_rx, _stderr_handle) =
+        mcp_support::spawn_stderr_reader(child.stderr.take().unwrap());
+    wait_for_stdio_ready(&mut child, &stderr_rx);
 
     writeln!(
         stdin,


### PR DESCRIPTION
## Summary

Stabilizes the `serve_mcp_stdio_lists_calls_and_cancels_exported_functions` integration test in `harn-cli` (added in #457). The test was sending the JSON-RPC `initialize` request immediately after spawning the `harn` binary, before the child had finished setting up its stdio loop. Pipes buffer the write, but the child cannot consume it until its MCP server is up — and cold-starting the debug `harn` binary from nextest takes roughly a second on its own (link, parse, set up the server). The 2 s `recv_until` budget then expires before the response can land, and the test fails deterministically (caught when `release_ship.sh --bump patch` ran the pre-push test gate while preparing v0.7.31).

The HTTP sibling test already does the right thing: capture the child's stderr, wait for the `MCP workflow server ready on …` log the binary emits at the end of startup, then send requests. This change applies the same pattern to the stdio test:

- Pipe stderr (was `Stdio::null`) and spawn the existing stderr reader.
- Wait for the readiness suffix on stderr before writing `initialize`.
- Distinguish process readiness from in-flight response budgets via a new `PROCESS_READY_TIMEOUT` (5 s, matches the orchestrator integration tests' `PROCESS_FAIL_FAST_TIMEOUT`) and keep the tighter `TEST_TIMEOUT` (2 s) for every subsequent `recv_until`.
- Switch `wait_for_http_listener` to the same `PROCESS_READY_TIMEOUT` for consistency.
- On `recv_until` timeout, dump the non-matching messages observed so far so future failures show what arrived rather than just the bare "timed out" panic.

This is a structural fix — distinguishing process-startup latency from in-flight event latency — not a blanket timeout bump. The 5 s startup budget matches an existing convention in this exact crate. The 2 s response budget is unchanged.

## Test plan

- [x] `cargo nextest run -p harn-cli --test harn_serve_mcp_cli` — both stdio and http tests pass.
- [x] Ran the suite 5× in a row to confirm determinism: all five runs passed in ~2.1–2.3 s each.
- [x] Pre-push gate (full workspace `make test` via nextest): 1947/1947 passed.

## Why this is its own PR

Per the release flow, the `Bump version to X.Y.Z` PR must contain only `Cargo.toml` and `Cargo.lock`. This stabilization fix lands separately so the v0.7.31 bump PR remains clean. After this lands, I'll re-run `release_ship.sh --bump patch` to open the bump PR for v0.7.31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)