### PR TITLE
Add provider response-parser routing awareness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,10 +65,6 @@ granular archaeology.
   block on hover so the function declaration stays the single source of
   truth. Attribute argument syntax also accepts list literals and
   multi-line forms so provenance blocks can carry rich evidence.
-## Unreleased
-
-### Added
-
 - **Flow `InvariantResult` graded-verdict types and Harn bindings (#581).**
   Predicates now return a structured `InvariantResult { verdict, evidence,
   remediation, confidence }` value where `verdict` grades as `Allow`, `Warn`,

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -811,6 +811,10 @@ async fn print_model_info(args: &ModelInfoArgs) -> bool {
             "prompt_caching": capabilities.prompt_caching,
             "thinking": capabilities.thinking,
             "preserve_thinking": capabilities.preserve_thinking,
+            "server_parser": capabilities.server_parser,
+            "honors_chat_template_kwargs": capabilities.honors_chat_template_kwargs,
+            "recommended_endpoint": capabilities.recommended_endpoint,
+            "text_tool_wire_format_supported": capabilities.text_tool_wire_format_supported,
         },
         "qc_default_model": harn_vm::llm_config::qc_default_model(&resolved.provider),
     });

--- a/crates/harn-vm/src/flow/mod.rs
+++ b/crates/harn-vm/src/flow/mod.rs
@@ -22,13 +22,12 @@ pub use intent::{
     TranscriptSpan,
 };
 pub use predicates::{
-    Approver, ByteSpan,
-    discover_invariants, parse_invariants_source, resolve_predicates, ArchivistMetadata,
-    CheapJudge, CheapJudgeRequest, CheapJudgeResponse, DiscoveredInvariantFile,
-    DiscoveredPredicate, DiscoveryDiagnostic, DiscoveryDiagnosticSeverity, ParsedInvariantFile,
-    EvidenceItem, InvariantBlockError, InvariantResult,
-    PredicateContext, PredicateExecutionRecord, PredicateExecutionReport, PredicateExecutor,
-    PredicateExecutorConfig, PredicateKind, PredicateRunner, Remediation, Verdict, INVARIANTS_FILE,
+    discover_invariants, parse_invariants_source, resolve_predicates, Approver, ArchivistMetadata,
+    ByteSpan, CheapJudge, CheapJudgeRequest, CheapJudgeResponse, DiscoveredInvariantFile,
+    DiscoveredPredicate, DiscoveryDiagnostic, DiscoveryDiagnosticSeverity, EvidenceItem,
+    InvariantBlockError, InvariantResult, ParsedInvariantFile, PredicateContext,
+    PredicateExecutionRecord, PredicateExecutionReport, PredicateExecutor, PredicateExecutorConfig,
+    PredicateKind, PredicateRunner, Remediation, Verdict, INVARIANTS_FILE,
 };
 pub use slice::{
     derive_slice, Approval, CoverageMap, PredicateHash, Slice, SliceDerivationError,

--- a/crates/harn-vm/src/llm/agent/turn_preflight.rs
+++ b/crates/harn-vm/src/llm/agent/turn_preflight.rs
@@ -161,6 +161,15 @@ pub(super) async fn run_turn_preflight(
             content: content.clone(),
         })
         .await;
