### PR TITLE
Expose headers in HTTP mock call records

### DIFF
--- a/conformance/tests/runtime/http_mock.harn
+++ b/conformance/tests/runtime/http_mock.harn
@@ -24,12 +24,12 @@ pipeline test(task) {
   assert_eq(post_resp.status, 201)
   log("post status: " + to_string(post_resp.status))
   // Check recorded calls
-  let calls = http_mock_calls()
+  let calls = http_mock_calls({include_sensitive: true})
   assert_eq(len(calls), 2)
   assert_eq(calls[0].method, "GET")
   assert_eq(calls[1].method, "POST")
-  assert_eq(calls[1].headers.Authorization, "Bearer test-token")
-  assert_eq(calls[1].headers["Content-Type"], "application/json")
+  assert_eq(calls[1].headers.authorization, "Bearer test-token")
+  assert_eq(calls[1].headers["content-type"], "application/json")
   assert_eq(json_parse(calls[1].body).name, "test")
   log("calls: " + to_string(len(calls)))
   // Clear mocks

--- a/conformance/tests/stdlib/graphql_sdk.harn
+++ b/conformance/tests/stdlib/graphql_sdk.harn
@@ -53,9 +53,9 @@ pipeline test(task) {
   println(envelope.meta.rate_limit.complexity)
   println(envelope.meta.request_id)
   println(envelope.result.meta.status)
-  let calls = http_mock_calls()
+  let calls = http_mock_calls({include_sensitive: true})
   println(json_parse(calls[0].body).operationName)
-  println(calls[0].headers.Authorization)
+  println(calls[0].headers.authorization)
   let page = graphql_page_info({nodes: [{id: "ISS-1"}], pageInfo: {hasNextPage: true, endCursor: "cursor-1"}})
   println(page.nodes[0].id)
   println(

--- a/conformance/tests/stdlib/http_mock_calls_headers.expected
+++ b/conformance/tests/stdlib/http_mock_calls_headers.expected
@@ -1,0 +1,1 @@
+http_mock_calls_headers_ok

--- a/conformance/tests/stdlib/http_mock_calls_headers.harn
+++ b/conformance/tests/stdlib/http_mock_calls_headers.harn
@@ -1,0 +1,39 @@
+pipeline test(task) {
+  http_mock_clear()
+  http_mock(
+    "GET",
+    "https://api.example.com/items?api_key=secret&limit=2",
+    {status: 200, body: "ok", headers: {}},
+  )
+  let get_resp = http_get(
+    "https://api.example.com/items",
+    {
+      headers: {Authorization: "Bearer secret-token", ["X-Api-Key"]: "header-secret", Accept: "application/json"},
+      query: {api_key: "secret", limit: 2},
+    },
+  )
+  assert_eq(get_resp.status, 200)
+  let redacted = http_mock_calls()
+  assert_eq(len(redacted), 1)
+  assert_eq(redacted[0].method, "GET")
+  assert_eq(redacted[0].url, "https://api.example.com/items?api_key=%5Bredacted%5D&limit=2")
+  assert_eq(redacted[0].headers.authorization, "[redacted]")
+  assert_eq(redacted[0].headers["x-api-key"], "[redacted]")
+  assert_eq(redacted[0].headers.accept, "application/json")
+  let raw = http_mock_calls({redact_sensitive: false})
+  assert_eq(raw[0].url, "https://api.example.com/items?api_key=secret&limit=2")
+  assert_eq(raw[0].headers.authorization, "Bearer secret-token")
+  assert_eq(raw[0].headers["x-api-key"], "header-secret")
+  http_mock("POST", "https://api.example.com/items", {status: 201, body: "created", headers: {}})
+  let post_resp = http_post(
+    "https://api.example.com/items",
+    "{\"name\":\"Ada\"}",
+    {headers: {Cookie: "sid=session-secret", ["Content-Type"]: "application/json"}},
+  )
+  assert_eq(post_resp.status, 201)
+  let with_sensitive = http_mock_calls({include_sensitive: true})
+  assert_eq(with_sensitive[1].headers.cookie, "sid=session-secret")
+  assert_eq(with_sensitive[1].headers["content-type"], "application/json")
+  assert_eq(with_sensitive[1].body, "{\"name\":\"Ada\"}")
+  println("http_mock_calls_headers_ok")
+}

--- a/crates/harn-vm/src/http.rs
+++ b/crates/harn-vm/src/http.rs
@@ -854,6 +854,86 @@ fn consume_http_mock(
     Some(response)
 }
 
+fn is_sensitive_http_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "authorization"
+            | "proxy-authorization"
+            | "cookie"
+            | "set-cookie"
+            | "x-api-key"
+            | "api-key"
+            | "x-auth-token"
+            | "x-csrf-token"
+            | "x-xsrf-token"
+    )
+}
+
+fn is_sensitive_url_param(name: &str) -> bool {
+    let normalized = name.to_ascii_lowercase();
+    normalized == "api_key"
+        || normalized == "apikey"
+        || normalized == "access_token"
+        || normalized == "refresh_token"
+        || normalized == "id_token"
+        || normalized == "client_secret"
+        || normalized == "password"
+        || normalized == "secret"
+        || normalized == "token"
+        || normalized.ends_with("_token")
+        || normalized.ends_with("_secret")
+}
+
+fn redact_mock_call_url(url: &str, redact: bool) -> String {
+    if !redact {
+        return url.to_string();
+    }
+    let Ok(mut parsed) = url::Url::parse(url) else {
+        return url.to_string();
+    };
+    let mut redacted_any = false;
+    let pairs: Vec<(String, String)> = parsed
+        .query_pairs()
+        .map(|(key, value)| {
+            let value = if is_sensitive_url_param(&key) {
+                redacted_any = true;
+                "[redacted]".to_string()
+            } else {
+                value.into_owned()
+            };
+            (key.into_owned(), value)
+        })
+        .collect();
+    if !redacted_any {
+        return url.to_string();
+    }
+    parsed.set_query(None);
+    {
+        let mut query = parsed.query_pairs_mut();
+        for (key, value) in pairs {
+            query.append_pair(&key, &value);
+        }
+    }
+    parsed.to_string()
+}
+
+fn mock_call_headers_value(
+    headers: &BTreeMap<String, VmValue>,
+    redact_headers: bool,
+) -> BTreeMap<String, VmValue> {
+    headers
+        .iter()
+        .map(|(key, value)| {
+            let value = if redact_headers && is_sensitive_http_header(key) {
+                VmValue::String(Rc::from("[redacted]"))
+            } else {
+                value.clone()
+            };
+            (key.clone(), value)
+        })
+        .collect()
+}
+
 fn vm_string(value: impl AsRef<str>) -> VmValue {
     VmValue::String(Rc::from(value.as_ref()))
 }
@@ -1783,8 +1863,16 @@ pub fn register_http_builtins(vm: &mut Vm) {
         Ok(VmValue::Nil)
     });
 
