### PR TITLE
Release v0.7.45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.44"
+version = "0.7.45"
 dependencies = [
  "async-trait",
  "axum",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.44"
+version = "0.7.45"
 dependencies = [
  "harn-vm",
  "serde",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.44"
+version = "0.7.45"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.44"
+version = "0.7.45"
 dependencies = [
  "anyhow",
  "base64",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.44"
+version = "0.7.45"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1740,11 +1740,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.44"
+version = "0.7.45"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.44"
+version = "0.7.45"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.44"
+version = "0.7.45"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.44"
+version = "0.7.45"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.44"
+version = "0.7.45"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.44"
+version = "0.7.45"
 dependencies = [
  "async-trait",
  "axum",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "harn-vm"
-version = "0.7.44"
+version = "0.7.45"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.44"
+version = "0.7.45"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
## Summary

Cuts harn v0.7.45 — two new features land:

- **Cross-slice predicate budget scheduler** ([#736](https://github.com/burin-labs/harn/issues/736), [#768](https://github.com/burin-labs/harn/pull/768)) — `PredicateExecutor` now schedules predicate work fairly across multiple candidate slices via `execute_slices(slices)` and the `PredicateSchedulerConfig` knobs. Global semaphores cap concurrent deterministic and semantic predicate evaluations; per-slice caps prevent monopolization of scarce semantic lanes; per-slice `slice_*_envelope` budgets short-circuit exhausted slices to a structured `Block { error: { code: "budget_exceeded" } }` while other slices continue.
- **`meta-invariants.harn` bootstrap policy validation** ([#734](https://github.com/burin-labs/harn/issues/734), [#769](https://github.com/burin-labs/harn/pull/769)) — closes decision 2 of the predicate-language design record. Repo-root `meta-invariants.harn` carries the bootstrap policy (sha256 + `@bootstrap_maintainers` approver list); `validate_predicate_edit` and `validate_bootstrap_edit` enforce stable error codes and route bootstrap edits through `RequireApproval`.

## Test plan

- [x] `release_ship.sh --prepare --bump patch` passed full audit + workspace publish dry-run + version bump + derived-files regen.
- [x] CHANGELOG.md top heading is `## v0.7.45` matching the bumped Cargo workspace version.
- [ ] CI passes through the merge queue.
- [ ] After merge, the Finalize Release workflow auto-fires on tag drift, tags `v0.7.45`, publishes to crates.io, and creates the GitHub release with platform binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)