+        crate::llm::agent_observe::append_llm_observability_entry(
+            "feedback_injected",
+            serde_json::Map::from_iter([
+                ("iteration".to_string(), serde_json::json!(ctx.iteration)),
+                ("session_id".to_string(), serde_json::json!(ctx.session_id)),
+                ("kind".to_string(), serde_json::json!(kind.clone())),
+                ("content".to_string(), serde_json::json!(content.clone())),
+            ]),
+        );
         if kind == "prefill_assistant" {
             opts.prefill = Some(content);
             continue;

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -51,6 +51,7 @@ pub use readiness::{
     ModelReadiness,
 };
 pub(crate) use result::{vm_build_llm_result, LlmResult};
+pub(crate) use thinking::{split_openai_thinking_blocks, ThinkingStreamSplitter};
 pub(crate) use transport::vm_call_llm_api_with_body;
 
 use transport::vm_call_llm_api;
@@ -325,7 +326,8 @@ mod tests {
     fn openai_compat_prefill_appends_assistant_and_sets_chat_template_kwargs() {
         use crate::llm::providers::OpenAiCompatibleProvider;
 
-        let mut opts = base_opts("openai");
+        let mut opts = base_opts("local");
+        opts.model = "Qwen/Qwen3.5-Coder-32B".to_string();
         opts.prefill = Some("<done>##DONE##</done>".to_string());
         let payload = LlmRequestPayload::from(&opts);
         let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
@@ -643,6 +645,43 @@ mod tests {
         (addr, handle)
     }
 
+    fn spawn_ollama_raw_generate_stub(
+        captured: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    ) -> (std::net::SocketAddr, std::thread::JoinHandle<()>) {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ollama raw stub");
+        let addr = listener.local_addr().expect("stub addr");
+        let handle = std::thread::spawn(move || {
+            let mut stream = accept_with_deadline(&listener, "ollama raw stub");
+            let mut buf = vec![0u8; 16384];
+            let n = stream.read(&mut buf).expect("read request");
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+            assert!(request.starts_with("POST /api/generate HTTP/1.1\r\n"));
+            let body = request
+                .split("\r\n\r\n")
+                .nth(1)
+                .unwrap_or_default()
+                .to_string();
+            *captured.lock().expect("capture body") = Some(body);
+
+            let body = concat!(
+                "{\"response\":\"<tool_call>\\nedit({ path: \\\"a.rs\\\" })\\n</tool_call>\",\"done\":false,\"model\":\"qwen3.5:stub\"}\n",
+                "{\"done\":true,\"prompt_eval_count\":7,\"eval_count\":11,\"model\":\"qwen3.5:stub\",\"done_reason\":\"stop\"}\n"
+            );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/x-ndjson\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        });
+        (addr, handle)
+    }
+
     #[test]
     fn offthread_streaming_completes_inside_localset() {
         let _guard = env_lock().lock().expect("env lock");
@@ -757,6 +796,76 @@ mod tests {
             let json: serde_json::Value = serde_json::from_str(&body).expect("valid request json");
             assert_eq!(json["keep_alive"].as_i64(), Some(-1));
             assert_eq!(json["options"]["num_ctx"].as_u64(), Some(131072));
+        });
+    }
+
+    #[test]
+    fn ollama_qwen_text_tool_route_bypasses_chat_parser_with_raw_generate() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _allow_llm_transport = allow_stubbed_llm_transport();
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(2)
+            .build()
+            .expect("runtime");
+
+        runtime.block_on(async {
+            let captured = std::sync::Arc::new(std::sync::Mutex::new(None));
+            let (addr, server) = spawn_ollama_raw_generate_stub(captured.clone());
+            let prev_ollama_host = std::env::var("OLLAMA_HOST").ok();
+            unsafe {
+                std::env::set_var("OLLAMA_HOST", format!("http://{addr}"));
+            }
+
+            let local = tokio::task::LocalSet::new();
+            let result = local
+                .run_until(async {
+                    let mut opts = base_opts("ollama");
+                    opts.model = "qwen3.5:35b-a3b-coding-nvfp4".to_string();
+                    opts.native_tools = None;
+                    opts.response_format = None;
+                    opts.json_schema = None;
+                    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+                    let result = vm_call_llm_full_streaming_offthread(&opts, tx)
+                        .await
+                        .expect("raw-generate route should succeed");
+                    let mut deltas = Vec::new();
+                    while let Ok(delta) = rx.try_recv() {
+                        deltas.push(delta);
+                    }
+                    (result, deltas)
+                })
+                .await;
+
+            match prev_ollama_host {
+                Some(value) => unsafe { std::env::set_var("OLLAMA_HOST", value) },
+                None => unsafe { std::env::remove_var("OLLAMA_HOST") },
+            }
+
+            server.join().expect("stub server");
+            let (result, deltas) = result;
+            assert_eq!(
+                result.text,
+                "<tool_call>\nedit({ path: \"a.rs\" })\n</tool_call>"
+            );
+            assert_eq!(deltas.join(""), result.text);
+            assert_eq!(result.model, "qwen3.5:stub");
+            assert_eq!(result.input_tokens, 7);
+            assert_eq!(result.output_tokens, 11);
+            assert_eq!(result.stop_reason.as_deref(), Some("stop"));
+
+            let body = captured
+                .lock()
+                .expect("captured body")
+                .clone()
+                .expect("request body");
+            let json: serde_json::Value = serde_json::from_str(&body).expect("valid request json");
+            assert_eq!(json["raw"].as_bool(), Some(true));
+            assert!(json["prompt"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("<|im_start|>assistant\n"));
+            assert!(json.get("chat_template_kwargs").is_none());
         });
     }
 

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -110,9 +110,13 @@ pub(super) async fn vm_call_llm_api(
     let is_ollama = provider == "ollama" || resolved.endpoint.contains("/api/chat");
     let is_anthropic = resolved.is_anthropic_style;
 
-    let body = if is_ollama {
-        crate::llm::providers::OllamaProvider::build_request_body(opts)
-    } else if is_anthropic {
+    if is_ollama {
+        return crate::llm::providers::OllamaProvider
+            .chat_impl(opts, delta_tx)
+            .await;
+    }
+
+    let body = if is_anthropic {
         crate::llm::providers::AnthropicProvider::build_request_body(opts)
     } else {
         crate::llm::providers::OpenAiCompatibleProvider::build_request_body(opts, false)

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -76,12 +76,30 @@ pub struct ProviderRule {
     /// the same role there.
     #[serde(default)]
     pub preserve_thinking: Option<bool>,
+    /// Name of any server-side response parser that can transform model
+    /// bytes before Harn sees them. `none` means the provider returns the
+    /// model text/tool channel without an implicit parser.
+    #[serde(default)]
+    pub server_parser: Option<String>,
+    /// Whether provider-specific `chat_template_kwargs` are honored.
+    /// Some OpenAI-compatible servers silently drop unknown kwargs.
+    #[serde(default)]
+    pub honors_chat_template_kwargs: Option<bool>,
+    /// Preferred endpoint family for this provider/model route. Values
+    /// are descriptive labels consumed by providers, e.g.
+    /// `/api/generate-raw` for Ollama raw prompt bypass.
+    #[serde(default)]
+    pub recommended_endpoint: Option<String>,
+    /// Whether Harn's text-tool protocol (`<tool_call>name({...})`) can
+    /// survive the provider route and return in the visible response body.
+    #[serde(default)]
+    pub text_tool_wire_format_supported: Option<bool>,
 }
 
 /// Resolved capabilities for a `(provider, model)` pair. Unset rule
 /// fields resolve to `false` / empty / `None` so callers never have to
 /// unwrap an `Option<bool>` for what are really boolean gates.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Capabilities {
     pub native_tools: bool,
     pub defer_loading: bool,
@@ -90,6 +108,28 @@ pub struct Capabilities {
     pub prompt_caching: bool,
     pub thinking: bool,
     pub preserve_thinking: bool,
+    pub server_parser: String,
+    pub honors_chat_template_kwargs: bool,
+    pub recommended_endpoint: Option<String>,
+    pub text_tool_wire_format_supported: bool,
+}
+
+impl Default for Capabilities {
+    fn default() -> Self {
+        Self {
+            native_tools: false,
+            defer_loading: false,
+            tool_search: Vec::new(),
+            max_tools: None,
+            prompt_caching: false,
+            thinking: false,
+            preserve_thinking: false,
+            server_parser: "none".to_string(),
+            honors_chat_template_kwargs: false,
+            recommended_endpoint: None,
+            text_tool_wire_format_supported: true,
+        }
+    }
 }
 
 thread_local! {
@@ -244,6 +284,13 @@ fn rule_to_caps(rule: &ProviderRule) -> Capabilities {
         prompt_caching: rule.prompt_caching.unwrap_or(false),
         thinking: rule.thinking.unwrap_or(false),
         preserve_thinking: rule.preserve_thinking.unwrap_or(false),
+        server_parser: rule
+            .server_parser
+            .clone()
+            .unwrap_or_else(|| "none".to_string()),
+        honors_chat_template_kwargs: rule.honors_chat_template_kwargs.unwrap_or(false),
+        recommended_endpoint: rule.recommended_endpoint.clone(),
+        text_tool_wire_format_supported: rule.text_tool_wire_format_supported.unwrap_or(true),
     }
 }
 
@@ -410,6 +457,13 @@ mod tests {
             caps.preserve_thinking,
             "Qwen3.6 should enable preserve_thinking by default for long-horizon loops"
         );
+        assert_eq!(caps.server_parser, "ollama_qwen3coder");
+        assert!(!caps.honors_chat_template_kwargs);
+        assert_eq!(
+            caps.recommended_endpoint.as_deref(),
+            Some("/api/generate-raw")
+        );
+        assert!(!caps.text_tool_wire_format_supported);
     }
 
     #[test]
@@ -422,6 +476,8 @@ mod tests {
             !caps.preserve_thinking,
             "Qwen3.5 lacks the preserve_thinking kwarg — rely on the chat template's rolling checkpoint instead"
         );
+        assert_eq!(caps.server_parser, "ollama_qwen3coder");
+        assert!(!caps.text_tool_wire_format_supported);
     }
 
     #[test]
@@ -445,7 +501,24 @@ mod tests {
                 "{provider}/{model}: preserve_thinking must be on for Qwen3.6"
             );
             assert!(caps.native_tools, "{provider}/{model}: native_tools");
+            assert_ne!(
+                caps.server_parser, "ollama_qwen3coder",
+                "{provider}/{model}: only Ollama routes through the qwen3coder response parser"
+            );
         }
+    }
+
+    #[test]
+    fn llamacpp_qwen_keeps_text_tool_wire_format() {
+        reset();
+        let caps = lookup("llamacpp", "unsloth/Qwen3.5-Coder-GGUF");
+        assert_eq!(caps.server_parser, "none");
+        assert!(caps.honors_chat_template_kwargs);
+        assert!(caps.text_tool_wire_format_supported);
+        assert_eq!(
+            caps.recommended_endpoint.as_deref(),
+            Some("/v1/chat/completions")
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -30,6 +30,11 @@
 #                     Used by harn-lint to warn about oversized registries.
 #   prompt_caching  : whether the provider honors cache_control blocks.
 #   thinking        : whether extended / adaptive thinking is available.
+#   preserve_thinking: whether prior <think> blocks should be carried forward.
+#   server_parser   : server-side response parser that transforms model output.
+#   honors_chat_template_kwargs: whether chat_template_kwargs are honored.
+#   recommended_endpoint: preferred endpoint family for this route.
+#   text_tool_wire_format_supported: whether Harn text tool calls survive.
 
 # ---------- Anthropic (Claude) ------------------------------------------------
 
@@ -164,11 +169,19 @@ model_match = "qwen3.6*"
 native_tools = true
 thinking = true
 preserve_thinking = true
+server_parser = "ollama_qwen3coder"
+honors_chat_template_kwargs = false
+recommended_endpoint = "/api/generate-raw"
+text_tool_wire_format_supported = false
 
 [[provider.ollama]]
 model_match = "qwen3*"
 native_tools = true
 thinking = true
+server_parser = "ollama_qwen3coder"
+honors_chat_template_kwargs = false
+recommended_endpoint = "/api/generate-raw"
+text_tool_wire_format_supported = false
 
 # llama.cpp / llama-server speaks OpenAI-compat but is a separate
 # provider entry from Ollama. Give it the same Qwen3.6 wiring so the
@@ -178,11 +191,19 @@ model_match = "*qwen3.6*"
 native_tools = true
 thinking = true
 preserve_thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 [[provider.llamacpp]]
 model_match = "*qwen3*"
 native_tools = true
 thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 # Local vLLM / SGLang — same story. The capability rules here gate
 # chat_template_kwargs emission in openai_compat; the actual model has
@@ -192,11 +213,19 @@ model_match = "*qwen3.6*"
 native_tools = true
 thinking = true
 preserve_thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 [[provider.local]]
 model_match = "*qwen3*"
 native_tools = true
 thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 # Apple Silicon MLX server (mlx-vlm). OpenAI-compat with vision; honors
 # the same `chat_template_kwargs.preserve_thinking` knob as vLLM, since
@@ -206,37 +235,57 @@ model_match = "*qwen3.6*"
 native_tools = true
 thinking = true
 preserve_thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 [[provider.mlx]]
 model_match = "*qwen3*"
 native_tools = true
 thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 # ---------- Qwen3.6 family (routed providers) --------------------------------
 #
-# DashScope is the authoritative Qwen host; Fireworks and OpenRouter
-# carry the closed Plus variant. They all speak OpenAI-compat + honour
-# the Qwen `chat_template_kwargs`, so the wiring is identical to local
-# vLLM. The sibling fallthrough to `[[provider.openai]]` would match the
-# gpt-* rules (which don't apply) so we declare Qwen explicitly here to
-# prevent a silent fallthrough to empty capabilities.
+# DashScope is the authoritative Qwen host; Fireworks and the local
+# OpenAI-compatible servers honor Qwen `chat_template_kwargs`.
+# OpenRouter forwards thinking through its `reasoning` field instead.
+# The sibling fallthrough to `[[provider.openai]]` would match the gpt-*
+# rules (which don't apply) so we declare Qwen explicitly here to prevent
+# a silent fallthrough to empty capabilities.
 
 [[provider.dashscope]]
 model_match = "qwen3.6*"
 native_tools = true
 thinking = true
 preserve_thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 [[provider.dashscope]]
 model_match = "qwen*"
 native_tools = true
 thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 [[provider.fireworks]]
 model_match = "*qwen3.6*"
 native_tools = true
 thinking = true
 preserve_thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 # Fireworks's own model IDs squash dots to `p` (`qwen3p6`, `qwen3p5`),
 # so we need a second rule to catch their canonical naming.
@@ -245,11 +294,19 @@ model_match = "*qwen3p6*"
 native_tools = true
 thinking = true
 preserve_thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 [[provider.fireworks]]
 model_match = "*qwen*"
 native_tools = true
 thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 # OpenRouter: forwards Qwen thinking via its `reasoning` field (not
 # chat_template_kwargs — transform_request strips that). Preservation
@@ -260,11 +317,19 @@ model_match = "qwen/qwen3.6*"
 native_tools = true
 thinking = true
 preserve_thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = false
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 [[provider.openrouter]]
 model_match = "qwen/*"
 native_tools = true
 thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = false
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 # HuggingFace router + Together pass Qwen chat_template_kwargs through
 # unchanged. Match the qwen3.6 model card shape (`Qwen/Qwen3.6-*`).
@@ -273,22 +338,38 @@ model_match = "qwen/qwen3.6*"
 native_tools = true
 thinking = true
 preserve_thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 [[provider.huggingface]]
 model_match = "qwen/*"
 native_tools = true
 thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 [[provider.together]]
 model_match = "qwen/qwen3.6*"
 native_tools = true
 thinking = true
 preserve_thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 [[provider.together]]
 model_match = "qwen/*"
 native_tools = true
 thinking = true
+server_parser = "none"
+honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
 
 # ---------- DeepSeek reasoning (across host providers) -----------------------
 #
@@ -303,18 +384,24 @@ model_match = "deepseek-ai/deepseek-v3*"
 native_tools = true
 thinking = true
 prompt_caching = true
+server_parser = "none"
+honors_chat_template_kwargs = true
 
 [[provider.huggingface]]
 model_match = "deepseek-ai/deepseek-v3*"
 native_tools = true
 thinking = true
 prompt_caching = true
+server_parser = "none"
+honors_chat_template_kwargs = true
 
 [[provider.openrouter]]
 model_match = "deepseek/deepseek-v3*"
 native_tools = true
 thinking = true
 prompt_caching = true
+server_parser = "none"
+honors_chat_template_kwargs = false
 
 # ---------- Google Gemini + Gemma 4 (via OpenRouter) -------------------------
 #

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -375,11 +375,15 @@ pub(crate) fn extract_llm_options(
         .and_then(|v| match v {
             VmValue::Bool(true) => Some(ThinkingConfig::Enabled),
             VmValue::Dict(d) => {
-                let budget = d
-                    .get("budget_tokens")
-                    .and_then(|b| b.as_int())
-                    .unwrap_or(10000);
-                Some(ThinkingConfig::WithBudget(budget))
+                if d.get("enabled").is_some_and(|enabled| !enabled.is_truthy()) {
+                    None
+                } else {
+                    let budget = d
+                        .get("budget_tokens")
+                        .and_then(|b| b.as_int())
+                        .unwrap_or(10000);
+                    Some(ThinkingConfig::WithBudget(budget))
+                }
             }
             _ if v.is_truthy() => Some(ThinkingConfig::Enabled),
             _ => None,
@@ -1033,5 +1037,32 @@ mod routing_tests {
         assert_eq!(opts.model, "fast-mid-model");
         crate::llm_config::clear_user_overrides();
         super::super::reset_provider_key_cache();
+    }
+
+    #[test]
+    fn thinking_dict_enabled_false_disables_thinking() {
+        let mut options = BTreeMap::new();
+        options.insert(
+            "provider".to_string(),
+            VmValue::String(Rc::from("mock".to_string())),
+        );
+        options.insert(
+            "model".to_string(),
+            VmValue::String(Rc::from("gpt-5.4".to_string())),
+        );
+        options.insert(
+            "thinking".to_string(),
+            VmValue::Dict(Rc::new(BTreeMap::from([(
+                "enabled".to_string(),
+                VmValue::Bool(false),
+            )]))),
+        );
+        let opts = extract_llm_options(&[
+            VmValue::String(Rc::from("hello".to_string())),
+            VmValue::Nil,
+            VmValue::Dict(Rc::new(options)),
+        ])
+        .expect("options");
+        assert!(opts.thinking.is_none());
     }
 }

--- a/crates/harn-vm/src/llm/providers/ollama.rs
+++ b/crates/harn-vm/src/llm/providers/ollama.rs
@@ -2,7 +2,8 @@
 
 use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult, ThinkingConfig};
 use crate::llm::provider::{LlmProvider, LlmProviderChat};
-use crate::value::VmError;
+use crate::value::{VmError, VmValue};
+use std::rc::Rc;
 
 /// Zero-cost unit struct for the Ollama provider.
 pub(crate) struct OllamaProvider;
@@ -69,12 +70,67 @@ impl OllamaProvider {
         body
     }
 
+    pub(crate) fn should_route_via_raw_generate(opts: &LlmRequestPayload) -> bool {
+        let caps = crate::llm::capabilities::lookup(&opts.provider, &opts.model);
+        caps.recommended_endpoint.as_deref() == Some("/api/generate-raw")
+            && !caps.text_tool_wire_format_supported
+            && opts
+                .native_tools
+                .as_ref()
+                .is_none_or(|tools| tools.is_empty())
+    }
+
+    pub(crate) fn build_raw_generate_body(opts: &LlmRequestPayload) -> serde_json::Value {
+        let mut options = serde_json::Map::new();
+        if let Some(temp) = opts.temperature {
+            options.insert("temperature".to_string(), serde_json::json!(temp));
+        }
+        if let Some(top_p) = opts.top_p {
+            options.insert("top_p".to_string(), serde_json::json!(top_p));
+        }
+        if let Some(top_k) = opts.top_k {
+            options.insert("top_k".to_string(), serde_json::json!(top_k));
+        }
+        if let Some(seed) = opts.seed {
+            options.insert("seed".to_string(), serde_json::json!(seed));
+        }
+        if let Some(stop) = &opts.stop {
+            options.insert("stop".to_string(), serde_json::json!(stop));
+        }
+        if opts.max_tokens > 0 {
+            options.insert(
+                "num_predict".to_string(),
+                serde_json::json!(opts.max_tokens),
+            );
+        }
+
+        let mut body = serde_json::json!({
+            "model": opts.model,
+            "prompt": render_qwen_chat_prompt(opts),
+            "stream": opts.stream,
+            "raw": true,
+            "options": options,
+        });
+        if opts.response_format.as_deref() == Some("json") {
+            if let Some(schema) = opts.json_schema.clone() {
+                body["format"] = schema;
+            } else {
+                body["format"] = serde_json::json!("json");
+            }
+        }
+        crate::llm::api::apply_ollama_runtime_settings(&mut body, opts.provider_overrides.as_ref());
+        body
+    }
+
     /// The actual chat implementation.
     pub(crate) async fn chat_impl(
         &self,
         request: &LlmRequestPayload,
         delta_tx: Option<DeltaSender>,
     ) -> Result<LlmResult, VmError> {
+        if Self::should_route_via_raw_generate(request) {
+            return self.raw_generate_chat_impl(request, delta_tx).await;
+        }
         let body = Self::build_request_body(request);
         crate::llm::api::vm_call_llm_api_with_body(
             request, delta_tx, body, false, // is_anthropic_style
@@ -82,6 +138,323 @@ impl OllamaProvider {
         )
         .await
     }
+
+    async fn raw_generate_chat_impl(
+        &self,
+        request: &LlmRequestPayload,
+        delta_tx: Option<DeltaSender>,
+    ) -> Result<LlmResult, VmError> {
+        let body = Self::build_raw_generate_body(request);
+        let pdef = crate::llm_config::provider_config(&request.provider);
+        let base_url = pdef
+            .as_ref()
+            .map(crate::llm_config::resolve_base_url)
+            .unwrap_or_else(|| "http://localhost:11434".to_string());
+        let endpoint = pdef
+            .as_ref()
+            .and_then(|provider| provider.completion_endpoint.as_deref())
+            .unwrap_or("/api/generate");
+        let client = if request.stream {
+            crate::llm::shared_streaming_client().clone()
+        } else {
+            crate::llm::shared_blocking_client().clone()
+        };
+        let req = client
+            .post(format!("{base_url}{endpoint}"))
+            .header("Content-Type", "application/json")
+            .timeout(std::time::Duration::from_secs(request.resolve_timeout()))
+            .json(&body);
+        let req = crate::llm::api::apply_auth_headers(req, &request.api_key, pdef.as_ref());
+        let response = req.send().await.map_err(|error| {
+            VmError::Thrown(VmValue::String(Rc::from(format!(
+                "ollama raw generate API error: {error}"
+            ))))
+        })?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                "ollama raw generate API error HTTP {status}: {body}"
+            )))));
+        }
+        if request.stream {
+            let tx = delta_tx.unwrap_or_else(|| {
+                let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+                tx
+            });
+            parse_raw_generate_stream(response, &request.provider, &request.model, tx).await
+        } else {
+            parse_raw_generate_response(response, request).await
+        }
+    }
+}
+
+fn render_qwen_chat_prompt(opts: &LlmRequestPayload) -> String {
+    let mut rendered = String::new();
+    if let Some(system) = opts.system.as_deref().filter(|value| !value.is_empty()) {
+        push_qwen_message(&mut rendered, "system", system, true);
+    }
+    for message in &opts.messages {
+        let role = message
+            .get("role")
+            .and_then(|value| value.as_str())
+            .unwrap_or("user");
+        let role = match role {
+            "assistant" | "system" | "user" => role,
+            // Raw text-mode conversations should not rely on provider
+            // native tool roles. Make tool outputs visible as ordinary
+            // user context if a restored transcript contains them.
+            _ => "user",
+        };
+        let content = render_message_text(message);
+        push_qwen_message(&mut rendered, role, &content, true);
+    }
+    if let Some(prefill) = opts.prefill.as_deref() {
+        push_qwen_message(&mut rendered, "assistant", prefill, false);
+    } else {
+        rendered.push_str("<|im_start|>assistant\n");
+    }
+    rendered
+}
+
+fn push_qwen_message(out: &mut String, role: &str, content: &str, close: bool) {
+    out.push_str("<|im_start|>");
+    out.push_str(role);
+    out.push('\n');
+    out.push_str(content);
+    if close {
+        out.push_str("\n<|im_end|>\n");
+    }
+}
+
+fn render_message_text(message: &serde_json::Value) -> String {
+    let mut text = render_content_text(message.get("content").unwrap_or(&serde_json::Value::Null));
+    if let Some(tool_name) = message.get("tool_name").and_then(|value| value.as_str()) {
+        text = format!("[tool result: {tool_name}]\n{text}");
+    } else if let Some(tool_call_id) = message.get("tool_call_id").and_then(|value| value.as_str())
+    {
+        text = format!("[tool result: {tool_call_id}]\n{text}");
+    }
+    if let Some(tool_calls) = message.get("tool_calls").and_then(|value| value.as_array()) {
+        if text.trim().is_empty() {
+            text.push_str("[assistant tool calls]\n");
+        } else {
+            text.push_str("\n\n[assistant tool calls]\n");
+        }
+        text.push_str(&serde_json::to_string(tool_calls).unwrap_or_default());
+    }
+    text
+}
+
+fn render_content_text(content: &serde_json::Value) -> String {
+    match content {
+        serde_json::Value::String(text) => text.clone(),
+        serde_json::Value::Array(blocks) => {
+            let mut rendered = String::new();
+            for block in blocks {
+                let block_type = block.get("type").and_then(|value| value.as_str());
+                if matches!(block_type, Some("reasoning" | "thinking")) {
+                    continue;
+                }
+                let fragment = match block_type {
+                    Some("text" | "output_text") => block
+                        .get("text")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    Some("tool_result") => {
+                        let content = block
+                            .get("content")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or_default();
+                        format!("[tool result]\n{content}")
+                    }
+                    Some("tool_call") => serde_json::to_string(block).unwrap_or_default(),
+                    _ => block
+                        .get("text")
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string)
+                        .unwrap_or_else(|| block.to_string()),
+                };
+                if fragment.is_empty() {
+                    continue;
+                }
+                if !rendered.is_empty() {
+                    rendered.push_str("\n\n");
+                }
+                rendered.push_str(&fragment);
+            }
+            rendered
+        }
+        serde_json::Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+async fn parse_raw_generate_response(
+    response: reqwest::Response,
+    request: &LlmRequestPayload,
+) -> Result<LlmResult, VmError> {
+    let json: serde_json::Value = response.json().await.map_err(|error| {
+        VmError::Thrown(VmValue::String(Rc::from(format!(
+            "ollama raw generate response parse error: {error}"
+        ))))
+    })?;
+    if let Some(error) = json.get("error").and_then(|value| value.as_str()) {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+            "ollama raw generate API error: {error}"
+        )))));
+    }
+    let raw = json
+        .get("response")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    let (mut text, thinking) = crate::llm::api::split_openai_thinking_blocks(raw);
+    if text.is_empty() && !thinking.is_empty() {
+        text = thinking.clone();
+    }
+    let input_tokens = json
+        .get("prompt_eval_count")
+        .and_then(|value| value.as_i64())
+        .unwrap_or(0);
+    let output_tokens = json
+        .get("eval_count")
+        .and_then(|value| value.as_i64())
+        .unwrap_or(0);
+    if text.is_empty() && output_tokens > 0 {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+            "ollama raw-generate model {} reported eval_count={output_tokens} but delivered no content or thinking",
+            request.model
+        )))));
+    }
+    Ok(LlmResult {
+        blocks: blocks_from_text_and_thinking(&text, &thinking),
+        text,
+        tool_calls: Vec::new(),
+        input_tokens,
+        output_tokens,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        model: json
+            .get("model")
+            .and_then(|value| value.as_str())
+            .unwrap_or(&request.model)
+            .to_string(),
+        provider: request.provider.clone(),
+        thinking: (!thinking.is_empty()).then_some(thinking),
+        stop_reason: json
+            .get("done_reason")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+    })
+}
+
+async fn parse_raw_generate_stream(
+    response: reqwest::Response,
+    provider: &str,
+    model: &str,
+    delta_tx: DeltaSender,
+) -> Result<LlmResult, VmError> {
+    use tokio::io::AsyncBufReadExt;
+    use tokio_stream::StreamExt;
+
+    let stream = response.bytes_stream();
+    let reader = tokio::io::BufReader::new(tokio_util::io::StreamReader::new(
+        stream.map(|result| result.map_err(std::io::Error::other)),
+    ));
+    let mut lines = reader.lines();
+    let mut splitter = crate::llm::api::ThinkingStreamSplitter::new();
+    let mut text = String::new();
+    let mut result_model = model.to_string();
+    let mut input_tokens = 0;
+    let mut output_tokens = 0;
+    let mut stop_reason = None;
+
+    while let Ok(Some(line)) = lines.next_line().await {
+        if line.is_empty() {
+            continue;
+        }
+        let json: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        if let Some(error) = json.get("error").and_then(|value| value.as_str()) {
+            return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                "ollama raw generate API error: {error}"
+            )))));
+        }
+        if let Some(chunk) = json.get("response").and_then(|value| value.as_str()) {
+            let visible = splitter.push(chunk);
+            if !visible.is_empty() {
+                text.push_str(&visible);
+                let _ = delta_tx.send(visible);
+            }
+        }
+        if let Some(value) = json.get("model").and_then(|value| value.as_str()) {
+            result_model = value.to_string();
+        }
+        if json.get("done").and_then(|value| value.as_bool()) == Some(true) {
+            input_tokens = json
+                .get("prompt_eval_count")
+                .and_then(|value| value.as_i64())
+                .unwrap_or(0);
+            output_tokens = json
+                .get("eval_count")
+                .and_then(|value| value.as_i64())
+                .unwrap_or(0);
+            stop_reason = json
+                .get("done_reason")
+                .and_then(|value| value.as_str())
+                .map(str::to_string);
+            break;
+        }
+    }
+    let tail = splitter.flush();
+    if !tail.is_empty() {
+        text.push_str(&tail);
+        let _ = delta_tx.send(tail);
+    }
+    let thinking = splitter.thinking.trim().to_string();
+    if text.is_empty() && !thinking.is_empty() {
+        text = thinking.clone();
+    }
+    if text.is_empty() && output_tokens > 0 {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+            "ollama raw-generate model {model} reported eval_count={output_tokens} but delivered no content or thinking"
+        )))));
+    }
+    Ok(LlmResult {
+        blocks: blocks_from_text_and_thinking(&text, &thinking),
+        text,
+        tool_calls: Vec::new(),
+        input_tokens,
+        output_tokens,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        model: result_model,
+        provider: provider.to_string(),
+        thinking: (!thinking.is_empty()).then_some(thinking),
+        stop_reason,
+    })
+}
+
+fn blocks_from_text_and_thinking(text: &str, thinking: &str) -> Vec<serde_json::Value> {
+    let mut blocks = Vec::new();
+    if !thinking.is_empty() {
+        blocks.push(serde_json::json!({
+            "type": "reasoning",
+            "text": thinking,
+            "visibility": "private",
+        }));
+    }
+    if !text.is_empty() {
+        blocks.push(serde_json::json!({
+            "type": "output_text",
+            "text": text,
+            "visibility": "public",
+        }));
+    }
+    blocks
 }
 
 #[cfg(test)]
