### PR TITLE
Implement worker transcript carry modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ granular archaeology.
 
 ### Added
 
+- **Delegated worker transcript carry policies (#700).** `spawn_agent(...)`
+  and background `sub_agent_run(...)` workers now persist explicit
+  `carry.transcript_mode` semantics: `inherit`, `fork`, `reset`, and
+  `compact`. Worker snapshots round-trip the selected mode, compact mode
+  reduces persisted carried transcripts while preserving non-message events,
+  and parent-facing `worker_result` artifacts now keep compact payloads that
+  omit nested full transcripts/artifact lists by default.
 - **First-class worker lifecycle events on ACP and A2A (#703).** Adds
   two new typed `WorkerEvent` variants (`WorkerProgressed`,
   `WorkerWaitingForInput`) and surfaces every worker lifecycle

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ enforcement.
 - `sub_agent_run(task, options?)` for isolated child agent loops that preserve a
   clean parent transcript while returning a typed summary envelope or a
   background worker handle.
-- Explicit continuation policy for delegated workers: artifact carryover,
-  transcript fork/reset/compaction, workflow resume control, and normalized
-  `worker_result` artifacts.
+- Explicit continuation policy for delegated workers: `carry.transcript_mode`
+  (`inherit`, `fork`, `reset`, `compact`), artifact carryover, workflow resume
+  control, and compact parent-facing `worker_result` artifacts.
 - Runtime schema helpers for structured LLM I/O: `schema_check(...)`,
   `schema_parse(...)`, `schema_is(...)`, JSON Schema/OpenAPI conversion, and
   schema composition helpers, plus a lazy `std/schema` builder module for

--- a/conformance/tests/agents/worker_transcript_carry.expected
+++ b/conformance/tests/agents/worker_transcript_carry.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/conformance/tests/agents/worker_transcript_carry.harn
+++ b/conformance/tests/agents/worker_transcript_carry.harn
@@ -1,0 +1,20 @@
+pipeline main() {
+  llm_mock({text: "first carried answer"})
+  llm_mock({text: "second reset answer"})
+  let worker = sub_agent_run(
+    "Answer the first prompt.",
+    {provider: "mock", background: true, carry: {transcript_mode: "reset"}},
+  )
+  let first = wait_agent(worker)
+  let first_snapshot = json_parse(read_file(first?.snapshot_path))
+  println(first_snapshot?.carry_policy?.transcript_mode == "reset")
+  println(
+    contains(json_stringify(first_snapshot?.transcript?.messages ?? []), "first carried answer"),
+  )
+  let resumed = send_input(first, "Answer the second prompt.")
+  let second = wait_agent(resumed)
+  let second_snapshot = json_parse(read_file(second?.snapshot_path))
+  let second_messages = json_stringify(second_snapshot?.transcript?.messages ?? [])
+  println(contains(second_messages, "second reset answer"))
+  println(!contains(second_messages, "first carried answer"))
+}

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -20,11 +20,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use self::agents_workers::{
-    apply_worker_artifact_policy, emit_worker_event, ensure_worker_config_session_ids,
-    load_worker_state_snapshot, next_worker_id, parse_worker_config, persist_worker_state_snapshot,
-    spawn_worker_task, with_worker_state, worker_event_snapshot, worker_id_from_value,
-    worker_request_for_config, worker_snapshot_path, worker_summary, worker_trigger_payload_text,
-    worker_wait_blocks, WorkerConfig, WorkerState, WORKER_REGISTRY,
+    apply_worker_artifact_policy, apply_worker_transcript_policy, emit_worker_event,
+    ensure_worker_config_session_ids, load_worker_state_snapshot, next_worker_id,
+    parse_worker_config, persist_worker_state_snapshot, spawn_worker_task, with_worker_state,
+    worker_event_snapshot, worker_id_from_value, worker_request_for_config, worker_snapshot_path,
+    worker_summary, worker_trigger_payload_text, worker_wait_blocks, WorkerConfig, WorkerState,
+    WORKER_REGISTRY,
 };
 use self::sub_agent::{execute_sub_agent, parse_sub_agent_request};
 use crate::value::{VmError, VmValue};
@@ -53,7 +54,11 @@ pub(super) struct SubAgentExecutionResult {
     pub(super) transcript: VmValue,
 }
 
-fn restart_worker_run(worker: &mut WorkerState, next_task: &str, clear_latest_payload: bool) {
+fn restart_worker_run(
+    worker: &mut WorkerState,
+    next_task: &str,
+    clear_latest_payload: bool,
+) -> Result<(), VmError> {
     worker.cancel_token = Arc::new(AtomicBool::new(false));
     worker.task = next_task.to_string();
     worker.history.push(next_task.to_string());
@@ -67,7 +72,9 @@ fn restart_worker_run(worker: &mut WorkerState, next_task: &str, clear_latest_pa
         worker.latest_payload = None;
     }
     let next_artifacts = apply_worker_artifact_policy(&worker.artifacts, &worker.carry_policy);
-    let next_transcript = worker.transcript.clone();
+    let next_transcript =
+        apply_worker_transcript_policy(worker.transcript.clone(), &worker.carry_policy)?;
+    worker.transcript = next_transcript.clone();
     let worker_parent = worker.id.clone();
     let worker_id = worker.id.clone();
     let resume_workflow = worker.carry_policy.resume_workflow;
@@ -112,8 +119,15 @@ fn restart_worker_run(worker: &mut WorkerState, next_task: &str, clear_latest_pa
         }
         WorkerConfig::SubAgent { spec } => {
             spec.task = next_task.to_string();
+            if matches!(
+                worker.carry_policy.transcript_mode.as_str(),
+                "fork" | "reset"
+            ) {
+                spec.session_id = format!("sub_agent_session_{}", uuid::Uuid::now_v7());
+            }
         }
     }
+    Ok(())
 }
 
 async fn wait_for_worker_terminal(
@@ -377,7 +391,7 @@ pub(crate) fn register_agent_builtins(vm: &mut Vm) {
                     worker.id
                 )));
             }
