### PR TITLE
Release v0.7.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ granular archaeology.
 
 ## Unreleased
 
+### Unreleased
+
+- No entries yet. Add items here for the next release.
+
+## v0.7.46
+
 ### Changed
 
 - **Sharper diagnostics for missing `render_prompt` / `render` targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.45"
+version = "0.7.46"
 dependencies = [
  "async-trait",
  "axum",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.45"
+version = "0.7.46"
 dependencies = [
  "harn-vm",
  "serde",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.45"
+version = "0.7.46"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.45"
+version = "0.7.46"
 dependencies = [
  "anyhow",
  "base64",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.45"
+version = "0.7.46"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1740,11 +1740,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.45"
+version = "0.7.46"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.45"
+version = "0.7.46"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.45"
+version = "0.7.46"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.45"
+version = "0.7.46"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.45"
+version = "0.7.46"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.45"
+version = "0.7.46"
 dependencies = [
  "async-trait",
  "axum",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "harn-vm"
-version = "0.7.45"
+version = "0.7.46"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.45"
+version = "0.7.46"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
## Release v0.7.46

This PR carries the patch release content prepared by `scripts/release_ship.sh --prepare --bump patch`:

- Changelog release notes for v0.7.46
- Workspace and crate version bump to 0.7.46
- `Cargo.lock` and generated mirrors

After this PR lands through the merge queue, the publish-release workflow will:

- tag v0.7.46
- publish crates.io crates
- create/update the GitHub release
- trigger the build-release-binaries workflow
