### PR TITLE
Implement Flow Archivist proposal scan

### DIFF
--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -2041,6 +2041,15 @@ pub(crate) struct FlowArchivistScanArgs {
     /// Repo root to scan.
     #[arg(value_name = "REPO", default_value = ".")]
     pub repo: PathBuf,
+    /// Optional persona manifest to validate. Defaults to repo-local Flow persona manifests when present.
+    #[arg(long, value_name = "PATH")]
+    pub manifest: Option<PathBuf>,
+    /// SQLite Flow store path used for shadow evaluation.
+    #[arg(long, value_name = "PATH", default_value = ".harn/flow.sqlite")]
+    pub store: PathBuf,
+    /// Number of recent atom days to include in shadow evaluation.
+    #[arg(long = "shadow-days", value_name = "DAYS", default_value_t = 30)]
+    pub shadow_days: u32,
     /// Write the proposal JSON to this path.
     #[arg(long, value_name = "PATH")]
     pub out: Option<PathBuf>,
@@ -2411,11 +2420,11 @@ mod tests {
     use std::time::Duration as StdDuration;
 
     use super::{
-        Cli, Command, ConnectCommand, FlowCommand, McpCommand, OrchestratorCommand,
-        OrchestratorDeployProvider, OrchestratorLogFormat, OrchestratorQueueCommand,
-        OrchestratorTenantCommand, PackageCacheCommand, PackageCommand, ProjectTemplate,
-        RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand, TraceCommand,
-        TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
+        Cli, Command, ConnectCommand, FlowArchivistCommand, FlowCommand, McpCommand,
+        OrchestratorCommand, OrchestratorDeployProvider, OrchestratorLogFormat,
+        OrchestratorQueueCommand, OrchestratorTenantCommand, PackageCacheCommand, PackageCommand,
+        ProjectTemplate, RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand,
+        SkillsCommand, TraceCommand, TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
     };
     use clap::Parser;
 
@@ -2856,6 +2865,46 @@ mod tests {
         assert_eq!(audit.since.as_deref(), Some("2026-04-26"));
         assert!(audit.fail_on_drift);
         assert!(audit.json);
+    }
+
+    #[test]
+    fn test_parses_flow_archivist_scan_flags() {
+        let cli = Cli::parse_from([
+            "harn",
+            "flow",
+            "archivist",
+            "scan",
+            ".",
+            "--manifest",
+            "examples/personas/flow.harn.toml",
+            "--store",
+            ".harn/flow.sqlite",
+            "--shadow-days",
+            "14",
+            "--out",
+            ".harn/archivist/proposals.json",
+            "--json",
+        ]);
+
+        let Command::Flow(args) = cli.command.unwrap() else {
+            panic!("expected flow command");
+        };
+        let FlowCommand::Archivist(archivist) = args.command else {
+            panic!("expected archivist command");
+        };
+        let FlowArchivistCommand::Scan(scan) = archivist.command;
+        assert_eq!(scan.repo, PathBuf::from("."));
+        assert_eq!(
+            scan.manifest,
+            Some(PathBuf::from("examples/personas/flow.harn.toml"))
+        );
+        assert_eq!(scan.store, PathBuf::from(".harn/flow.sqlite"));
+        assert_eq!(scan.shadow_days, 14);
+        assert_eq!(
+            scan.out,
+            Some(PathBuf::from(".harn/archivist/proposals.json"))
+        );
+        assert!(scan.json);
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/flow.rs
+++ b/crates/harn-cli/src/commands/flow.rs
@@ -1,11 +1,14 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
-use harn_vm::flow::{IntentClusterer, ObservedAtom, SqliteFlowStore, VcsBackend};
+use harn_vm::flow::{IntentClusterer, ObservedAtom, SqliteFlowStore, TextOp, VcsBackend};
+use serde::ser::SerializeStruct;
+use serde::Serialize;
 use serde_json::json;
 use time::format_description::well_known::Rfc3339;
-use time::{Date, OffsetDateTime, Time};
+use time::{Date, Duration, OffsetDateTime, Time};
 
 use crate::cli::{
     FlowArchivistCommand, FlowArgs, FlowCommand, FlowReplayAuditArgs, FlowShipCommand,
@@ -240,13 +243,29 @@ fn discovery_severity_label(severity: harn_vm::flow::DiscoveryDiagnosticSeverity
 }
 
 fn run_archivist_scan(args: &crate::cli::FlowArchivistScanArgs) -> Result<i32, String> {
-    let stack_hints = stack_hints(&args.repo);
-    let invariant_files = find_invariant_dirs(&args.repo);
+    let repo = args
+        .repo
+        .canonicalize()
+        .unwrap_or_else(|_| args.repo.clone());
+    let source_date = OffsetDateTime::now_utc().date().to_string();
+    let inventory = inventory_repo(&repo);
+    let stack_hints = inventory.stack_hints.clone();
+    let manifest = load_archivist_manifest(&repo, args.manifest.as_deref());
+    let invariant_files = find_invariant_dirs(&repo);
     let mut seen = BTreeSet::new();
     let mut predicates = Vec::new();
+    let mut discovery_diagnostics = Vec::new();
     for dir in &invariant_files {
-        for file in harn_vm::flow::discover_invariants(&args.repo, dir) {
-            let relative_dir = file.relative_dir;
+        for file in harn_vm::flow::discover_invariants(&repo, dir) {
+            let relative_dir = file.relative_dir.clone();
+            for diagnostic in &file.diagnostics {
+                discovery_diagnostics.push(json!({
+                    "relative_dir": relative_dir,
+                    "path": file.path,
+                    "severity": format!("{:?}", diagnostic.severity).to_lowercase(),
+                    "message": diagnostic.message,
+                }));
+            }
             for predicate in file.predicates {
                 if !seen.insert(predicate.source_hash.clone()) {
                     continue;
@@ -268,13 +287,39 @@ fn run_archivist_scan(args: &crate::cli::FlowArchivistScanArgs) -> Result<i32, S
             }
         }
     }
-    let proposals = default_archivist_proposals(&stack_hints, predicates.is_empty());
+    let convention = mine_convention_signals(&repo);
+    let motion = mine_motion_signals(&repo);
+    let proposals = archivist_proposals(
+        &repo,
+        &inventory,
+        &convention,
+        &motion,
+        predicates.is_empty(),
+        &source_date,
+    );
+    let shadow_evaluation = shadow_evaluate(&repo, &args.store, args.shadow_days, &proposals)?;
     let payload = json!({
         "status": "proposal_set",
-        "repo": args.repo,
+        "persona": {
+            "name": "archivist",
+            "mode": "propose_only",
+            "autonomy": "propose_only",
+            "promotion": "human_review_required",
+        },
+        "repo": repo,
+        "manifest": manifest,
+        "inventory": inventory,
         "stack_hints": stack_hints,
+        "convention_signals": convention,
+        "motion_signals": motion,
+        "seed_library": {
+            "repository": "https://github.com/burin-labs/harn-canon",
+            "strategy": "detected-stack seeds are copied into proposals, then repo-local evidence prunes them before review",
+        },
         "existing_predicates": predicates,
+        "discovery_diagnostics": discovery_diagnostics,
         "proposals": proposals,
+        "shadow_evaluation": shadow_evaluation,
     });
 
     if let Some(path) = &args.out {
@@ -283,6 +328,698 @@ fn run_archivist_scan(args: &crate::cli::FlowArchivistScanArgs) -> Result<i32, S
     }
     print_payload(args.json, "Archivist proposal set emitted.", &payload);
     Ok(0)
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+struct RepoInventory {
+    stack_hints: Vec<&'static str>,
+    lockfiles: Vec<String>,
+    config_files: Vec<String>,
+    source_roots: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Signal {
+    kind: &'static str,
+    path: String,
+    detail: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct MotionSignal {
+    kind: &'static str,
+    count: usize,
+    examples: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+struct ArchivistProposal {
+    id: &'static str,
+    title: &'static str,
+    path: String,
+    rationale: String,
+    predicate_name: &'static str,
+    match_terms: Vec<&'static str>,
+    evidence: Vec<String>,
+    confidence: f64,
+    coverage_examples: Vec<String>,
+    source: String,
+}
+
+impl Serialize for ArchivistProposal {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut state = serializer.serialize_struct("ArchivistProposal", 11)?;
+        state.serialize_field("id", self.id)?;
+        state.serialize_field("title", self.title)?;
+        state.serialize_field("path", &self.path)?;
+        state.serialize_field("rationale", &self.rationale)?;
+        state.serialize_field("predicate_name", self.predicate_name)?;
+        state.serialize_field("autonomy", "propose_only")?;
+        state.serialize_field("promotion", "human_review_required")?;
+        state.serialize_field("evidence", &self.evidence)?;
+        state.serialize_field("confidence", &self.confidence)?;
+        state.serialize_field("coverage_examples", &self.coverage_examples)?;
+        state.serialize_field("predicate_source", &self.source)?;
+        state.end()
+    }
+}
+
+fn inventory_repo(repo: &Path) -> RepoInventory {
+    let mut inventory = RepoInventory::default();
+    let known = [
+        ("Cargo.toml", "rust", "config"),
+        ("Cargo.lock", "rust", "lockfile"),
+        ("rust-toolchain.toml", "rust", "config"),
+        ("rustfmt.toml", "rust", "config"),
+        ("clippy.toml", "rust", "config"),
+        ("package.json", "javascript", "config"),
+        ("package-lock.json", "javascript", "lockfile"),
+        ("pnpm-lock.yaml", "javascript", "lockfile"),
+        ("yarn.lock", "javascript", "lockfile"),
+        ("tsconfig.json", "typescript", "config"),
+        ("pyproject.toml", "python", "config"),
+        ("poetry.lock", "python", "lockfile"),
+        ("uv.lock", "python", "lockfile"),
+        ("go.mod", "go", "config"),
+        ("go.sum", "go", "lockfile"),
+        ("Package.swift", "swift", "config"),
+    ];
+    for (path, stack, kind) in known {
+        if repo.join(path).exists() {
+            push_unique(&mut inventory.stack_hints, stack);
+            match kind {
+                "lockfile" => inventory.lockfiles.push(path.to_string()),
+                _ => inventory.config_files.push(path.to_string()),
+            }
+        }
+    }
+    if repo.join(".github/workflows").is_dir() {
+        inventory.config_files.push(".github/workflows".to_string());
+    }
+    for root in ["crates", "src", "docs/src", "conformance/tests", "examples"] {
+        if repo.join(root).exists() {
+            inventory.source_roots.push(root.to_string());
+        }
+    }
+    inventory
+}
+
+fn push_unique(values: &mut Vec<&'static str>, value: &'static str) {
+    if !values.contains(&value) {
+        values.push(value);
+    }
+}
+
+fn load_archivist_manifest(repo: &Path, explicit: Option<&Path>) -> serde_json::Value {
+    let explicit_manifest = explicit.is_some();
+    let candidates = explicit
+        .map(|path| vec![path.to_path_buf()])
+        .unwrap_or_else(|| {
+            [
+                repo.join("harn.toml"),
+                repo.join("examples/personas/flow.harn.toml"),
+                repo.join("examples/personas/harn.toml"),
+            ]
+            .into_iter()
+            .filter(|path| path.is_file())
+            .collect()
+        });
+    let mut loaded_without_archivist = None;
+    let mut first_invalid = None;
+    for candidate in candidates {
+        match crate::package::load_personas_from_manifest_path(&candidate) {
+            Ok(catalog) => {
+                let archivist = catalog
+                    .personas
+                    .iter()
+                    .find(|persona| persona.name.as_deref() == Some("archivist"));
+                if let Some(persona) = archivist {
+                    return json!({
+                        "status": "loaded",
+                        "path": catalog.manifest_path,
+                        "persona": persona,
+                    });
+                }
+                loaded_without_archivist.get_or_insert_with(|| json!({
+                    "status": "loaded_without_archivist",
+                    "path": catalog.manifest_path,
+                    "personas": catalog.personas.iter().filter_map(|p| p.name.clone()).collect::<Vec<_>>(),
+                }));
+            }
+            Err(errors) => {
+                let invalid = json!({
+                    "status": "invalid",
+                    "path": candidate,
+                    "errors": errors.iter().map(ToString::to_string).collect::<Vec<_>>(),
+                });
+                if explicit_manifest {
+                    return invalid;
+                }
+                first_invalid.get_or_insert(invalid);
+            }
+        }
+    }
+    if let Some(loaded) = loaded_without_archivist {
+        return loaded;
+    }
+    if let Some(invalid) = first_invalid {
+        return invalid;
+    }
+    json!({
+        "status": "not_found",
+        "searched": ["harn.toml", "examples/personas/flow.harn.toml", "examples/personas/harn.toml"],
+    })
+}
+
+fn mine_convention_signals(repo: &Path) -> Vec<Signal> {
+    let mut signals = Vec::new();
+    for path in walk_repo_files(repo, 4_000) {
+        let relative = relative_path(repo, &path);
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        if matches!(
+            file_name,
+            "rustfmt.toml" | "clippy.toml" | "deny.toml" | ".markdownlint.json" | ".prettierrc"
+        ) {
+            signals.push(Signal {
+                kind: "lint_config",
+                path: relative.clone(),
+                detail: "repo-local style or lint policy".to_string(),
+            });
+        }
+        if relative.ends_with(".harn")
+            || relative.ends_with(".rs")
+            || relative.ends_with(".md")
+            || relative.ends_with(".toml")
+        {
+            if let Ok(source) = fs::read_to_string(&path) {
+                for (index, line) in source.lines().enumerate() {
+                    let trimmed = line.trim_start();
+                    let is_comment = trimmed.starts_with("//")
+                        || trimmed.starts_with('#')
+                        || trimmed.starts_with("<!--");
+                    if is_comment {
+                        if let Some(pos) = trimmed.to_ascii_lowercase().find("invariant:") {
+                            signals.push(Signal {
+                                kind: "inline_invariant",
+                                path: format!("{relative}:{}", index + 1),
+                                detail: trimmed[pos..].trim().chars().take(180).collect(),
+                            });
+                        }
+                    }
+                    if signals.len() >= 80 {
+                        return signals;
+                    }
+                }
+            }
+        }
+    }
+    signals
+}
+
+fn mine_motion_signals(repo: &Path) -> Vec<MotionSignal> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args([
+            "log",
+            "--since=90 days ago",
+            "--pretty=%s",
+            "--max-count=200",
+        ])
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let buckets: [(&str, &[&str]); 4] = [
+        ("tests", &["test", "coverage", "conformance"]),
+        ("lint_format", &["lint", "format", "fmt", "clippy"]),
+        (
+            "flow_predicates",
+            &["flow", "predicate", "invariant", "archivist"],
+        ),
+        ("release_docs", &["release", "docs", "changelog"]),
+    ];
+    let mut counts: BTreeMap<&'static str, Vec<String>> = BTreeMap::new();
+    for subject in stdout.lines() {
+        let lower = subject.to_ascii_lowercase();
+        for (kind, terms) in buckets {
+            if terms.iter().any(|term| lower.contains(term)) {
+                counts
+                    .entry(kind)
+                    .or_default()
+                    .push(subject.chars().take(140).collect());
+            }
+        }
+    }
+    counts
+        .into_iter()
+        .map(|(kind, examples)| MotionSignal {
+            kind,
+            count: examples.len(),
+            examples: examples.into_iter().take(5).collect(),
+        })
+        .collect()
+}
+
+fn archivist_proposals(
+    repo: &Path,
+    inventory: &RepoInventory,
+    convention: &[Signal],
+    motion: &[MotionSignal],
+    no_existing_predicates: bool,
+    source_date: &str,
+) -> Vec<ArchivistProposal> {
+    let mut proposals = Vec::new();
+    if no_existing_predicates {
+        proposals.push(bootstrap_proposal(source_date));
+    }
+    if inventory.stack_hints.contains(&"rust") {
+        proposals.push(rust_unsafe_proposal(repo, source_date));
+        proposals.push(rust_panics_proposal(repo, source_date));
+    }
+    if inventory
+        .config_files
+        .iter()
+        .any(|path| path == ".github/workflows")
+    {
+        proposals.push(github_actions_permissions_proposal(source_date));
+    }
+    if motion
+        .iter()
+        .any(|signal| signal.kind == "tests" && signal.count >= 3)
+    {
+        proposals.push(test_motion_proposal(source_date));
+    }
+    let inline_signals = convention
+        .iter()
+        .filter(|signal| signal.kind == "inline_invariant")
+        .take(5)
+        .collect::<Vec<_>>();
+    if !inline_signals.is_empty() {
+        proposals.push(inline_invariant_proposal(&inline_signals, source_date));
+    }
+    proposals
+}
+
+fn bootstrap_proposal(source_date: &str) -> ArchivistProposal {
+    let evidence = vec![
+        "https://slsa.dev/spec/v1.0/provenance".to_string(),
+        "https://in-toto.io/attestation-spec/".to_string(),
+    ];
+    let coverage_examples = vec![
+        "invariants.harn".to_string(),
+        "meta-invariants.harn".to_string(),
+    ];
+    proposal(
+        "bootstrap-meta-invariants",
+        "Seed repo-wide predicate authorship metadata",
+        "invariants.harn",
+        "The repository has no discovered Flow predicates; seed review-only bootstrap metadata before expanding policy.",
+        "predicate_metadata_is_reviewable",
+        vec!["@archivist", "@semantic", "@deterministic"],
+        evidence,
+        0.72,
+        coverage_examples,
+        source_date,
+        "flow_invariant_warn(\"bootstrap predicate metadata should be reviewed by a human maintainer\")",
+    )
+}
+
+fn rust_unsafe_proposal(repo: &Path, source_date: &str) -> ArchivistProposal {
+    let examples = files_containing(repo, "unsafe", &["rs"], 5);
+    proposal(
+        "rust-unsafe-safety-comment",
+        "Require review evidence near new Rust unsafe blocks",
+        "invariants.harn",
+        "Rust is detected and unsafe blocks are a recurring high-value review boundary; propose a deterministic guard that warns on unsafe additions without nearby safety rationale.",
+        "rust_unsafe_requires_safety_comment",
+        vec!["unsafe", "SAFETY:"],
+        vec![
+            "https://doc.rust-lang.org/clippy/lint_configuration.html#undocumented_unsafe_blocks".to_string(),
+            "https://rust-lang.github.io/api-guidelines/documentation.html".to_string(),
+        ],
+        0.82,
+        examples,
+        source_date,
+        "flow_invariant_warn(\"new unsafe code should include nearby SAFETY rationale or explicit reviewer approval\")",
+    )
+}
+
+fn rust_panics_proposal(repo: &Path, source_date: &str) -> ArchivistProposal {
+    let mut examples = files_containing(repo, "panic!", &["rs"], 5);
+    examples.extend(files_containing(
+        repo,
+        ".unwrap()",
+        &["rs"],
+        5 - examples.len().min(5),
+    ));
+    proposal(
+        "rust-library-panic-surface",
+        "Flag new library panic surfaces without tests or documentation",
+        "invariants.harn",
+        "The Rust API Guidelines call out documented panic conditions; Flow can cheaply warn when atoms add panic-prone surfaces in library crates.",
+        "rust_library_panics_are_documented",
+        vec!["panic!", "unwrap()", "expect("],
+        vec![
+            "https://rust-lang.github.io/api-guidelines/documentation.html#c-failure".to_string(),
+            "https://rust-lang.github.io/rust-clippy/beta/".to_string(),
+        ],
+        0.76,
+        examples,
+        source_date,
+        "flow_invariant_warn(\"new panic-prone Rust paths should include tests or documented panic conditions\")",
+    )
+}
+
+fn github_actions_permissions_proposal(source_date: &str) -> ArchivistProposal {
+    proposal(
+        "github-actions-minimal-permissions",
+        "Warn on workflow edits without explicit permissions",
+        ".github/invariants.harn",
+        "GitHub workflow files are present; explicit job/workflow permissions make CI authority reviewable and reduce supply-chain blast radius.",
+        "github_actions_permissions_are_explicit",
+        vec!["permissions:", "uses:"],
+        vec![
+            "https://docs.github.com/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions".to_string(),
+            "https://docs.github.com/code-security/supply-chain-security/understanding-your-software-supply-chain/about-supply-chain-security".to_string(),
+        ],
+        0.79,
+        vec![".github/workflows".to_string()],
+        source_date,
+        "flow_invariant_warn(\"workflow edits should keep explicit least-privilege permissions\")",
+    )
+}
+
+fn test_motion_proposal(source_date: &str) -> ArchivistProposal {
+    proposal(
+        "motion-tests-near-flow-changes",
+        "Keep test coverage close to recurring Flow changes",
+        "invariants.harn",
+        "Recent history repeatedly touches tests/conformance around Flow work; propose a warning when Flow atoms lack nearby test coverage evidence.",
+        "flow_changes_keep_tests_nearby",
+        vec!["flow", "predicate", "conformance", "test"],
+        vec![
+            "git log --since='90 days ago' --pretty=%s".to_string(),
+            "conformance/tests/".to_string(),
+        ],
+        0.68,
+        vec!["crates/harn-vm/src/flow".to_string(), "conformance/tests".to_string()],
+        source_date,
+        "flow_invariant_warn(\"Flow predicate/runtime changes should carry focused tests or conformance coverage\")",
+    )
+}
+
+fn inline_invariant_proposal(signals: &[&Signal], source_date: &str) -> ArchivistProposal {
+    let id = "inline-invariant-crystallization";
+    let examples = signals
+        .iter()
+        .map(|signal| signal.path.clone())
+        .collect::<Vec<_>>();
+    proposal(
+        id,
+        "Crystallize inline invariant comment into Flow predicate",
+        "invariants.harn",
+        "Found inline invariant comments; propose turning recurring comments into reviewable predicate metadata.",
+        "inline_invariant_comment_is_crystallized",
+        vec!["invariant:"],
+        examples.clone(),
+        0.64,
+        examples,
+        source_date,
+        "flow_invariant_warn(\"inline invariant comments should graduate into reviewable Flow predicates when they recur\")",
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn proposal(
+    id: &'static str,
+    title: &'static str,
+    path: &str,
+    rationale: &str,
+    predicate_name: &'static str,
+    match_terms: Vec<&'static str>,
+    evidence: Vec<String>,
+    confidence: f64,
+    coverage_examples: Vec<String>,
+    source_date: &str,
+    result_expr: &str,
+) -> ArchivistProposal {
+    let evidence_harn = evidence
+        .iter()
+        .map(|item| format!("{:?}", item))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let coverage_harn = coverage_examples
+        .iter()
+        .map(|item| format!("{:?}", item))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let source = format!(
+        "@invariant\n@deterministic\n@archivist(evidence: [{evidence_harn}], confidence: {confidence:.2}, source_date: {:?}, coverage_examples: [{coverage_harn}])\nfn {predicate_name}(slice) {{\n  return {result_expr}\n}}\n",
+        source_date
+    );
+    ArchivistProposal {
+        id,
+        title,
+        path: path.to_string(),
+        rationale: rationale.to_string(),
+        predicate_name,
+        match_terms,
+        evidence,
+        confidence,
+        coverage_examples,
+        source,
+    }
+}
+
+fn shadow_evaluate(
+    repo: &Path,
+    store_path: &Path,
+    shadow_days: u32,
+    proposals: &[ArchivistProposal],
+) -> Result<serde_json::Value, String> {
+    let store_path = if store_path.is_absolute() {
+        store_path.to_path_buf()
+    } else {
+        repo.join(store_path)
+    };
+    if !store_path.is_file() {
+        return Ok(json!({
+            "status": "no_flow_store",
+            "store": store_path,
+            "window_days": shadow_days,
+            "recent_atoms": 0,
+            "proposal_results": empty_shadow_results(proposals),
+            "false_positive_candidates": [],
+        }));
+    }
+    let store = SqliteFlowStore::open(&store_path, "archivist-shadow").map_err(|error| {
+        format!(
+            "failed to open Flow store {}: {error}",
+            store_path.display()
+        )
+    })?;
+    let since = OffsetDateTime::now_utc() - Duration::days(i64::from(shadow_days));
+    let refs = store
+        .list_atoms()
+        .map_err(|error| format!("failed to list Flow atoms: {error}"))?;
+    let mut recent_atoms = Vec::new();
+    for atom_ref in refs {
+        let atom = store
+            .get_atom(atom_ref.atom_id)
+            .map_err(|error| format!("failed to load Flow atom {}: {error}", atom_ref.atom_id))?;
+        if atom.provenance.timestamp >= since {
+            recent_atoms.push(atom);
+        }
+    }
+
+    let mut false_positive_candidates = Vec::new();
+    let mut results = Vec::new();
+    for proposal in proposals {
+        let mut matched_atoms = 0usize;
+        for atom in &recent_atoms {
+            let inserted = inserted_text(atom);
+            if proposal.match_terms.iter().any(|term| {
+                inserted
+                    .to_ascii_lowercase()
+                    .contains(&term.to_ascii_lowercase())
+            }) {
+                matched_atoms += 1;
+                if likely_false_positive(proposal, &inserted) {
+                    false_positive_candidates.push(json!({
+                        "proposal_id": proposal.id,
+                        "atom": atom.id,
+                        "transcript_ref": atom.provenance.transcript_ref,
+                        "diff_span": first_insert_span(atom),
+                        "reason": "heuristic match may already contain satisfying context",
+                    }));
+                }
+            }
+        }
+        results.push(json!({
+            "proposal_id": proposal.id,
+            "recent_atoms": recent_atoms.len(),
+            "matching_atoms": matched_atoms,
+            "estimated_coverage": if recent_atoms.is_empty() { 0.0 } else { matched_atoms as f64 / recent_atoms.len() as f64 },
+        }));
+    }
+    Ok(json!({
+        "status": "evaluated",
+        "store": store_path,
+        "window_days": shadow_days,
+        "recent_atoms": recent_atoms.len(),
+        "proposal_results": results,
+        "false_positive_candidates": false_positive_candidates,
+    }))
+}
+
+fn empty_shadow_results(proposals: &[ArchivistProposal]) -> Vec<serde_json::Value> {
+    proposals
+        .iter()
+        .map(|proposal| {
+            json!({
+                "proposal_id": proposal.id,
+                "recent_atoms": 0,
+                "matching_atoms": 0,
+                "estimated_coverage": 0.0,
+            })
+        })
+        .collect()
+}
+
+fn inserted_text(atom: &harn_vm::flow::Atom) -> String {
+    atom.ops
+        .iter()
+        .filter_map(|op| match op {
+            TextOp::Insert { content, .. } => Some(content.as_str()),
+            TextOp::Delete { .. } => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn first_insert_span(atom: &harn_vm::flow::Atom) -> serde_json::Value {
+    atom.ops
+        .iter()
+        .find_map(|op| match op {
+            TextOp::Insert { offset, content } => Some(json!({
+                "start": offset,
+                "end": offset.saturating_add(content.len() as u64),
+            })),
+            TextOp::Delete { .. } => None,
+        })
+        .unwrap_or_else(|| json!({"start": 0, "end": 0}))
+}
+
+fn likely_false_positive(proposal: &ArchivistProposal, inserted: &str) -> bool {
+    match proposal.id {
+        "rust-unsafe-safety-comment" => {
+            inserted.contains("unsafe") && inserted.to_ascii_lowercase().contains("safety")
+        }
+        "github-actions-minimal-permissions" => {
+            inserted.contains("permissions:") && inserted.contains("uses:")
+        }
+        _ => false,
+    }
+}
+
+fn files_containing(repo: &Path, needle: &str, extensions: &[&str], limit: usize) -> Vec<String> {
+    if limit == 0 {
+        return Vec::new();
+    }
+    let needle = needle.to_ascii_lowercase();
+    let mut matches = Vec::new();
+    for path in walk_repo_files(repo, 4_000) {
+        let Some(ext) = path.extension().and_then(|ext| ext.to_str()) else {
+            continue;
+        };
+        if !extensions.contains(&ext) {
+            continue;
+        }
+        let Ok(source) = fs::read_to_string(&path) else {
+            continue;
+        };
+        if source.to_ascii_lowercase().contains(&needle) {
+            matches.push(relative_path(repo, &path));
+            if matches.len() >= limit {
+                break;
+            }
+        }
+    }
+    matches
+}
+
+fn walk_repo_files(repo: &Path, limit: usize) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    collect_repo_files(repo, repo, limit, &mut files);
+    files
+}
+
+fn collect_repo_files(root: &Path, dir: &Path, limit: usize, out: &mut Vec<PathBuf>) {
+    if out.len() >= limit {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
+    entries.sort_by_key(|entry| entry.path());
+    for entry in entries {
+        if out.len() >= limit {
+            return;
+        }
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
+        if path.is_dir() {
+            if should_skip_scan_dir(name) {
+                continue;
+            }
+            collect_repo_files(root, &path, limit, out);
+        } else if path.is_file() {
+            let relative = relative_path(root, &path);
+            if !relative.ends_with(".lock")
+                || matches!(name, "Cargo.lock" | "package-lock.json" | "yarn.lock")
+            {
+                out.push(path);
+            }
+        }
+    }
+}
+
+fn should_skip_scan_dir(name: &str) -> bool {
+    matches!(
+        name,
+        ".git"
+            | "target"
+            | "node_modules"
+            | "docs/dist"
+            | ".harn"
+            | ".harn-runs"
+            | ".claude"
+            | ".burin"
+    )
+}
+
+fn relative_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(name) => Some(name.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 fn current_predicate_chains(
@@ -336,47 +1073,6 @@ fn collect_invariant_dirs(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) {
             out.push(path.parent().unwrap_or(root).to_path_buf());
         }
     }
-}
-
-fn stack_hints(repo: &Path) -> Vec<&'static str> {
-    let mut hints = Vec::new();
-    if repo.join("Cargo.toml").exists() {
-        hints.push("rust");
-    }
-    if repo.join("package.json").exists() {
-        hints.push("javascript");
-    }
-    if repo.join("pyproject.toml").exists() {
-        hints.push("python");
-    }
-    if repo.join("go.mod").exists() {
-        hints.push("go");
-    }
-    hints
-}
-
-fn default_archivist_proposals(
-    stack_hints: &[&str],
-    no_existing_predicates: bool,
-) -> Vec<serde_json::Value> {
-    let mut proposals = Vec::new();
-    if no_existing_predicates {
-        proposals.push(json!({
-            "path": "invariants.harn",
-            "title": "Seed repo-wide meta-invariants",
-            "body": "Add hand-authored bootstrap rules requiring @archivist evidence and deterministic fallbacks for semantic predicates.",
-            "autonomy": "propose_only",
-        }));
-    }
-    if stack_hints.contains(&"rust") {
-        proposals.push(json!({
-            "path": "invariants.harn",
-            "title": "Rust unsafe and panic surface guard",
-            "body": "Propose deterministic predicates for new unsafe blocks, panic paths in library code, and missing tests near touched atoms.",
-            "autonomy": "propose_only",
-        }));
-    }
-    proposals
 }
 
 fn print_human_report(
@@ -491,6 +1187,8 @@ fn parse_since(raw: &str) -> Result<OffsetDateTime, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ed25519_dalek::SigningKey;
+    use harn_vm::flow::{Atom, Provenance};
 
     #[test]
     fn parse_since_accepts_rfc3339_unix_and_date() {
@@ -508,5 +1206,77 @@ mod tests {
             parse_since("2026-04-26").unwrap().unix_timestamp(),
             1_777_161_600
         );
+    }
+
+    #[test]
+    fn archivist_rust_proposal_is_parseable_harn_with_provenance() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join("Cargo.toml"),
+            "[package]\nname = \"demo\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(temp.path().join("src")).unwrap();
+        fs::write(temp.path().join("src/lib.rs"), "pub unsafe fn raw() {}\n").unwrap();
+
+        let inventory = inventory_repo(temp.path());
+        let proposals = archivist_proposals(temp.path(), &inventory, &[], &[], true, "2026-04-26");
+        let rust = proposals
+            .iter()
+            .find(|proposal| proposal.id == "rust-unsafe-safety-comment")
+            .expect("rust unsafe proposal");
+
+        let parsed = harn_vm::flow::parse_invariants_source(&rust.source);
+        assert!(
+            parsed.diagnostics.is_empty(),
+            "generated source should parse cleanly: {:?}",
+            parsed.diagnostics
+        );
+        assert_eq!(
+            parsed.predicates[0].name,
+            "rust_unsafe_requires_safety_comment"
+        );
+        assert!(parsed.predicates[0].archivist.is_some());
+    }
+
+    #[test]
+    fn shadow_evaluate_reports_false_positive_atom_pointers() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join("Cargo.toml"),
+            "[package]\nname = \"demo\"\n",
+        )
+        .unwrap();
+        let store_path = temp.path().join(".harn/flow.sqlite");
+        fs::create_dir_all(store_path.parent().unwrap()).unwrap();
+
+        {
+            let store = SqliteFlowStore::open(&store_path, "test").unwrap();
+            let principal = SigningKey::from_bytes(&[7; 32]);
+            let persona = SigningKey::from_bytes(&[8; 32]);
+            let atom = Atom::sign(
+                vec![TextOp::Insert {
+                    offset: 0,
+                    content: "unsafe { /* SAFETY: fixture */ }".to_string(),
+                }],
+                Vec::new(),
+                Provenance::new("user:test", "archivist-test", "run-1", "trace-1", "tx-1"),
+                None,
+                &principal,
+                &persona,
+            )
+            .unwrap();
+            store.emit_atoms(&[atom]).unwrap();
+        }
+
+        let proposal = rust_unsafe_proposal(temp.path(), "2026-04-26");
+        let report = shadow_evaluate(temp.path(), &store_path, 30, &[proposal]).unwrap();
+        assert_eq!(report["status"], "evaluated");
+        assert_eq!(report["recent_atoms"], 1);
+        assert_eq!(
+            report["false_positive_candidates"][0]["transcript_ref"],
+            "tx-1"
+        );
+        assert!(report["false_positive_candidates"][0]["atom"].is_string());
     }
 }

--- a/docs/src/flow-predicates.md
+++ b/docs/src/flow-predicates.md
@@ -25,7 +25,7 @@ The design in this document assumes the following ticket state as of
 | `InvariantResult`, evidence, and remediation types | Landed in #581. |
 | Hierarchical predicate composition | In review in #731, closing #582. |
 | Predicate hash replay audit | In review in #730, closing #583. |
-| Archivist persona | Open in #586. |
+| Archivist persona | Landed in #586 as deterministic propose-only scan output. |
 | Fixer persona | In review in #729, closing #587. |
 
 ## Predicate Declarations
@@ -215,6 +215,41 @@ Replay audit is advisory by default:
 
 This matches the append-only Flow model: new facts create new atoms, slices, or
 audit records; they do not mutate old shipping decisions.
+
+## Archivist Proposal Scans
+
+Archivist v0 is intentionally dumb and review-first. It does not promote
+predicates and it does not fetch live evidence during slice evaluation. The CLI
+entrypoint inventories a repository, loads the Flow persona manifest when it is
+present, mines local convention and motion signals, and emits proposal records
+with concrete Harn predicate source:
+
+```bash
+harn flow archivist scan . --json
+harn flow archivist scan . --manifest examples/personas/flow.harn.toml \
+  --store .harn/flow.sqlite --shadow-days 30 --out .harn/archivist/proposals.json
+```
+
+The JSON payload contains:
+
+- `manifest`: whether the Archivist persona manifest loaded and which
+  `[[personas]]` entry was used.
+- `inventory`: detected stacks, lockfiles, config files, and source roots.
+- `convention_signals`: lint/config files and inline `invariant:` comments.
+- `motion_signals`: recent git-log buckets such as tests, formatting, Flow
+  predicates, and release docs.
+- `existing_predicates`: discovered `invariants.harn` predicates and discovery
+  diagnostics.
+- `proposals`: review-ready `@invariant` + `@archivist(...)` predicate source,
+  evidence URLs, confidence, source date, coverage examples, and a permanent
+  `propose_only` autonomy marker.
+- `shadow_evaluation`: best-effort coverage against recent Flow atoms in the
+  local SQLite store, including false-positive candidates with atom ids,
+  transcript refs, and diff spans.
+
+If no Flow store exists, `shadow_evaluation.status` is `no_flow_store` rather
+than an error. That keeps initial repo bootstrap useful while making the
+absence of atom history explicit.
 
 ## Follow-Up Implementation Tickets
 


### PR DESCRIPTION
## Summary
- implements `harn flow archivist scan` as a deterministic propose-only proposal generator
- loads the Archivist persona manifest, inventories repo stack/config signals, mines convention and git motion signals, and emits review-ready `@invariant` + `@archivist(...)` Harn predicate source
- adds stable shadow-evaluation output over recent Flow atoms, including false-positive candidates with atom ids, transcript refs, and diff spans
- documents the proposal scan payload and CLI usage

Closes #586.

## Verification
- `cargo test -p harn-cli flow -- --nocapture`
- `cargo check -p harn-cli`
- `cargo clippy -p harn-cli -- -D warnings`
- `/private/tmp/harn-586-target/debug/harn flow archivist scan . --manifest examples/personas/flow.harn.toml --json --out /private/tmp/harn-586-archivist-proposals.json`
- `/private/tmp/harn-586-target/debug/harn test conformance --filter attributes_flow_invariant`
- pre-commit hook: formatting, workspace clippy, markdownlint
- pre-push hook: 2602 workspace tests, markdownlint

## Research / References
- Notion: Harn Flow invariant predicate language spec
- GitHub: #571, #578-#584, #586, harn-canon repository
- External citations used in generated proposal evidence include Rust API Guidelines, Rust Clippy docs, GitHub Actions hardening docs, GitHub supply-chain docs, SLSA provenance, and in-toto attestations.
