### PR TITLE
Add persona template pack v0 for captains

### DIFF
--- a/docs/src/personas.md
+++ b/docs/src/personas.md
@@ -101,6 +101,38 @@ consume. It includes name, version, tools, capabilities, autonomy tier, model
 policy, budget, triggers, handoffs, context packs, evals, receipt policy, and
 manifest source.
 
+## Template pack
+
+The first checked-in template pack lives under `examples/personas/`. It ships
+three starter personas:
+
+- `merge_captain`
+- `review_captain`
+- `oncall_captain`
+
+The pack is intentionally conservative:
+
+- dry-run and approval-first defaults for side-effecting roles
+- cheap default model routing with explicit escalation models
+- placeholder secrets only
+- checked-in context packs, fixtures, and smoke eval manifests
+
+Treat these as code and policy that your team forks and edits. They are not
+opaque hosted behavior.
+
+## Current v1 gaps
+
+Persona manifest v1 is a contract surface, not a scheduler. Harn currently
+parses, validates, lists, and inspects personas; it does not yet execute them
+from `[[personas]]` entries.
+
+That means template packs should stay honest about missing platform scope:
+
+- schedules validate now but are not runtime wakeups yet
+- handoffs validate now but are not typed persona-runtime dispatch yet
+- backend-specific systems such as Honeycomb and Splunk should be expressed
+  through current tool wiring such as MCP rather than invented manifest fields
+
 ## Skill Vs Persona Vs Workflow
 
 | Concept | What It Is | Main Unit | Executes? |

--- a/examples/personas/README.md
+++ b/examples/personas/README.md
@@ -1,15 +1,90 @@
-# Persona manifest examples
+# Persona template pack v0
 
-These examples are non-executing `[[personas]]` manifest entries for durable
-agent roles:
+This directory is the first concrete template pack for persona manifest v1.
+It is intentionally simple:
 
-- `merge_captain`
-- `review_captain`
-- `oncall_captain`
+- `harn.toml` contains the durable role contracts.
+- `workflows/` contains tiny deterministic starter workflows.
+- `fixtures/` contains sample payloads teams can fork and extend.
+- `context-packs/` contains editable policy/runbook notes.
+- `evals/` and `runs/` contain smoke fixtures that work without live
+  credentials.
 
-Inspect them with:
+These templates are safe by default:
+
+- side-effecting personas use `autonomy_tier = "act_with_approval"`
+- every persona carries `runtime.dry_run` in its capability policy
+- model routing defaults to a cheap model and escalates only when needed
+- secrets live in [secrets.example.env](./secrets.example.env) as placeholders
+
+## What works today
+
+Persona manifest v1 is inspection and validation only. The runtime does not yet
+schedule personas from `[[personas]]` entries or execute typed persona handoffs
+directly. The checked-in workflows, fixtures, and evals are therefore starter
+artifacts for teams to fork, not a hidden SaaS control plane.
+
+The current templates make gaps explicit instead of inventing more platform
+scope:
+
+- `oncall_captain` uses `tools = ["mcp"]` for observability because Honeycomb
+  and Splunk are expected to arrive through MCP wiring today.
+- `handoffs` are declared in the manifest and modeled in workflow output, but
+  persona-runtime handoff dispatch is not wired in v1.
+- schedules are validated now and can be consumed by future runtime work, but
+  they do not wake these personas up by themselves yet.
+
+## Layout
+
+- [harn.toml](./harn.toml)
+- [workflows](./workflows)
+- [fixtures](./fixtures)
+- [context-packs](./context-packs)
+- [evals](./evals)
+- [runs](./runs)
+- [secrets.example.env](./secrets.example.env)
+
+## Validate and inspect
 
 ```bash
 harn persona --manifest examples/personas/harn.toml list
 harn persona --manifest examples/personas/harn.toml inspect merge_captain --json
+harn persona --manifest examples/personas/harn.toml inspect review_captain --json
+harn persona --manifest examples/personas/harn.toml inspect oncall_captain --json
 ```
