### PR TITLE
Implement eval v2 replay tooling

### DIFF
--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -86,6 +86,8 @@ SCRIPTING
     Portal(PortalArgs),
     /// Replay and inspect historical trigger dispatches from the event log.
     Trigger(TriggerArgs),
+    /// Import third-party eval traces into replayable Harn fixtures.
+    Trace(TraceArgs),
     /// Query and manage trust-graph autonomy state.
     Trust(TrustArgs),
     /// Query and verify trust-graph autonomy state.
@@ -332,6 +334,9 @@ pub(crate) struct TestArgs {
     /// Replay LLM fixtures from .harn-fixtures/.
     #[arg(long)]
     pub replay: bool,
+    /// Record then replay each selected pipeline and assert deterministic output.
+    #[arg(long)]
+    pub determinism: bool,
     /// Extra skill-discovery roots (repeatable). See `harn run
     /// --skill-dir` — applied the same way to user tests and
     /// conformance fixtures so bundled `skills/` dirs are picked up.
@@ -860,6 +865,31 @@ pub(crate) struct TriggerCancelArgs {
     /// Max operations per second for bulk runs. Omit to run without throttling.
     #[arg(long = "rate-limit", value_name = "OPS_PER_SEC")]
     pub rate_limit: Option<f64>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct TraceArgs {
+    #[command(subcommand)]
+    pub command: TraceCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum TraceCommand {
+    /// Convert a generic JSONL trace into a replayable `--llm-mock` fixture.
+    Import(TraceImportArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct TraceImportArgs {
+    /// Source JSONL trace file with `{prompt,response,tool_calls}` records.
+    #[arg(long = "trace-file", value_name = "PATH")]
+    pub trace_file: String,
+    /// Optional trace id to filter when the source file contains multiple traces.
+    #[arg(long = "trace-id", value_name = "ID")]
+    pub trace_id: Option<String>,
+    /// Output path for the generated replay fixture JSONL.
+    #[arg(long = "output", value_name = "PATH")]
+    pub output: String,
 }
 
 #[derive(Debug, Args)]
@@ -1852,7 +1882,7 @@ mod tests {
         Cli, Command, ConnectCommand, McpCommand, OrchestratorCommand, OrchestratorDeployProvider,
         OrchestratorLogFormat, OrchestratorQueueCommand, PackageCacheCommand, PackageCommand,
         ProjectTemplate, RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand,
-        SkillsCommand, TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
+        SkillsCommand, TraceCommand, TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
     };
     use clap::Parser;
 
@@ -2101,6 +2131,29 @@ mod tests {
     }
 
     #[test]
+    fn test_parses_trace_import_args() {
+        let cli = Cli::parse_from([
+            "harn",
+            "trace",
+            "import",
+            "--trace-file",
+            "langfuse.jsonl",
+            "--trace-id",
+            "trace_123",
+            "--output",
+            "fixtures/imported.jsonl",
+        ]);
+
+        let Command::Trace(args) = cli.command.unwrap() else {
+            panic!("expected trace command");
+        };
+        let TraceCommand::Import(import) = args.command;
+        assert_eq!(import.trace_file, "langfuse.jsonl");
+        assert_eq!(import.trace_id.as_deref(), Some("trace_123"));
+        assert_eq!(import.output, "fixtures/imported.jsonl");
+    }
+
+    #[test]
     fn test_parses_trigger_replay_flags() {
         let cli = Cli::parse_from([
             "harn",
@@ -2122,6 +2175,25 @@ mod tests {
         assert!(replay.diff);
         assert_eq!(replay.as_of.as_deref(), Some("2026-04-19T18:00:00Z"));
         assert!(replay.where_expr.is_none());
+    }
+
+    #[test]
+    fn test_parses_test_determinism_flag() {
+        let cli = Cli::parse_from([
+            "harn",
+            "test",
+            "--determinism",
+            "--filter",
+            "agent",
+            "tests/agent_loop.harn",
+        ]);
+
+        let Command::Test(args) = cli.command.unwrap() else {
+            panic!("expected test command");
+        };
+        assert!(args.determinism);
+        assert_eq!(args.filter.as_deref(), Some("agent"));
+        assert_eq!(args.target.as_deref(), Some("tests/agent_loop.harn"));
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod serve;
 pub(crate) mod skill;
 pub(crate) mod skills;
 pub(crate) mod test;
+pub(crate) mod trace;
 pub(crate) mod trigger;
 pub(crate) mod trust;
 pub(crate) mod viz;

--- a/crates/harn-cli/src/commands/test.rs
+++ b/crates/harn-cli/src/commands/test.rs
@@ -3,8 +3,11 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use regex::Regex;
+use serde_json::Value;
 
-use crate::commands::run::{install_cli_llm_mock_mode, CliLlmMockMode};
+use crate::commands::run::{
+    install_cli_llm_mock_mode, persist_cli_llm_mock_recording, CliLlmMockMode,
+};
 use crate::env_guard::ScopedEnvVar;
 use crate::execute;
 use crate::test_runner;
@@ -570,6 +573,337 @@ pub(crate) async fn run_user_tests(
     if summary.failed > 0 {
         process::exit(1);
     }
+}
+
+fn collect_user_test_files(path_str: &str) -> Result<Vec<PathBuf>, String> {
+    let path = PathBuf::from(path_str);
+    if !path.exists() {
+        return Err(format!("Path not found: {path_str}"));
+    }
+    if path.is_file() {
+        return Ok(vec![path]);
+    }
+    let files = collect_harn_files_sorted(&path);
+    if files.is_empty() {
+        return Err(format!("No .harn files found under {}", path.display()));
+    }
+    Ok(files)
+}
+
+fn sibling_llm_fixture(path: &Path) -> Option<PathBuf> {
+    let fixture = path.with_extension("llm-mock.jsonl");
+    fixture.is_file().then_some(fixture)
+}
+
+fn load_run_records(dir: &Path) -> Result<Vec<harn_vm::orchestration::RunRecord>, String> {
+    let mut paths: Vec<_> = fs::read_dir(dir)
+        .map_err(|error| format!("failed to read {}: {error}", dir.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    paths.sort();
+    paths
+        .iter()
+        .map(|path| {
+            harn_vm::orchestration::load_run_record(path)
+                .map_err(|error| format!("failed to load {}: {error}", path.display()))
+        })
+        .collect()
+}
+
+fn load_transcript_responses(dir: &Path) -> Result<Vec<Value>, String> {
+    let path = dir.join("llm_transcript.jsonl");
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(&path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|event| event.get("type").and_then(Value::as_str) == Some("provider_call_response"))
+        .map(|event| {
+            Ok(serde_json::json!({
+                "provider": event.get("provider").cloned().unwrap_or(Value::Null),
+                "model": event.get("model").cloned().unwrap_or(Value::Null),
+                "text": event.get("text").cloned().unwrap_or(Value::Null),
+                "tool_calls": event.get("tool_calls").cloned().unwrap_or(Value::Null),
+                "input_tokens": event.get("input_tokens").cloned().unwrap_or(Value::Null),
+                "output_tokens": event.get("output_tokens").cloned().unwrap_or(Value::Null),
+                "thinking": event.get("thinking").cloned().unwrap_or(Value::Null),
+            }))
+        })
+        .collect()
+}
+
+async fn execute_determinism_run(
+    source: &str,
+    path: &Path,
+    timeout_ms: u64,
+    llm_mock_mode: &CliLlmMockMode,
+    run_dir: &tempfile::TempDir,
+    transcript_dir: &tempfile::TempDir,
+) -> Result<String, String> {
+    harn_vm::reset_thread_local_state();
+    install_cli_llm_mock_mode(llm_mock_mode)?;
+    let run_dir_guard = ScopedEnvVar::set(
+        harn_vm::runtime_paths::HARN_RUN_DIR_ENV,
+        &run_dir.path().to_string_lossy(),
+    );
+    let transcript_dir_guard = ScopedEnvVar::set(
+        "HARN_LLM_TRANSCRIPT_DIR",
+        &transcript_dir.path().to_string_lossy(),
+    );
+    let result = tokio::time::timeout(
+        std::time::Duration::from_millis(timeout_ms),
+        execute(source, Some(path)),
+    )
+    .await;
+    let persist_result = persist_cli_llm_mock_recording(llm_mock_mode);
+    harn_vm::llm::clear_cli_llm_mock_mode();
+    drop(transcript_dir_guard);
+    drop(run_dir_guard);
+    persist_result?;
+    match result {
+        Ok(Ok(output)) => Ok(output),
+        Ok(Err(error)) => Err(error),
+        Err(_) => Err(format!("timed out after {timeout_ms}ms")),
+    }
+}
+
+fn compare_determinism_artifacts(
+    path: &Path,
+    left_runs: &[harn_vm::orchestration::RunRecord],
+    right_runs: &[harn_vm::orchestration::RunRecord],
+    left_responses: &[Value],
+    right_responses: &[Value],
+) -> Result<(), String> {
+    if left_runs.len() != right_runs.len() {
+        return Err(format!(
+            "{} produced {} run record(s) on the first pass and {} on replay",
+            path.display(),
+            left_runs.len(),
+            right_runs.len()
+        ));
+    }
+    for (idx, (left, right)) in left_runs.iter().zip(right_runs.iter()).enumerate() {
+        let diff = harn_vm::orchestration::diff_run_records(left, right);
+        if !diff.identical
+            || left.tool_recordings != right.tool_recordings
+            || left.hitl_questions != right.hitl_questions
+        {
+            return Err(format!(
+                "{} replay diverged for run #{idx}: identical={} tool_recordings_equal={} hitl_questions_equal={}",
+                path.display(),
+                diff.identical,
+                left.tool_recordings == right.tool_recordings,
+                left.hitl_questions == right.hitl_questions
+            ));
+        }
+    }
+    if left_responses != right_responses {
+        return Err(format!(
+            "{} replay changed provider_call_response output",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+async fn run_determinism_case(path: &Path, timeout_ms: u64) -> Result<(), String> {
+    let source = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let recording_dir = tempfile::Builder::new()
+        .prefix("harn-determinism-record-")
+        .tempdir()
+        .map_err(|error| format!("failed to create determinism tempdir: {error}"))?;
+    let replay_dir = tempfile::Builder::new()
+        .prefix("harn-determinism-replay-")
+        .tempdir()
+        .map_err(|error| format!("failed to create determinism tempdir: {error}"))?;
+    let record_transcript = tempfile::Builder::new()
+        .prefix("harn-determinism-record-llm-")
+        .tempdir()
+        .map_err(|error| format!("failed to create transcript tempdir: {error}"))?;
+    let replay_transcript = tempfile::Builder::new()
+        .prefix("harn-determinism-replay-llm-")
+        .tempdir()
+        .map_err(|error| format!("failed to create transcript tempdir: {error}"))?;
+    let fixture_mode = sibling_llm_fixture(path);
+    let fixture_path = fixture_mode
+        .clone()
+        .unwrap_or_else(|| recording_dir.path().join("fixture.jsonl"));
+    let first_mode = fixture_mode
+        .clone()
+        .map(|fixture_path| CliLlmMockMode::Replay { fixture_path })
+        .unwrap_or_else(|| CliLlmMockMode::Record {
+            fixture_path: fixture_path.clone(),
+        });
+    let second_mode = CliLlmMockMode::Replay {
+        fixture_path: fixture_path.clone(),
+    };
+
+    let first_output = execute_determinism_run(
+        &source,
+        path,
+        timeout_ms,
+        &first_mode,
+        &recording_dir,
+        &record_transcript,
+    )
+    .await?;
+    let second_output = execute_determinism_run(
+        &source,
+        path,
+        timeout_ms,
+        &second_mode,
+        &replay_dir,
+        &replay_transcript,
+    )
+    .await?;
+
+    if first_output != second_output {
+        return Err(format!(
+            "{} replay changed stdout\nfirst:\n{}\nsecond:\n{}",
+            path.display(),
+            first_output,
+            second_output
+        ));
+    }
+
+    let first_runs = load_run_records(recording_dir.path())?;
+    let second_runs = load_run_records(replay_dir.path())?;
+    let first_responses = load_transcript_responses(record_transcript.path())?;
+    let second_responses = load_transcript_responses(replay_transcript.path())?;
+    compare_determinism_artifacts(
+        path,
+        &first_runs,
+        &second_runs,
+        &first_responses,
+        &second_responses,
+    )
+}
+
+pub(crate) async fn run_determinism_tests(path_str: &str, filter: Option<&str>, timeout_ms: u64) {
+    let files = collect_user_test_files(path_str).unwrap_or_else(|error| {
+        eprintln!("{error}");
+        process::exit(1);
+    });
+    let mut passed = 0usize;
+    let mut failed = 0usize;
+    let mut errors = Vec::new();
+
+    for path in files {
+        let rel_path = path.display().to_string();
+        if let Some(pattern) = filter {
+            let matched = if let Some(re_pat) = pattern.strip_prefix("re:") {
+                Regex::new(re_pat).is_ok_and(|re| re.is_match(&rel_path))
+            } else {
+                rel_path.contains(pattern)
+            };
+            if !matched {
+                continue;
+            }
+        }
+
+        match run_determinism_case(&path, timeout_ms).await {
+            Ok(()) => {
+                println!("  \x1b[32mPASS\x1b[0m  {rel_path}");
+                passed += 1;
+            }
+            Err(error) => {
+                println!("  \x1b[31mFAIL\x1b[0m  {rel_path}");
+                failed += 1;
+                errors.push(error);
+            }
+        }
+    }
+
+    println!();
+    if failed > 0 {
+        println!(
+            "\x1b[31m{passed} passed, {failed} failed, {} total\x1b[0m",
+            passed + failed
+        );
+        println!();
+        println!("Failures:");
+        for error in errors {
+            println!("  {error}");
+        }
+        process::exit(1);
+    }
+    println!(
+        "\x1b[32m{passed} passed, {failed} failed, {} total\x1b[0m",
+        passed + failed
+    );
+}
+
+pub(crate) async fn run_conformance_determinism_tests(
+    dir: &str,
+    selection: Option<&str>,
+    filter: Option<&str>,
+    timeout_ms: u64,
+) {
+    let dir_path = PathBuf::from(dir);
+    let suite_root = canonicalize_or_err(&dir_path).unwrap_or_else(|error| {
+        eprintln!("{error}");
+        process::exit(1);
+    });
+    let files = resolve_conformance_selection(&suite_root, selection).unwrap_or_else(|error| {
+        eprintln!("{error}");
+        process::exit(1);
+    });
+    let mut passed = 0usize;
+    let mut failed = 0usize;
+    let mut errors = Vec::new();
+
+    for path in files {
+        let rel_path = path
+            .strip_prefix(&suite_root)
+            .unwrap_or(&path)
+            .display()
+            .to_string();
+        if let Some(pattern) = filter {
+            let matched = if let Some(re_pat) = pattern.strip_prefix("re:") {
+                Regex::new(re_pat).is_ok_and(|re| re.is_match(&rel_path))
+            } else {
+                rel_path.contains(pattern)
+            };
+            if !matched {
+                continue;
+            }
+        }
+        match run_determinism_case(&path, timeout_ms).await {
+            Ok(()) => {
+                println!("  \x1b[32mPASS\x1b[0m  {rel_path}");
+                passed += 1;
+            }
+            Err(error) => {
+                println!("  \x1b[31mFAIL\x1b[0m  {rel_path}");
+                failed += 1;
+                errors.push(error);
+            }
+        }
+    }
+
+    println!();
+    if failed > 0 {
+        println!(
+            "\x1b[31m{passed} passed, {failed} failed, {} total\x1b[0m",
+            passed + failed
+        );
+        println!();
+        println!("Failures:");
+        for error in errors {
+            println!("  {error}");
+        }
+        process::exit(1);
+    }
+    println!(
+        "\x1b[32m{passed} passed, {failed} failed, {} total\x1b[0m",
+        passed + failed
+    );
 }
 
 pub(crate) async fn run_watch_tests(

--- a/crates/harn-cli/src/commands/trace.rs
+++ b/crates/harn-cli/src/commands/trace.rs
@@ -1,0 +1,194 @@
+use std::fs;
+use std::path::Path;
+
+use serde_json::{json, Map, Value};
+
+use crate::cli::{TraceArgs, TraceCommand, TraceImportArgs};
+
+pub(crate) async fn handle(args: TraceArgs) -> Result<(), String> {
+    match args.command {
+        TraceCommand::Import(import) => run_import(import),
+    }
+}
+
+fn run_import(args: TraceImportArgs) -> Result<(), String> {
+    let content = fs::read_to_string(&args.trace_file)
+        .map_err(|error| format!("failed to read {}: {error}", args.trace_file))?;
+    let lines = convert_trace_jsonl(&content, args.trace_id.as_deref())?;
+    let body = if lines.is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", lines.join("\n"))
+    };
+    if let Some(parent) = Path::new(&args.output).parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+        }
+    }
+    fs::write(&args.output, body)
+        .map_err(|error| format!("failed to write {}: {error}", args.output))?;
+    println!("{}", args.output);
+    Ok(())
+}
+
+fn convert_trace_jsonl(content: &str, trace_id: Option<&str>) -> Result<Vec<String>, String> {
+    let mut fixtures = Vec::new();
+    for (idx, raw_line) in content.lines().enumerate() {
+        let line_no = idx + 1;
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(line)
+            .map_err(|error| format!("invalid JSON in trace line {line_no}: {error}"))?;
+        if let Some(expected_trace_id) = trace_id {
+            let actual_trace_id = value.get("trace_id").and_then(Value::as_str);
+            if actual_trace_id != Some(expected_trace_id) {
+                continue;
+            }
+        }
+        fixtures.push(trace_record_to_fixture(&value, line_no)?);
+    }
+    if trace_id.is_some() && fixtures.is_empty() {
+        return Err("trace filter matched no records".to_string());
+    }
+    Ok(fixtures)
+}
+
+fn trace_record_to_fixture(value: &Value, line_no: usize) -> Result<String, String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| format!("trace line {line_no} must be a JSON object"))?;
+    if object.get("prompt").is_none() {
+        return Err(format!("trace line {line_no} is missing `prompt`"));
+    }
+
+    let response = object.get("response").unwrap_or(&Value::Null);
+    let top_level_tool_calls = parse_tool_calls(object.get("tool_calls"))?;
+    let response_tool_calls = parse_tool_calls(response.get("tool_calls"))?;
+    let tool_calls = if !top_level_tool_calls.is_empty() {
+        top_level_tool_calls
+    } else {
+        response_tool_calls
+    };
+
+    let text = match response {
+        Value::String(text) => text.clone(),
+        Value::Object(map) => optional_string(map, "text")
+            .or_else(|| optional_string(map, "content"))
+            .unwrap_or_default(),
+        Value::Null => String::new(),
+        _ => {
+            return Err(format!(
+                "trace line {line_no} has unsupported `response`; expected string or object"
+            ))
+        }
+    };
+
+    let mut fixture = Map::new();
+    if !text.is_empty() {
+        fixture.insert("text".to_string(), Value::String(text));
+    }
+    if !tool_calls.is_empty() {
+        fixture.insert("tool_calls".to_string(), Value::Array(tool_calls));
+    }
+    fixture.insert(
+        "model".to_string(),
+        Value::String(
+            object
+                .get("model")
+                .and_then(Value::as_str)
+                .or_else(|| response.get("model").and_then(Value::as_str))
+                .unwrap_or("imported-trace")
+                .to_string(),
+        ),
+    );
+    if let Some(provider) = object
+        .get("provider")
+        .and_then(Value::as_str)
+        .or_else(|| response.get("provider").and_then(Value::as_str))
+    {
+        fixture.insert("provider".to_string(), Value::String(provider.to_string()));
+    }
+    if let Some(input_tokens) = object
+        .get("input_tokens")
+        .and_then(Value::as_i64)
+        .or_else(|| response.get("input_tokens").and_then(Value::as_i64))
+    {
+        fixture.insert("input_tokens".to_string(), json!(input_tokens));
+    }
+    if let Some(output_tokens) = object
+        .get("output_tokens")
+        .and_then(Value::as_i64)
+        .or_else(|| response.get("output_tokens").and_then(Value::as_i64))
+    {
+        fixture.insert("output_tokens".to_string(), json!(output_tokens));
+    }
+    serde_json::to_string(&Value::Object(fixture)).map_err(|error| {
+        format!("failed to serialize imported fixture for line {line_no}: {error}")
+    })
+}
+
+fn parse_tool_calls(value: Option<&Value>) -> Result<Vec<Value>, String> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let Some(items) = value.as_array() else {
+        return Err("tool_calls must be an array".to_string());
+    };
+    items
+        .iter()
+        .enumerate()
+        .map(|(idx, item)| {
+            let object = item
+                .as_object()
+                .ok_or_else(|| format!("tool_calls[{idx}] must be an object"))?;
+            let name = optional_string(object, "name")
+                .ok_or_else(|| format!("tool_calls[{idx}] is missing `name`"))?;
+            Ok(json!({
+                "name": name,
+                "args": object
+                    .get("arguments")
+                    .cloned()
+                    .or_else(|| object.get("args").cloned())
+                    .unwrap_or_else(|| json!({})),
+            }))
+        })
+        .collect()
+}
+
+fn optional_string(object: &Map<String, Value>, key: &str) -> Option<String> {
+    object.get(key).and_then(Value::as_str).map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::convert_trace_jsonl;
+
+    #[test]
+    fn converts_generic_trace_jsonl_to_cli_fixture() {
+        let trace = concat!(
+            "{\"trace_id\":\"trace-1\",\"prompt\":\"Question\",\"response\":{\"text\":\"Answer\",\"model\":\"gpt-test\"},\"tool_calls\":[{\"name\":\"read_file\",\"arguments\":{\"path\":\"README.md\"}}]}\n",
+            "{\"trace_id\":\"trace-2\",\"prompt\":\"Ignored\",\"response\":\"Nope\"}\n"
+        );
+
+        let fixtures = convert_trace_jsonl(trace, Some("trace-1")).unwrap();
+
+        assert_eq!(fixtures.len(), 1);
+        assert!(fixtures[0].contains("\"text\":\"Answer\""));
+        assert!(fixtures[0].contains("\"model\":\"gpt-test\""));
+        assert!(fixtures[0].contains("\"name\":\"read_file\""));
+    }
+
+    #[test]
+    fn rejects_empty_trace_filter_result() {
+        let error = convert_trace_jsonl(
+            "{\"trace_id\":\"trace-1\",\"prompt\":\"Question\",\"response\":\"Answer\"}\n",
+            Some("trace-missing"),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("matched no records"));
+    }
+}

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -280,78 +280,126 @@ async fn main() {
             commands::check::fmt_targets(&targets, args.check, &opts);
         }
         Command::Test(args) => {
-            if args.record {
-                harn_vm::llm::set_replay_mode(
-                    harn_vm::llm::LlmReplayMode::Record,
-                    ".harn-fixtures",
-                );
-            } else if args.replay {
-                harn_vm::llm::set_replay_mode(
-                    harn_vm::llm::LlmReplayMode::Replay,
-                    ".harn-fixtures",
-                );
-            }
-
-            if let Some(t) = args.target.as_deref() {
-                if t == "conformance" {
-                    commands::test::run_conformance_tests(
-                        t,
-                        args.selection.as_deref(),
-                        args.filter.as_deref(),
-                        args.junit.as_deref(),
-                        args.timeout,
-                        args.verbose,
-                        args.timing,
-                    )
-                    .await;
-                } else if args.selection.is_some() {
-                    command_error(
-                        "only `harn test conformance` accepts a second positional target",
-                    );
-                } else if args.watch {
-                    commands::test::run_watch_tests(
-                        t,
-                        args.filter.as_deref(),
-                        args.timeout,
-                        args.parallel,
-                    )
-                    .await;
+            if args.determinism {
+                if args.watch {
+                    command_error("--determinism cannot be combined with --watch");
+                }
+                if args.record || args.replay {
+                    command_error("--determinism manages its own record/replay cycle");
+                }
+                if let Some(t) = args.target.as_deref() {
+                    if t == "conformance" {
+                        commands::test::run_conformance_determinism_tests(
+                            t,
+                            args.selection.as_deref(),
+                            args.filter.as_deref(),
+                            args.timeout,
+                        )
+                        .await;
+                    } else if args.selection.is_some() {
+                        command_error(
+                            "only `harn test conformance` accepts a second positional target",
+                        );
+                    } else {
+                        commands::test::run_determinism_tests(
+                            t,
+                            args.filter.as_deref(),
+                            args.timeout,
+                        )
+                        .await;
+                    }
                 } else {
-                    commands::test::run_user_tests(
-                        t,
+                    let test_dir = if PathBuf::from("tests").is_dir() {
+                        "tests".to_string()
+                    } else {
+                        command_error("no path specified and no tests/ directory found");
+                    };
+                    if args.selection.is_some() {
+                        command_error(
+                            "only `harn test conformance` accepts a second positional target",
+                        );
+                    }
+                    commands::test::run_determinism_tests(
+                        &test_dir,
                         args.filter.as_deref(),
                         args.timeout,
-                        args.parallel,
                     )
                     .await;
                 }
             } else {
-                let test_dir = if PathBuf::from("tests").is_dir() {
-                    "tests".to_string()
-                } else {
-                    command_error("no path specified and no tests/ directory found");
-                };
-                if args.selection.is_some() {
-                    command_error(
-                        "only `harn test conformance` accepts a second positional target",
+                if args.record {
+                    harn_vm::llm::set_replay_mode(
+                        harn_vm::llm::LlmReplayMode::Record,
+                        ".harn-fixtures",
+                    );
+                } else if args.replay {
+                    harn_vm::llm::set_replay_mode(
+                        harn_vm::llm::LlmReplayMode::Replay,
+                        ".harn-fixtures",
                     );
                 }
-                if args.watch {
-                    commands::test::run_watch_tests(
-                        &test_dir,
-                        args.filter.as_deref(),
-                        args.timeout,
-                        args.parallel,
-                    )
-                    .await;
+
+                if let Some(t) = args.target.as_deref() {
+                    if t == "conformance" {
+                        commands::test::run_conformance_tests(
+                            t,
+                            args.selection.as_deref(),
+                            args.filter.as_deref(),
+                            args.junit.as_deref(),
+                            args.timeout,
+                            args.verbose,
+                            args.timing,
+                        )
+                        .await;
+                    } else if args.selection.is_some() {
+                        command_error(
+                            "only `harn test conformance` accepts a second positional target",
+                        );
+                    } else if args.watch {
+                        commands::test::run_watch_tests(
+                            t,
+                            args.filter.as_deref(),
+                            args.timeout,
+                            args.parallel,
+                        )
+                        .await;
+                    } else {
+                        commands::test::run_user_tests(
+                            t,
+                            args.filter.as_deref(),
+                            args.timeout,
+                            args.parallel,
+                        )
+                        .await;
+                    }
                 } else {
-                    commands::test::run_user_tests(
-                        &test_dir,
-                        args.filter.as_deref(),
-                        args.timeout,
-                        args.parallel,
-                    )
-                    .await;
+                    let test_dir = if PathBuf::from("tests").is_dir() {
+                        "tests".to_string()
+                    } else {
+                        command_error("no path specified and no tests/ directory found");
+                    };
+                    if args.selection.is_some() {
+                        command_error(
+                            "only `harn test conformance` accepts a second positional target",
+                        );
+                    }
+                    if args.watch {
+                        commands::test::run_watch_tests(
+                            &test_dir,
+                            args.filter.as_deref(),
+                            args.timeout,
+                            args.parallel,
+                        )
+                        .await;
+                    } else {
+                        commands::test::run_user_tests(
+                            &test_dir,
+                            args.filter.as_deref(),
+                            args.timeout,
+                            args.parallel,
+                        )
+                        .await;
+                    }
                 }
             }
         }
@@ -392,6 +440,12 @@ async fn main() {
         }
         Command::Trigger(args) => {
             if let Err(error) = commands::trigger::handle(args).await {
+                eprintln!("error: {error}");
+                process::exit(1);
+            }
+        }
+        Command::Trace(args) => {
+            if let Err(error) = commands::trace::handle(args).await {
                 eprintln!("error: {error}");
                 process::exit(1);
             }
@@ -674,6 +728,7 @@ fn inspect_run_record(path: &str, compare: Option<&str>) {
     println!("Artifacts: {}", run.artifacts.len());
     println!("Transitions: {}", run.transitions.len());
     println!("Checkpoints: {}", run.checkpoints.len());
+    println!("HITL questions: {}", run.hitl_questions.len());
     if let Some(observability) = &run.observability {
         println!("Planner rounds: {}", observability.planner_rounds.len());
         println!("Research facts: {}", observability.research_fact_count);

--- a/crates/harn-vm/src/orchestration/records.rs
+++ b/crates/harn-vm/src/orchestration/records.rs
@@ -9,7 +9,9 @@ use super::{
     default_run_dir, new_id, now_rfc3339, parse_json_payload, parse_json_value, sync_run_handoffs,
     ArtifactRecord, CapabilityPolicy, HandoffArtifact,
 };
-use crate::event_log::{active_event_log, EventLog, LogEvent as EventLogRecord, Topic};
+use crate::event_log::{
+    active_event_log, AnyEventLog, EventLog, LogEvent as EventLogRecord, Topic,
+};
 use crate::llm::vm_value_to_json;
 use crate::triggers::{SignatureStatus, TriggerEvent};
 use crate::value::{VmError, VmValue};
@@ -117,8 +119,21 @@ pub struct ReplayFixture {
     pub workflow_id: String,
     pub workflow_name: Option<String>,
     pub created_at: String,
+    pub eval_kind: Option<String>,
+    pub clarifying_question: Option<ClarifyingQuestionEvalSpec>,
     pub expected_status: String,
     pub stage_assertions: Vec<ReplayStageAssertion>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ClarifyingQuestionEvalSpec {
+    pub expected_question: Option<String>,
+    pub accepted_questions: Vec<String>,
+    pub required_terms: Vec<String>,
+    pub forbidden_terms: Vec<String>,
+    pub min_questions: usize,
+    pub max_questions: Option<usize>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -386,6 +401,16 @@ pub struct EvalSuiteCase {
     pub compare_to: Option<String>,
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct RunHitlQuestionRecord {
+    pub request_id: String,
+    pub prompt: String,
+    pub agent: String,
+    pub trace_id: Option<String>,
+    pub asked_at: String,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct RunRecord {
@@ -416,6 +441,7 @@ pub struct RunRecord {
     pub observability: Option<RunObservabilityRecord>,
     pub trace_spans: Vec<RunTraceSpanRecord>,
     pub tool_recordings: Vec<ToolCallRecord>,
+    pub hitl_questions: Vec<RunHitlQuestionRecord>,
     pub metadata: BTreeMap<String, serde_json::Value>,
     pub persisted_path: Option<String>,
 }
@@ -493,6 +519,119 @@ pub struct RunExecutionRecord {
 
 fn compact_json_value(value: &serde_json::Value) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| value.to_string())
+}
+
+fn normalize_question_text(text: &str) -> String {
+    text.chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch.is_whitespace() {
+                ch.to_ascii_lowercase()
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn clarifying_min_questions(spec: &ClarifyingQuestionEvalSpec) -> usize {
+    spec.min_questions.max(1)
+}
+
+fn clarifying_max_questions(spec: &ClarifyingQuestionEvalSpec) -> usize {
+    spec.max_questions.unwrap_or(1).max(1)
+}
+
+fn read_topic_records(
+    log: &AnyEventLog,
+    topic: &Topic,
+) -> Vec<(crate::event_log::EventId, EventLogRecord)> {
+    let mut from = None;
+    let mut records = Vec::new();
+    loop {
+        let batch =
+            futures::executor::block_on(log.read_range(topic, from, 256)).unwrap_or_default();
+        if batch.is_empty() {
+            break;
+        }
+        from = batch.last().map(|(event_id, _)| *event_id);
+        records.extend(batch);
+    }
+    records
+}
+
+fn merge_hitl_questions_from_active_log(run: &mut RunRecord) {
+    let Some(log) = active_event_log() else {
+        return;
+    };
+    let topic = Topic::new(crate::HITL_QUESTIONS_TOPIC)
+        .expect("static hitl.questions topic should always be valid");
+    let mut merged = run
+        .hitl_questions
+        .iter()
+        .cloned()
+        .map(|question| (question.request_id.clone(), question))
+        .collect::<BTreeMap<_, _>>();
+
+    for (_, event) in read_topic_records(log.as_ref(), &topic) {
+        if event.kind != "hitl.question_asked" {
+            continue;
+        }
+        let payload = &event.payload;
+        let matches_run = event
+            .headers
+            .get("run_id")
+            .is_some_and(|value| value == &run.id)
+            || payload
+                .get("run_id")
+                .and_then(|value| value.as_str())
+                .is_some_and(|value| value == run.id);
+        if !matches_run {
+            continue;
+        }
+        let request_id = payload
+            .get("request_id")
+            .and_then(|value| value.as_str())
+            .or_else(|| event.headers.get("request_id").map(String::as_str))
+            .unwrap_or_default();
+        let prompt = payload
+            .get("payload")
+            .and_then(|value| value.get("prompt"))
+            .and_then(|value| value.as_str())
+            .unwrap_or_default();
+        if request_id.is_empty() || prompt.is_empty() {
+            continue;
+        }
+        merged.insert(
+            request_id.to_string(),
+            RunHitlQuestionRecord {
+                request_id: request_id.to_string(),
+                prompt: prompt.to_string(),
+                agent: payload
+                    .get("agent")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                trace_id: payload
+                    .get("trace_id")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string),
+                asked_at: payload
+                    .get("requested_at")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+            },
+        );
+    }
+
+    run.hitl_questions = merged.into_values().collect();
+    run.hitl_questions.sort_by(|left, right| {
+        (left.asked_at.as_str(), left.request_id.as_str())
+            .cmp(&(right.asked_at.as_str(), right.request_id.as_str()))
+    });
 }
 
 fn signature_status_label(status: &SignatureStatus) -> &'static str {
@@ -1265,6 +1404,7 @@ pub fn normalize_run_record(value: &VmValue) -> Result<RunRecord, VmError> {
     if run.replay_fixture.is_none() {
         run.replay_fixture = Some(replay_fixture_from_run(&run));
     }
+    merge_hitl_questions_from_active_log(&mut run);
     sync_run_handoffs(&mut run);
     if run.observability.is_none() {
         let persisted_path = run.persisted_path.clone();
@@ -1477,6 +1617,7 @@ pub fn save_run_record(run: &RunRecord, path: Option<&str>) -> Result<String, Vm
         .map(PathBuf::from)
         .unwrap_or_else(|| default_run_dir().join(format!("{}.json", run.id)));
     let mut materialized = run.clone();
+    merge_hitl_questions_from_active_log(&mut materialized);
     if materialized.replay_fixture.is_none() {
         materialized.replay_fixture = Some(replay_fixture_from_run(&materialized));
     }
@@ -1527,6 +1668,8 @@ pub fn replay_fixture_from_run(run: &RunRecord) -> ReplayFixture {
         workflow_id: run.workflow_id.clone(),
         workflow_name: run.workflow_name.clone(),
         created_at: now_rfc3339(),
+        eval_kind: Some("replay".to_string()),
+        clarifying_question: None,
         expected_status: run.status.clone(),
         stage_assertions: run
             .stages
@@ -1552,6 +1695,9 @@ pub fn replay_fixture_from_run(run: &RunRecord) -> ReplayFixture {
 }
 
 pub fn evaluate_run_against_fixture(run: &RunRecord, fixture: &ReplayFixture) -> ReplayEvalReport {
+    if fixture.eval_kind.as_deref() == Some("clarifying_question") {
+        return evaluate_clarifying_question(run, fixture);
+    }
     let mut failures = Vec::new();
     if run.status != fixture.expected_status {
         failures.push(format!(
@@ -1605,6 +1751,94 @@ pub fn evaluate_run_against_fixture(run: &RunRecord, fixture: &ReplayFixture) ->
                 ));
             }
         }
+    }
+
+    ReplayEvalReport {
+        pass: failures.is_empty(),
+        failures,
+        stage_count: run.stages.len(),
+    }
+}
+
+fn evaluate_clarifying_question(run: &RunRecord, fixture: &ReplayFixture) -> ReplayEvalReport {
+    let mut failures = Vec::new();
+    let spec = fixture.clarifying_question.clone().unwrap_or_default();
+    let min_questions = clarifying_min_questions(&spec);
+    let max_questions = clarifying_max_questions(&spec);
+    let questions = &run.hitl_questions;
+
+    if run.status != fixture.expected_status {
+        failures.push(format!(
+            "run status mismatch: expected {}, got {}",
+            fixture.expected_status, run.status
+        ));
+    }
+    if questions.len() < min_questions {
+        failures.push(format!(
+            "expected at least {min_questions} clarifying question(s), got {}",
+            questions.len()
+        ));
+    }
+    if questions.len() > max_questions {
+        failures.push(format!(
+            "expected at most {max_questions} clarifying question(s), got {}",
+            questions.len()
+        ));
+    }
+
+    let normalized_expected = spec
+        .expected_question
+        .as_deref()
+        .map(normalize_question_text);
+    let normalized_accepted = spec
+        .accepted_questions
+        .iter()
+        .map(|question| normalize_question_text(question))
+        .collect::<Vec<_>>();
+    let required_terms = spec
+        .required_terms
+        .iter()
+        .map(|term| normalize_question_text(term))
+        .collect::<Vec<_>>();
+    let forbidden_terms = spec
+        .forbidden_terms
+        .iter()
+        .map(|term| normalize_question_text(term))
+        .collect::<Vec<_>>();
+
+    let matched = questions.iter().any(|question| {
+        let normalized = normalize_question_text(&question.prompt);
+        let matches_expected = normalized_expected
+            .as_ref()
+            .is_none_or(|expected| &normalized == expected)
+            && (normalized_accepted.is_empty()
+                || normalized_accepted
+                    .iter()
+                    .any(|candidate| candidate == &normalized));
+        let has_required_terms = required_terms
+            .iter()
+            .all(|term| normalized.contains(term.as_str()));
+        let avoids_forbidden_terms = forbidden_terms
+            .iter()
+            .all(|term| !normalized.contains(term.as_str()));
+        matches_expected && has_required_terms && avoids_forbidden_terms
+    });
+
+    if !questions.is_empty()
+        && (!normalized_accepted.is_empty()
+            || normalized_expected.is_some()
+            || !required_terms.is_empty()
+            || !forbidden_terms.is_empty())
+        && !matched
+    {
+        failures.push(format!(
+            "no clarifying question matched fixture; actual questions: {}",
+            questions
+                .iter()
+                .map(|question| format!("{:?}", question.prompt))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
     }
 
     ReplayEvalReport {

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -263,6 +263,7 @@ fn replay_fixture_round_trip_passes() {
         observability: None,
         trace_spans: vec![],
         tool_recordings: vec![],
+        hitl_questions: vec![],
         metadata: BTreeMap::new(),
         persisted_path: None,
     };
@@ -314,6 +315,96 @@ fn replay_eval_suite_reports_failed_case() {
     assert_eq!(suite.total, 2);
     assert_eq!(suite.failed, 1);
     assert!(suite.cases.iter().any(|case| !case.pass));
+}
+
+#[test]
+fn clarifying_question_eval_requires_matching_hitl_prompt() {
+    let run = RunRecord {
+        id: "run_clarify".to_string(),
+        workflow_id: "wf".to_string(),
+        status: "completed".to_string(),
+        hitl_questions: vec![RunHitlQuestionRecord {
+            request_id: "hitl_question_1".to_string(),
+            prompt: "Which repository should I patch?".to_string(),
+            agent: "planner".to_string(),
+            trace_id: Some("trace-1".to_string()),
+            asked_at: "2026-04-23T12:00:00Z".to_string(),
+        }],
+        ..Default::default()
+    };
+    let fixture = ReplayFixture {
+        type_name: "replay_fixture".to_string(),
+        id: "fixture_clarify".to_string(),
+        source_run_id: run.id.clone(),
+        workflow_id: run.workflow_id.clone(),
+        created_at: "2026-04-23T12:00:01Z".to_string(),
+        eval_kind: Some("clarifying_question".to_string()),
+        clarifying_question: Some(ClarifyingQuestionEvalSpec {
+            required_terms: vec!["repository".to_string()],
+            forbidden_terms: vec!["branch".to_string()],
+            ..Default::default()
+        }),
+        expected_status: "completed".to_string(),
+        stage_assertions: vec![],
+        ..Default::default()
+    };
+
+    let report = evaluate_run_against_fixture(&run, &fixture);
+
+    assert!(report.pass, "failures: {:?}", report.failures);
+}
+
+#[test]
+fn save_run_record_materializes_hitl_questions_from_active_event_log() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    crate::event_log::reset_active_event_log();
+    let log =
+        crate::event_log::install_default_for_base_dir(temp_dir.path()).expect("install event log");
+    let topic = crate::event_log::Topic::new(crate::HITL_QUESTIONS_TOPIC).unwrap();
+    futures::executor::block_on(
+        log.append(
+            &topic,
+            crate::event_log::LogEvent::new(
+                "hitl.question_asked",
+                serde_json::json!({
+                    "request_id": "hitl_question_1",
+                    "kind": "question",
+                    "agent": "planner",
+                    "trace_id": "trace_1",
+                    "run_id": "run_hitl",
+                    "requested_at": "2026-04-23T12:00:00Z",
+                    "payload": {
+                        "prompt": "Which environment should I deploy to?"
+                    }
+                }),
+            )
+            .with_headers(std::collections::BTreeMap::from([
+                ("request_id".to_string(), "hitl_question_1".to_string()),
+                ("trace_id".to_string(), "trace_1".to_string()),
+                ("run_id".to_string(), "run_hitl".to_string()),
+            ])),
+        ),
+    )
+    .unwrap();
+
+    let path = temp_dir.path().join("run.json");
+    let run = RunRecord {
+        id: "run_hitl".to_string(),
+        workflow_id: "wf".to_string(),
+        status: "completed".to_string(),
+        ..Default::default()
+    };
+
+    save_run_record(&run, Some(path.to_str().unwrap())).unwrap();
+    let loaded = load_run_record(&path).unwrap();
+
+    assert_eq!(loaded.hitl_questions.len(), 1);
+    assert_eq!(
+        loaded.hitl_questions[0].prompt,
+        "Which environment should I deploy to?"
+    );
+
+    crate::event_log::reset_active_event_log();
 }
 
 #[test]

--- a/crates/harn-vm/src/stdlib/hitl.rs
+++ b/crates/harn-vm/src/stdlib/hitl.rs
@@ -126,6 +126,8 @@ struct HitlRequestEnvelope {
     #[serde(default)]
     agent: String,
     trace_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    run_id: Option<String>,
     requested_at: String,
     payload: JsonValue,
 }
@@ -273,6 +275,7 @@ pub async fn append_approval_request_on(
         kind: HitlRequestKind::Approval,
         agent: agent.into(),
         trace_id: trace_id.clone(),
+        run_id: None,
         requested_at: now_rfc3339(),
         payload: json!({
             "action": action.into(),
@@ -306,6 +309,7 @@ async fn ask_user_impl(args: &[VmValue]) -> Result<VmValue, VmError> {
             .map(|keys| keys.agent.clone())
             .unwrap_or_default(),
         trace_id: trace_id.clone(),
+        run_id: crate::orchestration::current_mutation_session().and_then(|session| session.run_id),
         requested_at: now_rfc3339(),
         payload: json!({
             "prompt": prompt,
@@ -373,6 +377,7 @@ async fn request_approval_impl(args: &[VmValue]) -> Result<VmValue, VmError> {
             .map(|keys| keys.agent.clone())
             .unwrap_or_default(),
         trace_id: trace_id.clone(),
+        run_id: crate::orchestration::current_mutation_session().and_then(|session| session.run_id),
         requested_at: now_rfc3339(),
         payload: json!({
             "action": action,
@@ -444,6 +449,7 @@ async fn dual_control_impl(args: &[VmValue]) -> Result<VmValue, VmError> {
             .map(|keys| keys.agent.clone())
             .unwrap_or_default(),
         trace_id: trace_id.clone(),
+        run_id: crate::orchestration::current_mutation_session().and_then(|session| session.run_id),
         requested_at: now_rfc3339(),
         payload: json!({
             "n": n,
@@ -514,6 +520,7 @@ async fn escalate_to_impl(args: &[VmValue]) -> Result<VmValue, VmError> {
             .map(|keys| keys.agent.clone())
             .unwrap_or_default(),
         trace_id: trace_id.clone(),
+        run_id: crate::orchestration::current_mutation_session().and_then(|session| session.run_id),
         requested_at: now_rfc3339(),
         payload: json!({
             "role": role,
@@ -1318,7 +1325,11 @@ fn next_request_id(kind: HitlRequestKind, dispatch_keys: Option<&DispatchKeys>) 
 }
 
 fn request_headers(request: &HitlRequestEnvelope) -> BTreeMap<String, String> {
-    headers_with_trace(&request.request_id, &request.trace_id)
+    let mut headers = headers_with_trace(&request.request_id, &request.trace_id);
+    if let Some(run_id) = request.run_id.as_ref() {
+        headers.insert("run_id".to_string(), run_id.clone());
+    }
+    headers
 }
 
 fn response_headers(request_id: &str) -> BTreeMap<String, String> {

--- a/crates/harn-vm/src/stdlib/workflow/register.rs
+++ b/crates/harn-vm/src/stdlib/workflow/register.rs
@@ -170,6 +170,7 @@ pub(in crate::stdlib) async fn execute_workflow(
         observability: None,
         trace_spans: Vec::new(),
         tool_recordings: Vec::new(),
+        hitl_questions: Vec::new(),
         metadata: BTreeMap::new(),
         persisted_path: None,
     });

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -545,6 +545,7 @@ harn eval .harn-runs/<run>.json
 harn eval .harn-runs/<run>.json --compare baseline.json
 harn eval .harn-runs/
 harn eval evals/regression.json
+harn eval evals/clarifying-question.json
 harn eval --llm-mock fixtures.jsonl --structural-experiment doubled_prompt pipeline.harn
 ```
 
@@ -553,6 +554,12 @@ harn eval --llm-mock fixtures.jsonl --structural-experiment doubled_prompt pipel
 - a single run record JSON file
 - a directory of run record JSON files
 - an eval suite manifest JSON file with grouped cases and optional baseline comparisons
+
+Clarifying-question evals use an explicit fixture with
+`"eval_kind": "clarifying_question"`. The fixture checks persisted
+`ask_user(...)` prompts captured in the run record and can enforce a
+single minimal question via `required_terms`, `forbidden_terms`, and
+question-count bounds.
 
 When `path` is a `.harn` pipeline file, `--structural-experiment <spec>` runs
 the pipeline twice in isolated temp run directories: once as the baseline and
@@ -661,6 +668,23 @@ caps bulk execution throughput in operations per second.
 Every bulk replay appends an audit envelope to
 `trigger.operations.audit` describing who ran it, when, the normalized
 filter, and the affected records.
+
+## harn trace import
+
+Convert a third-party eval trace into a standard `--llm-mock` fixture.
+
+```bash
+harn trace import \
+  --trace-file traces/generic.jsonl \
+  --trace-id trace_123 \
+  --output fixtures/imported.jsonl
+```
+
+The source file is JSONL. Each line should contain at least
+`{prompt, response}` and may also include `tool_calls`, `model`,
+`provider`, token counts, and `trace_id`. The generated fixture can be
+used directly with `harn run --llm-mock ...`, `harn eval
+--llm-mock ...`, or `harn test --determinism`.
 
 ## harn trigger cancel
 

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -161,6 +161,68 @@ harn playground --script pipeline.harn --llm-mock-record fixtures.jsonl
 harn playground --script pipeline.harn --llm-mock fixtures.jsonl
 ```
 
+To import an external eval trace into the same fixture format:
+
+```bash
+harn trace import \
+  --trace-file traces/generic.jsonl \
+  --trace-id trace_123 \
+  --output fixtures/imported.jsonl
+```
+
+The importer expects JSONL records shaped like
+`{prompt, response, tool_calls}` and passes through common metadata
+such as `model`, `provider`, and token counts when present.
+
+## Eval kinds
+
+`harn eval` supports the default replay fixture flow plus an explicit
+clarifying-question kind for ambiguous tasks.
+
+### Replay evals
+
+Replay evals are the default. They compare a run's persisted status and
+stage outcomes against an embedded or explicit replay fixture.
+
+### Clarifying-question evals
+
+Clarifying-question evals assert that the agent called `ask_user(...)`
+and asked the minimal question required to proceed. The run record
+persists `ask_user` prompts, and the fixture can require a single
+question plus term-level constraints:
+
+```json
+{
+  "_type": "replay_fixture",
+  "eval_kind": "clarifying_question",
+  "expected_status": "completed",
+  "clarifying_question": {
+    "required_terms": ["repository"],
+    "forbidden_terms": ["branch"],
+    "min_questions": 1,
+    "max_questions": 1
+  }
+}
+```
+
+Use this when defaults would be unsafe and the right behavior is to ask
+the user before continuing.
+
+## Determinism harness
+
+Use `harn test --determinism` to assert that a pipeline replays the same
+way on a second pass:
+
+```bash
+harn test --determinism tests/agent_loop.harn
+```
+
+The harness records once and replays once when no sibling
+`<name>.llm-mock.jsonl` exists. If a sibling fixture is already
+present, it replays both passes from that fixture. It compares stdout,
+provider response payloads from `llm_transcript.jsonl`, and persisted
+run-record structure to catch branching drift.
+
 ## Built-in assertions
 
 Harn provides `assert`, `assert_eq`, and `assert_ne` builtins for test pipelines:


### PR DESCRIPTION
## Summary
- add clarifying-question eval fixtures plus persisted HITL question capture on run records
- add `harn trace import` to ingest generic JSONL traces into standard replay fixtures
- add `harn test --determinism` and document the new eval tooling

## Verification
- cargo fmt
- cargo test -p harn-vm clarifying_question_eval_requires_matching_hitl_prompt
- cargo test -p harn-vm save_run_record_materializes_hitl_questions_from_active_event_log
- cargo test -p harn-cli test_parses_trace_import_args
- cargo test -p harn-cli converts_generic_trace_jsonl_to_cli_fixture
- cargo test -p harn-cli test_parses_test_determinism_flag
- cargo run --quiet --bin harn -- trace import --trace-file /tmp/harn-trace-import-input.jsonl --trace-id trace_123 --output /tmp/harn-trace-import-output.jsonl
- cargo run --quiet --bin harn -- test --determinism conformance tests/stdlib/project_enrich_cache.harn

Closes #306