### PR TITLE
parser+lint: exempt hostlib_-prefixed names + backfill CHANGELOG for #818-#821

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## Unreleased
+
+### Added
+
+- **A2A AgentCard discovery alignment (#806/#821).** Serve
+  `/.well-known/agent-card.json` as the canonical A2A discovery endpoint
+  while preserving legacy aliases (`/agent/card`, `/.well-known/a2a-agent`,
+  `/.well-known/agent.json`). The emitted card now matches the current
+  upstream schema — `supportedInterfaces` array (with `protocolBinding` /
+  `protocolVersion`), `defaultInputModes` / `defaultOutputModes`,
+  per-skill `tags` / `examples` / `inputModes` / `outputModes`,
+  `securitySchemes` as object — and outbound A2A discovery prefers the
+  canonical path with a fallback chain. The Harn Agents API card schema
+  is now `HarnAgentCard` with a nested `a2a_agent_card` projection.
+
+- **ACP lifecycle extension contract formalized (#817/#820).** Harn now
+  advertises its ACP extensions during `initialize` under
+  `agentCapabilities._meta.harn`, including pinned upstream-schema
+  compatibility, extension `sessionUpdate` discriminators, and the
+  tool/content extension fields. Emitted `plan` updates align with the
+  upstream schema by using `entries` instead of the old Harn-local
+  `plan` key. Host rendering and compatibility expectations are
+  documented in `docs/src/bridge-protocol.md`.
+
+### Changed
+
+- **OpenAI-compatible streaming preserves token usage (#173/#818).**
+  OpenAI-compatible streaming endpoints (including Ollama when wired
+  through `/v1/chat/completions`) now request
+  `stream_options.include_usage` so usage figures survive streamed
+  responses. Native Ollama `/api/chat` behavior is preserved (usage
+  arrives in the final NDJSON chunk). OpenRouter / OpenAI-compatible
+  cache-write usage is now read from
+  `usage.prompt_tokens_details.cache_write_tokens`.
+
+- **Documentation IA reorganized (#814/#819).** mdBook summary split
+  into smaller top-level groups (language, agent runtime, protocols,
+  orchestration, packages/connectors, observability, operations,
+  reference, migrations). New protocol support matrix and cross-links
+  to the canonical MCP/ACP/A2A guides. Release-workflow material moved
+  out of the CLI reference, README release section trimmed, and stale
+  implementation-wave issue/path references removed from user docs.
+
+### Fixed
+
+- **`hostlib_*` calls in static `.harn` files no longer break
+  `harn check --workspace` and `harn lint`.** Hostlib builtins
+  (`hostlib_code_index_*`, `hostlib_ast_*`, `hostlib_scanner_*`, …)
+  are registered onto the VM at runtime by
+  `harn_hostlib::install_default` and have no static signature in the
+  parser's BUILTIN_SIGNATURES table. Before this fix, calling them
+  directly from a workspace `.harn` file raised
+  `error: call target X is not defined or imported` at typecheck and
+  `lint[undefined-function]` warnings during lint. The cross-module
+  resolver and the lint's call-graph walk now treat `hostlib_*` as an
+  opaque escape hatch — the same way `__`-prefixed names are
+  treated. The runtime VM still does the real dispatch, so typos
+  surface there instead of at parse time (the same trade-off
+  `host_call("…")` already accepts).
+
 ## v0.7.47
 
 ### Added

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -1046,6 +1046,9 @@ impl<'a> Linter<'a> {
             if name.starts_with("__") {
                 continue;
             }
+            if name.starts_with("hostlib_") {
+                continue;
+            }
             let suggestion = if let Some(closest) =
                 find_closest_match(name, self.known_functions.iter().map(|s| s.as_str()), 2)
             {

--- a/crates/harn-lint/src/tests/imports.rs
+++ b/crates/harn-lint/src/tests/imports.rs
@@ -105,3 +105,18 @@ fn test_import_order_stdlib_before_third_party() {
         "stdlib should come before third-party, got: {diags:?}"
     );
 }
+
+#[test]
+fn test_hostlib_prefix_skips_undefined_function_warning() {
+    // `hostlib_*` names are runtime-registered VM builtins
+    // (`harn_hostlib::install_default`); the lint's static call
+    // graph cannot see them. Suppressing the warning matches the
+    // existing `__`-prefix exemption.
+    let source =
+        "pipeline default(task) {\n  hostlib_code_index_stats({})\n  hostlib_ast_parse_file({})\n}\n";
+    let diags = lint_source(source);
+    assert!(
+        !has_rule(&diags, "undefined-function"),
+        "hostlib_-prefixed calls should not raise undefined-function, got: {diags:?}"
+    );
+}

--- a/crates/harn-parser/src/typechecker/inference/calls.rs
+++ b/crates/harn-parser/src/typechecker/inference/calls.rs
@@ -595,6 +595,13 @@ impl TypeChecker {
                 || imported.contains(name)
                 || scope.is_generic_type_param(name)
                 || name.starts_with("__")
+                // `hostlib_*` builtins are registered onto the VM at
+                // runtime by `harn_hostlib::install_default` (see the
+                // `hostlib` cargo feature in `harn-cli`). The parser
+                // has no static signature for them, so static
+                // resolution treats the prefix as an opaque escape
+                // hatch — same idea as `__`-prefixed names.
+                || name.starts_with("hostlib_")
                 // Built-in value constructors — `Ok`/`Err` are VM
                 // builtins (Result variants) but are not in the
                 // parser's BUILTIN_SIGNATURES table because they have

--- a/crates/harn-parser/src/typechecker/tests/strict_types.rs
+++ b/crates/harn-parser/src/typechecker/tests/strict_types.rs
@@ -306,3 +306,24 @@ fn test_cross_module_builtin_not_flagged() {
         .collect();
     assert!(errs.is_empty(), "builtin should not error, got: {errs:?}");
 }
+
+#[test]
+fn test_cross_module_hostlib_prefix_not_flagged() {
+    // `hostlib_*` names are registered onto the VM at runtime by
+    // `harn_hostlib::install_default`. The parser's static
+    // BUILTIN_SIGNATURES table does not (and should not) enumerate
+    // them, so the cross-module resolver treats the prefix as an
+    // opaque escape hatch — the same way `__`-prefixed names are
+    // treated.
+    let diags =
+        check_source_with_imports(r#"pipeline t(task) { hostlib_code_index_stats({}) }"#, &[]);
+    let errs: Vec<&String> = diags
+        .iter()
+        .filter(|d| d.severity == DiagnosticSeverity::Error)
+        .map(|d| &d.message)
+        .collect();
+    assert!(
+        errs.is_empty(),
+        "hostlib_-prefixed call should not error, got: {errs:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- **Parser + lint fix**: `hostlib_*` calls in static `.harn` files no longer break `harn check --workspace` and `harn lint`. Hostlib builtins are registered onto the VM at runtime by `harn_hostlib::install_default` and have no static signature in the parser's BUILTIN_SIGNATURES table. Treat the prefix as an opaque escape hatch — same way `__`-prefixed names are treated. The runtime VM still does the real dispatch.
- **CHANGELOG backfill**: adds entries for #818 (OpenAI streaming token usage), #819 (docs IA), #820 (ACP lifecycle extension contract), #821 (A2A AgentCard discovery alignment) — none of those PRs touched CHANGELOG.

## Why this matters now

burin-code PR 431 calls `hostlib_code_index_*` directly from `lib/host/codeindex.harn`; without this fix, `harn check --workspace` errors out on those calls and `Harn lint` fires `undefined-function` warnings. This is the blocking change for landing burin-code 431.

## Test plan
- [x] Added `test_cross_module_hostlib_prefix_not_flagged` in `crates/harn-parser/src/typechecker/tests/strict_types.rs`
- [x] Added `test_hostlib_prefix_skips_undefined_function_warning` in `crates/harn-lint/src/tests/imports.rs`
- [x] All 366 harn-parser + harn-lint tests pass locally
- [x] Full pre-push hook (cargo fmt, clippy --workspace, markdown lint) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)