### PR TITLE
Add meta-invariants.harn bootstrap policy validation (#734)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,28 @@ granular archaeology.
   records sort by predicate hash within each slice, and reports stay
   in input slice order. Closes #736 and lands the implementation
   follow-up to the design in `docs/src/flow-predicates.md`.
+- **`meta-invariants.harn` bootstrap policy validation (#734).** Closes
+  decision 2 of the predicate-language design record. A repo-root
+  `meta-invariants.harn` file (separate from per-directory
+  `invariants.harn`) carries a hand-authored bootstrap policy: its
+  `sha256:` content hash and a maintainer list pulled from a
+  `@bootstrap_maintainers(approvers: [...])` attribute (defaulting to
+  `role:flow-platform` when absent). Two new library entrypoints in
+  `crates/harn-vm/src/flow/predicates/bootstrap.rs` enforce the policy:
+  `validate_predicate_edit` promotes the parser's soft warnings on
+  proposed `invariants.harn` edits into hard `Block` verdicts with stable
+  codes (`bootstrap_missing_archivist`,
+  `bootstrap_archivist_provenance_incomplete`,
+  `bootstrap_kind_collision`, `bootstrap_missing_semantic_fallback`),
+  and `validate_bootstrap_edit` rejects Archivist authorship of
+  `meta-invariants.harn` outright (`bootstrap_archivist_cannot_author_bootstrap`)
+  while routing every other author to `RequireApproval` against a
+  maintainer from the previous policy. Both validators pin the previous
+  policy hash so the slice approval chain has an explicit audit pointer.
+  `harn flow ship watch` and `harn flow archivist scan` surface a new
+  `bootstrap_policy` field in their JSON payloads carrying the discovered
+  hash, maintainer list, and parser diagnostics — or `status = "absent"`
+  when the file is missing.
 
 ## v0.7.44
 

--- a/crates/harn-cli/src/commands/flow.rs
+++ b/crates/harn-cli/src/commands/flow.rs
@@ -147,6 +147,7 @@ fn run_ship_watch(args: &crate::cli::FlowShipWatchArgs) -> Result<i32, String> {
     if !args.json {
         print_discovery_warnings(&diagnostics);
     }
+    let bootstrap_payload = bootstrap_policy_payload(&args.predicate_root);
     let predicates = harn_vm::flow::resolve_predicates_for_touched_directories(&chains);
     let predicate_payload = predicates
         .iter()
@@ -219,6 +220,7 @@ fn run_ship_watch(args: &crate::cli::FlowShipWatchArgs) -> Result<i32, String> {
             "status": validation_status,
             "predicates": predicate_payload,
             "ceiling": ceiling_payload,
+            "bootstrap_policy": bootstrap_payload,
             "diagnostics": diagnostics.iter().map(|(path, diagnostic)| json!({
                 "path": path,
                 "severity": discovery_severity_label(diagnostic.severity),
@@ -280,6 +282,42 @@ fn serialize_ceiling_outcome(
     payload
 }
 
+fn bootstrap_policy_payload(predicate_root: &Path) -> serde_json::Value {
+    use harn_vm::flow::Approver;
+    let Some(discovered) = harn_vm::flow::discover_bootstrap_policy(predicate_root) else {
+        return json!({
+            "status": "absent",
+            "path": predicate_root.join(harn_vm::flow::META_INVARIANTS_FILE),
+        });
+    };
+    let maintainers = discovered
+        .policy
+        .maintainers
+        .iter()
+        .map(|approver| match approver {
+            Approver::Role { name } => json!({"kind": "role", "id": name}),
+            Approver::Principal { id } => json!({"kind": "principal", "id": id}),
+        })
+        .collect::<Vec<_>>();
+    let diagnostics = discovered
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            json!({
+                "severity": discovery_severity_label(diagnostic.severity),
+                "message": diagnostic.message,
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "status": "present",
+        "path": discovered.path,
+        "hash": discovered.policy.hash,
+        "maintainers": maintainers,
+        "diagnostics": diagnostics,
+    })
+}
+
 fn discovery_severity_label(severity: harn_vm::flow::DiscoveryDiagnosticSeverity) -> &'static str {
     match severity {
         harn_vm::flow::DiscoveryDiagnosticSeverity::Warning => "warning",
@@ -334,6 +372,7 @@ fn run_archivist_scan(args: &crate::cli::FlowArchivistScanArgs) -> Result<i32, S
     }
     let convention = mine_convention_signals(&repo);
     let motion = mine_motion_signals(&repo);
+    let bootstrap_payload = bootstrap_policy_payload(&repo);
     let proposals = archivist_proposals(
         &repo,
         &inventory,
@@ -363,6 +402,7 @@ fn run_archivist_scan(args: &crate::cli::FlowArchivistScanArgs) -> Result<i32, S
         },
         "existing_predicates": predicates,
         "discovery_diagnostics": discovery_diagnostics,
+        "bootstrap_policy": bootstrap_payload,
         "proposals": proposals,
         "shadow_evaluation": shadow_evaluation,
     });

--- a/crates/harn-cli/tests/flow_ship_cli.rs
+++ b/crates/harn-cli/tests/flow_ship_cli.rs
@@ -167,6 +167,98 @@ fn write_invariants_with_many_predicates(dir: &std::path::Path, count: usize) {
 }
 
 #[test]
+fn flow_ship_watch_surfaces_bootstrap_policy_when_present() {
+    let repo = demo_repo();
+    fs::write(
+        repo.path().join("meta-invariants.harn"),
+        r#"
+@bootstrap_maintainers(approvers: ["role:flow-platform", "user:alice"])
+fn _bootstrap_marker() {
+  return nil
+}
+"#,
+    )
+    .unwrap();
+    let store_path = repo.path().join(".harn/flow.sqlite");
+    let store = SqliteFlowStore::open(&store_path, "flow-bootstrap").unwrap();
+    let mut atoms = Vec::new();
+    for index in 0..3 {
+        let parents = atoms
+            .last()
+            .map(|atom: &Atom| vec![atom.id])
+            .unwrap_or_default();
+        atoms.push(atom(index, parents));
+    }
+    for atom in &atoms {
+        store.emit_atom(atom).unwrap();
+    }
+    drop(store);
+
+    let mock_pr_path = repo.path().join(".harn/flow/mock-pr.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(repo.path())
+        .args([
+            "flow",
+            "ship",
+            "watch",
+            "--store",
+            store_path.to_str().unwrap(),
+            "--mock-pr-out",
+            mock_pr_path.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let bootstrap = &payload["predicate_validation"]["bootstrap_policy"];
+    assert_eq!(bootstrap["status"], "present");
+    let hash = bootstrap["hash"].as_str().unwrap();
+    assert!(hash.starts_with("sha256:"), "{hash}");
+    let maintainers = bootstrap["maintainers"].as_array().unwrap();
+    assert_eq!(maintainers.len(), 2);
+    assert_eq!(maintainers[0]["kind"], "role");
+    assert_eq!(maintainers[0]["id"], "flow-platform");
+    assert_eq!(maintainers[1]["kind"], "principal");
+    assert_eq!(maintainers[1]["id"], "user:alice");
+}
+
+#[test]
+fn flow_ship_watch_marks_bootstrap_policy_absent_when_missing() {
+    let repo = demo_repo();
+    let store_path = repo.path().join(".harn/flow.sqlite");
+    let store = SqliteFlowStore::open(&store_path, "flow-bootstrap-absent").unwrap();
+    store.emit_atom(&atom(0, Vec::new())).unwrap();
+    drop(store);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(repo.path())
+        .args([
+            "flow",
+            "ship",
+            "watch",
+            "--store",
+            store_path.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        payload["predicate_validation"]["bootstrap_policy"]["status"],
+        "absent"
+    );
+}
+
+#[test]
 fn flow_ship_watch_blocks_when_predicate_union_explodes() {
     let temp = TempDir::new().unwrap();
     let repo = temp.path();

--- a/crates/harn-vm/src/flow/mod.rs
+++ b/crates/harn-vm/src/flow/mod.rs
@@ -32,17 +32,20 @@ pub use intent::{
     TranscriptSpan,
 };
 pub use predicates::{
-    compose_predicate_results, discover_invariants, enforce_predicate_ceiling,
-    parse_invariants_source, resolve_predicates, resolve_predicates_for_touched_directories,
-    Approver, ArchivistMetadata, ByteSpan, CheapJudge, CheapJudgeRequest, CheapJudgeResponse,
-    ComposedPredicateEvaluation, DirectoryContribution, DiscoveredInvariantFile,
-    DiscoveredPredicate, DiscoveryDiagnostic, DiscoveryDiagnosticSeverity, EvidenceItem,
+    compose_predicate_results, discover_bootstrap_policy, discover_invariants,
+    enforce_predicate_ceiling, parse_invariants_source, resolve_predicates,
+    resolve_predicates_for_touched_directories, validate_bootstrap_edit, validate_predicate_edit,
+    Approver, ArchivistMetadata, BootstrapPolicy, BootstrapValidation, BootstrapViolation,
+    ByteSpan, CheapJudge, CheapJudgeRequest, CheapJudgeResponse, ComposedPredicateEvaluation,
+    DirectoryContribution, DiscoveredBootstrapPolicy, DiscoveredInvariantFile, DiscoveredPredicate,
+    DiscoveryDiagnostic, DiscoveryDiagnosticSeverity, EditAuthor, EvidenceItem,
     InvariantBlockError, InvariantResult, ParsedInvariantFile, PredicateCeiling,
     PredicateCeilingLevel, PredicateCeilingOutcome, PredicateCeilingViolation, PredicateContext,
     PredicateEvaluation, PredicateExecutionRecord, PredicateExecutionReport, PredicateExecutor,
     PredicateExecutorConfig, PredicateKind, PredicateRunner, PredicateSchedulerConfig,
     PredicateSource, Remediation, ResolvedPredicate, SemanticReplayAuditMetadata, Verdict,
-    VerdictStrictness, INVARIANTS_FILE, PREDICATE_COUNT_EXPLOSION_CODE,
+    VerdictStrictness, DEFAULT_MAINTAINER_ROLE, INVARIANTS_FILE, META_INVARIANTS_FILE,
+    PREDICATE_COUNT_EXPLOSION_CODE,
 };
 pub use slice::{
     derive_slice, Approval, CoverageMap, PredicateHash, Slice, SliceDerivationError,

--- a/crates/harn-vm/src/flow/predicates/bootstrap.rs
+++ b/crates/harn-vm/src/flow/predicates/bootstrap.rs
@@ -1,0 +1,779 @@
+//! Repo-root `meta-invariants.harn` bootstrap policy.
+//!
+//! Solves the "predicate code that gates predicate code" problem flagged in
+//! decision 2 of `docs/src/flow-predicates.md`. Per-directory `invariants.harn`
+//! files declare slice gates; this module declares the small, hand-authored
+//! policy that gates *those* gates' authorship.
+//!
+//! Two validation entrypoints front the policy:
+//!
+//! - [`validate_predicate_edit`] checks a proposed edit to an
+//!   `invariants.harn` file. Archivist may propose; humans and other
+//!   non-Archivist actors may also propose. Promotion still requires the
+//!   normal slice approval chain — this function only enforces the bootstrap
+//!   rules (parseability, kind annotation, archivist provenance, semantic
+//!   fallback presence).
+//! - [`validate_bootstrap_edit`] checks a proposed edit to
+//!   `meta-invariants.harn` itself. Archivist authorship is rejected outright;
+//!   any other author yields `RequireApproval` routing to a human maintainer
+//!   listed in the previous policy. The previous policy hash is pinned in the
+//!   result so the slice approval chain has an explicit audit reference.
+//!
+//! See parent epic #571, the predicate decision record (#584), and the
+//! implementation ticket (#734).
+
+use std::path::{Path, PathBuf};
+
+use harn_lexer::Lexer;
+use harn_parser::{peel_attributes, Attribute, AttributeArg, Node, Parser};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::discovery::{
+    parse_invariants_source, ArchivistMetadata, DiagnosticSeverity, DiscoveryDiagnostic,
+};
+use super::result::{Approver, InvariantBlockError, Verdict};
+use crate::flow::slice::PredicateHash;
+
+/// Filename used for the repo-root bootstrap policy file.
+pub const META_INVARIANTS_FILE: &str = "meta-invariants.harn";
+
+/// Default maintainer routed when the discovered policy doesn't list any.
+///
+/// Mirrors the Ship Captain ceiling default approver so a freshly-seeded
+/// repository still ends up at the same human review desk.
+pub const DEFAULT_MAINTAINER_ROLE: &str = "flow-platform";
+
+/// Stable error codes attached to [`BootstrapViolation`]s.
+pub mod codes {
+    pub const PARSE_ERROR: &str = "bootstrap_parse_error";
+    pub const KIND_COLLISION: &str = "bootstrap_kind_collision";
+    pub const MISSING_ARCHIVIST: &str = "bootstrap_missing_archivist";
+    pub const ARCHIVIST_PROVENANCE_INCOMPLETE: &str = "bootstrap_archivist_provenance_incomplete";
+    pub const MISSING_SEMANTIC_FALLBACK: &str = "bootstrap_missing_semantic_fallback";
+    pub const UNRESOLVED_SEMANTIC_FALLBACK: &str = "bootstrap_unresolved_semantic_fallback";
+    pub const ARCHIVIST_AUTHORED_BOOTSTRAP: &str = "bootstrap_archivist_cannot_author_bootstrap";
+}
+
+/// Identity of the actor proposing a predicate-authorship change.
+///
+/// Stored on the proposal envelope and consulted by both validators: the
+/// bootstrap policy is the only place Archivist authorship is a hard error,
+/// and only the meta-invariants validator checks the discriminant — normal
+/// `invariants.harn` edits accept any author because the slice approval chain
+/// is responsible for promotion.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EditAuthor {
+    /// The Archivist persona — propose-only, never auto-promotes bootstrap.
+    Archivist,
+    /// A named human maintainer (e.g. `user:alice`).
+    Human { id: String },
+    /// Any other automated actor (Fixer, Ship Captain, replay tools).
+    System { id: String },
+}
+
+impl EditAuthor {
+    pub fn human(id: impl Into<String>) -> Self {
+        Self::Human { id: id.into() }
+    }
+
+    pub fn system(id: impl Into<String>) -> Self {
+        Self::System { id: id.into() }
+    }
+
+    fn label(&self) -> String {
+        match self {
+            EditAuthor::Archivist => "archivist".to_string(),
+            EditAuthor::Human { id } => format!("human:{id}"),
+            EditAuthor::System { id } => format!("system:{id}"),
+        }
+    }
+}
+
+/// One bootstrap-policy violation produced by the validators.
+///
+/// The `code` field is owned `String` so the type round-trips through serde.
+/// The static codes in [`codes`] are the canonical authoring source.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapViolation {
+    pub code: String,
+    pub message: String,
+    /// Predicate name when the violation is tied to a specific declaration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub predicate: Option<String>,
+}
+
+impl BootstrapViolation {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code: code.to_string(),
+            message: message.into(),
+            predicate: None,
+        }
+    }
+
+    fn with_predicate(mut self, predicate: impl Into<String>) -> Self {
+        self.predicate = Some(predicate.into());
+        self
+    }
+}
+
+/// Parsed `meta-invariants.harn` contents.
+///
+/// The file is ordinary Harn syntax so the existing lexer and parser handle
+/// it. The policy carries the file's content hash (pinned for replay audit)
+/// and the maintainer routing list extracted from a top-level
+/// `@bootstrap_maintainers(...)` attribute, if present. Parser diagnostics
+/// are returned alongside via [`BootstrapPolicy::parse_with_diagnostics`] so
+/// the policy struct itself is serde-clean for audit payloads.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapPolicy {
+    /// Stable content hash of the entire file source.
+    pub hash: PredicateHash,
+    /// Maintainer approvers in source order. At least one entry is always
+    /// present — empty input lists fall back to [`DEFAULT_MAINTAINER_ROLE`].
+    pub maintainers: Vec<Approver>,
+}
+
+impl BootstrapPolicy {
+    /// Parse a `meta-invariants.harn` source string. Discards any parser
+    /// diagnostics; use [`BootstrapPolicy::parse_with_diagnostics`] when you
+    /// need to surface them.
+    ///
+    /// The hash is computed across the full source bytes so any change — even
+    /// reordering whitespace — produces a new hash. This matches the existing
+    /// `predicate_source_hash` shape (`sha256:<hex>`).
+    pub fn parse(source: &str) -> Self {
+        Self::parse_with_diagnostics(source).0
+    }
+
+    /// Parse a `meta-invariants.harn` source string and return the structural
+    /// diagnostics raised by the lexer/parser. Missing optional configuration
+    /// (e.g. no `@bootstrap_maintainers` attribute) is a silent fall back to
+    /// defaults — only real parse errors appear here.
+    pub fn parse_with_diagnostics(source: &str) -> (Self, Vec<DiscoveryDiagnostic>) {
+        let hash = bootstrap_hash(source);
+        let parsed = parse_invariants_source(source);
+        let mut diagnostics = parsed.diagnostics;
+
+        let mut maintainers = Vec::new();
+        match collect_top_level_attributes(source) {
+            Ok(attrs) => {
+                for attr in attrs {
+                    if attr.name == "bootstrap_maintainers" {
+                        maintainers.extend(parse_maintainers(&attr.args));
+                    }
+                }
+            }
+            Err(diagnostic) => diagnostics.push(diagnostic),
+        }
+        if maintainers.is_empty() {
+            maintainers.push(Approver::role(DEFAULT_MAINTAINER_ROLE));
+        }
+
+        (Self { hash, maintainers }, diagnostics)
+    }
+}
+
+/// Bootstrap policy as discovered on disk.
+#[derive(Clone, Debug)]
+pub struct DiscoveredBootstrapPolicy {
+    /// Absolute path to `meta-invariants.harn`.
+    pub path: PathBuf,
+    /// Raw source — kept around so callers can render diagnostics or echo it
+    /// back in audit payloads.
+    pub source: String,
+    /// Parsed policy contents.
+    pub policy: BootstrapPolicy,
+    /// Diagnostics raised while parsing.
+    pub diagnostics: Vec<DiscoveryDiagnostic>,
+}
+
+/// Look for `<root>/meta-invariants.harn` and parse it if present.
+///
+/// Returns `None` when the file is missing or unreadable. A parse failure is
+/// surfaced as `Some(...)` with the structural diagnostics returned on
+/// [`DiscoveredBootstrapPolicy::diagnostics`] — callers that need to
+/// fail-fast should inspect that field.
+pub fn discover_bootstrap_policy(root: &Path) -> Option<DiscoveredBootstrapPolicy> {
+    let path = root.join(META_INVARIANTS_FILE);
+    if !path.is_file() {
+        return None;
+    }
+    let source = std::fs::read_to_string(&path).ok()?;
+    let (policy, diagnostics) = BootstrapPolicy::parse_with_diagnostics(&source);
+    Some(DiscoveredBootstrapPolicy {
+        path,
+        source,
+        policy,
+        diagnostics,
+    })
+}
+
+/// Result of running a bootstrap validator.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapValidation {
+    /// Effective verdict for the proposed edit. `Block` when the proposal
+    /// violates a structural rule or — for bootstrap edits — the author lacks
+    /// authorship rights. `RequireApproval` when a human cosigner must
+    /// promote the edit. `Allow` only when the edit is structurally clean and
+    /// no approval routing is required.
+    pub verdict: Verdict,
+    /// Hash of the previous committed bootstrap policy. `None` for an initial
+    /// seed where there is no prior policy to compare against.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_policy_hash: Option<PredicateHash>,
+    /// Hash of the proposed `meta-invariants.harn` source. Set only by
+    /// [`validate_bootstrap_edit`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proposed_policy_hash: Option<PredicateHash>,
+    /// Author label echoed back for audit-log convenience.
+    pub author: String,
+    /// Structured violations. Empty on the happy path.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub violations: Vec<BootstrapViolation>,
+}
+
+impl BootstrapValidation {
+    /// True when the validation produced a structural `Block`.
+    pub fn is_blocked(&self) -> bool {
+        matches!(self.verdict, Verdict::Block { .. })
+    }
+
+    /// True when the proposal needs an approver cosignature before promotion.
+    pub fn requires_approval(&self) -> bool {
+        matches!(self.verdict, Verdict::RequireApproval { .. })
+    }
+}
+
+/// Validate a proposed edit to a per-directory `invariants.harn` file.
+///
+/// Bootstrap policy promotes the soft warnings on `parse_invariants_source`
+/// into hard errors:
+///
+/// - Source must lex/parse cleanly.
+/// - Every `@invariant` predicate must declare exactly one of
+///   `@deterministic` or `@semantic`.
+/// - Every predicate must carry a complete `@archivist(evidence,
+///   confidence, source_date, coverage_examples)` provenance block.
+/// - `@semantic` predicates must declare a fallback whose target is a
+///   deterministic predicate visible in the proposed source.
+///
+/// `previous_policy` lets the caller pin the previously committed bootstrap
+/// hash into the validation result for audit. It does not change the rules
+/// applied — the bootstrap rules themselves live in this function so a
+/// repository can roll its policy hash forward without rewriting Rust.
+pub fn validate_predicate_edit(
+    proposed_source: &str,
+    author: &EditAuthor,
+    previous_policy: Option<&BootstrapPolicy>,
+) -> BootstrapValidation {
+    let violations = collect_predicate_edit_violations(proposed_source);
+    let verdict = if violations.is_empty() {
+        Verdict::Allow
+    } else {
+        Verdict::Block {
+            error: build_block_error(codes::PARSE_ERROR, &violations),
+        }
+    };
+    BootstrapValidation {
+        verdict,
+        previous_policy_hash: previous_policy.map(|policy| policy.hash.clone()),
+        proposed_policy_hash: None,
+        author: author.label(),
+        violations,
+    }
+}
+
+/// Validate a proposed edit to `meta-invariants.harn`.
+///
+/// - Archivist authorship is a hard `Block` with the stable code
+///   `bootstrap_archivist_cannot_author_bootstrap`.
+/// - Otherwise, the proposed source is parsed for structural problems. If
+///   parsing fails, the result is `Block`.
+/// - Clean proposals from a non-Archivist author yield `RequireApproval`,
+///   routed to one of the maintainers listed in the previous policy (or the
+///   default maintainer role on initial seed). The previous policy's hash and
+///   the proposed policy's hash are both pinned in the result so the slice
+///   approval chain has explicit audit pointers.
+pub fn validate_bootstrap_edit(
+    proposed_source: &str,
+    author: &EditAuthor,
+    previous_policy: Option<&BootstrapPolicy>,
+) -> BootstrapValidation {
+    let proposed_hash = bootstrap_hash(proposed_source);
+    let previous_hash = previous_policy.map(|policy| policy.hash.clone());
+    let mut violations = Vec::new();
+
+    if matches!(author, EditAuthor::Archivist) {
+        violations.push(BootstrapViolation::new(
+            codes::ARCHIVIST_AUTHORED_BOOTSTRAP,
+            "Archivist persona is propose-only and may not author or promote \
+             meta-invariants.harn edits — escalate to a human maintainer",
+        ));
+        let error = build_block_error(codes::ARCHIVIST_AUTHORED_BOOTSTRAP, &violations);
+        return BootstrapValidation {
+            verdict: Verdict::Block { error },
+            previous_policy_hash: previous_hash,
+            proposed_policy_hash: Some(proposed_hash),
+            author: author.label(),
+            violations,
+        };
+    }
+
+    let (parsed_policy, parse_diagnostics) =
+        BootstrapPolicy::parse_with_diagnostics(proposed_source);
+    for diagnostic in parse_diagnostics
+        .iter()
+        .filter(|d| d.severity == DiagnosticSeverity::Error)
+    {
+        violations.push(BootstrapViolation::new(
+            codes::PARSE_ERROR,
+            diagnostic.message.clone(),
+        ));
+    }
+
+    if !violations.is_empty() {
+        let error = build_block_error(codes::PARSE_ERROR, &violations);
+        return BootstrapValidation {
+            verdict: Verdict::Block { error },
+            previous_policy_hash: previous_hash,
+            proposed_policy_hash: Some(proposed_hash),
+            author: author.label(),
+            violations,
+        };
+    }
+
+    let approver = previous_policy
+        .and_then(|policy| policy.maintainers.first().cloned())
+        .or_else(|| parsed_policy.maintainers.first().cloned())
+        .unwrap_or_else(|| Approver::role(DEFAULT_MAINTAINER_ROLE));
+
+    BootstrapValidation {
+        verdict: Verdict::RequireApproval { approver },
+        previous_policy_hash: previous_hash,
+        proposed_policy_hash: Some(proposed_hash),
+        author: author.label(),
+        violations,
+    }
+}
+
+fn collect_predicate_edit_violations(proposed_source: &str) -> Vec<BootstrapViolation> {
+    let parsed = parse_invariants_source(proposed_source);
+    let mut violations = Vec::new();
+
+    for diagnostic in &parsed.diagnostics {
+        if diagnostic.severity != DiagnosticSeverity::Error {
+            continue;
+        }
+        let code = if diagnostic.message.contains("pick exactly one") {
+            codes::KIND_COLLISION
+        } else if diagnostic
+            .message
+            .contains("must declare a deterministic fallback")
+        {
+            codes::MISSING_SEMANTIC_FALLBACK
+        } else if diagnostic
+            .message
+            .contains("same invariants.harn file or an ancestor file")
+        {
+            codes::UNRESOLVED_SEMANTIC_FALLBACK
+        } else {
+            codes::PARSE_ERROR
+        };
+        violations.push(BootstrapViolation::new(code, diagnostic.message.clone()));
+    }
+
+    for predicate in &parsed.predicates {
+        // The parser already raises kind-collision and missing-semantic-fallback
+        // as error diagnostics, picked up in the loop above. Bootstrap adds the
+        // missing-/incomplete-archivist checks because the parser only warns.
+        match predicate.archivist.as_ref() {
+            None => {
+                violations.push(
+                    BootstrapViolation::new(
+                        codes::MISSING_ARCHIVIST,
+                        format!(
+                            "predicate `{}` must declare `@archivist(...)` provenance \
+                             before promotion",
+                            predicate.name
+                        ),
+                    )
+                    .with_predicate(&predicate.name),
+                );
+            }
+            Some(archivist) => {
+                for missing in archivist_missing_fields(archivist) {
+                    violations.push(
+                        BootstrapViolation::new(
+                            codes::ARCHIVIST_PROVENANCE_INCOMPLETE,
+                            format!(
+                                "predicate `{}` is missing required @archivist field `{missing}`",
+                                predicate.name
+                            ),
+                        )
+                        .with_predicate(&predicate.name),
+                    );
+                }
+            }
+        }
+    }
+
+    deduplicate_violations(violations)
+}
+
+fn deduplicate_violations(violations: Vec<BootstrapViolation>) -> Vec<BootstrapViolation> {
+    let mut seen = std::collections::BTreeSet::<(String, String, Option<String>)>::new();
+    let mut out = Vec::with_capacity(violations.len());
+    for violation in violations {
+        let key = (
+            violation.code.to_string(),
+            violation.message.clone(),
+            violation.predicate.clone(),
+        );
+        if seen.insert(key) {
+            out.push(violation);
+        }
+    }
+    out
+}
+
+fn archivist_missing_fields(archivist: &ArchivistMetadata) -> Vec<&'static str> {
+    let mut missing = Vec::new();
+    if archivist.evidence.is_empty() {
+        missing.push("evidence");
+    }
+    if archivist.confidence.is_none() {
+        missing.push("confidence");
+    }
+    if archivist.source_date.is_none() {
+        missing.push("source_date");
+    }
+    if archivist.coverage_examples.is_empty() {
+        missing.push("coverage_examples");
+    }
+    missing
+}
+
+fn build_block_error(code: &'static str, violations: &[BootstrapViolation]) -> InvariantBlockError {
+    let summary = violations
+        .iter()
+        .map(|v| {
+            if let Some(predicate) = &v.predicate {
+                format!("{} (in `{predicate}`): {}", v.code, v.message)
+            } else {
+                format!("{}: {}", v.code, v.message)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    let message = if summary.is_empty() {
+        "bootstrap policy rejected the proposed edit".to_string()
+    } else {
+        format!("bootstrap policy rejected the proposed edit: {summary}")
+    };
+    InvariantBlockError::new(code, message)
+}
+
+fn bootstrap_hash(source: &str) -> PredicateHash {
+    PredicateHash::new(format!(
+        "sha256:{}",
+        hex::encode(Sha256::digest(source.as_bytes()))
+    ))
+}
+
+fn parse_maintainers(args: &[AttributeArg]) -> Vec<Approver> {
+    args.iter()
+        .flat_map(|arg| match &arg.value.node {
+            Node::ListLiteral(items) => items
+                .iter()
+                .filter_map(|item| match &item.node {
+                    Node::StringLiteral(s) | Node::RawStringLiteral(s) => {
+                        Some(parse_maintainer_str(s))
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+            Node::StringLiteral(s) | Node::RawStringLiteral(s) => {
+                vec![parse_maintainer_str(s)]
+            }
+            _ => Vec::new(),
+        })
+        .collect()
+}
+
+fn parse_maintainer_str(value: &str) -> Approver {
+    if let Some(role) = value.strip_prefix("role:") {
+        Approver::role(role.trim())
+    } else if let Some(principal) = value.strip_prefix("user:") {
+        Approver::principal(format!("user:{}", principal.trim()))
+    } else {
+        Approver::principal(value.trim())
+    }
+}
+
+/// Walk the top-level attribute lists in a Harn source string. Used by the
+/// bootstrap parser to find a `@bootstrap_maintainers(...)` configuration
+/// without needing it to live on a real predicate function.
+fn collect_top_level_attributes(source: &str) -> Result<Vec<Attribute>, DiscoveryDiagnostic> {
+    let tokens = Lexer::new(source)
+        .tokenize()
+        .map_err(|error| DiscoveryDiagnostic {
+            severity: DiagnosticSeverity::Error,
+            message: format!("lex error: {error:?}"),
+            span: None,
+        })?;
+    let program = Parser::new(tokens)
+        .parse()
+        .map_err(|error| DiscoveryDiagnostic {
+            severity: DiagnosticSeverity::Error,
+            message: format!("parse error: {error:?}"),
+            span: None,
+        })?;
+    let mut out = Vec::new();
+    for node in &program {
+        let (attrs, _inner) = peel_attributes(node);
+        out.extend(attrs.iter().cloned());
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    const VALID_PREDICATE: &str = r#"
+@invariant
+@deterministic
+@archivist(
+  evidence: ["https://example.com/spec"],
+  confidence: 0.95,
+  source_date: "2026-04-26",
+  coverage_examples: ["crates/api/src/auth.rs"]
+)
+fn no_raw_tokens(slice) {
+  return flow_invariant_allow()
+}
+"#;
+
+    const VALID_BOOTSTRAP: &str = r#"
+@bootstrap_maintainers(approvers: ["role:flow-platform", "user:alice"])
+fn _meta_invariants_marker() {
+  return nil
+}
+"#;
+
+    #[test]
+    fn parses_bootstrap_policy_hash_and_maintainers() {
+        let policy = BootstrapPolicy::parse(VALID_BOOTSTRAP);
+        assert!(policy.hash.as_str().starts_with("sha256:"));
+        assert_eq!(policy.maintainers.len(), 2);
+        assert!(matches!(
+            policy.maintainers[0],
+            Approver::Role { ref name } if name == "flow-platform"
+        ));
+        assert!(matches!(
+            policy.maintainers[1],
+            Approver::Principal { ref id } if id == "user:alice"
+        ));
+    }
+
+    #[test]
+    fn bootstrap_hash_is_stable_across_identical_sources() {
+        let a = BootstrapPolicy::parse(VALID_BOOTSTRAP);
+        let b = BootstrapPolicy::parse(VALID_BOOTSTRAP);
+        assert_eq!(a.hash, b.hash);
+    }
+
+    #[test]
+    fn bootstrap_hash_changes_when_source_changes() {
+        let a = BootstrapPolicy::parse(VALID_BOOTSTRAP);
+        let b = BootstrapPolicy::parse(&VALID_BOOTSTRAP.replace("alice", "bob"));
+        assert_ne!(a.hash, b.hash);
+    }
+
+    #[test]
+    fn bootstrap_default_maintainer_when_attribute_missing() {
+        let policy = BootstrapPolicy::parse("// no maintainer attribute here\n");
+        assert_eq!(policy.maintainers.len(), 1);
+        assert!(matches!(
+            policy.maintainers[0],
+            Approver::Role { ref name } if name == DEFAULT_MAINTAINER_ROLE
+        ));
+    }
+
+    #[test]
+    fn validate_initial_seed_predicate_edit_passes_without_prior_policy() {
+        let result = validate_predicate_edit(VALID_PREDICATE, &EditAuthor::Archivist, None);
+        assert!(matches!(result.verdict, Verdict::Allow), "{result:?}");
+        assert_eq!(result.previous_policy_hash, None);
+        assert!(result.violations.is_empty());
+        assert_eq!(result.author, "archivist");
+    }
+
+    #[test]
+    fn validate_normal_predicate_edit_pins_previous_policy_hash() {
+        let policy = BootstrapPolicy::parse(VALID_BOOTSTRAP);
+        let result = validate_predicate_edit(
+            VALID_PREDICATE,
+            &EditAuthor::human("user:alice"),
+            Some(&policy),
+        );
+        assert!(matches!(result.verdict, Verdict::Allow));
+        assert_eq!(result.previous_policy_hash, Some(policy.hash.clone()));
+    }
+
+    #[test]
+    fn validate_predicate_edit_blocks_when_archivist_provenance_missing() {
+        let source = r#"
+@invariant
+@deterministic
+fn no_provenance(slice) { return true }
+"#;
+        let result = validate_predicate_edit(source, &EditAuthor::Archivist, None);
+        assert!(result.is_blocked());
+        let codes: Vec<&str> = result.violations.iter().map(|v| v.code.as_str()).collect();
+        assert!(codes.contains(&codes::MISSING_ARCHIVIST), "{codes:?}");
+    }
+
+    #[test]
+    fn validate_predicate_edit_blocks_when_archivist_provenance_partial() {
+        let source = r#"
+@invariant
+@deterministic
+@archivist(evidence: ["https://x"])
+fn partial_provenance(slice) { return true }
+"#;
+        let result = validate_predicate_edit(source, &EditAuthor::Archivist, None);
+        assert!(result.is_blocked());
+        let missing_fields: Vec<String> = result
+            .violations
+            .iter()
+            .filter(|v| v.code == codes::ARCHIVIST_PROVENANCE_INCOMPLETE)
+            .map(|v| v.message.clone())
+            .collect();
+        assert!(
+            missing_fields.iter().any(|m| m.contains("confidence")),
+            "{missing_fields:?}"
+        );
+        assert!(
+            missing_fields.iter().any(|m| m.contains("source_date")),
+            "{missing_fields:?}"
+        );
+        assert!(
+            missing_fields
+                .iter()
+                .any(|m| m.contains("coverage_examples")),
+            "{missing_fields:?}"
+        );
+    }
+
+    #[test]
+    fn validate_predicate_edit_blocks_when_kinds_collide() {
+        let source = r#"
+@invariant
+@deterministic
+@semantic
+@archivist(evidence: ["x"], confidence: 0.5, source_date: "2026-04-26", coverage_examples: ["a"])
+fn dual_mode(slice) { return true }
+"#;
+        let result = validate_predicate_edit(source, &EditAuthor::Archivist, None);
+        assert!(result.is_blocked());
+        let codes: Vec<&str> = result.violations.iter().map(|v| v.code.as_str()).collect();
+        assert!(codes.contains(&codes::KIND_COLLISION), "{codes:?}");
+    }
+
+    #[test]
+    fn validate_predicate_edit_blocks_when_semantic_fallback_missing() {
+        let source = r#"
+@invariant
+@semantic
+@archivist(evidence: ["x"], confidence: 0.5, source_date: "2026-04-26", coverage_examples: ["a"])
+fn semantic_no_fallback(slice) { return true }
+"#;
+        let result = validate_predicate_edit(source, &EditAuthor::Archivist, None);
+        assert!(result.is_blocked());
+        let codes: Vec<&str> = result.violations.iter().map(|v| v.code.as_str()).collect();
+        assert!(
+            codes.contains(&codes::MISSING_SEMANTIC_FALLBACK),
+            "{codes:?}"
+        );
+    }
+
+    #[test]
+    fn validate_bootstrap_edit_rejects_archivist_authorship() {
+        let previous = BootstrapPolicy::parse(VALID_BOOTSTRAP);
+        let proposed = VALID_BOOTSTRAP.replace("alice", "mallory");
+        let result = validate_bootstrap_edit(&proposed, &EditAuthor::Archivist, Some(&previous));
+        assert!(result.is_blocked());
+        let codes: Vec<&str> = result.violations.iter().map(|v| v.code.as_str()).collect();
+        assert_eq!(codes, vec![codes::ARCHIVIST_AUTHORED_BOOTSTRAP]);
+        assert_eq!(result.previous_policy_hash, Some(previous.hash));
+        assert!(result.proposed_policy_hash.is_some());
+    }
+
+    #[test]
+    fn validate_bootstrap_edit_routes_human_to_require_approval() {
+        let previous = BootstrapPolicy::parse(VALID_BOOTSTRAP);
+        let proposed = VALID_BOOTSTRAP.replace("alice", "carol");
+        let result =
+            validate_bootstrap_edit(&proposed, &EditAuthor::human("user:carol"), Some(&previous));
+        assert!(result.requires_approval(), "{result:?}");
+        let approver = match &result.verdict {
+            Verdict::RequireApproval { approver } => approver.clone(),
+            other => panic!("expected RequireApproval, got {other:?}"),
+        };
+        assert!(matches!(approver, Approver::Role { ref name } if name == "flow-platform"));
+        assert_eq!(result.previous_policy_hash, Some(previous.hash));
+    }
+
+    #[test]
+    fn validate_bootstrap_edit_initial_seed_uses_default_role() {
+        let result =
+            validate_bootstrap_edit("// initial seed\n", &EditAuthor::human("user:alice"), None);
+        assert!(result.requires_approval());
+        let approver = match &result.verdict {
+            Verdict::RequireApproval { approver } => approver.clone(),
+            other => panic!("expected RequireApproval, got {other:?}"),
+        };
+        assert!(matches!(
+            approver,
+            Approver::Role { ref name } if name == DEFAULT_MAINTAINER_ROLE
+        ));
+        assert_eq!(result.previous_policy_hash, None);
+    }
+
+    #[test]
+    fn validate_bootstrap_edit_blocks_unparseable_source() {
+        let proposed = r#"
+@invariant
+@deterministic
+@semantic
+@archivist(evidence: ["x"])
+fn bad(slice) { return true }
+"#;
+        let previous = BootstrapPolicy::parse(VALID_BOOTSTRAP);
+        let result =
+            validate_bootstrap_edit(proposed, &EditAuthor::human("user:alice"), Some(&previous));
+        assert!(result.is_blocked(), "{result:?}");
+    }
+
+    #[test]
+    fn discover_returns_none_when_file_missing() {
+        let tmp = TempDir::new().unwrap();
+        assert!(discover_bootstrap_policy(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn discover_loads_meta_invariants_from_root() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(META_INVARIANTS_FILE), VALID_BOOTSTRAP).unwrap();
+        let discovered = discover_bootstrap_policy(tmp.path()).expect("policy present");
+        assert!(discovered.path.ends_with(META_INVARIANTS_FILE));
+        assert_eq!(discovered.policy.maintainers.len(), 2);
+        assert_eq!(discovered.source, VALID_BOOTSTRAP);
+    }
+}

--- a/crates/harn-vm/src/flow/predicates/mod.rs
+++ b/crates/harn-vm/src/flow/predicates/mod.rs
@@ -1,10 +1,16 @@
 //! Flow invariant predicate execution.
 
+pub mod bootstrap;
 pub mod compose;
 pub mod discovery;
 pub mod executor;
 pub mod result;
 
+pub use bootstrap::{
+    discover_bootstrap_policy, validate_bootstrap_edit, validate_predicate_edit, BootstrapPolicy,
+    BootstrapValidation, BootstrapViolation, DiscoveredBootstrapPolicy, EditAuthor,
+    DEFAULT_MAINTAINER_ROLE, META_INVARIANTS_FILE,
+};
 pub use compose::{
     compose_predicate_results, enforce_predicate_ceiling, resolve_predicates,
     resolve_predicates_for_touched_directories, ComposedPredicateEvaluation, DirectoryContribution,

--- a/docs/src/flow-predicates.md
+++ b/docs/src/flow-predicates.md
@@ -172,6 +172,49 @@ in-toto/SLSA: the policy code, the subject it evaluated, and the actor that
 approved it must be separable audit facts. Harn's subject is a Flow slice rather
 than a build artifact, but the trust boundary is the same.
 
+### `meta-invariants.harn` shape and validators
+
+The bootstrap file is parsed by the existing Harn lexer/parser — the only
+syntactic novelty is a top-level `@bootstrap_maintainers(approvers: [...])`
+attribute that lists human maintainer roles or principals allowed to promote
+bootstrap edits. A maintainer entry is `"role:<name>"` (matched as
+`Approver::Role`) or `"user:<id>"` / any other string (matched as
+`Approver::Principal`). Repos that omit the attribute fall back to a single
+`role:flow-platform` approver — the same default used by the Ship Captain
+predicate-count ceiling.
+
+Two Rust functions in
+`crates/harn-vm/src/flow/predicates/bootstrap.rs` carry the policy:
+
+- `validate_predicate_edit(proposed_source, author, previous_policy)` runs
+  the bootstrap rules against a proposed `invariants.harn` edit. Missing
+  `@archivist(...)` provenance, partial provenance fields, kind-collision
+  attributes, and unresolved semantic fallbacks are all promoted from the
+  parser's soft warnings into hard `Block` verdicts with stable codes
+  (`bootstrap_missing_archivist`, `bootstrap_archivist_provenance_incomplete`,
+  `bootstrap_kind_collision`, `bootstrap_missing_semantic_fallback`,
+  `bootstrap_unresolved_semantic_fallback`). The previous bootstrap policy
+  hash is pinned in the validation result so the slice approval chain has an
+  explicit audit pointer.
+- `validate_bootstrap_edit(proposed_source, author, previous_policy)` runs
+  against a proposed `meta-invariants.harn` edit. Archivist authorship is a
+  hard `Block` (`bootstrap_archivist_cannot_author_bootstrap`); any
+  non-Archivist actor returns `RequireApproval` routed to one of the
+  previous policy's maintainers (or the default role on initial seed). The
+  previous policy hash and the proposed policy hash are both pinned in the
+  result.
+
+`harn flow ship watch` and `harn flow archivist scan` now surface the
+discovered bootstrap policy alongside the existing predicate validation
+payload. When `meta-invariants.harn` is present at the predicate root, the
+JSON output includes `bootstrap_policy.status = "present"` together with the
+policy hash and the resolved maintainer list; otherwise the field reports
+`status = "absent"` and the path Flow looked for. The actual `Block` /
+`RequireApproval` verdicts from the validators are returned to in-process
+callers (Archivist promotion, future `harn flow validate` subcommand) — Ship
+Captain only surfaces the discovered policy hash and maintainers, since
+Phase 0 doesn't yet evaluate proposed edits during atom emission.
+
 ## Decision 3: Semantic Predicate Determinism
 
 Default stance: every `@semantic` predicate must have a deterministic fallback.
@@ -314,8 +357,11 @@ absence of atom history explicit.
 The decisions above leave concrete implementation work beyond the already
 landed and in-review predicate tickets:
 
-- [#734](https://github.com/burin-labs/harn/issues/734): add
-  `meta-invariants.harn` bootstrap validation and approval-chain checks.
+- ~~[#734](https://github.com/burin-labs/harn/issues/734): add
+  `meta-invariants.harn` bootstrap validation and approval-chain checks.~~
+  Closed by `validate_predicate_edit` /
+  `validate_bootstrap_edit` plus the `bootstrap_policy` field surfaced in
+  `harn flow ship watch` and `harn flow archivist scan`.
 - [#735](https://github.com/burin-labs/harn/issues/735): deterministic
   fallback metadata and enforcement for `@semantic` predicates.
 - ~~[#736](https://github.com/burin-labs/harn/issues/736): add cross-slice


### PR DESCRIPTION
## Summary

Closes [#734](https://github.com/burin-labs/harn/issues/734) and the remaining open implementation work from decision 2 of the predicate-language design record ([#584](https://github.com/burin-labs/harn/issues/584)).

A repo-root `meta-invariants.harn` (separate from per-directory `invariants.harn`) carries a small, hand-authored bootstrap policy: its `sha256:` content hash plus a maintainer list pulled from a top-level `@bootstrap_maintainers(approvers: [...])` attribute. Two validators in the new `crates/harn-vm/src/flow/predicates/bootstrap.rs` enforce the policy.

- `validate_predicate_edit` runs against a proposed `invariants.harn` edit and promotes the parser's soft warnings into hard `Block` verdicts. Stable codes cover missing `@archivist(...)` provenance, partial provenance fields, kind collisions, and missing/unresolved semantic fallbacks.
- `validate_bootstrap_edit` runs against a proposed `meta-invariants.harn` edit. **Archivist authorship is rejected outright** (`bootstrap_archivist_cannot_author_bootstrap`); any non-Archivist actor returns `RequireApproval` routed to one of the previous policy's maintainers (or the default `flow-platform` role on initial seed). Both validators pin the previous policy hash in the result so the slice approval chain has an explicit audit pointer.
- `harn flow ship watch` and `harn flow archivist scan` surface a new `bootstrap_policy` field in their JSON payloads — hash, maintainer list, and parser diagnostics when present, `status: "absent"` otherwise.

## Test plan

- [x] `cargo test -p harn-vm --lib bootstrap` — 16 inline unit tests covering initial seed, normal predicate edit pass/fail (kind collision, missing/partial provenance, missing fallback), Archivist-authored bootstrap rejection, default-role fallback, hash stability, and discovery from disk.
- [x] `cargo test -p harn-cli --test flow_ship_cli` — 4 integration tests, including new `flow_ship_watch_surfaces_bootstrap_policy_when_present` and `flow_ship_watch_marks_bootstrap_policy_absent_when_missing`.
- [x] `make all` (cargo fmt, clippy, full Rust test suite, conformance, markdown lint, docs snippet check, portal lint+build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)