### PR TITLE
[codex] Document connector epic closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ granular archaeology.
 
 ### Added
 
+- **Connector epic closure docs (#151).** Added a connector architecture
+  status page that records the current core/external-package boundary,
+  maps the old Rust-provider library epic to the shipped core substrate, and
+  points provider-specific work at the pure-Harn package repos plus #350/#446.
+  Updated generic webhook docs to describe the current route-backed listener,
+  raw-body `TriggerEvent` path, and durable inbox dedupe instead of the old
+  O-02/T-09 deferrals.
 - **Tool-call timing on ACP `tool_call_update` (#689).** Terminal
   `tool_call_update` events now carry `durationMs` (the parse-to-finish
   total — model emits the call → tool result is appended) and

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -45,6 +45,7 @@
 - [Trigger dispatcher](./triggers/dispatcher.md)
 - [Trigger observability in the action graph](./observability/triggers-in-action-graph.md)
 - [Connector authoring](./connectors/authoring.md)
+- [Connector architecture status](./connectors/architecture.md)
 - [Connector catalog](./connectors/catalog.md)
 - [Connector testkit](./connectors/testkit.md)
 - [Trigger registry](./triggers/registry.md)

--- a/docs/src/connectors/architecture.md
+++ b/docs/src/connectors/architecture.md
@@ -1,0 +1,94 @@
+# Connector architecture status
+
+Issue [#151](https://github.com/burin-labs/harn/issues/151) originally tracked
+the full Rust-side connector library: shared connector traits, generic
+webhooks, cron, GitHub, Slack, Linear, Notion, OAuth helpers, catalog docs, and
+provider-specific runtime behavior. That plan has since been split into a
+smaller core substrate plus pure-Harn provider packages.
+
+This page is the current source of truth for what belongs in this repository
+after the connector pivot.
+
+## Core responsibilities
+
+Harn core owns the primitives that every connector implementation needs:
+
+- the `Connector` trait, registry, provider catalog, and Harn module adapter
+- raw HTTP ingress into `RawInbound`, including original body bytes and headers
+- `TriggerEvent` normalization, raw-body exposure, dispatcher handoff, and
+  inbox/outbox dedupe
+- signature helpers for raw-body HMAC verification, constant-time comparison,
+  timestamp-window replay checks, and audit events
+- the `cron`, generic `webhook`, `a2a-push`, and stream ingress providers
+- `NormalizeResult` v1 for ack-first webhooks and batched deliveries
+- `poll_tick` scheduling for Harn connector packages
+- connector hot-path effect policy for deterministic `normalize_inbound`
+  exports
+- shared HTTP, encoding, OAuth/connect, package-manager, and testkit surfaces
+  that provider packages compose
+
+Provider-specific business logic should not be added to Harn core unless the
+ticket is explicitly about compatibility or removal of an existing Rust shim.
+
+## External provider packages
+
+Provider business logic now lives in first-party or community Harn packages.
+The first-party package track is:
+
+| Provider | Package repo | Core issue |
+|---|---|---|
+| GitHub | <https://github.com/burin-labs/harn-github-connector> | [#350](https://github.com/burin-labs/harn/issues/350) |
+| Slack | <https://github.com/burin-labs/harn-slack-connector> | [#350](https://github.com/burin-labs/harn/issues/350) |
+| Linear | <https://github.com/burin-labs/harn-linear-connector> | [#350](https://github.com/burin-labs/harn/issues/350) |
+| Notion | <https://github.com/burin-labs/harn-notion-connector> | [#350](https://github.com/burin-labs/harn/issues/350) |
+| GitLab | <https://github.com/burin-labs/harn-gitlab-connector> | [#305](https://github.com/burin-labs/harn/issues/305) |
+
+Each package should declare connector contract v1 metadata, ship deterministic
+fixtures, and pass:
+
+```sh
+harn connector check .
+```
+
+Poll-based packages should also run:
+
+```sh
+harn connector check . --run-poll-tick
+```
+
+## Rust compatibility shims
+
+The in-repo Rust GitHub, Slack, Linear, and Notion connectors are compatibility
+shims during the pure-Harn package soak. Their sunset and removal are tracked by
+[#446](https://github.com/burin-labs/harn/issues/446).
+
+Do not use #151 as the active tracker for new provider work. Use:
+
+- [#350](https://github.com/burin-labs/harn/issues/350) for the pure-Harn
+  connector pivot.
+- [#446](https://github.com/burin-labs/harn/issues/446) for Rust provider
+  deprecation and removal.
+- The external provider package repos for provider-specific event support,
+  outbound methods, scopes, fixtures, and release readiness.
+- [#305](https://github.com/burin-labs/harn/issues/305) for additional forge
+  connector packages.
+
+## Closure checklist for #151
+
+The old #151 scope is considered complete in this repository when these
+repository-local surfaces exist and are tested:
+
+| Surface | Current home |
+|---|---|
+| Connector trait, registry, and provider metadata | `crates/harn-vm/src/connectors/mod.rs`, `std/triggers::list_providers()` |
+| Raw webhook substrate and signed generic webhook receiver | `crates/harn-vm/src/connectors/webhook/`, `crates/harn-cli/src/commands/orchestrator/listener.rs` |
+| Cron scheduler primitive | `crates/harn-vm/src/connectors/cron/` |
+| Raw body, bytes, HMAC, encoding, and constant-time helpers | `TriggerEvent.raw_body`, stdlib crypto/encoding builtins, `connectors::hmac` |
+| Durable inbox dedupe and dispatcher handoff | `crates/harn-vm/src/triggers/inbox.rs`, `triggers/dispatcher/` |
+| Rate-limit and `Retry-After` behavior | connector clients plus shared HTTP retry/backoff builtins |
+| Harn connector contract, `NormalizeResult`, `poll_tick`, and effect policy | `crates/harn-vm/src/connectors/harn_module.rs`, `crates/harn-lint/src/tests/connector_effect_policy.rs` |
+| Connector package conformance harness | `harn connector check` and connector contract fixtures |
+| Catalog, examples, and migration guidance | `docs/src/connectors/catalog.md`, `examples/triggers/`, `docs/src/migrations/rust-connectors-to-harn-packages.md` |
+
+Future work should update those newer ownership surfaces, not reopen the old
+Rust-provider plugin-library plan.

--- a/docs/src/connectors/authoring.md
+++ b/docs/src/connectors/authoring.md
@@ -437,8 +437,8 @@ checks. The helper enforces the non-negotiable rules from issue `#167`:
 - timestamped schemes reject outside a caller-provided window
 - rejection paths write an audit event to the `audit.signature_verify` topic
 
-The helper currently supports the three MVP HMAC header styles needed by the
-planned connector tickets:
+The helper supports the raw-body HMAC header styles used by the built-in
+compatibility shims and first-party connector packages:
 
 - GitHub: `X-Hub-Signature-256: sha256=<hex>`
 - Notion: `X-Notion-Signature: sha256=<hex>`
@@ -454,12 +454,11 @@ process-local token bucket keyed by `(provider_id, scope_key)`. That keeps the
 first landing trait-pure while giving upcoming provider clients one place to
 enforce per-installation or per-tenant quotas.
 
-## What is deliberately not here yet
+## Ownership boundary
 
-This foundation PR does not define:
-
-- outbound stdlib client wrappers for connector-specific APIs
-- third-party manifest ABI for external connector packages
-
-Those land in follow-up tickets once the shared trait, provider catalog,
-runtime registry, audit, and verification primitives are in place.
+New provider business logic belongs in Harn connector packages, not in new
+Rust-side provider modules. Keep Harn core changes focused on the shared
+runtime substrate: `RawInbound`, `TriggerEvent`, signing helpers, the package
+contract adapter, the connector testkit, effect policy, scheduling, and
+dispatcher integration. Provider packages can then ship event-specific
+normalization and outbound methods on their own release cadence.

--- a/docs/src/connectors/catalog.md
+++ b/docs/src/connectors/catalog.md
@@ -11,6 +11,9 @@ transition plan:
 - Community connectors are Harn packages that export connector contract v1 and
   pass `harn connector check`.
 
+For the architecture and ownership split that closes the old connector-library
+epic, see [Connector architecture status](./architecture.md).
+
 > **Deprecated: Rust-side GitHub, Slack, Linear, and Notion connectors.**
 > Per [#446](https://github.com/burin-labs/harn/issues/446), the Rust-side
 > business logic for these four providers is on a sunset path. New deployments

--- a/docs/src/connectors/webhook.md
+++ b/docs/src/connectors/webhook.md
@@ -1,20 +1,20 @@
 # Generic webhook connector
 
-`GenericWebhookConnector` is the first concrete inbound connector built on top
-of the C-01 `Connector` trait. It accepts generic HTTP webhook deliveries,
-verifies supported HMAC signature conventions against the raw request body, and
-normalizes the delivery into a `TriggerEvent` with the built-in
-`GenericWebhookPayload` shape.
+`GenericWebhookConnector` is the built-in raw HTTP ingress primitive for
+generic webhook deliveries. It verifies supported HMAC signature conventions
+against the raw request body, normalizes the delivery into a `TriggerEvent`
+with the built-in `GenericWebhookPayload` shape, and relies on the
+orchestrator listener for route selection, backpressure, and inbox dedupe.
 
-The current implementation is intentionally small:
+This connector is intentionally provider-neutral:
 
-- activation-only; the O-02 HTTP listener still wires request routing later
+- route-backed ingestion through `harn orchestrator serve`
 - raw-body verification for Standard Webhooks, Stripe-style, and GitHub-style
   signatures
-- `TriggerEvent` normalization with header redaction and provider payload
-  preservation
-- process-local dedupe stub keyed by the manifest `dedupe_key` opt-in until the
-  durable trigger inbox lands
+- `TriggerEvent` normalization with header redaction, `raw_body` retention, and
+  provider payload preservation
+- durable inbox-backed dedupe keyed by the normalized `event.dedupe_key` when
+  the trigger manifest opts into `dedupe_key`
 
 ## Manifest shape
 
@@ -86,22 +86,28 @@ from the binding's optional `webhook.source` override.
 ## Dedupe
 
 If the trigger manifest declares `dedupe_key`, the connector records the
-normalized `event.dedupe_key` in the current inbox dedupe stub and rejects
-replays for the same binding. This is process-local today; durable inbox-backed
-dedupe is still deferred to T-09.
+normalized `event.dedupe_key` in the trigger inbox before dispatch. Replays for
+the same binding are dropped before handler execution, and the dedupe claim is
+durable across orchestrator restarts for the configured retry retention window.
 
 ## Activation and listener integration
 
 The connector's `activate()` hook validates the binding config and reserves
-unique `match.path` values across active bindings. Because O-02 is still
-outstanding, request routing is not implemented here. Until the listener lands:
+unique `match.path` values across active bindings. The orchestrator listener
+maps each incoming HTTP request path to the active trigger binding, passes the
+original bytes through `RawInbound`, applies connector normalization, and then
+appends accepted events to the dispatcher queue.
 
-- a single active binding can call `normalize_inbound(...)` directly
-- multiple active bindings must pass the selected `binding_id` in
-  `RawInbound.metadata.binding_id`
+Direct `normalize_inbound(...)` calls remain useful for tests and embedding.
+When more than one binding is active, callers must pass the selected
+`binding_id` in `RawInbound.metadata.binding_id` so the connector can resolve
+the configured secret and signature variant.
 
 ## Notes and follow-up
 
 - Signature failures are audited even when normalization returns an error.
-- Production TLS handling is owned by the eventual listener, not this connector.
-- Streaming request bodies larger than 10 MiB is still a follow-up item.
+- Production TLS and request-size limits are owned by the orchestrator listener
+  and HTTP server layer, not by this connector.
+- Provider-specific business logic should live in pure-Harn connector packages
+  that compose this raw webhook substrate rather than adding more Rust
+  provider-specific branches here.


### PR DESCRIPTION
## Summary

- add a connector architecture status page that maps the old #151 Rust-provider epic to the shipped core substrate and newer ownership surfaces
- update generic webhook docs to describe current route-backed listener integration, raw-body TriggerEvent handling, and durable inbox dedupe
- refresh connector authoring/catalog docs to steer new provider logic toward pure-Harn packages and #350/#446

Closes #151

## Verification

- make lint-md
- make check-docs-snippets
- pre-commit markdown check
- pre-push markdown check