### PR TITLE
Align A2A AgentCard discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,6 +1806,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "tower 0.5.3",
  "tracing",
  "url",
  "uuid",

--- a/crates/harn-serve/Cargo.toml
+++ b/crates/harn-serve/Cargo.toml
@@ -30,3 +30,4 @@ uuid = { version = "1", features = ["v4", "v7"] }
 [dev-dependencies]
 hex = "0.4"
 tempfile = "3"
+tower = { version = "0.5", features = ["util"] }

--- a/crates/harn-serve/src/adapters/a2a.rs
+++ b/crates/harn-serve/src/adapters/a2a.rs
@@ -26,10 +26,12 @@ use crate::{
     DispatchError, ExportCatalog, HttpTlsConfig, TransportAdapter,
 };
 
-pub const A2A_PROTOCOL_VERSION: &str = "1.0.0";
+pub const A2A_PROTOCOL_VERSION: &str = "1.0";
 
 const A2A_VERSION_HEADER: &str = "a2a-version";
 const A2A_TRACE_HEADER: &str = "a2a-trace-id";
+const A2A_LEGACY_PROTOCOL_VERSION: &str = "1.0.0";
+const A2A_AGENT_CARD_PATH: &str = "/.well-known/agent-card.json";
 
 const A2A_TASK_NOT_FOUND: i64 = -32001;
 const A2A_TASK_NOT_CANCELABLE: i64 = -32002;
@@ -193,8 +195,21 @@ impl A2aServer {
             server: self,
             public_url: public_url.clone(),
         };
