### PR TITLE
Add protocol conformance gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
         env:
           NEXTEST_PROFILE: ci
       - run: make conformance
+      - run: make protocol-conformance
       - run: make lint-harn
       - run: make fmt-harn
       # Audit gates promoted from release_gate.sh audit so a stale

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,7 +103,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -100,7 +114,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -407,6 +421,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +463,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -1189,6 +1215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,7 +1254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1266,6 +1301,17 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -1318,6 +1364,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1399,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1641,6 +1708,7 @@ dependencies = [
  "hmac 0.13.0",
  "include_dir",
  "jmespath",
+ "jsonschema",
  "notify",
  "nu-ansi-term",
  "rand 0.10.1",
@@ -1909,6 +1977,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -2435,6 +2505,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.46.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbe92a2f8b00686061eab5cdcfd6f382c27f2084456e7be90ae9f0fe4a30552a"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,6 +2745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2740,7 +2843,21 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -2750,6 +2867,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -2765,6 +2897,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2912,6 +3066,12 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking"
@@ -3385,6 +3545,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.46.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e125f10bdcd507598c702daada18c47fe5bfba4d7a9545b015b5d432f7168ca3"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3546,7 +3743,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3965,7 +4162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4181,7 +4378,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4906,6 +5103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4995,6 +5198,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5011,6 +5224,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"
@@ -5267,7 +5486,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup install-hooks configure-merge-drivers check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-cargo test-fast conformance bench-vm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref check-trigger-examples check-docs-snippets sync-language-spec check-language-spec
+.PHONY: setup install-hooks configure-merge-drivers check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-cargo test-fast conformance protocol-conformance bench-vm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref check-trigger-examples check-docs-snippets sync-language-spec check-language-spec
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test conformance check-highlight check-language-spec check-trigger-quickref check-trigger-examples check-docs-snippets portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test conformance protocol-conformance check-highlight check-language-spec check-trigger-quickref check-trigger-examples check-docs-snippets portal-check
 
 check: all
 
@@ -49,6 +49,9 @@ test-fast:
 # Run Harn conformance test suite
 conformance:
 	HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test conformance
+
+protocol-conformance:
+	HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test protocols
 
 bench-vm:
 	./scripts/bench_vm.sh

--- a/conformance/protocols/README.md
+++ b/conformance/protocols/README.md
@@ -1,0 +1,23 @@
+# Protocol conformance fixtures
+
+`harn test protocols` validates checked-in ACP, A2A, and MCP JSON wire fixtures
+against pinned JSON Schema snapshots. This gate is intentionally separate from
+`harn test conformance`, which remains the executable Harn language/runtime
+suite.
+
+The schemas are compact Harn adapter profiles derived from the public protocol
+schemas/specifications cited in each schema file. They pin the protocol surface
+Harn currently emits or accepts and include negative fixtures for unsupported
+versions, missing required fields, and unsupported extension discriminators.
+
+Run:
+
+```sh
+make protocol-conformance
+```
+
+or:
+
+```sh
+cargo run --bin harn -- test protocols
+```

--- a/conformance/protocols/fixtures/a2a/agent_card.valid.json
+++ b/conformance/protocols/fixtures/a2a/agent_card.valid.json
@@ -1,0 +1,46 @@
+{
+  "name": "a2a.agent_card.discovery",
+  "protocol": "a2a",
+  "schema": "schemas/a2a-1.0.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "name": "reviewer",
+      "description": "Harn peer agent",
+      "supportedInterfaces": [
+        {
+          "url": "https://agent.example.com/a2a",
+          "protocolBinding": "JSONRPC",
+          "protocolVersion": "1.0"
+        }
+      ],
+      "version": "0.7.48",
+      "provider": {
+        "organization": "Harn",
+        "url": "https://harn.dev"
+      },
+      "securitySchemes": {},
+      "security": [],
+      "defaultInputModes": ["application/json", "text/plain"],
+      "defaultOutputModes": ["application/json", "text/plain"],
+      "capabilities": {
+        "streaming": true,
+        "pushNotifications": true,
+        "extendedAgentCard": false
+      },
+      "skills": [
+        {
+          "id": "review",
+          "name": "review",
+          "description": "Invoke exported Harn function 'review'.",
+          "tags": ["harn", "function"],
+          "inputModes": ["application/json", "text/plain"],
+          "outputModes": ["application/json", "text/plain"],
+          "inputSchema": {
+            "type": "object"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/conformance/protocols/fixtures/a2a/agent_card_missing_supported_interfaces.invalid.json
+++ b/conformance/protocols/fixtures/a2a/agent_card_missing_supported_interfaces.invalid.json
@@ -1,0 +1,17 @@
+{
+  "name": "a2a.agent_card.missing_supported_interfaces",
+  "protocol": "a2a",
+  "schema": "schemas/a2a-1.0.schema.json",
+  "expect": "invalid",
+  "documents": [
+    {
+      "name": "legacy-agent",
+      "description": "Legacy discovery shape",
+      "url": "https://agent.example.com/rpc",
+      "protocolVersion": "1.0",
+      "version": "0.7.48",
+      "capabilities": {},
+      "skills": []
+    }
+  ]
+}

--- a/conformance/protocols/fixtures/a2a/task_and_stream.valid.json
+++ b/conformance/protocols/fixtures/a2a/task_and_stream.valid.json
@@ -1,0 +1,64 @@
+{
+  "name": "a2a.task_and_stream.messages",
+  "protocol": "a2a",
+  "schema": "schemas/a2a-1.0.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "SendMessage",
+      "params": {
+        "message": {
+          "id": "msg-1",
+          "role": "user",
+          "parts": [
+            {
+              "text": "Review this patch"
+            }
+          ]
+        },
+        "configuration": {
+          "returnImmediately": true
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "id": "task-1",
+        "contextId": "ctx-1",
+        "status": {
+          "state": "working"
+        },
+        "history": [
+          {
+            "id": "msg-1",
+            "role": "user",
+            "parts": [
+              {
+                "type": "text",
+                "text": "Review this patch"
+              }
+            ]
+          }
+        ],
+        "artifacts": []
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": null,
+      "result": {
+        "statusUpdate": {
+          "taskId": "task-1",
+          "contextId": "ctx-1",
+          "status": {
+            "state": "completed"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/conformance/protocols/fixtures/a2a/unsupported_interface_version.invalid.json
+++ b/conformance/protocols/fixtures/a2a/unsupported_interface_version.invalid.json
@@ -1,0 +1,22 @@
+{
+  "name": "a2a.agent_card.unsupported_interface_version",
+  "protocol": "a2a",
+  "schema": "schemas/a2a-1.0.schema.json",
+  "expect": "invalid",
+  "documents": [
+    {
+      "name": "reviewer",
+      "description": "Harn peer agent",
+      "supportedInterfaces": [
+        {
+          "url": "https://agent.example.com/a2a",
+          "protocolBinding": "JSONRPC",
+          "protocolVersion": "0.2"
+        }
+      ],
+      "version": "0.7.48",
+      "capabilities": {},
+      "skills": []
+    }
+  ]
+}

--- a/conformance/protocols/fixtures/acp/session_update_extensions.valid.json
+++ b/conformance/protocols/fixtures/acp/session_update_extensions.valid.json
@@ -1,0 +1,58 @@
+{
+  "name": "acp.session_update.harn_extensions",
+  "protocol": "acp",
+  "schema": "schemas/acp-session-update.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "sessionUpdate": "skill_activated",
+          "skillName": "rust-review",
+          "iteration": 1,
+          "reason": "matched"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "sessionUpdate": "tool_search_query",
+          "toolUseId": "search-1",
+          "name": "tool_search",
+          "query": {
+            "q": "filesystem read"
+          },
+          "strategy": "bm25",
+          "mode": "client"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "sessionUpdate": "worker_update",
+          "workerId": "worker-1",
+          "workerName": "reviewer",
+          "workerTask": "review patch",
+          "workerMode": "delegated_stage",
+          "event": "worker_waiting_for_input",
+          "status": "awaiting_input",
+          "terminal": false,
+          "metadata": {
+            "child_run_id": "run_1"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/conformance/protocols/fixtures/acp/session_update_missing_session.invalid.json
+++ b/conformance/protocols/fixtures/acp/session_update_missing_session.invalid.json
@@ -1,0 +1,21 @@
+{
+  "name": "acp.session_update.missing_session_id",
+  "protocol": "acp",
+  "schema": "schemas/acp-session-update.schema.json",
+  "expect": "invalid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "update": {
+          "sessionUpdate": "agent_message_chunk",
+          "content": {
+            "type": "text",
+            "text": "missing session id"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/conformance/protocols/fixtures/acp/session_update_standard.valid.json
+++ b/conformance/protocols/fixtures/acp/session_update_standard.valid.json
@@ -1,0 +1,59 @@
+{
+  "name": "acp.session_update.standard",
+  "protocol": "acp",
+  "schema": "schemas/acp-session-update.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "sessionUpdate": "agent_message_chunk",
+          "content": {
+            "type": "text",
+            "text": "hello",
+            "visible_text": "hello",
+            "visible_delta": "hello"
+          }
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tool-1",
+          "title": "read_file",
+          "status": "completed",
+          "durationMs": 8,
+          "executionDurationMs": 6,
+          "executor": "harn_builtin",
+          "rawOutput": {
+            "ok": true
+          }
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "sessionUpdate": "plan",
+          "entries": [
+            {
+              "content": "inspect protocol fixtures",
+              "status": "completed"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/conformance/protocols/fixtures/acp/session_update_unknown_extension.invalid.json
+++ b/conformance/protocols/fixtures/acp/session_update_unknown_extension.invalid.json
@@ -1,0 +1,19 @@
+{
+  "name": "acp.session_update.unknown_extension",
+  "protocol": "acp",
+  "schema": "schemas/acp-session-update.schema.json",
+  "expect": "invalid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "sessionUpdate": "unadvertised_harn_extension",
+          "payload": true
+        }
+      }
+    }
+  ]
+}

--- a/conformance/protocols/fixtures/mcp/initialize.valid.json
+++ b/conformance/protocols/fixtures/mcp/initialize.valid.json
@@ -1,0 +1,43 @@
+{
+  "name": "mcp.initialize.2025_11_25",
+  "protocol": "mcp",
+  "schema": "schemas/mcp-2025-11-25.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "initialize",
+      "params": {
+        "protocolVersion": "2025-11-25",
+        "capabilities": {},
+        "clientInfo": {
+          "name": "harn-protocol-conformance",
+          "version": "0.1.0"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "protocolVersion": "2025-11-25",
+        "capabilities": {
+          "tools": {},
+          "resources": {},
+          "prompts": {},
+          "logging": {}
+        },
+        "serverInfo": {
+          "name": "harn",
+          "version": "0.7.48"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "notifications/initialized",
+      "params": {}
+    }
+  ]
+}

--- a/conformance/protocols/fixtures/mcp/initialize_unsupported_version.invalid.json
+++ b/conformance/protocols/fixtures/mcp/initialize_unsupported_version.invalid.json
@@ -1,0 +1,21 @@
+{
+  "name": "mcp.initialize.unsupported_version",
+  "protocol": "mcp",
+  "schema": "schemas/mcp-2025-11-25.schema.json",
+  "expect": "invalid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "initialize",
+      "params": {
+        "protocolVersion": "1900-01-01",
+        "capabilities": {},
+        "clientInfo": {
+          "name": "old-client",
+          "version": "0.0.1"
+        }
+      }
+    }
+  ]
+}

--- a/conformance/protocols/fixtures/mcp/tools_missing_jsonrpc.invalid.json
+++ b/conformance/protocols/fixtures/mcp/tools_missing_jsonrpc.invalid.json
@@ -1,0 +1,13 @@
+{
+  "name": "mcp.tools_list.missing_jsonrpc",
+  "protocol": "mcp",
+  "schema": "schemas/mcp-2025-11-25.schema.json",
+  "expect": "invalid",
+  "documents": [
+    {
+      "id": 2,
+      "method": "tools/list",
+      "params": {}
+    }
+  ]
+}

--- a/conformance/protocols/fixtures/mcp/tools_resources_prompts.valid.json
+++ b/conformance/protocols/fixtures/mcp/tools_resources_prompts.valid.json
@@ -1,0 +1,81 @@
+{
+  "name": "mcp.tools_resources_prompts.lists",
+  "protocol": "mcp",
+  "schema": "schemas/mcp-2025-11-25.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "method": "tools/list",
+      "params": {}
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "result": {
+        "tools": [
+          {
+            "name": "echo",
+            "description": "Echo input",
+            "inputSchema": {
+              "type": "object",
+              "properties": {
+                "text": {
+                  "type": "string"
+                }
+              }
+            },
+            "annotations": {
+              "readOnlyHint": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 3,
+      "result": {
+        "resources": [
+          {
+            "uri": "harn://resource/readme",
+            "name": "README",
+            "mimeType": "text/markdown"
+          }
+        ]
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 4,
+      "result": {
+        "resourceTemplates": [
+          {
+            "uriTemplate": "harn://resource/{name}",
+            "name": "named-resource",
+            "mimeType": "text/plain"
+          }
+        ]
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 5,
+      "result": {
+        "prompts": [
+          {
+            "name": "review",
+            "description": "Review a change",
+            "arguments": [
+              {
+                "name": "diff",
+                "required": true
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/conformance/protocols/schemas/a2a-1.0.schema.json
+++ b/conformance/protocols/schemas/a2a-1.0.schema.json
@@ -1,0 +1,320 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/conformance/protocols/a2a-1.0.schema.json",
+  "title": "Harn A2A 1.0 adapter profile",
+  "description": "Pinned profile derived from the A2A specification and a2aproject/A2A specification/a2a.proto for the JSON-RPC/card/task surface Harn serves.",
+  "anyOf": [
+    { "$ref": "#/$defs/AgentCard" },
+    { "$ref": "#/$defs/JsonRpcRequest" },
+    { "$ref": "#/$defs/JsonRpcResultResponse" },
+    { "$ref": "#/$defs/JsonRpcErrorResponse" },
+    { "$ref": "#/$defs/StreamEventResponse" }
+  ],
+  "$defs": {
+    "AgentCard": {
+      "type": "object",
+      "required": [
+        "name",
+        "description",
+        "supportedInterfaces",
+        "version",
+        "capabilities",
+        "skills"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "supportedInterfaces": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/AgentInterface" }
+        },
+        "version": { "type": "string", "minLength": 1 },
+        "provider": { "type": "object" },
+        "capabilities": { "$ref": "#/$defs/AgentCapabilities" },
+        "skills": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/AgentSkill" }
+        },
+        "securitySchemes": { "type": "object" },
+        "security": { "type": "array" },
+        "defaultInputModes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "defaultOutputModes": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "not": {
+        "anyOf": [
+          { "required": ["protocolVersion"] },
+          { "required": ["interfaces"] },
+          { "required": ["url"] }
+        ]
+      }
+    },
+    "AgentInterface": {
+      "type": "object",
+      "required": ["url", "protocolBinding", "protocolVersion"],
+      "additionalProperties": true,
+      "properties": {
+        "url": { "type": "string", "format": "uri" },
+        "protocolBinding": {
+          "enum": ["JSONRPC", "GRPC", "HTTP+JSON"]
+        },
+        "protocolVersion": { "const": "1.0" }
+      }
+    },
+    "AgentCapabilities": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "streaming": { "type": "boolean" },
+        "pushNotifications": { "type": "boolean" },
+        "stateTransitionHistory": { "type": "boolean" },
+        "extendedAgentCard": { "type": "boolean" }
+      }
+    },
+    "AgentSkill": {
+      "type": "object",
+      "required": ["id", "name", "description"],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "inputModes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "outputModes": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "JsonRpcRequest": {
+      "type": "object",
+      "required": ["jsonrpc", "id", "method"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/RequestId" },
+        "method": {
+          "enum": [
+            "SendMessage",
+            "SendStreamingMessage",
+            "GetTask",
+            "ListTasks",
+            "CancelTask",
+            "SubscribeToTask",
+            "GetExtendedAgentCard",
+            "a2a.SendMessage",
+            "a2a.SendStreamingMessage",
+            "a2a.GetTask",
+            "a2a.ListTasks",
+            "a2a.CancelTask",
+            "a2a.ResubscribeTask",
+            "tasks/send",
+            "tasks/send_and_wait",
+            "tasks/sendSubscribe",
+            "tasks/get",
+            "tasks/list",
+            "tasks/cancel",
+            "tasks/resubscribe"
+          ]
+        },
+        "params": { "type": "object" }
+      }
+    },
+    "JsonRpcResultResponse": {
+      "type": "object",
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/RequestId" },
+        "result": {
+          "oneOf": [
+            { "$ref": "#/$defs/Task" },
+            { "$ref": "#/$defs/TaskList" },
+            { "$ref": "#/$defs/TaskEvent" },
+            { "$ref": "#/$defs/Message" }
+          ]
+        }
+      }
+    },
+    "StreamEventResponse": {
+      "type": "object",
+      "required": ["jsonrpc", "result"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": {},
+        "result": { "$ref": "#/$defs/TaskEvent" }
+      }
+    },
+    "JsonRpcErrorResponse": {
+      "type": "object",
+      "required": ["jsonrpc", "error"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": {},
+        "error": {
+          "type": "object",
+          "required": ["code", "message"],
+          "additionalProperties": true,
+          "properties": {
+            "code": { "type": "integer" },
+            "message": { "type": "string" }
+          }
+        }
+      }
+    },
+    "RequestId": {
+      "type": ["string", "integer", "null"]
+    },
+    "TaskList": {
+      "type": "object",
+      "required": ["tasks"],
+      "additionalProperties": true,
+      "properties": {
+        "tasks": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Task" }
+        }
+      }
+    },
+    "Task": {
+      "type": "object",
+      "required": ["id", "status"],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "contextId": { "type": ["string", "null"] },
+        "status": { "$ref": "#/$defs/TaskStatus" },
+        "history": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Message" }
+        },
+        "artifacts": { "type": "array" },
+        "metadata": { "type": "object" }
+      }
+    },
+    "TaskStatus": {
+      "type": "object",
+      "required": ["state"],
+      "additionalProperties": true,
+      "properties": {
+        "state": {
+          "enum": [
+            "submitted",
+            "working",
+            "completed",
+            "failed",
+            "canceled",
+            "cancelled",
+            "input_required",
+            "rejected",
+            "auth_required"
+          ]
+        },
+        "message": { "$ref": "#/$defs/Message" },
+        "timestamp": { "type": "string" }
+      }
+    },
+    "Message": {
+      "type": "object",
+      "required": ["id", "role", "parts"],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "role": { "enum": ["user", "agent"] },
+        "parts": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/Part" }
+        }
+      }
+    },
+    "Part": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["text"],
+          "not": { "required": ["type"] },
+          "additionalProperties": true,
+          "properties": {
+            "text": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type", "text"],
+          "additionalProperties": true,
+          "properties": {
+            "type": { "const": "text" },
+            "text": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["data"],
+          "additionalProperties": true,
+          "properties": {
+            "data": {},
+            "mediaType": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "TaskEvent": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["statusUpdate"],
+          "additionalProperties": true,
+          "properties": {
+            "statusUpdate": {
+              "type": "object",
+              "required": ["taskId", "status"],
+              "additionalProperties": true,
+              "properties": {
+                "taskId": { "type": "string", "minLength": 1 },
+                "contextId": { "type": ["string", "null"] },
+                "status": { "$ref": "#/$defs/TaskStatus" }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type", "taskId", "status"],
+          "additionalProperties": true,
+          "properties": {
+            "type": { "const": "status" },
+            "taskId": { "type": "string", "minLength": 1 },
+            "status": { "$ref": "#/$defs/TaskStatus" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type", "taskId", "message"],
+          "additionalProperties": true,
+          "properties": {
+            "type": { "enum": ["message", "worker_update"] },
+            "taskId": { "type": "string", "minLength": 1 }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/conformance/protocols/schemas/acp-session-update.schema.json
+++ b/conformance/protocols/schemas/acp-session-update.schema.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/conformance/protocols/acp-session-update.schema.json",
+  "title": "Harn ACP session/update profile",
+  "description": "Pinned profile derived from agentclientprotocol/agent-client-protocol schema v0.12.2 plus Harn-advertised session/update extensions.",
+  "type": "object",
+  "required": ["jsonrpc", "method", "params"],
+  "additionalProperties": true,
+  "properties": {
+    "jsonrpc": { "const": "2.0" },
+    "method": { "const": "session/update" },
+    "params": { "$ref": "#/$defs/SessionUpdateParams" }
+  },
+  "$defs": {
+    "SessionUpdateParams": {
+      "type": "object",
+      "required": ["sessionId", "update"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionId": { "type": "string", "minLength": 1 },
+        "update": { "$ref": "#/$defs/SessionUpdate" }
+      }
+    },
+    "SessionUpdate": {
+      "oneOf": [
+        { "$ref": "#/$defs/UserMessageChunk" },
+        { "$ref": "#/$defs/AgentMessageChunk" },
+        { "$ref": "#/$defs/AgentThoughtChunk" },
+        { "$ref": "#/$defs/ToolCall" },
+        { "$ref": "#/$defs/ToolCallUpdate" },
+        { "$ref": "#/$defs/Plan" },
+        { "$ref": "#/$defs/SessionInfoUpdate" },
+        { "$ref": "#/$defs/SkillActivated" },
+        { "$ref": "#/$defs/SkillDeactivated" },
+        { "$ref": "#/$defs/SkillScopeTools" },
+        { "$ref": "#/$defs/ToolSearchQuery" },
+        { "$ref": "#/$defs/ToolSearchResult" },
+        { "$ref": "#/$defs/TranscriptCompacted" },
+        { "$ref": "#/$defs/Handoff" },
+        { "$ref": "#/$defs/FsWatch" },
+        { "$ref": "#/$defs/WorkerUpdate" }
+      ]
+    },
+    "ContentBlock": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": true,
+      "properties": {
+        "type": { "enum": ["text", "resource_link", "resource", "image", "audio"] },
+        "text": { "type": "string" }
+      }
+    },
+    "UserMessageChunk": {
+      "type": "object",
+      "required": ["sessionUpdate"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "user_message_chunk" },
+        "content": { "$ref": "#/$defs/ContentBlock" }
+      }
+    },
+    "AgentMessageChunk": {
+      "type": "object",
+      "required": ["sessionUpdate", "content"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "agent_message_chunk" },
+        "content": { "$ref": "#/$defs/ContentBlock" }
+      }
+    },
+    "AgentThoughtChunk": {
+      "type": "object",
+      "required": ["sessionUpdate", "content"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "agent_thought_chunk" },
+        "content": { "$ref": "#/$defs/ContentBlock" }
+      }
+    },
+    "ToolCall": {
+      "type": "object",
+      "required": ["sessionUpdate", "toolCallId", "title"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "tool_call" },
+        "toolCallId": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "status": { "$ref": "#/$defs/ToolCallStatus" }
+      }
+    },
+    "ToolCallUpdate": {
+      "type": "object",
+      "required": ["sessionUpdate", "toolCallId"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "tool_call_update" },
+        "toolCallId": { "type": "string", "minLength": 1 },
+        "title": { "type": ["string", "null"] },
+        "status": { "$ref": "#/$defs/NullableToolCallStatus" },
+        "durationMs": { "type": "number", "minimum": 0 },
+        "executionDurationMs": { "type": "number", "minimum": 0 }
+      }
+    },
+    "ToolCallStatus": {
+      "enum": ["pending", "in_progress", "completed", "failed"]
+    },
+    "NullableToolCallStatus": {
+      "anyOf": [
+        { "$ref": "#/$defs/ToolCallStatus" },
+        { "type": "null" }
+      ]
+    },
+    "Plan": {
+      "type": "object",
+      "required": ["sessionUpdate", "entries"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "plan" },
+        "entries": { "type": "array" }
+      }
+    },
+    "SessionInfoUpdate": {
+      "type": "object",
+      "required": ["sessionUpdate"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "session_info_update" }
+      }
+    },
+    "SkillActivated": {
+      "type": "object",
+      "required": ["sessionUpdate", "skillName"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "skill_activated" },
+        "skillName": { "type": "string", "minLength": 1 },
+        "iteration": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "SkillDeactivated": {
+      "type": "object",
+      "required": ["sessionUpdate", "skillName"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "skill_deactivated" },
+        "skillName": { "type": "string", "minLength": 1 }
+      }
+    },
+    "SkillScopeTools": {
+      "type": "object",
+      "required": ["sessionUpdate", "skillName", "allowedTools"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "skill_scope_tools" },
+        "skillName": { "type": "string", "minLength": 1 },
+        "allowedTools": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "ToolSearchQuery": {
+      "type": "object",
+      "required": ["sessionUpdate", "toolUseId", "name", "query"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "tool_search_query" },
+        "toolUseId": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "query": {}
+      }
+    },
+    "ToolSearchResult": {
+      "type": "object",
+      "required": ["sessionUpdate", "toolUseId", "promoted"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "tool_search_result" },
+        "toolUseId": { "type": "string", "minLength": 1 },
+        "promoted": { "type": "array" }
+      }
+    },
+    "TranscriptCompacted": {
+      "type": "object",
+      "required": ["sessionUpdate", "mode", "strategy"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "transcript_compacted" },
+        "mode": { "type": "string" },
+        "strategy": { "type": "string" }
+      }
+    },
+    "Handoff": {
+      "type": "object",
+      "required": ["sessionUpdate", "handoffId", "artifactId", "handoff"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "handoff" },
+        "handoffId": { "type": "string", "minLength": 1 },
+        "artifactId": { "type": "string", "minLength": 1 },
+        "handoff": { "type": "object" }
+      }
+    },
+    "FsWatch": {
+      "type": "object",
+      "required": ["sessionUpdate", "subscriptionId", "events"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "fs_watch" },
+        "subscriptionId": { "type": "string", "minLength": 1 },
+        "events": { "type": "array" }
+      }
+    },
+    "WorkerUpdate": {
+      "type": "object",
+      "required": ["sessionUpdate", "workerId", "event", "status", "terminal"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "worker_update" },
+        "workerId": { "type": "string", "minLength": 1 },
+        "event": { "type": "string", "minLength": 1 },
+        "status": { "type": "string", "minLength": 1 },
+        "terminal": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/conformance/protocols/schemas/mcp-2025-11-25.schema.json
+++ b/conformance/protocols/schemas/mcp-2025-11-25.schema.json
@@ -1,0 +1,271 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/conformance/protocols/mcp-2025-11-25.schema.json",
+  "title": "Harn MCP 2025-11-25 adapter profile",
+  "description": "Pinned profile derived from modelcontextprotocol/modelcontextprotocol schema/2025-11-25/schema.json for initialize, tools, resources, and prompts.",
+  "oneOf": [
+    { "$ref": "#/$defs/InitializeRequest" },
+    { "$ref": "#/$defs/ListToolsRequest" },
+    { "$ref": "#/$defs/ListResourcesRequest" },
+    { "$ref": "#/$defs/ListResourceTemplatesRequest" },
+    { "$ref": "#/$defs/ListPromptsRequest" },
+    { "$ref": "#/$defs/JsonRpcResultResponse" },
+    { "$ref": "#/$defs/JsonRpcErrorResponse" },
+    { "$ref": "#/$defs/InitializedNotification" }
+  ],
+  "$defs": {
+    "RequestId": {
+      "type": ["string", "integer"]
+    },
+    "JsonRpcRequestBase": {
+      "type": "object",
+      "required": ["jsonrpc", "id", "method"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/RequestId" },
+        "params": { "type": "object" }
+      }
+    },
+    "InitializeRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/JsonRpcRequestBase" },
+        {
+          "type": "object",
+          "required": ["params"],
+          "properties": {
+            "method": { "const": "initialize" },
+            "params": {
+              "type": "object",
+              "required": ["protocolVersion", "capabilities", "clientInfo"],
+              "additionalProperties": true,
+              "properties": {
+                "protocolVersion": { "const": "2025-11-25" },
+                "capabilities": { "type": "object" },
+                "clientInfo": { "$ref": "#/$defs/Implementation" }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "ListToolsRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/JsonRpcRequestBase" },
+        {
+          "type": "object",
+          "properties": {
+            "method": { "const": "tools/list" }
+          }
+        }
+      ]
+    },
+    "ListResourcesRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/JsonRpcRequestBase" },
+        {
+          "type": "object",
+          "properties": {
+            "method": { "const": "resources/list" }
+          }
+        }
+      ]
+    },
+    "ListResourceTemplatesRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/JsonRpcRequestBase" },
+        {
+          "type": "object",
+          "properties": {
+            "method": { "const": "resources/templates/list" }
+          }
+        }
+      ]
+    },
+    "ListPromptsRequest": {
+      "allOf": [
+        { "$ref": "#/$defs/JsonRpcRequestBase" },
+        {
+          "type": "object",
+          "properties": {
+            "method": { "const": "prompts/list" }
+          }
+        }
+      ]
+    },
+    "InitializedNotification": {
+      "type": "object",
+      "required": ["jsonrpc", "method"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "method": { "const": "notifications/initialized" },
+        "params": { "type": "object" }
+      }
+    },
+    "JsonRpcResultResponse": {
+      "type": "object",
+      "required": ["jsonrpc", "id", "result"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": { "$ref": "#/$defs/RequestId" },
+        "result": {
+          "oneOf": [
+            { "$ref": "#/$defs/InitializeResult" },
+            { "$ref": "#/$defs/ListToolsResult" },
+            { "$ref": "#/$defs/ListResourcesResult" },
+            { "$ref": "#/$defs/ListResourceTemplatesResult" },
+            { "$ref": "#/$defs/ListPromptsResult" }
+          ]
+        }
+      }
+    },
+    "JsonRpcErrorResponse": {
+      "type": "object",
+      "required": ["jsonrpc", "id", "error"],
+      "additionalProperties": true,
+      "properties": {
+        "jsonrpc": { "const": "2.0" },
+        "id": {},
+        "error": {
+          "type": "object",
+          "required": ["code", "message"],
+          "additionalProperties": true,
+          "properties": {
+            "code": { "type": "integer" },
+            "message": { "type": "string" }
+          }
+        }
+      }
+    },
+    "InitializeResult": {
+      "type": "object",
+      "required": ["protocolVersion", "capabilities", "serverInfo"],
+      "additionalProperties": true,
+      "properties": {
+        "protocolVersion": { "const": "2025-11-25" },
+        "capabilities": { "$ref": "#/$defs/ServerCapabilities" },
+        "serverInfo": { "$ref": "#/$defs/Implementation" }
+      }
+    },
+    "Implementation": {
+      "type": "object",
+      "required": ["name", "version"],
+      "additionalProperties": true,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 }
+      }
+    },
+    "ServerCapabilities": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "tools": { "type": "object" },
+        "resources": { "type": "object" },
+        "prompts": { "type": "object" },
+        "logging": { "type": "object" }
+      }
+    },
+    "ListToolsResult": {
+      "type": "object",
+      "required": ["tools"],
+      "additionalProperties": true,
+      "properties": {
+        "tools": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Tool" }
+        },
+        "nextCursor": { "type": "string" }
+      }
+    },
+    "Tool": {
+      "type": "object",
+      "required": ["name", "inputSchema"],
+      "additionalProperties": true,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "inputSchema": { "type": "object" },
+        "outputSchema": { "type": "object" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "ListResourcesResult": {
+      "type": "object",
+      "required": ["resources"],
+      "additionalProperties": true,
+      "properties": {
+        "resources": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Resource" }
+        },
+        "nextCursor": { "type": "string" }
+      }
+    },
+    "ListResourceTemplatesResult": {
+      "type": "object",
+      "required": ["resourceTemplates"],
+      "additionalProperties": true,
+      "properties": {
+        "resourceTemplates": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ResourceTemplate" }
+        },
+        "nextCursor": { "type": "string" }
+      }
+    },
+    "Resource": {
+      "type": "object",
+      "required": ["uri", "name"],
+      "additionalProperties": true,
+      "properties": {
+        "uri": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "mimeType": { "type": "string" }
+      }
+    },
+    "ResourceTemplate": {
+      "type": "object",
+      "required": ["uriTemplate", "name"],
+      "additionalProperties": true,
+      "properties": {
+        "uriTemplate": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "mimeType": { "type": "string" }
+      }
+    },
+    "ListPromptsResult": {
+      "type": "object",
+      "required": ["prompts"],
+      "additionalProperties": true,
+      "properties": {
+        "prompts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Prompt" }
+        },
+        "nextCursor": { "type": "string" }
+      }
+    },
+    "Prompt": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": true,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "arguments": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    }
+  }
+}

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -60,6 +60,7 @@ url = "2"
 webbrowser = "1"
 rand = "0.10"
 regex = "1"
+jsonschema = { version = "0.46.3", default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
 tower = { version = "0.5", features = ["util"] }
 time = { version = "0.3", features = ["formatting", "parsing"] }

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -387,9 +387,9 @@ pub(crate) struct TestArgs {
     /// conformance fixtures so bundled `skills/` dirs are picked up.
     #[arg(long = "skill-dir", value_name = "PATH")]
     pub skill_dir: Vec<String>,
-    /// User test path, or `conformance` to target the conformance suite.
+    /// User test path, `conformance`, or `protocols`.
     pub target: Option<String>,
-    /// Optional file or directory under conformance/ when target is `conformance`.
+    /// Optional file or directory under conformance/ or conformance/protocols/.
     pub selection: Option<String>,
 }
 

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod orchestrator;
 pub(crate) mod persona;
 pub(crate) mod playground;
 pub(crate) mod portal;
+pub(crate) mod protocol_conformance;
 pub(crate) mod repl;
 pub(crate) mod run;
 pub(crate) mod serve;

--- a/crates/harn-cli/src/commands/protocol_conformance.rs
+++ b/crates/harn-cli/src/commands/protocol_conformance.rs
@@ -1,0 +1,303 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process;
+
+use regex::Regex;
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum FixtureExpectation {
+    #[default]
+    Valid,
+    Invalid,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProtocolFixture {
+    name: String,
+    protocol: String,
+    schema: String,
+    #[serde(default)]
+    expect: FixtureExpectation,
+    documents: Vec<Value>,
+}
+
+#[derive(Debug, Default)]
+struct ProtocolConformanceReport {
+    passed: usize,
+    failed: usize,
+    skipped: usize,
+    errors: Vec<String>,
+}
+
+pub(crate) fn run_protocol_conformance(
+    selection: Option<&str>,
+    filter: Option<&str>,
+    verbose: bool,
+) {
+    let root = PathBuf::from("conformance/protocols");
+    let report = run_protocol_conformance_inner(&root, selection, filter, verbose);
+    if report.failed > 0 {
+        eprintln!();
+        for error in &report.errors {
+            eprintln!("{error}");
+        }
+        eprintln!(
+            "Protocol conformance failed: {} passed, {} failed, {} skipped",
+            report.passed, report.failed, report.skipped
+        );
+        process::exit(1);
+    }
+    println!(
+        "Protocol conformance passed: {} passed, {} skipped",
+        report.passed, report.skipped
+    );
+}
+
+fn run_protocol_conformance_inner(
+    root: &Path,
+    selection: Option<&str>,
+    filter: Option<&str>,
+    verbose: bool,
+) -> ProtocolConformanceReport {
+    let mut report = ProtocolConformanceReport::default();
+    if !root.exists() {
+        report.failed += 1;
+        report.errors.push(format!(
+            "Protocol conformance root not found: {}",
+            root.display()
+        ));
+        return report;
+    }
+
+    let fixtures = match resolve_fixture_files(root, selection) {
+        Ok(fixtures) => fixtures,
+        Err(error) => {
+            report.failed += 1;
+            report.errors.push(error);
+            return report;
+        }
+    };
+    let display_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+
+    for fixture_path in fixtures {
+        let relative_path = fixture_path
+            .strip_prefix(&display_root)
+            .unwrap_or(&fixture_path)
+            .display()
+            .to_string();
+        let fixture = match read_fixture(&fixture_path) {
+            Ok(fixture) => fixture,
+            Err(error) => {
+                report.failed += 1;
+                report.errors.push(format!("{relative_path}: {error}"));
+                println!("  \x1b[31mFAIL\x1b[0m  {relative_path}");
+                continue;
+            }
+        };
+
+        if !matches_filter(filter, &fixture, &relative_path) {
+            report.skipped += 1;
+            continue;
+        }
+
+        match run_fixture(root, &fixture_path, &fixture) {
+            Ok(()) => {
+                report.passed += 1;
+                if verbose {
+                    println!(
+                        "  \x1b[32mPASS\x1b[0m  {} ({})",
+                        fixture.name, relative_path
+                    );
+                } else {
+                    println!("  \x1b[32mPASS\x1b[0m  {}", fixture.name);
+                }
+            }
+            Err(error) => {
+                report.failed += 1;
+                report.errors.push(format!("{relative_path}: {error}"));
+                println!("  \x1b[31mFAIL\x1b[0m  {}", fixture.name);
+            }
+        }
+    }
+
+    report
+}
+
+fn resolve_fixture_files(root: &Path, selection: Option<&str>) -> Result<Vec<PathBuf>, String> {
+    let fixture_root = root.join("fixtures");
+    let selected = match selection {
+        Some(selection) => {
+            let raw = PathBuf::from(selection);
+            if raw.is_absolute() || raw.starts_with(root) {
+                raw
+            } else {
+                root.join(raw)
+            }
+        }
+        None => fixture_root,
+    };
+
+    if !selected.exists() {
+        return Err(format!(
+            "Protocol conformance target not found: {}",
+            selected.display()
+        ));
+    }
+    let selected = canonicalize_under(root, &selected)?;
+    let mut files = Vec::new();
+    collect_json_files(&selected, &mut files);
+    if files.is_empty() {
+        return Err(format!(
+            "No protocol fixture JSON files found under {}",
+            selected.display()
+        ));
+    }
+    Ok(files)
+}
+
+fn canonicalize_under(root: &Path, path: &Path) -> Result<PathBuf, String> {
+    let root = root
+        .canonicalize()
+        .map_err(|error| format!("Failed to canonicalize {}: {error}", root.display()))?;
+    let path = path
+        .canonicalize()
+        .map_err(|error| format!("Failed to canonicalize {}: {error}", path.display()))?;
+    if !path.starts_with(&root) {
+        return Err(format!(
+            "Protocol conformance target must be inside {}: {}",
+            root.display(),
+            path.display()
+        ));
+    }
+    Ok(path)
+}
+
+fn collect_json_files(path: &Path, out: &mut Vec<PathBuf>) {
+    if path.is_file() {
+        if path.extension().is_some_and(|ext| ext == "json") {
+            out.push(path.to_path_buf());
+        }
+        return;
+    }
+    let Ok(entries) = fs::read_dir(path) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.filter_map(Result::ok).collect();
+    entries.sort_by_key(|entry| entry.path());
+    for entry in entries {
+        collect_json_files(&entry.path(), out);
+    }
+}
+
+fn read_fixture(path: &Path) -> Result<ProtocolFixture, String> {
+    let text =
+        fs::read_to_string(path).map_err(|error| format!("failed to read fixture: {error}"))?;
+    let fixture: ProtocolFixture =
+        serde_json::from_str(&text).map_err(|error| format!("invalid fixture JSON: {error}"))?;
+    if fixture.documents.is_empty() {
+        return Err("fixture must contain at least one document".to_string());
+    }
+    Ok(fixture)
+}
+
+fn matches_filter(filter: Option<&str>, fixture: &ProtocolFixture, relative_path: &str) -> bool {
+    let Some(filter) = filter else {
+        return true;
+    };
+    if let Some(pattern) = filter.strip_prefix("re:") {
+        return Regex::new(pattern).is_ok_and(|regex| {
+            regex.is_match(&fixture.name)
+                || regex.is_match(&fixture.protocol)
+                || regex.is_match(relative_path)
+        });
+    }
+    fixture.name.contains(filter)
+        || fixture.protocol.contains(filter)
+        || relative_path.contains(filter)
+}
+
+fn run_fixture(root: &Path, fixture_path: &Path, fixture: &ProtocolFixture) -> Result<(), String> {
+    let schema_path = resolve_schema_path(root, fixture_path, &fixture.schema)?;
+    let schema_text = fs::read_to_string(&schema_path)
+        .map_err(|error| format!("failed to read schema {}: {error}", schema_path.display()))?;
+    let schema: Value = serde_json::from_str(&schema_text)
+        .map_err(|error| format!("invalid schema JSON {}: {error}", schema_path.display()))?;
+    jsonschema::draft202012::meta::validate(&schema).map_err(|error| {
+        format!(
+            "schema {} is not valid JSON Schema 2020-12: {error}",
+            schema_path.display()
+        )
+    })?;
+    let validator = jsonschema::draft202012::new(&schema).map_err(|error| {
+        format!(
+            "failed to compile schema {}: {error}",
+            schema_path.display()
+        )
+    })?;
+
+    for (index, document) in fixture.documents.iter().enumerate() {
+        let result = validator.validate(document);
+        match (&fixture.expect, result) {
+            (FixtureExpectation::Valid, Ok(())) => {}
+            (FixtureExpectation::Valid, Err(error)) => {
+                return Err(format!(
+                    "document #{index} was expected to be valid against {}: {error}",
+                    schema_path.display()
+                ));
+            }
+            (FixtureExpectation::Invalid, Ok(())) => {
+                return Err(format!(
+                    "document #{index} was expected to be rejected by {}",
+                    schema_path.display()
+                ));
+            }
+            (FixtureExpectation::Invalid, Err(_)) => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_schema_path(root: &Path, fixture_path: &Path, schema: &str) -> Result<PathBuf, String> {
+    let raw = PathBuf::from(schema);
+    let path = if raw.is_absolute() || raw.starts_with(root) {
+        raw
+    } else if schema.starts_with("schemas/") {
+        root.join(raw)
+    } else {
+        fixture_path.parent().unwrap_or(root).join(raw)
+    };
+    canonicalize_under(root, &path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{run_protocol_conformance_inner, FixtureExpectation, ProtocolFixture};
+
+    #[test]
+    fn expectation_defaults_to_valid() {
+        let fixture: ProtocolFixture = serde_json::from_str(
+            r#"{
+              "name": "sample",
+              "protocol": "mcp",
+              "schema": "schemas/mcp-2025-11-25.schema.json",
+              "documents": [{}]
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(fixture.expect, FixtureExpectation::Valid);
+    }
+
+    #[test]
+    fn checked_in_protocol_fixtures_pass() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("conformance/protocols");
+        let report = run_protocol_conformance_inner(&root, None, None, false);
+        assert_eq!(report.failed, 0, "{:#?}", report.errors);
+        assert!(report.passed >= 6);
+    }
+}

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -340,6 +340,34 @@ async fn async_main() {
                 .await;
                 return;
             }
+            if args.target.as_deref() == Some("protocols") {
+                if args.evals || args.determinism || args.record || args.replay || args.watch {
+                    command_error(
+                        "`harn test protocols` cannot be combined with --evals, --determinism, --record, --replay, or --watch",
+                    );
+                }
+                if args.junit.is_some()
+                    || args.agents_target.is_some()
+                    || args.agents_api_key.is_some()
+                    || !args.agents_category.is_empty()
+                    || args.json
+                    || args.json_out.is_some()
+                    || args.agents_workspace_id.is_some()
+                    || args.agents_session_id.is_some()
+                    || args.parallel
+                    || !args.skill_dir.is_empty()
+                {
+                    command_error(
+                        "`harn test protocols` accepts only --filter, --verbose, --timing, and an optional fixture selection",
+                    );
+                }
+                commands::protocol_conformance::run_protocol_conformance(
+                    args.selection.as_deref(),
+                    args.filter.as_deref(),
+                    args.verbose || args.timing,
+                );
+                return;
+            }
             if args.evals {
                 if args.determinism || args.record || args.replay || args.watch {
                     command_error("--evals cannot be combined with --determinism, --record, --replay, or --watch");

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -166,6 +166,7 @@ run_rust_audit() {
 
 run_harn_audit() {
   time_phase "harn conformance" make conformance
+  time_phase "protocol conformance" make protocol-conformance
   time_phase "harn lint" make lint-harn
   time_phase "harn fmt --check" make fmt-harn
 }


### PR DESCRIPTION
## Summary
- add `harn test protocols` for offline ACP/A2A/MCP JSON schema fixture conformance
- add checked-in protocol schemas plus positive and negative fixtures under `conformance/protocols`
- wire the gate into `make all`, CI, and the release gate

Closes #807.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-issue807 cargo check -p harn-cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue807 HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test protocols --verbose`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue807 HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --bin harn protocol_conformance`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue807 make protocol-conformance`
- temporary known-bad MCP fixture rejected as expected, then removed and re-ran `make protocol-conformance`
- `cargo fmt --all -- --check`
- `git diff --check` and `git diff --cached --check`
- pre-commit hook: `cargo fmt`, workspace clippy, markdown lint, actionlint
- pre-push hook: workspace Rust tests, markdown lint

## Self-review
- Checked path handling: selections are canonicalized under `conformance/protocols` to prevent traversal.
- Checked execution behavior: the conformance gate is offline-only and does not hit live protocol endpoints.
- Checked fixture validation semantics: negative fixtures only pass when schema validation rejects them.
- Kept schema compilation simple because the checked-in corpus is tiny; no caching complexity needed at this size.