+
+## Smoke checks
+
+```bash
+harn run examples/personas/workflows/merge_captain.harn
+harn run examples/personas/workflows/review_captain.harn
+harn run examples/personas/workflows/oncall_captain.harn
+harn eval examples/personas/evals/template_pack_smoke.json
+```
+
+## Customize for a team
+
+1. Copy `examples/personas/` into your repo or package.
+2. Edit `harn.toml` to rename owners, triggers, schedules, budgets, and
+   connectors.
+3. Replace the placeholder context packs with your actual repo policy, release
+   rules, review rubric, and on-call runbook.
+4. Swap the starter workflows for repo-specific workflows once the role is
+   clear.
+5. Replace the placeholder secret values in `secrets.example.env` with your own
+   local or deployment secret wiring.
+6. Re-run persona inspection and the smoke eval before widening rollout.
+
+## External dependencies
+
+The manifests declare tools only from the current v1 surface. Teams still need
+to wire the backing systems:
+
+| Persona | Expected systems |
+|---|---|
+| `merge_captain` | GitHub, CI, Linear, Notion, Slack |
+| `review_captain` | GitHub, Notion, Slack |
+| `oncall_captain` | PagerDuty, Slack, Notion, GitHub, observability via MCP |
+
+Use placeholder or sandbox credentials while iterating. The smoke fixtures in
+this directory do not require any live credentials.

--- a/examples/personas/context-packs/merge_policy.md
+++ b/examples/personas/context-packs/merge_policy.md
@@ -1,0 +1,5 @@
+# Merge policy
+
+- Dry-run first.
+- Ask for approval before applying labels, posting comments, or landing code.
+- Hand off unresolved review risk to `review_captain` or a human maintainer.

--- a/examples/personas/context-packs/oncall_runbook.md
+++ b/examples/personas/context-packs/oncall_runbook.md
@@ -1,0 +1,6 @@
+# On-call runbook
+
+- Start with the human hypothesis and turn it into a verification plan.
+- Query observability systems through MCP or equivalent read-only tooling first.
+- Record one of: confirmed, disproven, unresolved.
+- Leave remediation approval to the human owner unless the team says otherwise.

--- a/examples/personas/context-packs/release_policy.md
+++ b/examples/personas/context-packs/release_policy.md
@@ -1,0 +1,5 @@
+# Release policy
+
+- Block merges when release notes or rollout approvals are missing.
+- Treat production rollbacks as human-owned decisions.
+- Record the reason for any release-blocking label or escalation.

--- a/examples/personas/context-packs/repo_policy.md
+++ b/examples/personas/context-packs/repo_policy.md
@@ -1,0 +1,6 @@
+# Repo policy
+
+- Require a reproducible summary before proposing a merge.
+- Keep side effects behind explicit approval.
+- Attach receipts to human-visible follow-up comments.
+- Prefer checked-in fixtures over live-system mutation while iterating.

--- a/examples/personas/context-packs/review_policy.md
+++ b/examples/personas/context-packs/review_policy.md
@@ -1,0 +1,5 @@
+# Review policy
+
+- Focus on regressions, missing tests, risky diffs, and policy violations.
+- Emit a structured receipt instead of a vague summary.
+- Escalate ambiguous release risk back to `merge_captain`.

--- a/examples/personas/context-packs/service_ownership.md
+++ b/examples/personas/context-packs/service_ownership.md
@@ -1,0 +1,5 @@
+# Service ownership
+
+- `orchestrator-api`: primary owner `primary-oncall`
+- `portal-ui`: secondary owner `frontend-oncall`
+- `release-automation`: escalation owner `platform`

--- a/examples/personas/evals/merge_captain_smoke.json
+++ b/examples/personas/evals/merge_captain_smoke.json
@@ -1,0 +1,11 @@
+{
+  "_type": "eval_suite_manifest",
+  "id": "merge_captain_smoke",
+  "name": "merge_captain smoke",
+  "cases": [
+    {
+      "label": "merge_captain_dry_run_plan",
+      "run_path": "../runs/merge_captain_smoke.run.json"
+    }
+  ]
+}

