### PR TITLE
Prepare v0.7.32 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
-## v0.7.31
+## v0.7.32
 
 ### Added
 

--- a/conformance/tests/stdlib/prompt_library.harn
+++ b/conformance/tests/stdlib/prompt_library.harn
@@ -1,8 +1,12 @@
 import "std/prompt_library"
 
 pipeline test(task) {
+  let root = path_join(temp_dir(), "harn-prompt-library-" + uuid())
+  mkdir(root)
+  let catalog_path = path_join(root, "prompt_library_catalog.toml")
+  let front_path = path_join(root, "prompt_library_front.harn.prompt")
   write_file(
-    "prompt_library_catalog.toml",
+    catalog_path,
     "[[prompt_fragments]]\n"
     + "id = \"rust-repo-conventions-v1\"\n"
     + "title = \"Rust repo conventions\"\n"
@@ -12,7 +16,7 @@ pipeline test(task) {
     + "body = \"Use nextest for {{crate}} and keep sccache warm.\"\n",
   )
   write_file(
-    "prompt_library_front.harn.prompt",
+    front_path,
     "---\n"
     + "id = \"ops-prefix\"\n"
     + "title = \"Ops prefix\"\n"
@@ -20,7 +24,7 @@ pipeline test(task) {
     + "---\n"
     + "Operate in {{env}} with low-noise status updates.",
   )
-  let library = prompt_library_load(["prompt_library_catalog.toml", "prompt_library_front.harn.prompt"])
+  let library = prompt_library_load([catalog_path, front_path])
   assert_eq(
     prompt_library_inject(library, "rust-repo-conventions-v1", {crate: "harn-vm"}),
     "Use nextest for harn-vm and keep sccache warm.",

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1341,7 +1341,7 @@ let memo = shared_map({scope: "workflow_run", key: "memo"})
 let lock = sync_mutex_acquire("memo:customer-42", 250ms)
 guard lock != nil else { throw "state lock timeout" }
 try {
-  shared_map_set(memo, "customer-42", compute_customer_summary())
+  shared_map_set(memo, "customer-42", "summary")
 } finally {
   sync_release(lock)
 }

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1339,7 +1339,7 @@ let memo = shared_map({scope: "workflow_run", key: "memo"})
 let lock = sync_mutex_acquire("memo:customer-42", 250ms)
 guard lock != nil else { throw "state lock timeout" }
 try {
-  shared_map_set(memo, "customer-42", compute_customer_summary())
+  shared_map_set(memo, "customer-42", "summary")
 } finally {
   sync_release(lock)
 }


### PR DESCRIPTION
## Summary
- promote CHANGELOG top entry to v0.7.32 so the release bot derives a patch bump
- fix the shared-state spec snippet so language-spec verification stays executable
- keep prompt-library conformance fixtures under temp_dir() so release/conformance runs do not leak root files

## Validation
- ./scripts/release_gate.sh audit
- cargo run --quiet --bin harn -- test conformance --filter prompt_library
- pre-push hook: 1990 passed (1 leaky), affected Harn fmt/lint, markdownlint
