### PR TITLE
Complete Flow predicate audit surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ granular archaeology.
   invariant result, a `harn-vm` Fixer helper that re-signs suggested atoms as
   auditable Fixer atoms and derives a follow-up slice, plus the checked-in
   `personas/fixer` role manifest.
+- **Flow predicate composition and replay audit (#571, #582, #583, #584).**
+  Flow predicate discovery now pins content hashes that include
+  `@archivist(...)` metadata, keeps parent and child predicates applicable for
+  hierarchical composition, and exposes conservative stricter-child composition
+  checks. `harn flow replay-audit` compares historical slice predicate pins
+  with the current `invariants.harn` set, while `harn flow ship watch` and
+  `harn flow archivist scan` provide the Phase 0 Ship Captain and Archivist
+  command surfaces for shadow-mode workflows.
 - **First-class worker lifecycle events on ACP and A2A (#703).** Adds
   two new typed `WorkerEvent` variants (`WorkerProgressed`,
   `WorkerWaitingForInput`) and surfaces every worker lifecycle

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -1013,45 +1013,6 @@ pub(crate) struct TrustArgs {
     pub command: TrustCommand,
 }
 
-#[derive(Debug, Args)]
-pub(crate) struct FlowArgs {
-    #[command(subcommand)]
-    pub command: FlowCommand,
-}
-
-#[derive(Debug, Subcommand)]
-pub(crate) enum FlowCommand {
-    /// Audit historical shipped slices against current retroactive predicates.
-    #[command(name = "replay-audit")]
-    ReplayAudit(FlowReplayAuditArgs),
-}
-
-#[derive(Debug, Args)]
-pub(crate) struct FlowReplayAuditArgs {
-    /// SQLite Flow store to audit.
-    #[arg(
-        long = "store",
-        value_name = "PATH",
-        default_value = ".harn/flow.sqlite"
-    )]
-    pub store: PathBuf,
-    /// Repository root used for `invariants.harn` discovery.
-    #[arg(long = "root", value_name = "PATH", default_value = ".")]
-    pub root: PathBuf,
-    /// Target directory whose effective current predicate set should be used.
-    #[arg(long = "target-dir", value_name = "PATH", default_value = ".")]
-    pub target_dir: PathBuf,
-    /// Include shipped slices created at or after this date/timestamp.
-    #[arg(long = "since", value_name = "DATE")]
-    pub since: String,
-    /// Exit non-zero when advisory drift is found.
-    #[arg(long = "fail-on-drift")]
-    pub fail_on_drift: bool,
-    /// Emit JSON instead of human-readable output.
-    #[arg(long)]
-    pub json: bool,
-}
-
 #[derive(Debug, Subcommand)]
 pub(crate) enum TrustCommand {
     /// Query trust records from the event log.
@@ -1981,6 +1942,99 @@ pub(crate) struct PersonaArgs {
     pub state_dir: PathBuf,
 }
 
+#[derive(Debug, Args)]
+pub(crate) struct FlowArgs {
+    #[command(subcommand)]
+    pub command: FlowCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum FlowCommand {
+    /// Replay-audit historical slices against the current invariant predicates.
+    ReplayAudit(FlowReplayAuditArgs),
+    /// Ship Captain Phase 0 utilities.
+    Ship(FlowShipArgs),
+    /// Archivist Phase 0 utilities.
+    Archivist(FlowArchivistArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct FlowReplayAuditArgs {
+    /// SQLite Flow store path.
+    #[arg(long, value_name = "PATH", default_value = ".harn/flow.sqlite")]
+    pub store: PathBuf,
+    /// Repo root used to discover current `invariants.harn` predicates.
+    #[arg(
+        long = "predicate-root",
+        alias = "root",
+        value_name = "PATH",
+        default_value = "."
+    )]
+    pub predicate_root: PathBuf,
+    /// Touched directory to resolve predicates for. Repeat for cross-directory slices.
+    #[arg(long = "touched-dir", alias = "target-dir", value_name = "PATH")]
+    pub touched_dirs: Vec<PathBuf>,
+    /// SQLite created_at lower bound, for example `2026-04-26` or `2026-04-26 12:00:00`.
+    #[arg(long, value_name = "DATE")]
+    pub since: Option<String>,
+    /// Emit JSON instead of text.
+    #[arg(long)]
+    pub json: bool,
+    /// Exit non-zero when drift is detected.
+    #[arg(long)]
+    pub fail_on_drift: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct FlowShipArgs {
+    #[command(subcommand)]
+    pub command: FlowShipCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum FlowShipCommand {
+    /// Derive a candidate slice from stored atoms and emit a mock PR receipt.
+    Watch(FlowShipWatchArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct FlowShipWatchArgs {
+    /// SQLite Flow store path.
+    #[arg(long, value_name = "PATH", default_value = ".harn/flow.sqlite")]
+    pub store: PathBuf,
+    /// Write the Phase 0 mock PR receipt to this path.
+    #[arg(long = "mock-pr-out", value_name = "PATH")]
+    pub mock_pr_out: Option<PathBuf>,
+    /// Emit JSON instead of text.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct FlowArchivistArgs {
+    #[command(subcommand)]
+    pub command: FlowArchivistCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum FlowArchivistCommand {
+    /// Scan a repo and emit review-ready predicate proposal metadata.
+    Scan(FlowArchivistScanArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct FlowArchivistScanArgs {
+    /// Repo root to scan.
+    #[arg(value_name = "REPO", default_value = ".")]
+    pub repo: PathBuf,
+    /// Write the proposal JSON to this path.
+    #[arg(long, value_name = "PATH")]
+    pub out: Option<PathBuf>,
+    /// Emit JSON instead of text.
+    #[arg(long)]
+    pub json: bool,
+}
+
 #[derive(Debug, Subcommand)]
 pub(crate) enum PersonaCommand {
     /// List personas declared in the resolved harn.toml.
@@ -2766,9 +2820,9 @@ mod tests {
             "replay-audit",
             "--store",
             ".harn/flow.sqlite",
-            "--root",
+            "--predicate-root",
             ".",
-            "--target-dir",
+            "--touched-dir",
             "crates/harn-vm",
             "--since",
             "2026-04-26",
@@ -2779,11 +2833,13 @@ mod tests {
         let Command::Flow(args) = cli.command.unwrap() else {
             panic!("expected flow command");
         };
-        let FlowCommand::ReplayAudit(audit) = args.command;
+        let FlowCommand::ReplayAudit(audit) = args.command else {
+            panic!("expected replay-audit command");
+        };
         assert_eq!(audit.store, PathBuf::from(".harn/flow.sqlite"));
-        assert_eq!(audit.root, PathBuf::from("."));
-        assert_eq!(audit.target_dir, PathBuf::from("crates/harn-vm"));
-        assert_eq!(audit.since, "2026-04-26");
+        assert_eq!(audit.predicate_root, PathBuf::from("."));
+        assert_eq!(audit.touched_dirs, vec![PathBuf::from("crates/harn-vm")]);
+        assert_eq!(audit.since.as_deref(), Some("2026-04-26"));
         assert!(audit.fail_on_drift);
         assert!(audit.json);
     }

--- a/crates/harn-cli/src/commands/flow.rs
+++ b/crates/harn-cli/src/commands/flow.rs
@@ -1,27 +1,47 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use harn_vm::flow::{SqliteFlowStore, VcsBackend};
+use serde_json::json;
 use time::format_description::well_known::Rfc3339;
 use time::{Date, OffsetDateTime, Time};
 
-use crate::cli::FlowReplayAuditArgs;
+use crate::cli::{
+    FlowArchivistCommand, FlowArgs, FlowCommand, FlowReplayAuditArgs, FlowShipCommand,
+};
+
+pub(crate) fn run_flow(args: &FlowArgs) -> Result<i32, String> {
+    match &args.command {
+        FlowCommand::ReplayAudit(replay) => run_replay_audit(replay),
+        FlowCommand::Ship(ship) => match &ship.command {
+            FlowShipCommand::Watch(watch) => run_ship_watch(watch),
+        },
+        FlowCommand::Archivist(archivist) => match &archivist.command {
+            FlowArchivistCommand::Scan(scan) => run_archivist_scan(scan),
+        },
+    }
+}
 
 pub(crate) fn run_replay_audit(args: &FlowReplayAuditArgs) -> Result<i32, String> {
-    let since = parse_since(&args.since)?;
+    let since = args.since.as_deref().map(parse_since).transpose()?;
     if !args.store.is_file() {
         return Err(format!(
             "Flow store {} does not exist",
             args.store.display()
         ));
     }
-    let store =
-        harn_vm::flow::SqliteFlowStore::open(&args.store, "replay-audit").map_err(|error| {
-            format!(
-                "failed to open Flow store {}: {error}",
-                args.store.display()
-            )
-        })?;
+    let store = SqliteFlowStore::open(&args.store, "replay-audit").map_err(|error| {
+        format!(
+            "failed to open Flow store {}: {error}",
+            args.store.display()
+        )
+    })?;
 
-    let files = harn_vm::flow::discover_invariants(&args.root, &args.target_dir);
-    let diagnostics = files
+    let chains = current_predicate_chains(&args.predicate_root, &args.touched_dirs);
+    let diagnostics = chains
         .iter()
+        .flat_map(|chain| chain.iter())
         .flat_map(|file| {
             file.diagnostics
                 .iter()
@@ -35,20 +55,16 @@ pub(crate) fn run_replay_audit(args: &FlowReplayAuditArgs) -> Result<i32, String
         return Err(render_discovery_diagnostics(&diagnostics));
     }
     if !args.json {
-        let warnings = diagnostics
-            .iter()
-            .filter(|(_, diagnostic)| {
-                diagnostic.severity == harn_vm::flow::DiscoveryDiagnosticSeverity::Warning
-            })
-            .collect::<Vec<_>>();
-        for (path, diagnostic) in warnings {
+        for (path, diagnostic) in diagnostics.iter().filter(|(_, diagnostic)| {
+            diagnostic.severity == harn_vm::flow::DiscoveryDiagnosticSeverity::Warning
+        }) {
             eprintln!("warning: {path}: {}", diagnostic.message);
         }
     }
 
-    let current_predicates = harn_vm::flow::resolve_predicates(&files);
+    let current_predicates = harn_vm::flow::resolve_predicates_for_touched_directories(&chains);
     let stored = store
-        .shipped_derived_slices_since(Some(since))
+        .shipped_derived_slices_since(since)
         .map_err(|error| format!("failed to list shipped slices: {error}"))?;
     let created_at_by_slice = stored
         .iter()
@@ -64,7 +80,11 @@ pub(crate) fn run_replay_audit(args: &FlowReplayAuditArgs) -> Result<i32, String
             .map_err(|error| format!("failed to encode replay-audit report: {error}"))?;
         println!("{json}");
     } else {
-        print_human_report(&args.since, &report, &created_at_by_slice);
+        print_human_report(
+            args.since.as_deref().unwrap_or("beginning"),
+            &report,
+            &created_at_by_slice,
+        );
     }
 
     Ok(if args.fail_on_drift && report.has_drift() {
@@ -72,6 +92,186 @@ pub(crate) fn run_replay_audit(args: &FlowReplayAuditArgs) -> Result<i32, String
     } else {
         0
     })
+}
+
+fn run_ship_watch(args: &crate::cli::FlowShipWatchArgs) -> Result<i32, String> {
+    let store = open_store(&args.store)?;
+    let atoms = store
+        .list_atoms()
+        .map_err(|error| format!("failed to list Flow atoms: {error}"))?;
+    if atoms.is_empty() {
+        let payload = json!({"status": "idle", "reason": "no_atoms"});
+        print_payload(
+            args.json,
+            "Ship Captain idle: no atoms in the Flow store.",
+            &payload,
+        );
+        return Ok(0);
+    }
+
+    let atom_ids: Vec<_> = atoms.iter().map(|atom| atom.atom_id).collect();
+    let slice = store
+        .derive_slice(&atom_ids)
+        .map_err(|error| format!("failed to derive candidate slice: {error}"))?;
+    let payload = json!({
+        "status": "candidate_slice",
+        "slice_id": slice.id,
+        "atoms": slice.atoms,
+        "mock_pr": {
+            "title": format!("Flow slice {}", slice.id),
+            "body": "Shadow-mode Ship Captain candidate slice. No remote PR was opened.",
+        },
+    });
+
+    if let Some(path) = &args.mock_pr_out {
+        write_json(path, &payload)
+            .map_err(|error| format!("failed to write mock PR receipt: {error}"))?;
+    }
+    print_payload(
+        args.json,
+        &format!("candidate slice {}", slice.id),
+        &payload,
+    );
+    Ok(0)
+}
+
+fn run_archivist_scan(args: &crate::cli::FlowArchivistScanArgs) -> Result<i32, String> {
+    let stack_hints = stack_hints(&args.repo);
+    let invariant_files = find_invariant_dirs(&args.repo);
+    let mut seen = BTreeSet::new();
+    let mut predicates = Vec::new();
+    for dir in &invariant_files {
+        for file in harn_vm::flow::discover_invariants(&args.repo, dir) {
+            let relative_dir = file.relative_dir;
+            for predicate in file.predicates {
+                if !seen.insert(predicate.source_hash.clone()) {
+                    continue;
+                }
+                predicates.push(json!({
+                    "name": predicate.name,
+                    "hash": predicate.source_hash,
+                    "kind": predicate.kind,
+                    "relative_dir": relative_dir.clone(),
+                    "retroactive": predicate.retroactive,
+                    "archivist": predicate.archivist.map(|archivist| json!({
+                        "evidence": archivist.evidence,
+                        "confidence": archivist.confidence,
+                        "source_date": archivist.source_date,
+                        "coverage_examples": archivist.coverage_examples,
+                    })),
+                }));
+            }
+        }
+    }
+    let proposals = default_archivist_proposals(&stack_hints, predicates.is_empty());
+    let payload = json!({
+        "status": "proposal_set",
+        "repo": args.repo,
+        "stack_hints": stack_hints,
+        "existing_predicates": predicates,
+        "proposals": proposals,
+    });
+
+    if let Some(path) = &args.out {
+        write_json(path, &payload)
+            .map_err(|error| format!("failed to write Archivist proposal set: {error}"))?;
+    }
+    print_payload(args.json, "Archivist proposal set emitted.", &payload);
+    Ok(0)
+}
+
+fn current_predicate_chains(
+    root: &Path,
+    touched_dirs: &[PathBuf],
+) -> Vec<Vec<harn_vm::flow::DiscoveredInvariantFile>> {
+    let dirs: Vec<PathBuf> = if touched_dirs.is_empty() {
+        vec![PathBuf::from(".")]
+    } else {
+        touched_dirs.to_vec()
+    };
+    dirs.into_iter()
+        .map(|dir| harn_vm::flow::discover_invariants(root, &dir))
+        .collect()
+}
+
+fn open_store(path: &Path) -> Result<SqliteFlowStore, String> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    SqliteFlowStore::open(path, "flow-cli").map_err(|error| error.to_string())
+}
+
+fn find_invariant_dirs(root: &Path) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    collect_invariant_dirs(root, root, &mut dirs);
+    dirs
+}
+
+fn collect_invariant_dirs(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
+    entries.sort_by_key(|entry| entry.path());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default();
+            if matches!(name, ".git" | "target" | "node_modules") {
+                continue;
+            }
+            collect_invariant_dirs(root, &path, out);
+        } else if path.file_name().and_then(|name| name.to_str()) == Some("invariants.harn") {
+            out.push(path.parent().unwrap_or(root).to_path_buf());
+        }
+    }
+}
+
+fn stack_hints(repo: &Path) -> Vec<&'static str> {
+    let mut hints = Vec::new();
+    if repo.join("Cargo.toml").exists() {
+        hints.push("rust");
+    }
+    if repo.join("package.json").exists() {
+        hints.push("javascript");
+    }
+    if repo.join("pyproject.toml").exists() {
+        hints.push("python");
+    }
+    if repo.join("go.mod").exists() {
+        hints.push("go");
+    }
+    hints
+}
+
+fn default_archivist_proposals(
+    stack_hints: &[&str],
+    no_existing_predicates: bool,
+) -> Vec<serde_json::Value> {
+    let mut proposals = Vec::new();
+    if no_existing_predicates {
+        proposals.push(json!({
+            "path": "invariants.harn",
+            "title": "Seed repo-wide meta-invariants",
+            "body": "Add hand-authored bootstrap rules requiring @archivist evidence and deterministic fallbacks for semantic predicates.",
+            "autonomy": "propose_only",
+        }));
+    }
+    if stack_hints.contains(&"rust") {
+        proposals.push(json!({
+            "path": "invariants.harn",
+            "title": "Rust unsafe and panic surface guard",
+            "body": "Propose deterministic predicates for new unsafe blocks, panic paths in library code, and missing tests near touched atoms.",
+            "autonomy": "propose_only",
+        }));
+    }
+    proposals
 }
 
 fn print_human_report(
@@ -115,6 +315,24 @@ fn render_discovery_diagnostics(
         .map(|(path, diagnostic)| format!("{path}: {}", diagnostic.message))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn write_json(path: &Path, value: &serde_json::Value) -> Result<(), std::io::Error> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_vec_pretty(value).unwrap())
+}
+
+fn print_payload(json_output: bool, text: &str, payload: &serde_json::Value) {
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(payload).unwrap());
+    } else {
+        println!("{text}");
+    }
 }
 
 fn parse_since(raw: &str) -> Result<OffsetDateTime, String> {

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 use std::{env, fs, process, thread};
 
 use cli::{
-    Cli, Command, FlowCommand, ModelInfoArgs, PackageCacheCommand, PackageCommand, PersonaCommand,
-    RunsCommand, ServeCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand,
+    Cli, Command, ModelInfoArgs, PackageCacheCommand, PackageCommand, PersonaCommand, RunsCommand,
+    ServeCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand,
 };
 use harn_lexer::Lexer;
 use harn_parser::{DiagnosticSeverity, Parser, TypeChecker};
@@ -513,15 +513,13 @@ async fn async_main() {
                 process::exit(1);
             }
         }
-        Command::Flow(args) => match args.command {
-            FlowCommand::ReplayAudit(replay) => match commands::flow::run_replay_audit(&replay) {
-                Ok(code) => {
-                    if code != 0 {
-                        process::exit(code);
-                    }
+        Command::Flow(args) => match commands::flow::run_flow(&args) {
+            Ok(code) => {
+                if code != 0 {
+                    process::exit(code);
                 }
-                Err(error) => command_error(&error),
-            },
+            }
+            Err(error) => command_error(&error),
         },
         Command::Trace(args) => {
             if let Err(error) = commands::trace::handle(args).await {

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -139,6 +139,29 @@ harn viz main.harn --output docs/graph.mmd
 graph showing pipelines, functions, branches, loops, and other workflow-shaped
 control-flow nodes.
 
+## harn flow
+
+Inspect and operate the Flow shipping substrate.
+
+```bash
+harn flow replay-audit --store .harn/flow.sqlite --predicate-root . --touched-dir crates/harn-vm
+harn flow replay-audit --since 2026-04-26 --fail-on-drift --json
+harn flow ship watch --store .harn/flow.sqlite --mock-pr-out .harn/flow/mock-pr.json --json
+harn flow archivist scan . --out .harn/flow/archivist-proposals.json --json
+```
+
+`replay-audit` compares predicate hashes pinned in derived slices with the
+current `invariants.harn` predicate set. Drift is advisory unless
+`--fail-on-drift` is present.
+
+`ship watch` is the Phase 0 Ship Captain shadow-mode surface. It derives a
+candidate slice from stored atoms and can write a mock PR receipt without
+touching a remote GitHub repository.
+
+`archivist scan` emits review-ready predicate proposal metadata from the repo's
+stack hints and existing Flow predicates. It is propose-only; it does not edit
+`invariants.harn`.
+
 ## harn persona
 
 List, inspect, and control durable agent persona manifests from `harn.toml`.

--- a/examples/personas/flow.harn.toml
+++ b/examples/personas/flow.harn.toml
@@ -1,0 +1,85 @@
+[package]
+name = "harn-flow-personas"
+version = "0.1.0"
+
+[[personas]]
+name = "ship_captain"
+version = "0.1.0"
+description = "Shadow-mode Flow captain that groups atoms into candidate slices, validates gates, and emits mock PR receipts."
+entry_workflow = "workflows/flow_ship_captain.harn#run"
+tools = ["github", "ci", "filesystem", "mcp"]
+capabilities = [
+  "git.get_diff",
+  "project.scan",
+  "project.test_commands",
+  "runtime.approved_plan",
+  "runtime.dry_run",
+  "runtime.record_run",
+]
+autonomy_tier = "act_with_approval"
+receipt_policy = "required"
+triggers = ["flow.atoms_changed", "github.check_failed"]
+schedules = ["*/15 * * * *"]
+handoffs = ["fixer"]
+context_packs = ["repo_policy", "release_policy"]
+evals = ["slice_quality", "false_ship_rate", "coverage_fidelity", "latency_pr_to_merge"]
+owner = "platform"
+budget = { daily_usd = 8.0, frontier_escalations = 1, max_tokens = 50000, max_runtime_seconds = 600 }
+model_policy = { default_model = "gpt-5.4-mini", escalation_model = "gpt-5.4", fallback_models = ["gpt-5.2"], reasoning_effort = "medium" }
+rollout_policy = { mode = "approval_only", percentage = 100, cohorts = ["flow-phase-0"] }
+package_source = { package = "harn-flow-personas", path = "examples/personas" }
+
+[[personas]]
+name = "archivist"
+version = "0.1.0"
+description = "Propose-only Flow predicate author that scans repo conventions and emits review-ready invariant proposals."
+entry_workflow = "workflows/flow_archivist.harn#run"
+tools = ["filesystem", "github", "notion", "mcp"]
+capabilities = [
+  "project.code_patterns",
+  "project.scan",
+  "runtime.dry_run",
+  "runtime.record_run",
+  "session.changed_paths",
+]
+autonomy_tier = "suggest"
+receipt_policy = "required"
+triggers = ["repo.initialized", "deps.changed", "directory_metadata.stale"]
+schedules = ["0 9 * * 1"]
+handoffs = ["ship_captain"]
+context_packs = ["repo_policy", "review_policy"]
+evals = ["predicate_false_positive_rate", "predicate_coverage"]
+owner = "platform"
+budget = { daily_usd = 5.0, frontier_escalations = 1, max_tokens = 40000, max_runtime_seconds = 600 }
+model_policy = { default_model = "gpt-5.4-mini", escalation_model = "gpt-5.4", fallback_models = ["gpt-5.2"], reasoning_effort = "medium" }
+rollout_policy = { mode = "approval_only", percentage = 100, cohorts = ["flow-phase-0"] }
+package_source = { package = "harn-flow-personas", path = "examples/personas" }
+
+[[personas]]
+name = "fixer"
+version = "0.1.0"
+description = "Flow remediation persona that consumes blocked invariant remediation and proposes follow-up slices."
+entry_workflow = "workflows/flow_fixer.harn#run"
+tools = ["filesystem", "github", "ci", "mcp"]
+capabilities = [
+  "workspace.read_text",
+  "workspace.write_text",
+  "workspace.apply_edit",
+  "git.get_diff",
+  "project.test_commands",
+  "runtime.approved_plan",
+  "runtime.dry_run",
+  "runtime.record_run",
+]
+autonomy_tier = "act_with_approval"
+receipt_policy = "required"
+triggers = ["invariant.blocked_with_remediation"]
+schedules = ["*/30 * * * *"]
+handoffs = ["ship_captain"]
+context_packs = ["repo_policy", "review_policy"]
+evals = ["remediation_slice_smoke"]
+owner = "platform"
+budget = { daily_usd = 6.0, frontier_escalations = 1, max_tokens = 50000, max_runtime_seconds = 600 }
+model_policy = { default_model = "gpt-5.4-mini", escalation_model = "gpt-5.4", fallback_models = ["gpt-5.2"], reasoning_effort = "medium" }
+rollout_policy = { mode = "approval_only", percentage = 100, cohorts = ["flow-phase-0"] }
+package_source = { package = "harn-flow-personas", path = "examples/personas" }

--- a/examples/personas/workflows/flow_archivist.harn
+++ b/examples/personas/workflows/flow_archivist.harn
@@ -1,0 +1,4 @@
+/** Return the propose-only Archivist action envelope for a Flow event. */
+pub fn run(event) {
+  {persona: "archivist", mode: "propose_only", event: event, action: "emit_predicate_proposals"}
+}

--- a/examples/personas/workflows/flow_fixer.harn
+++ b/examples/personas/workflows/flow_fixer.harn
@@ -1,0 +1,4 @@
+/** Return the approval-first Fixer action envelope for a Flow remediation event. */
+pub fn run(event) {
+  {persona: "fixer", mode: "approval_first", event: event, action: "propose_remediation_slice"}
+}

--- a/examples/personas/workflows/flow_ship_captain.harn
+++ b/examples/personas/workflows/flow_ship_captain.harn
@@ -1,0 +1,4 @@
+/** Return the shadow-mode Ship Captain action envelope for a Flow event. */
+pub fn run(event) {
+  {persona: "ship_captain", mode: "shadow_pr", event: event, action: "derive_candidate_slice"}
+}


### PR DESCRIPTION
## Summary
- add Flow predicate content hashes, hierarchical stricter-child composition, and advisory replay-audit primitives
- add `harn flow replay-audit`, `harn flow ship watch`, and `harn flow archivist scan` Phase 0 command surfaces
- document the Flow predicate language decisions and add loadable Flow persona v0 manifests/workflows

Closes #582.
Closes #583.
Closes #584.
Refs #571, #585, #586, #587.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-571-target cargo test -p harn-vm flow:: --lib`
- `CARGO_TARGET_DIR=/tmp/harn-571-target cargo check -p harn-cli`
- `CARGO_TARGET_DIR=/tmp/harn-571-target cargo run -p harn-cli --quiet -- persona --manifest examples/personas/flow.harn.toml list --json`
- `CARGO_TARGET_DIR=/tmp/harn-571-target cargo run -p harn-cli --quiet -- flow replay-audit --store /tmp/harn-flow-empty.sqlite --predicate-root . --json`
- `CARGO_TARGET_DIR=/tmp/harn-571-target cargo run -p harn-cli --quiet -- flow ship watch --store /tmp/harn-flow-empty.sqlite --json`
- `CARGO_TARGET_DIR=/tmp/harn-571-target cargo run -p harn-cli --quiet -- flow archivist scan . --json`
- `CARGO_TARGET_DIR=/tmp/harn-571-target cargo run -p harn-cli --quiet -- fmt --check examples/personas/workflows/flow_ship_captain.harn examples/personas/workflows/flow_archivist.harn examples/personas/workflows/flow_fixer.harn`
- `CARGO_TARGET_DIR=/tmp/harn-571-target cargo run -p harn-cli --quiet -- check examples/personas/workflows/flow_ship_captain.harn examples/personas/workflows/flow_archivist.harn examples/personas/workflows/flow_fixer.harn`
- pre-commit hook: rustfmt, Harn fmt/lint, workspace clippy, markdownlint
- pre-push hook: 2573 nextest tests passed, Harn fmt/lint, markdownlint