### PR TITLE
[codex] Add package authoring workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ granular archaeology.
   per-tenant budgets, and topic/namespace helpers. Dispatcher routing
   now scopes all dispatch traffic to tenant topics so one tenant's
   load cannot leak into another's queues.
+- **Package authoring workflow (#471).** Extends `harn.toml`
+  `[package]` with `description`, `license`, `repository`, `harn`
+  (version range), and `docs_url`, adds `harn package new <name>`,
+  `harn package validate`, and `harn package publish --dry-run`, and
+  documents the authoring flow in `docs/src/package-authoring.md`.
 
 ### Changed
 

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -63,8 +63,8 @@ SCRIPTING
     Test(TestArgs),
     /// Scaffold a new project with harn.toml.
     Init(InitArgs),
-    /// Scaffold a new project from a starter template.
-    New(InitArgs),
+    /// Scaffold a new project, package, or connector from a starter template.
+    New(NewArgs),
     /// Diagnose the local Harn environment and provider setup.
     Doctor(DoctorArgs),
     /// Register outbound connector resources with a provider.
@@ -119,6 +119,8 @@ SCRIPTING
     Lock,
     /// Manage Harn package caches and integrity verification.
     Package(PackageArgs),
+    /// Prepare a package for publication. Real registry submission is not yet enabled.
+    Publish(PublishArgs),
     /// List and inspect durable agent persona manifests.
     Persona(PersonaArgs),
     /// Print resolved metadata for a model alias or model id as JSON.
@@ -374,6 +376,19 @@ pub(crate) enum ProjectTemplate {
     Eval,
     #[value(name = "pipeline-lab")]
     PipelineLab,
+    Package,
+    Connector,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct NewArgs {
+    /// Project name, or `package` / `connector` when using `harn new package NAME`.
+    pub first: Option<String>,
+    /// Package or connector name when the first positional argument is a kind.
+    pub second: Option<String>,
+    /// Starter template to scaffold.
+    #[arg(long, value_enum)]
+    pub template: Option<ProjectTemplate>,
 }
 
 #[derive(Debug, Args)]
@@ -1687,8 +1702,50 @@ pub(crate) enum PackageCommand {
     Search(PackageSearchArgs),
     /// Show package registry metadata for one package.
     Info(PackageInfoArgs),
+    /// Validate a package manifest and publish readiness.
+    Check(PackageCheckArgs),
+    /// Build an inspectable package artifact directory.
+    Pack(PackagePackArgs),
+    /// Generate package API docs from exported Harn symbols.
+    Docs(PackageDocsArgs),
     /// Inspect, clean, and verify the shared package cache.
     Cache(PackageCacheArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PackageCheckArgs {
+    /// Package directory, harn.toml, or file under the package. Defaults to cwd.
+    pub package: Option<PathBuf>,
+    /// Emit JSON instead of a human-readable report.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PackagePackArgs {
+    /// Package directory, harn.toml, or file under the package. Defaults to cwd.
+    pub package: Option<PathBuf>,
+    /// Output artifact directory. Defaults to .harn/dist/<name>-<version>.
+    #[arg(long, value_name = "DIR")]
+    pub output: Option<PathBuf>,
+    /// Validate and print the file list without writing the artifact.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Emit JSON instead of a human-readable report.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PackageDocsArgs {
+    /// Package directory, harn.toml, or file under the package. Defaults to cwd.
+    pub package: Option<PathBuf>,
+    /// Output Markdown file. Defaults to docs/api.md.
+    #[arg(long, value_name = "PATH")]
+    pub output: Option<PathBuf>,
+    /// Verify the output file already matches generated docs.
+    #[arg(long)]
+    pub check: bool,
 }
 
 #[derive(Debug, Args)]
@@ -1711,6 +1768,21 @@ pub(crate) struct PackageInfoArgs {
     #[arg(long, value_name = "URL|PATH")]
     pub registry: Option<String>,
     /// Emit JSON instead of human-readable metadata.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PublishArgs {
+    /// Package directory, harn.toml, or file under the package. Defaults to cwd.
+    pub package: Option<PathBuf>,
+    /// Required until registry submission support lands.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Package registry index URL or path to report as the submission target.
+    #[arg(long, value_name = "URL|PATH")]
+    pub registry: Option<String>,
+    /// Emit JSON instead of a human-readable report.
     #[arg(long)]
     pub json: bool,
 }
@@ -2975,8 +3047,21 @@ mod tests {
         let Command::New(args) = cli.command.unwrap() else {
             panic!("expected new command");
         };
-        assert_eq!(args.name.as_deref(), Some("review-bot"));
-        assert_eq!(args.template, ProjectTemplate::Agent);
+        assert_eq!(args.first.as_deref(), Some("review-bot"));
+        assert_eq!(args.second.as_deref(), None);
+        assert_eq!(args.template, Some(ProjectTemplate::Agent));
+    }
+
+    #[test]
+    fn test_parses_new_package_kind() {
+        let cli = Cli::parse_from(["harn", "new", "package", "acme-lib"]);
+
+        let Command::New(args) = cli.command.unwrap() else {
+            panic!("expected new command");
+        };
+        assert_eq!(args.first.as_deref(), Some("package"));
+        assert_eq!(args.second.as_deref(), Some("acme-lib"));
+        assert_eq!(args.template, None);
     }
 
     #[test]
@@ -2992,7 +3077,7 @@ mod tests {
         let Command::New(args) = cli.command.unwrap() else {
             panic!("expected new command");
         };
-        assert_eq!(args.template, ProjectTemplate::PipelineLab);
+        assert_eq!(args.template, Some(ProjectTemplate::PipelineLab));
     }
 
     #[test]
@@ -3125,6 +3210,36 @@ mod tests {
         };
         assert_eq!(info.name, "@burin/notion-sdk@1.2.3");
         assert_eq!(info.registry.as_deref(), Some("index.toml"));
+
+        let cli = Cli::parse_from(["harn", "package", "check", "pkg", "--json"]);
+        let Command::Package(args) = cli.command.unwrap() else {
+            panic!("expected package command");
+        };
+        let PackageCommand::Check(check) = args.command else {
+            panic!("expected package check");
+        };
+        assert_eq!(check.package, Some(PathBuf::from("pkg")));
+        assert!(check.json);
+
+        let cli = Cli::parse_from(["harn", "package", "pack", "pkg", "--dry-run"]);
+        let Command::Package(args) = cli.command.unwrap() else {
+            panic!("expected package command");
+        };
+        let PackageCommand::Pack(pack) = args.command else {
+            panic!("expected package pack");
+        };
+        assert_eq!(pack.package, Some(PathBuf::from("pkg")));
+        assert!(pack.dry_run);
+
+        let cli = Cli::parse_from(["harn", "package", "docs", "pkg", "--check"]);
+        let Command::Package(args) = cli.command.unwrap() else {
+            panic!("expected package command");
+        };
+        let PackageCommand::Docs(docs) = args.command else {
+            panic!("expected package docs");
+        };
+        assert_eq!(docs.package, Some(PathBuf::from("pkg")));
+        assert!(docs.check);
 
         let cli = Cli::parse_from(["harn", "package", "cache", "list"]);
         let Command::Package(args) = cli.command.unwrap() else {

--- a/crates/harn-cli/src/commands/init.rs
+++ b/crates/harn-cli/src/commands/init.rs
@@ -2,7 +2,27 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process;
 
-use crate::cli::ProjectTemplate;
+use crate::cli::{NewArgs, ProjectTemplate};
+
+pub(crate) fn resolve_new_args(
+    args: &NewArgs,
+) -> Result<(Option<String>, ProjectTemplate), String> {
+    let template = args.template.unwrap_or(ProjectTemplate::Basic);
+    match (args.first.as_deref(), args.second.as_deref()) {
+        (Some("package"), Some(name)) => Ok((Some(name.to_string()), ProjectTemplate::Package)),
+        (Some("connector"), Some(name)) => Ok((Some(name.to_string()), ProjectTemplate::Connector)),
+        (Some(kind @ ("package" | "connector")), None) => Err(format!(
+            "`harn new {kind}` requires a package name, for example `harn new {kind} my-{kind}`"
+        )),
+        (Some(name), None) => Ok((Some(name.to_string()), template)),
+        (None, None) => Ok((None, template)),
+        (Some(_), Some(_)) => Err(
+            "unexpected second positional argument; use `harn new package NAME` or `harn new NAME --template package`"
+                .to_string(),
+        ),
+        (None, Some(_)) => unreachable!("clap cannot fill second positional without first"),
+    }
+}
 
 pub(crate) fn init_project(name: Option<&str>, template: ProjectTemplate) {
     let dir = match name {
@@ -25,7 +45,9 @@ pub(crate) fn init_project(name: Option<&str>, template: ProjectTemplate) {
         }
     };
 
-    let project_name = name.unwrap_or("my-project");
+    let project_name = name
+        .and_then(|value| Path::new(value).file_name().and_then(|name| name.to_str()))
+        .unwrap_or("my-project");
     for (relative_path, content) in template_files(project_name, template) {
         write_if_new(&dir.join(relative_path), &content);
     }
@@ -35,7 +57,11 @@ pub(crate) fn init_project(name: Option<&str>, template: ProjectTemplate) {
         println!("  cd {}", n);
     }
     match template {
-        ProjectTemplate::Basic | ProjectTemplate::Agent | ProjectTemplate::Eval => {
+        ProjectTemplate::Basic
+        | ProjectTemplate::Agent
+        | ProjectTemplate::Eval
+        | ProjectTemplate::Package
+        | ProjectTemplate::Connector => {
             println!("  harn run main.harn       # run the program");
             println!("  harn test tests/         # run the tests");
         }
@@ -49,6 +75,14 @@ pub(crate) fn init_project(name: Option<&str>, template: ProjectTemplate) {
     }
     println!("  harn fmt main.harn       # format code");
     println!("  harn lint main.harn      # lint code");
+    if matches!(
+        template,
+        ProjectTemplate::Package | ProjectTemplate::Connector
+    ) {
+        println!("  harn package check       # validate publish readiness");
+        println!("  harn package docs        # generate API docs");
+        println!("  harn package pack        # build an inspectable artifact");
+    }
     println!("  harn doctor              # verify the local environment");
 }
 
@@ -312,13 +346,325 @@ Edit `host.harn` or `pipeline.harn` and the playground will re-run automatically
                 .to_string(),
             ),
         ],
+        ProjectTemplate::Package => vec![
+            (
+                "harn.toml",
+                format!(
+                    r#"[package]
+name = "{project_name}"
+version = "0.1.0"
+description = "Reusable Harn package."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/OWNER/{project_name}"
+harn = ">=0.7,<0.8"
+docs_url = "docs/api.md"
+
+[exports]
+lib = "lib/main.harn"
+
+[dependencies]
+"#
+                ),
+            ),
+            (
+                "lib/main.harn",
+                r#"/// Return a greeting for `name`.
+pub fn greet(name: string) -> string {
+  return "Hello, " + name + "!"
+}
+"#
+                .to_string(),
+            ),
+            (
+                "main.harn",
+                r#"import "lib/main"
+
+pipeline default(task) {
+  println(greet("world"))
+}
+"#
+                .to_string(),
+            ),
+            (
+                "tests/test_main.harn",
+                r#"import "../lib/main"
+
+pipeline test_greet(task) {
+  assert_eq(greet("Harn"), "Hello, Harn!")
+}
+"#
+                .to_string(),
+            ),
+            (
+                ".github/workflows/harn-package.yml",
+                r#"name: Harn package
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-binstall
+      - run: cargo binstall harn-cli --no-confirm
+      - run: harn install --locked --offline || harn install
+      - run: harn test tests/
+      - run: harn package check
+      - run: harn package docs --check
+      - run: harn package pack --dry-run
+"#
+                .to_string(),
+            ),
+            (
+                "README.md",
+                format!(
+                    r#"# {project_name}
+
+Reusable Harn package.
+
+## Quickstart
+
+```bash
+harn add ../{project_name}
+harn test tests/
+harn package check
+harn package docs
+harn package pack
+```
+
+Consumers import stable modules through the `[exports]` entries in `harn.toml`.
+"#
+                ),
+            ),
+            (
+                "LICENSE",
+                "MIT OR Apache-2.0\n".to_string(),
+            ),
+            (
+                "docs/api.md",
+                format!(
+                    r#"# API Reference: {project_name}
+
+Generated by `harn package docs`.
+
+Version: `0.1.0`
+
+## Export `lib`
+
+`lib/main.harn`
+
+### fn `greet`
+
+Return a greeting for `name`.
+
+```harn
+pub fn greet(name: string) -> string
+```
+"#
+                ),
+            ),
+        ],
+        ProjectTemplate::Connector => vec![
+            (
+                "harn.toml",
+                format!(
+                    r#"[package]
+name = "{project_name}"
+version = "0.1.0"
+description = "Pure-Harn connector package."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/OWNER/{project_name}"
+harn = ">=0.7,<0.8"
+docs_url = "docs/api.md"
+
+[exports]
+connector = "connectors/echo.harn"
+
+[[providers]]
+id = "echo"
+connector = {{ harn = "connectors/echo" }}
+
+[connector_contract]
+version = 1
+
+[[connector_contract.fixtures]]
+provider = "echo"
+name = "message"
+kind = "webhook"
+body_json = {{ message = "hello" }}
+expect_type = "event"
+expect_kind = "webhook"
+expect_event_count = 1
+
+[dependencies]
+"#
+                ),
+            ),
+            (
+                "connectors/echo.harn",
+                r#"/// Connector provider id.
+pub fn provider_id() {
+  return "echo"
+}
+
+/// Trigger kinds emitted by this connector.
+pub fn kinds() {
+  return ["webhook"]
+}
+
+/// JSON payload schema for normalized inbound events.
+pub fn payload_schema() {
+  return {
+    harn_schema_name: "EchoEventPayload",
+    json_schema: {
+      type: "object",
+      additionalProperties: true,
+    },
+  }
+}
+
+/// Convert one inbound request into Harn trigger events.
+pub fn normalize_inbound(raw) {
+  let body = raw.body_json ?? json_parse(raw.body_text)
+  return {
+    type: "event",
+    event: {
+      kind: "webhook",
+      dedupe_key: "echo:" + (body.message ?? "message"),
+      payload: body,
+    },
+  }
+}
+"#
+                .to_string(),
+            ),
+            (
+                "main.harn",
+                r#"import "connectors/echo"
+
+pipeline default(task) {
+  println(provider_id())
+}
+"#
+                .to_string(),
+            ),
+            (
+                "tests/test_connector.harn",
+                r#"import "../connectors/echo"
+
+pipeline test_provider_id(task) {
+  assert_eq(provider_id(), "echo")
+  assert_eq(kinds(), ["webhook"])
+}
+"#
+                .to_string(),
+            ),
+            (
+                ".github/workflows/harn-package.yml",
+                r#"name: Harn connector package
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-binstall
+      - run: cargo binstall harn-cli --no-confirm
+      - run: harn install --locked --offline || harn install
+      - run: harn test tests/
+      - run: harn connector check .
+      - run: harn package check
+      - run: harn package docs --check
+      - run: harn package pack --dry-run
+"#
+                .to_string(),
+            ),
+            (
+                "README.md",
+                format!(
+                    r#"# {project_name}
+
+Pure-Harn connector package.
+
+## Quickstart
+
+```bash
+harn connector check .
+harn test tests/
+harn package check
+harn package docs
+harn package pack
+```
+
+Consumers import the connector through the stable `[exports]` entry in `harn.toml`.
+"#
+                ),
+            ),
+            ("LICENSE", "MIT OR Apache-2.0\n".to_string()),
+            (
+                "docs/api.md",
+                format!(
+                    r#"# API Reference: {project_name}
+
+Generated by `harn package docs`.
+
+Version: `0.1.0`
+
+## Export `connector`
+
+`connectors/echo.harn`
+
+### fn `provider_id`
+
+Connector provider id.
+
+```harn
+pub fn provider_id()
+```
+
+### fn `kinds`
+
+Trigger kinds emitted by this connector.
+
+```harn
+pub fn kinds()
+```
+
+### fn `payload_schema`
+
+JSON payload schema for normalized inbound events.
+
+```harn
+pub fn payload_schema()
+```
+
+### fn `normalize_inbound`
+
+Convert one inbound request into Harn trigger events.
+
+```harn
+pub fn normalize_inbound(raw)
+```
+"#
+                ),
+            ),
+        ],
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::template_files;
-    use crate::cli::ProjectTemplate;
+    use super::{resolve_new_args, template_files};
+    use crate::cli::{NewArgs, ProjectTemplate};
 
     #[test]
     fn basic_template_keeps_library_layout() {
@@ -347,5 +693,28 @@ mod tests {
         assert!(pipeline_lab
             .iter()
             .any(|(path, _)| *path == "pipeline.harn"));
+
+        let package = template_files("sample", ProjectTemplate::Package);
+        assert!(package.iter().any(|(path, _)| *path == "lib/main.harn"));
+        assert!(package
+            .iter()
+            .any(|(path, _)| *path == ".github/workflows/harn-package.yml"));
+
+        let connector = template_files("sample", ProjectTemplate::Connector);
+        assert!(connector
+            .iter()
+            .any(|(path, _)| *path == "connectors/echo.harn"));
+    }
+
+    #[test]
+    fn new_package_kind_resolves_to_package_template() {
+        let args = NewArgs {
+            first: Some("package".to_string()),
+            second: Some("sample".to_string()),
+            template: None,
+        };
+        let (name, template) = resolve_new_args(&args).unwrap();
+        assert_eq!(name.as_deref(), Some("sample"));
+        assert_eq!(template, ProjectTemplate::Package);
     }
 }

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -411,9 +411,14 @@ async fn main() {
                 }
             }
         }
-        Command::Init(args) | Command::New(args) => {
-            commands::init::init_project(args.name.as_deref(), args.template)
-        }
+        Command::Init(args) => commands::init::init_project(args.name.as_deref(), args.template),
+        Command::New(args) => match commands::init::resolve_new_args(&args) {
+            Ok((name, template)) => commands::init::init_project(name.as_deref(), template),
+            Err(error) => {
+                eprintln!("error: {error}");
+                process::exit(1);
+            }
+        },
         Command::Doctor(args) => commands::doctor::run_doctor(!args.no_network).await,
         Command::Serve(args) => match args.command {
             ServeCommand::Acp(args) => {
@@ -547,6 +552,20 @@ async fn main() {
             PackageCommand::Info(info) => {
                 package::show_package_registry_info(&info.name, info.registry.as_deref(), info.json)
             }
+            PackageCommand::Check(check) => {
+                package::check_package(check.package.as_deref(), check.json)
+            }
+            PackageCommand::Pack(pack) => package::pack_package(
+                pack.package.as_deref(),
+                pack.output.as_deref(),
+                pack.dry_run,
+                pack.json,
+            ),
+            PackageCommand::Docs(docs) => package::generate_package_docs(
+                docs.package.as_deref(),
+                docs.output.as_deref(),
+                docs.check,
+            ),
             PackageCommand::Cache(cache) => match cache.command {
                 PackageCacheCommand::List => package::list_package_cache(),
                 PackageCacheCommand::Clean(clean) => package::clean_package_cache(clean.all),
@@ -555,6 +574,12 @@ async fn main() {
                 }
             },
         },
+        Command::Publish(args) => package::publish_package(
+            args.package.as_deref(),
+            args.dry_run,
+            args.registry.as_deref(),
+            args.json,
+        ),
         Command::Persona(args) => match args.command {
             PersonaCommand::List(list) => {
                 commands::persona::run_list(args.manifest.as_deref(), &list)

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -9,6 +9,7 @@ use std::{fs, process};
 
 use chrono_tz::Tz;
 use fs2::FileExt;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::str::FromStr;
@@ -792,6 +793,16 @@ pub struct PackageInfo {
     pub version: Option<String>,
     #[serde(default)]
     pub evals: Vec<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub license: Option<String>,
+    #[serde(default)]
+    pub repository: Option<String>,
+    #[serde(default, alias = "harn_version", alias = "harn_version_range")]
+    pub harn: Option<String>,
+    #[serde(default)]
+    pub docs_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -6010,6 +6021,832 @@ pub fn add_package_with_registry(
     }
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageCheckReport {
+    pub package_dir: String,
+    pub manifest_path: String,
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub errors: Vec<PackageCheckDiagnostic>,
+    pub warnings: Vec<PackageCheckDiagnostic>,
+    pub exports: Vec<PackageExportReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageCheckDiagnostic {
+    pub field: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageExportReport {
+    pub name: String,
+    pub path: String,
+    pub symbols: Vec<PackageApiSymbol>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageApiSymbol {
+    pub kind: String,
+    pub name: String,
+    pub signature: String,
+    pub docs: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackagePackReport {
+    pub package_dir: String,
+    pub artifact_dir: String,
+    pub dry_run: bool,
+    pub files: Vec<String>,
+    pub check: PackageCheckReport,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PackagePublishReport {
+    pub dry_run: bool,
+    pub registry: String,
+    pub artifact_dir: String,
+    pub files: Vec<String>,
+    pub check: PackageCheckReport,
+}
+
+pub fn check_package(anchor: Option<&Path>, json: bool) {
+    match check_package_impl(anchor) {
+        Ok(report) => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report)
+                        .unwrap_or_else(|error| format!(r#"{{"error":"{error}"}}"#))
+                );
+            } else {
+                print_package_check_report(&report);
+            }
+            if !report.errors.is_empty() {
+                process::exit(1);
+            }
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            process::exit(1);
+        }
+    }
+}
+
+pub fn pack_package(anchor: Option<&Path>, output: Option<&Path>, dry_run: bool, json: bool) {
+    match pack_package_impl(anchor, output, dry_run) {
+        Ok(report) => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report)
+                        .unwrap_or_else(|error| format!(r#"{{"error":"{error}"}}"#))
+                );
+            } else {
+                print_package_pack_report(&report);
+            }
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            process::exit(1);
+        }
+    }
+}
+
+pub fn generate_package_docs(anchor: Option<&Path>, output: Option<&Path>, check: bool) {
+    match generate_package_docs_impl(anchor, output, check) {
+        Ok(path) if check => println!("{} is up to date.", path.display()),
+        Ok(path) => println!("Wrote {}.", path.display()),
+        Err(error) => {
+            eprintln!("error: {error}");
+            process::exit(1);
+        }
+    }
+}
+
+pub fn publish_package(anchor: Option<&Path>, dry_run: bool, registry: Option<&str>, json: bool) {
+    if !dry_run {
+        eprintln!(
+            "error: registry submission is not enabled yet; use `harn publish --dry-run` to validate the package and inspect the artifact"
+        );
+        process::exit(1);
+    }
+
+    match publish_package_impl(anchor, registry) {
+        Ok(report) => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report)
+                        .unwrap_or_else(|error| format!(r#"{{"error":"{error}"}}"#))
+                );
+            } else {
+                println!("Dry-run publish to {} succeeded.", report.registry);
+                println!("artifact: {}", report.artifact_dir);
+                println!("files: {}", report.files.len());
+            }
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            process::exit(1);
+        }
+    }
+}
+
+fn check_package_impl(anchor: Option<&Path>) -> Result<PackageCheckReport, String> {
+    let ctx = load_manifest_context_for_anchor(anchor)?;
+    let manifest_path = ctx.manifest_path();
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+
+    let package = ctx.manifest.package.as_ref();
+    let name = package.and_then(|package| package.name.clone());
+    let version = package.and_then(|package| package.version.clone());
+    let package_name = required_package_string(
+        package.and_then(|package| package.name.as_deref()),
+        "[package].name",
+        &mut errors,
+    );
+    if let Some(name) = package_name {
+        if let Err(message) = validate_package_alias(name) {
+            push_error(&mut errors, "[package].name", message);
+        }
+    }
+    required_package_string(
+        package.and_then(|package| package.version.as_deref()),
+        "[package].version",
+        &mut errors,
+    );
+    required_package_string(
+        package.and_then(|package| package.description.as_deref()),
+        "[package].description",
+        &mut errors,
+    );
+    required_package_string(
+        package.and_then(|package| package.license.as_deref()),
+        "[package].license",
+        &mut errors,
+    );
+    if !ctx.dir.join("README.md").is_file() {
+        push_error(&mut errors, "README.md", "package README.md is required");
+    }
+    if !ctx.dir.join("LICENSE").is_file() && package.and_then(|p| p.license.as_deref()).is_none() {
+        push_error(
+            &mut errors,
+            "[package].license",
+            "publishable packages require a license field or LICENSE file",
+        );
+    }
+
+    validate_optional_url(
+        package.and_then(|package| package.repository.as_deref()),
+        "[package].repository",
+        &mut errors,
+    );
+    validate_docs_url(
+        &ctx.dir,
+        package.and_then(|package| package.docs_url.as_deref()),
+        &mut errors,
+        &mut warnings,
+    );
+    match package.and_then(|package| package.harn.as_deref()) {
+        Some(range) if supports_current_harn(range) => {}
+        Some(range) => push_error(
+            &mut errors,
+            "[package].harn",
+            format!(
+                "unsupported Harn version range '{range}'; include the current 0.7 line, for example >=0.7,<0.8"
+            ),
+        ),
+        None => push_error(
+            &mut errors,
+            "[package].harn",
+            "missing Harn compatibility metadata; add harn = \">=0.7,<0.8\"",
+        ),
+    }
+
+    validate_dependencies_for_publish(&ctx, &mut errors, &mut warnings);
+    let exports = validate_exports_for_publish(&ctx, &mut errors, &mut warnings);
+
+    Ok(PackageCheckReport {
+        package_dir: ctx.dir.display().to_string(),
+        manifest_path: manifest_path.display().to_string(),
+        name,
+        version,
+        errors,
+        warnings,
+        exports,
+    })
+}
+
+fn pack_package_impl(
+    anchor: Option<&Path>,
+    output: Option<&Path>,
+    dry_run: bool,
+) -> Result<PackagePackReport, String> {
+    let report = check_package_impl(anchor)?;
+    fail_if_package_errors(&report)?;
+    let ctx = load_manifest_context_for_anchor(anchor)?;
+    let files = collect_package_files(&ctx.dir)?;
+    let artifact_dir = output
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| default_artifact_dir(&ctx, &report));
+
+    if !dry_run {
+        if artifact_dir.exists() {
+            return Err(format!(
+                "artifact output {} already exists",
+                artifact_dir.display()
+            ));
+        }
+        fs::create_dir_all(&artifact_dir)
+            .map_err(|error| format!("failed to create {}: {error}", artifact_dir.display()))?;
+        for rel in &files {
+            let src = ctx.dir.join(rel);
+            let dst = artifact_dir.join(rel);
+            if let Some(parent) = dst.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+            }
+            fs::copy(&src, &dst)
+                .map_err(|error| format!("failed to copy {}: {error}", src.display()))?;
+        }
+        fs::write(
+            artifact_dir.join(".harn-package-manifest.json"),
+            serde_json::to_string_pretty(&report)
+                .map_err(|error| format!("failed to render package manifest: {error}"))?
+                + "\n",
+        )
+        .map_err(|error| {
+            format!(
+                "failed to write {}: {error}",
+                artifact_dir.join(".harn-package-manifest.json").display()
+            )
+        })?;
+    }
+
+    Ok(PackagePackReport {
+        package_dir: ctx.dir.display().to_string(),
+        artifact_dir: artifact_dir.display().to_string(),
+        dry_run,
+        files,
+        check: report,
+    })
+}
+
+fn generate_package_docs_impl(
+    anchor: Option<&Path>,
+    output: Option<&Path>,
+    check: bool,
+) -> Result<PathBuf, String> {
+    let report = check_package_impl(anchor)?;
+    let ctx = load_manifest_context_for_anchor(anchor)?;
+    let output_path = output
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| ctx.dir.join("docs").join("api.md"));
+    let rendered = render_package_api_docs(&report);
+    if check {
+        let existing = fs::read_to_string(&output_path)
+            .map_err(|error| format!("failed to read {}: {error}", output_path.display()))?;
+        if normalize_newlines(&existing) != normalize_newlines(&rendered) {
+            return Err(format!(
+                "{} is stale; run `harn package docs`",
+                output_path.display()
+            ));
+        }
+        return Ok(output_path);
+    }
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+    fs::write(&output_path, rendered)
+        .map_err(|error| format!("failed to write {}: {error}", output_path.display()))?;
+    Ok(output_path)
+}
+
+fn publish_package_impl(
+    anchor: Option<&Path>,
+    registry: Option<&str>,
+) -> Result<PackagePublishReport, String> {
+    let pack = pack_package_impl(anchor, None, true)?;
+    let registry = resolve_configured_registry_source(registry)?;
+    Ok(PackagePublishReport {
+        dry_run: true,
+        registry,
+        artifact_dir: pack.artifact_dir,
+        files: pack.files,
+        check: pack.check,
+    })
+}
+
+fn load_manifest_context_for_anchor(anchor: Option<&Path>) -> Result<ManifestContext, String> {
+    let anchor = anchor
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let manifest_path = if anchor.is_dir() {
+        anchor.join(MANIFEST)
+    } else if anchor.file_name() == Some(OsStr::new(MANIFEST)) {
+        anchor.clone()
+    } else {
+        let (_, dir) = find_nearest_manifest(&anchor)
+            .ok_or_else(|| format!("no {MANIFEST} found from {}", anchor.display()))?;
+        dir.join(MANIFEST)
+    };
+    let manifest = read_manifest_from_path(&manifest_path)?;
+    let dir = manifest_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    Ok(ManifestContext { manifest, dir })
+}
+
+fn required_package_string<'a>(
+    value: Option<&'a str>,
+    field: &str,
+    errors: &mut Vec<PackageCheckDiagnostic>,
+) -> Option<&'a str> {
+    match value.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(value) => Some(value),
+        None => {
+            push_error(errors, field, format!("missing required {field}"));
+            None
+        }
+    }
+}
+
+fn push_error(
+    diagnostics: &mut Vec<PackageCheckDiagnostic>,
+    field: impl Into<String>,
+    message: impl Into<String>,
+) {
+    diagnostics.push(PackageCheckDiagnostic {
+        field: field.into(),
+        message: message.into(),
+    });
+}
+
+fn push_warning(
+    diagnostics: &mut Vec<PackageCheckDiagnostic>,
+    field: impl Into<String>,
+    message: impl Into<String>,
+) {
+    push_error(diagnostics, field, message);
+}
+
+fn validate_optional_url(
+    value: Option<&str>,
+    field: &str,
+    errors: &mut Vec<PackageCheckDiagnostic>,
+) {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        push_error(errors, field, format!("missing required {field}"));
+        return;
+    };
+    if Url::parse(value).is_err() {
+        push_error(errors, field, format!("{field} must be an absolute URL"));
+    }
+}
+
+fn validate_docs_url(
+    root: &Path,
+    value: Option<&str>,
+    errors: &mut Vec<PackageCheckDiagnostic>,
+    warnings: &mut Vec<PackageCheckDiagnostic>,
+) {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        push_warning(
+            warnings,
+            "[package].docs_url",
+            "missing docs_url; `harn package docs` defaults to docs/api.md",
+        );
+        return;
+    };
+    if Url::parse(value).is_ok() {
+        return;
+    }
+    let path = PathBuf::from(value);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        root.join(path)
+    };
+    if !path.exists() {
+        push_error(
+            errors,
+            "[package].docs_url",
+            format!("docs_url path {} does not exist", path.display()),
+        );
+    }
+}
+
+fn validate_dependencies_for_publish(
+    ctx: &ManifestContext,
+    errors: &mut Vec<PackageCheckDiagnostic>,
+    warnings: &mut Vec<PackageCheckDiagnostic>,
+) {
+    let mut aliases = BTreeSet::new();
+    for (alias, dependency) in &ctx.manifest.dependencies {
+        let field = format!("[dependencies].{alias}");
+        if let Err(message) = validate_package_alias(alias) {
+            push_error(errors, &field, message);
+        }
+        if !aliases.insert(alias) {
+            push_error(errors, &field, "duplicate dependency alias");
+        }
+        match dependency {
+            Dependency::Path(path) => push_error(
+                errors,
+                &field,
+                format!("path-only dependency '{path}' is not publishable; pin a git rev or registry version"),
+            ),
+            Dependency::Table(table) => {
+                if table.path.is_some() {
+                    push_error(
+                        errors,
+                        &field,
+                        "path dependencies are not publishable; pin a git rev or registry version",
+                    );
+                }
+                if table.git.is_none() && table.path.is_none() {
+                    push_error(errors, &field, "dependency must specify git, registry-expanded git, or path");
+                }
+                if table.rev.is_some() && table.branch.is_some() {
+                    push_error(errors, &field, "dependency cannot specify both rev and branch");
+                }
+                if table.git.is_some() && table.rev.is_none() && table.branch.is_none() {
+                    push_error(errors, &field, "git dependency must specify rev or branch");
+                }
+                if table.branch.is_some() {
+                    push_warning(
+                        warnings,
+                        &field,
+                        "branch dependencies are allowed but rev pins are more reproducible for publishing",
+                    );
+                }
+                if let Some(git) = table.git.as_deref() {
+                    if normalize_git_url(git).is_err() {
+                        push_error(errors, &field, format!("invalid git source '{git}'"));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn validate_exports_for_publish(
+    ctx: &ManifestContext,
+    errors: &mut Vec<PackageCheckDiagnostic>,
+    warnings: &mut Vec<PackageCheckDiagnostic>,
+) -> Vec<PackageExportReport> {
+    if ctx.manifest.exports.is_empty() {
+        push_error(
+            errors,
+            "[exports]",
+            "publishable packages require at least one stable export",
+        );
+        return Vec::new();
+    }
+
+    let mut exports = Vec::new();
+    for (name, rel_path) in &ctx.manifest.exports {
+        let field = format!("[exports].{name}");
+        if let Err(message) = validate_package_alias(name) {
+            push_error(errors, &field, message);
+        }
+        let Ok(path) = safe_package_relative_path(&ctx.dir, rel_path) else {
+            push_error(
+                errors,
+                &field,
+                "export path must stay inside the package directory",
+            );
+            continue;
+        };
+        if path.extension() != Some(OsStr::new("harn")) {
+            push_error(errors, &field, "export path must point at a .harn file");
+            continue;
+        }
+        let content = match fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(error) => {
+                push_error(
+                    errors,
+                    &field,
+                    format!("failed to read export {}: {error}", path.display()),
+                );
+                continue;
+            }
+        };
+        if let Err(error) = parse_harn_source(&content) {
+            push_error(errors, &field, format!("failed to parse export: {error}"));
+        }
+        let symbols = extract_api_symbols(&content);
+        if symbols.is_empty() {
+            push_warning(
+                warnings,
+                &field,
+                "exported module has no public symbols to document",
+            );
+        }
+        for symbol in &symbols {
+            if symbol.docs.is_none() {
+                push_warning(
+                    warnings,
+                    &field,
+                    format!(
+                        "public {} '{}' has no doc comment",
+                        symbol.kind, symbol.name
+                    ),
+                );
+            }
+        }
+        exports.push(PackageExportReport {
+            name: name.clone(),
+            path: rel_path.clone(),
+            symbols,
+        });
+    }
+    exports.sort_by(|left, right| left.name.cmp(&right.name));
+    exports
+}
+
+fn parse_harn_source(source: &str) -> Result<(), String> {
+    let mut lexer = harn_lexer::Lexer::new(source);
+    let tokens = lexer.tokenize().map_err(|error| error.to_string())?;
+    let mut parser = harn_parser::Parser::new(tokens);
+    parser
+        .parse()
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+fn safe_package_relative_path(root: &Path, rel_path: &str) -> Result<PathBuf, String> {
+    let rel = PathBuf::from(rel_path);
+    if rel.is_absolute()
+        || rel
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(format!("path {rel_path:?} escapes package root"));
+    }
+    Ok(root.join(rel))
+}
+
+fn extract_api_symbols(source: &str) -> Vec<PackageApiSymbol> {
+    static DECL_RE: OnceLock<Regex> = OnceLock::new();
+    let decl_re = DECL_RE.get_or_init(|| {
+        Regex::new(r"^\s*pub\s+(fn|pipeline|tool|skill|struct|enum|type|interface)\s+([A-Za-z_][A-Za-z0-9_]*)\b(.*)$")
+            .expect("valid declaration regex")
+    });
+    let mut docs: Vec<String> = Vec::new();
+    let mut symbols = Vec::new();
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if let Some(doc) = trimmed.strip_prefix("///") {
+            docs.push(doc.trim().to_string());
+            continue;
+        }
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(captures) = decl_re.captures(line) {
+            let kind = captures.get(1).expect("kind").as_str().to_string();
+            let name = captures.get(2).expect("name").as_str().to_string();
+            let signature = trim_signature(line);
+            let doc_text = (!docs.is_empty()).then(|| docs.join("\n"));
+            symbols.push(PackageApiSymbol {
+                kind,
+                name,
+                signature,
+                docs: doc_text,
+            });
+        }
+        docs.clear();
+    }
+    symbols
+}
+
+fn trim_signature(line: &str) -> String {
+    let mut signature = line.trim().to_string();
+    if let Some((before, _)) = signature.split_once('{') {
+        signature = before.trim_end().to_string();
+    }
+    signature
+}
+
+fn supports_current_harn(range: &str) -> bool {
+    let current = env!("CARGO_PKG_VERSION");
+    let Some((major, minor)) = parse_major_minor(current) else {
+        return true;
+    };
+    let range = range.trim();
+    if range.is_empty() {
+        return false;
+    }
+    if let Some(rest) = range.strip_prefix('^') {
+        return parse_major_minor(rest).is_some_and(|(m, n)| m == major && n == minor);
+    }
+    if !range.contains([',', '<', '>', '=']) {
+        return parse_major_minor(range).is_some_and(|(m, n)| m == major && n == minor);
+    }
+
+    let current_value = major * 1000 + minor;
+    let mut lower_ok = true;
+    let mut upper_ok = true;
+    let mut saw_constraint = false;
+    for raw in range.split(',') {
+        let part = raw.trim();
+        if part.is_empty() {
+            continue;
+        }
+        saw_constraint = true;
+        if let Some(rest) = part.strip_prefix(">=") {
+            if let Some((m, n)) = parse_major_minor(rest.trim()) {
+                lower_ok &= current_value >= m * 1000 + n;
+            } else {
+                return false;
+            }
+        } else if let Some(rest) = part.strip_prefix('>') {
+            if let Some((m, n)) = parse_major_minor(rest.trim()) {
+                lower_ok &= current_value > m * 1000 + n;
+            } else {
+                return false;
+            }
+        } else if let Some(rest) = part.strip_prefix("<=") {
+            if let Some((m, n)) = parse_major_minor(rest.trim()) {
+                upper_ok &= current_value <= m * 1000 + n;
+            } else {
+                return false;
+            }
+        } else if let Some(rest) = part.strip_prefix('<') {
+            if let Some((m, n)) = parse_major_minor(rest.trim()) {
+                upper_ok &= current_value < m * 1000 + n;
+            } else {
+                return false;
+            }
+        } else if let Some(rest) = part.strip_prefix('=') {
+            if let Some((m, n)) = parse_major_minor(rest.trim()) {
+                lower_ok &= current_value == m * 1000 + n;
+                upper_ok &= current_value == m * 1000 + n;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+    saw_constraint && lower_ok && upper_ok
+}
+
+fn parse_major_minor(raw: &str) -> Option<(u64, u64)> {
+    let raw = raw.trim().trim_start_matches('v');
+    let mut parts = raw.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.trim_end_matches('x').parse().ok()?;
+    Some((major, minor))
+}
+
+fn collect_package_files(root: &Path) -> Result<Vec<String>, String> {
+    let mut files = Vec::new();
+    collect_package_files_inner(root, root, &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+fn collect_package_files_inner(
+    root: &Path,
+    dir: &Path,
+    out: &mut Vec<String>,
+) -> Result<(), String> {
+    for entry in
+        fs::read_dir(dir).map_err(|error| format!("failed to read {}: {error}", dir.display()))?
+    {
+        let entry =
+            entry.map_err(|error| format!("failed to read {} entry: {error}", dir.display()))?;
+        let path = entry.path();
+        let name = entry.file_name();
+        if path.is_dir() {
+            if should_skip_package_dir(&name) {
+                continue;
+            }
+            collect_package_files_inner(root, &path, out)?;
+        } else if path.is_file() {
+            let rel = path
+                .strip_prefix(root)
+                .map_err(|error| format!("failed to relativize {}: {error}", path.display()))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            out.push(rel);
+        }
+    }
+    Ok(())
+}
+
+fn should_skip_package_dir(name: &OsStr) -> bool {
+    matches!(
+        name.to_str(),
+        Some(".git" | ".harn" | "target" | "node_modules" | "docs/dist")
+    )
+}
+
+fn default_artifact_dir(ctx: &ManifestContext, report: &PackageCheckReport) -> PathBuf {
+    let name = report.name.as_deref().unwrap_or("package");
+    let version = report.version.as_deref().unwrap_or("0.0.0");
+    ctx.dir
+        .join(".harn")
+        .join("dist")
+        .join(format!("{name}-{version}"))
+}
+
+fn fail_if_package_errors(report: &PackageCheckReport) -> Result<(), String> {
+    if report.errors.is_empty() {
+        return Ok(());
+    }
+    Err(format!(
+        "package check failed:\n{}",
+        report
+            .errors
+            .iter()
+            .map(|diagnostic| format!("- {}: {}", diagnostic.field, diagnostic.message))
+            .collect::<Vec<_>>()
+            .join("\n")
+    ))
+}
+
+fn render_package_api_docs(report: &PackageCheckReport) -> String {
+    let title = report.name.as_deref().unwrap_or("package");
+    let mut out = format!("# API Reference: {title}\n\nGenerated by `harn package docs`.\n");
+    if let Some(version) = report.version.as_deref() {
+        out.push_str(&format!("\nVersion: `{version}`\n"));
+    }
+    for export in &report.exports {
+        out.push_str(&format!(
+            "\n## Export `{}`\n\n`{}`\n",
+            export.name, export.path
+        ));
+        for symbol in &export.symbols {
+            out.push_str(&format!("\n### {} `{}`\n\n", symbol.kind, symbol.name));
+            if let Some(docs) = symbol.docs.as_deref() {
+                out.push_str(docs);
+                out.push_str("\n\n");
+            }
+            out.push_str("```harn\n");
+            out.push_str(&symbol.signature);
+            out.push_str("\n```\n");
+        }
+    }
+    out
+}
+
+fn normalize_newlines(input: &str) -> String {
+    input.replace("\r\n", "\n")
+}
+
+fn print_package_check_report(report: &PackageCheckReport) {
+    println!(
+        "Package {} {}",
+        report.name.as_deref().unwrap_or("<unnamed>"),
+        report.version.as_deref().unwrap_or("<unversioned>")
+    );
+    println!("manifest: {}", report.manifest_path);
+    for export in &report.exports {
+        println!(
+            "export {} -> {} ({} public symbol(s))",
+            export.name,
+            export.path,
+            export.symbols.len()
+        );
+    }
+    if !report.warnings.is_empty() {
+        println!("\nwarnings:");
+        for warning in &report.warnings {
+            println!("- {}: {}", warning.field, warning.message);
+        }
+    }
+    if !report.errors.is_empty() {
+        println!("\nerrors:");
+        for error in &report.errors {
+            println!("- {}: {}", error.field, error.message);
+        }
+    } else {
+        println!("\npackage check passed");
+    }
+}
+
+fn print_package_pack_report(report: &PackagePackReport) {
+    if report.dry_run {
+        println!("Package pack dry run succeeded.");
+    } else {
+        println!("Packed package artifact.");
+    }
+    println!("artifact: {}", report.artifact_dir);
+    println!("files:");
+    for file in &report.files {
+        println!("- {file}");
+    }
+}
+
 /// Resolved `[skills]` section plus the directory the manifest came
 /// from. Paths in `skills.paths` are joined against `manifest_dir`;
 /// `[[skill.source]]` fs entries get absolutized here too.
@@ -8507,6 +9344,104 @@ pub fn should_handle(event: TriggerEvent) -> bool {
                 .and_then(Dependency::local_path),
             Some(path)
         );
+    }
+
+    fn write_publishable_package(root: &Path) {
+        fs::create_dir_all(root.join("lib")).unwrap();
+        fs::create_dir_all(root.join("docs")).unwrap();
+        fs::write(
+            root.join(MANIFEST),
+            r#"[package]
+name = "acme-lib"
+version = "0.1.0"
+description = "Acme helpers"
+license = "MIT"
+repository = "https://github.com/acme/acme-lib"
+harn = ">=0.7,<0.8"
+docs_url = "docs/api.md"
+
+[exports]
+lib = "lib/main.harn"
+
+[dependencies]
+"#,
+        )
+        .unwrap();
+        fs::write(
+            root.join("lib/main.harn"),
+            r#"/// Return a greeting.
+pub fn greet(name: string) -> string {
+  return "hi " + name
+}
+"#,
+        )
+        .unwrap();
+        fs::write(root.join("README.md"), "# acme-lib\n").unwrap();
+        fs::write(root.join("LICENSE"), "MIT\n").unwrap();
+        fs::write(root.join("docs/api.md"), "").unwrap();
+    }
+
+    #[test]
+    fn package_check_accepts_publishable_package() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_publishable_package(tmp.path());
+
+        let report = check_package_impl(Some(tmp.path())).unwrap();
+
+        assert!(report.errors.is_empty(), "{:?}", report.errors);
+        assert_eq!(report.name.as_deref(), Some("acme-lib"));
+        assert_eq!(report.exports[0].symbols[0].name, "greet");
+    }
+
+    #[test]
+    fn package_check_rejects_path_dependencies_and_bad_harn_range() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_publishable_package(tmp.path());
+        fs::write(
+            tmp.path().join(MANIFEST),
+            r#"[package]
+name = "acme-lib"
+version = "0.1.0"
+description = "Acme helpers"
+license = "MIT"
+repository = "https://github.com/acme/acme-lib"
+harn = ">=0.8,<0.9"
+docs_url = "docs/api.md"
+
+[exports]
+lib = "lib/main.harn"
+
+[dependencies]
+local = { path = "../local" }
+"#,
+        )
+        .unwrap();
+
+        let report = check_package_impl(Some(tmp.path())).unwrap();
+        let messages = report
+            .errors
+            .iter()
+            .map(|diagnostic| diagnostic.message.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(messages.contains("unsupported Harn version range"));
+        assert!(messages.contains("path dependencies are not publishable"));
+    }
+
+    #[test]
+    fn package_docs_and_pack_use_exports() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_publishable_package(tmp.path());
+
+        let docs_path = generate_package_docs_impl(Some(tmp.path()), None, false).unwrap();
+        let docs = fs::read_to_string(docs_path).unwrap();
+        assert!(docs.contains("### fn `greet`"));
+        assert!(docs.contains("Return a greeting."));
+
+        let pack = pack_package_impl(Some(tmp.path()), None, true).unwrap();
+        assert!(pack.files.contains(&"harn.toml".to_string()));
+        assert!(pack.files.contains(&"lib/main.harn".to_string()));
     }
 
     #[test]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -33,6 +33,7 @@
 - [Skills](./skills.md)
 - [Personas](./personas.md)
 - [Skill provenance](./skill-provenance.md)
+- [Package authoring](./package-authoring.md)
 - [Sessions](./sessions.md)
 - [Agent state](./agent-state.md)
 - [Transcript architecture](./transcript-architecture.md)

--- a/docs/src/package-authoring.md
+++ b/docs/src/package-authoring.md
@@ -1,0 +1,115 @@
+# Package authoring
+
+Harn packages are ordinary Harn projects with package metadata, stable exports,
+tests, and optional connector contracts in `harn.toml`. They use the same
+`[dependencies]`, `.harn/packages/`, and `harn.lock` workflow as applications.
+
+## Create a package
+
+```bash
+harn new package acme-tools
+cd acme-tools
+harn test tests/
+harn package check
+harn package docs
+harn package pack
+```
+
+The package template creates:
+
+- `harn.toml` with `[package]` metadata, `[exports]`, and `[dependencies]`
+- `lib/main.harn` with a documented public function
+- `tests/` smoke tests
+- `README.md`, `LICENSE`, `docs/api.md`
+- CI that installs `harn-cli`, runs tests, checks docs drift, and runs
+  `harn package pack --dry-run`
+
+Consumers can add a local package while developing:
+
+```bash
+harn add ../acme-tools
+harn install
+```
+
+Before publishing, replace local path dependencies with registry or git
+dependencies pinned to a version or rev.
+
+## Create a connector package
+
+```bash
+harn new connector echo-connector
+cd echo-connector
+harn connector check .
+harn test tests/
+harn package check
+harn package docs
+harn publish --dry-run
+```
+
+Connector packages use the same package checks plus `harn connector check .` for
+the pure-Harn connector contract. First-party and community connectors should
+keep this CI shape so package consumers get the same authoring workflow.
+
+## Manifest metadata
+
+Publishable packages should include:
+
+```toml
+[package]
+name = "acme-tools"
+version = "0.1.0"
+description = "Reusable Harn helpers."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/acme/acme-tools"
+harn = ">=0.7,<0.8"
+docs_url = "docs/api.md"
+
+[exports]
+lib = "lib/main.harn"
+
+[dependencies]
+json-helpers = { git = "https://github.com/acme/json-helpers", rev = "v0.1.0" }
+```
+
+`harn package check` validates required metadata, dependency declarations,
+stable exports, README/license presence, docs links, and Harn compatibility.
+Publish readiness rejects path-only dependencies and unsupported Harn version
+ranges because they cannot be reproduced from a registry index.
+
+## API docs
+
+Document exported symbols with doc comments:
+
+```harn
+/// Return a greeting for `name`.
+pub fn greet(name: string) -> string {
+  return "Hello, " + name + "!"
+}
+```
+
+Generate docs with:
+
+```bash
+harn package docs
+```
+
+CI should use:
+
+```bash
+harn package docs --check
+```
+
+## Pack and publish dry run
+
+`harn package pack` validates the package and writes an inspectable artifact
+directory at `.harn/dist/<name>-<version>`. It excludes local build state such
+as `.git/`, `.harn/`, `target/`, and `node_modules/`.
+
+```bash
+harn package pack --dry-run
+harn package pack
+```
+
+`harn publish --dry-run` runs the same publish-readiness checks and reports the
+registry target that would receive the submission. Real registry submission is
+reserved for the registry/index workflow.


### PR DESCRIPTION
## Summary

Closes #471.

This adds the package authoring workflow requested in the issue:

- adds direct `harn new package NAME` and `harn new connector NAME` scaffolds, while preserving `harn new NAME --template ...`
- adds `harn package check`, `harn package docs`, and `harn package pack` for publish-readiness validation, API docs generation, and inspectable artifacts
- adds `harn publish --dry-run` as the registry-submission preview path until real registry submission lands
- validates package metadata, docs links, exports, dependency declarations, path-only dependencies, and Harn compatibility ranges
- documents the full package-author quickstart in the mdBook

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-issue-471 cargo test -p harn-cli package`
- package scaffold smoke: `harn new package ...`, `harn package check`, `harn package docs --check`, `harn package pack --dry-run`, `harn publish --dry-run --registry index.toml`
- connector scaffold smoke: `harn new connector ...`, `harn package check`, `harn package docs --check`, `harn package pack --dry-run`, `harn connector check .`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-471 cargo check --workspace`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-471 cargo test -p harn-cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-471 cargo clippy -p harn-cli --all-targets -- -D warnings`
- pre-commit hook: formatting, workspace clippy, markdown lint
- pre-push hook: 2051 nextest tests, markdown lint