### PR TITLE
Add --at to persona status; fix UTC-day budget flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## Unreleased
+
+### Added
+
+- **`harn persona status --at <RFC3339>` (#TBD).** Mirrors the
+  existing `tick --at` flag: pins the budget-window query to a
+  deterministic UTC moment instead of using the wall clock. Lets
+  tests pair a `tick --at <T>` with a `status --at <T>` and assert
+  on `spent_today_usd` / `tokens_today` without flaking when the
+  test happens to run after `<T>`'s UTC midnight.
+
+### Fixed
+
+- **`persona_runtime_status_tick_and_budget_are_persisted` UTC-day
+  flake (#TBD).** The test pinned `tick --at 2026-04-24T12:30:00Z`
+  but read `status` against the wall clock, so the
+  `spent_today_usd == 0.25` assertion silently dropped to `0.0`
+  every time the test ran after the tick's UTC midnight (i.e.
+  basically any time of day in PT/CT/ET). The status command now
+  accepts the same `--at` flag and the test threads it through.
+
 ## v0.7.37
 
 ### Added

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -1862,6 +1862,10 @@ pub(crate) struct PersonaInspectArgs {
 pub(crate) struct PersonaStatusArgs {
     /// Persona name to query.
     pub name: String,
+    /// RFC3339 timestamp to use for deterministic budget windows. When
+    /// omitted, falls back to the current UTC wall clock.
+    #[arg(long, value_name = "RFC3339")]
+    pub at: Option<String>,
     /// Emit stable JSON for Harn Cloud, Burin Code, or other hosts.
     #[arg(long)]
     pub json: bool,

--- a/crates/harn-cli/src/commands/persona.rs
+++ b/crates/harn-cli/src/commands/persona.rs
@@ -135,7 +135,11 @@ pub(crate) async fn run_status(
     let catalog = load_catalog_result(manifest)?;
     let binding = runtime_binding_or_err(&catalog, &args.name)?;
     let log = open_persona_log(state_dir)?;
-    let status = harn_vm::persona_status(&log, &binding, harn_vm::persona_now_ms()).await?;
+    let now_ms = match &args.at {
+        Some(at) => harn_vm::parse_persona_ms(at)?,
+        None => harn_vm::persona_now_ms(),
+    };
+    let status = harn_vm::persona_status(&log, &binding, now_ms).await?;
     print_status(&status, args.json);
     Ok(())
 }

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -253,6 +253,10 @@ fn persona_runtime_status_tick_and_budget_are_persisted() {
         .unwrap()
         .starts_with("persona_lease_"));
 
+    // Pin the status query to the same UTC day as the tick above. Without
+    // --at, the budget window is computed from real wall-clock time, so the
+    // assertion silently breaks the moment the test runs after the tick's
+    // UTC midnight (i.e. roughly any time of day in PT/CT/ET).
     let status = Command::new(env!("CARGO_BIN_EXE_harn"))
         .current_dir(temp.path())
         .args([
@@ -261,6 +265,8 @@ fn persona_runtime_status_tick_and_budget_are_persisted() {
             state_dir.to_str().unwrap(),
             "status",
             "merge_captain",
+            "--at",
+            "2026-04-24T12:30:00Z",
             "--json",
         ])
         .output()


### PR DESCRIPTION
## Summary

- Adds `--at <RFC3339>` to `harn persona status`, mirroring the same flag already on `harn persona tick`. When omitted, behavior is unchanged (wall-clock UTC).
- Fixes the `persona_runtime_status_tick_and_budget_are_persisted` test that flaked any time the wall clock crossed the UTC midnight after the test's hardcoded `tick --at 2026-04-24T12:30:00Z` (≈5 PM PDT the day before, in this case).

## Why

`budget_status` computes `day_start = now_ms - now_ms.rem_euclid(86_400_000)`. The status command was passing `persona_now_ms()` (real wall clock), so a deterministically-timestamped `tick` followed by a wall-clock-based `status` would silently bucket the spend into "yesterday" and report `spent_today_usd: 0.0`. Discovered while investigating a pre-push hook failure on a sibling PR — repros against `origin/main` directly.

## Test plan

- [x] `cargo test -p harn-cli --test persona_cli persona_runtime_status_tick_and_budget_are_persisted` (passes deterministically — previously flaked after UTC midnight)
- [x] Pre-commit + pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)