### PR TITLE
harn-hostlib: implement process-lifecycle tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ granular archaeology.
 
 ## Unreleased
 
+### Added
+
+- **`harn-hostlib` process-lifecycle tools (#568, #606).** Implemented
+  `run_command`, `run_test`, `run_build_command`,
+  `inspect_test_results`, and `manage_packages` under the gated
+  `tools:deterministic` hostlib surface. Process spawns use argv-only
+  execution, cwd/env/stdin/timeout handling, structured build diagnostic
+  parsing, process-local test result handles, package-manager command
+  assembly, and the public `harn_vm::process_sandbox` helpers so active
+  Linux seccomp/landlock and macOS sandbox-exec policies still apply.
+
 ### Changed
 
 - **Release scripts: harden new-workspace-crate first-release path
@@ -81,12 +92,9 @@ granular archaeology.
   arg-list invocations only, never `sh -c`, plus rev-string validation
   that rejects flag lookalikes and control bytes). The surface is
   gated by a per-session opt-in: pipelines call
-  `hostlib_enable("tools:deterministic")` before any of the seven
+  `hostlib_enable("tools:deterministic")` before any of these seven
   deterministic tools will execute, otherwise calls fail with a
-  structured error pointing at the enable builtin. Process tools
-  (`run_command`, `run_test`, `run_build_command`,
-  `inspect_test_results`, `manage_packages`) remain
-  `Unimplemented`-routed for issue C2.
+  structured error pointing at the enable builtin.
 
 - **Fair-share scheduler for worker-queue claims (#477).** New
   deficit-round-robin policy in front of `WorkerQueue::claim_next` so a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,6 +1275,7 @@ dependencies = [
  "harn-vm",
  "ignore",
  "notify",
+ "once_cell",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/harn-hostlib/Cargo.toml
+++ b/crates/harn-hostlib/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["rt", "macros", "sync", "fs", "process", "time"] }
 anyhow = "1"
 thiserror = "2"
+once_cell = "1"
 
 # Foundational dependencies for the upcoming module implementations
 # (B2/B3/B4/C1/C2/C3). They are wired in here so the workspace lockfile is

--- a/crates/harn-hostlib/README.md
+++ b/crates/harn-hostlib/README.md
@@ -21,6 +21,9 @@ scaffold (every method routed through `HostlibError::Unimplemented`).
 [#567](https://github.com/burin-labs/harn/issues/567) lights up the
 deterministic-tool surface: `search`, `read_file`, `write_file`,
 `delete_file`, `list_directory`, `get_file_outline`, and `git`.
+[#568](https://github.com/burin-labs/harn/issues/568) lights up the
+process-lifecycle surface: `run_command`, `run_test`,
+`run_build_command`, `inspect_test_results`, and `manage_packages`.
 
 | Issue | Module | What lands | Status |
 |-------|--------|-----------|--------|
@@ -31,7 +34,31 @@ deterministic-tool surface: `search`, `read_file`, `write_file`,
 | C1    | `fs_watch/`        | `subscribe`, `unsubscribe`                                                                | unimplemented |
 | #567  | `tools/` (read & search) | `search`, `read_file`, `list_directory`, `get_file_outline`, `git`                 | ✅ shipped (this issue) |
 | #567  | `tools/` (mutating)      | `write_file`, `delete_file`                                                        | ✅ shipped (this issue) |
-| C2    | `tools/` (process)       | `run_command`, `run_test`, `run_build_command`, `inspect_test_results`, `manage_packages` | unimplemented |
+| #568  | `tools/` (process)       | `run_command`, `run_test`, `run_build_command`, `inspect_test_results`, `manage_packages` | ✅ shipped |
+
+### Process tools
+
+The five process-lifecycle tools spawn real subprocesses and route through
+`harn_vm::process_sandbox`. That keeps every spawn under the active
+orchestration capability policy: Linux seccomp/landlock filters via
+`pre_exec`, macOS `sandbox-exec` wrapping, and cwd enforcement against the
+workspace roots the embedder configured.
+
+- `tools/run_command` accepts `argv: [string]` (no shell parsing), captures
+  stdout/stderr, enforces `timeout_ms` by killing the child and reporting
+  `timed_out: true`, and forwards optional `cwd`, `env`, and `stdin`.
+- `tools/run_test` runs explicit `argv` verbatim or detects a default test
+  runner from manifests in `cwd`. Pytest and vitest get a JUnit XML output
+  path so `inspect_test_results` can drill into per-test records.
+- `tools/run_build_command` runs explicit `argv` or a detected build
+  command. Cargo uses `--message-format=json-diagnostic-rendered-ansi`;
+  other runners fall back to go/generic diagnostic parsing.
+- `tools/inspect_test_results` reads the opaque `result_handle` from
+  `run_test` and parses JUnit XML, cargo libtest text, or go test text.
+- `tools/manage_packages` assembles install/add/remove/update/refresh
+  commands for cargo, npm, pnpm, yarn, pip, uv, poetry, go, swift, gradle,
+  maven, bundler, composer, and dotnet, with lockfile mtime change
+  detection.
 
 ## Why a separate crate?
 
@@ -51,7 +78,9 @@ boundary.
 ## Per-session opt-in for deterministic tools
 
 The deterministic-tool surface (`tools/{search, read_file, write_file,
-delete_file, list_directory, get_file_outline, git}`) is **gated**.
+delete_file, list_directory, get_file_outline, git, run_command,
+run_test, run_build_command, inspect_test_results, manage_packages}`) is
+**gated**.
 `install_default` registers the contract for every method, but the
 handlers refuse to run until the pipeline opts in by calling
 
@@ -63,8 +92,9 @@ hostlib_enable("tools:deterministic")
 matches the safety story called out in
 [#567](https://github.com/burin-labs/harn/issues/567): a Harn script that
 hasn't asked for filesystem / git / search access cannot get it even
-though the contract is wired in. The opt-in is per-thread, so each VM
-gets an independent enable set.
+though the contract is wired in. The same gate applies to process and
+package-manager tools. The opt-in is per-thread, so each VM gets an
+independent enable set.
 
 Embedders that want to enable the surface from Rust without going through
 the builtin can use [`tools::permissions::enable_for_test`] (test-only)

--- a/crates/harn-hostlib/src/tools/diagnostics.rs
+++ b/crates/harn-hostlib/src/tools/diagnostics.rs
@@ -1,0 +1,313 @@
+//! Build-output diagnostic parsers.
+//!
+//! Each ecosystem emits errors in a different shape. Where possible we
+//! consume the runner's machine-readable output (cargo's
+//! `--message-format=json`, gocompile's `path:line:col: text` lines).
+//! Otherwise we fall back to a generic regex sweep that picks up
+//! `path:line:col: error: message` and `error: message` patterns common to
+//! C/C++/Swift/TypeScript.
+
+/// Severity of a build diagnostic. Maps 1:1 to the schema enum at
+/// `schemas/tools/run_build_command.response.json#/$defs/Diagnostic/properties/severity`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Severity {
+    Error,
+    Warning,
+    Note,
+    Help,
+}
+
+impl Severity {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+            Severity::Note => "note",
+            Severity::Help => "help",
+        }
+    }
+
+    fn parse(token: &str) -> Option<Severity> {
+        match token.trim().to_ascii_lowercase().as_str() {
+            "error" | "fatal error" | "fatal" => Some(Severity::Error),
+            "warning" | "warn" => Some(Severity::Warning),
+            "note" | "info" => Some(Severity::Note),
+            "help" | "hint" => Some(Severity::Help),
+            _ => None,
+        }
+    }
+}
+
+/// One parsed diagnostic. Matches the `Diagnostic` schema in
+/// `run_build_command.response.json`.
+#[derive(Debug, Clone)]
+pub(crate) struct Diagnostic {
+    pub(crate) severity: Severity,
+    pub(crate) message: String,
+    pub(crate) path: Option<String>,
+    pub(crate) line: Option<i64>,
+    pub(crate) column: Option<i64>,
+}
+
+/// Which parser to apply to the captured stdout/stderr. Determined either
+/// by the requested ecosystem or — when the caller passed argv — by
+/// pattern-matching the first argv element.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum DiagnosticSource {
+    /// Cargo with `--message-format=json` (one JSON object per line).
+    CargoJson,
+    /// `go build` / `go vet` `path:line: text` style output.
+    GoBuild,
+    /// Last-resort regex sweep over both streams.
+    Generic,
+}
+
+pub(crate) fn parse_diagnostics(
+    source: DiagnosticSource,
+    stdout: &str,
+    stderr: &str,
+) -> Vec<Diagnostic> {
+    match source {
+        DiagnosticSource::CargoJson => {
+            let mut found = parse_cargo_json(stdout);
+            // Some cargo versions still print the human-rendered tail to
+            // stderr for hard build failures — sweep it generically so we
+            // don't drop the headline on the floor.
+            if found.is_empty() {
+                found.extend(parse_generic(stderr));
+            }
+            found
+        }
+        DiagnosticSource::GoBuild => {
+            let mut combined = String::new();
+            combined.push_str(stdout);
+            combined.push('\n');
+            combined.push_str(stderr);
+            parse_go(&combined)
+        }
+        DiagnosticSource::Generic => {
+            let mut combined = String::new();
+            combined.push_str(stdout);
+            combined.push('\n');
+            combined.push_str(stderr);
+            parse_generic(&combined)
+        }
+    }
+}
+
+fn parse_cargo_json(stdout: &str) -> Vec<Diagnostic> {
+    let mut out = Vec::new();
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('{') {
+            continue;
+        }
+        let value: serde_json::Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if value.get("reason").and_then(|r| r.as_str()) != Some("compiler-message") {
+            continue;
+        }
+        let message = match value.get("message") {
+            Some(m) => m,
+            None => continue,
+        };
+        let severity = message
+            .get("level")
+            .and_then(|l| l.as_str())
+            .and_then(Severity::parse)
+            .unwrap_or(Severity::Error);
+        let text = message
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("")
+            .to_string();
+        let primary_span = message
+            .get("spans")
+            .and_then(|s| s.as_array())
+            .and_then(|spans| {
+                spans.iter().find(|s| {
+                    s.get("is_primary")
+                        .and_then(|p| p.as_bool())
+                        .unwrap_or(false)
+                })
+            });
+        let (path, line, column) = match primary_span {
+            Some(span) => (
+                span.get("file_name")
+                    .and_then(|f| f.as_str())
+                    .map(str::to_string),
+                span.get("line_start").and_then(|l| l.as_i64()),
+                span.get("column_start").and_then(|c| c.as_i64()),
+            ),
+            None => (None, None, None),
+        };
+        out.push(Diagnostic {
+            severity,
+            message: text,
+            path,
+            line,
+            column,
+        });
+    }
+    out
+}
+
+fn parse_go(text: &str) -> Vec<Diagnostic> {
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        // ./pkg/foo.go:12:3: undefined: bar
+        let (head, _) = match trimmed.split_once(": ") {
+            Some(parts) => parts,
+            None => continue,
+        };
+        let mut iter = head.splitn(3, ':');
+        let path = iter.next();
+        let line_no = iter.next();
+        let col = iter.next();
+        let (Some(path), Some(line_no)) = (path, line_no) else {
+            continue;
+        };
+        let Ok(line_no) = line_no.parse::<i64>() else {
+            continue;
+        };
+        let column = col.and_then(|c| c.parse::<i64>().ok());
+        let message = trimmed[head.len() + 2..].to_string();
+        if message.is_empty() {
+            continue;
+        }
+        out.push(Diagnostic {
+            severity: Severity::Error,
+            message,
+            path: Some(path.to_string()),
+            line: Some(line_no),
+            column,
+        });
+    }
+    out
+}
+
+fn parse_generic(text: &str) -> Vec<Diagnostic> {
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        if let Some(d) = parse_generic_line(trimmed) {
+            out.push(d);
+        }
+    }
+    out
+}
+
+fn parse_generic_line(line: &str) -> Option<Diagnostic> {
+    const SEVERITIES: &[&str] = &["fatal error", "error", "warning", "warn", "note", "help"];
+
+    // Pattern A: <head>: <severity>: <message> — head becomes path[:line[:col]].
+    for sev in SEVERITIES {
+        let needle = format!(": {sev}: ");
+        if let Some(idx) = line.find(needle.as_str()) {
+            let head = &line[..idx];
+            let message = &line[idx + needle.len()..];
+            let (path, line_no, column) = parse_path_position(head)?;
+            return Some(Diagnostic {
+                severity: Severity::parse(sev).unwrap(),
+                message: message.trim().to_string(),
+                path: Some(path),
+                line: line_no,
+                column,
+            });
+        }
+    }
+    // Pattern B: <severity>: <message> (no path).
+    for sev in SEVERITIES {
+        let prefix = format!("{sev}: ");
+        if let Some(stripped) = line.strip_prefix(prefix.as_str()) {
+            return Some(Diagnostic {
+                severity: Severity::parse(sev).unwrap(),
+                message: stripped.trim().to_string(),
+                path: None,
+                line: None,
+                column: None,
+            });
+        }
+    }
+    None
+}
+
+fn parse_path_position(text: &str) -> Option<(String, Option<i64>, Option<i64>)> {
+    // Accept path, path:line, or path:line:col.
+    let mut parts = text.split(':').collect::<Vec<_>>();
+    if parts.is_empty() {
+        return None;
+    }
+    let mut column = None;
+    let mut line = None;
+    if parts.len() >= 3 {
+        if let Ok(c) = parts[parts.len() - 1].parse::<i64>() {
+            if let Ok(l) = parts[parts.len() - 2].parse::<i64>() {
+                column = Some(c);
+                line = Some(l);
+                parts.truncate(parts.len() - 2);
+            }
+        }
+    }
+    if line.is_none() && parts.len() >= 2 {
+        if let Ok(l) = parts[parts.len() - 1].parse::<i64>() {
+            line = Some(l);
+            parts.truncate(parts.len() - 1);
+        }
+    }
+    let path = parts.join(":");
+    if path.is_empty() {
+        return None;
+    }
+    Some((path, line, column))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_cargo_json_diagnostic() {
+        let stdout = r#"{"reason":"compiler-message","message":{"message":"cannot find value `x` in this scope","level":"error","spans":[{"file_name":"src/lib.rs","line_start":3,"column_start":7,"is_primary":true}]}}"#;
+        let diags = parse_diagnostics(DiagnosticSource::CargoJson, stdout, "");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert_eq!(diags[0].path.as_deref(), Some("src/lib.rs"));
+        assert_eq!(diags[0].line, Some(3));
+        assert_eq!(diags[0].column, Some(7));
+    }
+
+    #[test]
+    fn parses_go_path_line_col() {
+        let stderr = "./pkg/foo.go:12:3: undefined: bar\n";
+        let diags = parse_diagnostics(DiagnosticSource::GoBuild, "", stderr);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].path.as_deref(), Some("./pkg/foo.go"));
+        assert_eq!(diags[0].line, Some(12));
+        assert_eq!(diags[0].column, Some(3));
+        assert_eq!(diags[0].message, "undefined: bar");
+    }
+
+    #[test]
+    fn generic_picks_up_clang_style_error() {
+        let stderr = "src/main.cpp:42:10: error: expected ';' before '}' token\n";
+        let diags = parse_diagnostics(DiagnosticSource::Generic, "", stderr);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].path.as_deref(), Some("src/main.cpp"));
+        assert_eq!(diags[0].line, Some(42));
+        assert_eq!(diags[0].column, Some(10));
+    }
+
+    #[test]
+    fn generic_picks_up_severity_only() {
+        let stderr = "warning: deprecated API call\n";
+        let diags = parse_diagnostics(DiagnosticSource::Generic, "", stderr);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Warning);
+        assert_eq!(diags[0].message, "deprecated API call");
+        assert!(diags[0].path.is_none());
+    }
+}

