### PR TITLE
Prepare v0.7.34 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## v0.7.34
+
+### Added
+
+- **Eval v2 replay tooling (#525).** Adds `harn trace import` to ingest
+  generic `{prompt, response, tool_calls}` JSONL traces into standard
+  `--llm-mock` fixtures, a `harn test --determinism` harness that
+  records then replays each pipeline and diffs stdout, provider
+  responses, and persisted run records, and a clarifying-question eval
+  kind backed by a new `hitl_questions` run-record field populated from
+  the HITL event log.
+
+### Changed
+
+- **Protocol-aware done sentinel guidance (#524).** Persistent no-tool
+  and native-tool loops now surface bare `##DONE##` in prompts, nudges,
+  mock-LLM behavior, editor hover docs, and docs snippets, while tagged
+  text-tool flows continue to use `<done>##DONE##</done>`. Adds prompt
+  coverage so the no-tool variant can't silently regress to the tagged
+  sentinel.
+
 ## v0.7.33
 
 ### Added


### PR DESCRIPTION
## Summary
- Document the eval v2 replay tooling landed in #525: `harn trace import` for generic JSONL→`--llm-mock` conversion, `harn test --determinism` record-then-replay harness, and a `clarifying_question` eval kind backed by the new `hitl_questions` run-record field.
- Document the protocol-aware done sentinel normalization landed in #524: persistent no-tool and native-tool loops use bare `##DONE##`, tagged text-tool flows keep `<done>##DONE##</done>`, and prompt/mock/editor/docs surfaces stay aligned with that split.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `./scripts/release_gate.sh audit` (warm-prebuild 32s, full audit 151s — all lanes ok)
- [x] `scripts/verify_release_metadata.py` (confirms CHANGELOG `## v0.7.34` is one patch ahead of Cargo.toml v0.7.33)
- [x] `scripts/detect_bump_type.py` → `patch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)