### PR TITLE
Add orchestrator ACP WebSocket endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -166,8 +167,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.28.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -1173,6 +1176,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "tokio-tungstenite 0.28.0",
  "toml",
  "tower 0.5.3",
  "tracing",
@@ -1316,7 +1320,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "tokio-util",
  "toml",
  "tracing",
@@ -3425,7 +3429,23 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.26.2",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -3709,6 +3729,25 @@ name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -39,7 +39,7 @@ harn-modules = { path = "../harn-modules", version = "0.7" }
 harn-fmt = { path = "../harn-fmt", version = "0.7" }
 harn-serve = { path = "../harn-serve", version = "0.7" }
 async-trait = "0.1"
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "sync", "time"] }
 serde_json = "1"
@@ -74,3 +74,4 @@ fs2 = "0.4"
 [dev-dependencies]
 hmac = "0.13"
 rcgen = "0.13"
+tokio-tungstenite = { version = "0.28", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }

--- a/crates/harn-cli/src/acp/events.rs
+++ b/crates/harn-cli/src/acp/events.rs
@@ -1,22 +1,21 @@
 //! ACP AgentEventSink — translates canonical `AgentEvent` variants into ACP
 //! `session/update` notifications. Registered per-session at prompt start.
 
-use std::io::Write;
-use std::sync::Arc;
-
 use harn_vm::agent_events::{AgentEvent, AgentEventSink};
 use harn_vm::visible_text::sanitize_visible_assistant_text;
+
+use super::AcpOutput;
 
 /// Writes canonical ACP `session/update` notifications for each
 /// `AgentEvent` the turn loop emits. Holds only the minimum state needed
 /// to serialize notifications without the full AcpBridge.
 pub(super) struct AcpAgentEventSink {
-    stdout_lock: Arc<std::sync::Mutex<()>>,
+    output: AcpOutput,
 }
 
 impl AcpAgentEventSink {
-    pub(super) fn new(stdout_lock: Arc<std::sync::Mutex<()>>) -> Self {
-        Self { stdout_lock }
+    pub(super) fn new(output: AcpOutput) -> Self {
+        Self { output }
     }
 
     fn write_notification(&self, params: serde_json::Value) {
@@ -26,11 +25,7 @@ impl AcpAgentEventSink {
             "params": params,
         });
         if let Ok(line) = serde_json::to_string(&notification) {
-            let _guard = self.stdout_lock.lock().unwrap_or_else(|e| e.into_inner());
-            let mut stdout = std::io::stdout().lock();
-            let _ = stdout.write_all(line.as_bytes());
-            let _ = stdout.write_all(b"\n");
-            let _ = stdout.flush();
+            self.output.write_line(&line);
         }
     }
 

--- a/crates/harn-cli/src/acp/io.rs
+++ b/crates/harn-cli/src/acp/io.rs
@@ -1,49 +1,14 @@
-//! Free-standing ACP stdout writers shared between the server and bridge.
+//! Free-standing ACP writers shared between the server and bridge.
 //!
 //! These helpers bypass `AcpServer`/`AcpBridge` and write directly through
-//! the stdout mutex. They are used from contexts where we only hold the
-//! lock (e.g. cancellation/error paths and the agent event sink).
+//! the transport output sink. They are used from contexts where we only hold
+//! the sink (e.g. cancellation/error paths).
 
-use std::io::Write;
-use std::sync::Arc;
+use super::AcpOutput;
 
-use harn_vm::visible_text::sanitize_visible_assistant_text;
-
-/// Write a `session/update` notification directly through a stdout lock.
-pub(super) fn send_update_raw(
-    stdout_lock: &Arc<std::sync::Mutex<()>>,
-    session_id: &str,
-    text: &str,
-) {
-    let visible_text = sanitize_visible_assistant_text(text, true);
-    let notification = serde_json::json!({
-        "jsonrpc": "2.0",
-        "method": "session/update",
-        "params": {
-            "sessionId": session_id,
-            "update": {
-                "sessionUpdate": "agent_message_chunk",
-                "content": {
-                    "type": "text",
-                    "text": text,
-                    "visible_text": visible_text.clone(),
-                    "visible_delta": visible_text,
-                },
-            },
-        },
-    });
-    if let Ok(line) = serde_json::to_string(&notification) {
-        let _guard = stdout_lock.lock().unwrap_or_else(|e| e.into_inner());
-        let mut stdout = std::io::stdout().lock();
-        let _ = stdout.write_all(line.as_bytes());
-        let _ = stdout.write_all(b"\n");
-        let _ = stdout.flush();
-    }
-}
-
-/// Write a JSON-RPC response directly through a stdout lock.
+/// Write a JSON-RPC response directly through a transport output sink.
 pub(super) fn send_json_response(
-    stdout_lock: &Arc<std::sync::Mutex<()>>,
+    output: &AcpOutput,
     id: &serde_json::Value,
     result: serde_json::Value,
 ) {
@@ -53,52 +18,6 @@ pub(super) fn send_json_response(
         "result": result,
     });
     if let Ok(line) = serde_json::to_string(&response) {
-        let _guard = stdout_lock.lock().unwrap_or_else(|e| e.into_inner());
-        let mut stdout = std::io::stdout().lock();
-        let _ = stdout.write_all(line.as_bytes());
-        let _ = stdout.write_all(b"\n");
-        let _ = stdout.flush();
+        output.write_line(&line);
     }
-}
-
-/// Write a JSON-RPC error response directly through a stdout lock.
-pub(super) fn send_json_error(
-    stdout_lock: &Arc<std::sync::Mutex<()>>,
-    id: &serde_json::Value,
-    code: i64,
-    message: &str,
-) {
-    let response = serde_json::json!({
-        "jsonrpc": "2.0",
-        "id": id,
-        "error": {
-            "code": code,
-            "message": message,
-        },
-    });
-    if let Ok(line) = serde_json::to_string(&response) {
-        let _guard = stdout_lock.lock().unwrap_or_else(|e| e.into_inner());
-        let mut stdout = std::io::stdout().lock();
-        let _ = stdout.write_all(line.as_bytes());
-        let _ = stdout.write_all(b"\n");
-        let _ = stdout.flush();
-    }
-}
-
-pub(super) fn flush_stdio() {
-    let _ = std::io::stdout().flush();
-    let _ = std::io::stderr().flush();
-}
-
-pub(super) fn exit_after_fatal_prompt_error(
-    stdout_lock: &Arc<std::sync::Mutex<()>>,
-    session_id: &str,
-    id: &serde_json::Value,
-    message: &str,
-) -> ! {
-    send_update_raw(stdout_lock, session_id, &format!("Error: {message}\n"));
-    send_json_error(stdout_lock, id, -32000, message);
-    eprintln!("{message}");
-    flush_stdio();
-    std::process::exit(2);
 }

