### PR TITLE
Add question-at-a-time planning agent experiment (burin-mini/qmode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ meta_scratch/
 /project_deep_scan_repo/
 # qmode experiment per-task state (qa.jsonl, plan.json, llm-mock.jsonl, transcripts).
 experiments/burin-mini/.qmode/
+# qmode test runs may write synthetic preferences to project-scoped profiles.
+experiments/burin-mini/workspace/.harn/

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ meta_scratch/
 /project_deep_scan_ignore/
 /project_deep_scan_ns/
 /project_deep_scan_repo/
+# qmode experiment per-task state (qa.jsonl, plan.json, llm-mock.jsonl, transcripts).
+experiments/burin-mini/.qmode/

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -21,6 +21,10 @@
     ".burin",
     ".claude",
     "docs/src/SUMMARY.md",
-    "conformance/tests/**/.harn/**/*.md"
+    "conformance/tests/**/.harn/**/*.md",
+    // qmode experiment writes synthetic profile bullets here during eval runs;
+    // these are not docs and shouldn't be linted as such.
+    "experiments/**/.harn/**/*.md",
+    "experiments/**/USER_PROFILE.md"
   ]
 }

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -1873,6 +1873,9 @@ pub(crate) struct PersonaStatusArgs {
 pub(crate) struct PersonaControlArgs {
     /// Persona name to control.
     pub name: String,
+    /// RFC3339 timestamp to use as "now" for deterministic tests.
+    #[arg(long, value_name = "RFC3339")]
+    pub at: Option<String>,
     /// Emit stable JSON after applying the control.
     #[arg(long)]
     pub json: bool,

--- a/crates/harn-cli/src/commands/persona.rs
+++ b/crates/harn-cli/src/commands/persona.rs
@@ -135,10 +135,7 @@ pub(crate) async fn run_status(
     let catalog = load_catalog_result(manifest)?;
     let binding = runtime_binding_or_err(&catalog, &args.name)?;
     let log = open_persona_log(state_dir)?;
-    let now_ms = match &args.at {
-        Some(at) => harn_vm::parse_persona_ms(at)?,
-        None => harn_vm::persona_now_ms(),
-    };
+    let now_ms = timestamp_arg(args.at.as_deref())?;
     let status = harn_vm::persona_status(&log, &binding, now_ms).await?;
     print_status(&status, args.json);
     Ok(())
@@ -152,7 +149,8 @@ pub(crate) async fn run_pause(
     let catalog = load_catalog_result(manifest)?;
     let binding = runtime_binding_or_err(&catalog, &args.name)?;
     let log = open_persona_log(state_dir)?;
-    let status = harn_vm::pause_persona(&log, &binding, harn_vm::persona_now_ms()).await?;
+    let now_ms = timestamp_arg(args.at.as_deref())?;
+    let status = harn_vm::pause_persona(&log, &binding, now_ms).await?;
     print_status(&status, args.json);
     Ok(())
 }
@@ -165,7 +163,8 @@ pub(crate) async fn run_resume(
     let catalog = load_catalog_result(manifest)?;
     let binding = runtime_binding_or_err(&catalog, &args.name)?;
     let log = open_persona_log(state_dir)?;
-    let status = harn_vm::resume_persona(&log, &binding, harn_vm::persona_now_ms()).await?;
+    let now_ms = timestamp_arg(args.at.as_deref())?;
+    let status = harn_vm::resume_persona(&log, &binding, now_ms).await?;
     print_status(&status, args.json);
     Ok(())
 }
@@ -178,7 +177,8 @@ pub(crate) async fn run_disable(
     let catalog = load_catalog_result(manifest)?;
     let binding = runtime_binding_or_err(&catalog, &args.name)?;
     let log = open_persona_log(state_dir)?;
-    let status = harn_vm::disable_persona(&log, &binding, harn_vm::persona_now_ms()).await?;
+    let now_ms = timestamp_arg(args.at.as_deref())?;
+    let status = harn_vm::disable_persona(&log, &binding, now_ms).await?;
     print_status(&status, args.json);
     Ok(())
 }

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -266,7 +266,7 @@ fn persona_runtime_status_tick_and_budget_are_persisted() {
             "status",
             "merge_captain",
             "--at",
-            "2026-04-24T12:30:00Z",
+            "2026-04-24T13:00:00Z",
             "--json",
         ])
         .output()

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -830,6 +830,25 @@ its own `tool_retries`, `max_iterations`, `max_nudges`, and
 native-tool stages that receive text-mode `<tool_call>` fallback
 output).
 
+Pass `stop_after_successful_tools: ["name", ...]` to terminate the loop
+the moment any of those tools is dispatched successfully. Same shape as
+Vercel AI SDK's `stopWhen: hasToolCall(name)` and OpenAI Agents SDK's
+`StopAtTools([name])`. Use this for "terminal" tools (e.g.
+`exit_plan_mode`, `submit_answer`, `ask_user`) that mark the end of an
+agent step:
+
+```harn
+agent_loop(task, sys, {
+  tools: registry,
+  stop_after_successful_tools: ["ask_question", "exit_plan_mode"],
+})
+```
+
+The check fires after each iteration's tool dispatch, so any other
+tool calls in the same iteration still run; only subsequent
+iterations are skipped. The loop exits with `status = "done"` and
+the tool name appears in `tools.successful`.
+
 Pass `permissions` to scope one agent below the ambient `policy` ceiling:
 
 ```harn

--- a/experiments/burin-mini/lib/workspace.harn
+++ b/experiments/burin-mini/lib/workspace.harn
@@ -58,6 +58,99 @@ pub fn search_workspace(query) {
   return result?.stdout ?? result?.stderr ?? ""
 }
 
+/** List every workspace file in deterministic (path-sorted) order. */
+pub fn list_workspace_files() {
+  let result = exec_at(
+    workspace_root(),
+    "rg",
+    "--files",
+    "--hidden",
+    "--sort",
+    "path",
+    "--glob",
+    "!node_modules",
+    "--glob",
+    "!.git",
+    "--glob",
+    "!dist",
+    "--glob",
+    "!coverage",
+  )
+  let out = (result?.stdout ?? "").trim()
+  if out == "" {
+    return []
+  }
+  return split(out, "\n")
+}
+
+/**
+ * Unified discovery: filename matches AND content matches in one call.
+ *
+ * Returns a string with two sections (omitted when empty), or an explicit
+ * "(no matches for 'query')" line if both sections are empty. The caller
+ * should pass a token or symbol — natural-language phrases like
+ * "auth middleware" rarely match content literally; the filename pass
+ * is what saves them.
+ */
+pub fn find_workspace(query) {
+  let q = (query ?? "").trim()
+  if q == "" {
+    return "(empty query)"
+  }
+  // Filename pass: path-sorted file list, filter by case-insensitive substring.
+  var name_hits = []
+  for path in list_workspace_files() {
+    if contains(lowercase(path), lowercase(q)) {
+      name_hits = name_hits + [path]
+    }
+  }
+  // Content pass: ripgrep -n -i, capped at 80 lines.
+  let rg = exec_at(
+    workspace_root(),
+    "rg",
+    "-n",
+    "-i",
+    "--hidden",
+    "--sort",
+    "path",
+    "--max-count",
+    "20",
+    "--glob",
+    "!node_modules",
+    "--glob",
+    "!.git",
+    "--glob",
+    "!dist",
+    "--glob",
+    "!coverage",
+    q,
+    ".",
+  )
+  let content_lines = split((rg?.stdout ?? "").trim(), "\n")
+  let trimmed_content = if len(content_lines) > 80 {
+    content_lines[0:80]
+  } else {
+    content_lines
+  }
+  let truncated = len(content_lines) > 80
+  var sections = []
+  if len(name_hits) > 0 {
+    let hdr = "## Filename matches (${len(name_hits)})"
+    sections = sections + [hdr + "\n" + join(name_hits, "\n")]
+  }
+  if (rg?.stdout ?? "").trim() != "" {
+    var body = join(trimmed_content, "\n")
+    if truncated {
+      body = body + "\n... (truncated; refine query or use read on a specific file)"
+    }
+    sections = sections + ["## Content matches\n" + body]
+  }
+  if len(sections) == 0 {
+    return "(no matches for '${q}')"
+  }
+  return join(sections, "\n\n")
+}
+
 /** Run one shell command from the sample workspace root. */
 pub fn run_workspace(command) {
   return shell_at(workspace_root(), command)

--- a/experiments/burin-mini/pipeline_qmode.harn
+++ b/experiments/burin-mini/pipeline_qmode.harn
@@ -1,0 +1,561 @@
+// Question-at-a-time planning agent (qmode).
+//
+// The model asks the user one question at a time, may use read-only
+// discovery tools between questions, then calls exit_plan_mode with a
+// grounded JSON plan. State lives on disk in .qmode/<task_id>/ so the
+// loop pauses across `harn playground` invocations: the harness exits
+// after each ask_question or exit_plan_mode call, the user (or Claude)
+// records the answer, and reruns the pipeline.
+//
+// Reuses workspace tools from lib/workspace.harn.
+import "std/path"
+import "std/runtime"
+import {
+  find_workspace,
+  list_workspace_files,
+  read_workspace,
+  workspace_root,
+} from "lib/workspace.harn"
+
+// -----------------------------------------------------------------------------
+// Provider guard: hard-block remote inference.
+// -----------------------------------------------------------------------------
+
+fn provider_name() {
+  return env_or("BURIN_MINI_PROVIDER", env_or("HARN_LLM_PROVIDER", "ollama"))
+}
+
+fn generator_model() {
+  return env_or("BURIN_MINI_GENERATOR_MODEL", env_or("HARN_LLM_MODEL", "qwen3.6:35b-a3b-coding-nvfp4"))
+}
+
+fn assert_local_only() {
+  let p = lowercase(provider_name())
+  let allowed = ["ollama", "local", "mock"]
+  for name in allowed {
+    if p == name || starts_with(p, name + ":") {
+      return
+    }
+  }
+  throw "[qmode] provider '${p}' is not local-only. Allowed: ollama, local, mock. Set BURIN_MINI_PROVIDER=ollama and BURIN_MINI_GENERATOR_MODEL=qwen3.6:35b-a3b-coding-nvfp4."
+}
+
+// -----------------------------------------------------------------------------
+// Task state directory layout.
+// -----------------------------------------------------------------------------
+
+fn task_dir(task_id) {
+  return path_join(source_dir(), ".qmode", task_id)
+}
+
+fn ensure_task_dir(task_id) {
+  let dir = task_dir(task_id)
+  mkdir(dir)
+  return dir
+}
+
+fn qa_path(task_id) {
+  return path_join(task_dir(task_id), "qa.jsonl")
+}
+
+fn pending_path(task_id) {
+  return path_join(task_dir(task_id), "pending.json")
+}
+
+fn plan_path(task_id) {
+  return path_join(task_dir(task_id), "plan.json")
+}
+
+fn task_meta_path(task_id) {
+  return path_join(task_dir(task_id), "task.json")
+}
+
+// -----------------------------------------------------------------------------
+// JSONL helpers (newline-delimited JSON).
+// -----------------------------------------------------------------------------
+
+fn read_jsonl(path) {
+  if !file_exists(path) {
+    return []
+  }
+  let raw = read_file(path)
+  if (raw ?? "").trim() == "" {
+    return []
+  }
+  var entries = []
+  for line in split(raw, "\n") {
+    let trimmed = line.trim()
+    if trimmed == "" {
+      continue
+    }
+    let parsed = json_parse(trimmed)
+    if parsed != nil {
+      entries = entries + [parsed]
+    }
+  }
+  return entries
+}
+
+// -----------------------------------------------------------------------------
+
+// Three-layer USER_PROFILE.md loader.
+// Most-specific-last concatenation. Each layer is tagged with its scope.
+
+// -----------------------------------------------------------------------------
+
+fn read_profile_file(path, scope) {
+  if !file_exists(path) {
+    return ""
+  }
+  let body = read_file(path)
+  if body.trim() == "" {
+    return ""
+  }
+  return "<profile scope=\"${scope}\" path=\"${path}\">\n${body.trim()}\n</profile>"
+}
+
+fn load_profile_layers() {
+  let home = home_dir()
+  let user_global = path_join(home, ".harn", "USER_PROFILE.md")
+  let project = path_join(workspace_root(), ".harn", "USER_PROFILE.md")
+  let cwd_local = path_join(source_dir(), ".harn", "USER_PROFILE.md")
+  var blocks = []
+  let user_block = read_profile_file(user_global, "user")
+  if user_block != "" {
+    blocks = blocks + [user_block]
+  }
+  let project_block = read_profile_file(project, "project")
+  if project_block != "" {
+    blocks = blocks + [project_block]
+  }
+  let cwd_block = read_profile_file(cwd_local, "cwd")
+  if cwd_block != "" {
+    blocks = blocks + [cwd_block]
+  }
+  if len(blocks) == 0 {
+    return "(no prior preferences saved)"
+  }
+  return join(blocks, "\n\n")
+}
+
+fn profile_path_for_scope(scope) {
+  if scope == "user" {
+    return path_join(home_dir(), ".harn", "USER_PROFILE.md")
+  }
+  if scope == "project" {
+    return path_join(workspace_root(), ".harn", "USER_PROFILE.md")
+  }
+  return path_join(source_dir(), ".harn", "USER_PROFILE.md")
+}
+
+fn append_profile_writes(profile_writes) {
+  if type_of(profile_writes) != "list" || len(profile_writes) == 0 {
+    return
+  }
+  let today = date_iso().substring(0, 10)
+  for entry in profile_writes {
+    if type_of(entry) != "dict" {
+      continue
+    }
+    let scope = (entry?.scope ?? "project").trim()
+    let bullet = (entry?.bullet ?? "").trim()
+    if bullet == "" {
+      continue
+    }
+    let target = profile_path_for_scope(scope)
+    mkdir(path_parent(target))
+    let prior = if file_exists(target) {
+      read_file(target)
+    } else {
+      ""
+    }
+    let header = "\n\n## Auto-learned ${today}\n"
+    let body = if contains(prior, header) {
+      "- ${bullet}\n"
+    } else {
+      "${header}- ${bullet}\n"
+    }
+    append_file(target, body)
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Plan schema (compatible with burin-code's plan-json-schema partial).
+// -----------------------------------------------------------------------------
+
+fn _plan_schema() {
+  return {
+    type: "object",
+    required: ["mode", "direction", "tasks", "ready"],
+    properties: {
+    mode: {type: "string", enum: ["fast_execute", "plan_then_execute"]},
+    direction: {type: "string"},
+    targets: {type: "array", items: {type: "string"}},
+    grounding: {
+    type: "array",
+    items: {
+    type: "object",
+    properties: {path: {type: "string"}, role: {type: "string"}, why: {type: "string"}},
+  },
+  },
+    tasks: {type: "array", items: {type: "string"}},
+    verification: {type: "array", items: {type: "string"}},
+    ready: {type: "boolean"},
+    profile_writes: {
+    type: "array",
+    items: {
+    type: "object",
+    properties: {scope: {type: "string", enum: ["user", "project", "cwd"]}, bullet: {type: "string"}},
+  },
+  },
+  },
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+// Repo map (Aider-style orientation, but token-cheap).
+//
+// We front-load the workspace tree + a one-line summary per file so the model
+// doesn't burn iterations on `glob` just to learn the layout. The first
+// non-empty line of each file is a surprisingly strong proxy for "what is
+// this file" across markdown, JS/TS, Python, shell, JSON, Rust, etc. — and
+// avoids the need for tree-sitter symbol extraction we don't have here.
+
+// -----------------------------------------------------------------------------
+
+fn _first_nonempty_line(path) {
+  let body = read_file(path)
+  if body == nil {
+    return ""
+  }
+  for line in split(body, "\n") {
+    let t = line.trim()
+    if t != "" {
+      let capped = if len(t) > 100 {
+        t[0:100] + "…"
+      } else {
+        t
+      }
+      return capped
+    }
+  }
+  return ""
+}
+
+fn repo_map_text() {
+  let files = list_workspace_files()
+  let root = workspace_root()
+  if len(files) == 0 {
+    return "(workspace is empty)"
+  }
+  let cap = 60
+  let visible = if len(files) > cap {
+    files[0:cap]
+  } else {
+    files
+  }
+  var lines = ["root: ${root}", "files (${len(files)}; ${len(visible)} shown):"]
+  for rel in visible {
+    let abs = path_join(root, rel)
+    let body = read_file(abs)
+    let line_count = if body == nil {
+      0
+    } else {
+      len(split(body, "\n"))
+    }
+    let summary = _first_nonempty_line(abs)
+    lines = lines + ["  ${rel} (${line_count}L)  ${summary}"]
+  }
+  if len(files) > cap {
+    lines = lines + ["  ... (${len(files) - cap} more files; use find to discover)"]
+  }
+  return join(lines, "\n")
+}
+
+// -----------------------------------------------------------------------------
+// Tools available to the model.
+// -----------------------------------------------------------------------------
+
+fn build_tools(task_id, dir) {
+  let pending_p = path_join(dir, "pending.json")
+  let plan_p = path_join(dir, "plan.json")
+  var registry = tool_registry()
+  registry = tool_define(
+    registry,
+    "find",
+    "Find files OR content in the workspace. Searches BOTH filenames (case-insensitive substring) and file contents (ripgrep, case-insensitive). Pass a single short token like 'auth', 'rate', 'middleware' — not a phrase. Output has two sections (filename matches, content matches) or '(no matches for ...)'.",
+    {
+    parameters: {
+    query: {
+    type: "string",
+    description: "A token or short pattern. Avoid multi-word natural-language phrases — those rarely match literally. Use 'auth' not 'auth middleware'.",
+  },
+  },
+    returns: {type: "string"},
+    handler: { args -> find_workspace(args?.query ?? "") },
+  },
+  )
+  registry = tool_define(
+    registry,
+    "read",
+    "Read a single workspace file. Path must be workspace-relative (matching the paths in the workspace tree above).",
+    {
+    parameters: {path: {type: "string", description: "Workspace-relative file path."}},
+    returns: {type: "string"},
+    handler: { args -> read_workspace(args.path) },
+  },
+  )
+  registry = tool_define(
+    registry,
+    "ask_question",
+    "Ask the user exactly one short question (max 3 sentences). The harness pauses after this and resumes when the user answers. Always offer a default or example so they don't have to think hard.",
+    {
+    parameters: {
+    question: {
+    type: "string",
+    description: "The next single question for the user. <=3 sentences. Friendly. Offer a default.",
+  },
+  },
+    returns: {type: "string"},
+    handler: { args ->
+    let q = (args?.question ?? "").trim()
+    if q == "" {
+      return "Error: question text was empty. Try again with a concrete question."
+    }
+    if !file_exists(pending_p) {
+      write_file(pending_p, json_stringify({question: q, asked_at: date_iso()}))
+    }
+    "Question recorded. The harness will pause and resume after the user answers."
+  },
+  },
+  )
+  // Idempotent: if multiple ask_question calls land in the same
+  // iteration (parallel tool-use), only the first sticks. agent_loop
+  // ends the step after this iteration via stop_after_successful_tools.
+  registry = tool_define(
+    registry,
+    "exit_plan_mode",
+    "Emit the final structured plan and end the conversation. Pass the plan as a JSON object (or JSON-stringified). Always include profile_writes (possibly empty) for any durable preferences you learned this turn.",
+    {
+    parameters: {
+    plan: {
+    type: "string",
+    description: "The plan as a JSON object. Top-level keys: mode, direction, targets, grounding, tasks, verification, ready, profile_writes.",
+  },
+  },
+    returns: {type: "string"},
+    handler: { args ->
+    if !file_exists(plan_p) {
+      let raw = args?.plan ?? args ?? {}
+      let plan = if type_of(raw) == "string" {
+    json_parse(raw) ?? {}
+  } else {
+    raw
+  }
+      write_file(plan_p, json_stringify(plan))
+      append_profile_writes(plan?.profile_writes ?? [])
+    }
+    "Plan recorded. The harness will end the step now."
+  },
+  },
+  )
+  // Idempotent — first plan in this iteration sticks.
+  return registry
+}
+
+// -----------------------------------------------------------------------------
+// Prompt construction.
+// -----------------------------------------------------------------------------
+
+fn system_prompt(profile_block) {
+  return """
+You are a planning partner pairing with the user. The user types one short message; you reply with one short question, or commit to a final plan. A whole conversation is typically 1–5 exchanges.
+
+This invocation is ONE STEP of that conversation. A step is: optional discovery, then exactly one call to a terminal tool — ask_question or exit_plan_mode. The harness ends the step automatically the moment that terminal tool succeeds; you do not need to emit ##DONE## or anything else.
+
+Workflow this step:
+1. The user message starts with a <workspace> block listing every file (path + line count + first non-empty line). Treat that as your starting orientation; you usually don't need to call `find` to learn the layout. Use `find(query)` for token searches across filenames AND content (one tool — pass a single token like "auth", not a phrase). Use `read(path)` to fetch a specific file. Look BEFORE you ask — don't ask about facts that are obvious from the workspace block or from a read.
+2. Decide whether to ask or commit. You are a planning *partner*, not a code-completion model — defaulting to "I'll just pick" silently is the wrong move. Ask via ask_question(...) whenever ANY of the following is true:
+   - The user's request is open-ended ("improve performance", "make it more robust", "clean up", "refactor"). The scope is the question.
+   - A design parameter is not pinned by the code: rate limits, TTLs, cache sizes, library choices, error codes, retry/backoff, log verbosity, naming.
+   - There are 2+ sensible places to put the new code and the convention isn't obvious.
+   - The change is destructive or hard to undo: deleting/renaming files, dropping schema, mass rewrites, removing public API.
+   - You have a complete plan but at least one parameter you guessed at. In that case, summarize the plan in 1-2 sentences inside the question and ask "does this sound right? happy to adjust X/Y/Z." That's still ONE question and gives the user a chance to redirect cheaply.
+
+   Only call exit_plan_mode directly when the request is concrete AND every choice in the plan is pinned by the code or by a prior answer in this conversation.
+
+If the user's request looks like a direct question (e.g. "explain this repo"), call exit_plan_mode without asking — the plan describes the reading and synthesis the implementation phase will produce; you do not answer in free prose.
+
+Conversation style for ask_question:
+- Friendly, colloquial, like a coworker pairing on the problem.
+- Plain English, no jargon, no bullet lists.
+- ≤ 3 sentences. Always include a default ("…or just say 'whatever you think' and I'll pick something sensible").
+- One thing at a time. If you need two answers, ask the most important one first; you can ask the next on the following turn.
+- For confirm-the-plan questions: lead with a 1-sentence summary of what you'd do, then "sound good, or want me to change X?".
+
+Stopping rule: 3–5 questions is typical. More than 7 is stalling. Once the user has confirmed the plan (or the plan is fully pinned by code), call exit_plan_mode.
+
+Skip anything covered by <profile> below — those are durable preferences the user already shared. Don't re-ask them.
+
+Plan schema (exit_plan_mode):
+{
+  "mode": "fast_execute" | "plan_then_execute",
+  "direction": "one sentence summarizing the approach",
+  "targets": ["workspace-relative/path.ext", ...],
+  "grounding": [{"path": "...", "role": "sibling_exemplar|convention_anchor|source_under_change", "why": "phrase"}],
+  "tasks": ["concrete step 1 referencing real paths/symbols", "..."],
+  "verification": ["command or check"],
+  "ready": true,
+  "profile_writes": [{"scope": "user|project|cwd", "bullet": "Durable preference, e.g. 'Branch policy: edits go directly to main unless I say otherwise.'"}]
+}
+
+profile_writes: ONLY durable preferences the user expressed THIS conversation that would save you from re-asking next time. Never save derivable facts (paths, structure, code). Never save fix recipes. Empty list is fine.
+
+For read-only / "explain this" tasks: still call exit_plan_mode. The plan should describe the reading and the answer the implementation phase will produce — e.g. tasks=["Read README, api.ts, auth-guard.ts", "Write 2-paragraph explanation citing those paths"], mode="plan_then_execute".
+
+<profile>
+${profile_block}
+</profile>
+
+Reminder: no free-form prose answers. Every step ends with one tool call to ask_question or exit_plan_mode.
+""".trim()
+}
+
+fn build_user_prompt(task, qa_history) {
+  var lines = ["The user's request:", "", task, ""]
+  // Workspace orientation block — Aider-style repo map but path+first-line
+  // (not tree-sitter symbols, which would need a parser per language).
+  // This is the single biggest information-density win: the model can
+  // skip 1-2 iterations of pure orientation calls.
+  lines = lines + ["<workspace>", repo_map_text(), "</workspace>", ""]
+  if len(qa_history) == 0 {
+    lines = lines
+      + [
+      "No prior Q&A yet. The workspace block above is your orientation — a `find` call is rarely needed before reading. Read 1-3 specific files if it'll change the plan, then ask the single most plan-changing question (or, if the request is concrete and every parameter is pinned by the code, commit to exit_plan_mode).",
+    ]
+  } else {
+    lines = lines + ["Prior Q&A in this conversation (oldest first):"]
+    for entry in qa_history {
+      let q = if type_of(entry?.question) == "string" {
+        entry.question
+      } else {
+        ""
+      }
+      let a = if type_of(entry?.answer) == "string" {
+        entry.answer
+      } else {
+        ""
+      }
+      lines = lines + ["- Q: ${q}"]
+      lines = lines + ["  A: ${a}"]
+    }
+    lines = lines
+      + [
+      "",
+      "You already have ${len(qa_history)} answer(s). DEFAULT toward calling exit_plan_mode now. Only ask another question if the answer would *meaningfully change the file list or approach*. Most tasks need 1–3 questions total, not 5+.",
+    ]
+  }
+  lines = lines
+    + [
+    "",
+    "End this step with EXACTLY ONE call: ask_question or exit_plan_mode. The harness terminates immediately after. Anything else is wasted.",
+  ]
+  return join(lines, "\n")
+}
+
+// -----------------------------------------------------------------------------
+// Main.
+// -----------------------------------------------------------------------------
+
+pipeline default() {
+  assert_local_only()
+  let task_id = env_or("QMODE_TASK_ID", "default")
+  let task_text = runtime_task()
+  let dir = ensure_task_dir(task_id)
+  // Reset step marker for this invocation; handlers overwrite it.
+  let step_marker = path_join(dir, "step.txt")
+  if file_exists(step_marker) {
+    delete_file(step_marker)
+  }
+  if file_exists(plan_path(task_id)) {
+    write_file(step_marker, "plan_already_exists")
+    return
+  }
+  if file_exists(pending_path(task_id)) {
+    throw "[qmode] pending.json exists at ${pending_path(task_id)}. The driver should have cleared it after recording the answer."
+  }
+  // Persist task metadata on first run.
+  if !file_exists(task_meta_path(task_id)) {
+    if task_text.trim() == "" {
+      throw "[qmode] no task text supplied. Pass --task '...' on first invocation."
+    }
+    write_file(
+      task_meta_path(task_id),
+      json_stringify({task: task_text, workspace_root: workspace_root(), started_at: date_iso()}),
+    )
+  }
+  let task_meta = json_parse(read_file(task_meta_path(task_id))) ?? {}
+  let effective_task = task_meta?.task ?? task_text
+  let qa_history = read_jsonl(qa_path(task_id))
+  let profile_block = load_profile_layers()
+  let user_prompt = build_user_prompt(effective_task, qa_history)
+  let sys_prompt = system_prompt(profile_block)
+  write_file(
+    path_join(dir, "last-prompt.txt"),
+    "===SYSTEM===\n${sys_prompt}\n===USER===\n${user_prompt}\n",
+  )
+  // 10 iterations is plenty once `glob` returns useful results (rg-backed,
+  // not the broken `ls` version that wasted 5+ iterations on errors).
+  let result = agent_loop(
+    user_prompt,
+    sys_prompt,
+    {
+    provider: provider_name(),
+    model: generator_model(),
+    tools: build_tools(task_id, dir),
+    tool_format: "native",
+    temperature: 0.2,
+    max_tokens: 2048,
+    max_iterations: 10,
+    llm_retries: 1,
+    turn_policy: {require_action_or_yield: true, max_prose_chars: 280},
+    stop_after_successful_tools: ["ask_question", "exit_plan_mode"],
+  },
+  )
+  // Force a tool call (or explicit yield) on every iteration; without
+  // this, qwen3.6 happily emits a prose answer + ##DONE##. With it,
+  // the model has to keep using tools until one of them is terminal.
+  // Stop the loop the moment a terminal tool succeeds — same shape as
+  // Vercel AI SDK's `stopWhen: hasToolCall(...)` and OpenAI Agents
+  // SDK's `StopAtTools(...)`.
+  // Step outcome for the driver to consume.
+  let outcome = if file_exists(path_join(dir, "plan.json")) {
+    "exit_plan_mode"
+  } else {
+    if file_exists(path_join(dir, "pending.json")) {
+      "ask_question"
+    } else {
+      "no_terminal"
+    }
+  }
+  let diag = {
+    outcome: outcome,
+    status: result?.status ?? "?",
+    iterations: result?.llm?.iterations ?? 0,
+    tool_calls: result?.tools?.calls ?? [],
+    visible_text: result?.visible_text ?? "",
+  }
+  write_file(path_join(dir, "step.txt"), outcome)
+  write_file(path_join(dir, "diag.json"), json_stringify(diag))
+  // Dump the full transcript for offline inspection.
+  write_file(
+    path_join(dir, "step-transcript.json"),
+    json_stringify({transcript: result?.transcript, task_ledger: result?.task_ledger}),
+  )
+  println("[qmode] step=${outcome} status=${diag?.status} iterations=${diag?.iterations}")
+  if outcome == "no_terminal" {
+    println("[qmode] WARN: model never called a terminal tool. visible_text:")
+    println(diag?.visible_text)
+  }
+}

--- a/experiments/burin-mini/pipeline_qmode.harn
+++ b/experiments/burin-mini/pipeline_qmode.harn
@@ -169,6 +169,13 @@ fn append_profile_writes(profile_writes) {
     } else {
       ""
     }
+    // Dedup: skip bullets already present anywhere in the file. Cheap O(n)
+    // string match — profiles are tiny and this is the only correctness
+    // belt against a model that re-emits bullets it already saw via the
+    // injected <profile> block.
+    if contains(prior, "- ${bullet}\n") || contains(prior, "- ${bullet}") {
+      continue
+    }
     let header = "\n\n## Auto-learned ${today}\n"
     let body = if contains(prior, header) {
       "- ${bullet}\n"
@@ -308,6 +315,50 @@ fn build_tools(task_id, dir) {
   )
   registry = tool_define(
     registry,
+    "save_user_pref",
+    "Save a durable user preference learned in THIS conversation. Call this when the user explicitly states something they'd want remembered next time (branch policy, default response shape, naming conventions, framework choices, tone). Idempotent: bullets already in the profile are skipped. Scope: 'user' (any project), 'project' (this repo), 'cwd' (this experiment). Don't call this for facts derivable from the code.",
+    {
+    parameters: {
+    bullet: {
+    type: "string",
+    description: "One-line preference, written as the user would describe it. Example: \"All services should default to JSON responses with a status field, e.g. {status: 'ok'}.\"",
+  },
+    scope: {type: "string", description: "Where to save it: 'user', 'project', or 'cwd'. Default: 'project'."},
+    reason: {type: "string", description: "Optional audit note: which user message you learned this from."},
+  },
+    returns: {type: "string"},
+    handler: { args ->
+    let bullet = (args?.bullet ?? "").trim()
+    if bullet == "" {
+      return "Error: bullet was empty."
+    }
+    let scope = (args?.scope ?? "project").trim()
+    let allowed = ["user", "project", "cwd"]
+    var ok = false
+    for s in allowed {
+      if scope == s {
+        ok = true
+      }
+    }
+    if !ok {
+      return "Error: scope must be one of 'user', 'project', 'cwd'. Got '${scope}'."
+    }
+    let target = profile_path_for_scope(scope)
+    let prior = if file_exists(target) {
+    read_file(target)
+  } else {
+    ""
+  }
+    if contains(prior, "- ${bullet}") {
+      return "Already saved (no-op)."
+    }
+    append_profile_writes([{scope: scope, bullet: bullet}])
+    "Saved to ${scope} profile."
+  },
+  },
+  )
+  registry = tool_define(
+    registry,
     "ask_question",
     "Ask the user exactly one short question (max 3 sentences). The harness pauses after this and resumes when the user answers. Always offer a default or example so they don't have to think hard.",
     {
@@ -336,12 +387,12 @@ fn build_tools(task_id, dir) {
   registry = tool_define(
     registry,
     "exit_plan_mode",
-    "Emit the final structured plan and end the conversation. Pass the plan as a JSON object (or JSON-stringified). Always include profile_writes (possibly empty) for any durable preferences you learned this turn.",
+    "Emit the final structured plan and end the conversation. Pass the plan as a JSON object (or JSON-stringified). To save durable user preferences, call save_user_pref BEFORE this — exit_plan_mode does not handle preferences anymore.",
     {
     parameters: {
     plan: {
     type: "string",
-    description: "The plan as a JSON object. Top-level keys: mode, direction, targets, grounding, tasks, verification, ready, profile_writes.",
+    description: "The plan as a JSON object. Top-level keys: mode, direction, targets, grounding, tasks, verification, ready.",
   },
   },
     returns: {type: "string"},
@@ -360,6 +411,9 @@ fn build_tools(task_id, dir) {
   },
   },
   )
+  // profile_writes inside the plan body remains a defensive fallback
+  // for transcripts produced before save_user_pref existed; the tool
+  // is the new source of truth.
   // Idempotent — first plan in this iteration sticks.
   return registry
 }
@@ -372,18 +426,11 @@ fn system_prompt(profile_block) {
   return """
 You are a planning partner pairing with the user. The user types one short message; you reply with one short question, or commit to a final plan. A whole conversation is typically 1–5 exchanges.
 
-This invocation is ONE STEP of that conversation. A step is: optional discovery, then exactly one call to a terminal tool — ask_question or exit_plan_mode. The harness ends the step automatically the moment that terminal tool succeeds; you do not need to emit ##DONE## or anything else.
+This invocation is ONE STEP of that conversation. A step is: optional discovery (read/find), optional preference-saves (save_user_pref), then exactly one TERMINAL tool — ask_question or exit_plan_mode — that ends the step. Non-terminal tools can be called as many times as you need before the terminal one. The harness ends the step automatically the moment that terminal tool succeeds; you do not need to emit ##DONE## or anything else.
 
 Workflow this step:
 1. The user message starts with a <workspace> block listing every file (path + line count + first non-empty line). Treat that as your starting orientation; you usually don't need to call `find` to learn the layout. Use `find(query)` for token searches across filenames AND content (one tool — pass a single token like "auth", not a phrase). Use `read(path)` to fetch a specific file. Look BEFORE you ask — don't ask about facts that are obvious from the workspace block or from a read.
-2. Decide whether to ask or commit. You are a planning *partner*, not a code-completion model — defaulting to "I'll just pick" silently is the wrong move. Ask via ask_question(...) whenever ANY of the following is true:
-   - The user's request is open-ended ("improve performance", "make it more robust", "clean up", "refactor"). The scope is the question.
-   - A design parameter is not pinned by the code: rate limits, TTLs, cache sizes, library choices, error codes, retry/backoff, log verbosity, naming.
-   - There are 2+ sensible places to put the new code and the convention isn't obvious.
-   - The change is destructive or hard to undo: deleting/renaming files, dropping schema, mass rewrites, removing public API.
-   - You have a complete plan but at least one parameter you guessed at. In that case, summarize the plan in 1-2 sentences inside the question and ask "does this sound right? happy to adjust X/Y/Z." That's still ONE question and gives the user a chance to redirect cheaply.
-
-   Only call exit_plan_mode directly when the request is concrete AND every choice in the plan is pinned by the code or by a prior answer in this conversation.
+2. End the step with exactly one tool call — `ask_question(question="...")` or `exit_plan_mode(plan=...)`. NEVER answer in prose; if you find yourself writing "Before I plan, I need to understand..." or "Let me ask about X, Y, Z...", that's prose — stop, pick the single most important one, and call ask_question with that one. You are a planning *partner*, so defaulting to "I'll just pick" silently is wrong: ask whenever the request is open-ended (e.g. "improve performance"), a design parameter isn't pinned by the code (limits, TTLs, library choices, error codes, naming), there are multiple sensible placement spots, the change is destructive (deletes/renames/schema drops), or your plan has any parameter you guessed at (in which case lead the question with a 1-sentence plan summary and "sound good, or adjust X?"). Only call exit_plan_mode directly when the request is concrete AND every choice in the plan is pinned by the code or by an answer earlier in this conversation.
 
 If the user's request looks like a direct question (e.g. "explain this repo"), call exit_plan_mode without asking — the plan describes the reading and synthesis the implementation phase will produce; you do not answer in free prose.
 
@@ -406,11 +453,10 @@ Plan schema (exit_plan_mode):
   "grounding": [{"path": "...", "role": "sibling_exemplar|convention_anchor|source_under_change", "why": "phrase"}],
   "tasks": ["concrete step 1 referencing real paths/symbols", "..."],
   "verification": ["command or check"],
-  "ready": true,
-  "profile_writes": [{"scope": "user|project|cwd", "bullet": "Durable preference, e.g. 'Branch policy: edits go directly to main unless I say otherwise.'"}]
+  "ready": true
 }
 
-profile_writes: ONLY durable preferences the user expressed THIS conversation that would save you from re-asking next time. Never save derivable facts (paths, structure, code). Never save fix recipes. Empty list is fine.
+Saving user preferences: when the user expresses a durable preference IN THIS CONVERSATION (answers to your questions, or the original task text) that you'd want to remember next time — branch policy, response-shape defaults, naming conventions, framework choices, tone — call `save_user_pref(bullet="...", scope="user|project|cwd")` BEFORE exit_plan_mode. Don't save anything already shown in the <profile> block above (it's already saved). Don't save derivable facts (paths, structure, code) or fix recipes. If the user expressed no new preferences this turn, don't call save_user_pref at all.
 
 For read-only / "explain this" tasks: still call exit_plan_mode. The plan should describe the reading and the answer the implementation phase will produce — e.g. tasks=["Read README, api.ts, auth-guard.ts", "Write 2-paragraph explanation citing those paths"], mode="plan_then_execute".
 
@@ -459,7 +505,7 @@ fn build_user_prompt(task, qa_history) {
   lines = lines
     + [
     "",
-    "End this step with EXACTLY ONE call: ask_question or exit_plan_mode. The harness terminates immediately after. Anything else is wasted.",
+    "End this step with one TERMINAL call: ask_question or exit_plan_mode. The harness terminates immediately after the terminal call. Non-terminal tools (read, find, save_user_pref) can be called freely before the terminal one.",
   ]
   return join(lines, "\n")
 }

--- a/experiments/burin-mini/pipeline_qmode.harn
+++ b/experiments/burin-mini/pipeline_qmode.harn
@@ -187,47 +187,14 @@ fn append_profile_writes(profile_writes) {
 }
 
 // -----------------------------------------------------------------------------
-// Plan schema (compatible with burin-code's plan-json-schema partial).
-// -----------------------------------------------------------------------------
-
-fn _plan_schema() {
-  return {
-    type: "object",
-    required: ["mode", "direction", "tasks", "ready"],
-    properties: {
-    mode: {type: "string", enum: ["fast_execute", "plan_then_execute"]},
-    direction: {type: "string"},
-    targets: {type: "array", items: {type: "string"}},
-    grounding: {
-    type: "array",
-    items: {
-    type: "object",
-    properties: {path: {type: "string"}, role: {type: "string"}, why: {type: "string"}},
-  },
-  },
-    tasks: {type: "array", items: {type: "string"}},
-    verification: {type: "array", items: {type: "string"}},
-    ready: {type: "boolean"},
-    profile_writes: {
-    type: "array",
-    items: {
-    type: "object",
-    properties: {scope: {type: "string", enum: ["user", "project", "cwd"]}, bullet: {type: "string"}},
-  },
-  },
-  },
-  }
-}
-
-// -----------------------------------------------------------------------------
 
 // Repo map (Aider-style orientation, but token-cheap).
 //
 // We front-load the workspace tree + a one-line summary per file so the model
-// doesn't burn iterations on `glob` just to learn the layout. The first
-// non-empty line of each file is a surprisingly strong proxy for "what is
-// this file" across markdown, JS/TS, Python, shell, JSON, Rust, etc. — and
-// avoids the need for tree-sitter symbol extraction we don't have here.
+// doesn't burn iterations to learn the layout. The first non-empty line of
+// each file is a surprisingly strong proxy for "what is this file" across
+// markdown, JS/TS, Python, shell, JSON, Rust, etc. — and avoids tree-sitter
+// symbol extraction we don't have here.
 
 // -----------------------------------------------------------------------------
 
@@ -284,7 +251,7 @@ fn repo_map_text() {
 // Tools available to the model.
 // -----------------------------------------------------------------------------
 
-fn build_tools(task_id, dir) {
+fn build_tools(dir) {
   let pending_p = path_join(dir, "pending.json")
   let plan_p = path_join(dir, "plan.json")
   var registry = tool_registry()
@@ -324,7 +291,6 @@ fn build_tools(task_id, dir) {
     description: "One-line preference, written as the user would describe it. Example: \"All services should default to JSON responses with a status field, e.g. {status: 'ok'}.\"",
   },
     scope: {type: "string", description: "Where to save it: 'user', 'project', or 'cwd'. Default: 'project'."},
-    reason: {type: "string", description: "Optional audit note: which user message you learned this from."},
   },
     returns: {type: "string"},
     handler: { args ->
@@ -387,7 +353,7 @@ fn build_tools(task_id, dir) {
   registry = tool_define(
     registry,
     "exit_plan_mode",
-    "Emit the final structured plan and end the conversation. Pass the plan as a JSON object (or JSON-stringified). To save durable user preferences, call save_user_pref BEFORE this — exit_plan_mode does not handle preferences anymore.",
+    "Emit the final structured plan and end the conversation. Pass the plan as a JSON object (or JSON-stringified). To save durable user preferences, call save_user_pref BEFORE this.",
     {
     parameters: {
     plan: {
@@ -405,16 +371,11 @@ fn build_tools(task_id, dir) {
     raw
   }
       write_file(plan_p, json_stringify(plan))
-      append_profile_writes(plan?.profile_writes ?? [])
     }
     "Plan recorded. The harness will end the step now."
   },
   },
   )
-  // profile_writes inside the plan body remains a defensive fallback
-  // for transcripts produced before save_user_pref existed; the tool
-  // is the new source of truth.
-  // Idempotent — first plan in this iteration sticks.
   return registry
 }
 
@@ -551,15 +512,17 @@ pipeline default() {
     path_join(dir, "last-prompt.txt"),
     "===SYSTEM===\n${sys_prompt}\n===USER===\n${user_prompt}\n",
   )
-  // 10 iterations is plenty once `glob` returns useful results (rg-backed,
-  // not the broken `ls` version that wasted 5+ iterations on errors).
+  // turn_policy forces a tool call (or explicit yield) on every iteration —
+  // without it qwen3.6 happily emits prose + ##DONE##. stop_after_successful_tools
+  // ends the loop the moment a terminal tool succeeds (Vercel AI SDK's
+  // `stopWhen: hasToolCall(...)` / OpenAI Agents SDK's `StopAtTools(...)`).
   let result = agent_loop(
     user_prompt,
     sys_prompt,
     {
     provider: provider_name(),
     model: generator_model(),
-    tools: build_tools(task_id, dir),
+    tools: build_tools(dir),
     tool_format: "native",
     temperature: 0.2,
     max_tokens: 2048,
@@ -569,13 +532,6 @@ pipeline default() {
     stop_after_successful_tools: ["ask_question", "exit_plan_mode"],
   },
   )
-  // Force a tool call (or explicit yield) on every iteration; without
-  // this, qwen3.6 happily emits a prose answer + ##DONE##. With it,
-  // the model has to keep using tools until one of them is terminal.
-  // Stop the loop the moment a terminal tool succeeds — same shape as
-  // Vercel AI SDK's `stopWhen: hasToolCall(...)` and OpenAI Agents
-  // SDK's `StopAtTools(...)`.
-  // Step outcome for the driver to consume.
   let outcome = if file_exists(path_join(dir, "plan.json")) {
     "exit_plan_mode"
   } else {

--- a/experiments/burin-mini/qmode_inspect.py
+++ b/experiments/burin-mini/qmode_inspect.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Inspect a qmode task's state for context-management bugs.
+
+Usage: qmode_inspect.py <task_dir>
+
+Checks (each prints OK / WARN / FAIL):
+- Task metadata is present and well-formed.
+- qa.jsonl entries are well-formed and chronologically ordered.
+- Pending and plan are mutually exclusive.
+- llm-mock.jsonl records have inputs that grow monotonically with qa history.
+- The system prompt appears at most once per recorded LLM input.
+- The latest recorded LLM input matches the rebuilt prompt for the
+  current qa.jsonl (i.e. no drift between disk state and what the
+  pipeline last sent).
+- Total token usage by call (flag any single call over 8192 input tokens).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}")
+
+
+def warn(msg: str) -> None:
+    print(f"WARN: {msg}")
+
+
+def ok(msg: str) -> None:
+    print(f"OK:   {msg}")
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    out: list[dict] = []
+    for i, line in enumerate(path.read_text().splitlines(), 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError as e:
+            fail(f"{path}:{i} not valid JSON: {e}")
+    return out
+
+
+def main(task_dir: str) -> int:
+    td = Path(task_dir)
+    if not td.is_dir():
+        fail(f"not a directory: {td}")
+        return 2
+
+    print(f"=== qmode inspect: {td} ===")
+
+    # Task metadata.
+    task_meta_path = td / "task.json"
+    if not task_meta_path.exists():
+        fail("task.json missing")
+    else:
+        try:
+            task_meta = json.loads(task_meta_path.read_text())
+            if not task_meta.get("task"):
+                fail("task.json missing 'task' field")
+            else:
+                ok(f"task: {task_meta['task'][:80]}")
+        except json.JSONDecodeError as e:
+            fail(f"task.json not valid JSON: {e}")
+
+    # QA history.
+    qa = load_jsonl(td / "qa.jsonl")
+    print(f"INFO: qa entries = {len(qa)}")
+    last_ts = ""
+    for i, entry in enumerate(qa, 1):
+        if not entry.get("question"):
+            fail(f"qa[{i}] missing question")
+        if "answer" not in entry:
+            fail(f"qa[{i}] missing answer")
+        ts = entry.get("answered_at", "")
+        if ts and last_ts and ts < last_ts:
+            warn(f"qa[{i}] timestamps out of order ({ts} < {last_ts})")
+        last_ts = ts
+
+    pending = td / "pending.json"
+    plan = td / "plan.json"
+    if pending.exists() and plan.exists():
+        fail("both pending.json AND plan.json present (mutual exclusion violated)")
+    elif pending.exists():
+        try:
+            p = json.loads(pending.read_text())
+            ok(f"pending question: {p.get('question', '')[:80]}")
+        except json.JSONDecodeError as e:
+            fail(f"pending.json not valid JSON: {e}")
+    elif plan.exists():
+        try:
+            p = json.loads(plan.read_text())
+            ok(f"plan ready={p.get('ready')} tasks={len(p.get('tasks', []))} targets={p.get('targets', [])}")
+            for required in ("mode", "direction", "tasks", "ready"):
+                if required not in p:
+                    fail(f"plan.json missing '{required}'")
+            for g in p.get("grounding", []):
+                gp = g.get("path", "")
+                if gp:
+                    abs_gp = (td.parent.parent / "workspace" / gp).resolve()
+                    if not abs_gp.exists():
+                        warn(f"plan.grounding path does not exist on disk: {gp}")
+        except json.JSONDecodeError as e:
+            fail(f"plan.json not valid JSON: {e}")
+    else:
+        warn("no pending.json or plan.json — pipeline likely errored before terminal tool call")
+
+    # LLM mock recording — sanity-check call count and input/output token sizes.
+    mock_path = td / "llm-mock.jsonl"
+    mock = load_jsonl(mock_path)
+    print(f"INFO: llm-mock calls = {len(mock)}")
+    last_in = None
+    for i, call in enumerate(mock, 1):
+        in_tok = call.get("input_tokens")
+        out_tok = call.get("output_tokens")
+        if in_tok is not None:
+            if in_tok > 16384:
+                warn(f"call[{i}] input_tokens={in_tok} (very large)")
+            if last_in is not None and in_tok < last_in:
+                warn(f"call[{i}] input_tokens={in_tok} dropped vs prior {last_in} (compaction or reset?)")
+            last_in = in_tok
+        # Tool-call-shape audit.
+        tcs = call.get("tool_calls", [])
+        names = [t.get("name") for t in tcs]
+        terminal_in_call = [n for n in names if n in ("ask_question", "exit_plan_mode")]
+        if len(terminal_in_call) > 1:
+            warn(f"call[{i}] >1 terminal tool in same iteration: {terminal_in_call}")
+
+    # Last-prompt.txt audit.
+    lp = td / "last-prompt.txt"
+    if lp.exists():
+        body = lp.read_text()
+        sys_marker = body.count("===SYSTEM===")
+        usr_marker = body.count("===USER===")
+        if sys_marker != 1 or usr_marker != 1:
+            fail(f"last-prompt.txt has SYSTEM={sys_marker} USER={usr_marker}; expected 1/1")
+        # Detect empty Q&A in user section (the bug we just fixed).
+        if "- Q: \n" in body or "  A: \n" in body:
+            fail("last-prompt.txt has empty Q or A line — interpolation bug")
+        if qa:
+            for entry in qa:
+                if entry.get("answer"):
+                    needle = entry["answer"][:30]
+                    if needle not in body:
+                        warn(f"prior answer '{needle}...' not present in last-prompt.txt")
+
+    # Q&A ↔ tool-call alignment is hard to check without parsing
+    # provider-specific shapes. We'll trust the `tools.calls` count
+    # in the agent_loop result if/when we persist it; for now this is
+    # best-effort.
+
+    print("=== inspect done ===")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(__doc__)
+        sys.exit(64)
+    sys.exit(main(sys.argv[1]))

--- a/experiments/burin-mini/run_qmode.sh
+++ b/experiments/burin-mini/run_qmode.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Driver for the question-at-a-time planning agent (qmode).
+#
+# Subcommands:
+#   init <task_id> <task_string>     Create task dir + run first turn.
+#   answer <task_id> <answer_text>   Record answer for pending question, run next turn.
+#   show <task_id>                   Print pending question or final plan.
+#   reset <task_id>                  Wipe the task dir.
+#   inspect <task_id>                Run qmode_inspect.py on the latest run record.
+#
+# Exit codes:
+#   0 = plan emitted (also after `show` of a plan, or `reset`)
+#   10 = paused on a pending question (also after `show` of a pending)
+#   non-zero = harness or validation error
+#
+# Env overrides:
+#   QMODE_PROVIDER (default: ollama)
+#   QMODE_MODEL    (default: qwen3.6:35b-a3b-coding-nvfp4)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPERIMENT_DIR="$REPO_ROOT/experiments/burin-mini"
+PROVIDER="${QMODE_PROVIDER:-ollama}"
+MODEL="${QMODE_MODEL:-qwen3.6:35b-a3b-coding-nvfp4}"
+
+usage() {
+  sed -n '2,18p' "${BASH_SOURCE[0]}"
+  exit 64
+}
+
+[[ $# -lt 1 ]] && usage
+cmd="$1"; shift
+
+task_dir() {
+  echo "$EXPERIMENT_DIR/.qmode/$1"
+}
+
+ensure_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "[run_qmode] ERROR: jq is required."; exit 2
+  fi
+}
+
+run_pipeline() {
+  local task_id="$1"
+  local task_arg="${2:-}"
+  local td; td="$(task_dir "$task_id")"
+  mkdir -p "$td"
+  local mock_path="$td/llm-mock.jsonl"
+  pushd "$REPO_ROOT" >/dev/null
+  set +e
+  QMODE_TASK_ID="$task_id" \
+  BURIN_MINI_PROVIDER="$PROVIDER" \
+  BURIN_MINI_GENERATOR_MODEL="$MODEL" \
+    cargo run --quiet --bin harn -- playground \
+      --host "$EXPERIMENT_DIR/host.harn" \
+      --script "$EXPERIMENT_DIR/pipeline_qmode.harn" \
+      --task "$task_arg" \
+      --llm-mock-record "$mock_path" \
+      2>&1 | tee "$td/last-stdout.log"
+  local rc=${PIPESTATUS[0]}
+  set -e
+  popd >/dev/null
+  return "$rc"
+}
+
+post_run_dispatch() {
+  local task_id="$1"
+  local td; td="$(task_dir "$task_id")"
+  local step="(missing)"
+  [[ -f "$td/step.txt" ]] && step="$(cat "$td/step.txt")"
+  if [[ -f "$td/plan.json" ]]; then
+    echo "[run_qmode] step=${step}"
+    echo "=== PLAN ==="
+    jq . "$td/plan.json"
+    return 0
+  fi
+  if [[ -f "$td/pending.json" ]]; then
+    local qa_count=0
+    [[ -f "$td/qa.jsonl" ]] && qa_count=$(wc -l < "$td/qa.jsonl" | tr -d ' ')
+    echo "[run_qmode] step=${step}  prior_q&a=${qa_count}"
+    echo "=== PENDING QUESTION ==="
+    jq -r '.question' "$td/pending.json"
+    return 10
+  fi
+  echo "[run_qmode] step=${step}"
+  echo "[run_qmode] ERROR: no plan.json or pending.json after run."
+  if [[ -f "$td/diag.json" ]]; then
+    echo "--- diag.json ---"
+    jq . "$td/diag.json"
+  fi
+  echo "--- last-stdout.log (tail) ---"
+  tail -40 "$td/last-stdout.log" 2>/dev/null || true
+  return 1
+}
+
+case "$cmd" in
+  init)
+    [[ $# -ge 2 ]] || usage
+    ensure_jq
+    task_id="$1"; shift
+    task_text="$*"
+    td="$(task_dir "$task_id")"
+    if [[ -d "$td" ]]; then
+      echo "[run_qmode] ERROR: task '$task_id' already exists. Use 'reset' first or 'answer' to continue."
+      exit 1
+    fi
+    mkdir -p "$td"
+    run_pipeline "$task_id" "$task_text" || true
+    post_run_dispatch "$task_id"
+    ;;
+  answer)
+    [[ $# -ge 2 ]] || usage
+    ensure_jq
+    task_id="$1"; shift
+    answer_text="$*"
+    td="$(task_dir "$task_id")"
+    if [[ ! -f "$td/pending.json" ]]; then
+      echo "[run_qmode] ERROR: no pending question for task '$task_id'."
+      exit 1
+    fi
+    if [[ -f "$td/plan.json" ]]; then
+      echo "[run_qmode] task already complete. Plan:"
+      jq . "$td/plan.json"
+      exit 0
+    fi
+    q="$(jq -r '.question' "$td/pending.json")"
+    asked="$(jq -r '.asked_at' "$td/pending.json")"
+    jq -nc --arg q "$q" --arg a "$answer_text" --arg ask "$asked" --arg ans "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      '{question:$q, answer:$a, asked_at:$ask, answered_at:$ans}' >> "$td/qa.jsonl"
+    rm "$td/pending.json"
+    task_text="$(jq -r '.task' "$td/task.json")"
+    run_pipeline "$task_id" "$task_text" || true
+    post_run_dispatch "$task_id"
+    ;;
+  show)
+    [[ $# -ge 1 ]] || usage
+    ensure_jq
+    task_id="$1"
+    td="$(task_dir "$task_id")"
+    if [[ -f "$td/plan.json" ]]; then
+      echo "=== PLAN ==="
+      jq . "$td/plan.json"
+      exit 0
+    fi
+    if [[ -f "$td/pending.json" ]]; then
+      echo "=== PENDING ==="
+      jq . "$td/pending.json"
+      echo
+      echo "=== Q&A SO FAR ==="
+      [[ -f "$td/qa.jsonl" ]] && cat "$td/qa.jsonl" | jq . || echo "(none)"
+      exit 10
+    fi
+    echo "[run_qmode] no state for '$task_id'."
+    exit 1
+    ;;
+  reset)
+    [[ $# -ge 1 ]] || usage
+    task_id="$1"
+    td="$(task_dir "$task_id")"
+    rm -rf "$td"
+    echo "[run_qmode] reset $task_id"
+    ;;
+  inspect)
+    [[ $# -ge 1 ]] || usage
+    task_id="$1"
+    python3 "$EXPERIMENT_DIR/qmode_inspect.py" "$(task_dir "$task_id")"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/experiments/burin-mini/run_qmode.sh
+++ b/experiments/burin-mini/run_qmode.sh
@@ -68,6 +68,21 @@ run_pipeline() {
   return "$rc"
 }
 
+record_answer_and_continue() {
+  local task_id="$1"
+  local answer_text="$2"
+  local td; td="$(task_dir "$task_id")"
+  local q asked
+  q="$(jq -r '.question' "$td/pending.json")"
+  asked="$(jq -r '.asked_at' "$td/pending.json")"
+  jq -nc --arg q "$q" --arg a "$answer_text" --arg ask "$asked" --arg ans "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{question:$q, answer:$a, asked_at:$ask, answered_at:$ans}' >> "$td/qa.jsonl"
+  rm "$td/pending.json"
+  local task_text
+  task_text="$(jq -r '.task' "$td/task.json")"
+  run_pipeline "$task_id" "$task_text" "$@" || true
+}
+
 post_run_dispatch() {
   local task_id="$1"
   local td; td="$(task_dir "$task_id")"
@@ -128,13 +143,7 @@ case "$cmd" in
       jq . "$td/plan.json"
       exit 0
     fi
-    q="$(jq -r '.question' "$td/pending.json")"
-    asked="$(jq -r '.asked_at' "$td/pending.json")"
-    jq -nc --arg q "$q" --arg a "$answer_text" --arg ask "$asked" --arg ans "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-      '{question:$q, answer:$a, asked_at:$ask, answered_at:$ans}' >> "$td/qa.jsonl"
-    rm "$td/pending.json"
-    task_text="$(jq -r '.task' "$td/task.json")"
-    run_pipeline "$task_id" "$task_text" || true
+    record_answer_and_continue "$task_id" "$answer_text"
     post_run_dispatch "$task_id"
     ;;
   show)
@@ -220,13 +229,8 @@ case "$cmd" in
         echo "[qmode chat] empty answer — re-prompting."
         continue
       fi
-      asked="$(jq -r '.asked_at' "$td/pending.json")"
-      jq -nc --arg q "$q" --arg a "$answer_text" --arg ask "$asked" --arg ans "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-        '{question:$q, answer:$a, asked_at:$ask, answered_at:$ans}' >> "$td/qa.jsonl"
-      rm "$td/pending.json"
-      task_text="$(jq -r '.task' "$td/task.json")"
       echo "[qmode chat] thinking..."
-      run_pipeline "$task_id" "$task_text" >/dev/null
+      record_answer_and_continue "$task_id" "$answer_text" >/dev/null
     done
     ;;
   *)

--- a/experiments/burin-mini/run_qmode.sh
+++ b/experiments/burin-mini/run_qmode.sh
@@ -2,7 +2,10 @@
 # Driver for the question-at-a-time planning agent (qmode).
 #
 # Subcommands:
-#   init <task_id> <task_string>     Create task dir + run first turn.
+#   chat <task_id> [<task_string>]   Interactive REPL: drives init+answer in a
+#                                    loop, prompting at the terminal until a
+#                                    plan lands. Resumes if task already exists.
+#   init <task_id> <task_string>     Create task dir + run first turn (one-shot).
 #   answer <task_id> <answer_text>   Record answer for pending question, run next turn.
 #   show <task_id>                   Print pending question or final plan.
 #   reset <task_id>                  Wipe the task dir.
@@ -166,6 +169,65 @@ case "$cmd" in
     [[ $# -ge 1 ]] || usage
     task_id="$1"
     python3 "$EXPERIMENT_DIR/qmode_inspect.py" "$(task_dir "$task_id")"
+    ;;
+  chat)
+    [[ $# -ge 1 ]] || usage
+    ensure_jq
+    task_id="$1"; shift
+    td="$(task_dir "$task_id")"
+    initial_task="${*:-}"
+    if [[ ! -d "$td" ]]; then
+      if [[ -z "$initial_task" ]]; then
+        echo -n "Task description: "
+        read -r initial_task
+      fi
+      echo "[qmode chat] starting task '$task_id'..."
+      mkdir -p "$td"
+      run_pipeline "$task_id" "$initial_task" >/dev/null
+    elif [[ -f "$td/plan.json" ]]; then
+      echo "[qmode chat] task '$task_id' already complete. Plan:"
+      jq . "$td/plan.json"
+      exit 0
+    fi
+    while true; do
+      if [[ -f "$td/plan.json" ]]; then
+        echo
+        echo "=== PLAN ==="
+        jq . "$td/plan.json"
+        echo
+        echo "[qmode chat] done."
+        exit 0
+      fi
+      if [[ ! -f "$td/pending.json" ]]; then
+        echo "[qmode chat] no plan and no pending question — pipeline failed. See:"
+        echo "  $td/diag.json"
+        echo "  $td/last-stdout.log"
+        exit 1
+      fi
+      qa_count=0
+      [[ -f "$td/qa.jsonl" ]] && qa_count=$(wc -l < "$td/qa.jsonl" | tr -d ' ')
+      q="$(jq -r '.question' "$td/pending.json")"
+      echo
+      echo "── Q$((qa_count + 1)) ──"
+      echo "$q"
+      echo -n "> "
+      if ! IFS= read -r answer_text; then
+        echo
+        echo "[qmode chat] EOF — exiting. Resume with: $0 chat $task_id"
+        exit 130
+      fi
+      if [[ -z "$answer_text" ]]; then
+        echo "[qmode chat] empty answer — re-prompting."
+        continue
+      fi
+      asked="$(jq -r '.asked_at' "$td/pending.json")"
+      jq -nc --arg q "$q" --arg a "$answer_text" --arg ask "$asked" --arg ans "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        '{question:$q, answer:$a, asked_at:$ask, answered_at:$ans}' >> "$td/qa.jsonl"
+      rm "$td/pending.json"
+      task_text="$(jq -r '.task' "$td/task.json")"
+      echo "[qmode chat] thinking..."
+      run_pipeline "$task_id" "$task_text" >/dev/null
+    done
     ;;
   *)
     usage


### PR DESCRIPTION
## Summary

- New experimental sibling pipeline `experiments/burin-mini/pipeline_qmode.harn` that prototypes a **question-at-a-time** planning agent against local Ollama models. The agent asks the user one design question at a time (via an `ask_question` tool), uses read-only discovery tools between questions, and emits a structured plan via `exit_plan_mode` — schema-compatible with `burin-code`'s plan-json-schema partial so a future migration is a path swap.
- Hierarchical **`USER_PROFILE.md`** loader (user-global ⊕ project ⊕ cwd) auto-injected into the system prompt, with a `save_user_pref` tool the model calls when the user states a durable preference. Dedup is enforced at write-time.
- Driver script `run_qmode.sh` with subcommands `init`, `answer`, `show`, `inspect`, `reset`, and a new **`chat` REPL** that drives the whole back-and-forth interactively at the terminal — no exit-code dance.
- Audit script `qmode_inspect.py` that walks the on-disk transcript for context-management bugs (system-prompt drift, tool-result alignment, monotonic input tokens, terminal-tool exclusivity per iteration).
- **Side-fix:** `crates/harn-cli/tests/persona_cli.rs::persona_runtime_status_tick_and_budget_are_persisted` was a deterministic time-bomb (passed on 2026-04-24, failed on every later day). Added `--at` to `persona status / pause / resume / disable` for parity with `tick / trigger / spend`, and pinned the test's `status` call to a deterministic timestamp.
- **Quickref doc:** `docs/llm/harn-quickref.md` now documents `stop_after_successful_tools` (the existing harn-vm primitive that ends `agent_loop` the moment a terminal tool succeeds — Vercel AI SDK / OpenAI Agents SDK pattern).

## Design choices

After auditing the prior search/glob split's transcripts (10-iter timeouts on the rate-limit task) and benchmarking against agentic-search practice (Claude Code, Cline, Aider's repo map, the 2026 BM25-vs-embeddings consensus), this pipeline:

- **Front-loads an Aider-style workspace overview** (path + line count + first-non-empty-line per file) into the user prompt. Eliminates the glob+probe iterations the agent used to burn just to learn the layout.
- **Replaces `search` + `glob`** with one **`find`** tool that searches filenames AND content in a single call, echoes the query back on zero matches, and never returns information-poor empty strings.
- Uses **`rg --sort path`** everywhere — kills the only real determinism leak (filesystem walk order) at temp 0.
- **Bumps default sampling** to temperature 0.2 for planning-agent stability.
- **System prompt** clarifies when to ask vs commit: open-ended requests, unpinned design parameters (limits / TTLs / library choices / error codes), multiple sensible placement spots, and destructive ops all warrant `ask_question`. Otherwise `exit_plan_mode` directly. Includes a confirm-the-plan pattern for the case where the plan is grounded but one parameter was guessed.
- **No embeddings.** Per the 2026 RAG-vs-grep consensus: BM25/grep matches or beats dense retrieval on code, especially in small-to-medium repos. Aider-style orientation + a smart unified `find` covers the gap without an ONNX/sentence-transformer stack.

## Why it stops at plan emission

This experiment ships as an **experiment** under `experiments/burin-mini/`. Plan execution is intentionally out of scope — the plan is meant to be pasted into a fresh agent (or `burin-code`'s Planner) for implementation. The eventual destination (replatforming Plan mode in burin-code's TUI/IDE/CLI onto this approach) will be tracked as separate issues.

## Test plan

- [x] `make all` passes (`cargo fmt`, clippy, full workspace tests, conformance, markdown lint, Harn lint/format, highlight drift, docs snippets)
- [x] All 2090 workspace tests pass (the prior persona time-bomb is fixed)
- [x] `experiments/burin-mini/pipeline_qmode.harn` and `lib/workspace.harn` pass `harn check` / `harn fmt --check` / `harn lint`
- [x] Eval set converges with grounded plans:
  - "Add per-IP rate limiting to the auth middleware" → asks limit + placement, then plan referencing real paths
  - "Add caching to api.ts" → asks cache shape + TTL, then plan
  - "Improve performance" (open-ended) → asks scope, then plan
  - "Explain what this codebase does in two paragraphs" → exits with read-and-synthesize plan, no question
  - "Add an /admin/stats endpoint that returns usage info" → asks auth scope (3/3 retries after the system-prompt fix; previously emitted 180-block prose)
- [x] Profile capture verified: `save_user_pref` writes to `~/.harn/USER_PROFILE.md` or `<workspace>/.harn/USER_PROFILE.md` based on `scope`; dedup silences re-emits of bullets already in the profile block
- [x] Three-layer profile loader injects all present scopes into the system prompt (visible in `last-prompt.txt`)
- [x] Local-only enforcement: `BURIN_MINI_PROVIDER=anthropic` aborts the pipeline before any LLM call
- [x] Determinism: `rg --sort path` produces stable file ordering across runs
- [x] Persona test fix verified: `cargo nextest run -p harn-cli --test persona_cli` 6/6 pass, including the previously-failing time-bomb