--- a/crates/harn-hostlib/src/tools/inspect_test_results.rs
+++ b/crates/harn-hostlib/src/tools/inspect_test_results.rs
@@ -1,0 +1,200 @@
+//! `tools/inspect_test_results` — drill into the structured per-test record
+//! from a previous `run_test`.
+//!
+//! Schema: `schemas/tools/inspect_test_results.{request,response}.json`.
+//!
+//! `run_test` stores raw stdout/stderr + the JUnit XML path it asked the
+//! runner to write into a process-local cache, keyed by an opaque
+//! `result_handle`. This builtin pulls that record out and parses it into
+//! `TestRecord`s. Parsers in [`crate::tools::test_parsers`] handle the
+//! per-runner formats (JUnit XML, cargo libtest plain text, go test text).
+//!
+//! The cache is intentionally scoped to the hostlib process: handles are
+//! ephemeral, not persisted to disk, and are not shared across embedders.
+//! That keeps the contract simple and avoids inventing a cross-session
+//! handle namespace before there's a real consumer for one.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use harn_vm::VmValue;
+use once_cell::sync::Lazy;
+
+use crate::error::HostlibError;
+use crate::tools::payload::{optional_bool, require_dict_arg, require_string};
+use crate::tools::response::ResponseBuilder;
+use crate::tools::test_parsers;
+
+pub(crate) const NAME: &str = "hostlib_tools_inspect_test_results";
+
+/// Captured outcome of a `run_test` invocation, plus the metadata
+/// `inspect_test_results` needs to build per-test records on demand.
+///
+/// `exit_code` and `argv` are kept on the struct (not just for debugging) so
+/// future parsers can correlate per-test status with the runner's exit code
+/// — e.g. cargo libtest exits non-zero even when the failure summary is
+/// empty (build errors). Today no parser uses them yet.
+#[derive(Debug, Clone)]
+pub(crate) struct RawArtifacts {
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+    #[allow(dead_code)]
+    pub(crate) exit_code: i32,
+    pub(crate) junit_path: Option<PathBuf>,
+    pub(crate) ecosystem: Option<String>,
+    #[allow(dead_code)]
+    pub(crate) argv: Vec<String>,
+}
+
+/// Three-way summary surfaced inline by `run_test`. Same shape as the
+/// `summary` dict in the schema.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct TestSummaryData {
+    pub(crate) passed: u32,
+    pub(crate) failed: u32,
+    pub(crate) skipped: u32,
+}
+
+impl RawArtifacts {
+    /// Produce an inline `(passed, failed, skipped)` summary by parsing
+    /// whatever output the runner emitted. Returns `None` when no parser
+    /// matched — `run_test` then omits the `summary` field entirely
+    /// rather than returning fabricated zeros.
+    pub(crate) fn compute_summary(&self) -> Option<TestSummaryData> {
+        let records = self.parse_records();
+        if records.is_empty() {
+            return None;
+        }
+        let mut data = TestSummaryData::default();
+        for r in &records {
+            match r.status {
+                test_parsers::Status::Passed => data.passed += 1,
+                test_parsers::Status::Failed | test_parsers::Status::Errored => data.failed += 1,
+                test_parsers::Status::Skipped => data.skipped += 1,
+            }
+        }
+        Some(data)
+    }
+
+    fn parse_records(&self) -> Vec<test_parsers::TestRecord> {
+        if let Some(path) = self.junit_path.as_ref() {
+            if let Ok(bytes) = std::fs::read(path) {
+                if let Ok(records) = test_parsers::parse_junit_xml(&bytes) {
+                    return records;
+                }
+            }
+        }
+        if let Some(eco) = self.ecosystem.as_deref() {
+            if eco == "cargo" {
+                return test_parsers::parse_cargo_libtest(&self.stdout);
+            }
+            if eco == "go" {
+                return test_parsers::parse_go_text(&self.stdout, &self.stderr);
+            }
+        }
+        // Last-chance heuristic: if it *looks* like libtest output, parse
+        // it as such — covers the explicit-argv cargo case.
+        if self.stdout.contains("test result:") {
+            return test_parsers::parse_cargo_libtest(&self.stdout);
+        }
+        Vec::new()
+    }
+}
+
+#[derive(Default)]
+struct HandleStore {
+    entries: BTreeMap<String, RawArtifacts>,
+}
+
+static STORE: Lazy<Mutex<HandleStore>> = Lazy::new(|| Mutex::new(HandleStore::default()));
+static HANDLE_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Cache `artifacts` and return the opaque `result_handle` for them.
+pub(crate) fn store_run(artifacts: RawArtifacts) -> String {
+    let id = HANDLE_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let handle = format!("htr-{:x}-{id}", std::process::id());
+    let mut store = STORE.lock().expect("hostlib test handle store poisoned");
+    store.entries.insert(handle.clone(), artifacts);
+    handle
+}
+
+pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let map = require_dict_arg(NAME, args)?;
+    let handle = require_string(NAME, &map, "result_handle")?;
+    let include_passing = optional_bool(NAME, &map, "include_passing")?.unwrap_or(false);
+
+    let artifacts = {
+        let store = STORE.lock().expect("hostlib test handle store poisoned");
+        store
+            .entries
+            .get(&handle)
+            .cloned()
+            .ok_or(HostlibError::InvalidParameter {
+                builtin: NAME,
+                param: "result_handle",
+                message: format!("no test results stored under handle {handle}"),
+            })?
+    };
+
+    let mut records = artifacts.parse_records();
+    if !include_passing {
+        records.retain(|r| !matches!(r.status, test_parsers::Status::Passed));
+    }
+    let entries: Vec<VmValue> = records
+        .into_iter()
+        .map(|r| VmValue::Dict(Rc::new(record_to_map(r))))
+        .collect();
+    Ok(ResponseBuilder::new()
+        .str("result_handle", handle)
+        .list("tests", entries)
+        .build())
+}
+
+fn record_to_map(record: test_parsers::TestRecord) -> BTreeMap<String, VmValue> {
+    let mut map = BTreeMap::new();
+    map.insert("name".to_string(), VmValue::String(Rc::from(record.name)));
+    map.insert(
+        "status".to_string(),
+        VmValue::String(Rc::from(record.status.as_str())),
+    );
+    map.insert(
+        "duration_ms".to_string(),
+        VmValue::Int(record.duration_ms as i64),
+    );
+    map.insert(
+        "message".to_string(),
+        record
+            .message
+            .map(|m| VmValue::String(Rc::from(m)))
+            .unwrap_or(VmValue::Nil),
+    );
+    map.insert(
+        "stdout".to_string(),
+        record
+            .stdout
+            .map(|s| VmValue::String(Rc::from(s)))
+            .unwrap_or(VmValue::Nil),
+    );
+    map.insert(
+        "stderr".to_string(),
+        record
+            .stderr
+            .map(|s| VmValue::String(Rc::from(s)))
+            .unwrap_or(VmValue::Nil),
+    );
+    map.insert(
+        "path".to_string(),
+        record
+            .path
+            .map(|p| VmValue::String(Rc::from(p)))
+            .unwrap_or(VmValue::Nil),
+    );
+    map.insert(
+        "line".to_string(),
+        record.line.map(VmValue::Int).unwrap_or(VmValue::Nil),
+    );
+    map
+}

--- a/crates/harn-hostlib/src/tools/lang.rs
+++ b/crates/harn-hostlib/src/tools/lang.rs
@@ -1,0 +1,185 @@
+//! Workspace ecosystem detection.
+//!
+//! `run_test`, `run_build_command`, and `manage_packages` need to map a
+//! `cwd` to a runner (`cargo`, `npm`, `pytest`, `go`, `swift`, …) when the
+//! caller doesn't pass an explicit argv / ecosystem.
+//!
+//! Detection is intentionally manifest-only — we never read user shell
+//! profiles or scan outside `cwd`. The caller can always force a specific
+//! runner by passing `argv` (for `run_*`) or `ecosystem` (for
+//! `manage_packages`), bypassing detection entirely.
+//!
+//! Divergence vs. Swift `BurinCore`: the Swift implementation also
+//! consulted `LanguageConfigRegistry` JSON files shipped inside the IDE
+//! bundle. We do *not* port that here — the IDE shim can keep doing its
+//! own override before invoking `run_test`. The behaviors here are the
+//! sane defaults for the manifests every supported ecosystem ships.
+
+use std::path::Path;
+
+/// One of the package ecosystems hostlib knows how to drive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Ecosystem {
+    Cargo,
+    Npm,
+    Pnpm,
+    Yarn,
+    Pip,
+    Uv,
+    Poetry,
+    Go,
+    Swift,
+    Gradle,
+    Maven,
+    Bundler,
+    Composer,
+    Dotnet,
+}
+
+impl Ecosystem {
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Ecosystem::Cargo => "cargo",
+            Ecosystem::Npm => "npm",
+            Ecosystem::Pnpm => "pnpm",
+            Ecosystem::Yarn => "yarn",
+            Ecosystem::Pip => "pip",
+            Ecosystem::Uv => "uv",
+            Ecosystem::Poetry => "poetry",
+            Ecosystem::Go => "go",
+            Ecosystem::Swift => "swift",
+            Ecosystem::Gradle => "gradle",
+            Ecosystem::Maven => "maven",
+            Ecosystem::Bundler => "bundler",
+            Ecosystem::Composer => "composer",
+            Ecosystem::Dotnet => "dotnet",
+        }
+    }
+
+    /// Map the user-facing ecosystem name (from the request payload) to a
+    /// detected variant. Aliases follow Swift's `packageManager(from:)`.
+    pub(crate) fn parse(name: &str) -> Option<Ecosystem> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "cargo" | "rust" => Some(Ecosystem::Cargo),
+            "npm" => Some(Ecosystem::Npm),
+            "pnpm" => Some(Ecosystem::Pnpm),
+            "yarn" => Some(Ecosystem::Yarn),
+            "pip" | "python" => Some(Ecosystem::Pip),
+            "uv" => Some(Ecosystem::Uv),
+            "poetry" => Some(Ecosystem::Poetry),
+            "go" | "golang" => Some(Ecosystem::Go),
+            "swift" | "swiftpm" => Some(Ecosystem::Swift),
+            "gradle" => Some(Ecosystem::Gradle),
+            "maven" | "mvn" => Some(Ecosystem::Maven),
+            "bundle" | "bundler" | "ruby" => Some(Ecosystem::Bundler),
+            "composer" | "php" => Some(Ecosystem::Composer),
+            "dotnet" | ".net" | "csharp" => Some(Ecosystem::Dotnet),
+            _ => None,
+        }
+    }
+}
+
+/// Detect the most likely ecosystem for a workspace by inspecting manifests.
+///
+/// Returns `None` if no recognized manifest is present. Detection order
+/// matches the strictest-first heuristic Swift used: lockfile-bearing JS
+/// managers beat plain `npm`; `uv.lock` / `poetry.lock` beat plain `pip`.
+pub(crate) fn detect(cwd: &Path) -> Option<Ecosystem> {
+    if cwd.join("Cargo.toml").is_file() {
+        return Some(Ecosystem::Cargo);
+    }
+    if cwd.join("Package.swift").is_file() {
+        return Some(Ecosystem::Swift);
+    }
+    if cwd.join("go.mod").is_file() {
+        return Some(Ecosystem::Go);
+    }
+    if cwd.join("pnpm-lock.yaml").is_file() {
+        return Some(Ecosystem::Pnpm);
+    }
+    if cwd.join("yarn.lock").is_file() {
+        return Some(Ecosystem::Yarn);
+    }
+    if cwd.join("package.json").is_file() {
+        return Some(Ecosystem::Npm);
+    }
+    if cwd.join("uv.lock").is_file() {
+        return Some(Ecosystem::Uv);
+    }
+    if cwd.join("poetry.lock").is_file() {
+        return Some(Ecosystem::Poetry);
+    }
+    if cwd.join("pyproject.toml").is_file() || cwd.join("setup.py").is_file() {
+        return Some(Ecosystem::Pip);
+    }
+    if cwd.join("Gemfile").is_file() {
+        return Some(Ecosystem::Bundler);
+    }
+    if cwd.join("composer.json").is_file() {
+        return Some(Ecosystem::Composer);
+    }
+    if cwd.join("build.gradle").is_file() || cwd.join("build.gradle.kts").is_file() {
+        return Some(Ecosystem::Gradle);
+    }
+    if cwd.join("pom.xml").is_file() {
+        return Some(Ecosystem::Maven);
+    }
+    if has_dotnet_project(cwd) {
+        return Some(Ecosystem::Dotnet);
+    }
+    None
+}
+
+fn has_dotnet_project(cwd: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(cwd) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        entry
+            .file_name()
+            .to_str()
+            .map(|name| {
+                name.ends_with(".csproj") || name.ends_with(".sln") || name.ends_with(".slnx")
+            })
+            .unwrap_or(false)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn touch(dir: &Path, name: &str) {
+        std::fs::write(dir.join(name), b"").unwrap();
+    }
+
+    #[test]
+    fn detects_cargo_workspace() {
+        let dir = tempdir().unwrap();
+        touch(dir.path(), "Cargo.toml");
+        assert_eq!(detect(dir.path()), Some(Ecosystem::Cargo));
+    }
+
+    #[test]
+    fn pnpm_lockfile_beats_package_json() {
+        let dir = tempdir().unwrap();
+        touch(dir.path(), "package.json");
+        touch(dir.path(), "pnpm-lock.yaml");
+        assert_eq!(detect(dir.path()), Some(Ecosystem::Pnpm));
+    }
+
+    #[test]
+    fn returns_none_for_empty_directory() {
+        let dir = tempdir().unwrap();
+        assert!(detect(dir.path()).is_none());
+    }
+
+    #[test]
+    fn parses_ecosystem_aliases() {
+        assert_eq!(Ecosystem::parse("rust"), Some(Ecosystem::Cargo));
+        assert_eq!(Ecosystem::parse("Python"), Some(Ecosystem::Pip));
+        assert_eq!(Ecosystem::parse("swiftpm"), Some(Ecosystem::Swift));
+        assert_eq!(Ecosystem::parse("nope"), None);
+    }
+}