--- a/examples/personas/evals/oncall_captain_smoke.json
+++ b/examples/personas/evals/oncall_captain_smoke.json
@@ -1,0 +1,11 @@
+{
+  "_type": "eval_suite_manifest",
+  "id": "oncall_captain_smoke",
+  "name": "oncall_captain smoke",
+  "cases": [
+    {
+      "label": "oncall_captain_verification_plan",
+      "run_path": "../runs/oncall_captain_smoke.run.json"
+    }
+  ]
+}

--- a/examples/personas/evals/review_captain_smoke.json
+++ b/examples/personas/evals/review_captain_smoke.json
@@ -1,0 +1,11 @@
+{
+  "_type": "eval_suite_manifest",
+  "id": "review_captain_smoke",
+  "name": "review_captain smoke",
+  "cases": [
+    {
+      "label": "review_captain_structured_receipt",
+      "run_path": "../runs/review_captain_smoke.run.json"
+    }
+  ]
+}

--- a/examples/personas/evals/template_pack_smoke.json
+++ b/examples/personas/evals/template_pack_smoke.json
@@ -1,0 +1,19 @@
+{
+  "_type": "eval_suite_manifest",
+  "id": "persona_template_pack_smoke",
+  "name": "persona template pack smoke",
+  "cases": [
+    {
+      "label": "merge_captain_dry_run_plan",
+      "run_path": "../runs/merge_captain_smoke.run.json"
+    },
+    {
+      "label": "review_captain_structured_receipt",
+      "run_path": "../runs/review_captain_smoke.run.json"
+    },
+    {
+      "label": "oncall_captain_verification_plan",
+      "run_path": "../runs/oncall_captain_smoke.run.json"
+    }
+  ]
+}

--- a/examples/personas/fixtures/merge_captain/event.json
+++ b/examples/personas/fixtures/merge_captain/event.json
@@ -1,0 +1,16 @@
+{
+  "event": "github.pr_opened",
+  "repo": "burin-labs/harn",
+  "number": 463,
+  "title": "Persona template pack v0",
+  "failing_checks": [
+    "ci / rust"
+  ],
+  "stale_threads": [
+    "acceptance coverage"
+  ],
+  "release_blockers": [
+    "needs-human-release-note"
+  ],
+  "merge_conflicts": false
+}

--- a/examples/personas/fixtures/oncall_captain/incident.json
+++ b/examples/personas/fixtures/oncall_captain/incident.json
@@ -1,0 +1,15 @@
+{
+  "event": "pagerduty.incident_triggered",
+  "service": "orchestrator-api",
+  "hypothesis": "a deploy introduced a replay-loop regression",
+  "symptoms": [
+    "pagerduty page",
+    "error-rate spike",
+    "slack escalation"
+  ],
+  "observability_backends": [
+    "mcp:honeycomb",
+    "mcp:splunk"
+  ],
+  "human_owner": "primary-oncall"
+}

--- a/examples/personas/fixtures/review_captain/handoff.json
+++ b/examples/personas/fixtures/review_captain/handoff.json
@@ -1,0 +1,15 @@
+{
+  "event": "github.review_requested",
+  "repo": "burin-labs/harn",
+  "pr_number": 463,
+  "changed_files": [
+    "examples/personas/harn.toml",
+    "examples/personas/workflows/merge_captain.harn"
+  ],
+  "missing_tests": [
+    "template smoke for oncall_captain"
+  ],
+  "risky_paths": [
+    "examples/personas/harn.toml"
+  ]
+}

--- a/examples/personas/harn.toml
+++ b/examples/personas/harn.toml
@@ -1,63 +1,88 @@
 [package]
-name = "harn-persona-examples"
+name = "harn-persona-template-pack"
 version = "0.1.0"
 
 [[personas]]
 name = "merge_captain"
 version = "0.1.0"
