### PR TITLE
Implement hierarchical Flow predicate composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,17 @@ granular archaeology.
   block on hover so the function declaration stays the single source of
   truth. Attribute argument syntax also accepts list literals and
   multi-line forms so provenance blocks can carry rich evidence.
+
+## Unreleased
+
+### Added
+
+- **Flow hierarchical predicate composition (#582).** Adds
+  `crates/harn-vm/src/flow/predicates/compose.rs` with depth-stamped
+  predicate resolution, touched-directory union, and strictness-based result
+  composition. Ancestor and child declarations are evaluated together so a
+  child can tighten an ancestor verdict, but cannot relax a shallower `Block`;
+  equal-severity ties keep the shallower predicate canonical.
 - **Flow `InvariantResult` graded-verdict types and Harn bindings (#581).**
   Predicates now return a structured `InvariantResult { verdict, evidence,
   remediation, confidence }` value where `verdict` grades as `Allow`, `Warn`,

--- a/crates/harn-vm/src/flow/mod.rs
+++ b/crates/harn-vm/src/flow/mod.rs
@@ -27,12 +27,14 @@ pub use intent::{
     TranscriptSpan,
 };
 pub use predicates::{
-    discover_invariants, parse_invariants_source, resolve_predicates, Approver, ArchivistMetadata,
-    ByteSpan, CheapJudge, CheapJudgeRequest, CheapJudgeResponse, DiscoveredInvariantFile,
+    compose_predicate_results, discover_invariants, parse_invariants_source, resolve_predicates,
+    resolve_predicates_for_touched_directories, Approver, ArchivistMetadata, ByteSpan, CheapJudge,
+    CheapJudgeRequest, CheapJudgeResponse, ComposedPredicateEvaluation, DiscoveredInvariantFile,
     DiscoveredPredicate, DiscoveryDiagnostic, DiscoveryDiagnosticSeverity, EvidenceItem,
     InvariantBlockError, InvariantResult, ParsedInvariantFile, PredicateContext,
-    PredicateExecutionRecord, PredicateExecutionReport, PredicateExecutor, PredicateExecutorConfig,
-    PredicateKind, PredicateRunner, Remediation, Verdict, INVARIANTS_FILE,
+    PredicateEvaluation, PredicateExecutionRecord, PredicateExecutionReport, PredicateExecutor,
+    PredicateExecutorConfig, PredicateKind, PredicateRunner, PredicateSource, Remediation,
+    ResolvedPredicate, Verdict, VerdictStrictness, INVARIANTS_FILE,
 };
 pub use slice::{
     derive_slice, Approval, CoverageMap, PredicateHash, Slice, SliceDerivationError,

--- a/crates/harn-vm/src/flow/predicates/compose.rs
+++ b/crates/harn-vm/src/flow/predicates/compose.rs
@@ -1,0 +1,447 @@
+//! Hierarchical composition for Flow predicates.
+//!
+//! Discovery finds `invariants.harn` files. This module turns those files into
+//! applicable predicate declarations and composes their evaluated verdicts
+//! without letting a deeper directory relax a shallower rule.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::discovery::{DiscoveredInvariantFile, DiscoveredPredicate};
+use super::result::{InvariantResult, Verdict};
+
+/// Source location of a predicate within the directory hierarchy.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct PredicateSource {
+    /// Directory relative to the discovery root. The root is represented as
+    /// `"."`, matching [`DiscoveredInvariantFile::relative_dir`].
+    pub relative_dir: String,
+    /// Root is depth 0; each descendant component increments the depth.
+    pub depth: usize,
+}
+
+impl PredicateSource {
+    pub fn new(relative_dir: impl Into<String>) -> Self {
+        let relative_dir = normalize_relative_dir(relative_dir.into());
+        let depth = directory_depth(&relative_dir);
+        Self {
+            relative_dir,
+            depth,
+        }
+    }
+
+    fn is_ancestor_of_or_same(&self, other: &Self) -> bool {
+        is_ancestor_dir(&self.relative_dir, &other.relative_dir)
+    }
+}
+
+/// One predicate declaration after hierarchical resolution.
+#[derive(Clone, Debug)]
+pub struct ResolvedPredicate {
+    /// Stable UI/logging name, e.g. `services/api::no_pii`.
+    pub qualified_name: String,
+    /// Function name used to identify ancestor/child override lineages.
+    pub logical_name: String,
+    pub source: PredicateSource,
+    /// Stable source-order index within the resolved set.
+    pub source_order: usize,
+    pub predicate: DiscoveredPredicate,
+}
+
+/// Strictness rank for merging verdicts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum VerdictStrictness {
+    Allow,
+    Warn,
+    RequireApproval,
+    Block,
+}
+
+/// A predicate evaluation stamped with its source depth.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PredicateEvaluation {
+    pub qualified_name: String,
+    pub logical_name: String,
+    pub source: PredicateSource,
+    pub result: InvariantResult,
+}
+
+impl PredicateEvaluation {
+    pub fn new(resolved: &ResolvedPredicate, result: InvariantResult) -> Self {
+        Self {
+            qualified_name: resolved.qualified_name.clone(),
+            logical_name: resolved.logical_name.clone(),
+            source: resolved.source.clone(),
+            result,
+        }
+    }
+}
+
+/// Effective verdict for one predicate evaluation after ancestor composition.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComposedPredicateEvaluation {
+    pub qualified_name: String,
+    pub logical_name: String,
+    pub source: PredicateSource,
+    /// The predicate declaration whose verdict governs this evaluation after
+    /// applying strictness and shallower-tie rules.
+    pub selected_qualified_name: String,
+    pub selected_source: PredicateSource,
+    pub result: InvariantResult,
+}
+
+/// Resolve the applicable predicates for a single root-to-leaf discovery chain.
+///
+/// Unlike the older override resolver, this keeps ancestor and child
+/// declarations. Both must be evaluated so a child can tighten a parent but
+/// cannot relax an ancestor's blocking verdict.
+pub fn resolve_predicates(files: &[DiscoveredInvariantFile]) -> Vec<ResolvedPredicate> {
+    let mut resolved = Vec::new();
+    for file in files {
+        let source = PredicateSource::new(&file.relative_dir);
+        for predicate in &file.predicates {
+            resolved.push(ResolvedPredicate {
+                qualified_name: qualified_name(&file.relative_dir, &predicate.name),
+                logical_name: predicate.name.clone(),
+                source: source.clone(),
+                source_order: resolved.len(),
+                predicate: predicate.clone(),
+            });
+        }
+    }
+    resolved
+}
+
+/// Resolve predicate declarations for every touched directory and union them.
+///
+/// Shared ancestors are de-duplicated by `(source_dir, predicate_name)`, while
+/// sibling directories keep same-named predicates as independent declarations.
+pub fn resolve_predicates_for_touched_directories(
+    chains: &[Vec<DiscoveredInvariantFile>],
+) -> Vec<ResolvedPredicate> {
+    let mut by_source_and_name: BTreeMap<(String, String), ResolvedPredicate> = BTreeMap::new();
+
+    for chain in chains {
+        for resolved in resolve_predicates(chain) {
+            let key = (
+                resolved.source.relative_dir.clone(),
+                resolved.logical_name.clone(),
+            );
+            let source_order = by_source_and_name.len();
+            by_source_and_name
+                .entry(key)
+                .or_insert_with(|| ResolvedPredicate {
+                    source_order,
+                    ..resolved
+                });
+        }
+    }
+
+    let mut resolved = by_source_and_name.into_values().collect::<Vec<_>>();
+    resolved.sort_by(|left, right| {
+        left.source
+            .depth
+            .cmp(&right.source.depth)
+            .then_with(|| left.source.relative_dir.cmp(&right.source.relative_dir))
+            .then_with(|| left.source_order.cmp(&right.source_order))
+            .then_with(|| left.logical_name.cmp(&right.logical_name))
+    });
+    resolved
+}
+
+/// Compose evaluated predicate results under stricter-child / shallower-tie
+/// semantics.
+///
+/// For each evaluation, only same-name predicates from ancestor directories are
+/// eligible to govern it. The strictest verdict wins; equal strictness selects
+/// the shallower source. This prevents a leaf `Allow` from shadowing a repo-wide
+/// `Block`, while still letting a leaf `Block` tighten an ancestor `Warn`.
+pub fn compose_predicate_results(
+    evaluations: &[PredicateEvaluation],
+) -> Vec<ComposedPredicateEvaluation> {
+    let mut composed = Vec::with_capacity(evaluations.len());
+
+    for evaluation in evaluations {
+        let selected = evaluations
+            .iter()
+            .filter(|candidate| {
+                candidate.logical_name == evaluation.logical_name
+                    && candidate.source.is_ancestor_of_or_same(&evaluation.source)
+            })
+            .max_by(|left, right| compare_evaluations(left, right))
+            .unwrap_or(evaluation);
+
+        composed.push(ComposedPredicateEvaluation {
+            qualified_name: evaluation.qualified_name.clone(),
+            logical_name: evaluation.logical_name.clone(),
+            source: evaluation.source.clone(),
+            selected_qualified_name: selected.qualified_name.clone(),
+            selected_source: selected.source.clone(),
+            result: selected.result.clone(),
+        });
+    }
+
+    composed
+}
+
+pub fn verdict_strictness(verdict: &Verdict) -> VerdictStrictness {
+    match verdict {
+        Verdict::Allow => VerdictStrictness::Allow,
+        Verdict::Warn { .. } => VerdictStrictness::Warn,
+        Verdict::RequireApproval { .. } => VerdictStrictness::RequireApproval,
+        Verdict::Block { .. } => VerdictStrictness::Block,
+    }
+}
+
+fn compare_evaluations(
+    left: &PredicateEvaluation,
+    right: &PredicateEvaluation,
+) -> std::cmp::Ordering {
+    let left_strictness = verdict_strictness(&left.result.verdict);
+    let right_strictness = verdict_strictness(&right.result.verdict);
+    left_strictness
+        .cmp(&right_strictness)
+        // `max_by` keeps the greater value, so reverse depth for shallower ties.
+        .then_with(|| right.source.depth.cmp(&left.source.depth))
+        .then_with(|| right.qualified_name.cmp(&left.qualified_name))
+}
+
+fn qualified_name(relative_dir: &str, name: &str) -> String {
+    let relative_dir = normalize_relative_dir(relative_dir.to_string());
+    if relative_dir == "." {
+        name.to_string()
+    } else {
+        format!("{relative_dir}::{name}")
+    }
+}
+
+fn normalize_relative_dir(value: String) -> String {
+    let parts = value
+        .split('/')
+        .filter(|part| !part.is_empty() && *part != "." && *part != "..")
+        .collect::<Vec<_>>();
+    if parts.is_empty() {
+        ".".to_string()
+    } else {
+        parts.join("/")
+    }
+}
+
+fn directory_depth(relative_dir: &str) -> usize {
+    if relative_dir == "." {
+        0
+    } else {
+        relative_dir
+            .split('/')
+            .filter(|part| !part.is_empty())
+            .count()
+    }
+}
+
+fn is_ancestor_dir(ancestor: &str, descendant: &str) -> bool {
+    let ancestor = normalize_relative_dir(ancestor.to_string());
+    let descendant = normalize_relative_dir(descendant.to_string());
+    if ancestor == "." || ancestor == descendant {
+        return true;
+    }
+    descendant
+        .strip_prefix(&ancestor)
+        .is_some_and(|remaining| remaining.starts_with('/'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::flow::{Approver, InvariantBlockError, PredicateKind};
+    use harn_lexer::Span;
+    use std::path::PathBuf;
+
+    fn predicate(name: &str) -> DiscoveredPredicate {
+        DiscoveredPredicate {
+            name: name.to_string(),
+            kind: PredicateKind::Deterministic,
+            archivist: None,
+            retroactive: false,
+            span: Span::dummy(),
+        }
+    }
+
+    fn file(relative_dir: &str, names: &[&str]) -> DiscoveredInvariantFile {
+        DiscoveredInvariantFile {
+            path: PathBuf::from(relative_dir).join("invariants.harn"),
+            relative_dir: relative_dir.to_string(),
+            source: String::new(),
+            predicates: names.iter().map(|name| predicate(name)).collect(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn evaluation(
+        qualified_name: &str,
+        logical_name: &str,
+        relative_dir: &str,
+        result: InvariantResult,
+    ) -> PredicateEvaluation {
+        PredicateEvaluation {
+            qualified_name: qualified_name.to_string(),
+            logical_name: logical_name.to_string(),
+            source: PredicateSource::new(relative_dir),
+            result,
+        }
+    }
+
+    #[test]
+    fn resolve_predicates_keeps_ancestor_and_child_declarations() {
+        let resolved = resolve_predicates(&[file(".", &["shared"]), file("src", &["shared"])]);
+        let qualified = resolved
+            .iter()
+            .map(|predicate| predicate.qualified_name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(qualified, vec!["shared", "src::shared"]);
+        assert_eq!(resolved[0].source.depth, 0);
+        assert_eq!(resolved[1].source.depth, 1);
+    }
+
+    #[test]
+    fn override_narrowing_allows_deeper_stricter_verdict() {
+        let evaluations = vec![
+            evaluation(
+                "security",
+                "security",
+                ".",
+                InvariantResult::warn("repo warning"),
+            ),
+            evaluation(
+                "src::security",
+                "security",
+                "src",
+                InvariantResult::block(InvariantBlockError::new(
+                    "leaf_policy",
+                    "leaf policy blocks this slice",
+                )),
+            ),
+        ];
+
+        let composed = compose_predicate_results(&evaluations);
+        let child = composed
+            .iter()
+            .find(|item| item.qualified_name == "src::security")
+            .unwrap();
+        assert_eq!(child.selected_qualified_name, "src::security");
+        assert_eq!(
+            verdict_strictness(&child.result.verdict),
+            VerdictStrictness::Block
+        );
+    }
+
+    #[test]
+    fn override_relaxing_keeps_shallower_block() {
+        let evaluations = vec![
+            evaluation(
+                "security",
+                "security",
+                ".",
+                InvariantResult::block(InvariantBlockError::new(
+                    "repo_policy",
+                    "repo policy blocks this slice",
+                )),
+            ),
+            evaluation("src::security", "security", "src", InvariantResult::allow()),
+        ];
+
+        let composed = compose_predicate_results(&evaluations);
+        let child = composed
+            .iter()
+            .find(|item| item.qualified_name == "src::security")
+            .unwrap();
+        assert_eq!(child.selected_qualified_name, "security");
+        assert_eq!(
+            verdict_strictness(&child.result.verdict),
+            VerdictStrictness::Block
+        );
+    }
+
+    #[test]
+    fn equal_strictness_ties_go_to_shallower_predicate() {
+        let evaluations = vec![
+            evaluation(
+                "review",
+                "review",
+                ".",
+                InvariantResult::require_approval(Approver::role("platform")),
+            ),
+            evaluation(
+                "src::review",
+                "review",
+                "src",
+                InvariantResult::require_approval(Approver::role("local")),
+            ),
+        ];
+
+        let composed = compose_predicate_results(&evaluations);
+        let child = composed
+            .iter()
+            .find(|item| item.qualified_name == "src::review")
+            .unwrap();
+        assert_eq!(child.selected_qualified_name, "review");
+    }
+
+    #[test]
+    fn cross_directory_union_deduplicates_shared_ancestors_only() {
+        let api_chain = vec![
+            file(".", &["repo"]),
+            file("services/api", &["api", "shared_name"]),
+        ];
+        let web_chain = vec![
+            file(".", &["repo"]),
+            file("services/web", &["web", "shared_name"]),
+        ];
+
+        let resolved = resolve_predicates_for_touched_directories(&[api_chain, web_chain]);
+        let qualified = resolved
+            .iter()
+            .map(|predicate| predicate.qualified_name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            qualified,
+            vec![
+                "repo",
+                "services/api::api",
+                "services/api::shared_name",
+                "services/web::web",
+                "services/web::shared_name"
+            ]
+        );
+    }
+
+    #[test]
+    fn sibling_same_name_predicates_do_not_shadow_each_other() {
+        let evaluations = vec![
+            evaluation(
+                "services/api::guard",
+                "guard",
+                "services/api",
+                InvariantResult::block(InvariantBlockError::new("api", "api blocked")),
+            ),
+            evaluation(
+                "services/web::guard",
+                "guard",
+                "services/web",
+                InvariantResult::allow(),
+            ),
+        ];
+
+        let composed = compose_predicate_results(&evaluations);
+        let web = composed
+            .iter()
+            .find(|item| item.qualified_name == "services/web::guard")
+            .unwrap();
+        assert_eq!(web.selected_qualified_name, "services/web::guard");
+        assert_eq!(
+            verdict_strictness(&web.result.verdict),
+            VerdictStrictness::Allow
+        );
+    }
+}

--- a/crates/harn-vm/src/flow/predicates/discovery.rs
+++ b/crates/harn-vm/src/flow/predicates/discovery.rs
@@ -1,13 +1,12 @@
 //! Discovery and parsing of `invariants.harn` Flow predicate files.
 //!
 //! Mirrors `metadata_resolve` semantics: predicates declared in higher
-//! directories apply to all descendants, with stricter (closer-to-leaf)
-//! files overriding when names collide. This module owns the walk + parse;
-//! evaluation lives in [`super::executor`].
+//! directories apply to all descendants. This module owns the walk + parse;
+//! hierarchy merging lives in [`super::compose`], and evaluation lives in
+//! [`super::executor`].
 //!
 //! See parent epic #571 and ticket #579 for the design rationale.
 
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use harn_lexer::{Lexer, Span};
@@ -37,8 +36,8 @@ pub struct DiscoveredInvariantFile {
 /// One Flow predicate declaration parsed out of an invariants file.
 #[derive(Clone, Debug)]
 pub struct DiscoveredPredicate {
-    /// Function name. Composition uses `relative_dir + name` as the
-    /// identity for stricter-child overrides.
+    /// Function name. Composition uses this name plus the source directory
+    /// ancestry to identify stricter-child override lineages.
     pub name: String,
     /// `Deterministic` (default) or `Semantic`.
     pub kind: PredicateKind,
@@ -79,8 +78,8 @@ pub enum DiagnosticSeverity {
 /// Walk from `root` down through every component of `target_dir`,
 /// collecting `invariants.harn` at each level.
 ///
-/// Returns the files in root-to-leaf order so callers can apply
-/// stricter-child overrides simply by iterating in order.
+/// Returns the files in root-to-leaf order so composition can stamp source
+/// depth and evaluate ancestor/child predicates together.
 ///
 /// `target_dir` is interpreted relative to `root`. Absolute paths or
 /// paths that escape `root` are silently clamped — discovery never reads
@@ -331,33 +330,10 @@ fn relative_dir_label(root: &Path, dir: &Path) -> String {
     }
 }
 
-/// Resolve a directory's effective predicate set.
-///
-/// Walks the discovered files in root-to-leaf order, layering them so a
-/// stricter (closer-to-leaf) declaration with the same name overrides the
-/// ancestor. Returns predicates in deterministic source order, oldest
-/// ancestor first then newest within each level.
-pub fn resolve_predicates(files: &[DiscoveredInvariantFile]) -> Vec<(String, DiscoveredPredicate)> {
-    // Use a BTreeMap for stable iteration so callers get deterministic
-    // output regardless of disk ordering.
-    let mut effective: BTreeMap<String, (String, DiscoveredPredicate)> = BTreeMap::new();
-    for file in files {
-        for predicate in &file.predicates {
-            let key = predicate.name.clone();
-            let qualified = if file.relative_dir == "." {
-                predicate.name.clone()
-            } else {
-                format!("{}::{}", file.relative_dir, predicate.name)
-            };
-            effective.insert(key, (qualified, predicate.clone()));
-        }
-    }
-    effective.into_values().collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::flow::resolve_predicates;
     use std::fs;
     use tempfile::TempDir;
 
@@ -480,7 +456,7 @@ fn handler_check(slice) -> bool { return true }
     }
 
     #[test]
-    fn resolve_predicates_overrides_ancestors() {
+    fn resolve_predicates_keeps_ancestors_for_composition() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
         write(root, INVARIANTS_FILE, &sample_predicate("shared"));
@@ -498,12 +474,12 @@ fn handler_check(slice) -> bool { return true }
 
         let files = discover_invariants(root, &nested);
         let resolved = resolve_predicates(&files);
-        let qualified: Vec<_> = resolved.iter().map(|(q, _)| q.clone()).collect();
-        // `shared` is overridden by the deeper file → qualified path.
+        let qualified: Vec<_> = resolved.iter().map(|p| p.qualified_name.clone()).collect();
+        // Composition needs both versions so child results can tighten but
+        // cannot relax ancestor verdicts.
+        assert!(qualified.contains(&"shared".to_string()));
         assert!(qualified.contains(&"crates::shared".to_string()));
         // `extra` only exists in the deeper file.
         assert!(qualified.contains(&"crates::extra".to_string()));
-        // The root version should not appear in the resolved set.
-        assert!(!qualified.contains(&"shared".to_string()));
     }
 }

--- a/crates/harn-vm/src/flow/predicates/mod.rs
+++ b/crates/harn-vm/src/flow/predicates/mod.rs
@@ -1,11 +1,17 @@
 //! Flow invariant predicate execution.
 
+pub mod compose;
 pub mod discovery;
 pub mod executor;
 pub mod result;
 
+pub use compose::{
+    compose_predicate_results, resolve_predicates, resolve_predicates_for_touched_directories,
+    ComposedPredicateEvaluation, PredicateEvaluation, PredicateSource, ResolvedPredicate,
+    VerdictStrictness,
+};
 pub use discovery::{
-    discover_invariants, parse_invariants_source, resolve_predicates, ArchivistMetadata,
+    discover_invariants, parse_invariants_source, ArchivistMetadata,
     DiagnosticSeverity as DiscoveryDiagnosticSeverity, DiscoveredInvariantFile,
     DiscoveredPredicate, DiscoveryDiagnostic, ParsedInvariantFile, INVARIANTS_FILE,
 };


### PR DESCRIPTION
## Summary
- add `flow::predicates::compose` with depth-stamped predicate resolution and touched-directory union
- compose evaluated predicate verdicts by strictness so child rules can tighten ancestors but cannot relax shallower blockers
- update discovery exports/tests and changelog for #582

Closes #582.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-7c0b-582-target cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/harn-7c0b-582-target cargo test -p harn-vm flow::predicates`
- `CARGO_TARGET_DIR=/tmp/harn-7c0b-582-target cargo clippy -p harn-vm --all-targets -- -D warnings`
- pre-commit hook: workspace clippy + markdownlint
- pre-push hook: 2574 nextest tests + markdownlint

Note: an exploratory parallel `cargo test -p harn-vm` run initially exposed unrelated egress-policy global-state failures in connector/http tests; representative failed cases passed when rerun exactly/serially, and the pre-push nextest gate passed all 2574 tests.