### PR TITLE
[codex] Publish OpenTrustGraph spec artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ granular archaeology.
   (version range), and `docs_url`, adds `harn package new <name>`,
   `harn package validate`, and `harn package publish --dry-run`, and
   documents the authoring flow in `docs/src/package-authoring.md`.
+- **OpenTrustGraph v0 spec artifact (#449).** Publishes
+  `opentrustgraph-spec/` as the canonical v0 artifact inside the Harn
+  repo with a chain-export JSON Schema, approval-evidence rules,
+  valid tier-transition fixture, and an invalid missing-approval
+  fixture. Fixtures are deterministic chain envelopes and are
+  validated from Harn runtime tests; the artifact is cross-linked
+  from docs, portal docs, and the README for Harn Cloud and
+  supervision references.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ provider/runtime code: products declare workflows, policies, capabilities,
 and UI hooks, while Harn owns transcripts, context assembly, retries,
 tool routing, persistence, replay, and provider normalization.
 
+Harn also emits portable `opentrustgraph/v0` trust records for autonomy
+decisions, approval gates, and tier transitions. The public schema and fixtures
+live in [`opentrustgraph-spec/`](./opentrustgraph-spec/).
+
 ## Install
 
 From a GitHub release:

--- a/crates/harn-vm/src/trust_graph.rs
+++ b/crates/harn-vm/src/trust_graph.rs
@@ -645,6 +645,36 @@ mod tests {
     use crate::event_log::MemoryEventLog;
     use time::Duration;
 
+    const RECORD_SCHEMA_JSON: &str =
+        include_str!("../../../opentrustgraph-spec/schemas/trust-record.v0.schema.json");
+    const CHAIN_SCHEMA_JSON: &str =
+        include_str!("../../../opentrustgraph-spec/schemas/trust-chain.v0.schema.json");
+    const VALID_DECISION_CHAIN_JSON: &str =
+        include_str!("../../../opentrustgraph-spec/fixtures/valid/decision-chain.json");
+    const VALID_TIER_TRANSITION_JSON: &str =
+        include_str!("../../../opentrustgraph-spec/fixtures/valid/tier-transition.json");
+    const INVALID_TAMPERED_CHAIN_JSON: &str =
+        include_str!("../../../opentrustgraph-spec/fixtures/invalid/tampered-chain.json");
+    const INVALID_MISSING_APPROVAL_JSON: &str =
+        include_str!("../../../opentrustgraph-spec/fixtures/invalid/missing-approval.json");
+
+    #[derive(Debug, serde::Deserialize)]
+    struct TrustChainFixture {
+        schema: String,
+        chain: TrustChainFixtureMetadata,
+        records: Vec<TrustRecord>,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct TrustChainFixtureMetadata {
+        topic: String,
+        total: u64,
+        root_hash: Option<String>,
+        verified: bool,
+        generated_at: String,
+        producer: BTreeMap<String, serde_json::Value>,
+    }
+
     #[tokio::test]
     async fn append_and_query_round_trip() {
         let log: Arc<AnyEventLog> = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(16)));
@@ -779,7 +809,7 @@ mod tests {
     #[tokio::test]
     async fn query_limit_keeps_newest_matching_records() {
         let log: Arc<AnyEventLog> = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(16)));
-        let base = OffsetDateTime::now_utc();
+        let base = OffsetDateTime::from_unix_timestamp(1_775_000_000).unwrap();
         for (offset, action) in ["first", "second", "third"].into_iter().enumerate() {
             let mut record = TrustRecord::new(
                 "bot",
@@ -834,5 +864,243 @@ mod tests {
         assert_eq!(grouped[0].records.len(), 2);
         assert_eq!(grouped[0].records[1].action, "third");
         assert_eq!(grouped[1].trace_id, "trace-2");
+    }
+
+    #[test]
+    fn opentrustgraph_schema_files_are_parseable_and_match_runtime_enums() {
+        let record_schema: serde_json::Value = serde_json::from_str(RECORD_SCHEMA_JSON).unwrap();
+        let chain_schema: serde_json::Value = serde_json::from_str(CHAIN_SCHEMA_JSON).unwrap();
+
+        assert_eq!(
+            record_schema["properties"]["schema"]["const"],
+            serde_json::json!(OPENTRUSTGRAPH_SCHEMA_V0)
+        );
+        assert_eq!(
+            chain_schema["properties"]["schema"]["const"],
+            serde_json::json!("opentrustgraph-chain/v0")
+        );
+
+        let outcomes = record_schema["properties"]["outcome"]["enum"]
+            .as_array()
+            .unwrap();
+        for outcome in [
+            TrustOutcome::Success,
+            TrustOutcome::Failure,
+            TrustOutcome::Denied,
+            TrustOutcome::Timeout,
+        ] {
+            assert!(outcomes.contains(&serde_json::json!(outcome.as_str())));
+        }
+
+        let tiers = record_schema["properties"]["autonomy_tier"]["enum"]
+            .as_array()
+            .unwrap();
+        for tier in [
+            AutonomyTier::Shadow,
+            AutonomyTier::Suggest,
+            AutonomyTier::ActWithApproval,
+            AutonomyTier::ActAuto,
+        ] {
+            assert!(tiers.contains(&serde_json::json!(tier.as_str())));
+        }
+    }
+
+    #[test]
+    fn opentrustgraph_valid_fixtures_match_runtime_contract() {
+        for (name, fixture) in [
+            ("decision-chain", VALID_DECISION_CHAIN_JSON),
+            ("tier-transition", VALID_TIER_TRANSITION_JSON),
+        ] {
+            let fixture = parse_chain_fixture(fixture);
+            let errors = validate_chain_fixture(&fixture);
+            assert!(errors.is_empty(), "{name} errors: {errors:?}");
+        }
+    }
+
+    #[test]
+    fn opentrustgraph_invalid_fixtures_exercise_expected_failures() {
+        let tampered = parse_chain_fixture(INVALID_TAMPERED_CHAIN_JSON);
+        let tampered_errors = validate_chain_fixture(&tampered);
+        assert!(
+            tampered_errors
+                .iter()
+                .any(|error| error.contains("previous_hash mismatch")),
+            "tampered-chain errors: {tampered_errors:?}"
+        );
+        assert!(
+            !tampered_errors
+                .iter()
+                .any(|error| error.contains("entry_hash mismatch")),
+            "tampered-chain should isolate hash-link tampering: {tampered_errors:?}"
+        );
+
+        let missing_approval = parse_chain_fixture(INVALID_MISSING_APPROVAL_JSON);
+        let missing_errors = validate_chain_fixture(&missing_approval);
+        assert!(
+            missing_errors
+                .iter()
+                .any(|error| error.contains("approval required")),
+            "missing-approval errors: {missing_errors:?}"
+        );
+    }
+
+    fn parse_chain_fixture(input: &str) -> TrustChainFixture {
+        serde_json::from_str(input).unwrap()
+    }
+
+    fn validate_chain_fixture(fixture: &TrustChainFixture) -> Vec<String> {
+        let mut errors = Vec::new();
+        if fixture.schema != "opentrustgraph-chain/v0" {
+            errors.push(format!("unsupported chain schema {}", fixture.schema));
+        }
+        if fixture.chain.topic.trim().is_empty() {
+            errors.push("chain topic is empty".to_string());
+        }
+        if fixture.chain.total != fixture.records.len() as u64 {
+            errors.push(format!(
+                "chain total mismatch; expected {}, found {}",
+                fixture.records.len(),
+                fixture.chain.total
+            ));
+        }
+        if fixture
+            .chain
+            .producer
+            .get("name")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .trim()
+            .is_empty()
+        {
+            errors.push("chain producer.name is empty".to_string());
+        }
+        if OffsetDateTime::parse(
+            &fixture.chain.generated_at,
+            &time::format_description::well_known::Rfc3339,
+        )
+        .is_err()
+        {
+            errors.push("chain generated_at is not RFC3339".to_string());
+        }
+
+        for (index, record) in fixture.records.iter().enumerate() {
+            errors.extend(validate_fixture_record_contract(index, record));
+        }
+        errors.extend(validate_fixture_hash_chain(fixture));
+
+        let expected_verified = errors.is_empty();
+        if fixture.chain.verified != expected_verified {
+            errors.push(format!(
+                "chain verified flag mismatch; expected {expected_verified}, found {}",
+                fixture.chain.verified
+            ));
+        }
+        errors
+    }
+
+    fn validate_fixture_record_contract(index: usize, record: &TrustRecord) -> Vec<String> {
+        let mut errors = Vec::new();
+        let label = format!("record {index}");
+        if record.schema != OPENTRUSTGRAPH_SCHEMA_V0 {
+            errors.push(format!("{label}: unsupported schema {}", record.schema));
+        }
+        if record.record_id.trim().is_empty() {
+            errors.push(format!("{label}: record_id is empty"));
+        }
+        if record.agent.trim().is_empty() {
+            errors.push(format!("{label}: agent is empty"));
+        }
+        if record.action.trim().is_empty() {
+            errors.push(format!("{label}: action is empty"));
+        }
+        if record.trace_id.trim().is_empty() {
+            errors.push(format!("{label}: trace_id is empty"));
+        }
+        if !record.entry_hash.starts_with("sha256:") {
+            errors.push(format!("{label}: entry_hash is not sha256-prefixed"));
+        }
+        if let Some(cost_usd) = record.cost_usd {
+            if cost_usd < 0.0 {
+                errors.push(format!("{label}: cost_usd is negative"));
+            }
+        }
+
+        if record.outcome == TrustOutcome::Success
+            && record.autonomy_tier == AutonomyTier::ActWithApproval
+            && approval_required(record)
+        {
+            if record
+                .approver
+                .as_deref()
+                .unwrap_or_default()
+                .trim()
+                .is_empty()
+            {
+                errors.push(format!("{label}: approval required but approver is empty"));
+            }
+            if approval_signature_count(record) == 0 {
+                errors.push(format!(
+                    "{label}: approval required but signatures are empty"
+                ));
+            }
+        }
+
+        errors
+    }
+
+    fn validate_fixture_hash_chain(fixture: &TrustChainFixture) -> Vec<String> {
+        let mut errors = Vec::new();
+        let mut previous_hash: Option<String> = None;
+
+        for (position, record) in fixture.records.iter().enumerate() {
+            let expected_index = position as u64 + 1;
+            if record.chain_index != expected_index {
+                errors.push(format!(
+                    "record {position}: expected chain_index {expected_index}, found {}",
+                    record.chain_index
+                ));
+            }
+            if record.previous_hash != previous_hash {
+                errors.push(format!(
+                    "record {position}: previous_hash mismatch; expected {:?}, found {:?}",
+                    previous_hash, record.previous_hash
+                ));
+            }
+            let expected_hash = compute_trust_record_hash(record).unwrap();
+            if expected_hash != record.entry_hash {
+                errors.push(format!(
+                    "record {position}: entry_hash mismatch; expected {expected_hash}, found {}",
+                    record.entry_hash
+                ));
+            }
+            previous_hash = Some(record.entry_hash.clone());
+        }
+
+        if fixture.chain.root_hash != previous_hash {
+            errors.push(format!(
+                "chain root_hash mismatch; expected {:?}, found {:?}",
+                previous_hash, fixture.chain.root_hash
+            ));
+        }
+        errors
+    }
+
+    fn approval_required(record: &TrustRecord) -> bool {
+        record
+            .metadata
+            .get("approval")
+            .and_then(|approval| approval.get("required"))
+            .and_then(|required| required.as_bool())
+            .unwrap_or(false)
+    }
+
+    fn approval_signature_count(record: &TrustRecord) -> usize {
+        record
+            .metadata
+            .get("approval")
+            .and_then(|approval| approval.get("signatures"))
+            .and_then(|signatures| signatures.as_array())
+            .map(Vec::len)
+            .unwrap_or(0)
     }
 }

--- a/docs/src/portal.md
+++ b/docs/src/portal.md
@@ -111,6 +111,13 @@ The portal is intentionally generic. It does not assume a particular editor,
 client, or host integration. If Harn persisted the run, the portal can inspect
 it.
 
+For autonomy supervision, the portal's trust-graph API exposes the same
+`opentrustgraph/v0` records documented in
+[`opentrustgraph-spec/`](../../opentrustgraph-spec/). Harn Cloud receipt views
+and Burin supervision surfaces can use that artifact as the stable public
+format reference while projecting portal verification metadata into
+`opentrustgraph-chain/v0` exports.
+
 ## Live updates
 
 The portal polls conservatively instead of hammering the run directory:

--- a/docs/src/trust-graph.md
+++ b/docs/src/trust-graph.md
@@ -27,7 +27,11 @@ Each record carries:
 - `metadata`
 
 See [`spec/opentrustgraph.md`](../../spec/opentrustgraph.md) for the normative
-schema, JSON Schema, and sample event stream.
+record model, chain export model, and sample event stream. The small public
+artifact that Harn Cloud receipts, Burin supervision UI planning, and external
+verifiers should link to is
+[`opentrustgraph-spec/`](../../opentrustgraph-spec/). It contains the JSON
+Schema files and conformance fixtures used by Harn's runtime tests.
 
 ## Autonomy tiers
 
@@ -135,4 +139,7 @@ The portal exposes `GET /api/trust-graph` for external UIs. Query parameters
 mirror the CLI filters: `agent`, `action`, `limit`, and `grouped_by_trace`.
 The response includes flat records, optional trace groups, per-agent summary
 rows, the current chain verification report, and the topic names the portal is
-reading.
+reading. A supervision UI can project that response into the
+`opentrustgraph-chain/v0` envelope by using the verification report's topic,
+total, root hash, and verified flag as `chain` metadata and the returned records
+as `records`.

--- a/opentrustgraph-spec/README.md
+++ b/opentrustgraph-spec/README.md
@@ -1,19 +1,63 @@
 # OpenTrustGraph Spec
 
-This directory is the repo-ready seed for the standalone `opentrustgraph-spec`
-repository. It contains the normative v0 JSON Schema and conformance fixtures
-used by Harn's trust-graph runtime.
+This directory is the canonical OpenTrustGraph v0 artifact for Harn. It is
+kept small enough to vendor into Harn today and direct-publish as a standalone
+`burin-labs/opentrustgraph-spec` repository later without changing the format.
+Until that repository exists, the public URL for the artifact is:
+
+<https://github.com/burin-labs/harn/tree/main/opentrustgraph-spec>
 
 OpenTrustGraph records autonomy decisions as append-only, hash-chained events.
 Each record captures the agent, action, optional approver, outcome, trace id,
-effective autonomy tier, and runtime metadata.
+effective autonomy tier, runtime metadata, and hash-chain position. Chain export
+documents wrap those records with enough metadata for Harn Cloud receipts,
+supervision UIs, and third-party verifiers to display the chain root without
+inventing another envelope.
+
+## Version markers
+
+- Trust record: `opentrustgraph/v0`
+- Chain export: `opentrustgraph-chain/v0`
 
 ## Contents
 
 - `schemas/trust-record.v0.schema.json`: JSON Schema for one v0 trust record.
-- `fixtures/valid/decision-chain.json`: a valid two-entry hash chain.
-- `fixtures/invalid/tampered-chain.json`: a chain with an invalid previous hash.
+- `schemas/trust-chain.v0.schema.json`: JSON Schema for a v0 chain export with
+  chain metadata and ordered records.
+- `fixtures/valid/decision-chain.json`: a valid two-entry decision chain.
+- `fixtures/valid/tier-transition.json`: a valid chain showing a tier
+  transition and approval-backed action.
+- `fixtures/invalid/tampered-chain.json`: a chain with a self-consistent record
+  hash but invalid previous-hash linkage.
+- `fixtures/invalid/missing-approval.json`: a record that declares approval was
+  required but omits the approver/signature evidence.
 
-Consumers should validate each record against the schema and then verify the
-chain by recomputing `entry_hash` over the canonical record with `entry_hash`
-removed and comparing each `previous_hash` to the prior entry.
+## Verification contract
+
+Consumers should:
+
+1. Validate the export against `trust-chain.v0.schema.json`.
+2. Validate each record against `trust-record.v0.schema.json`.
+3. Recompute every `entry_hash` over the canonical record with `entry_hash`
+   removed.
+4. Compare each record's `previous_hash` to the prior record's `entry_hash`.
+5. Compare `chain.total` and `chain.root_hash` to the record list.
+
+Harn computes record hashes by serializing the typed `TrustRecord` with
+`entry_hash` removed and hashing the resulting JSON bytes with SHA-256. The
+stored value uses the `sha256:` prefix.
+
+When `metadata.approval.required` is `true` and a successful record runs at
+`act_with_approval`, the record must include a non-empty `approver` and at least
+one signature receipt in `metadata.approval.signatures`.
+
+## Harn integration points
+
+- Runtime events are emitted to `trust_graph` plus `trust_graph.<agent_id>`.
+- `harn trust-graph verify-chain --json` exposes verification metadata that can
+  be projected into the chain export shape.
+- The portal `GET /api/trust-graph` endpoint returns records, summaries, and
+  verification status for local supervision surfaces.
+- Harn Cloud receipts and Burin supervision UI planning should link to this
+  directory or the future standalone repository instead of describing the format
+  informally.

--- a/opentrustgraph-spec/fixtures/invalid/missing-approval.json
+++ b/opentrustgraph-spec/fixtures/invalid/missing-approval.json
@@ -1,0 +1,39 @@
+{
+  "schema": "opentrustgraph-chain/v0",
+  "chain": {
+    "topic": "trust_graph",
+    "total": 1,
+    "root_hash": "sha256:bc337327340a47fa65876090ed7e73218259cb91ca04b9a027670a6bcb9ea5ad",
+    "verified": false,
+    "generated_at": "2026-04-19T20:01:00Z",
+    "producer": {
+      "name": "harn",
+      "version": "0.7.x"
+    }
+  },
+  "records": [
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-2000-7763-9b4b-d2bfe8050001",
+      "agent": "deploy-agent",
+      "action": "deploy.prod",
+      "approver": null,
+      "outcome": "success",
+      "trace_id": "trace_missing_approval_01",
+      "autonomy_tier": "act_with_approval",
+      "timestamp": "2026-04-19T20:00:00Z",
+      "cost_usd": 0.21,
+      "chain_index": 1,
+      "previous_hash": null,
+      "entry_hash": "sha256:bc337327340a47fa65876090ed7e73218259cb91ca04b9a027670a6bcb9ea5ad",
+      "metadata": {
+        "approval": {
+          "required": true,
+          "quorum": 1,
+          "signatures": []
+        },
+        "provider": "github"
+      }
+    }
+  ]
+}

--- a/opentrustgraph-spec/fixtures/invalid/tampered-chain.json
+++ b/opentrustgraph-spec/fixtures/invalid/tampered-chain.json
@@ -1,38 +1,54 @@
-[
-  {
-    "schema": "opentrustgraph/v0",
-    "record_id": "01966f4c-0f31-7b5d-b44b-f7f8e7e1d384",
-    "agent": "github-triage-bot",
-    "action": "github.issue.opened",
-    "approver": null,
-    "outcome": "success",
-    "trace_id": "trace_invalid_01",
-    "autonomy_tier": "suggest",
-    "timestamp": "2026-04-19T18:42:11Z",
-    "cost_usd": null,
-    "chain_index": 1,
-    "previous_hash": null,
-    "entry_hash": "sha256:bd9f5d07cd3185d88cc15b255a491e09b46b7bbdd095b795f45a709e4bb74f8f",
-    "metadata": {
-      "provider": "github"
+{
+  "schema": "opentrustgraph-chain/v0",
+  "chain": {
+    "topic": "trust_graph",
+    "total": 2,
+    "root_hash": "sha256:13f9bf66cea6d09b868318afd40dad1fa6acb35994f64ab3fffcc57d30658c41",
+    "verified": false,
+    "generated_at": "2026-04-19T18:45:00Z",
+    "producer": {
+      "name": "harn",
+      "version": "0.7.x"
     }
   },
-  {
-    "schema": "opentrustgraph/v0",
-    "record_id": "01966f4c-0f32-7d37-b443-d72dd96f0f4f",
-    "agent": "github-triage-bot",
-    "action": "trust.promote",
-    "approver": "maintainer-1",
-    "outcome": "success",
-    "trace_id": "trace_invalid_02",
-    "autonomy_tier": "act_auto",
-    "timestamp": "2026-04-19T18:43:02Z",
-    "cost_usd": null,
-    "chain_index": 2,
-    "previous_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-    "entry_hash": "sha256:75955793c1806c9e56248b5b756f5d909ed4f1680c780f83075738c7552b93af",
-    "metadata": {
-      "control": true
+  "records": [
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-0f31-7b5d-b44b-f7f8e7e1d384",
+      "agent": "github-triage-bot",
+      "action": "github.issue.opened",
+      "approver": null,
+      "outcome": "success",
+      "trace_id": "trace_valid_01",
+      "autonomy_tier": "suggest",
+      "timestamp": "2026-04-19T18:42:11Z",
+      "cost_usd": null,
+      "chain_index": 1,
+      "previous_hash": null,
+      "entry_hash": "sha256:84facae7d56fd304e040ea18d80bd019e274ad86ddd5a4d732f3ac3d984c48ec",
+      "metadata": {
+        "provider": "github"
+      }
+    },
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-0f32-7d37-b443-d72dd96f0f4f",
+      "agent": "github-triage-bot",
+      "action": "trust.promote",
+      "approver": "maintainer-1",
+      "outcome": "success",
+      "trace_id": "trace_valid_02",
+      "autonomy_tier": "act_auto",
+      "timestamp": "2026-04-19T18:43:02Z",
+      "cost_usd": null,
+      "chain_index": 2,
+      "previous_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "entry_hash": "sha256:13f9bf66cea6d09b868318afd40dad1fa6acb35994f64ab3fffcc57d30658c41",
+      "metadata": {
+        "control": true,
+        "from_tier": "suggest",
+        "to_tier": "act_auto"
+      }
     }
-  }
-]
+  ]
+}

--- a/opentrustgraph-spec/fixtures/valid/decision-chain.json
+++ b/opentrustgraph-spec/fixtures/valid/decision-chain.json
@@ -1,38 +1,54 @@
-[
-  {
-    "schema": "opentrustgraph/v0",
-    "record_id": "01966f4c-0f31-7b5d-b44b-f7f8e7e1d384",
-    "agent": "github-triage-bot",
-    "action": "github.issue.opened",
-    "approver": null,
-    "outcome": "success",
-    "trace_id": "trace_valid_01",
-    "autonomy_tier": "suggest",
-    "timestamp": "2026-04-19T18:42:11Z",
-    "cost_usd": null,
-    "chain_index": 1,
-    "previous_hash": null,
-    "entry_hash": "sha256:bd9f5d07cd3185d88cc15b255a491e09b46b7bbdd095b795f45a709e4bb74f8f",
-    "metadata": {
-      "provider": "github"
+{
+  "schema": "opentrustgraph-chain/v0",
+  "chain": {
+    "topic": "trust_graph",
+    "total": 2,
+    "root_hash": "sha256:6bb2b155ba07c67443c881f2d9dd954083bb44542df81520db1490fcbfdd5bf9",
+    "verified": true,
+    "generated_at": "2026-04-19T18:45:00Z",
+    "producer": {
+      "name": "harn",
+      "version": "0.7.x"
     }
   },
-  {
-    "schema": "opentrustgraph/v0",
-    "record_id": "01966f4c-0f32-7d37-b443-d72dd96f0f4f",
-    "agent": "github-triage-bot",
-    "action": "trust.promote",
-    "approver": "maintainer-1",
-    "outcome": "success",
-    "trace_id": "trace_valid_02",
-    "autonomy_tier": "act_auto",
-    "timestamp": "2026-04-19T18:43:02Z",
-    "cost_usd": null,
-    "chain_index": 2,
-    "previous_hash": "sha256:bd9f5d07cd3185d88cc15b255a491e09b46b7bbdd095b795f45a709e4bb74f8f",
-    "entry_hash": "sha256:75955793c1806c9e56248b5b756f5d909ed4f1680c780f83075738c7552b93af",
-    "metadata": {
-      "control": true
+  "records": [
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-0f31-7b5d-b44b-f7f8e7e1d384",
+      "agent": "github-triage-bot",
+      "action": "github.issue.opened",
+      "approver": null,
+      "outcome": "success",
+      "trace_id": "trace_valid_01",
+      "autonomy_tier": "suggest",
+      "timestamp": "2026-04-19T18:42:11Z",
+      "cost_usd": null,
+      "chain_index": 1,
+      "previous_hash": null,
+      "entry_hash": "sha256:84facae7d56fd304e040ea18d80bd019e274ad86ddd5a4d732f3ac3d984c48ec",
+      "metadata": {
+        "provider": "github"
+      }
+    },
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-0f32-7d37-b443-d72dd96f0f4f",
+      "agent": "github-triage-bot",
+      "action": "trust.promote",
+      "approver": "maintainer-1",
+      "outcome": "success",
+      "trace_id": "trace_valid_02",
+      "autonomy_tier": "act_auto",
+      "timestamp": "2026-04-19T18:43:02Z",
+      "cost_usd": null,
+      "chain_index": 2,
+      "previous_hash": "sha256:84facae7d56fd304e040ea18d80bd019e274ad86ddd5a4d732f3ac3d984c48ec",
+      "entry_hash": "sha256:6bb2b155ba07c67443c881f2d9dd954083bb44542df81520db1490fcbfdd5bf9",
+      "metadata": {
+        "control": true,
+        "from_tier": "suggest",
+        "to_tier": "act_auto"
+      }
     }
-  }
-]
+  ]
+}

--- a/opentrustgraph-spec/fixtures/valid/tier-transition.json
+++ b/opentrustgraph-spec/fixtures/valid/tier-transition.json
@@ -1,0 +1,95 @@
+{
+  "schema": "opentrustgraph-chain/v0",
+  "chain": {
+    "topic": "trust_graph",
+    "total": 3,
+    "root_hash": "sha256:e1ca0fc25124ed404fb05d31a468d4ddb33fab3325f86a58ad4068671188b57a",
+    "verified": true,
+    "generated_at": "2026-04-19T19:03:00Z",
+    "producer": {
+      "name": "harn",
+      "version": "0.7.x"
+    }
+  },
+  "records": [
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-1000-78a1-91d6-407b18572001",
+      "agent": "deploy-agent",
+      "action": "deploy.preview",
+      "approver": null,
+      "outcome": "denied",
+      "trace_id": "trace_tier_01",
+      "autonomy_tier": "shadow",
+      "timestamp": "2026-04-19T19:00:00Z",
+      "cost_usd": null,
+      "chain_index": 1,
+      "previous_hash": null,
+      "entry_hash": "sha256:12fd52408e6feb50e7bbaa2d308ee4896464264a7e59893e40142cdc649cf654",
+      "metadata": {
+        "terminal_status": "blocked",
+        "reason": "shadow tier blocks direct mutation"
+      }
+    },
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-1001-71da-9e75-e5b339a30002",
+      "agent": "deploy-agent",
+      "action": "trust.promote",
+      "approver": "ops-lead",
+      "outcome": "success",
+      "trace_id": "trace_tier_02",
+      "autonomy_tier": "act_with_approval",
+      "timestamp": "2026-04-19T19:01:00Z",
+      "cost_usd": null,
+      "chain_index": 2,
+      "previous_hash": "sha256:12fd52408e6feb50e7bbaa2d308ee4896464264a7e59893e40142cdc649cf654",
+      "entry_hash": "sha256:51af6fa6f2cc790749d6c892939a27e43d10ac191fa8d42ae611a5ade0d01813",
+      "metadata": {
+        "control": true,
+        "from_tier": "shadow",
+        "to_tier": "act_with_approval",
+        "approval": {
+          "required": true,
+          "quorum": 1,
+          "signatures": [
+            {
+              "reviewer": "ops-lead",
+              "signed_at": "2026-04-19T19:00:59Z",
+              "signature": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-1002-765e-a26e-17403bc70003",
+      "agent": "deploy-agent",
+      "action": "deploy.preview",
+      "approver": "ops-lead",
+      "outcome": "success",
+      "trace_id": "trace_tier_03",
+      "autonomy_tier": "act_with_approval",
+      "timestamp": "2026-04-19T19:02:00Z",
+      "cost_usd": 0.034,
+      "chain_index": 3,
+      "previous_hash": "sha256:51af6fa6f2cc790749d6c892939a27e43d10ac191fa8d42ae611a5ade0d01813",
+      "entry_hash": "sha256:e1ca0fc25124ed404fb05d31a468d4ddb33fab3325f86a58ad4068671188b57a",
+      "metadata": {
+        "provider": "github",
+        "approval": {
+          "required": true,
+          "quorum": 1,
+          "signatures": [
+            {
+              "reviewer": "ops-lead",
+              "signed_at": "2026-04-19T19:01:58Z",
+              "signature": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/opentrustgraph-spec/schemas/trust-chain.v0.schema.json
+++ b/opentrustgraph-spec/schemas/trust-chain.v0.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/opentrustgraph/v0/trust-chain.schema.json",
+  "title": "OpenTrustGraph TrustChainExport",
+  "description": "Ordered OpenTrustGraph records plus chain verification metadata.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "chain", "records"],
+  "properties": {
+    "schema": {
+      "const": "opentrustgraph-chain/v0"
+    },
+    "chain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "topic",
+        "total",
+        "root_hash",
+        "verified",
+        "generated_at",
+        "producer"
+      ],
+      "properties": {
+        "topic": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Canonical event-log topic or exported stream name."
+        },
+        "total": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of records in this ordered export."
+        },
+        "root_hash": {
+          "type": ["string", "null"],
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "The final record's entry_hash, or null for an empty export."
+        },
+        "verified": {
+          "type": "boolean",
+          "description": "Whether the producer verified record contracts, required approval evidence, record hashes, and hash linkage before export."
+        },
+        "generated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "producer": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "version"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "version": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "records": {
+      "type": "array",
+      "items": {
+        "$ref": "trust-record.v0.schema.json"
+      }
+    }
+  }
+}

--- a/opentrustgraph-spec/schemas/trust-record.v0.schema.json
+++ b/opentrustgraph-spec/schemas/trust-record.v0.schema.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/opentrustgraph/v0/trust-record.schema.json",
   "title": "OpenTrustGraph TrustRecord",
+  "description": "One autonomy, approval, or control-plane event in an append-only OpenTrustGraph chain.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -36,7 +37,9 @@
       "minLength": 1
     },
     "approver": {
-      "type": ["string", "null"]
+      "type": ["string", "null"],
+      "minLength": 1,
+      "description": "Actor that satisfied the approval gate, or null when no approval gate applied."
     },
     "outcome": {
       "type": "string",
@@ -55,7 +58,8 @@
       "format": "date-time"
     },
     "cost_usd": {
-      "type": ["number", "null"]
+      "type": ["number", "null"],
+      "minimum": 0
     },
     "chain_index": {
       "type": "integer",
@@ -70,7 +74,95 @@
       "pattern": "^sha256:[0-9a-f]{64}$"
     },
     "metadata": {
-      "type": "object"
+      "type": "object",
+      "description": "Runtime-specific detail bag. Consumers must preserve unknown keys."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "outcome": {
+            "const": "success"
+          },
+          "autonomy_tier": {
+            "const": "act_with_approval"
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "approval": {
+                "type": "object",
+                "properties": {
+                  "required": {
+                    "const": true
+                  }
+                },
+                "required": ["required"]
+              }
+            },
+            "required": ["approval"]
+          }
+        },
+        "required": ["outcome", "autonomy_tier", "metadata"]
+      },
+      "then": {
+        "properties": {
+          "approver": {
+            "type": "string",
+            "minLength": 1
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "approval": {
+                "$ref": "#/$defs/approvalReceipt"
+              }
+            },
+            "required": ["approval"]
+          }
+        },
+        "required": ["approver"]
+      }
+    }
+  ],
+  "$defs": {
+    "approvalReceipt": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["required", "quorum", "signatures"],
+      "properties": {
+        "required": {
+          "const": true
+        },
+        "quorum": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "signatures": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["reviewer", "signed_at", "signature"],
+            "properties": {
+              "reviewer": {
+                "type": "string",
+                "minLength": 1
+              },
+              "signed_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "signature": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/spec/opentrustgraph.md
+++ b/spec/opentrustgraph.md
@@ -7,10 +7,14 @@ for compatibility), but the format is designed to
 be runtime-neutral so other schedulers and workflow engines can adopt the same
 stream shape.
 
-Version marker:
+Version markers:
 
 ```json
 {"schema":"opentrustgraph/v0"}
+```
+
+```json
+{"schema":"opentrustgraph-chain/v0"}
 ```
 
 ## TrustRecord
@@ -72,148 +76,120 @@ Autonomy tier enum:
 - `act_with_approval`
 - `act_auto`
 
-## JSON Schema
+Approval evidence:
+
+- When `metadata.approval.required` is `true`, `outcome` is `success`, and
+  `autonomy_tier` is `act_with_approval`, the record must include a non-empty
+  `approver`.
+- The same record must include at least one signature receipt in
+  `metadata.approval.signatures`.
+- Signature receipt objects are intentionally extensible. Harn uses
+  `reviewer`, `signed_at`, and `signature` fields today.
+
+## Chain export
+
+A `TrustChainExport` wraps ordered records with metadata for receipts,
+supervision UIs, and third-party verification:
 
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://harnlang.com/schemas/opentrustgraph/v0/trust-record.schema.json",
-  "title": "OpenTrustGraph TrustRecord",
-  "type": "object",
-  "additionalProperties": false,
-  "required": [
-    "schema",
-    "record_id",
-    "agent",
-    "action",
-    "outcome",
-    "trace_id",
-    "autonomy_tier",
-    "timestamp",
-    "chain_index",
-    "previous_hash",
-    "entry_hash",
-    "metadata"
-  ],
-  "properties": {
-    "schema": {
-      "const": "opentrustgraph/v0"
+  "schema": "opentrustgraph-chain/v0",
+  "chain": {
+    "topic": "trust_graph",
+    "total": 2,
+    "root_hash": "sha256:6bb2b155ba07c67443c881f2d9dd954083bb44542df81520db1490fcbfdd5bf9",
+    "verified": true,
+    "generated_at": "2026-04-19T18:45:00Z",
+    "producer": {
+      "name": "harn",
+      "version": "0.7.x"
     },
-    "record_id": {
-      "type": "string",
-      "description": "UUIDv7 recommended."
-    },
-    "agent": {
-      "type": "string",
-      "minLength": 1
-    },
-    "action": {
-      "type": "string",
-      "minLength": 1
-    },
-    "approver": {
-      "type": ["string", "null"]
-    },
-    "outcome": {
-      "type": "string",
-      "enum": ["success", "failure", "denied", "timeout"]
-    },
-    "trace_id": {
-      "type": "string",
-      "minLength": 1
-    },
-    "autonomy_tier": {
-      "type": "string",
-      "enum": ["shadow", "suggest", "act_with_approval", "act_auto"]
-    },
-    "timestamp": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "cost_usd": {
-      "type": ["number", "null"]
-    },
-    "chain_index": {
-      "type": "integer",
-      "minimum": 1
-    },
-    "previous_hash": {
-      "type": ["string", "null"],
-      "pattern": "^(sha256:[0-9a-f]{64})$"
-    },
-    "entry_hash": {
-      "type": "string",
-      "pattern": "^sha256:[0-9a-f]{64}$"
-    },
-    "metadata": {
-      "type": "object"
-    }
-  }
+  },
+  "records": []
 }
 ```
 
-## Sample stream
+Fields:
+
+- `schema`: chain-export schema/version discriminator. Current value:
+  `opentrustgraph-chain/v0`.
+- `chain.topic`: canonical event-log topic or exported stream name.
+- `chain.total`: number of records in the ordered export.
+- `chain.root_hash`: final record's `entry_hash`, or `null` for an empty
+  export.
+- `chain.verified`: whether the producer verified record hashes, previous-hash
+  linkage, and required approval evidence before export.
+- `chain.generated_at`: RFC3339 UTC timestamp for the export.
+- `chain.producer`: producer name and version.
+- `records`: ordered `TrustRecord` list.
+
+## JSON Schema
+
+The normative JSON Schema files live in the public artifact directory:
+
+- [`opentrustgraph-spec/schemas/trust-record.v0.schema.json`](../opentrustgraph-spec/schemas/trust-record.v0.schema.json)
+- [`opentrustgraph-spec/schemas/trust-chain.v0.schema.json`](../opentrustgraph-spec/schemas/trust-chain.v0.schema.json)
+
+Harn tests parse those schema files and all fixtures directly, so the spec
+artifact and runtime hash contract stay in sync.
+
+## Sample export
 
 ```json
-[
-  {
-    "schema": "opentrustgraph/v0",
-    "record_id": "01966f4c-0f31-7b5d-b44b-f7f8e7e1d384",
-    "agent": "github-triage-bot",
-    "action": "github.issue.opened",
-    "approver": null,
-    "outcome": "denied",
-    "trace_id": "trace_shadow_01",
-    "autonomy_tier": "shadow",
-    "timestamp": "2026-04-19T18:42:11Z",
-    "cost_usd": null,
-    "chain_index": 1,
-    "previous_hash": null,
-    "entry_hash": "sha256:bd9f5d07cd3185d88cc15b255a491e09b46b7bbdd095b795f45a709e4bb74f8f",
-    "metadata": {
-      "terminal_status": "failed",
-      "reason": "shadow tier blocks direct mutation"
+{
+  "schema": "opentrustgraph-chain/v0",
+  "chain": {
+    "topic": "trust_graph",
+    "total": 2,
+    "root_hash": "sha256:6bb2b155ba07c67443c881f2d9dd954083bb44542df81520db1490fcbfdd5bf9",
+    "verified": true,
+    "generated_at": "2026-04-19T18:45:00Z",
+    "producer": {
+      "name": "harn",
+      "version": "0.7.x"
     }
   },
-  {
-    "schema": "opentrustgraph/v0",
-    "record_id": "01966f4c-0f32-7d37-b443-d72dd96f0f4f",
-    "agent": "github-triage-bot",
-    "action": "trust.promote",
-    "approver": "maintainer-1",
-    "outcome": "success",
-    "trace_id": "trustctl-01966f4c-0f32-7d37-b443-d72dd96f0f4f",
-    "autonomy_tier": "act_auto",
-    "timestamp": "2026-04-19T18:43:02Z",
-    "cost_usd": null,
-    "chain_index": 2,
-    "previous_hash": "sha256:bd9f5d07cd3185d88cc15b255a491e09b46b7bbdd095b795f45a709e4bb74f8f",
-    "entry_hash": "sha256:75955793c1806c9e56248b5b756f5d909ed4f1680c780f83075738c7552b93af",
-    "metadata": {
-      "control": true
+  "records": [
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-0f31-7b5d-b44b-f7f8e7e1d384",
+      "agent": "github-triage-bot",
+      "action": "github.issue.opened",
+      "approver": null,
+      "outcome": "success",
+      "trace_id": "trace_valid_01",
+      "autonomy_tier": "suggest",
+      "timestamp": "2026-04-19T18:42:11Z",
+      "cost_usd": null,
+      "chain_index": 1,
+      "previous_hash": null,
+      "entry_hash": "sha256:84facae7d56fd304e040ea18d80bd019e274ad86ddd5a4d732f3ac3d984c48ec",
+      "metadata": {
+        "provider": "github"
+      }
+    },
+    {
+      "schema": "opentrustgraph/v0",
+      "record_id": "01966f4c-0f32-7d37-b443-d72dd96f0f4f",
+      "agent": "github-triage-bot",
+      "action": "trust.promote",
+      "approver": "maintainer-1",
+      "outcome": "success",
+      "trace_id": "trace_valid_02",
+      "autonomy_tier": "act_auto",
+      "timestamp": "2026-04-19T18:43:02Z",
+      "cost_usd": null,
+      "chain_index": 2,
+      "previous_hash": "sha256:84facae7d56fd304e040ea18d80bd019e274ad86ddd5a4d732f3ac3d984c48ec",
+      "entry_hash": "sha256:6bb2b155ba07c67443c881f2d9dd954083bb44542df81520db1490fcbfdd5bf9",
+      "metadata": {
+        "control": true,
+        "from_tier": "suggest",
+        "to_tier": "act_auto"
+      }
     }
-  },
-  {
-    "schema": "opentrustgraph/v0",
-    "record_id": "01966f4c-0f33-79f7-a4a8-82c6900e31f8",
-    "agent": "github-triage-bot",
-    "action": "github.issue.opened",
-    "approver": null,
-    "outcome": "success",
-    "trace_id": "trace_live_01",
-    "autonomy_tier": "act_auto",
-    "timestamp": "2026-04-19T18:43:10Z",
-    "cost_usd": 0.0041,
-    "chain_index": 3,
-    "previous_hash": "sha256:75955793c1806c9e56248b5b756f5d909ed4f1680c780f83075738c7552b93af",
-    "entry_hash": "sha256:bea6b8da017bc3639ff8c1e8cf704fbbb57a2a662a45639d6fed4b30a538ec41",
-    "metadata": {
-      "provider": "github",
-      "binding_version": 4,
-      "terminal_status": "succeeded"
-    }
-  }
-]
+  ]
+}
 ```
 
 ## Portability notes


### PR DESCRIPTION
## Summary

Closes #449.

- make `opentrustgraph-spec/` the canonical public OpenTrustGraph v0 artifact inside Harn until a standalone repo exists
- add a chain export JSON Schema, approval evidence rules, valid tier-transition fixture, and invalid missing-approval fixture
- convert fixtures to deterministic chain envelopes and validate them from Harn runtime tests
- link the artifact from Harn docs, portal docs, and README for Harn Cloud/supervision references

## Validation

- `python3 -m json.tool ...` over all OpenTrustGraph schemas and fixtures
- `CARGO_TARGET_DIR=/tmp/harn-target-issue449 cargo test -p harn-vm trust_graph::tests -- --nocapture`
- `npm run lint:md`
- `git diff --check`
- pre-commit hook: `cargo fmt`, workspace clippy, markdownlint
- pre-push hook ran `make test`: 2060/2061 passed; `harn-cli::orchestrator_inbox_dedupe restart_after_emit_does_not_duplicate_cron_dispatch` timed out waiting for an unrelated startup log line
- targeted rerun of that failing test passed: `CARGO_TARGET_DIR=/tmp/harn-target-issue449 cargo test -p harn-cli --test orchestrator_inbox_dedupe restart_after_emit_does_not_duplicate_cron_dispatch -- --nocapture`
