### PR TITLE
Add tag input to release workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,47 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to (re-)release, e.g. v0.7.31. Required for workflow_dispatch.'
+        required: true
+        type: string
 
 permissions:
   contents: write
   packages: write
 
 jobs:
+  setup:
+    name: Resolve target tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+      major_minor: ${{ steps.resolve.outputs.major_minor }}
+    steps:
+      - name: Resolve tag from event
+        id: resolve
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          TAG="${INPUT_TAG:-$REF_NAME}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::expected tag of form vX.Y.Z, got '$TAG'"
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          MAJOR_MINOR="$(echo "$VERSION" | awk -F. '{print $1"."$2}')"
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "major_minor=$MAJOR_MINOR"
+          } >> "$GITHUB_OUTPUT"
+
   build:
     name: Build ${{ matrix.target }}
+    needs: setup
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -27,6 +60,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.setup.outputs.tag }}
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # master
         with:
@@ -69,10 +104,12 @@ jobs:
 
   container:
     name: Publish Container
-    needs: build
+    needs: [setup, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.setup.outputs.tag }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
@@ -92,9 +129,15 @@ jobs:
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/burin-labs/harn
+          # Use raw tags computed from the resolved version so the
+          # workflow can publish for an explicit input.tag (recovery
+          # path) just as well as for an auto-fired tag push. The
+          # semver type=match,pattern=... approach only works when the
+          # workflow itself was triggered by a tag push, which the
+          # recovery / re-release path isn't.
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ needs.setup.outputs.version }}
+            type=raw,value=${{ needs.setup.outputs.major_minor }}
             type=raw,value=latest
 
       - name: Build and push container image
@@ -111,10 +154,12 @@ jobs:
 
   release:
     name: Create Release
-    needs: [build, container]
+    needs: [setup, build, container]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.setup.outputs.tag }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -125,11 +170,12 @@ jobs:
       - name: Render release notes from changelog
         run: |
           python3 scripts/render_release_notes.py \
-            --version "${GITHUB_REF_NAME#v}" \
+            --version "${{ needs.setup.outputs.version }}" \
             --output release-notes.md
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
+          tag_name: ${{ needs.setup.outputs.tag }}
           body_path: release-notes.md
           files: artifacts/*.tar.gz


### PR DESCRIPTION
## Summary

#499 added `workflow_dispatch:` to the Release workflow so operators could re-fire it for a specific tag, but `gh workflow run release.yml --ref vX.Y.Z` reads the workflow file AT that ref — any tag created before #499 has the older release.yml without `workflow_dispatch`, and the dispatch fails with `HTTP 422: Workflow does not have 'workflow_dispatch' trigger`. Hit this trying to recover v0.7.31 binaries.

Make the recovery path actually work:

- Add a required `tag` input to `workflow_dispatch`. Operators run from main: `gh workflow run release.yml --ref main -f tag=vX.Y.Z`.
- Add a `setup` job that resolves the effective tag from `inputs.tag` (dispatch) or `github.ref_name` (push), validates `vX.Y.Z` shape, and emits `tag`/`version`/`major_minor` outputs.
- Thread the resolved tag through every dependent job:
  - `actions/checkout ref:` so build/container/release run against tagged code.
  - `docker/metadata-action` switches from `type=semver` (tag-push only) to `type=raw` driven by setup outputs — recovery path produces identical container tags as auto path.
  - Release notes reads `version` from setup output.
  - `softprops/action-gh-release` gets explicit `tag_name`. Default "create or update" behavior makes recovery (release object already exists from a finalize-run-only path) idempotent.

The regular auto-trigger on tag push continues to work unchanged.

## Test plan

- [x] `actionlint .github/workflows/release.yml` — clean.
- [ ] After landing: `gh workflow run release.yml --ref main -f tag=v0.7.31` to recover the v0.7.31 binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)