### PR TITLE
Rewrite llm_call schema-retry as single-turn correction (#533)

### DIFF
--- a/conformance/tests/integration/llm_schema_retry.expected
+++ b/conformance/tests/integration/llm_schema_retry.expected
@@ -2,8 +2,16 @@ YES
 2
 true
 true
+false
+true
+1
+true
+true
+true
+true
 1
 YES
 2
-assistant
+user
+true
 true

--- a/conformance/tests/integration/llm_schema_retry.harn
+++ b/conformance/tests/integration/llm_schema_retry.harn
@@ -28,6 +28,33 @@ pipeline default() {
   let second_msgs = calls[1].messages
   let last_msg = second_msgs[len(second_msgs) - 1]
   println(contains(last_msg.content, "schema"))
+  // Issue #533: the invalid response is NOT persisted on retry.
+  // The second call replays the original messages + one correction
+  // user turn, so the message count grows by exactly 1 vs. the first
+  // call, and no "assistant" role appears among the replayed turns.
+  println(len(second_msgs) == len(calls[0].messages) + 1)
+  var has_assistant = false
+  for msg in second_msgs {
+    if msg.role == "assistant" {
+      has_assistant = true
+    }
+  }
+  println(has_assistant)
+  // Issue #533: SchemaRetry trace events carry both the validation
+  // errors AND the correction prompt text, so a transcript reader can
+  // see why a retry happened and what the model received.
+  let trace = agent_trace()
+  var retry_event = nil
+  for ev in trace {
+    if ev.type == "schema_retry" {
+      retry_event = ev
+    }
+  }
+  println(retry_event != nil)
+  println(retry_event.attempt)
+  println(len(retry_event.errors) > 0)
+  println(contains(retry_event.correction_prompt, "schema"))
+  println(retry_event.nudge_used)
   // schema_retries: 0 — no retry; invalid JSON surfaces as an error.
   llm_mock_clear()
   llm_mock({text: "{\"improvement\": \"try again\"}"})
@@ -67,7 +94,11 @@ pipeline default() {
   let bare_calls = llm_mock_calls()
   println(len(bare_calls))
   let bare_second = bare_calls[1].messages
+  // schema_retry_nudge: false replays the original messages exactly;
+  // the invalid response is NOT persisted as an assistant turn, so
+  // the last role on the retry call is still "user".
   println(bare_second[len(bare_second) - 1].role)
+  println(len(bare_second) == len(bare_calls[0].messages))
   // Exhausted prose-only retries surface as hard schema failures.
   llm_mock_clear()
   llm_mock({text: "Analyzing the user task"})

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -416,6 +416,12 @@ pub(crate) async fn execute_llm_call(
     let nudge_mode = parse_schema_nudge(&options);
 
     let tool_format = helpers::opt_str(&options, "tool_format");
+    // Snapshot the caller's original messages once. Each schema retry
+    // replays this snapshot plus a single corrective user message, so
+    // the invalid response never pollutes subsequent attempts — the
+    // retry is a single-turn correction rather than a multi-turn
+    // conversation. See issue #533.
+    let original_messages = opts.messages.clone();
     for attempt in 0..=schema_retries {
         let result = agent_observe::observed_llm_call(
             &opts,
@@ -447,13 +453,15 @@ pub(crate) async fn execute_llm_call(
                 attempt: attempt + 1,
                 errors: errors.clone(),
                 nudge_used: !nudge.is_empty(),
+                correction_prompt: nudge.clone(),
             });
-            // Append broken response + corrective nudge so the next
-            // call has progressively richer context.
-            opts.messages.push(serde_json::json!({
-                "role": "assistant",
-                "content": result.text,
-            }));
+            // Replay the original messages with a single corrective
+            // user turn appended. The invalid assistant response is
+            // deliberately dropped — smaller / local models get
+            // confused by a user→assistant(bad)→user(nudge)→assistant
+            // shape, and the verbatim bad response otherwise sits in
+            // context for every subsequent retry.
+            opts.messages = original_messages.clone();
             if !nudge.is_empty() {
                 opts.messages.push(serde_json::json!({
                     "role": "user",

--- a/crates/harn-vm/src/llm/trace.rs
+++ b/crates/harn-vm/src/llm/trace.rs
@@ -116,10 +116,17 @@ pub enum AgentTraceEvent {
     /// response failed `output_schema` validation. One event per retry;
     /// `attempt` counts retries (the initial call is attempt 0 and
     /// produces no event; the first retry emits `attempt: 1`).
+    ///
+    /// The retry does **not** persist the invalid response — the
+    /// original messages are replayed with a single appended user-role
+    /// correction that cites the validation errors and schema. That
+    /// correction text is surfaced here as `correction_prompt` so
+    /// transcripts show both why the retry happened and what was sent.
     SchemaRetry {
         attempt: usize,
         errors: Vec<String>,
         nudge_used: bool,
+        correction_prompt: String,
     },
     NativeToolFallback {
         iteration: usize,

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -485,8 +485,8 @@ println(response.output_tokens)
 | `response_format` | string | nil | `"json"` asks the provider for JSON mode. |
 | `output_schema` | `Schema<T>` (dict \| type-alias) | nil | JSON-schema-shaped dict, or a top-level `type T = ...` alias (compiler lowers to the schema dict). The generic parameter `T` flows into the narrowed `r.data: T`. Validated after parse. |
 | `output_validation` | string | `"off"` | `"error"` throws on mismatch; `"warn"` logs. |
-| `schema_retries` | int | 1 | When validation fails, re-prompt up to N times with a corrective nudge. Works alongside `output_validation: "error"`. |
-| `schema_retry_nudge` | string \| bool | auto | String = verbatim corrective message (+ validation errors appended). `true` = auto nudge from schema required/properties keys. `false` = retry without a nudge. |
+| `schema_retries` | int | 1 | When validation fails, re-prompt up to N times with a corrective user turn. Each retry is a single-turn correction — the invalid response is NOT persisted; the original messages are replayed with one appended user-role correction citing the validation errors + schema. Works alongside `output_validation: "error"`. |
+| `schema_retry_nudge` | string \| bool | auto | String = verbatim corrective message (+ validation errors appended). `true` = auto nudge from schema required/properties keys. `false` = bare retry — replays the original messages unchanged, no correction appended. |
 | `llm_retries` | int | 2 | Retries on transient HTTP / provider errors. Set to 0 for fail-fast. |
 | `llm_backoff_ms` | int | 2000 | Base exponential backoff. |
 | `stream` | bool | true | SSE streaming transport. |
@@ -1027,6 +1027,14 @@ in-flight work. Use both when batching LLM calls at scale.
   corrective nudge. `llm_retries` retries transient provider errors.
   They compose orthogonally — each schema retry starts a fresh
   transient budget.
+- A schema retry is a **single-turn correction**, not a multi-turn
+  conversation. The invalid response is not persisted; the retry
+  replays the original messages with one appended user-role correction
+  that cites the validation errors and the schema. For cost / cache
+  purposes, treat the retry as one extra prompt+response on the same
+  prefix as the original call (not a growing conversation). The
+  correction text is surfaced on the `SchemaRetry` trace event as
+  `correction_prompt`.
 - Module-level `var` cross-fn mutation is not shared yet. Prefer
   atomics (`atomic(0)` / `atomic_add`) for shared counters.
 - Small / local models benefit heavily from:


### PR DESCRIPTION
## Summary

Fixes #533. Replaces the append-then-nudge schema-retry loop in
`crates/harn-vm/src/llm/mod.rs` with a single-turn correction strategy:

- **Do not persist the invalid response in subsequent retries.** Each
  retry replays the caller's original messages plus one appended
  user-role correction that cites the validation errors and the
  schema. The invalid assistant turn is deliberately dropped instead
  of shifting the conversation into a `user → assistant(bad) →
  user(nudge) → assistant` shape that confuses smaller / local
  models.
- **`SchemaRetry` trace event gains `correction_prompt`.** Existing
  fields (`attempt`, `errors`, `nudge_used`) are preserved; the new
  field carries the corrective message text so transcripts show both
  why the retry happened and what the model received.
- **`schema_retry_nudge: false`** now means a bare retry — the
  original messages are replayed unchanged, no corrective user turn
  is appended.

## Docs

- `docs/llm/harn-quickref.md` — updated the `schema_retries` /
  `schema_retry_nudge` option rows and added a "single-turn
  correction" note that schema retries cost one extra prompt+response
  on the same prefix as the original call.

## Tests

- Expanded `conformance/tests/integration/llm_schema_retry.harn` to
  assert the new invariants: on retry the second call's message list
  grows by exactly 1 vs. the first call, no `assistant` role appears
  among replayed turns, and the `SchemaRetry` trace event carries
  `errors`, `attempt: 1`, and a `correction_prompt` that mentions the
  schema. Under `schema_retry_nudge: false`, the retry replays the
  caller's messages byte-identically (last role is `user`, length
  unchanged).

## Test plan

- [x] `cargo test -p harn-vm` (1119 passed)
- [x] `cargo run --bin harn -- test conformance --filter llm_schema_retry` (1 passed)
- [x] `cargo run --bin harn -- test conformance --filter project_enrich_schema` (2 passed, verifies no regression in stdlib/project_enrich path)
- [x] `cargo clippy -p harn-vm --all-targets --no-deps -- -D warnings`
- [x] `cargo fmt --all`
- [x] `harn lint` on the updated conformance fixture
- [x] `markdownlint-cli2 docs/llm/harn-quickref.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)