### PR TITLE
[codex] Add eval pack manifest v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,11 @@ enforcement.
   and `llm_mock_clear()` — queue specific text, tool calls, or mixed
   responses for the mock provider. Supports FIFO queuing and glob-pattern
   matching against prompts.
-- Eval suite manifests and baseline comparisons via `eval_suite_manifest(...)`,
-  `eval_suite_run(...)`, and `harn eval <manifest.json>`, so grouped replay
-  regression suites are first-class runtime data instead of external scripts.
+- Eval suite manifests and portable eval packs via `eval_suite_manifest(...)`,
+  `eval_suite_run(...)`, `harn eval <manifest.json|harn.eval.toml>`, and
+  `harn test package --evals`, so grouped replay, rubric, threshold, and
+  package-shipped connector evals are first-class runtime data instead of
+  external scripts.
 - Typed artifacts and resources as the real context boundary. Context
   selection is artifact-aware, budget-aware, and policy-driven rather than
   raw prompt concatenation.

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -337,6 +337,9 @@ pub(crate) struct TestArgs {
     /// Record then replay each selected pipeline and assert deterministic output.
     #[arg(long)]
     pub determinism: bool,
+    /// Run eval packs declared by the nearest package manifest.
+    #[arg(long)]
+    pub evals: bool,
     /// Extra skill-discovery roots (repeatable). See `harn run
     /// --skill-dir` — applied the same way to user tests and
     /// conformance fixtures so bundled `skills/` dirs are picked up.
@@ -2151,6 +2154,17 @@ mod tests {
         assert_eq!(import.trace_file, "langfuse.jsonl");
         assert_eq!(import.trace_id.as_deref(), Some("trace_123"));
         assert_eq!(import.output, "fixtures/imported.jsonl");
+    }
+
+    #[test]
+    fn test_parses_package_evals_flag() {
+        let cli = Cli::parse_from(["harn", "test", "package", "--evals"]);
+
+        let Command::Test(args) = cli.command.unwrap() else {
+            panic!("expected test command");
+        };
+        assert_eq!(args.target.as_deref(), Some("package"));
+        assert!(args.evals);
     }
 
     #[test]

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -280,7 +280,15 @@ async fn main() {
             commands::check::fmt_targets(&targets, args.check, &opts);
         }
         Command::Test(args) => {
-            if args.determinism {
+            if args.evals {
+                if args.determinism || args.record || args.replay || args.watch {
+                    command_error("--evals cannot be combined with --determinism, --record, --replay, or --watch");
+                }
+                if args.target.as_deref() != Some("package") || args.selection.is_some() {
+                    command_error("package evals are run with `harn test package --evals`");
+                }
+                run_package_evals();
+            } else if args.determinism {
                 if args.watch {
                     command_error("--determinism cannot be combined with --watch");
                 }
@@ -635,22 +643,30 @@ fn load_run_record_or_exit(path: &Path) -> harn_vm::orchestration::RunRecord {
 }
 
 fn load_eval_suite_manifest_or_exit(path: &Path) -> harn_vm::orchestration::EvalSuiteManifest {
-    let content = fs::read_to_string(path).unwrap_or_else(|error| {
-        eprintln!("Failed to read eval manifest {}: {error}", path.display());
+    harn_vm::orchestration::load_eval_suite_manifest(path).unwrap_or_else(|error| {
+        eprintln!("Failed to load eval manifest {}: {error}", path.display());
         process::exit(1);
-    });
-    let mut manifest: harn_vm::orchestration::EvalSuiteManifest = serde_json::from_str(&content)
-        .unwrap_or_else(|error| {
-            eprintln!("Failed to parse eval manifest {}: {error}", path.display());
-            process::exit(1);
-        });
-    if manifest.base_dir.is_none() {
-        manifest.base_dir = path.parent().map(|parent| parent.display().to_string());
-    }
-    manifest
+    })
+}
+
+fn load_eval_pack_manifest_or_exit(path: &Path) -> harn_vm::orchestration::EvalPackManifest {
+    harn_vm::orchestration::load_eval_pack_manifest(path).unwrap_or_else(|error| {
+        eprintln!("Failed to load eval pack {}: {error}", path.display());
+        process::exit(1);
+    })
 }
 
 fn file_looks_like_eval_manifest(path: &Path) -> bool {
+    if path.file_name().and_then(|name| name.to_str()) == Some("harn.eval.toml") {
+        return true;
+    }
+    if path.extension().and_then(|ext| ext.to_str()) == Some("toml") {
+        let Ok(content) = fs::read_to_string(path) else {
+            return false;
+        };
+        return toml::from_str::<harn_vm::orchestration::EvalPackManifest>(&content)
+            .is_ok_and(|manifest| !manifest.cases.is_empty());
+    }
     let Ok(content) = fs::read_to_string(path) else {
         return false;
     };
@@ -659,6 +675,24 @@ fn file_looks_like_eval_manifest(path: &Path) -> bool {
     };
     json.get("_type").and_then(|value| value.as_str()) == Some("eval_suite_manifest")
         || json.get("cases").is_some()
+}
+
+fn file_looks_like_eval_pack_manifest(path: &Path) -> bool {
+    if path.file_name().and_then(|name| name.to_str()) == Some("harn.eval.toml") {
+        return true;
+    }
+    if path.extension().and_then(|ext| ext.to_str()) == Some("toml") {
+        return file_looks_like_eval_manifest(path);
+    }
+    let Ok(content) = fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+    json.get("version").is_some()
+        && json.get("cases").is_some()
+        && json.get("_type").and_then(|value| value.as_str()) != Some("eval_suite_manifest")
 }
 
 fn collect_run_record_paths(path: &str) -> Vec<PathBuf> {
@@ -943,6 +977,28 @@ fn eval_run_record(
     }
 
     let path_buf = PathBuf::from(path);
+    if path_buf.is_file() && file_looks_like_eval_pack_manifest(&path_buf) {
+        if compare.is_some() {
+            eprintln!("--compare is not supported with eval pack manifests");
+            process::exit(1);
+        }
+        let manifest = load_eval_pack_manifest_or_exit(&path_buf);
+        let report = harn_vm::orchestration::evaluate_eval_pack_manifest(&manifest).unwrap_or_else(
+            |error| {
+                eprintln!(
+                    "Failed to evaluate eval pack {}: {error}",
+                    path_buf.display()
+                );
+                process::exit(1);
+            },
+        );
+        print_eval_pack_report(&report);
+        if !report.pass {
+            process::exit(1);
+        }
+        return;
+    }
+
     if path_buf.is_file() && file_looks_like_eval_manifest(&path_buf) {
         if compare.is_some() {
             eprintln!("--compare is not supported with eval suite manifests");
@@ -1054,6 +1110,71 @@ fn eval_run_record(
         }
     }
     if !report.pass {
+        process::exit(1);
+    }
+}
+
+fn print_eval_pack_report(report: &harn_vm::orchestration::EvalPackReport) {
+    println!(
+        "{} {} passed, {} blocking failed, {} warning, {} informational, {} total",
+        if report.pass { "PASS" } else { "FAIL" },
+        report.passed,
+        report.blocking_failed,
+        report.warning_failed,
+        report.informational_failed,
+        report.total
+    );
+    for case in &report.cases {
+        println!(
+            "- {} [{}] {} ({})",
+            case.label,
+            case.workflow_id,
+            if case.pass { "PASS" } else { "FAIL" },
+            case.severity
+        );
+        if let Some(path) = &case.source_path {
+            println!("  path: {}", path);
+        }
+        if let Some(comparison) = &case.comparison {
+            println!("  baseline identical: {}", comparison.identical);
+            if !comparison.identical {
+                println!(
+                    "  baseline status: {} -> {}",
+                    comparison.left_status, comparison.right_status
+                );
+            }
+        }
+        for failure in &case.failures {
+            println!("  {}", failure);
+        }
+        for warning in &case.warnings {
+            println!("  warning: {}", warning);
+        }
+        for item in &case.informational {
+            println!("  info: {}", item);
+        }
+    }
+}
+
+fn run_package_evals() {
+    let paths = package::load_package_eval_pack_paths(None).unwrap_or_else(|error| {
+        eprintln!("{error}");
+        process::exit(1);
+    });
+    let mut all_pass = true;
+    for path in &paths {
+        println!("Eval pack: {}", path.display());
+        let manifest = load_eval_pack_manifest_or_exit(path);
+        let report = harn_vm::orchestration::evaluate_eval_pack_manifest(&manifest).unwrap_or_else(
+            |error| {
+                eprintln!("Failed to evaluate eval pack {}: {error}", path.display());
+                process::exit(1);
+            },
+        );
+        print_eval_pack_report(&report);
+        all_pass &= report.pass;
+    }
+    if !all_pass {
         process::exit(1);
     }
 }

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -790,6 +790,8 @@ pub struct McpServerConfig {
 pub struct PackageInfo {
     pub name: Option<String>,
     pub version: Option<String>,
+    #[serde(default)]
+    pub evals: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -3120,6 +3122,53 @@ pub fn load_workspace_config(anchor: Option<&Path>) -> Option<(WorkspaceConfig, 
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
     let (manifest, dir) = find_nearest_manifest(&anchor)?;
     Some((manifest.workspace, dir))
+}
+
+pub fn load_package_eval_pack_paths(anchor: Option<&Path>) -> Result<Vec<PathBuf>, String> {
+    let anchor = anchor
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let Some((manifest, dir)) = find_nearest_manifest(&anchor) else {
+        return Err("no harn.toml found for package eval discovery".to_string());
+    };
+
+    let declared = manifest
+        .package
+        .as_ref()
+        .map(|package| package.evals.clone())
+        .unwrap_or_default();
+    let mut paths = if declared.is_empty() {
+        let default_pack = dir.join("harn.eval.toml");
+        if default_pack.is_file() {
+            vec![default_pack]
+        } else {
+            Vec::new()
+        }
+    } else {
+        declared
+            .iter()
+            .map(|entry| {
+                let path = PathBuf::from(entry);
+                if path.is_absolute() {
+                    path
+                } else {
+                    dir.join(path)
+                }
+            })
+            .collect()
+    };
+    paths.sort();
+    if paths.is_empty() {
+        return Err(
+            "package declares no eval packs; add [package].evals or harn.eval.toml".to_string(),
+        );
+    }
+    for path in &paths {
+        if !path.is_file() {
+            return Err(format!("eval pack does not exist: {}", path.display()));
+        }
+    }
+    Ok(paths)
 }
 
 pub fn load_personas_from_manifest_path(
@@ -6104,6 +6153,33 @@ mod tests {
         let harn_file = root.join("main.harn");
         fs::write(&harn_file, "pipeline main() {}\n").unwrap();
         harn_file
+    }
+
+    #[test]
+    fn package_eval_pack_paths_use_package_manifest_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::create_dir_all(root.join("evals")).unwrap();
+        fs::write(
+            root.join(MANIFEST),
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+evals = ["evals/webhook.toml"]
+"#,
+        )
+        .unwrap();
+        fs::write(
+            root.join("evals/webhook.toml"),
+            "version = 1\n[[cases]]\nrun = \"run.json\"\n",
+        )
+        .unwrap();
+
+        let paths = load_package_eval_pack_paths(Some(&root.join("src/main.harn"))).unwrap();
+
+        assert_eq!(paths, vec![root.join("evals/webhook.toml")]);
     }
 
     struct TestEnvGuard {

--- a/crates/harn-vm/src/orchestration/records.rs
+++ b/crates/harn-vm/src/orchestration/records.rs
@@ -401,6 +401,176 @@ pub struct EvalSuiteCase {
     pub compare_to: Option<String>,
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct EvalPackManifest {
+    pub version: u32,
+    pub id: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub base_dir: Option<String>,
+    pub package: Option<EvalPackPackage>,
+    pub defaults: EvalPackDefaults,
+    pub fixtures: Vec<EvalPackFixtureRef>,
+    pub rubrics: Vec<EvalPackRubric>,
+    pub judge: Option<EvalPackJudgeConfig>,
+    pub cases: Vec<EvalPackCase>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct EvalPackPackage {
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub source: Option<String>,
+    pub templates: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct EvalPackDefaults {
+    pub severity: Option<String>,
+    pub fixture_root: Option<String>,
+    pub thresholds: EvalPackThresholds,
+    pub judge: Option<EvalPackJudgeConfig>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct EvalPackFixtureRef {
+    pub id: String,
+    pub kind: String,
+    pub path: Option<String>,
+    #[serde(default, alias = "trace-id")]
+    pub trace_id: Option<String>,
+    pub provider: Option<String>,
+    #[serde(default, alias = "event-kind")]
+    pub event_kind: Option<String>,
+    pub inline: Option<serde_json::Value>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct EvalPackRubric {
+    pub id: String,
+    pub kind: String,
+    pub description: Option<String>,
+    pub prompt: Option<String>,
+    pub assertions: Vec<EvalPackAssertion>,
+    pub judge: Option<EvalPackJudgeConfig>,
+    pub calibration: Vec<EvalPackGoldenExample>,
+    pub thresholds: EvalPackThresholds,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct EvalPackAssertion {
+    pub kind: String,
+    pub stage: Option<String>,
+    pub path: Option<String>,
+    pub op: Option<String>,
+    pub expected: Option<serde_json::Value>,
+    pub contains: Option<String>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct EvalPackJudgeConfig {
+    pub model: Option<String>,
+    #[serde(default, alias = "prompt-version")]
+    pub prompt_version: Option<String>,
+    #[serde(default, alias = "tie-break")]
+    pub tie_break: Option<String>,
+    #[serde(default, alias = "confidence-min")]
+    pub confidence_min: Option<f64>,
+    pub temperature: Option<f64>,
+    pub rubric: Option<String>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct EvalPackGoldenExample {
+    pub input: serde_json::Value,
+    pub output: serde_json::Value,
+    pub score: Option<f64>,
+    pub explanation: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct EvalPackThresholds {
+    pub severity: Option<String>,
+    #[serde(default, alias = "min-score")]
+    pub min_score: Option<f64>,
+    #[serde(default, alias = "min-confidence")]
+    pub min_confidence: Option<f64>,
+    #[serde(default, alias = "max-cost-usd")]
+    pub max_cost_usd: Option<f64>,
+    #[serde(default, alias = "max-latency-ms")]
+    pub max_latency_ms: Option<i64>,
+    #[serde(default, alias = "max-tokens")]
+    pub max_tokens: Option<i64>,
+    #[serde(default, alias = "max-stage-count")]
+    pub max_stage_count: Option<usize>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct EvalPackCase {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub run: Option<String>,
+    #[serde(default, alias = "run-path")]
+    pub run_path: Option<String>,
+    pub fixture: Option<String>,
+    #[serde(default, alias = "fixture-path")]
+    pub fixture_path: Option<String>,
+    #[serde(default, alias = "compare-to")]
+    pub compare_to: Option<String>,
+    pub rubrics: Vec<String>,
+    pub severity: Option<String>,
+    pub thresholds: EvalPackThresholds,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct EvalPackReport {
+    pub pack_id: String,
+    pub pass: bool,
+    pub total: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub blocking_failed: usize,
+    pub warning_failed: usize,
+    pub informational_failed: usize,
+    pub cases: Vec<EvalPackCaseReport>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct EvalPackCaseReport {
+    pub id: String,
+    pub label: String,
+    pub severity: String,
+    pub pass: bool,
+    pub blocking: bool,
+    pub run_id: String,
+    pub workflow_id: String,
+    pub source_path: Option<String>,
+    pub stage_count: usize,
+    pub failures: Vec<String>,
+    pub warnings: Vec<String>,
+    pub informational: Vec<String>,
+    pub comparison: Option<RunDiffReport>,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct RunHitlQuestionRecord {
@@ -1427,11 +1597,88 @@ pub fn normalize_eval_suite_manifest(value: &VmValue) -> Result<EvalSuiteManifes
     Ok(manifest)
 }
 
+pub fn load_eval_suite_manifest(path: &Path) -> Result<EvalSuiteManifest, VmError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| VmError::Runtime(format!("failed to read eval suite manifest: {e}")))?;
+    let mut manifest: EvalSuiteManifest = serde_json::from_str(&content)
+        .map_err(|e| VmError::Runtime(format!("failed to parse eval suite manifest: {e}")))?;
+    if manifest.base_dir.is_none() {
+        manifest.base_dir = path.parent().map(|parent| parent.display().to_string());
+    }
+    Ok(manifest)
+}
+
+pub fn load_eval_pack_manifest(path: &Path) -> Result<EvalPackManifest, VmError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| VmError::Runtime(format!("failed to read eval pack manifest: {e}")))?;
+    let mut manifest: EvalPackManifest =
+        if path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+            serde_json::from_str(&content)
+                .map_err(|e| VmError::Runtime(format!("failed to parse eval pack JSON: {e}")))?
+        } else {
+            toml::from_str(&content)
+                .map_err(|e| VmError::Runtime(format!("failed to parse eval pack TOML: {e}")))?
+        };
+    normalize_eval_pack_manifest(&mut manifest);
+    if manifest.base_dir.is_none() {
+        manifest.base_dir = path.parent().map(|parent| parent.display().to_string());
+    }
+    Ok(manifest)
+}
+
+fn normalize_eval_pack_manifest(manifest: &mut EvalPackManifest) {
+    if manifest.version == 0 {
+        manifest.version = 1;
+    }
+    if manifest.id.is_empty() {
+        manifest.id = manifest
+            .name
+            .clone()
+            .filter(|name| !name.trim().is_empty())
+            .unwrap_or_else(|| new_id("eval_pack"));
+    }
+}
+
 fn load_replay_fixture(path: &Path) -> Result<ReplayFixture, VmError> {
     let content = std::fs::read_to_string(path)
         .map_err(|e| VmError::Runtime(format!("failed to read replay fixture: {e}")))?;
     serde_json::from_str(&content)
         .map_err(|e| VmError::Runtime(format!("failed to parse replay fixture: {e}")))
+}
+
+fn load_run_record_from_fixture_ref(
+    fixture: &EvalPackFixtureRef,
+    base_dir: Option<&Path>,
+) -> Result<RunRecord, VmError> {
+    if let Some(inline) = &fixture.inline {
+        let run: RunRecord = serde_json::from_value(inline.clone())
+            .map_err(|e| VmError::Runtime(format!("failed to parse inline run record: {e}")))?;
+        return Ok(run);
+    }
+    let path = fixture.path.as_deref().ok_or_else(|| {
+        VmError::Runtime(format!(
+            "fixture '{}' is missing path or inline run",
+            fixture.id
+        ))
+    })?;
+    load_run_record(&resolve_manifest_path(base_dir, path))
+}
+
+fn load_replay_fixture_from_ref(
+    fixture: &EvalPackFixtureRef,
+    base_dir: Option<&Path>,
+) -> Result<ReplayFixture, VmError> {
+    if let Some(inline) = &fixture.inline {
+        return serde_json::from_value(inline.clone())
+            .map_err(|e| VmError::Runtime(format!("failed to parse inline replay fixture: {e}")));
+    }
+    let path = fixture.path.as_deref().ok_or_else(|| {
+        VmError::Runtime(format!(
+            "fixture '{}' is missing path or inline replay fixture",
+            fixture.id
+        ))
+    })?;
+    load_replay_fixture(&resolve_manifest_path(base_dir, path))
 }
 
 fn resolve_manifest_path(base_dir: Option<&Path>, path: &str) -> PathBuf {
@@ -1501,6 +1748,398 @@ pub fn evaluate_run_suite_manifest(
         failed,
         cases: reports,
     })
+}
+
+pub fn evaluate_eval_pack_manifest(manifest: &EvalPackManifest) -> Result<EvalPackReport, VmError> {
+    let base_dir = manifest.base_dir.as_deref().map(Path::new);
+    let fixture_base_dir_buf = manifest
+        .defaults
+        .fixture_root
+        .as_deref()
+        .map(|root| resolve_manifest_path(base_dir, root));
+    let fixture_base_dir = fixture_base_dir_buf.as_deref().or(base_dir);
+    let fixtures_by_id: BTreeMap<&str, &EvalPackFixtureRef> = manifest
+        .fixtures
+        .iter()
+        .filter(|fixture| !fixture.id.is_empty())
+        .map(|fixture| (fixture.id.as_str(), fixture))
+        .collect();
+    let rubrics_by_id: BTreeMap<&str, &EvalPackRubric> = manifest
+        .rubrics
+        .iter()
+        .filter(|rubric| !rubric.id.is_empty())
+        .map(|rubric| (rubric.id.as_str(), rubric))
+        .collect();
+
+    let mut reports = Vec::new();
+    for (index, case) in manifest.cases.iter().enumerate() {
+        let case_id = case
+            .id
+            .clone()
+            .filter(|id| !id.trim().is_empty())
+            .unwrap_or_else(|| format!("case_{}", index + 1));
+        let label = case
+            .name
+            .clone()
+            .or_else(|| case.id.clone())
+            .unwrap_or_else(|| case_id.clone());
+        let severity = eval_pack_case_severity(manifest, case);
+        let blocking = severity == "blocking";
+        let mut failures = Vec::new();
+        let mut warnings = Vec::new();
+        let mut informational = Vec::new();
+
+        let run = load_eval_pack_case_run(case, base_dir, fixture_base_dir, &fixtures_by_id)?;
+        let fixture =
+            load_eval_pack_case_fixture(case, base_dir, fixture_base_dir, &fixtures_by_id, &run)?;
+        let eval = evaluate_run_against_fixture(&run, &fixture);
+        failures.extend(eval.failures);
+        apply_eval_pack_thresholds(&run, &manifest.defaults.thresholds, &mut failures);
+        apply_eval_pack_thresholds(&run, &case.thresholds, &mut failures);
+
+        let comparison = match &case.compare_to {
+            Some(path) => {
+                let baseline_path = resolve_manifest_path(base_dir, path);
+                let baseline = load_run_record(&baseline_path)?;
+                let diff = diff_run_records(&baseline, &run);
+                if !diff.identical {
+                    failures.push(format!(
+                        "run differs from baseline {} with {} stage changes",
+                        baseline_path.display(),
+                        diff.stage_diffs.len()
+                    ));
+                }
+                Some(diff)
+            }
+            None => None,
+        };
+
+        for rubric_id in &case.rubrics {
+            let Some(rubric) = rubrics_by_id.get(rubric_id.as_str()) else {
+                failures.push(format!("case references unknown rubric '{rubric_id}'"));
+                continue;
+            };
+            apply_eval_pack_rubric(rubric, &run, &mut failures, &mut warnings);
+        }
+
+        let pass = failures.is_empty() || !blocking;
+        if !failures.is_empty() && !blocking {
+            if severity == "warning" {
+                warnings.append(&mut failures);
+            } else {
+                informational.append(&mut failures);
+            }
+        }
+        reports.push(EvalPackCaseReport {
+            id: case_id,
+            label,
+            severity,
+            pass,
+            blocking,
+            run_id: run.id.clone(),
+            workflow_id: run.workflow_id.clone(),
+            source_path: eval_pack_case_source_path(
+                case,
+                base_dir,
+                fixture_base_dir,
+                &fixtures_by_id,
+            ),
+            stage_count: eval.stage_count,
+            failures,
+            warnings,
+            informational,
+            comparison,
+        });
+    }
+
+    let total = reports.len();
+    let blocking_failed = reports
+        .iter()
+        .filter(|report| report.blocking && !report.failures.is_empty())
+        .count();
+    let warning_failed = reports
+        .iter()
+        .filter(|report| !report.warnings.is_empty())
+        .count();
+    let informational_failed = reports
+        .iter()
+        .filter(|report| !report.informational.is_empty())
+        .count();
+    let passed = reports.iter().filter(|report| report.pass).count();
+    Ok(EvalPackReport {
+        pack_id: manifest.id.clone(),
+        pass: blocking_failed == 0,
+        total,
+        passed,
+        failed: total.saturating_sub(passed),
+        blocking_failed,
+        warning_failed,
+        informational_failed,
+        cases: reports,
+    })
+}
+
+fn eval_pack_case_severity(manifest: &EvalPackManifest, case: &EvalPackCase) -> String {
+    normalize_eval_pack_severity(
+        case.severity
+            .as_deref()
+            .or(case.thresholds.severity.as_deref())
+            .or(manifest.defaults.severity.as_deref())
+            .or(manifest.defaults.thresholds.severity.as_deref())
+            .unwrap_or("blocking"),
+    )
+}
+
+fn normalize_eval_pack_severity(value: &str) -> String {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "warn" | "warning" => "warning".to_string(),
+        "info" | "informational" => "informational".to_string(),
+        _ => "blocking".to_string(),
+    }
+}
+
+fn load_eval_pack_case_run(
+    case: &EvalPackCase,
+    base_dir: Option<&Path>,
+    fixture_base_dir: Option<&Path>,
+    fixtures_by_id: &BTreeMap<&str, &EvalPackFixtureRef>,
+) -> Result<RunRecord, VmError> {
+    if let Some(run_ref) = case.run.as_deref().or(case.run_path.as_deref()) {
+        if let Some(fixture) = fixtures_by_id.get(run_ref) {
+            return load_run_record_from_fixture_ref(fixture, fixture_base_dir);
+        }
+        return load_run_record(&resolve_manifest_path(base_dir, run_ref));
+    }
+    Err(VmError::Runtime(
+        "eval pack case is missing run or run_path".to_string(),
+    ))
+}
+
+fn load_eval_pack_case_fixture(
+    case: &EvalPackCase,
+    base_dir: Option<&Path>,
+    fixture_base_dir: Option<&Path>,
+    fixtures_by_id: &BTreeMap<&str, &EvalPackFixtureRef>,
+    run: &RunRecord,
+) -> Result<ReplayFixture, VmError> {
+    if let Some(fixture_ref) = case.fixture.as_deref().or(case.fixture_path.as_deref()) {
+        if let Some(fixture) = fixtures_by_id.get(fixture_ref) {
+            return load_replay_fixture_from_ref(fixture, fixture_base_dir);
+        }
+        return load_replay_fixture(&resolve_manifest_path(base_dir, fixture_ref));
+    }
+    Ok(run
+        .replay_fixture
+        .clone()
+        .unwrap_or_else(|| replay_fixture_from_run(run)))
+}
+
+fn eval_pack_case_source_path(
+    case: &EvalPackCase,
+    base_dir: Option<&Path>,
+    fixture_base_dir: Option<&Path>,
+    fixtures_by_id: &BTreeMap<&str, &EvalPackFixtureRef>,
+) -> Option<String> {
+    let run_ref = case.run.as_deref().or(case.run_path.as_deref())?;
+    if let Some(fixture) = fixtures_by_id.get(run_ref) {
+        return fixture.path.as_ref().map(|path| {
+            resolve_manifest_path(fixture_base_dir, path)
+                .display()
+                .to_string()
+        });
+    }
+    Some(
+        resolve_manifest_path(base_dir, run_ref)
+            .display()
+            .to_string(),
+    )
+}
+
+fn apply_eval_pack_thresholds(
+    run: &RunRecord,
+    thresholds: &EvalPackThresholds,
+    failures: &mut Vec<String>,
+) {
+    if let Some(max_stage_count) = thresholds.max_stage_count {
+        if run.stages.len() > max_stage_count {
+            failures.push(format!(
+                "stage count {} exceeds threshold {}",
+                run.stages.len(),
+                max_stage_count
+            ));
+        }
+    }
+    if let Some(max_latency_ms) = thresholds.max_latency_ms {
+        let actual = run
+            .usage
+            .as_ref()
+            .map(|usage| usage.total_duration_ms)
+            .unwrap_or_default();
+        if actual > max_latency_ms {
+            failures.push(format!(
+                "latency {actual}ms exceeds threshold {max_latency_ms}ms"
+            ));
+        }
+    }
+    if let Some(max_cost_usd) = thresholds.max_cost_usd {
+        let actual = run
+            .usage
+            .as_ref()
+            .map(|usage| usage.total_cost)
+            .unwrap_or_default();
+        if actual > max_cost_usd {
+            failures.push(format!(
+                "cost ${actual:.6} exceeds threshold ${max_cost_usd:.6}"
+            ));
+        }
+    }
+    if let Some(max_tokens) = thresholds.max_tokens {
+        let actual = run
+            .usage
+            .as_ref()
+            .map(|usage| usage.input_tokens + usage.output_tokens)
+            .unwrap_or_default();
+        if actual > max_tokens {
+            failures.push(format!(
+                "token count {actual} exceeds threshold {max_tokens}"
+            ));
+        }
+    }
+}
+
+fn apply_eval_pack_rubric(
+    rubric: &EvalPackRubric,
+    run: &RunRecord,
+    failures: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+) {
+    match rubric.kind.as_str() {
+        "" | "deterministic" | "replay" | "budget" | "hitl" | "side-effect" => {
+            apply_eval_pack_thresholds(run, &rubric.thresholds, failures);
+            for assertion in &rubric.assertions {
+                apply_eval_pack_assertion(rubric, assertion, run, failures);
+            }
+        }
+        "llm-judge" | "llm_as_judge" | "judge" => {
+            let severity = normalize_eval_pack_severity(
+                rubric.thresholds.severity.as_deref().unwrap_or("blocking"),
+            );
+            let message = format!(
+                "rubric '{}' requires an external LLM judge and was not run locally",
+                rubric.id
+            );
+            if severity == "blocking" {
+                failures.push(message);
+            } else {
+                warnings.push(message);
+            }
+        }
+        other => warnings.push(format!(
+            "rubric '{}' has unknown kind '{}' and was not run locally",
+            rubric.id, other
+        )),
+    }
+}
+
+fn apply_eval_pack_assertion(
+    rubric: &EvalPackRubric,
+    assertion: &EvalPackAssertion,
+    run: &RunRecord,
+    failures: &mut Vec<String>,
+) {
+    match assertion.kind.as_str() {
+        "run-status" | "run_status" | "status" => {
+            let expected = assertion.expected.as_ref().and_then(|value| value.as_str());
+            if let Some(expected) = expected {
+                if run.status != expected {
+                    failures.push(format!(
+                        "rubric '{}' expected run status {}, got {}",
+                        rubric.id, expected, run.status
+                    ));
+                }
+            }
+        }
+        "stage-status" | "stage_status" => {
+            let Some(stage_id) = assertion.stage.as_deref() else {
+                failures.push(format!(
+                    "rubric '{}' stage-status assertion missing stage",
+                    rubric.id
+                ));
+                return;
+            };
+            let expected = assertion.expected.as_ref().and_then(|value| value.as_str());
+            let Some(expected) = expected else {
+                failures.push(format!(
+                    "rubric '{}' stage-status assertion missing expected string",
+                    rubric.id
+                ));
+                return;
+            };
+            match run.stages.iter().find(|stage| stage.node_id == stage_id) {
+                Some(stage) if stage.status == expected => {}
+                Some(stage) => failures.push(format!(
+                    "rubric '{}' expected stage {} status {}, got {}",
+                    rubric.id, stage_id, expected, stage.status
+                )),
+                None => failures.push(format!(
+                    "rubric '{}' expected stage {} to exist",
+                    rubric.id, stage_id
+                )),
+            }
+        }
+        "visible-text-contains" | "visible_text_contains" => {
+            let Some(needle) = assertion.contains.as_deref() else {
+                failures.push(format!(
+                    "rubric '{}' visible-text assertion missing contains",
+                    rubric.id
+                ));
+                return;
+            };
+            let matched = match assertion.stage.as_deref() {
+                Some(stage_id) => run
+                    .stages
+                    .iter()
+                    .find(|stage| stage.node_id == stage_id)
+                    .and_then(|stage| stage.visible_text.as_deref())
+                    .is_some_and(|text| text.contains(needle)),
+                None => run
+                    .stages
+                    .iter()
+                    .filter_map(|stage| stage.visible_text.as_deref())
+                    .any(|text| text.contains(needle)),
+            };
+            if !matched {
+                failures.push(format!(
+                    "rubric '{}' expected visible text to contain {:?}",
+                    rubric.id, needle
+                ));
+            }
+        }
+        "hitl-question-contains" | "hitl_question_contains" => {
+            let Some(needle) = assertion.contains.as_deref() else {
+                failures.push(format!(
+                    "rubric '{}' HITL assertion missing contains",
+                    rubric.id
+                ));
+                return;
+            };
+            if !run
+                .hitl_questions
+                .iter()
+                .any(|question| question.prompt.contains(needle))
+            {
+                failures.push(format!(
+                    "rubric '{}' expected HITL question to contain {:?}",
+                    rubric.id, needle
+                ));
+            }
+        }
+        "" => {}
+        other => failures.push(format!(
+            "rubric '{}' has unsupported assertion kind '{}'",
+            rubric.id, other
+        )),
+    }
 }
 
 /// Edit operation in a diff sequence.
@@ -2468,5 +3107,111 @@ pub fn diff_run_records(left: &RunRecord, right: &RunRecord) -> RunDiffReport {
         transition_count_delta: right.transitions.len() as isize - left.transitions.len() as isize,
         artifact_count_delta: right.artifacts.len() as isize - left.artifacts.len() as isize,
         checkpoint_count_delta: right.checkpoints.len() as isize - left.checkpoints.len() as isize,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn minimal_run(status: &str) -> RunRecord {
+        RunRecord {
+            type_name: "workflow_run".to_string(),
+            id: "run_1".to_string(),
+            workflow_id: "workflow_1".to_string(),
+            status: status.to_string(),
+            usage: Some(LlmUsageRecord {
+                total_duration_ms: 12,
+                total_cost: 0.01,
+                input_tokens: 3,
+                output_tokens: 4,
+                call_count: 1,
+                models: vec!["mock".to_string()],
+            }),
+            replay_fixture: Some(ReplayFixture {
+                type_name: "replay_fixture".to_string(),
+                expected_status: "completed".to_string(),
+                ..ReplayFixture::default()
+            }),
+            ..RunRecord::default()
+        }
+    }
+
+    #[test]
+    fn eval_pack_manifest_toml_runs_replay_case() {
+        let temp = tempfile::tempdir().unwrap();
+        let run_path = temp.path().join("run.json");
+        fs::write(
+            &run_path,
+            serde_json::to_string(&minimal_run("completed")).unwrap(),
+        )
+        .unwrap();
+        let pack_path = temp.path().join("harn.eval.toml");
+        fs::write(
+            &pack_path,
+            r#"
+version = 1
+id = "connector-regressions"
+name = "Connector regressions"
+
+[[cases]]
+id = "webhook"
+name = "Webhook normalization"
+run = "run.json"
+rubrics = ["status"]
+
+[[rubrics]]
+id = "status"
+kind = "deterministic"
+
+[[rubrics.assertions]]
+kind = "run-status"
+expected = "completed"
+"#,
+        )
+        .unwrap();
+
+        let manifest = load_eval_pack_manifest(&pack_path).unwrap();
+        let report = evaluate_eval_pack_manifest(&manifest).unwrap();
+
+        assert!(report.pass);
+        assert_eq!(report.total, 1);
+        assert_eq!(report.cases[0].label, "Webhook normalization");
+    }
+
+    #[test]
+    fn eval_pack_warning_case_does_not_block() {
+        let temp = tempfile::tempdir().unwrap();
+        let run_path = temp.path().join("run.json");
+        fs::write(
+            &run_path,
+            serde_json::to_string(&minimal_run("completed")).unwrap(),
+        )
+        .unwrap();
+        let pack_path = temp.path().join("harn.eval.toml");
+        fs::write(
+            &pack_path,
+            r#"
+version = 1
+id = "budgets"
+
+[[cases]]
+id = "latency-budget"
+run = "run.json"
+severity = "warning"
+
+[cases.thresholds]
+max-latency-ms = 1
+"#,
+        )
+        .unwrap();
+
+        let manifest = load_eval_pack_manifest(&pack_path).unwrap();
+        let report = evaluate_eval_pack_manifest(&manifest).unwrap();
+
+        assert!(report.pass);
+        assert_eq!(report.warning_failed, 1);
+        assert!(report.cases[0].warnings[0].contains("latency"));
     }
 }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -545,15 +545,26 @@ harn eval .harn-runs/<run>.json
 harn eval .harn-runs/<run>.json --compare baseline.json
 harn eval .harn-runs/
 harn eval evals/regression.json
+harn eval harn.eval.toml
 harn eval evals/clarifying-question.json
 harn eval --llm-mock fixtures.jsonl --structural-experiment doubled_prompt pipeline.harn
 ```
 
-`harn eval` accepts three inputs:
+`harn eval` accepts four inputs:
 
 - a single run record JSON file
 - a directory of run record JSON files
 - an eval suite manifest JSON file with grouped cases and optional baseline comparisons
+- an eval-pack v1 TOML/JSON manifest such as `harn.eval.toml`
+
+Run eval packs declared by a package manifest with:
+
+```bash
+harn test package --evals
+```
+
+Package eval discovery uses `[package].evals = ["evals/webhooks.toml"]` when
+present, otherwise it falls back to `harn.eval.toml` in the package root.
 
 Clarifying-question evals use an explicit fixture with
 `"eval_kind": "clarifying_question"`. The fixture checks persisted

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -3775,6 +3775,78 @@ stem. Use `harn add <alias> --path ../repo` for the legacy explicit
 alias form, or `harn add <alias> --git ../repo` when a local git checkout
 should be pinned by commit instead of live-linked.
 
+### Eval packs
+
+Packages can ship portable eval packs in `harn.eval.toml` or in paths listed
+under `[package].evals`:
+
+```toml
+[package]
+name = "slack-connector"
+version = "0.1.0"
+evals = ["evals/webhooks.toml"]
+```
+
+An eval pack is a TOML document with `version = 1`, package metadata, fixture
+references, rubrics, optional judge calibration, thresholds, and cases:
+
+```toml
+version = 1
+id = "slack-connector"
+name = "Slack connector evals"
+
+[[fixtures]]
+id = "url-verification-run"
+kind = "run-record"
+path = "fixtures/url-verification.run.json"
+
+[[fixtures]]
+id = "url-verification-replay"
+kind = "replay-fixture"
+path = "fixtures/url-verification.replay.json"
+
+[[rubrics]]
+id = "normalization"
+kind = "deterministic"
+
+[[rubrics.assertions]]
+kind = "run-status"
+expected = "completed"
+
+[[cases]]
+id = "url-verification"
+run = "url-verification-run"
+fixture = "url-verification-replay"
+rubrics = ["normalization"]
+severity = "blocking"
+
+[cases.thresholds]
+max-latency-ms = 500
+max-cost-usd = 0.001
+```
+
+Fixture `kind` values are portable labels: `run-record`, `replay-fixture`,
+`jsonl-trace`, `provider-events`, and `connector-payload`. Local CLI evaluation
+executes run-record/replay-fixture cases and deterministic assertions; other
+fixture kinds remain importable metadata for hosted runners.
+
+Rubric `kind` values include `deterministic`, `replay`, `budget`, `hitl`,
+`side-effect`, and `llm-judge`. LLM judge rubrics declare model selection,
+prompt version, tie handling, confidence minimums, and golden examples, but a
+blocking `llm-judge` rubric fails local evaluation unless an explicit judge
+runner handles it.
+
+Threshold severity controls deployment-gate behavior:
+
+| Severity | Meaning |
+|---|---|
+| `blocking` | Failure exits non-zero locally and blocks deployment gates |
+| `warning` | Failure is reported but does not block |
+| `informational` | Failure is reported for comparison and dashboards only |
+
+Run a pack directly with `harn eval harn.eval.toml`, or run package-declared
+packs with `harn test package --evals`.
+
 ### Package registry index
 
 `harn package search`, `harn package info`, and registry-name

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -179,6 +179,100 @@ such as `model`, `provider`, and token counts when present.
 `harn eval` supports the default replay fixture flow plus an explicit
 clarifying-question kind for ambiguous tasks.
 
+## Eval packs
+
+Portable eval packs live in `harn.eval.toml` or another TOML file listed in
+`[package].evals` in `harn.toml`. The same pack can be run locally and imported
+by hosted tooling because it contains only portable fixture references, rubrics,
+judge metadata, thresholds, and package metadata.
+
+```toml
+version = 1
+id = "slack-connector"
+name = "Slack connector evals"
+
+[package]
+name = "slack-connector"
+version = "0.1.0"
+
+[[fixtures]]
+id = "url-verification-run"
+kind = "run-record"
+path = "fixtures/url-verification.run.json"
+
+[[fixtures]]
+id = "url-verification-replay"
+kind = "replay-fixture"
+path = "fixtures/url-verification.replay.json"
+
+[[rubrics]]
+id = "webhook-normalization"
+kind = "deterministic"
+description = "Webhook normalization keeps status and response shape stable."
+
+[[rubrics.assertions]]
+kind = "run-status"
+expected = "completed"
+
+[[cases]]
+id = "url-verification"
+name = "URL verification handshake"
+run = "url-verification-run"
+fixture = "url-verification-replay"
+rubrics = ["webhook-normalization"]
+severity = "blocking"
+
+[cases.thresholds]
+max-latency-ms = 500
+max-cost-usd = 0.001
+```
+
+Run a single pack directly:
+
+```bash
+harn eval harn.eval.toml
+```
+
+Run the eval packs shipped by a package:
+
+```bash
+harn test package --evals
+```
+
+`[package].evals` is optional when the package root contains
+`harn.eval.toml`; otherwise declare one or more package-relative pack paths:
+
+```toml
+[package]
+name = "slack-connector"
+version = "0.1.0"
+evals = ["evals/webhooks.toml", "evals/replay.toml"]
+```
+
+Fixture refs support these portable `kind` values:
+
+| Kind | Local behavior |
+|---|---|
+| `run-record` or `recorded-run` | Loads a persisted Harn run record JSON file |
+| `replay-fixture` | Loads a replay fixture JSON file |
+| `jsonl-trace` | Reserved for imported trace fixture metadata |
+| `provider-events` | Reserved for synthetic provider event streams |
+| `connector-payload` | Reserved for connector payload samples |
+
+Local `harn eval` executes replay fixtures, baseline comparisons,
+deterministic assertions, HITL question assertions, and cost/latency/token/stage
+thresholds. `llm-judge` rubrics carry judge model, calibration, tie-break, and
+prompt-version metadata for hosted or explicit judge runners; a blocking
+`llm-judge` rubric fails locally rather than being silently skipped.
+
+Threshold `severity` controls gate behavior:
+
+| Severity | Local gate behavior |
+|---|---|
+| `blocking` | Failing case exits non-zero |
+| `warning` | Failure is reported but does not fail the command |
+| `informational` | Failure is reported as info only |
+
 ### Replay evals
 
 Replay evals are the default. They compare a run's persisted status and

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -3773,6 +3773,78 @@ stem. Use `harn add <alias> --path ../repo` for the legacy explicit
 alias form, or `harn add <alias> --git ../repo` when a local git checkout
 should be pinned by commit instead of live-linked.
 
+### Eval packs
+
+Packages can ship portable eval packs in `harn.eval.toml` or in paths listed
+under `[package].evals`:
+
+```toml
+[package]
+name = "slack-connector"
+version = "0.1.0"
+evals = ["evals/webhooks.toml"]
+```
+
+An eval pack is a TOML document with `version = 1`, package metadata, fixture
+references, rubrics, optional judge calibration, thresholds, and cases:
+
+```toml
+version = 1
+id = "slack-connector"
+name = "Slack connector evals"
+
+[[fixtures]]
+id = "url-verification-run"
+kind = "run-record"
+path = "fixtures/url-verification.run.json"
+
+[[fixtures]]
+id = "url-verification-replay"
+kind = "replay-fixture"
+path = "fixtures/url-verification.replay.json"
+
+[[rubrics]]
+id = "normalization"
+kind = "deterministic"
+
+[[rubrics.assertions]]
+kind = "run-status"
+expected = "completed"
+
+[[cases]]
+id = "url-verification"
+run = "url-verification-run"
+fixture = "url-verification-replay"
+rubrics = ["normalization"]
+severity = "blocking"
+
+[cases.thresholds]
+max-latency-ms = 500
+max-cost-usd = 0.001
+```
+
+Fixture `kind` values are portable labels: `run-record`, `replay-fixture`,
+`jsonl-trace`, `provider-events`, and `connector-payload`. Local CLI evaluation
+executes run-record/replay-fixture cases and deterministic assertions; other
+fixture kinds remain importable metadata for hosted runners.
+
+Rubric `kind` values include `deterministic`, `replay`, `budget`, `hitl`,
+`side-effect`, and `llm-judge`. LLM judge rubrics declare model selection,
+prompt version, tie handling, confidence minimums, and golden examples, but a
+blocking `llm-judge` rubric fails local evaluation unless an explicit judge
+runner handles it.
+
+Threshold severity controls deployment-gate behavior:
+
+| Severity | Meaning |
+|---|---|
+| `blocking` | Failure exits non-zero locally and blocks deployment gates |
+| `warning` | Failure is reported but does not block |
+| `informational` | Failure is reported for comparison and dashboards only |
+
+Run a pack directly with `harn eval harn.eval.toml`, or run package-declared
+packs with `harn test package --evals`.
+
 ### Package registry index
 
 `harn package search`, `harn package info`, and registry-name


### PR DESCRIPTION
## Summary

- Add eval-pack v1 manifest structs and TOML/JSON loading in harn-vm.
- Evaluate portable packs through existing replay fixtures, baseline diffs, deterministic/HITL assertions, and cost/latency/token/stage thresholds.
- Add `harn eval harn.eval.toml` and `harn test package --evals` with `[package].evals` discovery.
- Document the pack format, fixture/rubric kinds, judge metadata, and threshold severities.

Closes #450.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-issue450 cargo test -p harn-vm orchestration::records::tests::eval_pack --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue450 cargo test -p harn-cli package_eval_pack_paths_use_package_manifest_entries --bin harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue450 cargo test -p harn-cli test_parses_package_evals_flag --bin harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue450 cargo check -p harn-vm -p harn-cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue450 make check-docs-snippets`
- `harn eval harn.eval.toml` smoke test against a temp pack
- `harn test package --evals` smoke test against a temp package
- pre-commit hook: fmt, clippy --workspace --all-targets -D warnings, markdownlint
- pre-push hook: nextest 2050/2050 passed, markdownlint
