### PR TITLE
Release v0.7.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
-## Unreleased
+## v0.7.48
 
 ### Added
+
+- **MCP script surfaces served over HTTP (#808/#828).** Script-authored
+  `mcp_tools` / resources / templates / prompts now serve over Streamable
+  HTTP as well as stdio, sharing the VM MCP JSON-RPC handler with the
+  new script HTTP wrapper (sessions, Streamable HTTP POST/GET, legacy
+  SSE compatibility). DispatchCore `pub fn` MCP servers can now carry
+  Server Card metadata, and the surface adds resource/list/read plus
+  prompt/resource-template discovery fallbacks with cursor pagination.
 
 - **A2A AgentCard discovery alignment (#806/#821).** Serve
   `/.well-known/agent-card.json` as the canonical A2A discovery endpoint


### PR DESCRIPTION
## Summary
- Prepares the v0.7.48 release: bumps workspace versions, regenerates derived files, and finalizes CHANGELOG entries for the prior batch (#806/#821 A2A AgentCard, #817/#820 ACP lifecycle, #173/#818 OpenAI streaming, #814/#819 docs IA, #808/#828 MCP scripts over HTTP, #831 hostlib_-prefix exemption).

## Test plan
- [ ] CI green (cargo check, clippy, conformance, format)
- [ ] After merge, finalize-release workflow tags and publishes to crates.io
- [ ] After binaries build, bump burin-code/.harn-version to v0.7.48

🤖 Generated with [Claude Code](https://claude.com/claude-code)