### PR TITLE
Add hostlib_ast_parse_errors and hostlib_ast_undefined_names (#773)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ granular archaeology.
 
 ### Added
 
+- **`hostlib_ast_parse_errors` and `hostlib_ast_undefined_names`
+  (#773).** Two new builtins on the `ast::*` hostlib surface so
+  burin-code's syntax-validation and tertiary-diagnostic paths can
+  delete their Swift `Sources/ASTEngine/TreeSitterParseErrors.swift` /
+  `TreeSitterUndefinedNames.swift` fallbacks. `parse_errors` walks the
+  tree-sitter parse for `ERROR` and `MISSING` nodes and emits a flat
+  list with 0-based row/column ranges, byte ranges, a short
+  human-readable `message`, the offending `snippet` (truncated to 60
+  chars, newlines escaped), and a `missing` flag — plus
+  `top_level_decl_count` keyed off the same per-language declaration
+  table the Swift fallback uses (TypeScript, JavaScript, Go, Rust,
+  Python, Java, C/C++, C#, Kotlin, Ruby, PHP, Scala). Both `content`
+  and `path` payloads are accepted; `language` accepts canonical wire
+  names ("python", "typescript") or bare extensions ("py", "ts") for
+  parity with the Swift call sites. `undefined_names` ports the
+  per-language profile walker for Python, JavaScript (incl. JSX),
+  TypeScript (incl. TSX), Go, and Ruby, dedupes references by name,
+  and filters against the curated builtin stop-list. Profiles for
+  unsupported languages return `supported = false` so callers fall
+  back to an external linter (LSP / ruff / tsc / go vet). New JSON
+  schemas under `crates/harn-hostlib/schemas/ast/parse_errors.*.json`
+  and `undefined_names.*.json` ship with the crate so downstream
+  schema-drift tests see the contract.
 - **Cross-slice predicate budget scheduler (#736).** `PredicateExecutor`
   now schedules predicate work fairly across multiple candidate slices
   via a new `execute_slices(slices)` entrypoint and the

--- a/crates/harn-hostlib/schemas/ast/parse_errors.request.json
+++ b/crates/harn-hostlib/schemas/ast/parse_errors.request.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/parse_errors.request.json",
+  "title": "ast.parse_errors request",
+  "description": "Surface tree-sitter ERROR and MISSING nodes plus the count of top-level declarations. Mirrors the Swift `TreeSitterParseErrors.analyze(content:extension:)` surface from burin-code's ASTEngine. Pass `content` for an in-memory string or `path` to read from disk; supply `language` (canonical name like \"python\" or a bare extension like \"py\") when the path-based grammar lookup is ambiguous.",
+  "type": "object",
+  "properties": {
+    "content": {
+      "type": "string",
+      "description": "Source text to parse. When supplied, takes precedence over `path`."
+    },
+    "path": {
+      "type": "string",
+      "description": "File path to read (used when `content` is omitted, and as a fallback for grammar detection when `language` is omitted)."
+    },
+    "language": {
+      "type": "string",
+      "description": "Language hint. Accepts canonical wire names (\"python\", \"typescript\") or bare extensions (\"py\", \"ts\")."
+    },
+    "max_bytes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Optional cap on bytes parsed; 0 means unlimited."
+    }
+  },
+  "anyOf": [
+    {"required": ["content"]},
+    {"required": ["path"]}
+  ],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/ast/parse_errors.response.json
+++ b/crates/harn-hostlib/schemas/ast/parse_errors.response.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/parse_errors.response.json",
+  "title": "ast.parse_errors response",
+  "description": "Tree-sitter ERROR / MISSING node list plus a top-level declaration count. Coordinates are 0-based to match the rest of `ast::*` builtins; consumers that need 1-based line numbers (the Swift fallback shape) add one to `start_row`. `supported` is false only when the grammar refuses to load — a clean parse with zero errors still returns `supported = true`.",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Echo of the request `path` (empty string when content-only)."
+    },
+    "language": {
+      "type": "string",
+      "description": "Resolved language wire name."
+    },
+    "supported": {
+      "type": "boolean",
+      "description": "False when the grammar could not be loaded; in that case `errors` is empty."
+    },
+    "had_errors": {
+      "type": "boolean",
+      "description": "True when the parse tree contains any ERROR or MISSING node."
+    },
+    "errors": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/ParseError" }
+    },
+    "top_level_decl_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Count of top-level declaration nodes per the language profile (mirrors Swift's `topLevelDeclCount`). Languages without an explicit declaration map return 0."
+    }
+  },
+  "required": ["path", "language", "supported", "had_errors", "errors", "top_level_decl_count"],
+  "additionalProperties": false,
+  "$defs": {
+    "ParseError": {
+      "type": "object",
+      "properties": {
+        "start_row": { "type": "integer", "minimum": 0 },
+        "start_col": { "type": "integer", "minimum": 0 },
+        "end_row": { "type": "integer", "minimum": 0 },
+        "end_col": { "type": "integer", "minimum": 0 },
+        "start_byte": { "type": "integer", "minimum": 0 },
+        "end_byte": { "type": "integer", "minimum": 0 },
+        "message": {
+          "type": "string",
+          "description": "Short human-readable description (e.g. \"unexpected '+' \", \"missing ')'\")."
+        },
+        "snippet": {
+          "type": "string",
+          "description": "First 60 chars of the offending node's source text, with newlines escaped as \"\\n\"."
+        },
+        "missing": {
+          "type": "boolean",
+          "description": "True when tree-sitter flagged this as a MISSING token (the grammar expected a token that wasn't present)."
+        }
+      },
+      "required": [
+        "start_row",
+        "start_col",
+        "end_row",
+        "end_col",
+        "start_byte",
+        "end_byte",
+        "message",
+        "snippet",
+        "missing"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/schemas/ast/undefined_names.request.json
+++ b/crates/harn-hostlib/schemas/ast/undefined_names.request.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/undefined_names.request.json",
+  "title": "ast.undefined_names request",
+  "description": "Language-aware single-file undefined-identifier detection. Mirrors the Swift `TreeSitterUndefinedNames.diagnose(content:extension:)` surface from burin-code's ASTEngine. Profiles ship for Python, JavaScript (incl. JSX), TypeScript (incl. TSX), Go, and Ruby; other languages return `supported = false` so callers can fall back to an external linter (LSP / ruff / tsc / go vet).",
+  "type": "object",
+  "properties": {
+    "content": {
+      "type": "string",
+      "description": "Source text to analyze. When supplied, takes precedence over `path`."
+    },
+    "path": {
+      "type": "string",
+      "description": "File path to read (used when `content` is omitted, and as a fallback for grammar detection when `language` is omitted)."
+    },
+    "language": {
+      "type": "string",
+      "description": "Language hint. Accepts canonical wire names (\"python\", \"typescript\") or bare extensions (\"py\", \"ts\")."
+    },
+    "max_bytes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Optional cap on bytes analyzed; 0 means unlimited."
+    }
+  },
+  "anyOf": [
+    {"required": ["content"]},
+    {"required": ["path"]}
+  ],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/ast/undefined_names.response.json
+++ b/crates/harn-hostlib/schemas/ast/undefined_names.response.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/undefined_names.response.json",
+  "title": "ast.undefined_names response",
+  "description": "Single-file undefined-identifier diagnostics. Coordinates are 0-based to match the rest of `ast::*` builtins. Diagnostics are deduplicated by name (first occurrence wins) so callers see one entry per missing import / typo, not one per usage. The Swift consumer maps `row + 1` / `column + 1` back into `UndefinedNameDiagnostic.line` / `.column`.",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string" },
+    "language": { "type": "string" },
+    "supported": {
+      "type": "boolean",
+      "description": "False when no profile exists for the resolved language. In that case `diagnostics` is empty."
+    },
+    "diagnostics": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Diagnostic" }
+    }
+  },
+  "required": ["path", "language", "supported", "diagnostics"],
+  "additionalProperties": false,
+  "$defs": {
+    "Diagnostic": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The undefined identifier."
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["identifier", "type"],
+          "description": "Reference flavor: `identifier` for value-side references, `type` for TypeScript type-only references."
+        },
+        "row": { "type": "integer", "minimum": 0 },
+        "column": { "type": "integer", "minimum": 0 },
+        "message": {
+          "type": "string",
+          "description": "Pre-formatted human-readable message (`undefined name 'foo'`)."
+        }
+      },
+      "required": ["name", "kind", "row", "column", "message"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/harn-hostlib/src/ast/mod.rs
+++ b/crates/harn-hostlib/src/ast/mod.rs
@@ -37,12 +37,14 @@ use crate::registry::{BuiltinRegistry, HostlibCapability, RegisteredBuiltin, Syn
 mod language;
 mod outline;
 mod parse;
+mod parse_errors;
 mod symbols;
 mod symbols_call;
 mod types;
+mod undefined_names;
 
 pub use language::Language;
-pub use types::{OutlineItem, ParsedNode, Symbol, SymbolKind};
+pub use types::{OutlineItem, ParseError, ParsedNode, Symbol, SymbolKind, UndefinedName};
 
 /// Programmatic entry point to the AST builtins. Embedders typically go
 /// through the registered builtins, but tests and tools that want
@@ -121,6 +123,18 @@ impl HostlibCapability for AstCapability {
             symbols_call::run,
         );
         register(registry, "hostlib_ast_outline", "outline", outline::run);
+        register(
+            registry,
+            "hostlib_ast_parse_errors",
+            "parse_errors",
+            parse_errors::run,
+        );
+        register(
+            registry,
+            "hostlib_ast_undefined_names",
+            "undefined_names",
+            undefined_names::run,
+        );
     }
 }
 

