### PR TITLE
Surface LLM error category on llm_call throw (#534)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## Unreleased
+
+### Changed
+
+- **`llm_call` throws a categorized error dict (#534).** The value
+  caught in `catch (e)` from a failed `llm_call` is now
+  `{category, message, retry_after_ms?, provider, model}` — the same
+  shape `llm_call_safe` exposes under `r.error`. Scripts can dispatch
+  on `e.category` against the 13 canonical `ErrorCategory` strings
+  (`"rate_limit"`, `"timeout"`, `"overloaded"`, `"server_error"`,
+  `"transient_network"`, `"schema_validation"`, `"auth"`,
+  `"not_found"`, `"circuit_open"`, `"tool_error"`, `"tool_rejected"`,
+  `"cancelled"`, `"generic"`) and honor `e.retry_after_ms` instead of
+  parsing the error message. **Breaking:** callers that
+  string-matched the previous thrown message (`e.contains("429")`)
+  must switch to `e.category == "rate_limit"` or use `e.message` to
+  keep the substring check. The `error_category(e)` and
+  `is_rate_limited(e)` helpers accept either the new dict shape or a
+  legacy string — no change for callers that already use them.
+  `llm_mock({error: {...}})` gained an optional
+  `retry_after_ms: <int>` field for tests that exercise the
+  rate-limit path end-to-end.
+
 ## v0.7.35
 
 ### Added

--- a/conformance/tests/integration/llm_call_error_categories.expected
+++ b/conformance/tests/integration/llm_call_error_categories.expected
@@ -1,0 +1,26 @@
+rate_limit thrown=rate_limit msg=synthetic-rate_limit provider=mock model=mock-model
+rate_limit safe=rate_limit msg=safe-rate_limit ok=false
+timeout thrown=timeout msg=synthetic-timeout provider=mock model=mock-model
+timeout safe=timeout msg=safe-timeout ok=false
+overloaded thrown=overloaded msg=synthetic-overloaded provider=mock model=mock-model
+overloaded safe=overloaded msg=safe-overloaded ok=false
+server_error thrown=server_error msg=synthetic-server_error provider=mock model=mock-model
+server_error safe=server_error msg=safe-server_error ok=false
+transient_network thrown=transient_network msg=synthetic-transient_network provider=mock model=mock-model
+transient_network safe=transient_network msg=safe-transient_network ok=false
+schema_validation thrown=schema_validation msg=synthetic-schema_validation provider=mock model=mock-model
+schema_validation safe=schema_validation msg=safe-schema_validation ok=false
+auth thrown=auth msg=synthetic-auth provider=mock model=mock-model
+auth safe=auth msg=safe-auth ok=false
+not_found thrown=not_found msg=synthetic-not_found provider=mock model=mock-model
+not_found safe=not_found msg=safe-not_found ok=false
+circuit_open thrown=circuit_open msg=synthetic-circuit_open provider=mock model=mock-model
+circuit_open safe=circuit_open msg=safe-circuit_open ok=false
+tool_error thrown=tool_error msg=synthetic-tool_error provider=mock model=mock-model
+tool_error safe=tool_error msg=safe-tool_error ok=false
+tool_rejected thrown=tool_rejected msg=synthetic-tool_rejected provider=mock model=mock-model
+tool_rejected safe=tool_rejected msg=safe-tool_rejected ok=false
+cancelled thrown=cancelled msg=synthetic-cancelled provider=mock model=mock-model
+cancelled safe=cancelled msg=safe-cancelled ok=false
+generic thrown=generic msg=synthetic-generic provider=mock model=mock-model
+generic safe=generic msg=safe-generic ok=false

--- a/conformance/tests/integration/llm_call_error_categories.harn
+++ b/conformance/tests/integration/llm_call_error_categories.harn
@@ -1,0 +1,41 @@
+/**
+ * Walk every canonical ErrorCategory string and verify the thrown
+ * dict round-trips `category`, `message`, `provider`, and `model` on
+ * `llm_call`. The safe-envelope path mirrors the same shape under
+ * `r.error`.
+ */
+pipeline default(task) {
+  let categories = [
+    "rate_limit",
+    "timeout",
+    "overloaded",
+    "server_error",
+    "transient_network",
+    "schema_validation",
+    "auth",
+    "not_found",
+    "circuit_open",
+    "tool_error",
+    "tool_rejected",
+    "cancelled",
+    "generic",
+  ]
+  for category in categories {
+    llm_mock({error: {category: category, message: "synthetic-" + category}})
+    try {
+      llm_call("probe", nil, {provider: "mock", model: "mock-model", llm_retries: 0})
+    } catch (e) {
+      println(
+        category + " thrown=" + e.category + " msg=" + e.message + " provider=" + e.provider
+        + " model="
+        + e.model,
+      )
+    }
+    // Parity: llm_call_safe wraps the exact same fields.
+    llm_mock({error: {category: category, message: "safe-" + category}})
+    let r = llm_call_safe("probe", nil, {provider: "mock", model: "mock-model", llm_retries: 0})
+    println(
+      category + " safe=" + r.error.category + " msg=" + r.error.message + " ok=" + to_string(r.ok),
+    )
+  }
+}

--- a/conformance/tests/integration/llm_call_structured_retry.harn
+++ b/conformance/tests/integration/llm_call_structured_retry.harn
@@ -1,6 +1,8 @@
-// `llm_call_structured` reuses the standard schema-retry loop. First
-// mock: invalid (missing `verdict`). Second mock: valid. One retry
-// recovers; the caller gets the parsed data directly.
+/**
+ * `llm_call_structured` reuses the standard schema-retry loop. First
+ * mock: invalid (missing `verdict`). Second mock: valid. One retry
+ * recovers; the caller gets the parsed data directly.
+ */
 pipeline default() {
   let schema = {
     type: "object",
@@ -20,5 +22,7 @@ pipeline default() {
     llm_call_structured("Grade again", schema, {provider: "mock", retries: 0})
   }
   println(is_err(err))
-  println(contains(unwrap_err(err), "schema"))
+  // After #534 the thrown value is a {category, message, ...} dict
+  // — dispatch on category instead of string-matching the message.
+  println(unwrap_err(err)?.category == "schema_validation")
 }

--- a/conformance/tests/integration/llm_mock_error.expected
+++ b/conformance/tests/integration/llm_mock_error.expected
@@ -1,3 +1,8 @@
 rate_limit
 true
+rate_limit
+2500
+mock
+mock-model
 overloaded
+true

--- a/conformance/tests/integration/llm_mock_error.harn
+++ b/conformance/tests/integration/llm_mock_error.harn
@@ -1,19 +1,30 @@
-// Inject a categorized error via llm_mock({error: ...}) and verify
-// the category round-trips through the `try { llm_call } catch` path.
+/**
+ * `llm_call`'s catch value is a dict `{category, message,
+ * retry_after_ms?, provider, model}` — the same shape `llm_call_safe`
+ * returns inside its `error` envelope. `error_category(e)` and
+ * `is_rate_limited(e)` still work (they accept dict or string); scripts
+ * can also dispatch directly on `e.category`.
+ */
 pipeline default(task) {
   // `llm_retries: 0` disables the llm_call-internal transient retry so
   // a single injected error surfaces as a throw on the first attempt.
-  llm_mock({error: {category: "rate_limit", message: "429 Too Many Requests"}})
+  llm_mock({error: {category: "rate_limit", message: "429 Too Many Requests", retry_after_ms: 2500}})
   try {
-    llm_call("hello", nil, {provider: "mock", llm_retries: 0})
+    llm_call("hello", nil, {provider: "mock", model: "mock-model", llm_retries: 0})
   } catch (e) {
     println(error_category(e))
     println(is_rate_limited(e))
+    println(e.category)
+    println(e.retry_after_ms)
+    println(e.provider)
+    println(e.model)
   }
   llm_mock({error: {category: "overloaded", message: "529 overloaded"}})
   try {
     llm_call("hello again", nil, {provider: "mock", llm_retries: 0})
   } catch (e2) {
     println(error_category(e2))
+    // retry_after_ms is omitted when the provider didn't surface one.
+    println(e2.retry_after_ms == nil)
   }
 }

--- a/conformance/tests/integration/llm_schema_retry.harn
+++ b/conformance/tests/integration/llm_schema_retry.harn
@@ -71,7 +71,7 @@ pipeline default() {
   },
   )
   }
-  println(contains(unwrap_err(err), "schema"))
+  println(contains(unwrap_err(err).message, "schema"))
   println(len(llm_mock_calls()))
   // `schema_retry_nudge: false` still retries; it just omits the
   // corrective user message.
@@ -116,5 +116,5 @@ pipeline default() {
   },
   )
   }
