### PR TITLE
Add GraphQL connector substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ granular archaeology.
 
 ### Added
 
+- **GraphQL connector SDK substrate (#811).** Adds `import "std/graphql"`
+  for provider-neutral GraphQL-over-HTTP request bodies, auth headers,
+  normalized `{data, errors, extensions, meta}` envelopes, persisted-query
+  metadata, cursor pagination helpers, SDL/introspection normalization, and
+  generated-style operation wrapper source. The Linear stdlib wrapper now
+  drives outbound issue/comment/search helpers through shared GraphQL
+  operation specs, with a fixture schema and conformance smoke test covering
+  the generated-client path.
+
 - **Long-running tool handles for `run_command`, `run_test`,
   `run_build_command` (#778/#803).** Pass `long_running: true` to spawn
   the child process without blocking and receive a handle dict immediately

--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ enforcement.
   `schema_parse(...)`, `schema_is(...)`, JSON Schema/OpenAPI conversion, and
   schema composition helpers, plus a lazy `std/schema` builder module for
   ergonomic schema authoring when imported.
+- Provider-neutral GraphQL connector helpers via `import "std/graphql"`:
+  request/envelope normalization, introspection and SDL fixture parsing,
+  persisted-query metadata, cursor pagination helpers, auth headers, and
+  generated-style operation wrapper source for GraphQL-first providers such as
+  Linear.
 - Prompt fragment reuse via `import "std/prompt_library"`: load TOML catalogs
   or front-matter `.harn.prompt` files, render cache-aware fragment payloads,
   and propose tenant-scoped k-means hotspots for repeated context prefixes.

--- a/conformance/fixtures/graphql/linear_fixture.graphql
+++ b/conformance/fixtures/graphql/linear_fixture.graphql
@@ -1,0 +1,25 @@
+type Query {
+  viewer(id: String!): User
+  issues(first: Int, after: String): IssueConnection
+}
+
+type User {
+  id: ID!
+  name: String!
+}
+
+type Issue {
+  id: ID!
+  identifier: String!
+  title: String!
+}
+
+type IssueConnection {
+  nodes: [Issue!]!
+  pageInfo: PageInfo!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  endCursor: String
+}

--- a/conformance/tests/stdlib/graphql_sdk.expected
+++ b/conformance/tests/stdlib/graphql_sdk.expected
@@ -1,0 +1,15 @@
+String!
+Query
+true
+true
+Ada
+49
+7
+req-1
+200
+Viewer
+Bearer linear-token
+ISS-1
+cursor-1
+64
+true

--- a/conformance/tests/stdlib/graphql_sdk.harn
+++ b/conformance/tests/stdlib/graphql_sdk.harn
@@ -1,0 +1,70 @@
+import {
+  graphql_execute_operation,
+  graphql_generate_client,
+  graphql_next_page_variables,
+  graphql_normalize_response,
+  graphql_operation,
+  graphql_page_info,
+  graphql_parse_schema,
+  graphql_persisted_query,
+  graphql_schema_from_introspection,
+} from "std/graphql"
+
+pipeline test(task) {
+  let root = project_root() ?? cwd()
+  let schema_text = read_file(path_join(root, "conformance/fixtures/graphql/linear_fixture.graphql"))
+  let parsed = graphql_parse_schema(schema_text)
+  let issue = parsed.types.find({ entry -> return entry.name == "Issue" })
+  let identifier = issue.fields.find({ field -> return field.name == "identifier" })
+  println(identifier.type)
+  let introspected = graphql_schema_from_introspection(
+    {data: {__schema: {queryType: {name: "Query"}, types: [{kind: "OBJECT", name: "Issue"}]}}},
+  )
+  println(introspected.query_type)
+  let endpoint = "https://linear.example/graphql"
+  let query = "query Viewer($id: String!) { viewer(id: $id) { id name } }"
+  let operation = graphql_operation(
+    "viewer",
+    query,
+    {
+      root_field: "viewer",
+      variables_schema: {type: "dict", required: ["id"], properties: {id: {type: "string"}}},
+    },
+  )
+  let generated = graphql_generate_client([operation])
+  println(contains(generated, "pub fn viewer"))
+  http_mock(
+    "POST",
+    endpoint,
+    {
+      status: 200,
+      body: json_stringify({data: {viewer: {id: "user-1", name: "Ada"}}, extensions: {cost: 1}}),
+      headers: {["X-Complexity"]: "7", ["X-RateLimit-Requests-Remaining"]: "49", ["X-Request-Id"]: "req-1"},
+    },
+  )
+  let envelope = graphql_execute_operation(
+    {endpoint: endpoint, auth: {access_token: "linear-token"}},
+    operation,
+    {id: "user-1"},
+  )
+  println(envelope.ok)
+  println(envelope.result.name)
+  println(envelope.meta.rate_limit.requests_remaining)
+  println(envelope.meta.rate_limit.complexity)
+  println(envelope.meta.request_id)
+  println(envelope.result.meta.status)
+  let calls = http_mock_calls()
+  println(json_parse(calls[0].body).operationName)
+  println(calls[0].headers.Authorization)
+  let page = graphql_page_info({nodes: [{id: "ISS-1"}], pageInfo: {hasNextPage: true, endCursor: "cursor-1"}})
+  println(page.nodes[0].id)
+  println(
+    graphql_next_page_variables({first: 1}, {pageInfo: {hasNextPage: true, endCursor: "cursor-1"}}).after,
+  )
+  let persisted = graphql_persisted_query(query)
+  println(len(persisted.sha256_hash))
+  let normalized = graphql_normalize_response(
+    {status: 200, headers: {}, body: "{\"data\":{\"ok\":true},\"errors\":[{\"message\":\"partial\"}]}"},
+  )
+  println(normalized.partial)
+}

--- a/crates/harn-modules/src/stdlib.rs
+++ b/crates/harn-modules/src/stdlib.rs
@@ -17,6 +17,7 @@ pub(crate) const STDLIB_SOURCES: &[(&str, &str)] = &[
     ("math", include_str!("stdlib/stdlib_math.harn")),
     ("path", include_str!("stdlib/stdlib_path.harn")),
     ("json", include_str!("stdlib/stdlib_json.harn")),
+    ("graphql", include_str!("stdlib/stdlib_graphql.harn")),
     ("schema", include_str!("stdlib/stdlib_schema.harn")),
     ("testing", include_str!("stdlib/stdlib_testing.harn")),
     ("vision", include_str!("stdlib/stdlib_vision.harn")),

--- a/crates/harn-modules/src/stdlib/stdlib_connectors_linear.harn
+++ b/crates/harn-modules/src/stdlib/stdlib_connectors_linear.harn
@@ -1,4 +1,10 @@
 import { filter_nil } from "std/collections"
+import {
+  graphql_assert_ok,
+  graphql_extract,
+  graphql_operation,
+  graphql_page_info,
+} from "std/graphql"
 import { merge } from "std/json"
 import { wait_for } from "std/monitors"
 
@@ -17,20 +23,85 @@ fn __call(method, params = {}) {
   return connector_call("linear", method, filter_nil(merge(linear_connector_config, params ?? {})))
 }
 
+pub fn operation(name, document, options = nil) {
+  return graphql_operation(name, document, options)
+}
+
+pub fn execute(operation, variables = nil, options = nil) {
+  let raw = graphql(
+    operation.document,
+    variables,
+    merge(options ?? {}, {operation_name: operation.operation_name ?? operation.name}),
+  )
+  let envelope = graphql_assert_ok(raw)
+  let result = if operation.root_field != nil {
+    graphql_extract(envelope, operation.root_field, operation.result_schema)
+  } else {
+    envelope.data
+  }
+  let shaped_result = if type_of(result) == "dict" {
+    merge(result, {meta: envelope.meta})
+  } else {
+    result
+  }
+  return merge(envelope, {result: shaped_result})
+}
+
+fn __list_issues_operation() {
+  return operation(
+    "ListIssues",
+    "query ListIssues($filter: IssueFilter, $first: Int, $after: String, $includeArchived: Boolean) { issues(filter: $filter, first: $first, after: $after, includeArchived: $includeArchived) { nodes { id identifier title priority estimate dueDate url createdAt updatedAt state { id name type } team { id key name } assignee { id name } project { id name } cycle { id name } labels { nodes { id name } } } pageInfo { hasNextPage endCursor } } }",
+    {root_field: "issues"},
+  )
+}
+
+fn __update_issue_operation() {
+  return operation(
+    "UpdateIssue",
+    "mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) { issueUpdate(id: $id, input: $input) { success issue { id identifier title priority estimate dueDate url updatedAt state { id name type } assignee { id name } project { id name } cycle { id name } labels { nodes { id name } } } } }",
+    {root_field: "issueUpdate"},
+  )
+}
+
+fn __create_comment_operation() {
+  return operation(
+    "CreateComment",
+    "mutation CreateComment($input: CommentCreateInput!) { commentCreate(input: $input) { success comment { id body url createdAt user { id name } issue { id identifier title } } } }",
+    {root_field: "commentCreate"},
+  )
+}
+
+fn __search_issues_operation() {
+  return operation(
+    "SearchIssues",
+    "query SearchIssues($query: String!, $first: Int) { searchIssues(query: $query, first: $first) { nodes { id identifier title url priority state { id name type } team { id key name } } pageInfo { hasNextPage endCursor } } }",
+    {root_field: "searchIssues"},
+  )
+}
+
 pub fn list_issues(filter = nil, options = nil) {
-  return __call("list_issues", filter_nil(options ?? {} + {filter: filter}))
+  let variables = filter_nil(
+    {
+      filter: filter,
+      first: options?.first,
+      after: options?.after,
+      includeArchived: options?.include_archived ?? options?.includeArchived,
+    },
+  )
+  let connection = execute(__list_issues_operation(), variables, options).result
+  return merge(connection, {page: graphql_page_info(connection)})
 }
 
 pub fn update_issue(id, changes, options = nil) {
-  return __call("update_issue", options ?? {} + {id: id, changes: changes})
+  return execute(__update_issue_operation(), {id: id, input: changes}, options).result
 }
 
 pub fn create_comment(issue_id, body, options = nil) {
-  return __call("create_comment", options ?? {} + {issue_id: issue_id, body: body})
+  return execute(__create_comment_operation(), {input: {issueId: issue_id, body: body}}, options).result
 }
 
 pub fn search(query, options = nil) {
-  return __call("search", options ?? {} + {query: query})
+  return execute(__search_issues_operation(), {query: query, first: options?.first}, options).result
 }
 
 pub fn graphql(query, variables = nil, options = nil) {
@@ -65,36 +136,36 @@ pub fn issue_state_source(issue_id, target_state = nil, options = nil) {
     label: "linear.issue_state:" + to_string(issue_id) + ":" + to_string(target_state ?? "*"),
     prefers_push: true,
     poll: { ctx ->
-    let payload = __linear_payload(ctx?.last_push_event)
-    if payload != nil && __linear_issue_matches(payload, issue_id) {
+      let payload = __linear_payload(ctx?.last_push_event)
+      if payload != nil && __linear_issue_matches(payload, issue_id) {
+        return {
+          matched: __linear_state_matches(payload.issue, target_state),
+          issue: payload.issue,
+          state: payload?.issue?.state,
+          event: payload,
+        }
+      }
+      let response = graphql(
+        "query HarnMonitorIssue($id: String!) { issue(id: $id) { id identifier title state { id name type } } }",
+        {id: issue_id},
+        options,
+      )
+      let issue = response?.data?.issue
       return {
-    matched: __linear_state_matches(payload.issue, target_state),
-    issue: payload.issue,
-    state: payload?.issue?.state,
-    event: payload,
-  }
-    }
-    let response = graphql(
-    "query HarnMonitorIssue($id: String!) { issue(id: $id) { id identifier title state { id name type } } }",
-    {id: issue_id},
-    options,
-  )
-    let issue = response?.data?.issue
-    return {
-    matched: __linear_state_matches(issue, target_state),
-    issue: issue,
-    state: issue?.state,
-    event: nil,
-  }
-  },
+        matched: __linear_state_matches(issue, target_state),
+        issue: issue,
+        state: issue?.state,
+        event: nil,
+      }
+    },
     push_filter: { log_event ->
-    let event = __linear_event(log_event)
-    let payload = __linear_payload(log_event)
-    return event?.provider == "linear"
-    && event?.kind == "issue"
-    && __linear_issue_matches(payload, issue_id)
-    && __linear_state_matches(payload?.issue, target_state)
-  },
+      let event = __linear_event(log_event)
+      let payload = __linear_payload(log_event)
+      return event?.provider == "linear"
+        && event?.kind == "issue"
+        && __linear_issue_matches(payload, issue_id)
+        && __linear_state_matches(payload?.issue, target_state)
+    },
   }
 }
 
