### PR TITLE
Workspace polish sweep: regex cache, dedupe, CLI clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## Unreleased
+
+### Performance
+
+- **Cache schema `pattern` regexes.** `schema.is`, `schema.expect`, and
+  `schema.result_of` previously called `regex::Regex::new` once per
+  validated value when the schema declared a `pattern`. Compilation
+  now happens at most once per pattern (capped 256-entry cache,
+  cleared when full), eliminating wasted work for hot-path validators
+  that re-validate the same shape thousands of times.
+  Crate: `harn-vm` (`schema/validate.rs`).
+
+### Fixed
+
+- **`harn-serve` ACP loader no longer silently swallows source-read
+  failures.** When the ACP bridge could not read the requested
+  `.harn` source for diagnostic context, it previously fell back to
+  empty source and continued, which produced misleading runtime
+  errors with no surrounding code. The error is now surfaced as
+  `failed to read pipeline source '<path>' for diagnostic context:
+  …`. Crate: `harn-serve`.
+- **`harn-lint` legacy-doc-comment scan no longer does O(n²) `Vec`
+  shifts** when trimming blank lines off a recovered `///` block.
+  Crate: `harn-lint` (`harndoc.rs`).
+
+### Internal / DX
+
+- **Centralized CLI timestamp/duration formatting in
+  `harn_cli::format`.** Five copies of `format_timestamp`,
+  `format_duration`, and `format_ms` across `trust`, `trigger
+  replay`, `portal/dlq`, `portal/util`, and `orchestrator` commands
+  are gone — the `orchestrator` and `portal` callsites now thinly
+  re-export from the shared module so user-facing output stays
+  byte-identical.
+- **`harn fmt`'s internal API uses `FmtMode::{Check, Write}`** instead
+  of a boolean flag, so call sites read what they mean rather than
+  `fmt_targets(targets, true, ...)`.
+- **CLI help text clarifications** for `harn explain`, `harn doctor`,
+  `harn publish`, and `harn trust-graph`. The previously cryptic
+  `harn explain` description now names the invariants it walks
+  (`fs.writes`, `approval.reachability`, …); `harn publish` is honest
+  about the registry-submission gap and points users at
+  `harn add <repo-or-path>` in the meantime.
+- **Spec preamble now identifies as pre-1.0** (tracking the workspace
+  `0.7.x` series) instead of claiming "Version: 1.0", which was
+  misleading given the surface-level breaking changes that still ship
+  across minor versions.
+- **Removed stale `#[allow(dead_code)]` annotations** on
+  `Manifest::package` and `Manifest::exports`; both fields are read
+  by package-loading and doctor code paths.
+
+### Tests
+
+- Added regression coverage for the new schema `pattern` cache:
+  repeated validation against a valid pattern still succeeds, and an
+  unparsable pattern (e.g. `[unclosed`) returns a stable
+  `invalid regex pattern` error rather than panicking on the cached
+  re-fetch.
+
 ## v0.7.45
 
 ### Added

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -51,7 +51,9 @@ SCRIPTING
     Run(RunArgs),
     /// Type-check .harn files or directories without executing them.
     Check(CheckArgs),
-    /// Explain the CFG path behind an invariant violation for one handler.
+    /// Explain the control-flow path that violates a Harn invariant
+    /// (e.g. `fs.writes`, `approval.reachability`) for a specific
+    /// function or trigger handler.
     Explain(ExplainArgs),
     /// Export machine-readable Harn contracts and bundle manifests.
     Contracts(ContractsArgs),
@@ -65,7 +67,10 @@ SCRIPTING
     Init(InitArgs),
     /// Scaffold a new project, package, or connector from a starter template.
     New(NewArgs),
-    /// Diagnose the local Harn environment and provider setup.
+    /// Diagnose the local Harn environment: toolchain version, configured
+    /// LLM providers and credentials, MCP server reachability, file
+    /// permissions on `~/.harn`, and project manifest health. Reports
+    /// each check as ok/warn/fail with a suggested fix.
     Doctor(DoctorArgs),
     /// Register outbound connector resources with a provider.
     Connect(Box<ConnectArgs>),
