### PR TITLE
[codex] register alternate forge connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ granular archaeology.
   `HARN_ORCHESTRATOR_API_KEYS` so trigger fire/list/replay, queue,
   DLQ, inspect, trust-query, and secret-scan tools remain behind the
   same bearer or `x-api-key` auth used by the orchestrator runtime.
+- **Alternate git forge connector catalog (#305).** Registers the
+  first-party pure-Harn Forgejo, Gitea, Bitbucket, SourceHut, and SVN
+  connector package repos alongside GitHub and GitLab in the connector
+  catalog, and includes them in the generated trigger quick reference
+  package table.
 - **Tool-call timing on ACP `tool_call_update` (#689).** Terminal
   `tool_call_update` events now carry `durationMs` (the parse-to-finish
   total — model emits the call → tool result is appended) and

--- a/crates/harn-cli/src/commands/dump_trigger_quickref.rs
+++ b/crates/harn-cli/src/commands/dump_trigger_quickref.rs
@@ -12,6 +12,76 @@ use harn_vm::{
     SignatureVerificationMetadata,
 };
 
+struct FirstPartyConnectorPackage {
+    provider: &'static str,
+    package_url: &'static str,
+    install: &'static str,
+    contract_check: &'static str,
+}
+
+const FIRST_PARTY_CONNECTOR_PACKAGES: &[FirstPartyConnectorPackage] = &[
+    FirstPartyConnectorPackage {
+        provider: "GitHub",
+        package_url: "https://github.com/burin-labs/harn-github-connector",
+        install: "harn add github.com/burin-labs/harn-github-connector@v0.1.0",
+        contract_check: "harn connector check . --provider github",
+    },
+    FirstPartyConnectorPackage {
+        provider: "Slack",
+        package_url: "https://github.com/burin-labs/harn-slack-connector",
+        install: "harn add github.com/burin-labs/harn-slack-connector@v0.1.0",
+        contract_check: "harn connector check . --provider slack",
+    },
+    FirstPartyConnectorPackage {
+        provider: "Linear",
+        package_url: "https://github.com/burin-labs/harn-linear-connector",
+        install: "harn add github.com/burin-labs/harn-linear-connector@v0.1.0",
+        contract_check: "harn connector check . --provider linear",
+    },
+    FirstPartyConnectorPackage {
+        provider: "Notion",
+        package_url: "https://github.com/burin-labs/harn-notion-connector",
+        install: "harn add github.com/burin-labs/harn-notion-connector@v0.1.0",
+        contract_check: "harn connector check . --provider notion --run-poll-tick",
+    },
+    FirstPartyConnectorPackage {
+        provider: "GitLab",
+        package_url: "https://github.com/burin-labs/harn-gitlab-connector",
+        install: "harn add github.com/burin-labs/harn-gitlab-connector@v0.1.0",
+        contract_check: "harn connector check . --provider gitlab",
+    },
+    FirstPartyConnectorPackage {
+        provider: "Forgejo",
+        package_url: "https://github.com/burin-labs/harn-forgejo-connector",
+        install: "harn add github.com/burin-labs/harn-forgejo-connector@v0.1.0",
+        contract_check: "harn connector check . --provider forgejo",
+    },
+    FirstPartyConnectorPackage {
+        provider: "Gitea",
+        package_url: "https://github.com/burin-labs/harn-gitea-connector",
+        install: "harn add github.com/burin-labs/harn-gitea-connector@v0.1.0",
+        contract_check: "harn connector check . --provider gitea",
+    },
+    FirstPartyConnectorPackage {
+        provider: "Bitbucket",
+        package_url: "https://github.com/burin-labs/harn-bitbucket-connector",
+        install: "harn add github.com/burin-labs/harn-bitbucket-connector@v0.1.0",
+        contract_check: "harn connector check . --provider bitbucket",
+    },
+    FirstPartyConnectorPackage {
+        provider: "SourceHut",
+        package_url: "https://github.com/burin-labs/harn-sourcehut-connector",
+        install: "harn add github.com/burin-labs/harn-sourcehut-connector@v0.1.0",
+        contract_check: "harn connector check . --provider sourcehut",
+    },
+    FirstPartyConnectorPackage {
+        provider: "Subversion",
+        package_url: "https://github.com/burin-labs/harn-svn-connector",
+        install: "harn add github.com/burin-labs/harn-svn-connector@v0.1.0",
+        contract_check: "harn connector check . --provider svn --run-poll-tick",
+    },
+];
+
 pub(crate) fn run(output_path: &str, check_only: bool) {
     let generated = generate_file();
     let path = Path::new(output_path);
@@ -85,10 +155,13 @@ fn generate_file() -> String {
     out.push_str("Prefer pure-Harn packages for provider business logic. The Rust providers remain compatibility defaults while the pure-Harn packages soak.\n\n");
     out.push_str("| Provider | Package | Install | Contract check |\n");
     out.push_str("|---|---|---|---|\n");
-    out.push_str("| GitHub | <https://github.com/burin-labs/harn-github-connector> | `harn add github.com/burin-labs/harn-github-connector@v0.1.0` | `harn connector check . --provider github` |\n");
-    out.push_str("| Slack | <https://github.com/burin-labs/harn-slack-connector> | `harn add github.com/burin-labs/harn-slack-connector@v0.1.0` | `harn connector check . --provider slack` |\n");
-    out.push_str("| Linear | <https://github.com/burin-labs/harn-linear-connector> | `harn add github.com/burin-labs/harn-linear-connector@v0.1.0` | `harn connector check . --provider linear` |\n");
-    out.push_str("| Notion | <https://github.com/burin-labs/harn-notion-connector> | `harn add github.com/burin-labs/harn-notion-connector@v0.1.0` | `harn connector check . --provider notion --run-poll-tick` |\n\n");
+    for package in FIRST_PARTY_CONNECTOR_PACKAGES {
+        out.push_str(&format!(
+            "| {} | <{}> | `{}` | `{}` |\n",
+            package.provider, package.package_url, package.install, package.contract_check
+        ));
+    }
+    out.push('\n');
     out.push_str("Community connectors are Harn packages that declare `connector_contract = \"v1\"` and export the connector functions below. Direct GitHub refs are enough for private or pre-registry packages; registry names such as `@burin/notion-connector` are for discoverable package-index entries.\n\n");
 
     out.push_str("## Connector Contract V1\n\n");
@@ -231,6 +304,8 @@ mod tests {
         assert!(out.contains("| `github` | `webhook` | `GitHubEventPayload` |"));
         assert!(out.contains("Connector Contract V1"));
         assert!(out.contains("harn connector check ."));
+        assert!(out.contains("harn-forgejo-connector"));
+        assert!(out.contains("harn-svn-connector"));
     }
 
     #[test]

--- a/docs/llm/harn-triggers-quickref.md
+++ b/docs/llm/harn-triggers-quickref.md
@@ -71,6 +71,12 @@ Prefer pure-Harn packages for provider business logic. The Rust providers remain
 | Slack | <https://github.com/burin-labs/harn-slack-connector> | `harn add github.com/burin-labs/harn-slack-connector@v0.1.0` | `harn connector check . --provider slack` |
 | Linear | <https://github.com/burin-labs/harn-linear-connector> | `harn add github.com/burin-labs/harn-linear-connector@v0.1.0` | `harn connector check . --provider linear` |
 | Notion | <https://github.com/burin-labs/harn-notion-connector> | `harn add github.com/burin-labs/harn-notion-connector@v0.1.0` | `harn connector check . --provider notion --run-poll-tick` |
+| GitLab | <https://github.com/burin-labs/harn-gitlab-connector> | `harn add github.com/burin-labs/harn-gitlab-connector@v0.1.0` | `harn connector check . --provider gitlab` |
+| Forgejo | <https://github.com/burin-labs/harn-forgejo-connector> | `harn add github.com/burin-labs/harn-forgejo-connector@v0.1.0` | `harn connector check . --provider forgejo` |
+| Gitea | <https://github.com/burin-labs/harn-gitea-connector> | `harn add github.com/burin-labs/harn-gitea-connector@v0.1.0` | `harn connector check . --provider gitea` |
+| Bitbucket | <https://github.com/burin-labs/harn-bitbucket-connector> | `harn add github.com/burin-labs/harn-bitbucket-connector@v0.1.0` | `harn connector check . --provider bitbucket` |
+| SourceHut | <https://github.com/burin-labs/harn-sourcehut-connector> | `harn add github.com/burin-labs/harn-sourcehut-connector@v0.1.0` | `harn connector check . --provider sourcehut` |
+| Subversion | <https://github.com/burin-labs/harn-svn-connector> | `harn add github.com/burin-labs/harn-svn-connector@v0.1.0` | `harn connector check . --provider svn --run-poll-tick` |
 
 Community connectors are Harn packages that declare `connector_contract = "v1"` and export the connector functions below. Direct GitHub refs are enough for private or pre-registry packages; registry names such as `@burin/notion-connector` are for discoverable package-index entries.
 

--- a/docs/src/connectors/catalog.md
+++ b/docs/src/connectors/catalog.md
@@ -98,6 +98,11 @@ Each first-party connector repo should publish:
 | Linear | <https://github.com/burin-labs/harn-linear-connector> | `harn add github.com/burin-labs/harn-linear-connector@v0.1.0` | `harn connector check . --provider linear` | Webhook signing secret; optional API key/access token for outbound GraphQL. | `Issue`, `Comment`, `IssueLabel`, `Project`, `Cycle`, `Customer`, `CustomerRequest`; outbound GraphQL. |
 | Notion | <https://github.com/burin-labs/harn-notion-connector> | `harn add github.com/burin-labs/harn-notion-connector@v0.1.0` | `harn connector check . --provider notion --run-poll-tick` | Webhook verification token; outbound API token. Notion integration capabilities depend on pages/databases/comments used. | Webhook events such as subscription verification, page updates, comments, data source schema updates; `poll_tick` database/page watchers; outbound Notion API via `notion-sdk-harn`. |
 | GitLab | <https://github.com/burin-labs/harn-gitlab-connector> | `harn add github.com/burin-labs/harn-gitlab-connector@v0.1.0` | `harn connector check . --provider gitlab` | Webhook signing secret (plain shared-secret `X-Gitlab-Token`, not HMAC); for outbound, an OAuth2 access token, PAT, or project/group access token with `api` scope. | `push`, `tag_push`, `merge_request`, `note`, `issue`, `pipeline`; outbound REST (notes, MR update/changes/approve, commit status, repository files), GraphQL passthrough, and OAuth2 helpers. |
+| Forgejo | <https://github.com/burin-labs/harn-forgejo-connector> | `harn add github.com/burin-labs/harn-forgejo-connector@v0.1.0` | `harn connector check . --provider forgejo` | Webhook signing secret verified as HMAC-SHA256 from `X-Gitea-Signature`; for outbound, a user, organization, or repository access token accepted by the instance API. | `push`, `pull_request`, `issues`, `issue_comment`, `release`, `repository`, `star`; outbound REST for comments, PR updates, commit statuses, repository contents, and raw API passthrough. |
+| Gitea | <https://github.com/burin-labs/harn-gitea-connector> | `harn add github.com/burin-labs/harn-gitea-connector@v0.1.0` | `harn connector check . --provider gitea` | Webhook signing secret verified as HMAC-SHA256 from `X-Gitea-Signature`; for outbound, an access token scoped to the target self-hosted instance. | `push`, `pull_request`, `issues`, `issue_comment`, `release`, `repository`, `star`; outbound REST for comments, PR updates, commit statuses, repository contents, and raw API passthrough. |
+| Bitbucket | <https://github.com/burin-labs/harn-bitbucket-connector> | `harn add github.com/burin-labs/harn-bitbucket-connector@v0.1.0` | `harn connector check . --provider bitbucket` | Optional webhook signing secret verified as HMAC-SHA256 from `X-Hub-Signature`; `X-Hook-UUID` and `X-Request-UUID` are preserved for dedupe. For outbound, app password, OAuth2 token, or Data Center PAT. | Cloud and Data Center `repo:push`, `pullrequest:*`, `issue:*`, `repo:commit_status_*`; outbound PR comments/updates, commit statuses, repository file fetches, and raw API passthrough. |
+| SourceHut | <https://github.com/burin-labs/harn-sourcehut-connector> | `harn add github.com/burin-labs/harn-sourcehut-connector@v0.1.0` | `harn connector check . --provider sourcehut` | Webhook public key verified with Ed25519 over the raw payload; outbound GraphQL/REST calls use an OAuth2 token or PAT. | Repository push/update events, todo/ticket changes, build notifications, mailing-list oriented message metadata; outbound GraphQL/REST passthrough. |
+| Subversion | <https://github.com/burin-labs/harn-svn-connector> | `harn add github.com/burin-labs/harn-svn-connector@v0.1.0` | `harn connector check . --provider svn --run-poll-tick` | Optional post-commit hook HMAC secret; polling credentials are repository URL plus username/password, SSH key, or ambient host-managed credential helper. | `commit`, `branch`, `tag`, `property_change`; webhook-style post-commit normalization plus `poll_tick` revision scanning for repositories that cannot install hooks. |
 
 Direct GitHub installs are the MVP path. Registry names such as
 `@burin/notion-connector` should be used once the hosted first-party index is
@@ -156,6 +161,31 @@ secrets = { verification_token = "notion/verification-token" }
 ```
 
 See `examples/triggers/notion-database-watcher`.
+
+### Git forge quickstart demo
+
+GitHub, GitLab, and Forgejo can be wired side by side with only provider
+package changes. Each provider owns its verification and outbound API details
+inside its pure-Harn connector package:
+
+```toml
+[dependencies]
+harn-github-connector = { git = "https://github.com/burin-labs/harn-github-connector", rev = "v0.1.0" }
+harn-gitlab-connector = { git = "https://github.com/burin-labs/harn-gitlab-connector", rev = "v0.1.0" }
+harn-forgejo-connector = { git = "https://github.com/burin-labs/harn-forgejo-connector", rev = "v0.1.0" }
+
+[[providers]]
+id = "github"
+connector = { harn = "harn-github-connector" }
+
+[[providers]]
+id = "gitlab"
+connector = { harn = "harn-gitlab-connector" }
+
+[[providers]]
+id = "forgejo"
+connector = { harn = "harn-forgejo-connector" }
+```
 
 ## Community connector discovery
 


### PR DESCRIPTION
## Summary

- publish and register first-party pure-Harn connector packages for Forgejo, Gitea, Bitbucket, SourceHut, and Subversion alongside the existing GitHub and GitLab packages
- update the connector catalog with install commands, contract checks, verification schemes, required auth material, supported event families, and a GitHub/GitLab/Forgejo quickstart demo
- generate the trigger quick reference from a single first-party package table so GitLab and the alternate forge package links do not drift from the CLI generator

Closes #305

## Published connector packages

- https://github.com/burin-labs/harn-forgejo-connector/tree/v0.1.0
- https://github.com/burin-labs/harn-gitea-connector/tree/v0.1.0
- https://github.com/burin-labs/harn-bitbucket-connector/tree/v0.1.0
- https://github.com/burin-labs/harn-sourcehut-connector/tree/v0.1.0
- https://github.com/burin-labs/harn-svn-connector/tree/v0.1.0

Each package includes `src/lib.harn`, `harn.toml`, `README.md`, `SKILL.md`, smoke tests, and connector-contract fixtures. Each is tagged `v0.1.0` to match the catalog install commands.

## Validation

- `cargo test -p harn-cli dump_trigger_quickref`
- `cargo check -p harn-cli`
- `make check-trigger-quickref`
- `npx markdownlint-cli2 "CHANGELOG.md" "docs/src/connectors/catalog.md" "docs/llm/harn-triggers-quickref.md"`
- `./scripts/check_docs_snippets.sh`
- pre-commit hook: `cargo fmt`, workspace clippy, markdownlint
- pre-push hook: workspace nextest suite, markdownlint
- for each new connector repo: `harn check src/lib.harn`, `harn fmt --check src/lib.harn tests/basic.harn`, `harn run tests/basic.harn`, `harn connector check . --provider <provider>`; SVN also used `--run-poll-tick`