@@ -102,8 +173,8 @@ pub fn issue_state_source(issue_id, target_state = nil, options = nil) {
 pub fn wait_until_issue_state(issue_id, target_state, options = nil) {
   return wait_for(
     merge(
-    options ?? {},
-    {source: issue_state_source(issue_id, target_state, options), condition: { state -> state.matched }},
-  ),
+      options ?? {},
+      {source: issue_state_source(issue_id, target_state, options), condition: { state -> state.matched }},
+    ),
   )
 }

--- a/crates/harn-modules/src/stdlib/stdlib_graphql.harn
+++ b/crates/harn-modules/src/stdlib/stdlib_graphql.harn
@@ -1,0 +1,453 @@
+// std/graphql — provider-neutral GraphQL request, envelope, pagination, and codegen helpers.
+//
+// Import with: import "std/graphql"
+import { filter_nil } from "std/collections"
+import { merge } from "std/json"
+
+fn __graphql_list(value) {
+  if value == nil {
+    return []
+  }
+  if type_of(value) == "list" {
+    return value
+  }
+  return [value]
+}
+
+fn __graphql_payload(response) {
+  let body = response?.body ?? response
+  if type_of(body) == "string" {
+    let parsed = try {
+      json_parse(body)
+    }
+    if is_ok(parsed) {
+      return unwrap(parsed)
+    }
+    return {errors: [{message: "GraphQL response body is not valid JSON"}]}
+  }
+  return body ?? {}
+}
+
+fn __graphql_header(headers, name) {
+  if headers == nil {
+    return nil
+  }
+  if headers[name] != nil {
+    return headers[name]
+  }
+  let lower = lowercase(name)
+  for entry in headers {
+    if lowercase(entry.key) == lower {
+      return entry.value
+    }
+  }
+  return nil
+}
+
+fn __graphql_int_header(headers, name) {
+  let value = __graphql_header(headers, name)
+  if value == nil || value == "" {
+    return nil
+  }
+  let parsed = try {
+    to_int(value)
+  }
+  if is_ok(parsed) {
+    return unwrap(parsed)
+  }
+  return nil
+}
+
+fn __graphql_operation_name(query, fallback = nil) {
+  let trimmed = trim(query ?? "")
+  if trimmed == "" {
+    return fallback
+  }
+  for keyword in ["query ", "mutation ", "subscription "] {
+    if starts_with(trimmed, keyword) {
+      let rest = trim(substring(trimmed, len(keyword)))
+      let name = split(split(rest, "(")[0], " ")[0]
+      if name != "" && name != "{" {
+        return name
+      }
+    }
+  }
+  return fallback
+}
+
+fn __graphql_root_field_from_query(query) {
+  let text = query ?? ""
+  let open = text.index_of("{")
+  if open < 0 {
+    return nil
+  }
+  let rest = trim(substring(text, open + 1))
+  if rest == "" {
+    return nil
+  }
+  let token = split(split(split(rest, "(")[0], "{")[0], " ")[0]
+  if token == "" || token == "..." {
+    return nil
+  }
+  return token
+}
+
+/** graphql_introspection_query. */
+pub fn graphql_introspection_query() {
+  return "query HarnIntrospection { __schema { queryType { name } mutationType { name } subscriptionType { name } types { kind name description fields(includeDeprecated: true) { name description args { name type { kind name ofType { kind name ofType { kind name } } } defaultValue } type { kind name ofType { kind name ofType { kind name } } } isDeprecated deprecationReason } inputFields { name description type { kind name ofType { kind name ofType { kind name } } } defaultValue } enumValues(includeDeprecated: true) { name description isDeprecated deprecationReason } interfaces { kind name } possibleTypes { kind name } } directives { name description locations args { name type { kind name ofType { kind name } } defaultValue } } } }"
+}
+
+/** graphql_auth_headers. */
+pub fn graphql_auth_headers(auth = nil, extra_headers = nil) {
+  var headers = {
+    ["Content-Type"]: "application/json",
+    Accept: "application/graphql-response+json, application/json",
+  }
+  if auth != nil {
+    if type_of(auth) == "string" {
+      headers = merge(headers, {Authorization: "Bearer " + auth})
+    } else if auth.authorization != nil {
+      headers = merge(headers, {Authorization: auth.authorization})
+    } else if auth.access_token != nil {
+      headers = merge(headers, {Authorization: "Bearer " + auth.access_token})
+    } else if auth.api_key != nil {
+      headers = merge(headers, {Authorization: auth.api_key})
+    } else if auth.token != nil {
+      let scheme = auth.scheme ?? "Bearer"
+      headers = merge(headers, {Authorization: scheme + " " + auth.token})
+    }
+  }
+  return merge(headers, extra_headers ?? {})
+}
+
+/** graphql_rate_limit_meta. */
+pub fn graphql_rate_limit_meta(headers = nil) {
+  return filter_nil(
+    {
+      requests_limit: __graphql_int_header(headers, "x-ratelimit-requests-limit")
+        ?? __graphql_int_header(headers, "x-ratelimit-limit"),
+      requests_remaining: __graphql_int_header(headers, "x-ratelimit-requests-remaining")
+        ?? __graphql_int_header(headers, "x-ratelimit-remaining"),
+      requests_reset: __graphql_int_header(headers, "x-ratelimit-requests-reset")
+        ?? __graphql_int_header(headers, "x-ratelimit-reset"),
+      endpoint_requests_limit: __graphql_int_header(headers, "x-ratelimit-endpoint-requests-limit"),
+      endpoint_requests_remaining: __graphql_int_header(headers, "x-ratelimit-endpoint-requests-remaining"),
+      endpoint_requests_reset: __graphql_int_header(headers, "x-ratelimit-endpoint-requests-reset"),
+      endpoint_name: __graphql_header(headers, "x-ratelimit-endpoint-name"),
+      complexity: __graphql_int_header(headers, "x-complexity"),
+      complexity_limit: __graphql_int_header(headers, "x-ratelimit-complexity-limit"),
+      complexity_remaining: __graphql_int_header(headers, "x-ratelimit-complexity-remaining"),
+      complexity_reset: __graphql_int_header(headers, "x-ratelimit-complexity-reset"),
+    },
+  )
+}
+
+/** graphql_persisted_query. */
+pub fn graphql_persisted_query(query, options = nil) {
+  let version = options?.version ?? 1
+  let hash = options?.sha256_hash ?? options?.sha256Hash ?? sha256(query)
+  return {
+    version: version,
+    sha256_hash: hash,
+    extensions: {persistedQuery: {version: version, sha256Hash: hash}},
+  }
+}
+
+/** graphql_request_body. */
+pub fn graphql_request_body(query, variables = nil, options = nil) {
+  var body = {}
+  let persisted = options?.persisted_query ?? options?.persistedQuery
+  if persisted != nil {
+    let persisted_meta = if persisted {
+      graphql_persisted_query(query)
+    } else {
+      persisted
+    }
+    body = merge(body, {extensions: persisted_meta.extensions ?? persisted_meta})
+    if persisted_meta.query && options?.include_query {
+      body = merge(body, {query: query})
+    }
+  } else {
+    body = merge(body, {query: query})
+  }
+  if variables != nil {
+    body = merge(body, {variables: variables})
+  }
+  let op_name = options?.operation_name ?? options?.operationName ?? __graphql_operation_name(query)
+  if op_name != nil {
+    body = merge(body, {operationName: op_name})
+  }
+  return body
+}
+
+/** graphql_normalize_response. */
+pub fn graphql_normalize_response(response, options = nil) {
+  let payload = __graphql_payload(response)
+  let status = response?.status ?? options?.status ?? 200
+  let headers = response?.headers ?? options?.headers ?? {}
+  let errors = __graphql_list(payload?.errors)
+  let has_errors = len(errors) > 0
+  let data = payload?.data
+  return {
+    ok: status >= 200 && status < 300 && !has_errors,
+    partial: data != nil && has_errors,
+    data: data,
+    errors: errors,
+    extensions: payload?.extensions ?? {},
+    meta: filter_nil(
+      {
+        status: status,
+        operation_name: options?.operation_name ?? options?.operationName,
+        request_id: __graphql_header(headers, "x-request-id")
+          ?? __graphql_header(headers, "linear-request-id")
+          ?? __graphql_header(headers, "apollographql-client-request-id"),
+        rate_limit: graphql_rate_limit_meta(headers),
+        persisted_query: options?.persisted_query ?? options?.persistedQuery,
+      },
+    ),
+  }
+}
+
+/** graphql_error_messages. */
+pub fn graphql_error_messages(envelope) {
+  return __graphql_list(envelope?.errors).map({ error -> return error?.message ?? to_string(error) })
+}
+
+/** graphql_assert_ok. */
+pub fn graphql_assert_ok(envelope) {
+  let messages = graphql_error_messages(envelope)
+  if envelope?.ok || (envelope?.ok == nil && len(messages) == 0) {
+    return envelope
+  }
+  if len(messages) == 0 {
+    throw_error("GraphQL request failed")
+  }
+  throw_error("GraphQL request failed: " + messages.join("; "))
+}
+
+/** graphql_extract. */
+pub fn graphql_extract(envelope, field, schema = nil) {
+  let value = envelope?.data?[field]
+  if schema != nil {
+    let checked = schema_check(value, schema)
+    if is_err(checked) {
+      throw_error(unwrap_err(checked).message)
+    }
+    return unwrap(checked)
+  }
+  return value
+}
+
+/** graphql_page_info. */
+pub fn graphql_page_info(connection) {
+  let page_info = connection?.pageInfo ?? {}
+  let nodes = connection?.nodes ?? connection?.edges?.map({ edge -> return edge.node }) ?? []
+  return {
+    nodes: nodes,
+    edges: connection?.edges ?? [],
+    has_next_page: page_info?.hasNextPage ?? false,
+    has_previous_page: page_info?.hasPreviousPage ?? false,
+    end_cursor: page_info?.endCursor,
+    start_cursor: page_info?.startCursor,
+  }
+}
+
+/** graphql_next_page_variables. */
+pub fn graphql_next_page_variables(variables, connection, cursor_key = "after") {
+  let page = graphql_page_info(connection)
+  if !page.has_next_page || page.end_cursor == nil {
+    return nil
+  }
+  return merge(variables ?? {}, {[cursor_key]: page.end_cursor})
+}
+
+/** graphql_request. */
+pub fn graphql_request(endpoint, query, variables = nil, options = nil) {
+  let auth = options?.auth ?? options?.authorization
+  let headers = graphql_auth_headers(auth, options?.headers)
+  let body = graphql_request_body(query, variables, options)
+  let response = http_request(
+    "POST",
+    endpoint,
+    filter_nil(
+      {
+        body: json_stringify(body),
+        headers: headers,
+        timeout_ms: options?.timeout_ms,
+        retry: options?.retry,
+      },
+    ),
+  )
+  return graphql_normalize_response(
+    response,
+    merge(
+      options ?? {},
+      {operation_name: body.operationName, persisted_query: options?.persisted_query},
+    ),
+  )
+}
+
+/** graphql_operation. */
+pub fn graphql_operation(name, document, options = nil) {
+  return merge(
+    options ?? {},
+    {
+      name: name,
+      document: document,
+      operation_name: options?.operation_name ?? options?.operationName ?? __graphql_operation_name(document, name),
+      root_field: options?.root_field ?? __graphql_root_field_from_query(document),
+      persisted_query: options?.persisted_query ?? options?.persistedQuery,
+    },
+  )
+}
+
+/** graphql_execute_operation. */
+pub fn graphql_execute_operation(client, operation, variables = nil, options = nil) {
+  let endpoint = if type_of(client) == "string" {
+    client
+  } else {
+    client.endpoint ?? client.url ?? client.api_base_url
+  }
+  let client_options = if type_of(client) == "dict" {
+    client
+  } else {
+    {}
+  }
+  let request_options = merge(client_options, options ?? {})
+  let checked_variables = if operation.variables_schema != nil {
+    let checked = schema_check(variables ?? {}, operation.variables_schema)
+    if is_err(checked) {
+      throw_error(unwrap_err(checked).message)
+    }
+    unwrap(checked)
+  } else {
+    variables
+  }
+  let envelope = graphql_request(
+    endpoint,
+    operation.document,
+    checked_variables,
+    merge(
+      request_options,
+      {
+        operation_name: operation.operation_name ?? operation.name,
+        persisted_query: request_options.persisted_query ?? operation.persisted_query,
+      },
+    ),
+  )
+  let result = if operation.root_field != nil {
+    graphql_extract(envelope, operation.root_field, operation.result_schema)
+  } else {
+    envelope.data
+  }
+  let shaped_result = if type_of(result) == "dict" {
+    merge(result, {meta: envelope.meta})
+  } else {
+    result
+  }
+  return merge(envelope, {result: shaped_result})
+}
+
+fn __graphql_type_header(line) {
+  for kind in ["type", "input", "interface", "enum", "union", "scalar"] {
+    let prefix = kind + " "
+    if starts_with(line, prefix) {
+      let rest = trim(substring(line, len(prefix)))
+      var name = split(split(split(rest, " ")[0], "{")[0], "=")[0]
+      name = trim(name)
+      if name != "" {
+        return {kind: kind, name: name, fields: []}
+      }
+    }
+  }
+  return nil
+}
+
+fn __graphql_field_from_line(line) {
+  let clean = trim(split(split(line, "#")[0], "@")[0])
+  let name = trim(split(split(clean, "(")[0], ":")[0])
+  let field_type = if contains(clean, ":") {
+    trim(split(clean, ":")[1])
+  } else {
+    nil
+  }
+  return filter_nil({name: name, type: field_type})
+}
+
+/** graphql_parse_schema. */
+pub fn graphql_parse_schema(schema_text) {
+  var types = []
+  var current = nil
+  for raw_line in split(schema_text ?? "", "\n") {
+    let line = trim(raw_line)
+    if line == "" || starts_with(line, "#") {
+      continue
+    }
+    let header = __graphql_type_header(line)
+    if header != nil {
+      if current != nil {
+        types = types + [current]
+      }
+      current = header
+      if contains(line, "}") {
+        types = types + [current]
+        current = nil
+      }
+      continue
+    }
+    if current != nil {
+      if starts_with(line, "}") {
+        types = types + [current]
+        current = nil
+      } else if contains(line, ":") {
+        current = merge(current, {fields: current.fields + [__graphql_field_from_line(line)]})
+      }
+    }
+  }
+  if current != nil {
+    types = types + [current]
+  }
+  return {format: "graphql-sdl", types: types}
+}
+
+/** graphql_schema_from_introspection. */
+pub fn graphql_schema_from_introspection(payload) {
+  let source = __graphql_payload(payload)
+  let schema = source?.data?.__schema ?? source?.__schema ?? source
+  return {
+    format: "graphql-introspection",
+    query_type: schema?.queryType?.name,
+    mutation_type: schema?.mutationType?.name,
+    subscription_type: schema?.subscriptionType?.name,
+    types: schema?.types ?? [],
+    directives: schema?.directives ?? [],
+  }
+}
+
+fn __graphql_harn_name(name) {
+  return replace(replace(name, "-", "_"), " ", "_")
+}
+
+/** graphql_codegen_wrapper. */
+pub fn graphql_codegen_wrapper(operation, client_param = "client") {
+  let name = __graphql_harn_name(operation.name ?? operation.operation_name)
+  let operation_json = json_stringify(operation)
+  let operation_literal = json_stringify(operation_json)
+  return "pub fn " + name + "(" + client_param + ", variables = nil, options = nil) {\n"
+    + "  let operation = json_parse("
+    + operation_literal
+    + ")\n"
+    + "  return graphql_execute_operation("
+    + client_param
+    + ", operation, variables, options)\n"
+    + "}\n"
+}
+
+/** graphql_generate_client. */
+pub fn graphql_generate_client(operations, options = nil) {
+  var source = "import { graphql_execute_operation } from \"std/graphql\"\n\n"
+  for operation in operations {
+    source = source + graphql_codegen_wrapper(operation, options?.client_param ?? "client") + "\n"
+  }
+  return source
+}

