### PR TITLE
[codex] Fix runtime, LSP, and test runner correctness gaps

### DIFF
--- a/crates/harn-cli/src/test_runner.rs
+++ b/crates/harn-cli/src/test_runner.rs
@@ -97,18 +97,9 @@ pub async fn run_test_file(
         let local = tokio::task::LocalSet::new();
         let path_str = path.display().to_string();
         let timeout = std::time::Duration::from_millis(timeout_ms);
-        let previous_cwd = if let Some(cwd) = execution_cwd {
-            let previous = std::env::current_dir().ok();
-            std::env::set_current_dir(cwd).map_err(|error| {
-                format!(
-                    "Failed to set current directory to {}: {error}",
-                    cwd.display()
-                )
-            })?;
-            previous
-        } else {
-            None
-        };
+        let execution_cwd = execution_cwd
+            .map(Path::to_path_buf)
+            .unwrap_or_else(test_execution_cwd);
         let result = tokio::time::timeout(
             timeout,
             local.run_until(async {
@@ -117,7 +108,6 @@ pub async fn run_test_file(
                 let source_parent = path.parent().unwrap_or(std::path::Path::new("."));
                 let project_root = harn_vm::stdlib::process::find_project_root(source_parent);
                 let store_base = project_root.as_deref().unwrap_or(source_parent);
-                let execution_cwd = test_execution_cwd();
                 let source_dir = source_parent.to_string_lossy().into_owned();
                 harn_vm::register_store_builtins(&mut vm, store_base);
                 harn_vm::register_metadata_builtins(&mut vm, store_base);
@@ -170,9 +160,6 @@ pub async fn run_test_file(
             }),
         )
         .await;
-        if let Some(previous) = previous_cwd {
-            let _ = std::env::set_current_dir(previous);
-        }
 
         let duration = start.elapsed().as_millis() as u64;
 
@@ -239,7 +226,17 @@ pub async fn run_tests(
                 for file in files {
                     let filter = filter.map(|s| s.to_string());
                     handles.push(tokio::task::spawn_local(async move {
-                        run_test_file(&file, filter.as_deref(), timeout_ms, None).await
+                        let execution_cwd = file
+                            .parent()
+                            .filter(|parent| !parent.as_os_str().is_empty())
+                            .map(Path::to_path_buf);
+                        run_test_file(
+                            &file,
+                            filter.as_deref(),
+                            timeout_ms,
+                            execution_cwd.as_deref(),
+                        )
+                        .await
                     }));
                 }
                 let mut results = Vec::new();
@@ -308,7 +305,7 @@ fn discover_test_files(dir: &Path) -> Vec<PathBuf> {
                 files.extend(discover_test_files(&path));
             } else if path.extension().is_some_and(|e| e == "harn") {
                 if let Ok(content) = std::fs::read_to_string(&path) {
-                    if content.contains("test_") {
+                    if content.contains("test_") || content.contains("@test") {
                         files.push(canonicalize_existing_path(&path));
                     }
                 }
@@ -369,6 +366,7 @@ mod tests {
         let temp = TempTestDir::new();
         temp.write("suite/test_alpha.harn", "pipeline test_alpha(task) {}");
         temp.write("suite/nested/test_beta.harn", "pipeline test_beta(task) {}");
+        temp.write("suite/annotated.harn", "@test\npipeline annotated(task) {}");
         temp.write("suite/ignore.harn", "pipeline build(task) {}");
 
         // Pass an absolute path rather than mutating process-wide cwd — the
@@ -376,7 +374,7 @@ mod tests {
         // from two tests concurrently causes cross-test flakiness.
         let files = discover_test_files(&temp.path().join("suite"));
 
-        assert_eq!(files.len(), 2);
+        assert_eq!(files.len(), 3);
         assert!(files.iter().all(|path| path.is_absolute()));
         assert!(files
             .iter()
@@ -384,6 +382,9 @@ mod tests {
         assert!(files
             .iter()
             .any(|path| path.ends_with("suite/nested/test_beta.harn")));
+        assert!(files
+            .iter()
+            .any(|path| path.ends_with("suite/annotated.harn")));
     }
 
     #[tokio::test]
@@ -410,5 +411,32 @@ pipeline test_current_dir(task) {
             fs::canonicalize(restored_cwd).unwrap(),
             fs::canonicalize(original_cwd).unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn parallel_run_tests_uses_each_file_parent_as_execution_cwd() {
+        let _cwd_guard = crate::tests::common::cwd_lock::lock_cwd_async().await;
+        let _env_guard = crate::tests::common::env_lock::lock_env().lock().await;
+        let temp = TempTestDir::new();
+        temp.write(
+            "suite/a/test_one.harn",
+            r#"
+pipeline test_one(task) {
+  assert_eq(cwd(), source_dir())
+}
+"#,
+        );
+        temp.write(
+            "suite/b/test_two.harn",
+            r#"
+pipeline test_two(task) {
+  assert_eq(cwd(), source_dir())
+}
+"#,
+        );
+
+        let summary = run_tests(&temp.path().join("suite"), None, 1_000, true).await;
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.passed, 2);
     }
 }

--- a/crates/harn-lsp/src/helpers.rs
+++ b/crates/harn-lsp/src/helpers.rs
@@ -17,31 +17,9 @@ pub(crate) fn span_to_range(span: &Span) -> Range {
 
 /// Convert a Span to an LSP Range using byte offsets for accurate end position.
 pub(crate) fn span_to_full_range(span: &Span, source: &str) -> Range {
-    let start_line = span.line.saturating_sub(1) as u32;
-    let start_col = span.column.saturating_sub(1) as u32;
-
-    let mut end_line = start_line;
-    let mut end_col = start_col;
-    if span.end > span.start && span.end <= source.len() {
-        let segment = &source[span.start..span.end];
-        for ch in segment.chars() {
-            if ch == '\n' {
-                end_line += 1;
-                end_col = 0;
-            } else {
-                end_col += 1;
-            }
-        }
-        if end_line == start_line {
-            end_col = start_col + segment.chars().count() as u32;
-        }
-    } else {
-        end_col = start_col + 1;
-    }
-
     Range {
-        start: Position::new(start_line, start_col),
-        end: Position::new(end_line, end_col),
+        start: offset_to_position(source, span.start),
+        end: offset_to_position(source, span.end.max(span.start + 1).min(source.len())),
     }
 }
 
@@ -62,99 +40,173 @@ pub(crate) fn position_in_span(pos: &Position, span: &Span, source: &str) -> boo
 
 /// Convert a 0-based LSP Position to a byte offset in the source string.
 pub(crate) fn lsp_position_to_offset(source: &str, pos: Position) -> usize {
-    let mut offset = 0;
-    for (i, line) in source.split('\n').enumerate() {
-        if i == pos.line as usize {
-            return offset + (pos.character as usize).min(line.len());
-        }
-        offset += line.len() + 1; // account for the stripped newline
-    }
-    source.len()
+    let Some((line_start, line_end)) = line_byte_range(source, pos.line as usize) else {
+        return source.len();
+    };
+    line_start + utf16_col_to_byte(&source[line_start..line_end], pos.character)
 }
 
 /// Convert a byte offset in `source` to a 0-based LSP Position.
 pub(crate) fn offset_to_position(source: &str, offset: usize) -> Position {
+    let offset = offset.min(source.len());
     let mut line = 0u32;
-    let mut col = 0u32;
+    let mut line_start = 0usize;
     for (i, ch) in source.char_indices() {
-        if i == offset {
+        if i >= offset {
+            let col = utf16_len(&source[line_start..offset]);
             return Position::new(line, col);
         }
         if ch == '\n' {
             line += 1;
-            col = 0;
-        } else {
-            col += 1;
+            line_start = i + ch.len_utf8();
         }
     }
-    Position::new(line, col)
+    Position::new(line, utf16_len(&source[line_start..offset]))
+}
+
+pub(crate) fn utf16_len(text: &str) -> u32 {
+    text.encode_utf16().count() as u32
+}
+
+fn line_byte_range(source: &str, line: usize) -> Option<(usize, usize)> {
+    let mut current_line = 0usize;
+    let mut line_start = 0usize;
+    for (idx, ch) in source.char_indices() {
+        if current_line == line && ch == '\n' {
+            return Some((line_start, idx));
+        }
+        if ch == '\n' {
+            if current_line == line {
+                return Some((line_start, idx));
+            }
+            current_line += 1;
+            line_start = idx + ch.len_utf8();
+        }
+    }
+    if current_line == line {
+        Some((line_start, source.len()))
+    } else {
+        None
+    }
+}
+
+fn utf16_col_to_byte(line: &str, character: u32) -> usize {
+    let mut units = 0u32;
+    for (idx, ch) in line.char_indices() {
+        let width = ch.len_utf16() as u32;
+        if units + width > character {
+            return idx;
+        }
+        units += width;
+        if units == character {
+            return idx + ch.len_utf8();
+        }
+    }
+    line.len()
 }
 
 /// Get the word at a given position.
 pub(crate) fn word_at_position(source: &str, position: Position) -> Option<String> {
-    let lines: Vec<&str> = source.lines().collect();
-    let line = lines.get(position.line as usize)?;
-    let col = position.character as usize;
-    if col > line.len() {
+    let offset = lsp_position_to_offset(source, position);
+    let (line_start, line_end) = line_byte_range(source, position.line as usize)?;
+    if offset < line_start || offset > line_end {
         return None;
     }
-
-    let chars: Vec<char> = line.chars().collect();
-    let mut start = col;
-    while start > 0 && (chars[start - 1].is_alphanumeric() || chars[start - 1] == '_') {
-        start -= 1;
+    let line = &source[line_start..line_end];
+    let mut rel = offset - line_start;
+    if !line.is_char_boundary(rel) {
+        rel = previous_char_boundary(line, rel);
     }
-    let mut end = col;
-    while end < chars.len() && (chars[end].is_alphanumeric() || chars[end] == '_') {
-        end += 1;
+
+    let mut start = rel;
+    while start > 0 {
+        let prev = previous_char_boundary(line, start);
+        let ch = line[prev..start].chars().next()?;
+        if !(ch.is_alphanumeric() || ch == '_') {
+            break;
+        }
+        start = prev;
+    }
+
+    let mut end = rel;
+    while end < line.len() {
+        let ch = line[end..].chars().next()?;
+        if !(ch.is_alphanumeric() || ch == '_') {
+            break;
+        }
+        end += ch.len_utf8();
     }
 
     if start == end {
         return None;
     }
-    Some(chars[start..end].iter().collect())
+    Some(line[start..end].to_string())
 }
 
 /// Check if cursor is right after a `.` (for method completion).
 pub(crate) fn char_before_position(source: &str, position: Position) -> Option<char> {
-    let lines: Vec<&str> = source.lines().collect();
-    let line = lines.get(position.line as usize)?;
-    let col = position.character as usize;
-    if col == 0 {
+    let offset = lsp_position_to_offset(source, position);
+    let (line_start, _) = line_byte_range(source, position.line as usize)?;
+    if offset <= line_start {
         return None;
     }
-    line.chars().nth(col - 1)
+    source[..offset].chars().next_back()
 }
 
 fn dot_receiver_identifier(source: &str, position: Position) -> Option<String> {
-    let lines: Vec<&str> = source.lines().collect();
-    let line = lines.get(position.line as usize)?;
-    let col = position.character as usize;
-    if col < 2 {
+    let offset = lsp_position_to_offset(source, position);
+    let (line_start, line_end) = line_byte_range(source, position.line as usize)?;
+    if offset <= line_start {
         return None;
     }
-
-    let chars: Vec<char> = line.chars().collect();
-    // `position` is after the `.`, so chars[col - 1] is `.`. Step back past it.
-    let mut end = col - 1;
-    if end == 0 {
+    let line = &source[line_start..line_end];
+    let mut rel = offset - line_start;
+    if !line.is_char_boundary(rel) {
+        rel = previous_char_boundary(line, rel);
+    }
+    let dot_start = previous_char_boundary(line, rel);
+    if &line[dot_start..rel] != "." || dot_start == 0 {
         return None;
     }
-    end -= 1;
+    let mut end = previous_char_boundary(line, dot_start);
 
-    while end > 0 && chars[end] == ' ' {
-        end -= 1;
+    while end > 0 {
+        let ch = line[end..].chars().next()?;
+        if ch != ' ' {
+            break;
+        }
+        end = previous_char_boundary(line, end);
     }
 
-    if !chars[end].is_alphanumeric() && chars[end] != '_' {
+    let ch = line[end..].chars().next()?;
+    if !ch.is_alphanumeric() && ch != '_' {
         return None;
     }
-    let id_end = end + 1;
+    let id_end = end + ch.len_utf8();
     let mut id_start = end;
-    while id_start > 0 && (chars[id_start - 1].is_alphanumeric() || chars[id_start - 1] == '_') {
-        id_start -= 1;
+    while id_start > 0 {
+        let prev = previous_char_boundary(line, id_start);
+        let ch = line[prev..id_start].chars().next()?;
+        if !(ch.is_alphanumeric() || ch == '_') {
+            break;
+        }
+        id_start = prev;
     }
-    Some(chars[id_start..id_end].iter().collect())
+    Some(line[id_start..id_end].to_string())
+}
+
+fn previous_char_boundary(text: &str, index: usize) -> usize {
+    let mut i = index.min(text.len());
+    while i > 0 && !text.is_char_boundary(i) {
+        i -= 1;
+    }
+    if i == 0 {
+        return 0;
+    }
+    text[..i]
+        .char_indices()
+        .next_back()
+        .map_or(0, |(idx, _)| idx)
 }
 
 pub(crate) fn infer_dot_receiver_name(source: &str, position: Position) -> Option<String> {
@@ -167,30 +219,37 @@ pub(crate) fn infer_dot_receiver_type(
     position: Position,
     symbols: &[SymbolInfo],
 ) -> Option<TypeExpr> {
-    let lines: Vec<&str> = source.lines().collect();
-    let line = lines.get(position.line as usize)?;
-    let col = position.character as usize;
-    if col < 2 {
+    let offset = lsp_position_to_offset(source, position);
+    let (line_start, line_end) = line_byte_range(source, position.line as usize)?;
+    if offset <= line_start {
         return None;
     }
-
-    let chars: Vec<char> = line.chars().collect();
-    let mut end = col - 1;
-    if end == 0 {
+    let line = &source[line_start..line_end];
+    let mut rel = offset - line_start;
+    if !line.is_char_boundary(rel) {
+        rel = previous_char_boundary(line, rel);
+    }
+    let dot_start = previous_char_boundary(line, rel);
+    if dot_start == 0 {
         return None;
     }
-    end -= 1;
-    while end > 0 && chars[end] == ' ' {
-        end -= 1;
+    let mut end = previous_char_boundary(line, dot_start);
+    while end > 0 {
+        let ch = line[end..].chars().next()?;
+        if ch != ' ' {
+            break;
+        }
+        end = previous_char_boundary(line, end);
     }
 
-    if chars[end] == '"' {
+    let ch = line[end..].chars().next()?;
+    if ch == '"' {
         return Some(TypeExpr::Named("string".to_string()));
     }
-    if chars[end] == ']' {
+    if ch == ']' {
         return Some(TypeExpr::Named("list".to_string()));
     }
-    if chars[end] == '}' {
+    if ch == '}' {
         return Some(TypeExpr::Named("dict".to_string()));
     }
 
@@ -295,4 +354,48 @@ pub(crate) fn find_word_in_region(region: &str, word: &str) -> Option<usize> {
         search_from = abs + 1;
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lsp_offsets_use_utf16_columns() {
+        let source = "let 😀name = \"é\"\nnext";
+        let name_offset = source.find("name").unwrap();
+        assert_eq!(
+            lsp_position_to_offset(source, Position::new(0, 6)),
+            name_offset
+        );
+        assert_eq!(offset_to_position(source, name_offset), Position::new(0, 6));
+    }
+
+    #[test]
+    fn word_at_position_handles_non_ascii_prefix() {
+        let source = "let café = 1";
+        assert_eq!(
+            word_at_position(source, Position::new(0, 6)).as_deref(),
+            Some("café")
+        );
+    }
+
+    #[test]
+    fn span_range_uses_utf16_length() {
+        let source = "let mood = \"😀\"";
+        let start = source.find("\"😀\"").unwrap();
+        let end = start + "\"😀\"".len();
+        let range = span_to_full_range(
+            &Span {
+                start,
+                end,
+                line: 1,
+                column: 12,
+                end_line: 1,
+            },
+            source,
+        );
+        assert_eq!(range.start, Position::new(0, 11));
+        assert_eq!(range.end, Position::new(0, 15));
+    }
 }

--- a/crates/harn-lsp/src/semantic_tokens.rs
+++ b/crates/harn-lsp/src/semantic_tokens.rs
@@ -2,6 +2,7 @@ use harn_lexer::{Span, Token, TokenKind};
 use tower_lsp::lsp_types::*;
 
 use crate::constants::{BUILTINS, TYPE_NAMES};
+use crate::helpers::{offset_to_position, utf16_len};
 use crate::symbols::{HarnSymbolKind, SymbolInfo};
 
 /// Indices into the semantic token legend's token types array.
@@ -205,9 +206,10 @@ pub(crate) fn build_semantic_tokens(
             },
         };
 
-        // LSP semantic tokens use 0-based line/column
-        let line = token.span.line.saturating_sub(1) as u32;
-        let start_char = token.span.column.saturating_sub(1) as u32;
+        // LSP semantic tokens use 0-based UTF-16 line/column positions.
+        let start_position = offset_to_position(source, token.span.start);
+        let line = start_position.line;
+        let start_char = start_position.character;
 
         // Calculate token length from byte offsets
         if token.span.end > token.span.start && token.span.end <= source.len() {
@@ -216,7 +218,7 @@ pub(crate) fn build_semantic_tokens(
 
             if lines_in_token.len() <= 1 {
                 // Single-line token
-                let length = segment.chars().count() as u32;
+                let length = utf16_len(segment);
                 let delta_line = line - prev_line;
                 let delta_start = if delta_line == 0 {
                     start_char - prev_start
@@ -237,7 +239,7 @@ pub(crate) fn build_semantic_tokens(
                 for (line_idx, line_text) in lines_in_token.iter().enumerate() {
                     let cur_line = line + line_idx as u32;
                     let cur_start = if line_idx == 0 { start_char } else { 0 };
-                    let length = line_text.chars().count() as u32;
+                    let length = utf16_len(line_text);
                     if length == 0 && line_idx > 0 {
                         continue; // skip empty intermediate lines
                     }
@@ -389,5 +391,24 @@ fn classify_identifier(name: &str, span: &Span, symbols: &[SymbolInfo], source: 
                 sem::VARIABLE
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harn_lexer::Lexer;
+
+    #[test]
+    fn semantic_token_lengths_are_utf16() {
+        let source = "let mood = \"😀\"\n";
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.tokenize_with_comments().unwrap();
+        let semantic = build_semantic_tokens(&tokens, &[], source);
+        let string_token = semantic
+            .iter()
+            .find(|token| token.token_type == sem::STRING)
+            .expect("string token");
+        assert_eq!(string_token.length, 4);
     }
 }

--- a/crates/harn-vm/src/stdlib/fs.rs
+++ b/crates/harn-vm/src/stdlib/fs.rs
@@ -1,13 +1,23 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::time::SystemTime;
 use std::{cell::RefCell, thread_local};
 
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
 thread_local! {
-    static FILE_TEXT_CACHE: RefCell<BTreeMap<PathBuf, Rc<str>>> = const { RefCell::new(BTreeMap::new()) };
+    static FILE_TEXT_CACHE: RefCell<BTreeMap<PathBuf, FileTextCacheEntry>> = const { RefCell::new(BTreeMap::new()) };
+}
+
+const FILE_TEXT_CACHE_MAX_ENTRIES: usize = 256;
+
+#[derive(Clone)]
+struct FileTextCacheEntry {
+    content: Rc<str>,
+    len: u64,
+    modified: Option<SystemTime>,
 }
 
 pub(crate) fn reset_fs_state() {
@@ -26,19 +36,58 @@ fn result_err(value: VmValue) -> VmValue {
     VmValue::enum_variant("Result", "Err", vec![value])
 }
 
+fn metadata_signature(path: &PathBuf) -> Option<(u64, Option<SystemTime>)> {
+    let metadata = std::fs::metadata(path).ok()?;
+    Some((metadata.len(), metadata.modified().ok()))
+}
+
+fn read_cached_text(path: &PathBuf) -> Option<Rc<str>> {
+    FILE_TEXT_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        let entry = cache.get(path).cloned()?;
+        match metadata_signature(path) {
+            Some((len, modified)) if len == entry.len && modified == entry.modified => {
+                Some(entry.content)
+            }
+            _ => {
+                cache.remove(path);
+                None
+            }
+        }
+    })
+}
+
+fn write_cached_text(path: PathBuf, content: Rc<str>) {
+    let Some((len, modified)) = metadata_signature(&path) else {
+        return;
+    };
+    FILE_TEXT_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if cache.len() >= FILE_TEXT_CACHE_MAX_ENTRIES && !cache.contains_key(&path) {
+            cache.pop_first();
+        }
+        cache.insert(
+            path,
+            FileTextCacheEntry {
+                content,
+                len,
+                modified,
+            },
+        );
+    });
+}
+
 pub(crate) fn register_fs_builtins(vm: &mut Vm) {
     vm.register_builtin("read_file", |args, _out| {
         let path = args.first().map(|a| a.display()).unwrap_or_default();
         let resolved = resolve_fs_path(&path);
-        if let Some(cached) = FILE_TEXT_CACHE.with(|cache| cache.borrow().get(&resolved).cloned()) {
+        if let Some(cached) = read_cached_text(&resolved) {
             return Ok(VmValue::String(cached));
         }
         match std::fs::read_to_string(&resolved) {
             Ok(content) => {
                 let shared: Rc<str> = Rc::from(content);
-                FILE_TEXT_CACHE.with(|cache| {
-                    cache.borrow_mut().insert(resolved.clone(), shared.clone());
-                });
+                write_cached_text(resolved.clone(), shared.clone());
                 Ok(VmValue::String(shared))
             }
             Err(e) => Err(VmError::Thrown(VmValue::String(Rc::from(format!(
@@ -51,15 +100,13 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
     vm.register_builtin("read_file_result", |args, _out| {
         let path = args.first().map(|a| a.display()).unwrap_or_default();
         let resolved = resolve_fs_path(&path);
-        if let Some(cached) = FILE_TEXT_CACHE.with(|cache| cache.borrow().get(&resolved).cloned()) {
+        if let Some(cached) = read_cached_text(&resolved) {
             return Ok(result_ok(VmValue::String(cached)));
         }
         match std::fs::read_to_string(&resolved) {
             Ok(content) => {
                 let shared: Rc<str> = Rc::from(content);
-                FILE_TEXT_CACHE.with(|cache| {
-                    cache.borrow_mut().insert(resolved.clone(), shared.clone());
-                });
+                write_cached_text(resolved.clone(), shared.clone());
                 Ok(result_ok(VmValue::String(shared)))
             }
             Err(e) => Ok(result_err(VmValue::String(Rc::from(format!(
@@ -92,9 +139,7 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
                     resolved.display()
                 ))))
             })?;
-            FILE_TEXT_CACHE.with(|cache| {
-                cache.borrow_mut().insert(resolved, Rc::from(content));
-            });
+            write_cached_text(resolved, Rc::from(content));
         }
         Ok(VmValue::Nil)
     });
@@ -279,4 +324,49 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
         }
         Ok(VmValue::Dict(Rc::new(info)))
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vm() -> Vm {
+        let mut vm = Vm::new();
+        register_fs_builtins(&mut vm);
+        vm
+    }
+
+    fn call(vm: &mut Vm, name: &str, args: Vec<VmValue>) -> Result<VmValue, VmError> {
+        let f = vm.builtins.get(name).unwrap().clone();
+        let mut out = String::new();
+        f(&args, &mut out)
+    }
+
+    fn s(v: &str) -> VmValue {
+        VmValue::String(Rc::from(v))
+    }
+
+    #[test]
+    fn read_file_cache_invalidates_after_external_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.txt");
+        std::fs::write(&path, "one").unwrap();
+        let path_arg = path.to_string_lossy().into_owned();
+        let mut vm = vm();
+
+        assert_eq!(
+            call(&mut vm, "read_file", vec![s(&path_arg)])
+                .unwrap()
+                .display(),
+            "one"
+        );
+        std::fs::write(&path, "two updated").unwrap();
+
+        assert_eq!(
+            call(&mut vm, "read_file", vec![s(&path_arg)])
+                .unwrap()
+                .display(),
+            "two updated"
+        );
+    }
 }

--- a/crates/harn-vm/src/stdlib/math.rs
+++ b/crates/harn-vm/src/stdlib/math.rs
@@ -4,7 +4,8 @@ use crate::vm::Vm;
 pub(crate) fn register_math_builtins(vm: &mut Vm) {
     vm.register_builtin("abs", |args, _out| {
         match args.first().unwrap_or(&VmValue::Nil) {
-            VmValue::Int(n) => Ok(VmValue::Int(n.wrapping_abs())),
+            VmValue::Int(i64::MIN) => Ok(VmValue::Float(9_223_372_036_854_775_808.0)),
+            VmValue::Int(n) => Ok(VmValue::Int(n.abs())),
             VmValue::Float(n) => Ok(VmValue::Float(n.abs())),
             _ => Ok(VmValue::Nil),
         }
@@ -40,7 +41,7 @@ pub(crate) fn register_math_builtins(vm: &mut Vm) {
 
     vm.register_builtin("floor", |args, _out| {
         match args.first().unwrap_or(&VmValue::Nil) {
-            VmValue::Float(n) => Ok(VmValue::Int(n.floor() as i64)),
+            VmValue::Float(n) => finite_float_to_i64(n.floor()).map(VmValue::Int),
             VmValue::Int(n) => Ok(VmValue::Int(*n)),
             _ => Ok(VmValue::Nil),
         }
@@ -48,7 +49,7 @@ pub(crate) fn register_math_builtins(vm: &mut Vm) {
 
     vm.register_builtin("ceil", |args, _out| {
         match args.first().unwrap_or(&VmValue::Nil) {
-            VmValue::Float(n) => Ok(VmValue::Int(n.ceil() as i64)),
+            VmValue::Float(n) => finite_float_to_i64(n.ceil()).map(VmValue::Int),
             VmValue::Int(n) => Ok(VmValue::Int(*n)),
             _ => Ok(VmValue::Nil),
         }
@@ -56,7 +57,7 @@ pub(crate) fn register_math_builtins(vm: &mut Vm) {
 
     vm.register_builtin("round", |args, _out| {
         match args.first().unwrap_or(&VmValue::Nil) {
-            VmValue::Float(n) => Ok(VmValue::Int(n.round() as i64)),
+            VmValue::Float(n) => finite_float_to_i64(n.round()).map(VmValue::Int),
             VmValue::Int(n) => Ok(VmValue::Int(*n)),
             _ => Ok(VmValue::Nil),
         }
@@ -75,7 +76,10 @@ pub(crate) fn register_math_builtins(vm: &mut Vm) {
             match (&args[0], &args[1]) {
                 (VmValue::Int(base), VmValue::Int(exp)) => {
                     if *exp >= 0 && *exp <= u32::MAX as i64 {
-                        Ok(VmValue::Int(base.wrapping_pow(*exp as u32)))
+                        match base.checked_pow(*exp as u32) {
+                            Some(value) => Ok(VmValue::Int(value)),
+                            None => Ok(VmValue::Float((*base as f64).powf(*exp as f64))),
+                        }
                     } else {
                         Ok(VmValue::Float((*base as f64).powf(*exp as f64)))
                     }
@@ -225,6 +229,20 @@ pub(crate) fn register_math_builtins(vm: &mut Vm) {
     });
 }
 
+fn finite_float_to_i64(n: f64) -> Result<i64, VmError> {
+    if !n.is_finite() {
+        return Err(VmError::Runtime(
+            "cannot convert non-finite float to int".to_string(),
+        ));
+    }
+    if n < i64::MIN as f64 || n >= 9_223_372_036_854_775_808.0 {
+        return Err(VmError::Runtime(
+            "float is outside the representable int range".to_string(),
+        ));
+    }
+    Ok(n as i64)
+}
+
 /// Helper to reduce boilerplate for unary float functions (sin, cos, etc.)
 fn register_unary_float(vm: &mut Vm, name: &'static str, f: fn(f64) -> f64) {
     vm.register_builtin(name, move |args, _out| {
@@ -235,4 +253,43 @@ fn register_unary_float(vm: &mut Vm, name: &'static str, f: fn(f64) -> f64) {
         };
         Ok(VmValue::Float(f(n)))
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vm() -> Vm {
+        let mut vm = Vm::new();
+        register_math_builtins(&mut vm);
+        vm
+    }
+
+    fn call(vm: &mut Vm, name: &str, args: Vec<VmValue>) -> Result<VmValue, VmError> {
+        let f = vm.builtins.get(name).unwrap().clone();
+        let mut out = String::new();
+        f(&args, &mut out)
+    }
+
+    #[test]
+    fn abs_does_not_wrap_i64_min() {
+        let mut vm = vm();
+        let value = call(&mut vm, "abs", vec![VmValue::Int(i64::MIN)]).unwrap();
+        assert_eq!(value.display(), "9223372036854776000");
+    }
+
+    #[test]
+    fn integer_pow_does_not_wrap_on_overflow() {
+        let mut vm = vm();
+        let value = call(&mut vm, "pow", vec![VmValue::Int(2), VmValue::Int(63)]).unwrap();
+        assert_eq!(value.display(), "9223372036854776000");
+    }
+
+    #[test]
+    fn rounding_rejects_non_finite_float_to_int() {
+        let mut vm = vm();
+        let error = call(&mut vm, "floor", vec![VmValue::Float(f64::INFINITY)])
+            .expect_err("infinite float cannot become int");
+        assert!(error.to_string().contains("non-finite"));
+    }
 }

--- a/crates/harn-vm/src/stdlib/path.rs
+++ b/crates/harn-vm/src/stdlib/path.rs
@@ -18,15 +18,15 @@ fn to_posix(s: &str) -> String {
     s.replace('\\', "/")
 }
 
-/// Returns true if the path is absolute (leading `/` on posix or `X:` drive
-/// letter on windows).
+/// Returns true if the path is absolute (leading `/` on posix or `X:/` drive
+/// root on windows). `X:foo` is drive-relative, not absolute.
 fn is_absolute_str(p: &str) -> bool {
     let p = to_posix(p);
     if p.starts_with('/') {
         return true;
     }
     let bytes = p.as_bytes();
-    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+    bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'/'
 }
 
 /// Split a path into segments, preserving whether it was absolute.
@@ -179,9 +179,9 @@ fn with_stem(p: &str, new_stem: &str) -> String {
 /// Compute the relative path from `base` to `p`. Returns `None` if `p` is
 /// not reachable as a descendant of `base` via relative traversal.
 fn relative_to(p: &str, base: &str) -> Option<String> {
-    let (p_abs, _, p_segs) = split_segments(&normalize(p));
-    let (b_abs, _, b_segs) = split_segments(&normalize(base));
-    if p_abs != b_abs {
+    let (p_abs, p_drive, p_segs) = split_segments(&normalize(p));
+    let (b_abs, b_drive, b_segs) = split_segments(&normalize(base));
+    if p_abs != b_abs || p_drive != b_drive {
         return None;
     }
     let common = p_segs
@@ -418,6 +418,7 @@ mod tests {
     fn is_absolute_detection() {
         assert!(is_absolute_str("/a/b"));
         assert!(is_absolute_str("C:/a/b"));
+        assert!(!is_absolute_str("C:a/b"));
         assert!(!is_absolute_str("a/b"));
         assert!(!is_absolute_str("./a"));
         assert!(!is_absolute_str(""));
@@ -429,5 +430,6 @@ mod tests {
         assert_eq!(relative_to("/a/c", "/a/b").as_deref(), Some("../c"));
         assert_eq!(relative_to("a/b/c", "a/b").as_deref(), Some("c"));
         assert_eq!(relative_to("/a", "b"), None);
+        assert_eq!(relative_to("C:/a/b", "D:/a/b"), None);
     }
 }

--- a/crates/harn-vm/src/stdlib/template/mod.rs
+++ b/crates/harn-vm/src/stdlib/template/mod.rs
@@ -309,8 +309,10 @@ pub(crate) fn render_template_with_provenance(
     })?;
     let mut out = String::with_capacity(template.len());
     let mut scope = Scope::new(bindings);
+    let include_root = base.map(|path| path.canonicalize().unwrap_or_else(|_| path.to_path_buf()));
     let mut rc = RenderCtx {
         base: base.map(Path::to_path_buf),
+        include_root,
         include_stack: Vec::new(),
         current_path: source_path.map(Path::to_path_buf),
         current_include_parent: None,

--- a/crates/harn-vm/src/stdlib/template/render.rs
+++ b/crates/harn-vm/src/stdlib/template/render.rs
@@ -62,6 +62,7 @@ impl<'a> Scope<'a> {
 
 pub(super) struct RenderCtx {
     pub(super) base: Option<PathBuf>,
+    pub(super) include_root: Option<PathBuf>,
     pub(super) include_stack: Vec<PathBuf>,
     pub(super) current_path: Option<PathBuf>,
     /// When inside an `{% include %}`, this holds the include-call's
@@ -267,6 +268,19 @@ fn render_node(
                 crate::stdlib::process::resolve_source_asset_path(&path_str)
             };
             let canonical = resolved.canonicalize().unwrap_or(resolved.clone());
+            if let Some(root) = &rc.include_root {
+                if !canonical.starts_with(root) {
+                    return Err(TemplateError::new(
+                        *line,
+                        *col,
+                        format!(
+                            "include path {} escapes template root {}",
+                            canonical.display(),
+                            root.display()
+                        ),
+                    ));
+                }
+            }
             if rc.include_stack.iter().any(|p| p == &canonical) {
                 let chain = rc
                     .include_stack
@@ -283,7 +297,7 @@ fn render_node(
                     ),
                 ));
             }
-            if rc.include_stack.len() > 32 {
+            if rc.include_stack.len() >= 32 {
                 return Err(TemplateError::new(
                     *line,
                     *col,

--- a/crates/harn-vm/src/stdlib/template/tests.rs
+++ b/crates/harn-vm/src/stdlib/template/tests.rs
@@ -368,6 +368,27 @@ fn include_cycle_detected() {
     assert!(r.unwrap_err().kind.contains("circular include"));
 }
 
+#[test]
+fn include_cannot_escape_template_root() {
+    use std::fs;
+    let dir = tempdir();
+    let sibling_name = format!("{}-outside", dir.file_name().unwrap().to_string_lossy());
+    let outside_dir = dir.parent().unwrap().join(&sibling_name);
+    fs::create_dir_all(&outside_dir).unwrap();
+    fs::write(outside_dir.join("secret.prompt"), "secret").unwrap();
+    let parent = dir.join("main.prompt");
+    fs::write(
+        &parent,
+        format!(r#"{{{{ include "../{sibling_name}/secret.prompt" }}}}"#),
+    )
+    .unwrap();
+    let src = fs::read_to_string(&parent).unwrap();
+    let r = render_template_result(&src, None, Some(&dir), Some(&parent));
+    let _ = fs::remove_dir_all(outside_dir);
+    assert!(r.is_err());
+    assert!(r.unwrap_err().kind.contains("escapes template root"));
+}
+
 fn tempdir() -> PathBuf {
     let base = std::env::temp_dir().join(format!("harn-tpl-{}", nanoid()));
     std::fs::create_dir_all(&base).unwrap();

--- a/crates/harn-vm/src/workspace_path.rs
+++ b/crates/harn-vm/src/workspace_path.rs
@@ -183,7 +183,7 @@ fn is_absolute_str(path: &str) -> bool {
         return true;
     }
     let bytes = path.as_bytes();
-    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+    bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'/'
 }
 
 fn split_segments(path: &str) -> (bool, Option<String>, Vec<String>) {
@@ -316,6 +316,14 @@ mod tests {
             info.reason.as_deref(),
             Some("workspace-relative path escapes the workspace root")
         );
+    }
+
+    #[test]
+    fn windows_drive_relative_path_is_not_host_absolute() {
+        let dir = tempfile::tempdir().unwrap();
+        let info = classify_workspace_path("C:src/main.harn", Some(dir.path()));
+        assert_eq!(info.kind, WorkspacePathKind::WorkspaceRelative);
+        assert_eq!(info.workspace_path.as_deref(), Some("C:src/main.harn"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This is a broad correctness and polishing pass across the runtime, CLI test runner, path handling, template rendering, and LSP surfaces.

- Hardened stdlib file reads with metadata-aware cache invalidation and a bounded cache, so external writes no longer return stale text.
- Tightened math builtins around integer overflow and invalid float-to-int conversions, including `abs(i64::MIN)`, overflowing integer `pow`, and non-finite/range-invalid rounding.
- Restricted template includes to the top-level template root and fixed the include-depth boundary.
- Removed process-wide cwd mutation from the CLI test runner, made parallel execution use each test file's parent cwd consistently, and discovered `@test`-annotated files.
- Corrected LSP helpers and semantic tokens to use LSP UTF-16 columns for offsets, ranges, word detection, dot receivers, and token lengths.
- Fixed Windows drive-relative path handling and cross-drive relative path behavior.

## Root Cause / Impact

Several existing paths mixed host-global state, cache lifetime, platform path conventions, and editor protocol units in ways that were locally plausible but incorrect under concurrency, Unicode input, external file mutation, or Windows-style paths. These fixes reduce stale runtime state, test runner races, LSP mis-highlighting/completion drift, and template include escape risk.

## Validation

- `cargo fmt --all`
- `cargo test -p harn-cli test_runner::tests`
- `cargo test -p harn-vm stdlib::fs::tests`
- `cargo test -p harn-vm stdlib::math::tests`
- `cargo test -p harn-vm stdlib::template::tests`
- `cargo test -p harn-vm workspace_path::tests`
- `cargo test -p harn-lsp helpers::tests`
- `cargo test -p harn-lsp semantic_tokens::tests`
- `cargo check --workspace`
- `make test`
- `cargo run --quiet --bin harn -- test conformance`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
- Pre-commit hook: passed
- Pre-push hook: passed (`1978 passed`, nextest reported 1 existing leaky test classification)