### PR TITLE
Drop windows-skip alias job from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,14 +145,6 @@ jobs:
           echo 'pipeline main() { println("ok") }' > smoke.harn
           ./target/debug/harn.exe run smoke.harn
 
-  windows-skip:
-    name: Rust on Windows (build + smoke test)
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.rust == 'false' && github.event_name == 'pull_request'
-    steps:
-      - run: echo "Skipped — no Rust/CI changes in this PR."
-
   portal:
     name: Portal frontend
     runs-on: ubuntu-latest
@@ -182,7 +174,7 @@ jobs:
     name: Check status
     runs-on: ubuntu-latest
     if: always()
-    needs: [fmt, lint-md, rust, windows, windows-skip, portal, actions]
+    needs: [fmt, lint-md, rust, windows, portal, actions]
     steps:
       - name: Verify required CI jobs
         run: |
@@ -194,16 +186,13 @@ jobs:
             ["GitHub Actions lint"]="${{ needs.actions.result }}"
           )
 
-          # Windows runs in one of two flavors per PR (real or skip-alias).
-          # Whichever one ran needs to be green; the other is skipped.
-          windows_real="${{ needs.windows.result }}"
-          windows_skip="${{ needs['windows-skip'].result }}"
-          echo "Rust on Windows (real): $windows_real"
-          echo "Rust on Windows (skip alias): $windows_skip"
-          if [ "$windows_real" = "success" ] || [ "$windows_skip" = "success" ]; then
-            :
-          else
-            echo "::error::Windows job did not succeed in either real or skip variant."
+          # The Windows job is gated on `changes.outputs.rust` and is skipped
+          # on PRs that don't touch Rust/CI. Treat `skipped` as passing here;
+          # only an actual failure should fail the gate.
+          windows_result="${{ needs.windows.result }}"
+          echo "Rust on Windows (build + smoke test): $windows_result"
+          if [ "$windows_result" != "success" ] && [ "$windows_result" != "skipped" ]; then
+            echo "::error::Windows job failed."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- The `windows-skip` job existed solely to post a green status under the same display name as the real Windows job whenever the real one was gated off (no Rust/CI changes in a PR). It produced two graph nodes labeled `Rust on Windows (build + smoke test)`, which was confusing.
- Branch protection on `main` only requires `Check status` (verified via `gh api repos/:owner/:repo/branches/main/protection`), so the alias is vestigial.
- `check-status` now treats a skipped `windows` job as passing — only an actual failure fails the gate. Other required jobs (`fmt`, `lint-md`, `rust`, `portal`, `actions`) are unconditional, so their existing strict-success check is unchanged.

## Test plan

- [ ] CI graph on this PR shows a single `Rust on Windows (build + smoke test)` node.
- [ ] Since this PR touches `.github/workflows/ci.yml`, the `changes` filter marks `rust=true` and the real Windows job actually runs (not skipped).
- [ ] `Check status` reports green.
- [ ] Follow-up sanity: a future PR that doesn't touch Rust/CI should show the Windows job as `Skipped` and `Check status` should still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)