### PR TITLE
[codex] Add MLX provider readiness probe

### DIFF
--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -124,6 +124,8 @@ SCRIPTING
     ModelInfo(ModelInfoArgs),
     /// Print the provider/model catalog Harn loaded as JSON.
     ProviderCatalog(ProviderCatalogArgs),
+    /// Probe a provider's /models endpoint and optionally verify a served model.
+    ProviderReady(ProviderReadyArgs),
     /// Manage and inspect Harn skills (list, inspect, match, install, new).
     Skills(SkillsArgs),
     /// Manage skill provenance: keys, signatures, verification, and trust policy.
@@ -2027,6 +2029,21 @@ pub(crate) struct ProviderCatalogArgs {
 }
 
 #[derive(Debug, Args)]
+pub(crate) struct ProviderReadyArgs {
+    /// Provider id from Harn provider config, for example mlx or local.
+    pub provider: String,
+    /// Model alias or provider-native model id to require in /models.
+    #[arg(long)]
+    pub model: Option<String>,
+    /// Override the configured provider base URL for this probe.
+    #[arg(long = "base-url")]
+    pub base_url: Option<String>,
+    /// Emit the full structured readiness result as JSON.
+    #[arg(long, default_value_t = false, action = ArgAction::SetTrue)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
 pub(crate) struct SkillsArgs {
     #[command(subcommand)]
     pub command: SkillsCommand,
@@ -3563,5 +3580,27 @@ mod tests {
             panic!("expected provider-catalog command");
         };
         assert!(args.available_only);
+    }
+
+    #[test]
+    fn test_parses_provider_ready_args() {
+        let cli = Cli::parse_from([
+            "harn",
+            "provider-ready",
+            "mlx",
+            "--model",
+            "mlx-qwen36-27b",
+            "--base-url",
+            "http://127.0.0.1:8002",
+            "--json",
+        ]);
+
+        let Command::ProviderReady(args) = cli.command.unwrap() else {
+            panic!("expected provider-ready command");
+        };
+        assert_eq!(args.provider, "mlx");
+        assert_eq!(args.model.as_deref(), Some("mlx-qwen36-27b"));
+        assert_eq!(args.base_url.as_deref(), Some("http://127.0.0.1:8002"));
+        assert!(args.json);
     }
 }