--- a/crates/harn-vm/src/stdlib_connectors_linear.harn
+++ b/crates/harn-vm/src/stdlib_connectors_linear.harn
@@ -1,4 +1,10 @@
 import { filter_nil } from "std/collections"
+import {
+  graphql_assert_ok,
+  graphql_extract,
+  graphql_operation,
+  graphql_page_info,
+} from "std/graphql"
 import { merge } from "std/json"
 import { wait_for } from "std/monitors"
 
@@ -17,20 +23,85 @@ fn __call(method, params = {}) {
   return connector_call("linear", method, filter_nil(merge(linear_connector_config, params ?? {})))
 }
 
+pub fn operation(name, document, options = nil) {
+  return graphql_operation(name, document, options)
+}
+
+pub fn execute(operation, variables = nil, options = nil) {
+  let raw = graphql(
+    operation.document,
+    variables,
+    merge(options ?? {}, {operation_name: operation.operation_name ?? operation.name}),
+  )
+  let envelope = graphql_assert_ok(raw)
+  let result = if operation.root_field != nil {
+    graphql_extract(envelope, operation.root_field, operation.result_schema)
+  } else {
+    envelope.data
+  }
+  let shaped_result = if type_of(result) == "dict" {
+    merge(result, {meta: envelope.meta})
+  } else {
+    result
+  }
+  return merge(envelope, {result: shaped_result})
+}
+
+fn __list_issues_operation() {
+  return operation(
+    "ListIssues",
+    "query ListIssues($filter: IssueFilter, $first: Int, $after: String, $includeArchived: Boolean) { issues(filter: $filter, first: $first, after: $after, includeArchived: $includeArchived) { nodes { id identifier title priority estimate dueDate url createdAt updatedAt state { id name type } team { id key name } assignee { id name } project { id name } cycle { id name } labels { nodes { id name } } } pageInfo { hasNextPage endCursor } } }",
+    {root_field: "issues"},
+  )
+}
+
+fn __update_issue_operation() {
+  return operation(
+    "UpdateIssue",
+    "mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) { issueUpdate(id: $id, input: $input) { success issue { id identifier title priority estimate dueDate url updatedAt state { id name type } assignee { id name } project { id name } cycle { id name } labels { nodes { id name } } } } }",
+    {root_field: "issueUpdate"},
+  )
+}
+
+fn __create_comment_operation() {
+  return operation(
+    "CreateComment",
+    "mutation CreateComment($input: CommentCreateInput!) { commentCreate(input: $input) { success comment { id body url createdAt user { id name } issue { id identifier title } } } }",
+    {root_field: "commentCreate"},
+  )
+}
+
+fn __search_issues_operation() {
+  return operation(
+    "SearchIssues",
+    "query SearchIssues($query: String!, $first: Int) { searchIssues(query: $query, first: $first) { nodes { id identifier title url priority state { id name type } team { id key name } } pageInfo { hasNextPage endCursor } } }",
+    {root_field: "searchIssues"},
+  )
+}
+
 pub fn list_issues(filter = nil, options = nil) {
-  return __call("list_issues", filter_nil(options ?? {} + {filter: filter}))
+  let variables = filter_nil(
+    {
+      filter: filter,
+      first: options?.first,
+      after: options?.after,
+      includeArchived: options?.include_archived ?? options?.includeArchived,
+    },
+  )
+  let connection = execute(__list_issues_operation(), variables, options).result
+  return merge(connection, {page: graphql_page_info(connection)})
 }
 
 pub fn update_issue(id, changes, options = nil) {
-  return __call("update_issue", options ?? {} + {id: id, changes: changes})
+  return execute(__update_issue_operation(), {id: id, input: changes}, options).result
 }
 
 pub fn create_comment(issue_id, body, options = nil) {
-  return __call("create_comment", options ?? {} + {issue_id: issue_id, body: body})
+  return execute(__create_comment_operation(), {input: {issueId: issue_id, body: body}}, options).result
 }
 
 pub fn search(query, options = nil) {
-  return __call("search", options ?? {} + {query: query})
+  return execute(__search_issues_operation(), {query: query, first: options?.first}, options).result
 }
 
 pub fn graphql(query, variables = nil, options = nil) {
@@ -65,36 +136,36 @@ pub fn issue_state_source(issue_id, target_state = nil, options = nil) {
     label: "linear.issue_state:" + to_string(issue_id) + ":" + to_string(target_state ?? "*"),
     prefers_push: true,
     poll: { ctx ->
-    let payload = __linear_payload(ctx?.last_push_event)
-    if payload != nil && __linear_issue_matches(payload, issue_id) {
+      let payload = __linear_payload(ctx?.last_push_event)
+      if payload != nil && __linear_issue_matches(payload, issue_id) {
+        return {
+          matched: __linear_state_matches(payload.issue, target_state),
+          issue: payload.issue,
+          state: payload?.issue?.state,
+          event: payload,
+        }
+      }
+      let response = graphql(
+        "query HarnMonitorIssue($id: String!) { issue(id: $id) { id identifier title state { id name type } } }",
+        {id: issue_id},
+        options,
+      )
+      let issue = response?.data?.issue
       return {
-    matched: __linear_state_matches(payload.issue, target_state),
-    issue: payload.issue,
-    state: payload?.issue?.state,
-    event: payload,
-  }
-    }
-    let response = graphql(
-    "query HarnMonitorIssue($id: String!) { issue(id: $id) { id identifier title state { id name type } } }",
-    {id: issue_id},
-    options,
-  )
-    let issue = response?.data?.issue
-    return {
-    matched: __linear_state_matches(issue, target_state),
-    issue: issue,
-    state: issue?.state,
-    event: nil,
-  }
-  },
+        matched: __linear_state_matches(issue, target_state),
+        issue: issue,
+        state: issue?.state,
+        event: nil,
+      }
+    },
     push_filter: { log_event ->
-    let event = __linear_event(log_event)
-    let payload = __linear_payload(log_event)
-    return event?.provider == "linear"
-    && event?.kind == "issue"
-    && __linear_issue_matches(payload, issue_id)
-    && __linear_state_matches(payload?.issue, target_state)
-  },
+      let event = __linear_event(log_event)
+      let payload = __linear_payload(log_event)
+      return event?.provider == "linear"
+        && event?.kind == "issue"
+        && __linear_issue_matches(payload, issue_id)
+        && __linear_state_matches(payload?.issue, target_state)
+    },
   }
 }
 
