### PR TITLE
[codex] Add Agents Protocol receipt format spec

### DIFF
--- a/agents-protocol-receipts/README.md
+++ b/agents-protocol-receipts/README.md
@@ -1,0 +1,120 @@
+# Harn Agents Protocol Receipt Format
+
+This directory is the canonical v1 receipt-format artifact for the Harn Agents
+Protocol. It formalizes receipts as portable proof summaries, distinct from raw
+event traces, so Harnesses can expose audit, replay, cost, approval, and
+side-effect evidence without exposing every private trace span by default.
+
+Until a standalone specification site exists, the public URL for this artifact
+is:
+
+<https://github.com/burin-labs/harn/tree/main/agents-protocol-receipts>
+
+## Version marker
+
+- Receipt envelope: `receipt-2026-04-25`
+
+## Contents
+
+- `schemas/receipt-2026-04-25.schema.json`: JSON Schema for the receipt
+  envelope.
+- `fixtures/valid/task-receipt.json`: a complete task receipt with approvals,
+  model routing, cost, replay material, side effects, final artifacts, and
+  hash-chain metadata.
+- `fixtures/invalid/missing-chain-hash.json`: an invalid receipt missing the
+  required receipt hash.
+
+## Receipt envelope
+
+A receipt is a JSON object with these top-level fields:
+
+- `schema`: version discriminator. Current value: `receipt-2026-04-25`.
+- `receipt_id`: stable receipt id.
+- `subject`: resource pointer for the Task, Outcome, Event, Artifact, approval,
+  tool use, or replay segment the receipt proves.
+- `issuer`: Harness identity that issued the receipt.
+- `issued_at`: RFC3339 UTC timestamp.
+- `identifiers`: tenant, workspace, session, task, persona, and branch
+  identifiers known for the run.
+- `lifecycle`: start, completion, and final-state data for the subject.
+- `approvals`: approval decisions and quorum proof references.
+- `trust`: autonomy tier at start and end.
+- `autonomy_budget`: budget consumed by model, tool, time, or money dimensions.
+- `replay_input`: deterministic replay material references or embedded replay
+  records.
+- `model_route`: chosen model, alternatives considered, and route-policy
+  rationale.
+- `cost`: total cost and per-provider breakdown.
+- `side_effects`: file-system writes, network egress, tool calls, and A2A
+  handoffs.
+- `final_artifacts`: final artifact references with stable hashes when bytes
+  are available.
+- `chain`: previous receipt hash, current receipt hash, and optional Merkle
+  root.
+- `redactions`: omitted private material with reason and proof hash when
+  available.
+- `signatures`: issuer or witness signatures over the receipt hash.
+- `metadata`: extensible implementation detail bag.
+
+## Canonical JSON form
+
+The storage and transport form is UTF-8 JSON. Producers MUST canonicalize the
+JSON data model with RFC 8785 JSON Canonicalization Scheme before hashing or
+signing. The `chain.receipt_hash` value is computed over the canonical receipt
+with `chain.receipt_hash` and `signatures` removed. The stored value uses the
+`sha256:` prefix.
+
+Consumers MUST preserve unknown fields only inside explicitly extensible
+objects such as `metadata`, `quorum_proof`, provider-specific cost metadata,
+and side-effect metadata. Unknown top-level fields are invalid for this schema
+version.
+
+## Verification contract
+
+Consumers should:
+
+1. Validate the receipt against `receipt-2026-04-25.schema.json`.
+2. Remove `chain.receipt_hash` and `signatures` from a copy of the receipt.
+3. Canonicalize the remaining JSON with RFC 8785.
+4. Compute SHA-256 over the canonical bytes and compare it with
+   `chain.receipt_hash`.
+5. Compare `chain.previous_receipt_hash` with the prior receipt in the stream
+   when one is available.
+6. Verify `chain.merkle_root` against the server-advertised receipt batch when
+   a batch root is present.
+7. Verify every signature over `chain.receipt_hash` with the advertised key id.
+
+Receipts can contain replay material directly, but large or sensitive replay
+inputs SHOULD be stored as Artifacts and referenced by URI plus hash. Receipts
+MUST redact secrets and hidden chain-of-thought. Redacted material SHOULD still
+leave stable hashes or artifact references when that is enough to prove replay
+completeness.
+
+## CBOR archive encoding
+
+The optional archive encoding is deterministic CBOR over the same JSON data
+model using RFC 8949 preferred serialization. The CBOR media type is:
+
+```text
+application/vnd.harn.receipt+cbor; schema=receipt-2026-04-25
+```
+
+CBOR archives do not change the hash contract. Producers compute
+`chain.receipt_hash` from the canonical JSON form, not from CBOR bytes, so JSON
+and CBOR encodings of the same receipt verify identically.
+
+## OpenAPI integration
+
+The Agents Protocol OpenAPI component for `Receipt` references the JSON Schema
+artifact directly:
+
+```yaml
+components:
+  schemas:
+    Receipt:
+      $ref: ../agents-protocol-receipts/schemas/receipt-2026-04-25.schema.json
+```
+
+Task, Outcome, Event, and Artifact resources should continue to carry
+`receipt_id` references for lightweight reads. Endpoints that return full
+receipt bodies should use the shared `Receipt` schema component.

