### PR TITLE
Fix 26 failing docs snippets so make check-docs-snippets is green

### DIFF
--- a/crates/harn-modules/src/stdlib/stdlib_host.harn
+++ b/crates/harn-modules/src/stdlib/stdlib_host.harn
@@ -5,9 +5,9 @@ pub fn host_tools() {
 
 /** host_tool_lookup. */
 pub fn host_tool_lookup(name: string) {
-  for tool in host_tool_list() {
-    if tool?.name == name {
-      return tool
+  for entry in host_tool_list() {
+    if entry?.name == name {
+      return entry
     }
   }
   return nil

--- a/crates/harn-vm/src/stdlib_host.harn
+++ b/crates/harn-vm/src/stdlib_host.harn
@@ -5,9 +5,9 @@ pub fn host_tools() {
 
 /** host_tool_lookup. */
 pub fn host_tool_lookup(name: string) {
-  for tool in host_tool_list() {
-    if tool?.name == name {
-      return tool
+  for entry in host_tool_list() {
+    if entry?.name == name {
+      return entry
     }
   }
   return nil

--- a/docs/src/agent-state.md
+++ b/docs/src/agent-state.md
@@ -157,6 +157,8 @@ context without importing the source transcript.
 Each handle can carry a writer identity and conflict policy:
 
 ```harn
+import "std/agent_state"
+
 let state = agent_state_init(".harn/state", {
   session_id: "demo",
   writer_id: "planner",

--- a/docs/src/concurrency.md
+++ b/docs/src/concurrency.md
@@ -197,7 +197,7 @@ read counters.
 Use the named synchronization primitives when an update needs a larger
 critical section:
 
-```harn
+```harn,ignore
 let memo = shared_map({scope: "workflow_run", key: "memo"})
 let permit = sync_mutex_acquire("memo:customer-42", 250ms)
 guard permit != nil else { throw "memo lock timeout" }
@@ -232,7 +232,7 @@ sent, received, failed send, and closed status.
 
 Examples:
 
-```harn
+```harn,ignore
 // Connector token refresh: only one task refreshes the token.
 let tokens = shared_map({scope: "tenant", tenant_id: "acme", key: "connector_tokens"})
 let lock = sync_mutex_acquire("token:acme:slack", 2s)

--- a/docs/src/error-handling.md
+++ b/docs/src/error-handling.md
@@ -46,7 +46,7 @@ try {
 A `return` statement inside a `try` block is **not** caught. It propagates
 out of the enclosing pipeline or function as expected.
 
-```harn
+```harn,ignore
 fn find_user(id) {
   try {
     let user = lookup(id)
@@ -168,7 +168,7 @@ handler's tail value on a caught throw. The lub of the two branch types is
 inferred automatically, and an explicit type annotation on the `let` binds
 the result:
 
-```harn
+```harn,ignore
 let parsed: dict = try { json_parse(input) } catch (e) { default_config() }
 ```
 
@@ -176,7 +176,7 @@ Typed catches work identically in expression position; when the thrown
 error's type does not match the catch's type filter, the throw propagates
 past the expression and the `let` binding is never established:
 
-```harn
+```harn,ignore
 let user: User = try {
   fetch_user(id)
 } catch (e: NetworkError) {

--- a/docs/src/hitl.md
+++ b/docs/src/hitl.md
@@ -208,7 +208,7 @@ if is_err(result) && unwrap_err(result).name == "ApprovalDeniedError" {
 
 Gate a destructive step behind dual control:
 
-```harn
+```harn,ignore
 let deleted = dual_control(2, 3, {
   delete_file("prod.db")
   return true

--- a/docs/src/language-basics.md
+++ b/docs/src/language-basics.md
@@ -604,7 +604,7 @@ function name.
 
 Binary operators, method chains, and pipes can span multiple lines:
 
-```harn
+```harn,ignore
 let message = "hello"
   + " "
   + "world"
@@ -631,7 +631,7 @@ backslash continuation.
 A backslash at the end of a line forces the next line to continue the
 current expression, even when no operator is present:
 
-```harn
+```harn,ignore
 let long_value = some_function( \
   arg1, arg2, arg3 \
 )
@@ -847,6 +847,11 @@ Structs can also be constructed with the struct name as a constructor,
 using named fields directly:
 
 ```harn
+struct Point {
+  x: int
+  y: int
+}
+
 let p = Point { x: 10, y: 20 }
 println(p.x)  // 10
 ```
@@ -965,7 +970,7 @@ both satisfy `Displayable`. No extra annotation is needed.
 
 Now you can write a function that accepts any `Displayable`:
 
-```harn
+```harn,ignore
 fn introduce(animal: Displayable) {
   println("Meet: ${animal.display()}")
 }
@@ -1080,7 +1085,7 @@ println(add(1, ...rest))  // 6
 
 Spread works in method calls too:
 
-```harn
+```harn,ignore
 let point = Point({x: 0, y: 0})
 let deltas = [10, 20]
 let moved = point.translate(...deltas)
@@ -1120,7 +1125,7 @@ parsed as the traditional `try`/`catch` statement instead.
 The `ask` expression is syntactic sugar for making an LLM call. It takes
 a set of key-value fields and returns the LLM response as a string:
 
-```harn
+```harn,ignore
 let answer = ask {
   system: "You are a helpful assistant.",
   user: "What is 2 + 2?"

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -773,7 +773,7 @@ scaffolding.
 
 ### Example
 
-```harn
+```harn,ignore
 skill ship {
   description "Ship a production release"
   when_to_use "User says ship/release/deploy"
@@ -847,7 +847,7 @@ Worker configs may also include `policy` to narrow the delegated worker to a
 subset of the parent's current execution ceiling, or a top-level
 `tools: ["name", ...]` shorthand:
 
-```harn
+```harn,ignore
 let worker = spawn_agent({
   task: "Read project files only",
   tools: ["read", "search"],
@@ -884,7 +884,7 @@ Use `sub_agent_run(...)` when you want a full child `agent_loop` with its own
 session and narrowed capability scope, but you do not want the child transcript
 to spill into the parent conversation history.
 
-```harn
+```harn,ignore
 let result = sub_agent_run("Find the config entrypoints.", {
   provider: "mock",
   tools: repo_tools(),

--- a/docs/src/project-scan.md
+++ b/docs/src/project-scan.md
@@ -60,6 +60,8 @@ Normalization rules:
 dictionary describing exactly that directory:
 
 ```harn
+import "std/project"
+
 let ev = project_scan(".", {tiers: ["ambient", "config"]})
 ```
 
@@ -98,6 +100,8 @@ monorepos, use `project_scan_tree(...)` and let callers decide how to combine
 sub-project evidence:
 
 ```harn
+import "std/project"
+
 let tree = project_scan_tree(".", {tiers: ["ambient"], depth: 3})
 // {".": {...}, "frontend": {...}, "backend": {...}}
 ```
@@ -126,6 +130,8 @@ selection, schema-retry plumbing, and content-hash caching.
 Typical use:
 
 ```harn
+import "std/project"
+
 let base = project_scan(".", {tiers: ["ambient", "config"]})
 let enriched = project_enrich(".", {
   base_evidence: base,
@@ -231,6 +237,8 @@ every turn.
 Typical shape:
 
 ```harn
+import "std/project"
+
 let tree = project_deep_scan(".", {
   namespace: "coding-enrichment-v1",
   tiers: ["ambient", "config", "enriched"],

--- a/docs/src/scripting-cheatsheet.md
+++ b/docs/src/scripting-cheatsheet.md
@@ -118,7 +118,7 @@ let prose = try { llm_call(prompt, nil, opts).prose } catch (e) { "fallback" }
 
 ## Concurrency
 
-```harn
+```harn,ignore
 // Spawn a task, collect its result.
 let h = spawn { long_work() }
 let value = await(h)

--- a/docs/src/stdlib/agent_session_current_id.md
+++ b/docs/src/stdlib/agent_session_current_id.md
@@ -5,7 +5,7 @@ VM thread.
 
 ## Signature
 
-```harn
+```harn,ignore
 agent_session_current_id() -> string | nil
 ```
 

--- a/docs/src/stdlib/monitors.md
+++ b/docs/src/stdlib/monitors.md
@@ -3,7 +3,7 @@
 `std/monitors` provides `wait_for(...)` for waiting on external state while
 preserving deterministic replay records.
 
-```harn
+```harn,ignore
 import { wait_for } from "std/monitors"
 
 let result = wait_for({

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -52,7 +52,7 @@ harn test conformance --timing --filter my_test
 Create a `.harn` file with a `pipeline default(task)` entry point and use
 `log()` or `println()` to produce output:
 
-```harn
+```harn,ignore
 // conformance/tests/<group>/my_feature.harn  (e.g. stdlib/, types/)
 pipeline default(task) {
   let result = my_feature(42)

--- a/docs/src/typed-tools.md
+++ b/docs/src/typed-tools.md
@@ -100,7 +100,7 @@ fn deterministic_tools() {
 
 Then hand the registry to `agent_loop(...)`:
 
-```harn
+```harn,ignore
 let result = agent_loop(
   "Read the screenshot, hash the extracted order id, and summarize the UI state.",
   "Use deterministic tools first. Prefer pure stdlib tools over free-form reasoning when possible.",

--- a/scripts/check_docs_snippets.sh
+++ b/scripts/check_docs_snippets.sh
@@ -18,14 +18,26 @@ cd "$ROOT_DIR"
 
 HARN_BIN="${HARN_BIN:-}"
 if [[ -z "$HARN_BIN" ]]; then
+  # Resolve the Cargo target directory so this works under
+  # CARGO_TARGET_DIR overrides and sccache/worktree-redirected targets
+  # where `target/` in the CWD does not exist.
+  target_dir=""
+  if command -v cargo >/dev/null 2>&1; then
+    target_dir="$(cargo metadata --no-deps --format-version 1 2>/dev/null \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin).get("target_directory", ""))' 2>/dev/null)"
+  fi
+  if [[ -z "$target_dir" ]]; then
+    target_dir="${CARGO_TARGET_DIR:-target}"
+  fi
+
   # Prefer a pre-built debug binary so the script is fast in a loop; fall
-  # back to `cargo run` for fresh clones.
-  if [[ -x "target/debug/harn" ]]; then
-    HARN_BIN="target/debug/harn"
+  # back to `cargo build` for fresh clones.
+  if [[ -x "$target_dir/debug/harn" ]]; then
+    HARN_BIN="$target_dir/debug/harn"
   else
     echo "building harn-cli (set HARN_BIN to skip)..." >&2
     cargo build -q -p harn-cli
-    HARN_BIN="target/debug/harn"
+    HARN_BIN="$target_dir/debug/harn"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Closes #535. Fixes all 26 failing `harn check` docs snippets across 13 files so `make check-docs-snippets` is clean again.

- Added `import "std/project"` to four `project-scan.md` blocks and `import "std/agent_state"` to the two-writer-discipline block in `agent-state.md` so the stdlib wrapper functions resolve in isolation.
- Renamed the loop variable `tool` (now a reserved keyword) to `entry` in `stdlib_host.harn` (both `harn-vm` and `harn-modules` copies) so the module actually parses. This unblocks the worked example in `bridge/host-tools.md` and any other caller of `import "std/host"`.
- Tagged the remaining intentional fragments as ```harn,ignore — syntax demos that depend on earlier blocks or undefined helpers (multiline expressions, `\`-continuation, struct/enum/interface examples, the `ask` expression, `spawn_agent`/`sub_agent_run`/`skill ship` examples, `wait_for`, `dual_control`, `agent_session_current_id()` signature, and the `try`/`catch` typed-catch examples).
- Inlined the `struct Point` declaration into the constructor-shorthand example so that one stays runnable.

Also fixes the follow-up in the issue body: `scripts/check_docs_snippets.sh` hardcoded `target/debug/harn`, which breaks in worktrees where `CARGO_TARGET_DIR` redirects `target/`. The script now resolves the target via `cargo metadata`, falling back to `$CARGO_TARGET_DIR`, then `target/`. `make check-docs-snippets` now works from any worktree.

Before:
```
docs snippets: 431 checked, 51 skipped (harn,ignore), 26 failed
```

After:
```
docs snippets: 412 checked, 70 skipped (harn,ignore), 0 failed
```

## Test plan

- [x] `make check-docs-snippets` — 0 failures
- [x] `make lint-md`
- [x] `make lint-harn`
- [x] `make fmt-harn`
- [x] `make check-highlight`
- [x] `cargo test -p harn-vm` (1143 tests)
- [x] `cargo test -p harn-modules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)