### PR TITLE
[codex] Add OpenAI-compatible model readiness probe

### DIFF
--- a/crates/harn-cli/src/commands/doctor.rs
+++ b/crates/harn-cli/src/commands/doctor.rs
@@ -582,9 +582,42 @@ async fn check_provider_health(network: bool) -> Vec<DoctorCheck> {
             continue;
         };
 
+        if harn_vm::llm::supports_model_readiness_probe(&def) {
+            if let Some(model) = harn_vm::llm::selected_model_for_provider(&provider_name) {
+                checks.push(run_model_readiness(&provider_name, &model, &auth.value).await);
+                continue;
+            }
+        }
+
         checks.push(run_healthcheck(&client, &provider_name, &def, &auth, healthcheck).await);
     }
     checks
+}
+
+async fn run_model_readiness(
+    provider_name: &str,
+    model: &str,
+    api_key: &Option<String>,
+) -> DoctorCheck {
+    let readiness = harn_vm::llm::probe_openai_compatible_model(
+        provider_name,
+        model,
+        api_key.as_deref().unwrap_or(""),
+    )
+    .await;
+    let status = if readiness.valid {
+        DoctorStatus::Ok
+    } else {
+        match readiness.category.as_str() {
+            "model_missing" | "bad_status" | "invalid_url" => DoctorStatus::Fail,
+            _ => DoctorStatus::Warn,
+        }
+    };
+    DoctorCheck {
+        status,
+        label: format!("provider:{provider_name}"),
+        detail: format!("{}: {}", readiness.category, readiness.message),
+    }
 }
 
 async fn run_healthcheck(

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -772,6 +772,7 @@ async fn print_model_info(model: &str) {
     let tool_format = harn_vm::llm_config::default_tool_format(&resolved_id, &provider);
     let context_window =
         harn_vm::llm::fetch_provider_max_context(&provider, &resolved_id, &api_key).await;
+    let readiness = local_openai_readiness(&provider, &resolved_id, &api_key).await;
     let payload = serde_json::json!({
         "alias": model,
         "id": resolved_id,
@@ -779,6 +780,7 @@ async fn print_model_info(model: &str) {
         "tool_format": tool_format,
         "api_key_set": api_key_set,
         "context_window": context_window,
+        "readiness": readiness,
     });
     println!(
         "{}",
@@ -786,6 +788,28 @@ async fn print_model_info(model: &str) {
             command_error(&format!("failed to serialize model info: {error}"))
         })
     );
+}
+
+async fn local_openai_readiness(
+    provider: &str,
+    model: &str,
+    api_key: &str,
+) -> Option<serde_json::Value> {
+    let def = harn_vm::llm_config::provider_config(provider)?;
+    if def.auth_style != "none" || !harn_vm::llm::supports_model_readiness_probe(&def) {
+        return None;
+    }
+    let readiness = harn_vm::llm::probe_openai_compatible_model(provider, model, api_key).await;
+    Some(serde_json::json!({
+        "valid": readiness.valid,
+        "category": readiness.category,
+        "message": readiness.message,
+        "provider": readiness.provider,
+        "model": readiness.model,
+        "url": readiness.url,
+        "status": readiness.status,
+        "available_models": readiness.available_models,
+    }))
 }
 
 fn command_error(message: &str) -> ! {

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -11,6 +11,7 @@ mod errors;
 mod ollama;
 mod openai_normalize;
 mod options;
+mod readiness;
 mod response;
 mod result;
 mod thinking;
@@ -37,6 +38,10 @@ pub(crate) use options::{
     DeltaSender, LlmCallOptions, LlmRequestPayload, LlmRouteAlternative, LlmRoutePolicy,
     LlmRoutingDecision, ThinkingConfig, ToolSearchConfig, ToolSearchMode, ToolSearchStrategy,
     ToolSearchVariant,
+};
+pub use readiness::{
+    probe_openai_compatible_model, selected_model_for_provider, supports_model_readiness_probe,
+    ModelReadiness,
 };
 pub(crate) use result::{vm_build_llm_result, LlmResult};
 pub(crate) use transport::vm_call_llm_api_with_body;

--- a/crates/harn-vm/src/llm/api/context_window.rs
+++ b/crates/harn-vm/src/llm/api/context_window.rs
@@ -133,7 +133,10 @@ async fn fetch_openai_compatible_context_window(
 ) -> Option<usize> {
     let pdef = crate::llm_config::provider_config(provider);
     let client = crate::llm::shared_utility_client();
-    let url = format!("{base_url}/models");
+    let url = pdef
+        .as_ref()
+        .and_then(|def| super::readiness::build_models_url(def).ok())
+        .unwrap_or_else(|| format!("{}/models", base_url.trim_end_matches('/')));
     let req = client
         .get(&url)
         .header("Content-Type", "application/json")

--- a/crates/harn-vm/src/llm/api/readiness.rs
+++ b/crates/harn-vm/src/llm/api/readiness.rs
@@ -1,0 +1,530 @@
+//! OpenAI-compatible model readiness probes.
+//!
+//! Local llama.cpp/vLLM-style servers expose their loaded model aliases
+//! through `/v1/models`. Unlike context-window discovery, this module keeps
+//! distinct user-facing failure categories so hosts can surface actionable
+//! startup diagnostics before the first chat request.
+
+use crate::llm_config::{self, ProviderDef};
+
+use super::auth::apply_auth_headers;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelReadiness {
+    pub valid: bool,
+    pub category: String,
+    pub message: String,
+    pub provider: String,
+    pub model: String,
+    pub url: Option<String>,
+    pub status: Option<u16>,
+    pub available_models: Vec<String>,
+}
+
+impl ModelReadiness {
+    fn ok(
+        provider: &str,
+        model: &str,
+        url: &str,
+        status: u16,
+        available_models: Vec<String>,
+    ) -> Self {
+        Self {
+            valid: true,
+            category: "ok".to_string(),
+            message: format!("{provider} is reachable and serves model '{model}' at {url}"),
+            provider: provider.to_string(),
+            model: model.to_string(),
+            url: Some(url.to_string()),
+            status: Some(status),
+            available_models,
+        }
+    }
+
+    fn error(
+        provider: &str,
+        model: &str,
+        category: &str,
+        message: String,
+        url: Option<String>,
+        status: Option<u16>,
+        available_models: Vec<String>,
+    ) -> Self {
+        Self {
+            valid: false,
+            category: category.to_string(),
+            message,
+            provider: provider.to_string(),
+            model: model.to_string(),
+            url,
+            status,
+            available_models,
+        }
+    }
+}
+
+pub fn supports_model_readiness_probe(def: &ProviderDef) -> bool {
+    let healthcheck_uses_models = def.healthcheck.as_ref().is_some_and(|hc| {
+        hc.method.eq_ignore_ascii_case("GET") && {
+            hc.path
+                .as_deref()
+                .is_some_and(|path| path.contains("models"))
+                || hc.url.as_deref().is_some_and(|url| url.contains("models"))
+        }
+    });
+    healthcheck_uses_models || def.chat_endpoint.ends_with("/chat/completions")
+}
+
+pub fn selected_model_for_provider(provider: &str) -> Option<String> {
+    if provider == "local" {
+        if let Ok(model) = std::env::var("LOCAL_LLM_MODEL") {
+            if !model.trim().is_empty() {
+                let (resolved, _) = llm_config::resolve_model(model.trim());
+                return Some(resolved);
+            }
+        }
+    }
+
+    let selected_provider = std::env::var("HARN_LLM_PROVIDER")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    if selected_provider.as_deref() == Some(provider) {
+        if let Ok(model) = std::env::var("HARN_LLM_MODEL") {
+            if !model.trim().is_empty() {
+                let (resolved, _) = llm_config::resolve_model(model.trim());
+                return Some(resolved);
+            }
+        }
+    }
+
+    None
+}
+
+pub fn build_models_url(def: &ProviderDef) -> Result<String, String> {
+    let raw = models_healthcheck_url(def).unwrap_or_else(|| {
+        join_base_and_path(
+            &llm_config::resolve_base_url(def),
+            &model_path_from_chat_endpoint(&def.chat_endpoint),
+        )
+    });
+    validate_url(&normalize_loopback(&raw))
+}
+
+fn models_healthcheck_url(def: &ProviderDef) -> Option<String> {
+    let healthcheck = def.healthcheck.as_ref()?;
+    if !healthcheck.method.eq_ignore_ascii_case("GET") {
+        return None;
+    }
+    if let Some(url) = healthcheck.url.as_ref() {
+        return url.contains("models").then(|| url.clone());
+    }
+    let path = healthcheck.path.as_deref()?;
+    path.contains("models")
+        .then(|| join_base_and_path(&llm_config::resolve_base_url(def), path))
+}
+
+pub fn parse_model_ids(json: &serde_json::Value) -> Vec<String> {
+    if let Some(data) = json.get("data").and_then(|value| value.as_array()) {
+        return data
+            .iter()
+            .filter_map(|entry| entry.get("id").and_then(|value| value.as_str()))
+            .map(str::to_string)
+            .collect();
+    }
+
+    if let Some(models) = json.get("models").and_then(|value| value.as_array()) {
+        return models
+            .iter()
+            .filter_map(|entry| {
+                entry
+                    .get("id")
+                    .or_else(|| entry.get("name"))
+                    .and_then(|value| value.as_str())
+            })
+            .map(str::to_string)
+            .collect();
+    }
+
+    Vec::new()
+}
+
+pub fn model_is_served(available: &[String], model: &str) -> bool {
+    available
+        .iter()
+        .any(|id| id == model || id.starts_with(model))
+}
+
+pub async fn probe_openai_compatible_model(
+    provider: &str,
+    model: &str,
+    api_key: &str,
+) -> ModelReadiness {
+    let Some(def) = llm_config::provider_config(provider) else {
+        return ModelReadiness::error(
+            provider,
+            model,
+            "unknown_provider",
+            format!("Unknown provider: {provider}"),
+            None,
+            None,
+            Vec::new(),
+        );
+    };
+
+    probe_openai_compatible_model_with_def(provider, model, api_key, &def).await
+}
+
+pub(crate) async fn probe_openai_compatible_model_with_def(
+    provider: &str,
+    model: &str,
+    api_key: &str,
+    def: &ProviderDef,
+) -> ModelReadiness {
+    let url = match build_models_url(def) {
+        Ok(url) => url,
+        Err(error) => {
+            return ModelReadiness::error(
+                provider,
+                model,
+                "invalid_url",
+                format!("Invalid OpenAI-compatible models URL for {provider}: {error}"),
+                None,
+                None,
+                Vec::new(),
+            );
+        }
+    };
+
+    let client = crate::llm::shared_utility_client();
+    let req = client
+        .get(&url)
+        .header("Content-Type", "application/json")
+        .timeout(std::time::Duration::from_secs(10));
+    let req = apply_auth_headers(req, api_key, Some(def));
+    let req = def
+        .extra_headers
+        .iter()
+        .fold(req, |req, (name, value)| req.header(name, value));
+
+    let response = match req.send().await {
+        Ok(response) => response,
+        Err(error) => {
+            return ModelReadiness::error(
+                provider,
+                model,
+                "unreachable",
+                format!("{provider} OpenAI-compatible server not reachable at {url}: {error}"),
+                Some(url),
+                None,
+                Vec::new(),
+            );
+        }
+    };
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return ModelReadiness::error(
+            provider,
+            model,
+            "bad_status",
+            format!(
+                "{provider} returned HTTP {} at {url}: {body}",
+                status.as_u16()
+            ),
+            Some(url),
+            Some(status.as_u16()),
+            Vec::new(),
+        );
+    }
+
+    let status_code = status.as_u16();
+    let json: serde_json::Value = match response.json().await {
+        Ok(json) => json,
+        Err(error) => {
+            return ModelReadiness::error(
+                provider,
+                model,
+                "invalid_response",
+                format!("Could not parse {provider} /models response at {url}: {error}"),
+                Some(url),
+                Some(status_code),
+                Vec::new(),
+            );
+        }
+    };
+    let available_models = parse_model_ids(&json);
+    if available_models.is_empty() {
+        return ModelReadiness::error(
+            provider,
+            model,
+            "invalid_response",
+            format!("Could not find model ids in {provider} /models response at {url}"),
+            Some(url),
+            Some(status_code),
+            available_models,
+        );
+    }
+
+    if !model_is_served(&available_models, model) {
+        let available = available_models.join(", ");
+        return ModelReadiness::error(
+            provider,
+            model,
+            "model_missing",
+            format!(
+                "Model '{model}' is not served by {provider} at {url}. Currently served: {available}"
+            ),
+            Some(url),
+            Some(status_code),
+            available_models,
+        );
+    }
+
+    ModelReadiness::ok(provider, model, &url, status_code, available_models)
+}
+
+fn model_path_from_chat_endpoint(chat_endpoint: &str) -> String {
+    if let Some(prefix) = chat_endpoint.strip_suffix("/chat/completions") {
+        if prefix.is_empty() {
+            "/models".to_string()
+        } else {
+            format!("{prefix}/models")
+        }
+    } else {
+        "/models".to_string()
+    }
+}
+
+fn join_base_and_path(base: &str, path: &str) -> String {
+    let base = base.trim_end_matches('/');
+    if path.is_empty() {
+        base.to_string()
+    } else if path.starts_with('/') {
+        format!("{base}{path}")
+    } else {
+        format!("{base}/{path}")
+    }
+}
+
+fn normalize_loopback(url: &str) -> String {
+    url.replace("://localhost:", "://127.0.0.1:")
+}
+
+fn validate_url(url: &str) -> Result<String, String> {
+    reqwest::Url::parse(url)
+        .map(|_| url.to_string())
+        .map_err(|error| format!("{url} ({error})"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm_config::{HealthcheckDef, ProviderDef};
+
+    #[test]
+    fn parses_openai_and_ollama_style_model_ids() {
+        let openai = serde_json::json!({
+            "data": [{"id": "qwen-alias"}, {"id": "other"}]
+        });
+        assert_eq!(
+            parse_model_ids(&openai),
+            vec!["qwen-alias".to_string(), "other".to_string()]
+        );
+
+        let models = serde_json::json!({
+            "models": [{"name": "llama"}, {"id": "qwen"}]
+        });
+        assert_eq!(
+            parse_model_ids(&models),
+            vec!["llama".to_string(), "qwen".to_string()]
+        );
+    }
+
+    #[test]
+    fn model_matching_accepts_exact_or_prefix() {
+        let ids = vec![
+            "qwen36".to_string(),
+            "gpt-oss:20b".to_string(),
+            "llama-local-long-id".to_string(),
+        ];
+        assert!(model_is_served(&ids, "qwen36"));
+        assert!(model_is_served(&ids, "llama-local"));
+        assert!(!model_is_served(&ids, "missing"));
+    }
+
+    #[test]
+    fn models_url_uses_healthcheck_path_and_loopback_normalization() {
+        let def = ProviderDef {
+            base_url: "http://localhost:8001".to_string(),
+            chat_endpoint: "/v1/chat/completions".to_string(),
+            healthcheck: Some(HealthcheckDef {
+                method: "GET".to_string(),
+                path: Some("/v1/models".to_string()),
+                url: None,
+                body: None,
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            build_models_url(&def).unwrap(),
+            "http://127.0.0.1:8001/v1/models"
+        );
+    }
+
+    #[test]
+    fn models_url_derives_path_from_chat_endpoint() {
+        let def = ProviderDef {
+            base_url: "http://127.0.0.1:8000".to_string(),
+            chat_endpoint: "/v1/chat/completions".to_string(),
+            healthcheck: None,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            build_models_url(&def).unwrap(),
+            "http://127.0.0.1:8000/v1/models"
+        );
+    }
+
+    #[test]
+    fn models_url_ignores_non_model_healthcheck_path() {
+        let def = ProviderDef {
+            base_url: "http://127.0.0.1:8080".to_string(),
+            chat_endpoint: "/v1/chat/completions".to_string(),
+            healthcheck: Some(HealthcheckDef {
+                method: "GET".to_string(),
+                path: Some("/health".to_string()),
+                url: None,
+                body: None,
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            build_models_url(&def).unwrap(),
+            "http://127.0.0.1:8080/v1/models"
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_reports_ready_when_model_is_served() {
+        let def = test_def_with_response(200, r#"{"data":[{"id":"served-model-long"}]}"#).await;
+
+        let result =
+            probe_openai_compatible_model_with_def("local", "served-model", "", &def).await;
+
+        assert!(result.valid);
+        assert_eq!(result.category, "ok");
+        assert_eq!(
+            result.available_models,
+            vec!["served-model-long".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_distinguishes_model_missing() {
+        let def = test_def_with_response(200, r#"{"data":[{"id":"served-model"}]}"#).await;
+
+        let result = probe_openai_compatible_model_with_def("local", "missing", "", &def).await;
+
+        assert!(!result.valid);
+        assert_eq!(result.category, "model_missing");
+        assert_eq!(result.available_models, vec!["served-model".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn probe_distinguishes_bad_status() {
+        let def = test_def_with_response(503, "loading").await;
+
+        let result =
+            probe_openai_compatible_model_with_def("local", "served-model", "", &def).await;
+
+        assert!(!result.valid);
+        assert_eq!(result.category, "bad_status");
+        assert_eq!(result.status, Some(503));
+    }
+
+    #[tokio::test]
+    async fn probe_distinguishes_invalid_url() {
+        let def = ProviderDef {
+            base_url: "not a url".to_string(),
+            chat_endpoint: "/v1/chat/completions".to_string(),
+            healthcheck: Some(HealthcheckDef {
+                method: "GET".to_string(),
+                path: Some("/v1/models".to_string()),
+                url: None,
+                body: None,
+            }),
+            auth_style: "none".to_string(),
+            ..Default::default()
+        };
+
+        let result =
+            probe_openai_compatible_model_with_def("local", "served-model", "", &def).await;
+
+        assert!(!result.valid);
+        assert_eq!(result.category, "invalid_url");
+    }
+
+    #[tokio::test]
+    async fn probe_distinguishes_unreachable() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        drop(listener);
+        let def = ProviderDef {
+            base_url: format!("http://{addr}"),
+            chat_endpoint: "/v1/chat/completions".to_string(),
+            healthcheck: Some(HealthcheckDef {
+                method: "GET".to_string(),
+                path: Some("/v1/models".to_string()),
+                url: None,
+                body: None,
+            }),
+            auth_style: "none".to_string(),
+            ..Default::default()
+        };
+
+        let result =
+            probe_openai_compatible_model_with_def("local", "served-model", "", &def).await;
+
+        assert!(!result.valid);
+        assert_eq!(result.category, "unreachable");
+    }
+
+    async fn test_def_with_response(status: u16, body: &'static str) -> ProviderDef {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept");
+            let mut buf = [0_u8; 1024];
+            let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut buf).await;
+            let response = format!(
+                "HTTP/1.1 {status} OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            tokio::io::AsyncWriteExt::write_all(&mut socket, response.as_bytes())
+                .await
+                .expect("write");
+        });
+
+        ProviderDef {
+            base_url: format!("http://{addr}"),
+            chat_endpoint: "/v1/chat/completions".to_string(),
+            healthcheck: Some(HealthcheckDef {
+                method: "GET".to_string(),
+                path: Some("/v1/models".to_string()),
+                url: None,
+                body: None,
+            }),
+            auth_style: "none".to_string(),
+            ..Default::default()
+        }
+    }
+}

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -253,6 +253,16 @@ pub(crate) fn register_config_builtins(vm: &mut Vm) {
             }
         };
 
+        let requested_model = healthcheck_model_arg(&args)
+            .or_else(|| super::selected_model_for_provider(&provider_name));
+        if let Some(model) = requested_model.filter(|model| !model.trim().is_empty()) {
+            if super::supports_model_readiness_probe(&pdef) {
+                let readiness =
+                    super::probe_openai_compatible_model(&provider_name, &model, &api_key).await;
+                return Ok(readiness_result(&readiness));
+            }
+        }
+
         let hc = match &pdef.healthcheck {
             Some(h) => h,
             None => {
@@ -362,6 +372,62 @@ fn provider_def_to_vm_value(pdef: &llm_config::ProviderDef) -> VmValue {
         dict.insert("rpm".to_string(), VmValue::Int(rpm as i64));
     }
     VmValue::Dict(Rc::new(dict))
+}
+
+fn healthcheck_model_arg(args: &[VmValue]) -> Option<String> {
+    let raw = match args.get(1) {
+        Some(VmValue::Dict(dict)) => dict
+            .get("model")
+            .or_else(|| dict.get("alias"))
+            .map(|value| value.display())?,
+        Some(VmValue::Nil) => return None,
+        Some(value) => value.display(),
+        None => return None,
+    };
+    let (resolved, _) = llm_config::resolve_model(raw.trim());
+    Some(resolved)
+}
+
+fn readiness_result(readiness: &super::ModelReadiness) -> VmValue {
+    let mut meta = BTreeMap::new();
+    meta.insert(
+        "category".to_string(),
+        VmValue::String(Rc::from(readiness.category.as_str())),
+    );
+    meta.insert(
+        "provider".to_string(),
+        VmValue::String(Rc::from(readiness.provider.as_str())),
+    );
+    meta.insert(
+        "model".to_string(),
+        VmValue::String(Rc::from(readiness.model.as_str())),
+    );
+    meta.insert(
+        "url".to_string(),
+        readiness
+            .url
+            .as_ref()
+            .map(|url| VmValue::String(Rc::from(url.as_str())))
+            .unwrap_or(VmValue::Nil),
+    );
+    meta.insert(
+        "status".to_string(),
+        readiness
+            .status
+            .map(|status| VmValue::Int(status as i64))
+            .unwrap_or(VmValue::Nil),
+    );
+    meta.insert(
+        "available_models".to_string(),
+        VmValue::List(Rc::new(
+            readiness
+                .available_models
+                .iter()
+                .map(|model| VmValue::String(Rc::from(model.as_str())))
+                .collect(),
+        )),
+    );
+    healthcheck_result_with_meta(readiness.valid, &readiness.message, meta)
 }
 
 /// Build a healthcheck result dict with optional metadata.

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -365,8 +365,11 @@ pub use self::agent_config::{
     register_agent_loop_with_bridge, register_llm_call_structured_with_bridge,
     register_llm_call_with_bridge,
 };
-pub use self::api::fetch_provider_max_context;
 pub(crate) use self::api::vm_call_llm_full;
+pub use self::api::{
+    fetch_provider_max_context, probe_openai_compatible_model, selected_model_for_provider,
+    supports_model_readiness_probe, ModelReadiness,
+};
 pub use self::cost::{calculate_cost_for_provider, peek_total_cost};
 pub(crate) use self::helpers::extract_llm_options;
 pub use self::helpers::resolve_api_key;

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1354,7 +1354,7 @@ See [LLM calls and agent loops](llm-and-agents.md) for full documentation.
 | `llm_pick_model(target, options?)` | target: string, options: dict | dict | Resolve a model alias or tier to `{id, provider, tier}` |
 | `llm_infer_provider(model_id)` | model_id: string | string | Infer provider from model ID (e.g. `"claude-*"` → `"anthropic"`) |
 | `llm_model_tier(model_id)` | model_id: string | string | Get capability tier: `"small"`, `"mid"`, or `"frontier"` |
-| `llm_healthcheck(provider?)` | provider: string | dict | Validate API key. Returns `{valid, message, metadata}` |
+| `llm_healthcheck(provider?, model?)` | provider: string, model: string/dict | dict | Validate provider health. For OpenAI-compatible `/models` healthchecks, an explicit `model` string or `{model: "..."}` verifies the selected model/alias is served and returns distinct `metadata.category` values such as `unreachable`, `bad_status`, `model_missing`, and `invalid_url`. Returns `{valid, message, metadata}` |
 | `llm_rate_limit(provider, options?)` | provider: string, options: dict | int/nil/bool | Set (`{rpm: N}`), query, or clear (`{rpm: 0}`) per-provider rate limit |
 | `llm_providers()` | — | list | List all configured provider names |
 | `llm_config(provider?)` | provider: string | dict | Get provider config (base_url, auth_style, etc.) |


### PR DESCRIPTION
## Summary

Closes #677.

Adds a reusable OpenAI-compatible model readiness probe for llama.cpp/vLLM-style servers that expose loaded models through `/v1/models`. The probe preserves distinct categories for `unreachable`, `bad_status`, `model_missing`, `invalid_url`, and invalid responses, and treats exact or prefix model-id matches as served to match the existing Burin llama-server behavior.

Wires the probe into:

- `llm_healthcheck(provider, model)` / `llm_healthcheck(provider, { model = ... })`
- `harn model-info` JSON for local keyless OpenAI-compatible providers
- `harn doctor` when the selected provider/model points at a models-capable OpenAI-compatible endpoint
- context-window discovery URL construction, so local `/v1/models` probing uses the provider's configured model endpoint instead of a hardcoded suffix

## Validation

- `cargo test -p harn-vm llm::api::readiness -- --nocapture`
- `cargo check -p harn-cli`
- `cargo run --quiet --bin harn -- model-info local:test-model`
- pre-commit hook: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, markdownlint
- pre-push hook: 2,398 workspace tests, markdownlint, and applicable fast release-quality checks