--- a/agents-protocol-receipts/fixtures/invalid/missing-chain-hash.json
+++ b/agents-protocol-receipts/fixtures/invalid/missing-chain-hash.json
@@ -1,0 +1,60 @@
+{
+  "schema": "receipt-2026-04-25",
+  "receipt_id": "receipt_invalid_missing_chain_hash",
+  "subject": {
+    "object": "task",
+    "id": "task_invalid"
+  },
+  "issuer": {
+    "id": "harness_test",
+    "kind": "harness"
+  },
+  "issued_at": "2026-04-25T19:17:33Z",
+  "identifiers": {
+    "workspace_ref": "workspace_repo_01",
+    "session_id": "session_invalid",
+    "task_id": "task_invalid"
+  },
+  "lifecycle": {
+    "started_at": "2026-04-25T19:16:14Z",
+    "completed_at": "2026-04-25T19:17:33Z",
+    "final_state": "FAILED"
+  },
+  "trust": {
+    "start_tier": "shadow",
+    "end_tier": "shadow"
+  },
+  "autonomy_budget": {
+    "consumed": {
+      "tool_calls": 0
+    }
+  },
+  "replay_input": {
+    "determinism": "unavailable",
+    "materials": [],
+    "unavailable_reason": "test fixture intentionally incomplete"
+  },
+  "model_route": {
+    "chosen_model": {
+      "provider": "none",
+      "model": "none"
+    },
+    "alternatives_considered": [],
+    "route_policy_reason": "no model call was made"
+  },
+  "cost": {
+    "currency": "USD",
+    "total": 0,
+    "provider_breakdown": []
+  },
+  "side_effects": {
+    "fs_writes": [],
+    "network_egress": [],
+    "tool_calls": [],
+    "a2a_handoffs": []
+  },
+  "final_artifacts": [],
+  "chain": {
+    "previous_receipt_hash": null
+  }
+}