-description = "Owns pull request readiness, CI triage, merge approvals, and receipt-backed merge decisions."
+description = "Dry-run-first captain for pull request readiness, CI triage, release blockers, and receipt-backed merge plans."
 entry_workflow = "workflows/merge_captain.harn#run"
-tools = ["github", "ci", "linear", "notion", "slack"]
-capabilities = ["git.get_diff", "project.test_commands", "process.exec", "runtime.record_run"]
+tools = ["github", "ci", "linear", "notion", "slack", "mcp"]
+capabilities = [
+  "git.get_diff",
+  "project.scan",
+  "project.test_commands",
+  "runtime.approved_plan",
+  "runtime.dry_run",
+  "runtime.record_run",
+]
 autonomy_tier = "act_with_approval"
 receipt_policy = "required"
-triggers = ["github.pr_opened", "github.check_failed"]
+triggers = [
+  "github.pr_opened",
+  "github.check_failed",
+  "github.review_thread_stale",
+  "github.merge_conflict_detected",
+]
 schedules = ["*/30 * * * *"]
 handoffs = ["review_captain"]
-context_packs = ["repo_policy", "release_rules", "flaky_tests"]
-evals = ["merge_safety", "regression_triage", "reviewer_quality"]
+context_packs = ["repo_policy", "release_policy", "merge_policy"]
+evals = ["merge_captain_smoke"]
 owner = "platform"
-budget = { daily_usd = 20.0, frontier_escalations = 3, max_tokens = 200000 }
-model_policy = { default_model = "gpt-5.4", escalation_model = "gpt-5.4", fallback_models = ["gpt-5.4-mini"], reasoning_effort = "medium" }
-rollout_policy = { mode = "shadow_then_approval", percentage = 25, cohorts = ["core-repos"] }
-package_source = { package = "harn-persona-examples", path = "examples/personas" }
+budget = { daily_usd = 10.0, frontier_escalations = 1, max_tokens = 60000, max_runtime_seconds = 600 }
+model_policy = { default_model = "gpt-5.4-mini", escalation_model = "gpt-5.4", fallback_models = ["gpt-5.2"], reasoning_effort = "medium" }
+rollout_policy = { mode = "approval_only", percentage = 100, cohorts = ["template-pack"] }
+package_source = { package = "harn-persona-template-pack", path = "examples/personas" }
 
 [[personas]]
 name = "review_captain"
 version = "0.1.0"
-description = "Keeps review quality high by routing reviewers, summarizing risk, and checking follow-up comments."
+description = "Review specialist for regression spotting, missing tests, structured receipts, and human-risk handoff."
 entry_workflow = "workflows/review_captain.harn#run"
-tools = ["github", "slack", "notion"]
-capabilities = ["git.get_diff", "project.code_patterns", "runtime.record_run"]
+tools = ["github", "notion", "slack", "mcp"]
+capabilities = [
+  "git.get_diff",
+  "project.code_patterns",
+  "project.scan",
+  "runtime.dry_run",
+  "runtime.record_run",
+]
 autonomy_tier = "suggest"
 receipt_policy = "required"
-triggers = ["github.review_requested", "github.review_comment_created"]
+triggers = ["github.review_requested", "github.pull_request_synchronized"]
 schedules = ["0 */2 * * *"]
 handoffs = ["merge_captain"]
-context_packs = ["repo_policy", "review_rubric"]
-evals = ["reviewer_quality"]
+context_packs = ["repo_policy", "review_policy"]
+evals = ["review_captain_smoke"]
 owner = "engineering"