@@ -102,8 +173,8 @@ pub fn issue_state_source(issue_id, target_state = nil, options = nil) {
 pub fn wait_until_issue_state(issue_id, target_state, options = nil) {
   return wait_for(
     merge(
-    options ?? {},
-    {source: issue_state_source(issue_id, target_state, options), condition: { state -> state.matched }},
-  ),
+      options ?? {},
+      {source: issue_state_source(issue_id, target_state, options), condition: { state -> state.matched }},
+    ),
   )
 }

--- a/crates/harn-vm/src/stdlib_graphql.harn
+++ b/crates/harn-vm/src/stdlib_graphql.harn
@@ -1,0 +1,453 @@
+// std/graphql — provider-neutral GraphQL request, envelope, pagination, and codegen helpers.
+//
+// Import with: import "std/graphql"
+import { filter_nil } from "std/collections"
+import { merge } from "std/json"
+
+fn __graphql_list(value) {
+  if value == nil {
+    return []
+  }
+  if type_of(value) == "list" {
+    return value
+  }
+  return [value]
+}
+
+fn __graphql_payload(response) {
+  let body = response?.body ?? response
+  if type_of(body) == "string" {
+    let parsed = try {
+      json_parse(body)
+    }
+    if is_ok(parsed) {
+      return unwrap(parsed)
+    }
+    return {errors: [{message: "GraphQL response body is not valid JSON"}]}
+  }
+  return body ?? {}
+}
+
+fn __graphql_header(headers, name) {
+  if headers == nil {
+    return nil
+  }
+  if headers[name] != nil {
+    return headers[name]
+  }
+  let lower = lowercase(name)
+  for entry in headers {
+    if lowercase(entry.key) == lower {
+      return entry.value
+    }
+  }
+  return nil
+}
+
+fn __graphql_int_header(headers, name) {
+  let value = __graphql_header(headers, name)
+  if value == nil || value == "" {
+    return nil
+  }
+  let parsed = try {
+    to_int(value)
+  }
+  if is_ok(parsed) {
+    return unwrap(parsed)
+  }
+  return nil
+}
+
+fn __graphql_operation_name(query, fallback = nil) {
+  let trimmed = trim(query ?? "")
+  if trimmed == "" {
+    return fallback
+  }
+  for keyword in ["query ", "mutation ", "subscription "] {
+    if starts_with(trimmed, keyword) {
+      let rest = trim(substring(trimmed, len(keyword)))
+      let name = split(split(rest, "(")[0], " ")[0]
+      if name != "" && name != "{" {
+        return name
+      }
+    }
+  }
+  return fallback
+}
+
+fn __graphql_root_field_from_query(query) {
+  let text = query ?? ""
+  let open = text.index_of("{")
+  if open < 0 {
+    return nil
+  }
+  let rest = trim(substring(text, open + 1))
+  if rest == "" {
+    return nil
+  }
+  let token = split(split(split(rest, "(")[0], "{")[0], " ")[0]
+  if token == "" || token == "..." {
+    return nil
+  }
+  return token
+}
+
+/** graphql_introspection_query. */
+pub fn graphql_introspection_query() {
+  return "query HarnIntrospection { __schema { queryType { name } mutationType { name } subscriptionType { name } types { kind name description fields(includeDeprecated: true) { name description args { name type { kind name ofType { kind name ofType { kind name } } } defaultValue } type { kind name ofType { kind name ofType { kind name } } } isDeprecated deprecationReason } inputFields { name description type { kind name ofType { kind name ofType { kind name } } } defaultValue } enumValues(includeDeprecated: true) { name description isDeprecated deprecationReason } interfaces { kind name } possibleTypes { kind name } } directives { name description locations args { name type { kind name ofType { kind name } } defaultValue } } } }"
+}
+
+/** graphql_auth_headers. */
+pub fn graphql_auth_headers(auth = nil, extra_headers = nil) {
+  var headers = {
+    ["Content-Type"]: "application/json",
+    Accept: "application/graphql-response+json, application/json",
+  }
+  if auth != nil {
+    if type_of(auth) == "string" {
+      headers = merge(headers, {Authorization: "Bearer " + auth})
+    } else if auth.authorization != nil {
+      headers = merge(headers, {Authorization: auth.authorization})
+    } else if auth.access_token != nil {
+      headers = merge(headers, {Authorization: "Bearer " + auth.access_token})
+    } else if auth.api_key != nil {
+      headers = merge(headers, {Authorization: auth.api_key})
+    } else if auth.token != nil {
+      let scheme = auth.scheme ?? "Bearer"
+      headers = merge(headers, {Authorization: scheme + " " + auth.token})
+    }
+  }
+  return merge(headers, extra_headers ?? {})
+}
+
+/** graphql_rate_limit_meta. */
+pub fn graphql_rate_limit_meta(headers = nil) {
+  return filter_nil(
+    {
+      requests_limit: __graphql_int_header(headers, "x-ratelimit-requests-limit")
+        ?? __graphql_int_header(headers, "x-ratelimit-limit"),
+      requests_remaining: __graphql_int_header(headers, "x-ratelimit-requests-remaining")
+        ?? __graphql_int_header(headers, "x-ratelimit-remaining"),
+      requests_reset: __graphql_int_header(headers, "x-ratelimit-requests-reset")
+        ?? __graphql_int_header(headers, "x-ratelimit-reset"),
+      endpoint_requests_limit: __graphql_int_header(headers, "x-ratelimit-endpoint-requests-limit"),
+      endpoint_requests_remaining: __graphql_int_header(headers, "x-ratelimit-endpoint-requests-remaining"),
+      endpoint_requests_reset: __graphql_int_header(headers, "x-ratelimit-endpoint-requests-reset"),
+      endpoint_name: __graphql_header(headers, "x-ratelimit-endpoint-name"),
+      complexity: __graphql_int_header(headers, "x-complexity"),
+      complexity_limit: __graphql_int_header(headers, "x-ratelimit-complexity-limit"),
+      complexity_remaining: __graphql_int_header(headers, "x-ratelimit-complexity-remaining"),
+      complexity_reset: __graphql_int_header(headers, "x-ratelimit-complexity-reset"),
+    },
+  )
+}
+
+/** graphql_persisted_query. */
+pub fn graphql_persisted_query(query, options = nil) {
+  let version = options?.version ?? 1
+  let hash = options?.sha256_hash ?? options?.sha256Hash ?? sha256(query)
+  return {
+    version: version,
+    sha256_hash: hash,
+    extensions: {persistedQuery: {version: version, sha256Hash: hash}},
+  }
+}
+
+/** graphql_request_body. */
+pub fn graphql_request_body(query, variables = nil, options = nil) {
+  var body = {}
+  let persisted = options?.persisted_query ?? options?.persistedQuery
+  if persisted != nil {
+    let persisted_meta = if persisted {
+      graphql_persisted_query(query)
+    } else {
+      persisted
+    }
+    body = merge(body, {extensions: persisted_meta.extensions ?? persisted_meta})
+    if persisted_meta.query && options?.include_query {
+      body = merge(body, {query: query})
+    }
+  } else {
+    body = merge(body, {query: query})
+  }
+  if variables != nil {
+    body = merge(body, {variables: variables})
+  }
+  let op_name = options?.operation_name ?? options?.operationName ?? __graphql_operation_name(query)
+  if op_name != nil {
+    body = merge(body, {operationName: op_name})
+  }
+  return body
+}
+
+/** graphql_normalize_response. */
+pub fn graphql_normalize_response(response, options = nil) {
+  let payload = __graphql_payload(response)
+  let status = response?.status ?? options?.status ?? 200
+  let headers = response?.headers ?? options?.headers ?? {}
+  let errors = __graphql_list(payload?.errors)
+  let has_errors = len(errors) > 0
+  let data = payload?.data
+  return {
+    ok: status >= 200 && status < 300 && !has_errors,
+    partial: data != nil && has_errors,
+    data: data,
+    errors: errors,
+    extensions: payload?.extensions ?? {},
+    meta: filter_nil(
+      {
+        status: status,
+        operation_name: options?.operation_name ?? options?.operationName,
+        request_id: __graphql_header(headers, "x-request-id")
+          ?? __graphql_header(headers, "linear-request-id")
+          ?? __graphql_header(headers, "apollographql-client-request-id"),
+        rate_limit: graphql_rate_limit_meta(headers),
+        persisted_query: options?.persisted_query ?? options?.persistedQuery,
+      },
+    ),
+  }
+}
+
+/** graphql_error_messages. */
+pub fn graphql_error_messages(envelope) {
+  return __graphql_list(envelope?.errors).map({ error -> return error?.message ?? to_string(error) })
+}
+
+/** graphql_assert_ok. */
+pub fn graphql_assert_ok(envelope) {
+  let messages = graphql_error_messages(envelope)
+  if envelope?.ok || (envelope?.ok == nil && len(messages) == 0) {
+    return envelope
+  }
+  if len(messages) == 0 {
+    throw_error("GraphQL request failed")
+  }
+  throw_error("GraphQL request failed: " + messages.join("; "))
+}
+
+/** graphql_extract. */
+pub fn graphql_extract(envelope, field, schema = nil) {
+  let value = envelope?.data?[field]
+  if schema != nil {
+    let checked = schema_check(value, schema)
+    if is_err(checked) {
+      throw_error(unwrap_err(checked).message)
+    }
+    return unwrap(checked)
+  }
+  return value
+}
+
+/** graphql_page_info. */
+pub fn graphql_page_info(connection) {
+  let page_info = connection?.pageInfo ?? {}
+  let nodes = connection?.nodes ?? connection?.edges?.map({ edge -> return edge.node }) ?? []
+  return {
+    nodes: nodes,
+    edges: connection?.edges ?? [],
+    has_next_page: page_info?.hasNextPage ?? false,
+    has_previous_page: page_info?.hasPreviousPage ?? false,
+    end_cursor: page_info?.endCursor,
+    start_cursor: page_info?.startCursor,
+  }
+}
+
+/** graphql_next_page_variables. */
+pub fn graphql_next_page_variables(variables, connection, cursor_key = "after") {
+  let page = graphql_page_info(connection)
+  if !page.has_next_page || page.end_cursor == nil {
+    return nil
+  }
+  return merge(variables ?? {}, {[cursor_key]: page.end_cursor})
+}
+
+/** graphql_request. */
+pub fn graphql_request(endpoint, query, variables = nil, options = nil) {
+  let auth = options?.auth ?? options?.authorization
+  let headers = graphql_auth_headers(auth, options?.headers)
+  let body = graphql_request_body(query, variables, options)
+  let response = http_request(
+    "POST",
+    endpoint,
+    filter_nil(
+      {
+        body: json_stringify(body),
+        headers: headers,
+        timeout_ms: options?.timeout_ms,
+        retry: options?.retry,
+      },
+    ),
+  )
+  return graphql_normalize_response(
+    response,
+    merge(
+      options ?? {},
+      {operation_name: body.operationName, persisted_query: options?.persisted_query},
+    ),
+  )
+}
+
+/** graphql_operation. */
+pub fn graphql_operation(name, document, options = nil) {
+  return merge(
+    options ?? {},
+    {
+      name: name,
+      document: document,
+      operation_name: options?.operation_name ?? options?.operationName ?? __graphql_operation_name(document, name),
+      root_field: options?.root_field ?? __graphql_root_field_from_query(document),
+      persisted_query: options?.persisted_query ?? options?.persistedQuery,
+    },
+  )
+}
+
+/** graphql_execute_operation. */
+pub fn graphql_execute_operation(client, operation, variables = nil, options = nil) {
+  let endpoint = if type_of(client) == "string" {
+    client
+  } else {
+    client.endpoint ?? client.url ?? client.api_base_url
+  }
+  let client_options = if type_of(client) == "dict" {
+    client
+  } else {
+    {}
+  }
+  let request_options = merge(client_options, options ?? {})
+  let checked_variables = if operation.variables_schema != nil {
+    let checked = schema_check(variables ?? {}, operation.variables_schema)
+    if is_err(checked) {
+      throw_error(unwrap_err(checked).message)
+    }
+    unwrap(checked)
+  } else {
+    variables
+  }
+  let envelope = graphql_request(
+    endpoint,
+    operation.document,
+    checked_variables,
+    merge(
+      request_options,
+      {
+        operation_name: operation.operation_name ?? operation.name,
+        persisted_query: request_options.persisted_query ?? operation.persisted_query,
+      },
+    ),
+  )
+  let result = if operation.root_field != nil {
+    graphql_extract(envelope, operation.root_field, operation.result_schema)
+  } else {
+    envelope.data
+  }
+  let shaped_result = if type_of(result) == "dict" {
+    merge(result, {meta: envelope.meta})
+  } else {
+    result
+  }
+  return merge(envelope, {result: shaped_result})
+}
+
+fn __graphql_type_header(line) {
+  for kind in ["type", "input", "interface", "enum", "union", "scalar"] {
+    let prefix = kind + " "
+    if starts_with(line, prefix) {
+      let rest = trim(substring(line, len(prefix)))
+      var name = split(split(split(rest, " ")[0], "{")[0], "=")[0]
+      name = trim(name)
+      if name != "" {
+        return {kind: kind, name: name, fields: []}
+      }
+    }
+  }
+  return nil
+}
+
+fn __graphql_field_from_line(line) {
+  let clean = trim(split(split(line, "#")[0], "@")[0])
+  let name = trim(split(split(clean, "(")[0], ":")[0])
+  let field_type = if contains(clean, ":") {
+    trim(split(clean, ":")[1])
+  } else {
+    nil
+  }
+  return filter_nil({name: name, type: field_type})
+}
+
+/** graphql_parse_schema. */
+pub fn graphql_parse_schema(schema_text) {
+  var types = []
+  var current = nil
+  for raw_line in split(schema_text ?? "", "\n") {
+    let line = trim(raw_line)
+    if line == "" || starts_with(line, "#") {
+      continue
+    }
+    let header = __graphql_type_header(line)
+    if header != nil {
+      if current != nil {
+        types = types + [current]
+      }
+      current = header
+      if contains(line, "}") {
+        types = types + [current]
+        current = nil
+      }
+      continue
+    }
+    if current != nil {
+      if starts_with(line, "}") {
+        types = types + [current]
+        current = nil
+      } else if contains(line, ":") {
+        current = merge(current, {fields: current.fields + [__graphql_field_from_line(line)]})
+      }
+    }
+  }
+  if current != nil {
+    types = types + [current]
+  }
+  return {format: "graphql-sdl", types: types}
+}
+
+/** graphql_schema_from_introspection. */
+pub fn graphql_schema_from_introspection(payload) {
+  let source = __graphql_payload(payload)
+  let schema = source?.data?.__schema ?? source?.__schema ?? source
+  return {
+    format: "graphql-introspection",
+    query_type: schema?.queryType?.name,
+    mutation_type: schema?.mutationType?.name,
+    subscription_type: schema?.subscriptionType?.name,
+    types: schema?.types ?? [],
+    directives: schema?.directives ?? [],
+  }
+}
+
+fn __graphql_harn_name(name) {
+  return replace(replace(name, "-", "_"), " ", "_")
+}
+
+/** graphql_codegen_wrapper. */
+pub fn graphql_codegen_wrapper(operation, client_param = "client") {
+  let name = __graphql_harn_name(operation.name ?? operation.operation_name)
+  let operation_json = json_stringify(operation)
+  let operation_literal = json_stringify(operation_json)
+  return "pub fn " + name + "(" + client_param + ", variables = nil, options = nil) {\n"
+    + "  let operation = json_parse("
+    + operation_literal
+    + ")\n"
+    + "  return graphql_execute_operation("
+    + client_param
+    + ", operation, variables, options)\n"
+    + "}\n"
+}
+
+/** graphql_generate_client. */
+pub fn graphql_generate_client(operations, options = nil) {
+  var source = "import { graphql_execute_operation } from \"std/graphql\"\n\n"
+  for operation in operations {
+    source = source + graphql_codegen_wrapper(operation, options?.client_param ?? "client") + "\n"
+  }
+  return source
+}

