### PR TITLE
Harden release scripts for new-workspace-crate first release (#609)

### DIFF
--- a/.claude/commands/release-harn.md
+++ b/.claude/commands/release-harn.md
@@ -71,6 +71,71 @@ done — do **not** run `release_ship.sh` locally as a default step.
    `CHANGELOG.md`. Do **not** include `Cargo.toml` / `Cargo.lock` version
    bumps in this PR — the bot's bump PR carries those.
 
+## New-crate first-release pre-flight (harn#609)
+
+**When this applies.** The pending release adds a new workspace crate
+(e.g. `crates/harn-foo`) AND wires an already-published crate (most
+commonly `harn-cli`, but any of the published members) to depend on it
+via the standard `harn-foo = { path = "../harn-foo", version = "0.7" }`
+pattern.
+
+**Why it matters.** During the audit's `package-audit` lane,
+`scripts/verify_crate_packages.sh` runs `cargo package -p harn-cli
+--no-verify`. Cargo strips the path dep, replaces it with the version
+requirement, and queries crates.io to validate it. If `harn-foo` has
+never been published, the lookup fails with `no matching package named
+harn-foo found`. `--no-verify` only skips the staged build, not the
+dependency-resolution step that fails here. The Bump Release workflow
+audit therefore aborts before the publish dry-run ever runs.
+
+**Recommended pre-flight (do this BEFORE landing the prepare PR):**
+
+```bash
+# From a clean worktree at main HEAD (or the prepare branch), seed
+# the new crate at the current workspace version.
+cargo publish -p harn-foo --no-verify --allow-dirty
+```
+
+After this, every subsequent release goes through the normal automated
+flow without intervention. Confirm crates.io picked it up
+(`https://crates.io/crates/harn-foo`) before merging the prepare PR.
+
+**Recovery path (use when the prepare PR already landed and the bump
+workflow is failing in audit):**
+
+1. Manually re-trigger Bump Release with the bootstrap input:
+
+   ```bash
+   gh workflow run bump-release.yml \
+     -f bootstrap_new_crates=true
+   ```
+
+2. The flag sets `HARN_BOOTSTRAP_NEW_CRATES=1`, which tells
+   `release_ship.sh` to skip the publish dry-run AND tells
+   `verify_crate_packages.sh` to skip the harn-cli package check. The
+   bump PR opens normally.
+3. Land the bump PR through the merge queue. If Finalize Release also
+   fails the same way, re-trigger it the same way:
+
+   ```bash
+   gh workflow run finalize-release.yml \
+     -f bootstrap_new_crates=true
+   ```
+
+   The real `cargo publish --workspace` inside finalize orders
+   intra-workspace deps correctly and will publish `harn-foo` before
+   `harn-cli`.
+
+**For maintenance.** Add the new crate to:
+
+- `scripts/publish.sh`'s `WORKSPACE_CRATES` array in dependency order
+  (the per-crate fallback walks this list when the workspace publish
+  bails mid-stream).
+- Optionally, an explicit `cargo package -p harn-foo --allow-dirty
+  --no-verify` step in `scripts/verify_crate_packages.sh` to catch
+  packaging issues for the new crate as a separate audit signal
+  (see the existing `harn-hostlib` step for the pattern).
+
 ## What happens automatically after the prepare PR lands
 
 9. **Bump Release** workflow (`.github/workflows/bump-release.yml`) fires on

--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -21,6 +21,24 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      bootstrap_new_crates:
+        description: >-
+          First-release bootstrap for a new workspace crate that an
+          already-published crate (e.g. harn-cli) now depends on. Sets
+          HARN_BOOTSTRAP_NEW_CRATES=1, which skips the publish dry-run
+          and the audit's harn-cli package check. The real publish on
+          finalize uses `cargo publish --workspace` which orders
+          intra-workspace deps correctly. See harn#609.
+        type: boolean
+        default: false
+      skip_dry_run:
+        description: >-
+          Skip only the publish dry-run gate. Useful if the dry-run is
+          flaky for an unrelated reason and you've already validated
+          the release content elsewhere.
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -142,4 +160,15 @@ jobs:
           # create`. Using the App token makes the bump PR author the
           # bot, consistent with the branch pusher.
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: ./scripts/release_ship.sh --bump ${{ steps.bump.outputs.type }}
+          # First-release bootstrap for a brand-new workspace crate.
+          # release_ship.sh + verify_crate_packages.sh both honor the
+          # env var: skip the publish dry-run and the harn-cli package
+          # check that fails when a path-dep crate isn't on crates.io
+          # yet. Defaults to "0" on push events.
+          HARN_BOOTSTRAP_NEW_CRATES: ${{ inputs.bootstrap_new_crates && '1' || '0' }}
+        run: |
+          args=(--bump "${{ steps.bump.outputs.type }}")
+          if [[ "${{ inputs.skip_dry_run }}" == "true" ]]; then
+            args+=(--skip-dry-run)
+          fi
+          ./scripts/release_ship.sh "${args[@]}"

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -21,6 +21,24 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      bootstrap_new_crates:
+        description: >-
+          First-release bootstrap for a new workspace crate that an
+          already-published crate now depends on. Sets
+          HARN_BOOTSTRAP_NEW_CRATES=1, which skips the publish dry-run
+          and the audit's harn-cli package check. The real publish
+          uses `cargo publish --workspace`, which orders intra-workspace
+          deps correctly. See harn#609.
+        type: boolean
+        default: false
+      skip_dry_run:
+        description: >-
+          Skip only the publish dry-run gate. Useful if the dry-run is
+          flaky for an unrelated reason and you've already validated
+          the release content elsewhere.
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -154,4 +172,15 @@ jobs:
           # Use the App token so the GitHub release author is the bot,
           # consistent with the tag pusher.
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: ./scripts/release_ship.sh --finalize
+          # First-release bootstrap recovery path. See harn#609.
+          # release_ship.sh + verify_crate_packages.sh both honor the
+          # env var: skip the publish dry-run and the harn-cli package
+          # check that fails when a path-dep crate isn't on crates.io
+          # yet. Defaults to "0" on push events.
+          HARN_BOOTSTRAP_NEW_CRATES: ${{ inputs.bootstrap_new_crates && '1' || '0' }}
+        run: |
+          args=(--finalize)
+          if [[ "${{ inputs.skip_dry_run }}" == "true" ]]; then
+            args+=(--skip-dry-run)
+          fi
+          ./scripts/release_ship.sh "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## Unreleased
+
+### Changed
+
+- **Release scripts: harden new-workspace-crate first-release path
+  (#609).** When a "Prepare vX.Y.Z release" PR adds a new workspace
+  crate that an already-published crate (e.g. `harn-cli`) depends on,
+  cargo's dependency-resolution step inside `cargo package -p harn-cli`
+  fails with `no matching package named <new-crate> found` — even with
+  `--no-verify`, which only skips the staged build. The Bump Release
+  workflow's audit lane therefore fails for the first release that
+  ships such a crate. Bootstrap pattern, in priority order:
+  - **Recommended:** before landing the prepare PR, manually
+    `cargo publish -p <new-crate> --no-verify --allow-dirty` from
+    main HEAD to seed the crate at the current workspace version.
+    Subsequent releases proceed through the normal automated flow.
+  - **Recovery:** if the prepare PR already landed and the bump
+    workflow is failing, manually re-trigger Bump Release (or
+    Finalize Release) with `bootstrap_new_crates: true`. The flag
+    sets `HARN_BOOTSTRAP_NEW_CRATES=1` for `release_ship.sh`, which
+    skips the publish dry-run and tells `verify_crate_packages.sh`
+    to skip the `harn-cli` package check. The real publish later
+    uses `cargo publish --workspace`, which orders intra-workspace
+    deps correctly. `scripts/publish.sh`'s `WORKSPACE_CRATES`
+    fallback list now includes `harn-hostlib` between `harn-lsp`
+    and `harn-cli` so the per-crate fallback covers it. The
+    merge-captain runbook (`.claude/commands/release-harn.md`) and
+    the burin-code merge-captain skill carry the same pre-flight.
+
 ## v0.7.39
 
 ### Added

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -79,6 +79,7 @@ WORKSPACE_CRATES=(
   harn-dap
   harn-serve
   harn-lsp
+  harn-hostlib
   harn-cli
 )
 

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -82,6 +82,16 @@ After that PR lands through the merge queue, run:
 
   ./scripts/release_ship.sh --finalize
 
+Environment variables:
+  HARN_BOOTSTRAP_NEW_CRATES=1
+    First-release bootstrap mode for a brand-new workspace crate that
+    an already-published crate now depends on. Skips the publish
+    dry-run and tells verify_crate_packages.sh to skip the harn-cli
+    package check (which fails when a path-dep crate isn't on
+    crates.io yet). The real publish later uses
+    `cargo publish --workspace`, which orders intra-workspace deps
+    correctly. See harn#609.
+
 Finalize mode:
   1. Runs ./scripts/release_gate.sh audit
   2. Optionally runs ./scripts/release_gate.sh publish --dry-run
@@ -165,6 +175,20 @@ run_common_gates() {
   # would otherwise get the build.rs placeholder.
   log_step "Build portal frontend"
   make portal-check
+
+  # New-crate bootstrap mode: if the prepare PR introduced a workspace
+  # crate that's also depended on by an already-published crate (e.g.
+  # harn-cli pulling in the brand-new harn-hostlib), cargo's
+  # dependency-resolution step inside `cargo package -p harn-cli` will
+  # fail looking that crate up on crates.io even with --no-verify. Skip
+  # the dry-run and let `cargo publish --workspace` order the crates at
+  # real-publish time. The audit's package-audit lane reads the same
+  # env var via verify_crate_packages.sh and skips the harn-cli check.
+  # See harn#609 for the full failure mode.
+  if [[ "${HARN_BOOTSTRAP_NEW_CRATES:-0}" == "1" ]]; then
+    echo "=== HARN_BOOTSTRAP_NEW_CRATES=1: skipping publish dry-run ==="
+    SKIP_DRY_RUN=1
+  fi
 
   log_step "Release audit"
   ./scripts/release_gate.sh audit

--- a/scripts/verify_crate_packages.sh
+++ b/scripts/verify_crate_packages.sh
@@ -5,19 +5,29 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 VERIFY_CLI=0
+SKIP_CLI=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --verify-cli)
       VERIFY_CLI=1
       shift
       ;;
+    --skip-cli)
+      SKIP_CLI=1
+      shift
+      ;;
     *)
       echo "error: unknown arg: $1" >&2
