### PR TITLE
[codex] Fix stranded envelope conformance flake

### DIFF
--- a/conformance/tests/integration/orchestrator_recover_stranded_envelopes.harn
+++ b/conformance/tests/integration/orchestrator_recover_stranded_envelopes.harn
@@ -17,11 +17,33 @@ fn wait_for_listener_url(log_path) {
   return url
 }
 
+fn process_alive(pid) {
+  let probe = shell("kill -0 " + pid + " >/dev/null 2>&1")
+  return probe.success
+}
+
+fn wait_for_readyz(url, pid) {
+  var attempts = 0
+  while attempts < 200 {
+    if !process_alive(pid) {
+      return false
+    }
+    try {
+      let response = http_request("GET", url + "/readyz", {timeout_ms: 250})
+      if response.status == 200 {
+        return true
+      }
+    }
+    sleep(25ms)
+    attempts = attempts + 1
+  }
+  return false
+}
+
 fn wait_for_exit(pid) {
   var attempts = 0
   while attempts < 200 {
-    let probe = shell("kill -0 " + pid + " >/dev/null 2>&1")
-    if !probe.success {
+    if !process_alive(pid) {
       return true
     }
     sleep(50ms)
@@ -75,6 +97,7 @@ pipeline test(task) {
   assert(crash_start.success && crash_pid != "", "failed to start crashing orchestrator")
   let crash_url = wait_for_listener_url(path_join(root, "orchestrator-crash.log"))
   assert(crash_url != nil, "crashing listener URL did not appear in log")
+  assert(wait_for_readyz(crash_url, crash_pid), "crashing listener did not become ready")
   let response = http_request(
     "POST",
     crash_url + "/a2a/review",
@@ -94,7 +117,7 @@ pipeline test(task) {
   assert(restart.success && restart_pid != "", "failed to restart orchestrator")
   let restart_url = wait_for_listener_url(path_join(root, "orchestrator-restart.log"))
   assert(restart_url != nil, "restart listener URL did not appear in log")
-  sleep(50ms)
+  assert(wait_for_readyz(restart_url, restart_pid), "restart listener did not become ready")
   let state_dir = path_join(root, "state")
   let config_path = path_join(root, "harn.toml")
   let queue = shell_at(


### PR DESCRIPTION
## Summary

- Add a `/readyz` polling gate to `orchestrator_recover_stranded_envelopes.harn` after the listener URL appears in stderr.
- Reuse the process-alive check for readiness and shutdown polling so the fixture fails fast if the child exits before serving requests.
- Remove the fixed post-restart sleep and wait for explicit orchestrator readiness instead.

## Root Cause

The fixture treated the `HTTP listener ready on ...` log line as sufficient before sending the first A2A request. The Rust orchestrator HTTP tests also probe `/readyz`; without that second gate, the conformance fixture could race the listener bind/accept path and intermittently hit connection refused.

## Validation

- `cargo run --quiet --bin harn -- test conformance --filter orchestrator_recover_stranded_envelopes`
- `for i in $(seq 1 20); do cargo run --quiet --bin harn -- test conformance --filter orchestrator_recover_stranded_envelopes || exit $?; done`
- `cargo run --quiet --bin harn -- fmt --check conformance/tests/integration/orchestrator_recover_stranded_envelopes.harn`
- `git diff --check`
- pre-commit hook: Harn format and lint on staged file
- pre-push hook: workspace Rust tests via nextest, affected Harn formatting, affected Harn lint

Closes #549.