### PR TITLE
[codex] Close pure-Harn connector pivot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ granular archaeology.
   `reset_all_sinks` / `reset_thread_local_state` calls. Lets host
   embedders observe a single loop's events without contending on the
   shared registry.
+- **Pure-Harn connector pivot closure guard (#350).** Centralizes the
+  deprecated Rust compatibility provider list for GitHub, Slack, Linear,
+  and Notion and adds a VM regression test that permits only core runtime
+  providers or those explicit compatibility shims to remain Rust builtin
+  connectors. The migration and connector reference docs now describe
+  #446 as completed core groundwork under the #350 pivot, with new
+  service connector work directed to pure-Harn packages.
 
 ## v0.7.40
 

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -653,26 +653,19 @@ fn connector_for(
     }
 }
 
-/// Providers whose Rust-side business logic is on the deprecation path tracked
-/// by https://github.com/burin-labs/harn/issues/446. New deployments should
-/// configure the corresponding pure-Harn connector package on the
-/// `[[providers]]` table to silence the orchestrator-startup deprecation
-/// warning.
-const RUST_DEPRECATED_PROVIDERS: &[&str] = &["github", "linear", "notion", "slack"];
-
 /// Returns a one-line deprecation warning when a manifest leaves a Rust-side
 /// provider connector (github/slack/linear/notion) auto-selected. Pointing the
 /// `[[providers]]` table at the corresponding pure-Harn package suppresses the
 /// warning for that provider.
 fn rust_deprecated_provider_warning(provider: &str) -> Option<String> {
-    if !RUST_DEPRECATED_PROVIDERS.contains(&provider) {
+    if !harn_vm::is_rust_provider_connector_compat_provider(provider) {
         return None;
     }
     Some(format!(
         "warning: provider '{provider}' is using the deprecated Rust-side connector. \
          Set `connector = {{ harn = \"...\" }}` on the [[providers]] table to use the \
          pure-Harn `harn-{provider}-connector` package; see \
-         docs/migrations/rust-connectors-to-harn-packages.md (issue #446)."
+         docs/migrations/rust-connectors-to-harn-packages.md (issue #350)."
     ))
 }
 
@@ -2650,8 +2643,8 @@ mod tests {
                 "warning for '{provider}' should suggest the manifest override: {message}",
             );
             assert!(
-                message.contains("issue #446"),
-                "warning for '{provider}' should reference issue #446: {message}",
+                message.contains("issue #350"),
+                "warning for '{provider}' should reference issue #350: {message}",
             );
         }
     }

--- a/crates/harn-vm/src/connectors/mod.rs
+++ b/crates/harn-vm/src/connectors/mod.rs
@@ -71,6 +71,17 @@ pub use webhook::{GenericWebhookConnector, WebhookSignatureVariant};
 
 const OUTBOUND_CONNECTOR_HTTP_TIMEOUT: StdDuration = StdDuration::from_secs(30);
 
+/// Third-party provider ids that still ship Rust-side compatibility
+/// connectors while the pure-Harn connector packages complete their
+/// deprecation soak. New service connectors should be Harn packages that
+/// register through `[[providers]] connector = { harn = "..." }` instead.
+pub const RUST_PROVIDER_CONNECTOR_COMPAT_PROVIDERS: &[&str] =
+    &["github", "linear", "notion", "slack"];
+
+pub fn is_rust_provider_connector_compat_provider(provider: &str) -> bool {
+    RUST_PROVIDER_CONNECTOR_COMPAT_PROVIDERS.contains(&provider)
+}
+
 pub(crate) fn outbound_http_client(user_agent: &'static str) -> reqwest::Client {
     reqwest::Client::builder()
         .user_agent(user_agent)
@@ -2056,6 +2067,36 @@ mod tests {
         assert!(providers.contains(&ProviderId::from("cron")));
         assert!(providers.contains(&ProviderId::from("github")));
         assert!(providers.contains(&ProviderId::from("webhook")));
+    }
+
+    #[test]
+    fn pure_harn_pivot_only_keeps_core_or_compat_builtin_connectors() {
+        let core_runtime_providers = [
+            "a2a-push",
+            "cron",
+            "email",
+            "kafka",
+            "nats",
+            "postgres-cdc",
+            "pulsar",
+            "webhook",
+            "websocket",
+        ];
+
+        for provider in registered_provider_metadata() {
+            if !matches!(provider.runtime, ProviderRuntimeMetadata::Builtin { .. }) {
+                continue;
+            }
+
+            let allowed_core = core_runtime_providers.contains(&provider.provider.as_str());
+            let allowed_compat = is_rust_provider_connector_compat_provider(&provider.provider);
+            assert!(
+                allowed_core || allowed_compat,
+                "provider '{}' is registered as a Rust builtin connector; new service connectors \
+                 must ship as pure-Harn packages and register with connector = {{ harn = \"...\" }}",
+                provider.provider
+            );
+        }
     }
 
     #[test]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -63,13 +63,15 @@ pub use connectors::{
     },
     hmac::verify_hmac_signed,
     install_active_connector_clients, install_active_metrics_registry,
