### PR TITLE
Document and reject MCP latest-spec gaps

### DIFF
--- a/crates/harn-cli/src/commands/mcp/serve.rs
+++ b/crates/harn-cli/src/commands/mcp/serve.rs
@@ -20,6 +20,7 @@ use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
 use harn_vm::event_log::{EventLog, LogEvent, Topic};
+use harn_vm::mcp_protocol;
 use harn_vm::{append_secret_scan_audit, secret_scan_content, SecretFinding};
 
 use crate::cli::{McpServeArgs, McpServeTransport, OrchestratorLocalArgs};
@@ -262,6 +263,15 @@ impl McpOrchestratorService {
             "tools/call" => self.handle_tools_call(id, session, &params).await,
             "resources/list" => self.handle_resources_list(id).await,
             "resources/read" => self.handle_resources_read(id, &params).await,
+            "resources/templates/list" => {
+                harn_vm::jsonrpc::response(id, json!({"resourceTemplates": []}))
+            }
+            "prompts/list" => harn_vm::jsonrpc::response(id, json!({"prompts": []})),
+            "prompts/get" => harn_vm::jsonrpc::error_response(id, -32602, "Unknown prompt"),
+            _ if mcp_protocol::unsupported_latest_spec_method(method).is_some() => {
+                mcp_protocol::unsupported_latest_spec_method_response(id, method)
+                    .expect("checked unsupported MCP method")
+            }
             _ => {
                 harn_vm::jsonrpc::error_response(id, -32601, &format!("Method not found: {method}"))
             }
@@ -505,6 +515,9 @@ impl McpOrchestratorService {
             .get("name")
             .and_then(JsonValue::as_str)
             .unwrap_or_default();
+        if mcp_protocol::requests_task_augmentation(params) {
+            return mcp_protocol::unsupported_task_augmentation_response(id, "tools/call");
+        }
         let arguments = params
             .get("arguments")
             .cloned()
@@ -1644,6 +1657,89 @@ pub fn on_fail(event: TriggerEvent) -> any {
             .as_str()
             .expect("resource text");
         serde_json::from_str(text).unwrap_or_else(|_| json!(text))
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn latest_spec_gap_methods_return_explicit_json_rpc_errors() {
+        let _guard = lock_harn_state();
+        let temp = TempDir::new().unwrap();
+        write_fixture(&temp);
+        let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
+        let mut session = init_session(&service).await;
+
+        for method in mcp_protocol::UNSUPPORTED_LATEST_SPEC_METHODS
+            .iter()
+            .map(|entry| entry.method)
+        {
+            let response = service
+                .handle_request(
+                    &mut session,
+                    harn_vm::jsonrpc::request(99, method, json!({})),
+                )
+                .await;
+            assert_eq!(response["error"]["code"], json!(-32601), "{method}");
+            assert_eq!(response["error"]["data"]["method"], json!(method));
+            assert_eq!(response["error"]["data"]["status"], json!("unsupported"));
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn empty_prompt_and_resource_template_lists_roundtrip() {
+        let _guard = lock_harn_state();
+        let temp = TempDir::new().unwrap();
+        write_fixture(&temp);
+        let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
+        let mut session = init_session(&service).await;
+
+        let templates = service
+            .handle_request(
+                &mut session,
+                harn_vm::jsonrpc::request(10, "resources/templates/list", json!({})),
+            )
+            .await;
+        assert_eq!(templates["result"]["resourceTemplates"], json!([]));
+
+        let prompts = service
+            .handle_request(
+                &mut session,
+                harn_vm::jsonrpc::request(11, "prompts/list", json!({})),
+            )
+            .await;
+        assert_eq!(prompts["result"]["prompts"], json!([]));
+
+        let prompt = service
+            .handle_request(
+                &mut session,
+                harn_vm::jsonrpc::request(12, "prompts/get", json!({"name": "missing"})),
+            )
+            .await;
+        assert_eq!(prompt["error"]["code"], json!(-32602));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tool_call_rejects_task_augmentation() {
+        let _guard = lock_harn_state();
+        let temp = TempDir::new().unwrap();
+        write_fixture(&temp);
+        let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
+        let mut session = init_session(&service).await;
+
+        let response = service
+            .handle_request(
+                &mut session,
+                harn_vm::jsonrpc::request(
+                    100,
+                    "tools/call",
+                    json!({
+                        "name": "harn.trigger.list",
+                        "arguments": {},
+                        "task": {"title": "async please"}
+                    }),
+                ),
+            )
+            .await;
+        assert_eq!(response["error"]["code"], json!(-32602));
+        assert_eq!(response["error"]["data"]["feature"], json!("tasks"));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-serve/src/adapters/mcp.rs
+++ b/crates/harn-serve/src/adapters/mcp.rs
@@ -14,6 +14,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::{stream, StreamExt};
+use harn_vm::mcp_protocol;
 use serde_json::{json, Value as JsonValue};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{mpsc, oneshot};
@@ -408,6 +409,12 @@ impl McpServer {
                 -32602,
                 "Unknown prompt",
             )),
+            _ if mcp_protocol::unsupported_latest_spec_method(method).is_some() => {
+                ImmediateResult::Response(
+                    mcp_protocol::unsupported_latest_spec_method_response(id, method)
+                        .expect("checked unsupported MCP method"),
+                )
+            }
             _ => ImmediateResult::Response(harn_vm::jsonrpc::error_response(
                 id,
                 -32601,
@@ -499,6 +506,12 @@ impl McpServer {
             .and_then(JsonValue::as_str)
             .unwrap_or_default()
             .to_string();
+        if mcp_protocol::requests_task_augmentation(&params) {
+            return Err(mcp_protocol::unsupported_task_augmentation_response(
+                request_id,
+                "tools/call",
+            ));
+        }
         if self.catalog.function(&tool_name).is_none() {
             return Err(harn_vm::jsonrpc::error_response(
                 request_id,
@@ -1277,6 +1290,105 @@ pub fn greet(name: string) -> string {
             .as_str()
             .unwrap()
             .contains("fixture-card"));
+    }
+
+    #[tokio::test]
+    async fn latest_spec_gap_methods_return_explicit_json_rpc_errors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(
+            &script,
+            r#"
+pub fn greet(name: string) -> string {
+  return name
+}
+"#,
+        )
+        .expect("write script");
+        let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+        let server = McpServer::new(McpServerConfig::new(core));
+        let session = SharedSession::new();
+        let _ = server.handle_initialize(
+            json!(1),
+            &session,
+            &json!({
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "clientInfo": {"name": "test", "version": "1"}
+            }),
+        );
+
+        for method in harn_vm::mcp_protocol::UNSUPPORTED_LATEST_SPEC_METHODS
+            .iter()
+            .map(|entry| entry.method)
+        {
+            let response = match server
+                .process_message(
+                    harn_vm::jsonrpc::request(2, method, json!({})),
+                    session.clone(),
+                    AuthRequest::default(),
+                )
+                .await
+            {
+                ImmediateResult::Response(response) => response,
+                ImmediateResult::Accepted | ImmediateResult::Stream(_) => {
+                    panic!("expected error response for {method}")
+                }
+            };
+            assert_eq!(response["error"]["code"], json!(-32601), "{method}");
+            assert_eq!(response["error"]["data"]["method"], json!(method));
+            assert_eq!(response["error"]["data"]["status"], json!("unsupported"));
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_call_rejects_task_augmentation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(
+            &script,
+            r#"
+pub fn greet(name: string) -> string {
+  return name
+}
+"#,
+        )
+        .expect("write script");
+        let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+        let server = McpServer::new(McpServerConfig::new(core));
+        let session = SharedSession::new();
+        let _ = server.handle_initialize(
+            json!(1),
+            &session,
+            &json!({
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "clientInfo": {"name": "test", "version": "1"}
+            }),
+        );
+
+        let response = match server
+            .process_message(
+                harn_vm::jsonrpc::request(
+                    2,
+                    "tools/call",
+                    json!({
+                        "name": "greet",
+                        "arguments": {"name": "alice"},
+                        "task": {"title": "async please"}
+                    }),
+                ),
+                session,
+                AuthRequest::default(),
+            )
+            .await
+        {
+            ImmediateResult::Response(response) => response,
+            ImmediateResult::Accepted | ImmediateResult::Stream(_) => {
+                panic!("expected task-augmentation error response")
+            }
+        };
+
+        assert_eq!(response["error"]["code"], json!(-32602));
+        assert_eq!(response["error"]["data"]["feature"], json!("tasks"));
     }
 
     #[test]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -19,6 +19,7 @@ pub mod llm;
 pub mod llm_config;
 pub mod mcp;
 pub mod mcp_card;
+pub mod mcp_protocol;
 pub mod mcp_registry;
 pub mod mcp_server;
 pub mod metadata;

--- a/crates/harn-vm/src/mcp.rs
+++ b/crates/harn-vm/src/mcp.rs
@@ -183,8 +183,30 @@ async fn stdio_call(
             continue;
         }
 
-        if msg["id"].as_u64() == Some(id) {
+        if msg["id"].as_u64() == Some(id)
+            && (msg.get("result").is_some() || msg.get("error").is_some())
+        {
             return parse_jsonrpc_result(msg);
+        }
+
+        if let Some(response) = client_request_rejection(&msg) {
+            let line = serde_json::to_string(&response)
+                .map_err(|e| VmError::Runtime(format!("MCP serialization error: {e}")))?;
+            inner
+                .stdin
+                .write_all(line.as_bytes())
+                .await
+                .map_err(|e| VmError::Runtime(format!("MCP write error: {e}")))?;
+            inner
+                .stdin
+                .write_all(b"\n")
+                .await
+                .map_err(|e| VmError::Runtime(format!("MCP write error: {e}")))?;
+            inner
+                .stdin
+                .flush()
+                .await
+                .map_err(|e| VmError::Runtime(format!("MCP flush error: {e}")))?;
         }
     }
 }
@@ -484,6 +506,19 @@ fn jsonrpc_error_to_vm_error(error: &serde_json::Value) -> VmError {
     VmError::Thrown(VmValue::String(Rc::from(format!(
         "MCP error ({code}): {message}"
     ))))
+}
+
+fn client_request_rejection(msg: &serde_json::Value) -> Option<serde_json::Value> {
+    let request_id = msg.get("id")?.clone();
+    let method = msg.get("method").and_then(|value| value.as_str())?;
+    crate::mcp_protocol::unsupported_latest_spec_method_response(request_id.clone(), method)
+        .or_else(|| {
+            Some(crate::jsonrpc::error_response(
+                request_id,
+                -32601,
+                &format!("Method not found: {method}"),
+            ))
+        })
 }
 
 async fn mcp_connect_stdio_impl(
@@ -1141,5 +1176,31 @@ mod tests {
         let body = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\"}\n\nevent: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n";
         let parsed = parse_sse_jsonrpc_body(body).unwrap();
         assert_eq!(parsed["result"]["tools"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn client_rejects_unadvertised_server_to_client_requests() {
+        let roots = client_request_rejection(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "roots-1",
+            "method": "roots/list",
+            "params": {}
+        }))
+        .expect("rejection");
+        assert_eq!(roots["error"]["code"], serde_json::json!(-32601));
+        assert_eq!(
+            roots["error"]["data"]["feature"],
+            serde_json::json!("roots")
+        );
+
+        let unknown = client_request_rejection(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "custom-1",
+            "method": "custom/method",
+            "params": {}
+        }))
+        .expect("rejection");
+        assert_eq!(unknown["error"]["code"], serde_json::json!(-32601));
+        assert!(unknown["error"].get("data").is_none());
     }
 }

--- a/crates/harn-vm/src/mcp_protocol.rs
+++ b/crates/harn-vm/src/mcp_protocol.rs
@@ -1,0 +1,164 @@
+//! Shared MCP protocol-version and feature-gap helpers.
+
+use serde_json::{json, Value as JsonValue};
+
+pub const PROTOCOL_VERSION: &str = "2025-11-25";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UnsupportedMcpMethod {
+    pub method: &'static str,
+    pub feature: &'static str,
+    pub role: &'static str,
+    pub reason: &'static str,
+}
+
+pub const UNSUPPORTED_LATEST_SPEC_METHODS: &[UnsupportedMcpMethod] = &[
+    UnsupportedMcpMethod {
+        method: "completion/complete",
+        feature: "completions",
+        role: "server",
+        reason: "Harn does not expose prompt or resource-template argument completion.",
+    },
+    UnsupportedMcpMethod {
+        method: "resources/subscribe",
+        feature: "resource subscriptions",
+        role: "server",
+        reason: "Harn resources are read on demand and are not backed by subscription state.",
+    },
+    UnsupportedMcpMethod {
+        method: "resources/unsubscribe",
+        feature: "resource subscriptions",
+        role: "server",
+        reason: "Harn resources are read on demand and are not backed by subscription state.",
+    },
+    UnsupportedMcpMethod {
+        method: "roots/list",
+        feature: "roots",
+        role: "client",
+        reason: "Harn does not currently expose host root discovery to MCP servers.",
+    },
+    UnsupportedMcpMethod {
+        method: "sampling/createMessage",
+        feature: "sampling",
+        role: "client",
+        reason: "Harn does not currently let MCP servers invoke a client-side model sampler.",
+    },
+    UnsupportedMcpMethod {
+        method: "elicitation/create",
+        feature: "elicitation",
+        role: "client",
+        reason: "Harn does not currently let MCP servers request client-side user elicitation.",
+    },
+    UnsupportedMcpMethod {
+        method: "tasks/get",
+        feature: "tasks",
+        role: "server",
+        reason: "Harn MCP tools execute inline; MCP task polling is not implemented.",
+    },
+    UnsupportedMcpMethod {
+        method: "tasks/result",
+        feature: "tasks",
+        role: "server",
+        reason: "Harn MCP tools execute inline; MCP task result retrieval is not implemented.",
+    },
+    UnsupportedMcpMethod {
+        method: "tasks/list",
+        feature: "tasks",
+        role: "server",
+        reason: "Harn MCP tools execute inline; MCP task listing is not implemented.",
+    },
+    UnsupportedMcpMethod {
+        method: "tasks/cancel",
+        feature: "tasks",
+        role: "server",
+        reason: "Harn MCP cancellation uses notifications/cancelled instead of MCP tasks.",
+    },
+];
+
+pub fn unsupported_latest_spec_method(method: &str) -> Option<&'static UnsupportedMcpMethod> {
+    UNSUPPORTED_LATEST_SPEC_METHODS
+        .iter()
+        .find(|entry| entry.method == method)
+}
+
+pub fn unsupported_latest_spec_method_response(
+    id: impl Into<JsonValue>,
+    method: &str,
+) -> Option<JsonValue> {
+    unsupported_latest_spec_method(method).map(|entry| {
+        crate::jsonrpc::error_response_with_data(
+            id,
+            -32601,
+            &format!("Unsupported MCP method: {method}"),
+            unsupported_method_data(entry),
+        )
+    })
+}
+
+pub fn unsupported_task_augmentation_response(id: impl Into<JsonValue>, method: &str) -> JsonValue {
+    crate::jsonrpc::error_response_with_data(
+        id,
+        -32602,
+        "MCP task-augmented execution is not supported",
+        json!({
+            "type": "mcp.unsupportedFeature",
+            "protocolVersion": PROTOCOL_VERSION,
+            "method": method,
+            "feature": "tasks",
+            "status": "unsupported",
+            "reason": "Harn MCP tools execute inline and do not advertise taskSupport.",
+        }),
+    )
+}
+
+pub fn requests_task_augmentation(params: &JsonValue) -> bool {
+    params.get("task").is_some()
+}
+
+fn unsupported_method_data(entry: &UnsupportedMcpMethod) -> JsonValue {
+    json!({
+        "type": "mcp.unsupportedFeature",
+        "protocolVersion": PROTOCOL_VERSION,
+        "method": entry.method,
+        "feature": entry.feature,
+        "role": entry.role,
+        "status": "unsupported",
+        "reason": entry.reason,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latest_spec_gap_methods_are_explicit() {
+        for method in [
+            "completion/complete",
+            "resources/subscribe",
+            "resources/unsubscribe",
+            "roots/list",
+            "sampling/createMessage",
+            "elicitation/create",
+            "tasks/get",
+            "tasks/result",
+            "tasks/list",
+            "tasks/cancel",
+        ] {
+            let response = unsupported_latest_spec_method_response(json!(1), method)
+                .expect("expected explicit unsupported method");
+            assert_eq!(response["error"]["code"], json!(-32601));
+            assert_eq!(response["error"]["data"]["method"], json!(method));
+            assert_eq!(response["error"]["data"]["status"], json!("unsupported"));
+        }
+    }
+
+    #[test]
+    fn task_augmentation_error_is_json_rpc_shaped() {
+        let response = unsupported_task_augmentation_response(json!("call-1"), "tools/call");
+        assert_eq!(response["jsonrpc"], json!("2.0"));
+        assert_eq!(response["id"], json!("call-1"));
+        assert_eq!(response["error"]["code"], json!(-32602));
+        assert_eq!(response["error"]["data"]["feature"], json!("tasks"));
+    }
+}

--- a/crates/harn-vm/src/mcp_server/server.rs
+++ b/crates/harn-vm/src/mcp_server/server.rs
@@ -115,6 +115,10 @@ impl McpServer {
             "resources/templates/list" => self.handle_resource_templates_list(&id, &params),
             "prompts/list" => self.handle_prompts_list(&id, &params),
             "prompts/get" => self.handle_prompts_get(&id, &params, vm).await,
+            _ if crate::mcp_protocol::unsupported_latest_spec_method(method).is_some() => {
+                crate::mcp_protocol::unsupported_latest_spec_method_response(id.clone(), method)
+                    .expect("checked unsupported MCP method")
+            }
             _ => serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": id,
@@ -208,6 +212,12 @@ impl McpServer {
         vm: &mut Vm,
     ) -> serde_json::Value {
         let tool_name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
+        if crate::mcp_protocol::requests_task_augmentation(params) {
+            return crate::mcp_protocol::unsupported_task_augmentation_response(
+                id.clone(),
+                "tools/call",
+            );
+        }
 
         let tool = match self.tools.iter().find(|t| t.name == tool_name) {
             Some(t) => t,

--- a/crates/harn-vm/src/mcp_server/tests.rs
+++ b/crates/harn-vm/src/mcp_server/tests.rs
@@ -7,6 +7,7 @@ use super::convert::{annotations_to_json, prompt_value_to_messages};
 use super::tool_registry_to_mcp_tools;
 use super::tools_schema::params_to_json_schema;
 use super::uri::match_uri_template;
+use super::McpServer;
 
 #[test]
 fn test_params_to_json_schema_empty() {
@@ -128,4 +129,71 @@ fn test_annotations_to_json() {
 fn test_annotations_empty_returns_none() {
     let d = BTreeMap::new();
     assert!(annotations_to_json(&VmValue::Dict(Rc::new(d))).is_none());
+}
+
+#[tokio::test]
+async fn server_latest_spec_gap_methods_return_explicit_json_rpc_errors() {
+    let server = McpServer::new(
+        "test".to_string(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let mut vm = crate::Vm::new();
+
+    for method in crate::mcp_protocol::UNSUPPORTED_LATEST_SPEC_METHODS
+        .iter()
+        .map(|entry| entry.method)
+    {
+        let response = server
+            .handle_json_rpc(
+                crate::jsonrpc::request(1, method, serde_json::json!({})),
+                &mut vm,
+            )
+            .await
+            .expect("response");
+        assert_eq!(response["error"]["code"], serde_json::json!(-32601));
+        assert_eq!(
+            response["error"]["data"]["method"],
+            serde_json::json!(method)
+        );
+        assert_eq!(
+            response["error"]["data"]["status"],
+            serde_json::json!("unsupported")
+        );
+    }
+}
+
+#[tokio::test]
+async fn server_tool_call_rejects_task_augmentation() {
+    let server = McpServer::new(
+        "test".to_string(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let mut vm = crate::Vm::new();
+    let response = server
+        .handle_json_rpc(
+            crate::jsonrpc::request(
+                1,
+                "tools/call",
+                serde_json::json!({
+                    "name": "missing",
+                    "arguments": {},
+                    "task": {"title": "async please"}
+                }),
+            ),
+            &mut vm,
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response["error"]["code"], serde_json::json!(-32602));
+    assert_eq!(
+        response["error"]["data"]["feature"],
+        serde_json::json!("tasks")
+    );
 }

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -52,6 +52,25 @@ let prompts = mcp_list_prompts(client)
 let prompt = mcp_get_prompt(client, "review", {code: "fn main() {}"})
 ```
 
+### MCP client support matrix
+
+Harn's MCP client negotiates protocol version `2025-11-25` and advertises no
+client-side roots, sampling, elicitation, or task capabilities. Servers should
+therefore treat those features as unavailable when connected to Harn.
+
+| Method or feature | Harn as MCP client |
+|---|---|
+| `initialize`, `notifications/initialized` | Supported |
+| `ping` | Supported when Harn sends it to a server |
+| `tools/list`, `tools/call` | Supported through `mcp_list_tools` and `mcp_call` |
+| `resources/list`, `resources/read`, `resources/templates/list` | Supported through resource builtins |
+| `prompts/list`, `prompts/get` | Supported through prompt builtins |
+| `completion/complete` | Not exposed as a Harn builtin |
+| `roots/list` | Unsupported; Harn does not advertise roots |
+| `sampling/createMessage` | Unsupported; Harn does not advertise sampling |
+| `elicitation/create` | Unsupported; Harn does not advertise elicitation |
+| MCP task methods and task-augmented requests | Unsupported; Harn does not advertise task support |
+
 ### Disconnecting
 
 ```harn
@@ -333,6 +352,28 @@ above and serves the appropriate one over stdio or Streamable HTTP. All
 `print`/`println` output goes to stderr when stdio is the MCP transport.
 The server supports the `2025-11-25` MCP protocol version on both
 transports.
+
+### MCP server support matrix
+
+Harn's MCP servers implement the core tool/resource/prompt path and explicitly
+reject latest-spec features that are out of scope for this release with a
+JSON-RPC error containing `error.data.type = "mcp.unsupportedFeature"`.
+
+| Method or feature | Harn as MCP server |
+|---|---|
+| `initialize`, `notifications/initialized`, `ping` | Supported |
+| `logging/setLevel` | Accepted |
+| `tools/list`, `tools/call` | Supported |
+| `notifications/progress`, `notifications/cancelled` | Supported for long-running tool calls |
+| `resources/list`, `resources/read`, `resources/templates/list` | Supported for registered entries and cards |
+| `prompts/list`, `prompts/get` | Supported for registered prompts |
+| `completion/complete` | Explicitly unsupported |
+| `resources/subscribe`, `resources/unsubscribe` | Explicitly unsupported |
+| `roots/list` | Explicitly unsupported; client-side roots are not served by Harn |
+| `sampling/createMessage` | Explicitly unsupported; Harn does not let connected servers invoke sampling |
+| `elicitation/create` | Explicitly unsupported; Harn does not expose client-side elicitation |
+| `tasks/get`, `tasks/result`, `tasks/list`, `tasks/cancel` | Explicitly unsupported |
+| `tools/call` with `params.task` | Rejected with `-32602`; task-augmented execution is not advertised |
 
 #### Publishing a Server Card
 

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -215,6 +215,37 @@ The server exposes these MCP resources:
 `harn://event/<event_id>` includes the recorded trigger event plus related
 outbox/attempt/DLQ/action-graph trace entries.
 
+## Protocol Support
+
+`harn mcp serve` negotiates MCP protocol version `2025-11-25`. It is a
+control-plane server for Harn orchestration state, so it supports tools,
+resources, logging, cancellation, progress, and streamable HTTP sessions. It
+does not expose prompts, completions, resource subscriptions, roots, sampling,
+elicitation, or MCP tasks.
+
+| Method or feature | Status |
+|---|---|
+| `initialize`, `notifications/initialized`, `ping` | Supported |
+| `logging/setLevel` | Accepted |
+| `tools/list`, `tools/call` | Supported for the Harn tool catalog above |
+| `notifications/progress`, `notifications/cancelled` | Supported for cancellable work |
+| `resources/list`, `resources/read` | Supported for manifest, event, and DLQ resources |
+| `resources/templates/list` | Supported; returns an empty list |
+| `prompts/list` | Supported; returns an empty list |
+| `prompts/get` | Supported error for unknown prompts; the orchestrator server exposes no prompts |
+| `completion/complete` | Explicitly unsupported |
+| `resources/subscribe`, `resources/unsubscribe` | Explicitly unsupported |
+| `roots/list` | Explicitly unsupported |
+| `sampling/createMessage` | Explicitly unsupported |
+| `elicitation/create` | Explicitly unsupported |
+| `tasks/get`, `tasks/result`, `tasks/list`, `tasks/cancel` | Explicitly unsupported |
+| `tools/call` with `params.task` | Rejected; task-augmented execution is not advertised |
+
+Explicitly unsupported methods return a JSON-RPC error with code `-32601` and
+`error.data.type = "mcp.unsupportedFeature"`. Tool calls that request
+task-augmented execution return `-32602` because the request parameters ask for
+a capability Harn does not advertise.
+
 ## Observability
 
 Every MCP tool call appends an `observability.action_graph` event and emits a


### PR DESCRIPTION
## Summary
- add a shared MCP latest-spec feature-gap helper with explicit JSON-RPC unsupported-feature errors
- wire unsupported completion/resource-subscription/roots/sampling/elicitation/task methods through Harn MCP client/server paths
- document MCP client/server support matrices in the MCP guides

Closes #809.

## Tests
- cargo test -p harn-vm latest_spec_gap_methods
- cargo test -p harn-vm client_rejects_unadvertised_server_to_client_requests
- cargo test -p harn-vm task_augmentation_error_is_json_rpc_shaped
- cargo test -p harn-vm server_tool_call_rejects_task_augmentation
- cargo test -p harn-serve latest_spec_gap_methods
- cargo test -p harn-serve tool_call_rejects_task_augmentation
- cargo test -p harn-cli latest_spec_gap_methods
- cargo test -p harn-cli tool_call_rejects_task_augmentation
- cargo test -p harn-cli empty_prompt_and_resource_template_lists_roundtrip
- pre-commit hook: cargo fmt, workspace clippy, highlight keyword sync, markdown lint
- pre-push hook: 2863 nextest tests, markdown lint, configured fast checks