--- a/crates/harn-hostlib/src/ast/parse_errors.rs
+++ b/crates/harn-hostlib/src/ast/parse_errors.rs
@@ -1,0 +1,447 @@
+//! `ast.parse_errors` — surface tree-sitter `ERROR` and `MISSING` nodes
+//! plus the count of top-level declarations.
+//!
+//! Mirrors `TreeSitterParseErrors.analyze` in burin-code's Swift
+//! `ASTEngine` (`Sources/ASTEngine/TreeSitterParseErrors.swift`). The
+//! Swift surface returns a `(supported, errors, top_level_decl_count)`
+//! triple keyed off a file extension; this builtin accepts either an
+//! in-memory `content` string or a `path` plus an optional `language`
+//! hint. Coordinates here are 0-based to match the rest of the
+//! `ast::*` builtins.
+//!
+//! The counterpart Swift consumer maps `errors[].start_row + 1` and the
+//! `snippet` field back into `TreeSitterParseError.line` / `.snippet`,
+//! and `errors[].missing` flips through unchanged.
+
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use harn_vm::VmValue;
+use tree_sitter::Node;
+
+use crate::error::HostlibError;
+use crate::tools::args::{build_dict, dict_arg, optional_int, optional_string, str_value};
+
+use super::language::Language;
+use super::parse::{parse_source, read_source};
+use super::types::ParseError;
+
+const BUILTIN: &str = "hostlib_ast_parse_errors";
+
+pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN, args)?;
+    let dict = raw.as_ref();
+
+    let content = optional_string(BUILTIN, dict, "content")?;
+    let path_str = optional_string(BUILTIN, dict, "path")?;
+    let language_hint = optional_string(BUILTIN, dict, "language")?;
+    let max_bytes = optional_int(BUILTIN, dict, "max_bytes", 0)?;
+    if max_bytes < 0 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "max_bytes",
+            message: "must be >= 0".into(),
+        });
+    }
+
+    if content.is_none() && path_str.is_none() {
+        return Err(HostlibError::MissingParameter {
+            builtin: BUILTIN,
+            param: "content_or_path",
+        });
+    }
+
+    let language = resolve_language(path_str.as_deref(), language_hint.as_deref())?;
+    let source = match (&content, &path_str) {
+        (Some(text), _) => truncate_source(text, max_bytes as usize),
+        (None, Some(path)) => read_source(path, max_bytes as usize)?,
+        _ => unreachable!("guarded above"),
+    };
+
+    let tree = match parse_source(&source, language) {
+        Ok(tree) => tree,
+        Err(_) => {
+            return Ok(build_dict([
+                ("path", str_value(path_str.as_deref().unwrap_or(""))),
+                ("language", str_value(language.name())),
+                ("supported", VmValue::Bool(false)),
+                ("had_errors", VmValue::Bool(false)),
+                ("errors", VmValue::List(Rc::new(Vec::new()))),
+                ("top_level_decl_count", VmValue::Int(0)),
+            ]))
+        }
+    };
+
+    let mut errors: Vec<ParseError> = Vec::new();
+    collect_errors(tree.root_node(), source.as_bytes(), &mut errors);
+    let top_level = count_top_level_declarations(tree.root_node(), language);
+    let had_errors = tree.root_node().has_error() || !errors.is_empty();
+
+    let errors_list: Vec<VmValue> = errors.iter().map(ParseError::to_vm_value).collect();
+
+    Ok(build_dict([
+        ("path", str_value(path_str.as_deref().unwrap_or(""))),
+        ("language", str_value(language.name())),
+        ("supported", VmValue::Bool(true)),
+        ("had_errors", VmValue::Bool(had_errors)),
+        ("errors", VmValue::List(Rc::new(errors_list))),
+        ("top_level_decl_count", VmValue::Int(top_level as i64)),
+    ]))
+}
+
+fn resolve_language(
+    path: Option<&str>,
+    language_hint: Option<&str>,
+) -> Result<Language, HostlibError> {
+    if let Some(name) = language_hint.filter(|s| !s.is_empty()) {
+        // Accept either a canonical wire name or a bare extension here so
+        // callers that only know the file extension (e.g. burin-code's
+        // `extension` field) don't need a separate translation step.
+        if let Some(lang) = Language::from_name(name) {
+            return Ok(lang);
+        }
+        if let Some(lang) = Language::from_extension(name) {
+            return Ok(lang);
+        }
+    }
+    if let Some(p) = path.filter(|s| !s.is_empty()) {
+        if let Some(lang) = Language::detect(&PathBuf::from(p), language_hint) {
+            return Ok(lang);
+        }
+    }
+    Err(HostlibError::InvalidParameter {
+        builtin: BUILTIN,
+        param: "language",
+        message: format!(
+            "could not infer a tree-sitter grammar (path = `{}`, language = `{}`)",
+            path.unwrap_or(""),
+            language_hint.unwrap_or("")
+        ),
+    })
+}
+
+fn truncate_source(text: &str, max_bytes: usize) -> String {
+    if max_bytes == 0 || text.len() <= max_bytes {
+        return text.to_string();
+    }
+    // Trim to the last UTF-8 boundary at or below max_bytes so we never
+    // hand tree-sitter a half-codepoint.
+    let bytes = text.as_bytes();
+    let mut end = max_bytes;
+    while end > 0 && (bytes[end] & 0xC0) == 0x80 {
+        end -= 1;
+    }
+    String::from_utf8_lossy(&bytes[..end]).into_owned()
+}
+
+/// Depth-first walk; record any node that's flagged ERROR or MISSING.
+fn collect_errors(root: Node<'_>, source: &[u8], out: &mut Vec<ParseError>) {
+    let mut stack: Vec<Node<'_>> = vec![root];
+    while let Some(node) = stack.pop() {
+        let kind = node.kind();
+        if kind == "ERROR" || node.is_missing() {
+            let start = node.start_position();
+            let end = node.end_position();
+            let raw = source
+                .get(node.start_byte()..node.end_byte())
+                .and_then(|b| std::str::from_utf8(b).ok())
+                .unwrap_or("");
+            let snippet_raw: String = raw.chars().take(60).collect();
+            let snippet = snippet_raw.replace('\n', "\\n");
+            let message = if node.is_missing() {
+                // tree-sitter's `is_missing` marks the absence of a literal
+                // grammar token. The node `kind` is the token that should
+                // have been there.
+                format!("missing '{kind}'")
+            } else if snippet.is_empty() {
+                "unexpected syntax".to_string()
+            } else {
+                format!("unexpected '{snippet}'")
+            };
+            out.push(ParseError {
+                start_row: start.row as u32,
+                start_col: start.column as u32,
+                end_row: end.row as u32,
+                end_col: end.column as u32,
+                start_byte: node.start_byte() as u32,
+                end_byte: node.end_byte() as u32,
+                message,
+                snippet,
+                missing: node.is_missing(),
+            });
+        }
+        // Visit children in reverse so the natural order is preserved
+        // when popping off the stack.
+        let mut cursor = node.walk();
+        let mut children: Vec<Node<'_>> = Vec::new();
+        for child in node.children(&mut cursor) {
+            children.push(child);
+        }
+        for child in children.into_iter().rev() {
+            stack.push(child);
+        }
+    }
+    // Sort by start_byte so the wire order matches a left-to-right pass.
+    out.sort_by_key(|e| e.start_byte);
+}
+
+/// Count top-level declarations in `root` for `language`. Mirrors
+/// `TreeSitterParseErrors.declarationTypesMap` in
+/// `Sources/ASTEngine/TreeSitterParseErrors.swift` verbatim — the
+/// (decls, wrappers) pair determines what counts as a declaration and
+/// which container kinds get expanded one level (e.g. TypeScript's
+/// `export_statement` wrapping a `function_declaration`).
+fn count_top_level_declarations(root: Node<'_>, language: Language) -> u32 {
+    let (decls, wrappers) = declaration_kinds(language);
+    if decls.is_empty() {
+        return 0;
+    }
+    let mut count: u32 = 0;
+    let mut cursor = root.walk();
+    for child in root.children(&mut cursor) {
+        let kind = child.kind();
+        if decls.contains(&kind) {
+            count += 1;
+        }
+        if wrappers.contains(&kind) {
+            let mut inner = child.walk();
+            for grandchild in child.children(&mut inner) {
+                if decls.contains(&grandchild.kind()) {
+                    count += 1;
+                }
+            }
+        }
+    }
+    count
+}
+
+#[allow(clippy::type_complexity)]
+fn declaration_kinds(language: Language) -> (&'static [&'static str], &'static [&'static str]) {
+    match language {
+        Language::TypeScript | Language::Tsx => (
+            &[
+                "function_declaration",
+                "class_declaration",
+                "interface_declaration",
+                "enum_declaration",
+                "type_alias_declaration",
+                "lexical_declaration",
+                "export_statement",
+            ],
+            &["export_statement"],
+        ),
+        Language::JavaScript | Language::Jsx => (
+            &[
+                "function_declaration",
+                "class_declaration",
+                "lexical_declaration",
+                "export_statement",
+            ],
+            &["export_statement"],
+        ),
+        Language::Go => (
+            &[
+                "function_declaration",
+                "method_declaration",
+                "type_declaration",
+            ],
+            &[],
+        ),
+        Language::Rust => (
+            &[
+                "function_item",
+                "struct_item",
+                "enum_item",
+                "trait_item",
+                "impl_item",
+                "type_item",
+            ],
+            &["impl_item"],
+        ),
+        Language::Python => (
+            &[
+                "function_definition",
+                "class_definition",
+                "decorated_definition",
+            ],
+            &[],
+        ),
+        Language::Java => (
+            &[
+                "class_declaration",
+                "interface_declaration",
+                "enum_declaration",
+                "method_declaration",
+            ],
+            &[],
+        ),
+        Language::C => (
+            &[
+                "function_definition",
+                "struct_specifier",
+                "enum_specifier",
+                "type_definition",
+                "declaration",
+            ],
+            &[],
+        ),
+        Language::Cpp => (
+            &[
+                "function_definition",
+                "class_specifier",
+                "struct_specifier",
+                "enum_specifier",
+                "namespace_definition",
+                "template_declaration",
+            ],
+            &["namespace_definition"],
+        ),
+        Language::Kotlin => (
+            &[
+                "function_declaration",
+                "class_declaration",
+                "object_declaration",
+                "interface_declaration",
+            ],
+            &[],
+        ),
+        Language::Ruby => (
+            &["class", "module", "method", "singleton_method"],
+            &["module"],
+        ),
+        Language::CSharp => (
+            &[
+                "class_declaration",
+                "struct_declaration",
+                "interface_declaration",
+                "enum_declaration",
+                "method_declaration",
+                "namespace_declaration",
+            ],
+            &["namespace_declaration"],
+        ),
+        Language::Php => (
+            &[
+                "class_declaration",
+                "interface_declaration",
+                "enum_declaration",
+                "function_definition",
+                "method_declaration",
+            ],
+            &[],
+        ),
+        Language::Scala => (
+            &[
+                "class_definition",
+                "trait_definition",
+                "object_definition",
+                "enum_definition",
+                "function_definition",
+                "type_definition",
+            ],
+            &["object_definition"],
+        ),
+        // Languages without an explicit profile contribute no top-level
+        // count. The wire field stays present; consumers can ignore it.
+        Language::Bash
+        | Language::Swift
+        | Language::Zig
+        | Language::Elixir
+        | Language::Lua
+        | Language::Haskell
+        | Language::R => (&[], &[]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run_with(content: &str, language: &str) -> VmValue {
+        use std::collections::BTreeMap;
+        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        dict.insert("content".into(), VmValue::String(Rc::from(content)));
+        dict.insert("language".into(), VmValue::String(Rc::from(language)));
+        run(&[VmValue::Dict(Rc::new(dict))]).expect("parse_errors run")
+    }
+
+    fn list_field(value: &VmValue, key: &str) -> Rc<Vec<VmValue>> {
+        match value {
+            VmValue::Dict(d) => match d.get(key) {
+                Some(VmValue::List(l)) => l.clone(),
+                _ => panic!("missing list field {key} on {value:?}"),
+            },
+            _ => panic!("expected dict"),
+        }
+    }
+
+    #[test]
+    fn clean_python_source_has_no_errors() {
+        let result = run_with("x = 1\n", "python");
+        let errors = list_field(&result, "errors");
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn missing_close_paren_in_python_is_flagged() {
+        let result = run_with("def foo(\n    pass\n", "py");
+        let errors = list_field(&result, "errors");
+        assert!(!errors.is_empty(), "expected errors, got {errors:?}");
+        // At least one entry should be either ERROR or MISSING.
+        let any_missing = errors.iter().any(|err| match err {
+            VmValue::Dict(d) => matches!(d.get("missing"), Some(VmValue::Bool(true))),
+            _ => false,
+        });
+        let any_error_msg = errors.iter().any(|err| match err {
+            VmValue::Dict(d) => matches!(
+                d.get("message"),
+                Some(VmValue::String(s)) if !s.is_empty()
+            ),
+            _ => false,
+        });
+        assert!(any_missing || any_error_msg);
+    }
+
+    #[test]
+    fn typescript_top_level_decl_count_includes_exports() {
+        let source = "export function foo() {}\nexport const bar = 1;\n";
+        let result = run_with(source, "typescript");
+        let count = match &result {
+            VmValue::Dict(d) => match d.get("top_level_decl_count") {
+                Some(VmValue::Int(n)) => *n,
+                _ => panic!("missing top_level_decl_count"),
+            },
+            _ => panic!("expected dict"),
+        };
+        assert!(count >= 2, "expected >= 2 top-level decls, got {count}");
+    }
+
+    #[test]
+    fn rejects_when_no_content_or_path() {
+        use std::collections::BTreeMap;
+        let dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let err = run(&[VmValue::Dict(Rc::new(dict))]).expect_err("must reject empty payload");
+        match err {
+            HostlibError::MissingParameter { builtin, param } => {
+                assert_eq!(builtin, BUILTIN);
+                assert_eq!(param, "content_or_path");
+            }
+            other => panic!("expected MissingParameter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extension_is_accepted_as_language_alias() {
+        // burin-code passes the file extension (e.g. "py") rather than
+        // the canonical wire name; we accept both.
+        let result = run_with("x = 1\n", "py");
+        let language = match &result {
+            VmValue::Dict(d) => match d.get("language") {
+                Some(VmValue::String(s)) => s.to_string(),
+                _ => panic!("missing language"),
+            },
+            _ => panic!("expected dict"),
+        };
+        assert_eq!(language, "python");
+    }
+}

--- a/crates/harn-hostlib/src/ast/types.rs
+++ b/crates/harn-hostlib/src/ast/types.rs
@@ -171,3 +171,72 @@ impl ParsedNode {
         VmValue::Dict(Rc::new(dict))
     }
 }
+
+/// One ERROR / MISSING node from a tree-sitter parse. All row/column
+/// coordinates are 0-based, matching tree-sitter's native Point.
+///
+/// `message` is a short human-readable description (e.g. `"unexpected
+/// '+'"`, `"missing ')'"`). `snippet` is the raw source text covered by
+/// the node, truncated to 60 chars and with newlines escaped — kept
+/// separately so callers can render the message without re-parsing it.
+#[derive(Debug, Clone)]
+pub struct ParseError {
+    pub start_row: u32,
+    pub start_col: u32,
+    pub end_row: u32,
+    pub end_col: u32,
+    pub start_byte: u32,
+    pub end_byte: u32,
+    pub message: String,
+    pub snippet: String,
+    pub missing: bool,
+}
+
+impl ParseError {
+    pub fn to_vm_value(&self) -> VmValue {
+        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        dict.insert("start_row".into(), VmValue::Int(self.start_row as i64));
+        dict.insert("start_col".into(), VmValue::Int(self.start_col as i64));
+        dict.insert("end_row".into(), VmValue::Int(self.end_row as i64));
+        dict.insert("end_col".into(), VmValue::Int(self.end_col as i64));
+        dict.insert("start_byte".into(), VmValue::Int(self.start_byte as i64));
+        dict.insert("end_byte".into(), VmValue::Int(self.end_byte as i64));
+        dict.insert(
+            "message".into(),
+            VmValue::String(Rc::from(self.message.as_str())),
+        );
+        dict.insert(
+            "snippet".into(),
+            VmValue::String(Rc::from(self.snippet.as_str())),
+        );
+        dict.insert("missing".into(), VmValue::Bool(self.missing));
+        VmValue::Dict(Rc::new(dict))
+    }
+}
+
+/// Reference to an identifier that wasn't defined within the current
+/// file. Coordinates are 0-based. `kind` is `"identifier"` for value-side
+/// references and `"type"` for type-only references (TypeScript only).
+#[derive(Debug, Clone)]
+pub struct UndefinedName {
+    pub name: String,
+    pub kind: &'static str,
+    pub row: u32,
+    pub column: u32,
+}
+
+impl UndefinedName {
+    pub fn to_vm_value(&self) -> VmValue {
+        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        dict.insert("name".into(), VmValue::String(Rc::from(self.name.as_str())));
+        dict.insert("kind".into(), VmValue::String(Rc::from(self.kind)));
+        dict.insert("row".into(), VmValue::Int(self.row as i64));
+        dict.insert("column".into(), VmValue::Int(self.column as i64));
+        let message = format!("undefined name '{}'", self.name);
+        dict.insert(
+            "message".into(),
+            VmValue::String(Rc::from(message.as_str())),
+        );
+        VmValue::Dict(Rc::new(dict))
+    }
+}

--- a/crates/harn-hostlib/src/ast/undefined_names.rs
+++ b/crates/harn-hostlib/src/ast/undefined_names.rs
@@ -1,0 +1,1535 @@
+//! `ast.undefined_names` — language-aware undefined-identifier detection.
+//!
+//! Mirrors `TreeSitterUndefinedNames.diagnose` in burin-code's Swift
+//! `ASTEngine` (`Sources/ASTEngine/TreeSitterUndefinedNames.swift`). The
+//! contract:
+//!
+//! - Walk the tree-sitter parse, collect every identifier reference and
+//!   every name *defined* in this file (imports, parameters, locals,
+//!   class names, etc.).
+//! - Subtract definitions and a curated language-builtins stop-list from
+//!   the references to produce the "undefined name" set.
+//! - Deduplicate by name on first occurrence so callers see one
+//!   diagnostic per missing import / typo, not one per usage.
+//!
+//! Profiles ship for Python, JavaScript, TypeScript, Go, and Ruby —
+//! exactly the language set the Swift fallback supports today. Other
+//! languages return `supported = false` so callers can fall back to an
+//! external linter.
+//!
+//! Single-file scope is a deliberate restriction: cross-file resolution,
+//! re-exports, dynamic attribute access, and `exec`/`eval`-style name
+//! discovery are out of scope, matching the Swift surface.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use harn_vm::VmValue;
+use tree_sitter::{Node, Tree};
+
+use crate::error::HostlibError;
+use crate::tools::args::{build_dict, dict_arg, optional_int, optional_string, str_value};
+
+use super::language::Language;
+use super::parse::{parse_source, read_source};
+use super::types::UndefinedName;
+
+const BUILTIN: &str = "hostlib_ast_undefined_names";
+
+pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN, args)?;
+    let dict = raw.as_ref();
+
+    let content = optional_string(BUILTIN, dict, "content")?;
+    let path_str = optional_string(BUILTIN, dict, "path")?;
+    let language_hint = optional_string(BUILTIN, dict, "language")?;
+    let max_bytes = optional_int(BUILTIN, dict, "max_bytes", 0)?;
+    if max_bytes < 0 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param: "max_bytes",
+            message: "must be >= 0".into(),
+        });
+    }
+
+    if content.is_none() && path_str.is_none() {
+        return Err(HostlibError::MissingParameter {
+            builtin: BUILTIN,
+            param: "content_or_path",
+        });
+    }
+
+    let language = resolve_language(path_str.as_deref(), language_hint.as_deref())?;
+
+    if !is_supported(language) {
+        return Ok(unsupported_response(path_str.as_deref(), language));
+    }
+
+    let source = match (&content, &path_str) {
+        (Some(text), _) => clip(text, max_bytes as usize),
+        (None, Some(path)) => read_source(path, max_bytes as usize)?,
+        _ => unreachable!("guarded above"),
+    };
+
+    let tree = match parse_source(&source, language) {
+        Ok(tree) => tree,
+        Err(_) => {
+            return Ok(empty_response(path_str.as_deref(), language));
+        }
+    };
+
+    let diagnostics = diagnose(&tree, &source, language);
+    let dlist: Vec<VmValue> = diagnostics.iter().map(UndefinedName::to_vm_value).collect();
+
+    Ok(build_dict([
+        ("path", str_value(path_str.as_deref().unwrap_or(""))),
+        ("language", str_value(language.name())),
+        ("supported", VmValue::Bool(true)),
+        ("diagnostics", VmValue::List(Rc::new(dlist))),
+    ]))
+}
+
+fn unsupported_response(path: Option<&str>, language: Language) -> VmValue {
+    build_dict([
+        ("path", str_value(path.unwrap_or(""))),
+        ("language", str_value(language.name())),
+        ("supported", VmValue::Bool(false)),
+        ("diagnostics", VmValue::List(Rc::new(Vec::new()))),
+    ])
+}
+
+fn empty_response(path: Option<&str>, language: Language) -> VmValue {
+    build_dict([
+        ("path", str_value(path.unwrap_or(""))),
+        ("language", str_value(language.name())),
+        ("supported", VmValue::Bool(true)),
+        ("diagnostics", VmValue::List(Rc::new(Vec::new()))),
+    ])
+}
+
+fn resolve_language(
+    path: Option<&str>,
+    language_hint: Option<&str>,
+) -> Result<Language, HostlibError> {
+    if let Some(name) = language_hint.filter(|s| !s.is_empty()) {
+        if let Some(lang) = Language::from_name(name) {
+            return Ok(lang);
+        }
+        if let Some(lang) = Language::from_extension(name) {
+            return Ok(lang);
+        }
+    }
+    if let Some(p) = path.filter(|s| !s.is_empty()) {
+        if let Some(lang) = Language::detect(&PathBuf::from(p), language_hint) {
+            return Ok(lang);
+        }
+    }
+    Err(HostlibError::InvalidParameter {
+        builtin: BUILTIN,
+        param: "language",
+        message: format!(
+            "could not infer a tree-sitter grammar (path = `{}`, language = `{}`)",
+            path.unwrap_or(""),
+            language_hint.unwrap_or("")
+        ),
+    })
+}
+
+fn clip(text: &str, max_bytes: usize) -> String {
+    if max_bytes == 0 || text.len() <= max_bytes {
+        return text.to_string();
+    }
+    let bytes = text.as_bytes();
+    let mut end = max_bytes;
+    while end > 0 && (bytes[end] & 0xC0) == 0x80 {
+        end -= 1;
+    }
+    String::from_utf8_lossy(&bytes[..end]).into_owned()
+}
+
+/// Whether we ship a language profile for `language`.
+pub(super) fn is_supported(language: Language) -> bool {
+    matches!(
+        language,
+        Language::Python
+            | Language::JavaScript
+            | Language::Jsx
+            | Language::TypeScript
+            | Language::Tsx
+            | Language::Go
+            | Language::Ruby
+    )
+}
+
+/// Run the appropriate per-language profile against `tree` / `source`
+/// and return the deduplicated undefined-name list.
+fn diagnose(tree: &Tree, source: &str, language: Language) -> Vec<UndefinedName> {
+    let mut defined: HashSet<String> = HashSet::new();
+    let mut references: Vec<UndefinedName> = Vec::new();
+    let root = tree.root_node();
+
+    match language {
+        Language::Python => python::collect(root, source, &mut defined, &mut references),
+        Language::JavaScript | Language::Jsx => {
+            javascript::collect(root, source, &mut defined, &mut references, false)
+        }
+        Language::TypeScript | Language::Tsx => {
+            javascript::collect(root, source, &mut defined, &mut references, true)
+        }
+        Language::Go => go::collect(root, source, &mut defined, &mut references),
+        Language::Ruby => ruby::collect(root, source, &mut defined, &mut references),
+        _ => return Vec::new(),
+    }
+
+    let builtins = builtins_for(language);
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<UndefinedName> = Vec::new();
+    for refr in references {
+        if defined.contains(&refr.name) || builtins.contains(refr.name.as_str()) {
+            continue;
+        }
+        if !seen.insert(refr.name.clone()) {
+            continue;
+        }
+        out.push(refr);
+    }
+    out
+}
+
+fn builtins_for(language: Language) -> &'static HashSet<&'static str> {
+    match language {
+        Language::Python => &python::BUILTINS,
+        Language::JavaScript | Language::Jsx => &javascript::JS_BUILTINS,
+        Language::TypeScript | Language::Tsx => &javascript::TS_BUILTINS,
+        Language::Go => &go::BUILTINS,
+        Language::Ruby => &ruby::BUILTINS,
+        _ => &EMPTY_BUILTINS,
+    }
+}
+
+use once_cell::sync::Lazy;
+static EMPTY_BUILTINS: Lazy<HashSet<&'static str>> = Lazy::new(HashSet::new);
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+
+pub(super) fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {
+    let bytes = source.as_bytes();
+    let start = node.start_byte().min(bytes.len());
+    let end = node.end_byte().min(bytes.len());
+    std::str::from_utf8(&bytes[start..end]).unwrap_or("")
+}
+
+pub(super) fn position(node: Node<'_>) -> (u32, u32) {
+    let p = node.start_position();
+    (p.row as u32, p.column as u32)
+}
+
+/// Recursive depth-first walk over every child (named and anonymous).
+/// Threads the tree's lifetime through `F` so closures can capture nodes
+/// into outside containers (the `for<'r>` HRTB form would require any
+/// lifetime, breaking that).
+pub(super) fn walk<'tree, F>(node: Node<'tree>, visit: &mut F)
+where
+    F: FnMut(Node<'tree>),
+{
+    visit(node);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk(child, visit);
+    }
+}
+
+/// First identifier found in a depth-first walk of `node`.
+pub(super) fn first_identifier<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
+    if node.kind() == "identifier" {
+        return Some(node);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(found) = first_identifier(child) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Field name this node occupies in its parent, if any.
+pub(super) fn field_name(node: Node<'_>) -> Option<&'static str> {
+    let parent = node.parent()?;
+    let mut cursor = parent.walk();
+    for (idx, child) in parent.children(&mut cursor).enumerate() {
+        if child.id() == node.id() {
+            return parent.field_name_for_child(idx as u32);
+        }
+    }
+    None
+}
+
+fn add_reference(refs: &mut Vec<UndefinedName>, node: Node<'_>, source: &str, kind: &'static str) {
+    let (row, col) = position(node);
+    refs.push(UndefinedName {
+        name: node_text(node, source).to_string(),
+        kind,
+        row,
+        column: col,
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Profiles
+
+mod python {
+    use super::*;
+    use once_cell::sync::Lazy;
+
+    pub(super) static BUILTINS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+        [
+            "__name__",
+            "__main__",
+            "__file__",
+            "__doc__",
+            "__builtins__",
+            "__dict__",
+            "__init__",
+            "__class__",
+            "__all__",
+            "__author__",
+            "__version__",
+            "True",
+            "False",
+            "None",
+            "NotImplemented",
+            "Ellipsis",
+            "self",
+            "cls",
+            "super",
+            "abs",
+            "all",
+            "any",
+            "ascii",
+            "bin",
+            "bool",
+            "breakpoint",
+            "bytearray",
+            "bytes",
+            "callable",
+            "chr",
+            "classmethod",
+            "compile",
+            "complex",
+            "delattr",
+            "dict",
+            "dir",
+            "divmod",
+            "enumerate",
+            "eval",
+            "exec",
+            "exit",
+            "filter",
+            "float",
+            "format",
+            "frozenset",
+            "getattr",
+            "globals",
+            "hasattr",
+            "hash",
+            "help",
+            "hex",
+            "id",
+            "input",
+            "int",
+            "isinstance",
+            "issubclass",
+            "iter",
+            "len",
+            "list",
+            "locals",
+            "map",
+            "max",
+            "memoryview",
+            "min",
+            "next",
+            "object",
+            "oct",
+            "open",
+            "ord",
+            "pow",
+            "print",
+            "property",
+            "range",
+            "repr",
+            "reversed",
+            "round",
+            "set",
+            "setattr",
+            "slice",
+            "sorted",
+            "staticmethod",
+            "str",
+            "sum",
+            "tuple",
+            "type",
+            "vars",
+            "zip",
+            "Exception",
+            "BaseException",
+            "ValueError",
+            "TypeError",
+            "KeyError",
+            "IndexError",
+            "AttributeError",
+            "RuntimeError",
+            "StopIteration",
+            "NotImplementedError",
+            "FileNotFoundError",
+            "IOError",
+            "OSError",
+            "ArithmeticError",
+            "ZeroDivisionError",
+            "OverflowError",
+            "NameError",
+            "UnicodeDecodeError",
+            "UnicodeEncodeError",
+            "ImportError",
+            "ModuleNotFoundError",
+            "GeneratorExit",
+            "KeyboardInterrupt",
+            "SystemExit",
+            "match",
+            "case",
+        ]
+        .into_iter()
+        .collect()
+    });
+
+    pub(super) fn collect(
+        root: Node<'_>,
+        source: &str,
+        defined: &mut HashSet<String>,
+        refs: &mut Vec<UndefinedName>,
+    ) {
+        visit(root, source, defined, refs);
+    }
+
+    fn visit(
+        node: Node<'_>,
+        source: &str,
+        defined: &mut HashSet<String>,
+        refs: &mut Vec<UndefinedName>,
+    ) {
+        match node.kind() {
+            "function_definition" | "lambda" => {
+                if node.kind() == "function_definition" {
+                    if let Some(name) = node.child_by_field_name("name") {
+                        defined.insert(node_text(name, source).to_string());
+                    }
+                }
+                if let Some(params) = node.child_by_field_name("parameters") {
+                    collect_python_parameters(params, source, defined);
+                    // Defaults are *references*: walk the parameter list
+                    // and visit any default value node we find.
+                    let mut visit_defaults = |child: Node<'_>| {
+                        let t = child.kind();
+                        let has_default =
+                            t == "default_parameter" || t == "typed_default_parameter";
+                        if has_default {
+                            if let Some(value) = child.child_by_field_name("value") {
+                                visit(value, source, defined, refs);
+                            }
+                        }
+                    };
+                    walk(params, &mut visit_defaults);
+                }
+                if let Some(rt) = node.child_by_field_name("return_type") {
+                    visit(rt, source, defined, refs);
+                }
+                if let Some(body) = node.child_by_field_name("body") {
+                    visit(body, source, defined, refs);
+                }
+            }
+            "class_definition" => {
+                if let Some(name) = node.child_by_field_name("name") {
+                    defined.insert(node_text(name, source).to_string());
+                }
+                if let Some(bases) = node.child_by_field_name("superclasses") {
+                    visit(bases, source, defined, refs);
+                }
+                if let Some(body) = node.child_by_field_name("body") {
+                    visit(body, source, defined, refs);
+                }
+            }
+            "import_statement" | "import_from_statement" => {
+                collect_python_imports(node, source, defined);
+            }
+            "for_statement" | "for_in_clause" => {
+                if let Some(target) = node.child_by_field_name("left") {
+                    collect_python_targets(target, source, defined);
+                }
+                if let Some(right) = node.child_by_field_name("right") {
+                    visit(right, source, defined, refs);
+                }
+                if let Some(body) = node.child_by_field_name("body") {
+                    visit(body, source, defined, refs);
+                }
+            }
+            "assignment" => {
+                if let Some(right) = node.child_by_field_name("right") {
+                    visit(right, source, defined, refs);
+                }
+                if let Some(left) = node.child_by_field_name("left") {
+                    collect_python_targets(left, source, defined);
+                }
+            }
+            "named_expression" => {
+                if let Some(value) = node.child_by_field_name("value") {
+                    visit(value, source, defined, refs);
+                }
+                if let Some(name) = node.child_by_field_name("name") {
+                    defined.insert(node_text(name, source).to_string());
+                }
+            }
+            "global_statement" | "nonlocal_statement" => {
+                let mut cursor = node.walk();
+                for child in node.named_children(&mut cursor) {
+                    if child.kind() == "identifier" {
+                        defined.insert(node_text(child, source).to_string());
+                    }
+                }
+            }
+            "with_statement" => {
+                let mut cursor = node.walk();
+                for item in node.named_children(&mut cursor) {
+                    let mut vis = |child: Node<'_>| {
+                        if child.kind() == "as_pattern_target" {
+                            if let Some(ident) = first_identifier(child) {
+                                defined.insert(node_text(ident, source).to_string());
+                            }
+                        }
+                    };
+                    walk(item, &mut vis);
+                    if let Some(value) = item.child_by_field_name("value") {
+                        visit(value, source, defined, refs);
+                    }
+                }
+            }
+            "except_clause" => {
+                let mut saw_as = false;
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    if child.kind() == "as" {
+                        saw_as = true;
+                        continue;
+                    }
+                    if saw_as && child.kind() == "identifier" {
+                        defined.insert(node_text(child, source).to_string());
+                        saw_as = false;
+                    } else if child.is_named() {
+                        visit(child, source, defined, refs);
+                    }
+                }
+            }
+            "attribute" => {
+                if let Some(object) = node.child_by_field_name("object") {
+                    visit(object, source, defined, refs);
+                }
+            }
+            "keyword_argument" => {
+                if let Some(value) = node.child_by_field_name("value") {
+                    visit(value, source, defined, refs);
+                }
+            }
+            "identifier" => {
+                add_reference(refs, node, source, "identifier");
+            }
+            _ => {
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    visit(child, source, defined, refs);
+                }
+            }
+        }
+    }
+
+    fn collect_python_parameters(params: Node<'_>, source: &str, defined: &mut HashSet<String>) {
+        let mut cursor = params.walk();
+        for child in params.named_children(&mut cursor) {
+            match child.kind() {
+                "identifier" => {
+                    defined.insert(node_text(child, source).to_string());
+                }
+                "typed_parameter"
+                | "default_parameter"
+                | "typed_default_parameter"
+                | "list_splat_pattern"
+                | "dictionary_splat_pattern" => {
+                    if let Some(name) = child.child_by_field_name("name") {
+                        defined.insert(node_text(name, source).to_string());
+                    } else if let Some(ident) = first_identifier(child) {
+                        defined.insert(node_text(ident, source).to_string());
+                    }
+                }
+                _ => {
+                    if let Some(ident) = first_identifier(child) {
+                        defined.insert(node_text(ident, source).to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_python_imports(node: Node<'_>, source: &str, defined: &mut HashSet<String>) {
+        // Bind aliases and bare module names from anywhere in the import.
+        let mut vis = |child: Node<'_>| match child.kind() {
+            "aliased_import" => {
+                if let Some(alias) = child.child_by_field_name("alias") {
+                    defined.insert(node_text(alias, source).to_string());
+                }
+            }
+            "dotted_name" => {
+                if let Some(first) = child.named_child(0) {
+                    defined.insert(node_text(first, source).to_string());
+                }
+            }
+            _ => {}
+        };
+        walk(node, &mut vis);
+
+        // `from x import y, z` — direct identifiers after `import`.
+        if node.kind() == "import_from_statement" {
+            let mut saw_import = false;
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if child.kind() == "import" {
+                    saw_import = true;
+                    continue;
+                }
+                if saw_import {
+                    if child.kind() == "identifier" {
+                        defined.insert(node_text(child, source).to_string());
+                    } else if child.kind() == "dotted_name" {
+                        let count = child.named_child_count();
+                        if count > 0 {
+                            if let Some(last) = child.named_child((count - 1) as u32) {
+                                defined.insert(node_text(last, source).to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_python_targets(node: Node<'_>, source: &str, defined: &mut HashSet<String>) {
+        match node.kind() {
+            "identifier" => {
+                defined.insert(node_text(node, source).to_string());
+            }
+            "pattern_list" | "tuple_pattern" | "list_pattern" => {
+                let mut cursor = node.walk();
+                for child in node.named_children(&mut cursor) {
+                    collect_python_targets(child, source, defined);
+                }
+            }
+            "list_splat_pattern" => {
+                if let Some(ident) = first_identifier(node) {
+                    defined.insert(node_text(ident, source).to_string());
+                }
+            }
+            // Assignment to `a.b` / `a[b]` doesn't bind a new local.
+            "attribute" | "subscript" => {}
+            _ => {}
+        }
+    }
+}
+
+mod javascript {
+    use super::*;
+    use once_cell::sync::Lazy;
+
+    pub(super) static JS_BUILTINS: Lazy<HashSet<&'static str>> = Lazy::new(base_builtins);
+    pub(super) static TS_BUILTINS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+        let mut set = base_builtins();
+        // TS-only builtin type names so references don't fire on every
+        // `string` / `number`.
+        for extra in [
+            "string",
+            "number",
+            "boolean",
+            "any",
+            "unknown",
+            "never",
+            "void",
+            "object",
+            "bigint",
+            "symbol",
+            "Record",
+            "Partial",
+            "Required",
+            "Readonly",
+            "Pick",
+            "Omit",
+            "Exclude",
+            "Extract",
+            "NonNullable",
+            "Parameters",
+            "ReturnType",
+            "InstanceType",
+            "ThisParameterType",
+            "OmitThisParameter",
+            "ThisType",
+            "Awaited",
+            "Array",
+        ] {
+            set.insert(extra);
+        }
+        set
+    });
+
+    fn base_builtins() -> HashSet<&'static str> {
+        [
+            "undefined",
+            "null",
+            "true",
+            "false",
+            "this",
+            "arguments",
+            "globalThis",
+            "console",
+            "process",
+            "window",
+            "document",
+            "navigator",
+            "setTimeout",
+            "clearTimeout",
+            "setInterval",
+            "clearInterval",
+            "setImmediate",
+            "queueMicrotask",
+            "requestAnimationFrame",
+            "Promise",
+            "Error",
+            "TypeError",
+            "RangeError",
+            "SyntaxError",
+            "ReferenceError",
+            "URIError",
+            "EvalError",
+            "Array",
+            "Object",
+            "String",
+            "Number",
+            "Boolean",
+            "Symbol",
+            "BigInt",
+            "RegExp",
+            "Date",
+            "Math",
+            "JSON",
+            "Map",
+            "Set",
+            "WeakMap",
+            "WeakSet",
+            "Int8Array",
+            "Int16Array",
+            "Int32Array",
+            "Uint8Array",
+            "Uint16Array",
+            "Uint32Array",
+            "Uint8ClampedArray",
+            "Float32Array",
+            "Float64Array",
+            "ArrayBuffer",
+            "DataView",
+            "SharedArrayBuffer",
+            "Atomics",
+            "parseInt",
+            "parseFloat",
+            "isNaN",
+            "isFinite",
+            "encodeURI",
+            "decodeURI",
+            "encodeURIComponent",
+            "decodeURIComponent",
+            "escape",
+            "unescape",
+            "NaN",
+            "Infinity",
+            "require",
+            "module",
+            "exports",
+            "__dirname",
+            "__filename",
+            "Buffer",
+            "React",
+            "JSX",
+            "async",
+            "await",
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    pub(super) fn collect(
+        root: Node<'_>,
+        source: &str,
+        defined: &mut HashSet<String>,
+        refs: &mut Vec<UndefinedName>,
+        typescript: bool,
+    ) {
+        visit(root, source, defined, refs, typescript);
+    }
+
+    fn bind_pattern(
+        node: Node<'_>,
+        source: &str,
+        defined: &mut HashSet<String>,
+        refs: &mut Vec<UndefinedName>,
+        typescript: bool,
+    ) {
+        match node.kind() {
+            "identifier" | "shorthand_property_identifier_pattern" => {
+                defined.insert(node_text(node, source).to_string());
+            }
+            "array_pattern" | "object_pattern" => {
+                let mut cursor = node.walk();
+                for child in node.named_children(&mut cursor) {
+                    bind_pattern(child, source, defined, refs, typescript);
+                }
+            }
+            "assignment_pattern" => {
+                if let Some(left) = node.child_by_field_name("left") {
+                    bind_pattern(left, source, defined, refs, typescript);
+                }
+                if let Some(right) = node.child_by_field_name("right") {
+                    visit(right, source, defined, refs, typescript);
+                }
+            }
+            "rest_pattern" => {
+                if let Some(ident) = first_identifier(node) {
+                    defined.insert(node_text(ident, source).to_string());
+                }
+            }
+            "pair_pattern" => {
+                if let Some(value) = node.child_by_field_name("value") {
+                    bind_pattern(value, source, defined, refs, typescript);
+                }
+            }
+            _ => {
+                if let Some(ident) = first_identifier(node) {
+                    defined.insert(node_text(ident, source).to_string());
+                }
+            }
+        }
+    }
+
+    fn visit(
+        node: Node<'_>,
+        source: &str,
+        defined: &mut HashSet<String>,
+        refs: &mut Vec<UndefinedName>,
+        typescript: bool,
+    ) {
+        match node.kind() {
+            "import_statement" => {
+                let mut vis = |child: Node<'_>| match child.kind() {
+                    "identifier" if field_name(child) != Some("source") => {
+                        defined.insert(node_text(child, source).to_string());
+                    }
+                    "namespace_import" => {
+                        if let Some(ident) = first_identifier(child) {
+                            defined.insert(node_text(ident, source).to_string());
+                        }
+                    }
+                    "import_specifier" => {
+                        if let Some(alias) = child.child_by_field_name("alias") {
+                            defined.insert(node_text(alias, source).to_string());
+                        } else if let Some(name) = child.child_by_field_name("name") {
+                            defined.insert(node_text(name, source).to_string());
+                        }
+                    }
+                    _ => {}
+                };
+                walk(node, &mut vis);
+            }
+            "function_declaration" | "generator_function_declaration" => {
+                if let Some(name) = node.child_by_field_name("name") {
+                    defined.insert(node_text(name, source).to_string());
+                }
+                if let Some(params) = node.child_by_field_name("parameters") {
+                    collect_js_parameters(params, source, defined);
+                    visit_param_annotations(params, source, defined, refs, typescript);
+                }
+                if let Some(body) = node.child_by_field_name("body") {
+                    visit(body, source, defined, refs, typescript);
+                }
+            }
+            "class_declaration" | "class" => {
+                if let Some(name) = node.child_by_field_name("name") {
+                    defined.insert(node_text(name, source).to_string());
+                }
+                if let Some(superclass) = node.child_by_field_name("superclass") {
+                    visit(superclass, source, defined, refs, typescript);
+                }
+                if let Some(body) = node.child_by_field_name("body") {
+                    visit(body, source, defined, refs, typescript);
+                }
+            }
+            "interface_declaration" | "type_alias_declaration" | "enum_declaration" => {
+                let name_node = node.child_by_field_name("name");
+                if let Some(name) = name_node {
+                    defined.insert(node_text(name, source).to_string());
+                }
+                let mut cursor = node.walk();
+                for child in node.named_children(&mut cursor) {
+                    if name_node.map(|n| n.id()) != Some(child.id()) {
+                        visit(child, source, defined, refs, typescript);
+                    }
+                }
+            }
+            "variable_declarator" => {
+                if let Some(value) = node.child_by_field_name("value") {
+                    visit(value, source, defined, refs, typescript);
+                }
+                if let Some(name) = node.child_by_field_name("name") {
+                    bind_pattern(name, source, defined, refs, typescript);
+                }
+            }
+            "arrow_function"
+            | "function"
+            | "method_definition"
+            | "function_expression"
+            | "generator_function" => {
+                if let Some(params) = node.child_by_field_name("parameters") {
+                    collect_js_parameters(params, source, defined);
+                    visit_param_annotations(params, source, defined, refs, typescript);
+                } else if let Some(param) = node.child_by_field_name("parameter") {
+                    bind_pattern(param, source, defined, refs, typescript);
+                }
+                if let Some(body) = node.child_by_field_name("body") {
+                    visit(body, source, defined, refs, typescript);
+                }
+            }
+            "catch_clause" => {
+                if let Some(param) = node.child_by_field_name("parameter") {
+                    bind_pattern(param, source, defined, refs, typescript);
+                }
+                if let Some(body) = node.child_by_field_name("body") {
+                    visit(body, source, defined, refs, typescript);
+                }
+            }
+            "for_in_statement" | "for_statement" => {
+                if let Some(left) = node.child_by_field_name("left") {
+                    if matches!(left.kind(), "variable_declaration" | "lexical_declaration") {
+                        let mut vis = |child: Node<'_>| {
+                            if child.kind() == "variable_declarator" {
+                                if let Some(name) = child.child_by_field_name("name") {
+                                    bind_pattern(name, source, defined, refs, typescript);
+                                }
+                            }
+                        };
+                        walk(left, &mut vis);
+                    } else {
+                        bind_pattern(left, source, defined, refs, typescript);
+                    }
+                }
+                for fname in [
+                    "right",
+                    "condition",
+                    "update",
+                    "initializer",
+                    "increment",
+                    "body",
+                ] {
+                    if let Some(child) = node.child_by_field_name(fname) {
+                        visit(child, source, defined, refs, typescript);
+                    }
+                }
+            }
+            "member_expression" => {
+                if let Some(object) = node.child_by_field_name("object") {
+                    visit(object, source, defined, refs, typescript);
+                }
+            }
+            "subscript_expression" => {
+                if let Some(object) = node.child_by_field_name("object") {
+                    visit(object, source, defined, refs, typescript);
+                }
+                if let Some(index) = node.child_by_field_name("index") {
+                    visit(index, source, defined, refs, typescript);
+                }
+            }
+            "property_identifier"
+            | "shorthand_property_identifier"
+            | "statement_identifier"
+            | "label_identifier" => {}
+            "pair" => {
+                if let Some(value) = node.child_by_field_name("value") {
+                    visit(value, source, defined, refs, typescript);
+                }
+            }
+            "jsx_attribute" => {
+                if let Some(value) = node.child_by_field_name("value") {
+                    visit(value, source, defined, refs, typescript);
+                }
+            }
+            "type_identifier" => {
+                if typescript {
+                    add_reference(refs, node, source, "type");
+                }
+            }
+            "identifier" => {
+                add_reference(refs, node, source, "identifier");
+            }
+            _ => {
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    visit(child, source, defined, refs, typescript);
+                }
+            }
+        }
+    }
+
+    fn collect_js_parameters(params: Node<'_>, source: &str, defined: &mut HashSet<String>) {
+        let mut vis = |child: Node<'_>| match child.kind() {
+            "identifier" if !is_inside_type_annotation(child) => {
+                defined.insert(node_text(child, source).to_string());
+            }
+            "shorthand_property_identifier_pattern" => {
+                defined.insert(node_text(child, source).to_string());
+            }
+            _ => {}
+        };
+        walk(params, &mut vis);
+    }
+
+    fn is_inside_type_annotation(node: Node<'_>) -> bool {
+        let mut current = node.parent();
+        while let Some(n) = current {
+            match n.kind() {
+                "type_annotation" | "type_parameters" | "generic_type" | "predefined_type"
+                | "type_arguments" => return true,
+                _ => {}
+            }
+            current = n.parent();
+        }
+        false
+    }
+
+    fn visit_param_annotations<'tree>(
+        params: Node<'tree>,
+        source: &str,
+        defined: &mut HashSet<String>,
+        refs: &mut Vec<UndefinedName>,
+        typescript: bool,
+    ) {
+        // Collect candidate annotation/default nodes first so we don't
+        // pull `defined`/`refs` aliases through the closure during the
+        // walk (which would clash with the recursive `visit` borrows).
+        let mut to_visit: Vec<Node<'tree>> = Vec::new();
+        {
+            let mut collect = |child: Node<'tree>| {
+                let t = child.kind();
+                if t == "type_annotation" {
+                    let mut cur = child.walk();
+                    for c in child.named_children(&mut cur) {
+                        to_visit.push(c);
+                    }
+                } else if t == "assignment_pattern" {
+                    if let Some(right) = child.child_by_field_name("right") {
+                        to_visit.push(right);
+                    }
+                }
+            };
+            walk(params, &mut collect);
+        }
+
+        for n in to_visit {
+            visit(n, source, defined, refs, typescript);
+        }
+    }
+}
+
+mod go {
+    use super::*;
+    use once_cell::sync::Lazy;
+
+    pub(super) static BUILTINS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+        [
+            "true",
+            "false",
+            "nil",
+            "iota",
+            "append",
+            "cap",
+            "close",
+            "complex",
+            "copy",
+            "delete",
+            "imag",
+            "len",
+            "make",
+            "new",
+            "panic",
+            "print",
+            "println",
+            "real",
+            "recover",
+            "any",
+            "bool",
+            "byte",
+            "comparable",
+            "complex64",
+            "complex128",
+            "error",
+            "float32",
+            "float64",
+            "int",
+            "int8",
+            "int16",
+            "int32",
+            "int64",
+            "rune",
+            "string",
+            "uint",
+            "uint8",
+            "uint16",
+            "uint32",
+            "uint64",
+            "uintptr",
+            "_",
+        ]
+        .into_iter()
+        .collect()
+    });
+
+    pub(super) fn collect(
+        root: Node<'_>,
+        source: &str,
+        defined: &mut HashSet<String>,
+        refs: &mut Vec<UndefinedName>,
+    ) {
+        visit(root, source, defined, refs);
+    }
+
+    fn visit(
+        node: Node<'_>,
+        source: &str,
+        defined: &mut HashSet<String>,
+        refs: &mut Vec<UndefinedName>,
+    ) {
+        match node.kind() {
+            "import_spec" => {
+                if let Some(name) = node.child_by_field_name("name") {
+                    defined.insert(node_text(name, source).to_string());
+                } else if let Some(path) = node.child_by_field_name("path") {
+                    let raw = node_text(path, source).trim_matches('"');
+                    if let Some(last) = raw.rsplit('/').next() {
+                        defined.insert(last.to_string());
+                    }
+                }
+            }
+            "function_declaration" | "method_declaration" => {
+                if let Some(name) = node.child_by_field_name("name") {
+                    defined.insert(node_text(name, source).to_string());
+                }
+                if let Some(receiver) = node.child_by_field_name("receiver") {
+                    collect_go_field_idents(receiver, source, defined);
+                }
+                if let Some(params) = node.child_by_field_name("parameters") {
+                    collect_go_field_idents(params, source, defined);
+                }
+                if let Some(result) = node.child_by_field_name("result") {
+                    visit(result, source, defined, refs);
+                }
+                if let Some(body) = node.child_by_field_name("body") {
+                    visit(body, source, defined, refs);
+                }
+            }
+            "type_declaration" => {
+                let mut vis = |child: Node<'_>| {
+                    if child.kind() == "type_spec" {
+                        if let Some(name) = child.child_by_field_name("name") {
+                            defined.insert(node_text(name, source).to_string());
+                        }
+                    }
+                };
+                walk(node, &mut vis);
+                let mut cursor = node.walk();
+                for spec in node.named_children(&mut cursor) {
+                    if let Some(t) = spec.child_by_field_name("type") {
+                        visit(t, source, defined, refs);
+                    }
+                }
+            }
+            "short_var_declaration" | "var_spec" | "const_spec" => {
+                if let Some(left) = node.child_by_field_name("left") {
+                    let mut cursor = left.walk();
+                    for child in left.named_children(&mut cursor) {
+                        if child.kind() == "identifier" {
+                            defined.insert(node_text(child, source).to_string());
+                        }
+                    }
+                } else {
+                    let mut cursor = node.walk();
+                    for child in node.named_children(&mut cursor) {
+                        if child.kind() == "identifier" {
+                            defined.insert(node_text(child, source).to_string());
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                if let Some(right) = node.child_by_field_name("right") {
+                    visit(right, source, defined, refs);
+                }
+                if let Some(t) = node.child_by_field_name("type") {
+                    visit(t, source, defined, refs);
+                }
+            }
+            "range_clause" => {
+                if let Some(left) = node.child_by_field_name("left") {
+                    let mut cursor = left.walk();
+                    for child in left.named_children(&mut cursor) {
+                        if child.kind() == "identifier" {
+                            defined.insert(node_text(child, source).to_string());
+                        }
+                    }
+                }
+                if let Some(right) = node.child_by_field_name("right") {
+                    visit(right, source, defined, refs);
+                }
+            }
+            "selector_expression" => {
+                if let Some(operand) = node.child_by_field_name("operand") {
+                    visit(operand, source, defined, refs);
+                }
+            }
+            "field_identifier" | "type_identifier" => {}
+            "keyed_element" => {
+                let count = node.named_child_count();
+                for i in 1..count {
+                    if let Some(child) = node.named_child(i as u32) {
+                        visit(child, source, defined, refs);
+                    }
+                }
+            }
+            "identifier" => {
+                add_reference(refs, node, source, "identifier");
+            }
+            _ => {
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    visit(child, source, defined, refs);
+                }
+            }
+        }
+    }
+
+    fn collect_go_field_idents(node: Node<'_>, source: &str, defined: &mut HashSet<String>) {
+        let mut vis = |child: Node<'_>| {
+            if child.kind() == "parameter_declaration" {
+                let mut cursor = child.walk();
+                for c in child.named_children(&mut cursor) {
+                    if c.kind() == "identifier" {
+                        defined.insert(node_text(c, source).to_string());
+                    }
+                }
+            }
+        };
+        walk(node, &mut vis);
+    }
+}
+
+mod ruby {
+    use super::*;
+    use once_cell::sync::Lazy;
+
+    pub(super) static BUILTINS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+        [
+            "self",
+            "super",
+            "nil",
+            "true",
+            "false",
+            "__method__",
+            "__callee__",
+            "Array",
+            "Hash",
+            "String",
+            "Integer",
+            "Float",
+            "Symbol",
+            "Range",
+            "Regexp",
+            "Proc",
+            "Lambda",
+            "Module",
+            "Class",
+            "Object",
+            "Kernel",
+            "Comparable",
+            "Enumerable",
+            "Exception",
+            "StandardError",
+            "RuntimeError",
+            "ArgumentError",
+            "TypeError",
+            "NameError",
+            "NoMethodError",
+            "IOError",
+            "p",
+            "pp",
+            "print",
+            "puts",
+            "gets",
+            "require",
+            "require_relative",
+            "load",
+            "raise",
+            "throw",
+            "catch",
+            "lambda",
+            "proc",
+            "yield",
+            "attr_reader",
+            "attr_writer",
+            "attr_accessor",
+            "initialize",
+            "include",
+            "extend",
+            "prepend",
+            "private",
+            "public",
+            "protected",
+        ]
+        .into_iter()
+        .collect()
+    });
+
+    pub(super) fn collect(
+        root: Node<'_>,
+        source: &str,
+        defined: &mut HashSet<String>,
+        refs: &mut Vec<UndefinedName>,
+    ) {
+        visit(root, source, defined, refs);
+    }
+
+    fn visit(
+        node: Node<'_>,
+        source: &str,
+        defined: &mut HashSet<String>,
+        refs: &mut Vec<UndefinedName>,
+    ) {
+        match node.kind() {
+            "method" | "singleton_method" => {
+                if let Some(name) = node.child_by_field_name("name") {
+                    defined.insert(node_text(name, source).to_string());
+                }
+                if let Some(params) = node.child_by_field_name("parameters") {
+                    let mut vis = |child: Node<'_>| {
+                        if child.kind() == "identifier" || child.kind() == "simple_symbol" {
+                            defined.insert(node_text(child, source).to_string());
+                        }
+                    };
+                    walk(params, &mut vis);
+                }
+                if let Some(body) = node.child_by_field_name("body") {
+                    visit(body, source, defined, refs);
+                }
+            }
+            "class" | "module" => {
+                if let Some(name) = node.child_by_field_name("name") {
+                    defined.insert(node_text(name, source).to_string());
+                }
+                if let Some(body) = node.child_by_field_name("body") {
+                    visit(body, source, defined, refs);
+                }
+            }
+            "assignment" | "operator_assignment" => {
+                if let Some(right) = node.child_by_field_name("right") {
+                    visit(right, source, defined, refs);
+                }
+                if let Some(left) = node.child_by_field_name("left") {
+                    if left.kind() == "identifier" || left.kind() == "constant" {
+                        defined.insert(node_text(left, source).to_string());
+                    } else {
+                        visit(left, source, defined, refs);
+                    }
+                }
+            }
+            "block_parameters" | "method_parameters" => {
+                let mut vis = |child: Node<'_>| {
+                    if child.kind() == "identifier" {
+                        defined.insert(node_text(child, source).to_string());
+                    }
+                };
+                walk(node, &mut vis);
+            }
+            "call" => {
+                if let Some(receiver) = node.child_by_field_name("receiver") {
+                    visit(receiver, source, defined, refs);
+                } else if let Some(method) = node.child_by_field_name("method") {
+                    visit(method, source, defined, refs);
+                }
+                if let Some(args) = node.child_by_field_name("arguments") {
+                    visit(args, source, defined, refs);
+                }
+                if let Some(block) = node.child_by_field_name("block") {
+                    visit(block, source, defined, refs);
+                }
+            }
+            "hash_key_symbol" | "simple_symbol" => {}
+            "pair" => {
+                if let Some(value) = node.child_by_field_name("value") {
+                    visit(value, source, defined, refs);
+                }
+            }
+            "identifier" | "constant" => {
+                add_reference(refs, node, source, "identifier");
+            }
+            _ => {
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    visit(child, source, defined, refs);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn run_with(content: &str, language: &str) -> VmValue {
+        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        dict.insert("content".into(), VmValue::String(Rc::from(content)));
+        dict.insert("language".into(), VmValue::String(Rc::from(language)));
+        run(&[VmValue::Dict(Rc::new(dict))]).expect("undefined_names run")
+    }
+
+    fn names(result: &VmValue) -> Vec<String> {
+        let diagnostics = match result {
+            VmValue::Dict(d) => match d.get("diagnostics") {
+                Some(VmValue::List(l)) => l.clone(),
+                _ => panic!("missing diagnostics"),
+            },
+            _ => panic!("expected dict"),
+        };
+        diagnostics
+            .iter()
+            .map(|d| match d {
+                VmValue::Dict(dict) => match dict.get("name") {
+                    Some(VmValue::String(s)) => s.to_string(),
+                    _ => panic!("missing name"),
+                },
+                _ => panic!("expected dict"),
+            })
+            .collect()
+    }
+
+    fn supported(result: &VmValue) -> bool {
+        match result {
+            VmValue::Dict(d) => match d.get("supported") {
+                Some(VmValue::Bool(b)) => *b,
+                _ => panic!("missing supported"),
+            },
+            _ => panic!("expected dict"),
+        }
+    }
+
+    #[test]
+    fn python_flags_undefined_call() {
+        let src = "def foo():\n    bar()\n";
+        let result = run_with(src, "python");
+        let n = names(&result);
+        assert_eq!(n, vec!["bar".to_string()]);
+    }
+
+    #[test]
+    fn python_imports_satisfy_references() {
+        let src = "import os\nfrom collections import OrderedDict as OD\nos.path\nOD()\n";
+        let result = run_with(src, "py");
+        let n = names(&result);
+        assert!(n.is_empty(), "expected no undefined, got {n:?}");
+    }
+
+    #[test]
+    fn python_skips_attribute_rhs() {
+        let src = "import os\nos.path.join('a', 'b')\n";
+        let result = run_with(src, "py");
+        let n = names(&result);
+        assert!(n.is_empty(), "got {n:?}");
+    }
+
+    #[test]
+    fn javascript_flags_typo() {
+        let src = "import { foo } from './m';\nfoo(); baz();\n";
+        let result = run_with(src, "js");
+        let n = names(&result);
+        assert_eq!(n, vec!["baz".to_string()]);
+    }
+
+    #[test]
+    fn typescript_flags_unknown_type_reference() {
+        let src = "function f(x: SomeType) { return x; }\n";
+        let result = run_with(src, "ts");
+        let n = names(&result);
+        assert!(n.contains(&"SomeType".to_string()), "got {n:?}");
+    }
+
+    #[test]
+    fn go_resolves_imports_and_decls() {
+        let src = "package main\nimport \"fmt\"\nfunc main() { fmt.Println(\"hi\") }\n";
+        let result = run_with(src, "go");
+        let n = names(&result);
+        assert!(n.is_empty(), "got {n:?}");
+    }
+
+    #[test]
+    fn go_flags_unknown_call() {
+        let src = "package main\nfunc main() { mystery() }\n";
+        let result = run_with(src, "go");
+        let n = names(&result);
+        assert_eq!(n, vec!["mystery".to_string()]);
+    }
+
+    #[test]
+    fn ruby_flags_unknown_call() {
+        let src = "def greet(name)\n  hello(name)\nend\n";
+        let result = run_with(src, "rb");
+        let n = names(&result);
+        assert_eq!(n, vec!["hello".to_string()]);
+    }
+
+    #[test]
+    fn unsupported_language_returns_supported_false() {
+        let src = "fn main() {}\n";
+        let result = run_with(src, "rust");
+        assert!(!supported(&result));
+        let n = names(&result);
+        assert!(n.is_empty());
+    }
+
+    #[test]
+    fn missing_payload_is_rejected() {
+        let dict: std::collections::BTreeMap<String, VmValue> = std::collections::BTreeMap::new();
+        let err = run(&[VmValue::Dict(Rc::new(dict))]).expect_err("must reject");
+        match err {
+            HostlibError::MissingParameter { builtin, .. } => assert_eq!(builtin, BUILTIN),
+            other => panic!("got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deduplicates_repeated_references() {
+        let src = "missing()\nmissing()\nmissing()\n";
+        let result = run_with(src, "py");
+        let n = names(&result);
+        assert_eq!(n, vec!["missing".to_string()]);
+    }
+}

--- a/crates/harn-hostlib/src/schemas.rs
+++ b/crates/harn-hostlib/src/schemas.rs
@@ -61,6 +61,30 @@ pub const SCHEMAS: &[(&str, &str, SchemaKind, &str)] = &[
         SchemaKind::Response,
         include_str!("../schemas/ast/outline.response.json"),
     ),
+    (
+        "ast",
+        "parse_errors",
+        SchemaKind::Request,
+        include_str!("../schemas/ast/parse_errors.request.json"),
+    ),
+    (
+        "ast",
+        "parse_errors",
+        SchemaKind::Response,
+        include_str!("../schemas/ast/parse_errors.response.json"),
+    ),
+    (
+        "ast",
+        "undefined_names",
+        SchemaKind::Request,
+        include_str!("../schemas/ast/undefined_names.request.json"),
+    ),
+    (
+        "ast",
+        "undefined_names",
+        SchemaKind::Response,
+        include_str!("../schemas/ast/undefined_names.response.json"),
+    ),
     // code_index/
     (
         "code_index",

--- a/crates/harn-hostlib/tests/ast_builtins.rs
+++ b/crates/harn-hostlib/tests/ast_builtins.rs
@@ -197,6 +197,154 @@ fn parse_file_meets_perf_budget_on_a_known_input() {
 }
 
 #[test]
+fn parse_errors_returns_clean_payload_for_valid_python() {
+    let registry = ast_registry();
+    let payload = dict(&[
+        ("content", VmValue::String(Rc::from("x = 1\n"))),
+        ("language", VmValue::String(Rc::from("python"))),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_parse_errors", payload);
+
+    assert_eq!(string_value(&dict_field(&result, "language")), "python");
+    let errors = list_value(&dict_field(&result, "errors"));
+    assert!(errors.is_empty(), "valid Python should have no errors");
+    let supported = match dict_field(&result, "supported") {
+        VmValue::Bool(b) => b,
+        other => panic!("expected bool, got {other:?}"),
+    };
+    assert!(supported);
+}
+
+#[test]
+fn parse_errors_flags_typescript_syntax_error() {
+    let registry = ast_registry();
+    let payload = dict(&[
+        // Mismatched paren — tree-sitter will emit at least one ERROR or
+        // MISSING node here.
+        (
+            "content",
+            VmValue::String(Rc::from("function foo(\n  return 1;\n}")),
+        ),
+        ("language", VmValue::String(Rc::from("typescript"))),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_parse_errors", payload);
+    let errors = list_value(&dict_field(&result, "errors"));
+    assert!(!errors.is_empty(), "expected errors, got {errors:?}");
+
+    // Each error has the documented field set.
+    for entry in errors.iter() {
+        for field in [
+            "start_row",
+            "start_col",
+            "end_row",
+            "end_col",
+            "start_byte",
+            "end_byte",
+            "message",
+            "snippet",
+            "missing",
+        ] {
+            let _ = dict_field(entry, field);
+        }
+    }
+}
+
+#[test]
+fn parse_errors_top_level_decl_count_matches_swift_profile() {
+    // Mirrors Swift's `topLevelDeclCount` for a couple of canonical
+    // language profiles. Drift in this number means our profile fell out
+    // of sync with `TreeSitterParseErrors.declarationTypesMap`.
+    let registry = ast_registry();
+
+    let cases = [
+        ("rust", "fn a() {}\nfn b() {}\nstruct C;\n", 3),
+        ("python", "def a():\n    pass\nclass B:\n    pass\n", 2),
+        // TS lists `export_statement` as both a declaration and a
+        // wrapper, so each `export X` contributes 2 (the export itself
+        // plus the wrapped decl). Mirrors Swift exactly.
+        (
+            "typescript",
+            "export function a() {}\nexport const b = 1;\nfunction c() {}\n",
+            5,
+        ),
+    ];
+    for (lang, src, want) in cases {
+        let payload = dict(&[
+            ("content", VmValue::String(Rc::from(src))),
+            ("language", VmValue::String(Rc::from(lang))),
+        ]);
+        let result = invoke(&registry, "hostlib_ast_parse_errors", payload);
+        let count = int_value(&dict_field(&result, "top_level_decl_count"));
+        assert_eq!(count, want, "{lang} top_level_decl_count");
+    }
+}
+
+#[test]
+fn undefined_names_python_returns_dedup_diagnostics() {
+    let registry = ast_registry();
+    let payload = dict(&[
+        (
+            "content",
+            VmValue::String(Rc::from(
+                "import os\n\
+                 def foo(x):\n    \
+                     return x + missing()\n\
+                 missing()\n\
+                 missing()\n",
+            )),
+        ),
+        ("language", VmValue::String(Rc::from("python"))),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_undefined_names", payload);
+    let supported = match dict_field(&result, "supported") {
+        VmValue::Bool(b) => b,
+        other => panic!("expected bool, got {other:?}"),
+    };
+    assert!(supported);
+
+    let diagnostics = list_value(&dict_field(&result, "diagnostics"));
+    let names: Vec<String> = diagnostics
+        .iter()
+        .map(|d| string_value(&dict_field(d, "name")).to_string())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["missing".to_string()],
+        "expected single dedup'd 'missing', got {names:?}"
+    );
+
+    // Each diagnostic carries the documented fields.
+    for d in diagnostics.iter() {
+        let kind_value = dict_field(d, "kind");
+        let kind = string_value(&kind_value).to_string();
+        assert!(kind == "identifier" || kind == "type", "kind = {kind}");
+        let msg_value = dict_field(d, "message");
+        let message = string_value(&msg_value).to_string();
+        assert!(message.contains("undefined name"), "message = {message}");
+    }
+}
+
+#[test]
+fn undefined_names_marks_unsupported_languages() {
+    let registry = ast_registry();
+    let payload = dict(&[
+        ("content", VmValue::String(Rc::from("fn main() {}\n"))),
+        ("language", VmValue::String(Rc::from("rust"))),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_undefined_names", payload);
+    let supported = match dict_field(&result, "supported") {
+        VmValue::Bool(b) => b,
+        other => panic!("expected bool, got {other:?}"),
+    };
+    assert!(
+        !supported,
+        "rust isn't in the Swift profile set; must report supported = false"
+    );
+    let diagnostics = list_value(&dict_field(&result, "diagnostics"));
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
 fn perf_smoke_against_burin_code_when_available() {
     // The issue calls out `~/projects/burin-code/Package.swift`. That
     // path only exists on the maintainer's box; skip silently otherwise

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -29,17 +29,27 @@ fn ast_capability_registers_documented_methods() {
             "hostlib_ast_parse_file",
             "hostlib_ast_symbols",
             "hostlib_ast_outline",
+            "hostlib_ast_parse_errors",
+            "hostlib_ast_undefined_names",
         ]
     );
-    // Issue #564 implemented every AST builtin. With no `path` parameter
-    // each one routes through `MissingParameter` rather than the scaffold
-    // `Unimplemented` — the contract surface is real now.
+    // Each AST builtin must reject an empty payload with `MissingParameter`
+    // (never `Unimplemented`). The required field differs per method:
+    // file-based builtins want `path`; the analysis builtins added by #773
+    // accept either `content` or `path` and surface that as the
+    // `content_or_path` synthetic parameter.
+    let expected_param = |name: &str| -> &'static str {
+        match name {
+            "hostlib_ast_parse_errors" | "hostlib_ast_undefined_names" => "content_or_path",
+            _ => "path",
+        }
+    };
     for entry in registry.iter() {
         let err = (entry.handler)(&[]).expect_err("handler must error on empty args");
         match err {
             HostlibError::MissingParameter { builtin, param } => {
                 assert_eq!(builtin, entry.name);
-                assert_eq!(param, "path");
+                assert_eq!(param, expected_param(entry.name));
             }
             other => panic!(
                 "expected MissingParameter for {}, got {other:?}",
@@ -194,9 +204,9 @@ fn install_default_wires_every_module_into_a_vm() {
         registry.modules(),
         &["ast", "code_index", "scanner", "fs_watch", "tools"]
     );
-    // Builtin count: 3 ast + 5 code_index + 2 scanner + 2 fs_watch + 12
-    // tools + 1 hostlib_enable = 25.
-    assert!(registry.builtins().len() >= 25);
+    // Builtin count: 5 ast + 5 code_index + 2 scanner + 2 fs_watch + 12
+    // tools + 1 hostlib_enable = 27.
+    assert!(registry.builtins().len() >= 27);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes [#773](https://github.com/burin-labs/harn/issues/773). Two new builtins on the `ast::*` hostlib surface so [burin-code](https://github.com/burin-labs/burin-code) can drop its Swift `Sources/ASTEngine/TreeSitterParseErrors.swift` and `TreeSitterUndefinedNames.swift` fallbacks.

- **`hostlib_ast_parse_errors`** walks the tree-sitter parse, emits `ERROR`/`MISSING` nodes with 0-based row/col + byte ranges, a short human-readable `message`, the offending `snippet` (60-char truncation, newlines escaped), and a `missing` flag. Also returns `top_level_decl_count` keyed off the same per-language declaration table the Swift fallback uses (TS, JS, Go, Rust, Python, Java, C/C++, C#, Kotlin, Ruby, PHP, Scala). An integration test pins the count so profile drift fails loudly.
- **`hostlib_ast_undefined_names`** ports the per-language profile walker for Python, JavaScript (incl. JSX), TypeScript (incl. TSX), Go, and Ruby — exactly the language set the Swift surface supports today. Output is deduped by name (first occurrence wins) and filtered against the curated builtin stop-list. Languages outside the profile set return `supported = false` so callers fall back to LSP / ruff / tsc / go vet.

Both accept `content` (in-memory) or `path` (file IO); `language` accepts canonical wire names (`"python"`) or bare extensions (`"py"`) so existing Swift call sites that pass a file extension don't need to translate.

JSON schemas under `crates/harn-hostlib/schemas/ast/` ship with the crate so downstream schema-drift tests see the contract.

## Test plan

- [x] `cargo test -p harn-hostlib` — 11 new integration tests (parse_errors clean/error/decl-count drift; undefined_names dedup/unsupported/python/JS/TS/Go/Ruby) plus the existing 200+ unit tests stay green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] Pre-commit + pre-push hooks pass (rustfmt, clippy, markdown lint, full Rust test gate).
- [ ] Follow-up: burin-code's `HarnASTHostlibClient.swift` learns the `parseErrors` and `undefinedNames` ops, then `Sources/ASTEngine/TreeSitter{ParseErrors,UndefinedNames}.swift` can be deleted (tracked in [burin-code#296](https://github.com/burin-labs/burin-code/issues/296)).

## Out of scope (per the issue)

- Migrating burin-code's `ASTRPC.parseErrors` / `HarnHostServer+ASTPrimitives.handleASTDiagnoseUndefined` consumers — separate ticket.
- Replacing tree-sitter grammars; the existing `ast::language::Language` registry is reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)