### PR TITLE
[codex] Add HTTP server stdlib primitives

### DIFF
--- a/conformance/tests/integration/http_server_stdlib.expected
+++ b/conformance/tests/integration/http_server_stdlib.expected
@@ -1,0 +1,12 @@
+202
+after-b
+push
+before-a,before-b,handler,after-a,after-b
+413
+4
+true:kept-text
+503
+false
+503
+true
+503

--- a/conformance/tests/integration/http_server_stdlib.harn
+++ b/conformance/tests/integration/http_server_stdlib.harn
@@ -1,0 +1,80 @@
+pipeline default() {
+  let server = http_server({max_body_bytes: 16, retain_raw_body: true})
+  http_server_before(server, { req -> req + {order: "before-a"} })
+  http_server_before(server, { req -> req + {order: req.order + ",before-b"} })
+  http_server_after(
+    server,
+    { response, _req ->
+    let prior = response.headers["x-order"] ?? ""
+    response + {headers: response.headers + {["x-order"]: prior + ",after-a"}}
+  },
+  )
+  http_server_after(
+    server,
+    { response, _req ->
+    let prior = response.headers["x-order"] ?? ""
+    response
+    + {headers: response.headers + {["x-order"]: prior + ",after-b", ["x-after"]: "after-b"}}
+  },
+  )
+  http_server_route(
+    server,
+    "POST",
+    "/hooks/{tenant}/{trigger}",
+    { req ->
+    assert(req.path_params.tenant == "acme", "tenant path param")
+    assert(req.path_params.trigger == "push", "trigger path param")
+    assert(req.query.mode == "fast", "query param")
+    assert(http_header(req, "X-Signature") == "sig", "case-insensitive header")
+    assert(bytes_to_string(req.raw_body) == "{\"ok\":true}", "raw body is retained")
+    assert(req.client_ip == "203.0.113.7", "client IP metadata")
+    http_response_json(
+    {accepted: req.path_params.trigger, tenant: req.path_params.tenant},
+    {status: 202, headers: {["x-handler"]: "ok", ["x-order"]: req.order + ",handler"}},
+  )
+  },
+    {max_body_bytes: 64},
+  )
+  let response = http_server_test(
+    server,
+    {
+    method: "post",
+    path: "/hooks/acme/push?mode=fast",
+    headers: {["X-Signature"]: "sig"},
+    body: "{\"ok\":true}",
+    client_ip: "203.0.113.7",
+  },
+  )
+  println(response.status)
+  println(http_header(response, "X-After"))
+  println(json_parse(response.body).accepted)
+  println(http_header(response, "x-order"))
+  http_server_route(
+    server,
+    "POST",
+    "/limited",
+    { _req -> http_response_text("unreachable") },
+    {max_body_bytes: 4},
+  )
+  let rejected = http_server_request(server, {method: "POST", path: "/limited", body: "12345"})
+  println(rejected.status)
+  println(http_header(rejected, "x-harn-body-limit"))
+  http_server_route(
+    server,
+    "POST",
+    "/discard",
+    { req -> http_response_text(to_string(req.raw_body == nil) + ":" + req.body) },
+    {retain_raw_body: false},
+  )
+  let discarded = http_server_test(server, {method: "POST", path: "/discard", body: "kept-text"})
+  println(discarded.body)
+  http_server_set_ready(server, false)
+  println(http_server_test(server, {method: "POST", path: "/discard"}).status)
+  http_server_set_ready(server, true)
+  http_server_readiness(server, { _server -> false })
+  println(http_server_ready(server))
+  println(http_server_test(server, {method: "POST", path: "/discard"}).status)
+  http_server_on_shutdown(server, { _server -> nil })
+  println(http_server_shutdown(server))
+  println(http_server_test(server, {method: "POST", path: "/discard"}).status)
+}

--- a/crates/harn-parser/src/builtin_signatures/signatures/integrations.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/integrations.rs
@@ -60,6 +60,10 @@ pub(crate) const SIGNATURES: &[BuiltinSig] = &[
         return_type: Some(BuiltinReturn::Named("dict")),
     },
     BuiltinSig {
+        name: "http_header",
+        return_type: Some(BuiltinReturn::Union(UNION_STRING_NIL)),
+    },
+    BuiltinSig {
         name: "http_mock",
         return_type: Some(BuiltinReturn::Named("nil")),
     },
