### PR TITLE
[codex] Add per-agent dynamic permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ granular archaeology.
   manifest validation and deterministic suggestion generation from
   repeated friction evidence; extends eval packs with
   `friction-events` fixtures and `context-pack-suggestion` assertions.
+- **Per-agent dynamic permissions (#529).** `agent_loop`,
+  `sub_agent_run`, workflow stages, and `spawn_agent` now accept a
+  `permissions.allow` / `permissions.deny` dict with tool-name globs,
+  argument pattern lists, keyed argument patterns, and VM predicates
+  over tool args. Child agents inherit parent scopes by intersection,
+  so delegation cannot widen trust. Permission denials surface as
+  structured tool results rather than opaque failures.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,12 @@ enforcement.
 - Per-agent capability policies with argument-level constraints: `agent_loop`
   accepts a `policy` dict to scope tool permissions, including `tool_arg_constraints`
   for pattern-matching on tool arguments.
+- Dynamic per-agent permissions: `agent_loop`, `sub_agent_run`, and
+  `spawn_agent` accept `permissions` with `allow` / `deny` tool rules, VM
+  predicates over the tool args, and `on_escalation` callbacks that can grant a
+  denied call once or for the session. Permission decisions emit
+  `PermissionGrant`, `PermissionDeny`, and `PermissionEscalation` transcript
+  events.
 - Generic call-site type checking is stricter: `where`-clause interface
   violations are errors, repeated generic parameters must bind to one concrete
   type, and container bindings like `list<T>` propagate their element type.

--- a/conformance/tests/agents/per_agent_permissions_dynamic.expected
+++ b/conformance/tests/agents/per_agent_permissions_dynamic.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/conformance/tests/agents/per_agent_permissions_dynamic.harn
+++ b/conformance/tests/agents/per_agent_permissions_dynamic.harn
@@ -1,0 +1,54 @@
+fn note_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "read_note",
+    "Read a note",
+    {
+    handler: { args -> "read " + args.path },
+    parameters: {path: {type: "string"}},
+    returns: {type: "string"},
+  },
+  )
+  tools = tool_define(
+    tools,
+    "write_note",
+    "Write a note",
+    {
+    handler: { args -> "wrote " + args.path },
+    parameters: {path: {type: "string"}},
+    returns: {type: "string"},
+  },
+  )
+  return tools
+}
+
+pipeline main() {
+  llm_mock(
+    {
+    tool_calls: [
+    {id: "read_1", name: "read_note", arguments: {path: "/workspace/a.txt"}},
+    {id: "write_1", name: "write_note", arguments: {path: "/workspace/a.txt"}},
+  ],
+  },
+  )
+  let result = agent_loop(
+    "Read then write.",
+    "Use tools.",
+    {
+    provider: "mock",
+    tools: note_tools(),
+    tool_format: "native",
+    max_iterations: 1,
+    permissions: {
+    allow: {read_note: { args -> args.path.starts_with("/workspace/") }},
+    deny: {write_note: { args -> true }},
+  },
+  },
+  )
+  let events = transcript_events(result?.transcript)
+  println(len(transcript_events_by_kind(result?.transcript, "PermissionGrant")) == 1)
+  println(len(transcript_events_by_kind(result?.transcript, "PermissionDeny")) == 1)
+  println(result?.tools?.rejected[0] == "write_note")
+  println(json_stringify(events).contains("/workspace/a.txt"))
+}

--- a/conformance/tests/agents/per_agent_permissions_escalation.expected
+++ b/conformance/tests/agents/per_agent_permissions_escalation.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/conformance/tests/agents/per_agent_permissions_escalation.harn
+++ b/conformance/tests/agents/per_agent_permissions_escalation.harn
@@ -1,0 +1,48 @@
+fn write_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "write_note",
+    "Write a note",
+    {
+    handler: { args -> "wrote " + args.path },
+    parameters: {path: {type: "string"}},
+    returns: {type: "string"},
+  },
+  )
+  return tools
+}
+
+pipeline main() {
+  llm_mock(
+    {
+    tool_calls: [
+    {id: "write_1", name: "write_note", arguments: {path: "/workspace/a.txt"}},
+    {id: "write_2", name: "write_note", arguments: {path: "/workspace/a.txt"}},
+  ],
+  },
+  )
+  let result = agent_loop(
+    "Write twice.",
+    "Use tools.",
+    {
+    provider: "mock",
+    tools: write_tools(),
+    tool_format: "native",
+    max_iterations: 1,
+    permissions: {
+    deny: ["write_note"],
+    on_escalation: { request ->
+    if request.tool == "write_note" && request.args.path.starts_with("/workspace/") {
+      return {grant: "session", approver: "tester", reason: "workspace write approved"}
+    }
+    return false
+  },
+  },
+  },
+  )
+  println(len(transcript_events_by_kind(result?.transcript, "PermissionEscalation")) == 1)
+  println(len(transcript_events_by_kind(result?.transcript, "PermissionGrant")) == 2)
+  println(len(result?.tools?.rejected ?? []) == 0)
+  println(transcript_render_full(result?.transcript).contains("workspace write approved"))
+}

--- a/conformance/tests/agents/spawn_agent_permissions.expected
+++ b/conformance/tests/agents/spawn_agent_permissions.expected
@@ -1,0 +1,3 @@
+true
+true
+true

--- a/conformance/tests/agents/spawn_agent_permissions.harn
+++ b/conformance/tests/agents/spawn_agent_permissions.harn
@@ -1,0 +1,37 @@
+import "std/agents"
+
+fn write_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "write_note",
+    "Write a note",
+    {
+    handler: { args -> "wrote " + args.path },
+    parameters: {path: {type: "string"}},
+    returns: {type: "string"},
+  },
+  )
+  return tools
+}
+
+pipeline main() {
+  llm_mock({tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "/workspace/a.txt"}}]})
+  let worker = spawn_agent(
+    {
+    name: "permission-worker",
+    task: "Try to write.",
+    wait: true,
+    permissions: {deny: ["write_note"]},
+    node: {
+    kind: "stage",
+    mode: "agent",
+    model_policy: {provider: "mock", tool_format: "native", max_iterations: 1},
+    tools: write_tools(),
+  },
+  },
+  )
+  println(worker?.status == "completed")
+  println(worker?.result?.result?.tools?.rejected[0] == "write_note")
+  println(len(transcript_events_by_kind(worker?.result?.transcript, "PermissionDeny")) == 1)
+}

