### PR TITLE
Fix streaming reasoning deltas joined with newlines per token

### DIFF
--- a/crates/harn-vm/src/llm/api/openai_normalize.rs
+++ b/crates/harn-vm/src/llm/api/openai_normalize.rs
@@ -94,6 +94,28 @@ pub(super) fn append_paragraph(target: &mut String, text: &str) {
     target.push_str(text.trim());
 }
 
+/// Extract a streaming-delta field as a raw `&str` without trimming or
+/// paragraph-joining. Use this for the per-chunk path where deltas are
+/// fragments that must concatenate verbatim (`"Here"`, `"'s"`, `" a"`)
+/// — `extract_openai_message_field_as_text` would `.trim()` each fragment
+/// and lose the inter-token whitespace, and `append_paragraph` would
+/// inject a newline between every chunk, producing one-token-per-line
+/// reasoning text. Returns the empty string when no recognised field is
+/// present.
+pub(super) fn extract_openai_delta_field_str<'a>(
+    delta: &'a serde_json::Value,
+    field_names: &[&str],
+) -> &'a str {
+    for field_name in field_names {
+        if let Some(s) = delta.get(*field_name).and_then(serde_json::Value::as_str) {
+            if !s.is_empty() {
+                return s;
+            }
+        }
+    }
+    ""
+}
+
 pub(super) fn normalize_openai_message_text(message: &serde_json::Value) -> (String, String) {
     let raw_text = extract_openai_message_field_as_text(message, &["content"]);
     let reasoning_text =
@@ -185,7 +207,10 @@ pub(crate) fn debug_log_message_shapes(label: &str, messages: &[serde_json::Valu
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_openai_message_text;
+    use super::{
+        extract_openai_delta_field_str, extract_openai_message_field_as_text,
+        normalize_openai_message_text,
+    };
 
     #[test]
     fn normalize_openai_message_text_uses_reasoning_when_content_missing() {
@@ -206,5 +231,60 @@ mod tests {
         let (visible, thinking) = normalize_openai_message_text(&message);
         assert_eq!(visible, "visible answer");
         assert_eq!(thinking, "separate reasoning\ninline reasoning");
+    }
+
+    #[test]
+    fn extract_openai_delta_field_str_returns_raw_chunk_with_inter_token_whitespace() {
+        // Ollama's qwen3.6 streaming delivers reasoning as token-sized
+        // fragments — leading/trailing whitespace must survive so the
+        // accumulated text reads "Here's a thinking process" not
+        // "Here'sathinking" or "Here\n's\na\nthinking\nprocess".
+        for chunk in [r#""Here""#, r#""'s""#, r#"" a""#, r#"" thinking""#] {
+            let delta: serde_json::Value =
+                serde_json::from_str(&format!(r#"{{"reasoning":{chunk}}}"#)).unwrap();
+            let raw = extract_openai_delta_field_str(&delta, &["reasoning", "reasoning_content"]);
+            assert_eq!(raw, chunk.trim_matches('"'));
+        }
+    }
+
+    #[test]
+    fn extract_openai_delta_field_str_prefers_first_present_field() {
+        let delta = serde_json::json!({
+            "reasoning_content": "from-content",
+            "reasoning": "from-bare",
+        });
+        let raw = extract_openai_delta_field_str(&delta, &["reasoning", "reasoning_content"]);
+        assert_eq!(raw, "from-bare");
+    }
+
+    #[test]
+    fn extract_openai_delta_field_str_skips_empty_fields() {
+        let delta = serde_json::json!({
+            "reasoning": "",
+            "reasoning_content": " token-with-leading-space",
+        });
+        let raw = extract_openai_delta_field_str(&delta, &["reasoning", "reasoning_content"]);
+        assert_eq!(raw, " token-with-leading-space");
+    }
+
+    #[test]
+    fn extract_openai_delta_field_str_returns_empty_for_missing_fields() {
+        let delta = serde_json::json!({"content": "anything"});
+        let raw = extract_openai_delta_field_str(&delta, &["reasoning", "reasoning_content"]);
+        assert!(raw.is_empty());
+    }
+
+    #[test]
+    fn extract_openai_message_field_still_paragraph_joins_for_non_streaming_blocks() {
+        // The non-streaming response normalizer keeps paragraph-style
+        // joining: each `field_names` entry is a complete block, not a
+        // streaming delta.
+        let message = serde_json::json!({
+            "reasoning": "  block one  ",
+            "reasoning_content": "block two",
+        });
+        let combined =
+            extract_openai_message_field_as_text(&message, &["reasoning", "reasoning_content"]);
+        assert_eq!(combined, "block one\nblock two");
     }
 }

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -9,7 +9,7 @@ use crate::value::{VmError, VmValue};
 
 use super::errors::classify_http_error;
 use super::openai_normalize::{
-    append_paragraph, debug_log_message_shapes, extract_openai_message_field_as_text,
+    append_paragraph, debug_log_message_shapes, extract_openai_delta_field_str,
 };
 use super::options::{DeltaSender, LlmRequestPayload};
 use super::response::{extract_cache_read_tokens, extract_cache_write_tokens, parse_llm_response};
@@ -508,10 +508,21 @@ async fn vm_call_llm_api_sse_from_response(
                     blocks.push(serde_json::json!({"type": "output_text", "text": visible, "visibility": "public"}));
                 }
             }
+            // Streaming deltas for `reasoning` (Ollama OpenAI-compat,
+            // OpenRouter passthrough) and `reasoning_content` (DashScope,
+            // Together) arrive as token-sized fragments — `"Here"`,
+            // `"'s"`, `" a"`, `" thinking"`. Concatenate them verbatim;
+            // `extract_openai_message_field_as_text` + `append_paragraph`
+            // would `.trim()` each fragment (losing inter-token spaces)
+            // and inject a newline between every chunk, producing the
+            // one-token-per-line reasoning text we used to surface as
+            // `"The\ntask\nis\nto\nextend"`. The non-streaming response
+            // path still uses `append_paragraph` because there each
+            // field arrives as a single complete block.
             let reasoning_delta =
-                extract_openai_message_field_as_text(delta, &["reasoning", "reasoning_content"]);
+                extract_openai_delta_field_str(delta, &["reasoning", "reasoning_content"]);
             if !reasoning_delta.is_empty() {
-                append_paragraph(&mut thinking_text, &reasoning_delta);
+                thinking_text.push_str(reasoning_delta);
                 blocks.push(serde_json::json!({"type": "reasoning", "text": reasoning_delta, "visibility": "private"}));
             }
 


### PR DESCRIPTION
## Summary

The OpenAI streaming response path called `extract_openai_message_field_as_text` + `append_paragraph` for every per-token `delta.reasoning` / `delta.reasoning_content` chunk. Both helpers are designed for non-streaming responses where each field arrives as one complete block: the first `.trim()`s its input, the second inserts `\n` between successive non-empty appends.

When a thinking-mode model — Qwen 3.6 via Ollama, DashScope, OpenRouter passthrough, Together — streamed reasoning chunks like `"Here"`, `"'s"`, `" a"`, `" thinking"`, the per-chunk pipeline trimmed each fragment (losing inter-token whitespace) and inserted a newline between every chunk. The accumulated `thinking_text` ended up as one-token-per-line:

```
Here
's
a
thinking
process
```

When `delta.content` is empty (common during the initial reasoning burst), the fallback in `vm_call_llm_full_streaming` uses `thinking_text` as the visible response. Burin's text-tool parser then rejects it as `Stray text outside response tags` because the broken-up shape parses as neither prose nor a tool call, and the workflow re-prompts until the eval times out.

## Fix

Add a streaming-safe extractor `extract_openai_delta_field_str` that returns the first present field as `&str` without trimming or paragraph joining. Use it on the streaming path (`transport.rs:511`); non-streaming paths still go through `append_paragraph` because there each field arrives as one complete block.

## Test plan

- [x] `cargo test -p harn-vm --lib openai_normalize` — 7/7 pass, including:
  - `extract_openai_delta_field_str_returns_raw_chunk_with_inter_token_whitespace` — leading-space tokens like `" thinking"` survive
  - `extract_openai_delta_field_str_prefers_first_present_field` — `reasoning` beats `reasoning_content` when both arrive
  - `extract_openai_delta_field_str_skips_empty_fields` — empty `reasoning` falls through to `reasoning_content`
  - `extract_openai_delta_field_str_returns_empty_for_missing_fields` — no panic when neither field is present
  - `extract_openai_message_field_still_paragraph_joins_for_non_streaming_blocks` — regression check for the non-streaming response path

## Validation context

Surfaced while running burin-code's `all-verified` eval suite against `qwen3.6:35b-a3b-coding-nvfp4` via Ollama. Pre-fix: every reasoning paragraph in the LLM transcript was one-token-per-line. Post-fix (verified locally with the rebuilt `release/harn` binary): reasoning streams arrive as coherent paragraphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)