-    // http_mock_calls() -> list of {method, url, headers, body}
-    vm.register_builtin("http_mock_calls", |_args, _out| {
+    // http_mock_calls(options?) -> list of {method, url, headers, body}
+    vm.register_builtin("http_mock_calls", |args, _out| {
+        let options = get_options_arg(args, 0);
+        let include_sensitive = get_bool_option(&options, "include_sensitive", false)
+            || get_bool_option(&options, "include_sensitive_headers", false);
+        let redact_sensitive = get_bool_option(
+            &options,
+            "redact_sensitive",
+            get_bool_option(&options, "redact_headers", true),
+        ) && !include_sensitive;
         let calls = HTTP_MOCK_CALLS.with(|calls| calls.borrow().clone());
         let result: Vec<VmValue> = calls
             .iter()
@@ -1794,10 +1882,16 @@ pub fn register_http_builtins(vm: &mut Vm) {
                     "method".to_string(),
                     VmValue::String(Rc::from(c.method.as_str())),
                 );
-                dict.insert("url".to_string(), VmValue::String(Rc::from(c.url.as_str())));
+                dict.insert(
+                    "url".to_string(),
+                    VmValue::String(Rc::from(redact_mock_call_url(&c.url, redact_sensitive))),
+                );
                 dict.insert(
                     "headers".to_string(),
-                    VmValue::Dict(Rc::new(c.headers.clone())),
+                    VmValue::Dict(Rc::new(mock_call_headers_value(
+                        &c.headers,
+                        redact_sensitive,
+                    ))),
                 );
                 dict.insert(
                     "body".to_string(),
@@ -2747,7 +2841,7 @@ fn parse_http_request_parts(
                     .map_err(|e| vm_error(format!("http: invalid auth header value: {e}")))?;
                 header_map.insert(reqwest::header::AUTHORIZATION, hv);
                 recorded_headers.insert(
-                    "Authorization".to_string(),
+                    "authorization".to_string(),
                     VmValue::String(Rc::from(s.as_ref())),
                 );
             }
@@ -2759,7 +2853,7 @@ fn parse_http_request_parts(
                         .map_err(|e| vm_error(format!("http: invalid bearer token: {e}")))?;
                     header_map.insert(reqwest::header::AUTHORIZATION, hv);
                     recorded_headers.insert(
-                        "Authorization".to_string(),
+                        "authorization".to_string(),
                         VmValue::String(Rc::from(authorization)),
                     );
                 } else if let Some(VmValue::Dict(basic)) = d.get("basic") {
@@ -2776,7 +2870,7 @@ fn parse_http_request_parts(
                         .map_err(|e| vm_error(format!("http: invalid basic auth: {e}")))?;
                     header_map.insert(reqwest::header::AUTHORIZATION, hv);
                     recorded_headers.insert(
-                        "Authorization".to_string(),
+                        "authorization".to_string(),
                         VmValue::String(Rc::from(authorization)),
                     );
                 }
@@ -2792,7 +2886,10 @@ fn parse_http_request_parts(
             let val = reqwest::header::HeaderValue::from_str(&v.display())
                 .map_err(|e| vm_error(format!("http: invalid header value for '{k}': {e}")))?;
             header_map.insert(name, val);
-            recorded_headers.insert(k.clone(), VmValue::String(Rc::from(v.display())));
+            recorded_headers.insert(
+                k.to_ascii_lowercase(),
+                VmValue::String(Rc::from(v.display())),
+            );
         }
     }
 
@@ -2822,6 +2919,27 @@ fn parse_http_request_parts(
         },
         multipart,
     })
+}
+
+fn final_http_url(
+    url: &str,
+    options: &BTreeMap<String, VmValue>,
+    builtin: &str,
+) -> Result<String, VmError> {
+    let Some(query) = options.get("query").and_then(VmValue::as_dict) else {
+        return Ok(url.to_string());
+    };
+    let mut parsed = url::Url::parse(url)
+        .map_err(|error| vm_error(format!("{builtin}: invalid URL '{url}': {error}")))?;
+    {
+        let mut pairs = parsed.query_pairs_mut();
+        for (key, value) in query.iter() {
+            if !matches!(value, VmValue::Nil) {
+                pairs.append_pair(key, &value.display());
+            }
+        }
+    }
+    Ok(parsed.to_string())
 }
 
 fn session_from_options(options: &BTreeMap<String, VmValue>) -> Option<String> {
@@ -3799,18 +3917,19 @@ async fn vm_execute_http_request_with_client(
     options: &BTreeMap<String, VmValue>,
 ) -> Result<VmValue, VmError> {
     let parts = parse_http_request_parts(method, options)?;
+    let final_url = final_http_url(url, options, "http")?;
 
-    if !url.starts_with("http://") && !url.starts_with("https://") {
+    if !final_url.starts_with("http://") && !final_url.starts_with("https://") {
         return Err(vm_error(format!(
             "http: URL must start with http:// or https://, got '{url}'"
         )));
     }
-    crate::egress::enforce_url_allowed("http_request", url).await?;
+    crate::egress::enforce_url_allowed("http_request", &final_url).await?;
 
     for attempt in 0..=config.retry.max {
         if let Some(mock_response) = consume_http_mock(
             method,
-            url,
+            &final_url,
             parts.recorded_headers.clone(),
             parts.body.clone(),
         ) {
@@ -3837,7 +3956,7 @@ async fn vm_execute_http_request_with_client(
             ));
         }
 
-        let mut req = client.request(parts.method.clone(), url);
+        let mut req = client.request(parts.method.clone(), &final_url);
         req = req
             .headers(parts.headers.clone())
             .timeout(Duration::from_millis(config.total_timeout_ms));
@@ -3900,9 +4019,10 @@ async fn vm_http_download(
         .unwrap_or_else(|| "GET".to_string())
         .to_uppercase();
     let parts = parse_http_request_parts(&method, options)?;
+    let final_url = final_http_url(url, options, "http_download")?;
     if let Some(mock_response) = consume_http_mock(
         &method,
-        url,
+        &final_url,
         parts.recorded_headers.clone(),
         parts.body.clone(),
     ) {
@@ -3924,12 +4044,12 @@ async fn vm_http_download(
         ));
     }
 
-    if !url.starts_with("http://") && !url.starts_with("https://") {
+    if !final_url.starts_with("http://") && !final_url.starts_with("https://") {
         return Err(vm_error(format!(
             "http_download: URL must start with http:// or https://, got '{url}'"
         )));
     }
-    crate::egress::enforce_url_allowed("http_download", url).await?;
+    crate::egress::enforce_url_allowed("http_download", &final_url).await?;
     let config = parse_http_options(options);
     let client = if let Some(session_id) = session_from_options(options) {
         HTTP_SESSIONS
@@ -3944,7 +4064,7 @@ async fn vm_http_download(
         pooled_http_client(&config)?
     };
     let mut request = client
-        .request(parts.method, url)
+        .request(parts.method, &final_url)
         .headers(parts.headers)
         .timeout(Duration::from_millis(config.total_timeout_ms));
     if let Some(multipart) = &parts.multipart {
@@ -3998,10 +4118,11 @@ async fn vm_http_stream_open(
         .unwrap_or_else(|| "GET".to_string())
         .to_uppercase();
     let parts = parse_http_request_parts(&method, options)?;
+    let final_url = final_http_url(url, options, "http_stream_open")?;
     let id = next_transport_handle("http-stream");
     if let Some(mock_response) = consume_http_mock(
         &method,
-        url,
+        &final_url,
         parts.recorded_headers.clone(),
         parts.body.clone(),
     ) {
@@ -4025,12 +4146,12 @@ async fn vm_http_stream_open(
         return Ok(VmValue::String(Rc::from(id)));
     }
 
-    if !url.starts_with("http://") && !url.starts_with("https://") {
+    if !final_url.starts_with("http://") && !final_url.starts_with("https://") {
         return Err(vm_error(format!(
             "http_stream_open: URL must start with http:// or https://, got '{url}'"
         )));
     }
-    crate::egress::enforce_url_allowed("http_stream_open", url).await?;
+    crate::egress::enforce_url_allowed("http_stream_open", &final_url).await?;
     let config = parse_http_options(options);
     let client = if let Some(session_id) = session_from_options(options) {
         HTTP_SESSIONS
@@ -4045,7 +4166,7 @@ async fn vm_http_stream_open(
         pooled_http_client(&config)?
     };
     let mut request = client
-        .request(parts.method, url)
+        .request(parts.method, &final_url)
         .headers(parts.headers)
         .timeout(Duration::from_millis(config.total_timeout_ms));
     if let Some(multipart) = &parts.multipart {
@@ -5177,12 +5298,12 @@ async fn vm_websocket_close(socket_id: &str) -> Result<VmValue, VmError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        compute_retry_delay, handle_from_value, http_mock_calls_snapshot, parse_retry_after_value,
-        push_http_mock, reset_http_state, vm_execute_http_request, vm_http_download,
-        vm_http_stream_info, vm_http_stream_open, vm_http_stream_read, vm_sse_event_frame,
-        vm_sse_server_cancel, vm_sse_server_heartbeat, vm_sse_server_mock_disconnect,
-        vm_sse_server_mock_receive, vm_sse_server_observed_bool, vm_sse_server_response,
-        vm_sse_server_send, HttpMockResponse,
+        compute_retry_delay, handle_from_value, http_mock_calls_snapshot, mock_call_headers_value,
+        parse_retry_after_value, push_http_mock, redact_mock_call_url, reset_http_state,
+        vm_execute_http_request, vm_http_download, vm_http_stream_info, vm_http_stream_open,
+        vm_http_stream_read, vm_sse_event_frame, vm_sse_server_cancel, vm_sse_server_heartbeat,
+        vm_sse_server_mock_disconnect, vm_sse_server_mock_receive, vm_sse_server_observed_bool,
+        vm_sse_server_response, vm_sse_server_send, HttpMockResponse,
     };
     use crate::connectors::test_util::{
         accept_http_connection, read_http_request, write_http_response,
@@ -5262,6 +5383,98 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].url, "https://api.example.com/retry");
         reset_http_state();
+    }
+
+    #[tokio::test]
+    async fn http_mock_records_normalized_headers_and_final_query_url() {
+        reset_http_state();
+        push_http_mock(
+            "GET",
+            "https://api.example.com/items?api_key=secret&limit=2",
+            vec![HttpMockResponse::new(200, "ok")],
+        );
+        let options = BTreeMap::from([
+            (
+                "headers".to_string(),
+                VmValue::Dict(Rc::new(BTreeMap::from([
+                    (
+                        "Authorization".to_string(),
+                        VmValue::String(Rc::from("Bearer secret")),
+                    ),
+                    ("X-Trace".to_string(), VmValue::String(Rc::from("trace-1"))),
+                ]))),
+            ),
+            (
+                "query".to_string(),
+                VmValue::Dict(Rc::new(BTreeMap::from([
+                    ("api_key".to_string(), VmValue::String(Rc::from("secret"))),
+                    ("limit".to_string(), VmValue::Int(2)),
+                ]))),
+            ),
+        ]);
+
+        let response = vm_execute_http_request("GET", "https://api.example.com/items", &options)
+            .await
+            .expect("mocked request with query");
+        let response = response.as_dict().expect("response dict");
+        assert_eq!(response["status"].as_int(), Some(200));
+
+        let calls = http_mock_calls_snapshot();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].url,
+            "https://api.example.com/items?api_key=secret&limit=2"
+        );
+        assert_eq!(
+            calls[0].headers.get("authorization").map(String::as_str),
+            Some("Bearer secret")
+        );
+        assert_eq!(
+            calls[0].headers.get("x-trace").map(String::as_str),
+            Some("trace-1")
+        );
+        reset_http_state();
+    }
+
+    #[test]
+    fn mock_call_headers_redact_sensitive_values() {
+        let headers = BTreeMap::from([
+            (
+                "authorization".to_string(),
+                VmValue::String(Rc::from("Bearer secret")),
+            ),
+            (
+                "accept".to_string(),
+                VmValue::String(Rc::from("application/json")),
+            ),
+            ("x-api-key".to_string(), VmValue::String(Rc::from("secret"))),
+        ]);
+        let redacted = mock_call_headers_value(&headers, true);
+        assert_eq!(redacted["authorization"].display(), "[redacted]");
+        assert_eq!(redacted["x-api-key"].display(), "[redacted]");
+        assert_eq!(redacted["accept"].display(), "application/json");
+
+        let raw = mock_call_headers_value(&headers, false);
+        assert_eq!(raw["authorization"].display(), "Bearer secret");
+    }
+
+    #[test]
+    fn mock_call_url_redacts_sensitive_query_values() {
+        assert_eq!(
+            redact_mock_call_url(
+                "https://api.example.com/items?api_key=secret&limit=2&access_token=token",
+                true,
+            ),
+            "https://api.example.com/items?api_key=%5Bredacted%5D&limit=2&access_token=%5Bredacted%5D"
+        );
+        assert_eq!(
+            redact_mock_call_url("https://api.example.com/items?api_key=secret", false),
+            "https://api.example.com/items?api_key=secret"
+        );
+        assert_eq!(
+            redact_mock_call_url("https://api.example.com/items?q=a%20b", true),
+            "https://api.example.com/items?q=a%20b"
+        );
     }
 
     #[tokio::test]

--- a/crates/harn-vm/src/http.rs
+++ b/crates/harn-vm/src/http.rs
@@ -25,73 +25,15 @@ use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 use x509_parser::prelude::{FromDer, X509Certificate};
 
-// Mock HTTP framework (thread-local, mirrors the mock LLM pattern).
+mod mock;
 
-#[derive(Clone)]
-struct MockResponse {
-    status: i64,
-    body: String,
-    headers: BTreeMap<String, VmValue>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HttpMockResponse {
-    pub status: i64,
-    pub body: String,
-    pub headers: BTreeMap<String, String>,
-}
-
-impl HttpMockResponse {
-    pub fn new(status: i64, body: impl Into<String>) -> Self {
-        Self {
-            status,
-            body: body.into(),
-            headers: BTreeMap::new(),
-        }
-    }
-
-    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
-        self.headers.insert(name.into(), value.into());
-        self
-    }
-}
-
-impl From<HttpMockResponse> for MockResponse {
-    fn from(value: HttpMockResponse) -> Self {
-        Self {
-            status: value.status,
-            body: value.body,
-            headers: value
-                .headers
-                .into_iter()
-                .map(|(key, value)| (key, VmValue::String(Rc::from(value))))
-                .collect(),
-        }
-    }
-}
-
-struct HttpMock {
-    method: String,
-    url_pattern: String,
-    responses: Vec<MockResponse>,
-    next_response: usize,
-}
-
-#[derive(Clone)]
-struct HttpMockCall {
-    method: String,
-    url: String,
-    headers: BTreeMap<String, VmValue>,
-    body: Option<String>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HttpMockCallSnapshot {
-    pub method: String,
-    pub url: String,
-    pub headers: BTreeMap<String, String>,
-    pub body: Option<String>,
-}
+use mock::{
+    clear_http_mocks, consume_http_mock, http_mock_calls_value, parse_mock_responses,
+    register_http_mock, reset_http_mocks, url_matches,
+};
+pub use mock::{http_mock_calls_snapshot, push_http_mock, HttpMockCallSnapshot, HttpMockResponse};
+#[cfg(test)]
+use mock::{mock_call_headers_value, redact_mock_call_url};
 
 #[derive(Clone)]
 struct RetryConfig {
@@ -344,8 +286,6 @@ const MAX_HTTP_SERVERS: usize = 128;
 const MAX_WEBSOCKET_SERVERS: usize = 16;
 
 thread_local! {
-    static HTTP_MOCKS: RefCell<Vec<HttpMock>> = const { RefCell::new(Vec::new()) };
-    static HTTP_MOCK_CALLS: RefCell<Vec<HttpMockCall>> = const { RefCell::new(Vec::new()) };
     static HTTP_CLIENTS: RefCell<HashMap<String, reqwest::Client>> = RefCell::new(HashMap::new());
     static HTTP_SESSIONS: RefCell<HashMap<String, HttpSession>> = RefCell::new(HashMap::new());
     static HTTP_STREAMS: RefCell<HashMap<String, HttpStreamHandle>> = RefCell::new(HashMap::new());
@@ -362,8 +302,7 @@ thread_local! {
 
 /// Reset thread-local HTTP mock state. Call between test runs.
 pub fn reset_http_state() {
-    HTTP_MOCKS.with(|m| m.borrow_mut().clear());
-    HTTP_MOCK_CALLS.with(|c| c.borrow_mut().clear());
+    reset_http_mocks();
     HTTP_CLIENTS.with(|clients| clients.borrow_mut().clear());
     HTTP_SESSIONS.with(|sessions| sessions.borrow_mut().clear());
     HTTP_STREAMS.with(|streams| streams.borrow_mut().clear());
@@ -392,88 +331,6 @@ pub fn reset_http_state() {
     TRANSPORT_MOCK_CALLS.with(|calls| calls.borrow_mut().clear());
     TRANSPORT_HANDLE_COUNTER.with(|counter| *counter.borrow_mut() = 0);
     HTTP_SERVERS.with(|servers| servers.borrow_mut().clear());
-}
-
-pub fn push_http_mock(
-    method: impl Into<String>,
-    url_pattern: impl Into<String>,
-    responses: Vec<HttpMockResponse>,
-) {
-    let responses = if responses.is_empty() {
-        vec![MockResponse::from(HttpMockResponse::new(200, ""))]
-    } else {
-        responses.into_iter().map(MockResponse::from).collect()
-    };
-    let method = method.into();
-    let url_pattern = url_pattern.into();
-    HTTP_MOCKS.with(|mocks| {
-        let mut mocks = mocks.borrow_mut();
-        // Re-registering the same (method, url_pattern) replaces the prior
-        // mock so tests can override per-case responses without first calling
-        // http_mock_clear(). Without this, the original mock keeps matching
-        // forever and the new one is dead.
-        mocks.retain(|mock| !(mock.method == method && mock.url_pattern == url_pattern));
-        mocks.push(HttpMock {
-            method,
-            url_pattern,
-            responses,
-            next_response: 0,
-        });
-    });
-}
-
-pub fn http_mock_calls_snapshot() -> Vec<HttpMockCallSnapshot> {
-    HTTP_MOCK_CALLS.with(|calls| {
-        calls
-            .borrow()
-            .iter()
-            .map(|call| HttpMockCallSnapshot {
-                method: call.method.clone(),
-                url: call.url.clone(),
-                headers: call
-                    .headers
-                    .iter()
-                    .map(|(key, value)| (key.clone(), value.display()))
-                    .collect(),
-                body: call.body.clone(),
-            })
-            .collect()
-    })
-}
-
-/// Check if a URL matches a mock pattern (exact or glob with `*`).
-fn url_matches(pattern: &str, url: &str) -> bool {
-    if pattern == "*" {
-        return true;
-    }
-    if !pattern.contains('*') {
-        return pattern == url;
-    }
-    // Multi-glob: split on `*` and match segments in order.
-    let parts: Vec<&str> = pattern.split('*').collect();
-    let mut remaining = url;
-    for (i, part) in parts.iter().enumerate() {
-        if part.is_empty() {
-            continue;
-        }
-        if i == 0 {
-            if !remaining.starts_with(part) {
-                return false;
-            }
-            remaining = &remaining[part.len()..];
-        } else if i == parts.len() - 1 {
-            if !remaining.ends_with(part) {
-                return false;
-            }
-            remaining = "";
-        } else {
-            match remaining.find(part) {
-                Some(pos) => remaining = &remaining[pos + part.len()..],
-                None => return false,
-            }
-        }
-    }
-    true
 }
 
 /// Build a standard HTTP response dict with status, headers, body, and ok fields.
@@ -772,166 +629,6 @@ async fn http_verb_handler(
         options.insert("body".to_string(), VmValue::String(Rc::from(body)));
     }
     vm_execute_http_request(method, &url, &options).await
-}
-
-fn parse_mock_response_dict(response: &BTreeMap<String, VmValue>) -> MockResponse {
-    let status = response
-        .get("status")
-        .and_then(|v| v.as_int())
-        .unwrap_or(200);
-    let body = response
-        .get("body")
-        .map(|v| v.display())
-        .unwrap_or_default();
-    let headers = response
-        .get("headers")
-        .and_then(|v| v.as_dict())
-        .cloned()
-        .unwrap_or_default();
-    MockResponse {
-        status,
-        body,
-        headers,
-    }
-}
-
-fn parse_mock_responses(response: &BTreeMap<String, VmValue>) -> Vec<MockResponse> {
-    let scripted = response
-        .get("responses")
-        .and_then(|value| match value {
-            VmValue::List(items) => Some(
-                items
-                    .iter()
-                    .filter_map(|item| item.as_dict().map(parse_mock_response_dict))
-                    .collect::<Vec<_>>(),
-            ),
-            _ => None,
-        })
-        .unwrap_or_default();
-
-    if scripted.is_empty() {
-        vec![parse_mock_response_dict(response)]
-    } else {
-        scripted
-    }
-}
-
-fn consume_http_mock(
-    method: &str,
-    url: &str,
-    headers: BTreeMap<String, VmValue>,
-    body: Option<String>,
-) -> Option<MockResponse> {
-    let response = HTTP_MOCKS.with(|mocks| {
-        let mut mocks = mocks.borrow_mut();
-        for mock in mocks.iter_mut() {
-            if (mock.method == "*" || mock.method.eq_ignore_ascii_case(method))
-                && url_matches(&mock.url_pattern, url)
-            {
-                let Some(last_index) = mock.responses.len().checked_sub(1) else {
-                    continue;
-                };
-                let index = mock.next_response.min(last_index);
-                let response = mock.responses[index].clone();
-                if mock.next_response < last_index {
-                    mock.next_response += 1;
-                }
-                return Some(response);
-            }
-        }
-        None
-    })?;
-
-    HTTP_MOCK_CALLS.with(|calls| {
-        calls.borrow_mut().push(HttpMockCall {
-            method: method.to_string(),
-            url: url.to_string(),
-            headers,
-            body,
-        });
-    });
-
-    Some(response)
-}
-
-fn is_sensitive_http_header(name: &str) -> bool {
-    matches!(
-        name.to_ascii_lowercase().as_str(),
-        "authorization"
-            | "proxy-authorization"
-            | "cookie"
-            | "set-cookie"
-            | "x-api-key"
-            | "api-key"
-            | "x-auth-token"
-            | "x-csrf-token"
-            | "x-xsrf-token"
-    )
-}
-
-fn is_sensitive_url_param(name: &str) -> bool {
-    let normalized = name.to_ascii_lowercase();
-    normalized == "api_key"
-        || normalized == "apikey"
-        || normalized == "access_token"
-        || normalized == "refresh_token"
-        || normalized == "id_token"
-        || normalized == "client_secret"
-        || normalized == "password"
-        || normalized == "secret"
-        || normalized == "token"
-        || normalized.ends_with("_token")
-        || normalized.ends_with("_secret")
-}
-
-fn redact_mock_call_url(url: &str, redact: bool) -> String {
-    if !redact {
-        return url.to_string();
-    }
-    let Ok(mut parsed) = url::Url::parse(url) else {
-        return url.to_string();
-    };
-    let mut redacted_any = false;
-    let pairs: Vec<(String, String)> = parsed
-        .query_pairs()
-        .map(|(key, value)| {
-            let value = if is_sensitive_url_param(&key) {
-                redacted_any = true;
-                "[redacted]".to_string()
-            } else {
-                value.into_owned()
-            };
-            (key.into_owned(), value)
-        })
-        .collect();
-    if !redacted_any {
-        return url.to_string();
-    }
-    parsed.set_query(None);
-    {
-        let mut query = parsed.query_pairs_mut();
-        for (key, value) in pairs {
-            query.append_pair(&key, &value);
-        }
-    }
-    parsed.to_string()
-}
-
-fn mock_call_headers_value(
-    headers: &BTreeMap<String, VmValue>,
-    redact_headers: bool,
-) -> BTreeMap<String, VmValue> {
-    headers
-        .iter()
-        .map(|(key, value)| {
-            let value = if redact_headers && is_sensitive_http_header(key) {
-                VmValue::String(Rc::from("[redacted]"))
-            } else {
-                value.clone()
-            };
-            (key.clone(), value)
-        })
-        .collect()
 }
 
 fn vm_string(value: impl AsRef<str>) -> VmValue {
@@ -1842,23 +1539,13 @@ pub fn register_http_builtins(vm: &mut Vm) {
             .unwrap_or_default();
         let responses = parse_mock_responses(&response);
 
-        HTTP_MOCKS.with(|mocks| {
-            let mut mocks = mocks.borrow_mut();
-            mocks.retain(|mock| !(mock.method == method && mock.url_pattern == url_pattern));
-            mocks.push(HttpMock {
-                method,
-                url_pattern,
-                responses,
-                next_response: 0,
-            });
-        });
+        register_http_mock(method, url_pattern, responses);
         Ok(VmValue::Nil)
     });
 
     // http_mock_clear() -> nil
     vm.register_builtin("http_mock_clear", |_args, _out| {
-        HTTP_MOCKS.with(|mocks| mocks.borrow_mut().clear());
-        HTTP_MOCK_CALLS.with(|calls| calls.borrow_mut().clear());
+        clear_http_mocks();
         HTTP_STREAMS.with(|streams| streams.borrow_mut().clear());
         Ok(VmValue::Nil)
     });
@@ -1873,37 +1560,9 @@ pub fn register_http_builtins(vm: &mut Vm) {
             "redact_sensitive",
             get_bool_option(&options, "redact_headers", true),
         ) && !include_sensitive;
-        let calls = HTTP_MOCK_CALLS.with(|calls| calls.borrow().clone());
-        let result: Vec<VmValue> = calls
-            .iter()
-            .map(|c| {
-                let mut dict = BTreeMap::new();
-                dict.insert(
-                    "method".to_string(),
-                    VmValue::String(Rc::from(c.method.as_str())),
-                );
-                dict.insert(
-                    "url".to_string(),
-                    VmValue::String(Rc::from(redact_mock_call_url(&c.url, redact_sensitive))),
-                );
-                dict.insert(
-                    "headers".to_string(),
-                    VmValue::Dict(Rc::new(mock_call_headers_value(
-                        &c.headers,
-                        redact_sensitive,
-                    ))),
-                );
-                dict.insert(
-                    "body".to_string(),
-                    match &c.body {
-                        Some(b) => VmValue::String(Rc::from(b.as_str())),
-                        None => VmValue::Nil,
-                    },
-                );
-                VmValue::Dict(Rc::new(dict))
-            })
-            .collect();
-        Ok(VmValue::List(Rc::new(result)))
+        Ok(VmValue::List(Rc::new(http_mock_calls_value(
+            redact_sensitive,
+        ))))
     });
 
     vm.register_async_builtin("http_request", |args| async move {

--- a/crates/harn-vm/src/http/mock.rs
+++ b/crates/harn-vm/src/http/mock.rs
@@ -1,0 +1,370 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use crate::value::VmValue;
+
+#[derive(Clone)]
+pub(super) struct MockResponse {
+    pub(super) status: i64,
+    pub(super) body: String,
+    pub(super) headers: BTreeMap<String, VmValue>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpMockResponse {
+    pub status: i64,
+    pub body: String,
+    pub headers: BTreeMap<String, String>,
+}
+
+impl HttpMockResponse {
+    pub fn new(status: i64, body: impl Into<String>) -> Self {
+        Self {
+            status,
+            body: body.into(),
+            headers: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.insert(name.into(), value.into());
+        self
+    }
+}
+
+impl From<HttpMockResponse> for MockResponse {
+    fn from(value: HttpMockResponse) -> Self {
+        Self {
+            status: value.status,
+            body: value.body,
+            headers: value
+                .headers
+                .into_iter()
+                .map(|(key, value)| (key, VmValue::String(Rc::from(value))))
+                .collect(),
+        }
+    }
+}
+
+struct HttpMock {
+    method: String,
+    url_pattern: String,
+    responses: Vec<MockResponse>,
+    next_response: usize,
+}
+
+#[derive(Clone)]
+struct HttpMockCall {
+    method: String,
+    url: String,
+    headers: BTreeMap<String, VmValue>,
+    body: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HttpMockCallSnapshot {
+    pub method: String,
+    pub url: String,
+    pub headers: BTreeMap<String, String>,
+    pub body: Option<String>,
+}
+
+thread_local! {
+    static HTTP_MOCKS: RefCell<Vec<HttpMock>> = const { RefCell::new(Vec::new()) };
+    static HTTP_MOCK_CALLS: RefCell<Vec<HttpMockCall>> = const { RefCell::new(Vec::new()) };
+}
+
+pub(super) fn reset_http_mocks() {
+    HTTP_MOCKS.with(|mocks| mocks.borrow_mut().clear());
+    HTTP_MOCK_CALLS.with(|calls| calls.borrow_mut().clear());
+}
+
+pub(super) fn clear_http_mocks() {
+    reset_http_mocks();
+}
+
+pub fn push_http_mock(
+    method: impl Into<String>,
+    url_pattern: impl Into<String>,
+    responses: Vec<HttpMockResponse>,
+) {
+    let responses = if responses.is_empty() {
+        vec![MockResponse::from(HttpMockResponse::new(200, ""))]
+    } else {
+        responses.into_iter().map(MockResponse::from).collect()
+    };
+    register_http_mock(method.into(), url_pattern.into(), responses);
+}
+
+pub(super) fn register_http_mock(
+    method: impl Into<String>,
+    url_pattern: impl Into<String>,
+    responses: Vec<MockResponse>,
+) {
+    let method = method.into();
+    let url_pattern = url_pattern.into();
+    HTTP_MOCKS.with(|mocks| {
+        let mut mocks = mocks.borrow_mut();
+        // Re-registering the same (method, url_pattern) replaces the prior
+        // mock so tests can override per-case responses without first calling
+        // http_mock_clear(). Without this, the original mock keeps matching
+        // forever and the new one is dead.
+        mocks.retain(|mock| !(mock.method == method && mock.url_pattern == url_pattern));
+        mocks.push(HttpMock {
+            method,
+            url_pattern,
+            responses,
+            next_response: 0,
+        });
+    });
+}
+
+pub fn http_mock_calls_snapshot() -> Vec<HttpMockCallSnapshot> {
+    HTTP_MOCK_CALLS.with(|calls| {
+        calls
+            .borrow()
+            .iter()
+            .map(|call| HttpMockCallSnapshot {
+                method: call.method.clone(),
+                url: call.url.clone(),
+                headers: call
+                    .headers
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.display()))
+                    .collect(),
+                body: call.body.clone(),
+            })
+            .collect()
+    })
+}
+
+pub(super) fn http_mock_calls_value(redact_sensitive: bool) -> Vec<VmValue> {
+    HTTP_MOCK_CALLS.with(|calls| {
+        calls
+            .borrow()
+            .iter()
+            .map(|call| {
+                let mut dict = BTreeMap::new();
+                dict.insert(
+                    "method".to_string(),
+                    VmValue::String(Rc::from(call.method.as_str())),
+                );
+                dict.insert(
+                    "url".to_string(),
+                    VmValue::String(Rc::from(redact_mock_call_url(&call.url, redact_sensitive))),
+                );
+                dict.insert(
+                    "headers".to_string(),
+                    VmValue::Dict(Rc::new(mock_call_headers_value(
+                        &call.headers,
+                        redact_sensitive,
+                    ))),
+                );
+                dict.insert(
+                    "body".to_string(),
+                    match &call.body {
+                        Some(body) => VmValue::String(Rc::from(body.as_str())),
+                        None => VmValue::Nil,
+                    },
+                );
+                VmValue::Dict(Rc::new(dict))
+            })
+            .collect()
+    })
+}
+
+pub(super) fn parse_mock_responses(response: &BTreeMap<String, VmValue>) -> Vec<MockResponse> {
+    let scripted = response
+        .get("responses")
+        .and_then(|value| match value {
+            VmValue::List(items) => Some(
+                items
+                    .iter()
+                    .filter_map(|item| item.as_dict().map(parse_mock_response_dict))
+                    .collect::<Vec<_>>(),
+            ),
+            _ => None,
+        })
+        .unwrap_or_default();
+
+    if scripted.is_empty() {
+        vec![parse_mock_response_dict(response)]
+    } else {
+        scripted
+    }
+}
+
+fn parse_mock_response_dict(response: &BTreeMap<String, VmValue>) -> MockResponse {
+    let status = response
+        .get("status")
+        .and_then(|v| v.as_int())
+        .unwrap_or(200);
+    let body = response
+        .get("body")
+        .map(|v| v.display())
+        .unwrap_or_default();
+    let headers = response
+        .get("headers")
+        .and_then(|v| v.as_dict())
+        .cloned()
+        .unwrap_or_default();
+    MockResponse {
+        status,
+        body,
+        headers,
+    }
+}
+
+pub(super) fn consume_http_mock(
+    method: &str,
+    url: &str,
+    headers: BTreeMap<String, VmValue>,
+    body: Option<String>,
+) -> Option<MockResponse> {
+    let response = HTTP_MOCKS.with(|mocks| {
+        let mut mocks = mocks.borrow_mut();
+        for mock in mocks.iter_mut() {
+            if (mock.method == "*" || mock.method.eq_ignore_ascii_case(method))
+                && url_matches(&mock.url_pattern, url)
+            {
+                let Some(last_index) = mock.responses.len().checked_sub(1) else {
+                    continue;
+                };
+                let index = mock.next_response.min(last_index);
+                let response = mock.responses[index].clone();
+                if mock.next_response < last_index {
+                    mock.next_response += 1;
+                }
+                return Some(response);
+            }
+        }
+        None
+    })?;
+
+    HTTP_MOCK_CALLS.with(|calls| {
+        calls.borrow_mut().push(HttpMockCall {
+            method: method.to_string(),
+            url: url.to_string(),
+            headers,
+            body,
+        });
+    });
+
+    Some(response)
+}
+
+/// Check if a URL matches a mock pattern (exact or glob with `*`).
+pub(super) fn url_matches(pattern: &str, url: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if !pattern.contains('*') {
+        return pattern == url;
+    }
+    // Multi-glob: split on `*` and match segments in order.
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut remaining = url;
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            if !remaining.starts_with(part) {
+                return false;
+            }
+            remaining = &remaining[part.len()..];
+        } else if i == parts.len() - 1 {
+            if !remaining.ends_with(part) {
+                return false;
+            }
+            remaining = "";
+        } else {
+            match remaining.find(part) {
+                Some(pos) => remaining = &remaining[pos + part.len()..],
+                None => return false,
+            }
+        }
+    }
+    true
+}
+
+fn is_sensitive_http_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "authorization"
+            | "proxy-authorization"
+            | "cookie"
+            | "set-cookie"
+            | "x-api-key"
+            | "api-key"
+            | "x-auth-token"
+            | "x-csrf-token"
+            | "x-xsrf-token"
+    )
+}
+
+fn is_sensitive_url_param(name: &str) -> bool {
+    let normalized = name.to_ascii_lowercase();
+    normalized == "api_key"
+        || normalized == "apikey"
+        || normalized == "access_token"
+        || normalized == "refresh_token"
+        || normalized == "id_token"
+        || normalized == "client_secret"
+        || normalized == "password"
+        || normalized == "secret"
+        || normalized == "token"
+        || normalized.ends_with("_token")
+        || normalized.ends_with("_secret")
+}
+
+pub(super) fn redact_mock_call_url(url: &str, redact: bool) -> String {
+    if !redact {
+        return url.to_string();
+    }
+    let Ok(mut parsed) = url::Url::parse(url) else {
+        return url.to_string();
+    };
+    let mut redacted_any = false;
+    let pairs: Vec<(String, String)> = parsed
+        .query_pairs()
+        .map(|(key, value)| {
+            let value = if is_sensitive_url_param(&key) {
+                redacted_any = true;
+                "[redacted]".to_string()
+            } else {
+                value.into_owned()
+            };
+            (key.into_owned(), value)
+        })
+        .collect();
+    if !redacted_any {
+        return url.to_string();
+    }
+    parsed.set_query(None);
+    {
+        let mut query = parsed.query_pairs_mut();
+        for (key, value) in pairs {
+            query.append_pair(&key, &value);
+        }
+    }
+    parsed.to_string()
+}
+
+pub(super) fn mock_call_headers_value(
+    headers: &BTreeMap<String, VmValue>,
+    redact_headers: bool,
+) -> BTreeMap<String, VmValue> {
+    headers
+        .iter()
+        .map(|(key, value)| {
+            let value = if redact_headers && is_sensitive_http_header(key) {
+                VmValue::String(Rc::from("[redacted]"))
+            } else {
+                value.clone()
+            };
+            (key.clone(), value)
+        })
+        .collect()
+}

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -950,7 +950,8 @@ Options: `timeout_ms` (alias `timeout`, both in ms), `total_timeout_ms`,
 `connect_timeout_ms`, `read_timeout_ms`, `retry: {max, backoff_ms}`,
 legacy aliases `retries` / `backoff`, optional `retry_on` (status list),
 optional `retry_methods` (defaults to `GET`, `HEAD`, `PUT`, `DELETE`,
-`OPTIONS`), `headers` (dict), `auth` (string or `{bearer: "token"}` or
+`OPTIONS`), `headers` (dict), `query` (dict; nil values omitted and other
+values stringified), `auth` (string or `{bearer: "token"}` or
 `{basic: {user, password}}`), `follow_redirects` (bool),
 `max_redirects` (int), `body` (string), `multipart`
 (`list<{name, value|value_base64|path, filename?, content_type?}>`),
@@ -1154,7 +1155,7 @@ For testing pipelines that make HTTP calls without hitting real servers.
 |---|---|---|---|
 | `http_mock(method, url_pattern, response)` | method: string, url_pattern: string, response: dict | nil | Register a mock. Use `*` in url_pattern for glob matching (supports multiple `*` wildcards, e.g., `https://api.example.com/*/items/*`). `response` may be a single `{status, body, headers}` dict or `{responses: [...]}` to script retries. |
 | `http_mock_clear()` | none | nil | Clear all mocks and recorded calls |
-| `http_mock_calls()` | none | list | Return list of `{method, url, headers, body}` for all intercepted calls |
+| `http_mock_calls(options?)` | options: dict | list | Return list of `{method, url, headers, body}` for all intercepted calls. Header names are normalized to lowercase. Sensitive request headers and query parameters are redacted by default; pass `{redact_sensitive: false}` or `{include_sensitive: true}` to inspect raw values in tests. |
 | `sse_mock(url_pattern, events_or_config)` | url_pattern: string, events_or_config: list or dict | nil | Register an in-process SSE stream mock. Events may be strings or `{event, data, id?, retry_ms?}` dicts. |
 | `websocket_mock(url_pattern, messages_or_config)` | url_pattern: string, messages_or_config: list or dict | nil | Register an in-process WebSocket mock. Messages may be strings/bytes or `{type, data}` dicts; `{messages: [...], echo: true}` enables echoing sends. |
 | `transport_mock_calls()` | none | list | Return recorded mocked SSE/WebSocket connect/send/close calls |
@@ -1171,6 +1172,19 @@ let resp = http_get("https://api.example.com/users", {
   retry: {max: 1, backoff_ms: 0}
 })
 assert_eq(resp.status, 200)
+```
+
+Mocks match and record the final request URL after `query` options are appended:
+
+```harn
+http_mock("GET", "https://api.example.com/users?limit=2", {status: 200})
+http_get("https://api.example.com/users", {
+  headers: {Authorization: "Bearer test-token"},
+  query: {limit: 2},
+})
+let call = http_mock_calls({redact_sensitive: false})[0]
+assert_eq(call.url, "https://api.example.com/users?limit=2")
+assert_eq(call.headers.authorization, "Bearer test-token")
 ```
 
 ```harn


### PR DESCRIPTION
Closes #810.

## Summary
- record normalized lowercase request headers in `http_mock_calls()` for request, download, and stream mock paths
- build and record final URLs from `query` options, with sensitive header and query values redacted by default
- add explicit raw-value opt-in options, docs, Rust coverage, and conformance coverage for the new mock-call shape

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-issue-810-target cargo test -p harn-vm http_mock --lib`
- `CARGO_TARGET_DIR=/tmp/harn-issue-810-target cargo test -p harn-vm mock_call --lib`
- `CARGO_TARGET_DIR=/tmp/harn-issue-810-target cargo run --quiet --bin harn -- fmt --check conformance/tests/stdlib/http_mock_calls_headers.harn`
- `CARGO_TARGET_DIR=/tmp/harn-issue-810-target cargo run --quiet --bin harn -- test conformance --filter http_mock_calls_headers`
- `HARN_LLM_CALLS_DISABLED=1 CARGO_TARGET_DIR=/tmp/harn-issue-810-target cargo nextest run --workspace -j 2 --build-jobs 2`