### PR TITLE
Implement deterministic tool host builtins (#567)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,26 @@ granular archaeology.
   schema-drift tests can lock the public surface immediately. Wired
   into `harn-cli`'s ACP server behind the default-on `hostlib` cargo
   feature.
+- **Deterministic tool host builtins (#567).** `harn-hostlib`'s
+  `tools/` module gains live implementations for `search` (ripgrep
+  semantics via `grep-searcher` + `ignore` with structured matches and
+  context lines), `read_file` (utf-8 + base64 with offset/limit and
+  truncation reporting), `write_file` (parent-dir creation, overwrite
+  guard, base64 input), `delete_file` (recursive opt-in for
+  directories), `list_directory` (sorted entries, hidden filter,
+  pagination), `get_file_outline` (language-agnostic regex extractor
+  matching `ast.outline` shape), and `git` (read-only inspection:
+  `status`, `diff`, `log`, `blame`, `show`, `branch_list`,
+  `current_branch`, `remote_list` — shelling out to system `git` with
+  arg-list invocations only, never `sh -c`, plus rev-string validation
+  that rejects flag lookalikes and control bytes). The surface is
+  gated by a per-session opt-in: pipelines call
+  `hostlib_enable("tools:deterministic")` before any of the seven
+  deterministic tools will execute, otherwise calls fail with a
+  structured error pointing at the enable builtin. Process tools
+  (`run_command`, `run_test`, `run_build_command`,
+  `inspect_test_results`, `manage_packages`) remain
+  `Unimplemented`-routed for issue C2.
 
 ### Deprecated
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -1146,6 +1147,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "grep-regex"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce0c256c3ad82bcc07b812c15a45ec1d398122e8e15124f96695234db7112ef"
+dependencies = [
+ "bstr",
+ "grep-matcher",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "grep-searcher"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,7 +1266,12 @@ name = "harn-hostlib"
 version = "0.7.38"
 dependencies = [
  "anyhow",
+ "base64",
+ "grep-matcher",
+ "grep-regex",
  "grep-searcher",
+ "harn-lexer",
+ "harn-parser",
  "harn-vm",
  "ignore",
  "notify",

--- a/crates/harn-hostlib/Cargo.toml
+++ b/crates/harn-hostlib/Cargo.toml
@@ -35,10 +35,15 @@ thiserror = "2"
 # `git` if anything urgent comes up.
 tree-sitter = "0.26"
 grep-searcher = "0.1"
+grep-matcher = "0.1"
+grep-regex = "0.1"
 ignore = "0.4"
 notify = "8"
 walkdir = "2"
+base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3"
 serde_json = "1"
+harn-lexer = { path = "../harn-lexer", version = "0.7" }
+harn-parser = { path = "../harn-parser", version = "0.7" }

--- a/crates/harn-hostlib/README.md
+++ b/crates/harn-hostlib/README.md
@@ -16,21 +16,22 @@ Opt-in host builtins for the Harn VM that provide:
 
 ## Status
 
-This is the **scaffold** that issue
-[#563](https://github.com/burin-labs/harn/issues/563) introduced. Every host
-method registered here today returns
-`HostlibError::Unimplemented { builtin }`. Implementations land in the
-follow-up issues called out in the parent epic
-[`burin-labs/burin-code#289`](https://github.com/burin-labs/burin-code/issues/289):
+[#563](https://github.com/burin-labs/harn/issues/563) introduced the
+scaffold (every method routed through `HostlibError::Unimplemented`).
+[#567](https://github.com/burin-labs/harn/issues/567) lights up the
+deterministic-tool surface: `search`, `read_file`, `write_file`,
+`delete_file`, `list_directory`, `get_file_outline`, and `git`.
 
-| Issue | Module | What lands |
-|-------|--------|-----------|
-| B2    | `ast/`         | `parse_file`, `symbols`, `outline` |
-| B3    | `code_index/`  | `query`, `rebuild`, `stats`, `imports_for`, `importers_of` |
-| B4    | `scanner/`     | `scan_project`, `scan_incremental` |
-| C1    | `fs_watch/`    | `subscribe`, `unsubscribe` |
-| C2    | `tools/` (read & search) | `search`, `read_file`, `list_directory`, `get_file_outline`, `git` |
-| C3    | `tools/` (mutating) | `write_file`, `delete_file`, `run_command`, `run_test`, `run_build_command`, `inspect_test_results`, `manage_packages` |
+| Issue | Module | What lands | Status |
+|-------|--------|-----------|--------|
+| B1 (#563) | scaffold       | crate + schemas + registration plumbing                                                   | ✅ shipped |
+| B2    | `ast/`             | `parse_file`, `symbols`, `outline`                                                        | unimplemented |
+| B3    | `code_index/`      | `query`, `rebuild`, `stats`, `imports_for`, `importers_of`                                | unimplemented |
+| B4    | `scanner/`         | `scan_project`, `scan_incremental`                                                        | unimplemented |
+| C1    | `fs_watch/`        | `subscribe`, `unsubscribe`                                                                | unimplemented |
+| #567  | `tools/` (read & search) | `search`, `read_file`, `list_directory`, `get_file_outline`, `git`                 | ✅ shipped (this issue) |
+| #567  | `tools/` (mutating)      | `write_file`, `delete_file`                                                        | ✅ shipped (this issue) |
+| C2    | `tools/` (process)       | `run_command`, `run_test`, `run_build_command`, `inspect_test_results`, `manage_packages` | unimplemented |
 
 ## Why a separate crate?
 
@@ -46,6 +47,28 @@ transcript lifecycle, replay/eval, mutation session audit metadata —
 stays there. See
 [`AGENTS.md`](../../CLAUDE.md#trust-boundary) for the canonical trust
 boundary.
+
+## Per-session opt-in for deterministic tools
+
+The deterministic-tool surface (`tools/{search, read_file, write_file,
+delete_file, list_directory, get_file_outline, git}`) is **gated**.
+`install_default` registers the contract for every method, but the
+handlers refuse to run until the pipeline opts in by calling
+
+```text
+hostlib_enable("tools:deterministic")
+```
+
+(a builtin registered alongside the rest of the `tools/` surface). This
+matches the safety story called out in
+[#567](https://github.com/burin-labs/harn/issues/567): a Harn script that
+hasn't asked for filesystem / git / search access cannot get it even
+though the contract is wired in. The opt-in is per-thread, so each VM
+gets an independent enable set.
+
+Embedders that want to enable the surface from Rust without going through
+the builtin can use [`tools::permissions::enable_for_test`] (test-only)
+or call `tools::permissions::enable("tools:deterministic")` directly.
 
 ## How embedders consume it
 

--- a/crates/harn-hostlib/schemas/tools/enable.request.json
+++ b/crates/harn-hostlib/schemas/tools/enable.request.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/enable.request.json",
+  "title": "tools.enable request",
+  "description": "Per-session opt-in for the deterministic-tools surface. Pipelines call `hostlib_enable(\"tools:deterministic\")` before invoking any of `tools/{search, read_file, write_file, delete_file, list_directory, get_file_outline, git}`.",
+  "type": "object",
+  "properties": {
+    "feature": {
+      "type": "string",
+      "enum": ["tools:deterministic"]
+    }
+  },
+  "required": ["feature"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/tools/enable.response.json
+++ b/crates/harn-hostlib/schemas/tools/enable.response.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/tools/enable.response.json",
+  "title": "tools.enable response",
+  "type": "object",
+  "properties": {
+    "feature": { "type": "string" },
+    "enabled": { "type": "boolean" },
+    "newly_enabled": {
+      "type": "boolean",
+      "description": "True when this call flipped the feature from off to on; false when the feature was already enabled."
+    }
+  },
+  "required": ["feature", "enabled", "newly_enabled"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/src/schemas.rs
+++ b/crates/harn-hostlib/src/schemas.rs
@@ -317,6 +317,18 @@ pub const SCHEMAS: &[(&str, &str, SchemaKind, &str)] = &[
         SchemaKind::Response,
         include_str!("../schemas/tools/manage_packages.response.json"),
     ),
+    (
+        "tools",
+        "enable",
+        SchemaKind::Request,
+        include_str!("../schemas/tools/enable.request.json"),
+    ),
+    (
+        "tools",
+        "enable",
+        SchemaKind::Response,
+        include_str!("../schemas/tools/enable.response.json"),
+    ),
 ];
 
 /// Look up a single schema as raw JSON text.

--- a/crates/harn-hostlib/src/tools/args.rs
+++ b/crates/harn-hostlib/src/tools/args.rs
@@ -1,0 +1,132 @@
+//! Parameter parsing helpers for tool builtins.
+//!
+//! Tools accept a single `Dict` argument from Harn (so callers can write
+//! `hostlib_tools_search({pattern: "TODO", path: "src"})`). These helpers
+//! pull strongly-typed values out of that dict and produce
+//! [`HostlibError`] variants on shape mismatches so the script side gets a
+//! structured exception.
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+
+/// Extract the first argument as a Dict. Tools always receive a single
+/// dict from Harn-side callers; if the caller passed nothing we treat it
+/// as an empty payload.
+pub fn dict_arg(
+    builtin: &'static str,
+    args: &[VmValue],
+) -> Result<Rc<BTreeMap<String, VmValue>>, HostlibError> {
+    match args.first() {
+        Some(VmValue::Dict(dict)) => Ok(dict.clone()),
+        Some(VmValue::Nil) | None => Ok(Rc::new(BTreeMap::new())),
+        Some(other) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: "params",
+            message: format!(
+                "expected a dict argument, got {} ({:?})",
+                other.type_name(),
+                other
+            ),
+        }),
+    }
+}
+
+/// Required string field.
+pub fn require_string(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<String, HostlibError> {
+    match dict.get(key) {
+        Some(VmValue::String(s)) => Ok(s.to_string()),
+        Some(other) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected string, got {}", other.type_name()),
+        }),
+        None => Err(HostlibError::MissingParameter {
+            builtin,
+            param: key,
+        }),
+    }
+}
+
+/// Optional string field. Missing/`Nil` returns `None`.
+pub fn optional_string(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<String>, HostlibError> {
+    match dict.get(key) {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(VmValue::String(s)) => Ok(Some(s.to_string())),
+        Some(other) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected string, got {}", other.type_name()),
+        }),
+    }
+}
+
+/// Optional `bool`. Defaults to `default` when missing or `Nil`.
+pub fn optional_bool(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+    default: bool,
+) -> Result<bool, HostlibError> {
+    match dict.get(key) {
+        None | Some(VmValue::Nil) => Ok(default),
+        Some(VmValue::Bool(b)) => Ok(*b),
+        Some(other) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected bool, got {}", other.type_name()),
+        }),
+    }
+}
+
+/// Optional integer. Defaults to `default` when missing or `Nil`.
+/// Also accepts `Float` values that are whole numbers (Harn treats numeric
+/// literals as ints by default, but JSON-decoded payloads can show up as
+/// floats).
+pub fn optional_int(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+    default: i64,
+) -> Result<i64, HostlibError> {
+    match dict.get(key) {
+        None | Some(VmValue::Nil) => Ok(default),
+        Some(VmValue::Int(n)) => Ok(*n),
+        Some(VmValue::Float(f)) if f.fract() == 0.0 => Ok(*f as i64),
+        Some(other) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected integer, got {}", other.type_name()),
+        }),
+    }
+}
+
+/// Construct a [`VmValue::Dict`] from a `(key, value)` iterable. Used by
+/// tool handlers when shaping their JSON-Schema-mirrored response.
+pub fn build_dict<I, K>(entries: I) -> VmValue
+where
+    I: IntoIterator<Item = (K, VmValue)>,
+    K: Into<String>,
+{
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in entries {
+        map.insert(k.into(), v);
+    }
+    VmValue::Dict(Rc::new(map))
+}
+
+/// Convenience constructor for `VmValue::String` from a `&str`.
+pub fn str_value(s: impl AsRef<str>) -> VmValue {
+    VmValue::String(Rc::from(s.as_ref()))
+}

--- a/crates/harn-hostlib/src/tools/file_io.rs
+++ b/crates/harn-hostlib/src/tools/file_io.rs
@@ -1,0 +1,341 @@
+//! `tools/{read_file, write_file, delete_file, list_directory}` —
+//! deterministic filesystem primitives.
+//!
+//! Shapes are locked by `schemas/tools/{read_file,write_file,delete_file,list_directory}.{request,response}.json`.
+
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use base64::Engine;
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::tools::args::{
+    build_dict, dict_arg, optional_bool, optional_int, optional_string, require_string, str_value,
+};
+
+const READ_FILE_BUILTIN: &str = "hostlib_tools_read_file";
+const WRITE_FILE_BUILTIN: &str = "hostlib_tools_write_file";
+const DELETE_FILE_BUILTIN: &str = "hostlib_tools_delete_file";
+const LIST_DIRECTORY_BUILTIN: &str = "hostlib_tools_list_directory";
+
+/// Encoding flavors accepted by [`read_file`] / produced by [`write_file`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Encoding {
+    Utf8,
+    Binary,
+}
+
+impl Encoding {
+    fn parse(builtin: &'static str, raw: Option<&str>) -> Result<Self, HostlibError> {
+        match raw {
+            None | Some("utf-8") => Ok(Encoding::Utf8),
+            Some("binary") => Ok(Encoding::Binary),
+            Some(other) => Err(HostlibError::InvalidParameter {
+                builtin,
+                param: "encoding",
+                message: format!("expected one of [\"utf-8\", \"binary\"], got `{other}`"),
+            }),
+        }
+    }
+}
+
+pub(super) fn read_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(READ_FILE_BUILTIN, args)?;
+    let dict = raw.as_ref();
+
+    let path_str = require_string(READ_FILE_BUILTIN, dict, "path")?;
+    let offset = optional_int(READ_FILE_BUILTIN, dict, "offset", 0)?;
+    let limit_bytes = optional_int(READ_FILE_BUILTIN, dict, "limit_bytes", 0)?;
+    let encoding_raw = optional_string(READ_FILE_BUILTIN, dict, "encoding")?;
+    let encoding = Encoding::parse(READ_FILE_BUILTIN, encoding_raw.as_deref())?;
+
+    if offset < 0 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: READ_FILE_BUILTIN,
+            param: "offset",
+            message: "must be >= 0".to_string(),
+        });
+    }
+    if limit_bytes < 0 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: READ_FILE_BUILTIN,
+            param: "limit_bytes",
+            message: "must be >= 0".to_string(),
+        });
+    }
+
+    let path = PathBuf::from(&path_str);
+
+    let metadata = fs::metadata(&path).map_err(|err| HostlibError::Backend {
+        builtin: READ_FILE_BUILTIN,
+        message: format!("stat `{path_str}`: {err}"),
+    })?;
+    if !metadata.is_file() {
+        return Err(HostlibError::Backend {
+            builtin: READ_FILE_BUILTIN,
+            message: format!("`{path_str}` is not a regular file"),
+        });
+    }
+
+    let total_size = metadata.len();
+    let offset_u64 = offset as u64;
+    if offset_u64 > total_size {
+        return Err(HostlibError::InvalidParameter {
+            builtin: READ_FILE_BUILTIN,
+            param: "offset",
+            message: format!("offset {offset_u64} exceeds file length {total_size}"),
+        });
+    }
+
+    let mut file = fs::File::open(&path).map_err(|err| HostlibError::Backend {
+        builtin: READ_FILE_BUILTIN,
+        message: format!("open `{path_str}`: {err}"),
+    })?;
+    if offset_u64 > 0 {
+        use std::io::Seek;
+        file.seek(std::io::SeekFrom::Start(offset_u64))
+            .map_err(|err| HostlibError::Backend {
+                builtin: READ_FILE_BUILTIN,
+                message: format!("seek `{path_str}`: {err}"),
+            })?;
+    }
+
+    let to_read_planned: u64 = if limit_bytes == 0 {
+        total_size - offset_u64
+    } else {
+        std::cmp::min(limit_bytes as u64, total_size - offset_u64)
+    };
+
+    let mut buf = Vec::with_capacity(to_read_planned as usize);
+    file.take(to_read_planned)
+        .read_to_end(&mut buf)
+        .map_err(|err| HostlibError::Backend {
+            builtin: READ_FILE_BUILTIN,
+            message: format!("read `{path_str}`: {err}"),
+        })?;
+
+    let truncated = (offset_u64 + buf.len() as u64) < total_size;
+
+    let (content, response_encoding) = match encoding {
+        Encoding::Utf8 => match std::str::from_utf8(&buf) {
+            Ok(s) => (s.to_string(), "utf-8"),
+            Err(_) => {
+                // Fall back to base64 when the bytes aren't valid UTF-8 so
+                // callers always get a string they can transport over JSON.
+                (
+                    base64::engine::general_purpose::STANDARD.encode(&buf),
+                    "base64",
+                )
+            }
+        },
+        Encoding::Binary => (
+            base64::engine::general_purpose::STANDARD.encode(&buf),
+            "base64",
+        ),
+    };
+
+    Ok(build_dict([
+        ("path", str_value(&path_str)),
+        ("encoding", str_value(response_encoding)),
+        ("content", str_value(&content)),
+        ("size", VmValue::Int(buf.len() as i64)),
+        ("truncated", VmValue::Bool(truncated)),
+    ]))
+}
+
+pub(super) fn write_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(WRITE_FILE_BUILTIN, args)?;
+    let dict = raw.as_ref();
+
+    let path_str = require_string(WRITE_FILE_BUILTIN, dict, "path")?;
+    let content = require_string(WRITE_FILE_BUILTIN, dict, "content")?;
+    let encoding_raw = optional_string(WRITE_FILE_BUILTIN, dict, "encoding")?;
+    let create_parents = optional_bool(WRITE_FILE_BUILTIN, dict, "create_parents", true)?;
+    let overwrite = optional_bool(WRITE_FILE_BUILTIN, dict, "overwrite", true)?;
+
+    let path = PathBuf::from(&path_str);
+
+    let bytes: Vec<u8> = match encoding_raw.as_deref() {
+        None | Some("utf-8") => content.into_bytes(),
+        Some("base64") => base64::engine::general_purpose::STANDARD
+            .decode(content.as_bytes())
+            .map_err(|err| HostlibError::InvalidParameter {
+                builtin: WRITE_FILE_BUILTIN,
+                param: "content",
+                message: format!("invalid base64: {err}"),
+            })?,
+        Some(other) => {
+            return Err(HostlibError::InvalidParameter {
+                builtin: WRITE_FILE_BUILTIN,
+                param: "encoding",
+                message: format!("expected one of [\"utf-8\", \"base64\"], got `{other}`"),
+            });
+        }
+    };
+
+    let preexisted = path.exists();
+    if preexisted && !overwrite {
+        return Err(HostlibError::Backend {
+            builtin: WRITE_FILE_BUILTIN,
+            message: format!("`{path_str}` exists and overwrite=false"),
+        });
+    }
+
+    if create_parents {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent).map_err(|err| HostlibError::Backend {
+                    builtin: WRITE_FILE_BUILTIN,
+                    message: format!("mkdir `{}`: {err}", parent.display()),
+                })?;
+            }
+        }
+    }
+
+    fs::write(&path, &bytes).map_err(|err| HostlibError::Backend {
+        builtin: WRITE_FILE_BUILTIN,
+        message: format!("write `{path_str}`: {err}"),
+    })?;
+
+    Ok(build_dict([
+        ("path", str_value(&path_str)),
+        ("bytes_written", VmValue::Int(bytes.len() as i64)),
+        ("created", VmValue::Bool(!preexisted)),
+    ]))
+}
+
+pub(super) fn delete_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(DELETE_FILE_BUILTIN, args)?;
+    let dict = raw.as_ref();
+
+    let path_str = require_string(DELETE_FILE_BUILTIN, dict, "path")?;
+    let recursive = optional_bool(DELETE_FILE_BUILTIN, dict, "recursive", false)?;
+
+    let path = PathBuf::from(&path_str);
+
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(m) => m,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(build_dict([
+                ("path", str_value(&path_str)),
+                ("removed", VmValue::Bool(false)),
+            ]));
+        }
+        Err(err) => {
+            return Err(HostlibError::Backend {
+                builtin: DELETE_FILE_BUILTIN,
+                message: format!("stat `{path_str}`: {err}"),
+            });
+        }
+    };
+
+    let removed = if metadata.is_dir() {
+        if recursive {
+            fs::remove_dir_all(&path).map_err(|err| HostlibError::Backend {
+                builtin: DELETE_FILE_BUILTIN,
+                message: format!("remove_dir_all `{path_str}`: {err}"),
+            })?;
+            true
+        } else {
+            fs::remove_dir(&path).map_err(|err| HostlibError::Backend {
+                builtin: DELETE_FILE_BUILTIN,
+                message: format!(
+                    "remove_dir `{path_str}` (pass recursive=true to delete non-empty dirs): {err}"
+                ),
+            })?;
+            true
+        }
+    } else {
+        fs::remove_file(&path).map_err(|err| HostlibError::Backend {
+            builtin: DELETE_FILE_BUILTIN,
+            message: format!("remove_file `{path_str}`: {err}"),
+        })?;
+        true
+    };
+
+    Ok(build_dict([
+        ("path", str_value(&path_str)),
+        ("removed", VmValue::Bool(removed)),
+    ]))
+}
+
+pub(super) fn list_directory(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(LIST_DIRECTORY_BUILTIN, args)?;
+    let dict = raw.as_ref();
+
+    let path_str = require_string(LIST_DIRECTORY_BUILTIN, dict, "path")?;
+    let include_hidden = optional_bool(LIST_DIRECTORY_BUILTIN, dict, "include_hidden", false)?;
+    let max_entries = optional_int(LIST_DIRECTORY_BUILTIN, dict, "max_entries", 0)?;
+
+    if max_entries < 0 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: LIST_DIRECTORY_BUILTIN,
+            param: "max_entries",
+            message: "must be >= 0".to_string(),
+        });
+    }
+    let cap = if max_entries == 0 {
+        usize::MAX
+    } else {
+        max_entries as usize
+    };
+
+    let path = PathBuf::from(&path_str);
+    let read = fs::read_dir(&path).map_err(|err| HostlibError::Backend {
+        builtin: LIST_DIRECTORY_BUILTIN,
+        message: format!("read_dir `{path_str}`: {err}"),
+    })?;
+
+    let mut entries: Vec<(String, VmValue)> = Vec::new();
+    let mut truncated = false;
+    let mut all_names: Vec<(String, fs::DirEntry, fs::Metadata)> = Vec::new();
+
+    for entry in read {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if !include_hidden && name.starts_with('.') {
+            continue;
+        }
+        let metadata = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        all_names.push((name, entry, metadata));
+    }
+    all_names.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (name, entry, metadata) in all_names {
+        if entries.len() >= cap {
+            truncated = true;
+            break;
+        }
+        let file_type = entry.file_type().ok();
+        let is_dir = file_type.map(|t| t.is_dir()).unwrap_or(false);
+        let is_symlink = file_type.map(|t| t.is_symlink()).unwrap_or(false);
+        let size = file_size(&metadata);
+        let entry_value = build_dict([
+            ("name", str_value(&name)),
+            ("is_dir", VmValue::Bool(is_dir)),
+            ("is_symlink", VmValue::Bool(is_symlink)),
+            ("size", VmValue::Int(size as i64)),
+        ]);
+        entries.push((name, entry_value));
+    }
+
+    let entries_list: Vec<VmValue> = entries.into_iter().map(|(_, v)| v).collect();
+    Ok(build_dict([
+        ("path", str_value(&path_str)),
+        ("entries", VmValue::List(Rc::new(entries_list))),
+        ("truncated", VmValue::Bool(truncated)),
+    ]))
+}
+
+fn file_size(metadata: &fs::Metadata) -> u64 {
+    metadata.len()
+}

