### PR TITLE
Tighten Harn no-tool loops and transcript thinking handling

### DIFF
--- a/crates/harn-vm/src/llm/agent/helpers.rs
+++ b/crates/harn-vm/src/llm/agent/helpers.rs
@@ -145,6 +145,7 @@ pub(crate) fn assistant_history_text(
 
 pub(crate) fn action_turn_nudge(
     tool_format: &str,
+    has_tools: bool,
     turn_policy: Option<&crate::orchestration::TurnPolicy>,
     prose_too_long: bool,
 ) -> Option<String> {
@@ -162,12 +163,16 @@ pub(crate) fn action_turn_nudge(
     } else {
         ""
     };
-    let completion_clause = if policy.allow_done_sentinel {
+    let completion_clause = if has_tools && policy.allow_done_sentinel {
         "either make concrete progress with a well-formed <tool_call> block, switch phase, or emit a <done> block if the task is genuinely complete."
-    } else {
+    } else if has_tools {
         "either make concrete progress with a well-formed <tool_call> block or switch phase if the workflow allows it."
+    } else if policy.allow_done_sentinel {
+        "either make concrete progress in your reply, switch phase, or emit a <done> block if the task is genuinely complete."
+    } else {
+        "either make concrete progress in your reply or switch phase if the workflow allows it."
     };
-    let mode_clause = if tool_format == "native" {
+    let mode_clause = if has_tools && tool_format == "native" {
         " Use the provider tool channel only; handwritten tool-call text is invalid in this transcript."
     } else {
         ""
@@ -186,7 +191,7 @@ pub(crate) fn sentinel_without_action_nudge(
     } else {
         "You emitted a <done> block without taking any tool action. The task is not complete yet. Make concrete progress with an available tool now, or switch phase if the workflow allows it. Do not emit <done> again until you have acted.".to_string()
     };
-    if let Some(nudge) = action_turn_nudge(tool_format, turn_policy, false) {
+    if let Some(nudge) = action_turn_nudge(tool_format, true, turn_policy, false) {
         message.push(' ');
         message.push_str(&nudge);
     }

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -437,13 +437,22 @@ pub(super) async fn run_llm_call(
 
     // Check sentinel on every response; when it coexists with tool calls
     // we still process the tools, then exit.
-    let sentinel_in_text = tagged_done_marker
+    let tagged_done_hit = tagged_done_marker
         .as_deref()
-        .is_some_and(|body| body == ctx.done_sentinel)
-        // Native-format and no-tools paths bypass the tagged parser —
-        // fall back to substring match.
-        || (ctx.tool_format == "native" && text.contains(ctx.done_sentinel))
-        || (!ctx.has_tools && text.contains(ctx.done_sentinel));
+        .is_some_and(|body| body == ctx.done_sentinel);
+    let plain_done_hit = if ctx.tool_format == "native" {
+        // Native-mode providers may surface the sentinel in visible prose
+        // while tool calls travel separately via the provider channel.
+        text.contains(ctx.done_sentinel)
+    } else if !ctx.has_tools {
+        // No-tool loops advertise the plain sentinel form, not a tagged
+        // `<done>` block. Honor only visible prose so tagged control
+        // blocks do not terminate a text-only loop early.
+        text_prose.contains(ctx.done_sentinel)
+    } else {
+        false
+    };
+    let sentinel_in_text = (ctx.has_tools && tagged_done_hit) || plain_done_hit;
     let phase_change = ctx
         .break_unless_phase
         .is_some_and(|phase| loop_state_requests_phase_change(&text, phase));

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -414,7 +414,7 @@ pub(super) async fn run_llm_call(
 
     // Teach the model to fix grammar violations. Done before tool-call
     // dispatch so protocol errors surface even in mixed turns.
-    if !protocol_violations.is_empty() && ctx.tool_format != "native" {
+    if !protocol_violations.is_empty() && ctx.has_tools && ctx.tool_format != "native" {
         let feedback = format!(
             "Your response violated the tagged response protocol. Each issue:\n- {}\n\n\
              Re-emit using only these top-level tags, separated by whitespace:\n\n\
@@ -472,12 +472,14 @@ pub(super) async fn run_llm_call(
     let verified = !ctx.exit_when_verified || state.last_run_exit_code == Some(0);
     // Guard against premature exit where the model emits done without acting.
     let has_acted = !state.all_tools_used.is_empty() || !tool_calls.is_empty();
+    let completion_ready = has_acted || !ctx.has_tools;
     // Ledger gate: reject done while open/blocked deliverables remain.
     let ledger_blocks_done = state.task_ledger.gates_done();
     let completion_requested =
         sentinel_in_text || (allow_done_sentinel && user_response.as_deref().is_some());
     let sentinel_hit = ctx.persistent
-        && ((completion_requested && verified && has_acted && !ledger_blocks_done) || phase_change);
+        && ((completion_requested && verified && completion_ready && !ledger_blocks_done)
+            || phase_change);
 
     if completion_requested && ledger_blocks_done && ctx.persistent {
         let corrective = state.task_ledger.done_gate_feedback();

--- a/crates/harn-vm/src/llm/agent/mod.rs
+++ b/crates/harn-vm/src/llm/agent/mod.rs
@@ -340,6 +340,7 @@ pub async fn run_agent_loop_internal(
                 bridge: &bridge,
                 session_id: &session_id,
                 tool_format: &tool_format,
+                has_tools,
                 max_nudges,
                 persistent,
                 daemon,

--- a/crates/harn-vm/src/llm/agent/post_turn.rs
+++ b/crates/harn-vm/src/llm/agent/post_turn.rs
@@ -65,6 +65,7 @@ pub(super) struct PostTurnContext<'a> {
     pub bridge: &'a Option<Rc<HostBridge>>,
     pub session_id: &'a str,
     pub tool_format: &'a str,
+    pub has_tools: bool,
     pub max_nudges: usize,
     pub persistent: bool,
     pub daemon: bool,
@@ -408,9 +409,19 @@ pub(super) async fn run_post_turn(
             .await?;
             return Ok(IterationOutcome::Break);
         }
-        let guidance =
-            action_turn_nudge(ctx.tool_format, ctx.turn_policy, call_result.prose_too_long)
-                .unwrap_or_else(|| "Use a tool call to make progress.".to_string());
+        let guidance = action_turn_nudge(
+            ctx.tool_format,
+            ctx.has_tools,
+            ctx.turn_policy,
+            call_result.prose_too_long,
+        )
+        .unwrap_or_else(|| {
+            if ctx.has_tools {
+                "Use a tool call to make progress.".to_string()
+            } else {
+                "Make concrete progress in your reply.".to_string()
+            }
+        });
         append_message_to_contexts(
             &mut state.visible_messages,
             &mut state.recorded_messages,
@@ -726,9 +737,20 @@ pub(super) async fn run_post_turn(
         return Ok(IterationOutcome::Break);
     }
 
-    let nudge = action_turn_nudge(ctx.tool_format, ctx.turn_policy, call_result.prose_too_long)
-        .or_else(|| ctx.custom_nudge.clone())
-        .unwrap_or_else(|| "Continue — use a tool call to make progress.".to_string());
+    let nudge = action_turn_nudge(
+        ctx.tool_format,
+        ctx.has_tools,
+        ctx.turn_policy,
+        call_result.prose_too_long,
+    )
+    .or_else(|| ctx.custom_nudge.clone())
+    .unwrap_or_else(|| {
+        if ctx.has_tools {
+            "Continue — use a tool call to make progress.".to_string()
+        } else {
+            "Continue — make progress in your reply.".to_string()
+        }
+    });
     append_message_to_contexts(
         &mut state.visible_messages,
         &mut state.recorded_messages,

--- a/crates/harn-vm/src/llm/agent/state.rs
+++ b/crates/harn-vm/src/llm/agent/state.rs
@@ -1116,33 +1116,34 @@ impl AgentLoopState {
             format!("emit `<done>{done_sentinel}</done>` as its own top-level block")
         };
         let persistent_system_prompt = if persistent {
+            let progress_instruction = if has_tools {
+                "Take action with tool calls — do not stop to explain."
+            } else {
+                "Solve the request directly in assistant text — do not stop early to explain or summarize."
+            };
             if exit_when_verified {
                 if allow_done_sentinel {
                     Some(format!(
-                        "\n\nKeep working until the current request is complete. Take action with tool \
-                         calls — do not stop to explain. {} only after the current request passes verification.",
-                        done_instruction
+                        "\n\nKeep working until the current request is complete. {progress_instruction} {} only after the current request passes verification.",
+                        done_instruction,
                     ))
                 } else {
-                    Some(
-                        "\n\nKeep working until the current request is complete. Take action with tool calls — \
-                         do not stop to explain."
-                            .to_string(),
-                    )
+                    Some(format!(
+                        "\n\nKeep working until the current request is complete. {progress_instruction}"
+                    ))
                 }
             } else if allow_done_sentinel {
                 Some(format!(
                     "\n\nIMPORTANT: You MUST keep working until the current request is complete. \
-                     Do NOT stop to explain or summarize — take action with tool calls. \
+                     {progress_instruction} \
                      When the requested work is complete, {}.",
                     done_instruction
                 ))
             } else {
-                Some(
+                Some(format!(
                     "\n\nIMPORTANT: You MUST keep working until the current request is complete. \
-                     Do NOT stop to explain or summarize — take action with tool calls."
-                        .to_string(),
-                )
+                     {progress_instruction}"
+                ))
             }
         } else {
             None

--- a/crates/harn-vm/src/llm/agent/tests/prompts.rs
+++ b/crates/harn-vm/src/llm/agent/tests/prompts.rs
@@ -22,7 +22,7 @@ fn action_turn_nudge_mentions_action_or_yield() {
         allow_done_sentinel: true,
         max_prose_chars: Some(120),
     };
-    let msg = action_turn_nudge("text", Some(&policy), true).expect("nudge");
+    let msg = action_turn_nudge("text", true, Some(&policy), true).expect("nudge");
     assert!(
         msg.contains("either make concrete progress with a well-formed <tool_call> block, switch phase, or emit a <done> block")
     );
@@ -51,7 +51,7 @@ fn action_turn_nudge_omits_done_sentinel_when_stage_disallows_it() {
         allow_done_sentinel: false,
         max_prose_chars: Some(90),
     };
-    let msg = action_turn_nudge("text", Some(&policy), false).expect("nudge");
+    let msg = action_turn_nudge("text", true, Some(&policy), false).expect("nudge");
     assert!(!msg.contains("<done>"));
     assert!(msg.contains(
         "either make concrete progress with a well-formed <tool_call> block or switch phase"
@@ -77,7 +77,7 @@ fn native_action_turn_nudge_mentions_native_channel() {
         allow_done_sentinel: false,
         max_prose_chars: Some(90),
     };
-    let msg = action_turn_nudge("native", Some(&policy), false).expect("nudge");
+    let msg = action_turn_nudge("native", true, Some(&policy), false).expect("nudge");
     assert!(msg.contains("provider tool channel only"));
     assert!(msg.contains("handwritten tool-call text is invalid"));
 }
@@ -103,8 +103,41 @@ async fn persistent_prompt_omits_done_sentinel_when_stage_disallows_it() {
         .last()
         .and_then(|call| call.system.as_ref())
         .expect("mock call system prompt");
-    assert!(system.contains("take action with tool calls"));
+    assert!(system.contains("Solve the request directly in assistant text"));
     assert!(!system.contains("##DONE##"));
+    reset_llm_mock_state();
+}
+
+#[test]
+fn action_turn_nudge_uses_reply_language_when_no_tools_exist() {
+    let policy = TurnPolicy {
+        require_action_or_yield: true,
+        allow_done_sentinel: true,
+        max_prose_chars: Some(80),
+    };
+    let msg = action_turn_nudge("text", false, Some(&policy), false).expect("nudge");
+    assert!(msg.contains("make concrete progress in your reply"));
+    assert!(!msg.contains("<tool_call>"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn persistent_prompt_without_tools_avoids_tool_call_language() {
+    reset_llm_mock_state();
+    let mut opts = base_opts(vec![serde_json::json!({
+        "role": "user",
+        "content": "answer the math question directly",
+    })]);
+    let mut config = base_agent_config();
+    config.persistent = true;
+
+    let _ = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    let calls = get_llm_mock_calls();
+    let system = calls
+        .last()
+        .and_then(|call| call.system.as_ref())
+        .expect("mock call system prompt");
+    assert!(system.contains("Solve the request directly in assistant text"));
+    assert!(!system.contains("take action with tool calls"));
     reset_llm_mock_state();
 }
 

--- a/crates/harn-vm/src/llm/agent/tests/result_build.rs
+++ b/crates/harn-vm/src/llm/agent/tests/result_build.rs
@@ -135,6 +135,39 @@ fn build_llm_call_result_leaves_plain_text_unflagged_without_tools() {
 }
 
 #[test]
+fn build_llm_call_result_unwraps_tagged_no_tool_visible_text() {
+    let opts = base_opts(vec![json!({"role": "user", "content": "Say hello"})]);
+    let result = LlmResult {
+        text: "<assistant_prose>Hello there</assistant_prose>\n<done>##DONE##</done>".to_string(),
+        tool_calls: Vec::new(),
+        input_tokens: 8,
+        output_tokens: 4,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        model: "mock".to_string(),
+        provider: "mock".to_string(),
+        thinking: None,
+        stop_reason: None,
+        blocks: Vec::new(),
+    };
+
+    let vm_result = build_llm_call_result(&result, &opts);
+    let dict = vm_result.as_dict().expect("dict");
+    assert_eq!(
+        dict.get("prose").map(VmValue::display).as_deref(),
+        Some("Hello there")
+    );
+    assert_eq!(
+        dict.get("visible_text").map(VmValue::display).as_deref(),
+        Some("Hello there")
+    );
+    assert!(
+        dict.get("protocol_violations").is_none(),
+        "well-formed tagged no-tool responses should not report protocol violations"
+    );
+}
+
+#[test]
 fn build_llm_call_transcript_keeps_private_reasoning_out_of_visible_message_text() {
     let opts = base_opts(vec![json!({"role": "user", "content": "Explain the repo"})]);
     let result = LlmResult {

--- a/crates/harn-vm/src/llm/agent/tests/result_build.rs
+++ b/crates/harn-vm/src/llm/agent/tests/result_build.rs
@@ -104,3 +104,96 @@ fn build_llm_call_result_extracts_json_from_tagged_prose() {
         "tagged prose should still populate structured data"
     );
 }
+
+#[test]
+fn build_llm_call_result_leaves_plain_text_unflagged_without_tools() {
+    let opts = base_opts(vec![json!({"role": "user", "content": "What is 2 + 2?"})]);
+    let result = LlmResult {
+        text: "4".to_string(),
+        tool_calls: Vec::new(),
+        input_tokens: 8,
+        output_tokens: 1,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        model: "mock".to_string(),
+        provider: "mock".to_string(),
+        thinking: None,
+        stop_reason: None,
+        blocks: Vec::new(),
+    };
+
+    let vm_result = build_llm_call_result(&result, &opts);
+    let dict = vm_result.as_dict().expect("dict");
+    assert_eq!(
+        dict.get("prose").map(VmValue::display).as_deref(),
+        Some("4")
+    );
+    assert!(
+        dict.get("protocol_violations").is_none(),
+        "plain no-tool llm_call should not be judged against the tagged agent protocol"
+    );
+}
+
+#[test]
+fn build_llm_call_transcript_keeps_private_reasoning_out_of_visible_message_text() {
+    let opts = base_opts(vec![json!({"role": "user", "content": "Explain the repo"})]);
+    let result = LlmResult {
+        text: "Visible answer".to_string(),
+        tool_calls: Vec::new(),
+        input_tokens: 10,
+        output_tokens: 3,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        model: "mock".to_string(),
+        provider: "mock".to_string(),
+        thinking: Some("private chain of thought".to_string()),
+        stop_reason: None,
+        blocks: vec![
+            json!({
+                "type": "reasoning",
+                "text": "private chain of thought",
+                "visibility": "private",
+            }),
+            json!({
+                "type": "output_text",
+                "text": "Visible answer",
+                "visibility": "public",
+            }),
+        ],
+    };
+
+    let vm_result = build_llm_call_result(&result, &opts);
+    let dict = vm_result.as_dict().expect("dict");
+    let transcript = dict
+        .get("transcript")
+        .and_then(VmValue::as_dict)
+        .expect("transcript");
+    let events = match transcript.get("events") {
+        Some(VmValue::List(events)) => events,
+        _ => panic!("events"),
+    };
+    let assistant_message = events
+        .iter()
+        .find(|event| {
+            event
+                .as_dict()
+                .and_then(|dict| dict.get("kind"))
+                .map(VmValue::display)
+                .as_deref()
+                == Some("message")
+                && event
+                    .as_dict()
+                    .and_then(|dict| dict.get("role"))
+                    .map(VmValue::display)
+                    .as_deref()
+                    == Some("assistant")
+        })
+        .and_then(VmValue::as_dict)
+        .expect("assistant message event");
+    let text = assistant_message
+        .get("text")
+        .map(VmValue::display)
+        .unwrap_or_default();
+    assert_eq!(text, "Visible answer");
+    assert!(!text.contains("private chain of thought"));
+}

--- a/crates/harn-vm/src/llm/agent/tests/transcript.rs
+++ b/crates/harn-vm/src/llm/agent/tests/transcript.rs
@@ -130,6 +130,62 @@ async fn observed_llm_call_transcript_uses_explicit_tool_format() {
     reset_llm_mock_state();
 }
 
+#[tokio::test(flavor = "current_thread")]
+#[allow(clippy::await_holding_lock)]
+async fn observed_llm_call_transcript_records_thinking_settings() {
+    let _guard = transcript_env_lock();
+    reset_llm_mock_state();
+    let dir = std::env::temp_dir().join(format!(
+        "harn-llm-transcript-thinking-{}",
+        uuid::Uuid::now_v7()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let old_dir = std::env::var("HARN_LLM_TRANSCRIPT_DIR").ok();
+    std::env::set_var(
+        "HARN_LLM_TRANSCRIPT_DIR",
+        dir.to_string_lossy().into_owned(),
+    );
+
+    let mut opts = base_opts(vec![serde_json::json!({
+        "role": "user",
+        "content": "reason about this task",
+    })]);
+    opts.thinking = Some(crate::llm::api::ThinkingConfig::WithBudget(2048));
+
+    let _ = observed_llm_call(
+        &opts,
+        Some("text"),
+        None,
+        &LlmRetryConfig::default(),
+        Some(0),
+        false,
+        false,
+    )
+    .await
+    .unwrap();
+
+    let transcript =
+        std::fs::read_to_string(dir.join("llm_transcript.jsonl")).expect("transcript file");
+    let request = transcript
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .find(|line| line["type"] == "provider_call_request")
+        .expect("provider_call_request event");
+    assert_eq!(request["thinking"]["enabled"], serde_json::json!(true));
+    assert_eq!(
+        request["thinking"]["budget_tokens"],
+        serde_json::json!(2048)
+    );
+
+    if let Some(previous) = old_dir {
+        std::env::set_var("HARN_LLM_TRANSCRIPT_DIR", previous);
+    } else {
+        std::env::remove_var("HARN_LLM_TRANSCRIPT_DIR");
+    }
+    let _ = std::fs::remove_dir_all(dir);
+    reset_llm_mock_state();
+}
+
 async fn assert_observed_llm_call_bridge_user_visible(user_visible: bool) {
     reset_llm_mock_state();
 
@@ -481,6 +537,53 @@ async fn user_response_block_can_complete_persistent_loop_without_done_sentinel(
     let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
     assert_eq!(result["status"], "done");
     assert_eq!(result["visible_text"].as_str(), Some("Completed cleanly."));
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn plain_done_sentinel_can_complete_persistent_loop_without_tools() {
+    reset_llm_mock_state();
+    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
+        text: "1, 2, 3, 4, 5\n\n##DONE##".to_string(),
+        tool_calls: Vec::new(),
+        match_pattern: None,
+        consume_on_match: true,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: Some("count the numbers".to_string()),
+        stop_reason: None,
+        model: "mock".to_string(),
+        provider: None,
+        blocks: Some(vec![
+            serde_json::json!({
+                "type": "reasoning",
+                "text": "count the numbers",
+                "visibility": "private",
+            }),
+            serde_json::json!({
+                "type": "output_text",
+                "text": "1, 2, 3, 4, 5\n\n##DONE##",
+                "visibility": "public",
+            }),
+        ]),
+        error: None,
+    });
+
+    let mut opts = base_opts(vec![serde_json::json!({
+        "role": "user",
+        "content": "Count to five, then finish",
+    })]);
+    opts.thinking = Some(crate::llm::api::ThinkingConfig::Enabled);
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 2;
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_eq!(result["status"], "done");
+    assert_eq!(result["iterations"].as_u64(), Some(1));
+    assert_eq!(result["visible_text"].as_str(), Some("1, 2, 3, 4, 5"));
     reset_llm_mock_state();
 }
 

--- a/crates/harn-vm/src/llm/agent/tests/transcript.rs
+++ b/crates/harn-vm/src/llm/agent/tests/transcript.rs
@@ -588,6 +588,42 @@ async fn plain_done_sentinel_can_complete_persistent_loop_without_tools() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn tagged_done_block_does_not_complete_persistent_loop_without_tools() {
+    reset_llm_mock_state();
+    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
+        text: "<assistant_prose>Still working.</assistant_prose>\n<done>##DONE##</done>"
+            .to_string(),
+        tool_calls: Vec::new(),
+        match_pattern: None,
+        consume_on_match: true,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: None,
+        stop_reason: None,
+        model: "mock".to_string(),
+        provider: None,
+        blocks: None,
+        error: None,
+    });
+
+    let mut opts = base_opts(vec![serde_json::json!({
+        "role": "user",
+        "content": "Keep going until you are done",
+    })]);
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 1;
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_eq!(result["status"], "budget_exhausted");
+    assert_eq!(result["iterations"].as_u64(), Some(1));
+    assert_eq!(result["visible_text"].as_str(), Some("Still working."));
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn ledger_tool_is_rejected_when_no_task_ledger_is_active() {
     reset_llm_mock_state();
     crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -396,6 +396,20 @@ pub(super) fn dump_llm_request(
         "provider": opts.provider,
         "max_tokens": opts.max_tokens,
         "temperature": opts.temperature,
+        "thinking": match opts.thinking.as_ref() {
+            Some(super::api::ThinkingConfig::Enabled) => serde_json::json!({
+                "enabled": true,
+                "budget_tokens": serde_json::Value::Null,
+            }),
+            Some(super::api::ThinkingConfig::WithBudget(budget_tokens)) => serde_json::json!({
+                "enabled": true,
+                "budget_tokens": budget_tokens,
+            }),
+            None => serde_json::json!({
+                "enabled": false,
+                "budget_tokens": serde_json::Value::Null,
+            }),
+        },
         "tool_choice": opts.tool_choice,
         "tool_format": tool_format,
         "native_tool_count": opts.native_tools.as_ref().map(|tools| tools.len()).unwrap_or(0),

--- a/crates/harn-vm/src/llm/api/result.rs
+++ b/crates/harn-vm/src/llm/api/result.rs
@@ -72,7 +72,16 @@ pub(crate) fn vm_build_llm_result(
         dict.insert("data".to_string(), json_val);
     }
 
-    let has_text_tool_protocol = tools_val.is_some() || !result.tool_calls.is_empty();
+    let has_tagged_blocks = [
+        "<assistant_prose>",
+        "<user_response>",
+        "<done>",
+        "<tool_call>",
+    ]
+    .iter()
+    .any(|tag| result.text.contains(tag));
+    let has_text_tool_protocol =
+        tools_val.is_some() || !result.tool_calls.is_empty() || has_tagged_blocks;
     // Keep parsing available for tool-calling responses so llm_call can
     // expose canonical/prose/tool metadata, but do not surface tagged-protocol
     // violations for ordinary plain-text completions with no tools.
@@ -174,7 +183,7 @@ pub(crate) fn vm_build_llm_result(
             crate::llm::tools::parse_text_tool_calls_with_tools(&result.text, tools_val);
         parse_result.prose
     } else {
-        result.text.clone()
+        crate::visible_text::sanitize_visible_assistant_text(&result.text, false)
     };
     dict.insert(
         "visible_text".to_string(),

--- a/crates/harn-vm/src/llm/api/result.rs
+++ b/crates/harn-vm/src/llm/api/result.rs
@@ -72,14 +72,12 @@ pub(crate) fn vm_build_llm_result(
         dict.insert("data".to_string(), json_val);
     }
 
-    // Always run the tagged-protocol parser so canonical_text / violations /
-    // done_marker are available even with no tool registry. It's cheap and a
-    // no-op when the text has no tags. Native provider tool calls are
-    // authoritative and take precedence over text-parsed calls.
-    let tagged = Some(crate::llm::tools::parse_text_tool_calls_with_tools(
-        &result.text,
-        tools_val,
-    ));
+    let has_text_tool_protocol = tools_val.is_some() || !result.tool_calls.is_empty();
+    // Keep parsing available for tool-calling responses so llm_call can
+    // expose canonical/prose/tool metadata, but do not surface tagged-protocol
+    // violations for ordinary plain-text completions with no tools.
+    let tagged = has_text_tool_protocol
+        .then(|| crate::llm::tools::parse_text_tool_calls_with_tools(&result.text, tools_val));
 
     let merged_tool_calls: Vec<serde_json::Value> = if !result.tool_calls.is_empty() {
         result.tool_calls.clone()
@@ -139,6 +137,11 @@ pub(crate) fn vm_build_llm_result(
         dict.insert(
             "prose".to_string(),
             VmValue::String(Rc::from(prose.as_str())),
+        );
+    } else {
+        dict.insert(
+            "prose".to_string(),
+            VmValue::String(Rc::from(result.text.as_str())),
         );
     }
 

--- a/crates/harn-vm/src/llm/helpers/blocks.rs
+++ b/crates/harn-vm/src/llm/helpers/blocks.rs
@@ -88,11 +88,12 @@ pub(super) fn render_blocks_text(blocks: &[VmValue]) -> String {
             .map(|value| value.display())
             .unwrap_or_else(|| "text".to_string());
         let text = match kind.as_str() {
-            "text" | "output_text" | "reasoning" => dict
+            "text" | "output_text" => dict
                 .get("text")
                 .or_else(|| dict.get("content"))
                 .map(|value| value.display())
                 .unwrap_or_default(),
+            "reasoning" => String::new(),
             "tool_call" => {
                 let name = dict
                     .get("name")

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -886,9 +886,6 @@ fn validate_options(opts: &crate::llm::api::LlmCallOptions) {
             if opts.top_k.is_some() {
                 warn("top_k");
             }
-            if opts.thinking.is_some() {
-                warn("thinking");
-            }
             if opts.cache {
                 warn("cache");
             }

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -184,6 +184,7 @@ pub(crate) fn register_agent_builtins(vm: &mut Vm) {
         for key in [
             "provider",
             "model",
+            "thinking",
             "tools",
             "max_iterations",
             "tool_format",

--- a/experiments/burin-mini/lib/common.harn
+++ b/experiments/burin-mini/lib/common.harn
@@ -16,6 +16,25 @@ pub fn evaluator_model() {
   return env_or("BURIN_MINI_EVALUATOR_MODEL", generator_model())
 }
 
+fn bool_env(value) {
+  let normalized = lowercase((value ?? "").trim())
+  if normalized == "1" || normalized == "true" || normalized == "yes" || normalized == "on" {
+    return true
+  }
+  if normalized == "0" || normalized == "false" || normalized == "no" || normalized == "off" {
+    return false
+  }
+  return nil
+}
+
+fn thinking_enabled_for_model(provider, model) {
+  let thinking_pref = bool_env(env_or("BURIN_MINI_THINKING", ""))
+  if thinking_pref != nil {
+    return thinking_pref
+  }
+  return false
+}
+
 /** Return true when a list contains the given value. */
 pub fn list_contains(items, needle) {
   for item in items {
@@ -718,7 +737,7 @@ pub fn research_schema() {
 
 /** Build common generator sub-agent options. */
 pub fn generator_options(system, tools, allowed_tools) {
-  return {
+  var opts = {
     provider: provider_name(),
     model: generator_model(),
     system: system,
@@ -729,11 +748,15 @@ pub fn generator_options(system, tools, allowed_tools) {
     temperature: 0,
     max_iterations: 6,
   }
+  if len(allowed_tools ?? []) > 0 && thinking_enabled_for_model(provider_name(), generator_model()) {
+    opts = opts + {thinking: true}
+  }
+  return opts
 }
 
 /** Build common evaluator sub-agent options. */
 pub fn evaluator_options(system, tools) {
-  return {
+  var opts = {
     provider: provider_name(),
     model: evaluator_model(),
     system: system,
@@ -744,6 +767,10 @@ pub fn evaluator_options(system, tools) {
     temperature: 0,
     max_iterations: 4,
   }
+  if thinking_enabled_for_model(provider_name(), evaluator_model()) {
+    opts = opts + {thinking: true}
+  }
+  return opts
 }
 
 /** Safely parse a JSON object from model output. */

--- a/experiments/burin-mini/lib/common.harn
+++ b/experiments/burin-mini/lib/common.harn
@@ -27,7 +27,7 @@ fn bool_env(value) {
   return nil
 }
 
-fn thinking_enabled_for_model(provider, model) {
+fn thinking_enabled_for_model(_provider, _model) {
   let thinking_pref = bool_env(env_or("BURIN_MINI_THINKING", ""))
   if thinking_pref != nil {
     return thinking_pref


### PR DESCRIPTION
## Summary
- fix no-tool  and persistent  behavior so plain assistant replies are not treated like broken tool protocol turns
- keep private reasoning out of visible assistant transcript text while recording request thinking settings in transcript events
- preserve thinking across higher-level agent config surfaces and keep burin-mini reasoning opt-in for strict-JSON local-model stages

## Testing
- CARGO_TARGET_DIR=/tmp/harn-c677-target cargo test -p harn-vm llm::agent::tests:: -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-c677-target cargo run --quiet --bin harn -- lint experiments/burin-mini/lib/common.harn
- manual local-model verification with  for , , and thinking-enabled temp scripts
- manual burin-mini playground verification with  against local Ollama transcripts