-budget = { daily_usd = 8.0, frontier_escalations = 1, max_tokens = 100000 }
-model_policy = { default_model = "gpt-5.4-mini", escalation_model = "gpt-5.4", fallback_models = ["gpt-5.3-codex"], reasoning_effort = "medium" }
-rollout_policy = { mode = "approval_only", percentage = 100, cohorts = ["all-repos"] }
-package_source = { package = "harn-persona-examples", path = "examples/personas" }
+budget = { daily_usd = 4.0, frontier_escalations = 1, max_tokens = 40000, max_runtime_seconds = 300 }
+model_policy = { default_model = "gpt-5.4-mini", escalation_model = "gpt-5.4", fallback_models = ["gpt-5.2"], reasoning_effort = "medium" }
+rollout_policy = { mode = "approval_only", percentage = 100, cohorts = ["template-pack"] }
+package_source = { package = "harn-persona-template-pack", path = "examples/personas" }
 
 [[personas]]
 name = "oncall_captain"
 version = "0.1.0"
-description = "Coordinates incident intake, escalation, runbook context, and handoff receipts for the on-call rotation."
+description = "Approval-first incident captain for intake, hypothesis verification, MCP-backed observability checks, and outcome receipts."
 entry_workflow = "workflows/oncall_captain.harn#run"
-tools = ["slack", "pagerduty", "notion", "github"]
-capabilities = ["interaction.ask", "project.lessons", "runtime.record_run", "session.changed_paths"]
+tools = ["pagerduty", "slack", "notion", "github", "mcp"]
+capabilities = [
+  "interaction.ask",
+  "project.lessons",
+  "runtime.approved_plan",
+  "runtime.dry_run",
+  "runtime.record_run",
+  "session.changed_paths",
+]
 autonomy_tier = "act_with_approval"
 receipt_policy = "required"
-triggers = ["slack.incident_created", "pagerduty.incident_triggered"]
+triggers = ["pagerduty.incident_triggered", "slack.oncall_message"]
 schedules = ["*/15 * * * *"]
 handoffs = ["review_captain"]
-context_packs = ["incident_runbooks", "service_ownership", "release_rules"]
-evals = ["incident_triage", "handoff_quality"]
+context_packs = ["oncall_runbook", "service_ownership", "release_policy"]
+evals = ["oncall_captain_smoke"]
 owner = "sre"
-budget = { daily_usd = 15.0, frontier_escalations = 2, max_runtime_seconds = 900 }
+budget = { daily_usd = 8.0, frontier_escalations = 1, max_tokens = 50000, max_runtime_seconds = 900 }
 model_policy = { default_model = "gpt-5.4-mini", escalation_model = "gpt-5.4", fallback_models = ["gpt-5.2"], reasoning_effort = "high" }
-rollout_policy = { mode = "approval_only", percentage = 50, cohorts = ["primary-oncall"] }
-package_source = { package = "harn-persona-examples", path = "examples/personas" }
+rollout_policy = { mode = "approval_only", percentage = 100, cohorts = ["template-pack"] }
+package_source = { package = "harn-persona-template-pack", path = "examples/personas" }

--- a/examples/personas/runs/merge_captain_smoke.run.json
+++ b/examples/personas/runs/merge_captain_smoke.run.json
@@ -1,0 +1,58 @@
+{
+  "_type": "run_record",
+  "id": "merge-captain-smoke",
+  "workflow_id": "run",
+  "workflow_name": "merge_captain",
+  "task": "template smoke",
+  "status": "completed",
+  "started_at": "2026-04-22T00:00:00Z",
+  "finished_at": "2026-04-22T00:00:01Z",
+  "stages": [
+    {
+      "id": "stage_1",
+      "node_id": "run",
+      "kind": "stage",
+      "status": "completed",
+      "outcome": "success",
+      "started_at": "2026-04-22T00:00:00Z",
+      "finished_at": "2026-04-22T00:00:01Z",
+      "visible_text": "merge_captain produced a dry-run plan and approval request for PR #463"
+    }
+  ],
+  "completed_nodes": [
+    "run"
+  ],
+  "policy": {
+    "tools": [],
+    "capabilities": {},
+    "workspace_roots": [],
+    "side_effect_level": "read_only",
+    "recursion_limit": null,
+    "tool_arg_constraints": [],
+    "tool_annotations": {}
+  },
+  "metadata": {
+    "persona": "merge_captain",
+    "fixture": "fixtures/merge_captain/event.json",
+    "dry_run": true,
+    "approval_required": true
+  },
+  "replay_fixture": {
+    "_type": "replay_fixture",
+    "id": "merge-captain-smoke-fixture",
+    "source_run_id": "merge-captain-smoke",
+    "workflow_id": "run",
+    "workflow_name": "merge_captain",
+    "created_at": "2026-04-22T00:00:01Z",
+    "expected_status": "completed",
+    "stage_assertions": [
+      {
+        "node_id": "run",
+        "expected_status": "completed",
+        "expected_outcome": "success",
+        "required_artifact_kinds": [],
+        "visible_text_contains": "dry-run plan"
+      }
+    ]
+  }
+}

