### PR TITLE
[codex] Complete connector OAuth metadata flow

### DIFF
--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -417,6 +417,9 @@ pub(crate) struct DoctorArgs {
 }
 
 #[derive(Debug, Args)]
+#[command(
+    after_long_help = "Registered provider commands:\n  harn connect <provider> [OPTIONS]\n\nIf <provider> is not one of the built-in subcommands, Harn reads OAuth metadata from the nearest harn.toml [[providers]] entry."
+)]
 pub(crate) struct ConnectArgs {
     /// Show authenticated connector tokens known to the local keyring.
     #[arg(long)]
@@ -476,6 +479,9 @@ pub(crate) enum ConnectCommand {
     Notion(ConnectOAuthArgs),
     /// Run the generic OAuth 2.1 flow for any compliant provider.
     Generic(ConnectGenericArgs),
+    /// Authorize a provider registered in harn.toml [[providers]] metadata.
+    #[command(external_subcommand)]
+    Provider(Vec<String>),
 }
 
 #[derive(Debug, Args)]
@@ -2352,6 +2358,34 @@ mod tests {
         };
         assert!(linear.url.is_none());
         assert_eq!(linear.client_id.as_deref(), Some("linear-client"));
+
+        let cli = Cli::parse_from([
+            "harn",
+            "connect",
+            "acme",
+            "--client-id",
+            "acme-client",
+            "--scope",
+            "tickets.read",
+            "--no-open",
+        ]);
+        let Command::Connect(args) = cli.command.unwrap() else {
+            panic!("expected connect command");
+        };
+        let Some(ConnectCommand::Provider(raw)) = args.command else {
+            panic!("expected external provider connect command");
+        };
+        assert_eq!(
+            raw,
+            vec![
+                "acme".to_string(),
+                "--client-id".to_string(),
+                "acme-client".to_string(),
+                "--scope".to_string(),
+                "tickets.read".to_string(),
+                "--no-open".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/connect.rs
+++ b/crates/harn-cli/src/commands/connect.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use base64::Engine;
+use clap::Parser as ClapParser;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use sha2::{Digest, Sha256};
@@ -14,7 +15,7 @@ use crate::cli::{
     ConnectArgs, ConnectCommand, ConnectGenericArgs, ConnectGithubArgs, ConnectLinearArgs,
     ConnectOAuthArgs,
 };
-use crate::package;
+use crate::package::{self, ProviderOAuthManifest};
 use harn_vm::secrets::{KeyringSecretProvider, SecretBytes, SecretId, SecretProvider};
 
 const MANIFEST: &str = "harn.toml";
@@ -183,6 +184,7 @@ async fn run_connect_inner(args: ConnectArgs) -> Result<(), String> {
         .await;
     }
 
+    let json_output = args.json;
     match args.command.expect("validated one command action") {
         ConnectCommand::Github(args) => run_connect_github(&args).await,
         ConnectCommand::Linear(args) if args.url.is_some() => run_connect_linear(&args).await,
@@ -190,6 +192,10 @@ async fn run_connect_inner(args: ConnectArgs) -> Result<(), String> {
         ConnectCommand::Slack(args) => run_connect_named_oauth("slack", &args).await,
         ConnectCommand::Notion(args) => run_connect_named_oauth("notion", &args).await,
         ConnectCommand::Generic(args) => run_connect_generic(&args).await,
+        ConnectCommand::Provider(raw) => {
+            let parsed = parse_external_provider_connect(raw, json_output)?;
+            run_connect_registered_provider(&parsed.provider, &parsed.oauth).await
+        }
     }
 }
 
@@ -269,6 +275,97 @@ async fn run_connect_generic(args: &ConnectGenericArgs) -> Result<(), String> {
         json: args.oauth.json,
     })
     .await
+}
+
+async fn run_connect_registered_provider(
+    provider: &str,
+    args: &ConnectOAuthArgs,
+) -> Result<(), String> {
+    if let Some(metadata) = registered_provider_oauth(provider)? {
+        return run_oauth_connect(oauth_request_from_provider_metadata(
+            provider, args, &metadata,
+        )?)
+        .await;
+    }
+    if oauth_provider_defaults(provider).is_some() {
+        return run_connect_named_oauth(provider, args).await;
+    }
+    Err(format!(
+        "provider '{provider}' is not registered with OAuth metadata; add `oauth = {{ resource = \"...\" }}` to its [[providers]] entry or use `harn connect generic {provider} <url>`"
+    ))
+}
+
+#[derive(Debug, ClapParser)]
+#[command(no_binary_name = true, disable_help_flag = true)]
+struct ExternalProviderConnectArgs {
+    provider: String,
+    #[command(flatten)]
+    oauth: ConnectOAuthArgs,
+}
+
+fn parse_external_provider_connect(
+    raw: Vec<String>,
+    json_output: bool,
+) -> Result<ExternalProviderConnectArgs, String> {
+    let mut parsed = ExternalProviderConnectArgs::try_parse_from(raw)
+        .map_err(|error| error.render().to_string())?;
+    parsed.oauth.json |= json_output;
+    Ok(parsed)
+}
+
+fn registered_provider_oauth(provider: &str) -> Result<Option<ProviderOAuthManifest>, String> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let extensions = package::try_load_runtime_extensions(&cwd)?;
+    Ok(extensions
+        .provider_connectors
+        .into_iter()
+        .find(|entry| entry.id.as_str() == provider)
+        .and_then(|entry| entry.oauth))
+}
+
+fn oauth_request_from_provider_metadata(
+    provider: &str,
+    args: &ConnectOAuthArgs,
+    metadata: &ProviderOAuthManifest,
+) -> Result<OAuthConnectRequest, String> {
+    let resource = args
+        .resource
+        .clone()
+        .or_else(|| metadata.resource.clone())
+        .ok_or_else(|| {
+            format!(
+                "registered provider '{provider}' OAuth metadata must include `resource`, or pass --resource"
+            )
+        })?;
+    Ok(OAuthConnectRequest {
+        provider: provider.to_string(),
+        resource,
+        authorization_endpoint: args
+            .auth_url
+            .clone()
+            .or_else(|| metadata.authorization_endpoint.clone()),
+        token_endpoint: args
+            .token_url
+            .clone()
+            .or_else(|| metadata.token_endpoint.clone()),
+        registration_endpoint: metadata.registration_endpoint.clone(),
+        client_id: args
+            .client_id
+            .clone()
+            .or_else(|| metadata.client_id.clone()),
+        client_secret: args
+            .client_secret
+            .clone()
+            .or_else(|| metadata.client_secret.clone()),
+        scopes: args.scope.clone().or_else(|| metadata.scopes.clone()),
+        redirect_uri: args.redirect_uri.clone(),
+        token_auth_method: args
+            .token_auth_method
+            .clone()
+            .or_else(|| metadata.token_endpoint_auth_method.clone()),
+        no_open: args.no_open,
+        json: args.json,
+    })
 }
 
 fn oauth_provider_defaults(provider: &str) -> Option<OAuthProviderDefaults> {
@@ -1652,6 +1749,9 @@ struct OAuthDiscoveryResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
+    use std::net::TcpStream;
+    use std::thread;
 
     #[test]
     fn derives_linear_resource_types_from_trigger_events() {
@@ -1730,6 +1830,45 @@ mod tests {
     }
 
     #[test]
+    fn registered_provider_metadata_builds_oauth_request_with_cli_overrides() {
+        let metadata = ProviderOAuthManifest {
+            authorization_endpoint: Some("https://auth.example.com/authorize".to_string()),
+            token_endpoint: Some("https://auth.example.com/token".to_string()),
+            registration_endpoint: Some("https://auth.example.com/register".to_string()),
+            resource: Some("https://api.example.com/".to_string()),
+            scopes: Some("default.read".to_string()),
+            client_id: Some("manifest-client".to_string()),
+            client_secret: Some("manifest-secret".to_string()),
+            token_endpoint_auth_method: Some("client_secret_post".to_string()),
+        };
+        let args = ConnectOAuthArgs {
+            client_id: Some("cli-client".to_string()),
+            client_secret: None,
+            scope: Some("cli.read".to_string()),
+            resource: None,
+            auth_url: None,
+            token_url: Some("https://override.example.com/token".to_string()),
+            token_auth_method: None,
+            redirect_uri: "http://127.0.0.1:0/oauth/callback".to_string(),
+            no_open: true,
+            json: true,
+        };
+        let request =
+            oauth_request_from_provider_metadata("acme", &args, &metadata).expect("request");
+        assert_eq!(request.provider, "acme");
+        assert_eq!(request.resource, "https://api.example.com/");
+        assert_eq!(request.client_id.as_deref(), Some("cli-client"));
+        assert_eq!(request.client_secret.as_deref(), Some("manifest-secret"));
+        assert_eq!(request.scopes.as_deref(), Some("cli.read"));
+        assert_eq!(
+            request.token_endpoint.as_deref(),
+            Some("https://override.example.com/token")
+        );
+        assert!(request.no_open);
+        assert!(request.json);
+    }
+
+    #[test]
     fn loopback_listener_rewrites_zero_port() {
         let (_listener, redirect_uri) =
             bind_loopback_listener("http://127.0.0.1:0/oauth/callback").expect("loopback listener");
@@ -1771,5 +1910,216 @@ mod tests {
             url.as_str(),
             "https://github.com/apps/harn-test/installations/new?state=state123"
         );
+    }
+
+    #[test]
+    fn github_install_callback_captures_installation_id() {
+        let (listener, redirect_uri) =
+            bind_loopback_listener("http://127.0.0.1:0/gh-install-callback")
+                .expect("loopback listener");
+        let parsed = Url::parse(&redirect_uri).unwrap();
+        let port = parsed.port().unwrap();
+        let client = thread::spawn(move || {
+            let mut stream = TcpStream::connect(("127.0.0.1", port)).expect("connect callback");
+            stream
+                .write_all(
+                    b"GET /gh-install-callback?installation_id=12345&state=state-ok HTTP/1.1\r\nHost: 127.0.0.1\r\nOrigin: null\r\n\r\n",
+                )
+                .expect("write callback");
+            let mut response = String::new();
+            stream
+                .read_to_string(&mut response)
+                .expect("read callback response");
+            assert!(response.contains("200 OK"));
+        });
+        let installation_id =
+            wait_for_github_installation(listener, &redirect_uri, Some("state-ok"))
+                .expect("installation id");
+        client.join().expect("callback client");
+        assert_eq!(installation_id, "12345");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mocked_builtin_oauth_token_endpoints_receive_pkce_and_resource_indicators() {
+        for provider in ["slack", "linear", "notion"] {
+            let defaults = oauth_provider_defaults(provider).expect("provider defaults");
+            let expected_resource = defaults.default_resource.to_string();
+            let token_endpoint = spawn_token_endpoint(move |form| {
+                assert_eq!(
+                    form.get("grant_type").map(String::as_str),
+                    Some("authorization_code")
+                );
+                assert_eq!(form.get("code").map(String::as_str), Some("code-123"));
+                assert_eq!(
+                    form.get("code_verifier").map(String::as_str),
+                    Some("verifier-123")
+                );
+                assert_eq!(
+                    form.get("resource").map(String::as_str),
+                    Some(expected_resource.as_str())
+                );
+            });
+            let token = exchange_authorization_code(
+                &token_endpoint,
+                AuthorizationCodeExchange {
+                    client_id: "client",
+                    client_secret: Some("secret"),
+                    token_auth_method: defaults.token_auth_method,
+                    redirect_uri: "http://127.0.0.1:49152/oauth/callback",
+                    resource: defaults.default_resource,
+                    scopes: Some("read write"),
+                    code: "code-123",
+                    code_verifier: "verifier-123",
+                },
+            )
+            .await
+            .expect("token exchange");
+            assert_eq!(token.access_token, "mock-access-token");
+            assert_eq!(token.refresh_token.as_deref(), Some("mock-refresh-token"));
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn generic_mcp_oauth_discovers_metadata_and_registers_client() {
+        let (base_url, server) = spawn_generic_mcp_oauth_server();
+        let discovery = discover_oauth_server(&format!("{base_url}/mcp/notion"))
+            .await
+            .expect("discover oauth server");
+        assert_eq!(
+            discovery.metadata.authorization_endpoint,
+            format!("{base_url}/oauth/authorize")
+        );
+        assert_eq!(
+            discovery.metadata.token_endpoint,
+            format!("{base_url}/oauth/token")
+        );
+        assert_eq!(
+            discovery.metadata.registration_endpoint.as_deref(),
+            Some(format!("{base_url}/oauth/register").as_str())
+        );
+        ensure_pkce_support(&discovery.metadata).expect("pkce support");
+        let registered = dynamic_client_registration(
+            discovery.metadata.registration_endpoint.as_deref().unwrap(),
+            "http://127.0.0.1:49152/oauth/callback",
+            Some("mcp.read"),
+        )
+        .await
+        .expect("dynamic registration");
+        assert_eq!(registered.client_id, "dynamic-client");
+        server.join().expect("mock oauth server");
+    }
+
+    fn spawn_token_endpoint<F>(assert_form: F) -> String
+    where
+        F: FnOnce(BTreeMap<String, String>) + Send + 'static,
+    {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("mock token listener");
+        let port = listener.local_addr().unwrap().port();
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("token request");
+            let request = read_http_request(&mut stream);
+            let body = request.split("\r\n\r\n").nth(1).unwrap_or_default();
+            let form = url::form_urlencoded::parse(body.as_bytes())
+                .map(|(key, value)| (key.into_owned(), value.into_owned()))
+                .collect::<BTreeMap<_, _>>();
+            assert_form(form);
+            write_json_response(
+                &mut stream,
+                r#"{"access_token":"mock-access-token","refresh_token":"mock-refresh-token","expires_in":3600}"#,
+            );
+        });
+        format!("http://127.0.0.1:{port}/oauth/token")
+    }
+
+    fn spawn_generic_mcp_oauth_server() -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("mock oauth listener");
+        let port = listener.local_addr().unwrap().port();
+        let base_url = format!("http://127.0.0.1:{port}");
+        let server_base_url = base_url.clone();
+        let handle = thread::spawn(move || {
+            for _ in 0..3 {
+                let (mut stream, _) = listener.accept().expect("oauth request");
+                let request = read_http_request(&mut stream);
+                let path = request
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or("/");
+                if path.starts_with("/.well-known/oauth-protected-resource/mcp/notion") {
+                    write_json_response(
+                        &mut stream,
+                        &format!(r#"{{"authorization_servers":["{server_base_url}/oauth"]}}"#),
+                    );
+                } else if path.starts_with("/.well-known/oauth-authorization-server/oauth") {
+                    write_json_response(
+                        &mut stream,
+                        &format!(
+                            r#"{{"authorization_endpoint":"{server_base_url}/oauth/authorize","token_endpoint":"{server_base_url}/oauth/token","registration_endpoint":"{server_base_url}/oauth/register","code_challenge_methods_supported":["S256"],"token_endpoint_auth_methods_supported":["none","client_secret_post"]}}"#
+                        ),
+                    );
+                } else if path.starts_with("/oauth/register") {
+                    assert!(request.contains("http://127.0.0.1:49152/oauth/callback"));
+                    assert!(request.contains("mcp.read"));
+                    write_json_response(
+                        &mut stream,
+                        r#"{"client_id":"dynamic-client","token_endpoint_auth_method":"none"}"#,
+                    );
+                } else {
+                    write_response(
+                        &mut stream,
+                        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                    );
+                }
+            }
+        });
+        (base_url, handle)
+    }
+
+    fn read_http_request(stream: &mut TcpStream) -> String {
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("set read timeout");
+        let mut buffer = Vec::new();
+        let mut chunk = [0u8; 1024];
+        loop {
+            let read = stream.read(&mut chunk).expect("read request");
+            if read == 0 {
+                break;
+            }
+            buffer.extend_from_slice(&chunk[..read]);
+            let text = String::from_utf8_lossy(&buffer);
+            if let Some((headers, body)) = text.split_once("\r\n\r\n") {
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                    .unwrap_or(0);
+                if body.len() >= content_length {
+                    break;
+                }
+            }
+        }
+        String::from_utf8_lossy(&buffer).to_string()
+    }
+
+    fn write_json_response(stream: &mut TcpStream, body: &str) {
+        write_response(
+            stream,
+            &format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            ),
+        );
+    }
+
+    fn write_response(stream: &mut TcpStream, response: &str) {
+        stream
+            .write_all(response.as_bytes())
+            .expect("write response");
     }
 }

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -953,6 +953,8 @@ pub struct RuntimeExtensions {
 pub struct ProviderManifestEntry {
     pub id: harn_vm::ProviderId,
     pub connector: ProviderConnectorManifest,
+    #[serde(default)]
+    pub oauth: Option<ProviderOAuthManifest>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -961,6 +963,26 @@ pub struct ProviderConnectorManifest {
     pub harn: Option<String>,
     #[serde(default)]
     pub rust: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+pub struct ProviderOAuthManifest {
+    #[serde(default, alias = "auth_url", alias = "authorization-endpoint")]
+    pub authorization_endpoint: Option<String>,
+    #[serde(default, alias = "token_url", alias = "token-endpoint")]
+    pub token_endpoint: Option<String>,
+    #[serde(default, alias = "registration_url", alias = "registration-endpoint")]
+    pub registration_endpoint: Option<String>,
+    #[serde(default)]
+    pub resource: Option<String>,
+    #[serde(default, alias = "scope")]
+    pub scopes: Option<String>,
+    #[serde(default, alias = "client-id")]
+    pub client_id: Option<String>,
+    #[serde(default, alias = "client-secret")]
+    pub client_secret: Option<String>,
+    #[serde(default, alias = "token_auth_method", alias = "token-auth-method")]
+    pub token_endpoint_auth_method: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1010,6 +1032,7 @@ pub struct ResolvedProviderConnectorConfig {
     pub id: harn_vm::ProviderId,
     pub manifest_dir: PathBuf,
     pub connector: ResolvedProviderConnectorKind,
+    pub oauth: Option<ProviderOAuthManifest>,
 }
 
 #[derive(Debug, Clone)]
@@ -1574,6 +1597,7 @@ fn resolved_provider_connectors_from_manifest(
                 id: provider.id.clone(),
                 manifest_dir: manifest_dir.to_path_buf(),
                 connector,
+                oauth: provider.oauth.clone(),
             }
         })
         .collect()
@@ -8207,6 +8231,7 @@ handler = "acme::audit_edit"
 [[providers]]
 id = "echo"
 connector = { harn = "./echo_connector.harn" }
+oauth = { resource = "https://echo.example/mcp", authorization_endpoint = "https://auth.echo.example/authorize", token_endpoint = "https://auth.echo.example/token", scopes = "echo.read" }
 
 [[providers]]
 id = "github"
@@ -8223,6 +8248,20 @@ connector = { rust = "builtin" }
             &extensions.provider_connectors[0].connector,
             ResolvedProviderConnectorKind::Harn { module } if module == "./echo_connector.harn"
         ));
+        assert_eq!(
+            extensions.provider_connectors[0]
+                .oauth
+                .as_ref()
+                .and_then(|oauth| oauth.resource.as_deref()),
+            Some("https://echo.example/mcp")
+        );
+        assert_eq!(
+            extensions.provider_connectors[0]
+                .oauth
+                .as_ref()
+                .and_then(|oauth| oauth.scopes.as_deref()),
+            Some("echo.read")
+        );
         assert!(matches!(
             extensions.provider_connectors[1].connector,
             ResolvedProviderConnectorKind::RustBuiltin

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -445,6 +445,7 @@ harn connect notion \
   --client-secret "$NOTION_CLIENT_SECRET"
 harn connect generic acme https://mcp.example.com/mcp
 harn connect --generic acme https://mcp.example.com/mcp
+harn connect acme
 harn connect --list
 harn connect --refresh notion
 harn connect --revoke slack
@@ -457,6 +458,11 @@ enabled. Generic OAuth discovers protected-resource and authorization-server
 metadata when explicit endpoints are not supplied, attempts dynamic client
 registration when available, and sends the `resource` parameter to both the
 authorization and token endpoints.
+
+`harn connect <provider>` is available for providers registered in the nearest
+`harn.toml` `[[providers]]` table with `oauth = { ... }` metadata. CLI flags
+such as `--client-id`, `--scope`, `--auth-url`, and `--token-url` override the
+manifest metadata for that run.
 
 Stored OAuth tokens are written under connector-friendly secret ids:
 

--- a/docs/src/connectors/authoring.md
+++ b/docs/src/connectors/authoring.md
@@ -40,6 +40,12 @@ Root manifests can override a provider's connector implementation:
 [[providers]]
 id = "echo"
 connector = { harn = "./echo_connector.harn" }
+oauth = {
+  resource = "https://api.echo.example/",
+  authorization_endpoint = "https://auth.echo.example/oauth/authorize",
+  token_endpoint = "https://auth.echo.example/oauth/token",
+  scopes = "echo.read echo.write",
+}
 
 [[triggers]]
 id = "echo-webhook"
@@ -49,6 +55,12 @@ path = "/hooks/echo"
 match = { path = "/hooks/echo", events = ["echo.received"] }
 handler = "handlers::on_echo"
 ```
+
+The optional `oauth` table is package-owned setup metadata consumed by
+`harn connect <provider>`. It supports `resource`,
+`authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `scopes`,
+`client_id`, `client_secret`, and `token_endpoint_auth_method`; operator CLI
+flags override those values for a single run.
 
 The referenced `.harn` module must export:
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -3518,6 +3518,29 @@ denied by default. `activate` uses the activation class with the same default
 restrictions as connector-outbound setup. Hosts may override these defaults for
 trusted private connectors by supplying an explicit export policy.
 
+Provider entries may declare setup OAuth metadata. This metadata is consumed by
+`harn connect <provider>` so connector packages can describe their OAuth
+surface without adding provider-specific Rust code:
+
+```toml
+[[providers]]
+id = "acme"
+connector = { harn = ".harn/packages/acme-connector/lib.harn" }
+oauth = {
+  resource = "https://api.acme.example/",
+  authorization_endpoint = "https://auth.acme.example/oauth/authorize",
+  token_endpoint = "https://auth.acme.example/oauth/token",
+  registration_endpoint = "https://auth.acme.example/oauth/register",
+  scopes = "acme.read acme.write",
+  token_endpoint_auth_method = "none",
+}
+```
+
+`resource` is required unless the operator supplies `--resource`. The endpoint
+fields may be omitted for compliant protected resources that advertise OAuth
+metadata. `client_id`, `client_secret`, and `token_endpoint_auth_method` are
+defaults only; CLI flags override them for a single connect run.
+
 Poll-capable providers export `poll_tick(ctx)`. The orchestrator invokes this
 hook for `kind = "poll"` bindings using the binding's `poll` configuration:
 `interval`/`interval_ms`/`interval_secs`, optional

--- a/docs/src/orchestrator/oauth.md
+++ b/docs/src/orchestrator/oauth.md
@@ -29,6 +29,24 @@ harn connect generic acme https://mcp.example.com/mcp
 harn connect --generic acme https://mcp.example.com/mcp
 ```
 
+Connector packages can also declare their setup metadata in the registered
+provider entry, letting operators run `harn connect <provider>` without
+hardcoded provider logic in core:
+
+```toml
+[[providers]]
+id = "acme"
+connector = { harn = ".harn/packages/acme-connector/lib.harn" }
+oauth = {
+  resource = "https://mcp.example.com/mcp",
+  authorization_endpoint = "https://auth.example.com/oauth/authorize",
+  token_endpoint = "https://auth.example.com/oauth/token",
+  registration_endpoint = "https://auth.example.com/oauth/register",
+  scopes = "mcp.read mcp.write",
+  token_endpoint_auth_method = "none",
+}
+```
+
 When endpoints are not supplied, Harn discovers protected-resource metadata,
 then authorization-server metadata. If the server advertises dynamic client
 registration and no `--client-id` is supplied, Harn registers a loopback client

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -3516,6 +3516,29 @@ denied by default. `activate` uses the activation class with the same default
 restrictions as connector-outbound setup. Hosts may override these defaults for
 trusted private connectors by supplying an explicit export policy.
 
+Provider entries may declare setup OAuth metadata. This metadata is consumed by
+`harn connect <provider>` so connector packages can describe their OAuth
+surface without adding provider-specific Rust code:
+
+```toml
+[[providers]]
+id = "acme"
+connector = { harn = ".harn/packages/acme-connector/lib.harn" }
+oauth = {
+  resource = "https://api.acme.example/",
+  authorization_endpoint = "https://auth.acme.example/oauth/authorize",
+  token_endpoint = "https://auth.acme.example/oauth/token",
+  registration_endpoint = "https://auth.acme.example/oauth/register",
+  scopes = "acme.read acme.write",
+  token_endpoint_auth_method = "none",
+}
+```
+
+`resource` is required unless the operator supplies `--resource`. The endpoint
+fields may be omitted for compliant protected resources that advertise OAuth
+metadata. `client_id`, `client_secret`, and `token_endpoint_auth_method` are
+defaults only; CLI flags override them for a single connect run.
+
 Poll-capable providers export `poll_tick(ctx)`. The orchestrator invokes this
 hook for `kind = "poll"` bindings using the binding's `poll` configuration:
 `interval`/`interval_ms`/`interval_secs`, optional


### PR DESCRIPTION
## Summary

Closes #176.

- Adds `oauth = { ... }` metadata to manifest `[[providers]]` entries so Harn connector packages can describe their setup flow without hardcoded Rust provider defaults.
- Allows `harn connect <provider>` for registered providers, while preserving built-in GitHub/Slack/Linear/Notion and generic OAuth commands.
- Adds deterministic loopback/mock-provider coverage for GitHub App callbacks, Slack/Linear/Notion token exchange parameters, and generic MCP-style OAuth discovery + dynamic client registration.
- Documents the provider-owned OAuth metadata in the CLI reference, connector OAuth docs, connector authoring docs, and canonical/generated language spec.

## Validation

- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/harn-issue176-target cargo test -p harn-cli connect -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-issue176-target cargo check -p harn-cli`
- `CARGO_TARGET_DIR=/tmp/harn-issue176-target cargo run --quiet -p harn-cli -- connect --help`
- `npm run lint:md -- docs/src/cli-reference.md docs/src/orchestrator/oauth.md docs/src/connectors/authoring.md docs/src/language-spec.md spec/HARN_SPEC.md`
- Pre-commit hook passed, including workspace clippy and markdown lint.
- Pre-push hook passed: 2,386 tests passed, markdown lint passed.
