### PR TITLE
[codex] Decouple hostlib docs from Burin migration language

### DIFF
--- a/crates/harn-hostlib/README.md
+++ b/crates/harn-hostlib/README.md
@@ -3,16 +3,12 @@
 Opt-in host builtins for the Harn VM that provide:
 
 1. **Code intelligence** — tree-sitter–backed parsing, deterministic
-   trigram/word indexing, and project-wide repo scanning. Ports the Swift
-   `Sources/ASTEngine/`, `Sources/BurinCodeIndex/`, and
-   `Sources/BurinCore/Scanner/` surface from
-   [`burin-labs/burin-code`](https://github.com/burin-labs/burin-code).
+   trigram/word indexing, project-wide repo scanning, file watching, and
+   live workspace state.
 2. **Deterministic tools** — content search (`grep-searcher` + `ignore`),
    file I/O, directory listing, file outline, git inspection (`gix`), file
    watching (`notify`), and process lifecycle (`run_command`, `run_test`,
-   `run_build_command`, `inspect_test_results`, `manage_packages`). Ports
-   the Swift `CoreToolExecutor` surface so calls no longer have to bounce
-   Harn → Swift → Harn.
+   `run_build_command`, `inspect_test_results`, `manage_packages`).
 
 ## Status
 
@@ -20,8 +16,7 @@ Opt-in host builtins for the Harn VM that provide:
 scaffold (every method routed through `HostlibError::Unimplemented`).
 [#564](https://github.com/burin-labs/harn/issues/564) lights up the
 `ast/` surface — tree-sitter parsing, symbol extraction, and outline
-generation for 22 host languages, mirroring the Swift `ASTEngine`
-coverage verbatim.
+generation for 22 host languages.
 [#567](https://github.com/burin-labs/harn/issues/567) lights up the
 deterministic-tool surface: `search`, `read_file`, `write_file`,
 `delete_file`, `list_directory`, `get_file_outline`, and `git`.
@@ -39,8 +34,9 @@ debounced AgentEvent batches.
 ### `ast/` languages
 
 Tree-sitter grammars are pinned in [`Cargo.toml`](Cargo.toml). Adding or
-dropping a language requires a coordinated change here, in the Swift
-`TreeSitterLanguage` enum, and in burin-code's bridge consumer.
+dropping a language requires a coordinated change to the language table,
+schemas, fixtures, and any host bridge that relies on the canonical
+language names.
 
 | Language       | Grammar crate                 | Extensions      |
 |----------------|-------------------------------|-----------------|
@@ -69,7 +65,7 @@ dropping a language requires a coordinated change here, in the Swift
 
 The `ast::*` builtins emit row/column coordinates as **0-based** values
 (matching tree-sitter native `Point`s). Symbol kinds are normalized to
-the lowercase string set Swift's `ASTEngine` already produced
+the lowercase hostlib wire set
 (`function`, `method`, `class`, `struct`, `enum`, `interface`,
 `protocol`, `type`, `variable`, `module`, `other`).
 
@@ -135,10 +131,9 @@ boundary.
 
 ## Scanner host capability
 
-`scanner/` ports `Sources/BurinCore/Scanner/CoreRepoScanner.swift` and emits
-the `ScanResult` shape that burin-code's intake pipeline consumes today
-(project metadata + file/folder/symbol records + dependency edges +
-sub-project boundaries + token-budgeted text repo map). Two builtins:
+`scanner/` emits the Harn `ScanResult` contract: project metadata,
+file/folder/symbol records, dependency edges, sub-project boundaries, and
+a token-budgeted text repo map. Two builtins:
 
 - `hostlib_scanner_scan_project({ root, include_hidden?, respect_gitignore?,
   max_files?, include_git_history?, repo_map_token_budget? })` — full scan.
@@ -189,8 +184,8 @@ let _registry = harn_hostlib::install_default(&mut vm);
 ```
 
 `install_default` registers every shipped capability and returns a
-`HostlibRegistry` that can be introspected (e.g. for
-`burin-code`'s schema-drift tests) without mutating the VM further.
+`HostlibRegistry` that can be introspected by schema-compatibility tests
+without mutating the VM further.
 
 Pick-and-choose embedders that only want a subset of modules can build a
 custom registry:
@@ -206,24 +201,23 @@ The cargo feature `hostlib` on `harn-cli` is **default-on**. Embedders
 can disable it with `--no-default-features` for a slimmer build that
 omits the tree-sitter/notify/gix dependency tree entirely.
 
-## How `burin-code` consumes it
+## Schema compatibility
 
-`burin-code` pulls hostlib in transitively via the harn release pinned in
-its `.harn-version` manifest. After this scaffold lands, the parent epic
-ships:
-
-1. A harn release bumping the version in this repo (per
-   [`scripts/release_ship.sh`](../../scripts/release_ship.sh)).
-2. A burin-code PR bumping `.harn-version` to that release.
-3. burin-code progressively retires its Swift-side `BurinCore`
-   counterparts as each implementation issue lands here.
+Harn-owned hosts usually consume hostlib through a pinned `harn` release
+or through a direct Cargo dependency on this crate. Host integrations
+should treat the JSON schemas and registered builtin list as the public
+contract, then run their own compatibility tests against those exported
+contracts during upgrades.
 
 The schemas under `schemas/<module>/<method>.{request,response}.json` are
-the **source of truth** for burin-code's schema-drift tests. They ship
-with the published crate (see the `include` field in `Cargo.toml`) and
-are also mirrored at compile time via `include_str!` into
+the **source of truth** for hostlib request/response compatibility. They
+ship with the published crate (see the `include` field in `Cargo.toml`)
+and are also mirrored at compile time via `include_str!` into
 [`schemas.rs`](src/schemas.rs) so embedders can fetch them
 programmatically without locating the on-disk schema directory.
+
+Historical notes about the original bridge migration live in
+[`docs/src/migrations/harn-hostlib-host-contracts.md`](../../docs/src/migrations/harn-hostlib-host-contracts.md).
 
 ## Directory layout
 
@@ -252,7 +246,7 @@ crates/harn-hostlib/
 └── tests/
     ├── registration.rs        # registration + schema parity tests
     ├── code_index.rs          # builtin-level integration tests
-    └── code_index_scenario.rs # scenario test over a Swift-shaped fixture
+    └── code_index_scenario.rs # scenario test over a host-shaped fixture
 ```
 
 ## Adding a new method

--- a/crates/harn-hostlib/data/code_index_import_rules.json
+++ b/crates/harn-hostlib/data/code_index_import_rules.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Ported from burin-code Sources/BurinCodeIndex/Resources/import-rules.json. Strategies and field semantics documented in src/code_index/imports.rs.",
+  "_comment": "Hostlib import-resolution rules. Strategies and field semantics are documented in src/code_index/imports.rs.",
   "languages": {
     "python": {
       "strategy": "dotted",

--- a/crates/harn-hostlib/schemas/ast/extract_imports.response.json
+++ b/crates/harn-hostlib/schemas/ast/extract_imports.response.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/extract_imports.response.json",
   "title": "ast.extract_imports response",
-  "description": "Deduped list of import statement strings. The response shape mirrors burin-code's existing handleASTImports decoder — `supported: false` (with empty `statements`) when language detection fails so callers can fall back without having to interpret an error.",
+  "description": "Deduped list of import statement strings. `supported: false` (with empty `statements`) means language detection failed, so callers can fall back without having to interpret an error.",
   "type": "object",
   "properties": {
     "path": { "type": ["string", "null"] },

--- a/crates/harn-hostlib/schemas/ast/function_bodies.request.json
+++ b/crates/harn-hostlib/schemas/ast/function_bodies.request.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/function_bodies.request.json",
   "title": "ast.function_bodies request",
-  "description": "Bulk variant of ast.function_body — pull multiple function bodies in a single round-trip. Mirrors Swift FunctionBodyExtractor.extractAll(functionNames:from:language:). The response is keyed by name so callers don't have to re-match.",
+  "description": "Bulk variant of ast.function_body — pull multiple function bodies in a single round-trip. The response is keyed by name so callers don't have to re-match.",
   "type": "object",
   "properties": {
     "source": { "type": "string" },

--- a/crates/harn-hostlib/schemas/ast/function_bodies.response.json
+++ b/crates/harn-hostlib/schemas/ast/function_bodies.response.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/function_bodies.response.json",
   "title": "ast.function_bodies response",
-  "description": "Map of function name → extracted body, plus a `missing` list naming requested functions that were not found. All line coordinates inside each body are 1-based, matching Swift.",
+  "description": "Map of function name → extracted body, plus a `missing` list naming requested functions that were not found. All line coordinates inside each body are 1-based.",
   "type": "object",
   "properties": {
     "path": { "type": ["string", "null"] },

--- a/crates/harn-hostlib/schemas/ast/function_body.request.json
+++ b/crates/harn-hostlib/schemas/ast/function_body.request.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/function_body.request.json",
   "title": "ast.function_body request",
-  "description": "Extract the body of a single named function from in-memory source or a file path. Mirrors Swift FunctionBodyExtractor.extract.",
+  "description": "Extract the body of a single named function from in-memory source or a file path.",
   "type": "object",
   "properties": {
     "source": {

--- a/crates/harn-hostlib/schemas/ast/function_body.response.json
+++ b/crates/harn-hostlib/schemas/ast/function_body.response.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/function_body.response.json",
   "title": "ast.function_body response",
-  "description": "One extracted function body. All line coordinates are 1-based, matching Swift's FunctionBodyExtractor.ExtractedBody convention. (Note: the symbols / outline / parse_file responses are 0-based — this is the documented exception.) When the function isn't found, `found` is false and the line/text fields are zero/empty.",
+  "description": "One extracted function body. All line coordinates are 1-based. (Note: the symbols / outline / parse_file responses are 0-based — this is the documented exception.) When the function isn't found, `found` is false and the line/text fields are zero/empty.",
   "type": "object",
   "properties": {
     "path": { "type": ["string", "null"] },
@@ -14,7 +14,7 @@
     "end_line": { "type": "integer", "minimum": 0 },
     "brace_based": {
       "type": "boolean",
-      "description": "True for every language except Python. Mirrors Swift's `language != \"py\"` flag so callers can branch on indentation-based vs. brace-based body shapes."
+      "description": "True for every language except Python so callers can branch on indentation-based vs. brace-based body shapes."
     },
     "return_object_fields": {
       "type": "array",

--- a/crates/harn-hostlib/schemas/ast/outline.request.json
+++ b/crates/harn-hostlib/schemas/ast/outline.request.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/outline.request.json",
   "title": "ast.outline request",
-  "description": "Produce a hierarchical outline (nested symbols) for a source file. Mirrors the Swift ASTEngine `Outline` shape.",
+  "description": "Produce a hierarchical outline (nested symbols) for a source file.",
   "type": "object",
   "properties": {
     "path": { "type": "string" },

--- a/crates/harn-hostlib/schemas/ast/parse_errors.request.json
+++ b/crates/harn-hostlib/schemas/ast/parse_errors.request.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/parse_errors.request.json",
   "title": "ast.parse_errors request",
-  "description": "Surface tree-sitter ERROR and MISSING nodes plus the count of top-level declarations. Mirrors the Swift `TreeSitterParseErrors.analyze(content:extension:)` surface from burin-code's ASTEngine. Pass `content` for an in-memory string or `path` to read from disk; supply `language` (canonical name like \"python\" or a bare extension like \"py\") when the path-based grammar lookup is ambiguous.",
+  "description": "Surface tree-sitter ERROR and MISSING nodes plus the count of top-level declarations. Pass `content` for an in-memory string or `path` to read from disk; supply `language` (canonical name like \"python\" or a bare extension like \"py\") when the path-based grammar lookup is ambiguous.",
   "type": "object",
   "properties": {
     "content": {

--- a/crates/harn-hostlib/schemas/ast/parse_errors.response.json
+++ b/crates/harn-hostlib/schemas/ast/parse_errors.response.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/parse_errors.response.json",
   "title": "ast.parse_errors response",
-  "description": "Tree-sitter ERROR / MISSING node list plus a top-level declaration count. Coordinates are 0-based to match the rest of `ast::*` builtins; consumers that need 1-based line numbers (the Swift fallback shape) add one to `start_row`. `supported` is false only when the grammar refuses to load — a clean parse with zero errors still returns `supported = true`.",
+  "description": "Tree-sitter ERROR / MISSING node list plus a top-level declaration count. Coordinates are 0-based to match the rest of `ast::*` builtins; consumers that need 1-based line numbers add one to `start_row`. `supported` is false only when the grammar refuses to load — a clean parse with zero errors still returns `supported = true`.",
   "type": "object",
   "properties": {
     "path": {
@@ -28,7 +28,7 @@
     "top_level_decl_count": {
       "type": "integer",
       "minimum": 0,
-      "description": "Count of top-level declaration nodes per the language profile (mirrors Swift's `topLevelDeclCount`). Languages without an explicit declaration map return 0."
+      "description": "Count of top-level declaration nodes per the language profile. Languages without an explicit declaration map return 0."
     }
   },
   "required": ["path", "language", "supported", "had_errors", "errors", "top_level_decl_count"],

--- a/crates/harn-hostlib/schemas/ast/symbol_delete.request.json
+++ b/crates/harn-hostlib/schemas/ast/symbol_delete.request.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/symbol_delete.request.json",
   "title": "ast.symbol_delete request",
-  "description": "Locate a named symbol in `source` and return the rewritten text with that symbol removed. Mirrors Swift `SymbolOperations.delete`.",
+  "description": "Locate a named symbol in `source` and return the rewritten text with that symbol removed.",
   "type": "object",
   "properties": {
     "source": {

--- a/crates/harn-hostlib/schemas/ast/symbol_extract.request.json
+++ b/crates/harn-hostlib/schemas/ast/symbol_extract.request.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/symbol_extract.request.json",
   "title": "ast.symbol_extract request",
-  "description": "Locate a named symbol in `source` and return its full text plus 1-based, inclusive line range. Mirrors the Swift `SymbolOperations.extract` surface so burin-code's symbol-scoped read tool can swap in a hostlib call.",
+  "description": "Locate a named symbol in `source` and return its full text plus a 1-based, inclusive line range.",
   "type": "object",
   "properties": {
     "source": {

--- a/crates/harn-hostlib/schemas/ast/symbol_replace.request.json
+++ b/crates/harn-hostlib/schemas/ast/symbol_replace.request.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/symbol_replace.request.json",
   "title": "ast.symbol_replace request",
-  "description": "Locate a named symbol in `source` and return the rewritten text with that symbol's lines replaced by `new_text`. Mirrors Swift `SymbolOperations.replace`.",
+  "description": "Locate a named symbol in `source` and return the rewritten text with that symbol's lines replaced by `new_text`.",
   "type": "object",
   "properties": {
     "source": {

--- a/crates/harn-hostlib/schemas/ast/undefined_names.request.json
+++ b/crates/harn-hostlib/schemas/ast/undefined_names.request.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/undefined_names.request.json",
   "title": "ast.undefined_names request",
-  "description": "Language-aware single-file undefined-identifier detection. Mirrors the Swift `TreeSitterUndefinedNames.diagnose(content:extension:)` surface from burin-code's ASTEngine. Profiles ship for Python, JavaScript (incl. JSX), TypeScript (incl. TSX), Go, and Ruby; other languages return `supported = false` so callers can fall back to an external linter (LSP / ruff / tsc / go vet).",
+  "description": "Language-aware single-file undefined-identifier detection. Profiles ship for Python, JavaScript (incl. JSX), TypeScript (incl. TSX), Go, and Ruby; other languages return `supported = false` so callers can fall back to an external linter (LSP / ruff / tsc / go vet).",
   "type": "object",
   "properties": {
     "content": {

--- a/crates/harn-hostlib/schemas/ast/undefined_names.response.json
+++ b/crates/harn-hostlib/schemas/ast/undefined_names.response.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/ast/undefined_names.response.json",
   "title": "ast.undefined_names response",
-  "description": "Single-file undefined-identifier diagnostics. Coordinates are 0-based to match the rest of `ast::*` builtins. Diagnostics are deduplicated by name (first occurrence wins) so callers see one entry per missing import / typo, not one per usage. The Swift consumer maps `row + 1` / `column + 1` back into `UndefinedNameDiagnostic.line` / `.column`.",
+  "description": "Single-file undefined-identifier diagnostics. Coordinates are 0-based to match the rest of `ast::*` builtins. Diagnostics are deduplicated by name (first occurrence wins) so callers see one entry per missing import / typo, not one per usage.",
   "type": "object",
   "properties": {
     "path": { "type": "string" },

--- a/crates/harn-hostlib/schemas/scanner/scan_project.request.json
+++ b/crates/harn-hostlib/schemas/scanner/scan_project.request.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/scanner/scan_project.request.json",
   "title": "scanner.scan_project request",
-  "description": "Walk a project root deterministically and emit a `ScanResult` matching the burin-code Swift CoreRepoScanner schema: project metadata, file/folder/symbol records, dependency edges, and a token-budgeted repo map. Honors `.gitignore` and language-specific excluded directories.",
+  "description": "Walk a project root deterministically and emit the Harn hostlib `ScanResult` contract: project metadata, file/folder/symbol records, dependency edges, and a token-budgeted repo map. Honors `.gitignore` and language-specific excluded directories.",
   "type": "object",
   "properties": {
     "root": {

--- a/crates/harn-hostlib/schemas/scanner/scan_project.response.json
+++ b/crates/harn-hostlib/schemas/scanner/scan_project.response.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/scanner/scan_project.response.json",
   "title": "scanner.scan_project response",
-  "description": "Mirror of the Swift `ScanResult` shape consumed by burin-code today: project metadata, folder/file/symbol records, dependency edges, and a text repo map. Times are ISO-8601 UTC strings. Paths are repo-relative POSIX paths.",
+  "description": "Harn hostlib `ScanResult`: project metadata, folder/file/symbol records, dependency edges, and a text repo map. Times are ISO-8601 UTC strings. Paths are repo-relative POSIX paths.",
   "type": "object",
   "properties": {
     "snapshot_token": {

--- a/crates/harn-hostlib/schemas/tools/get_file_outline.request.json
+++ b/crates/harn-hostlib/schemas/tools/get_file_outline.request.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/tools/get_file_outline.request.json",
   "title": "tools.get_file_outline request",
-  "description": "Convenience wrapper around `ast.outline` shaped to match the existing burin-code tool surface.",
+  "description": "Convenience wrapper around `ast.outline` for hosts that expose a file-outline tool surface.",
   "type": "object",
   "properties": {
     "path": { "type": "string" },

--- a/crates/harn-hostlib/src/ast/bracket_balance.rs
+++ b/crates/harn-hostlib/src/ast/bracket_balance.rs
@@ -1,11 +1,10 @@
 //! `ast.bracket_balance` — count unbalanced `()`, `[]`, `{}` in source.
 //!
-//! Direct port of `Sources/ASTEngine/BracketBalance.swift`. The lexer
-//! treats `//` and `/* */` as comments by default and switches to `#`
-//! line comments for Python; string literals (single, double, backtick)
-//! suppress bracket counting inside them. The output is signed counts
-//! per bracket family — positive means unclosed openers, negative means
-//! unmatched closers.
+//! The lexer treats `//` and `/* */` as comments by default and switches
+//! to `#` line comments for Python; string literals (single, double,
+//! backtick) suppress bracket counting inside them. The output is signed
+//! counts per bracket family — positive means unclosed openers, negative
+//! means unmatched closers.
 
 use harn_vm::VmValue;
 

--- a/crates/harn-hostlib/src/ast/function_body.rs
+++ b/crates/harn-hostlib/src/ast/function_body.rs
@@ -1,30 +1,24 @@
 //! `ast.function_body` — extract a single function's body by name, plus
 //! `ast.function_bodies` — extract many at once into a map keyed by name.
 //!
-//! Mirrors the Swift `FunctionBodyExtractor` in
-//! `~/projects/burin-code/Sources/ASTEngine/FunctionBodyExtractor.swift`
-//! so burin-code's `APIContractExtractor`, `ASTRPC`, and
-//! `HarnHostServer+ASTPrimitives` can replace their direct ASTEngine
-//! call sites with a single Harn hostlib round-trip.
+//! Provides a single hostlib round-trip for hosts that need function-body
+//! text plus return-object field hints.
 //!
 //! ## Wire format
 //!
 //! Both builtins accept either an in-memory `source` string or a file
 //! `path` (with optional `language` hint). At least one must be present.
-//! All line coordinates in the response are **1-based** to match Swift's
-//! `ExtractedBody.startLine` / `endLine` convention exactly. (Symbols /
-//! outline / parse_file responses are 0-based; this builtin is the one
-//! exception and the field name `start_line` vs. `start_row` flags it.)
+//! All line coordinates in the response are **1-based**. Symbols,
+//! outline, and parse_file responses are 0-based; this builtin is the one
+//! exception and the field name `start_line` vs. `start_row` flags it.
 //!
 //! ## Strategy
 //!
-//! Tree-sitter for all 21 supported languages (the Rust hostlib has full
-//! grammar coverage; the Swift port falls back to brace matching for
-//! some languages because its `TreeSitterLanguage` enum is narrower).
-//! For each function-like node whose name matches we read the `body` /
+//! Tree-sitter for all supported languages. For each function-like node
+//! whose name matches we read the `body` /
 //! `block` / `result` field, slice the source by row range, and return
 //! the joined text plus a regex-derived list of return-object field
-//! names — the latter is the signal `APIContractExtractor` needs.
+//! names for hosts that build API contract summaries.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
@@ -42,15 +36,14 @@ use super::symbols::helpers::{children, node_text};
 const SINGLE_BUILTIN: &str = "hostlib_ast_function_body";
 const BULK_BUILTIN: &str = "hostlib_ast_function_bodies";
 
-/// One extracted function body. Wire form mirrors Swift's
-/// `FunctionBodyExtractor.ExtractedBody`.
+/// One extracted function body.
 #[derive(Debug, Clone)]
 pub(super) struct ExtractedBody {
     pub name: String,
     pub body_text: String,
-    /// 1-based start line, matching Swift.
+    /// 1-based start line.
     pub start_line: u32,
-    /// 1-based end line, matching Swift.
+    /// 1-based end line.
     pub end_line: u32,
     pub return_object_fields: Vec<String>,
 }
@@ -277,9 +270,8 @@ pub(super) fn extract_body(
 }
 
 fn split_lines(source: &str) -> Vec<&str> {
-    // `split('\n')` matches the Swift `components(separatedBy: "\n")` —
-    // an N-line file with a trailing newline produces N+1 elements
-    // (the final empty string), but slicing by row range is safe.
+    // `split('\n')` keeps a trailing newline as a final empty element, but
+    // slicing by row range is safe.
     source.split('\n').collect()
 }
 
@@ -464,9 +456,9 @@ fn body_from_function_node(
     }
 
     if matches!(node.kind(), "call") && matches!(language, Language::Elixir) {
-        // For Elixir, body lives inside the second arg's do-block; just
-        // return the entire call node minus the first line as a stable
-        // approximation (the Swift extractor does similarly).
+        // For Elixir, body lives inside the second arg's do-block; return
+        // the entire call node minus the first line as a stable
+        // approximation.
         return whole_minus_first(node, function_name, lines);
     }
 
@@ -583,10 +575,9 @@ fn container_name_if_any(node: Node<'_>, source: &str, language: Language) -> Op
     }
 }
 
-/// Mirrors `FunctionBodyExtractor.extractReturnFields` from the Swift
-/// port. Walks the body line-by-line, tracking whether we're inside a
-/// `return { ... }` (or arrow-function `=> { ... }`) object literal,
-/// and pulls field names off `name:` / `'name':` / `"name":` lines.
+/// Walks the body line-by-line, tracking whether we're inside a `return {
+/// ... }` (or arrow-function `=> { ... }`) object literal, and pulls field
+/// names off `name:` / `'name':` / `"name":` lines.
 pub(super) fn extract_return_fields(body_text: &str) -> Vec<String> {
     let mut fields: Vec<String> = Vec::new();
     let mut in_return_object = false;
@@ -674,8 +665,7 @@ mod tests {
     fn return_fields_picks_up_object_literal() {
         // Each captured field must be followed by `,` or `:`. A bare
         // shorthand identifier on its own line (no trailing comma)
-        // intentionally doesn't count — the Swift regex behaves the
-        // same way and we want byte-identical output.
+        // intentionally doesn't count.
         let body = "return {\n  a: 1,\n  b: 2,\n  c,\n};";
         let fields = extract_return_fields(body);
         assert_eq!(fields, vec!["a", "b", "c"]);

--- a/crates/harn-hostlib/src/ast/fuzzy.rs
+++ b/crates/harn-hostlib/src/ast/fuzzy.rs
@@ -1,10 +1,8 @@
 //! Fuzzy string matching for "did you mean?" suggestions.
 //!
-//! Direct port of `Sources/ASTEngine/FuzzyMatcher.swift` so the
-//! `not_found` payload returned by symbol-mutation builtins surfaces the
-//! same suggestion list burin-code's Swift fallback produced. Matches
-//! characters in order (not necessarily contiguous): `cmpHndlr` matches
-//! `completionHandler`.
+//! Used by symbol-mutation builtins to populate `not_found` suggestions.
+//! Matches characters in order (not necessarily contiguous): `cmpHndlr`
+//! matches `completionHandler`.
 
 /// Find the best fuzzy matches for `query` in `candidates`. Returns up to
 /// `limit` candidates sorted by descending score.

--- a/crates/harn-hostlib/src/ast/imports.rs
+++ b/crates/harn-hostlib/src/ast/imports.rs
@@ -1,7 +1,5 @@
 //! `ast.extract_imports` — pull import statements out of a source file.
 //!
-//! Mirrors the Swift `TreeSitterImportExtractor` in
-//! `~/projects/burin-code/Sources/ASTEngine/TreeSitterImportExtractor.swift`.
 //! Walks the parse tree, collects nodes whose kind is on the
 //! [`IMPORT_NODE_TYPES`] list, and returns their text in document
 //! order. Falls back to a top-level keyword scan when the grammar's
@@ -11,8 +9,7 @@
 //! ## Wire format
 //!
 //! Accepts either an in-memory `source` (with `language`) or a `path`.
-//! The response shape mirrors burin-code's existing
-//! `handleASTImports` decoder so the bridge swap is a no-op:
+//! Response shape:
 //!
 //! ```json
 //! {
@@ -42,8 +39,7 @@ use super::symbols::helpers::{children, node_text};
 const BUILTIN: &str = "hostlib_ast_extract_imports";
 
 /// Tree-sitter node kinds that wrap an import declaration. The set is
-/// the union of every grammar's import-like node type — Swift uses the
-/// same superset since these are the actual node kinds emitted by the
+/// the union of every grammar's import-like node type emitted by the
 /// shipped grammars.
 const IMPORT_NODE_TYPES: &[&str] = &[
     // TS / JS / Python
@@ -86,8 +82,7 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
     // Soft-fail mode: when language detection fails (unsupported file
     // extension, no language hint), return `{supported: false}` rather
-    // than erroring out. burin-code's import-hint code path expects this
-    // shape so it can fall back to its own scanner.
+    // than erroring out so callers can fall back to another scanner.
     let language_opt = match language_in.as_deref() {
         Some(name) if !name.is_empty() => Language::from_name(name),
         _ => path_in

--- a/crates/harn-hostlib/src/ast/language.rs
+++ b/crates/harn-hostlib/src/ast/language.rs
@@ -1,11 +1,8 @@
 //! Tree-sitter language registry.
 //!
-//! Mirrors the Swift `TreeSitterLanguage` enum in
-//! `~/projects/burin-code/Sources/ASTEngine/TreeSitterIntegration.swift`
-//! verbatim. The set of languages, their canonical names, and their file
-//! extensions all match Swift exactly so the bridged outputs round-trip
-//! across the harn ↔ burin-code boundary without translation. Adding or
-//! dropping a language requires a coordinated change in both repos.
+//! The set of languages, their canonical names, and their file extensions
+//! form the hostlib AST wire contract. Adding or dropping a language
+//! requires coordinated schema, fixture, and host-bridge updates.
 
 use tree_sitter::Language as TsLanguage;
 
@@ -129,8 +126,7 @@ impl Language {
         })
     }
 
-    /// Resolve a language from a file extension. The mapping mirrors the
-    /// Swift `extensionMap` in `TreeSitterIntegration.swift`.
+    /// Resolve a language from a file extension.
     pub fn from_extension(ext: &str) -> Option<Self> {
         let normalized = ext.trim_start_matches('.').to_ascii_lowercase();
         Some(match normalized.as_str() {

--- a/crates/harn-hostlib/src/ast/mod.rs
+++ b/crates/harn-hostlib/src/ast/mod.rs
@@ -1,30 +1,26 @@
 //! AST host capability.
 //!
-//! Wraps tree-sitter parsing, symbol extraction, and outline generation —
-//! the Swift `Sources/ASTEngine/` surface ported into Rust. The implementation
-//! is fully wired so AST builtins share one canonical wire format.
+//! Wraps tree-sitter parsing, symbol extraction, and outline generation.
+//! The implementation is fully wired so AST builtins share one canonical
+//! wire format.
 //!
 //! ## Wire format
 //!
 //! - Row/column coordinates are **0-based** across all three builtins,
-//!   matching tree-sitter's native `Point` representation. Swift's
-//!   `ASTEngine` historically returned 1-based coordinates for symbols;
-//!   we normalize on 0-based here so `parse_file`, `symbols`, and
-//!   `outline` share one convention.
+//!   matching tree-sitter's native `Point` representation. `parse_file`,
+//!   `symbols`, and `outline` share one convention.
 //! - `parse_file` emits a flat node list with `parent_id` rather than
 //!   nested children — keeps the wire JSON-serializable without inflating
 //!   it with object copies.
 //! - `symbols` and `outline` carry a `signature` string (e.g.
-//!   `"fn foo(bar: i32)"`) on every entry to match Swift's
-//!   `TreeSitterSymbol.signature`.
+//!   `"fn foo(bar: i32)"`) on every entry.
 //!
 //! ## Languages
 //!
-//! [`language::Language`] mirrors Swift's `TreeSitterLanguage` enum
-//! verbatim: TypeScript/TSX, JavaScript/JSX, Python, Go, Rust, Java,
-//! C, C++, C#, Ruby, Kotlin, PHP, Scala, Bash, Swift, Zig, Elixir, Lua,
-//! Haskell, R. Adding/dropping languages requires a coordinated change
-//! in both repos.
+//! [`language::Language`] covers TypeScript/TSX, JavaScript/JSX, Python,
+//! Go, Rust, Java, C, C++, C#, Ruby, Kotlin, PHP, Scala, Bash, Swift, Zig,
+//! Elixir, Lua, Haskell, and R. Adding/dropping languages requires
+//! coordinated schema, fixture, and host-bridge updates.
 //!
 
 use std::sync::Arc;

--- a/crates/harn-hostlib/src/ast/mutation.rs
+++ b/crates/harn-hostlib/src/ast/mutation.rs
@@ -1,8 +1,7 @@
 //! Symbol-targeted source mutation: `extract`, `delete`, `replace`.
 //!
-//! These builtins mirror the surface of Swift `SymbolOperations`
-//! (`Sources/ASTEngine/SymbolOperations.swift`) so burin-code can drop
-//! the Swift fallback once it points its `HarnASTHostlibClient` at hostlib.
+//! These builtins provide symbol-scoped read and edit helpers for hosts
+//! that operate on line ranges.
 //!
 //! ## Wire shape
 //!
@@ -17,13 +16,11 @@
 //! - `syntax_error_after_edit` (delete/replace only) → `{ details }`
 //! - `parse_failure` (delete/replace only) → `{ details }`
 //!
-//! Coordinates are 1-based to match `SymbolOperations.ExtractedSymbol`,
-//! while the existing `ast.symbols` / `ast.outline` builtins stay 0-based
-//! per their tree-sitter native shape. The two conventions live side by
-//! side because they target different consumers — the existing ones feed
-//! editors that already think in tree-sitter coordinates; the new ones
-//! feed line-based file editing helpers that always thought in 1-based
-//! lines.
+//! Coordinates are 1-based, while the existing `ast.symbols` /
+//! `ast.outline` builtins stay 0-based per their tree-sitter native shape.
+//! The two conventions live side by side because they target different
+//! consumers: tree-sitter-oriented editor features and line-based file
+//! editing helpers.
 
 use std::collections::BTreeMap;
 use std::rc::Rc;
@@ -44,8 +41,7 @@ const DELETE_BUILTIN: &str = "hostlib_ast_symbol_delete";
 const REPLACE_BUILTIN: &str = "hostlib_ast_symbol_replace";
 
 /// 1-based, inclusive line range for a located symbol (after preamble
-/// expansion). Mirrors the implicit `(startLine, endLine)` tuple in
-/// `SymbolOperations.findSymbolRange`.
+/// expansion).
 #[derive(Debug, Clone, Copy)]
 struct SymbolRange {
     start_line: usize,
@@ -235,7 +231,7 @@ fn locate_symbol(
 
 /// Walk upward from a declaration line and return the 0-based line index
 /// where the symbol's preamble starts (decorators, doc comments,
-/// attributes). Mirrors `SymbolOperations.findPreambleStart`.
+/// attributes).
 fn find_preamble_start(lines: &[&str], decl_line_zero: usize, language: Language) -> usize {
     if decl_line_zero == 0 {
         return 0;
@@ -289,8 +285,7 @@ fn is_preamble_line(trimmed: &str, language: Language) -> bool {
 }
 
 /// Re-parse `source` and surface the first tree-sitter `ERROR` /
-/// `MISSING` node as a single-line diagnostic. Mirrors the post-edit
-/// guard in Swift `SymbolOperations.validateSyntax`.
+/// `MISSING` node as a single-line diagnostic.
 fn validate_syntax(source: &str, language: Language) -> Result<(), String> {
     let tree = match parse_source(source, language) {
         Ok(tree) => tree,
@@ -341,8 +336,7 @@ fn node_text(node: tree_sitter::Node<'_>, source: &str) -> String {
 // ---------------------------------------------------------------------------
 
 /// Slice `lines[start_line - 1 ..= end_line - 1]` (1-based inclusive)
-/// and re-join with newlines. Tolerates `end_line` past `lines.len()`,
-/// matching Swift's `min(endLine, lines.count)`.
+/// and re-join with newlines. Tolerates `end_line` past `lines.len()`.
 fn slice_lines(lines: &[&str], start_line: usize, end_line: usize) -> String {
     if start_line == 0 || start_line > lines.len() {
         return String::new();
@@ -387,7 +381,7 @@ fn replace_range(
     out
 }
 
-/// Collapse runs of 3+ blank lines to 2, matching Swift's `collapseBlankLines`.
+/// Collapse runs of 3+ blank lines to 2.
 fn collapse_blank_lines(lines: Vec<String>) -> Vec<String> {
     let mut out: Vec<String> = Vec::with_capacity(lines.len());
     let mut blank_count: usize = 0;

--- a/crates/harn-hostlib/src/ast/parse_errors.rs
+++ b/crates/harn-hostlib/src/ast/parse_errors.rs
@@ -1,17 +1,9 @@
 //! `ast.parse_errors` — surface tree-sitter `ERROR` and `MISSING` nodes
 //! plus the count of top-level declarations.
 //!
-//! Mirrors `TreeSitterParseErrors.analyze` in burin-code's Swift
-//! `ASTEngine` (`Sources/ASTEngine/TreeSitterParseErrors.swift`). The
-//! Swift surface returns a `(supported, errors, top_level_decl_count)`
-//! triple keyed off a file extension; this builtin accepts either an
-//! in-memory `content` string or a `path` plus an optional `language`
-//! hint. Coordinates here are 0-based to match the rest of the
-//! `ast::*` builtins.
-//!
-//! The counterpart Swift consumer maps `errors[].start_row + 1` and the
-//! `snippet` field back into `TreeSitterParseError.line` / `.snippet`,
-//! and `errors[].missing` flips through unchanged.
+//! This builtin accepts either an in-memory `content` string or a `path`
+//! plus an optional `language` hint. Coordinates here are 0-based to match
+//! the rest of the `ast::*` builtins.
 
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -95,8 +87,8 @@ fn resolve_language(
 ) -> Result<Language, HostlibError> {
     if let Some(name) = language_hint.filter(|s| !s.is_empty()) {
         // Accept either a canonical wire name or a bare extension here so
-        // callers that only know the file extension (e.g. burin-code's
-        // `extension` field) don't need a separate translation step.
+        // callers that only know the file extension don't need a separate
+        // translation step.
         if let Some(lang) = Language::from_name(name) {
             return Ok(lang);
         }
@@ -185,11 +177,9 @@ fn collect_errors(root: Node<'_>, source: &[u8], out: &mut Vec<ParseError>) {
     out.sort_by_key(|e| e.start_byte);
 }
 
-/// Count top-level declarations in `root` for `language`. Mirrors
-/// `TreeSitterParseErrors.declarationTypesMap` in
-/// `Sources/ASTEngine/TreeSitterParseErrors.swift` verbatim — the
-/// (decls, wrappers) pair determines what counts as a declaration and
-/// which container kinds get expanded one level (e.g. TypeScript's
+/// Count top-level declarations in `root` for `language`. The (decls,
+/// wrappers) pair determines what counts as a declaration and which
+/// container kinds get expanded one level (e.g. TypeScript's
 /// `export_statement` wrapping a `function_declaration`).
 fn count_top_level_declarations(root: Node<'_>, language: Language) -> u32 {
     let (decls, wrappers) = declaration_kinds(language);
@@ -432,8 +422,8 @@ mod tests {
 
     #[test]
     fn extension_is_accepted_as_language_alias() {
-        // burin-code passes the file extension (e.g. "py") rather than
-        // the canonical wire name; we accept both.
+        // Accept both a file extension (e.g. "py") and the canonical wire
+        // name.
         let result = run_with("x = 1\n", "py");
         let language = match &result {
             VmValue::Dict(d) => match d.get("language") {

--- a/crates/harn-hostlib/src/ast/symbols.rs
+++ b/crates/harn-hostlib/src/ast/symbols.rs
@@ -1,10 +1,9 @@
 //! Per-language tree-sitter symbol extractors.
 //!
 //! Each extractor walks a tree-sitter parse tree depth-first, emitting
-//! [`Symbol`] entries that mirror the Swift `TreeSitterSymbolExtractor`
-//! in `~/projects/burin-code/Sources/ASTEngine/`. Container kinds (class,
-//! struct, enum, ...) are stamped onto the `container` field of nested
-//! symbols so the outline fold in [`super::outline`] can rebuild a tree.
+//! [`Symbol`] entries. Container kinds (class, struct, enum, ...) are
+//! stamped onto the `container` field of nested symbols so the outline
+//! fold in [`super::outline`] can rebuild a tree.
 //!
 //! The shape of every extractor is identical:
 //!

--- a/crates/harn-hostlib/src/ast/symbols/helpers.rs
+++ b/crates/harn-hostlib/src/ast/symbols/helpers.rs
@@ -3,8 +3,7 @@
 //! Every per-language extractor in [`super`] reuses the same primitives
 //! (named-tree walk, container tracking, named-declaration shaping,
 //! function-signature shaping). Centralizing them here keeps the
-//! per-language match arms small and prevents the inevitable copy-paste
-//! drift that bit the Swift port.
+//! per-language match arms small and prevents copy-paste drift.
 
 use tree_sitter::Node;
 
@@ -58,8 +57,8 @@ pub(super) fn field_text(node: Node<'_>, field: &str, source: &str) -> Option<St
         .map(|n| node_text(n, source))
 }
 
-/// Truncate to `max` chars with an ellipsis suffix, matching the Swift
-/// `truncate(_, max:)` helper. Operates on Unicode scalars, not bytes.
+/// Truncate to `max` chars with an ellipsis suffix. Operates on Unicode
+/// scalars, not bytes.
 pub(super) fn truncate(s: &str, max: usize) -> String {
     if s.chars().count() > max {
         let mut out: String = s.chars().take(max).collect();
@@ -74,8 +73,7 @@ pub(super) fn truncate(s: &str, max: usize) -> String {
 /// the current container name; it may return a new container string to
 /// stamp on this node's descendants.
 ///
-/// This is the Rust equivalent of Swift's `walkTree(node:source:container:visitor:)`
-/// in `TreeSitterIntegration.swift`.
+/// Walk named descendants while threading the active container symbol.
 pub(super) fn walk_named<'tree, F>(node: Node<'tree>, container: Option<&str>, visitor: &mut F)
 where
     F: FnMut(Node<'tree>, Option<&str>) -> Option<String>,
@@ -151,8 +149,7 @@ pub(super) struct NamedDeclArgs<'src, 'tree, 'out> {
 }
 
 /// Push a "named declaration" symbol. Returns the symbol's name so the
-/// caller can stamp it as a container on descendants. Mirrors
-/// `extractNamedDecl(node:ctx:kind:keyword:)` in `TreeSitterIntegration.swift`.
+/// caller can stamp it as a container on descendants.
 pub(super) fn named_decl_with_keyword(args: NamedDeclArgs<'_, '_, '_>) -> Option<String> {
     let name_node = args.node.child_by_field_name("name")?;
     let name = node_text(name_node, args.source);
@@ -169,7 +166,7 @@ pub(super) fn named_decl_with_keyword(args: NamedDeclArgs<'_, '_, '_>) -> Option
     Some(name)
 }
 
-/// Args for the `extractFuncDecl`-equivalent helper.
+/// Args for function-style symbol extraction.
 pub(super) struct PushFuncArgs<'src, 'tree, 'out> {
     pub node: Node<'tree>,
     pub source: &'src str,
@@ -180,8 +177,7 @@ pub(super) struct PushFuncArgs<'src, 'tree, 'out> {
     pub out: &'out mut Vec<Symbol>,
 }
 
-/// Push a function-style symbol. Mirrors `extractFuncDecl` in
-/// `TreeSitterIntegration.swift`.
+/// Push a function-style symbol.
 pub(super) fn push_func(args: PushFuncArgs<'_, '_, '_>) {
     let Some(name_node) = args.node.child_by_field_name("name") else {
         return;

--- a/crates/harn-hostlib/src/ast/types.rs
+++ b/crates/harn-hostlib/src/ast/types.rs
@@ -14,10 +14,7 @@ use std::rc::Rc;
 use harn_vm::VmValue;
 
 /// Symbol kind. The wire form is the lowercase string returned by
-/// [`SymbolKind::as_str`]. Mirrors `symbolKindString` in
-/// `~/projects/burin-code/Sources/ASTEngine/SymbolOperations.swift` so
-/// burin-code receives the same labels regardless of which side of the
-/// bridge produced the symbol.
+/// [`SymbolKind::as_str`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SymbolKind {
     Function,

--- a/crates/harn-hostlib/src/ast/undefined_names.rs
+++ b/crates/harn-hostlib/src/ast/undefined_names.rs
@@ -1,8 +1,6 @@
 //! `ast.undefined_names` — language-aware undefined-identifier detection.
 //!
-//! Mirrors `TreeSitterUndefinedNames.diagnose` in burin-code's Swift
-//! `ASTEngine` (`Sources/ASTEngine/TreeSitterUndefinedNames.swift`). The
-//! contract:
+//! Contract:
 //!
 //! - Walk the tree-sitter parse, collect every identifier reference and
 //!   every name *defined* in this file (imports, parameters, locals,
@@ -12,14 +10,13 @@
 //! - Deduplicate by name on first occurrence so callers see one
 //!   diagnostic per missing import / typo, not one per usage.
 //!
-//! Profiles ship for Python, JavaScript, TypeScript, Go, and Ruby —
-//! exactly the language set the Swift fallback supports today. Other
+//! Profiles ship for Python, JavaScript, TypeScript, Go, and Ruby. Other
 //! languages return `supported = false` so callers can fall back to an
 //! external linter.
 //!
 //! Single-file scope is a deliberate restriction: cross-file resolution,
 //! re-exports, dynamic attribute access, and `exec`/`eval`-style name
-//! discovery are out of scope, matching the Swift surface.
+//! discovery are out of scope.
 
 use std::collections::HashSet;
 use std::path::PathBuf;

--- a/crates/harn-hostlib/src/code_index/agents.rs
+++ b/crates/harn-hostlib/src/code_index/agents.rs
@@ -1,6 +1,5 @@
 //! Per-workspace agent registry plus advisory per-file locks.
 //!
-//! Mirrors the Swift `AgentRegistry` actor in `Sources/BurinCodeIndex/`.
 //! Tracks live agents (IDE, background eval, agentic loops, etc.) and the
 //! TTL-based advisory locks they hold over files. Agents call `heartbeat`
 //! on their own cadence; the registry reaps anyone who has gone silent
@@ -62,12 +61,10 @@ pub struct AgentInfo {
     pub locked_paths: HashMap<String, i64>,
 }
 
-/// Registry config — defaults match the Swift actor on the burin-code
-/// side so the cross-repo schema-drift tests stay aligned.
+/// Registry config for agent liveness and lock expiry.
 #[derive(Debug, Clone, Copy)]
 pub struct RegistryConfig {
-    /// Default lock TTL when callers don't supply one. 30 seconds in the
-    /// Swift port.
+    /// Default lock TTL when callers don't supply one.
     pub default_lock_ttl_ms: i64,
     /// How long a registered agent can stay silent before the next reap
     /// downgrades it to `Crashed` and releases its locks. 45 seconds.
@@ -148,8 +145,7 @@ impl AgentRegistry {
     }
 
     /// Refresh an agent's `last_seen_ms`. If the agent isn't registered we
-    /// transparently register it with a placeholder name (`agent-<id>`),
-    /// matching the Swift actor's "self-heal" behaviour.
+    /// transparently register it with a placeholder name (`agent-<id>`).
     pub fn heartbeat(&mut self, id: AgentId, now_ms: i64) {
         match self.agents.get_mut(&id) {
             Some(info) => {
@@ -292,8 +288,8 @@ impl AgentRegistry {
 }
 
 /// On-disk layout for an agent record. Public so the snapshot module can
-/// embed it. Field shapes intentionally mirror the Swift `AgentInfo` so
-/// existing snapshots remain readable across the bridge.
+/// embed it. Field shapes are kept stable so existing snapshots remain
+/// readable across hostlib versions.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SerializedAgent {
     /// Stable identifier.

--- a/crates/harn-hostlib/src/code_index/file_table.rs
+++ b/crates/harn-hostlib/src/code_index/file_table.rs
@@ -53,9 +53,8 @@ pub struct IndexedFile {
     pub imports: Vec<String>,
 }
 
-/// Stable 64-bit FNV-1a hash. Used for content-change detection; matches
-/// the Swift `ContentHasher` byte-for-byte so shared snapshots stay
-/// interchangeable.
+/// Stable 64-bit FNV-1a hash used for content-change detection and
+/// snapshot compatibility.
 pub fn fnv1a64(bytes: &[u8]) -> u64 {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325;
     for byte in bytes {
@@ -71,7 +70,6 @@ mod tests {
 
     #[test]
     fn fnv_matches_swift_reference() {
-        // The Swift `ContentHasher.hash("hello world")` reference value.
         // FNV-1a 64-bit is deterministic; this guards against accidental
         // changes (e.g. switching to a different seed/prime) that would
         // silently break shared snapshot interop.

--- a/crates/harn-hostlib/src/code_index/graph.rs
+++ b/crates/harn-hostlib/src/code_index/graph.rs
@@ -2,9 +2,9 @@
 //!
 //! Edges are "file A imports file B", built from the import strings the
 //! `imports` module surfaces. Forward answers "what does A depend on?";
-//! reverse answers "who depends on A?". Mirrors the Swift `DepGraph`,
-//! including the `unresolved_imports` side-table for raw strings the
-//! resolver could not map back to a known file.
+//! reverse answers "who depends on A?". The `unresolved_imports`
+//! side-table stores raw strings the resolver could not map back to a
+//! known file.
 
 use std::collections::{HashMap, HashSet};
 

--- a/crates/harn-hostlib/src/code_index/imports.rs
+++ b/crates/harn-hostlib/src/code_index/imports.rs
@@ -3,10 +3,9 @@
 //! Two phases:
 //!
 //! 1. **Extraction** — scan source line-by-line for tokens that look like
-//!    import statements. Mirrors the *fallback* path of the Swift
-//!    `TreeSitterImportExtractor`: prefix-match common keywords per
-//!    language, capture the trimmed line. A tree-sitter-backed extractor can
-//!    replace this without changing the `code_index` public surface.
+//!    import statements: prefix-match common keywords per language and
+//!    capture the trimmed line. A tree-sitter-backed extractor can replace
+//!    this without changing the `code_index` public surface.
 //!
 //! 2. **Resolution** — for each extracted string, apply a per-language
 //!    rule to produce a workspace-relative path, then look that path up
@@ -453,7 +452,7 @@ mod tests {
     fn resolve_python_dotted() {
         let map = ids();
         // Python rule resolves the *package* (`foo.bar` -> `foo/bar.py`),
-        // not the imported symbol — matches Swift `ImportResolver` behaviour.
+        // not the imported symbol.
         let r = resolve(
             &["from foo.bar import baz".to_string()],
             "src/main.py",

--- a/crates/harn-hostlib/src/code_index/mod.rs
+++ b/crates/harn-hostlib/src/code_index/mod.rs
@@ -1,11 +1,10 @@
 //! Code index host capability.
 //!
-//! Ports the deterministic trigram/word index plus the live workspace
-//! state (agent registry, advisory locks, append-only version log, file
-//! id assignment, cached reads) that previously lived in
-//! `Sources/BurinCodeIndex/` on the Swift side. The capability owns one
-//! [`SharedIndex`] cell per instance; cloning the capability shares
-//! state with every Harn VM that has been wired against it.
+//! Deterministic trigram/word index plus live workspace state (agent
+//! registry, advisory locks, append-only version log, file id assignment,
+//! cached reads). The capability owns one [`SharedIndex`] cell per
+//! instance; cloning the capability shares state with every Harn VM that
+//! has been wired against it.
 //!
 //! Surface — every builtin is locked by `schemas/code_index/<method>.json`:
 //!
@@ -32,11 +31,10 @@
 //!
 //! ## Concurrency model
 //!
-//! All ops serialise through a single `Arc<Mutex<Option<IndexState>>>`.
-//! That matches the Swift actor: the IDE editor, eval, and live agent all
-//! see one consistent view. The capability is `Send + Sync` so embedders
-//! can share it across threads, but the mutex still serialises actual
-//! work.
+//! All ops serialise through a single `Arc<Mutex<Option<IndexState>>>` so
+//! the IDE editor, eval, and live agent all see one consistent view. The
+//! capability is `Send + Sync` so embedders can share it across threads,
+//! but the mutex still serialises actual work.
 
 mod agents;
 mod builtins;
@@ -112,8 +110,8 @@ impl CodeIndexCapability {
         std::mem::replace(&mut *guard, id)
     }
 
-    /// Restore from a previously saved snapshot at
-    /// `<root>/.burin/index/snapshot.json`. After restoring, runs
+    /// Restore from a previously saved snapshot at the path returned by
+    /// [`CodeIndexSnapshot::path_for`]. After restoring, runs
     /// [`IndexState::reap_after_recovery`] so stale agent records and
     /// locks are dropped before the daemon serves traffic.
     ///
@@ -134,8 +132,8 @@ impl CodeIndexCapability {
         }
     }
 
-    /// Persist the current in-memory state to
-    /// `<root>/.burin/index/snapshot.json`. Returns `Ok(false)` when the
+    /// Persist the current in-memory state to the path returned by
+    /// [`CodeIndexSnapshot::path_for`]. Returns `Ok(false)` when the
     /// capability is empty (nothing to save).
     pub fn persist_to_disk(&self) -> std::io::Result<bool> {
         let snap = {

--- a/crates/harn-hostlib/src/code_index/snapshot.rs
+++ b/crates/harn-hostlib/src/code_index/snapshot.rs
@@ -1,10 +1,9 @@
 //! Persistent on-disk snapshot of the workspace index.
 //!
-//! Mirrors the Swift `CodeIndexSnapshot` struct. v1 uses a single JSON
-//! file at `.burin/index/snapshot.json`. The shape is intentionally
-//! tolerant of missing sections so we can extend it in place without a
-//! version bump (e.g. add a new sub-index without invalidating earlier
-//! snapshots).
+//! v1 uses a single JSON file at `.burin/index/snapshot.json` for
+//! on-disk compatibility. The shape is intentionally tolerant of missing
+//! sections so we can extend it in place without a version bump (e.g. add
+//! a new sub-index without invalidating earlier snapshots).
 //!
 //! The snapshot is the recovery primitive. On daemon startup, the
 //! embedder restores from the snapshot if one exists, then calls

--- a/crates/harn-hostlib/src/code_index/state.rs
+++ b/crates/harn-hostlib/src/code_index/state.rs
@@ -8,7 +8,7 @@
 //!
 //! Single-file mutations (`reindex_file`, `remove_file`) flow through
 //! the same paths so the sub-indexes stay consistent across the
-//! incremental host ops the burin-code daemon drives.
+//! incremental host ops drive.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/crates/harn-hostlib/src/code_index/trigram.rs
+++ b/crates/harn-hostlib/src/code_index/trigram.rs
@@ -3,9 +3,9 @@
 //! Substring-accelerated full-text index: every 3-byte sliding window in a
 //! file becomes a posting in `index[trigram] -> Set<FileId>`. A query is
 //! decomposed into its trigrams; the candidate set is the intersection of
-//! those posting lists. Matches the Swift `TrigramIndex` byte-for-byte:
-//! ASCII case-fold on each byte (`A-Z` -> `a-z`), non-ASCII passes through,
-//! 3-byte sliding window packed `(a << 16) | (b << 8) | c` into a `u32`.
+//! those posting lists. The wire-stable algorithm ASCII case-folds each
+//! byte (`A-Z` -> `a-z`), leaves non-ASCII bytes unchanged, and packs each
+//! 3-byte sliding window as `(a << 16) | (b << 8) | c` into a `u32`.
 
 use std::collections::{HashMap, HashSet};
 
@@ -133,8 +133,7 @@ impl TrigramIndex {
 
 /// Extract every distinct trigram from `text`. Bytes are lowercased on the
 /// ASCII range; non-ASCII bytes pass through unchanged. Sliding 3-byte
-/// window over the UTF-8 bytes — matches Swift's
-/// `TrigramIndex.extractTrigrams` byte-for-byte.
+/// window over the UTF-8 bytes.
 pub fn extract_trigrams(text: &str) -> HashSet<Trigram> {
     let bytes = text.as_bytes();
     if bytes.len() < 3 {
@@ -151,9 +150,8 @@ pub fn extract_trigrams(text: &str) -> HashSet<Trigram> {
     out
 }
 
-/// Decompose a query into its constituent trigrams (deduped). Mirrors the
-/// Swift `TrigramIndex.queryTrigrams` shape so callers that pre-compute on
-/// the script side stay in lock-step with the host.
+/// Decompose a query into its constituent trigrams (deduped) so callers
+/// that pre-compute on the script side stay in lock-step with the host.
 pub fn query_trigrams(query: &str) -> Vec<Trigram> {
     extract_trigrams(query).into_iter().collect()
 }

--- a/crates/harn-hostlib/src/code_index/versions.rs
+++ b/crates/harn-hostlib/src/code_index/versions.rs
@@ -1,8 +1,7 @@
 //! Append-only version log of file mutations.
 //!
-//! Mirrors the Swift `VersionLog` struct in `Sources/BurinCodeIndex/`.
-//! Every successful write through the host's `version_record` op lands
-//! here with a monotonic sequence number. Agents call `changes_since(seq)`
+//! Every successful write through the host's `version_record` op lands here
+//! with a monotonic sequence number. Agents call `changes_since(seq)`
 //! to catch up between turns without re-reading every file, and the seq
 //! numbers let higher-level tooling spot "agent fighting itself" loops
 //! before they cause damage.
@@ -15,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Maximum number of entries kept per path. Older entries roll off the
-/// front in FIFO order — matches the Swift constant.
+/// front in FIFO order.
 pub const HISTORY_LIMIT: usize = 200;
 
 /// Edit-classification for one record. The string forms ride out to Harn
@@ -40,8 +39,7 @@ pub enum EditOp {
 }
 
 impl EditOp {
-    /// String form used by the Harn host bridge. Mirrors the Swift
-    /// `EditOp.rawValue` so cross-repo callers stay aligned.
+    /// String form used by the Harn host bridge.
     pub fn as_str(self) -> &'static str {
         match self {
             EditOp::Snapshot => "snapshot",

--- a/crates/harn-hostlib/src/code_index/walker.rs
+++ b/crates/harn-hostlib/src/code_index/walker.rs
@@ -1,7 +1,6 @@
 //! Filtered directory walker + sensitive-file filter.
 //!
-//! Ports the Swift `FilteredWalker` and `SensitiveFilter` together: a
-//! depth-first walk that prunes noisy directories before descending and
+//! Depth-first walk that prunes noisy directories before descending and
 //! refuses to ingest credential-shaped files. Kept self-contained so the
 //! `tools/search` crate can use `ignore` for honoring `.gitignore` while
 //! the indexer stays deterministic across systems regardless of the user's
@@ -57,7 +56,7 @@ const SKIP_DIRS: &[&str] = &[
     // Test coverage
     "coverage",
     ".nyc_output",
-    // Burin-owned
+    // Legacy host cache
     ".burin",
     // Claude Code
     ".claude",
@@ -97,9 +96,9 @@ pub(crate) fn is_indexable_file(path: &Path) -> bool {
     EXTENSIONLESS_ALLOWED.contains(&base.as_str())
 }
 
-/// Best-effort language tag for the supplied extension. Mirrors the Swift
-/// `languageByExtension` map; unknown extensions return the extension
-/// itself so downstream tools can route language-specific behaviour.
+/// Best-effort language tag for the supplied extension. Unknown extensions
+/// return the extension itself so downstream tools can route
+/// language-specific behaviour.
 pub(crate) fn language_for_extension(ext: &str) -> &str {
     match ext {
         "py" | "pyi" => "python",
@@ -133,7 +132,7 @@ pub(crate) fn is_sensitive_path(path: &Path) -> bool {
 }
 
 /// Returns `true` if the path looks like a credentials/secrets file that
-/// must never enter the index. Mirrors the Swift `SensitiveFilter`.
+/// must never enter the index.
 pub(crate) fn is_sensitive(path: &Path) -> bool {
     let lower = path.to_string_lossy().to_ascii_lowercase();
     let base = Path::new(&lower)
@@ -280,7 +279,7 @@ fn should_skip_basename(name: &str, skip_dirs: &HashSet<&str>) -> bool {
         }
         // Dot-prefixed dirs that aren't in `skip_dirs` (e.g. `.cargo`,
         // `.config`) are still walked — only dot-prefixed *files* are
-        // dropped, matching the Swift behaviour. We can't check
+        // dropped. We can't check
         // file-vs-dir here without another stat, so approximate by
         // returning false; the caller's metadata probe will let the dir
         // through and skip the dotfile via `is_indexable_file` (no

--- a/crates/harn-hostlib/src/code_index/words.rs
+++ b/crates/harn-hostlib/src/code_index/words.rs
@@ -3,8 +3,8 @@
 //! Inverted index `identifier -> Vec<(file_id, line)>`. Complements the
 //! trigram index: trigrams answer "which files contain this substring?",
 //! the word index answers "which lines mention this exact identifier?".
-//! Mirrors the Swift `WordIndex`: tokens are runs of `[A-Za-z_][A-Za-z0-9_]*`
-//! (single-character tokens are skipped), one entry per occurrence.
+//! Tokens are runs of `[A-Za-z_][A-Za-z0-9_]*` (single-character tokens
+//! are skipped), one entry per occurrence.
 
 use std::collections::{HashMap, HashSet};
 

--- a/crates/harn-hostlib/src/lib.rs
+++ b/crates/harn-hostlib/src/lib.rs
@@ -2,8 +2,7 @@
 //! repo scanning, deterministic indexing) and tool execution (search, file
 //! I/O, git, process lifecycle, file watcher).
 //!
-//! This crate is the Rust home of two classes of code that previously lived
-//! in `burin-labs/burin-code`'s Swift `BurinCore`:
+//! This crate is the Rust home of two classes of optional host capabilities:
 //!
 //! 1. **Code intelligence** — `ast/`, `code_index/`, `scanner/`, `fs_watch/`.
 //! 2. **Deterministic tools** — `tools/` (search, fs, git, process).
@@ -21,8 +20,8 @@
 //! The AST, scanner, code-index, and deterministic-tool surfaces are
 //! implemented. `fs_watch/` still registers its public contract with
 //! [`HostlibError::Unimplemented`] handlers. Module names, method names,
-//! and JSON schemas under `schemas/` are the source of truth for
-//! `burin-code`'s schema-drift tests, so they must stay stable while module
+//! and JSON schemas under `schemas/` are the source of truth for hostlib
+//! request/response compatibility, so they must stay stable while module
 //! bodies evolve.
 
 #![deny(rust_2018_idioms)]

--- a/crates/harn-hostlib/src/scanner/commands.rs
+++ b/crates/harn-hostlib/src/scanner/commands.rs
@@ -1,7 +1,6 @@
-//! Test-command + code-pattern detection. Mirrors
-//! `CoreRepoScanner.detectTestCommands` /
-//! `CoreRepoScanner.detectCodePatterns` and `TestPatternResolver` so the
-//! Rust scanner produces the same hints as the Swift one.
+//! Test-command + code-pattern detection so scanner metadata can power
+//! downstream "run tests" affordances without asking every host to
+//! rediscover package manifests.
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -265,7 +264,7 @@ fn scan_package_json(dir: &Path, prefix: Option<String>, commands: &mut BTreeMap
 // MARK: - Code pattern hints
 
 /// Detect ORM/test/auth/middleware patterns that help the agent write
-/// correct code. Best-effort; mirrors `detectCodePatterns` on the Swift side.
+/// correct code. Best-effort.
 pub fn detect_code_patterns(files: &[FileRecord], root: &Path) -> Vec<String> {
     let mut patterns: Vec<String> = Vec::new();
     let helper_candidates = collect_helper_candidates(files);

--- a/crates/harn-hostlib/src/scanner/discover.rs
+++ b/crates/harn-hostlib/src/scanner/discover.rs
@@ -1,7 +1,7 @@
 //! File discovery — walks a project root and produces deterministic
 //! `(relative_path, absolute_path)` tuples.
 //!
-//! Mirrors `CoreRepoScanner.discoverFiles` semantics:
+//! Discovery semantics:
 //!
 //! 1. Try `git ls-files --cached --others --exclude-standard` (so the file
 //!    set matches `git status` perfectly when run inside a checkout).

--- a/crates/harn-hostlib/src/scanner/extensions.rs
+++ b/crates/harn-hostlib/src/scanner/extensions.rs
@@ -1,9 +1,7 @@
-//! Source-extension and excluded-directory tables. Mirrors the constants
-//! in `Sources/BurinCore/Scanner/CoreRepoScanner.swift` so the Rust scanner
-//! and the Swift scanner classify files identically.
+//! Source-extension and excluded-directory tables for deterministic scans.
 
 /// Directory names that the scanner refuses to traverse, regardless of
-/// `.gitignore` state. Matches `CoreRepoScanner.excludedDirs`.
+/// `.gitignore` state.
 pub const EXCLUDED_DIRS: &[&str] = &[
     ".git",
     ".build",
@@ -34,8 +32,7 @@ pub const EXCLUDED_DIRS: &[&str] = &[
     ".parcel-cache",
 ];
 
-/// File extensions the scanner indexes. Matches
-/// `CoreRepoScanner.sourceExtensions`.
+/// File extensions the scanner indexes.
 pub const SOURCE_EXTENSIONS: &[&str] = &[
     "swift",
     "ts",

--- a/crates/harn-hostlib/src/scanner/folders.rs
+++ b/crates/harn-hostlib/src/scanner/folders.rs
@@ -1,6 +1,4 @@
-//! Folder aggregates, project metadata, and the text repo map. Mirrors
-//! `buildFolderRecords`, `buildProjectMetadata`, and `RepoMapBuilder.build`
-//! on the Swift side.
+//! Folder aggregates, project metadata, and the text repo map.
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -136,7 +134,7 @@ pub fn build_project_metadata(
 }
 
 /// Build the text repo map. Token budget is approximate — the builder caps
-/// emission at `4 * tokens` characters (matches the Swift heuristic).
+/// emission at `4 * tokens` characters.
 pub fn build_repo_map(
     symbols: &[SymbolRecord],
     _files: &[FileRecord],

--- a/crates/harn-hostlib/src/scanner/imports.rs
+++ b/crates/harn-hostlib/src/scanner/imports.rs
@@ -1,13 +1,8 @@
-//! Language-aware import-statement extraction. Ports
-//! `Sources/BurinCore/Scanner/ImportParser.swift` line-for-line so the
-//! Rust scanner produces the same `imports`/`dependencies` lists as the
-//! Swift one for any given input.
+//! Language-aware import-statement extraction for the scanner pipeline.
 //!
-//! Only the subset used by the scanner pipeline is ported here:
-//! `extract_imports`. The Swift module's import-rewriting helpers
-//! (`generateImportStatement`, `insertImport`, …) live on the burin-code
-//! editor surface, not the scanner intake — porting them belongs to a
-//! future B-series ticket if anyone needs them on the Rust side.
+//! Only the subset used by the scanner pipeline is implemented here:
+//! `extract_imports`. Import-rewriting belongs to editor-specific host
+//! surfaces and should be added as separate hostlib methods if needed.
 
 use regex::Regex;
 use std::sync::OnceLock;
@@ -15,7 +10,7 @@ use std::sync::OnceLock;
 /// Extract zero or more import-target strings from `content`.
 ///
 /// `language` is the lowercase file extension (`"rs"`, `"ts"`, …). Unknown
-/// languages return an empty vec — matching the Swift `default` arm.
+/// languages return an empty vec.
 pub fn extract_imports(content: &str, language: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut in_go_block = false;

--- a/crates/harn-hostlib/src/scanner/mod.rs
+++ b/crates/harn-hostlib/src/scanner/mod.rs
@@ -1,13 +1,11 @@
 //! Repo scanner host capability.
 //!
-//! Ports `Sources/BurinCore/Scanner/CoreRepoScanner.swift` from
-//! `burin-labs/burin-code` into Rust: deterministic project-wide file
-//! enumeration honoring `.gitignore` and the [`extensions::EXCLUDED_DIRS`]
-//! table, symbol extraction, import-derived dependency graph,
-//! reference + churn + importance scoring, source/test pairing, folder
-//! aggregates, project metadata (language stats + detected test
-//! commands + code-pattern hints), sub-project detection, and a
-//! token-budgeted text repo map.
+//! Deterministic project-wide file enumeration honoring `.gitignore` and
+//! the [`extensions::EXCLUDED_DIRS`] table, symbol extraction,
+//! import-derived dependency graph, reference + churn + importance
+//! scoring, source/test pairing, folder aggregates, project metadata
+//! (language stats + detected test commands + code-pattern hints),
+//! sub-project detection, and a token-budgeted text repo map.
 //!
 //! `scan_project` returns the full [`result::ScanResult`] alongside an
 //! opaque `snapshot_token` derived from the canonicalized root path. The

--- a/crates/harn-hostlib/src/scanner/result.rs
+++ b/crates/harn-hostlib/src/scanner/result.rs
@@ -1,14 +1,11 @@
-//! Owned data model for the scanner output. Mirrors the Swift
-//! `ScanResult`/`FileRecord`/`SymbolRecord`/etc. shape from
-//! `Sources/BurinCore/Scanner/RepoScannerModels.swift`.
+//! Owned data model for the scanner output.
 //!
-//! Fields are renamed `snake_case` (the JSON shape is also snake_case in
-//! schemas/scanner/scan_project.response.json — burin-code's consumers
-//! map between the two via Codable's coding keys).
+//! The JSON shape is snake_case and documented in
+//! `schemas/scanner/scan_project.response.json`.
 
 use serde::{Deserialize, Serialize};
 
-/// Coarse symbol kinds. Matches `SymbolKindRS` on the Swift side.
+/// Coarse symbol kinds emitted by the scanner.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum SymbolKind {
@@ -142,7 +139,7 @@ pub struct SymbolRecord {
 /// One folder's aggregate metadata.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FolderRecord {
-    /// Always equals `relative_path` (used by the Swift consumer for `Identifiable`).
+    /// Always equals `relative_path`, giving hosts a stable folder identifier.
     pub id: String,
     /// Folder path (`"."` for repo root).
     pub relative_path: String,

--- a/crates/harn-hostlib/src/scanner/scoring.rs
+++ b/crates/harn-hostlib/src/scanner/scoring.rs
@@ -1,7 +1,5 @@
 //! Reference counting + importance scoring + churn analysis.
 //!
-//! Mirrors the relevant phases in `CoreRepoScanner.swift`:
-//!
 //! * `computeReferenceCounts` — count how many times each symbol name
 //!   appears as the trailing component of an import path, plus 1 per extra
 //!   file that re-defines the same name.
@@ -11,9 +9,9 @@
 //!   `importance = 3*ref_count + 2*type_def + churn`, halved when the
 //!   symbol is contained in another type.
 //!
-//! These are deliberate, well-documented heuristics — burin-code consumers
-//! depend on the exact numeric output, so any changes here must be
-//! coordinated with the Swift implementation.
+//! These are deliberate, documented hostlib heuristics. Any scoring change
+//! is observable in repo-map ordering and should update fixtures and
+//! compatibility tests.
 
 use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
@@ -166,9 +164,9 @@ mod tests {
 
     #[test]
     fn ref_counts_pick_up_trailing_module_segment() {
-        // Swift `computeReferenceCounts` splits only on "/" — so "std::Foo"
-        // never matches because its trailing segment is `std::Foo`, not
-        // `Foo`. Trailing segments from "/" splits do match.
+        // Reference counts split only on "/" — so "std::Foo" never matches
+        // because its trailing segment is `std::Foo`, not `Foo`. Trailing
+        // segments from "/" splits do match.
         let files = vec![
             file("a.rs", &["std::Foo", "Foo"]),
             file("b.rs", &["bar/Foo"]),

--- a/crates/harn-hostlib/src/scanner/snapshot.rs
+++ b/crates/harn-hostlib/src/scanner/snapshot.rs
@@ -1,10 +1,7 @@
 //! Snapshot persistence for incremental scans.
 //!
-//! Mirrors the `loadCached` / `persistResult` pair on the Swift side, but
-//! lives under `<root>/.harn/hostlib/scanner-snapshot.json` instead of
-//! `<root>/.burin/index/scan-result.json` — `.harn/` is the canonical
-//! per-repo Harn working directory; `.burin/` is reserved for the burin-code
-//! IDE caches the bridge consumer maintains. The snapshot stores both the
+//! Snapshots live under `<root>/.harn/hostlib/scanner-snapshot.json`, the
+//! canonical per-repo Harn working directory. The snapshot stores both the
 //! [`ScanResult`] and the canonicalized root so [`load_for_token`] can
 //! refuse cross-root token reuse.
 

--- a/crates/harn-hostlib/src/scanner/symbols.rs
+++ b/crates/harn-hostlib/src/scanner/symbols.rs
@@ -1,10 +1,8 @@
-//! Symbol extraction for the scanner pipeline. Ports the regex/generic
-//! arms of `Sources/BurinCore/Scanner/SymbolExtractor.swift` plus the
-//! pragma extractor from `PragmaExtractor.swift`.
+//! Symbol extraction for the scanner pipeline.
 //!
-//! The Swift implementation routes most languages through tree-sitter and
-//! falls back to the regex extractor for Swift, Shell, Dart, and unknown
-//! languages. This Rust scanner keeps the same public record shape so the
+//! This regex extractor covers pragma sections, Dart, and the generic
+//! fallback path used for languages where the scanner does not need a full
+//! tree-sitter pass. The scanner keeps the same public record shape so the
 //! orchestrator in [`super::run_scan`] can swap extraction engines without
 //! disturbing callers.
 //!
@@ -112,7 +110,7 @@ fn extract_from_line(
     }
 }
 
-// MARK: - Dart (no tree-sitter grammar available on the Swift side)
+// MARK: - Dart (regex fallback)
 fn extract_dart(line: &str, line_number: usize, file_path: &str) -> Vec<SymbolRecord> {
     let mut out = Vec::new();
     if let Some(name) = capture(dart_class(), line) {
@@ -164,7 +162,7 @@ fn extract_dart(line: &str, line_number: usize, file_path: &str) -> Vec<SymbolRe
     out
 }
 
-// MARK: - Generic regex fallback (matches Swift `extractGeneric`)
+// MARK: - Generic regex fallback
 fn extract_generic(line: &str, line_number: usize, file_path: &str) -> Vec<SymbolRecord> {
     if let Some(name) = capture(generic_function(), line) {
         return vec![make_symbol(
@@ -456,10 +454,9 @@ mod tests {
 
     #[test]
     fn extracts_dart_function_with_signature() {
-        // The Swift regex extractor matches any `<word> <ident>(` line, so
-        // a function-call inside a body shows up as another function entry
-        // — match that behavior exactly. Production callers de-dupe at the
-        // tree-sitter / outline layer.
+        // The regex fallback matches any `<word> <ident>(` line, so a
+        // function-call inside a body shows up as another function entry.
+        // Production callers de-dupe at the tree-sitter / outline layer.
         let src = "void greet(String name) {\n  return name.length;\n}\n";
         let symbols = extract_symbols(src, "dart", "main.dart");
         let fns: Vec<_> = symbols

--- a/crates/harn-hostlib/src/scanner/test_mapping.rs
+++ b/crates/harn-hostlib/src/scanner/test_mapping.rs
@@ -1,16 +1,13 @@
 //! Source-file ↔ test-file pairing.
 //!
-//! Mirrors `CoreRepoScanner.mapTestFiles` and the test-file-pattern table
-//! that lives in `Sources/BurinCore/Resources/languages/*.json` on the
-//! Swift side. The patterns are inlined here rather than loaded from JSON
-//! so the scanner has zero filesystem dependencies — when burin-code adds
-//! a new language config it bumps both repos under the same release.
+//! The patterns are inlined here rather than loaded from JSON so the
+//! scanner has zero filesystem dependencies. Adding language coverage means
+//! updating this table and the matching scanner fixtures together.
 
 use crate::scanner::result::FileRecord;
 
 /// Substrings / suffixes that mark a file as a test for at least one
-/// language. Mirrors the union of `testFilePatterns` across every
-/// `Sources/BurinCore/Resources/languages/*.json`.
+/// language.
 const TEST_PATTERNS: &[&str] = &[
     // C++
     "_test.cpp",
@@ -96,7 +93,7 @@ pub fn is_test_file(relative_path: &str) -> bool {
 /// Populate [`FileRecord::corresponding_test_file`] for every non-test file
 /// that has a recognizable test-file partner. Mutates `files` in place.
 ///
-/// Heuristic (matches the Swift implementation):
+/// Heuristic:
 /// 1. Index test files by their leading basename token
 ///    (`accounts.integration.test.ts` → `accounts`).
 /// 2. For each non-test file, look up by its leading basename token.
@@ -195,7 +192,7 @@ mod tests {
     #[test]
     fn pairs_swift_source_with_swift_tests() {
         // Both files share the leading filename token "Foo" (split on `.`),
-        // so the Swift-matching algorithm pairs them.
+        // so the pairing algorithm matches them.
         let mut files = vec![record("Sources/Foo.swift"), record("Tests/Foo.Tests.swift")];
         map_test_files(&mut files);
         let src = files
@@ -210,10 +207,10 @@ mod tests {
 
     #[test]
     fn skips_when_leading_token_differs() {
-        // The Swift algorithm only pairs files that share their first
-        // dotted token. `test_foo.py` has token `test_foo`; `foo.py` has
-        // `foo` — they don't pair. Recorded as a known limitation; a
-        // future B-series ticket can layer prefix-stripping on top.
+        // The algorithm only pairs files that share their first dotted
+        // token. `test_foo.py` has token `test_foo`; `foo.py` has `foo` —
+        // they don't pair. Recorded as a known limitation; a future
+        // B-series ticket can layer prefix-stripping on top.
         let mut files = vec![record("foo.py"), record("test_foo.py")];
         map_test_files(&mut files);
         let src = files.iter().find(|f| f.relative_path == "foo.py").unwrap();

--- a/crates/harn-hostlib/src/schemas.rs
+++ b/crates/harn-hostlib/src/schemas.rs
@@ -2,9 +2,9 @@
 //!
 //! Schemas live at `schemas/<module>/<method>.{request,response}.json` and
 //! are baked into the crate at compile time via `include_str!`. They're the
-//! source of truth for `burin-code`'s schema-drift tests: the schema files
-//! ship with the crate (see the `include` field in `Cargo.toml`), and
-//! consumers fetch them through this module.
+//! source of truth for hostlib request/response compatibility: the schema
+//! files ship with the crate (see the `include` field in `Cargo.toml`),
+//! and consumers fetch them through this module.
 //!
 //! Schemas use JSON Schema draft 2020-12.
 
@@ -21,7 +21,7 @@ pub enum SchemaKind {
 ///
 /// Embedders use this catalog to:
 /// - assert that every registered builtin has a matching schema (drift test);
-/// - export the schemas to consumers like burin-code;
+/// - export the schemas to downstream consumers;
 /// - validate live request/response payloads in tests.
 pub const SCHEMAS: &[(&str, &str, SchemaKind, &str)] = &[
     // ast/

--- a/crates/harn-hostlib/src/tools/lang.rs
+++ b/crates/harn-hostlib/src/tools/lang.rs
@@ -9,11 +9,10 @@
 //! runner by passing `argv` (for `run_*`) or `ecosystem` (for
 //! `manage_packages`), bypassing detection entirely.
 //!
-//! Divergence vs. Swift `BurinCore`: the Swift implementation also
-//! consulted `LanguageConfigRegistry` JSON files shipped inside the IDE
-//! bundle. We do *not* port that here — the IDE shim can keep doing its
-//! own override before invoking `run_test`. The behaviors here are the
-//! sane defaults for the manifests every supported ecosystem ships.
+//! Detection is deliberately hostlib-local. IDE shims can apply their own
+//! project-specific overrides before invoking `run_test`; the behaviors
+//! here are the sane defaults for the manifests every supported ecosystem
+//! ships.
 
 use std::path::Path;
 
@@ -57,7 +56,7 @@ impl Ecosystem {
     }
 
     /// Map the user-facing ecosystem name (from the request payload) to a
-    /// detected variant. Aliases follow Swift's `packageManager(from:)`.
+    /// detected variant.
     pub(crate) fn parse(name: &str) -> Option<Ecosystem> {
         match name.trim().to_ascii_lowercase().as_str() {
             "cargo" | "rust" => Some(Ecosystem::Cargo),
@@ -82,8 +81,8 @@ impl Ecosystem {
 /// Detect the most likely ecosystem for a workspace by inspecting manifests.
 ///
 /// Returns `None` if no recognized manifest is present. Detection order
-/// matches the strictest-first heuristic Swift used: lockfile-bearing JS
-/// managers beat plain `npm`; `uv.lock` / `poetry.lock` beat plain `pip`.
+/// prefers lockfile-bearing JS managers over plain `npm`; `uv.lock` /
+/// `poetry.lock` beat plain `pip`.
 pub(crate) fn detect(cwd: &Path) -> Option<Ecosystem> {
     if cwd.join("Cargo.toml").is_file() {
         return Some(Ecosystem::Cargo);

--- a/crates/harn-hostlib/src/tools/manage_packages.rs
+++ b/crates/harn-hostlib/src/tools/manage_packages.rs
@@ -5,8 +5,7 @@
 //!
 //! Behavior:
 //! - `ecosystem` is required when `cwd` doesn't contain a recognized
-//!   manifest. (Swift's implementation refused to infer; we keep that
-//!   contract — callers must opt in to a specific manager.)
+//!   manifest; callers must opt in to a specific manager.
 //! - `lockfile_changed` is computed by snapshotting the relevant lockfile
 //!   path before/after the spawn and comparing mtimes. We don't read
 //!   contents to keep the cost predictable on large lockfiles.

--- a/crates/harn-hostlib/src/tools/mod.rs
+++ b/crates/harn-hostlib/src/tools/mod.rs
@@ -1,8 +1,7 @@
 //! Deterministic tools capability.
 //!
-//! Ports the Swift `CoreToolExecutor` surface: search (ripgrep via
-//! `grep-searcher` + `ignore`), file I/O, listing, file outline, git
-//! inspection, and
+//! Provides search (ripgrep via `grep-searcher` + `ignore`), file I/O,
+//! listing, file outline, git inspection, and
 //! process lifecycle (`run_command`, `run_test`, `run_build_command`,
 //! `inspect_test_results`, `manage_packages`, `cancel_handle`).
 //!

--- a/crates/harn-hostlib/src/tools/outline.rs
+++ b/crates/harn-hostlib/src/tools/outline.rs
@@ -1,11 +1,11 @@
 //! `tools/get_file_outline` — convenience wrapper that returns a
 //! structural outline (functions, classes, types) for a single source file.
 //!
-//! This module uses a small language-agnostic regex-backed extractor for the
-//! languages `burin-code` exposes in its outline UI: Swift, Rust, JS/TS,
-//! Python, Go, Ruby, Java/Kotlin, C/C++, and shell. The output shape is
-//! identical to `ast.outline`'s response schema, so the extractor can be
-//! replaced by a tree-sitter implementation without disturbing callers.
+//! This module uses a small language-agnostic regex-backed extractor for
+//! common host languages: Swift, Rust, JS/TS, Python, Go, Ruby,
+//! Java/Kotlin, C/C++, and shell. The output shape is identical to
+//! `ast.outline`'s response schema, so the extractor can be replaced by a
+//! tree-sitter implementation without disturbing callers.
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/harn-hostlib/src/tools/payload.rs
+++ b/crates/harn-hostlib/src/tools/payload.rs
@@ -101,7 +101,7 @@ pub(crate) fn optional_u64(
 }
 
 /// Convert an optional `timeout_ms` field into a `Duration`, treating zero
-/// or absent values as "no timeout" — matches the Swift surface.
+/// or absent values as "no timeout".
 pub(crate) fn optional_timeout(
     builtin: &'static str,
     map: &BTreeMap<String, VmValue>,

--- a/crates/harn-hostlib/src/tools/proc.rs
+++ b/crates/harn-hostlib/src/tools/proc.rs
@@ -6,8 +6,7 @@
 //!    orchestration capability policy applies (Linux seccomp/landlock,
 //!    macOS `sandbox-exec`, workspace-root cwd enforcement).
 //! 2. Pipe drains run on background threads so >64 KB output never
-//!    deadlocks `wait()` (the same trap the Swift implementation called
-//!    out in CoreToolExecutor+Commands.swift).
+//!    deadlocks `wait()`.
 //! 3. Timeout enforcement is uniform: when a deadline elapses, the child
 //!    is killed and `timed_out: true` is reported in the response.
 
@@ -75,8 +74,8 @@ pub(crate) fn run(req: SpawnRequest) -> Result<SpawnOutcome, HostlibError> {
     }
 
     if !req.env.is_empty() {
-        // Mirrors Swift's buildCleanEnvironment: the caller is responsible for
-        // every variable they want set; we don't merge in the parent env. This
+        // The caller is responsible for every variable they want set; we
+        // don't merge in the parent env. This
         // matches the schema (env is a complete map, not a patch).
         command.env_clear();
         for (key, value) in &req.env {
@@ -211,7 +210,7 @@ fn decode_status(status: std::process::ExitStatus) -> (i32, Option<String>) {
 
 #[cfg(unix)]
 fn format_signal(sig: i32) -> String {
-    // Stay minimal: mirror the names exposed by burin-code's UI surfaces.
+    // Stay minimal: expose the conventional signal names hosts render.
     match sig {
         1 => "SIGHUP".into(),
         2 => "SIGINT".into(),

--- a/crates/harn-hostlib/src/tools/run_command.rs
+++ b/crates/harn-hostlib/src/tools/run_command.rs
@@ -3,13 +3,12 @@
 //!
 //! Schema: `schemas/tools/run_command.{request,response}.json`.
 //!
-//! Divergence vs. Swift `CoreToolExecutor.runCommand`:
-//! - Input is `argv: [String]` (no shell parsing). The Swift implementation
-//!   accepted a shell `command: String` and routed through `ShellPathResolver`.
-//!   We require argv to eliminate the shell-injection surface; callers that
-//!   genuinely need a shell can pass `["sh", "-c", ...]` themselves.
+//! Behavior:
+//! - Input is `argv: [String]` (no shell parsing) to eliminate the
+//!   shell-injection surface; callers that genuinely need a shell can pass
+//!   `["sh", "-c", ...]` themselves.
 //! - `capture_stderr: false` collapses stderr into stdout instead of dropping
-//!   it (matches what Swift returned to LLMs).
+//!   it.
 //! - There is no implicit cap of 300s on `timeout_ms`; the caller decides.
 //!   Sandboxing limits the blast radius regardless.
 //! - `long_running: true` spawns without waiting and returns a handle dict

--- a/crates/harn-hostlib/src/tools/run_test.rs
+++ b/crates/harn-hostlib/src/tools/run_test.rs
@@ -11,7 +11,7 @@
 //! - When `filter` is supplied, append it through the runner's
 //!   pattern-filter flag (`-k`, `--filter`, `-run`, …).
 //!
-//! Divergence vs. Swift `runTest`:
+//! Hostlib-specific behavior:
 //! - We never invoke a Makefile or rely on `cachedBuildCommands` —
 //!   that's host-side state we don't have. Callers that drive a Makefile
 //!   should pass `argv: ["make", "test"]` explicitly.

--- a/crates/harn-hostlib/src/tools/search.rs
+++ b/crates/harn-hostlib/src/tools/search.rs
@@ -1,9 +1,8 @@
 //! `tools/search` — ripgrep-style content search backed by `grep-searcher`
 //! and `ignore`.
 //!
-//! Mirrors the Swift `CoreToolExecutor.searchCode` surface but returns
-//! structured matches (path/line/column/text/context) instead of a
-//! preformatted human string. The shape is locked by
+//! Returns structured matches (path/line/column/text/context) instead of
+//! a preformatted human string. The shape is locked by
 //! `schemas/tools/search.{request,response}.json`.
 
 use std::collections::VecDeque;
@@ -179,8 +178,8 @@ fn build_matcher(
         })
 }
 
-/// Normalize a user-supplied glob the way Swift's `searchCode` did so
-/// callers writing `internal/manifest/*.go` get matches at any depth.
+/// Normalize a user-supplied glob so callers writing
+/// `internal/manifest/*.go` get matches at any depth.
 fn normalize_glob(glob: &str) -> String {
     if glob.contains('/') && !glob.starts_with("**/") {
         format!("**/{glob}")

--- a/crates/harn-hostlib/tests/ast_builtins.rs
+++ b/crates/harn-hostlib/tests/ast_builtins.rs
@@ -172,9 +172,8 @@ fn outline_caps_depth_when_max_depth_supplied() {
 #[test]
 fn parse_file_meets_perf_budget_on_a_known_input() {
     let registry = ast_registry();
-    // Use the largest fixture we ship (Rust). The issue suggests
-    // burin-code's `Package.swift` as a reference; running against an
-    // in-tree fixture keeps the test hermetic and CI-friendly.
+    // Use the largest fixture we ship (Rust). Running against an in-tree
+    // fixture keeps the test hermetic and CI-friendly.
     let path = fixture_path("rust/source.rs");
     let payload = dict(&[(
         "path",
@@ -435,9 +434,9 @@ fn parse_errors_flags_typescript_syntax_error() {
 
 #[test]
 fn parse_errors_top_level_decl_count_matches_swift_profile() {
-    // Mirrors Swift's `topLevelDeclCount` for a couple of canonical
-    // language profiles. Drift in this number means our profile fell out
-    // of sync with `TreeSitterParseErrors.declarationTypesMap`.
+    // Covers top-level declaration counts for a couple of canonical
+    // language profiles. Drift in this number means our declaration map
+    // changed.
     let registry = ast_registry();
 
     let cases = [
@@ -445,7 +444,7 @@ fn parse_errors_top_level_decl_count_matches_swift_profile() {
         ("python", "def a():\n    pass\nclass B:\n    pass\n", 2),
         // TS lists `export_statement` as both a declaration and a
         // wrapper, so each `export X` contributes 2 (the export itself
-        // plus the wrapped decl). Mirrors Swift exactly.
+        // plus the wrapped decl).
         (
             "typescript",
             "export function a() {}\nexport const b = 1;\nfunction c() {}\n",
@@ -522,20 +521,19 @@ fn undefined_names_marks_unsupported_languages() {
     };
     assert!(
         !supported,
-        "rust isn't in the Swift profile set; must report supported = false"
+        "rust isn't in the undefined-name profile set; must report supported = false"
     );
     let diagnostics = list_value(&dict_field(&result, "diagnostics"));
     assert!(diagnostics.is_empty());
 }
 
 #[test]
-fn perf_smoke_against_burin_code_when_available() {
-    // The issue calls out `~/projects/burin-code/Package.swift`. That
-    // path only exists on the maintainer's box; skip silently otherwise
-    // so CI stays green.
-    let target = std::env::var("HOME")
+fn perf_smoke_against_external_file_when_available() {
+    // Optional maintainer smoke test for a larger real-world file. CI
+    // leaves this unset, so the test remains hermetic by default.
+    let target = std::env::var("HARN_AST_PERF_SMOKE_PATH")
         .ok()
-        .map(|home| PathBuf::from(home).join("projects/burin-code/Package.swift"));
+        .map(PathBuf::from);
     let Some(path) = target.filter(|p| p.exists()) else {
         return;
     };
@@ -551,7 +549,7 @@ fn perf_smoke_against_burin_code_when_available() {
     let elapsed = start.elapsed();
     let bytes = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
     eprintln!(
-        "burin-code Package.swift parse_file: {elapsed:?} ({} bytes)",
+        "external parse_file perf smoke: {elapsed:?} ({} bytes)",
         bytes
     );
     assert!(

--- a/crates/harn-hostlib/tests/ast_fixtures.rs
+++ b/crates/harn-hostlib/tests/ast_fixtures.rs
@@ -4,8 +4,8 @@
 //! goldens — `symbols.golden.json` and `outline.golden.json` — generated
 //! from the live extractor. Adding a new language is: drop in a source
 //! file, set `HARN_AST_UPDATE_GOLDEN=1`, run the test, commit. The
-//! per-language goldens are the contract burin-code's bridge consumer
-//! checks against, so changes here are visible in code review.
+//! per-language goldens are the hostlib compatibility contract, so changes
+//! here are visible in code review.
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/harn-hostlib/tests/code_index_live_state.rs
+++ b/crates/harn-hostlib/tests/code_index_live_state.rs
@@ -1,7 +1,6 @@
 //! Integration tests for the live workspace state added in #776.
 //!
-//! Covers everything the burin-code Swift bridge previously round-tripped
-//! through `BurinCodeIndex/`: agent registry + locks, the append-only
+//! Covers live code-index state: agent registry + locks, the append-only
 //! version log, file table accessors, cached read paths, and the snapshot
 //! recovery flow. The cross-process concurrency stress test exercises
 //! `agent_register/heartbeat/unregister + lock_try/release` from a
@@ -221,7 +220,7 @@ fn file_hash_reads_the_file_off_disk() {
     );
     let s = extract_str(&h);
     // FNV-1a of `# project\n` is deterministic; pre-computed by hand
-    // (mirroring the Swift `ContentHasher.hash` reference implementation).
+    // FNV-1a reference value for `hello world`.
     let expected: u64 = {
         let mut h: u64 = 0xcbf2_9ce4_8422_2325;
         for b in b"# project\n" {

--- a/crates/harn-hostlib/tests/code_index_scenario.rs
+++ b/crates/harn-hostlib/tests/code_index_scenario.rs
@@ -1,11 +1,7 @@
-//! Scenario test: build a real index over a Swift fixture that mirrors
-//! the layout of `burin-labs/burin-code`'s `Sources/BurinCodeIndex/`.
+//! Scenario test: build a real index over a Swift-shaped host fixture.
 //!
-//! The issue's "Tests" bullet asks for "a scenario test that builds an
-//! index over the `burin-code` repo itself and asserts known queries
-//! (golden fixture)". We can't depend on a sibling checkout from CI, so
-//! the fixture under `tests/fixtures/burin_code_subset/` reproduces the
-//! shape of the Swift module we're porting (file names, basic content,
+//! The fixture under `tests/fixtures/burin_code_subset/` reproduces the
+//! shape of a code-index host module (file names, basic content,
 //! cross-references). The asserts are picked to catch regressions in:
 //!
 //! - the trigram/word index (does `query("TrigramIndex")` find the file?)
@@ -15,10 +11,10 @@
 //!   not resolve standard-library imports — so the symmetric assertion
 //!   uses an in-fixture cross-reference instead).
 //!
-//! When `BURIN_CODE_REPO=<path>` is set in the environment, the scenario
-//! also rebuilds the index against that path and asserts the same set of
-//! invariants over the live repo. CI doesn't set the env var so the
-//! synthetic fixture path is the default.
+//! When `HARN_HOSTLIB_CODE_INDEX_SCENARIO_ROOT=<path>` is set in the
+//! environment, the scenario also rebuilds the index against that path and
+//! asserts the same set of invariants over a live repo. CI doesn't set the
+//! env var so the synthetic fixture path is the default.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -119,7 +115,7 @@ fn assert_substring_query_finds(registry: &BuiltinRegistry, needle: &str, expect
 }
 
 #[test]
-fn fixture_reproduces_swift_module_invariants() {
+fn fixture_reproduces_code_index_invariants() {
     let cap = CodeIndexCapability::new();
     let mut registry = BuiltinRegistry::new();
     cap.register_builtins(&mut registry);
@@ -161,18 +157,19 @@ fn fixture_reproduces_swift_module_invariants() {
     assert!(extract_int(stats.get("trigrams").unwrap()) > 0);
 }
 
-/// When `BURIN_CODE_REPO` points at a checkout, the same invariants are
-/// asserted over the real repo. The env-var gate keeps CI fast and
-/// hermetic — local runs that opt in get the realistic stress test.
+/// When `HARN_HOSTLIB_CODE_INDEX_SCENARIO_ROOT` points at a checkout, the
+/// same invariants are asserted over a real repo. The env-var gate keeps
+/// CI fast and hermetic; local runs that opt in get the realistic stress
+/// test.
 #[test]
-fn live_burin_code_smoke() {
-    let Some(path) = std::env::var_os("BURIN_CODE_REPO") else {
-        eprintln!("BURIN_CODE_REPO not set; skipping live scenario test");
+fn live_code_index_smoke() {
+    let Some(path) = std::env::var_os("HARN_HOSTLIB_CODE_INDEX_SCENARIO_ROOT") else {
+        eprintln!("HARN_HOSTLIB_CODE_INDEX_SCENARIO_ROOT not set; skipping live scenario test");
         return;
     };
     let path = PathBuf::from(path);
     if !path.exists() {
-        eprintln!("BURIN_CODE_REPO does not exist; skipping");
+        eprintln!("HARN_HOSTLIB_CODE_INDEX_SCENARIO_ROOT does not exist; skipping");
         return;
     }
     let cap = CodeIndexCapability::new();
@@ -183,7 +180,7 @@ fn live_burin_code_smoke() {
     let files_indexed = rebuild(&registry, &path);
     let elapsed = started.elapsed();
     eprintln!(
-        "live burin-code rebuild: {files_indexed} files in {:.2}s",
+        "live code-index scenario rebuild: {files_indexed} files in {:.2}s",
         elapsed.as_secs_f64()
     );
     assert!(files_indexed > 0);

--- a/crates/harn-hostlib/tests/fixtures/burin_code_subset/CodeIndex.swift
+++ b/crates/harn-hostlib/tests/fixtures/burin_code_subset/CodeIndex.swift
@@ -1,10 +1,9 @@
 // CodeIndex.swift
 //
-// Trimmed fixture mirroring the structure of
-// `burin-labs/burin-code/Sources/BurinCodeIndex/CodeIndex.swift`. Used by
-// `tests/code_index_scenario.rs` as a stand-in when the live repo isn't
-// available — the tree-shape and `import` declarations are what the
-// scenario asserts on, not the implementation details.
+// Trimmed Swift-shaped code-index fixture. Used by
+// `tests/code_index_scenario.rs`; the tree-shape and `import`
+// declarations are what the scenario asserts on, not the implementation
+// details.
 
 import Foundation
 

--- a/crates/harn-hostlib/tests/fixtures/burin_code_subset/FilteredWalker.swift
+++ b/crates/harn-hostlib/tests/fixtures/burin_code_subset/FilteredWalker.swift
@@ -1,6 +1,6 @@
 // FilteredWalker.swift
 //
-// Mirrors the Swift `FilteredWalker` shape. Used by the scenario test
+// Filtered-walker shaped fixture. Used by the scenario test
 // to assert substring queries find this file — the body is irrelevant.
 
 import Foundation

--- a/crates/harn-hostlib/tests/fixtures/burin_code_subset/TrigramIndex.swift
+++ b/crates/harn-hostlib/tests/fixtures/burin_code_subset/TrigramIndex.swift
@@ -1,7 +1,7 @@
 // TrigramIndex.swift
 //
 // Trimmed fixture for the scenario test. Mirrors the public surface of
-// the Swift `TrigramIndex` so the scenario asserts queries by substring
+// the trigram index so the scenario asserts queries by substring
 // can find this file.
 
 import Foundation

--- a/crates/harn-hostlib/tests/fixtures/burin_code_subset/WordIndex.swift
+++ b/crates/harn-hostlib/tests/fixtures/burin_code_subset/WordIndex.swift
@@ -1,6 +1,6 @@
 // WordIndex.swift
 //
-// Fixture stand-in for the Swift `WordIndex` actor. Only shape matters
+// Fixture stand-in for the word index. Only shape matters
 // for the scenario test — substring queries should find this file by
 // name.
 

--- a/crates/harn-hostlib/tests/scanner_e2e.rs
+++ b/crates/harn-hostlib/tests/scanner_e2e.rs
@@ -7,10 +7,10 @@
 //! sub-project boundaries, repo-map text, and the
 //! `scan_project → scan_incremental` round-trip.
 //!
-//! The fixture below is hand-shaped to exercise the same sub-tree patterns
-//! burin-code's pipeline relies on (Cargo + nested package.json,
-//! `__tests__/` test files, paginated-response helpers, prisma schema)
-//! without forcing a heavyweight checkout.
+//! The fixture below is hand-shaped to exercise common sub-tree patterns
+//! (Cargo + nested package.json, `__tests__/` test files,
+//! paginated-response helpers, prisma schema) without forcing a
+//! heavyweight checkout.
 
 use std::fs;
 use std::path::Path;

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -128,3 +128,4 @@
 - [Package-root prompt assets](./migrations/package-root-prompt-assets.md)
 - [Schema-as-type](./migrations/schema-as-type.md)
 - [Rust connectors → Harn packages](./migrations/rust-connectors-to-harn-packages.md)
+- [harn-hostlib host contracts](./migrations/harn-hostlib-host-contracts.md)

--- a/docs/src/migrations/harn-hostlib-host-contracts.md
+++ b/docs/src/migrations/harn-hostlib-host-contracts.md
@@ -1,0 +1,21 @@
+# Migration: harn-hostlib host contracts
+
+`harn-hostlib` began as a migration path for code-intelligence and tool
+surfaces that had lived in `burin-labs/burin-code`, including the Swift
+`BurinCore`, `Sources/ASTEngine`, and `Sources/BurinCodeIndex` modules.
+That history explains the early parity tests and the initial schema names,
+but it is no longer the ownership model.
+
+The current contract is Harn-owned:
+
+- JSON schemas under `crates/harn-hostlib/schemas/` define request and
+  response compatibility for every hostlib method.
+- `HostlibRegistry` is the authoritative runtime catalog of registered
+  modules and methods.
+- Consumer repositories should treat their bridge tests as compatibility
+  checks against Harn's published contract, not as the source of truth for
+  hostlib behavior.
+
+During migration, keep any consumer-specific bridge notes in this page or
+in the consumer repository. Public hostlib docs, schema descriptions, and
+module comments should describe the neutral Harn contract first.


### PR DESCRIPTION
## Summary

- Reframes `harn-hostlib` README, schema descriptions, rustdoc/module comments, and tests around neutral Harn-owned hostlib contracts.
- Moves the Burin-specific migration context into a dedicated docs migration page and links it from the hostlib README.
- Updates non-migration docs examples from Burin-specific paths to neutral workspace paths, regenerating `docs/src/language-spec.md` from `spec/HARN_SPEC.md`.

Closes #813.

## Validation

- `cargo fmt --check`
- `rg -n "burin-code|BurinCore|Sources/ASTEngine|Sources/BurinCodeIndex" crates/harn-hostlib docs/src` (only migration docs remain)
- `CARGO_TARGET_DIR=/tmp/harn-codex-target-issue-813 cargo test -p harn-hostlib`
- `CARGO_TARGET_DIR=/tmp/harn-codex-target-issue-813 make check-docs-snippets`
- `git diff --check`
- `make lint-md`
- pre-commit clippy hook passed before markdown heading fix; markdown was rerun after the fix
- pre-push gate passed: 2837 tests, markdown lint