--- a/examples/personas/runs/oncall_captain_smoke.run.json
+++ b/examples/personas/runs/oncall_captain_smoke.run.json
@@ -1,0 +1,58 @@
+{
+  "_type": "run_record",
+  "id": "oncall-captain-smoke",
+  "workflow_id": "run",
+  "workflow_name": "oncall_captain",
+  "task": "template smoke",
+  "status": "completed",
+  "started_at": "2026-04-22T00:00:00Z",
+  "finished_at": "2026-04-22T00:00:01Z",
+  "stages": [
+    {
+      "id": "stage_1",
+      "node_id": "run",
+      "kind": "stage",
+      "status": "completed",
+      "outcome": "success",
+      "started_at": "2026-04-22T00:00:00Z",
+      "finished_at": "2026-04-22T00:00:01Z",
+      "visible_text": "oncall_captain produced a verification plan for orchestrator-api and left side effects pending approval"
+    }
+  ],
+  "completed_nodes": [
+    "run"
+  ],
+  "policy": {
+    "tools": [],
+    "capabilities": {},
+    "workspace_roots": [],
+    "side_effect_level": "read_only",
+    "recursion_limit": null,
+    "tool_arg_constraints": [],
+    "tool_annotations": {}
+  },
+  "metadata": {
+    "persona": "oncall_captain",
+    "fixture": "fixtures/oncall_captain/incident.json",
+    "dry_run": true,
+    "approval_required": true
+  },
+  "replay_fixture": {
+    "_type": "replay_fixture",
+    "id": "oncall-captain-smoke-fixture",
+    "source_run_id": "oncall-captain-smoke",
+    "workflow_id": "run",
+    "workflow_name": "oncall_captain",
+    "created_at": "2026-04-22T00:00:01Z",
+    "expected_status": "completed",
+    "stage_assertions": [
+      {
+        "node_id": "run",
+        "expected_status": "completed",
+        "expected_outcome": "success",
+        "required_artifact_kinds": [],
+        "visible_text_contains": "verification plan"
+      }
+    ]
+  }
+}

--- a/examples/personas/runs/review_captain_smoke.run.json
+++ b/examples/personas/runs/review_captain_smoke.run.json
@@ -1,0 +1,57 @@
+{
+  "_type": "run_record",
+  "id": "review-captain-smoke",
+  "workflow_id": "run",
+  "workflow_name": "review_captain",
+  "task": "template smoke",
+  "status": "completed",
+  "started_at": "2026-04-22T00:00:00Z",
+  "finished_at": "2026-04-22T00:00:01Z",
+  "stages": [
+    {
+      "id": "stage_1",
+      "node_id": "run",
+      "kind": "stage",
+      "status": "completed",
+      "outcome": "success",
+      "started_at": "2026-04-22T00:00:00Z",
+      "finished_at": "2026-04-22T00:00:01Z",
+      "visible_text": "review_captain emitted a structured review receipt for PR #463"
+    }
+  ],
+  "completed_nodes": [
+    "run"
+  ],
+  "policy": {
+    "tools": [],
+    "capabilities": {},
+    "workspace_roots": [],
+    "side_effect_level": "read_only",
+    "recursion_limit": null,
+    "tool_arg_constraints": [],
+    "tool_annotations": {}
+  },
+  "metadata": {
+    "persona": "review_captain",
+    "fixture": "fixtures/review_captain/handoff.json",
+    "dry_run": true
+  },
+  "replay_fixture": {
+    "_type": "replay_fixture",
+    "id": "review-captain-smoke-fixture",
+    "source_run_id": "review-captain-smoke",
+    "workflow_id": "run",
+    "workflow_name": "review_captain",
+    "created_at": "2026-04-22T00:00:01Z",
+    "expected_status": "completed",
+    "stage_assertions": [
+      {
+        "node_id": "run",
+        "expected_status": "completed",
+        "expected_outcome": "success",
+        "required_artifact_kinds": [],
+        "visible_text_contains": "structured review receipt"
+      }
+    ]
+  }
+}