--- a/agents-protocol-receipts/fixtures/valid/task-receipt.json
+++ b/agents-protocol-receipts/fixtures/valid/task-receipt.json
@@ -1,0 +1,171 @@
+{
+  "schema": "receipt-2026-04-25",
+  "receipt_id": "receipt_01JZ6Y3B5K0QJ9GM61VZKX7P6G",
+  "subject": {
+    "object": "task",
+    "id": "task_01JZ6Y2ZKMB8H8DMXBGXR1FPGS"
+  },
+  "issuer": {
+    "id": "harness_burin_cloud",
+    "kind": "harness",
+    "name": "Burin Cloud",
+    "version": "agents-protocol-2026-04-25",
+    "public_key_id": "key_2026_04"
+  },
+  "issued_at": "2026-04-25T19:17:33Z",
+  "identifiers": {
+    "tenant_id": "tenant_acme",
+    "persona_ref": "persona_code_reviewer@v1",
+    "workspace_ref": "workspace_repo_01",
+    "session_id": "session_01JZ6Y2R2PJJZ48P40GFEPA4GV",
+    "task_id": "task_01JZ6Y2ZKMB8H8DMXBGXR1FPGS",
+    "branch_id": "branch_01JZ6Y30M129J4WHK6A4QFPFJV",
+    "trace_id": "trace_01JZ6Y30YAKNDHY60SRG64GEH4"
+  },
+  "lifecycle": {
+    "created_at": "2026-04-25T19:16:10Z",
+    "started_at": "2026-04-25T19:16:14Z",
+    "completed_at": "2026-04-25T19:17:33Z",
+    "final_state": "SUCCEEDED",
+    "failure": null
+  },
+  "approvals": [
+    {
+      "approval_id": "approval_01JZ6Y37WDP1H1EXG5YPRPKJ0H",
+      "actor": "user_maintainer_1",
+      "action": "workspace.patch.apply",
+      "decision": "approved",
+      "decided_at": "2026-04-25T19:17:02Z",
+      "quorum_proof": {
+        "required": 1,
+        "satisfied": 1
+      },
+      "evidence_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ],
+  "trust": {
+    "start_tier": "act_with_approval",
+    "end_tier": "act_with_approval",
+    "policy_ref": "policy_code_review_default"
+  },
+  "autonomy_budget": {
+    "limit": {
+      "usd": 2.0,
+      "input_tokens": 200000,
+      "output_tokens": 50000,
+      "tool_calls": 100,
+      "wall_time_ms": 600000
+    },
+    "consumed": {
+      "usd": 0.1842,
+      "input_tokens": 1800,
+      "output_tokens": 420,
+      "tool_calls": 4,
+      "wall_time_ms": 79000
+    }
+  },
+  "replay_input": {
+    "determinism": "byte_deterministic",
+    "materials": [
+      {
+        "kind": "llm_provider_response",
+        "id": "llm_call_01",
+        "uri": "artifact://artifact_llm_response_01",
+        "sha256": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "content_type": "application/jsonl"
+      },
+      {
+        "kind": "mcp_tool_return",
+        "id": "tool_return_01",
+        "uri": "artifact://artifact_tool_return_01",
+        "sha256": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "content_type": "application/json"
+      }
+    ]
+  },
+  "model_route": {
+    "chosen_model": {
+      "provider": "openai",
+      "model": "gpt-5.3-codex",
+      "version": "2026-04-25"
+    },
+    "alternatives_considered": [
+      {
+        "provider": "openai",
+        "model": "gpt-5.4",
+        "reason": "higher latency for requested edit size"
+      }
+    ],
+    "route_policy_reason": "code-editing task selected the coding-optimized model within budget"
+  },
+  "cost": {
+    "currency": "USD",
+    "total": 0.1842,
+    "provider_breakdown": [
+      {
+        "provider": "openai",
+        "model": "gpt-5.3-codex",
+        "amount": 0.1842,
+        "input_tokens": 1800,
+        "output_tokens": 420
+      }
+    ]
+  },
+  "side_effects": {
+    "fs_writes": [
+      {
+        "path": "src/lib.rs",
+        "operation": "modify",
+        "before_sha256": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "after_sha256": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      }
+    ],
+    "network_egress": [
+      {
+        "destination": "api.github.com",
+        "purpose": "open pull request",
+        "bytes_sent": 2048
+      }
+    ],
+    "tool_calls": [
+      {
+        "tool": "git.apply_patch",
+        "call_id": "tool_call_01",
+        "status": "succeeded",
+        "input_hash": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      }
+    ],
+    "a2a_handoffs": []
+  },
+  "final_artifacts": [
+    {
+      "artifact_id": "artifact_patch_01",
+      "kind": "patch",
+      "uri": "artifact://artifact_patch_01",
+      "sha256": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    }
+  ],
+  "chain": {
+    "previous_receipt_hash": null,
+    "receipt_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "merkle_root": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+  },
+  "redactions": [
+    {
+      "field": "/replay_input/materials/0/content",
+      "reason": "provider response stored as artifact",
+      "proof_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  ],
+  "signatures": [
+    {
+      "key_id": "key_2026_04",
+      "algorithm": "ed25519",
+      "signature": "base64:MEUCIQDexample",
+      "signed_at": "2026-04-25T19:17:34Z"
+    }
+  ],
+  "metadata": {
+    "source": "agents-protocol-conformance-fixture"
+  }
+}

--- a/agents-protocol-receipts/schemas/receipt-2026-04-25.schema.json
+++ b/agents-protocol-receipts/schemas/receipt-2026-04-25.schema.json
@@ -1,0 +1,604 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/agents-protocol/receipt-2026-04-25.schema.json",
+  "title": "Harn Agents Protocol Receipt",
+  "description": "Portable proof summary for a Harn Agents Protocol task, outcome, event, approval, tool use, artifact, or replay segment.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "receipt_id",
+    "subject",
+    "issuer",
+    "issued_at",
+    "identifiers",
+    "lifecycle",
+    "trust",
+    "autonomy_budget",
+    "replay_input",
+    "model_route",
+    "cost",
+    "side_effects",
+    "final_artifacts",
+    "chain"
+  ],
+  "properties": {
+    "schema": {
+      "const": "receipt-2026-04-25"
+    },
+    "receipt_id": {
+      "$ref": "#/$defs/nonEmptyString"
+    },
+    "subject": {
+      "$ref": "#/$defs/resourceRef"
+    },
+    "issuer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind"],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["harness", "host", "agent", "connector"]
+        },
+        "name": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "version": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "public_key_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "issued_at": {
+      "$ref": "#/$defs/dateTime"
+    },
+    "identifiers": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workspace_ref", "session_id", "task_id"],
+      "properties": {
+        "tenant_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "persona_ref": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "workspace_ref": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "session_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "task_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "branch_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "trace_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "lifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["started_at", "completed_at", "final_state"],
+      "properties": {
+        "created_at": {
+          "$ref": "#/$defs/dateTime"
+        },
+        "started_at": {
+          "$ref": "#/$defs/dateTime"
+        },
+        "completed_at": {
+          "$ref": "#/$defs/dateTime"
+        },
+        "final_state": {
+          "type": "string",
+          "enum": ["SUCCEEDED", "FAILED", "CANCELED"]
+        },
+        "failure": {
+          "type": ["object", "null"],
+          "additionalProperties": true
+        }
+      }
+    },
+    "approvals": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/approval"
+      },
+      "default": []
+    },
+    "trust": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start_tier", "end_tier"],
+      "properties": {
+        "start_tier": {
+          "$ref": "#/$defs/trustTier"
+        },
+        "end_tier": {
+          "$ref": "#/$defs/trustTier"
+        },
+        "policy_ref": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "autonomy_budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["consumed"],
+      "properties": {
+        "limit": {
+          "$ref": "#/$defs/budgetAmount"
+        },
+        "consumed": {
+          "$ref": "#/$defs/budgetAmount"
+        }
+      }
+    },
+    "replay_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["determinism", "materials"],
+      "properties": {
+        "determinism": {
+          "type": "string",
+          "enum": ["byte_deterministic", "best_effort", "unavailable"]
+        },
+        "materials": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/replayMaterial"
+          }
+        },
+        "unavailable_reason": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "model_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chosen_model", "alternatives_considered", "route_policy_reason"],
+      "properties": {
+        "chosen_model": {
+          "$ref": "#/$defs/modelRef"
+        },
+        "alternatives_considered": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/modelRef"
+          }
+        },
+        "route_policy_reason": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "cost": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["currency", "total", "provider_breakdown"],
+      "properties": {
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
+        },
+        "total": {
+          "type": "number",
+          "minimum": 0
+        },
+        "provider_breakdown": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/providerCost"
+          }
+        }
+      }
+    },
+    "side_effects": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fs_writes", "network_egress", "tool_calls", "a2a_handoffs"],
+      "properties": {
+        "fs_writes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/fileWrite"
+          }
+        },
+        "network_egress": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/networkEgress"
+          }
+        },
+        "tool_calls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/toolCall"
+          }
+        },
+        "a2a_handoffs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/a2aHandoff"
+          }
+        }
+      }
+    },
+    "final_artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/artifactRef"
+      }
+    },
+    "chain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["previous_receipt_hash", "receipt_hash"],
+      "properties": {
+        "previous_receipt_hash": {
+          "type": ["string", "null"],
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "receipt_hash": {
+          "$ref": "#/$defs/sha256"
+        },
+        "merkle_root": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "redactions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/redaction"
+      },
+      "default": []
+    },
+    "signatures": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/signature"
+      },
+      "default": []
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "dateTime": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "resourceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["object", "id"],
+      "properties": {
+        "object": {
+          "type": "string",
+          "enum": ["task", "outcome", "event", "artifact", "approval", "tool_call", "replay_segment"]
+        },
+        "id": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "trustTier": {
+      "type": "string",
+      "enum": ["shadow", "suggest", "act_with_approval", "act_auto"]
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actor", "action", "decision", "decided_at"],
+      "properties": {
+        "approval_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "actor": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "action": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "decision": {
+          "type": "string",
+          "enum": ["approved", "denied", "canceled", "timeout"]
+        },
+        "decided_at": {
+          "$ref": "#/$defs/dateTime"
+        },
+        "quorum_proof": {
+          "type": ["object", "null"],
+          "additionalProperties": true
+        },
+        "evidence_hash": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "budgetAmount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "usd": {
+          "type": "number",
+          "minimum": 0
+        },
+        "input_tokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "output_tokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tool_calls": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "wall_time_ms": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "replayMaterial": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["llm_provider_response", "mcp_tool_return", "event_log", "artifact", "host_fact"]
+        },
+        "id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "uri": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "content_type": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "bytes_base64": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["uri", "sha256"]
+        },
+        {
+          "required": ["bytes_base64", "sha256"]
+        },
+        {
+          "required": ["metadata"]
+        }
+      ]
+    },
+    "modelRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "model"],
+      "properties": {
+        "provider": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "model": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "version": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "reason": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "providerCost": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "amount"],
+      "properties": {
+        "provider": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "model": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "amount": {
+          "type": "number",
+          "minimum": 0
+        },
+        "input_tokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "output_tokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "fileWrite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "operation"],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "operation": {
+          "type": "string",
+          "enum": ["create", "modify", "delete", "rename"]
+        },
+        "before_sha256": {
+          "type": ["string", "null"],
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "after_sha256": {
+          "type": ["string", "null"],
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        }
+      }
+    },
+    "networkEgress": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["destination", "purpose"],
+      "properties": {
+        "destination": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "purpose": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "bytes_sent": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "toolCall": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tool", "call_id", "status"],
+      "properties": {
+        "tool": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "call_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["succeeded", "failed", "canceled"]
+        },
+        "input_hash": {
+          "$ref": "#/$defs/sha256"
+        },
+        "output_hash": {
+          "$ref": "#/$defs/sha256"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "a2aHandoff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target_agent", "task_id", "status"],
+      "properties": {
+        "target_agent": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "task_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["accepted", "rejected", "failed", "completed"]
+        },
+        "receipt_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "artifactRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact_id", "kind"],
+      "properties": {
+        "artifact_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "kind": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "uri": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "redaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "reason"],
+      "properties": {
+        "field": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "reason": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "proof_hash": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key_id", "algorithm", "signature"],
+      "properties": {
+        "key_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "algorithm": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "signature": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "signed_at": {
+          "$ref": "#/$defs/dateTime"
+        }
+      }
+    }
+  }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -89,6 +89,7 @@
 
 - [CLI reference](./cli-reference.md)
 - [Agents Protocol v1](./spec/agents-protocol/v1.md)