-            restart_worker_run(&mut worker, &next_task, true);
+            restart_worker_run(&mut worker, &next_task, true)?;
             if worker.carry_policy.persist_state {
                 persist_worker_state_snapshot(&worker)?;
             }
@@ -426,7 +440,7 @@ pub(crate) fn register_agent_builtins(vm: &mut Vm) {
                     worker.id, worker.status
                 )));
             }
-            restart_worker_run(&mut worker, &next_task, false);
+            restart_worker_run(&mut worker, &next_task, false)?;
             if worker.carry_policy.persist_state {
                 persist_worker_state_snapshot(&worker)?;
             }

--- a/crates/harn-vm/src/stdlib/agents_workers/config.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/config.rs
@@ -8,8 +8,8 @@ use super::super::{parse_artifact_list, parse_context_policy, SubAgentRunSpec};
 use super::audit::parse_worker_audit;
 use super::bridge::worker_snapshot_path;
 use super::policy::{
-    parse_worker_carry_policy, parse_worker_policy_value, resolve_worker_policy,
-    worker_policy_value,
+    parse_transcript_mode, parse_worker_carry_policy, parse_worker_policy_value,
+    resolve_worker_policy, worker_policy_value,
 };
 use super::{
     WorkerCarryPolicy, WorkerConfig, WorkerExecutionProfile, WorkerInit, WorkerRequestRecord,
@@ -201,6 +201,7 @@ pub(in super::super) fn persist_worker_state_snapshot(state: &WorkerState) -> Re
         "child_run_path": state.child_run_path,
         "carry_policy": {
             "artifact_mode": state.carry_policy.artifact_mode,
+            "transcript_mode": state.carry_policy.transcript_mode,
             "context_policy": state.carry_policy.context_policy,
             "resume_workflow": state.carry_policy.resume_workflow,
             "persist_state": state.carry_policy.persist_state,
@@ -241,8 +242,14 @@ pub(in super::super) fn load_worker_state_snapshot(target: &str) -> Result<Worke
             .map(|value| value.display())
             .filter(|value| !value.is_empty())
             .unwrap_or_else(|| "inherit".to_string());
+        let transcript_mode = dict
+            .get("transcript_mode")
+            .map(parse_transcript_mode)
+            .transpose()?
+            .unwrap_or_else(|| "inherit".to_string());
         WorkerCarryPolicy {
             artifact_mode,
+            transcript_mode,
             context_policy: parse_context_policy(dict.get("context_policy"))?,
             resume_workflow: !matches!(dict.get("resume_workflow"), Some(VmValue::Bool(false))),
             persist_state: !matches!(dict.get("persist_state"), Some(VmValue::Bool(false))),

--- a/crates/harn-vm/src/stdlib/agents_workers/execution.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/execution.rs
@@ -10,9 +10,9 @@ use super::worktree::{
     cleanup_worker_execution, ensure_worker_worktree, WorkerMutationSessionResetGuard,
 };
 use super::{
-    clone_worker_state, next_worker_id, worker_provenance, worker_request_for_config,
-    WorkerCarryPolicy, WorkerConfig, WorkerExecutionProfile, WorkerExecutionResult, WorkerState,
-    WORKER_REGISTRY,
+    clone_worker_state, compact_worker_transcript, next_worker_id, worker_provenance,
+    worker_request_for_config, WorkerCarryPolicy, WorkerConfig, WorkerExecutionProfile,
+    WorkerExecutionResult, WorkerState, WORKER_REGISTRY,
 };
 use crate::agent_events::WorkerEvent;
 use crate::orchestration::{
@@ -241,7 +241,17 @@ async fn execute_worker_config(
 
 pub(in super::super) fn spawn_worker_task(state: Rc<RefCell<WorkerState>>) {
     let child_vm = crate::vm::clone_async_builtin_child_vm();
-    let (worker_id, task, config, prior_transcript, execution, cancel_token, worker_policy, audit) = {
+    let (
+        worker_id,
+        task,
+        config,
+        prior_transcript,
+        execution,
+        cancel_token,
+        worker_policy,
+        transcript_mode,
+        audit,
+    ) = {
         let worker = state.borrow();
         if worker.carry_policy.persist_state {
             persist_worker_state_snapshot(&worker).ok();
@@ -254,6 +264,7 @@ pub(in super::super) fn spawn_worker_task(state: Rc<RefCell<WorkerState>>) {
             worker.execution.clone(),
             worker.cancel_token.clone(),
             worker.carry_policy.policy.clone(),
+            worker.carry_policy.transcript_mode.clone(),
             worker.audit.clone(),
         )
     };
@@ -288,7 +299,7 @@ pub(in super::super) fn spawn_worker_task(state: Rc<RefCell<WorkerState>>) {
                 worker_id: Some(worker_id.clone()),
             },
         );
-        let result =
+        let mut result =
             execute_worker_config(worker_id, task, config, prior_transcript, execution, audit)
                 .await;
         if worker_approval.is_some() {
@@ -296,6 +307,26 @@ pub(in super::super) fn spawn_worker_task(state: Rc<RefCell<WorkerState>>) {
         }
         if worker_policy.is_some() {
             pop_execution_policy();
+        }
+        if transcript_mode == "compact" {
+            if let Ok(executed) = &mut result {
+                if let Some(transcript) = executed.transcript.take() {
+                    match compact_worker_transcript(transcript).await {
+                        Ok(compacted) => {
+                            if let Some(object) = executed.payload.as_object_mut() {
+                                object.insert(
+                                    "transcript".to_string(),
+                                    crate::llm::helpers::vm_value_to_json(&compacted),
+                                );
+                            }
+                            executed.transcript = Some(compacted);
+                        }
+                        Err(error) => {
+                            result = Err(error);
+                        }
+                    }
+                }
+            }
         }
         {
             let completion = {
@@ -410,7 +441,7 @@ fn worker_result_artifact(
             "request": state.request,
             "provenance": worker_provenance(state),
             "execution": state.execution,
-            "payload": payload,
+            "payload": compact_parent_worker_payload(payload),
             "produced_artifact_ids": produced.iter().map(|artifact| artifact.id.clone()).collect::<Vec<_>>(),
         })),
         source: Some(node_id.to_string()),
@@ -428,6 +459,24 @@ fn worker_result_artifact(
         ]),
     }
     .normalize()
+}
+
+fn compact_parent_worker_payload(payload: &serde_json::Value) -> serde_json::Value {
+    let Some(object) = payload.as_object() else {
+        return payload.clone();
+    };
+    let mut compacted = object.clone();
+    compacted.remove("transcript");
+    compacted.remove("artifacts");
+    if let Some(result) = compacted
+        .get_mut("result")
+        .and_then(|value| value.as_object_mut())
+    {
+        result.remove("transcript");
+        result.remove("artifacts");
+    }
+    compacted.insert("payload_compacted".to_string(), serde_json::json!(true));
+    serde_json::Value::Object(compacted)
 }
 
 pub(in super::super) async fn execute_delegated_stage(
@@ -479,6 +528,7 @@ pub(in super::super) async fn execute_delegated_stage(
         child_run_path: None,
         carry_policy: WorkerCarryPolicy {
             artifact_mode: "inherit".to_string(),
+            transcript_mode: "inherit".to_string(),
             context_policy: ContextPolicy::default(),
             resume_workflow: true,
             persist_state: true,
@@ -542,4 +592,35 @@ pub(in super::super) async fn execute_delegated_stage(
             .collect::<Vec<_>>(),
     ));
     Ok((result, produced, executed.transcript))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compact_parent_worker_payload;
+
+    #[test]
+    fn compact_parent_payload_drops_nested_transcript_and_artifacts() {
+        let payload = serde_json::json!({
+            "status": "completed",
+            "transcript": {"messages": ["large"]},
+            "artifacts": [{"id": "artifact_1"}],
+            "result": {
+                "visible_text": "done",
+                "transcript": {"messages": ["nested"]},
+                "artifacts": [{"id": "artifact_2"}]
+            }
+        });
+
+        let compacted = compact_parent_worker_payload(&payload);
+
+        assert_eq!(compacted["payload_compacted"], serde_json::json!(true));
+        assert!(compacted.get("transcript").is_none());
+        assert!(compacted.get("artifacts").is_none());
+        assert!(compacted["result"].get("transcript").is_none());
+        assert!(compacted["result"].get("artifacts").is_none());
+        assert_eq!(
+            compacted["result"]["visible_text"],
+            serde_json::json!("done")
+        );
+    }
 }

--- a/crates/harn-vm/src/stdlib/agents_workers/mod.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/mod.rs
@@ -27,7 +27,8 @@ pub(super) use execution::{
     ensure_worker_config_session_ids, execute_delegated_stage, spawn_worker_task,
 };
 pub(super) use policy::{
-    apply_worker_artifact_policy, parse_worker_carry_policy, resolve_inherited_worker_policy,
+    apply_worker_artifact_policy, apply_worker_transcript_policy, compact_worker_transcript,
+    parse_worker_carry_policy, resolve_inherited_worker_policy,
 };
 
 #[derive(Clone)]
@@ -58,6 +59,7 @@ pub(super) struct WorkerExecutionResult {
 #[derive(Clone, Default)]
 pub(super) struct WorkerCarryPolicy {
     pub(super) artifact_mode: String,
+    pub(super) transcript_mode: String,
     pub(super) context_policy: ContextPolicy,
     pub(super) resume_workflow: bool,
     pub(super) persist_state: bool,

--- a/crates/harn-vm/src/stdlib/agents_workers/policy.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/policy.rs
@@ -19,6 +19,12 @@ pub(in crate::stdlib::agents) fn parse_worker_carry_policy(
         .map(|value| value.display())
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| "inherit".to_string());
+    let transcript_mode = carry
+        .get("transcript_mode")
+        .or_else(|| carry.get("transcript"))
+        .map(parse_transcript_mode)
+        .transpose()?
+        .unwrap_or_else(|| "inherit".to_string());
     let context_policy = parse_context_policy(carry.get("context_policy").or_else(|| {
         carry
             .get("artifacts")
@@ -27,12 +33,32 @@ pub(in crate::stdlib::agents) fn parse_worker_carry_policy(
 
     Ok(WorkerCarryPolicy {
         artifact_mode,
+        transcript_mode,
         context_policy,
         resume_workflow: !matches!(carry.get("resume_workflow"), Some(VmValue::Bool(false))),
         persist_state: !matches!(carry.get("persist_state"), Some(VmValue::Bool(false))),
         retriggerable: matches!(carry.get("retriggerable"), Some(VmValue::Bool(true))),
         policy: None,
     })
+}
+
+pub(super) fn parse_transcript_mode(value: &VmValue) -> Result<String, VmError> {
+    let mode = match value {
+        VmValue::String(text) => text.trim().to_string(),
+        VmValue::Dict(dict) => dict
+            .get("mode")
+            .map(|value| value.display())
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+        _ => value.display().trim().to_string(),
+    };
+    match mode.as_str() {
+        "inherit" | "fork" | "reset" | "compact" => Ok(mode),
+        _ => Err(VmError::Runtime(format!(
+            "spawn_agent: carry.transcript_mode must be one of inherit, fork, reset, compact; got `{mode}`"
+        ))),
+    }
 }
 
 pub(super) fn parse_worker_policy_value(value: &VmValue) -> Result<CapabilityPolicy, VmError> {
@@ -137,4 +163,100 @@ pub(in super::super) fn apply_worker_artifact_policy(
         return artifacts.to_vec();
     }
     select_artifacts(artifacts.to_vec(), &policy.context_policy)
+}
+
+pub(in super::super) fn apply_worker_transcript_policy(
+    transcript: Option<VmValue>,
+    policy: &WorkerCarryPolicy,
+) -> Result<Option<VmValue>, VmError> {
+    match policy.transcript_mode.as_str() {
+        "reset" => Ok(None),
+        "fork" => Ok(transcript.map(fork_worker_transcript)),
+        "inherit" | "compact" | "" => Ok(transcript),
+        other => Err(VmError::Runtime(format!(
+            "worker transcript policy: unknown transcript_mode `{other}`"
+        ))),
+    }
+}
+
+fn fork_worker_transcript(transcript: VmValue) -> VmValue {
+    let Some(dict) = transcript.as_dict() else {
+        return transcript;
+    };
+    let parent_id = dict.get("id").map(|value| value.display());
+    let mut next = dict.clone();
+    let new_id = uuid::Uuid::now_v7().to_string();
+    next.insert("id".to_string(), VmValue::String(std::rc::Rc::from(new_id)));
+    if let Some(parent_id) = parent_id.filter(|value| !value.is_empty()) {
+        let metadata = match next.get("metadata") {
+            Some(VmValue::Dict(metadata)) => {
+                let mut metadata = metadata.as_ref().clone();
+                metadata.insert(
+                    "parent_transcript_id".to_string(),
+                    VmValue::String(std::rc::Rc::from(parent_id)),
+                );
+                VmValue::Dict(std::rc::Rc::new(metadata))
+            }
+            _ => VmValue::Dict(std::rc::Rc::new(BTreeMap::from([(
+                "parent_transcript_id".to_string(),
+                VmValue::String(std::rc::Rc::from(parent_id)),
+            )]))),
+        };
+        next.insert("metadata".to_string(), metadata);
+    }
+    VmValue::Dict(std::rc::Rc::new(next))
+}
+
+pub(in super::super) async fn compact_worker_transcript(
+    transcript: VmValue,
+) -> Result<VmValue, VmError> {
+    let Some(dict) = transcript.as_dict() else {
+        return Ok(transcript);
+    };
+    let original_messages = crate::llm::helpers::transcript_message_list(dict)?;
+    let mut messages = original_messages
+        .iter()
+        .map(crate::llm::helpers::vm_value_to_json)
+        .collect::<Vec<_>>();
+    let config = crate::orchestration::AutoCompactConfig {
+        keep_last: 2,
+        compact_strategy: crate::orchestration::CompactStrategy::Truncate,
+        hard_limit_tokens: None,
+        ..Default::default()
+    };
+    let Some(summary) =
+        crate::orchestration::auto_compact_messages(&mut messages, &config, None).await?
+    else {
+        return Ok(transcript);
+    };
+
+    let vm_messages = messages
+        .iter()
+        .map(crate::stdlib::json_to_vm_value)
+        .collect::<Vec<_>>();
+    let original_message_event_count =
+        crate::llm::helpers::transcript_events_from_messages(&original_messages).len();
+    let mut events = crate::llm::helpers::transcript_events_from_messages(&vm_messages);
+    if let Some(VmValue::List(original_events)) = dict.get("events") {
+        events.extend(
+            original_events
+                .iter()
+                .skip(original_message_event_count)
+                .cloned(),
+        );
+    }
+    let mut next = dict.clone();
+    next.insert(
+        "messages".to_string(),
+        VmValue::List(std::rc::Rc::new(vm_messages.clone())),
+    );
+    next.insert(
+        "events".to_string(),
+        VmValue::List(std::rc::Rc::new(events)),
+    );
+    next.insert(
+        "summary".to_string(),
+        VmValue::String(std::rc::Rc::from(summary)),
+    );
+    Ok(VmValue::Dict(std::rc::Rc::new(next)))
 }

--- a/crates/harn-vm/src/stdlib/agents_workers/tests.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/tests.rs
@@ -87,6 +87,7 @@ fn worker_snapshot_round_trip_preserves_resume_fields() {
         child_run_path: Some(".harn-runs/run_1.json".to_string()),
         carry_policy: WorkerCarryPolicy {
             artifact_mode: "none".to_string(),
+            transcript_mode: "fork".to_string(),
             context_policy: ContextPolicy::default(),
             resume_workflow: false,
             persist_state: true,
@@ -120,6 +121,7 @@ fn worker_snapshot_round_trip_preserves_resume_fields() {
         Some(".harn-runs/run_1.json")
     );
     assert_eq!(loaded.carry_policy.artifact_mode, "none");
+    assert_eq!(loaded.carry_policy.transcript_mode, "fork");
     assert!(!loaded.carry_policy.resume_workflow);
     assert!(loaded.carry_policy.retriggerable);
     assert_eq!(
@@ -239,6 +241,100 @@ fn artifact_carry_policy_can_drop_all_artifacts() {
     }];
     let selected = apply_worker_artifact_policy(&artifacts, &policy);
     assert!(selected.is_empty());
+}
+
+#[test]
+fn transcript_carry_policy_can_reset_or_fork_transcripts() {
+    let transcript = crate::llm::helpers::new_transcript_with(
+        Some("parent-transcript".to_string()),
+        Vec::new(),
+        None,
+        None,
+    );
+    let reset = WorkerCarryPolicy {
+        transcript_mode: "reset".to_string(),
+        ..Default::default()
+    };
+    assert!(
+        apply_worker_transcript_policy(Some(transcript.clone()), &reset)
+            .unwrap()
+            .is_none()
+    );
+
+    let fork = WorkerCarryPolicy {
+        transcript_mode: "fork".to_string(),
+        ..Default::default()
+    };
+    let forked = apply_worker_transcript_policy(Some(transcript), &fork)
+        .unwrap()
+        .expect("forked transcript");
+    let dict = forked.as_dict().expect("transcript dict");
+    assert_ne!(
+        dict.get("id").map(VmValue::display).as_deref(),
+        Some("parent-transcript")
+    );
+    assert_eq!(
+        dict.get("metadata")
+            .and_then(VmValue::as_dict)
+            .and_then(|metadata| metadata.get("parent_transcript_id"))
+            .map(VmValue::display)
+            .as_deref(),
+        Some("parent-transcript")
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn compact_transcript_mode_reduces_carried_messages() {
+    let messages = vec![
+        VmValue::Dict(Rc::new(BTreeMap::from([
+            ("role".to_string(), VmValue::String(Rc::from("user"))),
+            ("content".to_string(), VmValue::String(Rc::from("one"))),
+        ]))),
+        VmValue::Dict(Rc::new(BTreeMap::from([
+            ("role".to_string(), VmValue::String(Rc::from("assistant"))),
+            ("content".to_string(), VmValue::String(Rc::from("two"))),
+        ]))),
+        VmValue::Dict(Rc::new(BTreeMap::from([
+            ("role".to_string(), VmValue::String(Rc::from("user"))),
+            ("content".to_string(), VmValue::String(Rc::from("three"))),
+        ]))),
+        VmValue::Dict(Rc::new(BTreeMap::from([
+            ("role".to_string(), VmValue::String(Rc::from("assistant"))),
+            ("content".to_string(), VmValue::String(Rc::from("four"))),
+        ]))),
+    ];
+    let transcript = crate::llm::helpers::new_transcript_with_events(
+        Some("compact-transcript".to_string()),
+        messages,
+        None,
+        None,
+        vec![crate::llm::helpers::transcript_event(
+            "worker_note",
+            "system",
+            "internal",
+            "preserve me",
+            None,
+        )],
+        Vec::new(),
+        None,
+    );
+
+    let compacted = compact_worker_transcript(transcript).await.unwrap();
+    let dict = compacted.as_dict().expect("transcript dict");
+    let messages = crate::llm::helpers::transcript_message_list(dict).unwrap();
+
+    assert!(messages.len() < 4);
+    assert!(dict.get("summary").is_some());
+    let events = dict
+        .get("events")
+        .and_then(|value| match value {
+            VmValue::List(list) => Some(list),
+            _ => None,
+        })
+        .expect("events");
+    assert!(events.iter().filter_map(VmValue::as_dict).any(|event| {
+        event.get("kind").map(VmValue::display).as_deref() == Some("worker_note")
+    }));
 }
 
 #[test]

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1325,6 +1325,18 @@ mailboxes are shared by every task that receives or resolves the handle.
 mailboxes, shared state handles, `agent_state_*`, or host storage for data
 exchange outside the transcript.
 
+Delegated workers accept `carry.transcript_mode` to define continuation
+semantics across `send_input(...)`, retriggered workers, and resumed snapshots.
+`inherit` carries the completed worker transcript into the next cycle. `fork`
+copies the completed transcript under a fresh transcript id and records the
+source id in `metadata.parent_transcript_id`. `reset` starts the next cycle
+without a carried transcript. `compact` compacts the completed worker
+transcript before persistence and subsequent inheritance. Parent-facing
+`worker_result` artifacts are compact summary artifacts: their `data.payload`
+must omit nested full `transcript` and `artifacts` payloads by default, while
+preserving request, provenance, execution profile, compact result fields, and
+the ids of artifacts produced by the worker.
+
 `agent_loop`, `sub_agent_run`, and `spawn_agent` accept a `permissions` option
 that scopes one agent below the ambient capability policy. `permissions.allow`
 and `permissions.deny` are tool-name glob lists or dicts keyed by tool-name

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -1058,10 +1058,27 @@ drop carried artifacts, or disable workflow resume against the previous child
 run record. Worker configs may also include `execution` to pin delegated work
 to an explicit cwd/env overlay or a managed git worktree:
 
+`carry.transcript_mode` is explicit and accepts:
+
+- `inherit` (default): pass the completed worker transcript into the next
+  `send_input(...)` / trigger cycle.
+- `fork`: start the next cycle from a copy of the completed transcript with a
+  fresh transcript id and `metadata.parent_transcript_id` pointing at the
+  source transcript.
+- `reset`: start the next cycle with no carried transcript.
+- `compact`: compact the completed worker transcript before it is persisted and
+  inherited by the next cycle.
+
+Worker result artifacts are parent-facing summaries. Their `data.payload`
+omits bulky nested `transcript` and `artifacts` fields by default while keeping
+the worker request, provenance, execution profile, result text/status, and
+produced artifact ids available for routing and audit.
+
 ```harn
 let worker = spawn_agent({
   task: "Run the repo-local verification pass",
   graph: some_graph,
+  carry: {transcript_mode: "compact", artifact_mode: "inherit"},
   execution: {
     worktree: {
       repo: ".",

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1323,6 +1323,18 @@ mailboxes are shared by every task that receives or resolves the handle.
 mailboxes, shared state handles, `agent_state_*`, or host storage for data
 exchange outside the transcript.
 
+Delegated workers accept `carry.transcript_mode` to define continuation
+semantics across `send_input(...)`, retriggered workers, and resumed snapshots.
+`inherit` carries the completed worker transcript into the next cycle. `fork`
+copies the completed transcript under a fresh transcript id and records the
+source id in `metadata.parent_transcript_id`. `reset` starts the next cycle
+without a carried transcript. `compact` compacts the completed worker
+transcript before persistence and subsequent inheritance. Parent-facing
+`worker_result` artifacts are compact summary artifacts: their `data.payload`
+must omit nested full `transcript` and `artifacts` payloads by default, while
+preserving request, provenance, execution profile, compact result fields, and
+the ids of artifacts produced by the worker.
+
 `agent_loop`, `sub_agent_run`, and `spawn_agent` accept a `permissions` option
 that scopes one agent below the ambient capability policy. `permissions.allow`
 and `permissions.deny` are tool-name glob lists or dicts keyed by tool-name


### PR DESCRIPTION
## Summary
- add explicit worker carry transcript modes: inherit, fork, reset, compact
- persist transcript_mode in worker snapshots and apply it on send_input/worker_trigger continuation
- compact parent-facing worker_result artifact payloads by dropping nested full transcripts/artifact lists
- document the normative worker carry/result-shaping behavior and add changelog coverage

Closes #700.

## Verification
- CARGO_TARGET_DIR=/tmp/harn-target-address-700 cargo test -p harn-vm agents_workers --lib
- CARGO_TARGET_DIR=/tmp/harn-target-address-700 cargo run --quiet --bin harn -- test conformance --filter worker_transcript_carry
- git diff --check
- pre-commit hook: cargo fmt, harn fmt/lint, clippy, highlight/spec sync, markdown lint
- pre-push hook: 2529 nextest tests passed, affected Harn format/lint, markdown lint