### PR TITLE
Consolidate release flow + rename workflows + close prevention gaps

### DIFF
--- a/.claude/commands/release-harn.md
+++ b/.claude/commands/release-harn.md
@@ -4,7 +4,7 @@ Run the merge-queue-safe Harn release workflow.
 
 The release is **one** human PR titled `Release vX.Y.Z`. It carries the
 changelog, code, docs, AND the `Cargo.toml`/`Cargo.lock` version bump together.
-After it lands through the merge queue, the Finalize Release workflow
+After it lands through the merge queue, the Publish release workflow
 auto-fires on tag drift, ships to crates.io, tags `vX.Y.Z`, and triggers the
 binary/container build. No second PR.
 
@@ -12,7 +12,7 @@ binary/container build. No second PR.
 human/agent: write & land "Release vX.Y.Z" PR
         │
         ▼  PR lands through merge queue (full audit ran in CI)
-bot:    Finalize Release workflow auto-fires on tag drift
+bot:    Publish release workflow auto-fires on tag drift
         │   pushes vX.Y.Z, runs cargo publish, creates GH release
         ▼  tag push cascades
 bot:    Release workflow builds binaries + multi-arch container
@@ -86,7 +86,7 @@ Steps 1-9 are the only steps that need judgment. After step 9 you are done
    `make check-highlight`, `make check-language-spec`,
    `make check-trigger-quickref`, `make check-trigger-examples`,
    `make check-docs-snippets`, `verify_release_metadata.py`, portal
-   lint+build, Windows smoke). Once it lands, Finalize Release fires.
+   lint+build, Windows smoke). Once it lands, Publish release fires.
 
 ## New-crate first-release pre-flight (harn#609)
 
@@ -123,14 +123,14 @@ HARN_BOOTSTRAP_NEW_CRATES=1 ./scripts/release_ship.sh --prepare --bump patch
 
 The flag tells `release_ship.sh` to skip the publish dry-run AND tells
 `verify_crate_packages.sh` to skip the harn-cli package check. The bump
-proceeds normally. After the consolidated PR lands, the Finalize Release
+proceeds normally. After the consolidated PR lands, the Publish release
 workflow's `cargo publish --workspace` orders intra-workspace deps
 correctly and publishes `harn-foo` before `harn-cli`.
 
 If finalize itself fails the same way, re-trigger it with the input set:
 
 ```bash
-gh workflow run finalize-release.yml -f bootstrap_new_crates=true
+gh workflow run publish-release.yml -f bootstrap_new_crates=true
 ```
 
 **For maintenance.** Add the new crate to:
@@ -143,14 +143,14 @@ gh workflow run finalize-release.yml -f bootstrap_new_crates=true
 
 ## What happens automatically after the release PR lands
 
-10. **Finalize Release** workflow (`.github/workflows/finalize-release.yml`)
+10. **Publish release** workflow (`.github/workflows/publish-release.yml`)
     detects tag drift (`Cargo.toml` ahead of latest `vX.Y.Z` tag) and runs
     `./scripts/release_ship.sh --finalize` under the App identity:
     portal-check + publish dry-run + push tag + `cargo publish` + render
     notes + create or update the GitHub release. **Audit is skipped** —
     the merge-queue CI just proved it.
-11. The tag push triggers **Release** workflow
-    (`.github/workflows/release.yml`), which builds darwin/linux × x86/arm
+11. The tag push triggers **Build release binaries** workflow
+    (`.github/workflows/build-release-binaries.yml`), which builds darwin/linux × x86/arm
     binary tarballs, publishes a multi-arch GHCR container image, and
     attaches the binaries to the GitHub release.
 
@@ -162,10 +162,10 @@ gh workflow run finalize-release.yml -f bootstrap_new_crates=true
   points where it should, `gh release` is view-then-edit-or-create. Pass
   `reaudit: true` if you want it to re-run the full audit (slower; only
   needed if something on main has changed since the PR landed).
-- **Release workflow needs to re-emit binaries** for an already-tagged
-  version: `gh workflow run release.yml --ref main -f tag=vX.Y.Z`.
+- **Build release binaries workflow needs to re-emit binaries** for an already-tagged
+  version: `gh workflow run build-release-binaries.yml --ref main -f tag=vX.Y.Z`.
 - **Accidentally landed a "Prepare vX.Y.Z release"-style commit on main
-  without the consolidated bump**: the `Bump Release (recovery)`
+  without the consolidated bump**: the `Open version bump PR (recovery)`
   workflow exists for this. Trigger via `gh workflow run
   bump-release.yml` to open the historical bump PR pattern.
 - **Truly stuck local recovery (rare)**: `./scripts/release_ship.sh
@@ -227,7 +227,7 @@ lanes (`rust-audit`, `harn-audit`, `docs-audit`, `grammar-audit`,
   investigating, not cold-cache cost.
 
 In CI, the merge-queue CI of the Release PR pays cold-cache cost
-(~10-15 min). The Finalize Release workflow no longer pays for an
+(~10-15 min). The Publish release workflow no longer pays for an
 audit (~7 min savings vs. the legacy two-PR flow).
 
 ## Useful shortcuts
@@ -240,8 +240,8 @@ audit (~7 min savings vs. the legacy two-PR flow).
 ./scripts/release_gate.sh notes
 
 # Manually re-trigger workflows (recovery):
-gh workflow run finalize-release.yml --ref main
-gh workflow run finalize-release.yml --ref main -f reaudit=true
-gh workflow run release.yml --ref main -f tag=vX.Y.Z
+gh workflow run publish-release.yml --ref main
+gh workflow run publish-release.yml --ref main -f reaudit=true
+gh workflow run build-release-binaries.yml --ref main -f tag=vX.Y.Z
 gh workflow run bump-release.yml          # legacy two-PR recovery
 ```

--- a/.claude/commands/release-harn.md
+++ b/.claude/commands/release-harn.md
@@ -2,40 +2,37 @@ Run the merge-queue-safe Harn release workflow.
 
 ## TL;DR
 
-The **only** part of a release that requires human/agent intuition is writing
-and landing the **"Prepare vX.Y.Z release"** PR. Everything from there is
-automated:
+The release is **one** human PR titled `Release vX.Y.Z`. It carries the
+changelog, code, docs, AND the `Cargo.toml`/`Cargo.lock` version bump together.
+After it lands through the merge queue, the Finalize Release workflow
+auto-fires on tag drift, ships to crates.io, tags `vX.Y.Z`, and triggers the
+binary/container build. No second PR.
 
 ```text
-land "Prepare vX.Y.Z release" PR
+human/agent: write & land "Release vX.Y.Z" PR
         │
-        ▼  Bump Release workflow auto-fires
-   opens "Bump version to X.Y.Z" PR
+        ▼  PR lands through merge queue (full audit ran in CI)
+bot:    Finalize Release workflow auto-fires on tag drift
+        │   pushes vX.Y.Z, runs cargo publish, creates GH release
+        ▼  tag push cascades
+bot:    Release workflow builds binaries + multi-arch container
         │
-        ▼  PR lands through merge queue
-   Finalize Release workflow auto-fires
-        │
-        ▼  pushes vX.Y.Z tag (under release-bot App identity)
-   Release workflow auto-fires
-        │
-        ▼  builds binaries + multi-arch container, populates GH release
-   v0.7.X is shipped
+        ▼
+        v0.7.X is shipped (binaries, container, crates.io, release notes)
 ```
-
-You write the prepare PR. Walk away. The bot opens the bump PR. The merge
-queue lands it. The bot tags, publishes to crates.io, builds binaries,
-publishes the container, and creates the GitHub release with rendered notes.
 
 ## What the human/agent owns
 
-Step 1-8 below are the only steps that need judgment. After step 8 you are
-done — do **not** run `release_ship.sh` locally as a default step.
+Steps 1-9 are the only steps that need judgment. After step 9 you are done
+— do **not** run `release_ship.sh --finalize` locally as a default step.
 
-1. Inspect the worktree with `git status --short` and `git diff --stat`.
+1. Branch off main: `git checkout -b release/vX.Y.Z`. The branch name is
+   conventional; the workflow keys on tag drift, not branch name.
+2. Inspect the worktree with `git status --short` and `git diff --stat`.
    Treat tracked and untracked changes as candidate release content unless the
    user scopes the release more narrowly.
-2. Read enough diff context to summarize the pending work accurately.
-3. Audit all pending changes for code quality, correctness, and test
+3. Read enough diff context to summarize the pending work accurately.
+4. Audit all pending changes for code quality, correctness, and test
    coverage. For each changed module or feature, check whether existing Rust
    tests and conformance tests (`conformance/tests/`) cover the new or
    changed behavior. Fill gaps:
@@ -49,138 +46,139 @@ done — do **not** run `release_ship.sh` locally as a default step.
      edit-test cycle fast.
    - **Full gate last**: once the audit is complete and all targeted tests
      pass, run `make test` and `cargo run --bin harn -- test conformance` as
-     the final gate before committing.
+     the final gate before continuing.
    Do not skip this step — shipping untested or buggy code is worse than
    delaying a release.
-4. Repo-consistency sweep. Update release-facing docs and operator guidance
+5. Repo-consistency sweep. Update release-facing docs and operator guidance
    as needed: `README.md`, `CLAUDE.md`, `docs/src/`, `spec/HARN_SPEC.md`,
    `CHANGELOG.md`, and developer-setup surfaces (`scripts/dev_setup.sh`,
    `Makefile`, `.githooks/`, `CONTRIBUTING.md`, `docs/src/portal.md`).
-5. If syntax, parser, lexer, or tree-sitter changed, update
+6. If syntax, parser, lexer, or tree-sitter changed, update
    `spec/HARN_SPEC.md` first — it is the formal language-spec source of
-   truth.
-6. Update `CHANGELOG.md` with a new top entry `## vX.Y.Z` describing the
+   truth. The pre-commit hook regenerates `docs/src/language-spec.md`
+   automatically; CI gates on it via `make check-language-spec`.
+7. Update `CHANGELOG.md` with a new top entry `## vX.Y.Z` describing the
    actual pending code changes that will ship. The version chosen here
-   (patch / minor / major bump from the current Cargo.toml version) drives
-   what the bot opens later — pick deliberately.
-7. Run `cargo fmt --all` once so the prep PR is formatting-clean.
-   `release_gate.sh audit` runs `cargo fmt -- --check` and will reject drift
-   later.
-8. Stage, commit, push, and open the **"Prepare vX.Y.Z release"** PR.
-   Include every file that ships in this version: code, docs,
-   `CHANGELOG.md`. Do **not** include `Cargo.toml` / `Cargo.lock` version
-   bumps in this PR — the bot's bump PR carries those.
+   (patch / minor / major bump from the current `Cargo.toml`) drives what
+   `--prepare` will bump to in the next step — pick deliberately.
+8. Run the consolidated prep script:
+
+   ```bash
+   ./scripts/release_ship.sh --prepare --bump patch
+   ```
+
+   This audits, dry-run-publishes, bumps `Cargo.toml`/`Cargo.lock`/per-crate
+   manifests, regenerates derived files (highlight keywords, language-spec
+   mirror), and `git add`s everything. Use `--skip-audit` to trust the
+   merge-queue CI when iterating fast; use `--skip-dry-run` for the same
+   reason on the publish dry-run.
+
+9. Commit, push, open the PR titled **`Release vX.Y.Z`**:
+
+   ```bash
+   git commit -m "Release vX.Y.Z"
+   git push -u origin release/vX.Y.Z
+   gh pr create --title "Release vX.Y.Z" --body "..."
+   ```
+
+   Then walk away. The merge queue runs the full CI gate (`make lint`,
+   `make test`, `make conformance`, `make lint-harn`, `make fmt-harn`,
+   `make check-highlight`, `make check-language-spec`,
+   `make check-trigger-quickref`, `make check-trigger-examples`,
+   `make check-docs-snippets`, `verify_release_metadata.py`, portal
+   lint+build, Windows smoke). Once it lands, Finalize Release fires.
 
 ## New-crate first-release pre-flight (harn#609)
 
 **When this applies.** The pending release adds a new workspace crate
 (e.g. `crates/harn-foo`) AND wires an already-published crate (most
-commonly `harn-cli`, but any of the published members) to depend on it
-via the standard `harn-foo = { path = "../harn-foo", version = "0.7" }`
-pattern.
+commonly `harn-cli`) to depend on it via the standard
+`harn-foo = { path = "../harn-foo", version = "0.7" }` pattern.
 