--- a/crates/harn-hostlib/src/tools/manage_packages.rs
+++ b/crates/harn-hostlib/src/tools/manage_packages.rs
@@ -1,0 +1,343 @@
+//! `tools/manage_packages` — install / add / remove / update / refresh deps
+//! across the package ecosystems hostlib can drive.
+//!
+//! Schema: `schemas/tools/manage_packages.{request,response}.json`.
+//!
+//! Behavior:
+//! - `ecosystem` is required when `cwd` doesn't contain a recognized
+//!   manifest. (Swift's implementation refused to infer; we keep that
+//!   contract — callers must opt in to a specific manager.)
+//! - `lockfile_changed` is computed by snapshotting the relevant lockfile
+//!   path before/after the spawn and comparing mtimes. We don't read
+//!   contents to keep the cost predictable on large lockfiles.
+//! - Approval/UX is the embedder's responsibility — by the time this
+//!   builtin is called, the host has already obtained user consent.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::tools::lang::{detect, Ecosystem};
+use crate::tools::payload::{
+    optional_bool, optional_string, optional_string_list, require_dict_arg, require_string,
+};
+use crate::tools::proc::{self, SpawnRequest};
+use crate::tools::response::ResponseBuilder;
+
+pub(crate) const NAME: &str = "hostlib_tools_manage_packages";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Operation {
+    Install,
+    Add,
+    Remove,
+    Update,
+    Refresh,
+}
+
+impl Operation {
+    fn parse(s: &str) -> Option<Operation> {
+        match s {
+            "install" => Some(Operation::Install),
+            "add" => Some(Operation::Add),
+            "remove" => Some(Operation::Remove),
+            "update" => Some(Operation::Update),
+            "refresh" => Some(Operation::Refresh),
+            _ => None,
+        }
+    }
+}
+
+pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let map = require_dict_arg(NAME, args)?;
+    let operation_str = require_string(NAME, &map, "operation")?;
+    let operation = Operation::parse(&operation_str).ok_or(HostlibError::InvalidParameter {
+        builtin: NAME,
+        param: "operation",
+        message: format!(
+            "expected one of install, add, remove, update, refresh — got {operation_str:?}"
+        ),
+    })?;
+
+    let cwd_raw = optional_string(NAME, &map, "cwd")?;
+    let cwd_path = proc::parse_cwd(NAME, cwd_raw.as_deref())?;
+    let cwd_for_detect = cwd_path
+        .clone()
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    let ecosystem = match optional_string(NAME, &map, "ecosystem")? {
+        Some(name) => Ecosystem::parse(&name).ok_or(HostlibError::InvalidParameter {
+            builtin: NAME,
+            param: "ecosystem",
+            message: format!("unknown ecosystem {name:?}"),
+        })?,
+        None => detect(&cwd_for_detect).ok_or(HostlibError::InvalidParameter {
+            builtin: NAME,
+            param: "ecosystem",
+            message: "no recognized manifest in cwd; pass `ecosystem` explicitly".to_string(),
+        })?,
+    };
+
+    let packages = optional_string_list(NAME, &map, "packages")?.unwrap_or_default();
+    let dev = optional_bool(NAME, &map, "dev")?.unwrap_or(false);
+
+    let argv =
+        build_argv(ecosystem, operation, &packages, dev).ok_or(HostlibError::InvalidParameter {
+            builtin: NAME,
+            param: "operation",
+            message: format!(
+                "operation {} not implemented for ecosystem {}",
+                operation_str,
+                ecosystem.name()
+            ),
+        })?;
+
+    let lockfile = lockfile_for(ecosystem).map(|name| cwd_for_detect.join(name));
+    let lockfile_before = lockfile.as_deref().and_then(snapshot_mtime);
+
+    let (program, args_tail) = match argv.split_first() {
+        Some((first, rest)) => (first.clone(), rest.to_vec()),
+        None => {
+            return Err(HostlibError::Backend {
+                builtin: NAME,
+                message: "internal: empty argv".to_string(),
+            });
+        }
+    };
+
+    let outcome = proc::run(SpawnRequest {
+        builtin: NAME,
+        program,
+        args: args_tail,
+        cwd: cwd_path,
+        env: BTreeMap::new(),
+        stdin: None,
+        timeout: None,
+    })?;
+
+    let lockfile_after = lockfile.as_deref().and_then(snapshot_mtime);
+    let lockfile_changed = lockfile_before != lockfile_after;
+
+    Ok(ResponseBuilder::new()
+        .str("operation", operation_str)
+        .str("ecosystem", ecosystem.name())
+        .int("exit_code", outcome.exit_code as i64)
+        .str("stdout", outcome.stdout)
+        .str("stderr", outcome.stderr)
+        .int("duration_ms", outcome.duration.as_millis() as i64)
+        .bool("lockfile_changed", lockfile_changed)
+        .build())
+}
+
+fn lockfile_for(eco: Ecosystem) -> Option<&'static str> {
+    Some(match eco {
+        Ecosystem::Cargo => "Cargo.lock",
+        Ecosystem::Npm => "package-lock.json",
+        Ecosystem::Pnpm => "pnpm-lock.yaml",
+        Ecosystem::Yarn => "yarn.lock",
+        Ecosystem::Uv => "uv.lock",
+        Ecosystem::Poetry => "poetry.lock",
+        Ecosystem::Bundler => "Gemfile.lock",
+        Ecosystem::Composer => "composer.lock",
+        Ecosystem::Swift => "Package.resolved",
+        Ecosystem::Go => "go.sum",
+        // No canonical lockfile path.
+        Ecosystem::Pip | Ecosystem::Gradle | Ecosystem::Maven | Ecosystem::Dotnet => return None,
+    })
+}
+
+fn snapshot_mtime(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+fn build_argv(
+    eco: Ecosystem,
+    op: Operation,
+    packages: &[String],
+    dev: bool,
+) -> Option<Vec<String>> {
+    use Ecosystem::*;
+    use Operation::*;
+    let pkgs = packages.to_vec();
+    let pkgs_some = !pkgs.is_empty();
+    Some(match (eco, op) {
+        (Cargo, Add) if pkgs_some => prepend("cargo", &["add"], &pkgs),
+        (Cargo, Remove) if pkgs_some => prepend("cargo", &["remove"], &pkgs),
+        (Cargo, Install | Refresh) => vec!["cargo".into(), "fetch".into()],
+        (Cargo, Update) => {
+            let mut argv = vec!["cargo".into(), "update".into()];
+            for p in &pkgs {
+                argv.push("-p".into());
+                argv.push(p.clone());
+            }
+            argv
+        }
+        (Npm, Add | Install) if pkgs_some => {
+            let mut argv = vec!["npm".into(), "install".into()];
+            if dev {
+                argv.push("--save-dev".into());
+            }
+            argv.extend(pkgs);
+            argv
+        }
+        (Npm, Install) => vec!["npm".into(), "install".into()],
+        (Npm, Remove) if pkgs_some => prepend("npm", &["uninstall"], &pkgs),
+        (Npm, Update) => prepend_or_default("npm", &["update"], &pkgs),
+        (Npm, Refresh) => vec!["npm".into(), "ci".into()],
+        (Pnpm, Add | Install) if pkgs_some => {
+            let mut argv = vec!["pnpm".into(), "add".into()];
+            if dev {
+                argv.push("--save-dev".into());
+            }
+            argv.extend(pkgs);
+            argv
+        }
+        (Pnpm, Install) => vec!["pnpm".into(), "install".into()],
+        (Pnpm, Remove) if pkgs_some => prepend("pnpm", &["remove"], &pkgs),
+        (Pnpm, Update) => prepend_or_default("pnpm", &["update"], &pkgs),
+        (Pnpm, Refresh) => vec!["pnpm".into(), "install".into(), "--frozen-lockfile".into()],
+        (Yarn, Add | Install) if pkgs_some => {
+            let mut argv = vec!["yarn".into(), "add".into()];
+            if dev {
+                argv.push("--dev".into());
+            }
+            argv.extend(pkgs);
+            argv
+        }
+        (Yarn, Install) => vec!["yarn".into(), "install".into()],
+        (Yarn, Remove) if pkgs_some => prepend("yarn", &["remove"], &pkgs),
+        (Yarn, Update) => prepend_or_default("yarn", &["upgrade"], &pkgs),
+        (Yarn, Refresh) => vec!["yarn".into(), "install".into(), "--frozen-lockfile".into()],
+        (Pip, Add | Install) if pkgs_some => prepend("python", &["-m", "pip", "install"], &pkgs),
+        (Pip, Install) => vec![
+            "python".into(),
+            "-m".into(),
+            "pip".into(),
+            "install".into(),
+            "-e".into(),
+            ".".into(),
+        ],
+        (Pip, Remove) if pkgs_some => prepend("python", &["-m", "pip", "uninstall", "-y"], &pkgs),
+        (Pip, Update) => {
+            prepend_or_default("python", &["-m", "pip", "install", "--upgrade"], &pkgs)
+        }
+        (Pip, Refresh) => vec![
+            "python".into(),
+            "-m".into(),
+            "pip".into(),
+            "install".into(),
+            "-r".into(),
+            "requirements.txt".into(),
+        ],
+        (Uv, Add) if pkgs_some => prepend("uv", &["add"], &pkgs),
+        (Uv, Install | Refresh) => vec!["uv".into(), "sync".into()],
+        (Uv, Remove) if pkgs_some => prepend("uv", &["remove"], &pkgs),
+        (Uv, Update) => prepend_or_default("uv", &["sync", "--upgrade"], &pkgs),
+        (Poetry, Add) if pkgs_some => {
+            let mut argv = vec!["poetry".into(), "add".into()];
+            if dev {
+                argv.push("--group".into());
+                argv.push("dev".into());
+            }
+            argv.extend(pkgs);
+            argv
+        }
+        (Poetry, Install | Refresh) => vec!["poetry".into(), "install".into()],
+        (Poetry, Remove) if pkgs_some => prepend("poetry", &["remove"], &pkgs),
+        (Poetry, Update) => prepend_or_default("poetry", &["update"], &pkgs),
+        (Go, Add) if pkgs_some => prepend("go", &["get"], &pkgs),
+        (Go, Install | Refresh) => vec!["go".into(), "mod".into(), "download".into()],
+        (Go, Update) => prepend_or_default("go", &["get", "-u"], &pkgs),
+        (Go, Remove) if pkgs_some => prepend("go", &["mod", "tidy"], &[]),
+        (Swift, Install | Add | Refresh) => {
+            vec!["swift".into(), "package".into(), "resolve".into()]
+        }
+        (Swift, Update) => vec!["swift".into(), "package".into(), "update".into()],
+        (Bundler, Install | Refresh) => vec!["bundle".into(), "install".into()],
+        (Bundler, Add) if pkgs_some => prepend("bundle", &["add"], &pkgs),
+        (Bundler, Remove) if pkgs_some => prepend("bundle", &["remove"], &pkgs),
+        (Bundler, Update) => prepend_or_default("bundle", &["update"], &pkgs),
+        (Composer, Install | Refresh) => vec!["composer".into(), "install".into()],
+        (Composer, Add) if pkgs_some => prepend("composer", &["require"], &pkgs),
+        (Composer, Remove) if pkgs_some => prepend("composer", &["remove"], &pkgs),
+        (Composer, Update) => prepend_or_default("composer", &["update"], &pkgs),
+        (Gradle, Install | Refresh) => vec![
+            "./gradlew".into(),
+            "build".into(),
+            "--refresh-dependencies".into(),
+        ],
+        (Maven, Install | Refresh) => vec!["mvn".into(), "install".into()],
+        (Dotnet, Install | Refresh) => vec!["dotnet".into(), "restore".into()],
+        (Dotnet, Add) if pkgs_some => prepend("dotnet", &["add", "package"], &pkgs),
+        (Dotnet, Remove) if pkgs_some => prepend("dotnet", &["remove", "package"], &pkgs),
+        _ => return None,
+    })
+}
+
+fn prepend(program: &str, flags: &[&str], packages: &[String]) -> Vec<String> {
+    let mut argv = vec![program.to_string()];
+    argv.extend(flags.iter().map(|s| s.to_string()));
+    argv.extend(packages.iter().cloned());
+    argv
+}
+
+fn prepend_or_default(program: &str, flags: &[&str], packages: &[String]) -> Vec<String> {
+    if packages.is_empty() {
+        let mut argv = vec![program.to_string()];
+        argv.extend(flags.iter().map(|s| s.to_string()));
+        argv
+    } else {
+        prepend(program, flags, packages)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn npm_install_dev_emits_save_dev_flag() {
+        let argv = build_argv(
+            Ecosystem::Npm,
+            Operation::Install,
+            &["lodash".to_string()],
+            true,
+        )
+        .unwrap();
+        assert_eq!(argv, vec!["npm", "install", "--save-dev", "lodash"]);
+    }
+
+    #[test]
+    fn cargo_refresh_uses_fetch() {
+        let argv = build_argv(Ecosystem::Cargo, Operation::Refresh, &[], false).unwrap();
+        assert_eq!(argv, vec!["cargo", "fetch"]);
+    }
+
+    #[test]
+    fn poetry_add_dev_uses_group_dev() {
+        let argv = build_argv(
+            Ecosystem::Poetry,
+            Operation::Add,
+            &["pytest".to_string()],
+            true,
+        )
+        .unwrap();
+        assert_eq!(argv, vec!["poetry", "add", "--group", "dev", "pytest"]);
+    }
+
+    #[test]
+    fn unsupported_pair_returns_none() {
+        // gradle has no defined `add` mapping today
+        assert!(build_argv(
+            Ecosystem::Gradle,
+            Operation::Add,
+            &["junit".to_string()],
+            false
+        )
+        .is_none());
+    }
+}

--- a/crates/harn-hostlib/src/tools/mod.rs
+++ b/crates/harn-hostlib/src/tools/mod.rs
@@ -17,15 +17,15 @@
 //! | `list_directory`        | implemented                     |
 //! | `get_file_outline`      | implemented (regex extractor)   |
 //! | `git`                   | implemented (system git CLI)    |
-//! | `run_command`           | unimplemented (issue C2)        |
-//! | `run_test`              | unimplemented (issue C2)        |
-//! | `run_build_command`     | unimplemented (issue C2)        |
-//! | `inspect_test_results`  | unimplemented (issue C2)        |
-//! | `manage_packages`       | unimplemented (issue C2)        |
+//! | `run_command`           | implemented                     |
+//! | `run_test`              | implemented                     |
+//! | `run_build_command`     | implemented                     |
+//! | `inspect_test_results`  | implemented                     |
+//! | `manage_packages`       | implemented                     |
 //!
 //! ### Per-session opt-in
 //!
-//! All seven deterministic tools are gated by a per-thread feature flag.
+//! All deterministic tools are gated by a per-thread feature flag.
 //! Pipelines must call `hostlib_enable("tools:deterministic")` (registered
 //! by [`ToolsCapability::register_builtins`]) before any of the tool
 //! methods will execute. Until then, calls return
@@ -43,11 +43,22 @@ use crate::error::HostlibError;
 use crate::registry::{BuiltinRegistry, HostlibCapability, RegisteredBuiltin, SyncHandler};
 
 mod args;
+mod diagnostics;
 mod file_io;
 mod git;
+mod inspect_test_results;
+mod lang;
+mod manage_packages;
 mod outline;
+mod payload;
 pub mod permissions;
+mod proc;
+mod response;
+mod run_build_command;
+mod run_command;
+mod run_test;
 mod search;
+mod test_parsers;
 
 pub use permissions::FEATURE_TOOLS_DETERMINISTIC;
 
@@ -94,23 +105,35 @@ impl HostlibCapability for ToolsCapability {
         );
         register_gated(registry, "hostlib_tools_git", "git", git::run);
 
-        // Process tools land in C2; keep the contract surface visible.
-        registry.register_unimplemented("hostlib_tools_run_command", "tools", "run_command");
-        registry.register_unimplemented("hostlib_tools_run_test", "tools", "run_test");
-        registry.register_unimplemented(
+        register_gated(
+            registry,
+            "hostlib_tools_run_command",
+            "run_command",
+            run_command::handle,
+        );
+        register_gated(
+            registry,
+            "hostlib_tools_run_test",
+            "run_test",
+            run_test::handle,
+        );
+        register_gated(
+            registry,
             "hostlib_tools_run_build_command",
-            "tools",
             "run_build_command",
+            run_build_command::handle,
         );
-        registry.register_unimplemented(
+        register_gated(
+            registry,
             "hostlib_tools_inspect_test_results",
-            "tools",
             "inspect_test_results",
+            inspect_test_results::handle,
         );
-        registry.register_unimplemented(
+        register_gated(
+            registry,
             "hostlib_tools_manage_packages",
-            "tools",
             "manage_packages",
+            manage_packages::handle,
         );
 
         // The opt-in builtin lives in the `tools` module so embedders that

--- a/crates/harn-hostlib/src/tools/payload.rs
+++ b/crates/harn-hostlib/src/tools/payload.rs
@@ -1,0 +1,254 @@
+//! VmValue → typed-payload helpers.
+//!
+//! Every tool builtin accepts a single dict argument shaped exactly like its
+//! JSON request schema in `schemas/tools/`. Helpers here pull typed fields
+//! out of that dict and surface schema mismatches as
+//! [`HostlibError::InvalidParameter`].
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+
+/// Pull the single dict argument from a builtin call's argv. The dict
+/// itself is the JSON request body; positional args are not used.
+pub(crate) fn require_dict_arg(
+    builtin: &'static str,
+    args: &[VmValue],
+) -> Result<BTreeMap<String, VmValue>, HostlibError> {
+    let first = args.first().ok_or(HostlibError::MissingParameter {
+        builtin,
+        param: "request",
+    })?;
+    match first {
+        VmValue::Dict(map) => Ok((**map).clone()),
+        other => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: "request",
+            message: format!(
+                "expected a dict (JSON request body), got {}",
+                describe(other)
+            ),
+        }),
+    }
+}
+
+/// Optional string field on a request dict.
+pub(crate) fn optional_string(
+    builtin: &'static str,
+    map: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<String>, HostlibError> {
+    let Some(value) = map.get(key) else {
+        return Ok(None);
+    };
+    match value {
+        VmValue::Nil => Ok(None),
+        VmValue::String(s) => Ok(Some(s.to_string())),
+        other => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected string, got {}", describe(other)),
+        }),
+    }
+}
+
+/// Optional bool field on a request dict.
+pub(crate) fn optional_bool(
+    builtin: &'static str,
+    map: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<bool>, HostlibError> {
+    let Some(value) = map.get(key) else {
+        return Ok(None);
+    };
+    match value {
+        VmValue::Nil => Ok(None),
+        VmValue::Bool(b) => Ok(Some(*b)),
+        other => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected bool, got {}", describe(other)),
+        }),
+    }
+}
+
+/// Optional non-negative integer field on a request dict.
+pub(crate) fn optional_u64(
+    builtin: &'static str,
+    map: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<u64>, HostlibError> {
+    let Some(value) = map.get(key) else {
+        return Ok(None);
+    };
+    match value {
+        VmValue::Nil => Ok(None),
+        VmValue::Int(i) if *i >= 0 => Ok(Some(*i as u64)),
+        VmValue::Int(i) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected non-negative integer, got {i}"),
+        }),
+        other => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected integer, got {}", describe(other)),
+        }),
+    }
+}
+
+/// Convert an optional `timeout_ms` field into a `Duration`, treating zero
+/// or absent values as "no timeout" — matches the Swift surface.
+pub(crate) fn optional_timeout(
+    builtin: &'static str,
+    map: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<Duration>, HostlibError> {
+    Ok(optional_u64(builtin, map, key)?.and_then(|ms| {
+        if ms == 0 {
+            None
+        } else {
+            Some(Duration::from_millis(ms))
+        }
+    }))
+}
+
+/// Optional `Vec<String>` field on a request dict (e.g. `argv`, `packages`).
+pub(crate) fn optional_string_list(
+    builtin: &'static str,
+    map: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<Vec<String>>, HostlibError> {
+    let Some(value) = map.get(key) else {
+        return Ok(None);
+    };
+    match value {
+        VmValue::Nil => Ok(None),
+        VmValue::List(list) => {
+            let mut out = Vec::with_capacity(list.len());
+            for (i, item) in list.iter().enumerate() {
+                let VmValue::String(s) = item else {
+                    return Err(HostlibError::InvalidParameter {
+                        builtin,
+                        param: key,
+                        message: format!("expected string at index {i}, got {}", describe(item)),
+                    });
+                };
+                out.push(s.to_string());
+            }
+            Ok(Some(out))
+        }
+        other => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected list of strings, got {}", describe(other)),
+        }),
+    }
+}
+
+/// Optional `BTreeMap<String, String>` field on a request dict (e.g. `env`).
+pub(crate) fn optional_string_map(
+    builtin: &'static str,
+    map: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<BTreeMap<String, String>>, HostlibError> {
+    let Some(value) = map.get(key) else {
+        return Ok(None);
+    };
+    match value {
+        VmValue::Nil => Ok(None),
+        VmValue::Dict(dict) => {
+            let mut out = BTreeMap::new();
+            for (k, v) in dict.iter() {
+                let VmValue::String(s) = v else {
+                    return Err(HostlibError::InvalidParameter {
+                        builtin,
+                        param: key,
+                        message: format!("value for {k:?} must be string, got {}", describe(v)),
+                    });
+                };
+                out.insert(k.clone(), s.to_string());
+            }
+            Ok(Some(out))
+        }
+        other => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected dict<string,string>, got {}", describe(other)),
+        }),
+    }
+}
+
+/// Required string field on a request dict — fails if missing or wrong type.
+pub(crate) fn require_string(
+    builtin: &'static str,
+    map: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<String, HostlibError> {
+    optional_string(builtin, map, key)?.ok_or(HostlibError::MissingParameter {
+        builtin,
+        param: key,
+    })
+}
+
+/// Split an argv list into `(program, remaining_args)`. Errors if the list
+/// is empty or the program element is empty.
+pub(crate) fn parse_argv_program(
+    builtin: &'static str,
+    mut argv: Vec<String>,
+) -> Result<(String, Vec<String>), HostlibError> {
+    if argv.is_empty() {
+        return Err(HostlibError::InvalidParameter {
+            builtin,
+            param: "argv",
+            message: "argv must contain at least one element".to_string(),
+        });
+    }
+    let program = argv.remove(0);
+    if program.is_empty() {
+        return Err(HostlibError::InvalidParameter {
+            builtin,
+            param: "argv",
+            message: "first argv element (program) must be non-empty".to_string(),
+        });
+    }
+    Ok((program, argv))
+}
+
+/// Required argv field with at least one element.
+pub(crate) fn require_argv(
+    builtin: &'static str,
+    map: &BTreeMap<String, VmValue>,
+) -> Result<Vec<String>, HostlibError> {
+    let argv =
+        optional_string_list(builtin, map, "argv")?.ok_or(HostlibError::MissingParameter {
+            builtin,
+            param: "argv",
+        })?;
+    if argv.is_empty() {
+        return Err(HostlibError::InvalidParameter {
+            builtin,
+            param: "argv",
+            message: "argv must contain at least one element".to_string(),
+        });
+    }
+    Ok(argv)
+}
+
+fn describe(value: &VmValue) -> &'static str {
+    match value {
+        VmValue::Int(_) => "int",
+        VmValue::Float(_) => "float",
+        VmValue::String(_) => "string",
+        VmValue::Bytes(_) => "bytes",
+        VmValue::Bool(_) => "bool",
+        VmValue::Nil => "nil",
+        VmValue::List(_) => "list",
+        VmValue::Dict(_) => "dict",
+        VmValue::Set(_) => "set",
+        _ => "other",
+    }
+}

