### PR TITLE
Make tool executors explicit and reject handlerless tools (#743)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,23 @@ granular archaeology.
   fail (test process hangs past 60 s) when the canonicalize-before-seen
   block in `crates/harn-modules/src/lib.rs` is reverted, and to pass
   (sub-second per command) with the fix in place.
+### Changed
+
+- **Explicit tool executors on `tool_define` (#743).** Every tool now
+  declares which backend runs it. `tool_define` accepts
+  `executor: "harn" | "host_bridge" | "mcp_server" | "provider_native"`,
+  with required pairing fields (`handler` for `harn`, `host_capability`
+  for `host_bridge`, `mcp_server` for `mcp_server`). Definitions with
+  no handler and no executor are rejected up-front instead of falling
+  through to the host bridge. `agent_loop` re-checks the registry on
+  entry and refuses to start when any tool has no executable backend,
+  and `harn check` flags `host_capability` literals that are not in
+  the discovered host capability manifest. The dispatcher and ACP
+  transcript both honor the declared executor verbatim, so
+  `tool_call_update.executor` reflects the source of truth instead of
+  an inferred value. Existing scripts that pass a `handler` continue
+  to compile (executor defaults to `"harn"`); handler-less scripts
+  must pick an executor explicitly.
 
 ## v0.7.43
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ granular archaeology.
   fail (test process hangs past 60 s) when the canonicalize-before-seen
   block in `crates/harn-modules/src/lib.rs` is reverted, and to pass
   (sub-second per command) with the fix in place.
+
 ### Changed
 
 - **Explicit tool executors on `tool_define` (#743).** Every tool now

--- a/conformance/errors/semantic/agent_loop_handlerless_tool.error
+++ b/conformance/errors/semantic/agent_loop_handlerless_tool.error
@@ -1,0 +1,1 @@
+re:agent_loop: registry contains 1 tool\(s\) with no executable backend: ghost

--- a/conformance/errors/semantic/agent_loop_handlerless_tool.harn
+++ b/conformance/errors/semantic/agent_loop_handlerless_tool.harn
@@ -1,0 +1,15 @@
+// harn#743: agent_loop refuses to start when the registry contains
+// a tool with no executable backend. tool_define rejects this at
+// definition time, but a registry assembled by hand (or merged
+// across packages) could still slip a handlerless entry through.
+// Match the same diagnostic before the first model call so the
+// failure surfaces with a clear message instead of an opaque
+// `[builtin_call] unhandled` later.
+pipeline test(task) {
+  let bare = {_type: "tool_registry", tools: [{name: "ghost", description: "no backing", parameters: {}}]}
+  agent_loop(
+    "Try the ghost tool",
+    "You are helpful",
+    {provider: "mock", tools: bare, max_iterations: 1},
+  )
+}

--- a/conformance/errors/semantic/tool_arg_constraint_rejection.harn
+++ b/conformance/errors/semantic/tool_arg_constraint_rejection.harn
@@ -5,7 +5,7 @@ fn list_tools() {
     "list_directory",
     "List directory contents",
     {
-    handler: nil,
+    handler: { args -> "ls " + args.path },
     parameters: {path: {type: "string", description: "Directory path"}},
     returns: {type: "string"},
   },
@@ -22,11 +22,7 @@ pipeline test(task) {
     tools: list_tools(),
     tool_format: "native",
     max_iterations: 1,
-    policy: {
-      tool_arg_constraints: [
-        {tool: "list_directory", arg_key: "path", arg_patterns: ["src/*"]},
-      ],
-    },
+    policy: {tool_arg_constraints: [{tool: "list_directory", arg_key: "path", arg_patterns: ["src/*"]}]},
   },
   )
   println(result?.tools?.rejected[0])

--- a/conformance/errors/semantic/tool_define_executor_harn_missing_handler.error
+++ b/conformance/errors/semantic/tool_define_executor_harn_missing_handler.error
@@ -1,0 +1,1 @@
+re:executor: "harn" requires a `handler` closure

--- a/conformance/errors/semantic/tool_define_executor_harn_missing_handler.harn
+++ b/conformance/errors/semantic/tool_define_executor_harn_missing_handler.harn
@@ -1,0 +1,7 @@
+// harn#743: executor: "harn" requires a `handler` closure. Empty
+// declarations would crash at the first dispatch call, so we reject
+// the definition up front.
+pipeline test(task) {
+  let r = tool_registry()
+  tool_define(r, "compute", "no handler", {executor: "harn", parameters: {}})
+}

--- a/conformance/errors/semantic/tool_define_executor_host_bridge_bad_capability_format.error
+++ b/conformance/errors/semantic/tool_define_executor_host_bridge_bad_capability_format.error
@@ -1,0 +1,1 @@
+re:`host_capability` must look like "capability.operation"

--- a/conformance/errors/semantic/tool_define_executor_host_bridge_bad_capability_format.harn
+++ b/conformance/errors/semantic/tool_define_executor_host_bridge_bad_capability_format.harn
@@ -1,0 +1,12 @@
+// harn#743: host_capability must be shaped "capability.operation"
+// (e.g. "interaction.ask"). A bare capability without an operation
+// can't be validated against the host manifest, so we reject it.
+pipeline test(task) {
+  let r = tool_registry()
+  tool_define(
+    r,
+    "ask_user",
+    "ask user",
+    {executor: "host_bridge", host_capability: "interaction", parameters: {}},
+  )
+}

--- a/conformance/errors/semantic/tool_define_executor_host_bridge_missing_capability.error
+++ b/conformance/errors/semantic/tool_define_executor_host_bridge_missing_capability.error
@@ -1,0 +1,1 @@
+re:executor: "host_bridge" requires a `host_capability:

--- a/conformance/errors/semantic/tool_define_executor_host_bridge_missing_capability.harn
+++ b/conformance/errors/semantic/tool_define_executor_host_bridge_missing_capability.harn
@@ -1,0 +1,7 @@
+// harn#743: executor: "host_bridge" requires a host_capability tag
+// shaped "capability.operation" so `harn check` can validate the host
+// surfaces it.
+pipeline test(task) {
+  let r = tool_registry()
+  tool_define(r, "ask_user", "ask user", {executor: "host_bridge", parameters: {}})
+}

--- a/conformance/errors/semantic/tool_define_executor_host_bridge_with_handler.error
+++ b/conformance/errors/semantic/tool_define_executor_host_bridge_with_handler.error
@@ -1,0 +1,1 @@
+re:executor: "host_bridge" must not declare a `handler`

--- a/conformance/errors/semantic/tool_define_executor_host_bridge_with_handler.harn
+++ b/conformance/errors/semantic/tool_define_executor_host_bridge_with_handler.harn
@@ -1,0 +1,16 @@
+// harn#743: executor: "host_bridge" forbids a `handler` so the
+// transcript truthfully reflects which backend ran the tool.
+pipeline test(task) {
+  let r = tool_registry()
+  tool_define(
+    r,
+    "ask_user",
+    "ask the user",
+    {
+    executor: "host_bridge",
+    host_capability: "interaction.ask",
+    handler: { args -> "ignored" },
+    parameters: {},
+  },
+  )
+}

--- a/conformance/errors/semantic/tool_define_executor_mcp_missing_server.error
+++ b/conformance/errors/semantic/tool_define_executor_mcp_missing_server.error
@@ -1,0 +1,1 @@
+re:executor: "mcp_server" requires an `mcp_server:

--- a/conformance/errors/semantic/tool_define_executor_mcp_missing_server.harn
+++ b/conformance/errors/semantic/tool_define_executor_mcp_missing_server.harn
@@ -1,0 +1,6 @@
+// harn#743: executor: "mcp_server" requires the configured server
+// name so the dispatcher knows which MCP client to route through.
+pipeline test(task) {
+  let r = tool_registry()
+  tool_define(r, "lookup", "lookup", {executor: "mcp_server", parameters: {}})
+}

--- a/conformance/errors/semantic/tool_define_executor_unknown.error
+++ b/conformance/errors/semantic/tool_define_executor_unknown.error
@@ -1,0 +1,1 @@
+re:unknown executor "wasm"

--- a/conformance/errors/semantic/tool_define_executor_unknown.harn
+++ b/conformance/errors/semantic/tool_define_executor_unknown.harn
@@ -1,0 +1,6 @@
+// harn#743: executor names are a closed set. Typos and aspirational
+// values would otherwise pass through to ACP transcript downstream.
+pipeline test(task) {
+  let r = tool_registry()
+  tool_define(r, "compute", "compute", {executor: "wasm", parameters: {}})
+}

--- a/conformance/errors/semantic/tool_define_no_executor_no_handler.error
+++ b/conformance/errors/semantic/tool_define_no_executor_no_handler.error
@@ -1,0 +1,1 @@
+re:tool_define\("ghost"\): tool has no `handler` and no explicit `executor`

--- a/conformance/errors/semantic/tool_define_no_executor_no_handler.harn
+++ b/conformance/errors/semantic/tool_define_no_executor_no_handler.harn
@@ -1,0 +1,8 @@
+// harn#743: a tool with neither `handler` nor `executor` has no
+// executable backend. tool_define rejects it at definition time so
+// the dispatcher never produces an opaque "tool unavailable" error
+// later in the agent loop.
+pipeline test(task) {
+  let r = tool_registry()
+  tool_define(r, "ghost", "no backing", {parameters: {}})
+}

--- a/conformance/tests/agents/agent_basic.harn
+++ b/conformance/tests/agents/agent_basic.harn
@@ -5,7 +5,7 @@ fn agent_tools() {
     "read",
     "Read a file",
     {
-    handler: nil,
+    handler: { _ -> "(stub)" },
     parameters: {path: {type: "string", description: "Path to read"}},
     returns: {type: "string"},
   },
@@ -15,7 +15,7 @@ fn agent_tools() {
     "search",
     "Search project files",
     {
-    handler: nil,
+    handler: { _ -> "(stub)" },
     parameters: {
     pattern: {type: "string", description: "Pattern to search"},
     file_glob: {type: "string", description: "Optional file glob", required: false},

--- a/conformance/tests/agents/agent_edge_cases.harn
+++ b/conformance/tests/agents/agent_edge_cases.harn
@@ -5,7 +5,7 @@ fn read_only_tools() {
     "read",
     "Read a file",
     {
-    handler: nil,
+    handler: { _ -> "(stub)" },
     parameters: {path: {type: "string", description: "Path to read"}},
     returns: {type: "string"},
   },

--- a/conformance/tests/agents/agent_runtime_features.harn
+++ b/conformance/tests/agents/agent_runtime_features.harn
@@ -5,7 +5,7 @@ fn list_tools() {
     "list_directory",
     "List directory contents",
     {
-    handler: nil,
+    handler: { _ -> "(stub)" },
     parameters: {path: {type: "string", description: "Directory path"}},
     returns: {type: "string"},
   },

--- a/conformance/tests/agents/agent_worker_policy.harn
+++ b/conformance/tests/agents/agent_worker_policy.harn
@@ -5,7 +5,7 @@ fn write_tools() {
     "write_note",
     "Write a note",
     {
-    handler: nil,
+    handler: { _ -> "(stub)" },
     parameters: {path: {type: "string", description: "Path to write"}},
     returns: {type: "string"},
   },

--- a/conformance/tests/agents/workflow_policy_guardrails.harn
+++ b/conformance/tests/agents/workflow_policy_guardrails.harn
@@ -4,13 +4,13 @@ pipeline main() {
     stage_tools,
     "edit",
     "Edit a file",
-    {handler: nil, parameters: {path: {type: "string"}}, returns: {type: "string"}},
+    {handler: { _ -> "(stub)" }, parameters: {path: {type: "string"}}, returns: {type: "string"}},
   )
   stage_tools = tool_define(
     stage_tools,
     "run",
     "Run a command",
-    {handler: nil, parameters: {command: {type: "string"}}, returns: {type: "string"}},
+    {handler: { _ -> "(stub)" }, parameters: {command: {type: "string"}}, returns: {type: "string"}},
   )
   let flow = workflow_graph(
     {

--- a/conformance/tests/integration/approval_policy_auto_approve.harn
+++ b/conformance/tests/integration/approval_policy_auto_approve.harn
@@ -4,7 +4,11 @@ fn read_tools() {
     tools,
     "read_file",
     "Read a file",
-    {handler: nil, parameters: {path: {type: "string", description: "Path"}}, returns: {type: "string"}},
+    {
+    handler: { _ -> "(stub)" },
+    parameters: {path: {type: "string", description: "Path"}},
+    returns: {type: "string"},
+  },
   )
   return tools
 }

--- a/conformance/tests/integration/approval_policy_auto_deny.harn
+++ b/conformance/tests/integration/approval_policy_auto_deny.harn
@@ -5,7 +5,7 @@ fn write_tools() {
     "shell_exec",
     "Run shell command",
     {
-    handler: nil,
+    handler: { _ -> "(stub)" },
     parameters: {cmd: {type: "string", description: "Command"}},
     returns: {type: "string"},
   },

--- a/conformance/tests/integration/approval_policy_write_path.harn
+++ b/conformance/tests/integration/approval_policy_write_path.harn
@@ -5,7 +5,7 @@ fn write_tools() {
     "write_file",
     "Write a file",
     {
-    handler: nil,
+    handler: { _ -> "(stub)" },
     parameters: {path: {type: "string", description: "Path"}},
     returns: {type: "string"},
     metadata: {path_params: ["path"], mutation_classification: "apply_workspace"},

--- a/conformance/tests/integration/tool_define_executor.expected
+++ b/conformance/tests/integration/tool_define_executor.expected
@@ -1,0 +1,1 @@
+[harn] tool_define_executor passed

--- a/conformance/tests/integration/tool_define_executor.harn
+++ b/conformance/tests/integration/tool_define_executor.harn
@@ -1,0 +1,65 @@
+/**
+ * harn#743: tool_define stamps an explicit `executor` on every tool
+ * entry so the dispatcher and ACP transcript see a single source of
+ * truth for the backing. This test covers each accepted shape:
+ *   - executor: "harn" (explicit + inferred from handler)
+ *   - executor: "host_bridge" with host_capability
+ *   - executor: "mcp_server" with mcp_server name
+ *   - executor: "provider_native"
+ */
+pipeline test(task) {
+  var registry = tool_registry()
+  // Default: handler present, executor inferred → "harn".
+  registry = tool_define(
+    registry,
+    "compute",
+    "compute a thing",
+    {handler: { args -> "ok:" + args.x }, parameters: {x: {type: "string"}}},
+  )
+  let compute = tool_find(registry, "compute")
+  assert(compute.executor == "harn", "missing executor + handler defaults to harn")
+  // Explicit harn echoes back through the entry.
+  registry = tool_define(
+    registry,
+    "compute_explicit",
+    "explicit harn",
+    {executor: "harn", handler: { args -> args.x }, parameters: {}},
+  )
+  assert(
+    tool_find(registry, "compute_explicit").executor == "harn",
+    "explicit harn executor preserved",
+  )
+  // Host bridge: handler-less, host_capability is required.
+  registry = tool_define(
+    registry,
+    "ask_user",
+    "Ask the user",
+    {executor: "host_bridge", host_capability: "interaction.ask", parameters: {}},
+  )
+  let ask = tool_find(registry, "ask_user")
+  assert(ask.executor == "host_bridge", "host_bridge executor preserved")
+  assert(ask.host_capability == "interaction.ask", "host_capability preserved")
+  assert(ask.handler == nil, "host_bridge entry stays handler-less")
+  // MCP server: handler-less, mcp_server names the configured server.
+  registry = tool_define(
+    registry,
+    "list_issues",
+    "List Linear issues",
+    {executor: "mcp_server", mcp_server: "linear", parameters: {}},
+  )
+  let issues = tool_find(registry, "list_issues")
+  assert(issues.executor == "mcp_server", "mcp_server executor preserved")
+  assert(issues.mcp_server == "linear", "mcp_server name preserved")
+  // Provider native: handler-less, no other backing required.
+  registry = tool_define(
+    registry,
+    "web_search",
+    "Provider-native search",
+    {executor: "provider_native", parameters: {q: {type: "string"}}},
+  )
+  assert(
+    tool_find(registry, "web_search").executor == "provider_native",
+    "provider_native executor preserved",
+  )
+  log("tool_define_executor passed")
+}

--- a/conformance/tests/integration/tool_ref_basic.harn
+++ b/conformance/tests/integration/tool_ref_basic.harn
@@ -1,7 +1,17 @@
 pipeline main(task) {
   var r = tool_registry()
-  r = tool_define(r, "edit", "Edit a file in place", {parameters: {path: "string"}})
-  r = tool_define(r, "search", "Search the codebase", {parameters: {query: "string"}})
+  r = tool_define(
+    r,
+    "edit",
+    "Edit a file in place",
+    {parameters: {path: "string"}, handler: { args -> "edit:" + args.path }},
+  )
+  r = tool_define(
+    r,
+    "search",
+    "Search the codebase",
+    {parameters: {query: "string"}, handler: { args -> "search:" + args.query }},
+  )
   tool_bind(r)
   assert(tool_ref("edit") == "edit", "tool_ref returns the name when registered")
   assert(tool_ref("search") == "search", "tool_ref resolves another registered tool")

--- a/crates/harn-cli/src/commands/check/preflight.rs
+++ b/crates/harn-cli/src/commands/check/preflight.rs
@@ -241,6 +241,45 @@ fn scan_node_preflight(
                 diagnostics,
             );
         }
+        Node::FunctionCall { name, args } if name == "tool_define" => {
+            // harn#743: when a tool declares `executor: "host_bridge"`,
+            // its `host_capability: "capability.operation"` literal must
+            // resolve against the loaded host capability manifest. The
+            // dispatcher would otherwise silently fall back to a
+            // not-available error at the first model call. We only flag
+            // declarations that pass a string literal for both fields —
+            // dynamic values are out of scope for static validation.
+            if let Some((cap, op, host_cap_span)) = parse_tool_define_host_capability(args) {
+                if !is_known_host_operation(host_capabilities, &cap, &op) {
+                    diagnostics.push(PreflightDiagnostic {
+                        path: file_path.display().to_string(),
+                        source: source.to_string(),
+                        span: host_cap_span,
+                        message: format!(
+                            "preflight: tool_define declares host_capability '{cap}.{op}' \
+                             that is not exposed by the host"
+                        ),
+                        help: Some(
+                            "declare the capability in [check].host_capabilities, \
+                             [check].host_capabilities_path, --host-capabilities, or \
+                             suppress with [check].preflight_allow if the host adds it at \
+                             runtime"
+                                .to_string(),
+                        ),
+                        tags: Some(format!("{cap}.{op}")),
+                    });
+                }
+            }
+            scan_children(
+                args,
+                file_path,
+                source,
+                config,
+                host_capabilities,
+                visited,
+                diagnostics,
+            );
+        }
         Node::FunctionCall { name, args } if name == "host_call" => {
             if let Some((cap, op, params_arg)) = parse_host_call_args(args) {
                 if !is_known_host_operation(host_capabilities, &cap, &op) {
@@ -1070,6 +1109,39 @@ pub(super) fn parse_host_call_args(args: &[SNode]) -> Option<(String, String, Op
     };
     let (capability, operation) = name.split_once('.')?;
     Some((capability.to_string(), operation.to_string(), args.get(1)))
+}
+
+/// Extract the `host_capability` field from a `tool_define(...)` config
+/// dict, returning `(capability, operation, span)` only when:
+///   1. arg 3 (the config) is a literal dict,
+///   2. it sets `executor: "host_bridge"` literally,
+///   3. it sets `host_capability: "capability.operation"` literally.
+///
+/// Anything dynamic (computed strings, variable executor, etc.) is out
+/// of scope for the static preflight check — at runtime `tool_define`
+/// itself rejects malformed declarations.
+pub(super) fn parse_tool_define_host_capability(
+    args: &[SNode],
+) -> Option<(String, String, harn_lexer::Span)> {
+    let config = args.get(3)?;
+    let Node::DictLiteral(_) = &config.node else {
+        return None;
+    };
+    let executor = dict_literal_field(config, "executor").and_then(literal_string)?;
+    if executor != "host_bridge" {
+        return None;
+    }
+    let host_cap_node = dict_literal_field(config, "host_capability")?;
+    let host_cap = literal_string(host_cap_node)?;
+    let (capability, operation) = host_cap.split_once('.')?;
+    if capability.is_empty() || operation.is_empty() {
+        return None;
+    }
+    Some((
+        capability.to_string(),
+        operation.to_string(),
+        host_cap_node.span,
+    ))
 }
 
 pub(super) fn literal_string(node: &SNode) -> Option<String> {

--- a/crates/harn-cli/src/commands/check/tests.rs
+++ b/crates/harn-cli/src/commands/check/tests.rs
@@ -221,6 +221,101 @@ pipeline main() {
 }
 
 #[test]
+fn preflight_reports_unknown_host_capability_on_tool_define() {
+    // harn#743: tool_define(.., {executor: "host_bridge", host_capability:
+    // "...."}) should fail preflight when the named capability is not
+    // exposed by the host capability manifest.
+    let dir = unique_temp_dir("harn-check-tool-bridge");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("main.harn");
+    let source = r#"
+pipeline main() {
+  var registry = tool_registry()
+  registry = tool_define(registry, "ask", "ask user", {
+    executor: "host_bridge",
+    host_capability: "unknown_cap.do_thing",
+    parameters: {},
+  })
+}
+"#;
+    let program = parse_program(source);
+    let diagnostics =
+        collect_preflight_diagnostics(&file, source, &program, &CheckConfig::default());
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("host_capability 'unknown_cap.do_thing'")),
+        "expected host_capability diagnostic, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn preflight_accepts_known_host_capability_on_tool_define() {
+    let dir = unique_temp_dir("harn-check-tool-bridge-ok");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("main.harn");
+    let source = r#"
+pipeline main() {
+  var registry = tool_registry()
+  registry = tool_define(registry, "ask", "ask user", {
+    executor: "host_bridge",
+    host_capability: "interaction.ask",
+    parameters: {},
+  })
+}
+"#;
+    let program = parse_program(source);
+    let diagnostics =
+        collect_preflight_diagnostics(&file, source, &program, &CheckConfig::default());
+    assert!(
+        diagnostics
+            .iter()
+            .all(|d| !d.message.contains("host_capability")),
+        "unexpected host_capability diagnostic for known capability: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn preflight_skips_tool_define_for_non_host_bridge_executors() {
+    // harn#743: only host_bridge declarations carry host_capability;
+    // Harn-handler / mcp_server / provider_native tools must not trip
+    // the preflight check even when no manifest is loaded.
+    let dir = unique_temp_dir("harn-check-tool-skip");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("main.harn");
+    let source = r#"
+pipeline main() {
+  var registry = tool_registry()
+  registry = tool_define(registry, "compute", "compute a thing", {
+    executor: "harn",
+    handler: { args -> "ok" },
+    parameters: {},
+  })
+  registry = tool_define(registry, "lookup", "look up", {
+    executor: "mcp_server",
+    mcp_server: "linear",
+    parameters: {},
+  })
+}
+"#;
+    let program = parse_program(source);
+    let diagnostics =
+        collect_preflight_diagnostics(&file, source, &program, &CheckConfig::default());
+    assert!(
+        diagnostics
+            .iter()
+            .all(|d| !d.message.contains("host_capability")),
+        "unexpected host_capability diagnostic for non-host_bridge tools: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn check_file_inner_enforces_invariants_when_requested() {
     let dir = unique_temp_dir("harn-check-invariants");
     std::fs::create_dir_all(&dir).unwrap();

--- a/crates/harn-vm/src/connectors/github/tests.rs
+++ b/crates/harn-vm/src/connectors/github/tests.rs
@@ -496,8 +496,17 @@ async fn normalizes_monitor_github_webhook_events() {
     }
 }
 
+// Holding the std egress test mutex across `.await` is intentional:
+// the lock simply serializes whole-test bodies against the
+// egress::tests suite (uncontended outside tests).
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn outbound_methods_share_cached_installation_token() {
+    // Connector tests share the global egress policy with the
+    // egress::tests suite. Hold the lock for the duration so a
+    // sibling deny policy can't flake the localhost mock-server
+    // request.
+    let _egress_guard = crate::egress::egress_test_guard();
     let scenario = Arc::new(Mutex::new(MockScenario::default()));
     let (base_url, server) = spawn_mock_server(8, scenario.clone());
     let client = initialized_client(Arc::new(StaticSecretProvider {
@@ -580,8 +589,10 @@ async fn outbound_methods_share_cached_installation_token() {
     assert_eq!(state.api_requests[6].path, "/repos/octo/demo/issues");
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn api_call_uses_authenticated_github_rest_request() {
+    let _egress_guard = crate::egress::egress_test_guard();
     let scenario = Arc::new(Mutex::new(MockScenario::default()));
     let (base_url, server) = spawn_mock_server(2, scenario.clone());
     let client = initialized_client(Arc::new(StaticSecretProvider {
@@ -629,8 +640,10 @@ async fn api_call_uses_authenticated_github_rest_request() {
     assert_eq!(response["ok"], json!(true));
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn unauthorized_response_invalidates_token_and_remints() {
+    let _egress_guard = crate::egress::egress_test_guard();
     let scenario = Arc::new(Mutex::new(MockScenario {
         unauthorized_once: HashSet::from(["/repos/octo/demo/issues/123/comments".to_string()]),
         ..MockScenario::default()
@@ -663,8 +676,10 @@ async fn unauthorized_response_invalidates_token_and_remints() {
     assert!(first_auth.contains("token-2"));
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn rate_limited_response_retries_once() {
+    let _egress_guard = crate::egress::egress_test_guard();
     let scenario = Arc::new(Mutex::new(MockScenario {
         rate_limit_once: HashSet::from(["/repos/octo/demo/issues/123/comments".to_string()]),
         ..MockScenario::default()

--- a/crates/harn-vm/src/connectors/linear/tests.rs
+++ b/crates/harn-vm/src/connectors/linear/tests.rs
@@ -382,8 +382,13 @@ async fn linear_connector_rejects_stale_timestamps_and_records_metric() {
     assert_eq!(metrics.snapshot().linear_timestamp_rejections_total, 1);
 }
 
+// Holding the std egress test mutex across `.await` is intentional:
+// the lock simply serializes whole-test bodies against the
+// egress::tests suite (uncontended outside tests).
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn linear_client_supports_typed_methods_and_escape_hatch() {
+    let _egress_guard = crate::egress::egress_test_guard();
     let requests = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
     let (base_url, handle) = spawn_mock_server(requests.clone(), 5);
     let client = initialized_client(&base_url).await;

--- a/crates/harn-vm/src/connectors/notion/tests.rs
+++ b/crates/harn-vm/src/connectors/notion/tests.rs
@@ -316,8 +316,13 @@ fn spawn_mock_server(
     (format!("http://{}", addr), handle)
 }
 
+// Holding the std egress test mutex across `.await` is intentional:
+// the lock simply serializes whole-test bodies against the
+// egress::tests suite (uncontended outside tests).
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn notion_client_methods_use_current_api_headers_and_paths() {
+    let _egress_guard = crate::egress::egress_test_guard();
     let captured = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
     let (base_url, handle) = spawn_mock_server(
         7,
@@ -417,8 +422,10 @@ async fn notion_client_methods_use_current_api_headers_and_paths() {
     assert_eq!(requests[6].path, "/pages/page_1");
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn notion_client_retries_once_after_rate_limit() {
+    let _egress_guard = crate::egress::egress_test_guard();
     let captured = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
     let (base_url, handle) = spawn_mock_server(
         2,
@@ -464,8 +471,10 @@ async fn notion_client_retries_once_after_rate_limit() {
     );
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn notion_poll_binding_emits_targeted_inbox_event_and_persists_high_water() {
+    let _egress_guard = crate::egress::egress_test_guard();
     let captured = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
     let page = json!({
         "id": "page_1",

--- a/crates/harn-vm/src/connectors/slack/tests.rs
+++ b/crates/harn-vm/src/connectors/slack/tests.rs
@@ -491,8 +491,13 @@ fn spawn_mock_server(
     (format!("http://{addr}"), handle)
 }
 
+// Holding the std egress test mutex across `.await` is intentional:
+// the lock simply serializes whole-test bodies against the
+// egress::tests suite (uncontended outside tests).
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn slack_outbound_helpers_hit_expected_api_methods() {
+    let _egress_guard = crate::egress::egress_test_guard();
     let client = initialized_client().await;
     let scenario = Arc::new(Mutex::new(MockScenario::default()));
     let (base_url, handle) = spawn_mock_server(9, scenario.clone());

--- a/crates/harn-vm/src/egress.rs
+++ b/crates/harn-vm/src/egress.rs
@@ -149,6 +149,46 @@ pub fn reset_egress_policy_for_tests() {
     reset_egress_policy_for_host();
 }
 
+/// Process-wide mutex serializing every test that touches the global
+/// egress policy. Held for the duration of:
+///
+/// - `egress::tests::*`, which install/uninstall a deny policy.
+/// - `http::tests::*` real-network tests (TLS pinning, proxy
+///   routing) — these don't touch the policy themselves but a
+///   parallel `egress::tests::*` test installing `deny` would
+///   otherwise flake their `vm_execute_http_request` calls with
+///   `EgressBlocked`.
+/// - Connector test-kit tests (`connectors::github/notion/slack/...`)
+///   that spin up a localhost mock server.
+///
+/// The lock keeps these suites mutually exclusive without changing
+/// production behavior. Pair it with `reset_egress_policy_for_tests()`
+/// at the start of each test to clear any policy left behind by a
+/// previous panicking run.
+#[cfg(test)]
+pub(crate) fn egress_test_lock() -> &'static std::sync::Mutex<()> {
+    use std::sync::Mutex;
+    static LOCK: Mutex<()> = Mutex::new(());
+    &LOCK
+}
+
+/// Acquire the [`egress_test_lock`] and reset the global egress
+/// policy, returning a `MutexGuard` that holds the lock for the
+/// caller's scope. Tests should bind it to `let _guard = ...` so the
+/// lock is released when the test returns.
+#[cfg(test)]
+pub(crate) fn egress_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    // `MutexGuard::map` is unstable; instead handle the poisoned-lock
+    // recovery here so tests aren't tripped up by an earlier panic
+    // poisoning the mutex.
+    let guard = match egress_test_lock().lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    reset_egress_policy_for_tests();
+    guard
+}
+
 fn check_url(surface: &str, raw_url: &str) -> Result<Option<EgressBlocked>, VmError> {
     ensure_env_seeded()?;
     let configured = {
@@ -581,11 +621,10 @@ impl std::fmt::Display for EgressBlocked {
 mod tests {
     use super::*;
 
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     fn install(config: &[(&str, VmValue)]) -> std::sync::MutexGuard<'static, ()> {
-        let guard = ENV_LOCK.lock().unwrap();
-        reset_egress_policy_for_tests();
+        // `egress_test_guard` already takes the shared lock and resets
+        // any leftover policy.
+        let guard = egress_test_guard();
         let map = config
             .iter()
             .cloned()
@@ -664,8 +703,7 @@ mod tests {
 
     #[test]
     fn env_seeding_is_honored() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        reset_egress_policy_for_tests();
+        let _guard = egress_test_guard();
         std::env::set_var(HARN_EGRESS_ALLOW_ENV, "env.example.com");
         std::env::set_var(HARN_EGRESS_DENY_ENV, "");
         std::env::set_var(HARN_EGRESS_DEFAULT_ENV, "deny");

--- a/crates/harn-vm/src/http.rs
+++ b/crates/harn-vm/src/http.rs
@@ -5376,8 +5376,17 @@ mod tests {
         reset_http_state();
     }
 
+    // Holding the std-lib egress test mutex across `.await` is
+    // intentional: the lock simply serializes whole-test bodies
+    // against the egress::tests suite (uncontended outside tests).
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn http_proxy_routes_requests_through_configured_proxy() {
+        // Real-network tests share the global egress policy with the
+        // egress::tests suite — hold the shared lock so a sibling
+        // test installing `default: "deny"` cannot mid-flight block
+        // our localhost proxy request.
+        let _egress_guard = crate::egress::egress_test_guard();
         reset_http_state();
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind proxy listener");
         let proxy_addr = listener.local_addr().expect("proxy addr");
@@ -5427,8 +5436,10 @@ mod tests {
         reset_http_state();
     }
 
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn custom_tls_ca_bundle_and_pin_allow_request() {
+        let _egress_guard = crate::egress::egress_test_guard();
         reset_http_state();
         install_rustls_provider();
         let temp = TempDir::new().expect("tempdir");
@@ -5488,8 +5499,10 @@ mod tests {
         reset_http_state();
     }
 
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn custom_tls_pin_mismatch_is_rejected() {
+        let _egress_guard = crate::egress::egress_test_guard();
         reset_http_state();
         install_rustls_provider();
         let temp = TempDir::new().expect("tempdir");

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -405,6 +405,11 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
             let (skill_registry, skill_match, working_files) =
                 super::agent::parse_skill_config(&options);
             let mut opts = extract_llm_options(&args)?;
+            // harn#743: refuse to start with a registry that has any
+            // tool lacking an executable backend. See the bare
+            // `agent_loop` registration in `llm/mod.rs` for the
+            // matching guard — both sites must stay in lockstep.
+            crate::stdlib::tools::ensure_tools_have_executors(opts.tools.as_ref())?;
             let result = run_agent_loop_internal(
                 &mut opts,
                 AgentLoopConfig {

--- a/crates/harn-vm/src/llm/agent_tools.rs
+++ b/crates/harn-vm/src/llm/agent_tools.rs
@@ -273,82 +273,96 @@ pub(super) async fn dispatch_tool_execution(
 
     let mut attempt = 0usize;
     let mut executor: Option<ToolExecutor> = None;
+    // harn#743: when the registry declares an executor for this tool
+    // (`tool_define(..., {executor: "..."})`), pin the transcript tag
+    // to the declared value. Falls back to dispatch-time inference for
+    // VM-stdlib tools and registries that pre-date the declaration.
+    let declared_executor = declared_executor_for_tool(tools_val, tool_name);
     loop {
-        let result = if let Some(local_result) = handle_tool_locally(tool_name, tool_args) {
-            // VM-stdlib short-circuit (read_file / list_directory). Any
-            // other tool falls through to the script-handler / bridge
-            // path below.
-            executor = Some(ToolExecutor::HarnBuiltin);
-            Ok(serde_json::Value::String(local_result))
-        } else if let Some(handler) = find_tool_handler(tools_val, tool_name) {
-            // A Harn-side handler closure exists — but if the tool was
-            // sourced from `mcp_list_tools`, the dict carries the
-            // originating server name as `_mcp_server`, and the call is
-            // semantically "served by MCP" even though dispatch goes
-            // through a Harn closure that ultimately invokes mcp_call.
-            executor = Some(match mcp_server_for_tool(tools_val, tool_name) {
-                Some(server_name) => ToolExecutor::McpServer { server_name },
-                None => ToolExecutor::HarnBuiltin,
-            });
-            let Some(mut vm) = crate::vm::clone_async_builtin_child_vm() else {
-                return ToolDispatchOutcome {
-                    result: Err(VmError::CategorizedError {
-                        message: format!(
+        let result =
+            if let Some(local_result) = handle_tool_locally(tool_name, tool_args) {
+                // VM-stdlib short-circuit (read_file / list_directory). Any
+                // other tool falls through to the script-handler / bridge
+                // path below.
+                executor = Some(
+                    declared_executor
+                        .clone()
+                        .unwrap_or(ToolExecutor::HarnBuiltin),
+                );
+                Ok(serde_json::Value::String(local_result))
+            } else if let Some(handler) = find_tool_handler(tools_val, tool_name) {
+                // A Harn-side handler closure exists — but if the tool was
+                // sourced from `mcp_list_tools`, the dict carries the
+                // originating server name as `_mcp_server`, and the call is
+                // semantically "served by MCP" even though dispatch goes
+                // through a Harn closure that ultimately invokes mcp_call.
+                executor = Some(declared_executor.clone().unwrap_or_else(|| {
+                    match mcp_server_for_tool(tools_val, tool_name) {
+                        Some(server_name) => ToolExecutor::McpServer { server_name },
+                        None => ToolExecutor::HarnBuiltin,
+                    }
+                }));
+                let Some(mut vm) = crate::vm::clone_async_builtin_child_vm() else {
+                    return ToolDispatchOutcome {
+                        result: Err(VmError::CategorizedError {
+                            message: format!(
                             "tool '{tool_name}' is Harn-owned but no child VM context was available"
                         ),
-                        category: ErrorCategory::ToolRejected,
-                    }),
-                    executor,
+                            category: ErrorCategory::ToolRejected,
+                        }),
+                        executor,
+                    };
                 };
-            };
-            let args_vm = crate::stdlib::json_to_vm_value(tool_args);
-            let _trusted_bridge_guard = crate::orchestration::allow_trusted_bridge_calls();
-            match vm.call_closure_pub(&handler, &[args_vm]).await {
-                Ok(val) => Ok(serde_json::Value::String(val.display())),
+                let args_vm = crate::stdlib::json_to_vm_value(tool_args);
+                let _trusted_bridge_guard = crate::orchestration::allow_trusted_bridge_calls();
+                match vm.call_closure_pub(&handler, &[args_vm]).await {
+                    Ok(val) => Ok(serde_json::Value::String(val.display())),
+                    Err(VmError::CategorizedError {
+                        message,
+                        category: ErrorCategory::ToolRejected,
+                    }) => Ok(denied_tool_result(tool_name, message)),
+                    Err(e) => Ok(serde_json::Value::String(format!("Error: {e}"))),
+                }
+            } else if let Some(bridge) = bridge {
+                // Same `_mcp_server` discriminator: a host that surfaces an
+                // MCP server's tools without a Harn-side closure (e.g. the
+                // CLI's eager-connect path) still routes through the bridge,
+                // but the executor is the MCP server, not the bridge itself.
+                executor = Some(declared_executor.clone().unwrap_or_else(|| {
+                    match mcp_server_for_tool(tools_val, tool_name) {
+                        Some(server_name) => ToolExecutor::McpServer { server_name },
+                        None => ToolExecutor::HostBridge,
+                    }
+                }));
+                match bridge
+                    .call(
+                        "builtin_call",
+                        serde_json::json!({
+                            "name": tool_name,
+                            "args": [tool_args],
+                        }),
+                    )
+                    .await
+                {
+                    Err(VmError::CategorizedError {
+                        message,
+                        category: ErrorCategory::ToolRejected,
+                    }) => Ok(denied_tool_result(tool_name, message)),
+                    other => other,
+                }
+            } else {
+                // No backend could claim the call — leave executor unset so
+                // the caller reports "tool unavailable" rather than blaming
+                // a specific backend.
                 Err(VmError::CategorizedError {
-                    message,
-                    category: ErrorCategory::ToolRejected,
-                }) => Ok(denied_tool_result(tool_name, message)),
-                Err(e) => Ok(serde_json::Value::String(format!("Error: {e}"))),
-            }
-        } else if let Some(bridge) = bridge {
-            // Same `_mcp_server` discriminator: a host that surfaces an
-            // MCP server's tools without a Harn-side closure (e.g. the
-            // CLI's eager-connect path) still routes through the bridge,
-            // but the executor is the MCP server, not the bridge itself.
-            executor = Some(match mcp_server_for_tool(tools_val, tool_name) {
-                Some(server_name) => ToolExecutor::McpServer { server_name },
-                None => ToolExecutor::HostBridge,
-            });
-            match bridge
-                .call(
-                    "builtin_call",
-                    serde_json::json!({
-                        "name": tool_name,
-                        "args": [tool_args],
-                    }),
-                )
-                .await
-            {
-                Err(VmError::CategorizedError {
-                    message,
-                    category: ErrorCategory::ToolRejected,
-                }) => Ok(denied_tool_result(tool_name, message)),
-                other => other,
-            }
-        } else {
-            // No backend could claim the call — leave executor unset so
-            // the caller reports "tool unavailable" rather than blaming
-            // a specific backend.
-            Err(VmError::CategorizedError {
-                message: format!(
-                    "Tool '{}' is not available in the current environment. \
+                    message: format!(
+                        "Tool '{}' is not available in the current environment. \
                      Use only the tools listed in the tool-calling contract.",
-                    tool_name
-                ),
-                category: ErrorCategory::ToolRejected,
-            })
-        };
+                        tool_name
+                    ),
+                    category: ErrorCategory::ToolRejected,
+                })
+            };
         match &result {
             Ok(_) => break ToolDispatchOutcome { result, executor },
             Err(VmError::CategorizedError {
@@ -432,6 +446,89 @@ pub(super) fn find_tool_handler(
             }
             return None;
         }
+    }
+    None
+}
+
+/// Map a tool entry's declared executor to the [`ToolExecutor`] tag.
+/// `executor: "mcp_server"` honors the entry's own `mcp_server` field,
+/// falling back to a `_mcp_server` tag (e.g. from `mcp_list_tools`)
+/// when the author defined the tool through `tool_define` but only
+/// named the server elsewhere — keeps the wire-level executor consistent
+/// with how MCP-discovered tools are tagged today (harn#743).
+fn executor_from_entry(
+    entry: &std::collections::BTreeMap<String, VmValue>,
+) -> Option<ToolExecutor> {
+    use crate::stdlib::tools::{
+        EXECUTOR_HARN, EXECUTOR_HOST_BRIDGE, EXECUTOR_MCP_SERVER, EXECUTOR_PROVIDER_NATIVE,
+    };
+    let kind = match entry.get("executor") {
+        Some(VmValue::String(s)) => s.to_string(),
+        _ => return None,
+    };
+    match kind.as_str() {
+        EXECUTOR_HARN => Some(ToolExecutor::HarnBuiltin),
+        EXECUTOR_HOST_BRIDGE => Some(ToolExecutor::HostBridge),
+        EXECUTOR_MCP_SERVER => {
+            let server_name = match entry.get("mcp_server") {
+                Some(VmValue::String(s)) if !s.is_empty() => s.to_string(),
+                _ => match entry.get("_mcp_server") {
+                    Some(VmValue::String(s)) if !s.is_empty() => s.to_string(),
+                    _ => return None,
+                },
+            };
+            Some(ToolExecutor::McpServer { server_name })
+        }
+        EXECUTOR_PROVIDER_NATIVE => Some(ToolExecutor::ProviderNative),
+        _ => None,
+    }
+}
+
+/// Read the declared executor for a tool from `tools_val`. The
+/// declaration wins over dispatch-time inference so the ACP transcript
+/// reflects the source-of-truth executor identity (harn#743). Falls
+/// back to the `_mcp_server` tag for MCP-discovered tools that never
+/// went through `tool_define`.
+pub(super) fn declared_executor_for_tool(
+    tools_val: Option<&VmValue>,
+    tool_name: &str,
+) -> Option<ToolExecutor> {
+    let dict = tools_val?.as_dict()?;
+    let tools_list = match dict.get("tools") {
+        Some(VmValue::List(l)) => l,
+        _ => return None,
+    };
+    for tool in tools_list.iter() {
+        let entry: &std::collections::BTreeMap<String, VmValue> = match tool {
+            VmValue::Dict(d) => d,
+            _ => continue,
+        };
+        let name = match entry.get("name") {
+            Some(v) => v.display(),
+            None => entry
+                .get("function")
+                .and_then(|f| f.as_dict())
+                .and_then(|f| f.get("name"))
+                .map(|v| v.display())
+                .unwrap_or_default(),
+        };
+        if name != tool_name {
+            continue;
+        }
+        if let Some(executor) = executor_from_entry(entry) {
+            return Some(executor);
+        }
+        // Legacy / MCP-discovered entries with no `executor` field but
+        // a `_mcp_server` tag — match what `mcp_server_for_tool`
+        // returns to keep the executor tag consistent.
+        if let Some(VmValue::String(s)) = entry.get("_mcp_server") {
+            if !s.is_empty() {
+                return Some(ToolExecutor::McpServer {
+                    server_name: s.to_string(),
+                });
+            }
+        }
+        return None;
     }
     None
 }
@@ -600,5 +697,74 @@ mod tests {
                 .await;
         assert!(outcome.result.is_err());
         assert!(outcome.executor.is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dispatch_honors_declared_host_bridge_executor_over_mcp_tag() {
+        // harn#743: when an entry declares `executor: "host_bridge"`
+        // the transcript must reflect the declaration even if the
+        // entry also carries an `_mcp_server` tag (e.g. a host-shimmed
+        // tool that proxies a fake server name). The declaration is
+        // the source of truth.
+        let bridge = crate::bridge::HostBridge::from_parts_with_writer(
+            Arc::new(Mutex::new(std::collections::HashMap::new())),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(|_| Err("test bridge".to_string())),
+            1,
+        );
+        let bridge = Rc::new(bridge);
+        let mut entry = BTreeMap::new();
+        entry.insert(
+            "executor".to_string(),
+            VmValue::String(Rc::from("host_bridge".to_string())),
+        );
+        entry.insert(
+            "host_capability".to_string(),
+            VmValue::String(Rc::from("interaction.ask".to_string())),
+        );
+        // Decoy `_mcp_server`: would normally tag the executor as
+        // McpServer, but the declared `host_bridge` wins.
+        entry.insert(
+            "_mcp_server".to_string(),
+            VmValue::String(Rc::from("linear".to_string())),
+        );
+        let tools = tools_dict(vec![("ask_user", entry)]);
+        let args = serde_json::json!({});
+        let outcome =
+            dispatch_tool_execution("ask_user", &args, Some(&tools), Some(&bridge), 0, 0).await;
+        assert_eq!(outcome.executor, Some(ToolExecutor::HostBridge));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dispatch_honors_declared_mcp_server_executor() {
+        // harn#743: `executor: "mcp_server"` with an explicit
+        // `mcp_server` field maps straight to McpServer { server_name }
+        // in the transcript.
+        let bridge = crate::bridge::HostBridge::from_parts_with_writer(
+            Arc::new(Mutex::new(std::collections::HashMap::new())),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(|_| Err("test bridge".to_string())),
+            1,
+        );
+        let bridge = Rc::new(bridge);
+        let mut entry = BTreeMap::new();
+        entry.insert(
+            "executor".to_string(),
+            VmValue::String(Rc::from("mcp_server".to_string())),
+        );
+        entry.insert(
+            "mcp_server".to_string(),
+            VmValue::String(Rc::from("github".to_string())),
+        );
+        let tools = tools_dict(vec![("create_pr", entry)]);
+        let args = serde_json::json!({});
+        let outcome =
+            dispatch_tool_execution("create_pr", &args, Some(&tools), Some(&bridge), 0, 0).await;
+        assert_eq!(
+            outcome.executor,
+            Some(ToolExecutor::McpServer {
+                server_name: "github".to_string()
+            })
+        );
     }
 }

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -978,6 +978,14 @@ pub fn register_llm_builtins(vm: &mut Vm) {
         let (skill_registry, skill_match, working_files) =
             crate::llm::agent::parse_skill_config(&options);
         let mut opts = extract_llm_options(&args)?;
+        // harn#743: refuse to start when the registry contains a tool
+        // with no executable backend. `tool_define` rejects this at
+        // definition time, but the agent loop is also fed registries
+        // that came from MCP discovery, manual dict construction, or
+        // tools merged across packages — re-check here so the error
+        // surfaces before the first model call rather than as an
+        // opaque `[builtin_call] unhandled` later.
+        crate::stdlib::tools::ensure_tools_have_executors(opts.tools.as_ref())?;
         let result = run_agent_loop_internal(
             &mut opts,
             AgentLoopConfig {

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -729,6 +729,9 @@ pub(super) async fn execute_sub_agent(
         VmValue::Dict(Rc::new(spec.options.clone())),
     ];
     let mut llm_opts = crate::llm::helpers::extract_llm_options(&args)?;
+    // harn#743: surface tool-registry validation through the sub-agent
+    // path too — same guard the bare `agent_loop` builtin runs.
+    crate::stdlib::tools::ensure_tools_have_executors(llm_opts.tools.as_ref())?;
     let config = sub_agent_loop_options(&spec)?;
     let result = crate::llm::run_agent_loop_internal(&mut llm_opts, config).await;
 

--- a/crates/harn-vm/src/stdlib/tools.rs
+++ b/crates/harn-vm/src/stdlib/tools.rs
@@ -362,8 +362,9 @@ pub(crate) fn register_tool_builtins(vm: &mut Vm) {
         Ok(VmValue::Dict(Rc::new(schema)))
     });
 
-    // Unknown config keys (beyond parameters/handler/returns/annotations) are
-    // preserved verbatim so integrators can attach policy/effect metadata.
+    // Unknown config keys (beyond parameters/handler/returns/annotations/
+    // executor/host_capability/mcp_server) are preserved verbatim so
+    // integrators can attach policy/effect metadata.
     vm.register_builtin("tool_define", |args, _out| {
         if args.len() < 4 {
             return Err(VmError::Thrown(VmValue::String(Rc::from(
@@ -394,12 +395,20 @@ pub(crate) fn register_tool_builtins(vm: &mut Vm) {
         };
 
         let handler = config.get("handler").cloned().unwrap_or(VmValue::Nil);
+        let has_handler = !matches!(handler, VmValue::Nil);
 
         if config.contains_key("params") && !config.contains_key("parameters") {
             return Err(VmError::Thrown(VmValue::String(Rc::from(
                 "tool_define: use 'parameters', not 'params'",
             ))));
         }
+
+        // Resolve executor (harn#743). Authors must pick exactly one
+        // backend; the dispatcher and ACP transcript both honor the
+        // declared value verbatim so clients can render "via host
+        // bridge" / "via mcp:linear" badges without inferring backends
+        // from missing fields.
+        let executor = resolve_tool_executor(&name, config, has_handler)?;
 
         // `defer_loading` controls progressive-disclosure behavior on
         // capable providers (Anthropic Claude 4.0+ and OpenAI GPT 5.4+).
@@ -449,15 +458,23 @@ pub(crate) fn register_tool_builtins(vm: &mut Vm) {
         if !matches!(output_schema, VmValue::Nil) {
             tool_entry.insert("outputSchema".to_string(), output_schema);
         }
+        tool_entry.insert(
+            "executor".to_string(),
+            VmValue::String(Rc::from(executor.as_str())),
+        );
 
         if let Some(annotations) = config.get("annotations") {
             tool_entry.insert("annotations".to_string(), annotations.clone());
         }
 
         for (key, value) in config.iter() {
+            // `executor` is normalized into the canonical entry above
+            // (the resolver fills the default for legacy `harn` handlers
+            // and rejects mismatches), so skip the raw author input
+            // here. Same for the fields that have dedicated slots.
             if matches!(
                 key.as_str(),
-                "handler" | "parameters" | "returns" | "annotations"
+                "handler" | "parameters" | "returns" | "annotations" | "executor"
             ) {
                 continue;
             }
@@ -682,6 +699,264 @@ fn vm_validate_registry(name: &str, dict: &BTreeMap<String, VmValue>) -> Result<
             "{name}: argument must be a tool registry (created with tool_registry())"
         ))))),
     }
+}
+
+/// Canonical executor identifiers accepted by `tool_define`. The
+/// dispatcher (`crate::llm::agent_tools::dispatch_tool_execution`)
+/// reads the chosen value verbatim and ACP forwards it on every
+/// `tool_call_update`, so the names must stay in lockstep with
+/// [`crate::agent_events::ToolExecutor`] (harn#743).
+pub(crate) const EXECUTOR_HARN: &str = "harn";
+pub(crate) const EXECUTOR_HOST_BRIDGE: &str = "host_bridge";
+pub(crate) const EXECUTOR_MCP_SERVER: &str = "mcp_server";
+pub(crate) const EXECUTOR_PROVIDER_NATIVE: &str = "provider_native";
+
+/// Resolve the declared executor for an in-registry tool entry,
+/// applying the same legacy fall-back as [`resolve_tool_executor`]
+/// (handler present + executor absent → `EXECUTOR_HARN`, MCP-discovered
+/// entries with `_mcp_server` → `EXECUTOR_MCP_SERVER`). Returns `None`
+/// when neither signal is present *or* when an explicit `executor`
+/// value is not one of the canonical names — both cases mean the
+/// tool has no executable backend the dispatcher can route to
+/// (harn#743).
+pub(crate) fn declared_executor_for_entry(entry: &BTreeMap<String, VmValue>) -> Option<String> {
+    if let Some(VmValue::String(s)) = entry.get("executor") {
+        return if known_executor(s) {
+            Some(s.to_string())
+        } else {
+            None
+        };
+    }
+    if entry.contains_key("_mcp_server") {
+        return Some(EXECUTOR_MCP_SERVER.to_string());
+    }
+    if matches!(entry.get("handler"), Some(v) if !matches!(v, VmValue::Nil)) {
+        return Some(EXECUTOR_HARN.to_string());
+    }
+    None
+}
+
+/// Walk a tool registry value (dict with `tools: List[Dict]`) and
+/// return a list of tool names that have no executable backend. Used
+/// by `agent_loop` to refuse to start when the registry contains a
+/// tool that the dispatcher would later fail to handle (harn#743).
+/// Non-registry shapes return an empty list — the existing argument
+/// validators in `agent_loop` / `extract_llm_options` already reject
+/// the bad shape with their own diagnostics.
+pub(crate) fn tools_missing_executor(tools_val: &VmValue) -> Vec<String> {
+    let dict = match tools_val {
+        VmValue::Dict(d) => d,
+        _ => return Vec::new(),
+    };
+    let tools = match dict.get("tools") {
+        Some(VmValue::List(list)) => list,
+        _ => return Vec::new(),
+    };
+    let mut missing = Vec::new();
+    for tool in tools.iter() {
+        let entry = match tool {
+            VmValue::Dict(d) => d,
+            _ => continue,
+        };
+        if declared_executor_for_entry(entry).is_some() {
+            continue;
+        }
+        let name = entry
+            .get("name")
+            .map(|v| v.display())
+            .unwrap_or_else(|| "<unnamed>".to_string());
+        missing.push(name);
+    }
+    missing
+}
+
+/// Run the [`tools_missing_executor`] guard and convert any missing
+/// backends into the canonical agent-loop error. Both `agent_loop`
+/// registrations (the bare and the bridge-attached variants) call
+/// this so the diagnostic stays in lockstep regardless of which
+/// builtin is bound (harn#743).
+pub(crate) fn ensure_tools_have_executors(tools_val: Option<&VmValue>) -> Result<(), VmError> {
+    let Some(tools_val) = tools_val else {
+        return Ok(());
+    };
+    let missing = tools_missing_executor(tools_val);
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+        "agent_loop: registry contains {} tool(s) with no executable backend: {}. \
+         Each tool must declare an `executor` (\"harn\", \"host_bridge\", \"mcp_server\", \
+         or \"provider_native\") with the matching backing field, or supply a `handler` \
+         closure for the legacy in-Harn case.",
+        missing.len(),
+        missing.join(", "),
+    )))))
+}
+
+fn known_executor(value: &str) -> bool {
+    matches!(
+        value,
+        EXECUTOR_HARN | EXECUTOR_HOST_BRIDGE | EXECUTOR_MCP_SERVER | EXECUTOR_PROVIDER_NATIVE
+    )
+}
+
+/// Validate the `executor` declaration on a `tool_define` config and
+/// return the canonical executor name. Authors must pick exactly one
+/// backend: missing handlers can no longer silently fall through to
+/// the host bridge (harn#743). When the author omits `executor` but
+/// provides a `handler`, this defaults to `EXECUTOR_HARN` so existing
+/// scripts keep compiling — the leaky case the issue calls out
+/// (handler-less tools relying on bridge fall-through) is the only
+/// one that has to declare an executor explicitly.
+fn resolve_tool_executor(
+    name: &str,
+    config: &BTreeMap<String, VmValue>,
+    has_handler: bool,
+) -> Result<String, VmError> {
+    let executor = match config.get("executor") {
+        Some(VmValue::String(s)) => Some(s.to_string()),
+        Some(VmValue::Nil) | None => None,
+        Some(other) => {
+            return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                "tool_define({name:?}): `executor` must be a string \
+                 (one of \"harn\", \"host_bridge\", \"mcp_server\", \"provider_native\"), \
+                 got {}",
+                other.display()
+            )))));
+        }
+    };
+
+    let host_capability = config.get("host_capability");
+    let mcp_server = config.get("mcp_server");
+
+    let executor = match executor {
+        Some(value) => {
+            if !known_executor(&value) {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "tool_define({name:?}): unknown executor {value:?}. \
+                     Expected one of \"harn\", \"host_bridge\", \"mcp_server\", \"provider_native\"."
+                )))));
+            }
+            value
+        }
+        None => {
+            if has_handler {
+                EXECUTOR_HARN.to_string()
+            } else {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "tool_define({name:?}): tool has no `handler` and no explicit `executor`. \
+                     Add `handler: ...` for an in-Harn tool, or declare \
+                     `executor: \"host_bridge\", host_capability: \"capability.operation\"` \
+                     for a tool the host backs (or `executor: \"mcp_server\", mcp_server: \"name\"` / \
+                     `executor: \"provider_native\"`)."
+                )))));
+            }
+        }
+    };
+
+    match executor.as_str() {
+        EXECUTOR_HARN => {
+            if !has_handler {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "tool_define({name:?}): executor: \"harn\" requires a `handler` closure. \
+                     Either supply `handler: {{ args -> ... }}` or pick a different executor."
+                )))));
+            }
+            if host_capability.is_some_and(|v| !matches!(v, VmValue::Nil)) {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "tool_define({name:?}): executor: \"harn\" must not declare \
+                     `host_capability`; that field is only valid for executor: \"host_bridge\"."
+                )))));
+            }
+            if mcp_server.is_some_and(|v| !matches!(v, VmValue::Nil)) {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "tool_define({name:?}): executor: \"harn\" must not declare \
+                     `mcp_server`; that field is only valid for executor: \"mcp_server\"."
+                )))));
+            }
+        }
+        EXECUTOR_HOST_BRIDGE => {
+            if has_handler {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "tool_define({name:?}): executor: \"host_bridge\" must not declare a \
+                     `handler` — the host owns execution. Drop the handler closure or pick \
+                     executor: \"harn\"."
+                )))));
+            }
+            match host_capability {
+                Some(VmValue::String(s)) if !s.is_empty() => {
+                    if s.split_once('.')
+                        .is_none_or(|(c, op)| c.is_empty() || op.is_empty())
+                    {
+                        return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                            "tool_define({name:?}): `host_capability` must look like \
+                             \"capability.operation\" (e.g. \"interaction.ask\"); got {s:?}."
+                        )))));
+                    }
+                }
+                _ => {
+                    return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                        "tool_define({name:?}): executor: \"host_bridge\" requires a \
+                         `host_capability: \"capability.operation\"` field so `harn check` can \
+                         validate the host backs the tool (e.g. \"interaction.ask\")."
+                    )))));
+                }
+            }
+            if mcp_server.is_some_and(|v| !matches!(v, VmValue::Nil)) {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "tool_define({name:?}): executor: \"host_bridge\" must not declare \
+                     `mcp_server`; that field is only valid for executor: \"mcp_server\"."
+                )))));
+            }
+        }
+        EXECUTOR_MCP_SERVER => {
+            if has_handler {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "tool_define({name:?}): executor: \"mcp_server\" must not declare a \
+                     `handler` — the MCP server owns execution. Drop the handler closure or \
+                     pick executor: \"harn\"."
+                )))));
+            }
+            match mcp_server {
+                Some(VmValue::String(s)) if !s.is_empty() => {}
+                _ => {
+                    return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                        "tool_define({name:?}): executor: \"mcp_server\" requires an \
+                         `mcp_server: \"<server name>\"` field naming the configured MCP server."
+                    )))));
+                }
+            }
+            if host_capability.is_some_and(|v| !matches!(v, VmValue::Nil)) {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "tool_define({name:?}): executor: \"mcp_server\" must not declare \
+                     `host_capability`; that field is only valid for executor: \"host_bridge\"."
+                )))));
+            }
+        }
+        EXECUTOR_PROVIDER_NATIVE => {
+            if has_handler {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "tool_define({name:?}): executor: \"provider_native\" must not declare a \
+                     `handler` — the provider already returns the executed result inline."
+                )))));
+            }
+            if host_capability.is_some_and(|v| !matches!(v, VmValue::Nil)) {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "tool_define({name:?}): executor: \"provider_native\" must not declare \
+                     `host_capability`."
+                )))));
+            }
+            if mcp_server.is_some_and(|v| !matches!(v, VmValue::Nil)) {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "tool_define({name:?}): executor: \"provider_native\" must not declare \
+                     `mcp_server`."
+                )))));
+            }
+        }
+        _ => unreachable!("known_executor guard above"),
+    }
+
+    Ok(executor)
 }
 
 fn vm_get_tools(dict: &BTreeMap<String, VmValue>) -> &[VmValue] {

--- a/crates/harn-vm/tests/tool_ref.rs
+++ b/crates/harn-vm/tests/tool_ref.rs
@@ -37,7 +37,7 @@ fn tool_ref_returns_name_when_registered() {
     let lines = out(r#"
 pipeline main(task) {
   var r = tool_registry()
-  r = tool_define(r, "edit", "Edit a file", {parameters: {path: "string"}})
+  r = tool_define(r, "edit", "Edit a file", {parameters: {path: "string"}, handler: { args -> args.path }})
   tool_bind(r)
   log(tool_ref("edit"))
 }
@@ -50,7 +50,7 @@ fn tool_ref_throws_on_unknown_name() {
     let err = run(r#"
 pipeline main(task) {
   var r = tool_registry()
-  r = tool_define(r, "edit", "Edit a file", {parameters: {path: "string"}})
+  r = tool_define(r, "edit", "Edit a file", {parameters: {path: "string"}, handler: { args -> args.path }})
   tool_bind(r)
   log(tool_ref("nonexistent"))
 }
@@ -85,7 +85,7 @@ fn tool_def_returns_registered_entry() {
     let lines = out(r#"
 pipeline main(task) {
   var r = tool_registry()
-  r = tool_define(r, "edit", "Edit a file in place", {parameters: {path: "string"}})
+  r = tool_define(r, "edit", "Edit a file in place", {parameters: {path: "string"}, handler: { args -> args.path }})
   tool_bind(r)
   let def = tool_def("edit")
   log(def.name)
@@ -100,7 +100,7 @@ fn tool_def_throws_on_unknown_name() {
     let err = run(r#"
 pipeline main(task) {
   var r = tool_registry()
-  r = tool_define(r, "edit", "Edit a file", {parameters: {path: "string"}})
+  r = tool_define(r, "edit", "Edit a file", {parameters: {path: "string"}, handler: { args -> args.path }})
   tool_bind(r)
   log(tool_def("nonexistent"))
 }
@@ -131,7 +131,7 @@ fn tool_bind_nil_clears_registry() {
     let err = run(r#"
 pipeline main(task) {
   var r = tool_registry()
-  r = tool_define(r, "edit", "Edit a file", {parameters: {path: "string"}})
+  r = tool_define(r, "edit", "Edit a file", {parameters: {path: "string"}, handler: { args -> args.path }})
   tool_bind(r)
   tool_bind(nil)
   log(tool_ref("edit"))

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -597,6 +597,58 @@ println(response.output_tokens)
 | `llm_backoff_ms` | int | 2000 | Base exponential backoff. |
 | `stream` | bool | true | SSE streaming transport. |
 
+### Tool executors
+
+Every `tool_define` declares which backend runs the tool. The
+declaration is the source of truth — the dispatcher and ACP
+transcript both honor the `executor` field verbatim (harn#743).
+
+```harn
+// In-VM (default when handler is set; can be made explicit).
+tool_define(registry, "deploy", "Deploy", {
+  executor: "harn",
+  handler: { args -> shell("deploy " + args.env) },
+  parameters: {env: {type: "string"}},
+})
+// Host-backed: handler-less, declares which host capability backs it.
+tool_define(registry, "ask_user", "Ask the user", {
+  executor: "host_bridge",
+  host_capability: "interaction.ask",
+  parameters: {prompt: {type: "string"}},
+})
+// MCP-backed: handler-less, names the configured server.
+tool_define(registry, "list_issues", "Linear issues", {
+  executor: "mcp_server",
+  mcp_server: "linear",
+  parameters: {limit: {type: "integer"}},
+})
+// Provider-native (e.g. OpenAI Responses-API server tools).
+tool_define(registry, "web_search", "Web search", {
+  executor: "provider_native",
+  parameters: {q: {type: "string"}},
+})
+```
+
+Rules `tool_define` enforces immediately (errors thrown at definition
+time, not the first model call):
+
+- A tool with no `handler` must declare an `executor`. Handler-less
+  tools no longer fall through to the host bridge implicitly.
+- `executor: "harn"` requires `handler`; forbids `host_capability` /
+  `mcp_server`.
+- `executor: "host_bridge"` forbids `handler`; requires
+  `host_capability: "capability.operation"`.
+- `executor: "mcp_server"` forbids `handler`; requires `mcp_server`
+  (server name).
+- `executor: "provider_native"` forbids `handler`, `host_capability`,
+  `mcp_server`.
+
+`agent_loop` re-checks the registry on entry and refuses to start if
+any tool is missing an executable backend. `harn check` flags
+literal `host_capability` values that aren't in the host capability
+manifest (`[check].host_capabilities`,
+`[check].host_capabilities_path`, `--host-capabilities`).
+
 ### Tool loading & search
 
 Mark tools that the model rarely needs with `defer_loading: true` and

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -227,6 +227,70 @@ instead of string-sniffing the message.
 - Call sites that prefer explicit branching over `try` blocks:
   `llm_call_structured_safe` (the non-throwing envelope).
 
+## Tool executors
+
+Every tool registered through `tool_define` declares which backend
+executes it. The dispatcher and ACP transcript both honor that
+declaration verbatim, so `tool_call_update.executor` always reflects
+the source of truth instead of an inferred value (harn#743).
+
+| `executor` | Required field | Forbidden field | Backing |
+|---|---|---|---|
+| `"harn"` (default when `handler` is set) | `handler` closure | — | The closure runs in-VM. |
+| `"host_bridge"` | `host_capability: "capability.operation"` | `handler` | The host process answers via `HostBridge.builtin_call`. |
+| `"mcp_server"` | `mcp_server: "<configured server name>"` | `handler` | Routed to the named MCP client. |
+| `"provider_native"` | — | `handler` | The provider returns the result inline (e.g. OpenAI Responses-API server tools). |
+
+```harn
+var registry = tool_registry()
+// In-VM tool: handler closure runs locally.
+registry = tool_define(registry, "deploy", "Deploy to production", {
+  executor: "harn",
+  parameters: {env: {type: "string"}},
+  handler: { args -> shell("deploy " + args.env) },
+})
+// Host-backed tool: `harn check` validates `interaction.ask` against
+// the discovered host capability manifest before the first run.
+registry = tool_define(registry, "ask_user", "Ask the user", {
+  executor: "host_bridge",
+  host_capability: "interaction.ask",
+  parameters: {prompt: {type: "string"}},
+})
+// MCP-discovered tool registered explicitly.
+registry = tool_define(registry, "list_issues", "List Linear issues", {
+  executor: "mcp_server",
+  mcp_server: "linear",
+  parameters: {limit: {type: "integer"}},
+})
+```
+
+Validation rules `tool_define` enforces immediately:
+
+- A tool with no `handler` must declare an `executor`. Handler-less
+  declarations no longer fall through to the host bridge implicitly —
+  authors must opt in explicitly.
+- `executor: "harn"` requires a `handler` and forbids
+  `host_capability` / `mcp_server`.
+- `executor: "host_bridge"` forbids `handler` and requires a
+  `"capability.operation"`-shaped `host_capability` literal.
+- `executor: "mcp_server"` forbids `handler` and requires a non-empty
+  `mcp_server` name.
+- `executor: "provider_native"` forbids `handler`, `host_capability`,
+  and `mcp_server`.
+
+`agent_loop` re-checks the registry on entry: if any tool reaches the
+agent without an executable backend (e.g. a registry assembled by
+hand or merged across packages), the call fails fast with a clear
+diagnostic instead of an opaque `[builtin_call] unhandled` later.
+
+`harn check` walks every literal `tool_define(..., {executor:
+"host_bridge", host_capability: "..."})` call and flags capabilities
+that are not in the discovered host manifest. Add unfamiliar
+capabilities to `[check].host_capabilities`,
+`[check].host_capabilities_path`, `--host-capabilities`, or suppress
+with `[check].preflight_allow` for capabilities the host adds at
+runtime.
+
 ## Tool Vault
 
 Harn's Tool Vault is the progressive-tool-disclosure primitive: tool


### PR DESCRIPTION
## Summary

- Makes `executor` a source-of-truth field on every `tool_define`. Authors pick one of `harn`, `host_bridge`, `mcp_server`, `provider_native`, with required pairing fields (`handler`, `host_capability`, `mcp_server`). Definitions with no handler **and** no executor are rejected at definition time instead of falling through to the host bridge.
- `agent_loop` (and the bridge-attached + sub-agent variants) re-check the registry on entry and refuse to start when any tool has no executable backend — replaces the opaque `[builtin_call] unhandled` runtime error with a clear diagnostic before the first model call.
- The dispatcher and ACP transcript both honor the declared `executor` verbatim, so `tool_call_update.executor` reflects the source of truth instead of an inferred value.
- `harn check` walks every literal `tool_define(..., {executor: "host_bridge", host_capability: "..."})` call and surfaces a preflight diagnostic when the named capability is not in the host capability manifest (`[check].host_capabilities`, `[check].host_capabilities_path`, `--host-capabilities`).
- Drive-by: serializes outbound-touching tests (`http::tests::*` TLS/proxy and `connectors::{github,notion,slack,linear}::tests`) against the egress suite via a new `egress_test_guard()`. Closes a long-standing flake where a parallel `egress::tests` test installing `default: "deny"` would block legitimate localhost mock-server requests.

Existing scripts that pass a `handler` keep compiling — executor defaults to `"harn"` when only a handler is present. Handler-less scripts must pick an executor explicitly. Burin can now drop the `host_bridge_tools` allowlist in `test_tool_surface_integrity.harn`.

Resolves [#743](https://github.com/burin-labs/harn/issues/743).

## Test plan

- [x] `cargo test --workspace` — 2617 passing, 0 failing (was 9 flaky failures before the egress lock fix)
- [x] `cargo test -p harn-vm` × 3 — stable across runs
- [x] `cargo run --bin harn -- test conformance` — 708 passing (699 baseline + 9 new)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `make all` — exit 0

New conformance coverage (each acceptance criterion from #743):

- `tests/integration/tool_define_executor.harn` — happy path for all four executors
- `errors/semantic/tool_define_no_executor_no_handler.harn`
- `errors/semantic/tool_define_executor_harn_missing_handler.harn`
- `errors/semantic/tool_define_executor_host_bridge_with_handler.harn`
- `errors/semantic/tool_define_executor_host_bridge_missing_capability.harn`
- `errors/semantic/tool_define_executor_host_bridge_bad_capability_format.harn`
- `errors/semantic/tool_define_executor_mcp_missing_server.harn`
- `errors/semantic/tool_define_executor_unknown.harn`
- `errors/semantic/agent_loop_handlerless_tool.harn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)