### PR TITLE
Remove `harn mcp-serve`, unify under `harn serve mcp` (#594)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## Unreleased
+
+### Removed
+
+- **`harn mcp-serve` (#594).** The hidden legacy alias for serving a
+  `.harn` tool bundle as an MCP server is gone. Use `harn serve mcp
+  <file>` instead — it auto-detects whether the script exposes its
+  surface through `pub fn` exports (the recommended path) or through
+  the `mcp_tools(...)` / `mcp_resource(...)` / `mcp_prompt(...)`
+  registration builtins, and serves the appropriate one over stdio.
+  `--card <PATH_OR_JSON>` carried over to `harn serve mcp` and is
+  honored for the script-driven surface. Update any
+  `claude_desktop_config.json` / Cursor / Continue launch snippets that
+  pass `["mcp-serve", "<file>"]` to `["serve", "mcp", "<file>"]`.
+
 ## v0.7.38
 
 ### Added

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -73,9 +73,6 @@ SCRIPTING
     Connector(ConnectorArgs),
     /// Serve a Harn workflow over a transport adapter.
     Serve(ServeArgs),
-    /// Legacy alias: expose a .harn tool bundle as an MCP server on stdio.
-    #[command(hide = true, name = "mcp-serve")]
-    McpServe(LegacyMcpServeArgs),
     /// Manage remote MCP OAuth credentials and status.
     Mcp(McpArgs),
     /// Watch a .harn file and re-run it on changes.
@@ -638,7 +635,10 @@ pub(crate) enum ServeCommand {
     Acp(ServeAcpArgs),
     /// Serve a .harn agent over HTTP using A2A.
     A2a(A2aServeArgs),
-    /// Serve exported `pub fn` entrypoints as MCP tools.
+    /// Serve a `.harn` file as an MCP server. Exposes either exported
+    /// `pub fn` entrypoints (recommended) or, when the script registers
+    /// tools/resources/prompts via `mcp_tools(...)` / `mcp_resource(...)`
+    /// / `mcp_prompt(...)`, that script-driven surface over stdio.
     Mcp(ServeMcpArgs),
 }
 
@@ -701,20 +701,18 @@ pub(crate) struct ServeMcpArgs {
     /// Shared secret for HMAC request signing on HTTP transports.
     #[arg(long = "hmac-secret", env = "HARN_SERVE_HMAC_SECRET")]
     pub hmac_secret: Option<String>,
-    /// Path to the `.harn` file whose exported `pub fn` entrypoints are served.
-    pub file: String,
-}
-
-#[derive(Debug, Args)]
-pub(crate) struct LegacyMcpServeArgs {
-    /// Path to the .harn file that defines the MCP surface.
-    pub file: String,
     /// Optional Server Card JSON to advertise (MCP v2.1). Path to a
     /// `.json` file OR an inline JSON string. The card is embedded in
     /// the `initialize` response's `serverInfo.card` field AND exposed
-    /// as a static resource at `well-known://mcp-card`.
+    /// as a static resource at `well-known://mcp-card`. Honored when
+    /// the script uses the legacy `mcp_tools(...)` registration surface.
     #[arg(long = "card", value_name = "PATH_OR_JSON")]
     pub card: Option<String>,
+    /// Path to the `.harn` file whose exported `pub fn` entrypoints are
+    /// served. Scripts that instead call `mcp_tools(registry)` /
+    /// `mcp_resource(...)` / `mcp_prompt(...)` are detected and served
+    /// via the script-driven surface (over stdio).
+    pub file: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/crates/harn-cli/src/commands/init.rs
+++ b/crates/harn-cli/src/commands/init.rs
@@ -66,7 +66,7 @@ pub(crate) fn init_project(name: Option<&str>, template: ProjectTemplate) {
             println!("  harn test tests/         # run the tests");
         }
         ProjectTemplate::McpServer => {
-            println!("  harn mcp-serve main.harn # expose the starter MCP server");
+            println!("  harn serve mcp main.harn # expose the starter MCP server");
         }
         ProjectTemplate::PipelineLab => {
             println!("  harn playground --task \"Explain this repo\"    # run the lab");

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -766,8 +766,14 @@ fn print_trace_summary() {
     );
 }
 
-/// Run a .harn file as an MCP server over stdio. The pipeline must call
-/// `mcp_serve(registry)` so the CLI can expose its tools.
+/// Run a .harn file as an MCP server over stdio using the script-driven
+/// surface. The pipeline must call `mcp_tools(registry)` (or the alias
+/// `mcp_serve(registry)`) so the CLI can expose its tools, and may
+/// register additional resources/prompts via `mcp_resource(...)` /
+/// `mcp_resource_template(...)` / `mcp_prompt(...)`.
+///
+/// Dispatched into by `harn serve mcp <file>` when the script does not
+/// define any `pub fn` exports — see `commands::serve::run_mcp_server`.
 ///
 /// `card_source` — optional `--card` argument. Accepts either a path to
 /// a JSON file or an inline JSON string. When present, the card is
@@ -916,7 +922,7 @@ pub(crate) async fn run_file_mcp_serve(path: &str, card_source: Option<&str>) {
                 ));
             }
             eprintln!(
-                "[harn] mcp-serve: serving {} as '{server_name}'",
+                "[harn] serve mcp: serving {} as '{server_name}'",
                 caps.join(", ")
             );
 

--- a/crates/harn-cli/src/commands/serve.rs
+++ b/crates/harn-cli/src/commands/serve.rs
@@ -1,11 +1,12 @@
 use std::collections::BTreeSet;
 use std::net::SocketAddr;
+use std::path::Path;
 use std::sync::Arc;
 
 use harn_serve::{
     A2aHttpServeOptions, A2aServer, A2aServerConfig, ApiKeyAuthConfig, AuthMethodConfig,
-    AuthPolicy, DispatchCore, DispatchCoreConfig, HmacAuthConfig, McpHttpServeOptions, McpServer,
-    McpServerConfig,
+    AuthPolicy, DispatchCore, DispatchCoreConfig, ExportCatalog, ExportedCallableKind,
+    HmacAuthConfig, McpHttpServeOptions, McpServer, McpServerConfig,
 };
 use time::Duration;
 
@@ -36,6 +37,40 @@ pub(crate) async fn run_mcp_server(args: &ServeMcpArgs) -> Result<(), String> {
         && (!args.api_key.is_empty() || args.hmac_secret.is_some())
     {
         return Err("HTTP auth flags require `harn serve mcp --transport http`".to_string());
+    }
+
+    // Scripts that author the MCP surface explicitly through
+    // `mcp_tools(registry)` / `mcp_resource(...)` / `mcp_prompt(...)`
+    // typically don't expose any `pub fn` entrypoints. Dispatch those to
+    // the legacy script-driven runner that runs the script once,
+    // collects the registered tools/resources/prompts, and serves them
+    // over stdio. The DispatchCore-based adapter only knows how to
+    // route incoming MCP calls to `pub fn` exports.
+    let catalog = ExportCatalog::from_path(Path::new(&args.file))
+        .map_err(|error| format!("failed to load script: {error}"))?;
+    let has_pub_fn_exports = catalog
+        .functions
+        .values()
+        .any(|function| function.kind == ExportedCallableKind::Function);
+
+    if !has_pub_fn_exports {
+        if args.transport != McpServeTransport::Stdio {
+            return Err(
+                "scripts using `mcp_tools(...)` are only served over stdio; \
+                 either expose `pub fn` entrypoints or omit `--transport http`"
+                    .to_string(),
+            );
+        }
+        crate::commands::run::run_file_mcp_serve(&args.file, args.card.as_deref()).await;
+        return Ok(());
+    }
+
+    if args.card.is_some() {
+        return Err(
+            "`--card` is only honored for legacy `mcp_tools(...)` scripts; \
+             attach card metadata directly to your `pub fn` exports instead"
+                .to_string(),
+        );
     }
 
     let mut config = DispatchCoreConfig::for_script(&args.file);

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -443,9 +443,6 @@ async fn main() {
                 process::exit(1);
             }
         }
-        Command::McpServe(args) => {
-            commands::run::run_file_mcp_serve(&args.file, args.card.as_deref()).await
-        }
         Command::Mcp(args) => commands::mcp::handle_mcp_command(&args.command).await,
         Command::Watch(args) => {
             let denied =

--- a/crates/harn-lsp/src/constants.rs
+++ b/crates/harn-lsp/src/constants.rs
@@ -713,7 +713,7 @@ pub(crate) fn builtin_doc(name: &str) -> Option<String> {
         "mcp_server_info" => "**mcp_server_info(client)** → dict — Server info: `{name, connected}`",
         "mcp_disconnect" => "**mcp_disconnect(client)** → nil — Disconnect and kill MCP server process",
         // MCP server
-        "mcp_tools" => "**mcp_tools(registry)** → nil — Register a tool registry for the MCP server (used with `harn mcp-serve`)",
+        "mcp_tools" => "**mcp_tools(registry)** → nil — Register a tool registry for the MCP server (used with `harn serve mcp`)",
         "mcp_serve" => "**mcp_serve(registry)** → nil — Alias for `mcp_tools` (deprecated)",
         "mcp_resource" => "**mcp_resource({uri, name, text, description?, mime_type?})** → nil — Register a static resource for the MCP server",
         "mcp_resource_template" => "**mcp_resource_template({uri_template, name, handler, description?, mime_type?})** → nil — Register a parameterized resource template (RFC 6570 URI template)",

--- a/crates/harn-vm/src/mcp_card.rs
+++ b/crates/harn-vm/src/mcp_card.rs
@@ -9,7 +9,7 @@
 //!   `.well-known/mcp-card` URL or a local file path, caches it in a
 //!   per-process LRU with a TTL so repeated reads are free.
 //! - **Publisher**: `load_server_card_from_path` parses a local card
-//!   file for `harn mcp-serve --card path/to/card.json`, which embeds
+//!   file for `harn serve mcp --card path/to/card.json`, which embeds
 //!   the card into the `initialize` response and exposes it as a static
 //!   resource at `well-known://mcp-card`.
 //!
@@ -124,7 +124,7 @@ pub async fn fetch_server_card(source: &str, ttl: Option<Duration>) -> Result<Va
     Ok(card)
 }
 
-/// Synchronous card loader from a local path — used by `harn mcp-serve
+/// Synchronous card loader from a local path — used by `harn serve mcp
 /// --card` at startup (before the tokio runtime is involved).
 pub fn load_server_card_from_path(path: &std::path::Path) -> Result<Value, CardError> {
     let contents = std::fs::read_to_string(path)

--- a/crates/harn-vm/src/mcp_server/mod.rs
+++ b/crates/harn-vm/src/mcp_server/mod.rs
@@ -3,8 +3,9 @@
 //!
 //! This is the mirror of `mcp.rs` (the client). A Harn pipeline registers
 //! capabilities with `mcp_tools()`, `mcp_resource()`, `mcp_resource_template()`,
-//! and `mcp_prompt()`, then the CLI's `mcp-serve` command starts this server,
-//! making them callable by Claude Desktop, Cursor, or any MCP client.
+//! and `mcp_prompt()`, then `harn serve mcp` detects the script-driven
+//! surface and starts this server, making them callable by Claude
+//! Desktop, Cursor, or any MCP client.
 
 mod convert;
 mod defs;

--- a/crates/harn-vm/src/mcp_server/server.rs
+++ b/crates/harn-vm/src/mcp_server/server.rs
@@ -24,7 +24,7 @@ pub struct McpServer {
     /// Optional Server Card payload — advertised in the `initialize`
     /// response's `serverInfo.card` field and exposed as a static
     /// resource at the well-known URI `well-known://mcp-card`.
-    /// Populated by `harn mcp-serve --card path/to/card.json`.
+    /// Populated by `harn serve mcp --card path/to/card.json`.
     server_card: Option<serde_json::Value>,
 }
 

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1317,7 +1317,7 @@ harn mcp login notion
 ### MCP server mode
 
 Harn pipelines can expose tools, resources, resource templates, and prompts
-as an MCP server using `harn mcp-serve`. The CLI serves them over stdio
+as an MCP server using `harn serve mcp`. The CLI serves them over stdio
 using the MCP protocol, making them callable by Claude Desktop, Cursor,
 or any MCP client.
 
@@ -1448,7 +1448,7 @@ pipeline main(task) {
 Run as an MCP server:
 
 ```bash
-harn mcp-serve agent.harn
+harn serve mcp agent.harn
 ```
 
 Configure in Claude Desktop (`claude_desktop_config.json`):
@@ -1458,7 +1458,7 @@ Configure in Claude Desktop (`claude_desktop_config.json`):
   "mcpServers": {
     "my-agent": {
       "command": "harn",
-      "args": ["mcp-serve", "agent.harn"]
+      "args": ["serve", "mcp", "agent.harn"]
     }
   }
 }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -807,6 +807,18 @@ derived from Harn type annotations. With `--transport http`, the server also
 supports Streamable HTTP on `--path` plus the legacy SSE compatibility
 endpoints `--sse-path` and `--messages-path`.
 
+For scripts that author the MCP surface through the registration
+builtins (`mcp_tools(registry)`, `mcp_resource(...)`, `mcp_prompt(...)`)
+instead of `pub fn` exports, `harn serve mcp` auto-detects that mode,
+runs the script once on stdio, and exposes the registered
+tools / resources / prompts. Pass `--card <PATH_OR_JSON>` to advertise
+an MCP v2.1 Server Card with the script-driven mode.
+
+```bash
+harn serve mcp agent.harn                  # auto-detect surface
+harn serve mcp agent.harn --card ./card.json
+```
+
 `harn serve a2a` uses the shared `harn-serve` dispatch core and exposes each
 exported `pub fn` in the target module as an A2A skill. The adapter publishes an
 agent card at `/.well-known/a2a-agent` and supports task send, send-and-wait,
@@ -822,22 +834,6 @@ notifications, and forwards permission prompts through
 
 See [MCP and ACP Integration](./mcp-and-acp.md) and
 [Outbound workflow server](./harn-serve.md) for protocol details.
-
-## harn mcp-serve
-
-Serve a Harn pipeline as an MCP server over stdio using the legacy
-tool-registry surface (`mcp_tools`, `mcp_resource`, `mcp_prompt`).
-
-```bash
-harn mcp-serve agent.harn
-```
-
-Use `harn serve mcp` when you want the newer `harn-serve` adapter that maps
-exported `pub fn` entrypoints automatically. Use `harn mcp-serve` when the
-server surface is authored explicitly through MCP registration builtins.
-
-See [MCP and ACP Integration](./mcp-and-acp.md) for details on defining
-tools, resources, and prompts.
 
 ## harn mcp
 

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -319,12 +319,15 @@ pipeline main(task) {
 ### Running as an MCP server
 
 ```bash
-harn mcp-serve agent.harn
+harn serve mcp agent.harn
 ```
 
-All `print`/`println` output goes to stderr (stdout is the MCP
-transport). The server supports the `2025-11-25` MCP protocol version
-over stdio.
+`harn serve mcp` auto-detects whether the script exposes its surface
+through `pub fn` exports or through the `mcp_tools(...)` /
+`mcp_resource(...)` / `mcp_prompt(...)` registration builtins shown
+above and serves the appropriate one over stdio. All `print`/`println`
+output goes to stderr (stdout is the MCP transport). The server supports
+the `2025-11-25` MCP protocol version over stdio.
 
 #### Publishing a Server Card
 
@@ -332,7 +335,7 @@ Attach a Server Card so clients can discover your server's identity and
 capabilities before connecting:
 
 ```bash
-harn mcp-serve agent.harn --card ./card.json
+harn serve mcp agent.harn --card ./card.json
 ```
 
 The card JSON is embedded in the `initialize` response's
@@ -364,7 +367,7 @@ Add to `claude_desktop_config.json`:
   "mcpServers": {
     "my-agent": {
       "command": "harn",
-      "args": ["mcp-serve", "agent.harn"]
+      "args": ["serve", "mcp", "agent.harn"]
     }
   }
 }

--- a/docs/src/tutorial-mcp-server.md
+++ b/docs/src/tutorial-mcp-server.md
@@ -6,7 +6,7 @@ tools, static resources, resource templates, and prompts over stdio.
 Use the companion example as a baseline:
 
 ```bash
-cargo run --bin harn -- mcp-serve examples/mcp_server.harn
+cargo run --bin harn -- serve mcp examples/mcp_server.harn
 ```
 
 ## 1. Register tools
@@ -104,8 +104,13 @@ Once the pipeline calls `mcp_tools()`, `mcp_resource()`, or `mcp_prompt()`,
 launch the server with:
 
 ```bash
-harn mcp-serve examples/mcp_server.harn
+harn serve mcp examples/mcp_server.harn
 ```
+
+`harn serve mcp` automatically detects whether the script defines its
+surface through `pub fn` exports (the recommended path) or through the
+`mcp_tools(...)` / `mcp_resource(...)` / `mcp_prompt(...)` registration
+builtins shown above and serves the appropriate one over stdio.
 
 All user-visible output goes to stderr; the MCP transport stays on stdout.
 That keeps the server compatible with Claude Desktop, Cursor, and other MCP

--- a/examples/mcp_server.harn
+++ b/examples/mcp_server.harn
@@ -1,79 +1,88 @@
-// MCP Server Example
-//
-// Run with: harn mcp-serve examples/mcp_server.harn
-//
-// This exposes tools, resources, resource templates, and prompts over MCP
-// stdio transport for use by Claude Desktop, Cursor, or any MCP client.
-//
-// Configure in Claude Desktop (claude_desktop_config.json):
-// {
-//   "mcpServers": {
-//     "harn-demo": {
-//       "command": "harn",
-//       "args": ["mcp-serve", "examples/mcp_server.harn"]
-//     }
-//   }
-// }
-
+/**
+ * MCP Server Example
+ *
+ * Run with: harn serve mcp examples/mcp_server.harn
+ *
+ * This exposes tools, resources, resource templates, and prompts over MCP
+ * stdio transport for use by Claude Desktop, Cursor, or any MCP client.
+ *
+ * Configure in Claude Desktop (claude_desktop_config.json):
+ * {
+ *   "mcpServers": {
+ *     "harn-demo": {
+ *       "command": "harn",
+ *       "args": ["serve", "mcp", "examples/mcp_server.harn"]
+ *     }
+ *   }
+ * }
+ */
 pipeline main(task) {
   // ---- Tools (with annotations) ----
   var tools = tool_registry()
-
-  tools = tool_define(tools, "greet", "Greet someone by name", {
-    params: { name: "string" },
+  tools = tool_define(
+    tools,
+    "greet",
+    "Greet someone by name",
+    {
+    params: {name: "string"},
     handler: { args -> "Hello, " + args.name + "! Welcome to Harn." },
-    annotations: {
-      title: "Greeting Tool",
-      readOnlyHint: true,
-      destructiveHint: false
-    }
-  })
-
-  tools = tool_define(tools, "add", "Add two numbers together", {
-    params: { a: "number", b: "number" },
+    annotations: {title: "Greeting Tool", readOnlyHint: true, destructiveHint: false},
+  },
+  )
+  tools = tool_define(
+    tools,
+    "add",
+    "Add two numbers together",
+    {
+    params: {a: "number", b: "number"},
     handler: { args -> to_string(args.a + args.b) },
-    annotations: { readOnlyHint: true }
-  })
-
+    annotations: {readOnlyHint: true},
+  },
+  )
   mcp_tools(tools)
-
   // ---- Static Resources ----
-  mcp_resource({
+  mcp_resource(
+    {
     uri: "docs://readme",
     name: "README",
     description: "Project documentation",
     mime_type: "text/markdown",
-    text: "# Harn MCP Demo\n\nThis is a demo MCP server built with Harn."
-  })
-
+    text: "# Harn MCP Demo\n\nThis is a demo MCP server built with Harn.",
+  },
+  )
   // ---- Resource Templates ----
-  mcp_resource_template({
+  mcp_resource_template(
+    {
     uri_template: "config://{key}",
     name: "Configuration Values",
     description: "Read configuration by key",
     mime_type: "text/plain",
     handler: { args ->
-      if args.key == "version" {
-        "0.4.23"
-      } else if args.key == "name" {
+    if args.key == "version" {
+      "0.4.23"
+    } else {
+      if args.key == "name" {
         "harn-demo"
       } else {
         "unknown key: " + args.key
       }
     }
-  })
-
+  },
+  },
+  )
   // ---- Prompts ----
-  mcp_prompt({
+  mcp_prompt(
+    {
     name: "code_review",
     description: "Review code for quality and suggest improvements",
     arguments: [
-      { name: "code", description: "The code to review", required: true },
-      { name: "language", description: "Programming language" }
-    ],
+    {name: "code", description: "The code to review", required: true},
+    {name: "language", description: "Programming language"},
+  ],
     handler: { args ->
-      let lang = args.language ?? "unknown"
-      "Please review this " + lang + " code for quality, bugs, and improvements:\n\n" + args.code
-    }
-  })
+    let lang = args.language ?? "unknown"
+    "Please review this " + lang + " code for quality, bugs, and improvements:\n\n" + args.code
+  },
+  },
+  )
 }


### PR DESCRIPTION
## Summary

Closes #594. Drops the hidden `harn mcp-serve` legacy alias and folds
its surface area into the canonical `harn serve mcp <file>` subcommand.

- `harn serve mcp <file>` now auto-detects whether the script exposes
  its MCP surface through `pub fn` exports (DispatchCore /
  `harn-serve` adapter path, the recommended one) or through the
  `mcp_tools(...)` / `mcp_resource(...)` / `mcp_prompt(...)`
  registration builtins (script-driven path), and dispatches
  accordingly.
- `--card <PATH_OR_JSON>` carries over from `mcp-serve` and is honored
  for the script-driven path. `--transport http` and HTTP auth flags
  remain `pub fn`-export-only.
- Sweeps `docs/src/{tutorial-mcp-server,cli-reference,mcp-and-acp,builtins}.md`,
  `examples/mcp_server.harn`, and the `harn init` template hint to use
  the new invocation. Updates Claude Desktop / Cursor launch snippets to
  `["serve", "mcp", "<file>"]`.
- `CHANGELOG.md` gets an `## Unreleased` `### Removed` entry.
- The handful of remaining inline doc-comments referencing `harn
  mcp-serve --card` (in `harn-vm` and `harn-lsp`) get pointed at
  `harn serve mcp --card`.

Old launch snippets that still pass `["mcp-serve", "<file>"]` now error
with `unrecognized subcommand 'mcp-serve'` (and clap's "did you mean
'mcp'?" hint).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p harn-cli --test mcp_server_cli` (2/2 pass)
- [x] `cargo run --bin harn -- test conformance` (660 pass, 0 fail)
- [x] `make check-docs-snippets` (420 checked, 0 failed)
- [x] `make lint-md`, `make lint-harn`, `make fmt-harn`
- [x] `make gen-highlight` — no diff (no keyword changes)
- [x] Manual smoke: `harn serve mcp <file>` initializes + `tools/list`
      against (a) a `pub fn` script and (b) a `pipeline main { mcp_tools(...) }`
      script; `--card` advertises the card on the legacy path; `--card`
      and `--transport http` correctly error on the wrong path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)