--- a/crates/harn-hostlib/src/tools/git.rs
+++ b/crates/harn-hostlib/src/tools/git.rs
@@ -347,6 +347,15 @@ fn validate_rev(rev: &str) -> Result<(), HostlibError> {
 
 fn run_git(repo: &PathBuf, args: &[&str]) -> Result<String, HostlibError> {
     let mut cmd = Command::new("git");
+    // Strip ambient `GIT_*` environment variables so that being invoked
+    // from inside a parent `git` process (e.g. a pre-push hook running
+    // tests, or a git alias) doesn't leak `GIT_DIR` / `GIT_INDEX_FILE` /
+    // etc. into our isolated repo paths.
+    for (key, _) in std::env::vars() {
+        if key.starts_with("GIT_") {
+            cmd.env_remove(&key);
+        }
+    }
     cmd.arg("-C").arg(repo);
     for arg in args {
         cmd.arg(arg);

--- a/crates/harn-hostlib/src/tools/git.rs
+++ b/crates/harn-hostlib/src/tools/git.rs
@@ -1,0 +1,404 @@
+//! `tools/git` — read-only git inspection.
+//!
+//! Per the issue plan we'd prefer `gix`, but the scaffold's `Cargo.toml`
+//! intentionally omits it because gix 0.82 fails to compile on the repo's
+//! current rustc. To avoid blocking the rest of the deterministic-tool
+//! work on a toolchain bump, this module shells out to the system `git`
+//! binary using `Command` with an **arg-list invocation only** (never
+//! `sh -c <string>`). That keeps the surface free of shell injection and
+//! preserves the contract documented in `schemas/tools/git.{request,response}.json`.
+//! When B2's toolchain bump unblocks `gix`, individual operations can be
+//! migrated one at a time without touching the public surface.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::rc::Rc;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::tools::args::{
+    build_dict, dict_arg, optional_int, optional_string, require_string, str_value,
+};
+
+const BUILTIN: &str = "hostlib_tools_git";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Operation {
+    Status,
+    Diff,
+    Log,
+    Blame,
+    Show,
+    BranchList,
+    CurrentBranch,
+    RemoteList,
+}
+
+impl Operation {
+    fn parse(raw: &str) -> Result<Self, HostlibError> {
+        match raw {
+            "status" => Ok(Operation::Status),
+            "diff" => Ok(Operation::Diff),
+            "log" => Ok(Operation::Log),
+            "blame" => Ok(Operation::Blame),
+            "show" => Ok(Operation::Show),
+            "branch_list" => Ok(Operation::BranchList),
+            "current_branch" => Ok(Operation::CurrentBranch),
+            "remote_list" => Ok(Operation::RemoteList),
+            other => Err(HostlibError::InvalidParameter {
+                builtin: BUILTIN,
+                param: "operation",
+                message: format!(
+                    "unknown operation `{other}`; expected one of \
+                    [status, diff, log, blame, show, branch_list, current_branch, remote_list]"
+                ),
+            }),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Operation::Status => "status",
+            Operation::Diff => "diff",
+            Operation::Log => "log",
+            Operation::Blame => "blame",
+            Operation::Show => "show",
+            Operation::BranchList => "branch_list",
+            Operation::CurrentBranch => "current_branch",
+            Operation::RemoteList => "remote_list",
+        }
+    }
+}
+
+pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN, args)?;
+    let dict = raw.as_ref();
+
+    let operation_raw = require_string(BUILTIN, dict, "operation")?;
+    let operation = Operation::parse(&operation_raw)?;
+
+    let repo = optional_string(BUILTIN, dict, "repo")?
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    let path = optional_string(BUILTIN, dict, "path")?;
+    let rev = optional_string(BUILTIN, dict, "rev")?;
+    let rev_range = optional_string(BUILTIN, dict, "rev_range")?;
+    let max_count = optional_int(BUILTIN, dict, "max_count", 0)?;
+    if max_count < 0 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "max_count",
+            message: "must be >= 0".to_string(),
+        });
+    }
+
+    let data = match operation {
+        Operation::Status => run_status(&repo)?,
+        Operation::Diff => run_diff(&repo, path.as_deref(), rev.as_deref())?,
+        Operation::Log => run_log(
+            &repo,
+            path.as_deref(),
+            rev.as_deref(),
+            rev_range.as_deref(),
+            max_count,
+        )?,
+        Operation::Blame => run_blame(&repo, path.as_deref(), rev.as_deref())?,
+        Operation::Show => run_show(&repo, rev.as_deref())?,
+        Operation::BranchList => run_branch_list(&repo)?,
+        Operation::CurrentBranch => run_current_branch(&repo)?,
+        Operation::RemoteList => run_remote_list(&repo)?,
+    };
+
+    Ok(build_dict([
+        ("operation", str_value(operation.as_str())),
+        ("repo", str_value(repo.to_string_lossy())),
+        ("data", data),
+    ]))
+}
+
+fn run_status(repo: &PathBuf) -> Result<VmValue, HostlibError> {
+    let stdout = run_git(repo, &["status", "--porcelain=v1", "-z"])?;
+    let mut entries: Vec<VmValue> = Vec::new();
+    for raw_entry in stdout.split('\0') {
+        if raw_entry.len() < 3 {
+            continue;
+        }
+        let bytes = raw_entry.as_bytes();
+        // Format is `XY <path>` where X and Y are status codes for index/worktree.
+        let index_status = bytes[0] as char;
+        let worktree_status = bytes[1] as char;
+        let path = String::from_utf8_lossy(&bytes[3..]).into_owned();
+        entries.push(build_dict([
+            ("index", str_value(index_status.to_string())),
+            ("worktree", str_value(worktree_status.to_string())),
+            ("path", str_value(path)),
+        ]));
+    }
+    Ok(VmValue::List(Rc::new(entries)))
+}
+
+fn run_diff(
+    repo: &PathBuf,
+    path: Option<&str>,
+    rev: Option<&str>,
+) -> Result<VmValue, HostlibError> {
+    let mut argv: Vec<String> = vec!["diff".to_string()];
+    if let Some(rev) = rev {
+        validate_rev(rev)?;
+        argv.push(rev.to_string());
+    }
+    argv.push("--".to_string());
+    if let Some(path) = path {
+        argv.push(path.to_string());
+    }
+    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let stdout = run_git(repo, &argv_refs)?;
+    Ok(str_value(&stdout))
+}
+
+fn run_log(
+    repo: &PathBuf,
+    path: Option<&str>,
+    rev: Option<&str>,
+    rev_range: Option<&str>,
+    max_count: i64,
+) -> Result<VmValue, HostlibError> {
+    let mut argv: Vec<String> = vec![
+        "log".to_string(),
+        "--pretty=format:%H%x1f%an%x1f%ae%x1f%aI%x1f%s%x1e".to_string(),
+    ];
+    if max_count > 0 {
+        argv.push(format!("-{}", max_count));
+    }
+    if let Some(rev) = rev {
+        validate_rev(rev)?;
+        argv.push(rev.to_string());
+    } else if let Some(range) = rev_range {
+        validate_rev(range)?;
+        argv.push(range.to_string());
+    }
+    if let Some(path) = path {
+        argv.push("--".to_string());
+        argv.push(path.to_string());
+    }
+    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let stdout = run_git(repo, &argv_refs)?;
+    let mut commits: Vec<VmValue> = Vec::new();
+    for record in stdout.split('\u{001e}') {
+        let trimmed = record.trim_matches(['\n']);
+        if trimmed.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = trimmed.split('\u{001f}').collect();
+        if parts.len() != 5 {
+            continue;
+        }
+        commits.push(build_dict([
+            ("sha", str_value(parts[0])),
+            ("author_name", str_value(parts[1])),
+            ("author_email", str_value(parts[2])),
+            ("author_date", str_value(parts[3])),
+            ("subject", str_value(parts[4])),
+        ]));
+    }
+    Ok(VmValue::List(Rc::new(commits)))
+}
+
+fn run_blame(
+    repo: &PathBuf,
+    path: Option<&str>,
+    rev: Option<&str>,
+) -> Result<VmValue, HostlibError> {
+    let path = path.ok_or(HostlibError::MissingParameter {
+        builtin: BUILTIN,
+        param: "path",
+    })?;
+    let mut argv: Vec<String> = vec!["blame".to_string(), "--line-porcelain".to_string()];
+    if let Some(rev) = rev {
+        validate_rev(rev)?;
+        argv.push(rev.to_string());
+    }
+    argv.push("--".to_string());
+    argv.push(path.to_string());
+    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let stdout = run_git(repo, &argv_refs)?;
+
+    let mut blame_entries: Vec<VmValue> = Vec::new();
+    let mut current_sha = String::new();
+    let mut current_author = String::new();
+    let mut line_no: i64 = 0;
+    for line in stdout.lines() {
+        if let Some(rest) = line.strip_prefix("author ") {
+            current_author = rest.to_string();
+        } else if line.len() >= 40 && line.chars().take(40).all(|c| c.is_ascii_hexdigit()) {
+            current_sha = line[..40].to_string();
+        } else if let Some(stripped) = line.strip_prefix('\t') {
+            line_no += 1;
+            blame_entries.push(build_dict([
+                ("line", VmValue::Int(line_no)),
+                ("sha", str_value(&current_sha)),
+                ("author", str_value(&current_author)),
+                ("text", str_value(stripped)),
+            ]));
+        }
+    }
+    Ok(VmValue::List(Rc::new(blame_entries)))
+}
+
+fn run_show(repo: &PathBuf, rev: Option<&str>) -> Result<VmValue, HostlibError> {
+    let rev = rev.ok_or(HostlibError::MissingParameter {
+        builtin: BUILTIN,
+        param: "rev",
+    })?;
+    validate_rev(rev)?;
+    let stdout = run_git(repo, &["show", "--stat", "--patch", rev])?;
+    Ok(str_value(&stdout))
+}
+
+fn run_branch_list(repo: &PathBuf) -> Result<VmValue, HostlibError> {
+    // `for-each-ref --format` does not honor `%x1f` literal-byte escapes
+    // (those are `git log`-only). Use a tab as the separator since branch
+    // names cannot contain tabs.
+    let stdout = run_git(
+        repo,
+        &[
+            "for-each-ref",
+            "--format=%(refname:short)\t%(objectname)",
+            "refs/heads/",
+        ],
+    )?;
+    let mut branches: Vec<VmValue> = Vec::new();
+    for line in stdout.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = line.splitn(2, '\t').collect();
+        if parts.len() != 2 {
+            continue;
+        }
+        branches.push(build_dict([
+            ("name", str_value(parts[0])),
+            ("sha", str_value(parts[1])),
+        ]));
+    }
+    Ok(VmValue::List(Rc::new(branches)))
+}
+
+fn run_current_branch(repo: &PathBuf) -> Result<VmValue, HostlibError> {
+    let stdout = run_git(repo, &["symbolic-ref", "--quiet", "--short", "HEAD"])
+        .or_else(|_| run_git(repo, &["rev-parse", "--short", "HEAD"]))?;
+    Ok(str_value(stdout.trim()))
+}
+
+fn run_remote_list(repo: &PathBuf) -> Result<VmValue, HostlibError> {
+    let stdout = run_git(repo, &["remote", "-v"])?;
+    let mut remotes: Vec<VmValue> = Vec::new();
+    let mut seen: Vec<String> = Vec::new();
+    for line in stdout.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 2 {
+            continue;
+        }
+        let name = parts[0];
+        let url = parts[1];
+        if seen.contains(&name.to_string()) {
+            continue;
+        }
+        seen.push(name.to_string());
+        remotes.push(build_dict([
+            ("name", str_value(name)),
+            ("url", str_value(url)),
+        ]));
+    }
+    Ok(VmValue::List(Rc::new(remotes)))
+}
+
+/// Validate a user-supplied revision/refspec/range. We forward the value
+/// to `git` as a positional argument (never via shell), so the only
+/// classes of injection we need to defend against are arguments that
+/// could be misinterpreted as flags. Reject anything starting with `-`
+/// (so `--exec` and friends can't sneak through), and anything containing
+/// NUL or newlines.
+fn validate_rev(rev: &str) -> Result<(), HostlibError> {
+    if rev.is_empty() {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "rev",
+            message: "must not be empty".to_string(),
+        });
+    }
+    if rev.starts_with('-') {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "rev",
+            message: "must not start with `-` (would be parsed as a flag by git)".to_string(),
+        });
+    }
+    if rev.contains('\0') || rev.contains('\n') {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "rev",
+            message: "must not contain NUL or newline".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn run_git(repo: &PathBuf, args: &[&str]) -> Result<String, HostlibError> {
+    let mut cmd = Command::new("git");
+    cmd.arg("-C").arg(repo);
+    for arg in args {
+        cmd.arg(arg);
+    }
+    let output = cmd.output().map_err(|err| HostlibError::Backend {
+        builtin: BUILTIN,
+        message: format!(
+            "spawn `git {} ...`: {err}",
+            args.first().copied().unwrap_or("?")
+        ),
+    })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(HostlibError::Backend {
+            builtin: BUILTIN,
+            message: format!(
+                "git {} exited with status {}: {}",
+                args.first().copied().unwrap_or("?"),
+                output.status,
+                stderr.trim()
+            ),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_rev_rejects_flag_lookalikes() {
+        assert!(validate_rev("--exec=rm").is_err());
+        assert!(validate_rev("-x").is_err());
+    }
+
+    #[test]
+    fn validate_rev_rejects_control_bytes() {
+        assert!(validate_rev("HEAD\nrm").is_err());
+        assert!(validate_rev("HEAD\0").is_err());
+    }
+
+    #[test]
+    fn validate_rev_accepts_normal_inputs() {
+        for ok in ["HEAD", "main", "abc1234", "v1.2.3", "main..feature"] {
+            assert!(validate_rev(ok).is_ok(), "{ok} should be accepted");
+        }
+    }
+
+    #[test]
+    fn operation_parse_is_total() {
+        assert!(Operation::parse("status").is_ok());
+        assert!(Operation::parse("nope").is_err());
+    }
+}

--- a/crates/harn-hostlib/src/tools/mod.rs
+++ b/crates/harn-hostlib/src/tools/mod.rs
@@ -2,12 +2,54 @@
 //!
 //! Ports the Swift `CoreToolExecutor` surface: search (ripgrep via
 //! `grep-searcher` + `ignore`), file I/O, listing, file outline, git via
-//! `gix`, and process lifecycle (`run_command`, `run_test`,
-//! `run_build_command`, `inspect_test_results`, `manage_packages`).
+//! `gix` (currently shelled-out — see [`git`] for the rationale), and
+//! process lifecycle (`run_command`, `run_test`, `run_build_command`,
+//! `inspect_test_results`, `manage_packages`).
 //!
-//! Implementation is split across follow-up issues C2/C3.
+//! Implementation status:
+//!
+//! | Method                  | Status                          |
+//! |-------------------------|---------------------------------|
+//! | `search`                | implemented                     |
+//! | `read_file`             | implemented                     |
+//! | `write_file`            | implemented                     |
+//! | `delete_file`           | implemented                     |
+//! | `list_directory`        | implemented                     |
+//! | `get_file_outline`      | implemented (regex extractor)   |
+//! | `git`                   | implemented (system git CLI)    |
+//! | `run_command`           | unimplemented (issue C2)        |
+//! | `run_test`              | unimplemented (issue C2)        |
+//! | `run_build_command`     | unimplemented (issue C2)        |
+//! | `inspect_test_results`  | unimplemented (issue C2)        |
+//! | `manage_packages`       | unimplemented (issue C2)        |
+//!
+//! ### Per-session opt-in
+//!
+//! All seven deterministic tools are gated by a per-thread feature flag.
+//! Pipelines must call `hostlib_enable("tools:deterministic")` (registered
+//! by [`ToolsCapability::register_builtins`]) before any of the tool
+//! methods will execute. Until then, calls return
+//! [`HostlibError::Backend`] with an explanatory message. This matches the
+//! "per-session opt-in" model called out in issue #567 and keeps the
+//! deterministic-tool surface sandbox-friendly.
 
-use crate::registry::{BuiltinRegistry, HostlibCapability};
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::registry::{BuiltinRegistry, HostlibCapability, RegisteredBuiltin, SyncHandler};
+
+mod args;
+mod file_io;
+mod git;
+mod outline;
+pub mod permissions;
+mod search;
+
+pub use permissions::FEATURE_TOOLS_DETERMINISTIC;
 
 /// Tools capability handle.
 #[derive(Default)]
@@ -19,17 +61,40 @@ impl HostlibCapability for ToolsCapability {
     }
 
     fn register_builtins(&self, registry: &mut BuiltinRegistry) {
-        registry.register_unimplemented("hostlib_tools_search", "tools", "search");
-        registry.register_unimplemented("hostlib_tools_read_file", "tools", "read_file");
-        registry.register_unimplemented("hostlib_tools_write_file", "tools", "write_file");
-        registry.register_unimplemented("hostlib_tools_delete_file", "tools", "delete_file");
-        registry.register_unimplemented("hostlib_tools_list_directory", "tools", "list_directory");
-        registry.register_unimplemented(
-            "hostlib_tools_get_file_outline",
-            "tools",
-            "get_file_outline",
+        register_gated(registry, "hostlib_tools_search", "search", search::run);
+        register_gated(
+            registry,
+            "hostlib_tools_read_file",
+            "read_file",
+            file_io::read_file,
         );
-        registry.register_unimplemented("hostlib_tools_git", "tools", "git");
+        register_gated(
+            registry,
+            "hostlib_tools_write_file",
+            "write_file",
+            file_io::write_file,
+        );
+        register_gated(
+            registry,
+            "hostlib_tools_delete_file",
+            "delete_file",
+            file_io::delete_file,
+        );
+        register_gated(
+            registry,
+            "hostlib_tools_list_directory",
+            "list_directory",
+            file_io::list_directory,
+        );
+        register_gated(
+            registry,
+            "hostlib_tools_get_file_outline",
+            "get_file_outline",
+            outline::run,
+        );
+        register_gated(registry, "hostlib_tools_git", "git", git::run);
+
+        // Process tools land in C2; keep the contract surface visible.
         registry.register_unimplemented("hostlib_tools_run_command", "tools", "run_command");
         registry.register_unimplemented("hostlib_tools_run_test", "tools", "run_test");
         registry.register_unimplemented(
@@ -47,5 +112,86 @@ impl HostlibCapability for ToolsCapability {
             "tools",
             "manage_packages",
         );
+
+        // The opt-in builtin lives in the `tools` module so embedders that
+        // don't compose `ToolsCapability` don't accidentally expose it.
+        let handler: SyncHandler = Arc::new(handle_enable);
+        registry.register(RegisteredBuiltin {
+            name: "hostlib_enable",
+            module: "tools",
+            method: "enable",
+            handler,
+        });
+    }
+}
+
+/// Register a builtin whose handler runs only when the deterministic-tools
+/// feature has been enabled on the current thread.
+fn register_gated(
+    registry: &mut BuiltinRegistry,
+    name: &'static str,
+    method: &'static str,
+    runner: fn(&[VmValue]) -> Result<VmValue, HostlibError>,
+) {
+    let handler: SyncHandler = Arc::new(move |args: &[VmValue]| {
+        if !permissions::is_enabled(permissions::FEATURE_TOOLS_DETERMINISTIC) {
+            return Err(HostlibError::Backend {
+                builtin: name,
+                message: format!(
+                    "feature `{}` is not enabled in this session — call \
+                     `hostlib_enable(\"{}\")` before invoking deterministic tools",
+                    permissions::FEATURE_TOOLS_DETERMINISTIC,
+                    permissions::FEATURE_TOOLS_DETERMINISTIC
+                ),
+            });
+        }
+        runner(args)
+    });
+    registry.register(RegisteredBuiltin {
+        name,
+        module: "tools",
+        method,
+        handler,
+    });
+}
+
+/// Implementation of the `hostlib_enable` builtin. Accepts either a bare
+/// string (`hostlib_enable("tools:deterministic")`) or a dict carrying a
+/// `feature` key (`hostlib_enable({feature: "..."})`) so callers can
+/// supply structured payloads in the future without breaking back-compat.
+fn handle_enable(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let feature = match args.first() {
+        Some(VmValue::String(s)) => s.to_string(),
+        Some(VmValue::Dict(dict)) => match dict.get("feature") {
+            Some(VmValue::String(s)) => s.to_string(),
+            _ => {
+                return Err(HostlibError::MissingParameter {
+                    builtin: "hostlib_enable",
+                    param: "feature",
+                });
+            }
+        },
+        _ => {
+            return Err(HostlibError::MissingParameter {
+                builtin: "hostlib_enable",
+                param: "feature",
+            });
+        }
+    };
+
+    match feature.as_str() {
+        permissions::FEATURE_TOOLS_DETERMINISTIC => {
+            let newly_enabled = permissions::enable(&feature);
+            let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+            map.insert("feature".to_string(), VmValue::String(Rc::from(feature)));
+            map.insert("enabled".to_string(), VmValue::Bool(true));
+            map.insert("newly_enabled".to_string(), VmValue::Bool(newly_enabled));
+            Ok(VmValue::Dict(Rc::new(map)))
+        }
+        other => Err(HostlibError::InvalidParameter {
+            builtin: "hostlib_enable",
+            param: "feature",
+            message: format!("unknown feature `{other}`; supported: [`tools:deterministic`]"),
+        }),
     }
 }

--- a/crates/harn-hostlib/src/tools/outline.rs
+++ b/crates/harn-hostlib/src/tools/outline.rs
@@ -1,0 +1,323 @@
+//! `tools/get_file_outline` — convenience wrapper that returns a
+//! structural outline (functions, classes, types) for a single source file.
+//!
+//! The issue's `tools/get_file_outline` description says "calls to
+//! `ast::outline`" — but `ast::outline` is the surface of B2, which lands
+//! after this issue. Until B2 ships, we use a small language-agnostic
+//! regex-backed extractor for the languages `burin-code` ships outline
+//! support for today: Swift, Rust, JS/TS, Python, Go, Ruby, Java/Kotlin,
+//! C/C++, and shell. The output shape is identical to `ast.outline`'s
+//! response schema, so when B2 lands the body of this function can swap
+//! the regex extractor for a tree-sitter call without disturbing callers.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::tools::args::{build_dict, dict_arg, optional_int, require_string, str_value};
+
+const BUILTIN: &str = "hostlib_tools_get_file_outline";
+
+pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN, args)?;
+    let dict = raw.as_ref();
+
+    let path_str = require_string(BUILTIN, dict, "path")?;
+    let max_depth = optional_int(BUILTIN, dict, "max_depth", 0)?;
+    if max_depth < 0 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "max_depth",
+            message: "must be >= 0".to_string(),
+        });
+    }
+    let _ = max_depth;
+
+    let path = PathBuf::from(&path_str);
+    let language = detect_language(&path);
+
+    let content = fs::read_to_string(&path).map_err(|err| HostlibError::Backend {
+        builtin: BUILTIN,
+        message: format!("read `{path_str}`: {err}"),
+    })?;
+
+    let items = extract(&content, language);
+    let items_list: Vec<VmValue> = items.into_iter().map(item_to_value).collect();
+
+    Ok(build_dict([
+        ("path", str_value(&path_str)),
+        ("language", str_value(language)),
+        ("items", VmValue::List(Rc::new(items_list))),
+    ]))
+}
+
+fn detect_language(path: &Path) -> &'static str {
+    let ext = path
+        .extension()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match ext.as_str() {
+        "rs" => "rust",
+        "swift" => "swift",
+        "go" => "go",
+        "py" => "python",
+        "js" | "mjs" | "cjs" | "jsx" => "javascript",
+        "ts" | "tsx" => "typescript",
+        "rb" => "ruby",
+        "java" => "java",
+        "kt" | "kts" => "kotlin",
+        "c" | "h" => "c",
+        "cc" | "cpp" | "cxx" | "hpp" | "hxx" => "cpp",
+        "sh" | "bash" | "zsh" => "shell",
+        "" => "plaintext",
+        other => leak_language(other),
+    }
+}
+
+fn leak_language(s: &str) -> &'static str {
+    Box::leak(s.to_string().into_boxed_str())
+}
+
+#[derive(Debug)]
+struct OutlineItem {
+    name: String,
+    kind: String,
+    start_row: usize,
+    end_row: usize,
+}
+
+fn extract(source: &str, language: &str) -> Vec<OutlineItem> {
+    let lines: Vec<&str> = source.lines().collect();
+    let total = lines.len();
+    let mut out = Vec::new();
+
+    for (idx, raw_line) in lines.iter().enumerate() {
+        let trimmed = raw_line.trim_start();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let item = match language {
+            "rust" => extract_rust(trimmed, idx, total),
+            "swift" => extract_swift(trimmed, idx, total),
+            "go" => extract_go(trimmed, idx, total),
+            "python" => extract_python(trimmed, idx, total),
+            "javascript" | "typescript" => extract_js_ts(trimmed, idx, total),
+            "ruby" => extract_ruby(trimmed, idx, total),
+            "java" | "kotlin" => extract_jvm(trimmed, idx, total),
+            "c" | "cpp" => extract_c_cpp(trimmed, idx, total),
+            "shell" => extract_shell(trimmed, idx, total),
+            _ => None,
+        };
+        if let Some(item) = item {
+            out.push(item);
+        }
+    }
+    out
+}
+
+fn extract_rust(line: &str, idx: usize, total: usize) -> Option<OutlineItem> {
+    let prefixes: &[(&str, &str)] = &[
+        ("pub fn ", "function"),
+        ("pub async fn ", "function"),
+        ("pub(crate) fn ", "function"),
+        ("pub(crate) async fn ", "function"),
+        ("pub(super) fn ", "function"),
+        ("fn ", "function"),
+        ("async fn ", "function"),
+        ("pub struct ", "struct"),
+        ("struct ", "struct"),
+        ("pub enum ", "enum"),
+        ("enum ", "enum"),
+        ("pub trait ", "trait"),
+        ("trait ", "trait"),
+        ("impl ", "impl"),
+        ("pub mod ", "module"),
+        ("mod ", "module"),
+        ("pub type ", "type"),
+        ("type ", "type"),
+    ];
+    for (prefix, kind) in prefixes {
+        if let Some(rest) = line.strip_prefix(prefix) {
+            let name = take_ident(rest);
+            if !name.is_empty() {
+                return Some(OutlineItem {
+                    name,
+                    kind: kind.to_string(),
+                    start_row: idx,
+                    end_row: idx.min(total.saturating_sub(1)),
+                });
+            }
+        }
+    }
+    None
+}
+
+fn extract_swift(line: &str, idx: usize, total: usize) -> Option<OutlineItem> {
+    let prefixes: &[(&str, &str)] = &[
+        ("public func ", "function"),
+        ("private func ", "function"),
+        ("internal func ", "function"),
+        ("func ", "function"),
+        ("public class ", "class"),
+        ("class ", "class"),
+        ("public struct ", "struct"),
+        ("struct ", "struct"),
+        ("public enum ", "enum"),
+        ("enum ", "enum"),
+        ("public protocol ", "protocol"),
+        ("protocol ", "protocol"),
+        ("extension ", "extension"),
+    ];
+    extract_with_prefixes(line, idx, total, prefixes)
+}
+
+fn extract_go(line: &str, idx: usize, total: usize) -> Option<OutlineItem> {
+    let prefixes: &[(&str, &str)] = &[
+        ("func ", "function"),
+        ("type ", "type"),
+        ("var ", "variable"),
+        ("const ", "constant"),
+    ];
+    extract_with_prefixes(line, idx, total, prefixes)
+}
+
+fn extract_python(line: &str, idx: usize, total: usize) -> Option<OutlineItem> {
+    let prefixes: &[(&str, &str)] = &[
+        ("def ", "function"),
+        ("async def ", "function"),
+        ("class ", "class"),
+    ];
+    extract_with_prefixes(line, idx, total, prefixes)
+}
+
+fn extract_js_ts(line: &str, idx: usize, total: usize) -> Option<OutlineItem> {
+    let prefixes: &[(&str, &str)] = &[
+        ("export function ", "function"),
+        ("export async function ", "function"),
+        ("export default function ", "function"),
+        ("function ", "function"),
+        ("async function ", "function"),
+        ("export class ", "class"),
+        ("class ", "class"),
+        ("export interface ", "interface"),
+        ("interface ", "interface"),
+        ("export type ", "type"),
+        ("type ", "type"),
+        ("export enum ", "enum"),
+        ("enum ", "enum"),
+    ];
+    extract_with_prefixes(line, idx, total, prefixes)
+}
+
+fn extract_ruby(line: &str, idx: usize, total: usize) -> Option<OutlineItem> {
+    let prefixes: &[(&str, &str)] = &[
+        ("def ", "function"),
+        ("class ", "class"),
+        ("module ", "module"),
+    ];
+    extract_with_prefixes(line, idx, total, prefixes)
+}
+
+fn extract_jvm(line: &str, idx: usize, total: usize) -> Option<OutlineItem> {
+    let prefixes: &[(&str, &str)] = &[
+        ("public class ", "class"),
+        ("class ", "class"),
+        ("public interface ", "interface"),
+        ("interface ", "interface"),
+        ("public enum ", "enum"),
+        ("enum ", "enum"),
+        ("fun ", "function"),
+        ("object ", "object"),
+    ];
+    extract_with_prefixes(line, idx, total, prefixes)
+}
+
+fn extract_c_cpp(line: &str, idx: usize, total: usize) -> Option<OutlineItem> {
+    let prefixes: &[(&str, &str)] = &[
+        ("class ", "class"),
+        ("struct ", "struct"),
+        ("namespace ", "namespace"),
+        ("template ", "template"),
+        ("typedef ", "type"),
+    ];
+    extract_with_prefixes(line, idx, total, prefixes)
+}
+
+fn extract_shell(line: &str, idx: usize, total: usize) -> Option<OutlineItem> {
+    if let Some(rest) = line.strip_prefix("function ") {
+        let name = take_ident(rest);
+        if !name.is_empty() {
+            return Some(OutlineItem {
+                name,
+                kind: "function".to_string(),
+                start_row: idx,
+                end_row: idx.min(total.saturating_sub(1)),
+            });
+        }
+    }
+    if let Some((name, rest)) = line.split_once("()") {
+        let trimmed_rest = rest.trim();
+        if trimmed_rest.starts_with('{') || trimmed_rest.is_empty() {
+            let candidate: String = name.trim().chars().take_while(is_ident_char).collect();
+            if !candidate.is_empty() {
+                return Some(OutlineItem {
+                    name: candidate,
+                    kind: "function".to_string(),
+                    start_row: idx,
+                    end_row: idx.min(total.saturating_sub(1)),
+                });
+            }
+        }
+    }
+    None
+}
+
+fn extract_with_prefixes(
+    line: &str,
+    idx: usize,
+    total: usize,
+    prefixes: &[(&str, &str)],
+) -> Option<OutlineItem> {
+    for (prefix, kind) in prefixes {
+        if let Some(rest) = line.strip_prefix(prefix) {
+            let name = take_ident(rest);
+            if !name.is_empty() {
+                return Some(OutlineItem {
+                    name,
+                    kind: kind.to_string(),
+                    start_row: idx,
+                    end_row: idx.min(total.saturating_sub(1)),
+                });
+            }
+        }
+    }
+    None
+}
+
+fn take_ident(s: &str) -> String {
+    s.chars().take_while(is_ident_char).collect()
+}
+
+fn is_ident_char(c: &char) -> bool {
+    c.is_alphanumeric() || *c == '_'
+}
+
+fn item_to_value(item: OutlineItem) -> VmValue {
+    let OutlineItem {
+        name,
+        kind,
+        start_row,
+        end_row,
+    } = item;
+    build_dict([
+        ("name", str_value(&name)),
+        ("kind", str_value(&kind)),
+        ("start_row", VmValue::Int(start_row as i64)),
+        ("end_row", VmValue::Int(end_row as i64)),
+        ("children", VmValue::List(Rc::new(Vec::new()))),
+    ])
+}

