### PR TITLE
Bump version to 0.7.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "async-trait",
  "axum",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-vm",
  "serde",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1209,11 +1209,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.30"
+version = "0.7.31"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "async-trait",
  "axum",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "harn-vm"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.30"
+version = "0.7.31"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
Automated version-bump PR for v0.7.31.

Release gates completed before opening this PR:

- ./scripts/release_gate.sh audit
- ./scripts/release_gate.sh publish --dry-run, unless --skip-dry-run was passed

After this PR lands through the merge queue, finalize from an up-to-date main:

```bash
./scripts/release_ship.sh --finalize
```