+- [Agents Protocol Receipt Format](./spec/agents-protocol/receipt-format-v1.md)
 - [Builtin functions](./builtins.md)
 - [Postgres](./postgres.md)
 - [Project scanning](./project-scan.md)

--- a/docs/src/spec/agents-protocol/receipt-format-v1.md
+++ b/docs/src/spec/agents-protocol/receipt-format-v1.md
@@ -1,0 +1,8 @@
+# Harn Agents Protocol Receipt Format
+
+The canonical receipt-format artifact lives in
+[`agents-protocol-receipts`](../../../../agents-protocol-receipts/README.md).
+
+It defines the `receipt-2026-04-25` JSON envelope, JSON Schema, fixtures,
+canonicalization and hash rules, optional CBOR archive encoding, and OpenAPI
+component reference for `Receipt` resources.

--- a/spec/AGENTS_PROTOCOL.md
+++ b/spec/AGENTS_PROTOCOL.md
@@ -298,22 +298,40 @@ best-effort unless a transport explicitly promises a single stream order.
 
 ### Receipt
 
-A Receipt is a portable proof summary for a Task, Outcome, approval, tool use,
-or replay segment. Receipts are not full traces.
+A Receipt is a portable proof summary for a Task, Outcome, Event, Artifact,
+approval, tool use, or replay segment. Receipts are not full traces.
 
