### PR TITLE
Register store_* builtins on the connector check VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,13 @@ granular archaeology.
   `set_color_mode` and `NO_COLOR`/`FORCE_COLOR` env vars and the
   computed TTY state of stdout.
 
+- **`harn connector check` registers `store_*` builtins** on the connector's
+  base VM, matching the runtime that backs `harn run` /
+  `harn orchestrator serve`. Previously connectors that used
+  `store_get`/`store_set`/`store_delete` for persistent state (e.g. for
+  installation-token caches) failed during contract verification with
+  `Undefined builtin: store_*`.
+
 ### CI
 
 - **Windows CI smoke job** (`.github/workflows/ci.yml`). Builds the

--- a/crates/harn-vm/src/connectors/harn_module.rs
+++ b/crates/harn-vm/src/connectors/harn_module.rs
@@ -851,6 +851,8 @@ async fn load_module_runtime(
 ) -> Result<(Vm, BTreeMap<String, Rc<VmClosure>>), ConnectorError> {
     let mut base_vm = Vm::new();
     register_vm_stdlib(&mut base_vm);
+    let store_base = module_path.parent().unwrap_or_else(|| Path::new("."));
+    crate::store::register_store_builtins(&mut base_vm, store_base);
     if let Some(parent) = module_path.parent() {
         base_vm.set_source_dir(parent);
         base_vm.set_project_root(parent);


### PR DESCRIPTION
## Summary

Connectors that use `store_get`/`store_set`/`store_delete` in their lifecycle
methods fail under \`harn connector check\` because the contract-check VM only
registers the core stdlib. Other harn entry points (\`harn run\`,
\`harn orchestrator serve\`, REPL, playground, bench, test runner, trigger
replay) all call \`register_store_builtins\` after \`register_vm_stdlib\`.
This patch matches that pattern in \`load_module_runtime\`, keyed to the
connector module's parent directory.

Surfaced by burin-labs/harn-github-connector#8, which uses \`store_*\` for
persistent installation-token caching.

## Verification

- \`cargo check -p harn-vm\` clean
- \`cargo nextest run -p harn-vm\` — 74 pass, 0 fail (existing behavior)
- Manually verified \`harn connector check .\` against a connector that calls
  \`store_delete\` during shutdown — the builtin now resolves.