### PR TITLE
[codex] Unify agent_loop llm_retries default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## Unreleased
+
+### Changed
+
+- **Unified `agent_loop` `llm_retries` default at 4 (#554).** Previously
+  the bridge-aware registration defaulted to 4 while the non-bridge
+  registration and `sub_agent_run` defaulted to 3. All three paths now
+  share a single `DEFAULT_AGENT_LOOP_LLM_RETRIES` constant, so an
+  unqualified `agent_loop` or `sub_agent_run` call retries transient
+  provider errors up to four times (five attempts total) regardless of
+  entry point. Callers that explicitly pass `llm_retries` are
+  unaffected.
+
 ## v0.7.36
 
 ### Added

--- a/conformance/tests/integration/agent_loop_llm_retries_default.expected
+++ b/conformance/tests/integration/agent_loop_llm_retries_default.expected
@@ -1,0 +1,3 @@
+done
+Recovered after default retries. ##DONE##
+5

--- a/conformance/tests/integration/agent_loop_llm_retries_default.harn
+++ b/conformance/tests/integration/agent_loop_llm_retries_default.harn
@@ -1,0 +1,14 @@
+pipeline default() {
+  llm_mock_clear()
+  // The default agent_loop retry budget is four retries after the
+  // first attempt. This succeeds only if the fifth mock response is reached.
+  llm_mock({error: {category: "rate_limit", message: "429 transient 1"}})
+  llm_mock({error: {category: "rate_limit", message: "429 transient 2"}})
+  llm_mock({error: {category: "rate_limit", message: "429 transient 3"}})
+  llm_mock({error: {category: "rate_limit", message: "429 transient 4"}})
+  llm_mock({text: "Recovered after default retries. ##DONE##"})
+  let result = agent_loop("finish", nil, {provider: "mock", llm_backoff_ms: 0})
+  println(result.status)
+  println(result.visible_text)
+  println(len(llm_mock_calls()))
+}

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -16,6 +16,8 @@ use super::helpers::{
 };
 use super::tools::build_assistant_response_message;
 
+pub(crate) const DEFAULT_AGENT_LOOP_LLM_RETRIES: usize = 4;
+
 #[derive(Clone)]
 pub struct AgentLoopConfig {
     pub persistent: bool,
@@ -415,7 +417,9 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                     approval_policy,
                     daemon,
                     daemon_config,
-                    llm_retries: opt_int(&options, "llm_retries").unwrap_or(4) as usize,
+                    llm_retries: opt_int(&options, "llm_retries")
+                        .unwrap_or(DEFAULT_AGENT_LOOP_LLM_RETRIES as i64)
+                        as usize,
                     llm_backoff_ms: opt_int(&options, "llm_backoff_ms").unwrap_or(2000) as u64,
                     token_budget: opt_int(&options, "token_budget"),
                     exit_when_verified: opt_bool(&options, "exit_when_verified"),

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -357,7 +357,9 @@ pub(crate) use self::agent::{
     current_agent_session_id, current_host_bridge, emit_agent_event as emit_live_agent_event,
     parse_skill_config, run_agent_loop_internal,
 };
-pub(crate) use self::agent_config::{agent_loop_result_from_llm, AgentLoopConfig};
+pub(crate) use self::agent_config::{
+    agent_loop_result_from_llm, AgentLoopConfig, DEFAULT_AGENT_LOOP_LLM_RETRIES,
+};
 pub use self::agent_config::{
     register_agent_loop_with_bridge, register_llm_call_structured_with_bridge,
     register_llm_call_with_bridge,
@@ -965,7 +967,8 @@ pub fn register_llm_builtins(vm: &mut Vm) {
                 approval_policy,
                 daemon,
                 daemon_config,
-                llm_retries: opt_int(&options, "llm_retries").unwrap_or(3) as usize,
+                llm_retries: opt_int(&options, "llm_retries")
+                    .unwrap_or(DEFAULT_AGENT_LOOP_LLM_RETRIES as i64) as usize,
                 llm_backoff_ms: opt_int(&options, "llm_backoff_ms").unwrap_or(2000) as u64,
                 token_budget: opt_int(&options, "token_budget"),
                 exit_when_verified,

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -661,7 +661,9 @@ fn sub_agent_loop_options(spec: &SubAgentRunSpec) -> Result<crate::llm::AgentLoo
         approval_policy,
         daemon: false,
         daemon_config: Default::default(),
-        llm_retries: crate::llm::helpers::opt_int(&options, "llm_retries").unwrap_or(3) as usize,
+        llm_retries: crate::llm::helpers::opt_int(&options, "llm_retries")
+            .unwrap_or(crate::llm::DEFAULT_AGENT_LOOP_LLM_RETRIES as i64)
+            as usize,
         llm_backoff_ms: crate::llm::helpers::opt_int(&options, "llm_backoff_ms").unwrap_or(2000)
             as u64,
         token_budget: crate::llm::helpers::opt_int(&options, "token_budget"),

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -821,7 +821,8 @@ Returns a namespaced dict: top-level `status`, `text`, `visible_text`
 (`iterations`, `duration_ms`, `input_tokens`, `output_tokens`); tool
 invocation data nested under `tools` (`calls`, `successful`, `rejected`,
 `mode`). Respects the same `llm_retries` / `llm_backoff_ms` options
-plus its own `tool_retries`, `max_iterations`, `max_nudges`, and
+as `llm_call`, with `agent_loop` defaulting `llm_retries` to 4, plus
+its own `tool_retries`, `max_iterations`, `max_nudges`, and
 `native_tool_fallback` (`"allow"`, `"allow_once"`, or `"reject"` for
 native-tool stages that receive text-mode `<tool_call>` fallback
 output).

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -595,6 +595,8 @@ Same as `llm_call`, plus additional options:
 | `max_iterations` | int | `50` | Maximum number of LLM round-trips |
 | `max_nudges` | int | `3` | Max consecutive text-only responses before stopping |
 | `nudge` | string | see below | Custom message to send when nudging the agent |
+| `llm_retries` | int | `4` | Retries on transient HTTP / provider errors. Set to `0` for fail-fast |
+| `llm_backoff_ms` | int | `2000` | Base exponential backoff in ms between LLM retries |
 | `tool_retries` | int | `0` | Number of retry attempts for failed tool calls |
 | `tool_backoff_ms` | int | `1000` | Base backoff delay in ms for tool retries (doubles each attempt) |
 | `policy` | dict | nil | Capability ceiling applied to this agent loop |


### PR DESCRIPTION
## Summary

- Centralize the direct `agent_loop` `llm_retries` default at 4 and use it in both bridge-aware and non-bridge registrations.
- Align `sub_agent_run` with the same `agent_loop` retry default because it builds an `AgentLoopConfig` from mirrored options.
- Document the `agent_loop` retry default and add conformance coverage that reaches the fifth mock provider attempt.

Fixes #536

## Validation

- `cargo run --quiet --bin harn -- test conformance --filter agent_loop_llm_retries_default`
- `cargo check -p harn-vm`
- pre-commit hook: Rust fmt, staged Harn fmt/lint, workspace clippy, highlight sync, markdown lint
- pre-push hook: workspace nextest suite, affected Harn fmt/lint, markdown lint