--- a/crates/harn-cli/src/commands/portal/llm.rs
+++ b/crates/harn-cli/src/commands/portal/llm.rs
@@ -8,7 +8,9 @@ pub(super) async fn build_llm_options() -> PortalLlmOptions {
         .ok()
         .filter(|value| !value.is_empty())
         .or_else(|| {
-            if std::env::var("LOCAL_LLM_BASE_URL").is_ok() {
+            if std::env::var("MLX_BASE_URL").is_ok() || std::env::var("MLX_MODEL_ID").is_ok() {
+                Some("mlx".to_string())
+            } else if std::env::var("LOCAL_LLM_BASE_URL").is_ok() {
                 Some("local".to_string())
             } else {
                 None
@@ -18,9 +20,18 @@ pub(super) async fn build_llm_options() -> PortalLlmOptions {
         .ok()
         .filter(|value| !value.is_empty())
         .or_else(|| {
-            std::env::var("LOCAL_LLM_MODEL")
+            std::env::var("MLX_MODEL_ID")
                 .ok()
                 .filter(|value| !value.is_empty())
+        })
+        .or_else(|| {
+            if std::env::var("LOCAL_LLM_BASE_URL").is_ok() {
+                std::env::var("LOCAL_LLM_MODEL")
+                    .ok()
+                    .filter(|value| !value.is_empty())
+            } else {
+                None
+            }
         });
 
     let mut providers = Vec::new();
@@ -117,6 +128,10 @@ fn default_model_for_provider(provider: &str) -> Option<String> {
                     .filter(|value| !value.is_empty())
             })
             .or_else(|| Some("gpt-4o".to_string())),
+        "mlx" => std::env::var("MLX_MODEL_ID")
+            .ok()
+            .filter(|value| !value.is_empty())
+            .or_else(|| Some("unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string())),
         "openai" => Some("gpt-4o".to_string()),
         "ollama" => Some("llama3.2".to_string()),
         "openrouter" => Some("Qwen/Qwen3.5-9B".to_string()),

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -720,6 +720,15 @@ async fn async_main() {
         },
         Command::ModelInfo(args) => print_model_info(&args.model).await,
         Command::ProviderCatalog(args) => print_provider_catalog(args.available_only),
+        Command::ProviderReady(args) => {
+            run_provider_ready(
+                &args.provider,
+                args.model.as_deref(),
+                args.base_url.as_deref(),
+                args.json,
+            )
+            .await
+        }
         Command::Skills(args) => match args.command {
             SkillsCommand::List(list) => commands::skills::run_list(&list),
             SkillsCommand::Inspect(inspect) => commands::skills::run_inspect(&inspect),
@@ -891,6 +900,29 @@ fn print_provider_catalog(available_only: bool) {
             command_error(&format!("failed to serialize provider catalog: {error}"))
         })
     );
+}
+
+async fn run_provider_ready(
+    provider: &str,
+    model: Option<&str>,
+    base_url: Option<&str>,
+    json: bool,
+) {
+    let readiness =
+        harn_vm::llm::readiness::probe_provider_readiness(provider, model, base_url).await;
+    if json {
+        match serde_json::to_string_pretty(&readiness) {
+            Ok(payload) => println!("{payload}"),
+            Err(error) => command_error(&format!("failed to serialize readiness result: {error}")),
+        }
+    } else if readiness.ok {
+        println!("{}", readiness.message);
+    } else {
+        eprintln!("{}", readiness.message);
+    }
+    if !readiness.ok {
+        process::exit(1);
+    }
 }
 
 fn command_error(message: &str) -> ! {

--- a/crates/harn-vm/src/llm/api/context_window.rs
+++ b/crates/harn-vm/src/llm/api/context_window.rs
@@ -192,6 +192,7 @@ async fn fetch_provider_max_context_uncached(
         provider,
         "local"
             | "openai"
+            | "mlx"
             | "vllm"
             | "groq"
             | "together"

--- a/crates/harn-vm/src/llm/helpers/provider.rs
+++ b/crates/harn-vm/src/llm/helpers/provider.rs
@@ -290,6 +290,8 @@ pub(crate) fn vm_resolve_model(
         "local" => std::env::var("LOCAL_LLM_MODEL")
             .or_else(|_| std::env::var("HARN_LLM_MODEL"))
             .unwrap_or_else(|_| "gpt-4o".to_string()),
+        "mlx" => std::env::var("MLX_MODEL_ID")
+            .unwrap_or_else(|_| "unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string()),
         "openai" => "gpt-4o".to_string(),
         "ollama" => "llama3.2".to_string(),
         "openrouter" => "anthropic/claude-sonnet-4.6".to_string(),

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod helpers;
 pub(crate) mod ledger;
 pub(crate) mod mock;
 pub(crate) mod permissions;
+pub mod readiness;
 pub(crate) mod structural_experiments;
 pub(crate) mod tool_search;
 mod transcript_stats;

--- a/crates/harn-vm/src/llm/provider.rs
+++ b/crates/harn-vm/src/llm/provider.rs
@@ -121,6 +121,7 @@ pub(crate) fn register_default_providers() {
             "fireworks",
             "huggingface",
             "local",
+            "mlx",
             "vllm",
             "tgi",
             "dashscope",

--- a/crates/harn-vm/src/llm/readiness.rs
+++ b/crates/harn-vm/src/llm/readiness.rs
@@ -1,0 +1,406 @@
+use serde::Serialize;
+
+use super::api::apply_auth_headers;
+use super::helpers::resolve_api_key;
+use crate::llm_config::{self, ProviderDef};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReadinessStatus {
+    Ok,
+    UnknownProvider,
+    InvalidUrl,
+    Unreachable,
+    BadStatus,
+    BadResponse,
+    ModelMissing,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProviderReadiness {
+    pub provider: String,
+    pub ok: bool,
+    pub status: ReadinessStatus,
+    pub message: String,
+    pub base_url: Option<String>,
+    pub url: Option<String>,
+    pub model: Option<String>,
+    pub requested_model: Option<String>,
+    pub served_models: Vec<String>,
+    pub http_status: Option<u16>,
+}
+
+impl ProviderReadiness {
+    fn fail(
+        provider: &str,
+        status: ReadinessStatus,
+        message: String,
+        base_url: Option<String>,
+        url: Option<String>,
+        model: Option<String>,
+        requested_model: Option<String>,
+        http_status: Option<u16>,
+    ) -> Self {
+        Self {
+            provider: provider.to_string(),
+            ok: false,
+            status,
+            message,
+            base_url,
+            url,
+            model,
+            requested_model,
+            served_models: Vec::new(),
+            http_status,
+        }
+    }
+}
+
+pub async fn probe_provider_readiness(
+    provider: &str,
+    requested_model: Option<&str>,
+    base_url_override: Option<&str>,
+) -> ProviderReadiness {
+    let Some(def) = llm_config::provider_config(provider) else {
+        return ProviderReadiness::fail(
+            provider,
+            ReadinessStatus::UnknownProvider,
+            format!("Unknown provider: {provider}"),
+            None,
+            None,
+            requested_model.map(ToOwned::to_owned),
+            requested_model.map(ToOwned::to_owned),
+            None,
+        );
+    };
+
+    let base_url = base_url_override
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| value.trim().to_string())
+        .unwrap_or_else(|| llm_config::resolve_base_url(&def));
+    let url = match models_url(&def, &base_url) {
+        Ok(url) => url,
+        Err(message) => {
+            return ProviderReadiness::fail(
+                provider,
+                ReadinessStatus::InvalidUrl,
+                message,
+                Some(base_url),
+                None,
+                requested_model.map(ToOwned::to_owned),
+                requested_model.map(ToOwned::to_owned),
+                None,
+            );
+        }
+    };
+
+    let (raw_model, resolved_model) = requested_model
+        .filter(|model| !model.trim().is_empty())
+        .map(|model| {
+            let trimmed = model.trim();
+            let (resolved, _) = llm_config::resolve_model(trimmed);
+            (Some(trimmed.to_string()), Some(resolved))
+        })
+        .unwrap_or_else(|| match configured_model_for_provider(provider) {
+            Some(model) => {
+                let (resolved, _) = llm_config::resolve_model(&model);
+                (Some(model), Some(resolved))
+            }
+            None => (None, None),
+        });
+
+    let client = super::shared_utility_client();
+    let api_key = resolve_api_key(provider).unwrap_or_default();
+    let request = client.get(&url).header("Content-Type", "application/json");
+    let request = apply_auth_headers(request, &api_key, Some(&def));
+    let request = def
+        .extra_headers
+        .iter()
+        .fold(request, |request, (name, value)| {
+            request.header(name.as_str(), value.as_str())
+        });
+
+    let response = match request.send().await {
+        Ok(response) => response,
+        Err(error) => {
+            return ProviderReadiness::fail(
+                provider,
+                ReadinessStatus::Unreachable,
+                format!("{provider} server is not reachable at {base_url}: {error}"),
+                Some(base_url),
+                Some(url),
+                resolved_model,
+                raw_model,
+                None,
+            );
+        }
+    };
+
+    let http_status = response.status().as_u16();
+    if !response.status().is_success() {
+        return ProviderReadiness::fail(
+            provider,
+            ReadinessStatus::BadStatus,
+            format!("{provider} returned HTTP {http_status} at {url}"),
+            Some(base_url),
+            Some(url),
+            resolved_model,
+            raw_model,
+            Some(http_status),
+        );
+    }
+
+    let body = match response.text().await {
+        Ok(body) => body,
+        Err(error) => {
+            return ProviderReadiness::fail(
+                provider,
+                ReadinessStatus::BadResponse,
+                format!("{provider} returned an unreadable /models response: {error}"),
+                Some(base_url),
+                Some(url),
+                resolved_model,
+                raw_model,
+                Some(http_status),
+            );
+        }
+    };
+    let served_models = match parse_model_ids(&body) {
+        Ok(models) if !models.is_empty() => models,
+        Ok(_) => {
+            return ProviderReadiness::fail(
+                provider,
+                ReadinessStatus::BadResponse,
+                format!("{provider} /models response did not include any model ids"),
+                Some(base_url),
+                Some(url),
+                resolved_model,
+                raw_model,
+                Some(http_status),
+            );
+        }
+        Err(error) => {
+            return ProviderReadiness::fail(
+                provider,
+                ReadinessStatus::BadResponse,
+                format!("{provider} returned an unparsable /models response: {error}"),
+                Some(base_url),
+                Some(url),
+                resolved_model,
+                raw_model,
+                Some(http_status),
+            );
+        }
+    };
+
+    if let Some(model) = resolved_model.as_deref() {
+        if !model_is_served(model, &served_models) {
+            return ProviderReadiness {
+                provider: provider.to_string(),
+                ok: false,
+                status: ReadinessStatus::ModelMissing,
+                message: format!(
+                    "Model '{model}' is not served by {provider} at {base_url}. Currently served: {}",
+                    served_models.join(", ")
+                ),
+                base_url: Some(base_url),
+                url: Some(url),
+                model: resolved_model,
+                requested_model: raw_model,
+                served_models,
+                http_status: Some(http_status),
+            };
+        }
+    }
+
+    let message = match resolved_model.as_deref() {
+        Some(model) => format!("{provider} is ready at {base_url}; model '{model}' is served"),
+        None => format!(
+            "{provider} is reachable at {base_url}; served models: {}",
+            served_models.join(", ")
+        ),
+    };
+
+    ProviderReadiness {
+        provider: provider.to_string(),
+        ok: true,
+        status: ReadinessStatus::Ok,
+        message,
+        base_url: Some(base_url),
+        url: Some(url),
+        model: resolved_model,
+        requested_model: raw_model,
+        served_models,
+        http_status: Some(http_status),
+    }
+}
+
+pub fn parse_model_ids(body: &str) -> Result<Vec<String>, serde_json::Error> {
+    let payload: serde_json::Value = serde_json::from_str(body)?;
+    let mut models = Vec::new();
+    if let Some(entries) = payload.get("data").and_then(|value| value.as_array()) {
+        for entry in entries {
+            if let Some(id) = entry.get("id").and_then(|value| value.as_str()) {
+                models.push(id.to_string());
+            }
+        }
+    }
+    if let Some(entries) = payload.get("models").and_then(|value| value.as_array()) {
+        for entry in entries {
+            if let Some(id) = entry
+                .get("id")
+                .or_else(|| entry.get("name"))
+                .and_then(|value| value.as_str())
+            {
+                models.push(id.to_string());
+            }
+        }
+    }
+    models.sort();
+    models.dedup();
+    Ok(models)
+}
+
+pub fn model_is_served(model: &str, served_models: &[String]) -> bool {
+    served_models
+        .iter()
+        .any(|served| served == model || served.starts_with(model))
+}
+
+pub fn configured_model_for_provider(provider: &str) -> Option<String> {
+    if provider == "mlx" {
+        if let Ok(model) = std::env::var("MLX_MODEL_ID") {
+            if !model.trim().is_empty() {
+                return Some(model);
+            }
+        }
+    }
+    if provider == "local" {
+        if let Ok(model) = std::env::var("LOCAL_LLM_MODEL") {
+            if !model.trim().is_empty() {
+                return Some(model);
+            }
+        }
+    }
+    let harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
+    let model = std::env::var("HARN_LLM_MODEL")
+        .ok()
+        .filter(|model| !model.trim().is_empty())?;
+    let (_, resolved_provider) = llm_config::resolve_model(&model);
+    if resolved_provider.as_deref() == Some(provider)
+        || (resolved_provider.is_none() && harn_provider.as_deref() == Some(provider))
+    {
+        return Some(model);
+    }
+    None
+}
+
+fn models_url(def: &ProviderDef, base_url: &str) -> Result<String, String> {
+    let path = def
+        .healthcheck
+        .as_ref()
+        .and_then(|healthcheck| {
+            if healthcheck.method.eq_ignore_ascii_case("GET") {
+                healthcheck
+                    .path
+                    .as_deref()
+                    .filter(|path| path.ends_with("/models") || *path == "/models")
+            } else {
+                None
+            }
+        })
+        .unwrap_or("/v1/models");
+    let url = if path.starts_with('/') {
+        format!("{}{}", base_url.trim_end_matches('/'), path)
+    } else {
+        format!("{}/{}", base_url.trim_end_matches('/'), path)
+    };
+    reqwest::Url::parse(&url)
+        .map(|_| url.clone())
+        .map_err(|error| format!("Invalid provider models URL '{url}': {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    #[test]
+    fn parse_model_ids_reads_openai_compatible_data() {
+        let models =
+            parse_model_ids(r#"{"object":"list","data":[{"id":"qwen"},{"id":"mlx-model"}]}"#)
+                .expect("parse models");
+        assert_eq!(models, vec!["mlx-model".to_string(), "qwen".to_string()]);
+    }
+
+    #[test]
+    fn model_is_served_accepts_exact_or_prefix() {
+        let models = vec!["unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string()];
+        assert!(model_is_served("unsloth/Qwen3.6-27B-UD-MLX-4bit", &models));
+        assert!(model_is_served("unsloth/Qwen3.6", &models));
+        assert!(!model_is_served("Qwen/Qwen3.6-27B", &models));
+    }
+
+    #[tokio::test]
+    async fn probe_provider_readiness_verifies_served_model() {
+        let (base_url, handle) = spawn_models_stub(
+            200,
+            r#"{"data":[{"id":"unsloth/Qwen3.6-27B-UD-MLX-4bit"}]}"#,
+        );
+        let result = probe_provider_readiness("mlx", Some("mlx-qwen36-27b"), Some(&base_url)).await;
+        handle.join().expect("stub joins");
+        assert!(result.ok);
+        assert_eq!(result.status, ReadinessStatus::Ok);
+        assert_eq!(
+            result.model.as_deref(),
+            Some("unsloth/Qwen3.6-27B-UD-MLX-4bit")
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_provider_readiness_reports_missing_model() {
+        let (base_url, handle) = spawn_models_stub(200, r#"{"data":[{"id":"other-model"}]}"#);
+        let result = probe_provider_readiness("mlx", Some("mlx-qwen36-27b"), Some(&base_url)).await;
+        handle.join().expect("stub joins");
+        assert!(!result.ok);
+        assert_eq!(result.status, ReadinessStatus::ModelMissing);
+        assert!(result.message.contains("Currently served: other-model"));
+    }
+
+    fn spawn_models_stub(status: u16, body: &'static str) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind models stub");
+        let addr = listener.local_addr().expect("stub addr");
+        let handle = std::thread::spawn(move || {
+            listener
+                .set_nonblocking(true)
+                .expect("set listener nonblocking");
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        if std::time::Instant::now() >= deadline {
+                            panic!("models stub: no client within 3s");
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(20));
+                    }
+                    Err(error) => panic!("models stub: accept failed: {error}"),
+                }
+            };
+            let mut buf = vec![0u8; 4096];
+            let n = stream.read(&mut buf).expect("read request");
+            let request = String::from_utf8_lossy(&buf[..n]);
+            assert!(request.starts_with("GET /v1/models HTTP/1.1\r\n"));
+            let response = format!(
+                "HTTP/1.1 {status} OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        });
+        (format!("http://{addr}"), handle)
+    }
+}

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -1031,6 +1031,30 @@ fn default_config() -> ProvidersConfig {
         },
     );
 
+    // Apple Silicon MLX OpenAI-compatible server. Harn owns readiness
+    // probing; hosts that want script-based auto-start should launch the
+    // process first, then call Harn again to verify readiness.
+    config.providers.insert(
+        "mlx".to_string(),
+        ProviderDef {
+            base_url: "http://127.0.0.1:8002".to_string(),
+            base_url_env: Some("MLX_BASE_URL".to_string()),
+            auth_style: "none".to_string(),
+            chat_endpoint: "/v1/chat/completions".to_string(),
+            completion_endpoint: Some("/v1/completions".to_string()),
+            healthcheck: Some(HealthcheckDef {
+                method: "GET".to_string(),
+                path: Some("/v1/models".to_string()),
+                url: None,
+                body: None,
+            }),
+            cost_per_1k_in: Some(0.0),
+            cost_per_1k_out: Some(0.0),
+            latency_p50_ms: Some(900),
+            ..Default::default()
+        },
+    );
+
     // vLLM OpenAI-compatible server.
     config.providers.insert(
         "vllm".to_string(),
@@ -1277,6 +1301,14 @@ fn default_config() -> ProvidersConfig {
             tool_format: None,
         },
     );
+    config.aliases.insert(
+        "mlx-qwen36-27b".to_string(),
+        AliasDef {
+            id: "unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string(),
+            provider: "mlx".to_string(),
+            tool_format: None,
+        },
+    );
 
     config.qc_defaults.extend(BTreeMap::from([
         (
@@ -1448,6 +1480,7 @@ mod tests {
         assert!(names.contains(&"anthropic".to_string()));
         assert!(names.contains(&"together".to_string()));
         assert!(names.contains(&"local".to_string()));
+        assert!(names.contains(&"mlx".to_string()));
         assert!(names.contains(&"openai".to_string()));
         assert!(names.contains(&"ollama".to_string()));
     }
@@ -1475,6 +1508,21 @@ mod tests {
         let pdef = provider_config("anthropic").unwrap();
         assert_eq!(pdef.auth_style, "header");
         assert_eq!(pdef.auth_header.as_deref(), Some("x-api-key"));
+    }
+
+    #[test]
+    fn test_provider_config_mlx() {
+        let pdef = provider_config("mlx").unwrap();
+        assert_eq!(pdef.base_url, "http://127.0.0.1:8002");
+        assert_eq!(pdef.base_url_env.as_deref(), Some("MLX_BASE_URL"));
+        assert_eq!(
+            pdef.healthcheck.unwrap().path.as_deref(),
+            Some("/v1/models")
+        );
+
+        let (model, provider) = resolve_model("mlx-qwen36-27b");
+        assert_eq!(model, "unsloth/Qwen3.6-27B-UD-MLX-4bit");
+        assert_eq!(provider.as_deref(), Some("mlx"));
     }
 
     #[test]

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -423,6 +423,25 @@ harn doctor
 harn doctor --no-network
 ```
 
+For OpenAI-compatible local providers, `/models` checks parse the model
+listing and report missing configured models instead of only checking HTTP
+reachability.
+
+## harn provider-ready
+
+Probe a configured provider's `/models` endpoint and optionally require a
+specific model alias or provider-native model id.
+
+```bash
+harn provider-ready mlx --model mlx-qwen36-27b
+harn provider-ready mlx --base-url http://127.0.0.1:8002 --json
+```
+
+The command exits non-zero for unreachable servers, bad HTTP status,
+unparsable model listings, and missing models. It does not run local launcher
+scripts; host applications that auto-start local servers should report launch
+failures themselves and then call this probe again.
+
 ## harn connect
 
 Authorize connector providers and store local connector secrets in the

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -4379,6 +4379,8 @@ The following environment variables configure runtime behavior:
 | `HARN_OLLAMA_KEEP_ALIVE` | Preferred Ollama keep-alive for Harn-owned Ollama chat, completion, and warmup requests. Takes precedence over `OLLAMA_KEEP_ALIVE`; default `30m`. `forever`, `infinite`, and `-1` normalize to Ollama's numeric `-1`; `default` normalizes to `30m`. |
 | `LOCAL_LLM_BASE_URL` | Base URL for a local OpenAI-compatible server. Default `http://localhost:8000`. |
 | `LOCAL_LLM_MODEL` | Default model ID for the local OpenAI-compatible provider. |
+| `MLX_BASE_URL` | Base URL for the MLX OpenAI-compatible provider. Default `http://127.0.0.1:8002`. |
+| `MLX_MODEL_ID` | Default model ID for the MLX OpenAI-compatible provider readiness probe. |
 
 ## Known limitations and future work
 

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -16,6 +16,7 @@ environment variable to authenticate or point Harn at a local endpoint:
 | HuggingFace | `HF_TOKEN` or `HUGGINGFACE_API_KEY` | explicit `model` |
 | Ollama | `OLLAMA_HOST` (optional) | `llama3.2` |
 | Local server | `LOCAL_LLM_BASE_URL` | `LOCAL_LLM_MODEL` or explicit `model` |
+| MLX OpenAI-compatible server | `MLX_BASE_URL` | `MLX_MODEL_ID` or `mlx-qwen36-27b` |
 
 Ollama runs locally and doesn't require an API key. The default host is
 `http://localhost:11434`.
@@ -24,6 +25,14 @@ For a generic OpenAI-compatible local server, set `LOCAL_LLM_BASE_URL` to
 something like `http://192.168.86.250:8000` and either pass
 `{provider: "local", model: "qwen2.5-coder-32b"}` or set
 `LOCAL_LLM_MODEL=qwen2.5-coder-32b`.
+
+For an Apple Silicon MLX OpenAI-compatible server, Harn uses
+`MLX_BASE_URL` with a default of `http://127.0.0.1:8002`. Run
+`harn provider-ready mlx --model mlx-qwen36-27b` to probe `/v1/models`
+and verify that the configured model or alias is currently served. Harn
+does not launch MLX scripts itself; hosts that support auto-start should
+run their launcher, report launcher failures, then call the Harn readiness
+probe again.
 
 ## llm_call
 
@@ -1265,6 +1274,14 @@ println("Remaining: $${llm_budget_remaining()}")
 - Default host: `http://localhost:8000`
 - No authentication required
 - Same message format as OpenAI
+
+### MLX OpenAI-compatible server
+
+- Endpoint: `<MLX_BASE_URL>/v1/chat/completions`
+- Readiness probe: `<MLX_BASE_URL>/v1/models`
+- Default host: `http://127.0.0.1:8002`
+- Default alias: `mlx-qwen36-27b`
+- No authentication required
 
 ## Testing with mock LLM responses
 

--- a/docs/src/providers.md
+++ b/docs/src/providers.md
@@ -70,6 +70,19 @@ export LOCAL_LLM_BASE_URL=http://localhost:11434
 export LOCAL_LLM_MODEL=llama3
 ```
 
+For an MLX OpenAI-compatible server:
+
+```bash
+export MLX_BASE_URL=http://127.0.0.1:8002
+export MLX_MODEL_ID=unsloth/Qwen3.6-27B-UD-MLX-4bit
+harn provider-ready mlx --model mlx-qwen36-27b
+```
+
+The readiness probe checks `/v1/models` and reports distinct failures for
+an unreachable server, a bad HTTP status, an unparsable model listing, or
+a missing model. Harn does not run optional host launcher scripts; hosts
+should surface launcher failures separately and then re-run the probe.
+
 Harn will automatically fall back to a local provider if no cloud API key
 is configured. This makes it easy to develop and test without incurring
 API costs.

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -4377,6 +4377,8 @@ The following environment variables configure runtime behavior:
 | `HARN_OLLAMA_KEEP_ALIVE` | Preferred Ollama keep-alive for Harn-owned Ollama chat, completion, and warmup requests. Takes precedence over `OLLAMA_KEEP_ALIVE`; default `30m`. `forever`, `infinite`, and `-1` normalize to Ollama's numeric `-1`; `default` normalizes to `30m`. |
 | `LOCAL_LLM_BASE_URL` | Base URL for a local OpenAI-compatible server. Default `http://localhost:8000`. |
 | `LOCAL_LLM_MODEL` | Default model ID for the local OpenAI-compatible provider. |
+| `MLX_BASE_URL` | Base URL for the MLX OpenAI-compatible provider. Default `http://127.0.0.1:8002`. |
+| `MLX_MODEL_ID` | Default model ID for the MLX OpenAI-compatible provider readiness probe. |
 
 ## Known limitations and future work
 


### PR DESCRIPTION
## Summary

- Add a shared Harn provider readiness probe for OpenAI-compatible `/models` endpoints, including model alias resolution and exact/prefix model matching.
- Add built-in `mlx` provider config, the `mlx-qwen36-27b` alias, and `harn provider-ready` for host/Burin preflight calls.
- Reuse the probe from `llm_healthcheck` and `harn doctor`, and document the boundary: Harn probes readiness; hosts own optional launcher execution and launcher failure UX.

Fixes #678.

## Verification

- `cargo test -p harn-vm llm::readiness -- --nocapture`
- `cargo test -p harn-vm mlx -- --nocapture`
- `cargo test -p harn-cli cli::tests::test_parses_provider_ready_args -- --nocapture`
- `cargo run --quiet --bin harn -- provider-ready unknown --json` exits 1 with structured JSON
- `cargo clippy -p harn-vm -p harn-cli --all-targets -- -D warnings`
- Pre-commit hook: cargo fmt, workspace clippy, language spec sync, markdownlint
- Pre-push hook: 2394 nextest tests passed, markdownlint
