### PR TITLE
[codex] Own Ollama runtime settings in Harn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ granular archaeology.
 
 ### Added
 
+- **Harn-owned Ollama runtime settings (#676).** Centralizes Ollama
+  `num_ctx` and `keep_alive` precedence, defaults, normalization, and
+  warmup request shaping in `harn-vm`. Hosts can pass raw persisted
+  preferences through `HARN_OLLAMA_NUM_CTX` and `HARN_OLLAMA_KEEP_ALIVE`
+  without duplicating env precedence or keep-alive normalization.
 - **Agents Protocol replay-as-API contract (#636).** Adds
   `POST /v1/tasks/{task_id}/replay` to the v1 OpenAPI surface with
   `exact`, `with_overrides`, and `from_checkpoint` modes, deterministic

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -31,7 +31,12 @@ pub(crate) use auth::apply_auth_headers;
 pub(crate) use completion::vm_call_completion_full;
 pub(crate) use context_window::adapt_auto_compact_to_provider;
 pub use context_window::fetch_provider_max_context;
-pub(crate) use ollama::{ollama_keep_alive_override, ollama_num_ctx_override};
+pub(crate) use ollama::apply_ollama_runtime_settings;
+pub use ollama::{
+    ollama_runtime_settings_from_env, warm_ollama_model, warm_ollama_model_with_settings,
+    OllamaRuntimeSettings, HARN_OLLAMA_KEEP_ALIVE_ENV, HARN_OLLAMA_NUM_CTX_ENV,
+    OLLAMA_DEFAULT_KEEP_ALIVE, OLLAMA_DEFAULT_NUM_CTX, OLLAMA_HOST_ENV,
+};
 pub(crate) use openai_normalize::{debug_log_message_shapes, normalize_openai_style_messages};
 pub(crate) use options::{
     DeltaSender, LlmCallOptions, LlmRequestPayload, LlmRouteAlternative, LlmRoutePolicy,
@@ -745,6 +750,39 @@ mod tests {
             let json: serde_json::Value = serde_json::from_str(&body).expect("valid request json");
             assert_eq!(json["keep_alive"].as_i64(), Some(-1));
             assert_eq!(json["options"]["num_ctx"].as_u64(), Some(131072));
+        });
+    }
+
+    #[test]
+    fn ollama_warmup_applies_shared_runtime_settings() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _allow_llm_transport = allow_stubbed_llm_transport();
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(2)
+            .build()
+            .expect("runtime");
+
+        runtime.block_on(async {
+            let captured = std::sync::Arc::new(std::sync::Mutex::new(None));
+            let (addr, server) = spawn_ollama_stub_with_body_capture(captured.clone());
+            let _num_ctx = ScopedEnvVar::set("HARN_OLLAMA_NUM_CTX", "65536");
+            let _keep_alive = ScopedEnvVar::set("HARN_OLLAMA_KEEP_ALIVE", "forever");
+
+            super::ollama::warm_ollama_model("qwen3.5:35b", Some(&format!("http://{addr}")))
+                .await
+                .expect("warmup should succeed");
+
+            server.join().expect("stub server");
+            let body = captured
+                .lock()
+                .expect("captured body")
+                .clone()
+                .expect("request body");
+            let json: serde_json::Value = serde_json::from_str(&body).expect("valid request json");
+            assert_eq!(json["model"].as_str(), Some("qwen3.5:35b"));
+            assert_eq!(json["keep_alive"].as_i64(), Some(-1));
+            assert_eq!(json["options"]["num_ctx"].as_u64(), Some(65536));
         });
     }
 

--- a/crates/harn-vm/src/llm/api/completion.rs
+++ b/crates/harn-vm/src/llm/api/completion.rs
@@ -8,7 +8,6 @@ use std::rc::Rc;
 use crate::value::{VmError, VmValue};
 
 use super::auth::apply_auth_headers;
-use super::ollama::{ollama_keep_alive_override, ollama_num_ctx_override};
 use super::options::LlmCallOptions;
 use super::response::{extract_cache_read_tokens, extract_cache_write_tokens};
 use super::result::{mock_completion_response, LlmResult};
