### PR TITLE
Add stable crystallization candidate bundle artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,19 @@ granular archaeology.
   Phase 0 command groups stored atoms into intents, discovers predicate gates,
   persists a local shipping receipt, and emits an approval-gated mock PR
   receipt with the required eval-pack hooks.
+- **Crystallization candidate bundle (#746).** Added the stable
+  `harn.crystallization.candidate.bundle` directory layout
+  (`candidate.json`, `workflow.harn`, `report.json`, `harn.eval.toml`, and
+  a redacted `fixtures/` tree) that Harn Cloud and other downstream
+  importers can consume without bespoke glue. `harn crystallize
+  --bundle BUNDLE_DIR` emits the bundle, `harn crystallize validate
+  BUNDLE_DIR` smoke-checks it (schema marker, required files, redaction,
+  logical-only secret ids), and `harn crystallize shadow BUNDLE_DIR`
+  re-runs the deterministic shadow comparison from the bundle's redacted
+  fixtures with no live side effects. Bundle redaction scrubs sensitive
+  keys (`token`, `secret`, `password`, `api_key`, `authorization`,
+  `cookie`) and secret-shaped values (`sk-…`, `ghp_…`, `xoxb-…`,
+  `AKIA…`, long credential-shaped runs) before fixtures are written.
 - **Flow predicate-language design record (#584).** Added
   `docs/src/flow-predicates.md` with explicit decisions for predicate budget
   semantics, bootstrap signing, semantic predicate determinism, and

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -978,18 +978,48 @@ pub(crate) struct TraceImportArgs {
 
 #[derive(Debug, Args)]
 pub(crate) struct CrystallizeArgs {
+    #[command(subcommand)]
+    pub command: Option<CrystallizeCommand>,
+
     /// Directory containing crystallization trace JSON files or persisted run records.
+    /// Required when no subcommand is given.
     #[arg(long = "from", value_name = "TRACE_DIR")]
-    pub from: String,
+    pub from: Option<String>,
     /// Output path for the generated .harn workflow candidate.
+    /// Required when no subcommand is given.
     #[arg(long = "out", value_name = "WORKFLOW")]
-    pub out: String,
+    pub out: Option<String>,
     /// Output path for the machine-readable crystallization report.
+    /// Required when no subcommand is given.
     #[arg(long = "report", value_name = "REPORT_JSON")]
-    pub report: String,
+    pub report: Option<String>,
     /// Optional output path for a minimal eval pack manifest.
     #[arg(long = "eval-pack", value_name = "HARN_EVAL_TOML")]
     pub eval_pack: Option<String>,
+    /// Optional bundle directory. When set, the CLI also emits a portable
+    /// crystallization bundle (`candidate.json`, `workflow.harn`,
+    /// `report.json`, `harn.eval.toml`, redacted `fixtures/`) ready for
+    /// Harn Cloud import.
+    #[arg(long = "bundle", value_name = "BUNDLE_DIR")]
+    pub bundle: Option<String>,
+    /// Override the bundle's external_key (defaults to a sanitized workflow name).
+    #[arg(long = "bundle-external-key", value_name = "KEY")]
+    pub bundle_external_key: Option<String>,
+    /// Override the bundle's title.
+    #[arg(long = "bundle-title", value_name = "TITLE")]
+    pub bundle_title: Option<String>,
+    /// Optional team label to place in the bundle manifest.
+    #[arg(long = "bundle-team", value_name = "TEAM")]
+    pub bundle_team: Option<String>,
+    /// Optional repo identifier to place in the bundle manifest.
+    #[arg(long = "bundle-repo", value_name = "REPO")]
+    pub bundle_repo: Option<String>,
+    /// Override the bundle's risk level (low/medium/high).
+    #[arg(long = "bundle-risk-level", value_name = "LEVEL")]
+    pub bundle_risk_level: Option<String>,
+    /// Override the bundle's rollout policy (defaults to `shadow_then_canary`).
+    #[arg(long = "bundle-rollout-policy", value_name = "POLICY")]
+    pub bundle_rollout_policy: Option<String>,
     /// Minimum number of traces that must contain the repeated sequence.
     #[arg(long = "min-examples", default_value_t = 2)]
     pub min_examples: usize,
@@ -1005,6 +1035,26 @@ pub(crate) struct CrystallizeArgs {
     /// Approver to include in promotion metadata.
     #[arg(long = "approver", value_name = "USER")]
     pub approver: Option<String>,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum CrystallizeCommand {
+    /// Validate a crystallization candidate bundle on disk.
+    Validate(CrystallizeValidateArgs),
+    /// Re-run shadow comparison from a bundle's redacted fixtures (no live side effects).
+    Shadow(CrystallizeShadowArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct CrystallizeValidateArgs {
+    /// Path to the bundle directory.
+    pub bundle_dir: String,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct CrystallizeShadowArgs {
+    /// Path to the bundle directory.
+    pub bundle_dir: String,
 }
 
 #[derive(Debug, Args)]
@@ -2420,8 +2470,8 @@ mod tests {
     use std::time::Duration as StdDuration;
 
     use super::{
-        Cli, Command, ConnectCommand, FlowArchivistCommand, FlowCommand, McpCommand,
-        OrchestratorCommand, OrchestratorDeployProvider, OrchestratorLogFormat,
+        Cli, Command, ConnectCommand, CrystallizeCommand, FlowArchivistCommand, FlowCommand,
+        McpCommand, OrchestratorCommand, OrchestratorDeployProvider, OrchestratorLogFormat,
         OrchestratorQueueCommand, OrchestratorTenantCommand, PackageCacheCommand, PackageCommand,
         ProjectTemplate, RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand,
         SkillsCommand, TraceCommand, TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
@@ -2792,12 +2842,54 @@ mod tests {
         let Command::Crystallize(args) = cli.command.unwrap() else {
             panic!("expected crystallize command");
         };
-        assert_eq!(args.from, "fixtures/crystallize");
-        assert_eq!(args.out, "workflows/version_bump.harn");
-        assert_eq!(args.report, "reports/version_bump.json");
+        assert!(args.command.is_none());
+        assert_eq!(args.from.as_deref(), Some("fixtures/crystallize"));
+        assert_eq!(args.out.as_deref(), Some("workflows/version_bump.harn"));
+        assert_eq!(args.report.as_deref(), Some("reports/version_bump.json"));
         assert_eq!(args.eval_pack.as_deref(), Some("harn.eval.toml"));
         assert_eq!(args.min_examples, 5);
         assert_eq!(args.workflow_name.as_deref(), Some("version_bump"));
+    }
+
+    #[test]
+    fn test_parses_crystallize_validate_subcommand() {
+        let cli = Cli::parse_from(["harn", "crystallize", "validate", "bundles/version-bump"]);
+
+        let Command::Crystallize(args) = cli.command.unwrap() else {
+            panic!("expected crystallize command");
+        };
+        let Some(CrystallizeCommand::Validate(validate)) = args.command else {
+            panic!("expected validate subcommand");
+        };
+        assert_eq!(validate.bundle_dir, "bundles/version-bump");
+    }
+
+    #[test]
+    fn test_parses_crystallize_bundle_flag() {
+        let cli = Cli::parse_from([
+            "harn",
+            "crystallize",
+            "--from",
+            "fixtures/crystallize",
+            "--out",
+            "workflows/version_bump.harn",
+            "--report",
+            "reports/version_bump.json",
+            "--bundle",
+            "bundles/version-bump",
+            "--bundle-team",
+            "platform",
+            "--bundle-risk-level",
+            "medium",
+        ]);
+
+        let Command::Crystallize(args) = cli.command.unwrap() else {
+            panic!("expected crystallize command");
+        };
+        assert!(args.command.is_none());
+        assert_eq!(args.bundle.as_deref(), Some("bundles/version-bump"));
+        assert_eq!(args.bundle_team.as_deref(), Some("platform"));
+        assert_eq!(args.bundle_risk_level.as_deref(), Some("medium"));
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/crystallize.rs
+++ b/crates/harn-cli/src/commands/crystallize.rs
@@ -1,11 +1,35 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use crate::cli::CrystallizeArgs;
+use crate::cli::{
+    CrystallizeArgs, CrystallizeCommand, CrystallizeShadowArgs, CrystallizeValidateArgs,
+};
 
 pub(crate) fn run(args: CrystallizeArgs) -> Result<(), String> {
-    let traces =
-        harn_vm::orchestration::load_crystallization_traces_from_dir(Path::new(&args.from))
-            .map_err(|error| error.to_string())?;
+    match args.command {
+        Some(CrystallizeCommand::Validate(validate)) => run_validate(validate),
+        Some(CrystallizeCommand::Shadow(shadow)) => run_shadow(shadow),
+        None => run_mine(args),
+    }
+}
+
+fn run_mine(args: CrystallizeArgs) -> Result<(), String> {
+    let from = args
+        .from
+        .as_deref()
+        .ok_or_else(|| "--from is required when no subcommand is given".to_string())?;
+    let out = args
+        .out
+        .as_deref()
+        .ok_or_else(|| "--out is required when no subcommand is given".to_string())?;
+    let report = args
+        .report
+        .as_deref()
+        .ok_or_else(|| "--report is required when no subcommand is given".to_string())?;
+
+    let trace_dir = PathBuf::from(from);
+    let traces = harn_vm::orchestration::load_crystallization_traces_from_dir(&trace_dir)
+        .map_err(|error| error.to_string())?;
+    let normalized = traces.clone();
     let artifacts = harn_vm::orchestration::crystallize_traces(
         traces,
         harn_vm::orchestration::CrystallizeOptions {
@@ -19,30 +43,136 @@ pub(crate) fn run(args: CrystallizeArgs) -> Result<(), String> {
     )
     .map_err(|error| error.to_string())?;
 
-    let report = harn_vm::orchestration::write_crystallization_artifacts(
+    let bundle = if args.bundle.is_some() {
+        Some(
+            harn_vm::orchestration::build_crystallization_bundle(
+                artifacts.clone(),
+                &normalized,
+                harn_vm::orchestration::BundleOptions {
+                    external_key: args.bundle_external_key.clone(),
+                    title: args.bundle_title.clone(),
+                    team: args.bundle_team.clone(),
+                    repo: args.bundle_repo.clone(),
+                    risk_level: args.bundle_risk_level.clone(),
+                    rollout_policy: args.bundle_rollout_policy.clone(),
+                },
+            )
+            .map_err(|error| error.to_string())?,
+        )
+    } else {
+        None
+    };
+
+    let report_struct = harn_vm::orchestration::write_crystallization_artifacts(
         artifacts,
-        Path::new(&args.out),
-        Path::new(&args.report),
+        Path::new(out),
+        Path::new(report),
         args.eval_pack.as_deref().map(Path::new),
     )
     .map_err(|error| error.to_string())?;
 
-    let selected = report.selected_candidate_id.as_deref().unwrap_or("none");
+    let selected = report_struct
+        .selected_candidate_id
+        .as_deref()
+        .unwrap_or("none");
     println!(
         "Crystallization: selected={selected} candidates={} rejected={} traces={}",
-        report.candidates.len(),
-        report.rejected_candidates.len(),
-        report.source_trace_count
+        report_struct.candidates.len(),
+        report_struct.rejected_candidates.len(),
+        report_struct.source_trace_count
     );
-    println!("Workflow: {}", args.out);
-    println!("Report: {}", args.report);
+    println!("Workflow: {out}");
+    println!("Report: {report}");
     if let Some(path) = args.eval_pack.as_deref() {
         println!("Eval pack: {path}");
     }
 
-    if report.selected_candidate_id.is_none() {
+    if let (Some(bundle_dir), Some(bundle)) = (args.bundle.as_deref(), bundle) {
+        let manifest =
+            harn_vm::orchestration::write_crystallization_bundle(&bundle, Path::new(bundle_dir))
+                .map_err(|error| error.to_string())?;
+        println!(
+            "Bundle: {bundle_dir} (kind={:?} schema_version={} fixtures={})",
+            manifest.kind,
+            manifest.schema_version,
+            manifest.fixtures.len()
+        );
+    }
+
+    if report_struct.selected_candidate_id.is_none() {
         return Err("no safe crystallization candidate was proposed".to_string());
     }
 
     Ok(())
+}
+
+fn run_validate(args: CrystallizeValidateArgs) -> Result<(), String> {
+    let validation =
+        harn_vm::orchestration::validate_crystallization_bundle(Path::new(&args.bundle_dir))
+            .map_err(|error| error.to_string())?;
+    println!(
+        "Bundle: {} (schema={} schema_version={} kind={:?} candidate_id={})",
+        validation.bundle_dir,
+        if validation.schema.is_empty() {
+            "(unknown)".to_string()
+        } else {
+            validation.schema.clone()
+        },
+        validation.schema_version,
+        validation.kind,
+        if validation.candidate_id.is_empty() {
+            "-"
+        } else {
+            validation.candidate_id.as_str()
+        }
+    );
+    println!(
+        "Checks: manifest={} workflow={} report={} eval_pack={} fixtures={} redaction={}",
+        ok_label(validation.manifest_ok),
+        ok_label(validation.workflow_ok),
+        ok_label(validation.report_ok),
+        ok_label(validation.eval_pack_ok),
+        ok_label(validation.fixtures_ok),
+        ok_label(validation.redaction_ok),
+    );
+    if validation.problems.is_empty() {
+        println!("OK");
+        Ok(())
+    } else {
+        for problem in &validation.problems {
+            eprintln!("- {problem}");
+        }
+        Err(format!(
+            "bundle validation failed with {} problem(s)",
+            validation.problems.len()
+        ))
+    }
+}
+
+fn run_shadow(args: CrystallizeShadowArgs) -> Result<(), String> {
+    let (manifest, shadow) =
+        harn_vm::orchestration::shadow_replay_bundle(Path::new(&args.bundle_dir))
+            .map_err(|error| error.to_string())?;
+    println!(
+        "Shadow replay: bundle={} candidate_id={} compared={} pass={}",
+        args.bundle_dir, manifest.candidate_id, shadow.compared_traces, shadow.pass
+    );
+    if !shadow.failures.is_empty() {
+        for failure in &shadow.failures {
+            eprintln!("- {failure}");
+        }
+        return Err(format!(
+            "shadow replay failed with {} failure(s)",
+            shadow.failures.len()
+        ));
+    }
+    Ok(())
+}
+
+fn ok_label(value: bool) -> &'static str {
+    if value {
+        "ok"
+    } else {
+        "fail"
+    }
 }

--- a/crates/harn-cli/tests/crystallize_cli.rs
+++ b/crates/harn-cli/tests/crystallize_cli.rs
@@ -1,0 +1,252 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+fn run_harn(cwd: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .expect("failed to spawn harn binary")
+}
+
+fn write_trace(dir: &Path, name: &str, payload: &Value) {
+    let path = dir.join(name);
+    fs::write(&path, serde_json::to_vec_pretty(payload).unwrap()).unwrap();
+}
+
+fn version_bump_trace(idx: usize) -> Value {
+    let version = format!("0.7.{idx}");
+    json!({
+        "version": 1,
+        "id": format!("trace_release_{idx}"),
+        "actions": [
+            {
+                "id": format!("trace_release_{idx}-checkout"),
+                "kind": "tool_call",
+                "name": "git.checkout_branch",
+                "parameters": {
+                    "repo_path": format!("/work/harn-{idx}"),
+                    "branch_name": format!("release-{version}")
+                },
+                "side_effects": [
+                    {"kind": "git_ref", "target": "release-branch", "capability": "git.write"}
+                ],
+                "capabilities": ["git.write"],
+                "deterministic": true
+            },
+            {
+                "id": format!("trace_release_{idx}-manifest"),
+                "kind": "file_mutation",
+                "name": "update_manifest_version",
+                "parameters": {"version": version, "path": "harn.toml"},
+                "inputs": {"path": "harn.toml", "version": version},
+                "side_effects": [
+                    {"kind": "file_write", "target": "harn.toml", "capability": "fs.write"}
+                ],
+                "capabilities": ["fs.write"],
+                "deterministic": true
+            },
+            {
+                "id": format!("trace_release_{idx}-release"),
+                "kind": "tool_call",
+                "name": "prepare_release_notes",
+                "parameters": {
+                    "release_target": "crates.io",
+                    "version": version
+                },
+                "deterministic": true
+            }
+        ]
+    })
+}
+
+fn plan_only_trace(idx: usize) -> Value {
+    json!({
+        "version": 1,
+        "id": format!("trace_plan_{idx}"),
+        "actions": [
+            {
+                "id": format!("trace_plan_{idx}-classify"),
+                "kind": "tool_call",
+                "name": "classify_issue",
+                "parameters": {
+                    "issue_id": format!("HAR-{idx}"),
+                    "team_key": "HAR"
+                },
+                "capabilities": ["linear.read"],
+                "deterministic": true
+            },
+            {
+                "id": format!("trace_plan_{idx}-receipt"),
+                "kind": "receipt_write",
+                "name": "emit_receipt",
+                "parameters": {"kind": "plan", "summary": format!("plan-only #{idx}")},
+                "side_effects": [
+                    {
+                        "kind": "receipt_write",
+                        "target": "tenant_event_log",
+                        "capability": "receipt.write"
+                    }
+                ],
+                "capabilities": ["receipt.write"],
+                "deterministic": true
+            }
+        ]
+    })
+}
+
+#[test]
+fn crystallize_version_bump_emits_validatable_bundle() {
+    let temp = TempDir::new().unwrap();
+    let traces_dir = temp.path().join("traces");
+    fs::create_dir_all(&traces_dir).unwrap();
+    for idx in 0..5 {
+        write_trace(
+            &traces_dir,
+            &format!("release_{idx}.json"),
+            &version_bump_trace(idx),
+        );
+    }
+    let workflow_path = temp.path().join("version_bump.harn");
+    let report_path = temp.path().join("report.json");
+    let eval_pack_path = temp.path().join("version_bump.harn.eval.toml");
+    let bundle_dir = temp.path().join("bundle");
+
+    let mine = run_harn(
+        temp.path(),
+        &[
+            "crystallize",
+            "--from",
+            traces_dir.to_str().unwrap(),
+            "--out",
+            workflow_path.to_str().unwrap(),
+            "--report",
+            report_path.to_str().unwrap(),
+            "--eval-pack",
+            eval_pack_path.to_str().unwrap(),
+            "--bundle",
+            bundle_dir.to_str().unwrap(),
+            "--workflow-name",
+            "version_bump",
+            "--package-name",
+            "release-workflows",
+            "--bundle-team",
+            "platform",
+            "--bundle-repo",
+            "burin-labs/harn",
+            "--min-examples",
+            "5",
+        ],
+    );
+    assert!(
+        mine.status.success(),
+        "mine failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&mine.stdout),
+        String::from_utf8_lossy(&mine.stderr),
+    );
+
+    // Manifest sanity check: schema marker, fixture redaction, plan-vs-candidate kind.
+    let manifest_path = bundle_dir.join("candidate.json");
+    let manifest: Value = serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
+    assert_eq!(
+        manifest["schema"],
+        Value::String("harn.crystallization.candidate.bundle".to_string())
+    );
+    assert_eq!(manifest["schema_version"], json!(1));
+    assert_eq!(manifest["kind"], json!("candidate"));
+    assert_eq!(manifest["external_key"], json!("version-bump"));
+    let workflow = &manifest["workflow"];
+    assert_eq!(workflow["name"], json!("version_bump"));
+    assert_eq!(workflow["package_name"], json!("release-workflows"));
+    assert_eq!(workflow["path"], json!("workflow.harn"));
+    assert_eq!(manifest["team"], json!("platform"));
+    let fixtures = manifest["fixtures"].as_array().unwrap();
+    assert_eq!(fixtures.len(), 5);
+    assert!(fixtures
+        .iter()
+        .all(|fixture| fixture["redacted"] == json!(true)));
+
+    // The validate subcommand exits 0 and reports OK.
+    let validate = run_harn(
+        temp.path(),
+        &["crystallize", "validate", bundle_dir.to_str().unwrap()],
+    );
+    assert!(
+        validate.status.success(),
+        "validate failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&validate.stdout),
+        String::from_utf8_lossy(&validate.stderr),
+    );
+    assert!(String::from_utf8_lossy(&validate.stdout).contains("OK"));
+
+    // Shadow replay also passes against the bundle's own redacted fixtures.
+    let shadow = run_harn(
+        temp.path(),
+        &["crystallize", "shadow", bundle_dir.to_str().unwrap()],
+    );
+    assert!(
+        shadow.status.success(),
+        "shadow failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&shadow.stdout),
+        String::from_utf8_lossy(&shadow.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&shadow.stdout);
+    assert!(stdout.contains("pass=true"));
+}
+
+#[test]
+fn crystallize_plan_only_bundle_keeps_plan_only_kind() {
+    let temp = TempDir::new().unwrap();
+    let traces_dir = temp.path().join("traces");
+    fs::create_dir_all(&traces_dir).unwrap();
+    for idx in 0..3 {
+        write_trace(
+            &traces_dir,
+            &format!("plan_{idx}.json"),
+            &plan_only_trace(idx),
+        );
+    }
+    let workflow_path = temp.path().join("plan.harn");
+    let report_path = temp.path().join("plan.report.json");
+    let bundle_dir = temp.path().join("bundle");
+
+    let mine = run_harn(
+        temp.path(),
+        &[
+            "crystallize",
+            "--from",
+            traces_dir.to_str().unwrap(),
+            "--out",
+            workflow_path.to_str().unwrap(),
+            "--report",
+            report_path.to_str().unwrap(),
+            "--bundle",
+            bundle_dir.to_str().unwrap(),
+            "--workflow-name",
+            "linear_triage_plan",
+            "--min-examples",
+            "3",
+        ],
+    );
+    assert!(mine.status.success(), "{:?}", mine);
+
+    let manifest: Value =
+        serde_json::from_slice(&fs::read(bundle_dir.join("candidate.json")).unwrap()).unwrap();
+    assert_eq!(manifest["kind"], json!("plan_only"));
+    assert_eq!(manifest["risk_level"], json!("low"));
+
+    let validate = run_harn(
+        temp.path(),
+        &["crystallize", "validate", bundle_dir.to_str().unwrap()],
+    );
+    assert!(
+        validate.status.success(),
+        "validate failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&validate.stdout),
+        String::from_utf8_lossy(&validate.stderr),
+    );
+}

--- a/crates/harn-vm/src/orchestration/crystallize.rs
+++ b/crates/harn-vm/src/orchestration/crystallize.rs
@@ -21,6 +21,25 @@ use crate::value::VmError;
 const TRACE_SCHEMA_VERSION: u32 = 1;
 const DEFAULT_MIN_EXAMPLES: usize = 2;
 
+/// Stable schema marker for `candidate.json` inside a crystallization
+/// bundle. Cloud importers and other downstream consumers should refuse
+/// bundles whose `schema` field is anything else.
+pub const BUNDLE_SCHEMA: &str = "harn.crystallization.candidate.bundle";
+/// Versioned schema number for the bundle manifest. Cloud importers and
+/// other consumers should refuse bundles whose `schema_version` is newer
+/// than the highest version they understand.
+pub const BUNDLE_SCHEMA_VERSION: u32 = 1;
+/// Conventional file names inside a crystallization bundle directory.
+pub const BUNDLE_MANIFEST_FILE: &str = "candidate.json";
+pub const BUNDLE_REPORT_FILE: &str = "report.json";
+pub const BUNDLE_WORKFLOW_FILE: &str = "workflow.harn";
+pub const BUNDLE_EVAL_PACK_FILE: &str = "harn.eval.toml";
+pub const BUNDLE_FIXTURES_DIR: &str = "fixtures";
+
+/// Default rollout policy applied when a bundle is emitted without one
+/// explicitly configured. Hosted promotion surfaces can override it.
+const DEFAULT_ROLLOUT_POLICY: &str = "shadow_then_canary";
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct CrystallizationTrace {
@@ -1424,6 +1443,931 @@ fn escape_harn_string(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
+// ===== Crystallization bundle =====
+//
+// A bundle is a directory layout that Harn writes and Harn Cloud (or any
+// other importer) reads without bespoke glue. The contract is:
+//
+//   bundle/
+//     candidate.json        # versioned manifest documented below
+//     workflow.harn         # generated/reviewable workflow code
+//     report.json           # full mining/shadow/eval report
+//     harn.eval.toml        # generated eval pack when available (optional)
+//     fixtures/             # redacted replay fixtures referenced by the
+//                           # report (optional, only when --bundle is used
+//                           # with `harn crystallize` and traces were on disk)
+//
+// `candidate.json` is the authoritative manifest. It must include the
+// `schema` and `schema_version` markers. Cloud importers MUST reject any
+// bundle whose `schema` is not exactly `harn.crystallization.candidate.bundle`
+// or whose `schema_version` is greater than the highest version they
+// understand. Only the documented additive fields may be added without
+// bumping `schema_version`.
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BundleGenerator {
+    pub tool: String,
+    pub version: String,
+}
+
+impl Default for BundleGenerator {
+    fn default() -> Self {
+        Self {
+            tool: "harn".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BundleWorkflowRef {
+    /// Relative path inside the bundle directory.
+    pub path: String,
+    /// Short identifier used in `pipeline NAME(...)`.
+    pub name: String,
+    /// Logical package name promotion uses to register the workflow.
+    pub package_name: String,
+    /// Initial workflow version proposed for promotion.
+    pub package_version: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BundleSourceTrace {
+    pub trace_id: String,
+    pub source_hash: String,
+    /// Optional human-visible URL (PR, issue, run record path) for the
+    /// trace. `None` when the trace was loaded from an in-memory store.
+    pub source_url: Option<String>,
+    /// Optional cloud-side receipt id when the trace was already promoted
+    /// into a tenant receipt. Cloud importers use this to wire candidate
+    /// evidence to existing receipts without round-tripping the raw payload.
+    pub source_receipt_id: Option<String>,
+    /// Relative path of the redacted fixture inside the bundle, if one
+    /// was emitted.
+    pub fixture_path: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct BundleStep {
+    pub index: usize,
+    pub kind: String,
+    pub name: String,
+    pub segment: SegmentKind,
+    pub parameter_refs: Vec<String>,
+    pub side_effects: Vec<CrystallizationSideEffect>,
+    pub capabilities: Vec<String>,
+    pub required_secrets: Vec<String>,
+    pub approval: Option<CrystallizationApproval>,
+    pub review_notes: Vec<String>,
+}
+
+impl BundleStep {
+    fn from_candidate_step(step: &WorkflowCandidateStep) -> Self {
+        Self {
+            index: step.index,
+            kind: step.kind.clone(),
+            name: step.name.clone(),
+            segment: step.segment.clone(),
+            parameter_refs: step.parameter_refs.clone(),
+            side_effects: step.side_effects.clone(),
+            capabilities: step.capabilities.clone(),
+            required_secrets: step.required_secrets.clone(),
+            approval: step.approval.clone(),
+            review_notes: step.review_notes.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BundleEvalPackRef {
+    /// Relative path of the eval pack inside the bundle directory.
+    pub path: String,
+    /// Optional external link the eval pack also lives at (e.g. a hosted
+    /// `eval-pack://` URI when the bundle was promoted into a tenant).
+    pub link: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BundleFixtureRef {
+    pub path: String,
+    pub trace_id: String,
+    pub source_hash: String,
+    pub redacted: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BundlePromotion {
+    pub owner: Option<String>,
+    pub approver: Option<String>,
+    pub author: Option<String>,
+    /// Logical rollout strategy. Defaults to `shadow_then_canary`. Hosted
+    /// surfaces may extend this enum but must keep existing values stable.
+    pub rollout_policy: String,
+    pub rollback_target: Option<String>,
+    pub created_at: String,
+    pub workflow_version: String,
+    pub package_name: String,
+}
+
+impl Default for BundlePromotion {
+    fn default() -> Self {
+        Self {
+            owner: None,
+            approver: None,
+            author: None,
+            rollout_policy: DEFAULT_ROLLOUT_POLICY.to_string(),
+            rollback_target: None,
+            created_at: String::new(),
+            workflow_version: String::new(),
+            package_name: String::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BundleRedactionSummary {
+    pub applied: bool,
+    pub rules: Vec<String>,
+    pub summary: String,
+    /// Number of fixture files copied into the bundle (0 when no fixture
+    /// directory was emitted).
+    pub fixture_count: usize,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct CrystallizationBundleManifest {
+    pub schema: String,
+    pub schema_version: u32,
+    pub generated_at: String,
+    pub generator: BundleGenerator,
+    pub kind: BundleKind,
+    pub candidate_id: String,
+    pub external_key: String,
+    pub title: String,
+    pub team: Option<String>,
+    pub repo: Option<String>,
+    pub risk_level: String,
+    pub workflow: BundleWorkflowRef,
+    pub source_trace_hashes: Vec<String>,
+    pub source_traces: Vec<BundleSourceTrace>,
+    pub deterministic_steps: Vec<BundleStep>,
+    pub fuzzy_steps: Vec<BundleStep>,
+    pub side_effects: Vec<CrystallizationSideEffect>,
+    pub capabilities: Vec<String>,
+    pub required_secrets: Vec<String>,
+    pub savings: SavingsEstimate,
+    pub shadow: ShadowRunReport,
+    pub eval_pack: Option<BundleEvalPackRef>,
+    pub fixtures: Vec<BundleFixtureRef>,
+    pub promotion: BundlePromotion,
+    pub redaction: BundleRedactionSummary,
+    pub confidence: f64,
+    pub rejection_reasons: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BundleKind {
+    /// A normal candidate that passed shadow comparison and is ready for
+    /// review and promotion.
+    #[default]
+    Candidate,
+    /// A "plan-only" candidate: every step has a side-effect-free, in-process
+    /// outcome (e.g. classify and write a receipt). Cloud importers can
+    /// promote these without explicit external-side-effect approval.
+    PlanOnly,
+    /// No safe candidate was selected. The bundle still records what was
+    /// attempted, the rejection reasons, and any rejected candidates so
+    /// reviewers can debug or feed it back into mining.
+    Rejected,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct BundleOptions {
+    /// Stable identifier downstream cloud importers use to dedupe bundles
+    /// across runs (defaults to a sanitized workflow name).
+    pub external_key: Option<String>,
+    pub title: Option<String>,
+    pub team: Option<String>,
+    pub repo: Option<String>,
+    pub risk_level: Option<String>,
+    pub rollout_policy: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct CrystallizationBundle {
+    pub manifest: CrystallizationBundleManifest,
+    pub report: CrystallizationReport,
+    pub harn_code: String,
+    pub eval_pack_toml: String,
+    pub fixtures: Vec<CrystallizationTrace>,
+}
+
+/// Errors surfaced when validating a bundle on disk.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BundleValidation {
+    pub bundle_dir: String,
+    pub schema: String,
+    pub schema_version: u32,
+    pub kind: BundleKind,
+    pub candidate_id: String,
+    pub manifest_ok: bool,
+    pub workflow_ok: bool,
+    pub report_ok: bool,
+    pub eval_pack_ok: bool,
+    pub fixtures_ok: bool,
+    pub redaction_ok: bool,
+    pub problems: Vec<String>,
+}
+
+impl BundleValidation {
+    pub fn is_ok(&self) -> bool {
+        self.problems.is_empty()
+    }
+}
+
+/// Build an in-memory bundle from already-mined artifacts. The traces
+/// passed here are the same normalized traces used to mine the candidate;
+/// they will be redacted before being attached as fixtures.
+pub fn build_crystallization_bundle(
+    artifacts: CrystallizationArtifacts,
+    traces: &[CrystallizationTrace],
+    options: BundleOptions,
+) -> Result<CrystallizationBundle, VmError> {
+    let CrystallizationArtifacts {
+        report,
+        harn_code,
+        eval_pack_toml,
+    } = artifacts;
+
+    let (selected, kind) = match report
+        .selected_candidate_id
+        .as_deref()
+        .and_then(|id| report.candidates.iter().find(|c| c.id == id))
+    {
+        Some(candidate) => {
+            let kind = if candidate_is_plan_only(candidate) {
+                BundleKind::PlanOnly
+            } else {
+                BundleKind::Candidate
+            };
+            (Some(candidate), kind)
+        }
+        None => (None, BundleKind::Rejected),
+    };
+
+    let workflow_name = selected
+        .map(|candidate| candidate.name.clone())
+        .unwrap_or_else(|| "crystallized_workflow".to_string());
+    let package_name = selected
+        .map(|candidate| candidate.promotion.package_name.clone())
+        .unwrap_or_else(|| workflow_name.replace('_', "-"));
+    let workflow_version = selected
+        .map(|candidate| candidate.promotion.version.clone())
+        .unwrap_or_else(|| "0.0.0".to_string());
+
+    let manifest_workflow = BundleWorkflowRef {
+        path: BUNDLE_WORKFLOW_FILE.to_string(),
+        name: workflow_name.clone(),
+        package_name: package_name.clone(),
+        package_version: workflow_version.clone(),
+    };
+
+    let external_key = options
+        .external_key
+        .clone()
+        .filter(|key| !key.trim().is_empty())
+        .unwrap_or_else(|| sanitize_external_key(&workflow_name));
+    let title = options
+        .title
+        .clone()
+        .filter(|title| !title.trim().is_empty())
+        .unwrap_or_else(|| infer_bundle_title(selected, &workflow_name));
+    let risk_level = options
+        .risk_level
+        .clone()
+        .filter(|risk| !risk.trim().is_empty())
+        .unwrap_or_else(|| infer_risk_level(selected));
+    let rollout_policy = options
+        .rollout_policy
+        .clone()
+        .filter(|policy| !policy.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_ROLLOUT_POLICY.to_string());
+
+    let (deterministic_steps, fuzzy_steps) = match selected {
+        Some(candidate) => candidate
+            .steps
+            .iter()
+            .map(BundleStep::from_candidate_step)
+            .partition::<Vec<_>, _>(|step| step.segment == SegmentKind::Deterministic),
+        None => (Vec::new(), Vec::new()),
+    };
+
+    let source_trace_hashes = selected
+        .map(|candidate| candidate.promotion.source_trace_hashes.clone())
+        .unwrap_or_default();
+
+    let mut source_traces = Vec::new();
+    let mut fixture_refs = Vec::new();
+    let mut fixture_payloads = Vec::new();
+    if let Some(candidate) = selected {
+        for example in &candidate.examples {
+            let trace = traces.iter().find(|trace| trace.id == example.trace_id);
+            let fixture_relative = trace.map(|trace| {
+                format!(
+                    "{BUNDLE_FIXTURES_DIR}/{}.json",
+                    sanitize_fixture_name(&trace.id)
+                )
+            });
+            source_traces.push(BundleSourceTrace {
+                trace_id: example.trace_id.clone(),
+                source_hash: example.source_hash.clone(),
+                source_url: trace.and_then(|trace| trace.source.clone()),
+                source_receipt_id: trace
+                    .and_then(|trace| trace.metadata.get("source_receipt_id"))
+                    .and_then(|value| value.as_str().map(str::to_string)),
+                fixture_path: fixture_relative.clone(),
+            });
+            if let (Some(trace), Some(fixture_path)) = (trace, fixture_relative.clone()) {
+                let mut redacted = trace.clone();
+                redact_trace_for_bundle(&mut redacted);
+                fixture_refs.push(BundleFixtureRef {
+                    path: fixture_path,
+                    trace_id: trace.id.clone(),
+                    source_hash: trace.source_hash.clone().unwrap_or_default(),
+                    redacted: true,
+                });
+                fixture_payloads.push(redacted);
+            }
+        }
+    }
+
+    // Owner defaults to author so cloud importers always have a populated
+    // ownership pointer, but stays separate from `author` so reviewers can
+    // assign a different owner in the manifest before promotion.
+    let author = selected.and_then(|candidate| candidate.promotion.author.clone());
+    let promotion = BundlePromotion {
+        owner: author.clone(),
+        approver: selected.and_then(|candidate| candidate.promotion.approver.clone()),
+        author,
+        rollout_policy,
+        rollback_target: selected.and_then(|candidate| candidate.promotion.rollback_target.clone()),
+        created_at: now_rfc3339(),
+        workflow_version,
+        package_name: package_name.clone(),
+    };
+
+    let redaction = BundleRedactionSummary {
+        applied: !fixture_payloads.is_empty(),
+        rules: vec![
+            "sensitive_keys".to_string(),
+            "secret_value_heuristic".to_string(),
+        ],
+        summary: if fixture_payloads.is_empty() {
+            "no fixtures emitted".to_string()
+        } else {
+            "fixture payloads scrubbed of secret-like values and sensitive keys before write"
+                .to_string()
+        },
+        fixture_count: fixture_payloads.len(),
+    };
+
+    let eval_pack = if eval_pack_toml.trim().is_empty() {
+        None
+    } else {
+        Some(BundleEvalPackRef {
+            path: BUNDLE_EVAL_PACK_FILE.to_string(),
+            link: selected
+                .and_then(|candidate| candidate.promotion.eval_pack_link.clone())
+                .filter(|link| !link.trim().is_empty()),
+        })
+    };
+
+    let manifest = CrystallizationBundleManifest {
+        schema: BUNDLE_SCHEMA.to_string(),
+        schema_version: BUNDLE_SCHEMA_VERSION,
+        generated_at: now_rfc3339(),
+        generator: BundleGenerator::default(),
+        kind,
+        candidate_id: selected
+            .map(|candidate| candidate.id.clone())
+            .unwrap_or_default(),
+        external_key,
+        title,
+        team: options.team,
+        repo: options.repo,
+        risk_level,
+        workflow: manifest_workflow,
+        source_trace_hashes,
+        source_traces,
+        deterministic_steps,
+        fuzzy_steps,
+        side_effects: selected
+            .map(|candidate| candidate.side_effects.clone())
+            .unwrap_or_default(),
+        capabilities: selected
+            .map(|candidate| candidate.capabilities.clone())
+            .unwrap_or_default(),
+        required_secrets: selected
+            .map(|candidate| candidate.required_secrets.clone())
+            .unwrap_or_default(),
+        savings: selected
+            .map(|candidate| candidate.savings.clone())
+            .unwrap_or_default(),
+        shadow: selected
+            .map(|candidate| candidate.shadow.clone())
+            .unwrap_or_default(),
+        eval_pack,
+        fixtures: fixture_refs,
+        promotion,
+        redaction,
+        confidence: selected
+            .map(|candidate| candidate.confidence)
+            .unwrap_or(0.0),
+        rejection_reasons: report
+            .rejected_candidates
+            .iter()
+            .flat_map(|candidate| candidate.rejection_reasons.iter().cloned())
+            .collect(),
+        warnings: report.warnings.clone(),
+    };
+
+    Ok(CrystallizationBundle {
+        manifest,
+        report,
+        harn_code,
+        eval_pack_toml,
+        fixtures: fixture_payloads,
+    })
+}
+
+/// Write a bundle to a directory. Creates the directory if it does not
+/// already exist. Returns the manifest with `generated_at` and any
+/// runtime-resolved metadata filled in.
+pub fn write_crystallization_bundle(
+    bundle: &CrystallizationBundle,
+    bundle_dir: &Path,
+) -> Result<CrystallizationBundleManifest, VmError> {
+    std::fs::create_dir_all(bundle_dir).map_err(|error| {
+        VmError::Runtime(format!(
+            "failed to create bundle dir {}: {error}",
+            bundle_dir.display()
+        ))
+    })?;
+    write_bytes(
+        &bundle_dir.join(BUNDLE_WORKFLOW_FILE),
+        bundle.harn_code.as_bytes(),
+    )?;
+    let report_json = serde_json::to_vec_pretty(&bundle.report)
+        .map_err(|error| VmError::Runtime(format!("failed to encode report JSON: {error}")))?;
+    write_bytes(&bundle_dir.join(BUNDLE_REPORT_FILE), &report_json)?;
+
+    if !bundle.eval_pack_toml.trim().is_empty() {
+        write_bytes(
+            &bundle_dir.join(BUNDLE_EVAL_PACK_FILE),
+            bundle.eval_pack_toml.as_bytes(),
+        )?;
+    }
+
+    if !bundle.fixtures.is_empty() {
+        let fixtures_dir = bundle_dir.join(BUNDLE_FIXTURES_DIR);
+        std::fs::create_dir_all(&fixtures_dir).map_err(|error| {
+            VmError::Runtime(format!(
+                "failed to create fixtures dir {}: {error}",
+                fixtures_dir.display()
+            ))
+        })?;
+        for trace in &bundle.fixtures {
+            let path = fixtures_dir.join(format!("{}.json", sanitize_fixture_name(&trace.id)));
+            let payload = serde_json::to_vec_pretty(trace).map_err(|error| {
+                VmError::Runtime(format!("failed to encode fixture {}: {error}", trace.id))
+            })?;
+            write_bytes(&path, &payload)?;
+        }
+    }
+
+    let manifest_json = serde_json::to_vec_pretty(&bundle.manifest)
+        .map_err(|error| VmError::Runtime(format!("failed to encode manifest JSON: {error}")))?;
+    write_bytes(&bundle_dir.join(BUNDLE_MANIFEST_FILE), &manifest_json)?;
+    Ok(bundle.manifest.clone())
+}
+
+/// Read a bundle manifest from disk. Verifies the schema marker but does
+/// not cross-check workflow/report/eval-pack sibling files; for a richer
+/// check use [`validate_crystallization_bundle`].
+pub fn load_crystallization_bundle_manifest(
+    bundle_dir: &Path,
+) -> Result<CrystallizationBundleManifest, VmError> {
+    let manifest_path = bundle_dir.join(BUNDLE_MANIFEST_FILE);
+    let bytes = std::fs::read(&manifest_path).map_err(|error| {
+        VmError::Runtime(format!(
+            "failed to read bundle manifest {}: {error}",
+            manifest_path.display()
+        ))
+    })?;
+    let manifest: CrystallizationBundleManifest =
+        serde_json::from_slice(&bytes).map_err(|error| {
+            VmError::Runtime(format!(
+                "failed to decode bundle manifest {}: {error}",
+                manifest_path.display()
+            ))
+        })?;
+    if manifest.schema != BUNDLE_SCHEMA {
+        return Err(VmError::Runtime(format!(
+            "bundle {} has unrecognized schema {:?} (expected {})",
+            bundle_dir.display(),
+            manifest.schema,
+            BUNDLE_SCHEMA
+        )));
+    }
+    if manifest.schema_version > BUNDLE_SCHEMA_VERSION {
+        return Err(VmError::Runtime(format!(
+            "bundle {} schema_version {} is newer than supported {}",
+            bundle_dir.display(),
+            manifest.schema_version,
+            BUNDLE_SCHEMA_VERSION
+        )));
+    }
+    Ok(manifest)
+}
+
+/// Read every fixture trace referenced by the bundle manifest. Returns
+/// the manifest plus loaded traces, in the order they appear in the
+/// manifest. Fixtures with `path: None` are skipped.
+pub fn load_crystallization_bundle(
+    bundle_dir: &Path,
+) -> Result<(CrystallizationBundleManifest, Vec<CrystallizationTrace>), VmError> {
+    let manifest = load_crystallization_bundle_manifest(bundle_dir)?;
+    let mut traces = Vec::new();
+    for fixture in &manifest.fixtures {
+        let path = bundle_dir.join(&fixture.path);
+        traces.push(load_crystallization_trace(&path)?);
+    }
+    Ok((manifest, traces))
+}
+
+/// Validate a bundle directory layout and contents. Cheap enough to call
+/// from a CLI smoke command; performs no live side effects.
+pub fn validate_crystallization_bundle(bundle_dir: &Path) -> Result<BundleValidation, VmError> {
+    let mut validation = BundleValidation {
+        bundle_dir: bundle_dir.display().to_string(),
+        ..BundleValidation::default()
+    };
+    let manifest = match load_crystallization_bundle_manifest(bundle_dir) {
+        Ok(manifest) => manifest,
+        Err(error) => {
+            validation.problems.push(error.to_string());
+            return Ok(validation);
+        }
+    };
+    validation.manifest_ok = true;
+    validation.schema = manifest.schema.clone();
+    validation.schema_version = manifest.schema_version;
+    validation.kind = manifest.kind.clone();
+    validation.candidate_id = manifest.candidate_id.clone();
+
+    let workflow_path = bundle_dir.join(&manifest.workflow.path);
+    if workflow_path.exists() {
+        validation.workflow_ok = true;
+    } else {
+        validation
+            .problems
+            .push(format!("missing workflow file {}", workflow_path.display()));
+    }
+
+    let report_path = bundle_dir.join(BUNDLE_REPORT_FILE);
+    match std::fs::read(&report_path) {
+        Ok(bytes) => match serde_json::from_slice::<CrystallizationReport>(&bytes) {
+            Ok(report) => {
+                validation.report_ok = true;
+                if matches!(manifest.kind, BundleKind::Candidate | BundleKind::PlanOnly)
+                    && manifest.candidate_id.is_empty()
+                {
+                    validation
+                        .problems
+                        .push("manifest is non-rejected but has empty candidate_id".to_string());
+                }
+                if matches!(manifest.kind, BundleKind::Candidate | BundleKind::PlanOnly)
+                    && report.selected_candidate_id.as_deref() != Some(&manifest.candidate_id)
+                {
+                    validation.problems.push(format!(
+                        "report selected_candidate_id {:?} does not match manifest candidate_id {}",
+                        report.selected_candidate_id, manifest.candidate_id
+                    ));
+                }
+            }
+            Err(error) => {
+                validation
+                    .problems
+                    .push(format!("invalid report.json: {error}"));
+            }
+        },
+        Err(error) => {
+            validation.problems.push(format!(
+                "missing report file {}: {error}",
+                report_path.display()
+            ));
+        }
+    }
+
+    if let Some(eval_pack) = &manifest.eval_pack {
+        let path = bundle_dir.join(&eval_pack.path);
+        if path.exists() {
+            validation.eval_pack_ok = true;
+        } else {
+            validation.problems.push(format!(
+                "manifest references eval pack {} but file is missing",
+                path.display()
+            ));
+        }
+    } else {
+        validation.eval_pack_ok = true;
+    }
+
+    let mut fixtures_problem = false;
+    for fixture in &manifest.fixtures {
+        let path = bundle_dir.join(&fixture.path);
+        if !path.exists() {
+            validation
+                .problems
+                .push(format!("missing fixture {}", path.display()));
+            fixtures_problem = true;
+            continue;
+        }
+        if !fixture.redacted {
+            validation.problems.push(format!(
+                "fixture {} is not marked redacted; bundle must not ship raw private payloads",
+                fixture.path
+            ));
+            fixtures_problem = true;
+        }
+    }
+    validation.fixtures_ok = !fixtures_problem;
+
+    if !manifest.redaction.applied && !manifest.fixtures.is_empty() {
+        validation
+            .problems
+            .push("redaction.applied is false but bundle includes fixtures".to_string());
+    } else {
+        validation.redaction_ok = true;
+    }
+    if !manifest
+        .required_secrets
+        .iter()
+        .all(|secret| secret_id_looks_logical(secret))
+    {
+        validation.problems.push(
+            "required_secrets contains a non-logical id (looks like a raw secret)".to_string(),
+        );
+    }
+
+    Ok(validation)
+}
+
+/// Replay shadow comparison from a bundle: re-runs the deterministic
+/// shadow check in-process against the bundle's redacted fixtures, with
+/// no live side effects. Returns the manifest and the freshly computed
+/// `ShadowRunReport`. The returned report is suitable for cloud import or
+/// for asserting determinism in CI.
+pub fn shadow_replay_bundle(
+    bundle_dir: &Path,
+) -> Result<(CrystallizationBundleManifest, ShadowRunReport), VmError> {
+    let (manifest, traces) = load_crystallization_bundle(bundle_dir)?;
+    let report_path = bundle_dir.join(BUNDLE_REPORT_FILE);
+    let bytes = std::fs::read(&report_path).map_err(|error| {
+        VmError::Runtime(format!(
+            "failed to read bundle report {}: {error}",
+            report_path.display()
+        ))
+    })?;
+    let report: CrystallizationReport = serde_json::from_slice(&bytes).map_err(|error| {
+        VmError::Runtime(format!(
+            "failed to decode bundle report {}: {error}",
+            report_path.display()
+        ))
+    })?;
+    let candidate = report
+        .selected_candidate_id
+        .as_deref()
+        .and_then(|id| report.candidates.iter().find(|c| c.id == id))
+        .ok_or_else(|| {
+            VmError::Runtime(format!(
+                "bundle {} has no selected candidate to replay",
+                bundle_dir.display()
+            ))
+        })?;
+    let shadow = shadow_candidate(candidate, &traces);
+    Ok((manifest, shadow))
+}
+
+fn write_bytes(path: &Path, bytes: &[u8]) -> Result<(), VmError> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            VmError::Runtime(format!(
+                "failed to create parent dir {}: {error}",
+                parent.display()
+            ))
+        })?;
+    }
+    std::fs::write(path, bytes)
+        .map_err(|error| VmError::Runtime(format!("failed to write {}: {error}", path.display())))
+}
+
+fn sanitize_fixture_name(raw: &str) -> String {
+    let cleaned = raw
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if cleaned.trim_matches('_').is_empty() {
+        "trace".to_string()
+    } else {
+        cleaned.trim_matches('_').to_string()
+    }
+}
+
+fn sanitize_external_key(raw: &str) -> String {
+    let mut out = String::new();
+    let mut prev_dash = false;
+    for ch in raw.chars() {
+        let lowered = ch.to_ascii_lowercase();
+        if lowered.is_ascii_alphanumeric() {
+            out.push(lowered);
+            prev_dash = false;
+        } else if !prev_dash && !out.is_empty() {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+    let trimmed = out.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        "crystallized-workflow".to_string()
+    } else {
+        trimmed
+    }
+}
+
+fn infer_bundle_title(candidate: Option<&WorkflowCandidate>, fallback_name: &str) -> String {
+    if let Some(candidate) = candidate {
+        format!(
+            "{} ({} step{})",
+            candidate.name,
+            candidate.steps.len(),
+            if candidate.steps.len() == 1 { "" } else { "s" }
+        )
+    } else {
+        format!("rejected: {fallback_name}")
+    }
+}
+
+fn infer_risk_level(candidate: Option<&WorkflowCandidate>) -> String {
+    let Some(candidate) = candidate else {
+        return "high".to_string();
+    };
+    let touches_external = candidate.side_effects.iter().any(side_effect_is_external);
+    let needs_secret = !candidate.required_secrets.is_empty();
+    if touches_external && needs_secret {
+        "high".to_string()
+    } else if touches_external || needs_secret {
+        "medium".to_string()
+    } else {
+        "low".to_string()
+    }
+}
+
+fn side_effect_is_external(effect: &CrystallizationSideEffect) -> bool {
+    let kind = effect.kind.to_ascii_lowercase();
+    if kind.is_empty() {
+        return false;
+    }
+    // Plan-only side effects stay inside Harn's own data plane: they
+    // write receipts, append to the in-process event log, or stash plans.
+    // None of those touch tenant-external systems.
+    let internal = kind.contains("receipt")
+        || kind.contains("event_log")
+        || kind.contains("memo")
+        || kind.contains("plan");
+    if internal {
+        return false;
+    }
+    kind.contains("post")
+        || kind.contains("write")
+        || kind.contains("publish")
+        || kind.contains("delete")
+        || kind.contains("send")
+}
+
+fn candidate_is_plan_only(candidate: &WorkflowCandidate) -> bool {
+    if candidate.steps.is_empty() {
+        return false;
+    }
+    candidate.side_effects.iter().all(|effect| {
+        let kind = effect.kind.to_ascii_lowercase();
+        // Plan-only side effects stay inside Harn's own data plane: receipt
+        // writes, in-memory event-log appends, file-only mutations, etc.
+        kind.is_empty()
+            || kind.contains("receipt")
+            || kind.contains("event_log")
+            || kind.contains("memo")
+            || kind.contains("plan")
+            || (kind.contains("file") && !kind.contains("publish"))
+    })
+}
+
+fn redact_trace_for_bundle(trace: &mut CrystallizationTrace) {
+    for action in &mut trace.actions {
+        redact_bundle_value(&mut action.inputs);
+        if let Some(output) = action.output.as_mut() {
+            redact_bundle_value(output);
+        }
+        if let Some(observed) = action.observed_output.as_mut() {
+            redact_bundle_value(observed);
+        }
+        for value in action.parameters.values_mut() {
+            redact_bundle_value(value);
+        }
+        for (_, value) in action.metadata.iter_mut() {
+            redact_bundle_value(value);
+        }
+    }
+    for (_, value) in trace.metadata.iter_mut() {
+        redact_bundle_value(value);
+    }
+}
+
+fn redact_bundle_value(value: &mut JsonValue) {
+    match value {
+        JsonValue::String(text) if looks_like_secret_value(text) => {
+            *text = "[redacted]".to_string();
+        }
+        JsonValue::Array(items) => {
+            for item in items {
+                redact_bundle_value(item);
+            }
+        }
+        JsonValue::Object(map) => {
+            for (key, child) in map.iter_mut() {
+                if is_sensitive_bundle_key(key) {
+                    *child = JsonValue::String("[redacted]".to_string());
+                } else {
+                    redact_bundle_value(child);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_sensitive_bundle_key(key: &str) -> bool {
+    let lower = key.to_ascii_lowercase();
+    lower.contains("secret")
+        || lower.contains("token")
+        || lower.contains("password")
+        || lower.contains("api_key")
+        || lower.contains("apikey")
+        || lower == "authorization"
+        || lower == "cookie"
+        || lower == "set-cookie"
+}
+
+fn looks_like_secret_value(value: &str) -> bool {
+    let trimmed = value.trim();
+    trimmed.starts_with("sk-")
+        || trimmed.starts_with("ghp_")
+        || trimmed.starts_with("ghs_")
+        || trimmed.starts_with("xoxb-")
+        || trimmed.starts_with("xoxp-")
+        || trimmed.starts_with("AKIA")
+        || (trimmed.len() > 48
+            && trimmed
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-'))
+}
+
+fn secret_id_looks_logical(value: &str) -> bool {
+    !looks_like_secret_value(value) && !value.trim().is_empty()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1577,5 +2521,370 @@ mod tests {
             .any(|step| step.segment == SegmentKind::Fuzzy));
         assert!(candidate.savings.remaining_model_calls > 0);
         assert!(artifacts.harn_code.contains("TODO: fuzzy segment"));
+    }
+
+    fn plan_only_trace(id: &str, suffix: &str) -> CrystallizationTrace {
+        CrystallizationTrace {
+            id: id.to_string(),
+            actions: vec![
+                CrystallizationAction {
+                    id: format!("{id}-classify"),
+                    kind: "tool_call".to_string(),
+                    name: "classify_issue".to_string(),
+                    parameters: BTreeMap::from([
+                        ("issue_id".to_string(), json!(format!("HAR-{suffix}"))),
+                        ("team_key".to_string(), json!("HAR")),
+                    ]),
+                    capabilities: vec!["linear.read".to_string()],
+                    deterministic: Some(true),
+                    duration_ms: Some(15),
+                    ..CrystallizationAction::default()
+                },
+                CrystallizationAction {
+                    id: format!("{id}-receipt"),
+                    kind: "receipt_write".to_string(),
+                    name: "emit_receipt".to_string(),
+                    inputs: json!({"summary": format!("plan only #{suffix}"), "kind": "plan"}),
+                    parameters: BTreeMap::from([
+                        ("kind".to_string(), json!("plan")),
+                        ("summary".to_string(), json!(format!("plan only #{suffix}"))),
+                    ]),
+                    side_effects: vec![CrystallizationSideEffect {
+                        kind: "receipt_write".to_string(),
+                        target: "tenant_event_log".to_string(),
+                        capability: Some("receipt.write".to_string()),
+                        ..CrystallizationSideEffect::default()
+                    }],
+                    capabilities: vec!["receipt.write".to_string()],
+                    deterministic: Some(true),
+                    duration_ms: Some(5),
+                    ..CrystallizationAction::default()
+                },
+            ],
+            ..CrystallizationTrace::default()
+        }
+    }
+
+    fn version_traces(count: usize) -> Vec<CrystallizationTrace> {
+        (0..count)
+            .map(|idx| {
+                version_trace(
+                    &format!("trace_{idx}"),
+                    &format!("0.7.{idx}"),
+                    "release-branch",
+                    false,
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn build_bundle_assembles_versioned_manifest() {
+        let traces = version_traces(5);
+        let artifacts = crystallize_traces(
+            traces.clone(),
+            CrystallizeOptions {
+                workflow_name: Some("version_bump".to_string()),
+                package_name: Some("release-workflows".to_string()),
+                author: Some("ops@example.com".to_string()),
+                approver: Some("lead@example.com".to_string()),
+                eval_pack_link: Some("eval-pack://release-workflows/v1".to_string()),
+                ..CrystallizeOptions::default()
+            },
+        )
+        .unwrap();
+
+        let bundle = build_crystallization_bundle(
+            artifacts,
+            &traces,
+            BundleOptions {
+                team: Some("platform".to_string()),
+                repo: Some("burin-labs/harn".to_string()),
+                ..BundleOptions::default()
+            },
+        )
+        .unwrap();
+
+        let manifest = &bundle.manifest;
+        assert_eq!(manifest.schema, BUNDLE_SCHEMA);
+        assert_eq!(manifest.schema_version, BUNDLE_SCHEMA_VERSION);
+        assert_eq!(manifest.kind, BundleKind::Candidate);
+        assert!(!manifest.candidate_id.is_empty());
+        assert_eq!(manifest.workflow.name, "version_bump");
+        assert_eq!(manifest.workflow.package_name, "release-workflows");
+        assert_eq!(manifest.workflow.path, BUNDLE_WORKFLOW_FILE);
+        assert_eq!(manifest.team.as_deref(), Some("platform"));
+        assert_eq!(manifest.repo.as_deref(), Some("burin-labs/harn"));
+        assert_eq!(manifest.external_key, "version-bump");
+        assert_eq!(manifest.promotion.rollout_policy, "shadow_then_canary");
+        assert_eq!(
+            manifest.promotion.author.as_deref(),
+            Some("ops@example.com")
+        );
+        assert_eq!(
+            manifest.promotion.approver.as_deref(),
+            Some("lead@example.com")
+        );
+        assert_eq!(manifest.promotion.workflow_version, "0.1.0");
+        assert!(manifest.deterministic_steps.len() + manifest.fuzzy_steps.len() > 0);
+        assert_eq!(manifest.source_traces.len(), traces.len());
+        assert_eq!(manifest.fixtures.len(), traces.len());
+        assert!(manifest.fixtures.iter().all(|fixture| fixture.redacted));
+        assert!(manifest.redaction.applied);
+        assert!(manifest.redaction.fixture_count > 0);
+        assert!(manifest
+            .eval_pack
+            .as_ref()
+            .is_some_and(|eval| eval.path == BUNDLE_EVAL_PACK_FILE));
+        assert!(manifest
+            .required_secrets
+            .iter()
+            .all(|secret| !secret.is_empty()));
+    }
+
+    #[test]
+    fn write_bundle_round_trips_through_disk() {
+        let traces = version_traces(5);
+        let artifacts = crystallize_traces(
+            traces.clone(),
+            CrystallizeOptions {
+                workflow_name: Some("version_bump".to_string()),
+                ..CrystallizeOptions::default()
+            },
+        )
+        .unwrap();
+        let bundle =
+            build_crystallization_bundle(artifacts, &traces, BundleOptions::default()).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let written = write_crystallization_bundle(&bundle, dir.path()).unwrap();
+        assert_eq!(written.candidate_id, bundle.manifest.candidate_id);
+
+        // Files exist on disk.
+        for relative in [
+            BUNDLE_MANIFEST_FILE,
+            BUNDLE_REPORT_FILE,
+            BUNDLE_WORKFLOW_FILE,
+            BUNDLE_EVAL_PACK_FILE,
+        ] {
+            assert!(dir.path().join(relative).exists(), "missing {relative}");
+        }
+        let fixtures_dir = dir.path().join(BUNDLE_FIXTURES_DIR);
+        assert!(fixtures_dir.is_dir());
+        assert_eq!(
+            std::fs::read_dir(&fixtures_dir).unwrap().count(),
+            traces.len()
+        );
+
+        // Manifest round-trips.
+        let (loaded_manifest, loaded_traces) = load_crystallization_bundle(dir.path()).unwrap();
+        assert_eq!(loaded_manifest, bundle.manifest);
+        assert_eq!(loaded_traces.len(), traces.len());
+
+        // Validation passes.
+        let validation = validate_crystallization_bundle(dir.path()).unwrap();
+        assert!(
+            validation.problems.is_empty(),
+            "unexpected problems: {:?}",
+            validation.problems
+        );
+        assert!(validation.is_ok());
+        assert!(validation.workflow_ok && validation.report_ok);
+        assert!(validation.fixtures_ok && validation.redaction_ok);
+
+        // Shadow replay matches the persisted shadow report.
+        let (replay_manifest, shadow) = shadow_replay_bundle(dir.path()).unwrap();
+        assert_eq!(replay_manifest.candidate_id, bundle.manifest.candidate_id);
+        assert!(shadow.pass, "shadow should still pass");
+        assert_eq!(shadow.compared_traces, traces.len());
+    }
+
+    #[test]
+    fn validate_rejects_bundle_with_missing_workflow() {
+        let traces = version_traces(3);
+        let artifacts = crystallize_traces(traces.clone(), CrystallizeOptions::default()).unwrap();
+        let bundle =
+            build_crystallization_bundle(artifacts, &traces, BundleOptions::default()).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        write_crystallization_bundle(&bundle, dir.path()).unwrap();
+        std::fs::remove_file(dir.path().join(BUNDLE_WORKFLOW_FILE)).unwrap();
+
+        let validation = validate_crystallization_bundle(dir.path()).unwrap();
+        assert!(!validation.is_ok());
+        assert!(validation
+            .problems
+            .iter()
+            .any(|problem| problem.contains("missing workflow file")));
+    }
+
+    #[test]
+    fn validate_rejects_bundle_with_unredacted_fixture() {
+        let traces = version_traces(3);
+        let artifacts = crystallize_traces(traces.clone(), CrystallizeOptions::default()).unwrap();
+        let mut bundle =
+            build_crystallization_bundle(artifacts, &traces, BundleOptions::default()).unwrap();
+        // Force a fixture to claim it is unredacted; this must trip
+        // validation so a malicious or careless producer cannot ship raw
+        // private payloads under the bundle contract.
+        bundle.manifest.fixtures[0].redacted = false;
+        let dir = tempfile::tempdir().unwrap();
+        write_crystallization_bundle(&bundle, dir.path()).unwrap();
+
+        let validation = validate_crystallization_bundle(dir.path()).unwrap();
+        assert!(!validation.is_ok());
+        assert!(validation
+            .problems
+            .iter()
+            .any(|problem| problem.contains("not marked redacted")));
+    }
+
+    #[test]
+    fn validate_rejects_unsupported_schema_version() {
+        let traces = version_traces(3);
+        let artifacts = crystallize_traces(traces.clone(), CrystallizeOptions::default()).unwrap();
+        let mut bundle =
+            build_crystallization_bundle(artifacts, &traces, BundleOptions::default()).unwrap();
+        bundle.manifest.schema_version = BUNDLE_SCHEMA_VERSION + 1;
+        let dir = tempfile::tempdir().unwrap();
+        write_crystallization_bundle(&bundle, dir.path()).unwrap();
+
+        let validation = validate_crystallization_bundle(dir.path()).unwrap();
+        assert!(!validation.is_ok());
+        assert!(validation
+            .problems
+            .iter()
+            .any(|problem| problem.contains("schema_version")));
+    }
+
+    #[test]
+    fn redacts_secret_like_values_in_fixtures() {
+        // Build secret-shaped strings at runtime so we exercise the
+        // redaction prefixes (`xoxb-`, `ghp_`, `sk-`) without checking in
+        // source that looks like a real credential to secret scanners.
+        let slack_prefix = format!("{}{}", "xo", "xb-");
+        let github_prefix = format!("{}{}", "gh", "p_");
+        let openai_prefix = "sk-".to_string();
+        let pad = "A".repeat(48);
+        let slack_secret = format!("{slack_prefix}1234567890-{pad}");
+        let github_secret = format!("{github_prefix}{pad}");
+        let openai_secret = format!("{openai_prefix}{pad}");
+
+        let mut secret_action = CrystallizationAction {
+            id: "secret".to_string(),
+            kind: "tool_call".to_string(),
+            name: "post_release_to_slack".to_string(),
+            parameters: BTreeMap::from([
+                ("slack_token".to_string(), json!(slack_secret)),
+                ("channel".to_string(), json!("#releases")),
+            ]),
+            inputs: json!({
+                "authorization": format!("Bearer {github_secret}"),
+                "version": "0.7.1",
+            }),
+            ..CrystallizationAction::default()
+        };
+        secret_action
+            .metadata
+            .insert("api_key".to_string(), json!(openai_secret));
+
+        let mut trace = CrystallizationTrace {
+            id: "trace_secret".to_string(),
+            actions: vec![secret_action],
+            ..CrystallizationTrace::default()
+        };
+        redact_trace_for_bundle(&mut trace);
+        let action = &trace.actions[0];
+        assert_eq!(
+            action.parameters.get("slack_token"),
+            Some(&json!("[redacted]"))
+        );
+        assert_eq!(action.parameters.get("channel"), Some(&json!("#releases")));
+        let inputs = action.inputs.as_object().unwrap();
+        assert_eq!(inputs.get("authorization"), Some(&json!("[redacted]")));
+        assert_eq!(inputs.get("version"), Some(&json!("0.7.1")));
+        assert_eq!(action.metadata.get("api_key"), Some(&json!("[redacted]")));
+    }
+
+    #[test]
+    fn plan_only_fixture_yields_plan_only_kind() {
+        let traces = (0..3)
+            .map(|idx| plan_only_trace(&format!("plan_{idx}"), &format!("{idx}")))
+            .collect::<Vec<_>>();
+        let artifacts = crystallize_traces(
+            traces.clone(),
+            CrystallizeOptions {
+                workflow_name: Some("plan_only_triage".to_string()),
+                ..CrystallizeOptions::default()
+            },
+        )
+        .unwrap();
+        let bundle =
+            build_crystallization_bundle(artifacts, &traces, BundleOptions::default()).unwrap();
+        assert_eq!(bundle.manifest.kind, BundleKind::PlanOnly);
+        assert_eq!(bundle.manifest.risk_level, "low");
+    }
+
+    #[test]
+    fn rejected_bundle_has_rejected_kind() {
+        let traces = vec![
+            version_trace("trace_a", "0.7.1", "release-branch", false),
+            version_trace("trace_b", "0.7.2", "main", false),
+            version_trace("trace_c", "0.7.3", "release-branch", false),
+        ];
+        let artifacts = crystallize_traces(traces.clone(), CrystallizeOptions::default()).unwrap();
+        let bundle =
+            build_crystallization_bundle(artifacts, &traces, BundleOptions::default()).unwrap();
+        assert_eq!(bundle.manifest.kind, BundleKind::Rejected);
+        assert!(bundle.manifest.candidate_id.is_empty());
+        assert!(!bundle.manifest.rejection_reasons.is_empty());
+        assert!(bundle.fixtures.is_empty());
+    }
+
+    #[test]
+    fn validate_round_trips_rejected_bundle() {
+        let traces = vec![
+            version_trace("trace_a", "0.7.1", "release-branch", false),
+            version_trace("trace_b", "0.7.2", "main", false),
+            version_trace("trace_c", "0.7.3", "release-branch", false),
+        ];
+        let artifacts = crystallize_traces(traces.clone(), CrystallizeOptions::default()).unwrap();
+        let bundle =
+            build_crystallization_bundle(artifacts, &traces, BundleOptions::default()).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        write_crystallization_bundle(&bundle, dir.path()).unwrap();
+
+        let validation = validate_crystallization_bundle(dir.path()).unwrap();
+        assert!(validation.is_ok(), "{:?}", validation.problems);
+        assert_eq!(validation.kind, BundleKind::Rejected);
+    }
+
+    #[test]
+    fn shadow_replay_fails_when_fixture_diverges() {
+        let traces = version_traces(3);
+        let artifacts = crystallize_traces(traces.clone(), CrystallizeOptions::default()).unwrap();
+        let bundle =
+            build_crystallization_bundle(artifacts, &traces, BundleOptions::default()).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        write_crystallization_bundle(&bundle, dir.path()).unwrap();
+
+        // Tamper with one redacted fixture so its action list no longer
+        // matches the candidate signature; the replay must fail without
+        // panicking.
+        let fixture_dir = dir.path().join(BUNDLE_FIXTURES_DIR);
+        let some_fixture = std::fs::read_dir(&fixture_dir)
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .path();
+        let mut tampered: CrystallizationTrace =
+            serde_json::from_slice(&std::fs::read(&some_fixture).unwrap()).unwrap();
+        tampered.actions.truncate(1);
+        std::fs::write(&some_fixture, serde_json::to_vec_pretty(&tampered).unwrap()).unwrap();
+
+        let (_, shadow) = shadow_replay_bundle(dir.path()).unwrap();
+        assert!(!shadow.pass);
+        assert!(!shadow.failures.is_empty());
     }
 }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -828,8 +828,46 @@ parameters, side effects, approval points, capability and secret requirements,
 shadow-mode pass/fail details, promotion metadata, and cost/token savings.
 Candidates with divergent side effects are rejected instead of promoted.
 
+Pass `--bundle <DIR>` to also emit a portable
+`harn.crystallization.candidate.bundle` directory (`candidate.json`,
+`workflow.harn`, `report.json`, `harn.eval.toml`, redacted `fixtures/`)
+that Harn Cloud or any other importer can consume without bespoke glue:
+
+```bash
+harn crystallize \
+  --from fixtures/crystallize/version-bump \
+  --out workflows/version_bump.harn \
+  --report reports/version_bump.crystallize.json \
+  --eval-pack evals/version_bump.toml \
+  --bundle bundles/version-bump \
+  --bundle-team platform \
+  --bundle-repo burin-labs/harn \
+  --bundle-risk-level medium \
+  --workflow-name version_bump
+```
+
+### harn crystallize validate
+
+Smoke-check a bundle on disk: confirms the schema marker and version, that
+every referenced file exists, that fixtures are marked redacted, and that
+`required_secrets` only lists logical ids (never raw secret values).
+
+```bash
+harn crystallize validate bundles/version-bump
+```
+
+### harn crystallize shadow
+
+Re-run the deterministic shadow comparison from a bundle's redacted fixtures
+in-process, with no live side effects. Returns non-zero on divergence, so it
+fits in CI gates.
+
+```bash
+harn crystallize shadow bundles/version-bump
+```
+
 See [Workflow crystallization](./workflow-crystallization.md) for the trace
-schema and review loop.
+schema, bundle layout, and review loop.
 
 ## harn trigger cancel
 

--- a/docs/src/workflow-crystallization.md
+++ b/docs/src/workflow-crystallization.md
@@ -141,3 +141,146 @@ When `--eval-pack` is supplied, the CLI writes a minimal eval-pack v1 manifest
 with a `crystallization-shadow` assertion. Hosted runners can attach the trace
 fixtures and richer rubrics later; the local artifact records the candidate id,
 source trace ids, and blocking shadow expectation.
+
+## Portable Bundle
+
+Pass `--bundle <DIR>` to also emit a portable crystallization-candidate
+**bundle** that Harn Cloud (and any other downstream importer) can consume
+without bespoke glue:
+
+```text
+bundle/
+├── candidate.json        # versioned manifest (see below)
+├── workflow.harn         # generated/reviewable workflow
+├── report.json           # full mining/shadow/eval report
+├── harn.eval.toml        # generated eval pack (when --eval-pack is set)
+└── fixtures/             # redacted replay fixtures referenced by the report
+    ├── trace_release_001.json
+    └── ...
+```
+
+`candidate.json` carries the stable schema markers and metadata Harn Cloud
+needs to import a candidate directly:
+
+```json
+{
+  "schema": "harn.crystallization.candidate.bundle",
+  "schema_version": 1,
+  "generated_at": "2026-04-26T12:34:56Z",
+  "generator": {"tool": "harn", "version": "0.7.43"},
+  "kind": "candidate",
+  "candidate_id": "candidate_4f5e...",
+  "external_key": "version-bump",
+  "title": "version_bump (3 steps)",
+  "team": "platform",
+  "repo": "burin-labs/harn",
+  "risk_level": "medium",
+  "workflow": {
+    "path": "workflow.harn",
+    "name": "version_bump",
+    "package_name": "release-workflows",
+    "package_version": "0.1.0"
+  },
+  "source_trace_hashes": ["sha256:..."],
+  "source_traces": [
+    {
+      "trace_id": "trace_release_001",
+      "source_hash": "sha256:...",
+      "source_url": "/work/harn/runs/release-001.json",
+      "source_receipt_id": null,
+      "fixture_path": "fixtures/trace_release_001.json"
+    }
+  ],
+  "deterministic_steps": [...],
+  "fuzzy_steps": [...],
+  "side_effects": [...],
+  "capabilities": ["fs.write", "git.write"],
+  "required_secrets": ["CRATES_IO_TOKEN"],
+  "savings": {...},
+  "shadow": {...},
+  "eval_pack": {"path": "harn.eval.toml", "link": null},
+  "fixtures": [
+    {
+      "path": "fixtures/trace_release_001.json",
+      "trace_id": "trace_release_001",
+      "source_hash": "sha256:...",
+      "redacted": true
+    }
+  ],
+  "promotion": {
+    "owner": null,
+    "approver": "lead@example.com",
+    "author": "ops@example.com",
+    "rollout_policy": "shadow_then_canary",
+    "rollback_target": "keep source traces and previous package version",
+    "created_at": "2026-04-26T12:34:56Z",
+    "workflow_version": "0.1.0",
+    "package_name": "release-workflows"
+  },
+  "redaction": {
+    "applied": true,
+    "rules": ["sensitive_keys", "secret_value_heuristic"],
+    "summary": "fixture payloads scrubbed of secret-like values and sensitive keys before write",
+    "fixture_count": 5
+  },
+  "confidence": 0.94,
+  "rejection_reasons": [],
+  "warnings": []
+}
+```
+
+Importers MUST refuse bundles whose `schema` is not exactly
+`harn.crystallization.candidate.bundle` or whose `schema_version` is greater
+than the highest version they understand. Only the documented additive fields
+may be added without bumping `schema_version`.
+
+`kind` is one of:
+
+- `candidate` — a normal candidate that passed shadow comparison.
+- `plan_only` — every side effect stays inside Harn's own data plane (receipt
+  writes, in-memory event-log appends, plan stashes). Cloud can promote these
+  without explicit external-side-effect approval.
+- `rejected` — no safe candidate was selected; the bundle still records what
+  was attempted and why so reviewers can debug or feed it back into mining.
+
+### Redaction
+
+Bundles never ship raw private trace payloads. Before fixtures are copied into
+`fixtures/`, the writer:
+
+- replaces values for sensitive keys (anything containing `token`, `secret`,
+  `password`, `api_key`, `apikey`, plus `authorization` and `cookie`) with
+  `"[redacted]"`,
+- redacts string values that look like raw API tokens
+  (`sk-…`, `ghp_…`, `ghs_…`, `xoxb-…`, `xoxp-…`, `AKIA…`, or a long
+  alphanumeric run that fits the credential heuristic).
+
+`required_secrets` always lists logical ids (e.g. `CRATES_IO_TOKEN`), never
+secret values.
+
+### Validating a bundle
+
+`harn crystallize validate <BUNDLE_DIR>` is a CLI smoke check that reads the
+manifest, verifies the schema marker and version, confirms each referenced
+file is present, and refuses bundles that include unredacted fixtures or
+secret-shaped logical ids:
+
+```bash
+harn crystallize validate bundles/version-bump
+# Bundle: bundles/version-bump (schema=harn.crystallization.candidate.bundle ...)
+# Checks: manifest=ok workflow=ok report=ok eval_pack=ok fixtures=ok redaction=ok
+# OK
+```
+
+### Shadow replay from a bundle
+
+`harn crystallize shadow <BUNDLE_DIR>` re-runs the deterministic shadow
+comparison in-process against the bundle's redacted fixtures, with no live
+side effects. The exit code is non-zero if the replay diverges from the
+recorded shadow report — useful in CI to prove the bundle stays
+self-consistent across Harn upgrades.
+
+```bash
+harn crystallize shadow bundles/version-bump
+# Shadow replay: bundle=bundles/version-bump candidate_id=candidate_... compared=5 pass=true
+```


### PR DESCRIPTION
## Summary

- Define and implement the stable
  [`harn.crystallization.candidate.bundle`](https://harnlang.com/docs/workflow-crystallization.html#portable-bundle)
  directory layout (`candidate.json` + `workflow.harn` + `report.json`
  + optional `harn.eval.toml` + redacted `fixtures/`) so Harn Cloud and
  other downstream importers can consume crystallization candidates
  without bespoke glue.
- Wire `harn crystallize --bundle <DIR>` to emit the bundle alongside
  the existing report; add `harn crystallize validate <DIR>` (smoke
  check: schema marker, required files, redaction, logical-only secret
  ids) and `harn crystallize shadow <DIR>` (replay the deterministic
  shadow comparison from the bundle's own redacted fixtures, no live
  side effects).
- Apply explicit redaction (sensitive keys + secret-shape heuristic)
  to every fixture before it lands on disk, and refuse to validate any
  bundle whose fixtures aren't marked `redacted` or whose
  `required_secrets` look like raw credentials.
- Companion harn-cloud doc PR:
  [burin-labs/harn-cloud#103](https://github.com/burin-labs/harn-cloud/pull/103).

Closes [#746](https://github.com/burin-labs/harn/issues/746).

## Acceptance criteria

- [x] Documented versioned schema for crystallization candidate
      artifacts (`schema = "harn.crystallization.candidate.bundle"`,
      `schema_version = 1`).
- [x] `harn crystallize` emits the artifact bundle in a stable
      directory layout (`--bundle <DIR>`).
- [x] `harn crystallize shadow <DIR>` consumes the bundle without
      live side effects.
- [x] Redaction rules in place so raw private trace payloads do not
      leak into shareable artifact fields.
- [x] CLI smoke command: `harn crystallize validate <DIR>`.
- [x] Synthetic fixture coverage for version-bump and plan-only
      candidates (CLI integration tests + library unit tests).
- [x] Updated Harn Cloud integration notes so `seed-fixtures` is the
      explicit demo path and bundle import is the real-data path.

## Test plan

- [x] `cargo test -p harn-vm --lib orchestration::crystallize`
- [x] `cargo test -p harn-cli --test crystallize_cli`
- [x] `cargo test -p harn-cli --bin harn cli::tests` (CLI parser
      backwards-compat for the existing `--from / --out / --report` flags)
- [x] `cargo clippy -p harn-vm -p harn-cli --tests`
- [x] `cargo fmt --check -p harn-vm -p harn-cli`
- [x] `npx markdownlint-cli2 CHANGELOG.md docs/src/workflow-crystallization.md docs/src/cli-reference.md`
- [x] `./scripts/check_docs_snippets.sh`
- [x] Local end-to-end smoke: emit + validate + shadow-replay a
      version-bump bundle and a plan-only bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)