-Required fields for v1 placeholders:
+Required fields:
 
-- `id`: stable receipt id.
+- `schema`: receipt format discriminator. Current value:
+  `receipt-2026-04-25`.
+- `receipt_id`: stable receipt id.
 - `subject`: `{object, id}` pointer.
-- `format`: receipt format discriminator.
-- `summary`: human-readable summary.
-- `issued_at`: timestamp.
 - `issuer`: Harness identity.
+- `issued_at`: timestamp.
+- `identifiers`: tenant, persona, workspace, session, task, branch, and trace
+  identifiers known for the run.
+- `lifecycle`: lifecycle timestamps and final state.
+- `trust`: autonomy tier at start and end.
+- `autonomy_budget`: consumed autonomy budget.
+- `replay_input`: replay material references sufficient for deterministic
+  replay when available.
+- `model_route`: chosen model, alternatives considered, and route-policy
+  reason.
+- `cost`: total cost and per-provider breakdown.
+- `side_effects`: file-system writes, network egress, tool calls, and A2A
+  handoffs.
+- `final_artifacts`: final artifact references.
+- `chain`: previous receipt hash, current receipt hash, and optional Merkle
+  root.
 
-The exact cryptographic receipt wire format is intentionally deferred to the
-receipt-format specification. This protocol requires all receipt references to
-be stable and retrievable, but it does not define hash-chain, signature, or
-redaction details beyond the placeholder fields above.
+Optional fields include `approvals`, `redactions`, `signatures`, and
+`metadata`.
+
+The normative JSON Schema lives in
+`agents-protocol-receipts/schemas/receipt-2026-04-25.schema.json`. The Agents
+Protocol OpenAPI `Receipt` component MUST reference that schema instead of
+duplicating it.
 
 ### Memory
 