--- a/crates/harn-hostlib/src/tools/permissions.rs
+++ b/crates/harn-hostlib/src/tools/permissions.rs
@@ -1,0 +1,63 @@
+//! Per-thread "enabled features" registry for the deterministic tools.
+//!
+//! `harn-hostlib` exposes the deterministic tool builtins on every VM that
+//! `install_default` runs against, but pipelines must explicitly opt in to
+//! their use by calling the `hostlib_enable("tools:deterministic")` builtin
+//! before any of the tool methods will execute. This keeps the surface
+//! sandbox-friendly: a script that doesn't ask for the tools cannot poke
+//! the host filesystem or shell out to `git` even though the contract is
+//! registered.
+//!
+//! State is held in a thread-local so that:
+//!
+//! * Each VM instance — which today runs single-threaded — gets an
+//!   independent enable set.
+//! * Cargo test isolation works without extra ceremony (each test runs on
+//!   its own thread).
+//!
+//! Embedders can also call [`enable_for_test`] / [`reset`] from Rust if
+//! they need to bypass the builtin (for example, tests that don't drive
+//! a live VM).
+
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+
+/// Feature key for the deterministic-tools surface.
+///
+/// Kept here as a constant so [`tools::register_builtins`](super::register_builtins)
+/// and the integration tests share the exact same string.
+pub const FEATURE_TOOLS_DETERMINISTIC: &str = "tools:deterministic";
+
+thread_local! {
+    static ENABLED: RefCell<BTreeSet<String>> = const { RefCell::new(BTreeSet::new()) };
+}
+
+/// Mark `feature` as enabled on the current thread. Returns `true` if the
+/// feature was newly enabled, `false` if it was already on.
+pub fn enable(feature: &str) -> bool {
+    ENABLED.with(|cell| cell.borrow_mut().insert(feature.to_string()))
+}
+
+/// Mark `feature` as disabled on the current thread. Returns `true` if the
+/// feature was previously enabled. Mostly useful in tests that want to
+/// assert the gate works.
+pub fn disable(feature: &str) -> bool {
+    ENABLED.with(|cell| cell.borrow_mut().remove(feature))
+}
+
+/// Bulk-clear every enabled feature on the current thread. Tests use this
+/// to start from a known state.
+pub fn reset() {
+    ENABLED.with(|cell| cell.borrow_mut().clear());
+}
+
+/// Report whether `feature` is currently enabled on the current thread.
+pub fn is_enabled(feature: &str) -> bool {
+    ENABLED.with(|cell| cell.borrow().contains(feature))
+}
+
+/// Convenience wrapper for tests: enable the deterministic tools in the
+/// current thread without needing to reach for the builtin.
+pub fn enable_for_test() {
+    enable(FEATURE_TOOLS_DETERMINISTIC);
+}

