### PR TITLE
Auto-open bump PR via Bump Release workflow

### DIFF
--- a/.claude/commands/release-harn.md
+++ b/.claude/commands/release-harn.md
@@ -1,177 +1,183 @@
-Run the merge-queue-safe Harn release workflow from the repo source of truth.
+Run the merge-queue-safe Harn release workflow.
 
 ## TL;DR
 
-```bash
-# From updated main, after the release-content PR has landed:
-./scripts/release_ship.sh --bump patch
+The **only** part of a release that requires human/agent intuition is writing
+and landing the **"Prepare vX.Y.Z release"** PR. Everything from there is
+automated:
+
+```text
+land "Prepare vX.Y.Z release" PR
+        │
+        ▼  Bump Release workflow auto-fires
+   opens "Bump version to X.Y.Z" PR
+        │
+        ▼  PR lands through merge queue
+   Finalize Release workflow auto-fires
+        │
+        ▼  pushes vX.Y.Z tag (under release-bot App identity)
+   Release workflow auto-fires
+        │
+        ▼  builds binaries + multi-arch container, populates GH release
+   v0.7.X is shipped
 ```
 
-`release_ship.sh --bump patch` handles audit, dry-run publish, version bump,
-branch push, and automated bump PR creation. After that PR lands through the
-merge queue, **the `Finalize Release` GitHub Action (`.github/workflows/finalize-release.yml`) runs `release_ship.sh --finalize` automatically** — it
-audits, tags, publishes to crates.io, and creates/updates the GitHub release.
-The human release path ends at opening the bump PR; the tag + publish are
-automated. Only run `./scripts/release_ship.sh --finalize` locally to recover
-from a failed workflow run, or manually re-trigger the workflow via "Run
-workflow" on the `Finalize Release` GitHub Actions page.
+You write the prepare PR. Walk away. The bot opens the bump PR. The merge
+queue lands it. The bot tags, publishes to crates.io, builds binaries,
+publishes the container, and creates the GitHub release with rendered notes.
 
-## Default workflow
+## What the human/agent owns
+
+Step 1-8 below are the only steps that need judgment. After step 8 you are
+done — do **not** run `release_ship.sh` locally as a default step.
 
 1. Inspect the worktree with `git status --short` and `git diff --stat`.
    Treat tracked and untracked changes as candidate release content unless the
    user scopes the release more narrowly.
 2. Read enough diff context to summarize the pending work accurately.
-3. Audit all pending changes for code quality, correctness, and test coverage.
-   For each changed module or feature, check whether existing Rust tests
-   and conformance tests (`conformance/tests/`) adequately cover the new or
+3. Audit all pending changes for code quality, correctness, and test
+   coverage. For each changed module or feature, check whether existing Rust
+   tests and conformance tests (`conformance/tests/`) cover the new or
    changed behavior. Fill gaps:
    - Add or update `#[test]` functions for new/changed Rust logic.
    - Add or update `.harn` + `.expected` conformance test pairs for any
      user-visible behavior changes or new builtins/features.
-   - Fix implementation bugs, edge cases, or incomplete code paths discovered
-     during the audit.
+   - Fix implementation bugs, edge cases, or incomplete code paths
+     discovered during the audit.
    - **Targeted tests first**: run tests only for changed crates during the
-     audit loop (e.g. `cargo nextest run -p harn-vm` or
-     `cargo test -p harn-vm`). This keeps the edit-test cycle fast.
+     audit loop (e.g. `cargo nextest run -p harn-vm`). Keeps the
+     edit-test cycle fast.
    - **Full gate last**: once the audit is complete and all targeted tests
-     pass, run `make test` (nextest when available, `cargo test --workspace`
-     as fallback) and `cargo run --bin harn -- test conformance` as the final
-     gate before committing.
+     pass, run `make test` and `cargo run --bin harn -- test conformance` as
+     the final gate before committing.
    Do not skip this step — shipping untested or buggy code is worse than
    delaying a release.
-4. Do a repo-consistency sweep before shipping. Update release-facing docs and
-   operator guidance as needed, especially `README.md`, `CLAUDE.md`,
-   `docs/src/`, `spec/HARN_SPEC.md`, `CHANGELOG.md`, and any developer setup
-   surfaces such as `scripts/dev_setup.sh`, `Makefile`, `.githooks/`,
-   `CONTRIBUTING.md`, and `docs/src/portal.md`.
+4. Repo-consistency sweep. Update release-facing docs and operator guidance
+   as needed: `README.md`, `CLAUDE.md`, `docs/src/`, `spec/HARN_SPEC.md`,
+   `CHANGELOG.md`, and developer-setup surfaces (`scripts/dev_setup.sh`,
+   `Makefile`, `.githooks/`, `CONTRIBUTING.md`, `docs/src/portal.md`).
 5. If syntax, parser, lexer, or tree-sitter changed, update
-   `spec/HARN_SPEC.md` first. Treat it as the formal language-spec source of
+   `spec/HARN_SPEC.md` first — it is the formal language-spec source of
    truth.
-6. Update `CHANGELOG.md` before bumping the version. The new top entry must
-   describe the actual pending code changes that will ship.
-7. Run `cargo fmt --all` once so the upcoming release content PR is
-   formatting-clean. `release_gate.sh audit` runs `cargo fmt -- --check` and
-   will reject drift later; catching it here avoids re-doing commits.
-8. Stage, commit, push, and open a "Prepare vX.Y.Z release" PR. Include every
-   file that ships in this version, including `CHANGELOG.md` and doc updates.
-   Do **not** include `Cargo.toml` / `Cargo.lock` version bumps in this PR —
-   the ship script produces those in a separate "Bump version to X.Y.Z" PR.
-9. After the release-content PR lands through the merge queue, sync `main` and
-   run `./scripts/release_ship.sh --bump patch` (or `minor`/`major`). The
-   script audits, dry-run publishes, bumps `Cargo.toml`, commits the bump,
-   pushes `release/vX.Y.Z`, and opens the bump PR.
-10. After the bump PR lands through the merge queue, the `Finalize Release`
-    GitHub Action runs `./scripts/release_ship.sh --finalize` automatically
-    against updated `main`. It audits, dry-run publishes, creates/pushes the
-    tag, publishes to crates.io, and creates/updates the GitHub release. Do
-    not run `--finalize` locally as a default step; only do so if the
-    workflow fails and the tree needs to be recovered manually. The
-    workflow also exposes a `workflow_dispatch` trigger for manual
-    re-runs from the GitHub Actions UI.
-11. For an all-in-one dry run that stops before any destructive action,
-    use `./scripts/release_gate.sh full --bump patch --dry-run`.
-12. Only drop down to the piecewise `release_gate.sh prepare` / `publish` /
-    `notes` commands when `release_ship.sh` cannot do what you need
-    (e.g. recovering a partial release).
+6. Update `CHANGELOG.md` with a new top entry `## vX.Y.Z` describing the
+   actual pending code changes that will ship. The version chosen here
+   (patch / minor / major bump from the current Cargo.toml version) drives
+   what the bot opens later — pick deliberately.
+7. Run `cargo fmt --all` once so the prep PR is formatting-clean.
+   `release_gate.sh audit` runs `cargo fmt -- --check` and will reject drift
+   later.
+8. Stage, commit, push, and open the **"Prepare vX.Y.Z release"** PR.
+   Include every file that ships in this version: code, docs,
+   `CHANGELOG.md`. Do **not** include `Cargo.toml` / `Cargo.lock` version
+   bumps in this PR — the bot's bump PR carries those.
+
+## What happens automatically after the prepare PR lands
+
+9. **Bump Release** workflow (`.github/workflows/bump-release.yml`) fires on
+   push to `main` when the head commit starts with `Prepare v`. It:
+   - Reads `CHANGELOG.md`'s top `## vX.Y.Z` entry, compares to
+     `Cargo.toml`'s current version, derives the bump type (patch / minor /
+     major) via `scripts/detect_bump_type.py`.
+   - Runs `./scripts/release_ship.sh --bump <type>` under the
+     `harn-release-bot` App identity: audit, dry-run publish, bump
+     `Cargo.toml` + `Cargo.lock`, commit `Bump version to X.Y.Z`, push
+     `release/vX.Y.Z`, open the bump PR.
+10. The bump PR's CI runs (because the App-pushed branch isn't suppressed
+    the way `GITHUB_TOKEN`-pushed branches are). Once green, the merge
+    queue lands it.
+11. **Finalize Release** workflow (`.github/workflows/finalize-release.yml`)
+    fires on push to `main` when the head commit starts with `Bump version
+    to`. It runs `./scripts/release_ship.sh --finalize` under the App
+    identity: audit, dry-run publish, push the tag, `cargo publish`, render
+    notes from `CHANGELOG.md`, create/update the GitHub release.
+12. The tag push triggers **Release** workflow
+    (`.github/workflows/release.yml`), which builds darwin/linux × x86/arm
+    binary tarballs, publishes a multi-arch GHCR container image, and
+    attaches the binaries to the GitHub release.
+
+## Recovery paths (don't reach for these unless something failed)
+
+- A workflow failed mid-run: **re-trigger from the Actions UI** (each
+  workflow exposes `workflow_dispatch`). All scripts are idempotent —
+  per-crate publish skips already-published, `ensure_tag_at_head` skips
+  if the tag already points where it should, `gh release` is
+  view-then-edit-or-create.
+- The Release workflow needs to re-emit binaries for an already-tagged
+  version: `gh workflow run release.yml --ref main -f tag=vX.Y.Z`. The
+  workflow accepts the tag input and runs at that tagged code.
+- A truly stuck local recovery (rare): `./scripts/release_ship.sh
+  --bump patch` or `./scripts/release_ship.sh --finalize` from updated
+  `main`.
 
 ## Source of truth
 
