### PR TITLE
Stream text-mode tool-call candidate lifecycle (closes #692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,21 @@ granular archaeology.
   connector package repos alongside GitHub and GitLab in the connector
   catalog, and includes them in the generated trigger quick reference
   package table.
+- **Streaming text-mode tool-call candidate events (#692).** While the
+  model is still writing a `<tool_call>` body or a bare `name({...})`
+  call, the runtime now emits a candidate-lifecycle stream so ACP
+  clients can render an in-flight chip instead of waiting for the full
+  response. Adds a `parsing` boolean on both `tool_call` and
+  `tool_call_update`: `parsing: true` opens the chip when a candidate
+  shape is detected at line start (or inside `<tool_call>`); the
+  terminal `tool_call_update { parsing: false }` either promotes
+  (`status: pending` with the parsed `rawInput`) or aborts
+  (`status: failed`, new `error_category: parse_aborted`) once the
+  args resolve. The detector respects markdown code-fence context so
+  `function(x)` snippets inside a triple-backtick block do not trigger
+  spurious candidate events. Tool dispatch IDs are unchanged — this is
+  purely additive observability layered ahead of the post-stream
+  parser.
 - **Tool-call timing on ACP `tool_call_update` (#689).** Terminal
   `tool_call_update` events now carry `durationMs` (the parse-to-finish
   total — model emits the call → tool result is appended) and

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -101,6 +101,7 @@ impl AgentEventSink for AcpAgentEventSink {
                 kind,
                 status,
                 raw_input,
+                parsing,
             } => {
                 let mut update = serde_json::json!({
                     "sessionUpdate": "tool_call",
@@ -111,6 +112,9 @@ impl AgentEventSink for AcpAgentEventSink {
                 });
                 if let Some(k) = kind {
                     update["kind"] = serde_json::to_value(k).unwrap_or_default();
+                }
+                if let Some(p) = parsing {
+                    update["parsing"] = serde_json::Value::Bool(*p);
                 }
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
@@ -128,6 +132,7 @@ impl AgentEventSink for AcpAgentEventSink {
                 execution_duration_ms,
                 error_category,
                 executor,
+                parsing,
             } => {
                 let mut update = serde_json::json!({
                     "sessionUpdate": "tool_call_update",
@@ -152,6 +157,9 @@ impl AgentEventSink for AcpAgentEventSink {
                 }
                 if let Some(exec) = executor {
                     update["executor"] = Self::executor_to_json(exec);
+                }
+                if let Some(p) = parsing {
+                    update["parsing"] = serde_json::Value::Bool(*p);
                 }
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
@@ -392,6 +400,7 @@ mod tests {
                 kind: Some(ToolKind::Read),
                 status: ToolCallStatus::Pending,
                 raw_input: serde_json::json!({"path": "README.md"}),
+                parsing: None,
             },
             AgentEvent::ToolCallUpdate {
                 session_id: "session-1".to_string(),
@@ -404,6 +413,7 @@ mod tests {
                 execution_duration_ms: Some(5),
                 error_category: None,
                 executor: Some(ToolExecutor::HarnBuiltin),
+                parsing: None,
             },
             AgentEvent::Plan {
                 session_id: "session-1".to_string(),
@@ -510,6 +520,7 @@ mod tests {
             execution_duration_ms: None,
             error_category: Some(ToolCallErrorCategory::SchemaValidation),
             executor: None,
+            parsing: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -543,11 +554,81 @@ mod tests {
             execution_duration_ms: None,
             error_category: None,
             executor: None,
+            parsing: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
         assert!(payload["params"]["update"].get("errorCategory").is_none());
         assert!(payload["params"]["update"].get("error").is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tool_call_carries_parsing_flag_through_to_acp_wire() {
+        // Harn#692: when the streaming candidate detector emits a
+        // tool_call with `parsing: Some(true)`, the ACP wire must carry
+        // a literal `"parsing": true` so clients can render the
+        // in-flight chip. The terminal `tool_call_update` likewise
+        // carries `"parsing": false` to retract it.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+
+        sink.handle_event(&AgentEvent::ToolCall {
+            session_id: "session-1".to_string(),
+            tool_call_id: "text-cand-1".to_string(),
+            tool_name: "edit".to_string(),
+            kind: None,
+            status: ToolCallStatus::Pending,
+            raw_input: serde_json::json!({}),
+            parsing: Some(true),
+        });
+        let line = rx.recv().await.expect("acp tool_call notification");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        assert_eq!(payload["params"]["update"]["sessionUpdate"], "tool_call");
+        assert_eq!(payload["params"]["update"]["parsing"], true);
+
+        sink.handle_event(&AgentEvent::ToolCallUpdate {
+            session_id: "session-1".to_string(),
+            tool_call_id: "text-cand-1".to_string(),
+            tool_name: "edit".to_string(),
+            status: ToolCallStatus::Failed,
+            raw_output: None,
+            error: Some("malformed args".to_string()),
+            duration_ms: None,
+            execution_duration_ms: None,
+            error_category: Some(ToolCallErrorCategory::ParseAborted),
+            executor: None,
+            parsing: Some(false),
+        });
+        let line = rx.recv().await.expect("acp tool_call_update notification");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        assert_eq!(
+            payload["params"]["update"]["sessionUpdate"],
+            "tool_call_update"
+        );
+        assert_eq!(payload["params"]["update"]["parsing"], false);
+        assert_eq!(
+            payload["params"]["update"]["errorCategory"],
+            "parse_aborted"
+        );
+
+        // Default `parsing: None` must not surface a `parsing` field
+        // at all, so existing ACP clients that don't know about the
+        // candidate phase don't see a misleading `null`.
+        sink.handle_event(&AgentEvent::ToolCall {
+            session_id: "session-1".to_string(),
+            tool_call_id: "tool-1".to_string(),
+            tool_name: "read".to_string(),
+            kind: None,
+            status: ToolCallStatus::Pending,
+            raw_input: serde_json::json!({}),
+            parsing: None,
+        });
+        let line = rx.recv().await.expect("acp tool_call notification");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        assert!(
+            payload["params"]["update"].get("parsing").is_none(),
+            "got: {payload}"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -586,6 +667,7 @@ mod tests {
                 execution_duration_ms: None,
                 error_category: None,
                 executor: Some(executor),
+                parsing: None,
             });
             let line = rx.recv().await.expect("acp tool_call_update notification");
             let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -609,6 +691,7 @@ mod tests {
             execution_duration_ms: None,
             error_category: None,
             executor: None,
+            parsing: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -109,6 +109,14 @@ pub enum ToolCallErrorCategory {
     /// The harn loop detector skipped this call because the same
     /// (tool, args) pair repeated past the configured threshold.
     RejectedLoop,
+    /// Streaming text candidate was detected (bare `name(` or
+    /// `<tool_call>` opener) but never resolved into a parseable call:
+    /// args parsed as malformed, the heredoc body broke, the tag closed
+    /// without a balanced expression, or the stream ended mid-call.
+    /// Used by the streaming candidate detector (harn#692) to retract a
+    /// `tool_call` candidate that turned out to be prose or syntactically
+    /// broken so clients can dismiss the in-flight chip.
+    ParseAborted,
     /// The tool exceeded its time budget.
     Timeout,
     /// Transient network / rate-limited / 5xx provider failure.
@@ -128,6 +136,7 @@ impl ToolCallErrorCategory {
             Self::HostBridgeError => "host_bridge_error",
             Self::PermissionDenied => "permission_denied",
             Self::RejectedLoop => "rejected_loop",
+            Self::ParseAborted => "parse_aborted",
             Self::Timeout => "timeout",
             Self::Network => "network",
             Self::Cancelled => "cancelled",
@@ -212,6 +221,20 @@ pub enum AgentEvent {
         kind: Option<ToolKind>,
         status: ToolCallStatus,
         raw_input: serde_json::Value,
+        /// Set to `Some(true)` by the streaming candidate detector
+        /// (harn#692) when this event represents a tool-call shape
+        /// detected in the model's in-flight assistant text but whose
+        /// arguments have not finished parsing yet. Clients can render a
+        /// spinner / placeholder while the model writes the body. The
+        /// detector follows up with a `ToolCallUpdate { parsing: false,
+        /// .. }` carrying either `status: pending` (promoted) or
+        /// `status: failed` with `error_category: parse_aborted`.
+        /// `None` (the default) means "this is a normal post-parse tool
+        /// call, no candidate phase was active" so the on-disk shape
+        /// stays compatible with replays recorded before this field
+        /// existed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parsing: Option<bool>,
     },
     ToolCallUpdate {
         session_id: String,
@@ -247,6 +270,16 @@ pub enum AgentEvent {
         /// dispatcher picks a backend).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         executor: Option<ToolExecutor>,
+        /// Companion to `ToolCall.parsing` (harn#692). The streaming
+        /// candidate detector emits the *terminal* candidate event as a
+        /// `ToolCallUpdate` with `parsing: Some(false)` to retract the
+        /// in-flight `parsing: true` chip — either by promoting the
+        /// candidate (`status: pending`, populated `raw_output: None`,
+        /// `error: None`) or aborting it (`status: failed`,
+        /// `error_category: parse_aborted`). `None` means this update is
+        /// not part of a candidate-phase transition.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parsing: Option<bool>,
     },
     Plan {
         session_id: String,
@@ -820,6 +853,7 @@ mod tests {
             execution_duration_ms: Some(7),
             error_category: None,
             executor: None,
+            parsing: None,
         };
         let value = serde_json::to_value(&terminal).unwrap();
         assert_eq!(value["duration_ms"], serde_json::json!(42));
@@ -839,6 +873,7 @@ mod tests {
             execution_duration_ms: None,
             error_category: None,
             executor: None,
+            parsing: None,
         };
         let value = serde_json::to_value(&intermediate).unwrap();
         let object = value.as_object().expect("update serializes as object");
@@ -908,6 +943,7 @@ mod tests {
             (ToolCallErrorCategory::HostBridgeError, "host_bridge_error"),
             (ToolCallErrorCategory::PermissionDenied, "permission_denied"),
             (ToolCallErrorCategory::RejectedLoop, "rejected_loop"),
+            (ToolCallErrorCategory::ParseAborted, "parse_aborted"),
             (ToolCallErrorCategory::Timeout, "timeout"),
             (ToolCallErrorCategory::Network, "network"),
             (ToolCallErrorCategory::Cancelled, "cancelled"),
@@ -1017,6 +1053,7 @@ mod tests {
             execution_duration_ms: None,
             error_category: None,
             executor: None,
+            parsing: None,
         };
         let v = serde_json::to_value(&event).unwrap();
         assert_eq!(v["type"], "tool_call_update");
@@ -1036,6 +1073,7 @@ mod tests {
             execution_duration_ms: None,
             error_category: Some(ToolCallErrorCategory::SchemaValidation),
             executor: None,
+            parsing: None,
         };
         let v = serde_json::to_value(&event).unwrap();
         assert_eq!(v["error_category"], "schema_validation");
@@ -1058,6 +1096,7 @@ mod tests {
             execution_duration_ms: None,
             error_category: None,
             executor: None,
+            parsing: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert!(json.get("executor").is_none(), "got: {json}");
@@ -1078,6 +1117,7 @@ mod tests {
             executor: Some(ToolExecutor::McpServer {
                 server_name: "github".into(),
             }),
+            parsing: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["executor"]["kind"], "mcp_server");

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -39,10 +39,10 @@ use crate::value::VmError;
 use crate::orchestration::TurnPolicy;
 
 use super::super::agent_observe::{
-    dump_llm_interpreted_response, observed_llm_call, LlmRetryConfig,
+    dump_llm_interpreted_response, observed_llm_call, LlmRetryConfig, StreamingDetectorContext,
 };
 use super::super::helpers::transcript_event;
-use super::super::tools::parse_text_tool_calls_with_tools;
+use super::super::tools::{collect_tool_schemas, parse_text_tool_calls_with_tools};
 use super::helpers::{
     append_message_to_contexts, loop_state_requests_phase_change, prose_exceeds_budget,
     runtime_feedback_message, sentinel_without_action_nudge, trim_prose_for_history,
@@ -83,6 +83,29 @@ pub(super) async fn run_llm_call(
     ctx: &LlmCallContext<'_>,
     iteration: usize,
 ) -> Result<LlmCallResult, VmError> {
+    // Streaming text-mode candidate detector (harn#692). Only relevant
+    // when this stage actually parses text-mode tool calls — native
+    // tool-channel calls have their own server-side streaming path
+    // (harn#693 / H4 in the parent epic) so spinning up a text
+    // detector for them would surface false-positive candidates from
+    // any tool-shaped narration the model emits before its native
+    // tool block.
+    let streaming_detector = if ctx.has_tools && ctx.tool_format != "native" {
+        let mut known: std::collections::BTreeSet<String> =
+            collect_tool_schemas(ctx.tools_val, None)
+                .into_iter()
+                .map(|schema| schema.name)
+                .collect();
+        // Mirror the post-stream parsers' pseudo-tool registration.
+        known.insert("ledger".to_string());
+        known.insert("load_skill".to_string());
+        Some(StreamingDetectorContext {
+            session_id: state.session_id.clone(),
+            known_tools: known,
+        })
+    } else {
+        None
+    };
     let result = observed_llm_call(
         opts,
         Some(ctx.tool_format),
@@ -94,6 +117,7 @@ pub(super) async fn run_llm_call(
         Some(iteration),
         true,
         false, // agent_loop runs on the local set, not offthread
+        streaming_detector,
     )
     .await?;
 
@@ -580,6 +604,7 @@ pub(super) fn provider_native_search_emissions(
                     kind: Some(ToolKind::Search),
                     status: ToolCallStatus::InProgress,
                     raw_input: query,
+                    parsing: None,
                 });
             }
             Some("tool_search_result") => {
@@ -642,6 +667,7 @@ pub(super) fn provider_native_search_emissions(
                     execution_duration_ms: None,
                     error_category: None,
                     executor: Some(ToolExecutor::ProviderNative),
+                    parsing: None,
                 });
             }
             _ => {}

--- a/crates/harn-vm/src/llm/agent/tests/transcript.rs
+++ b/crates/harn-vm/src/llm/agent/tests/transcript.rs
@@ -37,6 +37,7 @@ async fn observed_llm_call_transcript_deduplicates_system_and_tool_schemas() {
             Some(iteration),
             false,
             false,
+            None,
         )
         .await
         .unwrap();
@@ -113,6 +114,7 @@ async fn observed_llm_call_transcript_uses_explicit_tool_format() {
         Some(0),
         false,
         false,
+        None,
     )
     .await
     .unwrap();
@@ -162,6 +164,7 @@ async fn observed_llm_call_transcript_records_thinking_settings() {
         Some(0),
         false,
         false,
+        None,
     )
     .await
     .unwrap();
@@ -214,6 +217,7 @@ async fn assert_observed_llm_call_bridge_user_visible(user_visible: bool) {
                 None,
                 user_visible,
                 false,
+                None,
             )
             .await
             .unwrap();

--- a/crates/harn-vm/src/llm/agent/tool_dispatch.rs
+++ b/crates/harn-vm/src/llm/agent/tool_dispatch.rs
@@ -532,6 +532,7 @@ pub(super) async fn run_tool_dispatch(
             kind: tool_kind,
             status: ToolCallStatus::Pending,
             raw_input: tool_args.clone(),
+            parsing: None,
         })
         .await;
 
@@ -560,6 +561,7 @@ pub(super) async fn run_tool_dispatch(
                 execution_duration_ms: None,
                 error_category: Some(ToolCallErrorCategory::SchemaValidation),
                 executor: None,
+                parsing: None,
             })
             .await;
             if ctx.tool_format == "native" {
@@ -628,6 +630,7 @@ pub(super) async fn run_tool_dispatch(
                 execution_duration_ms: None,
                 error_category: Some(ToolCallErrorCategory::PermissionDenied),
                 executor: None,
+                parsing: None,
             })
             .await;
             if ctx.tool_format == "native" {
@@ -727,6 +730,7 @@ pub(super) async fn run_tool_dispatch(
                         execution_duration_ms: None,
                         error_category: Some(ToolCallErrorCategory::PermissionDenied),
                         executor: None,
+                        parsing: None,
                     })
                     .await;
                     if ctx.tool_format == "native" {
@@ -854,6 +858,7 @@ pub(super) async fn run_tool_dispatch(
                 execution_duration_ms: None,
                 error_category: Some(ToolCallErrorCategory::PermissionDenied),
                 executor: None,
+                parsing: None,
             })
             .await;
             if ctx.tool_format == "native" {
@@ -915,6 +920,7 @@ pub(super) async fn run_tool_dispatch(
                     execution_duration_ms: None,
                     error_category: Some(ToolCallErrorCategory::PermissionDenied),
                     executor: None,
+                    parsing: None,
                 })
                 .await;
                 if ctx.tool_format == "native" {
@@ -962,6 +968,7 @@ pub(super) async fn run_tool_dispatch(
                 execution_duration_ms: None,
                 error_category: Some(ToolCallErrorCategory::SchemaValidation),
                 executor: None,
+                parsing: None,
             })
             .await;
             if ctx.tool_format == "native" {
@@ -1006,6 +1013,7 @@ pub(super) async fn run_tool_dispatch(
             // The dispatcher picks the backend below; the in-progress
             // emission is unconditional and runs before that choice.
             executor: None,
+            parsing: None,
         })
         .await;
         let tool_span_id =
@@ -1084,6 +1092,7 @@ pub(super) async fn run_tool_dispatch(
                     // Loop intervention preempts the backend choice —
                     // the tool never ran.
                     executor: None,
+                    parsing: None,
                 })
                 .await;
                 continue;
@@ -1260,6 +1269,7 @@ pub(super) async fn run_tool_dispatch(
             execution_duration_ms: Some(execution_duration_ms),
             error_category: final_error_category,
             executor: tool_executor.clone(),
+            parsing: None,
         })
         .await;
 

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -595,6 +595,10 @@ pub fn register_llm_call_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Host
                 None,
                 user_visible,
                 true,
+                // Direct `llm_call` host invocations are not part of an
+                // agent loop, so the streaming candidate detector
+                // (harn#692) doesn't fire here.
+                None,
             )
             .await?;
 

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -498,23 +498,107 @@ pub(super) fn chrono_now() -> String {
     format!("{}.{:03}", now.as_secs(), now.subsec_millis())
 }
 
+/// Inputs required to wire a streaming candidate detector (harn#692)
+/// into a delta-forwarding task. When supplied, the detector consumes
+/// each text delta in parallel with the bridge progress notifier and
+/// emits `AgentEvent::ToolCall { parsing: true, .. }` /
+/// `AgentEvent::ToolCallUpdate { parsing: false, .. }` events through
+/// the global session sink registry so ACP clients render an in-flight
+/// chip while the model is still writing the args.
+pub(crate) struct StreamingDetectorContext {
+    pub session_id: String,
+    pub known_tools: std::collections::BTreeSet<String>,
+}
+
 /// Create an unbounded channel and spawn a local task that forwards text
-/// deltas to `bridge.send_call_progress()`.
+/// deltas to `bridge.send_call_progress()`. When `detector_ctx` is
+/// `Some`, the same task also drives a streaming text-tool-call
+/// candidate detector — emitting candidate-start / promoted / aborted
+/// events via the global session sink registry as the buffer grows
+/// (harn#692).
 pub(super) fn spawn_progress_forwarder(
     bridge: &Rc<crate::bridge::HostBridge>,
     call_id: String,
     user_visible: bool,
+    detector_ctx: Option<StreamingDetectorContext>,
 ) -> DeltaSender {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
     let bridge = bridge.clone();
+    let mut detector = detector_ctx.map(|ctx| {
+        crate::llm::tools::StreamingToolCallDetector::new(ctx.session_id, ctx.known_tools)
+    });
     tokio::task::spawn_local(async move {
         let mut token_count: u64 = 0;
         while let Some(delta) = rx.recv().await {
             token_count += 1;
             bridge.send_call_progress(&call_id, &delta, token_count, user_visible);
+            if let Some(d) = detector.as_mut() {
+                for event in d.push(&delta) {
+                    crate::agent_events::emit_event(&event);
+                }
+            }
+        }
+        if let Some(mut d) = detector {
+            for event in d.finalize() {
+                crate::agent_events::emit_event(&event);
+            }
         }
     });
     tx
+}
+
+/// No-bridge twin of `spawn_progress_forwarder`. Drives only the
+/// streaming candidate detector — the deltas are otherwise discarded
+/// (the bridge progress channel is the only consumer, and we don't have
+/// one). Used so non-bridge callers (offthread VM, CLI loops without an
+/// attached host) still see candidate events when they have a
+/// `StreamingDetectorContext`.
+pub(super) fn spawn_detector_only_forwarder(detector_ctx: StreamingDetectorContext) -> DeltaSender {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    tokio::task::spawn_local(run_detector_loop(detector_ctx, rx));
+    tx
+}
+
+/// Inner loop driving a [`StreamingToolCallDetector`] from a delta
+/// channel. Pulled out of `spawn_detector_only_forwarder` so tests can
+/// drive the same logic deterministically (await directly) without
+/// depending on `spawn_local` task scheduling.
+///
+/// `sink` is the function each emitted event flows through. Production
+/// passes `crate::agent_events::emit_event` so events fan out through
+/// the global session-keyed sink registry. Tests pass a closure that
+/// captures into a local buffer — sidestepping the global registry,
+/// which other tests in this binary mutate via `reset_all_sinks` and
+/// can race the per-session install.
+async fn run_detector_loop_with_sink(
+    detector_ctx: StreamingDetectorContext,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<String>,
+    mut sink: impl FnMut(&crate::agent_events::AgentEvent),
+) {
+    let mut detector = crate::llm::tools::StreamingToolCallDetector::new(
+        detector_ctx.session_id,
+        detector_ctx.known_tools,
+    );
+    while let Some(delta) = rx.recv().await {
+        for event in detector.push(&delta) {
+            sink(&event);
+        }
+    }
+    for event in detector.finalize() {
+        sink(&event);
+    }
+}
+
+/// Production wrapper: forwards every detector event through the global
+/// session sink registry so ACP / external sinks see them.
+async fn run_detector_loop(
+    detector_ctx: StreamingDetectorContext,
+    rx: tokio::sync::mpsc::UnboundedReceiver<String>,
+) {
+    run_detector_loop_with_sink(detector_ctx, rx, |event| {
+        crate::agent_events::emit_event(event);
+    })
+    .await;
 }
 
 /// Configuration for LLM call retries.
@@ -561,6 +645,7 @@ pub(crate) async fn observed_llm_call(
     iteration: Option<usize>,
     user_visible: bool,
     offthread: bool,
+    streaming_detector: Option<StreamingDetectorContext>,
 ) -> Result<super::api::LlmResult, VmError> {
     let effective_tool_format = tool_format
         .map(str::to_string)
@@ -626,15 +711,32 @@ pub(crate) async fn observed_llm_call(
         );
 
         let start = std::time::Instant::now();
+        // The streaming detector runs once per LLM call. Move the
+        // context into whichever forwarder we end up spawning so the
+        // detector finalizes when the stream closes (or never spawns
+        // if this call is non-streamed and there's nothing to listen
+        // to).
+        let detector_ctx = streaming_detector
+            .as_ref()
+            .map(|c| StreamingDetectorContext {
+                session_id: c.session_id.clone(),
+                known_tools: c.known_tools.clone(),
+            });
         let llm_result = if let Some(b) = bridge {
-            let delta_tx = spawn_progress_forwarder(b, call_id.clone(), user_visible);
+            let delta_tx = spawn_progress_forwarder(b, call_id.clone(), user_visible, detector_ctx);
             if offthread {
                 vm_call_llm_full_streaming_offthread(opts, delta_tx).await
             } else {
                 vm_call_llm_full_streaming(opts, delta_tx).await
             }
         } else if offthread {
-            let (delta_tx, _delta_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+            let delta_tx = match detector_ctx {
+                Some(ctx) => spawn_detector_only_forwarder(ctx),
+                None => {
+                    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+                    tx
+                }
+            };
             vm_call_llm_full_streaming_offthread(opts, delta_tx).await
         } else {
             super::api::vm_call_llm_full(opts).await
@@ -919,5 +1021,115 @@ mod retry_tests {
     #[test]
     fn retry_after_malformed_returns_none() {
         assert_eq!(parse_retry_after("retry-after: soon-ish"), None);
+    }
+}
+
+#[cfg(test)]
+mod streaming_detector_tests {
+    //! Verify the streaming candidate detector glue (harn#692). The
+    //! unit tests in `crate::llm::tools::parse::streaming` already cover
+    //! the detector's state machine; these tests cover the loop body
+    //! that pumps deltas through the detector and dispatches each event
+    //! to a sink. Uses `run_detector_loop_with_sink` with a captured
+    //! buffer so the test doesn't depend on the global session sink
+    //! registry — other tests in this binary mutate the registry via
+    //! `reset_all_sinks` and can race a per-session install otherwise.
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use crate::agent_events::{AgentEvent, ToolCallStatus};
+
+    use super::{run_detector_loop_with_sink, StreamingDetectorContext};
+
+    /// Pipe `chunks` through `run_detector_loop_with_sink`, await its
+    /// completion, and return the captured events in arrival order.
+    async fn drive(session_id: &str, known: &[&str], chunks: &[&str]) -> Vec<AgentEvent> {
+        let captured: Rc<RefCell<Vec<AgentEvent>>> = Rc::new(RefCell::new(Vec::new()));
+        let sink_buf = captured.clone();
+        let known_tools = known.iter().map(|s| (*s).to_string()).collect();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        for chunk in chunks {
+            tx.send((*chunk).to_string()).expect("send delta");
+        }
+        drop(tx);
+        run_detector_loop_with_sink(
+            StreamingDetectorContext {
+                session_id: session_id.to_string(),
+                known_tools,
+            },
+            rx,
+            move |event| sink_buf.borrow_mut().push(event.clone()),
+        )
+        .await;
+        let events = captured.borrow().clone();
+        events
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn detector_loop_emits_start_and_promoted_through_sink() {
+        let events = drive(
+            "session-stream-promote",
+            &["read"],
+            &["read({ path: \"a.md\" })"],
+        )
+        .await;
+        assert_eq!(
+            events.len(),
+            2,
+            "expected start + promoted, got: {events:#?}"
+        );
+        match &events[0] {
+            AgentEvent::ToolCall {
+                parsing,
+                tool_name,
+                status,
+                ..
+            } => {
+                assert_eq!(*parsing, Some(true));
+                assert_eq!(tool_name, "read");
+                assert_eq!(*status, ToolCallStatus::Pending);
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+        match &events[1] {
+            AgentEvent::ToolCallUpdate {
+                parsing,
+                status,
+                error_category,
+                ..
+            } => {
+                assert_eq!(*parsing, Some(false));
+                assert_eq!(*status, ToolCallStatus::Pending);
+                assert!(error_category.is_none());
+            }
+            other => panic!("expected ToolCallUpdate, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn detector_loop_finalizes_unclosed_tagged_block_as_aborted() {
+        let events = drive(
+            "session-stream-abort",
+            &["run"],
+            &["<tool_call>\nrun({ command: \"ls\""],
+        )
+        .await;
+        assert_eq!(events.len(), 2, "events={events:#?}");
+        match &events[1] {
+            AgentEvent::ToolCallUpdate {
+                status,
+                error_category,
+                parsing,
+                ..
+            } => {
+                assert_eq!(*status, ToolCallStatus::Failed);
+                assert_eq!(
+                    *error_category,
+                    Some(crate::agent_events::ToolCallErrorCategory::ParseAborted)
+                );
+                assert_eq!(*parsing, Some(false));
+            }
+            other => panic!("expected ToolCallUpdate, got {other:?}"),
+        }
     }
 }

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -510,6 +510,11 @@ pub(crate) async fn execute_llm_call(
             None,
             user_visible,
             bridged, // offthread=true on the bridge path, local set otherwise
+            // Top-level `llm_call` host calls don't have a session in the
+            // sense the streaming detector needs (no agent loop, no
+            // session_id), so skip candidate detection here. The agent
+            // loop's `run_llm_call` is the integration point that owns it.
+            None,
         )
         .await?;
 

--- a/crates/harn-vm/src/llm/tools/mod.rs
+++ b/crates/harn-vm/src/llm/tools/mod.rs
@@ -33,6 +33,7 @@ pub(crate) use native::{
     vm_tools_to_native,
 };
 pub(crate) use parse::parse_text_tool_calls_with_tools;
+pub(crate) use parse::StreamingToolCallDetector;
 #[cfg(test)]
 pub(crate) use parse::{parse_bare_calls_in_body, parse_native_json_tool_calls};
 

--- a/crates/harn-vm/src/llm/tools/parse/mod.rs
+++ b/crates/harn-vm/src/llm/tools/parse/mod.rs
@@ -7,6 +7,7 @@
 
 mod bare;
 mod native_json;
+mod streaming;
 mod syntax;
 mod tagged;
 
@@ -14,6 +15,7 @@ mod tagged;
 pub(crate) use bare::parse_bare_calls_in_body;
 #[cfg(test)]
 pub(crate) use native_json::parse_native_json_tool_calls;
+pub(crate) use streaming::StreamingToolCallDetector;
 pub(crate) use syntax::ident_length;
 pub(crate) use tagged::parse_text_tool_calls_with_tools;
 

--- a/crates/harn-vm/src/llm/tools/parse/streaming.rs
+++ b/crates/harn-vm/src/llm/tools/parse/streaming.rs
@@ -1,0 +1,655 @@
+//! Streaming candidate detector for text-mode tool calls (harn#692).
+//!
+//! Today the post-stream parsers (`parse_text_tool_calls_with_tools` and
+//! `parse_bare_calls_in_body`) only run after the full provider response
+//! is received, so clients see no progress while the model writes a
+//! 200-line `edit({...})` body. This detector consumes the in-flight
+//! assistant text buffer one delta at a time and emits the candidate
+//! lifecycle events that ACP clients render as a "parsing" chip:
+//!
+//! - **Candidate started.** A `<tool_call>` opener at the start of a
+//!   line, or a known-tool bare call shape `name(` at line start. Emits
+//!   `AgentEvent::ToolCall { status: Pending, parsing: Some(true), .. }`.
+//!   `tool_name` is populated for the bare path; for the tagged path it
+//!   stays empty until the body parses, since the inner `name(` may
+//!   arrive in a later delta.
+//! - **Candidate promoted.** Args parsed cleanly. Emits
+//!   `AgentEvent::ToolCallUpdate { status: Pending, parsing:
+//!   Some(false), raw_output: Some(<args>), .. }`. The dispatch path
+//!   (`tool_dispatch.rs`) picks up its own `tool_call_id` for the
+//!   subsequent `Pending → InProgress → Completed/Failed` flow; the
+//!   candidate id is only correlated WITHIN the candidate phase.
+//! - **Candidate aborted.** Args parse failed — malformed JSON, unclosed
+//!   tag, fallthrough to prose, or stream ended mid-call. Emits
+//!   `AgentEvent::ToolCallUpdate { status: Failed, parsing:
+//!   Some(false), error_category: Some(ParseAborted), error: Some(<msg>),
+//!   .. }` so clients dismiss the chip.
+//!
+//! The detector respects markdown code-fence context: a `function(x)`
+//! shape inside a triple-backtick fence does NOT trigger candidate
+//! events, even if `function` happens to be a known tool. The
+//! post-stream parsers are more permissive (they parse calls inside
+//! fences too), but they aren't running until after the stream
+//! completes, so the candidate stream is purely additional UX
+//! observability — never the source of truth for dispatch.
+
+use std::collections::BTreeSet;
+
+use crate::agent_events::{AgentEvent, ToolCallErrorCategory, ToolCallStatus};
+
+use super::syntax::{ident_length, parse_ts_call_from};
+
+const TAGGED_OPEN: &str = "<tool_call>";
+const TAGGED_CLOSE: &str = "</tool_call>";
+
+/// Streaming candidate detector for text-mode tool calls.
+///
+/// One detector per LLM call. Construct with [`StreamingToolCallDetector::new`],
+/// feed each text delta through [`Self::push`], and call
+/// [`Self::finalize`] when the stream ends — finalize emits the
+/// terminal abort event for any candidate that was opened but never
+/// closed (e.g. `<tool_call>` without a matching `</tool_call>`, or a
+/// bare `name(` whose `)` never arrived).
+pub(crate) struct StreamingToolCallDetector {
+    session_id: String,
+    known_tools: BTreeSet<String>,
+    buffer: String,
+    /// Byte position in `buffer` up to which the idle-state scanner has
+    /// consumed. Persists across `push` calls so each delta only
+    /// scans the new bytes (modulo state-machine transitions).
+    cursor: usize,
+    candidate_seq: u64,
+    state: DetectorState,
+    /// Inside a triple-backtick markdown fence. Suppresses candidate
+    /// detection so prose like `function(x)` in a code block doesn't
+    /// emit a candidate. Markdown fences are NOT nestable per the spec
+    /// — toggled on each fence line.
+    in_fence: bool,
+    /// Tracks whether the next byte the scanner sees is at the start of
+    /// a logical line. Bare-call detection only fires at line starts.
+    at_line_start: bool,
+}
+
+enum DetectorState {
+    Idle,
+    /// Inside a `<tool_call>...` block. Buffering until `</tool_call>`.
+    InTaggedBlock {
+        body_start: usize,
+        tool_call_id: String,
+    },
+    /// Inside a bare `name(` call. Buffering until the TS-call parser
+    /// can resolve a balanced `)`.
+    InBareCall {
+        name_start: usize,
+        tool_call_id: String,
+        name: String,
+    },
+}
+
+impl StreamingToolCallDetector {
+    pub(crate) fn new(session_id: String, known_tools: BTreeSet<String>) -> Self {
+        Self {
+            session_id,
+            known_tools,
+            buffer: String::new(),
+            cursor: 0,
+            candidate_seq: 0,
+            state: DetectorState::Idle,
+            in_fence: false,
+            at_line_start: true,
+        }
+    }
+
+    fn next_candidate_id(&mut self) -> String {
+        self.candidate_seq += 1;
+        format!("text-cand-{}", self.candidate_seq)
+    }
+
+    /// Append one streaming delta and return any candidate events that
+    /// the new bytes triggered. Always returns; never blocks on more
+    /// input.
+    pub(crate) fn push(&mut self, delta: &str) -> Vec<AgentEvent> {
+        if delta.is_empty() {
+            return Vec::new();
+        }
+        self.buffer.push_str(delta);
+        self.scan()
+    }
+
+    /// Signal end-of-stream. Emits the terminal abort event for any
+    /// candidate left in flight (unclosed `<tool_call>` tag, bare call
+    /// missing its `)`, or bare call whose final args reject parsing).
+    pub(crate) fn finalize(&mut self) -> Vec<AgentEvent> {
+        let mut events = self.scan();
+        match std::mem::replace(&mut self.state, DetectorState::Idle) {
+            DetectorState::Idle => {}
+            DetectorState::InTaggedBlock { tool_call_id, .. } => {
+                events.push(AgentEvent::ToolCallUpdate {
+                    session_id: self.session_id.clone(),
+                    tool_call_id,
+                    tool_name: String::new(),
+                    status: ToolCallStatus::Failed,
+                    raw_output: None,
+                    error: Some(
+                        "<tool_call> block did not close before the response ended.".to_string(),
+                    ),
+                    duration_ms: None,
+                    execution_duration_ms: None,
+                    error_category: Some(ToolCallErrorCategory::ParseAborted),
+                    executor: None,
+                    parsing: Some(false),
+                });
+            }
+            DetectorState::InBareCall {
+                name_start,
+                tool_call_id,
+                name,
+            } => {
+                let attempt = parse_ts_call_from(&self.buffer[name_start..], name.clone());
+                match attempt {
+                    Ok((args, _)) => {
+                        events.push(promote_event(&self.session_id, tool_call_id, name, args));
+                    }
+                    Err(msg) => {
+                        events.push(abort_event(&self.session_id, tool_call_id, name, msg));
+                    }
+                }
+            }
+        }
+        events
+    }
+
+    fn scan(&mut self) -> Vec<AgentEvent> {
+        let mut events = Vec::new();
+        loop {
+            let progressed = match self.state {
+                DetectorState::Idle => self.scan_idle(&mut events),
+                DetectorState::InTaggedBlock { .. } => self.scan_tagged(&mut events),
+                DetectorState::InBareCall { .. } => self.scan_bare(&mut events),
+            };
+            if !progressed {
+                break;
+            }
+        }
+        events
+    }
+
+    /// Walk forward from `cursor` looking for the next candidate marker.
+    /// Returns `true` if a candidate was found (and we transitioned out
+    /// of `Idle`), `false` if the rest of the buffer is consumed without
+    /// finding one. Tracks fence-depth and line-start state in-place so
+    /// the next call can resume cleanly.
+    fn scan_idle(&mut self, events: &mut Vec<AgentEvent>) -> bool {
+        let bytes = self.buffer.as_bytes();
+        let mut i = self.cursor;
+        while i < bytes.len() {
+            let b = bytes[i];
+            if b == b'\n' {
+                self.at_line_start = true;
+                i += 1;
+                continue;
+            }
+
+            if self.at_line_start {
+                // Skip leading whitespace to locate the first non-blank
+                // byte of the line.
+                let mut j = i;
+                while j < bytes.len() && (bytes[j] == b' ' || bytes[j] == b'\t') {
+                    j += 1;
+                }
+                if j >= bytes.len() {
+                    // Whitespace runs to end of buffer — wait for more.
+                    self.cursor = i;
+                    return false;
+                }
+
+                // Triple-backtick fence: require the line's `\n` to be
+                // present before committing to the toggle, otherwise an
+                // incomplete fence opener might be misclassified.
+                if bytes[j] == b'`'
+                    && bytes.get(j + 1) == Some(&b'`')
+                    && bytes.get(j + 2) == Some(&b'`')
+                {
+                    let eol = bytes[j + 3..].iter().position(|&c| c == b'\n');
+                    let Some(eol_rel) = eol else {
+                        // Fence opener without EOL yet — wait.
+                        self.cursor = i;
+                        return false;
+                    };
+                    self.in_fence = !self.in_fence;
+                    i = j + 3 + eol_rel + 1;
+                    self.at_line_start = true;
+                    continue;
+                }
+
+                if self.in_fence {
+                    // Skip to end of line; fence content is opaque.
+                    while i < bytes.len() && bytes[i] != b'\n' {
+                        i += 1;
+                    }
+                    continue;
+                }
+
+                // Tagged opener.
+                let rest = &self.buffer[j..];
+                if rest.starts_with(TAGGED_OPEN) {
+                    let body_start = j + TAGGED_OPEN.len();
+                    let id = self.next_candidate_id();
+                    events.push(AgentEvent::ToolCall {
+                        session_id: self.session_id.clone(),
+                        tool_call_id: id.clone(),
+                        tool_name: String::new(),
+                        kind: None,
+                        status: ToolCallStatus::Pending,
+                        raw_input: serde_json::json!({}),
+                        parsing: Some(true),
+                    });
+                    self.state = DetectorState::InTaggedBlock {
+                        body_start,
+                        tool_call_id: id,
+                    };
+                    self.cursor = body_start;
+                    return true;
+                }
+                if TAGGED_OPEN.starts_with(rest) {
+                    // Partial `<tool_call>` prefix — wait for the rest.
+                    self.cursor = i;
+                    return false;
+                }
+
+                // Bare ident + `(`. Require the identifier to be
+                // terminated (next byte not an identifier-continuation)
+                // before deciding, so a delta arriving mid-name doesn't
+                // commit to a wrong-shape conclusion.
+                if let Some(name_len) = ident_length(&bytes[j..]) {
+                    let term = j + name_len;
+                    if term >= bytes.len() {
+                        // Identifier still streaming.
+                        self.cursor = i;
+                        return false;
+                    }
+                    if bytes[term] == b'(' {
+                        let name = std::str::from_utf8(&bytes[j..term])
+                            .unwrap_or("")
+                            .to_string();
+                        if self.known_tools.contains(&name) {
+                            let id = self.next_candidate_id();
+                            events.push(AgentEvent::ToolCall {
+                                session_id: self.session_id.clone(),
+                                tool_call_id: id.clone(),
+                                tool_name: name.clone(),
+                                kind: None,
+                                status: ToolCallStatus::Pending,
+                                raw_input: serde_json::json!({}),
+                                parsing: Some(true),
+                            });
+                            self.state = DetectorState::InBareCall {
+                                name_start: j,
+                                tool_call_id: id,
+                                name,
+                            };
+                            self.cursor = j;
+                            return true;
+                        }
+                    }
+                    // Identifier didn't match a tool — skip past it.
+                    i = term;
+                    self.at_line_start = false;
+                    continue;
+                }
+
+                // Line starts with non-identifier non-fence non-tag —
+                // mark not-line-start and advance past current byte.
+                self.at_line_start = false;
+                i = j + 1;
+                continue;
+            }
+
+            // Mid-line: just walk forward.
+            i += 1;
+        }
+        self.cursor = i;
+        false
+    }
+
+    fn scan_tagged(&mut self, events: &mut Vec<AgentEvent>) -> bool {
+        let (body_start, tool_call_id) = match &self.state {
+            DetectorState::InTaggedBlock {
+                body_start,
+                tool_call_id,
+            } => (*body_start, tool_call_id.clone()),
+            _ => return false,
+        };
+        let Some(close_rel) = self.buffer[body_start..].find(TAGGED_CLOSE) else {
+            return false;
+        };
+        let body_end = body_start + close_rel;
+        let after = body_end + TAGGED_CLOSE.len();
+        let body = self.buffer[body_start..body_end].trim().to_string();
+        let parse_attempt = if body.is_empty() {
+            Err("<tool_call> body was empty.".to_string())
+        } else if let Some(name_len) = ident_length(body.as_bytes()) {
+            let name = body[..name_len].to_string();
+            if !self.known_tools.contains(&name) {
+                Err(format!("Unknown tool '{name}' in <tool_call> body."))
+            } else if body.as_bytes().get(name_len) != Some(&b'(') {
+                Err(format!(
+                    "Expected `{name}(` immediately after the tool name in <tool_call> body."
+                ))
+            } else {
+                parse_ts_call_from(&body, name.clone()).map(|(args, _)| (name, args))
+            }
+        } else {
+            Err("<tool_call> body did not begin with a `name(` identifier.".to_string())
+        };
+        match parse_attempt {
+            Ok((name, args)) => {
+                events.push(promote_event(&self.session_id, tool_call_id, name, args));
+            }
+            Err(msg) => {
+                events.push(abort_event(
+                    &self.session_id,
+                    tool_call_id,
+                    String::new(),
+                    msg,
+                ));
+            }
+        }
+        self.state = DetectorState::Idle;
+        self.cursor = after;
+        // Treat the `</tool_call>` close as a clean line break so the
+        // next bare call on its own line is still detected at line
+        // start, even if the source emitted them adjacently.
+        self.at_line_start = true;
+        true
+    }
+
+    fn scan_bare(&mut self, events: &mut Vec<AgentEvent>) -> bool {
+        let (name_start, tool_call_id, name) = match &self.state {
+            DetectorState::InBareCall {
+                name_start,
+                tool_call_id,
+                name,
+            } => (*name_start, tool_call_id.clone(), name.clone()),
+            _ => return false,
+        };
+        let attempt = parse_ts_call_from(&self.buffer[name_start..], name.clone());
+        match attempt {
+            Ok((args, consumed)) => {
+                events.push(promote_event(&self.session_id, tool_call_id, name, args));
+                self.state = DetectorState::Idle;
+                self.cursor = name_start + consumed;
+                self.at_line_start = false;
+                true
+            }
+            Err(_) => {
+                // Args still streaming. We don't try to distinguish
+                // "transient (waiting for `)`)" from "definitely
+                // malformed" mid-stream — the same parse runs at
+                // finalize() and reports the abort there. This avoids
+                // false aborts when a multi-line heredoc pauses between
+                // chunks.
+                false
+            }
+        }
+    }
+}
+
+fn promote_event(
+    session_id: &str,
+    tool_call_id: String,
+    name: String,
+    args: serde_json::Value,
+) -> AgentEvent {
+    AgentEvent::ToolCallUpdate {
+        session_id: session_id.to_string(),
+        tool_call_id,
+        tool_name: name,
+        status: ToolCallStatus::Pending,
+        raw_output: Some(args),
+        error: None,
+        duration_ms: None,
+        execution_duration_ms: None,
+        error_category: None,
+        executor: None,
+        parsing: Some(false),
+    }
+}
+
+fn abort_event(
+    session_id: &str,
+    tool_call_id: String,
+    tool_name: String,
+    msg: String,
+) -> AgentEvent {
+    AgentEvent::ToolCallUpdate {
+        session_id: session_id.to_string(),
+        tool_call_id,
+        tool_name,
+        status: ToolCallStatus::Failed,
+        raw_output: None,
+        error: Some(msg),
+        duration_ms: None,
+        execution_duration_ms: None,
+        error_category: Some(ToolCallErrorCategory::ParseAborted),
+        executor: None,
+        parsing: Some(false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn known_set(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    fn detector(names: &[&str]) -> StreamingToolCallDetector {
+        StreamingToolCallDetector::new("session-1".to_string(), known_set(names))
+    }
+
+    /// Walk every event the detector emits when fed `chunks`, finalize,
+    /// and return them in order. Tests assert on this flat list.
+    fn run(chunks: &[&str], detector: &mut StreamingToolCallDetector) -> Vec<AgentEvent> {
+        let mut all = Vec::new();
+        for chunk in chunks {
+            all.extend(detector.push(chunk));
+        }
+        all.extend(detector.finalize());
+        all
+    }
+
+    fn unwrap_call(event: &AgentEvent) -> (&str, &str, Option<bool>) {
+        match event {
+            AgentEvent::ToolCall {
+                tool_call_id,
+                tool_name,
+                parsing,
+                ..
+            } => (tool_call_id.as_str(), tool_name.as_str(), *parsing),
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+    }
+
+    fn unwrap_update(
+        event: &AgentEvent,
+    ) -> (
+        &str,
+        &str,
+        ToolCallStatus,
+        Option<bool>,
+        Option<ToolCallErrorCategory>,
+    ) {
+        match event {
+            AgentEvent::ToolCallUpdate {
+                tool_call_id,
+                tool_name,
+                status,
+                parsing,
+                error_category,
+                ..
+            } => (
+                tool_call_id.as_str(),
+                tool_name.as_str(),
+                *status,
+                *parsing,
+                *error_category,
+            ),
+            other => panic!("expected ToolCallUpdate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bare_candidate_promotes_on_balanced_close() {
+        let mut det = detector(&["read"]);
+        let events = run(&["read({", " path: \"a.md\" })"], &mut det);
+        assert_eq!(events.len(), 2, "events={events:#?}");
+        let (id, name, parsing) = unwrap_call(&events[0]);
+        assert_eq!(name, "read");
+        assert_eq!(parsing, Some(true));
+        let (id2, name2, status, parsing, cat) = unwrap_update(&events[1]);
+        assert_eq!(id, id2, "candidate id reused on promotion");
+        assert_eq!(name2, "read");
+        assert_eq!(status, ToolCallStatus::Pending);
+        assert_eq!(parsing, Some(false));
+        assert!(cat.is_none(), "promote has no error_category");
+    }
+
+    #[test]
+    fn bare_candidate_aborts_on_malformed_args() {
+        // The `name(` opens a candidate. The body is broken JSON and
+        // the stream ends without a balanced `)`. finalize() emits the
+        // abort with parse_aborted.
+        let mut det = detector(&["edit"]);
+        let events = run(&["edit({ broken: , }"], &mut det);
+        assert_eq!(events.len(), 2, "events={events:#?}");
+        let (start_id, start_name, start_parsing) = unwrap_call(&events[0]);
+        assert_eq!(start_name, "edit");
+        assert_eq!(start_parsing, Some(true));
+        let (terminal_id, _name, status, parsing, cat) = unwrap_update(&events[1]);
+        assert_eq!(start_id, terminal_id);
+        assert_eq!(status, ToolCallStatus::Failed);
+        assert_eq!(parsing, Some(false));
+        assert_eq!(cat, Some(ToolCallErrorCategory::ParseAborted));
+    }
+
+    #[test]
+    fn tagged_candidate_promotes_when_block_closes() {
+        let mut det = detector(&["run"]);
+        let events = run(
+            &[
+                "<tool_call>\n",
+                "run({ command: \"ls\" })\n",
+                "</tool_call>",
+            ],
+            &mut det,
+        );
+        assert_eq!(events.len(), 2, "events={events:#?}");
+        let (start_id, start_name, parsing) = unwrap_call(&events[0]);
+        assert_eq!(start_name, "");
+        assert_eq!(parsing, Some(true));
+        let (terminal_id, terminal_name, status, parsing, cat) = unwrap_update(&events[1]);
+        assert_eq!(start_id, terminal_id, "ids match across promote");
+        assert_eq!(terminal_name, "run");
+        assert_eq!(status, ToolCallStatus::Pending);
+        assert_eq!(parsing, Some(false));
+        assert!(cat.is_none());
+    }
+
+    #[test]
+    fn tagged_candidate_aborts_when_tag_never_closes() {
+        let mut det = detector(&["run"]);
+        let events = run(&["<tool_call>\nrun({ command: \"ls\" })"], &mut det);
+        assert_eq!(events.len(), 2);
+        let (start_id, _, parsing) = unwrap_call(&events[0]);
+        assert_eq!(parsing, Some(true));
+        let (terminal_id, _, status, parsing, cat) = unwrap_update(&events[1]);
+        assert_eq!(start_id, terminal_id);
+        assert_eq!(status, ToolCallStatus::Failed);
+        assert_eq!(parsing, Some(false));
+        assert_eq!(cat, Some(ToolCallErrorCategory::ParseAborted));
+    }
+
+    #[test]
+    fn prose_inside_code_fence_does_not_trigger_candidate() {
+        // `read(x)` inside a fenced code block must not emit a
+        // candidate, even though `read` is in the known-tools set.
+        let mut det = detector(&["read"]);
+        let events = run(
+            &[
+                "Here is some code:\n",
+                "```python\n",
+                "read(x)\n",
+                "```\n",
+                "Done.\n",
+            ],
+            &mut det,
+        );
+        assert!(
+            events.is_empty(),
+            "expected no candidate events inside fence, got: {events:#?}"
+        );
+    }
+
+    #[test]
+    fn unknown_tool_at_line_start_does_not_open_candidate() {
+        let mut det = detector(&["read", "edit"]);
+        let events = run(&["mystery({ foo: 1 })"], &mut det);
+        assert!(
+            events.is_empty(),
+            "unknown tool name must not open a candidate, got: {events:#?}"
+        );
+    }
+
+    #[test]
+    fn deltas_split_mid_identifier_do_not_commit_prematurely() {
+        // First delta arrives with only `re`. We must not conclude
+        // "no tool call" — once `read({...})` arrives we still emit
+        // a candidate. The detector waits when the identifier hasn't
+        // terminated yet.
+        let mut det = detector(&["read"]);
+        let events = run(&["re", "ad({ path: \"a.md\" })"], &mut det);
+        assert_eq!(events.len(), 2, "events={events:#?}");
+        let (_, name, parsing) = unwrap_call(&events[0]);
+        assert_eq!(name, "read");
+        assert_eq!(parsing, Some(true));
+        let (_, _, status, parsing, _) = unwrap_update(&events[1]);
+        assert_eq!(status, ToolCallStatus::Pending);
+        assert_eq!(parsing, Some(false));
+    }
+
+    #[test]
+    fn finalize_on_empty_stream_emits_nothing() {
+        let mut det = detector(&["read"]);
+        let events = run(&[], &mut det);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn empty_delta_is_a_noop() {
+        let mut det = detector(&["read"]);
+        let events = det.push("");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn multiple_sequential_candidates_each_get_a_distinct_id() {
+        let mut det = detector(&["read", "run"]);
+        let events = run(
+            &["read({ path: \"a.md\" })\n", "run({ command: \"ls\" })\n"],
+            &mut det,
+        );
+        // Expect: start1, promote1, start2, promote2.
+        assert_eq!(events.len(), 4, "events={events:#?}");
+        let (id1, name1, _) = unwrap_call(&events[0]);
+        let (id1u, _, _, _, _) = unwrap_update(&events[1]);
+        let (id2, name2, _) = unwrap_call(&events[2]);
+        let (id2u, _, _, _, _) = unwrap_update(&events[3]);
+        assert_eq!(id1, id1u);
+        assert_eq!(id2, id2u);
+        assert_ne!(id1, id2, "each candidate gets its own id");
+        assert_eq!(name1, "read");
+        assert_eq!(name2, "run");
+    }
+}

--- a/crates/harn-vm/src/llm/tools/parse/syntax.rs
+++ b/crates/harn-vm/src/llm/tools/parse/syntax.rs
@@ -204,7 +204,7 @@ pub(crate) fn ident_length(bytes: &[u8]) -> Option<usize> {
 /// `text`. Returns the parsed argument JSON and the number of bytes consumed
 /// (from the start of the name through the closing paren), or an error with
 /// a diagnostic suitable to show the model.
-pub(super) fn parse_ts_call_from(
+pub(crate) fn parse_ts_call_from(
     text: &str,
     name: String,
 ) -> Result<(serde_json::Value, usize), String> {


### PR DESCRIPTION
## Summary

Closes [harn#692](https://github.com/burin-labs/harn/issues/692). Make text-mode tool-call parsing observable in real time. Today the post-stream parsers (`parse_text_tool_calls_with_tools` and `parse_bare_calls_in_body`) only run after the full provider response is received, so clients see no progress while the model writes a 200-line `edit({...})` body.

This PR adds a streaming candidate detector that emits the lifecycle events ACP clients render as a "parsing" chip:

- **Candidate started.** `tool_call { parsing: true, status: pending }` when a candidate shape is detected — `<tool_call>` opener (tagged) or known-tool bare call `name(` at line start.
- **Candidate promoted.** `tool_call_update { parsing: false, status: pending, raw_output: <args> }` when args parse cleanly.
- **Candidate aborted.** `tool_call_update { parsing: false, status: failed, error_category: parse_aborted }` when args fail (malformed JSON, unbalanced brace, unclosed `<tool_call>` tag, stream ended mid-call).

The detector respects markdown code-fence context: a `function(x)` shape inside a triple-backtick fence does **not** trigger candidate events, even if `function` is in the known-tools set. The post-stream parsers are unchanged — the candidate stream is purely additional observability layered on top of the same buffer.

### What changed

- **`ToolCallErrorCategory::ParseAborted`** — extends harn#690's enum with `"parse_aborted"`.
- **`parsing: Option<bool>`** field on `AgentEvent::ToolCall` and `AgentEvent::ToolCallUpdate`. Serialized only when `Some` so older ACP clients see no shape change.
- **ACP wire mapping** — literal `"parsing": true|false` on `session/update` notifications.
- **`crates/harn-vm/src/llm/tools/parse/streaming.rs`** — the detector itself: state-machine, fence tracking, line-start detection.
- **`crates/harn-vm/src/llm/agent_observe.rs`** — wires the detector into both bridge-attached (`spawn_progress_forwarder`) and non-bridge (`spawn_detector_only_forwarder`) streaming paths.
- **`crates/harn-vm/src/llm/agent/llm_call.rs`** — constructs a `StreamingDetectorContext` from `state.session_id` + the registered tool set; skips for native-mode stages (provider-side server-side streaming is H4 / harn#693) and for direct `llm_call` host invocations outside an agent loop.
- **CHANGELOG.md** — entry under v0.7.41.

### Tests

12 new tests, all passing:

- **Detector unit tests** (`streaming.rs`, 10): bare promotes, bare aborts on malformed args, tagged promotes, tagged aborts on unclosed tag, prose inside code fence does not trigger candidate, mid-identifier delta split waits for more, multiple sequential candidates each get a distinct id, finalize on empty stream, empty delta no-op, and unknown tool name does not open a candidate.
- **Loop wiring tests** (`agent_observe.rs`, 2): the loop body that pumps deltas through the detector and dispatches each event to a sink.
- **ACP serialization test** (`harn-serve/.../events.rs`): asserts `parsing` round-trips through the wire format and is omitted when `None`.

## Test plan

- [x] `cargo test -p harn-vm --lib -- llm::tools::parse llm::agent_observe agent_events` — 42/42 passing
- [x] `cargo test -p harn-serve --lib` — 38/38 passing
- [x] `cargo clippy -p harn-vm -p harn-serve --lib --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI workspace test gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)