### PR TITLE
Release v0.7.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## v0.7.42
+
+### Added
+
+- **Flow predicate executor (#704).** Added predicate-mode Flow execution
+  with runtime attribute recognition for predicate declarations, pipelines,
+  and ACP skill surfaces. The release also tightens attribute placement
+  diagnostics so valid runtime annotations pass conformance while invalid
+  placements still warn.
+- **Workflow crystallization substrate (#713).** Added the substrate for
+  persisting and replaying crystallized workflows, including durable atom
+  storage and operator-facing hooks that let Harn turn repeated orchestration
+  patterns into reusable workflow state.
+- **Alternate forge connector catalog (#712).** Registers the pure-Harn
+  Forgejo, Gitea, Bitbucket, SourceHut, and SVN connector package repos in
+  the connector catalog and generated trigger quick reference alongside the
+  existing forge integrations.
+
+### Changed
+
+- **Embedded orchestrator MCP serving (#709).** `harn orchestrator serve`
+  now exposes the orchestrator MCP surface from the deployable listener so
+  trigger, queue, replay, inspection, trust-query, and secret-scan tools can
+  be served behind the orchestrator auth boundary.
+- **Connector and durability cleanup (#706, #707, #708, #710, #711).**
+  Adds the SQLite Flow atom store, closes connector epic documentation gaps,
+  hardens event-log durability paths, completes the pure-Harn connector pivot
+  guardrails, and strengthens orchestrator deploy secret synchronization.
+
 ## v0.7.41
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "async-trait",
  "axum",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "harn-vm",
  "serde",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "anyhow",
  "base64",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1740,11 +1740,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.41"
+version = "0.7.42"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "async-trait",
  "axum",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "harn-vm"
-version = "0.7.41"
+version = "0.7.42"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.41"
+version = "0.7.42"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"

--- a/crates/harn-vm/src/llm/readiness.rs
+++ b/crates/harn-vm/src/llm/readiness.rs
@@ -388,6 +388,7 @@ mod tests {
                     Err(error) => panic!("models stub: accept failed: {error}"),
                 }
             };
+            stream.set_nonblocking(false).expect("set stream blocking");
             let mut buf = vec![0u8; 4096];
             let n = stream.read(&mut buf).expect("read request");
             let request = String::from_utf8_lossy(&buf[..n]);


### PR DESCRIPTION
Release v0.7.42.\n\nHighlights:\n- Flow predicate executor and runtime attribute recognition (#704)\n- Workflow crystallization substrate (#713)\n- Alternate forge connector catalog and trigger quick reference entries (#712)\n- Embedded orchestrator MCP serving (#709)\n- Connector, event durability, Flow atom store, and deploy secret sync cleanup (#706, #707, #708, #710, #711)\n\nVerification performed locally:\n- ./scripts/release_ship.sh --prepare --bump patch (portal build, docs/grammar/security/package lanes passed; rust lane rerun separately after parallel gate reporting issue)\n- make test: 2,485 passed\n- release prepare rerun with --skip-audit for final bump/stage after the explicit audit checks above\n- pre-commit: cargo fmt, clippy, markdownlint passed\n\nAfter this lands through the merge queue, publish-release should detect tag drift and ship v0.7.42 automatically.