-Always prefer the repo scripts:
+When in doubt, prefer the repo scripts over re-inventing the steps:
 
 ```bash
+./scripts/release_ship.sh --bump patch         # only for local recovery
+./scripts/release_ship.sh --finalize           # only for local recovery
 ./scripts/release_gate.sh <audit|prepare|publish|notes|full> ...
-./scripts/release_ship.sh --bump patch
-./scripts/release_ship.sh --finalize
+./scripts/release_gate.sh full --bump patch --dry-run   # all-in-one dry run
 ```
-
-Do not re-invent the release ritual from memory if the script can do it.
-Use normal git commands for the parts that the release gate intentionally does
-not automate, such as analyzing pending local work and opening the
-"Prepare vX.Y.Z release" PR. Once that PR lands and the tree is clean, prefer
-`./scripts/release_ship.sh --bump patch` for the bump PR and
-`./scripts/release_ship.sh --finalize` for tag/publish mechanics.
 
 ## Rules
 
-- Report failures clearly and stop on the first failed gate.
-- Summarize the resulting version, bump PR or publish status, release notes,
-  and required tag/release follow-up.
-- If `mdbook` is not installed, mention that the docs audit skipped mdBook build.
-- If the tree is dirty, do not work around it silently for `prepare`; either
-  stop or commit the intended release content first.
-- If untracked files exist, call them out explicitly and decide whether they
-  belong in the release before staging them.
-- Treat repo consistency as part of the release gate, not an optional cleanup
-  pass. If behavior changes, update human-facing docs in the same release when
-  they describe that behavior.
-- If local development setup changed, keep `README.md`, `CONTRIBUTING.md`,
-  `scripts/dev_setup.sh`, and `Makefile` aligned so the bootstrap path stays
-  obvious and low-friction.
-- If observability surfaces changed, update `docs/src/portal.md` and any CLI
-  references that describe `harn portal`.
-- If grammar-related files changed, mention whether `spec/HARN_SPEC.md` was
-  updated in the same batch.
-- The grammar/spec audit includes `scripts/verify_language_spec.py`, which
-  extracts `harn` fences from `spec/HARN_SPEC.md` and runs `harn check` on
-  them. Treat failures there as spec drift, not just docs drift.
-- The grammar/spec audit also includes `scripts/verify_tree_sitter_parse.py`,
-  which sweeps positive `.harn` programs through the executable tree-sitter
-  grammar. Treat failures there as parser/grammar divergence.
+- Stop on the first failed gate. Report the actual error.
 - A real release has exactly two release commits on `main`, both landed via
   PR/merge queue: `Prepare vX.Y.Z release` (code + docs + `CHANGELOG.md`)
