### PR TITLE
Mark illustrative spec fences as harn,ignore

### DIFF
--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -586,7 +586,7 @@ Note: `-` does not support multiline continuation because it is also a unary
 negation prefix. Keyword operators `in`, `not in`, and `to` also require an
 explicit backslash continuation.
 
-```harn
+```harn,ignore
 let result = items
   .filter({ x -> x > 0 })
   .map({ x -> x * 2 })
@@ -2025,7 +2025,7 @@ Interfaces can be used as parameter types. At compile time, the type
 checker verifies that any struct passed to such a parameter satisfies
 the interface:
 
-```harn
+```harn,ignore
 fn show(item: Displayable) {
   println(item.display())
 }

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -584,7 +584,7 @@ Note: `-` does not support multiline continuation because it is also a unary
 negation prefix. Keyword operators `in`, `not in`, and `to` also require an
 explicit backslash continuation.
 
-```harn
+```harn,ignore
 let result = items
   .filter({ x -> x > 0 })
   .map({ x -> x * 2 })
@@ -2023,7 +2023,7 @@ Interfaces can be used as parameter types. At compile time, the type
 checker verifies that any struct passed to such a parameter satisfies
 the interface:
 
-```harn
+```harn,ignore
 fn show(item: Displayable) {
   println(item.display())
 }


### PR DESCRIPTION
## Summary

Two snippets in `spec/HARN_SPEC.md` reference names that are intentionally undeclared — they teach syntax, not executable code:

- `spec/HARN_SPEC.md:587` (multiline-expressions): uses `items`, `check_a`, `check_b`, `fallback` to show how the `&&`/`||`/`+`/`.` operators behave at the start of a continuation line.
- `spec/HARN_SPEC.md:2027` (using-interfaces-as-type-annotations): uses a user-defined struct `Dog` to demonstrate that any struct satisfying the interface contract is accepted as an interface-typed parameter.

`scripts/verify_language_spec.py` (run in the grammar-audit lane of `release_gate.sh audit`) hands every bare ```` ```harn ```` fence to `harn check`. Both snippets fail that pass as hard errors (`error: call target `foo` is not defined or imported`) and block the release gate.

The spec already uses the `harn,ignore` info-string for exactly this category of illustrative-only fragment — see existing snippets at lines 1371 / 1382 / 1411 / 1599 / 1641. This PR applies the same convention to the two blocks above.

The executable, standalone behavior of multiline expressions and interface-parameter subtyping continues to be covered by the conformance suite under `conformance/tests/`.

Also regenerates the docs mirror `docs/src/language-spec.md` via `scripts/sync_language_spec.sh`.

## Test plan

- [x] `./scripts/verify_language_spec.py` — exits 0, verifies 101 Harn code fences from `spec/HARN_SPEC.md`.
- [x] `./scripts/sync_language_spec.sh` — docs mirror regenerated.
- [x] Pre-commit + pre-push markdown lint: clean.

## Why this is its own PR

Caught by `release_ship.sh --bump patch` while preparing the v0.7.31 bump PR (the grammar-audit lane failed here; the rest of the release gate was green). Landing it as its own PR keeps the upcoming "Bump version to 0.7.31" PR pure Cargo.toml/Cargo.lock, per the release flow convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)