### PR TITLE
[codex] Strengthen connector sunset parity checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -516,9 +516,12 @@ granular archaeology.
   generic webhook connector with HMAC verification, A2A push, stream
   ingress, raw-body access, and signing primitives stay in core. Adds a
   `Rust connectors → Harn packages` migration guide under `docs/migrations/`
-  and deprecation banners on each affected connector reference page. No
-  Rust connector business logic has been removed; the timeline for that
-  removal is gated on the prerequisites called out on issue #446.
+  and deprecation banners on each affected connector reference page.
+  `harn connector check` fixtures can also assert dedupe keys, signature
+  state, provider-payload subsets, and immediate-response status/body so
+  first-party pure-Harn connector repos can pin Rust payload-shape parity
+  in CI. No Rust connector business logic has been removed; the timeline
+  for that removal is gated on the prerequisites called out on issue #446.
 
 ### Removed
 

--- a/conformance/fixtures/connectors/contract-v1/github/harn.toml
+++ b/conformance/fixtures/connectors/contract-v1/github/harn.toml
@@ -13,8 +13,11 @@ version = 1
 provider = "github"
 name = "issues opened webhook"
 kind = "webhook"
-headers = { "x-github-event" = "issues", "content-type" = "application/json" }
-body_json = { id = "evt-gh-1", action = "opened", issue = { number = 42, title = "Contract drift" } }
+headers = { "X-GitHub-Event" = "issues", "X-GitHub-Delivery" = "delivery-gh-1", "content-type" = "application/json" }
+body_json = { id = "evt-gh-1", action = "opened", installation = { id = 101 }, issue = { number = 42, title = "Contract drift" } }
 expect_type = "event"
-expect_kind = "github.issues.opened"
+expect_kind = "issues"
+expect_dedupe_key = "delivery-gh-1"
+expect_signature_state = "verified"
+expect_payload_contains = { provider = "github", event = "issues", action = "opened", delivery_id = "delivery-gh-1", installation_id = 101, issue = { number = 42, title = "Contract drift" } }
 expect_event_count = 1

--- a/conformance/fixtures/connectors/contract-v1/github/lib.harn
+++ b/conformance/fixtures/connectors/contract-v1/github/lib.harn
@@ -36,19 +36,15 @@ pub fn normalize_inbound(raw) {
   event_log_emit(
     "connectors.github.contract",
     "normalize",
-    {event: raw.headers["x-github-event"], token: token},
+    {event: raw.headers["X-GitHub-Event"] ?? raw.headers["x-github-event"], token: token},
   )
   return {
     type: "event",
     event: {
-    kind: "github.issues." + body.action,
-    dedupe_key: "github:" + body.id,
-    payload: {
-    delivery_id: body.id,
-    issue_number: body.issue.number,
-    title: body.issue.title,
-    binding_id: raw.binding_id,
-  },
+    kind: raw.headers["X-GitHub-Event"] ?? raw.headers["x-github-event"],
+    dedupe_key: raw.headers["X-GitHub-Delivery"] ?? raw.headers["x-github-delivery"],
+    payload: body,
+    signature_status: {state: "verified"},
   },
   }
 }

--- a/conformance/fixtures/connectors/contract-v1/linear/harn.toml
+++ b/conformance/fixtures/connectors/contract-v1/linear/harn.toml
@@ -13,8 +13,11 @@ version = 1
 provider = "linear"
 name = "issue update webhook"
 kind = "webhook"
-headers = { "content-type" = "application/json" }
-body_json = { id = "lin-evt-1", type = "Issue", action = "update", data = { id = "ISS-1", title = "Contract fixture" } }
+headers = { "Linear-Delivery" = "delivery-linear-1", "content-type" = "application/json" }
+body_json = { id = "lin-evt-1", type = "Issue", action = "update", organizationId = "org-1", webhookTimestamp = 1715000000000, webhookId = "wh-1", data = { id = "ISS-1", title = "Contract fixture" }, updatedFrom = { title = "Old title" } }
 expect_type = "event"
-expect_kind = "linear.issue.update"
+expect_kind = "issue.update"
+expect_dedupe_key = "delivery-linear-1"
+expect_signature_state = "verified"
+expect_payload_contains = { provider = "linear", event = "issue", action = "update", delivery_id = "delivery-linear-1", organization_id = "org-1", webhook_id = "wh-1", issue = { id = "ISS-1", title = "Contract fixture" } }
 expect_event_count = 1