-      echo "usage: ./scripts/verify_crate_packages.sh [--verify-cli]" >&2
+      echo "usage: ./scripts/verify_crate_packages.sh [--verify-cli|--skip-cli]" >&2
       exit 1
       ;;
   esac
 done
+
+if [[ "$VERIFY_CLI" -eq 1 && "$SKIP_CLI" -eq 1 ]]; then
+  echo "error: --verify-cli and --skip-cli are mutually exclusive" >&2
+  exit 1
+fi
 
 metadata="$(cargo metadata --format-version 1 --no-deps)"
 target_dir="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])' <<<"$metadata")"
@@ -62,6 +72,30 @@ fi
 
 echo "=== Check extracted harn-modules package ==="
 CARGO_TARGET_DIR="$tmp/target" cargo check --manifest-path "$modules_pkg/Cargo.toml"
+
+# `harn-hostlib` is a workspace path dep of `harn-cli`. Verifying it
+# packages cleanly here (a) catches scaffold issues for the crate on its
+# own and (b) mirrors the per-crate audit pattern used for harn-modules
+# above. The check is independent of the harn-cli step below — packaging
+# harn-hostlib does not preempt cargo's "must exist on crates.io" lookup
+# for harn-cli's version requirement on harn-hostlib.
+echo "=== Package harn-hostlib ==="
+cargo package -p harn-hostlib --allow-dirty --no-verify
+
+# `cargo package -p harn-cli` resolves harn-cli's path deps against
+# crates.io to validate the version requirement that cargo will publish.
+# When a workspace crate (e.g. harn-hostlib) was just added and has never
+# been published, that lookup fails with "no matching package named X
+# found" — even with --no-verify, which only skips the staged build, not
+# dependency resolution. Set HARN_BOOTSTRAP_NEW_CRATES=1 (or pass
+# --skip-cli) on the first release that ships such a crate; the real
+# `cargo publish --workspace` later will still order intra-workspace
+# deps correctly. See harn#609 for the full story.
+if [[ "${HARN_BOOTSTRAP_NEW_CRATES:-0}" == "1" || "$SKIP_CLI" -eq 1 ]]; then
+  echo "=== Skip harn-cli package check (bootstrap mode) ==="
+  echo "Package verification complete (skipped harn-cli for new-crate bootstrap)"
+  exit 0
+fi
 
 echo "=== Package harn-cli ==="
 if [[ "$VERIFY_CLI" -eq 1 ]]; then


