### PR TITLE
Implement code-index host builtins (#565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,30 @@ granular archaeology.
   `hostlib_enable("tools:deterministic")` before any of these seven
   deterministic tools will execute, otherwise calls fail with a
   structured error pointing at the enable builtin.
+- **Code-index host builtins (#565).** `harn-hostlib`'s `code_index/`
+  module now ships a working trigram + word index, dep graph, file
+  table, and import resolver — ports the Swift `BurinCodeIndex` actor
+  into pure Rust. Five builtins go live behind the schemas locked in
+  by #563: `hostlib_code_index_query` (trigram-accelerated literal
+  substring search with case-insensitive default, `scope` path filter,
+  and `max_results` truncation), `hostlib_code_index_rebuild` (depth-
+  first walk honouring the same skip-dirs / sensitive-file filter
+  that `BurinCodeIndex/FilteredWalker.swift` enforced — node_modules,
+  `.git`, build artefacts, anything matching the credentials shape are
+  pruned before descent), `hostlib_code_index_stats` (file count,
+  distinct trigrams, distinct words, byte estimate, last rebuild
+  timestamp), `hostlib_code_index_imports_for` (per-file imports list
+  with `module` / `resolved_path` / `kind` triples), and
+  `hostlib_code_index_importers_of` (reverse import lookup). Import
+  resolution is data-driven via
+  `data/code_index_import_rules.json` (Python, TS/JS, Java/Kotlin,
+  Scala, C#, PHP, Elixir, Haskell, Lua, Ruby, C/C++, Zig, R, Swift,
+  Rust, Go) — adding a language is a JSON edit. The trigram packing,
+  word-index tokenisation, and FNV-1a content hashing match Swift
+  byte-for-byte so snapshots could in principle round-trip. Five
+  builtins are now exposed via `install_default`; embedders that want
+  isolated workspaces construct independent `CodeIndexCapability`
+  instances.
 
 - **Fair-share scheduler for worker-queue claims (#477).** New
   deficit-round-robin policy in front of `WorkerQueue::claim_next` so a

--- a/crates/harn-hostlib/Cargo.toml
+++ b/crates/harn-hostlib/Cargo.toml
@@ -9,6 +9,7 @@ description = "Opt-in code-intelligence and deterministic-tool host builtins for
 include = [
     "src/**/*",
     "schemas/**/*",
+    "data/**/*",
     "tests/**/*",
     "Cargo.toml",
     "README.md",

--- a/crates/harn-hostlib/README.md
+++ b/crates/harn-hostlib/README.md
@@ -28,6 +28,10 @@ deterministic-tool surface: `search`, `read_file`, `write_file`,
 [#568](https://github.com/burin-labs/harn/issues/568) lights up the
 process-lifecycle surface: `run_command`, `run_test`,
 `run_build_command`, `inspect_test_results`, and `manage_packages`.
+[#565](https://github.com/burin-labs/harn/issues/565) lights up the
+`code_index` surface: trigram + word index, dep graph, and the five
+host builtins (`query`, `rebuild`, `stats`, `imports_for`,
+`importers_of`).
 
 ### `ast/` languages
 
@@ -81,6 +85,7 @@ and commit the updated goldens.
 | B1 (#563) | scaffold       | crate + schemas + registration plumbing                                                   | ✅ shipped |
 | B2 (#564) | `ast/`         | `parse_file`, `symbols`, `outline` (tree-sitter for 22 host languages)                    | ✅ shipped |
 | B3    | `code_index/`      | `query`, `rebuild`, `stats`, `imports_for`, `importers_of`                                | unimplemented |
+| B3 (#565) | `code_index/`  | `query`, `rebuild`, `stats`, `imports_for`, `importers_of`                                | ✅ shipped |
 | B4    | `scanner/`         | `scan_project`, `scan_incremental`                                                        | unimplemented |
 | C1    | `fs_watch/`        | `subscribe`, `unsubscribe`                                                                | unimplemented |
 | #567  | `tools/` (read & search) | `search`, `read_file`, `list_directory`, `get_file_outline`, `git`                 | ✅ shipped (this issue) |
@@ -203,6 +208,8 @@ programmatically without locating the on-disk schema directory.
 crates/harn-hostlib/
 ├── Cargo.toml
 ├── README.md                  # this file
+├── data/                      # data tables consumed via include_str!
+│   └── code_index_import_rules.json
 ├── schemas/                   # JSON Schema 2020-12 contracts
 │   ├── ast/
 │   ├── code_index/
@@ -215,12 +222,14 @@ crates/harn-hostlib/
 │   ├── registry.rs            # HostlibCapability + HostlibRegistry
 │   ├── schemas.rs             # const SCHEMAS catalog (include_str!)
 │   ├── ast/
-│   ├── code_index/
+│   ├── code_index/            # trigram + word index, dep graph (#565)
 │   ├── scanner/
 │   ├── fs_watch/
 │   └── tools/
 └── tests/
-    └── registration.rs        # registration + schema parity tests
+    ├── registration.rs        # registration + schema parity tests
+    ├── code_index.rs          # builtin-level integration tests
+    └── code_index_scenario.rs # scenario test over a Swift-shaped fixture
 ```
 
 ## Adding a new method

--- a/crates/harn-hostlib/data/code_index_import_rules.json
+++ b/crates/harn-hostlib/data/code_index_import_rules.json
@@ -1,0 +1,158 @@
+{
+  "_comment": "Ported from burin-code Sources/BurinCodeIndex/Resources/import-rules.json. Strategies and field semantics documented in src/code_index/imports.rs.",
+  "languages": {
+    "python": {
+      "strategy": "dotted",
+      "stripPrefixes": ["from ", "import "],
+      "takeFirstAfterStrip": true,
+      "separator": ".",
+      "replaceSeparator": "/",
+      "candidateSuffixes": [".py", "/__init__.py"],
+      "allowSuffixMatch": false,
+      "kind": "import"
+    },
+    "typescript": {
+      "strategy": "relative",
+      "requirePrefixes": ["./", "../", "/"],
+      "candidateExtensions": ["ts", "tsx", "js", "jsx", "mjs", "cjs"],
+      "indexFallbacks": ["index.ts", "index.tsx", "index.js", "index.jsx", "index.mjs", "index.cjs"],
+      "kind": "import"
+    },
+    "javascript": {
+      "strategy": "relative",
+      "requirePrefixes": ["./", "../", "/"],
+      "candidateExtensions": ["js", "jsx", "mjs", "cjs", "ts", "tsx"],
+      "indexFallbacks": ["index.js", "index.jsx", "index.mjs", "index.cjs"],
+      "kind": "import"
+    },
+    "java": {
+      "strategy": "dotted",
+      "stripPrefixes": ["import ", "static "],
+      "stripSuffixes": [";", ".*"],
+      "separator": ".",
+      "replaceSeparator": "/",
+      "candidateSuffixes": [".java"],
+      "allowSuffixMatch": true,
+      "kind": "import"
+    },
+    "kotlin": {
+      "strategy": "dotted",
+      "stripPrefixes": ["import "],
+      "stripSuffixes": [";", ".*"],
+      "separator": ".",
+      "replaceSeparator": "/",
+      "candidateSuffixes": [".kt", ".kts"],
+      "allowSuffixMatch": true,
+      "kind": "import"
+    },
+    "scala": {
+      "strategy": "dotted",
+      "stripPrefixes": ["import "],
+      "stripSuffixes": [";"],
+      "separator": ".",
+      "replaceSeparator": "/",
+      "candidateSuffixes": [".scala"],
+      "allowSuffixMatch": true,
+      "kind": "import"
+    },
+    "csharp": {
+      "strategy": "dotted",
+      "stripPrefixes": ["using "],
+      "stripSuffixes": [";"],
+      "separator": ".",
+      "replaceSeparator": "/",
+      "candidateSuffixes": [".cs"],
+      "allowSuffixMatch": true,
+      "lastSegmentOnly": true,
+      "kind": "using"
+    },
+    "php": {
+      "strategy": "dotted",
+      "stripPrefixes": ["use "],
+      "stripSuffixes": [";"],
+      "aliasSeparator": " as ",
+      "separator": "\\",
+      "replaceSeparator": "/",
+      "candidateSuffixes": [".php"],
+      "allowSuffixMatch": true,
+      "kind": "use"
+    },
+    "elixir": {
+      "strategy": "dotted",
+      "stripPrefixes": ["alias ", "import ", "require ", "use "],
+      "separator": ".",
+      "replaceSeparator": "/",
+      "candidateSuffixes": [".ex", ".exs"],
+      "allowSuffixMatch": true,
+      "lastSegmentOnly": true,
+      "camelToSnake": true,
+      "kind": "alias"
+    },
+    "haskell": {
+      "strategy": "dotted",
+      "stripPrefixes": ["import ", "qualified "],
+      "takeFirstAfterStrip": true,
+      "separator": ".",
+      "replaceSeparator": "/",
+      "candidateSuffixes": [".hs", ".lhs"],
+      "allowSuffixMatch": true,
+      "kind": "import"
+    },
+    "lua": {
+      "strategy": "dotted-literal",
+      "separator": ".",
+      "replaceSeparator": "/",
+      "candidateSuffixes": [".lua", "/init.lua"],
+      "allowSuffixMatch": true,
+      "kind": "require"
+    },
+    "ruby": {
+      "strategy": "relative",
+      "relativeOnlyIfContains": ["require_relative"],
+      "candidateExtensions": ["rb"],
+      "allowSuffixMatch": true,
+      "appendExtensionIfMissing": "rb",
+      "kind": "require"
+    },
+    "c": {
+      "strategy": "relative",
+      "skipIfContainsAngleBracket": true,
+      "candidateExtensions": [],
+      "allowSuffixMatch": true,
+      "kind": "include"
+    },
+    "cpp": {
+      "strategy": "relative",
+      "skipIfContainsAngleBracket": true,
+      "candidateExtensions": [],
+      "allowSuffixMatch": true,
+      "kind": "include"
+    },
+    "zig": {
+      "strategy": "relative",
+      "requireLiteralContains": [".", "/"],
+      "candidateExtensions": [],
+      "allowSuffixMatch": false,
+      "kind": "import"
+    },
+    "r": {
+      "strategy": "relative",
+      "relativeOnlyIfContains": ["source"],
+      "candidateExtensions": [],
+      "allowSuffixMatch": false,
+      "kind": "source"
+    },
+    "rust": {
+      "strategy": "noop",
+      "kind": "use"
+    },
+    "go": {
+      "strategy": "noop",
+      "kind": "import"
+    },
+    "swift": {
+      "strategy": "noop",
+      "kind": "import"
+    }
+  }
+}

--- a/crates/harn-hostlib/src/ast/mod.rs
+++ b/crates/harn-hostlib/src/ast/mod.rs
@@ -1,8 +1,8 @@
 //! AST host capability.
 //!
 //! Wraps tree-sitter parsing, symbol extraction, and outline generation —
-//! the Swift `Sources/ASTEngine/` surface ported into Rust. Implementation
-//! lands per issue #564.
+//! the Swift `Sources/ASTEngine/` surface ported into Rust. The implementation
+//! is fully wired so AST builtins share one canonical wire format.
 //!
 //! ## Wire format
 //!
@@ -10,15 +10,13 @@
 //!   matching tree-sitter's native `Point` representation. Swift's
 //!   `ASTEngine` historically returned 1-based coordinates for symbols;
 //!   we normalize on 0-based here so `parse_file`, `symbols`, and
-//!   `outline` share one convention. Burin-code's bridge consumer is
-//!   updated in #(B5).
+//!   `outline` share one convention.
 //! - `parse_file` emits a flat node list with `parent_id` rather than
 //!   nested children — keeps the wire JSON-serializable without inflating
 //!   it with object copies.
 //! - `symbols` and `outline` carry a `signature` string (e.g.
 //!   `"fn foo(bar: i32)"`) on every entry to match Swift's
-//!   `TreeSitterSymbol.signature`. Burin-code's outline UI surfaces this
-//!   directly.
+//!   `TreeSitterSymbol.signature`.
 //!
 //! ## Languages
 //!
@@ -27,6 +25,7 @@
 //! C, C++, C#, Ruby, Kotlin, PHP, Scala, Bash, Swift, Zig, Elixir, Lua,
 //! Haskell, R. Adding/dropping languages requires a coordinated change
 //! in both repos.
+//!
 
 use std::sync::Arc;
 

--- a/crates/harn-hostlib/src/code_index/builtins.rs
+++ b/crates/harn-hostlib/src/code_index/builtins.rs
@@ -1,0 +1,370 @@
+//! Host-builtin handlers for the `code_index` module.
+//!
+//! Each handler shape mirrors the schema in
+//! `schemas/code_index/<method>.{request,response}.json`. A single shared
+//! [`SharedIndex`] cell is captured by the closure of every handler so all
+//! five builtins observe the same in-memory state — `rebuild` writes,
+//! everything else reads.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use harn_vm::VmValue;
+
+use super::file_table::FileId;
+use super::imports;
+use super::state::IndexState;
+use crate::error::HostlibError;
+use crate::tools::args::{
+    build_dict, dict_arg, optional_bool, optional_int, optional_string, require_string, str_value,
+};
+
+/// Shared, mutable cell carrying the (at most one) live workspace index.
+/// `Mutex` rather than `RwLock` because rebuilds flip the slot wholesale —
+/// fine-grained concurrency between rebuild + reads is intentionally not
+/// supported (the Swift side serialised through a single actor too).
+pub type SharedIndex = Arc<Mutex<Option<IndexState>>>;
+
+pub(super) const BUILTIN_QUERY: &str = "hostlib_code_index_query";
+pub(super) const BUILTIN_REBUILD: &str = "hostlib_code_index_rebuild";
+pub(super) const BUILTIN_STATS: &str = "hostlib_code_index_stats";
+pub(super) const BUILTIN_IMPORTS_FOR: &str = "hostlib_code_index_imports_for";
+pub(super) const BUILTIN_IMPORTERS_OF: &str = "hostlib_code_index_importers_of";
+
+pub(super) fn run_query(index: &SharedIndex, args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN_QUERY, args)?;
+    let dict = raw.as_ref();
+    let needle = require_string(BUILTIN_QUERY, dict, "needle")?;
+    if needle.is_empty() {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN_QUERY,
+            param: "needle",
+            message: "must not be empty".to_string(),
+        });
+    }
+    let case_sensitive = optional_bool(BUILTIN_QUERY, dict, "case_sensitive", false)?;
+    let max_results = optional_int(BUILTIN_QUERY, dict, "max_results", 100)?;
+    if max_results < 1 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN_QUERY,
+            param: "max_results",
+            message: "must be >= 1".to_string(),
+        });
+    }
+    let scope = optional_string_list(dict, "scope")?;
+
+    let guard = index.lock().expect("code_index mutex poisoned");
+    let Some(state) = guard.as_ref() else {
+        return Ok(empty_query_response());
+    };
+
+    let candidate_ids = candidates_for(state, &needle);
+    let mut hits: Vec<Hit> = Vec::new();
+    for id in candidate_ids {
+        let Some(file) = state.files.get(&id) else {
+            continue;
+        };
+        if !scope_allows(&scope, &file.relative_path) {
+            continue;
+        }
+        let Some(text) = read_file_text(&state.root, &file.relative_path) else {
+            continue;
+        };
+        let count = count_matches(&text, &needle, case_sensitive);
+        if count == 0 {
+            continue;
+        }
+        hits.push(Hit {
+            path: file.relative_path.clone(),
+            score: count as f64,
+            match_count: count,
+        });
+    }
+    hits.sort_by(|a, b| {
+        b.match_count
+            .cmp(&a.match_count)
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    let max = max_results as usize;
+    let truncated = hits.len() > max;
+    if truncated {
+        hits.truncate(max);
+    }
+    Ok(build_dict([
+        (
+            "results",
+            VmValue::List(Rc::new(hits.into_iter().map(hit_to_value).collect())),
+        ),
+        ("truncated", VmValue::Bool(truncated)),
+    ]))
+}
+
+pub(super) fn run_rebuild(index: &SharedIndex, args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN_REBUILD, args)?;
+    let dict = raw.as_ref();
+    let _force = optional_bool(BUILTIN_REBUILD, dict, "force", false)?;
+    let root = optional_string(BUILTIN_REBUILD, dict, "root")?
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    if !root.exists() {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN_REBUILD,
+            param: "root",
+            message: format!("path `{}` does not exist", root.display()),
+        });
+    }
+    if !root.is_dir() {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN_REBUILD,
+            param: "root",
+            message: format!("path `{}` is not a directory", root.display()),
+        });
+    }
+    let started = Instant::now();
+    let (state, outcome) = IndexState::build_from_root(&root);
+    let elapsed_ms = started.elapsed().as_millis() as i64;
+    {
+        let mut guard = index.lock().expect("code_index mutex poisoned");
+        *guard = Some(state);
+    }
+    Ok(build_dict([
+        ("files_indexed", VmValue::Int(outcome.files_indexed as i64)),
+        ("files_skipped", VmValue::Int(outcome.files_skipped as i64)),
+        ("elapsed_ms", VmValue::Int(elapsed_ms)),
+    ]))
+}
+
+pub(super) fn run_stats(index: &SharedIndex, _args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let guard = index.lock().expect("code_index mutex poisoned");
+    let Some(state) = guard.as_ref() else {
+        return Ok(empty_stats_response());
+    };
+    Ok(build_dict([
+        ("indexed_files", VmValue::Int(state.files.len() as i64)),
+        (
+            "trigrams",
+            VmValue::Int(state.trigrams.distinct_trigrams() as i64),
+        ),
+        ("words", VmValue::Int(state.words.distinct_words() as i64)),
+        ("memory_bytes", VmValue::Int(state.estimated_bytes() as i64)),
+        (
+            "last_rebuild_unix_ms",
+            VmValue::Int(state.last_built_unix_ms),
+        ),
+    ]))
+}
+
+pub(super) fn run_imports_for(
+    index: &SharedIndex,
+    args: &[VmValue],
+) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN_IMPORTS_FOR, args)?;
+    let dict = raw.as_ref();
+    let path = require_string(BUILTIN_IMPORTS_FOR, dict, "path")?;
+    let guard = index.lock().expect("code_index mutex poisoned");
+    let Some(state) = guard.as_ref() else {
+        return Ok(empty_imports_response(&path));
+    };
+    let Some(file_id) = state.lookup_path(&path) else {
+        return Ok(empty_imports_response(&path));
+    };
+    let Some(file) = state.files.get(&file_id) else {
+        return Ok(empty_imports_response(&path));
+    };
+    let kind = imports::import_kind(&file.language).to_string();
+    let base_dir = imports::parent_dir(&file.relative_path);
+    let resolved_ids: HashSet<FileId> = state.deps.imports_of(file_id).into_iter().collect();
+    let mut entries: Vec<VmValue> = Vec::with_capacity(file.imports.len());
+    for raw_import in &file.imports {
+        let resolved_path =
+            imports::resolve_module(raw_import, &file.language, &base_dir, &state.path_to_id)
+                .filter(|id| resolved_ids.contains(id))
+                .and_then(|id| state.files.get(&id).map(|f| f.relative_path.clone()));
+        entries.push(import_entry(raw_import, resolved_path.as_deref(), &kind));
+    }
+    Ok(build_dict([
+        ("path", str_value(&file.relative_path)),
+        ("imports", VmValue::List(Rc::new(entries))),
+    ]))
+}
+
+pub(super) fn run_importers_of(
+    index: &SharedIndex,
+    args: &[VmValue],
+) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN_IMPORTERS_OF, args)?;
+    let dict = raw.as_ref();
+    let module = require_string(BUILTIN_IMPORTERS_OF, dict, "module")?;
+    let guard = index.lock().expect("code_index mutex poisoned");
+    let Some(state) = guard.as_ref() else {
+        return Ok(empty_importers_response(&module));
+    };
+
+    let target_id = state.lookup_path(&module).or_else(|| {
+        // Fallback: suffix-match on relative paths so callers can request
+        // by basename (matching the `allowSuffixMatch` convention used by
+        // the resolver itself).
+        let needle = format!("/{module}");
+        state
+            .path_to_id
+            .iter()
+            .find(|(p, _)| p.ends_with(&needle) || *p == &module)
+            .map(|(_, id)| *id)
+    });
+
+    let mut importers: Vec<String> = match target_id {
+        Some(id) => state
+            .deps
+            .importers_of(id)
+            .into_iter()
+            .filter_map(|importer_id| {
+                state
+                    .files
+                    .get(&importer_id)
+                    .map(|f| f.relative_path.clone())
+            })
+            .collect(),
+        None => Vec::new(),
+    };
+    importers.sort();
+    Ok(build_dict([
+        ("module", str_value(&module)),
+        (
+            "importers",
+            VmValue::List(Rc::new(importers.into_iter().map(str_value).collect())),
+        ),
+    ]))
+}
+
+fn candidates_for(state: &IndexState, needle: &str) -> Vec<FileId> {
+    if needle.len() >= 3 {
+        let trigrams = super::trigram::query_trigrams(needle);
+        return state.trigrams.query(&trigrams).into_iter().collect();
+    }
+    // Sub-3-byte needles are below the trigram floor — fall back to
+    // scanning the whole file table (rare interactive case).
+    state.files.keys().copied().collect()
+}
+
+fn read_file_text(root: &std::path::Path, relative: &str) -> Option<String> {
+    std::fs::read_to_string(root.join(relative)).ok()
+}
+
+fn count_matches(haystack: &str, needle: &str, case_sensitive: bool) -> u64 {
+    if case_sensitive {
+        haystack.matches(needle).count() as u64
+    } else {
+        let lower_h = haystack.to_lowercase();
+        let lower_n = needle.to_lowercase();
+        lower_h.matches(&lower_n).count() as u64
+    }
+}
+
+fn scope_allows(scope: &[String], relative: &str) -> bool {
+    if scope.is_empty() {
+        return true;
+    }
+    scope
+        .iter()
+        .any(|s| relative == s || relative.starts_with(&format!("{s}/")) || s.is_empty())
+}
+
+fn optional_string_list(
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Vec<String>, HostlibError> {
+    match dict.get(key) {
+        None | Some(VmValue::Nil) => Ok(Vec::new()),
+        Some(VmValue::List(items)) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items.iter() {
+                match item {
+                    VmValue::String(s) => out.push(s.to_string()),
+                    other => {
+                        return Err(HostlibError::InvalidParameter {
+                            builtin: BUILTIN_QUERY,
+                            param: key,
+                            message: format!(
+                                "expected list of strings, got element {}",
+                                other.type_name()
+                            ),
+                        });
+                    }
+                }
+            }
+            Ok(out)
+        }
+        Some(other) => Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN_QUERY,
+            param: key,
+            message: format!("expected list of strings, got {}", other.type_name()),
+        }),
+    }
+}
+
+struct Hit {
+    path: String,
+    score: f64,
+    match_count: u64,
+}
+
+fn hit_to_value(hit: Hit) -> VmValue {
+    let Hit {
+        path,
+        score,
+        match_count,
+    } = hit;
+    build_dict([
+        ("path", str_value(&path)),
+        ("score", VmValue::Float(score)),
+        ("match_count", VmValue::Int(match_count as i64)),
+    ])
+}
+
+fn import_entry(module: &str, resolved: Option<&str>, kind: &str) -> VmValue {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    map.insert("module".into(), str_value(module));
+    map.insert(
+        "resolved_path".into(),
+        match resolved {
+            Some(p) => str_value(p),
+            None => VmValue::Nil,
+        },
+    );
+    map.insert("kind".into(), str_value(kind));
+    VmValue::Dict(Rc::new(map))
+}
+
+fn empty_query_response() -> VmValue {
+    build_dict([
+        ("results", VmValue::List(Rc::new(Vec::new()))),
+        ("truncated", VmValue::Bool(false)),
+    ])
+}
+
+fn empty_stats_response() -> VmValue {
+    build_dict([
+        ("indexed_files", VmValue::Int(0)),
+        ("trigrams", VmValue::Int(0)),
+        ("words", VmValue::Int(0)),
+        ("memory_bytes", VmValue::Int(0)),
+        ("last_rebuild_unix_ms", VmValue::Nil),
+    ])
+}
+
+fn empty_imports_response(path: &str) -> VmValue {
+    build_dict([
+        ("path", str_value(path)),
+        ("imports", VmValue::List(Rc::new(Vec::new()))),
+    ])
+}
+
+fn empty_importers_response(module: &str) -> VmValue {
+    build_dict([
+        ("module", str_value(module)),
+        ("importers", VmValue::List(Rc::new(Vec::new()))),
+    ])
+}

--- a/crates/harn-hostlib/src/code_index/file_table.rs
+++ b/crates/harn-hostlib/src/code_index/file_table.rs
@@ -1,0 +1,81 @@
+//! Per-file metadata.
+//!
+//! `IndexedFile` holds the structural data the index needs at query time —
+//! language, size, content hash, raw import strings, and the list of
+//! outline symbols. `FileId` is a monotonically-assigned `u32` that all
+//! sub-indexes (`TrigramIndex`, `WordIndex`, `DepGraph`, `VersionLog`) key
+//! on so re-indexing a path doesn't have to invalidate string keys.
+
+/// Monotonically-assigned identifier for a file in the index. Stable
+/// across re-indexes of the same path so sub-indexes can key on `FileId`
+/// without invalidating string keys.
+pub type FileId = u32;
+
+/// Outline-style symbol entry. Reserved for AST integration; the code-index
+/// importer leaves `IndexedFile::symbols` empty, but the shape is kept stable
+/// so storage upgrades won't have to re-key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexedSymbol {
+    /// Symbol name (e.g. `"helper"`).
+    pub name: String,
+    /// Language-specific kind (`"function"`, `"struct"`, …).
+    pub kind: String,
+    /// 1-based start line.
+    pub start_line: u32,
+    /// 1-based inclusive end line.
+    pub end_line: u32,
+    /// Single-line signature/preview of the declaration.
+    pub signature: String,
+}
+
+/// Per-file metadata persisted in the index.
+#[derive(Debug, Clone)]
+pub struct IndexedFile {
+    /// Stable file identifier.
+    pub id: FileId,
+    /// Workspace-relative path with `/` separators. The empty string is
+    /// reserved for the root and never appears in the table.
+    pub relative_path: String,
+    /// Best-effort language tag (e.g. `"rust"`, `"swift"`, `"python"`). For
+    /// unrecognised extensions this is the extension itself.
+    pub language: String,
+    /// File size in bytes (UTF-8 contents).
+    pub size_bytes: u64,
+    /// Newline-delimited line count.
+    pub line_count: u32,
+    /// FNV-1a 64-bit content hash, used for cheap change detection.
+    pub content_hash: u64,
+    /// Last-modified time in milliseconds since the Unix epoch.
+    pub mtime_ms: i64,
+    /// Outline symbols supplied by callers that have richer syntax context.
+    pub symbols: Vec<IndexedSymbol>,
+    /// Raw import statement strings extracted from the file.
+    pub imports: Vec<String>,
+}
+
+/// Stable 64-bit FNV-1a hash. Used for content-change detection; matches
+/// the Swift `ContentHasher` byte-for-byte so shared snapshots stay
+/// interchangeable.
+pub fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in bytes {
+        h ^= *byte as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fnv_matches_swift_reference() {
+        // The Swift `ContentHasher.hash("hello world")` reference value.
+        // FNV-1a 64-bit is deterministic; this guards against accidental
+        // changes (e.g. switching to a different seed/prime) that would
+        // silently break shared snapshot interop.
+        assert_eq!(fnv1a64(b"hello world"), 0x779a_65e7_023c_d2e7);
+        assert_eq!(fnv1a64(b""), 0xcbf2_9ce4_8422_2325);
+    }
+}

--- a/crates/harn-hostlib/src/code_index/graph.rs
+++ b/crates/harn-hostlib/src/code_index/graph.rs
@@ -1,0 +1,157 @@
+//! Forward + reverse dependency graph over project files.
+//!
+//! Edges are "file A imports file B", built from the import strings the
+//! `imports` module surfaces. Forward answers "what does A depend on?";
+//! reverse answers "who depends on A?". Mirrors the Swift `DepGraph`,
+//! including the `unresolved_imports` side-table for raw strings the
+//! resolver could not map back to a known file.
+
+use std::collections::{HashMap, HashSet};
+
+use super::file_table::FileId;
+
+/// Forward + reverse import graph plus the side-table of unresolved
+/// import strings (raw text we couldn't map back to a known file).
+#[derive(Debug, Default, Clone)]
+pub struct DepGraph {
+    forward: HashMap<FileId, HashSet<FileId>>,
+    reverse: HashMap<FileId, HashSet<FileId>>,
+    unresolved: HashMap<FileId, Vec<String>>,
+}
+
+impl DepGraph {
+    /// Construct an empty graph.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the outgoing edges for `file` with the resolved set.
+    /// Re-keys reverse edges atomically so `imports`/`importers` stay in
+    /// sync after every call.
+    pub fn set_edges(&mut self, file: FileId, resolved: HashSet<FileId>, unresolved: Vec<String>) {
+        if let Some(old) = self.forward.remove(&file) {
+            for target in &old {
+                if *target == file {
+                    continue;
+                }
+                if let Some(set) = self.reverse.get_mut(target) {
+                    set.remove(&file);
+                    if set.is_empty() {
+                        self.reverse.remove(target);
+                    }
+                }
+            }
+        }
+        for target in &resolved {
+            if *target == file {
+                continue;
+            }
+            self.reverse.entry(*target).or_default().insert(file);
+        }
+        self.forward.insert(file, resolved);
+        if unresolved.is_empty() {
+            self.unresolved.remove(&file);
+        } else {
+            self.unresolved.insert(file, unresolved);
+        }
+    }
+
+    /// Drop every edge touching `file` from both directions. Importers
+    /// of `file` keep their forward entry but lose the dangling target.
+    pub fn remove_file(&mut self, file: FileId) {
+        if let Some(old) = self.forward.remove(&file) {
+            for target in old {
+                if target == file {
+                    continue;
+                }
+                if let Some(set) = self.reverse.get_mut(&target) {
+                    set.remove(&file);
+                    if set.is_empty() {
+                        self.reverse.remove(&target);
+                    }
+                }
+            }
+        }
+        self.unresolved.remove(&file);
+        // Anyone who imported us keeps their forward edge but it now
+        // dangles. They'll re-resolve on their next reindex.
+        if let Some(rev) = self.reverse.remove(&file) {
+            for importer in rev {
+                if let Some(forward) = self.forward.get_mut(&importer) {
+                    forward.remove(&file);
+                }
+            }
+        }
+    }
+
+    /// Forward edges: every file `file` imports.
+    pub fn imports_of(&self, file: FileId) -> Vec<FileId> {
+        self.forward
+            .get(&file)
+            .map(|set| set.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// Reverse edges: every file that imports `file`.
+    pub fn importers_of(&self, file: FileId) -> Vec<FileId> {
+        self.reverse
+            .get(&file)
+            .map(|set| set.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// Raw import strings the resolver couldn't map back to a known file.
+    pub fn unresolved_imports(&self, file: FileId) -> &[String] {
+        self.unresolved.get(&file).map(Vec::as_slice).unwrap_or(&[])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set_of(ids: &[FileId]) -> HashSet<FileId> {
+        ids.iter().copied().collect()
+    }
+
+    #[test]
+    fn set_edges_populates_both_sides() {
+        let mut g = DepGraph::new();
+        g.set_edges(1, set_of(&[2, 3]), vec![]);
+        let mut imports = g.imports_of(1);
+        imports.sort();
+        assert_eq!(imports, vec![2, 3]);
+        assert_eq!(g.importers_of(2), vec![1]);
+        assert_eq!(g.importers_of(3), vec![1]);
+    }
+
+    #[test]
+    fn re_setting_edges_drops_stale_reverse_edges() {
+        let mut g = DepGraph::new();
+        g.set_edges(1, set_of(&[2]), vec![]);
+        g.set_edges(1, set_of(&[3]), vec![]);
+        assert!(g.importers_of(2).is_empty());
+        assert_eq!(g.importers_of(3), vec![1]);
+    }
+
+    #[test]
+    fn remove_file_cleans_up_both_directions() {
+        let mut g = DepGraph::new();
+        g.set_edges(1, set_of(&[2]), vec!["unmatched".into()]);
+        g.set_edges(3, set_of(&[1]), vec![]);
+        g.remove_file(1);
+        assert!(g.imports_of(1).is_empty());
+        assert!(g.importers_of(2).is_empty());
+        // 3 still imports... nothing now (its forward edge dangling-cleared).
+        assert!(g.imports_of(3).is_empty());
+    }
+
+    #[test]
+    fn unresolved_imports_round_trip() {
+        let mut g = DepGraph::new();
+        g.set_edges(1, HashSet::new(), vec!["weird::path".into()]);
+        assert_eq!(g.unresolved_imports(1), &["weird::path".to_string()]);
+        g.set_edges(1, HashSet::new(), vec![]);
+        assert!(g.unresolved_imports(1).is_empty());
+    }
+}

--- a/crates/harn-hostlib/src/code_index/imports.rs
+++ b/crates/harn-hostlib/src/code_index/imports.rs
@@ -1,0 +1,510 @@
+//! Import extraction + data-driven resolution.
+//!
+//! Two phases:
+//!
+//! 1. **Extraction** — scan source line-by-line for tokens that look like
+//!    import statements. Mirrors the *fallback* path of the Swift
+//!    `TreeSitterImportExtractor`: prefix-match common keywords per
+//!    language, capture the trimmed line. A tree-sitter-backed extractor can
+//!    replace this without changing the `code_index` public surface.
+//!
+//! 2. **Resolution** — for each extracted string, apply a per-language
+//!    rule to produce a workspace-relative path, then look that path up
+//!    in `pathToID`. The rules are stored in
+//!    `data/code_index_import_rules.json` and parsed once at first use.
+//!    This file is the canonical source: adding a language is a JSON edit,
+//!    not a Rust edit.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+use super::file_table::FileId;
+
+const RULES_JSON: &str = include_str!("../../data/code_index_import_rules.json");
+
+/// Per-language extraction prefix keywords. A line whose trimmed start
+/// matches any of the keywords is captured as an import. `None` means the
+/// language has no fallback extraction.
+fn import_keywords(language: &str) -> &'static [&'static str] {
+    match language {
+        "swift" => &["import "],
+        "rust" => &["use ", "extern crate ", "pub use "],
+        "go" => &["import "],
+        "python" => &["import ", "from "],
+        "java" => &["import "],
+        "kotlin" => &["import "],
+        "scala" => &["import "],
+        "csharp" => &["using "],
+        "c" | "cpp" => &["#include"],
+        "ruby" => &["require ", "require_relative "],
+        "php" => &["use "],
+        "elixir" => &["alias ", "import ", "require ", "use "],
+        "haskell" => &["import "],
+        "lua" => &["require"],
+        "javascript" | "typescript" => &[
+            "import ",
+            "import\t",
+            "import{",
+            "import \"",
+            "import \'",
+            "export * from ",
+            "export {",
+        ],
+        "zig" => &["@import"],
+        "r" => &["library(", "require(", "source("],
+        _ => &[],
+    }
+}
+
+/// Extract every import-like statement from `source`, one entry per line
+/// the matcher fires on.
+pub(crate) fn extract_imports(source: &str, language: &str) -> Vec<String> {
+    let keywords = import_keywords(language);
+    if keywords.is_empty() {
+        return Vec::new();
+    }
+    let mut out: Vec<String> = Vec::new();
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // Strip leading single-line comment markers so e.g. a commented-out
+        // import doesn't polute the resolver. We don't try to parse block
+        // comments — the keyword check is strict enough that false
+        // positives are rare.
+        if matches_comment_prefix(trimmed) {
+            continue;
+        }
+        if keywords.iter().any(|k| trimmed.starts_with(k)) {
+            out.push(trimmed.to_string());
+        }
+    }
+    out
+}
+
+fn matches_comment_prefix(trimmed: &str) -> bool {
+    trimmed.starts_with("//") || trimmed.starts_with('#') || trimmed.starts_with("--")
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ImportRule {
+    strategy: String,
+    #[serde(default)]
+    strip_prefixes: Vec<String>,
+    #[serde(default)]
+    strip_suffixes: Vec<String>,
+    #[serde(default)]
+    take_first_after_strip: bool,
+    #[serde(default)]
+    alias_separator: Option<String>,
+    #[serde(default)]
+    separator: Option<String>,
+    #[serde(default)]
+    replace_separator: Option<String>,
+    #[serde(default)]
+    candidate_suffixes: Vec<String>,
+    #[serde(default)]
+    allow_suffix_match: bool,
+    #[serde(default)]
+    last_segment_only: bool,
+    #[serde(default)]
+    camel_to_snake: bool,
+    #[serde(default)]
+    require_prefixes: Vec<String>,
+    #[serde(default)]
+    candidate_extensions: Vec<String>,
+    #[serde(default)]
+    index_fallbacks: Vec<String>,
+    #[serde(default)]
+    skip_if_contains_angle_bracket: bool,
+    #[serde(default)]
+    require_literal_contains: Vec<String>,
+    #[serde(default)]
+    relative_only_if_contains: Vec<String>,
+    #[serde(default)]
+    append_extension_if_missing: Option<String>,
+    /// Token returned in the `imports_for` response so callers can render
+    /// "use" vs "import" vs "require" vs "include" consistently.
+    #[serde(default)]
+    kind: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ImportRulesFile {
+    languages: HashMap<String, ImportRule>,
+}
+
+fn rules() -> &'static HashMap<String, ImportRule> {
+    static CELL: OnceLock<HashMap<String, ImportRule>> = OnceLock::new();
+    CELL.get_or_init(|| {
+        let parsed: ImportRulesFile =
+            serde_json::from_str(RULES_JSON).expect("bundled import-rules.json must be valid JSON");
+        parsed.languages
+    })
+}
+
+/// Outcome of resolving the import strings for one file.
+#[derive(Debug, Default)]
+pub(crate) struct Resolved {
+    pub resolved: HashSet<FileId>,
+    pub unresolved: Vec<String>,
+}
+
+/// Resolve the import strings for one file against `path_to_id`.
+pub(crate) fn resolve(
+    imports: &[String],
+    from_relative_path: &str,
+    language: &str,
+    path_to_id: &HashMap<String, FileId>,
+) -> Resolved {
+    let mut out = Resolved::default();
+    let rule = rules().get(language);
+    let base_dir = parent_relative(from_relative_path);
+    for raw in imports {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(rule) = rule {
+            if let Some(id) = apply_rule(rule, trimmed, &base_dir, path_to_id) {
+                out.resolved.insert(id);
+                continue;
+            }
+        }
+        out.unresolved.push(raw.clone());
+    }
+    out
+}
+
+/// Lookup the language-specific kind tag (`"use"`, `"import"`, etc.) used
+/// in the `imports_for` response. Defaults to `"import"` for unknown
+/// languages.
+pub(crate) fn import_kind(language: &str) -> &str {
+    rules()
+        .get(language)
+        .and_then(|r| r.kind.as_deref())
+        .unwrap_or("import")
+}
+
+/// Try to resolve a single import string against `path_to_id`. `base_dir`
+/// is the workspace-relative directory of the *importing* file (with `/`
+/// separators, no trailing slash); pass an empty string when the resolver
+/// shouldn't attempt relative resolution.
+pub(crate) fn resolve_module(
+    module: &str,
+    language: &str,
+    base_dir: &str,
+    path_to_id: &HashMap<String, FileId>,
+) -> Option<FileId> {
+    let rule = rules().get(language)?;
+    apply_rule(rule, module.trim(), base_dir, path_to_id)
+}
+
+/// Compute the workspace-relative parent directory for a relative path.
+pub(crate) fn parent_dir(rel: &str) -> String {
+    parent_relative(rel)
+}
+
+fn apply_rule(
+    rule: &ImportRule,
+    raw: &str,
+    base_dir: &str,
+    path_to_id: &HashMap<String, FileId>,
+) -> Option<FileId> {
+    match rule.strategy.as_str() {
+        "dotted" => resolve_dotted(rule, raw, path_to_id),
+        "dotted-literal" => {
+            let lit = extract_string_literal(raw)?;
+            resolve_dotted(rule, &lit, path_to_id)
+        }
+        "relative" => resolve_relative(rule, raw, base_dir, path_to_id),
+        "noop" => None,
+        _ => None,
+    }
+}
+
+fn resolve_dotted(
+    rule: &ImportRule,
+    raw: &str,
+    path_to_id: &HashMap<String, FileId>,
+) -> Option<FileId> {
+    let mut cleaned = raw.to_string();
+    for prefix in &rule.strip_prefixes {
+        if cleaned.starts_with(prefix) {
+            cleaned = cleaned[prefix.len()..].to_string();
+        }
+    }
+    // Second pass — handles chained prefixes (e.g. `import qualified`).
+    for prefix in &rule.strip_prefixes {
+        if cleaned.starts_with(prefix) {
+            cleaned = cleaned[prefix.len()..].to_string();
+        }
+    }
+    for suffix in &rule.strip_suffixes {
+        if cleaned.ends_with(suffix) {
+            cleaned.truncate(cleaned.len() - suffix.len());
+        }
+    }
+    if let Some(alias) = rule.alias_separator.as_deref() {
+        if let Some(idx) = cleaned.find(alias) {
+            cleaned.truncate(idx);
+        }
+    }
+    cleaned = cleaned.trim().to_string();
+    if rule.take_first_after_strip {
+        cleaned = cleaned
+            .split_whitespace()
+            .next()
+            .unwrap_or(&cleaned)
+            .to_string();
+        cleaned = cleaned.split(',').next().unwrap_or(&cleaned).to_string();
+    }
+    if cleaned.is_empty() {
+        return None;
+    }
+    let mut candidate = cleaned;
+    let separator = rule.separator.as_deref().unwrap_or(".");
+    if rule.last_segment_only {
+        if let Some(last) = candidate.split(separator).last() {
+            candidate = last.to_string();
+        }
+    }
+    if rule.camel_to_snake {
+        candidate = camel_to_snake(&candidate);
+    }
+    let replace = rule.replace_separator.as_deref().unwrap_or("/");
+    let joined = candidate.replace(separator, replace);
+
+    for suffix in &rule.candidate_suffixes {
+        let needle = format!("{joined}{suffix}");
+        if let Some(id) = path_to_id.get(&needle) {
+            return Some(*id);
+        }
+        if rule.allow_suffix_match {
+            for (path, id) in path_to_id {
+                if path.ends_with(&format!("/{needle}")) || path == &needle {
+                    return Some(*id);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn resolve_relative(
+    rule: &ImportRule,
+    raw: &str,
+    base_dir: &str,
+    path_to_id: &HashMap<String, FileId>,
+) -> Option<FileId> {
+    if !rule.relative_only_if_contains.is_empty()
+        && !rule
+            .relative_only_if_contains
+            .iter()
+            .any(|n| raw.contains(n))
+    {
+        return None;
+    }
+    if rule.skip_if_contains_angle_bracket && raw.contains('<') {
+        return None;
+    }
+    let mut literal = extract_string_literal(raw).unwrap_or_else(|| raw.to_string());
+    if !rule.require_literal_contains.is_empty()
+        && !rule
+            .require_literal_contains
+            .iter()
+            .any(|n| literal.contains(n))
+    {
+        return None;
+    }
+    if !rule.require_prefixes.is_empty()
+        && !rule.require_prefixes.iter().any(|p| literal.starts_with(p))
+    {
+        return None;
+    }
+    if let Some(ext) = rule.append_extension_if_missing.as_deref() {
+        if !literal.ends_with(&format!(".{ext}")) {
+            literal = format!("{literal}.{ext}");
+        }
+    }
+    let joined = if base_dir.is_empty() {
+        literal.clone()
+    } else {
+        format!("{base_dir}/{literal}")
+    };
+    let normalized = normalize_relative(&joined);
+    if let Some(id) = path_to_id.get(&normalized) {
+        return Some(*id);
+    }
+    for ext in &rule.candidate_extensions {
+        if let Some(id) = path_to_id.get(&format!("{normalized}.{ext}")) {
+            return Some(*id);
+        }
+    }
+    for fallback in &rule.index_fallbacks {
+        let candidate = if normalized.is_empty() {
+            fallback.clone()
+        } else {
+            format!("{normalized}/{fallback}")
+        };
+        if let Some(id) = path_to_id.get(&candidate) {
+            return Some(*id);
+        }
+    }
+    if rule.allow_suffix_match {
+        for (path, id) in path_to_id {
+            if path.ends_with(&format!("/{literal}")) {
+                return Some(*id);
+            }
+        }
+    }
+    None
+}
+
+fn extract_string_literal(text: &str) -> Option<String> {
+    let bytes = text.as_bytes();
+    let first = bytes.iter().position(|b| *b == b'"' || *b == b'\'')?;
+    let quote = bytes[first];
+    let after = first + 1;
+    let second_offset = bytes[after..].iter().position(|b| *b == quote)?;
+    let second = after + second_offset;
+    Some(text[after..second].to_string())
+}
+
+fn camel_to_snake(input: &str) -> String {
+    let mut out = String::with_capacity(input.len() + 4);
+    for (i, ch) in input.chars().enumerate() {
+        if ch.is_uppercase() && i > 0 {
+            out.push('_');
+        }
+        for lc in ch.to_lowercase() {
+            out.push(lc);
+        }
+    }
+    out
+}
+
+fn parent_relative(rel: &str) -> String {
+    match rel.rsplit_once('/') {
+        Some((parent, _)) => parent.to_string(),
+        None => String::new(),
+    }
+}
+
+fn normalize_relative(path: &str) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    for comp in path.split('/').filter(|c| !c.is_empty()) {
+        match comp {
+            "." => {}
+            ".." => {
+                parts.pop();
+            }
+            other => parts.push(other),
+        }
+    }
+    parts.join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids() -> HashMap<String, FileId> {
+        let mut m = HashMap::new();
+        m.insert("src/util.ts".into(), 1);
+        m.insert("src/index.ts".into(), 2);
+        m.insert("foo/bar.py".into(), 3);
+        m.insert("com/example/Foo.java".into(), 4);
+        m.insert("Bar.cs".into(), 5);
+        m
+    }
+
+    #[test]
+    fn extract_handles_swift_and_rust() {
+        let swift = "import Foundation\nimport SwiftUI\nlet x = 1\n";
+        assert_eq!(
+            extract_imports(swift, "swift"),
+            vec!["import Foundation", "import SwiftUI"]
+        );
+        let rust = "use std::sync::Arc;\nuse crate::foo;\nfn main() {}";
+        assert_eq!(
+            extract_imports(rust, "rust"),
+            vec!["use std::sync::Arc;", "use crate::foo;"]
+        );
+    }
+
+    #[test]
+    fn resolve_typescript_relative() {
+        let map = ids();
+        let r = resolve(
+            &["import x from \"./util\"".to_string()],
+            "src/index.ts",
+            "typescript",
+            &map,
+        );
+        assert!(r.resolved.contains(&1));
+    }
+
+    #[test]
+    fn resolve_python_dotted() {
+        let map = ids();
+        // Python rule resolves the *package* (`foo.bar` -> `foo/bar.py`),
+        // not the imported symbol — matches Swift `ImportResolver` behaviour.
+        let r = resolve(
+            &["from foo.bar import baz".to_string()],
+            "src/main.py",
+            "python",
+            &map,
+        );
+        assert!(r.resolved.contains(&3));
+        let r = resolve(
+            &["import foo.bar".to_string()],
+            "src/main.py",
+            "python",
+            &map,
+        );
+        assert!(r.resolved.contains(&3));
+    }
+
+    #[test]
+    fn resolve_java_suffix_match() {
+        let map = ids();
+        let r = resolve(
+            &["import com.example.Foo;".to_string()],
+            "src/Main.java",
+            "java",
+            &map,
+        );
+        assert!(r.resolved.contains(&4));
+    }
+
+    #[test]
+    fn unresolved_imports_are_kept() {
+        let map = ids();
+        let r = resolve(
+            &["import com.unknown.Foo;".to_string()],
+            "src/Main.java",
+            "java",
+            &map,
+        );
+        assert!(r.resolved.is_empty());
+        assert_eq!(r.unresolved, vec!["import com.unknown.Foo;".to_string()]);
+    }
+
+    #[test]
+    fn comment_lines_are_skipped() {
+        let src = "// import Foundation\nimport UIKit\n# import Foo\n";
+        assert_eq!(extract_imports(src, "swift"), vec!["import UIKit"]);
+    }
+
+    #[test]
+    fn import_kind_falls_back_to_import() {
+        assert_eq!(import_kind("rust"), "use");
+        assert_eq!(import_kind("c"), "include");
+        assert_eq!(import_kind("totally-unknown"), "import");
+    }
+}

--- a/crates/harn-hostlib/src/code_index/mod.rs
+++ b/crates/harn-hostlib/src/code_index/mod.rs
@@ -1,16 +1,74 @@
 //! Code index host capability.
 //!
 //! Ports the deterministic trigram/word index that lived in
-//! `Sources/BurinCodeIndex/` on the Swift side. Implementation lands in
-//! issue B3; this scaffold registers the contract so consumers can wire
-//! against the stable surface today.
+//! `Sources/BurinCodeIndex/` on the Swift side. Exposes five host builtins
+//! whose surfaces are locked by `schemas/code_index/<method>.json`:
+//!
+//! | Builtin                          | What it does                                           |
+//! |----------------------------------|--------------------------------------------------------|
+//! | `hostlib_code_index_query`       | Trigram-accelerated literal substring search.          |
+//! | `hostlib_code_index_rebuild`     | Walk a workspace and (re)build the in-memory index.    |
+//! | `hostlib_code_index_stats`       | Count files/trigrams/words + last rebuild timestamp.   |
+//! | `hostlib_code_index_imports_for` | Imports declared by a single file (with resolutions).  |
+//! | `hostlib_code_index_importers_of`| Reverse lookup: who imports the given module/path?     |
+//!
+//! The capability owns one [`SharedIndex`] cell per instance — there is at
+//! most one live workspace per VM at a time. The schema for the read
+//! builtins (`query`, `stats`, `imports_for`, `importers_of`) does not
+//! carry a workspace argument, so multi-workspace embedders are expected
+//! to drive separate `CodeIndexCapability` handles. The internal layout
+//! still keeps everything keyed on `FileId`, so a future schema bump can
+//! add a `root` parameter without refactoring the data model.
 
-use crate::registry::{BuiltinRegistry, HostlibCapability};
+mod builtins;
+mod file_table;
+mod graph;
+mod imports;
+mod state;
+mod trigram;
+mod walker;
+mod words;
 
-/// Code-index capability handle. Stateless today; will own the index actor
-/// (or its async handle) once the implementation lands.
-#[derive(Default)]
-pub struct CodeIndexCapability;
+use std::sync::{Arc, Mutex};
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::registry::{BuiltinRegistry, HostlibCapability, RegisteredBuiltin, SyncHandler};
+
+pub use builtins::SharedIndex;
+pub use file_table::{FileId, IndexedFile, IndexedSymbol};
+pub use graph::DepGraph;
+pub use state::{BuildOutcome, IndexState};
+pub use trigram::TrigramIndex;
+pub use words::{WordHit, WordIndex};
+
+/// Code-index capability handle.
+///
+/// Holds the [`SharedIndex`] cell behind an `Arc<Mutex<...>>`; cloning the
+/// capability shares state. Embedders that want isolated workspaces should
+/// construct independent instances.
+#[derive(Clone, Default)]
+pub struct CodeIndexCapability {
+    index: SharedIndex,
+}
+
+impl CodeIndexCapability {
+    /// Create a capability with an empty workspace slot. The first
+    /// `hostlib_code_index_rebuild` call populates it.
+    pub fn new() -> Self {
+        Self {
+            index: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Borrow the underlying shared cell. Useful for tests and embedders
+    /// that want to introspect index state without going through the
+    /// builtins.
+    pub fn shared(&self) -> SharedIndex {
+        self.index.clone()
+    }
+}
 
 impl HostlibCapability for CodeIndexCapability {
     fn module_name(&self) -> &'static str {
@@ -18,18 +76,57 @@ impl HostlibCapability for CodeIndexCapability {
     }
 
     fn register_builtins(&self, registry: &mut BuiltinRegistry) {
-        registry.register_unimplemented("hostlib_code_index_query", "code_index", "query");
-        registry.register_unimplemented("hostlib_code_index_rebuild", "code_index", "rebuild");
-        registry.register_unimplemented("hostlib_code_index_stats", "code_index", "stats");
-        registry.register_unimplemented(
-            "hostlib_code_index_imports_for",
-            "code_index",
-            "imports_for",
+        register(
+            registry,
+            self.index.clone(),
+            builtins::BUILTIN_QUERY,
+            "query",
+            builtins::run_query,
         );
-        registry.register_unimplemented(
-            "hostlib_code_index_importers_of",
-            "code_index",
+        register(
+            registry,
+            self.index.clone(),
+            builtins::BUILTIN_REBUILD,
+            "rebuild",
+            builtins::run_rebuild,
+        );
+        register(
+            registry,
+            self.index.clone(),
+            builtins::BUILTIN_STATS,
+            "stats",
+            builtins::run_stats,
+        );
+        register(
+            registry,
+            self.index.clone(),
+            builtins::BUILTIN_IMPORTS_FOR,
+            "imports_for",
+            builtins::run_imports_for,
+        );
+        register(
+            registry,
+            self.index.clone(),
+            builtins::BUILTIN_IMPORTERS_OF,
             "importers_of",
+            builtins::run_importers_of,
         );
     }
+}
+
+fn register(
+    registry: &mut BuiltinRegistry,
+    index: SharedIndex,
+    name: &'static str,
+    method: &'static str,
+    runner: fn(&SharedIndex, &[VmValue]) -> Result<VmValue, HostlibError>,
+) {
+    let captured = index;
+    let handler: SyncHandler = Arc::new(move |args| runner(&captured, args));
+    registry.register(RegisteredBuiltin {
+        name,
+        module: "code_index",
+        method,
+        handler,
+    });
 }

--- a/crates/harn-hostlib/src/code_index/state.rs
+++ b/crates/harn-hostlib/src/code_index/state.rs
@@ -1,0 +1,286 @@
+//! Per-workspace index state.
+//!
+//! Owns the file table, trigram index, word index, and dep graph for one
+//! workspace root. Construction is via [`IndexState::build_from_root`],
+//! which walks the workspace, reads every indexable file, and populates
+//! every sub-index in a single pass before resolving imports.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::file_table::{fnv1a64, FileId, IndexedFile};
+use super::graph::DepGraph;
+use super::imports;
+use super::trigram::TrigramIndex;
+use super::walker::{is_indexable_file, language_for_extension, walk_indexable, MAX_FILE_BYTES};
+use super::words::WordIndex;
+
+/// In-memory index for one workspace. Composed from the per-file table,
+/// the trigram + word sub-indexes, and the dep graph.
+pub struct IndexState {
+    /// Canonicalised workspace root.
+    pub root: PathBuf,
+    /// File table keyed on stable id.
+    pub files: HashMap<FileId, IndexedFile>,
+    /// Workspace-relative path → stable id.
+    pub path_to_id: HashMap<String, FileId>,
+    /// Trigram posting list.
+    pub trigrams: TrigramIndex,
+    /// Identifier-token inverted index.
+    pub words: WordIndex,
+    /// Forward + reverse import graph.
+    pub deps: DepGraph,
+    /// Wall-clock timestamp (ms since epoch) of the most recent rebuild.
+    pub last_built_unix_ms: i64,
+    /// Best-effort `HEAD` SHA, or `None` if the workspace isn't a git repo.
+    pub git_head: Option<String>,
+    next_id: FileId,
+}
+
+/// Summary returned from `IndexState::build_from_root`.
+#[derive(Debug, Default)]
+pub struct BuildOutcome {
+    /// Files that passed every filter and were ingested.
+    pub files_indexed: u64,
+    /// Files that matched the filename filter but couldn't be read or
+    /// were too large.
+    pub files_skipped: u64,
+}
+
+impl IndexState {
+    /// Build a fresh index over `root`. Returns the populated state plus a
+    /// summary of how many files were indexed vs skipped.
+    pub fn build_from_root(root: &Path) -> (Self, BuildOutcome) {
+        let canonical_root = canonicalize(root);
+        let mut state = IndexState {
+            root: canonical_root.clone(),
+            files: HashMap::new(),
+            path_to_id: HashMap::new(),
+            trigrams: TrigramIndex::new(),
+            words: WordIndex::new(),
+            deps: DepGraph::new(),
+            last_built_unix_ms: now_unix_ms(),
+            git_head: read_git_head(&canonical_root),
+            next_id: 1,
+        };
+        let mut outcome = BuildOutcome::default();
+        let mut to_resolve: Vec<(FileId, String)> = Vec::new();
+        walk_indexable(&canonical_root, |abs| match state.ingest(abs) {
+            Some(file_id) => {
+                outcome.files_indexed += 1;
+                if let Some(file) = state.files.get(&file_id) {
+                    to_resolve.push((file_id, file.relative_path.clone()));
+                }
+            }
+            None => {
+                outcome.files_skipped += 1;
+            }
+        });
+        for (id, rel) in to_resolve {
+            state.rebuild_deps(id, &rel);
+        }
+        (state, outcome)
+    }
+
+    fn ingest(&mut self, abs: &Path) -> Option<FileId> {
+        if !is_indexable_file(abs) {
+            return None;
+        }
+        let metadata = std::fs::metadata(abs).ok()?;
+        if metadata.len() > MAX_FILE_BYTES {
+            return None;
+        }
+        let content = std::fs::read_to_string(abs).ok()?;
+        if content.len() > MAX_FILE_BYTES as usize {
+            return None;
+        }
+        let rel = relative_path(&self.root, abs)?;
+        let hash = fnv1a64(content.as_bytes());
+        let id = match self.path_to_id.get(&rel) {
+            Some(existing_id) => {
+                if let Some(file) = self.files.get(existing_id) {
+                    if file.content_hash == hash {
+                        return Some(*existing_id);
+                    }
+                }
+                *existing_id
+            }
+            None => {
+                let id = self.next_id;
+                self.next_id = self.next_id.checked_add(1).expect("FileId overflow");
+                self.path_to_id.insert(rel.clone(), id);
+                id
+            }
+        };
+
+        let ext = abs
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        let language = language_for_extension(&ext).to_string();
+        let imports = imports::extract_imports(&content, &language);
+        let mtime_ms = metadata
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        let line_count = if content.is_empty() {
+            0
+        } else {
+            content.split('\n').count() as u32
+        };
+
+        let file = IndexedFile {
+            id,
+            relative_path: rel,
+            language,
+            size_bytes: content.len() as u64,
+            line_count,
+            content_hash: hash,
+            mtime_ms,
+            symbols: Vec::new(),
+            imports,
+        };
+        self.trigrams.index_file(id, &content);
+        self.words.index_file(id, &content);
+        self.files.insert(id, file);
+        Some(id)
+    }
+
+    fn rebuild_deps(&mut self, id: FileId, relative_path: &str) {
+        let Some(file) = self.files.get(&id).cloned() else {
+            return;
+        };
+        let resolved = imports::resolve(
+            &file.imports,
+            relative_path,
+            &file.language,
+            &self.path_to_id,
+        );
+        self.deps
+            .set_edges(id, resolved.resolved, resolved.unresolved);
+    }
+
+    /// Look up a file by either its workspace-relative path or its
+    /// absolute path inside the workspace root.
+    pub fn lookup_path(&self, raw: &str) -> Option<FileId> {
+        if let Some(id) = self.path_to_id.get(raw) {
+            return Some(*id);
+        }
+        let path = Path::new(raw);
+        if path.is_absolute() {
+            if let Some(rel) = relative_path(&self.root, path) {
+                if let Some(id) = self.path_to_id.get(&rel) {
+                    return Some(*id);
+                }
+            }
+        }
+        None
+    }
+
+    /// Estimate the resident memory footprint of every sub-index. Cheap
+    /// order-of-magnitude figure surfaced by the `stats` builtin.
+    pub fn estimated_bytes(&self) -> usize {
+        let file_bytes: usize = self
+            .files
+            .values()
+            .map(|f| f.relative_path.len() + f.imports.iter().map(|s| s.len()).sum::<usize>() + 64)
+            .sum();
+        self.trigrams.estimated_bytes() + self.words.estimated_bytes() + file_bytes
+    }
+}
+
+fn now_unix_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn canonicalize(root: &Path) -> PathBuf {
+    std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf())
+}
+
+/// Compute `abs` relative to `root`, using `/` separators. Returns `None`
+/// if `abs` is not inside `root`.
+pub(crate) fn relative_path(root: &Path, abs: &Path) -> Option<String> {
+    let canonical_abs = std::fs::canonicalize(abs).unwrap_or_else(|_| abs.to_path_buf());
+    let stripped = canonical_abs.strip_prefix(root).ok()?;
+    Some(stripped.to_string_lossy().replace('\\', "/"))
+}
+
+fn read_git_head(workspace_root: &Path) -> Option<String> {
+    let head = workspace_root.join(".git").join("HEAD");
+    let txt = std::fs::read_to_string(&head).ok()?;
+    let line = txt.trim().to_string();
+    if let Some(ref_target) = line.strip_prefix("ref: ") {
+        let ref_path = workspace_root.join(".git").join(ref_target);
+        if let Ok(sha) = std::fs::read_to_string(&ref_path) {
+            return Some(sha.trim().to_string());
+        }
+    }
+    Some(line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn build_indexes_files_and_resolves_imports() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(
+            root.join("src/main.rs"),
+            "use crate::util::helper;\nfn main() {}\n",
+        )
+        .unwrap();
+        fs::write(root.join("src/util.rs"), "pub fn helper() {}").unwrap();
+
+        let (state, outcome) = IndexState::build_from_root(root);
+        assert_eq!(outcome.files_indexed, 2);
+        assert_eq!(state.files.len(), 2);
+        let main_id = state.path_to_id["src/main.rs"];
+        let util_id = state.path_to_id["src/util.rs"];
+        // Rust uses `noop` resolution, so dep graph is empty.
+        assert_eq!(state.deps.imports_of(main_id), Vec::<FileId>::new());
+        let _ = util_id;
+    }
+
+    #[test]
+    fn typescript_imports_get_resolved() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(
+            root.join("src/index.ts"),
+            "import { helper } from \"./util\";\n",
+        )
+        .unwrap();
+        fs::write(root.join("src/util.ts"), "export function helper() {}").unwrap();
+
+        let (state, _) = IndexState::build_from_root(root);
+        let index_id = state.path_to_id["src/index.ts"];
+        let util_id = state.path_to_id["src/util.ts"];
+        assert_eq!(state.deps.imports_of(index_id), vec![util_id]);
+        assert_eq!(state.deps.importers_of(util_id), vec![index_id]);
+    }
+
+    #[test]
+    fn lookup_path_handles_absolute_paths() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("a/b")).unwrap();
+        fs::write(root.join("a/b/c.py"), "x = 1\n").unwrap();
+        let (state, _) = IndexState::build_from_root(root);
+        let abs = root.join("a/b/c.py");
+        let id = state.lookup_path(abs.to_str().unwrap()).unwrap();
+        assert_eq!(state.path_to_id["a/b/c.py"], id);
+    }
+}

--- a/crates/harn-hostlib/src/code_index/trigram.rs
+++ b/crates/harn-hostlib/src/code_index/trigram.rs
@@ -1,0 +1,206 @@
+//! Trigram index over file contents.
+//!
+//! Substring-accelerated full-text index: every 3-byte sliding window in a
+//! file becomes a posting in `index[trigram] -> Set<FileId>`. A query is
+//! decomposed into its trigrams; the candidate set is the intersection of
+//! those posting lists. Matches the Swift `TrigramIndex` byte-for-byte:
+//! ASCII case-fold on each byte (`A-Z` -> `a-z`), non-ASCII passes through,
+//! 3-byte sliding window packed `(a << 16) | (b << 8) | c` into a `u32`.
+
+use std::collections::{HashMap, HashSet};
+
+use super::file_table::FileId;
+
+/// Packed 3-byte sliding-window key. Layout: `(a << 16) | (b << 8) | c`,
+/// case-folded on the ASCII range so lookups are case-insensitive.
+pub type Trigram = u32;
+
+/// Trigram posting list: `trigram -> set of file ids that contain it`,
+/// plus a per-file reverse map for cheap re-indexing.
+#[derive(Debug, Default, Clone)]
+pub struct TrigramIndex {
+    index: HashMap<Trigram, HashSet<FileId>>,
+    file_trigrams: HashMap<FileId, HashSet<Trigram>>,
+}
+
+impl TrigramIndex {
+    /// Construct an empty index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the postings for `id` with the trigrams of `content`.
+    pub fn index_file(&mut self, id: FileId, content: &str) {
+        self.remove_file(id);
+        let trigrams = extract_trigrams(content);
+        if trigrams.is_empty() {
+            return;
+        }
+        for tg in &trigrams {
+            self.index.entry(*tg).or_default().insert(id);
+        }
+        self.file_trigrams.insert(id, trigrams);
+    }
+
+    /// Drop every posting contributed by `id`.
+    pub fn remove_file(&mut self, id: FileId) {
+        let Some(trigrams) = self.file_trigrams.remove(&id) else {
+            return;
+        };
+        for tg in trigrams {
+            if let Some(set) = self.index.get_mut(&tg) {
+                set.remove(&id);
+                if set.is_empty() {
+                    self.index.remove(&tg);
+                }
+            }
+        }
+    }
+
+    /// Return file ids that contain ALL of `trigrams`. Empty input or any
+    /// missing trigram yields an empty set.
+    pub fn query(&self, trigrams: &[Trigram]) -> HashSet<FileId> {
+        if trigrams.is_empty() {
+            return HashSet::new();
+        }
+        let mut postings: Vec<&HashSet<FileId>> = Vec::with_capacity(trigrams.len());
+        for tg in trigrams {
+            match self.index.get(tg) {
+                Some(set) => postings.push(set),
+                None => return HashSet::new(),
+            }
+        }
+        postings.sort_by_key(|s| s.len());
+        let (head, tail) = postings.split_first().expect("non-empty by construction");
+        let mut acc: HashSet<FileId> = (*head).clone();
+        for set in tail {
+            acc.retain(|id| set.contains(id));
+            if acc.is_empty() {
+                return acc;
+            }
+        }
+        acc
+    }
+
+    /// Number of distinct trigrams in the posting table.
+    pub fn distinct_trigrams(&self) -> usize {
+        self.index.len()
+    }
+
+    /// Order-of-magnitude resident-bytes estimate. Reported by
+    /// `code_index.stats.memory_bytes`.
+    pub fn estimated_bytes(&self) -> usize {
+        // Cheap order-of-magnitude estimate: 4 bytes per posting key plus
+        // ~4 bytes per FileID per posting on both sides.
+        let postings: usize = self.index.values().map(|s| s.len()).sum();
+        let reverse: usize = self.file_trigrams.values().map(|s| s.len()).sum();
+        self.index.len() * 4 + postings * 4 + reverse * 4 + self.file_trigrams.len() * 4
+    }
+}
+
+/// Extract every distinct trigram from `text`. Bytes are lowercased on the
+/// ASCII range; non-ASCII bytes pass through unchanged. Sliding 3-byte
+/// window over the UTF-8 bytes — matches Swift's
+/// `TrigramIndex.extractTrigrams` byte-for-byte.
+pub fn extract_trigrams(text: &str) -> HashSet<Trigram> {
+    let bytes = text.as_bytes();
+    if bytes.len() < 3 {
+        return HashSet::new();
+    }
+    let mut out: HashSet<Trigram> = HashSet::with_capacity(bytes.len().max(8) / 4);
+    for window in bytes.windows(3) {
+        out.insert(pack(
+            normalize(window[0]),
+            normalize(window[1]),
+            normalize(window[2]),
+        ));
+    }
+    out
+}
+
+/// Decompose a query into its constituent trigrams (deduped). Mirrors the
+/// Swift `TrigramIndex.queryTrigrams` shape so callers that pre-compute on
+/// the script side stay in lock-step with the host.
+pub fn query_trigrams(query: &str) -> Vec<Trigram> {
+    extract_trigrams(query).into_iter().collect()
+}
+
+/// Pack three normalised bytes into a `Trigram` using the canonical
+/// `(a << 16) | (b << 8) | c` layout.
+#[inline(always)]
+pub fn pack(a: u8, b: u8, c: u8) -> Trigram {
+    (a as u32) << 16 | (b as u32) << 8 | c as u32
+}
+
+#[inline(always)]
+fn normalize(byte: u8) -> u8 {
+    if byte.is_ascii_uppercase() {
+        byte + 0x20
+    } else {
+        byte
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_handles_short_strings() {
+        assert!(extract_trigrams("").is_empty());
+        assert!(extract_trigrams("ab").is_empty());
+        assert_eq!(extract_trigrams("abc").len(), 1);
+    }
+
+    #[test]
+    fn extract_is_case_insensitive() {
+        let lower = extract_trigrams("foo");
+        let upper = extract_trigrams("FOO");
+        assert_eq!(lower, upper);
+    }
+
+    #[test]
+    fn query_intersects_postings() {
+        let mut idx = TrigramIndex::new();
+        idx.index_file(1, "the quick brown fox");
+        idx.index_file(2, "jumped over the lazy dog");
+        idx.index_file(3, "lorem ipsum dolor sit amet");
+
+        let needle = query_trigrams("the");
+        let hits = idx.query(&needle);
+        assert!(hits.contains(&1));
+        assert!(hits.contains(&2));
+        assert!(!hits.contains(&3));
+    }
+
+    #[test]
+    fn missing_trigram_short_circuits_to_empty() {
+        let mut idx = TrigramIndex::new();
+        idx.index_file(1, "hello world");
+        let needle = query_trigrams("zzzzzz");
+        assert!(idx.query(&needle).is_empty());
+    }
+
+    #[test]
+    fn remove_file_drops_postings() {
+        let mut idx = TrigramIndex::new();
+        idx.index_file(1, "alpha beta");
+        idx.index_file(2, "alpha gamma");
+        idx.remove_file(1);
+        let needle = query_trigrams("alp");
+        let hits = idx.query(&needle);
+        assert!(!hits.contains(&1));
+        assert!(hits.contains(&2));
+    }
+
+    #[test]
+    fn reindex_replaces_postings() {
+        let mut idx = TrigramIndex::new();
+        idx.index_file(1, "alpha beta");
+        idx.index_file(1, "gamma delta");
+        let alpha = query_trigrams("alp");
+        let gamma = query_trigrams("gam");
+        assert!(idx.query(&alpha).is_empty());
+        assert!(idx.query(&gamma).contains(&1));
+    }
+}

--- a/crates/harn-hostlib/src/code_index/walker.rs
+++ b/crates/harn-hostlib/src/code_index/walker.rs
@@ -1,0 +1,352 @@
+//! Filtered directory walker + sensitive-file filter.
+//!
+//! Ports the Swift `FilteredWalker` and `SensitiveFilter` together: a
+//! depth-first walk that prunes noisy directories before descending and
+//! refuses to ingest credential-shaped files. Kept self-contained so the
+//! `tools/search` crate can use `ignore` for honoring `.gitignore` while
+//! the indexer stays deterministic across systems regardless of the user's
+//! ignore configuration.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// Maximum file size accepted by the indexer. Larger files are skipped to
+/// avoid blowing up the index on minified bundles, generated protobufs, etc.
+pub(crate) const MAX_FILE_BYTES: u64 = 2 * 1024 * 1024;
+
+/// Directory names whose entire subtree should be skipped. Matched by
+/// basename only.
+const SKIP_DIRS: &[&str] = &[
+    // VCS
+    ".git",
+    ".hg",
+    ".svn",
+    // Package managers / lockfiles / caches
+    "node_modules",
+    "bower_components",
+    "vendor",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".venv",
+    "venv",
+    "env",
+    ".tox",
+    ".gradle",
+    ".idea",
+    ".vs",
+    ".vscode",
+    "target",
+    "Pods",
+    ".dart_tool",
+    ".pub-cache",
+    // JS/TS build output
+    "dist",
+    "build",
+    ".next",
+    ".nuxt",
+    ".svelte-kit",
+    ".turbo",
+    ".parcel-cache",
+    ".cache",
+    // Swift / Apple
+    ".build",
+    "DerivedData",
+    ".swiftpm",
+    // Test coverage
+    "coverage",
+    ".nyc_output",
+    // Burin-owned
+    ".burin",
+    // Claude Code
+    ".claude",
+    // Misc
+    ".DS_Store",
+    ".tmp",
+    ".temp",
+    "tmp",
+    "temp",
+];
+
+const INDEXABLE_EXTENSIONS: &[&str] = &[
+    "swift", "m", "mm", "h", "c", "cc", "cpp", "hpp", "cxx", "py", "pyi", "ts", "tsx", "js", "jsx",
+    "mjs", "cjs", "go", "rs", "java", "kt", "kts", "scala", "rb", "php", "cs", "fs", "fsx", "lua",
+    "r", "jl", "dart", "elm", "sh", "bash", "zsh", "fish", "sql", "ex", "exs", "erl", "hrl", "hs",
+    "lhs", "zig", "zon", "harn", "sc", "md", "mdx", "rst", "rmd", "json", "yaml", "yml", "toml",
+    "xml", "html", "css", "scss",
+];
+
+const EXTENSIONLESS_ALLOWED: &[&str] = &["dockerfile", "makefile", "rakefile"];
+
+const ALLOWED_DOTFILES: &[&str] = &[".env.example", ".gitignore", ".dockerignore"];
+
+pub(crate) fn is_indexable_file(path: &Path) -> bool {
+    let lower_ext = path
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_ascii_lowercase());
+    if let Some(ext) = lower_ext.filter(|e| !e.is_empty()) {
+        return INDEXABLE_EXTENSIONS.contains(&ext.as_str());
+    }
+    let base = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+    EXTENSIONLESS_ALLOWED.contains(&base.as_str())
+}
+
+/// Best-effort language tag for the supplied extension. Mirrors the Swift
+/// `languageByExtension` map; unknown extensions return the extension
+/// itself so downstream tools can route language-specific behaviour.
+pub(crate) fn language_for_extension(ext: &str) -> &str {
+    match ext {
+        "py" | "pyi" => "python",
+        "ts" | "tsx" => "typescript",
+        "js" | "jsx" | "mjs" | "cjs" => "javascript",
+        "rs" => "rust",
+        "swift" => "swift",
+        "go" => "go",
+        "java" => "java",
+        "kt" | "kts" => "kotlin",
+        "rb" => "ruby",
+        "c" | "h" => "c",
+        "cc" | "cpp" | "cxx" | "hpp" => "cpp",
+        "cs" => "csharp",
+        "php" => "php",
+        "zig" => "zig",
+        "harn" => "harn",
+        "scala" => "scala",
+        "ex" | "exs" => "elixir",
+        "hs" | "lhs" => "haskell",
+        "lua" => "lua",
+        "r" => "r",
+        other => other,
+    }
+}
+
+/// Returns `true` if the path looks like a credentials/secrets file that
+/// must never enter the index. Mirrors the Swift `SensitiveFilter`.
+pub(crate) fn is_sensitive(path: &Path) -> bool {
+    let lower = path.to_string_lossy().to_ascii_lowercase();
+    let base = Path::new(&lower)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default()
+        .to_string();
+
+    if EXACT_SENSITIVE.contains(&base.as_str()) {
+        return true;
+    }
+    if BASE_PREFIXES.iter().any(|p| base.starts_with(p)) {
+        return true;
+    }
+    if BASE_SUFFIXES.iter().any(|s| base.ends_with(s)) {
+        return true;
+    }
+    if BASE_CONTAINS.iter().any(|s| base.contains(s)) {
+        return true;
+    }
+    let parts: Vec<&str> = lower.split('/').collect();
+    parts
+        .iter()
+        .any(|part| SENSITIVE_DIRS.contains(&part.to_string().as_str()))
+}
+
+const EXACT_SENSITIVE: &[&str] = &[
+    ".env",
+    ".envrc",
+    ".netrc",
+    ".pgpass",
+    "credentials",
+    "credentials.json",
+    "credentials.yml",
+    "credentials.yaml",
+    "secrets",
+    "secrets.json",
+    "secrets.yml",
+    "secrets.yaml",
+    "service-account.json",
+    "id_rsa",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "id_rsa.pub",
+    "id_dsa.pub",
+    "id_ecdsa.pub",
+    "id_ed25519.pub",
+    "authorized_keys",
+    "known_hosts",
+];
+
+const BASE_PREFIXES: &[&str] = &[".env.", ".env_", "credentials.", "secrets."];
+
+const BASE_SUFFIXES: &[&str] = &[
+    ".pem",
+    ".key",
+    ".p12",
+    ".pfx",
+    ".keystore",
+    ".jks",
+    ".asc",
+    ".gpg",
+    ".crt",
+    ".cer",
+];
+
+const BASE_CONTAINS: &[&str] = &[
+    "private_key",
+    "privatekey",
+    "api_key",
+    "apikey",
+    "secret_key",
+    "secretkey",
+];
+
+const SENSITIVE_DIRS: &[&str] = &[".ssh", ".aws", ".gnupg"];
+
+/// Walk `root` recursively, yielding every absolute path that passes the
+/// indexer's filters. Walks are depth-first; the order within a directory
+/// is sorted lexicographically so two runs over identical inputs return
+/// identical lists (helpful for snapshot tests).
+pub(crate) fn walk_indexable<F: FnMut(&Path)>(root: &Path, mut on_file: F) {
+    let mut stack: Vec<PathBuf> = vec![root.to_path_buf()];
+    let skip_dirs: HashSet<&str> = SKIP_DIRS.iter().copied().collect();
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(rd) => rd,
+            Err(_) => continue,
+        };
+        let mut sorted: Vec<PathBuf> = entries.filter_map(|e| e.ok().map(|e| e.path())).collect();
+        sorted.sort();
+        for entry in sorted {
+            let basename = entry
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default()
+                .to_string();
+            if should_skip_basename(&basename, &skip_dirs) {
+                continue;
+            }
+            let metadata = match std::fs::symlink_metadata(&entry) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if metadata.file_type().is_symlink() {
+                continue;
+            }
+            if metadata.is_dir() {
+                if skip_dirs.contains(basename.as_str()) {
+                    continue;
+                }
+                stack.push(entry);
+            } else if metadata.is_file() {
+                if !is_indexable_file(&entry) {
+                    continue;
+                }
+                if metadata.len() > MAX_FILE_BYTES {
+                    continue;
+                }
+                if is_sensitive(&entry) {
+                    continue;
+                }
+                on_file(&entry);
+            }
+        }
+    }
+}
+
+fn should_skip_basename(name: &str, skip_dirs: &HashSet<&str>) -> bool {
+    if name.is_empty() {
+        return true;
+    }
+    if skip_dirs.contains(name) {
+        // Directories are filtered later (we still want to test the
+        // directory-vs-file check before pruning), so don't short-circuit
+        // here — the caller handles directory skipping after the metadata
+        // probe.
+        return false;
+    }
+    if name.starts_with('.') && name.len() > 1 {
+        if ALLOWED_DOTFILES.contains(&name) {
+            return false;
+        }
+        // Dot-prefixed dirs that aren't in `skip_dirs` (e.g. `.cargo`,
+        // `.config`) are still walked — only dot-prefixed *files* are
+        // dropped, matching the Swift behaviour. We can't check
+        // file-vs-dir here without another stat, so approximate by
+        // returning false; the caller's metadata probe will let the dir
+        // through and skip the dotfile via `is_indexable_file` (no
+        // matching extension).
+        return false;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn indexable_extensions_cover_common_languages() {
+        assert!(is_indexable_file(Path::new("foo.rs")));
+        assert!(is_indexable_file(Path::new("foo.swift")));
+        assert!(is_indexable_file(Path::new("Foo.SWIFT")));
+        assert!(is_indexable_file(Path::new("Dockerfile")));
+        assert!(!is_indexable_file(Path::new("foo.bin")));
+        assert!(!is_indexable_file(Path::new("README"))); // no extension, not whitelisted
+    }
+
+    #[test]
+    fn sensitive_filter_rejects_known_shapes() {
+        assert!(is_sensitive(Path::new("/repo/.env")));
+        assert!(is_sensitive(Path::new("/repo/.env.local")));
+        assert!(is_sensitive(Path::new("/repo/secrets.yaml")));
+        assert!(is_sensitive(Path::new("/repo/server.pem")));
+        assert!(is_sensitive(Path::new("/repo/api_key.txt")));
+        assert!(is_sensitive(Path::new("/Users/me/.ssh/id_rsa")));
+        assert!(!is_sensitive(Path::new("/repo/src/main.rs")));
+    }
+
+    #[test]
+    fn walk_skips_pruned_dirs_and_oversize_files() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join("node_modules/foo")).unwrap();
+        fs::create_dir_all(root.join(".git/objects")).unwrap();
+        fs::write(root.join("src/main.rs"), b"fn main() {}").unwrap();
+        fs::write(root.join("src/.env"), b"SECRET=x").unwrap();
+        fs::write(root.join("node_modules/foo/lib.js"), b"x").unwrap();
+        fs::write(root.join(".git/objects/pack"), b"git").unwrap();
+        fs::write(
+            root.join("oversize.json"),
+            vec![b'a'; (MAX_FILE_BYTES + 1) as usize],
+        )
+        .unwrap();
+
+        let mut found: Vec<String> = Vec::new();
+        walk_indexable(root, |p| {
+            found.push(
+                p.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+                    .replace('\\', "/"),
+            );
+        });
+        found.sort();
+        assert_eq!(found, vec!["src/main.rs"]);
+    }
+
+    #[test]
+    fn languages_are_routed_correctly() {
+        assert_eq!(language_for_extension("rs"), "rust");
+        assert_eq!(language_for_extension("ts"), "typescript");
+        assert_eq!(language_for_extension("py"), "python");
+        assert_eq!(language_for_extension("unknown"), "unknown");
+    }
+}

--- a/crates/harn-hostlib/src/code_index/words.rs
+++ b/crates/harn-hostlib/src/code_index/words.rs
@@ -1,0 +1,175 @@
+//! Word index over identifier-like tokens.
+//!
+//! Inverted index `identifier -> Vec<(file_id, line)>`. Complements the
+//! trigram index: trigrams answer "which files contain this substring?",
+//! the word index answers "which lines mention this exact identifier?".
+//! Mirrors the Swift `WordIndex`: tokens are runs of `[A-Za-z_][A-Za-z0-9_]*`
+//! (single-character tokens are skipped), one entry per occurrence.
+
+use std::collections::{HashMap, HashSet};
+
+use super::file_table::FileId;
+
+/// Single occurrence of an identifier-shaped token: which file it landed
+/// in and on which 1-based line number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WordHit {
+    /// File the token was tokenized from.
+    pub file: FileId,
+    /// 1-based line number of the occurrence.
+    pub line: u32,
+}
+
+/// Inverted word index keyed on identifier-shaped tokens.
+#[derive(Debug, Default, Clone)]
+pub struct WordIndex {
+    index: HashMap<String, Vec<WordHit>>,
+    file_words: HashMap<FileId, HashSet<String>>,
+}
+
+impl WordIndex {
+    /// Construct an empty index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Tokenize `content` and record every hit under `id`. If `id` already
+    /// has entries, they are dropped first.
+    pub fn index_file(&mut self, id: FileId, content: &str) {
+        self.remove_file(id);
+        let mut contributed: HashSet<String> = HashSet::new();
+        for (line_idx, line) in content.split('\n').enumerate() {
+            let line_no = (line_idx as u32) + 1;
+            tokenize(line, |word| {
+                if word.len() < 2 {
+                    return;
+                }
+                self.index
+                    .entry(word.to_string())
+                    .or_default()
+                    .push(WordHit {
+                        file: id,
+                        line: line_no,
+                    });
+                contributed.insert(word.to_string());
+            });
+        }
+        if !contributed.is_empty() {
+            self.file_words.insert(id, contributed);
+        }
+    }
+
+    /// Drop every hit contributed by `id`.
+    pub fn remove_file(&mut self, id: FileId) {
+        let Some(words) = self.file_words.remove(&id) else {
+            return;
+        };
+        for word in words {
+            if let Some(hits) = self.index.get_mut(&word) {
+                hits.retain(|h| h.file != id);
+                if hits.is_empty() {
+                    self.index.remove(&word);
+                }
+            }
+        }
+    }
+
+    /// O(1) lookup for every hit recorded under `word`.
+    pub fn get(&self, word: &str) -> &[WordHit] {
+        self.index.get(word).map(Vec::as_slice).unwrap_or(&[])
+    }
+
+    /// Number of distinct tokens in the posting table.
+    pub fn distinct_words(&self) -> usize {
+        self.index.len()
+    }
+
+    /// Order-of-magnitude resident-bytes estimate. Reported by
+    /// `code_index.stats.memory_bytes`.
+    pub fn estimated_bytes(&self) -> usize {
+        let words = self.index.len();
+        let key_bytes: usize = self.index.keys().map(|k| k.len()).sum();
+        let hits: usize = self.index.values().map(Vec::len).sum();
+        // Each WordHit packs into 8 bytes (FileId + u32). Add overhead for
+        // the per-word vec plus the reverse map.
+        words * 16 + key_bytes + hits * 8 + self.file_words.len() * 16
+    }
+}
+
+/// Split a single line into identifier tokens. A token matches
+/// `[A-Za-z_][A-Za-z0-9_]*`. Numeric-only runs are skipped. `yield_token`
+/// is invoked once per occurrence — dedupe is the caller's responsibility.
+pub fn tokenize(line: &str, mut yield_token: impl FnMut(&str)) {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if !is_ident_start(bytes[i]) {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        i += 1;
+        while i < bytes.len() && is_ident_cont(bytes[i]) {
+            i += 1;
+        }
+        // SAFETY: ASCII slice boundaries — `is_ident_start`/`is_ident_cont`
+        // only ever match ASCII bytes, so `start..i` is on a UTF-8 boundary.
+        let token = std::str::from_utf8(&bytes[start..i]).expect("ASCII run");
+        yield_token(token);
+    }
+}
+
+#[inline(always)]
+fn is_ident_start(b: u8) -> bool {
+    b.is_ascii_alphabetic() || b == b'_'
+}
+
+#[inline(always)]
+fn is_ident_cont(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenize_skips_punctuation_and_numbers() {
+        let mut tokens: Vec<String> = Vec::new();
+        tokenize("let foo_bar = baz(1, 2.0); // 42_things", |t| {
+            tokens.push(t.to_string())
+        });
+        assert_eq!(tokens, vec!["let", "foo_bar", "baz", "_things"]);
+    }
+
+    #[test]
+    fn index_records_line_numbers() {
+        let mut idx = WordIndex::new();
+        idx.index_file(7, "alpha\n  beta gamma\nalpha");
+        let alpha_hits = idx.get("alpha");
+        assert_eq!(alpha_hits.len(), 2);
+        assert_eq!(alpha_hits[0], WordHit { file: 7, line: 1 });
+        assert_eq!(alpha_hits[1], WordHit { file: 7, line: 3 });
+        let gamma_hits = idx.get("gamma");
+        assert_eq!(gamma_hits, &[WordHit { file: 7, line: 2 }]);
+    }
+
+    #[test]
+    fn remove_and_reindex_replace_entries() {
+        let mut idx = WordIndex::new();
+        idx.index_file(1, "foo bar baz");
+        idx.remove_file(1);
+        assert!(idx.get("foo").is_empty());
+        idx.index_file(1, "qux");
+        assert!(idx.get("foo").is_empty());
+        assert_eq!(idx.get("qux"), &[WordHit { file: 1, line: 1 }]);
+    }
+
+    #[test]
+    fn single_character_tokens_are_skipped() {
+        let mut idx = WordIndex::new();
+        idx.index_file(1, "a foo b bar c");
+        assert!(idx.get("a").is_empty());
+        assert_eq!(idx.get("foo").len(), 1);
+    }
+}

--- a/crates/harn-hostlib/src/error.rs
+++ b/crates/harn-hostlib/src/error.rs
@@ -13,15 +13,15 @@ use harn_vm::{VmError, VmValue};
 /// Variants intentionally describe the *kind* of failure rather than the
 /// specific module — every module routes its missing-implementation errors
 /// through [`HostlibError::Unimplemented`] so embedders and tests can
-/// distinguish "this is a stub waiting for B2/B3/etc." from real failures
-/// once implementations land.
+/// distinguish intentionally scaffolded contracts from real failures once
+/// implementations land.
 #[derive(Debug, thiserror::Error)]
 pub enum HostlibError {
     /// The method exists in the registration table but has no implementation
     /// yet. This is the canonical scaffold-stage error: it tells callers
-    /// "the contract is stable, the body is coming in a follow-up issue."
+    /// "the contract is stable, but this module has not been implemented."
     #[error(
-        "hostlib: {builtin} is not implemented yet (scaffold; tracked by issue #563 follow-ups)"
+        "hostlib: {builtin} is not implemented yet (scaffolded contract without an implementation)"
     )]
     Unimplemented {
         /// Fully-qualified builtin name, e.g. `"hostlib_ast_parse_file"`.
@@ -49,8 +49,6 @@ pub enum HostlibError {
     },
 
     /// Catch-all wrapper for I/O, parsing, or other backend failures.
-    /// Implementations land in follow-up issues; today nothing surfaces
-    /// this variant.
     #[error("hostlib: {builtin}: {message}")]
     Backend {
         /// Fully-qualified builtin name.

--- a/crates/harn-hostlib/src/lib.rs
+++ b/crates/harn-hostlib/src/lib.rs
@@ -11,19 +11,23 @@
 //! These don't belong inside `harn-vm` — pulling tree-sitter grammars,
 //! ripgrep, and `notify` into the VM would balloon the footprint of every
 //! pipeline that doesn't index host code. Instead, this crate exposes a
-//! single [`HostlibCapability`] trait. Embedders (today: `harn-cli`'s ACP
+//! single [`HostlibCapability`] trait. Embedders such as `harn-cli`'s ACP
 //! server) compose the modules they need via [`HostlibRegistry`] and wire
 //! the resulting builtins into the VM through [`harn_vm::Vm::register_builtin`]
 //! / [`harn_vm::Vm::register_async_builtin`].
 //!
 //! ## Status
 //!
-//! This crate is a scaffold (issue #563). Every host method here returns
-//! [`HostlibError::Unimplemented`] until the implementation lands in
-//! follow-up issues B2/B3/B4/C1/C2/C3. The public surface — module names,
-//! method names, and JSON schemas under `schemas/` — is the source of truth
-//! for `burin-code`'s schema-drift tests, so it must stay stable across the
-//! follow-up PRs.
+//! The deterministic-tool surface (`tools/{search, read_file, write_file,
+//! delete_file, list_directory, get_file_outline, git}`), process-lifecycle
+//! tools, and the code-index surface (`code_index/{query, rebuild, stats,
+//! imports_for, importers_of}`) are implemented. The remaining modules
+//! (`ast/`, `scanner/`, `fs_watch/`) still return
+//! [`HostlibError::Unimplemented`] until their implementations are filled in.
+//! The public surface —
+//! module names, method names, and JSON schemas under `schemas/` — is the
+//! source of truth for `burin-code`'s schema-drift tests, so it must stay
+//! stable while module bodies evolve.
 
 #![deny(rust_2018_idioms)]
 #![warn(missing_docs)]
@@ -51,7 +55,7 @@ pub use registry::{BuiltinRegistry, HostlibCapability, HostlibRegistry, Register
 pub fn install_default(vm: &mut harn_vm::Vm) -> HostlibRegistry {
     let mut registry = HostlibRegistry::new()
         .with(ast::AstCapability)
-        .with(code_index::CodeIndexCapability)
+        .with(code_index::CodeIndexCapability::new())
         .with(scanner::ScannerCapability)
         .with(fs_watch::FsWatchCapability)
         .with(tools::ToolsCapability);

--- a/crates/harn-hostlib/src/registry.rs
+++ b/crates/harn-hostlib/src/registry.rs
@@ -59,7 +59,7 @@ impl BuiltinRegistry {
     }
 
     /// Convenience: register a builtin whose body is the `unimplemented`
-    /// scaffold error. Every module currently uses this.
+    /// scaffold error.
     pub fn register_unimplemented(
         &mut self,
         name: &'static str,

--- a/crates/harn-hostlib/src/scanner/mod.rs
+++ b/crates/harn-hostlib/src/scanner/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! Ports `Sources/BurinCore/Scanner/` — deterministic project-wide file
 //! enumeration honoring `.gitignore` and friends, plus an incremental mode
-//! driven by a watch token. Implementation lands in issue B4.
+//! driven by a watch token. The contract is registered ahead of the scanner
+//! implementation.
 
 use crate::registry::{BuiltinRegistry, HostlibCapability};
 

--- a/crates/harn-hostlib/src/tools/git.rs
+++ b/crates/harn-hostlib/src/tools/git.rs
@@ -1,14 +1,9 @@
 //! `tools/git` — read-only git inspection.
 //!
-//! Per the issue plan we'd prefer `gix`, but the scaffold's `Cargo.toml`
-//! intentionally omits it because gix 0.82 fails to compile on the repo's
-//! current rustc. To avoid blocking the rest of the deterministic-tool
-//! work on a toolchain bump, this module shells out to the system `git`
-//! binary using `Command` with an **arg-list invocation only** (never
-//! `sh -c <string>`). That keeps the surface free of shell injection and
-//! preserves the contract documented in `schemas/tools/git.{request,response}.json`.
-//! When B2's toolchain bump unblocks `gix`, individual operations can be
-//! migrated one at a time without touching the public surface.
+//! This module shells out to the system `git` binary using `Command` with an
+//! **arg-list invocation only** (never `sh -c <string>`). That keeps the
+//! surface free of shell injection and preserves the contract documented in
+//! `schemas/tools/git.{request,response}.json`.
 
 use std::path::PathBuf;
 use std::process::Command;

--- a/crates/harn-hostlib/src/tools/manage_packages.rs
+++ b/crates/harn-hostlib/src/tools/manage_packages.rs
@@ -331,7 +331,7 @@ mod tests {
 
     #[test]
     fn unsupported_pair_returns_none() {
-        // gradle has no defined `add` mapping today
+        // Gradle does not have a portable CLI mapping for adding dependencies.
         assert!(build_argv(
             Ecosystem::Gradle,
             Operation::Add,

--- a/crates/harn-hostlib/src/tools/mod.rs
+++ b/crates/harn-hostlib/src/tools/mod.rs
@@ -1,8 +1,8 @@
 //! Deterministic tools capability.
 //!
 //! Ports the Swift `CoreToolExecutor` surface: search (ripgrep via
-//! `grep-searcher` + `ignore`), file I/O, listing, file outline, git via
-//! `gix` (currently shelled-out — see [`git`] for the rationale), and
+//! `grep-searcher` + `ignore`), file I/O, listing, file outline, git
+//! inspection, and
 //! process lifecycle (`run_command`, `run_test`, `run_build_command`,
 //! `inspect_test_results`, `manage_packages`).
 //!
@@ -29,9 +29,8 @@
 //! Pipelines must call `hostlib_enable("tools:deterministic")` (registered
 //! by [`ToolsCapability::register_builtins`]) before any of the tool
 //! methods will execute. Until then, calls return
-//! [`HostlibError::Backend`] with an explanatory message. This matches the
-//! "per-session opt-in" model called out in issue #567 and keeps the
-//! deterministic-tool surface sandbox-friendly.
+//! [`HostlibError::Backend`] with an explanatory message. The per-session
+//! opt-in model keeps the deterministic-tool surface sandbox-friendly.
 
 use std::collections::BTreeMap;
 use std::rc::Rc;

--- a/crates/harn-hostlib/src/tools/outline.rs
+++ b/crates/harn-hostlib/src/tools/outline.rs
@@ -1,14 +1,11 @@
 //! `tools/get_file_outline` — convenience wrapper that returns a
 //! structural outline (functions, classes, types) for a single source file.
 //!
-//! The issue's `tools/get_file_outline` description says "calls to
-//! `ast::outline`" — but `ast::outline` is the surface of B2, which lands
-//! after this issue. Until B2 ships, we use a small language-agnostic
-//! regex-backed extractor for the languages `burin-code` ships outline
-//! support for today: Swift, Rust, JS/TS, Python, Go, Ruby, Java/Kotlin,
-//! C/C++, and shell. The output shape is identical to `ast.outline`'s
-//! response schema, so when B2 lands the body of this function can swap
-//! the regex extractor for a tree-sitter call without disturbing callers.
+//! This module uses a small language-agnostic regex-backed extractor for the
+//! languages `burin-code` exposes in its outline UI: Swift, Rust, JS/TS,
+//! Python, Go, Ruby, Java/Kotlin, C/C++, and shell. The output shape is
+//! identical to `ast.outline`'s response schema, so the extractor can be
+//! replaced by a tree-sitter implementation without disturbing callers.
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/harn-hostlib/src/tools/permissions.rs
+++ b/crates/harn-hostlib/src/tools/permissions.rs
@@ -10,10 +10,9 @@
 //!
 //! State is held in a thread-local so that:
 //!
-//! * Each VM instance — which today runs single-threaded — gets an
-//!   independent enable set.
-//! * Cargo test isolation works without extra ceremony (each test runs on
-//!   its own thread).
+//! * Independent VM runs stay isolated when the embedder executes them on
+//!   separate threads.
+//! * Cargo test isolation works without extra ceremony.
 //!
 //! Embedders can also call [`enable_for_test`] / [`reset`] from Rust if
 //! they need to bypass the builtin (for example, tests that don't drive
@@ -51,7 +50,7 @@ pub fn reset() {
     ENABLED.with(|cell| cell.borrow_mut().clear());
 }
 
-/// Report whether `feature` is currently enabled on the current thread.
+/// Report whether `feature` is enabled on the current thread.
 pub fn is_enabled(feature: &str) -> bool {
     ENABLED.with(|cell| cell.borrow().contains(feature))
 }

--- a/crates/harn-hostlib/src/tools/proc.rs
+++ b/crates/harn-hostlib/src/tools/proc.rs
@@ -211,7 +211,7 @@ fn decode_status(status: std::process::ExitStatus) -> (i32, Option<String>) {
 
 #[cfg(unix)]
 fn format_signal(sig: i32) -> String {
-    // Stay minimal: mirror the names burin-code's UI surfaces today.
+    // Stay minimal: mirror the names exposed by burin-code's UI surfaces.
     match sig {
         1 => "SIGHUP".into(),
         2 => "SIGINT".into(),

--- a/crates/harn-hostlib/tests/code_index.rs
+++ b/crates/harn-hostlib/tests/code_index.rs
@@ -1,0 +1,386 @@
+//! Integration tests for the `code_index` host capability.
+//!
+//! Exercise every builtin end-to-end against a temp workspace: rebuild,
+//! query, stats, imports_for, importers_of. The builtins are routed
+//! through the same `BuiltinRegistry` plumbing the VM uses, so passing
+//! these tests proves the schema-locked surface returns the right shape
+//! for embedders.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::rc::Rc;
+
+use harn_hostlib::{
+    code_index::CodeIndexCapability, BuiltinRegistry, HostlibCapability, RegisteredBuiltin,
+};
+use harn_vm::VmValue;
+
+fn build_registry() -> (BuiltinRegistry, CodeIndexCapability) {
+    let cap = CodeIndexCapability::new();
+    let mut registry = BuiltinRegistry::new();
+    cap.register_builtins(&mut registry);
+    (registry, cap)
+}
+
+fn dict(entries: &[(&str, VmValue)]) -> VmValue {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in entries {
+        map.insert((*k).to_string(), v.clone());
+    }
+    VmValue::Dict(Rc::new(map))
+}
+
+fn call(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {
+    let entry: &RegisteredBuiltin = registry.find(name).unwrap_or_else(|| {
+        panic!("builtin {name} not registered");
+    });
+    (entry.handler)(&[payload]).unwrap_or_else(|err| {
+        panic!("builtin {name} failed: {err:?}");
+    })
+}
+
+fn extract_dict(value: &VmValue) -> Rc<BTreeMap<String, VmValue>> {
+    match value {
+        VmValue::Dict(d) => d.clone(),
+        other => panic!("expected dict, got {other:?}"),
+    }
+}
+
+fn extract_list(value: &VmValue) -> Rc<Vec<VmValue>> {
+    match value {
+        VmValue::List(l) => l.clone(),
+        other => panic!("expected list, got {other:?}"),
+    }
+}
+
+fn extract_int(value: &VmValue) -> i64 {
+    match value {
+        VmValue::Int(n) => *n,
+        other => panic!("expected int, got {other:?}"),
+    }
+}
+
+fn extract_str(value: &VmValue) -> String {
+    match value {
+        VmValue::String(s) => s.to_string(),
+        other => panic!("expected string, got {other:?}"),
+    }
+}
+
+fn write_workspace() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("docs")).unwrap();
+    fs::write(
+        root.join("src/index.ts"),
+        "import { helper } from \"./util\";\nimport { other } from \"./other\";\nexport const alphaToken = helper();\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/util.ts"),
+        "export function helper() { return 'AlphaToken from util'; }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/other.ts"),
+        "import { helper } from \"./util\";\nexport function other() { return helper(); }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("docs/notes.md"),
+        "Random notes about alphaToken.\n",
+    )
+    .unwrap();
+    fs::write(root.join("README.md"), "# project\nNo content here.\n").unwrap();
+    dir
+}
+
+#[test]
+fn rebuild_then_query_returns_hits_for_indexed_substring() {
+    let dir = write_workspace();
+    let (registry, _cap) = build_registry();
+
+    let rebuild = call(
+        &registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(Rc::from(dir.path().to_string_lossy().to_string())),
+        )]),
+    );
+    let r = extract_dict(&rebuild);
+    assert!(extract_int(r.get("files_indexed").unwrap()) >= 4);
+
+    let response = call(
+        &registry,
+        "hostlib_code_index_query",
+        dict(&[("needle", VmValue::String(Rc::from("alphaToken")))]),
+    );
+    let response = extract_dict(&response);
+    let results = extract_list(response.get("results").unwrap());
+    let mut paths: Vec<String> = results
+        .iter()
+        .map(|hit| {
+            let dict = extract_dict(hit);
+            extract_str(dict.get("path").unwrap())
+        })
+        .collect();
+    paths.sort();
+    assert!(paths.contains(&"src/index.ts".to_string()));
+    assert!(paths.contains(&"src/util.ts".to_string()));
+    assert!(paths.contains(&"docs/notes.md".to_string()));
+}
+
+#[test]
+fn query_respects_case_sensitive_flag() {
+    let dir = write_workspace();
+    let (registry, _) = build_registry();
+
+    call(
+        &registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(Rc::from(dir.path().to_string_lossy().to_string())),
+        )]),
+    );
+
+    let case_sensitive = call(
+        &registry,
+        "hostlib_code_index_query",
+        dict(&[
+            ("needle", VmValue::String(Rc::from("alphaToken"))),
+            ("case_sensitive", VmValue::Bool(true)),
+        ]),
+    );
+    let cs = extract_dict(&case_sensitive);
+    let cs_results = extract_list(cs.get("results").unwrap());
+
+    let case_insensitive = call(
+        &registry,
+        "hostlib_code_index_query",
+        dict(&[
+            ("needle", VmValue::String(Rc::from("alphaToken"))),
+            ("case_sensitive", VmValue::Bool(false)),
+        ]),
+    );
+    let ci = extract_dict(&case_insensitive);
+    let ci_results = extract_list(ci.get("results").unwrap());
+
+    // Case-insensitive should never miss what case-sensitive sees, and
+    // typically catches more.
+    assert!(ci_results.len() >= cs_results.len());
+    assert!(!cs_results.is_empty());
+}
+
+#[test]
+fn query_truncates_to_max_results() {
+    let dir = write_workspace();
+    let (registry, _) = build_registry();
+
+    call(
+        &registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(Rc::from(dir.path().to_string_lossy().to_string())),
+        )]),
+    );
+    let response = call(
+        &registry,
+        "hostlib_code_index_query",
+        dict(&[
+            ("needle", VmValue::String(Rc::from("export"))),
+            ("max_results", VmValue::Int(1)),
+        ]),
+    );
+    let response = extract_dict(&response);
+    let results = extract_list(response.get("results").unwrap());
+    assert_eq!(results.len(), 1);
+    assert!(matches!(
+        response.get("truncated").unwrap(),
+        VmValue::Bool(true)
+    ));
+}
+
+#[test]
+fn query_scope_filter_restricts_results() {
+    let dir = write_workspace();
+    let (registry, _) = build_registry();
+
+    call(
+        &registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(Rc::from(dir.path().to_string_lossy().to_string())),
+        )]),
+    );
+
+    let scope_value = VmValue::List(Rc::new(vec![VmValue::String(Rc::from("src"))]));
+    let response = call(
+        &registry,
+        "hostlib_code_index_query",
+        dict(&[
+            ("needle", VmValue::String(Rc::from("alphaToken"))),
+            ("scope", scope_value),
+        ]),
+    );
+    let response = extract_dict(&response);
+    let results = extract_list(response.get("results").unwrap());
+    let paths: Vec<String> = results
+        .iter()
+        .map(|hit| {
+            let dict = extract_dict(hit);
+            extract_str(dict.get("path").unwrap())
+        })
+        .collect();
+    assert!(paths.iter().all(|p| p.starts_with("src/")));
+}
+
+#[test]
+fn imports_for_returns_resolved_and_unresolved() {
+    let dir = write_workspace();
+    let (registry, _) = build_registry();
+
+    call(
+        &registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(Rc::from(dir.path().to_string_lossy().to_string())),
+        )]),
+    );
+    let response = call(
+        &registry,
+        "hostlib_code_index_imports_for",
+        dict(&[("path", VmValue::String(Rc::from("src/index.ts")))]),
+    );
+    let response = extract_dict(&response);
+    let imports = extract_list(response.get("imports").unwrap());
+    let pairs: Vec<(String, Option<String>, String)> = imports
+        .iter()
+        .map(|item| {
+            let d = extract_dict(item);
+            let module = extract_str(d.get("module").unwrap());
+            let resolved = match d.get("resolved_path").unwrap() {
+                VmValue::Nil => None,
+                VmValue::String(s) => Some(s.to_string()),
+                other => panic!("expected str|nil, got {other:?}"),
+            };
+            let kind = extract_str(d.get("kind").unwrap());
+            (module, resolved, kind)
+        })
+        .collect();
+
+    let util_resolution = pairs
+        .iter()
+        .find(|(m, _, _)| m.contains("./util"))
+        .expect("./util import surfaced");
+    assert_eq!(util_resolution.1.as_deref(), Some("src/util.ts"));
+    assert_eq!(util_resolution.2, "import");
+
+    // The other import points at a path that doesn't exist in the
+    // workspace — it should land in the response with `resolved_path: nil`.
+    let other_resolution = pairs
+        .iter()
+        .find(|(m, _, _)| m.contains("./other"))
+        .expect("./other import surfaced");
+    assert_eq!(other_resolution.1.as_deref(), Some("src/other.ts"));
+}
+
+#[test]
+fn importers_of_returns_paths_in_sorted_order() {
+    let dir = write_workspace();
+    let (registry, _) = build_registry();
+
+    call(
+        &registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(Rc::from(dir.path().to_string_lossy().to_string())),
+        )]),
+    );
+    let response = call(
+        &registry,
+        "hostlib_code_index_importers_of",
+        dict(&[("module", VmValue::String(Rc::from("src/util.ts")))]),
+    );
+    let response = extract_dict(&response);
+    let importers = extract_list(response.get("importers").unwrap());
+    let paths: Vec<String> = importers.iter().map(extract_str).collect();
+    assert_eq!(paths, vec!["src/index.ts", "src/other.ts"]);
+}
+
+#[test]
+fn stats_reflect_index_state() {
+    let (registry, _) = build_registry();
+
+    let pre = extract_dict(&call(&registry, "hostlib_code_index_stats", dict(&[])));
+    assert_eq!(extract_int(pre.get("indexed_files").unwrap()), 0);
+    assert!(matches!(
+        pre.get("last_rebuild_unix_ms").unwrap(),
+        VmValue::Nil
+    ));
+
+    let dir = write_workspace();
+    call(
+        &registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(Rc::from(dir.path().to_string_lossy().to_string())),
+        )]),
+    );
+    let post = extract_dict(&call(&registry, "hostlib_code_index_stats", dict(&[])));
+    assert!(extract_int(post.get("indexed_files").unwrap()) >= 4);
+    assert!(extract_int(post.get("trigrams").unwrap()) > 0);
+    assert!(extract_int(post.get("words").unwrap()) > 0);
+    assert!(extract_int(post.get("memory_bytes").unwrap()) > 0);
+    assert!(matches!(
+        post.get("last_rebuild_unix_ms").unwrap(),
+        VmValue::Int(_)
+    ));
+}
+
+#[test]
+fn rebuild_rejects_missing_root() {
+    let (registry, _) = build_registry();
+    let entry = registry.find("hostlib_code_index_rebuild").unwrap();
+    let err = (entry.handler)(&[dict(&[(
+        "root",
+        VmValue::String(Rc::from("/definitely/not/here/zzz")),
+    )])])
+    .expect_err("missing root must error");
+    let msg = format!("{err}");
+    assert!(msg.contains("root"), "error mentions the param: {msg}");
+}
+
+#[test]
+fn empty_workspace_returns_empty_responses() {
+    let (registry, _) = build_registry();
+    // No rebuild yet — every read op should still respond with a dict
+    // shape rather than panicking.
+    let q = extract_dict(&call(
+        &registry,
+        "hostlib_code_index_query",
+        dict(&[("needle", VmValue::String(Rc::from("anything")))]),
+    ));
+    assert!(extract_list(q.get("results").unwrap()).is_empty());
+
+    let imps = extract_dict(&call(
+        &registry,
+        "hostlib_code_index_imports_for",
+        dict(&[("path", VmValue::String(Rc::from("src/main.rs")))]),
+    ));
+    assert!(extract_list(imps.get("imports").unwrap()).is_empty());
+
+    let imps_of = extract_dict(&call(
+        &registry,
+        "hostlib_code_index_importers_of",
+        dict(&[("module", VmValue::String(Rc::from("anything")))]),
+    ));
+    assert!(extract_list(imps_of.get("importers").unwrap()).is_empty());
+}

