### PR TITLE
Add MLX provider to capability matrix

### DIFF
--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -435,6 +435,8 @@ mod tests {
             ("dashscope", "qwen3.6-plus"),
             ("llamacpp", "unsloth/Qwen3.6-35B-A3B-GGUF"),
             ("local", "Qwen3.6-35B-A3B"),
+            ("mlx", "unsloth/Qwen3.6-27B-UD-MLX-4bit"),
+            ("mlx", "Qwen/Qwen3.6-27B"),
         ] {
             let caps = lookup(provider, model);
             assert!(caps.thinking, "{provider}/{model}: thinking");

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -198,6 +198,20 @@ model_match = "*qwen3*"
 native_tools = true
 thinking = true
 
+# Apple Silicon MLX server (mlx-vlm). OpenAI-compat with vision; honors
+# the same `chat_template_kwargs.preserve_thinking` knob as vLLM, since
+# mlx-vlm reuses HF tokenizers / chat templates.
+[[provider.mlx]]
+model_match = "*qwen3.6*"
+native_tools = true
+thinking = true
+preserve_thinking = true
+
+[[provider.mlx]]
+model_match = "*qwen3*"
+native_tools = true
+thinking = true
+
 # ---------- Qwen3.6 family (routed providers) --------------------------------
 #
 # DashScope is the authoritative Qwen host; Fireworks and OpenRouter
@@ -346,3 +360,4 @@ local = "openai"
 # New April 2026 routes for Qwen3.6:
 dashscope = "openai"
 llamacpp = "openai"
+mlx = "openai"


### PR DESCRIPTION
## Summary
- Add `mlx = \"openai\"` to `[provider_family]` so the Apple-Silicon mlx-vlm server inherits OpenAI-shape capabilities for any model that lacks a dedicated rule.
- Add `[[provider.mlx]]` rules for Qwen3.6 (with `preserve_thinking = true`) and Qwen3 (catch-all for older Qwen) so MLX-served Qwen3.6 deployments get the chat_template_kwargs that keep `<think>` blocks alive across multi-turn agentic conversations.
- Extend `qwen36_routed_providers_all_preserve_thinking` to cover both the Unsloth MLX 4-bit alias and the bare `Qwen/Qwen3.6-27B` id.

## Why
Burin Code is wiring MLX as a first-class local-runtime provider on macOS (port 8002, alongside vLLM:8000 and llama.cpp:8001). Without this matrix entry, harn would emit a Qwen3.6 chat completion against MLX without `preserve_thinking`, defeating the multi-turn coding-agent use case mlx-vlm is being added for.

The change is additive — no existing rule is modified.

## Test plan
- [x] `cargo test -p harn-vm --lib llm::capabilities` (21/21 pass, including the extended `qwen36_routed_providers_all_preserve_thinking` test that now exercises MLX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)