### PR DESCRIPTION
## Summary

- Fixes #609: when a "Prepare vX.Y.Z release" PR adds a new workspace crate that an already-published crate (e.g. `harn-cli`) depends on, the Bump Release workflow's audit lane fails inside `cargo package -p harn-cli --no-verify` with `no matching package named <new-crate> found`. v0.7.39 hit this with `harn-hostlib`; the workaround was a manual `cargo publish -p harn-hostlib`.
- Recommended pre-flight is now documented (bootstrap-publish the new crate from main HEAD before landing the prepare PR), and a recovery path is wired through both Bump Release and Finalize Release workflows via `bootstrap_new_crates: true` (sets `HARN_BOOTSTRAP_NEW_CRATES=1`, which skips the publish dry-run and tells `verify_crate_packages.sh` to skip the harn-cli check).
- `scripts/publish.sh`'s per-crate-fallback `WORKSPACE_CRATES` array now includes `harn-hostlib` between `harn-lsp` and `harn-cli`. Skill docs (`.claude/commands/release-harn.md` here, `.claude/commands/merge-captain.md` in burin-code in a separate change) carry the new pre-flight section.

## Test plan

- [x] `bash -n` syntax-checks pass for `verify_crate_packages.sh`, `publish.sh`, `release_ship.sh`.
- [x] `actionlint` clean on both modified workflows.
- [x] `./scripts/verify_crate_packages.sh` succeeds end-to-end (harn-modules, harn-hostlib, harn-cli all package cleanly today since harn-hostlib v0.7.38 is on crates.io).
- [x] `HARN_BOOTSTRAP_NEW_CRATES=1 ./scripts/verify_crate_packages.sh` skips the harn-cli step and exits 0.
- [x] `./scripts/verify_crate_packages.sh --skip-cli` same behavior; `--verify-cli --skip-cli` errors out as expected.
- [x] `python3 scripts/verify_release_metadata.py` passes with the new `## Unreleased` section above `## v0.7.39`.
- [x] Pre-commit hook (markdown + GitHub Actions checks) and pre-push hook both green.
- [ ] Future verification: next release that introduces a brand-new workspace crate exercises the recommended pre-flight; if a maintainer forgets, the `bootstrap_new_crates: true` workflow input is the recovery path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)