--- a/crates/harn-hostlib/src/tools/search.rs
+++ b/crates/harn-hostlib/src/tools/search.rs
@@ -1,0 +1,296 @@
+//! `tools/search` — ripgrep-style content search backed by `grep-searcher`
+//! and `ignore`.
+//!
+//! Mirrors the Swift `CoreToolExecutor.searchCode` surface but returns
+//! structured matches (path/line/column/text/context) instead of a
+//! preformatted human string. The shape is locked by
+//! `schemas/tools/search.{request,response}.json`.
+
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use grep_matcher::Matcher;
+use grep_regex::{RegexMatcher, RegexMatcherBuilder};
+use grep_searcher::{Searcher, SearcherBuilder, Sink, SinkContext, SinkContextKind, SinkMatch};
+use harn_vm::VmValue;
+use ignore::WalkBuilder;
+
+use crate::error::HostlibError;
+use crate::tools::args::{
+    build_dict, dict_arg, optional_bool, optional_int, optional_string, require_string, str_value,
+};
+
+const BUILTIN: &str = "hostlib_tools_search";
+
+/// Public entry point invoked by the registered builtin.
+pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN, args)?;
+    let dict = raw.as_ref();
+
+    let pattern = require_string(BUILTIN, dict, "pattern")?;
+    if pattern.is_empty() {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "pattern",
+            message: "pattern must not be empty".to_string(),
+        });
+    }
+
+    let path = optional_string(BUILTIN, dict, "path")?
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    let glob = optional_string(BUILTIN, dict, "glob")?;
+    let case_insensitive = optional_bool(BUILTIN, dict, "case_insensitive", false)?;
+    let fixed_strings = optional_bool(BUILTIN, dict, "fixed_strings", false)?;
+    let include_hidden = optional_bool(BUILTIN, dict, "include_hidden", false)?;
+    let max_matches = optional_int(BUILTIN, dict, "max_matches", 1000)?;
+    let context_before = optional_int(BUILTIN, dict, "context_before", 0)?;
+    let context_after = optional_int(BUILTIN, dict, "context_after", 0)?;
+
+    if max_matches < 1 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "max_matches",
+            message: "must be >= 1".to_string(),
+        });
+    }
+    if context_before < 0 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "context_before",
+            message: "must be >= 0".to_string(),
+        });
+    }
+    if context_after < 0 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "context_after",
+            message: "must be >= 0".to_string(),
+        });
+    }
+
+    let max_matches = max_matches as usize;
+    let context_before = context_before as usize;
+    let context_after = context_after as usize;
+
+    let matcher = build_matcher(&pattern, case_insensitive, fixed_strings)?;
+
+    let mut walker = WalkBuilder::new(&path);
+    walker
+        .hidden(!include_hidden)
+        .ignore(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        // Honor `.gitignore` even outside a git repo. The deterministic-tools
+        // surface should match developer expectation: a `.gitignore` next to
+        // the search root filters results regardless of whether `.git/`
+        // exists. (Without this, `ignore` requires a `.git/` ancestor.)
+        .require_git(false)
+        .parents(true);
+    if let Some(glob_pat) = glob.as_deref() {
+        let mut builder = ignore::overrides::OverrideBuilder::new(&path);
+        let normalized = normalize_glob(glob_pat);
+        builder
+            .add(&normalized)
+            .map_err(|err| HostlibError::InvalidParameter {
+                builtin: BUILTIN,
+                param: "glob",
+                message: format!("invalid glob `{glob_pat}`: {err}"),
+            })?;
+        let overrides = builder
+            .build()
+            .map_err(|err| HostlibError::InvalidParameter {
+                builtin: BUILTIN,
+                param: "glob",
+                message: format!("invalid glob `{glob_pat}`: {err}"),
+            })?;
+        walker.overrides(overrides);
+    }
+
+    let mut all_rows: Vec<RowWithPath> = Vec::new();
+    let mut truncated = false;
+
+    'outer: for entry in walker.build() {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+        let file_path = entry.path().to_path_buf();
+        let mut sink = CollectorSink {
+            matcher: matcher.clone(),
+            rows: Vec::new(),
+            pending_before: VecDeque::new(),
+            context_before,
+            remaining: max_matches.saturating_sub(all_rows.len()),
+        };
+        let mut searcher = SearcherBuilder::new()
+            .before_context(context_before)
+            .after_context(context_after)
+            .line_number(true)
+            .build();
+        if let Err(err) = searcher.search_path(&matcher, &file_path, &mut sink) {
+            // I/O error reading one file — skip it and keep searching.
+            let _ = err;
+            continue;
+        }
+        for row in sink.rows {
+            all_rows.push(RowWithPath {
+                path: file_path.clone(),
+                row,
+            });
+            if all_rows.len() >= max_matches {
+                truncated = true;
+                break 'outer;
+            }
+        }
+        if all_rows.len() >= max_matches {
+            truncated = true;
+            break 'outer;
+        }
+    }
+
+    let matches: Vec<VmValue> = all_rows.into_iter().map(row_to_value).collect();
+
+    Ok(build_dict([
+        ("matches", VmValue::List(Rc::new(matches))),
+        ("truncated", VmValue::Bool(truncated)),
+    ]))
+}
+
+fn build_matcher(
+    pattern: &str,
+    case_insensitive: bool,
+    fixed_strings: bool,
+) -> Result<RegexMatcher, HostlibError> {
+    let mut builder = RegexMatcherBuilder::new();
+    builder.case_insensitive(case_insensitive);
+    builder.fixed_strings(fixed_strings);
+    builder
+        .build(pattern)
+        .map_err(|err| HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "pattern",
+            message: format!("invalid regex: {err}"),
+        })
+}
+
+/// Normalize a user-supplied glob the way Swift's `searchCode` did so
+/// callers writing `internal/manifest/*.go` get matches at any depth.
+fn normalize_glob(glob: &str) -> String {
+    if glob.contains('/') && !glob.starts_with("**/") {
+        format!("**/{glob}")
+    } else {
+        glob.to_string()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MatchRow {
+    line: u64,
+    column: u64,
+    text: String,
+    context_before: VecDeque<String>,
+    context_after: VecDeque<String>,
+}
+
+struct RowWithPath {
+    path: PathBuf,
+    row: MatchRow,
+}
+
+struct CollectorSink {
+    matcher: RegexMatcher,
+    rows: Vec<MatchRow>,
+    /// Sliding window of recent before-context lines published by
+    /// [`Sink::context`] before each [`Sink::matched`] call.
+    pending_before: VecDeque<String>,
+    context_before: usize,
+    remaining: usize,
+}
+
+impl Sink for CollectorSink {
+    type Error = std::io::Error;
+
+    fn matched(
+        &mut self,
+        _searcher: &Searcher,
+        sink_match: &SinkMatch<'_>,
+    ) -> Result<bool, std::io::Error> {
+        if self.remaining == 0 {
+            return Ok(false);
+        }
+
+        let line_number = sink_match.line_number().unwrap_or(0);
+        let raw_line = std::str::from_utf8(sink_match.bytes()).unwrap_or("");
+        let trimmed = raw_line.trim_end_matches(['\n', '\r']);
+
+        let mut column = 1u64;
+        if let Ok(Some(m)) = self.matcher.find(sink_match.bytes()) {
+            column = (m.start() as u64) + 1;
+        }
+
+        let before = std::mem::take(&mut self.pending_before);
+        self.rows.push(MatchRow {
+            line: line_number,
+            column,
+            text: trimmed.to_string(),
+            context_before: before,
+            context_after: VecDeque::new(),
+        });
+        self.remaining -= 1;
+        Ok(self.remaining > 0)
+    }
+
+    fn context(
+        &mut self,
+        _searcher: &Searcher,
+        ctx: &SinkContext<'_>,
+    ) -> Result<bool, std::io::Error> {
+        let line = std::str::from_utf8(ctx.bytes()).unwrap_or("");
+        let trimmed = line.trim_end_matches(['\n', '\r']).to_string();
+
+        match ctx.kind() {
+            SinkContextKind::Before => {
+                self.pending_before.push_back(trimmed);
+                while self.pending_before.len() > self.context_before {
+                    self.pending_before.pop_front();
+                }
+            }
+            SinkContextKind::After => {
+                if let Some(last) = self.rows.last_mut() {
+                    last.context_after.push_back(trimmed);
+                }
+            }
+            SinkContextKind::Other => {}
+        }
+        Ok(true)
+    }
+}
+
+fn row_to_value(rwp: RowWithPath) -> VmValue {
+    let RowWithPath { path, row } = rwp;
+    let MatchRow {
+        line,
+        column,
+        text,
+        context_before,
+        context_after,
+    } = row;
+
+    let before: Vec<VmValue> = context_before.into_iter().map(str_value).collect();
+    let after: Vec<VmValue> = context_after.into_iter().map(str_value).collect();
+
+    build_dict([
+        ("path", str_value(path.to_string_lossy())),
+        ("line", VmValue::Int(line as i64)),
+        ("column", VmValue::Int(column as i64)),
+        ("text", str_value(text)),
+        ("context_before", VmValue::List(Rc::new(before))),
+        ("context_after", VmValue::List(Rc::new(after))),
+    ])
+}

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -99,6 +99,9 @@ fn tools_capability_registers_documented_methods() {
     assert_eq!(
         names,
         vec![
+            // Deterministic tools — implementations live in
+            // `crates/harn-hostlib/src/tools/`. Gated by
+            // `hostlib_enable("tools:deterministic")`.
             "hostlib_tools_search",
             "hostlib_tools_read_file",
             "hostlib_tools_write_file",
@@ -106,14 +109,52 @@ fn tools_capability_registers_documented_methods() {
             "hostlib_tools_list_directory",
             "hostlib_tools_get_file_outline",
             "hostlib_tools_git",
+            // Process tools — slated for issue C2; still routed through
+            // `HostlibError::Unimplemented` until then.
             "hostlib_tools_run_command",
             "hostlib_tools_run_test",
             "hostlib_tools_run_build_command",
             "hostlib_tools_inspect_test_results",
             "hostlib_tools_manage_packages",
+            // Per-session opt-in builtin from issue #567.
+            "hostlib_enable",
         ]
     );
-    assert_all_unimplemented(&registry);
+
+    // Process tools must still route through `Unimplemented` — they are
+    // slated for issue C2.
+    let process_methods = [
+        "hostlib_tools_run_command",
+        "hostlib_tools_run_test",
+        "hostlib_tools_run_build_command",
+        "hostlib_tools_inspect_test_results",
+        "hostlib_tools_manage_packages",
+    ];
+    for name in process_methods {
+        let entry = registry.find(name).expect("registered");
+        let err = (entry.handler)(&[]).expect_err("must be unimplemented");
+        assert!(
+            matches!(err, HostlibError::Unimplemented { builtin } if builtin == name),
+            "expected Unimplemented for {name}, got {err:?}"
+        );
+    }
+
+    // Deterministic tools must refuse to run before
+    // `hostlib_enable("tools:deterministic")`. We check one representative
+    // builtin to confirm the gating handler is wired.
+    harn_hostlib::tools::permissions::reset();
+    let search = registry.find("hostlib_tools_search").expect("registered");
+    let err = (search.handler)(&[]).expect_err("disabled by default");
+    match err {
+        HostlibError::Backend { builtin, message } => {
+            assert_eq!(builtin, "hostlib_tools_search");
+            assert!(
+                message.contains("hostlib_enable"),
+                "gating error must point users at hostlib_enable: {message}"
+            );
+        }
+        other => panic!("expected Backend gate error, got {other:?}"),
+    }
 }
 
 #[test]
@@ -125,7 +166,9 @@ fn install_default_wires_every_module_into_a_vm() {
         registry.modules(),
         &["ast", "code_index", "scanner", "fs_watch", "tools"]
     );
-    assert!(registry.builtins().len() >= 24);
+    // Builtin count: 3 ast + 5 code_index + 2 scanner + 2 fs_watch + 12
+    // tools + 1 hostlib_enable = 25.
+    assert!(registry.builtins().len() >= 25);
 }
 
 #[test]

--- a/crates/harn-hostlib/tests/smoke_harn_script.rs
+++ b/crates/harn-hostlib/tests/smoke_harn_script.rs
@@ -170,12 +170,13 @@ fn end_to_end_git_via_harn_script() {
     let dir = TempDir::new().unwrap();
     let repo = dir.path();
     let run_git = |args: &[&str]| {
-        let output = std::process::Command::new("git")
-            .arg("-C")
-            .arg(repo)
-            .args(args)
-            .output()
-            .unwrap();
+        let mut cmd = std::process::Command::new("git");
+        for (key, _) in std::env::vars() {
+            if key.starts_with("GIT_") {
+                cmd.env_remove(&key);
+            }
+        }
+        let output = cmd.arg("-C").arg(repo).args(args).output().unwrap();
         assert!(
             output.status.success(),
             "git {args:?} failed: {}",

--- a/crates/harn-hostlib/tests/smoke_harn_script.rs
+++ b/crates/harn-hostlib/tests/smoke_harn_script.rs
@@ -1,0 +1,223 @@
+//! Smoke test for #567: drive every deterministic tool from a real
+//! `.harn` script through the full lexer + parser + compiler + VM
+//! pipeline.
+//!
+//! The standalone integration tests under `tests/tools_*.rs` exercise
+//! handlers directly. This file proves the contract end-to-end: that a
+//! Harn script can call `hostlib_enable("tools:deterministic")` and then
+//! invoke each of the seven deterministic builtins through the normal
+//! script surface.
+
+use std::fs;
+
+use harn_hostlib::tools::permissions;
+use harn_lexer::Lexer;
+use harn_parser::Parser;
+use harn_vm::{register_vm_stdlib, Compiler, Vm, VmValue};
+use tempfile::TempDir;
+
+fn run_harn(source: &str) -> (VmValue, String) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let mut lexer = Lexer::new(source);
+                let tokens = lexer.tokenize().expect("tokenize");
+                let mut parser = Parser::new(tokens);
+                let program = parser.parse().expect("parse");
+                let chunk = Compiler::new().compile(&program).expect("compile");
+
+                let mut vm = Vm::new();
+                register_vm_stdlib(&mut vm);
+                let _ = harn_hostlib::install_default(&mut vm);
+                let result = vm.execute(&chunk).await.expect("execute");
+                (result, vm.output().to_string())
+            })
+            .await
+    })
+}
+
+#[test]
+fn end_to_end_deterministic_tools_via_harn_script() {
+    permissions::reset();
+
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    fs::write(root.join("readable.txt"), "hello\nworld\n").unwrap();
+    fs::write(root.join("a.rs"), "pub fn main() {}\n").unwrap();
+    fs::write(root.join("b.rs"), "pub fn helper() {}\n").unwrap();
+    let nested = root.join("nested");
+    fs::create_dir(&nested).unwrap();
+    fs::write(nested.join("c.txt"), "another\n").unwrap();
+
+    let root_str = root.to_string_lossy().replace('\\', "/");
+    let new_file = format!("{}/created.txt", root_str);
+
+    // The script:
+    // 1. Enables the deterministic tools surface.
+    // 2. Reads, lists, searches, outlines, writes, and deletes files.
+    // 3. Stores intermediate results in a dict and returns it.
+    let source = format!(
+        r#"
+let _enable = hostlib_enable("tools:deterministic")
+
+let listed = hostlib_tools_list_directory({{ path: "{root}" }})
+let read = hostlib_tools_read_file({{ path: "{root}/readable.txt" }})
+let searched = hostlib_tools_search({{
+    pattern: "fn",
+    path: "{root}",
+    glob: "*.rs",
+    fixed_strings: true
+}})
+let outlined = hostlib_tools_get_file_outline({{ path: "{root}/a.rs" }})
+let wrote = hostlib_tools_write_file({{ path: "{new_path}", content: "ok" }})
+let deleted = hostlib_tools_delete_file({{ path: "{new_path}" }})
+
+return {{
+    enable: _enable,
+    listed_count: len(listed.entries),
+    read_size: read.size,
+    read_content: read.content,
+    matches: len(searched.matches),
+    outline_first: outlined.items[0].name,
+    bytes_written: wrote.bytes_written,
+    removed: deleted.removed,
+}}
+"#,
+        root = root_str,
+        new_path = new_file,
+    );
+
+    let (result, _stdout) = run_harn(&source);
+    let dict = match &result {
+        VmValue::Dict(d) => d,
+        other => panic!("expected dict, got {other:?}"),
+    };
+    let get = |k: &str| dict.get(k).unwrap_or_else(|| panic!("missing {k}"));
+
+    assert!(matches!(get("listed_count"), VmValue::Int(4)));
+    assert!(matches!(get("read_size"), VmValue::Int(12)));
+    assert!(matches!(get("read_content"), VmValue::String(s) if s.as_ref() == "hello\nworld\n"));
+
+    if let VmValue::Int(n) = get("matches") {
+        assert!(*n >= 2, "expected at least 2 fn matches, got {n}");
+    } else {
+        panic!("expected Int matches");
+    }
+
+    assert!(matches!(get("outline_first"), VmValue::String(s) if s.as_ref() == "main"));
+    assert!(matches!(get("bytes_written"), VmValue::Int(2)));
+    assert!(matches!(get("removed"), VmValue::Bool(true)));
+
+    // The new file must be gone now.
+    assert!(!std::path::Path::new(&new_file).exists());
+}
+
+#[test]
+fn end_to_end_gate_blocks_without_enable() {
+    permissions::reset();
+
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_string_lossy().replace('\\', "/");
+
+    // Note: no `hostlib_enable` call. The Harn script must catch the
+    // structured `Thrown` dict and return it.
+    let source = format!(
+        r#"
+try {{
+    return hostlib_tools_list_directory({{ path: "{root}" }})
+}} catch err {{
+    return err
+}}
+"#,
+        root = root,
+    );
+
+    let (result, _) = run_harn(&source);
+    let dict = match &result {
+        VmValue::Dict(d) => d,
+        other => panic!("expected gate error dict, got {other:?}"),
+    };
+    let kind = dict.get("kind").expect("kind present");
+    let message = dict.get("message").expect("message present");
+    assert!(matches!(kind, VmValue::String(s) if s.as_ref() == "backend_error"));
+    if let VmValue::String(msg) = message {
+        assert!(
+            msg.contains("hostlib_enable"),
+            "gate error must mention hostlib_enable, got `{msg}`"
+        );
+    } else {
+        panic!("expected message string");
+    }
+}
+
+#[test]
+fn end_to_end_git_via_harn_script() {
+    if std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping: git not installed");
+        return;
+    }
+    permissions::reset();
+
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path();
+    let run_git = |args: &[&str]| {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    run_git(&["init", "-q", "-b", "main"]);
+    run_git(&["config", "user.email", "tester@example.com"]);
+    run_git(&["config", "user.name", "Tester"]);
+    run_git(&["config", "commit.gpgsign", "false"]);
+    fs::write(repo.join("hello.txt"), "hi\n").unwrap();
+    run_git(&["add", "hello.txt"]);
+    run_git(&["commit", "-q", "-m", "first"]);
+
+    let repo_str = repo.to_string_lossy().replace('\\', "/");
+
+    let source = format!(
+        r#"
+let _ = hostlib_enable("tools:deterministic")
+let log = hostlib_tools_git({{ operation: "log", repo: "{repo}" }})
+let branch = hostlib_tools_git({{ operation: "current_branch", repo: "{repo}" }})
+return {{
+    log_count: len(log.data),
+    log_subject: log.data[0].subject,
+    branch: branch.data,
+}}
+"#,
+        repo = repo_str,
+    );
+
+    let (result, _) = run_harn(&source);
+    let dict = match &result {
+        VmValue::Dict(d) => d,
+        other => panic!("expected dict, got {other:?}"),
+    };
+    assert!(matches!(dict.get("log_count").unwrap(), VmValue::Int(1)));
+    assert!(matches!(
+        dict.get("log_subject").unwrap(),
+        VmValue::String(s) if s.as_ref() == "first"
+    ));
+    assert!(matches!(
+        dict.get("branch").unwrap(),
+        VmValue::String(s) if s.as_ref() == "main"
+    ));
+}

