### PR TITLE
Add Flow predicate replay audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,15 @@ granular archaeology.
   composition. Ancestor and child declarations are evaluated together so a
   child can tighten an ancestor verdict, but cannot relax a shallower `Block`;
   equal-severity ties keep the shallower predicate canonical.
+- **Flow predicate hash replay audit (#583).** `invariants.harn`
+  discovery now pins a `sha256:` source hash for every Flow predicate,
+  shipped derived slices can be queried from the SQLite Flow store
+  without mutating history, and slice tables now reject direct
+  update/delete attempts at the SQLite boundary. The new
+  `harn flow replay-audit --since <date>` command compares shipped
+  slice predicate hashes against the current `@retroactive` predicate
+  set, reports advisory drift in human or JSON form, and exits non-zero
+  only when `--fail-on-drift` is requested.
 - **Flow `InvariantResult` graded-verdict types and Harn bindings (#581).**
   Predicates now return a structured `InvariantResult { verdict, evidence,
   remediation, confidence }` value where `verdict` grades as `Allow`, `Warn`,

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -81,6 +81,8 @@ SCRIPTING
     Portal(PortalArgs),
     /// Replay and inspect historical trigger dispatches from the event log.
     Trigger(TriggerArgs),
+    /// Inspect Harn Flow atom, slice, and predicate audit state.
+    Flow(FlowArgs),
     /// Import third-party eval traces into replayable Harn fixtures.
     Trace(TraceArgs),
     /// Mine repeated traces into a reviewable deterministic Harn workflow candidate.
@@ -1009,6 +1011,45 @@ pub(crate) struct CrystallizeArgs {
 pub(crate) struct TrustArgs {
     #[command(subcommand)]
     pub command: TrustCommand,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct FlowArgs {
+    #[command(subcommand)]
+    pub command: FlowCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum FlowCommand {
+    /// Audit historical shipped slices against current retroactive predicates.
+    #[command(name = "replay-audit")]
+    ReplayAudit(FlowReplayAuditArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct FlowReplayAuditArgs {
+    /// SQLite Flow store to audit.
+    #[arg(
+        long = "store",
+        value_name = "PATH",
+        default_value = ".harn/flow.sqlite"
+    )]
+    pub store: PathBuf,
+    /// Repository root used for `invariants.harn` discovery.
+    #[arg(long = "root", value_name = "PATH", default_value = ".")]
+    pub root: PathBuf,
+    /// Target directory whose effective current predicate set should be used.
+    #[arg(long = "target-dir", value_name = "PATH", default_value = ".")]
+    pub target_dir: PathBuf,
+    /// Include shipped slices created at or after this date/timestamp.
+    #[arg(long = "since", value_name = "DATE")]
+    pub since: String,
+    /// Exit non-zero when advisory drift is found.
+    #[arg(long = "fail-on-drift")]
+    pub fail_on_drift: bool,
+    /// Emit JSON instead of human-readable output.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -2302,11 +2343,11 @@ mod tests {
     use std::time::Duration as StdDuration;
 
     use super::{
-        Cli, Command, ConnectCommand, McpCommand, OrchestratorCommand, OrchestratorDeployProvider,
-        OrchestratorLogFormat, OrchestratorQueueCommand, OrchestratorTenantCommand,
-        PackageCacheCommand, PackageCommand, ProjectTemplate, RunsCommand, SkillCommand,
-        SkillKeyCommand, SkillTrustCommand, SkillsCommand, TraceCommand, TriggerCommand,
-        TrustCommand, TrustOutcomeArg, TrustTierArg,
+        Cli, Command, ConnectCommand, FlowCommand, McpCommand, OrchestratorCommand,
+        OrchestratorDeployProvider, OrchestratorLogFormat, OrchestratorQueueCommand,
+        OrchestratorTenantCommand, PackageCacheCommand, PackageCommand, ProjectTemplate,
+        RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand, TraceCommand,
+        TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
     };
     use clap::Parser;
 
@@ -2715,6 +2756,36 @@ mod tests {
         assert!(replay.diff);
         assert_eq!(replay.as_of.as_deref(), Some("2026-04-19T18:00:00Z"));
         assert!(replay.where_expr.is_none());
+    }
+
+    #[test]
+    fn test_parses_flow_replay_audit_flags() {
+        let cli = Cli::parse_from([
+            "harn",
+            "flow",
+            "replay-audit",
+            "--store",
+            ".harn/flow.sqlite",
+            "--root",
+            ".",
+            "--target-dir",
+            "crates/harn-vm",
+            "--since",
+            "2026-04-26",
+            "--fail-on-drift",
+            "--json",
+        ]);
+
+        let Command::Flow(args) = cli.command.unwrap() else {
+            panic!("expected flow command");
+        };
+        let FlowCommand::ReplayAudit(audit) = args.command;
+        assert_eq!(audit.store, PathBuf::from(".harn/flow.sqlite"));
+        assert_eq!(audit.root, PathBuf::from("."));
+        assert_eq!(audit.target_dir, PathBuf::from("crates/harn-vm"));
+        assert_eq!(audit.since, "2026-04-26");
+        assert!(audit.fail_on_drift);
+        assert!(audit.json);
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/flow.rs
+++ b/crates/harn-cli/src/commands/flow.rs
@@ -1,0 +1,161 @@
+use time::format_description::well_known::Rfc3339;
+use time::{Date, OffsetDateTime, Time};
+
+use crate::cli::FlowReplayAuditArgs;
+
+pub(crate) fn run_replay_audit(args: &FlowReplayAuditArgs) -> Result<i32, String> {
+    let since = parse_since(&args.since)?;
+    if !args.store.is_file() {
+        return Err(format!(
+            "Flow store {} does not exist",
+            args.store.display()
+        ));
+    }
+    let store =
+        harn_vm::flow::SqliteFlowStore::open(&args.store, "replay-audit").map_err(|error| {
+            format!(
+                "failed to open Flow store {}: {error}",
+                args.store.display()
+            )
+        })?;
+
+    let files = harn_vm::flow::discover_invariants(&args.root, &args.target_dir);
+    let diagnostics = files
+        .iter()
+        .flat_map(|file| {
+            file.diagnostics
+                .iter()
+                .map(move |diagnostic| (file.path.display().to_string(), diagnostic))
+        })
+        .collect::<Vec<_>>();
+    let has_error = diagnostics.iter().any(|(_, diagnostic)| {
+        diagnostic.severity == harn_vm::flow::DiscoveryDiagnosticSeverity::Error
+    });
+    if has_error {
+        return Err(render_discovery_diagnostics(&diagnostics));
+    }
+    if !args.json {
+        let warnings = diagnostics
+            .iter()
+            .filter(|(_, diagnostic)| {
+                diagnostic.severity == harn_vm::flow::DiscoveryDiagnosticSeverity::Warning
+            })
+            .collect::<Vec<_>>();
+        for (path, diagnostic) in warnings {
+            eprintln!("warning: {path}: {}", diagnostic.message);
+        }
+    }
+
+    let current_predicates = harn_vm::flow::resolve_predicates(&files);
+    let stored = store
+        .shipped_derived_slices_since(Some(since))
+        .map_err(|error| format!("failed to list shipped slices: {error}"))?;
+    let created_at_by_slice = stored
+        .iter()
+        .map(|stored| (stored.slice.id, stored.created_at.clone()))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let report = harn_vm::flow::replay_audit_report(
+        stored.into_iter().map(|stored| stored.slice),
+        &current_predicates,
+    );
+
+    if args.json {
+        let json = serde_json::to_string_pretty(&report)
+            .map_err(|error| format!("failed to encode replay-audit report: {error}"))?;
+        println!("{json}");
+    } else {
+        print_human_report(&args.since, &report, &created_at_by_slice);
+    }
+
+    Ok(if args.fail_on_drift && report.has_drift() {
+        1
+    } else {
+        0
+    })
+}
+
+fn print_human_report(
+    since: &str,
+    report: &harn_vm::flow::ReplayAuditReport,
+    created_at_by_slice: &std::collections::BTreeMap<harn_vm::flow::SliceId, String>,
+) {
+    println!(
+        "Audited {} shipped derived slice(s) since {since}; {} slice(s) have advisory drift.",
+        report.audited_slices, report.drifted_slices
+    );
+    if report.slices.is_empty() {
+        return;
+    }
+    for slice in &report.slices {
+        let created_at = created_at_by_slice
+            .get(&slice.slice_id)
+            .map(String::as_str)
+            .unwrap_or("unknown");
+        println!("slice {} created_at={created_at}", slice.slice_id);
+        if !slice.advisory_drift.is_empty() {
+            println!("  current @retroactive predicates not pinned:");
+            for predicate in &slice.advisory_drift {
+                println!("    - {} {}", predicate.name, predicate.hash.as_str());
+            }
+        }
+        if !slice.historical_only_predicates.is_empty() {
+            println!("  historical predicate hashes no longer in current set:");
+            for hash in &slice.historical_only_predicates {
+                println!("    - {}", hash.as_str());
+            }
+        }
+    }
+}
+
+fn render_discovery_diagnostics(
+    diagnostics: &[(String, &harn_vm::flow::DiscoveryDiagnostic)],
+) -> String {
+    diagnostics
+        .iter()
+        .map(|(path, diagnostic)| format!("{path}: {}", diagnostic.message))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn parse_since(raw: &str) -> Result<OffsetDateTime, String> {
+    if let Ok(parsed) = OffsetDateTime::parse(raw, &Rfc3339) {
+        return Ok(parsed);
+    }
+    if let Ok(unix) = raw.parse::<i64>() {
+        let parsed = if raw.len() > 10 {
+            OffsetDateTime::from_unix_timestamp_nanos(unix as i128 * 1_000_000)
+        } else {
+            OffsetDateTime::from_unix_timestamp(unix)
+        };
+        return parsed.map_err(|error| format!("invalid --since timestamp '{raw}': {error}"));
+    }
+    let date_format = time::format_description::parse("[year]-[month]-[day]")
+        .map_err(|error| format!("failed to build date parser: {error}"))?;
+    let date = Date::parse(raw, &date_format).map_err(|_| {
+        format!("invalid --since date '{raw}'; use RFC3339, unix time, or YYYY-MM-DD")
+    })?;
+    Ok(date.with_time(Time::MIDNIGHT).assume_utc())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_since_accepts_rfc3339_unix_and_date() {
+        assert_eq!(
+            parse_since("2026-04-26T12:00:00Z")
+                .unwrap()
+                .unix_timestamp(),
+            1_777_204_800
+        );
+        assert_eq!(
+            parse_since("1777205600").unwrap().unix_timestamp(),
+            1_777_205_600
+        );
+        assert_eq!(
+            parse_since("2026-04-26").unwrap().unix_timestamp(),
+            1_777_161_600
+        );
+    }
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod doctor;
 pub(crate) mod dump_highlight_keywords;
 pub(crate) mod dump_trigger_quickref;
 pub(crate) mod explain;
+pub(crate) mod flow;
 pub(crate) mod init;
 pub(crate) mod mcp;
 pub(crate) mod orchestrator;

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 use std::{env, fs, process, thread};
 
 use cli::{
-    Cli, Command, ModelInfoArgs, PackageCacheCommand, PackageCommand, PersonaCommand, RunsCommand,
-    ServeCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand,
+    Cli, Command, FlowCommand, ModelInfoArgs, PackageCacheCommand, PackageCommand, PersonaCommand,
+    RunsCommand, ServeCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand,
 };
 use harn_lexer::Lexer;
 use harn_parser::{DiagnosticSeverity, Parser, TypeChecker};
@@ -513,6 +513,16 @@ async fn async_main() {
                 process::exit(1);
             }
         }
+        Command::Flow(args) => match args.command {
+            FlowCommand::ReplayAudit(replay) => match commands::flow::run_replay_audit(&replay) {
+                Ok(code) => {
+                    if code != 0 {
+                        process::exit(code);
+                    }
+                }
+                Err(error) => command_error(&error),
+            },
+        },
         Command::Trace(args) => {
             if let Err(error) = commands::trace::handle(args).await {
                 eprintln!("error: {error}");

--- a/crates/harn-vm/src/flow/audit.rs
+++ b/crates/harn-vm/src/flow/audit.rs
@@ -1,0 +1,184 @@
+//! Advisory replay audit for predicate hash drift.
+//!
+//! A shipped slice pins the predicate hashes that evaluated it. Current
+//! `@retroactive` predicates are advisory-only: if a historical slice does not
+//! carry the current hash, the audit reports drift but does not rewrite or
+//! block the slice.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use super::predicates::ResolvedPredicate;
+#[cfg(test)]
+use super::predicates::{DiscoveredPredicate, PredicateSource};
+use super::slice::{PredicateHash, Slice, SliceId};
+
+/// Current predicate metadata included in replay-audit reports.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplayAuditPredicate {
+    pub name: String,
+    pub hash: PredicateHash,
+}
+
+/// Per-slice replay-audit outcome.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SliceReplayAudit {
+    pub slice_id: SliceId,
+    pub recorded_predicates: usize,
+    pub current_retroactive_predicates: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub advisory_drift: Vec<ReplayAuditPredicate>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub historical_only_predicates: Vec<PredicateHash>,
+}
+
+impl SliceReplayAudit {
+    pub fn has_drift(&self) -> bool {
+        !self.advisory_drift.is_empty()
+    }
+}
+
+/// Aggregate replay-audit report.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplayAuditReport {
+    pub audited_slices: usize,
+    pub drifted_slices: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub slices: Vec<SliceReplayAudit>,
+}
+
+impl ReplayAuditReport {
+    pub fn has_drift(&self) -> bool {
+        self.drifted_slices > 0
+    }
+}
+
+/// Audit one shipped slice against the current predicate set.
+pub fn audit_slice_against_current_predicates(
+    slice: &Slice,
+    current_predicates: &[ResolvedPredicate],
+) -> SliceReplayAudit {
+    let recorded = slice
+        .invariants_applied
+        .iter()
+        .map(|(hash, _)| hash.clone())
+        .collect::<BTreeSet<_>>();
+    let current = current_predicates
+        .iter()
+        .map(|resolved| resolved.predicate.source_hash.clone())
+        .collect::<BTreeSet<_>>();
+    let advisory_drift = current_predicates
+        .iter()
+        .filter(|resolved| resolved.predicate.retroactive)
+        .filter(|resolved| !recorded.contains(&resolved.predicate.source_hash))
+        .map(|resolved| ReplayAuditPredicate {
+            name: resolved.qualified_name.clone(),
+            hash: resolved.predicate.source_hash.clone(),
+        })
+        .collect::<Vec<_>>();
+    let historical_only_predicates = recorded
+        .iter()
+        .filter(|hash| !current.contains(*hash))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    SliceReplayAudit {
+        slice_id: slice.id,
+        recorded_predicates: recorded.len(),
+        current_retroactive_predicates: current_predicates
+            .iter()
+            .filter(|resolved| resolved.predicate.retroactive)
+            .count(),
+        advisory_drift,
+        historical_only_predicates,
+    }
+}
+
+/// Audit many shipped slices and retain only slices with reportable content.
+pub fn replay_audit_report(
+    slices: impl IntoIterator<Item = Slice>,
+    current_predicates: &[ResolvedPredicate],
+) -> ReplayAuditReport {
+    let mut report = ReplayAuditReport::default();
+    for slice in slices {
+        report.audited_slices += 1;
+        let audit = audit_slice_against_current_predicates(&slice, current_predicates);
+        if audit.has_drift() {
+            report.drifted_slices += 1;
+        }
+        if audit.has_drift() || !audit.historical_only_predicates.is_empty() {
+            report.slices.push(audit);
+        }
+    }
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::flow::{Approval, AtomId, InvariantResult, PredicateKind, SliceStatus, TestId};
+    use harn_lexer::Span;
+
+    fn slice(applied: Vec<PredicateHash>) -> Slice {
+        Slice {
+            id: SliceId([1; 32]),
+            atoms: vec![AtomId([2; 32])],
+            intents: Vec::new(),
+            invariants_applied: applied
+                .into_iter()
+                .map(|hash| (hash, InvariantResult::allow()))
+                .collect(),
+            required_tests: vec![TestId::new("unit")],
+            approval_chain: Vec::<Approval>::new(),
+            base_ref: AtomId([0; 32]),
+            status: SliceStatus::Ready,
+        }
+    }
+
+    fn predicate(name: &str, hash: &str, retroactive: bool) -> ResolvedPredicate {
+        ResolvedPredicate {
+            qualified_name: name.to_string(),
+            logical_name: name.to_string(),
+            source: PredicateSource::new("."),
+            source_order: 0,
+            predicate: DiscoveredPredicate {
+                name: name.to_string(),
+                kind: PredicateKind::Deterministic,
+                archivist: None,
+                retroactive,
+                source_hash: PredicateHash::new(hash),
+                span: Span::dummy(),
+            },
+        }
+    }
+
+    #[test]
+    fn current_retroactive_predicate_missing_from_slice_reports_advisory_drift() {
+        let report = replay_audit_report(
+            vec![slice(vec![PredicateHash::new("sha256:old")])],
+            &[predicate("no_secrets", "sha256:new", true)],
+        );
+
+        assert!(report.has_drift());
+        assert_eq!(report.audited_slices, 1);
+        assert_eq!(report.drifted_slices, 1);
+        assert_eq!(report.slices[0].advisory_drift[0].name, "no_secrets");
+        assert_eq!(
+            report.slices[0].historical_only_predicates,
+            vec![PredicateHash::new("sha256:old")]
+        );
+    }
+
+    #[test]
+    fn non_retroactive_predicate_changes_do_not_surface_advisory_drift() {
+        let report = replay_audit_report(
+            vec![slice(vec![PredicateHash::new("sha256:old")])],
+            &[predicate("style", "sha256:new", false)],
+        );
+
+        assert!(!report.has_drift());
+        assert_eq!(report.drifted_slices, 0);
+        assert!(report.slices[0].advisory_drift.is_empty());
+    }
+}

--- a/crates/harn-vm/src/flow/mod.rs
+++ b/crates/harn-vm/src/flow/mod.rs
@@ -5,6 +5,7 @@
 //! [`Atom`](atom::Atom), [`Intent`](intent::Intent), and [`Slice`](slice::Slice).
 
 pub mod atom;
+pub mod audit;
 pub mod backend;
 pub mod fixer;
 pub mod intent;
@@ -13,6 +14,10 @@ pub mod slice;
 pub mod store;
 
 pub use atom::{Atom, AtomError, AtomId, AtomSignature, Provenance, TextOp};
+pub use audit::{
+    audit_slice_against_current_predicates, replay_audit_report, ReplayAuditPredicate,
+    ReplayAuditReport, SliceReplayAudit,
+};
 pub use backend::{
     AtomRef, FlowNativeBackend, FlowSlice, GitExportReceipt, ShadowGitBackend, ShipReceipt,
     VcsBackend, VcsBackendError,
@@ -40,4 +45,4 @@ pub use slice::{
     derive_slice, Approval, CoverageMap, PredicateHash, Slice, SliceDerivationError,
     SliceDerivationInput, SliceId, SliceStatus, TestId, UnresolvedParent,
 };
-pub use store::{AtomDelta, SqliteFlowStore, StateVector};
+pub use store::{AtomDelta, SqliteFlowStore, StateVector, StoredDerivedSlice};

--- a/crates/harn-vm/src/flow/predicates/compose.rs
+++ b/crates/harn-vm/src/flow/predicates/compose.rs
@@ -253,7 +253,7 @@ fn is_ancestor_dir(ancestor: &str, descendant: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::flow::{Approver, InvariantBlockError, PredicateKind};
+    use crate::flow::{Approver, InvariantBlockError, PredicateHash, PredicateKind};
     use harn_lexer::Span;
     use std::path::PathBuf;
 
@@ -263,6 +263,7 @@ mod tests {
             kind: PredicateKind::Deterministic,
             archivist: None,
             retroactive: false,
+            source_hash: PredicateHash::new(format!("sha256:{name}")),
             span: Span::dummy(),
         }
     }

--- a/crates/harn-vm/src/flow/predicates/discovery.rs
+++ b/crates/harn-vm/src/flow/predicates/discovery.rs
@@ -11,8 +11,10 @@ use std::path::{Path, PathBuf};
 
 use harn_lexer::{Lexer, Span};
 use harn_parser::{peel_attributes, Attribute, AttributeArg, Node, Parser};
+use sha2::{Digest, Sha256};
 
 use super::executor::PredicateKind;
+use crate::flow::slice::PredicateHash;
 
 /// Filename used for per-directory Flow invariant declarations.
 pub const INVARIANTS_FILE: &str = "invariants.harn";
@@ -46,6 +48,10 @@ pub struct DiscoveredPredicate {
     /// Advisory historical flag — predicates that legalise existing state
     /// rather than gate new atoms.
     pub retroactive: bool,
+    /// Stable content hash of the predicate declaration, including Flow
+    /// attributes. Shipped slices pin this value so later predicate edits are
+    /// append-only audit drift instead of retroactive blockers.
+    pub source_hash: PredicateHash,
     /// Span of the function declaration in the source file (1-based).
     pub span: Span,
 }
@@ -150,7 +156,8 @@ pub fn parse_invariants_source(source: &str) -> ParsedInvariantFile {
         let Node::FnDecl { name, .. } = &inner.node else {
             continue;
         };
-        let Some(predicate) = predicate_from_attributes(name, attrs, inner.span, &mut diagnostics)
+        let Some(predicate) =
+            predicate_from_attributes(source, name, attrs, inner.span, &mut diagnostics)
         else {
             continue;
         };
@@ -171,6 +178,7 @@ pub struct ParsedInvariantFile {
 }
 
 fn predicate_from_attributes(
+    source: &str,
     name: &str,
     attrs: &[Attribute],
     span: Span,
@@ -222,14 +230,28 @@ fn predicate_from_attributes(
     }
 
     let retroactive = attrs.iter().any(|a| a.name == "retroactive");
+    let source_hash = predicate_source_hash(source, attrs, span);
 
     Some(DiscoveredPredicate {
         name: name.to_string(),
         kind,
         archivist,
         retroactive,
+        source_hash,
         span,
     })
+}
+
+fn predicate_source_hash(source: &str, attrs: &[Attribute], span: Span) -> PredicateHash {
+    let start = attrs
+        .iter()
+        .map(|attr| attr.span.start)
+        .min()
+        .unwrap_or(span.start)
+        .min(source.len());
+    let end = span.end.min(source.len()).max(start);
+    let bytes = &source.as_bytes()[start..end];
+    PredicateHash::new(format!("sha256:{}", hex::encode(Sha256::digest(bytes))))
 }
 
 fn parse_archivist_attribute(attr: &Attribute) -> ArchivistMetadata {
@@ -393,6 +415,18 @@ fn {name}(slice) -> bool {{
         assert_eq!(arch.evidence, vec!["https://example.com/spec".to_string()]);
         assert_eq!(arch.confidence, Some(0.95));
         assert_eq!(arch.source_date.as_deref(), Some("2026-04-01"));
+    }
+
+    #[test]
+    fn parse_pins_predicate_source_hash() {
+        let source = sample_predicate("foo");
+        let parsed = parse_invariants_source(&source);
+        let original = parsed.predicates[0].source_hash.clone();
+
+        let changed = sample_predicate("foo").replace("return true", "return false");
+        let reparsed = parse_invariants_source(&changed);
+        assert_ne!(reparsed.predicates[0].source_hash, original);
+        assert!(original.as_str().starts_with("sha256:"));
     }
 
     #[test]

--- a/crates/harn-vm/src/flow/store.rs
+++ b/crates/harn-vm/src/flow/store.rs
@@ -13,6 +13,7 @@ use std::sync::{Mutex, MutexGuard};
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 use serde::{Deserialize, Serialize};
 use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
 use super::backend::{AtomRef, FlowSlice, GitExportReceipt, ShipReceipt, VcsBackend};
 use super::{Atom, AtomId, Intent, IntentId, Slice as DerivedSlice, SliceId, VcsBackendError};
@@ -52,6 +53,13 @@ pub struct AtomDelta {
     pub atom: Atom,
     pub site_id: String,
     pub clock: u64,
+}
+
+/// Persisted derived slice plus immutable store audit metadata.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StoredDerivedSlice {
+    pub slice: DerivedSlice,
+    pub created_at: String,
 }
 
 /// SQLite-backed Flow store.
@@ -404,6 +412,15 @@ impl SqliteFlowStore {
         self.insert_slice_record(slice.id, &slice.atoms, "derived", body, false)
     }
 
+    /// Persist a derived Flow slice as shipped.
+    ///
+    /// This writes the immutable shipped record directly; callers should not
+    /// persist an unshipped row first and later mutate it.
+    pub fn put_shipped_derived_slice(&self, slice: &DerivedSlice) -> Result<(), VcsBackendError> {
+        let body = serde_json::to_vec(slice)?;
+        self.insert_slice_record(slice.id, &slice.atoms, "derived", body, true)
+    }
+
     pub fn get_derived_slice(&self, slice_id: SliceId) -> Result<DerivedSlice, VcsBackendError> {
         let conn = self.lock_conn()?;
         let body = conn
@@ -415,6 +432,38 @@ impl SqliteFlowStore {
             .optional()?
             .ok_or_else(|| VcsBackendError::NotFound(format!("slice {slice_id} not found")))?;
         serde_json::from_slice(&body).map_err(Into::into)
+    }
+
+    /// List shipped derived slices, optionally filtering by store creation
+    /// timestamp.
+    pub fn shipped_derived_slices_since(
+        &self,
+        since: Option<OffsetDateTime>,
+    ) -> Result<Vec<StoredDerivedSlice>, VcsBackendError> {
+        let since = since
+            .map(|value| value.format(&Rfc3339))
+            .transpose()
+            .map_err(|error| VcsBackendError::Invalid(format!("timestamp format: {error}")))?;
+        let conn = self.lock_conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT body_json, created_at FROM slices
+             WHERE slice_kind = 'derived'
+               AND shipped = 1
+               AND (?1 IS NULL OR created_at >= datetime(?1))
+             ORDER BY created_at, id",
+        )?;
+        let rows = stmt.query_map(params![since.as_deref()], |row| {
+            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, String>(1)?))
+        })?;
+        let mut slices = Vec::new();
+        for row in rows {
+            let (body, created_at) = row?;
+            slices.push(StoredDerivedSlice {
+                slice: serde_json::from_slice(&body)?,
+                created_at,
+            });
+        }
+        Ok(slices)
     }
 
     fn insert_flow_slice(&self, slice: &FlowSlice, shipped: bool) -> Result<(), VcsBackendError> {
@@ -657,6 +706,30 @@ fn initialize_schema(conn: &Connection) -> Result<(), VcsBackendError> {
         BEFORE DELETE ON atom_parents
         BEGIN
             SELECT RAISE(ABORT, 'atom parent edges are append-only');
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS slices_no_update
+        BEFORE UPDATE ON slices
+        BEGIN
+            SELECT RAISE(ABORT, 'slices are append-only');
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS slices_no_delete
+        BEFORE DELETE ON slices
+        BEGIN
+            SELECT RAISE(ABORT, 'slices are append-only');
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS slice_atoms_no_update
+        BEFORE UPDATE ON slice_atoms
+        BEGIN
+            SELECT RAISE(ABORT, 'slice atom edges are append-only');
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS slice_atoms_no_delete
+        BEFORE DELETE ON slice_atoms
+        BEGIN
+            SELECT RAISE(ABORT, 'slice atom edges are append-only');
         END;
         "#,
     )?;
@@ -1093,6 +1166,45 @@ mod tests {
     }
 
     #[test]
+    fn lists_only_shipped_derived_slices_for_replay_audit() {
+        let store = SqliteFlowStore::in_memory("site-a").unwrap();
+        let first = atom(1, vec![]);
+        store.emit_atom(&first).unwrap();
+
+        let shipped = Slice {
+            id: SliceId([4; 32]),
+            atoms: vec![first.id],
+            intents: Vec::new(),
+            invariants_applied: vec![(
+                PredicateHash::new("sha256:retro"),
+                crate::flow::InvariantResult::allow(),
+            )],
+            required_tests: vec![TestId::new("flow-store")],
+            approval_chain: Vec::new(),
+            base_ref: first.id,
+            status: SliceStatus::Ready,
+        };
+        let unshipped = Slice {
+            id: SliceId([5; 32]),
+            atoms: vec![first.id],
+            intents: Vec::new(),
+            invariants_applied: Vec::new(),
+            required_tests: Vec::new(),
+            approval_chain: Vec::new(),
+            base_ref: first.id,
+            status: SliceStatus::Ready,
+        };
+
+        store.put_shipped_derived_slice(&shipped).unwrap();
+        store.put_derived_slice(&unshipped).unwrap();
+
+        let rows = store.shipped_derived_slices_since(None).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].slice, shipped);
+        assert!(!rows[0].created_at.is_empty());
+    }
+
+    #[test]
     fn atoms_are_append_only_at_sql_boundary() {
         let store = SqliteFlowStore::in_memory("site-a").unwrap();
         let first = atom(1, vec![]);
@@ -1106,5 +1218,32 @@ mod tests {
             )
             .unwrap_err();
         assert!(error.to_string().contains("atoms are append-only"));
+    }
+
+    #[test]
+    fn slices_are_append_only_at_sql_boundary() {
+        let store = SqliteFlowStore::in_memory("site-a").unwrap();
+        let first = atom(1, vec![]);
+        store.emit_atom(&first).unwrap();
+        let slice = Slice {
+            id: SliceId([6; 32]),
+            atoms: vec![first.id],
+            intents: Vec::new(),
+            invariants_applied: Vec::new(),
+            required_tests: Vec::new(),
+            approval_chain: Vec::new(),
+            base_ref: first.id,
+            status: SliceStatus::Ready,
+        };
+        store.put_shipped_derived_slice(&slice).unwrap();
+
+        let conn = store.lock_conn().unwrap();
+        let error = conn
+            .execute(
+                "DELETE FROM slices WHERE id = ?1",
+                params![slice.id.0.as_slice()],
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("slices are append-only"));
     }
 }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -742,6 +742,29 @@ Every bulk replay appends an audit envelope to
 `trigger.operations.audit` describing who ran it, when, the normalized
 filter, and the affected records.
 
+## harn flow replay-audit
+
+Audit shipped Flow slices against the current `@retroactive` predicate hashes.
+Historical slices remain append-only: drift is advisory unless
+`--fail-on-drift` is set.
+The `--store` path must already exist; the audit command does not create an
+empty Flow store.
+
+```bash
+harn flow replay-audit --since 2026-04-26
+harn flow replay-audit --since 2026-04-26T12:00:00Z --json
+harn flow replay-audit --store .harn/flow.sqlite --root . --target-dir crates/harn-vm --since 2026-04-26 --fail-on-drift
+```
+
+| Flag | Description |
+|---|---|
+| `--since <date>` | Include shipped derived slices created at or after an RFC3339 timestamp, unix timestamp, or `YYYY-MM-DD` |
+| `--store <path>` | SQLite Flow store to audit (default: `.harn/flow.sqlite`) |
+| `--root <path>` | Repository root used for `invariants.harn` discovery |
+| `--target-dir <path>` | Directory whose effective current predicate set is audited |
+| `--fail-on-drift` | Exit non-zero when advisory drift is found |
+| `--json` | Emit the replay-audit report as JSON |
+
 ## harn trace import
 
 Convert a third-party eval trace into a standard `--llm-mock` fixture.


### PR DESCRIPTION
## Summary
- pin `invariants.harn` Flow predicates with `sha256:` source hashes for shipped-slice audit records
- add append-only SQLite protections and shipped derived-slice queries for replay audits
- add `harn flow replay-audit --since <date>` with JSON output and advisory default exit behavior
- document the command and record the changelog entry for #583

Closes #583.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-583 cargo test -p harn-vm flow:: --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-583 cargo test -p harn-cli flow --bin harn`
- `TMPDIR=$(mktemp -d); touch "$TMPDIR/flow.sqlite"; CARGO_TARGET_DIR=/tmp/harn-target-issue-583 cargo run --quiet -p harn-cli -- flow replay-audit --store "$TMPDIR/flow.sqlite" --since 2026-04-26`
- `npx markdownlint-cli2 CHANGELOG.md docs/src/cli-reference.md`
- pre-commit hook: `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, full markdown lint
- pre-push hook: nextest workspace run, 2575 passed; full markdown lint
