### PR TITLE
docs: reorganize IA and protocol references

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,35 +298,8 @@ execution plus explicit host approval for destructive operations.
 
 ## Release Workflow
 
-Once the release content (code + docs + `CHANGELOG.md` entry for the next
-version) lands on `main` through the merge queue, maintainers open the
-automated version-bump PR with:
-
-```bash
-./scripts/release_ship.sh --bump patch
-```
-
-After that PR lands through the merge queue, finalize the release from an
-up-to-date `main`:
-
-```bash
-./scripts/release_ship.sh --finalize
-```
-
-The first command runs audit → dry-run publish → bump → commit → push
-`release/vX.Y.Z` → open PR. The finalize command runs audit → dry-run publish
-→ tag → push tag → `cargo publish` → GitHub release creation. The tag push
-happens **before** `cargo publish` so downstream consumers and GitHub
-release-binary workflows can start working in parallel with crates.io.
-
-For piecewise work (or a dry run that stops before destructive actions):
-
-```bash
-./scripts/release_gate.sh audit
-./scripts/release_gate.sh full --bump patch --dry-run
-```
-
-`scripts/publish.sh` remains the crates.io publisher used by the gate.
+Maintainer release commands and gates live in
+[Maintainer release workflow](docs/src/maintainer-release.md).
 
 ## Local Development
 
