### PR TITLE
Add workflow_dispatch trigger to Release workflow

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -65,6 +65,21 @@ jobs:
         working-directory: crates/harn-cli/portal
         run: npm ci
 
+      - name: Install ripgrep
+        # security-audit lane greps the repo via `rg` — install it
+        # explicitly so the runner matches the local dev expectation.
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Build tree-sitter grammar
+        # grammar-audit's verify_tree_sitter_parse.py loads the
+        # compiled grammar from tree-sitter-harn/harn.{so,dylib}.
+        # `npm run build` runs `tree-sitter generate && tree-sitter
+        # build`, which produces harn.so on Linux.
+        working-directory: tree-sitter-harn
+        run: |
+          npm ci
+          npm run build
+
       - name: Configure git identity
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "async-trait",
  "axum",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-vm",
  "serde",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1209,11 +1209,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.30"
+version = "0.7.31"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "async-trait",
  "axum",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "harn-vm"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.30"
+version = "0.7.31"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
## Summary

The `Release` workflow today only fires on `push: tags: ['v*']`. When the tag push originates from another workflow using `GITHUB_TOKEN` — as `Finalize Release` currently does — GitHub Actions suppresses the downstream chain and `Release` never runs. v0.7.31 just hit this: it shipped to crates.io with a populated GitHub release, but no binary tarballs and no GHCR container, because the tag push from `finalize-release.yml` didn't trigger this workflow.

Adding `workflow_dispatch:` lets us re-fire the workflow manually for a specific tag via:

```bash
gh workflow run release.yml --ref v0.7.31
```

This unblocks v0.7.31 binaries today and gives operators a recovery handle for any future case where the auto-trigger doesn't fire.

The longer-term fix is to push tags from `finalize-release.yml` using a GitHub App token instead of `GITHUB_TOKEN` so the cascade works automatically. This addition stays useful as the fallback path.

## Test plan

- [x] `actionlint .github/workflows/release.yml` — clean.
- [ ] After landing: `gh workflow run release.yml --ref v0.7.31`, verify binary tarballs and container land on the v0.7.31 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)