### PR TITLE
Add cross-slice predicate budget scheduler (#736)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## v0.7.45
+
+### Added
+
+- **Cross-slice predicate budget scheduler (#736).** `PredicateExecutor`
+  now schedules predicate work fairly across multiple candidate slices
+  via a new `execute_slices(slices)` entrypoint and the
+  `PredicateSchedulerConfig` knobs. Global semaphores cap concurrent
+  deterministic and semantic predicate evaluations across all slices;
+  per-slice caps (default semantic-per-slice = 1) keep one slice from
+  monopolizing scarce semantic lanes. Each slice independently tracks
+  aggregate per-kind wall-clock against `slice_deterministic_envelope`
+  and `slice_semantic_envelope`. When a slice's envelope exhausts,
+  every remaining predicate of that kind for that slice short-circuits
+  to a structured `Block { error: { code: "budget_exceeded" } }` —
+  never a panic, never an implicit approval — while other queued
+  slices continue unaffected. Output ordering remains deterministic:
+  records sort by predicate hash within each slice, and reports stay
+  in input slice order. Closes #736 and lands the implementation
+  follow-up to the design in `docs/src/flow-predicates.md`.
+
 ## v0.7.44
 
 ### Tests

--- a/crates/harn-vm/src/flow/mod.rs
+++ b/crates/harn-vm/src/flow/mod.rs
@@ -40,9 +40,9 @@ pub use predicates::{
     InvariantBlockError, InvariantResult, ParsedInvariantFile, PredicateCeiling,
     PredicateCeilingLevel, PredicateCeilingOutcome, PredicateCeilingViolation, PredicateContext,
     PredicateEvaluation, PredicateExecutionRecord, PredicateExecutionReport, PredicateExecutor,
-    PredicateExecutorConfig, PredicateKind, PredicateRunner, PredicateSource, Remediation,
-    ResolvedPredicate, SemanticReplayAuditMetadata, Verdict, VerdictStrictness, INVARIANTS_FILE,
-    PREDICATE_COUNT_EXPLOSION_CODE,
+    PredicateExecutorConfig, PredicateKind, PredicateRunner, PredicateSchedulerConfig,
+    PredicateSource, Remediation, ResolvedPredicate, SemanticReplayAuditMetadata, Verdict,
+    VerdictStrictness, INVARIANTS_FILE, PREDICATE_COUNT_EXPLOSION_CODE,
 };
 pub use slice::{
     derive_slice, Approval, CoverageMap, PredicateHash, Slice, SliceDerivationError,

--- a/crates/harn-vm/src/flow/predicates/executor.rs
+++ b/crates/harn-vm/src/flow/predicates/executor.rs
@@ -4,7 +4,7 @@
 //! this module owns scheduling, per-kind budgets, semantic cheap-judge limits,
 //! and deterministic replay drift detection.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -15,6 +15,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use tokio::sync::Semaphore;
 
 use super::compose::verdict_strictness;
 use crate::flow::{InvariantBlockError, InvariantResult, PredicateHash, Slice};
@@ -22,6 +23,12 @@ use crate::flow::{InvariantBlockError, InvariantResult, PredicateHash, Slice};
 const DEFAULT_DETERMINISTIC_BUDGET: Duration = Duration::from_millis(50);
 const DEFAULT_SEMANTIC_BUDGET: Duration = Duration::from_secs(2);
 const DEFAULT_SEMANTIC_TOKEN_CAP: u64 = 1024;
+const DEFAULT_MAX_DETERMINISTIC_LANES: usize = 16;
+const DEFAULT_MAX_SEMANTIC_LANES: usize = 2;
+const DEFAULT_MAX_DETERMINISTIC_LANES_PER_SLICE: usize = usize::MAX;
+const DEFAULT_MAX_SEMANTIC_LANES_PER_SLICE: usize = 1;
+const DEFAULT_SLICE_DETERMINISTIC_ENVELOPE: Duration = Duration::from_secs(5);
+const DEFAULT_SLICE_SEMANTIC_ENVELOPE: Duration = Duration::from_secs(20);
 
 /// Predicate execution mode declared by predicate author annotations.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -282,14 +289,74 @@ impl PredicateContext {
     }
 }
 
+/// Cross-slice scheduling configuration.
+///
+/// The fairness scheduler enforces three orthogonal limits on top of the
+/// existing per-predicate hard timeouts:
+///
+/// 1. **Global lane caps** (`max_deterministic_lanes`, `max_semantic_lanes`)
+///    bound how many predicates of each kind may run concurrently across all
+///    queued slices. Deterministic and semantic lanes are independent so
+///    deterministic work continues to make progress while semantic predicates
+///    wait for cheap-judge slots.
+/// 2. **Per-slice lane caps**
+///    (`max_deterministic_lanes_per_slice`, `max_semantic_lanes_per_slice`)
+///    keep one slice from monopolizing all global lanes. With the default
+///    semantic-per-slice cap of 1, two slices each holding a permit alternate
+///    fairly through the global semantic semaphore (FIFO under tokio).
+/// 3. **Aggregate per-slice envelopes**
+///    (`slice_deterministic_envelope`, `slice_semantic_envelope`) bound the
+///    total wall-clock spent on each kind within one slice. Once exhausted,
+///    every remaining predicate of that kind for that slice short-circuits to
+///    a structured `budget_exceeded` block — never a panic and never an
+///    implicit approval.
+#[derive(Clone, Debug)]
+pub struct PredicateSchedulerConfig {
+    /// Global cap on concurrent deterministic predicate evaluations across
+    /// all slices.
+    pub max_deterministic_lanes: usize,
+    /// Global cap on concurrent semantic predicate evaluations across all
+    /// slices.
+    pub max_semantic_lanes: usize,
+    /// Per-slice cap on concurrent deterministic predicate evaluations.
+    pub max_deterministic_lanes_per_slice: usize,
+    /// Per-slice cap on concurrent semantic predicate evaluations. Keep this
+    /// strictly less than `max_semantic_lanes` to enforce fairness when more
+    /// than one slice is queued.
+    pub max_semantic_lanes_per_slice: usize,
+    /// Aggregate wall-clock envelope summed across all deterministic predicate
+    /// attempts for one slice. Both the first attempt and the replay attempt
+    /// of a deterministic predicate count against this envelope. Setting this
+    /// to `Duration::ZERO` disables aggregate enforcement and falls back to
+    /// the per-predicate hard timeout alone.
+    pub slice_deterministic_envelope: Duration,
+    /// Aggregate wall-clock envelope summed across all semantic predicate
+    /// attempts for one slice. `Duration::ZERO` disables aggregate
+    /// enforcement.
+    pub slice_semantic_envelope: Duration,
+}
+
+impl Default for PredicateSchedulerConfig {
+    fn default() -> Self {
+        Self {
+            max_deterministic_lanes: DEFAULT_MAX_DETERMINISTIC_LANES,
+            max_semantic_lanes: DEFAULT_MAX_SEMANTIC_LANES,
+            max_deterministic_lanes_per_slice: DEFAULT_MAX_DETERMINISTIC_LANES_PER_SLICE,
+            max_semantic_lanes_per_slice: DEFAULT_MAX_SEMANTIC_LANES_PER_SLICE,
+            slice_deterministic_envelope: DEFAULT_SLICE_DETERMINISTIC_ENVELOPE,
+            slice_semantic_envelope: DEFAULT_SLICE_SEMANTIC_ENVELOPE,
+        }
+    }
+}
+
 /// Executor configuration.
 #[derive(Clone, Debug)]
 pub struct PredicateExecutorConfig {
     pub deterministic_budget: Duration,
     pub semantic_budget: Duration,
     pub semantic_token_cap: u64,
-    /// Maximum number of predicates polled concurrently for one slice.
-    pub max_parallel_predicates: usize,
+    /// Cross-slice fairness and aggregate-envelope scheduling knobs.
+    pub scheduler: PredicateSchedulerConfig,
 }
 
 impl Default for PredicateExecutorConfig {
@@ -298,7 +365,7 @@ impl Default for PredicateExecutorConfig {
             deterministic_budget: DEFAULT_DETERMINISTIC_BUDGET,
             semantic_budget: DEFAULT_SEMANTIC_BUDGET,
             semantic_token_cap: DEFAULT_SEMANTIC_TOKEN_CAP,
-            max_parallel_predicates: usize::MAX,
+            scheduler: PredicateSchedulerConfig::default(),
         }
     }
 }