@@ -754,15 +772,19 @@ failure is visible in streams and receipts.
 
 ## Receipt Wire Format
 
-The receipt-format sibling spec defines the normative receipt envelope,
-canonicalization, hash inputs, signatures, redaction rules, and verification
-algorithm.
+The receipt-format sibling artifact defines the normative receipt envelope,
+canonicalization, hash inputs, signatures, redaction rules, verification
+algorithm, JSON Schema, fixtures, and optional CBOR archive encoding.
 
-Until that spec is finalized, implementations MUST treat `Receipt` resources
-as opaque protocol resources with stable ids. Task, Outcome, Event, and
-Artifact objects MAY reference receipts by id. Clients MUST NOT infer
-cryptographic validity from the presence of a `receipt_id`; they must call the
-receipt verification surface when available.
+Receipt JSON uses the `receipt-2026-04-25` schema marker. Producers MUST
+canonicalize receipt JSON with RFC 8785 before hashing or signing. The
+`chain.receipt_hash` value is computed over the canonical receipt with
+`chain.receipt_hash` and `signatures` removed. The stored value uses the
+`sha256:` prefix.
+
+Task, Outcome, Event, and Artifact objects MAY reference receipts by id.
+Clients MUST NOT infer cryptographic validity from the presence of a
+`receipt_id`; they must call the receipt verification surface when available.
 
 ## Replay Contract
 

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,0 +1,13 @@
+openapi: 3.1.0
+info:
+  title: Harn Agents Protocol v1
+  version: agents-protocol-2026-04-25
+  description: |
+    OpenAPI component anchor for the Harn Agents Protocol v1 REST surface.
+    REST paths are defined by the narrative spec as they land; shared resource
+    schemas live under components so endpoint specs can reuse one contract.
+paths: {}
+components:
+  schemas:
+    Receipt:
+      $ref: ../agents-protocol-receipts/schemas/receipt-2026-04-25.schema.json


### PR DESCRIPTION
## Summary

- Adds the canonical `receipt-2026-04-25` Harn Agents Protocol receipt artifact with JSON Schema and valid/invalid fixtures.
- Updates the narrative Agents Protocol spec to make Receipt a concrete resource shape instead of a placeholder.
- Adds an OpenAPI `Receipt` component `$ref` and docs navigation entry for the receipt format.

Fixes #635.

## Verification

- `make lint-md`
- `git diff --check`
- Validated `agents-protocol-receipts/fixtures/valid/task-receipt.json` against `agents-protocol-receipts/schemas/receipt-2026-04-25.schema.json` with Ajv 8 / Draft 2020-12.
- Confirmed `agents-protocol-receipts/fixtures/invalid/missing-chain-hash.json` fails schema validation as expected.
- Parsed `spec/openapi.yaml` and checked the `components.schemas.Receipt.$ref` value.