### PR TITLE
Scaffold harn-hostlib crate (#563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ granular archaeology.
 
 ## Unreleased
 
+### Added
+
+- **`harn-hostlib` crate scaffold (#563).** New opt-in crate housing
+  code-intelligence and deterministic-tool host builtins ported from
+  `burin-code`'s Swift `BurinCore` (tree-sitter AST, trigram/word index,
+  repo scanner, filesystem watcher, search/file/git/process tooling).
+  Every method registered today returns `HostlibError::Unimplemented`;
+  follow-up issues fill in module bodies. Module skeletons + JSON
+  Schema 2020-12 contracts ship in this PR so `burin-code`'s
+  schema-drift tests can lock the public surface immediately. Wired
+  into `harn-cli`'s ACP server behind the default-on `hostlib` cargo
+  feature.
+
 ### Removed
 
 - **`harn mcp-serve` (#594).** The hidden legacy alias for serving a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1136,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "grep-matcher"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d7b71093325ab22d780b40d7df3066ae4aebb518ba719d38c697a8228a8023"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "grep-searcher"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac63295322dc48ebb20a25348147905d816318888e64f531bfc2a2bc0577dc34"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "encoding_rs_io",
+ "grep-matcher",
+ "log",
+ "memchr",
+ "memmap2",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1193,7 @@ dependencies = [
  "fs2",
  "futures",
  "harn-fmt",
+ "harn-hostlib",
  "harn-ir",
  "harn-lexer",
  "harn-lint",
@@ -1201,6 +1244,24 @@ version = "0.7.38"
 dependencies = [
  "harn-lexer",
  "harn-parser",
+]
+
+[[package]]
+name = "harn-hostlib"
+version = "0.7.38"
+dependencies = [
+ "anyhow",
+ "grep-searcher",
+ "harn-vm",
+ "ignore",
+ "notify",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tree-sitter",
+ "walkdir",
 ]
 
 [[package]]
@@ -2013,6 +2074,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -2935,6 +3005,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3179,6 +3250,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -3719,6 +3796,26 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "try-lock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/harn-dap",
     "crates/harn-fmt",
     "crates/harn-lint",
+    "crates/harn-hostlib",
 ]
 # Build harn-wasm separately: cd crates/harn-wasm && wasm-pack build
 exclude = ["crates/harn-wasm"]

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -35,6 +35,7 @@ harn-lexer = { path = "../harn-lexer", version = "0.7" }
 harn-parser = { path = "../harn-parser", version = "0.7" }
 harn-ir = { path = "../harn-ir", version = "0.7" }
 harn-vm = { path = "../harn-vm", version = "0.7", features = ["otel"] }
+harn-hostlib = { path = "../harn-hostlib", version = "0.7", optional = true }
 harn-lint = { path = "../harn-lint", version = "0.7" }
 harn-modules = { path = "../harn-modules", version = "0.7" }
 harn-fmt = { path = "../harn-fmt", version = "0.7" }
@@ -71,6 +72,14 @@ jmespath = "0.5.0"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 tracing = "0.1"
 fs2 = "0.4"
+
+[features]
+default = ["hostlib"]
+# Wire `harn-hostlib`'s code-intelligence and tool builtins into the ACP
+# server. Default-on so `harn run`-driven scripts that name a hostlib
+# builtin work without extra flags. Disable with `--no-default-features` if
+# you want a slimmer build that doesn't pull tree-sitter/notify/etc.
+hostlib = ["dep:harn-hostlib"]
 
 [dev-dependencies]
 hmac = "0.13"

--- a/crates/harn-cli/src/acp/mod.rs
+++ b/crates/harn-cli/src/acp/mod.rs
@@ -14,6 +14,16 @@ impl AcpRuntimeConfigurator for CliAcpRuntimeConfigurator {
         vm: &mut harn_vm::Vm,
         source_path: Option<&Path>,
     ) -> Result<(), String> {
+        // Hostlib registration is independent of the package/extension flow:
+        // even a `harn run` invocation that hasn't loaded a manifest should
+        // see the `hostlib_*` builtins so callers can probe the surface.
+        // Behind the `hostlib` cargo feature (default-on); see
+        // `crates/harn-hostlib/README.md` for the boundary contract.
+        #[cfg(feature = "hostlib")]
+        {
+            let _ = harn_hostlib::install_default(vm);
+        }
+
         let Some(path) = source_path else {
             return Ok(());
         };

--- a/crates/harn-hostlib/Cargo.toml
+++ b/crates/harn-hostlib/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "harn-hostlib"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Opt-in code-intelligence and deterministic-tool host builtins for the Harn VM"
+include = [
+    "src/**/*",
+    "schemas/**/*",
+    "tests/**/*",
+    "Cargo.toml",
+    "README.md",
+]
+
+[dependencies]
+harn-vm = { path = "../harn-vm", version = "0.7" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["rt", "macros", "sync", "fs", "process", "time"] }
+anyhow = "1"
+thiserror = "2"
+
+# Foundational dependencies for the upcoming module implementations
+# (B2/B3/B4/C1/C2/C3). They are wired in here so the workspace lockfile is
+# stable across follow-up issues — module code that lands later can use them
+# without bumping deps in a separate PR. Pinned to known-good releases at the
+# time of scaffolding.
+#
+# `gix` is intentionally not pinned here: 0.82 fails to compile on the
+# repo's current rustc against gix-hash 0.24's exhaustive match guards.
+# Issue C2 (the `tools/git` implementation) picks the version it needs
+# along with the toolchain bump; until then we shell out to the system
+# `git` if anything urgent comes up.
+tree-sitter = "0.26"
+grep-searcher = "0.1"
+ignore = "0.4"
+notify = "8"
+walkdir = "2"
+
+[dev-dependencies]
+tempfile = "3"
+serde_json = "1"

--- a/crates/harn-hostlib/README.md
+++ b/crates/harn-hostlib/README.md
@@ -1,0 +1,131 @@
+# harn-hostlib
+
+Opt-in host builtins for the Harn VM that provide:
+
+1. **Code intelligence** — tree-sitter–backed parsing, deterministic
+   trigram/word indexing, and project-wide repo scanning. Ports the Swift
+   `Sources/ASTEngine/`, `Sources/BurinCodeIndex/`, and
+   `Sources/BurinCore/Scanner/` surface from
+   [`burin-labs/burin-code`](https://github.com/burin-labs/burin-code).
+2. **Deterministic tools** — content search (`grep-searcher` + `ignore`),
+   file I/O, directory listing, file outline, git inspection (`gix`), file
+   watching (`notify`), and process lifecycle (`run_command`, `run_test`,
+   `run_build_command`, `inspect_test_results`, `manage_packages`). Ports
+   the Swift `CoreToolExecutor` surface so calls no longer have to bounce
+   Harn → Swift → Harn.
+
+## Status
+
+This is the **scaffold** that issue
+[#563](https://github.com/burin-labs/harn/issues/563) introduced. Every host
+method registered here today returns
+`HostlibError::Unimplemented { builtin }`. Implementations land in the
+follow-up issues called out in the parent epic
+[`burin-labs/burin-code#289`](https://github.com/burin-labs/burin-code/issues/289):
+
+| Issue | Module | What lands |
+|-------|--------|-----------|
+| B2    | `ast/`         | `parse_file`, `symbols`, `outline` |
+| B3    | `code_index/`  | `query`, `rebuild`, `stats`, `imports_for`, `importers_of` |
+| B4    | `scanner/`     | `scan_project`, `scan_incremental` |
+| C1    | `fs_watch/`    | `subscribe`, `unsubscribe` |
+| C2    | `tools/` (read & search) | `search`, `read_file`, `list_directory`, `get_file_outline`, `git` |
+| C3    | `tools/` (mutating) | `write_file`, `delete_file`, `run_command`, `run_test`, `run_build_command`, `inspect_test_results`, `manage_packages` |
+
+## Why a separate crate?
+
+`harn-vm` powers Harn pipelines that have nothing to do with editing host
+code. Pulling tree-sitter grammars, ripgrep, and `notify` into the VM
+crate would balloon its compile time and binary size for every embedder
+that doesn't index host source. `harn-hostlib` is **opt-in**: nothing
+inside `harn-vm` knows the crate exists. Embedders that want the surface
+ask for it.
+
+Conversely, the work that *does* belong in `harn-vm` — orchestration,
+transcript lifecycle, replay/eval, mutation session audit metadata —
+stays there. See
+[`AGENTS.md`](../../CLAUDE.md#trust-boundary) for the canonical trust
+boundary.
+
+## How embedders consume it
+
+The `harn-cli` ACP server wires hostlib in by default:
+
+```rust
+let mut vm = harn_vm::Vm::new();
+let _registry = harn_hostlib::install_default(&mut vm);
+```
+
+`install_default` registers every shipped capability and returns a
+`HostlibRegistry` that can be introspected (e.g. for
+`burin-code`'s schema-drift tests) without mutating the VM further.
+
+Pick-and-choose embedders that only want a subset of modules can build a
+custom registry:
+
+```rust
+let mut registry = harn_hostlib::HostlibRegistry::new()
+    .with(harn_hostlib::tools::ToolsCapability::default())
+    .with(harn_hostlib::ast::AstCapability::default());
+registry.register_into_vm(&mut vm);
+```
+
+The cargo feature `hostlib` on `harn-cli` is **default-on**. Embedders
+can disable it with `--no-default-features` for a slimmer build that
+omits the tree-sitter/notify/gix dependency tree entirely.
+
+## How `burin-code` consumes it
+
+`burin-code` pulls hostlib in transitively via the harn release pinned in
+its `.harn-version` manifest. After this scaffold lands, the parent epic
+ships:
+
+1. A harn release bumping the version in this repo (per
+   [`scripts/release_ship.sh`](../../scripts/release_ship.sh)).
+2. A burin-code PR bumping `.harn-version` to that release.
+3. burin-code progressively retires its Swift-side `BurinCore`
+   counterparts as each implementation issue lands here.
+
+The schemas under `schemas/<module>/<method>.{request,response}.json` are
+the **source of truth** for burin-code's schema-drift tests. They ship
+with the published crate (see the `include` field in `Cargo.toml`) and
+are also mirrored at compile time via `include_str!` into
+[`schemas.rs`](src/schemas.rs) so embedders can fetch them
+programmatically without locating the on-disk schema directory.
+
+## Directory layout
+
+```text
+crates/harn-hostlib/
+├── Cargo.toml
+├── README.md                  # this file
+├── schemas/                   # JSON Schema 2020-12 contracts
+│   ├── ast/
+│   ├── code_index/
+│   ├── scanner/
+│   ├── fs_watch/
+│   └── tools/
+├── src/
+│   ├── lib.rs                 # public surface + install_default
+│   ├── error.rs               # HostlibError → VmError translation
+│   ├── registry.rs            # HostlibCapability + HostlibRegistry
+│   ├── schemas.rs             # const SCHEMAS catalog (include_str!)
+│   ├── ast/
+│   ├── code_index/
+│   ├── scanner/
+│   ├── fs_watch/
+│   └── tools/
+└── tests/
+    └── registration.rs        # registration + schema parity tests
+```
+
+## Adding a new method
+
+1. Add a `register_unimplemented(...)` entry in the relevant module's
+   `register_builtins`.
+2. Drop `<method>.request.json` and `<method>.response.json` into
+   `schemas/<module>/`.
+3. Append two `include_str!` entries to `SCHEMAS` in `src/schemas.rs`.
+4. Add the method name to the `assert_eq!` list in `tests/registration.rs`.
+
+The integration tests catch any drift between the four locations.

--- a/crates/harn-hostlib/schemas/ast/outline.request.json
+++ b/crates/harn-hostlib/schemas/ast/outline.request.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/outline.request.json",
+  "title": "ast.outline request",
+  "description": "Produce a hierarchical outline (nested symbols) for a source file. Mirrors the Swift ASTEngine `Outline` shape.",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "language": { "type": "string" },
+    "max_depth": { "type": "integer", "minimum": 0 }
+  },
+  "required": ["path"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/ast/outline.response.json
+++ b/crates/harn-hostlib/schemas/ast/outline.response.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/outline.response.json",
+  "title": "ast.outline response",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "language": { "type": "string" },
+    "items": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/OutlineItem" }
+    }
+  },
+  "required": ["path", "language", "items"],
+  "additionalProperties": false,
+  "$defs": {
+    "OutlineItem": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "kind": { "type": "string" },
+        "start_row": { "type": "integer", "minimum": 0 },
+        "end_row": { "type": "integer", "minimum": 0 },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/OutlineItem" }
+        }
+      },
+      "required": ["name", "kind", "start_row", "end_row", "children"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/schemas/ast/parse_file.request.json
+++ b/crates/harn-hostlib/schemas/ast/parse_file.request.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/parse_file.request.json",
+  "title": "ast.parse_file request",
+  "description": "Parse a single source file into a tree-sitter AST. The grammar is selected from the file extension unless `language` is supplied explicitly.",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Absolute or workspace-relative path to the source file."
+    },
+    "language": {
+      "type": "string",
+      "description": "Optional override for the tree-sitter grammar (e.g. \"rust\", \"swift\", \"typescript\")."
+    },
+    "max_bytes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Optional cap on the number of bytes parsed; 0 means unlimited."
+    }
+  },
+  "required": ["path"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/ast/parse_file.response.json
+++ b/crates/harn-hostlib/schemas/ast/parse_file.response.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/parse_file.response.json",
+  "title": "ast.parse_file response",
+  "description": "Parsed tree-sitter result. The tree is reported as a flat node list to keep the wire format JSON-serializable; consumers reassemble parent/child relationships via `parent_id`.",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "language": { "type": "string" },
+    "root_id": { "type": "integer", "minimum": 0 },
+    "nodes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Node" }
+    },
+    "had_errors": { "type": "boolean" }
+  },
+  "required": ["path", "language", "root_id", "nodes", "had_errors"],
+  "additionalProperties": false,
+  "$defs": {
+    "Node": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "integer", "minimum": 0 },
+        "parent_id": { "type": ["integer", "null"], "minimum": 0 },
+        "kind": { "type": "string" },
+        "is_named": { "type": "boolean" },
+        "start_byte": { "type": "integer", "minimum": 0 },
+        "end_byte": { "type": "integer", "minimum": 0 },
+        "start_row": { "type": "integer", "minimum": 0 },
+        "start_col": { "type": "integer", "minimum": 0 },
+        "end_row": { "type": "integer", "minimum": 0 },
+        "end_col": { "type": "integer", "minimum": 0 }
+      },
+      "required": [
+        "id",
+        "parent_id",
+        "kind",
+        "is_named",
+        "start_byte",
+        "end_byte",
+        "start_row",
+        "start_col",
+        "end_row",
+        "end_col"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/schemas/ast/symbols.request.json
+++ b/crates/harn-hostlib/schemas/ast/symbols.request.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/symbols.request.json",
+  "title": "ast.symbols request",
+  "description": "Extract a flat symbol list (functions, classes, methods, etc.) from a single source file.",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "language": { "type": "string" },
+    "kinds": {
+      "type": "array",
+      "description": "Optional filter; when omitted all symbol kinds are returned.",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["path"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/ast/symbols.response.json
+++ b/crates/harn-hostlib/schemas/ast/symbols.response.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/symbols.response.json",
+  "title": "ast.symbols response",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "language": { "type": "string" },
+    "symbols": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Symbol" }
+    }
+  },
+  "required": ["path", "language", "symbols"],
+  "additionalProperties": false,
+  "$defs": {
+    "Symbol": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "kind": { "type": "string" },
+        "container": { "type": ["string", "null"] },
+        "start_row": { "type": "integer", "minimum": 0 },
+        "start_col": { "type": "integer", "minimum": 0 },
+        "end_row": { "type": "integer", "minimum": 0 },
+        "end_col": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["name", "kind", "start_row", "start_col", "end_row", "end_col"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/schemas/code_index/importers_of.request.json
+++ b/crates/harn-hostlib/schemas/code_index/importers_of.request.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/importers_of.request.json",
+  "title": "code_index.importers_of request",
+  "description": "Reverse import lookup: list every file that imports the given module/path.",
+  "type": "object",
+  "properties": {
+    "module": {
+      "type": "string",
+      "description": "Module identifier or absolute path."
+    }
+  },
+  "required": ["module"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/code_index/importers_of.response.json
+++ b/crates/harn-hostlib/schemas/code_index/importers_of.response.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/importers_of.response.json",
+  "title": "code_index.importers_of response",
+  "type": "object",
+  "properties": {
+    "module": { "type": "string" },
+    "importers": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["module", "importers"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/code_index/imports_for.request.json
+++ b/crates/harn-hostlib/schemas/code_index/imports_for.request.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/imports_for.request.json",
+  "title": "code_index.imports_for request",
+  "description": "List the modules/files that the given file imports.",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" }
+  },
+  "required": ["path"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/code_index/imports_for.response.json
+++ b/crates/harn-hostlib/schemas/code_index/imports_for.response.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/imports_for.response.json",
+  "title": "code_index.imports_for response",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "imports": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Import" }
+    }
+  },
+  "required": ["path", "imports"],
+  "additionalProperties": false,
+  "$defs": {
+    "Import": {
+      "type": "object",
+      "properties": {
+        "module": { "type": "string" },
+        "resolved_path": { "type": ["string", "null"] },
+        "kind": {
+          "type": "string",
+          "description": "Language-specific kind (e.g. \"use\", \"import\", \"require\", \"include\")."
+        }
+      },
+      "required": ["module", "kind"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/schemas/code_index/query.request.json
+++ b/crates/harn-hostlib/schemas/code_index/query.request.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/query.request.json",
+  "title": "code_index.query request",
+  "description": "Query the trigram/word index for files containing a literal substring. Designed for fast suggest-style lookups; use `tools.search` for full regex.",
+  "type": "object",
+  "properties": {
+    "needle": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Literal substring to look up."
+    },
+    "case_sensitive": { "type": "boolean", "default": false },
+    "max_results": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 100
+    },
+    "scope": {
+      "type": "array",
+      "description": "Optional list of paths to restrict the query to.",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["needle"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/code_index/query.response.json
+++ b/crates/harn-hostlib/schemas/code_index/query.response.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/query.response.json",
+  "title": "code_index.query response",
+  "type": "object",
+  "properties": {
+    "results": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Hit" }
+    },
+    "truncated": {
+      "type": "boolean",
+      "description": "True when `max_results` was reached and more candidate files remain."
+    }
+  },
+  "required": ["results", "truncated"],
+  "additionalProperties": false,
+  "$defs": {
+    "Hit": {
+      "type": "object",
+      "properties": {
+        "path": { "type": "string" },
+        "score": { "type": "number" },
+        "match_count": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["path", "score", "match_count"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/schemas/code_index/rebuild.request.json
+++ b/crates/harn-hostlib/schemas/code_index/rebuild.request.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/rebuild.request.json",
+  "title": "code_index.rebuild request",
+  "description": "Rebuild the code index from scratch. `force` skips the modification-time short-circuit.",
+  "type": "object",
+  "properties": {
+    "root": { "type": "string", "description": "Project root to index. Defaults to the current workspace root." },
+    "force": { "type": "boolean", "default": false }
+  },
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/code_index/rebuild.response.json
+++ b/crates/harn-hostlib/schemas/code_index/rebuild.response.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/rebuild.response.json",
+  "title": "code_index.rebuild response",
+  "type": "object",
+  "properties": {
+    "files_indexed": { "type": "integer", "minimum": 0 },
+    "files_skipped": { "type": "integer", "minimum": 0 },
+    "elapsed_ms": { "type": "integer", "minimum": 0 }
+  },
+  "required": ["files_indexed", "files_skipped", "elapsed_ms"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/code_index/stats.request.json
+++ b/crates/harn-hostlib/schemas/code_index/stats.request.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/stats.request.json",
+  "title": "code_index.stats request",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/code_index/stats.response.json
+++ b/crates/harn-hostlib/schemas/code_index/stats.response.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/stats.response.json",
+  "title": "code_index.stats response",
+  "type": "object",
+  "properties": {
+    "indexed_files": { "type": "integer", "minimum": 0 },
+    "trigrams": { "type": "integer", "minimum": 0 },
+    "words": { "type": "integer", "minimum": 0 },
+    "memory_bytes": { "type": "integer", "minimum": 0 },
+    "last_rebuild_unix_ms": { "type": ["integer", "null"], "minimum": 0 }
+  },
+  "required": ["indexed_files", "trigrams", "words", "memory_bytes", "last_rebuild_unix_ms"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs_watch/subscribe.request.json
+++ b/crates/harn-hostlib/schemas/fs_watch/subscribe.request.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs_watch/subscribe.request.json",
+  "title": "fs_watch.subscribe request",
+  "description": "Subscribe to filesystem change events under one or more paths. Returns a handle that the host uses to deliver events back over the bridge.",
+  "type": "object",
+  "properties": {
+    "paths": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "recursive": { "type": "boolean", "default": true },
+    "debounce_ms": { "type": "integer", "minimum": 0, "default": 50 },
+    "kinds": {
+      "type": "array",
+      "description": "Optional filter on event kinds (`create`, `modify`, `remove`, `rename`).",
+      "items": { "type": "string", "enum": ["create", "modify", "remove", "rename"] }
+    }
+  },
+  "required": ["paths"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs_watch/subscribe.response.json
+++ b/crates/harn-hostlib/schemas/fs_watch/subscribe.response.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs_watch/subscribe.response.json",
+  "title": "fs_watch.subscribe response",
+  "type": "object",
+  "properties": {
+    "subscription_id": { "type": "string" }
+  },
+  "required": ["subscription_id"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs_watch/unsubscribe.request.json
+++ b/crates/harn-hostlib/schemas/fs_watch/unsubscribe.request.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs_watch/unsubscribe.request.json",
+  "title": "fs_watch.unsubscribe request",
+  "type": "object",
+  "properties": {
+    "subscription_id": { "type": "string" }
+  },
+  "required": ["subscription_id"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs_watch/unsubscribe.response.json
+++ b/crates/harn-hostlib/schemas/fs_watch/unsubscribe.response.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs_watch/unsubscribe.response.json",
+  "title": "fs_watch.unsubscribe response",
+  "type": "object",
+  "properties": {
+    "removed": {
+      "type": "boolean",
+      "description": "False if the subscription_id was unknown (already gone)."
+    }
+  },
+  "required": ["removed"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/scanner/scan_incremental.request.json
+++ b/crates/harn-hostlib/schemas/scanner/scan_incremental.request.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/scanner/scan_incremental.request.json",
+  "title": "scanner.scan_incremental request",
+  "description": "Compute a delta against a prior `scan_project` snapshot.",
+  "type": "object",
+  "properties": {
+    "snapshot_token": { "type": "string" }
+  },
+  "required": ["snapshot_token"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/scanner/scan_incremental.response.json
+++ b/crates/harn-hostlib/schemas/scanner/scan_incremental.response.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/scanner/scan_incremental.response.json",
+  "title": "scanner.scan_incremental response",
+  "type": "object",
+  "properties": {
+    "snapshot_token": { "type": "string" },
+    "added": { "type": "array", "items": { "type": "string" } },
+    "modified": { "type": "array", "items": { "type": "string" } },
+    "removed": { "type": "array", "items": { "type": "string" } }
+  },
+  "required": ["snapshot_token", "added", "modified", "removed"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/scanner/scan_project.request.json
+++ b/crates/harn-hostlib/schemas/scanner/scan_project.request.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/scanner/scan_project.request.json",
+  "title": "scanner.scan_project request",
+  "description": "Walk the project root and return a deterministic file list. Honors `.gitignore` and friends through `ignore`.",
+  "type": "object",
+  "properties": {
+    "root": { "type": "string" },
+    "include_hidden": { "type": "boolean", "default": false },
+    "respect_gitignore": { "type": "boolean", "default": true },
+    "max_files": { "type": "integer", "minimum": 0, "default": 0 }
+  },
+  "required": ["root"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/scanner/scan_project.response.json
+++ b/crates/harn-hostlib/schemas/scanner/scan_project.response.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/scanner/scan_project.response.json",
+  "title": "scanner.scan_project response",
+  "type": "object",
+  "properties": {
+    "root": { "type": "string" },
+    "files": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Entry" }
+    },
+    "snapshot_token": {
+      "type": "string",
+      "description": "Opaque cookie passed back to `scan_incremental` to compute deltas."
+    },
+    "truncated": { "type": "boolean" }
+  },
+  "required": ["root", "files", "snapshot_token", "truncated"],
+  "additionalProperties": false,
+  "$defs": {
+    "Entry": {
+      "type": "object",
+      "properties": {
+        "path": { "type": "string" },
+        "size": { "type": "integer", "minimum": 0 },
+        "modified_unix_ms": { "type": "integer", "minimum": 0 },
+        "is_dir": { "type": "boolean" }
+      },
+      "required": ["path", "size", "modified_unix_ms", "is_dir"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/schemas/tools/delete_file.request.json
+++ b/crates/harn-hostlib/schemas/tools/delete_file.request.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/delete_file.request.json",
+  "title": "tools.delete_file request",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "recursive": { "type": "boolean", "default": false }
+  },
+  "required": ["path"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/delete_file.response.json
+++ b/crates/harn-hostlib/schemas/tools/delete_file.response.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/delete_file.response.json",
+  "title": "tools.delete_file response",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "removed": { "type": "boolean" }
+  },
+  "required": ["path", "removed"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/get_file_outline.request.json
+++ b/crates/harn-hostlib/schemas/tools/get_file_outline.request.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/get_file_outline.request.json",
+  "title": "tools.get_file_outline request",
+  "description": "Convenience wrapper around `ast.outline` shaped to match the existing burin-code tool surface.",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "max_depth": { "type": "integer", "minimum": 0 }
+  },
+  "required": ["path"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/get_file_outline.response.json
+++ b/crates/harn-hostlib/schemas/tools/get_file_outline.response.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/get_file_outline.response.json",
+  "title": "tools.get_file_outline response",
+  "description": "Same shape as `ast.outline`. Inlined rather than referenced so the schema is self-contained for downstream drift tests.",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "language": { "type": "string" },
+    "items": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/OutlineItem" }
+    }
+  },
+  "required": ["path", "language", "items"],
+  "additionalProperties": false,
+  "$defs": {
+    "OutlineItem": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "kind": { "type": "string" },
+        "start_row": { "type": "integer", "minimum": 0 },
+        "end_row": { "type": "integer", "minimum": 0 },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/OutlineItem" }
+        }
+      },
+      "required": ["name", "kind", "start_row", "end_row", "children"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/schemas/tools/git.request.json
+++ b/crates/harn-hostlib/schemas/tools/git.request.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/git.request.json",
+  "title": "tools.git request",
+  "description": "Read-only git inspection backed by `gix`. Commands that mutate the repo go through host-owned approval flows and are intentionally not part of this surface.",
+  "type": "object",
+  "properties": {
+    "operation": {
+      "type": "string",
+      "enum": [
+        "status",
+        "diff",
+        "log",
+        "blame",
+        "show",
+        "branch_list",
+        "current_branch",
+        "remote_list"
+      ]
+    },
+    "repo": { "type": "string" },
+    "path": { "type": "string" },
+    "rev": { "type": "string" },
+    "rev_range": { "type": "string" },
+    "max_count": { "type": "integer", "minimum": 1 }
+  },
+  "required": ["operation"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/git.response.json
+++ b/crates/harn-hostlib/schemas/tools/git.response.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/git.response.json",
+  "title": "tools.git response",
+  "description": "Free-form payload keyed by `operation`. Concrete shapes are nailed down in issue C2; until then the response is opaque JSON so the contract can evolve.",
+  "type": "object",
+  "properties": {
+    "operation": { "type": "string" },
+    "repo": { "type": "string" },
+    "data": {}
+  },
+  "required": ["operation", "data"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/inspect_test_results.request.json
+++ b/crates/harn-hostlib/schemas/tools/inspect_test_results.request.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/inspect_test_results.request.json",
+  "title": "tools.inspect_test_results request",
+  "description": "Fetch structured per-test failure detail for a previous `run_test` invocation.",
+  "type": "object",
+  "properties": {
+    "result_handle": { "type": "string" },
+    "include_passing": { "type": "boolean", "default": false }
+  },
+  "required": ["result_handle"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/inspect_test_results.response.json
+++ b/crates/harn-hostlib/schemas/tools/inspect_test_results.response.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/inspect_test_results.response.json",
+  "title": "tools.inspect_test_results response",
+  "type": "object",
+  "properties": {
+    "result_handle": { "type": "string" },
+    "tests": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/TestRecord" }
+    }
+  },
+  "required": ["result_handle", "tests"],
+  "additionalProperties": false,
+  "$defs": {
+    "TestRecord": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "status": {
+          "type": "string",
+          "enum": ["passed", "failed", "skipped", "errored"]
+        },
+        "duration_ms": { "type": "integer", "minimum": 0 },
+        "message": { "type": ["string", "null"] },
+        "stdout": { "type": ["string", "null"] },
+        "stderr": { "type": ["string", "null"] },
+        "path": { "type": ["string", "null"] },
+        "line": { "type": ["integer", "null"], "minimum": 1 }
+      },
+      "required": ["name", "status", "duration_ms"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/schemas/tools/list_directory.request.json
+++ b/crates/harn-hostlib/schemas/tools/list_directory.request.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/list_directory.request.json",
+  "title": "tools.list_directory request",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "include_hidden": { "type": "boolean", "default": false },
+    "max_entries": { "type": "integer", "minimum": 0, "default": 0 }
+  },
+  "required": ["path"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/list_directory.response.json
+++ b/crates/harn-hostlib/schemas/tools/list_directory.response.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/list_directory.response.json",
+  "title": "tools.list_directory response",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "entries": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Entry" }
+    },
+    "truncated": { "type": "boolean" }
+  },
+  "required": ["path", "entries", "truncated"],
+  "additionalProperties": false,
+  "$defs": {
+    "Entry": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "is_dir": { "type": "boolean" },
+        "is_symlink": { "type": "boolean" },
+        "size": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["name", "is_dir", "is_symlink", "size"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/schemas/tools/manage_packages.request.json
+++ b/crates/harn-hostlib/schemas/tools/manage_packages.request.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/manage_packages.request.json",
+  "title": "tools.manage_packages request",
+  "description": "Add, remove, or refresh project dependencies. The host is responsible for surfacing approval before any mutation actually runs.",
+  "type": "object",
+  "properties": {
+    "operation": {
+      "type": "string",
+      "enum": ["install", "add", "remove", "update", "refresh"]
+    },
+    "ecosystem": {
+      "type": "string",
+      "description": "e.g. \"cargo\", \"npm\", \"swift\", \"pip\"; resolved by the host when omitted."
+    },
+    "packages": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "cwd": { "type": "string" },
+    "dev": { "type": "boolean", "default": false }
+  },
+  "required": ["operation"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/manage_packages.response.json
+++ b/crates/harn-hostlib/schemas/tools/manage_packages.response.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/manage_packages.response.json",
+  "title": "tools.manage_packages response",
+  "type": "object",
+  "properties": {
+    "operation": { "type": "string" },
+    "ecosystem": { "type": "string" },
+    "exit_code": { "type": "integer" },
+    "stdout": { "type": "string" },
+    "stderr": { "type": "string" },
+    "duration_ms": { "type": "integer", "minimum": 0 },
+    "lockfile_changed": { "type": "boolean" }
+  },
+  "required": ["operation", "ecosystem", "exit_code", "stdout", "stderr", "duration_ms"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/read_file.request.json
+++ b/crates/harn-hostlib/schemas/tools/read_file.request.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/read_file.request.json",
+  "title": "tools.read_file request",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "offset": { "type": "integer", "minimum": 0, "default": 0 },
+    "limit_bytes": { "type": "integer", "minimum": 0, "default": 0 },
+    "encoding": {
+      "type": "string",
+      "enum": ["utf-8", "binary"],
+      "default": "utf-8"
+    }
+  },
+  "required": ["path"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/read_file.response.json
+++ b/crates/harn-hostlib/schemas/tools/read_file.response.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/read_file.response.json",
+  "title": "tools.read_file response",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "encoding": { "type": "string", "enum": ["utf-8", "base64"] },
+    "content": { "type": "string" },
+    "size": { "type": "integer", "minimum": 0 },
+    "truncated": { "type": "boolean" }
+  },
+  "required": ["path", "encoding", "content", "size", "truncated"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/run_build_command.request.json
+++ b/crates/harn-hostlib/schemas/tools/run_build_command.request.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/run_build_command.request.json",
+  "title": "tools.run_build_command request",
+  "type": "object",
+  "properties": {
+    "argv": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "cwd": { "type": "string" },
+    "target": { "type": "string" },
+    "release": { "type": "boolean", "default": false },
+    "timeout_ms": { "type": "integer", "minimum": 0 }
+  },
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/run_build_command.response.json
+++ b/crates/harn-hostlib/schemas/tools/run_build_command.response.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/run_build_command.response.json",
+  "title": "tools.run_build_command response",
+  "type": "object",
+  "properties": {
+    "exit_code": { "type": "integer" },
+    "stdout": { "type": "string" },
+    "stderr": { "type": "string" },
+    "duration_ms": { "type": "integer", "minimum": 0 },
+    "diagnostics": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Diagnostic" }
+    }
+  },
+  "required": ["exit_code", "stdout", "stderr", "duration_ms"],
+  "additionalProperties": false,
+  "$defs": {
+    "Diagnostic": {
+      "type": "object",
+      "properties": {
+        "severity": {
+          "type": "string",
+          "enum": ["error", "warning", "note", "help"]
+        },
+        "message": { "type": "string" },
+        "path": { "type": ["string", "null"] },
+        "line": { "type": ["integer", "null"], "minimum": 1 },
+        "column": { "type": ["integer", "null"], "minimum": 1 }
+      },
+      "required": ["severity", "message"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/schemas/tools/run_command.request.json
+++ b/crates/harn-hostlib/schemas/tools/run_command.request.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/run_command.request.json",
+  "title": "tools.run_command request",
+  "type": "object",
+  "properties": {
+    "argv": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "cwd": { "type": "string" },
+    "env": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "stdin": { "type": "string" },
+    "timeout_ms": { "type": "integer", "minimum": 0 },
+    "capture_stderr": { "type": "boolean", "default": true }
+  },
+  "required": ["argv"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/run_command.response.json
+++ b/crates/harn-hostlib/schemas/tools/run_command.response.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/run_command.response.json",
+  "title": "tools.run_command response",
+  "type": "object",
+  "properties": {
+    "exit_code": { "type": "integer" },
+    "signal": { "type": ["string", "null"] },
+    "stdout": { "type": "string" },
+    "stderr": { "type": "string" },
+    "duration_ms": { "type": "integer", "minimum": 0 },
+    "timed_out": { "type": "boolean" }
+  },
+  "required": ["exit_code", "stdout", "stderr", "duration_ms", "timed_out"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/run_test.request.json
+++ b/crates/harn-hostlib/schemas/tools/run_test.request.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/run_test.request.json",
+  "title": "tools.run_test request",
+  "description": "Run a project-defined test command. Resolves the runner from the workspace manifest unless `argv` is provided explicitly.",
+  "type": "object",
+  "properties": {
+    "argv": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "cwd": { "type": "string" },
+    "filter": {
+      "type": "string",
+      "description": "Optional test name / path filter passed through to the runner."
+    },
+    "timeout_ms": { "type": "integer", "minimum": 0 }
+  },
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/run_test.response.json
+++ b/crates/harn-hostlib/schemas/tools/run_test.response.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/run_test.response.json",
+  "title": "tools.run_test response",
+  "type": "object",
+  "properties": {
+    "exit_code": { "type": "integer" },
+    "stdout": { "type": "string" },
+    "stderr": { "type": "string" },
+    "duration_ms": { "type": "integer", "minimum": 0 },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "result_handle": {
+      "type": "string",
+      "description": "Opaque handle that callers pass to `inspect_test_results` to retrieve structured failures."
+    }
+  },
+  "required": ["exit_code", "stdout", "stderr", "duration_ms"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/search.request.json
+++ b/crates/harn-hostlib/schemas/tools/search.request.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/search.request.json",
+  "title": "tools.search request",
+  "description": "Ripgrep-style content search powered by `grep-searcher` + `ignore`.",
+  "type": "object",
+  "properties": {
+    "pattern": { "type": "string", "minLength": 1 },
+    "path": { "type": "string" },
+    "glob": { "type": "string" },
+    "case_insensitive": { "type": "boolean", "default": false },
+    "fixed_strings": {
+      "type": "boolean",
+      "description": "Treat `pattern` as a literal substring rather than a regex.",
+      "default": false
+    },
+    "max_matches": { "type": "integer", "minimum": 1, "default": 1000 },
+    "context_before": { "type": "integer", "minimum": 0, "default": 0 },
+    "context_after": { "type": "integer", "minimum": 0, "default": 0 },
+    "include_hidden": { "type": "boolean", "default": false }
+  },
+  "required": ["pattern"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/search.response.json
+++ b/crates/harn-hostlib/schemas/tools/search.response.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/search.response.json",
+  "title": "tools.search response",
+  "type": "object",
+  "properties": {
+    "matches": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Match" }
+    },
+    "truncated": { "type": "boolean" }
+  },
+  "required": ["matches", "truncated"],
+  "additionalProperties": false,
+  "$defs": {
+    "Match": {
+      "type": "object",
+      "properties": {
+        "path": { "type": "string" },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 },
+        "text": { "type": "string" },
+        "context_before": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "context_after": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["path", "line", "column", "text"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/schemas/tools/write_file.request.json
+++ b/crates/harn-hostlib/schemas/tools/write_file.request.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/write_file.request.json",
+  "title": "tools.write_file request",
+  "description": "Atomic file write. Hosts implement the actual on-disk mutation; this surface only describes the intent.",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "content": { "type": "string" },
+    "encoding": {
+      "type": "string",
+      "enum": ["utf-8", "base64"],
+      "default": "utf-8"
+    },
+    "create_parents": { "type": "boolean", "default": true },
+    "overwrite": { "type": "boolean", "default": true }
+  },
+  "required": ["path", "content"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/write_file.response.json
+++ b/crates/harn-hostlib/schemas/tools/write_file.response.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/write_file.response.json",
+  "title": "tools.write_file response",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "bytes_written": { "type": "integer", "minimum": 0 },
+    "created": { "type": "boolean" }
+  },
+  "required": ["path", "bytes_written", "created"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/src/ast/mod.rs
+++ b/crates/harn-hostlib/src/ast/mod.rs
@@ -1,0 +1,25 @@
+//! AST host capability.
+//!
+//! Wraps tree-sitter parsing, symbol extraction, and outline generation —
+//! the Swift `Sources/ASTEngine/` surface ported into Rust. Implementation
+//! lands in follow-up issue B2; this scaffold registers the contract so
+//! `burin-code`'s schema-drift tests can lock the public surface today.
+
+use crate::registry::{BuiltinRegistry, HostlibCapability};
+
+/// AST capability handle. Stateless today; will own a tree-sitter language
+/// registry and parser pool once the implementation lands.
+#[derive(Default)]
+pub struct AstCapability;
+
+impl HostlibCapability for AstCapability {
+    fn module_name(&self) -> &'static str {
+        "ast"
+    }
+
+    fn register_builtins(&self, registry: &mut BuiltinRegistry) {
+        registry.register_unimplemented("hostlib_ast_parse_file", "ast", "parse_file");
+        registry.register_unimplemented("hostlib_ast_symbols", "ast", "symbols");
+        registry.register_unimplemented("hostlib_ast_outline", "ast", "outline");
+    }
+}

--- a/crates/harn-hostlib/src/code_index/mod.rs
+++ b/crates/harn-hostlib/src/code_index/mod.rs
@@ -1,0 +1,35 @@
+//! Code index host capability.
+//!
+//! Ports the deterministic trigram/word index that lived in
+//! `Sources/BurinCodeIndex/` on the Swift side. Implementation lands in
+//! issue B3; this scaffold registers the contract so consumers can wire
+//! against the stable surface today.
+
+use crate::registry::{BuiltinRegistry, HostlibCapability};
+
+/// Code-index capability handle. Stateless today; will own the index actor
+/// (or its async handle) once the implementation lands.
+#[derive(Default)]
+pub struct CodeIndexCapability;
+
+impl HostlibCapability for CodeIndexCapability {
+    fn module_name(&self) -> &'static str {
+        "code_index"
+    }
+
+    fn register_builtins(&self, registry: &mut BuiltinRegistry) {
+        registry.register_unimplemented("hostlib_code_index_query", "code_index", "query");
+        registry.register_unimplemented("hostlib_code_index_rebuild", "code_index", "rebuild");
+        registry.register_unimplemented("hostlib_code_index_stats", "code_index", "stats");
+        registry.register_unimplemented(
+            "hostlib_code_index_imports_for",
+            "code_index",
+            "imports_for",
+        );
+        registry.register_unimplemented(
+            "hostlib_code_index_importers_of",
+            "code_index",
+            "importers_of",
+        );
+    }
+}

--- a/crates/harn-hostlib/src/error.rs
+++ b/crates/harn-hostlib/src/error.rs
@@ -1,0 +1,96 @@
+//! Error type for hostlib host calls.
+//!
+//! Builtins translate this into VM-level errors via [`Into<harn_vm::VmError>`]
+//! so that Harn scripts see structured exceptions rather than panics.
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use harn_vm::{VmError, VmValue};
+
+/// All errors a hostlib builtin can surface.
+///
+/// Variants intentionally describe the *kind* of failure rather than the
+/// specific module — every module routes its missing-implementation errors
+/// through [`HostlibError::Unimplemented`] so embedders and tests can
+/// distinguish "this is a stub waiting for B2/B3/etc." from real failures
+/// once implementations land.
+#[derive(Debug, thiserror::Error)]
+pub enum HostlibError {
+    /// The method exists in the registration table but has no implementation
+    /// yet. This is the canonical scaffold-stage error: it tells callers
+    /// "the contract is stable, the body is coming in a follow-up issue."
+    #[error(
+        "hostlib: {builtin} is not implemented yet (scaffold; tracked by issue #563 follow-ups)"
+    )]
+    Unimplemented {
+        /// Fully-qualified builtin name, e.g. `"hostlib_ast_parse_file"`.
+        builtin: &'static str,
+    },
+
+    /// A required parameter was missing from the call payload.
+    #[error("hostlib: {builtin}: missing required parameter '{param}'")]
+    MissingParameter {
+        /// Fully-qualified builtin name.
+        builtin: &'static str,
+        /// Name of the missing parameter.
+        param: &'static str,
+    },
+
+    /// A parameter was present but had the wrong shape (wrong type, malformed).
+    #[error("hostlib: {builtin}: invalid parameter '{param}': {message}")]
+    InvalidParameter {
+        /// Fully-qualified builtin name.
+        builtin: &'static str,
+        /// Name of the invalid parameter.
+        param: &'static str,
+        /// Human-readable description of the violation.
+        message: String,
+    },
+
+    /// Catch-all wrapper for I/O, parsing, or other backend failures.
+    /// Implementations land in follow-up issues; today nothing surfaces
+    /// this variant.
+    #[error("hostlib: {builtin}: {message}")]
+    Backend {
+        /// Fully-qualified builtin name.
+        builtin: &'static str,
+        /// Human-readable failure description.
+        message: String,
+    },
+}
+
+impl HostlibError {
+    /// The fully-qualified builtin name this error came from. Useful for
+    /// embedder logging and for the routing tests in `tests/`.
+    pub fn builtin(&self) -> &'static str {
+        match self {
+            HostlibError::Unimplemented { builtin }
+            | HostlibError::MissingParameter { builtin, .. }
+            | HostlibError::InvalidParameter { builtin, .. }
+            | HostlibError::Backend { builtin, .. } => builtin,
+        }
+    }
+}
+
+impl From<HostlibError> for VmError {
+    fn from(err: HostlibError) -> VmError {
+        // Surface as a `Thrown` dict so Harn `try`/`catch` can pattern-match
+        // on `kind`, `builtin`, and `message`. This matches how the existing
+        // `host_call` error path shapes its exceptions.
+        let kind = match err {
+            HostlibError::Unimplemented { .. } => "unimplemented",
+            HostlibError::MissingParameter { .. } => "missing_parameter",
+            HostlibError::InvalidParameter { .. } => "invalid_parameter",
+            HostlibError::Backend { .. } => "backend_error",
+        };
+        let builtin = err.builtin();
+        let message = err.to_string();
+
+        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        dict.insert("kind".to_string(), VmValue::String(Rc::from(kind)));
+        dict.insert("builtin".to_string(), VmValue::String(Rc::from(builtin)));
+        dict.insert("message".to_string(), VmValue::String(Rc::from(message)));
+        VmError::Thrown(VmValue::Dict(Rc::new(dict)))
+    }
+}

--- a/crates/harn-hostlib/src/fs_watch/mod.rs
+++ b/crates/harn-hostlib/src/fs_watch/mod.rs
@@ -1,0 +1,21 @@
+//! File-system watch host capability.
+//!
+//! Wraps `notify` to deliver change events to subscribers identified by
+//! handle. Implementation lands in issue C1.
+
+use crate::registry::{BuiltinRegistry, HostlibCapability};
+
+/// File-watch capability handle.
+#[derive(Default)]
+pub struct FsWatchCapability;
+
+impl HostlibCapability for FsWatchCapability {
+    fn module_name(&self) -> &'static str {
+        "fs_watch"
+    }
+
+    fn register_builtins(&self, registry: &mut BuiltinRegistry) {
+        registry.register_unimplemented("hostlib_fs_watch_subscribe", "fs_watch", "subscribe");
+        registry.register_unimplemented("hostlib_fs_watch_unsubscribe", "fs_watch", "unsubscribe");
+    }
+}

--- a/crates/harn-hostlib/src/lib.rs
+++ b/crates/harn-hostlib/src/lib.rs
@@ -1,0 +1,60 @@
+//! `harn-hostlib`: opt-in host builtins for code intelligence (tree-sitter,
+//! repo scanning, deterministic indexing) and tool execution (search, file
+//! I/O, git, process lifecycle, file watcher).
+//!
+//! This crate is the Rust home of two classes of code that previously lived
+//! in `burin-labs/burin-code`'s Swift `BurinCore`:
+//!
+//! 1. **Code intelligence** — `ast/`, `code_index/`, `scanner/`, `fs_watch/`.
+//! 2. **Deterministic tools** — `tools/` (search, fs, git, process).
+//!
+//! These don't belong inside `harn-vm` — pulling tree-sitter grammars,
+//! ripgrep, and `notify` into the VM would balloon the footprint of every
+//! pipeline that doesn't index host code. Instead, this crate exposes a
+//! single [`HostlibCapability`] trait. Embedders (today: `harn-cli`'s ACP
+//! server) compose the modules they need via [`HostlibRegistry`] and wire
+//! the resulting builtins into the VM through [`harn_vm::Vm::register_builtin`]
+//! / [`harn_vm::Vm::register_async_builtin`].
+//!
+//! ## Status
+//!
+//! This crate is a scaffold (issue #563). Every host method here returns
+//! [`HostlibError::Unimplemented`] until the implementation lands in
+//! follow-up issues B2/B3/B4/C1/C2/C3. The public surface — module names,
+//! method names, and JSON schemas under `schemas/` — is the source of truth
+//! for `burin-code`'s schema-drift tests, so it must stay stable across the
+//! follow-up PRs.
+
+#![deny(rust_2018_idioms)]
+#![warn(missing_docs)]
+
+pub mod ast;
+pub mod code_index;
+pub mod error;
+pub mod fs_watch;
+pub mod scanner;
+pub mod schemas;
+pub mod tools;
+
+mod registry;
+
+pub use error::HostlibError;
+pub use registry::{BuiltinRegistry, HostlibCapability, HostlibRegistry, RegisteredBuiltin};
+
+/// Convenience: build a `HostlibRegistry` populated with every capability
+/// the crate ships, register them on the supplied VM, and return the
+/// registry so callers can introspect (e.g. for schema-drift tests).
+///
+/// This is the canonical entry point for embedders that want the full
+/// hostlib surface; pick-and-choose embedders should construct
+/// [`HostlibRegistry`] directly.
+pub fn install_default(vm: &mut harn_vm::Vm) -> HostlibRegistry {
+    let mut registry = HostlibRegistry::new()
+        .with(ast::AstCapability)
+        .with(code_index::CodeIndexCapability)
+        .with(scanner::ScannerCapability)
+        .with(fs_watch::FsWatchCapability)
+        .with(tools::ToolsCapability);
+    registry.register_into_vm(vm);
+    registry
+}

--- a/crates/harn-hostlib/src/registry.rs
+++ b/crates/harn-hostlib/src/registry.rs
@@ -1,0 +1,206 @@
+//! Registration plumbing.
+//!
+//! Each module exposes a [`HostlibCapability`] implementation that pushes
+//! its builtins into a [`BuiltinRegistry`]. The registry can then either
+//! be wired into a real [`harn_vm::Vm`] (production path) or introspected
+//! by tests to assert the exposed surface without touching the VM.
+
+use std::sync::Arc;
+
+use harn_vm::{Vm, VmError, VmValue};
+
+use crate::error::HostlibError;
+
+/// Sync builtin handler signature. Mirrors the closure type accepted by
+/// [`harn_vm::Vm::register_builtin`]; we keep it `Send + Sync` so capability
+/// instances can be shared across threads if an embedder ever wants that.
+pub type SyncHandler = Arc<dyn Fn(&[VmValue]) -> Result<VmValue, HostlibError> + Send + Sync>;
+
+/// One registered builtin. The name is what Harn scripts call (e.g.
+/// `hostlib_ast_parse_file`); `module` and `method` are the canonical
+/// schema-directory coordinates (`schemas/<module>/<method>.request.json`).
+#[derive(Clone)]
+pub struct RegisteredBuiltin {
+    /// Builtin name as Harn scripts see it.
+    pub name: &'static str,
+    /// Module bucket (e.g. `"ast"`, `"tools"`).
+    pub module: &'static str,
+    /// Method name within the module (e.g. `"parse_file"`, `"search"`).
+    pub method: &'static str,
+    /// Handler invoked when Harn calls the builtin.
+    pub handler: SyncHandler,
+}
+
+impl std::fmt::Debug for RegisteredBuiltin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegisteredBuiltin")
+            .field("name", &self.name)
+            .field("module", &self.module)
+            .field("method", &self.method)
+            .finish()
+    }
+}
+
+/// Mutable collector each capability writes into during `register`.
+#[derive(Default)]
+pub struct BuiltinRegistry {
+    builtins: Vec<RegisteredBuiltin>,
+}
+
+impl BuiltinRegistry {
+    /// Construct an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Push one builtin. Capabilities call this from `register_builtins`.
+    pub fn register(&mut self, builtin: RegisteredBuiltin) {
+        self.builtins.push(builtin);
+    }
+
+    /// Convenience: register a builtin whose body is the `unimplemented`
+    /// scaffold error. Every module currently uses this.
+    pub fn register_unimplemented(
+        &mut self,
+        name: &'static str,
+        module: &'static str,
+        method: &'static str,
+    ) {
+        let handler: SyncHandler =
+            Arc::new(move |_args| Err(HostlibError::Unimplemented { builtin: name }));
+        self.register(RegisteredBuiltin {
+            name,
+            module,
+            method,
+            handler,
+        });
+    }
+
+    /// Iterate over every registered builtin.
+    pub fn iter(&self) -> impl Iterator<Item = &RegisteredBuiltin> {
+        self.builtins.iter()
+    }
+
+    /// Total count.
+    pub fn len(&self) -> usize {
+        self.builtins.len()
+    }
+
+    /// True when nothing has been registered yet.
+    pub fn is_empty(&self) -> bool {
+        self.builtins.is_empty()
+    }
+
+    /// Look up a builtin by its Harn-visible name.
+    pub fn find(&self, name: &str) -> Option<&RegisteredBuiltin> {
+        self.builtins.iter().find(|b| b.name == name)
+    }
+}
+
+/// One module's worth of builtins. Kept tiny on purpose: capabilities exist
+/// purely so tests can reason about the surface without booting a VM, and
+/// so embedders can opt into individual modules.
+pub trait HostlibCapability: 'static {
+    /// Module name (matches the `schemas/<module>/` directory).
+    fn module_name(&self) -> &'static str;
+
+    /// Push every builtin this module exposes into `registry`.
+    fn register_builtins(&self, registry: &mut BuiltinRegistry);
+}
+
+/// Composes capabilities and emits VM registrations.
+///
+/// `HostlibRegistry` is the type embedders interact with. It owns the
+/// capability instances and the populated [`BuiltinRegistry`] together so
+/// the same surface can be inspected by tests *and* wired into a VM.
+pub struct HostlibRegistry {
+    builtins: BuiltinRegistry,
+    modules: Vec<&'static str>,
+}
+
+impl Default for HostlibRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HostlibRegistry {
+    /// Construct an empty registry. Most callers want [`crate::install_default`]
+    /// instead, which pre-populates every shipped capability.
+    pub fn new() -> Self {
+        Self {
+            builtins: BuiltinRegistry::new(),
+            modules: Vec::new(),
+        }
+    }
+
+    /// Add one capability to the registry. Returns `self` for chaining.
+    #[must_use]
+    pub fn with<C: HostlibCapability>(mut self, capability: C) -> Self {
+        let module = capability.module_name();
+        capability.register_builtins(&mut self.builtins);
+        self.modules.push(module);
+        self
+    }
+
+    /// Wire every registered builtin into the supplied VM.
+    pub fn register_into_vm(&mut self, vm: &mut Vm) {
+        for builtin in self.builtins.iter().cloned().collect::<Vec<_>>() {
+            let handler = builtin.handler.clone();
+            vm.register_builtin(
+                builtin.name,
+                move |args, _out| -> Result<VmValue, VmError> {
+                    handler(args).map_err(VmError::from)
+                },
+            );
+        }
+    }
+
+    /// Borrow the underlying [`BuiltinRegistry`] for introspection (e.g.
+    /// schema-drift tests).
+    pub fn builtins(&self) -> &BuiltinRegistry {
+        &self.builtins
+    }
+
+    /// List the module names that have been registered, in insertion order.
+    pub fn modules(&self) -> &[&'static str] {
+        &self.modules
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unimplemented_builtins_route_through_error() {
+        let mut registry = BuiltinRegistry::new();
+        registry.register_unimplemented("hostlib_demo", "demo", "ping");
+        let entry = registry.find("hostlib_demo").expect("registered");
+        let err = (entry.handler)(&[]).expect_err("should be unimplemented");
+        assert!(
+            matches!(err, HostlibError::Unimplemented { builtin } if builtin == "hostlib_demo")
+        );
+    }
+
+    #[test]
+    fn registry_records_modules_in_order() {
+        struct First;
+        impl HostlibCapability for First {
+            fn module_name(&self) -> &'static str {
+                "first"
+            }
+            fn register_builtins(&self, _registry: &mut BuiltinRegistry) {}
+        }
+        struct Second;
+        impl HostlibCapability for Second {
+            fn module_name(&self) -> &'static str {
+                "second"
+            }
+            fn register_builtins(&self, _registry: &mut BuiltinRegistry) {}
+        }
+
+        let registry = HostlibRegistry::new().with(First).with(Second);
+        assert_eq!(registry.modules(), &["first", "second"]);
+    }
+}

--- a/crates/harn-hostlib/src/scanner/mod.rs
+++ b/crates/harn-hostlib/src/scanner/mod.rs
@@ -1,0 +1,26 @@
+//! Repo scanner host capability.
+//!
+//! Ports `Sources/BurinCore/Scanner/` — deterministic project-wide file
+//! enumeration honoring `.gitignore` and friends, plus an incremental mode
+//! driven by a watch token. Implementation lands in issue B4.
+
+use crate::registry::{BuiltinRegistry, HostlibCapability};
+
+/// Scanner capability handle.
+#[derive(Default)]
+pub struct ScannerCapability;
+
+impl HostlibCapability for ScannerCapability {
+    fn module_name(&self) -> &'static str {
+        "scanner"
+    }
+
+    fn register_builtins(&self, registry: &mut BuiltinRegistry) {
+        registry.register_unimplemented("hostlib_scanner_scan_project", "scanner", "scan_project");
+        registry.register_unimplemented(
+            "hostlib_scanner_scan_incremental",
+            "scanner",
+            "scan_incremental",
+        );
+    }
+}

--- a/crates/harn-hostlib/src/schemas.rs
+++ b/crates/harn-hostlib/src/schemas.rs
@@ -1,0 +1,328 @@
+//! Embedded JSON Schemas for every hostlib host method.
+//!
+//! Schemas live at `schemas/<module>/<method>.{request,response}.json` and
+//! are baked into the crate at compile time via `include_str!`. They're the
+//! source of truth for `burin-code`'s schema-drift tests: the schema files
+//! ship with the crate (see the `include` field in `Cargo.toml`), and
+//! consumers fetch them through this module.
+//!
+//! Schemas use JSON Schema draft 2020-12.
+
+/// Direction of a schema (request body vs. response body).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SchemaKind {
+    /// Schema for the *input* of a host method.
+    Request,
+    /// Schema for the *output* of a host method.
+    Response,
+}
+
+/// One `(module, method, kind, schema_text)` tuple for every shipped schema.
+///
+/// Embedders use this catalog to:
+/// - assert that every registered builtin has a matching schema (drift test);
+/// - export the schemas to consumers like burin-code;
+/// - validate live request/response payloads in tests.
+pub const SCHEMAS: &[(&str, &str, SchemaKind, &str)] = &[
+    // ast/
+    (
+        "ast",
+        "parse_file",
+        SchemaKind::Request,
+        include_str!("../schemas/ast/parse_file.request.json"),
+    ),
+    (
+        "ast",
+        "parse_file",
+        SchemaKind::Response,
+        include_str!("../schemas/ast/parse_file.response.json"),
+    ),
+    (
+        "ast",
+        "symbols",
+        SchemaKind::Request,
+        include_str!("../schemas/ast/symbols.request.json"),
+    ),
+    (
+        "ast",
+        "symbols",
+        SchemaKind::Response,
+        include_str!("../schemas/ast/symbols.response.json"),
+    ),
+    (
+        "ast",
+        "outline",
+        SchemaKind::Request,
+        include_str!("../schemas/ast/outline.request.json"),
+    ),
+    (
+        "ast",
+        "outline",
+        SchemaKind::Response,
+        include_str!("../schemas/ast/outline.response.json"),
+    ),
+    // code_index/
+    (
+        "code_index",
+        "query",
+        SchemaKind::Request,
+        include_str!("../schemas/code_index/query.request.json"),
+    ),
+    (
+        "code_index",
+        "query",
+        SchemaKind::Response,
+        include_str!("../schemas/code_index/query.response.json"),
+    ),
+    (
+        "code_index",
+        "rebuild",
+        SchemaKind::Request,
+        include_str!("../schemas/code_index/rebuild.request.json"),
+    ),
+    (
+        "code_index",
+        "rebuild",
+        SchemaKind::Response,
+        include_str!("../schemas/code_index/rebuild.response.json"),
+    ),
+    (
+        "code_index",
+        "stats",
+        SchemaKind::Request,
+        include_str!("../schemas/code_index/stats.request.json"),
+    ),
+    (
+        "code_index",
+        "stats",
+        SchemaKind::Response,
+        include_str!("../schemas/code_index/stats.response.json"),
+    ),
+    (
+        "code_index",
+        "imports_for",
+        SchemaKind::Request,
+        include_str!("../schemas/code_index/imports_for.request.json"),
+    ),
+    (
+        "code_index",
+        "imports_for",
+        SchemaKind::Response,
+        include_str!("../schemas/code_index/imports_for.response.json"),
+    ),
+    (
+        "code_index",
+        "importers_of",
+        SchemaKind::Request,
+        include_str!("../schemas/code_index/importers_of.request.json"),
+    ),
+    (
+        "code_index",
+        "importers_of",
+        SchemaKind::Response,
+        include_str!("../schemas/code_index/importers_of.response.json"),
+    ),
+    // scanner/
+    (
+        "scanner",
+        "scan_project",
+        SchemaKind::Request,
+        include_str!("../schemas/scanner/scan_project.request.json"),
+    ),
+    (
+        "scanner",
+        "scan_project",
+        SchemaKind::Response,
+        include_str!("../schemas/scanner/scan_project.response.json"),
+    ),
+    (
+        "scanner",
+        "scan_incremental",
+        SchemaKind::Request,
+        include_str!("../schemas/scanner/scan_incremental.request.json"),
+    ),
+    (
+        "scanner",
+        "scan_incremental",
+        SchemaKind::Response,
+        include_str!("../schemas/scanner/scan_incremental.response.json"),
+    ),
+    // fs_watch/
+    (
+        "fs_watch",
+        "subscribe",
+        SchemaKind::Request,
+        include_str!("../schemas/fs_watch/subscribe.request.json"),
+    ),
+    (
+        "fs_watch",
+        "subscribe",
+        SchemaKind::Response,
+        include_str!("../schemas/fs_watch/subscribe.response.json"),
+    ),
+    (
+        "fs_watch",
+        "unsubscribe",
+        SchemaKind::Request,
+        include_str!("../schemas/fs_watch/unsubscribe.request.json"),
+    ),
+    (
+        "fs_watch",
+        "unsubscribe",
+        SchemaKind::Response,
+        include_str!("../schemas/fs_watch/unsubscribe.response.json"),
+    ),
+    // tools/
+    (
+        "tools",
+        "search",
+        SchemaKind::Request,
+        include_str!("../schemas/tools/search.request.json"),
+    ),
+    (
+        "tools",
+        "search",
+        SchemaKind::Response,
+        include_str!("../schemas/tools/search.response.json"),
+    ),
+    (
+        "tools",
+        "read_file",
+        SchemaKind::Request,
+        include_str!("../schemas/tools/read_file.request.json"),
+    ),
+    (
+        "tools",
+        "read_file",
+        SchemaKind::Response,
+        include_str!("../schemas/tools/read_file.response.json"),
+    ),
+    (
+        "tools",
+        "write_file",
+        SchemaKind::Request,
+        include_str!("../schemas/tools/write_file.request.json"),
+    ),
+    (
+        "tools",
+        "write_file",
+        SchemaKind::Response,
+        include_str!("../schemas/tools/write_file.response.json"),
+    ),
+    (
+        "tools",
+        "delete_file",
+        SchemaKind::Request,
+        include_str!("../schemas/tools/delete_file.request.json"),
+    ),
+    (
+        "tools",
+        "delete_file",
+        SchemaKind::Response,
+        include_str!("../schemas/tools/delete_file.response.json"),
+    ),
+    (
+        "tools",
+        "list_directory",
+        SchemaKind::Request,
+        include_str!("../schemas/tools/list_directory.request.json"),
+    ),
+    (
+        "tools",
+        "list_directory",
+        SchemaKind::Response,
+        include_str!("../schemas/tools/list_directory.response.json"),
+    ),
+    (
+        "tools",
+        "get_file_outline",
+        SchemaKind::Request,
+        include_str!("../schemas/tools/get_file_outline.request.json"),
+    ),
+    (
+        "tools",
+        "get_file_outline",
+        SchemaKind::Response,
+        include_str!("../schemas/tools/get_file_outline.response.json"),
+    ),
+    (
+        "tools",
+        "git",
+        SchemaKind::Request,
+        include_str!("../schemas/tools/git.request.json"),
+    ),
+    (
+        "tools",
+        "git",
+        SchemaKind::Response,
+        include_str!("../schemas/tools/git.response.json"),
+    ),
+    (
+        "tools",
+        "run_command",
+        SchemaKind::Request,
+        include_str!("../schemas/tools/run_command.request.json"),
+    ),
+    (
+        "tools",
+        "run_command",
+        SchemaKind::Response,
+        include_str!("../schemas/tools/run_command.response.json"),
+    ),
+    (
+        "tools",
+        "run_test",
+        SchemaKind::Request,
+        include_str!("../schemas/tools/run_test.request.json"),
+    ),
+    (
+        "tools",
+        "run_test",
+        SchemaKind::Response,
+        include_str!("../schemas/tools/run_test.response.json"),
+    ),
+    (
+        "tools",
+        "run_build_command",
+        SchemaKind::Request,
+        include_str!("../schemas/tools/run_build_command.request.json"),
+    ),
+    (
+        "tools",
+        "run_build_command",
+        SchemaKind::Response,
+        include_str!("../schemas/tools/run_build_command.response.json"),
+    ),
+    (
+        "tools",
+        "inspect_test_results",
+        SchemaKind::Request,
+        include_str!("../schemas/tools/inspect_test_results.request.json"),
+    ),
+    (
+        "tools",
+        "inspect_test_results",
+        SchemaKind::Response,
+        include_str!("../schemas/tools/inspect_test_results.response.json"),
+    ),
+    (
+        "tools",
+        "manage_packages",
+        SchemaKind::Request,
+        include_str!("../schemas/tools/manage_packages.request.json"),
+    ),
+    (
+        "tools",
+        "manage_packages",
+        SchemaKind::Response,
+        include_str!("../schemas/tools/manage_packages.response.json"),
+    ),
+];
+
+/// Look up a single schema as raw JSON text.
+pub fn lookup(module: &str, method: &str, kind: SchemaKind) -> Option<&'static str> {
+    SCHEMAS
+        .iter()
+        .find(|(m, mt, k, _)| *m == module && *mt == method && *k == kind)
+        .map(|(_, _, _, body)| *body)
+}

--- a/crates/harn-hostlib/src/tools/mod.rs
+++ b/crates/harn-hostlib/src/tools/mod.rs
@@ -1,0 +1,51 @@
+//! Deterministic tools capability.
+//!
+//! Ports the Swift `CoreToolExecutor` surface: search (ripgrep via
+//! `grep-searcher` + `ignore`), file I/O, listing, file outline, git via
+//! `gix`, and process lifecycle (`run_command`, `run_test`,
+//! `run_build_command`, `inspect_test_results`, `manage_packages`).
+//!
+//! Implementation is split across follow-up issues C2/C3.
+
+use crate::registry::{BuiltinRegistry, HostlibCapability};
+
+/// Tools capability handle.
+#[derive(Default)]
+pub struct ToolsCapability;
+
+impl HostlibCapability for ToolsCapability {
+    fn module_name(&self) -> &'static str {
+        "tools"
+    }
+
+    fn register_builtins(&self, registry: &mut BuiltinRegistry) {
+        registry.register_unimplemented("hostlib_tools_search", "tools", "search");
+        registry.register_unimplemented("hostlib_tools_read_file", "tools", "read_file");
+        registry.register_unimplemented("hostlib_tools_write_file", "tools", "write_file");
+        registry.register_unimplemented("hostlib_tools_delete_file", "tools", "delete_file");
+        registry.register_unimplemented("hostlib_tools_list_directory", "tools", "list_directory");
+        registry.register_unimplemented(
+            "hostlib_tools_get_file_outline",
+            "tools",
+            "get_file_outline",
+        );
+        registry.register_unimplemented("hostlib_tools_git", "tools", "git");
+        registry.register_unimplemented("hostlib_tools_run_command", "tools", "run_command");
+        registry.register_unimplemented("hostlib_tools_run_test", "tools", "run_test");
+        registry.register_unimplemented(
+            "hostlib_tools_run_build_command",
+            "tools",
+            "run_build_command",
+        );
+        registry.register_unimplemented(
+            "hostlib_tools_inspect_test_results",
+            "tools",
+            "inspect_test_results",
+        );
+        registry.register_unimplemented(
+            "hostlib_tools_manage_packages",
+            "tools",
+            "manage_packages",
+        );
+    }
+}

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -1,0 +1,184 @@
+//! Integration tests asserting that every module's registration surface
+//! compiles, that unimplemented methods route through `HostlibError` rather
+//! than panicking, and that every registered builtin has a matching schema.
+//!
+//! These tests are the contract that follow-up implementation issues
+//! (B2/B3/B4/C1/C2/C3) must keep green: when an issue lands, the only
+//! change here should be that a routed `Unimplemented` becomes a real
+//! return value — never a removed builtin.
+
+use harn_hostlib::{
+    ast::AstCapability, code_index::CodeIndexCapability, fs_watch::FsWatchCapability,
+    scanner::ScannerCapability, schemas, tools::ToolsCapability, BuiltinRegistry,
+    HostlibCapability, HostlibError, HostlibRegistry,
+};
+
+fn collect_into_registry<C: HostlibCapability>(cap: C) -> BuiltinRegistry {
+    let mut registry = BuiltinRegistry::new();
+    cap.register_builtins(&mut registry);
+    registry
+}
+
+fn assert_all_unimplemented(registry: &BuiltinRegistry) {
+    for entry in registry.iter() {
+        let err = (entry.handler)(&[]).expect_err("scaffold methods must be unimplemented");
+        match err {
+            HostlibError::Unimplemented { builtin } => {
+                assert_eq!(
+                    builtin, entry.name,
+                    "builtin name mismatch: registry says {} but handler says {builtin}",
+                    entry.name
+                );
+            }
+            other => panic!("expected Unimplemented, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn ast_capability_registers_documented_methods() {
+    let registry = collect_into_registry(AstCapability);
+    let names: Vec<_> = registry.iter().map(|b| b.name).collect();
+    assert_eq!(
+        names,
+        vec![
+            "hostlib_ast_parse_file",
+            "hostlib_ast_symbols",
+            "hostlib_ast_outline",
+        ]
+    );
+    assert_all_unimplemented(&registry);
+}
+
+#[test]
+fn code_index_capability_registers_documented_methods() {
+    let registry = collect_into_registry(CodeIndexCapability);
+    let names: Vec<_> = registry.iter().map(|b| b.name).collect();
+    assert_eq!(
+        names,
+        vec![
+            "hostlib_code_index_query",
+            "hostlib_code_index_rebuild",
+            "hostlib_code_index_stats",
+            "hostlib_code_index_imports_for",
+            "hostlib_code_index_importers_of",
+        ]
+    );
+    assert_all_unimplemented(&registry);
+}
+
+#[test]
+fn scanner_capability_registers_documented_methods() {
+    let registry = collect_into_registry(ScannerCapability);
+    let names: Vec<_> = registry.iter().map(|b| b.name).collect();
+    assert_eq!(
+        names,
+        vec![
+            "hostlib_scanner_scan_project",
+            "hostlib_scanner_scan_incremental"
+        ]
+    );
+    assert_all_unimplemented(&registry);
+}
+
+#[test]
+fn fs_watch_capability_registers_documented_methods() {
+    let registry = collect_into_registry(FsWatchCapability);
+    let names: Vec<_> = registry.iter().map(|b| b.name).collect();
+    assert_eq!(
+        names,
+        vec!["hostlib_fs_watch_subscribe", "hostlib_fs_watch_unsubscribe"]
+    );
+    assert_all_unimplemented(&registry);
+}
+
+#[test]
+fn tools_capability_registers_documented_methods() {
+    let registry = collect_into_registry(ToolsCapability);
+    let names: Vec<_> = registry.iter().map(|b| b.name).collect();
+    assert_eq!(
+        names,
+        vec![
+            "hostlib_tools_search",
+            "hostlib_tools_read_file",
+            "hostlib_tools_write_file",
+            "hostlib_tools_delete_file",
+            "hostlib_tools_list_directory",
+            "hostlib_tools_get_file_outline",
+            "hostlib_tools_git",
+            "hostlib_tools_run_command",
+            "hostlib_tools_run_test",
+            "hostlib_tools_run_build_command",
+            "hostlib_tools_inspect_test_results",
+            "hostlib_tools_manage_packages",
+        ]
+    );
+    assert_all_unimplemented(&registry);
+}
+
+#[test]
+fn install_default_wires_every_module_into_a_vm() {
+    let mut vm = harn_vm::Vm::new();
+    let registry = harn_hostlib::install_default(&mut vm);
+
+    assert_eq!(
+        registry.modules(),
+        &["ast", "code_index", "scanner", "fs_watch", "tools"]
+    );
+    assert!(registry.builtins().len() >= 24);
+}
+
+#[test]
+fn every_registered_builtin_has_request_and_response_schemas() {
+    let registry = HostlibRegistry::new()
+        .with(AstCapability)
+        .with(CodeIndexCapability)
+        .with(ScannerCapability)
+        .with(FsWatchCapability)
+        .with(ToolsCapability);
+
+    for entry in registry.builtins().iter() {
+        assert!(
+            schemas::lookup(entry.module, entry.method, schemas::SchemaKind::Request).is_some(),
+            "missing request schema for {}.{}",
+            entry.module,
+            entry.method
+        );
+        assert!(
+            schemas::lookup(entry.module, entry.method, schemas::SchemaKind::Response).is_some(),
+            "missing response schema for {}.{}",
+            entry.module,
+            entry.method
+        );
+    }
+}
+
+#[test]
+fn every_schema_parses_as_valid_json_schema_2020_12() {
+    for (module, method, kind, body) in schemas::SCHEMAS {
+        let value: serde_json::Value = serde_json::from_str(body).unwrap_or_else(|err| {
+            panic!("schema for {module}.{method} ({kind:?}) is not valid JSON: {err}")
+        });
+        let dialect = value
+            .get("$schema")
+            .and_then(|v| v.as_str())
+            .expect("every shipped schema must declare its dialect via $schema");
+        assert!(
+            dialect.contains("draft/2020-12"),
+            "schema for {module}.{method} ({kind:?}) declares unexpected dialect: {dialect}"
+        );
+        // Sanity check on shape: every schema must be an object and either
+        // declare a top-level `type` or be a pure `$ref`. This catches
+        // accidental empty or malformed files without forcing a full
+        // schema-validator dependency at scaffold stage.
+        assert!(
+            value.is_object(),
+            "schema for {module}.{method} ({kind:?}) must be a JSON object"
+        );
+        let object = value.as_object().unwrap();
+        assert!(
+            object.contains_key("type") || object.contains_key("$ref"),
+            "schema for {module}.{method} ({kind:?}) must declare `type` or `$ref`"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- New opt-in `harn-hostlib` crate that will host the code-intelligence (`ast`, `code_index`, `scanner`, `fs_watch`) and deterministic-tool (`tools`) host builtins ported from `burin-code`'s Swift `BurinCore`.
- 24 builtin contracts registered today, every one routing through `HostlibError::Unimplemented` until the implementation issues (B2/B3/B4/C1/C2/C3 in [`burin-labs/burin-code#289`](https://github.com/burin-labs/burin-code/issues/289)) fill in module bodies.
- Canonical JSON Schema 2020-12 contracts under `crates/harn-hostlib/schemas/` plus a `include_str!` catalog (`schemas.rs`) so consumers can fetch them programmatically. These are the source of truth for `burin-code`'s schema-drift tests.
- Wired into `harn-cli`'s ACP server behind a default-on `hostlib` cargo feature.

Closes [burin-labs/harn#563](https://github.com/burin-labs/harn/issues/563).

## What's inside

- `Cargo.toml` + workspace member entry.
- `HostlibCapability` trait + `BuiltinRegistry` + `HostlibRegistry` that compose per-module builtin sets and emit `harn_vm::Vm` registrations.
- Module skeletons (`ast/`, `code_index/`, `scanner/`, `fs_watch/`, `tools/`) with the 24 documented method names.
- `HostlibError` with structured `Thrown` mapping into `VmError` so Harn `try`/`catch` can pattern-match on `kind` / `builtin` / `message`.
- README documenting the boundary vs `harn-vm`, opt-in model, and `burin-code` consumption flow.
- CHANGELOG entry under a new `Unreleased` section.

## Notes

- `gix` is intentionally *not* pinned at this scaffold stage: 0.82 fails to compile against the repo's current rustc against gix-hash 0.24's exhaustive-match guards. Issue C2 (`tools/git`) will pick a working version alongside its toolchain bump. The README and `Cargo.toml` document this.
- `harn-cli --no-default-features` builds cleanly without hostlib for slim embedders.

## Test plan

- [x] `cargo build -p harn-hostlib` clean
- [x] `cargo test -p harn-hostlib` — 10 tests pass (2 unit + 8 integration)
- [x] `cargo clippy -p harn-hostlib --all-targets -- -D warnings` clean
- [x] `cargo check --workspace` clean
- [x] `cargo check -p harn-cli --no-default-features` clean (hostlib disabled)
- [x] `cargo test -p harn-cli` — 271 tests pass, no regressions
- [x] Pre-push hooks: full workspace clippy + 2101 tests pass via `cargo nextest`
- [x] `markdownlint-cli2` clean across all 142 markdown files
- [x] Build performed against an isolated `CARGO_TARGET_DIR=/tmp/harn-hostlib-target`

## Cross-repo sequencing

After merge, the parent epic ships:

1. Cut a harn release (per the `/release-harn` skill) bumping the crate version.
2. burin-code PR bumps `.harn-version` to that release; downstream Swift `BurinCore` retirement follows as each implementation issue lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)