-**Why it matters.** During the audit's `package-audit` lane,
-`scripts/verify_crate_packages.sh` runs `cargo package -p harn-cli
---no-verify`. Cargo strips the path dep, replaces it with the version
-requirement, and queries crates.io to validate it. If `harn-foo` has
-never been published, the lookup fails with `no matching package named
-harn-foo found`. `--no-verify` only skips the staged build, not the
-dependency-resolution step that fails here. The Bump Release workflow
-audit therefore aborts before the publish dry-run ever runs.
+**Why it matters.** During `release_gate.sh audit` (run by `--prepare`),
+the `package-audit` lane runs `scripts/verify_crate_packages.sh`, which
+runs `cargo package -p harn-cli --no-verify`. Cargo strips the path dep,
+replaces it with the version requirement, and queries crates.io to
+validate it. If `harn-foo` has never been published, the lookup fails
+with `no matching package named harn-foo found`. `--no-verify` only
+skips the staged build, not dependency-resolution.
 
-**Recommended pre-flight (do this BEFORE landing the prepare PR):**
+**Recommended pre-flight (do this BEFORE running `--prepare`):**
 
 ```bash
-# From a clean worktree at main HEAD (or the prepare branch), seed
-# the new crate at the current workspace version.
+# From a clean worktree, seed the new crate at the current version.
 cargo publish -p harn-foo --no-verify --allow-dirty
 ```
 
-After this, every subsequent release goes through the normal automated
-flow without intervention. Confirm crates.io picked it up
-(`https://crates.io/crates/harn-foo`) before merging the prepare PR.
+After this, every subsequent release flows through the consolidated PR
+without intervention.
 
-**Recovery path (use when the prepare PR already landed and the bump
-workflow is failing in audit):**
+**Recovery path (if the prepare step fails in audit):**
 
-1. Manually re-trigger Bump Release with the bootstrap input:
+Run `--prepare` with the bootstrap env var:
 
-   ```bash
-   gh workflow run bump-release.yml \
-     -f bootstrap_new_crates=true
-   ```
+```bash
+HARN_BOOTSTRAP_NEW_CRATES=1 ./scripts/release_ship.sh --prepare --bump patch
+```
 
-2. The flag sets `HARN_BOOTSTRAP_NEW_CRATES=1`, which tells
-   `release_ship.sh` to skip the publish dry-run AND tells
-   `verify_crate_packages.sh` to skip the harn-cli package check. The
-   bump PR opens normally.
-3. Land the bump PR through the merge queue. If Finalize Release also
-   fails the same way, re-trigger it the same way:
+The flag tells `release_ship.sh` to skip the publish dry-run AND tells
+`verify_crate_packages.sh` to skip the harn-cli package check. The bump
+proceeds normally. After the consolidated PR lands, the Finalize Release
+workflow's `cargo publish --workspace` orders intra-workspace deps
+correctly and publishes `harn-foo` before `harn-cli`.
 
-   ```bash
-   gh workflow run finalize-release.yml \
-     -f bootstrap_new_crates=true
-   ```
+If finalize itself fails the same way, re-trigger it with the input set:
 
-   The real `cargo publish --workspace` inside finalize orders
-   intra-workspace deps correctly and will publish `harn-foo` before
-   `harn-cli`.
+```bash
+gh workflow run finalize-release.yml -f bootstrap_new_crates=true
+```
 
 **For maintenance.** Add the new crate to:
 
 - `scripts/publish.sh`'s `WORKSPACE_CRATES` array in dependency order
-  (the per-crate fallback walks this list when the workspace publish
-  bails mid-stream).
+  (the per-crate fallback walks this list).
 - Optionally, an explicit `cargo package -p harn-foo --allow-dirty
   --no-verify` step in `scripts/verify_crate_packages.sh` to catch
-  packaging issues for the new crate as a separate audit signal
-  (see the existing `harn-hostlib` step for the pattern).
+  packaging issues for the new crate as a separate audit signal.
 
-## What happens automatically after the prepare PR lands
+## What happens automatically after the release PR lands
 
-9. **Bump Release** workflow (`.github/workflows/bump-release.yml`) fires on
-   push to `main` when the head commit starts with `Prepare v`. It:
-   - Reads `CHANGELOG.md`'s top `## vX.Y.Z` entry, compares to
-     `Cargo.toml`'s current version, derives the bump type (patch / minor /
-     major) via `scripts/detect_bump_type.py`.
-   - Runs `./scripts/release_ship.sh --bump <type>` under the
-     `harn-release-bot` App identity: audit, dry-run publish, bump
-     `Cargo.toml` + `Cargo.lock`, commit `Bump version to X.Y.Z`, push
-     `release/vX.Y.Z`, open the bump PR.
-10. The bump PR's CI runs (because the App-pushed branch isn't suppressed
-    the way `GITHUB_TOKEN`-pushed branches are). Once green, the merge
-    queue lands it.
-11. **Finalize Release** workflow (`.github/workflows/finalize-release.yml`)
-    fires on push to `main` when the head commit starts with `Bump version
-    to`. It runs `./scripts/release_ship.sh --finalize` under the App
-    identity: audit, dry-run publish, push the tag, `cargo publish`, render
-    notes from `CHANGELOG.md`, create/update the GitHub release.
-12. The tag push triggers **Release** workflow
+10. **Finalize Release** workflow (`.github/workflows/finalize-release.yml`)
+    detects tag drift (`Cargo.toml` ahead of latest `vX.Y.Z` tag) and runs
+    `./scripts/release_ship.sh --finalize` under the App identity:
+    portal-check + publish dry-run + push tag + `cargo publish` + render
+    notes + create or update the GitHub release. **Audit is skipped** —
+    the merge-queue CI just proved it.
+11. The tag push triggers **Release** workflow
     (`.github/workflows/release.yml`), which builds darwin/linux × x86/arm
     binary tarballs, publishes a multi-arch GHCR container image, and
     attaches the binaries to the GitHub release.
 
 ## Recovery paths (don't reach for these unless something failed)
 
-- A workflow failed mid-run: **re-trigger from the Actions UI** (each
-  workflow exposes `workflow_dispatch`). All scripts are idempotent —
-  per-crate publish skips already-published, `ensure_tag_at_head` skips
-  if the tag already points where it should, `gh release` is
-  view-then-edit-or-create.
-- The Release workflow needs to re-emit binaries for an already-tagged
-  version: `gh workflow run release.yml --ref main -f tag=vX.Y.Z`. The
-  workflow accepts the tag input and runs at that tagged code.
-- A truly stuck local recovery (rare): `./scripts/release_ship.sh
-  --bump patch` or `./scripts/release_ship.sh --finalize` from updated
-  `main`.
+- **Finalize failed mid-run**: re-trigger from the Actions UI
+  (workflow_dispatch). All scripts are idempotent — per-crate publish
+  skips already-published, `ensure_tag_at_head` skips if the tag already
+  points where it should, `gh release` is view-then-edit-or-create. Pass
+  `reaudit: true` if you want it to re-run the full audit (slower; only
+  needed if something on main has changed since the PR landed).
+- **Release workflow needs to re-emit binaries** for an already-tagged
+  version: `gh workflow run release.yml --ref main -f tag=vX.Y.Z`.
+- **Accidentally landed a "Prepare vX.Y.Z release"-style commit on main
+  without the consolidated bump**: the `Bump Release (recovery)`
+  workflow exists for this. Trigger via `gh workflow run
+  bump-release.yml` to open the historical bump PR pattern.
+- **Truly stuck local recovery (rare)**: `./scripts/release_ship.sh
+  --prepare --bump patch` from a fresh release branch, or
+  `./scripts/release_ship.sh --finalize` from updated `main`.
 
 ## Source of truth
 
 When in doubt, prefer the repo scripts over re-inventing the steps:
 
 ```bash
-./scripts/release_ship.sh --bump patch         # only for local recovery
-./scripts/release_ship.sh --finalize           # only for local recovery
+./scripts/release_ship.sh --prepare --bump patch     # consolidated prep
+./scripts/release_ship.sh --finalize                  # only for local recovery
 ./scripts/release_gate.sh <audit|prepare|publish|notes|full> ...
 ./scripts/release_gate.sh full --bump patch --dry-run   # all-in-one dry run
 ```
@@ -188,39 +186,39 @@ When in doubt, prefer the repo scripts over re-inventing the steps:
 ## Rules
 
 - Stop on the first failed gate. Report the actual error.
-- A real release has exactly two release commits on `main`, both landed via
-  PR/merge queue: `Prepare vX.Y.Z release` (code + docs + `CHANGELOG.md`)
-  followed by `Bump version to X.Y.Z` (Cargo.toml + Cargo.lock only). The
-  human/agent creates the first; the bot creates the second.
-- Treat repo consistency as part of the prepare PR, not an optional
-  cleanup pass. If behavior changes, update human-facing docs in the same
-  prep PR.
+- A real release has exactly one release commit on `main`, landed via
+  PR/merge queue: `Release vX.Y.Z`. Author writes the changelog +
+  code + docs + version bump in one shot via `--prepare`.
+- Treat repo consistency as part of the release PR, not an optional
+  cleanup pass. If behavior changes, update human-facing docs in the
+  same release PR.
 - If syntax / parser / lexer / tree-sitter changed, update
-  `spec/HARN_SPEC.md` (the source of truth) and run
-  `scripts/sync_language_spec.sh` to regenerate the docs mirror.
-- The grammar/spec audit includes `scripts/verify_language_spec.py`
-  (extracts ` ```harn ` fences and runs `harn check`) and
-  `scripts/verify_tree_sitter_parse.py` (sweeps positive `.harn`
-  programs through the executable tree-sitter grammar). Treat failures
-  as spec drift, not just docs drift.
-- `verify_release_metadata.py` accepts the pre-bump state — it passes
-  when the top `CHANGELOG.md` entry is exactly one patch / minor / major
-  step ahead of `Cargo.toml`. The Bump Release workflow relies on this.
+  `spec/HARN_SPEC.md` (the source of truth). The pre-commit hook
+  regenerates `docs/src/language-spec.md` for you;
+  `make check-language-spec` gates on the result in CI.
+- The grammar/spec audit (run during `--prepare`) includes
+  `scripts/verify_language_spec.py` (extracts ` ```harn ` fences and
+  runs `harn check`) and `scripts/verify_tree_sitter_parse.py` (sweeps
+  positive `.harn` programs through the executable tree-sitter
+  grammar). Treat failures as spec drift, not just docs drift.
+- `verify_release_metadata.py` (now wired into merge-queue CI) accepts
+  either a matching state (`Cargo.toml == CHANGELOG top`, the new
+  consolidated baseline) or one-bump-ahead (the legacy intermediate
+  state).
 - `release_ship.sh --finalize` pushes the tag **before** `cargo publish`
   so binary build / GHCR / downstream fetchers (e.g. `burin-code`'s
-  `fetch-harn`) run in parallel with crates.io. Both the local script
-  and the Finalize Release workflow honor this ordering.
+  `fetch-harn`) run in parallel with crates.io.
 - The release-bot App needs `Contents: write`, `Pull requests: write`,
   `Actions: write`, `Metadata: read` on the repo. Repo secrets:
   `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`, `CARGO_REGISTRY_TOKEN`.
 - `CHANGELOG.md` is the release-language source of truth. Notes are
   rendered from it via `scripts/render_release_notes.py`.
 
-## Audit wall-clock expectations
+## Wall-clock expectations
 
