### PR TITLE
Attach mutation-session audit to tool_call ACP events (closes #699)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,17 @@ granular archaeology.
   The `tool_dispatch.rs` lifecycle (`Pending → InProgress →
   Completed/Failed`) still owns the canonical end-of-call state with
   the fully-parsed args.
+- **Mutation-session audit on tool_call ACP events (#699).** Both
+  `tool_call` and `tool_call_update` `session/update` notifications now
+  carry an optional `audit` field mirroring the active
+  `MutationSessionRecord` (session id, run id, worker id, mutation
+  scope, approval policy). Hosts can now group every write-capable
+  dispatch into the right mutation session straight off the canonical
+  ACP stream — no more correlating against the
+  `session/request_permission.mutation` payload (which only fires on
+  approval-gated calls) or the `worker_update.audit` mirror. The field
+  is omitted when no mutation session is installed, so existing clients
+  see no wire change.
 
 ## v0.7.42
 

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -102,6 +102,7 @@ impl AgentEventSink for AcpAgentEventSink {
                 status,
                 raw_input,
                 parsing,
+                audit,
             } => {
                 let mut update = serde_json::json!({
                     "sessionUpdate": "tool_call",
@@ -115,6 +116,11 @@ impl AgentEventSink for AcpAgentEventSink {
                 }
                 if let Some(p) = parsing {
                     update["parsing"] = serde_json::Value::Bool(*p);
+                }
+                if let Some(record) = audit {
+                    if let Ok(value) = serde_json::to_value(record) {
+                        update["audit"] = value;
+                    }
                 }
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
@@ -135,6 +141,7 @@ impl AgentEventSink for AcpAgentEventSink {
                 parsing,
                 raw_input,
                 raw_input_partial,
+                audit,
             } => {
                 let mut update = serde_json::json!({
                     "sessionUpdate": "tool_call_update",
@@ -162,6 +169,11 @@ impl AgentEventSink for AcpAgentEventSink {
                 }
                 if let Some(p) = parsing {
                     update["parsing"] = serde_json::Value::Bool(*p);
+                }
+                if let Some(record) = audit {
+                    if let Ok(value) = serde_json::to_value(record) {
+                        update["audit"] = value;
+                    }
                 }
                 if let Some(input) = raw_input {
                     update["rawInput"] = input.clone();
@@ -364,7 +376,9 @@ mod tests {
         AgentEvent, AgentEventSink, FsWatchEvent, ToolCallErrorCategory, ToolCallStatus,
         ToolExecutor,
     };
-    use harn_vm::orchestration::{HandoffArtifact, HandoffTargetRecord};
+    use harn_vm::orchestration::{
+        HandoffArtifact, HandoffTargetRecord, MutationSessionRecord, ToolApprovalPolicy,
+    };
     use harn_vm::tool_annotations::ToolKind;
     use tokio::sync::mpsc;
 
@@ -535,6 +549,7 @@ mod tests {
                 status: ToolCallStatus::Pending,
                 raw_input: serde_json::json!({"path": "README.md"}),
                 parsing: None,
+                audit: None,
             },
             AgentEvent::ToolCallUpdate {
                 session_id: "session-1".to_string(),
@@ -551,6 +566,7 @@ mod tests {
 
                 raw_input: None,
                 raw_input_partial: None,
+                audit: None,
             },
             AgentEvent::Plan {
                 session_id: "session-1".to_string(),
@@ -661,6 +677,7 @@ mod tests {
 
             raw_input: None,
             raw_input_partial: None,
+            audit: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -698,6 +715,7 @@ mod tests {
 
             raw_input: None,
             raw_input_partial: None,
+            audit: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -723,6 +741,7 @@ mod tests {
             status: ToolCallStatus::Pending,
             raw_input: serde_json::json!({}),
             parsing: Some(true),
+            audit: None,
         });
         let line = rx.recv().await.expect("acp tool_call notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -745,6 +764,7 @@ mod tests {
             raw_input: None,
 
             raw_input_partial: None,
+            audit: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -769,6 +789,7 @@ mod tests {
             status: ToolCallStatus::Pending,
             raw_input: serde_json::json!({}),
             parsing: None,
+            audit: None,
         });
         let line = rx.recv().await.expect("acp tool_call notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -818,6 +839,7 @@ mod tests {
 
                 raw_input: None,
                 raw_input_partial: None,
+                audit: None,
             });
             let line = rx.recv().await.expect("acp tool_call_update notification");
             let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -845,6 +867,7 @@ mod tests {
 
             raw_input: None,
             raw_input_partial: None,
+            audit: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -877,6 +900,7 @@ mod tests {
             executor: None,
             raw_input: Some(serde_json::json!({"q": "hello"})),
             raw_input_partial: None,
+            audit: None,
 
             parsing: None,
         });
@@ -900,6 +924,7 @@ mod tests {
             parsing: None,
             raw_input: None,
             raw_input_partial: Some(r#"{"q":"hel"#.to_string()),
+            audit: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
@@ -924,12 +949,149 @@ mod tests {
             parsing: None,
             raw_input: None,
             raw_input_partial: None,
+            audit: None,
         });
         let line = rx.recv().await.expect("acp tool_call_update notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
         assert!(payload["params"]["update"].get("rawInput").is_none());
         assert!(payload["params"]["update"].get("rawInputPartial").is_none());
         assert_eq!(payload["params"]["update"]["status"], "completed");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tool_call_includes_audit_when_mutation_session_is_active() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+        let policy = ToolApprovalPolicy {
+            require_approval: vec!["edit_*".into()],
+            write_path_allowlist: vec!["src/**".into()],
+            ..Default::default()
+        };
+        let audit = MutationSessionRecord {
+            session_id: "session_42".into(),
+            parent_session_id: Some("session_root".into()),
+            run_id: Some("run_42".into()),
+            worker_id: Some("worker_3".into()),
+            execution_kind: Some("worker".into()),
+            mutation_scope: "apply_workspace".into(),
+            approval_policy: Some(policy),
+        };
+        sink.handle_event(&AgentEvent::ToolCall {
+            session_id: "session-1".to_string(),
+            tool_call_id: "tool-1".to_string(),
+            tool_name: "edit_file".to_string(),
+            kind: None,
+            status: ToolCallStatus::Pending,
+            raw_input: serde_json::json!({"path": "src/main.rs"}),
+            parsing: None,
+            audit: Some(audit),
+        });
+        let line = rx.recv().await.expect("acp tool_call notification");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        let audit_value = &payload["params"]["update"]["audit"];
+        assert_eq!(audit_value["session_id"], "session_42");
+        assert_eq!(audit_value["parent_session_id"], "session_root");
+        assert_eq!(audit_value["run_id"], "run_42");
+        assert_eq!(audit_value["worker_id"], "worker_3");
+        assert_eq!(audit_value["execution_kind"], "worker");
+        assert_eq!(audit_value["mutation_scope"], "apply_workspace");
+        assert_eq!(
+            audit_value["approval_policy"]["require_approval"][0],
+            "edit_*"
+        );
+        assert_eq!(
+            audit_value["approval_policy"]["write_path_allowlist"][0],
+            "src/**"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tool_call_omits_audit_when_no_mutation_session() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+        sink.handle_event(&AgentEvent::ToolCall {
+            session_id: "session-1".to_string(),
+            tool_call_id: "tool-1".to_string(),
+            tool_name: "read".to_string(),
+            kind: Some(ToolKind::Read),
+            status: ToolCallStatus::Pending,
+            raw_input: serde_json::json!({"path": "README.md"}),
+            parsing: None,
+            audit: None,
+        });
+        let line = rx.recv().await.expect("acp tool_call notification");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        assert!(
+            payload["params"]["update"].get("audit").is_none(),
+            "got: {payload}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tool_call_update_includes_audit_when_mutation_session_is_active() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+        let audit = MutationSessionRecord {
+            session_id: "session_42".into(),
+            run_id: Some("run_42".into()),
+            mutation_scope: "apply_workspace".into(),
+            execution_kind: Some("workflow".into()),
+            ..Default::default()
+        };
+        sink.handle_event(&AgentEvent::ToolCallUpdate {
+            session_id: "session-1".to_string(),
+            tool_call_id: "tool-1".to_string(),
+            tool_name: "edit_file".to_string(),
+            status: ToolCallStatus::Completed,
+            raw_output: Some(serde_json::json!({"text": "ok"})),
+            error: None,
+            duration_ms: Some(11),
+            execution_duration_ms: Some(7),
+            error_category: None,
+            executor: Some(ToolExecutor::HostBridge),
+            parsing: None,
+            raw_input: None,
+            raw_input_partial: None,
+            audit: Some(audit),
+        });
+        let line = rx.recv().await.expect("acp tool_call_update notification");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        let update = &payload["params"]["update"];
+        assert_eq!(update["sessionUpdate"], "tool_call_update");
+        assert_eq!(update["audit"]["session_id"], "session_42");
+        assert_eq!(update["audit"]["run_id"], "run_42");
+        assert_eq!(update["audit"]["mutation_scope"], "apply_workspace");
+        assert_eq!(update["audit"]["execution_kind"], "workflow");
+        assert_eq!(update["executor"], "host_bridge");
+        assert_eq!(update["durationMs"], 11);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tool_call_update_omits_audit_when_no_mutation_session() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+        sink.handle_event(&AgentEvent::ToolCallUpdate {
+            session_id: "session-1".to_string(),
+            tool_call_id: "tool-1".to_string(),
+            tool_name: "read".to_string(),
+            status: ToolCallStatus::Completed,
+            raw_output: None,
+            error: None,
+            duration_ms: None,
+            execution_duration_ms: None,
+            error_category: None,
+            executor: None,
+            parsing: None,
+            raw_input: None,
+            raw_input_partial: None,
+            audit: None,
+        });
+        let line = rx.recv().await.expect("acp tool_call_update notification");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        assert!(
+            payload["params"]["update"].get("audit").is_none(),
+            "got: {payload}"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, Mutex, OnceLock, RwLock};
 use serde::{Deserialize, Serialize};
 
 use crate::event_log::{AnyEventLog, EventLog, LogEvent as EventLogRecord, Topic};
-use crate::orchestration::HandoffArtifact;
+use crate::orchestration::{HandoffArtifact, MutationSessionRecord};
 use crate::tool_annotations::ToolKind;
 
 /// One coalesced filesystem notification from a hostlib `fs_watch`
@@ -265,6 +265,11 @@ pub enum AgentEvent {
         /// existed.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         parsing: Option<bool>,
+        /// Mutation-session audit context active when the tool was
+        /// dispatched (see harn#699). Hosts use it to group every tool
+        /// emission belonging to the same write-capable session.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        audit: Option<MutationSessionRecord>,
     },
     ToolCallUpdate {
         session_id: String,
@@ -324,6 +329,12 @@ pub enum AgentEvent {
         /// with `raw_input`: clients render whichever is present.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         raw_input_partial: Option<String>,
+        /// Mutation-session audit context for the tool call. Carries the
+        /// same payload as on the paired `ToolCall` event so a host
+        /// processing a single update doesn't have to correlate against
+        /// the prior pending event.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        audit: Option<MutationSessionRecord>,
     },
     Plan {
         session_id: String,
@@ -928,6 +939,7 @@ mod tests {
 
             raw_input: None,
             raw_input_partial: None,
+            audit: None,
         };
         let value = serde_json::to_value(&terminal).unwrap();
         assert_eq!(value["duration_ms"], serde_json::json!(42));
@@ -951,6 +963,7 @@ mod tests {
 
             raw_input: None,
             raw_input_partial: None,
+            audit: None,
         };
         let value = serde_json::to_value(&intermediate).unwrap();
         let object = value.as_object().expect("update serializes as object");
@@ -1134,6 +1147,7 @@ mod tests {
 
             raw_input: None,
             raw_input_partial: None,
+            audit: None,
         };
         let v = serde_json::to_value(&event).unwrap();
         assert_eq!(v["type"], "tool_call_update");
@@ -1157,6 +1171,7 @@ mod tests {
 
             raw_input: None,
             raw_input_partial: None,
+            audit: None,
         };
         let v = serde_json::to_value(&event).unwrap();
         assert_eq!(v["error_category"], "schema_validation");
@@ -1183,6 +1198,7 @@ mod tests {
 
             raw_input: None,
             raw_input_partial: None,
+            audit: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert!(json.get("executor").is_none(), "got: {json}");
@@ -1344,9 +1360,84 @@ mod tests {
 
             raw_input: None,
             raw_input_partial: None,
+            audit: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["executor"]["kind"], "mcp_server");
         assert_eq!(json["executor"]["server_name"], "github");
+    }
+
+    #[test]
+    fn tool_call_update_omits_audit_when_absent() {
+        let event = AgentEvent::ToolCallUpdate {
+            session_id: "s".into(),
+            tool_call_id: "tc-1".into(),
+            tool_name: "read".into(),
+            status: ToolCallStatus::Completed,
+            raw_output: None,
+            error: None,
+            duration_ms: None,
+            execution_duration_ms: None,
+            error_category: None,
+            executor: None,
+            parsing: None,
+            raw_input: None,
+            raw_input_partial: None,
+            audit: None,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert!(json.get("audit").is_none(), "got: {json}");
+    }
+
+    #[test]
+    fn tool_call_update_includes_audit_when_present() {
+        let audit = MutationSessionRecord {
+            session_id: "session_42".into(),
+            run_id: Some("run_42".into()),
+            mutation_scope: "apply_workspace".into(),
+            execution_kind: Some("worker".into()),
+            ..Default::default()
+        };
+        let event = AgentEvent::ToolCallUpdate {
+            session_id: "s".into(),
+            tool_call_id: "tc-1".into(),
+            tool_name: "edit_file".into(),
+            status: ToolCallStatus::Completed,
+            raw_output: None,
+            error: None,
+            duration_ms: None,
+            execution_duration_ms: None,
+            error_category: None,
+            executor: Some(ToolExecutor::HostBridge),
+            parsing: None,
+            raw_input: None,
+            raw_input_partial: None,
+            audit: Some(audit),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["audit"]["session_id"], "session_42");
+        assert_eq!(json["audit"]["run_id"], "run_42");
+        assert_eq!(json["audit"]["mutation_scope"], "apply_workspace");
+        assert_eq!(json["audit"]["execution_kind"], "worker");
+    }
+
+    #[test]
+    fn tool_call_update_deserializes_without_audit_field_for_back_compat() {
+        let raw = serde_json::json!({
+            "type": "tool_call_update",
+            "session_id": "s",
+            "tool_call_id": "tc-1",
+            "tool_name": "read",
+            "status": "completed",
+            "raw_output": null,
+            "error": null,
+        });
+        let event: AgentEvent = serde_json::from_value(raw).expect("parses without audit key");
+        match event {
+            AgentEvent::ToolCallUpdate { audit, .. } => {
+                assert!(audit.is_none());
+            }
+            other => panic!("expected ToolCallUpdate, got {other:?}"),
+        }
     }
 }

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -611,6 +611,7 @@ pub(super) fn provider_native_search_emissions(
                     status: ToolCallStatus::InProgress,
                     raw_input: query,
                     parsing: None,
+                    audit: crate::orchestration::current_mutation_session(),
                 });
             }
             Some("tool_search_result") => {
@@ -677,6 +678,7 @@ pub(super) fn provider_native_search_emissions(
 
                     raw_input: None,
                     raw_input_partial: None,
+                    audit: crate::orchestration::current_mutation_session(),
                 });
             }
             _ => {}

--- a/crates/harn-vm/src/llm/agent/tool_dispatch.rs
+++ b/crates/harn-vm/src/llm/agent/tool_dispatch.rs
@@ -525,6 +525,7 @@ pub(super) async fn run_tool_dispatch(
             format!("tool-{tool_id}")
         };
         let tool_kind = crate::orchestration::current_tool_annotations(tool_name).map(|a| a.kind);
+        let tool_audit = crate::orchestration::current_mutation_session();
         super::emit_agent_event(&AgentEvent::ToolCall {
             session_id: ctx.session_id.to_string(),
             tool_call_id: tool_call_id.clone(),
@@ -533,6 +534,7 @@ pub(super) async fn run_tool_dispatch(
             status: ToolCallStatus::Pending,
             raw_input: tool_args.clone(),
             parsing: None,
+            audit: tool_audit.clone(),
         })
         .await;
 
@@ -565,6 +567,7 @@ pub(super) async fn run_tool_dispatch(
 
                 raw_input: None,
                 raw_input_partial: None,
+                audit: tool_audit.clone(),
             })
             .await;
             if ctx.tool_format == "native" {
@@ -637,6 +640,7 @@ pub(super) async fn run_tool_dispatch(
 
                 raw_input: None,
                 raw_input_partial: None,
+                audit: tool_audit.clone(),
             })
             .await;
             if ctx.tool_format == "native" {
@@ -740,6 +744,7 @@ pub(super) async fn run_tool_dispatch(
 
                         raw_input: None,
                         raw_input_partial: None,
+                        audit: tool_audit.clone(),
                     })
                     .await;
                     if ctx.tool_format == "native" {
@@ -871,6 +876,7 @@ pub(super) async fn run_tool_dispatch(
 
                 raw_input: None,
                 raw_input_partial: None,
+                audit: tool_audit.clone(),
             })
             .await;
             if ctx.tool_format == "native" {
@@ -936,6 +942,7 @@ pub(super) async fn run_tool_dispatch(
 
                     raw_input: None,
                     raw_input_partial: None,
+                    audit: tool_audit.clone(),
                 })
                 .await;
                 if ctx.tool_format == "native" {
@@ -987,6 +994,7 @@ pub(super) async fn run_tool_dispatch(
 
                 raw_input: None,
                 raw_input_partial: None,
+                audit: tool_audit.clone(),
             })
             .await;
             if ctx.tool_format == "native" {
@@ -1035,6 +1043,7 @@ pub(super) async fn run_tool_dispatch(
 
             raw_input: None,
             raw_input_partial: None,
+            audit: tool_audit.clone(),
         })
         .await;
         let tool_span_id =
@@ -1117,6 +1126,7 @@ pub(super) async fn run_tool_dispatch(
 
                     raw_input: None,
                     raw_input_partial: None,
+                    audit: tool_audit.clone(),
                 })
                 .await;
                 continue;
@@ -1297,6 +1307,7 @@ pub(super) async fn run_tool_dispatch(
 
             raw_input: None,
             raw_input_partial: None,
+            audit: tool_audit.clone(),
         })
         .await;
 

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -374,6 +374,7 @@ fn try_emit_partial_tool_args(
         executor: None,
         raw_input: value,
         raw_input_partial: raw_partial,
+        audit: crate::orchestration::current_mutation_session(),
 
         parsing: None,
     };
@@ -522,6 +523,7 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
                                     kind: tool_kind,
                                     status: ToolCallStatus::Pending,
                                     raw_input: serde_json::Value::Object(Default::default()),
+                                    audit: crate::orchestration::current_mutation_session(),
 
                                     parsing: None,
                                 });
@@ -776,6 +778,7 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
                                 kind: tool_kind,
                                 status: ToolCallStatus::Pending,
                                 raw_input: serde_json::Value::Object(Default::default()),
+                                audit: crate::orchestration::current_mutation_session(),
 
                                 parsing: None,
                             });

--- a/crates/harn-vm/src/llm/tools/parse/streaming.rs
+++ b/crates/harn-vm/src/llm/tools/parse/streaming.rs
@@ -142,6 +142,7 @@ impl StreamingToolCallDetector {
                     raw_input: None,
 
                     raw_input_partial: None,
+                    audit: None,
                 });
             }
             DetectorState::InBareCall {
@@ -247,6 +248,7 @@ impl StreamingToolCallDetector {
                         status: ToolCallStatus::Pending,
                         raw_input: serde_json::json!({}),
                         parsing: Some(true),
+                        audit: None,
                     });
                     self.state = DetectorState::InTaggedBlock {
                         body_start,
@@ -286,6 +288,7 @@ impl StreamingToolCallDetector {
                                 status: ToolCallStatus::Pending,
                                 raw_input: serde_json::json!({}),
                                 parsing: Some(true),
+                                audit: None,
                             });
                             self.state = DetectorState::InBareCall {
                                 name_start: j,
@@ -421,6 +424,7 @@ fn promote_event(
         raw_input: None,
 
         raw_input_partial: None,
+        audit: None,
     }
 }
 
@@ -446,6 +450,7 @@ fn abort_event(
         raw_input: None,
 
         raw_input_partial: None,
+        audit: None,
     }
 }
 

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -25,6 +25,51 @@ Internally, the agent loop emits `AgentEvent::ToolCall` +
 translates them into `session/update` notifications via an `AgentEventSink` it
 registers per session.
 
+### `audit` tag
+
+Both `tool_call` and `tool_call_update` carry an optional `audit`
+field that mirrors the active mutation session for the dispatch (see
+[Trust boundary](../../spec/opentrustgraph.md)). Hosts use it to:
+
+- group every tool emission belonging to the same write-capable
+  session (so undo/redo and audit logs never cross sessions even when
+  multiple workers run in parallel);
+- correlate the canonical `tool_call` stream against
+  `session/update.worker_update.audit` and the optional
+  `session/request_permission.mutation` payloads — they all carry the
+  same `MutationSessionRecord`, so a host that already understands one
+  reuses the same codepath for the others;
+- decide whether to surface a tool dispatch in trust-boundary UX
+  (e.g. badge writes that escape `mutation_scope: read_only`) without
+  guessing from the tool name.
+
+Wire shape (snake_case fields, matching the existing `worker_update.audit`
+contract):
+
+```json
+{
+  "audit": {
+    "session_id": "session_42",
+    "parent_session_id": "session_root",
+    "run_id": "run_42",
+    "worker_id": "worker_3",
+    "execution_kind": "worker",
+    "mutation_scope": "apply_workspace",
+    "approval_policy": {
+      "auto_approve": [],
+      "auto_deny": [],
+      "require_approval": ["edit_*"],
+      "write_path_allowlist": ["src/**"]
+    }
+  }
+}
+```
+
+The field is omitted when no mutation session is installed (read-only
+`harn run` invocations, conformance fixtures, scripts that don't enter
+a workflow). Existing clients that don't know about `audit` see the
+same wire shape they always did.
+
 ### `executor` tag
 
 `tool_call_update` carries an optional `executor` field that names the


### PR DESCRIPTION
## Summary

Closes #699.

Both `tool_call` and `tool_call_update` ACP `session/update` notifications now carry an optional `audit` field mirroring the active `MutationSessionRecord` (session id, parent session id, run id, worker id, execution kind, mutation scope, approval policy). This was the last remaining audit-surface gap on the issue: previously a host could only see mutation-session lineage on the `session/request_permission.mutation` payload (which fires only for approval-gated calls) or on the `worker_update.audit` mirror (delegated workers only). After this change, hosts can group every write-capable dispatch into the right mutation session straight off the canonical ACP stream — no correlation, no scraping, no special-casing.

### Wire shape

Snake_case fields, matching the existing `worker_update.audit` contract and the `MutationSessionRecord` serde derive — a host that already understands one audit shape reuses the same codepath here.

```json
{
  "audit": {
    "session_id": "session_42",
    "parent_session_id": "session_root",
    "run_id": "run_42",
    "worker_id": "worker_3",
    "execution_kind": "worker",
    "mutation_scope": "apply_workspace",
    "approval_policy": {
      "auto_approve": [],
      "auto_deny": [],
      "require_approval": ["edit_*"],
      "write_path_allowlist": ["src/**"]
    }
  }
}
```

The field is omitted (not `null`) when no mutation session is installed — read-only `harn run`, conformance, scripts that never enter a workflow — so the wire stays identical for existing clients. Persisted event-log entries written before this change continue to deserialize because the field is `#[serde(default)]`.

### Touched

- `crates/harn-vm/src/agent_events.rs`: add `audit: Option<MutationSessionRecord>` to both variants, `#[serde(default, skip_serializing_if = "Option::is_none")]`.
- `crates/harn-vm/src/llm/agent/tool_dispatch.rs`: snapshot `current_mutation_session()` once per tool dispatch iteration, thread it through all 9 `ToolCall` / `ToolCallUpdate` emission sites (pending, parse-error, policy-denial, host-approval-denial, pre-tool-hook-denial, schema-validation, in-progress, loop-skip, terminal).
- `crates/harn-vm/src/llm/agent/llm_call.rs`: thread audit through the 2 provider-native `tool_search` emissions.
- `crates/harn-serve/src/adapters/acp/events.rs`: serialize the field on the wire under both `tool_call` and `tool_call_update`.
- `docs/src/bridge-protocol.md`: new "audit tag" section documenting the wire shape and pointing at the trust-boundary contract.

### Tests added

- `tool_call_update_omits_audit_when_absent` / `tool_call_update_includes_audit_when_present` — canonical event serializes correctly with snake_case fields.
- `tool_call_update_deserializes_without_audit_field_for_back_compat` — pre-#699 event-log replays still parse.
- `tool_call_omits_audit_when_no_mutation_session` / `tool_call_includes_audit_when_mutation_session_is_active` — ACP `tool_call` adapter omits / serializes correctly.
- `tool_call_update_omits_audit_when_no_mutation_session` / `tool_call_update_includes_audit_when_mutation_session_is_active` — ACP `tool_call_update` adapter omits / serializes correctly.

## Test plan

- [x] `cargo check --workspace --tests` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p harn-vm --lib agent_events` — 16/16 pass (incl. 3 new)
- [x] `cargo test -p harn-serve --lib tool_call` — 7/7 pass (incl. 4 new)
- [x] `cargo test -p harn-vm --lib tool_durations` — passes (existing integration test still green)
- [x] `cargo run --bin harn -- test conformance` — 696/696
- [x] `make lint-md` clean
- [x] `make check-docs-snippets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)