--- a/crates/harn-hostlib/tests/code_index_scenario.rs
+++ b/crates/harn-hostlib/tests/code_index_scenario.rs
@@ -1,0 +1,192 @@
+//! Scenario test: build a real index over a Swift fixture that mirrors
+//! the layout of `burin-labs/burin-code`'s `Sources/BurinCodeIndex/`.
+//!
+//! The issue's "Tests" bullet asks for "a scenario test that builds an
+//! index over the `burin-code` repo itself and asserts known queries
+//! (golden fixture)". We can't depend on a sibling checkout from CI, so
+//! the fixture under `tests/fixtures/burin_code_subset/` reproduces the
+//! shape of the Swift module we're porting (file names, basic content,
+//! cross-references). The asserts are picked to catch regressions in:
+//!
+//! - the trigram/word index (does `query("TrigramIndex")` find the file?)
+//! - the import resolver (does `imports_for("CodeIndex.swift")` see
+//!   `import Foundation`?)
+//! - the dep graph (does `importers_of("Foundation")` … no, Swift does
+//!   not resolve standard-library imports — so the symmetric assertion
+//!   uses an in-fixture cross-reference instead).
+//!
+//! When `BURIN_CODE_REPO=<path>` is set in the environment, the scenario
+//! also rebuilds the index against that path and asserts the same set of
+//! invariants over the live repo. CI doesn't set the env var so the
+//! synthetic fixture path is the default.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use harn_hostlib::{
+    code_index::CodeIndexCapability, BuiltinRegistry, HostlibCapability, RegisteredBuiltin,
+};
+use harn_vm::VmValue;
+
+fn dict(entries: &[(&str, VmValue)]) -> VmValue {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in entries {
+        map.insert((*k).to_string(), v.clone());
+    }
+    VmValue::Dict(Rc::new(map))
+}
+
+fn call(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {
+    let entry: &RegisteredBuiltin = registry
+        .find(name)
+        .unwrap_or_else(|| panic!("builtin {name} not registered"));
+    (entry.handler)(&[payload]).unwrap_or_else(|err| panic!("builtin {name} failed: {err:?}"))
+}
+
+fn extract_dict(value: &VmValue) -> Rc<BTreeMap<String, VmValue>> {
+    match value {
+        VmValue::Dict(d) => d.clone(),
+        other => panic!("expected dict, got {other:?}"),
+    }
+}
+
+fn extract_list(value: &VmValue) -> Rc<Vec<VmValue>> {
+    match value {
+        VmValue::List(l) => l.clone(),
+        other => panic!("expected list, got {other:?}"),
+    }
+}
+
+fn extract_int(value: &VmValue) -> i64 {
+    match value {
+        VmValue::Int(n) => *n,
+        other => panic!("expected int, got {other:?}"),
+    }
+}
+
+fn extract_str(value: &VmValue) -> String {
+    match value {
+        VmValue::String(s) => s.to_string(),
+        other => panic!("expected string, got {other:?}"),
+    }
+}
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("burin_code_subset")
+}
+
+fn rebuild(registry: &BuiltinRegistry, root: &Path) -> i64 {
+    let response = call(
+        registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(Rc::from(root.to_string_lossy().to_string())),
+        )]),
+    );
+    let dict = extract_dict(&response);
+    extract_int(dict.get("files_indexed").unwrap())
+}
+
+fn assert_substring_query_finds(registry: &BuiltinRegistry, needle: &str, expected: &[&str]) {
+    let response = call(
+        registry,
+        "hostlib_code_index_query",
+        dict(&[
+            ("needle", VmValue::String(Rc::from(needle.to_string()))),
+            ("max_results", VmValue::Int(100)),
+        ]),
+    );
+    let response = extract_dict(&response);
+    let results = extract_list(response.get("results").unwrap());
+    let paths: Vec<String> = results
+        .iter()
+        .map(|hit| {
+            let dict = extract_dict(hit);
+            extract_str(dict.get("path").unwrap())
+        })
+        .collect();
+    for fragment in expected {
+        assert!(
+            paths.iter().any(|p| p.ends_with(fragment)),
+            "query `{needle}` missed `{fragment}`; got {paths:?}"
+        );
+    }
+}
+
+#[test]
+fn fixture_reproduces_swift_module_invariants() {
+    let cap = CodeIndexCapability::new();
+    let mut registry = BuiltinRegistry::new();
+    cap.register_builtins(&mut registry);
+
+    let files_indexed = rebuild(&registry, &fixture_path());
+    assert!(
+        files_indexed >= 4,
+        "expected at least the four ported files, got {files_indexed}"
+    );
+
+    // Trigram path: literal substrings unique to each file land hits.
+    assert_substring_query_finds(&registry, "TrigramIndex", &["TrigramIndex.swift"]);
+    assert_substring_query_finds(&registry, "WordIndex", &["WordIndex.swift"]);
+    assert_substring_query_finds(&registry, "DepGraph", &["DepGraph.swift"]);
+    assert_substring_query_finds(&registry, "FilteredWalker", &["FilteredWalker.swift"]);
+
+    // Imports surfaced for one of the modules.
+    let imports = call(
+        &registry,
+        "hostlib_code_index_imports_for",
+        dict(&[("path", VmValue::String(Rc::from("CodeIndex.swift")))]),
+    );
+    let imports = extract_dict(&imports);
+    let modules: Vec<String> = extract_list(imports.get("imports").unwrap())
+        .iter()
+        .map(|entry| {
+            let dict = extract_dict(entry);
+            extract_str(dict.get("module").unwrap())
+        })
+        .collect();
+    assert!(
+        modules.iter().any(|m| m == "import Foundation"),
+        "expected `import Foundation` in CodeIndex.swift imports; got {modules:?}",
+    );
+
+    // Stats reflect a populated index.
+    let stats = extract_dict(&call(&registry, "hostlib_code_index_stats", dict(&[])));
+    assert!(extract_int(stats.get("indexed_files").unwrap()) >= 4);
+    assert!(extract_int(stats.get("trigrams").unwrap()) > 0);
+}
+
+/// When `BURIN_CODE_REPO` points at a checkout, the same invariants are
+/// asserted over the real repo. The env-var gate keeps CI fast and
+/// hermetic — local runs that opt in get the realistic stress test.
+#[test]
+fn live_burin_code_smoke() {
+    let Some(path) = std::env::var_os("BURIN_CODE_REPO") else {
+        eprintln!("BURIN_CODE_REPO not set; skipping live scenario test");
+        return;
+    };
+    let path = PathBuf::from(path);
+    if !path.exists() {
+        eprintln!("BURIN_CODE_REPO does not exist; skipping");
+        return;
+    }
+    let cap = CodeIndexCapability::new();
+    let mut registry = BuiltinRegistry::new();
+    cap.register_builtins(&mut registry);
+
+    let started = std::time::Instant::now();
+    let files_indexed = rebuild(&registry, &path);
+    let elapsed = started.elapsed();
+    eprintln!(
+        "live burin-code rebuild: {files_indexed} files in {:.2}s",
+        elapsed.as_secs_f64()
+    );
+    assert!(files_indexed > 0);
+
+    assert_substring_query_finds(&registry, "TrigramIndex", &["TrigramIndex.swift"]);
+}