-`release_gate.sh audit` runs a serial `cargo build --workspace
---all-targets` warm prebuild before spawning 5 parallel lanes
-(`rust-audit`, `harn-audit`, `docs-audit`, `grammar-audit`,
+`release_gate.sh audit` (run by `--prepare`) does a serial `cargo build
+--workspace --all-targets` warm prebuild before spawning 5 parallel
+lanes (`rust-audit`, `harn-audit`, `docs-audit`, `grammar-audit`,
 `security-audit`). Typical wall-clock:
 
 - Cold `target/`: ~6-10 min, dominated by prebuild.
@@ -228,9 +226,9 @@ When in doubt, prefer the repo scripts over re-inventing the steps:
 - A lane exceeding ~5 min after the prebuild is a regression worth
   investigating, not cold-cache cost.
 
-In CI, both Bump Release and Finalize Release pay cold-cache audit cost
-(~8-12 min total). The audit + publish wall-clock is typical for a
-full release run.
+In CI, the merge-queue CI of the Release PR pays cold-cache cost
+(~10-15 min). The Finalize Release workflow no longer pays for an
+audit (~7 min savings vs. the legacy two-PR flow).
 
 ## Useful shortcuts
 
@@ -241,8 +239,9 @@ full release run.
 # Render the GitHub release body locally from CHANGELOG.md:
 ./scripts/release_gate.sh notes
 
-# Manually re-trigger any of the workflows:
-gh workflow run bump-release.yml --ref main
+# Manually re-trigger workflows (recovery):
 gh workflow run finalize-release.yml --ref main
+gh workflow run finalize-release.yml --ref main -f reaudit=true
 gh workflow run release.yml --ref main -f tag=vX.Y.Z
+gh workflow run bump-release.yml          # legacy two-PR recovery
 ```

--- a/.codex/commands/harn-release.md
+++ b/.codex/commands/harn-release.md
@@ -4,7 +4,7 @@ Run the merge-queue-safe Harn release workflow.
 
 The release is **one** human PR titled `Release vX.Y.Z`. It carries the
 changelog, code, docs, AND the `Cargo.toml`/`Cargo.lock` bump together. After
-it lands through the merge queue, the Finalize Release workflow auto-fires on
+it lands through the merge queue, the Publish release workflow auto-fires on
 tag drift and ships everything. No second PR.
 
 ## End-state flow
@@ -12,7 +12,7 @@ tag drift and ships everything. No second PR.
 ```text
 human/agent: write & land "Release vX.Y.Z" PR (changelog + code + docs + bump)
         │  ↓ merge queue runs full audit set in CI
-bot:    Finalize Release workflow auto-fires on tag drift
+bot:    Publish release workflow auto-fires on tag drift
         │   pushes vX.Y.Z, runs cargo publish, creates GH release notes
         │  ↓ tag push cascades
 bot:    Release workflow builds binaries + multi-arch container
@@ -71,34 +71,34 @@ That's it. Stop here. The bot takes over once the PR lands.
 
 ## What happens automatically after the release PR lands
 
-- **`Finalize Release`** workflow
-  (`.github/workflows/finalize-release.yml`) detects tag drift
+- **`Publish release`** workflow
+  (`.github/workflows/publish-release.yml`) detects tag drift
   (`Cargo.toml` ahead of latest `vX.Y.Z` tag) and runs
   `./scripts/release_ship.sh --finalize` under the App identity:
   portal-check + publish dry-run + push tag + `cargo publish` + render
   notes + create or update the GitHub release. **Audit is skipped** —
   the merge-queue CI of the just-landed Release PR proved the same
   gates a few minutes ago.
-- The tag push triggers **`Release`** workflow
-  (`.github/workflows/release.yml`), which builds the darwin/linux ×
+- The tag push triggers **`Build release binaries`** workflow
+  (`.github/workflows/build-release-binaries.yml`), which builds the darwin/linux ×
   x86/arm binary tarballs, publishes the multi-arch GHCR container,
   and attaches the binaries to the GitHub release.
 
 ## Recovery (only when something breaks)
 
 - **Finalize failed mid-run**: re-trigger from the GitHub Actions UI
-  (`gh workflow run finalize-release.yml`). Scripts are idempotent —
+  (`gh workflow run publish-release.yml`). Scripts are idempotent —
   per-crate publish skips already-published, the tag step no-ops if
   it already points where it should, `gh release` is
   view-then-edit-or-create. Pass `reaudit: true` if you want it to
   re-run the full audit (only needed if main has changed since the
   PR landed).
-- **Release workflow needs to re-emit binaries** for an
+- **Build release binaries workflow needs to re-emit binaries** for an
   already-tagged version: `gh workflow run release.yml --ref main -f
   tag=vX.Y.Z`. The workflow accepts the tag input and runs at that
   tagged code.
 - **Accidentally landed a "Prepare vX.Y.Z release"-style commit on
-  main without the consolidated bump**: the `Bump Release (recovery)`
+  main without the consolidated bump**: the `Open version bump PR (recovery)`
   workflow exists for this. `gh workflow run bump-release.yml` opens
   a historical-style bump PR.
 - **Truly stuck local recovery (very rare)**: run
@@ -147,8 +147,8 @@ That's it. Stop here. The bot takes over once the PR lands.
 ./scripts/release_gate.sh notes
 
 # Manually re-trigger workflows (recovery):
-gh workflow run finalize-release.yml --ref main
-gh workflow run finalize-release.yml --ref main -f reaudit=true
-gh workflow run release.yml --ref main -f tag=vX.Y.Z
+gh workflow run publish-release.yml --ref main
+gh workflow run publish-release.yml --ref main -f reaudit=true
+gh workflow run build-release-binaries.yml --ref main -f tag=vX.Y.Z
 gh workflow run bump-release.yml          # legacy two-PR recovery
 ```

--- a/.codex/commands/harn-release.md
+++ b/.codex/commands/harn-release.md
@@ -2,18 +2,18 @@
 
 Run the merge-queue-safe Harn release workflow.
 
-The **only** part of a release that requires intuition is writing and landing
-the **"Prepare vX.Y.Z release"** PR. Everything from there is automated by
-GitHub Actions running under the `harn-release-bot` App identity.
+The release is **one** human PR titled `Release vX.Y.Z`. It carries the
+changelog, code, docs, AND the `Cargo.toml`/`Cargo.lock` bump together. After
+it lands through the merge queue, the Finalize Release workflow auto-fires on
+tag drift and ships everything. No second PR.
 
 ## End-state flow
 
 ```text
-human/agent: write "Prepare vX.Y.Z release" PR (changelog, docs, code)
-        │  ↓ lands through merge queue
-bot:    Bump Release workflow opens "Bump version to X.Y.Z" PR
-        │  ↓ CI green, lands through merge queue
-bot:    Finalize Release workflow tags + crates.io + GH release notes
+human/agent: write & land "Release vX.Y.Z" PR (changelog + code + docs + bump)
+        │  ↓ merge queue runs full audit set in CI
+bot:    Finalize Release workflow auto-fires on tag drift
+        │   pushes vX.Y.Z, runs cargo publish, creates GH release notes
         │  ↓ tag push cascades
 bot:    Release workflow builds binaries + multi-arch container
         │  ↓
@@ -22,97 +22,113 @@ bot:    Release workflow builds binaries + multi-arch container
 
 ## What you (the agent) actually do
 
-The work is in the prepare PR. After that, hands off.
+The work is in the one release PR. After that, hands off.
 
-1. Inspect the worktree first with `git status --short` and `git diff --stat`.
+1. Branch off main: `git checkout -b release/vX.Y.Z`. Conventional name; the
+   workflow keys on tag drift, not branch name.
+2. Inspect the worktree first with `git status --short` and `git diff --stat`.
    Treat tracked and untracked changes as candidate release content unless
    the user scopes it differently.
-2. Read enough diff context to summarize the pending work accurately.
-3. Audit pending changes for correctness and test coverage. Add Rust tests
+3. Read enough diff context to summarize the pending work accurately.
+4. Audit pending changes for correctness and test coverage. Add Rust tests
    or conformance pairs for new or changed user-visible behavior; fix bugs
    discovered during the audit instead of shipping them.
    - Targeted crate tests in the inner loop (`cargo nextest run -p harn-vm`).
    - `make test` and `cargo run --bin harn -- test conformance` before
      proceeding with release mechanics.
-4. Repo-consistency sweep. Update release-facing docs as needed:
+5. Repo-consistency sweep. Update release-facing docs as needed:
    `README.md`, `CLAUDE.md`, `docs/src/`, `spec/HARN_SPEC.md`,
    `CHANGELOG.md`, and developer-setup surfaces (`scripts/dev_setup.sh`,
    `Makefile`, `.githooks/`, the first-party `harn portal` docs).
-5. If syntax / parser / lexer / tree-sitter changed, update
+6. If syntax / parser / lexer / tree-sitter changed, update
    `spec/HARN_SPEC.md` first. It is the formal language-spec source of
-   truth.
-6. Update `CHANGELOG.md` with a new top entry `## vX.Y.Z` describing the
+   truth. The pre-commit hook regenerates `docs/src/language-spec.md`
+   automatically; CI gates on it via `make check-language-spec`.
+7. Update `CHANGELOG.md` with a new top entry `## vX.Y.Z` describing the
    actual pending code changes that will ship. The version chosen here
-   (patch / minor / major bump from the current Cargo.toml) drives what
-   the bot opens later — pick deliberately.
-7. Run `cargo fmt --all` once so the prep commit is formatting-clean.
-   `release_gate.sh audit` runs `cargo fmt -- --check` and rejects drift
-   later.
-8. Stage, commit, push, and open the **"Prepare vX.Y.Z release"** PR.
-   Include every file that ships in this version: code, docs,
-   `CHANGELOG.md`. Do **not** touch `Cargo.toml` / `Cargo.lock` version
-   strings — the bot's bump PR carries those.
+   (patch / minor / major from the current `Cargo.toml`) drives what
+   `--prepare` will bump to next — pick deliberately.
+8. Run the consolidated prep:
 
-That's it. Stop here. The bot takes over.
+   ```bash
+   ./scripts/release_ship.sh --prepare --bump patch
+   ```
 
-## What happens automatically after the prepare PR lands
+   This audits, dry-run-publishes, bumps `Cargo.toml`/`Cargo.lock`/per-crate
+   manifests, regenerates derived files, and `git add`s everything. Use
+   `--skip-audit` / `--skip-dry-run` to trust the merge-queue CI when
+   iterating.
 
-- **`Bump Release`** workflow (`.github/workflows/bump-release.yml`) fires
-  on push to `main` when the head commit starts with `Prepare v`. It
-  derives the bump type via `scripts/detect_bump_type.py` (compares
-  `CHANGELOG.md` top entry to `Cargo.toml`), then runs
-  `./scripts/release_ship.sh --bump <type>` under the App identity. That
-  audits, dry-run publishes, bumps `Cargo.toml` + `Cargo.lock`, commits,
-  pushes `release/vX.Y.Z`, and opens the bump PR.
-- The bump PR's CI fires normally (App-pushed branches don't trigger
-  GHA's downstream-workflow suppression). Auto-merge on, queue lands it.
+9. Commit, push, open the PR titled **`Release vX.Y.Z`**:
+
+   ```bash
+   git commit -m "Release vX.Y.Z"
+   git push -u origin release/vX.Y.Z
+   gh pr create --title "Release vX.Y.Z" --body "..."
+   ```
+
+That's it. Stop here. The bot takes over once the PR lands.
+
+## What happens automatically after the release PR lands
+
 - **`Finalize Release`** workflow
-  (`.github/workflows/finalize-release.yml`) fires on push to `main` when
-  the head commit starts with `Bump version to`. It runs
-  `./scripts/release_ship.sh --finalize` under the App identity: audit,
-  dry-run publish, push the tag, `cargo publish`, render notes, create
-  or update the GitHub release.
+  (`.github/workflows/finalize-release.yml`) detects tag drift
+  (`Cargo.toml` ahead of latest `vX.Y.Z` tag) and runs
+  `./scripts/release_ship.sh --finalize` under the App identity:
+  portal-check + publish dry-run + push tag + `cargo publish` + render
+  notes + create or update the GitHub release. **Audit is skipped** —
+  the merge-queue CI of the just-landed Release PR proved the same
+  gates a few minutes ago.
 - The tag push triggers **`Release`** workflow
   (`.github/workflows/release.yml`), which builds the darwin/linux ×
-  x86/arm binary tarballs, publishes the multi-arch GHCR container, and
-  attaches the binaries to the GitHub release.
+  x86/arm binary tarballs, publishes the multi-arch GHCR container,
+  and attaches the binaries to the GitHub release.
 
 ## Recovery (only when something breaks)
 
-- **A workflow failed mid-run**: re-trigger from the GitHub Actions UI
-  (each workflow exposes `workflow_dispatch`). The scripts are
-  idempotent — per-crate publish skips already-published, the tag step
-  no-ops if it already points where it should, `gh release` is
-  view-then-edit-or-create.
-- **The Release workflow needs to re-emit binaries** for an
+- **Finalize failed mid-run**: re-trigger from the GitHub Actions UI
+  (`gh workflow run finalize-release.yml`). Scripts are idempotent —
+  per-crate publish skips already-published, the tag step no-ops if
+  it already points where it should, `gh release` is
+  view-then-edit-or-create. Pass `reaudit: true` if you want it to
+  re-run the full audit (only needed if main has changed since the
+  PR landed).
+- **Release workflow needs to re-emit binaries** for an
   already-tagged version: `gh workflow run release.yml --ref main -f
   tag=vX.Y.Z`. The workflow accepts the tag input and runs at that
   tagged code.
-- **Truly stuck local recovery** (very rare): run
-  `./scripts/release_ship.sh --bump patch` or `--finalize` from updated
-  `main`. Same script the bot runs.
+- **Accidentally landed a "Prepare vX.Y.Z release"-style commit on
+  main without the consolidated bump**: the `Bump Release (recovery)`
+  workflow exists for this. `gh workflow run bump-release.yml` opens
+  a historical-style bump PR.
+- **Truly stuck local recovery (very rare)**: run
+  `./scripts/release_ship.sh --prepare --bump patch` from a fresh
+  release branch, or `./scripts/release_ship.sh --finalize` from
+  updated `main`. Same scripts the bot runs.
 
 ## Rules
 
-- `release_ship.sh --bump` and `--finalize` are now bot-driven by
-  default. Running them locally is a recovery action, not the default
-  step. Never amend or skip the bot path silently.
-- A real release has exactly two release commits on `main`, both landed
-  via PR/merge queue: `Prepare vX.Y.Z release` (you) followed by
-  `Bump version to X.Y.Z` (bot).
-- Do not bypass a dirty tree silently for `prepare`; either stop or
-  commit the intended release content first.
+- The default release flow is **one PR titled `Release vX.Y.Z`**. The
+  legacy two-PR flow (`Prepare vX.Y.Z release` → bot opens `Bump
+  version to X.Y.Z`) is recovery only.
+- `release_ship.sh --finalize` is bot-driven by default. Running it
+  locally is a recovery action.
+- Do not amend or skip the bot finalize path silently.
 - If syntax / parser / lexer / tree-sitter changed, update
-  `spec/HARN_SPEC.md` before opening the prepare PR.
+  `spec/HARN_SPEC.md` before running `--prepare`. The pre-commit
+  hook regenerates `docs/src/language-spec.md` for you.
 - If command behavior, release workflow, or operator guidance changed,
   update `README.md`, `CLAUDE.md`, `CONTRIBUTING.md`, and mdBook pages
-  that describe the changed surface in the same prep PR.
+  that describe the changed surface in the same release PR.
 - Treat `CHANGELOG.md` as the source of truth for GitHub release notes.
   `scripts/render_release_notes.py` and `release_gate.sh notes` derive
-  the body from it.
-- `release_gate.sh audit` begins with a serial `cargo build --workspace
-  --all-targets` warm prebuild before spawning the five parallel lanes.
-  Cold wall-clock ~6-10 min, warm ~10-30 s.
+  the body from it. `verify_release_metadata.py` (now in merge-queue
+  CI) rejects malformed headings, duplicates, out-of-order entries,
+  and empty section bodies.
+- `release_gate.sh audit` (called by `--prepare`) starts with a
+  serial `cargo build --workspace --all-targets` warm prebuild before
+  spawning the five parallel lanes. Cold wall-clock ~6-10 min, warm
+  ~10-30 s. Finalize no longer pays this cost.
 - The release-bot App needs `Contents: write`, `Pull requests: write`,
   `Actions: write`, `Metadata: read` installed on this repo. Repo
   secrets that gate the workflows: `RELEASE_APP_ID`,
@@ -121,14 +137,18 @@ That's it. Stop here. The bot takes over.
 ## Useful shortcuts
 
 ```bash
+# Consolidated prep (the default release entry point):
+./scripts/release_ship.sh --prepare --bump patch
+
 # All-in-one dry run, stops before any destructive action:
 ./scripts/release_gate.sh full --bump patch --dry-run
 
 # Render the GitHub release body locally from CHANGELOG.md:
 ./scripts/release_gate.sh notes
 
-# Manually re-trigger workflows:
-gh workflow run bump-release.yml --ref main
+# Manually re-trigger workflows (recovery):
 gh workflow run finalize-release.yml --ref main
+gh workflow run finalize-release.yml --ref main -f reaudit=true
 gh workflow run release.yml --ref main -f tag=vX.Y.Z
+gh workflow run bump-release.yml          # legacy two-PR recovery
 ```

--- a/.codex/skills/harn-release/SKILL.md
+++ b/.codex/skills/harn-release/SKILL.md
@@ -1,96 +1,70 @@
 ---
 name: harn-release
-description: Use this skill for Harn release prep, bump PRs, publishing, tagging, and release notes.
+description: Use this skill for Harn release prep, version bumps, publishing, tagging, and release notes.
 ---
 
-# Harn Release Gate
+# Harn release gate
 
-The **only** part of a Harn release that requires your intuition is writing
-and landing the **"Prepare vX.Y.Z release"** PR. Everything from there is
-automated by GitHub Actions running under the `harn-release-bot` App
-identity.
-
-## End-state flow
+The release is **one** human PR titled `Release vX.Y.Z`. It carries the
+changelog, code, docs, AND the `Cargo.toml`/`Cargo.lock` bump together.
+After it lands through the merge queue, the **publish-release**
+workflow auto-fires on tag drift, ships to crates.io, and tags
+`vX.Y.Z`. The tag push triggers the **build-release-binaries**
+workflow for binary tarballs and a multi-arch container.
 
 ```text
-human/agent: write "Prepare vX.Y.Z release" PR (changelog, docs, code)
-        │  ↓ lands through merge queue
-bot:    Bump Release workflow opens "Bump version to X.Y.Z" PR
-        │  ↓ CI green, lands through merge queue
-bot:    Finalize Release workflow tags + crates.io + GH release notes
+human/agent: write & land "Release vX.Y.Z" PR
+        │  ↓ merge queue runs full audit set in CI
+bot:    publish-release workflow auto-fires on tag drift
+        │   pushes vX.Y.Z, runs cargo publish, creates GH release notes
         │  ↓ tag push cascades
-bot:    Release workflow builds binaries + multi-arch container
+bot:    build-release-binaries workflow assembles binaries + container
         │  ↓
-        v0.7.X is shipped
+        v0.7.X is shipped (binaries, container, crates.io, release notes)
 ```
 
-The three bot workflows live at:
+The bot workflows live at:
 
-- `.github/workflows/bump-release.yml`
-- `.github/workflows/finalize-release.yml`
-- `.github/workflows/release.yml`
+- `.github/workflows/publish-release.yml` (display name: "Publish release")
+- `.github/workflows/build-release-binaries.yml` (display name: "Build release binaries")
+- `.github/workflows/bump-release.yml` (display name: "Open version bump PR (recovery)" — workflow_dispatch only)
 
 ## Source of truth
 
-All bot workflows invoke the same scripts you'd run locally for recovery:
+All bot workflows invoke the same scripts you'd run locally:
 
 ```bash
-# Recovery only — bot does these by default:
-./scripts/release_ship.sh --bump <patch|minor|major>
-./scripts/release_ship.sh --finalize
-
-# Lower-level pieces, when --bump/--finalize can't help:
+./scripts/release_ship.sh --prepare --bump <patch|minor|major>   # default flow
+./scripts/release_ship.sh --finalize                              # recovery
+./scripts/release_ship.sh --bump <patch|minor|major>              # legacy recovery
 ./scripts/release_gate.sh <audit|prepare|publish|notes|full> ...
 ```
 
 Do not re-invent the release ritual from memory if the script can do it.
-The only step that is intentionally not scripted is producing the
-"Prepare vX.Y.Z release" PR.
 
-## Merge-queue mode
+## Single-PR mode
 
-A real release has exactly two release commits on `main`, both landed via
-PR/merge queue:
+A real release has exactly one release commit on `main`, landed via
+PR/merge queue: `Release vX.Y.Z`. It contains code, docs,
+`CHANGELOG.md`, `Cargo.toml` / `Cargo.lock` and per-crate manifest
+bumps, and regenerated derived files (highlight keywords,
+language-spec mirror).
 
-1. **`Prepare vX.Y.Z release`** — code + docs + `CHANGELOG.md`, no Cargo
-   version bump. Written by you.
-2. **`Bump version to X.Y.Z`** — `Cargo.toml` + `Cargo.lock` only,
-   opened by Bump Release workflow under the bot identity.
-
-Watch the Actions runs after #1 lands. Do not poll local status. The
-finalize and release workflows fire downstream automatically.
+After the prepare PR lands, watch the Actions runs. The publish and
+binary-build workflows fire downstream automatically. Wall-clock
+~3-5 min for crates.io publish + ~10-15 min for binary tarballs.
 
 Failure modes, roughly in frequency order, with recovery:
 
-- `release_gate.sh audit` clippy / test failure during bump or finalize:
-  fix the code in a small follow-up PR (treat it as release-prep
-  cleanup), let it land, then re-trigger the failed workflow via
-  `gh workflow run <name> --ref main`.
-- `publish --dry-run` failure: usually a missing `include = [...]` file
-  in a crate manifest. Fix in a small PR, re-trigger.
-- `cargo publish` rate-limit / transient network during finalize:
-  re-trigger Finalize Release; it falls back to per-crate publish and
-  treats `already exists on crates.io index` as success.
-- Release workflow needs to re-emit binaries for an already-tagged
-  version: `gh workflow run release.yml --ref main -f tag=vX.Y.Z`.
-
-## Batching multiple tickets in one release
-
-When several unrelated tickets are ready to ship together:
-
-1. Merge each ticket's PR to `main` through the merge queue (each may
-   carry a one-line CHANGELOG addition under an "Unreleased" heading —
-   that is fine).
-2. Immediately before releasing, consolidate the CHANGELOG: promote the
-   "Unreleased" section to `## vX.Y.Z` with the grouped entries and
-   reference each closed ticket by number.
-3. Open and land the **"Prepare vX.Y.Z release"** PR with that
-   consolidation (docs / spec edits ride along if needed).
-4. Walk away. The bot opens the bump PR, that lands, the bot finalizes.
-
-Prefer larger batches over many small releases when the tickets are
-topically related. A single batched release is one cargo publish cycle
-instead of N, and downstream consumers pick up a coherent surface.
+- `release_gate.sh audit` clippy / test failure during `--prepare`:
+  fix the code on the same release branch, re-run `--prepare
+  --skip-audit` if you've already run audit successfully once.
+- `cargo publish` rate-limit / transient network during the publish
+  workflow: re-trigger via `gh workflow run publish-release.yml --ref main`.
+  The script falls back to per-crate publish and treats `already
+  exists on crates.io index` as success.
+- Binary build needs to re-emit for an already-tagged version:
+  `gh workflow run build-release-binaries.yml --ref main -f tag=vX.Y.Z`.
 
 ## Cross-repo iteration does not wait on releases
 
