### PR TITLE
Begin Rust provider connector deprecation soak (#446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,26 @@ granular archaeology.
   into `harn-cli`'s ACP server behind the default-on `hostlib` cargo
   feature.
 
+### Deprecated
+
+- **Rust-side GitHub, Slack, Linear, and Notion provider connectors
+  (#602, #446).** New deployments should configure the corresponding
+  pure-Harn connector packages
+  ([harn-github-connector](https://github.com/burin-labs/harn-github-connector),
+  [harn-slack-connector](https://github.com/burin-labs/harn-slack-connector),
+  [harn-linear-connector](https://github.com/burin-labs/harn-linear-connector),
+  [harn-notion-connector](https://github.com/burin-labs/harn-notion-connector))
+  by pointing `[[providers]]` at `connector = { harn = "..." }`.
+  `harn orchestrator serve` now emits a single `warning:` line per
+  affected provider at startup when the Rust default is auto-selected; the
+  warning is silenced once a Harn package override is in place. Cron, the
+  generic webhook connector with HMAC verification, A2A push, stream
+  ingress, raw-body access, and signing primitives stay in core. Adds a
+  `Rust connectors → Harn packages` migration guide under `docs/migrations/`
+  and deprecation banners on each affected connector reference page. No
+  Rust connector business logic has been removed; the timeline for that
+  removal is gated on the prerequisites called out on issue #446.
+
 ### Removed
 
 - **`harn mcp-serve` (#594).** The hidden legacy alias for serving a

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -532,11 +532,20 @@ async fn initialize_connectors(
     let mut handles = Vec::new();
     for (provider, kinds) in grouped_kinds {
         let provider_name = provider.as_str().to_string();
-        if let Some(connector) = connector_override_for(&provider, provider_overrides).await? {
-            registry.remove(&provider);
-            registry
-                .register(connector)
-                .map_err(|error| error.to_string())?;
+        let used_harn_override =
+            if let Some(connector) = connector_override_for(&provider, provider_overrides).await? {
+                registry.remove(&provider);
+                registry
+                    .register(connector)
+                    .map_err(|error| error.to_string())?;
+                true
+            } else {
+                false
+            };
+        if !used_harn_override {
+            if let Some(message) = rust_deprecated_provider_warning(provider.as_str()) {
+                eprintln!("{message}");
+            }
         }
         if registry.get(&provider).is_none() {
             let connector = connector_for(&provider, kinds);
@@ -639,6 +648,29 @@ fn connector_for(
         "cron" => Box::new(harn_vm::CronConnector::new()),
         _ => Box::new(PlaceholderConnector::new(provider.clone(), kinds)),
     }
+}
+
+/// Providers whose Rust-side business logic is on the deprecation path tracked
+/// by https://github.com/burin-labs/harn/issues/446. New deployments should
+/// configure the corresponding pure-Harn connector package on the
+/// `[[providers]]` table to silence the orchestrator-startup deprecation
+/// warning.
+const RUST_DEPRECATED_PROVIDERS: &[&str] = &["github", "linear", "notion", "slack"];
+
+/// Returns a one-line deprecation warning when a manifest leaves a Rust-side
+/// provider connector (github/slack/linear/notion) auto-selected. Pointing the
+/// `[[providers]]` table at the corresponding pure-Harn package suppresses the
+/// warning for that provider.
+fn rust_deprecated_provider_warning(provider: &str) -> Option<String> {
+    if !RUST_DEPRECATED_PROVIDERS.contains(&provider) {
+        return None;
+    }
+    Some(format!(
+        "warning: provider '{provider}' is using the deprecated Rust-side connector. \
+         Set `connector = {{ harn = \"...\" }}` on the [[providers]] table to use the \
+         pure-Harn `harn-{provider}-connector` package; see \
+         docs/migrations/rust-connectors-to-harn-packages.md (issue #446)."
+    ))
 }
 
 async fn connector_override_for(
@@ -2576,5 +2608,40 @@ impl harn_vm::Connector for PlaceholderConnector {
 
     fn client(&self) -> Arc<dyn harn_vm::ConnectorClient> {
         Arc::new(PlaceholderClient)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_deprecated_provider_warning_fires_for_sunset_providers() {
+        for provider in ["github", "slack", "linear", "notion"] {
+            let message = rust_deprecated_provider_warning(provider)
+                .unwrap_or_else(|| panic!("expected deprecation warning for '{provider}'"));
+            assert!(
+                message.contains(provider),
+                "warning for '{provider}' should mention the provider id: {message}",
+            );
+            assert!(
+                message.contains("connector = { harn"),
+                "warning for '{provider}' should suggest the manifest override: {message}",
+            );
+            assert!(
+                message.contains("issue #446"),
+                "warning for '{provider}' should reference issue #446: {message}",
+            );
+        }
+    }
+
+    #[test]
+    fn rust_deprecated_provider_warning_silent_for_core_providers() {
+        for provider in ["cron", "webhook", "a2a-push", "stream", "kafka", "acme"] {
+            assert!(
+                rust_deprecated_provider_warning(provider).is_none(),
+                "core provider '{provider}' must not trigger the sunset warning"
+            );
+        }
     }
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -101,3 +101,4 @@
 - [0.6.x → 0.7.0](./migrations/v0.7.md)
 - [Prompt templates: v2](./migrations/template-engine-v2.md)
 - [Schema-as-type](./migrations/schema-as-type.md)
+- [Rust connectors → Harn packages](./migrations/rust-connectors-to-harn-packages.md)

--- a/docs/src/connectors/catalog.md
+++ b/docs/src/connectors/catalog.md
@@ -11,6 +11,19 @@ transition plan:
 - Community connectors are Harn packages that export connector contract v1 and
   pass `harn connector check`.
 
+> **Deprecated: Rust-side GitHub, Slack, Linear, and Notion connectors.**
+> Per [#446](https://github.com/burin-labs/harn/issues/446), the Rust-side
+> business logic for these four providers is on a sunset path. New deployments
+> should point manifests at the corresponding pure-Harn packages
+> (`harn-github-connector`, `harn-slack-connector`, `harn-linear-connector`,
+> `harn-notion-connector`) by setting `connector = { harn = "..." }` on the
+> `[[providers]]` table. The Rust shims will keep working until the
+> prerequisite tickets enumerated on issue #446 are complete and the
+> deprecation soak elapses; until then, leaving the manifest unchanged still
+> resolves to the existing Rust connector. See the
+> [Rust-to-Harn-package migration guide](../migrations/rust-connectors-to-harn-packages.md)
+> for a no-downtime cutover.
+
 For an LLM-sized version of this page, use
 [`docs/llm/harn-triggers-quickref.md`](../../llm/harn-triggers-quickref.md).
 That file is generated from the live provider catalog and checked by CI.

--- a/docs/src/connectors/github.md
+++ b/docs/src/connectors/github.md
@@ -1,5 +1,15 @@
 # GitHub App connector
 
+> **Deprecated.** The Rust-side `GitHubConnector` is on the sunset path tracked
+> by [#446](https://github.com/burin-labs/harn/issues/446). The recommended
+> implementation is the pure-Harn
+> [`harn-github-connector`](https://github.com/burin-labs/harn-github-connector)
+> package. This page documents the existing Rust connector for users who have
+> not yet migrated; new deployments should configure the Harn package via
+> `connector = { harn = "..." }` on the `[[providers]]` table. See the
+> [Rust-to-Harn-package migration guide](../migrations/rust-connectors-to-harn-packages.md)
+> for a no-downtime cutover path.
+
 `GitHubConnector` is Harn's built-in GitHub App integration for inbound webhook
 events plus outbound GitHub REST calls authenticated as an installation.
 

--- a/docs/src/connectors/linear.md
+++ b/docs/src/connectors/linear.md
@@ -1,5 +1,15 @@
 # Linear connector
 
+> **Deprecated.** The Rust-side `LinearConnector` is on the sunset path tracked
+> by [#446](https://github.com/burin-labs/harn/issues/446). The recommended
+> implementation is the pure-Harn
+> [`harn-linear-connector`](https://github.com/burin-labs/harn-linear-connector)
+> package. This page documents the existing Rust connector for users who have
+> not yet migrated; new deployments should configure the Harn package via
+> `connector = { harn = "..." }` on the `[[providers]]` table. See the
+> [Rust-to-Harn-package migration guide](../migrations/rust-connectors-to-harn-packages.md)
+> for a no-downtime cutover path.
+
 `LinearConnector` is Harn's built-in Linear integration for inbound webhook
 deliveries plus outbound GraphQL calls.
 

--- a/docs/src/connectors/notion.md
+++ b/docs/src/connectors/notion.md
@@ -1,5 +1,15 @@
 # Notion connector
 
+> **Deprecated.** The Rust-side `NotionConnector` is on the sunset path tracked
+> by [#446](https://github.com/burin-labs/harn/issues/446). The recommended
+> implementation is the pure-Harn
+> [`harn-notion-connector`](https://github.com/burin-labs/harn-notion-connector)
+> package. This page documents the existing Rust connector for users who have
+> not yet migrated; new deployments should configure the Harn package via
+> `connector = { harn = "..." }` on the `[[providers]]` table. See the
+> [Rust-to-Harn-package migration guide](../migrations/rust-connectors-to-harn-packages.md)
+> for a no-downtime cutover path.
+
 `NotionConnector` is Harn's built-in hybrid Notion integration. It combines:
 
 - webhook ingest for the event families Notion can push directly

--- a/docs/src/connectors/slack-events.md
+++ b/docs/src/connectors/slack-events.md
@@ -1,5 +1,15 @@
 # Slack Events connector
 
+> **Deprecated.** The Rust-side `SlackConnector` is on the sunset path tracked
+> by [#446](https://github.com/burin-labs/harn/issues/446). The recommended
+> implementation is the pure-Harn
+> [`harn-slack-connector`](https://github.com/burin-labs/harn-slack-connector)
+> package. This page documents the existing Rust connector for users who have
+> not yet migrated; new deployments should configure the Harn package via
+> `connector = { harn = "..." }` on the `[[providers]]` table. See the
+> [Rust-to-Harn-package migration guide](../migrations/rust-connectors-to-harn-packages.md)
+> for a no-downtime cutover path.
+
 `SlackConnector` is Harn's built-in Slack Events API integration. It verifies
 Slack's signed webhook requests, narrows the event families most useful for
 agent orchestration into typed `SlackEventPayload` variants, and exposes a

--- a/docs/src/migrations/rust-connectors-to-harn-packages.md
+++ b/docs/src/migrations/rust-connectors-to-harn-packages.md
@@ -1,0 +1,145 @@
+# Migrating Rust provider connectors to pure-Harn packages
+
+The Rust-side GitHub, Slack, Linear, and Notion connectors are on the sunset
+path tracked by [#446](https://github.com/burin-labs/harn/issues/446). New
+provider business logic ships in pure-Harn connector packages so that
+Harn Cloud and self-hosted orchestrators can adopt connector fixes,
+new event families, and provider API changes without waiting for a Harn core
+release.
+
+This guide is the no-downtime migration path for an orchestrator that today
+uses one of the Rust-side providers and wants to cut over to the pure-Harn
+package equivalent.
+
+The cron, generic webhook, A2A push, and stream connectors stay in Harn core
+and are **not** affected by this migration. HMAC verification, raw-body
+access, signature header constants, and signing primitives also stay in core
+so that pure-Harn connectors do not need to reimplement them.
+
+## What is changing
+
+Each first-party provider has a pure-Harn replacement that exposes the same
+event shape through the connector contract v1 surface:
+
+| Provider | Pure-Harn package |
+|---|---|
+| GitHub | <https://github.com/burin-labs/harn-github-connector> |
+| Slack | <https://github.com/burin-labs/harn-slack-connector> |
+| Linear | <https://github.com/burin-labs/harn-linear-connector> |
+| Notion | <https://github.com/burin-labs/harn-notion-connector> |
+
+Manifests opt into the pure-Harn replacement by declaring a
+`[[providers]]` table that points `connector = { harn = "..." }` at the
+package's connector module. The orchestrator already prefers a configured
+Harn module over the Rust default, so the Rust connector keeps running
+unchanged for any provider that does not declare an override.
+
+## Cutover checklist
+
+The cutover is intentionally per-provider so that an orchestrator can soak
+one provider on the pure-Harn implementation before moving the rest.
+
+1. **Install the package.** Add the package as a dependency and run
+   `harn install --locked`.
+
+   ```sh
+   harn add github.com/burin-labs/harn-github-connector@v0.1.0
+   harn install --locked
+   ```
+
+2. **Run the contract check.** Confirm the package matches the connector
+   contract and your supported event families.
+
+   ```sh
+   harn connector check . --provider github
+   ```
+
+   For Notion, also exercise the poll path:
+
+   ```sh
+   harn connector check . --provider notion --run-poll-tick
+   ```
+
+3. **Add a `[[providers]]` override.** Tell the orchestrator to load the
+   pure-Harn module for this provider.
+
+   ```toml
+   [[providers]]
+   id = "github"
+   connector = { harn = "vendor/harn-github-connector/src/lib.harn" }
+   ```
+
+   Leave existing trigger entries unchanged. Triggers with
+   `provider = "github"` automatically resolve through the new connector
+   once the override is in place.
+
+4. **Run a parity check against your fixtures.** The recommended pattern
+   is to feed canonical webhook bodies through both the Rust connector and
+   the pure-Harn package and assert the resulting `TriggerEvent`
+   `kind` / `dedupe_key` / `provider_payload` shapes match. The connector
+   testkit (`docs/src/connectors/testkit.md`) has the primitives needed to
+   stage a `RawInbound` and capture the normalized event in tests.
+
+   First-party connector packages run a parity matrix against the Rust
+   payload shapes in their own CI. If your handlers depend on a vendor
+   field that is not in the parity fixtures, add it to your local
+   `[connector_contract]` fixture set before cutover.
+
+5. **Roll out and verify.** Deploy the manifest change. The orchestrator
+   logs a one-line confirmation when it loads the Harn module instead of
+   the Rust default. `harn doctor` reports `trigger:<id>` as
+   `via <provider>` regardless of which connector implementation is in
+   use, so existing health checks keep working.
+
+6. **Keep the Rust connector available during the soak.** If the
+   pure-Harn package needs a hotfix, remove the `connector = { harn = ... }`
+   override and the orchestrator falls back to the Rust connector with no
+   downtime. There is no on-disk migration of inbox state, so a fallback is
+   safe to perform mid-flight.
+
+## Harn Cloud specifics
+
+Managed Harn Cloud orchestrators load pure-Harn connector packages through
+the same `[[providers]]` mechanism documented above. Connector packages are
+resolved through the package manager so the cutover is a manifest change,
+not a Harn Cloud release.
+
+## What stays in core
+
+The following primitives stay in Harn core and continue to be the only
+supported way to express their respective concerns:
+
+- The `cron` connector (`docs/src/connectors/cron.md`).
+- The generic `webhook` connector with HMAC verification, including the
+  `webhook-signature` / `webhook-timestamp` / `webhook-id` Standard
+  Webhooks-style headers (`docs/src/connectors/webhook.md`).
+- HMAC verification helpers under `harn_vm::connectors::hmac`, including
+  the canonical signature-header constants used by GitHub, Slack, Linear,
+  Notion, Stripe, and Standard Webhooks.
+- The A2A push connector and the stream connector for queue-shaped
+  ingress.
+- Raw HTTP request access (`raw_body`, headers) and signing primitives.
+
+Pure-Harn provider connectors compose these primitives — they do not
+duplicate them.
+
+## Removal timeline
+
+Following the work breakdown in [#446](https://github.com/burin-labs/harn/issues/446),
+the Rust-side per-provider business logic for GitHub, Slack, Linear, and
+Notion is removed only after:
+
+1. The connector contract conformance harness ([#468](https://github.com/burin-labs/harn/issues/468))
+   validates the pure-Harn replacements through the same adapter path
+   Harn Cloud and self-hosted orchestrators use.
+2. `NormalizeResult` v1 ([#464](https://github.com/burin-labs/harn/issues/464)),
+   the `poll_tick` scheduled hook ([#465](https://github.com/burin-labs/harn/issues/465)),
+   and the hot-path effect policy ([#467](https://github.com/burin-labs/harn/issues/467))
+   are in place so the pure-Harn connectors can replace every Rust path.
+3. The OAuth / connect CLI ([#176](https://github.com/burin-labs/harn/issues/176))
+   and package-manager pinning sweep ([#445](https://github.com/burin-labs/harn/issues/445))
+   give first-party connector packages a stable install + auth path.
+4. At least GitHub and Slack have parity fixtures landed in their
+   connector repos before the deprecation banners ship in Harn core.
+
+Until those are complete, the Rust connectors keep working unchanged.


### PR DESCRIPTION
## Summary

Implements [#446](https://github.com/burin-labs/harn/issues/446) — kicks off the deprecation soak for the Rust-side GitHub, Slack, Linear, and Notion provider connectors **without removing any business logic**. The Rust connectors remain the auto-selected default; manifests opt into the pure-Harn replacement packages on a per-provider basis through the existing `connector = { harn = \"...\" }` field on the `[[providers]]` table.

Per the grooming note on the issue, full Rust removal is gated on prerequisites (#468, #464, #465, #467, #176, #445, #473) plus parity fixtures landing in the per-provider package repos and at least one release of soak. None of those are merged yet, so this PR intentionally stays at the deprecation/migration step.

### What changed

- **Migration guide.** New [`docs/src/migrations/rust-connectors-to-harn-packages.md`](https://github.com/burin-labs/harn/pull/0/files) covers a no-downtime per-provider cutover for self-hosted orchestrators and Harn Cloud, the parity-test pattern, what stays in core (cron, generic webhook with HMAC, A2A push, stream, raw-body access, signing primitives), and the removal-timeline gates. Linked from `docs/src/SUMMARY.md` under Migrations.
- **Deprecation banners.** Catalog header (`docs/src/connectors/catalog.md`) and the four affected per-provider reference pages (`github.md`, `slack-events.md`, `linear.md`, `notion.md`) call out the sunset path and link to the migration guide.
- **Orchestrator startup warning.** `harn orchestrator serve` now emits a single `warning:` line per affected provider when the Rust default is auto-selected, pointing users at the manifest override and the migration guide. The warning is silenced as soon as the manifest declares `connector = { harn = \"...\" }` for that provider — the existing override resolution path needed no changes.
- **Tests.** New unit tests for the `rust_deprecated_provider_warning` helper covering all four sunset providers and a representative set of core providers (cron, webhook, a2a-push, stream, kafka, plus a generic extension provider) which must stay silent.
- **CHANGELOG.** New `Unreleased / Deprecated` section documenting the deprecation, the runtime warning, and explicitly noting that no Rust connector business logic has been removed.

### What did not change

- No Rust connector files under `crates/harn-vm/src/connectors/{github,slack,linear,notion}/` were modified.
- The provider catalog, conformance fixtures (`integration/{slack,github,linear}_connector_*.harn`, `triggers/trigger_webhook_*.harn`), and stdlib facades all keep their existing behavior.
- Cron, generic webhook, A2A push, stream, HMAC primitives, raw-body access, and signing primitives stay in core, as required by the issue's last unchecked item.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p harn-cli --tests -- -D warnings` clean
- [x] `cargo test -p harn-cli --bin harn` — 273 passed
- [x] `cargo run --bin harn -- test conformance --filter slack` — 3 passed
- [x] `cargo run --bin harn -- test conformance --filter \"linear|notion|github\"` — 4 passed
- [x] `make lint-md` — 0 errors across 142 files
- [x] `make check-docs-snippets` — 420 checked, 70 ignored, 0 failed
- [x] Pre-push hook ran the full workspace `cargo nextest` — 2093 / 2093 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)