--- a/crates/harn-cli/src/acp/mod.rs
+++ b/crates/harn-cli/src/acp/mod.rs
@@ -21,10 +21,10 @@ use std::time::Instant;
 use harn_vm::agent_events::{clear_session_sinks, register_sink};
 use harn_vm::visible_text::{sanitize_visible_assistant_text, VisibleTextState};
 use tokio::io::AsyncBufReadExt;
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::{mpsc, oneshot, Mutex};
 
 use events::AcpAgentEventSink;
-use io::{exit_after_fatal_prompt_error, send_json_response};
+use io::send_json_response;
 
 fn verbose_bridge_logs_enabled() -> bool {
     matches!(
@@ -84,42 +84,66 @@ struct Session {
     info: SessionInfo,
 }
 
-/// ACP server that reads JSON-RPC requests from stdin and writes
-/// responses / notifications to stdout.
+#[derive(Clone)]
+pub(super) enum AcpOutput {
+    Stdout(Arc<std::sync::Mutex<()>>),
+    Channel(mpsc::UnboundedSender<String>),
+}
+
+impl AcpOutput {
+    fn stdout() -> Self {
+        Self::Stdout(Arc::new(std::sync::Mutex::new(())))
+    }
+
+    pub(super) fn write_line(&self, line: &str) {
+        match self {
+            Self::Stdout(lock) => {
+                let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+                let mut stdout = std::io::stdout().lock();
+                let _ = stdout.write_all(line.as_bytes());
+                let _ = stdout.write_all(b"\n");
+                let _ = stdout.flush();
+            }
+            Self::Channel(tx) => {
+                let _ = tx.send(line.to_string());
+            }
+        }
+    }
+}
+
+/// ACP server that reads JSON-RPC requests from a transport and writes
+/// responses / notifications back to that same transport.
 pub struct AcpServer {
     /// Optional pipeline file to execute on each `session/prompt`.
     pipeline: Option<String>,
     /// Active sessions keyed by session ID.
     sessions: HashMap<String, Session>,
-    /// Counter for generating unique session IDs.
-    session_counter: u64,
     /// Monotonically increasing JSON-RPC request ID for outgoing requests.
     next_id: AtomicU64,
     /// Pending outgoing request waiters, keyed by JSON-RPC id.
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<serde_json::Value>>>>,
-    /// Mutex protecting stdout writes to prevent interleaving.
-    stdout_lock: Arc<std::sync::Mutex<()>>,
+    /// Transport output sink.
+    output: AcpOutput,
 }
 
 impl AcpServer {
     fn new(pipeline: Option<String>) -> Self {
+        Self::new_with_output(pipeline, AcpOutput::stdout())
+    }
+
+    fn new_with_output(pipeline: Option<String>, output: AcpOutput) -> Self {
         Self {
             pipeline,
             sessions: HashMap::new(),
-            session_counter: 0,
             next_id: AtomicU64::new(1),
             pending: Arc::new(Mutex::new(HashMap::new())),
-            stdout_lock: Arc::new(std::sync::Mutex::new(())),
+            output,
         }
     }
 
-    /// Write a complete JSON-RPC line to stdout, serialized through a mutex.
+    /// Write a complete JSON-RPC message to the current transport.
     fn write_line(&self, line: &str) {
-        let _guard = self.stdout_lock.lock().unwrap_or_else(|e| e.into_inner());
-        let mut stdout = std::io::stdout().lock();
-        let _ = stdout.write_all(line.as_bytes());
-        let _ = stdout.write_all(b"\n");
-        let _ = stdout.flush();
+        self.output.write_line(line);
     }
 
     /// Send a JSON-RPC success response.
@@ -168,21 +192,15 @@ impl AcpServer {
         );
     }
 
+    fn send_prompt_error(&self, session_id: &str, id: &serde_json::Value, message: &str) {
+        self.send_update(session_id, &format!("Error: {message}\n"));
+        self.send_error(id, -32000, message);
+        eprintln!("{message}");
+    }
+
     /// Generate a unique session ID.
     fn next_session_id(&mut self) -> String {
-        self.session_counter += 1;
-        format!(
-            "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
-            self.session_counter,
-            std::process::id() & 0xFFFF,
-            0x4000 | (self.session_counter & 0x0FFF),
-            0x8000 | ((self.session_counter >> 12) & 0x3FFF),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-                & 0xFFFF_FFFF_FFFF
-        )
+        uuid::Uuid::new_v4().to_string()
     }
 
     fn handle_initialize(&self, id: &serde_json::Value) {
@@ -194,6 +212,7 @@ impl AcpServer {
                     "promptCapabilities": {},
                     "sessionCapabilities": {
                         "fork": {},
+                        "load": {},
                     },
                 },
                 "agentInfo": {
@@ -400,10 +419,6 @@ impl AcpServer {
         harn_vm::agent_sessions::open_or_create(Some(session_id.clone()));
         let _session_guard = harn_vm::agent_sessions::enter_current_session(session_id.clone());
 
-        let fatal_prompt_error = |message: String| -> ! {
-            exit_after_fatal_prompt_error(&self.stdout_lock, &session_id, id, &message)
-        };
-
         let (source, source_path) = if let Some(ref pipeline_path) = self.pipeline {
             let full_path = if std::path::Path::new(pipeline_path).is_absolute() {
                 PathBuf::from(pipeline_path)
@@ -412,10 +427,11 @@ impl AcpServer {
             };
             match std::fs::read_to_string(&full_path) {
                 Ok(src) => (src, Some(full_path)),
-                Err(e) => fatal_prompt_error(format!(
-                    "Failed to read pipeline {}: {e}",
-                    full_path.display()
-                )),
+                Err(e) => {
+                    let message = format!("Failed to read pipeline {}: {e}", full_path.display());
+                    self.send_prompt_error(&session_id, id, &message);
+                    return;
+                }
             }
         } else {
             // Wrap inline prompt source in a pipeline so the compiler has
@@ -424,7 +440,7 @@ impl AcpServer {
             (wrapped, None)
         };
 
-        let stdout_lock = self.stdout_lock.clone();
+        let output = self.output.clone();
         let pending = self.pending.clone();
         let next_id = &self.next_id;
         let sid = session_id.clone();
@@ -433,22 +449,26 @@ impl AcpServer {
         // the client observes tool lifecycle on the wire.
         register_sink(
             session_id.clone(),
-            Arc::new(AcpAgentEventSink::new(stdout_lock.clone())),
+            Arc::new(AcpAgentEventSink::new(output.clone())),
         );
 
         let bridge = Rc::new(AcpBridge {
             session_id: sid.clone(),
-            stdout_lock: stdout_lock.clone(),
+            output: output.clone(),
             pending: pending.clone(),
             next_id_counter: AtomicU64::new(next_id.fetch_add(1000, Ordering::SeqCst)),
             cancelled: cancelled.clone(),
             script_name: std::sync::Mutex::new(String::new()),
             assistant_state: std::sync::Mutex::new(VisibleTextState::default()),
         });
-        let host_bridge = Rc::new(harn_vm::bridge::HostBridge::from_parts(
+        let bridge_output = output.clone();
+        let host_bridge = Rc::new(harn_vm::bridge::HostBridge::from_parts_with_writer(
             bridge.pending.clone(),
             Arc::new(AtomicBool::new(false)),
-            bridge.stdout_lock.clone(),
+            Arc::new(move |line| {
+                bridge_output.write_line(line);
+                Ok(())
+            }),
             bridge.next_id_counter.fetch_add(10_000, Ordering::SeqCst),
         ));
         host_bridge.set_session_id(&bridge.session_id);
@@ -456,7 +476,10 @@ impl AcpServer {
         let compile_started = Instant::now();
         let chunk = match harn_vm::compile_source(&source) {
             Ok(c) => c,
-            Err(e) => fatal_prompt_error(format!("Compilation error: {e}")),
+            Err(e) => {
+                self.send_prompt_error(&session_id, id, &format!("Compilation error: {e}"));
+                return;
+            }
         };
         let compile_ms = compile_started.elapsed().as_millis() as u64;
         bridge.send_log(
@@ -475,7 +498,7 @@ impl AcpServer {
         }
 
         let id_owned = id.clone();
-        let send_lock = self.stdout_lock.clone();
+        let send_output = self.output.clone();
         let result = execute::execute_chunk(
             chunk,
             bridge.clone(),
@@ -499,7 +522,7 @@ impl AcpServer {
                     bridge.send_update(&output);
                 }
                 send_json_response(
-                    &send_lock,
+                    &send_output,
                     &id_owned,
                     serde_json::json!({"stopReason": "completed"}),
                 );
@@ -507,12 +530,12 @@ impl AcpServer {
             Err(e) => {
                 if cancelled.load(Ordering::SeqCst) {
                     send_json_response(
-                        &send_lock,
+                        &send_output,
                         &id_owned,
                         serde_json::json!({"stopReason": "cancelled"}),
                     );
                 } else {
-                    exit_after_fatal_prompt_error(&send_lock, &sid, &id_owned, &e);
+                    self.send_prompt_error(&sid, &id_owned, &e);
                 }
             }
         }
@@ -734,13 +757,159 @@ impl AcpServer {
             Err(error) => self.send_error(id, -32000, &error),
         }
     }
+
+    fn handle_session_load(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
+        let Some(session_id) = params
+            .get("sessionId")
+            .or_else(|| params.get("session_id"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            self.send_error(id, -32602, "session/load requires sessionId");
+            return;
+        };
+
+        let Some(session) = self.sessions.get(session_id) else {
+            self.send_error(id, -32004, &format!("Session not found: {session_id}"));
+            return;
+        };
+
+        let mut session_value = serde_json::json!({
+            "sessionId": session_id,
+            "cwd": session.cwd.display().to_string(),
+        });
+        if let Some(title) = session.info.title.as_ref() {
+            session_value["title"] = serde_json::json!(title);
+        }
+        if !session.info.meta.is_empty() {
+            session_value["_meta"] = serde_json::Value::Object(session.info.meta.clone());
+        }
+
+        self.send_response(
+            id,
+            serde_json::json!({
+                "session": session_value,
+                "replayed": [],
+            }),
+        );
+    }
+
+    async fn handle_incoming_message(&mut self, msg: serde_json::Value) {
+        if msg.get("method").is_none() && msg.get("id").is_some() {
+            if let Some(id) = msg["id"].as_u64() {
+                let mut pending = self.pending.lock().await;
+                if let Some(sender) = pending.remove(&id) {
+                    let _ = sender.send(msg);
+                }
+            }
+            return;
+        }
+
+        let method = match msg.get("method").and_then(|v| v.as_str()) {
+            Some(m) => m.to_string(),
+            None => return,
+        };
+        let id = msg.get("id").cloned().unwrap_or(serde_json::Value::Null);
+        let params = msg.get("params").cloned().unwrap_or(serde_json::json!({}));
+
+        match method.as_str() {
+            "initialize" => {
+                self.handle_initialize(&id);
+            }
+            "session/new" => {
+                self.handle_session_new(&id, &params);
+            }
+            "session/load" => {
+                self.handle_session_load(&id, &params);
+            }
+            "session/fork" => {
+                self.handle_session_fork(&id, &params);
+            }
+            "session/prompt" => {
+                self.handle_session_prompt(&id, &params).await;
+            }
+            "session/cancel" => {
+                self.handle_session_cancel(&params);
+            }
+            "session/input" | "user_message" | "agent/user_message" => {
+                self.handle_session_input(&params).await;
+            }
+            "agent/resume" => {
+                self.handle_agent_resume(&params);
+            }
+            "harn.hitl.respond" => {
+                self.handle_hitl_respond(&id, &params).await;
+            }
+            "workflow/signal" | "harn.workflow.signal" => {
+                self.handle_workflow_signal(&id, &params).await;
+            }
+            "workflow/query" | "harn.workflow.query" => {
+                self.handle_workflow_query(&id, &params);
+            }
+            "workflow/update" | "harn.workflow.update" => {
+                self.handle_workflow_update(&id, &params).await;
+            }
+            "workflow/pause" | "harn.workflow.pause" => {
+                self.handle_workflow_pause(&id, &params);
+            }
+            "workflow/resume" | "harn.workflow.resume" => {
+                self.handle_workflow_resume(&id, &params);
+            }
+            "session/list" => {
+                self.handle_session_list(&id);
+            }
+            _ => {
+                if !id.is_null() {
+                    self.send_error(&id, -32601, &format!("Method not found: {method}"));
+                }
+            }
+        }
+    }
+}
+
+pub(crate) async fn run_acp_channel_server(
+    pipeline: Option<String>,
+    mut request_rx: mpsc::UnboundedReceiver<serde_json::Value>,
+    response_tx: mpsc::UnboundedSender<String>,
+) {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async move {
+            let mut server = AcpServer::new_with_output(pipeline, AcpOutput::Channel(response_tx));
+            let pending_clone = server.pending.clone();
+            let (routed_tx, mut routed_rx) =
+                tokio::sync::mpsc::unbounded_channel::<serde_json::Value>();
+
+            tokio::task::spawn_local(async move {
+                while let Some(msg) = request_rx.recv().await {
+                    if msg.get("method").is_none() && msg.get("id").is_some() {
+                        if let Some(id) = msg["id"].as_u64() {
+                            let mut pending = pending_clone.lock().await;
+                            if let Some(sender) = pending.remove(&id) {
+                                let _ = sender.send(msg);
+                            }
+                        }
+                        continue;
+                    }
+
+                    let _ = routed_tx.send(msg);
+                }
+
+                let mut pending = pending_clone.lock().await;
+                pending.clear();
+            });
+
+            while let Some(msg) = routed_rx.recv().await {
+                server.handle_incoming_message(msg).await;
+            }
+        })
+        .await;
 }
 
 /// Shared state that bridge-style builtins use to communicate with the
 /// ACP client (editor) over JSON-RPC.
 pub(super) struct AcpBridge {
     pub(super) session_id: String,
-    pub(super) stdout_lock: Arc<std::sync::Mutex<()>>,
+    pub(super) output: AcpOutput,
     pub(super) pending: Arc<Mutex<HashMap<u64, oneshot::Sender<serde_json::Value>>>>,
     pub(super) next_id_counter: AtomicU64,
     pub(super) cancelled: Arc<AtomicBool>,
@@ -752,11 +921,7 @@ pub(super) struct AcpBridge {
 impl AcpBridge {
     /// Write a complete JSON-RPC line to stdout.
     fn write_line(&self, line: &str) {
-        let _guard = self.stdout_lock.lock().unwrap_or_else(|e| e.into_inner());
-        let mut stdout = std::io::stdout().lock();
-        let _ = stdout.write_all(line.as_bytes());
-        let _ = stdout.write_all(b"\n");
-        let _ = stdout.flush();
+        self.output.write_line(line);
     }
 
     /// Send a JSON-RPC notification.
@@ -966,62 +1131,7 @@ pub async fn run_acp_server(pipeline: Option<&str>) {
             });
 
             while let Some(msg) = request_rx.recv().await {
-                let method = match msg.get("method").and_then(|v| v.as_str()) {
-                    Some(m) => m.to_string(),
-                    None => continue,
-                };
-                let id = msg.get("id").cloned().unwrap_or(serde_json::Value::Null);
-                let params = msg.get("params").cloned().unwrap_or(serde_json::json!({}));
-
-                match method.as_str() {
-                    "initialize" => {
-                        server.handle_initialize(&id);
-                    }
-                    "session/new" => {
-                        server.handle_session_new(&id, &params);
-                    }
-                    "session/fork" => {
-                        server.handle_session_fork(&id, &params);
-                    }
-                    "session/prompt" => {
-                        server.handle_session_prompt(&id, &params).await;
-                    }
-                    "session/cancel" => {
-                        server.handle_session_cancel(&params);
-                    }
-                    "session/input" | "user_message" | "agent/user_message" => {
-                        server.handle_session_input(&params).await;
-                    }
-                    "agent/resume" => {
-                        server.handle_agent_resume(&params);
-                    }
-                    "harn.hitl.respond" => {
-                        server.handle_hitl_respond(&id, &params).await;
-                    }
-                    "workflow/signal" | "harn.workflow.signal" => {
-                        server.handle_workflow_signal(&id, &params).await;
-                    }
-                    "workflow/query" | "harn.workflow.query" => {
-                        server.handle_workflow_query(&id, &params);
-                    }
-                    "workflow/update" | "harn.workflow.update" => {
-                        server.handle_workflow_update(&id, &params).await;
-                    }
-                    "workflow/pause" | "harn.workflow.pause" => {
-                        server.handle_workflow_pause(&id, &params);
-                    }
-                    "workflow/resume" | "harn.workflow.resume" => {
-                        server.handle_workflow_resume(&id, &params);
-                    }
-                    "session/list" => {
-                        server.handle_session_list(&id);
-                    }
-                    _ => {
-                        if !id.is_null() {
-                            server.send_error(&id, -32601, &format!("Method not found: {method}"));
-                        }
-                    }
-                }
+                server.handle_incoming_message(msg).await;
             }
         })
         .await;

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -5,12 +5,14 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use axum::body::{Body, Bytes};
+use axum::extract::ws::{Message as WsMessage, WebSocket, WebSocketUpgrade};
 use axum::extract::{DefaultBodyLimit, Extension, OriginalUri, Query};
 use axum::http::{HeaderMap, Method, StatusCode};
 use axum::middleware;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Router;
+use futures::{SinkExt, StreamExt};
 use serde_json::{json, Value as JsonValue};
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
@@ -33,6 +35,10 @@ const REQUEST_RELEASE_FILE_ENV: &str = "HARN_ORCHESTRATOR_TEST_REQUEST_RELEASE_F
 const API_KEYS_ENV: &str = "HARN_ORCHESTRATOR_API_KEYS";
 const HMAC_SECRET_ENV: &str = "HARN_ORCHESTRATOR_HMAC_SECRET";
 const AUTH_TIMESTAMP_WINDOW_SECS: i64 = 5 * 60;
+const ACP_PATH: &str = "/acp";
+const ACP_TOPIC_PREFIX: &str = "acp.session";
+const ACP_PING_INTERVAL: Duration = Duration::from_secs(30);
+const ACP_PONG_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Clone)]
 pub(crate) struct ListenerConfig {
@@ -123,6 +129,11 @@ impl ListenerRuntime {
                 reload,
             })
         });
+        let acp_state = Arc::new(AcpWebSocketState {
+            event_log: config.event_log.clone(),
+            auth: auth.clone(),
+            pipeline: None,
+        });
         let routes = Arc::new(RouteRegistry::new(
             config.routes,
             config.event_log.clone(),
@@ -150,6 +161,10 @@ impl ListenerRuntime {
                 "/metrics",
                 get(metrics_endpoint).layer(Extension(config.metrics_registry.clone())),
             );
+        app = app.route(
+            ACP_PATH,
+            get(acp_websocket_endpoint).layer(Extension(acp_state)),
+        );
         if let Some(admin_state) = admin_state {
             app = app.route(
                 ADMIN_RELOAD_PATH,
@@ -367,6 +382,13 @@ struct AdminReloadState {
     event_log: Arc<AnyEventLog>,
     auth: Arc<ListenerAuth>,
     reload: AdminReloadHandle,
+}
+
+#[derive(Clone)]
+struct AcpWebSocketState {
+    event_log: Arc<AnyEventLog>,
+    auth: Arc<ListenerAuth>,
+    pipeline: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -803,6 +825,265 @@ async fn admin_reload_endpoint(
         )
             .into_response(),
     }
+}
+
+async fn acp_websocket_endpoint(
+    Extension(state): Extension<Arc<AcpWebSocketState>>,
+    ws: WebSocketUpgrade,
+    method: Method,
+    OriginalUri(uri): OriginalUri,
+    headers: HeaderMap,
+) -> Response {
+    let normalized_headers = normalize_headers(&headers);
+    if state.auth.has_credentials()
+        && state
+            .auth
+            .authorize(
+                state.event_log.as_ref(),
+                method.as_str(),
+                uri.path(),
+                &normalized_headers,
+                &[],
+            )
+            .await
+            .is_err()
+    {
+        return HttpError::unauthorized("auth failed").into_response();
+    }
+
+    ws.on_upgrade(move |socket| run_acp_websocket(socket, state))
+        .into_response()
+}
+
+async fn run_acp_websocket(socket: WebSocket, state: Arc<AcpWebSocketState>) {
+    let connection_id = uuid::Uuid::new_v4().to_string();
+    append_acp_event(
+        &state.event_log,
+        &connection_id,
+        "connection_opened",
+        json!({
+            "transport": "websocket",
+            "path": ACP_PATH,
+        }),
+    )
+    .await;
+
+    let (to_acp_tx, to_acp_rx) = mpsc::unbounded_channel::<JsonValue>();
+    let (from_acp_tx, mut from_acp_rx) = mpsc::unbounded_channel::<String>();
+    let pipeline = state.pipeline.clone();
+    let worker = std::thread::Builder::new()
+        .name(format!("harn-acp-ws-{connection_id}"))
+        .spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    eprintln!("[harn] failed to start ACP WebSocket worker: {error}");
+                    return;
+                }
+            };
+            runtime.block_on(crate::acp::run_acp_channel_server(
+                pipeline,
+                to_acp_rx,
+                from_acp_tx,
+            ));
+        });
+
+    let Ok(worker) = worker else {
+        append_acp_event(
+            &state.event_log,
+            &connection_id,
+            "connection_failed",
+            json!({"reason": "worker_spawn_failed"}),
+        )
+        .await;
+        return;
+    };
+
+    let (mut sender, mut receiver) = socket.split();
+    let mut ping_interval = tokio::time::interval(ACP_PING_INTERVAL);
+    ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut liveness_interval = tokio::time::interval(Duration::from_secs(1));
+    liveness_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut ping_sent_at: Option<Instant> = None;
+    let mut session_id: Option<String> = None;
+
+    loop {
+        tokio::select! {
+            Some(line) = from_acp_rx.recv() => {
+                if let Some(id) = session_id_from_acp_response(&line) {
+                    session_id = Some(id.clone());
+                    append_acp_event(
+                        &state.event_log,
+                        &connection_id,
+                        "session_opened",
+                        json!({"session_id": id}),
+                    )
+                    .await;
+                }
+                append_acp_event(
+                    &state.event_log,
+                    &connection_id,
+                    "message_sent",
+                    acp_message_log_payload(&line, session_id.as_deref()),
+                )
+                .await;
+                if sender.send(WsMessage::Text(line.into())).await.is_err() {
+                    break;
+                }
+            }
+            frame = receiver.next() => {
+                let Some(frame) = frame else {
+                    break;
+                };
+                let Ok(frame) = frame else {
+                    break;
+                };
+                match frame {
+                    WsMessage::Text(text) => {
+                        let line = text.to_string();
+                        append_acp_event(
+                            &state.event_log,
+                            &connection_id,
+                            "message_received",
+                            acp_message_log_payload(&line, session_id.as_deref()),
+                        )
+                        .await;
+                        match serde_json::from_str::<JsonValue>(&line) {
+                            Ok(value) => {
+                                if to_acp_tx.send(value).is_err() {
+                                    break;
+                                }
+                            }
+                            Err(error) => {
+                                let response = harn_vm::jsonrpc::error_response(
+                                    JsonValue::Null,
+                                    -32700,
+                                    &format!("Parse error: {error}"),
+                                );
+                                if let Ok(line) = serde_json::to_string(&response) {
+                                    let _ = sender.send(WsMessage::Text(line.into())).await;
+                                }
+                            }
+                        }
+                    }
+                    WsMessage::Binary(_) => {
+                        let response = harn_vm::jsonrpc::error_response(
+                            JsonValue::Null,
+                            -32600,
+                            "ACP WebSocket transport only accepts JSON-RPC text frames",
+                        );
+                        if let Ok(line) = serde_json::to_string(&response) {
+                            let _ = sender.send(WsMessage::Text(line.into())).await;
+                        }
+                    }
+                    WsMessage::Ping(payload) => {
+                        if sender.send(WsMessage::Pong(payload)).await.is_err() {
+                            break;
+                        }
+                    }
+                    WsMessage::Pong(_) => {
+                        ping_sent_at = None;
+                    }
+                    WsMessage::Close(_) => {
+                        break;
+                    }
+                }
+            }
+            _ = ping_interval.tick() => {
+                if ping_sent_at.is_none() {
+                    ping_sent_at = Some(Instant::now());
+                    if sender.send(WsMessage::Ping(Vec::new().into())).await.is_err() {
+                        break;
+                    }
+                }
+            }
+            _ = liveness_interval.tick() => {
+                if ping_sent_at.is_some_and(|sent| sent.elapsed() > ACP_PONG_TIMEOUT) {
+                    let _ = sender.send(WsMessage::Close(None)).await;
+                    append_acp_event(
+                        &state.event_log,
+                        &connection_id,
+                        "connection_liveness_timeout",
+                        json!({"timeout_ms": ACP_PONG_TIMEOUT.as_millis()}),
+                    )
+                    .await;
+                    break;
+                }
+            }
+        }
+    }
+
+    drop(to_acp_tx);
+    let _ = tokio::task::spawn_blocking(move || worker.join()).await;
+    append_acp_event(
+        &state.event_log,
+        &connection_id,
+        "connection_closed",
+        json!({
+            "session_id": session_id,
+            "retention_ms": 5 * 60 * 1000u64,
+        }),
+    )
+    .await;
+}
+
+async fn append_acp_event(
+    event_log: &Arc<AnyEventLog>,
+    connection_id: &str,
+    kind: &str,
+    payload: JsonValue,
+) {
+    let Ok(topic) = Topic::new(format!("{ACP_TOPIC_PREFIX}.{connection_id}")) else {
+        return;
+    };
+    let _ = event_log.append(&topic, LogEvent::new(kind, payload)).await;
+}
+
+fn acp_message_log_payload(line: &str, session_id: Option<&str>) -> JsonValue {
+    match serde_json::from_str::<JsonValue>(line) {
+        Ok(value) => {
+            let mut payload = json!({
+                "method": value.get("method").and_then(JsonValue::as_str),
+                "id": value.get("id").cloned(),
+                "session_id": session_id,
+            });
+            if let Some(params_session_id) = value
+                .get("params")
+                .and_then(|params| params.get("sessionId").or_else(|| params.get("session_id")))
+                .and_then(JsonValue::as_str)
+            {
+                payload["session_id"] = json!(params_session_id);
+            }
+            if let Some(result_session_id) = value
+                .get("result")
+                .and_then(|result| result.get("sessionId").or_else(|| result.get("session_id")))
+                .and_then(JsonValue::as_str)
+            {
+                payload["session_id"] = json!(result_session_id);
+            }
+            payload
+        }
+        Err(_) => json!({
+            "malformed": true,
+            "session_id": session_id,
+        }),
+    }
+}
+
+fn session_id_from_acp_response(line: &str) -> Option<String> {
+    serde_json::from_str::<JsonValue>(line)
+        .ok()
+        .and_then(|value| value.get("result").cloned())
+        .and_then(|result| {
+            result
+                .get("sessionId")
+                .or_else(|| result.get("session_id"))
+                .and_then(JsonValue::as_str)
+                .map(ToString::to_string)
+        })
 }
 
 async fn authorize_request(
@@ -1335,6 +1616,10 @@ impl ListenerAuth {
 
     pub(crate) fn has_api_keys(&self) -> bool {
         !self.api_keys.is_empty()
+    }
+
+    pub(crate) fn has_credentials(&self) -> bool {
+        self.has_api_keys() || self.hmac_secret.is_some()
     }
 
     pub(crate) async fn authorize(
@@ -1871,6 +2156,93 @@ mod tests {
         format!("sha256={encoded}")
     }
 
+    fn authorized_acp_request(
+        addr: std::net::SocketAddr,
+    ) -> tokio_tungstenite::tungstenite::http::Request<()> {
+        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+        let mut request = format!("ws://{addr}{ACP_PATH}")
+            .into_client_request()
+            .expect("client request");
+        request.headers_mut().insert(
+            tokio_tungstenite::tungstenite::http::header::AUTHORIZATION,
+            "Bearer ws-test-key".parse().expect("authorization header"),
+        );
+        request
+    }
+
+    async fn next_acp_text(
+        socket: &mut tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    ) -> JsonValue {
+        loop {
+            let message = socket
+                .next()
+                .await
+                .expect("websocket message")
+                .expect("websocket ok");
+            if let tokio_tungstenite::tungstenite::Message::Text(text) = message {
+                return serde_json::from_str(&text).expect("json-rpc text");
+            }
+        }
+    }
+
+    async fn acp_request(
+        socket: &mut tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        id: u64,
+        method: &str,
+        params: JsonValue,
+    ) -> JsonValue {
+        socket
+            .send(tokio_tungstenite::tungstenite::Message::Text(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "method": method,
+                    "params": params,
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .expect("send acp request");
+        loop {
+            let message = next_acp_text(socket).await;
+            if message.get("method").is_some() && message.get("id").is_some() {
+                socket
+                    .send(tokio_tungstenite::tungstenite::Message::Text(
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": message["id"].clone(),
+                            "result": {},
+                        })
+                        .to_string()
+                        .into(),
+                    ))
+                    .await
+                    .expect("send host response");
+                continue;
+            }
+            if message.get("id").and_then(JsonValue::as_u64) == Some(id) {
+                return message;
+            }
+        }
+    }
+
+    async fn new_acp_session(addr: std::net::SocketAddr) -> String {
+        let (mut socket, _) = tokio_tungstenite::connect_async(authorized_acp_request(addr))
+            .await
+            .expect("connect acp websocket");
+        let response = acp_request(&mut socket, 1, "session/new", json!({})).await;
+        response["result"]["sessionId"]
+            .as_str()
+            .expect("session id")
+            .to_string()
+    }
+
     async fn pending_events(log: &Arc<AnyEventLog>) -> Vec<(u64, harn_vm::event_log::LogEvent)> {
         log.read_range(&Topic::new(PENDING_TOPIC).expect("pending topic"), None, 16)
             .await
@@ -1885,6 +2257,127 @@ mod tests {
         )
         .await
         .expect("read claim events")
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_websocket_requires_configured_bearer_auth() {
+        let _guard = lock_harn_state();
+        reset_active_event_log();
+        std::env::set_var(API_KEYS_ENV, "ws-test-key");
+        std::env::remove_var(HMAC_SECRET_ENV);
+
+        let dir = tempdir().expect("tempdir");
+        let log = install_default_for_base_dir(dir.path()).expect("install event log");
+        let listener = ListenerRuntime::start(ListenerConfig {
+            bind: "127.0.0.1:0".parse().expect("bind addr"),
+            tls: None,
+            event_log: log,
+            secrets: Arc::new(harn_vm::secrets::EnvSecretProvider::new(
+                "harn/listener-test",
+            )),
+            allowed_origins: OriginAllowList::wildcard(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
+            admin_reload: None,
+            routes: Vec::new(),
+        })
+        .await
+        .expect("start listener");
+
+        let unauthorized =
+            tokio_tungstenite::connect_async(format!("ws://{}{}", listener.local_addr(), ACP_PATH))
+                .await;
+        assert!(unauthorized.is_err(), "missing bearer should fail upgrade");
+
+        let (mut socket, _) =
+            tokio_tungstenite::connect_async(authorized_acp_request(listener.local_addr()))
+                .await
+                .expect("authorized connect");
+        let response = acp_request(&mut socket, 1, "initialize", json!({})).await;
+        assert_eq!(response["result"]["agentInfo"]["name"], "harn");
+        assert!(
+            response["result"]["agentCapabilities"]["sessionCapabilities"]
+                .get("load")
+                .is_some()
+        );
+
+        listener
+            .shutdown(Duration::from_secs(5))
+            .await
+            .expect("shutdown listener");
+        std::env::remove_var(API_KEYS_ENV);
+        reset_active_event_log();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_websocket_parallel_clients_get_distinct_sessions_and_can_load_active_session() {
+        let _guard = lock_harn_state();
+        reset_active_event_log();
+        std::env::set_var(API_KEYS_ENV, "ws-test-key");
+        std::env::remove_var(HMAC_SECRET_ENV);
+
+        let dir = tempdir().expect("tempdir");
+        let log = install_default_for_base_dir(dir.path()).expect("install event log");
+        let listener = ListenerRuntime::start(ListenerConfig {
+            bind: "127.0.0.1:0".parse().expect("bind addr"),
+            tls: None,
+            event_log: log,
+            secrets: Arc::new(harn_vm::secrets::EnvSecretProvider::new(
+                "harn/listener-test",
+            )),
+            allowed_origins: OriginAllowList::wildcard(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
+            admin_reload: None,
+            routes: Vec::new(),
+        })
+        .await
+        .expect("start listener");
+
+        let (first, second) = tokio::join!(
+            new_acp_session(listener.local_addr()),
+            new_acp_session(listener.local_addr())
+        );
+        assert_ne!(first, second);
+
+        let (mut socket, _) =
+            tokio_tungstenite::connect_async(authorized_acp_request(listener.local_addr()))
+                .await
+                .expect("authorized connect");
+        let created = acp_request(&mut socket, 1, "session/new", json!({})).await;
+        let session_id = created["result"]["sessionId"]
+            .as_str()
+            .expect("session id")
+            .to_string();
+        let loaded = acp_request(
+            &mut socket,
+            2,
+            "session/load",
+            json!({"sessionId": session_id}),
+        )
+        .await;
+        assert_eq!(
+            loaded["result"]["session"]["sessionId"],
+            created["result"]["sessionId"]
+        );
+        let prompted = acp_request(
+            &mut socket,
+            3,
+            "session/prompt",
+            json!({
+                "sessionId": session_id,
+                "prompt": [{"type": "text", "text": "println(\"websocket prompt\")"}],
+            }),
+        )
+        .await;
+        assert_eq!(prompted["result"]["stopReason"], "completed");
+
+        listener
+            .shutdown(Duration::from_secs(5))
+            .await
+            .expect("shutdown listener");
+        std::env::remove_var(API_KEYS_ENV);
+        reset_active_event_log();
     }
 
     fn unix_now_ms() -> i64 {

--- a/crates/harn-vm/src/bridge.rs
+++ b/crates/harn-vm/src/bridge.rs
@@ -23,6 +23,25 @@ use crate::vm::Vm;
 /// Default timeout for bridge calls (5 minutes).
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(300);
 
+pub type HostBridgeWriter = Arc<dyn Fn(&str) -> Result<(), String> + Send + Sync>;
+
+fn stdout_writer(stdout_lock: Arc<std::sync::Mutex<()>>) -> HostBridgeWriter {
+    Arc::new(move |line: &str| {
+        let _guard = stdout_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let mut stdout = std::io::stdout().lock();
+        stdout
+            .write_all(line.as_bytes())
+            .map_err(|e| format!("Bridge write error: {e}"))?;
+        stdout
+            .write_all(b"\n")
+            .map_err(|e| format!("Bridge write error: {e}"))?;
+        stdout
+            .flush()
+            .map_err(|e| format!("Bridge flush error: {e}"))?;
+        Ok(())
+    })
+}
+
 /// A JSON-RPC 2.0 bridge to a host process over stdin/stdout.
 ///
 /// The bridge sends requests to the host on stdout and receives responses
@@ -35,8 +54,8 @@ pub struct HostBridge {
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<serde_json::Value>>>>,
     /// Whether the host has sent a cancel notification.
     cancelled: Arc<AtomicBool>,
-    /// Mutex protecting stdout writes to prevent interleaving.
-    stdout_lock: Arc<std::sync::Mutex<()>>,
+    /// Transport writer used to send JSON-RPC to the host.
+    writer: HostBridgeWriter,
     /// ACP session ID (set in ACP mode for session-scoped notifications).
     session_id: std::sync::Mutex<String>,
     /// Name of the currently executing Harn script (without .harn suffix).
@@ -311,7 +330,7 @@ impl HostBridge {
             next_id: AtomicU64::new(1),
             pending,
             cancelled,
-            stdout_lock: Arc::new(std::sync::Mutex::new(())),
+            writer: stdout_writer(Arc::new(std::sync::Mutex::new(()))),
             session_id: std::sync::Mutex::new(String::new()),
             script_name: std::sync::Mutex::new(String::new()),
             queued_user_messages,
@@ -337,11 +356,20 @@ impl HostBridge {
         stdout_lock: Arc<std::sync::Mutex<()>>,
         start_id: u64,
     ) -> Self {
+        Self::from_parts_with_writer(pending, cancelled, stdout_writer(stdout_lock), start_id)
+    }
+
+    pub fn from_parts_with_writer(
+        pending: Arc<Mutex<HashMap<u64, oneshot::Sender<serde_json::Value>>>>,
+        cancelled: Arc<AtomicBool>,
+        writer: HostBridgeWriter,
+        start_id: u64,
+    ) -> Self {
         Self {
             next_id: AtomicU64::new(start_id),
             pending,
             cancelled,
-            stdout_lock,
+            writer,
             session_id: std::sync::Mutex::new(String::new()),
             script_name: std::sync::Mutex::new(String::new()),
             queued_user_messages: Arc::new(Mutex::new(VecDeque::new())),
@@ -364,7 +392,7 @@ impl HostBridge {
             next_id: AtomicU64::new(1),
             pending: Arc::new(Mutex::new(HashMap::new())),
             cancelled: Arc::new(AtomicBool::new(false)),
-            stdout_lock: Arc::new(std::sync::Mutex::new(())),
+            writer: stdout_writer(Arc::new(std::sync::Mutex::new(()))),
             session_id: std::sync::Mutex::new(String::new()),
             script_name: std::sync::Mutex::new(String::new()),
             queued_user_messages: Arc::new(Mutex::new(VecDeque::new())),
@@ -411,18 +439,7 @@ impl HostBridge {
 
     /// Write a complete JSON-RPC line to stdout, serialized through a mutex.
     fn write_line(&self, line: &str) -> Result<(), VmError> {
-        let _guard = self.stdout_lock.lock().unwrap_or_else(|e| e.into_inner());
-        let mut stdout = std::io::stdout().lock();
-        stdout
-            .write_all(line.as_bytes())
-            .map_err(|e| VmError::Runtime(format!("Bridge write error: {e}")))?;
-        stdout
-            .write_all(b"\n")
-            .map_err(|e| VmError::Runtime(format!("Bridge write error: {e}")))?;
-        stdout
-            .flush()
-            .map_err(|e| VmError::Runtime(format!("Bridge flush error: {e}")))?;
-        Ok(())
+        (self.writer)(line).map_err(VmError::Runtime)
     }
 
     /// Send a JSON-RPC request to the host and wait for the response.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -62,6 +62,7 @@
 - [Bridge protocol](./bridge-protocol.md)
 - [Host tools over the bridge](./bridge/host-tools.md)
 - [MCP and ACP integration](./mcp-and-acp.md)
+- [ACP over WebSocket](./acp/websocket.md)
 - [Outbound workflow server](./harn-serve.md)
 - [Orchestrator MCP server](./mcp-server.md)
 - [Harn portal](./portal.md)

--- a/docs/src/acp/websocket.md
+++ b/docs/src/acp/websocket.md
@@ -1,0 +1,95 @@
+# ACP over WebSocket
+
+`harn orchestrator serve` exposes ACP at:
+
+```text
+ws://<host>/acp
+wss://<host>/acp
+Authorization: Bearer <api-key>
+```
+
+Use `wss://` when the orchestrator is served with `--cert` and `--key`.
+Plain `ws://` is intended for local development or trusted private networks.
+
+## Authentication
+
+If `HARN_ORCHESTRATOR_API_KEYS` is set, `/acp` requires
+`Authorization: Bearer <api-key>` during the WebSocket upgrade. Failed
+authentication returns `401 Unauthorized` before the upgrade completes.
+
+The endpoint uses the orchestrator listener origin guard. Configure browser
+origins in `harn.toml`:
+
+```toml
+[orchestrator]
+allowed_origins = ["https://ide.example.com"]
+```
+
+## Framing
+
+ACP messages are JSON-RPC 2.0 objects sent as individual WebSocket text frames.
+There is no NDJSON, SSE, or extra wrapper envelope.
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
+```
+
+The server responds with one JSON-RPC object in one text frame. Binary frames
+are rejected with JSON-RPC `Invalid Request`.
+
+## Liveness
+
+The server sends WebSocket ping frames every 30 seconds. If a pong is not
+observed within 10 seconds, the server closes the connection and records a
+liveness timeout event.
+
+## Sessions
+
+Each WebSocket connection runs an ACP dispatcher backed by the same method
+surface as stdio ACP:
+
+- `initialize`
+- `session/new`
+- `session/load`
+- `session/list`
+- `session/prompt`
+- `session/cancel`
+- `session/input`
+- `session/fork`
+- `agent/resume`
+- `workflow/*`
+- `harn.hitl.respond`
+
+`session/load` can reload an active session in the current dispatcher. The
+WebSocket transport also records connection and session lifecycle events on
+`acp.session.<connection-id>` EventLog topics so durable replay can build on
+the same audit trail.
+
+## Example
+
+Node clients can set the `Authorization` header directly. Browser-hosted
+clients usually need a trusted backend or extension host to perform the
+authenticated upgrade because the browser `WebSocket` API does not allow
+custom headers.
+
+```js
+import WebSocket from "ws";
+
+const socket = new WebSocket("wss://orchestrator.example.com/acp", {
+  headers: { Authorization: "Bearer " + apiKey },
+});
+
+socket.addEventListener("open", () => {
+  socket.send(JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {},
+  }));
+});
+
+socket.addEventListener("message", (event) => {
+  const message = JSON.parse(event.data);
+  console.log(message);
+});
+```

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -190,7 +190,8 @@ Health probes stay public:
 
 Webhook routes keep using their provider-specific signature checks.
 `a2a-push` routes require either a bearer API key or a shared-secret
-HMAC authorization header.
+HMAC authorization header. The `/acp` WebSocket endpoint requires bearer
+auth when `HARN_ORCHESTRATOR_API_KEYS` is configured.
 
 Configure the auth material with environment variables:
 
@@ -204,6 +205,10 @@ Bearer requests use:
 ```text
 Authorization: Bearer <api-key>
 ```
+
+ACP browser or remote-IDE clients connect to `ws://<host>/acp` or
+`wss://<host>/acp` and send one JSON-RPC ACP message per text frame. See
+[ACP over WebSocket](./acp/websocket.md).
 
 HMAC requests use:
 


### PR DESCRIPTION
## Summary

- Adds `/acp` to the orchestrator HTTP listener as a WebSocket ACP transport with JSON-RPC text-frame routing, bearer/HMAC upgrade auth reuse, origin guard coverage, and ping/pong liveness.
- Refactors ACP output and the VM host bridge so stdio ACP and WebSocket ACP share the same method dispatcher and host-request routing without assuming stdout.
- Adds active `session/load`, UUID ACP session ids for parallel dispatchers, EventLog audit events under `acp.session.<connection-id>`, targeted WebSocket coverage, and `docs/src/acp/websocket.md`.

## Notes

This lands the network transport and active-session load path. Durable replay after process-disconnected sessions is represented in the EventLog audit trail, but full missed-event replay from a previous disconnected worker remains a follow-up to the broader persistent ACP session model.

Refs #189.

## Validation

- `cargo check -p harn-cli`
- `cargo test -p harn-cli commands::orchestrator::listener::tests::acp_websocket -- --nocapture`
- `cargo test -p harn-cli acp_session_fork_branches_runtime_state_and_dispatches_independently -- --nocapture`
- `cargo test -p harn-cli serve_mcp_stdio_lists_calls_and_cancels_exported_functions -- --nocapture`
- `cargo test -p harn-cli serve_mcp_http_streams_progress_and_enforces_api_keys -- --nocapture`
- Pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`, markdown lint

Pre-push note: the full hook ran 1965 tests and reported 1963 passed / 2 readiness-timeout failures in MCP serve tests under parallel nextest; both failed tests passed immediately when rerun directly as listed above.