### PR TITLE
Prepare v0.7.36 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
-## Unreleased
+## v0.7.36
+
+### Added
+
+- **`assemble_context` builtin (#530).** Adaptive context-assembly
+  primitive that returns a packed prompt of relevance-ranked snippets
+  bounded by a token budget. Pipelines can pass typed source records
+  and per-source metadata; the builtin handles ranking, dedup, and
+  truncation so workflows don't reimplement the same context-packing
+  logic.
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Renames the "Unreleased" section to \`## v0.7.36\` and adds a
CHANGELOG entry for #530 (assemble_context builtin) — #543 landed it
without one. #534 (categorized error-dict throws) was already
captured under "Unreleased" by its own PR (#544).

## Ships in v0.7.36

- #530 — \`assemble_context\` builtin for adaptive context assembly
- #534 — **BREAKING:** \`llm_call\` throws a \`{category, message,
  retry_after_ms?, provider, model}\` dict instead of a string

## Test plan

- [x] \`markdownlint-cli2 CHANGELOG.md\` — 0 errors
- [x] \`cargo fmt --check\` — clean
- [ ] Bump Release workflow auto-fires after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)