### PR TITLE
Add AST hostlib symbol mutation + bracket balance builtins (#775)

### DIFF
--- a/crates/harn-hostlib/schemas/ast/bracket_balance.request.json
+++ b/crates/harn-hostlib/schemas/ast/bracket_balance.request.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/bracket_balance.request.json",
+  "title": "ast.bracket_balance request",
+  "description": "Count unbalanced parentheses, square brackets, and braces in `source`, ignoring brackets inside string literals and comments. The `language` field selects comment syntax; only Python (`py`) switches to `#` line comments and disables `//` / `/* */`.",
+  "type": "object",
+  "properties": {
+    "source": {
+      "type": "string",
+      "description": "Full source text to scan."
+    },
+    "language": {
+      "type": "string",
+      "description": "Canonical language name. Optional; defaults to brace-language comment syntax (`//`, `/* */`)."
+    }
+  },
+  "required": ["source"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/ast/bracket_balance.response.json
+++ b/crates/harn-hostlib/schemas/ast/bracket_balance.response.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/bracket_balance.response.json",
+  "title": "ast.bracket_balance response",
+  "description": "Signed bracket counts. Positive means unclosed openers; negative means unmatched closers. A balanced source returns zeros across all three families.",
+  "type": "object",
+  "properties": {
+    "parens": {
+      "type": "integer",
+      "description": "Net `(` minus `)` outside of strings/comments."
+    },
+    "brackets": {
+      "type": "integer",
+      "description": "Net `[` minus `]` outside of strings/comments."
+    },
+    "braces": {
+      "type": "integer",
+      "description": "Net `{` minus `}` outside of strings/comments."
+    }
+  },
+  "required": ["parens", "brackets", "braces"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/ast/symbol_delete.request.json
+++ b/crates/harn-hostlib/schemas/ast/symbol_delete.request.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/symbol_delete.request.json",
+  "title": "ast.symbol_delete request",
+  "description": "Locate a named symbol in `source` and return the rewritten text with that symbol removed. Mirrors Swift `SymbolOperations.delete`.",
+  "type": "object",
+  "properties": {
+    "source": {
+      "type": "string",
+      "description": "Full source text to mutate."
+    },
+    "language": {
+      "type": "string",
+      "description": "Canonical language name."
+    },
+    "symbol_name": {
+      "type": "string",
+      "description": "Symbol to delete. Optionally prefixed with a single container, e.g. `Greeter.greet`."
+    }
+  },
+  "required": ["source", "language", "symbol_name"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/ast/symbol_delete.response.json
+++ b/crates/harn-hostlib/schemas/ast/symbol_delete.response.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/symbol_delete.response.json",
+  "title": "ast.symbol_delete response",
+  "description": "Tagged-union response for ast.symbol_delete. After removing the symbol's lines and collapsing 3+ blank-line runs, the rewritten source is re-parsed; if tree-sitter reports an ERROR/MISSING node the call returns `syntax_error_after_edit` rather than the rewritten source.",
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string",
+      "enum": [
+        "removed",
+        "not_found",
+        "ambiguous",
+        "unsupported_language",
+        "syntax_error_after_edit"
+      ]
+    },
+    "source": {
+      "type": "string",
+      "description": "Rewritten source. Set only when `result` is `removed`."
+    },
+    "available": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "suggestions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "match_count": {
+      "type": "integer",
+      "minimum": 2
+    },
+    "language": {
+      "type": "string"
+    },
+    "details": {
+      "type": "string",
+      "description": "First-line diagnostic from the post-edit re-parse. Set only when `result` is `syntax_error_after_edit`."
+    }
+  },
+  "required": ["result"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/ast/symbol_extract.request.json
+++ b/crates/harn-hostlib/schemas/ast/symbol_extract.request.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/symbol_extract.request.json",
+  "title": "ast.symbol_extract request",
+  "description": "Locate a named symbol in `source` and return its full text plus 1-based, inclusive line range. Mirrors the Swift `SymbolOperations.extract` surface so burin-code's symbol-scoped read tool can swap in a hostlib call.",
+  "type": "object",
+  "properties": {
+    "source": {
+      "type": "string",
+      "description": "Full source text to search."
+    },
+    "language": {
+      "type": "string",
+      "description": "Canonical language name, e.g. \"rust\", \"swift\", \"python\". Aliases like `ts`, `py`, `c++` are accepted."
+    },
+    "symbol_name": {
+      "type": "string",
+      "description": "Symbol to locate. Optionally prefixed with a single container, e.g. `Greeter.greet`."
+    }
+  },
+  "required": ["source", "language", "symbol_name"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/ast/symbol_extract.response.json
+++ b/crates/harn-hostlib/schemas/ast/symbol_extract.response.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/symbol_extract.response.json",
+  "title": "ast.symbol_extract response",
+  "description": "Tagged-union response for ast.symbol_extract. The `result` field selects the variant; companion fields are populated only for the variant that produced them.",
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string",
+      "enum": ["extracted", "not_found", "ambiguous", "unsupported_language"]
+    },
+    "text": {
+      "type": "string",
+      "description": "Symbol text including its preamble (decorators, doc comments, attributes). Set only when `result` is `extracted`."
+    },
+    "start_line": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "1-based start line, inclusive. Set only when `result` is `extracted`."
+    },
+    "end_line": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "1-based end line, inclusive. Set only when `result` is `extracted`."
+    },
+    "available": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Names of every symbol in `source`. Set only when `result` is `not_found`."
+    },
+    "suggestions": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Up to three fuzzy-matched suggestions for the supplied `symbol_name`. Set only when `result` is `not_found`."
+    },
+    "match_count": {
+      "type": "integer",
+      "minimum": 2,
+      "description": "Number of symbols matching the unqualified `symbol_name`. Set only when `result` is `ambiguous`."
+    },
+    "language": {
+      "type": "string",
+      "description": "Echo of the unrecognized `language` field. Set only when `result` is `unsupported_language`."
+    }
+  },
+  "required": ["result"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/ast/symbol_replace.request.json
+++ b/crates/harn-hostlib/schemas/ast/symbol_replace.request.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/symbol_replace.request.json",
+  "title": "ast.symbol_replace request",
+  "description": "Locate a named symbol in `source` and return the rewritten text with that symbol's lines replaced by `new_text`. Mirrors Swift `SymbolOperations.replace`.",
+  "type": "object",
+  "properties": {
+    "source": {
+      "type": "string",
+      "description": "Full source text to mutate."
+    },
+    "language": {
+      "type": "string",
+      "description": "Canonical language name."
+    },
+    "symbol_name": {
+      "type": "string",
+      "description": "Symbol to replace. Optionally prefixed with a single container, e.g. `Greeter.greet`."
+    },
+    "new_text": {
+      "type": "string",
+      "description": "Replacement text spliced in for the symbol's full preamble + signature + body."
+    }
+  },
+  "required": ["source", "language", "symbol_name", "new_text"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/ast/symbol_replace.response.json
+++ b/crates/harn-hostlib/schemas/ast/symbol_replace.response.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/ast/symbol_replace.response.json",
+  "title": "ast.symbol_replace response",
+  "description": "Tagged-union response for ast.symbol_replace. After splicing in `new_text` and collapsing 3+ blank-line runs, the rewritten source is re-parsed; if tree-sitter reports an ERROR/MISSING node the call returns `syntax_error_after_edit` rather than the rewritten source.",
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string",
+      "enum": [
+        "replaced",
+        "not_found",
+        "ambiguous",
+        "unsupported_language",
+        "syntax_error_after_edit"
+      ]
+    },
+    "source": {
+      "type": "string",
+      "description": "Rewritten source. Set only when `result` is `replaced`."
+    },
+    "available": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "suggestions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "match_count": {
+      "type": "integer",
+      "minimum": 2
+    },
+    "language": {
+      "type": "string"
+    },
+    "details": {
+      "type": "string",
+      "description": "First-line diagnostic from the post-edit re-parse. Set only when `result` is `syntax_error_after_edit`."
+    }
+  },
+  "required": ["result"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/src/ast/bracket_balance.rs
+++ b/crates/harn-hostlib/src/ast/bracket_balance.rs
@@ -1,0 +1,265 @@
+//! `ast.bracket_balance` — count unbalanced `()`, `[]`, `{}` in source.
+//!
+//! Direct port of `Sources/ASTEngine/BracketBalance.swift`. The lexer
+//! treats `//` and `/* */` as comments by default and switches to `#`
+//! line comments for Python; string literals (single, double, backtick)
+//! suppress bracket counting inside them. The output is signed counts
+//! per bracket family — positive means unclosed openers, negative means
+//! unmatched closers.
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::tools::args::{build_dict, dict_arg, optional_string, require_string};
+
+use super::language::Language;
+
+const BUILTIN: &str = "hostlib_ast_bracket_balance";
+
+pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN, args)?;
+    let dict = raw.as_ref();
+    let source = require_string(BUILTIN, dict, "source")?;
+    let language_name = optional_string(BUILTIN, dict, "language")?;
+    let is_python = language_name
+        .as_deref()
+        .and_then(Language::from_name)
+        .map(|l| matches!(l, Language::Python))
+        .unwrap_or(false);
+
+    let balance = count(&source, is_python);
+    Ok(build_dict([
+        ("parens", VmValue::Int(balance.parens as i64)),
+        ("brackets", VmValue::Int(balance.brackets as i64)),
+        ("braces", VmValue::Int(balance.braces as i64)),
+    ]))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Balance {
+    parens: i32,
+    brackets: i32,
+    braces: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LexState {
+    Code,
+    LineComment,
+    BlockComment,
+    SingleQuoteString,
+    DoubleQuoteString,
+    BacktickString,
+}
+
+fn count(source: &str, is_python: bool) -> Balance {
+    let chars: Vec<char> = source.chars().collect();
+    let len = chars.len();
+    let mut state = LexState::Code;
+    let mut counts = Balance {
+        parens: 0,
+        brackets: 0,
+        braces: 0,
+    };
+    let mut i: usize = 0;
+    while i < len {
+        let c = chars[i];
+        let next = if i + 1 < len {
+            Some(chars[i + 1])
+        } else {
+            None
+        };
+        match state {
+            LexState::Code => {
+                i += process_code_char(c, next, is_python, &mut state, &mut counts);
+            }
+            other => {
+                i += process_non_code_char(c, next, other, &mut state);
+            }
+        }
+    }
+    counts
+}
+
+fn process_code_char(
+    c: char,
+    next: Option<char>,
+    is_python: bool,
+    state: &mut LexState,
+    counts: &mut Balance,
+) -> usize {
+    if let Some(advance) = check_comment_start(c, next, is_python, state) {
+        return advance;
+    }
+    if let Some(string_state) = check_string_start(c) {
+        *state = string_state;
+        return 1;
+    }
+    match c {
+        '(' => counts.parens += 1,
+        ')' => counts.parens -= 1,
+        '[' => counts.brackets += 1,
+        ']' => counts.brackets -= 1,
+        '{' => counts.braces += 1,
+        '}' => counts.braces -= 1,
+        _ => {}
+    }
+    1
+}
+
+fn process_non_code_char(
+    c: char,
+    next: Option<char>,
+    state_in: LexState,
+    state: &mut LexState,
+) -> usize {
+    match state_in {
+        LexState::LineComment => {
+            if c == '\n' {
+                *state = LexState::Code;
+            }
+            1
+        }
+        LexState::BlockComment => {
+            if c == '*' && next == Some('/') {
+                *state = LexState::Code;
+                2
+            } else {
+                1
+            }
+        }
+        LexState::DoubleQuoteString => process_string_char(c, '"', state),
+        LexState::SingleQuoteString => process_string_char(c, '\'', state),
+        LexState::BacktickString => process_string_char(c, '`', state),
+        LexState::Code => 1,
+    }
+}
+
+fn process_string_char(c: char, terminator: char, state: &mut LexState) -> usize {
+    if c == '\\' {
+        return 2;
+    }
+    if c == terminator {
+        *state = LexState::Code;
+    }
+    1
+}
+
+fn check_comment_start(
+    c: char,
+    next: Option<char>,
+    is_python: bool,
+    state: &mut LexState,
+) -> Option<usize> {
+    if c == '/' && next == Some('/') && !is_python {
+        *state = LexState::LineComment;
+        return Some(2);
+    }
+    if c == '/' && next == Some('*') && !is_python {
+        *state = LexState::BlockComment;
+        return Some(2);
+    }
+    if c == '#' && is_python {
+        *state = LexState::LineComment;
+        return Some(1);
+    }
+    None
+}
+
+fn check_string_start(c: char) -> Option<LexState> {
+    match c {
+        '"' => Some(LexState::DoubleQuoteString),
+        '\'' => Some(LexState::SingleQuoteString),
+        '`' => Some(LexState::BacktickString),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn balance(source: &str, lang: &str) -> Balance {
+        count(source, lang == "py" || lang == "python")
+    }
+
+    #[test]
+    fn balanced_source_reports_zero() {
+        let b = balance("fn foo() { let x = [1, 2, 3]; }", "rust");
+        assert_eq!(b.parens, 0);
+        assert_eq!(b.brackets, 0);
+        assert_eq!(b.braces, 0);
+    }
+
+    #[test]
+    fn missing_closing_brace_reports_positive_one() {
+        let b = balance("fn foo() {", "rust");
+        assert_eq!(b.braces, 1);
+    }
+
+    #[test]
+    fn extra_closing_paren_reports_negative_one() {
+        let b = balance("foo())", "rust");
+        assert_eq!(b.parens, -1);
+    }
+
+    #[test]
+    fn brackets_inside_strings_are_ignored() {
+        let b = balance(r#"let s = "[}{)";"#, "rust");
+        assert_eq!(b.parens, 0);
+        assert_eq!(b.brackets, 0);
+        assert_eq!(b.braces, 0);
+    }
+
+    #[test]
+    fn brackets_inside_line_comments_are_ignored() {
+        let b = balance("// {[(\nlet x = 1;", "rust");
+        assert_eq!(b.parens, 0);
+        assert_eq!(b.brackets, 0);
+        assert_eq!(b.braces, 0);
+    }
+
+    #[test]
+    fn brackets_inside_block_comments_are_ignored() {
+        let b = balance("/* {[( */ ()", "rust");
+        assert_eq!(b.parens, 0);
+        assert_eq!(b.braces, 0);
+    }
+
+    #[test]
+    fn python_uses_hash_comments() {
+        let b = balance("# {[(\nx = 1", "python");
+        assert_eq!(b.parens, 0);
+    }
+
+    #[test]
+    fn python_does_not_treat_double_slash_as_comment() {
+        // `//` is integer division in Python — must not flip lexer to LineComment.
+        let b = balance("x = 5 // 2  # cmt with [\n", "python");
+        assert_eq!(b.brackets, 0);
+    }
+
+    #[test]
+    fn handler_returns_three_int_fields() {
+        let raw = std::collections::BTreeMap::from([
+            (
+                "source".to_string(),
+                VmValue::String(std::rc::Rc::from("fn foo() {")),
+            ),
+            (
+                "language".to_string(),
+                VmValue::String(std::rc::Rc::from("rust")),
+            ),
+        ]);
+        let payload = VmValue::Dict(std::rc::Rc::new(raw));
+        let result = run(&[payload]).expect("handler runs");
+        match &result {
+            VmValue::Dict(d) => {
+                assert!(matches!(d.get("parens"), Some(VmValue::Int(_))));
+                assert!(matches!(d.get("brackets"), Some(VmValue::Int(_))));
+                assert!(matches!(d.get("braces"), Some(VmValue::Int(_))));
+            }
+            _ => panic!("expected dict"),
+        }
+    }
+}

--- a/crates/harn-hostlib/src/ast/fuzzy.rs
+++ b/crates/harn-hostlib/src/ast/fuzzy.rs
@@ -1,0 +1,138 @@
+//! Fuzzy string matching for "did you mean?" suggestions.
+//!
+//! Direct port of `Sources/ASTEngine/FuzzyMatcher.swift` so the
+//! `not_found` payload returned by symbol-mutation builtins surfaces the
+//! same suggestion list burin-code's Swift fallback produced. Matches
+//! characters in order (not necessarily contiguous): `cmpHndlr` matches
+//! `completionHandler`.
+
+/// Find the best fuzzy matches for `query` in `candidates`. Returns up to
+/// `limit` candidates sorted by descending score.
+pub(super) fn best_matches(query: &str, candidates: &[String], limit: usize) -> Vec<String> {
+    let mut scored: Vec<(String, i32)> = Vec::new();
+    for candidate in candidates {
+        if let Some(score) = match_score(query, candidate) {
+            scored.push((candidate.clone(), score));
+        }
+    }
+    scored.sort_by_key(|entry| std::cmp::Reverse(entry.1));
+    scored.into_iter().take(limit).map(|(s, _)| s).collect()
+}
+
+/// Score `pattern` against `text`. Returns `None` if the pattern's
+/// characters don't appear in order in `text`.
+fn match_score(pattern: &str, text: &str) -> Option<i32> {
+    if pattern.is_empty() {
+        return Some(0);
+    }
+    if text.is_empty() {
+        return None;
+    }
+
+    let pattern_chars: Vec<char> = pattern.to_lowercase().chars().collect();
+    let text_chars: Vec<char> = text.chars().collect();
+    let text_lower: Vec<char> = text.to_lowercase().chars().collect();
+
+    if pattern_chars.len() > text_chars.len() {
+        return None;
+    }
+
+    let mut pattern_idx: usize = 0;
+    let mut score: i32 = 0;
+    let mut last_match: Option<usize> = None;
+
+    for (text_idx, ch) in text_lower.iter().enumerate() {
+        if pattern_idx >= pattern_chars.len() {
+            break;
+        }
+        if *ch == pattern_chars[pattern_idx] {
+            score += score_for_match(text_idx, last_match, &text_chars);
+            last_match = Some(text_idx);
+            pattern_idx += 1;
+        }
+    }
+
+    if pattern_idx != pattern_chars.len() {
+        return None;
+    }
+
+    if text.to_lowercase().starts_with(&pattern.to_lowercase()) {
+        score += 20;
+    }
+
+    let length_bonus = 10 - (text_chars.len() as i32 - pattern_chars.len() as i32);
+    score += length_bonus.max(0);
+
+    Some(score)
+}
+
+fn score_for_match(text_idx: usize, last_match: Option<usize>, text_chars: &[char]) -> i32 {
+    let mut bonus: i32 = 0;
+    if text_idx == 0 {
+        bonus += 10;
+    }
+    if let Some(last) = last_match {
+        if text_idx == last + 1 {
+            bonus += 5;
+        }
+    }
+    if text_idx > 0 {
+        bonus += word_boundary_bonus(text_chars, text_idx);
+    }
+    if let Some(last) = last_match {
+        let gap = (text_idx - last - 1) as i32;
+        bonus -= gap;
+    }
+    bonus
+}
+
+fn word_boundary_bonus(text_chars: &[char], text_idx: usize) -> i32 {
+    let prev = text_chars[text_idx - 1];
+    let curr = text_chars[text_idx];
+    if prev == '_' || prev == '.' || prev == '/' {
+        return 8;
+    }
+    if curr.is_uppercase() && prev.is_lowercase() {
+        return 8;
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(values: &[&str]) -> Vec<String> {
+        values.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn finds_camel_case_subsequence() {
+        // Pattern characters need only appear in order; doSomething has no
+        // matching subsequence and must be filtered out, while the two
+        // *Handler candidates both qualify.
+        let candidates = names(&["completionHandler", "completeHandler", "doSomething"]);
+        let hits = best_matches("cmpHndlr", &candidates, 3);
+        assert_eq!(hits.len(), 2);
+        assert!(hits.contains(&"completionHandler".to_string()));
+        assert!(hits.contains(&"completeHandler".to_string()));
+        assert!(!hits.contains(&"doSomething".to_string()));
+    }
+
+    #[test]
+    fn rejects_when_pattern_chars_do_not_appear_in_order() {
+        assert!(match_score("zzz", "abc").is_none());
+    }
+
+    #[test]
+    fn empty_pattern_scores_zero() {
+        assert_eq!(match_score("", "anything"), Some(0));
+    }
+
+    #[test]
+    fn limit_caps_results() {
+        let candidates = names(&["foo1", "foo2", "foo3", "foo4", "foo5"]);
+        let hits = best_matches("foo", &candidates, 2);
+        assert_eq!(hits.len(), 2);
+    }
+}

--- a/crates/harn-hostlib/src/ast/mod.rs
+++ b/crates/harn-hostlib/src/ast/mod.rs
@@ -34,9 +34,12 @@ use harn_vm::VmValue;
 use crate::error::HostlibError;
 use crate::registry::{BuiltinRegistry, HostlibCapability, RegisteredBuiltin, SyncHandler};
 
+mod bracket_balance;
 mod function_body;
+mod fuzzy;
 mod imports;
 mod language;
+mod mutation;
 mod outline;
 mod parse;
 mod parse_errors;
@@ -154,6 +157,30 @@ impl HostlibCapability for AstCapability {
             "hostlib_ast_extract_imports",
             "extract_imports",
             imports::run,
+        );
+        register(
+            registry,
+            "hostlib_ast_symbol_extract",
+            "symbol_extract",
+            mutation::run_extract,
+        );
+        register(
+            registry,
+            "hostlib_ast_symbol_delete",
+            "symbol_delete",
+            mutation::run_delete,
+        );
+        register(
+            registry,
+            "hostlib_ast_symbol_replace",
+            "symbol_replace",
+            mutation::run_replace,
+        );
+        register(
+            registry,
+            "hostlib_ast_bracket_balance",
+            "bracket_balance",
+            bracket_balance::run,
         );
     }
 }

--- a/crates/harn-hostlib/src/ast/mutation.rs
+++ b/crates/harn-hostlib/src/ast/mutation.rs
@@ -1,0 +1,630 @@
+//! Symbol-targeted source mutation: `extract`, `delete`, `replace`.
+//!
+//! These builtins mirror the surface of Swift `SymbolOperations`
+//! (`Sources/ASTEngine/SymbolOperations.swift`) so burin-code can drop
+//! the Swift fallback once it points its `HarnASTHostlibClient` at hostlib.
+//!
+//! ## Wire shape
+//!
+//! Every handler accepts `{ source, language, symbol_name, ... }` and
+//! returns a tagged-union dict with a `result` field driving the variant:
+//!
+//! - `extracted` → `{ text, start_line, end_line }` (1-based, inclusive)
+//! - `removed` / `replaced` → `{ source }` (rewritten text)
+//! - `not_found` → `{ available, suggestions }`
+//! - `ambiguous` → `{ match_count }`
+//! - `unsupported_language` → no extra fields
+//! - `syntax_error_after_edit` (delete/replace only) → `{ details }`
+//! - `parse_failure` (delete/replace only) → `{ details }`
+//!
+//! Coordinates are 1-based to match `SymbolOperations.ExtractedSymbol`,
+//! while the existing `ast.symbols` / `ast.outline` builtins stay 0-based
+//! per their tree-sitter native shape. The two conventions live side by
+//! side because they target different consumers — the existing ones feed
+//! editors that already think in tree-sitter coordinates; the new ones
+//! feed line-based file editing helpers that always thought in 1-based
+//! lines.
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::tools::args::{build_dict, dict_arg, require_string, str_value};
+
+use super::fuzzy;
+use super::language::Language;
+use super::parse::parse_source;
+use super::symbols::extract;
+use super::types::Symbol;
+
+const EXTRACT_BUILTIN: &str = "hostlib_ast_symbol_extract";
+const DELETE_BUILTIN: &str = "hostlib_ast_symbol_delete";
+const REPLACE_BUILTIN: &str = "hostlib_ast_symbol_replace";
+
+/// 1-based, inclusive line range for a located symbol (after preamble
+/// expansion). Mirrors the implicit `(startLine, endLine)` tuple in
+/// `SymbolOperations.findSymbolRange`.
+#[derive(Debug, Clone, Copy)]
+struct SymbolRange {
+    start_line: usize,
+    end_line: usize,
+}
+
+/// Outcome of resolving a `symbol_name` against a parsed source.
+enum LocateOutcome {
+    Found(SymbolRange),
+    NotFound {
+        available: Vec<String>,
+        suggestions: Vec<String>,
+    },
+    Ambiguous {
+        match_count: usize,
+    },
+}
+
+pub(super) fn run_extract(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(EXTRACT_BUILTIN, args)?;
+    let dict = raw.as_ref();
+    let source = require_string(EXTRACT_BUILTIN, dict, "source")?;
+    let language_name = require_string(EXTRACT_BUILTIN, dict, "language")?;
+    let symbol_name = require_string(EXTRACT_BUILTIN, dict, "symbol_name")?;
+
+    let Some(language) = Language::from_name(&language_name) else {
+        return Ok(unsupported_language_response(&language_name));
+    };
+
+    let lines = source.split('\n').collect::<Vec<&str>>();
+    let outcome = locate_symbol(EXTRACT_BUILTIN, &source, language, &symbol_name, &lines)?;
+    match outcome {
+        LocateOutcome::Found(range) => {
+            let text = slice_lines(&lines, range.start_line, range.end_line);
+            Ok(build_dict([
+                ("result", str_value("extracted")),
+                ("text", str_value(text)),
+                ("start_line", VmValue::Int(range.start_line as i64)),
+                ("end_line", VmValue::Int(range.end_line as i64)),
+            ]))
+        }
+        LocateOutcome::NotFound {
+            available,
+            suggestions,
+        } => Ok(not_found_response(available, suggestions)),
+        LocateOutcome::Ambiguous { match_count } => Ok(ambiguous_response(match_count)),
+    }
+}
+
+pub(super) fn run_delete(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(DELETE_BUILTIN, args)?;
+    let dict = raw.as_ref();
+    let source = require_string(DELETE_BUILTIN, dict, "source")?;
+    let language_name = require_string(DELETE_BUILTIN, dict, "language")?;
+    let symbol_name = require_string(DELETE_BUILTIN, dict, "symbol_name")?;
+
+    let Some(language) = Language::from_name(&language_name) else {
+        return Ok(unsupported_language_response(&language_name));
+    };
+
+    let lines = source.split('\n').collect::<Vec<&str>>();
+    let outcome = locate_symbol(DELETE_BUILTIN, &source, language, &symbol_name, &lines)?;
+    match outcome {
+        LocateOutcome::Found(range) => {
+            let new_lines = remove_range(&lines, range.start_line, range.end_line);
+            let collapsed = collapse_blank_lines(new_lines);
+            let new_source = collapsed.join("\n");
+            match validate_syntax(&new_source, language) {
+                Ok(()) => Ok(build_dict([
+                    ("result", str_value("removed")),
+                    ("source", str_value(&new_source)),
+                ])),
+                Err(details) => Ok(build_dict([
+                    ("result", str_value("syntax_error_after_edit")),
+                    ("details", str_value(&details)),
+                ])),
+            }
+        }
+        LocateOutcome::NotFound {
+            available,
+            suggestions,
+        } => Ok(not_found_response(available, suggestions)),
+        LocateOutcome::Ambiguous { match_count } => Ok(ambiguous_response(match_count)),
+    }
+}
+
+pub(super) fn run_replace(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(REPLACE_BUILTIN, args)?;
+    let dict = raw.as_ref();
+    let source = require_string(REPLACE_BUILTIN, dict, "source")?;
+    let language_name = require_string(REPLACE_BUILTIN, dict, "language")?;
+    let symbol_name = require_string(REPLACE_BUILTIN, dict, "symbol_name")?;
+    let new_text = require_string(REPLACE_BUILTIN, dict, "new_text")?;
+
+    let Some(language) = Language::from_name(&language_name) else {
+        return Ok(unsupported_language_response(&language_name));
+    };
+
+    let lines = source.split('\n').collect::<Vec<&str>>();
+    let outcome = locate_symbol(REPLACE_BUILTIN, &source, language, &symbol_name, &lines)?;
+    match outcome {
+        LocateOutcome::Found(range) => {
+            let new_lines = replace_range(&lines, range.start_line, range.end_line, &new_text);
+            let collapsed = collapse_blank_lines(new_lines);
+            let new_source = collapsed.join("\n");
+            match validate_syntax(&new_source, language) {
+                Ok(()) => Ok(build_dict([
+                    ("result", str_value("replaced")),
+                    ("source", str_value(&new_source)),
+                ])),
+                Err(details) => Ok(build_dict([
+                    ("result", str_value("syntax_error_after_edit")),
+                    ("details", str_value(&details)),
+                ])),
+            }
+        }
+        LocateOutcome::NotFound {
+            available,
+            suggestions,
+        } => Ok(not_found_response(available, suggestions)),
+        LocateOutcome::Ambiguous { match_count } => Ok(ambiguous_response(match_count)),
+    }
+}
+
+/// Parse `source`, run the existing symbol extractor, then resolve
+/// `symbol_name` (optionally `Container.member`) against the extracted
+/// list. Returns ranges in 1-based, inclusive form, with the start
+/// extended upward to capture decorators / doc comments / attributes
+/// that share the symbol's preamble.
+fn locate_symbol(
+    builtin: &'static str,
+    source: &str,
+    language: Language,
+    symbol_name: &str,
+    lines: &[&str],
+) -> Result<LocateOutcome, HostlibError> {
+    let tree = parse_source(source, language).map_err(|err| HostlibError::Backend {
+        builtin,
+        message: err.to_string(),
+    })?;
+    let symbols = extract(&tree, source, language);
+
+    let parts: Vec<&str> = symbol_name.splitn(2, '.').collect();
+    let (qualifier, base_name) = if parts.len() == 2 {
+        (Some(parts[0]), parts[1])
+    } else {
+        (None, parts[0])
+    };
+
+    let matches: Vec<&Symbol> = symbols
+        .iter()
+        .filter(|s| {
+            s.name == base_name
+                && match qualifier {
+                    Some(q) => s.container.as_deref() == Some(q),
+                    None => true,
+                }
+        })
+        .collect();
+
+    if matches.len() > 1 {
+        return Ok(LocateOutcome::Ambiguous {
+            match_count: matches.len(),
+        });
+    }
+    let Some(matched) = matches.first().copied() else {
+        let available: Vec<String> = symbols.iter().map(|s| s.name.clone()).collect();
+        let suggestions = fuzzy::best_matches(symbol_name, &available, 3);
+        return Ok(LocateOutcome::NotFound {
+            available,
+            suggestions,
+        });
+    };
+
+    let decl_line_zero = matched.start_row as usize;
+    let preamble_start_zero = find_preamble_start(lines, decl_line_zero, language);
+    let start_line = preamble_start_zero + 1;
+    let end_line = (matched.end_row as usize)
+        .saturating_add(1)
+        .min(lines.len());
+
+    Ok(LocateOutcome::Found(SymbolRange {
+        start_line,
+        end_line,
+    }))
+}
+
+/// Walk upward from a declaration line and return the 0-based line index
+/// where the symbol's preamble starts (decorators, doc comments,
+/// attributes). Mirrors `SymbolOperations.findPreambleStart`.
+fn find_preamble_start(lines: &[&str], decl_line_zero: usize, language: Language) -> usize {
+    if decl_line_zero == 0 {
+        return 0;
+    }
+    let mut start = decl_line_zero;
+    let mut i = decl_line_zero as isize - 1;
+    while i >= 0 {
+        let trimmed = lines[i as usize].trim();
+        if trimmed.is_empty() {
+            break;
+        }
+        if !is_preamble_line(trimmed, language) {
+            break;
+        }
+        start = i as usize;
+        i -= 1;
+    }
+    start
+}
+
+fn is_preamble_line(trimmed: &str, language: Language) -> bool {
+    match language {
+        Language::Python => trimmed.starts_with('@'),
+        Language::Rust => {
+            trimmed.starts_with("#[") || trimmed.starts_with("///") || trimmed.starts_with("//!")
+        }
+        Language::Go => trimmed.starts_with("//"),
+        Language::TypeScript | Language::Tsx | Language::JavaScript | Language::Jsx => {
+            trimmed.starts_with("/**")
+                || trimmed.starts_with('*')
+                || trimmed.starts_with("*/")
+                || trimmed.starts_with('@')
+                || trimmed.starts_with("//")
+        }
+        Language::Swift => trimmed.starts_with("///") || trimmed.starts_with('@'),
+        Language::Java | Language::Kotlin => {
+            trimmed.starts_with("/**")
+                || trimmed.starts_with('*')
+                || trimmed.starts_with("*/")
+                || trimmed.starts_with('@')
+                || trimmed.starts_with("//")
+        }
+        _ => {
+            trimmed.starts_with("///")
+                || trimmed.starts_with("//")
+                || trimmed.starts_with('@')
+                || trimmed.starts_with("#[")
+                || trimmed.starts_with("/**")
+        }
+    }
+}
+
+/// Re-parse `source` and surface the first tree-sitter `ERROR` /
+/// `MISSING` node as a single-line diagnostic. Mirrors the post-edit
+/// guard in Swift `SymbolOperations.validateSyntax`.
+fn validate_syntax(source: &str, language: Language) -> Result<(), String> {
+    let tree = match parse_source(source, language) {
+        Ok(tree) => tree,
+        Err(_) => return Err("Failed to parse modified source".into()),
+    };
+    let root = tree.root_node();
+    let errors = collect_errors(root, source);
+    if let Some(first) = errors.into_iter().next() {
+        return Err(first);
+    }
+    Ok(())
+}
+
+fn collect_errors(root: tree_sitter::Node<'_>, source: &str) -> Vec<String> {
+    let mut errors = Vec::new();
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        let kind = node.kind();
+        if kind == "ERROR" || kind.starts_with("MISSING") || node.is_missing() {
+            let line = node.start_position().row + 1;
+            let snippet = node_text(node, source);
+            let trimmed: String = snippet.chars().take(40).collect();
+            errors.push(format!("line {line}: unexpected '{trimmed}'"));
+        }
+        for i in (0..node.child_count()).rev() {
+            if let Some(child) = node.child(i as u32) {
+                stack.push(child);
+            }
+        }
+    }
+    errors
+}
+
+fn node_text(node: tree_sitter::Node<'_>, source: &str) -> String {
+    let bytes = source.as_bytes();
+    let start = node.start_byte().min(bytes.len());
+    let end = node.end_byte().min(bytes.len());
+    if start >= end {
+        return String::new();
+    }
+    std::str::from_utf8(&bytes[start..end])
+        .map(|s| s.to_string())
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// Line-range helpers
+// ---------------------------------------------------------------------------
+
+/// Slice `lines[start_line - 1 ..= end_line - 1]` (1-based inclusive)
+/// and re-join with newlines. Tolerates `end_line` past `lines.len()`,
+/// matching Swift's `min(endLine, lines.count)`.
+fn slice_lines(lines: &[&str], start_line: usize, end_line: usize) -> String {
+    if start_line == 0 || start_line > lines.len() {
+        return String::new();
+    }
+    let start = start_line - 1;
+    let end = end_line.min(lines.len());
+    if start >= end {
+        return String::new();
+    }
+    lines[start..end].join("\n")
+}
+
+/// Remove `lines[start_line - 1 ..= end_line - 1]` (1-based inclusive)
+/// and return the surviving lines in document order.
+fn remove_range(lines: &[&str], start_line: usize, end_line: usize) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(lines.len());
+    let start = start_line.saturating_sub(1);
+    let end = end_line.min(lines.len());
+    out.extend(lines[..start].iter().map(|s| (*s).to_string()));
+    if end < lines.len() {
+        out.extend(lines[end..].iter().map(|s| (*s).to_string()));
+    }
+    out
+}
+
+/// Replace `lines[start_line - 1 ..= end_line - 1]` with the lines of
+/// `new_text` (split on `\n`).
+fn replace_range(
+    lines: &[&str],
+    start_line: usize,
+    end_line: usize,
+    new_text: &str,
+) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(lines.len());
+    let start = start_line.saturating_sub(1);
+    let end = end_line.min(lines.len());
+    out.extend(lines[..start].iter().map(|s| (*s).to_string()));
+    out.extend(new_text.split('\n').map(|s| s.to_string()));
+    if end < lines.len() {
+        out.extend(lines[end..].iter().map(|s| (*s).to_string()));
+    }
+    out
+}
+
+/// Collapse runs of 3+ blank lines to 2, matching Swift's `collapseBlankLines`.
+fn collapse_blank_lines(lines: Vec<String>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(lines.len());
+    let mut blank_count: usize = 0;
+    for line in lines {
+        if line.trim().is_empty() {
+            blank_count += 1;
+            if blank_count <= 2 {
+                out.push(line);
+            }
+        } else {
+            blank_count = 0;
+            out.push(line);
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Response shaping
+// ---------------------------------------------------------------------------
+
+fn unsupported_language_response(name: &str) -> VmValue {
+    build_dict([
+        ("result", str_value("unsupported_language")),
+        ("language", str_value(name)),
+    ])
+}
+
+fn not_found_response(available: Vec<String>, suggestions: Vec<String>) -> VmValue {
+    let available_list = VmValue::List(Rc::new(
+        available.into_iter().map(|s| str_value(&s)).collect(),
+    ));
+    let suggestions_list = VmValue::List(Rc::new(
+        suggestions.into_iter().map(|s| str_value(&s)).collect(),
+    ));
+    let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+    dict.insert("result".into(), str_value("not_found"));
+    dict.insert("available".into(), available_list);
+    dict.insert("suggestions".into(), suggestions_list);
+    VmValue::Dict(Rc::new(dict))
+}
+
+fn ambiguous_response(match_count: usize) -> VmValue {
+    build_dict([
+        ("result", str_value("ambiguous")),
+        ("match_count", VmValue::Int(match_count as i64)),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vm_string(s: &str) -> VmValue {
+        VmValue::String(Rc::from(s))
+    }
+
+    fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
+        let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+        for (k, v) in pairs {
+            map.insert((*k).to_string(), v.clone());
+        }
+        VmValue::Dict(Rc::new(map))
+    }
+
+    fn dict_field<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {
+        match value {
+            VmValue::Dict(d) => d.get(key).expect("missing field"),
+            _ => panic!("expected dict"),
+        }
+    }
+
+    fn string_field(value: &VmValue, key: &str) -> String {
+        match dict_field(value, key) {
+            VmValue::String(s) => s.to_string(),
+            other => panic!("expected string for {key}, got {other:?}"),
+        }
+    }
+
+    fn int_field(value: &VmValue, key: &str) -> i64 {
+        match dict_field(value, key) {
+            VmValue::Int(n) => *n,
+            other => panic!("expected int for {key}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn collapse_drops_runs_of_three_or_more() {
+        let lines = vec!["a", "", "", "", "b"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let collapsed = collapse_blank_lines(lines);
+        assert_eq!(collapsed, vec!["a", "", "", "b"]);
+    }
+
+    #[test]
+    fn extract_returns_text_and_one_based_line_range() {
+        let source = "fn alpha() {}\nfn beta() {}\nfn gamma() {}\n";
+        let result = run_extract(&[dict(&[
+            ("source", vm_string(source)),
+            ("language", vm_string("rust")),
+            ("symbol_name", vm_string("beta")),
+        ])])
+        .expect("extract works");
+        assert_eq!(string_field(&result, "result"), "extracted");
+        assert_eq!(int_field(&result, "start_line"), 2);
+        assert_eq!(int_field(&result, "end_line"), 2);
+        assert_eq!(string_field(&result, "text"), "fn beta() {}");
+    }
+
+    #[test]
+    fn delete_removes_target_function_and_validates_syntax() {
+        let source = "fn alpha() {}\nfn beta() {}\nfn gamma() {}\n";
+        let result = run_delete(&[dict(&[
+            ("source", vm_string(source)),
+            ("language", vm_string("rust")),
+            ("symbol_name", vm_string("beta")),
+        ])])
+        .expect("delete works");
+        assert_eq!(string_field(&result, "result"), "removed");
+        let new_source = string_field(&result, "source");
+        assert!(!new_source.contains("beta"));
+        assert!(new_source.contains("alpha"));
+        assert!(new_source.contains("gamma"));
+    }
+
+    #[test]
+    fn replace_swaps_in_new_text_and_validates() {
+        let source = "fn alpha() {}\nfn beta() {}\n";
+        let new_text = "fn beta() -> i32 { 42 }";
+        let result = run_replace(&[dict(&[
+            ("source", vm_string(source)),
+            ("language", vm_string("rust")),
+            ("symbol_name", vm_string("beta")),
+            ("new_text", vm_string(new_text)),
+        ])])
+        .expect("replace works");
+        assert_eq!(string_field(&result, "result"), "replaced");
+        let new_source = string_field(&result, "source");
+        assert!(new_source.contains("-> i32 { 42 }"));
+    }
+
+    #[test]
+    fn replace_reports_syntax_error_after_edit() {
+        let source = "fn alpha() {}\nfn beta() {}\n";
+        let new_text = "fn beta( {"; // intentional syntax error
+        let result = run_replace(&[dict(&[
+            ("source", vm_string(source)),
+            ("language", vm_string("rust")),
+            ("symbol_name", vm_string("beta")),
+            ("new_text", vm_string(new_text)),
+        ])])
+        .expect("replace handler runs");
+        assert_eq!(string_field(&result, "result"), "syntax_error_after_edit");
+        assert!(!string_field(&result, "details").is_empty());
+    }
+
+    #[test]
+    fn not_found_returns_available_and_suggestions() {
+        let source = "fn parse_query() {}\nfn parse_other() {}\n";
+        let result = run_extract(&[dict(&[
+            ("source", vm_string(source)),
+            ("language", vm_string("rust")),
+            ("symbol_name", vm_string("parse_qury")),
+        ])])
+        .expect("extract handler runs");
+        assert_eq!(string_field(&result, "result"), "not_found");
+        match dict_field(&result, "available") {
+            VmValue::List(items) => assert!(!items.is_empty()),
+            other => panic!("expected list, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ambiguous_when_multiple_unqualified_matches() {
+        // Two methods named `greet` in different classes.
+        let source = "class A:\n    def greet(self): pass\nclass B:\n    def greet(self): pass\n";
+        let result = run_extract(&[dict(&[
+            ("source", vm_string(source)),
+            ("language", vm_string("python")),
+            ("symbol_name", vm_string("greet")),
+        ])])
+        .expect("extract handler runs");
+        assert_eq!(string_field(&result, "result"), "ambiguous");
+        assert!(int_field(&result, "match_count") >= 2);
+    }
+
+    #[test]
+    fn qualified_name_disambiguates() {
+        let source = "class A:\n    def greet(self): pass\nclass B:\n    def greet(self): pass\n";
+        let result = run_extract(&[dict(&[
+            ("source", vm_string(source)),
+            ("language", vm_string("python")),
+            ("symbol_name", vm_string("A.greet")),
+        ])])
+        .expect("extract handler runs");
+        assert_eq!(string_field(&result, "result"), "extracted");
+        assert_eq!(int_field(&result, "start_line"), 2);
+    }
+
+    #[test]
+    fn extract_includes_python_decorator_preamble() {
+        let source = "@dataclass\nclass Greeter:\n    name: str\n";
+        let result = run_extract(&[dict(&[
+            ("source", vm_string(source)),
+            ("language", vm_string("python")),
+            ("symbol_name", vm_string("Greeter")),
+        ])])
+        .expect("extract handler runs");
+        assert_eq!(string_field(&result, "result"), "extracted");
+        assert_eq!(int_field(&result, "start_line"), 1);
+        assert!(string_field(&result, "text").contains("@dataclass"));
+    }
+
+    #[test]
+    fn extract_includes_rust_attribute_preamble() {
+        let source = "#[test]\nfn it_works() {}\n";
+        let result = run_extract(&[dict(&[
+            ("source", vm_string(source)),
+            ("language", vm_string("rust")),
+            ("symbol_name", vm_string("it_works")),
+        ])])
+        .expect("extract handler runs");
+        assert_eq!(string_field(&result, "result"), "extracted");
+        assert_eq!(int_field(&result, "start_line"), 1);
+        assert!(string_field(&result, "text").starts_with("#[test]"));
+    }
+
+    #[test]
+    fn unsupported_language_short_circuits() {
+        let result = run_extract(&[dict(&[
+            ("source", vm_string("hello")),
+            ("language", vm_string("klingon")),
+            ("symbol_name", vm_string("greet")),
+        ])])
+        .expect("extract handler runs");
+        assert_eq!(string_field(&result, "result"), "unsupported_language");
+    }
+}

--- a/crates/harn-hostlib/src/schemas.rs
+++ b/crates/harn-hostlib/src/schemas.rs
@@ -121,6 +121,54 @@ pub const SCHEMAS: &[(&str, &str, SchemaKind, &str)] = &[
         SchemaKind::Response,
         include_str!("../schemas/ast/extract_imports.response.json"),
     ),
+    (
+        "ast",
+        "symbol_extract",
+        SchemaKind::Request,
+        include_str!("../schemas/ast/symbol_extract.request.json"),
+    ),
+    (
+        "ast",
+        "symbol_extract",
+        SchemaKind::Response,
+        include_str!("../schemas/ast/symbol_extract.response.json"),
+    ),
+    (
+        "ast",
+        "symbol_delete",
+        SchemaKind::Request,
+        include_str!("../schemas/ast/symbol_delete.request.json"),
+    ),
+    (
+        "ast",
+        "symbol_delete",
+        SchemaKind::Response,
+        include_str!("../schemas/ast/symbol_delete.response.json"),
+    ),
+    (
+        "ast",
+        "symbol_replace",
+        SchemaKind::Request,
+        include_str!("../schemas/ast/symbol_replace.request.json"),
+    ),
+    (
+        "ast",
+        "symbol_replace",
+        SchemaKind::Response,
+        include_str!("../schemas/ast/symbol_replace.response.json"),
+    ),
+    (
+        "ast",
+        "bracket_balance",
+        SchemaKind::Request,
+        include_str!("../schemas/ast/bracket_balance.request.json"),
+    ),
+    (
+        "ast",
+        "bracket_balance",
+        SchemaKind::Response,
+        include_str!("../schemas/ast/bracket_balance.response.json"),
+    ),
     // code_index/
     (
         "code_index",

--- a/crates/harn-hostlib/tests/ast_builtins.rs
+++ b/crates/harn-hostlib/tests/ast_builtins.rs
@@ -196,6 +196,190 @@ fn parse_file_meets_perf_budget_on_a_known_input() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Mutation + bracket-balance builtins (issue #775)
+// ---------------------------------------------------------------------------
+
+fn vm_string(s: &str) -> VmValue {
+    VmValue::String(Rc::from(s))
+}
+
+#[test]
+fn symbol_extract_returns_one_based_inclusive_lines() {
+    let registry = ast_registry();
+    let source = "fn alpha() {}\nfn beta() {}\nfn gamma() {}\n";
+    let payload = dict(&[
+        ("source", vm_string(source)),
+        ("language", vm_string("rust")),
+        ("symbol_name", vm_string("beta")),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_symbol_extract", payload);
+    assert_eq!(string_value(&dict_field(&result, "result")), "extracted");
+    assert_eq!(int_value(&dict_field(&result, "start_line")), 2);
+    assert_eq!(int_value(&dict_field(&result, "end_line")), 2);
+    assert_eq!(string_value(&dict_field(&result, "text")), "fn beta() {}");
+}
+
+#[test]
+fn symbol_delete_removes_function_and_keeps_syntax_valid() {
+    let registry = ast_registry();
+    let source = "fn alpha() {}\nfn beta() {}\nfn gamma() {}\n";
+    let payload = dict(&[
+        ("source", vm_string(source)),
+        ("language", vm_string("rust")),
+        ("symbol_name", vm_string("beta")),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_symbol_delete", payload);
+    assert_eq!(string_value(&dict_field(&result, "result")), "removed");
+    let new_source = string_value(&dict_field(&result, "source")).to_string();
+    assert!(!new_source.contains("beta"));
+    assert!(new_source.contains("alpha"));
+    assert!(new_source.contains("gamma"));
+}
+
+#[test]
+fn symbol_replace_swaps_in_caller_text() {
+    let registry = ast_registry();
+    let source = "fn alpha() {}\nfn beta() -> i32 { 0 }\n";
+    let payload = dict(&[
+        ("source", vm_string(source)),
+        ("language", vm_string("rust")),
+        ("symbol_name", vm_string("beta")),
+        ("new_text", vm_string("fn beta() -> i32 { 42 }")),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_symbol_replace", payload);
+    assert_eq!(string_value(&dict_field(&result, "result")), "replaced");
+    assert!(string_value(&dict_field(&result, "source")).contains("42"));
+}
+
+#[test]
+fn symbol_replace_flags_post_edit_syntax_error() {
+    let registry = ast_registry();
+    let source = "fn alpha() {}\nfn beta() {}\n";
+    let payload = dict(&[
+        ("source", vm_string(source)),
+        ("language", vm_string("rust")),
+        ("symbol_name", vm_string("beta")),
+        // Unclosed paren intentionally breaks the edit.
+        ("new_text", vm_string("fn beta( {")),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_symbol_replace", payload);
+    assert_eq!(
+        string_value(&dict_field(&result, "result")),
+        "syntax_error_after_edit"
+    );
+    assert!(!string_value(&dict_field(&result, "details")).is_empty());
+}
+
+#[test]
+fn symbol_lookup_reports_ambiguity_with_match_count() {
+    let registry = ast_registry();
+    let source = "class A:\n    def greet(self): pass\nclass B:\n    def greet(self): pass\n";
+    let payload = dict(&[
+        ("source", vm_string(source)),
+        ("language", vm_string("python")),
+        ("symbol_name", vm_string("greet")),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_symbol_extract", payload);
+    assert_eq!(string_value(&dict_field(&result, "result")), "ambiguous");
+    assert!(int_value(&dict_field(&result, "match_count")) >= 2);
+}
+
+#[test]
+fn symbol_lookup_qualified_name_disambiguates() {
+    let registry = ast_registry();
+    let source = "class A:\n    def greet(self): pass\nclass B:\n    def greet(self): pass\n";
+    let payload = dict(&[
+        ("source", vm_string(source)),
+        ("language", vm_string("python")),
+        ("symbol_name", vm_string("B.greet")),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_symbol_extract", payload);
+    assert_eq!(string_value(&dict_field(&result, "result")), "extracted");
+    assert!(string_value(&dict_field(&result, "text")).contains("greet"));
+    assert_eq!(int_value(&dict_field(&result, "start_line")), 4);
+}
+
+#[test]
+fn symbol_lookup_emits_suggestions_when_typo_misses() {
+    let registry = ast_registry();
+    let source = "fn parse_query() {}\nfn parse_other() {}\n";
+    let payload = dict(&[
+        ("source", vm_string(source)),
+        ("language", vm_string("rust")),
+        ("symbol_name", vm_string("parse_qury")),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_symbol_extract", payload);
+    assert_eq!(string_value(&dict_field(&result, "result")), "not_found");
+    let suggestions = list_value(&dict_field(&result, "suggestions"));
+    assert!(!suggestions.is_empty());
+    let names: Vec<&str> = suggestions.iter().map(string_value).collect();
+    assert!(names.contains(&"parse_query"));
+}
+
+#[test]
+fn unsupported_language_short_circuits_on_mutation_builtins() {
+    let registry = ast_registry();
+    for builtin in &[
+        "hostlib_ast_symbol_extract",
+        "hostlib_ast_symbol_delete",
+        "hostlib_ast_symbol_replace",
+    ] {
+        let mut entries = vec![
+            ("source", vm_string("hello")),
+            ("language", vm_string("klingon")),
+            ("symbol_name", vm_string("greet")),
+        ];
+        if *builtin == "hostlib_ast_symbol_replace" {
+            entries.push(("new_text", vm_string("replacement")));
+        }
+        let result = invoke(&registry, builtin, dict(&entries));
+        assert_eq!(
+            string_value(&dict_field(&result, "result")),
+            "unsupported_language",
+            "{builtin} did not short-circuit on klingon",
+        );
+    }
+}
+
+#[test]
+fn bracket_balance_counts_unmatched_opener() {
+    let registry = ast_registry();
+    let payload = dict(&[
+        ("source", vm_string("fn foo() {")),
+        ("language", vm_string("rust")),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_bracket_balance", payload);
+    assert_eq!(int_value(&dict_field(&result, "parens")), 0);
+    assert_eq!(int_value(&dict_field(&result, "brackets")), 0);
+    assert_eq!(int_value(&dict_field(&result, "braces")), 1);
+}
+
+#[test]
+fn bracket_balance_ignores_brackets_inside_strings() {
+    let registry = ast_registry();
+    let payload = dict(&[
+        ("source", vm_string(r#"let s = "}{)";"#)),
+        ("language", vm_string("rust")),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_bracket_balance", payload);
+    assert_eq!(int_value(&dict_field(&result, "parens")), 0);
+    assert_eq!(int_value(&dict_field(&result, "braces")), 0);
+}
+
+#[test]
+fn bracket_balance_python_uses_hash_comments() {
+    let registry = ast_registry();
+    let payload = dict(&[
+        // Python `//` is integer division; must not be parsed as a comment.
+        ("source", vm_string("x = 5 // 2  # cmt with [\n")),
+        ("language", vm_string("python")),
+    ]);
+    let result = invoke(&registry, "hostlib_ast_bracket_balance", payload);
+    assert_eq!(int_value(&dict_field(&result, "brackets")), 0);
+    assert_eq!(int_value(&dict_field(&result, "parens")), 0);
+}
+
 #[test]
 fn parse_errors_returns_clean_payload_for_valid_python() {
     let registry = ast_registry();

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -34,14 +34,18 @@ fn ast_capability_registers_documented_methods() {
             "hostlib_ast_function_body",
             "hostlib_ast_function_bodies",
             "hostlib_ast_extract_imports",
+            "hostlib_ast_symbol_extract",
+            "hostlib_ast_symbol_delete",
+            "hostlib_ast_symbol_replace",
+            "hostlib_ast_bracket_balance",
         ]
     );
     // Each AST builtin must reject empty input with a structured
     // `MissingParameter`. The required field differs per method:
-    // file-based builtins want `path`; the analysis builtins added by
-    // #773 accept either `content` or `path` and surface that as the
-    // `content_or_path` synthetic parameter; the new builtins added by
-    // #774 require the function-name / list-of-names / source field.
+    // file-based builtins want `path`; analysis builtins (#773) accept
+    // either `content` or `path`; the source-mutation builtins (#774/#775)
+    // take `source`; function_body takes `function_name`; function_bodies
+    // takes `names`.
     let expected_missing: &[(&str, &str)] = &[
         ("hostlib_ast_parse_file", "path"),
         ("hostlib_ast_symbols", "path"),
@@ -51,6 +55,10 @@ fn ast_capability_registers_documented_methods() {
         ("hostlib_ast_function_body", "function_name"),
         ("hostlib_ast_function_bodies", "names"),
         ("hostlib_ast_extract_imports", "source"),
+        ("hostlib_ast_symbol_extract", "source"),
+        ("hostlib_ast_symbol_delete", "source"),
+        ("hostlib_ast_symbol_replace", "source"),
+        ("hostlib_ast_bracket_balance", "source"),
     ];
     for (name, expected_param) in expected_missing {
         let entry = registry.find(name).expect("registered");
@@ -237,9 +245,9 @@ fn install_default_wires_every_module_into_a_vm() {
         registry.modules(),
         &["ast", "code_index", "scanner", "fs_watch", "tools"]
     );
-    // Builtin count: 8 ast + 27 code_index + 2 scanner + 2 fs_watch + 12
-    // tools + 1 hostlib_enable = 52.
-    assert!(registry.builtins().len() >= 52);
+    // Builtin count: 12 ast + 27 code_index + 2 scanner + 2 fs_watch + 12
+    // tools + 1 hostlib_enable = 56.
+    assert!(registry.builtins().len() >= 56);
 }
 
 #[test]


### PR DESCRIPTION
Closes #775.

## Summary

Extends `crates/harn-hostlib/src/ast` with four new builtins so burin-code can retire `Sources/ASTEngine/SymbolOperations.swift` and `BracketBalance.swift`:

- **`hostlib_ast_symbol_extract`** — locate a named symbol and return its text + 1-based inclusive line range. Mirrors `SymbolOperations.extract`.
- **`hostlib_ast_symbol_delete`** — remove a named symbol from source, collapse 3+ blank-line runs, re-parse to validate. Mirrors `SymbolOperations.delete`.
- **`hostlib_ast_symbol_replace`** — splice caller-provided text in place of a named symbol's preamble + signature + body, re-parse to validate. Mirrors `SymbolOperations.replace`.
- **`hostlib_ast_bracket_balance`** — signed parens/brackets/braces counts with string + comment lexer states. Mirrors `BracketBalanceCounter`.

All four follow the same tagged-union envelope: a `result` enum (`extracted` / `removed` / `replaced` / `not_found` / `ambiguous` / `unsupported_language` / `syntax_error_after_edit`) drives which companion fields are populated.

## Implementation notes

- **Symbol resolution** reuses the existing per-language extractors in `ast/symbols.rs` rather than reimplementing tree-sitter walks. Container-qualified names (`Foo.bar`) disambiguate when the unqualified name has multiple matches; bare names with >1 match return `ambiguous` with `match_count`.
- **Preamble expansion** walks upward from the declaration line to capture decorators, doc comments, and attributes per language — Python `@`, Rust `#[...]` / `///` / `//!`, Go `//`, JS/TS JSDoc / decorators / `//`, Swift `///` / `@`, Java/Kotlin `@` / Javadoc.
- **Post-edit validation** for `delete` / `replace` re-parses the rewritten source; if tree-sitter reports an `ERROR` / `MISSING` node the call returns `syntax_error_after_edit` with a `details` string rather than the rewritten source.
- **Fuzzy suggestions** port `Sources/ASTEngine/FuzzyMatcher.swift` (subsequence-with-bonuses scoring), so the `not_found` payload surfaces the same \"did you mean?\" suggestions the Swift fallback produced.
- **Coordinates**: 1-based inclusive lines for the new builtins (matching `SymbolOperations.ExtractedSymbol`); the existing `ast.symbols` / `ast.outline` builtins stay 0-based per their tree-sitter native shape.

## Wire surface

| Builtin | Module / Method | Schemas added |
| --- | --- | --- |
| `hostlib_ast_symbol_extract` | `ast.symbol_extract` | `symbol_extract.{request,response}.json` |
| `hostlib_ast_symbol_delete` | `ast.symbol_delete` | `symbol_delete.{request,response}.json` |
| `hostlib_ast_symbol_replace` | `ast.symbol_replace` | `symbol_replace.{request,response}.json` |
| `hostlib_ast_bracket_balance` | `ast.bracket_balance` | `bracket_balance.{request,response}.json` |

Each schema declares JSON Schema draft 2020-12 and is wired into `schemas::SCHEMAS`. The schema-drift contract test (`every_registered_builtin_has_request_and_response_schemas`) covers the new pairs automatically.

## Test plan

- [x] Hostlib unit tests pass (114 passed, including new fuzzy matcher and inline mutation tests)
- [x] Hostlib integration tests pass — `tests/registration.rs` (8) + `tests/ast_builtins.rs` (17, with 11 new ones for the mutation + bracket-balance surface)
- [x] Workspace `cargo check`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean
- [x] `make test` (2727 tests) green
- [x] Pre-commit hooks pass (rustfmt + clippy)
- [ ] Once burin-code wires `HarnASTHostlibClient` to these builtins, schema-drift coverage on the burin-code side will exercise the response shape in CI

## Out of scope

- Migrating burin-code's `ASTRPC.swift`, `HarnHostServer+ASTPrimitives.swift`, `HarnHostServer+HostCapabilities.swift`, `CoreToolExecutor+Search.swift` call sites to the new builtins (separate burin-code ticket).
- Sibling tickets on the burin-code epic [burin-labs/burin-code#289](https://github.com/burin-labs/burin-code/issues/289): #773 (parse-error / undefined-name diagnostics), #774 (function body + import extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)