### PR TITLE
[codex] Implement continuous persona runtime primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ granular archaeology.
 
 ### Added
 
+- **Continuous persona runtime primitives (#462).** Adds an
+  event-sourced `persona.runtime.events` runtime with lifecycle state,
+  single-writer leases, schedule and external trigger wake receipts,
+  pause/resume/disable controls, per-persona budget enforcement, and
+  stable `harn persona status <name> --json` output for hosts.
 - **`assemble_context` builtin (#530).** Adaptive context-assembly
   primitive that returns a packed prompt of relevance-ranked snippets
   bounded by a token budget. Pipelines can pass typed source records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ granular archaeology.
 
 ## Unreleased
 
+### Added
+
+- **Continuous persona runtime primitives (#462).** Adds an
+  event-sourced `persona.runtime.events` runtime with lifecycle state,
+  single-writer leases, schedule and external trigger wake receipts,
+  pause/resume/disable controls, per-persona budget enforcement, and
+  stable `harn persona status <name> --json` output for hosts.
+
 ### Changed
 
 - **Unified `agent_loop` `llm_retries` default at 4 (#554).** Previously
@@ -24,11 +32,6 @@ granular archaeology.
 
 ### Added
 
-- **Continuous persona runtime primitives (#462).** Adds an
-  event-sourced `persona.runtime.events` runtime with lifecycle state,
-  single-writer leases, schedule and external trigger wake receipts,
-  pause/resume/disable controls, per-persona budget enforcement, and
-  stable `harn persona status <name> --json` output for hosts.
 - **`assemble_context` builtin (#530).** Adaptive context-assembly
   primitive that returns a packed prompt of relevance-ranked snippets
   bounded by a token budget. Pipelines can pass typed source records

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -1651,6 +1651,14 @@ pub(crate) struct PersonaArgs {
     /// Explicit harn.toml path or directory. Defaults to nearest harn.toml from cwd.
     #[arg(long, global = true, value_name = "PATH")]
     pub manifest: Option<PathBuf>,
+    /// Directory used for durable persona runtime state and event-log data.
+    #[arg(
+        long,
+        global = true,
+        value_name = "DIR",
+        default_value = ".harn/personas"
+    )]
+    pub state_dir: PathBuf,
 }
 
 #[derive(Debug, Subcommand)]
@@ -1659,6 +1667,20 @@ pub(crate) enum PersonaCommand {
     List(PersonaListArgs),
     /// Inspect one persona from the resolved harn.toml.
     Inspect(PersonaInspectArgs),
+    /// Query durable persona lifecycle, lease, budget, and queue status.
+    Status(PersonaStatusArgs),
+    /// Pause a persona; matching events queue until resume drains them.
+    Pause(PersonaControlArgs),
+    /// Resume a persona and drain queued events once under leases.
+    Resume(PersonaControlArgs),
+    /// Disable a persona; matching events are recorded as dead-lettered.
+    Disable(PersonaControlArgs),
+    /// Fire a synthetic schedule tick for a persona.
+    Tick(PersonaTickArgs),
+    /// Fire a synthetic external trigger envelope for a persona.
+    Trigger(PersonaTriggerArgs),
+    /// Record an expensive-work budget receipt for a persona.
+    Spend(PersonaSpendArgs),
 }
 
 #[derive(Debug, Args)]
@@ -1673,6 +1695,87 @@ pub(crate) struct PersonaInspectArgs {
     /// Persona name to inspect.
     pub name: String,
     /// Emit stable JSON for Harn Cloud, Burin Code, or other hosts.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PersonaStatusArgs {
+    /// Persona name to query.
+    pub name: String,
+    /// Emit stable JSON for Harn Cloud, Burin Code, or other hosts.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PersonaControlArgs {
+    /// Persona name to control.
+    pub name: String,
+    /// Emit stable JSON after applying the control.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PersonaTickArgs {
+    /// Persona name to wake from its schedule binding.
+    pub name: String,
+    /// RFC3339 timestamp to use for deterministic tests.
+    #[arg(long, value_name = "RFC3339")]
+    pub at: Option<String>,
+    /// Estimated expensive-work cost for budget enforcement.
+    #[arg(long, default_value_t = 0.0)]
+    pub cost_usd: f64,
+    /// Estimated token count for budget enforcement.
+    #[arg(long, default_value_t = 0)]
+    pub tokens: u64,
+    /// Emit stable JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PersonaTriggerArgs {
+    /// Persona name to wake from an external trigger.
+    pub name: String,
+    /// Provider name, for example github, linear, slack, or webhook.
+    #[arg(long)]
+    pub provider: String,
+    /// Provider event kind, for example pull_request, check_run, issue, or message.
+    #[arg(long)]
+    pub kind: String,
+    /// Normalized metadata as key=value. Repeat for multiple fields.
+    #[arg(long = "metadata", value_name = "KEY=VALUE")]
+    pub metadata: Vec<String>,
+    /// RFC3339 timestamp to use for deterministic tests.
+    #[arg(long, value_name = "RFC3339")]
+    pub at: Option<String>,
+    /// Estimated expensive-work cost for budget enforcement.
+    #[arg(long, default_value_t = 0.0)]
+    pub cost_usd: f64,
+    /// Estimated token count for budget enforcement.
+    #[arg(long, default_value_t = 0)]
+    pub tokens: u64,
+    /// Emit stable JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PersonaSpendArgs {
+    /// Persona name to charge.
+    pub name: String,
+    /// Cost in USD to record.
+    #[arg(long)]
+    pub cost_usd: f64,
+    /// Tokens to record.
+    #[arg(long, default_value_t = 0)]
+    pub tokens: u64,
+    /// RFC3339 timestamp to use for deterministic tests.
+    #[arg(long, value_name = "RFC3339")]
+    pub at: Option<String>,
+    /// Emit stable JSON.
     #[arg(long)]
     pub json: bool,
 }

--- a/crates/harn-cli/src/commands/persona.rs
+++ b/crates/harn-cli/src/commands/persona.rs
@@ -1,7 +1,14 @@
-use std::path::Path;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 use std::process;
+use std::sync::Arc;
 
-use crate::cli::{PersonaInspectArgs, PersonaListArgs};
+use harn_vm::event_log::{AnyEventLog, EventLog};
+
+use crate::cli::{
+    PersonaControlArgs, PersonaInspectArgs, PersonaListArgs, PersonaSpendArgs, PersonaStatusArgs,
+    PersonaTickArgs, PersonaTriggerArgs,
+};
 use crate::package::{self, PersonaManifestEntry, ResolvedPersonaManifest};
 
 pub(crate) fn run_list(manifest: Option<&Path>, args: &PersonaListArgs) {
@@ -120,22 +127,300 @@ pub(crate) fn run_inspect(manifest: Option<&Path>, args: &PersonaInspectArgs) {
     println!("manifest:       {}", catalog.manifest_path.display());
 }
 
+pub(crate) async fn run_status(
+    manifest: Option<&Path>,
+    state_dir: &Path,
+    args: &PersonaStatusArgs,
+) -> Result<(), String> {
+    let catalog = load_catalog_result(manifest)?;
+    let binding = runtime_binding_or_err(&catalog, &args.name)?;
+    let log = open_persona_log(state_dir)?;
+    let status = harn_vm::persona_status(&log, &binding, harn_vm::persona_now_ms()).await?;
+    print_status(&status, args.json);
+    Ok(())
+}
+
+pub(crate) async fn run_pause(
+    manifest: Option<&Path>,
+    state_dir: &Path,
+    args: &PersonaControlArgs,
+) -> Result<(), String> {
+    let catalog = load_catalog_result(manifest)?;
+    let binding = runtime_binding_or_err(&catalog, &args.name)?;
+    let log = open_persona_log(state_dir)?;
+    let status = harn_vm::pause_persona(&log, &binding, harn_vm::persona_now_ms()).await?;
+    print_status(&status, args.json);
+    Ok(())
+}
+
+pub(crate) async fn run_resume(
+    manifest: Option<&Path>,
+    state_dir: &Path,
+    args: &PersonaControlArgs,
+) -> Result<(), String> {
+    let catalog = load_catalog_result(manifest)?;
+    let binding = runtime_binding_or_err(&catalog, &args.name)?;
+    let log = open_persona_log(state_dir)?;
+    let status = harn_vm::resume_persona(&log, &binding, harn_vm::persona_now_ms()).await?;
+    print_status(&status, args.json);
+    Ok(())
+}
+
+pub(crate) async fn run_disable(
+    manifest: Option<&Path>,
+    state_dir: &Path,
+    args: &PersonaControlArgs,
+) -> Result<(), String> {
+    let catalog = load_catalog_result(manifest)?;
+    let binding = runtime_binding_or_err(&catalog, &args.name)?;
+    let log = open_persona_log(state_dir)?;
+    let status = harn_vm::disable_persona(&log, &binding, harn_vm::persona_now_ms()).await?;
+    print_status(&status, args.json);
+    Ok(())
+}
+
+pub(crate) async fn run_tick(
+    manifest: Option<&Path>,
+    state_dir: &Path,
+    args: &PersonaTickArgs,
+) -> Result<(), String> {
+    let catalog = load_catalog_result(manifest)?;
+    let binding = runtime_binding_or_err(&catalog, &args.name)?;
+    let log = open_persona_log(state_dir)?;
+    let now_ms = timestamp_arg(args.at.as_deref())?;
+    let receipt = harn_vm::fire_persona_schedule(
+        &log,
+        &binding,
+        harn_vm::PersonaRunCost {
+            cost_usd: args.cost_usd,
+            tokens: args.tokens,
+        },
+        now_ms,
+    )
+    .await?;
+    log.flush().await.map_err(|error| error.to_string())?;
+    print_receipt(&receipt, args.json);
+    Ok(())
+}
+
+pub(crate) async fn run_trigger(
+    manifest: Option<&Path>,
+    state_dir: &Path,
+    args: &PersonaTriggerArgs,
+) -> Result<(), String> {
+    let catalog = load_catalog_result(manifest)?;
+    let binding = runtime_binding_or_err(&catalog, &args.name)?;
+    let log = open_persona_log(state_dir)?;
+    let now_ms = timestamp_arg(args.at.as_deref())?;
+    let metadata = parse_metadata(&args.metadata)?;
+    let receipt = harn_vm::fire_persona_trigger(
+        &log,
+        &binding,
+        &args.provider,
+        &args.kind,
+        metadata,
+        harn_vm::PersonaRunCost {
+            cost_usd: args.cost_usd,
+            tokens: args.tokens,
+        },
+        now_ms,
+    )
+    .await?;
+    log.flush().await.map_err(|error| error.to_string())?;
+    print_receipt(&receipt, args.json);
+    Ok(())
+}
+
+pub(crate) async fn run_spend(
+    manifest: Option<&Path>,
+    state_dir: &Path,
+    args: &PersonaSpendArgs,
+) -> Result<(), String> {
+    let catalog = load_catalog_result(manifest)?;
+    let binding = runtime_binding_or_err(&catalog, &args.name)?;
+    let log = open_persona_log(state_dir)?;
+    let now_ms = timestamp_arg(args.at.as_deref())?;
+    let budget = harn_vm::record_persona_spend(
+        &log,
+        &binding,
+        harn_vm::PersonaRunCost {
+            cost_usd: args.cost_usd,
+            tokens: args.tokens,
+        },
+        now_ms,
+    )
+    .await?;
+    log.flush().await.map_err(|error| error.to_string())?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&budget)
+                .unwrap_or_else(|error| fatal(&format!("failed to serialize budget: {error}")))
+        );
+    } else {
+        println!(
+            "budget: spent_today=${:.4} tokens_today={} exhausted={}",
+            budget.spent_today_usd, budget.tokens_today, budget.exhausted
+        );
+    }
+    Ok(())
+}
+
 fn load_catalog_or_exit(manifest: Option<&Path>) -> ResolvedPersonaManifest {
+    match load_catalog_result(manifest) {
+        Ok(catalog) => catalog,
+        Err(message) => fatal(&message),
+    }
+}
+
+fn load_catalog_result(manifest: Option<&Path>) -> Result<ResolvedPersonaManifest, String> {
     let result = if let Some(path) = manifest {
         package::load_personas_from_manifest_path(path).map(Some)
     } else {
         package::load_personas_config(None)
     };
     match result {
-        Ok(Some(catalog)) => catalog,
-        Ok(None) => {
-            fatal("no harn.toml found; pass --manifest <path> or run inside a Harn project")
+        Ok(Some(catalog)) => Ok(catalog),
+        Ok(None) => Err(
+            "no harn.toml found; pass --manifest <path> or run inside a Harn project".to_string(),
+        ),
+        Err(errors) => Err(errors
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")),
+    }
+}
+
+fn runtime_binding_or_err(
+    catalog: &ResolvedPersonaManifest,
+    name: &str,
+) -> Result<harn_vm::PersonaRuntimeBinding, String> {
+    let persona = catalog
+        .personas
+        .iter()
+        .find(|persona| persona.name.as_deref() == Some(name))
+        .ok_or_else(|| {
+            format!(
+                "persona '{}' not found in {}",
+                name,
+                catalog.manifest_path.display()
+            )
+        })?;
+    Ok(harn_vm::PersonaRuntimeBinding {
+        name: persona.name.clone().unwrap_or_default(),
+        entry_workflow: persona.entry_workflow.clone().unwrap_or_default(),
+        schedules: persona.schedules.clone(),
+        triggers: persona.triggers.clone(),
+        budget: harn_vm::PersonaBudgetPolicy {
+            daily_usd: persona.budget.daily_usd,
+            hourly_usd: persona.budget.hourly_usd,
+            run_usd: persona.budget.run_usd,
+            max_tokens: persona.budget.max_tokens,
+        },
+    })
+}
+
+fn open_persona_log(state_dir: &Path) -> Result<Arc<AnyEventLog>, String> {
+    let state_dir = absolutize_from_cwd(state_dir)?;
+    std::fs::create_dir_all(&state_dir).map_err(|error| {
+        format!(
+            "failed to create persona state dir {}: {error}",
+            state_dir.display()
+        )
+    })?;
+    harn_vm::event_log::install_default_for_base_dir(&state_dir)
+        .map_err(|error| format!("failed to open persona event log: {error}"))
+}
+
+fn absolutize_from_cwd(path: &Path) -> Result<PathBuf, String> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    std::env::current_dir()
+        .map(|cwd| cwd.join(path))
+        .map_err(|error| format!("failed to read current directory: {error}"))
+}
+
+fn timestamp_arg(value: Option<&str>) -> Result<i64, String> {
+    match value {
+        Some(value) => harn_vm::parse_persona_ms(value),
+        None => Ok(harn_vm::persona_now_ms()),
+    }
+}
+
+fn parse_metadata(values: &[String]) -> Result<BTreeMap<String, String>, String> {
+    let mut metadata = BTreeMap::new();
+    for value in values {
+        let Some((key, raw)) = value.split_once('=') else {
+            return Err(format!("metadata '{value}' must use KEY=VALUE syntax"));
+        };
+        let key = key.trim();
+        if key.is_empty() {
+            return Err(format!("metadata '{value}' has an empty key"));
         }
-        Err(errors) => {
-            for error in &errors {
-                eprintln!("error: {error}");
-            }
-            process::exit(1);
+        metadata.insert(key.to_string(), raw.to_string());
+    }
+    Ok(metadata)
+}
+
+fn print_status(status: &harn_vm::PersonaStatus, json: bool) {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(status)
+                .unwrap_or_else(|error| fatal(&format!("failed to serialize status: {error}")))
+        );
+        return;
+    }
+    println!("persona:        {}", status.name);
+    println!("state:          {}", status.state.as_str());
+    println!("entry_workflow: {}", status.entry_workflow);
+    println!(
+        "last_run:       {}",
+        status.last_run.as_deref().unwrap_or("-")
+    );
+    println!(
+        "next_run:       {}",
+        status.next_scheduled_run.as_deref().unwrap_or("-")
+    );
+    println!("queued_events:  {}", status.queued_events);
+    println!(
+        "active_lease:   {}",
+        status
+            .active_lease
+            .as_ref()
+            .map(|lease| lease.id.as_str())
+            .unwrap_or("-")
+    );
+    println!(
+        "budget:         spent_today=${:.4} remaining_today={}",
+        status.budget.spent_today_usd,
+        status
+            .budget
+            .remaining_today_usd
+            .map(|value| format!("${value:.4}"))
+            .unwrap_or_else(|| "-".to_string())
+    );
+    if let Some(error) = &status.last_error {
+        println!("last_error:     {error}");
+    }
+}
+
+fn print_receipt(receipt: &harn_vm::PersonaRunReceipt, json: bool) {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(receipt)
+                .unwrap_or_else(|error| fatal(&format!("failed to serialize receipt: {error}")))
+        );
+    } else {
+        println!(
+            "persona={} status={} work_key={} queued={}",
+            receipt.persona, receipt.status, receipt.work_key, receipt.queued
+        );
+        if let Some(error) = &receipt.error {
+            println!("error={error}");
         }
     }
 }

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -558,6 +558,84 @@ async fn main() {
             PersonaCommand::Inspect(inspect) => {
                 commands::persona::run_inspect(args.manifest.as_deref(), &inspect)
             }
+            PersonaCommand::Status(status) => {
+                if let Err(error) = commands::persona::run_status(
+                    args.manifest.as_deref(),
+                    &args.state_dir,
+                    &status,
+                )
+                .await
+                {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                }
+            }
+            PersonaCommand::Pause(control) => {
+                if let Err(error) = commands::persona::run_pause(
+                    args.manifest.as_deref(),
+                    &args.state_dir,
+                    &control,
+                )
+                .await
+                {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                }
+            }
+            PersonaCommand::Resume(control) => {
+                if let Err(error) = commands::persona::run_resume(
+                    args.manifest.as_deref(),
+                    &args.state_dir,
+                    &control,
+                )
+                .await
+                {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                }
+            }
+            PersonaCommand::Disable(control) => {
+                if let Err(error) = commands::persona::run_disable(
+                    args.manifest.as_deref(),
+                    &args.state_dir,
+                    &control,
+                )
+                .await
+                {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                }
+            }
+            PersonaCommand::Tick(tick) => {
+                if let Err(error) =
+                    commands::persona::run_tick(args.manifest.as_deref(), &args.state_dir, &tick)
+                        .await
+                {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                }
+            }
+            PersonaCommand::Trigger(trigger) => {
+                if let Err(error) = commands::persona::run_trigger(
+                    args.manifest.as_deref(),
+                    &args.state_dir,
+                    &trigger,
+                )
+                .await
+                {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                }
+            }
+            PersonaCommand::Spend(spend) => {
+                if let Err(error) =
+                    commands::persona::run_spend(args.manifest.as_deref(), &args.state_dir, &spend)
+                        .await
+                {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                }
+            }
         },
         Command::ModelInfo(args) => print_model_info(&args.model).await,
         Command::Skills(args) => match args.command {

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -193,3 +193,253 @@ fn persona_manifest_flag_loads_example_personas() {
     assert_eq!(persona["name"], "merge_captain");
     assert_eq!(persona["receipt_policy"], "required");
 }
+
+#[test]
+fn persona_runtime_status_tick_and_budget_are_persisted() {
+    let temp = write_manifest(valid_manifest());
+    let state_dir = temp.path().join(".harn-personas-test");
+
+    let status = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .args([
+            "persona",
+            "--state-dir",
+            state_dir.to_str().unwrap(),
+            "status",
+            "merge_captain",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        status.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&status.stdout),
+        String::from_utf8_lossy(&status.stderr)
+    );
+    let status_json: serde_json::Value = serde_json::from_slice(&status.stdout).unwrap();
+    assert_eq!(status_json["state"], "idle");
+    assert_eq!(status_json["queued_events"], 0);
+    assert_eq!(status_json["budget"]["daily_usd"], 20.0);
+
+    let tick = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .args([
+            "persona",
+            "--state-dir",
+            state_dir.to_str().unwrap(),
+            "tick",
+            "merge_captain",
+            "--at",
+            "2026-04-24T12:30:00Z",
+            "--cost-usd",
+            "0.25",
+            "--tokens",
+            "12",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        tick.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&tick.stdout),
+        String::from_utf8_lossy(&tick.stderr)
+    );
+    let receipt: serde_json::Value = serde_json::from_slice(&tick.stdout).unwrap();
+    assert_eq!(receipt["status"], "completed");
+    assert!(receipt["lease"]["id"]
+        .as_str()
+        .unwrap()
+        .starts_with("persona_lease_"));
+
+    let status = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .args([
+            "persona",
+            "--state-dir",
+            state_dir.to_str().unwrap(),
+            "status",
+            "merge_captain",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(status.status.success());
+    let status_json: serde_json::Value = serde_json::from_slice(&status.stdout).unwrap();
+    assert_eq!(status_json["state"], "idle");
+    assert_eq!(status_json["last_run"], "2026-04-24T12:30:00Z");
+    assert_eq!(status_json["budget"]["spent_today_usd"], 0.25);
+    assert_eq!(status_json["budget"]["tokens_today"], 12);
+}
+
+#[test]
+fn persona_pause_resume_disable_trigger_controls_are_durable() {
+    let temp = write_manifest(valid_manifest());
+    let state_dir = temp.path().join(".harn-personas-test");
+
+    let pause = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .args([
+            "persona",
+            "--state-dir",
+            state_dir.to_str().unwrap(),
+            "pause",
+            "merge_captain",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(pause.status.success());
+
+    let trigger = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .args([
+            "persona",
+            "--state-dir",
+            state_dir.to_str().unwrap(),
+            "trigger",
+            "merge_captain",
+            "--provider",
+            "github",
+            "--kind",
+            "pull_request",
+            "--metadata",
+            "repository=burin-labs/harn",
+            "--metadata",
+            "number=462",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        trigger.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&trigger.stdout),
+        String::from_utf8_lossy(&trigger.stderr)
+    );
+    let receipt: serde_json::Value = serde_json::from_slice(&trigger.stdout).unwrap();
+    assert_eq!(receipt["status"], "queued");
+    assert_eq!(receipt["work_key"], "github:burin-labs/harn:pr:462");
+
+    let resume = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .args([
+            "persona",
+            "--state-dir",
+            state_dir.to_str().unwrap(),
+            "resume",
+            "merge_captain",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(resume.status.success());
+    let status_json: serde_json::Value = serde_json::from_slice(&resume.stdout).unwrap();
+    assert_eq!(status_json["state"], "idle");
+    assert_eq!(status_json["queued_events"], 0);
+
+    let disable = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .args([
+            "persona",
+            "--state-dir",
+            state_dir.to_str().unwrap(),
+            "disable",
+            "merge_captain",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(disable.status.success());
+
+    let trigger = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .args([
+            "persona",
+            "--state-dir",
+            state_dir.to_str().unwrap(),
+            "trigger",
+            "merge_captain",
+            "--provider",
+            "slack",
+            "--kind",
+            "message",
+            "--metadata",
+            "channel=C123",
+            "--metadata",
+            "ts=1713988800.000100",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(trigger.status.success());
+    let receipt: serde_json::Value = serde_json::from_slice(&trigger.stdout).unwrap();
+    assert_eq!(receipt["status"], "dead_lettered");
+}
+
+#[test]
+fn persona_runtime_blocks_budget_exhaustion() {
+    let temp = write_manifest(
+        r#"
+[[personas]]
+name = "merge_captain"
+description = "Owns merge readiness."
+entry_workflow = "workflows/merge.harn#run"
+tools = ["github"]
+capabilities = ["git.get_diff"]
+autonomy_tier = "act_with_approval"
+receipt_policy = "required"
+triggers = ["github.pr_opened"]
+budget = { daily_usd = 0.01, run_usd = 0.01, max_tokens = 10 }
+"#,
+    );
+    let state_dir = temp.path().join(".harn-personas-test");
+    let trigger = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .args([
+            "persona",
+            "--state-dir",
+            state_dir.to_str().unwrap(),
+            "trigger",
+            "merge_captain",
+            "--provider",
+            "github",
+            "--kind",
+            "check_run",
+            "--metadata",
+            "repository=burin-labs/harn",
+            "--metadata",
+            "check_name=ci",
+            "--cost-usd",
+            "0.02",
+            "--tokens",
+            "1",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(trigger.status.success());
+    let receipt: serde_json::Value = serde_json::from_slice(&trigger.stdout).unwrap();
+    assert_eq!(receipt["status"], "budget_exhausted");
+    assert!(receipt["error"].as_str().unwrap().contains("run_usd"));
+
+    let status = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(temp.path())
+        .args([
+            "persona",
+            "--state-dir",
+            state_dir.to_str().unwrap(),
+            "status",
+            "merge_captain",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(status.status.success());
+    let status_json: serde_json::Value = serde_json::from_slice(&status.stdout).unwrap();
+    assert!(status_json["last_error"]
+        .as_str()
+        .unwrap()
+        .contains("run_usd"));
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -22,6 +22,7 @@ pub mod mcp_server;
 pub mod metadata;
 pub mod observability;
 pub mod orchestration;
+pub mod personas;
 pub mod record_filter;
 pub mod runtime_context;
 pub mod runtime_paths;
@@ -86,6 +87,13 @@ pub use mcp_server::{
     take_mcp_serve_resources, tool_registry_to_mcp_tools, McpServer,
 };
 pub use metadata::{register_metadata_builtins, register_scan_builtins};
+pub use personas::{
+    disable_persona, fire_schedule as fire_persona_schedule, fire_trigger as fire_persona_trigger,
+    format_ms as format_persona_ms, now_ms as persona_now_ms, parse_rfc3339_ms as parse_persona_ms,
+    pause_persona, persona_status, record_persona_spend, resume_persona, PersonaBudgetPolicy,
+    PersonaBudgetStatus, PersonaLease, PersonaLifecycleState, PersonaRunCost, PersonaRunReceipt,
+    PersonaRuntimeBinding, PersonaStatus, PersonaTriggerEnvelope, PERSONA_RUNTIME_TOPIC,
+};
 pub use record_filter::{normalize_record_filter_expression, CompiledRecordFilter};
 pub use schema::json_to_vm_value;
 pub use stdlib::hitl::{

--- a/crates/harn-vm/src/personas.rs
+++ b/crates/harn-vm/src/personas.rs
@@ -1,0 +1,1180 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use chrono::{TimeZone, Utc};
+use croner::Cron;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::event_log::{AnyEventLog, EventLog, LogEvent, Topic};
+
+pub const PERSONA_RUNTIME_TOPIC: &str = "persona.runtime.events";
+
+const DEFAULT_LEASE_TTL_MS: i64 = 5 * 60 * 1000;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PersonaLifecycleState {
+    Inactive,
+    Starting,
+    #[default]
+    Idle,
+    Running,
+    Paused,
+    Draining,
+    Failed,
+    Disabled,
+}
+
+impl PersonaLifecycleState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Inactive => "inactive",
+            Self::Starting => "starting",
+            Self::Idle => "idle",
+            Self::Running => "running",
+            Self::Paused => "paused",
+            Self::Draining => "draining",
+            Self::Failed => "failed",
+            Self::Disabled => "disabled",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaBudgetPolicy {
+    pub daily_usd: Option<f64>,
+    pub hourly_usd: Option<f64>,
+    pub run_usd: Option<f64>,
+    pub max_tokens: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PersonaRuntimeBinding {
+    pub name: String,
+    pub entry_workflow: String,
+    #[serde(default)]
+    pub schedules: Vec<String>,
+    #[serde(default)]
+    pub triggers: Vec<String>,
+    #[serde(default)]
+    pub budget: PersonaBudgetPolicy,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PersonaLease {
+    pub id: String,
+    pub holder: String,
+    pub work_key: String,
+    pub acquired_at_ms: i64,
+    pub expires_at_ms: i64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaBudgetStatus {
+    pub daily_usd: Option<f64>,
+    pub hourly_usd: Option<f64>,
+    pub run_usd: Option<f64>,
+    pub max_tokens: Option<u64>,
+    pub spent_today_usd: f64,
+    pub spent_this_hour_usd: f64,
+    pub spent_last_run_usd: f64,
+    pub tokens_today: u64,
+    pub remaining_today_usd: Option<f64>,
+    pub remaining_hour_usd: Option<f64>,
+    pub exhausted: bool,
+    pub reason: Option<String>,
+    pub last_receipt_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaStatus {
+    pub name: String,
+    pub state: PersonaLifecycleState,
+    pub entry_workflow: String,
+    pub last_run: Option<String>,
+    pub next_scheduled_run: Option<String>,
+    pub active_lease: Option<PersonaLease>,
+    pub budget: PersonaBudgetStatus,
+    pub last_error: Option<String>,
+    pub queued_events: usize,
+    pub disabled_events: usize,
+    pub paused_event_policy: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaTriggerEnvelope {
+    pub provider: String,
+    pub kind: String,
+    pub subject_key: String,
+    pub source_event_id: Option<String>,
+    pub received_at_ms: i64,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, String>,
+    #[serde(default)]
+    pub raw: serde_json::Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PersonaRunReceipt {
+    pub status: String,
+    pub persona: String,
+    pub work_key: String,
+    pub lease: Option<PersonaLease>,
+    pub queued: bool,
+    pub error: Option<String>,
+    pub budget_receipt_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaRunCost {
+    pub cost_usd: f64,
+    pub tokens: u64,
+}
+
+pub async fn persona_status(
+    log: &Arc<AnyEventLog>,
+    binding: &PersonaRuntimeBinding,
+    now_ms: i64,
+) -> Result<PersonaStatus, String> {
+    let events = read_persona_events(log, &binding.name).await?;
+    let mut state = PersonaLifecycleState::Idle;
+    let mut last_run_ms = None;
+    let mut active_lease = None;
+    let mut last_error = None;
+    let mut queued = BTreeSet::<String>::new();
+    let mut completed = BTreeSet::<String>::new();
+    let mut disabled_events = 0usize;
+    let mut budget_receipt = None;
+    let mut budget_exhaustion_reason = None;
+    let mut spent = Vec::<(i64, f64, u64)>::new();
+
+    for (_, event) in events {
+        match event.kind.as_str() {
+            "persona.control.paused" => state = PersonaLifecycleState::Paused,
+            "persona.control.resumed" => state = PersonaLifecycleState::Idle,
+            "persona.control.disabled" => state = PersonaLifecycleState::Disabled,
+            "persona.control.draining" => state = PersonaLifecycleState::Draining,
+            "persona.lease.acquired" => {
+                if let Ok(lease) = serde_json::from_value::<PersonaLease>(event.payload.clone()) {
+                    active_lease = Some(lease);
+                    state = PersonaLifecycleState::Running;
+                }
+            }
+            "persona.lease.released" => {
+                active_lease = None;
+                if !matches!(
+                    state,
+                    PersonaLifecycleState::Paused | PersonaLifecycleState::Disabled
+                ) {
+                    state = PersonaLifecycleState::Idle;
+                }
+            }
+            "persona.lease.expired" => {
+                active_lease = None;
+                if !matches!(
+                    state,
+                    PersonaLifecycleState::Paused | PersonaLifecycleState::Disabled
+                ) {
+                    state = PersonaLifecycleState::Idle;
+                }
+            }
+            "persona.run.started" => state = PersonaLifecycleState::Running,
+            "persona.run.completed" => {
+                last_run_ms = event
+                    .payload
+                    .get("completed_at_ms")
+                    .and_then(serde_json::Value::as_i64)
+                    .or(Some(event.occurred_at_ms));
+                if let Some(work_key) = event
+                    .payload
+                    .get("work_key")
+                    .and_then(serde_json::Value::as_str)
+                {
+                    completed.insert(work_key.to_string());
+                }
+                if !matches!(
+                    state,
+                    PersonaLifecycleState::Paused | PersonaLifecycleState::Disabled
+                ) {
+                    state = PersonaLifecycleState::Idle;
+                }
+            }
+            "persona.run.failed" => {
+                state = PersonaLifecycleState::Failed;
+                last_error = event
+                    .payload
+                    .get("error")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToString::to_string);
+            }
+            "persona.trigger.queued" => {
+                if let Some(work_key) = event
+                    .payload
+                    .get("work_key")
+                    .and_then(serde_json::Value::as_str)
+                {
+                    queued.insert(work_key.to_string());
+                }
+            }
+            "persona.trigger.dead_lettered" => disabled_events += 1,
+            "persona.budget.recorded" => {
+                budget_receipt = event
+                    .payload
+                    .get("receipt_id")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToString::to_string);
+                spent.push((
+                    event.occurred_at_ms,
+                    event
+                        .payload
+                        .get("cost_usd")
+                        .and_then(serde_json::Value::as_f64)
+                        .unwrap_or_default(),
+                    event
+                        .payload
+                        .get("tokens")
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or_default(),
+                ));
+            }
+            "persona.budget.exhausted" => {
+                budget_exhaustion_reason = event
+                    .payload
+                    .get("reason")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToString::to_string);
+                last_error = budget_exhaustion_reason
+                    .as_ref()
+                    .map(|reason| format!("persona budget exhausted: {reason}"));
+                budget_receipt = event
+                    .payload
+                    .get("receipt_id")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToString::to_string);
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(lease) = active_lease.as_ref() {
+        if lease.expires_at_ms <= now_ms {
+            active_lease = None;
+            if !matches!(
+                state,
+                PersonaLifecycleState::Paused | PersonaLifecycleState::Disabled
+            ) {
+                state = PersonaLifecycleState::Idle;
+            }
+        }
+    }
+
+    queued.retain(|work_key| !completed.contains(work_key));
+
+    let mut budget = budget_status(&binding.budget, &spent, now_ms);
+    if budget.reason.is_none() {
+        if let Some(reason) = budget_exhaustion_reason {
+            budget.exhausted = true;
+            budget.reason = Some(reason);
+        }
+    }
+    if budget.last_receipt_id.is_none() {
+        budget.last_receipt_id = budget_receipt;
+    }
+
+    Ok(PersonaStatus {
+        name: binding.name.clone(),
+        state,
+        entry_workflow: binding.entry_workflow.clone(),
+        last_run: last_run_ms.map(format_ms),
+        next_scheduled_run: next_scheduled_run(binding, last_run_ms, now_ms),
+        active_lease,
+        budget,
+        last_error,
+        queued_events: queued.len(),
+        disabled_events,
+        paused_event_policy: "queue_then_drain_on_resume".to_string(),
+    })
+}
+
+pub async fn pause_persona(
+    log: &Arc<AnyEventLog>,
+    binding: &PersonaRuntimeBinding,
+    now_ms: i64,
+) -> Result<PersonaStatus, String> {
+    append_persona_event(
+        log,
+        &binding.name,
+        "persona.control.paused",
+        json!({"paused_at_ms": now_ms, "policy": "queue_then_drain_on_resume"}),
+        now_ms,
+    )
+    .await?;
+    persona_status(log, binding, now_ms).await
+}
+
+pub async fn resume_persona(
+    log: &Arc<AnyEventLog>,
+    binding: &PersonaRuntimeBinding,
+    now_ms: i64,
+) -> Result<PersonaStatus, String> {
+    append_persona_event(
+        log,
+        &binding.name,
+        "persona.control.resumed",
+        json!({"resumed_at_ms": now_ms, "drain": true}),
+        now_ms,
+    )
+    .await?;
+    let queued = queued_events(log, &binding.name).await?;
+    for envelope in queued {
+        let cost = PersonaRunCost::default();
+        let _ = run_for_envelope(log, binding, envelope, cost, now_ms).await?;
+    }
+    persona_status(log, binding, now_ms).await
+}
+
+pub async fn disable_persona(
+    log: &Arc<AnyEventLog>,
+    binding: &PersonaRuntimeBinding,
+    now_ms: i64,
+) -> Result<PersonaStatus, String> {
+    append_persona_event(
+        log,
+        &binding.name,
+        "persona.control.disabled",
+        json!({"disabled_at_ms": now_ms}),
+        now_ms,
+    )
+    .await?;
+    persona_status(log, binding, now_ms).await
+}
+
+pub async fn fire_schedule(
+    log: &Arc<AnyEventLog>,
+    binding: &PersonaRuntimeBinding,
+    cost: PersonaRunCost,
+    now_ms: i64,
+) -> Result<PersonaRunReceipt, String> {
+    let schedule = binding
+        .schedules
+        .first()
+        .cloned()
+        .unwrap_or_else(|| "manual".to_string());
+    let envelope = PersonaTriggerEnvelope {
+        provider: "schedule".to_string(),
+        kind: "cron.tick".to_string(),
+        subject_key: format!("schedule:{}:{schedule}:{}", binding.name, format_ms(now_ms)),
+        source_event_id: None,
+        received_at_ms: now_ms,
+        metadata: BTreeMap::from([
+            ("persona".to_string(), binding.name.clone()),
+            ("schedule".to_string(), schedule),
+            ("fired_at".to_string(), format_ms(now_ms)),
+        ]),
+        raw: json!({}),
+    };
+    append_persona_event(
+        log,
+        &binding.name,
+        "persona.schedule.fired",
+        json!({"persona": binding.name, "envelope": envelope}),
+        now_ms,
+    )
+    .await?;
+    run_for_envelope(log, binding, envelope, cost, now_ms).await
+}
+
+pub async fn fire_trigger(
+    log: &Arc<AnyEventLog>,
+    binding: &PersonaRuntimeBinding,
+    provider: &str,
+    kind: &str,
+    metadata: BTreeMap<String, String>,
+    cost: PersonaRunCost,
+    now_ms: i64,
+) -> Result<PersonaRunReceipt, String> {
+    let envelope = normalize_trigger_envelope(provider, kind, metadata, now_ms);
+    append_persona_event(
+        log,
+        &binding.name,
+        "persona.trigger.received",
+        json!({"persona": binding.name, "envelope": envelope}),
+        now_ms,
+    )
+    .await?;
+    run_for_envelope(log, binding, envelope, cost, now_ms).await
+}
+
+pub async fn record_persona_spend(
+    log: &Arc<AnyEventLog>,
+    binding: &PersonaRuntimeBinding,
+    cost: PersonaRunCost,
+    now_ms: i64,
+) -> Result<PersonaBudgetStatus, String> {
+    enforce_budget(log, binding, &cost, now_ms).await?;
+    append_budget_record(log, &binding.name, &cost, None, now_ms).await?;
+    persona_status(log, binding, now_ms)
+        .await
+        .map(|status| status.budget)
+}
+
+async fn run_for_envelope(
+    log: &Arc<AnyEventLog>,
+    binding: &PersonaRuntimeBinding,
+    envelope: PersonaTriggerEnvelope,
+    cost: PersonaRunCost,
+    now_ms: i64,
+) -> Result<PersonaRunReceipt, String> {
+    let status = persona_status(log, binding, now_ms).await?;
+    match status.state {
+        PersonaLifecycleState::Paused => {
+            append_persona_event(
+                log,
+                &binding.name,
+                "persona.trigger.queued",
+                json!({
+                    "work_key": envelope.subject_key,
+                    "envelope": envelope,
+                    "reason": "paused",
+                }),
+                now_ms,
+            )
+            .await?;
+            return Ok(PersonaRunReceipt {
+                status: "queued".to_string(),
+                persona: binding.name.clone(),
+                work_key: envelope.subject_key,
+                lease: None,
+                queued: true,
+                error: None,
+                budget_receipt_id: None,
+            });
+        }
+        PersonaLifecycleState::Disabled => {
+            append_persona_event(
+                log,
+                &binding.name,
+                "persona.trigger.dead_lettered",
+                json!({
+                    "work_key": envelope.subject_key,
+                    "envelope": envelope,
+                    "reason": "disabled",
+                }),
+                now_ms,
+            )
+            .await?;
+            return Ok(PersonaRunReceipt {
+                status: "dead_lettered".to_string(),
+                persona: binding.name.clone(),
+                work_key: envelope.subject_key,
+                lease: None,
+                queued: false,
+                error: Some("persona is disabled".to_string()),
+                budget_receipt_id: None,
+            });
+        }
+        _ => {}
+    }
+
+    if let Err(error) = enforce_budget(log, binding, &cost, now_ms).await {
+        return Ok(PersonaRunReceipt {
+            status: "budget_exhausted".to_string(),
+            persona: binding.name.clone(),
+            work_key: envelope.subject_key,
+            lease: None,
+            queued: false,
+            error: Some(error),
+            budget_receipt_id: None,
+        });
+    }
+
+    if work_completed(log, &binding.name, &envelope.subject_key).await? {
+        append_persona_event(
+            log,
+            &binding.name,
+            "persona.trigger.duplicate",
+            json!({
+                "work_key": envelope.subject_key,
+                "envelope": envelope,
+                "reason": "already_completed",
+            }),
+            now_ms,
+        )
+        .await?;
+        return Ok(PersonaRunReceipt {
+            status: "duplicate".to_string(),
+            persona: binding.name.clone(),
+            work_key: envelope.subject_key,
+            lease: None,
+            queued: false,
+            error: None,
+            budget_receipt_id: None,
+        });
+    }
+
+    let Some(lease) = acquire_lease(
+        log,
+        binding,
+        &envelope.subject_key,
+        "persona-runtime",
+        DEFAULT_LEASE_TTL_MS,
+        now_ms,
+    )
+    .await?
+    else {
+        return Ok(PersonaRunReceipt {
+            status: "lease_busy".to_string(),
+            persona: binding.name.clone(),
+            work_key: envelope.subject_key,
+            lease: status.active_lease,
+            queued: false,
+            error: Some("active lease already owns persona work".to_string()),
+            budget_receipt_id: None,
+        });
+    };
+
+    append_persona_event(
+        log,
+        &binding.name,
+        "persona.run.started",
+        json!({
+            "work_key": envelope.subject_key,
+            "started_at_ms": now_ms,
+            "entry_workflow": binding.entry_workflow,
+            "lease_id": lease.id,
+        }),
+        now_ms,
+    )
+    .await?;
+    let budget_receipt_id =
+        append_budget_record(log, &binding.name, &cost, Some(&lease.id), now_ms).await?;
+    append_persona_event(
+        log,
+        &binding.name,
+        "persona.run.completed",
+        json!({
+            "work_key": envelope.subject_key,
+            "completed_at_ms": now_ms,
+            "entry_workflow": binding.entry_workflow,
+            "lease_id": lease.id,
+        }),
+        now_ms,
+    )
+    .await?;
+    append_persona_event(
+        log,
+        &binding.name,
+        "persona.lease.released",
+        json!({
+            "id": lease.id,
+            "work_key": envelope.subject_key,
+            "released_at_ms": now_ms,
+        }),
+        now_ms,
+    )
+    .await?;
+    Ok(PersonaRunReceipt {
+        status: "completed".to_string(),
+        persona: binding.name.clone(),
+        work_key: envelope.subject_key,
+        lease: Some(lease),
+        queued: false,
+        error: None,
+        budget_receipt_id: Some(budget_receipt_id),
+    })
+}
+
+async fn acquire_lease(
+    log: &Arc<AnyEventLog>,
+    binding: &PersonaRuntimeBinding,
+    work_key: &str,
+    holder: &str,
+    ttl_ms: i64,
+    now_ms: i64,
+) -> Result<Option<PersonaLease>, String> {
+    let status = persona_status(log, binding, now_ms).await?;
+    if let Some(lease) = status.active_lease {
+        if lease.expires_at_ms > now_ms {
+            append_persona_event(
+                log,
+                &binding.name,
+                "persona.lease.conflict",
+                json!({
+                    "active_lease": lease,
+                    "requested_work_key": work_key,
+                    "at_ms": now_ms,
+                }),
+                now_ms,
+            )
+            .await?;
+            return Ok(None);
+        }
+        append_persona_event(
+            log,
+            &binding.name,
+            "persona.lease.expired",
+            json!({
+                "id": lease.id,
+                "work_key": lease.work_key,
+                "expired_at_ms": now_ms,
+            }),
+            now_ms,
+        )
+        .await?;
+    }
+
+    let lease = PersonaLease {
+        id: format!("persona_lease_{}", Uuid::now_v7()),
+        holder: holder.to_string(),
+        work_key: work_key.to_string(),
+        acquired_at_ms: now_ms,
+        expires_at_ms: now_ms + ttl_ms,
+    };
+    append_persona_event(
+        log,
+        &binding.name,
+        "persona.lease.acquired",
+        serde_json::to_value(&lease).map_err(|error| error.to_string())?,
+        now_ms,
+    )
+    .await?;
+    Ok(Some(lease))
+}
+
+async fn enforce_budget(
+    log: &Arc<AnyEventLog>,
+    binding: &PersonaRuntimeBinding,
+    cost: &PersonaRunCost,
+    now_ms: i64,
+) -> Result<(), String> {
+    let status = persona_status(log, binding, now_ms).await?;
+    let reason = if binding
+        .budget
+        .run_usd
+        .is_some_and(|limit| cost.cost_usd > limit)
+    {
+        Some("run_usd")
+    } else if binding
+        .budget
+        .daily_usd
+        .is_some_and(|limit| status.budget.spent_today_usd + cost.cost_usd > limit)
+    {
+        Some("daily_usd")
+    } else if binding
+        .budget
+        .hourly_usd
+        .is_some_and(|limit| status.budget.spent_this_hour_usd + cost.cost_usd > limit)
+    {
+        Some("hourly_usd")
+    } else if binding
+        .budget
+        .max_tokens
+        .is_some_and(|limit| status.budget.tokens_today + cost.tokens > limit)
+    {
+        Some("max_tokens")
+    } else {
+        None
+    };
+
+    if let Some(reason) = reason {
+        let receipt_id = format!("persona_budget_{}", Uuid::now_v7());
+        append_persona_event(
+            log,
+            &binding.name,
+            "persona.budget.exhausted",
+            json!({
+                "receipt_id": receipt_id,
+                "reason": reason,
+                "attempted_cost_usd": cost.cost_usd,
+                "attempted_tokens": cost.tokens,
+                "persona": binding.name,
+            }),
+            now_ms,
+        )
+        .await?;
+        return Err(format!("persona budget exhausted: {reason}"));
+    }
+
+    Ok(())
+}
+
+async fn append_budget_record(
+    log: &Arc<AnyEventLog>,
+    persona: &str,
+    cost: &PersonaRunCost,
+    lease_id: Option<&str>,
+    now_ms: i64,
+) -> Result<String, String> {
+    let receipt_id = format!("persona_budget_{}", Uuid::now_v7());
+    append_persona_event(
+        log,
+        persona,
+        "persona.budget.recorded",
+        json!({
+            "receipt_id": receipt_id,
+            "persona": persona,
+            "cost_usd": cost.cost_usd,
+            "tokens": cost.tokens,
+            "lease_id": lease_id,
+        }),
+        now_ms,
+    )
+    .await?;
+    Ok(receipt_id)
+}
+
+fn normalize_trigger_envelope(
+    provider: &str,
+    kind: &str,
+    metadata: BTreeMap<String, String>,
+    now_ms: i64,
+) -> PersonaTriggerEnvelope {
+    let provider = provider.to_ascii_lowercase();
+    let kind = kind.to_string();
+    let source_event_id = metadata
+        .get("event_id")
+        .or_else(|| metadata.get("id"))
+        .cloned();
+    let subject_key = match provider.as_str() {
+        "github" => {
+            let repo = metadata
+                .get("repository")
+                .or_else(|| metadata.get("repository.full_name"))
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string());
+            if let Some(number) = metadata
+                .get("pr")
+                .or_else(|| metadata.get("pull_request.number"))
+                .or_else(|| metadata.get("number"))
+            {
+                format!("github:{repo}:pr:{number}")
+            } else if let Some(check) = metadata
+                .get("check_run.name")
+                .or_else(|| metadata.get("check_name"))
+            {
+                format!("github:{repo}:check:{check}")
+            } else {
+                format!("github:{repo}:{kind}")
+            }
+        }
+        "linear" => {
+            let issue = metadata
+                .get("issue_key")
+                .or_else(|| metadata.get("issue.identifier"))
+                .or_else(|| metadata.get("issue_id"))
+                .or_else(|| metadata.get("id"))
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string());
+            format!("linear:issue:{issue}")
+        }
+        "slack" => {
+            let channel = metadata
+                .get("channel")
+                .or_else(|| metadata.get("channel_id"))
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string());
+            let ts = metadata
+                .get("ts")
+                .or_else(|| metadata.get("event_ts"))
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string());
+            format!("slack:{channel}:{ts}")
+        }
+        "webhook" => metadata
+            .get("dedupe_key")
+            .or_else(|| metadata.get("event_id"))
+            .map(|value| format!("webhook:{value}"))
+            .unwrap_or_else(|| format!("webhook:{kind}:{}", Uuid::now_v7())),
+        _ => metadata
+            .get("dedupe_key")
+            .or_else(|| metadata.get("event_id"))
+            .map(|value| format!("{provider}:{kind}:{value}"))
+            .unwrap_or_else(|| format!("{provider}:{kind}:{}", Uuid::now_v7())),
+    };
+
+    PersonaTriggerEnvelope {
+        provider,
+        kind,
+        subject_key,
+        source_event_id,
+        received_at_ms: now_ms,
+        raw: json!({"metadata": metadata}),
+        metadata,
+    }
+}
+
+async fn queued_events(
+    log: &Arc<AnyEventLog>,
+    persona: &str,
+) -> Result<Vec<PersonaTriggerEnvelope>, String> {
+    let events = read_persona_events(log, persona).await?;
+    let mut queued = BTreeMap::<String, PersonaTriggerEnvelope>::new();
+    let mut completed = BTreeSet::<String>::new();
+    for (_, event) in events {
+        match event.kind.as_str() {
+            "persona.trigger.queued" => {
+                let Some(envelope) = event.payload.get("envelope") else {
+                    continue;
+                };
+                let envelope: PersonaTriggerEnvelope =
+                    serde_json::from_value(envelope.clone()).map_err(|error| error.to_string())?;
+                queued.insert(envelope.subject_key.clone(), envelope);
+            }
+            "persona.run.completed" => {
+                if let Some(work_key) = event
+                    .payload
+                    .get("work_key")
+                    .and_then(serde_json::Value::as_str)
+                {
+                    completed.insert(work_key.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    queued.retain(|work_key, _| !completed.contains(work_key));
+    Ok(queued.into_values().collect())
+}
+
+async fn work_completed(
+    log: &Arc<AnyEventLog>,
+    persona: &str,
+    work_key: &str,
+) -> Result<bool, String> {
+    let events = read_persona_events(log, persona).await?;
+    Ok(events.into_iter().any(|(_, event)| {
+        event.kind == "persona.run.completed"
+            && event
+                .payload
+                .get("work_key")
+                .and_then(serde_json::Value::as_str)
+                == Some(work_key)
+    }))
+}
+
+async fn read_persona_events(
+    log: &Arc<AnyEventLog>,
+    persona: &str,
+) -> Result<Vec<(u64, LogEvent)>, String> {
+    let topic = runtime_topic()?;
+    Ok(log
+        .read_range(&topic, None, usize::MAX)
+        .await
+        .map_err(|error| error.to_string())?
+        .into_iter()
+        .filter(|(_, event)| {
+            event
+                .headers
+                .get("persona")
+                .is_some_and(|name| name == persona)
+        })
+        .collect())
+}
+
+async fn append_persona_event(
+    log: &Arc<AnyEventLog>,
+    persona: &str,
+    kind: &str,
+    payload: serde_json::Value,
+    now_ms: i64,
+) -> Result<u64, String> {
+    let mut headers = BTreeMap::new();
+    headers.insert("persona".to_string(), persona.to_string());
+    let event = LogEvent {
+        kind: kind.to_string(),
+        payload,
+        headers,
+        occurred_at_ms: now_ms,
+    };
+    log.append(&runtime_topic()?, event)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+fn budget_status(
+    policy: &PersonaBudgetPolicy,
+    spent: &[(i64, f64, u64)],
+    now_ms: i64,
+) -> PersonaBudgetStatus {
+    let day_start = now_ms - (now_ms.rem_euclid(86_400_000));
+    let hour_start = now_ms - (now_ms.rem_euclid(3_600_000));
+    let mut spent_today_usd = 0.0;
+    let mut spent_this_hour_usd = 0.0;
+    let mut tokens_today = 0u64;
+    let mut spent_last_run_usd = 0.0;
+    for (at_ms, cost, tokens) in spent {
+        spent_last_run_usd = *cost;
+        if *at_ms >= day_start {
+            spent_today_usd += cost;
+            tokens_today += tokens;
+        }
+        if *at_ms >= hour_start {
+            spent_this_hour_usd += cost;
+        }
+    }
+
+    let remaining_today_usd = policy
+        .daily_usd
+        .map(|limit| (limit - spent_today_usd).max(0.0));
+    let remaining_hour_usd = policy
+        .hourly_usd
+        .map(|limit| (limit - spent_this_hour_usd).max(0.0));
+    let reason = if policy
+        .daily_usd
+        .is_some_and(|limit| spent_today_usd >= limit && limit >= 0.0)
+    {
+        Some("daily_usd".to_string())
+    } else if policy
+        .hourly_usd
+        .is_some_and(|limit| spent_this_hour_usd >= limit && limit >= 0.0)
+    {
+        Some("hourly_usd".to_string())
+    } else if policy
+        .max_tokens
+        .is_some_and(|limit| tokens_today >= limit && limit > 0)
+    {
+        Some("max_tokens".to_string())
+    } else {
+        None
+    };
+
+    PersonaBudgetStatus {
+        daily_usd: policy.daily_usd,
+        hourly_usd: policy.hourly_usd,
+        run_usd: policy.run_usd,
+        max_tokens: policy.max_tokens,
+        spent_today_usd,
+        spent_this_hour_usd,
+        spent_last_run_usd,
+        tokens_today,
+        remaining_today_usd,
+        remaining_hour_usd,
+        exhausted: reason.is_some(),
+        reason,
+        last_receipt_id: None,
+    }
+}
+
+fn next_scheduled_run(
+    binding: &PersonaRuntimeBinding,
+    last_run_ms: Option<i64>,
+    now_ms: i64,
+) -> Option<String> {
+    binding
+        .schedules
+        .iter()
+        .filter_map(|schedule| next_cron_ms(schedule, last_run_ms.unwrap_or(now_ms)).ok())
+        .min()
+        .map(format_ms)
+}
+
+fn next_cron_ms(schedule: &str, after_ms: i64) -> Result<i64, String> {
+    let cron = schedule
+        .parse::<Cron>()
+        .map_err(|error| error.to_string())?;
+    let after = Utc
+        .timestamp_millis_opt(after_ms)
+        .single()
+        .ok_or_else(|| "invalid timestamp".to_string())?;
+    let next = cron
+        .find_next_occurrence(&after, false)
+        .map_err(|error| error.to_string())?;
+    Ok(next.timestamp_millis())
+}
+
+pub fn now_ms() -> i64 {
+    OffsetDateTime::now_utc().unix_timestamp_nanos() as i64 / 1_000_000
+}
+
+pub fn format_ms(ms: i64) -> String {
+    OffsetDateTime::from_unix_timestamp_nanos((ms as i128) * 1_000_000)
+        .unwrap_or(OffsetDateTime::UNIX_EPOCH)
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+pub fn parse_rfc3339_ms(value: &str) -> Result<i64, String> {
+    let ts = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|error| format!("invalid RFC3339 timestamp '{value}': {error}"))?;
+    Ok(ts.unix_timestamp_nanos() as i64 / 1_000_000)
+}
+
+fn runtime_topic() -> Result<Topic, String> {
+    Topic::new(PERSONA_RUNTIME_TOPIC).map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event_log::{AnyEventLog, MemoryEventLog};
+
+    fn binding() -> PersonaRuntimeBinding {
+        PersonaRuntimeBinding {
+            name: "merge_captain".to_string(),
+            entry_workflow: "workflows/merge.harn#run".to_string(),
+            schedules: vec!["*/30 * * * *".to_string()],
+            triggers: vec!["github.pr_opened".to_string()],
+            budget: PersonaBudgetPolicy {
+                daily_usd: Some(0.02),
+                hourly_usd: None,
+                run_usd: Some(0.02),
+                max_tokens: Some(100),
+            },
+        }
+    }
+
+    fn log() -> Arc<AnyEventLog> {
+        Arc::new(AnyEventLog::Memory(MemoryEventLog::new(64)))
+    }
+
+    #[tokio::test]
+    async fn schedule_tick_records_lifecycle_status_and_receipt() {
+        let log = log();
+        let binding = binding();
+        let now = parse_rfc3339_ms("2026-04-24T12:30:00Z").unwrap();
+        let receipt = fire_schedule(
+            &log,
+            &binding,
+            PersonaRunCost {
+                cost_usd: 0.01,
+                tokens: 10,
+            },
+            now,
+        )
+        .await
+        .unwrap();
+        assert_eq!(receipt.status, "completed");
+        assert!(receipt.lease.is_some());
+        let status = persona_status(&log, &binding, now).await.unwrap();
+        assert_eq!(status.state, PersonaLifecycleState::Idle);
+        assert_eq!(status.last_run.as_deref(), Some("2026-04-24T12:30:00Z"));
+        assert!(status.next_scheduled_run.is_some());
+        assert_eq!(status.budget.spent_today_usd, 0.01);
+    }
+
+    #[tokio::test]
+    async fn paused_personas_queue_and_resume_drains_once() {
+        let log = log();
+        let binding = binding();
+        let now = parse_rfc3339_ms("2026-04-24T12:00:00Z").unwrap();
+        pause_persona(&log, &binding, now).await.unwrap();
+        let receipt = fire_trigger(
+            &log,
+            &binding,
+            "github",
+            "pull_request",
+            BTreeMap::from([
+                ("repository".to_string(), "burin-labs/harn".to_string()),
+                ("number".to_string(), "462".to_string()),
+            ]),
+            PersonaRunCost::default(),
+            now,
+        )
+        .await
+        .unwrap();
+        assert_eq!(receipt.status, "queued");
+        assert_eq!(
+            persona_status(&log, &binding, now)
+                .await
+                .unwrap()
+                .queued_events,
+            1
+        );
+        let status = resume_persona(&log, &binding, now + 1000).await.unwrap();
+        assert_eq!(status.state, PersonaLifecycleState::Idle);
+        assert_eq!(status.queued_events, 0);
+    }
+
+    #[tokio::test]
+    async fn duplicate_trigger_envelope_is_not_processed_twice() {
+        let log = log();
+        let binding = binding();
+        let now = parse_rfc3339_ms("2026-04-24T12:00:00Z").unwrap();
+        let metadata = BTreeMap::from([
+            ("repository".to_string(), "burin-labs/harn".to_string()),
+            ("number".to_string(), "462".to_string()),
+        ]);
+        let first = fire_trigger(
+            &log,
+            &binding,
+            "github",
+            "pull_request",
+            metadata.clone(),
+            PersonaRunCost::default(),
+            now,
+        )
+        .await
+        .unwrap();
+        let second = fire_trigger(
+            &log,
+            &binding,
+            "github",
+            "pull_request",
+            metadata,
+            PersonaRunCost::default(),
+            now + 1000,
+        )
+        .await
+        .unwrap();
+        assert_eq!(first.status, "completed");
+        assert_eq!(second.status, "duplicate");
+        assert!(second.lease.is_none());
+    }
+
+    #[tokio::test]
+    async fn disabled_personas_dead_letter_events() {
+        let log = log();
+        let binding = binding();
+        let now = parse_rfc3339_ms("2026-04-24T12:00:00Z").unwrap();
+        disable_persona(&log, &binding, now).await.unwrap();
+        let receipt = fire_trigger(
+            &log,
+            &binding,
+            "slack",
+            "message",
+            BTreeMap::from([
+                ("channel".to_string(), "C123".to_string()),
+                ("ts".to_string(), "1713988800.000100".to_string()),
+            ]),
+            PersonaRunCost::default(),
+            now,
+        )
+        .await
+        .unwrap();
+        assert_eq!(receipt.status, "dead_lettered");
+        let status = persona_status(&log, &binding, now).await.unwrap();
+        assert_eq!(status.state, PersonaLifecycleState::Disabled);
+        assert_eq!(status.disabled_events, 1);
+    }
+
+    #[tokio::test]
+    async fn budget_exhaustion_blocks_expensive_work() {
+        let log = log();
+        let mut binding = binding();
+        binding.budget.daily_usd = Some(0.01);
+        let now = parse_rfc3339_ms("2026-04-24T12:00:00Z").unwrap();
+        let receipt = fire_trigger(
+            &log,
+            &binding,
+            "linear",
+            "issue",
+            BTreeMap::from([("issue_key".to_string(), "HAR-462".to_string())]),
+            PersonaRunCost {
+                cost_usd: 0.02,
+                tokens: 1,
+            },
+            now,
+        )
+        .await
+        .unwrap();
+        assert_eq!(receipt.status, "budget_exhausted");
+        let status = persona_status(&log, &binding, now).await.unwrap();
+        assert_eq!(status.budget.reason.as_deref(), Some("daily_usd"));
+        assert!(status.budget.exhausted);
+        assert!(status.last_error.as_deref().unwrap().contains("daily_usd"));
+    }
+}

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -135,7 +135,7 @@ control-flow nodes.
 
 ## harn persona
 
-List and inspect durable agent persona manifests from `harn.toml`.
+List, inspect, and control durable agent persona manifests from `harn.toml`.
 
 ```bash
 harn persona list
@@ -143,16 +143,31 @@ harn persona list --json
 harn persona inspect merge_captain
 harn persona inspect merge_captain --json
 harn persona --manifest examples/personas/harn.toml inspect merge_captain --json
+harn persona --manifest examples/personas/harn.toml status merge_captain --json
+harn persona --manifest examples/personas/harn.toml tick merge_captain --json
+harn persona --manifest examples/personas/harn.toml trigger merge_captain \
+  --provider github --kind pull_request \
+  --metadata repository=burin-labs/harn --metadata number=462 --json
+harn persona --manifest examples/personas/harn.toml pause merge_captain
+harn persona --manifest examples/personas/harn.toml resume merge_captain
+harn persona --manifest examples/personas/harn.toml disable merge_captain
 ```
 
 | Flag | Description |
 |---|---|
 | `--manifest <path>` | Use an explicit `harn.toml` path or directory containing one |
-| `--json` | Emit stable JSON for `list` or `inspect` |
+| `--state-dir <dir>` | Store persona runtime events under a durable EventLog base directory, default `.harn/personas` |
+| `--json` | Emit stable JSON for list, inspect, status, controls, trigger, tick, and budget receipts |
 
 `harn persona` validates the manifest before printing. It rejects missing entry
 workflows, unknown capabilities, invalid budget fields, invalid schedules, and
 handoffs that point at undeclared personas.
+
+Runtime commands append event-sourced lifecycle records to
+`persona.runtime.events`. `pause` queues matching trigger events,
+`resume` drains queued events once under a lease, and `disable` records later
+events as dead-lettered. `tick`, `trigger`, and `spend` enforce per-persona
+daily, hourly, run, and token budgets before recording expensive-work receipts.
 
 ## harn fmt
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -3693,9 +3693,11 @@ directory when none is supplied).
 ### `[[personas]]` — durable agent role manifests
 
 `[[personas]]` entries define durable agent roles in the package/workspace
-manifest. Persona v1 is static: tooling parses, validates, lists, and inspects
-the contract, while runtime scheduling and handoff execution remain separate
-runtime work.
+manifest. Tooling parses, validates, lists, and inspects the contract. The
+continuous runtime records lifecycle controls, schedule and trigger wake
+receipts, single-writer leases, budget receipts, and status snapshots in the
+`persona.runtime.events` EventLog topic; long-lived hosted wake loops and typed
+handoff dispatch remain host/orchestrator work.
 
 Required fields are `name`, `description`, `entry_workflow`, either `tools` or
 `capabilities`, `autonomy_tier`, and `receipt_policy`. Optional fields include
@@ -3725,6 +3727,10 @@ Validation rejects missing required fields, malformed or unknown
 unknown budget/model/source/rollout fields, negative budget amounts, and invalid
 rollout percentages. `harn persona list` and `harn persona inspect <name>
 --json` expose the resolved schema for hosts such as IDEs and cloud runners.
+`harn persona status <name> --json` exposes stable runtime state including
+lifecycle state, active lease, last run, next scheduled run, budget status, and
+last error. `pause` queues later events, `resume` drains queued events under
+leases, and `disable` records later events as dead-lettered.
 
 ### `[dependencies]` and `harn.lock` — git-backed package installs
 

--- a/docs/src/personas.md
+++ b/docs/src/personas.md
@@ -13,8 +13,9 @@ not just natural-language behavior.
 
 Persona v1 lives in `harn.toml` as `[[personas]]` entries. This keeps personas
 compatible with package manifests and the existing manifest discovery model.
-Runtime scheduling and typed handoff execution are intentionally outside this
-first pass; the CLI only parses, validates, lists, and inspects manifests.
+The continuous runtime is intentionally small and event-sourced: it records
+schedule and trigger wakes, leases, lifecycle controls, budget receipts, and
+status snapshots without inventing a hidden hosted scheduler.
 
 ```toml
 [[personas]]
@@ -90,6 +91,15 @@ harn persona list --json
 harn persona inspect merge_captain
 harn persona inspect merge_captain --json
 harn persona --manifest examples/personas/harn.toml inspect merge_captain --json
+harn persona --manifest examples/personas/harn.toml status merge_captain --json
+harn persona --manifest examples/personas/harn.toml tick merge_captain \
+  --at 2026-04-24T12:30:00Z --cost-usd 0.02 --tokens 120 --json
+harn persona --manifest examples/personas/harn.toml trigger merge_captain \
+  --provider github --kind pull_request \
+  --metadata repository=burin-labs/harn --metadata number=462 --json
+harn persona --manifest examples/personas/harn.toml pause merge_captain
+harn persona --manifest examples/personas/harn.toml resume merge_captain
+harn persona --manifest examples/personas/harn.toml disable merge_captain
 ```
 
 `--manifest` accepts a `harn.toml` path or a directory containing one. Without
@@ -100,6 +110,38 @@ The JSON output is stable enough for hosts such as IDEs and cloud runners to
 consume. It includes name, version, tools, capabilities, autonomy tier, model
 policy, budget, triggers, handoffs, context packs, evals, receipt policy, and
 manifest source.
+
+## Continuous runtime
+
+Persona runtime commands write durable records to the active EventLog topic
+`persona.runtime.events` under `--state-dir` (default `.harn/personas`). The
+status query replays those records and returns stable JSON with:
+
+- lifecycle state: `inactive`, `starting`, `idle`, `running`, `paused`,
+  `draining`, `failed`, or `disabled`
+- `last_run` and `next_scheduled_run`
+- active lease id, holder, work key, acquisition time, and expiry
+- budget limits, spend, token usage, exhaustion reason, and last receipt id
+- queued event count, disabled/dead-lettered event count, and last error
+
+Leases are single-writer. A persona run acquires one active lease for the
+normalized work key and records a conflict instead of processing duplicate work
+while the lease is live. Expired leases are recovered by appending a
+`persona.lease.expired` event before the next acquisition.
+
+Pause/resume/disable are explicit controls. Paused personas do not drop events:
+incoming events are queued with a `queue_then_drain_on_resume` policy. `resume`
+sets the state back to idle and drains queued events once under normal lease and
+budget checks. Disabled personas record later events as dead-lettered.
+
+Budget checks run before schedule and trigger work records. Per-persona
+`daily_usd`, `hourly_usd`, `run_usd`, and `max_tokens` caps block expensive
+work and append a structured budget-exhaustion event with a receipt id.
+
+External trigger metadata is normalized for common continuous-persona sources:
+GitHub PRs and check runs, Linear issues, Slack messages, and generic webhooks.
+For example, GitHub PR metadata with `repository=burin-labs/harn` and
+`number=462` normalizes to the work key `github:burin-labs/harn:pr:462`.
 
 ## Template pack
 
@@ -122,13 +164,15 @@ opaque hosted behavior.
 
 ## Current v1 gaps
 
-Persona manifest v1 is a contract surface, not a scheduler. Harn currently
-parses, validates, lists, and inspects personas; it does not yet execute them
-from `[[personas]]` entries.
+Persona manifest v1 is a contract and runtime-control surface, not a managed
+cloud scheduler. Harn records durable wakes and receipts from CLI/runtime
+commands, but it does not yet run a long-lived hosted persona supervisor from
+`[[personas]]` entries by itself.
 
 That means template packs should stay honest about missing platform scope:
 
-- schedules validate now but are not runtime wakeups yet
+- schedule bindings can be fired and recorded, but deployment-specific
+  long-running wake loops still belong to the orchestrator/host
 - handoffs validate now but are not typed persona-runtime dispatch yet
 - backend-specific systems such as Honeycomb and Splunk should be expressed
   through current tool wiring such as MCP rather than invented manifest fields
@@ -139,7 +183,7 @@ That means template packs should stay honest about missing platform scope:
 |---|---|---|---|
 | Skill | Reusable instructions, activation metadata, and optional bundled files. | `SKILL.md` bundle or `skill NAME { ... }`. | No, but it can be loaded into an agent turn. |
 | Workflow | Deterministic Harn code that performs work. | `.harn` pipeline/workflow entrypoint. | Yes, when run by the VM or orchestrator. |
-| Persona | Durable operational role that points at workflows and adds policy. | `[[personas]]` manifest entry. | Not in v1; it is parsed and validated for later runtime execution. |
+| Persona | Durable operational role that points at workflows and adds policy. | `[[personas]]` manifest entry. | Yes for runtime wake/control receipts; workflow execution is still host/orchestrator-owned. |
 
 A skill can teach a model how to do a task. A workflow is the executable path.
 A persona says which role owns the work, when it should wake up, what it may

--- a/examples/personas/README.md
+++ b/examples/personas/README.md
@@ -19,10 +19,11 @@ These templates are safe by default:
 
 ## What works today
 
-Persona manifest v1 is inspection and validation only. The runtime does not yet
-schedule personas from `[[personas]]` entries or execute typed persona handoffs
-directly. The checked-in workflows, fixtures, and evals are therefore starter
-artifacts for teams to fork, not a hidden SaaS control plane.
+Persona manifest v1 is now inspection, validation, and durable runtime control.
+The CLI can record schedule wakes, trigger wakes, leases, pause/resume/disable
+controls, budget receipts, and status JSON for these entries. The checked-in
+workflows, fixtures, and evals remain starter artifacts for teams to fork, not
+a hidden SaaS control plane.
 
 The current templates make gaps explicit instead of inventing more platform
 scope:
@@ -31,8 +32,9 @@ scope:
   and Splunk are expected to arrive through MCP wiring today.
 - `handoffs` are declared in the manifest and modeled in workflow output, but
   persona-runtime handoff dispatch is not wired in v1.
-- schedules are validated now and can be consumed by future runtime work, but
-  they do not wake these personas up by themselves yet.
+- schedules can be fired and recorded with `harn persona tick`, but
+  deployment-specific always-on wake loops still belong to the orchestrator or
+  host.
 
 ## Layout
 
@@ -51,11 +53,16 @@ harn persona --manifest examples/personas/harn.toml list
 harn persona --manifest examples/personas/harn.toml inspect merge_captain --json
 harn persona --manifest examples/personas/harn.toml inspect review_captain --json
 harn persona --manifest examples/personas/harn.toml inspect oncall_captain --json
+harn persona --manifest examples/personas/harn.toml status merge_captain --json
 ```
 
 ## Smoke checks
 
 ```bash
+harn persona --manifest examples/personas/harn.toml tick merge_captain --json
+harn persona --manifest examples/personas/harn.toml trigger merge_captain \
+  --provider github --kind pull_request \
+  --metadata repository=burin-labs/harn --metadata number=462 --json
 harn run examples/personas/workflows/merge_captain.harn
 harn run examples/personas/workflows/review_captain.harn
 harn run examples/personas/workflows/oncall_captain.harn

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -3691,9 +3691,11 @@ directory when none is supplied).
 ### `[[personas]]` — durable agent role manifests
 
 `[[personas]]` entries define durable agent roles in the package/workspace
-manifest. Persona v1 is static: tooling parses, validates, lists, and inspects
-the contract, while runtime scheduling and handoff execution remain separate
-runtime work.
+manifest. Tooling parses, validates, lists, and inspects the contract. The
+continuous runtime records lifecycle controls, schedule and trigger wake
+receipts, single-writer leases, budget receipts, and status snapshots in the
+`persona.runtime.events` EventLog topic; long-lived hosted wake loops and typed
+handoff dispatch remain host/orchestrator work.
 
 Required fields are `name`, `description`, `entry_workflow`, either `tools` or
 `capabilities`, `autonomy_tier`, and `receipt_policy`. Optional fields include
@@ -3723,6 +3725,10 @@ Validation rejects missing required fields, malformed or unknown
 unknown budget/model/source/rollout fields, negative budget amounts, and invalid
 rollout percentages. `harn persona list` and `harn persona inspect <name>
 --json` expose the resolved schema for hosts such as IDEs and cloud runners.
+`harn persona status <name> --json` exposes stable runtime state including
+lifecycle state, active lease, last run, next scheduled run, budget status, and
+last error. `pause` queues later events, `resume` drains queued events under
+leases, and `disable` records later events as dead-lettered.
 
 ### `[dependencies]` and `harn.lock` — git-backed package installs
 


### PR DESCRIPTION
## Summary

Implements the continuous persona runtime primitives requested in #462:

- adds an event-sourced `harn_vm::personas` runtime on `persona.runtime.events` with lifecycle state, single-writer leases, duplicate trigger protection, pause/resume/disable controls, schedule wakes, external trigger normalization, budget receipts, and stable status snapshots
- extends `harn persona` with durable runtime commands: `status`, `pause`, `resume`, `disable`, `tick`, `trigger`, and `spend`, backed by `--state-dir`
- documents the runtime/control surface in the CLI reference, persona guide, spec, generated language spec, template README, and changelog

Closes #462.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-issue462 cargo test -p harn-vm personas::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue462 cargo test -p harn-cli --test persona_cli -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue462 cargo check -p harn-vm -p harn-cli`
- pre-commit hook: `cargo fmt`, workspace clippy, highlight sync, markdown lint
- pre-push hook: 2054 workspace tests passed, markdown lint passed