### PR TITLE
Stream partial native tool-call arguments as ToolCallUpdate(pending) (closes #693)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ granular archaeology.
 
 ### Added
 
+- **Streaming partial native tool-call arguments (#693).** Provider
+  SSE streams now surface their `tool_use` / `tool_calls` blocks
+  through the agent-event stream the moment they open instead of
+  waiting for `content_block_stop` / end-of-stream. The Anthropic
+  `input_json_delta` and OpenAI `tool_calls[].function.arguments`
+  channels each emit a typed `NativeToolCallDelta` lifecycle: a
+  one-shot `Start { tool_use_id, tool_name }` on the first sighting,
+  then `InputDelta { accumulated_partial_json }` events coalesced
+  into ~50ms windows so slow clients aren't drowned in per-character
+  churn. The agent-loop progress forwarder rewrites those deltas as
+  `AgentEvent::ToolCall { status: Pending, raw_input: {} }` followed
+  by repeating `AgentEvent::ToolCallUpdate { status: Pending,
+  raw_input | raw_input_partial }` notifications, both routed under
+  the owning session id. ACP clients (Burin CLI/TUI/IDE) can render
+  "calling search_web…" instantly and watch the arguments grow as
+  they stream — the live `rawInput` / `rawInputPartial` previews are
+  a permissive partial-JSON parse with a raw-bytes fallback when the
+  in-flight stream is structurally unrecoverable. The terminal
+  `tool_call_update(Pending → InProgress → Completed/Failed)`
+  lifecycle is unchanged, so the existing dispatch-side telemetry
+  still lands as before.
 - **Tool-call timing on ACP `tool_call_update` (#689).** Terminal
   `tool_call_update` events now carry `durationMs` (the parse-to-finish
   total — model emits the call → tool result is appended) and

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -128,6 +128,8 @@ impl AgentEventSink for AcpAgentEventSink {
                 execution_duration_ms,
                 error_category,
                 executor,
+                raw_input,
+                raw_input_partial,
             } => {
                 let mut update = serde_json::json!({
                     "sessionUpdate": "tool_call_update",
@@ -152,6 +154,18 @@ impl AgentEventSink for AcpAgentEventSink {
                 }
                 if let Some(exec) = executor {
                     update["executor"] = Self::executor_to_json(exec);
+                }
+                // Streaming-only fields (harn#693). The two are
+                // mutually exclusive: when the partial JSON parsed, the
+                // structured value lands as `rawInput`; on parse
+                // failure the raw bytes spill into `rawInputPartial`.
+                // Clients keying off `rawInput` get a no-op on parse
+                // failure and can fall back to the partial-bytes path.
+                if let Some(input) = raw_input {
+                    update["rawInput"] = input.clone();
+                }
+                if let Some(partial) = raw_input_partial {
+                    update["rawInputPartial"] = serde_json::Value::String(partial.clone());
                 }
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
@@ -404,6 +418,8 @@ mod tests {
                 execution_duration_ms: Some(5),
                 error_category: None,
                 executor: Some(ToolExecutor::HarnBuiltin),
+                raw_input: None,
+                raw_input_partial: None,
             },
             AgentEvent::Plan {
                 session_id: "session-1".to_string(),
@@ -510,6 +526,8 @@ mod tests {
             execution_duration_ms: None,
             error_category: Some(ToolCallErrorCategory::SchemaValidation),
             executor: None,
+            raw_input: None,
+            raw_input_partial: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -543,6 +561,8 @@ mod tests {
             execution_duration_ms: None,
             error_category: None,
             executor: None,
+            raw_input: None,
+            raw_input_partial: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -586,6 +606,8 @@ mod tests {
                 execution_duration_ms: None,
                 error_category: None,
                 executor: Some(executor),
+                raw_input: None,
+                raw_input_partial: None,
             });
             let line = rx.recv().await.expect("acp tool_call_update notification");
             let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -609,6 +631,8 @@ mod tests {
             execution_duration_ms: None,
             error_category: None,
             executor: None,
+            raw_input: None,
+            raw_input_partial: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -616,6 +640,100 @@ mod tests {
             payload["params"]["update"].get("executor").is_none(),
             "got: {payload}"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tool_call_update_serializes_raw_input_when_partial_parse_succeeded() {
+        // harn#693: streaming `Pending` updates from the native-streaming
+        // forwarder carry the structured value in `rawInput` whenever
+        // the permissive partial-JSON parser succeeded. ACP clients can
+        // render the live preview directly off `rawInput`.
+        use harn_vm::agent_events::ToolCallStatus;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+        sink.handle_event(&AgentEvent::ToolCallUpdate {
+            session_id: "session-1".to_string(),
+            tool_call_id: "tool-toolu_42".to_string(),
+            tool_name: "edit".to_string(),
+            status: ToolCallStatus::Pending,
+            raw_output: None,
+            error: None,
+            duration_ms: None,
+            execution_duration_ms: None,
+            error_category: None,
+            executor: None,
+            raw_input: Some(serde_json::json!({"path": "src/lib"})),
+            raw_input_partial: None,
+        });
+        let line = rx.recv().await.expect("acp tool_call_update notification");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        assert_eq!(payload["params"]["update"]["status"], "pending");
+        assert_eq!(
+            payload["params"]["update"]["rawInput"],
+            serde_json::json!({"path": "src/lib"})
+        );
+        // Mutually exclusive with `rawInputPartial` — must be absent
+        // when `rawInput` was set.
+        assert!(
+            payload["params"]["update"].get("rawInputPartial").is_none(),
+            "got: {payload}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tool_call_update_serializes_raw_input_partial_when_partial_parse_failed() {
+        use harn_vm::agent_events::ToolCallStatus;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+        sink.handle_event(&AgentEvent::ToolCallUpdate {
+            session_id: "session-1".to_string(),
+            tool_call_id: "tool-toolu_42".to_string(),
+            tool_name: "edit".to_string(),
+            status: ToolCallStatus::Pending,
+            raw_output: None,
+            error: None,
+            duration_ms: None,
+            execution_duration_ms: None,
+            error_category: None,
+            executor: None,
+            raw_input: None,
+            raw_input_partial: Some(r#"{"path": "a\"#.to_string()),
+        });
+        let line = rx.recv().await.expect("acp tool_call_update notification");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        assert_eq!(
+            payload["params"]["update"]["rawInputPartial"],
+            r#"{"path": "a\"#
+        );
+        assert!(payload["params"]["update"].get("rawInput").is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tool_call_update_omits_streaming_fields_when_absent() {
+        // Terminal updates (Completed/Failed) carry neither `rawInput`
+        // nor `rawInputPartial`. The wire format must omit both keys
+        // so legacy clients keying off presence aren't confused.
+        use harn_vm::agent_events::ToolCallStatus;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+        sink.handle_event(&AgentEvent::ToolCallUpdate {
+            session_id: "session-1".to_string(),
+            tool_call_id: "tool-toolu_42".to_string(),
+            tool_name: "edit".to_string(),
+            status: ToolCallStatus::Completed,
+            raw_output: Some(serde_json::json!({"ok": true})),
+            error: None,
+            duration_ms: Some(7),
+            execution_duration_ms: Some(5),
+            error_category: None,
+            executor: None,
+            raw_input: None,
+            raw_input_partial: None,
+        });
+        let line = rx.recv().await.expect("acp tool_call_update notification");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        assert!(payload["params"]["update"].get("rawInput").is_none());
+        assert!(payload["params"]["update"].get("rawInputPartial").is_none());
     }
 
     #[test]

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -247,6 +247,26 @@ pub enum AgentEvent {
         /// dispatcher picks a backend).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         executor: Option<ToolExecutor>,
+        /// Best-effort partial parse of the in-progress tool-call
+        /// arguments, populated only on the streaming `Pending` updates
+        /// emitted by the native-streaming SSE handler (harn#693). The
+        /// value grows with each delta as more JSON arrives. `None` on
+        /// the post-dispatch `InProgress` / `Completed` / `Failed`
+        /// updates and on every update emitted before a tool block
+        /// reaches the partial-parsable threshold. Mutually populated
+        /// with `raw_input_partial`: when the partial JSON parses
+        /// cleanly, this is `Some`; when the parse fails, the raw
+        /// concatenated bytes spill into `raw_input_partial` instead.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        raw_input: Option<serde_json::Value>,
+        /// Raw concatenated bytes of in-progress tool-call arguments
+        /// JSON when `raw_input` could not be partial-parsed. Streaming
+        /// clients render this verbatim (or with their own permissive
+        /// parser) so users see a live preview of arguments as they
+        /// arrive (harn#693). `None` whenever `raw_input` is `Some` and
+        /// on every non-streaming update.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        raw_input_partial: Option<String>,
     },
     Plan {
         session_id: String,
@@ -820,6 +840,8 @@ mod tests {
             execution_duration_ms: Some(7),
             error_category: None,
             executor: None,
+            raw_input: None,
+            raw_input_partial: None,
         };
         let value = serde_json::to_value(&terminal).unwrap();
         assert_eq!(value["duration_ms"], serde_json::json!(42));
@@ -839,6 +861,8 @@ mod tests {
             execution_duration_ms: None,
             error_category: None,
             executor: None,
+            raw_input: None,
+            raw_input_partial: None,
         };
         let value = serde_json::to_value(&intermediate).unwrap();
         let object = value.as_object().expect("update serializes as object");
@@ -1017,6 +1041,8 @@ mod tests {
             execution_duration_ms: None,
             error_category: None,
             executor: None,
+            raw_input: None,
+            raw_input_partial: None,
         };
         let v = serde_json::to_value(&event).unwrap();
         assert_eq!(v["type"], "tool_call_update");
@@ -1036,6 +1062,8 @@ mod tests {
             execution_duration_ms: None,
             error_category: Some(ToolCallErrorCategory::SchemaValidation),
             executor: None,
+            raw_input: None,
+            raw_input_partial: None,
         };
         let v = serde_json::to_value(&event).unwrap();
         assert_eq!(v["error_category"], "schema_validation");
@@ -1058,6 +1086,8 @@ mod tests {
             execution_duration_ms: None,
             error_category: None,
             executor: None,
+            raw_input: None,
+            raw_input_partial: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert!(json.get("executor").is_none(), "got: {json}");
@@ -1078,6 +1108,8 @@ mod tests {
             executor: Some(ToolExecutor::McpServer {
                 server_name: "github".into(),
             }),
+            raw_input: None,
+            raw_input_partial: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["executor"]["kind"], "mcp_server");

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -94,6 +94,10 @@ pub(super) async fn run_llm_call(
         Some(iteration),
         true,
         false, // agent_loop runs on the local set, not offthread
+        // The agent loop owns the session — pass it through so
+        // native tool-call streaming events route to ACP/closure
+        // subscribers under the right session id (harn#693).
+        Some(state.session_id.as_str()),
     )
     .await?;
 
@@ -642,6 +646,8 @@ pub(super) fn provider_native_search_emissions(
                     execution_duration_ms: None,
                     error_category: None,
                     executor: Some(ToolExecutor::ProviderNative),
+                    raw_input: None,
+                    raw_input_partial: None,
                 });
             }
             _ => {}

--- a/crates/harn-vm/src/llm/agent/tests/transcript.rs
+++ b/crates/harn-vm/src/llm/agent/tests/transcript.rs
@@ -37,6 +37,7 @@ async fn observed_llm_call_transcript_deduplicates_system_and_tool_schemas() {
             Some(iteration),
             false,
             false,
+            None,
         )
         .await
         .unwrap();
@@ -113,6 +114,7 @@ async fn observed_llm_call_transcript_uses_explicit_tool_format() {
         Some(0),
         false,
         false,
+        None,
     )
     .await
     .unwrap();
@@ -162,6 +164,7 @@ async fn observed_llm_call_transcript_records_thinking_settings() {
         Some(0),
         false,
         false,
+        None,
     )
     .await
     .unwrap();
@@ -214,6 +217,7 @@ async fn assert_observed_llm_call_bridge_user_visible(user_visible: bool) {
                 None,
                 user_visible,
                 false,
+                None,
             )
             .await
             .unwrap();

--- a/crates/harn-vm/src/llm/agent/tool_dispatch.rs
+++ b/crates/harn-vm/src/llm/agent/tool_dispatch.rs
@@ -560,6 +560,8 @@ pub(super) async fn run_tool_dispatch(
                 execution_duration_ms: None,
                 error_category: Some(ToolCallErrorCategory::SchemaValidation),
                 executor: None,
+                raw_input: None,
+                raw_input_partial: None,
             })
             .await;
             if ctx.tool_format == "native" {
@@ -628,6 +630,8 @@ pub(super) async fn run_tool_dispatch(
                 execution_duration_ms: None,
                 error_category: Some(ToolCallErrorCategory::PermissionDenied),
                 executor: None,
+                raw_input: None,
+                raw_input_partial: None,
             })
             .await;
             if ctx.tool_format == "native" {
@@ -727,6 +731,8 @@ pub(super) async fn run_tool_dispatch(
                         execution_duration_ms: None,
                         error_category: Some(ToolCallErrorCategory::PermissionDenied),
                         executor: None,
+                        raw_input: None,
+                        raw_input_partial: None,
                     })
                     .await;
                     if ctx.tool_format == "native" {
@@ -854,6 +860,8 @@ pub(super) async fn run_tool_dispatch(
                 execution_duration_ms: None,
                 error_category: Some(ToolCallErrorCategory::PermissionDenied),
                 executor: None,
+                raw_input: None,
+                raw_input_partial: None,
             })
             .await;
             if ctx.tool_format == "native" {
@@ -915,6 +923,8 @@ pub(super) async fn run_tool_dispatch(
                     execution_duration_ms: None,
                     error_category: Some(ToolCallErrorCategory::PermissionDenied),
                     executor: None,
+                    raw_input: None,
+                    raw_input_partial: None,
                 })
                 .await;
                 if ctx.tool_format == "native" {
@@ -962,6 +972,8 @@ pub(super) async fn run_tool_dispatch(
                 execution_duration_ms: None,
                 error_category: Some(ToolCallErrorCategory::SchemaValidation),
                 executor: None,
+                raw_input: None,
+                raw_input_partial: None,
             })
             .await;
             if ctx.tool_format == "native" {
@@ -1006,6 +1018,8 @@ pub(super) async fn run_tool_dispatch(
             // The dispatcher picks the backend below; the in-progress
             // emission is unconditional and runs before that choice.
             executor: None,
+            raw_input: None,
+            raw_input_partial: None,
         })
         .await;
         let tool_span_id =
@@ -1084,6 +1098,8 @@ pub(super) async fn run_tool_dispatch(
                     // Loop intervention preempts the backend choice —
                     // the tool never ran.
                     executor: None,
+                    raw_input: None,
+                    raw_input_partial: None,
                 })
                 .await;
                 continue;
@@ -1260,6 +1276,8 @@ pub(super) async fn run_tool_dispatch(
             execution_duration_ms: Some(execution_duration_ms),
             error_category: final_error_category,
             executor: tool_executor.clone(),
+            raw_input: None,
+            raw_input_partial: None,
         })
         .await;
 

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -595,6 +595,10 @@ pub fn register_llm_call_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Host
                 None,
                 user_visible,
                 true,
+                // No session — this is the standalone `llm_call` builtin
+                // path. Native tool-call streaming events have no
+                // ACP/closure subscribers to fan out to.
+                None,
             )
             .await?;
 

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -42,6 +42,8 @@ use crate::value::VmError;
 use super::api::{vm_call_llm_full_streaming, vm_call_llm_full_streaming_offthread, DeltaSender};
 use super::trace::{trace_llm_call, LlmTraceEntry};
 
+use crate::agent_events::{AgentEvent, ToolCallStatus};
+
 use super::agent_tools::next_call_id;
 
 thread_local! {
@@ -498,23 +500,188 @@ pub(super) fn chrono_now() -> String {
     format!("{}.{:03}", now.as_secs(), now.subsec_millis())
 }
 
-/// Create an unbounded channel and spawn a local task that forwards text
-/// deltas to `bridge.send_call_progress()`.
+/// Create the streaming text + native-tool channels and spawn the
+/// per-call forwarders. Text deltas go to `bridge.send_call_progress()`;
+/// native tool-call lifecycle events are translated into
+/// `AgentEvent::ToolCall` / `ToolCallUpdate` and emitted under the
+/// caller's `session_id` so ACP / closure subscribers see in-progress
+/// argument streaming as `tool_call_update(pending)` events with a
+/// growing `rawInput` (harn#693).
+///
+/// `session_id` is `None` only for callers outside the agent loop (e.g.
+/// the standalone `llm_call` builtin) where there's no session to
+/// route events to. In that case the native channel is never wired —
+/// the SSE handler emits no native deltas and the savings are real.
 pub(super) fn spawn_progress_forwarder(
     bridge: &Rc<crate::bridge::HostBridge>,
     call_id: String,
     user_visible: bool,
+    session_id: Option<String>,
 ) -> DeltaSender {
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-    let bridge = bridge.clone();
+    let (text_tx, mut text_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let bridge_text = bridge.clone();
+    let call_id_text = call_id.clone();
     tokio::task::spawn_local(async move {
         let mut token_count: u64 = 0;
-        while let Some(delta) = rx.recv().await {
+        while let Some(delta) = text_rx.recv().await {
             token_count += 1;
-            bridge.send_call_progress(&call_id, &delta, token_count, user_visible);
+            bridge_text.send_call_progress(&call_id_text, &delta, token_count, user_visible);
         }
     });
-    tx
+
+    let Some(session_id) = session_id else {
+        return DeltaSender::text_only(text_tx);
+    };
+
+    let (native_tx, mut native_rx) =
+        tokio::sync::mpsc::unbounded_channel::<crate::llm::api::NativeToolCallDelta>();
+    tokio::task::spawn_local(async move {
+        use crate::llm::api::NativeToolCallDelta;
+        while let Some(delta) = native_rx.recv().await {
+            match delta {
+                NativeToolCallDelta::Start {
+                    tool_use_id,
+                    tool_name,
+                } => {
+                    let event = AgentEvent::ToolCall {
+                        session_id: session_id.clone(),
+                        tool_call_id: native_tool_call_id(&tool_use_id),
+                        tool_name,
+                        kind: None,
+                        status: ToolCallStatus::Pending,
+                        raw_input: serde_json::Value::Object(Default::default()),
+                    };
+                    super::agent::emit_agent_event(&event).await;
+                }
+                NativeToolCallDelta::InputDelta {
+                    tool_use_id,
+                    tool_name,
+                    accumulated_partial_json,
+                } => {
+                    let (raw_input, raw_input_partial) =
+                        match try_parse_partial_json(&accumulated_partial_json) {
+                            Some(value) => (Some(value), None),
+                            None => (None, Some(accumulated_partial_json.clone())),
+                        };
+                    let event = AgentEvent::ToolCallUpdate {
+                        session_id: session_id.clone(),
+                        tool_call_id: native_tool_call_id(&tool_use_id),
+                        tool_name,
+                        status: ToolCallStatus::Pending,
+                        raw_output: None,
+                        error: None,
+                        duration_ms: None,
+                        execution_duration_ms: None,
+                        error_category: None,
+                        executor: None,
+                        raw_input,
+                        raw_input_partial,
+                    };
+                    super::agent::emit_agent_event(&event).await;
+                }
+            }
+        }
+    });
+
+    DeltaSender::with_native_tool(text_tx, native_tx)
+}
+
+/// Construct the canonical `tool_call_id` used by both the streaming
+/// `ToolCall(Pending)` events emitted by `spawn_progress_forwarder` and
+/// the post-dispatch lifecycle events emitted by
+/// `crate::llm::agent::tool_dispatch`. Keeping the format aligned (the
+/// `tool-` prefix + provider tool-use id) lets clients correlate the
+/// two halves of the event stream by id.
+fn native_tool_call_id(tool_use_id: &str) -> String {
+    if tool_use_id.is_empty() {
+        "tool-stream".to_string()
+    } else {
+        format!("tool-{tool_use_id}")
+    }
+}
+
+/// Permissive partial-JSON parser used to surface in-progress tool-call
+/// arguments to clients during streaming (harn#693). Returns `Some(value)`
+/// when the input parses cleanly under one of:
+///   1. Direct `serde_json::from_str`. Object/array values that the
+///      provider has already closed parse without recovery.
+///   2. Best-effort completion: walk the input balancing quotes,
+///      braces, and brackets, then append the missing closers and
+///      retry. Recovers the common case where the stream cut mid-token,
+///      mid-string, or after a trailing comma.
+///
+/// Returns `None` when neither attempt succeeds — the forwarder then
+/// stows the raw bytes in `raw_input_partial` instead.
+pub(crate) fn try_parse_partial_json(input: &str) -> Option<serde_json::Value> {
+    let trimmed = input.trim_start();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        return Some(value);
+    }
+    let completed = complete_partial_json(trimmed)?;
+    serde_json::from_str::<serde_json::Value>(&completed).ok()
+}
+
+/// Walk `input` and append the smallest suffix (close-string + close
+/// containers) that turns it into a syntactically valid JSON value.
+/// Returns `None` when the input contains a structural impossibility
+/// (e.g. mismatched closers, control chars in a string, lone backslash
+/// at end of input). Strips trailing commas before attempting closure.
+fn complete_partial_json(input: &str) -> Option<String> {
+    let mut stack: Vec<char> = Vec::new();
+    let mut in_string = false;
+    let mut escape = false;
+    for ch in input.chars() {
+        if in_string {
+            if escape {
+                escape = false;
+                continue;
+            }
+            match ch {
+                '\\' => escape = true,
+                '"' => in_string = false,
+                _ => {}
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '{' => stack.push('}'),
+            '[' => stack.push(']'),
+            '}' | ']' if stack.pop() != Some(ch) => return None,
+            _ => {}
+        }
+    }
+    if escape {
+        return None;
+    }
+    let mut out = input.to_string();
+    if in_string {
+        out.push('"');
+    }
+    // Trailing commas (e.g. `{"a": 1, `) make `serde_json::from_str`
+    // fail even after closing braces. Strip the trailing comma + any
+    // whitespace that follows it before appending closers. Also
+    // strip a trailing `:` (mid-key, e.g. `{"a"`) by closing the value
+    // with a JSON null so the parse succeeds.
+    while let Some(last) = out.chars().last() {
+        if last.is_whitespace() {
+            out.pop();
+        } else {
+            break;
+        }
+    }
+    if out.ends_with(',') {
+        out.pop();
+    } else if out.ends_with(':') {
+        out.push_str("null");
+    }
+    for closer in stack.into_iter().rev() {
+        out.push(closer);
+    }
+    Some(out)
 }
 
 /// Configuration for LLM call retries.
@@ -553,6 +720,12 @@ fn llm_retry_backoff_ms(
 /// Make one LLM call with full observability: call-id generation, bridge
 /// notifications (call_start / call_progress / call_end), span annotation,
 /// retry with exponential backoff, and tracing.
+///
+/// `session_id` is the agent-loop session that owns this call. Pass `None`
+/// when the call sits outside an agent loop (the standalone `llm_call`
+/// builtin). Forwarded into `spawn_progress_forwarder` so streaming
+/// native-tool deltas can be translated into `AgentEvent::ToolCallUpdate`
+/// notifications routed under the right session (harn#693).
 pub(crate) async fn observed_llm_call(
     opts: &super::api::LlmCallOptions,
     tool_format: Option<&str>,
@@ -561,6 +734,7 @@ pub(crate) async fn observed_llm_call(
     iteration: Option<usize>,
     user_visible: bool,
     offthread: bool,
+    session_id: Option<&str>,
 ) -> Result<super::api::LlmResult, VmError> {
     let effective_tool_format = tool_format
         .map(str::to_string)
@@ -627,7 +801,12 @@ pub(crate) async fn observed_llm_call(
 
         let start = std::time::Instant::now();
         let llm_result = if let Some(b) = bridge {
-            let delta_tx = spawn_progress_forwarder(b, call_id.clone(), user_visible);
+            let delta_tx = spawn_progress_forwarder(
+                b,
+                call_id.clone(),
+                user_visible,
+                session_id.map(str::to_string),
+            );
             if offthread {
                 vm_call_llm_full_streaming_offthread(opts, delta_tx).await
             } else {
@@ -635,7 +814,7 @@ pub(crate) async fn observed_llm_call(
             }
         } else if offthread {
             let (delta_tx, _delta_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-            vm_call_llm_full_streaming_offthread(opts, delta_tx).await
+            vm_call_llm_full_streaming_offthread(opts, DeltaSender::text_only(delta_tx)).await
         } else {
             super::api::vm_call_llm_full(opts).await
         };
@@ -919,5 +1098,265 @@ mod retry_tests {
     #[test]
     fn retry_after_malformed_returns_none() {
         assert_eq!(parse_retry_after("retry-after: soon-ish"), None);
+    }
+}
+
+#[cfg(test)]
+mod partial_json_tests {
+    //! Coverage for the permissive partial-JSON parser used to surface
+    //! in-progress native tool-call arguments to clients during streaming
+    //! (harn#693). The parser must:
+    //!   - return the parsed value when input is already syntactically
+    //!     complete,
+    //!   - recover the common "stream cut mid-token" cases,
+    //!   - return `None` when the stream is structurally impossible (so
+    //!     the forwarder falls back to `raw_input_partial`).
+
+    use super::try_parse_partial_json;
+    use serde_json::json;
+
+    #[test]
+    fn complete_object_parses_directly() {
+        assert_eq!(
+            try_parse_partial_json(r#"{"path": "README.md"}"#),
+            Some(json!({"path": "README.md"})),
+        );
+    }
+
+    #[test]
+    fn unterminated_string_recovers() {
+        // The model is mid-write of a string value. Closing the string
+        // and balancing the object should produce a usable preview.
+        let parsed = try_parse_partial_json(r#"{"path": "READ"#);
+        assert_eq!(parsed, Some(json!({"path": "READ"})));
+    }
+
+    #[test]
+    fn unterminated_object_recovers() {
+        let parsed = try_parse_partial_json(r#"{"path": "README.md""#);
+        assert_eq!(parsed, Some(json!({"path": "README.md"})));
+    }
+
+    #[test]
+    fn trailing_comma_is_stripped_before_closing() {
+        let parsed = try_parse_partial_json(r#"{"path": "README.md", "#);
+        assert_eq!(parsed, Some(json!({"path": "README.md"})));
+    }
+
+    #[test]
+    fn trailing_colon_becomes_null_value() {
+        // Mid-key emission ending right after the colon. Closing with
+        // `null` keeps the partial parsable rather than discarding the
+        // whole object.
+        let parsed = try_parse_partial_json(r#"{"path":"#);
+        assert_eq!(parsed, Some(json!({"path": null})));
+    }
+
+    #[test]
+    fn nested_array_recovers() {
+        let parsed = try_parse_partial_json(r#"{"paths": ["a", "b"#);
+        assert_eq!(parsed, Some(json!({"paths": ["a", "b"]})));
+    }
+
+    #[test]
+    fn empty_string_returns_none() {
+        assert!(try_parse_partial_json("").is_none());
+    }
+
+    #[test]
+    fn dangling_backslash_is_unrecoverable() {
+        // A trailing `\` inside a string is structurally impossible to
+        // recover without guessing what byte was about to be escaped.
+        assert!(try_parse_partial_json(r#"{"path": "a\"#).is_none());
+    }
+
+    #[test]
+    fn mismatched_close_is_unrecoverable() {
+        // `]` where a `}` was expected — caller must fall back to
+        // `raw_input_partial`.
+        assert!(try_parse_partial_json("{ \"a\": [1, 2 }").is_none());
+    }
+
+    #[test]
+    fn array_root_recovers() {
+        let parsed = try_parse_partial_json(r#"[1, 2, "#);
+        assert_eq!(parsed, Some(json!([1, 2])));
+    }
+}
+
+#[cfg(test)]
+mod native_tool_forwarder_tests {
+    //! Coverage for the `spawn_progress_forwarder` translation path:
+    //! `NativeToolCallDelta` events from the SSE handler get rewritten
+    //! as `AgentEvent::ToolCall` / `ToolCallUpdate` notifications under
+    //! the caller's session id (harn#693). The forwarder is the seam
+    //! between transport-layer telemetry and the canonical agent-event
+    //! stream; clients see the latter, so it's where we assert the
+    //! `raw_input` / `raw_input_partial` contract.
+
+    use crate::agent_events::{
+        register_sink, reset_all_sinks, AgentEvent, AgentEventSink, ToolCallStatus,
+    };
+    use crate::llm::api::NativeToolCallDelta;
+    use std::sync::{Arc, Mutex};
+
+    /// Test sink that records every event it sees so assertions can
+    /// run after the forwarder task drains its channel.
+    struct CaptureSink(Arc<Mutex<Vec<AgentEvent>>>);
+
+    impl AgentEventSink for CaptureSink {
+        fn handle_event(&self, event: &AgentEvent) {
+            self.0.lock().expect("capture mutex").push(event.clone());
+        }
+    }
+
+    /// Run the same translation logic the production forwarder does,
+    /// but synchronously on the test thread. Mirrors the body of the
+    /// `spawn_local` task in `spawn_progress_forwarder` exactly so the
+    /// assertions cover the real translation rather than a stub.
+    async fn drive_forwarder(
+        session_id: &str,
+        deltas: Vec<NativeToolCallDelta>,
+    ) -> Vec<AgentEvent> {
+        let captured = Arc::new(Mutex::new(Vec::<AgentEvent>::new()));
+        register_sink(session_id, Arc::new(CaptureSink(captured.clone())));
+
+        for delta in deltas {
+            match delta {
+                NativeToolCallDelta::Start {
+                    tool_use_id,
+                    tool_name,
+                } => {
+                    let event = AgentEvent::ToolCall {
+                        session_id: session_id.to_string(),
+                        tool_call_id: super::native_tool_call_id(&tool_use_id),
+                        tool_name,
+                        kind: None,
+                        status: ToolCallStatus::Pending,
+                        raw_input: serde_json::Value::Object(Default::default()),
+                    };
+                    super::super::agent::emit_agent_event(&event).await;
+                }
+                NativeToolCallDelta::InputDelta {
+                    tool_use_id,
+                    tool_name,
+                    accumulated_partial_json,
+                } => {
+                    let (raw_input, raw_input_partial) =
+                        match super::try_parse_partial_json(&accumulated_partial_json) {
+                            Some(value) => (Some(value), None),
+                            None => (None, Some(accumulated_partial_json.clone())),
+                        };
+                    let event = AgentEvent::ToolCallUpdate {
+                        session_id: session_id.to_string(),
+                        tool_call_id: super::native_tool_call_id(&tool_use_id),
+                        tool_name,
+                        status: ToolCallStatus::Pending,
+                        raw_output: None,
+                        error: None,
+                        duration_ms: None,
+                        execution_duration_ms: None,
+                        error_category: None,
+                        executor: None,
+                        raw_input,
+                        raw_input_partial,
+                    };
+                    super::super::agent::emit_agent_event(&event).await;
+                }
+            }
+        }
+
+        let events = captured.lock().expect("capture mutex").clone();
+        reset_all_sinks();
+        events
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn start_event_translates_to_pending_tool_call_with_empty_raw_input() {
+        let events = drive_forwarder(
+            "session-693-start",
+            vec![NativeToolCallDelta::Start {
+                tool_use_id: "toolu_42".into(),
+                tool_name: "search_web".into(),
+            }],
+        )
+        .await;
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AgentEvent::ToolCall {
+                tool_call_id,
+                tool_name,
+                status,
+                raw_input,
+                ..
+            } => {
+                assert_eq!(tool_call_id, "tool-toolu_42");
+                assert_eq!(tool_name, "search_web");
+                assert_eq!(*status, ToolCallStatus::Pending);
+                assert_eq!(raw_input, &serde_json::json!({}));
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn input_delta_with_parsable_partial_populates_raw_input() {
+        let events = drive_forwarder(
+            "session-693-parsable",
+            vec![NativeToolCallDelta::InputDelta {
+                tool_use_id: "toolu_42".into(),
+                tool_name: "edit".into(),
+                accumulated_partial_json: r#"{"path": "src/lib"#.into(),
+            }],
+        )
+        .await;
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AgentEvent::ToolCallUpdate {
+                status,
+                raw_input,
+                raw_input_partial,
+                ..
+            } => {
+                assert_eq!(*status, ToolCallStatus::Pending);
+                // Partial-JSON parser closes the unterminated string
+                // and surfaces the structured value.
+                assert_eq!(
+                    raw_input.as_ref(),
+                    Some(&serde_json::json!({"path": "src/lib"}))
+                );
+                assert!(raw_input_partial.is_none(), "{raw_input_partial:?}");
+            }
+            other => panic!("expected ToolCallUpdate, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn input_delta_with_unparsable_partial_falls_back_to_raw_input_partial() {
+        // A dangling backslash inside a string is unrecoverable for
+        // the partial-JSON parser. The forwarder must spill the raw
+        // bytes into `raw_input_partial` so streaming clients still
+        // see *something* during that window.
+        let events = drive_forwarder(
+            "session-693-fallback",
+            vec![NativeToolCallDelta::InputDelta {
+                tool_use_id: "toolu_42".into(),
+                tool_name: "edit".into(),
+                accumulated_partial_json: r#"{"path": "a\"#.into(),
+            }],
+        )
+        .await;
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AgentEvent::ToolCallUpdate {
+                raw_input,
+                raw_input_partial,
+                ..
+            } => {
+                assert!(raw_input.is_none(), "{raw_input:?}");
+                assert_eq!(raw_input_partial.as_deref(), Some(r#"{"path": "a\"#));
+            }
+            other => panic!("expected ToolCallUpdate, got {other:?}"),
+        }
     }
 }

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -42,8 +42,8 @@ pub use ollama::{
 pub(crate) use openai_normalize::{debug_log_message_shapes, normalize_openai_style_messages};
 pub(crate) use options::{
     DeltaSender, LlmCallOptions, LlmRequestPayload, LlmRouteAlternative, LlmRoutePolicy,
-    LlmRoutingDecision, ThinkingConfig, ToolSearchConfig, ToolSearchMode, ToolSearchStrategy,
-    ToolSearchVariant,
+    LlmRoutingDecision, NativeToolCallDelta, ThinkingConfig, ToolSearchConfig, ToolSearchMode,
+    ToolSearchStrategy, ToolSearchVariant,
 };
 pub use readiness::{
     probe_openai_compatible_model, selected_model_for_provider, supports_model_readiness_probe,
@@ -59,7 +59,7 @@ use transport::vm_call_llm_api;
 /// handling; non-streaming callers just drop the receiver.
 pub(crate) async fn vm_call_llm_full(opts: &LlmCallOptions) -> Result<LlmResult, VmError> {
     let (delta_tx, _delta_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-    vm_call_llm_full_inner(opts, Some(delta_tx)).await
+    vm_call_llm_full_inner(opts, Some(DeltaSender::text_only(delta_tx))).await
 }
 
 /// Execute an LLM call, streaming text deltas to `delta_tx`.
@@ -105,7 +105,7 @@ async fn vm_call_llm_full_inner_request(
         record_cli_llm_result(&result);
         if let Some(tx) = delta_tx {
             if !result.text.is_empty() {
-                let _ = tx.send(result.text.clone());
+                let _ = tx.send_text(result.text.clone());
             }
         }
         return Ok(result);
@@ -121,7 +121,7 @@ async fn vm_call_llm_full_inner_request(
         record_cli_llm_result(&result);
         if let Some(tx) = delta_tx {
             if !result.text.is_empty() {
-                let _ = tx.send(result.text.clone());
+                let _ = tx.send_text(result.text.clone());
             }
         }
         return Ok(result);
@@ -666,7 +666,10 @@ mod tests {
                     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
                     let result = tokio::time::timeout(
                         std::time::Duration::from_secs(5),
-                        vm_call_llm_full_streaming_offthread(&opts, tx),
+                        vm_call_llm_full_streaming_offthread(
+                            &opts,
+                            super::DeltaSender::text_only(tx),
+                        ),
                     )
                     .await
                     .expect("llm call timed out")
@@ -727,7 +730,7 @@ mod tests {
                 .run_until(async {
                     let opts = base_opts("ollama");
                     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-                    vm_call_llm_full_streaming_offthread(&opts, tx)
+                    vm_call_llm_full_streaming_offthread(&opts, super::DeltaSender::text_only(tx))
                         .await
                         .expect("llm call should succeed")
                 })
@@ -883,7 +886,10 @@ mod tests {
                     let call = tokio::time::timeout(
                         // Must stay inside the stub's fail-fast accept window.
                         std::time::Duration::from_secs(2),
-                        vm_call_llm_full_streaming_offthread(&opts, tx),
+                        vm_call_llm_full_streaming_offthread(
+                            &opts,
+                            super::DeltaSender::text_only(tx),
+                        ),
                     )
                     .await;
                     match call {

--- a/crates/harn-vm/src/llm/api/options.rs
+++ b/crates/harn-vm/src/llm/api/options.rs
@@ -3,8 +3,96 @@
 
 use crate::value::VmValue;
 
-/// Sender for streaming text deltas from an in-flight LLM call.
-pub(crate) type DeltaSender = tokio::sync::mpsc::UnboundedSender<String>;
+/// Lifecycle event for a single provider-streamed native tool call,
+/// emitted by the SSE handler as `tool_use` blocks open and their
+/// arguments JSON streams in. The agent-loop forwarder translates each
+/// event into an `AgentEvent::ToolCall` / `ToolCallUpdate` (harn#693)
+/// so clients can render arguments as they arrive instead of waiting
+/// for the entire streamed call to be parsed at end-of-block.
+#[derive(Clone, Debug)]
+pub(crate) enum NativeToolCallDelta {
+    /// First sighting of a tool block. For Anthropic this fires on the
+    /// `content_block_start` envelope for `type: "tool_use"`; for
+    /// OpenAI-style providers it fires the first time a `tool_calls`
+    /// entry at a given index carries a non-empty `function.name`.
+    Start {
+        tool_use_id: String,
+        tool_name: String,
+    },
+    /// Streaming arguments delta. `accumulated_partial_json` is the
+    /// concatenation of every `partial_json` (Anthropic) /
+    /// `function.arguments` (OpenAI) chunk seen so far for this block,
+    /// **including** the chunk that triggered this event. The SSE
+    /// handler coalesces multiple chunks arriving within ~50ms into a
+    /// single `InputDelta` to keep slow clients off the event-storm
+    /// hot path; consumers should treat each event as a snapshot of the
+    /// current accumulated input rather than a per-chunk delta.
+    InputDelta {
+        tool_use_id: String,
+        tool_name: String,
+        accumulated_partial_json: String,
+    },
+}
+
+/// Channel pair for forwarding streaming-time observations from the LLM
+/// transport up to the agent loop. `text` carries visible/thought text
+/// chunks (the original `delta_tx` contract), and `native_tool` carries
+/// provider-native tool-call lifecycle events (harn#693). The native
+/// channel is `None` for callers that don't care — every legacy call
+/// site continues to compile after the refactor by constructing a
+/// `DeltaSender` that only wires text.
+#[derive(Clone)]
+pub(crate) struct DeltaSender {
+    text: tokio::sync::mpsc::UnboundedSender<String>,
+    native_tool: Option<tokio::sync::mpsc::UnboundedSender<NativeToolCallDelta>>,
+}
+
+impl DeltaSender {
+    /// Wrap an existing text-only sender. Used by all callers that don't
+    /// observe native tool-call streaming.
+    pub(crate) fn text_only(text: tokio::sync::mpsc::UnboundedSender<String>) -> Self {
+        Self {
+            text,
+            native_tool: None,
+        }
+    }
+
+    /// Wrap both a text sender and a native-tool sender. Used by the
+    /// agent loop's progress forwarder, which translates native deltas
+    /// into `AgentEvent::ToolCall` / `ToolCallUpdate`.
+    pub(crate) fn with_native_tool(
+        text: tokio::sync::mpsc::UnboundedSender<String>,
+        native_tool: tokio::sync::mpsc::UnboundedSender<NativeToolCallDelta>,
+    ) -> Self {
+        Self {
+            text,
+            native_tool: Some(native_tool),
+        }
+    }
+
+    /// Send a text chunk. Drops silently if the receiver is gone — the
+    /// historical contract.
+    pub(crate) fn send_text(
+        &self,
+        chunk: String,
+    ) -> Result<(), tokio::sync::mpsc::error::SendError<String>> {
+        self.text.send(chunk)
+    }
+
+    /// Send a native tool-call lifecycle event. No-op when the caller
+    /// did not wire a native channel (most non-agent-loop callers).
+    pub(crate) fn send_native_tool(&self, delta: NativeToolCallDelta) {
+        if let Some(tx) = &self.native_tool {
+            let _ = tx.send(delta);
+        }
+    }
+
+    /// Whether a native-tool channel is wired. Used by the SSE handler
+    /// to skip coalescing bookkeeping when no observer cares.
+    pub(crate) fn has_native_tool(&self) -> bool {
+        self.native_tool.is_some()
+    }
+}
 
 /// Extended thinking configuration.
 #[derive(Clone, Debug, serde::Serialize)]

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -11,10 +11,18 @@ use super::errors::classify_http_error;
 use super::openai_normalize::{
     append_paragraph, debug_log_message_shapes, extract_openai_message_field_as_text,
 };
-use super::options::{DeltaSender, LlmRequestPayload};
+use super::options::{DeltaSender, LlmRequestPayload, NativeToolCallDelta};
 use super::response::{extract_cache_read_tokens, extract_cache_write_tokens, parse_llm_response};
 use super::result::LlmResult;
 use super::thinking::ThinkingStreamSplitter;
+
+/// Minimum gap between successive `NativeToolCallDelta::InputDelta` emissions
+/// for the same tool block (harn#693). Bursts of provider deltas inside this
+/// window collapse into a single update so slow clients don't drown in
+/// per-character churn. The block-stop / stream-end paths always flush a
+/// final un-coalesced update so the last seen `accumulated_partial_json`
+/// reaches subscribers regardless of timing.
+const NATIVE_TOOL_DELTA_COALESCE_MS: u64 = 50;
 
 fn parse_ollama_tool_arguments(arguments: &serde_json::Value) -> serde_json::Value {
     match arguments {
@@ -228,7 +236,7 @@ pub(crate) async fn vm_call_llm_api_with_body(
             tx
         } else {
             let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-            tx
+            DeltaSender::text_only(tx)
         };
         let response = req.send().await.map_err(|e| {
             let kind = if e.is_timeout() {
@@ -310,13 +318,31 @@ async fn vm_call_llm_api_sse_from_response(
     resolved: &crate::llm::helpers::ResolvedProvider,
     delta_tx: DeltaSender,
 ) -> Result<LlmResult, VmError> {
-    use tokio::io::AsyncBufReadExt;
     use tokio_stream::StreamExt;
 
     let stream = response.bytes_stream();
     let reader = tokio::io::BufReader::new(tokio_util::io::StreamReader::new(
         stream.map(|r| r.map_err(std::io::Error::other)),
     ));
+    consume_sse_lines(reader, model, resolved, delta_tx).await
+}
+
+/// Inner SSE body parser, factored out from
+/// [`vm_call_llm_api_sse_from_response`] so tests can drive it directly
+/// from a `Cursor` over canned bytes (harn#693). The wire format is
+/// identical between the two paths — the only difference is the source
+/// of the byte stream.
+async fn consume_sse_lines<R>(
+    reader: R,
+    model: &str,
+    resolved: &crate::llm::helpers::ResolvedProvider,
+    delta_tx: DeltaSender,
+) -> Result<LlmResult, VmError>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+{
+    use tokio::io::AsyncBufReadExt;
+
     let mut lines = reader.lines();
 
     let mut text = String::new();
@@ -329,6 +355,11 @@ async fn vm_call_llm_api_sse_from_response(
         id: String,
         name: String,
         input_json: String,
+        /// Per-block coalescing watermark for `NativeToolCallDelta::InputDelta`
+        /// emissions (harn#693). Reset on block open, updated on every
+        /// emitted delta. The block-stop path always flushes a final
+        /// un-coalesced update so callers see the complete partial JSON.
+        last_emit: Option<std::time::Instant>,
     }
     let mut current_tool: Option<ToolBlock> = None;
     // Mirror structure for server-side tool-search queries: Anthropic
@@ -347,7 +378,20 @@ async fn vm_call_llm_api_sse_from_response(
     let mut cache_read_tokens: i64 = 0;
     let mut cache_write_tokens: i64 = 0;
 
-    let mut oai_tool_map: std::collections::HashMap<u64, (String, String, String)> =
+    /// Per-index OpenAI tool-call accumulator. `start_emitted` gates the
+    /// `NativeToolCallDelta::Start` emission on the first chunk that
+    /// carries the function name (some providers split id and name
+    /// across chunks). `last_emit` drives the same coalescing window
+    /// used by the Anthropic path. `id` may stay empty until the model
+    /// fills it in mid-stream — the agent loop tolerates the empty case.
+    struct OaiToolEntry {
+        id: String,
+        name: String,
+        args: String,
+        start_emitted: bool,
+        last_emit: Option<std::time::Instant>,
+    }
+    let mut oai_tool_map: std::collections::HashMap<u64, OaiToolEntry> =
         std::collections::HashMap::new();
     // Qwen3/3.5 via vLLM emit inline `<think>...</think>`. Strip these
     // out of the visible delta stream so the tool-call parser / progress
@@ -388,10 +432,20 @@ async fn vm_call_llm_api_sse_from_response(
                     let block = &json["content_block"];
                     match block["type"].as_str() {
                         Some("tool_use") => {
+                            let id = block["id"].as_str().unwrap_or("").to_string();
+                            let name = block["name"].as_str().unwrap_or("").to_string();
+                            // Fire the lifecycle `Start` immediately so a
+                            // client can render "calling foo…" before any
+                            // arguments arrive (harn#693).
+                            delta_tx.send_native_tool(NativeToolCallDelta::Start {
+                                tool_use_id: id.clone(),
+                                tool_name: name.clone(),
+                            });
                             current_tool = Some(ToolBlock {
-                                id: block["id"].as_str().unwrap_or("").to_string(),
-                                name: block["name"].as_str().unwrap_or("").to_string(),
+                                id,
+                                name,
                                 input_json: String::new(),
+                                last_emit: None,
                             });
                         }
                         Some("server_tool_use") => {
@@ -429,7 +483,7 @@ async fn vm_call_llm_api_sse_from_response(
                         Some("text_delta") => {
                             if let Some(t) = delta["text"].as_str() {
                                 text.push_str(t);
-                                let _ = delta_tx.send(t.to_string());
+                                let _ = delta_tx.send_text(t.to_string());
                                 blocks.push(serde_json::json!({"type": "output_text", "text": t, "visibility": "public"}));
                             }
                         }
@@ -443,6 +497,21 @@ async fn vm_call_llm_api_sse_from_response(
                             if let Some(ref mut tool) = current_tool {
                                 if let Some(j) = delta["partial_json"].as_str() {
                                     tool.input_json.push_str(j);
+                                    let now = std::time::Instant::now();
+                                    let should_emit = tool.last_emit.is_none_or(|last| {
+                                        now.duration_since(last).as_millis() as u64
+                                            >= NATIVE_TOOL_DELTA_COALESCE_MS
+                                    });
+                                    if should_emit && delta_tx.has_native_tool() {
+                                        delta_tx.send_native_tool(
+                                            NativeToolCallDelta::InputDelta {
+                                                tool_use_id: tool.id.clone(),
+                                                tool_name: tool.name.clone(),
+                                                accumulated_partial_json: tool.input_json.clone(),
+                                            },
+                                        );
+                                        tool.last_emit = Some(now);
+                                    }
                                 }
                             } else if let Some(ref mut server_tool) = current_server_tool {
                                 if let Some(j) = delta["partial_json"].as_str() {
@@ -455,6 +524,16 @@ async fn vm_call_llm_api_sse_from_response(
                 }
                 Some("content_block_stop") => {
                     if let Some(tool) = current_tool.take() {
+                        // Final un-coalesced flush so subscribers see the
+                        // complete `accumulated_partial_json` regardless
+                        // of the 50ms window state (harn#693).
+                        if delta_tx.has_native_tool() {
+                            delta_tx.send_native_tool(NativeToolCallDelta::InputDelta {
+                                tool_use_id: tool.id.clone(),
+                                tool_name: tool.name.clone(),
+                                accumulated_partial_json: tool.input_json.clone(),
+                            });
+                        }
                         let args = serde_json::from_str::<serde_json::Value>(&tool.input_json)
                             .unwrap_or(serde_json::Value::Object(Default::default()));
                         tool_calls.push(serde_json::json!({
@@ -504,7 +583,7 @@ async fn vm_call_llm_api_sse_from_response(
                 let visible = oai_thinking_splitter.push(content);
                 if !visible.is_empty() {
                     text.push_str(&visible);
-                    let _ = delta_tx.send(visible.clone());
+                    let _ = delta_tx.send_text(visible.clone());
                     blocks.push(serde_json::json!({"type": "output_text", "text": visible, "visibility": "public"}));
                 }
             }
@@ -565,13 +644,51 @@ async fn vm_call_llm_api_sse_from_response(
                         continue;
                     }
                     let idx = tc["index"].as_u64().unwrap_or(0);
-                    let entry = oai_tool_map.entry(idx).or_insert_with(|| {
-                        let id = tc["id"].as_str().unwrap_or("").to_string();
-                        let name = tc["function"]["name"].as_str().unwrap_or("").to_string();
-                        (id, name, String::new())
+                    let entry = oai_tool_map.entry(idx).or_insert_with(|| OaiToolEntry {
+                        id: tc["id"].as_str().unwrap_or("").to_string(),
+                        name: tc["function"]["name"].as_str().unwrap_or("").to_string(),
+                        args: String::new(),
+                        start_emitted: false,
+                        last_emit: None,
                     });
+                    // Some providers send the id/name on a later chunk —
+                    // backfill the accumulator and only emit `Start`
+                    // once both are known so downstream UIs don't
+                    // render an empty placeholder.
+                    if entry.id.is_empty() {
+                        if let Some(id) = tc["id"].as_str() {
+                            entry.id = id.to_string();
+                        }
+                    }
+                    if entry.name.is_empty() {
+                        if let Some(name) = tc["function"]["name"].as_str() {
+                            entry.name = name.to_string();
+                        }
+                    }
+                    if !entry.start_emitted && !entry.name.is_empty() {
+                        delta_tx.send_native_tool(NativeToolCallDelta::Start {
+                            tool_use_id: entry.id.clone(),
+                            tool_name: entry.name.clone(),
+                        });
+                        entry.start_emitted = true;
+                    }
                     if let Some(args) = tc["function"]["arguments"].as_str() {
-                        entry.2.push_str(args);
+                        entry.args.push_str(args);
+                        if entry.start_emitted && delta_tx.has_native_tool() {
+                            let now = std::time::Instant::now();
+                            let should_emit = entry.last_emit.is_none_or(|last| {
+                                now.duration_since(last).as_millis() as u64
+                                    >= NATIVE_TOOL_DELTA_COALESCE_MS
+                            });
+                            if should_emit {
+                                delta_tx.send_native_tool(NativeToolCallDelta::InputDelta {
+                                    tool_use_id: entry.id.clone(),
+                                    tool_name: entry.name.clone(),
+                                    accumulated_partial_json: entry.args.clone(),
+                                });
+                                entry.last_emit = Some(now);
+                            }
+                        }
                     }
                 }
             }
@@ -595,19 +712,34 @@ async fn vm_call_llm_api_sse_from_response(
         }
     }
 
-    for (_, (id, name, args_str)) in oai_tool_map {
-        let args = serde_json::from_str::<serde_json::Value>(&args_str)
+    // Stream is over: flush a final un-coalesced `InputDelta` per
+    // accumulated entry so the last seen `accumulated_partial_json`
+    // reaches subscribers regardless of the 50ms window state, then
+    // promote each entry into the canonical `tool_calls` array
+    // (harn#693). Iterate in index order so `tool_calls` matches the
+    // provider's original ordering.
+    let mut oai_entries: Vec<(u64, OaiToolEntry)> = oai_tool_map.into_iter().collect();
+    oai_entries.sort_by_key(|(idx, _)| *idx);
+    for (_, entry) in oai_entries {
+        if entry.start_emitted && delta_tx.has_native_tool() {
+            delta_tx.send_native_tool(NativeToolCallDelta::InputDelta {
+                tool_use_id: entry.id.clone(),
+                tool_name: entry.name.clone(),
+                accumulated_partial_json: entry.args.clone(),
+            });
+        }
+        let args = serde_json::from_str::<serde_json::Value>(&entry.args)
             .unwrap_or(serde_json::Value::Object(Default::default()));
         tool_calls.push(serde_json::json!({
-            "id": id, "name": name, "arguments": args,
+            "id": entry.id, "name": entry.name, "arguments": args,
         }));
-        blocks.push(serde_json::json!({"type": "tool_call", "id": id, "name": name, "arguments": args, "visibility": "internal"}));
+        blocks.push(serde_json::json!({"type": "tool_call", "id": entry.id, "name": entry.name, "arguments": args, "visibility": "internal"}));
     }
 
     let final_visible = oai_thinking_splitter.flush();
     if !final_visible.is_empty() {
         text.push_str(&final_visible);
-        let _ = delta_tx.send(final_visible.clone());
+        let _ = delta_tx.send_text(final_visible.clone());
         blocks.push(serde_json::json!({"type": "output_text", "text": final_visible, "visibility": "public"}));
     }
     if !oai_thinking_splitter.thinking.is_empty() {
@@ -708,13 +840,13 @@ async fn vm_call_llm_api_ndjson_from_response(
         let thinking = json["message"]["thinking"].as_str().unwrap_or("");
         if !content.is_empty() {
             text.push_str(content);
-            let _ = delta_tx.send(content.to_string());
+            let _ = delta_tx.send_text(content.to_string());
             blocks.push(
                 serde_json::json!({"type": "output_text", "text": content, "visibility": "public"}),
             );
         } else if !thinking.is_empty() {
             thinking_text.push_str(thinking);
-            let _ = delta_tx.send(thinking.to_string());
+            let _ = delta_tx.send_text(thinking.to_string());
             blocks.push(
                 serde_json::json!({"type": "reasoning", "text": thinking, "visibility": "private"}),
             );
@@ -811,5 +943,258 @@ mod tests {
         assert_eq!(tool_calls[0]["arguments"]["path"], "README.md");
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0]["type"], "tool_call");
+    }
+}
+
+#[cfg(test)]
+mod native_tool_streaming_tests {
+    //! Coverage for harn#693: the SSE handler must surface
+    //! `NativeToolCallDelta::Start` on the first chunk of a tool block
+    //! (so clients can render "calling foo…" before any arguments
+    //! arrive), then a coalesced sequence of `InputDelta` events as
+    //! `partial_json` / `function.arguments` chunks land, and finally
+    //! a flush at block stop / stream end so the last seen partial
+    //! reaches subscribers regardless of timing.
+
+    use super::{consume_sse_lines, DeltaSender, NativeToolCallDelta};
+    use crate::llm::helpers::ResolvedProvider;
+    use std::io::Cursor;
+    use tokio::sync::mpsc;
+
+    /// Drive `consume_sse_lines` against a canned SSE body and return
+    /// the (LlmResult, text deltas, native tool deltas) triple.
+    async fn drive_sse(
+        body: &str,
+        provider_for_resolve: &str,
+    ) -> (super::LlmResult, Vec<String>, Vec<NativeToolCallDelta>) {
+        let (text_tx, mut text_rx) = mpsc::unbounded_channel::<String>();
+        let (native_tx, mut native_rx) = mpsc::unbounded_channel::<NativeToolCallDelta>();
+        let delta_tx = DeltaSender::with_native_tool(text_tx, native_tx);
+        let resolved = ResolvedProvider::resolve(provider_for_resolve);
+
+        let cursor = Cursor::new(body.to_string().into_bytes());
+        let buffered = tokio::io::BufReader::new(cursor);
+        let result = consume_sse_lines(buffered, "test-model", &resolved, delta_tx)
+            .await
+            .expect("sse parse");
+
+        let mut text_deltas = Vec::new();
+        while let Ok(delta) = text_rx.try_recv() {
+            text_deltas.push(delta);
+        }
+        let mut native_deltas = Vec::new();
+        while let Ok(delta) = native_rx.try_recv() {
+            native_deltas.push(delta);
+        }
+        (result, text_deltas, native_deltas)
+    }
+
+    /// Render the Anthropic-style SSE body for a single `tool_use` block
+    /// where the input JSON arrives in the listed `partial_json` chunks.
+    fn anthropic_tool_use_body(id: &str, name: &str, partials: &[&str]) -> String {
+        let mut out = String::new();
+        out.push_str(
+            "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":1}}}\n",
+        );
+        out.push_str(&format!(
+            "data: {{\"type\":\"content_block_start\",\"content_block\":{{\"type\":\"tool_use\",\"id\":\"{id}\",\"name\":\"{name}\"}}}}\n"
+        ));
+        for partial in partials {
+            // Quote-escape the partial JSON for embedding inside the
+            // outer SSE-line JSON envelope.
+            let escaped = serde_json::to_string(partial).expect("quote partial");
+            out.push_str(&format!(
+                "data: {{\"type\":\"content_block_delta\",\"delta\":{{\"type\":\"input_json_delta\",\"partial_json\":{escaped}}}}}\n"
+            ));
+        }
+        out.push_str("data: {\"type\":\"content_block_stop\"}\n");
+        out.push_str(
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n",
+        );
+        out.push_str("data: [DONE]\n");
+        out
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn anthropic_first_event_fires_on_block_start_with_tool_name() {
+        // Single tool block, single chunk of arguments. The first
+        // `NativeToolCallDelta` must be `Start { tool_name }` and must
+        // arrive before any `InputDelta` so a UI can render "calling
+        // search_web…" the moment the model commits to a tool.
+        let body = anthropic_tool_use_body("toolu_1", "search_web", &[r#"{"q": "rust"}"#]);
+        let (result, _text, native) = drive_sse(&body, "anthropic").await;
+        assert!(!native.is_empty(), "expected native tool deltas");
+        match &native[0] {
+            NativeToolCallDelta::Start {
+                tool_use_id,
+                tool_name,
+            } => {
+                assert_eq!(tool_use_id, "toolu_1");
+                assert_eq!(tool_name, "search_web");
+            }
+            other => panic!("first event must be Start, got {other:?}"),
+        }
+        // The terminal LlmResult must still carry the fully-parsed
+        // tool call — streaming events are additive observability.
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0]["name"], "search_web");
+        assert_eq!(result.tool_calls[0]["arguments"]["q"], "rust");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn anthropic_input_delta_emits_growing_partial_json() {
+        // Three deltas. Coalescing inside the 50ms window may collapse
+        // some intermediate emissions, but the final flush at
+        // `content_block_stop` always carries the full accumulated
+        // string. We assert on the last `InputDelta` rather than the
+        // middle ones so the test is robust to clock jitter.
+        let body = anthropic_tool_use_body(
+            "toolu_1",
+            "edit",
+            &[r#"{"path": "#, r#""src/lib"#, r#".rs"}"#],
+        );
+        let (_result, _text, native) = drive_sse(&body, "anthropic").await;
+        let input_deltas: Vec<&NativeToolCallDelta> = native
+            .iter()
+            .filter(|d| matches!(d, NativeToolCallDelta::InputDelta { .. }))
+            .collect();
+        assert!(
+            !input_deltas.is_empty(),
+            "expected at least one InputDelta, got: {native:?}"
+        );
+        // The last delta must contain the complete accumulated
+        // `partial_json` regardless of coalescing.
+        match input_deltas.last().expect("last input delta") {
+            NativeToolCallDelta::InputDelta {
+                tool_use_id,
+                tool_name,
+                accumulated_partial_json,
+            } => {
+                assert_eq!(tool_use_id, "toolu_1");
+                assert_eq!(tool_name, "edit");
+                assert_eq!(accumulated_partial_json, r#"{"path": "src/lib.rs"}"#);
+            }
+            other => unreachable!("filtered to InputDelta only, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn anthropic_burst_of_deltas_is_coalesced_inside_window() {
+        // 200 fast deltas inside the 50ms window must collapse to far
+        // fewer `InputDelta` emissions than chunks. We don't pin an
+        // exact count (clock jitter), but we assert <= one third of
+        // the chunk count, which is achievable only with coalescing.
+        let chunks: Vec<String> = (0..200).map(|i| format!("\"k{i}\":{i},")).collect();
+        // Wrap as a JSON object: open brace, all chunks, then close.
+        let mut all = String::from("{");
+        for chunk in &chunks {
+            all.push_str(chunk);
+        }
+        all.push_str("\"final\":true}");
+        // Split into 200 single-key chunks for the SSE body.
+        let mut partials: Vec<&str> = chunks.iter().map(String::as_str).collect();
+        let opening = "{";
+        partials.insert(0, opening);
+        partials.push("\"final\":true}");
+        let body = anthropic_tool_use_body("toolu_burst", "noop", &partials);
+
+        let (_result, _text, native) = drive_sse(&body, "anthropic").await;
+        let input_count = native
+            .iter()
+            .filter(|d| matches!(d, NativeToolCallDelta::InputDelta { .. }))
+            .count();
+        assert!(
+            input_count <= partials.len() / 3 + 2, // +2 for the final flush + first emit
+            "expected coalescing to reduce {} chunks to <= {}, got {input_count}",
+            partials.len(),
+            partials.len() / 3 + 2,
+        );
+        // And a final flush must still see the full string.
+        match native
+            .iter()
+            .rev()
+            .find(|d| matches!(d, NativeToolCallDelta::InputDelta { .. }))
+            .expect("last input delta")
+        {
+            NativeToolCallDelta::InputDelta {
+                accumulated_partial_json,
+                ..
+            } => {
+                assert!(accumulated_partial_json.ends_with("\"final\":true}"));
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn anthropic_native_channel_unwired_skips_emissions() {
+        // When the caller doesn't wire the native channel (text-only
+        // DeltaSender), the SSE handler must not waste time formatting
+        // delta events. The `LlmResult` must still come out correct.
+        let body = anthropic_tool_use_body("toolu_1", "edit", &[r#"{"a":1}"#]);
+        let (text_tx, _rx) = mpsc::unbounded_channel::<String>();
+        let delta_tx = DeltaSender::text_only(text_tx);
+        let resolved = ResolvedProvider::resolve("anthropic");
+        let cursor = Cursor::new(body.into_bytes());
+        let buffered = tokio::io::BufReader::new(cursor);
+        let result = consume_sse_lines(buffered, "test-model", &resolved, delta_tx)
+            .await
+            .expect("sse parse");
+        assert_eq!(result.tool_calls.len(), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn openai_first_event_fires_on_first_chunk_with_tool_name() {
+        // OpenAI splits tool start across chunks: first carries id +
+        // function.name, subsequent chunks carry function.arguments
+        // deltas. The `Start` event must arrive before any `InputDelta`.
+        let body = "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_a\",\"function\":{\"name\":\"edit\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}\n\
+data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\"}}]}}]}\n\
+data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"src/lib.rs\\\"}\"}}]}}]}\n\
+data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\
+data: [DONE]\n";
+        let (result, _text, native) = drive_sse(body, "openai").await;
+        assert!(
+            !native.is_empty(),
+            "expected native tool deltas: {native:?}"
+        );
+        match &native[0] {
+            NativeToolCallDelta::Start {
+                tool_use_id,
+                tool_name,
+            } => {
+                assert_eq!(tool_use_id, "call_a");
+                assert_eq!(tool_name, "edit");
+            }
+            other => panic!("first event must be Start, got {other:?}"),
+        }
+        // The full input must round-trip into the LlmResult.
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0]["arguments"]["path"], "src/lib.rs");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn openai_final_flush_carries_complete_arguments() {
+        // The trailing flush after the SSE stream ends must always
+        // emit one last `InputDelta` per accumulator so subscribers
+        // see the full `accumulated_partial_json` even when coalescing
+        // suppressed the final mid-stream emission.
+        let body = "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_x\",\"function\":{\"name\":\"e\",\"arguments\":\"{}\"}}]}}]}\n\
+data: [DONE]\n";
+        let (_result, _text, native) = drive_sse(body, "openai").await;
+        let last_input = native
+            .iter()
+            .rev()
+            .find(|d| matches!(d, NativeToolCallDelta::InputDelta { .. }))
+            .expect("at least one input delta");
+        match last_input {
+            NativeToolCallDelta::InputDelta {
+                accumulated_partial_json,
+                ..
+            } => {
+                assert_eq!(accumulated_partial_json, "{}");
+            }
+            _ => unreachable!(),
+        }
     }
 }

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -510,6 +510,8 @@ pub(crate) async fn execute_llm_call(
             None,
             user_visible,
             bridged, // offthread=true on the bridge path, local set otherwise
+            // Standalone `llm_call` has no agent-loop session.
+            None,
         )
         .await?;
 


### PR DESCRIPTION
## Summary

Closes [#693](https://github.com/burin-labs/harn/issues/693).

Provider SSE streams now surface their `tool_use` / `tool_calls` blocks through the agent-event stream the moment they open, instead of waiting for `content_block_stop` (Anthropic) or end-of-stream (OpenAI). ACP clients (Burin CLI/TUI/IDE) can render *"calling search_web…"* the instant the model commits to a tool, then watch the arguments grow in real time as they stream — currently those calls are completely opaque to the client until the entire streamed call is parsed.

### Wire shape

- A new typed `NativeToolCallDelta` lifecycle inside transport: `Start { tool_use_id, tool_name }` on the first sighting, then `InputDelta { accumulated_partial_json }` on each chunk.
- The agent-loop progress forwarder rewrites those deltas as `AgentEvent::ToolCall { status: Pending, raw_input: {} }` followed by repeating `AgentEvent::ToolCallUpdate { status: Pending, raw_input | raw_input_partial }` notifications, both routed under the owning session id.
- Two new mutually-exclusive fields on `ToolCallUpdate`:
  - `raw_input: Option<Value>` — populated when the permissive partial-JSON parser succeeds.
  - `raw_input_partial: Option<String>` — raw concatenated bytes when the in-flight stream is structurally unrecoverable.
- ACP wire serialization mirrors them as `rawInput` / `rawInputPartial`. Both are `skip_serializing_if = "Option::is_none"` so legacy clients see no shape change.

### Coalescing

A 50ms window per tool block collapses bursts of provider chunks into a single `InputDelta` so slow clients don't drown in per-character churn. Block-stop (Anthropic) and stream-end (OpenAI) **always** flush a final un-coalesced update so the last seen `accumulated_partial_json` reaches subscribers regardless of timing.

### Lifecycle compatibility

- The terminal `tool_call_update(Pending → InProgress → Completed/Failed)` flow from the dispatcher is unchanged. Streaming-time events are additive observability with the same `tool_call_id` (`tool-{tool_use_id}`) so clients keying off id treat them as updates to the same card.
- Callers that don't wire a native channel (the standalone `llm_call` builtin) bypass the streaming emissions entirely — `DeltaSender::has_native_tool()` short-circuits the SSE handler.

### Implementation notes

- `DeltaSender` is now a struct wrapping `text` + optional `native_tool` channels. Construction goes through `DeltaSender::text_only(...)` or `DeltaSender::with_native_tool(...)` — a much smaller change than threading a second parameter through 10+ provider-trait impls.
- `spawn_progress_forwarder` now takes `session_id: Option<String>` and spawns a second translator task when the session is known. Out-of-loop `llm_call` paths pass `None`.
- The permissive partial-JSON recovery walks brace/bracket/quote balance once, strips trailing comma/colon, and retries — no new dependency.

## Test plan

- [x] `cargo test -p harn-vm --lib llm::api::transport::native_tool_streaming_tests` (6 SSE coalescing/lifecycle tests, all green)
- [x] `cargo test -p harn-vm --lib llm::agent_observe::partial_json_tests` (10 partial-parser edge-case tests)
- [x] `cargo test -p harn-vm --lib llm::agent_observe::native_tool_forwarder_tests` (3 translation tests covering both `raw_input` and `raw_input_partial` fallback paths)
- [x] `cargo test -p harn-serve --lib adapters::acp::events::` (3 new ACP wire-format tests + existing 6, all green)
- [x] `cargo nextest run --workspace` — only pre-existing flakes (`llm::readiness::tests::*`, `llm::healthcheck::tests::*`, `harn_serve_mcp_cli::*`); all pass in isolation
- [x] `cargo run --bin harn -- test conformance` — 696/696 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Visual smoke in the Burin TUI/IDE once B7 (`burin-labs/burin-code#339`) lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)