### PR TITLE
Sharpen render_prompt / render preflight diagnostics (#771)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
-## v0.7.45
+## Unreleased
+
+### Changed
+
+- **Sharper diagnostics for missing `render_prompt` / `render` targets
+  (#771).** `harn check`'s preflight pass already validated literal
+  template paths, but the message read `preflight: render target ...`
+  regardless of which builtin was called and the help text only ever
+  pointed at the generic guidance. The diagnostic now names the actual
+  builtin (`render_prompt target ...` vs `render target ...`) and, when
+  the missing basename has a unique match elsewhere under the project
+  root, prepends a `did you mean '<rel>'? (found at <abs>)` suggestion
+  so the most common typo — file misfiled in a sibling directory —
+  becomes a one-keystroke fix. Raw string literals (`r"..."`) are also
+  validated alongside ordinary string literals; non-literal first
+  arguments (variables, interpolated strings) continue to be skipped
+  silently.
 
 ### Added
 

--- a/crates/harn-cli/src/commands/check/preflight.rs
+++ b/crates/harn-cli/src/commands/check/preflight.rs
@@ -143,8 +143,8 @@ fn scan_node_preflight(
             }
         }
         Node::FunctionCall { name, args } if name == "render" || name == "render_prompt" => {
-            if let Some(Node::StringLiteral(template_path)) = args.first().map(|arg| &arg.node) {
-                if let Some(asset_ref) = harn_modules::asset_paths::parse(template_path) {
+            if let Some(template_path) = args.first().and_then(literal_template_path) {
+                if let Some(asset_ref) = harn_modules::asset_paths::parse(&template_path) {
                     let anchor = file_path.parent().unwrap_or(Path::new("."));
                     if let Err(err) = harn_modules::asset_paths::resolve(&asset_ref, anchor) {
                         // Surface resolver errors (no project root, unknown
@@ -164,7 +164,7 @@ fn scan_node_preflight(
                         return;
                     }
                 }
-                let resolved = resolve_preflight_target(file_path, template_path, config);
+                let resolved = resolve_preflight_target(file_path, &template_path, config);
                 if let Some(existing) = resolved.iter().find(|path| path.exists()) {
                     if let Ok(body) = std::fs::read_to_string(existing) {
                         if let Err(err) = harn_vm::stdlib::template::validate_template_syntax(&body)
@@ -191,14 +191,11 @@ fn scan_node_preflight(
                         source: source.to_string(),
                         span: args[0].span,
                         message: format!(
-                            "preflight: render target '{}' does not exist at {}",
+                            "preflight: {name} target '{}' does not exist at {}",
                             template_path,
                             render_candidate_paths(&resolved)
                         ),
-                        help: Some(
-                            "keep template paths relative to the pipeline source file, or set [check].bundle_root / --bundle-root for bundled layouts. Use `@/...` for project-root paths"
-                                .to_string(),
-                        ),
+                        help: Some(render_target_miss_help(file_path, &template_path)),
                         tags: None,
                     });
                 }
@@ -1154,6 +1151,108 @@ pub(super) fn literal_string(node: &SNode) -> Option<String> {
     match &node.node {
         Node::StringLiteral(value) => Some(value.clone()),
         _ => None,
+    }
+}
+
+/// `render(...)` and `render_prompt(...)` accept either form of static
+/// string literal as their first argument. Both are statically
+/// verifiable; only `InterpolatedString` and arbitrary expressions are
+/// dynamic and must be skipped.
+fn literal_template_path(node: &SNode) -> Option<String> {
+    match &node.node {
+        Node::StringLiteral(value) | Node::RawStringLiteral(value) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+/// Build the help text for a missing `render(...)` / `render_prompt(...)`
+/// target. When the basename can be located somewhere else under the
+/// caller's project root (and the search produces a unique hit), prepend
+/// a "did you mean ...?" suggestion so the most common typo — file
+/// misfiled in a sibling directory — is one keystroke from a fix. Falls
+/// back to the generic guidance when the search is ambiguous or finds
+/// nothing.
+fn render_target_miss_help(file_path: &Path, template_path: &str) -> String {
+    const GENERIC: &str = "keep template paths relative to the pipeline source file, or set [check].bundle_root / --bundle-root for bundled layouts. Use `@/...` for project-root paths";
+    let Some(basename) = Path::new(template_path)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+    else {
+        return GENERIC.to_string();
+    };
+    let anchor = file_path.parent().unwrap_or(Path::new("."));
+    let project_root = harn_modules::asset_paths::find_project_root(anchor)
+        .unwrap_or_else(|| anchor.to_path_buf());
+    let Some(near) = find_unique_basename(&project_root, &basename) else {
+        return GENERIC.to_string();
+    };
+    let caller_dir = file_path.parent();
+    if near.parent() == caller_dir {
+        // The runtime would have found the file at the caller's dir
+        // anyway; avoid suggesting a redundant "did you mean ...?".
+        return GENERIC.to_string();
+    }
+    let display = near
+        .strip_prefix(&project_root)
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| near.display().to_string());
+    format!(
+        "did you mean '{display}'? (found at {}). Otherwise: {GENERIC}",
+        near.display()
+    )
+}
+
+/// Returns the unique location of `basename` under `root`, or `None`
+/// when the search finds zero or multiple matches. Skips standard
+/// build/dependency directories so a misfiled prompt is not lost in
+/// vendor noise.
+fn find_unique_basename(root: &Path, basename: &str) -> Option<PathBuf> {
+    let mut matches: Vec<PathBuf> = Vec::with_capacity(2);
+    walk_for_basename(root, basename, 0, 8, &mut matches);
+    (matches.len() == 1).then(|| matches.into_iter().next().expect("len == 1"))
+}
+
+fn walk_for_basename(
+    dir: &Path,
+    basename: &str,
+    depth: usize,
+    max_depth: usize,
+    out: &mut Vec<PathBuf>,
+) {
+    if depth > max_depth || out.len() > 1 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let name_str = file_name.to_string_lossy();
+        if name_str.starts_with('.')
+            || matches!(
+                name_str.as_ref(),
+                "target" | "node_modules" | "dist" | "build" | "out" | ".harn-runs"
+            )
+        {
+            continue;
+        }
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        let path = entry.path();
+        if file_type.is_file() {
+            if name_str == basename {
+                out.push(path);
+                if out.len() > 1 {
+                    return;
+                }
+            }
+        } else if file_type.is_dir() {
+            walk_for_basename(&path, basename, depth + 1, max_depth, out);
+            if out.len() > 1 {
+                return;
+            }
+        }
     }
 }
 

--- a/crates/harn-cli/src/commands/check/tests.rs
+++ b/crates/harn-cli/src/commands/check/tests.rs
@@ -75,6 +75,315 @@ pipeline main() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// Acceptance for issue #771: `render_prompt(...)` literal-string targets
+/// must be validated alongside `render(...)`, the diagnostic must name
+/// the actual builtin (`render_prompt`), and the resolved candidate path
+/// must be visible so the author can see exactly where the lookup tried
+/// to land.
+#[test]
+fn preflight_reports_missing_literal_render_prompt_target() {
+    let dir = unique_temp_dir("harn-check-render-prompt");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("chat.harn");
+    let source = r#"
+pub fn chat() -> string {
+  let trimmed = "hello"
+  return render_prompt("lane-classifier.harn.prompt", {task: trimmed})
+}
+"#;
+    let program = parse_program(source);
+    let diagnostics =
+        collect_preflight_diagnostics(&file, source, &program, &CheckConfig::default());
+    assert_eq!(diagnostics.len(), 1);
+    let diag = &diagnostics[0];
+    assert!(
+        diag.message.contains("render_prompt target"),
+        "expected diagnostic to name render_prompt, got: {}",
+        diag.message
+    );
+    assert!(
+        diag.message.contains("lane-classifier.harn.prompt"),
+        "expected diagnostic to include the literal path, got: {}",
+        diag.message
+    );
+    assert!(
+        diag.message.contains(
+            &dir.join("lane-classifier.harn.prompt")
+                .display()
+                .to_string()
+        ),
+        "expected diagnostic to include the resolved candidate path, got: {}",
+        diag.message
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Acceptance for issue #771: dynamic first arguments are not statically
+/// checkable, so `render_prompt(some_var, ...)` must be silently
+/// skipped — no false positives on legitimate dynamic dispatch.
+#[test]
+fn preflight_skips_non_literal_render_prompt_target() {
+    let dir = unique_temp_dir("harn-check-render-dynamic");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("main.harn");
+    let source = r#"
+pipeline main() {
+  let path = "missing.harn.prompt"
+  let prompt = render_prompt(path, {})
+  let key = "1"
+  let interp = render_prompt("missing_${key}.prompt", {})
+  println(prompt + interp)
+}
+"#;
+    let program = parse_program(source);
+    let diagnostics =
+        collect_preflight_diagnostics(&file, source, &program, &CheckConfig::default());
+    assert!(
+        diagnostics
+            .iter()
+            .all(|d| !d.message.contains("render_prompt target")),
+        "dynamic first args must not produce render-target diagnostics, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Acceptance for issue #771: raw string literals (`r"foo"`) are still
+/// statically known and must be validated like ordinary string literals.
+#[test]
+fn preflight_reports_missing_render_prompt_target_for_raw_string() {
+    let dir = unique_temp_dir("harn-check-render-raw");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("main.harn");
+    let source = r#"
+pipeline main() {
+  let prompt = render_prompt(r"missing.prompt", {})
+  println(prompt)
+}
+"#;
+    let program = parse_program(source);
+    let diagnostics =
+        collect_preflight_diagnostics(&file, source, &program, &CheckConfig::default());
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("render_prompt target")),
+        "raw string literal must trigger preflight check, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Acceptance for issue #771: the diagnostic span must point at the
+/// literal-string argument, not the whole `render_prompt(...)`
+/// expression — this is what enables an editor's quick-fix to jump
+/// straight to the path that needs editing.
+#[test]
+fn preflight_render_prompt_diagnostic_spans_literal_argument() {
+    let dir = unique_temp_dir("harn-check-render-span");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("main.harn");
+    let source = r#"
+pipeline main() {
+  let prompt = render_prompt("missing.prompt", {})
+  println(prompt)
+}
+"#;
+    let program = parse_program(source);
+    let diagnostics =
+        collect_preflight_diagnostics(&file, source, &program, &CheckConfig::default());
+    let render_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("render_prompt target"))
+        .expect("expected render_prompt target diagnostic");
+    let span_text = &source[render_diag.span.start..render_diag.span.end];
+    assert_eq!(
+        span_text, "\"missing.prompt\"",
+        "expected diagnostic span to cover only the literal-string argument"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Acceptance for issue #771: `@/<rel>` forms must resolve through the
+/// same `harn_modules::asset_paths` logic the runtime uses, so a missing
+/// project-root prompt fails the static check.
+#[test]
+fn preflight_reports_missing_project_root_asset_path() {
+    let dir = unique_temp_dir("harn-check-asset-projroot");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("harn.toml"), "[package]\nname = \"x\"\n").unwrap();
+    let file = dir.join("main.harn");
+    let source = r#"
+pipeline main() {
+  let prompt = render_prompt("@/prompts/missing.harn.prompt", {})
+  println(prompt)
+}
+"#;
+    let program = parse_program(source);
+    let diagnostics =
+        collect_preflight_diagnostics(&file, source, &program, &CheckConfig::default());
+    let render_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("render_prompt target"))
+        .expect("expected render_prompt target diagnostic for missing @/ asset");
+    assert!(
+        render_diag.message.contains(
+            &dir.join("prompts/missing.harn.prompt")
+                .display()
+                .to_string()
+        ),
+        "expected diagnostic to surface the resolved project-root path, got: {}",
+        render_diag.message
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Acceptance for issue #771: `@<alias>/<rel>` with an unknown alias
+/// must surface the asset-resolver's structural error so the user sees
+/// the missing `[asset_roots]` entry, not a generic file-existence
+/// message.
+#[test]
+fn preflight_reports_unknown_asset_alias() {
+    let dir = unique_temp_dir("harn-check-asset-alias");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("harn.toml"), "[package]\nname = \"x\"\n").unwrap();
+    let file = dir.join("main.harn");
+    let source = r#"
+pipeline main() {
+  let prompt = render_prompt("@unknown/foo.harn.prompt", {})
+  println(prompt)
+}
+"#;
+    let program = parse_program(source);
+    let diagnostics =
+        collect_preflight_diagnostics(&file, source, &program, &CheckConfig::default());
+    let alias_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("[asset_roots]"))
+        .expect("expected unknown-alias diagnostic citing [asset_roots]");
+    assert!(
+        alias_diag.message.contains("unknown"),
+        "expected diagnostic to name the missing alias, got: {}",
+        alias_diag.message
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Acceptance for issue #771: a defined `@<alias>/<rel>` resolves
+/// through the same logic the runtime uses, so a missing file under the
+/// alias is still flagged.
+#[test]
+fn preflight_reports_missing_aliased_asset_path() {
+    let dir = unique_temp_dir("harn-check-asset-alias-missing");
+    std::fs::create_dir_all(dir.join("src/prompts")).unwrap();
+    std::fs::write(
+        dir.join("harn.toml"),
+        "[package]\nname = \"x\"\n[asset_roots]\npartials = \"src/prompts\"\n",
+    )
+    .unwrap();
+    let file = dir.join("main.harn");
+    let source = r#"
+pipeline main() {
+  let prompt = render_prompt("@partials/missing.harn.prompt", {})
+  println(prompt)
+}
+"#;
+    let program = parse_program(source);
+    let diagnostics =
+        collect_preflight_diagnostics(&file, source, &program, &CheckConfig::default());
+    let render_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("render_prompt target"))
+        .expect("expected render_prompt target diagnostic for missing aliased asset");
+    assert!(
+        render_diag.message.contains(
+            &dir.join("src/prompts/missing.harn.prompt")
+                .display()
+                .to_string()
+        ),
+        "expected diagnostic to surface the alias-resolved path, got: {}",
+        render_diag.message
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Acceptance for issue #771 (the burin-code repro): when the missing
+/// prompt file exists elsewhere under the same project root, the
+/// diagnostic must include a "did you mean ...?" suggestion pointing at
+/// the misfiled location — that's the one-keystroke fix the issue is
+/// asking for.
+#[test]
+fn preflight_suggests_misfiled_render_prompt_target() {
+    let dir = unique_temp_dir("harn-check-render-suggest");
+    std::fs::create_dir_all(dir.join("lib/runtime")).unwrap();
+    std::fs::create_dir_all(dir.join("lib/mode")).unwrap();
+    std::fs::write(dir.join("harn.toml"), "[package]\nname = \"x\"\n").unwrap();
+    std::fs::write(
+        dir.join("lib/mode/lane-classifier.harn.prompt"),
+        "task: {{task}}\n",
+    )
+    .unwrap();
+    let file = dir.join("lib/runtime/chat.harn");
+    let source = r#"
+pub fn chat() -> string {
+  return render_prompt("lane-classifier.harn.prompt", {task: "hi"})
+}
+"#;
+    let program = parse_program(source);
+    let diagnostics =
+        collect_preflight_diagnostics(&file, source, &program, &CheckConfig::default());
+    let render_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("render_prompt target"))
+        .expect("expected render_prompt target diagnostic");
+    let help = render_diag
+        .help
+        .as_ref()
+        .expect("expected diagnostic help text");
+    assert!(
+        help.contains("did you mean"),
+        "expected help text to include 'did you mean' suggestion, got: {help}",
+    );
+    assert!(
+        help.contains("lib/mode/lane-classifier.harn.prompt"),
+        "expected help text to point at the misfiled location, got: {help}",
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Acceptance for issue #771: when no near-miss exists, the diagnostic
+/// must still emit useful generic guidance instead of the misleading
+/// "did you mean ..." prefix.
+#[test]
+fn preflight_omits_did_you_mean_when_no_near_miss() {
+    let dir = unique_temp_dir("harn-check-render-no-suggest");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("harn.toml"), "[package]\nname = \"x\"\n").unwrap();
+    let file = dir.join("main.harn");
+    let source = r#"
+pipeline main() {
+  let prompt = render_prompt("nowhere.harn.prompt", {})
+  println(prompt)
+}
+"#;
+    let program = parse_program(source);
+    let diagnostics =
+        collect_preflight_diagnostics(&file, source, &program, &CheckConfig::default());
+    let render_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("render_prompt target"))
+        .expect("expected render_prompt target diagnostic");
+    let help = render_diag
+        .help
+        .as_ref()
+        .expect("expected diagnostic help text");
+    assert!(
+        !help.contains("did you mean"),
+        "expected no 'did you mean' when there's no near-miss, got: {help}",
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn preflight_resolves_imports_with_implicit_harn_extension() {
     let dir = unique_temp_dir("harn-check");


### PR DESCRIPTION
Closes #771.

## Summary

`harn check`'s preflight pass already validated literal-string targets to `render(...)` and `render_prompt(...)`, but the diagnostic was generic enough that the failure mode the issue describes — file misfiled in a sibling directory — only became obvious at runtime. This sharpens the diagnostic.

- **Names the actual builtin:** `preflight: render_prompt target '...' does not exist at <path>` (vs. `render target ...`), so the reported error matches the call site.
- **"Did you mean ...?" suggestion:** when the basename has a unique match elsewhere under the project root, the help text now prepends `did you mean '<rel>'? (found at <abs>)`. The walker skips standard build/dependency directories (`target`, `node_modules`, `dist`, `build`, `out`, `.harn-runs`, hidden dirs) and only suggests on a unique match to avoid noise.
- **Raw string literals (`r"..."`)** are validated alongside ordinary string literals — same content at runtime, no reason to skip.
- **Non-literal first arguments** (variables, `${...}`-interpolated strings) continue to be skipped silently — the issue's `render_prompt(my_var, ...)` case stays a false-positive-free no-op.

## What this looks like

The burin-code repro from the issue (`pipelines/lib/runtime/chat.harn` calls `render_prompt("lane-classifier.harn.prompt", ...)` while the prompt is actually at `pipelines/lib/mode/lane-classifier.harn.prompt`):

```
error: preflight: render_prompt target 'lane-classifier.harn.prompt' does not exist at .../pipelines/lib/runtime/lane-classifier.harn.prompt
  --> pipelines/lib/runtime/chat.harn:3:30
   |
 3 |   let prompt = render_prompt("lane-classifier.harn.prompt", {task: trimmed})
   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ preflight
   = help: did you mean 'pipelines/lib/mode/lane-classifier.harn.prompt'? (found at .../pipelines/lib/mode/lane-classifier.harn.prompt). Otherwise: keep template paths relative to the pipeline source file, or set [check].bundle_root / --bundle-root for bundled layouts. Use `@/...` for project-root paths
```

## Acceptance coverage

Tests in [tests.rs](crates/harn-cli/src/commands/check/tests.rs) cover each criterion from the issue:

- [x] `harn check` on a workspace with a missing `render_prompt` literal target fails with a path-resolution diagnostic at the literal's source span
- [x] `render(...)` and `render_prompt(...)` are both validated, and the diagnostic names the actual builtin
- [x] Non-literal first args (variables, `${...}`-interpolated strings) are skipped without false positives
- [x] `@<alias>/<rel>` and `@/<rel>` forms resolve through `harn_modules::asset_paths` (same logic the runtime uses)
- [x] Diagnostic includes the resolved candidate path
- [x] Span lands on the literal-string argument (so editor quick-fixes can target just the path)
- [x] "Did you mean" suggestion fires only when a unique near-miss exists elsewhere under the project root
- [x] Unknown `@<alias>/...` surfaces the structural `[asset_roots]` error rather than a generic "does not exist" message

## Test plan

- [x] `cargo test -p harn-cli` — 309 + 309 dispatch passing (28 preflight tests including 9 new acceptance tests)
- [x] `make test` — 2701/2701 pass
- [x] `cargo run --bin harn -- test conformance` — 720/720 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `make lint-md` — clean
- [x] `make check-docs-snippets` — 446 checked, 0 failed
- [x] Manual end-to-end repro: `harn check` on the burin-code-style misfiled-prompt layout emits the new diagnostic with the "did you mean" hint pointing at the misfiled location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)