--- a/crates/harn-vm/src/stdlib_modules.rs
+++ b/crates/harn-vm/src/stdlib_modules.rs
@@ -9,6 +9,7 @@ pub fn get_stdlib_source(module: &str) -> Option<&'static str> {
         "math" => Some(include_str!("stdlib_math.harn")),
         "path" => Some(include_str!("stdlib_path.harn")),
         "json" => Some(include_str!("stdlib_json.harn")),
+        "graphql" => Some(include_str!("stdlib_graphql.harn")),
         "schema" => Some(include_str!("stdlib_schema.harn")),
         "testing" => Some(include_str!("stdlib_testing.harn")),
         "vision" => Some(include_str!("stdlib_vision.harn")),

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -27,6 +27,7 @@
 - [Triggers](./triggers.md)
 - [Trigger stdlib](./stdlib/triggers.md)
 - [Monitor stdlib](./stdlib/monitors.md)
+- [GraphQL stdlib](./stdlib/graphql.md)
 - [Prompt library stdlib](./stdlib/prompt-library.md)
 - [Human in the loop](./hitl.md)
 - [Trust graph](./trust-graph.md)

--- a/docs/src/stdlib/graphql.md
+++ b/docs/src/stdlib/graphql.md
@@ -1,0 +1,53 @@
+# GraphQL Stdlib
+
+`import "std/graphql"` provides a small provider-neutral substrate for GraphQL-backed
+connector packages.
+
+Use it when a connector needs to own GraphQL documents in Harn instead of
+hand-assembling request JSON, error envelopes, cursor metadata, and generated
+wrapper source in each package.
+
+## Core Helpers
+
+- `graphql_request(endpoint, query, variables?, options?)` sends a GraphQL-over-HTTP
+  `POST` request and returns a normalized envelope.
+- `graphql_normalize_response(response, options?)` converts HTTP or GraphQL-like
+  values into `{ ok, partial, data, errors, extensions, meta }`.
+- `graphql_operation(name, document, options?)` captures an operation document plus
+  root-field, schema, and persisted-query metadata.
+- `graphql_execute_operation(client, operation, variables?, options?)` validates
+  variables when `variables_schema` is present, runs the operation, and returns
+  the envelope plus `result`.
+- `graphql_generate_client(operations, options?)` emits Harn source for generated-style operation wrappers.
+- `graphql_parse_schema(sdl)` parses lightweight SDL fixtures into type records.
+- `graphql_introspection_query()` and `graphql_schema_from_introspection(payload)` normalize introspection responses.
+
+## Connector Example
+
+```harn
+import {
+  graphql_execute_operation,
+  graphql_operation,
+  graphql_page_info,
+} from "std/graphql"
+
+let issues = graphql_operation(
+  "ListIssues",
+  "query ListIssues($first: Int, $after: String) { issues(first: $first, after: $after) { nodes { id identifier title } pageInfo { hasNextPage endCursor } } }",
+  {root_field: "issues"},
+)
+
+pipeline default() {
+  let envelope = graphql_execute_operation(
+    {endpoint: "https://api.linear.app/graphql", auth: {access_token: secret_get("linear/token")}},
+    issues,
+    {first: 25},
+  )
+  let page = graphql_page_info(envelope.result)
+  println(page.end_cursor)
+}
+```
+
+`auth` accepts `{access_token}`, `{api_key}`, `{token, scheme}`, or
+`{authorization}`. Rate-limit metadata is collected from common `X-RateLimit-*`,
+Linear endpoint, and complexity headers.