@@ -89,7 +94,7 @@ SCRIPTING
     Crystallize(CrystallizeArgs),
     /// Query and manage trust-graph autonomy state.
     Trust(TrustArgs),
-    /// Query and verify trust-graph autonomy state.
+    /// Alias for `harn trust`. Query and verify trust-graph autonomy state.
     #[command(name = "trust-graph")]
     TrustGraph(TrustArgs),
     /// Start the orchestrator process that hosts triggers and connector dispatch.
@@ -120,7 +125,11 @@ SCRIPTING
     Lock,
     /// Manage Harn package caches and integrity verification.
     Package(PackageArgs),
-    /// Prepare a package for publication. Real registry submission is not yet enabled.
+    /// Prepare a package manifest and bundle for publication. Validates
+    /// `harn.toml` and produces a publishable archive locally; remote
+    /// registry submission is not yet implemented (the resulting
+    /// archive can be installed via `harn add <repo-or-path>` in the
+    /// meantime).
     Publish(PublishArgs),
     /// List and inspect durable agent persona manifests.
     Persona(PersonaArgs),

--- a/crates/harn-cli/src/commands/check/fmt.rs
+++ b/crates/harn-cli/src/commands/check/fmt.rs
@@ -2,8 +2,31 @@ use std::process;
 
 use harn_fmt::{format_source_opts, FmtOptions};
 
+/// Whether `harn fmt` should rewrite files in place or just report drift.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum FmtMode {
+    /// Rewrite files that aren't already formatted.
+    Write,
+    /// Only report files that would be reformatted; never write to disk.
+    Check,
+}
+
+impl FmtMode {
+    pub(crate) fn from_check_flag(check: bool) -> Self {
+        if check {
+            Self::Check
+        } else {
+            Self::Write
+        }
+    }
+
+    fn is_check(self) -> bool {
+        matches!(self, Self::Check)
+    }
+}
+
 /// Format one or more files or directories. Accepts multiple targets.