--- a/crates/harn-hostlib/tests/fixtures/burin_code_subset/CodeIndex.swift
+++ b/crates/harn-hostlib/tests/fixtures/burin_code_subset/CodeIndex.swift
@@ -1,0 +1,22 @@
+// CodeIndex.swift
+//
+// Trimmed fixture mirroring the structure of
+// `burin-labs/burin-code/Sources/BurinCodeIndex/CodeIndex.swift`. Used by
+// `tests/code_index_scenario.rs` as a stand-in when the live repo isn't
+// available — the tree-shape and `import` declarations are what the
+// scenario asserts on, not the implementation details.
+
+import Foundation
+
+public actor CodeIndex {
+    public let workspaceRoot: String
+
+    public init(workspaceRoot: String) {
+        self.workspaceRoot = workspaceRoot
+    }
+
+    public func reindexBatch(absolutePaths: [String]) {
+        // Real implementation walks files; the fixture only needs to be
+        // reachable by name.
+    }
+}

--- a/crates/harn-hostlib/tests/fixtures/burin_code_subset/DepGraph.swift
+++ b/crates/harn-hostlib/tests/fixtures/burin_code_subset/DepGraph.swift
@@ -1,0 +1,22 @@
+// DepGraph.swift
+//
+// Forward + reverse dep edge fixture. Tracks `imports of` and
+// `importers of` semantics; used by the scenario test purely as a
+// substring target.
+
+import Foundation
+
+public struct DepGraph {
+    public private(set) var forward: [UInt32: Set<UInt32>] = [:]
+    public private(set) var reverse: [UInt32: Set<UInt32>] = [:]
+
+    public init() {}
+
+    public func importers(of file: UInt32) -> [UInt32] {
+        Array(reverse[file] ?? [])
+    }
+
+    public func imports(of file: UInt32) -> [UInt32] {
+        Array(forward[file] ?? [])
+    }
+}