--- a/crates/harn-hostlib/src/tools/proc.rs
+++ b/crates/harn-hostlib/src/tools/proc.rs
@@ -1,0 +1,250 @@
+//! Shared subprocess spawn / wait / timeout machinery used by every
+//! `tools/run_*` and `tools/manage_packages` builtin.
+//!
+//! All process tools funnel through here so:
+//! 1. Each spawn goes through [`harn_vm::process_sandbox`], so the active
+//!    orchestration capability policy applies (Linux seccomp/landlock,
+//!    macOS `sandbox-exec`, workspace-root cwd enforcement).
+//! 2. Pipe drains run on background threads so >64 KB output never
+//!    deadlocks `wait()` (the same trap the Swift implementation called
+//!    out in CoreToolExecutor+Commands.swift).
+//! 3. Timeout enforcement is uniform: when a deadline elapses, the child
+//!    is killed and `timed_out: true` is reported in the response.
+
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use harn_vm::process_sandbox;
+
+use crate::error::HostlibError;
+
+/// Resolved request payload for a subprocess spawn.
+#[derive(Debug, Clone)]
+pub(crate) struct SpawnRequest {
+    pub(crate) builtin: &'static str,
+    pub(crate) program: String,
+    pub(crate) args: Vec<String>,
+    pub(crate) cwd: Option<PathBuf>,
+    pub(crate) env: BTreeMap<String, String>,
+    pub(crate) stdin: Option<String>,
+    pub(crate) timeout: Option<Duration>,
+}
+
+/// Result of running a subprocess to completion (or to the deadline).
+#[derive(Debug, Clone)]
+pub(crate) struct SpawnOutcome {
+    pub(crate) exit_code: i32,
+    pub(crate) signal: Option<String>,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+    pub(crate) duration: Duration,
+    pub(crate) timed_out: bool,
+}
+
+/// Spawn the configured command, capture stdout + stderr in full, and
+/// enforce the timeout. Translates spawn / sandbox failures into
+/// `HostlibError::Backend` so the surrounding builtin gets a uniform
+/// `Thrown` dict on the script side.
+pub(crate) fn run(req: SpawnRequest) -> Result<SpawnOutcome, HostlibError> {
+    if req.program.is_empty() {
+        return Err(HostlibError::InvalidParameter {
+            builtin: req.builtin,
+            param: "argv",
+            message: "first element of argv must be a non-empty program name".to_string(),
+        });
+    }
+
+    let mut command = process_sandbox::std_command_for(&req.program, &req.args).map_err(|e| {
+        HostlibError::Backend {
+            builtin: req.builtin,
+            message: format!("sandbox setup failed: {e:?}"),
+        }
+    })?;
+
+    if let Some(cwd) = req.cwd.as_ref() {
+        process_sandbox::enforce_process_cwd(cwd).map_err(|e| HostlibError::Backend {
+            builtin: req.builtin,
+            message: format!("sandbox cwd rejected: {e:?}"),
+        })?;
+        command.current_dir(cwd);
+    }
+
+    if !req.env.is_empty() {
+        // Mirrors Swift's buildCleanEnvironment: the caller is responsible for
+        // every variable they want set; we don't merge in the parent env. This
+        // matches the schema (env is a complete map, not a patch).
+        command.env_clear();
+        for (key, value) in &req.env {
+            command.env(key, value);
+        }
+    }
+
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+    command.stdin(if req.stdin.is_some() {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    });
+
+    let started = Instant::now();
+    let mut child = command.spawn().map_err(|e| {
+        if let Some(violation) = process_sandbox::process_spawn_error(&e) {
+            return HostlibError::Backend {
+                builtin: req.builtin,
+                message: format!("sandbox rejected spawn: {violation:?}"),
+            };
+        }
+        HostlibError::Backend {
+            builtin: req.builtin,
+            message: format!("spawn failed: {e}"),
+        }
+    })?;
+
+    if let Some(stdin_data) = req.stdin.as_ref() {
+        if let Some(mut stdin) = child.stdin.take() {
+            use std::io::Write;
+            // A failed write is non-fatal — the child may have closed stdin
+            // immediately. We surface the eventual exit code regardless.
+            let _ = stdin.write_all(stdin_data.as_bytes());
+        }
+    }
+
+    let stdout_handle = child.stdout.take();
+    let stderr_handle = child.stderr.take();
+
+    let (out_tx, out_rx) = mpsc::channel::<Vec<u8>>();
+    let (err_tx, err_rx) = mpsc::channel::<Vec<u8>>();
+
+    let stdout_thread = stdout_handle.map(|mut handle| {
+        thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = handle.read_to_end(&mut buf);
+            let _ = out_tx.send(buf);
+        })
+    });
+    let stderr_thread = stderr_handle.map(|mut handle| {
+        thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = handle.read_to_end(&mut buf);
+            let _ = err_tx.send(buf);
+        })
+    });
+
+    let (status, timed_out) = wait_with_timeout(&mut child, req.timeout);
+
+    if let Some(t) = stdout_thread {
+        let _ = t.join();
+    }
+    if let Some(t) = stderr_thread {
+        let _ = t.join();
+    }
+
+    let stdout_bytes: Vec<u8> = out_rx.try_iter().flatten().collect();
+    let stderr_bytes: Vec<u8> = err_rx.try_iter().flatten().collect();
+
+    let stdout = String::from_utf8_lossy(&stdout_bytes).into_owned();
+    let stderr = String::from_utf8_lossy(&stderr_bytes).into_owned();
+
+    let (exit_code, signal) = match status {
+        Some(status) => decode_status(status),
+        None => (-1, Some("SIGKILL".to_string())),
+    };
+
+    Ok(SpawnOutcome {
+        exit_code,
+        signal,
+        stdout,
+        stderr,
+        duration: started.elapsed(),
+        timed_out,
+    })
+}
+
+fn wait_with_timeout(
+    child: &mut std::process::Child,
+    timeout: Option<Duration>,
+) -> (Option<std::process::ExitStatus>, bool) {
+    let Some(timeout) = timeout else {
+        return (child.wait().ok(), false);
+    };
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return (Some(status), false),
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return (None, true);
+                }
+                // Cheap poll. Real workloads are dominated by spawn cost
+                // and pipe drain, not this sleep.
+                thread::sleep(Duration::from_millis(20));
+            }
+            Err(_) => return (child.wait().ok(), false),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn decode_status(status: std::process::ExitStatus) -> (i32, Option<String>) {
+    use std::os::unix::process::ExitStatusExt;
+    if let Some(code) = status.code() {
+        (code, None)
+    } else if let Some(sig) = status.signal() {
+        (-1, Some(format_signal(sig)))
+    } else {
+        (-1, None)
+    }
+}
+
+#[cfg(not(unix))]
+fn decode_status(status: std::process::ExitStatus) -> (i32, Option<String>) {
+    (status.code().unwrap_or(-1), None)
+}
+
+#[cfg(unix)]
+fn format_signal(sig: i32) -> String {
+    // Stay minimal: mirror the names burin-code's UI surfaces today.
+    match sig {
+        1 => "SIGHUP".into(),
+        2 => "SIGINT".into(),
+        3 => "SIGQUIT".into(),
+        6 => "SIGABRT".into(),
+        9 => "SIGKILL".into(),
+        13 => "SIGPIPE".into(),
+        14 => "SIGALRM".into(),
+        15 => "SIGTERM".into(),
+        24 => "SIGXCPU".into(),
+        25 => "SIGXFSZ".into(),
+        other => format!("SIG{other}"),
+    }
+}
+
+/// Parse `cwd` from the request payload, validating that it is an existing
+/// directory. Optional fields stay `None` so the spawned child inherits the
+/// hostlib process's cwd.
+pub(crate) fn parse_cwd(
+    builtin: &'static str,
+    raw: Option<&str>,
+) -> Result<Option<PathBuf>, HostlibError> {
+    let Some(raw) = raw else { return Ok(None) };
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    let path = Path::new(raw);
+    if !path.is_dir() {
+        return Err(HostlibError::InvalidParameter {
+            builtin,
+            param: "cwd",
+            message: format!("not an existing directory: {raw}"),
+        });
+    }
+    Ok(Some(path.to_path_buf()))
+}

