### PR TITLE
[codex] Optimize Windows Rust CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,25 +128,23 @@ jobs:
           tool: nextest@0.9.133
       # Don't gate the whole pipeline on the full Windows test surface yet —
       # this job exists to catch hard regressions (compile breaks, missing
-      # cfg-gates, hardcoded `/bin/sh`, etc.). It runs harn-lexer/parser/vm
-      # unit tests and a smoke `harn run`. Sandbox + signal-handler tests
-      # are skipped automatically via existing `#![cfg(unix)]` gates.
+      # cfg-gates, hardcoded `/bin/sh`, etc.). It compiles the whole workspace
+      # test graph, then runs harn-lexer/parser/vm and adjacent core crate unit
+      # tests plus a smoke `harn run`. Sandbox + signal-handler tests are
+      # skipped automatically via existing `#![cfg(unix)]` gates.
       #
-      # `cargo check --workspace --tests` does the type/borrow check across
-      # the entire workspace without producing test binaries we won't run.
-      # Then we build only the harn binary (for the smoke test) and the
-      # test crates we actually run. This roughly halves Windows wall time
-      # vs. the previous `cargo build --workspace --tests`.
-      - name: Compile-check workspace + tests
-        run: cargo check --workspace --tests
-      - name: Build harn binary
-        run: cargo build --bin harn
-      - name: Run unit tests for core crates
+      # Keep the Rust work in one test-profile build. Mixing `cargo check`,
+      # `cargo build`, and nextest made Windows recompile the same local crates
+      # three times in separate artifact sets; `--workspace` preserves compile
+      # coverage while the filter limits the tests that actually execute.
+      - name: Compile workspace tests and run Windows unit slice
         shell: bash
         run: |
+          windows_filter='package(harn-lexer) or package(harn-parser) or package(harn-vm) or package(harn-hostlib) or package(harn-fmt) or package(harn-lint) or package(harn-modules)'
           if command -v cargo-nextest >/dev/null 2>&1; then
-            cargo nextest run -p harn-lexer -p harn-parser -p harn-vm -p harn-hostlib -p harn-fmt -p harn-lint -p harn-modules
+            cargo nextest run --workspace -E "$windows_filter"
           else
+            cargo test --workspace --no-run
             cargo test -p harn-lexer -p harn-parser -p harn-vm -p harn-hostlib -p harn-fmt -p harn-lint -p harn-modules
           fi
       - name: Smoke test harn run


### PR DESCRIPTION
## Summary

- Collapse the Windows Rust `cargo check` + `cargo build` + package-selected nextest sequence into a single `cargo nextest run --workspace -E ...` step.
- Keep full workspace Windows test compilation coverage while still only executing the existing core-crate Windows unit slice.
- Continue running the `harn run` smoke test against the binary emitted by that same test-profile build.

## Timing notes from run 24959855757

| Step group | Windows job | Non-Windows job |
| --- | ---: | ---: |
| Total job wall time | 8m31s | 5m16s |
| checkout | 11s | 1s |
| toolchain | 32s | 9s |
| sccache action | 21s | 1s |
| rust-cache | 48s | 22s |
| cargo-nextest install | 4s | 1s |
| main Rust work | 86s check + 128s build + 170s test | 58s lint + 125s test + 79s conformance |

The actionable gap is the Windows Rust work: the previous job compiled overlapping local crates in check, dev, and test artifact sets. This PR switches the Windows job to one test-profile build via nextest.

The slower pinned action setup on Windows appears to be runner/tool/cache overhead rather than something the pinned SHAs themselves introduce. GitHub Actions steps within one job cannot run in parallel, and splitting the Windows Rust work into separate jobs would lose the warmed target directory and likely duplicate the expensive restore/build work.

## Validation

- `make lint-actions`
- `git diff --check`
- `cargo nextest run --workspace -E 'package(harn-lexer) or package(harn-parser) or package(harn-vm) or package(harn-hostlib) or package(harn-fmt) or package(harn-lint) or package(harn-modules)' --no-run --cargo-quiet --target-dir /tmp/harn-nextest-filter-verify`
- `cargo nextest run --workspace -E 'package(harn-lexer) or package(harn-parser) or package(harn-vm) or package(harn-hostlib) or package(harn-fmt) or package(harn-lint) or package(harn-modules)' --target-dir /tmp/harn-nextest-filter-verify`
- `/tmp/harn-nextest-filter-verify/debug/harn run /tmp/harn-windows-ci-smoke.harn`