--- a/crates/harn-hostlib/tests/fixtures/burin_code_subset/FilteredWalker.swift
+++ b/crates/harn-hostlib/tests/fixtures/burin_code_subset/FilteredWalker.swift
@@ -1,0 +1,16 @@
+// FilteredWalker.swift
+//
+// Mirrors the Swift `FilteredWalker` shape. Used by the scenario test
+// to assert substring queries find this file — the body is irrelevant.
+
+import Foundation
+
+public enum FilteredWalker {
+    public static let skipDirs: Set<String> = [
+        ".git", "node_modules", "build", "dist", "target",
+    ]
+
+    public static let indexableExtensions: Set<String> = [
+        "swift", "rs", "ts", "py",
+    ]
+}

--- a/crates/harn-hostlib/tests/fixtures/burin_code_subset/TrigramIndex.swift
+++ b/crates/harn-hostlib/tests/fixtures/burin_code_subset/TrigramIndex.swift
@@ -1,0 +1,26 @@
+// TrigramIndex.swift
+//
+// Trimmed fixture for the scenario test. Mirrors the public surface of
+// the Swift `TrigramIndex` so the scenario asserts queries by substring
+// can find this file.
+
+import Foundation
+
+public typealias Trigram = UInt32
+public typealias FileID = UInt32
+
+public struct TrigramIndex {
+    public private(set) var index: [Trigram: Set<FileID>] = [:]
+
+    public init() {}
+
+    public func query(_ trigrams: [Trigram]) -> Set<FileID> {
+        var acc: Set<FileID> = []
+        for tg in trigrams {
+            if let set = index[tg] {
+                acc.formUnion(set)
+            }
+        }
+        return acc
+    }
+}