--- a/conformance/fixtures/connectors/contract-v1/linear/lib.harn
+++ b/conformance/fixtures/connectors/contract-v1/linear/lib.harn
@@ -20,9 +20,10 @@ pub fn normalize_inbound(raw) {
   return {
     type: "event",
     event: {
-    kind: "linear.issue." + body.action,
-    dedupe_key: "linear:" + body.id,
-    payload: {id: body.data.id, title: body.data.title, action: body.action},
+    kind: "issue." + body.action,
+    dedupe_key: raw.headers["Linear-Delivery"],
+    payload: body,
+    signature_status: {state: "verified"},
   },
   }
 }

--- a/conformance/fixtures/connectors/contract-v1/notion/harn.toml
+++ b/conformance/fixtures/connectors/contract-v1/notion/harn.toml
@@ -13,8 +13,11 @@ version = 1
 provider = "notion"
 name = "page webhook"
 kind = "webhook"
-headers = { "content-type" = "application/json" }
-body_json = { id = "notion-evt-1", type = "page.updated", page_id = "page-1" }
+headers = { "request-id" = "req-notion-1", "content-type" = "application/json" }
+body_json = { id = "notion-evt-1", type = "page.content_updated", workspace_id = "ws-1", subscription_id = "sub-1", integration_id = "int-1", entity = { id = "page-1", type = "page" }, api_version = "2022-06-28" }
 expect_type = "event"
-expect_kind = "notion.page.updated"
+expect_kind = "page.content_updated"
+expect_dedupe_key = "notion:page-1"
+expect_signature_state = "verified"
+expect_payload_contains = { provider = "notion", event = "page.content_updated", workspace_id = "ws-1", request_id = "req-notion-1", subscription_id = "sub-1", integration_id = "int-1", entity_id = "page-1", entity_type = "page", api_version = "2022-06-28" }
 expect_event_count = 1

--- a/conformance/fixtures/connectors/contract-v1/notion/lib.harn
+++ b/conformance/fixtures/connectors/contract-v1/notion/lib.harn
@@ -25,9 +25,10 @@ pub fn normalize_inbound(raw) {
   return {
     type: "event",
     event: {
-    kind: "notion." + body.type,
-    dedupe_key: "notion:" + body.id,
-    payload: {id: body.id, page_id: body.page_id},
+    kind: body.type,
+    dedupe_key: "notion:" + body.entity.id,
+    payload: body,
+    signature_status: {state: "verified"},
   },
   }
 }

--- a/conformance/fixtures/connectors/contract-v1/slack/harn.toml
+++ b/conformance/fixtures/connectors/contract-v1/slack/harn.toml
@@ -16,6 +16,8 @@ kind = "webhook"
 headers = { "content-type" = "application/json" }
 body_json = { type = "url_verification", challenge = "challenge-token" }
 expect_type = "immediate_response"
+expect_response_status = 200
+expect_response_body = "challenge-token"
 expect_event_count = 0
 
 [[connector_contract.fixtures]]
@@ -23,7 +25,10 @@ provider = "slack"
 name = "message event"
 kind = "webhook"
 headers = { "content-type" = "application/json" }
-body_json = { type = "event_callback", event_id = "Ev1", event = { type = "message", text = "hello", channel = "C1" } }
+body_json = { type = "event_callback", event_id = "Ev1", team_id = "T1", api_app_id = "A1", event = { type = "message", text = "hello", channel = "C1", channel_type = "channel", user = "U1", ts = "1710000000.000100", event_ts = "1710000000.000100" } }
 expect_type = "event"
-expect_kind = "slack.message"
+expect_kind = "message.channels"
+expect_dedupe_key = "Ev1"
+expect_signature_state = "verified"
+expect_payload_contains = { provider = "slack", event = "message.channels", event_id = "Ev1", team_id = "T1", api_app_id = "A1", channel_id = "C1", channel_type = "channel", text = "hello", user = "U1" }
 expect_event_count = 1

--- a/conformance/fixtures/connectors/contract-v1/slack/lib.harn
+++ b/conformance/fixtures/connectors/contract-v1/slack/lib.harn
@@ -31,9 +31,14 @@ pub fn normalize_inbound(raw) {
   return {
     type: "event",
     event: {
-    kind: "slack." + body.event.type,
-    dedupe_key: "slack:" + body.event_id,
-    payload: {event_id: body.event_id, event: body.event},
+    kind: if body.event.type == "message" && body.event.channel_type == "channel" {
+    "message.channels"
+  } else {
+    body.event.type
+  },
+    dedupe_key: body.event_id,
+    payload: body,
+    signature_status: {state: "verified"},
   },
   }
 }

