### PR TITLE
Prepare v0.7.35 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
-## Unreleased
+## v0.7.35
 
 ### Added
 
@@ -66,6 +66,13 @@ granular archaeology.
   path now defaults `llm_retries` to 2, matching the non-bridge path
   and the documented "transient errors retry, schema errors don't"
   posture. Pass `llm_retries: 0` to opt out.
+- **`llm_call` schema-retry is now a single-turn correction (#533).**
+  The invalid assistant response is no longer replayed across retries.
+  Each retry replays the caller's original messages plus one appended
+  corrective user turn — avoiding the `user → assistant(bad) →
+  user(nudge) → assistant` shape that confuses smaller / local models.
+  The `SchemaRetry` trace event gains a `correction_prompt` field; set
+  `schema_retry_nudge: false` for a bare retry with no appended turn.
 
 ### Fixed
 
@@ -76,6 +83,9 @@ granular archaeology.
   `harn-serve` invokes `tokio::fs::read_to_string` for script reads
   inside async handlers so the runtime isn't blocked on large
   scripts.
+- **Docs snippets (#535).** Fixed 26 failing `harn check` docs
+  snippets across 13 files so `make check-docs-snippets` is clean
+  again.
 
 ## v0.7.34
 


### PR DESCRIPTION
## Summary

Renames the "Unreleased" section to `## v0.7.35` and fills in CHANGELOG
entries for two PRs that landed without them:

- **#538 — `llm_call` schema-retry single-turn correction.** The
  retry loop no longer replays the invalid assistant response; each
  retry replays the caller's original messages plus one corrective
  user turn. `SchemaRetry` trace event gains `correction_prompt`.
- **#540 — Docs snippets fix (#535).** `make check-docs-snippets` is
  clean again after fixing 26 failures across 13 files.

All other `v0.7.35` entries (`llm_call_structured` #531, namespaced
`agent_loop` result shape #532, housekeeping sweep) were already
captured in their respective PRs under `Unreleased`.

## Ships in v0.7.35

- #531 — Ergonomic `llm_call_structured` stdlib helper
- #532 — **BREAKING**: Namespaced `agent_loop` result shape
- #533 — `llm_call` schema-retry rewritten as single-turn correction
- #535 — Docs snippets fixed
- #537 — Housekeeping sweep (host-agnostic defaults, cross-platform
  fixes, formatter regression tests, cancellation docs, unified
  `llm_call` retry default, Ollama env-var rename)

## Test plan

- [x] `markdownlint-cli2 CHANGELOG.md` — 0 errors
- [x] Local `cargo check --workspace --tests` on current main — pass
- [x] Local `cargo nextest run --workspace` on current main — 2035/2035 pass
- [x] Local `harn test conformance` on current main — 641/641 pass
- [ ] Bump Release workflow will auto-fire after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)