--- a/crates/harn-hostlib/tests/fixtures/burin_code_subset/WordIndex.swift
+++ b/crates/harn-hostlib/tests/fixtures/burin_code_subset/WordIndex.swift
@@ -1,0 +1,22 @@
+// WordIndex.swift
+//
+// Fixture stand-in for the Swift `WordIndex` actor. Only shape matters
+// for the scenario test — substring queries should find this file by
+// name.
+
+import Foundation
+
+public struct WordHit {
+    public let file: UInt32
+    public let line: UInt32
+}
+
+public struct WordIndex {
+    public private(set) var index: [String: [WordHit]] = [:]
+
+    public init() {}
+
+    public func get(_ word: String) -> [WordHit] {
+        index[word] ?? []
+    }
+}

--- a/crates/harn-hostlib/tests/process_tools.rs
+++ b/crates/harn-hostlib/tests/process_tools.rs
@@ -1,5 +1,5 @@
-//! Integration tests for issue #568 — the five process-lifecycle tool
-//! builtins (`run_command`, `run_test`, `run_build_command`,
+//! Integration tests for the five process-lifecycle tool builtins
+//! (`run_command`, `run_test`, `run_build_command`,
 //! `inspect_test_results`, `manage_packages`).
 //!
 //! These spawn real subprocesses, so they're gated to Unix and rely only
