### PR TITLE
[codex] Add handler capability sandbox enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,6 +1299,7 @@ dependencies = [
  "ignore",
  "jsonwebtoken",
  "keyring",
+ "libc",
  "md-5",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -30,6 +30,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 reqwest-eventsource = "0.6"
 tokio-tungstenite = { version = "0.26", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
+libc = "0.2"
 tokio-stream = "0.1"
 base64 = "0.22"
 data-encoding = "2"

--- a/crates/harn-vm/src/orchestration/policy/mod.rs
+++ b/crates/harn-vm/src/orchestration/policy/mod.rs
@@ -278,7 +278,9 @@ pub fn enforce_current_policy_for_builtin(name: &str, args: &[VmValue]) -> Resul
         return Ok(());
     };
     match name {
-        "read_file" if !policy_allows_capability(&policy, "workspace", "read_text") => {
+        "read_file" | "read_file_result" | "read_file_bytes"
+            if !policy_allows_capability(&policy, "workspace", "read_text") =>
+        {
             return reject_policy(format!(
                 "builtin '{name}' exceeds workspace.read_text ceiling"
             ));
@@ -289,7 +291,7 @@ pub fn enforce_current_policy_for_builtin(name: &str, args: &[VmValue]) -> Resul
         "file_exists" | "stat" if !policy_allows_capability(&policy, "workspace", "exists") => {
             return reject_policy(format!("builtin '{name}' exceeds workspace.exists ceiling"));
         }
-        "write_file" | "append_file" | "mkdir" | "copy_file"
+        "write_file" | "write_file_bytes" | "append_file" | "mkdir" | "copy_file"
             if !policy_allows_capability(&policy, "workspace", "write_text")
                 || !policy_allows_side_effect(&policy, "workspace_write") =>
         {

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1287,17 +1287,20 @@ pub async fn execute_stage_node(
             .filter(|value| !value.is_empty())
         {
             let mut process = if cfg!(target_os = "windows") {
-                let mut cmd = tokio::process::Command::new("cmd");
-                cmd.arg("/C").arg(command);
-                cmd
+                crate::stdlib::sandbox::tokio_command_for(
+                    "cmd",
+                    &["/C".to_string(), command.to_string()],
+                )?
             } else {
-                let mut cmd = tokio::process::Command::new("/bin/sh");
-                cmd.arg("-lc").arg(command);
-                cmd
+                crate::stdlib::sandbox::tokio_command_for(
+                    "/bin/sh",
+                    &["-lc".to_string(), command.to_string()],
+                )?
             };
             process.stdin(std::process::Stdio::null());
             if let Some(context) = crate::stdlib::process::current_execution_context() {
                 if let Some(cwd) = context.cwd.filter(|cwd| !cwd.is_empty()) {
+                    crate::stdlib::sandbox::enforce_process_cwd(std::path::Path::new(&cwd))?;
                     process.current_dir(cwd);
                 }
                 if !context.env.is_empty() {
@@ -1308,6 +1311,9 @@ pub async fn execute_stage_node(
                 .output()
                 .await
                 .map_err(|e| VmError::Runtime(format!("workflow verify exec failed: {e}")))?;
+            if let Some(error) = crate::stdlib::sandbox::process_violation_error(&output) {
+                return Err(error);
+            }
             let stdout = String::from_utf8_lossy(&output.stdout).to_string();
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();
             let combined = if stderr.is_empty() {

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1307,10 +1307,11 @@ pub async fn execute_stage_node(
                     process.envs(context.env);
                 }
             }
-            let output = process
-                .output()
-                .await
-                .map_err(|e| VmError::Runtime(format!("workflow verify exec failed: {e}")))?;
+            let output = process.output().await.map_err(|e| {
+                crate::stdlib::sandbox::process_spawn_error(&e).unwrap_or_else(|| {
+                    VmError::Runtime(format!("workflow verify exec failed: {e}"))
+                })
+            })?;
             if let Some(error) = crate::stdlib::sandbox::process_violation_error(&output) {
                 return Err(error);
             }

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -26,6 +26,7 @@ mod project_catalog;
 mod project_enrich;
 mod regex;
 mod review;
+pub(crate) mod sandbox;
 pub mod secret_scan;
 mod sets;
 mod shapes;
@@ -146,6 +147,7 @@ pub fn stdlib_builtin_names() -> Vec<String> {
 pub fn reset_stdlib_state() {
     logging::reset_logging_state();
     process::reset_process_state();
+    sandbox::reset_sandbox_state();
     fs::reset_fs_state();
     json::reset_json_state();
     host::reset_host_state();

--- a/crates/harn-vm/src/stdlib/fs.rs
+++ b/crates/harn-vm/src/stdlib/fs.rs
@@ -81,6 +81,11 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
     vm.register_builtin("read_file", |args, _out| {
         let path = args.first().map(|a| a.display()).unwrap_or_default();
         let resolved = resolve_fs_path(&path);
+        crate::stdlib::sandbox::enforce_fs_path(
+            "read_file",
+            &resolved,
+            crate::stdlib::sandbox::FsAccess::Read,
+        )?;
         if let Some(cached) = read_cached_text(&resolved) {
             return Ok(VmValue::String(cached));
         }
@@ -100,6 +105,13 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
     vm.register_builtin("read_file_result", |args, _out| {
         let path = args.first().map(|a| a.display()).unwrap_or_default();
         let resolved = resolve_fs_path(&path);
+        if let Err(error) = crate::stdlib::sandbox::enforce_fs_path(
+            "read_file_result",
+            &resolved,
+            crate::stdlib::sandbox::FsAccess::Read,
+        ) {
+            return Ok(result_err(VmValue::String(Rc::from(error.to_string()))));
+        }
         if let Some(cached) = read_cached_text(&resolved) {
             return Ok(result_ok(VmValue::String(cached)));
         }
@@ -119,6 +131,11 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
     vm.register_builtin("read_file_bytes", |args, _out| {
         let path = args.first().map(|a| a.display()).unwrap_or_default();
         let resolved = resolve_fs_path(&path);
+        crate::stdlib::sandbox::enforce_fs_path(
+            "read_file_bytes",
+            &resolved,
+            crate::stdlib::sandbox::FsAccess::Read,
+        )?;
         match std::fs::read(&resolved) {
             Ok(content) => Ok(VmValue::Bytes(Rc::new(content))),
             Err(e) => Err(VmError::Thrown(VmValue::String(Rc::from(format!(
@@ -133,6 +150,11 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
             let path = args[0].display();
             let content = args[1].display();
             let resolved = resolve_fs_path(&path);
+            crate::stdlib::sandbox::enforce_fs_path(
+                "write_file",
+                &resolved,
+                crate::stdlib::sandbox::FsAccess::Write,
+            )?;
             std::fs::write(&resolved, &content).map_err(|e| {
                 VmError::Thrown(VmValue::String(Rc::from(format!(
                     "Failed to write file {}: {e}",
@@ -157,6 +179,11 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
                     )))));
                 }
             };
+            crate::stdlib::sandbox::enforce_fs_path(
+                "write_file_bytes",
+                &resolved,
+                crate::stdlib::sandbox::FsAccess::Write,
+            )?;
             std::fs::write(&resolved, content).map_err(|e| {
                 VmError::Thrown(VmValue::String(Rc::from(format!(
                     "Failed to write file {}: {e}",
@@ -173,12 +200,22 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
     vm.register_builtin("file_exists", |args, _out| {
         let path = args.first().map(|a| a.display()).unwrap_or_default();
         let resolved = resolve_fs_path(&path);
+        crate::stdlib::sandbox::enforce_fs_path(
+            "file_exists",
+            &resolved,
+            crate::stdlib::sandbox::FsAccess::Read,
+        )?;
         Ok(VmValue::Bool(resolved.exists()))
     });
 
     vm.register_builtin("delete_file", |args, _out| {
         let path = args.first().map(|a| a.display()).unwrap_or_default();
         let resolved = resolve_fs_path(&path);
+        crate::stdlib::sandbox::enforce_fs_path(
+            "delete_file",
+            &resolved,
+            crate::stdlib::sandbox::FsAccess::Delete,
+        )?;
         if resolved.is_dir() {
             std::fs::remove_dir_all(&resolved).map_err(|e| {
                 VmError::Thrown(VmValue::String(Rc::from(format!(
@@ -206,6 +243,11 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
             let path = args[0].display();
             let content = args[1].display();
             let resolved = resolve_fs_path(&path);
+            crate::stdlib::sandbox::enforce_fs_path(
+                "append_file",
+                &resolved,
+                crate::stdlib::sandbox::FsAccess::Write,
+            )?;
             let mut file = std::fs::OpenOptions::new()
                 .append(true)
                 .create(true)
@@ -235,6 +277,11 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
             .map(|a| a.display())
             .unwrap_or_else(|| ".".to_string());
         let resolved = resolve_fs_path(&path);
+        crate::stdlib::sandbox::enforce_fs_path(
+            "list_dir",
+            &resolved,
+            crate::stdlib::sandbox::FsAccess::Read,
+        )?;
         let entries = std::fs::read_dir(&resolved).map_err(|e| {
             VmError::Thrown(VmValue::String(Rc::from(format!(
                 "Failed to list directory {}: {e}",
@@ -255,6 +302,11 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
     vm.register_builtin("mkdir", |args, _out| {
         let path = args.first().map(|a| a.display()).unwrap_or_default();
         let resolved = resolve_fs_path(&path);
+        crate::stdlib::sandbox::enforce_fs_path(
+            "mkdir",
+            &resolved,
+            crate::stdlib::sandbox::FsAccess::Write,
+        )?;
         std::fs::create_dir_all(&resolved).map_err(|e| {
             VmError::Thrown(VmValue::String(Rc::from(format!(
                 "Failed to create directory {}: {e}",
@@ -280,6 +332,16 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
             let dst = args[1].display();
             let resolved_src = resolve_fs_path(&src);
             let resolved_dst = resolve_fs_path(&dst);
+            crate::stdlib::sandbox::enforce_fs_path(
+                "copy_file",
+                &resolved_src,
+                crate::stdlib::sandbox::FsAccess::Read,
+            )?;
+            crate::stdlib::sandbox::enforce_fs_path(
+                "copy_file",
+                &resolved_dst,
+                crate::stdlib::sandbox::FsAccess::Write,
+            )?;
             std::fs::copy(&resolved_src, &resolved_dst).map_err(|e| {
                 VmError::Thrown(VmValue::String(Rc::from(format!(
                     "Failed to copy {} to {}: {e}",
@@ -303,6 +365,11 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
     vm.register_builtin("stat", |args, _out| {
         let path = args.first().map(|a| a.display()).unwrap_or_default();
         let resolved = resolve_fs_path(&path);
+        crate::stdlib::sandbox::enforce_fs_path(
+            "stat",
+            &resolved,
+            crate::stdlib::sandbox::FsAccess::Read,
+        )?;
         let metadata = std::fs::metadata(&resolved).map_err(|e| {
             VmError::Thrown(VmValue::String(Rc::from(format!(
                 "Failed to stat {}: {e}",

--- a/crates/harn-vm/src/stdlib/process.rs
+++ b/crates/harn-vm/src/stdlib/process.rs
@@ -410,9 +410,11 @@ fn exec_command(
 ) -> Result<std::process::Output, VmError> {
     let mut command = crate::stdlib::sandbox::std_command_for(cmd, args)?;
     apply_execution_context(&mut command, dir)?;
-    let output = command
-        .output()
-        .map_err(|e| VmError::Thrown(VmValue::String(Rc::from(format!("exec failed: {e}")))))?;
+    let output = command.output().map_err(|e| {
+        crate::stdlib::sandbox::process_spawn_error(&e).unwrap_or_else(|| {
+            VmError::Thrown(VmValue::String(Rc::from(format!("exec failed: {e}"))))
+        })
+    })?;
     if let Some(error) = crate::stdlib::sandbox::process_violation_error(&output) {
         return Err(error);
     }
@@ -428,9 +430,11 @@ fn exec_shell(
     let args = vec![flag.to_string(), script.to_string()];
     let mut command = crate::stdlib::sandbox::std_command_for(shell, &args)?;
     apply_execution_context(&mut command, dir)?;
-    let output = command
-        .output()
-        .map_err(|e| VmError::Thrown(VmValue::String(Rc::from(format!("shell failed: {e}")))))?;
+    let output = command.output().map_err(|e| {
+        crate::stdlib::sandbox::process_spawn_error(&e).unwrap_or_else(|| {
+            VmError::Thrown(VmValue::String(Rc::from(format!("shell failed: {e}"))))
+        })
+    })?;
     if let Some(error) = crate::stdlib::sandbox::process_violation_error(&output) {
         return Err(error);
     }

--- a/crates/harn-vm/src/stdlib/process.rs
+++ b/crates/harn-vm/src/stdlib/process.rs
@@ -137,8 +137,7 @@ pub(crate) fn register_process_builtins(vm: &mut Vm) {
         }
         let cmd = args[0].display();
         let cmd_args: Vec<String> = args[1..].iter().map(|a| a.display()).collect();
-        let output = exec_command(None, &cmd, &cmd_args)
-            .map_err(|e| VmError::Thrown(VmValue::String(Rc::from(e))))?;
+        let output = exec_command(None, &cmd, &cmd_args)?;
         Ok(vm_output_to_value(output))
     });
 
@@ -159,8 +158,7 @@ pub(crate) fn register_process_builtins(vm: &mut Vm) {
         } else {
             "-c"
         };
-        let output = exec_shell(None, shell, flag, &cmd)
-            .map_err(|e| VmError::Thrown(VmValue::String(Rc::from(e))))?;
+        let output = exec_shell(None, shell, flag, &cmd)?;
         Ok(vm_output_to_value(output))
     });
 
@@ -173,8 +171,7 @@ pub(crate) fn register_process_builtins(vm: &mut Vm) {
         let dir = args[0].display();
         let cmd = args[1].display();
         let cmd_args: Vec<String> = args[2..].iter().map(|a| a.display()).collect();
-        let output = exec_command(Some(dir.as_str()), &cmd, &cmd_args)
-            .map_err(|e| VmError::Thrown(VmValue::String(Rc::from(e))))?;
+        let output = exec_command(Some(dir.as_str()), &cmd, &cmd_args)?;
         Ok(vm_output_to_value(output))
     });
 
@@ -201,8 +198,7 @@ pub(crate) fn register_process_builtins(vm: &mut Vm) {
         } else {
             "-c"
         };
-        let output = exec_shell(Some(dir.as_str()), shell, flag, &cmd)
-            .map_err(|e| VmError::Thrown(VmValue::String(Rc::from(e))))?;
+        let output = exec_shell(Some(dir.as_str()), shell, flag, &cmd)?;
         Ok(vm_output_to_value(output))
     });
 
@@ -411,11 +407,16 @@ fn exec_command(
     dir: Option<&str>,
     cmd: &str,
     args: &[String],
-) -> Result<std::process::Output, String> {
-    let mut command = std::process::Command::new(cmd);
-    command.args(args);
-    apply_execution_context(&mut command, dir);
-    command.output().map_err(|e| format!("exec failed: {e}"))
+) -> Result<std::process::Output, VmError> {
+    let mut command = crate::stdlib::sandbox::std_command_for(cmd, args)?;
+    apply_execution_context(&mut command, dir)?;
+    let output = command
+        .output()
+        .map_err(|e| VmError::Thrown(VmValue::String(Rc::from(format!("exec failed: {e}")))))?;
+    if let Some(error) = crate::stdlib::sandbox::process_violation_error(&output) {
+        return Err(error);
+    }
+    Ok(output)
 }
 
 fn exec_shell(
@@ -423,18 +424,30 @@ fn exec_shell(
     shell: &str,
     flag: &str,
     script: &str,
-) -> Result<std::process::Output, String> {
-    let mut command = std::process::Command::new(shell);
-    command.arg(flag).arg(script);
-    apply_execution_context(&mut command, dir);
-    command.output().map_err(|e| format!("shell failed: {e}"))
+) -> Result<std::process::Output, VmError> {
+    let args = vec![flag.to_string(), script.to_string()];
+    let mut command = crate::stdlib::sandbox::std_command_for(shell, &args)?;
+    apply_execution_context(&mut command, dir)?;
+    let output = command
+        .output()
+        .map_err(|e| VmError::Thrown(VmValue::String(Rc::from(format!("shell failed: {e}")))))?;
+    if let Some(error) = crate::stdlib::sandbox::process_violation_error(&output) {
+        return Err(error);
+    }
+    Ok(output)
 }
 
-fn apply_execution_context(command: &mut std::process::Command, dir: Option<&str>) {
+fn apply_execution_context(
+    command: &mut std::process::Command,
+    dir: Option<&str>,
+) -> Result<(), VmError> {
     if let Some(dir) = dir {
-        command.current_dir(resolve_command_dir(dir));
+        let resolved = resolve_command_dir(dir);
+        crate::stdlib::sandbox::enforce_process_cwd(&resolved)?;
+        command.current_dir(resolved);
     } else if let Some(context) = current_execution_context() {
         if let Some(cwd) = context.cwd.filter(|cwd| !cwd.is_empty()) {
+            crate::stdlib::sandbox::enforce_process_cwd(std::path::Path::new(&cwd))?;
             command.current_dir(cwd);
         }
         if !context.env.is_empty() {
@@ -444,6 +457,7 @@ fn apply_execution_context(command: &mut std::process::Command, dir: Option<&str
     if let Some(value) = env_override(HARN_REPLAY_ENV) {
         command.env(HARN_REPLAY_ENV, value);
     }
+    Ok(())
 }
 
 fn resolve_command_dir(dir: &str) -> PathBuf {

--- a/crates/harn-vm/src/stdlib/sandbox.rs
+++ b/crates/harn-vm/src/stdlib/sandbox.rs
@@ -6,6 +6,13 @@ use std::process::Command;
 use crate::orchestration::CapabilityPolicy;
 use crate::value::{ErrorCategory, VmError};
 
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
+use std::io;
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
+use std::os::unix::process::CommandExt;
+
 const HANDLER_SANDBOX_ENV: &str = "HARN_HANDLER_SANDBOX";
 
 thread_local! {
@@ -78,12 +85,17 @@ pub(crate) fn enforce_process_cwd(path: &Path) -> Result<(), VmError> {
 }
 
 pub(crate) fn std_command_for(program: &str, args: &[String]) -> Result<Command, VmError> {
-    match command_wrapper(program, args)? {
+    let policy = active_sandbox_policy();
+    match command_wrapper(program, args, policy.as_ref())? {
         CommandWrapper::Direct => {
             let mut command = Command::new(program);
             command.args(args);
+            if let Some(policy) = policy {
+                platform_configure_std_command(&mut command, &policy)?;
+            }
             Ok(command)
         }
+        #[cfg(target_os = "macos")]
         CommandWrapper::Sandboxed { wrapper, args } => {
             let mut command = Command::new(wrapper);
             command.args(args);
@@ -96,12 +108,17 @@ pub(crate) fn tokio_command_for(
     program: &str,
     args: &[String],
 ) -> Result<tokio::process::Command, VmError> {
-    match command_wrapper(program, args)? {
+    let policy = active_sandbox_policy();
+    match command_wrapper(program, args, policy.as_ref())? {
         CommandWrapper::Direct => {
             let mut command = tokio::process::Command::new(program);
             command.args(args);
+            if let Some(policy) = policy {
+                platform_configure_tokio_command(&mut command, &policy)?;
+            }
             Ok(command)
         }
+        #[cfg(target_os = "macos")]
         CommandWrapper::Sandboxed { wrapper, args } => {
             let mut command = tokio::process::Command::new(wrapper);
             command.args(args);
@@ -127,7 +144,50 @@ pub(crate) fn process_violation_error(output: &std::process::Output) -> Option<V
             output.status.code().unwrap_or(-1)
         )));
     }
+    if sandbox_signal_status(output) {
+        return Some(sandbox_rejection(format!(
+            "sandbox violation: process was terminated by the OS sandbox (status {})",
+            output.status
+        )));
+    }
     None
+}
+
+pub(crate) fn process_spawn_error(error: &std::io::Error) -> Option<VmError> {
+    crate::orchestration::current_execution_policy()?;
+    if fallback_mode() == SandboxFallback::Off || !platform_sandbox_available() {
+        return None;
+    }
+    let message = error.to_string().to_ascii_lowercase();
+    if error.kind() == std::io::ErrorKind::PermissionDenied
+        || message.contains("operation not permitted")
+        || message.contains("permission denied")
+    {
+        return Some(sandbox_rejection(format!(
+            "sandbox violation: process was denied by the OS sandbox before exec: {error}"
+        )));
+    }
+    None
+}
+
+#[cfg(unix)]
+fn sandbox_signal_status(output: &std::process::Output) -> bool {
+    use std::os::unix::process::ExitStatusExt;
+
+    matches!(
+        output.status.signal(),
+        Some(libc::SIGSYS) | Some(libc::SIGABRT) | Some(libc::SIGKILL)
+    )
+}
+
+#[cfg(not(unix))]
+fn sandbox_signal_status(_output: &std::process::Output) -> bool {
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn platform_sandbox_available() -> bool {
+    linux_seccomp_available() || linux_landlock_abi_version() > 0
 }
 
 #[cfg(target_os = "macos")]
@@ -135,24 +195,81 @@ fn platform_sandbox_available() -> bool {
     Path::new("/usr/bin/sandbox-exec").exists()
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "openbsd")]
+fn platform_sandbox_available() -> bool {
+    true
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "openbsd")))]
 fn platform_sandbox_available() -> bool {
     false
 }
 
 enum CommandWrapper {
     Direct,
-    Sandboxed { wrapper: String, args: Vec<String> },
+    #[cfg(target_os = "macos")]
+    Sandboxed {
+        wrapper: String,
+        args: Vec<String>,
+    },
 }
 
-fn command_wrapper(program: &str, args: &[String]) -> Result<CommandWrapper, VmError> {
-    let Some(policy) = crate::orchestration::current_execution_policy() else {
+fn command_wrapper(
+    program: &str,
+    args: &[String],
+    policy: Option<&CapabilityPolicy>,
+) -> Result<CommandWrapper, VmError> {
+    let Some(policy) = policy else {
         return Ok(CommandWrapper::Direct);
     };
+    platform_command_wrapper(program, args, policy)
+}
+
+fn active_sandbox_policy() -> Option<CapabilityPolicy> {
     if fallback_mode() == SandboxFallback::Off {
-        return Ok(CommandWrapper::Direct);
+        return None;
     }
-    platform_command_wrapper(program, args, &policy)
+    crate::orchestration::current_execution_policy()
+}
+
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
+fn platform_configure_std_command(
+    command: &mut Command,
+    policy: &CapabilityPolicy,
+) -> Result<(), VmError> {
+    let profile = platform_process_profile(policy)?;
+    unsafe {
+        command.pre_exec(move || platform_apply_process_profile(&profile));
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
+fn platform_configure_tokio_command(
+    command: &mut tokio::process::Command,
+    policy: &CapabilityPolicy,
+) -> Result<(), VmError> {
+    let profile = platform_process_profile(policy)?;
+    unsafe {
+        command.pre_exec(move || platform_apply_process_profile(&profile));
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "openbsd")))]
+fn platform_configure_std_command(
+    _command: &mut Command,
+    _policy: &CapabilityPolicy,
+) -> Result<(), VmError> {
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "openbsd")))]
+fn platform_configure_tokio_command(
+    _command: &mut tokio::process::Command,
+    _policy: &CapabilityPolicy,
+) -> Result<(), VmError> {
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
@@ -178,7 +295,16 @@ fn platform_command_wrapper(
     })
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
+fn platform_command_wrapper(
+    _program: &str,
+    _args: &[String],
+    _policy: &CapabilityPolicy,
+) -> Result<CommandWrapper, VmError> {
+    Ok(CommandWrapper::Direct)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "openbsd")))]
 fn platform_command_wrapper(
     _program: &str,
     _args: &[String],
@@ -202,11 +328,13 @@ fn macos_sandbox_profile(policy: &CapabilityPolicy) -> String {
          (allow file-read*)\n\
          (allow file-write* (subpath \"/dev\") (subpath \"/tmp\") (subpath \"/private/tmp\"))\n",
     );
-    for root in roots {
-        profile.push_str(&format!(
-            "(allow file-write* (subpath \"{}\"))\n",
-            sandbox_profile_escape(&root.display().to_string())
-        ));
+    if policy_allows_workspace_write(policy) {
+        for root in roots {
+            profile.push_str(&format!(
+                "(allow file-write* (subpath \"{}\"))\n",
+                sandbox_profile_escape(&root.display().to_string())
+            ));
+        }
     }
     if policy_allows_network(policy) {
         profile.push_str("(allow network*)\n");
@@ -219,6 +347,495 @@ fn sandbox_profile_escape(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
+#[cfg(target_os = "linux")]
+struct PlatformProcessProfile {
+    landlock: Option<LinuxLandlockProfile>,
+    denied_syscalls: Vec<libc::c_long>,
+}
+
+#[cfg(target_os = "linux")]
+struct LinuxLandlockProfile {
+    ruleset_fd: libc::c_int,
+    rules: Vec<LinuxLandlockRule>,
+    handled_access_fs: u64,
+}
+
+#[cfg(target_os = "linux")]
+struct LinuxLandlockRule {
+    file: std::fs::File,
+    allowed_access: u64,
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for LinuxLandlockProfile {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.ruleset_fd);
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn platform_process_profile(policy: &CapabilityPolicy) -> Result<PlatformProcessProfile, VmError> {
+    Ok(PlatformProcessProfile {
+        landlock: linux_landlock_profile(policy)?,
+        denied_syscalls: linux_denied_syscalls(policy),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn platform_apply_process_profile(profile: &PlatformProcessProfile) -> io::Result<()> {
+    install_seccomp_filter(&profile.denied_syscalls)?;
+    if let Some(landlock) = &profile.landlock {
+        install_landlock_ruleset(landlock)?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn linux_seccomp_available() -> bool {
+    true
+}
+
+#[cfg(target_os = "linux")]
+fn linux_landlock_profile(
+    policy: &CapabilityPolicy,
+) -> Result<Option<LinuxLandlockProfile>, VmError> {
+    let abi = linux_landlock_abi_version();
+    if abi == 0 {
+        match fallback_mode() {
+            SandboxFallback::Enforce => {
+                return Err(sandbox_rejection(
+                    "Linux Landlock is not available; set HARN_HANDLER_SANDBOX=warn or off to run without filesystem isolation".to_string(),
+                ));
+            }
+            SandboxFallback::Warn => warn_once(
+                "handler_sandbox_linux_landlock_unavailable",
+                "Linux Landlock is not available; process filesystem isolation is disabled",
+            ),
+            SandboxFallback::Off => {}
+        }
+        return Ok(None);
+    }
+
+    let handled_access_fs = linux_landlock_handled_access(abi);
+    let ruleset_attr = LinuxLandlockRulesetAttr { handled_access_fs };
+    let ruleset_fd = unsafe {
+        libc::syscall(
+            libc::SYS_landlock_create_ruleset,
+            &ruleset_attr as *const LinuxLandlockRulesetAttr,
+            std::mem::size_of::<LinuxLandlockRulesetAttr>(),
+            0,
+        ) as libc::c_int
+    };
+    if ruleset_fd < 0 {
+        return Err(sandbox_rejection(format!(
+            "failed to create Linux Landlock ruleset: {}",
+            io::Error::last_os_error()
+        )));
+    }
+
+    let mut profile = LinuxLandlockProfile {
+        ruleset_fd,
+        rules: Vec::new(),
+        handled_access_fs,
+    };
+    for path in linux_system_read_roots() {
+        push_linux_landlock_rule(
+            &mut profile,
+            path,
+            LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR | LANDLOCK_ACCESS_FS_EXECUTE,
+            true,
+        )?;
+    }
+    let workspace_access = linux_workspace_access(policy);
+    for root in process_sandbox_roots(policy) {
+        push_linux_landlock_rule(&mut profile, root, workspace_access, false)?;
+    }
+    Ok(Some(profile))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_system_read_roots() -> Vec<PathBuf> {
+    [
+        "/bin",
+        "/lib",
+        "/lib64",
+        "/usr",
+        "/etc",
+        "/nix/store",
+        "/System",
+    ]
+    .into_iter()
+    .map(PathBuf::from)
+    .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn push_linux_landlock_rule(
+    profile: &mut LinuxLandlockProfile,
+    path: PathBuf,
+    allowed_access: u64,
+    optional: bool,
+) -> Result<(), VmError> {
+    let path = normalize_for_policy(&path);
+    let file = match std::fs::File::open(&path) {
+        Ok(file) => file,
+        Err(error) if optional && error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(sandbox_rejection(format!(
+                "failed to open sandbox path '{}': {error}",
+                path.display()
+            )));
+        }
+    };
+    profile.rules.push(LinuxLandlockRule {
+        file,
+        allowed_access: allowed_access & profile.handled_access_fs,
+    });
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn install_landlock_ruleset(profile: &LinuxLandlockProfile) -> io::Result<()> {
+    for rule in &profile.rules {
+        let path_beneath = LinuxLandlockPathBeneathAttr {
+            allowed_access: rule.allowed_access,
+            parent_fd: rule.file.as_raw_fd(),
+        };
+        let result = unsafe {
+            libc::syscall(
+                libc::SYS_landlock_add_rule,
+                profile.ruleset_fd,
+                LANDLOCK_RULE_PATH_BENEATH,
+                &path_beneath as *const LinuxLandlockPathBeneathAttr,
+                0,
+            )
+        };
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    unsafe {
+        if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let result = libc::syscall(libc::SYS_landlock_restrict_self, profile.ruleset_fd, 0);
+        if result < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn install_seccomp_filter(denied_syscalls: &[libc::c_long]) -> io::Result<()> {
+    unsafe {
+        if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    let mut filter = Vec::with_capacity(denied_syscalls.len() * 2 + 1);
+    filter.push(bpf_stmt(
+        (libc::BPF_LD | libc::BPF_W | libc::BPF_ABS) as u16,
+        0,
+    ));
+    for syscall in denied_syscalls {
+        filter.push(bpf_jump(
+            (libc::BPF_JMP | libc::BPF_JEQ | libc::BPF_K) as u16,
+            *syscall as u32,
+            0,
+            1,
+        ));
+        filter.push(bpf_stmt(
+            (libc::BPF_RET | libc::BPF_K) as u16,
+            libc::SECCOMP_RET_ERRNO | libc::EPERM as u32,
+        ));
+    }
+    filter.push(bpf_stmt(
+        (libc::BPF_RET | libc::BPF_K) as u16,
+        libc::SECCOMP_RET_ALLOW,
+    ));
+    let mut program = libc::sock_fprog {
+        len: filter.len() as u16,
+        filter: filter.as_mut_ptr(),
+    };
+    unsafe {
+        if libc::prctl(
+            libc::PR_SET_SECCOMP,
+            libc::SECCOMP_MODE_FILTER,
+            &mut program as *mut libc::sock_fprog,
+            0,
+            0,
+        ) != 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn bpf_stmt(code: u16, k: u32) -> libc::sock_filter {
+    libc::sock_filter {
+        code,
+        jt: 0,
+        jf: 0,
+        k,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn bpf_jump(code: u16, k: u32, jt: u8, jf: u8) -> libc::sock_filter {
+    libc::sock_filter { code, jt, jf, k }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_denied_syscalls(policy: &CapabilityPolicy) -> Vec<libc::c_long> {
+    let mut syscalls = vec![
+        libc::SYS_bpf,
+        libc::SYS_delete_module,
+        libc::SYS_fanotify_init,
+        libc::SYS_finit_module,
+        libc::SYS_init_module,
+        libc::SYS_kexec_file_load,
+        libc::SYS_kexec_load,
+        libc::SYS_mount,
+        libc::SYS_open_by_handle_at,
+        libc::SYS_perf_event_open,
+        libc::SYS_process_vm_readv,
+        libc::SYS_process_vm_writev,
+        libc::SYS_ptrace,
+        libc::SYS_reboot,
+        libc::SYS_swapon,
+        libc::SYS_swapoff,
+        libc::SYS_umount2,
+        libc::SYS_userfaultfd,
+    ];
+    if !policy_allows_network(policy) {
+        syscalls.extend([
+            libc::SYS_accept,
+            libc::SYS_accept4,
+            libc::SYS_bind,
+            libc::SYS_connect,
+            libc::SYS_listen,
+            libc::SYS_recvfrom,
+            libc::SYS_recvmsg,
+            libc::SYS_sendmsg,
+            libc::SYS_sendto,
+            libc::SYS_socket,
+            libc::SYS_socketpair,
+        ]);
+    }
+    syscalls.sort_unstable();
+    syscalls.dedup();
+    syscalls
+}
+
+#[cfg(target_os = "linux")]
+fn linux_workspace_access(policy: &CapabilityPolicy) -> u64 {
+    let read_access =
+        LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR | LANDLOCK_ACCESS_FS_EXECUTE;
+    let write_access = LANDLOCK_ACCESS_FS_WRITE_FILE
+        | LANDLOCK_ACCESS_FS_REMOVE_DIR
+        | LANDLOCK_ACCESS_FS_REMOVE_FILE
+        | LANDLOCK_ACCESS_FS_MAKE_CHAR
+        | LANDLOCK_ACCESS_FS_MAKE_DIR
+        | LANDLOCK_ACCESS_FS_MAKE_REG
+        | LANDLOCK_ACCESS_FS_MAKE_SOCK
+        | LANDLOCK_ACCESS_FS_MAKE_FIFO
+        | LANDLOCK_ACCESS_FS_MAKE_BLOCK
+        | LANDLOCK_ACCESS_FS_MAKE_SYM
+        | LANDLOCK_ACCESS_FS_REFER
+        | LANDLOCK_ACCESS_FS_TRUNCATE;
+    if policy.capabilities.is_empty() {
+        return read_access | write_access;
+    }
+    let mut access = 0;
+    if policy_allows_capability(policy, "workspace", &["read_text", "list", "exists"]) {
+        access |= read_access;
+    }
+    if policy_allows_capability(policy, "workspace", &["write_text"]) {
+        access |= write_access;
+    }
+    if policy_allows_capability(policy, "workspace", &["delete"]) {
+        access |= LANDLOCK_ACCESS_FS_REMOVE_DIR | LANDLOCK_ACCESS_FS_REMOVE_FILE;
+    }
+    if access == 0 {
+        read_access
+    } else {
+        access
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_landlock_abi_version() -> u32 {
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_landlock_create_ruleset,
+            std::ptr::null::<libc::c_void>(),
+            0,
+            LANDLOCK_CREATE_RULESET_VERSION,
+        )
+    };
+    if result <= 0 {
+        0
+    } else {
+        result as u32
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_landlock_handled_access(abi: u32) -> u64 {
+    let mut access = LANDLOCK_ACCESS_FS_EXECUTE
+        | LANDLOCK_ACCESS_FS_WRITE_FILE
+        | LANDLOCK_ACCESS_FS_READ_FILE
+        | LANDLOCK_ACCESS_FS_READ_DIR
+        | LANDLOCK_ACCESS_FS_REMOVE_DIR
+        | LANDLOCK_ACCESS_FS_REMOVE_FILE
+        | LANDLOCK_ACCESS_FS_MAKE_CHAR
+        | LANDLOCK_ACCESS_FS_MAKE_DIR
+        | LANDLOCK_ACCESS_FS_MAKE_REG
+        | LANDLOCK_ACCESS_FS_MAKE_SOCK
+        | LANDLOCK_ACCESS_FS_MAKE_FIFO
+        | LANDLOCK_ACCESS_FS_MAKE_BLOCK
+        | LANDLOCK_ACCESS_FS_MAKE_SYM;
+    if abi >= 2 {
+        access |= LANDLOCK_ACCESS_FS_REFER;
+    }
+    if abi >= 3 {
+        access |= LANDLOCK_ACCESS_FS_TRUNCATE;
+    }
+    access
+}
+
+#[cfg(target_os = "linux")]
+#[repr(C)]
+struct LinuxLandlockRulesetAttr {
+    handled_access_fs: u64,
+}
+
+#[cfg(target_os = "linux")]
+#[repr(C)]
+struct LinuxLandlockPathBeneathAttr {
+    allowed_access: u64,
+    parent_fd: libc::c_int,
+}
+
+#[cfg(target_os = "linux")]
+const LANDLOCK_CREATE_RULESET_VERSION: u32 = 1 << 0;
+#[cfg(target_os = "linux")]
+const LANDLOCK_RULE_PATH_BENEATH: libc::c_int = 1;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_EXECUTE: u64 = 1 << 0;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_WRITE_FILE: u64 = 1 << 1;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_READ_FILE: u64 = 1 << 2;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_READ_DIR: u64 = 1 << 3;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_REMOVE_DIR: u64 = 1 << 4;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_REMOVE_FILE: u64 = 1 << 5;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_MAKE_CHAR: u64 = 1 << 6;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_MAKE_DIR: u64 = 1 << 7;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_MAKE_REG: u64 = 1 << 8;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_MAKE_SOCK: u64 = 1 << 9;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_MAKE_FIFO: u64 = 1 << 10;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_MAKE_BLOCK: u64 = 1 << 11;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_MAKE_SYM: u64 = 1 << 12;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_REFER: u64 = 1 << 13;
+#[cfg(target_os = "linux")]
+const LANDLOCK_ACCESS_FS_TRUNCATE: u64 = 1 << 14;
+
+#[cfg(target_os = "openbsd")]
+struct PlatformProcessProfile {
+    unveil_rules: Vec<(String, String)>,
+    promises: String,
+}
+
+#[cfg(target_os = "openbsd")]
+fn platform_process_profile(policy: &CapabilityPolicy) -> Result<PlatformProcessProfile, VmError> {
+    let workspace_permissions = if policy_allows_workspace_write(policy) {
+        "rwcx"
+    } else {
+        "rx"
+    };
+    let mut unveil_rules = vec![
+        ("/bin".to_string(), "rx".to_string()),
+        ("/usr".to_string(), "rx".to_string()),
+        ("/lib".to_string(), "rx".to_string()),
+        ("/etc".to_string(), "r".to_string()),
+        ("/dev".to_string(), "rw".to_string()),
+    ];
+    for root in process_sandbox_roots(policy) {
+        unveil_rules.push((
+            root.display().to_string(),
+            workspace_permissions.to_string(),
+        ));
+    }
+
+    let mut promises = vec!["stdio", "rpath", "proc", "exec"];
+    if policy_allows_workspace_write(policy) {
+        promises.extend(["wpath", "cpath", "dpath"]);
+    }
+    if policy_allows_network(policy) {
+        promises.extend(["inet", "dns"]);
+    }
+    Ok(PlatformProcessProfile {
+        unveil_rules,
+        promises: promises.join(" "),
+    })
+}
+
+#[cfg(target_os = "openbsd")]
+fn platform_apply_process_profile(profile: &PlatformProcessProfile) -> io::Result<()> {
+    for (path, permissions) in &profile.unveil_rules {
+        let path = std::ffi::CString::new(path.as_str())
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "unveil path contains NUL"))?;
+        let permissions = std::ffi::CString::new(permissions.as_str()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "unveil permissions contain NUL",
+            )
+        })?;
+        unsafe {
+            if unveil(path.as_ptr(), permissions.as_ptr()) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+    }
+    unsafe {
+        if unveil(std::ptr::null(), std::ptr::null()) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    let promises = std::ffi::CString::new(profile.promises.as_str())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "pledge promises contain NUL"))?;
+    unsafe {
+        if pledge(promises.as_ptr(), std::ptr::null()) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "openbsd")]
+extern "C" {
+    fn pledge(promises: *const libc::c_char, execpromises: *const libc::c_char) -> libc::c_int;
+    fn unveil(path: *const libc::c_char, permissions: *const libc::c_char) -> libc::c_int;
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "openbsd")))]
 fn unavailable(message: &str) -> Result<CommandWrapper, VmError> {
     match fallback_mode() {
         SandboxFallback::Off | SandboxFallback::Warn => {
@@ -353,6 +970,24 @@ fn policy_allows_network(policy: &CapabilityPolicy) -> bool {
         .as_ref()
         .map(|level| rank(level) >= rank("network"))
         .unwrap_or(true)
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "openbsd"))]
+fn policy_allows_workspace_write(policy: &CapabilityPolicy) -> bool {
+    policy.capabilities.is_empty()
+        || policy_allows_capability(policy, "workspace", &["write_text", "delete"])
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "openbsd"))]
+fn policy_allows_capability(policy: &CapabilityPolicy, capability: &str, ops: &[&str]) -> bool {
+    policy
+        .capabilities
+        .get(capability)
+        .map(|allowed| {
+            ops.iter()
+                .any(|op| allowed.iter().any(|candidate| candidate == op))
+        })
+        .unwrap_or(false)
 }
 
 impl FsAccess {

--- a/crates/harn-vm/src/stdlib/sandbox.rs
+++ b/crates/harn-vm/src/stdlib/sandbox.rs
@@ -972,7 +972,7 @@ fn policy_allows_network(policy: &CapabilityPolicy) -> bool {
         .unwrap_or(true)
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "openbsd"))]
+#[cfg(any(target_os = "macos", target_os = "openbsd"))]
 fn policy_allows_workspace_write(policy: &CapabilityPolicy) -> bool {
     policy.capabilities.is_empty()
         || policy_allows_capability(policy, "workspace", &["write_text", "delete"])

--- a/crates/harn-vm/src/stdlib/sandbox.rs
+++ b/crates/harn-vm/src/stdlib/sandbox.rs
@@ -1,0 +1,393 @@
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use crate::orchestration::CapabilityPolicy;
+use crate::value::{ErrorCategory, VmError};
+
+const HANDLER_SANDBOX_ENV: &str = "HARN_HANDLER_SANDBOX";
+
+thread_local! {
+    static WARNED_KEYS: RefCell<BTreeSet<String>> = const { RefCell::new(BTreeSet::new()) };
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum FsAccess {
+    Read,
+    Write,
+    Delete,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SandboxFallback {
+    Off,
+    Warn,
+    Enforce,
+}
+
+pub(crate) fn reset_sandbox_state() {
+    WARNED_KEYS.with(|keys| keys.borrow_mut().clear());
+}
+
+pub(crate) fn enforce_fs_path(builtin: &str, path: &Path, access: FsAccess) -> Result<(), VmError> {
+    let Some(policy) = crate::orchestration::current_execution_policy() else {
+        return Ok(());
+    };
+    if policy.workspace_roots.is_empty() {
+        return Ok(());
+    }
+    let candidate = normalize_for_policy(path);
+    let roots = normalized_workspace_roots(&policy);
+    if roots.iter().any(|root| path_is_within(&candidate, root)) {
+        return Ok(());
+    }
+    Err(sandbox_rejection(format!(
+        "sandbox violation: builtin '{builtin}' attempted to {} '{}' outside workspace_roots [{}]",
+        access.verb(),
+        candidate.display(),
+        roots
+            .iter()
+            .map(|root| root.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )))
+}
+
+pub(crate) fn enforce_process_cwd(path: &Path) -> Result<(), VmError> {
+    let Some(policy) = crate::orchestration::current_execution_policy() else {
+        return Ok(());
+    };
+    if policy.workspace_roots.is_empty() {
+        return Ok(());
+    }
+    let candidate = normalize_for_policy(path);
+    let roots = normalized_workspace_roots(&policy);
+    if roots.iter().any(|root| path_is_within(&candidate, root)) {
+        return Ok(());
+    }
+    Err(sandbox_rejection(format!(
+        "sandbox violation: process cwd '{}' is outside workspace_roots [{}]",
+        candidate.display(),
+        roots
+            .iter()
+            .map(|root| root.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )))
+}
+
+pub(crate) fn std_command_for(program: &str, args: &[String]) -> Result<Command, VmError> {
+    match command_wrapper(program, args)? {
+        CommandWrapper::Direct => {
+            let mut command = Command::new(program);
+            command.args(args);
+            Ok(command)
+        }
+        CommandWrapper::Sandboxed { wrapper, args } => {
+            let mut command = Command::new(wrapper);
+            command.args(args);
+            Ok(command)
+        }
+    }
+}
+
+pub(crate) fn tokio_command_for(
+    program: &str,
+    args: &[String],
+) -> Result<tokio::process::Command, VmError> {
+    match command_wrapper(program, args)? {
+        CommandWrapper::Direct => {
+            let mut command = tokio::process::Command::new(program);
+            command.args(args);
+            Ok(command)
+        }
+        CommandWrapper::Sandboxed { wrapper, args } => {
+            let mut command = tokio::process::Command::new(wrapper);
+            command.args(args);
+            Ok(command)
+        }
+    }
+}
+
+pub(crate) fn process_violation_error(output: &std::process::Output) -> Option<VmError> {
+    crate::orchestration::current_execution_policy()?;
+    if fallback_mode() == SandboxFallback::Off || !platform_sandbox_available() {
+        return None;
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+    let stdout = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
+    if !output.status.success()
+        && (stderr.contains("operation not permitted")
+            || stderr.contains("permission denied")
+            || stdout.contains("operation not permitted"))
+    {
+        return Some(sandbox_rejection(format!(
+            "sandbox violation: process was denied by the OS sandbox (status {})",
+            output.status.code().unwrap_or(-1)
+        )));
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn platform_sandbox_available() -> bool {
+    Path::new("/usr/bin/sandbox-exec").exists()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn platform_sandbox_available() -> bool {
+    false
+}
+
+enum CommandWrapper {
+    Direct,
+    Sandboxed { wrapper: String, args: Vec<String> },
+}
+
+fn command_wrapper(program: &str, args: &[String]) -> Result<CommandWrapper, VmError> {
+    let Some(policy) = crate::orchestration::current_execution_policy() else {
+        return Ok(CommandWrapper::Direct);
+    };
+    if fallback_mode() == SandboxFallback::Off {
+        return Ok(CommandWrapper::Direct);
+    }
+    platform_command_wrapper(program, args, &policy)
+}
+
+#[cfg(target_os = "macos")]
+fn platform_command_wrapper(
+    program: &str,
+    args: &[String],
+    policy: &CapabilityPolicy,
+) -> Result<CommandWrapper, VmError> {
+    let sandbox_exec = Path::new("/usr/bin/sandbox-exec");
+    if !sandbox_exec.exists() {
+        return unavailable("macOS sandbox-exec is not available");
+    }
+    let mut wrapped_args = vec![
+        "-p".to_string(),
+        macos_sandbox_profile(policy),
+        "--".to_string(),
+        program.to_string(),
+    ];
+    wrapped_args.extend(args.iter().cloned());
+    Ok(CommandWrapper::Sandboxed {
+        wrapper: sandbox_exec.display().to_string(),
+        args: wrapped_args,
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn platform_command_wrapper(
+    _program: &str,
+    _args: &[String],
+    _policy: &CapabilityPolicy,
+) -> Result<CommandWrapper, VmError> {
+    unavailable(&format!(
+        "handler OS sandbox is not implemented for {}",
+        std::env::consts::OS
+    ))
+}
+
+#[cfg(target_os = "macos")]
+fn macos_sandbox_profile(policy: &CapabilityPolicy) -> String {
+    let roots = process_sandbox_roots(policy);
+    let mut profile = String::from(
+        "(version 1)\n\
+         (deny default)\n\
+         (allow process*)\n\
+         (allow sysctl-read)\n\
+         (allow mach-lookup)\n\
+         (allow file-read*)\n\
+         (allow file-write* (subpath \"/dev\") (subpath \"/tmp\") (subpath \"/private/tmp\"))\n",
+    );
+    for root in roots {
+        profile.push_str(&format!(
+            "(allow file-write* (subpath \"{}\"))\n",
+            sandbox_profile_escape(&root.display().to_string())
+        ));
+    }
+    if policy_allows_network(policy) {
+        profile.push_str("(allow network*)\n");
+    }
+    profile
+}
+
+#[cfg(target_os = "macos")]
+fn sandbox_profile_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn unavailable(message: &str) -> Result<CommandWrapper, VmError> {
+    match fallback_mode() {
+        SandboxFallback::Off | SandboxFallback::Warn => {
+            warn_once("handler_sandbox_unavailable", message);
+            Ok(CommandWrapper::Direct)
+        }
+        SandboxFallback::Enforce => Err(sandbox_rejection(format!(
+            "{message}; set {HANDLER_SANDBOX_ENV}=warn or off to run unsandboxed"
+        ))),
+    }
+}
+
+fn fallback_mode() -> SandboxFallback {
+    match std::env::var(HANDLER_SANDBOX_ENV)
+        .unwrap_or_else(|_| "warn".to_string())
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "0" | "false" | "off" | "none" => SandboxFallback::Off,
+        "1" | "true" | "enforce" | "required" => SandboxFallback::Enforce,
+        _ => SandboxFallback::Warn,
+    }
+}
+
+fn warn_once(key: &str, message: &str) {
+    let inserted = WARNED_KEYS.with(|keys| keys.borrow_mut().insert(key.to_string()));
+    if inserted {
+        crate::events::log_warn("handler_sandbox", message);
+    }
+}
+
+fn sandbox_rejection(message: String) -> VmError {
+    VmError::CategorizedError {
+        message,
+        category: ErrorCategory::ToolRejected,
+    }
+}
+
+fn normalized_workspace_roots(policy: &CapabilityPolicy) -> Vec<PathBuf> {
+    policy
+        .workspace_roots
+        .iter()
+        .map(|root| normalize_for_policy(&resolve_policy_path(root)))
+        .collect()
+}
+
+fn process_sandbox_roots(policy: &CapabilityPolicy) -> Vec<PathBuf> {
+    let roots = if policy.workspace_roots.is_empty() {
+        vec![crate::stdlib::process::execution_root_path()]
+    } else {
+        normalized_workspace_roots(policy)
+    };
+    roots
+        .into_iter()
+        .map(|root| normalize_for_policy(&root))
+        .collect()
+}
+
+fn resolve_policy_path(path: &str) -> PathBuf {
+    let candidate = PathBuf::from(path);
+    if candidate.is_absolute() {
+        candidate
+    } else {
+        crate::stdlib::process::execution_root_path().join(candidate)
+    }
+}
+
+fn normalize_for_policy(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        crate::stdlib::process::execution_root_path().join(path)
+    };
+    let absolute = normalize_lexically(&absolute);
+    if let Ok(canonical) = absolute.canonicalize() {
+        return canonical;
+    }
+
+    let mut existing = absolute.as_path();
+    let mut suffix = Vec::new();
+    while !existing.exists() {
+        let Some(parent) = existing.parent() else {
+            return normalize_lexically(&absolute);
+        };
+        if let Some(name) = existing.file_name() {
+            suffix.push(name.to_os_string());
+        }
+        existing = parent;
+    }
+
+    let mut normalized = existing
+        .canonicalize()
+        .unwrap_or_else(|_| normalize_lexically(existing));
+    for component in suffix.iter().rev() {
+        normalized.push(component);
+    }
+    normalize_lexically(&normalized)
+}
+
+fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn path_is_within(path: &Path, root: &Path) -> bool {
+    path == root || path.starts_with(root)
+}
+
+fn policy_allows_network(policy: &CapabilityPolicy) -> bool {
+    fn rank(value: &str) -> usize {
+        match value {
+            "none" => 0,
+            "read_only" => 1,
+            "workspace_write" => 2,
+            "process_exec" => 3,
+            "network" => 4,
+            _ => 5,
+        }
+    }
+    policy
+        .side_effect_level
+        .as_ref()
+        .map(|level| rank(level) >= rank("network"))
+        .unwrap_or(true)
+}
+
+impl FsAccess {
+    fn verb(self) -> &'static str {
+        match self {
+            FsAccess::Read => "read",
+            FsAccess::Write => "write",
+            FsAccess::Delete => "delete",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_create_path_normalizes_against_existing_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("a/../new.txt");
+        let normalized = normalize_for_policy(&nested);
+        assert_eq!(
+            normalized,
+            normalize_for_policy(&dir.path().join("new.txt"))
+        );
+    }
+
+    #[test]
+    fn path_within_root_accepts_root_and_children() {
+        let root = Path::new("/tmp/harn-root");
+        assert!(path_is_within(root, root));
+        assert!(path_is_within(Path::new("/tmp/harn-root/file"), root));
+        assert!(!path_is_within(
+            Path::new("/tmp/harn-root-other/file"),
+            root
+        ));
+    }
+}

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -142,6 +142,16 @@ where
     })
 }
 
+fn run_harn_with_policy(
+    source: &str,
+    policy: crate::orchestration::CapabilityPolicy,
+) -> Result<(String, VmValue), VmError> {
+    crate::orchestration::push_execution_policy(policy);
+    let result = run_harn_result(source);
+    crate::orchestration::pop_execution_policy();
+    result
+}
+
 fn run_vm(source: &str) -> String {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -1214,6 +1224,173 @@ let results = parallel(2) { i ->
         msg.contains("not permitted"),
         "expected not permitted in parallel VM, got: {msg}"
     );
+}
+
+#[test]
+fn test_policy_workspace_roots_catch_filesystem_escapes() {
+    let allowed = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let outside_file = outside.path().join("secret.txt");
+    std::fs::write(&outside_file, "secret").unwrap();
+    let outside_copy = outside.path().join("copy.txt");
+    let outside_new = outside.path().join("new.txt");
+    let outside_dir = outside.path().join("new_dir");
+
+    let policy = crate::orchestration::CapabilityPolicy {
+        capabilities: std::collections::BTreeMap::from([(
+            "workspace".to_string(),
+            vec![
+                "read_text".to_string(),
+                "list".to_string(),
+                "exists".to_string(),
+                "write_text".to_string(),
+                "delete".to_string(),
+            ],
+        )]),
+        workspace_roots: vec![allowed.path().display().to_string()],
+        side_effect_level: Some("workspace_write".to_string()),
+        ..Default::default()
+    };
+
+    let escapes = [
+        format!(
+            r#"pipeline t(task) {{ read_file("{}") }}"#,
+            outside_file.display()
+        ),
+        format!(
+            r#"pipeline t(task) {{ read_file_bytes("{}") }}"#,
+            outside_file.display()
+        ),
+        format!(
+            r#"pipeline t(task) {{ write_file("{}", "x") }}"#,
+            outside_new.display()
+        ),
+        format!(
+            r#"pipeline t(task) {{ append_file("{}", "x") }}"#,
+            outside_file.display()
+        ),
+        format!(
+            r#"pipeline t(task) {{ copy_file("{}", "{}") }}"#,
+            outside_file.display(),
+            allowed.path().join("copy.txt").display()
+        ),
+        format!(
+            r#"pipeline t(task) {{ copy_file("{}", "{}") }}"#,
+            allowed.path().join("missing.txt").display(),
+            outside_copy.display()
+        ),
+        format!(
+            r#"pipeline t(task) {{ list_dir("{}") }}"#,
+            outside.path().display()
+        ),
+        format!(
+            r#"pipeline t(task) {{ mkdir("{}") }}"#,
+            outside_dir.display()
+        ),
+        format!(
+            r#"pipeline t(task) {{ stat("{}") }}"#,
+            outside_file.display()
+        ),
+        format!(
+            r#"pipeline t(task) {{ delete_file("{}") }}"#,
+            outside_file.display()
+        ),
+        format!(
+            r#"pipeline t(task) {{ file_exists("{}") }}"#,
+            outside_file.display()
+        ),
+    ];
+
+    for source in escapes {
+        let err = run_harn_with_policy(&source, policy.clone()).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                VmError::CategorizedError {
+                    category: crate::value::ErrorCategory::ToolRejected,
+                    ..
+                }
+            ),
+            "expected tool_rejected for source {source}, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("sandbox violation"),
+            "expected sandbox violation message, got {err}"
+        );
+    }
+}
+
+#[test]
+fn test_policy_workspace_roots_reject_process_cwd_escape() {
+    let allowed = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let policy = crate::orchestration::CapabilityPolicy {
+        capabilities: std::collections::BTreeMap::from([(
+            "process".to_string(),
+            vec!["exec".to_string()],
+        )]),
+        workspace_roots: vec![allowed.path().display().to_string()],
+        side_effect_level: Some("process_exec".to_string()),
+        ..Default::default()
+    };
+
+    let source = format!(
+        r#"pipeline t(task) {{ exec_at("{}", "sh", "-c", "true") }}"#,
+        outside.path().display()
+    );
+    let err = run_harn_with_policy(&source, policy).unwrap_err();
+    assert!(matches!(
+        err,
+        VmError::CategorizedError {
+            category: crate::value::ErrorCategory::ToolRejected,
+            ..
+        }
+    ));
+    assert!(err.to_string().contains("process cwd"));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn test_macos_process_sandbox_surfaces_denial_as_typed_error() {
+    if !std::path::Path::new("/usr/bin/sandbox-exec").exists() {
+        return;
+    }
+    let cwd = std::env::current_dir().unwrap();
+    let allowed = tempfile::tempdir_in(&cwd).unwrap();
+    let outside_base = cwd.parent().unwrap_or(cwd.as_path());
+    let outside = tempfile::tempdir_in(outside_base).unwrap();
+    let outside_file = outside.path().join("blocked.txt");
+    let previous = std::env::var("HARN_HANDLER_SANDBOX").ok();
+    std::env::set_var("HARN_HANDLER_SANDBOX", "enforce");
+
+    let policy = crate::orchestration::CapabilityPolicy {
+        capabilities: std::collections::BTreeMap::from([(
+            "process".to_string(),
+            vec!["exec".to_string()],
+        )]),
+        workspace_roots: vec![allowed.path().display().to_string()],
+        side_effect_level: Some("process_exec".to_string()),
+        ..Default::default()
+    };
+    let source = format!(
+        r#"pipeline t(task) {{ shell("printf denied > '{}'") }}"#,
+        outside_file.display()
+    );
+    let err = run_harn_with_policy(&source, policy).unwrap_err();
+    match previous {
+        Some(value) => std::env::set_var("HARN_HANDLER_SANDBOX", value),
+        None => std::env::remove_var("HARN_HANDLER_SANDBOX"),
+    }
+
+    assert!(matches!(
+        err,
+        VmError::CategorizedError {
+            category: crate::value::ErrorCategory::ToolRejected,
+            ..
+        }
+    ));
+    assert!(err.to_string().contains("sandbox violation"));
+    assert!(!outside_file.exists());
 }
 
 #[test]

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -1357,7 +1357,13 @@ fn test_macos_process_sandbox_surfaces_denial_as_typed_error() {
     }
     let cwd = std::env::current_dir().unwrap();
     let allowed = tempfile::tempdir_in(&cwd).unwrap();
-    let outside_base = cwd.parent().unwrap_or(cwd.as_path());
+    let outside_base = std::env::var_os("HOME")
+        .map(std::path::PathBuf::from)
+        .filter(|path| path.is_dir())
+        .unwrap_or_else(|| cwd.parent().unwrap_or(cwd.as_path()).to_path_buf());
+    if outside_base.starts_with("/tmp") || outside_base.starts_with("/private/tmp") {
+        return;
+    }
     let outside = tempfile::tempdir_in(outside_base).unwrap();
     let outside_file = outside.path().join("blocked.txt");
     let previous = std::env::var("HARN_HANDLER_SANDBOX").ok();

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -1393,6 +1393,114 @@ fn test_macos_process_sandbox_surfaces_denial_as_typed_error() {
     assert!(!outside_file.exists());
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn test_linux_process_sandbox_catches_ten_process_escapes() {
+    let allowed = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let outside_file = outside.path().join("secret.txt");
+    let outside_new = outside.path().join("new.txt");
+    let outside_copy = outside.path().join("copy.txt");
+    let outside_dir = outside.path().join("new_dir");
+    let allowed_file = allowed.path().join("allowed.txt");
+    std::fs::write(&outside_file, "secret").unwrap();
+    std::fs::write(&allowed_file, "allowed").unwrap();
+
+    let previous = std::env::var("HARN_HANDLER_SANDBOX").ok();
+    std::env::set_var("HARN_HANDLER_SANDBOX", "enforce");
+
+    let policy = crate::orchestration::CapabilityPolicy {
+        capabilities: std::collections::BTreeMap::from([
+            ("process".to_string(), vec!["exec".to_string()]),
+            (
+                "workspace".to_string(),
+                vec![
+                    "read_text".to_string(),
+                    "list".to_string(),
+                    "exists".to_string(),
+                    "write_text".to_string(),
+                    "delete".to_string(),
+                ],
+            ),
+        ]),
+        workspace_roots: vec![allowed.path().display().to_string()],
+        side_effect_level: Some("process_exec".to_string()),
+        ..Default::default()
+    };
+
+    let escapes = [
+        format!("cat {}", shell_quote(&outside_file)),
+        format!("printf x > {}", shell_quote(&outside_new)),
+        format!("printf x >> {}", shell_quote(&outside_file)),
+        format!("mkdir {}", shell_quote(&outside_dir)),
+        format!("rm {}", shell_quote(&outside_file)),
+        format!(
+            "cp {} {}",
+            shell_quote(&outside_file),
+            shell_quote(&allowed.path().join("copy.txt"))
+        ),
+        format!(
+            "cp {} {}",
+            shell_quote(&allowed_file),
+            shell_quote(&outside_copy)
+        ),
+        format!(
+            "mv {} {}",
+            shell_quote(&allowed_file),
+            shell_quote(&outside.path().join("moved.txt"))
+        ),
+        format!(
+            "ln -s {} {} && cat {}",
+            shell_quote(&outside_file),
+            shell_quote(&allowed.path().join("link.txt")),
+            shell_quote(&allowed.path().join("link.txt"))
+        ),
+        format!("touch {}", shell_quote(&outside.path().join("touched.txt"))),
+    ];
+    assert_eq!(escapes.len(), 10);
+
+    for command in escapes {
+        let source = format!(
+            r#"pipeline t(task) {{ shell("{}") }}"#,
+            harn_string_escape(&command)
+        );
+        let err = run_harn_with_policy(&source, policy.clone()).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                VmError::CategorizedError {
+                    category: crate::value::ErrorCategory::ToolRejected,
+                    ..
+                }
+            ),
+            "expected tool_rejected for command {command}, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("sandbox violation"),
+            "expected sandbox violation for command {command}, got {err}"
+        );
+    }
+
+    match previous {
+        Some(value) => std::env::set_var("HARN_HANDLER_SANDBOX", value),
+        None => std::env::remove_var("HARN_HANDLER_SANDBOX"),
+    }
+    assert!(outside_file.exists());
+    assert!(!outside_new.exists());
+    assert!(!outside_copy.exists());
+    assert!(!outside_dir.exists());
+}
+
+#[cfg(target_os = "linux")]
+fn shell_quote(path: &std::path::Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
+}
+
+#[cfg(target_os = "linux")]
+fn harn_string_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 #[test]
 fn test_if_else_has_lexical_block_scope() {
     let out = run_output(

--- a/crates/harn-wasm/Cargo.toml
+++ b/crates/harn-wasm/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "harn-wasm"
-version.workspace = true
-edition.workspace = true
-license.workspace = true
-repository.workspace = true
+version = "0.7.31"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/burin-labs/harn"
 description = "WebAssembly target for the Harn programming language playground"
 
 [lib]

--- a/crates/harn-wasm/src/lib.rs
+++ b/crates/harn-wasm/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use harn_lexer::Lexer;
-use harn_parser::{Node, Parser};
+use harn_parser::{Node, Parser, SNode, TypedParam};
 use wasm_bindgen::prelude::*;
 
 /// Execute Harn source code and return the output as a plain string.
@@ -46,6 +46,17 @@ pub fn execute(source: &str) -> Result<String, JsError> {
     Ok(interp.output)
 }
 
+/// Execute a pure-compute handler through the WASM sandbox entrypoint.
+///
+/// The exported name mirrors the `harn:pure-handler/run` WIT function in
+/// `wit/harn-pure.wit`. The sync interpreter intentionally has no filesystem,
+/// process, network, LLM, or async host imports, so unsupported side effects
+/// fail as ordinary runtime errors inside the component boundary.
+#[wasm_bindgen(js_name = executePureComponent)]
+pub fn execute_pure_component(source: &str) -> Result<String, JsError> {
+    execute(source)
+}
+
 /// Lex source code and return tokens as JSON.
 #[wasm_bindgen]
 pub fn tokenize(source: &str) -> Result<String, JsError> {
@@ -83,11 +94,9 @@ pub fn format_code(source: &str) -> String {
 // This is a stripped-down version of the async Interpreter, without tokio dependencies.
 
 use harn_lexer::StringSegment;
-use harn_parser::{DictEntry, MatchArm};
-
 struct SyncInterpreter {
     env: Env,
-    pipelines: BTreeMap<String, Node>,
+    pipelines: BTreeMap<String, SNode>,
     output: String,
 }
 
@@ -100,7 +109,7 @@ enum Val {
     Nil,
     List(Vec<Val>),
     Dict(BTreeMap<String, Val>),
-    Closure(Vec<String>, Vec<Node>, Env),
+    Closure(Vec<String>, Vec<SNode>, Env),
 }
 
 impl Val {
@@ -135,16 +144,14 @@ impl Val {
                 format!("[{}]", inner.join(", "))
             }
             Val::Dict(map) => {
-                let inner: Vec<String> =
-                    map.iter().map(|(k, v)| format!("{k}: {}", v.as_string())).collect();
+                let inner: Vec<String> = map
+                    .iter()
+                    .map(|(k, v)| format!("{k}: {}", v.as_string()))
+                    .collect();
                 format!("{{{}}}", inner.join(", "))
             }
             Val::Closure(..) => "<fn>".to_string(),
         }
-    }
-
-    fn as_int(&self) -> Option<i64> {
-        if let Val::Int(n) = self { Some(*n) } else { None }
     }
 }
 
@@ -169,15 +176,23 @@ struct Env {
 
 impl Env {
     fn new() -> Self {
-        Self { values: BTreeMap::new(), parent: None }
+        Self {
+            values: BTreeMap::new(),
+            parent: None,
+        }
     }
 
     fn child(&self) -> Self {
-        Self { values: BTreeMap::new(), parent: Some(Box::new(self.clone())) }
+        Self {
+            values: BTreeMap::new(),
+            parent: Some(Box::new(self.clone())),
+        }
     }
 
     fn get(&self, name: &str) -> Option<Val> {
-        self.values.get(name).map(|(v, _)| v.clone())
+        self.values
+            .get(name)
+            .map(|(v, _)| v.clone())
             .or_else(|| self.parent.as_ref()?.get(name))
     }
 
@@ -210,18 +225,27 @@ impl SyncInterpreter {
         }
     }
 
-    fn run(&mut self, program: &[Node]) -> Result<(), String> {
+    fn run(&mut self, program: &[SNode]) -> Result<(), String> {
         for node in program {
-            if let Node::Pipeline { name, .. } = node {
+            if let Node::Pipeline { name, .. } = &node.node {
                 self.pipelines.insert(name.clone(), node.clone());
             }
         }
 
         let main = self.pipelines.get("default").cloned().or_else(|| {
-            program.iter().find(|n| matches!(n, Node::Pipeline { .. })).cloned()
+            program
+                .iter()
+                .find(|n| matches!(&n.node, Node::Pipeline { .. }))
+                .cloned()
         });
 
-        let Some(Node::Pipeline { params, body, .. }) = main else { return Ok(()) };
+        let Some(SNode {
+            node: Node::Pipeline { params, body, .. },
+            ..
+        }) = main
+        else {
+            return Ok(());
+        };
 
         if params.iter().any(|p| p == "task") {
             self.env.define("task", Val::String(String::new()), false);
@@ -233,7 +257,7 @@ impl SyncInterpreter {
         }
     }
 
-    fn exec(&mut self, stmts: &[Node]) -> Result<Val, EvalStop> {
+    fn exec(&mut self, stmts: &[SNode]) -> Result<Val, EvalStop> {
         let mut result = Val::Nil;
         for stmt in stmts {
             result = self.eval(stmt)?;
@@ -283,11 +307,12 @@ impl SyncInterpreter {
                     }
                 }
             }
+            harn_parser::BindingPattern::Pair(_, _) => {}
         }
     }
 
-    fn eval(&mut self, node: &Node) -> Result<Val, EvalStop> {
-        match node {
+    fn eval(&mut self, node: &SNode) -> Result<Val, EvalStop> {
+        match &node.node {
             Node::LetBinding { pattern, value, .. } => {
                 let val = self.eval(value)?;
                 self.define_pattern(pattern, val, false);
@@ -300,12 +325,16 @@ impl SyncInterpreter {
             }
             Node::Assignment { target, value, .. } => {
                 let val = self.eval(value)?;
-                if let Node::Identifier(name) = target.as_ref() {
+                if let Node::Identifier(name) = &target.as_ref().node {
                     self.env.assign(name, val).map_err(EvalStop::Error)?;
                 }
                 Ok(Val::Nil)
             }
-            Node::IfElse { condition, then_body, else_body } => {
+            Node::IfElse {
+                condition,
+                then_body,
+                else_body,
+            } => {
                 if self.eval(condition)?.is_truthy() {
                     self.exec(then_body)
                 } else if let Some(eb) = else_body {
@@ -314,16 +343,23 @@ impl SyncInterpreter {
                     Ok(Val::Nil)
                 }
             }
-            Node::ForIn { pattern, iterable, body } => {
+            Node::ForIn {
+                pattern,
+                iterable,
+                body,
+            } => {
                 let iter_val = self.eval(iterable)?;
                 let items = match iter_val {
                     Val::List(items) => items,
-                    Val::Dict(map) => map.into_iter().map(|(k, v)| {
-                        Val::Dict(BTreeMap::from([
-                            ("key".to_string(), Val::String(k)),
-                            ("value".to_string(), v),
-                        ]))
-                    }).collect(),
+                    Val::Dict(map) => map
+                        .into_iter()
+                        .map(|(k, v)| {
+                            Val::Dict(BTreeMap::from([
+                                ("key".to_string(), Val::String(k)),
+                                ("value".to_string(), v),
+                            ]))
+                        })
+                        .collect(),
                     _ => return Ok(Val::Nil),
                 };
                 let saved = self.env.clone();
@@ -339,7 +375,9 @@ impl SyncInterpreter {
             Node::WhileLoop { condition, body } => {
                 let mut result = Val::Nil;
                 for _ in 0..10_000 {
-                    if !self.eval(condition)?.is_truthy() { break; }
+                    if !self.eval(condition)?.is_truthy() {
+                        break;
+                    }
                     result = self.exec(body)?;
                 }
                 Ok(result)
@@ -352,7 +390,13 @@ impl SyncInterpreter {
                 let val = self.eval(value)?;
                 Err(EvalStop::Error(format!("Thrown: {}", val.as_string())))
             }
-            Node::TryCatch { body, error_var, catch_body, finally_body, .. } => {
+            Node::TryCatch {
+                body,
+                error_var,
+                catch_body,
+                finally_body,
+                ..
+            } => {
                 let result = match self.exec(body) {
                     Ok(v) => Ok(v),
                     Err(EvalStop::Return(v)) => Err(EvalStop::Return(v)),
@@ -368,23 +412,24 @@ impl SyncInterpreter {
                 }
                 result
             }
-            Node::TryExpr { body } => {
-                match self.exec(body) {
-                    Ok(v) => {
-                        let mut d = BTreeMap::new();
-                        d.insert("ok".into(), v);
-                        Ok(Val::Dict(d))
-                    }
-                    Err(EvalStop::Return(v)) => Err(EvalStop::Return(v)),
-                    Err(EvalStop::Error(e)) => {
-                        let mut d = BTreeMap::new();
-                        d.insert("err".into(), Val::String(e));
-                        Ok(Val::Dict(d))
-                    }
+            Node::TryExpr { body } => match self.exec(body) {
+                Ok(v) => {
+                    let mut d = BTreeMap::new();
+                    d.insert("ok".into(), v);
+                    Ok(Val::Dict(d))
                 }
-            }
-            Node::FnDecl { name, params, body, .. } => {
-                let closure = Val::Closure(params.clone(), body.clone(), self.env.clone());
+                Err(EvalStop::Return(v)) => Err(EvalStop::Return(v)),
+                Err(EvalStop::Error(e)) => {
+                    let mut d = BTreeMap::new();
+                    d.insert("err".into(), Val::String(e));
+                    Ok(Val::Dict(d))
+                }
+            },
+            Node::FnDecl {
+                name, params, body, ..
+            } => {
+                let closure =
+                    Val::Closure(TypedParam::names(params), body.clone(), self.env.clone());
                 self.env.define(name, closure, false);
                 Ok(Val::Nil)
             }
@@ -401,13 +446,21 @@ impl SyncInterpreter {
                 }
                 Err(EvalStop::Error(format!("Undefined builtin: {name}")))
             }
-            Node::MethodCall { object, method, args } => {
+            Node::MethodCall {
+                object,
+                method,
+                args,
+            } => {
                 let obj = self.eval(object)?;
                 let arg_vals: Result<Vec<_>, _> = args.iter().map(|a| self.eval(a)).collect();
                 let arg_vals = arg_vals?;
                 self.eval_method(obj, method, &arg_vals)
             }
-            Node::OptionalMethodCall { object, method, args } => {
+            Node::OptionalMethodCall {
+                object,
+                method,
+                args,
+            } => {
                 let obj = self.eval(object)?;
                 if matches!(obj, Val::Nil) {
                     return Ok(Val::Nil);
@@ -419,7 +472,10 @@ impl SyncInterpreter {
             Node::PropertyAccess { object, property }
             | Node::OptionalPropertyAccess { object, property } => {
                 let obj = self.eval(object)?;
-                if matches!((&obj, &node.node), (Val::Nil, Node::OptionalPropertyAccess { .. })) {
+                if matches!(
+                    (&obj, &node.node),
+                    (Val::Nil, Node::OptionalPropertyAccess { .. })
+                ) {
                     return Ok(Val::Nil);
                 }
                 match &obj {
@@ -467,12 +523,24 @@ impl SyncInterpreter {
                         let len = items.len() as i64;
                         let s = match &start_val {
                             Val::Nil => 0,
-                            Val::Int(i) => if *i < 0 { (len + *i).max(0) } else { (*i).min(len) },
+                            Val::Int(i) => {
+                                if *i < 0 {
+                                    (len + *i).max(0)
+                                } else {
+                                    (*i).min(len)
+                                }
+                            }
                             _ => 0,
                         };
                         let e = match &end_val {
                             Val::Nil => len,
-                            Val::Int(i) => if *i < 0 { (len + *i).max(0) } else { (*i).min(len) },
+                            Val::Int(i) => {
+                                if *i < 0 {
+                                    (len + *i).max(0)
+                                } else {
+                                    (*i).min(len)
+                                }
+                            }
                             _ => len,
                         };
                         if s >= e {
@@ -486,12 +554,24 @@ impl SyncInterpreter {
                         let len = chars.len() as i64;
                         let s = match &start_val {
                             Val::Nil => 0,
-                            Val::Int(i) => if *i < 0 { (len + *i).max(0) } else { (*i).min(len) },
+                            Val::Int(i) => {
+                                if *i < 0 {
+                                    (len + *i).max(0)
+                                } else {
+                                    (*i).min(len)
+                                }
+                            }
                             _ => 0,
                         };
                         let e = match &end_val {
                             Val::Nil => len,
-                            Val::Int(i) => if *i < 0 { (len + *i).max(0) } else { (*i).min(len) },
+                            Val::Int(i) => {
+                                if *i < 0 {
+                                    (len + *i).max(0)
+                                } else {
+                                    (*i).min(len)
+                                }
+                            }
                             _ => len,
                         };
                         if s >= e {
@@ -516,7 +596,11 @@ impl SyncInterpreter {
                     _ => Ok(Val::Nil),
                 }
             }
-            Node::Ternary { condition, true_expr, false_expr } => {
+            Node::Ternary {
+                condition,
+                true_expr,
+                false_expr,
+            } => {
                 if self.eval(condition)?.is_truthy() {
                     self.eval(true_expr)
                 } else {
@@ -530,9 +614,13 @@ impl SyncInterpreter {
                         StringSegment::Literal(s) => result.push_str(s),
                         StringSegment::Expression(expr, line, col) => {
                             let mut lexer = Lexer::with_position(expr, *line, *col);
-                            let tokens = lexer.tokenize().map_err(|e| EvalStop::Error(e.to_string()))?;
+                            let tokens = lexer
+                                .tokenize()
+                                .map_err(|e| EvalStop::Error(e.to_string()))?;
                             let mut parser = Parser::new(tokens);
-                            let node = parser.parse_single_expression().map_err(|e| EvalStop::Error(e.to_string()))?;
+                            let node = parser
+                                .parse_single_expression()
+                                .map_err(|e| EvalStop::Error(e.to_string()))?;
                             let val = self.eval(&node)?;
                             result.push_str(&val.as_string());
                         }
@@ -559,9 +647,11 @@ impl SyncInterpreter {
                 }
                 Ok(Val::Dict(map))
             }
-            Node::Closure { params, body } => {
-                Ok(Val::Closure(params.clone(), body.clone(), self.env.clone()))
-            }
+            Node::Closure { params, body, .. } => Ok(Val::Closure(
+                TypedParam::names(params),
+                body.clone(),
+                self.env.clone(),
+            )),
             Node::MatchExpr { value, arms } => {
                 let val = self.eval(value)?;
                 for arm in arms {
@@ -576,11 +666,18 @@ impl SyncInterpreter {
         }
     }
 
-    fn invoke_closure(&mut self, params: &[String], body: &[Node], cenv: &Env, args: &[Val]) -> Result<Val, EvalStop> {
+    fn invoke_closure(
+        &mut self,
+        params: &[String],
+        body: &[SNode],
+        cenv: &Env,
+        args: &[Val],
+    ) -> Result<Val, EvalStop> {
         let saved = self.env.clone();
         self.env = cenv.child();
         for (i, param) in params.iter().enumerate() {
-            self.env.define(param, args.get(i).cloned().unwrap_or(Val::Nil), false);
+            self.env
+                .define(param, args.get(i).cloned().unwrap_or(Val::Nil), false);
         }
         let result = self.exec(body);
         self.env = saved;
@@ -594,15 +691,25 @@ impl SyncInterpreter {
     fn eval_method(&mut self, obj: Val, method: &str, args: &[Val]) -> Result<Val, EvalStop> {
         match &obj {
             Val::String(s) => match method {
-                "contains" => Ok(Val::Bool(s.contains(&args.first().map(|a| a.as_string()).unwrap_or_default()))),
-                "replace" if args.len() >= 2 => Ok(Val::String(s.replace(&args[0].as_string(), &args[1].as_string()))),
+                "contains" => Ok(Val::Bool(
+                    s.contains(&args.first().map(|a| a.as_string()).unwrap_or_default()),
+                )),
+                "replace" if args.len() >= 2 => Ok(Val::String(
+                    s.replace(&args[0].as_string(), &args[1].as_string()),
+                )),
                 "split" => {
                     let sep = args.first().map(|a| a.as_string()).unwrap_or(",".into());
-                    Ok(Val::List(s.split(&sep).map(|p| Val::String(p.to_string())).collect()))
+                    Ok(Val::List(
+                        s.split(&sep).map(|p| Val::String(p.to_string())).collect(),
+                    ))
                 }
                 "trim" => Ok(Val::String(s.trim().to_string())),
-                "starts_with" => Ok(Val::Bool(s.starts_with(&args.first().map(|a| a.as_string()).unwrap_or_default()))),
-                "ends_with" => Ok(Val::Bool(s.ends_with(&args.first().map(|a| a.as_string()).unwrap_or_default()))),
+                "starts_with" => Ok(Val::Bool(
+                    s.starts_with(&args.first().map(|a| a.as_string()).unwrap_or_default()),
+                )),
+                "ends_with" => Ok(Val::Bool(
+                    s.ends_with(&args.first().map(|a| a.as_string()).unwrap_or_default()),
+                )),
                 "lowercase" => Ok(Val::String(s.to_lowercase())),
                 "uppercase" => Ok(Val::String(s.to_uppercase())),
                 "count" => Ok(Val::Int(s.chars().count() as i64)),
@@ -616,28 +723,44 @@ impl SyncInterpreter {
                     if let Some(Val::Closure(params, body, cenv)) = args.first() {
                         let mut results = Vec::new();
                         for item in items {
-                            results.push(self.invoke_closure(params, body, cenv, &[item.clone()])?);
+                            results.push(self.invoke_closure(
+                                params,
+                                body,
+                                cenv,
+                                &[item.clone()],
+                            )?);
                         }
                         Ok(Val::List(results))
-                    } else { Ok(Val::Nil) }
+                    } else {
+                        Ok(Val::Nil)
+                    }
                 }
                 "filter" => {
                     if let Some(Val::Closure(params, body, cenv)) = args.first() {
                         let mut results = Vec::new();
                         for item in items {
-                            if self.invoke_closure(params, body, cenv, &[item.clone()])?.is_truthy() {
+                            if self
+                                .invoke_closure(params, body, cenv, &[item.clone()])?
+                                .is_truthy()
+                            {
                                 results.push(item.clone());
                             }
                         }
                         Ok(Val::List(results))
-                    } else { Ok(Val::Nil) }
+                    } else {
+                        Ok(Val::Nil)
+                    }
                 }
                 _ => Ok(Val::Nil),
             },
             Val::Dict(map) => match method {
-                "keys" => Ok(Val::List(map.keys().map(|k| Val::String(k.clone())).collect())),
+                "keys" => Ok(Val::List(
+                    map.keys().map(|k| Val::String(k.clone())).collect(),
+                )),
                 "values" => Ok(Val::List(map.values().cloned().collect())),
-                "has" => Ok(Val::Bool(map.contains_key(&args.first().map(|a| a.as_string()).unwrap_or_default()))),
+                "has" => Ok(Val::Bool(map.contains_key(
+                    &args.first().map(|a| a.as_string()).unwrap_or_default(),
+                ))),
                 "count" => Ok(Val::Int(map.len() as i64)),
                 _ => Ok(Val::Nil),
             },
@@ -645,17 +768,27 @@ impl SyncInterpreter {
         }
     }
 
-    fn eval_binary(&mut self, op: &str, left: &Node, right: &Node) -> Result<Val, EvalStop> {
+    fn eval_binary(&mut self, op: &str, left: &SNode, right: &SNode) -> Result<Val, EvalStop> {
         if op == "??" {
             let lv = self.eval(left)?;
-            return if matches!(lv, Val::Nil) { self.eval(right) } else { Ok(lv) };
+            return if matches!(lv, Val::Nil) {
+                self.eval(right)
+            } else {
+                Ok(lv)
+            };
         }
         if op == "&&" {
-            return Ok(Val::Bool(self.eval(left)?.is_truthy() && self.eval(right)?.is_truthy()));
+            return Ok(Val::Bool(
+                self.eval(left)?.is_truthy() && self.eval(right)?.is_truthy(),
+            ));
         }
         if op == "||" {
             let lv = self.eval(left)?;
-            return if lv.is_truthy() { Ok(Val::Bool(true)) } else { Ok(Val::Bool(self.eval(right)?.is_truthy())) };
+            return if lv.is_truthy() {
+                Ok(Val::Bool(true))
+            } else {
+                Ok(Val::Bool(self.eval(right)?.is_truthy()))
+            };
         }
         if op == "|>" {
             let lv = self.eval(left)?;
@@ -663,7 +796,7 @@ impl SyncInterpreter {
             if let Val::Closure(params, body, cenv) = rv {
                 return self.invoke_closure(&params, &body, &cenv, &[lv]);
             }
-            if let Node::Identifier(name) = right {
+            if let Node::Identifier(name) = &right.node {
                 if let Some(Val::Closure(params, body, cenv)) = self.env.get(name) {
                     return self.invoke_closure(&params, &body, &cenv, &[lv]);
                 }
@@ -707,9 +840,35 @@ impl SyncInterpreter {
             "<" | ">" | "<=" | ">=" => {
                 let cmp = match (&lv, &rv) {
                     (Val::Int(a), Val::Int(b)) => a.cmp(b) as i32,
-                    (Val::Float(a), Val::Float(b)) => if a < b { -1 } else if a > b { 1 } else { 0 },
-                    (Val::Int(a), Val::Float(b)) => { let a = *a as f64; if a < *b { -1 } else if a > *b { 1 } else { 0 } },
-                    (Val::Float(a), Val::Int(b)) => { let b = *b as f64; if *a < b { -1 } else if *a > b { 1 } else { 0 } },
+                    (Val::Float(a), Val::Float(b)) => {
+                        if a < b {
+                            -1
+                        } else if a > b {
+                            1
+                        } else {
+                            0
+                        }
+                    }
+                    (Val::Int(a), Val::Float(b)) => {
+                        let a = *a as f64;
+                        if a < *b {
+                            -1
+                        } else if a > *b {
+                            1
+                        } else {
+                            0
+                        }
+                    }
+                    (Val::Float(a), Val::Int(b)) => {
+                        let b = *b as f64;
+                        if *a < b {
+                            -1
+                        } else if *a > b {
+                            1
+                        } else {
+                            0
+                        }
+                    }
                     _ => 0,
                 };
                 Ok(Val::Bool(match op {
@@ -719,7 +878,7 @@ impl SyncInterpreter {
                     ">=" => cmp >= 0,
                     _ => false,
                 }))
-            },
+            }
             "in" => {
                 let result = match &rv {
                     Val::List(items) => items.iter().any(|v| vals_equal(v, &lv)),

--- a/crates/harn-wasm/wit/harn-pure.wit
+++ b/crates/harn-wasm/wit/harn-pure.wit
@@ -1,0 +1,9 @@
+package harn:pure-handler;
+
+world pure-handler {
+  /// Run a pure-compute Harn handler and return captured output.
+  ///
+  /// Implementations of this world must not import filesystem, process,
+  /// network, clock, random, or LLM host capabilities.
+  export run: func(source: string) -> result<string, string>;
+}

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -3821,6 +3821,23 @@ Sandbox restrictions propagate to child VMs created by `spawn`,
 `parallel`, and `parallel each`. A child VM inherits the same set of
 denied builtins as its parent.
 
+### Handler capability sandbox
+
+When a workflow or handler runs under an active `CapabilityPolicy`,
+Harn also enforces `workspace_roots` at runtime for filesystem builtins.
+Attempts to read, write, create, copy, stat, list, or delete paths outside
+the declared roots fail as typed `tool_rejected` sandbox violations.
+Process cwd escapes through `exec_at` / `shell_at` are rejected the same way.
+
+Process execution is wrapped in an OS sandbox when Harn can do so for the
+current platform. On macOS, Harn generates a `sandbox-exec` profile from
+the active capability policy: writes are limited to declared
+`workspace_roots` plus process plumbing locations, and network access is
+allowed only when the policy side-effect ceiling permits `network`.
+Unsupported platforms warn once and run the process unsandboxed by default.
+Set `HARN_HANDLER_SANDBOX=enforce` to fail closed when no OS sandbox is
+available, or `HARN_HANDLER_SANDBOX=off` to disable the process wrapper.
+
 ## Test framework
 
 Harn includes a built-in test runner invoked via `harn test`.

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -3829,14 +3829,25 @@ Attempts to read, write, create, copy, stat, list, or delete paths outside
 the declared roots fail as typed `tool_rejected` sandbox violations.
 Process cwd escapes through `exec_at` / `shell_at` are rejected the same way.
 
+Pure-compute handlers can run through the WASM sandbox entrypoint exposed
+by `harn-wasm` as `executePureComponent` and described by
+`crates/harn-wasm/wit/harn-pure.wit`. That component surface has no host
+imports for filesystem, process, network, clock, random, LLM, or async
+effects, so attempted side effects fail inside the component boundary.
+
 Process execution is wrapped in an OS sandbox when Harn can do so for the
-current platform. On macOS, Harn generates a `sandbox-exec` profile from
-the active capability policy: writes are limited to declared
-`workspace_roots` plus process plumbing locations, and network access is
-allowed only when the policy side-effect ceiling permits `network`.
-Unsupported platforms warn once and run the process unsandboxed by default.
-Set `HARN_HANDLER_SANDBOX=enforce` to fail closed when no OS sandbox is
-available, or `HARN_HANDLER_SANDBOX=off` to disable the process wrapper.
+current platform. On Linux, Harn installs a seccomp-BPF filter that returns
+`EPERM` for denied syscalls and a Landlock filesystem ruleset derived from
+the active `CapabilityPolicy`. On OpenBSD, Harn applies `pledge` promises
+and `unveil` path permissions derived from the same policy. On macOS, Harn
+generates a `sandbox-exec` profile from the active capability policy:
+writes are limited to process plumbing locations plus declared
+`workspace_roots` only when the policy allows workspace writes, and network
+access is allowed only when the policy side-effect ceiling permits
+`network`. Unsupported platforms warn once and run the process unsandboxed
+by default. Set `HARN_HANDLER_SANDBOX=enforce` to fail closed when no OS
+sandbox is available, or `HARN_HANDLER_SANDBOX=off` to disable the process
+wrapper.
 
 ## Test framework
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -3827,14 +3827,25 @@ Attempts to read, write, create, copy, stat, list, or delete paths outside
 the declared roots fail as typed `tool_rejected` sandbox violations.
 Process cwd escapes through `exec_at` / `shell_at` are rejected the same way.
 
+Pure-compute handlers can run through the WASM sandbox entrypoint exposed
+by `harn-wasm` as `executePureComponent` and described by
+`crates/harn-wasm/wit/harn-pure.wit`. That component surface has no host
+imports for filesystem, process, network, clock, random, LLM, or async
+effects, so attempted side effects fail inside the component boundary.
+
 Process execution is wrapped in an OS sandbox when Harn can do so for the
-current platform. On macOS, Harn generates a `sandbox-exec` profile from
-the active capability policy: writes are limited to declared
-`workspace_roots` plus process plumbing locations, and network access is
-allowed only when the policy side-effect ceiling permits `network`.
-Unsupported platforms warn once and run the process unsandboxed by default.
-Set `HARN_HANDLER_SANDBOX=enforce` to fail closed when no OS sandbox is
-available, or `HARN_HANDLER_SANDBOX=off` to disable the process wrapper.
+current platform. On Linux, Harn installs a seccomp-BPF filter that returns
+`EPERM` for denied syscalls and a Landlock filesystem ruleset derived from
+the active `CapabilityPolicy`. On OpenBSD, Harn applies `pledge` promises
+and `unveil` path permissions derived from the same policy. On macOS, Harn
+generates a `sandbox-exec` profile from the active capability policy:
+writes are limited to process plumbing locations plus declared
+`workspace_roots` only when the policy allows workspace writes, and network
+access is allowed only when the policy side-effect ceiling permits
+`network`. Unsupported platforms warn once and run the process unsandboxed
+by default. Set `HARN_HANDLER_SANDBOX=enforce` to fail closed when no OS
+sandbox is available, or `HARN_HANDLER_SANDBOX=off` to disable the process
+wrapper.
 
 ## Test framework
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -3819,6 +3819,23 @@ Sandbox restrictions propagate to child VMs created by `spawn`,
 `parallel`, and `parallel each`. A child VM inherits the same set of
 denied builtins as its parent.
 
+### Handler capability sandbox
+
+When a workflow or handler runs under an active `CapabilityPolicy`,
+Harn also enforces `workspace_roots` at runtime for filesystem builtins.
+Attempts to read, write, create, copy, stat, list, or delete paths outside
+the declared roots fail as typed `tool_rejected` sandbox violations.
+Process cwd escapes through `exec_at` / `shell_at` are rejected the same way.
+
+Process execution is wrapped in an OS sandbox when Harn can do so for the
+current platform. On macOS, Harn generates a `sandbox-exec` profile from
+the active capability policy: writes are limited to declared
+`workspace_roots` plus process plumbing locations, and network access is
+allowed only when the policy side-effect ceiling permits `network`.
+Unsupported platforms warn once and run the process unsandboxed by default.
+Set `HARN_HANDLER_SANDBOX=enforce` to fail closed when no OS sandbox is
+available, or `HARN_HANDLER_SANDBOX=off` to disable the process wrapper.
+
 ## Test framework
 
 Harn includes a built-in test runner invoked via `harn test`.


### PR DESCRIPTION
## Summary

- add a policy-derived handler sandbox layer for filesystem and process escape surfaces
- enforce `CapabilityPolicy.workspace_roots` for filesystem builtins and process cwd selection with typed `tool_rejected` errors
- wrap process execution with platform sandboxes when an execution policy is active:
  - Linux: seccomp-BPF `EPERM` deny rules plus Landlock filesystem rulesets derived from policy roots/capabilities
  - OpenBSD: `pledge` promises plus `unveil` path permissions derived from policy roots/capabilities
  - macOS: generated `sandbox-exec` profile with policy-derived write/network permissions
- expose a pure-compute WASM handler entrypoint and WIT contract for component-model-style sandboxing without host imports
- keep unsupported-platform behavior configurable with `HARN_HANDLER_SANDBOX=warn|enforce|off`
- document the handler sandbox behavior in the language spec

Closes #296

## Validation

- `cargo fmt --check`
- `cargo check -p harn-vm`
- `cargo test -p harn-vm policy_workspace_roots -- --nocapture`
- `cargo test -p harn-vm sandbox -- --nocapture`
- `cargo test -p harn-vm`
- `cd crates/harn-wasm && cargo fmt --check && cargo check`
- Docker Linux: `cargo test -p harn-vm test_linux_process_sandbox_catches_ten_process_escapes -- --nocapture`
- pre-commit hook: fmt, clippy, highlight sync, markdownlint
- pre-push hook: nextest workspace suite (1,968 passed), markdownlint