@@ -102,74 +76,87 @@ the *published* version surface; it never blocks cross-repo iteration.
 
 ## What you actually do for a release
 
-Steps 1-8 are the only ones requiring judgment. After step 8 you are
-done — do **not** run `release_ship.sh` locally as a default step.
+Steps 1-9 are the only ones requiring judgment. After step 9 you are
+done — do **not** run `release_ship.sh --finalize` locally as a
+default step.
 
-1. Inspect the worktree first with `git status --short` and
+1. Branch off main: `git checkout -b release/vX.Y.Z`.
+2. Inspect the worktree first with `git status --short` and
    `git diff --stat`. Treat tracked and untracked changes as candidate
    release content unless the user scopes the release more narrowly.
-2. Read enough diff context to summarize the pending work accurately.
-3. Audit pending changes for correctness and test coverage. Add Rust
+3. Read enough diff context to summarize the pending work accurately.
+4. Audit pending changes for correctness and test coverage. Add Rust
    tests or conformance pairs for new or changed user-visible behavior;
    fix bugs discovered during the audit instead of shipping them.
-   - Targeted crate tests during the inner loop (`cargo nextest run -p
-     harn-vm` or `cargo test -p harn-vm`).
+   - Targeted crate tests during the inner loop (`cargo nextest run -p harn-vm`).
    - `make test` and `cargo run --bin harn -- test conformance` before
      proceeding with release mechanics.
-4. Repo-consistency sweep before shipping. Update release-facing docs
+5. Repo-consistency sweep before shipping. Update release-facing docs
    and operator guidance as needed: `README.md`, `CLAUDE.md`,
    `docs/src/`, `spec/HARN_SPEC.md`, `CHANGELOG.md`, and developer-setup
    surfaces (`scripts/dev_setup.sh`, `Makefile`, `.githooks/`,
    `docs/src/portal.md`).
-5. If syntax / parser / lexer / tree-sitter changed, update
+6. If syntax / parser / lexer / tree-sitter changed, update
    `spec/HARN_SPEC.md` first — formal language-spec source of truth.
-6. Update `CHANGELOG.md` with a new top entry `## vX.Y.Z`. The version
-   chosen here drives the bump type the bot derives. Pick deliberately.
-7. Run `cargo fmt --all` once so the prep commit is formatting-clean.
-8. Stage, commit, push, open the **"Prepare vX.Y.Z release"** PR.
-   Include code + docs + `CHANGELOG.md` for this version. Do **not**
-   include `Cargo.toml` / `Cargo.lock` version bumps.
+   The pre-commit hook regenerates `docs/src/language-spec.md`
+   automatically; CI gates on it via `make check-language-spec`.
+7. Update `CHANGELOG.md` with a new top entry `## vX.Y.Z` describing
+   the actual pending code changes that will ship. The version chosen
+   here drives what `--prepare` will bump to.
+8. Run the consolidated prep:
+
+   ```bash
+   ./scripts/release_ship.sh --prepare --bump patch
+   ```
+
+   This audits, dry-run-publishes, bumps `Cargo.toml`/`Cargo.lock`/per-crate
+   manifests, regenerates derived files, and `git add`s everything.
+9. Commit + push + open the PR titled `Release vX.Y.Z`. Walk away.
 
 ## Expectations
 
