### PR TITLE
[codex] Add orchestrator backpressure circuits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@ granular archaeology.
   dependencies. Transitive `path` dependencies from Git-installed
   packages are rejected so publishable packages do not depend on
   sibling checkouts.
+- **Orchestrator backpressure and destination circuits (#191).**
+  Webhook ingest now has global and per-provider token buckets that
+  return `503` with `Retry-After` when saturated, dispatcher
+  destinations open a 60-second circuit after five consecutive
+  retryable failures and fail fast into DLQ while open, and
+  `harn_backpressure_events_total{dimension, action}` exposes
+  admission and circuit decisions for operators.
 - **Connector `NormalizeResult` v1 (#464, #476).** A
   `ConnectorNormalizeResult` contract lets connector `normalize`
   exports return `event`, `batch`, `immediate_response`, or `reject`

--- a/conformance/tests/triggers/orchestrator_backpressure_ingest_saturation.expected
+++ b/conformance/tests/triggers/orchestrator_backpressure_ingest_saturation.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/conformance/tests/triggers/orchestrator_backpressure_ingest_saturation.harn
+++ b/conformance/tests/triggers/orchestrator_backpressure_ingest_saturation.harn
@@ -1,0 +1,7 @@
+pipeline test(task) {
+  let result = trigger_test_harness("orchestrator_backpressure_ingest_saturation")
+  println(result.ok)
+  println(result.attempts[1].status == "ingest_saturated")
+  println(result.attempts[1].backoff_ms == 60000)
+  println(result.details.status == 503)
+}

--- a/conformance/tests/triggers/orchestrator_circuit_breaker_trips.expected
+++ b/conformance/tests/triggers/orchestrator_circuit_breaker_trips.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/conformance/tests/triggers/orchestrator_circuit_breaker_trips.harn
+++ b/conformance/tests/triggers/orchestrator_circuit_breaker_trips.harn
@@ -1,0 +1,9 @@
+pipeline test(task) {
+  let result = trigger_test_harness("orchestrator_circuit_breaker_trips")
+  println(result.ok)
+  println(len(result.attempts) == 5)
+  println(result.dlq[0].attempts == 5)
+  println(
+    result.details.opened && result.details.fast_failed && result.details.probe_closes_after_success,
+  )
+}

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use axum::body::{Body, Bytes};
 use axum::extract::ws::{Message as WsMessage, WebSocket, WebSocketUpgrade};
 use axum::extract::{DefaultBodyLimit, Extension, OriginalUri, Query};
-use axum::http::{HeaderMap, Method, StatusCode};
+use axum::http::{header, HeaderMap, HeaderValue, Method, StatusCode};
 use axum::middleware;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -39,6 +39,12 @@ const ACP_PATH: &str = "/acp";
 const ACP_TOPIC_PREFIX: &str = "acp.session";
 const ACP_PING_INTERVAL: Duration = Duration::from_secs(30);
 const ACP_PONG_TIMEOUT: Duration = Duration::from_secs(10);
+const INGEST_GLOBAL_CAPACITY_ENV: &str = "HARN_ORCHESTRATOR_INGEST_GLOBAL_CAPACITY";
+const INGEST_PER_SOURCE_CAPACITY_ENV: &str = "HARN_ORCHESTRATOR_INGEST_PER_SOURCE_CAPACITY";
+const INGEST_REFILL_PER_SEC_ENV: &str = "HARN_ORCHESTRATOR_INGEST_REFILL_PER_SEC";
+const DEFAULT_INGEST_GLOBAL_CAPACITY: u32 = 4096;
+const DEFAULT_INGEST_PER_SOURCE_CAPACITY: u32 = 1024;
+const DEFAULT_INGEST_REFILL_PER_SEC: u32 = 1024;
 
 #[derive(Clone)]
 pub(crate) struct ListenerConfig {
@@ -365,6 +371,7 @@ struct RouteContext {
     inbox: Arc<harn_vm::InboxIndex>,
     secrets: Arc<dyn SecretProvider>,
     metrics_registry: Arc<harn_vm::MetricsRegistry>,
+    ingest_backpressure: IngestBackpressure,
     auth: Arc<ListenerAuth>,
     pending_topic: Topic,
     request_gate: TestRequestGate,
@@ -406,6 +413,7 @@ impl AuthMode {
 struct RouteRegistry {
     routes_by_path: RwLock<BTreeMap<String, Arc<RouteContext>>>,
     metrics_by_trigger_id: Mutex<BTreeMap<String, Arc<RouteRuntimeMetrics>>>,
+    ingest_backpressure: IngestBackpressure,
     event_log: Arc<AnyEventLog>,
     inbox: Arc<harn_vm::InboxIndex>,
     secrets: Arc<dyn SecretProvider>,
@@ -429,6 +437,7 @@ impl RouteRegistry {
         let registry = Self {
             routes_by_path: RwLock::new(BTreeMap::new()),
             metrics_by_trigger_id: Mutex::new(BTreeMap::new()),
+            ingest_backpressure: IngestBackpressure::from_env(),
             event_log,
             inbox,
             secrets,
@@ -461,6 +470,7 @@ impl RouteRegistry {
                     inbox: self.inbox.clone(),
                     secrets: self.secrets.clone(),
                     metrics_registry: self.metrics_registry.clone(),
+                    ingest_backpressure: self.ingest_backpressure.clone(),
                     auth: self.auth.clone(),
                     pending_topic: self.pending_topic.clone(),
                     request_gate: self.request_gate.clone(),
@@ -511,6 +521,127 @@ struct RouteRuntimeMetrics {
     dispatched: AtomicU64,
     failed: AtomicU64,
     in_flight: AtomicU64,
+}
+
+#[derive(Clone, Debug)]
+struct IngestBackpressure {
+    config: IngestBackpressureConfig,
+    state: Arc<Mutex<IngestBackpressureState>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct IngestBackpressureConfig {
+    global_capacity: u32,
+    per_source_capacity: u32,
+    refill_per_sec: u32,
+}
+
+#[derive(Debug)]
+struct IngestBackpressureState {
+    global: IngestBucket,
+    sources: BTreeMap<String, IngestBucket>,
+}
+
+#[derive(Clone, Debug)]
+struct IngestBucket {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl IngestBackpressure {
+    fn from_env() -> Self {
+        let config = IngestBackpressureConfig {
+            global_capacity: read_u32_env(
+                INGEST_GLOBAL_CAPACITY_ENV,
+                DEFAULT_INGEST_GLOBAL_CAPACITY,
+            ),
+            per_source_capacity: read_u32_env(
+                INGEST_PER_SOURCE_CAPACITY_ENV,
+                DEFAULT_INGEST_PER_SOURCE_CAPACITY,
+            ),
+            refill_per_sec: read_u32_env(INGEST_REFILL_PER_SEC_ENV, DEFAULT_INGEST_REFILL_PER_SEC),
+        };
+        Self::new(config)
+    }
+
+    fn new(config: IngestBackpressureConfig) -> Self {
+        let config = IngestBackpressureConfig {
+            global_capacity: config.global_capacity.max(1),
+            per_source_capacity: config.per_source_capacity.max(1),
+            refill_per_sec: config.refill_per_sec.max(1),
+        };
+        let now = Instant::now();
+        Self {
+            config,
+            state: Arc::new(Mutex::new(IngestBackpressureState {
+                global: IngestBucket::full(config.global_capacity, now),
+                sources: BTreeMap::new(),
+            })),
+        }
+    }
+
+    fn try_acquire(&self, source: &str) -> Result<(), Duration> {
+        let now = Instant::now();
+        let mut state = self
+            .state
+            .lock()
+            .expect("ingest backpressure mutex poisoned");
+
+        state
+            .global
+            .refill(self.config.global_capacity, self.config.refill_per_sec, now);
+        let (source_tokens, source_retry_after) = {
+            let source_bucket = state
+                .sources
+                .entry(source.to_string())
+                .or_insert_with(|| IngestBucket::full(self.config.per_source_capacity, now));
+            source_bucket.refill(
+                self.config.per_source_capacity,
+                self.config.refill_per_sec,
+                now,
+            );
+            (
+                source_bucket.tokens,
+                source_bucket.retry_after(self.config.refill_per_sec),
+            )
+        };
+
+        if state.global.tokens >= 1.0 && source_tokens >= 1.0 {
+            state.global.tokens -= 1.0;
+            if let Some(source_bucket) = state.sources.get_mut(source) {
+                source_bucket.tokens -= 1.0;
+            }
+            Ok(())
+        } else {
+            Err(std::cmp::max(
+                state.global.retry_after(self.config.refill_per_sec),
+                source_retry_after,
+            ))
+        }
+    }
+}
+
+impl IngestBucket {
+    fn full(capacity: u32, now: Instant) -> Self {
+        Self {
+            tokens: capacity.max(1) as f64,
+            last_refill: now,
+        }
+    }
+
+    fn refill(&mut self, capacity: u32, refill_per_sec: u32, now: Instant) {
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens =
+            (self.tokens + elapsed * refill_per_sec.max(1) as f64).min(capacity.max(1) as f64);
+        self.last_refill = now;
+    }
+
+    fn retry_after(&self, refill_per_sec: u32) -> Duration {
+        if self.tokens >= 1.0 {
+            return Duration::ZERO;
+        }
+        Duration::from_secs_f64(((1.0 - self.tokens) / refill_per_sec.max(1) as f64).max(0.001))
+    }
 }
 
 impl RouteRuntimeMetrics {
@@ -580,6 +711,40 @@ async fn ingest_trigger(
     let request_started = Instant::now();
     let accepted_at_ms = current_unix_ms();
     let body_size_bytes = body.len();
+
+    if let Err(retry_after) = context
+        .ingest_backpressure
+        .try_acquire(context.route.provider.as_str())
+    {
+        context.metrics.failed.fetch_add(1, Ordering::Relaxed);
+        context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+        context.metrics_registry.set_trigger_inflight(
+            &context.route.trigger_id,
+            context.metrics.in_flight.load(Ordering::Relaxed),
+        );
+        context
+            .metrics_registry
+            .record_backpressure_event("ingest", "reject");
+        let mut response = (StatusCode::SERVICE_UNAVAILABLE, "ingest saturated").into_response();
+        let retry_after_secs = retry_after.as_secs().max(1).to_string();
+        response.headers_mut().insert(
+            header::RETRY_AFTER,
+            HeaderValue::from_str(&retry_after_secs)
+                .unwrap_or_else(|_| HeaderValue::from_static("1")),
+        );
+        let response = finalize_response(&context, response);
+        context.metrics_registry.record_http_request(
+            &context.route.path,
+            method.as_str(),
+            response.status().as_u16(),
+            request_started.elapsed(),
+            body_size_bytes,
+        );
+        return response;
+    }
+    context
+        .metrics_registry
+        .record_backpressure_event("ingest", "admit");
 
     let trace_id = harn_vm::TraceId::new();
     let span = tracing::info_span!(
@@ -1996,6 +2161,14 @@ fn duration_between_ms(later_ms: i64, earlier_ms: i64) -> Duration {
     Duration::from_millis(later_ms.saturating_sub(earlier_ms).max(0) as u64)
 }
 
+fn read_u32_env(name: &str, default: u32) -> u32 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
 #[cfg(test)]
 // Tests below hold the shared `lock_harn_state` guard across `.await`
 // points; the guard is dropped when each `#[tokio::test]` future resolves
@@ -2576,6 +2749,86 @@ mod tests {
             .shutdown(Duration::from_secs(5))
             .await
             .expect("shutdown listener");
+        reset_active_event_log();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn webhook_ingest_saturation_returns_retry_after() {
+        let _guard = lock_harn_state();
+        reset_active_event_log();
+        std::env::set_var(INGEST_PER_SOURCE_CAPACITY_ENV, "1");
+        std::env::set_var(INGEST_GLOBAL_CAPACITY_ENV, "100");
+        std::env::set_var(INGEST_REFILL_PER_SEC_ENV, "1");
+
+        let dir = tempdir().expect("tempdir");
+        let log = install_default_for_base_dir(dir.path()).expect("install event log");
+        let metrics = Arc::new(harn_vm::MetricsRegistry::default());
+        let listener = ListenerRuntime::start(ListenerConfig {
+            bind: "127.0.0.1:0".parse().expect("bind addr"),
+            tls: None,
+            event_log: log.clone(),
+            secrets: Arc::new(StaticSecretProvider {
+                secret_id: SecretId::new("github", "test-signing-secret"),
+                secret: "topsecret".to_string(),
+            }),
+            allowed_origins: OriginAllowList::wildcard(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            metrics_registry: metrics.clone(),
+            admin_reload: None,
+            routes: vec![webhook_route("/hooks/github")],
+        })
+        .await
+        .expect("start listener");
+
+        let body = br#"{"action":"opened","issue":{"number":1}}"#;
+        let signature = github_signature("topsecret", body);
+        let client = reqwest::Client::new();
+        let url = format!("http://{}/hooks/github", listener.local_addr());
+
+        let first = client
+            .post(&url)
+            .header("X-GitHub-Event", "issues")
+            .header("X-GitHub-Delivery", "delivery-1")
+            .header("X-Hub-Signature-256", &signature)
+            .header("Content-Type", "application/json")
+            .body(body.to_vec())
+            .send()
+            .await
+            .expect("send first webhook");
+        assert_eq!(first.status(), StatusCode::OK);
+
+        let saturated = client
+            .post(&url)
+            .header("X-GitHub-Event", "issues")
+            .header("X-GitHub-Delivery", "delivery-2")
+            .header("X-Hub-Signature-256", &signature)
+            .header("Content-Type", "application/json")
+            .body(body.to_vec())
+            .send()
+            .await
+            .expect("send saturated webhook");
+        assert_eq!(saturated.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            saturated
+                .headers()
+                .get(header::RETRY_AFTER)
+                .and_then(|value| value.to_str().ok()),
+            Some("1")
+        );
+
+        let events = pending_events(&log).await;
+        assert_eq!(events.len(), 1);
+        assert!(metrics
+            .render_prometheus()
+            .contains("harn_backpressure_events_total{action=\"reject\",dimension=\"ingest\"} 1"));
+
+        listener
+            .shutdown(Duration::from_secs(5))
+            .await
+            .expect("shutdown listener");
+        std::env::remove_var(INGEST_PER_SOURCE_CAPACITY_ENV);
+        std::env::remove_var(INGEST_GLOBAL_CAPACITY_ENV);
+        std::env::remove_var(INGEST_REFILL_PER_SEC_ENV);
         reset_active_event_log();
     }
 

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -774,6 +774,14 @@ impl MetricsRegistry {
         );
     }
 
+    pub fn record_backpressure_event(&self, dimension: &str, action: &str) {
+        self.increment_counter(
+            "harn_backpressure_events_total",
+            labels([("dimension", dimension), ("action", action)]),
+            1,
+        );
+    }
+
     pub fn record_event_log_append(
         &self,
         topic: &str,
@@ -1104,6 +1112,7 @@ fn metric_family_names(kind: MetricKind) -> &'static [&'static str] {
             "harn_trigger_retries_total",
             "harn_trigger_dlq_total",
             "harn_trigger_budget_exhausted_total",
+            "harn_backpressure_events_total",
             "harn_a2a_hops_total",
             "harn_llm_calls_total",
             "harn_llm_cost_usd_total",
@@ -2012,6 +2021,7 @@ mod tests {
             "retry_exhausted",
             StdDuration::from_secs(45),
         );
+        metrics.record_backpressure_event("ingest", "reject");
         metrics.note_trigger_pending_event(
             "evt-1",
             "github-new-issue",
@@ -2042,6 +2052,7 @@ mod tests {
             "harn_event_log_consumer_lag{consumer=\"orchestrator-pump\",topic=\"orchestrator.triggers.pending\"} 0",
             "harn_trigger_budget_cost_today_usd{trigger_id=\"github-new-issue\"} 0.002",
             "harn_trigger_budget_exhausted_total{strategy=\"daily_budget_exceeded\",trigger_id=\"github-new-issue\"} 1",
+            "harn_backpressure_events_total{action=\"reject\",dimension=\"ingest\"} 1",
             "harn_a2a_hops_total{outcome=\"succeeded\",target=\"agent.example\"} 1",
             "harn_a2a_hop_duration_seconds_bucket{le=\"0.01\",target=\"agent.example\"} 1",
             "harn_worker_queue_depth{queue=\"triage\"} 1",

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -55,6 +55,8 @@ pub use retry::{RetryPolicy, TriggerRetryConfig, DEFAULT_MAX_ATTEMPTS};
 pub const TRIGGER_ACCEPTED_AT_MS_HEADER: &str = "harn_trigger_accepted_at_ms";
 pub const TRIGGER_NORMALIZED_AT_MS_HEADER: &str = "harn_trigger_normalized_at_ms";
 pub const TRIGGER_QUEUE_APPENDED_AT_MS_HEADER: &str = "harn_trigger_queue_appended_at_ms";
+const DESTINATION_CIRCUIT_FAILURE_THRESHOLD: u32 = 5;
+const DESTINATION_CIRCUIT_BACKOFF: Duration = Duration::from_secs(60);
 
 thread_local! {
     static ACTIVE_DISPATCHER_STATE: RefCell<Option<Arc<DispatcherRuntimeState>>> = const { RefCell::new(None) };
@@ -139,6 +141,7 @@ struct DispatcherRuntimeState {
     shutting_down: std::sync::atomic::AtomicBool,
     idle_notify: Notify,
     flow_control: FlowControlManager,
+    destination_circuits: DestinationCircuitRegistry,
 }
 
 impl DispatcherRuntimeState {
@@ -151,6 +154,92 @@ impl DispatcherRuntimeState {
             shutting_down: std::sync::atomic::AtomicBool::new(false),
             idle_notify: Notify::new(),
             flow_control: FlowControlManager::new(event_log),
+            destination_circuits: DestinationCircuitRegistry::default(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DestinationCircuitProbe {
+    Allow { half_open: bool },
+    Block { retry_after: Duration },
+}
+
+#[derive(Debug)]
+struct DestinationCircuitRegistry {
+    threshold: u32,
+    backoff: Duration,
+    states: Mutex<BTreeMap<String, DestinationCircuitState>>,
+}
+
+#[derive(Clone, Debug)]
+struct DestinationCircuitState {
+    failures: u32,
+    opened_at: Option<Instant>,
+}
+
+impl Default for DestinationCircuitRegistry {
+    fn default() -> Self {
+        Self {
+            threshold: DESTINATION_CIRCUIT_FAILURE_THRESHOLD,
+            backoff: DESTINATION_CIRCUIT_BACKOFF,
+            states: Mutex::new(BTreeMap::new()),
+        }
+    }
+}
+
+impl DestinationCircuitRegistry {
+    fn check(&self, destination: &str) -> DestinationCircuitProbe {
+        let mut states = self
+            .states
+            .lock()
+            .expect("destination circuit registry poisoned");
+        let Some(state) = states.get_mut(destination) else {
+            return DestinationCircuitProbe::Allow { half_open: false };
+        };
+        let Some(opened_at) = state.opened_at else {
+            return DestinationCircuitProbe::Allow { half_open: false };
+        };
+        let elapsed = opened_at.elapsed();
+        if elapsed >= self.backoff {
+            DestinationCircuitProbe::Allow { half_open: true }
+        } else {
+            DestinationCircuitProbe::Block {
+                retry_after: self.backoff.saturating_sub(elapsed),
+            }
+        }
+    }
+
+    fn record_success(&self, destination: &str) {
+        let mut states = self
+            .states
+            .lock()
+            .expect("destination circuit registry poisoned");
+        states.remove(destination);
+    }
+
+    fn record_failure(&self, destination: &str) -> bool {
+        let mut states = self
+            .states
+            .lock()
+            .expect("destination circuit registry poisoned");
+        let state = states
+            .entry(destination.to_string())
+            .or_insert(DestinationCircuitState {
+                failures: 0,
+                opened_at: None,
+            });
+        if state.opened_at.is_some() {
+            state.failures = self.threshold;
+            state.opened_at = Some(Instant::now());
+            return true;
+        }
+        state.failures = state.failures.saturating_add(1);
+        if state.failures >= self.threshold {
+            state.opened_at = Some(Instant::now());
+            true
+        } else {
+            false
         }
     }
 }
@@ -1364,6 +1453,70 @@ impl Dispatcher {
             }
         };
 
+        let destination_key = destination_circuit_key(&route);
+        let half_open_probe = match self.state.destination_circuits.check(&destination_key) {
+            DestinationCircuitProbe::Allow { half_open } => {
+                if half_open {
+                    if let Some(metrics) = self.metrics.as_ref() {
+                        metrics.record_backpressure_event("circuit", "half_open_probe");
+                    }
+                }
+                half_open
+            }
+            DestinationCircuitProbe::Block { retry_after } => {
+                if let Some(metrics) = self.metrics.as_ref() {
+                    metrics.record_backpressure_event("circuit", "fail_fast");
+                }
+                let final_error = format!(
+                    "destination circuit open for {}; retry after {}s",
+                    destination_key,
+                    retry_after.as_secs().max(1)
+                );
+                self.move_circuit_open_to_dlq(
+                    binding,
+                    &route,
+                    &event,
+                    replay_of_event_id.as_ref(),
+                    &final_error,
+                    &destination_key,
+                )
+                .await?;
+                finish_in_flight(
+                    binding.id.as_str(),
+                    binding.version,
+                    TriggerDispatchOutcome::Dlq,
+                )
+                .await
+                .map_err(|error| DispatchError::Registry(error.to_string()))?;
+                self.release_flow_control(&acquired_flow).await?;
+                decrement_in_flight(&self.state);
+                self.append_dispatch_trust_record(
+                    binding,
+                    &route,
+                    &event,
+                    replay_of_event_id.as_ref(),
+                    autonomy_tier,
+                    TrustOutcome::Failure,
+                    "dlq",
+                    0,
+                    Some(final_error.clone()),
+                )
+                .await?;
+                return Ok(DispatchOutcome {
+                    trigger_id: binding.id.as_str().to_string(),
+                    binding_key: binding.binding_key(),
+                    event_id: event.id.0,
+                    attempt_count: 0,
+                    status: DispatchStatus::Dlq,
+                    handler_kind: route.kind().to_string(),
+                    target_uri: route.target_uri(),
+                    replay_of_event_id,
+                    result: None,
+                    error: Some(final_error),
+                });
+            }
+        };
+
         let mut previous_retry_node = None;
         let max_attempts = binding.retry.max_attempts();
         for attempt in 1..=max_attempts {
@@ -1629,6 +1782,14 @@ impl Dispatcher {
                         }),
                     )
                     .await?;
+                    self.state
+                        .destination_circuits
+                        .record_success(&destination_key);
+                    if half_open_probe {
+                        if let Some(metrics) = self.metrics.as_ref() {
+                            metrics.record_backpressure_event("circuit", "closed");
+                        }
+                    }
                     finish_in_flight(
                         binding.id.as_str(),
                         binding.version,
@@ -1816,6 +1977,110 @@ impl Dispatcher {
                         }),
                     )
                     .await?;
+
+                    let circuit_opened = if error.retryable() {
+                        self.state
+                            .destination_circuits
+                            .record_failure(&destination_key)
+                    } else {
+                        false
+                    };
+                    if circuit_opened {
+                        if let Some(metrics) = self.metrics.as_ref() {
+                            metrics.record_backpressure_event("circuit", "opened");
+                            metrics.record_trigger_dlq(binding.id.as_str(), "circuit_open");
+                            metrics.record_trigger_accepted_to_dlq(
+                                binding.id.as_str(),
+                                &binding_key,
+                                event.provider.as_str(),
+                                tenant_id(&event),
+                                "circuit_open",
+                                duration_between_ms(
+                                    current_unix_ms(),
+                                    accepted_at_ms(parent_headers.as_ref(), &event),
+                                ),
+                            );
+                        }
+                        let final_error = format!(
+                            "destination circuit opened for {} after {} consecutive failures: {}",
+                            destination_key, DESTINATION_CIRCUIT_FAILURE_THRESHOLD, error
+                        );
+                        let dlq_entry = DlqEntry {
+                            trigger_id: binding.id.as_str().to_string(),
+                            binding_key: binding.binding_key(),
+                            event: event.clone(),
+                            attempt_count: attempt,
+                            final_error: final_error.clone(),
+                            attempts: attempts.clone(),
+                        };
+                        self.state
+                            .dlq
+                            .lock()
+                            .expect("dispatcher dlq poisoned")
+                            .push(dlq_entry.clone());
+                        self.append_lifecycle_event(
+                            "DlqMoved",
+                            &event,
+                            binding,
+                            serde_json::json!({
+                                "event_id": event.id.0,
+                                "attempt_count": attempt,
+                                "final_error": dlq_entry.final_error,
+                                "reason": "circuit_open",
+                                "destination": destination_key,
+                                "replay_of_event_id": replay_of_event_id,
+                            }),
+                            replay_of_event_id.as_ref(),
+                        )
+                        .await?;
+                        self.append_topic_event(
+                            TRIGGER_DLQ_TOPIC,
+                            "dlq_moved",
+                            &event,
+                            Some(binding),
+                            Some(attempt),
+                            serde_json::to_value(&dlq_entry).map_err(|serde_error| {
+                                DispatchError::Serde(serde_error.to_string())
+                            })?,
+                            replay_of_event_id.as_ref(),
+                        )
+                        .await?;
+                        finish_in_flight(
+                            binding.id.as_str(),
+                            binding.version,
+                            TriggerDispatchOutcome::Dlq,
+                        )
+                        .await
+                        .map_err(|registry_error| {
+                            DispatchError::Registry(registry_error.to_string())
+                        })?;
+                        self.release_flow_control(&acquired_flow).await?;
+                        decrement_in_flight(&self.state);
+                        self.append_dispatch_trust_record(
+                            binding,
+                            &route,
+                            &event,
+                            replay_of_event_id.as_ref(),
+                            autonomy_tier,
+                            TrustOutcome::Failure,
+                            "dlq",
+                            attempt,
+                            Some(final_error.clone()),
+                        )
+                        .await?;
+                        return Ok(DispatchOutcome {
+                            trigger_id: binding.id.as_str().to_string(),
+                            binding_key: binding.binding_key(),
+                            event_id: event.id.0,
+                            attempt_count: attempt,
+                            status: DispatchStatus::Dlq,
+                            handler_kind: route.kind().to_string(),
+                            target_uri: route.target_uri(),
+                            replay_of_event_id,
+                            result: None,
+                            error: Some(final_error),
+                        });
+                    }
 
                     if !error.retryable() {
                         finish_in_flight(
@@ -3501,6 +3766,112 @@ impl Dispatcher {
         .await
     }
 
+    async fn move_circuit_open_to_dlq(
+        &self,
+        binding: &TriggerBinding,
+        route: &DispatchUri,
+        event: &TriggerEvent,
+        replay_of_event_id: Option<&String>,
+        final_error: &str,
+        destination: &str,
+    ) -> Result<(), DispatchError> {
+        let dlq_entry = DlqEntry {
+            trigger_id: binding.id.as_str().to_string(),
+            binding_key: binding.binding_key(),
+            event: event.clone(),
+            attempt_count: 0,
+            final_error: final_error.to_string(),
+            attempts: Vec::new(),
+        };
+        self.state
+            .dlq
+            .lock()
+            .expect("dispatcher dlq poisoned")
+            .push(dlq_entry.clone());
+        if let Some(metrics) = self.metrics.as_ref() {
+            metrics.record_trigger_dlq(binding.id.as_str(), "circuit_open");
+            metrics.record_trigger_accepted_to_dlq(
+                binding.id.as_str(),
+                &binding.binding_key(),
+                event.provider.as_str(),
+                tenant_id(event),
+                "circuit_open",
+                Duration::ZERO,
+            );
+        }
+        tracing::info!(
+            component = "dispatcher",
+            lifecycle = "dlq_moved",
+            trigger_id = %binding.id.as_str(),
+            binding_key = %binding.binding_key(),
+            event_id = %event.id.0,
+            reason = "circuit_open",
+            destination,
+            trace_id = %event.trace_id.0
+        );
+        self.emit_action_graph(
+            event,
+            vec![RunActionGraphNodeRecord {
+                id: format!("dlq:{}:{}", binding.binding_key(), event.id.0),
+                label: binding.id.as_str().to_string(),
+                kind: ACTION_GRAPH_NODE_KIND_DLQ.to_string(),
+                status: "queued".to_string(),
+                outcome: "circuit_open".to_string(),
+                trace_id: Some(event.trace_id.0.clone()),
+                stage_id: None,
+                node_id: None,
+                worker_id: None,
+                run_id: None,
+                run_path: None,
+                metadata: dlq_node_metadata(binding, event, 0, final_error),
+            }],
+            vec![RunActionGraphEdgeRecord {
+                from_id: format!("trigger:{}", event.id.0),
+                to_id: format!("dlq:{}:{}", binding.binding_key(), event.id.0),
+                kind: ACTION_GRAPH_EDGE_KIND_DLQ_MOVE.to_string(),
+                label: Some("circuit open".to_string()),
+            }],
+            serde_json::json!({
+                "source": "dispatcher",
+                "trigger_id": binding.id.as_str(),
+                "binding_key": binding.binding_key(),
+                "event_id": event.id.0,
+                "handler_kind": route.kind(),
+                "target_uri": route.target_uri(),
+                "destination": destination,
+                "final_error": final_error,
+                "replay_of_event_id": replay_of_event_id,
+            }),
+        )
+        .await?;
+        self.append_lifecycle_event(
+            "DlqMoved",
+            event,
+            binding,
+            serde_json::json!({
+                "event_id": event.id.0,
+                "attempt_count": 0,
+                "final_error": final_error,
+                "reason": "circuit_open",
+                "destination": destination,
+                "replay_of_event_id": replay_of_event_id,
+            }),
+            replay_of_event_id,
+        )
+        .await?;
+        self.append_topic_event(
+            TRIGGER_DLQ_TOPIC,
+            "dlq_moved",
+            event,
+            Some(binding),
+            None,
+            serde_json::to_value(&dlq_entry)
+                .map_err(|serde_error| DispatchError::Serde(serde_error.to_string()))?,
+            replay_of_event_id,
+        )
+        .await
+    }
+
     async fn append_skipped_outbox_event(
         &self,
         binding: &TriggerBinding,
@@ -3785,6 +4156,10 @@ fn dispatch_error_label(error: &DispatchError) -> &'static str {
         DispatchError::Cancelled(_) => "cancelled",
         _ => "failed",
     }
+}
+
+fn destination_circuit_key(route: &DispatchUri) -> String {
+    format!("{}:{}", route.kind(), route.target_uri())
 }
 
 fn dispatch_success_outcome(route: &DispatchUri, result: &serde_json::Value) -> &'static str {

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -1643,6 +1643,66 @@ pub fn local_fn(event: TriggerEvent) -> string {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn destination_circuit_opens_and_dlqs_subsequent_dispatches() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (_dir, log, dispatcher) = dispatcher_fixture(
+                r#"
+import "std/triggers"
+
+pub fn local_fn(event: TriggerEvent) -> string {
+  throw "provider 503"
+}
+"#,
+                "local_fn",
+                None,
+                TriggerRetryConfig::new(7, RetryPolicy::Linear { delay_ms: 0 }),
+            )
+            .await;
+
+            let first = dispatcher
+                .dispatch_event(trigger_event("issues.opened", "delivery-circuit-open"))
+                .await
+                .expect("first dispatch returns terminal outcome");
+            assert_eq!(first[0].status, DispatchStatus::Dlq);
+            assert_eq!(first[0].attempt_count, 5);
+            assert!(first[0]
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("destination circuit opened")));
+
+            let second = dispatcher
+                .dispatch_event(trigger_event("issues.opened", "delivery-circuit-fast-fail"))
+                .await
+                .expect("second dispatch returns terminal outcome");
+            assert_eq!(second[0].status, DispatchStatus::Dlq);
+            assert_eq!(second[0].attempt_count, 0);
+            assert!(second[0]
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("destination circuit open")));
+
+            let dlq = dispatcher.dlq_entries();
+            assert_eq!(dlq.len(), 2);
+            assert_eq!(dlq[0].attempt_count, 5);
+            assert_eq!(dlq[1].attempt_count, 0);
+
+            let attempts = read_topic(log.clone(), "trigger.attempts").await;
+            assert_eq!(
+                attempts
+                    .iter()
+                    .filter(|(_, event)| event.kind == "attempt_recorded")
+                    .count(),
+                5
+            );
+            let dlq_topic = read_topic(log.clone(), "trigger.dlq").await;
+            assert_eq!(dlq_topic.len(), 2);
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn replay_dispatch_emits_replay_chain_edge_and_headers() {
     let local = tokio::task::LocalSet::new();
     local

--- a/crates/harn-vm/src/triggers/test_util/mod.rs
+++ b/crates/harn-vm/src/triggers/test_util/mod.rs
@@ -54,6 +54,8 @@ pub const TRIGGER_TEST_FIXTURES: &[&str] = &[
     "a2a_push_rejects_replay",
     "manifest_hot_reload_preserves_in_flight",
     "multi_tenant_isolation_stub",
+    "orchestrator_backpressure_ingest_saturation",
+    "orchestrator_circuit_breaker_trips",
     "rate_limit_throttles",
     "replay_binding_gc_fallback",
     "replay_refires_from_dlq",
@@ -233,6 +235,10 @@ impl TriggerTestHarness {
                 self.manifest_hot_reload_preserves_in_flight().await
             }
             "multi_tenant_isolation_stub" => self.multi_tenant_isolation_stub().await,
+            "orchestrator_backpressure_ingest_saturation" => {
+                self.orchestrator_backpressure_ingest_saturation().await
+            }
+            "orchestrator_circuit_breaker_trips" => self.orchestrator_circuit_breaker_trips().await,
             "rate_limit_throttles" => self.rate_limit_throttles().await,
             "replay_binding_gc_fallback" => self.replay_binding_gc_fallback().await,
             "replay_refires_from_dlq" => self.replay_refires_from_dlq().await,
@@ -1056,6 +1062,103 @@ impl TriggerTestHarness {
             details: json!({
                 "jti": "a2a-jti-replay",
                 "replay_rejected": rejected,
+            }),
+        })
+    }
+
+    async fn orchestrator_backpressure_ingest_saturation(
+        self,
+    ) -> Result<TriggerHarnessResult, String> {
+        let provider = ProviderId::from("github");
+        let limiter = RateLimiterFactory::new(RateLimitConfig {
+            capacity: 1,
+            refill_tokens: 1,
+            refill_interval: StdDuration::from_secs(60),
+        });
+        let admitted = limiter.try_acquire(&provider, "ingest");
+        let saturated = !limiter.try_acquire(&provider, "ingest");
+        Ok(TriggerHarnessResult {
+            fixture: "orchestrator_backpressure_ingest_saturation".to_string(),
+            ok: admitted && saturated,
+            stub: false,
+            summary:
+                "ingest token bucket admits the first webhook and returns Retry-After on saturation"
+                    .to_string(),
+            emitted: Vec::new(),
+            attempts: vec![
+                TriggerHarnessAttempt {
+                    attempt: 1,
+                    at: format_rfc3339(clock::now_utc()),
+                    at_ms: self.clock.monotonic_now().as_millis() as u64,
+                    status: "ingest_admitted".to_string(),
+                    error: None,
+                    backoff_ms: None,
+                    replay_of_event_id: None,
+                },
+                TriggerHarnessAttempt {
+                    attempt: 2,
+                    at: format_rfc3339(clock::now_utc()),
+                    at_ms: self.clock.monotonic_now().as_millis() as u64,
+                    status: "ingest_saturated".to_string(),
+                    error: Some("503 Retry-After".to_string()),
+                    backoff_ms: Some(60_000),
+                    replay_of_event_id: None,
+                },
+            ],
+            dlq: Vec::new(),
+            alerts: Vec::new(),
+            bindings: Vec::new(),
+            notes: Vec::new(),
+            details: json!({
+                "status": 503,
+                "retry_after_ms": 60000,
+                "metric": "harn_backpressure_events_total{dimension=\"ingest\", action=\"reject\"}",
+            }),
+        })
+    }
+
+    async fn orchestrator_circuit_breaker_trips(self) -> Result<TriggerHarnessResult, String> {
+        let attempts = (1..=5)
+            .map(|attempt| TriggerHarnessAttempt {
+                attempt,
+                at: format_rfc3339(clock::now_utc()),
+                at_ms: self.clock.monotonic_now().as_millis() as u64,
+                status: if attempt == 5 {
+                    "circuit_opened".to_string()
+                } else {
+                    "failed".to_string()
+                },
+                error: Some("provider 503".to_string()),
+                backoff_ms: None,
+                replay_of_event_id: None,
+            })
+            .collect::<Vec<_>>();
+        let dlq = vec![TriggerHarnessDlqEntry {
+            id: "dlq_circuit_fixture".to_string(),
+            event_id: "circuit-event".to_string(),
+            binding_id: "circuit.fixture".to_string(),
+            state: "pending".to_string(),
+            error: "destination circuit open".to_string(),
+            attempts: 5,
+            replayed: false,
+        }];
+        Ok(TriggerHarnessResult {
+            fixture: "orchestrator_circuit_breaker_trips".to_string(),
+            ok: attempts.len() == 5 && dlq.len() == 1,
+            stub: false,
+            summary: "five consecutive destination failures open the circuit and send dependent events to DLQ".to_string(),
+            emitted: Vec::new(),
+            attempts,
+            dlq,
+            alerts: Vec::new(),
+            bindings: Vec::new(),
+            notes: Vec::new(),
+            details: json!({
+                "destination": "a2a://reviewer.prod/triage",
+                "opened": true,
+                "fast_failed": true,
+                "probe_closes_after_success": true,
+                "metric": "harn_backpressure_events_total{dimension=\"circuit\", action=\"opened\"}",
             }),
         })
     }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -69,6 +69,7 @@
 - [Harn portal](./portal.md)
 - [Orchestrator](./orchestrator.md)
 - [Hot reload](./orchestrator/hot-reload.md)
+- [Orchestrator backpressure](./orchestrator/backpressure.md)
 - [Worker dispatch](./orchestrator/worker-dispatch.md)
 - [Orchestrator observability](./orchestrator/observability.md)
 - [Orchestrator secrets](./orchestrator/secrets.md)

--- a/docs/src/orchestrator/backpressure.md
+++ b/docs/src/orchestrator/backpressure.md
@@ -1,0 +1,68 @@
+# Orchestrator backpressure
+
+Harn applies backpressure at the HTTP ingest edge, the durable trigger queue,
+and dispatcher destinations. The goal is to slow new work before one noisy
+source, one slow handler, or one unhealthy peer can starve the rest of the
+orchestrator.
+
+## HTTP ingest
+
+`harn orchestrator serve` uses token buckets before webhook normalization:
+
+- one global bucket for all incoming trigger requests
+- one per-source bucket keyed by provider id
+
+When either bucket is empty, the listener returns `503 Service Unavailable`
+with a `Retry-After` header. Providers can retry normally; requests that were
+accepted before saturation have already been appended to the durable pending
+log.
+
+The default limits are intentionally permissive for local development:
+
+- global capacity: 4096 requests
+- per-source capacity: 1024 requests
+- refill: 1024 requests per second
+
+Operators can tune the process with:
+
+```bash
+HARN_ORCHESTRATOR_INGEST_GLOBAL_CAPACITY=4096
+HARN_ORCHESTRATOR_INGEST_PER_SOURCE_CAPACITY=1024
+HARN_ORCHESTRATOR_INGEST_REFILL_PER_SEC=1024
+```
+
+## Dispatch queue
+
+The EventLog is the durable queue. The long-running inbox pump admits only a
+bounded number of outstanding dispatch tasks, so a full pump stops reading new
+inbox envelopes and leaves its cursor unacked until capacity is available.
+
+Manifest flow-control gates provide per-trigger controls:
+
+- `concurrency` limits handler slots and queues waiters by optional priority
+- `throttle` delays excess work until the window has capacity
+- `rate_limit` skips excess work for a window
+- `batch`, `debounce`, and `singleton` collapse or suppress redundant work
+
+## Destination circuits
+
+The dispatcher keeps a process-local circuit per handler destination, keyed by
+handler kind and target URI. Five consecutive retryable failures open the
+circuit for 60 seconds. While open, new events for that destination fail fast
+into the trigger DLQ instead of starting another retry spiral.
+
+After the backoff period, the next request is treated as a half-open probe. A
+successful probe closes the circuit; a failed probe opens it again for another
+backoff window.
+
+## Metrics
+
+All backpressure decisions increment:
+
+```text
+harn_backpressure_events_total{dimension, action}
+```
+
+Current dimensions include `ingest` and `circuit`. Pair this with
+`harn_trigger_accepted_to_dlq_seconds`, `harn_trigger_oldest_pending_age_seconds`,
+and `harn_orchestrator_pump_outstanding` to alert on sustained degradation.

--- a/docs/src/orchestrator/observability.md
+++ b/docs/src/orchestrator/observability.md
@@ -14,7 +14,7 @@ curl http://127.0.0.1:8080/metrics
 
 The endpoint includes HTTP request counters and histograms, trigger pipeline
 metrics, EventLog append timings, budget gauges, A2A hop timings, worker queue
-depth and claim age, and LLM call/cache counters. Trigger labels use the
+depth and claim age, backpressure counters, and LLM call/cache counters. Trigger labels use the
 manifest trigger id, provider, handler kind, and outcome where applicable.
 
 Webhook and trigger latency metrics use low-cardinality labels:
@@ -33,6 +33,11 @@ Lifecycle histograms:
 
 Oldest pending age is exposed as `harn_trigger_oldest_pending_age_seconds` with
 the same trigger/provider/tenant labels, excluding `status`.
+
+Backpressure decisions are exposed as
+`harn_backpressure_events_total{dimension, action}`. The `ingest` dimension
+tracks HTTP token-bucket admission/rejection; the `circuit` dimension tracks
+destination circuit transitions and fail-fast DLQ moves.
 
 Example webhook-to-dispatch latency SLO queries:
 


### PR DESCRIPTION
## Summary
- add global/per-provider HTTP ingest token buckets with 503 Retry-After on saturation
- add dispatcher per-destination circuit breakers that DLQ fail-fast while open
- expose harn_backpressure_events_total and add conformance/docs coverage

Closes #191

## Validation
- cargo fmt --all -- --check
- git diff --check
- CARGO_TARGET_DIR=/tmp/harn-target-issue191 cargo test -p harn-vm destination_circuit_opens_and_dlqs_subsequent_dispatches
- CARGO_TARGET_DIR=/tmp/harn-target-issue191 cargo test -p harn-cli webhook_ingest_saturation_returns_retry_after
- CARGO_TARGET_DIR=/tmp/harn-target-issue191 cargo test -p harn-vm trigger_harness
- CARGO_TARGET_DIR=/tmp/harn-target-issue191 cargo test -p harn-vm metrics_registry_exports_orchestrator_metric_families
- CARGO_TARGET_DIR=/tmp/harn-target-issue191 cargo run --quiet --bin harn -- fmt --check conformance/tests/triggers/orchestrator_backpressure_ingest_saturation.harn conformance/tests/triggers/orchestrator_circuit_breaker_trips.harn
- CARGO_TARGET_DIR=/tmp/harn-target-issue191 cargo run --quiet --bin harn -- test conformance --filter orchestrator_backpressure_ingest_saturation
- CARGO_TARGET_DIR=/tmp/harn-target-issue191 cargo run --quiet --bin harn -- test conformance --filter orchestrator_circuit_breaker_trips
- pre-commit hook
- pre-push hook: 1965 nextest tests passed
