### PR TITLE
[codex] Formalize ACP lifecycle extension contract

### DIFF
--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -191,7 +191,7 @@ impl AgentEventSink for AcpAgentEventSink {
                     "sessionId": session_id,
                     "update": {
                         "sessionUpdate": "plan",
-                        "plan": plan,
+                        "entries": plan,
                     },
                 }));
             }
@@ -382,7 +382,219 @@ mod tests {
     use harn_vm::tool_annotations::ToolKind;
     use tokio::sync::mpsc;
 
+    use super::super::HARN_SESSION_UPDATE_EXTENSIONS;
     use super::{AcpAgentEventSink, AcpOutput};
+
+    const ACP_V0_12_2_SESSION_UPDATES: &[&str] = &[
+        "user_message_chunk",
+        "agent_message_chunk",
+        "agent_thought_chunk",
+        "tool_call",
+        "tool_call_update",
+        "plan",
+        "available_commands_update",
+        "current_mode_update",
+        "config_option_update",
+        "session_info_update",
+    ];
+
+    async fn collect_notifications(events: Vec<AgentEvent>) -> Vec<serde_json::Value> {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+        let expected_len = events.len();
+        for event in events {
+            sink.handle_event(&event);
+        }
+
+        let mut notifications = Vec::with_capacity(expected_len);
+        for _ in 0..expected_len {
+            let line = rx.recv().await.expect("ACP event notification");
+            notifications.push(serde_json::from_str(&line).expect("json"));
+        }
+        notifications
+    }
+
+    fn fixture_handoff() -> HandoffArtifact {
+        HandoffArtifact {
+            type_name: "handoff_artifact".to_string(),
+            id: "handoff-1".to_string(),
+            parent_run_id: None,
+            source_persona: "merge_captain".to_string(),
+            target_persona_or_human: HandoffTargetRecord {
+                kind: "persona".to_string(),
+                id: Some("review_captain".to_string()),
+                label: Some("review_captain".to_string()),
+            },
+            task: "Review the patch".to_string(),
+            reason: "Merge queue requires review".to_string(),
+            created_at: "2026-04-28T00:00:00Z".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn standard_fixture_events() -> Vec<AgentEvent> {
+        vec![
+            AgentEvent::AgentMessageChunk {
+                session_id: "session-1".to_string(),
+                content: "hello".to_string(),
+            },
+            AgentEvent::AgentThoughtChunk {
+                session_id: "session-1".to_string(),
+                content: "thinking".to_string(),
+            },
+            AgentEvent::ToolCall {
+                session_id: "session-1".to_string(),
+                tool_call_id: "tool-1".to_string(),
+                tool_name: "read".to_string(),
+                kind: Some(ToolKind::Read),
+                status: ToolCallStatus::Pending,
+                raw_input: serde_json::json!({"path": "README.md"}),
+                parsing: None,
+                audit: None,
+            },
+            AgentEvent::ToolCallUpdate {
+                session_id: "session-1".to_string(),
+                tool_call_id: "tool-1".to_string(),
+                tool_name: "read".to_string(),
+                status: ToolCallStatus::Completed,
+                raw_output: Some(serde_json::json!({"ok": true})),
+                error: None,
+                duration_ms: Some(7),
+                execution_duration_ms: Some(5),
+                error_category: None,
+                executor: Some(ToolExecutor::HarnBuiltin),
+                parsing: None,
+                raw_input: None,
+                raw_input_partial: None,
+                audit: None,
+            },
+            AgentEvent::Plan {
+                session_id: "session-1".to_string(),
+                plan: serde_json::json!([
+                    {"content": "edit", "status": "pending"}
+                ]),
+            },
+        ]
+    }
+
+    fn extension_fixture_events() -> Vec<AgentEvent> {
+        vec![
+            AgentEvent::SkillActivated {
+                session_id: "session-1".to_string(),
+                skill_name: "rust".to_string(),
+                iteration: 1,
+                reason: "matched".to_string(),
+            },
+            AgentEvent::SkillDeactivated {
+                session_id: "session-1".to_string(),
+                skill_name: "rust".to_string(),
+                iteration: 2,
+            },
+            AgentEvent::SkillScopeTools {
+                session_id: "session-1".to_string(),
+                skill_name: "rust".to_string(),
+                allowed_tools: vec!["read".to_string()],
+            },
+            AgentEvent::ToolSearchQuery {
+                session_id: "session-1".to_string(),
+                tool_use_id: "search-1".to_string(),
+                name: "tool_search".to_string(),
+                query: serde_json::json!({"q": "read"}),
+                strategy: "semantic".to_string(),
+                mode: "client".to_string(),
+            },
+            AgentEvent::ToolSearchResult {
+                session_id: "session-1".to_string(),
+                tool_use_id: "search-1".to_string(),
+                promoted: vec!["read".to_string()],
+                strategy: "semantic".to_string(),
+                mode: "client".to_string(),
+            },
+            AgentEvent::TranscriptCompacted {
+                session_id: "session-1".to_string(),
+                mode: "auto".to_string(),
+                strategy: "summary".to_string(),
+                archived_messages: 3,
+                estimated_tokens_before: 100,
+                estimated_tokens_after: 40,
+                snapshot_asset_id: Some("asset-1".to_string()),
+            },
+            AgentEvent::Handoff {
+                session_id: "session-1".to_string(),
+                artifact_id: "artifact-1".to_string(),
+                handoff: Box::new(fixture_handoff()),
+            },
+            AgentEvent::FsWatch {
+                session_id: "session-1".to_string(),
+                subscription_id: "fsw-1".to_string(),
+                events: vec![FsWatchEvent {
+                    kind: "modify".to_string(),
+                    paths: vec!["/tmp/project/src/lib.rs".to_string()],
+                    relative_paths: vec!["src/lib.rs".to_string()],
+                    raw_kind: "Modify(Any)".to_string(),
+                    error: None,
+                }],
+            },
+            AgentEvent::WorkerUpdate {
+                session_id: "session-1".into(),
+                worker_id: "worker-1".into(),
+                worker_name: "review".into(),
+                worker_task: "review pr".into(),
+                worker_mode: "delegated_stage".into(),
+                event: harn_vm::agent_events::WorkerEvent::WorkerWaitingForInput,
+                status: "awaiting_input".into(),
+                metadata: serde_json::json!({
+                    "child_run_id": "run_x",
+                    "child_run_path": ".harn-runs/run_x",
+                }),
+                audit: Some(serde_json::json!({"run_id": "run_x"})),
+            },
+        ]
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn standard_session_update_fixtures_match_acp_schema_v0_12_2_discriminators() {
+        let actual = collect_notifications(standard_fixture_events()).await;
+        let expected: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/acp/session_update_standard.json"
+        ))
+        .expect("fixture json");
+        assert_eq!(serde_json::Value::Array(actual.clone()), expected);
+
+        for notification in actual {
+            let session_update = notification["params"]["update"]["sessionUpdate"]
+                .as_str()
+                .expect("sessionUpdate");
+            assert!(
+                ACP_V0_12_2_SESSION_UPDATES.contains(&session_update),
+                "{session_update} is not a standard ACP v0.12.2 SessionUpdate"
+            );
+            if session_update == "plan" {
+                assert!(notification["params"]["update"].get("entries").is_some());
+                assert!(notification["params"]["update"].get("plan").is_none());
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn harn_extension_session_update_fixtures_are_pinned() {
+        let actual = collect_notifications(extension_fixture_events()).await;
+        let expected: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/acp/session_update_extensions.json"
+        ))
+        .expect("fixture json");
+        assert_eq!(serde_json::Value::Array(actual.clone()), expected);
+
+        for notification in actual {
+            let session_update = notification["params"]["update"]["sessionUpdate"]
+                .as_str()
+                .expect("sessionUpdate");
+            assert!(
+                HARN_SESSION_UPDATE_EXTENSIONS.contains(&session_update),
+                "{session_update} is not advertised as a Harn ACP extension"
+            );
+        }
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn worker_update_serializes_to_session_update_with_lifecycle_metadata() {

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -28,6 +28,48 @@ use crate::{AdapterDescriptor, AuthPolicy, AuthRequest, AuthorizationDecision};
 use events::AcpAgentEventSink;
 use io::send_json_response;
 
+pub(super) const ACP_SCHEMA_COMPATIBILITY: &str =
+    "agentclientprotocol/agent-client-protocol schema v0.12.2";
+
+pub(super) const HARN_SESSION_UPDATE_EXTENSIONS: &[&str] = &[
+    "fs_watch",
+    "handoff",
+    "log",
+    "progress",
+    "skill_activated",
+    "skill_deactivated",
+    "skill_scope_tools",
+    "tool_search_query",
+    "tool_search_result",
+    "transcript_compacted",
+    "worker_update",
+];
+
+pub(super) const HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS: &[&str] = &[
+    "audit",
+    "durationMs",
+    "error",
+    "errorCategory",
+    "executionDurationMs",
+    "executor",
+    "parsing",
+    "rawInputPartial",
+];
+
+pub(super) const HARN_CONTENT_EXTENSION_FIELDS: &[&str] = &["visible_delta", "visible_text"];
+
+fn harn_acp_extension_meta() -> serde_json::Value {
+    serde_json::json!({
+        "harn": {
+            "schemaCompatibility": ACP_SCHEMA_COMPATIBILITY,
+            "sessionUpdateExtensions": HARN_SESSION_UPDATE_EXTENSIONS,
+            "toolLifecycleExtensionFields": HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS,
+            "contentExtensionFields": HARN_CONTENT_EXTENSION_FIELDS,
+            "extensionContract": "docs/src/bridge-protocol.md#acp-compatibility-contract",
+        }
+    })
+}
+
 fn verbose_bridge_logs_enabled() -> bool {
     matches!(
         std::env::var("HARN_ACP_VERBOSE").ok().as_deref(),
@@ -275,6 +317,7 @@ impl AcpServer {
             serde_json::json!({
                 "protocolVersion": 1,
                 "agentCapabilities": {
+                    "_meta": harn_acp_extension_meta(),
                     "promptCapabilities": {},
                     "sessionCapabilities": {
                         "fork": {},
@@ -1227,6 +1270,8 @@ mod tests {
     use super::builtins::normalize_host_capability_manifest;
     use super::{
         sanitize_visible_assistant_text, AcpBridge, AcpOutput, AcpServer, AcpServerConfig,
+        ACP_SCHEMA_COMPATIBILITY, HARN_SESSION_UPDATE_EXTENSIONS,
+        HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS,
     };
     use crate::{ApiKeyAuthConfig, AuthMethodConfig, AuthPolicy};
     use harn_vm::visible_text::VisibleTextState;
@@ -1336,6 +1381,21 @@ mod tests {
                 let initialize = recv_json(&mut response_rx).await;
                 assert_eq!(initialize["id"], 1);
                 assert_eq!(initialize["result"]["agentInfo"]["name"], "harn");
+                assert_eq!(
+                    initialize["result"]["agentCapabilities"]["_meta"]["harn"]
+                        ["schemaCompatibility"],
+                    ACP_SCHEMA_COMPATIBILITY
+                );
+                assert_eq!(
+                    initialize["result"]["agentCapabilities"]["_meta"]["harn"]
+                        ["sessionUpdateExtensions"],
+                    serde_json::json!(HARN_SESSION_UPDATE_EXTENSIONS)
+                );
+                assert_eq!(
+                    initialize["result"]["agentCapabilities"]["_meta"]["harn"]
+                        ["toolLifecycleExtensionFields"],
+                    serde_json::json!(HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS)
+                );
 
                 request_tx
                     .send(serde_json::json!({

--- a/crates/harn-serve/tests/fixtures/acp/session_update_extensions.json
+++ b/crates/harn-serve/tests/fixtures/acp/session_update_extensions.json
@@ -1,0 +1,175 @@
+[
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "iteration": 1,
+        "reason": "matched",
+        "sessionUpdate": "skill_activated",
+        "skillName": "rust"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "iteration": 2,
+        "sessionUpdate": "skill_deactivated",
+        "skillName": "rust"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "allowedTools": [
+          "read"
+        ],
+        "sessionUpdate": "skill_scope_tools",
+        "skillName": "rust"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "mode": "client",
+        "name": "tool_search",
+        "query": {
+          "q": "read"
+        },
+        "sessionUpdate": "tool_search_query",
+        "strategy": "semantic",
+        "toolUseId": "search-1"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "mode": "client",
+        "promoted": [
+          "read"
+        ],
+        "sessionUpdate": "tool_search_result",
+        "strategy": "semantic",
+        "toolUseId": "search-1"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "archivedMessages": 3,
+        "estimatedTokensAfter": 40,
+        "estimatedTokensBefore": 100,
+        "mode": "auto",
+        "sessionUpdate": "transcript_compacted",
+        "snapshotAssetId": "asset-1",
+        "strategy": "summary"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "artifactId": "artifact-1",
+        "handoff": {
+          "_type": "handoff_artifact",
+          "allowed_side_effects": [],
+          "blocked_on": [],
+          "budget_remaining": null,
+          "confidence": null,
+          "created_at": "2026-04-28T00:00:00Z",
+          "deadline_checkback": null,
+          "evidence_refs": [],
+          "files_or_entities_touched": [],
+          "id": "handoff-1",
+          "metadata": {},
+          "open_questions": [],
+          "parent_run_id": null,
+          "reason": "Merge queue requires review",
+          "receipt_links": [],
+          "requested_capabilities": [],
+          "source_persona": "merge_captain",
+          "target_persona_or_human": {
+            "id": "review_captain",
+            "kind": "persona",
+            "label": "review_captain"
+          },
+          "task": "Review the patch"
+        },
+        "handoffId": "handoff-1",
+        "sessionUpdate": "handoff"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "events": [
+          {
+            "error": null,
+            "kind": "modify",
+            "paths": [
+              "/tmp/project/src/lib.rs"
+            ],
+            "raw_kind": "Modify(Any)",
+            "relative_paths": [
+              "src/lib.rs"
+            ]
+          }
+        ],
+        "sessionUpdate": "fs_watch",
+        "subscriptionId": "fsw-1"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "audit": {
+          "run_id": "run_x"
+        },
+        "event": "WorkerWaitingForInput",
+        "metadata": {
+          "child_run_id": "run_x",
+          "child_run_path": ".harn-runs/run_x"
+        },
+        "sessionUpdate": "worker_update",
+        "status": "awaiting_input",
+        "terminal": false,
+        "workerId": "worker-1",
+        "workerMode": "delegated_stage",
+        "workerName": "review",
+        "workerTask": "review pr"
+      }
+    }
+  }
+]

--- a/crates/harn-serve/tests/fixtures/acp/session_update_standard.json
+++ b/crates/harn-serve/tests/fixtures/acp/session_update_standard.json
@@ -1,0 +1,84 @@
+[
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "content": {
+          "text": "hello",
+          "type": "text",
+          "visible_delta": "hello",
+          "visible_text": "hello"
+        },
+        "sessionUpdate": "agent_message_chunk"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "content": {
+          "text": "thinking",
+          "type": "text"
+        },
+        "sessionUpdate": "agent_thought_chunk"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "kind": "read",
+        "rawInput": {
+          "path": "README.md"
+        },
+        "sessionUpdate": "tool_call",
+        "status": "pending",
+        "title": "read",
+        "toolCallId": "tool-1"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "durationMs": 7,
+        "executionDurationMs": 5,
+        "executor": "harn_builtin",
+        "rawOutput": {
+          "ok": true
+        },
+        "sessionUpdate": "tool_call_update",
+        "status": "completed",
+        "title": "read",
+        "toolCallId": "tool-1"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "entries": [
+          {
+            "content": "edit",
+            "status": "pending"
+          }
+        ],
+        "sessionUpdate": "plan"
+      }
+    }
+  }
+]

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -25,6 +25,63 @@ Internally, the agent loop emits `AgentEvent::ToolCall` +
 translates them into `session/update` notifications via an `AgentEventSink` it
 registers per session.
 
+### ACP Compatibility Contract
+
+Harn tracks the upstream Agent Client Protocol schema and pins its
+wire contract against `agentclientprotocol/agent-client-protocol` schema
+`v0.12.2`. The adapter treats these `session/update` values as standard
+ACP variants:
+
+- `agent_message_chunk`
+- `agent_thought_chunk`
+- `tool_call`
+- `tool_call_update`
+- `plan`
+
+Harn also emits host-facing lifecycle updates that are not ACP-standard.
+They are intentionally kept as top-level `sessionUpdate` discriminators
+for compatibility with existing Burin Code and other host renderers, and
+are advertised during `initialize` under
+`agentCapabilities._meta.harn.sessionUpdateExtensions`:
+
+- `fs_watch`
+- `handoff`
+- `log`
+- `progress`
+- `skill_activated`
+- `skill_deactivated`
+- `skill_scope_tools`
+- `tool_search_query`
+- `tool_search_result`
+- `transcript_compacted`
+- `worker_update`
+
+Hosts that do not recognize one of these values should ignore it using
+normal ACP forward-compatibility behavior. Hosts that render Harn
+extensions should key off the explicit extension list from `initialize`
+instead of discovering behavior from a local allow-list.
+
+Harn keeps several high-value tool-rendering fields at the top level of
+`tool_call` / `tool_call_update` rather than moving them under `_meta`,
+because downstream UIs already consume them directly. These field
+extensions are also advertised during `initialize` under
+`agentCapabilities._meta.harn.toolLifecycleExtensionFields`:
+
+- `audit`
+- `durationMs`
+- `error`
+- `errorCategory`
+- `executionDurationMs`
+- `executor`
+- `parsing`
+- `rawInputPartial`
+
+The standard ACP fields (`toolCallId`, `title`, `kind`, `status`,
+`content`, `locations`, `rawInput`, and `rawOutput`) remain available in
+their ACP locations. Harn's pinned fixtures under
+`crates/harn-serve/tests/fixtures/acp/` pin both the standard and
+extension shapes so host integrations can reference stable examples.
+
 ### `audit` tag
 
 Both `tool_call` and `tool_call_update` carry an optional `audit`
@@ -473,6 +530,8 @@ Alternative shapes accepted for host convenience:
 
 Agents emit ACP `session/update` notifications for skill lifecycle
 transitions so hosts can surface active-skill state in real time.
+These are Harn extension variants advertised during `initialize`, not
+upstream ACP `SessionUpdate` variants.
 The packaged `harn-serve` ACP adapter translates the canonical `AgentEvent`
 variants into:
 


### PR DESCRIPTION
## Summary

- Advertise Harn ACP extension support during `initialize` under `agentCapabilities._meta.harn`, including the pinned upstream schema compatibility, extension `sessionUpdate` discriminators, and tool/content extension fields.
- Pin standard and Harn-extension `session/update` fixtures for the harn-serve ACP adapter.
- Align emitted ACP `plan` updates with the upstream schema by using `entries` instead of the old Harn-local `plan` key.
- Document the host rendering and compatibility contract in `docs/src/bridge-protocol.md`.

Closes #817.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-817.xce6eX cargo test -p harn-serve`
- `cargo fmt --check`
- `git diff --check`
- `npx markdownlint-cli2 docs/src/bridge-protocol.md`
- Pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`, full markdown lint
- Pre-push hook: 2,839 nextest tests passed, full markdown lint

## Notes

The issue referenced ACP v0.12.0 from April 17, 2026; the latest upstream release I checked during this work is v0.12.2, published April 23, 2026, so the contract is pinned to that schema version.