### PR TITLE
Prepare v0.7.39 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,26 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
-## Unreleased
+## v0.7.39
 
 ### Added
+
+- **Atom primitive for Harn Flow (#601).** New
+  `crates/harn-vm/src/flow/atom.rs` foundational primitive for Harn
+  Flow (parent epic #571): content-addressed, signed, and
+  constructively invertible.
+  `Atom { id, ops, parents, provenance, signature, inverse_of }`
+  carries a `Provenance { principal, persona, agent_run_id,
+  tool_call_id, trace_id, transcript_ref, timestamp }` plus dual
+  Ed25519 signatures (principal + persona) over the `AtomId`, ready
+  to chain into the trust graph in a follow-up.
+  `TextOp::{Insert, Delete}` apply / invert with deletes carrying the
+  removed bytes so the inverse is reconstructible without consulting
+  the document. Two round-tripping encodings on the same struct:
+  serde-JSON for interchange / event-log payloads and a versioned
+  length-prefixed canonical binary form (deterministic, used for
+  hashing and storage) — both decoders re-derive and verify the
+  content hash.
 
 - **`harn-hostlib` crate scaffold (#563).** New opt-in crate housing
   code-intelligence and deterministic-tool host builtins ported from


### PR DESCRIPTION
## Summary

Promotes the `## Unreleased` CHANGELOG block to `## v0.7.39` and adds the missing entry for the Atom primitive that landed in [#601](https://github.com/burin-labs/harn/pull/601). Once this lands, the **Bump Release** workflow auto-fires and opens the version-bump PR.

## What ships in v0.7.39

### Added

- **Atom primitive for Harn Flow** ([#601](https://github.com/burin-labs/harn/pull/601)) — content-addressed, signed, and constructively invertible foundational primitive for parent epic [#571](https://github.com/burin-labs/harn/issues/571). Dual Ed25519 signatures + canonical binary encoding ready for trust-graph chaining.
- **`harn-hostlib` crate scaffold** ([#600](https://github.com/burin-labs/harn/pull/600)) — opt-in crate housing code-intelligence + deterministic-tool host builtins ported from `burin-code`'s Swift `BurinCore`. 24 contracts registered, `HostlibError::Unimplemented` until follow-ups fill them in.
- **Deterministic tool host builtins** ([#605](https://github.com/burin-labs/harn/pull/605)) — live implementations for `search`, `read_file`, `write_file`, `delete_file`, `list_directory`, `get_file_outline`, and `git` gated by `hostlib_enable(\"tools:deterministic\")`. Process tool builtins remain unimplemented (tracked in [#606](https://github.com/burin-labs/harn/issues/606)).
- **Fair-share scheduler for worker-queue claims** ([#603](https://github.com/burin-labs/harn/pull/603)) — deterministic weighted DRR in front of `WorkerQueue::claim_next`. Default stays FIFO; opt-in via `HARN_SCHEDULER_STRATEGY=drr`. New `harn orchestrator queue ls --json` `scheduler` block + 5 Prometheus metrics.

### Deprecated

- **Rust-side GitHub, Slack, Linear, and Notion provider connectors** ([#602](https://github.com/burin-labs/harn/pull/602), [#446](https://github.com/burin-labs/harn/issues/446)) — orchestrator startup warning per affected provider; migration guide for the per-provider cutover to pure-Harn connector packages.

### Removed

- **`harn mcp-serve` legacy alias** ([#599](https://github.com/burin-labs/harn/pull/599), [#594](https://github.com/burin-labs/harn/issues/594)) — unified under `harn serve mcp <file>`. Auto-detects between `pub fn` exports and `mcp_tools(...)` builtins. Sweeps tutorial / cookbook / cli-reference / builtins docs.

## Known follow-ups

- **[#606](https://github.com/burin-labs/harn/issues/606)** — re-open the orphaned [#604](https://github.com/burin-labs/harn/pull/604) (harn-hostlib process-lifecycle tools) against `main`. Was filed against [#600](https://github.com/burin-labs/harn/pull/600)'s branch as a stacked PR; merge target was deleted when #600 landed.

## Test plan

- [x] CHANGELOG is the only file changed in this PR; format check + markdown lint clean via pre-commit hook.
- [x] All six feature PRs landed cleanly through the merge queue.
- [ ] After merge, Bump Release workflow opens the v0.7.39 bump PR carrying `Cargo.toml` / `Cargo.lock` version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)