### PR TITLE
Release v0.7.43

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -18,6 +18,7 @@
     "node_modules",
     "**/node_modules",
     "target",
+    "docs/dist",
     ".burin",
     ".claude",
     "docs/src/SUMMARY.md",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ granular archaeology.
   with the current `invariants.harn` set, while `harn flow ship watch` and
   `harn flow archivist scan` provide the Phase 0 Ship Captain and Archivist
   command surfaces for shadow-mode workflows.
+- **Flow `InvariantResult` graded-verdict types and Harn bindings (#581).**
+  Predicates now return a structured `InvariantResult { verdict, evidence,
+  remediation, confidence }` value where `verdict` grades as `Allow`, `Warn`,
+  `Block`, or `RequireApproval` (routing to a specific `Principal` or
+  `Role`). Evidence items cover `AtomPointer`, `MetadataPath`,
+  `TranscriptExcerpt`, and `ExternalCitation`. Matching Harn-side builtins let
+  `.harn` predicates produce these values idiomatically.
 - **First-class worker lifecycle events on ACP and A2A (#703).** Adds
   two new typed `WorkerEvent` variants (`WorkerProgressed`,
   `WorkerWaitingForInput`) and surfaces every worker lifecycle
@@ -96,38 +103,6 @@ granular archaeology.
   block on hover so the function declaration stays the single source of
   truth. Attribute argument syntax also accepts list literals and
   multi-line forms so provenance blocks can carry rich evidence.
-
-## Unreleased
-
-### Added
-
-- **Flow hierarchical predicate composition (#582).** Adds
-  `crates/harn-vm/src/flow/predicates/compose.rs` with depth-stamped
-  predicate resolution, touched-directory union, and strictness-based result
-  composition. Ancestor and child declarations are evaluated together so a
-  child can tighten an ancestor verdict, but cannot relax a shallower `Block`;
-  equal-severity ties keep the shallower predicate canonical.
-- **Flow predicate hash replay audit (#583).** `invariants.harn`
-  discovery now pins a `sha256:` source hash for every Flow predicate,
-  shipped derived slices can be queried from the SQLite Flow store
-  without mutating history, and slice tables now reject direct
-  update/delete attempts at the SQLite boundary. The new
-  `harn flow replay-audit --since <date>` command compares shipped
-  slice predicate hashes against the current `@retroactive` predicate
-  set, reports advisory drift in human or JSON form, and exits non-zero
-  only when `--fail-on-drift` is requested.
-- **Flow `InvariantResult` graded-verdict types and Harn bindings (#581).**
-  Predicates now return a structured `InvariantResult { verdict, evidence,
-  remediation, confidence }` value where `verdict` grades as `Allow`, `Warn`,
-  `Block`, or `RequireApproval` (routing to a specific `Principal` or
-  `Role`). Evidence items cover `AtomPointer`, `MetadataPath`,
-  `TranscriptExcerpt`, and `ExternalCitation`. The Rust types live in
-  `crates/harn-vm/src/flow/predicates/result.rs`; matching Harn-side
-  builtins (`flow_invariant_allow`/`warn`/`block`/`require_approval`,
-  `flow_evidence_*`, `flow_remediation`, `flow_with_*`,
-  `flow_invariant_kind`/`is_blocking`/`confidence`) let `.harn` predicates
-  produce these values idiomatically. Remediations are inert and earmarked
-  for the future Fixer persona (#587).
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.42"
+version = "0.7.43"
 dependencies = [
  "async-trait",
  "axum",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.42"
+version = "0.7.43"
 dependencies = [
  "harn-vm",
  "serde",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.42"
+version = "0.7.43"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.42"
+version = "0.7.43"
 dependencies = [
  "anyhow",
  "base64",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.42"
+version = "0.7.43"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1740,11 +1740,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.42"
+version = "0.7.43"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.42"
+version = "0.7.43"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.42"
+version = "0.7.43"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.42"
+version = "0.7.43"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.42"
+version = "0.7.43"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.42"
+version = "0.7.43"
 dependencies = [
  "async-trait",
  "axum",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "harn-vm"
-version = "0.7.42"
+version = "0.7.43"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.42"
+version = "0.7.43"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ lint-actions:
 lint-harn:
 	@echo "=== Linting Harn conformance tests ==="
 	@cargo build --quiet --bin harn
-	@workers=$$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 8); \
+	@harn_bin=$$(cargo metadata --format-version=1 --no-deps | python3 -c 'import json,sys; meta=json.load(sys.stdin); suffix=".exe" if sys.platform == "win32" else ""; print(meta["target_directory"] + "/debug/harn" + suffix)'); \
+	workers=$$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 8); \
 	tmp=$$(mktemp -d); \
 	status=0; \
 	find conformance/tests -name '*.harn' -print0 | while IFS= read -r -d '' f; do \
@@ -86,11 +87,11 @@ lint-harn:
 		printf '%s\0' "$$f"; \
 	done | \
 		TMP_RESULTS="$$tmp" xargs -0 -P "$$workers" -I{} sh -c '\
-			output=$$(target/debug/harn check "$$1" 2>&1); \
+			output=$$("$$0" check "$$1" 2>&1); \
 			if echo "$$output" | grep -qE "^.+: (warning|error)\["; then \
 				printf "%s\n" "$$output" | grep -v ": ok$$" > "$$TMP_RESULTS/$$(basename "$$1").out"; \
 				exit 1; \
-			fi' sh {} || status=$$?; \
+			fi' "$$harn_bin" {} || status=$$?; \
 	if ls "$$tmp"/*.out >/dev/null 2>&1; then \
 		cat "$$tmp"/*.out; \
 	fi; \

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -178,8 +178,8 @@ cmd_audit() {
   # Serial warm prebuild before spawning the parallel lanes. The 3
   # cargo-using lanes (rust-audit runs clippy + nextest; harn-audit
   # runs `cargo build --bin harn` via `make lint-harn` and `cargo run`
-  # via conformance/fmt-harn; grammar-audit shells `target/debug/harn`
-  # via verify_language_spec.py) otherwise race for the same
+  # via conformance/fmt-harn; grammar-audit shells the active Cargo
+  # target-dir harn binary via verify_language_spec.py) otherwise race for the same
   # `.cargo-lock` and repeatedly invalidate each other's incremental
   # artifacts. Historically the harn lint phase alone stretched to
   # ~12 min cold because it was waiting on the shared target dir

--- a/scripts/render_release_notes.py
+++ b/scripts/render_release_notes.py
@@ -37,7 +37,7 @@ def changelog_versions(changelog: str) -> list[str]:
 
 def extract_section(changelog: str, version: str) -> str:
     match = re.search(
-        rf"(?ms)^## v{re.escape(version)}\n(.*?)(?=^## v|\Z)",
+        rf"(?ms)^## v{re.escape(version)}\n(.*?)(?=^## |\Z)",
         changelog,
     )
     if not match:

--- a/scripts/verify_language_spec.py
+++ b/scripts/verify_language_spec.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import json
 import re
 import shutil
 import subprocess
@@ -78,10 +79,26 @@ def should_skip_snippet(snippet: str) -> bool:
 
 
 def harn_check_command() -> list[str]:
-    debug_binary = ROOT / "target" / "debug" / "harn"
+    override = os.environ.get("HARN_CHECK_BIN")
+    if override:
+        return [override, "check"]
+
+    metadata = subprocess.run(
+        ["cargo", "metadata", "--format-version=1", "--no-deps"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    if metadata.returncode == 0:
+        target_dir = Path(json.loads(metadata.stdout)["target_directory"])
+        binary_name = "harn.exe" if sys.platform == "win32" else "harn"
+        debug_binary = target_dir / "debug" / binary_name
+    else:
+        debug_binary = ROOT / "target" / "debug" / "harn"
+
     if debug_binary.exists() and os.access(debug_binary, os.X_OK):
         return [str(debug_binary), "check"]
-    return ["cargo", "run", "-q", "-p", "harn-cli", "--", "check"]
+    return ["cargo", "run", "--quiet", "--bin", "harn", "--", "check"]
 
 
 def main() -> int:

--- a/scripts/verify_release_metadata.py
+++ b/scripts/verify_release_metadata.py
@@ -29,7 +29,7 @@ def changelog_section_body(version: str) -> str:
     """Return the body content under `## vX.Y.Z` up to the next heading."""
     text = CHANGELOG.read_text()
     match = re.search(
-        rf"(?ms)^## v{re.escape(version)}\n(.*?)(?=^## v|\Z)",
+        rf"(?ms)^## v{re.escape(version)}\n(.*?)(?=^## |\Z)",
         text,
     )
     return match.group(1).strip() if match else ""

--- a/tree-sitter-harn/grammar.js
+++ b/tree-sitter-harn/grammar.js
@@ -97,6 +97,8 @@ module.exports = grammar({
         $.true,
         $.false,
         $.nil,
+        $.list_literal,
+        $.dict_literal,
         $.identifier
       ),
 

--- a/tree-sitter-harn/src/grammar.json
+++ b/tree-sitter-harn/src/grammar.json
@@ -386,6 +386,14 @@
         },
         {
           "type": "SYMBOL",
+          "name": "list_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "dict_literal"
+        },
+        {
+          "type": "SYMBOL",
           "name": "identifier"
         }
       ]

--- a/tree-sitter-harn/src/node-types.json
+++ b/tree-sitter-harn/src/node-types.json
@@ -423,6 +423,10 @@
         "required": false,
         "types": [
           {
+            "type": "dict_literal",
+            "named": true
+          },
+          {
             "type": "false",
             "named": true
           },
@@ -436,6 +440,10 @@
           },
           {
             "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "list_literal",
             "named": true
           },
           {
@@ -462,6 +470,10 @@
       "required": false,
       "types": [
         {
+          "type": "dict_literal",
+          "named": true
+        },
+        {
           "type": "false",
           "named": true
         },
@@ -475,6 +487,10 @@
         },
         {
           "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "list_literal",
           "named": true
         },
         {

--- a/tree-sitter-harn/test/corpus/attributes.txt
+++ b/tree-sitter-harn/test/corpus/attributes.txt
@@ -1,0 +1,44 @@
+==================
+Attribute Literal Values
+==================
+
+@invariant
+@deterministic
+@archivist(evidence: ["https://example.com/spec"], confidence: 0.95, metadata: {source: "design"})
+fn no_secrets(slice) -> bool {
+  return true
+}
+
+---
+
+(source_file
+  (attributed_declaration
+    (attribute
+      name: (identifier))
+    (attribute
+      name: (identifier))
+    (attribute
+      name: (identifier)
+      (attribute_arg
+        name: (identifier)
+        value: (list_literal
+          (string_literal)))
+      (attribute_arg
+        name: (identifier)
+        value: (float_literal))
+      (attribute_arg
+        name: (identifier)
+        value: (dict_literal
+          (dict_entry
+            key: (identifier)
+            value: (string_literal)))))
+    (fn_declaration
+      name: (identifier)
+      (parameter_list
+        (typed_parameter
+          name: (identifier)))
+      (type_annotation
+        (identifier))
+      body: (block
+        (return_statement
+          (true))))))


### PR DESCRIPTION
## Release v0.7.43

This release PR was prepared with the Harn release workflow after reviewing the full delta since v0.7.42.

Local validation completed:
- `./scripts/release_ship.sh --prepare --bump patch`
- Full release audit lanes: rust, harn, docs, grammar, security, package
- Publish dry-run
- Pre-push release-quality checks: 2,599 tests passed, markdown lint passed

Release-hardening fixes included in this PR:
- Keep release-note rendering and metadata verification from leaking `## Unreleased` content into a versioned release section.
- Resolve the active Cargo target-dir `harn` binary in language spec / Harn lint checks, so per-worktree target directories do not accidentally use stale `target/debug/harn` binaries.
- Exclude generated `docs/dist` Markdown shims from markdownlint.
- Teach tree-sitter attributes to parse list/dict literal values used by Flow annotations.