-- Stop on the first failed gate in the prepare PR. Do not paper over.
-- Once the prepare PR lands, watch the Actions UI. The bump → finalize →
-  release cascade should complete in ~20-30 min wall-clock total. Each
-  workflow has `workflow_dispatch` for manual recovery.
-- Treat repo consistency as part of the prepare PR, not an optional
+- Stop on the first failed gate during `--prepare`. Do not paper over.
+- Once the release PR lands, watch the Actions UI. The publish →
+  binary-build cascade should complete in ~12-18 min wall-clock total.
+  Each workflow has `workflow_dispatch` for manual recovery.
+- Treat repo consistency as part of the release PR, not an optional
   cleanup pass. If behavior changes, update human-facing docs in the
-  same prep PR.
+  same PR.
 - The grammar / spec audit includes `scripts/verify_language_spec.py`
   (extracts ` ```harn ` fences from `spec/HARN_SPEC.md` and runs `harn
   check`) and `scripts/verify_tree_sitter_parse.py` (sweeps positive
   `.harn` programs through the executable tree-sitter grammar). Treat
   failures as spec drift, not just docs drift.
+- **Never push to a PR that's already in the merge queue** —
+  GitHub silently snapshots the PR at enqueue time and ignores
+  subsequent pushes. The pre-push hook detects this and aborts.
 
 ## Notes
 
 - `scripts/publish.sh` remains the crates.io publisher. It tries
   `cargo publish --workspace` first with retries, then falls back to
   per-crate publish where `already exists on crates.io index` is
-  treated as success — so partial-publish recovery is automatic.
+  treated as success.
 - `CHANGELOG.md` is the release-language source of truth. Notes are
-  rendered from it by `scripts/render_release_notes.py` /
-  `scripts/release_gate.sh notes`.
+  rendered from it by `scripts/render_release_notes.py`. CI runs
+  `verify_release_metadata.py` to reject malformed headings, empty
+  section bodies, or out-of-order entries.
 - GitHub release artifacts (binary tarballs + GHCR container) are
-  produced by `release.yml` once the tag is pushed. Tag push from
-  Finalize Release uses the App identity, so the cascade fires
-  normally — `GITHUB_TOKEN`-pushed tags would NOT trigger it.
+  produced by `build-release-binaries.yml` once the tag is pushed.
+  Tag push from `publish-release.yml` uses the App identity, so the
+  cascade fires normally — `GITHUB_TOKEN`-pushed tags would NOT
+  trigger it.
 - `release_ship.sh --finalize` pushes the tag **before** running
-  `cargo publish`, so the GitHub release-binary workflow and downstream
+  `cargo publish`, so the binary-build workflow and downstream
   fetchers (e.g. `burin-code`'s `fetch-harn`) can start working in
   parallel with crates.io publication.
-- `verify_release_metadata.py` (run from `release_gate.sh audit`)
-  accepts the pre-bump state: it passes when the top `CHANGELOG.md`
-  entry is exactly one patch / minor / major step ahead of `Cargo.toml`.
-  The Bump Release workflow's `scripts/detect_bump_type.py` relies on
-  this same invariant.
-- `release_gate.sh audit` starts with a serial
-  `cargo build --workspace --all-targets` warm prebuild before spawning
-  the five parallel lanes. Cold ~6-10 min, warm ~10-30 s.
+- `release_ship.sh --finalize` skips the audit by default
+  (`RELEASE_FINALIZE_REAUDIT=0`); merge-queue CI of the just-landed
+  Release PR proved the same gates a few minutes ago. Pass
+  `--reaudit` to opt back in for paranoid local recovery.
+- `release_gate.sh audit` (called by `--prepare`) starts with a
+  serial `cargo build --workspace --all-targets` warm prebuild before
+  spawning the five parallel lanes. Cold ~6-10 min, warm ~10-30 s.
 - The release-bot App needs `Contents: write`, `Pull requests: write`,
   `Actions: write`, `Metadata: read` installed on this repo. Required
   repo secrets: `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`,

--- a/.codex/skills/release-harn/SKILL.md
+++ b/.codex/skills/release-harn/SKILL.md
@@ -7,22 +7,21 @@ description: Alias for the Harn release workflow skill.
 
 Use the same workflow as [`harn-release`](../harn-release/SKILL.md).
 
-The **only** human/agent-driven step is writing and landing the
-**"Prepare vX.Y.Z release"** PR. After that, three GitHub Actions
-workflows cascade automatically under the `harn-release-bot` App
-identity:
+The release is **one** human PR titled `Release vX.Y.Z` carrying
+changelog + code + docs + Cargo.toml bump together. After it lands
+through the merge queue, two GitHub Actions workflows cascade
+automatically under the `harn-release-bot` App identity:
 
 ```text
-land "Prepare vX.Y.Z release" → Bump Release opens "Bump version" PR
-        → Bump PR lands → Finalize Release tags + publishes crates.io
-        → tag push → Release builds binaries + GHCR container
+land "Release vX.Y.Z" → publish-release pushes tag + cargo publish + GH release
+        → tag push → build-release-binaries assembles binaries + GHCR container
 ```
 
 The repo source of truth (only invoke locally for recovery):
 
 ```bash
-./scripts/release_ship.sh --bump <patch|minor|major>   # recovery only
-./scripts/release_ship.sh --finalize                   # recovery only
+./scripts/release_ship.sh --prepare --bump <patch|minor|major>   # default flow
+./scripts/release_ship.sh --finalize                              # recovery
 ./scripts/release_gate.sh <audit|prepare|publish|notes|full> ...
 ```
 
@@ -32,7 +31,7 @@ installs the binaries directly — use it during cross-repo iteration
 instead of waiting for crates.io. Release batching is a published-version
 concern, not a developer-loop concern.
 
-Before opening the prepare PR, make sure the local developer workflow and
+Before opening the release PR, make sure the local developer workflow and
 observability surface are documented coherently:
 
 - `README.md`
@@ -44,24 +43,34 @@ observability surface are documented coherently:
 
 Commit pattern for a real release:
 
-1. **`Prepare vX.Y.Z release`** — code + docs + `CHANGELOG.md`, no
-   Cargo.toml. Authored by you, landed through PR/merge queue.
-2. **`Bump version to X.Y.Z`** — `Cargo.toml` + `Cargo.lock` only,
-   opened by Bump Release workflow under the bot identity, landed
-   through PR/merge queue. Triggers Finalize Release on landing.
+1. **`Release vX.Y.Z`** — code + docs + `CHANGELOG.md` + Cargo.toml /
+   Cargo.lock + per-crate manifest bumps + regenerated mirrors. Authored
+   by you via `release_ship.sh --prepare --bump <type>`, landed through
+   PR/merge queue.
+
+That's it. The bot takes over once it lands.
 
 Workflows:
 
-- `.github/workflows/bump-release.yml` — fires on `Prepare v` commits.
-- `.github/workflows/finalize-release.yml` — fires on `Bump version to`
-  commits. Pushes the tag using the App token so downstream cascades
-  fire (a `GITHUB_TOKEN` tag push would be suppressed by GHA).
-- `.github/workflows/release.yml` — fires on tag push. Also accepts a
-  `tag` input via `workflow_dispatch` for re-running against an existing
-  tag.
+- `.github/workflows/publish-release.yml` (display name: "Publish release")
+  — fires on push to main when `Cargo.toml` is ahead of the latest
+  `vX.Y.Z` tag (i.e. tag drift). Pushes the tag using the App token so
+  downstream cascades fire (a `GITHUB_TOKEN` tag push would be
+  suppressed by GHA).
+- `.github/workflows/build-release-binaries.yml` (display name: "Build
+  release binaries") — fires on tag push. Also accepts a `tag` input via
+  `workflow_dispatch` for re-running against an existing tag.
+- `.github/workflows/bump-release.yml` (display name: "Open version bump
+  PR (recovery)") — workflow_dispatch only, used to reconstruct a bump
+  PR if a "Prepare vX.Y.Z release"-style commit accidentally lands on
+  main without the consolidated bump.
 
 All three expose `workflow_dispatch` for manual recovery. `gh workflow
 run <name> --ref main` re-fires.
+
+**Never push to a PR that's already in the merge queue** — GitHub
+silently snapshots the PR at enqueue time and ignores subsequent
+pushes. The pre-push hook detects this and aborts.
 
 Required repo state:
 

--- a/.githooks/lib.sh
+++ b/.githooks/lib.sh
@@ -7,6 +7,7 @@ HOOK_MARKDOWN_PATTERN='\.md$'
 HOOK_ACTIONS_PATTERN='(^\.github/workflows/|^\.githooks/|^Makefile$)'
 HOOK_PORTAL_PATTERN='(^crates/harn-cli/portal/|^package(-lock)?\.json$)'
 HOOK_HIGHLIGHT_PATTERN='(^crates/harn-lexer/|^crates/harn-vm/src/(stdlib|stdlib_.*\.harn|lib\.rs)|^crates/harn-modules/|^docs/theme/harn-keywords\.js$)'
+HOOK_LANGSPEC_PATTERN='(^spec/HARN_SPEC\.md$|^docs/src/language-spec\.md$)'
 HOOK_HARN_FORMAT_SKIP=' semicolon_statements.harn semicolon_if_else_invalid.harn semicolon_try_catch_invalid.harn semicolon_empty_statement_invalid.harn '
 
 hook_paths_match() {

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -65,6 +65,19 @@ else
   echo "=== Pre-commit: skipping highlight sync (no lexer/stdlib changes) ==="
 fi
 
+if hook_paths_match "$changed" "$HOOK_LANGSPEC_PATTERN"; then
+  # spec/HARN_SPEC.md is the authoring source; docs/src/language-spec.md
+  # is a `cat`-with-header mirror. Regen + restage is sub-second, so do
+  # the consistency fixup inline rather than failing the commit and
+  # leaving the human to run the script. Mirrors the highlight stanza.
+  echo "=== Pre-commit: syncing generated language spec ==="
+  ./scripts/sync_language_spec.sh
+  git add docs/src/language-spec.md
+  echo "    Language spec OK."
+else
+  echo "=== Pre-commit: skipping language spec sync (no spec changes) ==="
+fi
+
 if hook_paths_match "$changed" "$HOOK_MARKDOWN_PATTERN" && command -v npx >/dev/null 2>&1; then
   echo "=== Pre-commit: checking markdown ==="
   make lint-md

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,6 +10,45 @@ harn_lint_files=$(mktemp)
 trap 'rm -f "$changed" "$harn_format_files" "$harn_lint_files"' EXIT
 hook_write_push_files "$changed"
 
+# Merge-queue guard. GitHub does not reject pushes to a PR that's already
+# in the merge queue — it just keeps using the snapshot it took when the
+# PR was enqueued. Any commit pushed after that point is silently dropped
+# from the merged state. Bypass with `--no-verify` if you mean it.
+if command -v gh >/dev/null 2>&1; then
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [ -n "$branch" ] && [ "$branch" != "HEAD" ] && [ "$branch" != "main" ]; then
+    queued_branches=$(gh api graphql -f query='
+      query($owner: String!, $name: String!) {
+        repository(owner: $owner, name: $name) {
+          mergeQueue(branch: "main") {
+            entries(first: 100) {
+              nodes { pullRequest { headRefName } }
+            }
+          }
+        }
+      }' -f owner=burin-labs -f name=harn \
+      --jq '.data.repository.mergeQueue.entries.nodes[].pullRequest.headRefName' \
+      2>/dev/null || true)
+    if [ -n "$queued_branches" ] && echo "$queued_branches" | grep -Fxq "$branch"; then
+      echo ""
+      echo "error: branch '$branch' is currently in the merge queue."
+      echo ""
+      echo "  GitHub snapshotted your PR when it entered the queue. Pushing"
+      echo "  more commits now silently drops them from the merged state."
+      echo ""
+      echo "  Fix:"
+      echo "    1. gh pr merge $branch --disable-auto      # dequeue"
+      echo "       (if --disable-auto says 'already queued',"
+      echo "        use the GraphQL dequeuePullRequest mutation)"
+      echo "    2. git push                                  # push again"
+      echo "    3. gh pr merge $branch --auto                # re-enqueue"
+      echo ""
+      echo "  Or bypass: git push --no-verify"
+      exit 1
+    fi
+  fi
+fi
+
 echo "=== Pre-push: running fast release-quality checks ==="
 if hook_paths_match "$changed" "$HOOK_TEST_PATTERN"; then
   make test

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Build release binaries
 
 on:
   push:
@@ -125,7 +125,7 @@ jobs:
           path: dist/harn-${{ matrix.target }}.zip
 
   container:
-    name: Publish Container
+    name: Publish container
     needs: [setup, build]
     runs-on: ubuntu-latest
     steps:
@@ -175,7 +175,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   release:
-    name: Create Release
+    name: Create GitHub release
     needs: [setup, build, container]
     runs-on: ubuntu-latest
     steps:
@@ -195,7 +195,7 @@ jobs:
             --version "${{ needs.setup.outputs.version }}" \
             --output release-notes.md
 
-      - name: Create or update GitHub Release
+      - name: Create or update GitHub release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ needs.setup.outputs.tag }}

--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -1,4 +1,4 @@
-name: Bump Release (recovery)
+name: Open version bump PR (recovery)
 
 # RECOVERY-ONLY workflow. Default release flow consolidates the prepare
 # and bump into a single human PR titled "Release vX.Y.Z" — see
@@ -15,7 +15,7 @@ name: Bump Release (recovery)
 #
 # Runs ./scripts/release_ship.sh --bump <type> under the
 # harn-release-bot App identity. Once this workflow's PR lands, the
-# Finalize Release workflow auto-fires on tag drift to ship.
+# publish-release.yml workflow auto-fires on tag drift to ship.
 on:
   workflow_dispatch:
     inputs:
@@ -42,7 +42,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: bump-release
+  group: open-version-bump-pr
   cancel-in-progress: false
 
 env:
@@ -51,8 +51,8 @@ env:
   SCCACHE_GHA_ENABLED: "true"
 
 jobs:
-  bump:
-    name: Open bump PR
+  open-bump-pr:
+    name: Open version bump PR
     runs-on: ubuntu-latest
     # workflow_dispatch only — the push trigger was removed when the
     # release flow consolidated to a single PR.

--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -1,25 +1,22 @@
-name: Bump Release
+name: Bump Release (recovery)
 
-# Fires when a "Prepare vX.Y.Z release" commit lands on main through the
-# merge queue. Runs ./scripts/release_ship.sh --bump <type> under the
-# release-bot App identity, which audits, dry-run publishes, bumps
-# Cargo.toml + Cargo.lock, commits, pushes release/vX.Y.Z, and opens
-# the "Bump version to X.Y.Z" PR. The bump PR's CI fires normally
-# (App-pushed branch IS subject to downstream workflows), and once it
-# lands the Finalize Release workflow takes over to tag, publish to
-# crates.io, cascade to the Release workflow for binaries, and create
-# the GitHub release.
+# RECOVERY-ONLY workflow. Default release flow consolidates the prepare
+# and bump into a single human PR titled "Release vX.Y.Z" — see
+# .claude/commands/release-harn.md and .codex/commands/harn-release.md.
+# This workflow used to auto-fire on push to main; it now requires a
+# manual workflow_dispatch and exists for two recovery cases:
 #
-# End-state human flow: write and land "Prepare vX.Y.Z release". Walk
-# away. Everything else is automated.
+#   1. A "Prepare vX.Y.Z release"-style commit accidentally landed on
+#      main without the consolidated Cargo.toml/Cargo.lock bump. Run
+#      this workflow to open the bump PR after the fact.
+#   2. Bootstrapping a brand-new workspace crate (HARN_BOOTSTRAP_NEW_CRATES);
+#      the audit's package-audit lane needs special handling that the
+#      consolidated flow can also opt into, but historically lived here.
 #
-# workflow_dispatch is the manual recovery path — if this workflow
-# fails mid-run, re-run it; release_ship.sh's bump path is idempotent
-# in the sense that the existing release/vX.Y.Z branch will be
-# re-pushed cleanly.
+# Runs ./scripts/release_ship.sh --bump <type> under the
+# harn-release-bot App identity. Once this workflow's PR lands, the
+# Finalize Release workflow auto-fires on tag drift to ship.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       bootstrap_new_crates:
@@ -57,9 +54,9 @@ jobs:
   bump:
     name: Open bump PR
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      startsWith(github.event.head_commit.message, 'Prepare v')
+    # workflow_dispatch only — the push trigger was removed when the
+    # release flow consolidated to a single PR.
+    if: github.event_name == 'workflow_dispatch'
     steps:
       # Mint a short-lived App installation token so the bump branch
       # push and the bump PR are authored by harn-release-bot. Using

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,16 @@ jobs:
       - run: make conformance
       - run: make lint-harn
       - run: make fmt-harn
+      # Audit gates promoted from release_gate.sh audit so a stale
+      # generated artifact (highlight keywords, language-spec mirror,
+      # trigger quickref, docs snippets, release metadata) fails the
+      # PR instead of waiting until release time.
+      - run: make check-highlight
+      - run: make check-language-spec
+      - run: make check-trigger-quickref
+      - run: make check-trigger-examples
+      - run: make check-docs-snippets
+      - run: python3 scripts/verify_release_metadata.py
 
   changes:
     name: Detect code changes

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -2,16 +2,26 @@ name: Finalize Release
 
 # Fires whenever main has tag drift — i.e. Cargo.toml's workspace version
 # is ahead of the latest `vX.Y.Z` git tag. Runs ./scripts/release_ship.sh
-# --finalize, which audits, dry-run publishes, tags, publishes to
-# crates.io, and creates/updates the GitHub release. The tag push (under
-# the harn-release-bot App identity) cascades to release.yml for binary
+# --finalize, which dry-run publishes, tags, publishes to crates.io, and
+# creates/updates the GitHub release. The tag push (under the
+# harn-release-bot App identity) cascades to release.yml for binary
 # tarballs + multi-arch container.
+#
+# In the consolidated release flow, the human's "Release vX.Y.Z" PR
+# carries both the changelog content AND the Cargo.toml bump. Once it
+# lands, this workflow detects the resulting tag drift and ships
+# vX.Y.Z without a second PR.
+#
+# Audit is skipped by default (RELEASE_FINALIZE_REAUDIT=0): the
+# merge-queue CI of the just-landed Release PR ran the same gates a
+# few minutes ago. Set the env var or pass `--reaudit` (workflow input
+# `reaudit: true`) to opt back in for paranoid local runs.
 #
 # Tag-drift detection (vs. the older "head commit starts with 'Bump
 # version to '" trigger) means this workflow auto-recovers when an
 # earlier finalize run failed BEFORE pushing the tag. Any subsequent
-# push to main will see drift still present and re-run audit + publish.
-# Once the tag exists at HEAD, drift goes away and the job no-ops.
+# push to main will see drift still present and re-run publish. Once
+# the tag exists at HEAD, drift goes away and the job no-ops.
 #
 # workflow_dispatch is the recovery path for the one residual case:
 # failure AFTER tag push but BEFORE crates.io publish completed (drift
@@ -37,6 +47,13 @@ on:
           Skip only the publish dry-run gate. Useful if the dry-run is
           flaky for an unrelated reason and you've already validated
           the release content elsewhere.
+        type: boolean
+        default: false
+      reaudit:
+        description: >-
+          Re-run the full release-gate audit before finalizing. Defaults
+          off — merge-queue CI of the just-landed Release PR already
+          ran the same gates a few minutes ago.
         type: boolean
         default: false
 
@@ -146,15 +163,18 @@ jobs:
         run: npm ci
 
       - name: Install ripgrep
-        # security-audit lane greps the repo via `rg` — install it
-        # explicitly so the runner matches the local dev expectation.
+        # security-audit lane (only runs under --reaudit) greps the
+        # repo via `rg` — install it explicitly so the runner matches
+        # the local dev expectation when reaudit is on.
+        if: inputs.reaudit
         run: sudo apt-get update && sudo apt-get install -y ripgrep
 
       - name: Build tree-sitter grammar
-        # grammar-audit's verify_tree_sitter_parse.py loads the
-        # compiled grammar from tree-sitter-harn/harn.{so,dylib}.
-        # `npm run build` runs `tree-sitter generate && tree-sitter
-        # build`, which produces harn.so on Linux.
+        # Only needed when --reaudit re-runs the grammar-audit lane
+        # (which loads tree-sitter-harn/harn.{so,dylib} via
+        # verify_tree_sitter_parse.py). The default no-audit finalize
+        # doesn't touch tree-sitter.
+        if: inputs.reaudit
         working-directory: tree-sitter-harn
         run: |
           npm ci
@@ -178,6 +198,11 @@ jobs:
           # check that fails when a path-dep crate isn't on crates.io
           # yet. Defaults to "0" on push events.
           HARN_BOOTSTRAP_NEW_CRATES: ${{ inputs.bootstrap_new_crates && '1' || '0' }}
+          # Default off — merge-queue CI of the just-landed Release PR
+          # already proved the same gates a few minutes ago. The
+          # `reaudit: true` workflow input opts back in for paranoid
+          # local recovery runs.
+          RELEASE_FINALIZE_REAUDIT: ${{ inputs.reaudit && '1' || '0' }}
         run: |
           args=(--finalize)
           if [[ "${{ inputs.skip_dry_run }}" == "true" ]]; then

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,11 +1,11 @@
-name: Finalize Release
+name: Publish release
 
 # Fires whenever main has tag drift — i.e. Cargo.toml's workspace version
 # is ahead of the latest `vX.Y.Z` git tag. Runs ./scripts/release_ship.sh
 # --finalize, which dry-run publishes, tags, publishes to crates.io, and
 # creates/updates the GitHub release. The tag push (under the
-# harn-release-bot App identity) cascades to release.yml for binary
-# tarballs + multi-arch container.
+# harn-release-bot App identity) cascades to build-release-binaries.yml
+# for binary tarballs + multi-arch container.
 #
 # In the consolidated release flow, the human's "Release vX.Y.Z" PR
 # carries both the changelog content AND the Cargo.toml bump. Once it
@@ -61,7 +61,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: finalize-release
+  group: publish-release
   cancel-in-progress: false
 
 env:
@@ -108,8 +108,8 @@ jobs:
             echo "latest_tag=$LATEST_TAG"
           } >> "$GITHUB_OUTPUT"
 