@@ -191,5 +564,50 @@ mod tests {
         assert_eq!(body["keep_alive"], serde_json::json!(-1));
         assert_eq!(body["think"], serde_json::json!(true));
         assert!(body.get("num_ctx").is_none());
+    }
+
+    #[test]
+    fn qwen_text_tool_route_uses_raw_generate_bypass() {
+        let mut payload = base_payload();
+        payload.response_format = None;
+        payload.json_schema = None;
+        payload.native_tools = None;
+
+        assert!(OllamaProvider::should_route_via_raw_generate(&payload));
+        let body = OllamaProvider::build_raw_generate_body(&payload);
+        assert_eq!(body["raw"], serde_json::json!(true));
+        assert_eq!(
+            body["model"],
+            serde_json::json!("qwen3.5:35b-a3b-coding-nvfp4")
+        );
+        let prompt = body["prompt"].as_str().unwrap_or_default();
+        assert!(prompt.contains("<|im_start|>user\nhello\n<|im_end|>"));
+        assert!(prompt.ends_with("<|im_start|>assistant\n"));
+        assert!(body.get("chat_template_kwargs").is_none());
+    }
+
+    #[test]
+    fn qwen_native_tool_route_stays_on_ollama_chat() {
+        let mut payload = base_payload();
+        payload.response_format = None;
+        payload.json_schema = None;
+        payload.native_tools = Some(vec![serde_json::json!({
+            "type": "function",
+            "function": {"name": "read"}
+        })]);
+
+        assert!(!OllamaProvider::should_route_via_raw_generate(&payload));
+    }
+
+    #[test]
+    fn raw_generate_prompt_continues_prefill_without_end_token() {
+        let mut payload = base_payload();
+        payload.response_format = None;
+        payload.json_schema = None;
+        payload.prefill = Some("<tool_call>\nedit(".to_string());
+        let body = OllamaProvider::build_raw_generate_body(&payload);
+        let prompt = body["prompt"].as_str().unwrap_or_default();
+        assert!(prompt.ends_with("<|im_start|>assistant\n<tool_call>\nedit("));
+        assert!(!prompt.ends_with("<|im_end|>\n"));
     }
 }

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -186,29 +186,29 @@ impl OpenAiCompatibleProvider {
         if let Some(ref tc) = opts.tool_choice {
             body["tool_choice"] = tc.clone();
         }
-        // Always set explicitly: Qwen templates default enabled when
-        // absent, making fast tool-call turns waste budget on thinking.
-        // OpenRouter / Anthropic-routed strip it via transform_request().
-        // When prefill is present we also set `add_generation_prompt:
-        // false` so vLLM continues the final assistant message instead
-        // of starting a fresh assistant turn after it.
-        let mut chat_template_kwargs = serde_json::json!({
-            "enable_thinking": opts.thinking.is_some(),
-        });
-        if opts.prefill.is_some() {
-            chat_template_kwargs["add_generation_prompt"] = serde_json::json!(false);
-            chat_template_kwargs["continue_final_message"] = serde_json::json!(true);
-        }
-        // Qwen3.6 introduced `preserve_thinking`. When the capability
-        // matrix says the current (provider, model) pair honours it,
-        // emit the flag so the chat template carries `<think>` blocks
-        // across turns. Alibaba recommends it for long-horizon tool
-        // loops. Providers that don't understand the kwarg ignore it.
         let caps = crate::llm::capabilities::lookup(&opts.provider, &opts.model);
-        if caps.preserve_thinking {
-            chat_template_kwargs["preserve_thinking"] = serde_json::json!(true);
+        if caps.honors_chat_template_kwargs {
+            // Always set explicitly for compatible Qwen/DeepSeek
+            // templates: some default thinking on when absent, making
+            // fast tool-call turns waste budget on reasoning.
+            // When prefill is present, continue the final assistant
+            // message instead of starting a fresh assistant turn.
+            let mut chat_template_kwargs = serde_json::json!({
+                "enable_thinking": opts.thinking.is_some(),
+            });
+            if opts.prefill.is_some() {
+                chat_template_kwargs["add_generation_prompt"] = serde_json::json!(false);
+                chat_template_kwargs["continue_final_message"] = serde_json::json!(true);
+            }
+            // Qwen3.6 introduced `preserve_thinking`. When the capability
+            // matrix says the current (provider, model) pair honours it,
+            // emit the flag so the chat template carries `<think>` blocks
+            // across turns.
+            if caps.preserve_thinking {
+                chat_template_kwargs["preserve_thinking"] = serde_json::json!(true);
+            }
+            body["chat_template_kwargs"] = chat_template_kwargs;
         }
-        body["chat_template_kwargs"] = chat_template_kwargs;
         body
     }
 
@@ -351,19 +351,26 @@ mod tests {
     }
 
     #[test]
-    fn qwen35_does_not_emit_preserve_thinking() {
+    fn ollama_qwen35_does_not_emit_chat_template_kwargs() {
         let mut payload = base_request_payload();
         payload.provider = "ollama".to_string();
         payload.model = "qwen3.5:35b-a3b-coding-nvfp4".to_string();
         payload.thinking = Some(ThinkingConfig::Enabled);
         let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
         assert!(
-            body["chat_template_kwargs"]
-                .get("preserve_thinking")
-                .is_none(),
-            "Qwen3.5 lacks the kwarg — we shouldn't send it"
+            body.get("chat_template_kwargs").is_none(),
+            "Ollama silently drops chat_template_kwargs today; gate them so strict validation would not break requests"
         );
-        assert_eq!(body["chat_template_kwargs"]["enable_thinking"], true);
+    }
+
+    #[test]
+    fn qwen35_local_disables_thinking_when_absent() {
+        let mut payload = base_request_payload();
+        payload.provider = "local".to_string();
+        payload.model = "Qwen/Qwen3.5-Coder-32B".to_string();
+        payload.thinking = None;
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert_eq!(body["chat_template_kwargs"]["enable_thinking"], false);
     }
 
     fn base_request_payload() -> LlmRequestPayload {


### PR DESCRIPTION
## Summary

Closes #724.

Adds first-class provider/model capability metadata for server-side response parsers and endpoint safety, then uses it to route Ollama Qwen3 text-tool calls through raw `/api/generate` instead of `/api/chat` so Ollama's qwen3coder parser cannot silently drop Harn `<tool_call>...</tool_call>` content.

## Changes

- Extend `capabilities.toml` / `Capabilities` with:
  - `server_parser`
  - `honors_chat_template_kwargs`
  - `recommended_endpoint`
  - `text_tool_wire_format_supported`
- Mark Ollama `qwen3*` as `server_parser = "ollama_qwen3coder"`, `text_tool_wire_format_supported = false`, and `recommended_endpoint = "/api/generate-raw"`.
- Add an Ollama raw-generate chat path that:
  - renders a Qwen chat prompt locally,
  - posts to `/api/generate` with `raw: true`,
  - preserves text-tool response bodies verbatim,
  - handles streaming/non-streaming responses and `<think>` splitting.
- Gate `chat_template_kwargs` emission on `honors_chat_template_kwargs`, so Ollama no longer receives kwargs it ignores.
- Parse `thinking: { enabled: false }` as disabled instead of enabling a budgeted thinking config.
- Add `feedback_injected` rows to the LLM transcript observability stream.
- Surface the new capability fields in `harn model-info` JSON.

## Verification

- `cargo fmt --all`
- `git diff --check`
- `RUSTUP_TOOLCHAIN=stable CARGO_TARGET_DIR=/tmp/harn-target-issue-724 cargo test -p harn-vm capabilities --lib`
- `RUSTUP_TOOLCHAIN=stable CARGO_TARGET_DIR=/tmp/harn-target-issue-724 cargo test -p harn-vm providers::ollama --lib`
- `RUSTUP_TOOLCHAIN=stable CARGO_TARGET_DIR=/tmp/harn-target-issue-724 cargo test -p harn-vm providers::openai_compat --lib`
- `RUSTUP_TOOLCHAIN=stable CARGO_TARGET_DIR=/tmp/harn-target-issue-724 cargo test -p harn-vm ollama_qwen_text_tool_route_bypasses_chat_parser_with_raw_generate --lib`
- `RUSTUP_TOOLCHAIN=stable CARGO_TARGET_DIR=/tmp/harn-target-issue-724 cargo test -p harn-vm thinking_dict_enabled_false_disables_thinking --lib`
- `RUSTUP_TOOLCHAIN=stable CARGO_TARGET_DIR=/tmp/harn-target-issue-724 cargo check -p harn-cli`
- Pre-commit hook: passed, including workspace clippy.
- Pre-push hook: passed, including 2,518 nextest tests.

Note: a direct `cargo test -p harn-vm --lib -- --test-threads=1` run before the pre-push hook showed 1,317 passing and 3 HTTP egress test failures. The repo pre-push nextest run subsequently passed those HTTP tests and the full pushed gate, so I treated the earlier failures as local test isolation/order state rather than this change.
