### PR TITLE
Enforce semantic predicate fallbacks

### DIFF
--- a/conformance/tests/integration/attributes_flow_invariant.harn
+++ b/conformance/tests/integration/attributes_flow_invariant.harn
@@ -10,7 +10,7 @@ fn no_secrets_in_diff(_slice) -> bool {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_secrets_in_diff)
 @retroactive
 @archivist(evidence: ["https://example.com/style"], confidence: 0.6)
 fn naming_style(_slice) -> bool {

--- a/crates/harn-cli/src/commands/flow.rs
+++ b/crates/harn-cli/src/commands/flow.rs
@@ -151,6 +151,7 @@ fn run_archivist_scan(args: &crate::cli::FlowArchivistScanArgs) -> Result<i32, S
                     "name": predicate.name,
                     "hash": predicate.source_hash,
                     "kind": predicate.kind,
+                    "fallback": predicate.fallback,
                     "relative_dir": relative_dir.clone(),
                     "retroactive": predicate.retroactive,
                     "archivist": predicate.archivist.map(|archivist| json!({

--- a/crates/harn-lsp/src/symbols.rs
+++ b/crates/harn-lsp/src/symbols.rs
@@ -76,7 +76,7 @@ pub(crate) fn format_flow_attributes_block(attributes: &[Attribute]) -> Option<S
             }
             "semantic" => {
                 lines.push(
-                    "- `@semantic` — may invoke `cheap_judge` over pre-baked evidence".to_string(),
+                    "- `@semantic(fallback: name)` — may invoke `cheap_judge` over pre-baked evidence with a deterministic fallback".to_string(),
                 );
                 saw_relevant = true;
             }

--- a/crates/harn-vm/src/flow/audit.rs
+++ b/crates/harn-vm/src/flow/audit.rs
@@ -142,9 +142,11 @@ mod tests {
             logical_name: name.to_string(),
             source: PredicateSource::new("."),
             source_order: 0,
+            fallback_hash: None,
             predicate: DiscoveredPredicate {
                 name: name.to_string(),
                 kind: PredicateKind::Deterministic,
+                fallback: None,
                 archivist: None,
                 retroactive,
                 source_hash: PredicateHash::new(hash),

--- a/crates/harn-vm/src/flow/mod.rs
+++ b/crates/harn-vm/src/flow/mod.rs
@@ -39,7 +39,7 @@ pub use predicates::{
     InvariantBlockError, InvariantResult, ParsedInvariantFile, PredicateContext,
     PredicateEvaluation, PredicateExecutionRecord, PredicateExecutionReport, PredicateExecutor,
     PredicateExecutorConfig, PredicateKind, PredicateRunner, PredicateSource, Remediation,
-    ResolvedPredicate, Verdict, VerdictStrictness, INVARIANTS_FILE,
+    ResolvedPredicate, SemanticReplayAuditMetadata, Verdict, VerdictStrictness, INVARIANTS_FILE,
 };
 pub use slice::{
     derive_slice, Approval, CoverageMap, PredicateHash, Slice, SliceDerivationError,

--- a/crates/harn-vm/src/flow/predicates/compose.rs
+++ b/crates/harn-vm/src/flow/predicates/compose.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use super::discovery::{DiscoveredInvariantFile, DiscoveredPredicate};
 use super::result::{InvariantResult, Verdict};
+use crate::flow::{PredicateHash, PredicateKind};
 
 /// Source location of a predicate within the directory hierarchy.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -46,6 +47,8 @@ pub struct ResolvedPredicate {
     pub source: PredicateSource,
     /// Stable source-order index within the resolved set.
     pub source_order: usize,
+    /// Resolved source hash of a semantic predicate's deterministic fallback.
+    pub fallback_hash: Option<PredicateHash>,
     pub predicate: DiscoveredPredicate,
 }
 
@@ -98,14 +101,26 @@ pub struct ComposedPredicateEvaluation {
 /// cannot relax an ancestor's blocking verdict.
 pub fn resolve_predicates(files: &[DiscoveredInvariantFile]) -> Vec<ResolvedPredicate> {
     let mut resolved = Vec::new();
+    let mut visible_deterministic = BTreeMap::<String, PredicateHash>::new();
     for file in files {
         let source = PredicateSource::new(&file.relative_dir);
         for predicate in &file.predicates {
+            if predicate.kind == PredicateKind::Deterministic {
+                visible_deterministic.insert(predicate.name.clone(), predicate.source_hash.clone());
+            }
+        }
+        for predicate in &file.predicates {
+            let fallback_hash = predicate
+                .fallback
+                .as_ref()
+                .and_then(|fallback| visible_deterministic.get(fallback))
+                .cloned();
             resolved.push(ResolvedPredicate {
                 qualified_name: qualified_name(&file.relative_dir, &predicate.name),
                 logical_name: predicate.name.clone(),
                 source: source.clone(),
                 source_order: resolved.len(),
+                fallback_hash,
                 predicate: predicate.clone(),
             });
         }
@@ -261,6 +276,7 @@ mod tests {
         DiscoveredPredicate {
             name: name.to_string(),
             kind: PredicateKind::Deterministic,
+            fallback: None,
             archivist: None,
             retroactive: false,
             source_hash: PredicateHash::new(format!("sha256:{name}")),

--- a/crates/harn-vm/src/flow/predicates/discovery.rs
+++ b/crates/harn-vm/src/flow/predicates/discovery.rs
@@ -7,6 +7,7 @@
 //!
 //! See parent epic #571 and ticket #579 for the design rationale.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use harn_lexer::{Lexer, Span};
@@ -43,6 +44,9 @@ pub struct DiscoveredPredicate {
     pub name: String,
     /// `Deterministic` (default) or `Semantic`.
     pub kind: PredicateKind,
+    /// For `@semantic` predicates, the named deterministic predicate that
+    /// carries the replayable enforcement path.
+    pub fallback: Option<String>,
     /// Optional Archivist provenance block.
     pub archivist: Option<ArchivistMetadata>,
     /// Advisory historical flag — predicates that legalise existing state
@@ -114,6 +118,7 @@ pub fn discover_invariants(root: &Path, target_dir: &Path) -> Vec<DiscoveredInva
         });
     }
 
+    validate_semantic_fallbacks(&mut files);
     files
 }
 
@@ -230,16 +235,73 @@ fn predicate_from_attributes(
     }
 
     let retroactive = attrs.iter().any(|a| a.name == "retroactive");
+    let fallback = attrs
+        .iter()
+        .find(|a| a.name == "semantic")
+        .and_then(parse_semantic_fallback);
+    if kind == PredicateKind::Semantic && fallback.is_none() {
+        diagnostics.push(DiscoveryDiagnostic {
+            severity: DiagnosticSeverity::Error,
+            message: format!(
+                "semantic predicate `{name}` must declare a deterministic fallback with \
+                 `@semantic(fallback: \"predicate_name\")`"
+            ),
+            span: Some(span),
+        });
+    }
     let source_hash = predicate_source_hash(source, attrs, span);
 
     Some(DiscoveredPredicate {
         name: name.to_string(),
         kind,
+        fallback,
         archivist,
         retroactive,
         source_hash,
         span,
     })
+}
+
+fn parse_semantic_fallback(attr: &Attribute) -> Option<String> {
+    attr.args
+        .iter()
+        .find(|arg| arg.name.as_deref() == Some("fallback"))
+        .or_else(|| attr.args.iter().find(|arg| arg.name.is_none()))
+        .and_then(identifier_or_string_arg)
+}
+
+fn validate_semantic_fallbacks(files: &mut [DiscoveredInvariantFile]) {
+    let mut visible_deterministic = BTreeMap::<String, PredicateHash>::new();
+
+    for file in files {
+        for predicate in &file.predicates {
+            if predicate.kind == PredicateKind::Deterministic {
+                visible_deterministic.insert(predicate.name.clone(), predicate.source_hash.clone());
+            }
+        }
+
+        let diagnostics = file
+            .predicates
+            .iter()
+            .filter(|predicate| predicate.kind == PredicateKind::Semantic)
+            .filter_map(|predicate| {
+                let fallback = predicate.fallback.as_ref()?;
+                if visible_deterministic.contains_key(fallback) {
+                    return None;
+                }
+                Some(DiscoveryDiagnostic {
+                    severity: DiagnosticSeverity::Error,
+                    message: format!(
+                        "semantic predicate `{}` fallback `{fallback}` must name a \
+                         deterministic predicate in the same invariants.harn file or an ancestor file",
+                        predicate.name
+                    ),
+                    span: Some(predicate.span),
+                })
+            })
+            .collect::<Vec<_>>();
+        file.diagnostics.extend(diagnostics);
+    }
 }
 
 fn predicate_source_hash(source: &str, attrs: &[Attribute], span: Span) -> PredicateHash {
@@ -274,6 +336,13 @@ fn parse_archivist_attribute(attr: &Attribute) -> ArchivistMetadata {
 fn string_arg(arg: &AttributeArg) -> Option<String> {
     match &arg.value.node {
         Node::StringLiteral(s) | Node::RawStringLiteral(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+fn identifier_or_string_arg(arg: &AttributeArg) -> Option<String> {
+    match &arg.value.node {
+        Node::Identifier(s) | Node::StringLiteral(s) | Node::RawStringLiteral(s) => Some(s.clone()),
         _ => None,
     }
 }
@@ -465,16 +534,102 @@ fn both_modes(slice) -> bool { return true }
     fn parse_recognises_semantic_mode_and_retroactive() {
         let source = r#"
 @invariant
-@semantic
+@semantic(fallback: "fallback_check")
 @retroactive
+@archivist(evidence: ["https://x"], confidence: 0.5)
+fn check(slice) -> bool { return true }
+
+@invariant
+@deterministic
+@archivist(evidence: ["https://x"])
+fn fallback_check(slice) -> bool { return true }
+"#;
+        let parsed = parse_invariants_source(source);
+        assert_eq!(parsed.predicates.len(), 2);
+        let pred = &parsed.predicates[0];
+        assert_eq!(pred.kind, PredicateKind::Semantic);
+        assert_eq!(pred.fallback.as_deref(), Some("fallback_check"));
+        assert!(pred.retroactive);
+    }
+
+    #[test]
+    fn parse_errors_when_semantic_fallback_missing() {
+        let source = r#"
+@invariant
+@semantic
 @archivist(evidence: ["https://x"], confidence: 0.5)
 fn check(slice) -> bool { return true }
 "#;
         let parsed = parse_invariants_source(source);
-        assert_eq!(parsed.predicates.len(), 1);
-        let pred = &parsed.predicates[0];
-        assert_eq!(pred.kind, PredicateKind::Semantic);
-        assert!(pred.retroactive);
+        assert!(parsed.diagnostics.iter().any(|d| {
+            d.severity == DiagnosticSeverity::Error
+                && d.message.contains("must declare a deterministic fallback")
+        }));
+    }
+
+    #[test]
+    fn discover_accepts_semantic_fallback_from_ancestor() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write(root, INVARIANTS_FILE, &sample_predicate("root_fallback"));
+        let nested = root.join("crates");
+        write(
+            &nested,
+            INVARIANTS_FILE,
+            r#"
+@invariant
+@semantic(fallback: root_fallback)
+@archivist(evidence: ["https://x"], confidence: 0.5)
+fn semantic_check(slice) -> bool { return true }
+"#,
+        );
+
+        let files = discover_invariants(root, &nested);
+
+        assert!(files
+            .iter()
+            .flat_map(|file| file.diagnostics.iter())
+            .all(|diagnostic| diagnostic.severity != DiagnosticSeverity::Error));
+        let resolved = resolve_predicates(&files);
+        let semantic = resolved
+            .iter()
+            .find(|predicate| predicate.logical_name == "semantic_check")
+            .unwrap();
+        assert_eq!(
+            semantic.fallback_hash,
+            Some(files[0].predicates[0].source_hash.clone())
+        );
+    }
+
+    #[test]
+    fn discover_rejects_semantic_fallback_from_descendant_only() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write(
+            root,
+            INVARIANTS_FILE,
+            r#"
+@invariant
+@semantic(fallback: child_fallback)
+@archivist(evidence: ["https://x"], confidence: 0.5)
+fn semantic_check(slice) -> bool { return true }
+"#,
+        );
+        let nested = root.join("crates");
+        write(
+            &nested,
+            INVARIANTS_FILE,
+            &sample_predicate("child_fallback"),
+        );
+
+        let files = discover_invariants(root, &nested);
+
+        assert!(files[0].diagnostics.iter().any(|diagnostic| {
+            diagnostic.severity == DiagnosticSeverity::Error
+                && diagnostic
+                    .message
+                    .contains("same invariants.harn file or an ancestor file")
+        }));
     }
 
     #[test]

--- a/crates/harn-vm/src/flow/predicates/executor.rs
+++ b/crates/harn-vm/src/flow/predicates/executor.rs
@@ -16,6 +16,7 @@ use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use super::compose::verdict_strictness;
 use crate::flow::{InvariantBlockError, InvariantResult, PredicateHash, Slice};
 
 const DEFAULT_DETERMINISTIC_BUDGET: Duration = Duration::from_millis(50);
@@ -51,6 +52,26 @@ pub struct CheapJudgeResponse {
     pub input_tokens: u64,
     #[serde(default)]
     pub output_tokens: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cheap_judge_version: Option<String>,
+}
+
+/// Replay-audit metadata for a semantic predicate's judge call.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SemanticReplayAuditMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    pub prompt_hash: String,
+    pub evidence_hashes: BTreeMap<String, String>,
+    pub token_cap: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cheap_judge_version: Option<String>,
 }
 
 /// Host-provided adapter for semantic predicate judging.
@@ -67,6 +88,9 @@ pub trait CheapJudge {
 pub trait PredicateRunner {
     fn hash(&self) -> PredicateHash;
     fn kind(&self) -> PredicateKind;
+    fn fallback_hash(&self) -> Option<PredicateHash> {
+        None
+    }
 
     /// Static evidence captured when the predicate was authored. Semantic
     /// predicates may only judge over this map; the executor never fetches
@@ -99,6 +123,7 @@ struct JudgeBudgetState {
     calls: u64,
     tokens: u64,
     block_error: Option<InvariantBlockError>,
+    semantic_audit: Option<SemanticReplayAuditMetadata>,
 }
 
 impl PredicateContext {
@@ -198,15 +223,31 @@ impl PredicateContext {
 
         let response = match judge
             .cheap_judge(CheapJudgeRequest {
-                prompt,
-                evidence_key,
-                evidence,
+                prompt: prompt.clone(),
+                evidence_key: evidence_key.clone(),
+                evidence: evidence.clone(),
             })
             .await
         {
             Ok(response) => response,
             Err(error) => return Err(self.record_block(error)),
         };
+        {
+            let mut state = self.inner.judge_state.borrow_mut();
+            state.semantic_audit = Some(SemanticReplayAuditMetadata {
+                provider_id: response.provider_id.clone(),
+                model_id: response.model_id.clone(),
+                prompt_hash: stable_hash(prompt.as_bytes()),
+                evidence_hashes: self
+                    .inner
+                    .evidence
+                    .iter()
+                    .map(|(key, value)| (key.clone(), stable_hash(value.as_bytes())))
+                    .collect(),
+                token_cap: self.inner.semantic_token_cap,
+                cheap_judge_version: response.cheap_judge_version.clone(),
+            });
+        }
         let response_tokens = response.input_tokens.saturating_add(response.output_tokens);
         {
             let mut state = self.inner.judge_state.borrow_mut();
@@ -229,6 +270,10 @@ impl PredicateContext {
 
     fn block_error(&self) -> Option<InvariantBlockError> {
         self.inner.judge_state.borrow().block_error.clone()
+    }
+
+    fn semantic_audit(&self) -> Option<SemanticReplayAuditMetadata> {
+        self.inner.judge_state.borrow().semantic_audit.clone()
     }
 
     fn record_block(&self, error: InvariantBlockError) -> InvariantBlockError {
@@ -301,6 +346,7 @@ impl PredicateExecutor {
             .await;
 
         let mut records = records;
+        self.apply_semantic_fallbacks(&mut records);
         records.sort_by(|left, right| left.predicate_hash.cmp(&right.predicate_hash));
         PredicateExecutionReport { records }
     }
@@ -314,18 +360,19 @@ impl PredicateExecutor {
         let predicate_hash = runner.hash();
         let kind = runner.kind();
         let first = self.run_attempt(slice.clone(), runner).await;
-        let first_hash = hash_result(&first);
-        let mut result = first;
+        let first_hash = hash_result(&first.result);
+        let mut result = first.result;
         let mut attempts = 1;
         let mut second_hash = None;
+        let semantic_replay_audit = first.semantic_audit;
 
         if kind == PredicateKind::Deterministic && !result.is_blocking() {
             let second = self.run_attempt(slice, runner).await;
             attempts = 2;
-            let replay_hash = hash_result(&second);
+            let replay_hash = hash_result(&second.result);
             second_hash = replay_hash.clone();
-            if second.is_blocking() {
-                result = second;
+            if second.result.is_blocking() {
+                result = second.result;
             } else {
                 match (first_hash.as_ref(), replay_hash.as_ref()) {
                     (Some(left), Some(right)) if left == right => {}
@@ -349,16 +396,22 @@ impl PredicateExecutor {
         PredicateExecutionRecord {
             predicate_hash,
             kind,
+            fallback_hash: runner.fallback_hash(),
             result,
             elapsed_ms: started.elapsed().as_millis() as u64,
             attempts,
             replayable: kind == PredicateKind::Deterministic,
             first_result_hash: first_hash,
             second_result_hash: second_hash,
+            semantic_replay_audit,
         }
     }
 
-    async fn run_attempt(&self, slice: Rc<Slice>, runner: &dyn PredicateRunner) -> InvariantResult {
+    async fn run_attempt(
+        &self,
+        slice: Rc<Slice>,
+        runner: &dyn PredicateRunner,
+    ) -> PredicateAttempt {
         let kind = runner.kind();
         let timeout = match kind {
             PredicateKind::Deterministic => self.config.deterministic_budget,
@@ -373,17 +426,69 @@ impl PredicateExecutor {
             Arc::new(AtomicBool::new(false)),
         );
         match tokio::time::timeout(timeout, runner.evaluate(context.clone())).await {
-            Ok(result) => context
-                .block_error()
-                .map(InvariantResult::block)
-                .unwrap_or(result),
+            Ok(result) => PredicateAttempt {
+                result: context
+                    .block_error()
+                    .map(InvariantResult::block)
+                    .unwrap_or(result),
+                semantic_audit: context.semantic_audit(),
+            },
             Err(_) => {
                 context.cancel();
-                InvariantResult::block(InvariantBlockError::budget_exceeded(format!(
-                    "{kind:?} predicate exceeded {}ms budget",
-                    timeout.as_millis()
-                )))
+                PredicateAttempt {
+                    result: InvariantResult::block(InvariantBlockError::budget_exceeded(format!(
+                        "{kind:?} predicate exceeded {}ms budget",
+                        timeout.as_millis()
+                    ))),
+                    semantic_audit: context.semantic_audit(),
+                }
             }
+        }
+    }
+
+    fn apply_semantic_fallbacks(&self, records: &mut [PredicateExecutionRecord]) {
+        let by_hash = records
+            .iter()
+            .map(|record| {
+                (
+                    record.predicate_hash.clone(),
+                    (record.kind, record.result.clone()),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        for record in records {
+            if record.kind != PredicateKind::Semantic {
+                continue;
+            }
+            let Some(fallback_hash) = record.fallback_hash.as_ref() else {
+                record.result = InvariantResult::block(InvariantBlockError::new(
+                    "fallback_missing",
+                    "semantic predicate did not declare a deterministic fallback",
+                ));
+                continue;
+            };
+            let Some((fallback_kind, fallback_result)) = by_hash.get(fallback_hash) else {
+                record.result = InvariantResult::block(InvariantBlockError::new(
+                    "fallback_missing",
+                    format!(
+                        "semantic predicate fallback {} was not evaluated",
+                        fallback_hash.as_str()
+                    ),
+                ));
+                continue;
+            };
+            if *fallback_kind != PredicateKind::Deterministic {
+                record.result = InvariantResult::block(InvariantBlockError::new(
+                    "fallback_not_deterministic",
+                    format!(
+                        "semantic predicate fallback {} is not deterministic",
+                        fallback_hash.as_str()
+                    ),
+                ));
+                continue;
+            }
+            record.result = stricter_result(&record.result, fallback_result);
         }
     }
 }
@@ -399,6 +504,8 @@ impl Default for PredicateExecutor {
 pub struct PredicateExecutionRecord {
     pub predicate_hash: PredicateHash,
     pub kind: PredicateKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fallback_hash: Option<PredicateHash>,
     pub result: InvariantResult,
     pub elapsed_ms: u64,
     pub attempts: u8,
@@ -407,6 +514,8 @@ pub struct PredicateExecutionRecord {
     pub first_result_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub second_result_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_replay_audit: Option<SemanticReplayAuditMetadata>,
 }
 
 /// Complete result of executing all predicates for one slice.
@@ -429,8 +538,25 @@ fn hash_result(result: &InvariantResult) -> Option<String> {
     Some(hex::encode(Sha256::digest(bytes)))
 }
 
+fn stable_hash(bytes: &[u8]) -> String {
+    format!("sha256:{}", hex::encode(Sha256::digest(bytes)))
+}
+
+fn stricter_result(left: &InvariantResult, right: &InvariantResult) -> InvariantResult {
+    if verdict_strictness(&left.verdict) >= verdict_strictness(&right.verdict) {
+        left.clone()
+    } else {
+        right.clone()
+    }
+}
+
 fn estimate_tokens(value: &str) -> u64 {
     value.split_whitespace().count().max(1) as u64
+}
+
+struct PredicateAttempt {
+    result: InvariantResult,
+    semantic_audit: Option<SemanticReplayAuditMetadata>,
 }
 
 #[cfg(test)]
@@ -455,6 +581,7 @@ mod tests {
     struct StaticPredicate {
         hash: &'static str,
         kind: PredicateKind,
+        fallback_hash: Option<&'static str>,
         result: InvariantResult,
         delay: Duration,
     }
@@ -467,6 +594,10 @@ mod tests {
 
         fn kind(&self) -> PredicateKind {
             self.kind
+        }
+
+        fn fallback_hash(&self) -> Option<PredicateHash> {
+            self.fallback_hash.map(PredicateHash::new)
         }
 
         async fn evaluate(&self, _context: PredicateContext) -> InvariantResult {
@@ -504,6 +635,7 @@ mod tests {
 
     struct SemanticPredicate {
         calls: u8,
+        fallback_hash: Option<&'static str>,
     }
 
     #[async_trait(?Send)]
@@ -514,6 +646,10 @@ mod tests {
 
         fn kind(&self) -> PredicateKind {
             PredicateKind::Semantic
+        }
+
+        fn fallback_hash(&self) -> Option<PredicateHash> {
+            self.fallback_hash.map(PredicateHash::new)
         }
 
         fn evidence(&self) -> BTreeMap<String, String> {
@@ -544,6 +680,9 @@ mod tests {
                 reason: None,
                 input_tokens: 2,
                 output_tokens: 1,
+                provider_id: Some("mock-provider".to_string()),
+                model_id: Some("mock-model-1".to_string()),
+                cheap_judge_version: Some("cheap-judge-v1".to_string()),
             })
         }
     }
@@ -580,6 +719,7 @@ mod tests {
         let predicates: Vec<Rc<dyn PredicateRunner>> = vec![Rc::new(StaticPredicate {
             hash: "stable",
             kind: PredicateKind::Deterministic,
+            fallback_hash: None,
             result: InvariantResult::allow(),
             delay: Duration::ZERO,
         })];
@@ -615,6 +755,7 @@ mod tests {
         let predicates: Vec<Rc<dyn PredicateRunner>> = vec![Rc::new(StaticPredicate {
             hash: "slow",
             kind: PredicateKind::Deterministic,
+            fallback_hash: None,
             result: InvariantResult::allow(),
             delay: Duration::from_millis(20),
         })];
@@ -656,13 +797,119 @@ mod tests {
             PredicateExecutorConfig::default(),
             Rc::new(PassingJudge),
         );
-        let predicates: Vec<Rc<dyn PredicateRunner>> =
-            vec![Rc::new(SemanticPredicate { calls: 2 })];
+        let predicates: Vec<Rc<dyn PredicateRunner>> = vec![
+            Rc::new(SemanticPredicate {
+                calls: 2,
+                fallback_hash: Some("fallback"),
+            }),
+            Rc::new(StaticPredicate {
+                hash: "fallback",
+                kind: PredicateKind::Deterministic,
+                fallback_hash: None,
+                result: InvariantResult::allow(),
+                delay: Duration::ZERO,
+            }),
+        ];
+
+        let report = executor.execute_slice(&slice(), &predicates).await;
+
+        let semantic = report
+            .records
+            .iter()
+            .find(|record| record.kind == PredicateKind::Semantic)
+            .unwrap();
+        let block = semantic.result.block_error().expect("blocked");
+        assert_eq!(block.code, "budget_exceeded");
+    }
+
+    #[tokio::test]
+    async fn semantic_and_fallback_agree_records_both_results() {
+        let executor = PredicateExecutor::default();
+        let predicates: Vec<Rc<dyn PredicateRunner>> = vec![
+            Rc::new(StaticPredicate {
+                hash: "semantic",
+                kind: PredicateKind::Semantic,
+                fallback_hash: Some("fallback"),
+                result: InvariantResult::warn("semantic concern"),
+                delay: Duration::ZERO,
+            }),
+            Rc::new(StaticPredicate {
+                hash: "fallback",
+                kind: PredicateKind::Deterministic,
+                fallback_hash: None,
+                result: InvariantResult::warn("fallback concern"),
+                delay: Duration::ZERO,
+            }),
+        ];
+
+        let report = executor.execute_slice(&slice(), &predicates).await;
+
+        assert_eq!(report.records.len(), 2);
+        assert_eq!(report.invariants_applied().len(), 2);
+        let semantic = report
+            .records
+            .iter()
+            .find(|record| record.predicate_hash == PredicateHash::new("semantic"))
+            .unwrap();
+        assert_eq!(semantic.fallback_hash, Some(PredicateHash::new("fallback")));
+        assert!(matches!(
+            semantic.result.verdict,
+            crate::flow::Verdict::Warn { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn semantic_fallback_disagreement_selects_stricter_verdict() {
+        let executor = PredicateExecutor::default();
+        let predicates: Vec<Rc<dyn PredicateRunner>> = vec![
+            Rc::new(StaticPredicate {
+                hash: "semantic",
+                kind: PredicateKind::Semantic,
+                fallback_hash: Some("fallback"),
+                result: InvariantResult::allow(),
+                delay: Duration::ZERO,
+            }),
+            Rc::new(StaticPredicate {
+                hash: "fallback",
+                kind: PredicateKind::Deterministic,
+                fallback_hash: None,
+                result: InvariantResult::block(InvariantBlockError::new(
+                    "fallback_policy",
+                    "fallback blocked",
+                )),
+                delay: Duration::ZERO,
+            }),
+        ];
+
+        let report = executor.execute_slice(&slice(), &predicates).await;
+        let semantic = report
+            .records
+            .iter()
+            .find(|record| record.predicate_hash == PredicateHash::new("semantic"))
+            .unwrap();
+
+        let block = semantic
+            .result
+            .block_error()
+            .expect("stricter fallback wins");
+        assert_eq!(block.code, "fallback_policy");
+    }
+
+    #[tokio::test]
+    async fn semantic_missing_fallback_blocks() {
+        let executor = PredicateExecutor::default();
+        let predicates: Vec<Rc<dyn PredicateRunner>> = vec![Rc::new(StaticPredicate {
+            hash: "semantic",
+            kind: PredicateKind::Semantic,
+            fallback_hash: None,
+            result: InvariantResult::allow(),
+            delay: Duration::ZERO,
+        })];
 
         let report = executor.execute_slice(&slice(), &predicates).await;
 
         let block = report.records[0].result.block_error().expect("blocked");
-        assert_eq!(block.code, "budget_exceeded");
+        assert_eq!(block.code, "fallback_missing");
     }
 
     #[tokio::test]
@@ -679,6 +926,10 @@ mod tests {
                 PredicateKind::Semantic
             }
 
+            fn fallback_hash(&self) -> Option<PredicateHash> {
+                Some(PredicateHash::new("fallback"))
+            }
+
             async fn evaluate(&self, context: PredicateContext) -> InvariantResult {
                 match context.cheap_judge("judge", "missing").await {
                     Ok(_) => InvariantResult::allow(),
@@ -691,11 +942,67 @@ mod tests {
             PredicateExecutorConfig::default(),
             Rc::new(PassingJudge),
         );
-        let predicates: Vec<Rc<dyn PredicateRunner>> = vec![Rc::new(MissingEvidence)];
+        let predicates: Vec<Rc<dyn PredicateRunner>> = vec![
+            Rc::new(MissingEvidence),
+            Rc::new(StaticPredicate {
+                hash: "fallback",
+                kind: PredicateKind::Deterministic,
+                fallback_hash: None,
+                result: InvariantResult::allow(),
+                delay: Duration::ZERO,
+            }),
+        ];
 
         let report = executor.execute_slice(&slice(), &predicates).await;
 
-        let block = report.records[0].result.block_error().expect("blocked");
+        let semantic = report
+            .records
+            .iter()
+            .find(|record| record.kind == PredicateKind::Semantic)
+            .unwrap();
+        let block = semantic.result.block_error().expect("blocked");
         assert_eq!(block.code, "evidence_missing");
+    }
+
+    #[tokio::test]
+    async fn semantic_replay_audit_records_judge_hashes() {
+        let executor = PredicateExecutor::with_cheap_judge(
+            PredicateExecutorConfig::default(),
+            Rc::new(PassingJudge),
+        );
+        let predicates: Vec<Rc<dyn PredicateRunner>> = vec![
+            Rc::new(SemanticPredicate {
+                calls: 1,
+                fallback_hash: Some("fallback"),
+            }),
+            Rc::new(StaticPredicate {
+                hash: "fallback",
+                kind: PredicateKind::Deterministic,
+                fallback_hash: None,
+                result: InvariantResult::allow(),
+                delay: Duration::ZERO,
+            }),
+        ];
+
+        let report = executor.execute_slice(&slice(), &predicates).await;
+        let semantic = report
+            .records
+            .iter()
+            .find(|record| record.kind == PredicateKind::Semantic)
+            .unwrap();
+        let audit = semantic
+            .semantic_replay_audit
+            .as_ref()
+            .expect("semantic audit metadata");
+
+        assert_eq!(audit.provider_id.as_deref(), Some("mock-provider"));
+        assert_eq!(audit.model_id.as_deref(), Some("mock-model-1"));
+        assert_eq!(audit.prompt_hash, stable_hash("judge the case".as_bytes()));
+        let expected_evidence_hash = stable_hash("pre-baked evidence".as_bytes());
+        assert_eq!(
+            audit.evidence_hashes.get("case").map(String::as_str),
+            Some(expected_evidence_hash.as_str())
+        );
+        assert_eq!(audit.token_cap, DEFAULT_SEMANTIC_TOKEN_CAP);
     }
 }

--- a/crates/harn-vm/src/flow/predicates/mod.rs
+++ b/crates/harn-vm/src/flow/predicates/mod.rs
@@ -18,7 +18,7 @@ pub use discovery::{
 pub use executor::{
     CheapJudge, CheapJudgeRequest, CheapJudgeResponse, PredicateContext, PredicateExecutionRecord,
     PredicateExecutionReport, PredicateExecutor, PredicateExecutorConfig, PredicateKind,
-    PredicateRunner,
+    PredicateRunner, SemanticReplayAuditMetadata,
 };
 pub use result::{
     Approver, ByteSpan, EvidenceItem, InvariantBlockError, InvariantResult, Remediation, Verdict,

--- a/docs/src/flow-predicates.md
+++ b/docs/src/flow-predicates.md
@@ -45,14 +45,27 @@ Every shipping predicate is a top-level Harn function marked with
 fn no_raw_tokens(slice) {
   return flow_invariant_allow()
 }
+
+@invariant
+@semantic(fallback: no_raw_tokens)
+@archivist(
+  evidence: ["https://example.com/team/security-rule"],
+  confidence: 0.84,
+  source_date: "2026-04-26",
+  coverage_examples: ["crates/api/src/auth.rs"]
+)
+fn no_raw_tokens_semantic_review(slice) {
+  return flow_invariant_warn("semantic review found risky token-like text")
+}
 ```
 
 `@deterministic` predicates are pure Harn. They cannot use the network, shell,
 LLM calls, host tools, clocks, random sources, or mutable ambient state.
 
-`@semantic` predicates may make one cheap judge call over pre-baked evidence
-captured in `@archivist(...)`. They still cannot fetch fresh evidence during
-slice evaluation.
+`@semantic(fallback: name)` predicates may make one cheap judge call over
+pre-baked evidence captured in `@archivist(...)`. The fallback must name a
+deterministic predicate declared in the same `invariants.harn` file or an
+ancestor file. They still cannot fetch fresh evidence during slice evaluation.
 
 The result is an `InvariantResult`:
 
@@ -210,7 +223,7 @@ landed and in-review predicate tickets:
 
 - [#734](https://github.com/burin-labs/harn/issues/734): add
   `meta-invariants.harn` bootstrap validation and approval-chain checks.
-- [#735](https://github.com/burin-labs/harn/issues/735): add deterministic
+- [#735](https://github.com/burin-labs/harn/issues/735): deterministic
   fallback metadata and enforcement for `@semantic` predicates.
 - [#736](https://github.com/burin-labs/harn/issues/736): add cross-slice fair
   scheduling and aggregate per-slice predicate budget envelopes.


### PR DESCRIPTION
## Summary

Closes #735.

- Add `@semantic(fallback: ...)` metadata parsing for Flow predicates and validate that semantic fallbacks resolve to deterministic predicates in the same `invariants.harn` file or an ancestor file.
- Resolve fallback source hashes into predicate metadata and have the predicate executor reconcile semantic verdicts against deterministic fallbacks using the stricter verdict ordering: `Block > RequireApproval > Warn > Allow`.
- Preserve both semantic and fallback records in `invariants_applied`, and add serializable semantic replay-audit metadata for provider/model ids, prompt hash, evidence hashes, token cap, and cheap judge version.
- Update Flow docs, Archivist scan output, LSP hover text, and the Flow attribute conformance sample for the required fallback form.

## Verification

- `CARGO_TARGET_DIR=/tmp/codex-harn-735-target cargo test -p harn-vm flow::predicates --lib`
- `CARGO_TARGET_DIR=/tmp/codex-harn-735-target cargo run --quiet --bin harn -- test conformance --filter attributes_flow_invariant`
- `CARGO_TARGET_DIR=/tmp/codex-harn-735-target cargo test -p harn-cli flow`
- `CARGO_TARGET_DIR=/tmp/codex-harn-735-target cargo test -p harn-lsp symbols`
- Pre-commit hook: `cargo fmt`, staged Harn fmt/lint, workspace clippy, markdown lint
- Pre-push hook: 2,606 nextest tests passed, affected Harn fmt/lint, markdown lint

## Notes

A plain full `cargo test -p harn-vm` in this shell initially failed unrelated connector/http mock-server egress tests because process egress defaulted to deny. The repo pre-push gate ran successfully afterward under its configured test environment.