--- a/stdlib/graphql.harn
+++ b/stdlib/graphql.harn
@@ -1,0 +1,453 @@
+// std/graphql — provider-neutral GraphQL request, envelope, pagination, and codegen helpers.
+//
+// Import with: import "std/graphql"
+import { filter_nil } from "std/collections"
+import { merge } from "std/json"
+
+fn __graphql_list(value) {
+  if value == nil {
+    return []
+  }
+  if type_of(value) == "list" {
+    return value
+  }
+  return [value]
+}
+
+fn __graphql_payload(response) {
+  let body = response?.body ?? response
+  if type_of(body) == "string" {
+    let parsed = try {
+      json_parse(body)
+    }
+    if is_ok(parsed) {
+      return unwrap(parsed)
+    }
+    return {errors: [{message: "GraphQL response body is not valid JSON"}]}
+  }
+  return body ?? {}
+}
+
+fn __graphql_header(headers, name) {
+  if headers == nil {
+    return nil
+  }
+  if headers[name] != nil {
+    return headers[name]
+  }
+  let lower = lowercase(name)
+  for entry in headers {
+    if lowercase(entry.key) == lower {
+      return entry.value
+    }
+  }
+  return nil
+}
+
+fn __graphql_int_header(headers, name) {
+  let value = __graphql_header(headers, name)
+  if value == nil || value == "" {
+    return nil
+  }
+  let parsed = try {
+    to_int(value)
+  }
+  if is_ok(parsed) {
+    return unwrap(parsed)
+  }
+  return nil
+}
+
+fn __graphql_operation_name(query, fallback = nil) {
+  let trimmed = trim(query ?? "")
+  if trimmed == "" {
+    return fallback
+  }
+  for keyword in ["query ", "mutation ", "subscription "] {
+    if starts_with(trimmed, keyword) {
+      let rest = trim(substring(trimmed, len(keyword)))
+      let name = split(split(rest, "(")[0], " ")[0]
+      if name != "" && name != "{" {
+        return name
+      }
+    }
+  }
+  return fallback
+}
+
+fn __graphql_root_field_from_query(query) {
+  let text = query ?? ""
+  let open = text.index_of("{")
+  if open < 0 {
+    return nil
+  }
+  let rest = trim(substring(text, open + 1))
+  if rest == "" {
+    return nil
+  }
+  let token = split(split(split(rest, "(")[0], "{")[0], " ")[0]
+  if token == "" || token == "..." {
+    return nil
+  }
+  return token
+}
+
+/** graphql_introspection_query. */
+pub fn graphql_introspection_query() {
+  return "query HarnIntrospection { __schema { queryType { name } mutationType { name } subscriptionType { name } types { kind name description fields(includeDeprecated: true) { name description args { name type { kind name ofType { kind name ofType { kind name } } } defaultValue } type { kind name ofType { kind name ofType { kind name } } } isDeprecated deprecationReason } inputFields { name description type { kind name ofType { kind name ofType { kind name } } } defaultValue } enumValues(includeDeprecated: true) { name description isDeprecated deprecationReason } interfaces { kind name } possibleTypes { kind name } } directives { name description locations args { name type { kind name ofType { kind name } } defaultValue } } } }"
+}
+
+/** graphql_auth_headers. */
+pub fn graphql_auth_headers(auth = nil, extra_headers = nil) {
+  var headers = {
+    ["Content-Type"]: "application/json",
+    Accept: "application/graphql-response+json, application/json",
+  }
+  if auth != nil {
+    if type_of(auth) == "string" {
+      headers = merge(headers, {Authorization: "Bearer " + auth})
+    } else if auth.authorization != nil {
+      headers = merge(headers, {Authorization: auth.authorization})
+    } else if auth.access_token != nil {
+      headers = merge(headers, {Authorization: "Bearer " + auth.access_token})
+    } else if auth.api_key != nil {
+      headers = merge(headers, {Authorization: auth.api_key})
+    } else if auth.token != nil {
+      let scheme = auth.scheme ?? "Bearer"
+      headers = merge(headers, {Authorization: scheme + " " + auth.token})
+    }
+  }
+  return merge(headers, extra_headers ?? {})
+}
+
+/** graphql_rate_limit_meta. */
+pub fn graphql_rate_limit_meta(headers = nil) {
+  return filter_nil(
+    {
+      requests_limit: __graphql_int_header(headers, "x-ratelimit-requests-limit")
+        ?? __graphql_int_header(headers, "x-ratelimit-limit"),
+      requests_remaining: __graphql_int_header(headers, "x-ratelimit-requests-remaining")
+        ?? __graphql_int_header(headers, "x-ratelimit-remaining"),
+      requests_reset: __graphql_int_header(headers, "x-ratelimit-requests-reset")
+        ?? __graphql_int_header(headers, "x-ratelimit-reset"),
+      endpoint_requests_limit: __graphql_int_header(headers, "x-ratelimit-endpoint-requests-limit"),
+      endpoint_requests_remaining: __graphql_int_header(headers, "x-ratelimit-endpoint-requests-remaining"),
+      endpoint_requests_reset: __graphql_int_header(headers, "x-ratelimit-endpoint-requests-reset"),
+      endpoint_name: __graphql_header(headers, "x-ratelimit-endpoint-name"),
+      complexity: __graphql_int_header(headers, "x-complexity"),
+      complexity_limit: __graphql_int_header(headers, "x-ratelimit-complexity-limit"),
+      complexity_remaining: __graphql_int_header(headers, "x-ratelimit-complexity-remaining"),
+      complexity_reset: __graphql_int_header(headers, "x-ratelimit-complexity-reset"),
+    },
+  )
+}
+
+/** graphql_persisted_query. */
+pub fn graphql_persisted_query(query, options = nil) {
+  let version = options?.version ?? 1
+  let hash = options?.sha256_hash ?? options?.sha256Hash ?? sha256(query)
+  return {
+    version: version,
+    sha256_hash: hash,
+    extensions: {persistedQuery: {version: version, sha256Hash: hash}},
+  }
+}
+
+/** graphql_request_body. */
+pub fn graphql_request_body(query, variables = nil, options = nil) {
+  var body = {}
+  let persisted = options?.persisted_query ?? options?.persistedQuery
+  if persisted != nil {
+    let persisted_meta = if persisted {
+      graphql_persisted_query(query)
+    } else {
+      persisted
+    }
+    body = merge(body, {extensions: persisted_meta.extensions ?? persisted_meta})
+    if persisted_meta.query && options?.include_query {
+      body = merge(body, {query: query})
+    }
+  } else {
+    body = merge(body, {query: query})
+  }
+  if variables != nil {
+    body = merge(body, {variables: variables})
+  }
+  let op_name = options?.operation_name ?? options?.operationName ?? __graphql_operation_name(query)
+  if op_name != nil {
+    body = merge(body, {operationName: op_name})
+  }
+  return body
+}
+
+/** graphql_normalize_response. */
+pub fn graphql_normalize_response(response, options = nil) {
+  let payload = __graphql_payload(response)
+  let status = response?.status ?? options?.status ?? 200
+  let headers = response?.headers ?? options?.headers ?? {}
+  let errors = __graphql_list(payload?.errors)
+  let has_errors = len(errors) > 0
+  let data = payload?.data
+  return {
+    ok: status >= 200 && status < 300 && !has_errors,
+    partial: data != nil && has_errors,
+    data: data,
+    errors: errors,
+    extensions: payload?.extensions ?? {},
+    meta: filter_nil(
+      {
+        status: status,
+        operation_name: options?.operation_name ?? options?.operationName,
+        request_id: __graphql_header(headers, "x-request-id")
+          ?? __graphql_header(headers, "linear-request-id")
+          ?? __graphql_header(headers, "apollographql-client-request-id"),
+        rate_limit: graphql_rate_limit_meta(headers),
+        persisted_query: options?.persisted_query ?? options?.persistedQuery,
+      },
+    ),
+  }
+}
+
+/** graphql_error_messages. */
+pub fn graphql_error_messages(envelope) {
+  return __graphql_list(envelope?.errors).map({ error -> return error?.message ?? to_string(error) })
+}
+
+/** graphql_assert_ok. */
+pub fn graphql_assert_ok(envelope) {
+  let messages = graphql_error_messages(envelope)
+  if envelope?.ok || (envelope?.ok == nil && len(messages) == 0) {
+    return envelope
+  }
+  if len(messages) == 0 {
+    throw_error("GraphQL request failed")
+  }
+  throw_error("GraphQL request failed: " + messages.join("; "))
+}
+
+/** graphql_extract. */
+pub fn graphql_extract(envelope, field, schema = nil) {
+  let value = envelope?.data?[field]
+  if schema != nil {
+    let checked = schema_check(value, schema)
+    if is_err(checked) {
+      throw_error(unwrap_err(checked).message)
+    }
+    return unwrap(checked)
+  }
+  return value
+}
+
+/** graphql_page_info. */
+pub fn graphql_page_info(connection) {
+  let page_info = connection?.pageInfo ?? {}
+  let nodes = connection?.nodes ?? connection?.edges?.map({ edge -> return edge.node }) ?? []
+  return {
+    nodes: nodes,
+    edges: connection?.edges ?? [],
+    has_next_page: page_info?.hasNextPage ?? false,
+    has_previous_page: page_info?.hasPreviousPage ?? false,
+    end_cursor: page_info?.endCursor,
+    start_cursor: page_info?.startCursor,
+  }
+}
+
+/** graphql_next_page_variables. */
+pub fn graphql_next_page_variables(variables, connection, cursor_key = "after") {
+  let page = graphql_page_info(connection)
+  if !page.has_next_page || page.end_cursor == nil {
+    return nil
+  }
+  return merge(variables ?? {}, {[cursor_key]: page.end_cursor})
+}
+
+/** graphql_request. */
+pub fn graphql_request(endpoint, query, variables = nil, options = nil) {
+  let auth = options?.auth ?? options?.authorization
+  let headers = graphql_auth_headers(auth, options?.headers)
+  let body = graphql_request_body(query, variables, options)
+  let response = http_request(
+    "POST",
+    endpoint,
+    filter_nil(
+      {
+        body: json_stringify(body),
+        headers: headers,
+        timeout_ms: options?.timeout_ms,
+        retry: options?.retry,
+      },
+    ),
+  )
+  return graphql_normalize_response(
+    response,
+    merge(
+      options ?? {},
+      {operation_name: body.operationName, persisted_query: options?.persisted_query},
+    ),
+  )
+}
+
+/** graphql_operation. */
+pub fn graphql_operation(name, document, options = nil) {
+  return merge(
+    options ?? {},
+    {
+      name: name,
+      document: document,
+      operation_name: options?.operation_name ?? options?.operationName ?? __graphql_operation_name(document, name),
+      root_field: options?.root_field ?? __graphql_root_field_from_query(document),
+      persisted_query: options?.persisted_query ?? options?.persistedQuery,
+    },
+  )
+}
+
+/** graphql_execute_operation. */
+pub fn graphql_execute_operation(client, operation, variables = nil, options = nil) {
+  let endpoint = if type_of(client) == "string" {
+    client
+  } else {
+    client.endpoint ?? client.url ?? client.api_base_url
+  }
+  let client_options = if type_of(client) == "dict" {
+    client
+  } else {
+    {}
+  }
+  let request_options = merge(client_options, options ?? {})
+  let checked_variables = if operation.variables_schema != nil {
+    let checked = schema_check(variables ?? {}, operation.variables_schema)
+    if is_err(checked) {
+      throw_error(unwrap_err(checked).message)
+    }
+    unwrap(checked)
+  } else {
+    variables
+  }
+  let envelope = graphql_request(
+    endpoint,
+    operation.document,
+    checked_variables,
+    merge(
+      request_options,
+      {
+        operation_name: operation.operation_name ?? operation.name,
+        persisted_query: request_options.persisted_query ?? operation.persisted_query,
+      },
+    ),
+  )
+  let result = if operation.root_field != nil {
+    graphql_extract(envelope, operation.root_field, operation.result_schema)
+  } else {
+    envelope.data
+  }
+  let shaped_result = if type_of(result) == "dict" {
+    merge(result, {meta: envelope.meta})
+  } else {
+    result
+  }
+  return merge(envelope, {result: shaped_result})
+}
+
+fn __graphql_type_header(line) {
+  for kind in ["type", "input", "interface", "enum", "union", "scalar"] {
+    let prefix = kind + " "
+    if starts_with(line, prefix) {
+      let rest = trim(substring(line, len(prefix)))
+      var name = split(split(split(rest, " ")[0], "{")[0], "=")[0]
+      name = trim(name)
+      if name != "" {
+        return {kind: kind, name: name, fields: []}
+      }
+    }
+  }
+  return nil
+}
+
+fn __graphql_field_from_line(line) {
+  let clean = trim(split(split(line, "#")[0], "@")[0])
+  let name = trim(split(split(clean, "(")[0], ":")[0])
+  let field_type = if contains(clean, ":") {
+    trim(split(clean, ":")[1])
+  } else {
+    nil
+  }
+  return filter_nil({name: name, type: field_type})
+}
+
+/** graphql_parse_schema. */
+pub fn graphql_parse_schema(schema_text) {
+  var types = []
+  var current = nil
+  for raw_line in split(schema_text ?? "", "\n") {
+    let line = trim(raw_line)
+    if line == "" || starts_with(line, "#") {
+      continue
+    }
+    let header = __graphql_type_header(line)
+    if header != nil {
+      if current != nil {
+        types = types + [current]
+      }
+      current = header
+      if contains(line, "}") {
+        types = types + [current]
+        current = nil
+      }
+      continue
+    }
+    if current != nil {
+      if starts_with(line, "}") {
+        types = types + [current]
+        current = nil
+      } else if contains(line, ":") {
+        current = merge(current, {fields: current.fields + [__graphql_field_from_line(line)]})
+      }
+    }
+  }
+  if current != nil {
+    types = types + [current]
+  }
+  return {format: "graphql-sdl", types: types}
+}
+
+/** graphql_schema_from_introspection. */
+pub fn graphql_schema_from_introspection(payload) {
+  let source = __graphql_payload(payload)
+  let schema = source?.data?.__schema ?? source?.__schema ?? source
+  return {
+    format: "graphql-introspection",
+    query_type: schema?.queryType?.name,
+    mutation_type: schema?.mutationType?.name,
+    subscription_type: schema?.subscriptionType?.name,
+    types: schema?.types ?? [],
+    directives: schema?.directives ?? [],
+  }
+}
+
+fn __graphql_harn_name(name) {
+  return replace(replace(name, "-", "_"), " ", "_")
+}
+
+/** graphql_codegen_wrapper. */
+pub fn graphql_codegen_wrapper(operation, client_param = "client") {
+  let name = __graphql_harn_name(operation.name ?? operation.operation_name)
+  let operation_json = json_stringify(operation)
+  let operation_literal = json_stringify(operation_json)
+  return "pub fn " + name + "(" + client_param + ", variables = nil, options = nil) {\n"
+    + "  let operation = json_parse("
+    + operation_literal
+    + ")\n"
+    + "  return graphql_execute_operation("
+    + client_param
+    + ", operation, variables, options)\n"
+    + "}\n"
+}
+
+/** graphql_generate_client. */
+pub fn graphql_generate_client(operations, options = nil) {
+  var source = "import { graphql_execute_operation } from \"std/graphql\"\n\n"
+  for operation in operations {
+    source = source + graphql_codegen_wrapper(operation, options?.client_param ?? "client") + "\n"
+  }
+  return source
+}


