### PR TITLE
Add structured error_category to tool_call_update events (#690)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ granular archaeology.
 
 ### Added
 
+- **Structured `error_category` on `tool_call_update` events (#690).**
+  Adds `ToolCallErrorCategory` (snake_case wire enum:
+  `schema_validation`, `tool_error`, `mcp_server_error`,
+  `host_bridge_error`, `permission_denied`, `rejected_loop`, `timeout`,
+  `network`, `cancelled`, `unknown`) on `AgentEvent::ToolCallUpdate`
+  alongside the existing free-form `error` string. The dispatch loop
+  now categorizes every failure path — schema validation, parse-error
+  short-circuit, policy denial, dynamic permission denial, host
+  approval denial, pre-tool hook deny, loop-detector skip, and the
+  final completion/rejection branch — and propagates the category to
+  the ACP wire as `errorCategory`. Each early-failure path also emits
+  a paired `ToolCall(Pending)` + `ToolCallUpdate(Failed)` so clients
+  see a consistent two-event lifecycle for rejected calls instead of
+  silence. The category is mirrored on the `tool_execution` transcript
+  event metadata so replay engines see the same classification.
 - **Harn-owned Ollama runtime settings (#676).** Centralizes Ollama
   `num_ctx` and `keep_alive` precedence, defaults, normalization, and
   warmup request shaping in `harn-vm`. Hosts can pass raw persisted

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -108,6 +108,7 @@ impl AgentEventSink for AcpAgentEventSink {
                 error,
                 duration_ms,
                 execution_duration_ms,
+                error_category,
             } => {
                 let mut update = serde_json::json!({
                     "sessionUpdate": "tool_call_update",
@@ -126,6 +127,9 @@ impl AgentEventSink for AcpAgentEventSink {
                 }
                 if let Some(d) = execution_duration_ms {
                     update["executionDurationMs"] = serde_json::Value::from(*d);
+                }
+                if let Some(cat) = error_category {
+                    update["errorCategory"] = serde_json::Value::String(cat.as_str().to_string());
                 }
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
@@ -288,7 +292,9 @@ impl AgentEventSink for AcpAgentEventSink {
 
 #[cfg(test)]
 mod tests {
-    use harn_vm::agent_events::{AgentEvent, AgentEventSink, FsWatchEvent, ToolCallStatus};
+    use harn_vm::agent_events::{
+        AgentEvent, AgentEventSink, FsWatchEvent, ToolCallErrorCategory, ToolCallStatus,
+    };
     use harn_vm::orchestration::{HandoffArtifact, HandoffTargetRecord};
     use harn_vm::tool_annotations::ToolKind;
     use tokio::sync::mpsc;
@@ -373,6 +379,7 @@ mod tests {
                 error: None,
                 duration_ms: Some(7),
                 execution_duration_ms: Some(5),
+                error_category: None,
             },
             AgentEvent::Plan {
                 session_id: "session-1".to_string(),
@@ -462,6 +469,59 @@ mod tests {
             assert_eq!(payload["params"]["sessionId"], "session-1");
             assert_eq!(payload["params"]["update"]["sessionUpdate"], expected);
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tool_call_update_serializes_error_category_in_camel_case() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+        sink.handle_event(&AgentEvent::ToolCallUpdate {
+            session_id: "session-1".to_string(),
+            tool_call_id: "tool-7".to_string(),
+            tool_name: "read".to_string(),
+            status: ToolCallStatus::Failed,
+            raw_output: None,
+            error: Some("missing required arg `path`".to_string()),
+            duration_ms: None,
+            execution_duration_ms: None,
+            error_category: Some(ToolCallErrorCategory::SchemaValidation),
+        });
+        let line = rx.recv().await.expect("acp tool_call_update");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        assert_eq!(
+            payload["params"]["update"]["sessionUpdate"],
+            "tool_call_update"
+        );
+        assert_eq!(payload["params"]["update"]["status"], "failed");
+        assert_eq!(
+            payload["params"]["update"]["errorCategory"],
+            "schema_validation"
+        );
+        assert_eq!(
+            payload["params"]["update"]["error"],
+            "missing required arg `path`"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tool_call_update_omits_error_category_when_none() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+        sink.handle_event(&AgentEvent::ToolCallUpdate {
+            session_id: "session-1".to_string(),
+            tool_call_id: "tool-7".to_string(),
+            tool_name: "read".to_string(),
+            status: ToolCallStatus::Completed,
+            raw_output: Some(serde_json::json!({"ok": true})),
+            error: None,
+            duration_ms: None,
+            execution_duration_ms: None,
+            error_category: None,
+        });
+        let line = rx.recv().await.expect("acp tool_call_update");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        assert!(payload["params"]["update"].get("errorCategory").is_none());
+        assert!(payload["params"]["update"].get("error").is_none());
     }
 
     #[test]

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -84,6 +84,84 @@ pub enum ToolCallStatus {
     Failed,
 }
 
+/// Wire-level classification of a `ToolCallUpdate` failure. Pairs with the
+/// human-readable `error` string so clients can render each failure type
+/// distinctly (e.g. surface a "permission denied" badge, or a different
+/// retry affordance for `network` vs `tool_error`). The enum is
+/// deliberately extensible — `unknown` is the default when the runtime
+/// could not classify a failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolCallErrorCategory {
+    /// Host-side validation rejected the args (missing required field,
+    /// invalid type, malformed JSON).
+    SchemaValidation,
+    /// The tool ran and returned an error result (e.g. `read_file` on a
+    /// missing path) — distinguished from a transport failure.
+    ToolError,
+    /// MCP transport / server-protocol error.
+    McpServerError,
+    /// Burin Swift host bridge returned an error during dispatch.
+    HostBridgeError,
+    /// `session/request_permission` denied by the client, or a policy
+    /// rule (static or dynamic) refused the call.
+    PermissionDenied,
+    /// The harn loop detector skipped this call because the same
+    /// (tool, args) pair repeated past the configured threshold.
+    RejectedLoop,
+    /// The tool exceeded its time budget.
+    Timeout,
+    /// Transient network / rate-limited / 5xx provider failure.
+    Network,
+    /// The tool was cancelled (e.g. session aborted).
+    Cancelled,
+    /// Default when classification was not performed.
+    Unknown,
+}
+
+impl ToolCallErrorCategory {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SchemaValidation => "schema_validation",
+            Self::ToolError => "tool_error",
+            Self::McpServerError => "mcp_server_error",
+            Self::HostBridgeError => "host_bridge_error",
+            Self::PermissionDenied => "permission_denied",
+            Self::RejectedLoop => "rejected_loop",
+            Self::Timeout => "timeout",
+            Self::Network => "network",
+            Self::Cancelled => "cancelled",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Map an internal `ErrorCategory` (used by the VM's `VmError`
+    /// classification) onto the wire enum. The internal taxonomy is
+    /// finer-grained — several transient categories collapse onto
+    /// `Network`, and the auth/quota family becomes `HostBridgeError`
+    /// because at the tool-dispatch boundary those errors come from
+    /// the bridge transport rather than the tool itself.
+    pub fn from_internal(category: &crate::value::ErrorCategory) -> Self {
+        use crate::value::ErrorCategory as Internal;
+        match category {
+            Internal::Timeout => Self::Timeout,
+            Internal::RateLimit
+            | Internal::Overloaded
+            | Internal::ServerError
+            | Internal::TransientNetwork => Self::Network,
+            Internal::SchemaValidation => Self::SchemaValidation,
+            Internal::ToolError => Self::ToolError,
+            Internal::ToolRejected => Self::PermissionDenied,
+            Internal::Cancelled => Self::Cancelled,
+            Internal::Auth
+            | Internal::EgressBlocked
+            | Internal::NotFound
+            | Internal::CircuitOpen
+            | Internal::Generic => Self::HostBridgeError,
+        }
+    }
+}
+
 /// Events emitted by the agent loop. The first five variants map 1:1
 /// to ACP `sessionUpdate` variants; the last three are harn-internal.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -126,6 +204,13 @@ pub enum AgentEvent {
         /// Populated only on the terminal update; `None` otherwise.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         execution_duration_ms: Option<u64>,
+        /// Structured classification of the failure (when `status` is
+        /// `Failed`). Paired with `error` so clients can render each
+        /// category distinctly without parsing free-form strings. Always
+        /// `None` for non-Failed updates and serialized as
+        /// `errorCategory` in the ACP wire format.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error_category: Option<ToolCallErrorCategory>,
     },
     Plan {
         session_id: String,
@@ -697,6 +782,7 @@ mod tests {
             error: None,
             duration_ms: Some(42),
             execution_duration_ms: Some(7),
+            error_category: None,
         };
         let value = serde_json::to_value(&terminal).unwrap();
         assert_eq!(value["duration_ms"], serde_json::json!(42));
@@ -714,6 +800,7 @@ mod tests {
             error: None,
             duration_ms: None,
             execution_duration_ms: None,
+            error_category: None,
         };
         let value = serde_json::to_value(&intermediate).unwrap();
         let object = value.as_object().expect("update serializes as object");
@@ -772,5 +859,116 @@ mod tests {
             serde_json::to_string(&ToolCallStatus::Failed).unwrap(),
             "\"failed\""
         );
+    }
+
+    #[test]
+    fn tool_call_error_category_serializes_as_snake_case() {
+        let pairs = [
+            (ToolCallErrorCategory::SchemaValidation, "schema_validation"),
+            (ToolCallErrorCategory::ToolError, "tool_error"),
+            (ToolCallErrorCategory::McpServerError, "mcp_server_error"),
+            (ToolCallErrorCategory::HostBridgeError, "host_bridge_error"),
+            (ToolCallErrorCategory::PermissionDenied, "permission_denied"),
+            (ToolCallErrorCategory::RejectedLoop, "rejected_loop"),
+            (ToolCallErrorCategory::Timeout, "timeout"),
+            (ToolCallErrorCategory::Network, "network"),
+            (ToolCallErrorCategory::Cancelled, "cancelled"),
+            (ToolCallErrorCategory::Unknown, "unknown"),
+        ];
+        for (variant, wire) in pairs {
+            let encoded = serde_json::to_string(&variant).unwrap();
+            assert_eq!(encoded, format!("\"{wire}\""));
+            assert_eq!(variant.as_str(), wire);
+            // Round-trip via deserialize so wire stability is enforced
+            // both ways.
+            let decoded: ToolCallErrorCategory = serde_json::from_str(&encoded).unwrap();
+            assert_eq!(decoded, variant);
+        }
+    }
+
+    #[test]
+    fn tool_call_error_category_from_internal_collapses_transient_family() {
+        use crate::value::ErrorCategory as Internal;
+        assert_eq!(
+            ToolCallErrorCategory::from_internal(&Internal::Timeout),
+            ToolCallErrorCategory::Timeout
+        );
+        for net in [
+            Internal::RateLimit,
+            Internal::Overloaded,
+            Internal::ServerError,
+            Internal::TransientNetwork,
+        ] {
+            assert_eq!(
+                ToolCallErrorCategory::from_internal(&net),
+                ToolCallErrorCategory::Network,
+                "{net:?} should map to Network",
+            );
+        }
+        assert_eq!(
+            ToolCallErrorCategory::from_internal(&Internal::SchemaValidation),
+            ToolCallErrorCategory::SchemaValidation
+        );
+        assert_eq!(
+            ToolCallErrorCategory::from_internal(&Internal::ToolError),
+            ToolCallErrorCategory::ToolError
+        );
+        assert_eq!(
+            ToolCallErrorCategory::from_internal(&Internal::ToolRejected),
+            ToolCallErrorCategory::PermissionDenied
+        );
+        assert_eq!(
+            ToolCallErrorCategory::from_internal(&Internal::Cancelled),
+            ToolCallErrorCategory::Cancelled
+        );
+        for bridge in [
+            Internal::Auth,
+            Internal::EgressBlocked,
+            Internal::NotFound,
+            Internal::CircuitOpen,
+            Internal::Generic,
+        ] {
+            assert_eq!(
+                ToolCallErrorCategory::from_internal(&bridge),
+                ToolCallErrorCategory::HostBridgeError,
+                "{bridge:?} should map to HostBridgeError",
+            );
+        }
+    }
+
+    #[test]
+    fn tool_call_update_event_omits_error_category_when_none() {
+        let event = AgentEvent::ToolCallUpdate {
+            session_id: "s".into(),
+            tool_call_id: "t".into(),
+            tool_name: "read".into(),
+            status: ToolCallStatus::Completed,
+            raw_output: None,
+            error: None,
+            duration_ms: None,
+            execution_duration_ms: None,
+            error_category: None,
+        };
+        let v = serde_json::to_value(&event).unwrap();
+        assert_eq!(v["type"], "tool_call_update");
+        assert!(v.get("error_category").is_none());
+    }
+
+    #[test]
+    fn tool_call_update_event_serializes_error_category_when_set() {
+        let event = AgentEvent::ToolCallUpdate {
+            session_id: "s".into(),
+            tool_call_id: "t".into(),
+            tool_name: "read".into(),
+            status: ToolCallStatus::Failed,
+            raw_output: None,
+            error: Some("missing required field".into()),
+            duration_ms: None,
+            execution_duration_ms: None,
+            error_category: Some(ToolCallErrorCategory::SchemaValidation),
+        };
+        let v = serde_json::to_value(&event).unwrap();
+        assert_eq!(v["error_category"], "schema_validation");
+        assert_eq!(v["error"], "missing required field");
     }
 }

--- a/crates/harn-vm/src/llm/agent/tests/mod.rs
+++ b/crates/harn-vm/src/llm/agent/tests/mod.rs
@@ -36,6 +36,7 @@ mod prompts;
 mod result_build;
 mod retry_after;
 mod tool_classification;
+mod tool_dispatch_categories;
 mod tool_durations;
 mod tool_format;
 mod transcript;

--- a/crates/harn-vm/src/llm/agent/tests/tool_dispatch_categories.rs
+++ b/crates/harn-vm/src/llm/agent/tests/tool_dispatch_categories.rs
@@ -1,0 +1,283 @@
+//! End-to-end tests for `error_category` on `ToolCallUpdate` events
+//! emitted by `run_tool_dispatch`. We assert against the loop result's
+//! `transcript.events` rather than the process-global sink registry —
+//! `agent_events::reset_all_sinks()` is invoked by `reset_thread_local_state`
+//! in unrelated tests, so a sink registered for our session can be wiped
+//! mid-run when those tests race ours on the same process. The
+//! transcript travels back to us via the loop's return value, which the
+//! reset cannot touch.
+//!
+//! The transcript-side assertions cover every category the issue calls
+//! out: schema_validation, permission_denied, rejected_loop, tool_error.
+//! For mcp_server_error / host_bridge_error the wire enum is tested via
+//! `from_internal` in `agent_events.rs::tests`, since those failure
+//! modes have no in-tree producer to drive end-to-end without standing
+//! up a fake bridge.
+
+// Each test holds a `std::sync::Mutex` across `.await` points so the
+// thread-local stacks (mocks, policies) and global registries the agent
+// loop touches don't interleave with sibling tests running on a shared
+// pool. The runtime is `current_thread` and the futures don't yield to
+// other lock-taking work, so the standard lint about awaiting under a
+// sync mutex doesn't apply here.
+#![allow(clippy::await_holding_lock)]
+
+use super::*;
+use crate::agent_events::ToolCallErrorCategory;
+use std::collections::BTreeMap;
+
+/// Serialize the tests in this module. The agent loop touches several
+/// thread-local stacks (mocks, execution policies, approval policies,
+/// dynamic permissions) that other tests in this crate also push to —
+/// running interleaved on the same OS thread means a leftover policy
+/// from a sibling test can mask the failure path we're trying to hit.
+fn serialize_tests() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Drain the thread-local policy stacks that other tests in this crate
+/// might have left behind. Without this, a leftover `auto_deny=*`
+/// approval policy or capability ceiling from a sibling test on the
+/// same OS thread short-circuits dispatch before we can observe the
+/// expected `error_category`.
+fn drain_thread_local_state() {
+    use crate::orchestration::{pop_approval_policy, pop_execution_policy};
+    for _ in 0..16 {
+        pop_execution_policy();
+        pop_approval_policy();
+    }
+}
+
+fn read_tool_registry() -> VmValue {
+    let mut tool_params = BTreeMap::new();
+    tool_params.insert(
+        "path".to_string(),
+        VmValue::Dict(Rc::new(BTreeMap::from([(
+            "type".to_string(),
+            VmValue::String(Rc::from("string")),
+        )]))),
+    );
+    let tool = VmValue::Dict(Rc::new(BTreeMap::from([
+        ("name".to_string(), VmValue::String(Rc::from("read"))),
+        (
+            "description".to_string(),
+            VmValue::String(Rc::from("Read a file.")),
+        ),
+        (
+            "parameters".to_string(),
+            VmValue::Dict(Rc::new(tool_params)),
+        ),
+    ])));
+    VmValue::Dict(Rc::new(BTreeMap::from([(
+        "tools".to_string(),
+        VmValue::List(Rc::new(vec![tool])),
+    )])))
+}
+
+fn done_mock() -> crate::llm::mock::LlmMock {
+    crate::llm::mock::LlmMock {
+        text: "<done>##DONE##</done>".to_string(),
+        tool_calls: Vec::new(),
+        match_pattern: None,
+        consume_on_match: true,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: None,
+        stop_reason: None,
+        model: "mock".to_string(),
+        provider: None,
+        blocks: None,
+        error: None,
+    }
+}
+
+fn tool_call_mock(tool_name: &str, args: serde_json::Value) -> crate::llm::mock::LlmMock {
+    crate::llm::mock::LlmMock {
+        text: String::new(),
+        tool_calls: vec![json!({
+            "id": format!("call_{tool_name}"),
+            "type": "tool_call",
+            "name": tool_name,
+            "arguments": args,
+        })],
+        match_pattern: None,
+        consume_on_match: true,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: None,
+        stop_reason: None,
+        model: "mock".to_string(),
+        provider: None,
+        blocks: None,
+        error: None,
+    }
+}
+
+fn assert_tool_execution_with_category(
+    result: &serde_json::Value,
+    expected_tool: &str,
+    expected: ToolCallErrorCategory,
+) {
+    let events = result["transcript"]["events"]
+        .as_array()
+        .expect("transcript.events must be an array");
+    let matched = events.iter().any(|event| {
+        event["kind"] == "tool_execution"
+            && event["metadata"]["tool_name"] == expected_tool
+            && event["metadata"]["error_category"] == expected.as_str()
+    });
+    assert!(
+        matched,
+        "expected a tool_execution event for tool '{expected_tool}' \
+         tagged with error_category '{}'; got transcript events: {events:#?}",
+        expected.as_str(),
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn schema_validation_failure_emits_categorized_event() {
+    let _guard = serialize_tests();
+    drain_thread_local_state();
+    reset_llm_mock_state();
+    crate::llm::mock::push_llm_mock(tool_call_mock("read", json!({})));
+    crate::llm::mock::push_llm_mock(done_mock());
+
+    let mut opts = base_opts(vec![json!({"role": "user", "content": "read"})]);
+    opts.tools = Some(read_tool_registry());
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 2;
+    config.tool_format = "native".to_string();
+    config.session_id = "test-cat-schema-validation".to_string();
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_tool_execution_with_category(&result, "read", ToolCallErrorCategory::SchemaValidation);
+
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unknown_tool_emits_permission_denied_category() {
+    // No bridge + no Harn-defined handler → dispatch_tool_execution falls
+    // through to the "Tool '<name>' is not available" arm, which returns
+    // `Err(VmError::CategorizedError { category: ToolRejected })`. The
+    // wire enum collapses ToolRejected to PermissionDenied.
+    let _guard = serialize_tests();
+    drain_thread_local_state();
+    reset_llm_mock_state();
+    crate::llm::mock::push_llm_mock(tool_call_mock("nonexistent_tool", json!({"arg": "value"})));
+    crate::llm::mock::push_llm_mock(done_mock());
+
+    let mut opts = base_opts(vec![json!({"role": "user", "content": "do work"})]);
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 2;
+    config.tool_format = "native".to_string();
+    config.session_id = "test-cat-permission-denied-unknown".to_string();
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_tool_execution_with_category(
+        &result,
+        "nonexistent_tool",
+        ToolCallErrorCategory::PermissionDenied,
+    );
+
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rejected_loop_skip_emits_rejected_loop_category() {
+    // Three identical tool calls with skip_threshold=2 — the third is
+    // skipped by the loop detector. We use `read_file` (handled locally
+    // without a bridge) so the calls actually execute and the loop
+    // tracker can record an identical-result repeat — repeats of
+    // *rejected* tools never reach `loop_tracker.record()`.
+    let _guard = serialize_tests();
+    drain_thread_local_state();
+    reset_llm_mock_state();
+    let args = json!({"path": "/nonexistent/test/path/that/never/exists"});
+    for _ in 0..3 {
+        crate::llm::mock::push_llm_mock(tool_call_mock("read_file", args.clone()));
+    }
+    crate::llm::mock::push_llm_mock(done_mock());
+
+    let mut opts = base_opts(vec![json!({"role": "user", "content": "read"})]);
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 4;
+    config.tool_format = "native".to_string();
+    config.session_id = "test-cat-rejected-loop".to_string();
+    // Enable detector and arrange for Skip on the third repeat.
+    config.loop_detect_warn = 1;
+    config.loop_detect_block = 2;
+    config.loop_detect_skip = 2;
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_tool_execution_with_category(&result, "read_file", ToolCallErrorCategory::RejectedLoop);
+
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tool_returning_error_string_emits_tool_error_category() {
+    // The local `read_file` handler responds with `Some("Error: cannot
+    // read file ...")` for an unreadable path. dispatch sees `Ok(...)`
+    // — not rejected, not a denied dict — but the result_text starts
+    // with "Error:". Final emission is Failed + ToolError.
+    let _guard = serialize_tests();
+    drain_thread_local_state();
+    reset_llm_mock_state();
+    crate::llm::mock::push_llm_mock(tool_call_mock(
+        "read_file",
+        json!({"path": "/nonexistent/path/for/tool_error_test"}),
+    ));
+    crate::llm::mock::push_llm_mock(done_mock());
+
+    let mut opts = base_opts(vec![json!({"role": "user", "content": "read"})]);
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 2;
+    config.tool_format = "native".to_string();
+    config.session_id = "test-cat-tool-error".to_string();
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_tool_execution_with_category(&result, "read_file", ToolCallErrorCategory::ToolError);
+
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn parse_error_emits_schema_validation_category() {
+    // The provider can deliver a malformed tool_calls payload — the
+    // VM normalizes that into args carrying a `__parse_error` sentinel,
+    // which the dispatch loop short-circuits as a SchemaValidation
+    // failure before any policy/permission/validation runs.
+    let _guard = serialize_tests();
+    drain_thread_local_state();
+    reset_llm_mock_state();
+    crate::llm::mock::push_llm_mock(tool_call_mock(
+        "read",
+        json!({"__parse_error": "could not decode arguments JSON"}),
+    ));
+    crate::llm::mock::push_llm_mock(done_mock());
+
+    let mut opts = base_opts(vec![json!({"role": "user", "content": "read"})]);
+    opts.tools = Some(read_tool_registry());
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 2;
+    config.tool_format = "native".to_string();
+    config.session_id = "test-cat-parse-error".to_string();
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_tool_execution_with_category(&result, "read", ToolCallErrorCategory::SchemaValidation);
+
+    reset_llm_mock_state();
+}

--- a/crates/harn-vm/src/llm/agent/tool_dispatch.rs
+++ b/crates/harn-vm/src/llm/agent/tool_dispatch.rs
@@ -33,7 +33,7 @@
 
 use std::rc::Rc;
 
-use crate::agent_events::{AgentEvent, ToolCallStatus};
+use crate::agent_events::{AgentEvent, ToolCallErrorCategory, ToolCallStatus};
 use crate::bridge::HostBridge;
 use crate::value::{ErrorCategory, VmError, VmValue};
 
@@ -508,6 +508,30 @@ pub(super) async fn run_tool_dispatch(
             continue;
         }
 
+        // Hoisted before any failure check so early-exit paths (parse
+        // error, policy denial, schema validation, permission denial,
+        // hook deny) can emit a `ToolCall(Pending)` + `ToolCallUpdate(
+        // Failed, error_category=...)` pair. Clients that today saw
+        // nothing for these failures now get a structured failure event.
+        // Synthetic dispatchers above this point (`is_client_search`,
+        // `load_skill`) intentionally bypass this — they have their
+        // own observation paths.
+        let tool_call_id = if tool_id.is_empty() {
+            format!("tool-iter-{iteration}-{tc_index}")
+        } else {
+            format!("tool-{tool_id}")
+        };
+        let tool_kind = crate::orchestration::current_tool_annotations(tool_name).map(|a| a.kind);
+        super::emit_agent_event(&AgentEvent::ToolCall {
+            session_id: ctx.session_id.to_string(),
+            tool_call_id: tool_call_id.clone(),
+            tool_name: tool_name.to_string(),
+            kind: tool_kind,
+            status: ToolCallStatus::Pending,
+            raw_input: tool_args.clone(),
+        })
+        .await;
+
         if let Some(parse_err) = tool_args.get("__parse_error").and_then(|v| v.as_str()) {
             let result_text = format!("ERROR: {parse_err}");
             state.transcript_events.push(transcript_event(
@@ -519,8 +543,21 @@ pub(super) async fn run_tool_dispatch(
                     "tool_name": tool_name,
                     "tool_use_id": tool_id,
                     "rejected": true,
+                    "error_category": ToolCallErrorCategory::SchemaValidation.as_str(),
                 })),
             ));
+            super::emit_agent_event(&AgentEvent::ToolCallUpdate {
+                session_id: ctx.session_id.to_string(),
+                tool_call_id: tool_call_id.clone(),
+                tool_name: tool_name.to_string(),
+                status: ToolCallStatus::Failed,
+                raw_output: None,
+                error: Some(parse_err.to_string()),
+                duration_ms: None,
+                execution_duration_ms: None,
+                error_category: Some(ToolCallErrorCategory::SchemaValidation),
+            })
+            .await;
             if ctx.tool_format == "native" {
                 append_message_to_contexts(
                     &mut state.visible_messages,
@@ -544,6 +581,7 @@ pub(super) async fn run_tool_dispatch(
                 )
             });
         if let Err(error) = policy_result {
+            let error_message = error.to_string();
             let result_text = render_tool_result(&denied_tool_result(
                 tool_name,
                 format!(
@@ -559,7 +597,7 @@ pub(super) async fn run_tool_dispatch(
                     "PermissionDeny",
                     tool_name,
                     &tool_args,
-                    &error.to_string(),
+                    &error_message,
                     false,
                 ));
             state.transcript_events.push(transcript_event(
@@ -572,8 +610,21 @@ pub(super) async fn run_tool_dispatch(
                     "tool_use_id": tool_id,
                     "rejected": true,
                     "arguments": tool_args.clone(),
+                    "error_category": ToolCallErrorCategory::PermissionDenied.as_str(),
                 })),
             ));
+            super::emit_agent_event(&AgentEvent::ToolCallUpdate {
+                session_id: ctx.session_id.to_string(),
+                tool_call_id: tool_call_id.clone(),
+                tool_name: tool_name.to_string(),
+                status: ToolCallStatus::Failed,
+                raw_output: None,
+                error: Some(error_message),
+                duration_ms: None,
+                execution_duration_ms: None,
+                error_category: Some(ToolCallErrorCategory::PermissionDenied),
+            })
+            .await;
             if ctx.tool_format == "native" {
                 append_message_to_contexts(
                     &mut state.visible_messages,
@@ -640,6 +691,7 @@ pub(super) async fn run_tool_dispatch(
                             escalated,
                         ),
                     );
+                    let denial_reason = reason.clone();
                     let result_text = render_tool_result(&denied_tool_result(tool_name, reason));
                     if !state.rejected_tools.contains(&tool_name.to_string()) {
                         state.rejected_tools.push(tool_name.to_string());
@@ -656,8 +708,21 @@ pub(super) async fn run_tool_dispatch(
                             "arguments": tool_args.clone(),
                             "permission": "denied",
                             "escalated": escalated,
+                            "error_category": ToolCallErrorCategory::PermissionDenied.as_str(),
                         })),
                     ));
+                    super::emit_agent_event(&AgentEvent::ToolCallUpdate {
+                        session_id: ctx.session_id.to_string(),
+                        tool_call_id: tool_call_id.clone(),
+                        tool_name: tool_name.to_string(),
+                        status: ToolCallStatus::Failed,
+                        raw_output: None,
+                        error: Some(denial_reason),
+                        duration_ms: None,
+                        execution_duration_ms: None,
+                        error_category: Some(ToolCallErrorCategory::PermissionDenied),
+                    })
+                    .await;
                     if ctx.tool_format == "native" {
                         append_message_to_contexts(
                             &mut state.visible_messages,
@@ -769,8 +834,21 @@ pub(super) async fn run_tool_dispatch(
                     "rejected": true,
                     "arguments": tool_args.clone(),
                     "approval": approval_status,
+                    "error_category": ToolCallErrorCategory::PermissionDenied.as_str(),
                 })),
             ));
+            super::emit_agent_event(&AgentEvent::ToolCallUpdate {
+                session_id: ctx.session_id.to_string(),
+                tool_call_id: tool_call_id.clone(),
+                tool_name: tool_name.to_string(),
+                status: ToolCallStatus::Failed,
+                raw_output: None,
+                error: Some(reason),
+                duration_ms: None,
+                execution_duration_ms: None,
+                error_category: Some(ToolCallErrorCategory::PermissionDenied),
+            })
+            .await;
             if ctx.tool_format == "native" {
                 append_message_to_contexts(
                     &mut state.visible_messages,
@@ -802,6 +880,7 @@ pub(super) async fn run_tool_dispatch(
         match crate::orchestration::run_pre_tool_hooks(tool_name, &tool_args).await? {
             crate::orchestration::PreToolAction::Allow => {}
             crate::orchestration::PreToolAction::Deny(reason) => {
+                let denial_reason = reason.clone();
                 let result_text = render_tool_result(&denied_tool_result(tool_name, reason));
                 if !state.rejected_tools.contains(&tool_name.to_string()) {
                     state.rejected_tools.push(tool_name.to_string());
@@ -811,10 +890,25 @@ pub(super) async fn run_tool_dispatch(
                     "tool",
                     "internal",
                     &result_text,
-                    Some(
-                        serde_json::json!({"tool_name": tool_name, "tool_use_id": tool_id, "rejected": true}),
-                    ),
+                    Some(serde_json::json!({
+                        "tool_name": tool_name,
+                        "tool_use_id": tool_id,
+                        "rejected": true,
+                        "error_category": ToolCallErrorCategory::PermissionDenied.as_str(),
+                    })),
                 ));
+                super::emit_agent_event(&AgentEvent::ToolCallUpdate {
+                    session_id: ctx.session_id.to_string(),
+                    tool_call_id: tool_call_id.clone(),
+                    tool_name: tool_name.to_string(),
+                    status: ToolCallStatus::Failed,
+                    raw_output: None,
+                    error: Some(denial_reason),
+                    duration_ms: None,
+                    execution_duration_ms: None,
+                    error_category: Some(ToolCallErrorCategory::PermissionDenied),
+                })
+                .await;
                 if ctx.tool_format == "native" {
                     append_message_to_contexts(
                         &mut state.visible_messages,
@@ -834,6 +928,7 @@ pub(super) async fn run_tool_dispatch(
         }
 
         if let Err(msg) = validate_tool_args(tool_name, &tool_args, &tool_schemas) {
+            let validation_message = msg.clone();
             let result_text = format!("ERROR: {msg}");
             state.transcript_events.push(transcript_event(
                 "tool_execution",
@@ -845,8 +940,21 @@ pub(super) async fn run_tool_dispatch(
                     "tool_use_id": tool_id,
                     "rejected": true,
                     "arguments": tool_args.clone(),
+                    "error_category": ToolCallErrorCategory::SchemaValidation.as_str(),
                 })),
             ));
+            super::emit_agent_event(&AgentEvent::ToolCallUpdate {
+                session_id: ctx.session_id.to_string(),
+                tool_call_id: tool_call_id.clone(),
+                tool_name: tool_name.to_string(),
+                status: ToolCallStatus::Failed,
+                raw_output: None,
+                error: Some(validation_message),
+                duration_ms: None,
+                execution_duration_ms: None,
+                error_category: Some(ToolCallErrorCategory::SchemaValidation),
+            })
+            .await;
             if ctx.tool_format == "native" {
                 append_message_to_contexts(
                     &mut state.visible_messages,
@@ -872,21 +980,10 @@ pub(super) async fn run_tool_dispatch(
         let mutation_classification = classify_tool_mutation(tool_name);
         let declared_paths_current = declared_paths(tool_name, &tool_args);
         let tool_started_at = std::time::Instant::now();
-        let tool_call_id = if tool_id.is_empty() {
-            format!("tool-iter-{iteration}-{}", tools_used_this_iter.len())
-        } else {
-            format!("tool-{tool_id}")
-        };
-        let tool_kind = crate::orchestration::current_tool_annotations(tool_name).map(|a| a.kind);
-        super::emit_agent_event(&AgentEvent::ToolCall {
-            session_id: ctx.session_id.to_string(),
-            tool_call_id: tool_call_id.clone(),
-            tool_name: tool_name.to_string(),
-            kind: tool_kind,
-            status: ToolCallStatus::Pending,
-            raw_input: tool_args.clone(),
-        })
-        .await;
+        // `ToolCall(Pending)` was already emitted at the top of the loop
+        // body so early-failure paths can pair it with a failed update.
+        // The InProgress transition runs only once we've cleared every
+        // pre-flight check and are about to dispatch.
         super::emit_agent_event(&AgentEvent::ToolCallUpdate {
             session_id: ctx.session_id.to_string(),
             tool_call_id: tool_call_id.clone(),
@@ -896,6 +993,7 @@ pub(super) async fn run_tool_dispatch(
             error: None,
             duration_ms: None,
             execution_duration_ms: None,
+            error_category: None,
         })
         .await;
         let tool_span_id =
@@ -940,6 +1038,8 @@ pub(super) async fn run_tool_dispatch(
                         "tool_use_id": tool_id,
                         "loop_skipped": true,
                         "repeat_count": count,
+                        "rejected": true,
+                        "error_category": ToolCallErrorCategory::RejectedLoop.as_str(),
                     })),
                 ));
                 if ctx.tool_format == "native" {
@@ -968,6 +1068,7 @@ pub(super) async fn run_tool_dispatch(
                     )),
                     duration_ms: Some(tool_started_at.elapsed().as_millis() as u64),
                     execution_duration_ms: None,
+                    error_category: Some(ToolCallErrorCategory::RejectedLoop),
                 })
                 .await;
                 continue;
@@ -983,44 +1084,66 @@ pub(super) async fn run_tool_dispatch(
         };
 
         let tool_start = std::time::Instant::now();
-        let (is_rejected, result_text) = if let Some(fixture) = replay_hit {
-            (fixture.is_rejected, fixture.result.clone())
-        } else {
-            // Reuse the parallel pre-fetch result when present.
-            let exec_result = if let Some(cached) = parallel_results.remove(&tc_index) {
-                cached
+        let (is_rejected, result_text, dispatch_error_category) =
+            if let Some(fixture) = replay_hit {
+                let category = fixture
+                    .is_rejected
+                    .then_some(ToolCallErrorCategory::PermissionDenied);
+                (fixture.is_rejected, fixture.result.clone(), category)
             } else {
-                dispatch_tool_execution(
-                    tool_name,
-                    &tool_args,
-                    ctx.tools_val,
-                    ctx.bridge.as_ref(),
-                    ctx.tool_retries,
-                    ctx.tool_backoff_ms,
-                )
-                .await
-            };
+                // Reuse the parallel pre-fetch result when present.
+                let exec_result = if let Some(cached) = parallel_results.remove(&tc_index) {
+                    cached
+                } else {
+                    dispatch_tool_execution(
+                        tool_name,
+                        &tool_args,
+                        ctx.tools_val,
+                        ctx.bridge.as_ref(),
+                        ctx.tool_retries,
+                        ctx.tool_backoff_ms,
+                    )
+                    .await
+                };
 
-            let rejected = matches!(
-                &exec_result,
-                Err(VmError::CategorizedError {
-                    category: ErrorCategory::ToolRejected,
-                    ..
-                })
-            ) || exec_result.as_ref().ok().is_some_and(is_denied_tool_result);
-            let text = match &exec_result {
-                Ok(val) => render_tool_result(val),
-                Err(VmError::CategorizedError {
-                    message,
-                    category: ErrorCategory::ToolRejected,
-                }) => render_tool_result(&denied_tool_result(
-                    tool_name,
-                    format!("{message} Do not retry this tool."),
-                )),
-                Err(error) => format!("Error: {error}"),
+                let rejected = matches!(
+                    &exec_result,
+                    Err(VmError::CategorizedError {
+                        category: ErrorCategory::ToolRejected,
+                        ..
+                    })
+                ) || exec_result.as_ref().ok().is_some_and(is_denied_tool_result);
+                // Categorize before flattening to a string. `ToolRejected`
+                // (or a denied dict) collapses to `permission_denied`; any
+                // other categorized error projects through `from_internal`;
+                // anything else is generic `tool_error`. This is the only
+                // emission site that has the original `VmError` in scope —
+                // downstream code only sees the rendered text.
+                let category: Option<ToolCallErrorCategory> = match &exec_result {
+                    Ok(val) => is_denied_tool_result(val)
+                        .then_some(ToolCallErrorCategory::PermissionDenied),
+                    Err(VmError::CategorizedError {
+                        category: ErrorCategory::ToolRejected,
+                        ..
+                    }) => Some(ToolCallErrorCategory::PermissionDenied),
+                    Err(VmError::CategorizedError { category: cat, .. }) => {
+                        Some(ToolCallErrorCategory::from_internal(cat))
+                    }
+                    Err(_) => Some(ToolCallErrorCategory::ToolError),
+                };
+                let text = match &exec_result {
+                    Ok(val) => render_tool_result(val),
+                    Err(VmError::CategorizedError {
+                        message,
+                        category: ErrorCategory::ToolRejected,
+                    }) => render_tool_result(&denied_tool_result(
+                        tool_name,
+                        format!("{message} Do not retry this tool."),
+                    )),
+                    Err(error) => format!("Error: {error}"),
+                };
+                (rejected, text, category)
             };
-            (rejected, text)
-        };
 
         if is_rejected && !state.rejected_tools.contains(&tool_name.to_string()) {
             state.rejected_tools.push(tool_name.to_string());
@@ -1079,11 +1202,25 @@ pub(super) async fn run_tool_dispatch(
 
         let execution_duration_ms = tool_start.elapsed().as_millis() as u64;
         let duration_ms = tool_started_at.elapsed().as_millis() as u64;
+        // Treat "Error:" / "ERROR:" prefixes (from a non-rejected
+        // dispatch error or a tool that returned an error string) as a
+        // failure on the wire — they were already classified as `error`
+        // in the per-iteration tool_results aggregate (see `tool_status`
+        // below). Pre-categorization at dispatch time supplies the
+        // `error_category`; if that's unset (replay path with no
+        // metadata), fall back to `ToolError` for the prefix case.
+        let final_status_failed =
+            is_rejected || result_text.starts_with("Error:") || result_text.starts_with("ERROR:");
+        let final_error_category = if final_status_failed {
+            dispatch_error_category.or(Some(ToolCallErrorCategory::ToolError))
+        } else {
+            None
+        };
         super::emit_agent_event(&AgentEvent::ToolCallUpdate {
             session_id: ctx.session_id.to_string(),
             tool_call_id: tool_call_id.clone(),
             tool_name: tool_name.to_string(),
-            status: if is_rejected {
+            status: if final_status_failed {
                 ToolCallStatus::Failed
             } else {
                 ToolCallStatus::Completed
@@ -1092,13 +1229,14 @@ pub(super) async fn run_tool_dispatch(
                 "text": result_text,
                 "tool_use_id": tool_id,
             })),
-            error: if is_rejected {
+            error: if final_status_failed {
                 Some(result_text.clone())
             } else {
                 None
             },
             duration_ms: Some(duration_ms),
             execution_duration_ms: Some(execution_duration_ms),
+            error_category: final_error_category,
         })
         .await;
 
@@ -1162,16 +1300,21 @@ pub(super) async fn run_tool_dispatch(
             "rejected": is_rejected,
         }));
 
+        let mut transcript_metadata = serde_json::json!({
+            "tool_name": tool_name,
+            "tool_use_id": tool_id,
+            "rejected": is_rejected,
+        });
+        if let Some(cat) = final_error_category {
+            transcript_metadata["error_category"] =
+                serde_json::Value::String(cat.as_str().to_string());
+        }
         state.transcript_events.push(transcript_event(
             "tool_execution",
             "tool",
             "internal",
             &result_text,
-            Some(serde_json::json!({
-                "tool_name": tool_name,
-                "tool_use_id": tool_id,
-                "rejected": is_rejected,
-            })),
+            Some(transcript_metadata),
         ));
 
         if is_rejected {


### PR DESCRIPTION
Closes #690.

## Summary
- New `ToolCallErrorCategory` wire enum on `AgentEvent::ToolCallUpdate` with snake_case variants: `schema_validation`, `tool_error`, `mcp_server_error`, `host_bridge_error`, `permission_denied`, `rejected_loop`, `timeout`, `network`, `cancelled`, `unknown`. Paired with the existing free-form `error` string.
- Every failure path inside `run_tool_dispatch` now categorizes its emission: schema validation, `__parse_error` short-circuit, capability-policy denial, dynamic permission denial, host `session/request_permission` denial, pre-tool hook deny, the loop-detector skip, and the post-dispatch completion/rejection branch (which threads the original `VmError` through `ToolCallErrorCategory::from_internal`).
- Each early-failure path now emits a `ToolCall(Pending)` + `ToolCallUpdate(Failed)` pair so clients see a consistent two-event lifecycle for rejected calls instead of silence.
- The category is mirrored on the `tool_execution` transcript event metadata so replay engines (and integration tests) see the same classification without subscribing to live events.
- ACP adapter forwards the new field as `errorCategory` (camelCase), omitted when `None`.

## Categorization map (post-dispatch branch)
- `Err(VmError::CategorizedError { category: ToolRejected, .. })` → `permission_denied`
- `Err(VmError::CategorizedError { category, .. })` → `from_internal(category)` (`Auth/EgressBlocked/NotFound/CircuitOpen/Generic` → `host_bridge_error`; transient family → `network`; etc.)
- `Err(_other)` → `tool_error`
- `Ok(denied_dict)` → `permission_denied`
- `result_text.starts_with("Error:") || "ERROR:"` → `tool_error` fallback (was previously emitted as `Completed`; now `Failed` to match the existing `tool_status="error"` aggregate)

## Test plan
- [x] `cargo test -p harn-vm --lib agent_events` (8/8 — enum serde, `from_internal` mapping, event-field round-trip)
- [x] `cargo test -p harn-vm --lib tool_dispatch_categories` (5/5 — schema_validation, parse_error, permission_denied via unknown tool, rejected_loop via loop detector, tool_error via builtin error string)
- [x] `cargo test -p harn-serve --lib adapters::acp::events` (5/5 — `errorCategory` camelCase serialization + omitted-when-none)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo run --bin harn -- test conformance` (694/694)
- [x] Full `cargo test -p harn-vm --lib` — only pre-existing network-dependent failures (egress-blocked, etc.); no new failures.

## Out of scope
- `parse_aborted` category (deferred per the issue; the enum is extensible).
- Display/rendering — owned by burin-labs/burin-code#339 children.

## Notes
- Integration tests assert against `result["transcript"]["events"]` rather than the global sink registry. `agent_events::reset_all_sinks()` (called by `reset_thread_local_state` in unrelated tests) wipes session-scoped sinks process-wide; the transcript travels back via the loop's return value and is unaffected.
- `mcp_server_error` and `host_bridge_error` have no in-tree producer to drive end-to-end without a fake bridge — the wire enum is exercised via the `from_internal` unit test instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)