--- a/examples/personas/secrets.example.env
+++ b/examples/personas/secrets.example.env
@@ -1,0 +1,18 @@
+# Placeholder values only. Do not commit real credentials into template forks.
+# These examples are here so teams can see the expected shape without needing
+# production access during local validation or fixture/eval runs.
+
+GITHUB_APP_ID=000000
+GITHUB_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nREPLACE_ME\n-----END PRIVATE KEY-----"
+GITHUB_WEBHOOK_SECRET=replace-me
+
+LINEAR_API_KEY=replace-me
+NOTION_TOKEN=secret_replace_me
+
+SLACK_BOT_TOKEN=xoxb-replace-me
+SLACK_SIGNING_SECRET=replace-me
+
+PAGERDUTY_API_TOKEN=replace-me
+
+HONEYCOMB_API_KEY=replace-me
+SPLUNK_HEC_TOKEN=replace-me

--- a/examples/personas/workflows/merge_captain.harn
+++ b/examples/personas/workflows/merge_captain.harn
@@ -1,0 +1,53 @@
+fn sample_pull_request() {
+  return {
+    repo: "burin-labs/harn",
+    number: 463,
+    title: "Persona template pack v0",
+    failing_checks: ["ci / rust"],
+    stale_threads: ["acceptance coverage"],
+    release_blockers: ["needs-human-release-note"],
+    merge_conflicts: false,
+  }
+}
+
+fn merge_risk(pr) {
+  if len(pr.failing_checks) > 0 || len(pr.stale_threads) > 0 || len(pr.release_blockers) > 0 {
+    return "high"
+  }
+  if pr.merge_conflicts {
+    return "high"
+  }
+  return "low"
+}
+
+pipeline run(task) {
+  let pr = sample_pull_request()
+  let risk = merge_risk(pr)
+  let handoff = if risk == "high" {
+    "review_captain"
+  } else {
+    nil
+  }
+  let result = {
+    persona: "merge_captain",
+    execution_mode: "dry_run",
+    approval_required: true,
+    repo: pr.repo,
+    pr_number: pr.number,
+    summary: "dry-run plan for PR #${pr.number}",
+    plan: [
+    "Summarize failing checks and stale review threads.",
+    "Ask for approval before posting receipts or mutating labels.",
+    "Hand off review risk when unresolved comments remain.",
+  ],
+    review_risk: risk,
+    receipt: {
+    kind: "merge_receipt",
+    status: "pending_approval",
+    blockers: pr.failing_checks + pr.stale_threads + pr.release_blockers,
+  },
+    handoff: handoff,
+  }
+  println(json_stringify(result))
+  return result
+}

