### PR TITLE
test(cli): regression for `lint <dir>` / `check --workspace` Linux hang (#748)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## Unreleased
+
+### Tests
+
+- **CLI regression for the `harn lint <dir>` / `harn check --workspace`
+  Linux hang (#748).** The path-spelling explosion in
+  `harn_modules::build()` was fixed in #93 (`harn-modules` unit test
+  `cross_directory_cycle_does_not_explode_module_count`), but burin-code
+  CI still ran a per-file `xargs -n1 harn lint` workaround because the
+  fix only had unit-level coverage. Adds
+  `lint_and_check_complete_on_large_cross_directory_cycle_workspace` in
+  `crates/harn-cli/tests/check_cli.rs`, which builds a 24-file pipeline
+  tree across four sibling directories with relative cross-directory
+  imports — the exact pattern that triggered the OOM-kill on Linux —
+  and asserts both `harn lint <dir>` and `harn check --workspace`
+  complete inside a 60 s budget through the CLI binary. Verified to
+  fail (test process hangs past 60 s) when the canonicalize-before-seen
+  block in `crates/harn-modules/src/lib.rs` is reverted, and to pass
+  (sub-second per command) with the fix in place.
+
 ## v0.7.43
 
 ### Added

--- a/crates/harn-cli/tests/check_cli.rs
+++ b/crates/harn-cli/tests/check_cli.rs
@@ -1,5 +1,7 @@
 use std::fs;
+use std::path::Path;
 use std::process::Command;
+use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 
@@ -31,4 +33,105 @@ fn check_reports_unknown_struct_type_in_stderr() {
         stderr.contains(&format!("{}:1:9", script.display())),
         "missing precise location in stderr: {stderr}"
     );
+}
+
+/// CLI-level regression for the Linux hang on `harn lint <dir>` and
+/// `harn check --workspace` against pipeline trees with cyclic
+/// cross-sibling-directory relative imports (#748). The underlying fix
+/// (`harn_modules::build()` canonicalizing before seen-set dedupe,
+/// #93) already has a unit test in `harn-modules`. This test guards
+/// the same regression at the CLI surface so a future walker change in
+/// `lint` / `check --workspace` that re-introduces the explosion is
+/// caught here rather than in downstream pipeline trees like
+/// burin-code's. Four sibling directories × six files importing every
+/// other directory by relative path — the exact pattern that produced
+/// fresh path spellings on every round-trip and OOM-killed Linux CI
+/// runners around 48 s pre-fix.
+#[test]
+fn lint_and_check_complete_on_large_cross_directory_cycle_workspace() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    let pipelines = root.join("Sources/pipelines");
+    write_cross_directory_cycle_workspace(&pipelines);
+
+    fs::write(
+        root.join("harn.toml"),
+        "[package]\n\
+         name = \"hang-regression\"\n\
+         version = \"0.0.0\"\n\
+         \n\
+         [workspace]\n\
+         pipelines = [\"Sources/pipelines\"]\n",
+    )
+    .unwrap();
+
+    // Post-fix this completes in well under a second on every supported
+    // platform; pre-fix on Linux it OOM-killed around 48 s. The 60 s
+    // budget gives slow CI shapes (qemu, sandboxed builders) headroom
+    // without letting a regression sit silently.
+    let budget = Duration::from_secs(60);
+
+    let lint_started = Instant::now();
+    let lint_output = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(root)
+        .args(["lint", pipelines.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let lint_elapsed = lint_started.elapsed();
+    assert!(
+        lint_output.status.success(),
+        "lint failed: status={:?} stdout={} stderr={}",
+        lint_output.status,
+        String::from_utf8_lossy(&lint_output.stdout),
+        String::from_utf8_lossy(&lint_output.stderr)
+    );
+    assert!(
+        lint_elapsed < budget,
+        "lint took {lint_elapsed:?} (>{budget:?}) — likely a regression to the path-spelling explosion fixed by #93"
+    );
+
+    let check_started = Instant::now();
+    let check_output = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(root)
+        .args(["check", "--workspace"])
+        .output()
+        .unwrap();
+    let check_elapsed = check_started.elapsed();
+    assert!(
+        check_output.status.success(),
+        "check --workspace failed: status={:?} stdout={} stderr={}",
+        check_output.status,
+        String::from_utf8_lossy(&check_output.stdout),
+        String::from_utf8_lossy(&check_output.stderr)
+    );
+    assert!(
+        check_elapsed < budget,
+        "check --workspace took {check_elapsed:?} (>{budget:?}) — likely a regression to the path-spelling explosion fixed by #93"
+    );
+}
+
+fn write_cross_directory_cycle_workspace(pipelines: &Path) {
+    let dirs = ["context", "runtime", "host", "tools"];
+    let files_per_dir = 6;
+    for dir in dirs {
+        fs::create_dir_all(pipelines.join(dir)).unwrap();
+    }
+    for (dir_idx, dir) in dirs.iter().enumerate() {
+        for file_idx in 0..files_per_dir {
+            let mut source = String::new();
+            for (other_idx, other) in dirs.iter().enumerate() {
+                if other_idx == dir_idx {
+                    continue;
+                }
+                let target = format!("m{}", (file_idx + other_idx) % files_per_dir);
+                source.push_str(&format!("import \"../{other}/{target}\"\n"));
+            }
+            source.push_str(&format!("pub fn {dir}_m{file_idx}() {{ {file_idx} }}\n"));
+            fs::write(
+                pipelines.join(dir).join(format!("m{file_idx}.harn")),
+                source,
+            )
+            .unwrap();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a CLI-level regression test (`lint_and_check_complete_on_large_cross_directory_cycle_workspace`) that builds a 24-file workspace tree across four sibling directories with relative cross-directory imports — the exact pattern that triggered the OOM-kill on Linux — and asserts both `harn lint <dir>` and `harn check --workspace` complete inside a 60 s budget through the CLI binary.
- The underlying fix (`harn_modules::build()` canonicalizing before seen-set dedupe) already shipped in burin-labs/harn#93 / v0.7.20+, but only had unit-level coverage in `harn-modules`. burin-code CI was still on a per-file `xargs -n1 harn lint` workaround as a result. This test guards the same regression at the CLI surface so a future walker change in `lint` / `check --workspace` is caught here, not in downstream pipeline trees.

## Closes

Closes #748.

## Why

The original hang was a path-spelling explosion in `harn_modules::build()`: two files in sibling directories importing each other via relative paths produced a fresh path entry on every round-trip (`.../runtime/../context/../runtime/...`). The walk only terminated when `path.exists()` failed at the filesystem `PATH_MAX` (1024 on macOS, 4096 on Linux), so Linux re-parsed the same handful of files thousands of times and got OOM-killed by CI runners around 48 s. Fix in #93 canonicalized each import path before inserting into the seen set.

The reproduction matched the burin-code pipeline tree shape (`lib/context/`, `lib/runtime/`, etc.) and was confirmed by manually downloading the v0.7.42 Linux binary and exercising it inside a `debian:trixie-slim` Docker container against `~/projects/burin-code/Sources/BurinCore/Resources/pipelines` — both `harn lint <dir>` and `harn check --workspace` now complete cleanly (~9 s and ~49 s respectively under qemu emulation; native Linux is several × faster).

## Test plan

- [x] `cargo test -p harn-cli --test check_cli` — both tests pass (3.5 s)
- [x] `cargo test -p harn-modules` — 14/14 pass (existing `cross_directory_cycle_does_not_explode_module_count` covers the same regression at the unit level)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p harn-cli --tests -- -D warnings` clean
- [x] `markdownlint-cli2 CHANGELOG.md` clean
- [x] **Reverted the canonicalize-before-seen block in `crates/harn-modules/src/lib.rs` and confirmed the new test process hangs past 60 s**, then restored the fix and confirmed the test passes again — proves the test actually catches the regression
- [x] Manual repro on Linux x86_64 via Docker against burin-code's pipeline tree (174 files, 4 sibling dirs deep) — both commands complete

## Follow-up

- [burin-labs/burin-code#379](https://github.com/burin-labs/burin-code/pull/379) drops the per-file `xargs -n1` workaround in burin-code's CI now that the directory / `--workspace` invocations are confirmed reliable on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)