--- a/crates/harn-hostlib/tests/tools_file_io.rs
+++ b/crates/harn-hostlib/tests/tools_file_io.rs
@@ -1,0 +1,303 @@
+//! Integration tests for `hostlib_tools_{read_file,write_file,delete_file,list_directory}`.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::rc::Rc;
+
+use harn_hostlib::tools::permissions;
+use harn_hostlib::{tools::ToolsCapability, BuiltinRegistry, HostlibCapability, HostlibError};
+use harn_vm::VmValue;
+use tempfile::TempDir;
+
+fn registry() -> BuiltinRegistry {
+    permissions::reset();
+    permissions::enable_for_test();
+    let mut registry = BuiltinRegistry::new();
+    ToolsCapability.register_builtins(&mut registry);
+    registry
+}
+
+fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in entries {
+        map.insert(k.to_string(), v.clone());
+    }
+    vec![VmValue::Dict(Rc::new(map))]
+}
+
+fn vm_string(s: &str) -> VmValue {
+    VmValue::String(Rc::from(s))
+}
+
+fn dict_get<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {
+    match value {
+        VmValue::Dict(d) => d.get(key).expect("key present"),
+        other => panic!("not a dict: {other:?}"),
+    }
+}
+
+fn path_str(p: &Path) -> String {
+    p.to_string_lossy().into_owned()
+}
+
+#[test]
+fn read_file_returns_utf8_payload_with_size() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("hello.txt");
+    fs::write(&file, "hello world").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_read_file").unwrap();
+    let result = (entry.handler)(&dict_arg(&[("path", vm_string(&path_str(&file)))])).unwrap();
+
+    assert!(matches!(dict_get(&result, "encoding"), VmValue::String(s) if s.as_ref() == "utf-8"));
+    assert!(
+        matches!(dict_get(&result, "content"), VmValue::String(s) if s.as_ref() == "hello world")
+    );
+    assert!(matches!(dict_get(&result, "size"), VmValue::Int(11)));
+    assert!(matches!(
+        dict_get(&result, "truncated"),
+        VmValue::Bool(false)
+    ));
+}
+
+#[test]
+fn read_file_offset_and_limit_apply() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("payload.txt");
+    fs::write(&file, "0123456789").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_read_file").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("path", vm_string(&path_str(&file))),
+        ("offset", VmValue::Int(2)),
+        ("limit_bytes", VmValue::Int(4)),
+    ]))
+    .unwrap();
+
+    assert!(matches!(dict_get(&result, "content"), VmValue::String(s) if s.as_ref() == "2345"));
+    assert!(matches!(
+        dict_get(&result, "truncated"),
+        VmValue::Bool(true)
+    ));
+}
+
+#[test]
+fn read_file_binary_returns_base64() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("bin.dat");
+    fs::write(&file, [0u8, 1, 2, 3, 0xff]).unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_read_file").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("path", vm_string(&path_str(&file))),
+        ("encoding", vm_string("binary")),
+    ]))
+    .unwrap();
+    assert!(matches!(dict_get(&result, "encoding"), VmValue::String(s) if s.as_ref() == "base64"));
+}
+
+#[test]
+fn read_file_invalid_utf8_falls_back_to_base64() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("notutf8.bin");
+    fs::write(&file, [0xff, 0xfe, 0xfd]).unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_read_file").unwrap();
+    let result = (entry.handler)(&dict_arg(&[("path", vm_string(&path_str(&file)))])).unwrap();
+    assert!(matches!(dict_get(&result, "encoding"), VmValue::String(s) if s.as_ref() == "base64"));
+}
+
+#[test]
+fn read_file_errors_when_missing() {
+    let dir = TempDir::new().unwrap();
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_read_file").unwrap();
+    let err = (entry.handler)(&dict_arg(&[(
+        "path",
+        vm_string(&path_str(&dir.path().join("nope"))),
+    )]))
+    .unwrap_err();
+    assert!(matches!(err, HostlibError::Backend { .. }));
+}
+
+#[test]
+fn write_file_creates_file_and_parent_directories() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("nested/deep/note.txt");
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_write_file").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("path", vm_string(&path_str(&nested))),
+        ("content", vm_string("welcome")),
+    ]))
+    .unwrap();
+
+    assert!(matches!(dict_get(&result, "created"), VmValue::Bool(true)));
+    assert!(matches!(
+        dict_get(&result, "bytes_written"),
+        VmValue::Int(7)
+    ));
+    assert_eq!(fs::read_to_string(&nested).unwrap(), "welcome");
+}
+
+#[test]
+fn write_file_respects_overwrite_false() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("locked.txt");
+    fs::write(&file, "existing").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_write_file").unwrap();
+    let err = (entry.handler)(&dict_arg(&[
+        ("path", vm_string(&path_str(&file))),
+        ("content", vm_string("new")),
+        ("overwrite", VmValue::Bool(false)),
+    ]))
+    .unwrap_err();
+    assert!(matches!(err, HostlibError::Backend { .. }));
+    assert_eq!(fs::read_to_string(&file).unwrap(), "existing");
+}
+
+#[test]
+fn write_file_base64_decodes_payload() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("binary.bin");
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_write_file").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("path", vm_string(&path_str(&file))),
+        ("content", vm_string("aGVsbG8=")), // "hello"
+        ("encoding", vm_string("base64")),
+    ]))
+    .unwrap();
+    assert!(matches!(
+        dict_get(&result, "bytes_written"),
+        VmValue::Int(5)
+    ));
+    assert_eq!(fs::read(&file).unwrap(), b"hello");
+}
+
+#[test]
+fn delete_file_removes_existing_file() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("doomed.txt");
+    fs::write(&file, "x").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_delete_file").unwrap();
+    let result = (entry.handler)(&dict_arg(&[("path", vm_string(&path_str(&file)))])).unwrap();
+    assert!(matches!(dict_get(&result, "removed"), VmValue::Bool(true)));
+    assert!(!file.exists());
+}
+
+#[test]
+fn delete_file_missing_returns_removed_false() {
+    let dir = TempDir::new().unwrap();
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_delete_file").unwrap();
+    let result = (entry.handler)(&dict_arg(&[(
+        "path",
+        vm_string(&path_str(&dir.path().join("absent"))),
+    )]))
+    .unwrap();
+    assert!(matches!(dict_get(&result, "removed"), VmValue::Bool(false)));
+}
+
+#[test]
+fn delete_file_directory_requires_recursive() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("a/b");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("inner.txt"), "x").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_delete_file").unwrap();
+    let err = (entry.handler)(&dict_arg(&[(
+        "path",
+        vm_string(&path_str(&dir.path().join("a"))),
+    )]))
+    .unwrap_err();
+    assert!(matches!(err, HostlibError::Backend { .. }));
+
+    let result = (entry.handler)(&dict_arg(&[
+        ("path", vm_string(&path_str(&dir.path().join("a")))),
+        ("recursive", VmValue::Bool(true)),
+    ]))
+    .unwrap();
+    assert!(matches!(dict_get(&result, "removed"), VmValue::Bool(true)));
+}
+
+#[test]
+fn list_directory_returns_entries_sorted() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "a").unwrap();
+    fs::write(dir.path().join("b.txt"), "b").unwrap();
+    fs::create_dir(dir.path().join("c_dir")).unwrap();
+    fs::write(dir.path().join(".hidden"), "h").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_list_directory").unwrap();
+    let result = (entry.handler)(&dict_arg(&[("path", vm_string(&path_str(dir.path())))])).unwrap();
+    let entries = match dict_get(&result, "entries") {
+        VmValue::List(l) => l.clone(),
+        other => panic!("expected list, got {other:?}"),
+    };
+    let names: Vec<String> = entries
+        .iter()
+        .map(|v| match dict_get(v, "name") {
+            VmValue::String(s) => s.to_string(),
+            _ => String::new(),
+        })
+        .collect();
+    assert_eq!(names, vec!["a.txt", "b.txt", "c_dir"]);
+}
+
+#[test]
+fn list_directory_include_hidden_works() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("visible"), "v").unwrap();
+    fs::write(dir.path().join(".hidden"), "h").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_list_directory").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("path", vm_string(&path_str(dir.path()))),
+        ("include_hidden", VmValue::Bool(true)),
+    ]))
+    .unwrap();
+    if let VmValue::List(rows) = dict_get(&result, "entries") {
+        assert_eq!(rows.len(), 2);
+    } else {
+        panic!("expected entries list");
+    }
+}
+
+#[test]
+fn list_directory_respects_max_entries_and_marks_truncated() {
+    let dir = TempDir::new().unwrap();
+    for i in 0..5 {
+        fs::write(dir.path().join(format!("f{i}.txt")), "x").unwrap();
+    }
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_list_directory").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("path", vm_string(&path_str(dir.path()))),
+        ("max_entries", VmValue::Int(2)),
+    ]))
+    .unwrap();
+    if let VmValue::List(rows) = dict_get(&result, "entries") {
+        assert_eq!(rows.len(), 2);
+    }
+    assert!(matches!(
+        dict_get(&result, "truncated"),
+        VmValue::Bool(true)
+    ));
+}

