### PR TITLE
[codex] Add Agents Protocol task replay contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ granular archaeology.
 
 ### Added
 
+- **Agents Protocol replay-as-API contract (#636).** Adds
+  `POST /v1/tasks/{task_id}/replay` to the v1 OpenAPI surface with
+  `exact`, `with_overrides`, and `from_checkpoint` modes, deterministic
+  override maps, replay event metadata, and Receipt delta requirements.
+  The new `agents-protocol-replay/` artifact documents the EventLog replay
+  contract and ships fixtures for byte-identical replay Receipt conformance.
 - **`unnecessary-cast` lint with autofix.** Flags conversion-builtin
   calls whose argument is already syntactically of the target type —
   `to_string("hi")`, `to_int(42)`, `to_float(1.5)`, `to_list([1,2,3])`,

--- a/agents-protocol-receipts/README.md
+++ b/agents-protocol-receipts/README.md
@@ -49,6 +49,8 @@ A receipt is a JSON object with these top-level fields:
   handoffs.
 - `final_artifacts`: final artifact references with stable hashes when bytes
   are available.
+- `deltas`: replay or repair substitutions applied to the receipt subject,
+  including override keys and before/after hashes when available.
 - `chain`: previous receipt hash, current receipt hash, and optional Merkle
   root.
 - `redactions`: omitted private material with reason and proof hash when

--- a/agents-protocol-receipts/schemas/receipt-2026-04-25.schema.json
+++ b/agents-protocol-receipts/schemas/receipt-2026-04-25.schema.json
@@ -243,6 +243,13 @@
         "$ref": "#/$defs/artifactRef"
       }
     },
+    "deltas": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/receiptDelta"
+      },
+      "default": []
+    },
     "chain": {
       "type": "object",
       "additionalProperties": false,
@@ -578,6 +585,43 @@
         },
         "proof_hash": {
           "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "receiptDelta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operation", "path"],
+      "properties": {
+        "delta_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "operation": {
+          "type": "string",
+          "enum": ["add", "replace", "remove"]
+        },
+        "path": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "override_key": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "event_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "before_sha256": {
+          "type": ["string", "null"],
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "after_sha256": {
+          "type": ["string", "null"],
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "artifact_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "reason": {
+          "$ref": "#/$defs/nonEmptyString"
         }
       }
     },

