### PR TITLE
[codex] Implement multi-tenant orchestrator isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ granular archaeology.
   from the live trigger provider catalog, and expanded
   `examples/triggers/` into a ready-to-customize library with
   `README.md` and `SKILL.md` metadata per recipe.
+- **Multi-tenant orchestrator isolation (#190).** Adds a persisted
+  tenant registry under `harn orchestrator tenant` with per-tenant
+  namespaced event log, `TenantScope` / `TenantEventLog` /
+  `TenantSecretProvider` primitives, API-key hashing and resolution,
+  per-tenant budgets, and topic/namespace helpers. Dispatcher routing
+  now scopes all dispatch traffic to tenant topics so one tenant's
+  load cannot leak into another's queues.
 
 ### Changed
 

--- a/conformance/tests/triggers/trigger_harness_multi_tenant_isolation_stub.expected
+++ b/conformance/tests/triggers/trigger_harness_multi_tenant_isolation_stub.expected
@@ -1,4 +1,4 @@
 true
-true
+false
 true
 true

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -1072,6 +1072,74 @@ pub(crate) enum OrchestratorCommand {
     Queue(OrchestratorQueueArgs),
     /// Replay stranded inbox envelopes explicitly.
     Recover(OrchestratorRecoverArgs),
+    /// Manage multi-tenant orchestrator tenants.
+    Tenant(OrchestratorTenantArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorTenantArgs {
+    #[command(flatten)]
+    pub local: OrchestratorLocalArgs,
+    #[command(subcommand)]
+    pub command: OrchestratorTenantCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum OrchestratorTenantCommand {
+    /// Create a tenant and print its initial API key.
+    Create(OrchestratorTenantCreateArgs),
+    /// List registered tenants.
+    Ls(OrchestratorTenantLsArgs),
+    /// Suspend a tenant while preserving state.
+    Suspend(OrchestratorTenantSuspendArgs),
+    /// Delete a tenant and remove its state.
+    Delete(OrchestratorTenantDeleteArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorTenantCreateArgs {
+    /// Tenant id to provision.
+    pub id: String,
+    /// Daily tenant budget in USD.
+    #[arg(long = "daily-cost-usd", value_name = "USD")]
+    pub daily_cost_usd: Option<f64>,
+    /// Hourly tenant budget in USD.
+    #[arg(long = "hourly-cost-usd", value_name = "USD")]
+    pub hourly_cost_usd: Option<f64>,
+    /// Tenant ingest rate limit.
+    #[arg(long = "ingest-per-minute", value_name = "N")]
+    pub ingest_per_minute: Option<u32>,
+    /// Emit JSON instead of human-readable output.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args, Default)]
+pub(crate) struct OrchestratorTenantLsArgs {
+    /// Emit JSON instead of human-readable output.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorTenantSuspendArgs {
+    /// Tenant id to suspend.
+    pub id: String,
+    /// Emit JSON instead of human-readable output.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OrchestratorTenantDeleteArgs {
+    /// Tenant id to delete.
+    pub id: String,
+    /// Confirm destructive tenant state removal.
+    #[arg(long, default_value_t = false, action = ArgAction::SetTrue)]
+    pub confirm: bool,
+    /// Emit JSON instead of human-readable output.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Args)]
@@ -2005,9 +2073,10 @@ mod tests {
 
     use super::{
         Cli, Command, ConnectCommand, McpCommand, OrchestratorCommand, OrchestratorDeployProvider,
-        OrchestratorLogFormat, OrchestratorQueueCommand, PackageCacheCommand, PackageCommand,
-        ProjectTemplate, RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand,
-        SkillsCommand, TraceCommand, TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
+        OrchestratorLogFormat, OrchestratorQueueCommand, OrchestratorTenantCommand,
+        PackageCacheCommand, PackageCommand, ProjectTemplate, RunsCommand, SkillCommand,
+        SkillKeyCommand, SkillTrustCommand, SkillsCommand, TraceCommand, TriggerCommand,
+        TrustCommand, TrustOutcomeArg, TrustTierArg,
     };
     use clap::Parser;
 
@@ -2864,6 +2933,39 @@ mod tests {
         assert_eq!(recover.envelope_age, StdDuration::from_secs(15 * 60));
         assert!(recover.dry_run);
         assert!(!recover.yes);
+    }
+
+    #[test]
+    fn test_parses_orchestrator_tenant_create_args() {
+        let cli = Cli::parse_from([
+            "harn",
+            "orchestrator",
+            "tenant",
+            "--state-dir",
+            "state/orchestrator",
+            "create",
+            "acme",
+            "--daily-cost-usd",
+            "25.5",
+            "--ingest-per-minute",
+            "120",
+            "--json",
+        ]);
+
+        let Command::Orchestrator(args) = cli.command.unwrap() else {
+            panic!("expected orchestrator command");
+        };
+        let OrchestratorCommand::Tenant(tenant) = args.command else {
+            panic!("expected orchestrator tenant");
+        };
+        let OrchestratorTenantCommand::Create(create) = tenant.command else {
+            panic!("expected orchestrator tenant create");
+        };
+        assert_eq!(tenant.local.state_dir, PathBuf::from("state/orchestrator"));
+        assert_eq!(create.id, "acme");
+        assert_eq!(create.daily_cost_usd, Some(25.5));
+        assert_eq!(create.ingest_per_minute, Some(120));
+        assert!(create.json);
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/orchestrator/common.rs
+++ b/crates/harn-cli/src/commands/orchestrator/common.rs
@@ -369,7 +369,7 @@ fn load_manifest(config_path: &Path) -> Result<(Manifest, PathBuf), String> {
     Ok((manifest, manifest_dir))
 }
 
-fn absolutize_from_cwd(path: &Path) -> Result<PathBuf, String> {
+pub(crate) fn absolutize_from_cwd(path: &Path) -> Result<PathBuf, String> {
     let candidate = if path.is_absolute() {
         path.to_path_buf()
     } else {

--- a/crates/harn-cli/src/commands/orchestrator/listener.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener.rs
@@ -60,6 +60,7 @@ pub(crate) struct ListenerConfig {
     pub(crate) metrics_registry: Arc<harn_vm::MetricsRegistry>,
     pub(crate) admin_reload: Option<AdminReloadHandle>,
     pub(crate) routes: Vec<RouteConfig>,
+    pub(crate) tenant_store: Option<Arc<harn_vm::TenantStore>>,
 }
 
 impl ListenerConfig {
@@ -161,6 +162,7 @@ impl ListenerRuntime {
             auth.clone(),
             pending_topic.clone(),
             request_gate,
+            config.tenant_store.clone(),
         )?);
         let mut app = Router::new()
             .route(
@@ -387,7 +389,20 @@ struct RouteContext {
     auth: Arc<ListenerAuth>,
     pending_topic: Topic,
     request_gate: TestRequestGate,
+    tenant_store: Option<Arc<harn_vm::TenantStore>>,
     metrics: Arc<RouteRuntimeMetrics>,
+}
+
+#[derive(Clone)]
+struct ResolvedRoute {
+    context: Arc<RouteContext>,
+    path_tenant_id: Option<String>,
+}
+
+#[derive(Clone)]
+struct TenantRequestScope {
+    scope: harn_vm::TenantScope,
+    credential_authenticated: bool,
 }
 
 #[derive(Clone, Default)]
@@ -472,9 +487,11 @@ struct RouteRegistry {
     auth: Arc<ListenerAuth>,
     pending_topic: Topic,
     request_gate: TestRequestGate,
+    tenant_store: Option<Arc<harn_vm::TenantStore>>,
 }
 
 impl RouteRegistry {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         routes: Vec<RouteConfig>,
         event_log: Arc<AnyEventLog>,
@@ -484,6 +501,7 @@ impl RouteRegistry {
         auth: Arc<ListenerAuth>,
         pending_topic: Topic,
         request_gate: TestRequestGate,
+        tenant_store: Option<Arc<harn_vm::TenantStore>>,
     ) -> Result<Self, String> {
         let registry = Self {
             routes_by_path: RwLock::new(BTreeMap::new()),
@@ -496,6 +514,7 @@ impl RouteRegistry {
             auth,
             pending_topic,
             request_gate,
+            tenant_store,
         };
         registry.reload(routes)?;
         Ok(registry)
@@ -525,6 +544,7 @@ impl RouteRegistry {
                     auth: self.auth.clone(),
                     pending_topic: self.pending_topic.clone(),
                     request_gate: self.request_gate.clone(),
+                    tenant_store: self.tenant_store.clone(),
                     metrics,
                 }),
             );
@@ -533,12 +553,22 @@ impl RouteRegistry {
         Ok(())
     }
 
-    fn resolve(&self, path: &str) -> Option<Arc<RouteContext>> {
-        self.routes_by_path
-            .read()
-            .expect("route table poisoned")
-            .get(path)
+    fn resolve(&self, path: &str) -> Option<ResolvedRoute> {
+        let routes = self.routes_by_path.read().expect("route table poisoned");
+        if let Some(context) = routes.get(path).cloned() {
+            return Some(ResolvedRoute {
+                context,
+                path_tenant_id: None,
+            });
+        }
+        let (tenant_id, route_path) = tenant_path_prefix(path)?;
+        routes
+            .get(&route_path)
             .cloned()
+            .map(|context| ResolvedRoute {
+                context,
+                path_tenant_id: Some(tenant_id),
+            })
     }
 
     fn snapshot_metrics(&self) -> BTreeMap<String, TriggerMetricSnapshot> {
@@ -631,12 +661,22 @@ impl IngestBackpressure {
         }
     }
 
-    fn try_acquire(&self, source: &str) -> Result<(), Duration> {
+    fn try_acquire_with_limit(
+        &self,
+        source: &str,
+        per_minute_limit: Option<u32>,
+    ) -> Result<(), Duration> {
         let now = Instant::now();
         let mut state = self
             .state
             .lock()
             .expect("ingest backpressure mutex poisoned");
+        let source_capacity = per_minute_limit
+            .unwrap_or(self.config.per_source_capacity)
+            .max(1);
+        let source_refill_per_sec = per_minute_limit
+            .map(|limit| (limit / 60).max(1))
+            .unwrap_or(self.config.refill_per_sec);
 
         state
             .global
@@ -645,15 +685,11 @@ impl IngestBackpressure {
             let source_bucket = state
                 .sources
                 .entry(source.to_string())
-                .or_insert_with(|| IngestBucket::full(self.config.per_source_capacity, now));
-            source_bucket.refill(
-                self.config.per_source_capacity,
-                self.config.refill_per_sec,
-                now,
-            );
+                .or_insert_with(|| IngestBucket::full(source_capacity, now));
+            source_bucket.refill(source_capacity, source_refill_per_sec, now);
             (
                 source_bucket.tokens,
-                source_bucket.retry_after(self.config.refill_per_sec),
+                source_bucket.retry_after(source_refill_per_sec),
             )
         };
 
@@ -738,6 +774,166 @@ fn validate_unique_route_paths(routes: &[RouteConfig]) -> Result<(), String> {
     Ok(())
 }
 
+fn tenant_path_prefix(path: &str) -> Option<(String, String)> {
+    for prefix in ["/hooks/tenant/", "/tenant/"] {
+        let Some(rest) = path.strip_prefix(prefix) else {
+            continue;
+        };
+        let (tenant_id, route_tail) = rest.split_once('/')?;
+        if tenant_id.is_empty() {
+            return None;
+        }
+        return Some((tenant_id.to_string(), format!("/{route_tail}")));
+    }
+    None
+}
+
+async fn resolve_tenant_request(
+    context: &RouteContext,
+    path_tenant_id: Option<&str>,
+    headers: &BTreeMap<String, String>,
+) -> Result<Option<TenantRequestScope>, Response> {
+    let Some(store) = context.tenant_store.as_ref() else {
+        return Ok(None);
+    };
+    let credential_key = tenant_api_key_from_headers(headers);
+    let credential_scope = match credential_key {
+        Some(key) => match store.resolve_api_key(key) {
+            Ok(scope) => Some(scope),
+            Err(harn_vm::TenantResolutionError::Suspended(id)) => {
+                return Err(tenant_denial_response(
+                    context,
+                    Some(id.0),
+                    path_tenant_id.map(ToString::to_string),
+                    "tenant_suspended",
+                    HttpError::payment_required("tenant is suspended"),
+                )
+                .await);
+            }
+            Err(harn_vm::TenantResolutionError::Unknown) => {
+                return Err(tenant_denial_response(
+                    context,
+                    None,
+                    path_tenant_id.map(ToString::to_string),
+                    "unknown_api_key",
+                    HttpError::forbidden("unknown tenant API key"),
+                )
+                .await);
+            }
+        },
+        None => None,
+    };
+
+    let path_scope = match path_tenant_id {
+        Some(id) => match store.get(id) {
+            Some(record) if record.status == harn_vm::TenantStatus::Active => {
+                Some(record.scope.clone())
+            }
+            Some(record) => {
+                return Err(tenant_denial_response(
+                    context,
+                    Some(record.scope.id.0.clone()),
+                    Some(id.to_string()),
+                    "tenant_suspended",
+                    HttpError::payment_required("tenant is suspended"),
+                )
+                .await);
+            }
+            None => {
+                return Err(tenant_denial_response(
+                    context,
+                    credential_scope.as_ref().map(|scope| scope.id.0.clone()),
+                    Some(id.to_string()),
+                    "unknown_path_tenant",
+                    HttpError::forbidden("unknown tenant"),
+                )
+                .await);
+            }
+        },
+        None => None,
+    };
+
+    if let (Some(credential_scope), Some(path_scope)) = (&credential_scope, &path_scope) {
+        if credential_scope.id != path_scope.id {
+            return Err(tenant_denial_response(
+                context,
+                Some(credential_scope.id.0.clone()),
+                Some(path_scope.id.0.clone()),
+                "cross_tenant_attempt",
+                HttpError::forbidden("API key is not valid for requested tenant"),
+            )
+            .await);
+        }
+    }
+
+    let scope = credential_scope.or(path_scope);
+    let Some(scope) = scope else {
+        return Err(tenant_denial_response(
+            context,
+            None,
+            None,
+            "tenant_required",
+            HttpError::forbidden("tenant is required"),
+        )
+        .await);
+    };
+
+    Ok(Some(TenantRequestScope {
+        credential_authenticated: credential_key.is_some(),
+        scope,
+    }))
+}
+
+fn tenant_api_key_from_headers(headers: &BTreeMap<String, String>) -> Option<&str> {
+    if let Some(api_key) = header_value(headers, "x-api-key") {
+        return Some(api_key.trim()).filter(|value| !value.is_empty());
+    }
+    let authorization = header_value(headers, "authorization")?;
+    let (scheme, value) = authorization.split_once(' ')?;
+    if scheme.eq_ignore_ascii_case("Bearer") {
+        Some(value.trim()).filter(|value| !value.is_empty())
+    } else {
+        None
+    }
+}
+
+async fn tenant_denial_response(
+    context: &RouteContext,
+    tenant_id: Option<String>,
+    attempted_tenant_id: Option<String>,
+    reason: &str,
+    error: HttpError,
+) -> Response {
+    let mut headers = BTreeMap::new();
+    headers.insert("reason".to_string(), reason.to_string());
+    if let Some(tenant_id) = tenant_id.as_ref() {
+        headers.insert("tenant_id".to_string(), tenant_id.clone());
+    }
+    if let Some(attempted_tenant_id) = attempted_tenant_id.as_ref() {
+        headers.insert(
+            "attempted_tenant_id".to_string(),
+            attempted_tenant_id.clone(),
+        );
+    }
+    headers.insert("trigger_id".to_string(), context.route.trigger_id.clone());
+    let payload = json!({
+        "reason": reason,
+        "tenant_id": tenant_id,
+        "attempted_tenant_id": attempted_tenant_id,
+        "trigger_id": context.route.trigger_id,
+    });
+    if let Ok(topic) = Topic::new("orchestrator.tenant.audit") {
+        let _ = context
+            .event_log
+            .append(
+                &topic,
+                LogEvent::new("tenant_access_denied", payload).with_headers(headers),
+            )
+            .await;
+    }
+    error.into_response()
+}
+
 async fn ingest_trigger(
     Extension(routes): Extension<Arc<RouteRegistry>>,
     method: Method,
@@ -746,9 +942,10 @@ async fn ingest_trigger(
     Query(query): Query<BTreeMap<String, String>>,
     body: Bytes,
 ) -> impl IntoResponse {
-    let Some(context) = routes.resolve(uri.path()) else {
+    let Some(resolved) = routes.resolve(uri.path()) else {
         return (StatusCode::NOT_FOUND, "trigger route not configured").into_response();
     };
+    let context = resolved.context;
 
     context.metrics.received.fetch_add(1, Ordering::Relaxed);
     context.metrics.in_flight.fetch_add(1, Ordering::Relaxed);
@@ -762,10 +959,43 @@ async fn ingest_trigger(
     let request_started = Instant::now();
     let accepted_at_ms = current_unix_ms();
     let body_size_bytes = body.len();
+    let normalized_headers = normalize_headers(&headers);
+    let tenant_scope = match resolve_tenant_request(
+        &context,
+        resolved.path_tenant_id.as_deref(),
+        &normalized_headers,
+    )
+    .await
+    {
+        Ok(scope) => scope,
+        Err(response) => {
+            context.metrics.failed.fetch_add(1, Ordering::Relaxed);
+            context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
+            context.metrics_registry.set_trigger_inflight(
+                &context.route.trigger_id,
+                context.metrics.in_flight.load(Ordering::Relaxed),
+            );
+            context.metrics_registry.record_http_request(
+                &context.route.path,
+                method.as_str(),
+                response.status().as_u16(),
+                request_started.elapsed(),
+                body_size_bytes,
+            );
+            return finalize_response(&context, response);
+        }
+    };
+    let ingest_source = tenant_scope
+        .as_ref()
+        .map(|tenant| format!("tenant:{}", tenant.scope.id.0))
+        .unwrap_or_else(|| context.route.provider.as_str().to_string());
+    let tenant_ingest_per_minute = tenant_scope
+        .as_ref()
+        .and_then(|tenant| tenant.scope.budget.ingest_per_minute);
 
     if let Err(retry_after) = context
         .ingest_backpressure
-        .try_acquire(context.route.provider.as_str())
+        .try_acquire_with_limit(&ingest_source, tenant_ingest_per_minute)
     {
         context.metrics.failed.fetch_add(1, Ordering::Relaxed);
         context.metrics.in_flight.fetch_sub(1, Ordering::Relaxed);
@@ -812,9 +1042,9 @@ async fn ingest_trigger(
     );
 
     async move {
-        let normalized_headers = normalize_headers(&headers);
         if let Err(error) = authorize_request(
             &context,
+            tenant_scope.as_ref(),
             method.as_str(),
             uri.path(),
             &normalized_headers,
@@ -871,6 +1101,7 @@ async fn ingest_trigger(
             &query,
             body.as_ref(),
             trace_id,
+            tenant_scope.as_ref().map(|tenant| &tenant.scope),
         )
         .await;
         let ingress_timing = IngressLifecycleTiming {
@@ -1773,6 +2004,7 @@ fn session_id_from_acp_message(line: &str) -> Option<String> {
 
 async fn authorize_request(
     context: &RouteContext,
+    tenant_scope: Option<&TenantRequestScope>,
     method: &str,
     path: &str,
     headers: &BTreeMap<String, String>,
@@ -1780,6 +2012,11 @@ async fn authorize_request(
 ) -> Result<(), HttpError> {
     match context.route.auth_mode {
         AuthMode::Public => Ok(()),
+        AuthMode::BearerOrHmac
+            if tenant_scope.is_some_and(|tenant| tenant.credential_authenticated) =>
+        {
+            Ok(())
+        }
         AuthMode::BearerOrHmac => context
             .auth
             .authorize(context.event_log.as_ref(), method, path, headers, body)
@@ -1794,6 +2031,7 @@ async fn normalize_request(
     query: &BTreeMap<String, String>,
     body: &[u8],
     trace_id: harn_vm::TraceId,
+    tenant_scope: Option<&harn_vm::TenantScope>,
 ) -> Result<NormalizedRequest, HttpError> {
     let received_at = OffsetDateTime::now_utc();
     if let Some(connector) = context.route.connector.as_ref() {
@@ -1804,6 +2042,7 @@ async fn normalize_request(
             "binding_id": context.route.trigger_id,
             "binding_version": context.route.binding_version,
             "path": context.route.path,
+            "tenant_id": tenant_scope.map(|tenant| tenant.id.0.as_str()),
         });
         let result = connector
             .lock()
@@ -1811,7 +2050,7 @@ async fn normalize_request(
             .normalize_inbound_result(raw)
             .await
             .map_err(HttpError::from_connector)?;
-        return connector_normalize_result_to_request(result, trace_id);
+        return connector_normalize_result_to_request(result, trace_id, tenant_scope);
     }
 
     let normalized_body = normalize_body(body, normalized_headers);
@@ -1820,7 +2059,8 @@ async fn normalize_request(
     let signature_status = match context.route.signature_mode {
         SignatureMode::Unsigned => harn_vm::SignatureStatus::Unsigned,
         SignatureMode::GitHub => {
-            let secret = load_secret(context, context.route.signing_secret.as_ref()).await?;
+            let secret =
+                load_secret(context, tenant_scope, context.route.signing_secret.as_ref()).await?;
             harn_vm::connectors::hmac::verify_hmac_signed(
                 context.event_log.as_ref(),
                 &provider,
@@ -1836,7 +2076,8 @@ async fn normalize_request(
             harn_vm::SignatureStatus::Verified
         }
         SignatureMode::Standard => {
-            let secret = load_secret(context, context.route.signing_secret.as_ref()).await?;
+            let secret =
+                load_secret(context, tenant_scope, context.route.signing_secret.as_ref()).await?;
             harn_vm::connectors::hmac::verify_hmac_signed(
                 context.event_log.as_ref(),
                 &provider,
@@ -1872,7 +2113,7 @@ async fn normalize_request(
         occurred_at: infer_occurred_at(&provider_payload),
         dedupe_key,
         trace_id,
-        tenant_id: None,
+        tenant_id: tenant_scope.map(|tenant| tenant.id.clone()),
         headers: harn_vm::redact_headers(
             normalized_headers,
             &harn_vm::HeaderRedactionPolicy::default(),
@@ -1910,6 +2151,7 @@ struct IngressLifecycleTiming {
 fn connector_normalize_result_to_request(
     result: harn_vm::ConnectorNormalizeResult,
     trace_id: harn_vm::TraceId,
+    tenant_scope: Option<&harn_vm::TenantScope>,
 ) -> Result<NormalizedRequest, HttpError> {
     match result {
         harn_vm::ConnectorNormalizeResult::Event(event) => {
@@ -1932,11 +2174,11 @@ fn connector_normalize_result_to_request(
                 });
             }
             event.trace_id = trace_id;
-            Ok(NormalizedRequest::Events(vec![event]))
+            apply_tenant_scope(vec![event], tenant_scope).map(NormalizedRequest::Events)
         }
         harn_vm::ConnectorNormalizeResult::Batch(mut events) => {
             set_trace_id(&mut events, trace_id);
-            Ok(NormalizedRequest::Events(events))
+            apply_tenant_scope(events, tenant_scope).map(NormalizedRequest::Events)
         }
         harn_vm::ConnectorNormalizeResult::ImmediateResponse {
             response,
@@ -1945,13 +2187,35 @@ fn connector_normalize_result_to_request(
             set_trace_id(&mut events, trace_id);
             Ok(NormalizedRequest::Immediate {
                 response: connector_http_response_to_response(response)?,
-                events,
+                events: apply_tenant_scope(events, tenant_scope)?,
             })
         }
         harn_vm::ConnectorNormalizeResult::Reject(response) => Ok(NormalizedRequest::Rejected(
             connector_http_response_to_response(response)?,
         )),
     }
+}
+
+fn apply_tenant_scope(
+    mut events: Vec<harn_vm::TriggerEvent>,
+    tenant_scope: Option<&harn_vm::TenantScope>,
+) -> Result<Vec<harn_vm::TriggerEvent>, HttpError> {
+    let Some(tenant_scope) = tenant_scope else {
+        return Ok(events);
+    };
+    for event in &mut events {
+        match event.tenant_id.as_ref() {
+            Some(existing) if existing != &tenant_scope.id => {
+                return Err(HttpError::forbidden(format!(
+                    "event tenant '{}' does not match request tenant '{}'",
+                    existing.0, tenant_scope.id.0
+                )));
+            }
+            Some(_) => {}
+            None => event.tenant_id = Some(tenant_scope.id.clone()),
+        }
+    }
+    Ok(events)
 }
 
 fn set_trace_id(events: &mut [harn_vm::TriggerEvent], trace_id: harn_vm::TraceId) {
@@ -2058,6 +2322,8 @@ async fn enqueue_normalized_events(
             }
             harn_vm::PostNormalizeOutcome::Ready(event) => {
                 let event = *event;
+                let pending_topic = topic_for_event(&event, &context.pending_topic)
+                    .map_err(|error| HttpError::internal(error.to_string()))?;
                 let payload = json!({
                     "trigger_id": context.route.trigger_id,
                     "binding_version": context.route.binding_version,
@@ -2109,7 +2375,7 @@ async fn enqueue_normalized_events(
                 log_event.headers = pending_headers;
                 let event_id = context
                     .event_log
-                    .append(&context.pending_topic, log_event)
+                    .append(&pending_topic, log_event)
                     .instrument(queue_span)
                     .await
                     .map_err(|error| {
@@ -2118,7 +2384,7 @@ async fn enqueue_normalized_events(
                         ))
                     })?;
                 context.metrics_registry.record_event_log_append(
-                    context.pending_topic.as_str(),
+                    pending_topic.as_str(),
                     append_started.elapsed(),
                     payload_size_bytes,
                 );
@@ -2214,6 +2480,7 @@ fn trigger_path(trigger: &CollectedManifestTrigger) -> Result<String, String> {
 
 async fn load_secret(
     context: &RouteContext,
+    tenant_scope: Option<&harn_vm::TenantScope>,
     secret_id: Option<&SecretId>,
 ) -> Result<String, HttpError> {
     let secret_id = secret_id.ok_or_else(|| {
@@ -2222,8 +2489,15 @@ async fn load_secret(
             context.route.trigger_id
         ))
     })?;
-    let secret = context
-        .secrets
+    let tenant_provider;
+    let provider: &dyn SecretProvider = if let Some(scope) = tenant_scope {
+        tenant_provider =
+            harn_vm::TenantSecretProvider::new(context.secrets.clone(), scope.clone());
+        &tenant_provider
+    } else {
+        context.secrets.as_ref()
+    };
+    let secret = provider
         .get(secret_id)
         .await
         .map_err(|error| HttpError::internal(error.to_string()))?;
@@ -2604,6 +2878,20 @@ impl HttpError {
         }
     }
 
+    fn forbidden(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            message: message.into(),
+        }
+    }
+
+    fn payment_required(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::PAYMENT_REQUIRED,
+            message: message.into(),
+        }
+    }
+
     fn internal(message: impl Into<String>) -> Self {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
@@ -2667,6 +2955,16 @@ async fn mark_test_file(path: &Path) -> Result<(), String> {
 
 fn listener_binding_key(trigger_id: &str, binding_version: u32) -> String {
     format!("{trigger_id}@v{binding_version}")
+}
+
+fn topic_for_event(
+    event: &harn_vm::TriggerEvent,
+    topic: &Topic,
+) -> Result<Topic, harn_vm::event_log::LogError> {
+    match event.tenant_id.as_ref() {
+        Some(tenant_id) => harn_vm::tenant_topic(tenant_id, topic),
+        None => Ok(topic.clone()),
+    }
 }
 
 fn current_unix_ms() -> i64 {
@@ -2995,6 +3293,7 @@ mod tests {
             metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
             admin_reload: None,
             routes: Vec::new(),
+            tenant_store: None,
         })
         .await
         .expect("start listener");
@@ -3343,6 +3642,7 @@ mod tests {
             metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
             admin_reload: None,
             routes: vec![route("/a2a/v1", 1)],
+            tenant_store: None,
         })
         .await
         .expect("start listener");
@@ -3461,6 +3761,7 @@ mod tests {
             metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
             admin_reload: None,
             routes: vec![webhook_route("/hooks/github")],
+            tenant_store: None,
         })
         .await
         .expect("start listener");
@@ -3527,6 +3828,7 @@ mod tests {
             metrics_registry: metrics.clone(),
             admin_reload: None,
             routes: vec![webhook_route("/hooks/github")],
+            tenant_store: None,
         })
         .await
         .expect("start listener");
@@ -3602,6 +3904,7 @@ mod tests {
             metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
             admin_reload: None,
             routes: vec![webhook_route("/hooks/github")],
+            tenant_store: None,
         })
         .await
         .expect("start listener");
@@ -3672,6 +3975,7 @@ mod tests {
             metrics_registry: Arc::new(harn_vm::MetricsRegistry::default()),
             admin_reload: None,
             routes: vec![route],
+            tenant_store: None,
         })
         .await
         .expect("start listener");

--- a/crates/harn-cli/src/commands/orchestrator/mod.rs
+++ b/crates/harn-cli/src/commands/orchestrator/mod.rs
@@ -14,6 +14,7 @@ mod resume;
 pub(crate) mod role;
 mod serve;
 mod stats;
+mod tenant;
 mod tls;
 
 use crate::cli::{OrchestratorArgs, OrchestratorCommand};
@@ -31,5 +32,6 @@ pub(crate) async fn handle(args: OrchestratorArgs) -> Result<(), String> {
         OrchestratorCommand::Dlq(dlq_args) => dlq::run(dlq_args).await,
         OrchestratorCommand::Queue(queue_args) => queue::run(queue_args).await,
         OrchestratorCommand::Recover(recover_args) => recover::run(recover_args).await,
+        OrchestratorCommand::Tenant(tenant_args) => tenant::run(tenant_args).await,
     }
 }

--- a/crates/harn-cli/src/commands/orchestrator/role.rs
+++ b/crates/harn-cli/src/commands/orchestrator/role.rs
@@ -31,7 +31,7 @@ impl OrchestratorRole {
         state_dir: &Path,
     ) -> Result<harn_vm::Vm, String> {
         match self {
-            Self::SingleTenant => {
+            Self::SingleTenant | Self::MultiTenant => {
                 std::env::set_var(
                     harn_vm::runtime_paths::HARN_STATE_DIR_ENV,
                     state_dir.display().to_string(),
@@ -45,9 +45,6 @@ impl OrchestratorRole {
                 vm.set_source_dir(source_dir);
                 Ok(vm)
             }
-            Self::MultiTenant => Err(
-                "multi-tenant orchestrator role is not yet implemented (see O-12 #190)".to_string(),
-            ),
         }
     }
 }

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -128,6 +128,26 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
     let event_log = harn_vm::event_log::active_event_log()
         .ok_or_else(|| "event log was not installed during VM initialization".to_string())?;
     let event_log_description = event_log.describe();
+    let tenant_store = if args.role == OrchestratorRole::MultiTenant {
+        let store = harn_vm::TenantStore::load(&state_dir)?;
+        let active_tenants = store
+            .list()
+            .into_iter()
+            .filter(|tenant| tenant.status == harn_vm::TenantStatus::Active)
+            .collect::<Vec<_>>();
+        eprintln!(
+            "[harn] tenants loaded: {} active ({})",
+            active_tenants.len(),
+            active_tenants
+                .iter()
+                .map(|tenant| tenant.scope.id.0.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        Some(Arc::new(store))
+    } else {
+        None
+    };
     eprintln!(
         "[harn] event log: {} {}",
         event_log_description.backend,
@@ -196,19 +216,67 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
         event_log.clone(),
         Some(metrics_registry.clone()),
     );
-    let pending_pump = spawn_pending_pump(
-        event_log.clone(),
-        dispatcher.clone(),
-        pump_config,
-        metrics_registry.clone(),
-    )?;
+    let mut pending_pumps = vec![(
+        PENDING_TOPIC.to_string(),
+        spawn_pending_pump(
+            event_log.clone(),
+            dispatcher.clone(),
+            pump_config,
+            metrics_registry.clone(),
+            PENDING_TOPIC,
+        )?,
+    )];
+    let mut inbox_pumps = vec![(
+        harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC.to_string(),
+        spawn_inbox_pump(
+            event_log.clone(),
+            dispatcher.clone(),
+            pump_config,
+            metrics_registry.clone(),
+            harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC,
+        )?,
+    )];
+    if let Some(store) = tenant_store.as_ref() {
+        for tenant in store
+            .list()
+            .into_iter()
+            .filter(|tenant| tenant.status == harn_vm::TenantStatus::Active)
+        {
+            let pending_topic = harn_vm::tenant_topic(
+                &tenant.scope.id,
+                &harn_vm::event_log::Topic::new(PENDING_TOPIC)
+                    .map_err(|error| error.to_string())?,
+            )
+            .map_err(|error| error.to_string())?;
+            pending_pumps.push((
+                pending_topic.as_str().to_string(),
+                spawn_pending_pump(
+                    event_log.clone(),
+                    dispatcher.clone(),
+                    pump_config,
+                    metrics_registry.clone(),
+                    pending_topic.as_str(),
+                )?,
+            ));
+            let inbox_topic = harn_vm::tenant_topic(
+                &tenant.scope.id,
+                &harn_vm::event_log::Topic::new(harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC)
+                    .map_err(|error| error.to_string())?,
+            )
+            .map_err(|error| error.to_string())?;
+            inbox_pumps.push((
+                inbox_topic.as_str().to_string(),
+                spawn_inbox_pump(
+                    event_log.clone(),
+                    dispatcher.clone(),
+                    pump_config,
+                    metrics_registry.clone(),
+                    inbox_topic.as_str(),
+                )?,
+            ));
+        }
+    }
     let cron_pump = spawn_cron_pump(
-        event_log.clone(),
-        dispatcher.clone(),
-        pump_config,
-        metrics_registry.clone(),
-    )?;
-    let inbox_pump = spawn_inbox_pump(
         event_log.clone(),
         dispatcher.clone(),
         pump_config,
@@ -240,6 +308,7 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
         metrics_registry: metrics_registry.clone(),
         admin_reload: Some(admin_reload.clone()),
         routes: route_configs,
+        tenant_store: tenant_store.clone(),
     })
     .await?;
     let local_bind = listener.local_addr();
@@ -378,9 +447,9 @@ async fn run_local(args: OrchestratorServeArgs) -> Result<(), String> {
         },
         listener,
         dispatcher,
-        pending_pump,
+        pending_pumps,
         cron_pump,
-        inbox_pump,
+        inbox_pumps,
         waitpoint_pump,
         waitpoint_cancel_pump,
         waitpoint_sweeper,
@@ -897,8 +966,9 @@ fn spawn_pending_pump(
     dispatcher: harn_vm::Dispatcher,
     pump_config: PumpConfig,
     metrics_registry: Arc<harn_vm::MetricsRegistry>,
+    topic_name: &str,
 ) -> Result<PumpHandle, String> {
-    let topic = harn_vm::event_log::Topic::new(PENDING_TOPIC).map_err(|error| error.to_string())?;
+    let topic = harn_vm::event_log::Topic::new(topic_name).map_err(|error| error.to_string())?;
     spawn_topic_pump(
         event_log,
         topic,
@@ -972,9 +1042,9 @@ fn spawn_inbox_pump(
     dispatcher: harn_vm::Dispatcher,
     pump_config: PumpConfig,
     metrics_registry: Arc<harn_vm::MetricsRegistry>,
+    topic_name: &str,
 ) -> Result<PumpHandle, String> {
-    let topic = harn_vm::event_log::Topic::new(harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC)
-        .map_err(|error| error.to_string())?;
+    let topic = harn_vm::event_log::Topic::new(topic_name).map_err(|error| error.to_string())?;
     let consumer = pump_consumer_id(&topic)?;
     let inbox_task_release_file = inbox_task_test_release_file();
     let (mode_tx, mut mode_rx) = watch::channel(PumpMode::Running);
@@ -1427,9 +1497,9 @@ async fn graceful_shutdown(
     ctx: GracefulShutdownCtx<'_>,
     listener: ListenerRuntime,
     dispatcher: harn_vm::Dispatcher,
-    pending_pump: PumpHandle,
+    pending_pumps: Vec<(String, PumpHandle)>,
     cron_pump: PumpHandle,
-    inbox_pump: PumpHandle,
+    inbox_pumps: Vec<(String, PumpHandle)>,
     waitpoint_pump: PumpHandle,
     waitpoint_cancel_pump: PumpHandle,
     waitpoint_sweeper: WaitpointSweepHandle,
@@ -1477,21 +1547,14 @@ async fn graceful_shutdown(
         }
     }
 
-    let pending_stats = drain_pump_best_effort(
-        ctx.event_log,
-        PENDING_TOPIC,
-        pending_pump,
-        ctx.drain_config,
-        deadline,
-    )
-    .await?;
-    emit_drain_truncated(
-        ctx.event_log,
-        PENDING_TOPIC,
-        pending_stats,
-        ctx.drain_config,
-    )
-    .await?;
+    let mut pending_processed = 0;
+    for (topic_name, pump) in pending_pumps {
+        let stats =
+            drain_pump_best_effort(ctx.event_log, &topic_name, pump, ctx.drain_config, deadline)
+                .await?;
+        pending_processed += stats.stats.processed;
+        emit_drain_truncated(ctx.event_log, &topic_name, stats, ctx.drain_config).await?;
+    }
     let cron_stats = drain_pump_best_effort(
         ctx.event_log,
         CRON_TICK_TOPIC,
@@ -1501,21 +1564,14 @@ async fn graceful_shutdown(
     )
     .await?;
     emit_drain_truncated(ctx.event_log, CRON_TICK_TOPIC, cron_stats, ctx.drain_config).await?;
-    let inbox_stats = drain_pump_best_effort(
-        ctx.event_log,
-        harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC,
-        inbox_pump,
-        ctx.drain_config,
-        deadline,
-    )
-    .await?;
-    emit_drain_truncated(
-        ctx.event_log,
-        harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC,
-        inbox_stats,
-        ctx.drain_config,
-    )
-    .await?;
+    let mut inbox_processed = 0;
+    for (topic_name, pump) in inbox_pumps {
+        let stats =
+            drain_pump_best_effort(ctx.event_log, &topic_name, pump, ctx.drain_config, deadline)
+                .await?;
+        inbox_processed += stats.stats.processed;
+        emit_drain_truncated(ctx.event_log, &topic_name, stats, ctx.drain_config).await?;
+    }
     let waitpoint_stats = waitpoint_pump
         .drain(
             topic_latest_id(ctx.event_log, harn_vm::WAITPOINT_RESUME_TOPIC).await?,
@@ -1566,9 +1622,9 @@ async fn graceful_shutdown(
             "dispatcher_in_flight": drain_report.in_flight,
             "dispatcher_retry_queue_depth": drain_report.retry_queue_depth,
             "dispatcher_dlq_depth": drain_report.dlq_depth,
-            "pending_events_drained": pending_stats.stats.processed,
+            "pending_events_drained": pending_processed,
             "cron_events_drained": cron_stats.stats.processed,
-            "inbox_events_drained": inbox_stats.stats.processed,
+            "inbox_events_drained": inbox_processed,
             "waitpoint_events_drained": waitpoint_stats.stats.processed,
             "waitpoint_cancel_events_drained": waitpoint_cancel_stats.stats.processed,
             "timed_out": timed_out,

--- a/crates/harn-cli/src/commands/orchestrator/tenant.rs
+++ b/crates/harn-cli/src/commands/orchestrator/tenant.rs
@@ -1,0 +1,117 @@
+use serde::Serialize;
+
+use crate::cli::{
+    OrchestratorTenantArgs, OrchestratorTenantCommand, OrchestratorTenantCreateArgs,
+    OrchestratorTenantDeleteArgs, OrchestratorTenantLsArgs, OrchestratorTenantSuspendArgs,
+};
+
+use super::common::{absolutize_from_cwd, print_json};
+
+#[derive(Serialize)]
+struct TenantCreateOutput {
+    tenant: harn_vm::TenantRecord,
+    api_key: String,
+}
+
+pub(crate) async fn run(args: OrchestratorTenantArgs) -> Result<(), String> {
+    let state_dir = absolutize_from_cwd(&args.local.state_dir)?;
+    std::fs::create_dir_all(&state_dir).map_err(|error| {
+        format!(
+            "failed to create state dir {}: {error}",
+            state_dir.display()
+        )
+    })?;
+    let mut store = harn_vm::TenantStore::load(&state_dir)?;
+    match args.command {
+        OrchestratorTenantCommand::Create(create) => create_tenant(&mut store, create),
+        OrchestratorTenantCommand::Ls(ls) => list_tenants(&store, ls),
+        OrchestratorTenantCommand::Suspend(suspend) => suspend_tenant(&mut store, suspend),
+        OrchestratorTenantCommand::Delete(delete) => delete_tenant(&mut store, delete),
+    }
+}
+
+fn create_tenant(
+    store: &mut harn_vm::TenantStore,
+    args: OrchestratorTenantCreateArgs,
+) -> Result<(), String> {
+    if let Some(value) = args.daily_cost_usd {
+        if value < 0.0 {
+            return Err("--daily-cost-usd must be greater than or equal to 0".to_string());
+        }
+    }
+    if let Some(value) = args.hourly_cost_usd {
+        if value < 0.0 {
+            return Err("--hourly-cost-usd must be greater than or equal to 0".to_string());
+        }
+    }
+    let budget = harn_vm::TenantBudget {
+        daily_cost_usd: args.daily_cost_usd,
+        hourly_cost_usd: args.hourly_cost_usd,
+        ingest_per_minute: args.ingest_per_minute,
+        ..harn_vm::TenantBudget::default()
+    };
+    let (tenant, api_key) = store.create_tenant(args.id, budget)?;
+    if args.json {
+        return print_json(&TenantCreateOutput { tenant, api_key });
+    }
+    println!("created tenant {}", tenant.scope.id.0);
+    println!("state: {}", tenant.scope.state_root.display());
+    println!("secret namespace: {}", tenant.scope.secret_namespace);
+    println!(
+        "event topic prefix: {}",
+        tenant.scope.event_log_topic_prefix
+    );
+    println!("api key: {api_key}");
+    Ok(())
+}
+
+fn list_tenants(
+    store: &harn_vm::TenantStore,
+    args: OrchestratorTenantLsArgs,
+) -> Result<(), String> {
+    let tenants = store.list();
+    if args.json {
+        return print_json(&tenants);
+    }
+    if tenants.is_empty() {
+        println!("no tenants");
+        return Ok(());
+    }
+    for tenant in tenants {
+        println!(
+            "{}\t{:?}\t{}\tkeys={}",
+            tenant.scope.id.0,
+            tenant.status,
+            tenant.scope.state_root.display(),
+            tenant.api_keys.len()
+        );
+    }
+    Ok(())
+}
+
+fn suspend_tenant(
+    store: &mut harn_vm::TenantStore,
+    args: OrchestratorTenantSuspendArgs,
+) -> Result<(), String> {
+    let tenant = store.suspend(&args.id)?;
+    if args.json {
+        return print_json(&tenant);
+    }
+    println!("suspended tenant {}", tenant.scope.id.0);
+    Ok(())
+}
+
+fn delete_tenant(
+    store: &mut harn_vm::TenantStore,
+    args: OrchestratorTenantDeleteArgs,
+) -> Result<(), String> {
+    if !args.confirm {
+        return Err("tenant delete is destructive; pass --confirm".to_string());
+    }
+    let tenant = store.delete(&args.id)?;
+    if args.json {
+        return print_json(&tenant);
+    }
+    println!("deleted tenant {}", tenant.scope.id.0);
+    Ok(())
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -34,6 +34,7 @@ pub mod stdlib;
 pub mod stdlib_modules;
 pub mod store;
 pub(crate) mod synchronization;
+pub mod tenant;
 pub mod tool_annotations;
 pub mod tracing;
 pub mod triggers;
@@ -121,6 +122,13 @@ pub use stdlib::{
     register_agent_stdlib, register_core_stdlib, register_io_stdlib, register_vm_stdlib,
 };
 pub use store::register_store_builtins;
+pub use tenant::{
+    tenant_event_topic_prefix, tenant_secret_namespace, tenant_topic, validate_tenant_id, ApiKeyId,
+    TenantApiKeyRecord, TenantBudget, TenantEventLog, TenantRecord, TenantRegistrySnapshot,
+    TenantResolutionError, TenantScope, TenantSecretProvider, TenantStatus, TenantStore,
+    TENANT_EVENT_TOPIC_PREFIX, TENANT_REGISTRY_DIR, TENANT_REGISTRY_FILE,
+    TENANT_SECRET_NAMESPACE_PREFIX,
+};
 pub use triggers::{
     append_dispatch_cancel_request, begin_in_flight, binding_autonomy_budget_would_exceed,
     binding_budget_would_exceed, binding_version_as_of, clear_dispatcher_state,

--- a/crates/harn-vm/src/tenant.rs
+++ b/crates/harn-vm/src/tenant.rs
@@ -1,0 +1,584 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+use time::OffsetDateTime;
+
+use crate::event_log::{
+    AnyEventLog, CompactReport, ConsumerId, EventId, EventLog, EventLogDescription, LogError,
+    LogEvent, Topic,
+};
+use crate::orchestration::CapabilityPolicy;
+use crate::secrets::{
+    RotationHandle, SecretBytes, SecretError, SecretId, SecretMeta, SecretProvider,
+};
+use crate::TenantId;
+
+pub const TENANT_REGISTRY_DIR: &str = "tenants";
+pub const TENANT_REGISTRY_FILE: &str = "registry.json";
+pub const TENANT_SECRET_NAMESPACE_PREFIX: &str = "harn.tenant.";
+pub const TENANT_EVENT_TOPIC_PREFIX: &str = "tenant.";
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ApiKeyId(pub String);
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TenantBudget {
+    pub daily_cost_usd: Option<f64>,
+    pub hourly_cost_usd: Option<f64>,
+    pub ingest_per_minute: Option<u32>,
+    pub event_log_size_bytes: u64,
+    pub in_flight_dispatches: u32,
+    pub dlq_entries: u32,
+}
+
+impl Default for TenantBudget {
+    fn default() -> Self {
+        Self {
+            daily_cost_usd: None,
+            hourly_cost_usd: None,
+            ingest_per_minute: None,
+            event_log_size_bytes: 10 * 1024 * 1024 * 1024,
+            in_flight_dispatches: 100,
+            dlq_entries: 10_000,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TenantScope {
+    pub id: TenantId,
+    pub state_root: PathBuf,
+    pub secret_namespace: String,
+    pub event_log_topic_prefix: String,
+    pub capability_ceiling: CapabilityPolicy,
+    pub budget: TenantBudget,
+    pub api_key_ids: Vec<ApiKeyId>,
+}
+
+impl TenantScope {
+    pub fn new(id: TenantId, orchestrator_state_root: impl AsRef<Path>) -> Result<Self, String> {
+        validate_tenant_id(&id.0)?;
+        let state_root = orchestrator_state_root
+            .as_ref()
+            .join(TENANT_REGISTRY_DIR)
+            .join(&id.0);
+        Ok(Self {
+            secret_namespace: tenant_secret_namespace(&id),
+            event_log_topic_prefix: tenant_event_topic_prefix(&id),
+            id,
+            state_root,
+            capability_ceiling: CapabilityPolicy::default(),
+            budget: TenantBudget::default(),
+            api_key_ids: Vec::new(),
+        })
+    }
+
+    pub fn topic(&self, topic: &Topic) -> Result<Topic, LogError> {
+        tenant_topic(&self.id, topic)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TenantStatus {
+    Active,
+    Suspended,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TenantApiKeyRecord {
+    pub id: ApiKeyId,
+    pub hash_sha256: String,
+    pub prefix: String,
+    pub created_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TenantRecord {
+    pub scope: TenantScope,
+    pub status: TenantStatus,
+    pub created_at: String,
+    pub suspended_at: Option<String>,
+    pub api_keys: Vec<TenantApiKeyRecord>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TenantRegistrySnapshot {
+    pub tenants: Vec<TenantRecord>,
+}
+
+#[derive(Clone, Debug)]
+pub struct TenantStore {
+    state_dir: PathBuf,
+    tenants: BTreeMap<String, TenantRecord>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TenantResolutionError {
+    Unknown,
+    Suspended(TenantId),
+}
+
+impl TenantStore {
+    pub fn load(state_dir: impl AsRef<Path>) -> Result<Self, String> {
+        let state_dir = state_dir.as_ref().to_path_buf();
+        let path = registry_path(&state_dir);
+        if !path.is_file() {
+            return Ok(Self {
+                state_dir,
+                tenants: BTreeMap::new(),
+            });
+        }
+        let content = std::fs::read_to_string(&path)
+            .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+        let snapshot: TenantRegistrySnapshot = serde_json::from_str(&content)
+            .map_err(|error| format!("failed to parse {}: {error}", path.display()))?;
+        let tenants = snapshot
+            .tenants
+            .into_iter()
+            .map(|record| (record.scope.id.0.clone(), record))
+            .collect();
+        Ok(Self { state_dir, tenants })
+    }
+
+    pub fn save(&self) -> Result<(), String> {
+        let dir = self.state_dir.join(TENANT_REGISTRY_DIR);
+        std::fs::create_dir_all(&dir)
+            .map_err(|error| format!("failed to create {}: {error}", dir.display()))?;
+        let snapshot = TenantRegistrySnapshot {
+            tenants: self.list().to_vec(),
+        };
+        let encoded = serde_json::to_string_pretty(&snapshot).map_err(|error| error.to_string())?;
+        let path = registry_path(&self.state_dir);
+        std::fs::write(&path, encoded)
+            .map_err(|error| format!("failed to write {}: {error}", path.display()))
+    }
+
+    pub fn create_tenant(
+        &mut self,
+        id: impl Into<String>,
+        budget: TenantBudget,
+    ) -> Result<(TenantRecord, String), String> {
+        let id = id.into();
+        validate_tenant_id(&id)?;
+        if self.tenants.contains_key(&id) {
+            return Err(format!("tenant '{id}' already exists"));
+        }
+        let api_key = generate_api_key(&id);
+        let api_key_id = ApiKeyId(format!("key_{}", uuid::Uuid::now_v7()));
+        let created_at = now_rfc3339();
+        let mut scope = TenantScope::new(TenantId::new(id.clone()), &self.state_dir)?;
+        scope.budget = budget;
+        scope.api_key_ids.push(api_key_id.clone());
+        std::fs::create_dir_all(&scope.state_root).map_err(|error| {
+            format!(
+                "failed to create tenant state dir {}: {error}",
+                scope.state_root.display()
+            )
+        })?;
+        let record = TenantRecord {
+            scope,
+            status: TenantStatus::Active,
+            created_at: created_at.clone(),
+            suspended_at: None,
+            api_keys: vec![TenantApiKeyRecord {
+                id: api_key_id,
+                hash_sha256: api_key_hash(&api_key),
+                prefix: api_key_prefix(&api_key),
+                created_at,
+            }],
+        };
+        self.tenants.insert(id, record.clone());
+        self.save()?;
+        Ok((record, api_key))
+    }
+
+    pub fn list(&self) -> Vec<TenantRecord> {
+        self.tenants.values().cloned().collect()
+    }
+
+    pub fn get(&self, id: &str) -> Option<&TenantRecord> {
+        self.tenants.get(id)
+    }
+
+    pub fn suspend(&mut self, id: &str) -> Result<TenantRecord, String> {
+        let record = self
+            .tenants
+            .get_mut(id)
+            .ok_or_else(|| format!("unknown tenant '{id}'"))?;
+        record.status = TenantStatus::Suspended;
+        record.suspended_at = Some(now_rfc3339());
+        let record = record.clone();
+        self.save()?;
+        Ok(record)
+    }
+
+    pub fn delete(&mut self, id: &str) -> Result<TenantRecord, String> {
+        let record = self
+            .tenants
+            .remove(id)
+            .ok_or_else(|| format!("unknown tenant '{id}'"))?;
+        if record.scope.state_root.exists() {
+            std::fs::remove_dir_all(&record.scope.state_root).map_err(|error| {
+                format!(
+                    "failed to remove tenant state dir {}: {error}",
+                    record.scope.state_root.display()
+                )
+            })?;
+        }
+        self.save()?;
+        Ok(record)
+    }
+
+    pub fn resolve_api_key(&self, candidate: &str) -> Result<TenantScope, TenantResolutionError> {
+        let candidate_hash = api_key_hash(candidate);
+        for record in self.tenants.values() {
+            let matched = record.api_keys.iter().any(|key| {
+                key.hash_sha256
+                    .as_bytes()
+                    .ct_eq(candidate_hash.as_bytes())
+                    .into()
+            });
+            if matched {
+                return match record.status {
+                    TenantStatus::Active => Ok(record.scope.clone()),
+                    TenantStatus::Suspended => {
+                        Err(TenantResolutionError::Suspended(record.scope.id.clone()))
+                    }
+                };
+            }
+        }
+        Err(TenantResolutionError::Unknown)
+    }
+}
+
+pub struct TenantEventLog {
+    inner: Arc<AnyEventLog>,
+    scope: TenantScope,
+}
+
+impl TenantEventLog {
+    pub fn new(inner: Arc<AnyEventLog>, scope: TenantScope) -> Self {
+        Self { inner, scope }
+    }
+
+    pub fn scope(&self) -> &TenantScope {
+        &self.scope
+    }
+
+    fn scoped_topic(&self, topic: &Topic) -> Result<Topic, LogError> {
+        if topic.as_str().starts_with(TENANT_EVENT_TOPIC_PREFIX) {
+            if topic
+                .as_str()
+                .starts_with(&self.scope.event_log_topic_prefix)
+            {
+                return Ok(topic.clone());
+            }
+            return Err(LogError::InvalidTopic(format!(
+                "topic '{}' is outside tenant scope '{}'",
+                topic.as_str(),
+                self.scope.id.0
+            )));
+        }
+        self.scope.topic(topic)
+    }
+}
+
+impl EventLog for TenantEventLog {
+    fn describe(&self) -> EventLogDescription {
+        self.inner.describe()
+    }
+
+    async fn append(&self, topic: &Topic, event: LogEvent) -> Result<EventId, LogError> {
+        self.inner.append(&self.scoped_topic(topic)?, event).await
+    }
+
+    async fn flush(&self) -> Result<(), LogError> {
+        self.inner.flush().await
+    }
+
+    async fn read_range(
+        &self,
+        topic: &Topic,
+        from: Option<EventId>,
+        limit: usize,
+    ) -> Result<Vec<(EventId, LogEvent)>, LogError> {
+        self.inner
+            .read_range(&self.scoped_topic(topic)?, from, limit)
+            .await
+    }
+
+    async fn subscribe(
+        self: Arc<Self>,
+        topic: &Topic,
+        from: Option<EventId>,
+    ) -> Result<BoxStream<'static, Result<(EventId, LogEvent), LogError>>, LogError> {
+        self.inner
+            .clone()
+            .subscribe(&self.scoped_topic(topic)?, from)
+            .await
+    }
+
+    async fn ack(
+        &self,
+        topic: &Topic,
+        consumer: &ConsumerId,
+        up_to: EventId,
+    ) -> Result<(), LogError> {
+        self.inner
+            .ack(&self.scoped_topic(topic)?, consumer, up_to)
+            .await
+    }
+
+    async fn consumer_cursor(
+        &self,
+        topic: &Topic,
+        consumer: &ConsumerId,
+    ) -> Result<Option<EventId>, LogError> {
+        self.inner
+            .consumer_cursor(&self.scoped_topic(topic)?, consumer)
+            .await
+    }
+
+    async fn latest(&self, topic: &Topic) -> Result<Option<EventId>, LogError> {
+        self.inner.latest(&self.scoped_topic(topic)?).await
+    }
+
+    async fn compact(&self, topic: &Topic, before: EventId) -> Result<CompactReport, LogError> {
+        self.inner.compact(&self.scoped_topic(topic)?, before).await
+    }
+}
+
+pub struct TenantSecretProvider {
+    inner: Arc<dyn SecretProvider>,
+    scope: TenantScope,
+}
+
+impl TenantSecretProvider {
+    pub fn new(inner: Arc<dyn SecretProvider>, scope: TenantScope) -> Self {
+        Self { inner, scope }
+    }
+
+    fn scoped_id(&self, id: &SecretId) -> Result<SecretId, SecretError> {
+        if id.namespace == self.scope.secret_namespace {
+            return Ok(id.clone());
+        }
+        if id.namespace.starts_with(TENANT_SECRET_NAMESPACE_PREFIX) {
+            return Err(SecretError::NotFound {
+                provider: self.namespace().to_string(),
+                id: id.clone(),
+            });
+        }
+        Ok(SecretId {
+            namespace: self.scope.secret_namespace.clone(),
+            name: id.name.clone(),
+            version: id.version.clone(),
+        })
+    }
+}
+
+#[async_trait]
+impl SecretProvider for TenantSecretProvider {
+    async fn get(&self, id: &SecretId) -> Result<SecretBytes, SecretError> {
+        self.inner.get(&self.scoped_id(id)?).await
+    }
+
+    async fn put(&self, id: &SecretId, value: SecretBytes) -> Result<(), SecretError> {
+        self.inner.put(&self.scoped_id(id)?, value).await
+    }
+
+    async fn rotate(&self, id: &SecretId) -> Result<RotationHandle, SecretError> {
+        self.inner.rotate(&self.scoped_id(id)?).await
+    }
+
+    async fn list(&self, prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError> {
+        self.inner.list(&self.scoped_id(prefix)?).await
+    }
+
+    fn namespace(&self) -> &str {
+        &self.scope.secret_namespace
+    }
+
+    fn supports_versions(&self) -> bool {
+        self.inner.supports_versions()
+    }
+}
+
+pub fn tenant_event_topic_prefix(id: &TenantId) -> String {
+    format!("{TENANT_EVENT_TOPIC_PREFIX}{}.", id.0)
+}
+
+pub fn tenant_secret_namespace(id: &TenantId) -> String {
+    format!("{TENANT_SECRET_NAMESPACE_PREFIX}{}", id.0)
+}
+
+pub fn tenant_topic(id: &TenantId, topic: &Topic) -> Result<Topic, LogError> {
+    validate_tenant_id(&id.0).map_err(LogError::InvalidTopic)?;
+    let prefix = tenant_event_topic_prefix(id);
+    if topic.as_str().starts_with(&prefix) {
+        return Ok(topic.clone());
+    }
+    if topic.as_str().starts_with(TENANT_EVENT_TOPIC_PREFIX) {
+        return Err(LogError::InvalidTopic(format!(
+            "topic '{}' is outside tenant scope '{}'",
+            topic.as_str(),
+            id.0
+        )));
+    }
+    Topic::new(format!("{prefix}{}", topic.as_str()))
+}
+
+pub fn validate_tenant_id(id: &str) -> Result<(), String> {
+    if id.trim().is_empty() {
+        return Err("tenant id cannot be empty".to_string());
+    }
+    if !id
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
+    {
+        return Err(format!(
+            "tenant id '{id}' contains unsupported characters; use ASCII letters, numbers, '_' or '-'"
+        ));
+    }
+    Ok(())
+}
+
+fn registry_path(state_dir: &Path) -> PathBuf {
+    state_dir
+        .join(TENANT_REGISTRY_DIR)
+        .join(TENANT_REGISTRY_FILE)
+}
+
+fn generate_api_key(id: &str) -> String {
+    let random: [u8; 32] = rand::random();
+    format!("harn_tenant_{id}_{}", hex::encode(random))
+}
+
+fn api_key_hash(value: &str) -> String {
+    hex::encode(Sha256::digest(value.as_bytes()))
+}
+
+fn api_key_prefix(value: &str) -> String {
+    value.chars().take(18).collect()
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::event_log::{EventLog, MemoryEventLog};
+
+    #[tokio::test]
+    async fn tenant_event_log_enforces_topic_prefix() {
+        let inner = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(8)));
+        let scope =
+            TenantScope::new(TenantId::new("tenant-a"), std::env::temp_dir()).expect("scope");
+        let tenant_log = Arc::new(TenantEventLog::new(inner.clone(), scope));
+        let base = Topic::new("trigger.outbox").unwrap();
+
+        tenant_log
+            .append(&base, LogEvent::new("ok", serde_json::json!({"n": 1})))
+            .await
+            .unwrap();
+
+        let scoped = Topic::new("tenant.tenant-a.trigger.outbox").unwrap();
+        assert_eq!(inner.read_range(&scoped, None, 10).await.unwrap().len(), 1);
+        let other = Topic::new("tenant.tenant-b.trigger.outbox").unwrap();
+        assert!(tenant_log
+            .append(&other, LogEvent::new("bad", serde_json::json!({})))
+            .await
+            .is_err());
+    }
+
+    struct MemorySecretProvider {
+        namespace: String,
+        values: Mutex<BTreeMap<SecretId, SecretBytes>>,
+    }
+
+    #[async_trait]
+    impl SecretProvider for MemorySecretProvider {
+        async fn get(&self, id: &SecretId) -> Result<SecretBytes, SecretError> {
+            self.values
+                .lock()
+                .expect("secret map")
+                .get(id)
+                .map(SecretBytes::reborrow)
+                .ok_or_else(|| SecretError::NotFound {
+                    provider: self.namespace.clone(),
+                    id: id.clone(),
+                })
+        }
+
+        async fn put(&self, id: &SecretId, value: SecretBytes) -> Result<(), SecretError> {
+            self.values
+                .lock()
+                .expect("secret map")
+                .insert(id.clone(), value);
+            Ok(())
+        }
+
+        async fn rotate(&self, _id: &SecretId) -> Result<RotationHandle, SecretError> {
+            Err(SecretError::Unsupported {
+                provider: self.namespace.clone(),
+                operation: "rotate",
+            })
+        }
+
+        async fn list(&self, _prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError> {
+            Ok(Vec::new())
+        }
+
+        fn namespace(&self) -> &str {
+            &self.namespace
+        }
+
+        fn supports_versions(&self) -> bool {
+            false
+        }
+    }
+
+    #[tokio::test]
+    async fn tenant_secret_provider_rescopes_and_denies_cross_tenant_ids() {
+        let inner = Arc::new(MemorySecretProvider {
+            namespace: "global".to_string(),
+            values: Mutex::new(BTreeMap::new()),
+        });
+        let scope =
+            TenantScope::new(TenantId::new("tenant-a"), std::env::temp_dir()).expect("scope");
+        let provider = TenantSecretProvider::new(inner.clone(), scope.clone());
+
+        provider
+            .put(
+                &SecretId::new("github", "webhook"),
+                SecretBytes::from("a-secret"),
+            )
+            .await
+            .unwrap();
+
+        let scoped_id = SecretId::new(scope.secret_namespace, "webhook");
+        let value = inner.get(&scoped_id).await.unwrap();
+        value.with_exposed(|bytes| assert_eq!(bytes, b"a-secret"));
+
+        let cross = SecretId::new("harn.tenant.tenant-b", "webhook");
+        assert!(provider.get(&cross).await.is_err());
+    }
+}

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -673,8 +673,7 @@ impl Dispatcher {
         event: TriggerEvent,
         parent_headers: Option<&BTreeMap<String, String>>,
     ) -> Result<u64, DispatchError> {
-        let topic = Topic::new(TRIGGER_INBOX_ENVELOPES_TOPIC)
-            .expect("static trigger inbox envelopes topic is valid");
+        let topic = topic_for_event(&event, TRIGGER_INBOX_ENVELOPES_TOPIC)?;
         let trigger_id_for_metrics = trigger_id.clone();
         let mut headers = parent_headers.cloned().unwrap_or_default();
         headers.extend(event_headers(&event, None, None, None));
@@ -3912,8 +3911,7 @@ impl Dispatcher {
         payload: serde_json::Value,
         replay_of_event_id: Option<&String>,
     ) -> Result<(), DispatchError> {
-        let topic = Topic::new(topic_name)
-            .expect("static trigger dispatcher topic names should always be valid");
+        let topic = topic_for_event(event, topic_name)?;
         let headers = event_headers(event, binding, attempt, replay_of_event_id);
         self.event_log
             .append(&topic, LogEvent::new(kind, payload).with_headers(headers))
@@ -4092,8 +4090,7 @@ pub async fn enqueue_trigger_event<L: EventLog + ?Sized>(
     event_log: &L,
     event: &TriggerEvent,
 ) -> Result<u64, DispatchError> {
-    let topic = Topic::new(TRIGGER_INBOX_ENVELOPES_TOPIC)
-        .expect("static trigger.inbox.envelopes topic is valid");
+    let topic = topic_for_event(event, TRIGGER_INBOX_ENVELOPES_TOPIC)?;
     let headers = event_headers(event, None, None, None);
     let payload =
         serde_json::to_value(event).map_err(|error| DispatchError::Serde(error.to_string()))?;
@@ -4516,6 +4513,9 @@ fn event_headers(
     if let Some(replay_of_event_id) = replay_of_event_id {
         headers.insert("replay_of_event_id".to_string(), replay_of_event_id.clone());
     }
+    if let Some(tenant_id) = event.tenant_id.as_ref() {
+        headers.insert("tenant_id".to_string(), tenant_id.0.clone());
+    }
     if let Some(binding) = binding {
         headers.insert("trigger_id".to_string(), binding.id.as_str().to_string());
         headers.insert("binding_key".to_string(), binding.binding_key());
@@ -4528,6 +4528,15 @@ fn event_headers(
         headers.insert("attempt".to_string(), attempt.to_string());
     }
     headers
+}
+
+fn topic_for_event(event: &TriggerEvent, topic_name: &str) -> Result<Topic, DispatchError> {
+    let topic = Topic::new(topic_name)
+        .expect("static trigger dispatcher topic names should always be valid");
+    match event.tenant_id.as_ref() {
+        Some(tenant_id) => crate::tenant_topic(tenant_id, &topic).map_err(DispatchError::from),
+        None => Ok(topic),
+    }
 }
 
 fn worker_queue_priority(

--- a/crates/harn-vm/src/triggers/test_util/mod.rs
+++ b/crates/harn-vm/src/triggers/test_util/mod.rs
@@ -1262,6 +1262,47 @@ impl TriggerTestHarness {
     async fn multi_tenant_isolation_stub(self) -> Result<TriggerHarnessResult, String> {
         let tenant_a = synthetic_event("tenant.event", "tenant-a", Some("tenant-a"));
         let tenant_b = synthetic_event("tenant.event", "tenant-b", Some("tenant-b"));
+        let event_log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(16)));
+        let scope_a = crate::TenantScope::new(TenantId::new("tenant-a"), std::env::temp_dir())?;
+        let scope_b = crate::TenantScope::new(TenantId::new("tenant-b"), std::env::temp_dir())?;
+        let tenant_a_log = Arc::new(crate::TenantEventLog::new(
+            event_log.clone(),
+            scope_a.clone(),
+        ));
+        let tenant_b_log = Arc::new(crate::TenantEventLog::new(
+            event_log.clone(),
+            scope_b.clone(),
+        ));
+        let topic = Topic::new(crate::TRIGGER_OUTBOX_TOPIC).map_err(|error| error.to_string())?;
+        tenant_a_log
+            .append(
+                &topic,
+                LogEvent::new("tenant.event", serde_json::to_value(&tenant_a).unwrap()),
+            )
+            .await
+            .map_err(|error| error.to_string())?;
+        tenant_b_log
+            .append(
+                &topic,
+                LogEvent::new("tenant.event", serde_json::to_value(&tenant_b).unwrap()),
+            )
+            .await
+            .map_err(|error| error.to_string())?;
+        let cross_tenant_denied = tenant_a_log
+            .append(
+                &scope_b.topic(&topic).map_err(|error| error.to_string())?,
+                LogEvent::new("tenant.event", serde_json::to_value(&tenant_b).unwrap()),
+            )
+            .await
+            .is_err();
+        let tenant_a_events = tenant_a_log
+            .read_range(&topic, None, 16)
+            .await
+            .map_err(|error| error.to_string())?;
+        let tenant_b_events = tenant_b_log
+            .read_range(&topic, None, 16)
+            .await
+            .map_err(|error| error.to_string())?;
         self.connector_registry.record_event(
             "tenant.fixture",
             1,
@@ -1279,17 +1320,25 @@ impl TriggerTestHarness {
         let emitted = self.connector_registry.emitted();
         Ok(TriggerHarnessResult {
             fixture: "multi_tenant_isolation_stub".to_string(),
-            ok: emitted.len() == 2,
-            stub: true,
-            summary: "single-tenant orchestrator remains the product reality; the harness only asserts tenant ids stay partitioned in envelopes".to_string(),
+            ok: emitted.len() == 2
+                && tenant_a_events.len() == 1
+                && tenant_b_events.len() == 1
+                && cross_tenant_denied,
+            stub: false,
+            summary:
+                "tenant-scoped EventLog wrappers keep tenant trigger envelopes on isolated topics"
+                    .to_string(),
             emitted,
             attempts: Vec::new(),
             dlq: Vec::new(),
             alerts: Vec::new(),
             bindings: Vec::new(),
-            notes: vec!["stub fixture: orchestrator multi-tenant routing is still pending".to_string()],
+            notes: Vec::new(),
             details: json!({
                 "cross_tenant_leak": false,
+                "cross_tenant_denied": cross_tenant_denied,
+                "tenant_a_events": tenant_a_events.len(),
+                "tenant_b_events": tenant_b_events.len(),
             }),
         })
     }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -76,6 +76,7 @@
 - [Worker dispatch](./orchestrator/worker-dispatch.md)
 - [Orchestrator observability](./orchestrator/observability.md)
 - [Orchestrator secrets](./orchestrator/secrets.md)
+- [Multi-tenant orchestrator](./orchestrator/multi-tenant.md)
 - [Connector OAuth](./orchestrator/oauth.md)
 - [Deploy to Render](./deploy/render.md)
 - [Deploy to Fly.io](./deploy/fly.md)

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -17,8 +17,9 @@ Today, the command:
 
 Current limitations:
 
-- `multi-tenant` returns a clear not-implemented error that points at
-  `O-12 #190`
+- Multi-tenant mode isolates listener ingress, tenant-scoped secrets, and
+  trigger EventLog topics. Shared scheduler/provider objects remain
+  orchestrator-global.
 
 ## Command
 
@@ -90,6 +91,11 @@ rotating file at `<state-dir>/logs/orchestrator.log`. Set
 `HARN_OTEL_ENDPOINT` to export OTLP traces. See
 [Orchestrator observability](./orchestrator/observability.md) for metric names,
 log configuration, and the dashboard example.
+
+Use `--role multi-tenant` with `harn orchestrator tenant` to provision API-key
+backed tenants, tenant-prefixed EventLog topics, and tenant-scoped secrets. See
+[Multi-tenant orchestrator](./orchestrator/multi-tenant.md) for the tenant
+lifecycle and isolation model.
 
 Hot reload now supports four equivalent entrypoints:
 

--- a/docs/src/orchestrator/multi-tenant.md
+++ b/docs/src/orchestrator/multi-tenant.md
@@ -1,0 +1,64 @@
+# Multi-tenant orchestrator
+
+Harn can run the orchestrator listener in a tenant-aware mode:
+
+```bash
+harn orchestrator tenant create acme --state-dir .harn/orchestrator
+harn orchestrator serve --role multi-tenant --state-dir .harn/orchestrator
+```
+
+Tenant records live under `<state-dir>/tenants/registry.json`. Each tenant gets:
+
+- a state root at `<state-dir>/tenants/<tenant-id>/`
+- a secret namespace named `harn.tenant.<tenant-id>`
+- event-log topics prefixed with `tenant.<tenant-id>.`
+- an initial API key mapped to that tenant
+- optional daily/hourly budget metadata and an ingest rate limit
+
+Tenant ids may contain ASCII letters, numbers, `_`, and `-`.
+
+## Request Resolution
+
+In multi-tenant mode every inbound trigger request must resolve to a tenant. The preferred mechanism
+is a tenant API key in `X-API-Key` or `Authorization: Bearer <key>`. Path-scoped ingress is also
+supported for webhook routing:
+
+```text
+/hooks/tenant/<tenant-id>/<configured-trigger-path>
+/tenant/<tenant-id>/<configured-trigger-path>
+```
+
+If both an API key and path tenant are present, they must name the same tenant. A mismatch returns
+`403` and appends `tenant_access_denied` to `orchestrator.tenant.audit`. Suspended tenants return
+`402` with state preserved.
+
+## Isolation
+
+Tenant-scoped ingress attaches `tenant_id` to normalized trigger events. Pending and inbox EventLog
+records for those events are written to tenant-prefixed topics such as:
+
+```text
+tenant.acme.orchestrator.triggers.pending
+tenant.acme.trigger.inbox.envelopes
+tenant.acme.trigger.outbox
+tenant.acme.trigger.attempts
+tenant.acme.trigger.dlq
+```
+
+The runtime also exposes `TenantEventLog`, which transparently prefixes unscoped topic names and
+rejects attempts to append or read another tenant's `tenant.<id>.` topic.
+
+Signing secrets are loaded through a tenant-scoped provider in multi-tenant requests. A trigger that
+references `github/webhook-signing-secret` resolves that name inside `harn.tenant.<tenant-id>`; an
+explicit `harn.tenant.<other-id>/...` lookup is rejected.
+
+## Tenant Lifecycle
+
+```bash
+harn orchestrator tenant ls --state-dir .harn/orchestrator
+harn orchestrator tenant suspend acme --state-dir .harn/orchestrator
+harn orchestrator tenant delete acme --confirm --state-dir .harn/orchestrator
+```
+
+`delete` removes the tenant registry entry and its state directory. `suspend` keeps state intact and
+causes future ingress for that tenant to return `402`.


### PR DESCRIPTION
## Summary

Implements the O-12 multi-tenant orchestrator foundation:

- adds persisted tenant registry/lifecycle commands under `harn orchestrator tenant`
- adds `TenantScope`, `TenantEventLog`, `TenantSecretProvider`, tenant budgets, API key hashing/resolution, and topic/namespace helpers
- enables `--role multi-tenant` instead of returning the old not-implemented error
- resolves ingress tenants from API keys or `/hooks/tenant/<id>/...` / `/tenant/<id>/...` paths, rejects cross-tenant mismatches with audit events, and returns 402 for suspended tenants
- writes tenant trigger pending/inbox/dispatch topics under `tenant.<id>.` and scopes signing-secret lookup to `harn.tenant.<id>`
- documents lifecycle, request resolution, and isolation behavior

Fixes #190.

## Validation

- `cargo test -p harn-cli test_parses_orchestrator_tenant_create_args -- --nocapture`
- `cargo test -p harn-vm tenant_ -- --nocapture`
- `cargo check -p harn-vm -p harn-cli`
- tenant CLI smoke: create/list tenant with JSON output
- `cargo run --quiet --bin harn -- test conformance --filter trigger_harness_multi_tenant_isolation_stub`
- pre-commit hook: fmt, clippy, generated keyword check, markdown lint
- pre-push hook: 2049 nextest tests passed, markdown lint
