### PR TITLE
Add duration_ms + execution_duration_ms to ACP tool_call_update events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## v0.7.41
+
+### Added
+
+- **Tool-call timing on ACP `tool_call_update` (#689).** Terminal
+  `tool_call_update` events now carry `durationMs` (the parse-to-finish
+  total — model emits the call → tool result is appended) and
+  `executionDurationMs` (only the inner host/builtin/MCP dispatch
+  window). Both fields are absent on intermediate `pending` /
+  `in_progress` updates so older clients see no shape change. ACP
+  clients (Burin CLI/TUI/IDE) can render duration without measuring
+  wall-clock time themselves.
+- **Per-loop `AgentEvent` sink wired through `AgentLoopConfig`.**
+  `AgentLoopConfig.event_sink` was previously a dead field; the loop
+  now installs the sink as a thread-local for the duration of the run
+  via a new `LoopSinkGuard`. Per-loop sinks fan out alongside the
+  global session-keyed registry, immune to concurrent
+  `reset_all_sinks` / `reset_thread_local_state` calls. Lets host
+  embedders observe a single loop's events without contending on the
+  shared registry.
+
 ## v0.7.40
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "async-trait",
  "axum",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "harn-vm",
  "serde",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "anyhow",
  "base64",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1651,11 +1651,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.40"
+version = "0.7.41"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "async-trait",
  "axum",
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "harn-vm"
-version = "0.7.40"
+version = "0.7.41"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.40"
+version = "0.7.41"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -106,6 +106,8 @@ impl AgentEventSink for AcpAgentEventSink {
                 status,
                 raw_output,
                 error,
+                duration_ms,
+                execution_duration_ms,
             } => {
                 let mut update = serde_json::json!({
                     "sessionUpdate": "tool_call_update",
@@ -118,6 +120,12 @@ impl AgentEventSink for AcpAgentEventSink {
                 }
                 if let Some(err) = error {
                     update["error"] = serde_json::Value::String(err.clone());
+                }
+                if let Some(d) = duration_ms {
+                    update["durationMs"] = serde_json::Value::from(*d);
+                }
+                if let Some(d) = execution_duration_ms {
+                    update["executionDurationMs"] = serde_json::Value::from(*d);
                 }
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
@@ -363,6 +371,8 @@ mod tests {
                 status: ToolCallStatus::Completed,
                 raw_output: Some(serde_json::json!({"ok": true})),
                 error: None,
+                duration_ms: Some(7),
+                execution_duration_ms: Some(5),
             },
             AgentEvent::Plan {
                 session_id: "session-1".to_string(),

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -112,6 +112,20 @@ pub enum AgentEvent {
         status: ToolCallStatus,
         raw_output: Option<serde_json::Value>,
         error: Option<String>,
+        /// Wall-clock milliseconds from the parse-to-execution boundary
+        /// to the terminal `Completed`/`Failed` update. Includes the
+        /// time spent in any wrapping orchestration logic (loop checks,
+        /// post-tool hooks, microcompaction). Populated only on the
+        /// terminal update — `None` on intermediate `Pending` /
+        /// `InProgress` updates so clients can ignore the field until
+        /// it shows up.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        duration_ms: Option<u64>,
+        /// Milliseconds spent in the actual host/builtin/MCP dispatch
+        /// call only (the inner `dispatch_tool_execution` window).
+        /// Populated only on the terminal update; `None` otherwise.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        execution_duration_ms: Option<u64>,
     },
     Plan {
         session_id: String,
@@ -666,6 +680,78 @@ mod tests {
         }
         assert_eq!(last_idx, 4);
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn tool_call_update_durations_serialize_when_present_and_skip_when_absent() {
+        // Terminal update with both durations populated — both fields
+        // appear in the JSON. Snake_case keys here because this is the
+        // canonical AgentEvent shape; the ACP adapter renames to
+        // camelCase separately.
+        let terminal = AgentEvent::ToolCallUpdate {
+            session_id: "s".into(),
+            tool_call_id: "tc-1".into(),
+            tool_name: "read".into(),
+            status: ToolCallStatus::Completed,
+            raw_output: None,
+            error: None,
+            duration_ms: Some(42),
+            execution_duration_ms: Some(7),
+        };
+        let value = serde_json::to_value(&terminal).unwrap();
+        assert_eq!(value["duration_ms"], serde_json::json!(42));
+        assert_eq!(value["execution_duration_ms"], serde_json::json!(7));
+
+        // In-progress update with `None` for both — both keys must be
+        // absent (not `null`) so older ACP clients that key off
+        // presence don't see a misleading zero.
+        let intermediate = AgentEvent::ToolCallUpdate {
+            session_id: "s".into(),
+            tool_call_id: "tc-1".into(),
+            tool_name: "read".into(),
+            status: ToolCallStatus::InProgress,
+            raw_output: None,
+            error: None,
+            duration_ms: None,
+            execution_duration_ms: None,
+        };
+        let value = serde_json::to_value(&intermediate).unwrap();
+        let object = value.as_object().expect("update serializes as object");
+        assert!(
+            !object.contains_key("duration_ms"),
+            "duration_ms must be omitted when None: {value}"
+        );
+        assert!(
+            !object.contains_key("execution_duration_ms"),
+            "execution_duration_ms must be omitted when None: {value}"
+        );
+    }
+
+    #[test]
+    fn tool_call_update_deserializes_without_duration_fields_for_back_compat() {
+        // Persisted event-log entries written before the fields existed
+        // must still deserialize cleanly. The missing keys map to None.
+        let raw = serde_json::json!({
+            "type": "tool_call_update",
+            "session_id": "s",
+            "tool_call_id": "tc-1",
+            "tool_name": "read",
+            "status": "completed",
+            "raw_output": null,
+            "error": null,
+        });
+        let event: AgentEvent = serde_json::from_value(raw).expect("parses without duration keys");
+        match event {
+            AgentEvent::ToolCallUpdate {
+                duration_ms,
+                execution_duration_ms,
+                ..
+            } => {
+                assert!(duration_ms.is_none());
+                assert!(execution_duration_ms.is_none());
+            }
+            other => panic!("expected ToolCallUpdate, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/agent/mod.rs
+++ b/crates/harn-vm/src/llm/agent/mod.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
+use std::sync::Arc;
 
-use crate::agent_events::{self, AgentEvent};
+use crate::agent_events::{self, AgentEvent, AgentEventSink};
 use crate::value::{VmError, VmValue};
 
 use super::agent_config::AgentLoopConfig;
@@ -29,6 +30,49 @@ thread_local! {
     /// entry as a runtime-feedback message.
     static PENDING_FEEDBACK: std::cell::RefCell<Vec<(String, String, String)>> =
         const { std::cell::RefCell::new(Vec::new()) };
+    /// Stack of per-loop event sinks installed via
+    /// `AgentLoopConfig.event_sink`. The agent loop pushes on entry and
+    /// pops on drop (via `LoopSinkGuard`); `emit_agent_event` fans the
+    /// event out to the top-of-stack sink in addition to the global
+    /// `agent_events` registry. Distinct from the global registry on
+    /// purpose: tests that wipe the global registry (`reset_all_sinks`,
+    /// `reset_thread_local_state`) cannot race with a per-loop
+    /// observation, and the host gets a non-cancellable observation
+    /// path that's guaranteed to fire even when no external session
+    /// subscriber is registered. Stack-shaped so nested loops (workflow
+    /// stages, sub-agents) don't bleed events upward into the parent's
+    /// sink.
+    static CURRENT_LOOP_SINKS: std::cell::RefCell<Vec<Arc<dyn AgentEventSink>>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// RAII guard that pushes a per-loop event sink onto the
+/// `CURRENT_LOOP_SINKS` stack and pops it on drop. Constructed from
+/// `AgentLoopConfig.event_sink`; if the config holds `None` the guard
+/// is a no-op.
+pub(crate) struct LoopSinkGuard {
+    pushed: bool,
+}
+
+impl LoopSinkGuard {
+    pub(crate) fn install(sink: Option<Arc<dyn AgentEventSink>>) -> Self {
+        if let Some(sink) = sink {
+            CURRENT_LOOP_SINKS.with(|stack| stack.borrow_mut().push(sink));
+            Self { pushed: true }
+        } else {
+            Self { pushed: false }
+        }
+    }
+}
+
+impl Drop for LoopSinkGuard {
+    fn drop(&mut self) {
+        if self.pushed {
+            CURRENT_LOOP_SINKS.with(|stack| {
+                let _ = stack.borrow_mut().pop();
+            });
+        }
+    }
 }
 
 /// Emit an event through both external sinks (sync) and closure
@@ -46,6 +90,15 @@ thread_local! {
 /// from their emit site.
 pub(crate) async fn emit_agent_event(event: &AgentEvent) {
     agent_events::emit_event(event);
+
+    // Per-loop sink (installed by `LoopSinkGuard` from
+    // `AgentLoopConfig.event_sink`) gets the event after the global
+    // registry. Snapshot the top-of-stack outside the borrow so the
+    // sink can re-enter `emit_agent_event` without panicking.
+    let loop_sink = CURRENT_LOOP_SINKS.with(|stack| stack.borrow().last().cloned());
+    if let Some(sink) = loop_sink {
+        sink.handle_event(event);
+    }
 
     let subscribers = crate::agent_sessions::subscribers_for(event.session_id());
     if subscribers.is_empty() {

--- a/crates/harn-vm/src/llm/agent/state.rs
+++ b/crates/harn-vm/src/llm/agent/state.rs
@@ -565,6 +565,7 @@ pub(super) struct AgentLoopState {
     pub(super) _approval_guard: ApprovalPolicyGuard,
     pub(super) _policy_guard: ExecutionPolicyGuard,
     pub(super) _sink_guard: SessionSinkGuard,
+    pub(super) _loop_sink_guard: super::LoopSinkGuard,
     pub(super) _current_session_guard: CurrentSessionGuard,
     pub(super) _iteration_guard: TranscriptIterationGuard,
 }
@@ -923,6 +924,7 @@ impl AgentLoopState {
         let _sink_guard = SessionSinkGuard {
             session_id: session_id.clone(),
         };
+        let _loop_sink_guard = super::LoopSinkGuard::install(config.event_sink.clone());
         if !session_id.is_empty() {
             crate::agent_sessions::push_current_session(session_id.clone());
         }
@@ -1308,6 +1310,7 @@ impl AgentLoopState {
             _approval_guard,
             _policy_guard,
             _sink_guard,
+            _loop_sink_guard,
             _current_session_guard,
             _iteration_guard,
         })

--- a/crates/harn-vm/src/llm/agent/tests/mod.rs
+++ b/crates/harn-vm/src/llm/agent/tests/mod.rs
@@ -36,6 +36,7 @@ mod prompts;
 mod result_build;
 mod retry_after;
 mod tool_classification;
+mod tool_durations;
 mod tool_format;
 mod transcript;
 

--- a/crates/harn-vm/src/llm/agent/tests/tool_durations.rs
+++ b/crates/harn-vm/src/llm/agent/tests/tool_durations.rs
@@ -1,0 +1,192 @@
+//! Tests for the timing fields added to `AgentEvent::ToolCallUpdate`
+//! (#689). Two invariants under verification:
+//!
+//! 1. The terminal `Completed`/`Failed` update carries both
+//!    `duration_ms` (parse-to-finish total) and `execution_duration_ms`
+//!    (inner host/builtin/MCP dispatch only).
+//! 2. Intermediate `Pending`/`InProgress` updates leave both as `None`
+//!    so ACP clients can render "still running" without inventing a
+//!    bogus zero duration.
+//!
+//! The test drives the real `run_agent_loop_internal` with a mock LLM
+//! that emits one `read_file` text-tool call against a temp file. That
+//! exercises the local-tool dispatch path end-to-end without touching
+//! the network or the host bridge.
+//!
+//! Events are captured via the per-loop `AgentLoopConfig.event_sink`
+//! (a thread-local installed by the loop entry) rather than the global
+//! `agent_events` registry, so concurrent tests that call
+//! `reset_all_sinks` / `reset_thread_local_state` cannot race the
+//! observation away mid-loop.
+
+use super::*;
+use crate::agent_events::{AgentEvent, AgentEventSink, ToolCallStatus};
+use std::sync::Mutex as StdMutex;
+
+struct CapturingSink {
+    events: Arc<StdMutex<Vec<AgentEvent>>>,
+}
+
+impl AgentEventSink for CapturingSink {
+    fn handle_event(&self, event: &AgentEvent) {
+        self.events
+            .lock()
+            .expect("event capture mutex poisoned")
+            .push(event.clone());
+    }
+}
+
+fn read_file_tool_decl() -> VmValue {
+    let mut path_param = std::collections::BTreeMap::new();
+    path_param.insert("type".to_string(), VmValue::String(Rc::from("string")));
+    let mut params = std::collections::BTreeMap::new();
+    params.insert("path".to_string(), VmValue::Dict(Rc::new(path_param)));
+    let mut tool = std::collections::BTreeMap::new();
+    tool.insert("name".to_string(), VmValue::String(Rc::from("read_file")));
+    tool.insert(
+        "description".to_string(),
+        VmValue::String(Rc::from("Read a file.")),
+    );
+    tool.insert("parameters".to_string(), VmValue::Dict(Rc::new(params)));
+    let mut envelope = std::collections::BTreeMap::new();
+    envelope.insert(
+        "tools".to_string(),
+        VmValue::List(Rc::new(vec![VmValue::Dict(Rc::new(tool))])),
+    );
+    VmValue::Dict(Rc::new(envelope))
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tool_call_update_durations_populated_on_terminal_absent_on_in_progress() {
+    reset_llm_mock_state();
+
+    // Stage a temp file the local `read_file` handler can read.
+    let dir =
+        std::env::temp_dir().join(format!("harn-tool-duration-test-{}", uuid::Uuid::now_v7()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let file_path = dir.join("hello.txt");
+    std::fs::write(&file_path, "hello world\n").expect("write temp file");
+    let file_path_str = file_path.to_string_lossy().into_owned();
+
+    // Mock LLM emits a single text-format `read_file` tool call. The
+    // agent loop dispatches it locally and then exhausts its budget.
+    let response_text = format!(
+        "<tool_call>\nread_file({{ path: \"{}\" }})\n</tool_call>",
+        file_path_str.replace('\\', "\\\\").replace('"', "\\\"")
+    );
+    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
+        text: response_text,
+        tool_calls: Vec::new(),
+        match_pattern: None,
+        consume_on_match: true,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: None,
+        stop_reason: None,
+        model: "mock".to_string(),
+        provider: None,
+        blocks: None,
+        error: None,
+    });
+
+    let captured: Arc<StdMutex<Vec<AgentEvent>>> = Arc::new(StdMutex::new(Vec::new()));
+    let sink = Arc::new(CapturingSink {
+        events: captured.clone(),
+    });
+
+    let mut opts = base_opts(vec![serde_json::json!({
+        "role": "user",
+        "content": "read the staged file",
+    })]);
+    opts.tools = Some(read_file_tool_decl());
+
+    let mut config = base_agent_config();
+    config.session_id = format!("tool-duration-test-{}", uuid::Uuid::now_v7());
+    config.persistent = true;
+    config.max_iterations = 1;
+    config.event_sink = Some(sink);
+
+    let _ = run_agent_loop_internal(&mut opts, config)
+        .await
+        .expect("agent loop runs");
+
+    let events = captured.lock().expect("captured events mutex poisoned");
+    let updates: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::ToolCallUpdate {
+                tool_name,
+                status,
+                duration_ms,
+                execution_duration_ms,
+                ..
+            } if tool_name == "read_file" => Some((*status, *duration_ms, *execution_duration_ms)),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !updates.is_empty(),
+        "expected at least one read_file ToolCallUpdate, got events: {:#?}",
+        events
+    );
+
+    let in_progress_count = updates
+        .iter()
+        .filter(|(s, _, _)| matches!(s, ToolCallStatus::InProgress))
+        .count();
+    let completed_updates: Vec<_> = updates
+        .iter()
+        .filter(|(s, _, _)| matches!(s, ToolCallStatus::Completed))
+        .collect();
+    assert!(
+        in_progress_count >= 1,
+        "expected an InProgress update before Completed; got: {updates:?}"
+    );
+    assert_eq!(
+        completed_updates.len(),
+        1,
+        "expected exactly one Completed terminal update; got: {updates:?}"
+    );
+
+    for (status, duration_ms, exec_ms) in &updates {
+        match status {
+            ToolCallStatus::Pending | ToolCallStatus::InProgress => {
+                assert!(
+                    duration_ms.is_none(),
+                    "intermediate {status:?} update must not carry duration_ms; got {duration_ms:?}"
+                );
+                assert!(
+                    exec_ms.is_none(),
+                    "intermediate {status:?} update must not carry execution_duration_ms; got {exec_ms:?}"
+                );
+            }
+            ToolCallStatus::Completed | ToolCallStatus::Failed => {
+                assert!(
+                    duration_ms.is_some(),
+                    "terminal {status:?} update must carry duration_ms"
+                );
+                assert!(
+                    exec_ms.is_some(),
+                    "terminal {status:?} update must carry execution_duration_ms"
+                );
+                let total = duration_ms.unwrap();
+                let exec = exec_ms.unwrap();
+                // duration_ms is the parse-to-finish window and so must
+                // be at least as long as the inner dispatch window. The
+                // measurements come from two different `Instant::now()`
+                // calls a few statements apart; allow 1ms slop for the
+                // edge case where both round to the same millisecond.
+                assert!(
+                    total + 1 >= exec,
+                    "duration_ms ({total}) should be >= execution_duration_ms ({exec})"
+                );
+            }
+        }
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+    reset_llm_mock_state();
+}

--- a/crates/harn-vm/src/llm/agent/tool_dispatch.rs
+++ b/crates/harn-vm/src/llm/agent/tool_dispatch.rs
@@ -894,6 +894,8 @@ pub(super) async fn run_tool_dispatch(
             status: ToolCallStatus::InProgress,
             raw_output: None,
             error: None,
+            duration_ms: None,
+            execution_duration_ms: None,
         })
         .await;
         let tool_span_id =
@@ -964,6 +966,8 @@ pub(super) async fn run_tool_dispatch(
                     error: Some(format!(
                         "tool loop detected (skipped after {count} repeats)"
                     )),
+                    duration_ms: Some(tool_started_at.elapsed().as_millis() as u64),
+                    execution_duration_ms: None,
                 })
                 .await;
                 continue;
@@ -1073,6 +1077,8 @@ pub(super) async fn run_tool_dispatch(
         let result_text =
             crate::orchestration::run_post_tool_hooks(tool_name, &tool_args, &result_text).await?;
 
+        let execution_duration_ms = tool_start.elapsed().as_millis() as u64;
+        let duration_ms = tool_started_at.elapsed().as_millis() as u64;
         super::emit_agent_event(&AgentEvent::ToolCallUpdate {
             session_id: ctx.session_id.to_string(),
             tool_call_id: tool_call_id.clone(),
@@ -1091,6 +1097,8 @@ pub(super) async fn run_tool_dispatch(
             } else {
                 None
             },
+            duration_ms: Some(duration_ms),
+            execution_duration_ms: Some(execution_duration_ms),
         })
         .await;
 


### PR DESCRIPTION
Closes #689.

## Summary
- Add `duration_ms` (parse-to-finish total) and `execution_duration_ms` (inner host/builtin/MCP dispatch only) to `AgentEvent::ToolCallUpdate`. Both `Option<u64>`, populated only on the terminal `Completed`/`Failed` update — `None` on intermediate `Pending`/`InProgress` updates so older clients see no shape change.
- Serialize as `durationMs` / `executionDurationMs` (camelCase) on the ACP wire format. Loop-skip `Failed` updates carry `duration_ms` but leave `execution_duration_ms` as `None` (the inner dispatch never ran).
- Wire the previously dead `AgentLoopConfig.event_sink` field as a per-loop thread-local sink (`LoopSinkGuard`). Per-loop sinks fan out alongside the global session-keyed registry, immune to concurrent `reset_all_sinks` / `reset_thread_local_state` calls — the new integration test uses this path so it survives parallel `cargo test`.
- Bump version to v0.7.41 and document in CHANGELOG.

## Test plan
- [x] `cargo test -p harn-vm --lib agent_events::` — new serde unit tests pass (terminal serializes both fields, intermediate omits via `skip_serializing_if`, back-compat deserialization for events written before the fields existed).
- [x] `cargo test -p harn-vm --lib tool_durations` — new integration test that drives `run_agent_loop_internal` with a mock LLM emitting a `read_file` tool call, captures events through the per-loop sink, and asserts: an `InProgress` update carries no durations; the terminal `Completed` update carries both, with `duration_ms >= execution_duration_ms`.
- [x] `cargo test -p harn-vm --lib` — full suite passes (1229/1238). The 9 remaining failures are pre-existing connector + http TLS/proxy network flakes (same set fails on `main`, same set passes in isolation).
- [x] `cargo test -p harn-serve --lib` — 34/34 pass. Updated `forwarded_agent_events_serialize_as_session_updates` fixture to include the new field shape.
- [x] `cargo nextest run -p harn-vm -p harn-serve` — 1296/1296 pass under the process-isolated runner.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo run --bin harn -- test conformance` — 694/694 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)