### PR TITLE
Enforce harn-modules stdlib mirror parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,22 @@ jobs:
         with:
           components: rustfmt
       - run: make fmt-check
+      - name: Check stdlib mirror parity
+        run: |
+          for vm_file in crates/harn-vm/src/stdlib*.harn; do
+            module_file="crates/harn-modules/src/stdlib/$(basename "$vm_file")"
+
+            if [ ! -f "$module_file" ]; then
+              echo "::error file=$vm_file::Missing stdlib mirror $module_file"
+              exit 1
+            fi
+
+            if ! cmp -s "$vm_file" "$module_file"; then
+              echo "::error file=$vm_file::Stdlib mirror drift: $vm_file must match $module_file byte-for-byte"
+              echo "Run: cp \"$vm_file\" \"$module_file\""
+              exit 1
+            fi
+          done
 
   lint-md:
     name: Markdown lint


### PR DESCRIPTION
## Summary

- Adds a stdlib mirror parity assertion to the existing CI format job.
- Checks every `crates/harn-vm/src/stdlib*.harn` file against the matching file in `crates/harn-modules/src/stdlib/` byte-for-byte.
- Emits a GitHub Actions error annotation and copy command when a mirror is missing or drifted.

## Validation

- Ran the mirror parity loop against the clean tree; it passed.
- Temporarily modified `crates/harn-vm/src/stdlib_text.harn` and verified the loop failed with a useful drift error and repair command, then removed the temporary edit.
- Ran `make lint-actions`.
- Commit hook ran GitHub Actions workflow lint successfully.
- Push hook passed.

Closes #547.