@@ -151,9 +150,6 @@ async fn vm_call_completion_ollama(
         .unwrap_or("/api/generate");
 
     let mut options = serde_json::Map::new();
-    if let Some(num_ctx) = ollama_num_ctx_override() {
-        options.insert("num_ctx".to_string(), serde_json::json!(num_ctx));
-    }
     if let Some(temp) = opts.temperature {
         options.insert("temperature".to_string(), serde_json::json!(temp));
     }
@@ -187,16 +183,7 @@ async fn vm_call_completion_ollama(
     if let Some(system) = &opts.system {
         body["system"] = serde_json::json!(system);
     }
-    if let Some(keep_alive) = ollama_keep_alive_override() {
-        body["keep_alive"] = keep_alive;
-    }
-    if let Some(overrides) = &opts.provider_overrides {
-        if let Some(obj) = overrides.as_object() {
-            for (k, v) in obj {
-                body[k] = v.clone();
-            }
-        }
-    }
+    super::apply_ollama_runtime_settings(&mut body, opts.provider_overrides.as_ref());
 
     let req = client
         .post(format!("{base_url}{endpoint}"))

--- a/crates/harn-vm/src/llm/api/context_window.rs
+++ b/crates/harn-vm/src/llm/api/context_window.rs
@@ -114,14 +114,7 @@ async fn fetch_ollama_context_window(model: &str, base_url: &str) -> Option<usiz
     {
         return Some(n as usize);
     }
-    // OLLAMA_NUM_CTX env override for a user-configured context window.
-    if let Ok(val) = std::env::var("OLLAMA_NUM_CTX") {
-        if let Ok(n) = val.parse::<usize>() {
-            return Some(n);
-        }
-    }
-    // Let caller use its default threshold (Ollama defaults vary 2048-8192).
-    None
+    Some(super::ollama::ollama_runtime_settings_from_env().num_ctx as usize)
 }
 
 /// Fetch context window from an OpenAI-compatible `/models` endpoint.

--- a/crates/harn-vm/src/llm/api/ollama.rs
+++ b/crates/harn-vm/src/llm/api/ollama.rs
@@ -1,74 +1,340 @@
-//! Ollama-specific env-driven overrides consumed by both the dedicated
-//! Ollama provider and any Ollama-flavored completion path.
+//! Ollama-specific runtime settings consumed by chat, completion, and
+//! model warmup paths.
 
-pub(crate) fn ollama_num_ctx_override() -> Option<u64> {
-    for key in [
-        "HARN_OLLAMA_NUM_CTX",
-        "OLLAMA_CONTEXT_LENGTH",
-        "OLLAMA_NUM_CTX",
-    ] {
-        if let Ok(raw) = std::env::var(key) {
-            if let Ok(parsed) = raw.trim().parse::<u64>() {
-                if parsed > 0 {
-                    return Some(parsed);
-                }
-            }
-        }
-    }
-    None
+use serde_json::Value;
+
+pub const OLLAMA_DEFAULT_NUM_CTX: u64 = 32_768;
+pub const OLLAMA_DEFAULT_KEEP_ALIVE: &str = "30m";
+pub const HARN_OLLAMA_NUM_CTX_ENV: &str = "HARN_OLLAMA_NUM_CTX";
+pub const HARN_OLLAMA_KEEP_ALIVE_ENV: &str = "HARN_OLLAMA_KEEP_ALIVE";
+pub const OLLAMA_HOST_ENV: &str = "OLLAMA_HOST";
+
+const OLLAMA_NUM_CTX_ENV_KEYS: [&str; 3] = [
+    HARN_OLLAMA_NUM_CTX_ENV,
+    "OLLAMA_CONTEXT_LENGTH",
+    "OLLAMA_NUM_CTX",
+];
+const OLLAMA_KEEP_ALIVE_ENV_KEYS: [&str; 2] = [HARN_OLLAMA_KEEP_ALIVE_ENV, "OLLAMA_KEEP_ALIVE"];
+const OLLAMA_DEFAULT_BASE_URL: &str = "http://localhost:11434";
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct OllamaRuntimeSettings {
+    pub num_ctx: u64,
+    pub keep_alive: Value,
 }
 
-pub(crate) fn ollama_keep_alive_override() -> Option<serde_json::Value> {
-    for key in ["HARN_OLLAMA_KEEP_ALIVE", "OLLAMA_KEEP_ALIVE"] {
-        if let Ok(raw) = std::env::var(key) {
-            let trimmed = raw.trim();
-            if !trimmed.is_empty() {
-                return Some(match trimmed.to_ascii_lowercase().as_str() {
-                    "default" => serde_json::json!("30m"),
-                    "forever" | "infinite" | "-1" => serde_json::json!(-1),
-                    _ => {
-                        if let Ok(n) = trimmed.parse::<i64>() {
-                            serde_json::json!(n)
-                        } else {
-                            serde_json::json!(trimmed)
+impl OllamaRuntimeSettings {
+    pub fn from_env() -> Self {
+        Self::from_env_and_overrides(None)
+    }
+
+    pub fn from_env_and_overrides(overrides: Option<&Value>) -> Self {
+        Self {
+            num_ctx: num_ctx_from_overrides(overrides)
+                .or_else(num_ctx_from_env)
+                .unwrap_or(OLLAMA_DEFAULT_NUM_CTX),
+            keep_alive: keep_alive_from_overrides(overrides)
+                .or_else(keep_alive_from_env)
+                .unwrap_or_else(default_keep_alive_value),
+        }
+    }
+
+    pub fn warmup_body(&self, model: &str) -> Value {
+        serde_json::json!({
+            "model": model,
+            "prompt": "",
+            "stream": false,
+            "keep_alive": self.keep_alive,
+            "options": {
+                "num_ctx": self.num_ctx,
+            },
+        })
+    }
+}
+
+pub fn ollama_runtime_settings_from_env() -> OllamaRuntimeSettings {
+    OllamaRuntimeSettings::from_env()
+}
+
+pub async fn warm_ollama_model(model: &str, base_url: Option<&str>) -> Result<(), String> {
+    let settings = OllamaRuntimeSettings::from_env();
+    warm_ollama_model_with_settings(model, base_url, &settings).await
+}
+
+pub async fn warm_ollama_model_with_settings(
+    model: &str,
+    base_url: Option<&str>,
+    settings: &OllamaRuntimeSettings,
+) -> Result<(), String> {
+    let base_url = resolve_ollama_base_url(base_url);
+    let url = format!("{}/api/generate", base_url.trim_end_matches('/'));
+    let response = crate::llm::shared_utility_client()
+        .post(url)
+        .header("Content-Type", "application/json")
+        .json(&settings.warmup_body(model))
+        .send()
+        .await
+        .map_err(|error| format!("Ollama warmup failed: {error}"))?;
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        Err(format!("Ollama warmup returned HTTP {status}: {body}"))
+    }
+}
+
+pub(crate) fn apply_ollama_runtime_settings(body: &mut Value, overrides: Option<&Value>) {
+    apply_non_runtime_ollama_overrides(body, overrides);
+
+    let explicit_num_ctx = num_ctx_from_overrides(overrides);
+    if explicit_num_ctx.is_some() || body.pointer("/options/num_ctx").is_none() {
+        let num_ctx = explicit_num_ctx
+            .or_else(num_ctx_from_env)
+            .unwrap_or(OLLAMA_DEFAULT_NUM_CTX);
+        ensure_options_object(body).insert("num_ctx".to_string(), serde_json::json!(num_ctx));
+    }
+
+    let explicit_keep_alive = keep_alive_from_overrides(overrides);
+    if let Some(keep_alive) = explicit_keep_alive
+        .or_else(|| body.get("keep_alive").cloned())
+        .or_else(keep_alive_from_env)
+        .or_else(|| Some(default_keep_alive_value()))
+    {
+        body["keep_alive"] = keep_alive;
+    }
+}
+
+fn resolve_ollama_base_url(base_url: Option<&str>) -> String {
+    base_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            std::env::var(OLLAMA_HOST_ENV)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .unwrap_or_else(|| OLLAMA_DEFAULT_BASE_URL.to_string())
+}
+
+fn num_ctx_from_env() -> Option<u64> {
+    OLLAMA_NUM_CTX_ENV_KEYS
+        .iter()
+        .find_map(|key| std::env::var(key).ok().and_then(|raw| parse_num_ctx(&raw)))
+}
+
+fn keep_alive_from_env() -> Option<Value> {
+    OLLAMA_KEEP_ALIVE_ENV_KEYS.iter().find_map(|key| {
+        std::env::var(key)
+            .ok()
+            .and_then(|raw| parse_keep_alive_str(&raw))
+    })
+}
+
+fn num_ctx_from_overrides(overrides: Option<&Value>) -> Option<u64> {
+    let obj = overrides?.as_object()?;
+    obj.get("num_ctx")
+        .and_then(parse_num_ctx_value)
+        .or_else(|| {
+            obj.get("options")
+                .and_then(|options| options.get("num_ctx"))
+                .and_then(parse_num_ctx_value)
+        })
+}
+
+fn keep_alive_from_overrides(overrides: Option<&Value>) -> Option<Value> {
+    overrides?
+        .as_object()?
+        .get("keep_alive")
+        .and_then(parse_keep_alive_value)
+}
+
+fn parse_num_ctx(raw: &str) -> Option<u64> {
+    raw.trim().parse::<u64>().ok().filter(|parsed| *parsed > 0)
+}
+
+fn parse_num_ctx_value(value: &Value) -> Option<u64> {
+    match value {
+        Value::Number(number) => number.as_u64().filter(|parsed| *parsed > 0),
+        Value::String(raw) => parse_num_ctx(raw),
+        _ => None,
+    }
+}
+
+fn parse_keep_alive_value(value: &Value) -> Option<Value> {
+    match value {
+        Value::String(raw) => parse_keep_alive_str(raw),
+        Value::Number(_) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn parse_keep_alive_str(raw: &str) -> Option<Value> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(match trimmed.to_ascii_lowercase().as_str() {
+        "default" => default_keep_alive_value(),
+        "forever" | "infinite" | "-1" => serde_json::json!(-1),
+        _ => {
+            if let Ok(n) = trimmed.parse::<i64>() {
+                serde_json::json!(n)
+            } else {
+                serde_json::json!(trimmed)
+            }
+        }
+    })
+}
+
+fn default_keep_alive_value() -> Value {
+    serde_json::json!(OLLAMA_DEFAULT_KEEP_ALIVE)
+}
+
+fn ensure_options_object(body: &mut Value) -> &mut serde_json::Map<String, Value> {
+    if !body.get("options").is_some_and(Value::is_object) {
+        body["options"] = serde_json::json!({});
+    }
+    body["options"]
+        .as_object_mut()
+        .expect("options initialized as object")
+}
+
+fn apply_non_runtime_ollama_overrides(body: &mut Value, overrides: Option<&Value>) {
+    let Some(obj) = overrides.and_then(Value::as_object) else {
+        return;
+    };
+
+    for (key, value) in obj {
+        match key.as_str() {
+            "num_ctx" | "keep_alive" => {}
+            "options" => {
+                if let Some(options) = value.as_object() {
+                    let body_options = ensure_options_object(body);
+                    for (option_key, option_value) in options {
+                        if option_key != "num_ctx" {
+                            body_options.insert(option_key.clone(), option_value.clone());
                         }
                     }
-                });
+                }
+            }
+            _ => {
+                body[key] = value.clone();
             }
         }
     }
-    None
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ollama_keep_alive_override, ollama_num_ctx_override};
+    use super::*;
     use crate::llm::env_lock;
 
-    #[test]
-    fn ollama_num_ctx_override_prefers_harn_env() {
-        let _guard = env_lock().lock().expect("env lock");
-        unsafe {
-            std::env::set_var("HARN_OLLAMA_NUM_CTX", "131072");
-            std::env::remove_var("OLLAMA_CONTEXT_LENGTH");
-            std::env::remove_var("OLLAMA_NUM_CTX");
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
         }
-        assert_eq!(ollama_num_ctx_override(), Some(131072));
-        unsafe {
-            std::env::remove_var("HARN_OLLAMA_NUM_CTX");
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
         }
     }
 
     #[test]
-    fn ollama_keep_alive_override_normalizes_forever() {
+    fn runtime_settings_use_harn_env_before_ollama_env() {
         let _guard = env_lock().lock().expect("env lock");
-        unsafe {
-            std::env::set_var("HARN_OLLAMA_KEEP_ALIVE", "forever");
-            std::env::remove_var("OLLAMA_KEEP_ALIVE");
-        }
-        assert_eq!(ollama_keep_alive_override(), Some(serde_json::json!(-1)));
-        unsafe {
-            std::env::remove_var("HARN_OLLAMA_KEEP_ALIVE");
-        }
+        let _env = [
+            ScopedEnvVar::set("HARN_OLLAMA_NUM_CTX", "131072"),
+            ScopedEnvVar::set("OLLAMA_CONTEXT_LENGTH", "32768"),
+            ScopedEnvVar::set("HARN_OLLAMA_KEEP_ALIVE", "forever"),
+            ScopedEnvVar::set("OLLAMA_KEEP_ALIVE", "5m"),
+        ];
+        let settings = OllamaRuntimeSettings::from_env();
+        assert_eq!(settings.num_ctx, 131072);
+        assert_eq!(settings.keep_alive, serde_json::json!(-1));
+    }
+
+    #[test]
+    fn runtime_settings_apply_harn_defaults() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _env = [
+            ScopedEnvVar::remove("HARN_OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
+            ScopedEnvVar::remove("OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("HARN_OLLAMA_KEEP_ALIVE"),
+            ScopedEnvVar::remove("OLLAMA_KEEP_ALIVE"),
+        ];
+        let settings = OllamaRuntimeSettings::from_env();
+        assert_eq!(settings.num_ctx, OLLAMA_DEFAULT_NUM_CTX);
+        assert_eq!(settings.keep_alive, serde_json::json!("30m"));
+    }
+
+    #[test]
+    fn provider_overrides_beat_env_and_normalize_keep_alive() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _env = [
+            ScopedEnvVar::set("HARN_OLLAMA_NUM_CTX", "131072"),
+            ScopedEnvVar::set("HARN_OLLAMA_KEEP_ALIVE", "5m"),
+        ];
+        let overrides = serde_json::json!({
+            "num_ctx": "65536",
+            "keep_alive": "infinite",
+        });
+        let settings = OllamaRuntimeSettings::from_env_and_overrides(Some(&overrides));
+        assert_eq!(settings.num_ctx, 65536);
+        assert_eq!(settings.keep_alive, serde_json::json!(-1));
+    }
+
+    #[test]
+    fn apply_runtime_settings_maps_ollama_overrides_to_native_shape() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _env = [
+            ScopedEnvVar::remove("HARN_OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
+            ScopedEnvVar::remove("OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("HARN_OLLAMA_KEEP_ALIVE"),
+            ScopedEnvVar::remove("OLLAMA_KEEP_ALIVE"),
+        ];
+        let mut body = serde_json::json!({
+            "model": "qwen",
+            "options": {"temperature": 0.1}
+        });
+        let overrides = serde_json::json!({
+            "num_ctx": 65536,
+            "keep_alive": "default",
+            "options": {"top_k": 20, "num_ctx": 999},
+            "think": true,
+        });
+        apply_ollama_runtime_settings(&mut body, Some(&overrides));
+        assert_eq!(body["options"]["num_ctx"], serde_json::json!(65536));
+        assert_eq!(body["options"]["top_k"], serde_json::json!(20));
+        assert_eq!(body["options"]["temperature"], serde_json::json!(0.1));
+        assert_eq!(body["keep_alive"], serde_json::json!("30m"));
+        assert_eq!(body["think"], serde_json::json!(true));
+        assert!(body.get("num_ctx").is_none());
     }
 }

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -185,10 +185,12 @@ pub(crate) async fn vm_call_llm_api_with_body(
         wants_streaming || is_ollama
     };
 
-    if let Some(ref overrides) = opts.provider_overrides {
-        if let Some(obj) = overrides.as_object() {
-            for (k, v) in obj {
-                body[k] = v.clone();
+    if !is_ollama {
+        if let Some(ref overrides) = opts.provider_overrides {
+            if let Some(obj) = overrides.as_object() {
+                for (k, v) in obj {
+                    body[k] = v.clone();
+                }
             }
         }
     }

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -87,6 +87,11 @@ fn client_builder_for_tests(builder: reqwest::ClientBuilder) -> reqwest::ClientB
     builder
 }
 
+pub use api::{
+    ollama_runtime_settings_from_env, warm_ollama_model, warm_ollama_model_with_settings,
+    OllamaRuntimeSettings, HARN_OLLAMA_KEEP_ALIVE_ENV, HARN_OLLAMA_NUM_CTX_ENV,
+    OLLAMA_DEFAULT_KEEP_ALIVE, OLLAMA_DEFAULT_NUM_CTX, OLLAMA_HOST_ENV,
+};
 pub use mock::{
     drain_tool_recordings, load_tool_replay_fixtures, set_tool_recording_mode, ToolRecordingMode,
 };

--- a/crates/harn-vm/src/llm/providers/ollama.rs
+++ b/crates/harn-vm/src/llm/providers/ollama.rs
@@ -44,14 +44,6 @@ impl OllamaProvider {
             }
         }
 
-        if body["options"].get("num_ctx").is_none() {
-            if let Some(num_ctx) = crate::llm::api::ollama_num_ctx_override() {
-                body["options"]["num_ctx"] = serde_json::json!(num_ctx);
-            }
-        }
-        if let Some(keep_alive) = crate::llm::api::ollama_keep_alive_override() {
-            body["keep_alive"] = keep_alive;
-        }
         if body["options"].get("min_p").is_none() {
             body["options"]["min_p"] = serde_json::json!(0.05);
         }
@@ -73,6 +65,7 @@ impl OllamaProvider {
             }
             None => serde_json::json!(false),
         };
+        crate::llm::api::apply_ollama_runtime_settings(&mut body, opts.provider_overrides.as_ref());
         body
     }
 
@@ -94,6 +87,30 @@ impl OllamaProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl ScopedEnvVar {
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
 
     fn base_payload() -> LlmRequestPayload {
         LlmRequestPayload {
@@ -138,5 +155,40 @@ mod tests {
         payload.json_schema = None;
         let body = OllamaProvider::build_request_body(&payload);
         assert!(body.get("format").is_none());
+    }
+
+    #[test]
+    fn defaults_ollama_runtime_settings() {
+        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _env = [
+            ScopedEnvVar::remove("HARN_OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
+            ScopedEnvVar::remove("OLLAMA_NUM_CTX"),
+            ScopedEnvVar::remove("HARN_OLLAMA_KEEP_ALIVE"),
+            ScopedEnvVar::remove("OLLAMA_KEEP_ALIVE"),
+        ];
+        let mut payload = base_payload();
+        payload.response_format = None;
+        payload.json_schema = None;
+        let body = OllamaProvider::build_request_body(&payload);
+        assert_eq!(body["options"]["num_ctx"], serde_json::json!(32768));
+        assert_eq!(body["keep_alive"], serde_json::json!("30m"));
+    }
+
+    #[test]
+    fn maps_provider_runtime_overrides_to_ollama_body() {
+        let mut payload = base_payload();
+        payload.provider_overrides = Some(serde_json::json!({
+            "num_ctx": 65536,
+            "keep_alive": "forever",
+            "options": {"top_k": 40},
+            "think": true,
+        }));
+        let body = OllamaProvider::build_request_body(&payload);
+        assert_eq!(body["options"]["num_ctx"], serde_json::json!(65536));
+        assert_eq!(body["options"]["top_k"], serde_json::json!(40));
+        assert_eq!(body["keep_alive"], serde_json::json!(-1));
+        assert_eq!(body["think"], serde_json::json!(true));
+        assert!(body.get("num_ctx").is_none());
     }
 }

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -4375,6 +4375,8 @@ The following environment variables configure runtime behavior:
 | `HF_TOKEN` | API key for the HuggingFace provider. |
 | `HUGGINGFACE_API_KEY` | Alternate API key name for the HuggingFace provider. |
 | `OLLAMA_HOST` | Override the Ollama host. Default `http://localhost:11434`. |
+| `HARN_OLLAMA_NUM_CTX` | Preferred Ollama context window for Harn-owned Ollama chat, completion, context-window fallback, and warmup requests. Must be a positive integer. Takes precedence over `OLLAMA_CONTEXT_LENGTH` and `OLLAMA_NUM_CTX`; default `32768`. Hosts that persist IDE preferences should pass the raw stored value here and let Harn validate/default it. |
+| `HARN_OLLAMA_KEEP_ALIVE` | Preferred Ollama keep-alive for Harn-owned Ollama chat, completion, and warmup requests. Takes precedence over `OLLAMA_KEEP_ALIVE`; default `30m`. `forever`, `infinite`, and `-1` normalize to Ollama's numeric `-1`; `default` normalizes to `30m`. |
 | `LOCAL_LLM_BASE_URL` | Base URL for a local OpenAI-compatible server. Default `http://localhost:8000`. |
 | `LOCAL_LLM_MODEL` | Default model ID for the local OpenAI-compatible provider. |
 

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -1250,6 +1250,14 @@ println("Remaining: $${llm_budget_remaining()}")
 - Default host: `http://localhost:11434`
 - No authentication required
 - Same message format as OpenAI
+- Harn applies shared runtime settings to Ollama chat, completion,
+  context-window fallback, and warmup requests. `HARN_OLLAMA_NUM_CTX` wins over
+  `OLLAMA_CONTEXT_LENGTH` and `OLLAMA_NUM_CTX`, then defaults to `32768`.
+  `HARN_OLLAMA_KEEP_ALIVE` wins over `OLLAMA_KEEP_ALIVE`, then defaults to
+  `30m`; `forever`, `infinite`, and `-1` normalize to numeric `-1`, while
+  `default` normalizes to `30m`. Hosts that persist IDE preferences should pass
+  the raw stored values via `HARN_OLLAMA_*` and let Harn own validation and
+  defaults.
 
 ### Local OpenAI-compatible server
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -4373,6 +4373,8 @@ The following environment variables configure runtime behavior:
 | `HF_TOKEN` | API key for the HuggingFace provider. |
 | `HUGGINGFACE_API_KEY` | Alternate API key name for the HuggingFace provider. |
 | `OLLAMA_HOST` | Override the Ollama host. Default `http://localhost:11434`. |
+| `HARN_OLLAMA_NUM_CTX` | Preferred Ollama context window for Harn-owned Ollama chat, completion, context-window fallback, and warmup requests. Must be a positive integer. Takes precedence over `OLLAMA_CONTEXT_LENGTH` and `OLLAMA_NUM_CTX`; default `32768`. Hosts that persist IDE preferences should pass the raw stored value here and let Harn validate/default it. |
+| `HARN_OLLAMA_KEEP_ALIVE` | Preferred Ollama keep-alive for Harn-owned Ollama chat, completion, and warmup requests. Takes precedence over `OLLAMA_KEEP_ALIVE`; default `30m`. `forever`, `infinite`, and `-1` normalize to Ollama's numeric `-1`; `default` normalizes to `30m`. |
 | `LOCAL_LLM_BASE_URL` | Base URL for a local OpenAI-compatible server. Default `http://localhost:8000`. |
 | `LOCAL_LLM_MODEL` | Default model ID for the local OpenAI-compatible provider. |
 


### PR DESCRIPTION
## Summary

Closes #676.

- centralize Ollama `num_ctx` and `keep_alive` resolution in `harn-vm`, including defaults, env precedence, provider override handling, and keep-alive normalization
- apply the shared runtime settings to Ollama chat, `/api/generate` completion, context-window fallback, and a new Harn-side warmup helper
- document the minimal host contract: hosts can pass raw persisted preferences through `HARN_OLLAMA_NUM_CTX` / `HARN_OLLAMA_KEEP_ALIVE` and let Harn own validation/defaults

## Validation

- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-676 cargo test -p harn-vm ollama -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-676 cargo check --workspace`
- pre-commit hook: rustfmt, clippy `--workspace --all-targets -D warnings`, generated language spec sync, markdown lint
- pre-push hook: 2,397 nextest tests passed, markdown lint passed

## Notes

A manual full `cargo test -p harn-vm` run before the pre-push gate reported 1,210/1,219 passing and 9 unrelated local-stub egress-policy failures (`no allow rule matched` for connector/HTTP localhost stubs). The pre-push nextest suite passed afterward.