@@ -85,6 +89,66 @@ pub(crate) const SIGNATURES: &[BuiltinSig] = &[
     },
     BuiltinSig {
         name: "http_request",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "http_response",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "http_response_bytes",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "http_response_json",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "http_response_text",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "http_server",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "http_server_after",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "http_server_before",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "http_server_on_shutdown",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "http_server_readiness",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "http_server_ready",
+        return_type: Some(BuiltinReturn::Named("bool")),
+    },
+    BuiltinSig {
+        name: "http_server_request",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "http_server_route",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "http_server_set_ready",
+        return_type: Some(BuiltinReturn::Named("bool")),
+    },
+    BuiltinSig {
+        name: "http_server_shutdown",
+        return_type: Some(BuiltinReturn::Named("bool")),
+    },
+    BuiltinSig {
+        name: "http_server_test",
         return_type: Some(BuiltinReturn::Named("dict")),
     },
     BuiltinSig {

--- a/crates/harn-vm/src/http.rs
+++ b/crates/harn-vm/src/http.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::rc::Rc;
 use std::time::{Duration, SystemTime};
 
-use crate::value::{VmError, VmValue};
+use crate::value::{VmClosure, VmError, VmValue};
 use crate::vm::Vm;
 
 use base64::Engine;
@@ -236,6 +236,28 @@ struct TransportMockCall {
     data: Option<String>,
 }
 
+#[derive(Clone)]
+struct HttpServerRoute {
+    method: String,
+    template: String,
+    handler: Rc<VmClosure>,
+    max_body_bytes: Option<usize>,
+    retain_raw_body: Option<bool>,
+}
+
+#[derive(Clone)]
+struct HttpServer {
+    routes: Vec<HttpServerRoute>,
+    before: Vec<Rc<VmClosure>>,
+    after: Vec<Rc<VmClosure>>,
+    ready: bool,
+    readiness: Option<Rc<VmClosure>>,
+    shutdown_hooks: Vec<Rc<VmClosure>>,
+    shutdown: bool,
+    max_body_bytes: usize,
+    retain_raw_body: bool,
+}
+
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_BACKOFF_MS: u64 = 1_000;
 const MAX_RETRY_DELAY_MS: u64 = 60_000;
@@ -244,11 +266,13 @@ const DEFAULT_RETRYABLE_METHODS: [&str; 5] = ["GET", "HEAD", "PUT", "DELETE", "O
 const DEFAULT_TRANSPORT_RECEIVE_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_MAX_STREAM_EVENTS: usize = 10_000;
 const DEFAULT_MAX_MESSAGE_BYTES: usize = 1024 * 1024;
+const DEFAULT_SERVER_MAX_BODY_BYTES: usize = 1024 * 1024;
 const MAX_HTTP_SESSIONS: usize = 64;
 const MAX_HTTP_STREAMS: usize = 64;
 const MAX_SSE_STREAMS: usize = 64;
 const MAX_WEBSOCKETS: usize = 64;
 const MULTIPART_MOCK_BOUNDARY: &str = "harn-boundary";
+const MAX_HTTP_SERVERS: usize = 128;
 
 thread_local! {
     static HTTP_MOCKS: RefCell<Vec<HttpMock>> = const { RefCell::new(Vec::new()) };
@@ -262,6 +286,7 @@ thread_local! {
     static WEBSOCKET_HANDLES: RefCell<HashMap<String, WebSocketHandle>> = RefCell::new(HashMap::new());
     static TRANSPORT_MOCK_CALLS: RefCell<Vec<TransportMockCall>> = const { RefCell::new(Vec::new()) };
     static TRANSPORT_HANDLE_COUNTER: RefCell<u64> = const { RefCell::new(0) };
+    static HTTP_SERVERS: RefCell<HashMap<String, HttpServer>> = RefCell::new(HashMap::new());
 }
 
 /// Reset thread-local HTTP mock state. Call between test runs.
@@ -286,6 +311,7 @@ pub fn reset_http_state() {
     WEBSOCKET_HANDLES.with(|handles| handles.borrow_mut().clear());
     TRANSPORT_MOCK_CALLS.with(|calls| calls.borrow_mut().clear());
     TRANSPORT_HANDLE_COUNTER.with(|counter| *counter.borrow_mut() = 0);
+    HTTP_SERVERS.with(|servers| servers.borrow_mut().clear());
 }
 
 pub fn push_http_mock(
@@ -741,6 +767,478 @@ fn consume_http_mock(
     Some(response)
 }
 
+fn vm_string(value: impl AsRef<str>) -> VmValue {
+    VmValue::String(Rc::from(value.as_ref()))
+}
+
+fn dict_value(entries: BTreeMap<String, VmValue>) -> VmValue {
+    VmValue::Dict(Rc::new(entries))
+}
+
+fn get_bool_option(options: &BTreeMap<String, VmValue>, key: &str, default: bool) -> bool {
+    match options.get(key) {
+        Some(VmValue::Bool(value)) => *value,
+        _ => default,
+    }
+}
+
+fn get_usize_option(
+    options: &BTreeMap<String, VmValue>,
+    key: &str,
+    default: usize,
+) -> Result<usize, VmError> {
+    match options.get(key).and_then(VmValue::as_int) {
+        Some(value) if value >= 0 => Ok(value as usize),
+        Some(_) => Err(vm_error(format!("http_server: {key} must be non-negative"))),
+        None => Ok(default),
+    }
+}
+
+fn get_optional_usize_option(
+    options: &BTreeMap<String, VmValue>,
+    key: &str,
+) -> Result<Option<usize>, VmError> {
+    match options.get(key).and_then(VmValue::as_int) {
+        Some(value) if value >= 0 => Ok(Some(value as usize)),
+        Some(_) => Err(vm_error(format!(
+            "http_server_route: {key} must be non-negative"
+        ))),
+        None => Ok(None),
+    }
+}
+
+fn server_from_value(value: &VmValue, builtin: &str) -> Result<String, VmError> {
+    handle_from_value(value, builtin)
+}
+
+fn closure_arg(args: &[VmValue], index: usize, builtin: &str) -> Result<Rc<VmClosure>, VmError> {
+    match args.get(index) {
+        Some(VmValue::Closure(closure)) => Ok(closure.clone()),
+        Some(other) => Err(vm_error(format!(
+            "{builtin}: argument {} must be a closure, got {}",
+            index + 1,
+            other.type_name()
+        ))),
+        None => Err(vm_error(format!(
+            "{builtin}: missing closure argument {}",
+            index + 1
+        ))),
+    }
+}
+
+fn http_server_handle_value(id: &str) -> VmValue {
+    let mut dict = BTreeMap::new();
+    dict.insert("id".to_string(), vm_string(id));
+    dict.insert("kind".to_string(), vm_string("http_server"));
+    dict_value(dict)
+}
+
+fn header_lookup_value(headers: &BTreeMap<String, VmValue>, name: &str) -> VmValue {
+    headers
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.clone())
+        .unwrap_or(VmValue::Nil)
+}
+
+fn headers_from_value(value: &VmValue) -> BTreeMap<String, VmValue> {
+    match value {
+        VmValue::Dict(dict) => dict
+            .get("headers")
+            .and_then(VmValue::as_dict)
+            .map(|headers| {
+                headers
+                    .iter()
+                    .map(|(key, value)| (key.to_ascii_lowercase(), vm_string(value.display())))
+                    .collect()
+            })
+            .unwrap_or_else(|| {
+                dict.iter()
+                    .map(|(key, value)| (key.to_ascii_lowercase(), vm_string(value.display())))
+                    .collect()
+            }),
+        _ => BTreeMap::new(),
+    }
+}
+
+fn normalize_headers(value: Option<&VmValue>) -> BTreeMap<String, VmValue> {
+    match value.and_then(VmValue::as_dict) {
+        Some(headers) => headers
+            .iter()
+            .map(|(key, value)| (key.to_ascii_lowercase(), vm_string(value.display())))
+            .collect(),
+        None => BTreeMap::new(),
+    }
+}
+
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'+' {
+            out.push(b' ');
+            i += 1;
+            continue;
+        }
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
+                out.push((hi << 4) | lo);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn hex_val(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn split_path_and_query(raw_path: &str) -> (String, BTreeMap<String, VmValue>) {
+    let (path, query) = raw_path.split_once('?').unwrap_or((raw_path, ""));
+    let mut query_map = BTreeMap::new();
+    for pair in query.split('&').filter(|part| !part.is_empty()) {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        query_map.insert(percent_decode(key), vm_string(percent_decode(value)));
+    }
+    (
+        if path.is_empty() { "/" } else { path }.to_string(),
+        query_map,
+    )
+}
+
+fn request_body_bytes(input: &BTreeMap<String, VmValue>) -> Vec<u8> {
+    match input.get("raw_body").or_else(|| input.get("body")) {
+        Some(VmValue::Bytes(bytes)) => bytes.as_ref().clone(),
+        Some(value) => value.display().into_bytes(),
+        None => Vec::new(),
+    }
+}
+
+fn request_value(
+    method: &str,
+    path: &str,
+    path_params: BTreeMap<String, VmValue>,
+    mut query: BTreeMap<String, VmValue>,
+    input: &BTreeMap<String, VmValue>,
+    body_bytes: &[u8],
+    retain_raw_body: bool,
+) -> VmValue {
+    if let Some(explicit_query) = input.get("query").and_then(VmValue::as_dict) {
+        query.extend(
+            explicit_query
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone())),
+        );
+    }
+
+    let headers = normalize_headers(input.get("headers"));
+    let body = String::from_utf8_lossy(body_bytes).into_owned();
+    let mut request = BTreeMap::new();
+    request.insert("method".to_string(), vm_string(method));
+    request.insert("path".to_string(), vm_string(path));
+    let path_params = dict_value(path_params);
+    request.insert("path_params".to_string(), path_params.clone());
+    request.insert("params".to_string(), path_params);
+    request.insert("query".to_string(), dict_value(query));
+    request.insert("headers".to_string(), dict_value(headers));
+    request.insert("body".to_string(), vm_string(body));
+    request.insert(
+        "raw_body".to_string(),
+        if retain_raw_body {
+            VmValue::Bytes(Rc::new(body_bytes.to_vec()))
+        } else {
+            VmValue::Nil
+        },
+    );
+    request.insert(
+        "body_bytes".to_string(),
+        VmValue::Int(body_bytes.len() as i64),
+    );
+    request.insert(
+        "remote_addr".to_string(),
+        input
+            .get("remote_addr")
+            .or_else(|| input.get("remote"))
+            .map(|value| vm_string(value.display()))
+            .unwrap_or(VmValue::Nil),
+    );
+    request.insert(
+        "client_ip".to_string(),
+        input
+            .get("client_ip")
+            .or_else(|| input.get("remote_ip"))
+            .or_else(|| input.get("ip"))
+            .map(|value| vm_string(value.display()))
+            .unwrap_or(VmValue::Nil),
+    );
+    dict_value(request)
+}
+
+fn normalize_status(status: i64) -> i64 {
+    if (100..=999).contains(&status) {
+        status
+    } else {
+        500
+    }
+}
+
+fn response_with_kind(
+    status: i64,
+    mut headers: BTreeMap<String, VmValue>,
+    body: VmValue,
+    body_kind: &str,
+) -> VmValue {
+    let status = normalize_status(status);
+    let mut response = BTreeMap::new();
+    if body_kind == "json" && matches!(header_lookup_value(&headers, "content-type"), VmValue::Nil)
+    {
+        headers.insert(
+            "content-type".to_string(),
+            vm_string("application/json; charset=utf-8"),
+        );
+    } else if body_kind == "text"
+        && matches!(header_lookup_value(&headers, "content-type"), VmValue::Nil)
+    {
+        headers.insert(
+            "content-type".to_string(),
+            vm_string("text/plain; charset=utf-8"),
+        );
+    }
+    response.insert("status".to_string(), VmValue::Int(status));
+    response.insert("headers".to_string(), dict_value(headers));
+    response.insert(
+        "ok".to_string(),
+        VmValue::Bool((200..300).contains(&status)),
+    );
+    response.insert("body_kind".to_string(), vm_string(body_kind));
+    match body {
+        VmValue::Bytes(bytes) => {
+            response.insert(
+                "body".to_string(),
+                vm_string(String::from_utf8_lossy(&bytes)),
+            );
+            response.insert("raw_body".to_string(), VmValue::Bytes(bytes));
+        }
+        other => {
+            response.insert("body".to_string(), vm_string(other.display()));
+            response.insert(
+                "raw_body".to_string(),
+                VmValue::Bytes(Rc::new(other.display().into_bytes())),
+            );
+        }
+    }
+    dict_value(response)
+}
+
+fn normalize_response(value: VmValue) -> VmValue {
+    match value {
+        VmValue::Dict(dict) if dict.contains_key("status") => {
+            let status = dict.get("status").and_then(VmValue::as_int).unwrap_or(200);
+            let headers = dict
+                .get("headers")
+                .and_then(VmValue::as_dict)
+                .cloned()
+                .unwrap_or_default();
+            let body_kind = dict
+                .get("body_kind")
+                .or_else(|| dict.get("kind"))
+                .map(|value| value.display())
+                .unwrap_or_else(|| "text".to_string());
+            let body = dict
+                .get("raw_body")
+                .filter(|value| matches!(value, VmValue::Bytes(_)))
+                .or_else(|| dict.get("body"))
+                .cloned()
+                .unwrap_or(VmValue::Nil);
+            response_with_kind(status, headers, body, &body_kind)
+        }
+        VmValue::Nil => response_with_kind(204, BTreeMap::new(), VmValue::Nil, "text"),
+        other => response_with_kind(200, BTreeMap::new(), other, "text"),
+    }
+}
+
+fn body_limit_response(limit: usize, actual: usize) -> VmValue {
+    let mut headers = BTreeMap::new();
+    headers.insert(
+        "content-type".to_string(),
+        vm_string("text/plain; charset=utf-8"),
+    );
+    headers.insert("connection".to_string(), vm_string("close"));
+    headers.insert(
+        "x-harn-body-limit".to_string(),
+        vm_string(limit.to_string()),
+    );
+    response_with_kind(
+        413,
+        headers,
+        vm_string(format!("request body too large: {actual} > {limit} bytes")),
+        "text",
+    )
+}
+
+fn not_found_response(method: &str, path: &str) -> VmValue {
+    response_with_kind(
+        404,
+        BTreeMap::new(),
+        vm_string(format!("no route for {method} {path}")),
+        "text",
+    )
+}
+
+fn unavailable_response(message: &str) -> VmValue {
+    response_with_kind(503, BTreeMap::new(), vm_string(message), "text")
+}
+
+fn route_template_match(template: &str, path: &str) -> Option<BTreeMap<String, VmValue>> {
+    let template_segments: Vec<&str> = template.trim_matches('/').split('/').collect();
+    let path_segments: Vec<&str> = path.trim_matches('/').split('/').collect();
+    if template == "/" && path == "/" {
+        return Some(BTreeMap::new());
+    }
+    if template_segments.len() != path_segments.len() {
+        return None;
+    }
+    let mut params = BTreeMap::new();
+    for (tmpl, actual) in template_segments.iter().zip(path_segments.iter()) {
+        if tmpl.starts_with('{') && tmpl.ends_with('}') && tmpl.len() > 2 {
+            params.insert(
+                tmpl[1..tmpl.len() - 1].to_string(),
+                vm_string(percent_decode(actual)),
+            );
+        } else if tmpl.starts_with(':') && tmpl.len() > 1 {
+            params.insert(tmpl[1..].to_string(), vm_string(percent_decode(actual)));
+        } else if tmpl != actual {
+            return None;
+        }
+    }
+    Some(params)
+}
+
+fn matching_route(
+    server: &HttpServer,
+    method: &str,
+    path: &str,
+) -> Option<(HttpServerRoute, BTreeMap<String, VmValue>)> {
+    server.routes.iter().find_map(|route| {
+        if route.method != "*" && !route.method.eq_ignore_ascii_case(method) {
+            return None;
+        }
+        route_template_match(&route.template, path).map(|params| (route.clone(), params))
+    })
+}
+
+async fn call_server_closure(
+    closure: &Rc<VmClosure>,
+    args: &[VmValue],
+    builtin: &str,
+) -> Result<VmValue, VmError> {
+    let mut vm = crate::vm::clone_async_builtin_child_vm()
+        .ok_or_else(|| vm_error(format!("{builtin}: requires an async builtin VM context")))?;
+    vm.call_closure_pub(closure, args).await
+}
+
+fn value_is_response(value: &VmValue) -> bool {
+    matches!(value, VmValue::Dict(dict) if dict.contains_key("status"))
+}
+
+async fn run_http_server_request(server_id: &str, request: VmValue) -> Result<VmValue, VmError> {
+    let server = HTTP_SERVERS.with(|servers| servers.borrow().get(server_id).cloned());
+    let Some(server) = server else {
+        return Err(vm_error(format!(
+            "http_server_request: unknown server handle '{server_id}'"
+        )));
+    };
+    if server.shutdown {
+        return Ok(unavailable_response("server is shut down"));
+    }
+    if !server.ready {
+        return Ok(unavailable_response("server is not ready"));
+    }
+    if let Some(readiness) = &server.readiness {
+        let ready = call_server_closure(
+            readiness,
+            &[http_server_handle_value(server_id)],
+            "http_server_request",
+        )
+        .await?;
+        if !ready.is_truthy() {
+            return Ok(unavailable_response("server is not ready"));
+        }
+    }
+
+    let input = request.as_dict().cloned().unwrap_or_default();
+    let method = input
+        .get("method")
+        .map(|value| value.display())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "GET".to_string())
+        .to_ascii_uppercase();
+    let raw_path = input
+        .get("path")
+        .map(|value| value.display())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "/".to_string());
+    let (path, query) = split_path_and_query(&raw_path);
+    let body_bytes = request_body_bytes(&input);
+
+    let Some((route, path_params)) = matching_route(&server, &method, &path) else {
+        return Ok(not_found_response(&method, &path));
+    };
+
+    let limit = route.max_body_bytes.unwrap_or(server.max_body_bytes);
+    if body_bytes.len() > limit {
+        return Ok(body_limit_response(limit, body_bytes.len()));
+    }
+    let retain_raw_body = route.retain_raw_body.unwrap_or(server.retain_raw_body);
+    let mut req = request_value(
+        &method,
+        &path,
+        path_params,
+        query,
+        &input,
+        &body_bytes,
+        retain_raw_body,
+    );
+
+    for before in &server.before {
+        let result = call_server_closure(before, &[req.clone()], "http_server_request").await?;
+        if value_is_response(&result) {
+            return Ok(normalize_response(result));
+        }
+        if !matches!(result, VmValue::Nil) {
+            req = result;
+        }
+    }
+
+    let handler_result =
+        call_server_closure(&route.handler, &[req.clone()], "http_server_request").await?;
+    let mut response = normalize_response(handler_result);
+
+    for after in &server.after {
+        let result = call_server_closure(
+            after,
+            &[response.clone(), req.clone()],
+            "http_server_request",
+        )
+        .await?;
+        if !matches!(result, VmValue::Nil) {
+            response = normalize_response(result);
+        }
+    }
+
+    Ok(response)
+}
+
 /// Register HTTP builtins on a VM.
 pub fn register_http_builtins(vm: &mut Vm) {
     vm.register_async_builtin("http_get", |args| async move {
@@ -757,6 +1255,318 @@ pub fn register_http_builtins(vm: &mut Vm) {
     });
     vm.register_async_builtin("http_delete", |args| async move {
         http_verb_handler("DELETE", false, args).await
+    });
+
+    // --- Inbound HTTP server primitives ---
+
+    vm.register_builtin("http_server", |args, _out| {
+        let options = get_options_arg(args, 0);
+        let server = HttpServer {
+            routes: Vec::new(),
+            before: Vec::new(),
+            after: Vec::new(),
+            ready: get_bool_option(&options, "ready", true),
+            readiness: None,
+            shutdown_hooks: Vec::new(),
+            shutdown: false,
+            max_body_bytes: get_usize_option(
+                &options,
+                "max_body_bytes",
+                DEFAULT_SERVER_MAX_BODY_BYTES,
+            )?,
+            retain_raw_body: get_bool_option(&options, "retain_raw_body", true),
+        };
+        let id = next_transport_handle("http-server");
+        HTTP_SERVERS.with(|servers| {
+            let mut servers = servers.borrow_mut();
+            if servers.len() >= MAX_HTTP_SERVERS {
+                return Err(vm_error(format!(
+                    "http_server: maximum open servers ({MAX_HTTP_SERVERS}) reached"
+                )));
+            }
+            servers.insert(id.clone(), server);
+            Ok(())
+        })?;
+        Ok(http_server_handle_value(&id))
+    });
+
+    vm.register_builtin("http_server_route", |args, _out| {
+        if args.len() < 4 {
+            return Err(vm_error(
+                "http_server_route: requires server, method, path template, and handler",
+            ));
+        }
+        let server_id = server_from_value(&args[0], "http_server_route")?;
+        let method = args[1].display().to_ascii_uppercase();
+        if method.is_empty() {
+            return Err(vm_error("http_server_route: method is required"));
+        }
+        let template = args[2].display();
+        if !template.starts_with('/') {
+            return Err(vm_error(
+                "http_server_route: path template must start with '/'",
+            ));
+        }
+        let handler = closure_arg(args, 3, "http_server_route")?;
+        let options = get_options_arg(args, 4);
+        let route = HttpServerRoute {
+            method,
+            template,
+            handler,
+            max_body_bytes: get_optional_usize_option(&options, "max_body_bytes")?,
+            retain_raw_body: match options.get("retain_raw_body") {
+                Some(VmValue::Bool(value)) => Some(*value),
+                _ => None,
+            },
+        };
+        HTTP_SERVERS.with(|servers| {
+            let mut servers = servers.borrow_mut();
+            let server = servers.get_mut(&server_id).ok_or_else(|| {
+                vm_error(format!("http_server_route: unknown server '{server_id}'"))
+            })?;
+            server.routes.push(route);
+            Ok::<_, VmError>(())
+        })?;
+        Ok(http_server_handle_value(&server_id))
+    });
+
+    vm.register_builtin("http_server_before", |args, _out| {
+        if args.len() < 2 {
+            return Err(vm_error("http_server_before: requires server and handler"));
+        }
+        let server_id = server_from_value(&args[0], "http_server_before")?;
+        let handler = closure_arg(args, 1, "http_server_before")?;
+        HTTP_SERVERS.with(|servers| {
+            let mut servers = servers.borrow_mut();
+            let server = servers.get_mut(&server_id).ok_or_else(|| {
+                vm_error(format!("http_server_before: unknown server '{server_id}'"))
+            })?;
+            server.before.push(handler);
+            Ok::<_, VmError>(())
+        })?;
+        Ok(http_server_handle_value(&server_id))
+    });
+
+    vm.register_builtin("http_server_after", |args, _out| {
+        if args.len() < 2 {
+            return Err(vm_error("http_server_after: requires server and handler"));
+        }
+        let server_id = server_from_value(&args[0], "http_server_after")?;
+        let handler = closure_arg(args, 1, "http_server_after")?;
+        HTTP_SERVERS.with(|servers| {
+            let mut servers = servers.borrow_mut();
+            let server = servers.get_mut(&server_id).ok_or_else(|| {
+                vm_error(format!("http_server_after: unknown server '{server_id}'"))
+            })?;
+            server.after.push(handler);
+            Ok::<_, VmError>(())
+        })?;
+        Ok(http_server_handle_value(&server_id))
+    });
+
+    vm.register_async_builtin("http_server_request", |args| async move {
+        if args.len() < 2 {
+            return Err(vm_error("http_server_request: requires server and request"));
+        }
+        let server_id = server_from_value(&args[0], "http_server_request")?;
+        run_http_server_request(&server_id, args[1].clone()).await
+    });
+
+    vm.register_async_builtin("http_server_test", |args| async move {
+        if args.len() < 2 {
+            return Err(vm_error("http_server_test: requires server and request"));
+        }
+        let server_id = server_from_value(&args[0], "http_server_test")?;
+        run_http_server_request(&server_id, args[1].clone()).await
+    });
+
+    vm.register_builtin("http_server_set_ready", |args, _out| {
+        if args.len() < 2 {
+            return Err(vm_error(
+                "http_server_set_ready: requires server and ready bool",
+            ));
+        }
+        let server_id = server_from_value(&args[0], "http_server_set_ready")?;
+        let ready = matches!(args[1], VmValue::Bool(true));
+        HTTP_SERVERS.with(|servers| {
+            let mut servers = servers.borrow_mut();
+            let server = servers.get_mut(&server_id).ok_or_else(|| {
+                vm_error(format!(
+                    "http_server_set_ready: unknown server '{server_id}'"
+                ))
+            })?;
+            server.ready = ready;
+            Ok::<_, VmError>(())
+        })?;
+        Ok(VmValue::Bool(ready))
+    });
+
+    vm.register_builtin("http_server_readiness", |args, _out| {
+        if args.len() < 2 {
+            return Err(vm_error(
+                "http_server_readiness: requires server and readiness closure",
+            ));
+        }
+        let server_id = server_from_value(&args[0], "http_server_readiness")?;
+        let handler = closure_arg(args, 1, "http_server_readiness")?;
+        HTTP_SERVERS.with(|servers| {
+            let mut servers = servers.borrow_mut();
+            let server = servers.get_mut(&server_id).ok_or_else(|| {
+                vm_error(format!(
+                    "http_server_readiness: unknown server '{server_id}'"
+                ))
+            })?;
+            server.readiness = Some(handler);
+            Ok::<_, VmError>(())
+        })?;
+        Ok(http_server_handle_value(&server_id))
+    });
+
+    vm.register_async_builtin("http_server_ready", |args| async move {
+        let Some(server_arg) = args.first() else {
+            return Err(vm_error("http_server_ready: requires server"));
+        };
+        let server_id = server_from_value(server_arg, "http_server_ready")?;
+        let server = HTTP_SERVERS.with(|servers| servers.borrow().get(&server_id).cloned());
+        let Some(server) = server else {
+            return Err(vm_error(format!(
+                "http_server_ready: unknown server '{server_id}'"
+            )));
+        };
+        if server.shutdown {
+            return Ok(VmValue::Bool(false));
+        }
+        let Some(readiness) = server.readiness else {
+            return Ok(VmValue::Bool(server.ready));
+        };
+        let result = call_server_closure(
+            &readiness,
+            &[http_server_handle_value(&server_id)],
+            "http_server_ready",
+        )
+        .await?;
+        Ok(VmValue::Bool(result.is_truthy()))
+    });
+
+    vm.register_builtin("http_server_on_shutdown", |args, _out| {
+        if args.len() < 2 {
+            return Err(vm_error(
+                "http_server_on_shutdown: requires server and handler",
+            ));
+        }
+        let server_id = server_from_value(&args[0], "http_server_on_shutdown")?;
+        let handler = closure_arg(args, 1, "http_server_on_shutdown")?;
+        HTTP_SERVERS.with(|servers| {
+            let mut servers = servers.borrow_mut();
+            let server = servers.get_mut(&server_id).ok_or_else(|| {
+                vm_error(format!(
+                    "http_server_on_shutdown: unknown server '{server_id}'"
+                ))
+            })?;
+            server.shutdown_hooks.push(handler);
+            Ok::<_, VmError>(())
+        })?;
+        Ok(http_server_handle_value(&server_id))
+    });
+
+    vm.register_async_builtin("http_server_shutdown", |args| async move {
+        let Some(server_arg) = args.first() else {
+            return Err(vm_error("http_server_shutdown: requires server"));
+        };
+        let server_id = server_from_value(server_arg, "http_server_shutdown")?;
+        let hooks = HTTP_SERVERS.with(|servers| {
+            let mut servers = servers.borrow_mut();
+            let server = servers.get_mut(&server_id).ok_or_else(|| {
+                vm_error(format!(
+                    "http_server_shutdown: unknown server '{server_id}'"
+                ))
+            })?;
+            server.shutdown = true;
+            Ok::<_, VmError>(server.shutdown_hooks.clone())
+        })?;
+        for hook in hooks {
+            let _ = call_server_closure(
+                &hook,
+                &[http_server_handle_value(&server_id)],
+                "http_server_shutdown",
+            )
+            .await?;
+        }
+        Ok(VmValue::Bool(true))
+    });
+
+    vm.register_builtin("http_response", |args, _out| {
+        let status = args.first().and_then(VmValue::as_int).unwrap_or(200);
+        let body = args.get(1).cloned().unwrap_or(VmValue::Nil);
+        let headers = args
+            .get(2)
+            .and_then(VmValue::as_dict)
+            .cloned()
+            .unwrap_or_default();
+        Ok(response_with_kind(status, headers, body, "text"))
+    });
+
+    vm.register_builtin("http_response_text", |args, _out| {
+        let body = args.first().cloned().unwrap_or(VmValue::Nil);
+        let options = get_options_arg(args, 1);
+        let status = options
+            .get("status")
+            .and_then(VmValue::as_int)
+            .unwrap_or(200);
+        let headers = options
+            .get("headers")
+            .and_then(VmValue::as_dict)
+            .cloned()
+            .unwrap_or_default();
+        Ok(response_with_kind(status, headers, body, "text"))
+    });
+
+    vm.register_builtin("http_response_json", |args, _out| {
+        let body = args
+            .first()
+            .map(crate::stdlib::json::vm_value_to_json)
+            .map(vm_string)
+            .unwrap_or_else(|| vm_string("null"));
+        let options = get_options_arg(args, 1);
+        let status = options
+            .get("status")
+            .and_then(VmValue::as_int)
+            .unwrap_or(200);
+        let headers = options
+            .get("headers")
+            .and_then(VmValue::as_dict)
+            .cloned()
+            .unwrap_or_default();
+        Ok(response_with_kind(status, headers, body, "json"))
+    });
+
+    vm.register_builtin("http_response_bytes", |args, _out| {
+        let body = match args.first() {
+            Some(VmValue::Bytes(bytes)) => VmValue::Bytes(bytes.clone()),
+            Some(value) => VmValue::Bytes(Rc::new(value.display().into_bytes())),
+            None => VmValue::Bytes(Rc::new(Vec::new())),
+        };
+        let options = get_options_arg(args, 1);
+        let status = options
+            .get("status")
+            .and_then(VmValue::as_int)
+            .unwrap_or(200);
+        let headers = options
+            .get("headers")
+            .and_then(VmValue::as_dict)
+            .cloned()
+            .unwrap_or_default();
+        Ok(response_with_kind(status, headers, body, "bytes"))
+    });
+
+    vm.register_builtin("http_header", |args, _out| {
+        if args.len() < 2 {
+            return Err(vm_error(
+                "http_header: requires headers/request/response and name",
+            ));
+        }
+        let headers = headers_from_value(&args[0]);
+        Ok(header_lookup_value(&headers, &args[1].display()))
     });
 
     // --- Mock HTTP builtins ---

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -174,6 +174,7 @@ pub fn reset_stdlib_state() {
     json::reset_json_state();
     host::reset_host_state();
     hitl::reset_hitl_state();
+    crate::http::reset_http_state();
     monitors::reset_monitor_state();
     waitpoints::reset_waitpoint_state();
     waitpoint::reset_waitpoint_state();

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -742,6 +742,22 @@ println(text.source.sha256)
 | `websocket_send(socket, message, options?)` | socket: string, message: string or bytes, options: dict | bool | Send a WebSocket text/binary/ping/pong/close message |
 | `websocket_receive(socket, timeout_ms?)` | socket: string, timeout_ms: int | dict or nil | Receive one WebSocket message with timeout/backpressure |
 | `websocket_close(socket)` | socket: string | bool | Close a WebSocket handle |
+| `http_server(options?)` | options: dict | dict | Create an in-process inbound HTTP server definition for host adapters or synthetic tests |
+| `http_server_route(server, method, path_template, handler, options?)` | server: dict/string, method: string, path_template: string, handler: closure, options: dict | dict | Register a route. Templates support `{name}` and `:name` path params |
+| `http_server_before(server, handler)` | server: dict/string, handler: closure | dict | Register before middleware. Return a request to continue or a response dict to short-circuit |
+| `http_server_after(server, handler)` | server: dict/string, handler: closure | dict | Register after middleware. Receives `(response, request)` and may return a replacement response |
+| `http_server_request(server, request)` | server: dict/string, request: dict | dict | Dispatch a synthetic or host-adapted request through the server |
+| `http_server_test(server, request)` | server: dict/string, request: dict | dict | Alias for `http_server_request`, intended for script-level tests |
+| `http_server_set_ready(server, ready)` | server: dict/string, ready: bool | bool | Set the server readiness gate used by request dispatch |
+| `http_server_readiness(server, handler)` | server: dict/string, handler: closure | dict | Register a readiness callback for `http_server_ready` |
+| `http_server_ready(server)` | server: dict/string | bool | Return readiness, invoking the readiness callback when present |
+| `http_server_on_shutdown(server, handler)` | server: dict/string, handler: closure | dict | Register a shutdown lifecycle callback |
+| `http_server_shutdown(server)` | server: dict/string | bool | Mark the server shut down and run shutdown callbacks |
+| `http_response(status, body?, headers?)` | status: int, body: any, headers: dict | dict | Build a response dict |
+| `http_response_text(text, options?)` | text: any, options: dict | dict | Build a text response. Options include `status` and `headers` |
+| `http_response_json(value, options?)` | value: any, options: dict | dict | Build a JSON response with a JSON content type |
+| `http_response_bytes(bytes, options?)` | bytes: bytes/string, options: dict | dict | Build a bytes response |
+| `http_header(headers_or_message, name)` | headers/request/response: dict, name: string | string or nil | Read a header case-insensitively from a header dict, request, or response |
 
 `http_get/post/put/patch/delete/request/session_request` return
 `{status: int, headers: dict, body: string, ok: bool}`.
@@ -782,6 +798,74 @@ retry_ms}`. WebSocket receives return `{type: "text", data}`, `{type:
 "binary", data_base64}`, `{type: "ping", data_base64}`, `{type: "pong",
 data_base64}`, `{type: "close"}`, or `{type: "timeout"}`. Options include
 `max_events`/`max_messages` and `max_message_bytes`.
+
+### Inbound HTTP server primitives
+
+The server builtins define a Harn-native request router without binding a
+socket themselves. A host adapter can translate real HTTP requests into
+`http_server_request(...)`; tests can use the same path with
+`http_server_test(...)`.
+
+Requests passed to route handlers include:
+
+- `method`, `path`, `path_params`/`params`, `query`, and normalized lowercase
+  `headers`
+- `body` as text plus `raw_body` bytes when retained
+- `body_bytes`, `remote_addr`, and `client_ip`
+
+`http_server({max_body_bytes, retain_raw_body, ready})` sets defaults.
+Routes can override `max_body_bytes` and `retain_raw_body`. Body-limit
+rejections return status `413` before middleware or handlers run.
+
+Minimal webhook example:
+
+```harn
+pipeline default() {
+  let server = http_server({max_body_bytes: 1048576, retain_raw_body: true})
+
+  http_server_before(server, { req ->
+    if http_header(req, "origin") != nil {
+      return http_response_text("browser origins are rejected", {status: 403})
+    }
+    req
+  })
+
+  http_server_after(server, { response, _req ->
+    response + {
+      headers: response.headers + {
+        ["strict-transport-security"]: "max-age=31536000",
+      },
+    }
+  })
+
+  http_server_route(server, "POST", "/hooks/{tenant}/{trigger}", { req ->
+    let signature = http_header(req, "x-hub-signature-256")
+    let expected = "sha256=" + hmac_sha256(secret_get("github/webhook-secret"), req.body)
+    if signature != expected {
+      return http_response_text("invalid signature", {status: 401})
+    }
+
+    let payload = json_parse(req.body)
+    trigger_fire("github-webhook", {
+      tenant: req.path_params.tenant,
+      trigger: req.path_params.trigger,
+      payload: payload,
+      raw_body: req.raw_body,
+      client_ip: req.client_ip,
+    })
+    http_response_json({accepted: true}, {status: 202, headers: {["retry-after"]: "0"}})
+  })
+
+  let probe = http_server_test(server, {
+    method: "POST",
+    path: "/hooks/acme/push",
+    headers: {["x-hub-signature-256"]: "sha256=..."},
+    body: "{\"ok\":true}",
+    client_ip: "203.0.113.10",
+  })
+  println(probe.status)
+}
+```
 
 ### Mock HTTP
 


### PR DESCRIPTION
## Summary

- add Harn stdlib primitives for in-process inbound HTTP server definitions, route templates, request shaping, response builders, before/after middleware, body limits, readiness, shutdown hooks, and synthetic dispatch
- add parser signatures and regenerate highlight keywords from the live stdlib registry
- document a minimal webhook server example and add conformance coverage for routing, params, raw body, headers, status/headers, body-limit rejection, readiness/shutdown, and middleware order

Closes #638.

## Validation

- `cargo check -p harn-vm`
- `cargo test -p harn-vm --test builtin_registry_alignment`
- `cargo run --quiet --bin harn -- test conformance --filter http_server_stdlib`
- `cargo run --quiet --bin harn -- fmt --check conformance/tests/integration/http_server_stdlib.harn`
- `cargo run --quiet -p harn-cli -- dump-highlight-keywords --check`
- `make check-docs-snippets`
- pre-commit hook: `cargo fmt --all`, Harn fmt/lint, `make lint`, `make gen-highlight`, markdown lint
- pre-push hook: workspace nextest suite (2310 passed), Harn format/lint, markdown lint
