### PR TITLE
[codex] Resolve Agents API agent card shape drift

### DIFF
--- a/crates/harn-cli/src/commands/agents_conformance.rs
+++ b/crates/harn-cli/src/commands/agents_conformance.rs
@@ -418,6 +418,22 @@ async fn agent_card(client: &ConformanceClient) -> ProbeResult {
     expect_field_eq(body, "protocol_version", PROTOCOL_VERSION)?;
     expect_array_field(body, "interfaces")?;
     expect_array_field(body, "skills")?;
+    let a2a_card = expect_object_field(body, "a2a_agent_card")?;
+    expect_string_field(a2a_card, "name")?;
+    expect_string_field(a2a_card, "description")?;
+    expect_string_field(a2a_card, "version")?;
+    expect_string_field(a2a_card, "url")?;
+    expect_object_field(a2a_card, "capabilities")?;
+    let interfaces = expect_array_field(a2a_card, "supportedInterfaces")?;
+    if interfaces.is_empty() {
+        return Err("a2a_agent_card.supportedInterfaces must not be empty".to_string());
+    }
+    for interface in interfaces {
+        expect_string_field(interface, "url")?;
+        expect_string_field(interface, "protocolBinding")?;
+        expect_string_field(interface, "protocolVersion")?;
+    }
+    expect_array_field(a2a_card, "skills")?;
     Ok(())
 }
 
@@ -1687,6 +1703,17 @@ fn expect_array_field<'a>(value: &'a Value, field: &str) -> ProbeResult<&'a [Val
         .and_then(Value::as_array)
         .map(Vec::as_slice)
         .ok_or_else(|| format!("{field} must be an array"))
