### PR TITLE
Enable auto-merge for release bump PRs

### DIFF
--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -154,8 +154,9 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           # gh CLI inside release_ship.sh uses GH_TOKEN for `gh pr
-          # create`. Using the App token makes the bump PR author the
-          # bot, consistent with the branch pusher.
+          # create` and `gh pr merge --auto`. Using the App token
+          # makes the bump PR author the bot, consistent with the
+          # branch pusher.
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           # First-release bootstrap for a brand-new workspace crate.
           # release_ship.sh + verify_crate_packages.sh both honor the

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -394,11 +394,16 @@ EOF
 
   if command -v gh &>/dev/null; then
     log_step "Open bump PR"
-    gh pr create \
+    local pr_url
+    pr_url="$(gh pr create \
       --base "$base" \
       --head "$branch" \
       --title "Bump version to $next" \
-      --body-file "$body_file"
+      --body-file "$body_file")"
+    echo "$pr_url"
+
+    log_step "Enable bump PR auto-merge"
+    gh pr merge "$pr_url" --auto --squash
   else
     echo "warning: gh CLI not found — skipping PR creation"
     echo "hint: open a PR from $branch into $base titled 'Bump version to $next'"
@@ -414,6 +419,7 @@ EOF
   echo "  Base branch:      $base"
   echo "  Bump branch:      $branch"
   echo "  Tag after merge:  $tag"
+  echo "  Auto-merge:       enabled"
   echo "  Total wall time:  $(_ship_fmt_ns "$TOTAL_NS")"
   echo "  Finalize after merge queue lands it: ./scripts/release_ship.sh --finalize"
 }


### PR DESCRIPTION
## Summary
- enable squash auto-merge immediately after release_ship.sh creates a recovery version bump PR
- update the bump-release workflow token comment for the new gh pr merge --auto usage

## Verification
- bash -n scripts/release_ship.sh
- actionlint .github/workflows/bump-release.yml
- make lint-actions
- git diff --check
- pre-push make test ran 2849 tests: 2848 passed, 1 unrelated local OAuth callback test failed with os error 35/connection reset