--- a/crates/harn-hostlib/tests/tools_git.rs
+++ b/crates/harn-hostlib/tests/tools_git.rs
@@ -1,0 +1,393 @@
+//! Integration tests for `hostlib_tools_git` against a real fixture repo.
+//!
+//! These tests require `git` on `$PATH`. CI installs it; local dev usually
+//! has it. If it's missing the tests are skipped via [`ensure_git`].
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Command;
+use std::rc::Rc;
+
+use harn_hostlib::tools::permissions;
+use harn_hostlib::{tools::ToolsCapability, BuiltinRegistry, HostlibCapability, HostlibError};
+use harn_vm::VmValue;
+use tempfile::TempDir;
+
+fn registry() -> BuiltinRegistry {
+    permissions::reset();
+    permissions::enable_for_test();
+    let mut registry = BuiltinRegistry::new();
+    ToolsCapability.register_builtins(&mut registry);
+    registry
+}
+
+fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in entries {
+        map.insert(k.to_string(), v.clone());
+    }
+    vec![VmValue::Dict(Rc::new(map))]
+}
+
+fn vm_string(s: &str) -> VmValue {
+    VmValue::String(Rc::from(s))
+}
+
+fn ensure_git() -> bool {
+    Command::new("git").arg("--version").output().is_ok()
+}
+
+/// Initialize a tiny git repo with two commits, configured locally so the
+/// test never reads global git config.
+fn fixture_repo() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    run_git(dir.path(), &["init", "-q", "-b", "main"]);
+    run_git(dir.path(), &["config", "user.email", "tester@example.com"]);
+    run_git(dir.path(), &["config", "user.name", "Tester"]);
+    run_git(dir.path(), &["config", "commit.gpgsign", "false"]);
+
+    std::fs::write(dir.path().join("a.txt"), "first\n").unwrap();
+    run_git(dir.path(), &["add", "a.txt"]);
+    run_git(dir.path(), &["commit", "-q", "-m", "first commit"]);
+
+    std::fs::write(dir.path().join("a.txt"), "first\nsecond\n").unwrap();
+    std::fs::write(dir.path().join("b.txt"), "new file\n").unwrap();
+    run_git(dir.path(), &["add", "a.txt", "b.txt"]);
+    run_git(dir.path(), &["commit", "-q", "-m", "second commit"]);
+
+    run_git(
+        dir.path(),
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://example.invalid/repo.git",
+        ],
+    );
+
+    dir
+}
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .unwrap_or_else(|err| {
+            panic!(
+                "git {} {} failed: {err}",
+                args.first().unwrap_or(&""),
+                repo.display()
+            )
+        });
+    assert!(
+        output.status.success(),
+        "git {} stderr: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn dict_get<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {
+    match value {
+        VmValue::Dict(d) => d.get(key).expect("key present"),
+        other => panic!("not a dict: {other:?}"),
+    }
+}
+
+fn list_of(value: &VmValue) -> &Rc<Vec<VmValue>> {
+    match value {
+        VmValue::List(l) => l,
+        other => panic!("expected list, got {other:?}"),
+    }
+}
+
+#[test]
+fn git_log_returns_structured_entries() {
+    if !ensure_git() {
+        eprintln!("skipping: git not installed");
+        return;
+    }
+    let repo = fixture_repo();
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_git").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("operation", vm_string("log")),
+        ("repo", vm_string(&repo.path().to_string_lossy())),
+    ]))
+    .unwrap();
+    let data = dict_get(&result, "data");
+    let commits = list_of(data);
+    assert_eq!(commits.len(), 2);
+    if let VmValue::Dict(latest) = &commits[0] {
+        if let Some(VmValue::String(s)) = latest.get("subject") {
+            assert_eq!(s.as_ref(), "second commit");
+        }
+        if let Some(VmValue::String(sha)) = latest.get("sha") {
+            assert_eq!(sha.len(), 40);
+        }
+    }
+}
+
+#[test]
+fn git_log_max_count_limits_results() {
+    if !ensure_git() {
+        return;
+    }
+    let repo = fixture_repo();
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_git").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("operation", vm_string("log")),
+        ("repo", vm_string(&repo.path().to_string_lossy())),
+        ("max_count", VmValue::Int(1)),
+    ]))
+    .unwrap();
+    let data = dict_get(&result, "data");
+    assert_eq!(list_of(data).len(), 1);
+}
+
+#[test]
+fn git_status_reports_dirty_paths() {
+    if !ensure_git() {
+        return;
+    }
+    let repo = fixture_repo();
+    std::fs::write(repo.path().join("c.txt"), "untracked\n").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_git").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("operation", vm_string("status")),
+        ("repo", vm_string(&repo.path().to_string_lossy())),
+    ]))
+    .unwrap();
+    let data = dict_get(&result, "data");
+    let entries = list_of(data);
+    assert!(entries.iter().any(|e| match dict_get(e, "path") {
+        VmValue::String(s) => s.as_ref() == "c.txt",
+        _ => false,
+    }));
+}
+
+#[test]
+fn git_current_branch_returns_main() {
+    if !ensure_git() {
+        return;
+    }
+    let repo = fixture_repo();
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_git").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("operation", vm_string("current_branch")),
+        ("repo", vm_string(&repo.path().to_string_lossy())),
+    ]))
+    .unwrap();
+    let data = dict_get(&result, "data");
+    if let VmValue::String(s) = data {
+        assert_eq!(s.as_ref(), "main");
+    } else {
+        panic!("expected string branch name, got {data:?}");
+    }
+}
+
+#[test]
+fn git_remote_list_returns_origin() {
+    if !ensure_git() {
+        return;
+    }
+    let repo = fixture_repo();
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_git").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("operation", vm_string("remote_list")),
+        ("repo", vm_string(&repo.path().to_string_lossy())),
+    ]))
+    .unwrap();
+    let data = dict_get(&result, "data");
+    let remotes = list_of(data);
+    assert_eq!(remotes.len(), 1);
+    if let VmValue::Dict(d) = &remotes[0] {
+        assert!(matches!(d.get("name"), Some(VmValue::String(s)) if s.as_ref() == "origin"));
+        assert!(matches!(
+            d.get("url"),
+            Some(VmValue::String(s)) if s.as_ref() == "https://example.invalid/repo.git"
+        ));
+    }
+}
+
+#[test]
+fn git_blame_returns_authors_per_line() {
+    if !ensure_git() {
+        return;
+    }
+    let repo = fixture_repo();
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_git").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("operation", vm_string("blame")),
+        ("repo", vm_string(&repo.path().to_string_lossy())),
+        ("path", vm_string("a.txt")),
+    ]))
+    .unwrap();
+    let data = dict_get(&result, "data");
+    let lines = list_of(data);
+    assert_eq!(lines.len(), 2);
+    if let VmValue::Dict(first) = &lines[0] {
+        assert!(matches!(
+            first.get("author"),
+            Some(VmValue::String(s)) if s.as_ref() == "Tester"
+        ));
+        assert!(matches!(first.get("line"), Some(VmValue::Int(1))));
+    }
+}
+
+#[test]
+fn git_show_emits_patch_text() {
+    if !ensure_git() {
+        return;
+    }
+    let repo = fixture_repo();
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_git").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("operation", vm_string("show")),
+        ("repo", vm_string(&repo.path().to_string_lossy())),
+        ("rev", vm_string("HEAD")),
+    ]))
+    .unwrap();
+    let data = dict_get(&result, "data");
+    if let VmValue::String(s) = data {
+        assert!(s.contains("second commit"));
+        assert!(s.contains("b.txt"));
+    } else {
+        panic!("expected string");
+    }
+}
+
+#[test]
+fn git_diff_handles_clean_repo() {
+    if !ensure_git() {
+        return;
+    }
+    let repo = fixture_repo();
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_git").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("operation", vm_string("diff")),
+        ("repo", vm_string(&repo.path().to_string_lossy())),
+    ]))
+    .unwrap();
+    let data = dict_get(&result, "data");
+    if let VmValue::String(s) = data {
+        assert!(s.is_empty(), "expected empty diff, got `{s}`");
+    }
+}
+
+#[test]
+fn git_branch_list_returns_main() {
+    if !ensure_git() {
+        return;
+    }
+    let repo = fixture_repo();
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_git").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("operation", vm_string("branch_list")),
+        ("repo", vm_string(&repo.path().to_string_lossy())),
+    ]))
+    .unwrap();
+    let data = dict_get(&result, "data");
+    let branches = list_of(data);
+    assert_eq!(branches.len(), 1);
+    if let VmValue::Dict(d) = &branches[0] {
+        assert!(matches!(d.get("name"), Some(VmValue::String(s)) if s.as_ref() == "main"));
+    }
+}
+
+#[test]
+fn git_rejects_flag_lookalike_revs() {
+    if !ensure_git() {
+        return;
+    }
+    let repo = fixture_repo();
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_git").unwrap();
+    let err = (entry.handler)(&dict_arg(&[
+        ("operation", vm_string("show")),
+        ("repo", vm_string(&repo.path().to_string_lossy())),
+        ("rev", vm_string("--exec=rm")),
+    ]))
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        HostlibError::InvalidParameter { param: "rev", .. }
+    ));
+}
+
+#[test]
+fn git_rejects_unknown_operation() {
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_git").unwrap();
+    let err = (entry.handler)(&dict_arg(&[("operation", vm_string("rm-rf"))])).unwrap_err();
+    assert!(matches!(
+        err,
+        HostlibError::InvalidParameter {
+            param: "operation",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn enable_builtin_flips_the_gate() {
+    permissions::reset();
+    let mut reg = BuiltinRegistry::new();
+    ToolsCapability.register_builtins(&mut reg);
+
+    // Pre-enable: search must refuse.
+    let search = reg.find("hostlib_tools_search").unwrap();
+    let err = (search.handler)(&dict_arg(&[("pattern", vm_string("foo"))])).unwrap_err();
+    assert!(matches!(err, HostlibError::Backend { .. }));
+
+    // hostlib_enable can be called with either a bare string or a dict.
+    let enable = reg.find("hostlib_enable").unwrap();
+    let result = (enable.handler)(&[vm_string("tools:deterministic")]).unwrap();
+    if let VmValue::Dict(d) = &result {
+        assert!(matches!(d.get("enabled"), Some(VmValue::Bool(true))));
+        assert!(matches!(d.get("newly_enabled"), Some(VmValue::Bool(true))));
+    } else {
+        panic!("expected dict");
+    }
+
+    // After enable: search returns Ok (with no matches in a tmpdir).
+    let dir = tempfile::TempDir::new().unwrap();
+    let result = (search.handler)(&dict_arg(&[
+        ("pattern", vm_string("foo")),
+        ("path", vm_string(&dir.path().to_string_lossy())),
+    ]))
+    .unwrap();
+    assert!(matches!(&result, VmValue::Dict(_)));
+
+    // Calling enable a second time reports the feature as already on.
+    let again = (enable.handler)(&[vm_string("tools:deterministic")]).unwrap();
+    if let VmValue::Dict(d) = &again {
+        assert!(matches!(d.get("newly_enabled"), Some(VmValue::Bool(false))));
+    }
+}
+
+#[test]
+fn enable_builtin_rejects_unknown_features() {
+    let mut reg = BuiltinRegistry::new();
+    ToolsCapability.register_builtins(&mut reg);
+    let enable = reg.find("hostlib_enable").unwrap();
+    let err = (enable.handler)(&[vm_string("tools:exec")]).unwrap_err();
+    assert!(matches!(
+        err,
+        HostlibError::InvalidParameter {
+            param: "feature",
+            ..
+        }
+    ));
+}

--- a/crates/harn-hostlib/tests/tools_git.rs
+++ b/crates/harn-hostlib/tests/tools_git.rs
@@ -69,7 +69,16 @@ fn fixture_repo() -> TempDir {
 }
 
 fn run_git(repo: &Path, args: &[&str]) {
-    let output = Command::new("git")
+    let mut cmd = Command::new("git");
+    // Drop ambient GIT_* env vars so the test isn't perturbed by an
+    // outer `git push` hook (which would otherwise leak GIT_DIR etc.
+    // into the subprocess and silently break our tempdir isolation).
+    for (key, _) in std::env::vars() {
+        if key.starts_with("GIT_") {
+            cmd.env_remove(&key);
+        }
+    }
+    let output = cmd
         .arg("-C")
         .arg(repo)
         .args(args)
@@ -83,8 +92,10 @@ fn run_git(repo: &Path, args: &[&str]) {
         });
     assert!(
         output.status.success(),
-        "git {} stderr: {}",
+        "git {} (cwd={}) status={:?} stderr={}",
         args.join(" "),
+        repo.display(),
+        output.status,
         String::from_utf8_lossy(&output.stderr)
     );
 }

--- a/crates/harn-hostlib/tests/tools_outline.rs
+++ b/crates/harn-hostlib/tests/tools_outline.rs
@@ -1,0 +1,126 @@
+//! Integration tests for `hostlib_tools_get_file_outline`.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::rc::Rc;
+
+use harn_hostlib::tools::permissions;
+use harn_hostlib::{tools::ToolsCapability, BuiltinRegistry, HostlibCapability};
+use harn_vm::VmValue;
+use tempfile::TempDir;
+
+fn registry() -> BuiltinRegistry {
+    permissions::reset();
+    permissions::enable_for_test();
+    let mut registry = BuiltinRegistry::new();
+    ToolsCapability.register_builtins(&mut registry);
+    registry
+}
+
+fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in entries {
+        map.insert(k.to_string(), v.clone());
+    }
+    vec![VmValue::Dict(Rc::new(map))]
+}
+
+fn vm_string(s: &str) -> VmValue {
+    VmValue::String(Rc::from(s))
+}
+
+fn outline_items(value: &VmValue) -> Vec<(String, String)> {
+    match value {
+        VmValue::Dict(d) => match d.get("items") {
+            Some(VmValue::List(items)) => items
+                .iter()
+                .filter_map(|item| {
+                    let dict = match item {
+                        VmValue::Dict(d) => d,
+                        _ => return None,
+                    };
+                    let name = match dict.get("name") {
+                        Some(VmValue::String(s)) => s.to_string(),
+                        _ => return None,
+                    };
+                    let kind = match dict.get("kind") {
+                        Some(VmValue::String(s)) => s.to_string(),
+                        _ => return None,
+                    };
+                    Some((kind, name))
+                })
+                .collect(),
+            _ => panic!("missing items"),
+        },
+        _ => panic!("expected dict"),
+    }
+}
+
+fn language(value: &VmValue) -> String {
+    match value {
+        VmValue::Dict(d) => match d.get("language") {
+            Some(VmValue::String(s)) => s.to_string(),
+            _ => panic!("missing language"),
+        },
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn outline_picks_up_rust_items() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("sample.rs");
+    fs::write(
+        &file,
+        "pub struct Foo;\nfn bar() {}\nimpl Foo { pub fn baz(&self) {} }\nenum E { A, B }\n",
+    )
+    .unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_get_file_outline").unwrap();
+    let result =
+        (entry.handler)(&dict_arg(&[("path", vm_string(&file.to_string_lossy()))])).unwrap();
+
+    assert_eq!(language(&result), "rust");
+    let items = outline_items(&result);
+    let names: Vec<&str> = items.iter().map(|(_, n)| n.as_str()).collect();
+    assert!(names.contains(&"Foo"));
+    assert!(names.contains(&"bar"));
+    assert!(names.contains(&"E"));
+}
+
+#[test]
+fn outline_supports_python() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("sample.py");
+    fs::write(
+        &file,
+        "def hello():\n    pass\n\nclass Greeter:\n    def greet(self):\n        pass\n",
+    )
+    .unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_get_file_outline").unwrap();
+    let result =
+        (entry.handler)(&dict_arg(&[("path", vm_string(&file.to_string_lossy()))])).unwrap();
+
+    assert_eq!(language(&result), "python");
+    let items = outline_items(&result);
+    let names: Vec<&str> = items.iter().map(|(_, n)| n.as_str()).collect();
+    assert!(names.contains(&"hello"));
+    assert!(names.contains(&"Greeter"));
+}
+
+#[test]
+fn outline_empty_for_unknown_extension() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("notes.weirdtext");
+    fs::write(&file, "this is just prose, no structure").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_get_file_outline").unwrap();
+    let result =
+        (entry.handler)(&dict_arg(&[("path", vm_string(&file.to_string_lossy()))])).unwrap();
+    let items = outline_items(&result);
+    assert!(items.is_empty(), "got: {items:?}");
+}

--- a/crates/harn-hostlib/tests/tools_search.rs
+++ b/crates/harn-hostlib/tests/tools_search.rs
@@ -1,0 +1,245 @@
+//! Integration tests for `hostlib_tools_search`.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::rc::Rc;
+
+use harn_hostlib::tools::permissions;
+use harn_hostlib::{tools::ToolsCapability, BuiltinRegistry, HostlibCapability};
+use harn_vm::VmValue;
+use tempfile::TempDir;
+
+fn registry() -> BuiltinRegistry {
+    permissions::reset();
+    permissions::enable_for_test();
+    let mut registry = BuiltinRegistry::new();
+    ToolsCapability.register_builtins(&mut registry);
+    registry
+}
+
+fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in entries {
+        map.insert(k.to_string(), v.clone());
+    }
+    vec![VmValue::Dict(Rc::new(map))]
+}
+
+fn vm_string(s: &str) -> VmValue {
+    VmValue::String(Rc::from(s))
+}
+
+fn matches_in(result: &VmValue) -> &Rc<Vec<VmValue>> {
+    match result {
+        VmValue::Dict(d) => match d.get("matches") {
+            Some(VmValue::List(rows)) => rows,
+            other => panic!("expected `matches` list, got {other:?}"),
+        },
+        other => panic!("expected dict result, got {other:?}"),
+    }
+}
+
+#[test]
+fn search_finds_literal_pattern() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "alpha\nbeta\ngamma\n").unwrap();
+    fs::write(dir.path().join("b.txt"), "alphabet\n").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_search").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("pattern", vm_string("alpha")),
+        ("path", vm_string(&dir.path().to_string_lossy())),
+        ("fixed_strings", VmValue::Bool(true)),
+    ]))
+    .expect("search ok");
+    let rows = matches_in(&result);
+    assert_eq!(rows.len(), 2);
+    let texts: Vec<String> = rows
+        .iter()
+        .map(|row| match row {
+            VmValue::Dict(d) => match d.get("text") {
+                Some(VmValue::String(s)) => s.to_string(),
+                _ => String::new(),
+            },
+            _ => String::new(),
+        })
+        .collect();
+    assert!(texts.iter().any(|t| t == "alpha"));
+    assert!(texts.iter().any(|t| t == "alphabet"));
+}
+
+#[test]
+fn search_respects_glob_filter() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("hit.rs"), "fn target() {}\n").unwrap();
+    fs::write(dir.path().join("ignored.txt"), "fn target() {}\n").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_search").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("pattern", vm_string("target")),
+        ("path", vm_string(&dir.path().to_string_lossy())),
+        ("glob", vm_string("*.rs")),
+        ("fixed_strings", VmValue::Bool(true)),
+    ]))
+    .unwrap();
+    let rows = matches_in(&result);
+    assert_eq!(rows.len(), 1);
+    if let VmValue::Dict(d) = &rows[0] {
+        if let Some(VmValue::String(s)) = d.get("path") {
+            assert!(s.ends_with("hit.rs"), "got {s}");
+        }
+    }
+}
+
+#[test]
+fn search_respects_max_matches_and_marks_truncated() {
+    let dir = TempDir::new().unwrap();
+    let mut buf = String::new();
+    for i in 0..10 {
+        buf.push_str(&format!("line{i} target\n"));
+    }
+    fs::write(dir.path().join("many.txt"), buf).unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_search").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("pattern", vm_string("target")),
+        ("path", vm_string(&dir.path().to_string_lossy())),
+        ("max_matches", VmValue::Int(3)),
+    ]))
+    .unwrap();
+    if let VmValue::Dict(d) = &result {
+        let truncated = matches!(d.get("truncated"), Some(VmValue::Bool(true)));
+        assert!(truncated, "expected truncated flag set");
+    }
+    let rows = matches_in(&result);
+    assert_eq!(rows.len(), 3);
+}
+
+#[test]
+fn search_returns_context_lines_when_requested() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("ctx.txt"),
+        "line1\nline2\nMATCH\nline4\nline5\n",
+    )
+    .unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_search").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("pattern", vm_string("MATCH")),
+        ("path", vm_string(&dir.path().to_string_lossy())),
+        ("context_before", VmValue::Int(1)),
+        ("context_after", VmValue::Int(1)),
+    ]))
+    .unwrap();
+    let rows = matches_in(&result);
+    assert_eq!(rows.len(), 1);
+    if let VmValue::Dict(d) = &rows[0] {
+        if let Some(VmValue::List(before)) = d.get("context_before") {
+            assert_eq!(before.len(), 1);
+        } else {
+            panic!("missing context_before");
+        }
+        if let Some(VmValue::List(after)) = d.get("context_after") {
+            assert_eq!(after.len(), 1);
+        } else {
+            panic!("missing context_after");
+        }
+    }
+}
+
+#[test]
+fn search_case_insensitive_flag_works() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("file.txt"), "HELLO world\nhello world\n").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_search").unwrap();
+
+    let exact = (entry.handler)(&dict_arg(&[
+        ("pattern", vm_string("hello")),
+        ("path", vm_string(&dir.path().to_string_lossy())),
+        ("fixed_strings", VmValue::Bool(true)),
+    ]))
+    .unwrap();
+    assert_eq!(matches_in(&exact).len(), 1);
+
+    let insensitive = (entry.handler)(&dict_arg(&[
+        ("pattern", vm_string("hello")),
+        ("path", vm_string(&dir.path().to_string_lossy())),
+        ("fixed_strings", VmValue::Bool(true)),
+        ("case_insensitive", VmValue::Bool(true)),
+    ]))
+    .unwrap();
+    assert_eq!(matches_in(&insensitive).len(), 2);
+}
+
+#[test]
+fn search_rejects_invalid_regex() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("file.txt"), "hello\n").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_search").unwrap();
+    let err = (entry.handler)(&dict_arg(&[
+        ("pattern", vm_string("(unclosed")),
+        ("path", vm_string(&dir.path().to_string_lossy())),
+    ]))
+    .expect_err("invalid regex must error");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("invalid regex") || msg.contains("invalid parameter"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn search_respects_gitignore_unless_overridden() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join(".gitignore"), "ignored.txt\n").unwrap();
+    fs::write(dir.path().join("ignored.txt"), "needle\n").unwrap();
+    fs::write(dir.path().join("included.txt"), "needle\n").unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_search").unwrap();
+    let result = (entry.handler)(&dict_arg(&[
+        ("pattern", vm_string("needle")),
+        ("path", vm_string(&dir.path().to_string_lossy())),
+        ("fixed_strings", VmValue::Bool(true)),
+    ]))
+    .unwrap();
+    let rows = matches_in(&result);
+    let paths: Vec<String> = rows
+        .iter()
+        .map(|row| match row {
+            VmValue::Dict(d) => match d.get("path") {
+                Some(VmValue::String(s)) => s.to_string(),
+                _ => String::new(),
+            },
+            _ => String::new(),
+        })
+        .collect();
+    assert!(paths.iter().any(|p| p.ends_with("included.txt")));
+    assert!(
+        !paths.iter().any(|p| p.ends_with("ignored.txt")),
+        "gitignored file should be skipped, got {paths:?}"
+    );
+}
+
+#[test]
+fn search_gate_blocks_when_feature_disabled() {
+    permissions::reset();
+    let mut reg = BuiltinRegistry::new();
+    ToolsCapability.register_builtins(&mut reg);
+    let entry = reg.find("hostlib_tools_search").unwrap();
+    let err = (entry.handler)(&dict_arg(&[("pattern", vm_string("x"))])).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("hostlib_enable"),
+        "expected gate message pointing at hostlib_enable, got `{msg}`"
+    );
+}