### PR DESCRIPTION
## Summary
- adds provider-neutral `std/graphql` helpers for request bodies, auth headers, response normalization, rate-limit metadata, pagination, schema normalization, and generated-style operation wrappers
- registers and mirrors the stdlib module across `harn-vm`, `harn-modules`, and the root `stdlib/` surface
- refactors the built-in Linear connector wrappers to execute through shared GraphQL operation specs while preserving typed method metadata
- documents the module and adds conformance coverage with a Linear fixture schema

Closes #811.

## Companion
- Companion Linear connector PR will be linked after creation.

## Verification
- `/tmp/harn-target-aa9a-811/debug/harn test conformance --filter graphql_sdk`
- `/tmp/harn-target-aa9a-811/debug/harn test conformance --filter linear_connector_outbound`
- `/tmp/harn-target-aa9a-811/debug/harn fmt --check crates/harn-vm/src/stdlib_graphql.harn crates/harn-vm/src/stdlib_connectors_linear.harn crates/harn-modules/src/stdlib/stdlib_graphql.harn crates/harn-modules/src/stdlib/stdlib_connectors_linear.harn stdlib/graphql.harn conformance/tests/stdlib/graphql_sdk.harn`
- `HARN_BIN=/tmp/harn-target-aa9a-811/debug/harn ./scripts/check_docs_snippets.sh`
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-aa9a-811 cargo check -p harn-modules -p harn-vm`
- pre-commit hook passed, including workspace clippy, markdown lint, staged Harn lint/format, and highlight sync checks

## Pre-push note
The full pre-push `make test` run compiled and executed the workspace with 2,834 passing tests and 3 failures in unrelated `harn-vm llm::api` streaming classification tests. The branch does not touch Rust LLM code, and each failed test passed when rerun directly with `/tmp/harn-target-aa9a-811`:
- `streaming_path_classifies_rate_limit_with_retry_after`
- `streaming_path_classifies_opaque_500_as_http_error`
- `streaming_path_classifies_context_overflow`