-        let router = Router::new()
+        let router = Self::http_router(state);
+        let router = crate::tls::apply_security_headers(router, &options.tls);
+
+        eprintln!("Harn A2A server listening on {public_url}");
+        eprintln!("[harn] A2A workflow server ready on {public_url}");
+        eprintln!("[harn] Agent card: {public_url}{A2A_AGENT_CARD_PATH}");
+        crate::tls::serve_router_from_tcp(listener, router, &options.tls)
+            .await
+            .map_err(|error| format!("A2A HTTP server failed: {error}"))
+    }
+
+    fn http_router(state: HttpState) -> Router {
+        Router::new()
             .route("/", post(jsonrpc_request))
+            .route(A2A_AGENT_CARD_PATH, get(agent_card_request))
             .route("/agent/card", get(agent_card_request))
             .route("/.well-known/a2a-agent", get(agent_card_request))
             .route("/.well-known/agent.json", get(agent_card_request))
@@ -202,15 +217,7 @@ impl A2aServer {
             .route("/tasks/send_and_wait", post(rest_send_and_wait_task))
             .route("/tasks/cancel", post(rest_cancel_task))
             .route("/tasks/resubscribe", post(rest_resubscribe_task))
-            .with_state(state);
-        let router = crate::tls::apply_security_headers(router, &options.tls);
-
-        eprintln!("Harn A2A server listening on {public_url}");
-        eprintln!("[harn] A2A workflow server ready on {public_url}");
-        eprintln!("[harn] Agent card: {public_url}/.well-known/a2a-agent");
-        crate::tls::serve_router_from_tcp(listener, router, &options.tls)
-            .await
-            .map_err(|error| format!("A2A HTTP server failed: {error}"))
+            .with_state(state)
     }
 
     fn agent_card(&self, public_url: &str) -> JsonValue {
@@ -223,30 +230,36 @@ impl A2aServer {
                     "id": function.name,
                     "name": function.name,
                     "description": format!("Invoke exported Harn function '{}'.", function.name),
+                    "tags": ["harn", "function"],
+                    "examples": [],
+                    "inputModes": ["application/json", "text/plain"],
+                    "outputModes": ["application/json", "text/plain"],
                     "inputSchema": function.input_schema,
                 })
             })
             .collect::<Vec<_>>();
         let mut card = json!({
-            "id": self.agent_name,
             "name": self.agent_name,
             "description": "Harn peer agent",
-            "url": public_url,
+            "supportedInterfaces": [
+                {
+                    "url": public_url,
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": A2A_PROTOCOL_VERSION,
+                }
+            ],
             "version": env!("CARGO_PKG_VERSION"),
-            "protocolVersion": A2A_PROTOCOL_VERSION,
             "provider": {
                 "organization": "Harn",
                 "url": "https://harn.dev"
             },
-            "interfaces": [
-                {"protocol": "jsonrpc", "url": "/"}
-            ],
-            "securitySchemes": [],
+            "securitySchemes": {},
+            "security": [],
+            "defaultInputModes": ["application/json", "text/plain"],
+            "defaultOutputModes": ["application/json", "text/plain"],
             "capabilities": {
                 "streaming": true,
                 "pushNotifications": true,
-                "resubscribe": true,
-                "cancel": true,
                 "extendedAgentCard": false
             },
             "skills": skills
@@ -926,7 +939,7 @@ fn check_version_header(headers: &HeaderMap, body: &[u8]) -> Option<JsonValue> {
     let version = headers
         .get(A2A_VERSION_HEADER)
         .and_then(|value| value.to_str().ok())?;
-    if version == A2A_PROTOCOL_VERSION {
+    if version == A2A_PROTOCOL_VERSION || version == A2A_LEGACY_PROTOCOL_VERSION {
         return None;
     }
     let rpc_id = serde_json::from_slice::<JsonValue>(body)
@@ -1115,14 +1128,24 @@ fn sign_card(card: &mut JsonValue, secret: &str) {
     let Ok(bytes) = serde_json::to_vec(card) else {
         return;
     };
+    let protected = json!({
+        "alg": "HS256",
+        "typ": "JOSE",
+        "kid": "harn-serve",
+    });
+    let Ok(protected_bytes) = serde_json::to_vec(&protected) else {
+        return;
+    };
+    let protected = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(protected_bytes);
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
     let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(secret.as_bytes()) else {
         return;
     };
-    mac.update(&bytes);
-    let signature = base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+    mac.update(format!("{protected}.{payload}").as_bytes());
+    let signature =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes());
     card["signatures"] = json!([{
-        "alg": "HS256",
-        "kid": "harn-serve",
+        "protected": protected,
         "signature": signature,
     }]);
 }
@@ -1224,28 +1247,115 @@ impl A2aPrepareError {
 mod tests {
     use super::*;
     use crate::{DispatchCore, DispatchCoreConfig};
+    use axum::body::{to_bytes, Body};
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    fn test_server(source: &str) -> (tempfile::TempDir, Arc<A2aServer>) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(&script, source).expect("write script");
+        let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+        (dir, Arc::new(A2aServer::new(A2aServerConfig::new(core))))
+    }
+
+    fn assert_current_agent_card_shape(card: &JsonValue, public_url: &str) {
+        assert_eq!(card["name"], "server");
+        assert_eq!(card["description"], "Harn peer agent");
+        assert_eq!(card["version"], env!("CARGO_PKG_VERSION"));
+        assert!(card.get("url").is_none(), "card must not emit legacy url");
+        assert!(
+            card.get("protocolVersion").is_none(),
+            "card must not emit legacy top-level protocolVersion"
+        );
+        assert!(
+            card.get("interfaces").is_none(),
+            "card must not emit legacy interfaces"
+        );
+        assert_eq!(card["supportedInterfaces"][0]["url"], public_url);
+        assert_eq!(card["supportedInterfaces"][0]["protocolBinding"], "JSONRPC");
+        assert_eq!(
+            card["supportedInterfaces"][0]["protocolVersion"],
+            A2A_PROTOCOL_VERSION
+        );
+        assert_eq!(card["securitySchemes"], json!({}));
+        assert_eq!(card["security"], json!([]));
+        assert_eq!(
+            card["defaultInputModes"],
+            json!(["application/json", "text/plain"])
+        );
+        assert_eq!(
+            card["defaultOutputModes"],
+            json!(["application/json", "text/plain"])
+        );
+        assert_eq!(card["capabilities"]["streaming"], true);
+        assert_eq!(card["capabilities"]["pushNotifications"], true);
+        assert_eq!(card["capabilities"]["extendedAgentCard"], false);
+        assert_eq!(card["skills"][0]["id"], "triage");
+        assert_eq!(card["skills"][0]["tags"], json!(["harn", "function"]));
+        assert_eq!(
+            card["skills"][0]["inputModes"],
+            json!(["application/json", "text/plain"])
+        );
+        assert_eq!(
+            card["skills"][0]["outputModes"],
+            json!(["application/json", "text/plain"])
+        );
+    }
 
     #[tokio::test]
     async fn agent_card_advertises_exported_functions() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let script = dir.path().join("server.harn");
-        std::fs::write(
-            &script,
+        let (_dir, server) = test_server(
             r#"
 pub fn triage(task: string) -> string {
   return task
 }
 "#,
-        )
-        .expect("write script");
-        let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
-        let server = A2aServer::new(A2aServerConfig::new(core));
+        );
 
         let card = server.agent_card("http://localhost:8080");
 
-        assert_eq!(card["capabilities"]["streaming"], true);
-        assert_eq!(card["capabilities"]["pushNotifications"], true);
-        assert_eq!(card["skills"][0]["id"], "triage");
+        assert_current_agent_card_shape(&card, "http://localhost:8080");
+    }
+
+    #[tokio::test]
+    async fn discovery_paths_serve_current_agent_card_shape() {
+        let (_dir, server) = test_server(
+            r#"
+pub fn triage(task: string) -> string {
+  return task
+}
+"#,
+        );
+        let public_url = "http://localhost:8080";
+        let router = A2aServer::http_router(HttpState {
+            server,
+            public_url: public_url.to_string(),
+        });
+
+        for path in [
+            A2A_AGENT_CARD_PATH,
+            "/.well-known/agent.json",
+            "/.well-known/a2a-agent",
+            "/agent/card",
+        ] {
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(path)
+                        .body(Body::empty())
+                        .expect("request"),
+                )
+                .await
+                .expect("response");
+            assert_eq!(response.status(), StatusCode::OK, "path: {path}");
+            let bytes = to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("body");
+            let card: JsonValue = serde_json::from_slice(&bytes).expect("card json");
+            assert_current_agent_card_shape(&card, public_url);
+        }
     }
 
     #[tokio::test]
@@ -1442,7 +1552,7 @@ pub fn triage(task: string) -> string {
         let mut card = json!({"id": "agent", "skills": []});
         sign_card(&mut card, "secret");
 
-        assert_eq!(card["signatures"][0]["alg"], "HS256");
+        assert!(card["signatures"][0]["protected"].as_str().unwrap().len() > 16);
         assert!(card["signatures"][0]["signature"].as_str().unwrap().len() > 16);
     }
 

--- a/crates/harn-vm/src/a2a/mod.rs
+++ b/crates/harn-vm/src/a2a/mod.rs
@@ -6,8 +6,13 @@ use tokio::sync::broadcast;
 
 use crate::triggers::TriggerEvent;
 
-const A2A_AGENT_CARD_PATH: &str = ".well-known/a2a-agent";
-const A2A_PROTOCOL_VERSION: &str = "1.0.0";
+const A2A_AGENT_CARD_PATHS: &[&str] = &[
+    ".well-known/agent-card.json",
+    ".well-known/a2a-agent",
+    ".well-known/agent.json",
+    "agent/card",
+];
+const A2A_PROTOCOL_VERSION: &str = "1.0";
 const A2A_PUSH_URL_ENV: &str = "HARN_A2A_PUSH_URL";
 const A2A_PUSH_TOKEN_ENV: &str = "HARN_A2A_PUSH_TOKEN";
 
@@ -316,30 +321,34 @@ async fn resolve_endpoint(
 ) -> Result<ResolvedA2aEndpoint, A2aClientError> {
     let mut last_error = None;
     for scheme in card_resolution_schemes(allow_cleartext) {
-        let card_url = format!("{scheme}://{}/{A2A_AGENT_CARD_PATH}", target.authority);
-        match fetch_agent_card(&card_url, cancel_rx).await {
-            Ok(card) => {
-                return endpoint_from_card(
-                    card_url,
-                    allow_cleartext,
-                    &target.authority,
-                    target.target_agent.clone(),
-                    &card,
-                );
-            }
-            Err(AgentCardFetchError::Cancelled(message)) => {
-                return Err(A2aClientError::Cancelled(message));
-            }
-            Err(error) => {
-                let message = agent_card_fetch_error_message(&error);
-                last_error = Some(message);
-                if should_try_cleartext_fallback(scheme, allow_cleartext, &error, &target.authority)
-                {
-                    continue;
+        let mut last_scheme_error = None;
+        for path in A2A_AGENT_CARD_PATHS {
+            let card_url = format!("{scheme}://{}/{path}", target.authority);
+            match fetch_agent_card(&card_url, cancel_rx).await {
+                Ok(card) => {
+                    return endpoint_from_card(
+                        card_url,
+                        allow_cleartext,
+                        &target.authority,
+                        target.target_agent.clone(),
+                        &card,
+                    );
                 }
-                break;
+                Err(AgentCardFetchError::Cancelled(message)) => {
+                    return Err(A2aClientError::Cancelled(message));
+                }
+                Err(error) => {
+                    last_error = Some(agent_card_fetch_error_message(&error));
+                    last_scheme_error = Some(error);
+                }
             }
         }
+        if last_scheme_error.as_ref().is_some_and(|error| {
+            should_try_cleartext_fallback(scheme, allow_cleartext, error, &target.authority)
+        }) {
+            continue;
+        }
+        break;
     }
     Err(A2aClientError::Discovery(format!(
         "could not resolve A2A agent card for '{}': {}",
@@ -387,6 +396,46 @@ fn endpoint_from_card(
     target_agent: String,
     card: &Value,
 ) -> Result<ResolvedA2aEndpoint, A2aClientError> {
+    if let Some(interfaces) = card.get("supportedInterfaces").and_then(Value::as_array) {
+        let interface = interfaces
+            .iter()
+            .find(|entry| {
+                entry
+                    .get("protocolBinding")
+                    .and_then(Value::as_str)
+                    .is_some_and(|binding| binding.eq_ignore_ascii_case("JSONRPC"))
+            })
+            .ok_or_else(|| {
+                A2aClientError::Discovery(
+                    "A2A agent card does not expose a JSONRPC supportedInterface".to_string(),
+                )
+            })?;
+        let interface_url = interface
+            .get("url")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                A2aClientError::Discovery("A2A JSONRPC supportedInterface missing url".to_string())
+            })?;
+        let rpc_url = Url::parse(interface_url).map_err(|error| {
+            A2aClientError::Discovery(format!(
+                "invalid A2A JSONRPC supportedInterface url '{interface_url}': {error}"
+            ))
+        })?;
+        ensure_cleartext_allowed(&rpc_url, allow_cleartext, "jsonrpc interface")?;
+        let interface_authority = url_authority(&rpc_url)?;
+        if !authorities_equivalent(&interface_authority, requested_authority) {
+            return Err(A2aClientError::Discovery(format!(
+                "A2A JSONRPC interface authority mismatch: requested '{requested_authority}', card returned '{interface_authority}'"
+            )));
+        }
+        return Ok(ResolvedA2aEndpoint {
+            card_url,
+            rpc_url: rpc_url.to_string(),
+            agent_id: card.get("id").and_then(Value::as_str).map(str::to_string),
+            target_agent,
+        });
+    }
+
     let base_url = card
         .get("url")
         .and_then(Value::as_str)
@@ -409,7 +458,12 @@ fn endpoint_from_card(
         })?;
     let jsonrpc_interfaces: Vec<&Value> = interfaces
         .iter()
-        .filter(|entry| entry.get("protocol").and_then(Value::as_str) == Some("jsonrpc"))
+        .filter(|entry| {
+            entry
+                .get("protocol")
+                .and_then(Value::as_str)
+                .is_some_and(|protocol| protocol.eq_ignore_ascii_case("jsonrpc"))
+        })
         .collect();
     if jsonrpc_interfaces.len() != 1 {
         return Err(A2aClientError::Discovery(format!(
@@ -694,6 +748,31 @@ mod tests {
     }
 
     #[test]
+    fn endpoint_from_card_accepts_current_supported_interfaces() {
+        let endpoint = endpoint_from_card(
+            "https://trusted.example/.well-known/agent-card.json".to_string(),
+            false,
+            "trusted.example",
+            "triage".to_string(),
+            &serde_json::json!({
+                "name": "trusted",
+                "supportedInterfaces": [{
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": "1.0",
+                    "url": "https://trusted.example/rpc"
+                }],
+            }),
+        )
+        .expect("current A2A card should resolve");
+        assert_eq!(endpoint.rpc_url, "https://trusted.example/rpc");
+        assert_eq!(
+            endpoint.card_url,
+            "https://trusted.example/.well-known/agent-card.json"
+        );
+        assert_eq!(endpoint.target_agent, "triage");
+    }
+
+    #[test]
     fn cleartext_fallback_only_after_https_connect_refused() {
         assert!(should_try_cleartext_fallback(
             "https",
@@ -795,7 +874,7 @@ mod tests {
     #[test]
     fn endpoint_from_card_rejects_card_url_authority_mismatch() {
         let error = endpoint_from_card(
-            "https://trusted.example/.well-known/a2a-agent".to_string(),
+            "https://trusted.example/.well-known/agent-card.json".to_string(),
             false,
             "trusted.example",
             "triage".to_string(),
@@ -814,7 +893,7 @@ mod tests {
     #[test]
     fn endpoint_from_card_rejects_cleartext_without_opt_in() {
         let error = endpoint_from_card(
-            "https://127.0.0.1:8080/.well-known/a2a-agent".to_string(),
+            "https://127.0.0.1:8080/.well-known/agent-card.json".to_string(),
             false,
             "127.0.0.1:8080",
             "triage".to_string(),
@@ -839,7 +918,7 @@ mod tests {
             "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
         });
         let endpoint = endpoint_from_card(
-            "http://127.0.0.1:8080/.well-known/a2a-agent".to_string(),
+            "http://127.0.0.1:8080/.well-known/agent-card.json".to_string(),
             true,
             "127.0.0.1:8080",
             "triage".to_string(),
@@ -854,7 +933,7 @@ mod tests {
             "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
         });
         let endpoint_v6 = endpoint_from_card(
-            "http://localhost:8080/.well-known/a2a-agent".to_string(),
+            "http://localhost:8080/.well-known/agent-card.json".to_string(),
             true,
             "localhost:8080",
             "triage".to_string(),
@@ -869,7 +948,7 @@ mod tests {
             "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
         });
         let error = endpoint_from_card(
-            "http://127.0.0.1:8080/.well-known/a2a-agent".to_string(),
+            "http://127.0.0.1:8080/.well-known/agent-card.json".to_string(),
             true,
             "127.0.0.1:8080",
             "triage".to_string(),

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -456,7 +456,10 @@ fn spawn_mock_a2a_server_with_schemes(
     let stop_thread = stop.clone();
     let tls_config = (listener_scheme == "https").then(mock_a2a_tls_config);
     let max_connections = if listener_scheme == "http" && card_scheme == "http" {
-        3
+        // HTTPS discovery probes the canonical card path plus legacy
+        // aliases before loopback HTTP fallback. Then the successful HTTP
+        // card fetch and JSON-RPC dispatch each use a connection.
+        6
     } else {
         2
     };
@@ -529,13 +532,33 @@ fn handle_mock_a2a_connection<T: Read + Write>(
     task_result: &serde_json::Value,
 ) {
     let (request_line, headers, body) = read_http_request(stream);
-    if request_line.starts_with("GET /.well-known/a2a-agent ") {
+    if request_line.starts_with("GET /.well-known/agent-card.json ") {
         write_json_response(
             stream,
             &serde_json::json!({
-                "id": "mock-a2a",
-                "url": format!("{card_scheme}://127.0.0.1:{port}"),
-                "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
+                "name": "mock-a2a",
+                "description": "Mock A2A peer",
+                "version": "1.0.0",
+                "supportedInterfaces": [{
+                    "url": format!("{card_scheme}://127.0.0.1:{port}/rpc"),
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": "1.0"
+                }],
+                "capabilities": {
+                    "streaming": true,
+                    "pushNotifications": true,
+                    "extendedAgentCard": false
+                },
+                "securitySchemes": {},
+                "security": [],
+                "defaultInputModes": ["application/json", "text/plain"],
+                "defaultOutputModes": ["application/json", "text/plain"],
+                "skills": [{
+                    "id": "triage",
+                    "name": "triage",
+                    "description": "Triage mock events",
+                    "tags": ["test"]
+                }],
             }),
         );
         return;
@@ -1414,8 +1437,8 @@ async fn a2a_handler_returns_pending_task_handle() {
                     "state": "working",
                     "target_agent": "triage",
                     "rpc_url": format!("https://{}/rpc", server.authority),
-                    "card_url": format!("https://{}/.well-known/a2a-agent", server.authority),
-                    "agent_id": "mock-a2a",
+                    "card_url": format!("https://{}/.well-known/agent-card.json", server.authority),
+                    "agent_id": null,
                 }))
             );
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -989,10 +989,11 @@ harn serve mcp agent.harn --card ./card.json
 
 `harn serve a2a` uses the shared `harn-serve` dispatch core and exposes each
 exported `pub fn` in the target module as an A2A skill. The adapter publishes an
-agent card at `/.well-known/a2a-agent` and supports task send, send-and-wait,
-streaming/resubscribe, push callback registration, and cancel propagation. The
-legacy shorthand `harn serve <file>` is preserved and rewrites internally to
-`harn serve a2a <file>`.
+AgentCard at `/.well-known/agent-card.json`, keeps the legacy
+`/.well-known/a2a-agent`, `/.well-known/agent.json`, and `/agent/card` aliases,
+and supports task send, send-and-wait, streaming/resubscribe, push callback
+registration, and cancel propagation. The legacy shorthand `harn serve <file>`
+is preserved and rewrites internally to `harn serve a2a <file>`.
 
 `harn serve acp` starts the packaged ACP adapter on stdio for editor and IDE
 hosts. It creates ACP sessions, executes the target pipeline for each

--- a/docs/src/harn-serve.md
+++ b/docs/src/harn-serve.md
@@ -116,8 +116,8 @@ harn serve a2a --cert certs/prod.pem --key certs/prod-key.pem server.harn
 Behavior today:
 
 - HTTP JSON-RPC endpoint at `/`
-- agent cards at `/.well-known/a2a-agent`, `/.well-known/agent.json`, and
-  `/agent/card`
+- A2A AgentCard at `/.well-known/agent-card.json`, with compatibility aliases
+  at `/.well-known/a2a-agent`, `/.well-known/agent.json`, and `/agent/card`
 - `a2a.SendMessage`, `a2a.SendStreamingMessage`, `a2a.GetTask`,
   `a2a.CancelTask`, and `a2a.ListTasks`
 - A2A task aliases `tasks/send`, `tasks/send_and_wait`, `tasks/resubscribe`,

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -579,7 +579,7 @@ builtins.
 ## A2A (Agent-to-Agent Protocol)
 
 A2A exposes exported Harn functions as a peer-agent HTTP server that other
-agents can interact with. The server implements A2A protocol version 1.0.0 and
+agents can interact with. The server implements A2A protocol version 1.0 and
 uses the shared `harn-serve` dispatch core.
 
 ### Running the server
@@ -592,9 +592,12 @@ harn serve a2a --port 3000 agent.harn
 
 ### Agent card
 
-The server publishes an agent card at `GET /.well-known/a2a-agent`, with
-compatibility aliases at `GET /.well-known/agent.json` and `GET /agent/card`.
-The card advertises each exported `pub fn` as an A2A skill. Set
+The server publishes an A2A AgentCard at
+`GET /.well-known/agent-card.json`, with compatibility aliases at
+`GET /.well-known/a2a-agent`, `GET /.well-known/agent.json`, and
+`GET /agent/card`. The card advertises each exported `pub fn` as an A2A skill
+through `supportedInterfaces`, default input/output modes, capabilities, and
+security declarations. Set
 `--card-signing-secret` or `HARN_SERVE_A2A_CARD_SECRET` to attach an HS256
 signature envelope to the card.
 

--- a/docs/src/triggers/dispatcher.md
+++ b/docs/src/triggers/dispatcher.md
@@ -53,10 +53,11 @@ stable handler kind and target URI in lifecycle logs and action-graph nodes.
 
 For `a2a://host[:port]/path` routes, the dispatcher:
 
-- fetches `/.well-known/a2a-agent` from the target host
+- fetches `/.well-known/agent-card.json` from the target host, with legacy
+  discovery fallbacks for older Harn A2A servers
 - defaults to HTTPS-only discovery + dispatch; cleartext HTTP is rejected unless
   the trigger binding explicitly sets `allow_cleartext = true`
-- requires exactly one JSON-RPC interface in the agent card before it will
+- selects the first JSON-RPC entry in `supportedInterfaces` before it will
   dispatch
 - treats the URI path as the `target_agent` label that propagates into the
   outbound envelope and the action graph

--- a/spec/AGENTS_PROTOCOL.md
+++ b/spec/AGENTS_PROTOCOL.md
@@ -255,10 +255,12 @@ Required Artifact fields:
 Servers SHOULD reference large payloads as Artifacts instead of inlining them
 in Message parts.
 
-### AgentCard
+### HarnAgentCard
 
-An AgentCard advertises an agent endpoint and its capabilities. It is aligned
-with A2A agent-card concepts while adding Harn policy and receipt metadata.
+`HarnAgentCard` is the Harn Agents API discovery envelope. It is intentionally
+distinct from the A2A `AgentCard` wire object so SDKs do not treat Harn policy
+and receipt metadata as A2A fields. When a Harn agent is also available through
+A2A, the envelope nests the current A2A card in `a2a_card`.
 
 Required fields:
 
@@ -266,11 +268,13 @@ Required fields:
 - `name`: display name.
 - `description`: agent description.
 - `protocol_version`: supported Harn Agents Protocol version.
-- `interfaces`: available transport interfaces.
+- `a2a_card`: current A2A AgentCard, including `supportedInterfaces`,
+  capabilities, default input/output modes, security declarations, and skills.
 - `skills`: callable skills or exported functions.
 
 Optional fields include `persona_ids`, `capabilities`, `auth_schemes`,
-`receipt_policy`, `quotas`, `provider`, `public_url`, and `signature`.
+`receipt_policy`, `quotas`, `provider`, `harn_interfaces`, `public_url`, and
+`signature`.
 
 Signed cards MUST state their signature algorithm and key id. Clients MUST NOT
 trust unsigned card metadata for authorization decisions.
@@ -389,8 +393,8 @@ delivery ids or equivalent event identities.
 
 ### Skill
 
-A Skill is a callable or loadable capability exposed by a Persona, AgentCard,
-host, connector, or Harn package.
+A Skill is a callable or loadable capability exposed by a Persona,
+HarnAgentCard, host, connector, or Harn package.
 
 Required fields:
 
@@ -450,7 +454,7 @@ The protocol defines three transport profiles over the same resource model:
 - WebSocket for bidirectional interactive sessions and host mediation.
 
 Servers MAY implement a subset of transports according to their conformance
-level. A server that advertises a transport in an AgentCard MUST implement that
+level. A server that advertises a transport in a HarnAgentCard MUST implement that
 transport according to this section.
 
 ### REST
@@ -458,7 +462,7 @@ transport according to this section.
 REST endpoints use HTTPS and JSON. The OpenAPI 3.1 artifact defines the exact
 paths and schemas. This narrative spec requires the REST surface to cover:
 
-- discovery and AgentCard retrieval
+- discovery and HarnAgentCard retrieval
 - Persona, Workspace, Session, Task, Branch, Message, Artifact, Event,
   Receipt, Memory, Connector, Skill, Outcome, and Quota reads
 - Session creation, close, fork, and message append
@@ -832,7 +836,7 @@ Core implementations support:
 
 - version negotiation
 - API key authentication
-- REST AgentCard, Session, Task, Message, Event, Artifact, Outcome reads
+- REST HarnAgentCard, Session, Task, Message, Event, Artifact, Outcome reads
 - Task submit, get, cancel
 - Task lifecycle state machine
 - `Idempotency-Key` for Task and Message creation
@@ -850,7 +854,7 @@ Extended implementations support all Core requirements plus:
 - host-mediated input and authorization requests
 - artifact upload or registration
 - connector delivery dedupe behavior
-- AgentCard signatures
+- HarnAgentCard signatures
 
 ### Receipts
 

--- a/spec/openapi.snapshot
+++ b/spec/openapi.snapshot
@@ -113,8 +113,15 @@ ImageRefPart
 Artifact
 ArtifactList
 RegisterArtifactRequest
-AgentCard
-AgentInterface
+HarnAgentCard
+A2aAgentCard
+A2aAgentInterface
+A2aAgentProvider
+A2aAgentCapabilities
+A2aAgentSkill
+A2aSecurityScheme
+A2aAgentCardSignature
+HarnAgentInterface
 CardSignature
 Event
 EventList

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -63,15 +63,15 @@ paths:
     get:
       tags: [Discovery]
       operationId: getAgentCard
-      summary: Retrieve the public AgentCard for this Harness.
+      summary: Retrieve the public Harn AgentCard envelope for this Harness.
       security: []
       responses:
         "200":
-          description: AgentCard.
+          description: Harn AgentCard envelope.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AgentCard"
+                $ref: "#/components/schemas/HarnAgentCard"
         default:
           $ref: "#/components/responses/Error"
 
@@ -2232,29 +2232,31 @@ components:
         metadata:
           $ref: "#/components/schemas/Metadata"
 
-    AgentCard:
+    HarnAgentCard:
       allOf:
         - $ref: "#/components/schemas/ResourceEnvelope"
         - type: object
-          required: [object, name, description, protocol_version, interfaces, skills]
+          required: [object, name, description, protocol_version, a2a_card, skills]
           properties:
             object:
               type: string
-              enum: [agent_card]
+              enum: [harn_agent_card]
             name:
               type: string
             description:
               type: string
             protocol_version:
               type: string
-            interfaces:
-              type: array
-              items:
-                $ref: "#/components/schemas/AgentInterface"
+            a2a_card:
+              $ref: "#/components/schemas/A2aAgentCard"
             skills:
               type: array
               items:
                 $ref: "#/components/schemas/Skill"
+            harn_interfaces:
+              type: array
+              items:
+                $ref: "#/components/schemas/HarnAgentInterface"
             persona_ids:
               type: array
               items:
@@ -2282,7 +2284,156 @@ components:
               oneOf:
                 - $ref: "#/components/schemas/CardSignature"
                 - type: "null"
-    AgentInterface:
+    A2aAgentCard:
+      type: object
+      required:
+        - name
+        - description
+        - supportedInterfaces
+        - version
+        - capabilities
+        - defaultInputModes
+        - defaultOutputModes
+        - skills
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        supportedInterfaces:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/A2aAgentInterface"
+        provider:
+          $ref: "#/components/schemas/A2aAgentProvider"
+        version:
+          type: string
+        documentationUrl:
+          type: [string, "null"]
+          format: uri
+        capabilities:
+          $ref: "#/components/schemas/A2aAgentCapabilities"
+        securitySchemes:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/A2aSecurityScheme"
+        security:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: string
+        defaultInputModes:
+          type: array
+          items:
+            type: string
+        defaultOutputModes:
+          type: array
+          items:
+            type: string
+        skills:
+          type: array
+          items:
+            $ref: "#/components/schemas/A2aAgentSkill"
+        signatures:
+          type: array
+          items:
+            $ref: "#/components/schemas/A2aAgentCardSignature"
+        iconUrl:
+          type: [string, "null"]
+          format: uri
+    A2aAgentInterface:
+      type: object
+      required: [url, protocolBinding, protocolVersion]
+      properties:
+        url:
+          type: string
+          format: uri
+        protocolBinding:
+          type: string
+          examples: [JSONRPC, GRPC, HTTP+JSON]
+        tenant:
+          type: [string, "null"]
+        protocolVersion:
+          type: string
+    A2aAgentProvider:
+      type: object
+      required: [organization, url]
+      properties:
+        organization:
+          type: string
+        url:
+          type: string
+          format: uri
+    A2aAgentCapabilities:
+      type: object
+      properties:
+        streaming:
+          type: boolean
+        pushNotifications:
+          type: boolean
+        extensions:
+          type: array
+          items:
+            $ref: "#/components/schemas/JsonObject"
+        extendedAgentCard:
+          type: boolean
+    A2aAgentSkill:
+      type: object
+      required: [id, name, description, tags]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        examples:
+          type: array
+          items:
+            type: string
+        inputModes:
+          type: array
+          items:
+            type: string
+        outputModes:
+          type: array
+          items:
+            type: string
+        security:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: string
+        inputSchema:
+          oneOf:
+            - $ref: "#/components/schemas/JsonObject"
+            - type: "null"
+    A2aSecurityScheme:
+      type: object
+      description: A2A SecurityScheme union member, following the A2A/OpenAPI security object shape.
+      additionalProperties: true
+    A2aAgentCardSignature:
+      type: object
+      required: [protected, signature]
+      properties:
+        protected:
+          type: string
+        signature:
+          type: string
+        header:
+          $ref: "#/components/schemas/JsonObject"
+    HarnAgentInterface:
       type: object
       required: [transport, url]
       properties:


### PR DESCRIPTION
## Summary

- Serve `/.well-known/agent-card.json` as the canonical A2A discovery endpoint while keeping legacy aliases.
- Emit current A2A AgentCard fields (`supportedInterfaces`, version, capabilities, security declarations, default modes, skills) and update signed card envelopes.
- Update outbound A2A discovery to prefer the canonical card path, parse current `supportedInterfaces`, and fall back to legacy card paths/shapes for compatibility.
- Split the Harn Agents API card schema into a distinct `HarnAgentCard` envelope with a nested `A2aAgentCard`, plus docs and OpenAPI snapshot updates.

Closes #806.
Refs #815.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-target-issue-806 cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-806 cargo test -p harn-serve a2a`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-806 cargo test -p harn-vm a2a`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-806 cargo run --bin harn -- serve a2a --help`
- `npx redocly lint spec/openapi.yaml`
- `./scripts/check_openapi_snapshot.py`
- `git diff --check`
- pre-commit hook passed: Rust fmt, workspace clippy, markdownlint

Pre-push hook note: full `make test` started and ran 2839 tests; changed A2A cases passed, but the hook failed because nine unrelated `harn-cli::orchestrator_http` tests timed out at nextest's 60s limit.
