### PR TITLE
Implement Windows process sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+ "windows-sys 0.61.2",
  "zeroize",
 ]
 

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -61,6 +61,18 @@ opentelemetry-otlp = { version = "0.31", default-features = false, features = ["
 tracing-opentelemetry = { version = "0.32", optional = true }
 zeroize = "1"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Security_Isolation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_JobObjects",
+    "Win32_System_Pipes",
+    "Win32_System_Threading",
+] }
+
 [dev-dependencies]
 rcgen = "0.13"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1299,35 +1299,25 @@ pub async fn execute_stage_node(
             .map(str::trim)
             .filter(|value| !value.is_empty())
         {
-            let mut process = if cfg!(target_os = "windows") {
-                crate::stdlib::sandbox::tokio_command_for(
-                    "cmd",
-                    &["/C".to_string(), command.to_string()],
-                )?
+            let (program, args) = if cfg!(target_os = "windows") {
+                ("cmd", vec!["/C".to_string(), command.to_string()])
             } else {
-                crate::stdlib::sandbox::tokio_command_for(
-                    "/bin/sh",
-                    &["-lc".to_string(), command.to_string()],
-                )?
+                ("/bin/sh", vec!["-lc".to_string(), command.to_string()])
             };
-            process.stdin(std::process::Stdio::null());
+            let mut process_config = crate::stdlib::sandbox::ProcessCommandConfig {
+                stdin_null: true,
+                ..Default::default()
+            };
             if let Some(context) = crate::stdlib::process::current_execution_context() {
                 if let Some(cwd) = context.cwd.filter(|cwd| !cwd.is_empty()) {
                     crate::stdlib::sandbox::enforce_process_cwd(std::path::Path::new(&cwd))?;
-                    process.current_dir(cwd);
+                    process_config.cwd = Some(std::path::PathBuf::from(cwd));
                 }
                 if !context.env.is_empty() {
-                    process.envs(context.env);
+                    process_config.env.extend(context.env);
                 }
             }
-            let output = process.output().await.map_err(|e| {
-                crate::stdlib::sandbox::process_spawn_error(&e).unwrap_or_else(|| {
-                    VmError::Runtime(format!("workflow verify exec failed: {e}"))
-                })
-            })?;
-            if let Some(error) = crate::stdlib::sandbox::process_violation_error(&output) {
-                return Err(error);
-            }
+            let output = crate::stdlib::sandbox::command_output(program, &args, &process_config)?;
             let stdout = String::from_utf8_lossy(&output.stdout).to_string();
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();
             let combined = if stderr.is_empty() {

--- a/crates/harn-vm/src/process_sandbox.rs
+++ b/crates/harn-vm/src/process_sandbox.rs
@@ -4,7 +4,8 @@
 //! `harn-hostlib` deterministic-tool builtins) must funnel every spawn
 //! through these helpers so the active orchestration capability policy is
 //! enforced — Linux seccomp/landlock filters via `pre_exec`, macOS
-//! `sandbox-exec` wrapping, plus workspace-root cwd enforcement.
+//! `sandbox-exec` wrapping, Windows AppContainer + Job Object launches
+//! through `command_output`, plus workspace-root cwd enforcement.
 //!
 //! The helpers themselves live next to the rest of the sandbox state in
 //! [`crate::stdlib::sandbox`]. This module exists so external crates have a
@@ -12,6 +13,6 @@
 //! `stdlib::*` plumbing.
 
 pub use crate::stdlib::sandbox::{
-    enforce_process_cwd, process_spawn_error, process_violation_error, std_command_for,
-    tokio_command_for,
+    command_output, enforce_process_cwd, process_spawn_error, process_violation_error,
+    std_command_for, tokio_command_for, ProcessCommandConfig,
 };

--- a/crates/harn-vm/src/stdlib/process.rs
+++ b/crates/harn-vm/src/stdlib/process.rs
@@ -408,17 +408,9 @@ fn exec_command(
     cmd: &str,
     args: &[String],
 ) -> Result<std::process::Output, VmError> {
-    let mut command = crate::stdlib::sandbox::std_command_for(cmd, args)?;
-    apply_execution_context(&mut command, dir)?;
-    let output = command.output().map_err(|e| {
-        crate::stdlib::sandbox::process_spawn_error(&e).unwrap_or_else(|| {
-            VmError::Thrown(VmValue::String(Rc::from(format!("exec failed: {e}"))))
-        })
-    })?;
-    if let Some(error) = crate::stdlib::sandbox::process_violation_error(&output) {
-        return Err(error);
-    }
-    Ok(output)
+    let config = process_command_config(dir)?;
+    crate::stdlib::sandbox::command_output(cmd, args, &config)
+        .map_err(|error| prefix_process_error(error, "exec"))
 }
 
 fn exec_shell(
@@ -428,40 +420,44 @@ fn exec_shell(
     script: &str,
 ) -> Result<std::process::Output, VmError> {
     let args = vec![flag.to_string(), script.to_string()];
-    let mut command = crate::stdlib::sandbox::std_command_for(shell, &args)?;
-    apply_execution_context(&mut command, dir)?;
-    let output = command.output().map_err(|e| {
-        crate::stdlib::sandbox::process_spawn_error(&e).unwrap_or_else(|| {
-            VmError::Thrown(VmValue::String(Rc::from(format!("shell failed: {e}"))))
-        })
-    })?;
-    if let Some(error) = crate::stdlib::sandbox::process_violation_error(&output) {
-        return Err(error);
-    }
-    Ok(output)
+    let config = process_command_config(dir)?;
+    crate::stdlib::sandbox::command_output(shell, &args, &config)
+        .map_err(|error| prefix_process_error(error, "shell"))
 }
 
-fn apply_execution_context(
-    command: &mut std::process::Command,
+fn process_command_config(
     dir: Option<&str>,
-) -> Result<(), VmError> {
+) -> Result<crate::stdlib::sandbox::ProcessCommandConfig, VmError> {
+    let mut config = crate::stdlib::sandbox::ProcessCommandConfig {
+        stdin_null: true,
+        ..Default::default()
+    };
     if let Some(dir) = dir {
         let resolved = resolve_command_dir(dir);
         crate::stdlib::sandbox::enforce_process_cwd(&resolved)?;
-        command.current_dir(resolved);
+        config.cwd = Some(resolved);
     } else if let Some(context) = current_execution_context() {
         if let Some(cwd) = context.cwd.filter(|cwd| !cwd.is_empty()) {
             crate::stdlib::sandbox::enforce_process_cwd(std::path::Path::new(&cwd))?;
-            command.current_dir(cwd);
+            config.cwd = Some(std::path::PathBuf::from(cwd));
         }
         if !context.env.is_empty() {
-            command.envs(context.env);
+            config.env.extend(context.env);
         }
     }
     if let Some(value) = env_override(HARN_REPLAY_ENV) {
-        command.env(HARN_REPLAY_ENV, value);
+        config.env.push((HARN_REPLAY_ENV.to_string(), value));
     }
-    Ok(())
+    Ok(config)
+}
+
+fn prefix_process_error(error: VmError, prefix: &str) -> VmError {
+    match error {
+        VmError::Thrown(VmValue::String(message)) => VmError::Thrown(VmValue::String(Rc::from(
+            format!("{prefix} failed: {message}"),
+        ))),
+        other => other,
+    }
 }
 
 fn resolve_command_dir(dir: &str) -> PathBuf {

--- a/crates/harn-vm/src/stdlib/sandbox.rs
+++ b/crates/harn-vm/src/stdlib/sandbox.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::collections::BTreeSet;
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output, Stdio};
 
 use crate::orchestration::CapabilityPolicy;
 use crate::value::{ErrorCategory, VmError};
@@ -12,6 +12,10 @@ use std::io;
 use std::os::fd::AsRawFd;
 #[cfg(any(target_os = "linux", target_os = "openbsd"))]
 use std::os::unix::process::CommandExt;
+
+#[cfg(target_os = "windows")]
+#[path = "sandbox/windows.rs"]
+mod windows;
 
 const HANDLER_SANDBOX_ENV: &str = "HARN_HANDLER_SANDBOX";
 
@@ -24,6 +28,13 @@ pub(crate) enum FsAccess {
     Read,
     Write,
     Delete,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ProcessCommandConfig {
+    pub cwd: Option<PathBuf>,
+    pub env: Vec<(String, String)>,
+    pub stdin_null: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -104,6 +115,34 @@ pub fn std_command_for(program: &str, args: &[String]) -> Result<Command, VmErro
     }
 }
 
+pub fn command_output(
+    program: &str,
+    args: &[String],
+    config: &ProcessCommandConfig,
+) -> Result<Output, VmError> {
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(policy) = active_sandbox_policy() {
+            let output = windows::sandboxed_output(program, args, config, &policy)
+                .map_err(|error| windows_process_error("process sandbox failed", error))?;
+            if let Some(error) = process_violation_error(&output) {
+                return Err(error);
+            }
+            return Ok(output);
+        }
+    }
+
+    let mut command = std_command_for(program, args)?;
+    apply_process_config(&mut command, config);
+    let output = command
+        .output()
+        .map_err(|error| process_spawn_error(&error).unwrap_or_else(|| spawn_error(error)))?;
+    if let Some(error) = process_violation_error(&output) {
+        return Err(error);
+    }
+    Ok(output)
+}
+
 pub fn tokio_command_for(
     program: &str,
     args: &[String],
@@ -137,6 +176,7 @@ pub fn process_violation_error(output: &std::process::Output) -> Option<VmError>
     if !output.status.success()
         && (stderr.contains("operation not permitted")
             || stderr.contains("permission denied")
+            || stderr.contains("access is denied")
             || stdout.contains("operation not permitted"))
     {
         return Some(sandbox_rejection(format!(
@@ -162,6 +202,7 @@ pub fn process_spawn_error(error: &std::io::Error) -> Option<VmError> {
     if error.kind() == std::io::ErrorKind::PermissionDenied
         || message.contains("operation not permitted")
         || message.contains("permission denied")
+        || message.contains("access is denied")
     {
         return Some(sandbox_rejection(format!(
             "sandbox violation: process was denied by the OS sandbox before exec: {error}"
@@ -200,7 +241,17 @@ fn platform_sandbox_available() -> bool {
     true
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "openbsd")))]
+#[cfg(target_os = "windows")]
+fn platform_sandbox_available() -> bool {
+    true
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "openbsd",
+    target_os = "windows"
+)))]
 fn platform_sandbox_available() -> bool {
     false
 }
@@ -304,7 +355,34 @@ fn platform_command_wrapper(
     Ok(CommandWrapper::Direct)
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "openbsd")))]
+#[cfg(target_os = "windows")]
+fn platform_command_wrapper(
+    _program: &str,
+    _args: &[String],
+    _policy: &CapabilityPolicy,
+) -> Result<CommandWrapper, VmError> {
+    match fallback_mode() {
+        SandboxFallback::Off => Ok(CommandWrapper::Direct),
+        SandboxFallback::Warn => {
+            warn_once(
+                "handler_sandbox_windows_command_for",
+                "Windows process sandboxing requires command_output(); std_command_for() cannot attach an AppContainer to std::process::Command",
+            );
+            Ok(CommandWrapper::Direct)
+        }
+        SandboxFallback::Enforce => Err(sandbox_rejection(
+            "Windows process sandboxing requires command_output(); std_command_for() cannot attach an AppContainer to std::process::Command"
+                .to_string(),
+        )),
+    }
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "openbsd",
+    target_os = "windows"
+)))]
 fn platform_command_wrapper(
     _program: &str,
     _args: &[String],
@@ -863,7 +941,7 @@ extern "C" {
     fn unveil(path: *const libc::c_char, permissions: *const libc::c_char) -> libc::c_int;
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "openbsd")))]
+#[cfg(not(any(target_os = "linux", target_os = "openbsd", target_os = "windows")))]
 fn unavailable(message: &str) -> Result<CommandWrapper, VmError> {
     match fallback_mode() {
         SandboxFallback::Off | SandboxFallback::Warn => {
@@ -874,6 +952,27 @@ fn unavailable(message: &str) -> Result<CommandWrapper, VmError> {
             "{message}; set {HANDLER_SANDBOX_ENV}=warn or off to run unsandboxed"
         ))),
     }
+}
+
+fn apply_process_config(command: &mut Command, config: &ProcessCommandConfig) {
+    if let Some(cwd) = config.cwd.as_ref() {
+        command.current_dir(cwd);
+    }
+    command.envs(config.env.iter().map(|(key, value)| (key, value)));
+    if config.stdin_null {
+        command.stdin(Stdio::null());
+    }
+}
+
+fn spawn_error(error: std::io::Error) -> VmError {
+    VmError::Thrown(crate::value::VmValue::String(std::rc::Rc::from(format!(
+        "process spawn failed: {error}"
+    ))))
+}
+
+#[cfg(target_os = "windows")]
+fn windows_process_error(context: &str, error: std::io::Error) -> VmError {
+    process_spawn_error(&error).unwrap_or_else(|| sandbox_rejection(format!("{context}: {error}")))
 }
 
 fn fallback_mode() -> SandboxFallback {
@@ -1000,13 +1099,18 @@ fn policy_allows_network(policy: &CapabilityPolicy) -> bool {
         .unwrap_or(true)
 }
 
-#[cfg(any(target_os = "macos", target_os = "openbsd"))]
+#[cfg(any(target_os = "macos", target_os = "openbsd", target_os = "windows"))]
 fn policy_allows_workspace_write(policy: &CapabilityPolicy) -> bool {
     policy.capabilities.is_empty()
         || policy_allows_capability(policy, "workspace", &["write_text", "delete"])
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "openbsd"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "openbsd",
+    target_os = "windows"
+))]
 fn policy_allows_capability(policy: &CapabilityPolicy, capability: &str, ops: &[&str]) -> bool {
     policy
         .capabilities

--- a/crates/harn-vm/src/stdlib/sandbox/windows.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/windows.rs
@@ -1,0 +1,625 @@
+use std::ffi::{OsStr, OsString};
+use std::io::{self, Read};
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+use std::os::windows::io::FromRawHandle;
+use std::os::windows::process::ExitStatusExt;
+use std::path::{Path, PathBuf};
+use std::process::{ExitStatus, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use windows_sys::Win32::Foundation::{
+    CloseHandle, LocalFree, SetHandleInformation, GENERIC_READ, HANDLE, HANDLE_FLAG_INHERIT,
+    INVALID_HANDLE_VALUE, WAIT_FAILED,
+};
+use windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW;
+use windows_sys::Win32::Security::Isolation::{
+    CreateAppContainerProfile, DeleteAppContainerProfile, DeriveAppContainerSidFromAppContainerName,
+};
+use windows_sys::Win32::Security::{PSID, SECURITY_ATTRIBUTES, SECURITY_CAPABILITIES};
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+};
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectBasicUIRestrictions,
+    JobObjectExtendedLimitInformation, SetInformationJobObject, JOBOBJECT_BASIC_UI_RESTRICTIONS,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_ACTIVE_PROCESS,
+    JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    JOB_OBJECT_LIMIT_PROCESS_MEMORY, JOB_OBJECT_UILIMIT_DESKTOP,
+    JOB_OBJECT_UILIMIT_DISPLAYSETTINGS, JOB_OBJECT_UILIMIT_EXITWINDOWS,
+    JOB_OBJECT_UILIMIT_GLOBALATOMS, JOB_OBJECT_UILIMIT_HANDLES, JOB_OBJECT_UILIMIT_READCLIPBOARD,
+    JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS, JOB_OBJECT_UILIMIT_WRITECLIPBOARD,
+};
+use windows_sys::Win32::System::Pipes::CreatePipe;
+use windows_sys::Win32::System::Threading::{
+    CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess,
+    InitializeProcThreadAttributeList, ResumeThread, TerminateProcess, UpdateProcThreadAttribute,
+    WaitForSingleObject, CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT,
+    EXTENDED_STARTUPINFO_PRESENT, INFINITE, PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+    PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES, STARTF_USESTDHANDLES, STARTUPINFOEXW,
+};
+
+use super::{policy_allows_workspace_write, process_sandbox_roots, ProcessCommandConfig};
+use crate::orchestration::CapabilityPolicy;
+
+static PROFILE_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+pub(super) fn sandboxed_output(
+    program: &str,
+    args: &[String],
+    config: &ProcessCommandConfig,
+    policy: &CapabilityPolicy,
+) -> io::Result<Output> {
+    let profile = AppContainerProfile::create()?;
+    let sid_string = profile.sid_string()?;
+    let grants = WorkspaceAclGrants::grant(&sid_string, policy)?;
+    let _grants = grants;
+
+    let stdout_pipe = InheritablePipe::new()?;
+    let stderr_pipe = InheritablePipe::new()?;
+    let stdin = OwnedHandle::nul_read()?;
+    let inherited_handles = [
+        stdin.raw(),
+        stdout_pipe.write.raw(),
+        stderr_pipe.write.raw(),
+    ];
+    let mut security_capabilities = profile.security_capabilities();
+    let mut attributes = ProcThreadAttributes::new(2)?;
+    attributes.update(
+        PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES as usize,
+        (&mut security_capabilities as *mut SECURITY_CAPABILITIES).cast(),
+        std::mem::size_of::<SECURITY_CAPABILITIES>(),
+    )?;
+    attributes.update(
+        PROC_THREAD_ATTRIBUTE_HANDLE_LIST as usize,
+        inherited_handles.as_ptr().cast(),
+        std::mem::size_of_val(&inherited_handles),
+    )?;
+
+    let mut stdout_reader = stdout_pipe.into_reader();
+    let mut stderr_reader = stderr_pipe.into_reader();
+
+    let mut startup = STARTUPINFOEXW::default();
+    startup.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as u32;
+    startup.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+    startup.StartupInfo.hStdInput = stdin.raw();
+    startup.StartupInfo.hStdOutput = stdout_reader.child_write_handle();
+    startup.StartupInfo.hStdError = stderr_reader.child_write_handle();
+    startup.lpAttributeList = attributes.as_mut_ptr();
+
+    let mut process_info = PROCESS_INFORMATION::default();
+    let mut command_line = command_line(program, args);
+    let application = resolve_application_name(program);
+    let mut environment = environment_block(&config.env);
+    let cwd = config.cwd.as_ref().map(|path| path_to_wide(path));
+    let job = JobObject::create()?;
+
+    let created = unsafe {
+        CreateProcessW(
+            application
+                .as_ref()
+                .map_or(std::ptr::null(), |value| value.as_ptr()),
+            command_line.as_mut_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            1,
+            EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT | CREATE_SUSPENDED,
+            if environment.is_empty() {
+                std::ptr::null()
+            } else {
+                environment.as_mut_ptr().cast()
+            },
+            cwd.as_ref()
+                .map_or(std::ptr::null(), |value| value.as_ptr()),
+            std::ptr::addr_of!(startup.StartupInfo),
+            &mut process_info,
+        )
+    };
+    if created == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let process = OwnedHandle::new(process_info.hProcess);
+    let thread = OwnedHandle::new(process_info.hThread);
+    if let Err(error) = job.assign(process.raw()) {
+        unsafe {
+            TerminateProcess(process.raw(), 1);
+        }
+        return Err(error);
+    }
+    stdout_reader.close_child_write();
+    stderr_reader.close_child_write();
+
+    if unsafe { ResumeThread(thread.raw()) } == u32::MAX {
+        return Err(io::Error::last_os_error());
+    }
+
+    let stdout = stdout_reader.read_async();
+    let stderr = stderr_reader.read_async();
+    let wait = unsafe { WaitForSingleObject(process.raw(), INFINITE) };
+    if wait == WAIT_FAILED {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut code = 1u32;
+    if unsafe { GetExitCodeProcess(process.raw(), &mut code) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(Output {
+        status: ExitStatus::from_raw(code),
+        stdout: join_reader(stdout)?,
+        stderr: join_reader(stderr)?,
+    })
+}
+
+struct AppContainerProfile {
+    name: Vec<u16>,
+    sid: PSID,
+}
+
+impl AppContainerProfile {
+    fn create() -> io::Result<Self> {
+        let id = PROFILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let name = format!("harn.sandbox.{}.{}", std::process::id(), id);
+        let wide_name = str_to_wide(&name);
+        let display = str_to_wide("Harn Sandbox");
+        let description = str_to_wide("Harn per-process no-capability sandbox");
+        let mut sid = std::ptr::null_mut();
+        let hr = unsafe {
+            CreateAppContainerProfile(
+                wide_name.as_ptr(),
+                display.as_ptr(),
+                description.as_ptr(),
+                std::ptr::null(),
+                0,
+                &mut sid,
+            )
+        };
+        if failed(hr) {
+            let derived =
+                unsafe { DeriveAppContainerSidFromAppContainerName(wide_name.as_ptr(), &mut sid) };
+            if failed(derived) {
+                return Err(io::Error::from_raw_os_error(derived));
+            }
+        }
+        Ok(Self {
+            name: wide_name,
+            sid,
+        })
+    }
+
+    fn security_capabilities(&self) -> SECURITY_CAPABILITIES {
+        SECURITY_CAPABILITIES {
+            AppContainerSid: self.sid,
+            Capabilities: std::ptr::null_mut(),
+            CapabilityCount: 0,
+            Reserved: 0,
+        }
+    }
+
+    fn sid_string(&self) -> io::Result<String> {
+        let mut raw = std::ptr::null_mut();
+        if unsafe { ConvertSidToStringSidW(self.sid, &mut raw) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let result = wide_ptr_to_string(raw);
+        unsafe {
+            LocalFree(raw.cast());
+        }
+        Ok(result)
+    }
+}
+
+impl Drop for AppContainerProfile {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.sid.is_null() {
+                LocalFree(self.sid.cast());
+            }
+            DeleteAppContainerProfile(self.name.as_ptr());
+        }
+    }
+}
+
+struct WorkspaceAclGrants {
+    sid: String,
+    paths: Vec<PathBuf>,
+}
+
+impl WorkspaceAclGrants {
+    fn grant(sid: &str, policy: &CapabilityPolicy) -> io::Result<Self> {
+        let permission = if policy_allows_workspace_write(policy) {
+            "(OI)(CI)M"
+        } else {
+            "(OI)(CI)RX"
+        };
+        let mut paths = Vec::new();
+        for root in process_sandbox_roots(policy) {
+            if !root.exists() {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("sandbox workspace root '{}' does not exist", root.display()),
+                ));
+            }
+            run_icacls(
+                &root,
+                ["/grant", &format!("*{sid}:{permission}"), "/T", "/C"],
+            )?;
+            paths.push(root);
+        }
+        Ok(Self {
+            sid: sid.to_string(),
+            paths,
+        })
+    }
+}
+
+impl Drop for WorkspaceAclGrants {
+    fn drop(&mut self) {
+        for path in &self.paths {
+            let _ = run_icacls(path, ["/remove:g", &format!("*{}", self.sid), "/T", "/C"]);
+        }
+    }
+}
+
+struct JobObject {
+    handle: OwnedHandle,
+}
+
+impl JobObject {
+    fn create() -> io::Result<Self> {
+        let handle = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        let handle = OwnedHandle::new_checked(handle)?;
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+            | JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
+            | JOB_OBJECT_LIMIT_ACTIVE_PROCESS
+            | JOB_OBJECT_LIMIT_PROCESS_MEMORY;
+        limits.BasicLimitInformation.ActiveProcessLimit = 32;
+        limits.ProcessMemoryLimit = 512 * 1024 * 1024;
+        set_job_info(handle.raw(), JobObjectExtendedLimitInformation, &limits)?;
+
+        let ui = JOBOBJECT_BASIC_UI_RESTRICTIONS {
+            UIRestrictionsClass: JOB_OBJECT_UILIMIT_HANDLES
+                | JOB_OBJECT_UILIMIT_READCLIPBOARD
+                | JOB_OBJECT_UILIMIT_WRITECLIPBOARD
+                | JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS
+                | JOB_OBJECT_UILIMIT_DISPLAYSETTINGS
+                | JOB_OBJECT_UILIMIT_GLOBALATOMS
+                | JOB_OBJECT_UILIMIT_DESKTOP
+                | JOB_OBJECT_UILIMIT_EXITWINDOWS,
+        };
+        set_job_info(handle.raw(), JobObjectBasicUIRestrictions, &ui)?;
+        Ok(Self { handle })
+    }
+
+    fn assign(&self, process: HANDLE) -> io::Result<()> {
+        if unsafe { AssignProcessToJobObject(self.handle.raw(), process) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+fn set_job_info<T>(job: HANDLE, class: i32, value: &T) -> io::Result<()> {
+    if unsafe {
+        SetInformationJobObject(
+            job,
+            class,
+            std::ptr::from_ref(value).cast(),
+            std::mem::size_of::<T>() as u32,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+struct InheritablePipe {
+    read: OwnedHandle,
+    write: OwnedHandle,
+}
+
+impl InheritablePipe {
+    fn new() -> io::Result<Self> {
+        let mut sa = SECURITY_ATTRIBUTES {
+            nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: std::ptr::null_mut(),
+            bInheritHandle: 1,
+        };
+        let mut read = std::ptr::null_mut();
+        let mut write = std::ptr::null_mut();
+        if unsafe { CreatePipe(&mut read, &mut write, &mut sa, 0) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if unsafe { SetHandleInformation(read, HANDLE_FLAG_INHERIT, 0) } == 0 {
+            unsafe {
+                CloseHandle(read);
+                CloseHandle(write);
+            }
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self {
+            read: OwnedHandle::new(read),
+            write: OwnedHandle::new(write),
+        })
+    }
+
+    fn into_reader(self) -> PipeReader {
+        PipeReader {
+            read: Some(self.read),
+            child_write: Some(self.write),
+        }
+    }
+}
+
+struct PipeReader {
+    read: Option<OwnedHandle>,
+    child_write: Option<OwnedHandle>,
+}
+
+impl PipeReader {
+    fn child_write_handle(&self) -> HANDLE {
+        self.child_write
+            .as_ref()
+            .map_or(std::ptr::null_mut(), OwnedHandle::raw)
+    }
+
+    fn close_child_write(&mut self) {
+        self.child_write.take();
+    }
+
+    fn read_async(&mut self) -> std::thread::JoinHandle<io::Result<Vec<u8>>> {
+        let handle = self.read.take().expect("pipe reader already consumed");
+        std::thread::spawn(move || {
+            let mut file = unsafe { std::fs::File::from_raw_handle(handle.into_raw().cast()) };
+            let mut output = Vec::new();
+            file.read_to_end(&mut output)?;
+            Ok(output)
+        })
+    }
+}
+
+struct OwnedHandle(HANDLE);
+
+unsafe impl Send for OwnedHandle {}
+
+impl OwnedHandle {
+    fn new(handle: HANDLE) -> Self {
+        Self(handle)
+    }
+
+    fn new_checked(handle: HANDLE) -> io::Result<Self> {
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self(handle))
+    }
+
+    fn nul_read() -> io::Result<Self> {
+        let mut sa = SECURITY_ATTRIBUTES {
+            nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: std::ptr::null_mut(),
+            bInheritHandle: 1,
+        };
+        let path = str_to_wide("NUL");
+        let handle = unsafe {
+            CreateFileW(
+                path.as_ptr(),
+                GENERIC_READ,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                &mut sa,
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                std::ptr::null_mut(),
+            )
+        };
+        Self::new_checked(handle)
+    }
+
+    fn raw(&self) -> HANDLE {
+        self.0
+    }
+
+    fn into_raw(mut self) -> HANDLE {
+        let handle = self.0;
+        self.0 = std::ptr::null_mut();
+        handle
+    }
+}
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        if !self.0.is_null() && self.0 != INVALID_HANDLE_VALUE {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+}
+
+fn join_reader(handle: std::thread::JoinHandle<io::Result<Vec<u8>>>) -> io::Result<Vec<u8>> {
+    handle
+        .join()
+        .map_err(|_| io::Error::other("process pipe reader thread panicked"))?
+}
+
+struct ProcThreadAttributes {
+    buffer: Vec<u8>,
+}
+
+impl ProcThreadAttributes {
+    fn new(count: u32) -> io::Result<Self> {
+        let mut size = 0usize;
+        unsafe {
+            InitializeProcThreadAttributeList(std::ptr::null_mut(), count, 0, &mut size);
+        }
+        if size == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let mut buffer = vec![0u8; size];
+        if unsafe {
+            InitializeProcThreadAttributeList(buffer.as_mut_ptr().cast(), count, 0, &mut size)
+        } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self { buffer })
+    }
+
+    fn update(
+        &mut self,
+        attribute: usize,
+        value: *const std::ffi::c_void,
+        size: usize,
+    ) -> io::Result<()> {
+        if unsafe {
+            UpdateProcThreadAttribute(
+                self.as_mut_ptr(),
+                0,
+                attribute,
+                value,
+                size,
+                std::ptr::null_mut(),
+                std::ptr::null(),
+            )
+        } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut std::ffi::c_void {
+        self.buffer.as_mut_ptr().cast()
+    }
+}
+
+impl Drop for ProcThreadAttributes {
+    fn drop(&mut self) {
+        unsafe {
+            DeleteProcThreadAttributeList(self.buffer.as_mut_ptr().cast());
+        }
+    }
+}
+
+fn run_icacls<const N: usize>(path: &Path, args: [&str; N]) -> io::Result<()> {
+    let output = std::process::Command::new("icacls")
+        .arg(path)
+        .args(args)
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "icacls failed for '{}': {}{}",
+                path.display(),
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn command_line(program: &str, args: &[String]) -> Vec<u16> {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(quote_arg(OsStr::new(program)));
+    parts.extend(args.iter().map(|arg| quote_arg(OsStr::new(arg))));
+    str_to_wide(&parts.join(" "))
+}
+
+fn quote_arg(arg: &OsStr) -> String {
+    let value: Vec<u16> = arg.encode_wide().collect();
+    if value.is_empty() {
+        return "\"\"".to_string();
+    }
+    let needs_quotes = value.iter().any(|ch| {
+        *ch == b' ' as u16 || *ch == b'\t' as u16 || *ch == b'\n' as u16 || *ch == b'"' as u16
+    });
+    if !needs_quotes {
+        return OsString::from_wide(&value).to_string_lossy().into_owned();
+    }
+
+    let mut quoted = String::from("\"");
+    let mut backslashes = 0usize;
+    for ch in OsString::from_wide(&value).to_string_lossy().chars() {
+        match ch {
+            '\\' => backslashes += 1,
+            '"' => {
+                quoted.push_str(&"\\".repeat(backslashes * 2 + 1));
+                quoted.push('"');
+                backslashes = 0;
+            }
+            _ => {
+                quoted.push_str(&"\\".repeat(backslashes));
+                backslashes = 0;
+                quoted.push(ch);
+            }
+        }
+    }
+    quoted.push_str(&"\\".repeat(backslashes * 2));
+    quoted.push('"');
+    quoted
+}
+
+fn resolve_application_name(program: &str) -> Option<Vec<u16>> {
+    let path = Path::new(program);
+    if path.components().count() > 1 {
+        Some(path_to_wide(path))
+    } else {
+        None
+    }
+}
+
+fn environment_block(overrides: &[(String, String)]) -> Vec<u16> {
+    let mut values: Vec<(String, String)> = std::env::vars().collect();
+    for (key, value) in overrides {
+        if let Some(existing) = values
+            .iter_mut()
+            .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        {
+            existing.1 = value.clone();
+        } else {
+            values.push((key.clone(), value.clone()));
+        }
+    }
+    values.sort_by(|left, right| {
+        left.0
+            .to_ascii_uppercase()
+            .cmp(&right.0.to_ascii_uppercase())
+    });
+
+    let mut block = Vec::new();
+    for (key, value) in values {
+        block.extend(OsStr::new(&format!("{key}={value}")).encode_wide());
+        block.push(0);
+    }
+    block.push(0);
+    block
+}
+
+fn path_to_wide(path: &Path) -> Vec<u16> {
+    path.as_os_str().encode_wide().chain(Some(0)).collect()
+}
+
+fn str_to_wide(value: &str) -> Vec<u16> {
+    OsStr::new(value).encode_wide().chain(Some(0)).collect()
+}
+
+fn wide_ptr_to_string(raw: *const u16) -> String {
+    let mut len = 0usize;
+    unsafe {
+        while *raw.add(len) != 0 {
+            len += 1;
+        }
+        OsString::from_wide(std::slice::from_raw_parts(raw, len))
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+fn failed(hr: i32) -> bool {
+    hr < 0
+}

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -1557,12 +1557,124 @@ fn test_linux_process_sandbox_catches_ten_process_escapes() {
     assert!(!outside_dir.exists());
 }
 
+#[cfg(target_os = "windows")]
+#[test]
+fn test_windows_process_sandbox_allows_process_exec_in_workspace() {
+    let allowed = tempfile::tempdir().unwrap();
+    let allowed_file = allowed.path().join("allowed.txt");
+    let previous = std::env::var("HARN_HANDLER_SANDBOX").ok();
+    std::env::set_var("HARN_HANDLER_SANDBOX", "enforce");
+
+    let policy = crate::orchestration::CapabilityPolicy {
+        capabilities: std::collections::BTreeMap::from([
+            ("process".to_string(), vec!["exec".to_string()]),
+            ("workspace".to_string(), vec!["write_text".to_string()]),
+        ]),
+        workspace_roots: vec![allowed.path().display().to_string()],
+        side_effect_level: Some("process_exec".to_string()),
+        ..Default::default()
+    };
+    let command = format!("echo allowed> {}", windows_cmd_quote(&allowed_file));
+    let source = format!(
+        r#"pipeline t(task) {{ shell("{}") }}"#,
+        harn_string_escape(&command)
+    );
+    let result = run_harn_with_policy(&source, policy);
+
+    match previous {
+        Some(value) => std::env::set_var("HARN_HANDLER_SANDBOX", value),
+        None => std::env::remove_var("HARN_HANDLER_SANDBOX"),
+    }
+
+    result.unwrap();
+    assert!(allowed_file.exists());
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn test_windows_process_sandbox_allows_exec_argv0() {
+    let allowed = tempfile::tempdir().unwrap();
+    let previous = std::env::var("HARN_HANDLER_SANDBOX").ok();
+    std::env::set_var("HARN_HANDLER_SANDBOX", "enforce");
+
+    let policy = crate::orchestration::CapabilityPolicy {
+        capabilities: std::collections::BTreeMap::from([(
+            "process".to_string(),
+            vec!["exec".to_string()],
+        )]),
+        workspace_roots: vec![allowed.path().display().to_string()],
+        side_effect_level: Some("process_exec".to_string()),
+        ..Default::default()
+    };
+    let result = run_harn_with_policy(
+        r#"pipeline t(task) { exec("cmd", "/C", "exit 0") }"#,
+        policy,
+    );
+
+    match previous {
+        Some(value) => std::env::set_var("HARN_HANDLER_SANDBOX", value),
+        None => std::env::remove_var("HARN_HANDLER_SANDBOX"),
+    }
+
+    result.unwrap();
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn test_windows_process_sandbox_denies_write_outside_workspace() {
+    let allowed = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let outside_file = outside.path().join("blocked.txt");
+    let previous = std::env::var("HARN_HANDLER_SANDBOX").ok();
+    std::env::set_var("HARN_HANDLER_SANDBOX", "enforce");
+
+    let policy = crate::orchestration::CapabilityPolicy {
+        capabilities: std::collections::BTreeMap::from([
+            ("process".to_string(), vec!["exec".to_string()]),
+            ("workspace".to_string(), vec!["write_text".to_string()]),
+        ]),
+        workspace_roots: vec![allowed.path().display().to_string()],
+        side_effect_level: Some("process_exec".to_string()),
+        ..Default::default()
+    };
+    let command = format!("echo denied> {}", windows_cmd_quote(&outside_file));
+    let source = format!(
+        r#"pipeline t(task) {{ shell("{}") }}"#,
+        harn_string_escape(&command)
+    );
+    let err = run_harn_with_policy(&source, policy).unwrap_err();
+
+    match previous {
+        Some(value) => std::env::set_var("HARN_HANDLER_SANDBOX", value),
+        None => std::env::remove_var("HARN_HANDLER_SANDBOX"),
+    }
+
+    assert!(matches!(
+        err,
+        VmError::CategorizedError {
+            category: crate::value::ErrorCategory::ToolRejected,
+            ..
+        }
+    ));
+    assert!(
+        err.to_string().contains("sandbox violation")
+            || err.to_string().contains("process sandbox failed"),
+        "expected sandbox denial, got {err}"
+    );
+    assert!(!outside_file.exists());
+}
+
+#[cfg(target_os = "windows")]
+fn windows_cmd_quote(path: &std::path::Path) -> String {
+    format!(r#""{}""#, path.display())
+}
+
 #[cfg(target_os = "linux")]
 fn shell_quote(path: &std::path::Path) -> String {
     format!("'{}'", path.display().to_string().replace('\'', "'\\''"))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 fn harn_string_escape(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }


### PR DESCRIPTION
## Summary
- add a Windows process launcher that runs policy-scoped commands in a no-capability AppContainer and restrictive Job Object
- temporarily grant AppContainer ACL access only to workspace roots and clean those grants up after the child exits
- route internal exec/shell/workflow verify command paths through a shared command_output helper and add Windows-gated runtime tests

Closes #615.

## Verification
- cargo fmt
- CARGO_TARGET_DIR=/tmp/harn-target-issue615 cargo check -p harn-vm
- CARGO_TARGET_DIR=/tmp/harn-target-issue615 cargo test -p harn-vm sandbox -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-target-issue615 cargo test -p harn-vm test_policy_workspace_roots_reject_process_cwd_escape -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-target-issue615 make test
- CARGO_TARGET_DIR=/tmp/harn-win-sandbox-check-target cargo check --target x86_64-pc-windows-msvc (temporary Windows-only launcher harness)
- pre-commit hook: fmt, clippy, gen-highlight
- pre-push hook: 2216 tests passed

Note: full `cargo check -p harn-vm --target x86_64-pc-windows-msvc` cannot complete on this macOS host because transitive C crates require Windows SDK/C headers (`ring`, `aws-lc-sys`, `libsqlite3-sys`). The Windows-only launcher itself was type-checked in a minimal Windows-target harness.