--- a/crates/harn-hostlib/src/tools/response.rs
+++ b/crates/harn-hostlib/src/tools/response.rs
@@ -1,0 +1,66 @@
+//! Helpers for assembling [`VmValue::Dict`] response bodies that match the
+//! `schemas/tools/<method>.response.json` contracts.
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use harn_vm::VmValue;
+
+/// Type-erased builder for the dict that becomes a tool's response.
+#[derive(Default)]
+pub(crate) struct ResponseBuilder {
+    inner: BTreeMap<String, VmValue>,
+}
+
+impl ResponseBuilder {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn str(mut self, key: &str, value: impl Into<String>) -> Self {
+        self.inner
+            .insert(key.to_string(), VmValue::String(Rc::from(value.into())));
+        self
+    }
+
+    pub(crate) fn int(mut self, key: &str, value: i64) -> Self {
+        self.inner.insert(key.to_string(), VmValue::Int(value));
+        self
+    }
+
+    pub(crate) fn bool(mut self, key: &str, value: bool) -> Self {
+        self.inner.insert(key.to_string(), VmValue::Bool(value));
+        self
+    }
+
+    pub(crate) fn opt_str(mut self, key: &str, value: Option<impl Into<String>>) -> Self {
+        match value {
+            Some(v) => {
+                self.inner
+                    .insert(key.to_string(), VmValue::String(Rc::from(v.into())));
+            }
+            None => {
+                self.inner.insert(key.to_string(), VmValue::Nil);
+            }
+        }
+        self
+    }
+
+    pub(crate) fn dict(mut self, key: &str, value: BTreeMap<String, VmValue>) -> Self {
+        self.inner
+            .insert(key.to_string(), VmValue::Dict(Rc::new(value)));
+        self
+    }
+
+    pub(crate) fn list(mut self, key: &str, value: Vec<VmValue>) -> Self {
+        self.inner
+            .insert(key.to_string(), VmValue::List(Rc::new(value)));
+        self
+    }
+
+    pub(crate) fn build(self) -> VmValue {
+        VmValue::Dict(Rc::new(self.inner))
+    }
+}

--- a/crates/harn-hostlib/src/tools/run_build_command.rs
+++ b/crates/harn-hostlib/src/tools/run_build_command.rs
@@ -1,0 +1,210 @@
+//! `tools/run_build_command` — invoke the project build, then parse
+//! diagnostics back out of the runner's machine-readable output.
+//!
+//! Schema: `schemas/tools/run_build_command.{request,response}.json`.
+//!
+//! Behavior:
+//! - If `argv` is supplied, run it verbatim. We *still* try to parse
+//!   diagnostics from the output afterwards (cargo / tsc / eslint / go),
+//!   so explicit-argv callers benefit from the structured surface too.
+//! - Otherwise detect the workspace ecosystem and pick a default. For
+//!   `cargo`, swap in `--message-format=json-diagnostic-rendered-ansi`
+//!   so we can emit per-error diagnostics.
+//! - `release: true` and `target` are forwarded as flags where supported
+//!   (cargo, swift, dotnet).
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::tools::diagnostics::{parse_diagnostics, DiagnosticSource};
+use crate::tools::lang::{detect, Ecosystem};
+use crate::tools::payload::{
+    optional_bool, optional_string, optional_string_list, optional_timeout, parse_argv_program,
+    require_dict_arg,
+};
+use crate::tools::proc::{self, SpawnRequest};
+use crate::tools::response::ResponseBuilder;
+
+pub(crate) const NAME: &str = "hostlib_tools_run_build_command";
+
+pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let map = require_dict_arg(NAME, args)?;
+    let cwd_raw = optional_string(NAME, &map, "cwd")?;
+    let cwd_path = proc::parse_cwd(NAME, cwd_raw.as_deref())?;
+    let cwd_for_detect = cwd_path
+        .clone()
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let target = optional_string(NAME, &map, "target")?;
+    let release = optional_bool(NAME, &map, "release")?.unwrap_or(false);
+    let timeout = optional_timeout(NAME, &map, "timeout_ms")?;
+
+    let (argv, source) = if let Some(argv) = optional_string_list(NAME, &map, "argv")? {
+        let source = infer_diagnostic_source(&argv);
+        (argv, source)
+    } else {
+        let ecosystem = detect(&cwd_for_detect).ok_or(HostlibError::InvalidParameter {
+            builtin: NAME,
+            param: "argv",
+            message: "no recognized project manifest in cwd; pass argv explicitly".to_string(),
+        })?;
+        build_default_argv(ecosystem, target.as_deref(), release)
+    };
+
+    let (program, args_tail) = parse_argv_program(NAME, argv)?;
+    let outcome = proc::run(SpawnRequest {
+        builtin: NAME,
+        program,
+        args: args_tail,
+        cwd: cwd_path,
+        env: BTreeMap::new(),
+        stdin: None,
+        timeout,
+    })?;
+
+    let diagnostics = parse_diagnostics(source, &outcome.stdout, &outcome.stderr);
+    let diagnostic_values: Vec<VmValue> = diagnostics
+        .into_iter()
+        .map(|d| {
+            let mut entry: BTreeMap<String, VmValue> = BTreeMap::new();
+            entry.insert(
+                "severity".to_string(),
+                VmValue::String(Rc::from(d.severity.as_str())),
+            );
+            entry.insert("message".to_string(), VmValue::String(Rc::from(d.message)));
+            entry.insert(
+                "path".to_string(),
+                d.path
+                    .map(|p| VmValue::String(Rc::from(p)))
+                    .unwrap_or(VmValue::Nil),
+            );
+            entry.insert(
+                "line".to_string(),
+                d.line.map(VmValue::Int).unwrap_or(VmValue::Nil),
+            );
+            entry.insert(
+                "column".to_string(),
+                d.column.map(VmValue::Int).unwrap_or(VmValue::Nil),
+            );
+            VmValue::Dict(Rc::new(entry))
+        })
+        .collect();
+
+    Ok(ResponseBuilder::new()
+        .int("exit_code", outcome.exit_code as i64)
+        .str("stdout", outcome.stdout)
+        .str("stderr", outcome.stderr)
+        .int("duration_ms", outcome.duration.as_millis() as i64)
+        .list("diagnostics", diagnostic_values)
+        .build())
+}
+
+fn build_default_argv(
+    eco: Ecosystem,
+    target: Option<&str>,
+    release: bool,
+) -> (Vec<String>, DiagnosticSource) {
+    match eco {
+        Ecosystem::Cargo => {
+            let mut argv = vec![
+                "cargo".into(),
+                "build".into(),
+                "--message-format=json-diagnostic-rendered-ansi".into(),
+            ];
+            if release {
+                argv.push("--release".into());
+            }
+            if let Some(t) = target {
+                argv.push("--target".into());
+                argv.push(t.into());
+            }
+            (argv, DiagnosticSource::CargoJson)
+        }
+        Ecosystem::Go => {
+            let mut argv = vec!["go".into(), "build".into()];
+            if let Some(t) = target {
+                argv.push(t.into());
+            } else {
+                argv.push("./...".into());
+            }
+            (argv, DiagnosticSource::GoBuild)
+        }
+        Ecosystem::Swift => {
+            let mut argv = vec!["swift".into(), "build".into()];
+            if release {
+                argv.push("-c".into());
+                argv.push("release".into());
+            }
+            if let Some(t) = target {
+                argv.push("--target".into());
+                argv.push(t.into());
+            }
+            (argv, DiagnosticSource::Generic)
+        }
+        Ecosystem::Npm => (
+            vec!["npm".into(), "run".into(), "build".into()],
+            DiagnosticSource::Generic,
+        ),
+        Ecosystem::Pnpm => (
+            vec!["pnpm".into(), "run".into(), "build".into()],
+            DiagnosticSource::Generic,
+        ),
+        Ecosystem::Yarn => (
+            vec!["yarn".into(), "build".into()],
+            DiagnosticSource::Generic,
+        ),
+        Ecosystem::Gradle => (
+            vec!["./gradlew".into(), "build".into()],
+            DiagnosticSource::Generic,
+        ),
+        Ecosystem::Maven => (
+            vec!["mvn".into(), "package".into()],
+            DiagnosticSource::Generic,
+        ),
+        Ecosystem::Dotnet => {
+            let mut argv = vec!["dotnet".into(), "build".into()];
+            if release {
+                argv.push("-c".into());
+                argv.push("Release".into());
+            }
+            if let Some(t) = target {
+                argv.push(t.into());
+            }
+            (argv, DiagnosticSource::Generic)
+        }
+        // Build is a no-op concept for these — fall back to whatever the
+        // ecosystem treats as "make sure deps resolve".
+        Ecosystem::Pip => (
+            vec!["python".into(), "-m".into(), "build".into()],
+            DiagnosticSource::Generic,
+        ),
+        Ecosystem::Uv => (vec!["uv".into(), "build".into()], DiagnosticSource::Generic),
+        Ecosystem::Poetry => (
+            vec!["poetry".into(), "build".into()],
+            DiagnosticSource::Generic,
+        ),
+        Ecosystem::Bundler => (
+            vec!["bundle".into(), "install".into()],
+            DiagnosticSource::Generic,
+        ),
+        Ecosystem::Composer => (
+            vec!["composer".into(), "install".into()],
+            DiagnosticSource::Generic,
+        ),
+    }
+}
+
+fn infer_diagnostic_source(argv: &[String]) -> DiagnosticSource {
+    let joined = argv.join(" ");
+    if joined.contains("cargo") && joined.contains("--message-format=json") {
+        DiagnosticSource::CargoJson
+    } else if argv.first().map(|s| s.as_str()) == Some("go") {
+        DiagnosticSource::GoBuild
+    } else {
+        DiagnosticSource::Generic
+    }
+}

--- a/crates/harn-hostlib/src/tools/run_command.rs
+++ b/crates/harn-hostlib/src/tools/run_command.rs
@@ -1,0 +1,77 @@
+//! `tools/run_command` — spawn an arbitrary argv with sandbox + timeout +
+//! stdout/stderr capture.
+//!
+//! Schema: `schemas/tools/run_command.{request,response}.json`.
+//!
+//! Divergence vs. Swift `CoreToolExecutor.runCommand`:
+//! - Input is `argv: [String]` (no shell parsing). The Swift implementation
+//!   accepted a shell `command: String` and routed through `ShellPathResolver`.
+//!   We require argv to eliminate the shell-injection surface; callers that
+//!   genuinely need a shell can pass `["sh", "-c", ...]` themselves.
+//! - `capture_stderr: false` collapses stderr into stdout instead of dropping
+//!   it (matches what Swift returned to LLMs).
+//! - There is no implicit cap of 300s on `timeout_ms`; the caller decides.
+//!   Sandboxing limits the blast radius regardless.
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::tools::payload::{
+    optional_bool, optional_string_map, optional_timeout, parse_argv_program, require_argv,
+    require_dict_arg,
+};
+use crate::tools::proc::{self, SpawnRequest};
+use crate::tools::response::ResponseBuilder;
+
+pub(crate) const NAME: &str = "hostlib_tools_run_command";
+
+pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let map = require_dict_arg(NAME, args)?;
+    let argv = require_argv(NAME, &map)?;
+    let (program, args_tail) = parse_argv_program(NAME, argv)?;
+    let cwd = proc::parse_cwd(NAME, payload_str(&map, "cwd").as_deref())?;
+    let env = optional_string_map(NAME, &map, "env")?.unwrap_or_default();
+    let stdin = payload_str(&map, "stdin");
+    let timeout = optional_timeout(NAME, &map, "timeout_ms")?;
+    let capture_stderr = optional_bool(NAME, &map, "capture_stderr")?.unwrap_or(true);
+
+    let outcome = proc::run(SpawnRequest {
+        builtin: NAME,
+        program,
+        args: args_tail,
+        cwd,
+        env,
+        stdin,
+        timeout,
+    })?;
+
+    let (stdout, stderr) = if capture_stderr {
+        (outcome.stdout, outcome.stderr)
+    } else {
+        let mut merged = outcome.stdout;
+        if !outcome.stderr.is_empty() {
+            if !merged.is_empty() && !merged.ends_with('\n') {
+                merged.push('\n');
+            }
+            merged.push_str(&outcome.stderr);
+        }
+        (merged, String::new())
+    };
+
+    Ok(ResponseBuilder::new()
+        .int("exit_code", outcome.exit_code as i64)
+        .opt_str("signal", outcome.signal)
+        .str("stdout", stdout)
+        .str("stderr", stderr)
+        .int("duration_ms", outcome.duration.as_millis() as i64)
+        .bool("timed_out", outcome.timed_out)
+        .build())
+}
+
+fn payload_str(map: &std::collections::BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+    match map.get(key)? {
+        VmValue::String(s) => Some(s.to_string()),
+        VmValue::Nil => None,
+        _ => None,
+    }
+}