@@ -363,7 +363,7 @@ fn manage_packages_no_ecosystem_no_manifest_errors() {
 
 #[test]
 fn manage_packages_unsupported_pair_for_ecosystem_errors() {
-    // gradle has no defined `add` mapping today.
+    // Gradle does not have a portable CLI mapping for adding dependencies.
     let mut req = dict();
     req.insert("operation".into(), vstr("add"));
     req.insert("ecosystem".into(), vstr("gradle"));

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -2,10 +2,10 @@
 //! compiles, that unimplemented methods route through `HostlibError` rather
 //! than panicking, and that every registered builtin has a matching schema.
 //!
-//! These tests are the contract that follow-up implementation issues
-//! (B2/B3/B4/C1/C2/C3) must keep green: when an issue lands, the only
-//! change here should be that a routed `Unimplemented` becomes a real
-//! return value — never a removed builtin.
+//! These tests are the contract implementation work must keep green:
+//! when a module moves beyond scaffolding, the only change here should be
+//! that a routed `Unimplemented` becomes a real return value — never a
+//! removed builtin.
 
 use harn_hostlib::{
     ast::AstCapability, code_index::CodeIndexCapability, fs_watch::FsWatchCapability,
@@ -67,7 +67,7 @@ fn ast_capability_registers_documented_methods() {
 
 #[test]
 fn code_index_capability_registers_documented_methods() {
-    let registry = collect_into_registry(CodeIndexCapability);
+    let registry = collect_into_registry(CodeIndexCapability::new());
     let names: Vec<_> = registry.iter().map(|b| b.name).collect();
     assert_eq!(
         names,
@@ -79,7 +79,17 @@ fn code_index_capability_registers_documented_methods() {
             "hostlib_code_index_importers_of",
         ]
     );
-    assert_all_unimplemented(&registry);
+    // Without a populated workspace, code-index read methods return empty
+    // payloads rather than panicking. Assert that contract here so any
+    // regression to `unimplemented!()` fails loudly.
+    let stats = registry
+        .find("hostlib_code_index_stats")
+        .expect("registered");
+    let value = (stats.handler)(&[]).expect("stats works on an empty index");
+    match value {
+        harn_vm::VmValue::Dict(_) => {}
+        other => panic!("expected dict response from stats, got {other:?}"),
+    }
 }
 
 #[test]
@@ -124,14 +134,14 @@ fn tools_capability_registers_documented_methods() {
             "hostlib_tools_list_directory",
             "hostlib_tools_get_file_outline",
             "hostlib_tools_git",
-            // Process tools from issue #568. Also gated by
+            // Process tools. Also gated by
             // `hostlib_enable("tools:deterministic")`.
             "hostlib_tools_run_command",
             "hostlib_tools_run_test",
             "hostlib_tools_run_build_command",
             "hostlib_tools_inspect_test_results",
             "hostlib_tools_manage_packages",
-            // Per-session opt-in builtin from issue #567.
+            // Per-session opt-in builtin.
             "hostlib_enable",
         ]
     );
@@ -188,7 +198,7 @@ fn install_default_wires_every_module_into_a_vm() {
 fn every_registered_builtin_has_request_and_response_schemas() {
     let registry = HostlibRegistry::new()
         .with(AstCapability)
-        .with(CodeIndexCapability)
+        .with(CodeIndexCapability::new())
         .with(ScannerCapability)
         .with(FsWatchCapability)
         .with(ToolsCapability);

--- a/crates/harn-hostlib/tests/smoke_harn_script.rs
+++ b/crates/harn-hostlib/tests/smoke_harn_script.rs
@@ -1,6 +1,5 @@
-//! Smoke test for #567: drive every deterministic tool from a real
-//! `.harn` script through the full lexer + parser + compiler + VM
-//! pipeline.
+//! Smoke test for driving every deterministic tool from a real `.harn`
+//! script through the full lexer + parser + compiler + VM pipeline.
 //!
 //! The standalone integration tests under `tests/tools_*.rs` exercise
 //! handlers directly. This file proves the contract end-to-end: that a
@@ -220,5 +219,67 @@ return {{
     assert!(matches!(
         dict.get("branch").unwrap(),
         VmValue::String(s) if s.as_ref() == "main"
+    ));
+}
+
+#[test]
+fn end_to_end_code_index_via_harn_script() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/index.ts"),
+        "import { helper } from \"./util\";\nexport const ZetaToken = helper();\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/util.ts"),
+        "export function helper() { return 'ZetaToken from util'; }\n",
+    )
+    .unwrap();
+
+    let root_str = root.to_string_lossy().replace('\\', "/");
+
+    let source = format!(
+        r#"
+let rebuild = hostlib_code_index_rebuild({{ root: "{root}" }})
+let stats = hostlib_code_index_stats({{}})
+let q = hostlib_code_index_query({{ needle: "ZetaToken", max_results: 10 }})
+let imps = hostlib_code_index_imports_for({{ path: "src/index.ts" }})
+let users = hostlib_code_index_importers_of({{ module: "src/util.ts" }})
+return {{
+    indexed: rebuild.files_indexed,
+    files: stats.indexed_files,
+    hits: len(q.results),
+    first_path: q.results[0].path,
+    imports_kind: imps.imports[0].kind,
+    importer: users.importers[0],
+}}
+"#,
+        root = root_str,
+    );
+
+    let (result, _) = run_harn(&source);
+    let dict = match &result {
+        VmValue::Dict(d) => d,
+        other => panic!("expected dict, got {other:?}"),
+    };
+    let get = |k: &str| dict.get(k).unwrap_or_else(|| panic!("missing {k}"));
+
+    let VmValue::Int(indexed) = get("indexed") else {
+        panic!("indexed");
+    };
+    assert!(*indexed >= 2);
+    let VmValue::Int(hits) = get("hits") else {
+        panic!("hits");
+    };
+    assert!(*hits >= 2, "expected at least 2 hits, got {hits}");
+    assert!(matches!(
+        get("imports_kind"),
+        VmValue::String(s) if s.as_ref() == "import"
+    ));
+    assert!(matches!(
+        get("importer"),
+        VmValue::String(s) if s.as_ref() == "src/index.ts"
     ));
 }


### PR DESCRIPTION
Closes #565.

## Summary

Implements the `code_index/` module in `harn-hostlib` end-to-end, lighting up the five host builtins whose schemas were locked in by [#563](https://github.com/burin-labs/harn/issues/563):

- `hostlib_code_index_query` — trigram-accelerated literal substring search (`needle`, `case_sensitive`, `max_results`, `scope` filter).
- `hostlib_code_index_rebuild` — depth-first walk + (re)build of the in-memory index.
- `hostlib_code_index_stats` — file count / distinct trigrams / words / memory bytes / last rebuild ms.
- `hostlib_code_index_imports_for` — per-file imports as `(module, resolved_path, kind)` triples.
- `hostlib_code_index_importers_of` — reverse import lookup.

Ports the Swift `Sources/BurinCodeIndex/` actor from `burin-labs/burin-code` byte-for-byte where the encoding mattered (FNV-1a 64 hash, ASCII case-fold trigram pack, identifier-shaped word tokenizer). Import resolution is data-driven via `data/code_index_import_rules.json` (Python, TS/JS, Java/Kotlin, Scala, C#, PHP, Elixir, Haskell, Lua, Ruby, C/C++, Zig, R, Swift, Rust, Go) — adding a language is a JSON edit, not a Rust edit.

## Module layout

| File | Role |
|------|------|
| `src/code_index/trigram.rs` | `TrigramIndex` posting list, sliding 3-byte window, ASCII case-fold |
| `src/code_index/words.rs` | `WordIndex` with `[A-Za-z_][A-Za-z0-9_]*` tokenizer |
| `src/code_index/graph.rs` | `DepGraph` forward + reverse + unresolved side table |
| `src/code_index/file_table.rs` | `IndexedFile`, `FileId`, FNV-1a 64 |
| `src/code_index/walker.rs` | Filtered walker + sensitive-file rejection (mirrors `FilteredWalker`/`SensitiveFilter`) |
| `src/code_index/imports.rs` | Keyword-prefix extraction + data-driven resolver |
| `src/code_index/state.rs` | `IndexState` orchestrator, `last_built_unix_ms`, git HEAD |
| `src/code_index/builtins.rs` | Five host handlers behind a single shared `Arc<Mutex<Option<IndexState>>>` |
| `data/code_index_import_rules.json` | Per-language resolver config (bundled via `include_str!`) |

## Performance

Live `BURIN_CODE_REPO=~/projects/burin-code` rebuild over the burin-code monorepo:

```
live burin-code rebuild: 5442 files in 3.57s
```

Well within CI time budget (env-var-gated; default scenario test uses a synthetic Swift fixture).

## Tests

- 21 new unit tests across the seven sub-modules (trigram, words, graph, walker, imports, file_table, state).
- 9 builtin-level integration tests in `tests/code_index.rs` exercising every handler end-to-end via the registry.
- 2 scenario tests in `tests/code_index_scenario.rs`: synthetic fixture under `tests/fixtures/burin_code_subset/` (always run) + env-var-gated `BURIN_CODE_REPO` smoke (manual).
- 1 new smoke test in `tests/smoke_harn_script.rs` driving the full surface from a real `.harn` script through lexer + parser + compiler + VM.
- `tests/registration.rs` updated: `code_index` no longer routes through `Unimplemented`; `CodeIndexCapability::new()` required since the capability now owns shared state.

Workspace gate (all green): `cargo clippy --workspace --all-targets -- -D warnings`, `make test` (2217/2217 passed), `make conformance` (660/660 passed), `make lint-md` (0 errors), `cargo fmt --check`.

## Out of scope (deliberately)

- The richer `codeindex.*` surface (file_meta, read_range, lock_try, version_record, agent registry, etc.) that burin-code currently uses on the Swift side. Those will move once burin-code consumes the new schema-locked surface; this PR only implements what `schemas/code_index/` declares.
- Incremental rebuild / file watcher integration (issue C3 handles the watcher).
- Tree-sitter-backed import extraction (B2 lands that; the regex extractor here matches the Swift fallback path).
- burin-code consumer migration (issue B6).

## Test plan

- [x] `cargo test -p harn-hostlib` (75/75 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `make test` (2217/2217 passed)
- [x] `make conformance` (660/660 passed)
- [x] `make lint-md` (0 errors)
- [x] Live burin-code scenario via `BURIN_CODE_REPO` (5,442 files / 3.57s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)