--- a/conformance/tests/agents/sub_agent_permissions_intersection.expected
+++ b/conformance/tests/agents/sub_agent_permissions_intersection.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/conformance/tests/agents/sub_agent_permissions_intersection.harn
+++ b/conformance/tests/agents/sub_agent_permissions_intersection.harn
@@ -1,0 +1,33 @@
+fn write_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "write_note",
+    "Write a note",
+    {
+    handler: { args -> "wrote " + args.path },
+    parameters: {path: {type: "string"}},
+    returns: {type: "string"},
+  },
+  )
+  return tools
+}
+
+pipeline main() {
+  llm_mock({tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "/workspace/a.txt"}}]})
+  let denied = sub_agent_run(
+    "Try to write.",
+    {
+    provider: "mock",
+    tools: write_tools(),
+    tool_format: "native",
+    max_iterations: 1,
+    policy: {tools: ["read_note"]},
+    permissions: {allow: {write_note: { args -> true }}},
+  },
+  )
+  println(!denied?.ok)
+  println(denied?.error?.category == "permission_denied")
+  println(denied?.error?.tool == "write_note")
+  println(len(transcript_events_by_kind(denied?.transcript, "PermissionDeny")) == 1)
+}

--- a/crates/harn-vm/src/llm/agent/state.rs
+++ b/crates/harn-vm/src/llm/agent/state.rs
@@ -55,6 +55,20 @@ impl Drop for ApprovalPolicyGuard {
     }
 }
 
+/// Pops the loop-local dynamic permission policy off the stack when
+/// the loop exits. Only pops if the loop actually pushed a policy.
+pub(super) struct DynamicPermissionPolicyGuard {
+    pub(super) active: bool,
+}
+
+impl Drop for DynamicPermissionPolicyGuard {
+    fn drop(&mut self) {
+        if self.active {
+            crate::llm::permissions::pop_dynamic_permission_policy();
+        }
+    }
+}
+
 /// Owned handle for a temporarily-reshaped `VmValue` tools registry.
 /// The state struct doesn't own this — it holds a borrow into it via
 /// `tools_val_borrow` only during construction. Dropped before `Self::new`
