### PR TITLE
Preserve delegated run lineage on replay

### DIFF
--- a/crates/harn-vm/src/orchestration/records.rs
+++ b/crates/harn-vm/src/orchestration/records.rs
@@ -677,6 +677,161 @@ pub struct RunChildRecord {
     pub execution: Option<RunExecutionRecord>,
 }
 
+pub(crate) fn run_child_record_from_worker_metadata(
+    parent_stage_id: Option<String>,
+    worker: &serde_json::Value,
+) -> Option<RunChildRecord> {
+    let worker_id = worker.get("id").and_then(|value| value.as_str())?;
+    if worker_id.is_empty() {
+        return None;
+    }
+    Some(RunChildRecord {
+        worker_id: worker_id.to_string(),
+        worker_name: worker
+            .get("name")
+            .and_then(|value| value.as_str())
+            .unwrap_or("worker")
+            .to_string(),
+        parent_stage_id,
+        session_id: worker
+            .get("audit")
+            .and_then(|value| value.get("session_id"))
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        parent_session_id: worker
+            .get("audit")
+            .and_then(|value| value.get("parent_session_id"))
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        mutation_scope: worker
+            .get("audit")
+            .and_then(|value| value.get("mutation_scope"))
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        approval_policy: worker
+            .get("audit")
+            .and_then(|value| value.get("approval_policy"))
+            .and_then(|value| {
+                serde_json::from_value::<super::ToolApprovalPolicy>(value.clone()).ok()
+            }),
+        task: worker
+            .get("task")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        request: worker.get("request").cloned(),
+        provenance: worker.get("provenance").cloned(),
+        status: worker
+            .get("status")
+            .and_then(|value| value.as_str())
+            .unwrap_or("completed")
+            .to_string(),
+        started_at: worker
+            .get("started_at")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        finished_at: worker
+            .get("finished_at")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        run_id: worker
+            .get("child_run_id")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        run_path: worker
+            .get("child_run_path")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        snapshot_path: worker
+            .get("snapshot_path")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        execution: worker
+            .get("execution")
+            .cloned()
+            .and_then(|value| serde_json::from_value(value).ok()),
+    })
+}
+
+fn run_child_from_stage_metadata(stage: &RunStageRecord) -> Option<RunChildRecord> {
+    let parent_stage_id = if stage.id.is_empty() {
+        None
+    } else {
+        Some(stage.id.clone())
+    };
+    run_child_record_from_worker_metadata(parent_stage_id, stage.metadata.get("worker")?)
+}
+
+fn fill_missing_child_run_fields(existing: &mut RunChildRecord, child: RunChildRecord) {
+    if existing.worker_name.is_empty() {
+        existing.worker_name = child.worker_name;
+    }
+    if existing.parent_stage_id.is_none() {
+        existing.parent_stage_id = child.parent_stage_id;
+    }
+    if existing.session_id.is_none() {
+        existing.session_id = child.session_id;
+    }
+    if existing.parent_session_id.is_none() {
+        existing.parent_session_id = child.parent_session_id;
+    }
+    if existing.mutation_scope.is_none() {
+        existing.mutation_scope = child.mutation_scope;
+    }
+    if existing.approval_policy.is_none() {
+        existing.approval_policy = child.approval_policy;
+    }
+    if existing.task.is_empty() {
+        existing.task = child.task;
+    }
+    if existing.request.is_none() {
+        existing.request = child.request;
+    }
+    if existing.provenance.is_none() {
+        existing.provenance = child.provenance;
+    }
+    if existing.status.is_empty() {
+        existing.status = child.status;
+    }
+    if existing.started_at.is_empty() {
+        existing.started_at = child.started_at;
+    }
+    if existing.finished_at.is_none() {
+        existing.finished_at = child.finished_at;
+    }
+    if existing.run_id.is_none() {
+        existing.run_id = child.run_id;
+    }
+    if existing.run_path.is_none() {
+        existing.run_path = child.run_path;
+    }
+    if existing.snapshot_path.is_none() {
+        existing.snapshot_path = child.snapshot_path;
+    }
+    if existing.execution.is_none() {
+        existing.execution = child.execution;
+    }
+}
+
+fn materialize_child_runs_from_stage_metadata(run: &mut RunRecord) {
+    for child in run
+        .stages
+        .iter()
+        .filter_map(run_child_from_stage_metadata)
+        .collect::<Vec<_>>()
+    {
+        match run
+            .child_runs
+            .iter_mut()
+            .find(|existing| existing.worker_id == child.worker_id)
+        {
+            Some(existing) => fill_missing_child_run_fields(existing, child),
+            None => run.child_runs.push(child),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct RunExecutionRecord {
@@ -1581,6 +1736,7 @@ pub fn normalize_run_record(value: &VmValue) -> Result<RunRecord, VmError> {
         run.replay_fixture = Some(replay_fixture_from_run(&run));
     }
     merge_hitl_questions_from_active_log(&mut run);
+    materialize_child_runs_from_stage_metadata(&mut run);
     sync_run_handoffs(&mut run);
     if run.observability.is_none() {
         let persisted_path = run.persisted_path.clone();
@@ -2504,6 +2660,7 @@ pub fn save_run_record(run: &RunRecord, path: Option<&str>) -> Result<String, Vm
         .unwrap_or_else(|| default_run_dir().join(format!("{}.json", run.id)));
     let mut materialized = run.clone();
     merge_hitl_questions_from_active_log(&mut materialized);
+    materialize_child_runs_from_stage_metadata(&mut materialized);
     if materialized.replay_fixture.is_none() {
         materialized.replay_fixture = Some(replay_fixture_from_run(&materialized));
     }
@@ -2536,6 +2693,7 @@ pub fn load_run_record(path: &Path) -> Result<RunRecord, VmError> {
         .map_err(|e| VmError::Runtime(format!("failed to read run record: {e}")))?;
     let mut run: RunRecord = serde_json::from_str(&content)
         .map_err(|e| VmError::Runtime(format!("failed to parse run record: {e}")))?;
+    materialize_child_runs_from_stage_metadata(&mut run);
     if run.replay_fixture.is_none() {
         run.replay_fixture = Some(replay_fixture_from_run(&run));
     }

--- a/crates/harn-vm/src/stdlib/agents_workers/execution.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/execution.rs
@@ -144,6 +144,7 @@ async fn execute_worker_config(
     restore_worker_transcript(&config, prior_transcript.as_ref());
     let execution_record = execution_record(&execution);
     crate::stdlib::process::set_thread_execution_context(Some(execution_record.clone()));
+    let parent_run_id = audit.run_id.clone();
     crate::orchestration::install_current_mutation_session(Some(audit));
     let _mutation_guard = WorkerMutationSessionResetGuard;
     match config {
@@ -152,6 +153,16 @@ async fn execute_worker_config(
             artifacts,
             mut options,
         } => {
+            let resumes_existing_run =
+                options.contains_key("resume_path") || options.contains_key("resume_run");
+            if !resumes_existing_run && !options.contains_key("parent_run_id") {
+                if let Some(parent_run_id) = parent_run_id.clone() {
+                    options.insert(
+                        "parent_run_id".to_string(),
+                        VmValue::String(Rc::from(parent_run_id)),
+                    );
+                }
+            }
             if let Some(parent_worker_id) = options
                 .get("parent_worker_id")
                 .map(|value| value.display())

--- a/crates/harn-vm/src/stdlib/workflow/artifact.rs
+++ b/crates/harn-vm/src/stdlib/workflow/artifact.rs
@@ -3,8 +3,8 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use crate::orchestration::{
-    load_run_record, save_run_record, ArtifactRecord, RunCheckpointRecord, RunChildRecord,
-    RunExecutionRecord, RunRecord, RunTraceSpanRecord,
+    load_run_record, run_child_record_from_worker_metadata, save_run_record, ArtifactRecord,
+    RunCheckpointRecord, RunExecutionRecord, RunRecord, RunTraceSpanRecord,
 };
 use crate::value::{VmError, VmValue};
 
@@ -133,80 +133,9 @@ pub(super) fn append_child_run_record(
     let Some(worker) = stage.get("worker") else {
         return;
     };
-    let worker_id = worker
-        .get("id")
-        .and_then(|value| value.as_str())
-        .unwrap_or_default();
-    if worker_id.is_empty() {
+    let Some(child) = run_child_record_from_worker_metadata(Some(stage_id.to_string()), worker)
+    else {
         return;
-    }
-    let child = RunChildRecord {
-        worker_id: worker_id.to_string(),
-        worker_name: worker
-            .get("name")
-            .and_then(|value| value.as_str())
-            .unwrap_or("worker")
-            .to_string(),
-        parent_stage_id: Some(stage_id.to_string()),
-        session_id: worker
-            .get("audit")
-            .and_then(|value| value.get("session_id"))
-            .and_then(|value| value.as_str())
-            .map(|value| value.to_string()),
-        parent_session_id: worker
-            .get("audit")
-            .and_then(|value| value.get("parent_session_id"))
-            .and_then(|value| value.as_str())
-            .map(|value| value.to_string()),
-        mutation_scope: worker
-            .get("audit")
-            .and_then(|value| value.get("mutation_scope"))
-            .and_then(|value| value.as_str())
-            .map(|value| value.to_string()),
-        approval_policy: worker
-            .get("audit")
-            .and_then(|value| value.get("approval_policy"))
-            .and_then(|value| {
-                serde_json::from_value::<crate::orchestration::ToolApprovalPolicy>(value.clone())
-                    .ok()
-            }),
-        task: worker
-            .get("task")
-            .and_then(|value| value.as_str())
-            .unwrap_or_default()
-            .to_string(),
-        request: worker.get("request").cloned(),
-        provenance: worker.get("provenance").cloned(),
-        status: worker
-            .get("status")
-            .and_then(|value| value.as_str())
-            .unwrap_or("completed")
-            .to_string(),
-        started_at: worker
-            .get("started_at")
-            .and_then(|value| value.as_str())
-            .unwrap_or_default()
-            .to_string(),
-        finished_at: worker
-            .get("finished_at")
-            .and_then(|value| value.as_str())
-            .map(|value| value.to_string()),
-        run_id: worker
-            .get("child_run_id")
-            .and_then(|value| value.as_str())
-            .map(|value| value.to_string()),
-        run_path: worker
-            .get("child_run_path")
-            .and_then(|value| value.as_str())
-            .map(|value| value.to_string()),
-        snapshot_path: worker
-            .get("snapshot_path")
-            .and_then(|value| value.as_str())
-            .map(|value| value.to_string()),
-        execution: worker
-            .get("execution")
-            .cloned()
-            .and_then(|value| serde_json::from_value(value).ok()),
     };
     run.child_runs
         .retain(|existing| existing.worker_id != child.worker_id);

--- a/crates/harn-vm/src/stdlib/workflow/stage.rs
+++ b/crates/harn-vm/src/stdlib/workflow/stage.rs
@@ -45,15 +45,31 @@ pub(super) fn replay_stage(
             stage.node_id
         )));
     }
+    let mut result = serde_json::json!({
+        "status": stage.status,
+        "visible_text": stage.visible_text,
+        "private_reasoning": stage.private_reasoning,
+    });
+    for key in [
+        "worker",
+        "prompt",
+        "system_prompt",
+        "rendered_context",
+        "verification_contracts",
+        "rendered_verification_context",
+        "selected_artifact_ids",
+        "selected_artifact_titles",
+        "tools",
+    ] {
+        if let Some(value) = stage.metadata.get(key) {
+            result[key] = value.clone();
+        }
+    }
     Ok(ExecutedStage {
         status: stage.status.clone(),
         outcome: stage.outcome.clone(),
         branch: stage.branch.clone(),
-        result: serde_json::json!({
-            "status": stage.status,
-            "visible_text": stage.visible_text,
-            "private_reasoning": stage.private_reasoning,
-        }),
+        result,
         artifacts: stage.artifacts.clone(),
         transcript: stage
             .transcript

--- a/crates/harn-vm/src/stdlib/workflow/tests.rs
+++ b/crates/harn-vm/src/stdlib/workflow/tests.rs
@@ -1,12 +1,12 @@
 use super::artifact::{load_run_tree, snapshot_trace_spans};
 use super::map::{execute_join_policy, LocalTask};
 use super::register::execute_workflow;
-use super::stage::{classify_stage_outcome, execute_stage_attempts};
+use super::stage::{classify_stage_outcome, execute_stage_attempts, replay_stage};
 use crate::orchestration::{
     inject_workflow_verification_contracts, render_artifacts_context, render_workflow_prompt,
     save_run_record, workflow_verification_contracts, RunChildRecord, RunExecutionRecord,
-    RunRecord, VerificationContract, VerificationRequirement, WorkflowEdge, WorkflowGraph,
-    WorkflowNode,
+    RunRecord, RunStageRecord, VerificationContract, VerificationRequirement, WorkflowEdge,
+    WorkflowGraph, WorkflowNode,
 };
 use crate::tracing::{set_tracing_enabled, span_end, span_start, SpanKind};
 use crate::value::VmValue;
@@ -84,6 +84,86 @@ fn load_run_tree_recurses_into_child_runs() {
     assert_eq!(tree["children"][0]["run"]["id"], "child");
 
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn load_run_tree_recovers_child_runs_from_stage_worker_metadata() {
+    let dir = std::env::temp_dir().join(format!("harn-run-tree-{}", uuid::Uuid::now_v7()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let child_path = dir.join("child.json");
+    let parent_path = dir.join("parent.json");
+
+    let child = RunRecord {
+        id: "child".to_string(),
+        workflow_id: "wf".to_string(),
+        root_run_id: Some("parent".to_string()),
+        parent_run_id: Some("parent".to_string()),
+        status: "completed".to_string(),
+        ..Default::default()
+    };
+    let parent = RunRecord {
+        id: "parent".to_string(),
+        workflow_id: "wf".to_string(),
+        root_run_id: Some("parent".to_string()),
+        status: "completed".to_string(),
+        stages: vec![RunStageRecord {
+            id: "stage_1".to_string(),
+            node_id: "delegate".to_string(),
+            metadata: BTreeMap::from([(
+                "worker".to_string(),
+                serde_json::json!({
+                    "id": "worker_1",
+                    "name": "worker",
+                    "task": "delegate",
+                    "status": "completed",
+                    "child_run_id": "child",
+                    "child_run_path": child_path.to_string_lossy(),
+                    "snapshot_path": ".harn/workers/worker_1.json",
+                }),
+            )]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    save_run_record(&child, Some(child_path.to_str().unwrap())).unwrap();
+    save_run_record(&parent, Some(parent_path.to_str().unwrap())).unwrap();
+
+    let tree = load_run_tree(parent_path.to_str().unwrap()).unwrap();
+    assert_eq!(tree["run"]["child_runs"][0]["run_id"], "child");
+    assert_eq!(tree["children"][0]["run"]["id"], "child");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn deterministic_replay_preserves_worker_child_run_metadata() {
+    let child_path = ".harn-runs/child.json";
+    let mut stages = std::collections::VecDeque::from(vec![RunStageRecord {
+        id: "run:delegate:1".to_string(),
+        node_id: "delegate".to_string(),
+        kind: "subagent".to_string(),
+        status: "completed".to_string(),
+        outcome: "subagent_completed".to_string(),
+        branch: Some("success".to_string()),
+        metadata: BTreeMap::from([(
+            "worker".to_string(),
+            serde_json::json!({
+                "id": "worker_1",
+                "name": "delegate",
+                "task": "delegate task",
+                "status": "completed",
+                "child_run_id": "child",
+                "child_run_path": child_path,
+            }),
+        )]),
+        ..Default::default()
+    }]);
+
+    let replayed = replay_stage("delegate", &mut stages).unwrap();
+    assert_eq!(replayed.result["worker"]["id"], "worker_1");
+    assert_eq!(replayed.result["worker"]["child_run_id"], "child");
+    assert_eq!(replayed.result["worker"]["child_run_path"], child_path);
 }
 
 #[test]

--- a/docs/src/workflow-runtime.md
+++ b/docs/src/workflow-runtime.md
@@ -267,14 +267,19 @@ saved artifacts, transcript state, and traversed run-graph edges.
 Deterministic replay is now a runtime mode rather than a CLI-only inspection
 tool: passing a prior run via `replay_run` or `replay_path` replays saved stage
 records and artifacts through the workflow engine without calling providers or
-tools again.
+tools again. For delegated stages, replay also preserves the recorded worker
+envelope from stage metadata so replayed parent runs keep the same child
+run/snapshot pointers for inspection and evals.
 
 Delegated runs surface child worker lineage in each delegated stage's metadata.
 This makes replay/eval and host timelines able to distinguish parent execution
 from child execution without reconstructing that structure from plain text.
 Persisted runs also retain explicit `parent_run_id`, `root_run_id`, and
 `child_runs` lineage, and `load_run_tree(path)` materializes that hierarchy
-recursively for inspection or host-side task views.
+recursively for inspection or host-side task views. When a process exits after a
+stage record is written but before the parent `child_runs` list is refreshed,
+subsequent save/load/normalize passes recover the child entry from the stage's
+worker metadata before exposing or replaying the run.
 
 Map nodes can now execute branch work in parallel. `node.join_policy.strategy`
 accepts:


### PR DESCRIPTION
## Summary
- Preserve recorded worker envelopes during deterministic workflow replay so delegated child run and snapshot pointers survive replay.
- Materialize missing parent child_runs from stage worker metadata on run normalize/save/load, covering crash windows and older records.
- Thread parent run IDs into fresh workflow-worker child runs without self-parenting resumed child runs.
- Document the replay and crash-recovery lineage contract.

Closes #701

## Verification
- cargo fmt --all
- CARGO_TARGET_DIR=/tmp/harn-701-target cargo test -p harn-vm load_run_tree_recovers -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-701-target cargo test -p harn-vm deterministic_replay_preserves_worker_child_run_metadata -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-701-target cargo test -p harn-vm orchestration::tests:: -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-701-target cargo run --quiet --bin harn -- test conformance --filter workflow_replay_runtime
- CARGO_TARGET_DIR=/tmp/harn-701-target cargo run --quiet --bin harn -- test conformance --filter agent_workers
- Pre-commit hook: rustfmt, clippy, highlight keyword sync, markdownlint
- Pre-push hook: 2,528 nextest tests, markdownlint