@@ -328,24 +395,99 @@ impl PredicateExecutor {
         }
     }
 
+    /// Evaluate predicates for a single slice using the scheduler defaults.
+    ///
+    /// This is shorthand for [`execute_slices`](Self::execute_slices) with a
+    /// single-element queue. Even one slice still flows through the cross-slice
+    /// scheduler so the aggregate per-slice envelope and lane caps apply.
     pub async fn execute_slice(
         &self,
         slice: &Slice,
         predicates: &[Rc<dyn PredicateRunner>],
     ) -> PredicateExecutionReport {
-        let parallelism = self
-            .config
-            .max_parallel_predicates
-            .max(1)
-            .min(predicates.len().max(1));
-        let slice = Rc::new(slice.clone());
-        let records = futures::stream::iter(predicates.iter())
-            .map(|runner| self.execute_one(slice.clone(), runner.as_ref()))
-            .buffer_unordered(parallelism)
+        let mut reports = self
+            .execute_slices(vec![(slice.clone(), predicates.to_vec())])
+            .await;
+        reports.pop().unwrap_or(PredicateExecutionReport {
+            records: Vec::new(),
+        })
+    }
+
+    /// Evaluate predicates for several candidate slices fairly.
+    ///
+    /// All slices share the global deterministic and semantic lane semaphores
+    /// configured in [`PredicateSchedulerConfig`]. Each slice additionally
+    /// owns its own per-slice lane semaphores (so one slice cannot occupy all
+    /// global semantic lanes), and each slice independently tracks aggregate
+    /// wall-clock against the per-kind envelopes. Once a slice exhausts an
+    /// envelope, all remaining predicates of that kind for that slice
+    /// short-circuit to a `budget_exceeded` `Block`.
+    ///
+    /// Output preserves input slice order. Within each slice, records are
+    /// sorted by predicate hash so reports are deterministic regardless of
+    /// the order predicates finished.
+    pub async fn execute_slices(
+        &self,
+        slices: Vec<(Slice, Vec<Rc<dyn PredicateRunner>>)>,
+    ) -> Vec<PredicateExecutionReport> {
+        let scheduler = &self.config.scheduler;
+        let det_global = Arc::new(Semaphore::new(clamp_permits(
+            scheduler.max_deterministic_lanes,
+        )));
+        let sem_global = Arc::new(Semaphore::new(clamp_permits(scheduler.max_semantic_lanes)));
+
+        let slice_futures = slices
+            .into_iter()
+            .map(|(slice, predicates)| {
+                let det_global = det_global.clone();
+                let sem_global = sem_global.clone();
+                async move {
+                    self.execute_slice_inner(slice, predicates, det_global, sem_global)
+                        .await
+                }
+            })
+            .collect::<Vec<_>>();
+
+        futures::future::join_all(slice_futures).await
+    }
+
+    async fn execute_slice_inner(
+        &self,
+        slice: Slice,
+        predicates: Vec<Rc<dyn PredicateRunner>>,
+        det_global: Arc<Semaphore>,
+        sem_global: Arc<Semaphore>,
+    ) -> PredicateExecutionReport {
+        let scheduler = &self.config.scheduler;
+        let slice_rc = Rc::new(slice);
+        let lanes = SliceLanes::new(
+            det_global,
+            sem_global,
+            scheduler.max_deterministic_lanes_per_slice,
+            scheduler.max_semantic_lanes_per_slice,
+        );
+        let envelope = SliceEnvelope::new(
+            scheduler.slice_deterministic_envelope,
+            scheduler.slice_semantic_envelope,
+        );
+
+        // The lane semaphores enforce real concurrency. `buffer_unordered`
+        // just decides how many futures we polled-but-not-yet-completed at
+        // once; cap it at the actual predicate count so we don't allocate
+        // internal slots for predicates that don't exist.
+        let buffer = predicates.len().max(1);
+
+        let mut records = futures::stream::iter(predicates)
+            .map(|runner| {
+                let slice = slice_rc.clone();
+                let lanes = lanes.clone();
+                let envelope = envelope.clone();
+                async move { self.execute_one(slice, runner, lanes, envelope).await }
+            })
+            .buffer_unordered(buffer)
             .collect::<Vec<_>>()
             .await;
 
-        let mut records = records;
         self.apply_semantic_fallbacks(&mut records);
         records.sort_by(|left, right| left.predicate_hash.cmp(&right.predicate_hash));
         PredicateExecutionReport { records }
@@ -354,12 +496,16 @@ impl PredicateExecutor {
     async fn execute_one(
         &self,
         slice: Rc<Slice>,
-        runner: &dyn PredicateRunner,
+        runner: Rc<dyn PredicateRunner>,
+        lanes: SliceLanes,
+        envelope: SliceEnvelope,
     ) -> PredicateExecutionRecord {
         let started = Instant::now();
         let predicate_hash = runner.hash();
         let kind = runner.kind();
-        let first = self.run_attempt(slice.clone(), runner).await;
+        let first = self
+            .run_attempt(slice.clone(), runner.as_ref(), &lanes, &envelope)
+            .await;
         let first_hash = hash_result(&first.result);
         let mut result = first.result;
         let mut attempts = 1;
@@ -367,7 +513,9 @@ impl PredicateExecutor {
         let semantic_replay_audit = first.semantic_audit;
 
         if kind == PredicateKind::Deterministic && !result.is_blocking() {
-            let second = self.run_attempt(slice, runner).await;
+            let second = self
+                .run_attempt(slice, runner.as_ref(), &lanes, &envelope)
+                .await;
             attempts = 2;
             let replay_hash = hash_result(&second.result);
             second_hash = replay_hash.clone();
@@ -411,12 +559,31 @@ impl PredicateExecutor {
         &self,
         slice: Rc<Slice>,
         runner: &dyn PredicateRunner,
+        lanes: &SliceLanes,
+        envelope: &SliceEnvelope,
     ) -> PredicateAttempt {
         let kind = runner.kind();
         let timeout = match kind {
             PredicateKind::Deterministic => self.config.deterministic_budget,
             PredicateKind::Semantic => self.config.semantic_budget,
         };
+
+        if let Some(attempt) =
+            envelope_exhausted_attempt(envelope, kind, "before this predicate started")
+        {
+            return attempt;
+        }
+
+        let _permits = lanes.acquire(kind).await;
+
+        // Re-check after acquiring the lane: the queue may have been long
+        // enough that the slice's envelope drained while we waited.
+        if let Some(attempt) =
+            envelope_exhausted_attempt(envelope, kind, "while waiting for a lane")
+        {
+            return attempt;
+        }
+
         let context = PredicateContext::new(
             slice,
             kind,
@@ -425,7 +592,8 @@ impl PredicateExecutor {
             self.config.semantic_token_cap,
             Arc::new(AtomicBool::new(false)),
         );
-        match tokio::time::timeout(timeout, runner.evaluate(context.clone())).await {
+        let started = Instant::now();
+        let attempt = match tokio::time::timeout(timeout, runner.evaluate(context.clone())).await {
             Ok(result) => PredicateAttempt {
                 result: context
                     .block_error()
@@ -443,7 +611,9 @@ impl PredicateExecutor {
                     semantic_audit: context.semantic_audit(),
                 }
             }
-        }
+        };
+        envelope.charge(kind, started.elapsed());
+        attempt
     }
 
     fn apply_semantic_fallbacks(&self, records: &mut [PredicateExecutionRecord]) {
@@ -554,9 +724,137 @@ fn estimate_tokens(value: &str) -> u64 {
     value.split_whitespace().count().max(1) as u64
 }
 
+fn clamp_permits(value: usize) -> usize {
+    value.clamp(1, Semaphore::MAX_PERMITS)
+}
+
+/// Short-circuit return for predicates whose slice envelope is already
+/// exhausted. Returns `None` when the envelope still has headroom (or is
+/// disabled by a zero budget).
+fn envelope_exhausted_attempt(
+    envelope: &SliceEnvelope,
+    kind: PredicateKind,
+    when: &str,
+) -> Option<PredicateAttempt> {
+    let remaining = envelope.remaining(kind)?;
+    if !remaining.is_zero() {
+        return None;
+    }
+    Some(PredicateAttempt {
+        result: InvariantResult::block(InvariantBlockError::budget_exceeded(format!(
+            "slice {kind:?} envelope exhausted {when}"
+        ))),
+        semantic_audit: None,
+    })
+}
+
 struct PredicateAttempt {
     result: InvariantResult,
     semantic_audit: Option<SemanticReplayAuditMetadata>,
+}
+
+/// Per-slice lane semaphores. Pairs a global (cross-slice) semaphore with a
+/// per-slice semaphore so a single slice cannot occupy every global lane.
+#[derive(Clone)]
+struct SliceLanes {
+    deterministic_global: Arc<Semaphore>,
+    deterministic_local: Arc<Semaphore>,
+    semantic_global: Arc<Semaphore>,
+    semantic_local: Arc<Semaphore>,
+}
+
+impl SliceLanes {
+    fn new(
+        deterministic_global: Arc<Semaphore>,
+        semantic_global: Arc<Semaphore>,
+        deterministic_per_slice: usize,
+        semantic_per_slice: usize,
+    ) -> Self {
+        Self {
+            deterministic_global,
+            deterministic_local: Arc::new(Semaphore::new(clamp_permits(deterministic_per_slice))),
+            semantic_global,
+            semantic_local: Arc::new(Semaphore::new(clamp_permits(semantic_per_slice))),
+        }
+    }
+
+    async fn acquire(&self, kind: PredicateKind) -> LaneTickets {
+        let (global, local) = match kind {
+            PredicateKind::Deterministic => (&self.deterministic_global, &self.deterministic_local),
+            PredicateKind::Semantic => (&self.semantic_global, &self.semantic_local),
+        };
+        // Take per-slice first to preserve global FIFO admission. Acquiring
+        // the global permit first would let one slice park its waiters at the
+        // head of the global queue and starve other slices' lanes.
+        let local_ticket = local
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("predicate lane semaphore closed");
+        let global_ticket = global
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("predicate lane semaphore closed");
+        LaneTickets {
+            _local: local_ticket,
+            _global: global_ticket,
+        }
+    }
+}
+
+/// RAII permit holder. Both permits release when the value drops.
+struct LaneTickets {
+    _local: tokio::sync::OwnedSemaphorePermit,
+    _global: tokio::sync::OwnedSemaphorePermit,
+}
+
+/// Aggregate per-kind wall-clock counters for one slice's predicate envelope.
+#[derive(Clone)]
+struct SliceEnvelope {
+    deterministic_used: Rc<Cell<Duration>>,
+    semantic_used: Rc<Cell<Duration>>,
+    deterministic_budget: Duration,
+    semantic_budget: Duration,
+}
+
+impl SliceEnvelope {
+    fn new(deterministic_budget: Duration, semantic_budget: Duration) -> Self {
+        Self {
+            deterministic_used: Rc::new(Cell::new(Duration::ZERO)),
+            semantic_used: Rc::new(Cell::new(Duration::ZERO)),
+            deterministic_budget,
+            semantic_budget,
+        }
+    }
+
+    fn cell(&self, kind: PredicateKind) -> &Cell<Duration> {
+        match kind {
+            PredicateKind::Deterministic => &self.deterministic_used,
+            PredicateKind::Semantic => &self.semantic_used,
+        }
+    }
+
+    fn budget(&self, kind: PredicateKind) -> Duration {
+        match kind {
+            PredicateKind::Deterministic => self.deterministic_budget,
+            PredicateKind::Semantic => self.semantic_budget,
+        }
+    }
+
+    fn remaining(&self, kind: PredicateKind) -> Option<Duration> {
+        let budget = self.budget(kind);
+        if budget.is_zero() {
+            return None;
+        }
+        let used = self.cell(kind).get();
+        Some(budget.saturating_sub(used))
+    }
+
+    fn charge(&self, kind: PredicateKind, elapsed: Duration) {
+        let cell = self.cell(kind);
+        cell.set(cell.get().saturating_add(elapsed));
+    }
 }
 
 #[cfg(test)]
@@ -689,6 +987,7 @@ mod tests {
 
     struct ParallelProbe {
         hash: &'static str,
+        kind: PredicateKind,
         active: Rc<Cell<usize>>,
         max_active: Rc<Cell<usize>>,
     }
@@ -700,7 +999,7 @@ mod tests {
         }
 
         fn kind(&self) -> PredicateKind {
-            PredicateKind::Semantic
+            self.kind
         }
 
         async fn evaluate(&self, _context: PredicateContext) -> InvariantResult {
@@ -773,11 +1072,13 @@ mod tests {
         let predicates: Vec<Rc<dyn PredicateRunner>> = vec![
             Rc::new(ParallelProbe {
                 hash: "parallel-a",
+                kind: PredicateKind::Deterministic,
                 active: active.clone(),
                 max_active: max_active.clone(),
             }),
             Rc::new(ParallelProbe {
                 hash: "parallel-b",
+                kind: PredicateKind::Deterministic,
                 active,
                 max_active: max_active.clone(),
             }),
@@ -1004,5 +1305,438 @@ mod tests {
             Some(expected_evidence_hash.as_str())
         );
         assert_eq!(audit.token_cap, DEFAULT_SEMANTIC_TOKEN_CAP);
+    }
+
+    fn slice_with_id(id: u8) -> Slice {
+        let mut value = slice();
+        value.id = SliceId([id; 32]);
+        value
+    }
+
+    /// Probe that records the wall-clock instant it became active, so a test
+    /// can compare which slice actually got a lane first.
+    struct FinishingProbe {
+        hash: &'static str,
+        kind: PredicateKind,
+        delay: Duration,
+        // Per-slice list of (predicate_hash, finish_micros_since_start).
+        finish_log: Rc<RefCell<Vec<(String, u128)>>>,
+        epoch: Instant,
+    }
+
+    #[async_trait(?Send)]
+    impl PredicateRunner for FinishingProbe {
+        fn hash(&self) -> PredicateHash {
+            PredicateHash::new(self.hash)
+        }
+
+        fn kind(&self) -> PredicateKind {
+            self.kind
+        }
+
+        async fn evaluate(&self, _context: PredicateContext) -> InvariantResult {
+            tokio::time::sleep(self.delay).await;
+            self.finish_log
+                .borrow_mut()
+                .push((self.hash.to_string(), self.epoch.elapsed().as_micros()));
+            InvariantResult::allow()
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_slices_returns_one_report_per_slice_in_input_order() {
+        let executor = PredicateExecutor::default();
+        let slice_a = slice_with_id(1);
+        let slice_b = slice_with_id(2);
+
+        let predicates_a: Vec<Rc<dyn PredicateRunner>> = vec![Rc::new(StaticPredicate {
+            hash: "alpha",
+            kind: PredicateKind::Deterministic,
+            fallback_hash: None,
+            result: InvariantResult::allow(),
+            delay: Duration::ZERO,
+        })];
+        let predicates_b: Vec<Rc<dyn PredicateRunner>> = vec![Rc::new(StaticPredicate {
+            hash: "beta",
+            kind: PredicateKind::Deterministic,
+            fallback_hash: None,
+            result: InvariantResult::allow(),
+            delay: Duration::ZERO,
+        })];
+
+        let reports = executor
+            .execute_slices(vec![(slice_a, predicates_a), (slice_b, predicates_b)])
+            .await;
+
+        assert_eq!(reports.len(), 2);
+        assert_eq!(
+            reports[0].records[0].predicate_hash,
+            PredicateHash::new("alpha")
+        );
+        assert_eq!(
+            reports[1].records[0].predicate_hash,
+            PredicateHash::new("beta")
+        );
+    }
+
+    #[tokio::test]
+    async fn semantic_lane_fairness_prevents_monopolization() {
+        // Two slices each enqueue four semantic predicates. With one global
+        // semantic lane plus a per-slice cap of one, slice B's first
+        // predicate must execute before slice A's last predicate, even
+        // though slice A submitted its predicates first.
+        let config = PredicateExecutorConfig {
+            scheduler: PredicateSchedulerConfig {
+                max_semantic_lanes: 1,
+                max_semantic_lanes_per_slice: 1,
+                slice_semantic_envelope: Duration::from_secs(60),
+                ..PredicateSchedulerConfig::default()
+            },
+            ..PredicateExecutorConfig::default()
+        };
+        let executor = PredicateExecutor::with_cheap_judge(config, Rc::new(PassingJudge));
+
+        let log_a = Rc::new(RefCell::new(Vec::new()));
+        let log_b = Rc::new(RefCell::new(Vec::new()));
+        let epoch = Instant::now();
+
+        let predicates_a: Vec<Rc<dyn PredicateRunner>> = (0..4)
+            .map(|i| -> Rc<dyn PredicateRunner> {
+                Rc::new(FinishingProbe {
+                    hash: ["a0", "a1", "a2", "a3"][i],
+                    kind: PredicateKind::Semantic,
+                    delay: Duration::from_millis(20),
+                    finish_log: log_a.clone(),
+                    epoch,
+                })
+            })
+            .collect();
+        let predicates_b: Vec<Rc<dyn PredicateRunner>> = (0..4)
+            .map(|i| -> Rc<dyn PredicateRunner> {
+                Rc::new(FinishingProbe {
+                    hash: ["b0", "b1", "b2", "b3"][i],
+                    kind: PredicateKind::Semantic,
+                    delay: Duration::from_millis(20),
+                    finish_log: log_b.clone(),
+                    epoch,
+                })
+            })
+            .collect();
+
+        let _ = executor
+            .execute_slices(vec![
+                (slice_with_id(1), predicates_a),
+                (slice_with_id(2), predicates_b),
+            ])
+            .await;
+
+        let log_a_snapshot = log_a.borrow().clone();
+        let log_b_snapshot = log_b.borrow().clone();
+        assert_eq!(log_a_snapshot.len(), 4);
+        assert_eq!(log_b_snapshot.len(), 4);
+        let earliest_b = log_b_snapshot
+            .iter()
+            .map(|(_, micros)| *micros)
+            .min()
+            .unwrap();
+        let latest_a = log_a_snapshot
+            .iter()
+            .map(|(_, micros)| *micros)
+            .max()
+            .unwrap();
+        assert!(
+            earliest_b < latest_a,
+            "fair scheduler should interleave slices: B's first finished at {earliest_b}us, A's last at {latest_a}us",
+        );
+    }
+
+    #[tokio::test]
+    async fn deterministic_progress_continues_while_semantic_work_waits() {
+        // Single global semantic lane with a slow semantic predicate that
+        // dominates the scheduler. Deterministic predicates must complete
+        // before the semantic predicate because deterministic and semantic
+        // lanes are independent.
+        let config = PredicateExecutorConfig {
+            semantic_budget: Duration::from_secs(10),
+            scheduler: PredicateSchedulerConfig {
+                max_semantic_lanes: 1,
+                max_semantic_lanes_per_slice: 1,
+                slice_semantic_envelope: Duration::from_secs(60),
+                ..PredicateSchedulerConfig::default()
+            },
+            ..PredicateExecutorConfig::default()
+        };
+        let executor = PredicateExecutor::with_cheap_judge(config, Rc::new(PassingJudge));
+
+        let log = Rc::new(RefCell::new(Vec::new()));
+        let epoch = Instant::now();
+
+        let predicates: Vec<Rc<dyn PredicateRunner>> = vec![
+            Rc::new(FinishingProbe {
+                hash: "slow-semantic",
+                kind: PredicateKind::Semantic,
+                delay: Duration::from_millis(80),
+                finish_log: log.clone(),
+                epoch,
+            }),
+            Rc::new(FinishingProbe {
+                hash: "det-1",
+                kind: PredicateKind::Deterministic,
+                delay: Duration::from_millis(5),
+                finish_log: log.clone(),
+                epoch,
+            }),
+            Rc::new(FinishingProbe {
+                hash: "det-2",
+                kind: PredicateKind::Deterministic,
+                delay: Duration::from_millis(5),
+                finish_log: log.clone(),
+                epoch,
+            }),
+        ];
+
+        let _ = executor.execute_slice(&slice(), &predicates).await;
+        let snapshot = log.borrow().clone();
+        let det_finish = snapshot
+            .iter()
+            .filter_map(|(name, micros)| name.starts_with("det-").then_some(*micros))
+            .max()
+            .expect("deterministic finished");
+        let semantic_finish = snapshot
+            .iter()
+            .find(|(name, _)| name == "slow-semantic")
+            .map(|(_, micros)| *micros)
+            .expect("semantic finished");
+
+        assert!(
+            det_finish < semantic_finish,
+            "deterministic ({det_finish}us) should finish before slow semantic ({semantic_finish}us)",
+        );
+    }
+
+    #[tokio::test]
+    async fn slice_deterministic_envelope_blocks_remaining_predicates() {
+        // Tight aggregate envelope with predicates that each consume
+        // measurable wall-clock. After the first runs, the envelope is
+        // exhausted and the rest must short-circuit to budget_exceeded.
+        let config = PredicateExecutorConfig {
+            scheduler: PredicateSchedulerConfig {
+                max_deterministic_lanes_per_slice: 1,
+                slice_deterministic_envelope: Duration::from_millis(15),
+                ..PredicateSchedulerConfig::default()
+            },
+            ..PredicateExecutorConfig::default()
+        };
+        let executor = PredicateExecutor::new(config);
+        let predicates: Vec<Rc<dyn PredicateRunner>> = vec![
+            Rc::new(StaticPredicate {
+                hash: "first",
+                kind: PredicateKind::Deterministic,
+                fallback_hash: None,
+                result: InvariantResult::allow(),
+                delay: Duration::from_millis(20),
+            }),
+            Rc::new(StaticPredicate {
+                hash: "second",
+                kind: PredicateKind::Deterministic,
+                fallback_hash: None,
+                result: InvariantResult::allow(),
+                delay: Duration::ZERO,
+            }),
+            Rc::new(StaticPredicate {
+                hash: "third",
+                kind: PredicateKind::Deterministic,
+                fallback_hash: None,
+                result: InvariantResult::allow(),
+                delay: Duration::ZERO,
+            }),
+        ];
+
+        let report = executor.execute_slice(&slice(), &predicates).await;
+
+        let by_hash: BTreeMap<_, _> = report
+            .records
+            .iter()
+            .map(|record| (record.predicate_hash.as_str().to_string(), record))
+            .collect();
+        // The first predicate runs (and may itself block on the per-predicate
+        // 50ms timeout — irrelevant for envelope semantics). The second and
+        // third must be denied admission with structured budget_exceeded
+        // blocks rather than silently allowing them through.
+        let second = by_hash.get("second").expect("second present");
+        let third = by_hash.get("third").expect("third present");
+        let second_block = second.result.block_error().expect("second blocked");
+        assert_eq!(second_block.code, "budget_exceeded");
+        let third_block = third.result.block_error().expect("third blocked");
+        assert_eq!(third_block.code, "budget_exceeded");
+    }
+
+    #[tokio::test]
+    async fn slice_semantic_envelope_blocks_remaining_predicates() {
+        let config = PredicateExecutorConfig {
+            scheduler: PredicateSchedulerConfig {
+                max_semantic_lanes: 1,
+                max_semantic_lanes_per_slice: 1,
+                slice_semantic_envelope: Duration::from_millis(15),
+                ..PredicateSchedulerConfig::default()
+            },
+            ..PredicateExecutorConfig::default()
+        };
+        let executor = PredicateExecutor::with_cheap_judge(config, Rc::new(PassingJudge));
+
+        let predicates: Vec<Rc<dyn PredicateRunner>> = vec![
+            Rc::new(StaticPredicate {
+                hash: "sem-first",
+                kind: PredicateKind::Semantic,
+                fallback_hash: Some("sem-fallback"),
+                result: InvariantResult::allow(),
+                delay: Duration::from_millis(30),
+            }),
+            Rc::new(StaticPredicate {
+                hash: "sem-second",
+                kind: PredicateKind::Semantic,
+                fallback_hash: Some("sem-fallback"),
+                result: InvariantResult::allow(),
+                delay: Duration::ZERO,
+            }),
+            Rc::new(StaticPredicate {
+                hash: "sem-fallback",
+                kind: PredicateKind::Deterministic,
+                fallback_hash: None,
+                result: InvariantResult::allow(),
+                delay: Duration::ZERO,
+            }),
+        ];
+
+        let report = executor.execute_slice(&slice(), &predicates).await;
+        let second = report
+            .records
+            .iter()
+            .find(|record| record.predicate_hash == PredicateHash::new("sem-second"))
+            .expect("sem-second present");
+        let block = second.result.block_error().expect("blocked");
+        assert_eq!(block.code, "budget_exceeded");
+    }
+
+    #[tokio::test]
+    async fn slice_envelopes_are_independent_across_slices() {
+        // Slice A blows its semantic envelope. Slice B's semantic predicate
+        // must still run normally; envelopes are per-slice, not global.
+        let config = PredicateExecutorConfig {
+            scheduler: PredicateSchedulerConfig {
+                max_semantic_lanes: 2,
+                max_semantic_lanes_per_slice: 1,
+                slice_semantic_envelope: Duration::from_millis(15),
+                ..PredicateSchedulerConfig::default()
+            },
+            ..PredicateExecutorConfig::default()
+        };
+        let executor = PredicateExecutor::with_cheap_judge(config, Rc::new(PassingJudge));
+
+        let slice_a_preds: Vec<Rc<dyn PredicateRunner>> = vec![
+            Rc::new(StaticPredicate {
+                hash: "a-slow",
+                kind: PredicateKind::Semantic,
+                fallback_hash: Some("a-fallback"),
+                result: InvariantResult::allow(),
+                delay: Duration::from_millis(30),
+            }),
+            Rc::new(StaticPredicate {
+                hash: "a-second",
+                kind: PredicateKind::Semantic,
+                fallback_hash: Some("a-fallback"),
+                result: InvariantResult::allow(),
+                delay: Duration::ZERO,
+            }),
+            Rc::new(StaticPredicate {
+                hash: "a-fallback",
+                kind: PredicateKind::Deterministic,
+                fallback_hash: None,
+                result: InvariantResult::allow(),
+                delay: Duration::ZERO,
+            }),
+        ];
+        let slice_b_preds: Vec<Rc<dyn PredicateRunner>> = vec![
+            Rc::new(StaticPredicate {
+                hash: "b-fast",
+                kind: PredicateKind::Semantic,
+                fallback_hash: Some("b-fallback"),
+                result: InvariantResult::allow(),
+                delay: Duration::from_millis(2),
+            }),
+            Rc::new(StaticPredicate {
+                hash: "b-fallback",
+                kind: PredicateKind::Deterministic,
+                fallback_hash: None,
+                result: InvariantResult::allow(),
+                delay: Duration::ZERO,
+            }),
+        ];
+
+        let reports = executor
+            .execute_slices(vec![
+                (slice_with_id(1), slice_a_preds),
+                (slice_with_id(2), slice_b_preds),
+            ])
+            .await;
+
+        let slice_b = &reports[1];
+        let b_fast = slice_b
+            .records
+            .iter()
+            .find(|record| record.predicate_hash == PredicateHash::new("b-fast"))
+            .unwrap();
+        // b-fast must not be blocked by budget_exceeded — slice A's envelope
+        // exhaustion must not cross the slice boundary.
+        assert!(b_fast.result.block_error().is_none());
+    }
+
+    #[tokio::test]
+    async fn output_ordering_is_deterministic_across_random_finish_order() {
+        // Predicates with varying delays finish in non-deterministic order.
+        // The report must still sort by predicate hash so two replays of the
+        // same scheduler produce bit-identical record orderings.
+        let make_predicates = || -> Vec<Rc<dyn PredicateRunner>> {
+            vec![
+                Rc::new(StaticPredicate {
+                    hash: "z-last",
+                    kind: PredicateKind::Deterministic,
+                    fallback_hash: None,
+                    result: InvariantResult::allow(),
+                    delay: Duration::from_millis(15),
+                }),
+                Rc::new(StaticPredicate {
+                    hash: "a-first",
+                    kind: PredicateKind::Deterministic,
+                    fallback_hash: None,
+                    result: InvariantResult::allow(),
+                    delay: Duration::ZERO,
+                }),
+                Rc::new(StaticPredicate {
+                    hash: "m-mid",
+                    kind: PredicateKind::Deterministic,
+                    fallback_hash: None,
+                    result: InvariantResult::allow(),
+                    delay: Duration::from_millis(7),
+                }),
+            ]
+        };
+
+        let executor = PredicateExecutor::default();
+        let report_one = executor.execute_slice(&slice(), &make_predicates()).await;
+        let report_two = executor.execute_slice(&slice(), &make_predicates()).await;
+        let order_one: Vec<_> = report_one
+            .records
+            .iter()
+            .map(|record| record.predicate_hash.as_str().to_string())
+            .collect();
+        let order_two: Vec<_> = report_two
+            .records
+            .iter()
+            .map(|record| record.predicate_hash.as_str().to_string())
+            .collect();
+
+        assert_eq!(order_one, vec!["a-first", "m-mid", "z-last"]);
+        assert_eq!(order_one, order_two);
     }
 }

--- a/crates/harn-vm/src/flow/predicates/mod.rs
+++ b/crates/harn-vm/src/flow/predicates/mod.rs
@@ -20,7 +20,7 @@ pub use discovery::{
 pub use executor::{
     CheapJudge, CheapJudgeRequest, CheapJudgeResponse, PredicateContext, PredicateExecutionRecord,
     PredicateExecutionReport, PredicateExecutor, PredicateExecutorConfig, PredicateKind,
-    PredicateRunner, SemanticReplayAuditMetadata,
+    PredicateRunner, PredicateSchedulerConfig, SemanticReplayAuditMetadata,
 };
 pub use result::{
     Approver, ByteSpan, EvidenceItem, InvariantBlockError, InvariantResult, Remediation, Verdict,

--- a/docs/src/flow-predicates.md
+++ b/docs/src/flow-predicates.md
@@ -21,6 +21,7 @@ The design in this document assumes the following ticket state as of
 | Area | Status |
 |---|---|
 | Predicate executor and hard kind budgets | Landed in #578 / #704. |
+| Cross-slice fairness scheduler and aggregate budget envelopes | Landed in #736. |
 | `invariants.harn` discovery and attributes | Landed in #579. |
 | `InvariantResult`, evidence, and remediation types | Landed in #581. |
 | Hierarchical predicate composition | In review in #731, closing #582. |
@@ -112,6 +113,33 @@ by sorting records after execution, as the current executor already does.
 This keeps the mental model dumb: predicates are still ordinary Harn functions,
 but admission control is owned by the Flow scheduler instead of by each
 predicate.
+
+### Implementation
+
+The scheduler lives on
+[`PredicateExecutor`](https://docs.rs/harn-vm/latest/harn_vm/flow/struct.PredicateExecutor.html)
+and is configured via `PredicateSchedulerConfig`:
+
+- `max_deterministic_lanes` / `max_semantic_lanes` — global concurrency caps
+  shared across every queued slice. Deterministic and semantic lanes are
+  independent semaphores, which is what makes deterministic work continue to
+  make progress while semantic work is queued behind a scarce cheap-judge
+  budget.
+- `max_deterministic_lanes_per_slice` / `max_semantic_lanes_per_slice` —
+  per-slice caps that prevent any single slice from occupying every global
+  lane. The default semantic-per-slice cap of 1 plus FIFO permit ordering is
+  enough to interleave queued slices fairly under the typical 2-lane semantic
+  budget.
+- `slice_deterministic_envelope` / `slice_semantic_envelope` — aggregate
+  per-kind wall-clock envelopes for one slice. Once exhausted, every
+  remaining predicate of that kind for that slice short-circuits to a
+  structured `Block { error: { code: "budget_exceeded" } }` instead of
+  silently allowing it through.
+
+Use `PredicateExecutor::execute_slices(slices)` when more than one candidate
+slice is queued together. The single-slice convenience method
+`execute_slice(slice, predicates)` still works and routes through the same
+scheduler so per-slice envelopes apply uniformly.
 
 ## Decision 2: Bootstrap Signing
 
@@ -290,8 +318,10 @@ landed and in-review predicate tickets:
   `meta-invariants.harn` bootstrap validation and approval-chain checks.
 - [#735](https://github.com/burin-labs/harn/issues/735): deterministic
   fallback metadata and enforcement for `@semantic` predicates.
-- [#736](https://github.com/burin-labs/harn/issues/736): add cross-slice fair
-  scheduling and aggregate per-slice predicate budget envelopes.
+- ~~[#736](https://github.com/burin-labs/harn/issues/736): add cross-slice
+  fair scheduling and aggregate per-slice predicate budget envelopes.~~
+  Closed by `PredicateSchedulerConfig` and `execute_slices(slices)` documented
+  above.
 - ~~[#733](https://github.com/burin-labs/harn/issues/733): add
   cross-directory union benchmarks and predicate-count explosion limits before
   Ship Captain relies on unattended slice emission.~~ Closed by the


### PR DESCRIPTION
## Summary

- Adds a cross-slice fairness scheduler and aggregate per-slice predicate budget envelopes on `PredicateExecutor`, closing #736.
- Multiple candidate slices may now flow through `execute_slices(slices)`. Global semaphores cap concurrent deterministic and semantic predicate evaluations; per-slice caps (default semantic-per-slice = 1) keep one slice from monopolizing scarce semantic lanes; each slice independently tracks aggregate per-kind wall-clock against `slice_deterministic_envelope` / `slice_semantic_envelope`. When a slice exhausts an envelope, every remaining predicate of that kind for that slice short-circuits to a structured `Block { error: { code: "budget_exceeded" } }` — never a panic, never an implicit approval. Output remains deterministic: records sort by predicate hash within each slice and reports stay in input slice order.
- Existing per-predicate hard timeouts (50ms deterministic, 2s semantic with cheap-judge token cap) are unchanged; the scheduler layers on top of them.

## Implementation notes

- New `PredicateSchedulerConfig` exposes `max_*_lanes`, `max_*_lanes_per_slice`, and `slice_*_envelope` knobs. Defaults: 16 deterministic / 2 semantic global lanes, semantic-per-slice = 1 for fairness, 5s / 20s envelopes.
- Lane permits are taken local-then-global so a slice with many predicates parks waiters on its own per-slice semaphore instead of crowding the global queue.
- `execute_slice(slice, predicates)` is preserved as shorthand for the single-slice case and routes through the same scheduler so per-slice envelopes apply uniformly.
- Spec updated in [docs/src/flow-predicates.md](docs/src/flow-predicates.md) under Decision 1; CHANGELOG entry under v0.7.45.

## Test plan

- [x] Seven new unit tests in `crates/harn-vm/src/flow/predicates/executor.rs`:
  - `execute_slices_returns_one_report_per_slice_in_input_order`
  - `semantic_lane_fairness_prevents_monopolization` (4 predicates × 2 slices, 1 global semantic lane → B's first must finish before A's last)
  - `deterministic_progress_continues_while_semantic_work_waits` (deterministic completes before slow semantic on same slice)
  - `slice_deterministic_envelope_blocks_remaining_predicates`
  - `slice_semantic_envelope_blocks_remaining_predicates`
  - `slice_envelopes_are_independent_across_slices`
  - `output_ordering_is_deterministic_across_random_finish_order`
- [x] `cargo nextest run -p harn-vm` — 1451 tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `harn test conformance` — 720 / 720 pass.
- [x] `make check-docs-snippets` — 446 / 446 parse.
- [x] `make lint-md` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)