### PR TITLE
Release v0.7.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,35 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
-## Unreleased
+## v0.7.47
 
 ### Added
+
+- **Long-running tool handles for `run_command`, `run_test`,
+  `run_build_command` (#778/#803).** Pass `long_running: true` to spawn
+  the child process without blocking and receive a handle dict immediately
+  — `{ handle_id, started_at, command }`. A background waiter drains
+  stdout/stderr on separate threads (preventing pipe deadlock), calls
+  `child.wait()`, and injects the result into the agent's next turn via a
+  new cross-thread feedback queue (`push_pending_feedback_global` /
+  `drain_pending_feedback`). A new `tools.cancel_handle` builtin
+  SIGKILLs an in-flight handle by ID and suppresses the pending feedback
+  push. Session-end cleanup fires automatically: orphaned child processes
+  are killed when the agent-loop session exits via
+  `register_session_end_hook` / `cancel_session_handles`.
+
+- **AST hostlib symbol mutation + bracket balance (#775/#798).** Four
+  new builtins on the `ast::*` hostlib surface so burin-code can retire
+  `SymbolOperations.swift` and `BracketBalance.swift`:
+  `ast.symbol_extract` locates a named symbol and returns its text with
+  1-based inclusive line range; `ast.symbol_delete` removes it and
+  collapses resulting blank-line runs; `ast.symbol_replace` splices
+  caller-provided text in place of the symbol's preamble + signature +
+  body (both mutating ops re-parse to validate); `ast.bracket_balance`
+  returns signed paren/bracket/brace counts using a string + comment
+  lexer. All four follow the standard tagged-union envelope with result
+  variants `extracted` / `removed` / `replaced` / `not_found` /
+  `ambiguous` / `unsupported_language` / `syntax_error_after_edit`.
 
 - **`parse_junit_xml` stdlib builtin (#801).** New core builtin that
   parses a JUnit XML test report (`string` or `bytes`) into a list of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.46"
+version = "0.7.47"
 dependencies = [
  "async-trait",
  "axum",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.46"
+version = "0.7.47"
 dependencies = [
  "harn-vm",
  "serde",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.46"
+version = "0.7.47"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.46"
+version = "0.7.47"
 dependencies = [
  "anyhow",
  "base64",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.46"
+version = "0.7.47"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1740,11 +1740,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.46"
+version = "0.7.47"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.46"
+version = "0.7.47"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.46"
+version = "0.7.47"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.46"
+version = "0.7.47"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.46"
+version = "0.7.47"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.46"
+version = "0.7.47"
 dependencies = [
  "async-trait",
  "axum",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "harn-vm"
-version = "0.7.46"
+version = "0.7.47"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.46"
+version = "0.7.47"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
## Summary

- Long-running tool handles for `run_command` / `run_test` / `run_build_command` — pass `long_running: true` to get a handle dict immediately; background waiter injects result on the agent's next turn; `tools.cancel_handle` for SIGKILL; session-end auto-cleanup (#778/#803)
- AST hostlib symbol mutation + bracket balance — `ast.symbol_extract`, `ast.symbol_delete`, `ast.symbol_replace`, `ast.bracket_balance`; enables burin-code to retire `SymbolOperations.swift` and `BracketBalance.swift` (#775/#798)
- `parse_junit_xml` stdlib builtin — parses JUnit XML (GTest, Maven Surefire, pytest, vitest, cargo-nextest) into structured per-case dicts (#801)

## Release notes

### Added

- **Long-running tool handles for `run_command`, `run_test`, `run_build_command` (#778/#803).** Pass `long_running: true` to spawn the child process without blocking and receive a handle dict immediately — `{ handle_id, started_at, command }`. A background waiter drains stdout/stderr on separate threads (preventing pipe deadlock), calls `child.wait()`, and injects the result into the agent's next turn via a new cross-thread feedback queue. A new `tools.cancel_handle` builtin SIGKILLs an in-flight handle by ID. Session-end cleanup fires automatically via `register_session_end_hook` / `cancel_session_handles`.

- **AST hostlib symbol mutation + bracket balance (#775/#798).** Four new builtins: `ast.symbol_extract`, `ast.symbol_delete`, `ast.symbol_replace`, `ast.bracket_balance`. All follow the standard tagged-union envelope.

- **`parse_junit_xml` stdlib builtin (#801).** Parses a JUnit XML test report into a list of per-case dicts. Intentionally lenient — malformed input yields `[]`.

## Test plan

- [x] Pre-push hook ran all 2837 Rust tests (2837 passed, 0 skipped)
- [x] Pre-commit hook: fmt, clippy, markdown lint — all clean
- [x] Portal lint + build passed during `--prepare`
- [x] Full merge-queue CI will run conformance, harn lint/fmt, highlight drift, docs snippet checks, and Windows smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)