### PR TITLE
Implement ast/* host builtins with tree-sitter for 22 languages (#564)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,26 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tree-sitter",
+ "tree-sitter-bash",
+ "tree-sitter-c",
+ "tree-sitter-c-sharp",
+ "tree-sitter-cpp",
+ "tree-sitter-elixir",
+ "tree-sitter-go",
+ "tree-sitter-haskell",
+ "tree-sitter-java",
+ "tree-sitter-javascript",
+ "tree-sitter-kotlin-ng",
+ "tree-sitter-lua",
+ "tree-sitter-php",
+ "tree-sitter-python",
+ "tree-sitter-r",
+ "tree-sitter-ruby",
+ "tree-sitter-rust",
+ "tree-sitter-scala",
+ "tree-sitter-swift",
+ "tree-sitter-typescript",
+ "tree-sitter-zig",
  "walkdir",
 ]
 
@@ -3834,10 +3854,210 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-elixir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-haskell"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977c51e504548cba13fc27cb5a2edab2124cf6716a1934915d07ab99523b05a4"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-kotlin-ng"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e800ebbda938acfbf224f4d2c34947a31994b1295ee6e819b65226c7b51b4450"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-php"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c17c3ab69052c5eeaa7ff5cd972dd1bc25d1b97ee779fec391ad3b5df5592"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-r"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "429133cbda9f8a46e03ef3aae6abb6c3d22875f8585cad472138101bfd517255"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-scala"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5a4a7ff23a55474ce6a741d52aaeca7a82fe9421bb982b86e98c6ac8629397"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ef216011c3e3df4fa864736f347cb8d509b1066cf0c8549fb1fd81ac9832e59"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-zig"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab11fc124851b0db4dd5e55983bbd9631192e93238389dcd44521715e5d53e28"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "try-lock"

--- a/crates/harn-hostlib/Cargo.toml
+++ b/crates/harn-hostlib/Cargo.toml
@@ -43,6 +43,31 @@ notify = "8"
 walkdir = "2"
 base64 = "0.22"
 
+# Tree-sitter grammars driving `ast::*` (issue #564). Versions match the
+# Swift `ASTEngine` set verbatim — see the `ast` module for the language
+# table. Each crate exposes a `LANGUAGE` (or `LANGUAGE_*` for multi-grammar
+# crates) constant so we can construct `tree_sitter::Language` cheaply.
+tree-sitter-rust = "0.24"
+tree-sitter-typescript = "0.23"
+tree-sitter-javascript = "0.25"
+tree-sitter-python = "0.25"
+tree-sitter-go = "0.25"
+tree-sitter-java = "0.23"
+tree-sitter-c = "0.24"
+tree-sitter-cpp = "0.23"
+tree-sitter-c-sharp = "0.23"
+tree-sitter-ruby = "0.23"
+tree-sitter-kotlin-ng = "1.1"
+tree-sitter-php = "0.24"
+tree-sitter-scala = "0.26"
+tree-sitter-bash = "0.25"
+tree-sitter-swift = "0.7"
+tree-sitter-zig = "1.1"
+tree-sitter-elixir = "0.3"
+tree-sitter-lua = "0.5"
+tree-sitter-haskell = "0.23"
+tree-sitter-r = "1.2"
+
 [dev-dependencies]
 tempfile = "3"
 serde_json = "1"

--- a/crates/harn-hostlib/README.md
+++ b/crates/harn-hostlib/README.md
@@ -18,6 +18,10 @@ Opt-in host builtins for the Harn VM that provide:
 
 [#563](https://github.com/burin-labs/harn/issues/563) introduced the
 scaffold (every method routed through `HostlibError::Unimplemented`).
+[#564](https://github.com/burin-labs/harn/issues/564) lights up the
+`ast/` surface — tree-sitter parsing, symbol extraction, and outline
+generation for 22 host languages, mirroring the Swift `ASTEngine`
+coverage verbatim.
 [#567](https://github.com/burin-labs/harn/issues/567) lights up the
 deterministic-tool surface: `search`, `read_file`, `write_file`,
 `delete_file`, `list_directory`, `get_file_outline`, and `git`.
@@ -25,10 +29,57 @@ deterministic-tool surface: `search`, `read_file`, `write_file`,
 process-lifecycle surface: `run_command`, `run_test`,
 `run_build_command`, `inspect_test_results`, and `manage_packages`.
 
+### `ast/` languages
+
+Tree-sitter grammars are pinned in [`Cargo.toml`](Cargo.toml). Adding or
+dropping a language requires a coordinated change here, in the Swift
+`TreeSitterLanguage` enum, and in burin-code's bridge consumer.
+
+| Language       | Grammar crate                 | Extensions      |
+|----------------|-------------------------------|-----------------|
+| TypeScript     | `tree-sitter-typescript`      | `.ts`           |
+| TSX            | `tree-sitter-typescript`      | `.tsx`          |
+| JavaScript     | `tree-sitter-javascript`      | `.js .mjs .cjs` |
+| JSX            | `tree-sitter-javascript`      | `.jsx`          |
+| Python         | `tree-sitter-python`          | `.py`           |
+| Go             | `tree-sitter-go`              | `.go`           |
+| Rust           | `tree-sitter-rust`            | `.rs`           |
+| Java           | `tree-sitter-java`            | `.java`         |
+| C              | `tree-sitter-c`               | `.c .h`         |
+| C++            | `tree-sitter-cpp`             | `.cpp .cc .hpp` |
+| C#             | `tree-sitter-c-sharp`         | `.cs`           |
+| Ruby           | `tree-sitter-ruby`            | `.rb`           |
+| Kotlin         | `tree-sitter-kotlin-ng`       | `.kt .kts`      |
+| PHP            | `tree-sitter-php`             | `.php`          |
+| Scala          | `tree-sitter-scala`           | `.scala .sc`    |
+| Bash / shell   | `tree-sitter-bash`            | `.sh .bash .zsh`|
+| Swift          | `tree-sitter-swift`           | `.swift`        |
+| Zig            | `tree-sitter-zig`             | `.zig`          |
+| Elixir         | `tree-sitter-elixir`          | `.ex .exs`      |
+| Lua            | `tree-sitter-lua`             | `.lua`          |
+| Haskell        | `tree-sitter-haskell`         | `.hs .lhs`      |
+| R              | `tree-sitter-r`               | `.r`            |
+
+The `ast::*` builtins emit row/column coordinates as **0-based** values
+(matching tree-sitter native `Point`s). Symbol kinds are normalized to
+the lowercase string set Swift's `ASTEngine` already produced
+(`function`, `method`, `class`, `struct`, `enum`, `interface`,
+`protocol`, `type`, `variable`, `module`, `other`).
+
+Per-language fixture goldens live at
+`tests/fixtures/ast/<language>/{source.<ext>,symbols.golden.json,outline.golden.json}`.
+To regenerate after a deliberate change, run
+
+```text
+HARN_AST_UPDATE_GOLDEN=1 cargo test -p harn-hostlib --test ast_fixtures
+```
+
+and commit the updated goldens.
+
 | Issue | Module | What lands | Status |
 |-------|--------|-----------|--------|
 | B1 (#563) | scaffold       | crate + schemas + registration plumbing                                                   | ✅ shipped |
-| B2    | `ast/`             | `parse_file`, `symbols`, `outline`                                                        | unimplemented |
+| B2 (#564) | `ast/`         | `parse_file`, `symbols`, `outline` (tree-sitter for 22 host languages)                    | ✅ shipped |
 | B3    | `code_index/`      | `query`, `rebuild`, `stats`, `imports_for`, `importers_of`                                | unimplemented |
 | B4    | `scanner/`         | `scan_project`, `scan_incremental`                                                        | unimplemented |
 | C1    | `fs_watch/`        | `subscribe`, `unsubscribe`                                                                | unimplemented |

--- a/crates/harn-hostlib/schemas/ast/outline.response.json
+++ b/crates/harn-hostlib/schemas/ast/outline.response.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/outline.response.json",
   "title": "ast.outline response",
+  "description": "Hierarchical outline of a source file. Built by folding the flat symbol list (see ast.symbols) into a tree using each container's row range to decide ownership. All row coordinates are 0-based.",
   "type": "object",
   "properties": {
     "path": { "type": "string" },
@@ -18,7 +19,11 @@
       "type": "object",
       "properties": {
         "name": { "type": "string" },
-        "kind": { "type": "string" },
+        "kind": {
+          "type": "string",
+          "description": "Lowercase symbol kind. See schemas/ast/symbols.response.json."
+        },
+        "signature": { "type": "string" },
         "start_row": { "type": "integer", "minimum": 0 },
         "end_row": { "type": "integer", "minimum": 0 },
         "children": {
@@ -26,7 +31,7 @@
           "items": { "$ref": "#/$defs/OutlineItem" }
         }
       },
-      "required": ["name", "kind", "start_row", "end_row", "children"],
+      "required": ["name", "kind", "signature", "start_row", "end_row", "children"],
       "additionalProperties": false
     }
   }

--- a/crates/harn-hostlib/schemas/ast/symbols.response.json
+++ b/crates/harn-hostlib/schemas/ast/symbols.response.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/symbols.response.json",
   "title": "ast.symbols response",
+  "description": "Flat list of symbols extracted from a single source file. All row/column coordinates are 0-based, matching tree-sitter's native Point representation.",
   "type": "object",
   "properties": {
     "path": { "type": "string" },
@@ -18,14 +19,30 @@
       "type": "object",
       "properties": {
         "name": { "type": "string" },
-        "kind": { "type": "string" },
+        "kind": {
+          "type": "string",
+          "description": "Lowercase symbol kind. One of: function, method, class, struct, enum, interface, protocol, type, variable, module, other."
+        },
         "container": { "type": ["string", "null"] },
+        "signature": {
+          "type": "string",
+          "description": "Single-line, language-flavored signature (e.g. 'fn parse(input: &str)'). Truncated to 80 chars with an ellipsis."
+        },
         "start_row": { "type": "integer", "minimum": 0 },
         "start_col": { "type": "integer", "minimum": 0 },
         "end_row": { "type": "integer", "minimum": 0 },
         "end_col": { "type": "integer", "minimum": 0 }
       },
-      "required": ["name", "kind", "start_row", "start_col", "end_row", "end_col"],
+      "required": [
+        "name",
+        "kind",
+        "container",
+        "signature",
+        "start_row",
+        "start_col",
+        "end_row",
+        "end_col"
+      ],
       "additionalProperties": false
     }
   }

--- a/crates/harn-hostlib/src/ast/language.rs
+++ b/crates/harn-hostlib/src/ast/language.rs
@@ -1,0 +1,263 @@
+//! Tree-sitter language registry.
+//!
+//! Mirrors the Swift `TreeSitterLanguage` enum in
+//! `~/projects/burin-code/Sources/ASTEngine/TreeSitterIntegration.swift`
+//! verbatim. The set of languages, their canonical names, and their file
+//! extensions all match Swift exactly so the bridged outputs round-trip
+//! across the harn ↔ burin-code boundary without translation. Adding or
+//! dropping a language requires a coordinated change in both repos.
+
+use tree_sitter::Language as TsLanguage;
+
+/// Languages with tree-sitter symbol extraction support.
+///
+/// The string returned by [`Language::name`] is the canonical wire name;
+/// callers (and the JSON schemas) refer to languages by that string.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Language {
+    TypeScript,
+    Tsx,
+    JavaScript,
+    Jsx,
+    Python,
+    Go,
+    Rust,
+    Java,
+    C,
+    Cpp,
+    CSharp,
+    Ruby,
+    Kotlin,
+    Php,
+    Scala,
+    Bash,
+    Swift,
+    Zig,
+    Elixir,
+    Lua,
+    Haskell,
+    R,
+}
+
+impl Language {
+    /// Canonical wire name.
+    pub fn name(self) -> &'static str {
+        match self {
+            Language::TypeScript => "typescript",
+            Language::Tsx => "tsx",
+            Language::JavaScript => "javascript",
+            Language::Jsx => "jsx",
+            Language::Python => "python",
+            Language::Go => "go",
+            Language::Rust => "rust",
+            Language::Java => "java",
+            Language::C => "c",
+            Language::Cpp => "cpp",
+            Language::CSharp => "csharp",
+            Language::Ruby => "ruby",
+            Language::Kotlin => "kotlin",
+            Language::Php => "php",
+            Language::Scala => "scala",
+            Language::Bash => "bash",
+            Language::Swift => "swift",
+            Language::Zig => "zig",
+            Language::Elixir => "elixir",
+            Language::Lua => "lua",
+            Language::Haskell => "haskell",
+            Language::R => "r",
+        }
+    }
+
+    /// Tree-sitter grammar handle. Cheap; the underlying `LANGUAGE`
+    /// constants are static.
+    pub fn ts_language(self) -> TsLanguage {
+        match self {
+            Language::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            Language::Tsx => tree_sitter_typescript::LANGUAGE_TSX.into(),
+            Language::JavaScript | Language::Jsx => tree_sitter_javascript::LANGUAGE.into(),
+            Language::Python => tree_sitter_python::LANGUAGE.into(),
+            Language::Go => tree_sitter_go::LANGUAGE.into(),
+            Language::Rust => tree_sitter_rust::LANGUAGE.into(),
+            Language::Java => tree_sitter_java::LANGUAGE.into(),
+            Language::C => tree_sitter_c::LANGUAGE.into(),
+            Language::Cpp => tree_sitter_cpp::LANGUAGE.into(),
+            Language::CSharp => tree_sitter_c_sharp::LANGUAGE.into(),
+            Language::Ruby => tree_sitter_ruby::LANGUAGE.into(),
+            Language::Kotlin => tree_sitter_kotlin_ng::LANGUAGE.into(),
+            Language::Php => tree_sitter_php::LANGUAGE_PHP.into(),
+            Language::Scala => tree_sitter_scala::LANGUAGE.into(),
+            Language::Bash => tree_sitter_bash::LANGUAGE.into(),
+            Language::Swift => tree_sitter_swift::LANGUAGE.into(),
+            Language::Zig => tree_sitter_zig::LANGUAGE.into(),
+            Language::Elixir => tree_sitter_elixir::LANGUAGE.into(),
+            Language::Lua => tree_sitter_lua::LANGUAGE.into(),
+            Language::Haskell => tree_sitter_haskell::LANGUAGE.into(),
+            Language::R => tree_sitter_r::LANGUAGE.into(),
+        }
+    }
+
+    /// Resolve a language from its canonical wire name. Accepts a few
+    /// historical aliases (`ts`, `js`, `c++`, …) so users don't have to
+    /// memorize the exact spelling.
+    pub fn from_name(name: &str) -> Option<Self> {
+        let normalized = name.trim().to_ascii_lowercase();
+        Some(match normalized.as_str() {
+            "typescript" | "ts" => Language::TypeScript,
+            "tsx" => Language::Tsx,
+            "javascript" | "js" => Language::JavaScript,
+            "jsx" => Language::Jsx,
+            "python" | "py" => Language::Python,
+            "go" | "golang" => Language::Go,
+            "rust" | "rs" => Language::Rust,
+            "java" => Language::Java,
+            "c" => Language::C,
+            "cpp" | "c++" | "cxx" => Language::Cpp,
+            "csharp" | "c#" | "cs" => Language::CSharp,
+            "ruby" | "rb" => Language::Ruby,
+            "kotlin" | "kt" => Language::Kotlin,
+            "php" => Language::Php,
+            "scala" => Language::Scala,
+            "bash" | "shell" | "sh" | "zsh" => Language::Bash,
+            "swift" => Language::Swift,
+            "zig" => Language::Zig,
+            "elixir" | "ex" => Language::Elixir,
+            "lua" => Language::Lua,
+            "haskell" | "hs" => Language::Haskell,
+            "r" => Language::R,
+            _ => return None,
+        })
+    }
+
+    /// Resolve a language from a file extension. The mapping mirrors the
+    /// Swift `extensionMap` in `TreeSitterIntegration.swift`.
+    pub fn from_extension(ext: &str) -> Option<Self> {
+        let normalized = ext.trim_start_matches('.').to_ascii_lowercase();
+        Some(match normalized.as_str() {
+            "ts" => Language::TypeScript,
+            "tsx" => Language::Tsx,
+            "js" | "mjs" | "cjs" => Language::JavaScript,
+            "jsx" => Language::Jsx,
+            "py" => Language::Python,
+            "go" => Language::Go,
+            "rs" => Language::Rust,
+            "java" => Language::Java,
+            "c" | "h" => Language::C,
+            "cpp" | "cc" | "cxx" | "hpp" | "hxx" | "hh" => Language::Cpp,
+            "cs" | "csx" => Language::CSharp,
+            "rb" => Language::Ruby,
+            "kt" | "kts" => Language::Kotlin,
+            "php" => Language::Php,
+            "scala" | "sc" => Language::Scala,
+            "sh" | "bash" | "zsh" => Language::Bash,
+            "swift" => Language::Swift,
+            "zig" | "zon" => Language::Zig,
+            "ex" | "exs" => Language::Elixir,
+            "lua" => Language::Lua,
+            "hs" | "lhs" => Language::Haskell,
+            "r" => Language::R,
+            _ => return None,
+        })
+    }
+
+    /// Resolve from a file path: prefer explicit `language_hint` if
+    /// supplied, otherwise fall back to extension-based detection.
+    pub fn detect(path: &std::path::Path, language_hint: Option<&str>) -> Option<Self> {
+        if let Some(name) = language_hint.and_then(|s| (!s.is_empty()).then_some(s)) {
+            return Self::from_name(name);
+        }
+        let ext = path.extension().and_then(|s| s.to_str())?;
+        Self::from_extension(ext)
+    }
+
+    /// Every language we ship support for. Useful for tests + introspection.
+    pub fn all() -> &'static [Language] {
+        &[
+            Language::TypeScript,
+            Language::Tsx,
+            Language::JavaScript,
+            Language::Jsx,
+            Language::Python,
+            Language::Go,
+            Language::Rust,
+            Language::Java,
+            Language::C,
+            Language::Cpp,
+            Language::CSharp,
+            Language::Ruby,
+            Language::Kotlin,
+            Language::Php,
+            Language::Scala,
+            Language::Bash,
+            Language::Swift,
+            Language::Zig,
+            Language::Elixir,
+            Language::Lua,
+            Language::Haskell,
+            Language::R,
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_language_is_loadable() {
+        for &lang in Language::all() {
+            // Constructing the tree-sitter Language must not panic and must
+            // produce a non-trivial grammar.
+            let ts = lang.ts_language();
+            assert!(ts.node_kind_count() > 0, "{} grammar is empty", lang.name());
+        }
+    }
+
+    #[test]
+    fn extension_detection_round_trips_canonical_extensions() {
+        let cases: &[(&str, Language)] = &[
+            ("ts", Language::TypeScript),
+            ("tsx", Language::Tsx),
+            ("js", Language::JavaScript),
+            ("jsx", Language::Jsx),
+            ("py", Language::Python),
+            ("rs", Language::Rust),
+            ("go", Language::Go),
+            ("java", Language::Java),
+            ("c", Language::C),
+            ("cpp", Language::Cpp),
+            ("cs", Language::CSharp),
+            ("rb", Language::Ruby),
+            ("kt", Language::Kotlin),
+            ("php", Language::Php),
+            ("scala", Language::Scala),
+            ("sh", Language::Bash),
+            ("swift", Language::Swift),
+            ("zig", Language::Zig),
+            ("ex", Language::Elixir),
+            ("lua", Language::Lua),
+            ("hs", Language::Haskell),
+            ("r", Language::R),
+        ];
+        for (ext, want) in cases {
+            assert_eq!(Language::from_extension(ext), Some(*want), "ext {ext}");
+        }
+    }
+
+    #[test]
+    fn name_round_trips_for_every_language() {
+        for &lang in Language::all() {
+            assert_eq!(Language::from_name(lang.name()), Some(lang));
+        }
+    }
+
+    #[test]
+    fn detect_prefers_hint_over_extension() {
+        let path = std::path::Path::new("foo.ts");
+        assert_eq!(Language::detect(path, None), Some(Language::TypeScript));
+        assert_eq!(
+            Language::detect(path, Some("javascript")),
+            Some(Language::JavaScript)
+        );
+    }
+}

--- a/crates/harn-hostlib/src/ast/mod.rs
+++ b/crates/harn-hostlib/src/ast/mod.rs
@@ -2,13 +2,109 @@
 //!
 //! Wraps tree-sitter parsing, symbol extraction, and outline generation —
 //! the Swift `Sources/ASTEngine/` surface ported into Rust. Implementation
-//! lands in follow-up issue B2; this scaffold registers the contract so
-//! `burin-code`'s schema-drift tests can lock the public surface today.
+//! lands per issue #564.
+//!
+//! ## Wire format
+//!
+//! - Row/column coordinates are **0-based** across all three builtins,
+//!   matching tree-sitter's native `Point` representation. Swift's
+//!   `ASTEngine` historically returned 1-based coordinates for symbols;
+//!   we normalize on 0-based here so `parse_file`, `symbols`, and
+//!   `outline` share one convention. Burin-code's bridge consumer is
+//!   updated in #(B5).
+//! - `parse_file` emits a flat node list with `parent_id` rather than
+//!   nested children — keeps the wire JSON-serializable without inflating
+//!   it with object copies.
+//! - `symbols` and `outline` carry a `signature` string (e.g.
+//!   `"fn foo(bar: i32)"`) on every entry to match Swift's
+//!   `TreeSitterSymbol.signature`. Burin-code's outline UI surfaces this
+//!   directly.
+//!
+//! ## Languages
+//!
+//! [`language::Language`] mirrors Swift's `TreeSitterLanguage` enum
+//! verbatim: TypeScript/TSX, JavaScript/JSX, Python, Go, Rust, Java,
+//! C, C++, C#, Ruby, Kotlin, PHP, Scala, Bash, Swift, Zig, Elixir, Lua,
+//! Haskell, R. Adding/dropping languages requires a coordinated change
+//! in both repos.
 
-use crate::registry::{BuiltinRegistry, HostlibCapability};
+use std::sync::Arc;
 
-/// AST capability handle. Stateless today; will own a tree-sitter language
-/// registry and parser pool once the implementation lands.
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::registry::{BuiltinRegistry, HostlibCapability, RegisteredBuiltin, SyncHandler};
+
+mod language;
+mod outline;
+mod parse;
+mod symbols;
+mod symbols_call;
+mod types;
+
+pub use language::Language;
+pub use types::{OutlineItem, ParsedNode, Symbol, SymbolKind};
+
+/// Programmatic entry point to the AST builtins. Embedders typically go
+/// through the registered builtins, but tests and tools that want
+/// strongly-typed access can use these helpers directly.
+pub mod api {
+    use std::path::Path;
+
+    use crate::error::HostlibError;
+
+    use super::language::Language;
+    use super::outline::build_outline;
+    use super::parse::{parse_source, read_source};
+    use super::symbols::extract;
+    use super::types::{OutlineItem, Symbol};
+
+    /// Parse `path` (with optional language hint) and return its symbols.
+    pub fn symbols(
+        path: &Path,
+        language_hint: Option<&str>,
+    ) -> Result<(Language, Vec<Symbol>), HostlibError> {
+        let language = detect(path, language_hint)?;
+        let source = read_source(&path.to_string_lossy(), 0)?;
+        let tree = parse_source(&source, language)?;
+        Ok((language, extract(&tree, &source, language)))
+    }
+
+    /// Parse `path` and return a hierarchical outline.
+    pub fn outline(
+        path: &Path,
+        language_hint: Option<&str>,
+    ) -> Result<(Language, Vec<OutlineItem>), HostlibError> {
+        let (language, symbols) = symbols(path, language_hint)?;
+        Ok((language, build_outline(symbols)))
+    }
+
+    /// Parse a source `str` for `language` and return its symbols. Useful
+    /// for unit tests where the input lives in-memory rather than on disk.
+    pub fn symbols_from_source(
+        source: &str,
+        language: Language,
+    ) -> Result<Vec<Symbol>, HostlibError> {
+        let tree = parse_source(source, language)?;
+        Ok(extract(&tree, source, language))
+    }
+
+    fn detect(path: &Path, language_hint: Option<&str>) -> Result<Language, HostlibError> {
+        Language::detect(path, language_hint).ok_or_else(|| HostlibError::InvalidParameter {
+            builtin: "ast::api",
+            param: "language",
+            message: format!(
+                "could not infer a tree-sitter grammar for `{}` \
+                 (extension or `language` field unrecognized)",
+                path.display()
+            ),
+        })
+    }
+}
+
+/// AST capability handle. Stateless; tree-sitter parsers are constructed
+/// per-call (cheap relative to grammar lookup) so the capability itself
+/// has nothing to own.
 #[derive(Default)]
 pub struct AstCapability;
 
@@ -18,8 +114,28 @@ impl HostlibCapability for AstCapability {
     }
 
     fn register_builtins(&self, registry: &mut BuiltinRegistry) {
-        registry.register_unimplemented("hostlib_ast_parse_file", "ast", "parse_file");
-        registry.register_unimplemented("hostlib_ast_symbols", "ast", "symbols");
-        registry.register_unimplemented("hostlib_ast_outline", "ast", "outline");
+        register(registry, "hostlib_ast_parse_file", "parse_file", parse::run);
+        register(
+            registry,
+            "hostlib_ast_symbols",
+            "symbols",
+            symbols_call::run,
+        );
+        register(registry, "hostlib_ast_outline", "outline", outline::run);
     }
+}
+
+fn register(
+    registry: &mut BuiltinRegistry,
+    name: &'static str,
+    method: &'static str,
+    runner: fn(&[VmValue]) -> Result<VmValue, HostlibError>,
+) {
+    let handler: SyncHandler = Arc::new(runner);
+    registry.register(RegisteredBuiltin {
+        name,
+        module: "ast",
+        method,
+        handler,
+    });
 }

--- a/crates/harn-hostlib/src/ast/outline.rs
+++ b/crates/harn-hostlib/src/ast/outline.rs
@@ -1,0 +1,238 @@
+//! `ast.outline` — nested outline for a single source file.
+//!
+//! Built on top of [`super::symbols::extract`]: take the flat symbol
+//! list and fold it into a tree using each container's row range. The
+//! fold is language-agnostic, which keeps the per-language extractor
+//! count down — every grammar's "container vs. leaf" semantics flow
+//! through [`crate::ast::types::SymbolKind::is_container`].
+
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::tools::args::{
+    build_dict, dict_arg, optional_int, optional_string, require_string, str_value,
+};
+
+use super::language::Language;
+use super::parse::{parse_source, read_source};
+use super::symbols::extract;
+use super::types::{OutlineItem, Symbol};
+
+const BUILTIN: &str = "hostlib_ast_outline";
+
+pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN, args)?;
+    let dict = raw.as_ref();
+
+    let path_str = require_string(BUILTIN, dict, "path")?;
+    let language_hint = optional_string(BUILTIN, dict, "language")?;
+    let max_depth = optional_int(BUILTIN, dict, "max_depth", 0)?;
+    if max_depth < 0 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "max_depth",
+            message: "must be >= 0".into(),
+        });
+    }
+
+    let path = PathBuf::from(&path_str);
+    let language = Language::detect(&path, language_hint.as_deref()).ok_or_else(|| {
+        HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "language",
+            message: format!(
+                "could not infer a tree-sitter grammar for `{path_str}` \
+                 (extension or `language` field unrecognized)"
+            ),
+        }
+    })?;
+
+    let source = read_source(&path_str, 0)?;
+    let tree = parse_source(&source, language)?;
+    let symbols = extract(&tree, &source, language);
+    let mut items = build_outline(symbols);
+    if max_depth > 0 {
+        truncate_depth(&mut items, max_depth as usize, 1);
+    }
+
+    let items_list: Vec<VmValue> = items.iter().map(OutlineItem::to_vm_value).collect();
+
+    Ok(build_dict([
+        ("path", str_value(&path_str)),
+        ("language", str_value(language.name())),
+        ("items", VmValue::List(Rc::new(items_list))),
+    ]))
+}
+
+/// Fold a flat, document-ordered symbol list into a tree using each
+/// container's row range to decide ownership: a non-container symbol
+/// belongs to the innermost container whose range still encloses it.
+pub(super) fn build_outline(symbols: Vec<Symbol>) -> Vec<OutlineItem> {
+    let mut roots: Vec<OutlineItem> = Vec::new();
+    let mut stack: Vec<OutlineItem> = Vec::new();
+
+    for sym in symbols {
+        // Pop containers whose end row is strictly before this symbol's
+        // start row — they can't contain it.
+        while let Some(top) = stack.last() {
+            if top.end_row < sym.start_row {
+                let popped = stack.pop().unwrap();
+                attach(&mut stack, &mut roots, popped);
+            } else {
+                break;
+            }
+        }
+
+        let item = OutlineItem {
+            name: sym.name,
+            kind: sym.kind,
+            signature: sym.signature,
+            start_row: sym.start_row,
+            end_row: sym.end_row,
+            children: Vec::new(),
+        };
+
+        if sym.kind.is_container() {
+            stack.push(item);
+        } else {
+            attach(&mut stack, &mut roots, item);
+        }
+    }
+
+    while let Some(popped) = stack.pop() {
+        attach(&mut stack, &mut roots, popped);
+    }
+
+    roots
+}
+
+fn attach(stack: &mut [OutlineItem], roots: &mut Vec<OutlineItem>, item: OutlineItem) {
+    if let Some(parent) = stack.last_mut() {
+        parent.children.push(item);
+    } else {
+        roots.push(item);
+    }
+}
+
+fn truncate_depth(items: &mut [OutlineItem], max_depth: usize, current: usize) {
+    if current >= max_depth {
+        for item in items.iter_mut() {
+            item.children.clear();
+        }
+        return;
+    }
+    for item in items.iter_mut() {
+        truncate_depth(&mut item.children, max_depth, current + 1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::types::SymbolKind;
+
+    fn sym(name: &str, kind: SymbolKind, start: u32, end: u32) -> Symbol {
+        Symbol {
+            name: name.into(),
+            kind,
+            container: None,
+            signature: name.into(),
+            start_row: start,
+            start_col: 0,
+            end_row: end,
+            end_col: 0,
+        }
+    }
+
+    #[test]
+    fn flat_symbols_become_roots() {
+        let symbols = vec![
+            sym("a", SymbolKind::Function, 1, 3),
+            sym("b", SymbolKind::Function, 5, 7),
+        ];
+        let items = build_outline(symbols);
+        assert_eq!(items.len(), 2);
+        assert!(items.iter().all(|i| i.children.is_empty()));
+    }
+
+    #[test]
+    fn methods_attach_to_enclosing_class() {
+        let symbols = vec![
+            sym("Foo", SymbolKind::Class, 1, 10),
+            sym("bar", SymbolKind::Method, 2, 4),
+            sym("baz", SymbolKind::Method, 5, 7),
+        ];
+        let items = build_outline(symbols);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "Foo");
+        assert_eq!(items[0].children.len(), 2);
+        assert_eq!(items[0].children[0].name, "bar");
+        assert_eq!(items[0].children[1].name, "baz");
+    }
+
+    #[test]
+    fn sibling_classes_dont_swallow_each_other() {
+        let symbols = vec![
+            sym("Foo", SymbolKind::Class, 1, 5),
+            sym("foo_m", SymbolKind::Method, 2, 4),
+            sym("Bar", SymbolKind::Class, 6, 10),
+            sym("bar_m", SymbolKind::Method, 7, 9),
+        ];
+        let items = build_outline(symbols);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].name, "Foo");
+        assert_eq!(items[1].name, "Bar");
+        assert_eq!(items[0].children.len(), 1);
+        assert_eq!(items[1].children.len(), 1);
+    }
+
+    #[test]
+    fn nested_classes_chain_correctly() {
+        let symbols = vec![
+            sym("Outer", SymbolKind::Class, 1, 20),
+            sym("Inner", SymbolKind::Class, 2, 10),
+            sym("inner_m", SymbolKind::Method, 3, 5),
+            sym("outer_m", SymbolKind::Method, 12, 15),
+        ];
+        let items = build_outline(symbols);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "Outer");
+        assert_eq!(items[0].children.len(), 2);
+        assert_eq!(items[0].children[0].name, "Inner");
+        assert_eq!(items[0].children[0].children.len(), 1);
+        assert_eq!(items[0].children[0].children[0].name, "inner_m");
+        assert_eq!(items[0].children[1].name, "outer_m");
+    }
+
+    #[test]
+    fn truncate_depth_drops_grandchildren() {
+        let mut items = vec![OutlineItem {
+            name: "Outer".into(),
+            kind: SymbolKind::Class,
+            signature: "class Outer".into(),
+            start_row: 0,
+            end_row: 10,
+            children: vec![OutlineItem {
+                name: "Inner".into(),
+                kind: SymbolKind::Class,
+                signature: "class Inner".into(),
+                start_row: 1,
+                end_row: 5,
+                children: vec![OutlineItem {
+                    name: "deep".into(),
+                    kind: SymbolKind::Method,
+                    signature: "fn deep".into(),
+                    start_row: 2,
+                    end_row: 3,
+                    children: vec![],
+                }],
+            }],
+        }];
+        truncate_depth(&mut items, 2, 1);
+        assert_eq!(items[0].children.len(), 1);
+        assert!(items[0].children[0].children.is_empty());
+    }
+}

--- a/crates/harn-hostlib/src/ast/parse.rs
+++ b/crates/harn-hostlib/src/ast/parse.rs
@@ -1,0 +1,139 @@
+//! `ast.parse_file` — flatten a tree-sitter parse tree to a wire-format
+//! node list.
+//!
+//! Tree-sitter trees are pointer-rich and not directly JSON-serializable;
+//! this module walks the tree once and assigns sequential node ids so the
+//! response matches `schemas/ast/parse_file.response.json` (a flat
+//! `nodes: [{id, parent_id, ...}]` array with `root_id`).
+
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use harn_vm::VmValue;
+use tree_sitter::{Node, Parser, Tree};
+
+use crate::error::HostlibError;
+use crate::tools::args::{
+    build_dict, dict_arg, optional_int, optional_string, require_string, str_value,
+};
+
+use super::language::Language;
+use super::types::ParsedNode;
+
+const BUILTIN: &str = "hostlib_ast_parse_file";
+
+pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN, args)?;
+    let dict = raw.as_ref();
+
+    let path_str = require_string(BUILTIN, dict, "path")?;
+    let language_hint = optional_string(BUILTIN, dict, "language")?;
+    let max_bytes = optional_int(BUILTIN, dict, "max_bytes", 0)?;
+    if max_bytes < 0 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "max_bytes",
+            message: "must be >= 0".into(),
+        });
+    }
+
+    let path = PathBuf::from(&path_str);
+    let language = Language::detect(&path, language_hint.as_deref()).ok_or_else(|| {
+        HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "language",
+            message: format!(
+                "could not infer a tree-sitter grammar for `{path_str}` \
+                 (extension or `language` field unrecognized)"
+            ),
+        }
+    })?;
+
+    let source = read_source(&path_str, max_bytes as usize)?;
+    let tree = parse_source(&source, language)?;
+    let (root_id, nodes) = flatten(&tree);
+
+    let nodes_list: Vec<VmValue> = nodes.iter().map(ParsedNode::to_vm_value).collect();
+
+    Ok(build_dict([
+        ("path", str_value(&path_str)),
+        ("language", str_value(language.name())),
+        ("root_id", VmValue::Int(root_id as i64)),
+        ("nodes", VmValue::List(Rc::new(nodes_list))),
+        ("had_errors", VmValue::Bool(tree.root_node().has_error())),
+    ]))
+}
+
+/// Read the file, optionally truncating to the first `max_bytes` bytes.
+/// `max_bytes == 0` means unlimited (per the request schema).
+pub(super) fn read_source(path: &str, max_bytes: usize) -> Result<String, HostlibError> {
+    let bytes = std::fs::read(path).map_err(|err| HostlibError::Backend {
+        builtin: BUILTIN,
+        message: format!("read `{path}`: {err}"),
+    })?;
+    let slice = if max_bytes == 0 || bytes.len() <= max_bytes {
+        &bytes[..]
+    } else {
+        &bytes[..max_bytes]
+    };
+    // Lossy decode keeps tree-sitter happy when input contains stray
+    // bytes; in practice every shipped grammar handles UTF-8.
+    Ok(String::from_utf8_lossy(slice).into_owned())
+}
+
+/// Build a parser, point it at `language`'s grammar, and parse `source`.
+/// Tree-sitter parser construction is cheap; we don't bother pooling.
+pub(super) fn parse_source(source: &str, language: Language) -> Result<Tree, HostlibError> {
+    let mut parser = Parser::new();
+    parser
+        .set_language(&language.ts_language())
+        .map_err(|err| HostlibError::Backend {
+            builtin: BUILTIN,
+            message: format!("set tree-sitter language `{}`: {err}", language.name()),
+        })?;
+    parser
+        .parse(source, None)
+        .ok_or_else(|| HostlibError::Backend {
+            builtin: BUILTIN,
+            message: format!(
+                "tree-sitter parse failed for language `{}` (timeout or panic)",
+                language.name()
+            ),
+        })
+}
+
+/// Walk the tree breadth-first, assigning sequential ids. Breadth-first
+/// keeps siblings contiguous in the output, which makes the wire format
+/// easier to read in dumps.
+fn flatten(tree: &Tree) -> (u32, Vec<ParsedNode>) {
+    let root = tree.root_node();
+    let mut nodes: Vec<ParsedNode> = Vec::new();
+    let mut queue: std::collections::VecDeque<(Node<'_>, Option<u32>)> =
+        std::collections::VecDeque::new();
+    queue.push_back((root, None));
+
+    while let Some((node, parent_id)) = queue.pop_front() {
+        let id = nodes.len() as u32;
+        let s = node.start_position();
+        let e = node.end_position();
+        nodes.push(ParsedNode {
+            id,
+            parent_id,
+            kind: node.kind().to_string(),
+            is_named: node.is_named(),
+            start_byte: node.start_byte() as u32,
+            end_byte: node.end_byte() as u32,
+            start_row: s.row as u32,
+            start_col: s.column as u32,
+            end_row: e.row as u32,
+            end_col: e.column as u32,
+        });
+        for i in 0..node.child_count() {
+            if let Some(child) = node.child(i as u32) {
+                queue.push_back((child, Some(id)));
+            }
+        }
+    }
+
+    (0, nodes)
+}

--- a/crates/harn-hostlib/src/ast/symbols.rs
+++ b/crates/harn-hostlib/src/ast/symbols.rs
@@ -1,0 +1,1520 @@
+//! Per-language tree-sitter symbol extractors.
+//!
+//! Each extractor walks a tree-sitter parse tree depth-first, emitting
+//! [`Symbol`] entries that mirror the Swift `TreeSitterSymbolExtractor`
+//! in `~/projects/burin-code/Sources/ASTEngine/`. Container kinds (class,
+//! struct, enum, ...) are stamped onto the `container` field of nested
+//! symbols so the outline fold in [`super::outline`] can rebuild a tree.
+//!
+//! The shape of every extractor is identical:
+//!
+//! 1. Walk all named descendants of the root.
+//! 2. For each interesting node kind, emit a [`Symbol`] and (if it's a
+//!    container) return a new container name to stamp on its descendants.
+//!
+//! Common idioms — name extraction by field, `function f(args)` signature
+//! shaping, container tracking — live in the [`helpers`] sub-module so
+//! each per-language extractor stays small.
+
+use tree_sitter::{Node, Tree};
+
+use super::language::Language;
+use super::types::{Symbol, SymbolKind};
+
+mod helpers;
+
+use helpers::{
+    field_text, has_anonymous_child, named_decl_with_keyword, point_pos, push_func, truncate,
+    walk_named, NamedDeclArgs, NodePos, PushFuncArgs,
+};
+
+/// Extract a flat symbol list from a parsed tree.
+pub(super) fn extract(tree: &Tree, source: &str, language: Language) -> Vec<Symbol> {
+    let root = tree.root_node();
+    let mut out: Vec<Symbol> = Vec::new();
+
+    match language {
+        Language::TypeScript | Language::Tsx => extract_typescript(root, source, &mut out),
+        Language::JavaScript | Language::Jsx => extract_javascript(root, source, &mut out),
+        Language::Go => extract_go(root, source, &mut out),
+        Language::Rust => extract_rust(root, source, &mut out),
+        Language::Python => extract_python(root, source, &mut out),
+        Language::Java => extract_java(root, source, &mut out),
+        Language::C => extract_c(root, source, &mut out),
+        Language::Cpp => extract_cpp(root, source, &mut out),
+        Language::CSharp => extract_csharp(root, source, &mut out),
+        Language::Kotlin => extract_kotlin(root, source, &mut out),
+        Language::Ruby => extract_ruby(root, source, &mut out),
+        Language::Php => extract_php(root, source, &mut out),
+        Language::Scala => extract_scala(root, source, &mut out),
+        Language::Bash => extract_bash(root, source, &mut out),
+        Language::Swift => extract_swift(root, source, &mut out),
+        Language::Zig => extract_zig(root, source, &mut out),
+        Language::Elixir => extract_elixir(root, source, &mut out),
+        Language::Lua => extract_lua(root, source, &mut out),
+        Language::Haskell => extract_haskell(root, source, &mut out),
+        Language::R => extract_r(root, source, &mut out),
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// TypeScript / TSX
+// ---------------------------------------------------------------------------
+
+fn extract_typescript(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "class_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Class,
+                keyword: "class",
+                out,
+            }),
+            "interface_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Interface,
+                keyword: "interface",
+                out,
+            }),
+            "type_alias_declaration" => {
+                named_decl_with_keyword(NamedDeclArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Type,
+                    keyword: "type",
+                    out,
+                });
+                None
+            }
+            "enum_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Enum,
+                keyword: "enum",
+                out,
+            }),
+            "function_declaration" => {
+                push_func(PushFuncArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Function,
+                    prefix: "function",
+                    out,
+                });
+                None
+            }
+            "method_definition" => {
+                push_func(PushFuncArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Method,
+                    prefix: "",
+                    out,
+                });
+                None
+            }
+            "lexical_declaration" | "variable_declaration" => {
+                extract_arrow_functions(node, source, container, out);
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// JavaScript / JSX
+// ---------------------------------------------------------------------------
+
+fn extract_javascript(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "class_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Class,
+                keyword: "class",
+                out,
+            }),
+            "function_declaration" => {
+                push_func(PushFuncArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Function,
+                    prefix: "function",
+                    out,
+                });
+                None
+            }
+            "method_definition" => {
+                push_func(PushFuncArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Method,
+                    prefix: "",
+                    out,
+                });
+                None
+            }
+            "lexical_declaration" | "variable_declaration" => {
+                extract_arrow_functions(node, source, container, out);
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+/// JS/TS: `const f = (...) => ...` becomes a function symbol; top-level
+/// non-arrow `const`/`let` becomes a variable symbol so the outline shows it.
+fn extract_arrow_functions(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    out: &mut Vec<Symbol>,
+) {
+    let pos = point_pos(node);
+    for declarator in helpers::children(node) {
+        if !declarator.is_named() || declarator.kind() != "variable_declarator" {
+            continue;
+        }
+        let Some(name_node) = declarator.child_by_field_name("name") else {
+            continue;
+        };
+        let name = helpers::node_text(name_node, source);
+        let value = declarator.child_by_field_name("value");
+        let value_kind = value.map(|n| n.kind()).unwrap_or("");
+        if matches!(
+            value_kind,
+            "arrow_function" | "function" | "function_expression"
+        ) {
+            out.push(helpers::sym(
+                &name,
+                SymbolKind::Function,
+                container,
+                format!("const {name} = (...) =>"),
+                pos,
+            ));
+        } else if container.is_none() {
+            let snippet: String = helpers::node_text(node, source)
+                .chars()
+                .take(100)
+                .collect::<String>()
+                .lines()
+                .next()
+                .unwrap_or(&name)
+                .to_string();
+            out.push(helpers::sym(
+                &name,
+                SymbolKind::Variable,
+                container,
+                snippet,
+                pos,
+            ));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Go
+// ---------------------------------------------------------------------------
+
+fn extract_go(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    extract_go_package(root, source, out);
+
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "function_declaration" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                let params = field_text(node, "parameters", source).unwrap_or_else(|| "()".into());
+                let prefix = if name.starts_with("Test")
+                    || name.starts_with("Benchmark")
+                    || name.starts_with("Example")
+                {
+                    "[test] "
+                } else {
+                    ""
+                };
+                let sig = format!("{prefix}func {name}{}", truncate(&params, 80));
+                out.push(helpers::sym(
+                    &name,
+                    SymbolKind::Function,
+                    container,
+                    sig,
+                    pos,
+                ));
+                None
+            }
+            "method_declaration" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                let receiver = field_text(node, "receiver", source).unwrap_or_default();
+                let params = field_text(node, "parameters", source).unwrap_or_else(|| "()".into());
+                let sig = format!("func {receiver} {name}{}", truncate(&params, 80));
+                out.push(helpers::sym(&name, SymbolKind::Method, container, sig, pos));
+                None
+            }
+            "type_declaration" => extract_go_type_decl(node, source, container, pos, out),
+            _ => None,
+        }
+    });
+}
+
+fn extract_go_package(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    for child in helpers::children(root) {
+        if child.kind() != "package_clause" {
+            continue;
+        }
+        let name_node = child
+            .child_by_field_name("name")
+            .or_else(|| child.child(1u32));
+        if let Some(n) = name_node {
+            let name = helpers::node_text(n, source);
+            let pos = point_pos(child);
+            out.push(helpers::sym(
+                &name,
+                SymbolKind::Module,
+                None,
+                format!("package {name}"),
+                pos,
+            ));
+        }
+        break;
+    }
+}
+
+fn extract_go_type_decl(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    out: &mut Vec<Symbol>,
+) -> Option<String> {
+    for spec in helpers::children(node) {
+        if spec.kind() != "type_spec" {
+            continue;
+        }
+        let Some(name_node) = spec.child_by_field_name("name") else {
+            continue;
+        };
+        let Some(type_node) = spec.child_by_field_name("type") else {
+            continue;
+        };
+        let name = helpers::node_text(name_node, source);
+        match type_node.kind() {
+            "struct_type" => {
+                out.push(helpers::sym(
+                    &name,
+                    SymbolKind::Struct,
+                    container,
+                    format!("type {name} struct"),
+                    pos,
+                ));
+                return Some(name);
+            }
+            "interface_type" => {
+                out.push(helpers::sym(
+                    &name,
+                    SymbolKind::Interface,
+                    container,
+                    format!("type {name} interface"),
+                    pos,
+                ));
+                return Some(name);
+            }
+            _ => {
+                out.push(helpers::sym(
+                    &name,
+                    SymbolKind::Type,
+                    container,
+                    format!("type {name}"),
+                    pos,
+                ));
+            }
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Rust
+// ---------------------------------------------------------------------------
+
+fn extract_rust(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "function_item" => {
+                push_func(PushFuncArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Function,
+                    prefix: "fn",
+                    out,
+                });
+                None
+            }
+            "struct_item" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Struct,
+                keyword: "struct",
+                out,
+            }),
+            "enum_item" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Enum,
+                keyword: "enum",
+                out,
+            }),
+            "trait_item" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Protocol,
+                keyword: "trait",
+                out,
+            }),
+            "impl_item" => node
+                .child_by_field_name("type")
+                .map(|n| helpers::node_text(n, source)),
+            "type_item" => {
+                named_decl_with_keyword(NamedDeclArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Type,
+                    keyword: "type",
+                    out,
+                });
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Python
+// ---------------------------------------------------------------------------
+
+fn extract_python(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "class_definition" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Class,
+                keyword: "class",
+                out,
+            }),
+            "function_definition" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                let params = field_text(node, "parameters", source).unwrap_or_else(|| "()".into());
+                let cleaned = strip_self_param(&params);
+                let kind = if container.is_some() {
+                    SymbolKind::Method
+                } else {
+                    SymbolKind::Function
+                };
+                let sig = format!("def {name}{}", truncate(&cleaned, 80));
+                out.push(helpers::sym(&name, kind, container, sig, pos));
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+fn strip_self_param(params: &str) -> String {
+    if let Some(rest) = params.strip_prefix("(self,") {
+        return format!("({}", rest.trim_start());
+    }
+    if params.starts_with("(self)") {
+        return "()".into();
+    }
+    if let Some(rest) = params.strip_prefix("(cls,") {
+        return format!("({}", rest.trim_start());
+    }
+    if params.starts_with("(cls)") {
+        return "()".into();
+    }
+    params.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Java
+// ---------------------------------------------------------------------------
+
+fn extract_java(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "class_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Class,
+                keyword: "class",
+                out,
+            }),
+            "interface_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Interface,
+                keyword: "interface",
+                out,
+            }),
+            "enum_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Enum,
+                keyword: "enum",
+                out,
+            }),
+            "method_declaration" => {
+                push_jvm_method(node, source, container, pos, out);
+                None
+            }
+            "constructor_declaration" => {
+                push_func(PushFuncArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Method,
+                    prefix: "",
+                    out,
+                });
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+fn push_jvm_method(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    out: &mut Vec<Symbol>,
+) {
+    push_typed_method(node, source, container, pos, "type", out)
+}
+
+fn push_csharp_method(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    out: &mut Vec<Symbol>,
+) {
+    push_typed_method(node, source, container, pos, "returns", out)
+}
+
+/// Shared shape for languages that expose `name` + `parameters` +
+/// "return-type" fields on their method nodes (Java, C#).
+fn push_typed_method(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    return_field: &str,
+    out: &mut Vec<Symbol>,
+) {
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
+    let name = helpers::node_text(name_node, source);
+    let params = field_text(node, "parameters", source).unwrap_or_else(|| "()".into());
+    let return_type = field_text(node, return_field, source).unwrap_or_else(|| "void".into());
+    let kind = if container.is_some() {
+        SymbolKind::Method
+    } else {
+        SymbolKind::Function
+    };
+    let sig = format!("{return_type} {name}{}", truncate(&params, 80));
+    out.push(helpers::sym(&name, kind, container, sig, pos));
+}
+
+// ---------------------------------------------------------------------------
+// C / C++
+// ---------------------------------------------------------------------------
+
+fn extract_c(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "function_definition" => {
+                push_c_function(node, source, container, pos, SymbolKind::Function, out);
+                None
+            }
+            "struct_specifier" => push_c_specifier(
+                node,
+                source,
+                container,
+                pos,
+                SymbolKind::Struct,
+                "struct",
+                out,
+            ),
+            "enum_specifier" => {
+                push_c_specifier(node, source, container, pos, SymbolKind::Enum, "enum", out);
+                None
+            }
+            "type_definition" => {
+                push_c_typedef(node, source, container, pos, out);
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+fn extract_cpp(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "function_definition" => {
+                let kind = if container.is_some() {
+                    SymbolKind::Method
+                } else {
+                    SymbolKind::Function
+                };
+                push_c_function(node, source, container, pos, kind, out);
+                None
+            }
+            "class_specifier" => push_c_specifier(
+                node,
+                source,
+                container,
+                pos,
+                SymbolKind::Class,
+                "class",
+                out,
+            ),
+            "struct_specifier" => push_c_specifier(
+                node,
+                source,
+                container,
+                pos,
+                SymbolKind::Struct,
+                "struct",
+                out,
+            ),
+            "enum_specifier" => {
+                push_c_specifier(node, source, container, pos, SymbolKind::Enum, "enum", out);
+                None
+            }
+            "namespace_definition" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Module,
+                keyword: "namespace",
+                out,
+            }),
+            _ => None,
+        }
+    });
+}
+
+fn push_c_function(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    kind: SymbolKind,
+    out: &mut Vec<Symbol>,
+) {
+    let Some(declarator) = node.child_by_field_name("declarator") else {
+        return;
+    };
+    let Some(name) = declarator_name(declarator, source) else {
+        return;
+    };
+    let params = declarator_params(declarator, source);
+    let sig = format!("{name}{}", truncate(&params, 80));
+    out.push(helpers::sym(&name, kind, container, sig, pos));
+}
+
+fn push_c_specifier(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    kind: SymbolKind,
+    keyword: &str,
+    out: &mut Vec<Symbol>,
+) -> Option<String> {
+    let name_node = node.child_by_field_name("name")?;
+    let name = helpers::node_text(name_node, source);
+    if name.is_empty() {
+        return None;
+    }
+    out.push(helpers::sym(
+        &name,
+        kind,
+        container,
+        format!("{keyword} {name}"),
+        pos,
+    ));
+    Some(name)
+}
+
+fn push_c_typedef(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    out: &mut Vec<Symbol>,
+) {
+    for child in helpers::children(node) {
+        if child.kind() != "type_identifier" {
+            continue;
+        }
+        let name = helpers::node_text(child, source);
+        out.push(helpers::sym(
+            &name,
+            SymbolKind::Type,
+            container,
+            format!("typedef {name}"),
+            pos,
+        ));
+    }
+}
+
+/// Drill through nested pointer/reference declarators to find the
+/// underlying identifier.
+fn declarator_name(node: Node<'_>, source: &str) -> Option<String> {
+    let kind = node.kind();
+    if matches!(kind, "identifier" | "field_identifier" | "destructor_name") {
+        return Some(helpers::node_text(node, source));
+    }
+    if matches!(kind, "qualified_identifier" | "template_function") {
+        return Some(helpers::node_text(node, source));
+    }
+    if let Some(inner) = node.child_by_field_name("declarator") {
+        return declarator_name(inner, source);
+    }
+    if let Some(inner) = node.child_by_field_name("name") {
+        return declarator_name(inner, source);
+    }
+    None
+}
+
+fn declarator_params(node: Node<'_>, source: &str) -> String {
+    if node.kind() == "function_declarator" {
+        if let Some(params) = node.child_by_field_name("parameters") {
+            return helpers::node_text(params, source);
+        }
+    }
+    for child in helpers::children(node) {
+        let result = declarator_params(child, source);
+        if result != "()" {
+            return result;
+        }
+    }
+    "()".into()
+}
+
+// ---------------------------------------------------------------------------
+// C#
+// ---------------------------------------------------------------------------
+
+fn extract_csharp(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "namespace_declaration" | "file_scoped_namespace_declaration" => {
+                named_decl_with_keyword(NamedDeclArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Module,
+                    keyword: "namespace",
+                    out,
+                })
+            }
+            "class_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Class,
+                keyword: "class",
+                out,
+            }),
+            "struct_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Struct,
+                keyword: "struct",
+                out,
+            }),
+            "interface_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Interface,
+                keyword: "interface",
+                out,
+            }),
+            "enum_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Enum,
+                keyword: "enum",
+                out,
+            }),
+            "method_declaration" => {
+                push_csharp_method(node, source, container, pos, out);
+                None
+            }
+            "property_declaration" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                let prop_type = field_text(node, "type", source).unwrap_or_default();
+                out.push(helpers::sym(
+                    &name,
+                    SymbolKind::Variable,
+                    container,
+                    format!("{prop_type} {name}").trim().to_string(),
+                    pos,
+                ));
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Kotlin
+// ---------------------------------------------------------------------------
+
+fn extract_kotlin(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "class_declaration" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                let is_interface = has_anonymous_child(node, "interface", source);
+                let kind = if is_interface {
+                    SymbolKind::Interface
+                } else {
+                    SymbolKind::Class
+                };
+                let keyword = if is_interface { "interface" } else { "class" };
+                out.push(helpers::sym(
+                    &name,
+                    kind,
+                    container,
+                    format!("{keyword} {name}"),
+                    pos,
+                ));
+                Some(name)
+            }
+            "object_declaration" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                out.push(helpers::sym(
+                    &name,
+                    SymbolKind::Class,
+                    container,
+                    format!("object {name}"),
+                    pos,
+                ));
+                Some(name)
+            }
+            "function_declaration" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                let kind = if container.is_some() {
+                    SymbolKind::Method
+                } else {
+                    SymbolKind::Function
+                };
+                out.push(helpers::sym(
+                    &name,
+                    kind,
+                    container,
+                    format!("fun {name}"),
+                    pos,
+                ));
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Ruby
+// ---------------------------------------------------------------------------
+
+fn extract_ruby(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "class" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                out.push(helpers::sym(
+                    &name,
+                    SymbolKind::Class,
+                    container,
+                    format!("class {name}"),
+                    pos,
+                ));
+                Some(name)
+            }
+            "module" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                out.push(helpers::sym(
+                    &name,
+                    SymbolKind::Module,
+                    container,
+                    format!("module {name}"),
+                    pos,
+                ));
+                Some(name)
+            }
+            "method" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                let params = field_text(node, "parameters", source).unwrap_or_default();
+                let kind = if container.is_some() {
+                    SymbolKind::Method
+                } else {
+                    SymbolKind::Function
+                };
+                let sig = if params.is_empty() {
+                    format!("def {name}")
+                } else {
+                    format!("def {name}{}", truncate(&params, 80))
+                };
+                out.push(helpers::sym(&name, kind, container, sig, pos));
+                None
+            }
+            "singleton_method" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                out.push(helpers::sym(
+                    &name,
+                    SymbolKind::Method,
+                    container,
+                    format!("def self.{name}"),
+                    pos,
+                ));
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// PHP
+// ---------------------------------------------------------------------------
+
+fn extract_php(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "class_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Class,
+                keyword: "class",
+                out,
+            }),
+            "interface_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Interface,
+                keyword: "interface",
+                out,
+            }),
+            "enum_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Enum,
+                keyword: "enum",
+                out,
+            }),
+            "function_definition" => {
+                push_func(PushFuncArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Function,
+                    prefix: "function",
+                    out,
+                });
+                None
+            }
+            "method_declaration" => {
+                push_func(PushFuncArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Method,
+                    prefix: "",
+                    out,
+                });
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Scala
+// ---------------------------------------------------------------------------
+
+fn extract_scala(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "class_definition" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                let is_case = has_anonymous_child(node, "case", source);
+                let sig = if is_case {
+                    format!("case class {name}")
+                } else {
+                    format!("class {name}")
+                };
+                out.push(helpers::sym(&name, SymbolKind::Class, container, sig, pos));
+                Some(name)
+            }
+            "trait_definition" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Protocol,
+                keyword: "trait",
+                out,
+            }),
+            "object_definition" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Class,
+                keyword: "object",
+                out,
+            }),
+            "enum_definition" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Enum,
+                keyword: "enum",
+                out,
+            }),
+            "function_definition" | "function_declaration" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                let params = field_text(node, "parameters", source).unwrap_or_default();
+                let kind = if container.is_some() {
+                    SymbolKind::Method
+                } else {
+                    SymbolKind::Function
+                };
+                out.push(helpers::sym(
+                    &name,
+                    kind,
+                    container,
+                    format!("def {name}{}", truncate(&params, 80)),
+                    pos,
+                ));
+                None
+            }
+            "type_definition" => {
+                named_decl_with_keyword(NamedDeclArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Type,
+                    keyword: "type",
+                    out,
+                });
+                None
+            }
+            "val_definition" | "val_declaration" => {
+                push_scala_binding(
+                    node,
+                    source,
+                    container,
+                    pos,
+                    SymbolKind::Variable,
+                    "val",
+                    out,
+                );
+                None
+            }
+            "var_definition" | "var_declaration" => {
+                push_scala_binding(
+                    node,
+                    source,
+                    container,
+                    pos,
+                    SymbolKind::Variable,
+                    "var",
+                    out,
+                );
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+fn push_scala_binding(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    kind: SymbolKind,
+    keyword: &str,
+    out: &mut Vec<Symbol>,
+) {
+    let pattern = node
+        .child_by_field_name("pattern")
+        .or_else(|| node.child_by_field_name("name"));
+    let Some(node_text_src) = pattern else {
+        return;
+    };
+    let name = helpers::node_text(node_text_src, source);
+    if name.len() <= 1 {
+        return;
+    }
+    out.push(helpers::sym(
+        &name,
+        kind,
+        container,
+        format!("{keyword} {name}"),
+        pos,
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Bash
+// ---------------------------------------------------------------------------
+
+fn extract_bash(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        if node.kind() != "function_definition" {
+            return None;
+        }
+        let pos = point_pos(node);
+        let name_node = node.child_by_field_name("name")?;
+        let name = helpers::node_text(name_node, source);
+        out.push(helpers::sym(
+            &name,
+            SymbolKind::Function,
+            container,
+            format!("function {name}"),
+            pos,
+        ));
+        None
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Swift
+// ---------------------------------------------------------------------------
+
+fn extract_swift(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "function_declaration" => {
+                push_func(PushFuncArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Function,
+                    prefix: "func",
+                    out,
+                });
+                None
+            }
+            "class_declaration" => extract_swift_class(node, source, container, pos, out),
+            "protocol_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Protocol,
+                keyword: "protocol",
+                out,
+            }),
+            "property_declaration" => {
+                if let Some(name_node) = node.child_by_field_name("name") {
+                    let name = helpers::node_text(name_node, source);
+                    out.push(helpers::sym(
+                        &name,
+                        SymbolKind::Variable,
+                        container,
+                        name.clone(),
+                        pos,
+                    ));
+                }
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+fn extract_swift_class(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    out: &mut Vec<Symbol>,
+) -> Option<String> {
+    let (kind, keyword) = match node
+        .child_by_field_name("declaration_kind")
+        .map(|n| helpers::node_text(n, source))
+    {
+        Some(t) if t == "struct" => (SymbolKind::Struct, "struct"),
+        Some(t) if t == "enum" => (SymbolKind::Enum, "enum"),
+        Some(t) if t == "actor" => (SymbolKind::Class, "actor"),
+        Some(t) if t == "extension" => (SymbolKind::Other, "extension"),
+        _ => (SymbolKind::Class, "class"),
+    };
+    named_decl_with_keyword(NamedDeclArgs {
+        node,
+        source,
+        container,
+        pos,
+        kind,
+        keyword,
+        out,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Zig
+// ---------------------------------------------------------------------------
+
+fn extract_zig(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "function_declaration" => {
+                push_func(PushFuncArgs {
+                    node,
+                    source,
+                    container,
+                    pos,
+                    kind: SymbolKind::Function,
+                    prefix: "fn",
+                    out,
+                });
+                None
+            }
+            "container_declaration" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Struct,
+                keyword: "struct",
+                out,
+            }),
+            "test_declaration" => {
+                extract_zig_test(node, source, container, pos, out);
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+fn extract_zig_test(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    out: &mut Vec<Symbol>,
+) {
+    for child in helpers::children(node) {
+        if child.kind() != "string" {
+            continue;
+        }
+        let mut name = helpers::node_text(child, source);
+        for content in helpers::children(child) {
+            if content.kind() == "string_content" {
+                name = helpers::node_text(content, source);
+                break;
+            }
+        }
+        let trimmed = name.trim_matches('"').to_string();
+        out.push(helpers::sym(
+            &trimmed,
+            SymbolKind::Function,
+            container,
+            format!("test \"{trimmed}\""),
+            pos,
+        ));
+        return;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Elixir
+// ---------------------------------------------------------------------------
+
+fn extract_elixir(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        if node.kind() != "call" {
+            return None;
+        }
+        let pos = point_pos(node);
+        let target = node.child(0u32)?;
+        let keyword = helpers::node_text(target, source);
+        match keyword.as_str() {
+            "defmodule" => {
+                let arg = node.child(1u32)?;
+                let name = helpers::node_text(arg, source)
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .to_string();
+                out.push(helpers::sym(
+                    &name,
+                    SymbolKind::Module,
+                    container,
+                    format!("defmodule {name}"),
+                    pos,
+                ));
+                Some(name)
+            }
+            "def" | "defp" => {
+                let arg = node.child(1u32)?;
+                let sig = helpers::node_text(arg, source)
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .to_string();
+                let name = sig.split('(').next().unwrap_or(&sig).trim().to_string();
+                let kind = if container.is_some() {
+                    SymbolKind::Method
+                } else {
+                    SymbolKind::Function
+                };
+                out.push(helpers::sym(
+                    &name,
+                    kind,
+                    container,
+                    format!("{keyword} {}", truncate(&sig, 80)),
+                    pos,
+                ));
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Lua
+// ---------------------------------------------------------------------------
+
+fn extract_lua(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "function_declaration" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                let params = field_text(node, "parameters", source).unwrap_or_else(|| "()".into());
+                let kind = if name.contains(':') {
+                    SymbolKind::Method
+                } else {
+                    SymbolKind::Function
+                };
+                out.push(helpers::sym(
+                    &name,
+                    kind,
+                    container,
+                    format!("function {name}{}", truncate(&params, 80)),
+                    pos,
+                ));
+                None
+            }
+            "local_function" => {
+                let name_node = node.child_by_field_name("name")?;
+                let name = helpers::node_text(name_node, source);
+                let params = field_text(node, "parameters", source).unwrap_or_else(|| "()".into());
+                out.push(helpers::sym(
+                    &name,
+                    SymbolKind::Function,
+                    container,
+                    format!("local function {name}{}", truncate(&params, 80)),
+                    pos,
+                ));
+                None
+            }
+            _ => None,
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Haskell
+// ---------------------------------------------------------------------------
+
+fn extract_haskell(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "function" => {
+                if let Some(name_node) = node.child(0u32) {
+                    let name = helpers::node_text(name_node, source);
+                    if !name.is_empty() {
+                        out.push(helpers::sym(
+                            &name,
+                            SymbolKind::Function,
+                            container,
+                            name.clone(),
+                            pos,
+                        ));
+                    }
+                }
+                None
+            }
+            "adt" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Class,
+                keyword: "data",
+                out,
+            }),
+            "newtype" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Type,
+                keyword: "newtype",
+                out,
+            }),
+            "class" => named_decl_with_keyword(NamedDeclArgs {
+                node,
+                source,
+                container,
+                pos,
+                kind: SymbolKind::Interface,
+                keyword: "class",
+                out,
+            }),
+            _ => None,
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// R
+// ---------------------------------------------------------------------------
+
+fn extract_r(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        if node.kind() != "binary_operator" {
+            return None;
+        }
+        let pos = point_pos(node);
+        let name_node = node.child_by_field_name("lhs")?;
+        let value_node = node.child_by_field_name("rhs")?;
+        if value_node.kind() != "function_definition" {
+            return None;
+        }
+        let name = helpers::node_text(name_node, source);
+        let params = value_node
+            .child_by_field_name("parameters")
+            .map(|n| helpers::node_text(n, source))
+            .unwrap_or_else(|| "()".into());
+        out.push(helpers::sym(
+            &name,
+            SymbolKind::Function,
+            container,
+            format!("{name} <- function{}", truncate(&params, 80)),
+            pos,
+        ));
+        None
+    });
+}

--- a/crates/harn-hostlib/src/ast/symbols/helpers.rs
+++ b/crates/harn-hostlib/src/ast/symbols/helpers.rs
@@ -1,0 +1,198 @@
+//! Cross-language symbol-extraction helpers.
+//!
+//! Every per-language extractor in [`super`] reuses the same primitives
+//! (named-tree walk, container tracking, named-declaration shaping,
+//! function-signature shaping). Centralizing them here keeps the
+//! per-language match arms small and prevents the inevitable copy-paste
+//! drift that bit the Swift port.
+
+use tree_sitter::Node;
+
+use super::super::types::{Symbol, SymbolKind};
+
+/// Position quadruple used by helpers that build [`Symbol`]s. We pull
+/// these out once per node so the helper signatures stay short.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct NodePos {
+    pub start_row: u32,
+    pub start_col: u32,
+    pub end_row: u32,
+    pub end_col: u32,
+}
+
+/// Iterate every child (named + anonymous) of `node` in source order.
+/// Wraps the tree-sitter `child(i: u32)` API so per-language extractors
+/// can write `for child in children(node)` without dealing with the index
+/// cast.
+pub(super) fn children<'tree>(node: Node<'tree>) -> impl Iterator<Item = Node<'tree>> {
+    let count = node.child_count();
+    (0..count).filter_map(move |i| node.child(i as u32))
+}
+
+pub(super) fn point_pos(node: Node<'_>) -> NodePos {
+    let s = node.start_position();
+    let e = node.end_position();
+    NodePos {
+        start_row: s.row as u32,
+        start_col: s.column as u32,
+        end_row: e.row as u32,
+        end_col: e.column as u32,
+    }
+}
+
+/// UTF-8 source slice for a node. Tree-sitter byte ranges are guaranteed
+/// to land on UTF-8 boundaries, so the slice is always valid.
+pub(super) fn node_text(node: Node<'_>, source: &str) -> String {
+    let bytes = source.as_bytes();
+    let start = node.start_byte().min(bytes.len());
+    let end = node.end_byte().min(bytes.len());
+    std::str::from_utf8(&bytes[start..end])
+        .map(|s| s.to_string())
+        .unwrap_or_default()
+}
+
+/// Convenience: read a field by name and return its text. Returns `None`
+/// when the field isn't set on the node.
+pub(super) fn field_text(node: Node<'_>, field: &str, source: &str) -> Option<String> {
+    node.child_by_field_name(field)
+        .map(|n| node_text(n, source))
+}
+
+/// Truncate to `max` chars with an ellipsis suffix, matching the Swift
+/// `truncate(_, max:)` helper. Operates on Unicode scalars, not bytes.
+pub(super) fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() > max {
+        let mut out: String = s.chars().take(max).collect();
+        out.push('…');
+        out
+    } else {
+        s.to_string()
+    }
+}
+
+/// Depth-first named-tree walk. The visitor receives each named node and
+/// the current container name; it may return a new container string to
+/// stamp on this node's descendants.
+///
+/// This is the Rust equivalent of Swift's `walkTree(node:source:container:visitor:)`
+/// in `TreeSitterIntegration.swift`.
+pub(super) fn walk_named<'tree, F>(node: Node<'tree>, container: Option<&str>, visitor: &mut F)
+where
+    F: FnMut(Node<'tree>, Option<&str>) -> Option<String>,
+{
+    let new_container = visitor(node, container);
+    let effective: Option<&str> = match new_container.as_deref() {
+        Some(s) => Some(s),
+        None => container,
+    };
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let child = cursor.node();
+            if child.is_named() {
+                walk_named(child, effective, visitor);
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+/// True iff the node has a non-named (anonymous) child whose source text
+/// equals `text`. Used by Kotlin's `interface` keyword detection and
+/// Scala's `case class` detection — both grammars expose those keywords
+/// only as anonymous tokens, not via field names.
+pub(super) fn has_anonymous_child(node: Node<'_>, text: &str, source: &str) -> bool {
+    for child in children(node) {
+        if !child.is_named() && node_text(child, source) == text {
+            return true;
+        }
+    }
+    false
+}
+
+/// Shape a [`Symbol`]. Centralizes the field set so per-language code
+/// doesn't have to remember the field names.
+pub(super) fn sym(
+    name: &str,
+    kind: SymbolKind,
+    container: Option<&str>,
+    signature: String,
+    pos: NodePos,
+) -> Symbol {
+    Symbol {
+        name: name.to_string(),
+        kind,
+        container: container.map(str::to_string),
+        signature,
+        start_row: pos.start_row,
+        start_col: pos.start_col,
+        end_row: pos.end_row,
+        end_col: pos.end_col,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Common shapes used across multiple languages
+// ---------------------------------------------------------------------------
+
+/// Args for the `extractNamedDecl`-equivalent helper. Bundled into a
+/// struct because Rust's function-arg limit reads better than 7 args
+/// inline at every call site.
+pub(super) struct NamedDeclArgs<'src, 'tree, 'out> {
+    pub node: Node<'tree>,
+    pub source: &'src str,
+    pub container: Option<&'src str>,
+    pub pos: NodePos,
+    pub kind: SymbolKind,
+    pub keyword: &'static str,
+    pub out: &'out mut Vec<Symbol>,
+}
+
+/// Push a "named declaration" symbol. Returns the symbol's name so the
+/// caller can stamp it as a container on descendants. Mirrors
+/// `extractNamedDecl(node:ctx:kind:keyword:)` in `TreeSitterIntegration.swift`.
+pub(super) fn named_decl_with_keyword(args: NamedDeclArgs<'_, '_, '_>) -> Option<String> {
+    let name_node = args.node.child_by_field_name("name")?;
+    let name = node_text(name_node, args.source);
+    if name.is_empty() {
+        return None;
+    }
+    args.out.push(sym(
+        &name,
+        args.kind,
+        args.container,
+        format!("{} {name}", args.keyword),
+        args.pos,
+    ));
+    Some(name)
+}
+
+/// Args for the `extractFuncDecl`-equivalent helper.
+pub(super) struct PushFuncArgs<'src, 'tree, 'out> {
+    pub node: Node<'tree>,
+    pub source: &'src str,
+    pub container: Option<&'src str>,
+    pub pos: NodePos,
+    pub kind: SymbolKind,
+    pub prefix: &'static str,
+    pub out: &'out mut Vec<Symbol>,
+}
+
+/// Push a function-style symbol. Mirrors `extractFuncDecl` in
+/// `TreeSitterIntegration.swift`.
+pub(super) fn push_func(args: PushFuncArgs<'_, '_, '_>) {
+    let Some(name_node) = args.node.child_by_field_name("name") else {
+        return;
+    };
+    let name = node_text(name_node, args.source);
+    let params = field_text(args.node, "parameters", args.source).unwrap_or_else(|| "()".into());
+    let sig = if args.prefix.is_empty() {
+        format!("{name}{}", truncate(&params, 80))
+    } else {
+        format!("{} {name}{}", args.prefix, truncate(&params, 80))
+    };
+    args.out
+        .push(sym(&name, args.kind, args.container, sig, args.pos));
+}

--- a/crates/harn-hostlib/src/ast/symbols_call.rs
+++ b/crates/harn-hostlib/src/ast/symbols_call.rs
@@ -1,0 +1,87 @@
+//! `ast.symbols` — flat symbol list for a single source file.
+//!
+//! Thin wrapper around [`super::symbols::extract`] that handles parameter
+//! parsing, file IO, and shaping the response into the `VmValue::Dict`
+//! the schema expects.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::tools::args::{build_dict, dict_arg, optional_string, require_string, str_value};
+
+use super::language::Language;
+use super::parse::{parse_source, read_source};
+use super::symbols::extract;
+use super::types::Symbol;
+
+const BUILTIN: &str = "hostlib_ast_symbols";
+
+pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN, args)?;
+    let dict = raw.as_ref();
+
+    let path_str = require_string(BUILTIN, dict, "path")?;
+    let language_hint = optional_string(BUILTIN, dict, "language")?;
+    let kinds = parse_kinds_filter(dict)?;
+
+    let path = PathBuf::from(&path_str);
+    let language = Language::detect(&path, language_hint.as_deref()).ok_or_else(|| {
+        HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "language",
+            message: format!(
+                "could not infer a tree-sitter grammar for `{path_str}` \
+                 (extension or `language` field unrecognized)"
+            ),
+        }
+    })?;
+
+    let source = read_source(&path_str, 0)?;
+    let tree = parse_source(&source, language)?;
+    let mut symbols = extract(&tree, &source, language);
+    if let Some(filter) = kinds.as_ref() {
+        symbols.retain(|s| filter.contains(s.kind.as_str()));
+    }
+
+    let symbols_list: Vec<VmValue> = symbols.iter().map(Symbol::to_vm_value).collect();
+
+    Ok(build_dict([
+        ("path", str_value(&path_str)),
+        ("language", str_value(language.name())),
+        ("symbols", VmValue::List(Rc::new(symbols_list))),
+    ]))
+}
+
+fn parse_kinds_filter(
+    dict: &std::collections::BTreeMap<String, VmValue>,
+) -> Result<Option<HashSet<String>>, HostlibError> {
+    let Some(raw) = dict.get("kinds") else {
+        return Ok(None);
+    };
+    let VmValue::List(list) = raw else {
+        if matches!(raw, VmValue::Nil) {
+            return Ok(None);
+        }
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "kinds",
+            message: format!("expected list of strings, got {}", raw.type_name()),
+        });
+    };
+    let mut out = HashSet::new();
+    for item in list.iter() {
+        let VmValue::String(s) = item else {
+            return Err(HostlibError::InvalidParameter {
+                builtin: BUILTIN,
+                param: "kinds",
+                message: format!("entries must be strings, got {}", item.type_name()),
+            });
+        };
+        out.insert(s.to_string());
+    }
+    Ok(Some(out))
+}

--- a/crates/harn-hostlib/src/ast/types.rs
+++ b/crates/harn-hostlib/src/ast/types.rs
@@ -1,0 +1,173 @@
+//! Shared data types for the `ast::*` builtins.
+//!
+//! These mirror the JSON schemas in `crates/harn-hostlib/schemas/ast/` and
+//! are the structural source of truth for the wire format. The
+//! [`to_vm_value`](Symbol::to_vm_value) helpers shape each value into the
+//! `VmValue::Dict` layout the schema declares so handlers in
+//! [`crate::ast`] don't have to rebuild the field set in three places.
+
+#![allow(missing_docs)]
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use harn_vm::VmValue;
+
+/// Symbol kind. The wire form is the lowercase string returned by
+/// [`SymbolKind::as_str`]. Mirrors `symbolKindString` in
+/// `~/projects/burin-code/Sources/ASTEngine/SymbolOperations.swift` so
+/// burin-code receives the same labels regardless of which side of the
+/// bridge produced the symbol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SymbolKind {
+    Function,
+    Method,
+    Class,
+    Struct,
+    Enum,
+    Interface,
+    Protocol,
+    Type,
+    Variable,
+    Module,
+    Other,
+}
+
+impl SymbolKind {
+    /// Wire form ("function", "class", ...).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SymbolKind::Function => "function",
+            SymbolKind::Method => "method",
+            SymbolKind::Class => "class",
+            SymbolKind::Struct => "struct",
+            SymbolKind::Enum => "enum",
+            SymbolKind::Interface => "interface",
+            SymbolKind::Protocol => "protocol",
+            SymbolKind::Type => "type",
+            SymbolKind::Variable => "variable",
+            SymbolKind::Module => "module",
+            SymbolKind::Other => "other",
+        }
+    }
+
+    /// True for kinds that contain other symbols (classes, enums, …).
+    /// Drives the flat-symbols → nested-outline fold in
+    /// [`crate::ast::outline`].
+    pub fn is_container(self) -> bool {
+        matches!(
+            self,
+            SymbolKind::Class
+                | SymbolKind::Struct
+                | SymbolKind::Enum
+                | SymbolKind::Interface
+                | SymbolKind::Protocol
+                | SymbolKind::Module
+        )
+    }
+}
+
+/// A flat symbol record. All row/col coordinates are 0-based, matching
+/// tree-sitter native positions.
+#[derive(Debug, Clone)]
+pub struct Symbol {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub container: Option<String>,
+    pub signature: String,
+    pub start_row: u32,
+    pub start_col: u32,
+    pub end_row: u32,
+    pub end_col: u32,
+}
+
+impl Symbol {
+    /// Render as a `VmValue::Dict` matching `schemas/ast/symbols.response.json`.
+    pub fn to_vm_value(&self) -> VmValue {
+        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        dict.insert("name".into(), VmValue::String(Rc::from(self.name.as_str())));
+        dict.insert("kind".into(), VmValue::String(Rc::from(self.kind.as_str())));
+        dict.insert(
+            "container".into(),
+            match &self.container {
+                Some(s) => VmValue::String(Rc::from(s.as_str())),
+                None => VmValue::Nil,
+            },
+        );
+        dict.insert(
+            "signature".into(),
+            VmValue::String(Rc::from(self.signature.as_str())),
+        );
+        dict.insert("start_row".into(), VmValue::Int(self.start_row as i64));
+        dict.insert("start_col".into(), VmValue::Int(self.start_col as i64));
+        dict.insert("end_row".into(), VmValue::Int(self.end_row as i64));
+        dict.insert("end_col".into(), VmValue::Int(self.end_col as i64));
+        VmValue::Dict(Rc::new(dict))
+    }
+}
+
+/// One node in a hierarchical outline. The `children` list nests in
+/// document order; see [`crate::ast::outline`] for the fold algorithm.
+#[derive(Debug, Clone)]
+pub struct OutlineItem {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub signature: String,
+    pub start_row: u32,
+    pub end_row: u32,
+    pub children: Vec<OutlineItem>,
+}
+
+impl OutlineItem {
+    pub fn to_vm_value(&self) -> VmValue {
+        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        dict.insert("name".into(), VmValue::String(Rc::from(self.name.as_str())));
+        dict.insert("kind".into(), VmValue::String(Rc::from(self.kind.as_str())));
+        dict.insert(
+            "signature".into(),
+            VmValue::String(Rc::from(self.signature.as_str())),
+        );
+        dict.insert("start_row".into(), VmValue::Int(self.start_row as i64));
+        dict.insert("end_row".into(), VmValue::Int(self.end_row as i64));
+        let kids: Vec<VmValue> = self.children.iter().map(OutlineItem::to_vm_value).collect();
+        dict.insert("children".into(), VmValue::List(Rc::new(kids)));
+        VmValue::Dict(Rc::new(dict))
+    }
+}
+
+/// One tree-sitter node, flattened for `parse_file`'s wire format.
+/// Matches `schemas/ast/parse_file.response.json#/$defs/Node`.
+#[derive(Debug, Clone)]
+pub struct ParsedNode {
+    pub id: u32,
+    pub parent_id: Option<u32>,
+    pub kind: String,
+    pub is_named: bool,
+    pub start_byte: u32,
+    pub end_byte: u32,
+    pub start_row: u32,
+    pub start_col: u32,
+    pub end_row: u32,
+    pub end_col: u32,
+}
+
+impl ParsedNode {
+    pub fn to_vm_value(&self) -> VmValue {
+        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        dict.insert("id".into(), VmValue::Int(self.id as i64));
+        dict.insert(
+            "parent_id".into(),
+            self.parent_id
+                .map_or(VmValue::Nil, |id| VmValue::Int(id as i64)),
+        );
+        dict.insert("kind".into(), VmValue::String(Rc::from(self.kind.as_str())));
+        dict.insert("is_named".into(), VmValue::Bool(self.is_named));
+        dict.insert("start_byte".into(), VmValue::Int(self.start_byte as i64));
+        dict.insert("end_byte".into(), VmValue::Int(self.end_byte as i64));
+        dict.insert("start_row".into(), VmValue::Int(self.start_row as i64));
+        dict.insert("start_col".into(), VmValue::Int(self.start_col as i64));
+        dict.insert("end_row".into(), VmValue::Int(self.end_row as i64));
+        dict.insert("end_col".into(), VmValue::Int(self.end_col as i64));
+        VmValue::Dict(Rc::new(dict))
+    }
+}

--- a/crates/harn-hostlib/src/tools/mod.rs
+++ b/crates/harn-hostlib/src/tools/mod.rs
@@ -42,7 +42,7 @@ use harn_vm::VmValue;
 use crate::error::HostlibError;
 use crate::registry::{BuiltinRegistry, HostlibCapability, RegisteredBuiltin, SyncHandler};
 
-mod args;
+pub(crate) mod args;
 mod diagnostics;
 mod file_io;
 mod git;

--- a/crates/harn-hostlib/tests/ast_builtins.rs
+++ b/crates/harn-hostlib/tests/ast_builtins.rs
@@ -1,0 +1,229 @@
+//! End-to-end coverage for the wired-up `ast::*` builtins.
+//!
+//! Complements `ast_fixtures.rs` (golden-symbol/outline checks): this
+//! file drives the full builtin path through the registration table —
+//! parameter parsing, `VmValue::Dict` shape, schema field set — and
+//! includes a perf smoke check against a known input.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::time::Instant;
+
+use harn_hostlib::{ast::AstCapability, BuiltinRegistry, HostlibCapability};
+use harn_vm::VmValue;
+
+fn ast_registry() -> BuiltinRegistry {
+    let mut registry = BuiltinRegistry::new();
+    AstCapability.register_builtins(&mut registry);
+    registry
+}
+
+fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in pairs {
+        map.insert((*k).into(), v.clone());
+    }
+    VmValue::Dict(Rc::new(map))
+}
+
+fn fixture_path(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/ast")
+        .join(rel)
+}
+
+fn invoke(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {
+    let entry = registry
+        .find(name)
+        .unwrap_or_else(|| panic!("builtin {name} not registered"));
+    (entry.handler)(&[payload]).unwrap_or_else(|err| panic!("{name} failed: {err}"))
+}
+
+fn dict_field(value: &VmValue, key: &str) -> VmValue {
+    match value {
+        VmValue::Dict(d) => d
+            .get(key)
+            .cloned()
+            .unwrap_or_else(|| panic!("missing field `{key}` on {value:?}")),
+        other => panic!("expected dict, got {other:?}"),
+    }
+}
+
+fn string_value(value: &VmValue) -> &str {
+    match value {
+        VmValue::String(s) => s.as_ref(),
+        other => panic!("expected string, got {other:?}"),
+    }
+}
+
+fn list_value(value: &VmValue) -> Rc<Vec<VmValue>> {
+    match value {
+        VmValue::List(l) => l.clone(),
+        other => panic!("expected list, got {other:?}"),
+    }
+}
+
+fn int_value(value: &VmValue) -> i64 {
+    match value {
+        VmValue::Int(n) => *n,
+        other => panic!("expected int, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_file_produces_flat_node_list_with_root_id_zero() {
+    let registry = ast_registry();
+    let path = fixture_path("rust/source.rs");
+    let payload = dict(&[(
+        "path",
+        VmValue::String(Rc::from(path.to_string_lossy().as_ref())),
+    )]);
+
+    let result = invoke(&registry, "hostlib_ast_parse_file", payload);
+
+    assert_eq!(string_value(&dict_field(&result, "language")), "rust");
+    assert_eq!(int_value(&dict_field(&result, "root_id")), 0);
+    let nodes = list_value(&dict_field(&result, "nodes"));
+    assert!(
+        nodes.len() > 5,
+        "expected non-trivial tree, got {} nodes",
+        nodes.len()
+    );
+
+    // Root has parent_id = nil; every other node has an integer parent
+    // pointing at a smaller id (BFS guarantees this).
+    let first = &nodes[0];
+    assert!(matches!(dict_field(first, "parent_id"), VmValue::Nil));
+    for node in nodes.iter().skip(1) {
+        match dict_field(node, "parent_id") {
+            VmValue::Int(n) => assert!(
+                n >= 0 && (n as usize) < nodes.len(),
+                "parent_id out of range: {n}"
+            ),
+            other => panic!("expected int parent_id, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn parse_file_rejects_unknown_language() {
+    let registry = ast_registry();
+    let entry = registry.find("hostlib_ast_parse_file").expect("registered");
+    let payload = dict(&[
+        ("path", VmValue::String(Rc::from("foo.unknown"))),
+        ("language", VmValue::String(Rc::from("klingon"))),
+    ]);
+    let err = (entry.handler)(&[payload]).expect_err("must reject unknown language");
+    assert!(
+        err.to_string().contains("klingon") || err.to_string().contains("could not infer"),
+        "unexpected error message: {err}",
+    );
+}
+
+#[test]
+fn symbols_filters_by_kind() {
+    let registry = ast_registry();
+    let path = fixture_path("rust/source.rs");
+    let kinds = VmValue::List(Rc::new(vec![VmValue::String(Rc::from("function"))]));
+    let payload = dict(&[
+        (
+            "path",
+            VmValue::String(Rc::from(path.to_string_lossy().as_ref())),
+        ),
+        ("kinds", kinds),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_symbols", payload);
+    let symbols = list_value(&dict_field(&result, "symbols"));
+    assert!(!symbols.is_empty());
+    for sym in symbols.iter() {
+        assert_eq!(string_value(&dict_field(sym, "kind")), "function");
+    }
+}
+
+#[test]
+fn outline_caps_depth_when_max_depth_supplied() {
+    let registry = ast_registry();
+    let path = fixture_path("python/source.py");
+    let payload = dict(&[
+        (
+            "path",
+            VmValue::String(Rc::from(path.to_string_lossy().as_ref())),
+        ),
+        ("max_depth", VmValue::Int(1)),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_outline", payload);
+    let items = list_value(&dict_field(&result, "items"));
+    assert!(!items.is_empty());
+    for item in items.iter() {
+        let children = list_value(&dict_field(item, "children"));
+        assert!(
+            children.is_empty(),
+            "max_depth=1 must cap to root level, got children {children:?}"
+        );
+    }
+}
+
+/// Perf smoke test from issue #564: parse a known file within a budget.
+/// We don't pin the exact cutoff because tree-sitter performance varies
+/// across CI machines, but a 20ms budget is comfortable on local dev
+/// hardware and gives ample headroom on CI.
+#[test]
+fn parse_file_meets_perf_budget_on_a_known_input() {
+    let registry = ast_registry();
+    // Use the largest fixture we ship (Rust). The issue suggests
+    // burin-code's `Package.swift` as a reference; running against an
+    // in-tree fixture keeps the test hermetic and CI-friendly.
+    let path = fixture_path("rust/source.rs");
+    let payload = dict(&[(
+        "path",
+        VmValue::String(Rc::from(path.to_string_lossy().as_ref())),
+    )]);
+
+    // Warm up: first call sometimes pays a one-time grammar load.
+    let _ = invoke(&registry, "hostlib_ast_parse_file", payload.clone());
+
+    let start = Instant::now();
+    let _ = invoke(&registry, "hostlib_ast_parse_file", payload);
+    let elapsed = start.elapsed();
+
+    // 20ms target from the issue. Doubled to 40ms here so the test is
+    // immune to noisy CI; the realistic warm-call latency is sub-1ms.
+    assert!(
+        elapsed.as_millis() < 40,
+        "parse_file took {elapsed:?} (>40ms ceiling)",
+    );
+}
+
+#[test]
+fn perf_smoke_against_burin_code_when_available() {
+    // The issue calls out `~/projects/burin-code/Package.swift`. That
+    // path only exists on the maintainer's box; skip silently otherwise
+    // so CI stays green.
+    let target = std::env::var("HOME")
+        .ok()
+        .map(|home| PathBuf::from(home).join("projects/burin-code/Package.swift"));
+    let Some(path) = target.filter(|p| p.exists()) else {
+        return;
+    };
+
+    let registry = ast_registry();
+    let payload = dict(&[(
+        "path",
+        VmValue::String(Rc::from(path.to_string_lossy().as_ref())),
+    )]);
+    let _warmup = invoke(&registry, "hostlib_ast_parse_file", payload.clone());
+    let start = Instant::now();
+    let _ = invoke(&registry, "hostlib_ast_parse_file", payload);
+    let elapsed = start.elapsed();
+    let bytes = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+    eprintln!(
+        "burin-code Package.swift parse_file: {elapsed:?} ({} bytes)",
+        bytes
+    );
+    assert!(
+        elapsed.as_millis() < 50,
+        "Package.swift parse took {elapsed:?} (>50ms)"
+    );
+}

--- a/crates/harn-hostlib/tests/ast_fixtures.rs
+++ b/crates/harn-hostlib/tests/ast_fixtures.rs
@@ -1,0 +1,246 @@
+//! Fixture-based golden tests for the `ast::*` builtins (issue #564).
+//!
+//! Layout: `tests/fixtures/ast/<language>/source.<ext>` paired with two
+//! goldens — `symbols.golden.json` and `outline.golden.json` — generated
+//! from the live extractor. Adding a new language is: drop in a source
+//! file, set `HARN_AST_UPDATE_GOLDEN=1`, run the test, commit. The
+//! per-language goldens are the contract burin-code's bridge consumer
+//! checks against, so changes here are visible in code review.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use harn_hostlib::ast::{api, Language, OutlineItem, Symbol};
+
+const UPDATE_GOLDEN_ENV: &str = "HARN_AST_UPDATE_GOLDEN";
+
+/// Walk every language fixture and compare its symbols/outline against
+/// the goldens. One Rust test rather than 22 keeps the file lean and
+/// makes failures easy to scan.
+#[test]
+fn every_language_fixture_matches_its_golden() {
+    let fixtures_root = manifest_dir().join("tests/fixtures/ast");
+    let mut fixture_dirs: Vec<PathBuf> = fs::read_dir(&fixtures_root)
+        .unwrap_or_else(|err| panic!("read fixtures dir {}: {err}", fixtures_root.display()))
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .map(|entry| entry.path())
+        .collect();
+    fixture_dirs.sort();
+
+    assert!(
+        !fixture_dirs.is_empty(),
+        "no language fixtures under {}",
+        fixtures_root.display()
+    );
+
+    let update = std::env::var(UPDATE_GOLDEN_ENV).is_ok();
+    let mut failures: Vec<String> = Vec::new();
+
+    for dir in &fixture_dirs {
+        if let Err(message) = run_fixture(dir, update) {
+            failures.push(format!(
+                "[{}] {message}",
+                dir.file_name().unwrap().to_string_lossy()
+            ));
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "{} fixture(s) failed:\n  - {}\n\nRe-run with {UPDATE_GOLDEN_ENV}=1 to regenerate goldens.",
+            failures.len(),
+            failures.join("\n  - "),
+        );
+    }
+}
+
+/// Every shipped language must have a fixture. Catches "I added a new
+/// language but forgot the fixture" in code review.
+#[test]
+fn every_language_has_a_fixture() {
+    let fixtures_root = manifest_dir().join("tests/fixtures/ast");
+    let dirs: std::collections::HashSet<String> = fs::read_dir(&fixtures_root)
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .map(|entry| entry.file_name().to_string_lossy().to_string())
+        .collect();
+    let missing: Vec<&str> = Language::all()
+        .iter()
+        .map(|l| l.name())
+        .filter(|name| !dirs.contains(*name))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "languages without fixtures: {missing:?} (under {})",
+        fixtures_root.display()
+    );
+}
+
+fn run_fixture(dir: &Path, update: bool) -> Result<(), String> {
+    let language_name = dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| format!("non-UTF8 fixture dir {}", dir.display()))?;
+    let language = Language::from_name(language_name)
+        .ok_or_else(|| format!("unknown language `{language_name}`"))?;
+
+    let source_path =
+        find_source(dir).ok_or_else(|| format!("no source.* file under {}", dir.display()))?;
+
+    let (_, symbols) = api::symbols(&source_path, Some(language.name()))
+        .map_err(|err| format!("symbols extraction failed: {err}"))?;
+    let (_, outline) = api::outline(&source_path, Some(language.name()))
+        .map_err(|err| format!("outline build failed: {err}"))?;
+
+    compare_or_update(
+        &dir.join("symbols.golden.json"),
+        &symbols_to_json(&symbols),
+        update,
+    )?;
+    compare_or_update(
+        &dir.join("outline.golden.json"),
+        &outline_to_json(&outline),
+        update,
+    )?;
+    Ok(())
+}
+
+fn find_source(dir: &Path) -> Option<PathBuf> {
+    fs::read_dir(dir)
+        .ok()?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .find(|path| {
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .map(|name| name == "source")
+                .unwrap_or(false)
+                && path.extension().is_some()
+        })
+}
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn compare_or_update(path: &Path, actual: &str, update: bool) -> Result<(), String> {
+    let pretty = format!("{actual}\n");
+    if update || !path.exists() {
+        fs::write(path, &pretty).map_err(|err| format!("write {}: {err}", path.display()))?;
+        return Ok(());
+    }
+    let expected =
+        fs::read_to_string(path).map_err(|err| format!("read {}: {err}", path.display()))?;
+    if expected != pretty {
+        // Compute a small diff so the failure message is actionable.
+        let mismatch = first_mismatch(&expected, &pretty);
+        return Err(format!(
+            "golden {} does not match (first mismatch: {})\n--- expected\n{expected}\n+++ actual\n{pretty}",
+            path.display(),
+            mismatch,
+        ));
+    }
+    Ok(())
+}
+
+fn first_mismatch(a: &str, b: &str) -> String {
+    for (line, (la, lb)) in (1..).zip(a.lines().zip(b.lines())) {
+        if la != lb {
+            return format!("line {line}: `{la}` vs `{lb}`");
+        }
+    }
+    if a.lines().count() != b.lines().count() {
+        return format!(
+            "different line counts: {} vs {}",
+            a.lines().count(),
+            b.lines().count()
+        );
+    }
+    "trailing whitespace".into()
+}
+
+fn symbols_to_json(symbols: &[Symbol]) -> String {
+    let mut out = String::from("[\n");
+    for (i, sym) in symbols.iter().enumerate() {
+        let comma = if i + 1 == symbols.len() { "" } else { "," };
+        out.push_str(&format!(
+            "  {{\"name\":{}, \"kind\":\"{}\", \"container\":{}, \"signature\":{}, \"start_row\":{}, \"start_col\":{}, \"end_row\":{}, \"end_col\":{}}}{comma}\n",
+            quote(&sym.name),
+            sym.kind.as_str(),
+            sym.container
+                .as_ref()
+                .map(|s| quote(s))
+                .unwrap_or_else(|| "null".into()),
+            quote(&sym.signature),
+            sym.start_row,
+            sym.start_col,
+            sym.end_row,
+            sym.end_col,
+        ));
+    }
+    out.push(']');
+    out
+}
+
+fn outline_to_json(items: &[OutlineItem]) -> String {
+    let mut out = String::new();
+    write_outline_items(&mut out, items, 0);
+    out
+}
+
+fn write_outline_items(buf: &mut String, items: &[OutlineItem], depth: usize) {
+    let indent = "  ".repeat(depth);
+    if items.is_empty() {
+        buf.push_str(&indent);
+        buf.push_str("[]");
+        return;
+    }
+    buf.push_str(&indent);
+    buf.push_str("[\n");
+    for (i, item) in items.iter().enumerate() {
+        let inner = "  ".repeat(depth + 1);
+        buf.push_str(&inner);
+        buf.push_str(&format!(
+            "{{\"name\":{}, \"kind\":\"{}\", \"signature\":{}, \"start_row\":{}, \"end_row\":{}, \"children\":",
+            quote(&item.name),
+            item.kind.as_str(),
+            quote(&item.signature),
+            item.start_row,
+            item.end_row,
+        ));
+        if item.children.is_empty() {
+            buf.push_str("[]}");
+        } else {
+            buf.push('\n');
+            write_outline_items(buf, &item.children, depth + 2);
+            buf.push('\n');
+            buf.push_str(&inner);
+            buf.push('}');
+        }
+        if i + 1 < items.len() {
+            buf.push(',');
+        }
+        buf.push('\n');
+    }
+    buf.push_str(&indent);
+    buf.push(']');
+}
+
+fn quote(s: &str) -> String {
+    let mut out = String::from("\"");
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}

--- a/crates/harn-hostlib/tests/fixtures/ast/bash/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/bash/outline.golden.json
@@ -1,0 +1,5 @@
+[
+  {"name":"greet", "kind":"function", "signature":"function greet", "start_row":2, "end_row":4, "children":[]},
+  {"name":"shout", "kind":"function", "signature":"function shout", "start_row":6, "end_row":8, "children":[]},
+  {"name":"main", "kind":"function", "signature":"function main", "start_row":10, "end_row":13, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/bash/source.sh
+++ b/crates/harn-hostlib/tests/fixtures/ast/bash/source.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+greet() {
+    echo "hello $1"
+}
+
+function shout {
+    echo "$1" | tr '[:lower:]' '[:upper:]'
+}
+
+main() {
+    greet "world"
+    shout "hi"
+}
+
+main "$@"

--- a/crates/harn-hostlib/tests/fixtures/ast/bash/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/bash/symbols.golden.json
@@ -1,0 +1,5 @@
+[
+  {"name":"greet", "kind":"function", "container":null, "signature":"function greet", "start_row":2, "start_col":0, "end_row":4, "end_col":1},
+  {"name":"shout", "kind":"function", "container":null, "signature":"function shout", "start_row":6, "start_col":0, "end_row":8, "end_col":1},
+  {"name":"main", "kind":"function", "container":null, "signature":"function main", "start_row":10, "start_col":0, "end_row":13, "end_col":1}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/c/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/c/outline.golden.json
@@ -1,0 +1,8 @@
+[
+  {"name":"Greeter", "kind":"struct", "signature":"struct Greeter", "start_row":2, "end_row":4, "children":[]},
+  {"name":"Color", "kind":"enum", "signature":"enum Color", "start_row":6, "end_row":10, "children":[]},
+  {"name":"Counter", "kind":"type", "signature":"typedef Counter", "start_row":12, "end_row":12, "children":[]},
+  {"name":"add", "kind":"function", "signature":"add(int a, int b)", "start_row":14, "end_row":16, "children":[]},
+  {"name":"greet", "kind":"function", "signature":"greet(struct Greeter *g)", "start_row":18, "end_row":20, "children":[]},
+  {"name":"Greeter", "kind":"struct", "signature":"struct Greeter", "start_row":18, "end_row":18, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/c/source.c
+++ b/crates/harn-hostlib/tests/fixtures/ast/c/source.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+
+struct Greeter {
+    const char *name;
+};
+
+enum Color {
+    RED,
+    GREEN,
+    BLUE
+};
+
+typedef int Counter;
+
+int add(int a, int b) {
+    return a + b;
+}
+
+void greet(struct Greeter *g) {
+    printf("hello %s\n", g->name);
+}

--- a/crates/harn-hostlib/tests/fixtures/ast/c/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/c/symbols.golden.json
@@ -1,0 +1,8 @@
+[
+  {"name":"Greeter", "kind":"struct", "container":null, "signature":"struct Greeter", "start_row":2, "start_col":0, "end_row":4, "end_col":1},
+  {"name":"Color", "kind":"enum", "container":null, "signature":"enum Color", "start_row":6, "start_col":0, "end_row":10, "end_col":1},
+  {"name":"Counter", "kind":"type", "container":null, "signature":"typedef Counter", "start_row":12, "start_col":0, "end_row":12, "end_col":20},
+  {"name":"add", "kind":"function", "container":null, "signature":"add(int a, int b)", "start_row":14, "start_col":0, "end_row":16, "end_col":1},
+  {"name":"greet", "kind":"function", "container":null, "signature":"greet(struct Greeter *g)", "start_row":18, "start_col":0, "end_row":20, "end_col":1},
+  {"name":"Greeter", "kind":"struct", "container":null, "signature":"struct Greeter", "start_row":18, "start_col":11, "end_row":18, "end_col":25}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/cpp/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/cpp/outline.golden.json
@@ -1,0 +1,15 @@
+[
+  {"name":"fixture", "kind":"module", "signature":"namespace fixture", "start_row":0, "end_row":22, "children":
+    [
+      {"name":"Greeter", "kind":"class", "signature":"class Greeter", "start_row":2, "end_row":9, "children":
+        [
+          {"name":"Greeter", "kind":"method", "signature":"Greeter(const char *name)", "start_row":4, "end_row":4, "children":[]},
+          {"name":"greet", "kind":"method", "signature":"greet()", "start_row":5, "end_row":5, "children":[]}
+        ]
+      },
+      {"name":"Point", "kind":"struct", "signature":"struct Point", "start_row":11, "end_row":14, "children":[]},
+      {"name":"Color", "kind":"enum", "signature":"enum Color", "start_row":16, "end_row":16, "children":[]},
+      {"name":"add", "kind":"method", "signature":"add(int a, int b)", "start_row":18, "end_row":20, "children":[]}
+    ]
+  }
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/cpp/source.cpp
+++ b/crates/harn-hostlib/tests/fixtures/ast/cpp/source.cpp
@@ -1,0 +1,23 @@
+namespace fixture {
+
+class Greeter {
+public:
+    Greeter(const char *name) : name_(name) {}
+    std::string greet() const { return std::string("hello ") + name_; }
+
+private:
+    const char *name_;
+};
+
+struct Point {
+    int x;
+    int y;
+};
+
+enum Color { RED, GREEN, BLUE };
+
+int add(int a, int b) {
+    return a + b;
+}
+
+}

--- a/crates/harn-hostlib/tests/fixtures/ast/cpp/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/cpp/symbols.golden.json
@@ -1,0 +1,9 @@
+[
+  {"name":"fixture", "kind":"module", "container":null, "signature":"namespace fixture", "start_row":0, "start_col":0, "end_row":22, "end_col":1},
+  {"name":"Greeter", "kind":"class", "container":"fixture", "signature":"class Greeter", "start_row":2, "start_col":0, "end_row":9, "end_col":1},
+  {"name":"Greeter", "kind":"method", "container":"Greeter", "signature":"Greeter(const char *name)", "start_row":4, "start_col":4, "end_row":4, "end_col":46},
+  {"name":"greet", "kind":"method", "container":"Greeter", "signature":"greet()", "start_row":5, "start_col":4, "end_row":5, "end_col":71},
+  {"name":"Point", "kind":"struct", "container":"fixture", "signature":"struct Point", "start_row":11, "start_col":0, "end_row":14, "end_col":1},
+  {"name":"Color", "kind":"enum", "container":"fixture", "signature":"enum Color", "start_row":16, "start_col":0, "end_row":16, "end_col":31},
+  {"name":"add", "kind":"method", "container":"fixture", "signature":"add(int a, int b)", "start_row":18, "start_col":0, "end_row":20, "end_col":1}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/csharp/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/csharp/outline.golden.json
@@ -1,0 +1,18 @@
+[
+  {"name":"Fixture", "kind":"module", "signature":"namespace Fixture", "start_row":0, "end_row":23, "children":
+    [
+      {"name":"Greeter", "kind":"class", "signature":"class Greeter", "start_row":2, "end_row":10, "children":
+        [
+          {"name":"Name", "kind":"variable", "signature":"string Name", "start_row":4, "end_row":4, "children":[]},
+          {"name":"Greet", "kind":"method", "signature":"string Greet()", "start_row":6, "end_row":9, "children":[]}
+        ]
+      },
+      {"name":"ISpeaker", "kind":"interface", "signature":"interface ISpeaker", "start_row":12, "end_row":15, "children":
+        [
+          {"name":"Speak", "kind":"method", "signature":"string Speak()", "start_row":14, "end_row":14, "children":[]}
+        ]
+      },
+      {"name":"Color", "kind":"enum", "signature":"enum Color", "start_row":17, "end_row":22, "children":[]}
+    ]
+  }
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/csharp/source.cs
+++ b/crates/harn-hostlib/tests/fixtures/ast/csharp/source.cs
@@ -1,0 +1,24 @@
+namespace Fixture
+{
+    public class Greeter
+    {
+        public string Name { get; set; }
+
+        public string Greet()
+        {
+            return "hello " + Name;
+        }
+    }
+
+    public interface ISpeaker
+    {
+        string Speak();
+    }
+
+    public enum Color
+    {
+        Red,
+        Green,
+        Blue
+    }
+}

--- a/crates/harn-hostlib/tests/fixtures/ast/csharp/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/csharp/symbols.golden.json
@@ -1,0 +1,9 @@
+[
+  {"name":"Fixture", "kind":"module", "container":null, "signature":"namespace Fixture", "start_row":0, "start_col":0, "end_row":23, "end_col":1},
+  {"name":"Greeter", "kind":"class", "container":"Fixture", "signature":"class Greeter", "start_row":2, "start_col":4, "end_row":10, "end_col":5},
+  {"name":"Name", "kind":"variable", "container":"Greeter", "signature":"string Name", "start_row":4, "start_col":8, "end_row":4, "end_col":40},
+  {"name":"Greet", "kind":"method", "container":"Greeter", "signature":"string Greet()", "start_row":6, "start_col":8, "end_row":9, "end_col":9},
+  {"name":"ISpeaker", "kind":"interface", "container":"Fixture", "signature":"interface ISpeaker", "start_row":12, "start_col":4, "end_row":15, "end_col":5},
+  {"name":"Speak", "kind":"method", "container":"ISpeaker", "signature":"string Speak()", "start_row":14, "start_col":8, "end_row":14, "end_col":23},
+  {"name":"Color", "kind":"enum", "container":"Fixture", "signature":"enum Color", "start_row":17, "start_col":4, "end_row":22, "end_col":5}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/elixir/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/elixir/outline.golden.json
@@ -1,0 +1,13 @@
+[
+  {"name":"Fixture.Greeter", "kind":"module", "signature":"defmodule Fixture.Greeter", "start_row":0, "end_row":8, "children":
+    [
+      {"name":"greet", "kind":"method", "signature":"def greet(name)", "start_row":1, "end_row":3, "children":[]},
+      {"name":"internal_helper", "kind":"method", "signature":"defp internal_helper(s)", "start_row":5, "end_row":7, "children":[]}
+    ]
+  },
+  {"name":"Fixture.Shout", "kind":"module", "signature":"defmodule Fixture.Shout", "start_row":10, "end_row":12, "children":
+    [
+      {"name":"shout", "kind":"method", "signature":"def shout(s), do: String.upcase(s)", "start_row":11, "end_row":11, "children":[]}
+    ]
+  }
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/elixir/source.ex
+++ b/crates/harn-hostlib/tests/fixtures/ast/elixir/source.ex
@@ -1,0 +1,13 @@
+defmodule Fixture.Greeter do
+  def greet(name) do
+    "hello #{name}"
+  end
+
+  defp internal_helper(s) do
+    s
+  end
+end
+
+defmodule Fixture.Shout do
+  def shout(s), do: String.upcase(s)
+end

--- a/crates/harn-hostlib/tests/fixtures/ast/elixir/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/elixir/symbols.golden.json
@@ -1,0 +1,7 @@
+[
+  {"name":"Fixture.Greeter", "kind":"module", "container":null, "signature":"defmodule Fixture.Greeter", "start_row":0, "start_col":0, "end_row":8, "end_col":3},
+  {"name":"greet", "kind":"method", "container":"Fixture.Greeter", "signature":"def greet(name)", "start_row":1, "start_col":2, "end_row":3, "end_col":5},
+  {"name":"internal_helper", "kind":"method", "container":"Fixture.Greeter", "signature":"defp internal_helper(s)", "start_row":5, "start_col":2, "end_row":7, "end_col":5},
+  {"name":"Fixture.Shout", "kind":"module", "container":null, "signature":"defmodule Fixture.Shout", "start_row":10, "start_col":0, "end_row":12, "end_col":3},
+  {"name":"shout", "kind":"method", "container":"Fixture.Shout", "signature":"def shout(s), do: String.upcase(s)", "start_row":11, "start_col":2, "end_row":11, "end_col":36}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/go/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/go/outline.golden.json
@@ -1,0 +1,8 @@
+[
+  {"name":"fixture", "kind":"module", "signature":"package fixture", "start_row":0, "end_row":0, "children":[]},
+  {"name":"Greeter", "kind":"struct", "signature":"type Greeter struct", "start_row":2, "end_row":4, "children":[]},
+  {"name":"Speaker", "kind":"interface", "signature":"type Speaker interface", "start_row":6, "end_row":8, "children":[]},
+  {"name":"Greet", "kind":"method", "signature":"func (g Greeter) Greet()", "start_row":10, "end_row":12, "children":[]},
+  {"name":"Shout", "kind":"function", "signature":"func Shout(s string)", "start_row":14, "end_row":16, "children":[]},
+  {"name":"TestSomething", "kind":"function", "signature":"[test] func TestSomething()", "start_row":18, "end_row":18, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/go/source.go
+++ b/crates/harn-hostlib/tests/fixtures/ast/go/source.go
@@ -1,0 +1,19 @@
+package fixture
+
+type Greeter struct {
+	Name string
+}
+
+type Speaker interface {
+	Speak() string
+}
+
+func (g Greeter) Greet() string {
+	return "hello " + g.Name
+}
+
+func Shout(s string) string {
+	return s
+}
+
+func TestSomething() {}

--- a/crates/harn-hostlib/tests/fixtures/ast/go/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/go/symbols.golden.json
@@ -1,0 +1,8 @@
+[
+  {"name":"fixture", "kind":"module", "container":null, "signature":"package fixture", "start_row":0, "start_col":0, "end_row":0, "end_col":15},
+  {"name":"Greeter", "kind":"struct", "container":null, "signature":"type Greeter struct", "start_row":2, "start_col":0, "end_row":4, "end_col":1},
+  {"name":"Speaker", "kind":"interface", "container":null, "signature":"type Speaker interface", "start_row":6, "start_col":0, "end_row":8, "end_col":1},
+  {"name":"Greet", "kind":"method", "container":null, "signature":"func (g Greeter) Greet()", "start_row":10, "start_col":0, "end_row":12, "end_col":1},
+  {"name":"Shout", "kind":"function", "container":null, "signature":"func Shout(s string)", "start_row":14, "start_col":0, "end_row":16, "end_col":1},
+  {"name":"TestSomething", "kind":"function", "container":null, "signature":"[test] func TestSomething()", "start_row":18, "start_col":0, "end_row":18, "end_col":23}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/haskell/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/haskell/outline.golden.json
@@ -1,0 +1,11 @@
+[
+  {"name":"Counter", "kind":"type", "signature":"newtype Counter", "start_row":4, "end_row":4, "children":[]},
+  {"name":"Speaker", "kind":"interface", "signature":"class Speaker", "start_row":6, "end_row":7, "children":
+    [
+      {"name":"a", "kind":"function", "signature":"a", "start_row":7, "end_row":7, "children":[]}
+    ]
+  },
+  {"name":"String", "kind":"function", "signature":"String", "start_row":9, "end_row":9, "children":[]},
+  {"name":"greet", "kind":"function", "signature":"greet", "start_row":10, "end_row":10, "children":[]},
+  {"name":"String", "kind":"function", "signature":"String", "start_row":12, "end_row":12, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/haskell/source.hs
+++ b/crates/harn-hostlib/tests/fixtures/ast/haskell/source.hs
@@ -1,0 +1,14 @@
+module Fixture where
+
+data Color = Red | Green | Blue
+
+newtype Counter = Counter Int
+
+class Speaker a where
+  speak :: a -> String
+
+greet :: String -> String
+greet name = "hello " ++ name
+
+shout :: String -> String
+shout = map toUpper

--- a/crates/harn-hostlib/tests/fixtures/ast/haskell/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/haskell/symbols.golden.json
@@ -1,0 +1,8 @@
+[
+  {"name":"Counter", "kind":"type", "container":null, "signature":"newtype Counter", "start_row":4, "start_col":0, "end_row":4, "end_col":29},
+  {"name":"Speaker", "kind":"interface", "container":null, "signature":"class Speaker", "start_row":6, "start_col":0, "end_row":7, "end_col":22},
+  {"name":"a", "kind":"function", "container":"Speaker", "signature":"a", "start_row":7, "start_col":11, "end_row":7, "end_col":22},
+  {"name":"String", "kind":"function", "container":null, "signature":"String", "start_row":9, "start_col":9, "end_row":9, "end_col":25},
+  {"name":"greet", "kind":"function", "container":null, "signature":"greet", "start_row":10, "start_col":0, "end_row":10, "end_col":29},
+  {"name":"String", "kind":"function", "container":null, "signature":"String", "start_row":12, "start_col":9, "end_row":12, "end_col":25}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/java/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/java/outline.golden.json
@@ -1,0 +1,14 @@
+[
+  {"name":"Greeter", "kind":"class", "signature":"class Greeter", "start_row":0, "end_row":10, "children":
+    [
+      {"name":"Greeter", "kind":"method", "signature":"Greeter(String name)", "start_row":3, "end_row":5, "children":[]},
+      {"name":"greet", "kind":"method", "signature":"String greet()", "start_row":7, "end_row":9, "children":[]}
+    ]
+  },
+  {"name":"Speaker", "kind":"interface", "signature":"interface Speaker", "start_row":12, "end_row":14, "children":
+    [
+      {"name":"speak", "kind":"method", "signature":"String speak()", "start_row":13, "end_row":13, "children":[]}
+    ]
+  },
+  {"name":"Color", "kind":"enum", "signature":"enum Color", "start_row":16, "end_row":20, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/java/source.java
+++ b/crates/harn-hostlib/tests/fixtures/ast/java/source.java
@@ -1,0 +1,21 @@
+public class Greeter {
+    private final String name;
+
+    public Greeter(String name) {
+        this.name = name;
+    }
+
+    public String greet() {
+        return "hello " + name;
+    }
+}
+
+interface Speaker {
+    String speak();
+}
+
+enum Color {
+    RED,
+    GREEN,
+    BLUE
+}

--- a/crates/harn-hostlib/tests/fixtures/ast/java/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/java/symbols.golden.json
@@ -1,0 +1,8 @@
+[
+  {"name":"Greeter", "kind":"class", "container":null, "signature":"class Greeter", "start_row":0, "start_col":0, "end_row":10, "end_col":1},
+  {"name":"Greeter", "kind":"method", "container":"Greeter", "signature":"Greeter(String name)", "start_row":3, "start_col":4, "end_row":5, "end_col":5},
+  {"name":"greet", "kind":"method", "container":"Greeter", "signature":"String greet()", "start_row":7, "start_col":4, "end_row":9, "end_col":5},
+  {"name":"Speaker", "kind":"interface", "container":null, "signature":"interface Speaker", "start_row":12, "start_col":0, "end_row":14, "end_col":1},
+  {"name":"speak", "kind":"method", "container":"Speaker", "signature":"String speak()", "start_row":13, "start_col":4, "end_row":13, "end_col":19},
+  {"name":"Color", "kind":"enum", "container":null, "signature":"enum Color", "start_row":16, "start_col":0, "end_row":20, "end_col":1}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/javascript/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/javascript/outline.golden.json
@@ -1,0 +1,11 @@
+[
+  {"name":"Counter", "kind":"class", "signature":"class Counter", "start_row":0, "end_row":7, "children":
+    [
+      {"name":"constructor", "kind":"method", "signature":"constructor()", "start_row":1, "end_row":3, "children":[]},
+      {"name":"increment", "kind":"method", "signature":"increment()", "start_row":4, "end_row":6, "children":[]}
+    ]
+  },
+  {"name":"addOne", "kind":"function", "signature":"function addOne(n)", "start_row":9, "end_row":11, "children":[]},
+  {"name":"square", "kind":"function", "signature":"const square = (...) =>", "start_row":13, "end_row":13, "children":[]},
+  {"name":"VERSION", "kind":"variable", "signature":"const VERSION = \"1.0\";", "start_row":15, "end_row":15, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/javascript/source.js
+++ b/crates/harn-hostlib/tests/fixtures/ast/javascript/source.js
@@ -1,0 +1,16 @@
+class Counter {
+    constructor() {
+        this.value = 0;
+    }
+    increment() {
+        this.value += 1;
+    }
+}
+
+function addOne(n) {
+    return n + 1;
+}
+
+const square = (n) => n * n;
+
+const VERSION = "1.0";

--- a/crates/harn-hostlib/tests/fixtures/ast/javascript/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/javascript/symbols.golden.json
@@ -1,0 +1,8 @@
+[
+  {"name":"Counter", "kind":"class", "container":null, "signature":"class Counter", "start_row":0, "start_col":0, "end_row":7, "end_col":1},
+  {"name":"constructor", "kind":"method", "container":"Counter", "signature":"constructor()", "start_row":1, "start_col":4, "end_row":3, "end_col":5},
+  {"name":"increment", "kind":"method", "container":"Counter", "signature":"increment()", "start_row":4, "start_col":4, "end_row":6, "end_col":5},
+  {"name":"addOne", "kind":"function", "container":null, "signature":"function addOne(n)", "start_row":9, "start_col":0, "end_row":11, "end_col":1},
+  {"name":"square", "kind":"function", "container":null, "signature":"const square = (...) =>", "start_row":13, "start_col":0, "end_row":13, "end_col":28},
+  {"name":"VERSION", "kind":"variable", "container":null, "signature":"const VERSION = \"1.0\";", "start_row":15, "start_col":0, "end_row":15, "end_col":22}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/jsx/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/jsx/outline.golden.json
@@ -1,0 +1,9 @@
+[
+  {"name":"Header", "kind":"class", "signature":"class Header", "start_row":0, "end_row":7, "children":
+    [
+      {"name":"constructor", "kind":"method", "signature":"constructor(title)", "start_row":1, "end_row":3, "children":[]},
+      {"name":"render", "kind":"method", "signature":"render()", "start_row":4, "end_row":6, "children":[]}
+    ]
+  },
+  {"name":"shout", "kind":"function", "signature":"function shout(text)", "start_row":9, "end_row":11, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/jsx/source.jsx
+++ b/crates/harn-hostlib/tests/fixtures/ast/jsx/source.jsx
@@ -1,0 +1,12 @@
+class Header {
+    constructor(title) {
+        this.title = title;
+    }
+    render() {
+        return <h1>{this.title}</h1>;
+    }
+}
+
+function shout(text) {
+    return text.toUpperCase();
+}

--- a/crates/harn-hostlib/tests/fixtures/ast/jsx/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/jsx/symbols.golden.json
@@ -1,0 +1,6 @@
+[
+  {"name":"Header", "kind":"class", "container":null, "signature":"class Header", "start_row":0, "start_col":0, "end_row":7, "end_col":1},
+  {"name":"constructor", "kind":"method", "container":"Header", "signature":"constructor(title)", "start_row":1, "start_col":4, "end_row":3, "end_col":5},
+  {"name":"render", "kind":"method", "container":"Header", "signature":"render()", "start_row":4, "start_col":4, "end_row":6, "end_col":5},
+  {"name":"shout", "kind":"function", "container":null, "signature":"function shout(text)", "start_row":9, "start_col":0, "end_row":11, "end_col":1}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/kotlin/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/kotlin/outline.golden.json
@@ -1,0 +1,19 @@
+[
+  {"name":"Speaker", "kind":"interface", "signature":"interface Speaker", "start_row":0, "end_row":2, "children":
+    [
+      {"name":"speak", "kind":"method", "signature":"fun speak", "start_row":1, "end_row":1, "children":[]}
+    ]
+  },
+  {"name":"Greeter", "kind":"class", "signature":"class Greeter", "start_row":4, "end_row":12, "children":
+    [
+      {"name":"speak", "kind":"method", "signature":"fun speak", "start_row":5, "end_row":7, "children":[]},
+      {"name":"shout", "kind":"method", "signature":"fun shout", "start_row":9, "end_row":11, "children":[]}
+    ]
+  },
+  {"name":"Defaults", "kind":"class", "signature":"object Defaults", "start_row":14, "end_row":16, "children":
+    [
+      {"name":"world", "kind":"method", "signature":"fun world", "start_row":15, "end_row":15, "children":[]}
+    ]
+  },
+  {"name":"globalShout", "kind":"function", "signature":"fun globalShout", "start_row":18, "end_row":18, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/kotlin/source.kt
+++ b/crates/harn-hostlib/tests/fixtures/ast/kotlin/source.kt
@@ -1,0 +1,19 @@
+interface Speaker {
+    fun speak(): String
+}
+
+class Greeter(val name: String) : Speaker {
+    override fun speak(): String {
+        return "hello $name"
+    }
+
+    fun shout(message: String): String {
+        return message.uppercase()
+    }
+}
+
+object Defaults {
+    fun world(): Greeter = Greeter("world")
+}
+
+fun globalShout(s: String): String = s.uppercase()

--- a/crates/harn-hostlib/tests/fixtures/ast/kotlin/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/kotlin/symbols.golden.json
@@ -1,0 +1,10 @@
+[
+  {"name":"Speaker", "kind":"interface", "container":null, "signature":"interface Speaker", "start_row":0, "start_col":0, "end_row":2, "end_col":1},
+  {"name":"speak", "kind":"method", "container":"Speaker", "signature":"fun speak", "start_row":1, "start_col":4, "end_row":1, "end_col":23},
+  {"name":"Greeter", "kind":"class", "container":null, "signature":"class Greeter", "start_row":4, "start_col":0, "end_row":12, "end_col":1},
+  {"name":"speak", "kind":"method", "container":"Greeter", "signature":"fun speak", "start_row":5, "start_col":4, "end_row":7, "end_col":5},
+  {"name":"shout", "kind":"method", "container":"Greeter", "signature":"fun shout", "start_row":9, "start_col":4, "end_row":11, "end_col":5},
+  {"name":"Defaults", "kind":"class", "container":null, "signature":"object Defaults", "start_row":14, "start_col":0, "end_row":16, "end_col":1},
+  {"name":"world", "kind":"method", "container":"Defaults", "signature":"fun world", "start_row":15, "start_col":4, "end_row":15, "end_col":43},
+  {"name":"globalShout", "kind":"function", "container":null, "signature":"fun globalShout", "start_row":18, "start_col":0, "end_row":18, "end_col":50}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/lua/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/lua/outline.golden.json
@@ -1,0 +1,5 @@
+[
+  {"name":"M.greet", "kind":"function", "signature":"function M.greet(name)", "start_row":2, "end_row":4, "children":[]},
+  {"name":"M:shout", "kind":"method", "signature":"function M:shout(message)", "start_row":6, "end_row":8, "children":[]},
+  {"name":"helper", "kind":"function", "signature":"function helper(x)", "start_row":10, "end_row":12, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/lua/source.lua
+++ b/crates/harn-hostlib/tests/fixtures/ast/lua/source.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+function M.greet(name)
+    return "hello " .. name
+end
+
+function M:shout(message)
+    return message:upper()
+end
+
+local function helper(x)
+    return x + 1
+end
+
+return M

--- a/crates/harn-hostlib/tests/fixtures/ast/lua/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/lua/symbols.golden.json
@@ -1,0 +1,5 @@
+[
+  {"name":"M.greet", "kind":"function", "container":null, "signature":"function M.greet(name)", "start_row":2, "start_col":0, "end_row":4, "end_col":3},
+  {"name":"M:shout", "kind":"method", "container":null, "signature":"function M:shout(message)", "start_row":6, "start_col":0, "end_row":8, "end_col":3},
+  {"name":"helper", "kind":"function", "container":null, "signature":"function helper(x)", "start_row":10, "start_col":0, "end_row":12, "end_col":3}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/php/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/php/outline.golden.json
@@ -1,0 +1,14 @@
+[
+  {"name":"Greeter", "kind":"class", "signature":"class Greeter", "start_row":2, "end_row":12, "children":
+    [
+      {"name":"__construct", "kind":"method", "signature":"__construct(string $name)", "start_row":5, "end_row":7, "children":[]},
+      {"name":"greet", "kind":"method", "signature":"greet()", "start_row":9, "end_row":11, "children":[]}
+    ]
+  },
+  {"name":"Speaker", "kind":"interface", "signature":"interface Speaker", "start_row":14, "end_row":16, "children":
+    [
+      {"name":"speak", "kind":"method", "signature":"speak()", "start_row":15, "end_row":15, "children":[]}
+    ]
+  },
+  {"name":"shout", "kind":"function", "signature":"function shout(string $s)", "start_row":18, "end_row":20, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/php/source.php
+++ b/crates/harn-hostlib/tests/fixtures/ast/php/source.php
@@ -1,0 +1,21 @@
+<?php
+
+class Greeter {
+    private string $name;
+
+    public function __construct(string $name) {
+        $this->name = $name;
+    }
+
+    public function greet(): string {
+        return "hello " . $this->name;
+    }
+}
+
+interface Speaker {
+    public function speak(): string;
+}
+
+function shout(string $s): string {
+    return strtoupper($s);
+}

--- a/crates/harn-hostlib/tests/fixtures/ast/php/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/php/symbols.golden.json
@@ -1,0 +1,8 @@
+[
+  {"name":"Greeter", "kind":"class", "container":null, "signature":"class Greeter", "start_row":2, "start_col":0, "end_row":12, "end_col":1},
+  {"name":"__construct", "kind":"method", "container":"Greeter", "signature":"__construct(string $name)", "start_row":5, "start_col":4, "end_row":7, "end_col":5},
+  {"name":"greet", "kind":"method", "container":"Greeter", "signature":"greet()", "start_row":9, "start_col":4, "end_row":11, "end_col":5},
+  {"name":"Speaker", "kind":"interface", "container":null, "signature":"interface Speaker", "start_row":14, "start_col":0, "end_row":16, "end_col":1},
+  {"name":"speak", "kind":"method", "container":"Speaker", "signature":"speak()", "start_row":15, "start_col":4, "end_row":15, "end_col":36},
+  {"name":"shout", "kind":"function", "container":null, "signature":"function shout(string $s)", "start_row":18, "start_col":0, "end_row":20, "end_col":1}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/python/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/python/outline.golden.json
@@ -1,0 +1,10 @@
+[
+  {"name":"Greeter", "kind":"class", "signature":"class Greeter", "start_row":0, "end_row":5, "children":
+    [
+      {"name":"__init__", "kind":"method", "signature":"def __init__(name)", "start_row":1, "end_row":2, "children":[]},
+      {"name":"greet", "kind":"method", "signature":"def greet()", "start_row":4, "end_row":5, "children":[]}
+    ]
+  },
+  {"name":"shout", "kind":"function", "signature":"def shout(message)", "start_row":8, "end_row":9, "children":[]},
+  {"name":"fetch", "kind":"function", "signature":"def fetch(url)", "start_row":12, "end_row":13, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/python/source.py
+++ b/crates/harn-hostlib/tests/fixtures/ast/python/source.py
@@ -1,0 +1,14 @@
+class Greeter:
+    def __init__(self, name):
+        self.name = name
+
+    def greet(self):
+        return f"hello {self.name}"
+
+
+def shout(message):
+    return message.upper()
+
+
+async def fetch(url):
+    return url

--- a/crates/harn-hostlib/tests/fixtures/ast/python/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/python/symbols.golden.json
@@ -1,0 +1,7 @@
+[
+  {"name":"Greeter", "kind":"class", "container":null, "signature":"class Greeter", "start_row":0, "start_col":0, "end_row":5, "end_col":35},
+  {"name":"__init__", "kind":"method", "container":"Greeter", "signature":"def __init__(name)", "start_row":1, "start_col":4, "end_row":2, "end_col":24},
+  {"name":"greet", "kind":"method", "container":"Greeter", "signature":"def greet()", "start_row":4, "start_col":4, "end_row":5, "end_col":35},
+  {"name":"shout", "kind":"function", "container":null, "signature":"def shout(message)", "start_row":8, "start_col":0, "end_row":9, "end_col":26},
+  {"name":"fetch", "kind":"function", "container":null, "signature":"def fetch(url)", "start_row":12, "start_col":0, "end_row":13, "end_col":14}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/r/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/r/outline.golden.json
@@ -1,0 +1,5 @@
+[
+  {"name":"greet", "kind":"function", "signature":"greet <- function(name)", "start_row":0, "end_row":2, "children":[]},
+  {"name":"shout", "kind":"function", "signature":"shout <- function(s)", "start_row":4, "end_row":6, "children":[]},
+  {"name":"square", "kind":"function", "signature":"square <- function(n)", "start_row":8, "end_row":8, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/r/source.r
+++ b/crates/harn-hostlib/tests/fixtures/ast/r/source.r
@@ -1,0 +1,9 @@
+greet <- function(name) {
+    paste("hello", name)
+}
+
+shout <- function(s) {
+    toupper(s)
+}
+
+square <- function(n) n * n

--- a/crates/harn-hostlib/tests/fixtures/ast/r/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/r/symbols.golden.json
@@ -1,0 +1,5 @@
+[
+  {"name":"greet", "kind":"function", "container":null, "signature":"greet <- function(name)", "start_row":0, "start_col":0, "end_row":2, "end_col":1},
+  {"name":"shout", "kind":"function", "container":null, "signature":"shout <- function(s)", "start_row":4, "start_col":0, "end_row":6, "end_col":1},
+  {"name":"square", "kind":"function", "container":null, "signature":"square <- function(n)", "start_row":8, "start_col":0, "end_row":8, "end_col":27}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/ruby/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/ruby/outline.golden.json
@@ -1,0 +1,14 @@
+[
+  {"name":"Fixture", "kind":"module", "signature":"module Fixture", "start_row":0, "end_row":18, "children":
+    [
+      {"name":"Greeter", "kind":"class", "signature":"class Greeter", "start_row":1, "end_row":13, "children":
+        [
+          {"name":"initialize", "kind":"method", "signature":"def initialize(name)", "start_row":2, "end_row":4, "children":[]},
+          {"name":"greet", "kind":"method", "signature":"def greet", "start_row":6, "end_row":8, "children":[]},
+          {"name":"default", "kind":"method", "signature":"def self.default", "start_row":10, "end_row":12, "children":[]}
+        ]
+      },
+      {"name":"shout", "kind":"method", "signature":"def self.shout", "start_row":15, "end_row":17, "children":[]}
+    ]
+  }
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/ruby/source.rb
+++ b/crates/harn-hostlib/tests/fixtures/ast/ruby/source.rb
@@ -1,0 +1,19 @@
+module Fixture
+  class Greeter
+    def initialize(name)
+      @name = name
+    end
+
+    def greet
+      "hello #{@name}"
+    end
+
+    def self.default
+      new("world")
+    end
+  end
+
+  def self.shout(s)
+    s.upcase
+  end
+end

--- a/crates/harn-hostlib/tests/fixtures/ast/ruby/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/ruby/symbols.golden.json
@@ -1,0 +1,8 @@
+[
+  {"name":"Fixture", "kind":"module", "container":null, "signature":"module Fixture", "start_row":0, "start_col":0, "end_row":18, "end_col":3},
+  {"name":"Greeter", "kind":"class", "container":"Fixture", "signature":"class Greeter", "start_row":1, "start_col":2, "end_row":13, "end_col":5},
+  {"name":"initialize", "kind":"method", "container":"Greeter", "signature":"def initialize(name)", "start_row":2, "start_col":4, "end_row":4, "end_col":7},
+  {"name":"greet", "kind":"method", "container":"Greeter", "signature":"def greet", "start_row":6, "start_col":4, "end_row":8, "end_col":7},
+  {"name":"default", "kind":"method", "container":"Greeter", "signature":"def self.default", "start_row":10, "start_col":4, "end_row":12, "end_col":7},
+  {"name":"shout", "kind":"method", "container":"Fixture", "signature":"def self.shout", "start_row":15, "start_col":2, "end_row":17, "end_col":5}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/rust/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/rust/outline.golden.json
@@ -1,0 +1,8 @@
+[
+  {"name":"Greeter", "kind":"struct", "signature":"struct Greeter", "start_row":0, "end_row":2, "children":[]},
+  {"name":"Color", "kind":"enum", "signature":"enum Color", "start_row":4, "end_row":8, "children":[]},
+  {"name":"Speak", "kind":"protocol", "signature":"trait Speak", "start_row":10, "end_row":12, "children":[]},
+  {"name":"greet", "kind":"function", "signature":"fn greet(&self)", "start_row":15, "end_row":17, "children":[]},
+  {"name":"shout", "kind":"function", "signature":"fn shout(s: &str)", "start_row":20, "end_row":22, "children":[]},
+  {"name":"Counter", "kind":"type", "signature":"type Counter", "start_row":24, "end_row":24, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/rust/source.rs
+++ b/crates/harn-hostlib/tests/fixtures/ast/rust/source.rs
@@ -1,0 +1,25 @@
+struct Greeter {
+    name: String,
+}
+
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+trait Speak {
+    fn speak(&self) -> String;
+}
+
+impl Greeter {
+    fn greet(&self) -> String {
+        format!("hello {}", self.name)
+    }
+}
+
+fn shout(s: &str) -> String {
+    s.to_uppercase()
+}
+
+type Counter = i64;

--- a/crates/harn-hostlib/tests/fixtures/ast/rust/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/rust/symbols.golden.json
@@ -1,0 +1,8 @@
+[
+  {"name":"Greeter", "kind":"struct", "container":null, "signature":"struct Greeter", "start_row":0, "start_col":0, "end_row":2, "end_col":1},
+  {"name":"Color", "kind":"enum", "container":null, "signature":"enum Color", "start_row":4, "start_col":0, "end_row":8, "end_col":1},
+  {"name":"Speak", "kind":"protocol", "container":null, "signature":"trait Speak", "start_row":10, "start_col":0, "end_row":12, "end_col":1},
+  {"name":"greet", "kind":"function", "container":"Greeter", "signature":"fn greet(&self)", "start_row":15, "start_col":4, "end_row":17, "end_col":5},
+  {"name":"shout", "kind":"function", "container":null, "signature":"fn shout(s: &str)", "start_row":20, "start_col":0, "end_row":22, "end_col":1},
+  {"name":"Counter", "kind":"type", "container":null, "signature":"type Counter", "start_row":24, "start_col":0, "end_row":24, "end_col":19}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/scala/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/scala/outline.golden.json
@@ -1,0 +1,18 @@
+[
+  {"name":"Speaker", "kind":"protocol", "signature":"trait Speaker", "start_row":0, "end_row":2, "children":
+    [
+      {"name":"speak", "kind":"method", "signature":"def speak()", "start_row":1, "end_row":1, "children":[]}
+    ]
+  },
+  {"name":"Greeter", "kind":"class", "signature":"case class Greeter", "start_row":4, "end_row":6, "children":
+    [
+      {"name":"speak", "kind":"method", "signature":"def speak()", "start_row":5, "end_row":5, "children":[]}
+    ]
+  },
+  {"name":"Defaults", "kind":"class", "signature":"object Defaults", "start_row":8, "end_row":10, "children":
+    [
+      {"name":"World", "kind":"variable", "signature":"val World", "start_row":9, "end_row":9, "children":[]}
+    ]
+  },
+  {"name":"shout", "kind":"function", "signature":"def shout(s: String)", "start_row":12, "end_row":12, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/scala/source.scala
+++ b/crates/harn-hostlib/tests/fixtures/ast/scala/source.scala
@@ -1,0 +1,13 @@
+trait Speaker {
+  def speak(): String
+}
+
+case class Greeter(name: String) extends Speaker {
+  def speak(): String = s"hello $name"
+}
+
+object Defaults {
+  val World: Greeter = Greeter("world")
+}
+
+def shout(s: String): String = s.toUpperCase

--- a/crates/harn-hostlib/tests/fixtures/ast/scala/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/scala/symbols.golden.json
@@ -1,0 +1,9 @@
+[
+  {"name":"Speaker", "kind":"protocol", "container":null, "signature":"trait Speaker", "start_row":0, "start_col":0, "end_row":2, "end_col":1},
+  {"name":"speak", "kind":"method", "container":"Speaker", "signature":"def speak()", "start_row":1, "start_col":2, "end_row":1, "end_col":21},
+  {"name":"Greeter", "kind":"class", "container":null, "signature":"case class Greeter", "start_row":4, "start_col":0, "end_row":6, "end_col":1},
+  {"name":"speak", "kind":"method", "container":"Greeter", "signature":"def speak()", "start_row":5, "start_col":2, "end_row":5, "end_col":38},
+  {"name":"Defaults", "kind":"class", "container":null, "signature":"object Defaults", "start_row":8, "start_col":0, "end_row":10, "end_col":1},
+  {"name":"World", "kind":"variable", "container":"Defaults", "signature":"val World", "start_row":9, "start_col":2, "end_row":9, "end_col":39},
+  {"name":"shout", "kind":"function", "container":null, "signature":"def shout(s: String)", "start_row":12, "start_col":0, "end_row":12, "end_col":44}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/swift/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/swift/outline.golden.json
@@ -1,0 +1,17 @@
+[
+  {"name":"Speaker", "kind":"protocol", "signature":"protocol Speaker", "start_row":0, "end_row":2, "children":[]},
+  {"name":"Point", "kind":"struct", "signature":"struct Point", "start_row":4, "end_row":7, "children":
+    [
+      {"name":"x", "kind":"variable", "signature":"x", "start_row":5, "end_row":5, "children":[]},
+      {"name":"y", "kind":"variable", "signature":"y", "start_row":6, "end_row":6, "children":[]}
+    ]
+  },
+  {"name":"Color", "kind":"enum", "signature":"enum Color", "start_row":9, "end_row":13, "children":[]},
+  {"name":"Greeter", "kind":"class", "signature":"class Greeter", "start_row":15, "end_row":25, "children":
+    [
+      {"name":"name", "kind":"variable", "signature":"name", "start_row":16, "end_row":16, "children":[]},
+      {"name":"speak", "kind":"function", "signature":"func speak()", "start_row":22, "end_row":24, "children":[]}
+    ]
+  },
+  {"name":"shout", "kind":"function", "signature":"func shout()", "start_row":27, "end_row":29, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/swift/source.swift
+++ b/crates/harn-hostlib/tests/fixtures/ast/swift/source.swift
@@ -1,0 +1,30 @@
+protocol Speaker {
+    func speak() -> String
+}
+
+struct Point {
+    var x: Int
+    var y: Int
+}
+
+enum Color {
+    case red
+    case green
+    case blue
+}
+
+class Greeter: Speaker {
+    let name: String
+
+    init(name: String) {
+        self.name = name
+    }
+
+    func speak() -> String {
+        return "hello \(name)"
+    }
+}
+
+func shout(_ s: String) -> String {
+    return s.uppercased()
+}

--- a/crates/harn-hostlib/tests/fixtures/ast/swift/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/swift/symbols.golden.json
@@ -1,0 +1,11 @@
+[
+  {"name":"Speaker", "kind":"protocol", "container":null, "signature":"protocol Speaker", "start_row":0, "start_col":0, "end_row":2, "end_col":1},
+  {"name":"Point", "kind":"struct", "container":null, "signature":"struct Point", "start_row":4, "start_col":0, "end_row":7, "end_col":1},
+  {"name":"x", "kind":"variable", "container":"Point", "signature":"x", "start_row":5, "start_col":4, "end_row":5, "end_col":14},
+  {"name":"y", "kind":"variable", "container":"Point", "signature":"y", "start_row":6, "start_col":4, "end_row":6, "end_col":14},
+  {"name":"Color", "kind":"enum", "container":null, "signature":"enum Color", "start_row":9, "start_col":0, "end_row":13, "end_col":1},
+  {"name":"Greeter", "kind":"class", "container":null, "signature":"class Greeter", "start_row":15, "start_col":0, "end_row":25, "end_col":1},
+  {"name":"name", "kind":"variable", "container":"Greeter", "signature":"name", "start_row":16, "start_col":4, "end_row":16, "end_col":20},
+  {"name":"speak", "kind":"function", "container":"Greeter", "signature":"func speak()", "start_row":22, "start_col":4, "end_row":24, "end_col":5},
+  {"name":"shout", "kind":"function", "container":null, "signature":"func shout()", "start_row":27, "start_col":0, "end_row":29, "end_col":1}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/tsx/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/tsx/outline.golden.json
@@ -1,0 +1,9 @@
+[
+  {"name":"ButtonProps", "kind":"interface", "signature":"interface ButtonProps", "start_row":0, "end_row":2, "children":[]},
+  {"name":"Button", "kind":"class", "signature":"class Button", "start_row":4, "end_row":8, "children":
+    [
+      {"name":"render", "kind":"method", "signature":"render()", "start_row":5, "end_row":7, "children":[]}
+    ]
+  },
+  {"name":"App", "kind":"function", "signature":"function App()", "start_row":10, "end_row":12, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/tsx/source.tsx
+++ b/crates/harn-hostlib/tests/fixtures/ast/tsx/source.tsx
@@ -1,0 +1,13 @@
+interface ButtonProps {
+    label: string;
+}
+
+class Button extends Component<ButtonProps> {
+    render() {
+        return <button>{this.props.label}</button>;
+    }
+}
+
+function App() {
+    return <Button label="hi" />;
+}

--- a/crates/harn-hostlib/tests/fixtures/ast/tsx/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/tsx/symbols.golden.json
@@ -1,0 +1,6 @@
+[
+  {"name":"ButtonProps", "kind":"interface", "container":null, "signature":"interface ButtonProps", "start_row":0, "start_col":0, "end_row":2, "end_col":1},
+  {"name":"Button", "kind":"class", "container":null, "signature":"class Button", "start_row":4, "start_col":0, "end_row":8, "end_col":1},
+  {"name":"render", "kind":"method", "container":"Button", "signature":"render()", "start_row":5, "start_col":4, "end_row":7, "end_col":5},
+  {"name":"App", "kind":"function", "container":null, "signature":"function App()", "start_row":10, "start_col":0, "end_row":12, "end_col":1}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/typescript/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/typescript/outline.golden.json
@@ -1,0 +1,11 @@
+[
+  {"name":"Greeter", "kind":"interface", "signature":"interface Greeter", "start_row":0, "end_row":2, "children":[]},
+  {"name":"HelloGreeter", "kind":"class", "signature":"class HelloGreeter", "start_row":4, "end_row":8, "children":
+    [
+      {"name":"greet", "kind":"method", "signature":"greet(name: string)", "start_row":5, "end_row":7, "children":[]}
+    ]
+  },
+  {"name":"shout", "kind":"function", "signature":"function shout(message: string)", "start_row":10, "end_row":12, "children":[]},
+  {"name":"yell", "kind":"function", "signature":"const yell = (...) =>", "start_row":14, "end_row":14, "children":[]},
+  {"name":"Maybe", "kind":"type", "signature":"type Maybe", "start_row":16, "end_row":16, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/typescript/source.ts
+++ b/crates/harn-hostlib/tests/fixtures/ast/typescript/source.ts
@@ -1,0 +1,17 @@
+interface Greeter {
+    greet(name: string): string;
+}
+
+class HelloGreeter implements Greeter {
+    greet(name: string): string {
+        return `hello ${name}`;
+    }
+}
+
+function shout(message: string): string {
+    return message.toUpperCase();
+}
+
+const yell = (message: string) => shout(message);
+
+type Maybe<T> = T | null;

--- a/crates/harn-hostlib/tests/fixtures/ast/typescript/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/typescript/symbols.golden.json
@@ -1,0 +1,8 @@
+[
+  {"name":"Greeter", "kind":"interface", "container":null, "signature":"interface Greeter", "start_row":0, "start_col":0, "end_row":2, "end_col":1},
+  {"name":"HelloGreeter", "kind":"class", "container":null, "signature":"class HelloGreeter", "start_row":4, "start_col":0, "end_row":8, "end_col":1},
+  {"name":"greet", "kind":"method", "container":"HelloGreeter", "signature":"greet(name: string)", "start_row":5, "start_col":4, "end_row":7, "end_col":5},
+  {"name":"shout", "kind":"function", "container":null, "signature":"function shout(message: string)", "start_row":10, "start_col":0, "end_row":12, "end_col":1},
+  {"name":"yell", "kind":"function", "container":null, "signature":"const yell = (...) =>", "start_row":14, "start_col":0, "end_row":14, "end_col":49},
+  {"name":"Maybe", "kind":"type", "container":null, "signature":"type Maybe", "start_row":16, "start_col":0, "end_row":16, "end_col":25}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/zig/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/zig/outline.golden.json
@@ -1,0 +1,5 @@
+[
+  {"name":"add", "kind":"function", "signature":"fn add()", "start_row":2, "end_row":4, "children":[]},
+  {"name":"shout", "kind":"function", "signature":"fn shout()", "start_row":6, "end_row":8, "children":[]},
+  {"name":"add returns sum", "kind":"function", "signature":"test \"add returns sum\"", "start_row":10, "end_row":12, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/zig/source.zig
+++ b/crates/harn-hostlib/tests/fixtures/ast/zig/source.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+
+pub fn add(a: i32, b: i32) i32 {
+    return a + b;
+}
+
+pub fn shout(comptime s: []const u8) []const u8 {
+    return s;
+}
+
+test "add returns sum" {
+    try std.testing.expectEqual(@as(i32, 3), add(1, 2));
+}

--- a/crates/harn-hostlib/tests/fixtures/ast/zig/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/zig/symbols.golden.json
@@ -1,0 +1,5 @@
+[
+  {"name":"add", "kind":"function", "container":null, "signature":"fn add()", "start_row":2, "start_col":0, "end_row":4, "end_col":1},
+  {"name":"shout", "kind":"function", "container":null, "signature":"fn shout()", "start_row":6, "start_col":0, "end_row":8, "end_col":1},
+  {"name":"add returns sum", "kind":"function", "container":null, "signature":"test \"add returns sum\"", "start_row":10, "start_col":0, "end_row":12, "end_col":1}
+]

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -47,7 +47,22 @@ fn ast_capability_registers_documented_methods() {
             "hostlib_ast_outline",
         ]
     );
-    assert_all_unimplemented(&registry);
+    // Issue #564 implemented every AST builtin. With no `path` parameter
+    // each one routes through `MissingParameter` rather than the scaffold
+    // `Unimplemented` — the contract surface is real now.
+    for entry in registry.iter() {
+        let err = (entry.handler)(&[]).expect_err("handler must error on empty args");
+        match err {
+            HostlibError::MissingParameter { builtin, param } => {
+                assert_eq!(builtin, entry.name);
+                assert_eq!(param, "path");
+            }
+            other => panic!(
+                "expected MissingParameter for {}, got {other:?}",
+                entry.name
+            ),
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes [#564](https://github.com/burin-labs/harn/issues/564). Lights up `hostlib_ast_parse_file`, `hostlib_ast_symbols`, and `hostlib_ast_outline` — the surface scaffolded in [#563](https://github.com/burin-labs/harn/issues/563) — by porting the Swift `Sources/ASTEngine/` extractor verbatim into Rust on top of `tree-sitter` 0.26 grammars.

## Summary

- 22 host languages, exactly mirroring Swift `TreeSitterLanguage`: TypeScript, TSX, JavaScript, JSX, Python, Go, Rust, Java, C, C++, C#, Ruby, Kotlin, PHP, Scala, Bash, Swift, Zig, Elixir, Lua, Haskell, R. Grammar versions pinned in [`crates/harn-hostlib/Cargo.toml`](crates/harn-hostlib/Cargo.toml).
- Per-language extractors share a `walk_named` cursor walk plus a small `named_decl_with_keyword` / `push_func` helper set, so each language reduces to a tight match arm. The fold from flat symbols → nested outline is language-agnostic and lives in one place.
- Schemas for `symbols` / `outline` now carry `signature` and document 0-based row/col coordinates (matching tree-sitter's native `Point`s). `parse_file` flattens the tree breadth-first so the wire JSON stays serializable without inflating into nested copies.

## Wire format quick reference

| Builtin | Returns |
|---|---|
| `hostlib_ast_parse_file({path, language?, max_bytes?})` | `{path, language, root_id, nodes: [{id, parent_id, kind, ...}], had_errors}` |
| `hostlib_ast_symbols({path, language?, kinds?})` | `{path, language, symbols: [{name, kind, container, signature, start_row, ...}]}` |
| `hostlib_ast_outline({path, language?, max_depth?})` | `{path, language, items: [{name, kind, signature, start_row, end_row, children}]}` |

## Tests

- `crates/harn-hostlib/tests/ast_fixtures.rs` runs every shipped language against `crates/harn-hostlib/tests/fixtures/ast/<language>/source.*` and asserts symbols + outline goldens. To regenerate after a deliberate change: `HARN_AST_UPDATE_GOLDEN=1 cargo test -p harn-hostlib --test ast_fixtures`.
- `crates/harn-hostlib/tests/ast_builtins.rs` drives the wired-up builtins through the registry: `parse_file` tree shape, `symbols` `kinds` filter, `outline` `max_depth` cap, unknown-language rejection, and a perf smoke check.
- `crates/harn-hostlib/tests/registration.rs` now asserts AST builtins route through `MissingParameter` rather than the scaffold `Unimplemented` — the contract surface is real now.

## Benchmarks

Measured in `cargo test --release -p harn-hostlib --test ast_builtins -- --nocapture` on Apple M-series:

| Input | Latency (warm) |
|---|---|
| `tests/fixtures/ast/rust/source.rs` (~25 lines) | < 0.1 ms |
| `~/projects/burin-code/Package.swift` (~11 KB) | **2.6 ms** (issue's reference target was <20 ms) |

The issue-asserted budget is 20 ms; the test's CI ceiling is 40 ms (doubled vs. target so noisy CI hosts don't flake). The realistic warm-call latency is sub-millisecond on local hardware.

## Other

- `crates/harn-hostlib/src/tools/args` is now `pub(crate)` so the `ast/*` handlers reuse the dict-arg parsing helpers shipped with [#567](https://github.com/burin-labs/harn/issues/567) rather than duplicating them.
- README ([crates/harn-hostlib/README.md](crates/harn-hostlib/README.md)) gained the language matrix + golden-regen workflow.

## Test plan

- [x] `cargo test -p harn-hostlib` — all suites green (registration, ast_fixtures, ast_builtins, tools_*)
- [x] `cargo clippy -p harn-hostlib --all-targets -- -D warnings` — clean
- [x] `make all` — full repo gate (workspace clippy, workspace tests via nextest, conformance, markdown lint, Harn lint/format, docs snippets, portal lint/build) — exit 0; nextest reports 2194 tests passing across 36 binaries.
- [x] Round-tripped the JSON schemas: every registered builtin has matching request/response schemas (existing `tests/registration.rs::every_registered_builtin_has_request_and_response_schemas`).
- [x] Smoke-tested against `~/projects/burin-code/Package.swift` (the issue's reference perf target): 2.6 ms warm parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)