### PR TITLE
[codex] Tag tool_call_update with executor (closes #691)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ granular archaeology.
   see a consistent two-event lifecycle for rejected calls instead of
   silence. The category is mirrored on the `tool_execution` transcript
   event metadata so replay engines see the same classification.
+- **`tool_call_update.executor` tag (#691).** Distinguishes where a
+  tool ran — `harn_builtin`, `host_bridge`, `{kind: "mcp_server",
+  serverName: "..."}`, or `provider_native`. Lets ACP clients render
+  "via X" badges, attribute latency by transport, and route errors
+  correctly. Detection is automatic: the `_mcp_server` annotation that
+  `mcp_list_tools` injects survives through bridge-proxied dispatch,
+  so MCP-served tools tag correctly even when they physically call
+  the host bridge. Provider-native server tools (OpenAI Responses
+  `tool_search` etc.) emit a paired `tool_call`/`tool_call_update`
+  alongside the existing `tool_search_*` events so badge-rendering
+  clients don't have to special-case the search variants.
 - **Harn-owned Ollama runtime settings (#676).** Centralizes Ollama
   `num_ctx` and `keep_alive` precedence, defaults, normalization, and
   warmup request shaping in `harn-vm`. Hosts can pass raw persisted

--- a/crates/harn-modules/src/stdlib/stdlib_acp.harn
+++ b/crates/harn-modules/src/stdlib/stdlib_acp.harn
@@ -14,7 +14,7 @@ type AgentMessageChunk = {sessionUpdate: string, content: {type: string, text: s
 
 type ToolCall = {sessionUpdate: string, toolCallId: string, title: string | nil, kind: string | nil, status: string | nil, content: list<dict> | nil, locations: list<dict> | nil, rawInput: dict | nil, rawOutput: dict | nil}
 
-type ToolCallUpdate = {sessionUpdate: string, toolCallId: string, status: string | nil, title: string | nil, content: list<dict> | nil, locations: list<dict> | nil, rawOutput: dict | nil}
+type ToolCallUpdate = {sessionUpdate: string, toolCallId: string, status: string | nil, title: string | nil, content: list<dict> | nil, locations: list<dict> | nil, rawOutput: dict | nil, executor: string | dict | nil}
 
 type Plan = {sessionUpdate: string, entries: list<{content: string, priority: string | nil, status: string | nil}>}
 
@@ -51,6 +51,7 @@ pub fn tool_call_update(tool_call_id, status) {
     content: nil,
     locations: nil,
     rawOutput: nil,
+    executor: nil,
   }
 }
 

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -1,7 +1,7 @@
 //! ACP AgentEventSink — translates canonical `AgentEvent` variants into ACP
 //! `session/update` notifications. Registered per-session at prompt start.
 
-use harn_vm::agent_events::{AgentEvent, AgentEventSink};
+use harn_vm::agent_events::{AgentEvent, AgentEventSink, ToolExecutor};
 use harn_vm::visible_text::sanitize_visible_assistant_text;
 
 use super::AcpOutput;
@@ -36,6 +36,24 @@ impl AcpAgentEventSink {
             InProgress => "in_progress",
             Completed => "completed",
             Failed => "failed",
+        }
+    }
+
+    /// Render a `ToolExecutor` for the wire as either a bare string
+    /// (unit variants) or `{"kind": "mcp_server", "serverName": "..."}`
+    /// for the MCP variant. Matches harn#691's contract: clients can
+    /// `typeof executor === "string"` first, then drill into `kind`.
+    fn executor_to_json(executor: &ToolExecutor) -> serde_json::Value {
+        match executor {
+            ToolExecutor::HarnBuiltin => serde_json::Value::String("harn_builtin".to_string()),
+            ToolExecutor::HostBridge => serde_json::Value::String("host_bridge".to_string()),
+            ToolExecutor::McpServer { server_name } => serde_json::json!({
+                "kind": "mcp_server",
+                "serverName": server_name,
+            }),
+            ToolExecutor::ProviderNative => {
+                serde_json::Value::String("provider_native".to_string())
+            }
         }
     }
 }
@@ -109,6 +127,7 @@ impl AgentEventSink for AcpAgentEventSink {
                 duration_ms,
                 execution_duration_ms,
                 error_category,
+                executor,
             } => {
                 let mut update = serde_json::json!({
                     "sessionUpdate": "tool_call_update",
@@ -130,6 +149,9 @@ impl AgentEventSink for AcpAgentEventSink {
                 }
                 if let Some(cat) = error_category {
                     update["errorCategory"] = serde_json::Value::String(cat.as_str().to_string());
+                }
+                if let Some(exec) = executor {
+                    update["executor"] = Self::executor_to_json(exec);
                 }
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
@@ -294,6 +316,7 @@ impl AgentEventSink for AcpAgentEventSink {
 mod tests {
     use harn_vm::agent_events::{
         AgentEvent, AgentEventSink, FsWatchEvent, ToolCallErrorCategory, ToolCallStatus,
+        ToolExecutor,
     };
     use harn_vm::orchestration::{HandoffArtifact, HandoffTargetRecord};
     use harn_vm::tool_annotations::ToolKind;
@@ -380,6 +403,7 @@ mod tests {
                 duration_ms: Some(7),
                 execution_duration_ms: Some(5),
                 error_category: None,
+                executor: Some(ToolExecutor::HarnBuiltin),
             },
             AgentEvent::Plan {
                 session_id: "session-1".to_string(),
@@ -485,6 +509,7 @@ mod tests {
             duration_ms: None,
             execution_duration_ms: None,
             error_category: Some(ToolCallErrorCategory::SchemaValidation),
+            executor: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -517,11 +542,80 @@ mod tests {
             duration_ms: None,
             execution_duration_ms: None,
             error_category: None,
+            executor: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
         assert!(payload["params"]["update"].get("errorCategory").is_none());
         assert!(payload["params"]["update"].get("error").is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tool_call_update_serializes_executor_per_acp_wire_format() {
+        // Harn#691: clients render badges off the ACP `executor` field.
+        // The wire shape must distinguish bare-string variants from the
+        // McpServer object-with-serverName form so a UI can branch on
+        // `typeof executor === "string"`.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+
+        let cases = [
+            (ToolExecutor::HarnBuiltin, serde_json::json!("harn_builtin")),
+            (ToolExecutor::HostBridge, serde_json::json!("host_bridge")),
+            (
+                ToolExecutor::McpServer {
+                    server_name: "linear".into(),
+                },
+                serde_json::json!({"kind": "mcp_server", "serverName": "linear"}),
+            ),
+            (
+                ToolExecutor::ProviderNative,
+                serde_json::json!("provider_native"),
+            ),
+        ];
+
+        for (executor, expected) in cases {
+            sink.handle_event(&AgentEvent::ToolCallUpdate {
+                session_id: "session-1".to_string(),
+                tool_call_id: "tool-1".to_string(),
+                tool_name: "demo".to_string(),
+                status: ToolCallStatus::Completed,
+                raw_output: None,
+                error: None,
+                duration_ms: None,
+                execution_duration_ms: None,
+                error_category: None,
+                executor: Some(executor),
+            });
+            let line = rx.recv().await.expect("acp tool_call_update notification");
+            let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+            assert_eq!(
+                payload["params"]["update"]["sessionUpdate"],
+                "tool_call_update"
+            );
+            assert_eq!(payload["params"]["update"]["executor"], expected);
+        }
+
+        // `executor: None` must not surface on the wire so existing
+        // clients that don't know about the field aren't surprised.
+        sink.handle_event(&AgentEvent::ToolCallUpdate {
+            session_id: "session-1".to_string(),
+            tool_call_id: "tool-2".to_string(),
+            tool_name: "demo".to_string(),
+            status: ToolCallStatus::InProgress,
+            raw_output: None,
+            error: None,
+            duration_ms: None,
+            execution_duration_ms: None,
+            error_category: None,
+            executor: None,
+        });
+        let line = rx.recv().await.expect("acp tool_call_update notification");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        assert!(
+            payload["params"]["update"].get("executor").is_none(),
+            "got: {payload}"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -162,6 +162,36 @@ impl ToolCallErrorCategory {
     }
 }
 
+/// Where a tool actually ran. Tags `ToolCallUpdate` so clients can render
+/// "via mcp:linear" / "via host bridge" badges, attribute latency by
+/// transport, and route errors to the right surface (harn#691).
+///
+/// On the wire this serializes adjacently-tagged so the `mcp_server`
+/// case carries the configured server name. The ACP adapter rewrites
+/// unit variants as bare strings (`"harn_builtin"`, `"host_bridge"`,
+/// `"provider_native"`) and the `McpServer` case as
+/// `{"kind": "mcp_server", "serverName": "..."}` to match the protocol's
+/// camelCase convention.
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ToolExecutor {
+    /// VM-stdlib (`read_file`, `write_file`, `exec`, `http_*`, `mcp_*`)
+    /// or any Harn-side handler closure registered in `tools_val`.
+    HarnBuiltin,
+    /// Capability provided by the host through `HostBridge.builtin_call`
+    /// (Swift-side IDE bridge, BurinApp, BurinCLI host shells).
+    HostBridge,
+    /// Tool dispatched against a configured MCP server. Detected by the
+    /// `_mcp_server` tag that `mcp_list_tools` injects on every tool
+    /// dict before the agent loop sees it.
+    McpServer { server_name: String },
+    /// Provider-side server-side tool execution — currently OpenAI
+    /// Responses-API server tools (e.g. native `tool_search`). The
+    /// runtime never dispatches these locally; the model returns the
+    /// already-executed result inline.
+    ProviderNative,
+}
+
 /// Events emitted by the agent loop. The first five variants map 1:1
 /// to ACP `sessionUpdate` variants; the last three are harn-internal.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -211,6 +241,12 @@ pub enum AgentEvent {
         /// `errorCategory` in the ACP wire format.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         error_category: Option<ToolCallErrorCategory>,
+        /// Where the tool actually ran. `None` only for events emitted
+        /// from sites that pre-date the dispatch decision (e.g. the
+        /// pending → in-progress transition the loop emits before the
+        /// dispatcher picks a backend).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        executor: Option<ToolExecutor>,
     },
     Plan {
         session_id: String,
@@ -783,6 +819,7 @@ mod tests {
             duration_ms: Some(42),
             execution_duration_ms: Some(7),
             error_category: None,
+            executor: None,
         };
         let value = serde_json::to_value(&terminal).unwrap();
         assert_eq!(value["duration_ms"], serde_json::json!(42));
@@ -801,6 +838,7 @@ mod tests {
             duration_ms: None,
             execution_duration_ms: None,
             error_category: None,
+            executor: None,
         };
         let value = serde_json::to_value(&intermediate).unwrap();
         let object = value.as_object().expect("update serializes as object");
@@ -887,6 +925,36 @@ mod tests {
     }
 
     #[test]
+    fn tool_executor_round_trips_with_adjacent_tag() {
+        // Adjacent tagging keeps the wire shape uniform — every variant
+        // is a JSON object with a `kind` discriminator. The ACP adapter
+        // rewrites unit variants as bare strings; the on-disk event log
+        // keeps the object shape so deserialize can recover the variant.
+        for executor in [
+            ToolExecutor::HarnBuiltin,
+            ToolExecutor::HostBridge,
+            ToolExecutor::McpServer {
+                server_name: "linear".to_string(),
+            },
+            ToolExecutor::ProviderNative,
+        ] {
+            let json = serde_json::to_value(&executor).unwrap();
+            let kind = json.get("kind").and_then(|v| v.as_str()).unwrap();
+            match &executor {
+                ToolExecutor::HarnBuiltin => assert_eq!(kind, "harn_builtin"),
+                ToolExecutor::HostBridge => assert_eq!(kind, "host_bridge"),
+                ToolExecutor::McpServer { server_name } => {
+                    assert_eq!(kind, "mcp_server");
+                    assert_eq!(json["server_name"], *server_name);
+                }
+                ToolExecutor::ProviderNative => assert_eq!(kind, "provider_native"),
+            }
+            let recovered: ToolExecutor = serde_json::from_value(json).unwrap();
+            assert_eq!(recovered, executor);
+        }
+    }
+
+    #[test]
     fn tool_call_error_category_from_internal_collapses_transient_family() {
         use crate::value::ErrorCategory as Internal;
         assert_eq!(
@@ -948,6 +1016,7 @@ mod tests {
             duration_ms: None,
             execution_duration_ms: None,
             error_category: None,
+            executor: None,
         };
         let v = serde_json::to_value(&event).unwrap();
         assert_eq!(v["type"], "tool_call_update");
@@ -966,9 +1035,52 @@ mod tests {
             duration_ms: None,
             execution_duration_ms: None,
             error_category: Some(ToolCallErrorCategory::SchemaValidation),
+            executor: None,
         };
         let v = serde_json::to_value(&event).unwrap();
         assert_eq!(v["error_category"], "schema_validation");
         assert_eq!(v["error"], "missing required field");
+    }
+
+    #[test]
+    fn tool_call_update_omits_executor_when_absent() {
+        // `executor: None` must not appear in the serialized event so
+        // the on-disk shape stays backward-compatible with replays
+        // recorded before harn#691.
+        let event = AgentEvent::ToolCallUpdate {
+            session_id: "s".into(),
+            tool_call_id: "tc-1".into(),
+            tool_name: "read".into(),
+            status: ToolCallStatus::Completed,
+            raw_output: None,
+            error: None,
+            duration_ms: None,
+            execution_duration_ms: None,
+            error_category: None,
+            executor: None,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert!(json.get("executor").is_none(), "got: {json}");
+    }
+
+    #[test]
+    fn tool_call_update_includes_executor_when_present() {
+        let event = AgentEvent::ToolCallUpdate {
+            session_id: "s".into(),
+            tool_call_id: "tc-1".into(),
+            tool_name: "read".into(),
+            status: ToolCallStatus::Completed,
+            raw_output: None,
+            error: None,
+            duration_ms: None,
+            execution_duration_ms: None,
+            error_category: None,
+            executor: Some(ToolExecutor::McpServer {
+                server_name: "github".into(),
+            }),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["executor"]["kind"], "mcp_server");
+        assert_eq!(json["executor"]["server_name"], "github");
     }
 }

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -31,8 +31,9 @@
 
 use std::rc::Rc;
 
-use crate::agent_events::AgentEvent;
+use crate::agent_events::{AgentEvent, ToolCallStatus, ToolExecutor};
 use crate::bridge::HostBridge;
+use crate::tool_annotations::ToolKind;
 use crate::value::VmError;
 
 use crate::orchestration::TurnPolicy;
@@ -150,91 +151,13 @@ pub(super) async fn run_llm_call(
         } else {
             "openai"
         };
-    for block in &result.blocks {
-        match block.get("type").and_then(|v| v.as_str()) {
-            Some("tool_search_query") => {
-                let tool_use_id = block
-                    .get("id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let name = block
-                    .get("name")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let query = block
-                    .get("query")
-                    .cloned()
-                    .unwrap_or(serde_json::Value::Null);
-                state.transcript_events.push(transcript_event(
-                    "tool_search_query",
-                    "assistant",
-                    "internal",
-                    "",
-                    Some(serde_json::json!({
-                        "id": tool_use_id,
-                        "name": name,
-                        "query": query,
-                        "mode": native_search_mode,
-                    })),
-                ));
-                super::emit_agent_event(&AgentEvent::ToolSearchQuery {
-                    session_id: state.session_id.clone(),
-                    tool_use_id,
-                    name,
-                    query,
-                    // Native paths don't expose a strategy knob — the
-                    // provider chooses. Use an empty string so replays
-                    // can still match against `ev.metadata?.strategy`
-                    // without a nil guard.
-                    strategy: String::new(),
-                    mode: native_search_mode.to_string(),
-                })
-                .await;
-            }
-            Some("tool_search_result") => {
-                let tool_use_id = block
-                    .get("tool_use_id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let promoted: Vec<String> = block
-                    .get("tool_references")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|r| {
-                                r.get("tool_name")
-                                    .and_then(|n| n.as_str())
-                                    .map(String::from)
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                state.transcript_events.push(transcript_event(
-                    "tool_search_result",
-                    "tool",
-                    "internal",
-                    "",
-                    Some(serde_json::json!({
-                        "tool_use_id": tool_use_id,
-                        "tool_references": block.get("tool_references").cloned().unwrap_or(serde_json::Value::Array(Vec::new())),
-                        "promoted": promoted,
-                        "mode": native_search_mode,
-                    })),
-                ));
-                super::emit_agent_event(&AgentEvent::ToolSearchResult {
-                    session_id: state.session_id.clone(),
-                    tool_use_id,
-                    promoted,
-                    strategy: String::new(),
-                    mode: native_search_mode.to_string(),
-                })
-                .await;
-            }
-            _ => {}
-        }
+    let native_emissions =
+        provider_native_search_emissions(&result.blocks, &state.session_id, native_search_mode);
+    for transcript in native_emissions.transcript_events {
+        state.transcript_events.push(transcript);
+    }
+    for event in native_emissions.agent_events {
+        super::emit_agent_event(&event).await;
     }
 
     let mut tool_parse_errors: Vec<String> = Vec::new();
@@ -585,4 +508,218 @@ pub(super) async fn run_llm_call(
         input_tokens: result.input_tokens,
         output_tokens: result.output_tokens,
     })
+}
+
+/// Per-block translation of provider-native `tool_search_*` content into
+/// transcript + agent events. Pure: no global state, no I/O — the
+/// caller dispatches the produced events. Pulled out so harn#691 can
+/// unit-test the `ProviderNative` executor tagging without standing up
+/// an entire agent loop.
+pub(super) struct ProviderNativeSearchEmissions {
+    pub agent_events: Vec<AgentEvent>,
+    pub transcript_events: Vec<crate::value::VmValue>,
+}
+
+pub(super) fn provider_native_search_emissions(
+    blocks: &[serde_json::Value],
+    session_id: &str,
+    native_search_mode: &str,
+) -> ProviderNativeSearchEmissions {
+    let mut agent_events: Vec<AgentEvent> = Vec::new();
+    let mut transcript_events: Vec<crate::value::VmValue> = Vec::new();
+    for block in blocks {
+        match block.get("type").and_then(|v| v.as_str()) {
+            Some("tool_search_query") => {
+                let tool_use_id = block
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let name = block
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let query = block
+                    .get("query")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                transcript_events.push(transcript_event(
+                    "tool_search_query",
+                    "assistant",
+                    "internal",
+                    "",
+                    Some(serde_json::json!({
+                        "id": tool_use_id,
+                        "name": name,
+                        "query": query,
+                        "mode": native_search_mode,
+                    })),
+                ));
+                agent_events.push(AgentEvent::ToolSearchQuery {
+                    session_id: session_id.to_string(),
+                    tool_use_id: tool_use_id.clone(),
+                    name: name.clone(),
+                    query: query.clone(),
+                    // Native paths don't expose a strategy knob — the
+                    // provider chooses. Use an empty string so replays
+                    // can still match against `ev.metadata?.strategy`
+                    // without a nil guard.
+                    strategy: String::new(),
+                    mode: native_search_mode.to_string(),
+                });
+                // Mirror the search-specific emission as a generic
+                // tool-call pair tagged `ProviderNative` (harn#691).
+                // Clients keying off `ToolCall`/`ToolCallUpdate` to
+                // render badges can attribute the run to the provider
+                // without having to special-case `tool_search` blocks.
+                agent_events.push(AgentEvent::ToolCall {
+                    session_id: session_id.to_string(),
+                    tool_call_id: format!("provider-{tool_use_id}"),
+                    tool_name: name,
+                    kind: Some(ToolKind::Search),
+                    status: ToolCallStatus::InProgress,
+                    raw_input: query,
+                });
+            }
+            Some("tool_search_result") => {
+                let tool_use_id = block
+                    .get("tool_use_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let promoted: Vec<String> = block
+                    .get("tool_references")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|r| {
+                                r.get("tool_name")
+                                    .and_then(|n| n.as_str())
+                                    .map(String::from)
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let tool_references = block
+                    .get("tool_references")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Array(Vec::new()));
+                transcript_events.push(transcript_event(
+                    "tool_search_result",
+                    "tool",
+                    "internal",
+                    "",
+                    Some(serde_json::json!({
+                        "tool_use_id": tool_use_id,
+                        "tool_references": tool_references.clone(),
+                        "promoted": promoted,
+                        "mode": native_search_mode,
+                    })),
+                ));
+                agent_events.push(AgentEvent::ToolSearchResult {
+                    session_id: session_id.to_string(),
+                    tool_use_id: tool_use_id.clone(),
+                    promoted: promoted.clone(),
+                    strategy: String::new(),
+                    mode: native_search_mode.to_string(),
+                });
+                // Pair the ToolCall emitted on the corresponding query
+                // block. The `provider-` prefix matches above so a UI
+                // can correlate the two events.
+                agent_events.push(AgentEvent::ToolCallUpdate {
+                    session_id: session_id.to_string(),
+                    tool_call_id: format!("provider-{tool_use_id}"),
+                    tool_name: "tool_search".to_string(),
+                    status: ToolCallStatus::Completed,
+                    raw_output: Some(serde_json::json!({
+                        "tool_references": tool_references,
+                        "promoted": promoted,
+                        "mode": native_search_mode,
+                    })),
+                    error: None,
+                    duration_ms: None,
+                    execution_duration_ms: None,
+                    error_category: None,
+                    executor: Some(ToolExecutor::ProviderNative),
+                });
+            }
+            _ => {}
+        }
+    }
+    ProviderNativeSearchEmissions {
+        agent_events,
+        transcript_events,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Harn#691: assert the `ProviderNative` executor variant is
+    //! emitted when the response carries provider-native server-tool
+    //! result blocks (currently `tool_search_result`).
+
+    use super::*;
+
+    #[test]
+    fn tool_search_result_block_emits_provider_native_tool_call_update() {
+        let blocks = vec![
+            serde_json::json!({
+                "type": "tool_search_query",
+                "id": "tsq-1",
+                "name": "tool_search",
+                "query": {"q": "github"},
+            }),
+            serde_json::json!({
+                "type": "tool_search_result",
+                "tool_use_id": "tsq-1",
+                "tool_references": [{"tool_name": "create_issue"}],
+            }),
+        ];
+        let emissions = provider_native_search_emissions(&blocks, "session-1", "anthropic");
+        let updates: Vec<&AgentEvent> = emissions
+            .agent_events
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::ToolCallUpdate { .. }))
+            .collect();
+        assert_eq!(updates.len(), 1, "expected exactly one ToolCallUpdate");
+        match updates[0] {
+            AgentEvent::ToolCallUpdate {
+                executor,
+                tool_call_id,
+                status,
+                ..
+            } => {
+                assert_eq!(*status, ToolCallStatus::Completed);
+                assert_eq!(tool_call_id, "provider-tsq-1");
+                assert_eq!(*executor, Some(ToolExecutor::ProviderNative));
+            }
+            _ => unreachable!(),
+        }
+        // The corresponding query block should have produced an
+        // in-progress ToolCall paired by the same `provider-` prefix.
+        let calls: Vec<&AgentEvent> = emissions
+            .agent_events
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::ToolCall { .. }))
+            .collect();
+        assert_eq!(calls.len(), 1);
+        match calls[0] {
+            AgentEvent::ToolCall { tool_call_id, .. } => {
+                assert_eq!(tool_call_id, "provider-tsq-1");
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn unrelated_blocks_do_not_emit_provider_native_events() {
+        let blocks = vec![
+            serde_json::json!({"type": "output_text", "text": "hi"}),
+            serde_json::json!({"type": "reasoning", "text": "thinking"}),
+        ];
+        let emissions = provider_native_search_emissions(&blocks, "session-1", "openai");
+        assert!(emissions.agent_events.is_empty());
+        assert!(emissions.transcript_events.is_empty());
+    }
 }

--- a/crates/harn-vm/src/llm/agent/tool_dispatch.rs
+++ b/crates/harn-vm/src/llm/agent/tool_dispatch.rs
@@ -33,14 +33,14 @@
 
 use std::rc::Rc;
 
-use crate::agent_events::{AgentEvent, ToolCallErrorCategory, ToolCallStatus};
+use crate::agent_events::{AgentEvent, ToolCallErrorCategory, ToolCallStatus, ToolExecutor};
 use crate::bridge::HostBridge;
 use crate::value::{ErrorCategory, VmError, VmValue};
 
 use super::super::agent_tools::{
     classify_tool_mutation, declared_paths, denied_tool_result, dispatch_tool_execution,
     is_denied_tool_result, loop_intervention_message, render_tool_result, stable_hash,
-    stable_hash_str, LoopIntervention,
+    stable_hash_str, LoopIntervention, ToolDispatchOutcome,
 };
 use super::super::helpers::transcript_event;
 use super::super::tools::{
@@ -338,8 +338,10 @@ pub(super) async fn run_tool_dispatch(
     } else {
         Vec::new()
     };
-    let mut parallel_results: std::collections::HashMap<usize, Result<serde_json::Value, VmError>> =
-        std::collections::HashMap::new();
+    let mut parallel_results: std::collections::HashMap<
+        usize,
+        (Result<serde_json::Value, VmError>, Option<ToolExecutor>),
+    > = std::collections::HashMap::new();
     if !parallel_indices.is_empty() {
         // Use raw pre-hook tool_args; re-running a read-only tool when
         // a hook modifies/denies is at worst wasted work.
@@ -364,9 +366,10 @@ pub(super) async fn run_tool_dispatch(
                 .await
             }
         });
-        let joined: Vec<Result<serde_json::Value, VmError>> = join_all(futures).await;
+        let joined: Vec<ToolDispatchOutcome> = join_all(futures).await;
         for (i, idx) in parallel_indices.iter().enumerate() {
-            parallel_results.insert(*idx, joined[i].clone());
+            let outcome = &joined[i];
+            parallel_results.insert(*idx, (outcome.result.clone(), outcome.executor.clone()));
         }
     }
 
@@ -556,6 +559,7 @@ pub(super) async fn run_tool_dispatch(
                 duration_ms: None,
                 execution_duration_ms: None,
                 error_category: Some(ToolCallErrorCategory::SchemaValidation),
+                executor: None,
             })
             .await;
             if ctx.tool_format == "native" {
@@ -623,6 +627,7 @@ pub(super) async fn run_tool_dispatch(
                 duration_ms: None,
                 execution_duration_ms: None,
                 error_category: Some(ToolCallErrorCategory::PermissionDenied),
+                executor: None,
             })
             .await;
             if ctx.tool_format == "native" {
@@ -721,6 +726,7 @@ pub(super) async fn run_tool_dispatch(
                         duration_ms: None,
                         execution_duration_ms: None,
                         error_category: Some(ToolCallErrorCategory::PermissionDenied),
+                        executor: None,
                     })
                     .await;
                     if ctx.tool_format == "native" {
@@ -847,6 +853,7 @@ pub(super) async fn run_tool_dispatch(
                 duration_ms: None,
                 execution_duration_ms: None,
                 error_category: Some(ToolCallErrorCategory::PermissionDenied),
+                executor: None,
             })
             .await;
             if ctx.tool_format == "native" {
@@ -907,6 +914,7 @@ pub(super) async fn run_tool_dispatch(
                     duration_ms: None,
                     execution_duration_ms: None,
                     error_category: Some(ToolCallErrorCategory::PermissionDenied),
+                    executor: None,
                 })
                 .await;
                 if ctx.tool_format == "native" {
@@ -953,6 +961,7 @@ pub(super) async fn run_tool_dispatch(
                 duration_ms: None,
                 execution_duration_ms: None,
                 error_category: Some(ToolCallErrorCategory::SchemaValidation),
+                executor: None,
             })
             .await;
             if ctx.tool_format == "native" {
@@ -994,6 +1003,9 @@ pub(super) async fn run_tool_dispatch(
             duration_ms: None,
             execution_duration_ms: None,
             error_category: None,
+            // The dispatcher picks the backend below; the in-progress
+            // emission is unconditional and runs before that choice.
+            executor: None,
         })
         .await;
         let tool_span_id =
@@ -1069,6 +1081,9 @@ pub(super) async fn run_tool_dispatch(
                     duration_ms: Some(tool_started_at.elapsed().as_millis() as u64),
                     execution_duration_ms: None,
                     error_category: Some(ToolCallErrorCategory::RejectedLoop),
+                    // Loop intervention preempts the backend choice —
+                    // the tool never ran.
+                    executor: None,
                 })
                 .await;
                 continue;
@@ -1084,18 +1099,23 @@ pub(super) async fn run_tool_dispatch(
         };
 
         let tool_start = std::time::Instant::now();
+        let mut tool_executor: Option<ToolExecutor> = None;
         let (is_rejected, result_text, dispatch_error_category) =
             if let Some(fixture) = replay_hit {
                 let category = fixture
                     .is_rejected
                     .then_some(ToolCallErrorCategory::PermissionDenied);
+                // Replay fixtures pre-date the dispatch decision; the
+                // recording captured the result, not where it ran.
                 (fixture.is_rejected, fixture.result.clone(), category)
             } else {
                 // Reuse the parallel pre-fetch result when present.
-                let exec_result = if let Some(cached) = parallel_results.remove(&tc_index) {
-                    cached
+                let (exec_result, executor) = if let Some((cached_result, cached_executor)) =
+                    parallel_results.remove(&tc_index)
+                {
+                    (cached_result, cached_executor)
                 } else {
-                    dispatch_tool_execution(
+                    let outcome = dispatch_tool_execution(
                         tool_name,
                         &tool_args,
                         ctx.tools_val,
@@ -1103,8 +1123,10 @@ pub(super) async fn run_tool_dispatch(
                         ctx.tool_retries,
                         ctx.tool_backoff_ms,
                     )
-                    .await
+                    .await;
+                    (outcome.result, outcome.executor)
                 };
+                tool_executor = executor;
 
                 let rejected = matches!(
                     &exec_result,
@@ -1237,6 +1259,7 @@ pub(super) async fn run_tool_dispatch(
             duration_ms: Some(duration_ms),
             execution_duration_ms: Some(execution_duration_ms),
             error_category: final_error_category,
+            executor: tool_executor.clone(),
         })
         .await;
 

--- a/crates/harn-vm/src/llm/agent_tools.rs
+++ b/crates/harn-vm/src/llm/agent_tools.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use crate::agent_events::ToolExecutor;
 use crate::value::{ErrorCategory, VmClosure, VmError, VmValue};
 
 /// Hash a serde_json::Value deterministically for dedup purposes.
@@ -245,7 +246,21 @@ pub(super) fn normalize_tool_choice_for_format(
     None
 }
 
-/// Dispatch a single tool invocation to its execution backend.
+/// Outcome of a single tool dispatch — pairs the result with the
+/// backend that actually ran it (harn#691). The agent loop reads the
+/// `executor` value when emitting `AgentEvent::ToolCallUpdate` so
+/// clients can render "via mcp:linear" / "via host bridge" badges.
+pub(super) struct ToolDispatchOutcome {
+    pub result: Result<serde_json::Value, VmError>,
+    pub executor: Option<ToolExecutor>,
+}
+
+/// Dispatch a single tool invocation to its execution backend, recording
+/// which backend actually answered. The returned `executor` is `None`
+/// only when no backend could handle the call (no script handler, no
+/// bridge, not handled locally) — i.e. the categorized "tool not
+/// available" error. Retries don't change the executor: a tool that
+/// resolves via the bridge stays a `HostBridge` call across attempts.
 pub(super) async fn dispatch_tool_execution(
     tool_name: &str,
     tool_args: &serde_json::Value,
@@ -253,21 +268,38 @@ pub(super) async fn dispatch_tool_execution(
     bridge: Option<&Rc<crate::bridge::HostBridge>>,
     tool_retries: usize,
     tool_backoff_ms: u64,
-) -> Result<serde_json::Value, VmError> {
+) -> ToolDispatchOutcome {
     use super::tools::handle_tool_locally;
 
     let mut attempt = 0usize;
+    let mut executor: Option<ToolExecutor> = None;
     loop {
         let result = if let Some(local_result) = handle_tool_locally(tool_name, tool_args) {
+            // VM-stdlib short-circuit (read_file / list_directory). Any
+            // other tool falls through to the script-handler / bridge
+            // path below.
+            executor = Some(ToolExecutor::HarnBuiltin);
             Ok(serde_json::Value::String(local_result))
         } else if let Some(handler) = find_tool_handler(tools_val, tool_name) {
+            // A Harn-side handler closure exists — but if the tool was
+            // sourced from `mcp_list_tools`, the dict carries the
+            // originating server name as `_mcp_server`, and the call is
+            // semantically "served by MCP" even though dispatch goes
+            // through a Harn closure that ultimately invokes mcp_call.
+            executor = Some(match mcp_server_for_tool(tools_val, tool_name) {
+                Some(server_name) => ToolExecutor::McpServer { server_name },
+                None => ToolExecutor::HarnBuiltin,
+            });
             let Some(mut vm) = crate::vm::clone_async_builtin_child_vm() else {
-                return Err(VmError::CategorizedError {
-                    message: format!(
-                        "tool '{tool_name}' is Harn-owned but no child VM context was available"
-                    ),
-                    category: ErrorCategory::ToolRejected,
-                });
+                return ToolDispatchOutcome {
+                    result: Err(VmError::CategorizedError {
+                        message: format!(
+                            "tool '{tool_name}' is Harn-owned but no child VM context was available"
+                        ),
+                        category: ErrorCategory::ToolRejected,
+                    }),
+                    executor,
+                };
             };
             let args_vm = crate::stdlib::json_to_vm_value(tool_args);
             let _trusted_bridge_guard = crate::orchestration::allow_trusted_bridge_calls();
@@ -280,6 +312,14 @@ pub(super) async fn dispatch_tool_execution(
                 Err(e) => Ok(serde_json::Value::String(format!("Error: {e}"))),
             }
         } else if let Some(bridge) = bridge {
+            // Same `_mcp_server` discriminator: a host that surfaces an
+            // MCP server's tools without a Harn-side closure (e.g. the
+            // CLI's eager-connect path) still routes through the bridge,
+            // but the executor is the MCP server, not the bridge itself.
+            executor = Some(match mcp_server_for_tool(tools_val, tool_name) {
+                Some(server_name) => ToolExecutor::McpServer { server_name },
+                None => ToolExecutor::HostBridge,
+            });
             match bridge
                 .call(
                     "builtin_call",
@@ -297,6 +337,9 @@ pub(super) async fn dispatch_tool_execution(
                 other => other,
             }
         } else {
+            // No backend could claim the call — leave executor unset so
+            // the caller reports "tool unavailable" rather than blaming
+            // a specific backend.
             Err(VmError::CategorizedError {
                 message: format!(
                     "Tool '{}' is not available in the current environment. \
@@ -307,19 +350,61 @@ pub(super) async fn dispatch_tool_execution(
             })
         };
         match &result {
-            Ok(_) => break result,
+            Ok(_) => break ToolDispatchOutcome { result, executor },
             Err(VmError::CategorizedError {
                 category: ErrorCategory::ToolRejected,
                 ..
-            }) => break result,
+            }) => break ToolDispatchOutcome { result, executor },
             Err(_) if attempt < tool_retries => {
                 attempt += 1;
                 let delay = tool_backoff_ms * (1u64 << attempt.min(5));
                 tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
             }
-            Err(_) => break result,
+            Err(_) => break ToolDispatchOutcome { result, executor },
         }
     }
+}
+
+/// Inspect `tools_val` for a `_mcp_server` annotation on the entry
+/// matching `tool_name`. Returns the originating server name when the
+/// tool was sourced from `mcp_list_tools`, otherwise `None`. The
+/// annotation is a free-form dict key (it travels alongside the
+/// schema), so we also peek at a `function` sub-dict for OpenAI-shape
+/// entries that nest the metadata.
+pub(super) fn mcp_server_for_tool(tools_val: Option<&VmValue>, tool_name: &str) -> Option<String> {
+    let dict = tools_val?.as_dict()?;
+    let tools_list = match dict.get("tools") {
+        Some(VmValue::List(l)) => l,
+        _ => return None,
+    };
+    for tool in tools_list.iter() {
+        let entry: &std::collections::BTreeMap<String, VmValue> = match tool {
+            VmValue::Dict(d) => d,
+            _ => continue,
+        };
+        let name = match entry.get("name") {
+            Some(v) => v.display(),
+            None => entry
+                .get("function")
+                .and_then(|f| f.as_dict())
+                .and_then(|f| f.get("name"))
+                .map(|v| v.display())
+                .unwrap_or_default(),
+        };
+        if name != tool_name {
+            continue;
+        }
+        if let Some(VmValue::String(s)) = entry.get("_mcp_server") {
+            return Some(s.to_string());
+        }
+        if let Some(VmValue::Dict(func)) = entry.get("function") {
+            if let Some(VmValue::String(s)) = func.get("_mcp_server") {
+                return Some(s.to_string());
+            }
+        }
+        return None;
+    }
+    None
 }
 
 /// Look up the Harn-defined handler closure for a tool, if any.
@@ -357,4 +442,163 @@ pub(super) fn classify_tool_mutation(tool_name: &str) -> String {
 
 pub(super) fn declared_paths(tool_name: &str, tool_args: &serde_json::Value) -> Vec<String> {
     crate::orchestration::current_tool_declared_paths(tool_name, tool_args)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Harn#691: every dispatch path tags `ToolCallUpdate.executor` with
+    //! the backend that ran the tool. These tests exercise each branch
+    //! of `dispatch_tool_execution` without spinning up the full agent
+    //! loop.
+
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    fn tools_dict(entries: Vec<(&str, BTreeMap<String, VmValue>)>) -> VmValue {
+        let list: Vec<VmValue> = entries
+            .into_iter()
+            .map(|(name, mut entry)| {
+                entry
+                    .entry("name".to_string())
+                    .or_insert_with(|| VmValue::String(Rc::from(name.to_string())));
+                VmValue::Dict(Rc::new(entry))
+            })
+            .collect();
+        let mut dict = BTreeMap::new();
+        dict.insert("tools".to_string(), VmValue::List(Rc::new(list)));
+        VmValue::Dict(Rc::new(dict))
+    }
+
+    #[test]
+    fn mcp_server_for_tool_finds_top_level_annotation() {
+        // mcp_list_tools tags every entry with `_mcp_server`. The
+        // helper picks that up so the dispatch site can tag the
+        // executor as `McpServer { server_name }`.
+        let mut entry = BTreeMap::new();
+        entry.insert(
+            "_mcp_server".to_string(),
+            VmValue::String(Rc::from("linear".to_string())),
+        );
+        let tools = tools_dict(vec![("create_issue", entry)]);
+        assert_eq!(
+            mcp_server_for_tool(Some(&tools), "create_issue"),
+            Some("linear".to_string())
+        );
+    }
+
+    #[test]
+    fn mcp_server_for_tool_finds_nested_function_annotation() {
+        // OpenAI-shape tools nest `_mcp_server` inside a `function`
+        // sub-dict; the search must drill down a level.
+        let mut function = BTreeMap::new();
+        function.insert(
+            "name".to_string(),
+            VmValue::String(Rc::from("create_issue".to_string())),
+        );
+        function.insert(
+            "_mcp_server".to_string(),
+            VmValue::String(Rc::from("linear".to_string())),
+        );
+        let mut entry = BTreeMap::new();
+        entry.insert("function".to_string(), VmValue::Dict(Rc::new(function)));
+        // The outer entry has no `name` — fall back to function.name.
+        let mut dict = BTreeMap::new();
+        dict.insert(
+            "tools".to_string(),
+            VmValue::List(Rc::new(vec![VmValue::Dict(Rc::new(entry))])),
+        );
+        let tools = VmValue::Dict(Rc::new(dict));
+        assert_eq!(
+            mcp_server_for_tool(Some(&tools), "create_issue"),
+            Some("linear".to_string())
+        );
+    }
+
+    #[test]
+    fn mcp_server_for_tool_returns_none_for_plain_tool() {
+        let tools = tools_dict(vec![("read", BTreeMap::new())]);
+        assert!(mcp_server_for_tool(Some(&tools), "read").is_none());
+        assert!(mcp_server_for_tool(Some(&tools), "missing").is_none());
+        assert!(mcp_server_for_tool(None, "read").is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dispatch_tags_harn_builtin_for_local_short_circuit() {
+        // `read_file` is a `handle_tool_locally` short-circuit — the
+        // dispatcher resolves it without touching tools_val or the
+        // bridge, and tags executor=HarnBuiltin.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("hello.txt");
+        std::fs::write(&path, "harn#691").expect("write");
+        let args = serde_json::json!({ "path": path.to_string_lossy() });
+        let outcome = dispatch_tool_execution("read_file", &args, None, None, 0, 0).await;
+        assert!(outcome.result.is_ok(), "got: {:?}", outcome.result);
+        assert_eq!(outcome.executor, Some(ToolExecutor::HarnBuiltin));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dispatch_tags_host_bridge_when_only_bridge_can_serve() {
+        // No `handle_tool_locally` short-circuit, no script handler in
+        // tools_val — the bridge is the only backend left, so the
+        // executor must be `HostBridge`. Use a writer that errors so
+        // the call fails fast without needing a real host process.
+        let bridge = crate::bridge::HostBridge::from_parts_with_writer(
+            Arc::new(Mutex::new(std::collections::HashMap::new())),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(|_| Err("test bridge: no host attached".to_string())),
+            1,
+        );
+        let bridge = Rc::new(bridge);
+        let args = serde_json::json!({});
+        let outcome =
+            dispatch_tool_execution("custom_host_tool", &args, None, Some(&bridge), 0, 0).await;
+        // The call itself fails (no host responds) but the executor
+        // reflects the path that was attempted.
+        assert!(outcome.result.is_err());
+        assert_eq!(outcome.executor, Some(ToolExecutor::HostBridge));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dispatch_tags_mcp_server_when_tool_is_mcp_owned_via_bridge() {
+        // The bridge is present AND the tool entry carries a
+        // `_mcp_server` annotation: the executor must point to the
+        // MCP server, not the bridge that proxied the call.
+        let bridge = crate::bridge::HostBridge::from_parts_with_writer(
+            Arc::new(Mutex::new(std::collections::HashMap::new())),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(|_| Err("test bridge".to_string())),
+            1,
+        );
+        let bridge = Rc::new(bridge);
+        let mut entry = BTreeMap::new();
+        entry.insert(
+            "_mcp_server".to_string(),
+            VmValue::String(Rc::from("linear".to_string())),
+        );
+        let tools = tools_dict(vec![("create_issue", entry)]);
+        let args = serde_json::json!({});
+        let outcome =
+            dispatch_tool_execution("create_issue", &args, Some(&tools), Some(&bridge), 0, 0).await;
+        assert_eq!(
+            outcome.executor,
+            Some(ToolExecutor::McpServer {
+                server_name: "linear".to_string()
+            })
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dispatch_returns_none_executor_when_no_backend_available() {
+        // No local short-circuit, no script handler, no bridge — the
+        // dispatcher reports the tool as unavailable and the executor
+        // stays `None` so callers don't blame a specific backend.
+        let outcome =
+            dispatch_tool_execution("nonexistent_tool", &serde_json::json!({}), None, None, 0, 0)
+                .await;
+        assert!(outcome.result.is_err());
+        assert!(outcome.executor.is_none());
+    }
 }

--- a/crates/harn-vm/src/stdlib_acp.harn
+++ b/crates/harn-vm/src/stdlib_acp.harn
@@ -14,7 +14,7 @@ type AgentMessageChunk = {sessionUpdate: string, content: {type: string, text: s
 
 type ToolCall = {sessionUpdate: string, toolCallId: string, title: string | nil, kind: string | nil, status: string | nil, content: list<dict> | nil, locations: list<dict> | nil, rawInput: dict | nil, rawOutput: dict | nil}
 
-type ToolCallUpdate = {sessionUpdate: string, toolCallId: string, status: string | nil, title: string | nil, content: list<dict> | nil, locations: list<dict> | nil, rawOutput: dict | nil}
+type ToolCallUpdate = {sessionUpdate: string, toolCallId: string, status: string | nil, title: string | nil, content: list<dict> | nil, locations: list<dict> | nil, rawOutput: dict | nil, executor: string | dict | nil}
 
 type Plan = {sessionUpdate: string, entries: list<{content: string, priority: string | nil, status: string | nil}>}
 
@@ -51,6 +51,7 @@ pub fn tool_call_update(tool_call_id, status) {
     content: nil,
     locations: nil,
     rawOutput: nil,
+    executor: nil,
   }
 }
 

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -25,6 +25,33 @@ Internally, the agent loop emits `AgentEvent::ToolCall` +
 translates them into `session/update` notifications via an `AgentEventSink` it
 registers per session.
 
+### `executor` tag
+
+`tool_call_update` carries an optional `executor` field that names the
+backend that ran the tool, so clients can render "via mcp:linear" /
+"via host bridge" badges, attribute latency by transport, and route
+errors correctly. Variants:
+
+- `"harn_builtin"` — VM-stdlib (e.g. `read_file`, `write_file`,
+  `exec`, `http_*`, `mcp_*`) or any Harn-side handler closure
+  registered in the script's `tools` table.
+- `"host_bridge"` — capability provided by the host through the bridge
+  (Swift IDE bridge, BurinApp, BurinCLI host shells).
+- `{"kind": "mcp_server", "serverName": "<name>"}` — tool came from
+  `mcp_list_tools` against the named server. The agent loop detects
+  this from the `_mcp_server` annotation `mcp_list_tools` injects on
+  every dict, so the tag survives even when the call physically
+  proxies through a bridge.
+- `"provider_native"` — provider executed the tool server-side and
+  inlined the result (currently only OpenAI Responses-API
+  `tool_search` and the equivalent Anthropic native search; the agent
+  never dispatches these locally).
+
+Unit variants serialize as bare strings; the `mcp_server` case carries
+the configured server name. The field is omitted when unknown — most
+commonly for the in-progress emission that fires before the dispatch
+backend is picked.
+
 ### `session/request_permission`
 
 Request payload (harn-issued):


### PR DESCRIPTION
## Summary

- Adds a `ToolExecutor` enum (`HarnBuiltin` | `HostBridge` | `McpServer { server_name }` | `ProviderNative`) and an optional `executor` field on `AgentEvent::ToolCallUpdate`. The dispatcher and the provider-native search-block emitter both tag the event so clients can render "via mcp:linear" / "via host bridge" badges, attribute latency by transport, and route errors correctly.
- MCP detection is automatic via the `_mcp_server` annotation `mcp_list_tools` injects on every tool dict — the tag survives even when the call physically proxies through `HostBridge.builtin_call`.
- Provider-native search tools now emit a paired `ToolCall`/`ToolCallUpdate` alongside the existing `tool_search_*` events so badge-rendering clients no longer have to special-case search.
- ACP wire format keeps unit variants as bare strings (`"harn_builtin"`, `"host_bridge"`, `"provider_native"`) and renders the MCP case as `{"kind": "mcp_server", "serverName": "..."}` so a client can branch on `typeof executor === "string"` first.

Closes [#691](https://github.com/burin-labs/harn/issues/691).

## Implementation

- `crates/harn-vm/src/agent_events.rs` — new `ToolExecutor` enum + `executor: Option<ToolExecutor>` on `ToolCallUpdate` (skip-serializing-if-none for backward-compatible event logs).
- `crates/harn-vm/src/llm/agent_tools.rs` — `dispatch_tool_execution` returns `ToolDispatchOutcome` carrying the chosen backend; new `mcp_server_for_tool` helper detects MCP-owned tools from `tools_val`.
- `crates/harn-vm/src/llm/agent/tool_dispatch.rs` — propagates the executor through the parallel pre-fetch cache and the per-call dispatch path; populates the post-dispatch `ToolCallUpdate` emission.
- `crates/harn-vm/src/llm/agent/llm_call.rs` — extracts the per-block tool-search handling into a pure `provider_native_search_emissions` helper that emits a `ToolCall` + `ToolCallUpdate` pair tagged `ProviderNative` alongside the existing `ToolSearchQuery`/`Result` events.
- `crates/harn-serve/src/adapters/acp/events.rs` — translates the executor to the ACP wire format.
- `crates/harn-vm/src/stdlib_acp.harn` — extends the typed `ToolCallUpdate` alias with `executor: string | dict | nil`.
- `docs/src/bridge-protocol.md` + `CHANGELOG.md` — note the new field and its semantics.

## Test plan

- [x] `cargo test -p harn-vm --lib agent_events::tests` (3 new tests: serde round-trip, omits-when-absent, includes-when-present)
- [x] `cargo test -p harn-vm --lib llm::agent_tools::tests` (5 new tests: mcp_server_for_tool top-level, mcp_server_for_tool nested, plain tool returns None, dispatch tags HarnBuiltin / HostBridge / McpServer per path, returns None when no backend available)
- [x] `cargo test -p harn-vm --lib llm::agent::llm_call::tests` (2 new tests: tool_search_result emits ProviderNative-tagged ToolCallUpdate; unrelated blocks emit nothing)
- [x] `cargo test -p harn-serve --lib executor` (1 new integration test verifying ACP wire format for all four variants and absence when `executor: None`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Workspace builds cleanly across all crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)