### PR TITLE
[codex] Add prompt library stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ granular archaeology.
 
 ### Added
 
+- **Prompt Librarian stdlib (#313).** Adds `std/prompt_library` for reusable
+  prompt fragments, TOML/front-matter `.harn.prompt` catalog loading, cached
+  fragment payload metadata, tenant-scoped k-means hotspot proposals, and a
+  review-queue shape for host/portal handoff.
 - **`jwt_sign` crypto builtin (#454).** New
   `jwt_sign(alg, claims, private_key)` stdlib builtin produces compact
   JWT/JWS tokens signed with ES256 (P-256 PEM) or RS256 (RSA PEM) keys,

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ enforcement.
   `schema_parse(...)`, `schema_is(...)`, JSON Schema/OpenAPI conversion, and
   schema composition helpers, plus a lazy `std/schema` builder module for
   ergonomic schema authoring when imported.
+- Prompt fragment reuse via `import "std/prompt_library"`: load TOML catalogs
+  or front-matter `.harn.prompt` files, render cache-aware fragment payloads,
+  and propose tenant-scoped k-means hotspots for repeated context prefixes.
 - Deterministic vision OCR via `vision_ocr(...)` and `import "std/vision"`:
   image path / payload normalization, structured text output
   (`blocks`, `lines`, `tokens`), and event-log-backed OCR audit records for

--- a/conformance/tests/stdlib/prompt_library.expected
+++ b/conformance/tests/stdlib/prompt_library.expected
@@ -1,0 +1,1 @@
+[harn] prompt_library ok

--- a/conformance/tests/stdlib/prompt_library.harn
+++ b/conformance/tests/stdlib/prompt_library.harn
@@ -1,0 +1,88 @@
+import "std/prompt_library"
+
+pipeline test(task) {
+  write_file(
+    "prompt_library_catalog.toml",
+    "[[prompt_fragments]]\n"
+    + "id = \"rust-repo-conventions-v1\"\n"
+    + "title = \"Rust repo conventions\"\n"
+    + "tags = [\"rust\", \"testing\"]\n"
+    + "token_budget = 16\n"
+    + "cache_ttl = \"5m\"\n"
+    + "body = \"Use nextest for {{crate}} and keep sccache warm.\"\n",
+  )
+  write_file(
+    "prompt_library_front.harn.prompt",
+    "---\n"
+    + "id = \"ops-prefix\"\n"
+    + "title = \"Ops prefix\"\n"
+    + "tags = [\"ops\"]\n"
+    + "---\n"
+    + "Operate in {{env}} with low-noise status updates.",
+  )
+  let library = prompt_library_load(["prompt_library_catalog.toml", "prompt_library_front.harn.prompt"])
+  assert_eq(
+    prompt_library_inject(library, "rust-repo-conventions-v1", {crate: "harn-vm"}),
+    "Use nextest for harn-vm and keep sccache warm.",
+  )
+  assert_eq(prompt_library_list(library, {tag: "ops"})[0].id, "ops-prefix")
+  assert_eq(
+    prompt_library_payload(library, "ops-prefix", {env: "prod"}).cache_control.type,
+    "ephemeral",
+  )
+  let api = prompt_library_api(library)
+  assert_eq(
+    api.inject("ops-prefix", {env: "staging"}),
+    "Operate in staging with low-noise status updates.",
+  )
+  assert_eq(len(api.suggest({tags: ["rust"], limit: 1})), 1)
+  assert_eq(
+    prompt_library_suggest(library, {query: "sccache", limit: 1})[0].id,
+    "rust-repo-conventions-v1",
+  )
+  assert(
+    contains(
+    prompt_library_inject_cluster(library, {tag: "rust", max_tokens: 20}, {crate: "parser"}),
+    "parser",
+  ),
+  )
+  let conversations = [
+    {
+    id: "a1",
+    tenant_id: "tenant-a",
+    text: "System repo rust testing conventions use nextest sccache cargo workspace shared alpha",
+    embedding: [0.0, 0.0],
+  },
+    {
+    id: "a2",
+    tenant_id: "tenant-a",
+    text: "System repo rust testing conventions use nextest sccache cargo workspace shared beta",
+    embedding: [0.0, 0.1],
+  },
+    {
+    id: "b1",
+    tenant_id: "tenant-b",
+    text: "System docs api reference conventions publish mdbook snippets separately",
+    embedding: [10.0, 10.0],
+  },
+  ]
+  let proposals = prompt_library_hotspots(
+    conversations,
+    {
+    tenant_id: "tenant-a",
+    k: 1,
+    min_shared_tokens: 8,
+    dollars_per_token: 0.01,
+    daily_invocation_count: 1,
+  },
+  )
+  assert_eq(len(proposals), 1)
+  assert_eq(proposals[0].provenance, "kmeans")
+  assert_eq(proposals[0].tenant_id, "tenant-a")
+  assert(contains(proposals[0].body, "system repo rust testing conventions"))
+  let review_library = prompt_library_define(prompt_library(), proposals[0])
+  let queue = prompt_library_review_queue(review_library)
+  assert_eq(len(queue), 1)
+  assert_eq(queue[0].members, ["a1", "a2"])
+  log("prompt_library ok")
+}

--- a/crates/harn-modules/src/stdlib.rs
+++ b/crates/harn-modules/src/stdlib.rs
@@ -28,6 +28,10 @@ pub(crate) const STDLIB_SOURCES: &[(&str, &str)] = &[
         include_str!("stdlib/stdlib_experiments.harn"),
     ),
     ("project", include_str!("stdlib/stdlib_project.harn")),
+    (
+        "prompt_library",
+        include_str!("stdlib/stdlib_prompt_library.harn"),
+    ),
     ("async", include_str!("stdlib/stdlib_async.harn")),
     ("agents", include_str!("stdlib/stdlib_agents.harn")),
     (

--- a/crates/harn-modules/src/stdlib/stdlib_prompt_library.harn
+++ b/crates/harn-modules/src/stdlib/stdlib_prompt_library.harn
@@ -1,0 +1,625 @@
+// std/prompt_library — reusable prompt fragments and hotspot consolidation.
+//
+// Import with: import "std/prompt_library"
+import { filter_nil } from "std/collections"
+import { euclidean_distance, kmeans } from "std/math"
+
+fn __empty_library() {
+  return {_type: "prompt_library", fragments: []}
+}
+
+fn __require_library(library, name = "prompt_library") {
+  require library != nil && library._type == "prompt_library", name + ": expected a prompt library"
+  return library.fragments ?? []
+}
+
+fn __estimate_tokens_text(text) {
+  return to_int(ceil(len(text) * 1.0 / 4.0))
+}
+
+fn __fragment_id_from_path(path) {
+  let base = basename(path)
+  if ends_with(base, ".harn.prompt") {
+    return substring(base, 0, len(base) - len(".harn.prompt"))
+  }
+  let ext = extname(base)
+  if ext != "" {
+    return substring(base, 0, len(base) - len(ext))
+  }
+  return base
+}
+
+fn __normalize_words(text) {
+  let normalized = regex_replace("[^A-Za-z0-9_./:-]+", " ", lowercase(text))
+  return split(trim(normalized), " ").filter({ word -> word != "" })
+}
+
+fn __token_prefix(text, max_tokens) {
+  let words = __normalize_words(text)
+  if max_tokens == nil || max_tokens <= 0 || len(words) <= max_tokens {
+    return join(words, " ")
+  }
+  return join(words[:max_tokens], " ")
+}
+
+fn __fragment_from_config(config, base_dir = nil) {
+  var body = config?.body ?? config?.prompt ?? config?.text
+  var path = config?.path
+  if body == nil && path != nil {
+    let full_path = if base_dir != nil && !starts_with(path, "/") {
+      path_join(base_dir, path)
+    } else {
+      path
+    }
+    body = read_file(full_path)
+    path = full_path
+  }
+  require body != nil, "prompt_fragment: fragment requires body, prompt, text, or path"
+  let id = config?.id ?? if path != nil {
+    __fragment_id_from_path(path)
+  } else {
+    nil
+  }
+  require id != nil && id != "", "prompt_fragment: fragment id must be a non-empty string"
+  return prompt_fragment(id, body, config + {path: path})
+}
+
+fn __front_matter_fragment(path, text) {
+  if !starts_with(text, "---\n") {
+    return prompt_fragment(__fragment_id_from_path(path), text, {path: path, source_path: path})
+  }
+  let rest = substring(text, 4)
+  let marker = rest.index_of("\n---\n")
+  if marker < 0 {
+    return prompt_fragment(__fragment_id_from_path(path), text, {path: path, source_path: path})
+  }
+  let meta_text = substring(rest, 0, marker)
+  let body = substring(rest, marker + len("\n---\n"))
+  let meta = toml_parse(meta_text)
+  return __fragment_from_config(meta + {body: body, path: path, source_path: path}, dirname(path))
+}
+
+fn __load_one(path) {
+  let text = read_file(path)
+  let parsed = try {
+    toml_parse(text)
+  }
+  if is_ok(parsed) {
+    let data = unwrap(parsed)
+    if data?.prompt_fragments != nil {
+      let base_dir = dirname(path)
+      var library = __empty_library()
+      for fragment_config in data.prompt_fragments {
+        library = prompt_library_define(library, __fragment_from_config(fragment_config, base_dir))
+      }
+      return library
+    }
+  }
+  return prompt_library([__front_matter_fragment(path, text)])
+}
+
+fn __render_fragment(fragment, bindings = nil) {
+  let body = fragment?.body ?? fragment?.prompt ?? fragment?.text
+  require body != nil, "prompt_library_inject: fragment has no body"
+  return render_string(body, bindings ?? {})
+}
+
+fn __matches_filters(fragment, filters) {
+  if filters == nil {
+    return true
+  }
+  if filters?.id != nil && fragment.id != filters.id {
+    return false
+  }
+  if filters?.tenant_id != nil && fragment?.tenant_id != filters.tenant_id {
+    return false
+  }
+  if filters?.provenance != nil && fragment?.provenance != filters.provenance {
+    return false
+  }
+  if filters?.status != nil && fragment?.status != filters.status {
+    return false
+  }
+  if filters?.tag != nil && !(fragment?.tags ?? []).contains(filters.tag) {
+    return false
+  }
+  if filters?.tags != nil {
+    for tag in filters.tags {
+      if !(fragment?.tags ?? []).contains(tag) {
+        return false
+      }
+    }
+  }
+  return true
+}
+
+fn __score_fragment(fragment, ctx) {
+  var score = 0
+  let tags = fragment?.tags ?? []
+  for tag in ctx?.tags ?? [] {
+    if tags.contains(tag) {
+      score = score + 10
+    }
+  }
+  let query = trim(lowercase(ctx?.query ?? ctx?.text ?? ""))
+  if query != "" {
+    let fragment_id = fragment?.id ?? ""
+    let fragment_title = fragment?.title ?? ""
+    let fragment_body = fragment?.body ?? ""
+    let haystack = lowercase(fragment_id + " " + fragment_title + " " + fragment_body)
+    for word in __normalize_words(query) {
+      if contains(haystack, word) {
+        score = score + 1
+      }
+    }
+  }
+  return score
+}
+
+fn __top_scored(scored, limit) {
+  var remaining = scored
+  var out = []
+  while len(remaining) > 0 && (limit == nil || len(out) < limit) {
+    var best_index = 0
+    var best_score = remaining[0].score
+    var idx = 1
+    while idx < len(remaining) {
+      if remaining[idx].score > best_score {
+        best_index = idx
+        best_score = remaining[idx].score
+      }
+      idx = idx + 1
+    }
+    out = out.push(remaining[best_index].fragment)
+    remaining = remaining[:best_index] + remaining[best_index + 1:]
+  }
+  return out
+}
+
+fn __conversation_text(conversation) {
+  if type_of(conversation) == "string" {
+    return conversation
+  }
+  return conversation?.prefix
+    ?? conversation?.text
+    ?? conversation?.prompt
+    ?? conversation?.system
+    ?? conversation?.content
+    ?? json_stringify(conversation)
+}
+
+fn __conversation_id(conversation, index) {
+  if type_of(conversation) == "dict" && conversation?.id != nil {
+    return conversation.id
+  }
+  return "conversation-" + to_string(index)
+}
+
+fn __conversation_embedding(conversation, text) {
+  if type_of(conversation) == "dict" && conversation?.embedding != nil {
+    return conversation.embedding
+  }
+  let words = __normalize_words(text)
+  let vocab = [
+    "system",
+    "developer",
+    "tool",
+    "agent",
+    "context",
+    "repo",
+    "workspace",
+    "rust",
+    "test",
+    "error",
+    "fix",
+    "issue",
+    "github",
+    "docs",
+    "api",
+    "prompt",
+  ]
+  var vector = []
+  for term in vocab {
+    var count = 0
+    for word in words {
+      if word == term {
+        count = count + 1
+      }
+    }
+    vector = vector.push(count * 1.0)
+  }
+  vector = vector.push(len(words) * 1.0)
+  return vector
+}
+
+fn __avg_distance(point, points) {
+  if len(points) == 0 {
+    return 0.0
+  }
+  var total = 0.0
+  for other in points {
+    total = total + euclidean_distance(point, other)
+  }
+  return total / (len(points) * 1.0)
+}
+
+fn __silhouette(points, assignments, k) {
+  if k <= 1 || len(points) <= 1 {
+    return 0.0
+  }
+  var total = 0.0
+  var idx = 0
+  while idx < len(points) {
+    let cluster = assignments[idx]
+    var same = []
+    var other_clusters = []
+    var c = 0
+    while c < k {
+      other_clusters = other_clusters.push([])
+      c = c + 1
+    }
+    var j = 0
+    while j < len(points) {
+      if j != idx {
+        if assignments[j] == cluster {
+          same = same.push(points[j])
+        } else {
+          let other = assignments[j]
+          other_clusters[other] = other_clusters[other].push(points[j])
+        }
+      }
+      j = j + 1
+    }
+    let a = __avg_distance(points[idx], same)
+    var b = nil
+    for group in other_clusters {
+      if len(group) > 0 {
+        let d = __avg_distance(points[idx], group)
+        if b == nil || d < b {
+          b = d
+        }
+      }
+    }
+    if b != nil {
+      let denom = if a > b {
+        a
+      } else {
+        b
+      }
+      if denom > 0 {
+        total = total + (b - a) / denom
+      }
+    }
+    idx = idx + 1
+  }
+  return total / (len(points) * 1.0)
+}
+
+fn __choose_kmeans(points, options) {
+  let n = len(points)
+  let requested = options?.k
+  if requested != nil {
+    let result = kmeans(points, requested, {max_iterations: options?.max_iterations ?? 100})
+    return {k: requested, result: result, silhouette: __silhouette(points, result.assignments, requested)}
+  }
+  if n < 4 {
+    let result = kmeans(points, 1, {max_iterations: options?.max_iterations ?? 100})
+    return {k: 1, result: result, silhouette: 0.0}
+  }
+  let max_k = if options?.max_k != nil && options.max_k < n {
+    options.max_k
+  } else {
+    n
+  }
+  var k = 2
+  var best = nil
+  while k <= max_k && k <= 6 {
+    let result = kmeans(points, k, {max_iterations: options?.max_iterations ?? 100})
+    let score = __silhouette(points, result.assignments, k)
+    if best == nil || score > best.silhouette {
+      best = {k: k, result: result, silhouette: score}
+    }
+    k = k + 1
+  }
+  return best
+}
+
+fn __prefix_count(snippets, prefix) {
+  var count = 0
+  for snippet in snippets {
+    if starts_with(snippet, prefix) {
+      count = count + 1
+    }
+  }
+  return count
+}
+
+fn __shared_prefix(snippets, min_fraction, min_tokens) {
+  var best = {text: "", tokens: 0, support: 0}
+  for snippet in snippets {
+    let words = split(snippet, " ").filter({ word -> word != "" })
+    var n = len(words)
+    while n >= min_tokens {
+      let prefix = join(words[:n], " ")
+      let support = __prefix_count(snippets, prefix)
+      if support / (len(snippets) * 1.0) >= min_fraction && n > best.tokens {
+        best = {text: prefix, tokens: n, support: support}
+        break
+      }
+      n = n - 1
+    }
+  }
+  return best
+}
+
+/** Create a prompt library from a fragment list. */
+pub fn prompt_library(fragments = nil) {
+  var library = __empty_library()
+  for fragment in fragments ?? [] {
+    library = prompt_library_define(library, fragment)
+  }
+  return library
+}
+
+/** Normalize one prompt fragment. */
+pub fn prompt_fragment(id, body, config = nil) {
+  require id != nil && id != "", "prompt_fragment: id must be a non-empty string"
+  require body != nil, "prompt_fragment: body must not be nil"
+  let provenance = config?.provenance ?? "manual"
+  let status = config?.status ?? if provenance == "kmeans" {
+    "pending_review"
+  } else {
+    "accepted"
+  }
+  return filter_nil(
+    {
+    id: id,
+    title: config?.title ?? id,
+    tags: config?.tags ?? [],
+    token_budget: config?.token_budget ?? __estimate_tokens_text(body),
+    cache_ttl: config?.cache_ttl ?? "5m",
+    cache_control: config?.cache_control ?? {type: "ephemeral"},
+    body: body,
+    path: config?.path,
+    source_path: config?.source_path,
+    provenance: provenance,
+    status: status,
+    tenant_id: config?.tenant_id,
+    score: config?.score,
+    members: config?.members,
+    support: config?.support,
+    tokens_saved: config?.tokens_saved,
+    monthly_savings_usd: config?.monthly_savings_usd,
+  },
+  )
+}
+
+/** Add or replace a fragment by id. */
+pub fn prompt_library_define(library, fragment) {
+  let fragments = __require_library(library, "prompt_library_define")
+  require fragment?.id != nil && fragment.id != "", "prompt_library_define: fragment requires id"
+  var out = []
+  var replaced = false
+  for existing in fragments {
+    if existing.id == fragment.id {
+      out = out.push(fragment)
+      replaced = true
+    } else {
+      out = out.push(existing)
+    }
+  }
+  if !replaced {
+    out = out.push(fragment)
+  }
+  return {_type: "prompt_library", fragments: out}
+}
+
+/** Load fragments from a TOML catalog or `.harn.prompt` fragment file. */
+pub fn prompt_library_load(path_or_paths) {
+  if type_of(path_or_paths) == "list" {
+    var library = __empty_library()
+    for path in path_or_paths {
+      let loaded = prompt_library_load(path)
+      for fragment in loaded.fragments {
+        library = prompt_library_define(library, fragment)
+      }
+    }
+    return library
+  }
+  return __load_one(path_or_paths)
+}
+
+/** List fragments, optionally filtered by id, tag/tags, tenant, provenance, or status. */
+pub fn prompt_library_list(library, filters = nil) {
+  let fragments = __require_library(library, "prompt_library_list")
+  return fragments.filter({ fragment -> __matches_filters(fragment, filters) })
+}
+
+/** Find one fragment by id, returning nil when it is absent. */
+pub fn prompt_library_find(library, id) {
+  for fragment in __require_library(library, "prompt_library_find") {
+    if fragment.id == id {
+      return fragment
+    }
+  }
+  return nil
+}
+
+/** Render one fragment to text. */
+pub fn prompt_library_inject(library, id, bindings = nil) {
+  let fragment = prompt_library_find(library, id)
+  require fragment != nil, "prompt_library_inject: unknown fragment '" + id + "'"
+  return __render_fragment(fragment, bindings)
+}
+
+/** Render one fragment with cache metadata for hosts that consume prompt blocks. */
+pub fn prompt_library_payload(library, id, bindings = nil) {
+  let fragment = prompt_library_find(library, id)
+  require fragment != nil, "prompt_library_payload: unknown fragment '" + id + "'"
+  return {
+    fragment_id: fragment.id,
+    text: __render_fragment(fragment, bindings),
+    cache_control: fragment?.cache_control ?? {type: "ephemeral"},
+    cache_ttl: fragment?.cache_ttl ?? "5m",
+    token_budget: fragment?.token_budget,
+    provenance: fragment?.provenance,
+  }
+}
+
+/** Render all matching fragments until `max_tokens` would be exceeded. */
+pub fn prompt_library_inject_cluster(library, filters = nil, bindings = nil) {
+  let max_tokens = filters?.max_tokens
+  var used = 0
+  var blocks = []
+  for fragment in prompt_library_list(library, filters) {
+    let budget = fragment?.token_budget ?? __estimate_tokens_text(fragment?.body ?? "")
+    if max_tokens != nil && used + budget > max_tokens {
+      continue
+    }
+    blocks = blocks.push(__render_fragment(fragment, bindings))
+    used = used + budget
+  }
+  return join(blocks, "\n\n")
+}
+
+/** Score and return likely useful fragments for a context. */
+pub fn prompt_library_suggest(library, ctx = nil) {
+  var scored = []
+  for fragment in __require_library(library, "prompt_library_suggest") {
+    let score = __score_fragment(fragment, ctx ?? {})
+    if score > 0 || (ctx?.query == nil && ctx?.tags == nil) {
+      scored = scored.push({score: score, fragment: fragment})
+    }
+  }
+  return __top_scored(scored, ctx?.limit ?? ctx?.top_n ?? 5)
+}
+
+/** Return a closure-backed namespace for `library.inject(...)` style calls. */
+pub fn prompt_library_api(library) {
+  return {
+    inject: fn(id, bindings = nil) { return prompt_library_inject(library, id, bindings) },
+    inject_cluster: fn(filters = nil, bindings = nil) { return prompt_library_inject_cluster(library, filters, bindings) },
+    payload: fn(id, bindings = nil) { return prompt_library_payload(library, id, bindings) },
+    suggest: fn(ctx = nil) { return prompt_library_suggest(library, ctx) },
+    list: fn(filters = nil) { return prompt_library_list(library, filters) },
+    find: fn(id) { return prompt_library_find(library, id) },
+  }
+}
+
+/** Build k-means prompt-hotspot fragment proposals from tenant-scoped conversations. */
+pub fn prompt_library_hotspots(conversations, options = nil) {
+  let tenant = options?.tenant_id
+  let max_prefix_tokens = options?.max_prefix_tokens ?? 1200
+  let min_fraction = options?.min_fraction ?? 0.8
+  let min_shared_tokens = options?.min_shared_tokens ?? 8
+  let daily_invocations = options?.daily_invocation_count ?? 1
+  let dollars_per_token = options?.dollars_per_token ?? 0.0
+  let min_monthly_savings = options?.min_monthly_savings_usd ?? 0.0
+  var records = []
+  var points = []
+  var index = 0
+  for conversation in conversations {
+    if tenant == nil || type_of(conversation) != "dict" || conversation?.tenant_id == tenant {
+      let text = __conversation_text(conversation)
+      let snippet = __token_prefix(text, max_prefix_tokens)
+      records = records
+        .push(
+        {
+        id: __conversation_id(conversation, index),
+        tenant_id: if type_of(conversation) == "dict" {
+        conversation?.tenant_id
+      } else {
+        nil
+      },
+        snippet: snippet,
+        embedding: __conversation_embedding(conversation, snippet),
+      },
+      )
+      points = points.push(records[-1].embedding)
+    }
+    index = index + 1
+  }
+  if len(records) == 0 {
+    return []
+  }
+  let chosen = __choose_kmeans(points, options ?? {})
+  var snippets_by_cluster = []
+  var members_by_cluster = []
+  var k = 0
+  while k < chosen.k {
+    snippets_by_cluster = snippets_by_cluster.push([])
+    members_by_cluster = members_by_cluster.push([])
+    k = k + 1
+  }
+  var idx = 0
+  while idx < len(records) {
+    let cluster = chosen.result.assignments[idx]
+    snippets_by_cluster[cluster] = snippets_by_cluster[cluster].push(records[idx].snippet)
+    members_by_cluster[cluster] = members_by_cluster[cluster].push(records[idx].id)
+    idx = idx + 1
+  }
+  var proposals = []
+  var cluster_id = 0
+  while cluster_id < len(snippets_by_cluster) {
+    let snippets = snippets_by_cluster[cluster_id]
+    if len(snippets) > 0 {
+      let prefix = __shared_prefix(snippets, min_fraction, min_shared_tokens)
+      if prefix.tokens >= min_shared_tokens {
+        let tokens_saved = prefix.tokens * (prefix.support - 1)
+        let monthly = tokens_saved * daily_invocations * 30.0 * dollars_per_token
+        if monthly >= min_monthly_savings {
+          let scope = tenant ?? "default"
+          let id = "kmeans-" + scope + "-" + substring(sha256(prefix.text), 0, 12)
+          proposals = proposals
+            .push(
+            prompt_fragment(
+            id,
+            prefix.text,
+            {
+            title: "K-means hotspot " + to_string(cluster_id),
+            tags: options?.tags ?? ["hotspot"],
+            token_budget: prefix.tokens,
+            provenance: "kmeans",
+            tenant_id: tenant,
+            status: "pending_review",
+            score: chosen.silhouette,
+            members: members_by_cluster[cluster_id],
+            support: prefix.support,
+            tokens_saved: tokens_saved,
+            monthly_savings_usd: monthly,
+          },
+          ),
+          )
+        }
+      }
+    }
+    cluster_id = cluster_id + 1
+  }
+  return proposals
+}
+
+/** Return pending k-means proposals in the shape expected by review UIs. */
+pub fn prompt_library_review_queue(library, filters = nil) {
+  var queue = []
+  let base_filters = filters ?? {}
+  let review_status = filters?.status ?? "pending_review"
+  let review_filters = base_filters + {provenance: "kmeans", status: review_status}
+  for fragment in prompt_library_list(library, review_filters) {
+    queue = queue
+      .push(
+      {
+      id: fragment.id,
+      title: fragment.title,
+      tenant_id: fragment?.tenant_id,
+      text: fragment.body,
+      token_budget: fragment?.token_budget,
+      support: fragment?.support,
+      members: fragment?.members ?? [],
+      tokens_saved: fragment?.tokens_saved ?? 0,
+      monthly_savings_usd: fragment?.monthly_savings_usd ?? 0.0,
+      status: fragment.status,
+    },
+    )
+  }
+  return queue
+}

--- a/crates/harn-vm/src/stdlib_modules.rs
+++ b/crates/harn-vm/src/stdlib_modules.rs
@@ -17,6 +17,7 @@ pub fn get_stdlib_source(module: &str) -> Option<&'static str> {
         "review" => Some(include_str!("stdlib_review.harn")),
         "experiments" => Some(include_str!("stdlib_experiments.harn")),
         "project" => Some(include_str!("stdlib_project.harn")),
+        "prompt_library" => Some(include_str!("stdlib_prompt_library.harn")),
         "async" => Some(include_str!("stdlib_async.harn")),
         "agents" => Some(include_str!("stdlib_agents.harn")),
         "agent_state" => Some(include_str!("stdlib_agent_state.harn")),

--- a/crates/harn-vm/src/stdlib_prompt_library.harn
+++ b/crates/harn-vm/src/stdlib_prompt_library.harn
@@ -1,0 +1,625 @@
+// std/prompt_library — reusable prompt fragments and hotspot consolidation.
+//
+// Import with: import "std/prompt_library"
+import { filter_nil } from "std/collections"
+import { euclidean_distance, kmeans } from "std/math"
+
+fn __empty_library() {
+  return {_type: "prompt_library", fragments: []}
+}
+
+fn __require_library(library, name = "prompt_library") {
+  require library != nil && library._type == "prompt_library", name + ": expected a prompt library"
+  return library.fragments ?? []
+}
+
+fn __estimate_tokens_text(text) {
+  return to_int(ceil(len(text) * 1.0 / 4.0))
+}
+
+fn __fragment_id_from_path(path) {
+  let base = basename(path)
+  if ends_with(base, ".harn.prompt") {
+    return substring(base, 0, len(base) - len(".harn.prompt"))
+  }
+  let ext = extname(base)
+  if ext != "" {
+    return substring(base, 0, len(base) - len(ext))
+  }
+  return base
+}
+
+fn __normalize_words(text) {
+  let normalized = regex_replace("[^A-Za-z0-9_./:-]+", " ", lowercase(text))
+  return split(trim(normalized), " ").filter({ word -> word != "" })
+}
+
+fn __token_prefix(text, max_tokens) {
+  let words = __normalize_words(text)
+  if max_tokens == nil || max_tokens <= 0 || len(words) <= max_tokens {
+    return join(words, " ")
+  }
+  return join(words[:max_tokens], " ")
+}
+
+fn __fragment_from_config(config, base_dir = nil) {
+  var body = config?.body ?? config?.prompt ?? config?.text
+  var path = config?.path
+  if body == nil && path != nil {
+    let full_path = if base_dir != nil && !starts_with(path, "/") {
+      path_join(base_dir, path)
+    } else {
+      path
+    }
+    body = read_file(full_path)
+    path = full_path
+  }
+  require body != nil, "prompt_fragment: fragment requires body, prompt, text, or path"
+  let id = config?.id ?? if path != nil {
+    __fragment_id_from_path(path)
+  } else {
+    nil
+  }
+  require id != nil && id != "", "prompt_fragment: fragment id must be a non-empty string"
+  return prompt_fragment(id, body, config + {path: path})
+}
+
+fn __front_matter_fragment(path, text) {
+  if !starts_with(text, "---\n") {
+    return prompt_fragment(__fragment_id_from_path(path), text, {path: path, source_path: path})
+  }
+  let rest = substring(text, 4)
+  let marker = rest.index_of("\n---\n")
+  if marker < 0 {
+    return prompt_fragment(__fragment_id_from_path(path), text, {path: path, source_path: path})
+  }
+  let meta_text = substring(rest, 0, marker)
+  let body = substring(rest, marker + len("\n---\n"))
+  let meta = toml_parse(meta_text)
+  return __fragment_from_config(meta + {body: body, path: path, source_path: path}, dirname(path))
+}
+
+fn __load_one(path) {
+  let text = read_file(path)
+  let parsed = try {
+    toml_parse(text)
+  }
+  if is_ok(parsed) {
+    let data = unwrap(parsed)
+    if data?.prompt_fragments != nil {
+      let base_dir = dirname(path)
+      var library = __empty_library()
+      for fragment_config in data.prompt_fragments {
+        library = prompt_library_define(library, __fragment_from_config(fragment_config, base_dir))
+      }
+      return library
+    }
+  }
+  return prompt_library([__front_matter_fragment(path, text)])
+}
+
+fn __render_fragment(fragment, bindings = nil) {
+  let body = fragment?.body ?? fragment?.prompt ?? fragment?.text
+  require body != nil, "prompt_library_inject: fragment has no body"
+  return render_string(body, bindings ?? {})
+}
+
+fn __matches_filters(fragment, filters) {
+  if filters == nil {
+    return true
+  }
+  if filters?.id != nil && fragment.id != filters.id {
+    return false
+  }
+  if filters?.tenant_id != nil && fragment?.tenant_id != filters.tenant_id {
+    return false
+  }
+  if filters?.provenance != nil && fragment?.provenance != filters.provenance {
+    return false
+  }
+  if filters?.status != nil && fragment?.status != filters.status {
+    return false
+  }
+  if filters?.tag != nil && !(fragment?.tags ?? []).contains(filters.tag) {
+    return false
+  }
+  if filters?.tags != nil {
+    for tag in filters.tags {
+      if !(fragment?.tags ?? []).contains(tag) {
+        return false
+      }
+    }
+  }
+  return true
+}
+
+fn __score_fragment(fragment, ctx) {
+  var score = 0
+  let tags = fragment?.tags ?? []
+  for tag in ctx?.tags ?? [] {
+    if tags.contains(tag) {
+      score = score + 10
+    }
+  }
+  let query = trim(lowercase(ctx?.query ?? ctx?.text ?? ""))
+  if query != "" {
+    let fragment_id = fragment?.id ?? ""
+    let fragment_title = fragment?.title ?? ""
+    let fragment_body = fragment?.body ?? ""
+    let haystack = lowercase(fragment_id + " " + fragment_title + " " + fragment_body)
+    for word in __normalize_words(query) {
+      if contains(haystack, word) {
+        score = score + 1
+      }
+    }
+  }
+  return score
+}
+
+fn __top_scored(scored, limit) {
+  var remaining = scored
+  var out = []
+  while len(remaining) > 0 && (limit == nil || len(out) < limit) {
+    var best_index = 0
+    var best_score = remaining[0].score
+    var idx = 1
+    while idx < len(remaining) {
+      if remaining[idx].score > best_score {
+        best_index = idx
+        best_score = remaining[idx].score
+      }
+      idx = idx + 1
+    }
+    out = out.push(remaining[best_index].fragment)
+    remaining = remaining[:best_index] + remaining[best_index + 1:]
+  }
+  return out
+}
+
+fn __conversation_text(conversation) {
+  if type_of(conversation) == "string" {
+    return conversation
+  }
+  return conversation?.prefix
+    ?? conversation?.text
+    ?? conversation?.prompt
+    ?? conversation?.system
+    ?? conversation?.content
+    ?? json_stringify(conversation)
+}
+
+fn __conversation_id(conversation, index) {
+  if type_of(conversation) == "dict" && conversation?.id != nil {
+    return conversation.id
+  }
+  return "conversation-" + to_string(index)
+}
+
+fn __conversation_embedding(conversation, text) {
+  if type_of(conversation) == "dict" && conversation?.embedding != nil {
+    return conversation.embedding
+  }
+  let words = __normalize_words(text)
+  let vocab = [
+    "system",
+    "developer",
+    "tool",
+    "agent",
+    "context",
+    "repo",
+    "workspace",
+    "rust",
+    "test",
+    "error",
+    "fix",
+    "issue",
+    "github",
+    "docs",
+    "api",
+    "prompt",
+  ]
+  var vector = []
+  for term in vocab {
+    var count = 0
+    for word in words {
+      if word == term {
+        count = count + 1
+      }
+    }
+    vector = vector.push(count * 1.0)
+  }
+  vector = vector.push(len(words) * 1.0)
+  return vector
+}
+
+fn __avg_distance(point, points) {
+  if len(points) == 0 {
+    return 0.0
+  }
+  var total = 0.0
+  for other in points {
+    total = total + euclidean_distance(point, other)
+  }
+  return total / (len(points) * 1.0)
+}
+
+fn __silhouette(points, assignments, k) {
+  if k <= 1 || len(points) <= 1 {
+    return 0.0
+  }
+  var total = 0.0
+  var idx = 0
+  while idx < len(points) {
+    let cluster = assignments[idx]
+    var same = []
+    var other_clusters = []
+    var c = 0
+    while c < k {
+      other_clusters = other_clusters.push([])
+      c = c + 1
+    }
+    var j = 0
+    while j < len(points) {
+      if j != idx {
+        if assignments[j] == cluster {
+          same = same.push(points[j])
+        } else {
+          let other = assignments[j]
+          other_clusters[other] = other_clusters[other].push(points[j])
+        }
+      }
+      j = j + 1
+    }
+    let a = __avg_distance(points[idx], same)
+    var b = nil
+    for group in other_clusters {
+      if len(group) > 0 {
+        let d = __avg_distance(points[idx], group)
+        if b == nil || d < b {
+          b = d
+        }
+      }
+    }
+    if b != nil {
+      let denom = if a > b {
+        a
+      } else {
+        b
+      }
+      if denom > 0 {
+        total = total + (b - a) / denom
+      }
+    }
+    idx = idx + 1
+  }
+  return total / (len(points) * 1.0)
+}
+
+fn __choose_kmeans(points, options) {
+  let n = len(points)
+  let requested = options?.k
+  if requested != nil {
+    let result = kmeans(points, requested, {max_iterations: options?.max_iterations ?? 100})
+    return {k: requested, result: result, silhouette: __silhouette(points, result.assignments, requested)}
+  }
+  if n < 4 {
+    let result = kmeans(points, 1, {max_iterations: options?.max_iterations ?? 100})
+    return {k: 1, result: result, silhouette: 0.0}
+  }
+  let max_k = if options?.max_k != nil && options.max_k < n {
+    options.max_k
+  } else {
+    n
+  }
+  var k = 2
+  var best = nil
+  while k <= max_k && k <= 6 {
+    let result = kmeans(points, k, {max_iterations: options?.max_iterations ?? 100})
+    let score = __silhouette(points, result.assignments, k)
+    if best == nil || score > best.silhouette {
+      best = {k: k, result: result, silhouette: score}
+    }
+    k = k + 1
+  }
+  return best
+}
+
+fn __prefix_count(snippets, prefix) {
+  var count = 0
+  for snippet in snippets {
+    if starts_with(snippet, prefix) {
+      count = count + 1
+    }
+  }
+  return count
+}
+
+fn __shared_prefix(snippets, min_fraction, min_tokens) {
+  var best = {text: "", tokens: 0, support: 0}
+  for snippet in snippets {
+    let words = split(snippet, " ").filter({ word -> word != "" })
+    var n = len(words)
+    while n >= min_tokens {
+      let prefix = join(words[:n], " ")
+      let support = __prefix_count(snippets, prefix)
+      if support / (len(snippets) * 1.0) >= min_fraction && n > best.tokens {
+        best = {text: prefix, tokens: n, support: support}
+        break
+      }
+      n = n - 1
+    }
+  }
+  return best
+}
+
+/** Create a prompt library from a fragment list. */
+pub fn prompt_library(fragments = nil) {
+  var library = __empty_library()
+  for fragment in fragments ?? [] {
+    library = prompt_library_define(library, fragment)
+  }
+  return library
+}
+
+/** Normalize one prompt fragment. */
+pub fn prompt_fragment(id, body, config = nil) {
+  require id != nil && id != "", "prompt_fragment: id must be a non-empty string"
+  require body != nil, "prompt_fragment: body must not be nil"
+  let provenance = config?.provenance ?? "manual"
+  let status = config?.status ?? if provenance == "kmeans" {
+    "pending_review"
+  } else {
+    "accepted"
+  }
+  return filter_nil(
+    {
+    id: id,
+    title: config?.title ?? id,
+    tags: config?.tags ?? [],
+    token_budget: config?.token_budget ?? __estimate_tokens_text(body),
+    cache_ttl: config?.cache_ttl ?? "5m",
+    cache_control: config?.cache_control ?? {type: "ephemeral"},
+    body: body,
+    path: config?.path,
+    source_path: config?.source_path,
+    provenance: provenance,
+    status: status,
+    tenant_id: config?.tenant_id,
+    score: config?.score,
+    members: config?.members,
+    support: config?.support,
+    tokens_saved: config?.tokens_saved,
+    monthly_savings_usd: config?.monthly_savings_usd,
+  },
+  )
+}
+
+/** Add or replace a fragment by id. */
+pub fn prompt_library_define(library, fragment) {
+  let fragments = __require_library(library, "prompt_library_define")
+  require fragment?.id != nil && fragment.id != "", "prompt_library_define: fragment requires id"
+  var out = []
+  var replaced = false
+  for existing in fragments {
+    if existing.id == fragment.id {
+      out = out.push(fragment)
+      replaced = true
+    } else {
+      out = out.push(existing)
+    }
+  }
+  if !replaced {
+    out = out.push(fragment)
+  }
+  return {_type: "prompt_library", fragments: out}
+}
+
+/** Load fragments from a TOML catalog or `.harn.prompt` fragment file. */
+pub fn prompt_library_load(path_or_paths) {
+  if type_of(path_or_paths) == "list" {
+    var library = __empty_library()
+    for path in path_or_paths {
+      let loaded = prompt_library_load(path)
+      for fragment in loaded.fragments {
+        library = prompt_library_define(library, fragment)
+      }
+    }
+    return library
+  }
+  return __load_one(path_or_paths)
+}
+
+/** List fragments, optionally filtered by id, tag/tags, tenant, provenance, or status. */
+pub fn prompt_library_list(library, filters = nil) {
+  let fragments = __require_library(library, "prompt_library_list")
+  return fragments.filter({ fragment -> __matches_filters(fragment, filters) })
+}
+
+/** Find one fragment by id, returning nil when it is absent. */
+pub fn prompt_library_find(library, id) {
+  for fragment in __require_library(library, "prompt_library_find") {
+    if fragment.id == id {
+      return fragment
+    }
+  }
+  return nil
+}
+
+/** Render one fragment to text. */
+pub fn prompt_library_inject(library, id, bindings = nil) {
+  let fragment = prompt_library_find(library, id)
+  require fragment != nil, "prompt_library_inject: unknown fragment '" + id + "'"
+  return __render_fragment(fragment, bindings)
+}
+
+/** Render one fragment with cache metadata for hosts that consume prompt blocks. */
+pub fn prompt_library_payload(library, id, bindings = nil) {
+  let fragment = prompt_library_find(library, id)
+  require fragment != nil, "prompt_library_payload: unknown fragment '" + id + "'"
+  return {
+    fragment_id: fragment.id,
+    text: __render_fragment(fragment, bindings),
+    cache_control: fragment?.cache_control ?? {type: "ephemeral"},
+    cache_ttl: fragment?.cache_ttl ?? "5m",
+    token_budget: fragment?.token_budget,
+    provenance: fragment?.provenance,
+  }
+}
+
+/** Render all matching fragments until `max_tokens` would be exceeded. */
+pub fn prompt_library_inject_cluster(library, filters = nil, bindings = nil) {
+  let max_tokens = filters?.max_tokens
+  var used = 0
+  var blocks = []
+  for fragment in prompt_library_list(library, filters) {
+    let budget = fragment?.token_budget ?? __estimate_tokens_text(fragment?.body ?? "")
+    if max_tokens != nil && used + budget > max_tokens {
+      continue
+    }
+    blocks = blocks.push(__render_fragment(fragment, bindings))
+    used = used + budget
+  }
+  return join(blocks, "\n\n")
+}
+
+/** Score and return likely useful fragments for a context. */
+pub fn prompt_library_suggest(library, ctx = nil) {
+  var scored = []
+  for fragment in __require_library(library, "prompt_library_suggest") {
+    let score = __score_fragment(fragment, ctx ?? {})
+    if score > 0 || (ctx?.query == nil && ctx?.tags == nil) {
+      scored = scored.push({score: score, fragment: fragment})
+    }
+  }
+  return __top_scored(scored, ctx?.limit ?? ctx?.top_n ?? 5)
+}
+
+/** Return a closure-backed namespace for `library.inject(...)` style calls. */
+pub fn prompt_library_api(library) {
+  return {
+    inject: fn(id, bindings = nil) { return prompt_library_inject(library, id, bindings) },
+    inject_cluster: fn(filters = nil, bindings = nil) { return prompt_library_inject_cluster(library, filters, bindings) },
+    payload: fn(id, bindings = nil) { return prompt_library_payload(library, id, bindings) },
+    suggest: fn(ctx = nil) { return prompt_library_suggest(library, ctx) },
+    list: fn(filters = nil) { return prompt_library_list(library, filters) },
+    find: fn(id) { return prompt_library_find(library, id) },
+  }
+}
+
+/** Build k-means prompt-hotspot fragment proposals from tenant-scoped conversations. */
+pub fn prompt_library_hotspots(conversations, options = nil) {
+  let tenant = options?.tenant_id
+  let max_prefix_tokens = options?.max_prefix_tokens ?? 1200
+  let min_fraction = options?.min_fraction ?? 0.8
+  let min_shared_tokens = options?.min_shared_tokens ?? 8
+  let daily_invocations = options?.daily_invocation_count ?? 1
+  let dollars_per_token = options?.dollars_per_token ?? 0.0
+  let min_monthly_savings = options?.min_monthly_savings_usd ?? 0.0
+  var records = []
+  var points = []
+  var index = 0
+  for conversation in conversations {
+    if tenant == nil || type_of(conversation) != "dict" || conversation?.tenant_id == tenant {
+      let text = __conversation_text(conversation)
+      let snippet = __token_prefix(text, max_prefix_tokens)
+      records = records
+        .push(
+        {
+        id: __conversation_id(conversation, index),
+        tenant_id: if type_of(conversation) == "dict" {
+        conversation?.tenant_id
+      } else {
+        nil
+      },
+        snippet: snippet,
+        embedding: __conversation_embedding(conversation, snippet),
+      },
+      )
+      points = points.push(records[-1].embedding)
+    }
+    index = index + 1
+  }
+  if len(records) == 0 {
+    return []
+  }
+  let chosen = __choose_kmeans(points, options ?? {})
+  var snippets_by_cluster = []
+  var members_by_cluster = []
+  var k = 0
+  while k < chosen.k {
+    snippets_by_cluster = snippets_by_cluster.push([])
+    members_by_cluster = members_by_cluster.push([])
+    k = k + 1
+  }
+  var idx = 0
+  while idx < len(records) {
+    let cluster = chosen.result.assignments[idx]
+    snippets_by_cluster[cluster] = snippets_by_cluster[cluster].push(records[idx].snippet)
+    members_by_cluster[cluster] = members_by_cluster[cluster].push(records[idx].id)
+    idx = idx + 1
+  }
+  var proposals = []
+  var cluster_id = 0
+  while cluster_id < len(snippets_by_cluster) {
+    let snippets = snippets_by_cluster[cluster_id]
+    if len(snippets) > 0 {
+      let prefix = __shared_prefix(snippets, min_fraction, min_shared_tokens)
+      if prefix.tokens >= min_shared_tokens {
+        let tokens_saved = prefix.tokens * (prefix.support - 1)
+        let monthly = tokens_saved * daily_invocations * 30.0 * dollars_per_token
+        if monthly >= min_monthly_savings {
+          let scope = tenant ?? "default"
+          let id = "kmeans-" + scope + "-" + substring(sha256(prefix.text), 0, 12)
+          proposals = proposals
+            .push(
+            prompt_fragment(
+            id,
+            prefix.text,
+            {
+            title: "K-means hotspot " + to_string(cluster_id),
+            tags: options?.tags ?? ["hotspot"],
+            token_budget: prefix.tokens,
+            provenance: "kmeans",
+            tenant_id: tenant,
+            status: "pending_review",
+            score: chosen.silhouette,
+            members: members_by_cluster[cluster_id],
+            support: prefix.support,
+            tokens_saved: tokens_saved,
+            monthly_savings_usd: monthly,
+          },
+          ),
+          )
+        }
+      }
+    }
+    cluster_id = cluster_id + 1
+  }
+  return proposals
+}
+
+/** Return pending k-means proposals in the shape expected by review UIs. */
+pub fn prompt_library_review_queue(library, filters = nil) {
+  var queue = []
+  let base_filters = filters ?? {}
+  let review_status = filters?.status ?? "pending_review"
+  let review_filters = base_filters + {provenance: "kmeans", status: review_status}
+  for fragment in prompt_library_list(library, review_filters) {
+    queue = queue
+      .push(
+      {
+      id: fragment.id,
+      title: fragment.title,
+      tenant_id: fragment?.tenant_id,
+      text: fragment.body,
+      token_budget: fragment?.token_budget,
+      support: fragment?.support,
+      members: fragment?.members ?? [],
+      tokens_saved: fragment?.tokens_saved ?? 0,
+      monthly_savings_usd: fragment?.monthly_savings_usd ?? 0.0,
+      status: fragment.status,
+    },
+    )
+  }
+  return queue
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -26,6 +26,7 @@
 - [Triggers](./triggers.md)
 - [Trigger stdlib](./stdlib/triggers.md)
 - [Monitor stdlib](./stdlib/monitors.md)
+- [Prompt library stdlib](./stdlib/prompt-library.md)
 - [Human in the loop](./hitl.md)
 - [Trust graph](./trust-graph.md)
 - [Skills](./skills.md)

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -348,6 +348,8 @@ Imports starting with `std/` load embedded stdlib modules:
 - `import "std/collections"` — collection utilities (filter_nil, store_stale,
   store_refresh)
 - `import "std/vision"` — deterministic OCR helpers (`ocr(image, options?)`)
+- `import "std/prompt_library"` — reusable prompt fragments, cache metadata,
+  tenant-scoped k-means hotspot proposals, and review-queue records
 - `import "std/agent_state"` — durable session-scoped state helpers
   (agent_state_init, agent_state_resume, agent_state_write,
   agent_state_read, agent_state_list, agent_state_delete,

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -81,7 +81,7 @@ code or inside any pipeline.
 described below (`std/text`, `std/json`, `std/math`, `std/collections`,
 `std/path`, `std/vision`, `std/context`, `std/agent_state`, `std/agents`,
 `std/runtime`, `std/review`, `std/experiments`, `std/project`,
-`std/monitors`, `std/worktree`,
+`std/prompt_library`, `std/monitors`, `std/worktree`,
 `std/checkpoint`). These add layered
 utilities on top of the core builtins; the core builtins themselves are
 always available.
@@ -101,6 +101,7 @@ import "std/json"
 import "std/context"
 import "std/agent_state"
 import "std/agents"
+import "std/prompt_library"
 import "std/review"
 import "std/experiments"
 import "std/monitors"
@@ -149,6 +150,24 @@ Helpers for structural prompt experiments:
 | `latest_string_user_message(messages)` | Return `{index, message}` for the latest plain-string user message |
 | `replace_message(messages, index, message)` | Return a copy of `messages` with one entry replaced |
 | `prepend_message(messages, msg)` / `append_message(messages, msg)` | Convenience helpers for custom transforms |
+
+### std/prompt_library
+
+Reusable prompt fragments and deterministic prompt-hotspot proposals:
+
+| Function | Description |
+|---|---|
+| `prompt_library(fragments?)` | Create an in-memory prompt fragment library |
+| `prompt_library_load(path_or_paths)` | Load TOML `[[prompt_fragments]]` catalogs or front-matter `.harn.prompt` files |
+| `prompt_library_inject(library, id, bindings?)` | Render one fragment to text |
+| `prompt_library_payload(library, id, bindings?)` | Render one fragment plus cache metadata |
+| `prompt_library_inject_cluster(library, filters?, bindings?)` | Render matching fragments until `max_tokens` is reached |
+| `prompt_library_suggest(library, ctx?)` | Rank fragments by tags and query terms |
+| `prompt_library_hotspots(conversations, options?)` | Produce tenant-scoped k-means fragment proposals |
+| `prompt_library_review_queue(library, filters?)` | Return pending k-means proposals for review UIs |
+
+See [Prompt library stdlib](./stdlib/prompt-library.md) for the fragment file
+format and hotspot proposal shape.
 
 ### std/collections
 

--- a/docs/src/stdlib/prompt-library.md
+++ b/docs/src/stdlib/prompt-library.md
@@ -1,0 +1,95 @@
+# Prompt Library Stdlib
+
+`std/prompt_library` manages reusable prompt fragments and deterministic
+hotspot proposals for repeated context prefixes.
+
+```harn,ignore
+import "std/prompt_library"
+
+let library = prompt_library_load("prompts.toml")
+let prompt_library = prompt_library_api(library)
+
+let system_prefix = prompt_library.inject(
+  "rust-repo-conventions-v1",
+  {crate: "harn-vm"},
+)
+```
+
+## Fragment Catalogs
+
+Catalog files are TOML with one or more `[[prompt_fragments]]` entries:
+
+```toml
+[[prompt_fragments]]
+id = "rust-repo-conventions-v1"
+title = "Rust repo conventions"
+tags = ["rust", "testing"]
+token_budget = 1200
+cache_ttl = "5m"
+body = "Use nextest for {{crate}} and keep sccache warm."
+```
+
+An entry can use `body`, `prompt`, or `text` inline. It can also use `path` to
+load a sibling `.harn.prompt` / `.prompt` template relative to the catalog.
+
+Single `.harn.prompt` files can carry TOML front matter:
+
+```harn,ignore
+---
+id = "ops-prefix"
+tags = ["ops"]
+cache_ttl = "5m"
+---
+Operate in {{env}} with low-noise status updates.
+```
+
+Fragments default to `cache_control = {type: "ephemeral"}` so hosts can opt
+into provider prompt caching. `prompt_library_payload(...)` returns the rendered
+text together with that cache metadata; `prompt_library_inject(...)` returns
+only text.
+
+## Functions
+
+| Function | Description |
+|---|---|
+| `prompt_library(fragments?)` | Create an in-memory library |
+| `prompt_fragment(id, body, config?)` | Normalize one fragment |
+| `prompt_library_load(path_or_paths)` | Load a TOML catalog or front-matter `.harn.prompt` fragment |
+| `prompt_library_define(library, fragment)` | Add or replace a fragment by id |
+| `prompt_library_list(library, filters?)` | Filter by `id`, `tag`, `tags`, `tenant_id`, `provenance`, or `status` |
+| `prompt_library_find(library, id)` | Return one fragment or `nil` |
+| `prompt_library_inject(library, id, bindings?)` | Render one fragment to text |
+| `prompt_library_payload(library, id, bindings?)` | Render one fragment plus cache metadata |
+| `prompt_library_inject_cluster(library, filters?, bindings?)` | Render matching fragments until `max_tokens` is reached |
+| `prompt_library_suggest(library, ctx?)` | Rank fragments using query text and tag overlap |
+| `prompt_library_api(library)` | Return closure-backed `inject`, `inject_cluster`, `payload`, `suggest`, `list`, and `find` helpers |
+| `prompt_library_hotspots(conversations, options?)` | Produce tenant-scoped k-means fragment proposals from recent conversations |
+| `prompt_library_review_queue(library, filters?)` | Return pending k-means proposals for review UIs |
+
+## Hotspot Proposals
+
+`prompt_library_hotspots(...)` accepts recent conversations as strings or dicts.
+Dict records can include `id`, `tenant_id`, `text` / `prefix` / `prompt`, and an
+optional numeric `embedding`. When `embedding` is absent, Harn uses a small
+deterministic bag-of-words vector over prompt-setup terms. That keeps the stdlib
+worker testable without requiring an embedding provider.
+
+```harn,ignore
+let proposals = prompt_library_hotspots(recent_conversations, {
+  tenant_id: "tenant-a",
+  max_prefix_tokens: 1200,
+  min_fraction: 0.8,
+  min_shared_tokens: 64,
+  daily_invocation_count: 50,
+  dollars_per_token: 0.000000003,
+  min_monthly_savings_usd: 5.0,
+})
+
+let review_library = prompt_library(proposals)
+let queue = prompt_library_review_queue(review_library)
+```
+
+The function filters to the requested `tenant_id` before clustering. Proposed
+fragments are marked `provenance = "kmeans"` and `status = "pending_review"`,
+with `members`, `support`, `tokens_saved`, and `monthly_savings_usd` fields for
+portal or host review surfaces.

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -346,6 +346,8 @@ Imports starting with `std/` load embedded stdlib modules:
 - `import "std/collections"` — collection utilities (filter_nil, store_stale,
   store_refresh)
 - `import "std/vision"` — deterministic OCR helpers (`ocr(image, options?)`)
+- `import "std/prompt_library"` — reusable prompt fragments, cache metadata,
+  tenant-scoped k-means hotspot proposals, and review-queue records
 - `import "std/agent_state"` — durable session-scoped state helpers
   (agent_state_init, agent_state_resume, agent_state_write,
   agent_state_read, agent_state_list, agent_state_delete,

--- a/stdlib/prompt_library.harn
+++ b/stdlib/prompt_library.harn
@@ -1,0 +1,625 @@
+// std/prompt_library — reusable prompt fragments and hotspot consolidation.
+//
+// Import with: import "std/prompt_library"
+import { filter_nil } from "std/collections"
+import { euclidean_distance, kmeans } from "std/math"
+
+fn __empty_library() {
+  return {_type: "prompt_library", fragments: []}
+}
+
+fn __require_library(library, name = "prompt_library") {
+  require library != nil && library._type == "prompt_library", name + ": expected a prompt library"
+  return library.fragments ?? []
+}
+
+fn __estimate_tokens_text(text) {
+  return to_int(ceil(len(text) * 1.0 / 4.0))
+}
+
+fn __fragment_id_from_path(path) {
+  let base = basename(path)
+  if ends_with(base, ".harn.prompt") {
+    return substring(base, 0, len(base) - len(".harn.prompt"))
+  }
+  let ext = extname(base)
+  if ext != "" {
+    return substring(base, 0, len(base) - len(ext))
+  }
+  return base
+}
+
+fn __normalize_words(text) {
+  let normalized = regex_replace("[^A-Za-z0-9_./:-]+", " ", lowercase(text))
+  return split(trim(normalized), " ").filter({ word -> word != "" })
+}
+
+fn __token_prefix(text, max_tokens) {
+  let words = __normalize_words(text)
+  if max_tokens == nil || max_tokens <= 0 || len(words) <= max_tokens {
+    return join(words, " ")
+  }
+  return join(words[:max_tokens], " ")
+}
+
+fn __fragment_from_config(config, base_dir = nil) {
+  var body = config?.body ?? config?.prompt ?? config?.text
+  var path = config?.path
+  if body == nil && path != nil {
+    let full_path = if base_dir != nil && !starts_with(path, "/") {
+      path_join(base_dir, path)
+    } else {
+      path
+    }
+    body = read_file(full_path)
+    path = full_path
+  }
+  require body != nil, "prompt_fragment: fragment requires body, prompt, text, or path"
+  let id = config?.id ?? if path != nil {
+    __fragment_id_from_path(path)
+  } else {
+    nil
+  }
+  require id != nil && id != "", "prompt_fragment: fragment id must be a non-empty string"
+  return prompt_fragment(id, body, config + {path: path})
+}
+
+fn __front_matter_fragment(path, text) {
+  if !starts_with(text, "---\n") {
+    return prompt_fragment(__fragment_id_from_path(path), text, {path: path, source_path: path})
+  }
+  let rest = substring(text, 4)
+  let marker = rest.index_of("\n---\n")
+  if marker < 0 {
+    return prompt_fragment(__fragment_id_from_path(path), text, {path: path, source_path: path})
+  }
+  let meta_text = substring(rest, 0, marker)
+  let body = substring(rest, marker + len("\n---\n"))
+  let meta = toml_parse(meta_text)
+  return __fragment_from_config(meta + {body: body, path: path, source_path: path}, dirname(path))
+}
+
+fn __load_one(path) {
+  let text = read_file(path)
+  let parsed = try {
+    toml_parse(text)
+  }
+  if is_ok(parsed) {
+    let data = unwrap(parsed)
+    if data?.prompt_fragments != nil {
+      let base_dir = dirname(path)
+      var library = __empty_library()
+      for fragment_config in data.prompt_fragments {
+        library = prompt_library_define(library, __fragment_from_config(fragment_config, base_dir))
+      }
+      return library
+    }
+  }
+  return prompt_library([__front_matter_fragment(path, text)])
+}
+
+fn __render_fragment(fragment, bindings = nil) {
+  let body = fragment?.body ?? fragment?.prompt ?? fragment?.text
+  require body != nil, "prompt_library_inject: fragment has no body"
+  return render_string(body, bindings ?? {})
+}
+
+fn __matches_filters(fragment, filters) {
+  if filters == nil {
+    return true
+  }
+  if filters?.id != nil && fragment.id != filters.id {
+    return false
+  }
+  if filters?.tenant_id != nil && fragment?.tenant_id != filters.tenant_id {
+    return false
+  }
+  if filters?.provenance != nil && fragment?.provenance != filters.provenance {
+    return false
+  }
+  if filters?.status != nil && fragment?.status != filters.status {
+    return false
+  }
+  if filters?.tag != nil && !(fragment?.tags ?? []).contains(filters.tag) {
+    return false
+  }
+  if filters?.tags != nil {
+    for tag in filters.tags {
+      if !(fragment?.tags ?? []).contains(tag) {
+        return false
+      }
+    }
+  }
+  return true
+}
+
+fn __score_fragment(fragment, ctx) {
+  var score = 0
+  let tags = fragment?.tags ?? []
+  for tag in ctx?.tags ?? [] {
+    if tags.contains(tag) {
+      score = score + 10
+    }
+  }
+  let query = trim(lowercase(ctx?.query ?? ctx?.text ?? ""))
+  if query != "" {
+    let fragment_id = fragment?.id ?? ""
+    let fragment_title = fragment?.title ?? ""
+    let fragment_body = fragment?.body ?? ""
+    let haystack = lowercase(fragment_id + " " + fragment_title + " " + fragment_body)
+    for word in __normalize_words(query) {
+      if contains(haystack, word) {
+        score = score + 1
+      }
+    }
+  }
+  return score
+}
+
+fn __top_scored(scored, limit) {
+  var remaining = scored
+  var out = []
+  while len(remaining) > 0 && (limit == nil || len(out) < limit) {
+    var best_index = 0
+    var best_score = remaining[0].score
+    var idx = 1
+    while idx < len(remaining) {
+      if remaining[idx].score > best_score {
+        best_index = idx
+        best_score = remaining[idx].score
+      }
+      idx = idx + 1
+    }
+    out = out.push(remaining[best_index].fragment)
+    remaining = remaining[:best_index] + remaining[best_index + 1:]
+  }
+  return out
+}
+
+fn __conversation_text(conversation) {
+  if type_of(conversation) == "string" {
+    return conversation
+  }
+  return conversation?.prefix
+    ?? conversation?.text
+    ?? conversation?.prompt
+    ?? conversation?.system
+    ?? conversation?.content
+    ?? json_stringify(conversation)
+}
+
+fn __conversation_id(conversation, index) {
+  if type_of(conversation) == "dict" && conversation?.id != nil {
+    return conversation.id
+  }
+  return "conversation-" + to_string(index)
+}
+
+fn __conversation_embedding(conversation, text) {
+  if type_of(conversation) == "dict" && conversation?.embedding != nil {
+    return conversation.embedding
+  }
+  let words = __normalize_words(text)
+  let vocab = [
+    "system",
+    "developer",
+    "tool",
+    "agent",
+    "context",
+    "repo",
+    "workspace",
+    "rust",
+    "test",
+    "error",
+    "fix",
+    "issue",
+    "github",
+    "docs",
+    "api",
+    "prompt",
+  ]
+  var vector = []
+  for term in vocab {
+    var count = 0
+    for word in words {
+      if word == term {
+        count = count + 1
+      }
+    }
+    vector = vector.push(count * 1.0)
+  }
+  vector = vector.push(len(words) * 1.0)
+  return vector
+}
+
+fn __avg_distance(point, points) {
+  if len(points) == 0 {
+    return 0.0
+  }
+  var total = 0.0
+  for other in points {
+    total = total + euclidean_distance(point, other)
+  }
+  return total / (len(points) * 1.0)
+}
+
+fn __silhouette(points, assignments, k) {
+  if k <= 1 || len(points) <= 1 {
+    return 0.0
+  }
+  var total = 0.0
+  var idx = 0
+  while idx < len(points) {
+    let cluster = assignments[idx]
+    var same = []
+    var other_clusters = []
+    var c = 0
+    while c < k {
+      other_clusters = other_clusters.push([])
+      c = c + 1
+    }
+    var j = 0
+    while j < len(points) {
+      if j != idx {
+        if assignments[j] == cluster {
+          same = same.push(points[j])
+        } else {
+          let other = assignments[j]
+          other_clusters[other] = other_clusters[other].push(points[j])
+        }
+      }
+      j = j + 1
+    }
+    let a = __avg_distance(points[idx], same)
+    var b = nil
+    for group in other_clusters {
+      if len(group) > 0 {
+        let d = __avg_distance(points[idx], group)
+        if b == nil || d < b {
+          b = d
+        }
+      }
+    }
+    if b != nil {
+      let denom = if a > b {
+        a
+      } else {
+        b
+      }
+      if denom > 0 {
+        total = total + (b - a) / denom
+      }
+    }
+    idx = idx + 1
+  }
+  return total / (len(points) * 1.0)
+}
+
+fn __choose_kmeans(points, options) {
+  let n = len(points)
+  let requested = options?.k
+  if requested != nil {
+    let result = kmeans(points, requested, {max_iterations: options?.max_iterations ?? 100})
+    return {k: requested, result: result, silhouette: __silhouette(points, result.assignments, requested)}
+  }
+  if n < 4 {
+    let result = kmeans(points, 1, {max_iterations: options?.max_iterations ?? 100})
+    return {k: 1, result: result, silhouette: 0.0}
+  }
+  let max_k = if options?.max_k != nil && options.max_k < n {
+    options.max_k
+  } else {
+    n
+  }
+  var k = 2
+  var best = nil
+  while k <= max_k && k <= 6 {
+    let result = kmeans(points, k, {max_iterations: options?.max_iterations ?? 100})
+    let score = __silhouette(points, result.assignments, k)
+    if best == nil || score > best.silhouette {
+      best = {k: k, result: result, silhouette: score}
+    }
+    k = k + 1
+  }
+  return best
+}
+
+fn __prefix_count(snippets, prefix) {
+  var count = 0
+  for snippet in snippets {
+    if starts_with(snippet, prefix) {
+      count = count + 1
+    }
+  }
+  return count
+}
+
+fn __shared_prefix(snippets, min_fraction, min_tokens) {
+  var best = {text: "", tokens: 0, support: 0}
+  for snippet in snippets {
+    let words = split(snippet, " ").filter({ word -> word != "" })
+    var n = len(words)
+    while n >= min_tokens {
+      let prefix = join(words[:n], " ")
+      let support = __prefix_count(snippets, prefix)
+      if support / (len(snippets) * 1.0) >= min_fraction && n > best.tokens {
+        best = {text: prefix, tokens: n, support: support}
+        break
+      }
+      n = n - 1
+    }
+  }
+  return best
+}
+
+/** Create a prompt library from a fragment list. */
+pub fn prompt_library(fragments = nil) {
+  var library = __empty_library()
+  for fragment in fragments ?? [] {
+    library = prompt_library_define(library, fragment)
+  }
+  return library
+}
+
+/** Normalize one prompt fragment. */
+pub fn prompt_fragment(id, body, config = nil) {
+  require id != nil && id != "", "prompt_fragment: id must be a non-empty string"
+  require body != nil, "prompt_fragment: body must not be nil"
+  let provenance = config?.provenance ?? "manual"
+  let status = config?.status ?? if provenance == "kmeans" {
+    "pending_review"
+  } else {
+    "accepted"
+  }
+  return filter_nil(
+    {
+    id: id,
+    title: config?.title ?? id,
+    tags: config?.tags ?? [],
+    token_budget: config?.token_budget ?? __estimate_tokens_text(body),
+    cache_ttl: config?.cache_ttl ?? "5m",
+    cache_control: config?.cache_control ?? {type: "ephemeral"},
+    body: body,
+    path: config?.path,
+    source_path: config?.source_path,
+    provenance: provenance,
+    status: status,
+    tenant_id: config?.tenant_id,
+    score: config?.score,
+    members: config?.members,
+    support: config?.support,
+    tokens_saved: config?.tokens_saved,
+    monthly_savings_usd: config?.monthly_savings_usd,
+  },
+  )
+}
+
+/** Add or replace a fragment by id. */
+pub fn prompt_library_define(library, fragment) {
+  let fragments = __require_library(library, "prompt_library_define")
+  require fragment?.id != nil && fragment.id != "", "prompt_library_define: fragment requires id"
+  var out = []
+  var replaced = false
+  for existing in fragments {
+    if existing.id == fragment.id {
+      out = out.push(fragment)
+      replaced = true
+    } else {
+      out = out.push(existing)
+    }
+  }
+  if !replaced {
+    out = out.push(fragment)
+  }
+  return {_type: "prompt_library", fragments: out}
+}
+
+/** Load fragments from a TOML catalog or `.harn.prompt` fragment file. */
+pub fn prompt_library_load(path_or_paths) {
+  if type_of(path_or_paths) == "list" {
+    var library = __empty_library()
+    for path in path_or_paths {
+      let loaded = prompt_library_load(path)
+      for fragment in loaded.fragments {
+        library = prompt_library_define(library, fragment)
+      }
+    }
+    return library
+  }
+  return __load_one(path_or_paths)
+}
+
+/** List fragments, optionally filtered by id, tag/tags, tenant, provenance, or status. */
+pub fn prompt_library_list(library, filters = nil) {
+  let fragments = __require_library(library, "prompt_library_list")
+  return fragments.filter({ fragment -> __matches_filters(fragment, filters) })
+}
+
+/** Find one fragment by id, returning nil when it is absent. */
+pub fn prompt_library_find(library, id) {
+  for fragment in __require_library(library, "prompt_library_find") {
+    if fragment.id == id {
+      return fragment
+    }
+  }
+  return nil
+}
+
+/** Render one fragment to text. */
+pub fn prompt_library_inject(library, id, bindings = nil) {
+  let fragment = prompt_library_find(library, id)
+  require fragment != nil, "prompt_library_inject: unknown fragment '" + id + "'"
+  return __render_fragment(fragment, bindings)
+}
+
+/** Render one fragment with cache metadata for hosts that consume prompt blocks. */
+pub fn prompt_library_payload(library, id, bindings = nil) {
+  let fragment = prompt_library_find(library, id)
+  require fragment != nil, "prompt_library_payload: unknown fragment '" + id + "'"
+  return {
+    fragment_id: fragment.id,
+    text: __render_fragment(fragment, bindings),
+    cache_control: fragment?.cache_control ?? {type: "ephemeral"},
+    cache_ttl: fragment?.cache_ttl ?? "5m",
+    token_budget: fragment?.token_budget,
+    provenance: fragment?.provenance,
+  }
+}
+
+/** Render all matching fragments until `max_tokens` would be exceeded. */
+pub fn prompt_library_inject_cluster(library, filters = nil, bindings = nil) {
+  let max_tokens = filters?.max_tokens
+  var used = 0
+  var blocks = []
+  for fragment in prompt_library_list(library, filters) {
+    let budget = fragment?.token_budget ?? __estimate_tokens_text(fragment?.body ?? "")
+    if max_tokens != nil && used + budget > max_tokens {
+      continue
+    }
+    blocks = blocks.push(__render_fragment(fragment, bindings))
+    used = used + budget
+  }
+  return join(blocks, "\n\n")
+}
+
+/** Score and return likely useful fragments for a context. */
+pub fn prompt_library_suggest(library, ctx = nil) {
+  var scored = []
+  for fragment in __require_library(library, "prompt_library_suggest") {
+    let score = __score_fragment(fragment, ctx ?? {})
+    if score > 0 || (ctx?.query == nil && ctx?.tags == nil) {
+      scored = scored.push({score: score, fragment: fragment})
+    }
+  }
+  return __top_scored(scored, ctx?.limit ?? ctx?.top_n ?? 5)
+}
+
+/** Return a closure-backed namespace for `library.inject(...)` style calls. */
+pub fn prompt_library_api(library) {
+  return {
+    inject: fn(id, bindings = nil) { return prompt_library_inject(library, id, bindings) },
+    inject_cluster: fn(filters = nil, bindings = nil) { return prompt_library_inject_cluster(library, filters, bindings) },
+    payload: fn(id, bindings = nil) { return prompt_library_payload(library, id, bindings) },
+    suggest: fn(ctx = nil) { return prompt_library_suggest(library, ctx) },
+    list: fn(filters = nil) { return prompt_library_list(library, filters) },
+    find: fn(id) { return prompt_library_find(library, id) },
+  }
+}
+
+/** Build k-means prompt-hotspot fragment proposals from tenant-scoped conversations. */
+pub fn prompt_library_hotspots(conversations, options = nil) {
+  let tenant = options?.tenant_id
+  let max_prefix_tokens = options?.max_prefix_tokens ?? 1200
+  let min_fraction = options?.min_fraction ?? 0.8
+  let min_shared_tokens = options?.min_shared_tokens ?? 8
+  let daily_invocations = options?.daily_invocation_count ?? 1
+  let dollars_per_token = options?.dollars_per_token ?? 0.0
+  let min_monthly_savings = options?.min_monthly_savings_usd ?? 0.0
+  var records = []
+  var points = []
+  var index = 0
+  for conversation in conversations {
+    if tenant == nil || type_of(conversation) != "dict" || conversation?.tenant_id == tenant {
+      let text = __conversation_text(conversation)
+      let snippet = __token_prefix(text, max_prefix_tokens)
+      records = records
+        .push(
+        {
+        id: __conversation_id(conversation, index),
+        tenant_id: if type_of(conversation) == "dict" {
+        conversation?.tenant_id
+      } else {
+        nil
+      },
+        snippet: snippet,
+        embedding: __conversation_embedding(conversation, snippet),
+      },
+      )
+      points = points.push(records[-1].embedding)
+    }
+    index = index + 1
+  }
+  if len(records) == 0 {
+    return []
+  }
+  let chosen = __choose_kmeans(points, options ?? {})
+  var snippets_by_cluster = []
+  var members_by_cluster = []
+  var k = 0
+  while k < chosen.k {
+    snippets_by_cluster = snippets_by_cluster.push([])
+    members_by_cluster = members_by_cluster.push([])
+    k = k + 1
+  }
+  var idx = 0
+  while idx < len(records) {
+    let cluster = chosen.result.assignments[idx]
+    snippets_by_cluster[cluster] = snippets_by_cluster[cluster].push(records[idx].snippet)
+    members_by_cluster[cluster] = members_by_cluster[cluster].push(records[idx].id)
+    idx = idx + 1
+  }
+  var proposals = []
+  var cluster_id = 0
+  while cluster_id < len(snippets_by_cluster) {
+    let snippets = snippets_by_cluster[cluster_id]
+    if len(snippets) > 0 {
+      let prefix = __shared_prefix(snippets, min_fraction, min_shared_tokens)
+      if prefix.tokens >= min_shared_tokens {
+        let tokens_saved = prefix.tokens * (prefix.support - 1)
+        let monthly = tokens_saved * daily_invocations * 30.0 * dollars_per_token
+        if monthly >= min_monthly_savings {
+          let scope = tenant ?? "default"
+          let id = "kmeans-" + scope + "-" + substring(sha256(prefix.text), 0, 12)
+          proposals = proposals
+            .push(
+            prompt_fragment(
+            id,
+            prefix.text,
+            {
+            title: "K-means hotspot " + to_string(cluster_id),
+            tags: options?.tags ?? ["hotspot"],
+            token_budget: prefix.tokens,
+            provenance: "kmeans",
+            tenant_id: tenant,
+            status: "pending_review",
+            score: chosen.silhouette,
+            members: members_by_cluster[cluster_id],
+            support: prefix.support,
+            tokens_saved: tokens_saved,
+            monthly_savings_usd: monthly,
+          },
+          ),
+          )
+        }
+      }
+    }
+    cluster_id = cluster_id + 1
+  }
+  return proposals
+}
+
+/** Return pending k-means proposals in the shape expected by review UIs. */
+pub fn prompt_library_review_queue(library, filters = nil) {
+  var queue = []
+  let base_filters = filters ?? {}
+  let review_status = filters?.status ?? "pending_review"
+  let review_filters = base_filters + {provenance: "kmeans", status: review_status}
+  for fragment in prompt_library_list(library, review_filters) {
+    queue = queue
+      .push(
+      {
+      id: fragment.id,
+      title: fragment.title,
+      tenant_id: fragment?.tenant_id,
+      text: fragment.body,
+      token_budget: fragment?.token_budget,
+      support: fragment?.support,
+      members: fragment?.members ?? [],
+      tokens_saved: fragment?.tokens_saved ?? 0,
+      monthly_savings_usd: fragment?.monthly_savings_usd ?? 0.0,
+      status: fragment.status,
+    },
+    )
+  }
+  return queue
+}


### PR DESCRIPTION
## Summary
- add `std/prompt_library` for reusable prompt fragments, `.harn.prompt` front matter, TOML catalog loading, injection helpers, cache metadata payloads, and suggestion helpers
- add deterministic tenant-scoped k-means hotspot proposal generation plus review queue records for host/portal handoff
- wire the module into VM and packaged stdlib mirrors, add conformance coverage, and document the public API

Closes #313

## Validation
- `cargo run --quiet --bin harn -- test conformance --filter prompt_library`
- `cargo run --quiet --bin harn -- fmt --check crates/harn-vm/src/stdlib_prompt_library.harn conformance/tests/stdlib/prompt_library.harn`
- `cargo check -p harn-vm -p harn-modules`
- `./scripts/verify_crate_packages.sh`
- pre-commit hook: Rust fmt, Harn fmt/lint, clippy, highlight sync, markdownlint
- pre-push hook: workspace tests (`1963 passed`), affected Harn lint, markdownlint

Note: `HARN_BIN=/var/folders/1h/v3ltwjgn6h79_77xhvgxwgm80000gn/T/harn-target/7136-harn/debug/harn make check-docs-snippets` still reports existing unrelated ignored-snippet failures in other docs pages; the new prompt-library docs snippets are marked `harn,ignore` and did not introduce a reported failure.