### PR TITLE
Release v0.7.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
-## Unreleased
+## v0.7.44
 
 ### Tests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.43"
+version = "0.7.44"
 dependencies = [
  "async-trait",
  "axum",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.43"
+version = "0.7.44"
 dependencies = [
  "harn-vm",
  "serde",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.43"
+version = "0.7.44"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.43"
+version = "0.7.44"
 dependencies = [
  "anyhow",
  "base64",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.43"
+version = "0.7.44"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1740,11 +1740,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.43"
+version = "0.7.44"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.43"
+version = "0.7.44"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.43"
+version = "0.7.44"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.43"
+version = "0.7.44"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.43"
+version = "0.7.44"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.43"
+version = "0.7.44"
 dependencies = [
  "async-trait",
  "axum",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "harn-vm"
-version = "0.7.43"
+version = "0.7.44"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.43"
+version = "0.7.44"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
## Summary

Release v0.7.44 — patch bump rolling up four landed PRs since v0.7.43.

### Changed (breaking)

- **Explicit tool executors and pre-flight tool-registry validation (#743 via #764).** `tool_define` now requires every registration to declare its dispatch backend via an `executor` field — `"harn"` (with a callable `handler`), `"host_bridge"` (with a `host_capability: "cap.op"` binding), `"mcp_server"` (with a `mcp_server: "<name>"` binding), or `"provider_native"`. Definitions with no handler and no executor are rejected at definition time. `agent_loop` re-validates at startup and refuses to run a registry with any handlerless tool. `harn check` validates `executor: "host_bridge"` `host_capability` bindings against the discovered capability map. `tool_call_update.executor` on the ACP wire reflects the declared backend verbatim.

### Added

- **`llm_call_structured_result` diagnostic envelope (#744 via #762).** Stable `{ok, data, raw_text, error, error_category, attempts, repaired, extracted_json, usage, model, provider}` return shape so production agent pipelines can preserve raw text, attempt counts, and validation/repair state without hand-rolling `safe_parse → json_extract → repair → schema_check` chains. Optional `repair: {enabled, ...}` block runs a single-shot LLM repair pass on JSON-shaped failures only.
- **Predicate-count explosion limits for Flow slice union (#733 via #763).** `PredicateCeiling` (default 256 soft / 1024 hard, `flow-platform` role) and `enforce_predicate_ceiling()` in `crates/harn-vm/src/flow/predicates/compose.rs`. Returns a structured `PredicateCeilingViolation` with top contributing directories. Folds into the canonical `InvariantResult` pipeline (`Block` with stable code `predicate_count_explosion`, or `RequireApproval`).

### Tests

- **CLI regression for the `harn lint <dir>` / `harn check --workspace` Linux hang (#748).** Builds a 24-file pipeline tree across four sibling directories with relative cross-directory imports — the exact pattern that triggered the OOM-kill on Linux — and asserts both commands complete inside a 60 s budget through the CLI binary.

## Test plan

- [x] `cargo clippy --workspace --tests --all-features -- -D warnings` clean on main pre-bump
- [x] `cargo nextest run --workspace` 2667/2667 pass on main pre-bump
- [x] `cargo run --bin harn -- test conformance` 720/720 pass on main pre-bump
- [x] `make fmt-harn` clean
- [x] `release_ship.sh --prepare --bump patch` produced consistent CHANGELOG/Cargo.toml/Cargo.lock state
- [ ] Merge-queue CI gate
- [ ] Publish release workflow auto-fires on tag drift