-  println(contains(unwrap_err(prose_err), "parseable JSON"))
+  println(contains(unwrap_err(prose_err).message, "parseable JSON"))
 }

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -227,9 +227,9 @@ fn parse_cli_llm_mock_error(
     if value.is_null() {
         return Ok(None);
     }
-    let object = value
-        .as_object()
-        .ok_or_else(|| "error must be an object {category, message}".to_string())?;
+    let object = value.as_object().ok_or_else(|| {
+        "error must be an object {category, message, retry_after_ms?}".to_string()
+    })?;
     let category_str = object
         .get("category")
         .and_then(|value| value.as_str())
@@ -243,7 +243,19 @@ fn parse_cli_llm_mock_error(
         .and_then(|value| value.as_str())
         .unwrap_or_default()
         .to_string();
-    Ok(Some(harn_vm::llm::MockError { category, message }))
+    let retry_after_ms = match object.get("retry_after_ms") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::Number(n)) => match n.as_u64() {
+            Some(v) => Some(v),
+            None => return Err("error.retry_after_ms must be a non-negative integer".to_string()),
+        },
+        Some(_) => return Err("error.retry_after_ms must be a non-negative integer".to_string()),
+    };
+    Ok(Some(harn_vm::llm::MockError {
+        category,
+        message,
+        retry_after_ms,
+    }))
 }
 
 fn optional_string_field(

--- a/crates/harn-vm/src/llm/agent/tests/native_tool_fallback.rs
+++ b/crates/harn-vm/src/llm/agent/tests/native_tool_fallback.rs
@@ -174,6 +174,7 @@ async fn empty_completion_retry_is_counted_in_trace_summary() {
         error: Some(crate::llm::mock::MockError {
             category: crate::value::ErrorCategory::ServerError,
             message: "openai-compatible model mock reported completion_tokens=1 but delivered no content, reasoning, or tool calls".to_string(),
+            retry_after_ms: None,
         }),
     });
     crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {

--- a/crates/harn-vm/src/llm/mock.rs
+++ b/crates/harn-vm/src/llm/mock.rs
@@ -35,6 +35,12 @@ enum CliLlmMockMode {
 pub struct MockError {
     pub category: ErrorCategory,
     pub message: String,
+    /// Optional hint echoed into the error message as a synthetic
+    /// `retry-after:` header so the existing `extract_retry_after_ms`
+    /// parser recovers it — matches how real provider errors embed
+    /// the value. Lets tests assert that `e.retry_after_ms` flows
+    /// end-to-end on the thrown dict.
+    pub retry_after_ms: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -269,8 +275,25 @@ fn mock_last_prompt_text(messages: &[serde_json::Value]) -> String {
 /// provider path would have raised, so classification, retry, and
 /// `error_category` all behave identically to a real failure.
 fn mock_error_to_vm_error(err: &MockError) -> VmError {
+    // Embed `retry_after_ms` as a synthetic `retry-after:` header on
+    // the message so `agent_observe::extract_retry_after_ms` — the
+    // same parser that handles real HTTP 429s — surfaces the value
+    // on the caller's thrown dict. Keeps the mock path byte-for-byte
+    // compatible with a real rate-limit response.
+    let message = match err.retry_after_ms {
+        Some(ms) => {
+            let secs = (ms as f64 / 1000.0).max(0.0);
+            let sep = if err.message.is_empty() || err.message.ends_with('\n') {
+                ""
+            } else {
+                "\n"
+            };
+            format!("{}{sep}retry-after: {secs}\n", err.message)
+        }
+        None => err.message.clone(),
+    };
     VmError::CategorizedError {
-        message: err.message.clone(),
+        message,
         category: err.category.clone(),
     }
 }

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -392,11 +392,58 @@ pub fn reset_llm_state() {
 /// Shared implementation of `llm_call` / `llm_call_safe`. Runs the
 /// full schema-retry loop; on success returns the LLM result dict, on
 /// failure returns the underlying `VmError`. `llm_call` propagates the
-/// error; `llm_call_safe` wraps it in a `{ok: false, error: …}` envelope.
+/// error (re-wrapped as a thrown `{category, message, retry_after_ms?,
+/// provider, model}` dict so catch blocks can dispatch on category);
+/// `llm_call_safe` wraps it in a `{ok: false, error: …}` envelope with
+/// the same fields.
 async fn llm_call_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let options = args.get(2).and_then(|a| a.as_dict()).cloned();
     let opts = extract_llm_options(&args)?;
-    execute_llm_call(opts, options, None).await
+    let provider = opts.provider.clone();
+    let model = opts.model.clone();
+    match execute_llm_call(opts, options, None).await {
+        Ok(v) => Ok(v),
+        Err(err) => Err(VmError::Thrown(build_llm_error_dict(
+            &err, &provider, &model,
+        ))),
+    }
+}
+
+/// Build the `{category, message, retry_after_ms?, provider, model}`
+/// dict that `llm_call` throws on failure. `retry_after_ms` is only
+/// set when the underlying error carries a parseable `retry-after:`
+/// hint, so callers can pattern-match on its presence:
+///
+/// ```harn
+/// try { llm_call(prompt, nil, opts) } catch (e) {
+///   if e.category == "rate_limit" {
+///     sleep(e.retry_after_ms ?? 1000)
+///   }
+/// }
+/// ```
+pub(crate) fn build_llm_error_dict(err: &VmError, provider: &str, model: &str) -> VmValue {
+    let category = crate::value::error_to_category(err);
+    let message = match err {
+        VmError::CategorizedError { message, .. } => message.clone(),
+        VmError::Thrown(VmValue::String(s)) => s.to_string(),
+        VmError::Thrown(VmValue::Dict(d)) => d
+            .get("message")
+            .map(|v| v.display())
+            .unwrap_or_else(|| err.to_string()),
+        _ => err.to_string(),
+    };
+    let mut dict = std::collections::BTreeMap::new();
+    dict.insert(
+        "category".to_string(),
+        VmValue::String(Rc::from(category.as_str())),
+    );
+    dict.insert("message".to_string(), VmValue::String(Rc::from(message)));
+    if let Some(ms) = agent_observe::extract_retry_after_ms(err) {
+        dict.insert("retry_after_ms".to_string(), VmValue::Int(ms as i64));
+    }
+    dict.insert("provider".to_string(), VmValue::String(Rc::from(provider)));
+    dict.insert("model".to_string(), VmValue::String(Rc::from(model)));
+    VmValue::Dict(Rc::new(dict))
 }
 
 pub(crate) async fn execute_llm_call(
@@ -517,14 +564,22 @@ fn llm_safe_envelope_ok(response: VmValue) -> VmValue {
 }
 
 fn llm_safe_envelope_err(err: &VmError) -> VmValue {
+    // `llm_call_impl` pre-wraps its errors into a
+    // `VmError::Thrown(VmValue::Dict{category, message, retry_after_ms?,
+    // provider, model})`. Pass that dict through verbatim so
+    // `llm_call_safe` callers see the same fields as `try/catch`
+    // users — with `category` / `message` always populated.
+    if let VmError::Thrown(VmValue::Dict(d)) = err {
+        let mut dict = std::collections::BTreeMap::new();
+        dict.insert("ok".to_string(), VmValue::Bool(false));
+        dict.insert("response".to_string(), VmValue::Nil);
+        dict.insert("error".to_string(), VmValue::Dict(d.clone()));
+        return VmValue::Dict(Rc::new(dict));
+    }
     let category = crate::value::error_to_category(err);
     let message = match err {
         VmError::CategorizedError { message, .. } => message.clone(),
         VmError::Thrown(VmValue::String(s)) => s.to_string(),
-        VmError::Thrown(VmValue::Dict(d)) => d
-            .get("message")
-            .map(|v| v.display())
-            .unwrap_or_else(|| err.to_string()),
         _ => err.to_string(),
     };
     let mut err_dict = std::collections::BTreeMap::new();
@@ -1015,11 +1070,11 @@ fn register_llm_mock_builtins(vm: &mut Vm) {
             .map(|v| v.display())
             .unwrap_or_else(|| "mock".to_string());
 
-        // Optional error injection: {error: {category, message}}. When
-        // present the mock short-circuits the provider call and surfaces
-        // as `VmError::CategorizedError`, making it observable via
-        // `error_category`, `try { ... }`, and the `llm_call_safe`
-        // envelope.
+        // Optional error injection: {error: {category, message,
+        // retry_after_ms?}}. When present the mock short-circuits the
+        // provider call and surfaces as `VmError::CategorizedError`,
+        // making it observable via `error_category`, the `llm_call`
+        // thrown dict, and the `llm_call_safe` envelope.
         let error = match config.get("error") {
             None | Some(VmValue::Nil) => None,
             Some(VmValue::Dict(err_dict)) => {
@@ -1045,11 +1100,28 @@ fn register_llm_mock_builtins(vm: &mut Vm) {
                     .get("message")
                     .map(|v| v.display())
                     .unwrap_or_default();
-                Some(MockError { category, message })
+                let retry_after_ms = match err_dict.get("retry_after_ms") {
+                    None | Some(VmValue::Nil) => None,
+                    Some(v) => match v.as_int() {
+                        Some(n) if n >= 0 => Some(n as u64),
+                        _ => {
+                            return Err(crate::value::VmError::Runtime(
+                                "llm_mock: error.retry_after_ms must be a non-negative int"
+                                    .to_string(),
+                            ));
+                        }
+                    },
+                };
+                Some(MockError {
+                    category,
+                    message,
+                    retry_after_ms,
+                })
             }
             _ => {
                 return Err(crate::value::VmError::Runtime(
-                    "llm_mock: error must be a dict {category, message}".to_string(),
+                    "llm_mock: error must be a dict {category, message, retry_after_ms?}"
+                        .to_string(),
                 ));
             }
         };

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -983,8 +983,24 @@ removed — call the lifecycle verbs explicitly.
 
 ## Resilient LLM patterns
 
-`llm_call` throws on transport / schema / budget failures. Three
-helpers flatten the common recovery boilerplate:
+`llm_call` throws on transport / schema / budget failures. The thrown
+value is a dict with the same fields `llm_call_safe` exposes under
+`r.error`, so scripts can dispatch on category without string-sniffing:
+
+```harn
+try {
+  let r = llm_call(user_prompt, nil, opts)
+} catch (e) {
+  // e is {category, message, retry_after_ms?, provider, model}
+  if e.category == "rate_limit" {
+    sleep(e.retry_after_ms ?? 1000)
+    continue
+  }
+  throw e
+}
+```
+
+Three helpers flatten the common recovery boilerplate:
 
 ```harn
 // Non-throwing envelope: the ok/response/error shape eliminates the
@@ -1016,17 +1032,26 @@ let r = with_rate_limit("openai", fn() {
 }, {max_retries: 5, backoff_ms: 500})
 ```
 
-`llm_call_safe`'s `error.category` is one of the canonical
-`ErrorCategory` strings: `"rate_limit"`, `"timeout"`, `"overloaded"`,
-`"server_error"`, `"transient_network"`, `"schema_validation"`,
-`"auth"`, `"not_found"`, `"circuit_open"`, `"tool_error"`,
-`"tool_rejected"`, `"cancelled"`, `"generic"`. Match on these instead
-of string-sniffing the message.
+`error.category` (both on the thrown dict and on
+`r.error.category`) is one of the canonical `ErrorCategory` strings:
+`"rate_limit"`, `"timeout"`, `"overloaded"`, `"server_error"`,
+`"transient_network"`, `"schema_validation"`, `"auth"`, `"not_found"`,
+`"circuit_open"`, `"tool_error"`, `"tool_rejected"`, `"cancelled"`,
+`"generic"`. `retry_after_ms` is set when the provider surfaced a
+`Retry-After` hint (or `llm_mock` was told to); otherwise omitted.
 
-Pair with `llm_mock({error: {category, message}})` to write
-deterministic tests for either helper's error path:
+Pair with `llm_mock({error: {category, message, retry_after_ms?}})` to
+write deterministic tests for either helper's error path:
 
 ```harn
+llm_mock({error: {category: "rate_limit", message: "429", retry_after_ms: 2500}})
+try {
+  llm_call("hi", nil, {provider: "mock", llm_retries: 0})
+} catch (e) {
+  assert(e.category == "rate_limit")
+  assert(e.retry_after_ms == 2500)
+}
+
 llm_mock({error: {category: "rate_limit", message: "429"}})
 let r = llm_call_safe("hi", nil, {provider: "mock", llm_retries: 0})
 assert(!r.ok)


### PR DESCRIPTION
## Summary

- `llm_call` now throws a dict `{category, message, retry_after_ms?, provider, model}` — the same shape `llm_call_safe` exposes under `r.error`. Catch blocks can dispatch on `e.category` across the 13 canonical `ErrorCategory` strings and honor `e.retry_after_ms` instead of parsing the message.
- `llm_mock({error: {...}})` gained an optional `retry_after_ms` int so tests can exercise the rate-limit retry hint end-to-end (embedded in the message via a synthetic `retry-after:` header, matching how real provider errors surface it).
- Quickref "Resilient LLM patterns" section documents the new throw shape alongside the existing `llm_call_safe` path; CHANGELOG notes the breaking-change migration for callers that substring-matched `catch (e)`.

## Implementation

- `llm_call_impl` wraps the underlying `VmError` into a `Thrown(Dict)` via `build_llm_error_dict` before returning — category derived from `error_to_category`, `retry_after_ms` from the existing `extract_retry_after_ms` parser, `provider`/`model` pulled straight from the resolved `LlmCallOptions`. Everything downstream of `llm_call` (retry classifier, `is_retryable_llm_error`, internal `execute_llm_call` callers like `self_review` / `project.enrich`) is untouched.
- `llm_safe_envelope_err` now passes the pre-built dict through verbatim when the error is already `Thrown(Dict)`, so `llm_call_safe` callers see the same additional fields without diverging copies of the builder.
- `error_category(e)` / `is_rate_limited(e)` already accept either a dict or a string, so existing fixtures that chained them through a `catch` site keep working.

## Test plan

- [x] `make test` (2035 Rust tests pass)
- [x] `cargo run --bin harn -- test conformance` (641 conformance tests pass)
- [x] New fixture `llm_call_error_categories.harn` walks all 13 canonical categories and asserts both the throw-dict shape and the `llm_call_safe` envelope parity.
- [x] Updated `llm_mock_error.harn` verifies `e.category`, `e.retry_after_ms`, `e.provider`, `e.model` and that `error_category(e)` / `is_rate_limited(e)` still work.
- [x] `llm_schema_retry.harn` updated to read `.message` off the new dict (was `contains(unwrap_err(err), "schema")` → `contains(unwrap_err(err).message, "schema")`).
- [x] `make lint-harn`, `make fmt-harn`, clippy `-D warnings`, `cargo fmt --check`
- [ ] Pre-existing `make check-docs-snippets` failures in `docs/src/` (tracked separately in #535) — unchanged by this PR.

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)