### PR TITLE
[codex] Add Ollama readiness and warmup preflight

### DIFF
--- a/conformance/tests/integration/llm_config.harn
+++ b/conformance/tests/integration/llm_config.harn
@@ -25,5 +25,8 @@ pipeline test(task) {
   assert_eq(anthropic_config?.auth_style, "header")
   let local_config = llm_config("local")
   assert_eq(local_config?.auth_style, "none")
+  let ollama_warm_missing = llm_healthcheck("ollama", {warm: true})
+  assert_eq(ollama_warm_missing?.valid, false)
+  assert_eq(ollama_warm_missing?.status, "invalid_request")
   log("All llm_config tests passed")
 }

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -2017,6 +2017,15 @@ pub(crate) struct PackageCacheVerifyArgs {
 
 #[derive(Debug, Args)]
 pub(crate) struct ModelInfoArgs {
+    /// Verify provider-local readiness for the resolved model when supported.
+    #[arg(long)]
+    pub verify: bool,
+    /// Warm/preload the resolved model when supported. Implies --verify.
+    #[arg(long)]
+    pub warm: bool,
+    /// Ollama keep_alive value to use with --warm (for example 30m, forever, or -1).
+    #[arg(long = "keep-alive", value_name = "VALUE")]
+    pub keep_alive: Option<String>,
     /// Model alias or provider-native model id.
     pub model: String,
 }
@@ -3564,12 +3573,23 @@ mod tests {
 
     #[test]
     fn test_parses_model_info_args() {
-        let cli = Cli::parse_from(["harn", "model-info", "tog-gemma4-31b"]);
+        let cli = Cli::parse_from([
+            "harn",
+            "model-info",
+            "--verify",
+            "--warm",
+            "--keep-alive",
+            "forever",
+            "tog-gemma4-31b",
+        ]);
 
         let Command::ModelInfo(args) = cli.command.unwrap() else {
             panic!("expected model-info command");
         };
         assert_eq!(args.model, "tog-gemma4-31b");
+        assert!(args.verify);
+        assert!(args.warm);
+        assert_eq!(args.keep_alive.as_deref(), Some("forever"));
     }
 
     #[test]

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 use std::{env, fs, process, thread};
 
 use cli::{
-    Cli, Command, PackageCacheCommand, PackageCommand, PersonaCommand, RunsCommand, ServeCommand,
-    SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand,
+    Cli, Command, ModelInfoArgs, PackageCacheCommand, PackageCommand, PersonaCommand, RunsCommand,
+    ServeCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand,
 };
 use harn_lexer::Lexer;
 use harn_parser::{DiagnosticSeverity, Parser, TypeChecker};
@@ -718,7 +718,11 @@ async fn async_main() {
                 }
             }
         },
