### PR TITLE
Skip newlines after binary operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ granular archaeology.
   basically any time of day in PT/CT/ET). The status command now
   accepts the same `--at` flag and the test threads it through.
 
+- **Trailing binary operator + newline now parses (#TBD).** A binary
+  operator at the *end* of a line followed by the right operand on the
+  next line (e.g. `let x = a ??\n  b`) previously errored with
+  `expected expression, found \n`. Only the *leading*-operator
+  continuation form (`let x = a\n  ?? b`) worked. Both forms now
+  parse identically. Affects `|>`, `??`, `||`, `&&`, `==`, `!=`,
+  `<`, `>`, `<=`, `>=`, `in`, `not in`, `+`, `-`, `*`, `/`, `%`, `**`.
+
 ## v0.7.37
 
 ### Added

--- a/crates/harn-parser/src/parser/expressions.rs
+++ b/crates/harn-parser/src/parser/expressions.rs
@@ -21,6 +21,7 @@ impl Parser {
         while self.check_skip_newlines(&TokenKind::Pipe) {
             let start = left.span;
             self.advance();
+            self.skip_newlines();
             let right = self.parse_range()?;
             left = spanned(
                 Node::BinaryOp {
@@ -85,6 +86,7 @@ impl Parser {
         while self.check_skip_newlines(&TokenKind::NilCoal) {
             let start = left.span;
             self.advance();
+            self.skip_newlines();
             let right = self.parse_multiplicative()?;
             left = spanned(
                 Node::BinaryOp {
@@ -103,6 +105,7 @@ impl Parser {
         while self.check_skip_newlines(&TokenKind::Or) {
             let start = left.span;
             self.advance();
+            self.skip_newlines();
             let right = self.parse_logical_and()?;
             left = spanned(
                 Node::BinaryOp {
@@ -121,6 +124,7 @@ impl Parser {
         while self.check_skip_newlines(&TokenKind::And) {
             let start = left.span;
             self.advance();
+            self.skip_newlines();
             let right = self.parse_equality()?;
             left = spanned(
                 Node::BinaryOp {
@@ -145,6 +149,7 @@ impl Parser {
                 "!="
             };
             self.advance();
+            self.skip_newlines();
             let right = self.parse_comparison()?;
             left = spanned(
                 Node::BinaryOp {
@@ -175,6 +180,7 @@ impl Parser {
                     _ => "<",
                 };
                 self.advance();
+                self.skip_newlines();
                 let right = self.parse_additive()?;
                 left = spanned(
                     Node::BinaryOp {
@@ -187,6 +193,7 @@ impl Parser {
             } else if self.check(&TokenKind::In) {
                 let start = left.span;
                 self.advance();
+                self.skip_newlines();
                 let right = self.parse_additive()?;
                 left = spanned(
                     Node::BinaryOp {
@@ -202,6 +209,7 @@ impl Parser {
                 if self.check(&TokenKind::In) {
                     let start = left.span;
                     self.advance();
+                    self.skip_newlines();
                     let right = self.parse_additive()?;
                     left = spanned(
                         Node::BinaryOp {
@@ -232,6 +240,7 @@ impl Parser {
                 "-"
             };
             self.advance();
+            self.skip_newlines();
             let right = self.parse_nil_coalescing()?;
             left = spanned(
                 Node::BinaryOp {
@@ -260,6 +269,7 @@ impl Parser {
                 "%"
             };
             self.advance();
+            self.skip_newlines();
             let right = self.parse_exponent()?;
             left = spanned(
                 Node::BinaryOp {
@@ -281,6 +291,7 @@ impl Parser {
 
         let start = left.span;
         self.advance();
+        self.skip_newlines();
         let right = self.parse_exponent()?;
         Ok(spanned(
             Node::BinaryOp {

--- a/crates/harn-parser/src/parser/mod.rs
+++ b/crates/harn-parser/src/parser/mod.rs
@@ -56,6 +56,54 @@ pipeline p() {
     }
 
     #[test]
+    fn parses_line_trailing_infix_continuation_operators() {
+        // Sister case to the leading-operator test above. The trailing form
+        // (operator at the end of the previous line, right operand on the
+        // continuation line) used to error with "expected expression, found
+        // \\n" because each binary-op parser advanced past the operator and
+        // immediately tried to parse the right operand without skipping the
+        // newline that followed.
+        //
+        // We assert against a raw source string here rather than a
+        // conformance fixture because `harn fmt` canonicalizes the trailing
+        // form back to the leading form on save, so a fixture round-trips
+        // before the test ever validates the trailing form.
+        let source = r#"
+pipeline p() {
+  let nc = nil ??
+    "fallback"
+  let conj = true &&
+    true
+  let disj = false ||
+    true
+  let same = 1 ==
+    1
+  let diff = 1 !=
+    2
+  let lt = 1 <
+    2
+  let gte = 2 >=
+    2
+  let sum = 1 +
+    2
+  let mul = 4 *
+    2
+  let div = 8 /
+    2
+  let pow = 2 **
+    3
+  let chain = nil ??
+    nil ??
+    "chain"
+  let piped = 1 |>
+    to_string
+}
+"#;
+
+        assert!(parse_source(source).is_ok());
+    }
+
+    #[test]
     fn parses_public_declarations_and_generic_interfaces() {
         let source = r#"
 pub pipeline build(task) extends base {


### PR DESCRIPTION
## Summary

Fixes a parser bug where a binary operator at the **end** of a line followed by the right operand on the next line errors with `expected expression, found \n`. Only the leading-operator continuation form worked:

```harn
let x = a              // worked
  ?? b
let y = a ??           // failed before this PR
  b
```

The parsers for `??`, `||`, `&&`, `==`, `!=`, `<`, `>`, `<=`, `>=`, `in`, `not in`, `+`, `-`, `*`, `/`, `%`, `**`, and `|>` all consumed the operator and immediately tried to parse the right operand without first skipping the trailing newline. Each now calls `skip_newlines()` right after `advance()`.

## Why

Hit while writing the GitLab connector — `harn fmt` happens to canonicalize chained `??` into the leading-operator form, which works around the bug, but any source the user wrote by hand in trailing form would error before fmt ever ran. The leading- and trailing-operator forms should be interchangeable.

The leading-operator behavior of `-` is unchanged (still requires no preceding newline) because of the unary-negation prefix ambiguity — only the *trailing*-operator behavior is fixed across the board.

## Test plan

- [x] New parser unit test `parses_line_trailing_infix_continuation_operators` in `harn-parser`. Lives in Rust rather than as a `.harn` conformance fixture because `harn fmt` canonicalizes the trailing form back to the leading form on save (so a fixture would never validate the trailing form after the first format pass).
- [x] All 205 `harn-parser` tests pass
- [x] All 659 conformance tests pass
- [x] Existing `multiline_continuation_operators.harn` still passes (leading form still works)

## Note

Includes a merge of #592 (`fix/persona-status-at`) so the pre-push hook passes — that PR fixes a pre-existing UTC-midnight flake that blocks all PRs once the wall clock crosses ~5 PM PDT. Should rebase cleanly once #592 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)