### PR TITLE
[codex] Flow invariants.harn discovery + provenance attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,18 @@ granular archaeology.
   approval-gated calls) or the `worker_update.audit` mirror. The field
   is omitted when no mutation session is installed, so existing clients
   see no wire change.
+- **Flow `invariants.harn` discovery + provenance attributes (#579).**
+  Adds the discovery walker that mirrors `metadata_resolve` semantics
+  (root-to-leaf, stricter-child overrides) for per-directory
+  `invariants.harn` Flow predicate files, the structured
+  `@archivist(evidence: [...], confidence, source_date,
+  coverage_examples)` provenance attribute, and the advisory
+  `@retroactive` flag. The typechecker now warns when a bare
+  `@invariant` is missing exactly one of `@deterministic`/`@semantic` or
+  is missing `@archivist(...)`, and the LSP surfaces the full attribute
+  block on hover so the function declaration stays the single source of
+  truth. Attribute argument syntax also accepts list literals and
+  multi-line forms so provenance blocks can carry rich evidence.
 
 ## v0.7.42
 

--- a/conformance/tests/integration/attributes_flow_invariant.expected
+++ b/conformance/tests/integration/attributes_flow_invariant.expected
@@ -1,0 +1,1 @@
+[harn] attributes_flow_invariant ok

--- a/conformance/tests/integration/attributes_flow_invariant.harn
+++ b/conformance/tests/integration/attributes_flow_invariant.harn
@@ -1,0 +1,26 @@
+// Smoke test: parser accepts the full Flow predicate attribute stack
+// (`@invariant` + `@deterministic`/`@semantic` + `@archivist(...)` +
+// `@retroactive`) on a Harn function declaration and the runtime
+// executes it unchanged.
+@invariant
+@deterministic
+@archivist(evidence: ["https://example.com/spec", "https://example.com/changelog"], confidence: 0.95, source_date: "2026-04-01", coverage_examples: ["case-a", "case-b"])
+fn no_secrets_in_diff(_slice) -> bool {
+  return true
+}
+
+@invariant
+@semantic
+@retroactive
+@archivist(evidence: ["https://example.com/style"], confidence: 0.6)
+fn naming_style(_slice) -> bool {
+  return true
+}
+
+@test
+pipeline test_flow_attributes_smoke(task) {
+  // Both predicates remain ordinary callable functions.
+  assert(no_secrets_in_diff(nil), "deterministic predicate callable")
+  assert(naming_style(nil), "semantic predicate callable")
+  log("attributes_flow_invariant ok")
+}

--- a/crates/harn-lsp/src/handlers/hover.rs
+++ b/crates/harn-lsp/src/handlers/hover.rs
@@ -7,7 +7,8 @@ use tower_lsp::lsp_types::*;
 use crate::constants::{builtin_doc, keyword_doc, BUILTINS};
 use crate::helpers::{lsp_position_to_offset, word_at_position};
 use crate::symbols::{
-    format_shape_expanded, format_union_shapes_expanded, HarnSymbolKind, SymbolInfo,
+    format_flow_attributes_block, format_shape_expanded, format_union_shapes_expanded,
+    HarnSymbolKind, SymbolInfo,
 };
 use crate::HarnLsp;
 
@@ -148,6 +149,10 @@ impl HarnLsp {
 
             if let Some(ref doc) = sym.doc_comment {
                 hover_text.push_str(&format!("\n---\n\n{doc}"));
+            }
+
+            if let Some(block) = format_flow_attributes_block(&sym.attributes) {
+                hover_text.push_str(&block);
             }
 
             return Ok(Some(Hover {

--- a/crates/harn-lsp/src/main.rs
+++ b/crates/harn-lsp/src/main.rs
@@ -239,6 +239,33 @@ mod tests {
     }
 
     #[test]
+    fn hover_captures_flow_predicate_attributes() {
+        let source = concat!(
+            "@invariant\n",
+            "@deterministic\n",
+            "@archivist(evidence: [\"https://example.com/spec\"], confidence: 0.9, source_date: \"2026-04-01\")\n",
+            "fn no_secrets(slice) -> bool {\n",
+            "  return true\n",
+            "}\n",
+        );
+        let state = DocumentState::new(source.to_string());
+        let sym = state
+            .symbols
+            .iter()
+            .find(|s| s.name == "no_secrets" && s.kind == HarnSymbolKind::Function)
+            .expect("should find no_secrets");
+        let names: Vec<&str> = sym.attributes.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(names, vec!["invariant", "deterministic", "archivist"]);
+        let block = crate::symbols::format_flow_attributes_block(&sym.attributes)
+            .expect("flow metadata block");
+        assert!(block.contains("@invariant"));
+        assert!(block.contains("@deterministic"));
+        assert!(block.contains("@archivist"));
+        assert!(block.contains("evidence"));
+        assert!(block.contains("https://example.com/spec"));
+    }
+
+    #[test]
     fn hover_generic_interface_signature() {
         let source = "interface Repository<T> {\n  fn map<U>(value: T, f: fn(T) -> U) -> U\n}\n";
         let state = DocumentState::new(source.to_string());

--- a/crates/harn-lsp/src/symbols.rs
+++ b/crates/harn-lsp/src/symbols.rs
@@ -1,5 +1,7 @@
 use harn_lexer::Span;
-use harn_parser::{format_type, DictEntry, Node, SNode, ShapeField, TypeExpr, TypeParam};
+use harn_parser::{
+    format_type, Attribute, DictEntry, Node, SNode, ShapeField, TypeExpr, TypeParam,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum HarnSymbolKind {
@@ -37,15 +39,98 @@ pub(crate) struct SymbolInfo {
     pub(crate) fields: Vec<ShapeField>,
     /// Enum variants available on this enum symbol.
     pub(crate) enum_variants: Vec<EnumVariantInfo>,
+    /// Attributes (`@invariant`, `@archivist`, `@deterministic`, …)
+    /// attached to the immediately-preceding declaration. Used by hover
+    /// to surface Flow predicate metadata as a single source of truth.
+    pub(crate) attributes: Vec<Attribute>,
 }
 
 /// Walk the parsed AST and collect all definitions.
 pub(crate) fn build_symbol_table(program: &[SNode], source: &str) -> Vec<SymbolInfo> {
     let mut symbols = Vec::new();
     for snode in program {
-        collect_symbols(snode, &mut symbols, None, source, None);
+        collect_symbols(snode, &mut symbols, None, source, None, &[]);
     }
     symbols
+}
+
+/// Pretty-print a Flow predicate metadata block from the attribute list
+/// attached to a declaration. Returns `None` when no attribute is
+/// recognised, so hover can keep its existing layout for non-Flow
+/// symbols.
+pub(crate) fn format_flow_attributes_block(attributes: &[Attribute]) -> Option<String> {
+    if attributes.is_empty() {
+        return None;
+    }
+    let mut lines: Vec<String> = Vec::new();
+    let mut saw_relevant = false;
+    for attr in attributes {
+        match attr.name.as_str() {
+            "invariant" if attr.args.is_empty() => {
+                lines.push("- `@invariant` — Flow predicate".to_string());
+                saw_relevant = true;
+            }
+            "deterministic" => {
+                lines.push("- `@deterministic` — pure, replay-checked".to_string());
+                saw_relevant = true;
+            }
+            "semantic" => {
+                lines.push(
+                    "- `@semantic` — may invoke `cheap_judge` over pre-baked evidence".to_string(),
+                );
+                saw_relevant = true;
+            }
+            "retroactive" => {
+                lines.push(
+                    "- `@retroactive` — advisory historical flag (does not gate)".to_string(),
+                );
+                saw_relevant = true;
+            }
+            "archivist" => {
+                let mut detail: Vec<String> = Vec::new();
+                for arg in &attr.args {
+                    let Some(name) = arg.name.as_deref() else {
+                        continue;
+                    };
+                    let value = format_attribute_arg_value(&arg.value.node);
+                    if let Some(value) = value {
+                        detail.push(format!("    - `{name}`: {value}"));
+                    } else {
+                        detail.push(format!("    - `{name}`"));
+                    }
+                }
+                lines.push("- `@archivist(...)` — provenance:".to_string());
+                lines.extend(detail);
+                saw_relevant = true;
+            }
+            _ => {}
+        }
+    }
+    if !saw_relevant {
+        return None;
+    }
+    let mut block = String::from("\n---\n\n**Flow predicate metadata**\n\n");
+    block.push_str(&lines.join("\n"));
+    Some(block)
+}
+
+fn format_attribute_arg_value(node: &Node) -> Option<String> {
+    match node {
+        Node::StringLiteral(s) | Node::RawStringLiteral(s) => Some(format!("\"{s}\"")),
+        Node::IntLiteral(i) => Some(i.to_string()),
+        Node::FloatLiteral(f) => Some(format!("{f:.3}")),
+        Node::BoolLiteral(b) => Some(b.to_string()),
+        Node::NilLiteral => Some("nil".to_string()),
+        Node::Identifier(id) => Some(format!("`{id}`")),
+        Node::ListLiteral(items) => {
+            let rendered: Vec<String> = items
+                .iter()
+                .filter_map(|n| format_attribute_arg_value(&n.node))
+                .collect();
+            Some(format!("[{}]", rendered.join(", ")))
+        }
+        _ => None,
+    }
 }
 
 /// Extract leading `///` lines immediately above a span in the source.
@@ -131,6 +216,7 @@ fn collect_symbols(
     scope_span: Option<Span>,
     source: &str,
     impl_type_name: Option<&str>,
+    pending_attrs: &[Attribute],
 ) {
     // Helper macro for simple SymbolInfo with no doc/impl fields
     macro_rules! simple_sym {
@@ -146,6 +232,7 @@ fn collect_symbols(
                 impl_type: None,
                 fields: Vec::new(),
                 enum_variants: Vec::new(),
+                attributes: Vec::new(),
             }
         };
     }
@@ -153,7 +240,7 @@ fn collect_symbols(
     // Shorthand for recursive calls
     macro_rules! recurse {
         ($child:expr, $scope:expr) => {
-            collect_symbols($child, symbols, $scope, source, None)
+            collect_symbols($child, symbols, $scope, source, None, &[])
         };
     }
 
@@ -182,6 +269,7 @@ fn collect_symbols(
                 impl_type: None,
                 fields: Vec::new(),
                 enum_variants: Vec::new(),
+                attributes: pending_attrs.to_vec(),
             });
             // Params are plain strings (no individual spans), register them scoped to body.
             for p in params {
@@ -226,6 +314,7 @@ fn collect_symbols(
                 impl_type: impl_type_name.map(String::from),
                 fields: Vec::new(),
                 enum_variants: Vec::new(),
+                attributes: pending_attrs.to_vec(),
             });
             for p in params {
                 symbols.push(simple_sym!(
@@ -269,6 +358,7 @@ fn collect_symbols(
                 impl_type: None,
                 fields: Vec::new(),
                 enum_variants: Vec::new(),
+                attributes: pending_attrs.to_vec(),
             });
             for p in params {
                 symbols.push(simple_sym!(
@@ -302,6 +392,7 @@ fn collect_symbols(
                 impl_type: None,
                 fields: Vec::new(),
                 enum_variants: Vec::new(),
+                attributes: Vec::new(),
             });
             for (_k, value) in fields {
                 recurse!(value, Some(snode.span));
@@ -381,6 +472,7 @@ fn collect_symbols(
                             .collect(),
                     })
                     .collect(),
+                attributes: Vec::new(),
             });
         }
         Node::StructDecl {
@@ -426,6 +518,7 @@ fn collect_symbols(
                 impl_type: None,
                 fields: shape_fields,
                 enum_variants: Vec::new(),
+                attributes: Vec::new(),
             });
         }
         Node::InterfaceDecl {
@@ -472,6 +565,7 @@ fn collect_symbols(
                 impl_type: None,
                 fields: Vec::new(),
                 enum_variants: Vec::new(),
+                attributes: Vec::new(),
             });
         }
         Node::ImplBlock {
@@ -488,9 +582,10 @@ fn collect_symbols(
                 impl_type: None,
                 fields: Vec::new(),
                 enum_variants: Vec::new(),
+                attributes: Vec::new(),
             });
             for m in methods {
-                collect_symbols(m, symbols, Some(snode.span), source, Some(type_name));
+                collect_symbols(m, symbols, Some(snode.span), source, Some(type_name), &[]);
             }
         }
         Node::ForIn {
@@ -778,6 +873,7 @@ fn collect_symbols(
                 impl_type: None,
                 fields: Vec::new(),
                 enum_variants: Vec::new(),
+                attributes: Vec::new(),
             });
             for s in body {
                 recurse!(s, Some(snode.span));
@@ -809,13 +905,13 @@ fn collect_symbols(
         | Node::BreakStmt
         | Node::ContinueStmt => {}
 
-        Node::AttributedDecl { inner, .. } => {
-            collect_symbols(inner, symbols, scope_span, source, None);
+        Node::AttributedDecl { attributes, inner } => {
+            collect_symbols(inner, symbols, scope_span, source, None, attributes);
         }
 
         Node::OrPattern(alternatives) => {
             for alt in alternatives {
-                collect_symbols(alt, symbols, scope_span, source, None);
+                collect_symbols(alt, symbols, scope_span, source, None, &[]);
             }
         }
     }
@@ -828,8 +924,8 @@ fn collect_dict_entries(
     source: &str,
 ) {
     for entry in entries {
-        collect_symbols(&entry.key, symbols, scope_span, source, None);
-        collect_symbols(&entry.value, symbols, scope_span, source, None);
+        collect_symbols(&entry.key, symbols, scope_span, source, None, &[]);
+        collect_symbols(&entry.value, symbols, scope_span, source, None, &[]);
     }
 }
 

--- a/crates/harn-parser/src/parser/decls.rs
+++ b/crates/harn-parser/src/parser/decls.rs
@@ -151,8 +151,10 @@ impl Parser {
         let mut args = Vec::new();
         if self.check(&TokenKind::LParen) {
             self.advance();
+            self.skip_newlines();
             while !self.check(&TokenKind::RParen) {
                 args.push(self.parse_attribute_arg()?);
+                self.skip_newlines();
                 if self.check(&TokenKind::Comma) {
                     self.advance();
                     self.skip_newlines();
@@ -195,8 +197,10 @@ impl Parser {
 
     /// Parse a literal-or-identifier expression for an attribute argument.
     /// Restricted to keep attribute evaluation purely compile-time:
-    /// strings, ints, floats, bools, nil, and bare identifiers (typically
-    /// type names like `EditArgs` or sentinel values like `allow`).
+    /// strings, ints, floats, bools, nil, bare identifiers (typically
+    /// type names like `EditArgs` or sentinel values like `allow`), and
+    /// list literals containing the same restricted values (used by Flow
+    /// `@archivist(evidence: [...])` and similar provenance attributes).
     pub(super) fn parse_attribute_value(&mut self) -> Result<SNode, ParserError> {
         let span = self.current_span();
         let tok = self.current().ok_or_else(|| ParserError::UnexpectedEof {
@@ -212,6 +216,26 @@ impl Parser {
             TokenKind::False => Node::BoolLiteral(false),
             TokenKind::Nil => Node::NilLiteral,
             TokenKind::Identifier(name) => Node::Identifier(name.clone()),
+            TokenKind::LBracket => {
+                self.advance();
+                self.skip_newlines();
+                let mut items = Vec::new();
+                while !self.check(&TokenKind::RBracket) {
+                    items.push(self.parse_attribute_value()?);
+                    self.skip_newlines();
+                    if self.check(&TokenKind::Comma) {
+                        self.advance();
+                        self.skip_newlines();
+                    } else {
+                        break;
+                    }
+                }
+                self.consume(&TokenKind::RBracket, "]")?;
+                return Ok(spanned(
+                    Node::ListLiteral(items),
+                    Span::merge(span, self.prev_span()),
+                ));
+            }
             TokenKind::Minus => {
                 self.advance();
                 let inner_tok = self.current().ok_or_else(|| ParserError::UnexpectedEof {

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -11,6 +11,8 @@
 
 use std::collections::BTreeMap;
 
+use harn_lexer::Span;
+
 use crate::ast::*;
 use crate::builtin_signatures;
 
@@ -1407,9 +1409,19 @@ impl TypeChecker {
 
     /// Validate attribute usage and emit warnings for unknown attributes.
     /// Recognized attribute names: `deprecated`, `test`, `complexity`,
-    /// `acp_tool`, `acp_skill`, `invariant`, `deterministic`, `semantic`.
-    /// All other names produce a warning so misspellings surface early without
-    /// breaking compilation.
+    /// `acp_tool`, `acp_skill`, `invariant`, `deterministic`, `semantic`,
+    /// `archivist`, `retroactive`. All other names produce a warning so
+    /// misspellings surface early without breaking compilation.
+    ///
+    /// Flow predicate cross-attribute rules (epic #571 / #579):
+    /// - A bare `@invariant` (no arguments) is the Flow predicate marker.
+    ///   It must be paired with exactly one of `@deterministic`/`@semantic`
+    ///   and an `@archivist(...)` provenance block. The handler-IR
+    ///   `@invariant("name", ...)` form (positional args) is a separate
+    ///   feature validated in `harn_ir` and is left untouched here.
+    /// - `@deterministic` and `@semantic` are mutually exclusive.
+    /// - `@archivist(...)` and `@retroactive` only make sense on Flow
+    ///   predicate functions; we warn if they appear without `@invariant`.
     pub(in crate::typechecker) fn check_attributes(
         &mut self,
         attributes: &[Attribute],
@@ -1418,7 +1430,7 @@ impl TypeChecker {
         for attr in attributes {
             match attr.name.as_str() {
                 "deprecated" | "test" | "complexity" | "acp_tool" | "acp_skill" | "invariant"
-                | "deterministic" | "semantic" => {}
+                | "deterministic" | "semantic" | "archivist" | "retroactive" => {}
                 other => {
                     self.warning_at(format!("unknown attribute `@{}`", other), attr.span);
                 }
@@ -1442,8 +1454,10 @@ impl TypeChecker {
                     attr.span,
                 );
             }
-            if matches!(attr.name.as_str(), "deterministic" | "semantic")
-                && !matches!(inner.node, Node::FnDecl { .. })
+            if matches!(
+                attr.name.as_str(),
+                "deterministic" | "semantic" | "archivist" | "retroactive"
+            ) && !matches!(inner.node, Node::FnDecl { .. })
             {
                 self.warning_at(
                     format!("`@{}` only applies to function declarations", attr.name),
@@ -1462,6 +1476,135 @@ impl TypeChecker {
                     attr.span,
                 );
             }
+        }
+
+        // Flow predicate companion-attribute rules. These only apply when a
+        // bare `@invariant` (no arguments) is present — that's the Flow
+        // predicate marker. Handler-IR-style `@invariant("name", ...)` keeps
+        // its existing semantics validated by `harn_ir`.
+        let flow_invariant = attributes
+            .iter()
+            .find(|a| a.name == "invariant" && a.args.is_empty());
+        let deterministic = attributes.iter().find(|a| a.name == "deterministic");
+        let semantic = attributes.iter().find(|a| a.name == "semantic");
+        let archivist = attributes.iter().find(|a| a.name == "archivist");
+        let retroactive = attributes.iter().find(|a| a.name == "retroactive");
+
+        if let (Some(det), Some(sem)) = (deterministic, semantic) {
+            self.warning_at(
+                "`@deterministic` and `@semantic` are mutually exclusive; \
+                 a Flow predicate is one mode or the other"
+                    .to_string(),
+                Span::merge(sem.span, det.span),
+            );
+        }
+
+        if let Some(inv) = flow_invariant {
+            if deterministic.is_none() && semantic.is_none() {
+                self.warning_at(
+                    "Flow `@invariant` requires exactly one of `@deterministic` \
+                     (default) or `@semantic`"
+                        .to_string(),
+                    inv.span,
+                );
+            }
+            if archivist.is_none() {
+                self.warning_at(
+                    "Flow `@invariant` is missing `@archivist(...)` provenance \
+                     (evidence, confidence, source_date, coverage_examples)"
+                        .to_string(),
+                    inv.span,
+                );
+            }
+        } else {
+            if let Some(arch) = archivist {
+                self.warning_at(
+                    "`@archivist(...)` only applies to Flow predicates marked \
+                     with `@invariant`"
+                        .to_string(),
+                    arch.span,
+                );
+            }
+            if let Some(retro) = retroactive {
+                self.warning_at(
+                    "`@retroactive` only applies to Flow predicates marked \
+                     with `@invariant`"
+                        .to_string(),
+                    retro.span,
+                );
+            }
+        }
+
+        if let Some(arch) = archivist {
+            self.validate_archivist_args(arch);
+        }
+    }
+
+    /// Sanity-check the shape of an `@archivist(...)` block.
+    ///
+    /// Recognized arguments (all optional individually, but `evidence`
+    /// must be present for the block to carry meaningful provenance):
+    /// - `evidence`: list of URL strings (the linter only checks that the
+    ///   key exists; deep validation lives in the Archivist persona).
+    /// - `confidence`: float between 0.0 and 1.0
+    /// - `source_date`: string (ISO-8601 date)
+    /// - `coverage_examples`: list of strings
+    ///
+    /// Unknown keys produce a warning so typos surface early.
+    pub(in crate::typechecker) fn validate_archivist_args(&mut self, attr: &Attribute) {
+        const KNOWN_KEYS: &[&str] = &["evidence", "confidence", "source_date", "coverage_examples"];
+
+        let mut has_evidence = false;
+        for arg in &attr.args {
+            let Some(name) = arg.name.as_deref() else {
+                self.warning_at(
+                    "`@archivist(...)` arguments must be named (e.g. \
+                     `evidence: [...], confidence: 0.9`)"
+                        .to_string(),
+                    arg.span,
+                );
+                continue;
+            };
+            if !KNOWN_KEYS.contains(&name) {
+                self.warning_at(
+                    format!(
+                        "unknown `@archivist` argument `{name}`; expected one of \
+                         {KNOWN_KEYS:?}"
+                    ),
+                    arg.span,
+                );
+                continue;
+            }
+            if name == "evidence" {
+                has_evidence = true;
+            }
+            // Confidence must be a number between 0 and 1 when supplied as a
+            // literal. Bare identifiers (e.g. a constant reference) are
+            // allowed and validated at runtime.
+            if name == "confidence" {
+                match &arg.value.node {
+                    Node::FloatLiteral(f) if (0.0..=1.0).contains(f) => {}
+                    Node::IntLiteral(i) if *i == 0 || *i == 1 => {}
+                    Node::Identifier(_) => {}
+                    _ => {
+                        self.warning_at(
+                            "`@archivist(confidence: ...)` must be a float in \
+                             [0.0, 1.0]"
+                                .to_string(),
+                            arg.span,
+                        );
+                    }
+                }
+            }
+        }
+
+        if !has_evidence {
+            self.warning_at(
+                "`@archivist(...)` should declare `evidence: [...]` so \
+                 predicates can be audited"
+                    .to_string(),
+                attr.span,
+            );
         }
     }
 }

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -85,6 +85,153 @@ pipeline invalid(task) {}
 }
 
 #[test]
+fn test_flow_invariant_archivist_attributes_recognized() {
+    let warns = warnings(
+        r#"
+@invariant
+@deterministic
+@archivist(evidence: ["https://example.com/spec"], confidence: 0.95, source_date: "2026-04-01", coverage_examples: ["case-a"])
+@retroactive
+fn complete_predicate(slice) -> bool { return true }
+"#,
+    );
+    assert!(
+        warns
+            .iter()
+            .all(|warning| !warning.contains("unknown attribute")),
+        "archivist/retroactive attributes should be recognised: {warns:?}"
+    );
+}
+
+#[test]
+fn test_flow_invariant_requires_kind_and_archivist() {
+    let warns = warnings(
+        r#"
+@invariant
+fn bare_predicate(slice) -> bool { return true }
+"#,
+    );
+    assert!(
+        warns.iter().any(|w| w.contains("requires exactly one of")),
+        "expected kind-required warning, got {warns:?}"
+    );
+    assert!(
+        warns
+            .iter()
+            .any(|w| w.contains("missing `@archivist(...)`")),
+        "expected archivist-required warning, got {warns:?}"
+    );
+}
+
+#[test]
+fn test_flow_invariant_with_kind_only_still_warns_about_archivist() {
+    let warns = warnings(
+        r#"
+@invariant
+@deterministic
+fn kinded_predicate(slice) -> bool { return true }
+"#,
+    );
+    assert!(
+        warns
+            .iter()
+            .any(|w| w.contains("missing `@archivist(...)`")),
+        "expected archivist-required warning, got {warns:?}"
+    );
+    assert!(
+        warns.iter().all(|w| !w.contains("requires exactly one of")),
+        "should not also warn about missing kind: {warns:?}"
+    );
+}
+
+#[test]
+fn test_flow_invariant_kinds_are_mutually_exclusive() {
+    let warns = warnings(
+        r#"
+@invariant
+@deterministic
+@semantic
+@archivist(evidence: ["x"])
+fn confused(slice) -> bool { return true }
+"#,
+    );
+    assert!(
+        warns.iter().any(|w| w.contains("mutually exclusive")),
+        "expected mutual-exclusion warning, got {warns:?}"
+    );
+}
+
+#[test]
+fn test_archivist_without_invariant_warns() {
+    let warns = warnings(
+        r#"
+@archivist(evidence: ["https://x"])
+fn standalone() -> int { return 1 }
+"#,
+    );
+    assert!(
+        warns
+            .iter()
+            .any(|w| w.contains("only applies to Flow predicates marked")),
+        "expected standalone-archivist warning, got {warns:?}"
+    );
+}
+
+#[test]
+fn test_handler_ir_invariant_does_not_trigger_flow_lints() {
+    // `@invariant("name")` is the harn-ir handler form, validated
+    // separately. Flow lints must not fire for it.
+    let warns = warnings(
+        r#"
+@invariant("approval.reachability")
+fn handler() -> int { return 1 }
+"#,
+    );
+    assert!(
+        warns
+            .iter()
+            .all(|w| !w.contains("`@archivist(...)`") && !w.contains("requires exactly one of")),
+        "handler-IR @invariant should not trigger Flow lints: {warns:?}"
+    );
+}
+
+#[test]
+fn test_archivist_unknown_arg_warns() {
+    let warns = warnings(
+        r#"
+@invariant
+@deterministic
+@archivist(evidence: ["x"], typo_key: "oops")
+fn oops(slice) -> bool { return true }
+"#,
+    );
+    assert!(
+        warns
+            .iter()
+            .any(|w| w.contains("unknown `@archivist` argument `typo_key`")),
+        "expected unknown-arg warning, got {warns:?}"
+    );
+}
+
+#[test]
+fn test_archivist_confidence_out_of_range_warns() {
+    let warns = warnings(
+        r#"
+@invariant
+@deterministic
+@archivist(evidence: ["x"], confidence: 1.5)
+fn loud(slice) -> bool { return true }
+"#,
+    );
+    assert!(
+        warns
+            .iter()
+            .any(|w| w.contains("confidence") && w.contains("[0.0, 1.0]")),
+        "expected confidence-range warning, got {warns:?}"
+    );
+}
+
+#[test]
 fn test_fn_arg_type_mismatch() {
     let errs = errors(
         r#"pipeline t(task) { fn add(a: int, b: int) -> int { return a + b }

--- a/crates/harn-vm/src/flow/mod.rs
+++ b/crates/harn-vm/src/flow/mod.rs
@@ -22,9 +22,11 @@ pub use intent::{
     TranscriptSpan,
 };
 pub use predicates::{
-    CheapJudge, CheapJudgeRequest, CheapJudgeResponse, PredicateContext, PredicateExecutionRecord,
-    PredicateExecutionReport, PredicateExecutor, PredicateExecutorConfig, PredicateKind,
-    PredicateRunner,
+    discover_invariants, parse_invariants_source, resolve_predicates, ArchivistMetadata,
+    CheapJudge, CheapJudgeRequest, CheapJudgeResponse, DiscoveredInvariantFile,
+    DiscoveredPredicate, DiscoveryDiagnostic, DiscoveryDiagnosticSeverity, ParsedInvariantFile,
+    PredicateContext, PredicateExecutionRecord, PredicateExecutionReport, PredicateExecutor,
+    PredicateExecutorConfig, PredicateKind, PredicateRunner, INVARIANTS_FILE,
 };
 pub use slice::{
     derive_slice, Approval, CoverageMap, InvariantBlockError, InvariantResult, PredicateHash,

--- a/crates/harn-vm/src/flow/predicates/discovery.rs
+++ b/crates/harn-vm/src/flow/predicates/discovery.rs
@@ -1,0 +1,509 @@
+//! Discovery and parsing of `invariants.harn` Flow predicate files.
+//!
+//! Mirrors `metadata_resolve` semantics: predicates declared in higher
+//! directories apply to all descendants, with stricter (closer-to-leaf)
+//! files overriding when names collide. This module owns the walk + parse;
+//! evaluation lives in [`super::executor`].
+//!
+//! See parent epic #571 and ticket #579 for the design rationale.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use harn_lexer::{Lexer, Span};
+use harn_parser::{peel_attributes, Attribute, AttributeArg, Node, Parser};
+
+use super::executor::PredicateKind;
+
+/// Filename used for per-directory Flow invariant declarations.
+pub const INVARIANTS_FILE: &str = "invariants.harn";
+
+/// One `invariants.harn` file discovered on disk, with its predicates
+/// already parsed into typed metadata.
+#[derive(Clone, Debug)]
+pub struct DiscoveredInvariantFile {
+    /// Absolute path to the source file.
+    pub path: PathBuf,
+    /// Path relative to the discovery root, normalised with `/` separators.
+    pub relative_dir: String,
+    /// Raw source — kept around so callers can render diagnostics.
+    pub source: String,
+    /// Predicates declared at the top level, in source order.
+    pub predicates: Vec<DiscoveredPredicate>,
+    /// Parse / attribute errors encountered when reading this file.
+    pub diagnostics: Vec<DiscoveryDiagnostic>,
+}
+
+/// One Flow predicate declaration parsed out of an invariants file.
+#[derive(Clone, Debug)]
+pub struct DiscoveredPredicate {
+    /// Function name. Composition uses `relative_dir + name` as the
+    /// identity for stricter-child overrides.
+    pub name: String,
+    /// `Deterministic` (default) or `Semantic`.
+    pub kind: PredicateKind,
+    /// Optional Archivist provenance block.
+    pub archivist: Option<ArchivistMetadata>,
+    /// Advisory historical flag — predicates that legalise existing state
+    /// rather than gate new atoms.
+    pub retroactive: bool,
+    /// Span of the function declaration in the source file (1-based).
+    pub span: Span,
+}
+
+/// Provenance metadata pulled from `@archivist(...)`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ArchivistMetadata {
+    pub evidence: Vec<String>,
+    pub confidence: Option<f64>,
+    pub source_date: Option<String>,
+    pub coverage_examples: Vec<String>,
+}
+
+/// One diagnostic surfaced by discovery — covers both parse errors and
+/// the structural attribute checks that go beyond the typechecker
+/// (`@invariant` requires `@archivist`, etc.).
+#[derive(Clone, Debug)]
+pub struct DiscoveryDiagnostic {
+    pub severity: DiagnosticSeverity,
+    pub message: String,
+    pub span: Option<Span>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiagnosticSeverity {
+    Warning,
+    Error,
+}
+
+/// Walk from `root` down through every component of `target_dir`,
+/// collecting `invariants.harn` at each level.
+///
+/// Returns the files in root-to-leaf order so callers can apply
+/// stricter-child overrides simply by iterating in order.
+///
+/// `target_dir` is interpreted relative to `root`. Absolute paths or
+/// paths that escape `root` are silently clamped — discovery never reads
+/// files outside `root`.
+pub fn discover_invariants(root: &Path, target_dir: &Path) -> Vec<DiscoveredInvariantFile> {
+    let mut files = Vec::new();
+    let candidates = candidate_directories(root, target_dir);
+
+    for dir in candidates {
+        let path = dir.join(INVARIANTS_FILE);
+        if !path.is_file() {
+            continue;
+        }
+        let source = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let relative_dir = relative_dir_label(root, &dir);
+        let parsed = parse_invariants_source(&source);
+        files.push(DiscoveredInvariantFile {
+            path,
+            relative_dir,
+            source,
+            predicates: parsed.predicates,
+            diagnostics: parsed.diagnostics,
+        });
+    }
+
+    files
+}
+
+/// Parse a single `invariants.harn` source string. Exposed publicly for
+/// tests, the LSP, and tooling that has the file contents in hand.
+pub fn parse_invariants_source(source: &str) -> ParsedInvariantFile {
+    let mut diagnostics = Vec::new();
+    let tokens = match Lexer::new(source).tokenize() {
+        Ok(t) => t,
+        Err(error) => {
+            diagnostics.push(DiscoveryDiagnostic {
+                severity: DiagnosticSeverity::Error,
+                message: format!("lex error: {error:?}"),
+                span: None,
+            });
+            return ParsedInvariantFile {
+                predicates: Vec::new(),
+                diagnostics,
+            };
+        }
+    };
+    let program = match Parser::new(tokens).parse() {
+        Ok(p) => p,
+        Err(error) => {
+            diagnostics.push(DiscoveryDiagnostic {
+                severity: DiagnosticSeverity::Error,
+                message: format!("parse error: {error:?}"),
+                span: None,
+            });
+            return ParsedInvariantFile {
+                predicates: Vec::new(),
+                diagnostics,
+            };
+        }
+    };
+
+    let mut predicates = Vec::new();
+    for node in &program {
+        let (attrs, inner) = peel_attributes(node);
+        let Node::FnDecl { name, .. } = &inner.node else {
+            continue;
+        };
+        let Some(predicate) = predicate_from_attributes(name, attrs, inner.span, &mut diagnostics)
+        else {
+            continue;
+        };
+        predicates.push(predicate);
+    }
+
+    ParsedInvariantFile {
+        predicates,
+        diagnostics,
+    }
+}
+
+/// Parsed-but-not-yet-located output of [`parse_invariants_source`].
+#[derive(Clone, Debug, Default)]
+pub struct ParsedInvariantFile {
+    pub predicates: Vec<DiscoveredPredicate>,
+    pub diagnostics: Vec<DiscoveryDiagnostic>,
+}
+
+fn predicate_from_attributes(
+    name: &str,
+    attrs: &[Attribute],
+    span: Span,
+    diagnostics: &mut Vec<DiscoveryDiagnostic>,
+) -> Option<DiscoveredPredicate> {
+    // The Flow predicate marker is a *bare* `@invariant`. Anything with
+    // arguments is the handler-IR form and is not part of Flow discovery.
+    let invariant = attrs.iter().find(|a| a.name == "invariant")?;
+    if !invariant.args.is_empty() {
+        return None;
+    }
+
+    let deterministic = attrs.iter().any(|a| a.name == "deterministic");
+    let semantic = attrs.iter().any(|a| a.name == "semantic");
+    let kind = match (deterministic, semantic) {
+        (true, true) => {
+            diagnostics.push(DiscoveryDiagnostic {
+                severity: DiagnosticSeverity::Error,
+                message: format!(
+                    "predicate `{name}` declares both `@deterministic` and \
+                     `@semantic`; pick exactly one"
+                ),
+                span: Some(span),
+            });
+            PredicateKind::Deterministic
+        }
+        (false, false) => {
+            // Default per design: predicates without an explicit mode are
+            // deterministic.
+            PredicateKind::Deterministic
+        }
+        (true, false) => PredicateKind::Deterministic,
+        (false, true) => PredicateKind::Semantic,
+    };
+
+    let archivist = attrs
+        .iter()
+        .find(|a| a.name == "archivist")
+        .map(parse_archivist_attribute);
+    if archivist.is_none() {
+        diagnostics.push(DiscoveryDiagnostic {
+            severity: DiagnosticSeverity::Warning,
+            message: format!(
+                "predicate `{name}` is missing `@archivist(...)` provenance \
+                 (evidence, confidence, source_date, coverage_examples)"
+            ),
+            span: Some(span),
+        });
+    }
+
+    let retroactive = attrs.iter().any(|a| a.name == "retroactive");
+
+    Some(DiscoveredPredicate {
+        name: name.to_string(),
+        kind,
+        archivist,
+        retroactive,
+        span,
+    })
+}
+
+fn parse_archivist_attribute(attr: &Attribute) -> ArchivistMetadata {
+    let mut metadata = ArchivistMetadata::default();
+    for arg in &attr.args {
+        let Some(name) = arg.name.as_deref() else {
+            continue;
+        };
+        match name {
+            "evidence" => metadata.evidence = string_list_arg(arg),
+            "confidence" => metadata.confidence = number_arg(arg),
+            "source_date" => metadata.source_date = string_arg(arg),
+            "coverage_examples" => metadata.coverage_examples = string_list_arg(arg),
+            _ => {}
+        }
+    }
+    metadata
+}
+
+fn string_arg(arg: &AttributeArg) -> Option<String> {
+    match &arg.value.node {
+        Node::StringLiteral(s) | Node::RawStringLiteral(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+fn number_arg(arg: &AttributeArg) -> Option<f64> {
+    match &arg.value.node {
+        Node::FloatLiteral(f) => Some(*f),
+        Node::IntLiteral(i) => Some(*i as f64),
+        _ => None,
+    }
+}
+
+fn string_list_arg(arg: &AttributeArg) -> Vec<String> {
+    match &arg.value.node {
+        Node::ListLiteral(items) => items
+            .iter()
+            .filter_map(|item| match &item.node {
+                Node::StringLiteral(s) | Node::RawStringLiteral(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect(),
+        Node::StringLiteral(s) | Node::RawStringLiteral(s) => vec![s.clone()],
+        _ => Vec::new(),
+    }
+}
+
+/// Build the root → target chain of directories to inspect, in order.
+///
+/// Mirrors `MetadataState::resolve`: starts at `root`, then descends one
+/// component at a time. Empty / `.` / `..` components are stripped so a
+/// caller can't escape the root.
+fn candidate_directories(root: &Path, target_dir: &Path) -> Vec<PathBuf> {
+    let mut chain = vec![root.to_path_buf()];
+
+    // Make `target_dir` relative to `root` if it is absolute, otherwise
+    // treat it as already-relative.
+    let relative = target_dir.strip_prefix(root).unwrap_or_else(|_| {
+        if target_dir.is_absolute() {
+            Path::new("")
+        } else {
+            target_dir
+        }
+    });
+
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        use std::path::Component;
+        match component {
+            Component::Normal(name) => {
+                current.push(name);
+                chain.push(current.clone());
+            }
+            Component::CurDir => {}
+            // Refuse to escape `root`.
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                continue;
+            }
+        }
+    }
+
+    chain
+}
+
+fn relative_dir_label(root: &Path, dir: &Path) -> String {
+    let rel = dir.strip_prefix(root).unwrap_or(dir);
+    let mut parts: Vec<String> = Vec::new();
+    for component in rel.components() {
+        if let std::path::Component::Normal(name) = component {
+            parts.push(name.to_string_lossy().into_owned());
+        }
+    }
+    if parts.is_empty() {
+        ".".to_string()
+    } else {
+        parts.join("/")
+    }
+}
+
+/// Resolve a directory's effective predicate set.
+///
+/// Walks the discovered files in root-to-leaf order, layering them so a
+/// stricter (closer-to-leaf) declaration with the same name overrides the
+/// ancestor. Returns predicates in deterministic source order, oldest
+/// ancestor first then newest within each level.
+pub fn resolve_predicates(files: &[DiscoveredInvariantFile]) -> Vec<(String, DiscoveredPredicate)> {
+    // Use a BTreeMap for stable iteration so callers get deterministic
+    // output regardless of disk ordering.
+    let mut effective: BTreeMap<String, (String, DiscoveredPredicate)> = BTreeMap::new();
+    for file in files {
+        for predicate in &file.predicates {
+            let key = predicate.name.clone();
+            let qualified = if file.relative_dir == "." {
+                predicate.name.clone()
+            } else {
+                format!("{}::{}", file.relative_dir, predicate.name)
+            };
+            effective.insert(key, (qualified, predicate.clone()));
+        }
+    }
+    effective.into_values().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write(dir: &Path, name: &str, contents: &str) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join(name), contents).unwrap();
+    }
+
+    fn sample_predicate(name: &str) -> String {
+        format!(
+            r#"
+@invariant
+@deterministic
+@archivist(evidence: ["https://example.com/spec"], confidence: 0.95, source_date: "2026-04-01")
+fn {name}(slice) -> bool {{
+    return true
+}}
+"#
+        )
+    }
+
+    #[test]
+    fn discover_walks_from_root_to_leaf() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write(root, INVARIANTS_FILE, &sample_predicate("root_check"));
+        let nested = root.join("crates").join("foo");
+        write(&nested, INVARIANTS_FILE, &sample_predicate("inner_check"));
+
+        let files = discover_invariants(root, &nested);
+        let labels: Vec<_> = files.iter().map(|f| f.relative_dir.clone()).collect();
+        assert_eq!(labels, vec![".".to_string(), "crates/foo".to_string()]);
+        assert_eq!(files[0].predicates[0].name, "root_check");
+        assert_eq!(files[0].predicates[0].kind, PredicateKind::Deterministic);
+        assert_eq!(files[1].predicates[0].name, "inner_check");
+    }
+
+    #[test]
+    fn discover_clamps_parent_dir_traversal() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("repo");
+        fs::create_dir_all(&root).unwrap();
+        write(&root, INVARIANTS_FILE, &sample_predicate("root_check"));
+
+        let files = discover_invariants(&root, Path::new("../../escape"));
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].relative_dir, ".");
+    }
+
+    #[test]
+    fn parse_picks_up_archivist_metadata() {
+        let source = sample_predicate("foo");
+        let parsed = parse_invariants_source(&source);
+        assert!(parsed.diagnostics.is_empty(), "{:?}", parsed.diagnostics);
+        let pred = &parsed.predicates[0];
+        let arch = pred.archivist.as_ref().expect("archivist present");
+        assert_eq!(arch.evidence, vec!["https://example.com/spec".to_string()]);
+        assert_eq!(arch.confidence, Some(0.95));
+        assert_eq!(arch.source_date.as_deref(), Some("2026-04-01"));
+    }
+
+    #[test]
+    fn parse_warns_when_archivist_missing() {
+        let source = r#"
+@invariant
+@deterministic
+fn missing_arch(slice) -> bool { return true }
+"#;
+        let parsed = parse_invariants_source(source);
+        assert_eq!(parsed.predicates.len(), 1);
+        assert!(parsed
+            .diagnostics
+            .iter()
+            .any(|d| d.message.contains("missing `@archivist(...)`")));
+    }
+
+    #[test]
+    fn parse_errors_when_kinds_collide() {
+        let source = r#"
+@invariant
+@deterministic
+@semantic
+@archivist(evidence: ["x"])
+fn both_modes(slice) -> bool { return true }
+"#;
+        let parsed = parse_invariants_source(source);
+        assert!(parsed
+            .diagnostics
+            .iter()
+            .any(|d| d.severity == DiagnosticSeverity::Error
+                && d.message.contains("pick exactly one")));
+    }
+
+    #[test]
+    fn parse_recognises_semantic_mode_and_retroactive() {
+        let source = r#"
+@invariant
+@semantic
+@retroactive
+@archivist(evidence: ["https://x"], confidence: 0.5)
+fn check(slice) -> bool { return true }
+"#;
+        let parsed = parse_invariants_source(source);
+        assert_eq!(parsed.predicates.len(), 1);
+        let pred = &parsed.predicates[0];
+        assert_eq!(pred.kind, PredicateKind::Semantic);
+        assert!(pred.retroactive);
+    }
+
+    #[test]
+    fn parse_skips_handler_ir_invariants() {
+        // `@invariant("name", "glob")` is the harn-ir handler form; it
+        // should never be treated as a Flow predicate.
+        let source = r#"
+@invariant("fs.writes", "src/**")
+fn handler_check(slice) -> bool { return true }
+"#;
+        let parsed = parse_invariants_source(source);
+        assert!(parsed.predicates.is_empty(), "{:?}", parsed.predicates);
+    }
+
+    #[test]
+    fn resolve_predicates_overrides_ancestors() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write(root, INVARIANTS_FILE, &sample_predicate("shared"));
+        let nested = root.join("crates");
+        // Override `shared` and add `extra`.
+        write(
+            &nested,
+            INVARIANTS_FILE,
+            &format!(
+                "{}{}",
+                sample_predicate("shared"),
+                sample_predicate("extra")
+            ),
+        );
+
+        let files = discover_invariants(root, &nested);
+        let resolved = resolve_predicates(&files);
+        let qualified: Vec<_> = resolved.iter().map(|(q, _)| q.clone()).collect();
+        // `shared` is overridden by the deeper file → qualified path.
+        assert!(qualified.contains(&"crates::shared".to_string()));
+        // `extra` only exists in the deeper file.
+        assert!(qualified.contains(&"crates::extra".to_string()));
+        // The root version should not appear in the resolved set.
+        assert!(!qualified.contains(&"shared".to_string()));
+    }
+}

--- a/crates/harn-vm/src/flow/predicates/mod.rs
+++ b/crates/harn-vm/src/flow/predicates/mod.rs
@@ -1,7 +1,13 @@
 //! Flow invariant predicate execution.
 
+pub mod discovery;
 pub mod executor;
 
+pub use discovery::{
+    discover_invariants, parse_invariants_source, resolve_predicates, ArchivistMetadata,
+    DiagnosticSeverity as DiscoveryDiagnosticSeverity, DiscoveredInvariantFile,
+    DiscoveredPredicate, DiscoveryDiagnostic, ParsedInvariantFile, INVARIANTS_FILE,
+};
 pub use executor::{
     CheapJudge, CheapJudgeRequest, CheapJudgeResponse, PredicateContext, PredicateExecutionRecord,
     PredicateExecutionReport, PredicateExecutor, PredicateExecutorConfig, PredicateKind,


### PR DESCRIPTION
Closes #579.

## Summary

- Adds `flow::predicates::discovery`: an `invariants.harn` walker mirroring `metadata_resolve` semantics (root → leaf, stricter-child overrides) plus parsed-and-typed `DiscoveredPredicate` / `ArchivistMetadata` per file.
- Recognises the `@invariant` + `@deterministic`/`@semantic` + `@archivist(...)` + `@retroactive` Flow predicate stack as a single source of truth on the function declaration; `harn check` warns when the stack is incomplete and the LSP renders the metadata block on hover.
- Extends attribute argument syntax to accept list literals and multi-line forms so `@archivist(evidence: [...], coverage_examples: [...])` parses cleanly.

## Done-when (per ticket)

- [x] Parser recognises the new attributes (`@archivist`, `@retroactive`) and existing handler-IR `@invariant("name")` is left alone.
- [x] `harn check` surfaces missing `@archivist` provenance as a warning (also: missing kind, mutually-exclusive kinds, archivist/retroactive without `@invariant`, unknown archivist arg, confidence out of range).
- [x] LSP shows attribute metadata on hover via a new \"Flow predicate metadata\" block.

## Test plan

- [x] `cargo nextest run -p harn-parser -p harn-vm -p harn-lsp` (1569 pass)
- [x] `cargo run --bin harn -- test conformance` (697 pass; new `attributes_flow_invariant` smoke test)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Manual smoke: `harn check invariants.harn` on a bare `@invariant` file emits the expected `Flow @invariant requires …` and `missing @archivist(...)` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)