-  finalize:
-    name: Finalize release
+  publish:
+    name: Publish release
     needs: detect-drift
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || needs.detect-drift.outputs.drift == 'true'
@@ -118,9 +118,9 @@ jobs:
       # below comes from the harn-release-bot identity instead of
       # GITHUB_TOKEN. GHA suppresses workflow chains triggered by
       # GITHUB_TOKEN-authenticated pushes, so a tag pushed under the
-      # default token would NOT fire .github/workflows/release.yml — and
-      # we'd ship to crates.io without binaries or a container image. An
-      # App token bypasses that suppression cleanly.
+      # default token would NOT fire build-release-binaries.yml — and
+      # we'd ship to crates.io without binaries or a container image.
+      # An App token bypasses that suppression cleanly.
       - name: Mint GitHub App installation token
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -185,7 +185,7 @@ jobs:
           git config --global user.name "harn-release-bot[bot]"
           git config --global user.email "harn-release-bot[bot]@users.noreply.github.com"
 
-      - name: Finalize release
+      - name: Publish release
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           # gh CLI inside release_ship.sh uses GH_TOKEN for `gh release`.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup install-hooks configure-merge-drivers check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-cargo test-fast conformance bench-vm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref check-trigger-examples check-docs-snippets
+.PHONY: setup install-hooks configure-merge-drivers check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-cargo test-fast conformance bench-vm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref check-trigger-examples check-docs-snippets sync-language-spec check-language-spec
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test conformance check-highlight check-trigger-quickref check-trigger-examples check-docs-snippets portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test conformance check-highlight check-language-spec check-trigger-quickref check-trigger-examples check-docs-snippets portal-check
 
 check: all
 
@@ -151,6 +151,25 @@ check-highlight:
 	@echo "=== Checking docs/theme/harn-keywords.js is up to date ==="
 	@cargo run --quiet -p harn-cli -- dump-highlight-keywords --check
 	@echo "    Harn keyword file OK."
+
+# Regenerate docs/src/language-spec.md from spec/HARN_SPEC.md (the
+# canonical authoring source). Mirrors what release_gate.sh audit's
+# sync_language_spec.sh step does.
+sync-language-spec:
+	./scripts/sync_language_spec.sh
+
+# CI guard: fail if docs/src/language-spec.md is stale relative to
+# spec/HARN_SPEC.md. `make sync-language-spec` fixes it.
+check-language-spec:
+	@echo "=== Checking docs/src/language-spec.md is up to date ==="
+	@./scripts/sync_language_spec.sh
+	@if ! git diff --quiet --exit-code -- docs/src/language-spec.md; then \
+		echo "error: docs/src/language-spec.md is stale relative to spec/HARN_SPEC.md" >&2; \
+		echo "hint: run 'make sync-language-spec' and commit the result" >&2; \
+		git diff --stat -- docs/src/language-spec.md >&2; \
+		exit 1; \
+	fi
+	@echo "    Language spec mirror OK."
 
 # Regenerate the LLM trigger quickref from the live ProviderCatalog metadata.
 gen-trigger-quickref:

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -266,11 +266,20 @@ cmd_audit() {
 
 cmd_prepare() {
   local bump=""
+  local allow_dirty=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --bump)
         bump="${2:-}"
         shift 2
+        ;;
+      --allow-dirty)
+        # Used by `release_ship.sh --prepare`, which runs from a release
+        # branch that already has the human's authored release content
+        # (changelog, code, docs) staged or unstaged. The version-bump
+        # write below is additive; we don't need a clean tree.
+        allow_dirty=1
+        shift
         ;;
       *)
         echo "error: unknown prepare arg: $1"