-    load_pending_webhook_handshakes, postprocess_normalized_event, ActivationHandle, ClientError,
-    Connector, ConnectorClient, ConnectorCtx, ConnectorError, ConnectorExportEffectClass,
-    ConnectorHttpResponse, ConnectorMetricsSnapshot, ConnectorNormalizeResult, ConnectorRegistry,
-    GenericWebhookConnector, GitHubConnector, HarnConnectorEffectPolicies, LinearConnector,
-    MetricsRegistry, NotionConnector, PersistedNotionWebhookHandshake, PostNormalizeOutcome,
-    ProviderPayloadSchema, RateLimitConfig, RateLimiterFactory, RawInbound, SlackConnector,
-    StreamConnector, TriggerBinding, TriggerKind, TriggerRegistry, WebhookSignatureVariant,
+    is_rust_provider_connector_compat_provider, load_pending_webhook_handshakes,
+    postprocess_normalized_event, ActivationHandle, ClientError, Connector, ConnectorClient,
+    ConnectorCtx, ConnectorError, ConnectorExportEffectClass, ConnectorHttpResponse,
+    ConnectorMetricsSnapshot, ConnectorNormalizeResult, ConnectorRegistry, GenericWebhookConnector,
+    GitHubConnector, HarnConnectorEffectPolicies, LinearConnector, MetricsRegistry,
+    NotionConnector, PersistedNotionWebhookHandshake, PostNormalizeOutcome, ProviderPayloadSchema,
+    RateLimitConfig, RateLimiterFactory, RawInbound, SlackConnector, StreamConnector,
+    TriggerBinding, TriggerKind, TriggerRegistry, WebhookSignatureVariant,
+    RUST_PROVIDER_CONNECTOR_COMPAT_PROVIDERS,
 };
 pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;

--- a/docs/src/connectors/catalog.md
+++ b/docs/src/connectors/catalog.md
@@ -6,21 +6,20 @@ transition plan:
 
 - Cron, generic webhook, A2A push, and stream ingress are core runtime
   providers.
-- GitHub, Slack, Linear, and Notion still have Rust compatibility providers,
-  but new provider business logic should move to pure-Harn packages.
+- GitHub, Slack, Linear, and Notion still have deprecated Rust compatibility
+  shims, but new provider business logic belongs in pure-Harn packages.
 - Community connectors are Harn packages that export connector contract v1 and
   pass `harn connector check`.
 
 > **Deprecated: Rust-side GitHub, Slack, Linear, and Notion connectors.**
