### PR TITLE
Prepare v0.7.33 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## v0.7.33
+
+### Added
+
+- **Persona manifests and captain template packs (#460, #463, #514,
+  #519).** Adds `harn persona list` / `inspect --json`, validates
+  persona-manifest fields in `harn.toml`, and ships checked-in
+  `merge_captain`, `review_captain`, and `oncall_captain` template
+  packs with workflows, fixtures, evals, context packs, and operator
+  docs.
+- **Registry package discovery and typed delegation handoffs (#470,
+  #461, #515, #520).** Adds a first-party TOML package registry index
+  plus `harn package search` / `info`, teaches `harn add
+  <registry-name>@<version>` to resolve registry versions into the
+  existing Git dependency flow, and surfaces typed `HandoffArtifact`
+  metadata through receipts, ACP session updates, A2A responses, and
+  conformance fixtures.
+
+### Changed
+
+- **Docs and runtime policy refresh (#447, #473, #467, #513, #516,
+  #517).** Points docs, CLI metadata, quickrefs, and redirects at
+  `harnlang.com`, adds structured cancellation scopes for deadlines and
+  host cancellation, and enforces connector export-effect policy around
+  normalize/export calls with matching lint and contract-check
+  coverage.
+
+### Fixed
+
+- **Package resolution and sandbox hardening (#518).** Confines direct
+  imports, manifest exports, aliases, cache materialization, and Git
+  temp-dir handling to package roots, makes manifest provider schema
+  installation atomic under concurrent checks, and tightens macOS
+  process sandbox read/write scopes.
+- **Text-only agent loop completion and transcript surfaces (#521).**
+  No-tool persistent loops now honor only the plain visible done
+  sentinel instead of tagged `<done>` blocks, visible transcript text
+  keeps private reasoning hidden while preserving thinking metadata,
+  and higher-level agent config surfaces keep thinking settings wired
+  through local-model stages.
+
 ## v0.7.32
 
 ### Added

--- a/crates/harn-modules/src/stdlib/stdlib_acp.harn
+++ b/crates/harn-modules/src/stdlib/stdlib_acp.harn
@@ -1,71 +1,31 @@
-// std/acp — Canonical Agent Client Protocol envelope types.
-//
-// These type aliases match the ACP `sessionUpdate` schema
-// byte-for-byte, so a pipeline that declares `-> SessionUpdate` (or
-// one of the concrete variants below) can be validated at the
-// Harn→ACP boundary by the Harn type checker instead of relying on
-// the host bridge as the only enforcement point.
-//
-// Import with: `import "std/acp"`. See `docs/src/mcp-and-acp.md`
-// ("Typed pipeline returns") for end-to-end usage.
+/**
+ * std/acp — Canonical Agent Client Protocol envelope types.
+ *
+ * These type aliases match the ACP `sessionUpdate` schema
+ * byte-for-byte, so a pipeline that declares `-> SessionUpdate` (or
+ * one of the concrete variants below) can be validated at the
+ * Harn→ACP boundary by the Harn type checker instead of relying on
+ * the host bridge as the only enforcement point.
+ *
+ * Import with: `import "std/acp"`. See `docs/src/mcp-and-acp.md`
+ * ("Typed pipeline returns") for end-to-end usage.
+ */
+type AgentMessageChunk = {sessionUpdate: string, content: {type: string, text: string | nil, annotations: dict | nil}}
 
-type AgentMessageChunk = {
-  sessionUpdate: string,
-  content: {
-    type: string,
-    text: string | nil,
-    annotations: dict | nil,
-  },
-}
+type ToolCall = {sessionUpdate: string, toolCallId: string, title: string | nil, kind: string | nil, status: string | nil, content: list<dict> | nil, locations: list<dict> | nil, rawInput: dict | nil, rawOutput: dict | nil}
 
-type ToolCall = {
-  sessionUpdate: string,
-  toolCallId: string,
-  title: string | nil,
-  kind: string | nil,
-  status: string | nil,
-  content: list<dict> | nil,
-  locations: list<dict> | nil,
-  rawInput: dict | nil,
-  rawOutput: dict | nil,
-}
+type ToolCallUpdate = {sessionUpdate: string, toolCallId: string, status: string | nil, title: string | nil, content: list<dict> | nil, locations: list<dict> | nil, rawOutput: dict | nil}
 
-type ToolCallUpdate = {
-  sessionUpdate: string,
-  toolCallId: string,
-  status: string | nil,
-  title: string | nil,
-  content: list<dict> | nil,
-  locations: list<dict> | nil,
-  rawOutput: dict | nil,
-}
+type Plan = {sessionUpdate: string, entries: list<{content: string, priority: string | nil, status: string | nil}>}
 
-type Plan = {
-  sessionUpdate: string,
-  entries: list<{
-    content: string,
-    priority: string | nil,
-    status: string | nil,
-  }>,
-}
+type Handoff = {sessionUpdate: string, handoffId: string, artifactId: string | nil, handoff: dict}
 
-type SessionUpdate = AgentMessageChunk | ToolCall | ToolCallUpdate | Plan
+type SessionUpdate = AgentMessageChunk | ToolCall | ToolCallUpdate | Plan | Handoff
 
-type PipelineResult = {
-  text: string | nil,
-  events: list<SessionUpdate> | nil,
-  run_record: dict | nil,
-}
+type PipelineResult = {text: string | nil, events: list<SessionUpdate> | nil, run_record: dict | nil}
 
 pub fn agent_message_chunk(text) {
-  return {
-    sessionUpdate: "agent_message_chunk",
-    content: {
-      type: "text",
-      text: text,
-      annotations: nil,
-    },
-  }
+  return {sessionUpdate: "agent_message_chunk", content: {type: "text", text: text, annotations: nil}}
 }
 
 pub fn tool_call(tool_call_id, title) {
@@ -95,8 +55,9 @@ pub fn tool_call_update(tool_call_id, status) {
 }
 
 pub fn plan(entries) {
-  return {
-    sessionUpdate: "plan",
-    entries: entries,
-  }
+  return {sessionUpdate: "plan", entries: entries}
+}
+
+pub fn handoff_update(handoff_id, artifact_id, handoff) {
+  return {sessionUpdate: "handoff", handoffId: handoff_id, artifactId: artifact_id, handoff: handoff}
 }


### PR DESCRIPTION
## Summary
- promote the changelog top entry to `v0.7.33` for the merged #513-#521 batch
- sync the published `harn-modules` `std/acp` mirror with the live ACP stdlib, including typed handoff support and HarnDoc

## Validation
- `CODEX_WORKTREE_PATH=/tmp/harn-release-v0.7.33-take CARGO_TARGET_DIR=/tmp/harn-release-v0.7.33-target cargo fmt --all`
- `CODEX_WORKTREE_PATH=/tmp/harn-release-v0.7.33-take CARGO_TARGET_DIR=/tmp/harn-release-v0.7.33-target ./scripts/release_gate.sh audit`
- `CODEX_WORKTREE_PATH=/tmp/harn-release-v0.7.33-take CARGO_TARGET_DIR=/tmp/harn-release-v0.7.33-target ./scripts/verify_crate_packages.sh`