### PR TITLE
ci: never cancel in-progress release binary builds

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -25,7 +25,7 @@ permissions:
 
 concurrency:
   group: build-release-binaries-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

- Changes `cancel-in-progress` from `${{ github.ref == 'refs/heads/main' }}` to `false` in `build-release-binaries.yml`
- Previously, any push to `main` (e.g. a Dependabot bump landing post-release) would cancel an in-progress main-branch build
- With this change, the running build always completes; new triggers for the same `github.ref` queue behind it rather than evicting it
- Tag builds (`refs/tags/v*`) were already in their own per-ref concurrency group and unaffected — this just closes the gap for main-branch builds

## Trade-off

Main-branch builds now queue rather than cancel. If many PRs merge in quick succession, earlier builds have to finish before later ones start. Given how long these cross-platform Rust builds take, that's the better default for a release workflow — better to let a healthy build finish than to kill it for something that can wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)