@@ -283,7 +292,9 @@ cmd_prepare() {
     echo "error: prepare requires --bump patch|minor|major"
     exit 1
   fi
-  require_clean_tree
+  if [[ "$allow_dirty" -eq 0 ]]; then
+    require_clean_tree
+  fi
   local current next
   current="$(current_version)"
   next="$(next_version "$bump")"
@@ -292,9 +303,9 @@ cmd_prepare() {
   echo "Version updated: $current -> $next"
   echo "Next steps:"
   echo "  1. Review docs/release notes diff"
-  echo "  2. Commit on a release/v$next branch: git commit -am 'Bump version to $next'"
+  echo "  2. Commit on a release/v$next branch: git commit -am 'Release v$next'"
   echo "  3. Open a PR into main and let it land through the merge queue"
-  echo "  4. Finalize after merge: ./scripts/release_ship.sh --finalize"
+  echo "  4. Walk away — the Finalize Release workflow auto-fires on tag drift"
 }
 
 cmd_publish() {

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -305,7 +305,7 @@ cmd_prepare() {
   echo "  1. Review docs/release notes diff"
   echo "  2. Commit on a release/v$next branch: git commit -am 'Release v$next'"
   echo "  3. Open a PR into main and let it land through the merge queue"
-  echo "  4. Walk away — the Finalize Release workflow auto-fires on tag drift"
+  echo "  4. Walk away — the publish-release workflow auto-fires on tag drift"
 }
 
 cmd_publish() {

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -59,30 +59,86 @@ log_step() {
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/release_ship.sh [--bump patch|minor|major] [--skip-dry-run] [--base main]
-  ./scripts/release_ship.sh --finalize [--skip-dry-run] [--notes-output path] [--base main]
+  ./scripts/release_ship.sh --prepare --bump patch|minor|major [--skip-audit] [--skip-dry-run]
+  ./scripts/release_ship.sh --bump patch|minor|major [--skip-dry-run] [--base main]   # recovery
+  ./scripts/release_ship.sh --finalize [--skip-dry-run] [--reaudit] [--notes-output path] [--base main]
 
 Merge-queue-safe release sequence for a prepared Harn release.
 
-Assumptions:
-  - Codex or a human has already reviewed pending tracked/untracked work.
-  - README.md, CLAUDE.md, docs/, spec/, and CHANGELOG.md were updated as needed.
-  - The intended release content has already landed on main through the merge queue.
-  - The current worktree is clean before this script starts.
+==============================================================================
+DEFAULT FLOW (one human PR, then bot finalizes)
+==============================================================================
 
-Default mode then:
-  1. Runs ./scripts/release_gate.sh audit
-  2. Optionally runs ./scripts/release_gate.sh publish --dry-run
-  3. Creates release/vX.Y.Z
-  4. Runs ./scripts/release_gate.sh prepare --bump ...
-  5. Commits the version bump
-  6. Pushes release/vX.Y.Z and opens a "Bump version to X.Y.Z" PR.
+  1. Branch off main and write the release content:
+       git checkout -b release/vX.Y.Z
+       # author code/docs changes
+       # add `## vX.Y.Z` heading at the top of CHANGELOG.md
 
-After that PR lands through the merge queue, run:
+  2. Stage release-content files but do NOT commit yet.
 
-  ./scripts/release_ship.sh --finalize
+  3. Run prepare-here, which audits, dry-run-publishes, bumps
+     Cargo.toml/Cargo.lock, regenerates derived files, and stages
+     everything ready for a single commit:
+       ./scripts/release_ship.sh --prepare --bump patch
 
-Environment variables:
+  4. Commit + push + open PR (one commit, one PR for the whole release):
+       git commit -m "Release vX.Y.Z"
+       git push -u origin release/vX.Y.Z
+       gh pr create
+
+  5. Land the PR through the merge queue. Walk away — the Finalize
+     Release workflow auto-fires on tag drift, tags vX.Y.Z, publishes
+     to crates.io, and creates the GitHub release. No second PR.
+
+==============================================================================
+PREPARE MODE
+==============================================================================
+
+  - Runs from a non-main branch with the release content already authored.
+  - Detects bump type via --bump and confirms it matches the CHANGELOG
+    top entry (CHANGELOG must be at the next vX.Y.Z heading already).
+  - Runs the full audit (skip with --skip-audit) and publish dry-run
+    (skip with --skip-dry-run) so failures surface before push.
+  - Bumps Cargo.toml + crates/*/Cargo.toml + Cargo.lock to vX.Y.Z.
+  - Regenerates derived files (`docs/src/language-spec.md`,
+    `docs/theme/harn-keywords.js`).
+  - Stages everything; the human commits and pushes.
+
+==============================================================================
+LEGACY BUMP MODE (recovery only)
+==============================================================================
+
+  Pre-consolidation behavior kept for the recovery workflow_dispatch
+  path on .github/workflows/bump-release.yml. Runs from main, opens a
+  "Bump version to X.Y.Z" PR from a release/vX.Y.Z branch. Use only
+  when a "Prepare vX.Y.Z release"-style commit landed on main without
+  the consolidated bump (the workflow flips itself out of the default
+  push-trigger to make this an explicit recovery action).
+
+==============================================================================
+FINALIZE MODE
+==============================================================================
+
+  Trusts the merge-queue CI that just landed the consolidated PR (CI
+  runs the full audit set: cargo fmt/clippy/tests, conformance,
+  highlight + language-spec sync checks, docs-snippets, trigger
+  quickref + examples, verify_release_metadata, portal lint+build).
+
+  1. Builds the portal frontend (needed for the cargo-publish include).
+  2. Runs the publish dry-run as a quick pre-publish sanity check.
+  3. Creates and pushes tag vX.Y.Z from main.
+  4. Runs cargo publish to upload crates to crates.io.
+  5. Renders changelog-backed release notes.
+  6. Creates/updates a GitHub release with the rendered notes.
+
+  Set RELEASE_FINALIZE_REAUDIT=1 (or pass --reaudit) to opt back into
+  the full release-gate audit before finalizing — useful when running
+  --finalize locally after manual repo edits.
+
+==============================================================================
+ENVIRONMENT VARIABLES
+==============================================================================
+
   HARN_BOOTSTRAP_NEW_CRATES=1
     First-release bootstrap mode for a brand-new workspace crate that
     an already-published crate now depends on. Skips the publish
@@ -92,13 +148,10 @@ Environment variables:
     `cargo publish --workspace`, which orders intra-workspace deps
     correctly. See harn#609.
 
-Finalize mode:
-  1. Runs ./scripts/release_gate.sh audit
-  2. Optionally runs ./scripts/release_gate.sh publish --dry-run
-  3. Creates/pushes tag vX.Y.Z from main
-  4. Runs ./scripts/release_gate.sh publish to upload crates to crates.io
-  5. Renders changelog-backed release notes
-  6. Creates/updates a GitHub release with the rendered notes
+  RELEASE_FINALIZE_REAUDIT=1
+    Force --finalize to re-run the full release-gate audit. Defaults
+    off — merge-queue CI already proved the same gates a few minutes
+    ago. Use when finalizing locally after edits.
 EOF
 }
 
@@ -166,6 +219,48 @@ require_base_branch() {
   fi
 }
 
+require_release_branch() {
+  local base="$1"
+  local branch
+  branch="$(git branch --show-current)"
+  if [[ -z "$branch" ]]; then
+    echo "error: detached HEAD; create a release branch first (git checkout -b release/vX.Y.Z)"
+    exit 1
+  fi
+  if [[ "$branch" == "$base" ]]; then
+    echo "error: --prepare must run from a release branch, not $base"
+    echo "hint: git checkout -b release/vX.Y.Z"
+    exit 1
+  fi
+}
+
+# Verify the top CHANGELOG.md heading matches the expected next version.
+# The human is expected to have authored "## vX.Y.Z" before running prepare.
+require_changelog_top_matches() {
+  local expected="$1"
+  local top
+  top="$(python3 - <<'PY'
+from pathlib import Path
+import re
+text = Path("CHANGELOG.md").read_text()
+for line in text.splitlines():
+    m = re.match(r"^## v(\d+\.\d+\.\d+)\s*$", line)
+    if m:
+        print(m.group(1))
+        break
+PY
+)"
+  if [[ -z "$top" ]]; then
+    echo "error: CHANGELOG.md has no '## vX.Y.Z' heading"
+    exit 1
+  fi
+  if [[ "$top" != "$expected" ]]; then
+    echo "error: CHANGELOG.md top heading is v$top but --bump implies v$expected"
+    echo "hint: edit CHANGELOG.md to add '## v$expected' as the new top entry, then re-run"
+    exit 1
+  fi
+}
+
 run_common_gates() {
   # Build the portal frontend up front so `portal-dist/` exists for every
   # downstream step. The `harn-cli` crate embeds portal-dist via `include_dir!`
@@ -190,13 +285,26 @@ run_common_gates() {
     SKIP_DRY_RUN=1
   fi
 
-  log_step "Release audit"
-  ./scripts/release_gate.sh audit
+  if [[ "$SKIP_AUDIT" -eq 0 ]]; then
+    log_step "Release audit"
+    ./scripts/release_gate.sh audit
+  else
+    log_step "Skipping release audit (already proved by merge-queue CI)"
+  fi
 
   if [[ "$SKIP_DRY_RUN" -eq 0 ]]; then
     log_step "Publish dry run"
     ./scripts/release_gate.sh publish --dry-run
   fi
+}
+
+regenerate_derived_files() {
+  log_step "Regenerate derived files"
+  # Both targets are idempotent no-ops when the generated artifact is
+  # already current. They exist as Makefile targets so the same
+  # canonical command works locally and from CI.
+  make sync-language-spec
+  make gen-highlight
 }
 
 open_bump_pr() {
@@ -273,6 +381,55 @@ EOF
   echo "  Finalize after merge queue lands it: ./scripts/release_ship.sh --finalize"
 }
 
+prepare_here() {
+  local previous="$1"
+  local next="$2"
+  local branch
+  branch="$(git branch --show-current)"
+
+  # Run audit + dry-run from the dirty release branch. The audit's
+  # cargo steps don't care about uncommitted changes; the publish
+  # dry-run already auto-detects dirtiness and falls back to
+  # --allow-dirty (see scripts/publish.sh).
+  run_common_gates
+
+  log_step "Version bump (in place)"
+  ./scripts/release_gate.sh prepare --bump "$BUMP" --allow-dirty
+  local actual_next
+  actual_next="$(current_version)"
+  if [[ "$actual_next" != "$next" ]]; then
+    echo "error: expected version $next, got $actual_next"
+    exit 1
+  fi
+
+  regenerate_derived_files
+
+  log_step "Stage release content"
+  # Stage the version bump deterministically and then sweep tracked
+  # changes (changelog, code, docs, generated mirrors) so the human's
+  # next `git commit` captures the whole release in one shot.
+  git add Cargo.toml Cargo.lock crates/*/Cargo.toml
+  git add docs/src/language-spec.md docs/theme/harn-keywords.js
+  git add -u
+
+  log_step "Prepare-here ready"
+  TOTAL_NS=$(( $(_ship_now_ns) - SHIP_START_NS ))
+  echo ""
+  echo "Release content staged on $branch:"
+  echo "  Previous version: $previous"
+  echo "  Next version:     $next"
+  echo "  Total wall time:  $(_ship_fmt_ns "$TOTAL_NS")"
+  echo ""
+  echo "Next steps:"
+  echo "  git status                                # review staged changes"
+  echo "  git commit -m \"Release v$next\""
+  echo "  git push -u origin $branch"
+  echo "  gh pr create --title \"Release v$next\" --body \"...\""
+  echo ""
+  echo "After the PR lands through the merge queue, the Finalize Release"
+  echo "workflow auto-fires on tag drift and ships v$next."
+}
+
 tag_exists() {
   local tag="$1"
   git rev-parse -q --verify "refs/tags/$tag" >/dev/null
@@ -296,6 +453,7 @@ ensure_tag_at_head() {
 
 BUMP="patch"
 SKIP_DRY_RUN=0
+SKIP_AUDIT=0
 MODE="bump-pr"
 BASE_BRANCH="main"
 NOTES_OUTPUT=""
@@ -305,6 +463,10 @@ while [[ $# -gt 0 ]]; do
     --bump)
       BUMP="${2:-}"
       shift 2
+      ;;
+    --prepare)
+      MODE="prepare-here"
+      shift
       ;;
     --finalize)
       MODE="finalize"
@@ -316,6 +478,17 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-dry-run)
       SKIP_DRY_RUN=1
+      shift
+      ;;
+    --skip-audit)
+      SKIP_AUDIT=1
+      shift
+      ;;
+    --reaudit)
+      # --finalize defaults to skipping the audit (merge-queue CI just
+      # proved the same set). --reaudit forces it back on.
+      SKIP_AUDIT=0
+      RELEASE_FINALIZE_REAUDIT=1
       shift
       ;;
     --notes-output)