### PR DESCRIPTION
## Summary

Lights up `harn-hostlib`'s `tools/` surface with live implementations for the seven deterministic tools called out in [#567](https://github.com/burin-labs/harn/issues/567): `search`, `read_file`, `write_file`, `delete_file`, `list_directory`, `get_file_outline`, and `git`. All of them are gated by a per-session `hostlib_enable("tools:deterministic")` opt-in.

Stacks on top of [#600](https://github.com/burin-labs/harn/pull/600) (the B1 scaffold for [#563](https://github.com/burin-labs/harn/issues/563)). Diff against `main` includes the scaffold changes; merging order should be #600 → this PR.

Closes [#567](https://github.com/burin-labs/harn/issues/567).

## What's inside

### `tools/search`
- ripgrep semantics via `grep-searcher` + `ignore`
- structured matches: path / line / column / text / context_before / context_after
- flags: `case_insensitive`, `fixed_strings`, `include_hidden`, `glob` (with `**/<glob>` normalization matching the Swift surface), `max_matches`, `context_before`, `context_after`
- gitignore-aware via `require_git(false)` so `.gitignore` is honored even outside a real git repo
- `truncated` flag when `max_matches` caps results

### `tools/read_file`
- utf-8 reads with `offset` + `limit_bytes`
- automatic base64 fallback when bytes aren't valid utf-8 or `encoding: "binary"` is requested
- `truncated` flag

### `tools/write_file`
- atomic `fs::write` with parent-directory auto-creation
- `overwrite` guard
- base64-decoded payloads when `encoding: "base64"`

### `tools/delete_file`
- file or directory removal (recursive opt-in)
- missing path → `removed: false` instead of erroring

### `tools/list_directory`
- sorted entries, hidden filter, `max_entries` pagination
- `truncated` flag when capped

### `tools/get_file_outline`
- regex-backed extractor matching `ast.outline`'s response shape (Rust, Swift, Go, Python, JS/TS, Ruby, Java/Kotlin, C/C++, shell)
- body swaps to `ast.outline` once B2 lands; the contract surface is stable

### `tools/git`
- read-only inspection: `status`, `diff`, `log`, `blame`, `show`, `branch_list`, `current_branch`, `remote_list`
- shells out to system `git` with arg-list invocations only — never `sh -c`, never string concatenation
- rev-string validator rejects flag lookalikes (`--exec=`, `-x`) and control bytes (NUL, newline)
- strips ambient `GIT_*` env vars on the subprocess so being invoked from inside a parent `git` process (e.g. a pre-push hook) doesn't leak `GIT_DIR`/`GIT_INDEX_FILE` into the isolated repo path
- `gix` deferred until C2's toolchain bump per the scaffold's note

### Per-session opt-in (`hostlib_enable`)
- New `hostlib_enable` builtin (registered with module=`tools`, method=`enable`) flips a per-thread `BTreeSet<String>` of enabled features
- Gated handlers refuse to run before the feature is enabled and return a structured `Backend` error pointing callers at `hostlib_enable`
- JSON Schemas for `tools/enable.{request,response}` ship alongside the existing schema catalog

### Out of scope (still `Unimplemented`)
- `run_command`, `run_test`, `run_build_command`, `inspect_test_results`, `manage_packages` — covered by issue C2

## Safety review

- All git invocations use `Command::new("git").arg("-C").arg(repo).arg(...)` with arg-list semantics. No shell, no string concatenation, no user input ever spliced into a single command line.
- Rev/refspec/range arguments validated before being forwarded: empty strings, anything starting with `-`, and anything containing NUL or newline are rejected at the param-parsing layer.
- Walking respects `.gitignore` / `.ignore` by default to avoid accidental traversal into vendored or untracked-secret directories.
- The deterministic-tool surface is gated by an explicit per-session opt-in: a Harn pipeline that hasn't asked for filesystem / git / search access cannot get it even though the contract is wired in.
- File-system tools accept arbitrary paths today; embedders that want jail enforcement (matching how `burin-code`'s `validatePathInProject` lived above `CoreToolExecutor`) layer that on top of these primitives. Tracked separately.

## Test plan

- [x] `cargo test -p harn-hostlib` — 55 tests pass (6 unit + 8 registration + 8 search + 14 file_io + 13 git + 3 outline + 3 smoke)
- [x] `cargo clippy -p harn-hostlib --all-targets -- -D warnings` clean
- [x] `cargo clippy -p harn-cli --all-targets -- -D warnings` clean
- [x] `cargo check --workspace` clean
- [x] `cargo test -p harn-cli` — 271+ tests pass, no regressions
- [x] `cargo check -p harn-cli --no-default-features` clean (hostlib feature off)
- [x] `make test` (workspace `cargo nextest run`) — 2146/2146 pass
- [x] Pre-push hooks (full clippy + tests + markdown lint) pass green
- [x] Build performed against an isolated `CARGO_TARGET_DIR=/tmp/harn-567-target`
- [x] Smoke test runs every deterministic builtin through real lexer + parser + compiler + Vm in a `.harn` script

🤖 Generated with [Claude Code](https://claude.com/claude-code)