@@ -437,14 +451,15 @@ fn rehydrate_active_skills(
 /// let _sink_guard      = …;  // 2nd
 /// let _policy_guard    = …;  // 3rd
 /// let _approval_guard  = …;  // 4th
+/// let _permission_guard = …; // 5th
 /// ```
 ///
 /// `let` bindings drop in REVERSE declaration order, so the observable
-/// drop order was: approval → policy → sink → iteration. To preserve
+/// drop order is: permission → approval → policy → sink → iteration. To preserve
 /// that order with struct fields (forward drop order), the guard fields
 /// appear in this struct in the SAME sequence as the observable drop
-/// order: `_approval_guard`, `_policy_guard`, `_sink_guard`,
-/// `_iteration_guard`. **Do not reorder** without re-auditing the push/
+/// order: `_permission_guard`, `_approval_guard`, `_policy_guard`,
+/// `_sink_guard`, `_iteration_guard`. **Do not reorder** without re-auditing the push/
 /// pop lifetimes in `crate::orchestration`.
 pub(super) struct AgentLoopState {
     pub(super) config: AgentLoopConfig,
@@ -481,6 +496,7 @@ pub(super) struct AgentLoopState {
     pub(super) all_tools_used: Vec<String>,
     pub(super) successful_tools_used: Vec<String>,
     pub(super) rejected_tools: Vec<String>,
+    pub(super) permission_session_grants: std::collections::BTreeSet<String>,
     pub(super) deferred_user_messages: Vec<String>,
 
     pub(super) daemon_state: String,
@@ -545,6 +561,7 @@ pub(super) struct AgentLoopState {
     pub(crate) rehydrated_from_session: bool,
 
     // Drop guards: see "Drop ordering" on the struct docs.
+    pub(super) _permission_guard: DynamicPermissionPolicyGuard,
     pub(super) _approval_guard: ApprovalPolicyGuard,
     pub(super) _policy_guard: ExecutionPolicyGuard,
     pub(super) _sink_guard: SessionSinkGuard,
@@ -946,6 +963,14 @@ impl AgentLoopState {
             active: effective_approval_policy.is_some(),
         };
 
+        let effective_permissions = config.permissions.clone();
+        if let Some(ref permissions) = effective_permissions {
+            crate::llm::permissions::push_dynamic_permission_policy(permissions.clone());
+        }
+        let _permission_guard = DynamicPermissionPolicyGuard {
+            active: effective_permissions.is_some(),
+        };
+
         let has_skill_registry = config_skill_registry
             .as_ref()
             .and_then(|value| value.as_dict())
@@ -1248,6 +1273,7 @@ impl AgentLoopState {
             all_tools_used,
             successful_tools_used,
             rejected_tools,
+            permission_session_grants: std::collections::BTreeSet::new(),
             deferred_user_messages,
             daemon_state,
             daemon_snapshot_path,
@@ -1278,6 +1304,7 @@ impl AgentLoopState {
             skill_match: config_skill_match,
             working_files: config_working_files,
             native_tools_snapshot,
+            _permission_guard,
             _approval_guard,
             _policy_guard,
             _sink_guard,

--- a/crates/harn-vm/src/llm/agent/tests/mod.rs
+++ b/crates/harn-vm/src/llm/agent/tests/mod.rs
@@ -92,6 +92,7 @@ pub(super) fn base_agent_config() -> AgentLoopConfig {
         native_tool_fallback: crate::orchestration::NativeToolFallbackPolicy::Allow,
         auto_compact: None,
         policy: None,
+        permissions: None,
         approval_policy: None,
         daemon: false,
         daemon_config: DaemonLoopConfig::default(),

--- a/crates/harn-vm/src/llm/agent/tool_dispatch.rs
+++ b/crates/harn-vm/src/llm/agent/tool_dispatch.rs
@@ -553,6 +553,15 @@ pub(super) async fn run_tool_dispatch(
             if !state.rejected_tools.contains(&tool_name.to_string()) {
                 state.rejected_tools.push(tool_name.to_string());
             }
+            state
+                .transcript_events
+                .push(crate::llm::permissions::permission_transcript_event(
+                    "PermissionDeny",
+                    tool_name,
+                    &tool_args,
+                    &error.to_string(),
+                    false,
+                ));
             state.transcript_events.push(transcript_event(
                 "tool_execution",
                 "tool",
@@ -577,6 +586,97 @@ pub(super) async fn run_tool_dispatch(
                 ));
             }
             continue;
+        }
+
+        if let Some(permission) = crate::llm::permissions::check_dynamic_permission(
+            &mut state.permission_session_grants,
+            tool_name,
+            &tool_args,
+            ctx.session_id,
+        )
+        .await?
+        {
+            match permission {
+                crate::llm::permissions::PermissionCheck::Granted { reason, escalated } => {
+                    if escalated {
+                        state.transcript_events.push(
+                            crate::llm::permissions::permission_transcript_event(
+                                "PermissionEscalation",
+                                tool_name,
+                                &tool_args,
+                                &reason,
+                                true,
+                            ),
+                        );
+                    }
+                    state.transcript_events.push(
+                        crate::llm::permissions::permission_transcript_event(
+                            "PermissionGrant",
+                            tool_name,
+                            &tool_args,
+                            &reason,
+                            escalated,
+                        ),
+                    );
+                }
+                crate::llm::permissions::PermissionCheck::Denied { reason, escalated } => {
+                    if escalated {
+                        state.transcript_events.push(
+                            crate::llm::permissions::permission_transcript_event(
+                                "PermissionEscalation",
+                                tool_name,
+                                &tool_args,
+                                &reason,
+                                true,
+                            ),
+                        );
+                    }
+                    state.transcript_events.push(
+                        crate::llm::permissions::permission_transcript_event(
+                            "PermissionDeny",
+                            tool_name,
+                            &tool_args,
+                            &reason,
+                            escalated,
+                        ),
+                    );
+                    let result_text = render_tool_result(&denied_tool_result(tool_name, reason));
+                    if !state.rejected_tools.contains(&tool_name.to_string()) {
+                        state.rejected_tools.push(tool_name.to_string());
+                    }
+                    state.transcript_events.push(transcript_event(
+                        "tool_execution",
+                        "tool",
+                        "internal",
+                        &result_text,
+                        Some(serde_json::json!({
+                            "tool_name": tool_name,
+                            "tool_use_id": tool_id,
+                            "rejected": true,
+                            "arguments": tool_args.clone(),
+                            "permission": "denied",
+                            "escalated": escalated,
+                        })),
+                    ));
+                    if ctx.tool_format == "native" {
+                        append_message_to_contexts(
+                            &mut state.visible_messages,
+                            &mut state.recorded_messages,
+                            build_tool_result_message(
+                                tool_id,
+                                tool_name,
+                                &result_text,
+                                &opts.provider,
+                            ),
+                        );
+                    } else {
+                        observations.push_str(&format!(
+                            "[result of {tool_name}]\n{result_text}\n[end of {tool_name} result]\n\n"
+                        ));
+                    }
+                    continue;
+                }
+            }
         }
 
         let approval_decision = crate::orchestration::current_approval_policy()
@@ -645,10 +745,19 @@ pub(super) async fn run_tool_dispatch(
             }
         };
         if let Err((approval_status, reason)) = approval_outcome {
-            let result_text = render_tool_result(&denied_tool_result(tool_name, reason));
+            let result_text = render_tool_result(&denied_tool_result(tool_name, reason.clone()));
             if !state.rejected_tools.contains(&tool_name.to_string()) {
                 state.rejected_tools.push(tool_name.to_string());
             }
+            state
+                .transcript_events
+                .push(crate::llm::permissions::permission_transcript_event(
+                    "PermissionDeny",
+                    tool_name,
+                    &tool_args,
+                    &reason,
+                    false,
+                ));
             state.transcript_events.push(transcript_event(
                 "tool_execution",
                 "tool",

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -34,6 +34,8 @@ pub struct AgentLoopConfig {
     pub auto_compact: Option<crate::orchestration::AutoCompactConfig>,
     /// Capability policy scoped to this agent loop.
     pub policy: Option<crate::orchestration::CapabilityPolicy>,
+    /// Dynamic per-agent permission rules, including VM predicates and escalation.
+    pub permissions: Option<crate::llm::permissions::DynamicPermissionPolicy>,
     /// Declarative approval policy (auto-approve / auto-deny / require host confirmation).
     pub approval_policy: Option<crate::orchestration::ToolApprovalPolicy>,
     /// Daemon mode.
@@ -387,6 +389,10 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                         serde_json::from_value::<crate::orchestration::ToolApprovalPolicy>(json)
                             .unwrap_or_default()
                     });
+            let permissions = crate::llm::permissions::parse_dynamic_permission_policy(
+                options.as_ref().and_then(|o| o.get("permissions")),
+                "agent_loop",
+            )?;
             let daemon_config = parse_daemon_loop_config(options.as_ref());
             let turn_policy = options
                 .as_ref()
@@ -414,6 +420,7 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                     native_tool_fallback,
                     auto_compact,
                     policy,
+                    permissions,
                     approval_policy,
                     daemon,
                     daemon_config,

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod daemon;
 pub(crate) mod helpers;
 pub(crate) mod ledger;
 pub(crate) mod mock;
+pub(crate) mod permissions;
 pub(crate) mod structural_experiments;
 pub(crate) mod tool_search;
 mod transcript_stats;
@@ -942,6 +943,10 @@ pub fn register_llm_builtins(vm: &mut Vm) {
                 serde_json::from_value::<crate::orchestration::ToolApprovalPolicy>(json)
                     .unwrap_or_default()
             });
+        let permissions = crate::llm::permissions::parse_dynamic_permission_policy(
+            options.as_ref().and_then(|o| o.get("permissions")),
+            "agent_loop",
+        )?;
         let done_sentinel = opt_str(&options, "done_sentinel");
         let break_unless_phase = opt_str(&options, "break_unless_phase");
         let exit_when_verified = opt_bool(&options, "exit_when_verified");
@@ -964,6 +969,7 @@ pub fn register_llm_builtins(vm: &mut Vm) {
                 native_tool_fallback,
                 auto_compact,
                 policy,
+                permissions,
                 approval_policy,
                 daemon,
                 daemon_config,

--- a/crates/harn-vm/src/llm/permissions.rs
+++ b/crates/harn-vm/src/llm/permissions.rs
@@ -1,0 +1,619 @@
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
+use std::thread_local;
+
+use crate::llm::agent_tools::stable_hash;
+use crate::trust_graph::{AutonomyTier, TrustOutcome, TrustRecord};
+use crate::value::{VmError, VmValue};
+
+#[derive(Clone)]
+pub(crate) struct DynamicPermissionPolicy {
+    allow: Vec<PermissionRule>,
+    deny: Vec<PermissionRule>,
+    on_escalation: Option<VmValue>,
+}
+
+#[derive(Clone)]
+struct PermissionRule {
+    tool_pattern: String,
+    matcher: PermissionMatcher,
+}
+
+#[derive(Clone)]
+enum PermissionMatcher {
+    Any,
+    Bool(bool),
+    Patterns(Vec<String>),
+    KeyedPatterns {
+        arg_key: String,
+        patterns: Vec<String>,
+    },
+    Predicate(VmValue),
+}
+
+pub(crate) enum PermissionCheck {
+    Granted { reason: String, escalated: bool },
+    Denied { reason: String, escalated: bool },
+}
+
+thread_local! {
+    static DYNAMIC_PERMISSION_STACK: RefCell<Vec<DynamicPermissionPolicy>> = const { RefCell::new(Vec::new()) };
+}
+
+pub(crate) fn push_dynamic_permission_policy(policy: DynamicPermissionPolicy) {
+    DYNAMIC_PERMISSION_STACK.with(|stack| stack.borrow_mut().push(policy));
+}
+
+pub(crate) fn pop_dynamic_permission_policy() {
+    DYNAMIC_PERMISSION_STACK.with(|stack| {
+        stack.borrow_mut().pop();
+    });
+}
+
+pub(crate) fn current_dynamic_permission_policies() -> Vec<DynamicPermissionPolicy> {
+    DYNAMIC_PERMISSION_STACK.with(|stack| stack.borrow().clone())
+}
+
+pub(crate) fn parse_dynamic_permission_policy(
+    value: Option<&VmValue>,
+    label: &str,
+) -> Result<Option<DynamicPermissionPolicy>, VmError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if matches!(value, VmValue::Nil) {
+        return Ok(None);
+    }
+    let dict = value
+        .as_dict()
+        .ok_or_else(|| VmError::Runtime(format!("{label}: permissions must be a dict")))?;
+    let allow = parse_rule_set(dict.get("allow"), &format!("{label}.allow"))?;
+    let deny = parse_rule_set(dict.get("deny"), &format!("{label}.deny"))?;
+    let on_escalation = dict
+        .get("on_escalation")
+        .filter(|value| matches!(value, VmValue::Closure(_)))
+        .cloned();
+    Ok(Some(DynamicPermissionPolicy {
+        allow,
+        deny,
+        on_escalation,
+    }))
+}
+
+fn parse_rule_set(value: Option<&VmValue>, label: &str) -> Result<Vec<PermissionRule>, VmError> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    match value {
+        VmValue::Nil => Ok(Vec::new()),
+        VmValue::List(list) => {
+            let mut rules = Vec::new();
+            for item in list.iter() {
+                let VmValue::String(pattern) = item else {
+                    return Err(VmError::Runtime(format!(
+                        "{label}: list entries must be strings"
+                    )));
+                };
+                let pattern = pattern.trim();
+                if !pattern.is_empty() {
+                    rules.push(PermissionRule {
+                        tool_pattern: pattern.to_string(),
+                        matcher: PermissionMatcher::Any,
+                    });
+                }
+            }
+            Ok(rules)
+        }
+        VmValue::Dict(map) => {
+            let mut rules = Vec::new();
+            for (tool_pattern, matcher) in map.iter() {
+                if tool_pattern.trim().is_empty() {
+                    continue;
+                }
+                rules.push(PermissionRule {
+                    tool_pattern: tool_pattern.clone(),
+                    matcher: parse_matcher(matcher, &format!("{label}.{tool_pattern}"))?,
+                });
+            }
+            Ok(rules)
+        }
+        other => Err(VmError::Runtime(format!(
+            "{label}: expected a list or dict, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_matcher(value: &VmValue, label: &str) -> Result<PermissionMatcher, VmError> {
+    match value {
+        VmValue::Nil => Ok(PermissionMatcher::Any),
+        VmValue::Bool(value) => Ok(PermissionMatcher::Bool(*value)),
+        VmValue::String(pattern) => Ok(PermissionMatcher::Patterns(vec![pattern.to_string()])),
+        VmValue::Closure(_) => Ok(PermissionMatcher::Predicate(value.clone())),
+        VmValue::List(list) => {
+            let mut patterns = Vec::new();
+            for item in list.iter() {
+                let VmValue::String(pattern) = item else {
+                    return Err(VmError::Runtime(format!(
+                        "{label}: pattern list entries must be strings"
+                    )));
+                };
+                patterns.push(pattern.to_string());
+            }
+            Ok(PermissionMatcher::Patterns(patterns))
+        }
+        VmValue::Dict(map) => {
+            let arg_key = map
+                .get("arg_key")
+                .or_else(|| map.get("key"))
+                .map(|value| value.display())
+                .filter(|value| !value.trim().is_empty());
+            let patterns_value = map
+                .get("patterns")
+                .or_else(|| map.get("arg_patterns"))
+                .or_else(|| map.get("allow"));
+            if let (Some(arg_key), Some(patterns_value)) = (arg_key, patterns_value) {
+                let patterns = parse_pattern_list(patterns_value, label)?;
+                return Ok(PermissionMatcher::KeyedPatterns { arg_key, patterns });
+            }
+            Err(VmError::Runtime(format!(
+                "{label}: dict matchers must include arg_key and patterns"
+            )))
+        }
+        other => Err(VmError::Runtime(format!(
+            "{label}: unsupported matcher type {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_pattern_list(value: &VmValue, label: &str) -> Result<Vec<String>, VmError> {
+    match value {
+        VmValue::String(pattern) => Ok(vec![pattern.to_string()]),
+        VmValue::List(list) => list
+            .iter()
+            .map(|item| match item {
+                VmValue::String(pattern) => Ok(pattern.to_string()),
+                _ => Err(VmError::Runtime(format!(
+                    "{label}: patterns must be a string or list of strings"
+                ))),
+            })
+            .collect(),
+        _ => Err(VmError::Runtime(format!(
+            "{label}: patterns must be a string or list of strings"
+        ))),
+    }
+}
+
+pub(crate) async fn check_dynamic_permission(
+    session_grants: &mut BTreeSet<String>,
+    tool_name: &str,
+    args: &serde_json::Value,
+    session_id: &str,
+) -> Result<Option<PermissionCheck>, VmError> {
+    let policies = current_dynamic_permission_policies();
+    if policies.is_empty() {
+        return Ok(None);
+    }
+
+    let mut grant_result: Option<PermissionCheck> = None;
+    for (index, policy) in policies.iter().enumerate() {
+        match check_one_dynamic_permission(
+            policy,
+            index,
+            session_grants,
+            tool_name,
+            args,
+            session_id,
+        )
+        .await?
+        {
+            PermissionCheck::Denied { reason, escalated } => {
+                return Ok(Some(PermissionCheck::Denied { reason, escalated }));
+            }
+            grant @ PermissionCheck::Granted { .. } => {
+                grant_result = Some(grant);
+            }
+        }
+    }
+    Ok(grant_result)
+}
+
+async fn check_one_dynamic_permission(
+    policy: &DynamicPermissionPolicy,
+    scope_index: usize,
+    session_grants: &mut BTreeSet<String>,
+    tool_name: &str,
+    args: &serde_json::Value,
+    session_id: &str,
+) -> Result<PermissionCheck, VmError> {
+    let grant_key = session_grant_key(scope_index, tool_name, args);
+    if session_grants.contains(&grant_key) {
+        return Ok(PermissionCheck::Granted {
+            reason: "session grant".to_string(),
+            escalated: false,
+        });
+    }
+
+    let denied = first_matching_rule(&policy.deny, tool_name, args).await?;
+    let allowed = if policy.allow.is_empty() {
+        None
+    } else {
+        Some(first_matching_rule(&policy.allow, tool_name, args).await?)
+    };
+
+    let denial_reason = if let Some(reason) = denied {
+        Some(format!("permission denied by deny rule: {reason}"))
+    } else {
+        match allowed {
+            Some(Some(_)) | None => None,
+            Some(None) => Some(format!(
+                "permission denied: tool '{tool_name}' is not allowed by this agent's permissions"
+            )),
+        }
+    };
+
+    let Some(reason) = denial_reason else {
+        return Ok(PermissionCheck::Granted {
+            reason: "permission allow rule matched".to_string(),
+            escalated: false,
+        });
+    };
+
+    let Some(on_escalation) = policy.on_escalation.as_ref() else {
+        return Ok(PermissionCheck::Denied {
+            reason,
+            escalated: false,
+        });
+    };
+
+    let request = permission_request_value(tool_name, args, session_id, &reason);
+    let response = invoke_escalation_callback(on_escalation, &request).await?;
+    if response.granted {
+        emit_tier_promotion_if_needed(tool_name, args, response.approver.clone()).await;
+        if matches!(response.scope, GrantScope::Session) {
+            session_grants.insert(grant_key);
+        }
+        Ok(PermissionCheck::Granted {
+            reason: response
+                .reason
+                .unwrap_or_else(|| "permission escalation granted".to_string()),
+            escalated: true,
+        })
+    } else {
+        Ok(PermissionCheck::Denied {
+            reason: response
+                .reason
+                .unwrap_or_else(|| "permission escalation denied".to_string()),
+            escalated: true,
+        })
+    }
+}
+
+async fn first_matching_rule(
+    rules: &[PermissionRule],
+    tool_name: &str,
+    args: &serde_json::Value,
+) -> Result<Option<String>, VmError> {
+    for rule in rules {
+        if !crate::orchestration::glob_match(&rule.tool_pattern, tool_name) {
+            continue;
+        }
+        if matcher_allows(&rule.matcher, args).await? {
+            return Ok(Some(rule.tool_pattern.clone()));
+        }
+    }
+    Ok(None)
+}
+
+async fn matcher_allows(
+    matcher: &PermissionMatcher,
+    args: &serde_json::Value,
+) -> Result<bool, VmError> {
+    match matcher {
+        PermissionMatcher::Any => Ok(true),
+        PermissionMatcher::Bool(value) => Ok(*value),
+        PermissionMatcher::Patterns(patterns) => Ok(args_match_any_pattern(args, patterns)),
+        PermissionMatcher::KeyedPatterns { arg_key, patterns } => Ok(args
+            .get(arg_key)
+            .and_then(|value| value.as_str())
+            .is_some_and(|value| {
+                patterns
+                    .iter()
+                    .any(|pattern| crate::orchestration::glob_match(pattern, value))
+            })),
+        PermissionMatcher::Predicate(value) => {
+            let VmValue::Closure(closure) = value else {
+                return Ok(false);
+            };
+            let Some(mut vm) = crate::vm::clone_async_builtin_child_vm() else {
+                return Err(VmError::Runtime(
+                    "permissions predicate requires an async builtin VM context".to_string(),
+                ));
+            };
+            let result = vm
+                .call_closure_pub(closure, &[crate::stdlib::json_to_vm_value(args)])
+                .await?;
+            Ok(value_truthy(&result))
+        }
+    }
+}
+
+fn args_match_any_pattern(args: &serde_json::Value, patterns: &[String]) -> bool {
+    let mut values = Vec::new();
+    collect_string_values(args, &mut values);
+    if values.is_empty() {
+        values.push(serde_json::to_string(args).unwrap_or_default());
+    }
+    values.iter().any(|candidate| {
+        patterns
+            .iter()
+            .any(|pattern| crate::orchestration::glob_match(pattern, candidate))
+    })
+}
+
+fn collect_string_values(value: &serde_json::Value, out: &mut Vec<String>) {
+    match value {
+        serde_json::Value::String(text) => out.push(text.clone()),
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_string_values(value, out);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for value in map.values() {
+                collect_string_values(value, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn value_truthy(value: &VmValue) -> bool {
+    match value {
+        VmValue::Nil => false,
+        VmValue::Bool(value) => *value,
+        VmValue::Int(value) => *value != 0,
+        VmValue::Float(value) => *value != 0.0,
+        VmValue::String(value) => !value.is_empty(),
+        VmValue::List(value) => !value.is_empty(),
+        VmValue::Dict(value) => !value.is_empty(),
+        _ => true,
+    }
+}
+
+#[derive(Clone, Copy)]
+enum GrantScope {
+    Once,
+    Session,
+}
+
+struct EscalationResponse {
+    granted: bool,
+    scope: GrantScope,
+    reason: Option<String>,
+    approver: Option<String>,
+}
+
+async fn invoke_escalation_callback(
+    callback: &VmValue,
+    request: &VmValue,
+) -> Result<EscalationResponse, VmError> {
+    let VmValue::Closure(closure) = callback else {
+        return Ok(EscalationResponse {
+            granted: false,
+            scope: GrantScope::Once,
+            reason: Some("permission escalation callback is not callable".to_string()),
+            approver: None,
+        });
+    };
+    let Some(mut vm) = crate::vm::clone_async_builtin_child_vm() else {
+        return Err(VmError::Runtime(
+            "permissions on_escalation requires an async builtin VM context".to_string(),
+        ));
+    };
+    parse_escalation_response(vm.call_closure_pub(closure, &[request.clone()]).await?)
+}
+
+fn parse_escalation_response(value: VmValue) -> Result<EscalationResponse, VmError> {
+    match value {
+        VmValue::Bool(true) => Ok(EscalationResponse {
+            granted: true,
+            scope: GrantScope::Once,
+            reason: None,
+            approver: None,
+        }),
+        VmValue::Bool(false) | VmValue::Nil => Ok(EscalationResponse {
+            granted: false,
+            scope: GrantScope::Once,
+            reason: None,
+            approver: None,
+        }),
+        VmValue::String(scope) => grant_scope_from_string(scope.as_ref()).map(|scope| {
+            EscalationResponse {
+                granted: true,
+                scope,
+                reason: None,
+                approver: None,
+            }
+        }),
+        VmValue::Dict(map) => {
+            let grant = map.get("grant").or_else(|| map.get("granted"));
+            let (granted, scope) = match grant {
+                Some(VmValue::Bool(false)) => (false, GrantScope::Once),
+                Some(VmValue::Bool(true)) => (true, GrantScope::Once),
+                Some(VmValue::String(scope)) => (true, grant_scope_from_string(scope.as_ref())?),
+                Some(other) => {
+                    return Err(VmError::Runtime(format!(
+                        "permissions on_escalation grant must be false, true, 'once', or 'session', got {}",
+                        other.type_name()
+                    )))
+                }
+                None => (false, GrantScope::Once),
+            };
+            Ok(EscalationResponse {
+                granted,
+                scope,
+                reason: map
+                    .get("reason")
+                    .map(|value| value.display())
+                    .filter(|value| !value.is_empty()),
+                approver: map
+                    .get("approver")
+                    .map(|value| value.display())
+                    .filter(|value| !value.is_empty()),
+            })
+        }
+        other => Err(VmError::Runtime(format!(
+            "permissions on_escalation must return false, true, 'once', 'session', or {{grant}}, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn grant_scope_from_string(value: &str) -> Result<GrantScope, VmError> {
+    match value {
+        "once" => Ok(GrantScope::Once),
+        "session" => Ok(GrantScope::Session),
+        "deny" | "denied" | "false" => Err(VmError::Runtime(
+            "permissions on_escalation string denial must return false".to_string(),
+        )),
+        other => Err(VmError::Runtime(format!(
+            "permissions on_escalation unsupported grant scope '{other}'"
+        ))),
+    }
+}
+
+fn permission_request_value(
+    tool_name: &str,
+    args: &serde_json::Value,
+    session_id: &str,
+    reason: &str,
+) -> VmValue {
+    let mut request = BTreeMap::new();
+    request.insert(
+        "_type".to_string(),
+        VmValue::String(Rc::from("PermissionRequest")),
+    );
+    request.insert(
+        "tool".to_string(),
+        VmValue::String(Rc::from(tool_name.to_string())),
+    );
+    request.insert("args".to_string(), crate::stdlib::json_to_vm_value(args));
+    request.insert(
+        "session_id".to_string(),
+        VmValue::String(Rc::from(session_id.to_string())),
+    );
+    request.insert(
+        "reason".to_string(),
+        VmValue::String(Rc::from(reason.to_string())),
+    );
+    if let Some(context) = crate::triggers::dispatcher::current_dispatch_context() {
+        request.insert(
+            "agent".to_string(),
+            VmValue::String(Rc::from(context.agent_id)),
+        );
+        request.insert(
+            "action".to_string(),
+            VmValue::String(Rc::from(context.action)),
+        );
+        request.insert(
+            "trace_id".to_string(),
+            VmValue::String(Rc::from(context.trigger_event.trace_id.0)),
+        );
+        request.insert(
+            "autonomy_tier".to_string(),
+            VmValue::String(Rc::from(context.autonomy_tier.as_str())),
+        );
+        if matches!(
+            context.autonomy_tier,
+            AutonomyTier::Shadow | AutonomyTier::Suggest
+        ) {
+            request.insert(
+                "requested_tier".to_string(),
+                VmValue::String(Rc::from(AutonomyTier::ActWithApproval.as_str())),
+            );
+        }
+    }
+    request.insert(
+        "grant_options".to_string(),
+        VmValue::List(Rc::new(vec![
+            VmValue::String(Rc::from("once")),
+            VmValue::String(Rc::from("session")),
+            VmValue::Bool(false),
+        ])),
+    );
+    VmValue::Dict(Rc::new(request))
+}
+
+async fn emit_tier_promotion_if_needed(
+    tool_name: &str,
+    args: &serde_json::Value,
+    approver: Option<String>,
+) {
+    let Some(context) = crate::triggers::dispatcher::current_dispatch_context() else {
+        return;
+    };
+    if !matches!(
+        context.autonomy_tier,
+        AutonomyTier::Shadow | AutonomyTier::Suggest
+    ) {
+        return;
+    }
+    let mut record = TrustRecord::new(
+        context.agent_id,
+        "trust.promote",
+        approver,
+        TrustOutcome::Success,
+        context.trigger_event.trace_id.0,
+        AutonomyTier::ActWithApproval,
+    );
+    record.metadata.insert(
+        "reason".to_string(),
+        serde_json::json!("permission escalation granted"),
+    );
+    record
+        .metadata
+        .insert("tool".to_string(), serde_json::json!(tool_name));
+    record.metadata.insert("args".to_string(), args.clone());
+    record.metadata.insert(
+        "from_tier".to_string(),
+        serde_json::json!(context.autonomy_tier.as_str()),
+    );
+    record.metadata.insert(
+        "to_tier".to_string(),
+        serde_json::json!(AutonomyTier::ActWithApproval.as_str()),
+    );
+    if let Err(error) = crate::trust_graph::append_active_trust_record(&record).await {
+        crate::events::log_warn(
+            "permissions.trust_graph",
+            &format!("failed to append permission escalation trust record: {error}"),
+        );
+    }
+}
+
+pub(crate) fn permission_transcript_event(
+    kind: &str,
+    tool_name: &str,
+    args: &serde_json::Value,
+    reason: &str,
+    escalated: bool,
+) -> VmValue {
+    crate::llm::helpers::transcript_event(
+        kind,
+        "tool",
+        "internal",
+        reason,
+        Some(serde_json::json!({
+            "tool_name": tool_name,
+            "arguments": args,
+            "reason": reason,
+            "escalated": escalated,
+        })),
+    )
+}
+
+fn session_grant_key(scope_index: usize, tool_name: &str, args: &serde_json::Value) -> String {
+    format!("{scope_index}:{tool_name}:{}", stable_hash(args))
+}

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1412,6 +1412,13 @@ pub async fn execute_stage_node(
             let effective_policy = tool_policy
                 .intersect(&node.capability_policy)
                 .map_err(VmError::Runtime)?;
+            let permissions = crate::llm::permissions::parse_dynamic_permission_policy(
+                node.raw_model_policy
+                    .as_ref()
+                    .and_then(|value| value.as_dict())
+                    .and_then(|dict| dict.get("permissions")),
+                "workflow model_policy",
+            )?;
             crate::llm::run_agent_loop_internal(
                 &mut opts,
                 crate::llm::AgentLoopConfig {
@@ -1427,6 +1434,7 @@ pub async fn execute_stage_node(
                     native_tool_fallback: node.model_policy.native_tool_fallback,
                     auto_compact,
                     policy: Some(effective_policy),
+                    permissions,
                     approval_policy: Some(node.approval_policy.clone()),
                     daemon: false,
                     daemon_config: Default::default(),

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -266,6 +266,7 @@ fn wrap_sub_agent_error(
     budget_exceeded: bool,
     session_id: &str,
     error: VmValue,
+    transcript: Option<VmValue>,
 ) -> VmValue {
     let mut envelope = sub_agent_base_envelope(
         summary,
@@ -277,6 +278,9 @@ fn wrap_sub_agent_error(
     );
     envelope.insert("ok".to_string(), VmValue::Bool(false));
     envelope.insert("error".to_string(), error);
+    if let Some(transcript) = transcript {
+        envelope.insert("transcript".to_string(), transcript);
+    }
     VmValue::Dict(Rc::new(envelope))
 }
 
@@ -625,6 +629,10 @@ fn sub_agent_loop_options(spec: &SubAgentRunSpec) -> Result<crate::llm::AgentLoo
             )
             .unwrap_or_default()
         });
+    let permissions = crate::llm::permissions::parse_dynamic_permission_policy(
+        options.as_ref().and_then(|o| o.get("permissions")),
+        "sub_agent_run",
+    )?;
     let turn_policy = options
         .as_ref()
         .and_then(|o| o.get("turn_policy"))
@@ -658,6 +666,7 @@ fn sub_agent_loop_options(spec: &SubAgentRunSpec) -> Result<crate::llm::AgentLoo
         native_tool_fallback,
         auto_compact: None,
         policy,
+        permissions,
         approval_policy,
         daemon: false,
         daemon_config: Default::default(),
@@ -753,6 +762,7 @@ pub(super) async fn execute_sub_agent(
                 false,
                 &spec.session_id,
                 error_value.clone(),
+                Some(transcript.clone()),
             );
             append_parent_sub_agent_event(
                 spec.parent_session_id.as_deref(),
@@ -801,6 +811,7 @@ pub(super) async fn execute_sub_agent(
         budget_exceeded,
         &spec.session_id,
     );
+    envelope.insert("transcript".to_string(), transcript.clone());
 
     if spec.returns_schema.is_none() && option_requests_structured_output(&spec.options) {
         if let Some(candidate) = synthesized.structured_json.as_ref() {
@@ -846,6 +857,7 @@ pub(super) async fn execute_sub_agent(
                             message,
                             None,
                         ),
+                        Some(transcript.clone()),
                     )),
                     transcript,
                 });
@@ -878,6 +890,7 @@ pub(super) async fn execute_sub_agent(
                 budget_exceeded,
                 &spec.session_id,
                 sub_agent_error_dict("permission_denied", reason, Some(tool)),
+                Some(transcript.clone()),
             )),
             transcript,
         });

--- a/crates/harn-vm/src/stdlib/agents_workers/config.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/config.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -432,10 +433,17 @@ pub(in super::super) fn parse_worker_config(value: &VmValue) -> Result<WorkerIni
     let node_value = dict.get("node").ok_or_else(|| {
         VmError::Runtime("spawn_agent: config requires either graph or node".to_string())
     })?;
-    let node = crate::orchestration::parse_workflow_node_json(
-        crate::llm::vm_value_to_json(node_value),
-        "spawn_agent node",
-    )?;
+    let mut node = crate::orchestration::parse_workflow_node_value(node_value, "spawn_agent node")?;
+    if let Some(permissions) = dict.get("permissions").cloned() {
+        let mut raw_model_policy = node
+            .raw_model_policy
+            .as_ref()
+            .and_then(|value| value.as_dict())
+            .cloned()
+            .unwrap_or_default();
+        raw_model_policy.insert("permissions".to_string(), permissions);
+        node.raw_model_policy = Some(VmValue::Dict(Rc::new(raw_model_policy)));
+    }
     let artifacts = parse_artifact_list(dict.get("artifacts"))?;
     let transcript = dict.get("transcript").cloned();
     Ok(WorkerInit {

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -830,6 +830,24 @@ its own `tool_retries`, `max_iterations`, `max_nudges`, and
 native-tool stages that receive text-mode `<tool_call>` fallback
 output).
 
+Pass `permissions` to scope one agent below the ambient `policy` ceiling:
+
+```harn
+agent_loop(task, system, {
+  permissions: {
+    allow: {read_note: { args -> args.path.starts_with("/workspace/") }},
+    deny: ["write_note"],
+    on_escalation: { request -> {grant: "once", approver: "operator"} },
+  },
+})
+```
+
+`allow` and `deny` accept tool-name globs, argument pattern lists, or VM
+predicates. Deny rules win. Escalation callbacks receive a `PermissionRequest`
+dict and return `false`, `true`, `{grant: "once"}`, or `{grant: "session"}`.
+Child agents still intersect with the parent capability policy; escalation
+cannot widen a parent ceiling.
+
 ### Sessions (persistent conversations)
 
 Pass `session_id` to `agent_loop` to resume a multi-turn conversation:

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1319,6 +1319,20 @@ mailboxes are shared by every task that receives or resolves the handle.
 mailboxes, shared state handles, `agent_state_*`, or host storage for data
 exchange outside the transcript.
 
+`agent_loop`, `sub_agent_run`, and `spawn_agent` accept a `permissions` option
+that scopes one agent below the ambient capability policy. `permissions.allow`
+and `permissions.deny` are tool-name glob lists or dicts keyed by tool-name
+glob; dict values may be argument pattern lists or pure Harn predicates of the
+tool args. Deny rules win. If a call is denied and `on_escalation` is present,
+the runtime calls it with a `PermissionRequest` dict. The callback may return
+`false`, `true`, `{grant: "once"}`, or `{grant: "session"}`. Session grants are
+memoized for the same tool and argument payload. Child permissions are still
+intersected with parent `policy` ceilings and cannot widen them. Permission
+decisions append `PermissionGrant`, `PermissionDeny`, and
+`PermissionEscalation` transcript events; escalation grants from `shadow` or
+`suggest` trigger contexts append a `trust.promote` OpenTrustGraph record at
+`act_with_approval`.
+
 ```harn
 let budget = shared_cell({scope: "task_group", key: "tokens", initial: 0})
 

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -1022,9 +1022,19 @@ lineage metadata.
 - `tokens_used`
 - `budget_exceeded`
 - `session_id`
+- `transcript`
 - `data` when the child requests JSON mode or `returns.schema` succeeds
 - `error: {category, message, tool?}` when the child fails or a narrowed tool
   policy rejects a call
+
+`agent_loop(...)`, `sub_agent_run(...)`, and `spawn_agent(...)` also accept a
+`permissions` dict for per-agent dynamic policy. `allow` and `deny` entries can
+be tool-name glob lists, argument pattern lists, or Harn predicates over the tool
+args. `on_escalation` receives a `PermissionRequest` and may return
+`{grant: "once"}`, `{grant: "session"}`, `true`, or `false`. Permission
+decisions are recorded as `PermissionGrant`, `PermissionDeny`, and
+`PermissionEscalation` transcript events, while parent `policy` ceilings still
+intersect with child declarations.
 
 Set `background: true` to get a normal worker handle back instead of waiting
 inline. The resulting worker uses `mode: "sub_agent"` and can be resumed with

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1317,6 +1317,20 @@ mailboxes are shared by every task that receives or resolves the handle.
 mailboxes, shared state handles, `agent_state_*`, or host storage for data
 exchange outside the transcript.
 
+`agent_loop`, `sub_agent_run`, and `spawn_agent` accept a `permissions` option
+that scopes one agent below the ambient capability policy. `permissions.allow`
+and `permissions.deny` are tool-name glob lists or dicts keyed by tool-name
+glob; dict values may be argument pattern lists or pure Harn predicates of the
+tool args. Deny rules win. If a call is denied and `on_escalation` is present,
+the runtime calls it with a `PermissionRequest` dict. The callback may return
+`false`, `true`, `{grant: "once"}`, or `{grant: "session"}`. Session grants are
+memoized for the same tool and argument payload. Child permissions are still
+intersected with parent `policy` ceilings and cannot widen them. Permission
+decisions append `PermissionGrant`, `PermissionDeny`, and
+`PermissionEscalation` transcript events; escalation grants from `shadow` or
+`suggest` trigger contexts append a `trust.promote` OpenTrustGraph record at
+`act_with_approval`.
+
 ```harn
 let budget = shared_cell({scope: "task_group", key: "tokens", initial: 0})
 


### PR DESCRIPTION
## Summary

Closes #529.

Adds per-agent dynamic permissions for `agent_loop`, `sub_agent_run`, workflow stages, and `spawn_agent`:

- parses `permissions.allow` / `permissions.deny` rules with tool-name globs, argument pattern lists, keyed argument patterns, and VM predicates over tool args
- evaluates active permission scopes as an intersection so nested child agents cannot widen parent permissions
- supports `on_escalation` callbacks returning `true`, `{grant: "once"}`, `{grant: "session"}`, or `false`
- records `PermissionGrant`, `PermissionDeny`, and `PermissionEscalation` transcript events
- records `trust.promote` at `act_with_approval` when a granted permission escalation crosses from `shadow` / `suggest`
- exposes child transcripts in `sub_agent_run` result envelopes so callers can inspect permission events on both success and error

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-issue-529 cargo check -p harn-vm`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-529 cargo run --quiet --bin harn -- test conformance --filter permissions`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-529 cargo run --quiet --bin harn -- fmt --check conformance/tests/agents/per_agent_permissions_dynamic.harn conformance/tests/agents/per_agent_permissions_escalation.harn conformance/tests/agents/sub_agent_permissions_intersection.harn conformance/tests/agents/spawn_agent_permissions.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-529 make check-docs-snippets`
- `git diff --check`
- pre-commit hook: formatting, staged Harn lint, workspace clippy, markdown lint
- pre-push hook: 2046 nextest tests, affected Harn format/lint, markdown lint