--- a/agents-protocol-replay/README.md
+++ b/agents-protocol-replay/README.md
@@ -1,0 +1,113 @@
+# Harn Agents Protocol Replay Contract
+
+This directory is the canonical v1 replay-as-API contract for the Harn Agents
+Protocol. It makes Harn's durable EventLog replay model visible as a public API
+verb without exposing private runtime internals.
+
+Until a standalone specification site exists, the public URL for this artifact
+is:
+
+<https://github.com/burin-labs/harn/tree/main/agents-protocol-replay>
+
+## REST entrypoint
+
+Task replay is created with:
+
+```text
+POST /v1/tasks/{task_id}/replay
+```
+
+The response is a newly accepted Task. The replay Task MUST set
+`parent_task_id` to the source Task id, use the same Session and Workspace
+unless policy requires an isolated Branch, and emit normal Task lifecycle
+events for the replay run.
+
+The request body is optional:
+
+```json
+{
+  "mode": "with_overrides",
+  "override": {
+    "llm:main:1": {
+      "kind": "llm_provider_response",
+      "event_id": "event_01JZ7001",
+      "value": {
+        "id": "chatcmpl_fixture_1",
+        "choices": [
+          {
+            "message": {
+              "role": "assistant",
+              "content": "Done."
+            }
+          }
+        ]
+      },
+      "sha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "visibility": "receipt_only"
+    }
+  }
+}
+```
+
+## Modes
+
+- `exact`: replay only recorded EventLog material. The server MUST fail instead
+  of refreshing unavailable model responses, tool returns, secrets, time, or
+  host facts.
+- `with_overrides`: replay recorded EventLog material, but replace named
+  nondeterministic dependencies with the `override` map.
+- `from_checkpoint`: restore a recorded checkpoint boundary, then replay later
+  EventLog entries. The request MUST include `checkpoint_id` or
+  `checkpoint_event_id`.
+
+## Override keys
+
+Override keys are stable implementation-facing dependency labels. They SHOULD
+be deterministic across conforming implementations for the same module and
+input. Recommended forms are:
+
+- `llm:<call_id>` for provider responses.
+- `mcp:<server>:<tool_call_id>` for MCP tool returns.
+- `secret:<name>` for secret material supplied by the Harness.
+- `time:<label>` for wall-clock or monotonic clock reads.
+- `host:<capability>:<call_id>` for host facts or tool results.
+
+Override values MAY inline JSON in `value` or reference a durable Artifact via
+`artifact_id`. Secret overrides SHOULD use `visibility: receipt_only`.
+
+## EventLog use
+
+Replay MUST read the source Task's EventLog entries in event order. Replayed
+events SHOULD preserve original event ids when the transport can safely do so.
+When ids are remapped, events MUST include replay metadata with:
+
+- `source_task_id`
+- `replay_task_id`
+- `original_event_id`
+- `replay_cursor`
+- `mode`
+- `override_key` when a substitution produced the event
+
+## Receipt deltas
+
+Every applied override MUST be recorded as a Receipt delta. A delta identifies
+the original event or material path, the override key, before/after hashes when
+available, and the reason supplied by the caller or Harness policy.
+
+Replay Receipts MUST NOT expose hidden chain-of-thought or secret values.
+Receipt-only substitutions should record hashes and artifact references rather
+than raw material.
+
+## Determinism fixture
+
+The conformance fixture in `fixtures/valid/` defines the minimum byte-stable
+case:
+
+- `task-replay-request.json`: a replay request with deterministic overrides.
+- `replay-source.harn`: the module both implementations execute.
+- `task-replay-receipt.json`: the canonical Receipt shape expected after replay.
+
+Two conforming implementations that run the same module with the same EventLog
+history and the same overrides MUST produce byte-identical canonical Receipt
+JSON after RFC 8785 canonicalization, excluding signatures that are explicitly
+implementation-specific.

--- a/agents-protocol-replay/fixtures/valid/replay-source.harn
+++ b/agents-protocol-replay/fixtures/valid/replay-source.harn
@@ -1,0 +1,5 @@
+/** Deterministic replay conformance fixture entrypoint. */
+pub fn main(input) {
+  let stamped = {message: input?.message ?? "", verdict: "approved"}
+  return stamped
+}