--- a/crates/harn-hostlib/src/tools/run_test.rs
+++ b/crates/harn-hostlib/src/tools/run_test.rs
@@ -1,0 +1,213 @@
+//! `tools/run_test` — run a project-defined test command.
+//!
+//! Schema: `schemas/tools/run_test.{request,response}.json`.
+//!
+//! Behavior:
+//! - If `argv` is supplied, run it verbatim.
+//! - Otherwise detect the workspace ecosystem from `cwd` and pick a sensible
+//!   default test command (cargo test, pytest, vitest, go test, swift test,
+//!   …). When the runner supports it, append a JUnit-style reporter so we
+//!   can produce a `result_handle` for `inspect_test_results`.
+//! - When `filter` is supplied, append it through the runner's
+//!   pattern-filter flag (`-k`, `--filter`, `-run`, …).
+//!
+//! Divergence vs. Swift `runTest`:
+//! - We never invoke a Makefile or rely on `cachedBuildCommands` —
+//!   that's host-side state we don't have. Callers that drive a Makefile
+//!   should pass `argv: ["make", "test"]` explicitly.
+//! - JUnit XML / cargo libtest text is captured into the
+//!   `inspect_test_results` cache rather than parsed inline; that keeps
+//!   the response payload small and lets the caller drill in only when
+//!   they need to.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::path::PathBuf;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::tools::inspect_test_results::{store_run, RawArtifacts, TestSummaryData};
+use crate::tools::lang::{detect, Ecosystem};
+use crate::tools::payload::{
+    optional_string, optional_string_list, optional_timeout, parse_argv_program, require_dict_arg,
+};
+use crate::tools::proc::{self, SpawnRequest};
+use crate::tools::response::ResponseBuilder;
+
+pub(crate) const NAME: &str = "hostlib_tools_run_test";
+
+pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let map = require_dict_arg(NAME, args)?;
+    let cwd_raw = optional_string(NAME, &map, "cwd")?;
+    let cwd_path = proc::parse_cwd(NAME, cwd_raw.as_deref())?;
+    let cwd_for_detect = cwd_path
+        .clone()
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let filter = optional_string(NAME, &map, "filter")?;
+    let timeout = optional_timeout(NAME, &map, "timeout_ms")?;
+
+    let plan = if let Some(argv) = optional_string_list(NAME, &map, "argv")? {
+        TestPlan::Explicit(argv)
+    } else {
+        let ecosystem = detect(&cwd_for_detect).ok_or(HostlibError::InvalidParameter {
+            builtin: NAME,
+            param: "argv",
+            message: "no recognized project manifest in cwd; pass argv explicitly".to_string(),
+        })?;
+        TestPlan::Detected(ecosystem)
+    };
+
+    let (argv, junit_tmp) = plan.build_argv(filter.as_deref(), &cwd_for_detect)?;
+    let (program, args_tail) = parse_argv_program(NAME, argv.clone())?;
+
+    let outcome = proc::run(SpawnRequest {
+        builtin: NAME,
+        program,
+        args: args_tail,
+        cwd: cwd_path,
+        env: BTreeMap::new(),
+        stdin: None,
+        timeout,
+    })?;
+
+    let artifacts = RawArtifacts {
+        stdout: outcome.stdout.clone(),
+        stderr: outcome.stderr.clone(),
+        exit_code: outcome.exit_code,
+        junit_path: junit_tmp.clone(),
+        ecosystem: plan.ecosystem_name(),
+        argv,
+    };
+    let summary = artifacts.compute_summary();
+    let handle = store_run(artifacts);
+
+    let mut builder = ResponseBuilder::new()
+        .int("exit_code", outcome.exit_code as i64)
+        .str("stdout", outcome.stdout)
+        .str("stderr", outcome.stderr)
+        .int("duration_ms", outcome.duration.as_millis() as i64)
+        .str("result_handle", handle);
+
+    if let Some(summary) = summary {
+        builder = builder.dict("summary", summary_to_dict(summary));
+    }
+    Ok(builder.build())
+}
+
+fn summary_to_dict(summary: TestSummaryData) -> BTreeMap<String, VmValue> {
+    let mut map = BTreeMap::new();
+    map.insert("passed".to_string(), VmValue::Int(summary.passed as i64));
+    map.insert("failed".to_string(), VmValue::Int(summary.failed as i64));
+    map.insert("skipped".to_string(), VmValue::Int(summary.skipped as i64));
+    map
+}
+
+enum TestPlan {
+    Explicit(Vec<String>),
+    Detected(Ecosystem),
+}
+
+impl TestPlan {
+    fn ecosystem_name(&self) -> Option<String> {
+        match self {
+            TestPlan::Explicit(_) => None,
+            TestPlan::Detected(eco) => Some(eco.name().to_string()),
+        }
+    }
+
+    /// Returns `(argv, junit_tmp_file)`. `junit_tmp_file` is `Some` for the
+    /// runners we know how to point at a per-run JUnit output path.
+    fn build_argv(
+        &self,
+        filter: Option<&str>,
+        cwd: &Path,
+    ) -> Result<(Vec<String>, Option<PathBuf>), HostlibError> {
+        match self {
+            TestPlan::Explicit(argv) => Ok((argv.clone(), None)),
+            TestPlan::Detected(eco) => {
+                let mut argv = base_test_argv(*eco);
+                let mut junit_path = None;
+                match eco {
+                    Ecosystem::Pip | Ecosystem::Uv | Ecosystem::Poetry => {
+                        let path = junit_temp_path(cwd, "pytest");
+                        argv.push(format!("--junitxml={}", path.display()));
+                        junit_path = Some(path);
+                        if let Some(f) = filter {
+                            argv.push("-k".into());
+                            argv.push(f.into());
+                        }
+                    }
+                    Ecosystem::Pnpm | Ecosystem::Yarn | Ecosystem::Npm => {
+                        // Vitest is the most common JS runner that respects
+                        // these flags. Plain `npm test` hooks scripts —
+                        // we forward filter as a positional and let the
+                        // script consume it.
+                        let path = junit_temp_path(cwd, "vitest");
+                        argv.push("--reporter=junit".into());
+                        argv.push(format!("--outputFile={}", path.display()));
+                        junit_path = Some(path);
+                        if let Some(f) = filter {
+                            argv.push("-t".into());
+                            argv.push(f.into());
+                        }
+                    }
+                    Ecosystem::Cargo => {
+                        if let Some(f) = filter {
+                            argv.push(f.into());
+                        }
+                    }
+                    Ecosystem::Go => {
+                        if let Some(f) = filter {
+                            argv.push("-run".into());
+                            argv.push(f.into());
+                        }
+                    }
+                    Ecosystem::Swift => {
+                        if let Some(f) = filter {
+                            argv.push("--filter".into());
+                            argv.push(f.into());
+                        }
+                    }
+                    _ => {
+                        if let Some(f) = filter {
+                            argv.push(f.into());
+                        }
+                    }
+                }
+                Ok((argv, junit_path))
+            }
+        }
+    }
+}
+
+fn base_test_argv(eco: Ecosystem) -> Vec<String> {
+    match eco {
+        Ecosystem::Cargo => vec!["cargo".into(), "test".into()],
+        Ecosystem::Npm => vec!["npm".into(), "test".into()],
+        Ecosystem::Pnpm => vec!["pnpm".into(), "test".into()],
+        Ecosystem::Yarn => vec!["yarn".into(), "test".into()],
+        Ecosystem::Pip => vec!["pytest".into()],
+        Ecosystem::Uv => vec!["uv".into(), "run".into(), "pytest".into()],
+        Ecosystem::Poetry => vec!["poetry".into(), "run".into(), "pytest".into()],
+        Ecosystem::Go => vec!["go".into(), "test".into(), "./...".into()],
+        Ecosystem::Swift => vec!["swift".into(), "test".into()],
+        Ecosystem::Gradle => vec!["./gradlew".into(), "test".into()],
+        Ecosystem::Maven => vec!["mvn".into(), "test".into()],
+        Ecosystem::Bundler => vec!["bundle".into(), "exec".into(), "rake".into(), "test".into()],
+        Ecosystem::Composer => vec!["./vendor/bin/phpunit".into()],
+        Ecosystem::Dotnet => vec!["dotnet".into(), "test".into()],
+    }
+}
+
+fn junit_temp_path(cwd: &Path, prefix: &str) -> PathBuf {
+    let id: u64 = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let pid = std::process::id();
+    let target_dir = cwd.join(".harn").join("hostlib-tests");
+    let _ = std::fs::create_dir_all(&target_dir);
+    target_dir.join(format!("{prefix}-{pid}-{id}.xml"))
+}

--- a/crates/harn-hostlib/src/tools/test_parsers.rs
+++ b/crates/harn-hostlib/src/tools/test_parsers.rs
@@ -1,0 +1,359 @@
+//! Per-runner test-output parsers.
+//!
+//! - `parse_junit_xml`: handles pytest, vitest, gradle/maven surefire, and
+//!   the JUnit dialect cargo-nextest emits when configured to.
+//! - `parse_cargo_libtest`: parses the plain-text format `cargo test`
+//!   produces by default (`test foo::bar ... ok` lines + a summary).
+//! - `parse_go_text`: handles `go test` non-`-json` output (PASS/FAIL +
+//!   `--- FAIL: TestX (0.01s)` blocks).
+//!
+//! The parsers are deliberately lenient: a malformed run yields fewer
+//! records, never a parse error. Callers fall back to the raw stdout/stderr
+//! the response already includes.
+
+use std::time::Duration;
+
+/// Status of one test run, matching the `status` enum in the schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Status {
+    Passed,
+    Failed,
+    Skipped,
+    Errored,
+}
+
+impl Status {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Status::Passed => "passed",
+            Status::Failed => "failed",
+            Status::Skipped => "skipped",
+            Status::Errored => "errored",
+        }
+    }
+}
+
+/// One per-test record. Mirrors the `TestRecord` schema in
+/// `inspect_test_results.response.json`.
+#[derive(Debug, Clone)]
+pub(crate) struct TestRecord {
+    pub(crate) name: String,
+    pub(crate) status: Status,
+    pub(crate) duration_ms: u64,
+    pub(crate) message: Option<String>,
+    pub(crate) stdout: Option<String>,
+    pub(crate) stderr: Option<String>,
+    pub(crate) path: Option<String>,
+    pub(crate) line: Option<i64>,
+}
+
+impl TestRecord {
+    fn new(name: impl Into<String>, status: Status) -> Self {
+        Self {
+            name: name.into(),
+            status,
+            duration_ms: 0,
+            message: None,
+            stdout: None,
+            stderr: None,
+            path: None,
+            line: None,
+        }
+    }
+}
+
+/// Parse a JUnit XML byte stream into [`TestRecord`]s. Returns `Err(())` if
+/// the XML is malformed enough that we can't extract anything — the
+/// caller falls back to other parsers.
+pub(crate) fn parse_junit_xml(bytes: &[u8]) -> Result<Vec<TestRecord>, ()> {
+    let text = std::str::from_utf8(bytes).map_err(|_| ())?;
+    let mut out = Vec::new();
+    let mut cursor = 0;
+    while let Some(rel_open) = text[cursor..].find("<testcase") {
+        let open_start = cursor + rel_open;
+        let header_end = match text[open_start..].find('>') {
+            Some(idx) => open_start + idx,
+            None => break,
+        };
+        let header = &text[open_start..header_end];
+        let self_closing = header.ends_with('/');
+        let name = attr(header, "name").unwrap_or_default();
+        let classname = attr(header, "classname");
+        let time_seconds = attr(header, "time")
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(0.0);
+
+        let qualified = match (&classname, name.is_empty()) {
+            (Some(cls), false) if !cls.is_empty() => format!("{cls}::{name}"),
+            (_, _) => name.clone(),
+        };
+
+        let mut record = TestRecord::new(qualified, Status::Passed);
+        record.duration_ms = duration_seconds_to_ms(time_seconds);
+
+        if !self_closing {
+            let close_idx = match text[header_end..].find("</testcase>") {
+                Some(idx) => header_end + idx,
+                None => break,
+            };
+            let body = &text[header_end + 1..close_idx];
+            apply_body(&mut record, body);
+            cursor = close_idx + "</testcase>".len();
+        } else {
+            cursor = header_end + 1;
+        }
+
+        out.push(record);
+    }
+    Ok(out)
+}
+
+fn apply_body(record: &mut TestRecord, body: &str) {
+    if let Some((tag, message, body_text)) = first_child_with_message(body, "failure") {
+        record.status = Status::Failed;
+        record.message = Some(combined_message(message, body_text));
+        let _ = tag;
+    } else if let Some((tag, message, body_text)) = first_child_with_message(body, "error") {
+        record.status = Status::Errored;
+        record.message = Some(combined_message(message, body_text));
+        let _ = tag;
+    } else if body.contains("<skipped") {
+        record.status = Status::Skipped;
+    }
+
+    if let Some(text) = first_child_text(body, "system-out") {
+        record.stdout = Some(text);
+    }
+    if let Some(text) = first_child_text(body, "system-err") {
+        record.stderr = Some(text);
+    }
+}
+
+fn first_child_with_message<'a>(
+    body: &'a str,
+    tag: &'a str,
+) -> Option<(&'a str, Option<String>, String)> {
+    let open = format!("<{tag}");
+    let close_open = format!("</{tag}>");
+    let pos = body.find(open.as_str())?;
+    let header_end = body[pos..].find('>').map(|i| pos + i)?;
+    let header = &body[pos..header_end];
+    let message = attr(header, "message");
+    let self_closing = header.ends_with('/');
+    let body_text = if self_closing {
+        String::new()
+    } else {
+        let close_pos = body[header_end..]
+            .find(&close_open)
+            .map(|i| header_end + i)?;
+        body[header_end + 1..close_pos].trim().to_string()
+    };
+    Some((tag, message, body_text))
+}
+
+fn first_child_text(body: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}");
+    let close = format!("</{tag}>");
+    let pos = body.find(open.as_str())?;
+    let header_end = body[pos..].find('>').map(|i| pos + i)?;
+    let close_pos = body[header_end..].find(&close).map(|i| header_end + i)?;
+    Some(body[header_end + 1..close_pos].trim().to_string())
+}
+
+fn combined_message(message: Option<String>, body_text: String) -> String {
+    match (message, body_text.is_empty()) {
+        (Some(m), true) => m,
+        (Some(m), false) => format!("{m}\n{body_text}"),
+        (None, _) => body_text,
+    }
+}
+
+fn attr(header: &str, key: &str) -> Option<String> {
+    // Require a leading space so we don't match `name="..."` inside
+    // `classname="..."` and friends. XML attribute names always follow a
+    // space (or the tag name itself), so this is safe for well-formed
+    // input.
+    let needle = format!(" {key}=\"");
+    let start = header.find(&needle)?;
+    let after = &header[start + needle.len()..];
+    let end = after.find('"')?;
+    Some(unescape_xml(&after[..end]))
+}
+
+fn unescape_xml(text: &str) -> String {
+    text.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&amp;", "&")
+}
+
+fn duration_seconds_to_ms(seconds: f64) -> u64 {
+    if seconds.is_finite() && seconds >= 0.0 {
+        Duration::from_secs_f64(seconds).as_millis() as u64
+    } else {
+        0
+    }
+}
+
+/// Parse cargo's libtest plain-text output. Recognizes lines like
+/// `test foo::bar ... ok` / `... FAILED` / `... ignored`, and matches the
+/// trailing `failures:` block to attach failure messages.
+pub(crate) fn parse_cargo_libtest(stdout: &str) -> Vec<TestRecord> {
+    let mut out: Vec<TestRecord> = Vec::new();
+    for line in stdout.lines() {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with("test ") {
+            continue;
+        }
+        // skip aggregate "test result: ..." line
+        if trimmed.starts_with("test result:") {
+            continue;
+        }
+        let body = &trimmed[5..];
+        let Some((name, tail)) = body.split_once(" ... ") else {
+            continue;
+        };
+        let status = match tail.trim() {
+            "ok" => Status::Passed,
+            "FAILED" => Status::Failed,
+            "ignored" | "skipped" => Status::Skipped,
+            _ if tail.starts_with("ok") => Status::Passed,
+            _ if tail.starts_with("FAILED") => Status::Failed,
+            _ => continue,
+        };
+        out.push(TestRecord::new(name.trim(), status));
+    }
+    attach_libtest_failure_bodies(&mut out, stdout);
+    out
+}
+
+fn attach_libtest_failure_bodies(records: &mut [TestRecord], stdout: &str) {
+    let Some(idx) = stdout.find("\nfailures:\n\n") else {
+        return;
+    };
+    let body = &stdout[idx + "\nfailures:\n\n".len()..];
+    let blocks = body.split("\n\n");
+    for block in blocks {
+        let Some(first_line) = block.lines().next() else {
+            continue;
+        };
+        let header = first_line.trim();
+        if !header.starts_with("---- ") || !header.ends_with(" stdout ----") {
+            continue;
+        }
+        let name = header
+            .trim_start_matches("---- ")
+            .trim_end_matches(" stdout ----")
+            .trim();
+        let message = block.lines().skip(1).collect::<Vec<_>>().join("\n");
+        if let Some(record) = records.iter_mut().find(|r| r.name == name) {
+            if !message.is_empty() {
+                record.message = Some(message);
+            }
+        }
+    }
+}
+
+/// Parse plain-text `go test` output. Recognizes `--- PASS: TestX (0.01s)`
+/// / `--- FAIL: TestX` / `--- SKIP: TestX` lines.
+pub(crate) fn parse_go_text(stdout: &str, stderr: &str) -> Vec<TestRecord> {
+    let mut out = Vec::new();
+    let combined = format!("{stdout}\n{stderr}");
+    for line in combined.lines() {
+        let trimmed = line.trim_start();
+        let parsed = if let Some(rest) = trimmed.strip_prefix("--- PASS: ") {
+            parse_go_event(rest, Status::Passed)
+        } else if let Some(rest) = trimmed.strip_prefix("--- FAIL: ") {
+            parse_go_event(rest, Status::Failed)
+        } else if let Some(rest) = trimmed.strip_prefix("--- SKIP: ") {
+            parse_go_event(rest, Status::Skipped)
+        } else {
+            None
+        };
+        if let Some(record) = parsed {
+            out.push(record);
+        }
+    }
+    out
+}
+
+fn parse_go_event(rest: &str, status: Status) -> Option<TestRecord> {
+    // "TestFoo (0.00s)"
+    let (name, duration_part) = rest.split_once(" (").unwrap_or((rest, ""));
+    let mut record = TestRecord::new(name.trim(), status);
+    if let Some(secs) = duration_part.trim_end_matches(')').strip_suffix('s') {
+        if let Ok(value) = secs.parse::<f64>() {
+            record.duration_ms = duration_seconds_to_ms(value);
+        }
+    }
+    Some(record)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_junit_xml_with_failure_and_skip() {
+        let xml = r#"<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="suite">
+    <testcase classname="C" name="passes" time="0.001"/>
+    <testcase classname="C" name="fails" time="0.002">
+      <failure message="boom">stack trace here</failure>
+    </testcase>
+    <testcase classname="C" name="skipped"><skipped/></testcase>
+  </testsuite>
+</testsuites>"#;
+        let records = parse_junit_xml(xml.as_bytes()).unwrap();
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].status, Status::Passed);
+        assert_eq!(records[0].name, "C::passes");
+        assert_eq!(records[1].status, Status::Failed);
+        assert!(records[1].message.as_deref().unwrap().contains("boom"));
+        assert_eq!(records[2].status, Status::Skipped);
+    }
+
+    #[test]
+    fn parses_cargo_libtest_pass_and_fail() {
+        let out = "running 3 tests
+test mod_a::passes ... ok
+test mod_a::fails ... FAILED
+test mod_b::skipped ... ignored
+
+failures:
+
+---- mod_a::fails stdout ----
+assertion `left == right` failed
+  left: 1
+  right: 2
+
+failures:
+    mod_a::fails
+
+test result: FAILED. 1 passed; 1 failed; 1 ignored
+";
+        let records = parse_cargo_libtest(out);
+        assert_eq!(records.len(), 3);
+        let fail = records.iter().find(|r| r.name == "mod_a::fails").unwrap();
+        assert_eq!(fail.status, Status::Failed);
+        assert!(fail.message.as_deref().unwrap().contains("assertion"));
+    }
+
+    #[test]
+    fn parses_go_text_blocks() {
+        let stdout = "=== RUN TestA
+--- PASS: TestA (0.01s)
+=== RUN TestB
+--- FAIL: TestB (0.02s)
+PASS
+";
+        let records = parse_go_text(stdout, "");
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].status, Status::Passed);
+        assert_eq!(records[0].duration_ms, 10);
+        assert_eq!(records[1].status, Status::Failed);
+        assert_eq!(records[1].duration_ms, 20);
+    }
+}