-pub(crate) fn fmt_targets(targets: &[&str], check_mode: bool, opts: &FmtOptions) {
+pub(crate) fn fmt_targets(targets: &[&str], mode: FmtMode, opts: &FmtOptions) {
     let mut files = Vec::new();
     for target in targets {
         let path = std::path::Path::new(target);
@@ -20,7 +43,7 @@ pub(crate) fn fmt_targets(targets: &[&str], check_mode: bool, opts: &FmtOptions)
     let mut has_error = false;
     for file in &files {
         let path_str = file.to_string_lossy();
-        if !fmt_file_inner(&path_str, check_mode, opts) {
+        if !fmt_file_inner(&path_str, mode, opts) {
             has_error = true;
         }
     }
@@ -30,7 +53,7 @@ pub(crate) fn fmt_targets(targets: &[&str], check_mode: bool, opts: &FmtOptions)
 }
 
 /// Format a single file. Returns true on success, false on error.
-fn fmt_file_inner(path: &str, check_mode: bool, opts: &FmtOptions) -> bool {
+fn fmt_file_inner(path: &str, mode: FmtMode, opts: &FmtOptions) -> bool {
     let source = match std::fs::read_to_string(path) {
         Ok(s) => s,
         Err(e) => {
@@ -47,7 +70,7 @@ fn fmt_file_inner(path: &str, check_mode: bool, opts: &FmtOptions) -> bool {
         }
     };
 
-    if check_mode {
+    if mode.is_check() {
         if source != formatted {
             eprintln!("{path}: would be reformatted");
             return false;

--- a/crates/harn-cli/src/commands/check/mod.rs
+++ b/crates/harn-cli/src/commands/check/mod.rs
@@ -18,6 +18,6 @@ pub(crate) use config::{
     apply_harn_lint_config, build_module_graph, collect_cross_file_imports, collect_harn_targets,
     harn_lint_complexity_threshold, harn_lint_require_file_header,
 };
-pub(crate) use fmt::fmt_targets;
+pub(crate) use fmt::{fmt_targets, FmtMode};
 pub(crate) use host_capabilities::load_host_capabilities;
 pub(crate) use lint::{lint_file_inner, lint_fix_file};

--- a/crates/harn-cli/src/commands/orchestrator/common.rs
+++ b/crates/harn-cli/src/commands/orchestrator/common.rs
@@ -386,26 +386,9 @@ pub(crate) fn absolutize_from_cwd(path: &Path) -> Result<PathBuf, String> {
     Ok(candidate)
 }
 
-pub(super) fn format_timestamp(value: OffsetDateTime) -> String {
-    value.format(&Rfc3339).unwrap_or_else(|_| value.to_string())
-}
-
-pub(super) fn format_duration(value: StdDuration) -> String {
-    if value.as_secs() == 0 {
-        return format!("{}ms", value.as_millis());
-    }
-    let seconds = value.as_secs();
-    if seconds < 60 {
-        return format!("{seconds}s");
-    }
-    if seconds < 60 * 60 {
-        return format!("{}m", seconds / 60);
-    }
-    if seconds < 60 * 60 * 24 {
-        return format!("{}h", seconds / (60 * 60));
-    }
-    format!("{}d", seconds / (60 * 60 * 24))
-}
+pub(super) use crate::format::{
+    format_duration_coarse as format_duration, format_timestamp_rfc3339 as format_timestamp,
+};
 
 fn age_since(then: OffsetDateTime) -> StdDuration {
     let now = OffsetDateTime::now_utc();

--- a/crates/harn-cli/src/commands/portal/dlq.rs
+++ b/crates/harn-cli/src/commands/portal/dlq.rs
@@ -757,12 +757,7 @@ fn event_time(event: &LogEvent) -> String {
     format_ms(event.occurred_at_ms)
 }
 
-fn format_ms(ms: i64) -> String {
-    OffsetDateTime::from_unix_timestamp(ms.div_euclid(1000))
-        .unwrap_or(OffsetDateTime::UNIX_EPOCH)
-        .format(&Rfc3339)
-        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
-}
+use crate::format::format_unix_ms_rfc3339 as format_ms;
 
 fn parse_time_ms(raw: &str) -> Result<i64, String> {
     parse_time_ms_ok(raw).ok_or_else(|| format!("invalid RFC3339 timestamp '{raw}'"))

--- a/crates/harn-cli/src/commands/portal/util.rs
+++ b/crates/harn-cli/src/commands/portal/util.rs
@@ -133,15 +133,7 @@ pub(super) fn preview_text(text: &str) -> String {
     }
 }
 
-pub(super) fn format_duration(duration_ms: u64) -> String {
-    if duration_ms >= 60_000 {
-        format!("{:.1}m", duration_ms as f64 / 60_000.0)
-    } else if duration_ms >= 1_000 {
-        format!("{:.1}s", duration_ms as f64 / 1_000.0)
-    } else {
-        format!("{duration_ms}ms")
-    }
-}
+pub(super) use crate::format::format_duration_ms as format_duration;
 
 pub(super) fn is_completed_status(status: &str) -> bool {
     matches!(status, "complete" | "completed" | "success" | "verified")

--- a/crates/harn-cli/src/commands/trigger/replay.rs
+++ b/crates/harn-cli/src/commands/trigger/replay.rs
@@ -313,9 +313,7 @@ pub(crate) fn parse_timestamp(raw: &str) -> Result<OffsetDateTime, String> {
     ))
 }
 
-fn format_timestamp(value: OffsetDateTime) -> String {
-    value.format(&Rfc3339).unwrap_or_else(|_| value.to_string())
-}
+use crate::format::format_timestamp_rfc3339 as format_timestamp;
 
 async fn load_recorded_event(
     event_log: &Arc<AnyEventLog>,

--- a/crates/harn-cli/src/commands/trust.rs
+++ b/crates/harn-cli/src/commands/trust.rs
@@ -218,9 +218,7 @@ fn parse_timestamp(raw: &str) -> Result<OffsetDateTime, String> {
     ))
 }
 
-fn format_timestamp(value: OffsetDateTime) -> String {
-    value.format(&Rfc3339).unwrap_or_else(|_| value.to_string())
-}
+use crate::format::format_timestamp_rfc3339 as format_timestamp;
 
 fn compact_counts(counts: &BTreeMap<String, u64>) -> String {
     counts

--- a/crates/harn-cli/src/format.rs
+++ b/crates/harn-cli/src/format.rs
@@ -1,0 +1,94 @@
+//! Shared, lightweight formatting helpers for CLI commands.
+//!
+//! Multiple subcommands had grown private copies of the same RFC3339
+//! timestamp / human-friendly duration formatters; consolidating them
+//! here keeps formatting consistent across the user-facing surface.
+
+use std::time::Duration as StdDuration;
+
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+/// Render a UTC instant as RFC3339, falling back to `Display` if formatting
+/// fails (which `time` only does on internally inconsistent components).
+pub(crate) fn format_timestamp_rfc3339(value: OffsetDateTime) -> String {
+    value.format(&Rfc3339).unwrap_or_else(|_| value.to_string())
+}
+
+/// Render a unix-epoch millisecond timestamp as RFC3339.
+pub(crate) fn format_unix_ms_rfc3339(ms: i64) -> String {
+    let seconds = ms.div_euclid(1000);
+    let value = OffsetDateTime::from_unix_timestamp(seconds).unwrap_or(OffsetDateTime::UNIX_EPOCH);
+    format_timestamp_rfc3339(value)
+}
+
+/// Render a `std::time::Duration` as a coarse "5s / 2m / 3h / 1d" suffix.
+///
+/// Rounds toward zero on the chosen unit, mirroring the original behavior
+/// of the orchestrator command output.
+pub(crate) fn format_duration_coarse(value: StdDuration) -> String {
+    if value.as_secs() == 0 {
+        return format!("{}ms", value.as_millis());
+    }
+    let seconds = value.as_secs();
+    if seconds < 60 {
+        return format!("{seconds}s");
+    }
+    if seconds < 60 * 60 {
+        return format!("{}m", seconds / 60);
+    }
+    if seconds < 60 * 60 * 24 {
+        return format!("{}h", seconds / (60 * 60));
+    }
+    format!("{}d", seconds / (60 * 60 * 24))
+}
+
+/// Render a millisecond duration with a single decimal point of precision
+/// for the ">= 1s" cases (used by portal output).
+pub(crate) fn format_duration_ms(duration_ms: u64) -> String {
+    if duration_ms >= 60_000 {
+        format!("{:.1}m", duration_ms as f64 / 60_000.0)
+    } else if duration_ms >= 1_000 {
+        format!("{:.1}s", duration_ms as f64 / 1_000.0)
+    } else {
+        format!("{duration_ms}ms")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_uses_rfc3339() {
+        let value = OffsetDateTime::UNIX_EPOCH;
+        assert_eq!(format_timestamp_rfc3339(value), "1970-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn unix_ms_rounds_to_seconds() {
+        assert_eq!(format_unix_ms_rfc3339(0), "1970-01-01T00:00:00Z");
+        assert_eq!(format_unix_ms_rfc3339(1500), "1970-01-01T00:00:01Z");
+        // Negative ms before the epoch should not panic.
+        assert_eq!(format_unix_ms_rfc3339(-1), "1969-12-31T23:59:59Z");
+    }
+
+    #[test]
+    fn coarse_duration_picks_a_unit() {
+        assert_eq!(format_duration_coarse(StdDuration::from_millis(0)), "0ms");
+        assert_eq!(format_duration_coarse(StdDuration::from_secs(5)), "5s");
+        assert_eq!(format_duration_coarse(StdDuration::from_secs(120)), "2m");
+        assert_eq!(format_duration_coarse(StdDuration::from_secs(7200)), "2h");
+        assert_eq!(
+            format_duration_coarse(StdDuration::from_secs(86_400 * 3)),
+            "3d"
+        );
+    }
+
+    #[test]
+    fn ms_duration_uses_one_decimal_above_a_second() {
+        assert_eq!(format_duration_ms(500), "500ms");
+        assert_eq!(format_duration_ms(1_500), "1.5s");
+        assert_eq!(format_duration_ms(90_000), "1.5m");
+    }
+}

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -3,6 +3,7 @@ mod cli;
 mod commands;
 mod config;
 mod env_guard;
+mod format;
 mod package;
 mod skill_loader;
 mod skill_provenance;
@@ -302,7 +303,11 @@ async fn async_main() {
             if let Some(w) = args.separator_width {
                 opts.separator_width = w;
             }
-            commands::check::fmt_targets(&targets, args.check, &opts);
+            commands::check::fmt_targets(
+                &targets,
+                commands::check::FmtMode::from_check_flag(args.check),
+                &opts,
+            );
         }
         Command::Test(args) => {
             if args.target.as_deref() == Some("agents-conformance") {

--- a/crates/harn-cli/src/package.rs
+++ b/crates/harn-cli/src/package.rs
@@ -30,7 +30,6 @@ const TRIGGER_RETRY_MAX_LIMIT: u32 = 100;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Manifest {
-    #[allow(dead_code)]
     pub package: Option<PackageInfo>,
     #[serde(default)]
     pub dependencies: HashMap<String, Dependency>,
@@ -65,7 +64,6 @@ pub struct Manifest {
     /// Stable exported package modules. Keys are the logical import
     /// suffixes (e.g. `providers/openai`) and values are package-root-
     /// relative file paths. Consumers import them via `<package>/<key>`.
-    #[allow(dead_code)]
     #[serde(default)]
     pub exports: HashMap<String, String>,
     /// `[llm]` section — packaged provider definitions, aliases,

--- a/crates/harn-lint/src/harndoc.rs
+++ b/crates/harn-lint/src/harndoc.rs
@@ -274,7 +274,7 @@ pub(crate) fn extract_harndoc(source: &str, span: &Span) -> Option<String> {
         }
         start_idx -= 1;
     }
-    let mut body = Vec::new();
+    let mut body: Vec<String> = Vec::with_capacity((above_idx + 1).saturating_sub(start_idx));
     for (i, line) in lines.iter().enumerate().take(above_idx + 1).skip(start_idx) {
         let t = line.trim();
         let stripped: &str = if i == start_idx {
@@ -293,16 +293,17 @@ pub(crate) fn extract_harndoc(source: &str, span: &Span) -> Option<String> {
         };
         body.push(stripped.trim_end().to_string());
     }
-    // Trim leading/trailing empty lines.
-    while body.first().is_some_and(|s| s.is_empty()) {
-        body.remove(0);
+    // Trim leading/trailing empty lines without O(n) shifts.
+    let leading = body.iter().take_while(|s| s.is_empty()).count();
+    let trailing = body.iter().rev().take_while(|s| s.is_empty()).count();
+    if leading + trailing >= body.len() {
+        return None;
     }
-    while body.last().is_some_and(|s| s.is_empty()) {
-        body.pop();
-    }
-    if body.is_empty() {
+    let end = body.len() - trailing;
+    let trimmed: Vec<String> = body.drain(leading..end).collect();
+    if trimmed.is_empty() {
         None
     } else {
-        Some(body.join("\n"))
+        Some(trimmed.join("\n"))
     }
 }

--- a/crates/harn-serve/src/adapters/acp/execute.rs
+++ b/crates/harn-serve/src/adapters/acp/execute.rs
@@ -40,7 +40,9 @@ pub(super) async fn execute_chunk(
 
     if let Some(path) = source_path {
         let path_str = path.to_string_lossy();
-        let source = std::fs::read_to_string(path).unwrap_or_default();
+        let source = std::fs::read_to_string(path).map_err(|error| {
+            format!("failed to read pipeline source '{path_str}' for diagnostic context: {error}")
+        })?;
         vm.set_source_info(&path_str, &source);
         if let Some(parent) = path.parent() {
             if !parent.as_os_str().is_empty() {

--- a/crates/harn-vm/src/schema/tests.rs
+++ b/crates/harn-vm/src/schema/tests.rs
@@ -133,3 +133,50 @@ fn merge_schema_dicts_basic() {
     assert_eq!(merged.get("title").unwrap().display(), "Override");
     assert_eq!(merged.get("extra").unwrap().display(), "yes");
 }
+
+#[test]
+fn pattern_validation_accepts_and_rejects_consistently() {
+    // Exercises the cached-pattern path with repeated validations to make
+    // sure the cache returns equivalent results to a fresh compile.
+    let schema = make_vm_dict(vec![("type", s("string")), ("pattern", s(r"^[a-z]+\d+$"))]);
+    for _ in 0..3 {
+        assert!(schema_is_value(&s("abc123"), &schema).unwrap());
+        assert!(!schema_is_value(&s("ABC123"), &schema).unwrap());
+        assert!(!schema_is_value(&s("abc"), &schema).unwrap());
+    }
+}
+
+#[test]
+fn invalid_pattern_surfaces_a_clear_error() {
+    let schema = make_vm_dict(vec![
+        ("type", s("string")),
+        // An unclosed character class is rejected at compile time. The
+        // cache stores the error so we don't recompile every call.
+        ("pattern", s("[unclosed")),
+    ]);
+    let result = schema_result_value(&s("anything"), &schema, false);
+    let VmValue::EnumVariant {
+        variant, fields, ..
+    } = result
+    else {
+        panic!("expected Result variant");
+    };
+    assert_eq!(variant.as_ref(), "Err");
+    let payload_dict = fields
+        .first()
+        .and_then(|value| value.as_dict().cloned())
+        .expect("Err payload is a dict");
+    let errors = match payload_dict.get("errors") {
+        Some(VmValue::List(items)) => items.clone(),
+        other => panic!("expected errors list, got {other:?}"),
+    };
+    assert!(
+        errors
+            .iter()
+            .any(|err| err.display().contains("invalid regex pattern")),
+        "expected an invalid regex error, got: {errors:?}"
+    );
+    // Calling again hits the cached error path and must produce the same
+    // error rather than panicking on a re-compile.
+    let _ = schema_result_value(&s("anything"), &schema, false);
+}

--- a/crates/harn-vm/src/schema/validate.rs
+++ b/crates/harn-vm/src/schema/validate.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::rc::Rc;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::value::{values_equal, StructLayout, VmValue};
 
@@ -10,6 +12,44 @@ use super::type_check::{
     value_matches_type,
 };
 use super::{child_path, index_path, location_label, schema_bool, schema_i64, schema_number};
+
+// Schema patterns are typically a small, recurring set (e.g. `"^[a-z]+$"`),
+// and recompiling them on every value validated showed up as a hot-path
+// allocation cost. Cap the cache so adversarial schemas can't grow memory
+// unboundedly.
+const PATTERN_CACHE_LIMIT: usize = 256;
+
+#[derive(Clone)]
+enum PatternEntry {
+    Compiled(Arc<regex::Regex>),
+    Invalid(Arc<String>),
+}
+
+fn pattern_cache() -> &'static Mutex<HashMap<String, PatternEntry>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, PatternEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn cached_pattern(pattern: &str) -> PatternEntry {
+    if let Ok(mut cache) = pattern_cache().lock() {
+        if let Some(entry) = cache.get(pattern) {
+            return entry.clone();
+        }
+        let entry = match regex::Regex::new(pattern) {
+            Ok(re) => PatternEntry::Compiled(Arc::new(re)),
+            Err(error) => PatternEntry::Invalid(Arc::new(error.to_string())),
+        };
+        if cache.len() >= PATTERN_CACHE_LIMIT {
+            cache.clear();
+        }
+        cache.insert(pattern.to_string(), entry.clone());
+        return entry;
+    }
+    match regex::Regex::new(pattern) {
+        Ok(re) => PatternEntry::Compiled(Arc::new(re)),
+        Err(error) => PatternEntry::Invalid(Arc::new(error.to_string())),
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 pub(super) struct ValidationOptions {
@@ -207,8 +247,8 @@ fn validate_against_schema(
                 }
             }
             if let Some(VmValue::String(pattern)) = schema.get("pattern") {
-                match regex::Regex::new(pattern) {
-                    Ok(re) => {
+                match cached_pattern(pattern) {
+                    PatternEntry::Compiled(re) => {
                         if !re.is_match(text) {
                             errors.push(format!(
                                 "at {}: value does not match pattern '{}'",
@@ -217,7 +257,7 @@ fn validate_against_schema(
                             ));
                         }
                     }
-                    Err(error) => errors.push(format!(
+                    PatternEntry::Invalid(error) => errors.push(format!(
                         "at {}: invalid regex pattern '{}': {}",
                         location_label(path),
                         pattern,

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -2,7 +2,12 @@
 
 # Harn language specification
 
-Version: 1.0 (derived from implementation, 2026-04-01)
+Version: tracks the workspace `0.7.x` series; derived from the
+implementation and updated alongside it. The language is still
+pre-1.0 — surface-level breaking changes are possible between minor
+releases. See [`CHANGELOG.md`](../CHANGELOG.md) for what changed and
+when, and the `Stability` column in subsections below for per-feature
+guarantees.
 
 Harn is a pipeline-oriented programming language for orchestrating AI agents.
 It is implemented as a Rust workspace with a lexer, parser, type checker,

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -260,9 +260,12 @@ harn orchestrator serve \
 
 The default paths are:
 
-- `POST /mcp` for Streamable HTTP
-- `GET /sse` for legacy SSE streams
-- `POST /messages` for legacy SSE messages
+- `POST /mcp` for Streamable HTTP — the recommended transport for new
+  integrations.
+- `GET /sse` and `POST /messages` for the older split-channel SSE
+  transport, kept for compatibility with MCP clients that haven't yet
+  adopted Streamable HTTP. Both endpoints remain supported; they are
+  not slated for removal, but Streamable HTTP is preferred.
 
 Override them with `--mcp-path`, `--mcp-sse-path`, and
 `--mcp-messages-path`. Embedded MCP requires

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1,6 +1,11 @@
 # Harn language specification
 
-Version: 1.0 (derived from implementation, 2026-04-01)
+Version: tracks the workspace `0.7.x` series; derived from the
+implementation and updated alongside it. The language is still
+pre-1.0 — surface-level breaking changes are possible between minor
+releases. See [`CHANGELOG.md`](../CHANGELOG.md) for what changed and
+when, and the `Stability` column in subsections below for per-feature
+guarantees.
 
 Harn is a pipeline-oriented programming language for orchestrating AI agents.
 It is implemented as a Rust workspace with a lexer, parser, type checker,


### PR DESCRIPTION
## Summary

A holistic audit across the workspace surfaced a grab bag of correctness, performance, and DX issues. This PR ships them as one bundled cleanup. Each change is small and scoped tightly so they read independently.

### Performance
- **Cache schema `pattern` regexes in `harn-vm`.** `schema.is`, `schema.expect`, and `schema.result_of` previously called `regex::Regex::new` once per validated value. Compilation now happens at most once per pattern (capped 256-entry cache, cleared when full).

### Correctness
- **`harn-serve` ACP loader propagates source-read failures** instead of silently falling back to empty source — that fallback was producing diagnostics with no surrounding code.
- **`harn-lint` legacy-doc-comment scan no longer does O(n²) `Vec::remove(0)`** when trimming blank lines off a recovered `///` block.

### DX / cleanup
- **New `harn_cli::format` module** collapses five copies of timestamp/duration formatters across `trust`, `trigger replay`, `portal/{dlq,util}`, and `orchestrator/common`. Output is byte-identical.
- **`harn fmt` callsites now use `FmtMode::{Check, Write}`** instead of a positional bool flag.
- **CLI help text clarified** for `harn explain`, `harn doctor`, `harn publish`, and `harn trust-graph`.
- **`spec/HARN_SPEC.md` no longer claims "Version: 1.0".** Preamble identifies the spec as tracking the pre-1.0 0.7.x line and points at the changelog.
- **Orchestrator docs** clarify that the `/sse` + `/messages` endpoints are kept for compatibility, not slated for removal.
- **Removed stale `#[allow(dead_code)]`** on `Manifest::package` and `Manifest::exports` — both fields are read by package + doctor code.

### Tests
- Regression coverage for the regex cache: repeated valid validation works, and an unparsable pattern (e.g. `[unclosed`) returns a stable `invalid regex pattern` error rather than panicking on the cached re-fetch.
- `cargo nextest run --workspace`: 2698 passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.
- `markdownlint-cli2`: 0 errors across 157 files.

## Test plan
- [x] `cargo nextest run --workspace` (2698 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `npx markdownlint-cli2 "**/*.md"`
- [x] Pre-commit + pre-push hooks pass
- [x] Schema regex cache smoke test (added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)