--- a/agents-protocol-replay/fixtures/valid/task-replay-receipt.json
+++ b/agents-protocol-replay/fixtures/valid/task-replay-receipt.json
@@ -1,0 +1,123 @@
+{
+  "schema": "receipt-2026-04-25",
+  "receipt_id": "receipt_replay_01JZ6Y3B5K0QJ9GM61VZKX7P6G",
+  "subject": {
+    "object": "replay_segment",
+    "id": "task_replay_01JZ6Y2ZKMB8H8DMXBGXR1FPGS"
+  },
+  "issuer": {
+    "id": "harness_conformance",
+    "kind": "harness",
+    "name": "Harn replay conformance",
+    "version": "agents-protocol-2026-04-25"
+  },
+  "issued_at": "2026-04-25T19:17:33Z",
+  "identifiers": {
+    "workspace_ref": "workspace_replay_fixture",
+    "session_id": "session_replay_fixture",
+    "task_id": "task_replay_01JZ6Y2ZKMB8H8DMXBGXR1FPGS",
+    "trace_id": "trace_replay_fixture"
+  },
+  "lifecycle": {
+    "created_at": "2026-04-25T19:16:10Z",
+    "started_at": "2026-04-25T19:16:14Z",
+    "completed_at": "2026-04-25T19:17:33Z",
+    "final_state": "SUCCEEDED",
+    "failure": null
+  },
+  "trust": {
+    "start_tier": "act_auto",
+    "end_tier": "act_auto",
+    "policy_ref": "policy_replay_conformance"
+  },
+  "autonomy_budget": {
+    "consumed": {
+      "usd": 0,
+      "input_tokens": 0,
+      "output_tokens": 0,
+      "tool_calls": 0,
+      "wall_time_ms": 0
+    }
+  },
+  "replay_input": {
+    "determinism": "byte_deterministic",
+    "materials": [
+      {
+        "kind": "event_log",
+        "id": "event_log_source_task",
+        "uri": "artifact://artifact_event_log_source_task",
+        "sha256": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "content_type": "application/jsonl"
+      },
+      {
+        "kind": "llm_provider_response",
+        "id": "llm:main:1",
+        "sha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "metadata": {
+          "override_key": "llm:main:1"
+        }
+      }
+    ]
+  },
+  "model_route": {
+    "chosen_model": {
+      "provider": "fixture",
+      "model": "replay-fixture"
+    },
+    "alternatives_considered": [],
+    "route_policy_reason": "replayed from recorded provider response"
+  },
+  "cost": {
+    "currency": "USD",
+    "total": 0,
+    "provider_breakdown": []
+  },
+  "side_effects": {
+    "fs_writes": [],
+    "network_egress": [],
+    "tool_calls": [],
+    "a2a_handoffs": []
+  },
+  "final_artifacts": [
+    {
+      "artifact_id": "artifact_replay_output",
+      "kind": "dataset",
+      "uri": "artifact://artifact_replay_output",
+      "sha256": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    }
+  ],
+  "chain": {
+    "previous_receipt_hash": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "receipt_hash": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "merkle_root": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "deltas": [
+    {
+      "delta_id": "delta_llm_main_1",
+      "operation": "replace",
+      "path": "/replay_input/materials/llm:main:1",
+      "override_key": "llm:main:1",
+      "event_id": "event_01JZ7001",
+      "before_sha256": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "after_sha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "reason": "agents-protocol replay conformance fixture"
+    },
+    {
+      "delta_id": "delta_time_started_at",
+      "operation": "replace",
+      "path": "/lifecycle/started_at",
+      "override_key": "time:started_at",
+      "event_id": "event_01JZ7000",
+      "before_sha256": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "after_sha256": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "reason": "pin replay clock"
+    }
+  ],
+  "redactions": [],
+  "signatures": [],
+  "metadata": {
+    "source": "agents-protocol-replay-conformance-fixture",
+    "source_task_id": "task_source_01JZ6Y2ZKMB8H8DMXBGXR1FPGS",
+    "replay_mode": "with_overrides"
+  }
+}

