### PR TITLE
Add Flow Ship Captain persona v0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ granular archaeology.
 
 ### Added
 
+- **Ship Captain persona v0 (#585).** Adds the checked-in
+  `personas/ship_captain` pack and enriches `harn flow ship watch` so the
+  Phase 0 command groups stored atoms into intents, discovers predicate gates,
+  persists a local shipping receipt, and emits an approval-gated mock PR
+  receipt with the required eval-pack hooks.
 - **Flow predicate-language design record (#584).** Added
   `docs/src/flow-predicates.md` with explicit decisions for predicate budget
   semantics, bootstrap signing, semantic predicate determinism, and

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -2002,6 +2002,20 @@ pub(crate) struct FlowShipWatchArgs {
     /// SQLite Flow store path.
     #[arg(long, value_name = "PATH", default_value = ".harn/flow.sqlite")]
     pub store: PathBuf,
+    /// Repo root used to discover current `invariants.harn` predicates.
+    #[arg(
+        long = "predicate-root",
+        alias = "root",
+        value_name = "PATH",
+        default_value = "."
+    )]
+    pub predicate_root: PathBuf,
+    /// Touched directory to resolve predicates for. Repeat for cross-directory slices.
+    #[arg(long = "touched-dir", alias = "target-dir", value_name = "PATH")]
+    pub touched_dirs: Vec<PathBuf>,
+    /// Persona id written into the Phase 0 receipt.
+    #[arg(long, value_name = "NAME", default_value = "ship_captain")]
+    pub persona: String,
     /// Write the Phase 0 mock PR receipt to this path.
     #[arg(long = "mock-pr-out", value_name = "PATH")]
     pub mock_pr_out: Option<PathBuf>,

--- a/crates/harn-cli/src/commands/flow.rs
+++ b/crates/harn-cli/src/commands/flow.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use harn_vm::flow::{SqliteFlowStore, VcsBackend};
+use harn_vm::flow::{IntentClusterer, ObservedAtom, SqliteFlowStore, VcsBackend};
 use serde_json::json;
 use time::format_description::well_known::Rfc3339;
 use time::{Date, OffsetDateTime, Time};
@@ -10,6 +10,13 @@ use time::{Date, OffsetDateTime, Time};
 use crate::cli::{
     FlowArchivistCommand, FlowArgs, FlowCommand, FlowReplayAuditArgs, FlowShipCommand,
 };
+
+const SHIP_CAPTAIN_EVAL_PACKS: [&str; 4] = [
+    "slice_quality",
+    "false_ship_rate",
+    "coverage_fidelity",
+    "latency_pr_to_merge",
+];
 
 pub(crate) fn run_flow(args: &FlowArgs) -> Result<i32, String> {
     match &args.command {
@@ -39,27 +46,12 @@ pub(crate) fn run_replay_audit(args: &FlowReplayAuditArgs) -> Result<i32, String
     })?;
 
     let chains = current_predicate_chains(&args.predicate_root, &args.touched_dirs);
-    let diagnostics = chains
-        .iter()
-        .flat_map(|chain| chain.iter())
-        .flat_map(|file| {
-            file.diagnostics
-                .iter()
-                .map(move |diagnostic| (file.path.display().to_string(), diagnostic))
-        })
-        .collect::<Vec<_>>();
-    let has_error = diagnostics.iter().any(|(_, diagnostic)| {
-        diagnostic.severity == harn_vm::flow::DiscoveryDiagnosticSeverity::Error
-    });
-    if has_error {
+    let diagnostics = discovery_diagnostics(&chains);
+    if has_discovery_error(&diagnostics) {
         return Err(render_discovery_diagnostics(&diagnostics));
     }
     if !args.json {
-        for (path, diagnostic) in diagnostics.iter().filter(|(_, diagnostic)| {
-            diagnostic.severity == harn_vm::flow::DiscoveryDiagnosticSeverity::Warning
-        }) {
-            eprintln!("warning: {path}: {}", diagnostic.message);
-        }
+        print_discovery_warnings(&diagnostics);
     }
 
     let current_predicates = harn_vm::flow::resolve_predicates_for_touched_directories(&chains);
@@ -96,11 +88,19 @@ pub(crate) fn run_replay_audit(args: &FlowReplayAuditArgs) -> Result<i32, String
 
 fn run_ship_watch(args: &crate::cli::FlowShipWatchArgs) -> Result<i32, String> {
     let store = open_store(&args.store)?;
-    let atoms = store
+    let atom_refs = store
         .list_atoms()
         .map_err(|error| format!("failed to list Flow atoms: {error}"))?;
-    if atoms.is_empty() {
-        let payload = json!({"status": "idle", "reason": "no_atoms"});
+    if atom_refs.is_empty() {
+        let payload = json!({
+            "status": "idle",
+            "reason": "no_atoms",
+            "persona": args.persona,
+            "phase": "phase_0",
+            "mode": "shadow",
+            "autonomy": "propose_with_approval",
+            "receipts_required": true,
+        });
         print_payload(
             args.json,
             "Ship Captain idle: no atoms in the Flow store.",
@@ -109,18 +109,115 @@ fn run_ship_watch(args: &crate::cli::FlowShipWatchArgs) -> Result<i32, String> {
         return Ok(0);
     }
 
-    let atom_ids: Vec<_> = atoms.iter().map(|atom| atom.atom_id).collect();
+    let atoms = atom_refs
+        .iter()
+        .map(|atom_ref| {
+            store
+                .get_atom(atom_ref.atom_id)
+                .map_err(|error| format!("failed to load atom {}: {error}", atom_ref.atom_id))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let intents = IntentClusterer::default().cluster(
+        atoms
+            .iter()
+            .enumerate()
+            .map(|(index, atom)| ObservedAtom::from_atom(atom, (index + 1) as u64)),
+    );
+    let intent_payload = intents
+        .iter()
+        .map(|intent| {
+            json!({
+                "id": intent.id,
+                "goal_description": intent.goal_description,
+                "atoms": intent.atoms,
+                "confidence": intent.confidence,
+                "origin_transcript_span": intent.origin_transcript_span,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let chains = current_predicate_chains(&args.predicate_root, &args.touched_dirs);
+    let diagnostics = discovery_diagnostics(&chains);
+    if has_discovery_error(&diagnostics) {
+        return Err(render_discovery_diagnostics(&diagnostics));
+    }
+    if !args.json {
+        print_discovery_warnings(&diagnostics);
+    }
+    let predicates = harn_vm::flow::resolve_predicates_for_touched_directories(&chains);
+    let predicate_payload = predicates
+        .iter()
+        .map(|predicate| {
+            json!({
+                "qualified_name": predicate.qualified_name,
+                "logical_name": predicate.logical_name,
+                "hash": predicate.predicate.source_hash,
+                "kind": predicate.predicate.kind,
+                "relative_dir": predicate.source.relative_dir,
+                "retroactive": predicate.predicate.retroactive,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let atom_ids: Vec<_> = atom_refs.iter().map(|atom| atom.atom_id).collect();
     let slice = store
         .derive_slice(&atom_ids)
         .map_err(|error| format!("failed to derive candidate slice: {error}"))?;
+    let ship_receipt = store
+        .ship_slice(&slice)
+        .map_err(|error| format!("failed to persist Ship Captain receipt: {error}"))?;
+    let created_at = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .map_err(|error| format!("failed to format receipt timestamp: {error}"))?;
+    let mock_pr = json!({
+        "number": 0,
+        "state": "open",
+        "url": format!("mock://github/pull/{}", slice.id),
+        "title": format!("Flow slice {}", slice.id),
+        "body": format!(
+            "Shadow-mode Ship Captain candidate slice.\n\nAtoms: {}\nIntents: {}\nPredicates discovered: {}\n\nNo remote PR was opened.",
+            slice.atoms.len(),
+            intents.len(),
+            predicates.len(),
+        ),
+        "requires_approval": true,
+    });
     let payload = json!({
-        "status": "candidate_slice",
-        "slice_id": slice.id,
-        "atoms": slice.atoms,
-        "mock_pr": {
-            "title": format!("Flow slice {}", slice.id),
-            "body": "Shadow-mode Ship Captain candidate slice. No remote PR was opened.",
+        "status": "mock_pr_opened",
+        "persona": args.persona,
+        "phase": "phase_0",
+        "mode": "shadow",
+        "autonomy": "propose_with_approval",
+        "receipts_required": true,
+        "created_at": created_at,
+        "slice": {
+            "id": slice.id,
+            "atoms": slice.atoms,
+            "atom_count": slice.atoms.len(),
         },
+        "intents": intent_payload,
+        "predicate_validation": {
+            "predicate_root": args.predicate_root,
+            "touched_dirs": if args.touched_dirs.is_empty() {
+                vec![PathBuf::from(".")]
+            } else {
+                args.touched_dirs.clone()
+            },
+            "status": "ok",
+            "predicates": predicate_payload,
+            "diagnostics": diagnostics.iter().map(|(path, diagnostic)| json!({
+                "path": path,
+                "severity": discovery_severity_label(diagnostic.severity),
+                "message": diagnostic.message,
+            })).collect::<Vec<_>>(),
+        },
+        "ship_receipt": {
+            "slice_id": ship_receipt.slice_id,
+            "commit": ship_receipt.commit,
+            "ref_name": ship_receipt.ref_name,
+        },
+        "mock_pr": mock_pr,
+        "eval_packs": SHIP_CAPTAIN_EVAL_PACKS,
     });
 
     if let Some(path) = &args.mock_pr_out {
@@ -129,10 +226,17 @@ fn run_ship_watch(args: &crate::cli::FlowShipWatchArgs) -> Result<i32, String> {
     }
     print_payload(
         args.json,
-        &format!("candidate slice {}", slice.id),
+        &format!("mock PR opened for candidate slice {}", slice.id),
         &payload,
     );
     Ok(0)
+}
+
+fn discovery_severity_label(severity: harn_vm::flow::DiscoveryDiagnosticSeverity) -> &'static str {
+    match severity {
+        harn_vm::flow::DiscoveryDiagnosticSeverity::Warning => "warning",
+        harn_vm::flow::DiscoveryDiagnosticSeverity::Error => "error",
+    }
 }
 
 fn run_archivist_scan(args: &crate::cli::FlowArchivistScanArgs) -> Result<i32, String> {
@@ -304,6 +408,34 @@ fn print_human_report(
                 println!("    - {}", hash.as_str());
             }
         }
+    }
+}
+
+fn discovery_diagnostics(
+    chains: &[Vec<harn_vm::flow::DiscoveredInvariantFile>],
+) -> Vec<(String, &harn_vm::flow::DiscoveryDiagnostic)> {
+    chains
+        .iter()
+        .flat_map(|chain| chain.iter())
+        .flat_map(|file| {
+            file.diagnostics
+                .iter()
+                .map(move |diagnostic| (file.path.display().to_string(), diagnostic))
+        })
+        .collect()
+}
+
+fn has_discovery_error(diagnostics: &[(String, &harn_vm::flow::DiscoveryDiagnostic)]) -> bool {
+    diagnostics.iter().any(|(_, diagnostic)| {
+        diagnostic.severity == harn_vm::flow::DiscoveryDiagnosticSeverity::Error
+    })
+}
+
+fn print_discovery_warnings(diagnostics: &[(String, &harn_vm::flow::DiscoveryDiagnostic)]) {
+    for (path, diagnostic) in diagnostics.iter().filter(|(_, diagnostic)| {
+        diagnostic.severity == harn_vm::flow::DiscoveryDiagnosticSeverity::Warning
+    }) {
+        eprintln!("warning: {path}: {}", diagnostic.message);
     }
 }
 

--- a/crates/harn-cli/tests/flow_ship_cli.rs
+++ b/crates/harn-cli/tests/flow_ship_cli.rs
@@ -1,0 +1,133 @@
+use std::fs;
+use std::process::Command;
+
+use ed25519_dalek::SigningKey;
+use harn_vm::flow::{Atom, AtomId, Provenance, SqliteFlowStore, TextOp, VcsBackend};
+use tempfile::TempDir;
+use time::OffsetDateTime;
+
+fn key(seed: u8) -> SigningKey {
+    SigningKey::from_bytes(&[seed; 32])
+}
+
+fn atom(index: u64, parents: Vec<AtomId>) -> Atom {
+    let principal = key(1);
+    let persona = key(2);
+    Atom::sign(
+        vec![TextOp::Insert {
+            offset: index,
+            content: format!("atom-{index}\n"),
+        }],
+        parents,
+        Provenance {
+            principal: "user:alice".to_string(),
+            persona: "ship_captain".to_string(),
+            agent_run_id: "run-flow-demo".to_string(),
+            tool_call_id: Some(format!("tool-{index}")),
+            trace_id: "trace-flow-demo".to_string(),
+            transcript_ref: "transcript-flow-demo".to_string(),
+            timestamp: OffsetDateTime::from_unix_timestamp(1_777_200_000 + index as i64).unwrap(),
+        },
+        None,
+        &principal,
+        &persona,
+    )
+    .unwrap()
+}
+
+fn demo_repo() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    fs::create_dir_all(temp.path().join(".harn")).unwrap();
+    fs::write(
+        temp.path().join("invariants.harn"),
+        r#"
+@invariant
+@deterministic
+@archivist(
+  evidence: ["https://github.com/burin-labs/harn/issues/585"],
+  confidence: 0.9,
+  source_date: "2026-04-26",
+  coverage_examples: ["flow-demo"]
+)
+fn phase_zero_demo(slice) {
+  return flow_invariant_allow()
+}
+"#,
+    )
+    .unwrap();
+    temp
+}
+
+#[test]
+fn flow_ship_watch_injects_atoms_and_opens_mock_pr() {
+    let repo = demo_repo();
+    let store_path = repo.path().join(".harn/flow.sqlite");
+    let store = SqliteFlowStore::open(&store_path, "flow-demo").unwrap();
+    let mut atoms = Vec::new();
+    for index in 0..10 {
+        let parents = atoms
+            .last()
+            .map(|atom: &Atom| vec![atom.id])
+            .unwrap_or_default();
+        atoms.push(atom(index, parents));
+    }
+    for atom in &atoms {
+        store.emit_atom(atom).unwrap();
+    }
+    drop(store);
+
+    let mock_pr_path = repo.path().join(".harn/flow/mock-pr.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(repo.path())
+        .args([
+            "flow",
+            "ship",
+            "watch",
+            "--store",
+            store_path.to_str().unwrap(),
+            "--mock-pr-out",
+            mock_pr_path.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout_payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let file_payload: serde_json::Value =
+        serde_json::from_slice(&fs::read(&mock_pr_path).unwrap()).unwrap();
+    assert_eq!(stdout_payload, file_payload);
+    assert_eq!(file_payload["status"], "mock_pr_opened");
+    assert_eq!(file_payload["persona"], "ship_captain");
+    assert_eq!(file_payload["autonomy"], "propose_with_approval");
+    assert_eq!(file_payload["slice"]["atom_count"], 10);
+    assert_eq!(file_payload["slice"]["atoms"].as_array().unwrap().len(), 10);
+    assert_eq!(file_payload["intents"].as_array().unwrap().len(), 1);
+    assert_eq!(file_payload["mock_pr"]["state"], "open");
+    assert_eq!(file_payload["mock_pr"]["requires_approval"], true);
+    assert_eq!(
+        file_payload["predicate_validation"]["predicates"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        file_payload["eval_packs"].as_array().unwrap(),
+        &[
+            serde_json::json!("slice_quality"),
+            serde_json::json!("false_ship_rate"),
+            serde_json::json!("coverage_fidelity"),
+            serde_json::json!("latency_pr_to_merge"),
+        ]
+    );
+    assert!(file_payload["ship_receipt"]["ref_name"]
+        .as_str()
+        .unwrap()
+        .starts_with("sqlite://slices/"));
+}

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -224,6 +224,36 @@ fn persona_manifest_flag_loads_fixer_persona() {
 }
 
 #[test]
+fn persona_manifest_flag_loads_ship_captain_persona() {
+    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .args([
+            "persona",
+            "--manifest",
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../personas/ship_captain/harn.toml"
+            ),
+            "inspect",
+            "ship_captain",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let persona: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(persona["name"], "ship_captain");
+    assert_eq!(persona["triggers"][0], "flow.atom_stream_updated");
+    assert_eq!(persona["entry_workflow"], "manifest.harn#run");
+    assert_eq!(persona["receipt_policy"], "required");
+    assert_eq!(persona["evals"][0], "slice_quality");
+}
+
+#[test]
 fn persona_runtime_status_tick_and_budget_are_persisted() {
     let temp = write_manifest(valid_manifest());
     let state_dir = temp.path().join(".harn-personas-test");

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -146,7 +146,8 @@ Inspect and operate the Flow shipping substrate.
 ```bash
 harn flow replay-audit --store .harn/flow.sqlite --predicate-root . --touched-dir crates/harn-vm
 harn flow replay-audit --since 2026-04-26 --fail-on-drift --json
-harn flow ship watch --store .harn/flow.sqlite --mock-pr-out .harn/flow/mock-pr.json --json
+harn flow ship watch --store .harn/flow.sqlite --predicate-root . \
+  --touched-dir crates/harn-vm --mock-pr-out .harn/flow/mock-pr.json --json
 harn flow archivist scan . --out .harn/flow/archivist-proposals.json --json
 ```
 
@@ -154,9 +155,11 @@ harn flow archivist scan . --out .harn/flow/archivist-proposals.json --json
 current `invariants.harn` predicate set. Drift is advisory unless
 `--fail-on-drift` is present.
 
-`ship watch` is the Phase 0 Ship Captain shadow-mode surface. It derives a
-candidate slice from stored atoms and can write a mock PR receipt without
-touching a remote GitHub repository.
+`ship watch` is the Phase 0 Ship Captain shadow-mode surface. It groups stored
+atoms into intent summaries, derives a candidate slice, discovers applicable
+`invariants.harn` predicates for the touched directories, persists a local
+shipping receipt, and can write a mock PR receipt without touching a remote
+GitHub repository.
 
 `archivist scan` emits review-ready predicate proposal metadata from the repo's
 stack hints and existing Flow predicates. It is propose-only; it does not edit

--- a/docs/src/personas.md
+++ b/docs/src/personas.md
@@ -162,6 +162,18 @@ The pack is intentionally conservative:
 Treat these as code and policy that your team forks and edits. They are not
 opaque hosted behavior.
 
+Flow persona packs live under `personas/`:
+
+- `personas/ship_captain`: Phase 0 shadow-mode PR emitter for Flow slices.
+- `personas/fixer`: consumes inert predicate remediation and proposes follow-up
+  slices.
+
+Ship Captain can be inspected with:
+
+```bash
+harn persona --manifest personas/ship_captain/harn.toml inspect ship_captain --json
+```
+
 ## Current v1 gaps
 
 Persona manifest v1 is a contract and runtime-control surface, not a managed

--- a/personas/ship_captain/README.md
+++ b/personas/ship_captain/README.md
@@ -1,0 +1,16 @@
+# Ship Captain Persona
+
+Ship Captain is the Phase 0 Harn Flow persona. It watches stored Flow atoms,
+groups them into intent summaries, derives a candidate slice, validates the
+repo's invariant discovery surface, and emits an approval-gated mock PR receipt.
+
+The v0 workflow is intentionally shadow-mode. It writes local receipts through
+`harn flow ship watch` and does not open a remote GitHub PR.
+
+Validate locally:
+
+```bash
+harn persona --manifest personas/ship_captain/harn.toml inspect ship_captain --json
+harn check personas/ship_captain/manifest.harn
+harn flow ship watch --store .harn/flow.sqlite --mock-pr-out .harn/flow/mock-pr.json --json
+```

--- a/personas/ship_captain/harn.toml
+++ b/personas/ship_captain/harn.toml
@@ -1,0 +1,31 @@
+[package]
+name = "harn-ship-captain-persona"
+version = "0.1.0"
+
+[[personas]]
+name = "ship_captain"
+version = "0.1.0"
+description = "Watches Flow atoms, groups intents, derives candidate slices, and emits approval-gated Phase 0 mock PR receipts."
+entry_workflow = "manifest.harn#run"
+tools = ["github", "mcp"]
+capabilities = [
+  "git.get_diff",
+  "project.scan",
+  "project.scope_test_command",
+  "project.test_commands",
+  "runtime.approved_plan",
+  "runtime.dry_run",
+  "runtime.record_run",
+]
+autonomy_tier = "act_with_approval"
+receipt_policy = "required"
+triggers = ["flow.atom_stream_updated", "flow.slice_candidate_requested"]
+schedules = ["*/15 * * * *"]
+handoffs = []
+context_packs = ["flow_substrate", "repo_policy", "predicate_receipts"]
+evals = ["slice_quality", "false_ship_rate", "coverage_fidelity", "latency_pr_to_merge"]
+owner = "platform"
+budget = { daily_usd = 6.0, frontier_escalations = 1, max_tokens = 50000, max_runtime_seconds = 300 }
+model_policy = { default_model = "gpt-5.4-mini", escalation_model = "gpt-5.4", fallback_models = ["gpt-5.2"], reasoning_effort = "medium" }
+rollout_policy = { mode = "approval_only", percentage = 100, cohorts = ["flow-phase-0"] }
+package_source = { package = "harn-ship-captain-persona", path = "personas/ship_captain" }

--- a/personas/ship_captain/manifest.harn
+++ b/personas/ship_captain/manifest.harn
@@ -1,0 +1,43 @@
+fn ship_captain_manifest() {
+  return {
+    name: "ship_captain",
+    version: "0.1.0",
+    trigger: "flow.atom_stream_updated",
+    autonomy_tier: "act_with_approval",
+    phase: "phase_0",
+    mode: "shadow",
+    behavior: [
+    "Watch the Flow atom stream without mutating user history.",
+    "Group nearby atoms into intents using agent run and transcript boundaries.",
+    "Derive a coherent candidate slice from the selected atom closure.",
+    "Discover applicable invariants and surface diagnostics in the receipt.",
+    "Emit an approval-gated mock PR receipt instead of opening a remote PR.",
+    "Record enough receipt data to evaluate slice quality and merge latency.",
+  ],
+    handoffs: [
+    "archivist: propose predicate updates when invariant coverage is thin.",
+    "fixer: propose follow-up atoms when predicate remediation is available.",
+    "human_maintainer: approve Phase 0 mock PRs before any side effect.",
+  ],
+    evals: ["slice_quality", "false_ship_rate", "coverage_fidelity", "latency_pr_to_merge"],
+    receipts: {
+    required: true,
+    fields: ["persona", "slice.id", "slice.atoms", "intents", "predicate_validation", "ship_receipt", "mock_pr"],
+  },
+    required_capabilities: [
+    "git.get_diff",
+    "project.scan",
+    "project.scope_test_command",
+    "project.test_commands",
+    "runtime.approved_plan",
+    "runtime.dry_run",
+    "runtime.record_run",
+  ],
+  }
+}
+
+pipeline run(task) {
+  let manifest = ship_captain_manifest()
+  println(json_stringify(manifest))
+  return manifest
+}


### PR DESCRIPTION
## Summary
- add the checked-in `personas/ship_captain` persona pack with manifest, package metadata, receipt requirements, handoffs, evals, and README
- enrich `harn flow ship watch` to group stored atoms into intent summaries, discover applicable Flow predicates, persist a local ship receipt, and emit approval-gated mock PR JSON
- add CLI integration coverage for the 10-atom Phase 0 demo path and Ship Captain manifest loading

Closes #585.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-issue-585-target cargo test -p harn-cli --test flow_ship_cli --test persona_cli`
- `CARGO_TARGET_DIR=/tmp/harn-issue-585-target cargo test -p harn-cli commands::flow::tests::parse_since_accepts_rfc3339_unix_and_date`
- `CARGO_TARGET_DIR=/tmp/harn-issue-585-target cargo check -p harn-cli`
- `/tmp/harn-issue-585-target/debug/harn persona --manifest personas/ship_captain/harn.toml inspect ship_captain --json`
- `/tmp/harn-issue-585-target/debug/harn check personas/ship_captain/manifest.harn`
- pre-commit hook: staged Harn format/lint, workspace clippy, markdown lint
- pre-push hook: 2601 nextest tests, affected Harn lint/format, markdown lint
