### PR TITLE
Stabilize orchestrator/connector tests: notify-based file waits, generous spawn deadlines

### DIFF
--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -35,12 +35,16 @@ use tokio::sync::oneshot;
 const STARTUP_PREFIX: &str = "[harn] HTTP listener ready on ";
 const STARTUP_NEEDLE: &str = "HTTP listener ready";
 const SHUTDOWN_NEEDLE: &str = "graceful shutdown complete";
-// Was 5s; bumped to 15s to absorb the cold-start latency the harn-cli
-// binary takes when nextest runs all 2k+ workspace tests in parallel
-// under load. Local fail-fast loops still trip well before any real
-// startup hang surfaces.
-const PROCESS_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(15);
-const EVENT_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(5);
+// Process-level deadline for spawning the orchestrator subprocess and
+// waiting for it to bind its listener / shut down. Tests serialize
+// through a cross-process file lock, so a generous deadline here only
+// affects the failure path — happy-path tests still complete in well
+// under a second of post-spawn wall time. A previous 15s ceiling
+// produced spurious "timed out waiting for listener startup" failures
+// on macOS when dyld + amfi cold-cache lookups for the unsigned
+// debug-build binary exceeded the budget under nextest load.
+const PROCESS_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(60);
+const EVENT_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(10);
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -404,6 +408,11 @@ fn spawn_orchestrator(
         .arg("single-tenant")
         .arg("--bind")
         .arg("127.0.0.1:0")
+        // The 30s default is calibrated for production drains; tests don't
+        // queue real backlogs, so cap shutdown at 5s to keep flake-recovery
+        // bounded.
+        .arg("--shutdown-timeout")
+        .arg("5")
         .stderr(Stdio::piped())
         .stdout(Stdio::null());
     for arg in extra_args {
@@ -443,8 +452,13 @@ struct OrchestratorProcess {
 impl OrchestratorProcess {
     fn wait_for_listener_url(&mut self) -> String {
         let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
+        // Block on the stderr line stream with a coarse poll cadence. The
+        // recv_timeout only exists so we can periodically check whether the
+        // child died without printing the listener line — we don't need
+        // 25ms granularity for that.
+        let liveness_poll = Duration::from_millis(250);
         while Instant::now() < deadline {
-            match self.rx.recv_timeout(Duration::from_millis(25)) {
+            match self.rx.recv_timeout(liveness_poll) {
                 Ok(line) if line.contains(STARTUP_NEEDLE) => {
                     if let Some(url) = listener_url_from_line(&line) {
                         support::wait_for_readyz(&mut self.child, &url, PROCESS_FAIL_FAST_TIMEOUT)
@@ -631,12 +645,73 @@ fn json_headers() -> HeaderMap {
 }
 
 fn wait_for_path(path: &Path, timeout: Duration) {
+    use notify::event::EventKind;
+    use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+
+    if path.exists() {
+        return;
+    }
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    if !parent.exists() {
+        panic!("watch parent directory missing: {}", parent.display());
+    }
+    let target_name = path
+        .file_name()
+        .unwrap_or_else(|| panic!("wait_for_path requires a file name: {}", path.display()))
+        .to_owned();
+
+    let (tx, rx) = std::sync::mpsc::channel::<()>();
+    let target_for_handler = target_name.clone();
+    let mut watcher: RecommendedWatcher =
+        notify::recommended_watcher(move |event: Result<Event, notify::Error>| {
+            let Ok(event) = event else { return };
+            // We only need a hint that *something* under the parent directory
+            // changed; the outer loop re-checks `path.exists()` so false
+            // positives just trigger an extra cheap stat call.
+            let interesting = matches!(
+                event.kind,
+                EventKind::Create(_) | EventKind::Modify(_) | EventKind::Any
+            );
+            if !interesting {
+                return;
+            }
+            if event
+                .paths
+                .iter()
+                .any(|candidate| candidate.file_name() == Some(target_for_handler.as_os_str()))
+            {
+                let _ = tx.send(());
+            }
+        })
+        .unwrap_or_else(|error| panic!("failed to install notify watcher: {error}"));
+    watcher
+        .watch(parent, RecursiveMode::NonRecursive)
+        .unwrap_or_else(|error| {
+            panic!("failed to watch {}: {error}", parent.display());
+        });
+
+    // Race: the file may have been created between the existence check above
+    // and the watcher being armed. Re-check, then block on either an event
+    // notification or the deadline. Notify events are advisory — fall back
+    // to a 250ms wakeup so platforms with eventual-consistency semantics
+    // (e.g. FSEvents coalescing) still complete promptly.
     let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline {
+    loop {
         if path.exists() {
             return;
         }
-        thread::sleep(Duration::from_millis(50));
+        let remaining = match deadline.checked_duration_since(Instant::now()) {
+            Some(remaining) => remaining,
+            None => break,
+        };
+        match rx.recv_timeout(remaining.min(Duration::from_millis(250))) {
+            Ok(()) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        }
     }
     panic!("timed out waiting for {}", path.display());
 }

--- a/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
+++ b/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
@@ -20,8 +20,13 @@ use tempfile::TempDir;
 // fail-after-emit test hook can terminate the process before the HTTP listener
 // readiness line is logged.
 const STARTUP_NEEDLE: &str = "activated connectors: cron(1)";
-const PROCESS_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(5);
-const EVENT_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(2);
+// The previous 5s/2s budgets caused intermittent CI failures on macOS where
+// dyld + amfi cold-cache lookups for the unsigned debug-build binary plus
+// nextest's cargo-test launch overhead pushed subprocess spawn past the
+// budget. Tests serialize through a process-wide file lock, so a generous
+// upper bound only affects the failure path.
+const PROCESS_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(60);
+const EVENT_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(10);
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -66,6 +71,9 @@ fn spawn_orchestrator(
         .arg("127.0.0.1:0")
         .arg("--role")
         .arg("single-tenant")
+        // Cap shutdown drain at 5s; the dedupe fixture has no real backlog.
+        .arg("--shutdown-timeout")
+        .arg("5")
         .stderr(Stdio::piped())
         .stdout(Stdio::null());
     for (key, value) in extra_env {


### PR DESCRIPTION
## Summary

The five tests flagged in the recent stdlib-PR run all timed out at the
60s nextest ceiling not because of a product bug, but because of three
independent flakes in the orchestrator subprocess test harness:

| Test | Before | After |
| --- | --- | --- |
| `orchestrator_http::slack_url_verification_returns_plaintext_challenge` | 60s timeout / 22s slow run | 1.0–2.5s |
| `orchestrator_http::slack_webhook_acknowledges_before_handler_finishes` | 60s timeout / 22s slow run | 1.0–2.5s |
| `orchestrator_http::stream_trigger_route_uses_generic_stream_connector` | 60s timeout / 22s slow run | 1.0–2.5s |
| `orchestrator_http::watch_mode_reloads_manifest_changes` | 60s timeout / 22s slow run | 1.0–2.5s |
| `orchestrator_inbox_dedupe::restart_after_emit_does_not_duplicate_cron_dispatch` | 60s timeout / 5s consistent failure | 1.5–6s |

(Per-test elapsed numbers are when running just the named test through
nextest; the test serializes through a cross-process file lock, so the
"slow" path was previously a per-test wait, not parallel contention.)

## Diagnosis

I reproduced the slow run locally (one solo test taking 4–22s with the
same code, sometimes panicking at the 15s deadline). The orchestrator
binary itself starts and binds in ~0.5s when run directly, and shuts
down on SIGTERM in ~10ms. So the tests were starving on three avoidable
sources of variance:

1. **`PROCESS_FAIL_FAST_TIMEOUT` was too tight** — 15s in
   `orchestrator_http`, 5s in `orchestrator_inbox_dedupe`. macOS dyld +
   amfi cold-cache lookups for the unsigned 172MB debug-build `harn`
   binary regularly exceeded those budgets under nextest load, even
   for a *passing* run.
2. **`wait_for_path` polled `path.exists()` every 50ms.** Each marker
   file the test waits for adds a 0–50ms latency window, multiplied
   across the 5 sites that use it.
3. **`spawn_orchestrator` inherited the 30s production
   `--shutdown-timeout` default.** SIGTERM-then-wait could stall an
   entire test slot for the whole drain budget if the listener was
   doing literally anything cleanup-related.

## Fix (per item)

1. Bumped `PROCESS_FAIL_FAST_TIMEOUT` to 60s and `EVENT_FAIL_FAST_TIMEOUT`
   to 10s in both `orchestrator_http.rs` and `orchestrator_inbox_dedupe.rs`.
   Because tests serialize through a process-wide file lock, a generous
   upper bound only affects the panic-message path; the happy-path
   wall time is unchanged.
2. Replaced `wait_for_path` with a `notify::recommended_watcher`
   armed on the parent directory. The watcher blocks on the actual
   filesystem event (FSEvents on Apple, inotify on Linux) and the
   test thread re-checks `path.exists()` as the source of truth on
   each wakeup. Falls back to a 250ms ceiling on the recv_timeout so
   FSEvents coalescing doesn't drag a marker file past the deadline.
3. Pin `--shutdown-timeout 5` in `spawn_orchestrator` for both test
   files. Test fixtures have no real backlog, so 5s is plenty.

Also tightened `wait_for_listener_url`'s recv_timeout from 25ms to
250ms — the old cadence just burned CPU; the deadline is what bounds
the wait.

## Tests preserved, not deleted

All five tests still verify the same product behavior they did before:

- The Slack tests still sign with HMAC-SHA256 over `v0:{ts}:{body}`,
  still verify timestamp-window + signature behavior end-to-end. I did
  *not* mock the clock, because the verifier's 5-minute replay window
  is wider than any test wall-clock skew can produce.
- The watch-mode test still rewrites `harn.toml` and proves the
  reload picks it up.
- The stream-trigger test still goes through the generic stream
  connector path.
- The cron-dedupe test still verifies that crash-after-emit doesn't
  produce duplicate dispatches on restart.

No tests file-and-ignored.

## Verification

```
cargo nextest run -p harn-cli --test orchestrator_http \
  slack_url_verification_returns_plaintext_challenge \
  slack_webhook_acknowledges_before_handler_finishes \
  stream_trigger_route_uses_generic_stream_connector \
  watch_mode_reloads_manifest_changes
# 4 passed, 5 consecutive runs, never hit any timeout

cargo nextest run -p harn-cli --test orchestrator_inbox_dedupe \
  restart_after_emit_does_not_duplicate_cron_dispatch
# PASS in 6.3s

cargo nextest run --workspace
# Summary: 2321 tests run: 2321 passed, 0 skipped (25.4s)

cargo clippy --workspace --tests --all-features -- -D warnings
# Clean

cargo fmt --all --check
# Clean
```

## Test plan

- [x] All 5 originally-flaky tests pass in solo runs.
- [x] All 5 pass across 5 consecutive runs without flake.
- [x] Full workspace `cargo nextest run --workspace` green.
- [x] Workspace clippy + fmt clean.
- [ ] Merge-queue CI runs the full Linux + macOS matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)