### PR TITLE
Install finalize-release workflow prereqs

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -65,6 +65,21 @@ jobs:
         working-directory: crates/harn-cli/portal
         run: npm ci
 
+      - name: Install ripgrep
+        # security-audit lane greps the repo via `rg` — install it
+        # explicitly so the runner matches the local dev expectation.
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Build tree-sitter grammar
+        # grammar-audit's verify_tree_sitter_parse.py loads the
+        # compiled grammar from tree-sitter-harn/harn.{so,dylib}.
+        # `npm run build` runs `tree-sitter generate && tree-sitter
+        # build`, which produces harn.so on Linux.
+        working-directory: tree-sitter-harn
+        run: |
+          npm ci
+          npm run build
+
       - name: Configure git identity
         run: |
           git config --global user.name "github-actions[bot]"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "async-trait",
  "axum",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-vm",
  "serde",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1209,11 +1209,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.30"
+version = "0.7.31"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "async-trait",
  "axum",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "harn-vm"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.30"
+version = "0.7.31"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
## Summary

First real run of the Finalize Release workflow (#497, v0.7.31) failed the audit lane because the Ubuntu runner image is missing two tools the release gate assumes are present:

- **`ripgrep`** — `security-audit` in `scripts/release_gate.sh:156` greps the repo via `rg` for trust-boundary keywords; without it the lane errors with `rg: command not found`.
- **tree-sitter compiled grammar** — `grammar-audit`'s `scripts/verify_tree_sitter_parse.py:14` loads `tree-sitter-harn/harn.so` (or `.dylib` on macOS) and bails with `error: missing compiled tree-sitter library` when it's absent. Local `make setup` builds it via npm; the workflow didn't.

Adds two steps before `Finalize release`:

1. `sudo apt-get install -y ripgrep` — matches the local expectation.
2. `(cd tree-sitter-harn && npm ci && npm run build)` — runs `tree-sitter generate && tree-sitter build` to produce `harn.so` on the runner.

The fix is scoped to the workflow. The audit script stays the source of truth for what a release verifies.

## Current v0.7.31 state

After #497 merged, `main` is at commit `e3dbc153` with `Cargo.toml = 0.7.31`, but the tag, crates.io publish, and GitHub release didn't happen because the workflow bailed at the audit step. Once this fix lands, I'll manually re-trigger the workflow via `gh workflow run finalize-release.yml --ref main` to complete v0.7.31. `release_ship.sh --finalize` is idempotent on the tag-less post-bump state.

## Test plan

- [x] `actionlint .github/workflows/finalize-release.yml` — clean.
- [ ] First cascade: this PR lands → manually fire `Finalize Release` for v0.7.31 → verify tag + crates.io + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)