--- a/crates/harn-hostlib/tests/process_tools.rs
+++ b/crates/harn-hostlib/tests/process_tools.rs
@@ -1,0 +1,411 @@
+//! Integration tests for issue #568 — the five process-lifecycle tool
+//! builtins (`run_command`, `run_test`, `run_build_command`,
+//! `inspect_test_results`, `manage_packages`).
+//!
+//! These spawn real subprocesses, so they're gated to Unix and rely only
+//! on coreutils / shell that ship with both macOS and standard Linux
+//! distros. The tests assert on:
+//!
+//! - argv / cwd / env / stdin plumbing matches the request schema
+//! - timeout enforcement kills the child and reports `timed_out: true`
+//! - error variants (missing argv, bad cwd, malformed types) round-trip
+//!   through `HostlibError` rather than panicking
+//! - language detection picks the right runner from manifest files
+//! - inspect_test_results parses JUnit XML written by `run_test`
+
+#![cfg(unix)]
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use harn_hostlib::tools::ToolsCapability;
+use harn_hostlib::{BuiltinRegistry, HostlibCapability, HostlibError};
+use harn_vm::VmValue;
+use tempfile::tempdir;
+
+fn registry() -> BuiltinRegistry {
+    let mut registry = BuiltinRegistry::new();
+    ToolsCapability.register_builtins(&mut registry);
+    registry
+}
+
+fn call(builtin: &str, request: BTreeMap<String, VmValue>) -> Result<VmValue, HostlibError> {
+    harn_hostlib::tools::permissions::enable_for_test();
+    let registry = registry();
+    let entry = registry
+        .find(builtin)
+        .unwrap_or_else(|| panic!("builtin {builtin} not registered"));
+    let arg = VmValue::Dict(Rc::new(request));
+    (entry.handler)(&[arg])
+}
+
+fn dict() -> BTreeMap<String, VmValue> {
+    BTreeMap::new()
+}
+
+fn vstr(value: &str) -> VmValue {
+    VmValue::String(Rc::from(value))
+}
+
+fn vlist_str(values: &[&str]) -> VmValue {
+    VmValue::List(Rc::new(values.iter().map(|s| vstr(s)).collect()))
+}
+
+fn require_dict(value: VmValue) -> BTreeMap<String, VmValue> {
+    match value {
+        VmValue::Dict(map) => (*map).clone(),
+        other => panic!("expected dict response, got {other:?}"),
+    }
+}
+
+fn require_int(map: &BTreeMap<String, VmValue>, key: &str) -> i64 {
+    match map.get(key) {
+        Some(VmValue::Int(i)) => *i,
+        other => panic!("expected int at {key}, got {other:?}"),
+    }
+}
+
+fn require_str(map: &BTreeMap<String, VmValue>, key: &str) -> String {
+    match map.get(key) {
+        Some(VmValue::String(s)) => s.to_string(),
+        other => panic!("expected string at {key}, got {other:?}"),
+    }
+}
+
+fn require_bool(map: &BTreeMap<String, VmValue>, key: &str) -> bool {
+    match map.get(key) {
+        Some(VmValue::Bool(b)) => *b,
+        other => panic!("expected bool at {key}, got {other:?}"),
+    }
+}
+
+// -------- run_command --------
+
+#[test]
+fn run_command_echoes_stdout_and_reports_exit_zero() {
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["bash", "-c", "echo hello"]));
+    let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
+
+    assert_eq!(require_int(&resp, "exit_code"), 0);
+    assert_eq!(require_str(&resp, "stdout").trim(), "hello");
+    assert_eq!(require_str(&resp, "stderr"), "");
+    assert!(!require_bool(&resp, "timed_out"));
+    assert!(matches!(resp.get("signal"), Some(VmValue::Nil)));
+    assert!(require_int(&resp, "duration_ms") >= 0);
+}
+
+#[test]
+fn run_command_propagates_nonzero_exit_code() {
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["bash", "-c", "exit 7"]));
+    let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
+    assert_eq!(require_int(&resp, "exit_code"), 7);
+    assert!(!require_bool(&resp, "timed_out"));
+}
+
+#[test]
+fn run_command_pipes_stdin_into_child() {
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["cat"]));
+    req.insert("stdin".into(), vstr("from-stdin"));
+    let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
+    assert_eq!(require_str(&resp, "stdout"), "from-stdin");
+}
+
+#[test]
+fn run_command_runs_in_supplied_cwd() {
+    let dir = tempdir().unwrap();
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["bash", "-c", "pwd"]));
+    req.insert("cwd".into(), vstr(dir.path().to_str().unwrap()));
+    let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
+
+    let stdout = require_str(&resp, "stdout");
+    let canon_cwd = std::fs::canonicalize(dir.path()).unwrap();
+    let canon_stdout = std::fs::canonicalize(stdout.trim()).unwrap();
+    assert_eq!(canon_stdout, canon_cwd);
+}
+
+#[test]
+fn run_command_kills_child_when_timeout_elapses() {
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["sleep", "30"]));
+    req.insert("timeout_ms".into(), VmValue::Int(150));
+    let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
+    assert!(require_bool(&resp, "timed_out"));
+    // Killed children report exit_code -1 + a signal name.
+    assert!(matches!(resp.get("signal"), Some(VmValue::String(_))));
+}
+
+#[test]
+fn run_command_capture_stderr_false_merges_into_stdout() {
+    let mut req = dict();
+    req.insert(
+        "argv".into(),
+        vlist_str(&["bash", "-c", "echo out; echo err 1>&2"]),
+    );
+    req.insert("capture_stderr".into(), VmValue::Bool(false));
+    let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
+    let stdout = require_str(&resp, "stdout");
+    assert!(stdout.contains("out"), "stdout was {stdout:?}");
+    assert!(stdout.contains("err"), "stdout was {stdout:?}");
+    assert_eq!(require_str(&resp, "stderr"), "");
+}
+
+#[test]
+fn run_command_passes_env_when_supplied() {
+    let mut env_dict: BTreeMap<String, VmValue> = BTreeMap::new();
+    env_dict.insert("PATH".into(), vstr(env!("PATH")));
+    env_dict.insert("HOSTLIB_TEST_VAR".into(), vstr("value-42"));
+
+    let mut req = dict();
+    req.insert(
+        "argv".into(),
+        vlist_str(&["bash", "-c", "echo $HOSTLIB_TEST_VAR"]),
+    );
+    req.insert("env".into(), VmValue::Dict(Rc::new(env_dict)));
+    let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
+    assert_eq!(require_str(&resp, "stdout").trim(), "value-42");
+}
+
+#[test]
+fn run_command_missing_argv_returns_missing_parameter() {
+    let err = call("hostlib_tools_run_command", dict()).unwrap_err();
+    match err {
+        HostlibError::MissingParameter { param, .. } => assert_eq!(param, "argv"),
+        other => panic!("expected MissingParameter, got {other:?}"),
+    }
+}
+
+#[test]
+fn run_command_empty_argv_returns_invalid_parameter() {
+    let mut req = dict();
+    req.insert("argv".into(), VmValue::List(Rc::new(Vec::new())));
+    let err = call("hostlib_tools_run_command", req).unwrap_err();
+    assert!(matches!(err, HostlibError::InvalidParameter { param, .. } if param == "argv"));
+}
+
+#[test]
+fn run_command_rejects_nonexistent_cwd() {
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["true"]));
+    req.insert("cwd".into(), vstr("/this/does/not/exist/anywhere"));
+    let err = call("hostlib_tools_run_command", req).unwrap_err();
+    assert!(matches!(err, HostlibError::InvalidParameter { param, .. } if param == "cwd"));
+}
+
+#[test]
+fn run_command_argv_must_be_strings() {
+    let mut req = dict();
+    req.insert("argv".into(), VmValue::List(Rc::new(vec![VmValue::Int(1)])));
+    let err = call("hostlib_tools_run_command", req).unwrap_err();
+    assert!(matches!(err, HostlibError::InvalidParameter { param, .. } if param == "argv"));
+}
+
+// -------- run_test --------
+
+#[test]
+fn run_test_explicit_argv_runs_and_returns_handle() {
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["true"]));
+    let resp = require_dict(call("hostlib_tools_run_test", req).unwrap());
+    assert_eq!(require_int(&resp, "exit_code"), 0);
+    assert!(!require_str(&resp, "result_handle").is_empty());
+}
+
+#[test]
+fn run_test_without_argv_or_manifest_errors() {
+    let dir = tempdir().unwrap();
+    let mut req = dict();
+    req.insert("cwd".into(), vstr(dir.path().to_str().unwrap()));
+    let err = call("hostlib_tools_run_test", req).unwrap_err();
+    assert!(matches!(err, HostlibError::InvalidParameter { param, .. } if param == "argv"));
+}
+
+#[test]
+fn run_test_inspect_returns_parsed_records_for_explicit_junit() {
+    // Stage a JUnit XML that the bundled handler would have written, then
+    // ask `run_test` to drive a no-op runner and point at it via argv.
+    let dir = tempdir().unwrap();
+    let junit = dir.path().join("junit.xml");
+    std::fs::write(
+        &junit,
+        r#"<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="suite">
+    <testcase classname="C" name="passes" time="0.001"/>
+    <testcase classname="C" name="fails" time="0.005">
+      <failure message="boom">trace</failure>
+    </testcase>
+  </testsuite>
+</testsuites>"#,
+    )
+    .unwrap();
+
+    // Mock pytest by passing argv that just `cat`s the JUnit and exits 0,
+    // but since explicit-argv `run_test` won't know to look for the file,
+    // we test via inspect_test_results stable behavior: shape it like
+    // the cargo libtest text path which the parser auto-detects.
+    let mut req = dict();
+    req.insert(
+        "argv".into(),
+        vlist_str(&[
+            "bash",
+            "-c",
+            "echo 'running 2 tests'; echo 'test a::passes ... ok'; echo 'test a::fails ... FAILED'; printf '\\n'; echo 'test result: FAILED. 1 passed; 1 failed; 0 ignored'; exit 1",
+        ]),
+    );
+    let resp = require_dict(call("hostlib_tools_run_test", req).unwrap());
+    assert_eq!(require_int(&resp, "exit_code"), 1);
+    let handle = require_str(&resp, "result_handle");
+
+    let mut inspect_req = dict();
+    inspect_req.insert("result_handle".into(), vstr(&handle));
+    inspect_req.insert("include_passing".into(), VmValue::Bool(true));
+    let inspect = require_dict(call("hostlib_tools_inspect_test_results", inspect_req).unwrap());
+    assert_eq!(require_str(&inspect, "result_handle"), handle);
+    let tests = match inspect.get("tests") {
+        Some(VmValue::List(l)) => (**l).clone(),
+        other => panic!("expected list, got {other:?}"),
+    };
+    assert_eq!(tests.len(), 2);
+}
+
+#[test]
+fn run_test_summary_omitted_when_no_records_parsed() {
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["bash", "-c", "echo nothing"]));
+    let resp = require_dict(call("hostlib_tools_run_test", req).unwrap());
+    assert!(!resp.contains_key("summary"));
+}
+
+// -------- inspect_test_results --------
+
+#[test]
+fn inspect_test_results_unknown_handle_errors() {
+    let mut req = dict();
+    req.insert(
+        "result_handle".into(),
+        vstr("htr-deadbeef-this-is-not-real"),
+    );
+    let err = call("hostlib_tools_inspect_test_results", req).unwrap_err();
+    assert!(
+        matches!(err, HostlibError::InvalidParameter { param, .. } if param == "result_handle")
+    );
+}
+
+#[test]
+fn inspect_test_results_missing_handle_errors() {
+    let err = call("hostlib_tools_inspect_test_results", dict()).unwrap_err();
+    assert!(
+        matches!(err, HostlibError::MissingParameter { param, .. } if param == "result_handle")
+    );
+}
+
+// -------- run_build_command --------
+
+#[test]
+fn run_build_command_explicit_argv_runs_and_parses_diagnostics() {
+    let mut req = dict();
+    req.insert(
+        "argv".into(),
+        vlist_str(&[
+            "bash",
+            "-c",
+            "echo 'src/foo.rs:3:7: error: parse error here' 1>&2; exit 2",
+        ]),
+    );
+    let resp = require_dict(call("hostlib_tools_run_build_command", req).unwrap());
+    assert_eq!(require_int(&resp, "exit_code"), 2);
+    let diagnostics = match resp.get("diagnostics") {
+        Some(VmValue::List(l)) => (**l).clone(),
+        other => panic!("expected list, got {other:?}"),
+    };
+    assert!(!diagnostics.is_empty());
+}
+
+#[test]
+fn run_build_command_without_argv_or_manifest_errors() {
+    let dir = tempdir().unwrap();
+    let mut req = dict();
+    req.insert("cwd".into(), vstr(dir.path().to_str().unwrap()));
+    let err = call("hostlib_tools_run_build_command", req).unwrap_err();
+    assert!(matches!(err, HostlibError::InvalidParameter { param, .. } if param == "argv"));
+}
+
+// -------- manage_packages --------
+
+#[test]
+fn manage_packages_missing_operation_errors() {
+    let err = call("hostlib_tools_manage_packages", dict()).unwrap_err();
+    assert!(matches!(err, HostlibError::MissingParameter { param, .. } if param == "operation"));
+}
+
+#[test]
+fn manage_packages_unknown_operation_errors() {
+    let mut req = dict();
+    req.insert("operation".into(), vstr("frobnicate"));
+    req.insert("ecosystem".into(), vstr("npm"));
+    let err = call("hostlib_tools_manage_packages", req).unwrap_err();
+    assert!(matches!(err, HostlibError::InvalidParameter { param, .. } if param == "operation"));
+}
+
+#[test]
+fn manage_packages_no_ecosystem_no_manifest_errors() {
+    let dir = tempdir().unwrap();
+    let mut req = dict();
+    req.insert("operation".into(), vstr("install"));
+    req.insert("cwd".into(), vstr(dir.path().to_str().unwrap()));
+    let err = call("hostlib_tools_manage_packages", req).unwrap_err();
+    assert!(matches!(err, HostlibError::InvalidParameter { param, .. } if param == "ecosystem"));
+}
+
+#[test]
+fn manage_packages_unsupported_pair_for_ecosystem_errors() {
+    // gradle has no defined `add` mapping today.
+    let mut req = dict();
+    req.insert("operation".into(), vstr("add"));
+    req.insert("ecosystem".into(), vstr("gradle"));
+    req.insert("packages".into(), vlist_str(&["junit"]));
+    let err = call("hostlib_tools_manage_packages", req).unwrap_err();
+    assert!(matches!(err, HostlibError::InvalidParameter { param, .. } if param == "operation"));
+}
+
+#[test]
+fn manage_packages_runs_for_detected_npm_workspace_when_manifest_present() {
+    // We can't actually invoke `npm install` in a sandboxed tmp directory
+    // without network access, so use an `ecosystem` that maps to a tiny
+    // synthetic command via the executable-on-PATH machinery. We re-run
+    // the real plumbing by overriding the ecosystem to something whose
+    // first argv element is a no-op shell builtin.
+    //
+    // This test asserts that *given* an explicit ecosystem + a real cwd,
+    // the builtin assembles + spawns + collects an outcome. It uses the
+    // `bundler` ecosystem with `update` (no packages) → `bundle update`,
+    // then accepts whatever exit code the missing binary yields. The
+    // important part: no panic, structured response, lockfile_changed
+    // reported as a bool.
+    let dir = tempdir().unwrap();
+    let mut req = dict();
+    req.insert("operation".into(), vstr("update"));
+    req.insert("ecosystem".into(), vstr("bundler"));
+    req.insert("cwd".into(), vstr(dir.path().to_str().unwrap()));
+    let result = call("hostlib_tools_manage_packages", req);
+    match result {
+        Ok(value) => {
+            let resp = require_dict(value);
+            assert_eq!(require_str(&resp, "ecosystem"), "bundler");
+            assert_eq!(require_str(&resp, "operation"), "update");
+            assert!(matches!(
+                resp.get("lockfile_changed"),
+                Some(VmValue::Bool(_))
+            ));
+        }
+        Err(HostlibError::Backend { .. }) => {
+            // Spawn failed because `bundle` isn't installed in CI — that's
+            // a valid sandbox-aware backend error, not a contract bug.
+        }
+        Err(other) => panic!("unexpected error variant: {other:?}"),
+    }
+}

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -109,8 +109,8 @@ fn tools_capability_registers_documented_methods() {
             "hostlib_tools_list_directory",
             "hostlib_tools_get_file_outline",
             "hostlib_tools_git",
-            // Process tools — slated for issue C2; still routed through
-            // `HostlibError::Unimplemented` until then.
+            // Process tools from issue #568. Also gated by
+            // `hostlib_enable("tools:deterministic")`.
             "hostlib_tools_run_command",
             "hostlib_tools_run_test",
             "hostlib_tools_run_build_command",
@@ -121,39 +121,37 @@ fn tools_capability_registers_documented_methods() {
         ]
     );
 