--- a/agents-protocol-replay/fixtures/valid/task-replay-request.json
+++ b/agents-protocol-replay/fixtures/valid/task-replay-request.json
@@ -1,0 +1,34 @@
+{
+  "mode": "with_overrides",
+  "override": {
+    "llm:main:1": {
+      "kind": "llm_provider_response",
+      "event_id": "event_01JZ7001",
+      "target": "main",
+      "value": {
+        "id": "chatcmpl_fixture_1",
+        "choices": [
+          {
+            "message": {
+              "role": "assistant",
+              "content": "approved"
+            }
+          }
+        ]
+      },
+      "sha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "visibility": "receipt_only",
+      "reason": "agents-protocol replay conformance fixture"
+    },
+    "time:started_at": {
+      "kind": "time",
+      "event_id": "event_01JZ7000",
+      "target": "started_at",
+      "value": "2026-04-25T19:16:14Z",
+      "sha256": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "visibility": "internal",
+      "reason": "pin replay clock"
+    }
+  },
+  "reason": "byte-deterministic replay conformance"
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -90,6 +90,7 @@
 - [CLI reference](./cli-reference.md)
 - [Agents Protocol v1](./spec/agents-protocol/v1.md)
 - [Agents Protocol Receipt Format](./spec/agents-protocol/receipt-format-v1.md)
+- [Agents Protocol Replay Contract](./spec/agents-protocol/replay-v1.md)
 - [Builtin functions](./builtins.md)
 - [Postgres](./postgres.md)
 - [Project scanning](./project-scan.md)

--- a/docs/src/spec/agents-protocol/replay-v1.md
+++ b/docs/src/spec/agents-protocol/replay-v1.md
@@ -1,0 +1,3 @@
+# Harn Agents Protocol Replay Contract
+
+{{#include ../../../../agents-protocol-replay/README.md:2:}}

--- a/spec/AGENTS_PROTOCOL.md
+++ b/spec/AGENTS_PROTOCOL.md
@@ -791,6 +791,12 @@ Clients MUST NOT infer cryptographic validity from the presence of a
 The replay-as-API sibling spec defines exact REST paths and replay fixtures.
 This narrative spec requires:
 
+- `POST /v1/tasks/{task_id}/replay` creates a new Task by replaying the source
+  Task EventLog. The new Task MUST expose the source Task as `parent_task_id`.
+- Replay requests support `exact`, `with_overrides`, and `from_checkpoint`
+  modes. Overrides MUST be keyed deterministic substitutions for recorded
+  nondeterministic dependencies such as model responses, MCP tool returns,
+  secret values, clock reads, and host facts.
 - Events are durable enough to replay a Session or Task history within the
   server's advertised retention window.
 - Replayed stream events are marked as replayed.
@@ -799,6 +805,9 @@ This narrative spec requires:
 - Replay MUST NOT silently include refreshed Memory, changed secrets, or new
   host facts unless the replay request explicitly opts into non-deterministic
   refresh.
+- Applied substitutions MUST be recorded as Receipt deltas that identify the
+  override key, original event or material path, and before/after hashes when
+  available.
 - Replay failures MUST identify the first unavailable event, artifact, memory,
   receipt, or host dependency that prevents replay.
 

--- a/spec/openapi.snapshot
+++ b/spec/openapi.snapshot
@@ -29,6 +29,7 @@ GET /v1/tasks
 POST /v1/tasks
 GET /v1/tasks/{task_id}
 POST /v1/tasks/{task_id}/cancel
+POST /v1/tasks/{task_id}/replay
 POST /v1/tasks/{task_id}/messages
 GET /v1/tasks/{task_id}/events
 GET /v1/tasks/{task_id}/stream
@@ -87,6 +88,10 @@ TaskStatus
 TaskList
 SubmitTaskRequest
 CancelTaskRequest
+ReplayMode
+ReplayTaskRequest
+ReplayOverride
+ReplayEventMetadata
 Branch
 BranchList
 CreateBranchRequest

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -620,6 +620,38 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  /v1/tasks/{task_id}/replay:
+    post:
+      tags: [Tasks]
+      operationId: replayTask
+      summary: Replay a Task from its durable EventLog.
+      description: |
+        Creates a new Task by replaying the original Task's durable event log.
+        The returned Task is the replay Task and MUST set `parent_task_id` to
+        the source Task id. Overrides substitute recorded nondeterministic
+        dependencies such as LLM responses, MCP tool returns, secret values,
+        clock reads, and host facts; every applied substitution MUST be
+        represented as a replay Receipt delta.
+      parameters:
+        - $ref: "#/components/parameters/ProtocolVersion"
+        - $ref: "#/components/parameters/TaskId"
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReplayTaskRequest"
+      responses:
+        "202":
+          description: Accepted replay Task.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Task"
+        default:
+          $ref: "#/components/responses/Error"
+
   /v1/tasks/{task_id}/messages:
     post:
       tags: [Messages]
@@ -1760,6 +1792,7 @@ components:
               type: [string, "null"]
             parent_task_id:
               type: [string, "null"]
+              description: Source Task id for replay and delegated child Tasks, otherwise null.
             assigned_agent_id:
               type: [string, "null"]
             receipt_id:
@@ -1821,6 +1854,103 @@ components:
       type: object
       properties:
         reason:
+          type: [string, "null"]
+    ReplayMode:
+      type: string
+      enum: [exact, with_overrides, from_checkpoint]
+      description: |
+        `exact` reuses only recorded event-log material, `with_overrides`
+        applies explicit substitutions, and `from_checkpoint` resumes from a
+        recorded checkpoint before replaying later events.
+    ReplayTaskRequest:
+      type: object
+      properties:
+        mode:
+          $ref: "#/components/schemas/ReplayMode"
+          default: exact
+        override:
+          type: object
+          description: Map from stable override key to replacement replay material.
+          additionalProperties:
+            $ref: "#/components/schemas/ReplayOverride"
+          default: {}
+        checkpoint_id:
+          type: [string, "null"]
+          description: Required when `mode` is `from_checkpoint` unless `checkpoint_event_id` is supplied.
+        checkpoint_event_id:
+          type: [string, "null"]
+          description: Event id of the checkpoint boundary for `from_checkpoint` replay.
+        reason:
+          type: [string, "null"]
+        metadata:
+          $ref: "#/components/schemas/Metadata"
+      examples:
+        - mode: with_overrides
+          override:
+            llm:main:1:
+              kind: llm_provider_response
+              event_id: event_01JZ7001
+              value:
+                id: chatcmpl_fixture_1
+                choices:
+                  - message:
+                      role: assistant
+                      content: Done.
+              sha256: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ReplayOverride:
+      type: object
+      required: [kind]
+      properties:
+        kind:
+          type: string
+          enum:
+            - llm_provider_response
+            - mcp_tool_return
+            - secret_value
+            - time
+            - host_fact
+            - tool_result
+            - event_payload
+            - checkpoint_value
+        event_id:
+          type: [string, "null"]
+          description: Original EventLog event this override substitutes when known.
+        target:
+          type: [string, "null"]
+          description: Stable dependency key such as a model call id, tool call id, secret name, or clock label.
+        value:
+          $ref: "#/components/schemas/JsonValue"
+        artifact_id:
+          type: [string, "null"]
+          description: Artifact containing replacement material when the value is large or receipt-only.
+        sha256:
+          type: [string, "null"]
+          pattern: "^sha256:[0-9a-f]{64}$"
+        visibility:
+          type: string
+          enum: [public, internal, receipt_only]
+          default: receipt_only
+        reason:
+          type: [string, "null"]
+    ReplayEventMetadata:
+      type: object
+      required: [source_task_id, replay_task_id]
+      properties:
+        source_task_id:
+          type: string
+        replay_task_id:
+          type: string
+        original_event_id:
+          type: [string, "null"]
+        replay_cursor:
+          type: [string, "null"]
+          description: Cursor clients can use when replay remaps event ids.
+        mode:
+          $ref: "#/components/schemas/ReplayMode"
+        override_key:
+          type: [string, "null"]
+          description: Override map key applied to produce this replayed event, when any.
+        receipt_delta_id:
           type: [string, "null"]
 
     Branch:
@@ -2212,6 +2342,10 @@ components:
             replayed:
               type: boolean
               default: false
+            replay:
+              oneOf:
+                - $ref: "#/components/schemas/ReplayEventMetadata"
+                - type: "null"
     EventList:
       allOf:
         - $ref: "#/components/schemas/PaginatedList"


### PR DESCRIPTION
## Summary

Closes #636.

Adds the public Agents Protocol task replay contract around the existing EventLog replay model:

- adds `POST /v1/tasks/{task_id}/replay` to `spec/openapi.yaml`, returning the replay Task with `parent_task_id` pointing back to the source Task
- defines replay modes, override maps, replay event metadata, and snapshot updates for the OpenAPI surface
- adds the `agents-protocol-replay/` sibling artifact with the REST contract and deterministic replay conformance fixtures
- extends the receipt schema with optional Receipt `deltas` so replay substitutions have a typed audit location
- updates the narrative spec, mdBook summary, receipt docs, and changelog

## Validation

- `make spec-lint`
- `npx markdownlint-cli2 CHANGELOG.md agents-protocol-receipts/README.md agents-protocol-replay/README.md docs/src/spec/agents-protocol/replay-v1.md spec/AGENTS_PROTOCOL.md`
- `node` schema validation for `agents-protocol-receipts/fixtures/valid/task-receipt.json` and `agents-protocol-replay/fixtures/valid/task-replay-receipt.json`
- `cargo run --quiet --bin harn -- check agents-protocol-replay/fixtures/valid/replay-source.harn`
- `cargo run --quiet --bin harn -- fmt --check agents-protocol-replay/fixtures/valid/replay-source.harn`
- pre-push hook: 2368 nextest tests passed, affected Harn lint/format passed, markdown lint passed