### PR TITLE
Unblock release publishing on container build

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -216,7 +216,7 @@ jobs:
 
   release:
     name: Create GitHub release
-    needs: [setup, build, container]
+    needs: [setup, build]
     if: needs.setup.outputs.is_release == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,14 @@ granular archaeology.
 
 ### Fixed
 
+- **Decouple GitHub release from the multi-arch container publish.** The
+  `release` job in `build-release-binaries.yml` no longer waits on the
+  `Publish container` job, so the release tag and binary tarballs/zip
+  attach as soon as the build matrix completes. The container still
+  gates on the build matrix and publishes on its own schedule. This
+  shaves the container build's wall-clock (~5–15 min) off the
+  end-to-end release latency, which previously held up
+  `fetch-harn.sh`-driven downstream consumers.
 - **Stabilize integration tests under full nextest load.**
   `PROCESS_READY_TIMEOUT` in `harn_serve_mcp_cli` and `mcp_server_cli` was
   raised from 15s to 60s after observing 30–40s cold-starts of the debug


### PR DESCRIPTION
## Summary

The release job in `build-release-binaries.yml` no longer waits on the
Publish container job. The release tag and platform binaries
(`.tar.gz` / `.zip`) attach as soon as the build matrix is done,
shaving the multi-arch QEMU container build's wall-clock (~5-15 min)
off the end-to-end release latency.

Container still gates on `build`, so a failed binary build won't ship a
stale image, but the GitHub release no longer blocks on container
caching/QEMU. Downstream consumers like burin-code's `fetch-harn.sh`
see new versions immediately.

## Why

Reference run: https://github.com/burin-labs/harn/actions/runs/24963473384/job/73095695418
shows the container job alone running for >9 min after the last build
job finished. That entire delay was on the release path because of an
unnecessary `needs: [..., container]` edge.

## Test plan

- [ ] actionlint clean (verified locally)
- [ ] markdownlint clean (verified in pre-commit)
- [ ] CHANGELOG entry added under v0.7.43 \`### Fixed\`
- [ ] Verify on the next tag push that release tag + binaries publish
      promptly while container continues in parallel