+}
+
+fn expect_object_field<'a>(value: &'a Value, field: &str) -> ProbeResult<&'a Value> {
+    let object = value
+        .get(field)
+        .ok_or_else(|| format!("{field} must be an object"))?;
+    if object.as_object().is_some() {
+        Ok(object)
+    } else {
+        Err(format!("{field} must be an object"))
+    }
 }
 
 fn expect_string_array_contains(value: &Value, field: &str, expected: &str) -> ProbeResult {

--- a/crates/harn-serve/src/adapters/a2a.rs
+++ b/crates/harn-serve/src/adapters/a2a.rs
@@ -26,7 +26,8 @@ use crate::{
     DispatchError, ExportCatalog, HttpTlsConfig, TransportAdapter,
 };
 
-pub const A2A_PROTOCOL_VERSION: &str = "1.0.0";
+pub const A2A_PROTOCOL_VERSION: &str = "1.0";
+const A2A_LEGACY_PROTOCOL_VERSION: &str = "1.0.0";
 
 const A2A_VERSION_HEADER: &str = "a2a-version";
 const A2A_TRACE_HEADER: &str = "a2a-trace-id";
@@ -196,6 +197,7 @@ impl A2aServer {
         let router = Router::new()
             .route("/", post(jsonrpc_request))
             .route("/agent/card", get(agent_card_request))
+            .route("/.well-known/agent-card.json", get(agent_card_request))
             .route("/.well-known/a2a-agent", get(agent_card_request))
             .route("/.well-known/agent.json", get(agent_card_request))
             .route("/tasks/send", post(rest_send_task))
@@ -207,13 +209,14 @@ impl A2aServer {
 
         eprintln!("Harn A2A server listening on {public_url}");
         eprintln!("[harn] A2A workflow server ready on {public_url}");
-        eprintln!("[harn] Agent card: {public_url}/.well-known/a2a-agent");
+        eprintln!("[harn] Agent card: {public_url}/.well-known/agent-card.json");
         crate::tls::serve_router_from_tcp(listener, router, &options.tls)
             .await
             .map_err(|error| format!("A2A HTTP server failed: {error}"))
     }
 
     fn agent_card(&self, public_url: &str) -> JsonValue {
+        let base_url = public_url.trim_end_matches('/');
         let skills = self
             .catalog
             .functions
@@ -223,30 +226,34 @@ impl A2aServer {
                     "id": function.name,
                     "name": function.name,
                     "description": format!("Invoke exported Harn function '{}'.", function.name),
-                    "inputSchema": function.input_schema,
+                    "inputModes": ["application/json", "text/plain"],
+                    "outputModes": ["application/json", "text/plain"],
                 })
             })
             .collect::<Vec<_>>();
         let mut card = json!({
-            "id": self.agent_name,
             "name": self.agent_name,
             "description": "Harn peer agent",
-            "url": public_url,
+            "url": base_url,
             "version": env!("CARGO_PKG_VERSION"),
-            "protocolVersion": A2A_PROTOCOL_VERSION,
             "provider": {
                 "organization": "Harn",
                 "url": "https://harn.dev"
             },
-            "interfaces": [
-                {"protocol": "jsonrpc", "url": "/"}
+            "supportedInterfaces": [
+                {
+                    "url": base_url,
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": A2A_PROTOCOL_VERSION
+                }
             ],
-            "securitySchemes": [],
+            "securitySchemes": {},
+            "securityRequirements": [],
+            "defaultInputModes": ["application/json", "text/plain"],
+            "defaultOutputModes": ["application/json", "text/plain"],
             "capabilities": {
                 "streaming": true,
                 "pushNotifications": true,
-                "resubscribe": true,
-                "cancel": true,
                 "extendedAgentCard": false
             },
             "skills": skills
@@ -926,7 +933,7 @@ fn check_version_header(headers: &HeaderMap, body: &[u8]) -> Option<JsonValue> {
     let version = headers
         .get(A2A_VERSION_HEADER)
         .and_then(|value| value.to_str().ok())?;
-    if version == A2A_PROTOCOL_VERSION {
+    if matches!(version, A2A_PROTOCOL_VERSION | A2A_LEGACY_PROTOCOL_VERSION) {
         return None;
     }
     let rpc_id = serde_json::from_slice::<JsonValue>(body)
@@ -1119,10 +1126,12 @@ fn sign_card(card: &mut JsonValue, secret: &str) {
         return;
     };
     mac.update(&bytes);
-    let signature = base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+    let protected = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(r#"{"alg":"HS256","typ":"JWT","kid":"harn-serve"}"#);
+    let signature =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes());
     card["signatures"] = json!([{
-        "alg": "HS256",
-        "kid": "harn-serve",
+        "protected": protected,
         "signature": signature,
     }]);
 }
@@ -1245,7 +1254,14 @@ pub fn triage(task: string) -> string {
 
         assert_eq!(card["capabilities"]["streaming"], true);
         assert_eq!(card["capabilities"]["pushNotifications"], true);
+        assert_eq!(card["supportedInterfaces"][0]["protocolBinding"], "JSONRPC");
+        assert_eq!(
+            card["supportedInterfaces"][0]["protocolVersion"],
+            A2A_PROTOCOL_VERSION
+        );
         assert_eq!(card["skills"][0]["id"], "triage");
+        assert!(card.get("interfaces").is_none());
+        assert!(card["skills"][0].get("inputSchema").is_none());
     }
 
     #[tokio::test]
@@ -1442,8 +1458,24 @@ pub fn triage(task: string) -> string {
         let mut card = json!({"id": "agent", "skills": []});
         sign_card(&mut card, "secret");
 
-        assert_eq!(card["signatures"][0]["alg"], "HS256");
+        assert!(card["signatures"][0]["protected"].as_str().unwrap().len() > 16);
         assert!(card["signatures"][0]["signature"].as_str().unwrap().len() > 16);
+    }
+
+    #[test]
+    fn version_header_accepts_current_and_legacy_patch_version() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            A2A_VERSION_HEADER,
+            axum::http::HeaderValue::from_static("1.0"),
+        );
+        assert!(check_version_header(&headers, br#"{"id":1}"#).is_none());
+
+        headers.insert(
+            A2A_VERSION_HEADER,
+            axum::http::HeaderValue::from_static("1.0.0"),
+        );
+        assert!(check_version_header(&headers, br#"{"id":1}"#).is_none());
     }
 
     use harn_vm::agent_events::AgentEventSink as _;

--- a/crates/harn-vm/src/a2a/mod.rs
+++ b/crates/harn-vm/src/a2a/mod.rs
@@ -6,8 +6,8 @@ use tokio::sync::broadcast;
 
 use crate::triggers::TriggerEvent;
 
-const A2A_AGENT_CARD_PATH: &str = ".well-known/a2a-agent";
-const A2A_PROTOCOL_VERSION: &str = "1.0.0";
+const A2A_AGENT_CARD_PATHS: &[&str] = &[".well-known/agent-card.json", ".well-known/a2a-agent"];
+const A2A_PROTOCOL_VERSION: &str = "1.0";
 const A2A_PUSH_URL_ENV: &str = "HARN_A2A_PUSH_URL";
 const A2A_PUSH_TOKEN_ENV: &str = "HARN_A2A_PUSH_TOKEN";
 
@@ -316,28 +316,34 @@ async fn resolve_endpoint(
 ) -> Result<ResolvedA2aEndpoint, A2aClientError> {
     let mut last_error = None;
     for scheme in card_resolution_schemes(allow_cleartext) {
-        let card_url = format!("{scheme}://{}/{A2A_AGENT_CARD_PATH}", target.authority);
-        match fetch_agent_card(&card_url, cancel_rx).await {
-            Ok(card) => {
-                return endpoint_from_card(
-                    card_url,
-                    allow_cleartext,
-                    &target.authority,
-                    target.target_agent.clone(),
-                    &card,
-                );
-            }
-            Err(AgentCardFetchError::Cancelled(message)) => {
-                return Err(A2aClientError::Cancelled(message));
-            }
-            Err(error) => {
-                let message = agent_card_fetch_error_message(&error);
-                last_error = Some(message);
-                if should_try_cleartext_fallback(scheme, allow_cleartext, &error, &target.authority)
-                {
-                    continue;
+        for path in A2A_AGENT_CARD_PATHS {
+            let card_url = format!("{scheme}://{}/{path}", target.authority);
+            match fetch_agent_card(&card_url, cancel_rx).await {
+                Ok(card) => {
+                    return endpoint_from_card(
+                        card_url,
+                        allow_cleartext,
+                        &target.authority,
+                        target.target_agent.clone(),
+                        &card,
+                    );
                 }
-                break;
+                Err(AgentCardFetchError::Cancelled(message)) => {
+                    return Err(A2aClientError::Cancelled(message));
+                }
+                Err(error) => {
+                    let should_try_next_scheme = should_try_cleartext_fallback(
+                        scheme,
+                        allow_cleartext,
+                        &error,
+                        &target.authority,
+                    );
+                    let message = agent_card_fetch_error_message(&error);
+                    last_error = Some(message);
+                    if should_try_next_scheme {
+                        break;
+                    }
+                }
             }
         }
     }
@@ -401,28 +407,14 @@ fn endpoint_from_card(
             "A2A agent card url authority mismatch: requested '{requested_authority}', card returned '{card_authority}'"
         )));
     }
-    let interfaces = card
-        .get("interfaces")
-        .and_then(Value::as_array)
-        .ok_or_else(|| {
-            A2aClientError::Discovery("A2A agent card missing interfaces".to_string())
-        })?;
-    let jsonrpc_interfaces: Vec<&Value> = interfaces
-        .iter()
-        .filter(|entry| entry.get("protocol").and_then(Value::as_str) == Some("jsonrpc"))
-        .collect();
-    if jsonrpc_interfaces.len() != 1 {
+    let jsonrpc_interface_urls = jsonrpc_interface_urls(card)?;
+    if jsonrpc_interface_urls.len() != 1 {
         return Err(A2aClientError::Discovery(format!(
             "A2A agent card must expose exactly one jsonrpc interface, found {}",
-            jsonrpc_interfaces.len()
+            jsonrpc_interface_urls.len()
         )));
     }
-    let interface_url = jsonrpc_interfaces[0]
-        .get("url")
-        .and_then(Value::as_str)
-        .ok_or_else(|| {
-            A2aClientError::Discovery("A2A jsonrpc interface missing url".to_string())
-        })?;
+    let interface_url = jsonrpc_interface_urls[0];
     let rpc_url = base_url.join(interface_url).map_err(|error| {
         A2aClientError::Discovery(format!(
             "invalid A2A interface url '{interface_url}': {error}"
@@ -435,6 +427,43 @@ fn endpoint_from_card(
         agent_id: card.get("id").and_then(Value::as_str).map(str::to_string),
         target_agent,
     })
+}
+
+fn jsonrpc_interface_urls(card: &Value) -> Result<Vec<&str>, A2aClientError> {
+    if let Some(interfaces) = card.get("supportedInterfaces").and_then(Value::as_array) {
+        return interfaces
+            .iter()
+            .filter(|entry| {
+                entry
+                    .get("protocolBinding")
+                    .and_then(Value::as_str)
+                    .is_some_and(|binding| binding.eq_ignore_ascii_case("JSONRPC"))
+            })
+            .map(|entry| {
+                entry.get("url").and_then(Value::as_str).ok_or_else(|| {
+                    A2aClientError::Discovery(
+                        "A2A JSONRPC supportedInterfaces entry missing url".to_string(),
+                    )
+                })
+            })
+            .collect();
+    }
+
+    let interfaces = card
+        .get("interfaces")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            A2aClientError::Discovery("A2A agent card missing supportedInterfaces".to_string())
+        })?;
+    interfaces
+        .iter()
+        .filter(|entry| entry.get("protocol").and_then(Value::as_str) == Some("jsonrpc"))
+        .map(|entry| {
+            entry.get("url").and_then(Value::as_str).ok_or_else(|| {
+                A2aClientError::Discovery("A2A jsonrpc interface missing url".to_string())
+            })
+        })
+        .collect()
 }
 
 fn card_resolution_schemes(allow_cleartext: bool) -> &'static [&'static str] {
@@ -795,13 +824,17 @@ mod tests {
     #[test]
     fn endpoint_from_card_rejects_card_url_authority_mismatch() {
         let error = endpoint_from_card(
-            "https://trusted.example/.well-known/a2a-agent".to_string(),
+            "https://trusted.example/.well-known/agent-card.json".to_string(),
             false,
             "trusted.example",
             "triage".to_string(),
             &serde_json::json!({
                 "url": "https://evil.example",
-                "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
+                "supportedInterfaces": [{
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": "1.0.0",
+                    "url": "/rpc"
+                }],
             }),
         )
         .unwrap_err();
@@ -814,13 +847,17 @@ mod tests {
     #[test]
     fn endpoint_from_card_rejects_cleartext_without_opt_in() {
         let error = endpoint_from_card(
-            "https://127.0.0.1:8080/.well-known/a2a-agent".to_string(),
+            "https://127.0.0.1:8080/.well-known/agent-card.json".to_string(),
             false,
             "127.0.0.1:8080",
             "triage".to_string(),
             &serde_json::json!({
                 "url": "http://localhost:8080",
-                "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
+                "supportedInterfaces": [{
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": "1.0.0",
+                    "url": "/rpc"
+                }],
             }),
         )
         .expect_err("cleartext card should require explicit opt-in");
@@ -836,10 +873,14 @@ mod tests {
         // the authority check must not spuriously reject the pair.
         let card = serde_json::json!({
             "url": "http://localhost:8080",
-            "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
+            "supportedInterfaces": [{
+                "protocolBinding": "JSONRPC",
+                "protocolVersion": "1.0.0",
+                "url": "/rpc"
+            }],
         });
         let endpoint = endpoint_from_card(
-            "http://127.0.0.1:8080/.well-known/a2a-agent".to_string(),
+            "http://127.0.0.1:8080/.well-known/agent-card.json".to_string(),
             true,
             "127.0.0.1:8080",
             "triage".to_string(),
@@ -851,10 +892,14 @@ mod tests {
         // IPv6 loopback `[::1]` also aliases to `127.0.0.1` / `localhost`.
         let card_v6 = serde_json::json!({
             "url": "http://[::1]:8080",
-            "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
+            "supportedInterfaces": [{
+                "protocolBinding": "JSONRPC",
+                "protocolVersion": "1.0.0",
+                "url": "/rpc"
+            }],
         });
         let endpoint_v6 = endpoint_from_card(
-            "http://localhost:8080/.well-known/a2a-agent".to_string(),
+            "http://localhost:8080/.well-known/agent-card.json".to_string(),
             true,
             "localhost:8080",
             "triage".to_string(),
@@ -866,10 +911,14 @@ mod tests {
         // Port mismatch is still rejected even on loopback.
         let card_wrong_port = serde_json::json!({
             "url": "http://localhost:9000",
-            "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
+            "supportedInterfaces": [{
+                "protocolBinding": "JSONRPC",
+                "protocolVersion": "1.0.0",
+                "url": "/rpc"
+            }],
         });
         let error = endpoint_from_card(
-            "http://127.0.0.1:8080/.well-known/a2a-agent".to_string(),
+            "http://127.0.0.1:8080/.well-known/agent-card.json".to_string(),
             true,
             "127.0.0.1:8080",
             "triage".to_string(),
@@ -892,5 +941,22 @@ mod tests {
             "trusted.example:443",
             "trusted.example:443",
         ));
+    }
+
+    #[test]
+    fn endpoint_from_card_accepts_legacy_interfaces_field() {
+        let endpoint = endpoint_from_card(
+            "https://trusted.example/.well-known/a2a-agent".to_string(),
+            false,
+            "trusted.example",
+            "triage".to_string(),
+            &serde_json::json!({
+                "url": "https://trusted.example",
+                "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
+            }),
+        )
+        .expect("legacy Harn A2A card should remain accepted");
+
+        assert_eq!(endpoint.rpc_url, "https://trusted.example/rpc");
     }
 }

--- a/crates/harn-vm/src/triggers/dispatcher/tests.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests.rs
@@ -529,13 +529,19 @@ fn handle_mock_a2a_connection<T: Read + Write>(
     task_result: &serde_json::Value,
 ) {
     let (request_line, headers, body) = read_http_request(stream);
-    if request_line.starts_with("GET /.well-known/a2a-agent ") {
+    if request_line.starts_with("GET /.well-known/agent-card.json ")
+        || request_line.starts_with("GET /.well-known/a2a-agent ")
+    {
         write_json_response(
             stream,
             &serde_json::json!({
                 "id": "mock-a2a",
                 "url": format!("{card_scheme}://127.0.0.1:{port}"),
-                "interfaces": [{"protocol": "jsonrpc", "url": "/rpc"}],
+                "supportedInterfaces": [{
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": "1.0.0",
+                    "url": "/rpc"
+                }],
             }),
         );
         return;
@@ -1414,7 +1420,7 @@ async fn a2a_handler_returns_pending_task_handle() {
                     "state": "working",
                     "target_agent": "triage",
                     "rpc_url": format!("https://{}/rpc", server.authority),
-                    "card_url": format!("https://{}/.well-known/a2a-agent", server.authority),
+                    "card_url": format!("https://{}/.well-known/agent-card.json", server.authority),
                     "agent_id": "mock-a2a",
                 }))
             );

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -989,7 +989,7 @@ harn serve mcp agent.harn --card ./card.json
 
 `harn serve a2a` uses the shared `harn-serve` dispatch core and exposes each
 exported `pub fn` in the target module as an A2A skill. The adapter publishes an
-agent card at `/.well-known/a2a-agent` and supports task send, send-and-wait,
+agent card at `/.well-known/agent-card.json` and supports task send, send-and-wait,
 streaming/resubscribe, push callback registration, and cancel propagation. The
 legacy shorthand `harn serve <file>` is preserved and rewrites internally to
 `harn serve a2a <file>`.

--- a/docs/src/harn-serve.md
+++ b/docs/src/harn-serve.md
@@ -116,8 +116,8 @@ harn serve a2a --cert certs/prod.pem --key certs/prod-key.pem server.harn
 Behavior today:
 
 - HTTP JSON-RPC endpoint at `/`
-- agent cards at `/.well-known/a2a-agent`, `/.well-known/agent.json`, and
-  `/agent/card`
+- agent cards at `/.well-known/agent-card.json`, with compatibility aliases at
+  `/.well-known/a2a-agent`, `/.well-known/agent.json`, and `/agent/card`
 - `a2a.SendMessage`, `a2a.SendStreamingMessage`, `a2a.GetTask`,
   `a2a.CancelTask`, and `a2a.ListTasks`
 - A2A task aliases `tasks/send`, `tasks/send_and_wait`, `tasks/resubscribe`,

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -4056,6 +4056,11 @@ openapi = { git = "https://github.com/burin-labs/harn-openapi", branch = "main" 
 local-fixture = { path = "../fixture-lib" }
 ```
 
+The Agents API OpenAPI package intentionally names the REST discovery resource
+`HarnAgentCard` and the nested A2A projection `A2aAgentCard`. SDK bootstrap code
+should import `HarnAgentCard` for `/v1/agent-card` responses and pass only the
+`a2a_agent_card` field to A2A SDKs or validators.
+
 `[dependencies]` installs package sources into `.harn/packages/` so
 imports like `import "notion-sdk-harn"` or `import "notion/providers"`
 resolve without filesystem-relative hacks.

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -592,8 +592,9 @@ harn serve a2a --port 3000 agent.harn
 
 ### Agent card
 
-The server publishes an agent card at `GET /.well-known/a2a-agent`, with
-compatibility aliases at `GET /.well-known/agent.json` and `GET /agent/card`.
+The server publishes an agent card at `GET /.well-known/agent-card.json`, with
+compatibility aliases at `GET /.well-known/a2a-agent`,
+`GET /.well-known/agent.json`, and `GET /agent/card`.
 The card advertises each exported `pub fn` as an A2A skill. Set
 `--card-signing-secret` or `HARN_SERVE_A2A_CARD_SECRET` to attach an HS256
 signature envelope to the card.

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -622,6 +622,11 @@ harn install --frozen
 harn check main.harn
 ```
 
+Generated Agents API SDKs should keep the discovery types distinct:
+`/v1/agent-card` returns the Harn resource type `HarnAgentCard`, while its
+`a2a_agent_card` field is the A2A-compatible `A2aAgentCard` to pass to A2A
+SDKs or validators.
+
 Equivalent manifest entries:
 
 ```toml

--- a/docs/src/triggers/dispatcher.md
+++ b/docs/src/triggers/dispatcher.md
@@ -53,10 +53,11 @@ stable handler kind and target URI in lifecycle logs and action-graph nodes.
 
 For `a2a://host[:port]/path` routes, the dispatcher:
 
-- fetches `/.well-known/a2a-agent` from the target host
+- fetches `/.well-known/agent-card.json` from the target host, with
+  `/.well-known/a2a-agent` as a legacy fallback
 - defaults to HTTPS-only discovery + dispatch; cleartext HTTP is rejected unless
   the trigger binding explicitly sets `allow_cleartext = true`
-- requires exactly one JSON-RPC interface in the agent card before it will
+- requires exactly one JSON-RPC `supportedInterfaces` entry in the agent card before it will
   dispatch
 - treats the URI path as the `target_agent` label that propagates into the
   outbound envelope and the action graph

--- a/spec/AGENTS_PROTOCOL.md
+++ b/spec/AGENTS_PROTOCOL.md
@@ -257,8 +257,11 @@ in Message parts.
 
 ### AgentCard
 
-An AgentCard advertises an agent endpoint and its capabilities. It is aligned
-with A2A agent-card concepts while adding Harn policy and receipt metadata.
+The Harn Agents API `AgentCard` is a Harn resource envelope that advertises
+agent endpoints, policy, and capabilities. It is not itself an A2A AgentCard.
+When an implementation also wants to expose A2A discovery, it MUST place the
+A2A-compatible card in `a2a_agent_card` instead of mixing A2A camelCase fields
+into the Harn envelope.
 
 Required fields:
 
@@ -268,9 +271,22 @@ Required fields:
 - `protocol_version`: supported Harn Agents Protocol version.
 - `interfaces`: available transport interfaces.
 - `skills`: callable skills or exported functions.
+- `a2a_agent_card`: nested A2A AgentCard projection.
 
 Optional fields include `persona_ids`, `capabilities`, `auth_schemes`,
 `receipt_policy`, `quotas`, `provider`, `public_url`, and `signature`.
+
+The nested `a2a_agent_card` MUST use A2A field names such as `version`,
+`url`, `capabilities`, `supportedInterfaces`, `securitySchemes`,
+`securityRequirements`, `defaultInputModes`, `defaultOutputModes`, and
+`skills`. SDK generators should expose the REST resource as `HarnAgentCard`
+and the nested projection as `A2aAgentCard`; clients should pass only the
+nested object to A2A SDKs.
+
+For draft compatibility, servers MAY continue to emit the legacy top-level
+Harn fields `interfaces`, `auth_schemes`, `receipt_policy`, and `public_url`.
+New clients MUST prefer `a2a_agent_card` for A2A interop and treat those legacy
+top-level fields as Harn policy/discovery metadata only.
 
 Signed cards MUST state their signature algorithm and key id. Clients MUST NOT
 trust unsigned card metadata for authorization decisions.

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -4054,6 +4054,11 @@ openapi = { git = "https://github.com/burin-labs/harn-openapi", branch = "main" 
 local-fixture = { path = "../fixture-lib" }
 ```
 
+The Agents API OpenAPI package intentionally names the REST discovery resource
+`HarnAgentCard` and the nested A2A projection `A2aAgentCard`. SDK bootstrap code
+should import `HarnAgentCard` for `/v1/agent-card` responses and pass only the
+`a2a_agent_card` field to A2A SDKs or validators.
+
 `[dependencies]` installs package sources into `.harn/packages/` so
 imports like `import "notion-sdk-harn"` or `import "notion/providers"`
 resolve without filesystem-relative hacks.

--- a/spec/openapi.snapshot
+++ b/spec/openapi.snapshot
@@ -113,9 +113,15 @@ ImageRefPart
 Artifact
 ArtifactList
 RegisterArtifactRequest
-AgentCard
+HarnAgentCard
 AgentInterface
 CardSignature
+A2aAgentCard
+A2aAgentProvider
+A2aAgentCapabilities
+A2aAgentInterface
+A2aAgentSkill
+A2aAgentCardSignature
 Event
 EventList
 EventStream

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -62,16 +62,16 @@ paths:
   /v1/agent-card:
     get:
       tags: [Discovery]
-      operationId: getAgentCard
-      summary: Retrieve the public AgentCard for this Harness.
+      operationId: getHarnAgentCard
+      summary: Retrieve the public Harn AgentCard for this Harness.
       security: []
       responses:
         "200":
-          description: AgentCard.
+          description: Harn AgentCard envelope with a nested A2A AgentCard projection.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AgentCard"
+                $ref: "#/components/schemas/HarnAgentCard"
         default:
           $ref: "#/components/responses/Error"
 
@@ -2232,15 +2232,19 @@ components:
         metadata:
           $ref: "#/components/schemas/Metadata"
 
-    AgentCard:
+    HarnAgentCard:
       allOf:
         - $ref: "#/components/schemas/ResourceEnvelope"
         - type: object
-          required: [object, name, description, protocol_version, interfaces, skills]
+          required: [object, name, description, protocol_version, interfaces, skills, a2a_agent_card]
           properties:
             object:
               type: string
               enum: [agent_card]
+            kind:
+              type: string
+              enum: [harn_agent_card]
+              description: Stable SDK-friendly discriminator for the Harn Agents API envelope.
             name:
               type: string
             description:
@@ -2282,6 +2286,12 @@ components:
               oneOf:
                 - $ref: "#/components/schemas/CardSignature"
                 - type: "null"
+            a2a_agent_card:
+              $ref: "#/components/schemas/A2aAgentCard"
+              description: |
+                A2A-compatible AgentCard projection. This nested object is the only
+                field clients should pass to A2A SDKs; the surrounding resource is
+                Harn-specific policy and discovery metadata.
     AgentInterface:
       type: object
       required: [transport, url]
@@ -2301,6 +2311,130 @@ components:
         key_id:
           type: string
         value:
+          type: string
+
+    A2aAgentCard:
+      type: object
+      required: [name, description, version, url, capabilities, supportedInterfaces, skills]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        version:
+          type: string
+          description: Version of the advertised agent implementation.
+        url:
+          type: string
+          format: uri
+          description: Base URL for the A2A agent service.
+        provider:
+          $ref: "#/components/schemas/A2aAgentProvider"
+        capabilities:
+          $ref: "#/components/schemas/A2aAgentCapabilities"
+        supportedInterfaces:
+          type: array
+          items:
+            $ref: "#/components/schemas/A2aAgentInterface"
+        securitySchemes:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/JsonObject"
+        securityRequirements:
+          type: array
+          items:
+            $ref: "#/components/schemas/JsonObject"
+        defaultInputModes:
+          type: array
+          items:
+            type: string
+        defaultOutputModes:
+          type: array
+          items:
+            type: string
+        skills:
+          type: array
+          items:
+            $ref: "#/components/schemas/A2aAgentSkill"
+        signatures:
+          type: array
+          items:
+            $ref: "#/components/schemas/A2aAgentCardSignature"
+    A2aAgentProvider:
+      type: object
+      properties:
+        organization:
+          type: string
+        url:
+          type: string
+          format: uri
+    A2aAgentCapabilities:
+      type: object
+      properties:
+        streaming:
+          type: boolean
+        pushNotifications:
+          type: boolean
+        extendedAgentCard:
+          type: boolean
+        extensions:
+          type: array
+          items:
+            $ref: "#/components/schemas/JsonObject"
+      additionalProperties:
+        $ref: "#/components/schemas/JsonValue"
+    A2aAgentInterface:
+      type: object
+      required: [url, protocolBinding, protocolVersion]
+      properties:
+        url:
+          type: string
+          format: uri
+        protocolBinding:
+          type: string
+          description: A2A protocol binding, for example JSONRPC, GRPC, or HTTP+JSON.
+        protocolVersion:
+          type: string
+          description: A2A protocol version exposed at this interface.
+    A2aAgentSkill:
+      type: object
+      required: [id, name, description]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        examples:
+          type: array
+          items:
+            type: string
+        inputModes:
+          type: array
+          items:
+            type: string
+        outputModes:
+          type: array
+          items:
+            type: string
+        securityRequirements:
+          type: array
+          items:
+            $ref: "#/components/schemas/JsonObject"
+    A2aAgentCardSignature:
+      type: object
+      required: [protected, signature]
+      properties:
+        protected:
+          type: string
+        header:
+          $ref: "#/components/schemas/JsonObject"
+        signature:
           type: string
 
     Event:


### PR DESCRIPTION
## Summary

- Renames the Agents API discovery response schema to `HarnAgentCard` and nests the A2A-compatible projection under `a2a_agent_card`.
- Updates the A2A adapter/client to use current `supportedInterfaces` cards at `/.well-known/agent-card.json`, while keeping legacy aliases and parser compatibility.
- Updates the conformance probe, docs, generated language spec mirror, and SDK bootstrap notes for the stable type split.

Closes #815.

## Validation

- `./scripts/check_openapi_snapshot.py && npx redocly lint spec/openapi.yaml`
- `CARGO_TARGET_DIR=/tmp/codex-harn-815-target HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-serve -p harn-vm -p harn-cli a2a`
- `CARGO_TARGET_DIR=/tmp/codex-harn-815-target HARN_LLM_CALLS_DISABLED=1 cargo clippy -p harn-serve -p harn-vm -p harn-cli --all-targets -- -D warnings`
- `npx markdownlint-cli2 docs/src/modules.md docs/src/harn-serve.md docs/src/mcp-and-acp.md docs/src/cli-reference.md docs/src/triggers/dispatcher.md spec/AGENTS_PROTOCOL.md spec/HARN_SPEC.md docs/src/language-spec.md && make check-language-spec`
- Pre-commit hook: full workspace clippy + markdown
- Pre-push hook: full workspace nextest, 2,839 passed + markdown
