### PR TITLE
Replace prior http_mock on re-registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ granular archaeology.
   formatter/lint/IR/LSP/viz/preflight handling alongside the existing
   `SubscriptAccess` paths.
 
+### Changed
+
+- **`http_mock` re-registration now replaces (#TBD).** Calling
+  `http_mock(method, url_pattern, ...)` a second time with the same
+  `(method, url_pattern)` tuple now replaces the prior mock instead of
+  appending behind it. Previously the first registration matched
+  forever and the second was dead code, which made it surprisingly
+  hard to override a per-case response (e.g. a happy `200` followed by
+  a deliberate `429` for a rate-limit cap test) without first calling
+  `http_mock_clear()`. Distinct `(method, url_pattern)` tuples are
+  unaffected.
+
 ### Fixed
 
 - **`persona_runtime_status_tick_and_budget_are_persisted` UTC-day

--- a/conformance/tests/runtime/http_mock_replace_on_rereg.expected
+++ b/conformance/tests/runtime/http_mock_replace_on_rereg.expected
@@ -1,0 +1,6 @@
+429
+second
+201
+y-only
+202
+post-x

--- a/conformance/tests/runtime/http_mock_replace_on_rereg.harn
+++ b/conformance/tests/runtime/http_mock_replace_on_rereg.harn
@@ -1,0 +1,23 @@
+/**
+ * Re-registering http_mock with the same (method, url_pattern) replaces
+ * the prior mock. Lets tests override per-case responses without first
+ * calling http_mock_clear().
+ */
+pipeline default(task) {
+  http_mock("GET", "https://api.example.com/x", {status: 200, body: "first"})
+  http_mock("GET", "https://api.example.com/x", {status: 429, body: "second"})
+  let r = http_get("https://api.example.com/x")
+  println(r.status)
+  println(r.body)
+  // Different URL is unaffected by the replace above.
+  http_mock("GET", "https://api.example.com/y", {status: 201, body: "y-only"})
+  let other = http_get("https://api.example.com/y")
+  println(other.status)
+  println(other.body)
+  // Different method on the same path is also independent.
+  http_mock("POST", "https://api.example.com/x", {status: 202, body: "post-x"})
+  let posted = http_post("https://api.example.com/x", "{}", {})
+  println(posted.status)
+  println(posted.body)
+  http_mock_clear()
+}

--- a/crates/harn-vm/src/http.rs
+++ b/crates/harn-vm/src/http.rs
@@ -241,10 +241,18 @@ pub fn push_http_mock(
     } else {
         responses.into_iter().map(MockResponse::from).collect()
     };
+    let method = method.into();
+    let url_pattern = url_pattern.into();
     HTTP_MOCKS.with(|mocks| {
-        mocks.borrow_mut().push(HttpMock {
-            method: method.into(),
-            url_pattern: url_pattern.into(),
+        let mut mocks = mocks.borrow_mut();
+        // Re-registering the same (method, url_pattern) replaces the prior
+        // mock so tests can override per-case responses without first calling
+        // http_mock_clear(). Without this, the original mock keeps matching
+        // forever and the new one is dead.
+        mocks.retain(|mock| !(mock.method == method && mock.url_pattern == url_pattern));
+        mocks.push(HttpMock {
+            method,
+            url_pattern,
             responses,
             next_response: 0,
         });
@@ -531,6 +539,10 @@ pub fn register_http_builtins(vm: &mut Vm) {
     // --- Mock HTTP builtins ---
 
     // http_mock(method, url_pattern, response) -> nil
+    //
+    // Calling http_mock again with the same (method, url_pattern) tuple
+    // *replaces* the prior mock for that target — tests can override a
+    // per-case response without first calling http_mock_clear().
     vm.register_builtin("http_mock", |args, _out| {
         let method = args.first().map(|a| a.display()).unwrap_or_default();
         let url_pattern = args.get(1).map(|a| a.display()).unwrap_or_default();
@@ -542,7 +554,9 @@ pub fn register_http_builtins(vm: &mut Vm) {
         let responses = parse_mock_responses(&response);
 
         HTTP_MOCKS.with(|mocks| {
-            mocks.borrow_mut().push(HttpMock {
+            let mut mocks = mocks.borrow_mut();
+            mocks.retain(|mock| !(mock.method == method && mock.url_pattern == url_pattern));
+            mocks.push(HttpMock {
                 method,
                 url_pattern,
                 responses,


### PR DESCRIPTION
## Summary

Calling `http_mock(method, url_pattern, response)` a second time with the same `(method, url_pattern)` tuple now **replaces** the prior mock instead of appending behind it.

Previously the first registration matched forever and the second was dead code, so override-style flows like:

```harn
http_mock("GET", url, {status: 200, body: "ok"})  // happy default
// ... assertions ...
http_mock("GET", url, {status: 429, body: "rate limited"})  // override
```

required an `http_mock_clear()` between the two calls or the override silently did nothing. Distinct `(method, url_pattern)` tuples are unaffected.

## Why

Hit while writing the rate-limit cap test for `harn-gitlab-connector`. The test registered a 200 success mock for the happy path, then re-registered a 429 mock for the cap test, expecting it to override — instead the original 200 kept matching and the cap test silently passed for the wrong reason.

## Test plan

- [x] New conformance case `http_mock_replace_on_rereg.harn` covering same-target replacement, different-URL independence, and different-method-same-URL independence
- [x] All 659 conformance tests pass (`harn test conformance`)
- [x] `cargo test -p harn-vm --lib http::` (5/5)

## Note

Includes a merge of #592 (`fix/persona-status-at`) so the pre-push hook passes — that PR fixes a pre-existing UTC-midnight flake in `persona_runtime_status_tick_and_budget_are_persisted` that blocks all PRs once the wall clock crosses ~5 PM PDT. Should rebase cleanly once #592 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)