-        Command::ModelInfo(args) => print_model_info(&args.model).await,
+        Command::ModelInfo(args) => {
+            if !print_model_info(&args).await {
+                process::exit(1);
+            }
+        }
         Command::ProviderCatalog(args) => print_provider_catalog(args.available_only),
         Command::ProviderReady(args) => {
             run_provider_ready(
@@ -772,8 +776,8 @@ fn print_version() {
     );
 }
 
-async fn print_model_info(model: &str) {
-    let resolved = harn_vm::llm_config::resolve_model_info(model);
+async fn print_model_info(args: &ModelInfoArgs) -> bool {
+    let resolved = harn_vm::llm_config::resolve_model_info(&args.model);
     let api_key_result = harn_vm::llm::resolve_api_key(&resolved.provider);
     let api_key_set = api_key_result.is_ok();
     let api_key = api_key_result.unwrap_or_default();
@@ -782,8 +786,8 @@ async fn print_model_info(model: &str) {
     let readiness = local_openai_readiness(&resolved.provider, &resolved.id, &api_key).await;
     let catalog = harn_vm::llm_config::model_catalog_entry(&resolved.id);
     let capabilities = harn_vm::llm::capabilities::lookup(&resolved.provider, &resolved.id);
-    let payload = serde_json::json!({
-        "alias": model,
+    let mut payload = serde_json::json!({
+        "alias": args.model,
         "id": resolved.id,
         "provider": resolved.provider,
         "resolved_alias": resolved.alias,
@@ -804,12 +808,47 @@ async fn print_model_info(model: &str) {
         },
         "qc_default_model": harn_vm::llm_config::qc_default_model(&resolved.provider),
     });
+
+    let should_verify = args.verify || args.warm;
+    let mut ok = true;
+    if should_verify {
+        if resolved.provider == "ollama" {
+            let mut readiness = harn_vm::llm::OllamaReadinessOptions::new(resolved.id.clone());
+            readiness.warm = args.warm;
+            readiness.keep_alive = args
+                .keep_alive
+                .as_deref()
+                .and_then(harn_vm::llm::normalize_ollama_keep_alive);
+            let result = harn_vm::llm::ollama_readiness(readiness).await;
+            ok = result.valid;
+            payload["readiness"] = serde_json::to_value(&result).unwrap_or_else(|error| {
+                serde_json::json!({
+                    "valid": false,
+                    "status": "serialization_error",
+                    "message": format!("failed to serialize readiness result: {error}"),
+                })
+            });
+        } else {
+            ok = false;
+            payload["readiness"] = serde_json::json!({
+                "valid": false,
+                "status": "unsupported_provider",
+                "message": format!(
+                    "model-info --verify is only supported for Ollama models; resolved provider is '{}'",
+                    resolved.provider
+                ),
+                "provider": resolved.provider,
+            });
+        }
+    }
+
     println!(
         "{}",
         serde_json::to_string(&payload).unwrap_or_else(|error| {
             command_error(&format!("failed to serialize model info: {error}"))
         })
     );
+    ok
 }
 
 async fn local_openai_readiness(

--- a/crates/harn-lsp/src/constants.rs
+++ b/crates/harn-lsp/src/constants.rs
@@ -495,7 +495,10 @@ pub(crate) const BUILTINS: &[(&str, &str)] = &[
     ("eval_metrics", "eval_metrics() -> list"),
     ("llm_providers", "llm_providers() -> list"),
     ("llm_config", "llm_config(provider?) -> dict"),
-    ("llm_healthcheck", "llm_healthcheck(provider?) -> dict"),
+    (
+        "llm_healthcheck",
+        "llm_healthcheck(provider?, options?) -> dict",
+    ),
     // Timers
     ("timer_start", "timer_start(name?) -> dict"),
     ("timer_end", "timer_end(timer) -> int"),
@@ -822,7 +825,7 @@ pub(crate) fn builtin_doc(name: &str) -> Option<String> {
         "llm_resolve_model" => "**llm_resolve_model(alias)** → dict — Resolve a model alias to full model info",
         "llm_providers" => "**llm_providers()** → list — List all configured LLM providers",
         "llm_config" => "**llm_config(provider?)** → dict — Get provider configuration",
-        "llm_healthcheck" => "**llm_healthcheck(provider?)** → dict — Check provider health and connectivity",
+        "llm_healthcheck" => "**llm_healthcheck(provider?, options?)** → dict — Check provider health and connectivity; Ollama accepts `{model, warm}`",
         "transcript" => "**transcript(metadata?)** → dict — Create a new transcript",
         "transcript_compact" => "**transcript_compact(transcript, options?)** → dict — Compact a transcript with the runtime compaction engine",
         "transcript_summarize" => "**transcript_summarize(transcript, options?)** → dict — Summarize and compact a transcript with an LLM",

--- a/crates/harn-parser/src/builtin_signatures/signatures/agents.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/agents.rs
@@ -161,7 +161,7 @@ pub(crate) const SIGNATURES: &[BuiltinSig] = &[
     },
     BuiltinSig {
         name: "llm_healthcheck",
-        return_type: None,
+        return_type: Some(BuiltinReturn::Named("dict")),
     },
     BuiltinSig {
         name: "llm_available_providers",

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -34,9 +34,10 @@ pub(crate) use context_window::adapt_auto_compact_to_provider;
 pub use context_window::fetch_provider_max_context;
 pub(crate) use ollama::apply_ollama_runtime_settings;
 pub use ollama::{
-    ollama_runtime_settings_from_env, warm_ollama_model, warm_ollama_model_with_settings,
-    OllamaRuntimeSettings, HARN_OLLAMA_KEEP_ALIVE_ENV, HARN_OLLAMA_NUM_CTX_ENV,
-    OLLAMA_DEFAULT_KEEP_ALIVE, OLLAMA_DEFAULT_NUM_CTX, OLLAMA_HOST_ENV,
+    normalize_ollama_keep_alive, ollama_readiness, ollama_runtime_settings_from_env,
+    warm_ollama_model, warm_ollama_model_with_settings, OllamaReadinessOptions,
+    OllamaReadinessResult, OllamaRuntimeSettings, OllamaWarmupResult, HARN_OLLAMA_KEEP_ALIVE_ENV,
+    HARN_OLLAMA_NUM_CTX_ENV, OLLAMA_DEFAULT_KEEP_ALIVE, OLLAMA_DEFAULT_NUM_CTX, OLLAMA_HOST_ENV,
 };
 pub(crate) use openai_normalize::{debug_log_message_shapes, normalize_openai_style_messages};
 pub(crate) use options::{

--- a/crates/harn-vm/src/llm/api/ollama.rs
+++ b/crates/harn-vm/src/llm/api/ollama.rs
@@ -1,7 +1,76 @@
 //! Ollama-specific runtime settings consumed by chat, completion, and
 //! model warmup paths.
 
+use std::time::Duration;
+
+use serde::Serialize;
 use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OllamaWarmupResult {
+    pub valid: bool,
+    pub status: String,
+    pub message: String,
+    pub url: String,
+    pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_status: Option<u16>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OllamaReadinessResult {
+    pub valid: bool,
+    pub status: String,
+    pub message: String,
+    pub base_url: String,
+    pub tags_url: String,
+    pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matched_model: Option<String>,
+    pub available_models: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_status: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keep_alive: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warmup: Option<OllamaWarmupResult>,
+}
+
+#[derive(Debug, Clone)]
+pub struct OllamaReadinessOptions {
+    pub model: String,
+    pub base_url: Option<String>,
+    pub warm: bool,
+    pub keep_alive: Option<serde_json::Value>,
+    pub tags_timeout: Duration,
+    pub warmup_timeout: Duration,
+}
+
+impl OllamaReadinessOptions {
+    pub fn new(model: impl Into<String>) -> Self {
+        Self {
+            model: model.into(),
+            base_url: None,
+            warm: false,
+            keep_alive: None,
+            tags_timeout: Duration::from_secs(15),
+            warmup_timeout: Duration::from_secs(135),
+        }
+    }
+}
+
+/// Public wrapper around the internal keep-alive parser, used by callers
+/// (CLI flags, host bridges) that want the same normalization Harn applies
+/// to environment overrides.
+pub fn normalize_ollama_keep_alive(raw: &str) -> Option<serde_json::Value> {
+    parse_keep_alive_str(raw)
+}
+
+/// Resolve the keep-alive override from `HARN_OLLAMA_KEEP_ALIVE` /
+/// `OLLAMA_KEEP_ALIVE`, normalized through [`normalize_ollama_keep_alive`].
+pub fn ollama_keep_alive_override() -> Option<serde_json::Value> {
+    keep_alive_from_env()
+}
 
 pub const OLLAMA_DEFAULT_NUM_CTX: u64 = 32_768;
 pub const OLLAMA_DEFAULT_KEEP_ALIVE: &str = "30m";
@@ -227,10 +296,323 @@ fn apply_non_runtime_ollama_overrides(body: &mut Value, overrides: Option<&Value
     }
 }
 
+pub async fn ollama_readiness(options: OllamaReadinessOptions) -> OllamaReadinessResult {
+    let base_url = options.base_url.unwrap_or_else(default_ollama_base_url);
+    let tags_url = match ollama_endpoint_url(&base_url, "/api/tags") {
+        Ok(url) => url,
+        Err(message) => {
+            return OllamaReadinessResult {
+                valid: false,
+                status: "invalid_url".to_string(),
+                message,
+                base_url,
+                tags_url: String::new(),
+                model: options.model,
+                matched_model: None,
+                available_models: Vec::new(),
+                http_status: None,
+                keep_alive: None,
+                warmup: None,
+            };
+        }
+    };
+
+    let client = crate::llm::shared_utility_client();
+    let response = match client
+        .get(tags_url.clone())
+        .timeout(options.tags_timeout)
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            return OllamaReadinessResult {
+                valid: false,
+                status: "daemon_down".to_string(),
+                message: format!("Ollama not reachable at {tags_url}: {error}"),
+                base_url,
+                tags_url,
+                model: options.model,
+                matched_model: None,
+                available_models: Vec::new(),
+                http_status: None,
+                keep_alive: None,
+                warmup: None,
+            };
+        }
+    };
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return OllamaReadinessResult {
+            valid: false,
+            status: "bad_status".to_string(),
+            message: format!(
+                "Ollama returned HTTP {} from /api/tags: {}",
+                status.as_u16(),
+                body
+            ),
+            base_url,
+            tags_url,
+            model: options.model,
+            matched_model: None,
+            available_models: Vec::new(),
+            http_status: Some(status.as_u16()),
+            keep_alive: None,
+            warmup: None,
+        };
+    }
+
+    let body: serde_json::Value = match response.json().await {
+        Ok(value) => value,
+        Err(error) => {
+            return OllamaReadinessResult {
+                valid: false,
+                status: "invalid_response".to_string(),
+                message: format!("Could not parse Ollama model list: {error}"),
+                base_url,
+                tags_url,
+                model: options.model,
+                matched_model: None,
+                available_models: Vec::new(),
+                http_status: Some(status.as_u16()),
+                keep_alive: None,
+                warmup: None,
+            };
+        }
+    };
+
+    let Some(models) = parse_ollama_model_names(&body) else {
+        return OllamaReadinessResult {
+            valid: false,
+            status: "invalid_response".to_string(),
+            message: "Could not parse Ollama model list: missing models[].name".to_string(),
+            base_url,
+            tags_url,
+            model: options.model,
+            matched_model: None,
+            available_models: Vec::new(),
+            http_status: Some(status.as_u16()),
+            keep_alive: None,
+            warmup: None,
+        };
+    };
+
+    let matched_model = find_ollama_model_match(&models, &options.model);
+    let Some(matched) = matched_model.clone() else {
+        let available = if models.is_empty() {
+            "(none)".to_string()
+        } else {
+            models.join(", ")
+        };
+        return OllamaReadinessResult {
+            valid: false,
+            status: "model_missing".to_string(),
+            message: format!(
+                "Ollama model '{}' not found. Available: {available}",
+                options.model
+            ),
+            base_url,
+            tags_url,
+            model: options.model,
+            matched_model: None,
+            available_models: models,
+            http_status: Some(status.as_u16()),
+            keep_alive: None,
+            warmup: None,
+        };
+    };
+
+    let keep_alive = options
+        .keep_alive
+        .or_else(ollama_keep_alive_override)
+        .or_else(|| Some(serde_json::json!("30m")));
+    let mut warmup = None;
+    let mut valid = true;
+    let mut readiness_status = "ok".to_string();
+    let mut message = format!("Ollama is reachable and model '{matched}' is available");
+
+    if options.warm {
+        let warm = ollama_warmup(
+            &base_url,
+            &matched,
+            keep_alive.clone(),
+            options.warmup_timeout,
+        )
+        .await;
+        if !warm.valid {
+            valid = false;
+            readiness_status = "warmup_failed".to_string();
+            message = warm.message.clone();
+        } else {
+            message = format!("{message}; {}", warm.message);
+        }
+        warmup = Some(warm);
+    }
+
+    OllamaReadinessResult {
+        valid,
+        status: readiness_status,
+        message,
+        base_url,
+        tags_url,
+        model: options.model,
+        matched_model: Some(matched),
+        available_models: models,
+        http_status: Some(status.as_u16()),
+        keep_alive,
+        warmup,
+    }
+}
+
+fn default_ollama_base_url() -> String {
+    crate::llm_config::provider_config("ollama")
+        .as_ref()
+        .map(crate::llm_config::resolve_base_url)
+        .unwrap_or_else(|| "http://localhost:11434".to_string())
+}
+
+fn ollama_endpoint_url(base_url: &str, path: &str) -> Result<String, String> {
+    let mut url = reqwest::Url::parse(base_url)
+        .map_err(|error| format!("Invalid Ollama URL '{base_url}': {error}"))?;
+    if url.host_str() == Some("localhost") {
+        url.set_host(Some("127.0.0.1"))
+            .map_err(|_| format!("Invalid Ollama URL '{base_url}': could not normalize host"))?;
+    }
+    let base_path = url.path().trim_end_matches('/');
+    let suffix = path.trim_start_matches('/');
+    let joined = if base_path.is_empty() {
+        format!("/{suffix}")
+    } else {
+        format!("{base_path}/{suffix}")
+    };
+    url.set_path(&joined);
+    url.set_query(None);
+    Ok(url.to_string())
+}
+
+fn parse_ollama_model_names(value: &serde_json::Value) -> Option<Vec<String>> {
+    let models = value.get("models")?.as_array()?;
+    Some(
+        models
+            .iter()
+            .filter_map(|model| model.get("name").and_then(|name| name.as_str()))
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
+fn find_ollama_model_match(models: &[String], selected: &str) -> Option<String> {
+    models
+        .iter()
+        .find(|name| name.as_str() == selected)
+        .or_else(|| {
+            models
+                .iter()
+                .find(|name| name.strip_suffix(":latest") == Some(selected))
+        })
+        .or_else(|| models.iter().find(|name| name.starts_with(selected)))
+        .cloned()
+}
+
+async fn ollama_warmup(
+    base_url: &str,
+    model: &str,
+    keep_alive: Option<serde_json::Value>,
+    timeout: Duration,
+) -> OllamaWarmupResult {
+    let url = match ollama_endpoint_url(base_url, "/api/generate") {
+        Ok(url) => url,
+        Err(message) => {
+            return OllamaWarmupResult {
+                valid: false,
+                status: "invalid_url".to_string(),
+                message,
+                url: String::new(),
+                model: model.to_string(),
+                http_status: None,
+            };
+        }
+    };
+
+    let mut body = serde_json::json!({
+        "model": model,
+        "prompt": "",
+        "stream": false,
+    });
+    if let Some(value) = keep_alive {
+        body["keep_alive"] = value;
+    }
+
+    let client = crate::llm::shared_blocking_client();
+    let response = match client
+        .post(url.clone())
+        .header("Content-Type", "application/json")
+        .timeout(timeout)
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            return OllamaWarmupResult {
+                valid: false,
+                status: "warmup_failed".to_string(),
+                message: format!("Ollama warmup failed for model '{model}' at {url}: {error}"),
+                url,
+                model: model.to_string(),
+                http_status: None,
+            };
+        }
+    };
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return OllamaWarmupResult {
+            valid: false,
+            status: "warmup_failed".to_string(),
+            message: format!(
+                "Ollama warmup returned HTTP {} for model '{model}': {body}",
+                status.as_u16()
+            ),
+            url,
+            model: model.to_string(),
+            http_status: Some(status.as_u16()),
+        };
+    }
+
+    let body: serde_json::Value = response.json().await.unwrap_or_default();
+    if let Some(error) = body.get("error").and_then(|error| error.as_str()) {
+        return OllamaWarmupResult {
+            valid: false,
+            status: "warmup_failed".to_string(),
+            message: format!("Ollama warmup failed for model '{model}': {error}"),
+            url,
+            model: model.to_string(),
+            http_status: Some(status.as_u16()),
+        };
+    }
+
+    OllamaWarmupResult {
+        valid: true,
+        status: "ok".to_string(),
+        message: format!("Ollama model '{model}' warmed"),
+        url,
+        model: model.to_string(),
+        http_status: Some(status.as_u16()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::llm::env_lock;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     struct ScopedEnvVar {
         key: &'static str,
@@ -336,5 +718,150 @@ mod tests {
         assert_eq!(body["keep_alive"], serde_json::json!("30m"));
         assert_eq!(body["think"], serde_json::json!(true));
         assert!(body.get("num_ctx").is_none());
+    }
+
+    #[test]
+    fn ollama_keep_alive_normalization_handles_default_and_numbers() {
+        assert_eq!(
+            normalize_ollama_keep_alive("default"),
+            Some(serde_json::json!("30m"))
+        );
+        assert_eq!(
+            normalize_ollama_keep_alive("forever"),
+            Some(serde_json::json!(-1))
+        );
+        assert_eq!(
+            normalize_ollama_keep_alive("120"),
+            Some(serde_json::json!(120))
+        );
+        assert_eq!(
+            normalize_ollama_keep_alive("10m"),
+            Some(serde_json::json!("10m"))
+        );
+        assert_eq!(normalize_ollama_keep_alive("   "), None);
+    }
+
+    #[test]
+    fn ollama_readiness_verifies_model_and_warms_matched_tag() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let (addr, server) = spawn_stub(
+            vec![
+                (
+                    200,
+                    r#"{"models":[{"name":"qwen3:latest"},{"name":"llama3.2:latest"}]}"#,
+                ),
+                (200, r#"{"response":"","done":true}"#),
+            ],
+            captured.clone(),
+        );
+
+        let result = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(ollama_readiness(OllamaReadinessOptions {
+                model: "qwen3".to_string(),
+                base_url: Some(format!("http://{addr}")),
+                warm: true,
+                keep_alive: Some(serde_json::json!(-1)),
+                tags_timeout: Duration::from_secs(2),
+                warmup_timeout: Duration::from_secs(2),
+            }));
+
+        server.join().expect("stub server");
+        assert!(result.valid, "result was: {result:?}");
+        assert_eq!(result.status, "ok");
+        assert_eq!(result.matched_model.as_deref(), Some("qwen3:latest"));
+        assert!(result.warmup.as_ref().is_some_and(|warm| warm.valid));
+
+        let requests = captured.lock().expect("captured requests");
+        assert!(requests[0].starts_with("GET /api/tags "));
+        assert!(requests[1].starts_with("POST /api/generate "));
+        let body = requests[1].split("\r\n\r\n").nth(1).unwrap_or("");
+        let json: serde_json::Value = serde_json::from_str(body).expect("warmup body");
+        assert_eq!(json["model"], "qwen3:latest");
+        assert_eq!(json["prompt"], "");
+        assert_eq!(json["stream"], false);
+        assert_eq!(json["keep_alive"], -1);
+    }
+
+    #[test]
+    fn ollama_readiness_reports_missing_model_with_available_tags() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let (addr, server) = spawn_stub(
+            vec![(200, r#"{"models":[{"name":"llama3.2:latest"}]}"#)],
+            captured,
+        );
+
+        let result = tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(ollama_readiness(OllamaReadinessOptions {
+                model: "qwen3".to_string(),
+                base_url: Some(format!("http://{addr}")),
+                warm: false,
+                keep_alive: None,
+                tags_timeout: Duration::from_secs(2),
+                warmup_timeout: Duration::from_secs(2),
+            }));
+
+        server.join().expect("stub server");
+        assert!(!result.valid);
+        assert_eq!(result.status, "model_missing");
+        assert_eq!(result.available_models, vec!["llama3.2:latest"]);
+        assert!(result.message.contains("qwen3"));
+    }
+
+    fn spawn_stub(
+        responses: Vec<(u16, &'static str)>,
+        captured: Arc<Mutex<Vec<String>>>,
+    ) -> (std::net::SocketAddr, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ollama stub");
+        let addr = listener.local_addr().expect("stub addr");
+        let handle = std::thread::spawn(move || {
+            for (status, body) in responses {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(2)))
+                    .expect("read timeout");
+                let request = read_http_request(&mut stream);
+                captured.lock().expect("captured").push(request);
+                let reason = if status == 200 { "OK" } else { "ERROR" };
+                let response = format!(
+                    "HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
+            }
+        });
+        (addr, handle)
+    }
+
+    fn read_http_request(stream: &mut std::net::TcpStream) -> String {
+        let mut data = Vec::new();
+        let mut buf = [0_u8; 512];
+        loop {
+            let n = stream.read(&mut buf).expect("read request");
+            if n == 0 {
+                break;
+            }
+            data.extend_from_slice(&buf[..n]);
+            let text = String::from_utf8_lossy(&data);
+            if let Some(header_end) = text.find("\r\n\r\n") {
+                let headers = &text[..header_end];
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                    .unwrap_or(0);
+                if data.len() >= header_end + 4 + content_length {
+                    break;
+                }
+            }
+        }
+        String::from_utf8(data).expect("utf8 request")
     }
 }

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -2,8 +2,11 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use crate::llm_config;
+use crate::stdlib::json_to_vm_value;
 use crate::value::VmValue;
 use crate::vm::Vm;
+
+use super::helpers::vm_value_to_json;
 
 /// Register config-based LLM builtins (llm_infer_provider, llm_resolve_model, etc.).
 pub(crate) fn register_config_builtins(vm: &mut Vm) {
@@ -225,6 +228,68 @@ pub(crate) fn register_config_builtins(vm: &mut Vm) {
 
     vm.register_async_builtin("llm_healthcheck", |args| async move {
         let (provider_name, api_key) = parse_healthcheck_args(&args);
+
+        // Ollama-specific readiness probe (issue #675): supports `model`,
+        // `warm`, `base_url`, and `keep_alive` options to verify the daemon
+        // and optionally pre-warm a tag before the first chat call.
+        if provider_name == "ollama" {
+            let options = args
+                .iter()
+                .filter_map(|value| value.as_dict())
+                .find(|dict| {
+                    dict.contains_key("model")
+                        || dict.contains_key("warm")
+                        || dict.contains_key("preload")
+                        || dict.contains_key("base_url")
+                        || dict.contains_key("url")
+                        || dict.contains_key("keep_alive")
+                });
+            let model = options
+                .and_then(|opts| opts.get("model"))
+                .map(|value| value.display())
+                .or_else(|| std::env::var("HARN_LLM_MODEL").ok())
+                .or_else(|| std::env::var("LOCAL_LLM_MODEL").ok());
+            let warm = options
+                .and_then(|opts| opts.get("warm").or_else(|| opts.get("preload")))
+                .is_some_and(|value| matches!(value, VmValue::Bool(true)));
+
+            if warm && model.as_deref().unwrap_or("").is_empty() {
+                return Ok(json_to_vm_value(&serde_json::json!({
+                    "valid": false,
+                    "status": "invalid_request",
+                    "message": "Ollama warmup requires options.model",
+                })));
+            }
+
+            if let Some(model) = model.filter(|model| !model.trim().is_empty()) {
+                let (resolved_model, _) = llm_config::resolve_model(&model);
+                let mut readiness = super::api::OllamaReadinessOptions::new(resolved_model);
+                readiness.warm = warm;
+                readiness.base_url = options
+                    .and_then(|opts| opts.get("base_url").or_else(|| opts.get("url")))
+                    .map(|value| value.display())
+                    .filter(|value| !value.trim().is_empty());
+                readiness.keep_alive =
+                    options
+                        .and_then(|opts| opts.get("keep_alive"))
+                        .map(|value| match value {
+                            VmValue::String(raw) => super::api::normalize_ollama_keep_alive(raw)
+                                .unwrap_or_else(|| vm_value_to_json(value)),
+                            _ => vm_value_to_json(value),
+                        });
+                let result = super::api::ollama_readiness(readiness).await;
+                return Ok(json_to_vm_value(
+                    &serde_json::to_value(&result).unwrap_or_else(|_| {
+                        serde_json::json!({
+                            "valid": false,
+                            "status": "serialization_error",
+                            "message": "failed to serialize Ollama readiness result",
+                        })
+                    }),
+                ));
+            }
+        }
+
         let requested_model = healthcheck_model_arg(&args)
             .or_else(|| super::selected_model_for_provider(&provider_name));
 

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -151,6 +151,11 @@ use self::stream::vm_stream_llm;
 use self::trace::emit_agent_event;
 use self::trace::trace_llm_call;
 
+pub use self::api::{
+    normalize_ollama_keep_alive, ollama_readiness, OllamaReadinessOptions, OllamaReadinessResult,
+    OllamaWarmupResult,
+};
+
 pub fn install_current_host_bridge(bridge: Rc<crate::bridge::HostBridge>) {
     agent::install_current_host_bridge(bridge);
 }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -442,6 +442,22 @@ unparsable model listings, and missing models. It does not run local launcher
 scripts; host applications that auto-start local servers should report launch
 failures themselves and then call this probe again.
 
+## harn model-info
+
+Print resolved model metadata as JSON. For Ollama models, `--verify` probes
+`/api/tags` and checks the selected tag. `--warm` implies `--verify` and sends
+an empty `/api/generate` request to preload the matched tag.
+
+```bash
+harn model-info llama3.2:latest
+harn model-info --verify llama3.2
+harn model-info --warm --keep-alive 30m llama3.2
+```
+
+Ollama readiness failures use stable `readiness.status` values, including
+`daemon_down`, `bad_status`, `invalid_response`, `model_missing`, and
+`warmup_failed`. `--verify` and `--warm` exit non-zero when readiness fails.
+
 ## harn connect
 
 Authorize connector providers and store local connector secrets in the

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -1255,7 +1255,7 @@ println("Remaining: $${llm_budget_remaining()}")
 
 ### Ollama
 
-- Endpoint: `<OLLAMA_HOST>/v1/chat/completions`
+- Endpoint: `<OLLAMA_HOST>/api/chat`
 - Default host: `http://localhost:11434`
 - No authentication required
 - Same message format as OpenAI


### PR DESCRIPTION
## Summary
- Add shared Ollama readiness helpers for `/api/tags` reachability, selected tag matching, and optional `/api/generate` warmup with `keep_alive` normalization.
- Expose the checks through `llm_healthcheck("ollama", {model, warm})` and `harn model-info --verify/--warm` JSON, with stable statuses for `daemon_down`, `bad_status`, `invalid_response`, `model_missing`, and `warmup_failed`.
- Document the CLI/builtin surface and add Rust plus conformance coverage.

Closes #675.

## Validation
- `cargo test -p harn-vm ollama_ --lib`
- `cargo test -p harn-cli test_parses_model_info_args`
- `cargo check -p harn-parser`
- `cargo check -p harn-lsp`
- `harn run -e 'let r = llm_healthcheck("ollama", {model: "llama3.2:latest"}); println(r.status)'` with `OLLAMA_HOST=http://127.0.0.1:9`
- `harn test conformance --filter llm_config`
- `harn fmt --check conformance/tests/integration/llm_config.harn`
- `git diff --check`
- pre-commit hook: `cargo fmt`, Harn fmt/lint, workspace clippy, markdownlint
- pre-push hook: workspace nextest `2391 passed`, Harn fmt/lint, markdownlint