-  followed by `Bump version to X.Y.Z` (Cargo.toml + Cargo.lock only).
-  `release_ship.sh --bump patch` creates and opens the second PR
-  automatically; the human/agent creates the first.
-- `scripts/release_ship.sh --bump patch` assumes the real release content,
-  including docs consistency updates, has already landed through the merge
-  queue and the local `main` tree is clean before it starts.
-- `verify_release_metadata.py` accepts the pre-bump state — it passes when
-  the top `CHANGELOG.md` entry is exactly one patch/minor/major step ahead
-  of `Cargo.toml`. That means running `release_ship.sh --bump patch` on a
-  "Prepare vX.Y.Z release" commit is fine even though Cargo.toml still points
-  at the previous version.
-- `release_ship.sh --finalize` pushes the tag **before** calling
-  `cargo publish`, so GitHub release binary workflows and downstream fetchers
-  (e.g. `burin-code`'s `fetch-harn`) start working in parallel with crates.io
-  publication. The GitHub release body is created last so it can reference the
-  final crates.io state.
-- Finalize runs inside GitHub Actions via
-  `.github/workflows/finalize-release.yml`. The workflow fires on push to
-  `main` when the head commit starts with the prefix `Bump version to` (the
-  convention `release_ship.sh --bump` writes), and also exposes
-  `workflow_dispatch` for manual re-runs. It uses the repo secret
-  `CARGO_REGISTRY_TOKEN` for crates.io and the default `GITHUB_TOKEN` for
-  tag push + release creation. Running `release_ship.sh --finalize`
-  locally is only needed when the workflow fails and a human has to
-  recover — it is idempotent once the tag exists at HEAD.
-- `CHANGELOG.md` is the release-language source of truth. Use
-  `scripts/render_release_notes.py` or `./scripts/release_gate.sh notes` to
-  produce the exact GitHub release body from it.
+  followed by `Bump version to X.Y.Z` (Cargo.toml + Cargo.lock only). The
+  human/agent creates the first; the bot creates the second.
+- Treat repo consistency as part of the prepare PR, not an optional
+  cleanup pass. If behavior changes, update human-facing docs in the same
+  prep PR.
+- If syntax / parser / lexer / tree-sitter changed, update
+  `spec/HARN_SPEC.md` (the source of truth) and run
+  `scripts/sync_language_spec.sh` to regenerate the docs mirror.
+- The grammar/spec audit includes `scripts/verify_language_spec.py`
+  (extracts ` ```harn ` fences and runs `harn check`) and
+  `scripts/verify_tree_sitter_parse.py` (sweeps positive `.harn`
+  programs through the executable tree-sitter grammar). Treat failures
+  as spec drift, not just docs drift.
+- `verify_release_metadata.py` accepts the pre-bump state — it passes
+  when the top `CHANGELOG.md` entry is exactly one patch / minor / major
+  step ahead of `Cargo.toml`. The Bump Release workflow relies on this.
+- `release_ship.sh --finalize` pushes the tag **before** `cargo publish`
+  so binary build / GHCR / downstream fetchers (e.g. `burin-code`'s
+  `fetch-harn`) run in parallel with crates.io. Both the local script
+  and the Finalize Release workflow honor this ordering.
+- The release-bot App needs `Contents: write`, `Pull requests: write`,
+  `Actions: write`, `Metadata: read` on the repo. Repo secrets:
+  `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`, `CARGO_REGISTRY_TOKEN`.
+- `CHANGELOG.md` is the release-language source of truth. Notes are
+  rendered from it via `scripts/render_release_notes.py`.
 
 ## Audit wall-clock expectations
 
-`release_gate.sh audit` runs a serial `cargo build --workspace --all-targets`
-warm prebuild before spawning the 5 parallel lanes (`rust-audit`,
-`harn-audit`, `docs-audit`, `grammar-audit`, `security-audit`). The prebuild
-removes cargo-lock contention that historically made `harn-audit`'s lint
-phase stretch to ~12 min while fighting `rust-audit`'s clippy+nextest for
-`target/`. Typical wall-clock:
+`release_gate.sh audit` runs a serial `cargo build --workspace
+--all-targets` warm prebuild before spawning 5 parallel lanes
+(`rust-audit`, `harn-audit`, `docs-audit`, `grammar-audit`,
+`security-audit`). Typical wall-clock:
 
 - Cold `target/`: ~6-10 min, dominated by prebuild.
 - Warm `target/` after a recent build: ~10-30 s for the whole audit.
-- If any lane exceeds ~5 min after the prebuild, that is a regression —
-  check for a new `cargo`-shelling hotspot inside that lane rather than
-  assuming cold-cache cost.
+- A lane exceeding ~5 min after the prebuild is a regression worth
+  investigating, not cold-cache cost.
+
+In CI, both Bump Release and Finalize Release pay cold-cache audit cost
+(~8-12 min total). The audit + publish wall-clock is typical for a
+full release run.
 
 ## Useful shortcuts
 
 ```bash
-./scripts/release_ship.sh --bump patch               # open the bump PR
-./scripts/release_ship.sh --finalize                 # recovery only
+# All-in-one dry run, stops before any destructive action:
 ./scripts/release_gate.sh full --bump patch --dry-run
+
+# Render the GitHub release body locally from CHANGELOG.md:
 ./scripts/release_gate.sh notes
 
-# Manual re-trigger of the finalize workflow:
+# Manually re-trigger any of the workflows:
+gh workflow run bump-release.yml --ref main
 gh workflow run finalize-release.yml --ref main
+gh workflow run release.yml --ref main -f tag=vX.Y.Z
 ```

--- a/.codex/commands/harn-release.md
+++ b/.codex/commands/harn-release.md
@@ -1,102 +1,134 @@
 # Harn Release Command
 
-Run the merge-queue-safe Harn release workflow from the repo source of truth.
+Run the merge-queue-safe Harn release workflow.
 
-Default assumptions:
+The **only** part of a release that requires intuition is writing and landing
+the **"Prepare vX.Y.Z release"** PR. Everything from there is automated by
+GitHub Actions running under the `harn-release-bot` App identity.
 
-- Analyze the current worktree first with `git status --short`,
-  `git diff --stat`, and targeted `git diff` reads.
-- Use targeted crate tests during the audit loop, then run `make test` plus
-  `cargo run --bin harn -- test conformance` as the final Rust/conformance
-  gate before release. `make test` uses `cargo-nextest` when available and
-  falls back to `cargo test --workspace`.
-- Include all tracked and untracked local work in the release unless the user
-  scopes it differently.
-- Before any release mechanics, do a repo-consistency sweep and update
-  release-facing docs as needed, including `README.md`, `CLAUDE.md`,
-  `docs/src/`, `spec/HARN_SPEC.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, and
-  developer setup surfaces such as `scripts/dev_setup.sh`, `Makefile`,
-  `.githooks/`, and `docs/src/portal.md`.
-- Run `cargo fmt --all` once so the upcoming release content PR is
-  formatting-clean — `release_gate.sh audit` runs `cargo fmt -- --check` and
-  will reject drift later.
-- Open and land a "Prepare vX.Y.Z release" PR. Include every file that ships
-  in this version (code + docs + `CHANGELOG.md`) but **not** `Cargo.toml` /
-  `Cargo.lock` — `release_ship.sh` creates the "Bump version to X.Y.Z" PR
-  separately.
-- After that PR lands through the merge queue, sync `main` and run:
+## End-state flow
 
-```bash
-./scripts/release_ship.sh --bump patch
+```text
+human/agent: write "Prepare vX.Y.Z release" PR (changelog, docs, code)
+        │  ↓ lands through merge queue
+bot:    Bump Release workflow opens "Bump version to X.Y.Z" PR
+        │  ↓ CI green, lands through merge queue
+bot:    Finalize Release workflow tags + crates.io + GH release notes
+        │  ↓ tag push cascades
+bot:    Release workflow builds binaries + multi-arch container
+        │  ↓
+        v0.7.X is shipped (binaries, container, crates.io, release notes)
 ```
 
-- Adjust `patch` to `minor` or `major` if requested. This opens the automated
-  version-bump PR.
-- After the version-bump PR lands through the merge queue, the
-  `Finalize Release` GitHub Action
-  (`.github/workflows/finalize-release.yml`) runs `release_ship.sh --finalize`
-  automatically against updated `main`. Do not run the local `--finalize`
-  command as a default step. Only fall back to running it locally if the
-  workflow fails and a human has to recover, or re-trigger the workflow
-  via the GitHub Actions UI (it exposes a `workflow_dispatch` input):
+## What you (the agent) actually do
 
-```bash
-# Recovery path only — normally, the workflow does this for you.
-./scripts/release_ship.sh --finalize
+The work is in the prepare PR. After that, hands off.
 
-# Or re-trigger the workflow manually:
-gh workflow run finalize-release.yml --ref main
-```
+1. Inspect the worktree first with `git status --short` and `git diff --stat`.
+   Treat tracked and untracked changes as candidate release content unless
+   the user scopes it differently.
+2. Read enough diff context to summarize the pending work accurately.
+3. Audit pending changes for correctness and test coverage. Add Rust tests
+   or conformance pairs for new or changed user-visible behavior; fix bugs
+   discovered during the audit instead of shipping them.
+   - Targeted crate tests in the inner loop (`cargo nextest run -p harn-vm`).
+   - `make test` and `cargo run --bin harn -- test conformance` before
+     proceeding with release mechanics.
+4. Repo-consistency sweep. Update release-facing docs as needed:
+   `README.md`, `CLAUDE.md`, `docs/src/`, `spec/HARN_SPEC.md`,
+   `CHANGELOG.md`, and developer-setup surfaces (`scripts/dev_setup.sh`,
+   `Makefile`, `.githooks/`, the first-party `harn portal` docs).
+5. If syntax / parser / lexer / tree-sitter changed, update
+   `spec/HARN_SPEC.md` first. It is the formal language-spec source of
+   truth.
+6. Update `CHANGELOG.md` with a new top entry `## vX.Y.Z` describing the
+   actual pending code changes that will ship. The version chosen here
+   (patch / minor / major bump from the current Cargo.toml) drives what
+   the bot opens later — pick deliberately.
+7. Run `cargo fmt --all` once so the prep commit is formatting-clean.
+   `release_gate.sh audit` runs `cargo fmt -- --check` and rejects drift
+   later.
+8. Stage, commit, push, and open the **"Prepare vX.Y.Z release"** PR.
+   Include every file that ships in this version: code, docs,
+   `CHANGELOG.md`. Do **not** touch `Cargo.toml` / `Cargo.lock` version
+   strings — the bot's bump PR carries those.
 
-Rules:
+That's it. Stop here. The bot takes over.
 
-- `./scripts/release_ship.sh --bump patch` is the default mechanical entry
-  point once the release content and docs are consistent and landed on `main`.
-  It runs audit, dry-run publish, bump, commit, pushes `release/vX.Y.Z`, and
-  opens the version-bump PR. It does not tag, publish, or push to `main`.
-- `./scripts/release_ship.sh --finalize` runs only after the bump PR lands on
-  `main`. It runs audit, dry-run publish, creates/pushes the tag, publishes to
-  crates.io, and creates/updates the GitHub release. The tag push happens
-  **before** `cargo publish` so GitHub release-binary workflows and downstream
-  fetchers (e.g. `burin-code`'s `fetch-harn`) start in parallel with crates.io.
-  The GitHub release body is created last.
-- Finalize runs inside GitHub Actions via
-  `.github/workflows/finalize-release.yml`. The workflow fires on push to
-  `main` when the head commit starts with the prefix `Bump version to` (the convention
-  `release_ship.sh --bump` writes), and also exposes `workflow_dispatch` for
-  manual re-runs. It uses repo secret `CARGO_REGISTRY_TOKEN` for crates.io
-  and the default `GITHUB_TOKEN` for tag push + release creation. Local
-  `release_ship.sh --finalize` remains the recovery path and is idempotent
-  once the tag exists at HEAD.
-- `verify_release_metadata.py` accepts the pre-bump state — it passes when
-  `CHANGELOG.md` top is exactly one patch/minor/major step ahead of
-  `Cargo.toml`. That is why running `release_ship.sh --bump patch` on a
-  "Prepare vX.Y.Z release" commit is fine even though Cargo.toml still points
-  at the previous version.
-- Prefer `./scripts/release_gate.sh <audit|prepare|publish|notes|full>` over
-  ad hoc release commands only when working below the ship script (e.g.
-  recovering from a partial release).
-- Do not bypass a dirty tree silently for `prepare` or `release_ship.sh`;
-  either stop or commit the intended release content first.
-- If syntax, parser, lexer, or tree-sitter changed, update
-  `spec/HARN_SPEC.md` before the final gate.
-- If command behavior, release workflow, or operator guidance changed, update
-  `README.md`, `CLAUDE.md`, `CONTRIBUTING.md`, and mdBook pages that describe
-  the changed surface.
+## What happens automatically after the prepare PR lands
+
+- **`Bump Release`** workflow (`.github/workflows/bump-release.yml`) fires
+  on push to `main` when the head commit starts with `Prepare v`. It
+  derives the bump type via `scripts/detect_bump_type.py` (compares
+  `CHANGELOG.md` top entry to `Cargo.toml`), then runs
+  `./scripts/release_ship.sh --bump <type>` under the App identity. That
+  audits, dry-run publishes, bumps `Cargo.toml` + `Cargo.lock`, commits,
+  pushes `release/vX.Y.Z`, and opens the bump PR.
+- The bump PR's CI fires normally (App-pushed branches don't trigger
+  GHA's downstream-workflow suppression). Auto-merge on, queue lands it.
+- **`Finalize Release`** workflow
+  (`.github/workflows/finalize-release.yml`) fires on push to `main` when
+  the head commit starts with `Bump version to`. It runs
+  `./scripts/release_ship.sh --finalize` under the App identity: audit,
+  dry-run publish, push the tag, `cargo publish`, render notes, create
+  or update the GitHub release.
+- The tag push triggers **`Release`** workflow
+  (`.github/workflows/release.yml`), which builds the darwin/linux ×
+  x86/arm binary tarballs, publishes the multi-arch GHCR container, and
+  attaches the binaries to the GitHub release.
+
+## Recovery (only when something breaks)
+
+- **A workflow failed mid-run**: re-trigger from the GitHub Actions UI
+  (each workflow exposes `workflow_dispatch`). The scripts are
+  idempotent — per-crate publish skips already-published, the tag step
+  no-ops if it already points where it should, `gh release` is
+  view-then-edit-or-create.
+- **The Release workflow needs to re-emit binaries** for an
+  already-tagged version: `gh workflow run release.yml --ref main -f
+  tag=vX.Y.Z`. The workflow accepts the tag input and runs at that
+  tagged code.
+- **Truly stuck local recovery** (very rare): run
+  `./scripts/release_ship.sh --bump patch` or `--finalize` from updated
+  `main`. Same script the bot runs.
+
+## Rules
+
+- `release_ship.sh --bump` and `--finalize` are now bot-driven by
+  default. Running them locally is a recovery action, not the default
+  step. Never amend or skip the bot path silently.
+- A real release has exactly two release commits on `main`, both landed
+  via PR/merge queue: `Prepare vX.Y.Z release` (you) followed by
+  `Bump version to X.Y.Z` (bot).
+- Do not bypass a dirty tree silently for `prepare`; either stop or
+  commit the intended release content first.
+- If syntax / parser / lexer / tree-sitter changed, update
+  `spec/HARN_SPEC.md` before opening the prepare PR.
+- If command behavior, release workflow, or operator guidance changed,
+  update `README.md`, `CLAUDE.md`, `CONTRIBUTING.md`, and mdBook pages
+  that describe the changed surface in the same prep PR.
 - Treat `CHANGELOG.md` as the source of truth for GitHub release notes.
-- Summarize the shipped version, the release-content PR, the bump PR/commit,
-  publish status, and the exact notes body or compare link.
+  `scripts/render_release_notes.py` and `release_gate.sh notes` derive
+  the body from it.
 - `release_gate.sh audit` begins with a serial `cargo build --workspace
-  --all-targets` warm prebuild before spawning the five parallel lanes, so
-  the lanes don't serialize on the cargo lock. Expect ~6-10 min cold and
-  ~10-30 s with a warm target dir; lanes that exceed ~5 min after the
-  prebuild are real regressions.
+  --all-targets` warm prebuild before spawning the five parallel lanes.
+  Cold wall-clock ~6-10 min, warm ~10-30 s.
+- The release-bot App needs `Contents: write`, `Pull requests: write`,
+  `Actions: write`, `Metadata: read` installed on this repo. Repo
+  secrets that gate the workflows: `RELEASE_APP_ID`,
+  `RELEASE_APP_PRIVATE_KEY`, `CARGO_REGISTRY_TOKEN`.
 
-Useful shortcuts:
+## Useful shortcuts
 
 ```bash
-./scripts/release_ship.sh --bump patch
-./scripts/release_ship.sh --finalize
+# All-in-one dry run, stops before any destructive action:
 ./scripts/release_gate.sh full --bump patch --dry-run
+
+# Render the GitHub release body locally from CHANGELOG.md:
 ./scripts/release_gate.sh notes
+
+# Manually re-trigger workflows:
+gh workflow run bump-release.yml --ref main
+gh workflow run finalize-release.yml --ref main
+gh workflow run release.yml --ref main -f tag=vX.Y.Z
 ```

--- a/.codex/skills/harn-release/SKILL.md
+++ b/.codex/skills/harn-release/SKILL.md
@@ -5,219 +5,172 @@ description: Use this skill for Harn release prep, bump PRs, publishing, tagging
 
 # Harn Release Gate
 
-Use this skill when asked to run the final Harn release workflow, including
-analysis of pending local changes, repo-wide consistency updates, changelog
-prep, version-bump PR creation, crates.io publication, tagging, and
-release-note rendering.
+The **only** part of a Harn release that requires your intuition is writing
+and landing the **"Prepare vX.Y.Z release"** PR. Everything from there is
+automated by GitHub Actions running under the `harn-release-bot` App
+identity.
+
+## End-state flow
+
+```text
+human/agent: write "Prepare vX.Y.Z release" PR (changelog, docs, code)
+        │  ↓ lands through merge queue
+bot:    Bump Release workflow opens "Bump version to X.Y.Z" PR
+        │  ↓ CI green, lands through merge queue
+bot:    Finalize Release workflow tags + crates.io + GH release notes
+        │  ↓ tag push cascades
+bot:    Release workflow builds binaries + multi-arch container
+        │  ↓
+        v0.7.X is shipped
+```
+
+The three bot workflows live at:
+
+- `.github/workflows/bump-release.yml`
+- `.github/workflows/finalize-release.yml`
+- `.github/workflows/release.yml`
 
 ## Source of truth
 
-Always prefer the repo scripts:
+All bot workflows invoke the same scripts you'd run locally for recovery:
 
 ```bash
-./scripts/release_ship.sh --bump patch                     # open bump PR
-./scripts/release_ship.sh --finalize                       # tag/publish after merge
-./scripts/release_gate.sh <audit|prepare|publish|notes|full> ...  # piecewise
+# Recovery only — bot does these by default:
+./scripts/release_ship.sh --bump <patch|minor|major>
+./scripts/release_ship.sh --finalize
+
+# Lower-level pieces, when --bump/--finalize can't help:
+./scripts/release_gate.sh <audit|prepare|publish|notes|full> ...
 ```
 
-Do not re-invent the release ritual from memory if `release_ship.sh` can do
-it. Use normal git commands only for the parts that the release gate
-intentionally does not automate: analyzing pending local work and producing
-the "Prepare vX.Y.Z release" PR. Once that PR lands through the merge queue,
-`release_ship.sh --bump patch` handles audit, dry-run publish, bump-branch
-creation, version-bump commit, branch push, and PR creation. After the bump PR
-lands through the merge queue, the `Finalize Release` GitHub Action
-(`.github/workflows/finalize-release.yml`) runs `release_ship.sh --finalize`
-automatically, which tags `main`, publishes crates, renders notes, and
-creates/updates the GitHub release. Local `release_ship.sh --finalize` remains
-the recovery path when the workflow fails.
+Do not re-invent the release ritual from memory if the script can do it.
+The only step that is intentionally not scripted is producing the
+"Prepare vX.Y.Z release" PR.
 
 ## Merge-queue mode
 
-Direct pushes to `main` are not part of the release flow. The release has two
-merge-queue-reviewed PRs:
+A real release has exactly two release commits on `main`, both landed via
+PR/merge queue:
 
-1. `Prepare vX.Y.Z release` — code + docs + `CHANGELOG.md`, no Cargo version
-   bump.
-2. `Bump version to X.Y.Z` — `Cargo.toml` + `Cargo.lock` only, opened by
-   `./scripts/release_ship.sh --bump patch`.
+1. **`Prepare vX.Y.Z release`** — code + docs + `CHANGELOG.md`, no Cargo
+   version bump. Written by you.
+2. **`Bump version to X.Y.Z`** — `Cargo.toml` + `Cargo.lock` only,
+   opened by Bump Release workflow under the bot identity.
 
-Once the bump PR lands, the `Finalize Release` GitHub Action runs
-`./scripts/release_ship.sh --finalize` against updated `main` automatically.
-It fires on `push` to `main` when the head commit starts with
-the prefix `Bump version to` (which is exactly what `release_ship.sh --bump patch`
-writes), and also exposes `workflow_dispatch` for manual re-runs. Finalize
-creates/pushes the tag before `cargo publish` so release-binary workflows
-and downstream fetchers can still start in parallel with crates.io
-publication. Only run `--finalize` locally when the workflow fails and a
-human has to recover — the script is idempotent once the tag exists at HEAD.
+Watch the Actions runs after #1 lands. Do not poll local status. The
+finalize and release workflows fire downstream automatically.
 
-Both script phases run the release audit and stop on the first failed gate.
-Check the exit code when the bump script returns locally; for the finalize
-workflow, check the job status on the `Finalize Release` Actions page.
-If non-zero, the step names in stdout tell you which gate tripped.
+Failure modes, roughly in frequency order, with recovery:
 
-Typical wall-clock: ~6–10 min cold, ~2–4 min warm (sccache hot). Do not
-babysit it. Start the command and work on other things. Failure modes,
-roughly in frequency order:
-
-- `release_gate.sh audit` clippy/test failure → fix the code, re-commit
-  into the same "Prepare vX.Y.Z release" commit (amend), re-run.
-- `publish --dry-run` failure → usually a missing `include = [...]` file
-  in a crate manifest; fix and re-commit.
-- bump PR creation failure → the release bump branch has usually already been
-  pushed; create the PR manually from `release/vX.Y.Z` into `main`.
-- `cargo publish` rate-limit / transient network during finalize → re-run
-  the `Finalize Release` workflow via
-  `gh workflow run finalize-release.yml --ref main` (or run
-  `./scripts/release_ship.sh --finalize` locally); both are idempotent once
-  the tag exists at HEAD.
-- `gh release create` failure during finalize → the release is already on
-  crates.io and tagged; finish manually with
-  `gh release create <tag> --title <tag> --notes-file <rendered>`.
+- `release_gate.sh audit` clippy / test failure during bump or finalize:
+  fix the code in a small follow-up PR (treat it as release-prep
+  cleanup), let it land, then re-trigger the failed workflow via
+  `gh workflow run <name> --ref main`.
+- `publish --dry-run` failure: usually a missing `include = [...]` file
+  in a crate manifest. Fix in a small PR, re-trigger.
+- `cargo publish` rate-limit / transient network during finalize:
+  re-trigger Finalize Release; it falls back to per-crate publish and
+  treats `already exists on crates.io index` as success.
+- Release workflow needs to re-emit binaries for an already-tagged
+  version: `gh workflow run release.yml --ref main -f tag=vX.Y.Z`.
 
 ## Batching multiple tickets in one release
 
 When several unrelated tickets are ready to ship together:
 
-1. Merge each ticket's PR to `main` through the merge queue (each may carry a
-   one-line CHANGELOG addition under an "Unreleased" heading — that is
-   fine).
+1. Merge each ticket's PR to `main` through the merge queue (each may
+   carry a one-line CHANGELOG addition under an "Unreleased" heading —
+   that is fine).
 2. Immediately before releasing, consolidate the CHANGELOG: promote the
-   "Unreleased" section to `## [vX.Y.Z] - YYYY-MM-DD` with the grouped
-   entries and reference each closed ticket by number.
-3. Open and land a "Prepare vX.Y.Z release" PR with that consolidation
-   (docs/spec edits ride along if needed).
-4. From updated `main`, run `release_ship.sh --bump patch` once to open the
-   version-bump PR. The release covers all the batched tickets.
-5. After the bump PR lands, run `release_ship.sh --finalize`.
+   "Unreleased" section to `## vX.Y.Z` with the grouped entries and
+   reference each closed ticket by number.
+3. Open and land the **"Prepare vX.Y.Z release"** PR with that
+   consolidation (docs / spec edits ride along if needed).
+4. Walk away. The bot opens the bump PR, that lands, the bot finalizes.
 
 Prefer larger batches over many small releases when the tickets are
-topically related (e.g. the "iteration unblocker" pair, the "evidence
-stack" pair). A single batched release is one cargo publish cycle instead
-of N, and downstream consumers pick up a coherent surface.
+topically related. A single batched release is one cargo publish cycle
+instead of N, and downstream consumers pick up a coherent surface.
 
 ## Cross-repo iteration does not wait on releases
 
 Downstream repos (notably `burin-code`) can consume in-progress Harn
 changes without a release via `./scripts/fetch-harn.sh --local` in the
-consumer repo — it builds Harn from `~/projects/harn` in release mode and
-installs the binaries directly. Release batching exists to control the
-*published* version surface; it never blocks cross-repo iteration.
+consumer repo — it builds Harn from `~/projects/harn` in release mode
+and installs the binaries directly. Release batching exists to control
+the *published* version surface; it never blocks cross-repo iteration.
 
-## Default workflow
+## What you actually do for a release
 
-1. Inspect the worktree first with `git status --short` and `git diff --stat`.
-   Treat tracked and untracked changes as candidate release content unless the
-   user scopes the release more narrowly.
+Steps 1-8 are the only ones requiring judgment. After step 8 you are
+done — do **not** run `release_ship.sh` locally as a default step.
+
+1. Inspect the worktree first with `git status --short` and
+   `git diff --stat`. Treat tracked and untracked changes as candidate
+   release content unless the user scopes the release more narrowly.
 2. Read enough diff context to summarize the pending work accurately.
-3. Audit pending changes for correctness and test coverage. Add Rust tests or
-   conformance pairs for new or changed user-visible behavior; fix bugs
-   discovered during the audit instead of shipping them.
-   - Run targeted crate tests during the inner loop (`cargo nextest run -p harn-vm`
-     or `cargo test -p harn-vm`) so iteration stays fast.
-   - Run `make test` and `cargo run --bin harn -- test conformance` before
-     proceeding with the release mechanics. `make test` uses `cargo-nextest`
-     when available and falls back to `cargo test --workspace`.
-4. Do a repo-consistency sweep before shipping. Update release-facing docs and
-   operator guidance as needed, especially `README.md`, `CLAUDE.md`,
-   `docs/src/`, `spec/HARN_SPEC.md`, `CHANGELOG.md`, and any developer setup
-   surfaces such as `scripts/dev_setup.sh`, `Makefile`, `.githooks/`, and the
-   first-party `harn portal` docs.
-5. If syntax, parser, lexer, or tree-sitter changed, update
-   `spec/HARN_SPEC.md` first. Treat it as the formal language-spec source of
-   truth.
-6. Update `CHANGELOG.md` before bumping the version. The new top entry must
-   describe the actual pending code changes that will ship.
-7. Run `cargo fmt --all` once so the upcoming release content commit is
-   formatting-clean. `release_gate.sh audit` runs `cargo fmt -- --check` and
-   will reject drift later; catching it here avoids re-doing commits.
-8. Stage, commit, push, and open a "Prepare vX.Y.Z release" PR. Include every
-   file that ships in this version, including `CHANGELOG.md` and docs updates.
-   Do **not** touch `Cargo.toml` / `Cargo.lock` version strings — the bump PR
-   is separate.
-9. After the release-content PR lands through the merge queue, sync `main` and
-   run `./scripts/release_ship.sh --bump patch` (or `minor`/`major`). The
-   script runs audit, dry-run publish, creates `release/vX.Y.Z`, commits the
-   Cargo version bump, pushes that branch, and opens the bump PR.
-10. After the bump PR lands through the merge queue, the `Finalize Release`
-    GitHub Action runs `./scripts/release_ship.sh --finalize` automatically
-    against updated `main`. The workflow runs audit, dry-run publish,
-    creates/pushes the tag, publishes to crates.io, renders notes, and
-    creates/updates the GitHub release. Watch the run on the Actions page;
-    only run `--finalize` locally as a recovery step if the workflow
-    fails (it is idempotent once the tag exists at HEAD).
-11. For an all-in-one dry run that stops before any destructive action, use
-    `./scripts/release_gate.sh full --bump patch --dry-run`.
-12. Only fall back to the piecewise `release_gate.sh prepare` / `publish` /
-    `notes` commands when `release_ship.sh` cannot do what you need
-    (e.g. recovering a partial release).
+3. Audit pending changes for correctness and test coverage. Add Rust
+   tests or conformance pairs for new or changed user-visible behavior;
+   fix bugs discovered during the audit instead of shipping them.
+   - Targeted crate tests during the inner loop (`cargo nextest run -p
+     harn-vm` or `cargo test -p harn-vm`).
+   - `make test` and `cargo run --bin harn -- test conformance` before
+     proceeding with release mechanics.
+4. Repo-consistency sweep before shipping. Update release-facing docs
+   and operator guidance as needed: `README.md`, `CLAUDE.md`,
+   `docs/src/`, `spec/HARN_SPEC.md`, `CHANGELOG.md`, and developer-setup
+   surfaces (`scripts/dev_setup.sh`, `Makefile`, `.githooks/`,
+   `docs/src/portal.md`).
+5. If syntax / parser / lexer / tree-sitter changed, update
+   `spec/HARN_SPEC.md` first — formal language-spec source of truth.
+6. Update `CHANGELOG.md` with a new top entry `## vX.Y.Z`. The version
+   chosen here drives the bump type the bot derives. Pick deliberately.
+7. Run `cargo fmt --all` once so the prep commit is formatting-clean.
+8. Stage, commit, push, open the **"Prepare vX.Y.Z release"** PR.
+   Include code + docs + `CHANGELOG.md` for this version. Do **not**
+   include `Cargo.toml` / `Cargo.lock` version bumps.
 
 ## Expectations
 
-- Report failures clearly and stop on the first failed gate.
-- Summarize the resulting version, bump PR or publish status, release notes,
-  and required tag/release follow-up.
-- If `mdbook` is not installed, mention that the docs audit skipped mdBook build.
-- If the tree is dirty, do not work around it silently for `prepare`; either
-  stop or commit the intended release content first.
-- If untracked files exist, call them out explicitly and decide whether they
-  belong in the release before staging them.
-- Treat repo consistency as part of the release gate, not an optional cleanup
-  pass. If behavior changes, update human-facing docs in the same release when
-  they describe that behavior.
-- If local development setup changed, keep `README.md`, `CONTRIBUTING.md`,
-  `scripts/dev_setup.sh`, and `Makefile` aligned so the bootstrap path stays
-  obvious and low-friction.
-- If observability surfaces changed, update `docs/src/portal.md` and any CLI
-  references that describe `harn portal`.
-- If grammar-related files changed, mention whether `spec/HARN_SPEC.md` was
-  updated in the same batch.
-- The grammar/spec audit now includes `scripts/verify_language_spec.py`, which
-  extracts `harn` fences from `spec/HARN_SPEC.md` and runs `harn check` on
-  them. Treat failures there as spec drift, not just docs drift.
-- The grammar/spec audit also includes `scripts/verify_tree_sitter_parse.py`,
-  which sweeps positive `.harn` programs through the executable tree-sitter
-  grammar. Treat failures there as parser/grammar divergence.
+- Stop on the first failed gate in the prepare PR. Do not paper over.
+- Once the prepare PR lands, watch the Actions UI. The bump → finalize →
+  release cascade should complete in ~20-30 min wall-clock total. Each
+  workflow has `workflow_dispatch` for manual recovery.
+- Treat repo consistency as part of the prepare PR, not an optional
+  cleanup pass. If behavior changes, update human-facing docs in the
+  same prep PR.
+- The grammar / spec audit includes `scripts/verify_language_spec.py`
+  (extracts ` ```harn ` fences from `spec/HARN_SPEC.md` and runs `harn
+  check`) and `scripts/verify_tree_sitter_parse.py` (sweeps positive
+  `.harn` programs through the executable tree-sitter grammar). Treat
+  failures as spec drift, not just docs drift.
 
 ## Notes
 
-- `scripts/publish.sh` remains the crates.io publisher.
-- `CHANGELOG.md` is the release-language source of truth. Use
-  `scripts/render_release_notes.py` or `./scripts/release_gate.sh notes` to
-  produce the exact GitHub release body from it.
-- GitHub release artifacts are produced by the existing release workflow once
-  the tag is pushed during finalize.
+- `scripts/publish.sh` remains the crates.io publisher. It tries
+  `cargo publish --workspace` first with retries, then falls back to
+  per-crate publish where `already exists on crates.io index` is
+  treated as success — so partial-publish recovery is automatic.
+- `CHANGELOG.md` is the release-language source of truth. Notes are
+  rendered from it by `scripts/render_release_notes.py` /
+  `scripts/release_gate.sh notes`.
+- GitHub release artifacts (binary tarballs + GHCR container) are
+  produced by `release.yml` once the tag is pushed. Tag push from
+  Finalize Release uses the App identity, so the cascade fires
+  normally — `GITHUB_TOKEN`-pushed tags would NOT trigger it.
 - `release_ship.sh --finalize` pushes the tag **before** running
   `cargo publish`, so the GitHub release-binary workflow and downstream
-  fetchers (e.g. `burin-code`'s `fetch-harn`) can start working in parallel
-  with crates.io publication. The GitHub release body is created last so it
-  reflects the final crates.io + git state.
-- The `Finalize Release` workflow
-  (`.github/workflows/finalize-release.yml`) runs `--finalize` inside
-  GitHub Actions whenever a `Bump version to X.Y.Z` commit lands on
-  `main`. It authenticates to crates.io with repo secret
-  `CARGO_REGISTRY_TOKEN` and to GitHub with the default `GITHUB_TOKEN`.
-  `workflow_dispatch` is the manual re-trigger. Running `--finalize`
-  locally is still supported for recovery but is not the default
-  post-bump step.
-- A real release has exactly two release commits on `main`, both landed via
-  PR/merge queue: `Prepare vX.Y.Z release` (code + docs + `CHANGELOG.md`)
-  followed by `Bump version to X.Y.Z` (Cargo.toml + Cargo.lock only).
-  `release_ship.sh --bump patch` creates and opens the second PR
-  automatically; the human/agent creates the first.
-- `scripts/release_ship.sh --bump patch` assumes the real release content,
-  including docs consistency updates, has already landed through the merge
-  queue and the local `main` tree is clean before it starts. `--finalize`
-  assumes the automated bump PR has landed through the merge queue.
-- `verify_release_metadata.py` (run from `release_gate.sh audit`) accepts the
-  pre-bump state: it passes when the top `CHANGELOG.md` entry is exactly one
-  patch/minor/major step ahead of `Cargo.toml`. Running audit on a "Prepare
-  vX.Y.Z release" commit is fine even though Cargo.toml still points at the
-  previous version.
+  fetchers (e.g. `burin-code`'s `fetch-harn`) can start working in
+  parallel with crates.io publication.
+- `verify_release_metadata.py` (run from `release_gate.sh audit`)
+  accepts the pre-bump state: it passes when the top `CHANGELOG.md`
+  entry is exactly one patch / minor / major step ahead of `Cargo.toml`.
+  The Bump Release workflow's `scripts/detect_bump_type.py` relies on
+  this same invariant.
 - `release_gate.sh audit` starts with a serial
-  `cargo build --workspace --all-targets` warm prebuild before spawning the
-  five parallel lanes. Cold wall-clock is typically ~6-10 min (dominated by
-  the prebuild); a warm-cache audit finishes in ~10-30 s. Any lane that
-  exceeds ~5 min after the prebuild is a real regression, not cold-cache
-  noise.
+  `cargo build --workspace --all-targets` warm prebuild before spawning
+  the five parallel lanes. Cold ~6-10 min, warm ~10-30 s.
+- The release-bot App needs `Contents: write`, `Pull requests: write`,
+  `Actions: write`, `Metadata: read` installed on this repo. Required
+  repo secrets: `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`,
+  `CARGO_REGISTRY_TOKEN`.

--- a/.codex/skills/release-harn/SKILL.md
+++ b/.codex/skills/release-harn/SKILL.md
@@ -7,32 +7,24 @@ description: Alias for the Harn release workflow skill.
 
 Use the same workflow as [`harn-release`](../harn-release/SKILL.md).
 
-The repo source of truth remains:
+The **only** human/agent-driven step is writing and landing the
+**"Prepare vX.Y.Z release"** PR. After that, three GitHub Actions
+workflows cascade automatically under the `harn-release-bot` App
+identity:
 
-```bash
-./scripts/dev_setup.sh
-./scripts/release_ship.sh --bump patch                     # open bump PR
-./scripts/release_ship.sh --finalize                       # recovery only — normally automated
-./scripts/release_gate.sh <audit|prepare|publish|notes|full> ...  # piecewise
+```text
+land "Prepare vX.Y.Z release" → Bump Release opens "Bump version" PR
+        → Bump PR lands → Finalize Release tags + publishes crates.io
+        → tag push → Release builds binaries + GHCR container
 ```
 
-Direct pushes to `main` are not part of the release flow. After the release
-content PR lands through the merge queue, `release_ship.sh --bump patch` runs
-audit → dry-run publish → bump → commit → push `release/vX.Y.Z` → open a bump
-PR. After the bump PR lands, the `Finalize Release` GitHub Action
-(`.github/workflows/finalize-release.yml`) runs `release_ship.sh --finalize`
-automatically: audit → dry-run publish → tag → push tag → `cargo publish` →
-render notes → create/update the GitHub release. The tag push happens before
-`cargo publish` so downstream consumers (e.g. `burin-code`'s `fetch-harn`,
-GitHub release-binary workflows) can start working in parallel with crates.io.
+The repo source of truth (only invoke locally for recovery):
 
-**Merge-queue flow:** land a "Prepare vX.Y.Z release" PR first, run
-`release_ship.sh --bump patch` from updated `main` to open the automated bump
-PR, then wait for the bump PR to land through the merge queue — the
-`Finalize Release` workflow fires automatically and completes the release.
-Watch the Actions run on the `Finalize Release` page; `workflow_dispatch`
-is available for manual re-triggers. Only run `release_ship.sh --finalize`
-locally if the workflow fails and a human has to recover.
+```bash
+./scripts/release_ship.sh --bump <patch|minor|major>   # recovery only
+./scripts/release_ship.sh --finalize                   # recovery only
+./scripts/release_gate.sh <audit|prepare|publish|notes|full> ...
+```
 
 **Cross-repo consumers do not wait on releases.** `burin-code`'s
 `scripts/fetch-harn.sh --local` builds Harn from `~/projects/harn` and
@@ -40,8 +32,8 @@ installs the binaries directly — use it during cross-repo iteration
 instead of waiting for crates.io. Release batching is a published-version
 concern, not a developer-loop concern.
 
-Before releasing, make sure the local developer workflow and observability
-surface are documented coherently:
+Before opening the prepare PR, make sure the local developer workflow and
+observability surface are documented coherently:
 
 - `README.md`
 - `CONTRIBUTING.md`
@@ -52,9 +44,28 @@ surface are documented coherently:
 
 Commit pattern for a real release:
 
-1. `Prepare vX.Y.Z release` — code + docs + `CHANGELOG.md`, no Cargo.toml,
-   landed through PR/merge queue.
-2. `Bump version to X.Y.Z` — created automatically by `release_ship.sh --bump
-   patch`, landed through PR/merge queue. This commit landing on `main`
-   triggers the `Finalize Release` workflow, which produces the tag and
-   crates.io + GitHub release without further human action.
+1. **`Prepare vX.Y.Z release`** — code + docs + `CHANGELOG.md`, no
+   Cargo.toml. Authored by you, landed through PR/merge queue.
+2. **`Bump version to X.Y.Z`** — `Cargo.toml` + `Cargo.lock` only,
+   opened by Bump Release workflow under the bot identity, landed
+   through PR/merge queue. Triggers Finalize Release on landing.
+
+Workflows:
+
+- `.github/workflows/bump-release.yml` — fires on `Prepare v` commits.
+- `.github/workflows/finalize-release.yml` — fires on `Bump version to`
+  commits. Pushes the tag using the App token so downstream cascades
+  fire (a `GITHUB_TOKEN` tag push would be suppressed by GHA).
+- `.github/workflows/release.yml` — fires on tag push. Also accepts a
+  `tag` input via `workflow_dispatch` for re-running against an existing
+  tag.
+
+All three expose `workflow_dispatch` for manual recovery. `gh workflow
+run <name> --ref main` re-fires.
+
+Required repo state:
+
+- Secrets: `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`,
+  `CARGO_REGISTRY_TOKEN`.
+- App permissions on the repo: `Contents: write`, `Pull requests:
+  write`, `Actions: write`, `Metadata: read`.

--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -1,0 +1,145 @@
+name: Bump Release
+
+# Fires when a "Prepare vX.Y.Z release" commit lands on main through the
+# merge queue. Runs ./scripts/release_ship.sh --bump <type> under the
+# release-bot App identity, which audits, dry-run publishes, bumps
+# Cargo.toml + Cargo.lock, commits, pushes release/vX.Y.Z, and opens
+# the "Bump version to X.Y.Z" PR. The bump PR's CI fires normally
+# (App-pushed branch IS subject to downstream workflows), and once it
+# lands the Finalize Release workflow takes over to tag, publish to
+# crates.io, cascade to the Release workflow for binaries, and create
+# the GitHub release.
+#
+# End-state human flow: write and land "Prepare vX.Y.Z release". Walk
+# away. Everything else is automated.
+#
+# workflow_dispatch is the manual recovery path — if this workflow
+# fails mid-run, re-run it; release_ship.sh's bump path is idempotent
+# in the sense that the existing release/vX.Y.Z branch will be
+# re-pushed cleanly.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: bump-release
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  bump:
+    name: Open bump PR
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.head_commit.message, 'Prepare v')
+    steps:
+      # Mint a short-lived App installation token so the bump branch
+      # push and the bump PR are authored by harn-release-bot. Using
+      # the App identity also means the bump PR's CI will fire
+      # normally (GHA suppresses downstream workflows on
+      # GITHUB_TOKEN-authenticated pushes; App tokens bypass that).
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Detect bump type from CHANGELOG vs Cargo.toml
+        id: bump
+        run: |
+          set +e
+          BUMP="$(python3 scripts/detect_bump_type.py)"
+          rc=$?
+          set -e
+          if [[ $rc -eq 2 ]]; then
+            echo "::notice::No bump needed (Cargo.toml and CHANGELOG already match)."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ $rc -ne 0 ]]; then
+            echo "::error::detect_bump_type.py failed with exit code $rc"
+            exit $rc
+          fi
+          echo "type=$BUMP" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "Detected bump type: $BUMP"
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        if: steps.bump.outputs.skip != 'true'
+        with:
+          components: clippy, rustfmt
+
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+        if: steps.bump.outputs.skip != 'true'
+
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.9.1
+        if: steps.bump.outputs.skip != 'true'
+        with:
+          shared-key: workspace
+
+      - name: Install cargo-nextest
+        if: steps.bump.outputs.skip != 'true'
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
+        continue-on-error: true
+        with:
+          tool: nextest@0.9.133
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        if: steps.bump.outputs.skip != 'true'
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: crates/harn-cli/portal/package-lock.json
+
+      - name: Install portal dependencies
+        if: steps.bump.outputs.skip != 'true'
+        working-directory: crates/harn-cli/portal
+        run: npm ci
+
+      - name: Install ripgrep
+        # security-audit lane greps the repo via `rg` — install
+        # explicitly to match the local dev expectation.
+        if: steps.bump.outputs.skip != 'true'
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Build tree-sitter grammar
+        # grammar-audit's verify_tree_sitter_parse.py loads the
+        # compiled grammar from tree-sitter-harn/harn.{so,dylib}.
+        if: steps.bump.outputs.skip != 'true'
+        working-directory: tree-sitter-harn
+        run: |
+          npm ci
+          npm run build
+
+      - name: Configure git identity
+        if: steps.bump.outputs.skip != 'true'
+        run: |
+          git config --global user.name "harn-release-bot[bot]"
+          git config --global user.email "harn-release-bot[bot]@users.noreply.github.com"
+
+      - name: Run release_ship.sh --bump
+        if: steps.bump.outputs.skip != 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          # gh CLI inside release_ship.sh uses GH_TOKEN for `gh pr
+          # create`. Using the App token makes the bump PR author the
+          # bot, consistent with the branch pusher.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: ./scripts/release_ship.sh --bump ${{ steps.bump.outputs.type }}

--- a/scripts/detect_bump_type.py
+++ b/scripts/detect_bump_type.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Print the semver bump type that takes Cargo.toml's workspace version to
+CHANGELOG.md's top-entry version.
+
+Used by .github/workflows/bump-release.yml to derive the right
+`release_ship.sh --bump <type>` flag automatically when a "Prepare
+vX.Y.Z release" commit lands on main. The version comparison is
+canonical via CHANGELOG (verify_release_metadata.py already enforces
+that the top entry is exactly one patch/minor/major step ahead of
+Cargo.toml at prepare time), so this script just figures out which
+step it is.
+
+Exits 0 with `patch`, `minor`, or `major` on stdout. Exits non-zero
+on shape mismatch with a human-readable error on stderr.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CARGO_PATH = ROOT / "Cargo.toml"
+CHANGELOG_PATH = ROOT / "CHANGELOG.md"
+
+
+def read_cargo_version() -> str:
+    text = CARGO_PATH.read_text()
+    match = re.search(r'^version = "([^"]+)"', text, re.MULTILINE)
+    if not match:
+        raise SystemExit(f"error: could not find workspace version in {CARGO_PATH}")
+    return match.group(1)
+
+
+def read_changelog_top_version() -> str:
+    text = CHANGELOG_PATH.read_text()
+    for line in text.splitlines():
+        match = re.match(r"^## v(\d+\.\d+\.\d+)\s*$", line)
+        if match:
+            return match.group(1)
+    raise SystemExit(f"error: no `## vX.Y.Z` heading found in {CHANGELOG_PATH}")
+
+
+def parse(version: str) -> tuple[int, int, int]:
+    parts = version.split(".")
+    if len(parts) != 3:
+        raise SystemExit(f"error: not semver: {version}")
+    try:
+        return tuple(int(p) for p in parts)  # type: ignore[return-value]
+    except ValueError as exc:
+        raise SystemExit(f"error: not semver: {version}") from exc
+
+
+def detect(current: str, target: str) -> str:
+    cmaj, cmin, cpat = parse(current)
+    tmaj, tmin, tpat = parse(target)
+    if (tmaj, tmin, tpat) == (cmaj + 1, 0, 0):
+        return "major"
+    if (tmaj, tmin, tpat) == (cmaj, cmin + 1, 0):
+        return "minor"
+    if (tmaj, tmin, tpat) == (cmaj, cmin, cpat + 1):
+        return "patch"
+    raise SystemExit(
+        f"error: {current} -> {target} is not a single patch/minor/major bump"
+    )
+
+
+def main() -> int:
+    current = read_cargo_version()
+    target = read_changelog_top_version()
+    if current == target:
+        # Bump already applied; nothing to do. Exit 2 so the workflow
+        # can distinguish "no-op" from "real error".
+        print(f"warning: Cargo.toml and CHANGELOG.md both at {current}; nothing to bump", file=sys.stderr)
+        return 2
+    print(detect(current, target))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

End-state: the **only** release step requiring human/agent intuition is writing and landing the **"Prepare vX.Y.Z release"** PR. Everything from there is automated by GitHub Actions running under the `harn-release-bot` App identity:

```
land "Prepare vX.Y.Z release" PR
        │
        ▼  Bump Release workflow auto-fires
   opens "Bump version to X.Y.Z" PR
        │
        ▼  PR lands through merge queue
   Finalize Release workflow auto-fires
        │
        ▼  pushes vX.Y.Z tag (under release-bot App identity)
   Release workflow auto-fires
        │
        ▼  builds binaries + multi-arch container, populates GH release
```

## Changes

- **`.github/workflows/bump-release.yml`** — fires on push to main when the head commit starts with `Prepare v`. Mints an App token, derives the bump type via `scripts/detect_bump_type.py` (compares CHANGELOG top entry to Cargo.toml workspace version), and runs `release_ship.sh --bump <type>` under the App identity. The bump PR is then authored by the bot — App-pushed branches are NOT subject to GHA's downstream-workflow suppression, so the bump PR's CI fires normally and auto-merge can carry it through the queue.
- **`scripts/detect_bump_type.py`** — prints `patch`, `minor`, or `major` by comparing Cargo.toml to CHANGELOG.md's top `## vX.Y.Z` heading. Exits 2 on no-op (versions already match) so the workflow can distinguish "nothing to do" from a real failure.
- **Updated release-harn skill/command** for both Claude (`.claude/commands/release-harn.md`) and Codex (`.codex/commands/harn-release.md`, `.codex/skills/harn-release/SKILL.md`, `.codex/skills/release-harn/SKILL.md`) to reflect that step 8 (open the prepare PR) is the last step the agent owns. Steps 9-12 (bump PR, finalize, binaries, GH release) are now the bot's responsibility, with `workflow_dispatch` as the recovery handle on each.

## Required repo state (already configured)

- Secrets: `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`, `CARGO_REGISTRY_TOKEN`.
- `harn-release-bot` App permissions on this repo: `Contents: write`, `Pull requests: write`, `Actions: write`, `Metadata: read`.

## Test plan

- [x] `actionlint .github/workflows/bump-release.yml` — clean.
- [x] `python3 scripts/detect_bump_type.py` on current main (Cargo=0.7.31, CHANGELOG=0.7.31) → exits 2 with no-op message, doesn't fail.
- [ ] Next release: write a "Prepare v0.7.32 release" PR, land it, verify the bot opens "Bump version to 0.7.32" PR within ~10 min.

## Order of merge

This PR depends on #500 (App token wired into finalize-release.yml) being live so the same App identity is consistently the release author. #500 should land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)