@@ -347,13 +520,40 @@ case "$BUMP" in
     ;;
 esac
 
-require_clean_tree
-require_base_branch "$BASE_BRANCH"
+# Mode-specific guards. Each mode runs against a different baseline:
+#   prepare-here: feature branch with dirty tree (release content authored)
+#   bump-pr:      clean main, opens recovery release branch
+#   finalize:     clean main with Cargo.toml ahead of latest tag
+if [[ "$MODE" == "prepare-here" ]]; then
+  require_release_branch "$BASE_BRANCH"
+elif [[ "$MODE" == "finalize" ]]; then
+  require_clean_tree
+  require_base_branch "$BASE_BRANCH"
+  # Trust the merge-queue CI by default; opt-in re-audit via env var or
+  # --reaudit flag.
+  if [[ "${RELEASE_FINALIZE_REAUDIT:-0}" != "1" ]]; then
+    SKIP_AUDIT=1
+  fi
+else
+  require_clean_tree
+  require_base_branch "$BASE_BRANCH"
+fi
 
 PREVIOUS_VERSION="$(current_version)"
 if [[ -z "$PREVIOUS_VERSION" ]]; then
   echo "error: failed to detect current version"
   exit 1
+fi
+
+if [[ "$MODE" == "prepare-here" ]]; then
+  NEXT_VERSION="$(next_version "$BUMP")"
+  if [[ "$NEXT_VERSION" == "$PREVIOUS_VERSION" ]]; then
+    echo "error: --bump $BUMP would leave version unchanged at $PREVIOUS_VERSION"
+    exit 1
+  fi
+  require_changelog_top_matches "$NEXT_VERSION"
+  prepare_here "$PREVIOUS_VERSION" "$NEXT_VERSION"
+  exit 0
 fi
 
 if [[ "$MODE" == "bump-pr" ]]; then

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -219,6 +219,43 @@ require_base_branch() {
   fi
 }
 
+# Sync local base branch to origin/base instead of asserting strict
+# equality. Used by --finalize where the GHA runner clones main early
+# in setup, then sits through ~30s of toolchain installs before this
+# script runs — main can move during that window. The bump intent is
+# already in main's history regardless of where HEAD is now, so the
+# right move is to fast-forward the local clone and tag whichever
+# commit Cargo.toml's version is set on.
+sync_base_branch() {
+  local base="$1"
+  local branch
+  branch="$(git branch --show-current)"
+  if [[ "$branch" != "$base" ]]; then
+    echo "error: release_ship.sh --finalize must run from $base; current branch is ${branch:-detached}"
+    exit 1
+  fi
+  git fetch origin "$base" --quiet
+  local local_head remote_head
+  local_head="$(git rev-parse HEAD)"
+  remote_head="$(git rev-parse "origin/$base")"
+  if [[ "$local_head" != "$remote_head" ]]; then
+    echo "Local $base behind origin/$base; fast-forwarding."
+    echo "  was:  $local_head"
+    echo "  now:  $remote_head"
+    git pull --ff-only origin "$base" --quiet
+  fi
+  # Re-read Cargo.toml after the fast-forward — if main has continued
+  # past the bump and someone else has already bumped to a newer
+  # version, abort rather than silently tagging the wrong commit.
+  local fresh_version
+  fresh_version="$(current_version)"
+  if [[ -n "${EXPECTED_VERSION:-}" && "$fresh_version" != "$EXPECTED_VERSION" ]]; then
+    echo "error: Cargo.toml version moved from $EXPECTED_VERSION to $fresh_version while finalizing"
+    echo "hint: re-trigger publish-release.yml — it'll detect drift for the new version"
+    exit 1
+  fi
+}
+
 require_release_branch() {
   local base="$1"
   local branch
@@ -426,7 +463,7 @@ prepare_here() {
   echo "  git push -u origin $branch"
   echo "  gh pr create --title \"Release v$next\" --body \"...\""
   echo ""
-  echo "After the PR lands through the merge queue, the Finalize Release"
+  echo "After the PR lands through the merge queue, the publish-release"
   echo "workflow auto-fires on tag drift and ships v$next."
 }
 
@@ -528,7 +565,8 @@ if [[ "$MODE" == "prepare-here" ]]; then
   require_release_branch "$BASE_BRANCH"
 elif [[ "$MODE" == "finalize" ]]; then
   require_clean_tree
-  require_base_branch "$BASE_BRANCH"
+  EXPECTED_VERSION="$(current_version)"
+  sync_base_branch "$BASE_BRANCH"
   # Trust the merge-queue CI by default; opt-in re-audit via env var or
   # --reaudit flag.
   if [[ "${RELEASE_FINALIZE_REAUDIT:-0}" != "1" ]]; then

--- a/scripts/verify_release_metadata.py
+++ b/scripts/verify_release_metadata.py
@@ -25,6 +25,41 @@ def changelog_versions() -> list[str]:
     return re.findall(r"^## v([0-9]+\.[0-9]+\.[0-9]+)$", text, re.M)
 
 
+def changelog_section_body(version: str) -> str:
+    """Return the body content under `## vX.Y.Z` up to the next heading."""
+    text = CHANGELOG.read_text()
+    match = re.search(
+        rf"(?ms)^## v{re.escape(version)}\n(.*?)(?=^## v|\Z)",
+        text,
+    )
+    return match.group(1).strip() if match else ""
+
+
+def detect_misformatted_headings() -> list[str]:
+    """Catch headings that look like version markers but won't parse.
+
+    The canonical regex is `^## vX.Y.Z$` (no trailing whitespace, no
+    suffix). Variants like `## v0.7.41 ` or `## v0.7.41-rc1` would
+    silently fall through the strict version finder, masking a typo
+    as "missing entry" later.
+
+    Only flags lines that already contain a full 3-component vX.Y.Z
+    prefix followed by extra characters — historical headings like
+    `## v0.5 series (0.5.0 – 0.5.83)` only have two dot components
+    and aren't trying to be release headings.
+    """
+    text = CHANGELOG.read_text()
+    suspicious = []
+    for line in text.splitlines():
+        m = re.match(r"^## v\d+\.\d+\.\d+", line)
+        if not m:
+            continue
+        rest = line[len(m.group(0)):]
+        if rest:
+            suspicious.append(line)
+    return suspicious
+
+
 def parse_semver(version: str) -> tuple[int, int, int]:
     major, minor, patch = version.split(".")
     return int(major), int(minor), int(patch)
@@ -93,10 +128,24 @@ def is_bump_ahead(cargo_version: str, changelog_version: str) -> bool:
 
 def main() -> int:
     version = current_version()
+    misformatted = detect_misformatted_headings()
+    if misformatted:
+        joined = "\n  ".join(misformatted)
+        raise SystemExit(
+            "error: CHANGELOG.md has heading(s) that look like version markers but "
+            "don't match the canonical `## vX.Y.Z` regex (no trailing whitespace, "
+            "no suffix):\n  " + joined
+        )
     versions = changelog_versions()
     if not versions:
         raise SystemExit("error: CHANGELOG.md does not contain any version headings")
     top = versions[0]
+    body = changelog_section_body(top)
+    if not body:
+        raise SystemExit(
+            f"error: CHANGELOG.md '## v{top}' section has no body content; release "
+            "notes would be empty. Add bullet points describing the release."
+        )
     effective_version = version
     if top != version:
         if is_bump_ahead(version, top):

--- a/scripts/verify_release_metadata.py
+++ b/scripts/verify_release_metadata.py
@@ -79,6 +79,18 @@ def verify_release_notes(version: str) -> None:
 
 
 def verify_tag_state(version: str) -> None:
+    """Reject states that would silently re-release or rewrite history.
+
+    Passes when:
+      - the tag does not exist yet (we're staging a future release), OR
+      - HEAD is at the tagged commit, OR
+      - HEAD descends from the tagged commit (released; main has moved on
+        with non-release commits — fine, the next release PR will bump).
+
+    Fails only when HEAD is an ancestor of the tag, or unrelated — both
+    of which mean Cargo.toml is at version X.Y.Z but HEAD doesn't
+    contain the X.Y.Z release commit, which would tag the wrong state.
+    """
     tag = f"v{version}"
     tag_lookup = subprocess.run(
         ["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag}"],
@@ -102,11 +114,21 @@ def verify_tag_state(version: str) -> None:
         capture_output=True,
         check=True,
     ).stdout.strip()
-    if head != tag_commit:
-        raise SystemExit(
-            f"error: current version {version} is already tagged at {tag_commit}, "
-            f"but HEAD is {head}; bump the version or move off the released tag state"
-        )
+    if head == tag_commit:
+        return
+    is_descendant = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", tag_commit, head],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    if is_descendant.returncode == 0:
+        return
+    raise SystemExit(
+        f"error: current version {version} is already tagged at {tag_commit}, "
+        f"but HEAD ({head}) does not include that commit; either bump the "
+        f"version or rebase onto the tagged commit before continuing"
+    )
 
 
 def is_bump_ahead(cargo_version: str, changelog_version: str) -> bool:


### PR DESCRIPTION
## Summary

The companion to v0.7.40's release ordeal. Bundles the work that was supposed to land in #666 (silently dropped because GitHub doesn't reject pushes to queued PRs) plus follow-up fixes for the racing/naming/sloppiness pain points hit while shipping.

### Workflow rename + sentence case

Old | New | Does what
---|---|---
`Bump Release` | `Open version bump PR (recovery)` | Recovery only (workflow_dispatch)
`Finalize Release` (`finalize-release.yml`) | `Publish release` (`publish-release.yml`) | Tags + crates.io + GH release notes
`Release` (`release.yml`) | `Build release binaries` (`build-release-binaries.yml`) | Binary tarballs + container after tag push

All step + job names normalized to sentence case across the three files. Skill docs (`.claude/commands/release-harn.md`, `.codex/commands/harn-release.md`, both `.codex/skills/*-release/SKILL.md`) updated to match.

### Consolidated single-PR flow (from #666)

- New `release_ship.sh --prepare --bump <type>`: runs from a release branch, audits + dry-runs, bumps versions + regenerates derived files, stages everything for one commit.
- `release_ship.sh --finalize` skips the audit by default (`RELEASE_FINALIZE_REAUDIT=0`); opt back in via `--reaudit`.
- `bump-release.yml` demoted to recovery-only (workflow_dispatch).
- `publish-release.yml` skips ripgrep + tree-sitter setup unless `reaudit` is on.

### Race fix in `--finalize`

Replaces strict `require_base_branch` (was failing every retry today) with `sync_base_branch` that fast-forwards local main to current `origin/main` and sanity-checks Cargo.toml hasn't moved past the expected version. The bump intent is in main's history regardless of where HEAD is now.

### Merge-queue silent-snapshot guard

New pre-push hook queries the GitHub merge queue via GraphQL. If the current branch's PR is queued, push aborts with the dequeue/push/re-enqueue recipe and a `--no-verify` escape hatch. This is exactly what bit us on #666 (consolidation commit silently dropped because the PR was already queued).

### Prevention gates (from #666)

- Pre-commit hook regenerates `docs/src/language-spec.md` whenever `spec/HARN_SPEC.md` is staged (~50ms).
- New `make sync-language-spec` and `make check-language-spec` Makefile targets.
- CI now runs `check-highlight`, `check-language-spec`, `check-trigger-quickref`, `check-trigger-examples`, `check-docs-snippets`, `verify_release_metadata.py`.
- `verify_release_metadata.py` rejects empty release bodies, malformed headings (`## v0.7.41 `, `## v0.7.41-rc1`), and rebuilds the `verify_tag_state` constraint to allow descendant-of-tag HEAD (lets non-release PRs land after a tag without bumping).

## Test plan

- [x] `bash -n` syntax check on all modified shell scripts
- [x] `make check-language-spec` passes locally
- [x] `python3 scripts/verify_release_metadata.py` passes against current main (with v0.7.40 already tagged at an ancestor commit)
- [x] `make lint-actions` passes (workflows are valid)
- [x] Pre-commit hook runs cleanly on commit
- [x] Pre-push hook GraphQL query verified against the live merge queue
- [ ] Merge-queue CI green
- [ ] Future `Release vX.Y.Z` PR exercises `--prepare` + `--finalize` end-to-end with the new naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)