-> Per [#446](https://github.com/burin-labs/harn/issues/446), the Rust-side
-> business logic for these four providers is on a sunset path. New deployments
-> should point manifests at the corresponding pure-Harn packages
-> (`harn-github-connector`, `harn-slack-connector`, `harn-linear-connector`,
-> `harn-notion-connector`) by setting `connector = { harn = "..." }` on the
-> `[[providers]]` table. The Rust shims will keep working until the
-> prerequisite tickets enumerated on issue #446 are complete and the
-> deprecation soak elapses; until then, leaving the manifest unchanged still
-> resolves to the existing Rust connector. See the
+> The [#350](https://github.com/burin-labs/harn/issues/350) pure-Harn connector
+> pivot makes the corresponding pure-Harn packages the default path for new
+> deployments: `harn-github-connector`, `harn-slack-connector`,
+> `harn-linear-connector`, and `harn-notion-connector`. Configure one by setting
+> `connector = { harn = "..." }` on the `[[providers]]` table. The Rust shims
+> remain only as compatibility defaults during the deprecation window; leaving
+> the manifest unchanged still resolves to the existing Rust connector and
+> emits an orchestrator-startup warning. See the
 > [Rust-to-Harn-package migration guide](../migrations/rust-connectors-to-harn-packages.md)
 > for a no-downtime cutover.
 

--- a/docs/src/connectors/github.md
+++ b/docs/src/connectors/github.md
@@ -1,8 +1,8 @@
 # GitHub App connector
 
-> **Deprecated.** The Rust-side `GitHubConnector` is on the sunset path tracked
-> by [#446](https://github.com/burin-labs/harn/issues/446). The recommended
-> implementation is the pure-Harn
+> **Deprecated.** The Rust-side `GitHubConnector` is a compatibility shim under
+> the [#350](https://github.com/burin-labs/harn/issues/350) pure-Harn connector
+> pivot. The recommended implementation is the pure-Harn
 > [`harn-github-connector`](https://github.com/burin-labs/harn-github-connector)
 > package. This page documents the existing Rust connector for users who have
 > not yet migrated; new deployments should configure the Harn package via

--- a/docs/src/connectors/linear.md
+++ b/docs/src/connectors/linear.md
@@ -1,8 +1,8 @@
 # Linear connector
 
-> **Deprecated.** The Rust-side `LinearConnector` is on the sunset path tracked
-> by [#446](https://github.com/burin-labs/harn/issues/446). The recommended
-> implementation is the pure-Harn
+> **Deprecated.** The Rust-side `LinearConnector` is a compatibility shim under
+> the [#350](https://github.com/burin-labs/harn/issues/350) pure-Harn connector
+> pivot. The recommended implementation is the pure-Harn
 > [`harn-linear-connector`](https://github.com/burin-labs/harn-linear-connector)
 > package. This page documents the existing Rust connector for users who have
 > not yet migrated; new deployments should configure the Harn package via

--- a/docs/src/connectors/notion.md
+++ b/docs/src/connectors/notion.md
@@ -1,8 +1,8 @@
 # Notion connector
 
-> **Deprecated.** The Rust-side `NotionConnector` is on the sunset path tracked
-> by [#446](https://github.com/burin-labs/harn/issues/446). The recommended
-> implementation is the pure-Harn
+> **Deprecated.** The Rust-side `NotionConnector` is a compatibility shim under
+> the [#350](https://github.com/burin-labs/harn/issues/350) pure-Harn connector
+> pivot. The recommended implementation is the pure-Harn
 > [`harn-notion-connector`](https://github.com/burin-labs/harn-notion-connector)
 > package. This page documents the existing Rust connector for users who have
 > not yet migrated; new deployments should configure the Harn package via

--- a/docs/src/connectors/slack-events.md
+++ b/docs/src/connectors/slack-events.md
@@ -1,8 +1,8 @@
 # Slack Events connector
 
-> **Deprecated.** The Rust-side `SlackConnector` is on the sunset path tracked
-> by [#446](https://github.com/burin-labs/harn/issues/446). The recommended
-> implementation is the pure-Harn
+> **Deprecated.** The Rust-side `SlackConnector` is a compatibility shim under
+> the [#350](https://github.com/burin-labs/harn/issues/350) pure-Harn connector
+> pivot. The recommended implementation is the pure-Harn
 > [`harn-slack-connector`](https://github.com/burin-labs/harn-slack-connector)
 > package. This page documents the existing Rust connector for users who have
 > not yet migrated; new deployments should configure the Harn package via

--- a/docs/src/migrations/rust-connectors-to-harn-packages.md
+++ b/docs/src/migrations/rust-connectors-to-harn-packages.md
@@ -1,11 +1,12 @@
 # Migrating Rust provider connectors to pure-Harn packages
 
-The Rust-side GitHub, Slack, Linear, and Notion connectors are on the sunset
-path tracked by [#446](https://github.com/burin-labs/harn/issues/446). New
-provider business logic ships in pure-Harn connector packages so that
-Harn Cloud and self-hosted orchestrators can adopt connector fixes,
-new event families, and provider API changes without waiting for a Harn core
-release.
+The Rust-side GitHub, Slack, Linear, and Notion connectors are deprecated
+compatibility shims under the pure-Harn connector pivot tracked by
+[#350](https://github.com/burin-labs/harn/issues/350). The core sunset
+groundwork tracked by [#446](https://github.com/burin-labs/harn/issues/446)
+has landed; new provider business logic ships in pure-Harn connector packages
+so that Harn Cloud and self-hosted orchestrators can adopt connector fixes, new
+event families, and provider API changes without waiting for a Harn core release.
 
 This guide is the no-downtime migration path for an orchestrator that today
 uses one of the Rust-side providers and wants to cut over to the pure-Harn
@@ -123,23 +124,23 @@ supported way to express their respective concerns:
 Pure-Harn provider connectors compose these primitives — they do not
 duplicate them.
 
-## Removal timeline
+## Removal status
 
-Following the work breakdown in [#446](https://github.com/burin-labs/harn/issues/446),
-the Rust-side per-provider business logic for GitHub, Slack, Linear, and
-Notion is removed only after:
+The Harn core prerequisites from [#446](https://github.com/burin-labs/harn/issues/446)
+are complete:
 
-1. The connector contract conformance harness ([#468](https://github.com/burin-labs/harn/issues/468))
-   validates the pure-Harn replacements through the same adapter path
-   Harn Cloud and self-hosted orchestrators use.
-2. `NormalizeResult` v1 ([#464](https://github.com/burin-labs/harn/issues/464)),
-   the `poll_tick` scheduled hook ([#465](https://github.com/burin-labs/harn/issues/465)),
-   and the hot-path effect policy ([#467](https://github.com/burin-labs/harn/issues/467))
-   are in place so the pure-Harn connectors can replace every Rust path.
-3. The OAuth / connect CLI ([#176](https://github.com/burin-labs/harn/issues/176))
-   and package-manager pinning sweep ([#445](https://github.com/burin-labs/harn/issues/445))
-   give first-party connector packages a stable install + auth path.
-4. At least GitHub and Slack have parity fixtures landed in their
-   connector repos before the deprecation banners ship in Harn core.
+- The connector contract conformance harness validates pure-Harn replacements
+  through the same adapter path Harn Cloud and self-hosted orchestrators use.
+- `NormalizeResult` v1, `poll_tick`, hot-path effect policy, transport
+  primitives, structured concurrency, and the connector testkit are in core.
+- The OAuth / connect CLI and package manager give connector packages a stable
+  install + auth path.
+- Harn core has parity fixtures for GitHub, Slack, Linear, and Notion that pin
+  the Rust-compatible `TriggerEvent` payload shapes used by first-party package
+  CI.
 
-Until those are complete, the Rust connectors keep working unchanged.
+The remaining Rust code is intentionally compatibility-only for the deprecation
+window. Do not add new provider-specific Rust connector business logic in this
+repository; new service connectors should be packages that register with
+`connector = { harn = "..." }`. Removing the compatibility shims is a release
+coordination decision, not a prerequisite for new connector development.


### PR DESCRIPTION
## Summary

- centralizes the deprecated Rust compatibility provider list for GitHub, Slack, Linear, and Notion in `harn-vm`
- adds a regression guard that rejects any new Rust builtin service connector unless it is core runtime infrastructure or an explicit compatibility shim
- updates connector catalog, provider reference pages, migration docs, and changelog language so #446 is treated as completed core groundwork under the #350 pure-Harn connector pivot

Closes #350

## Verification

- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-350 cargo test -p harn-vm pure_harn_pivot_only_keeps_core_or_compat_builtin_connectors -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-350 cargo test -p harn-vm registered_provider_metadata_marks_builtin_connectors -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-350 cargo test -p harn-cli rust_deprecated_provider_warning -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-350 cargo test -p harn-cli --test orchestrator_http github_provider_prefers_configured_harn_connector_over_deprecated_rust_default -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-350 cargo clippy -p harn-vm -p harn-cli --tests -- -D warnings`
- `npx markdownlint-cli2 CHANGELOG.md docs/src/connectors/catalog.md docs/src/connectors/github.md docs/src/connectors/linear.md docs/src/connectors/notion.md docs/src/connectors/slack-events.md docs/src/migrations/rust-connectors-to-harn-packages.md`
- pre-commit hook passed: `cargo fmt`, workspace clippy, generated highlight sync, full markdown lint

## Pre-push note

The pre-push hook ran the full workspace nextest gate and failed under local load with 2,426 passing tests, 16 timeouts, and 6 unrelated fixture/proxy failures. The connector override timeout from that run was rerun in isolation and passed in 9.24s.