@@ -492,7 +465,8 @@ notifications:
 - [LLM quick reference](https://harnlang.com/docs/llm/harn-quickref.html)
 - [Workflow runtime guide](https://harnlang.com/workflow-runtime.html)
 - [LLM calls and agent loops](https://harnlang.com/llm-and-agents.html)
-- [MCP and ACP integration](https://harnlang.com/mcp-and-acp.html)
+- [Protocol support matrix](https://harnlang.com/protocol-support.html)
+- [MCP, ACP, and A2A integration](https://harnlang.com/mcp-and-acp.html)
 - [CLI reference](https://harnlang.com/cli-reference.html)
 - [Builtin reference](https://harnlang.com/builtins.html)
 - [Language spec](spec/HARN_SPEC.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -2,30 +2,28 @@
 
 [Introduction](./introduction.md)
 
-# Getting started
+# Getting Started
 
 - [Getting started](./getting-started.md)
 - [Scripting cheatsheet](./scripting-cheatsheet.md)
 - [LLM quick reference](./docs/llm/harn-quickref.md)
 - [Why Harn?](./why-harn.md)
 
-# The language
+# Language
 
 - [Language basics](./language-basics.md)
 - [Error handling](./error-handling.md)
 - [Modules and imports](./modules.md)
 - [Concurrency](./concurrency.md)
-- [Language specification](./language-spec.md)
 - [Runtime context](./runtime-context.md)
+- [Language specification](./language-spec.md)
 
-# Agents and workflows
+# Agent Runtime
 
 - [LLM calls and agent loops](./llm-and-agents.md)
 - [Typed tools for agent loops](./typed-tools.md)
 - [Daemon stdlib](./stdlib/daemon.md)
 - [Current session builtin](./stdlib/agent_session_current_id.md)
-- [Triggers](./triggers.md)
-- [Trigger stdlib](./stdlib/triggers.md)
 - [Monitor stdlib](./stdlib/monitors.md)
 - [Prompt library stdlib](./stdlib/prompt-library.md)
 - [Human in the loop](./hitl.md)
@@ -33,7 +31,6 @@
 - [Skills](./skills.md)
 - [Personas](./personas.md)
 - [Skill provenance](./skill-provenance.md)
-- [Package authoring](./package-authoring.md)
 - [Sessions](./sessions.md)
 - [Agent state](./agent-state.md)
 - [Transcript architecture](./transcript-architecture.md)
@@ -41,16 +38,45 @@
 - [Team learning and context packs](./team-learning.md)
 - [Workflow crystallization](./workflow-crystallization.md)
 - [Flow predicate language](./flow-predicates.md)
+
+# Protocols
+
+- [Protocol support matrix](./protocol-support.md)
+- [MCP, ACP, and A2A integration](./mcp-and-acp.md)
+- [Outbound workflow server](./harn-serve.md)
+- [Bridge protocol](./bridge-protocol.md)
+- [Host tools over the bridge](./bridge/host-tools.md)
+- [ACP over WebSocket](./acp/websocket.md)
+- [Agents Protocol v1](./spec/agents-protocol/v1.md)
+- [Agents Protocol Receipt Format](./spec/agents-protocol/receipt-format-v1.md)
+- [Agents Protocol Replay Contract](./spec/agents-protocol/replay-v1.md)
+
+# Orchestration
+
+- [Triggers](./triggers.md)
+- [Trigger stdlib](./stdlib/triggers.md)
 - [Trigger manifests](./triggers/manifest.md)
 - [Trigger budgets](./triggers/budgets.md)
 - [Trigger event schema](./triggers/event-schema.md)
 - [Trigger dispatcher](./triggers/dispatcher.md)
-- [Trigger observability in the action graph](./observability/triggers-in-action-graph.md)
+- [Trigger registry](./triggers/registry.md)
+- [Orchestrator](./orchestrator.md)
+- [Hot reload](./orchestrator/hot-reload.md)
+- [Orchestrator DLQ management](./orchestrator/dlq.md)
+- [Orchestrator backpressure](./orchestrator/backpressure.md)
+- [Worker dispatch](./orchestrator/worker-dispatch.md)
+- [Orchestrator secrets](./orchestrator/secrets.md)
+- [Multi-tenant orchestrator](./orchestrator/multi-tenant.md)
+- [Connector OAuth](./orchestrator/oauth.md)
+- [Orchestrator MCP server](./mcp-server.md)
+
+# Packages and Connectors
+
+- [Package authoring](./package-authoring.md)
 - [Connector authoring](./connectors/authoring.md)
 - [Connector architecture status](./connectors/architecture.md)
 - [Connector catalog](./connectors/catalog.md)
 - [Connector testkit](./connectors/testkit.md)
-- [Trigger registry](./triggers/registry.md)
 - [Cron connector](./connectors/cron.md)
 - [GitHub App connector](./connectors/github.md)
 - [Linear connector](./connectors/linear.md)
@@ -58,48 +84,39 @@
 - [Slack Events connector](./connectors/slack-events.md)
 - [Generic webhook connector](./connectors/webhook.md)
 - [A2A push connector](./connectors/a2a-push.md)
+
+# Observability
+
+- [Harn portal](./portal.md)
+- [Debugging agent runs](./debugging.md)
+- [Trigger observability in the action graph](./observability/triggers-in-action-graph.md)
+- [Orchestrator observability](./orchestrator/observability.md)
+
+# Operations
+
+- [Playground](./playground.md)
+- [Host boundary](./host-boundary.md)
+- [Deploy to Render](./deploy/render.md)
+- [Deploy to Fly.io](./deploy/fly.md)
+- [Deploy to Railway](./deploy/railway.md)
+- [Maintainer release workflow](./maintainer-release.md)
+
+# Tutorials and Guides
+
 - [Cookbook](./cookbook.md)
 - [Tutorial: code review agent](./tutorial-code-review-agent.md)
 - [Tutorial: MCP server](./tutorial-mcp-server.md)
 - [Tutorial: eval pipeline](./tutorial-eval-pipeline.md)
 - [Best practices](./best-practices.md)
 
-# Hosts and integration
-
-- [Playground](./playground.md)
-- [Host boundary](./host-boundary.md)
-- [Bridge protocol](./bridge-protocol.md)
-- [Host tools over the bridge](./bridge/host-tools.md)
-- [MCP and ACP integration](./mcp-and-acp.md)
-- [ACP over WebSocket](./acp/websocket.md)
-- [Outbound workflow server](./harn-serve.md)
-- [Orchestrator MCP server](./mcp-server.md)
-- [Harn portal](./portal.md)
-- [Orchestrator](./orchestrator.md)
-- [Hot reload](./orchestrator/hot-reload.md)
-- [Orchestrator DLQ management](./orchestrator/dlq.md)
-- [Orchestrator backpressure](./orchestrator/backpressure.md)
-- [Worker dispatch](./orchestrator/worker-dispatch.md)
-- [Orchestrator observability](./orchestrator/observability.md)
-- [Orchestrator secrets](./orchestrator/secrets.md)
-- [Multi-tenant orchestrator](./orchestrator/multi-tenant.md)
-- [Connector OAuth](./orchestrator/oauth.md)
-- [Deploy to Render](./deploy/render.md)
-- [Deploy to Fly.io](./deploy/fly.md)
-- [Deploy to Railway](./deploy/railway.md)
-
 # Reference
 
 - [CLI reference](./cli-reference.md)
-- [Agents Protocol v1](./spec/agents-protocol/v1.md)
-- [Agents Protocol Receipt Format](./spec/agents-protocol/receipt-format-v1.md)
-- [Agents Protocol Replay Contract](./spec/agents-protocol/replay-v1.md)
 - [Builtin functions](./builtins.md)
 - [Postgres](./postgres.md)
 - [Project scanning](./project-scan.md)
 - [Prompt templating](./prompt-templating.md)
 - [Configuring LLM providers](./providers.md)
-- [Debugging agent runs](./debugging.md)
 - [Editor integration](./editor-integration.md)
 - [Testing](./testing.md)
 

--- a/docs/src/acp/websocket.md
+++ b/docs/src/acp/websocket.md
@@ -8,6 +8,10 @@ wss://<host>/acp
 Authorization: Bearer <api-key>
 ```
 
+This page covers only the WebSocket transport. The canonical ACP behavior guide
+is [MCP, ACP, and A2A integration](../mcp-and-acp.md#acp-agent-client-protocol);
+the broader entry-point table is [Protocol support matrix](../protocol-support.md).
+
 Use `wss://` when the orchestrator is served with `--cert` and `--key`.
 Plain `ws://` is intended for local development or trusted private networks.
 

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -357,7 +357,7 @@ Invocation:
   existing `builtin_call` bridge request using `name` as the builtin
   name and `args` as the single argument payload.
 
-## Skill registry (issue #73)
+## Skill registry
 
 Hosts expose their own managed skill store to the VM through three RPCs.
 Filesystem skill discovery works without the bridge (`harn run` walks

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -346,7 +346,7 @@ preflight_allow = ["mystery.*", "runtime.task"]
 [workspace]
 # Directories or files checked by `harn check --workspace`. Paths are
 # resolved relative to harn.toml.
-pipelines = ["Sources/BurinCore/Resources/pipelines", "scripts"]
+pipelines = ["pipelines", "scripts"]
 ```
 
 Preflight diagnostics are reported under the `preflight` category so they
@@ -1041,35 +1041,11 @@ Security guidance:
 - treat configured `client_secret` values as secrets
 - review remote MCP capabilities before using them in autonomous workflows
 
-## Release gate
+## Maintainer release scripts
 
-For repo maintainers, the merge-queue-safe release path opens the automated
-version-bump PR after the release-content PR lands on `main`:
-
-```bash
-./scripts/release_ship.sh --bump patch
-```
-
-After that bump PR lands through the merge queue, finalize from an up-to-date
-`main`:
-
-```bash
-./scripts/release_ship.sh --finalize
-```
-
-The first command runs audit → dry-run publish → bump → commit → push
-`release/vX.Y.Z` → open PR. Finalize runs audit → dry-run publish → tag → push
-tag → `cargo publish` → GitHub release. The tag push happens before
-`cargo publish` so downstream consumers (GitHub release binary workflows,
-`burin-code`'s `fetch-harn`) start in parallel with crates.io.
-
-For piecewise work, the docs audit, verification gate, bump flow, and publish
-sequence are exposed individually:
-
-```bash
-./scripts/release_gate.sh audit
-./scripts/release_gate.sh full --bump patch --dry-run
-```
+Harn's repo-maintainer release scripts are documented in
+[Maintainer release workflow](./maintainer-release.md). They are not part of
+the end-user `harn` CLI surface.
 
 ## harn add
 

--- a/docs/src/connectors/architecture.md
+++ b/docs/src/connectors/architecture.md
@@ -1,10 +1,9 @@
 # Connector architecture status
 
-Issue [#151](https://github.com/burin-labs/harn/issues/151) originally tracked
-the full Rust-side connector library: shared connector traits, generic
-webhooks, cron, GitHub, Slack, Linear, Notion, OAuth helpers, catalog docs, and
-provider-specific runtime behavior. That plan has since been split into a
-smaller core substrate plus pure-Harn provider packages.
+The original Rust-side connector library plan covered shared connector traits,
+generic webhooks, cron, GitHub, Slack, Linear, Notion, OAuth helpers, catalog
+docs, and provider-specific runtime behavior. That plan has since been split
+into a smaller core substrate plus pure-Harn provider packages.
 
 This page is the current source of truth for what belongs in this repository
 after the connector pivot.
@@ -35,13 +34,13 @@ ticket is explicitly about compatibility or removal of an existing Rust shim.
 Provider business logic now lives in first-party or community Harn packages.
 The first-party package track is:
 
-| Provider | Package repo | Core issue |
+| Provider | Package repo | Status |
 |---|---|---|
-| GitHub | <https://github.com/burin-labs/harn-github-connector> | [#350](https://github.com/burin-labs/harn/issues/350) |
-| Slack | <https://github.com/burin-labs/harn-slack-connector> | [#350](https://github.com/burin-labs/harn/issues/350) |
-| Linear | <https://github.com/burin-labs/harn-linear-connector> | [#350](https://github.com/burin-labs/harn/issues/350) |
-| Notion | <https://github.com/burin-labs/harn-notion-connector> | [#350](https://github.com/burin-labs/harn/issues/350) |
-| GitLab | <https://github.com/burin-labs/harn-gitlab-connector> | [#305](https://github.com/burin-labs/harn/issues/305) |
+| GitHub | <https://github.com/burin-labs/harn-github-connector> | First-party package track |
+| Slack | <https://github.com/burin-labs/harn-slack-connector> | First-party package track |
+| Linear | <https://github.com/burin-labs/harn-linear-connector> | First-party package track |
+| Notion | <https://github.com/burin-labs/harn-notion-connector> | First-party package track |
+| GitLab | <https://github.com/burin-labs/harn-gitlab-connector> | Additional forge package track |
 
 Each package should declare connector contract v1 metadata, ship deterministic
 fixtures, and pass:
@@ -59,24 +58,21 @@ harn connector check . --run-poll-tick
 ## Rust compatibility shims
 
 The in-repo Rust GitHub, Slack, Linear, and Notion connectors are compatibility
-shims during the pure-Harn package soak. Their sunset and removal are tracked by
-[#446](https://github.com/burin-labs/harn/issues/446).
+shims during the pure-Harn package soak. Their sunset and removal use the same
+migration path as the pure-Harn package rollout.
 
-Do not use #151 as the active tracker for new provider work. Use:
+For new provider work, use:
 
-- [#350](https://github.com/burin-labs/harn/issues/350) for the pure-Harn
-  connector pivot.
-- [#446](https://github.com/burin-labs/harn/issues/446) for Rust provider
-  deprecation and removal.
+- the pure-Harn connector package track for provider packages
+- the Rust-provider deprecation path for shim removal
 - The external provider package repos for provider-specific event support,
   outbound methods, scopes, fixtures, and release readiness.
-- [#305](https://github.com/burin-labs/harn/issues/305) for additional forge
-  connector packages.
+- the additional forge package track for GitLab and similar providers
 
-## Closure checklist for #151
+## Core closure checklist
 
-The old #151 scope is considered complete in this repository when these
-repository-local surfaces exist and are tested:
+The repository-local connector substrate is considered complete when these
+surfaces exist and are tested:
 
 | Surface | Current home |
 |---|---|

--- a/docs/src/connectors/authoring.md
+++ b/docs/src/connectors/authoring.md
@@ -437,7 +437,7 @@ impl Connector for ExampleConnector {
 
 Webhook-style connectors should reuse
 `harn_vm::connectors::verify_hmac_signed(...)` instead of open-coding HMAC
-checks. The helper enforces the non-negotiable rules from issue `#167`:
+checks. The helper enforces these non-negotiable rules:
 
 - verification happens against the raw request body bytes
 - signature comparisons use constant-time equality

--- a/docs/src/connectors/catalog.md
+++ b/docs/src/connectors/catalog.md
@@ -15,8 +15,8 @@ For the architecture and ownership split that closes the old connector-library
 epic, see [Connector architecture status](./architecture.md).
 
 > **Deprecated: Rust-side GitHub, Slack, Linear, and Notion connectors.**
-> The [#350](https://github.com/burin-labs/harn/issues/350) pure-Harn connector
-> pivot makes the corresponding pure-Harn packages the default path for new
+> The pure-Harn connector pivot makes the corresponding pure-Harn packages the
+> default path for new
 > deployments: `harn-github-connector`, `harn-slack-connector`,
 > `harn-linear-connector`, and `harn-notion-connector`. Configure one by setting
 > `connector = { harn = "..." }` on the `[[providers]]` table. The Rust shims

--- a/docs/src/connectors/github.md
+++ b/docs/src/connectors/github.md
@@ -1,8 +1,7 @@
 # GitHub App connector
 
 > **Deprecated.** The Rust-side `GitHubConnector` is a compatibility shim under
-> the [#350](https://github.com/burin-labs/harn/issues/350) pure-Harn connector
-> pivot. The recommended implementation is the pure-Harn
+> the pure-Harn connector pivot. The recommended implementation is the pure-Harn
 > [`harn-github-connector`](https://github.com/burin-labs/harn-github-connector)
 > package. This page documents the existing Rust connector for users who have
 > not yet migrated; new deployments should configure the Harn package via
@@ -13,7 +12,7 @@
 `GitHubConnector` is Harn's built-in GitHub App integration for inbound webhook
 events plus outbound GitHub REST calls authenticated as an installation.
 
-The MVP scope in `#170` is intentionally narrow:
+The Rust compatibility shim intentionally stays narrow:
 
 - inbound GitHub webhook verification with `X-Hub-Signature-256`
 - strongly typed payload narrowing for the monitor-relevant event families:

--- a/docs/src/connectors/linear.md
+++ b/docs/src/connectors/linear.md
@@ -1,8 +1,7 @@
 # Linear connector
 
 > **Deprecated.** The Rust-side `LinearConnector` is a compatibility shim under
-> the [#350](https://github.com/burin-labs/harn/issues/350) pure-Harn connector
-> pivot. The recommended implementation is the pure-Harn
+> the pure-Harn connector pivot. The recommended implementation is the pure-Harn
 > [`harn-linear-connector`](https://github.com/burin-labs/harn-linear-connector)
 > package. This page documents the existing Rust connector for users who have
 > not yet migrated; new deployments should configure the Harn package via
@@ -13,7 +12,7 @@
 `LinearConnector` is Harn's built-in Linear integration for inbound webhook
 deliveries plus outbound GraphQL calls.
 
-The current landing covers the core connector contract from `#173`:
+The Rust compatibility shim covers:
 
 - inbound HMAC verification via `Linear-Signature`
 - replay protection using `webhookTimestamp` with a 60s window plus a default

--- a/docs/src/connectors/notion.md
+++ b/docs/src/connectors/notion.md
@@ -1,8 +1,7 @@
 # Notion connector
 
 > **Deprecated.** The Rust-side `NotionConnector` is a compatibility shim under
-> the [#350](https://github.com/burin-labs/harn/issues/350) pure-Harn connector
-> pivot. The recommended implementation is the pure-Harn
+> the pure-Harn connector pivot. The recommended implementation is the pure-Harn
 > [`harn-notion-connector`](https://github.com/burin-labs/harn-notion-connector)
 > package. This page documents the existing Rust connector for users who have
 > not yet migrated; new deployments should configure the Harn package via

--- a/docs/src/connectors/slack-events.md
+++ b/docs/src/connectors/slack-events.md
@@ -1,8 +1,7 @@
 # Slack Events connector
 
 > **Deprecated.** The Rust-side `SlackConnector` is a compatibility shim under
-> the [#350](https://github.com/burin-labs/harn/issues/350) pure-Harn connector
-> pivot. The recommended implementation is the pure-Harn
+> the pure-Harn connector pivot. The recommended implementation is the pure-Harn
 > [`harn-slack-connector`](https://github.com/burin-labs/harn-slack-connector)
 > package. This page documents the existing Rust connector for users who have
 > not yet migrated; new deployments should configure the Harn package via

--- a/docs/src/flow-predicates.md
+++ b/docs/src/flow-predicates.md
@@ -1,10 +1,7 @@
 # Flow Predicate Language
 
-Status: design decision record for Harn Flow v0. Parent issue:
-[harn#571](https://github.com/burin-labs/harn/issues/571). This page
-closes the four predicate-language review questions in
-[harn#584](https://github.com/burin-labs/harn/issues/584) and records the
-implementation work that is already landed or in flight.
+Status: design decision record for Harn Flow v0. This page records the
+predicate-language decisions and the implementation shape they imply.
 
 Flow predicates are repo-local Harn functions that gate candidate slices. They
 are not a separate DSL. A repository declares them in per-directory
@@ -13,21 +10,20 @@ shape used by directory metadata. The goal is a policy surface that can be
 audited, replayed, and proposed by agents without letting agents silently expand
 their own authority.
 
-## Current Implementation State
+## Implementation State
 
-The design in this document assumes the following ticket state as of
-2026-04-26:
+The design in this document assumes the following implementation state:
 
 | Area | Status |
 |---|---|
-| Predicate executor and hard kind budgets | Landed in #578 / #704. |
-| Cross-slice fairness scheduler and aggregate budget envelopes | Landed in #736. |
-| `invariants.harn` discovery and attributes | Landed in #579. |
-| `InvariantResult`, evidence, and remediation types | Landed in #581. |
-| Hierarchical predicate composition | In review in #731, closing #582. |
-| Predicate hash replay audit | In review in #730, closing #583. |
-| Archivist persona | Landed in #586 as deterministic propose-only scan output. |
-| Fixer persona | In review in #729, closing #587. |
+| Predicate executor and hard kind budgets | Landed. |
+| Cross-slice fairness scheduler and aggregate budget envelopes | Landed. |
+| `invariants.harn` discovery and attributes | Landed. |
+| `InvariantResult`, evidence, and remediation types | Landed. |
+| Hierarchical predicate composition | In progress. |
+| Predicate hash replay audit | In progress. |
+| Archivist persona | Landed as deterministic propose-only scan output. |
+| Fixer persona | In progress. |
 
 ## Predicate Declarations
 
@@ -352,29 +348,13 @@ If no Flow store exists, `shadow_evaluation.status` is `no_flow_store` rather
 than an error. That keeps initial repo bootstrap useful while making the
 absence of atom history explicit.
 
-## Follow-Up Implementation Tickets
+## Remaining Implementation Work
 
-The decisions above leave concrete implementation work beyond the already
-landed and in-review predicate tickets:
-
-- ~~[#734](https://github.com/burin-labs/harn/issues/734): add
-  `meta-invariants.harn` bootstrap validation and approval-chain checks.~~
-  Closed by `validate_predicate_edit` /
-  `validate_bootstrap_edit` plus the `bootstrap_policy` field surfaced in
-  `harn flow ship watch` and `harn flow archivist scan`.
-- [#735](https://github.com/burin-labs/harn/issues/735): deterministic
-  fallback metadata and enforcement for `@semantic` predicates.
-- ~~[#736](https://github.com/burin-labs/harn/issues/736): add cross-slice
-  fair scheduling and aggregate per-slice predicate budget envelopes.~~
-  Closed by `PredicateSchedulerConfig` and `execute_slices(slices)` documented
-  above.
-- ~~[#733](https://github.com/burin-labs/harn/issues/733): add
-  cross-directory union benchmarks and predicate-count explosion limits before
-  Ship Captain relies on unattended slice emission.~~ Closed by the
-  `PredicateCeiling` defaults documented above plus the
-  `flow_predicate_union` criterion bench.
-
-These are implementation follow-ups to #584, not new design questions.
+The decisions above leave one concrete implementation gap beyond the landed
+predicate runtime: deterministic fallback metadata and enforcement for
+`@semantic` predicates. Bootstrap validation, approval-chain checks,
+cross-slice scheduling, aggregate predicate budgets, and cross-directory
+predicate ceilings are covered by the implementation described above.
 
 ## External Reference Points
 

--- a/docs/src/harn-serve.md
+++ b/docs/src/harn-serve.md
@@ -4,6 +4,10 @@
 external callers. It contains the MCP, A2A, and ACP adapters plus the shared
 dispatch, auth, replay, and export-catalog pieces those adapters use.
 
+For user-facing protocol examples, start with
+[MCP, ACP, and A2A integration](./mcp-and-acp.md). For a quick status table
+across entry points, see [Protocol support matrix](./protocol-support.md).
+
 The goal is to keep protocol adapters thin:
 
 - load one `.harn` module and discover its exported `pub fn` entrypoints once

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -50,7 +50,8 @@ guide: install Harn, write a program, and run it in under five minutes.
 - **[Cookbook](./cookbook.md)** -- Practical recipes and patterns
 - **[Host boundary](./host-boundary.md)** -- How Harn integrates with host applications
 - **[Bridge protocol](./bridge-protocol.md)** -- JSON-RPC contract for host bridges
-- **[MCP and ACP integration](./mcp-and-acp.md)** -- MCP client/server, ACP, and A2A protocols
+- **[Protocol support matrix](./protocol-support.md)** -- ACP, A2A, and MCP entry points
+- **[MCP, ACP, and A2A integration](./mcp-and-acp.md)** -- Protocol examples and behavior
 - **[Harn portal](./portal.md)** -- Local observability UI for runs and transcripts
 - **[CLI reference](./cli-reference.md)** -- All CLI commands and flags
 - **[Builtin functions](./builtins.md)** -- Complete reference for all built-in functions

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -3993,7 +3993,7 @@ lives outside `harn.toml`.
 
 ```toml
 [workspace]
-pipelines = ["Sources/BurinCore/Resources/pipelines", "scripts"]
+pipelines = ["pipelines", "scripts"]
 ```
 
 `harn check --workspace` resolves each path in `pipelines` relative to
@@ -4073,8 +4073,8 @@ resolve without filesystem-relative hacks.
   shared git cache. Directory path dependencies are live-linked into
   `.harn/packages/<alias>` when the platform supports symlinks, with a
   copy fallback for restricted filesystems. This makes sibling-repo
-  development ergonomic for layouts such as `~/projects/{burin-code,
-  harn-cloud,harn-openapi}`: editing `../harn-openapi/lib.harn` is
+  development ergonomic for layouts such as `~/projects/{app,
+  shared-packages,harn-openapi}`: editing `../harn-openapi/lib.harn` is
   immediately visible to imports in the consuming project.
 
 Transitive package dependencies are resolved from installed package

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -361,7 +361,7 @@ Accepted shapes:
 | OpenRouter / Together / Groq / DeepSeek / Fireworks / HuggingFace / local | ✓ when routed model matches `gpt-5.4+` upstream | hosted forwarded; escape hatch below for proxies |
 | Gemini, Ollama, mock (default model) | ✗ | client fallback works today |
 
-The OpenAI native path (harn#71) emits a flat `{"type": "tool_search",
+The OpenAI native path emits a flat `{"type": "tool_search",
 "mode": "hosted"}` meta-tool at the front of the tools array, alongside
 `defer_loading: true` on the wrapper of each user tool. The server runs
 the search and replies with `tool_search_call` / `tool_search_output`
@@ -515,7 +515,7 @@ and model aliases without editing Rust-side registration code.
 ### Client-executed fallback
 
 On providers without native `defer_loading`, Harn falls back to an
-in-VM execution path (landed in [harn#70](https://github.com/burin-labs/harn/issues/70)).
+in-VM execution path.
 The fallback is identical to the native path from a script's point of
 view: same option surface, same transcript events, same promotion
 behavior across turns. Internally, Harn injects a synthetic tool

--- a/docs/src/maintainer-release.md
+++ b/docs/src/maintainer-release.md
@@ -1,0 +1,39 @@
+# Maintainer Release Workflow
+
+This page is for Harn maintainers cutting a release. User-facing CLI behavior
+lives in [CLI reference](./cli-reference.md).
+
+## Standard flow
+
+Once release content lands on `main` through the merge queue, open the
+automated version-bump PR:
+
+```bash
+./scripts/release_ship.sh --bump patch
+```
+
+After that PR lands through the merge queue, finalize from an up-to-date
+`main`:
+
+```bash
+./scripts/release_ship.sh --finalize
+```
+
+The bump command runs audit, dry-run publish, version bump, commit, push to
+`release/vX.Y.Z`, and PR creation. Finalize runs audit, dry-run publish, tag
+creation, tag push, crate publishing, and GitHub release creation.
+
+The tag is pushed before crate publishing so release-binary workflows and other
+downstream automation can start in parallel with crates.io publication.
+
+## Piecewise gates
+
+Use the lower-level gates when you need to audit or dry-run without opening a
+release PR:
+
+```bash
+./scripts/release_gate.sh audit
+./scripts/release_gate.sh full --bump patch --dry-run
+```
+
+`scripts/publish.sh` remains the crates.io publisher used by the release gate.

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -4,6 +4,10 @@ Harn has built-in support for the Model Context Protocol (MCP), Agent
 Client Protocol (ACP), and Agent-to-Agent (A2A) protocol. This guide
 covers how to use each from both client and server perspectives.
 
+For a scan-friendly status table across all protocol entry points, see the
+[protocol support matrix](./protocol-support.md). For shared serving internals,
+see [Outbound workflow server](./harn-serve.md).
+
 ## MCP client (connecting to MCP servers)
 
 Connect to any MCP-compatible tool server, list its capabilities, and
@@ -78,7 +82,7 @@ url = "https://mcp.notion.com/mcp"
 scopes = "read write"
 ```
 
-### Lazy boot (harn#75)
+### Lazy boot
 
 Servers marked `lazy = true` are NOT booted at pipeline startup. They
 start on the first `mcp_call`, `mcp_ensure_active("name")`, or skill

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -4,6 +4,11 @@
 client can fire triggers, inspect queues, replay events, and read runtime state
 without a Harn-specific adapter.
 
+This page is the canonical reference for the orchestrator control-plane MCP
+server. For the general MCP client/server guide, see
+[MCP, ACP, and A2A integration](./mcp-and-acp.md); for the full protocol routing
+table, see [Protocol support matrix](./protocol-support.md).
+
 The server is aimed at closed-loop agent clients that already know how to speak
 MCP, including:
 

--- a/docs/src/migrations/package-root-prompt-assets.md
+++ b/docs/src/migrations/package-root-prompt-assets.md
@@ -1,7 +1,6 @@
 # Migration: package-root prompt assets
 
-Issue [#742](https://github.com/burin-labs/harn/issues/742) added two
-refactor-safe forms for addressing `.harn.prompt` assets:
+Harn supports two refactor-safe forms for addressing `.harn.prompt` assets:
 
 - `@/<rel>` — anchored at the calling file's project root (the nearest
   `harn.toml` ancestor).
@@ -15,7 +14,7 @@ breaking when callers move.
 ## Before — relative paths break on file moves
 
 ```harn,ignore
-// Sources/BurinCore/Resources/pipelines/lib/runtime/workflow/graph-stages.harn
+// pipelines/lib/runtime/workflow/graph-stages.harn
 render_prompt("../../../partials/tool-examples.harn.prompt", bindings)
 ```
 
@@ -27,7 +26,7 @@ at a non-existent file.
 ## After — project-root form
 
 ```harn,ignore
-render_prompt("@/Sources/BurinCore/Resources/pipelines/partials/tool-examples.harn.prompt", bindings)
+render_prompt("@/pipelines/partials/tool-examples.harn.prompt", bindings)
 ```
 
 Verbose but resilient: the path resolves the same regardless of where
@@ -39,7 +38,7 @@ Define an alias in the project's `harn.toml`:
 
 ```toml
 [asset_roots]
-partials = "Sources/BurinCore/Resources/pipelines/partials"
+partials = "pipelines/partials"
 ```
 
 Then:

--- a/docs/src/migrations/rust-connectors-to-harn-packages.md
+++ b/docs/src/migrations/rust-connectors-to-harn-packages.md
@@ -1,12 +1,11 @@
 # Migrating Rust provider connectors to pure-Harn packages
 
 The Rust-side GitHub, Slack, Linear, and Notion connectors are deprecated
-compatibility shims under the pure-Harn connector pivot tracked by
-[#350](https://github.com/burin-labs/harn/issues/350). The core sunset
-groundwork tracked by [#446](https://github.com/burin-labs/harn/issues/446)
-has landed; new provider business logic ships in pure-Harn connector packages
-so that Harn Cloud and self-hosted orchestrators can adopt connector fixes, new
-event families, and provider API changes without waiting for a Harn core release.
+compatibility shims under the pure-Harn connector pivot. The core sunset
+groundwork has landed; new provider business logic ships in pure-Harn connector
+packages so that Harn Cloud and self-hosted orchestrators can adopt connector
+fixes, new event families, and provider API changes without waiting for a Harn
+core release.
 
 This guide is the no-downtime migration path for an orchestrator that today
 uses one of the Rust-side providers and wants to cut over to the pure-Harn
@@ -126,8 +125,7 @@ duplicate them.
 
 ## Removal status
 
-The Harn core prerequisites from [#446](https://github.com/burin-labs/harn/issues/446)
-are complete:
+The Harn core prerequisites are complete:
 
 - The connector contract conformance harness validates pure-Harn replacements
   through the same adapter path Harn Cloud and self-hosted orchestrators use.

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -535,8 +535,8 @@ Resolution rules:
 
   ```toml
   [asset_roots]
-  partials = "Sources/BurinCore/Resources/pipelines/partials"
-  prompts  = "Sources/BurinCore/Resources/pipelines"
+  partials = "pipelines/partials"
+  prompts  = "pipelines"
   ```
 
 Both forms reject `..` segments and absolute targets so a

--- a/docs/src/orchestrator.md
+++ b/docs/src/orchestrator.md
@@ -16,6 +16,11 @@ Today, the command:
 - expose `/metrics` and configurable process logs for production observability
 - write a state snapshot and stay up until shutdown
 
+For protocol entry-point routing across MCP, ACP, and A2A, see the
+[protocol support matrix](./protocol-support.md). The embedded MCP control
+plane links back to the canonical [Orchestrator MCP Server](./mcp-server.md)
+page.
+
 Current limitations:
 
 - Multi-tenant mode isolates listener ingress, tenant-scoped secrets, and

--- a/docs/src/protocol-support.md
+++ b/docs/src/protocol-support.md
@@ -1,0 +1,38 @@
+# Protocol Support Matrix
+
+This page is the quick routing table for Harn's protocol surfaces. The
+canonical task guides remain:
+
+- [MCP, ACP, and A2A integration](./mcp-and-acp.md) for user-facing protocol
+  usage.
+- [Outbound workflow server](./harn-serve.md) for the shared serving core used
+  by `harn serve mcp`, `harn serve a2a`, and `harn serve acp`.
+- [Orchestrator MCP server](./mcp-server.md) for controlling a local
+  orchestrator over MCP.
+- [Bridge protocol](./bridge-protocol.md) for host-mediated tool execution
+  underneath ACP.
+
+| Protocol surface | Harn role | Entry point | Transports | Discovery | Auth and control notes |
+|---|---|---|---|---|---|
+| MCP client | Connect from Harn code to external MCP servers. | `mcp_connect(...)`, `[[mcp]]` in `harn.toml`, `harn mcp login` for remote OAuth state. | stdio and remote HTTP. | Optional Server Cards through `mcp_server_card(...)` and `card = ...` config. | Lazy boot, ref-counted release, skill-scoped binding, OAuth token reuse, and tool-search indexing are covered in [MCP client](./mcp-and-acp.md#mcp-client-connecting-to-mcp-servers). |
+| MCP server for a Harn module | Expose exported `pub fn` functions or registered Harn tools/resources/prompts as MCP tools. | `harn serve mcp <file.harn>` | stdio, Streamable HTTP, legacy SSE compatibility endpoints. | Optional published Server Card through `--card`. | Uses the shared `harn-serve` dispatch core. See [MCP server](./mcp-and-acp.md#mcp-server-exposing-harn-as-an-mcp-server) and [Outbound workflow server](./harn-serve.md#mcp). |
+| Orchestrator MCP server | Let MCP clients fire triggers, inspect queues, retry DLQ entries, and read orchestrator state. | `harn mcp serve --config ./harn.toml --state-dir ./.harn/orchestrator` | stdio and HTTP. | MCP tool and resource catalog described on the page. | Optional API keys through `HARN_ORCHESTRATOR_API_KEYS`; HTTP accepts bearer or `x-api-key`. See [Orchestrator MCP server](./mcp-server.md). |
+| ACP stdio | Run Harn as an ACP backend for editor and local hosts. | `harn serve acp <file.harn>` | stdio JSON-RPC. | ACP `initialize` capability negotiation. | ACP owns session lifecycle while the [Bridge protocol](./bridge-protocol.md) keeps concrete tool execution under host control. See [ACP](./mcp-and-acp.md#acp-agent-client-protocol). |
+| ACP WebSocket | Expose ACP sessions from the orchestrator HTTP listener. | `harn orchestrator serve ...` with the `/acp` endpoint. | WebSocket text frames carrying one ACP JSON-RPC message each. | Same ACP method surface as stdio after connection. | Requires bearer auth on the orchestrator endpoint. See [ACP over WebSocket](./acp/websocket.md). |
+| A2A server | Expose a Harn module as a peer-agent endpoint. | `harn serve a2a <file.harn>` | HTTP JSON-RPC, SSE task streaming, REST-style task aliases. | Agent cards at `/.well-known/a2a-agent` plus compatibility aliases. | Supports task send, wait, stream, get, cancel, list, resubscribe, push callbacks, and optional card signing. See [A2A](./mcp-and-acp.md#a2a-agent-to-agent-protocol). |
+| A2A push connector | Receive A2A push notifications as orchestrator trigger events. | `kind = "a2a-push"` trigger manifest entries. | HTTP webhook ingress. | Trigger manifest and connector catalog. | Supports JWT/JWKS verification when `[triggers.a2a_push]` is configured; legacy routes can use bearer or HMAC auth. See [A2A push connector](./connectors/a2a-push.md). |
+
+## Canonical ownership
+
+Use [MCP, ACP, and A2A integration](./mcp-and-acp.md) when you need examples
+or user-facing protocol behavior. Use the narrower pages when you need the
+operational details for one host surface:
+
+- [Orchestrator MCP server](./mcp-server.md) owns the `harn mcp serve` control
+  plane.
+- [ACP over WebSocket](./acp/websocket.md) owns the orchestrator's browser and
+  remote-IDE ACP transport.
+- [Outbound workflow server](./harn-serve.md) owns shared adapter mechanics and
+  the "which adapter should I choose?" decision.
+- [Bridge protocol](./bridge-protocol.md) owns host bridge wire details and
+  tool-gate semantics.

--- a/docs/src/skills.md
+++ b/docs/src/skills.md
@@ -279,7 +279,7 @@ name = "acme/ops"
   checkout to live under `.harn/packages/<name>/skills/` — run
   `harn install` to populate it.
 - `registry` entries are accepted but inert until a Harn Skills
-  marketplace exists (tracked by [#73](https://github.com/burin-labs/harn/issues/73)).
+  marketplace exists.
 
 ## harn doctor
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -3991,7 +3991,7 @@ lives outside `harn.toml`.
 
 ```toml
 [workspace]
-pipelines = ["Sources/BurinCore/Resources/pipelines", "scripts"]
+pipelines = ["pipelines", "scripts"]
 ```
 
 `harn check --workspace` resolves each path in `pipelines` relative to
@@ -4071,8 +4071,8 @@ resolve without filesystem-relative hacks.
   shared git cache. Directory path dependencies are live-linked into
   `.harn/packages/<alias>` when the platform supports symlinks, with a
   copy fallback for restricted filesystems. This makes sibling-repo
-  development ergonomic for layouts such as `~/projects/{burin-code,
-  harn-cloud,harn-openapi}`: editing `../harn-openapi/lib.harn` is
+  development ergonomic for layouts such as `~/projects/{app,
+  shared-packages,harn-openapi}`: editing `../harn-openapi/lib.harn` is
   immediately visible to imports in the consuming project.
 
 Transitive package dependencies are resolved from installed package


### PR DESCRIPTION
## Summary

- Reorganize the mdBook summary into smaller top-level groups for language, agent runtime, protocols, orchestration, packages/connectors, observability, operations, reference, and migrations.
- Add a protocol support matrix and link MCP/ACP/A2A-related pages back to the canonical protocol guides.
- Move maintainer release workflow details out of the CLI reference, shorten the README release section, and scrub stale implementation-wave issue/path references from user docs and the generated language spec source.

Closes #814.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-814-target make check-docs-snippets`
- `mdbook build docs`
- `npm run lint:md`
- `make check-language-spec`
- `rg -n "harn#[0-9]+|Sources/BurinCore|burin-code" docs/src README.md` (no hits)
- `git diff --cached --check`

## Notes

- Self-review cleanup removed additional user-facing issue-number breadcrumbs beyond the exact requested regex where they were implementation-wave context rather than useful docs.
- The language-spec mirror was regenerated from `spec/HARN_SPEC.md`.