--- a/examples/personas/workflows/oncall_captain.harn
+++ b/examples/personas/workflows/oncall_captain.harn
@@ -1,0 +1,36 @@
+fn sample_incident() {
+  return {
+    service: "orchestrator-api",
+    hypothesis: "a deploy introduced a replay-loop regression",
+    symptoms: ["pagerduty page", "error-rate spike", "slack escalation"],
+    observability_backends: ["mcp:honeycomb", "mcp:splunk"],
+    human_owner: "primary-oncall",
+  }
+}
+
+pipeline run(task) {
+  let incident = sample_incident()
+  let result = {
+    persona: "oncall_captain",
+    execution_mode: "dry_run",
+    approval_required: true,
+    service: incident.service,
+    summary: "verification plan for ${incident.service}",
+    plan: [
+    "Check the current deploy and the most recent rollback candidate.",
+    "Query Honeycomb and Splunk through MCP before proposing side effects.",
+    "Record whether the hypothesis is confirmed, disproven, or unresolved.",
+  ],
+    status: "unresolved",
+    receipt: {
+    kind: "incident_receipt",
+    outcome: "unresolved",
+    hypothesis: incident.hypothesis,
+    backends: incident.observability_backends,
+    owner: incident.human_owner,
+  },
+    handoff: "review_captain",
+  }
+  println(json_stringify(result))
+  return result
+}

--- a/examples/personas/workflows/review_captain.harn
+++ b/examples/personas/workflows/review_captain.harn
@@ -1,0 +1,45 @@
+fn sample_review() {
+  return {
+    repo: "burin-labs/harn",
+    pr_number: 463,
+    changed_files: ["examples/personas/harn.toml", "examples/personas/workflows/merge_captain.harn"],
+    missing_tests: ["template smoke for oncall_captain"],
+    risky_paths: ["examples/personas/harn.toml"],
+  }
+}
+
+fn review_verdict(review) {
+  if len(review.missing_tests) > 0 || len(review.risky_paths) > 0 {
+    return "needs_follow_up"
+  }
+  return "low_risk"
+}
+
+pipeline run(task) {
+  let review = sample_review()
+  let verdict = review_verdict(review)
+  let handoff = if verdict == "needs_follow_up" {
+    "merge_captain"
+  } else {
+    nil
+  }
+  let result = {
+    persona: "review_captain",
+    execution_mode: "dry_run",
+    approval_required: false,
+    repo: review.repo,
+    pr_number: review.pr_number,
+    summary: "structured review receipt for PR #${review.pr_number}",
+    focus: ["regressions", "missing tests", "risky diffs"],
+    receipt: {
+    kind: "review_receipt",
+    verdict: verdict,
+    missing_tests: review.missing_tests,
+    risky_paths: review.risky_paths,
+    changed_files: review.changed_files,
+  },
+    handoff: handoff,
+  }
+  println(json_stringify(result))
+  return result
+}


### PR DESCRIPTION
## Summary
- turn `examples/personas` into a first template pack for `merge_captain`, `review_captain`, and `oncall_captain`
- add safe-by-default workflows, checked-in fixtures/evals, context packs, and placeholder secrets
- document customization steps plus explicit persona v1 gaps and connector expectations

## Verification
- `/tmp/harn-463-target/debug/harn persona --manifest examples/personas/harn.toml list --json`
- `/tmp/harn-463-target/debug/harn persona --manifest examples/personas/harn.toml inspect merge_captain --json`
- `/tmp/harn-463-target/debug/harn persona --manifest examples/personas/harn.toml inspect review_captain --json`
- `/tmp/harn-463-target/debug/harn persona --manifest examples/personas/harn.toml inspect oncall_captain --json`
- `/tmp/harn-463-target/debug/harn check|lint|fmt --check examples/personas/workflows/*.harn`
- `/tmp/harn-463-target/debug/harn run examples/personas/workflows/merge_captain.harn`
- `/tmp/harn-463-target/debug/harn run examples/personas/workflows/review_captain.harn`
- `/tmp/harn-463-target/debug/harn run examples/personas/workflows/oncall_captain.harn`
- `/tmp/harn-463-target/debug/harn eval examples/personas/evals/merge_captain_smoke.json`
- `/tmp/harn-463-target/debug/harn eval examples/personas/evals/review_captain_smoke.json`
- `/tmp/harn-463-target/debug/harn eval examples/personas/evals/oncall_captain_smoke.json`
- `/tmp/harn-463-target/debug/harn eval examples/personas/evals/template_pack_smoke.json`

Fixes #463