--- a/crates/harn-cli/src/commands/connector.rs
+++ b/crates/harn-cli/src/commands/connector.rs
@@ -525,6 +525,7 @@ fn validate_normalize_result(
                     ));
                 }
             }
+            validate_event_expectations(fixture, event.as_ref())?;
             ("event", 1)
         }
         harn_vm::ConnectorNormalizeResult::Batch(events) => {
@@ -538,9 +539,13 @@ fn validate_normalize_result(
                     ));
                 }
             }
+            for event in events {
+                validate_event_expectations(fixture, event)?;
+            }
             ("batch", events.len())
         }
-        harn_vm::ConnectorNormalizeResult::ImmediateResponse { events, .. } => {
+        harn_vm::ConnectorNormalizeResult::ImmediateResponse { response, events } => {
+            validate_response_expectations(fixture, "immediate_response", response)?;
             if let Some(expected_kind) = fixture.expect_kind.as_deref() {
                 if let Some(event) = events.iter().find(|event| event.kind != expected_kind) {
                     return Err(format!(
@@ -551,9 +556,15 @@ fn validate_normalize_result(
                     ));
                 }
             }
+            for event in events {
+                validate_event_expectations(fixture, event)?;
+            }
             ("immediate_response", events.len())
         }
-        harn_vm::ConnectorNormalizeResult::Reject(_) => ("reject", 0),
+        harn_vm::ConnectorNormalizeResult::Reject(response) => {
+            validate_response_expectations(fixture, "reject", response)?;
+            ("reject", 0)
+        }
     };
 
     if let Some(expected_type) = fixture.expect_type.as_deref() {
@@ -582,6 +593,120 @@ fn validate_normalize_result(
         result_type: result_type.to_string(),
         event_count,
     })
+}
+
+fn validate_event_expectations(
+    fixture: &ConnectorContractFixture,
+    event: &harn_vm::TriggerEvent,
+) -> Result<(), String> {
+    if let Some(expected_dedupe_key) = fixture.expect_dedupe_key.as_deref() {
+        if event.dedupe_key != expected_dedupe_key {
+            return Err(format!(
+                "fixture '{}' expected dedupe_key '{}' but got '{}'",
+                fixture_name(fixture),
+                expected_dedupe_key,
+                event.dedupe_key
+            ));
+        }
+    }
+    if let Some(expected_signature_state) = fixture.expect_signature_state.as_deref() {
+        let signature_state = match &event.signature_status {
+            harn_vm::SignatureStatus::Verified => "verified",
+            harn_vm::SignatureStatus::Unsigned => "unsigned",
+            harn_vm::SignatureStatus::Failed { .. } => "failed",
+        };
+        if signature_state != expected_signature_state {
+            return Err(format!(
+                "fixture '{}' expected signature state '{}' but got '{}'",
+                fixture_name(fixture),
+                expected_signature_state,
+                signature_state
+            ));
+        }
+    }
+    if let Some(expected_payload) = &fixture.expect_payload_contains {
+        let expected = toml_to_json(expected_payload)?;
+        let actual = serde_json::to_value(&event.provider_payload).map_err(|error| {
+            format!(
+                "fixture '{}' failed to serialize provider payload: {error}",
+                fixture_name(fixture)
+            )
+        })?;
+        assert_json_contains(fixture, "provider_payload", &actual, &expected)?;
+    }
+    Ok(())
+}
+
+fn validate_response_expectations(
+    fixture: &ConnectorContractFixture,
+    result_type: &str,
+    response: &harn_vm::ConnectorHttpResponse,
+) -> Result<(), String> {
+    if let Some(expected_status) = fixture.expect_response_status {
+        if response.status != expected_status {
+            return Err(format!(
+                "fixture '{}' expected {result_type} HTTP status {} but got {}",
+                fixture_name(fixture),
+                expected_status,
+                response.status
+            ));
+        }
+    }
+    if let Some(expected_body) = &fixture.expect_response_body {
+        let expected = toml_to_json(expected_body)?;
+        if response.body != expected {
+            return Err(format!(
+                "fixture '{}' expected {result_type} body {} but got {}",
+                fixture_name(fixture),
+                expected,
+                response.body
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn assert_json_contains(
+    fixture: &ConnectorContractFixture,
+    path: &str,
+    actual: &JsonValue,
+    expected: &JsonValue,
+) -> Result<(), String> {
+    match expected {
+        JsonValue::Object(expected_map) => {
+            let actual_map = actual.as_object().ok_or_else(|| {
+                format!(
+                    "fixture '{}' expected {path} to be an object containing {} but got {}",
+                    fixture_name(fixture),
+                    expected,
+                    actual
+                )
+            })?;
+            for (key, expected_value) in expected_map {
+                let actual_value = actual_map.get(key).ok_or_else(|| {
+                    format!(
+                        "fixture '{}' expected {path}.{key} to exist in {}",
+                        fixture_name(fixture),
+                        actual
+                    )
+                })?;
+                assert_json_contains(
+                    fixture,
+                    &format!("{path}.{key}"),
+                    actual_value,
+                    expected_value,
+                )?;
+            }
+            Ok(())
+        }
+        _ if actual == expected => Ok(()),
+        _ => Err(format!(
+            "fixture '{}' expected {path} to contain {} but got {}",
+            fixture_name(fixture),
+            expected,
+            actual
+        )),
+    }
 }
 
 fn fixture_name(fixture: &ConnectorContractFixture) -> String {

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -1015,6 +1015,16 @@ pub struct ConnectorContractFixture {
     #[serde(default)]
     pub expect_kind: Option<String>,
     #[serde(default)]
+    pub expect_dedupe_key: Option<String>,
+    #[serde(default)]
+    pub expect_signature_state: Option<String>,
+    #[serde(default)]
+    pub expect_payload_contains: Option<toml::Value>,
+    #[serde(default)]
+    pub expect_response_status: Option<u16>,
+    #[serde(default)]
+    pub expect_response_body: Option<toml::Value>,
+    #[serde(default)]
     pub expect_event_count: Option<usize>,
     #[serde(default)]
     pub expect_error_contains: Option<String>,

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -93,6 +93,35 @@ secrets = { signing_secret = "github/webhook-secret" }
     manifest
 }
 
+fn github_harn_override_manifest(orchestrator_block: Option<&str>) -> String {
+    let mut manifest = r#"
+[package]
+name = "fixture"
+
+[exports]
+handlers = "lib.harn"
+
+[[providers]]
+id = "github"
+connector = { harn = "github_connector.harn" }
+
+[[triggers]]
+id = "github-new-issue"
+kind = "webhook"
+provider = "github"
+match = { events = ["issues"] }
+handler = "handlers::on_issue"
+secrets = { signing_secret = "github/webhook-secret" }
+"#
+    .to_string();
+    if let Some(block) = orchestrator_block {
+        manifest.push('\n');
+        manifest.push_str(block);
+        manifest.push('\n');
+    }
+    manifest
+}
+
 fn handler_module() -> &'static str {
     r#"
 import "std/triggers"
@@ -101,6 +130,19 @@ pub fn on_issue(event: TriggerEvent) {
   log(event.kind)
 }
 "#
+}
+
+fn github_marker_handler_module(marker_path: &Path) -> String {
+    format!(
+        r#"
+import "std/triggers"
+
+pub fn on_issue(event: TriggerEvent) {{
+  write_file({marker:?}, event.kind)
+}}
+"#,
+        marker = marker_path.display().to_string()
+    )
 }
 
 fn slack_manifest(orchestrator_block: Option<&str>) -> String {
@@ -350,6 +392,51 @@ pub fn call(method, args) {
     }
   }
 
+  throw "method_not_found:" + method
+}
+"#
+}
+
+fn github_override_connector_module() -> &'static str {
+    r#"
+pub fn provider_id() {
+  return "github"
+}
+
+pub fn kinds() {
+  return ["webhook"]
+}
+
+pub fn payload_schema() {
+  return "GitHubEventPayload"
+}
+
+pub fn init(_ctx) {
+  event_log_emit("connectors.github.override", "init", {provider: "github"})
+}
+
+pub fn activate(bindings) {
+  metrics_inc("github_override_activate_bindings", len(bindings))
+}
+
+pub fn normalize_inbound(raw) {
+  let body = raw.body_json ?? json_parse(raw.body_text)
+  event_log_emit("connectors.github.override", "normalize", {
+    id: body.id,
+    action: body.action,
+  })
+  return {
+    type: "event",
+    event: {
+      kind: raw.headers["X-GitHub-Event"] ?? raw.headers["x-github-event"],
+      dedupe_key: "harn-github:" + body.id,
+      payload: body,
+      signature_status: {state: "unsigned"},
+    },
+  }
+}
+
+pub fn call(method, _args) {
   throw "method_not_found:" + method
 }
 "#
@@ -955,6 +1042,71 @@ async fn github_webhook_delivery_is_accepted_and_persisted() {
         snapshot.contains("\"dispatched\": 1"),
         "snapshot={snapshot}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn github_provider_prefers_configured_harn_connector_over_deprecated_rust_default() {
+    let _lock = lock_orchestrator_tests();
+    let temp = TempDir::new().unwrap();
+    let marker_path = temp.path().join("github-override-handler.txt");
+    write_file(
+        temp.path(),
+        "harn.toml",
+        &github_harn_override_manifest(None),
+    );
+    write_file(
+        temp.path(),
+        "lib.harn",
+        &github_marker_handler_module(&marker_path),
+    );
+    write_file(
+        temp.path(),
+        "github_connector.harn",
+        github_override_connector_module(),
+    );
+
+    let envs = [
+        ("HARN_SECRET_PROVIDERS", "env"),
+        ("HARN_SECRET_GITHUB_WEBHOOK_SECRET", "override-secret"),
+    ];
+    let mut process = spawn_orchestrator(&temp, &[], &envs);
+    let base_url = process.wait_for_listener_url();
+
+    let body = serde_json::to_vec(&serde_json::json!({
+        "id": "evt-gh-override-1",
+        "action": "opened",
+        "issue": {"number": 42, "title": "Harn connector override"}
+    }))
+    .unwrap();
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/triggers/github-new-issue"))
+        .header(CONTENT_TYPE, "application/json")
+        .header("X-GitHub-Event", "issues")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_status(response, StatusCode::OK).await;
+
+    wait_for_path(&marker_path, EVENT_FAIL_FAST_TIMEOUT);
+    let marker = fs::read_to_string(&marker_path).unwrap();
+    assert_eq!(marker, "issues");
+
+    send_sigterm(&process.child);
+    let status = wait_for_exit_async(&mut process.child).await;
+    let stderr = process.join_stderr();
+    assert!(status.success(), "status={status} stderr={stderr}");
+    assert!(
+        !stderr.contains("deprecated Rust-side connector"),
+        "Harn connector overrides must suppress Rust sunset warnings; stderr={stderr}"
+    );
+
+    let lifecycle = read_topic_events(&temp, "connectors.github.override").await;
+    let lifecycle_kinds: Vec<_> = lifecycle
+        .iter()
+        .map(|(_, event)| event.kind.as_str())
+        .collect();
+    assert_eq!(lifecycle_kinds, vec!["init", "normalize"]);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/harn-vm/src/connectors/testkit.rs
+++ b/crates/harn-vm/src/connectors/testkit.rs
@@ -516,6 +516,27 @@ pub fn linear_issue_update_fixture(secret: &str, received_at: OffsetDateTime) ->
     WebhookFixture { raw, body }
 }
 
+pub fn notion_page_content_updated_fixture(
+    secret: &str,
+    received_at: OffsetDateTime,
+) -> WebhookFixture {
+    let body = br#"{"id":"evt_1","type":"page.content_updated","workspace_id":"ws_1","subscription_id":"sub_1","integration_id":"int_1","entity":{"id":"page_1","type":"page"},"api_version":"2022-06-28"}"#.to_vec();
+    let mut raw = RawInbound::new(
+        "webhook",
+        BTreeMap::from([
+            ("content-type".to_string(), "application/json".to_string()),
+            (
+                "x-notion-signature".to_string(),
+                format!("sha256={}", hmac_sha256_hex(secret.as_bytes(), &body)),
+            ),
+            ("request-id".to_string(), "req_1".to_string()),
+        ]),
+        body.clone(),
+    );
+    raw.received_at = received_at;
+    WebhookFixture { raw, body }
+}
+
 pub fn webhook_binding(
     provider: impl Into<String>,
     binding_id: impl Into<String>,
@@ -681,5 +702,7 @@ mod tests {
         assert!(slack.raw.headers["x-slack-signature"].starts_with("v0="));
         let linear = linear_issue_update_fixture("topsecret", received_at);
         assert_eq!(linear.raw.headers["linear-signature"].len(), 64);
+        let notion = notion_page_content_updated_fixture("topsecret", received_at);
+        assert!(notion.raw.headers["x-notion-signature"].starts_with("sha256="));
     }
 }

--- a/docs/src/connectors/authoring.md
+++ b/docs/src/connectors/authoring.md
@@ -233,6 +233,8 @@ kind = "webhook"
 headers = { "content-type" = "application/json" }
 body_json = { type = "url_verification", challenge = "challenge-token" }
 expect_type = "immediate_response"
+expect_response_status = 200
+expect_response_body = "challenge-token"
 expect_event_count = 0
 ```
 
@@ -250,6 +252,11 @@ Fixture fields:
 | `body_json` | JSON request body encoded as TOML |
 | `expect_type` | Optional expected NormalizeResult type: `event`, `batch`, `immediate_response`, or `reject` |
 | `expect_kind` | Optional expected normalized event kind |
+| `expect_dedupe_key` | Optional exact normalized event dedupe key |
+| `expect_signature_state` | Optional normalized signature state: `verified`, `unsigned`, or `failed` |
+| `expect_payload_contains` | Optional TOML/JSON subset that must be present in the serialized `provider_payload`; use this for Rust-shape parity fixtures |
+| `expect_response_status` | Optional HTTP status expected for `immediate_response` or `reject` results |
+| `expect_response_body` | Optional exact body expected for `immediate_response` or `reject` results |
 | `expect_event_count` | Optional expected number of normalized events |
 | `expect_error_contains` | Optional substring expected in a deterministic `normalize_inbound` error, useful for proving denied effects fail without touching real services |
 

--- a/docs/src/connectors/catalog.md
+++ b/docs/src/connectors/catalog.md
@@ -192,6 +192,8 @@ headers = { "content-type" = "application/json" }
 body_json = { id = "evt-1", type = "thing.created" }
 expect_type = "event"
 expect_kind = "acme.thing.created"
+expect_dedupe_key = "evt-1"
+expect_payload_contains = { provider = "acme", event = "thing.created", id = "evt-1" }
 expect_event_count = 1
 ```
 

--- a/docs/src/connectors/testkit.md
+++ b/docs/src/connectors/testkit.md
@@ -10,7 +10,7 @@ testkit pieces they need:
 ```rust,ignore
 use harn_vm::connectors::testkit::{
     ConnectorTestkit, HttpMockGuard, HttpMockResponse, MemorySecretProvider,
-    github_ping_fixture, scoped_secret_id,
+    github_ping_fixture, notion_page_content_updated_fixture, scoped_secret_id,
 };
 ```
 
@@ -76,6 +76,7 @@ Webhook fixtures cover common first-party shapes:
 - `github_ping_fixture(secret, received_at)`
 - `slack_message_fixture(secret, timestamp, received_at)`
 - `linear_issue_update_fixture(secret, received_at)`
+- `notion_page_content_updated_fixture(secret, received_at)`
 
 They return a `WebhookFixture` containing the signed `RawInbound` and original
 body bytes. Use `.with_binding(...)` and `.with_tenant(...)` to attach runtime


### PR DESCRIPTION
## Summary

- strengthens `harn connector check` contract fixtures with assertions for dedupe keys, signature state, provider-payload subsets, and immediate response status/body
- updates the bundled GitHub, Slack, Linear, and Notion connector-contract fixtures to pin Rust-compatible payload shapes
- adds a Notion signed webhook testkit fixture and an orchestrator regression test proving configured Harn provider connectors override deprecated Rust defaults

## Verification

- `cargo run --quiet --bin harn -- connector check conformance/fixtures/connectors/contract-v1/github --provider github --json`
- `cargo run --quiet --bin harn -- connector check conformance/fixtures/connectors/contract-v1/slack --provider slack --json`
- `cargo run --quiet --bin harn -- connector check conformance/fixtures/connectors/contract-v1/linear --provider linear --json`
- `cargo run --quiet --bin harn -- connector check conformance/fixtures/connectors/contract-v1/notion --provider notion --run-poll-tick --json`
- `cargo test -p harn-vm connectors::testkit::tests::webhook_fixtures_include_provider_signatures`
- `cargo test -p harn-vm connectors::harn_module::tests::pure_harn_sunset_connectors_preserve_builtin_provider_payload_shapes`
- `cargo test -p harn-cli --test orchestrator_http github_provider_prefers_configured_harn_connector_over_deprecated_rust_default -- --nocapture`
- pre-commit hook: `cargo fmt`, staged Harn format/lint, workspace clippy, markdown lint
- pre-push hook: workspace nextest suite, 2,433 tests passed; affected Harn format/lint; markdown lint

Closes #446