-    // Process tools must still route through `Unimplemented` — they are
-    // slated for issue C2.
-    let process_methods = [
+    // All implemented tools must refuse to run before
+    // `hostlib_enable("tools:deterministic")`. We check each entry so newly
+    // wired tools cannot accidentally bypass the opt-in gate.
+    harn_hostlib::tools::permissions::reset();
+    let gated_methods = [
+        "hostlib_tools_search",
+        "hostlib_tools_read_file",
+        "hostlib_tools_write_file",
+        "hostlib_tools_delete_file",
+        "hostlib_tools_list_directory",
+        "hostlib_tools_get_file_outline",
+        "hostlib_tools_git",
         "hostlib_tools_run_command",
         "hostlib_tools_run_test",
         "hostlib_tools_run_build_command",
         "hostlib_tools_inspect_test_results",
         "hostlib_tools_manage_packages",
     ];
-    for name in process_methods {
+    for name in gated_methods {
         let entry = registry.find(name).expect("registered");
-        let err = (entry.handler)(&[]).expect_err("must be unimplemented");
-        assert!(
-            matches!(err, HostlibError::Unimplemented { builtin } if builtin == name),
-            "expected Unimplemented for {name}, got {err:?}"
-        );
-    }
-
-    // Deterministic tools must refuse to run before
-    // `hostlib_enable("tools:deterministic")`. We check one representative
-    // builtin to confirm the gating handler is wired.
-    harn_hostlib::tools::permissions::reset();
-    let search = registry.find("hostlib_tools_search").expect("registered");
-    let err = (search.handler)(&[]).expect_err("disabled by default");
-    match err {
-        HostlibError::Backend { builtin, message } => {
-            assert_eq!(builtin, "hostlib_tools_search");
-            assert!(
-                message.contains("hostlib_enable"),
-                "gating error must point users at hostlib_enable: {message}"
-            );
+        let err = (entry.handler)(&[]).expect_err("disabled by default");
+        match err {
+            HostlibError::Backend { builtin, message } => {
+                assert_eq!(builtin, name);
+                assert!(
+                    message.contains("hostlib_enable"),
+                    "gating error must point users at hostlib_enable: {message}"
+                );
+            }
+            other => panic!("expected Backend gate error for {name}, got {other:?}"),
         }
-        other => panic!("expected Backend gate error, got {other:?}"),
     }
 }
 

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -24,6 +24,7 @@ pub mod metadata;
 pub mod observability;
 pub mod orchestration;
 pub mod personas;
+pub mod process_sandbox;
 pub mod record_filter;
 pub mod runtime_context;
 pub mod runtime_paths;

--- a/crates/harn-vm/src/process_sandbox.rs
+++ b/crates/harn-vm/src/process_sandbox.rs
@@ -1,0 +1,17 @@
+//! Public re-exports of the platform-specific process sandbox primitives.
+//!
+//! Embedders that spawn subprocesses on behalf of Harn scripts (today: the
+//! `harn-hostlib` deterministic-tool builtins) must funnel every spawn
+//! through these helpers so the active orchestration capability policy is
+//! enforced — Linux seccomp/landlock filters via `pre_exec`, macOS
+//! `sandbox-exec` wrapping, plus workspace-root cwd enforcement.
+//!
+//! The helpers themselves live next to the rest of the sandbox state in
+//! [`crate::stdlib::sandbox`]. This module exists so external crates have a
+//! stable, documented surface to depend on without reaching into
+//! `stdlib::*` plumbing.
+
+pub use crate::stdlib::sandbox::{
+    enforce_process_cwd, process_spawn_error, process_violation_error, std_command_for,
+    tokio_command_for,
+};

--- a/crates/harn-vm/src/stdlib/sandbox.rs
+++ b/crates/harn-vm/src/stdlib/sandbox.rs
@@ -61,7 +61,7 @@ pub(crate) fn enforce_fs_path(builtin: &str, path: &Path, access: FsAccess) -> R
     )))
 }
 
-pub(crate) fn enforce_process_cwd(path: &Path) -> Result<(), VmError> {
+pub fn enforce_process_cwd(path: &Path) -> Result<(), VmError> {
     let Some(policy) = crate::orchestration::current_execution_policy() else {
         return Ok(());
     };
@@ -84,7 +84,7 @@ pub(crate) fn enforce_process_cwd(path: &Path) -> Result<(), VmError> {
     )))
 }
 
-pub(crate) fn std_command_for(program: &str, args: &[String]) -> Result<Command, VmError> {
+pub fn std_command_for(program: &str, args: &[String]) -> Result<Command, VmError> {
     let policy = active_sandbox_policy();
     match command_wrapper(program, args, policy.as_ref())? {
         CommandWrapper::Direct => {
@@ -104,7 +104,7 @@ pub(crate) fn std_command_for(program: &str, args: &[String]) -> Result<Command,
     }
 }
 
-pub(crate) fn tokio_command_for(
+pub fn tokio_command_for(
     program: &str,
     args: &[String],
 ) -> Result<tokio::process::Command, VmError> {
@@ -127,7 +127,7 @@ pub(crate) fn tokio_command_for(
     }
 }
 
-pub(crate) fn process_violation_error(output: &std::process::Output) -> Option<VmError> {
+pub fn process_violation_error(output: &std::process::Output) -> Option<VmError> {
     crate::orchestration::current_execution_policy()?;
     if fallback_mode() == SandboxFallback::Off || !platform_sandbox_available() {
         return None;
@@ -153,7 +153,7 @@ pub(crate) fn process_violation_error(output: &std::process::Output) -> Option<V
     None
 }
 
-pub(crate) fn process_spawn_error(error: &std::io::Error) -> Option<VmError> {
+pub fn process_spawn_error(error: &std::io::Error) -> Option<VmError> {
     crate::orchestration::current_execution_policy()?;
     if fallback_mode() == SandboxFallback::Off || !platform_sandbox_available() {
         return None;


### PR DESCRIPTION
## Summary

Reopens the orphaned #604 work against `main` for issue #606, without overwriting the deterministic tools that landed in #605.

- Implements the five `harn-hostlib` process-lifecycle tools: `run_command`, `run_test`, `run_build_command`, `inspect_test_results`, and `manage_packages`.
- Keeps all process tools behind the existing `tools:deterministic` per-session opt-in gate alongside search/file/git tools.
- Adds `harn_vm::process_sandbox` public re-exports so external embedders spawn through the VM sandbox helpers instead of reaching into stdlib internals.
- Updates registration tests, process-tool integration coverage, README status/docs, and the Unreleased changelog entry.

## Root Cause

PR #604 was merged into the stacked base branch `ksinder/harn-hostlib-scaffold` instead of `main`. When that parent branch was deleted, GitHub marked #604 merged even though its implementation commit never reached `origin/main`.

## Validation

- `cargo test -p harn-hostlib`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/harn-606-target cargo clippy -p harn-hostlib --all-targets -- -D warnings`
- `npx markdownlint-cli2 CHANGELOG.md crates/harn-hostlib/README.md`
- Pre-commit hook: `cargo fmt`, workspace clippy, generated highlight keyword sync check, repo markdown lint
- Pre-push hook: workspace nextest run, 2216 passed; repo markdown lint

Closes #606. Restores #568.