### PR TITLE
Add connector package gate

### DIFF
--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -467,6 +467,8 @@ pub(crate) struct ConnectorArgs {
 pub(crate) enum ConnectorCommand {
     /// Check a pure-Harn connector package against connector contract v1.
     Check(ConnectorCheckArgs),
+    /// Run the full first-party connector package gate.
+    Test(ConnectorTestArgs),
 }
 
 #[derive(Debug, Args, Clone)]
@@ -480,6 +482,22 @@ pub(crate) struct ConnectorCheckArgs {
     #[arg(long = "run-poll-tick")]
     pub run_poll_tick: bool,
     /// Emit the check report as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args, Clone)]
+pub(crate) struct ConnectorTestArgs {
+    /// Package directory, harn.toml, or file under the package to test.
+    #[arg(default_value = ".")]
+    pub package: String,
+    /// Restrict the gate to one provider id. Repeatable.
+    #[arg(long = "provider", value_name = "ID")]
+    pub providers: Vec<String>,
+    /// Run poll bindings long enough to execute the first poll_tick.
+    #[arg(long = "run-poll-tick")]
+    pub run_poll_tick: bool,
+    /// Emit the gate report as JSON.
     #[arg(long)]
     pub json: bool,
 }
@@ -2478,11 +2496,12 @@ mod tests {
     use std::time::Duration as StdDuration;
 
     use super::{
-        Cli, Command, ConnectCommand, CrystallizeCommand, FlowArchivistCommand, FlowCommand,
-        McpCommand, OrchestratorCommand, OrchestratorDeployProvider, OrchestratorLogFormat,
-        OrchestratorQueueCommand, OrchestratorTenantCommand, PackageCacheCommand, PackageCommand,
-        ProjectTemplate, RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand,
-        SkillsCommand, TraceCommand, TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
+        Cli, Command, ConnectCommand, ConnectorCommand, CrystallizeCommand, FlowArchivistCommand,
+        FlowCommand, McpCommand, OrchestratorCommand, OrchestratorDeployProvider,
+        OrchestratorLogFormat, OrchestratorQueueCommand, OrchestratorTenantCommand,
+        PackageCacheCommand, PackageCommand, ProjectTemplate, RunsCommand, SkillCommand,
+        SkillKeyCommand, SkillTrustCommand, SkillsCommand, TraceCommand, TriggerCommand,
+        TrustCommand, TrustOutcomeArg, TrustTierArg,
     };
     use clap::Parser;
 
@@ -3827,6 +3846,30 @@ mod tests {
             panic!("expected package cache verify");
         };
         assert!(verify.materialized);
+    }
+
+    #[test]
+    fn test_parses_connector_test_args() {
+        let cli = Cli::parse_from([
+            "harn",
+            "connector",
+            "test",
+            "pkg",
+            "--provider",
+            "notion",
+            "--run-poll-tick",
+            "--json",
+        ]);
+        let Command::Connector(args) = cli.command.unwrap() else {
+            panic!("expected connector command");
+        };
+        let ConnectorCommand::Test(test) = args.command else {
+            panic!("expected connector test");
+        };
+        assert_eq!(test.package, "pkg");
+        assert_eq!(test.providers, vec!["notion"]);
+        assert!(test.run_poll_tick);
+        assert!(test.json);
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/connector.rs
+++ b/crates/harn-cli/src/commands/connector.rs
@@ -1,7 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
 use std::sync::Arc;
 use std::time::Duration as StdDuration;
+use std::time::Instant;
 
 use async_trait::async_trait;
 use serde::Serialize;
@@ -9,7 +12,7 @@ use serde_json::{json, Value as JsonValue};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
-use crate::cli::{ConnectorArgs, ConnectorCheckArgs, ConnectorCommand};
+use crate::cli::{ConnectorArgs, ConnectorCheckArgs, ConnectorCommand, ConnectorTestArgs};
 use crate::package::{self, ConnectorContractFixture, ResolvedProviderConnectorKind};
 
 pub(crate) async fn handle_connector_command(args: ConnectorArgs) -> Result<(), String> {
@@ -26,6 +29,24 @@ pub(crate) async fn handle_connector_command(args: ConnectorArgs) -> Result<(), 
                 print_human_report(&report);
             }
             Ok(())
+        }
+        ConnectorCommand::Test(test) => {
+            let report = test_connector_package(&test).await;
+            if test.json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report).map_err(|error| format!(
+                        "failed to render connector gate report: {error}"
+                    ))?
+                );
+            } else {
+                print_gate_report(&report);
+            }
+            if report.status == "pass" {
+                Ok(())
+            } else {
+                Err("connector package gate failed".to_string())
+            }
         }
     }
 }
@@ -53,6 +74,41 @@ pub(crate) struct CheckedFixture {
     pub name: String,
     pub result_type: String,
     pub event_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ConnectorGateReport {
+    pub package: String,
+    pub status: String,
+    pub summary: ConnectorGateSummary,
+    pub checks: Vec<ConnectorGateCheck>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connector_contract: Option<ConnectorCheckReport>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct ConnectorGateSummary {
+    pub passed: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub warnings: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ConnectorGateCheck {
+    pub name: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub command: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub stdout: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub stderr: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub details: Vec<String>,
 }
 
 pub(crate) async fn check_connector_package(
@@ -158,6 +214,676 @@ pub(crate) async fn check_connector_package(
                 .join("\n")
         ))
     }
+}
+
+pub(crate) async fn test_connector_package(args: &ConnectorTestArgs) -> ConnectorGateReport {
+    let package = PathBuf::from(&args.package);
+    let anchor = normalize_anchor(&package);
+    let package_dir = package_dir_from_anchor(&package);
+    let package_label = package_dir.display().to_string();
+    let mut checks = Vec::new();
+    let mut connector_contract = None;
+
+    let metadata = validate_connector_package_metadata(&anchor);
+    let metadata_ok = metadata.status == "pass";
+    checks.push(metadata);
+
+    let package_harn_files = package_harn_file_args(&package_dir);
+    checks.push(run_package_harn_file_check(
+        "harn check",
+        &package_dir,
+        "check",
+        &package_harn_files,
+    ));
+    checks.push(run_package_harn_file_check(
+        "harn lint",
+        &package_dir,
+        "lint",
+        &package_harn_files,
+    ));
+    let mut fmt_args = vec!["fmt".to_string(), "--check".to_string()];
+    fmt_args.extend(package_harn_files.clone());
+    checks.push(run_harn_subcommand_owned(
+        "harn fmt --check",
+        &package_dir,
+        fmt_args,
+    ));
+
+    let check_args = ConnectorCheckArgs {
+        package: args.package.clone(),
+        providers: args.providers.clone(),
+        run_poll_tick: args.run_poll_tick,
+        json: false,
+    };
+    let started = Instant::now();
+    match check_connector_package(&check_args).await {
+        Ok(report) => {
+            let details = report
+                .warnings
+                .iter()
+                .map(|warning| format!("warning: {warning}"))
+                .collect::<Vec<_>>();
+            checks.push(ConnectorGateCheck {
+                name: "connector contract".to_string(),
+                status: "pass".to_string(),
+                command: connector_check_command(&check_args),
+                exit_code: Some(0),
+                duration_ms: elapsed_ms(started),
+                stdout: String::new(),
+                stderr: String::new(),
+                details,
+            });
+            connector_contract = Some(report);
+        }
+        Err(error) => {
+            checks.push(ConnectorGateCheck {
+                name: "connector contract".to_string(),
+                status: "fail".to_string(),
+                command: connector_check_command(&check_args),
+                exit_code: Some(1),
+                duration_ms: elapsed_ms(started),
+                stdout: String::new(),
+                stderr: error,
+                details: Vec::new(),
+            });
+        }
+    }
+
+    checks.push(run_connector_fixture_tests(&package_dir));
+    checks.push(run_install_import_smoke(&package_dir, metadata_ok));
+    checks.push(validate_doc_examples(&package_dir));
+
+    let summary = summarize_gate_checks(&checks);
+    let status = if summary.failed == 0 { "pass" } else { "fail" }.to_string();
+    ConnectorGateReport {
+        package: package_label,
+        status,
+        summary,
+        checks,
+        connector_contract,
+    }
+}
+
+fn validate_connector_package_metadata(anchor: &Path) -> ConnectorGateCheck {
+    let started = Instant::now();
+    let mut details = Vec::new();
+    let mut failures = Vec::new();
+    let package_dir = package_dir_from_anchor(anchor);
+
+    match package::try_load_runtime_extensions(anchor) {
+        Ok(extensions) => {
+            let Some(manifest) = extensions.root_manifest.as_ref() else {
+                failures.push(format!("no harn.toml found for {}", anchor.display()));
+                return gate_check_from_findings("package metadata", started, failures, details);
+            };
+            let package = manifest.package.as_ref();
+            require_metadata_field(
+                package.and_then(|package| package.name.as_deref()),
+                "[package].name",
+                &mut failures,
+            );
+            require_metadata_field(
+                package.and_then(|package| package.version.as_deref()),
+                "[package].version",
+                &mut failures,
+            );
+            require_metadata_field(
+                package.and_then(|package| package.description.as_deref()),
+                "[package].description",
+                &mut failures,
+            );
+            require_metadata_field(
+                package.and_then(|package| package.license.as_deref()),
+                "[package].license",
+                &mut failures,
+            );
+            require_metadata_field(
+                package.and_then(|package| package.repository.as_deref()),
+                "[package].repository",
+                &mut failures,
+            );
+            if manifest.exports.is_empty() {
+                failures
+                    .push("[exports] must expose at least one stable package module".to_string());
+            }
+            if extensions.provider_connectors.is_empty() {
+                failures
+                    .push("[[providers]] must declare at least one connector provider".to_string());
+            }
+            for provider in &extensions.provider_connectors {
+                match &provider.connector {
+                    ResolvedProviderConnectorKind::Harn { module } => details.push(format!(
+                        "provider '{}' uses Harn connector module {}",
+                        provider.id.as_str(),
+                        module
+                    )),
+                    ResolvedProviderConnectorKind::RustBuiltin => failures.push(format!(
+                        "provider '{}' uses a Rust builtin connector; connector packages must use connector.harn",
+                        provider.id.as_str()
+                    )),
+                    ResolvedProviderConnectorKind::Invalid(message) => failures.push(message.clone()),
+                }
+            }
+            if !package_dir.join("README.md").is_file() {
+                failures.push("README.md is required".to_string());
+            }
+            if manifest.connector_contract.version.unwrap_or(1) != 1 {
+                failures.push("connector_contract.version must be 1 when present".to_string());
+            }
+            details.push(format!("exports: {}", manifest.exports.len()));
+            details.push(format!(
+                "providers: {}",
+                extensions.provider_connectors.len()
+            ));
+        }
+        Err(error) => failures.push(error),
+    }
+
+    gate_check_from_findings("package metadata", started, failures, details)
+}
+
+fn require_metadata_field(value: Option<&str>, field: &str, failures: &mut Vec<String>) {
+    if value.is_none_or(|value| value.trim().is_empty()) {
+        failures.push(format!("{field} is required"));
+    }
+}
+
+fn gate_check_from_findings(
+    name: &str,
+    started: Instant,
+    failures: Vec<String>,
+    details: Vec<String>,
+) -> ConnectorGateCheck {
+    ConnectorGateCheck {
+        name: name.to_string(),
+        status: if failures.is_empty() { "pass" } else { "fail" }.to_string(),
+        command: Vec::new(),
+        exit_code: if failures.is_empty() {
+            Some(0)
+        } else {
+            Some(1)
+        },
+        duration_ms: elapsed_ms(started),
+        stdout: String::new(),
+        stderr: failures.join("\n"),
+        details,
+    }
+}
+
+fn run_harn_subcommand(name: &str, cwd: &Path, args: &[&str]) -> ConnectorGateCheck {
+    run_harn_subcommand_owned(
+        name,
+        cwd,
+        args.iter().map(|arg| (*arg).to_string()).collect(),
+    )
+}
+
+fn run_harn_subcommand_owned(name: &str, cwd: &Path, args: Vec<String>) -> ConnectorGateCheck {
+    let started = Instant::now();
+    let exe = match std::env::current_exe() {
+        Ok(exe) => exe,
+        Err(error) => {
+            return ConnectorGateCheck {
+                name: name.to_string(),
+                status: "fail".to_string(),
+                command: args,
+                exit_code: None,
+                duration_ms: elapsed_ms(started),
+                stdout: String::new(),
+                stderr: format!("failed to resolve current harn executable: {error}"),
+                details: Vec::new(),
+            };
+        }
+    };
+    let output = ProcessCommand::new(&exe)
+        .args(&args)
+        .current_dir(cwd)
+        .env("HARN_LLM_PROVIDER", "mock")
+        .env(harn_vm::llm::LLM_CALLS_DISABLED_ENV, "1")
+        .output();
+    match output {
+        Ok(output) => ConnectorGateCheck {
+            name: name.to_string(),
+            status: if output.status.success() {
+                "pass"
+            } else {
+                "fail"
+            }
+            .to_string(),
+            command: std::iter::once(exe.display().to_string())
+                .chain(args.iter().cloned())
+                .collect(),
+            exit_code: output.status.code(),
+            duration_ms: elapsed_ms(started),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            details: Vec::new(),
+        },
+        Err(error) => ConnectorGateCheck {
+            name: name.to_string(),
+            status: "fail".to_string(),
+            command: std::iter::once(exe.display().to_string())
+                .chain(args)
+                .collect(),
+            exit_code: None,
+            duration_ms: elapsed_ms(started),
+            stdout: String::new(),
+            stderr: format!("failed to run command: {error}"),
+            details: Vec::new(),
+        },
+    }
+}
+
+fn run_package_harn_file_check(
+    name: &str,
+    package_dir: &Path,
+    subcommand: &str,
+    package_harn_files: &[String],
+) -> ConnectorGateCheck {
+    if package_harn_files.is_empty() {
+        return ConnectorGateCheck {
+            name: name.to_string(),
+            status: "fail".to_string(),
+            command: Vec::new(),
+            exit_code: Some(1),
+            duration_ms: 0,
+            stdout: String::new(),
+            stderr: "no package-owned .harn files found".to_string(),
+            details: Vec::new(),
+        };
+    }
+    let mut args = vec![subcommand.to_string()];
+    args.extend(package_harn_files.iter().cloned());
+    run_harn_subcommand_owned(name, package_dir, args)
+}
+
+fn package_harn_file_args(package_dir: &Path) -> Vec<String> {
+    let mut files = Vec::new();
+    collect_package_harn_files(package_dir, &mut files);
+    files
+        .into_iter()
+        .filter_map(|path| {
+            path.strip_prefix(package_dir)
+                .ok()
+                .map(|rel| rel.to_string_lossy().into_owned())
+        })
+        .collect()
+}
+
+fn collect_package_harn_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries = entries.filter_map(Result::ok).collect::<Vec<_>>();
+    entries.sort_by_key(|entry| entry.path());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            if path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| matches!(name, ".git" | ".harn" | "target" | "node_modules"))
+            {
+                continue;
+            }
+            collect_package_harn_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "harn") {
+            out.push(path);
+        }
+    }
+}
+
+fn run_connector_fixture_tests(package_dir: &Path) -> ConnectorGateCheck {
+    let started = Instant::now();
+    let mut details = Vec::new();
+    let mut stderr = Vec::new();
+    let tests = connector_test_files(package_dir);
+    if tests.is_empty() {
+        return ConnectorGateCheck {
+            name: "connector fixture tests".to_string(),
+            status: "skipped".to_string(),
+            command: Vec::new(),
+            exit_code: None,
+            duration_ms: elapsed_ms(started),
+            stdout: String::new(),
+            stderr: String::new(),
+            details: vec!["no runnable tests/*.harn files found".to_string()],
+        };
+    }
+    let mut failed = false;
+    for test in tests {
+        let rel = test
+            .strip_prefix(package_dir)
+            .unwrap_or(test.as_path())
+            .to_string_lossy()
+            .into_owned();
+        let check = run_harn_subcommand(&format!("harn run {rel}"), package_dir, &["run", &rel]);
+        if check.status == "pass" {
+            details.push(format!("{rel}: pass"));
+        } else {
+            failed = true;
+            stderr.push(format!(
+                "{rel}: failed\nstdout:\n{}\nstderr:\n{}",
+                check.stdout, check.stderr
+            ));
+        }
+    }
+    ConnectorGateCheck {
+        name: "connector fixture tests".to_string(),
+        status: if failed { "fail" } else { "pass" }.to_string(),
+        command: Vec::new(),
+        exit_code: Some(if failed { 1 } else { 0 }),
+        duration_ms: elapsed_ms(started),
+        stdout: String::new(),
+        stderr: stderr.join("\n"),
+        details,
+    }
+}
+
+fn connector_test_files(package_dir: &Path) -> Vec<PathBuf> {
+    let tests_dir = package_dir.join("tests");
+    let mut files = match fs::read_dir(&tests_dir) {
+        Ok(entries) => entries
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().is_some_and(|ext| ext == "harn"))
+            .filter(|path| {
+                fs::read_to_string(path)
+                    .map(|source| source.contains("pipeline ") || source.contains("@test"))
+                    .unwrap_or(false)
+            })
+            .collect::<Vec<_>>(),
+        Err(_) => Vec::new(),
+    };
+    files.sort();
+    files
+}
+
+fn run_install_import_smoke(package_dir: &Path, metadata_ok: bool) -> ConnectorGateCheck {
+    let started = Instant::now();
+    if !metadata_ok {
+        return ConnectorGateCheck {
+            name: "package install/import smoke".to_string(),
+            status: "skipped".to_string(),
+            command: Vec::new(),
+            exit_code: None,
+            duration_ms: elapsed_ms(started),
+            stdout: String::new(),
+            stderr: String::new(),
+            details: vec!["skipped because package metadata did not pass".to_string()],
+        };
+    }
+    let manifest_path = package_dir.join("harn.toml");
+    let manifest_source = match fs::read_to_string(&manifest_path) {
+        Ok(source) => source,
+        Err(error) => {
+            return gate_check_from_findings(
+                "package install/import smoke",
+                started,
+                vec![format!(
+                    "failed to read {}: {error}",
+                    manifest_path.display()
+                )],
+                Vec::new(),
+            );
+        }
+    };
+    let manifest = match toml::from_str::<package::Manifest>(&manifest_source) {
+        Ok(manifest) => manifest,
+        Err(error) => {
+            return gate_check_from_findings(
+                "package install/import smoke",
+                started,
+                vec![format!(
+                    "failed to parse {}: {error}",
+                    manifest_path.display()
+                )],
+                Vec::new(),
+            );
+        }
+    };
+    let Some(package_name) = manifest
+        .package
+        .as_ref()
+        .and_then(|package| package.name.as_deref())
+        .map(str::to_string)
+    else {
+        return gate_check_from_findings(
+            "package install/import smoke",
+            started,
+            vec!["[package].name is required for install/import smoke".to_string()],
+            Vec::new(),
+        );
+    };
+    if manifest.exports.is_empty() {
+        return gate_check_from_findings(
+            "package install/import smoke",
+            started,
+            vec!["[exports] is required for install/import smoke".to_string()],
+            Vec::new(),
+        );
+    }
+
+    let temp = match tempfile::tempdir() {
+        Ok(temp) => temp,
+        Err(error) => {
+            return gate_check_from_findings(
+                "package install/import smoke",
+                started,
+                vec![format!(
+                    "failed to create temporary consumer package: {error}"
+                )],
+                Vec::new(),
+            );
+        }
+    };
+    let consumer = temp.path();
+    let manifest = format!(
+        "[package]\nname = \"connector-smoke-consumer\"\nversion = \"0.0.0\"\n\n[dependencies]\n\"{}\" = {{ path = \"{}\" }}\n",
+        toml_escape_basic_string(&package_name),
+        toml_escape_basic_string(&package_dir.display().to_string())
+    );
+    if let Err(error) = fs::write(consumer.join("harn.toml"), manifest) {
+        return gate_check_from_findings(
+            "package install/import smoke",
+            started,
+            vec![format!("failed to write consumer harn.toml: {error}")],
+            Vec::new(),
+        );
+    }
+    let install = run_harn_subcommand("harn install", consumer, &["install"]);
+    if install.status != "pass" {
+        return ConnectorGateCheck {
+            name: "package install/import smoke".to_string(),
+            status: "fail".to_string(),
+            command: install.command,
+            exit_code: install.exit_code,
+            duration_ms: elapsed_ms(started),
+            stdout: install.stdout,
+            stderr: install.stderr,
+            details: vec!["consumer package install failed".to_string()],
+        };
+    }
+
+    let mut details = vec!["consumer package install passed".to_string()];
+    let mut failures = Vec::new();
+    let mut exports = manifest_exports_sorted(&manifest_source);
+    exports.sort();
+    for export in exports {
+        let smoke_path = consumer.join(format!("smoke-{export}.harn"));
+        let source = format!("import \"{package_name}/{export}\"\n\npipeline default() {{\n}}\n");
+        if let Err(error) = fs::write(&smoke_path, source) {
+            failures.push(format!("failed to write {}: {error}", smoke_path.display()));
+            continue;
+        }
+        let rel = smoke_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("smoke.harn");
+        let check = run_harn_subcommand(
+            &format!("harn check {package_name}/{export}"),
+            consumer,
+            &["check", rel],
+        );
+        if check.status == "pass" {
+            details.push(format!("import \"{package_name}/{export}\": pass"));
+        } else {
+            failures.push(format!(
+                "import \"{package_name}/{export}\" failed\nstdout:\n{}\nstderr:\n{}",
+                check.stdout, check.stderr
+            ));
+        }
+    }
+
+    gate_check_from_findings("package install/import smoke", started, failures, details)
+}
+
+fn manifest_exports_sorted(manifest_source: &str) -> Vec<String> {
+    toml::from_str::<package::Manifest>(manifest_source)
+        .map(|manifest| manifest.exports.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+fn toml_escape_basic_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn validate_doc_examples(package_dir: &Path) -> ConnectorGateCheck {
+    let started = Instant::now();
+    let mut details = Vec::new();
+    let mut failures = Vec::new();
+    let mut markdown_files = Vec::new();
+    collect_markdown_files(package_dir, &mut markdown_files);
+    for markdown in markdown_files {
+        let Ok(source) = fs::read_to_string(&markdown) else {
+            continue;
+        };
+        for (idx, block) in harn_doc_blocks(&source).into_iter().enumerate() {
+            if !is_standalone_harn_doc_example(&block) {
+                details.push(format!(
+                    "{} harn block {}: skipped non-standalone snippet",
+                    markdown.display(),
+                    idx + 1
+                ));
+                continue;
+            }
+            match harn_parser::parse_source(&block) {
+                Ok(_) => details.push(format!(
+                    "{} harn block {}: parsed",
+                    markdown.display(),
+                    idx + 1
+                )),
+                Err(error) => failures.push(format!(
+                    "{} harn block {} failed to parse: {error}",
+                    markdown.display(),
+                    idx + 1
+                )),
+            }
+        }
+    }
+    if details.is_empty() && failures.is_empty() {
+        return ConnectorGateCheck {
+            name: "doc examples".to_string(),
+            status: "skipped".to_string(),
+            command: Vec::new(),
+            exit_code: None,
+            duration_ms: elapsed_ms(started),
+            stdout: String::new(),
+            stderr: String::new(),
+            details: vec!["no Markdown harn examples found".to_string()],
+        };
+    }
+    gate_check_from_findings("doc examples", started, failures, details)
+}
+
+fn collect_markdown_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries = entries.filter_map(Result::ok).collect::<Vec<_>>();
+    entries.sort_by_key(|entry| entry.path());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            if path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| matches!(name, ".git" | ".harn" | "target" | "node_modules"))
+            {
+                continue;
+            }
+            collect_markdown_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "md") {
+            out.push(path);
+        }
+    }
+}
+
+fn harn_doc_blocks(markdown: &str) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut current = Vec::new();
+    let mut in_harn = false;
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            if in_harn {
+                blocks.push(current.join("\n"));
+                current.clear();
+                in_harn = false;
+            } else {
+                let language = trimmed.trim_start_matches("```").trim();
+                in_harn = language == "harn";
+            }
+            continue;
+        }
+        if in_harn {
+            current.push(line);
+        }
+    }
+    blocks
+}
+
+fn is_standalone_harn_doc_example(source: &str) -> bool {
+    source.contains("pipeline ") || source.contains("pub fn ") || source.contains("\nfn ")
+}
+
+fn connector_check_command(args: &ConnectorCheckArgs) -> Vec<String> {
+    let mut command = vec![
+        "harn".to_string(),
+        "connector".to_string(),
+        "check".to_string(),
+        args.package.clone(),
+    ];
+    for provider in &args.providers {
+        command.push("--provider".to_string());
+        command.push(provider.clone());
+    }
+    if args.run_poll_tick {
+        command.push("--run-poll-tick".to_string());
+    }
+    command
+}
+
+fn summarize_gate_checks(checks: &[ConnectorGateCheck]) -> ConnectorGateSummary {
+    let mut summary = ConnectorGateSummary::default();
+    for check in checks {
+        match check.status.as_str() {
+            "pass" => summary.passed += 1,
+            "fail" => summary.failed += 1,
+            "skipped" => summary.skipped += 1,
+            _ => {}
+        }
+        summary.warnings += check
+            .details
+            .iter()
+            .filter(|detail| detail.starts_with("warning:"))
+            .count();
+    }
+    summary
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis() as u64
 }
 
 async fn check_one_connector(
@@ -724,6 +1450,22 @@ fn normalize_anchor(path: &Path) -> PathBuf {
     }
 }
 
+fn package_dir_from_anchor(path: &Path) -> PathBuf {
+    let start = if path.is_dir() {
+        path.to_path_buf()
+    } else {
+        path.parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."))
+    };
+    for dir in start.ancestors() {
+        if dir.join("harn.toml").is_file() {
+            return dir.to_path_buf();
+        }
+    }
+    start
+}
+
 fn print_human_report(report: &ConnectorCheckReport) {
     println!(
         "Connector contract check passed for {} connector(s), {} fixture(s).",
@@ -741,6 +1483,26 @@ fn print_human_report(report: &ConnectorCheckReport) {
     }
     for warning in &report.warnings {
         eprintln!("warning: {warning}");
+    }
+}
+
+fn print_gate_report(report: &ConnectorGateReport) {
+    println!(
+        "Connector package gate {} for {}: {} passed, {} failed, {} skipped.",
+        report.status,
+        report.package,
+        report.summary.passed,
+        report.summary.failed,
+        report.summary.skipped
+    );
+    for check in &report.checks {
+        println!("- {}: {}", check.name, check.status);
+        for detail in &check.details {
+            println!("  {detail}");
+        }
+        if !check.stderr.trim().is_empty() {
+            eprintln!("{} failed output:\n{}", check.name, check.stderr.trim());
+        }
     }
 }
 
@@ -787,6 +1549,17 @@ connector = {{ harn = "./lib.harn" }}
             run_poll_tick: false,
             json: false,
         }
+    }
+
+    #[test]
+    fn package_dir_from_anchor_finds_manifest_for_nested_file() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("src/nested")).unwrap();
+        fs::write(dir.path().join("harn.toml"), "[package]\nname = \"demo\"\n").unwrap();
+        let nested = dir.path().join("src/nested/lib.harn");
+        fs::write(&nested, "").unwrap();
+
+        assert_eq!(package_dir_from_anchor(&nested), dir.path());
     }
 
     #[tokio::test]

--- a/crates/harn-cli/src/commands/dump_trigger_quickref.rs
+++ b/crates/harn-cli/src/commands/dump_trigger_quickref.rs
@@ -16,7 +16,7 @@ struct FirstPartyConnectorPackage {
     provider: &'static str,
     package_url: &'static str,
     install: &'static str,
-    contract_check: &'static str,
+    package_gate: &'static str,
 }
 
 const FIRST_PARTY_CONNECTOR_PACKAGES: &[FirstPartyConnectorPackage] = &[
@@ -24,61 +24,61 @@ const FIRST_PARTY_CONNECTOR_PACKAGES: &[FirstPartyConnectorPackage] = &[
         provider: "GitHub",
         package_url: "https://github.com/burin-labs/harn-github-connector",
         install: "harn add github.com/burin-labs/harn-github-connector@v0.1.0",
-        contract_check: "harn connector check . --provider github",
+        package_gate: "harn connector test . --provider github",
     },
     FirstPartyConnectorPackage {
         provider: "Slack",
         package_url: "https://github.com/burin-labs/harn-slack-connector",
         install: "harn add github.com/burin-labs/harn-slack-connector@v0.1.0",
-        contract_check: "harn connector check . --provider slack",
+        package_gate: "harn connector test . --provider slack",
     },
     FirstPartyConnectorPackage {
         provider: "Linear",
         package_url: "https://github.com/burin-labs/harn-linear-connector",
         install: "harn add github.com/burin-labs/harn-linear-connector@v0.1.0",
-        contract_check: "harn connector check . --provider linear",
+        package_gate: "harn connector test . --provider linear",
     },
     FirstPartyConnectorPackage {
         provider: "Notion",
         package_url: "https://github.com/burin-labs/harn-notion-connector",
         install: "harn add github.com/burin-labs/harn-notion-connector@v0.1.0",
-        contract_check: "harn connector check . --provider notion --run-poll-tick",
+        package_gate: "harn connector test . --provider notion --run-poll-tick",
     },
     FirstPartyConnectorPackage {
         provider: "GitLab",
         package_url: "https://github.com/burin-labs/harn-gitlab-connector",
         install: "harn add github.com/burin-labs/harn-gitlab-connector@v0.1.0",
-        contract_check: "harn connector check . --provider gitlab",
+        package_gate: "harn connector test . --provider gitlab",
     },
     FirstPartyConnectorPackage {
         provider: "Forgejo",
         package_url: "https://github.com/burin-labs/harn-forgejo-connector",
         install: "harn add github.com/burin-labs/harn-forgejo-connector@v0.1.0",
-        contract_check: "harn connector check . --provider forgejo",
+        package_gate: "harn connector test . --provider forgejo",
     },
     FirstPartyConnectorPackage {
         provider: "Gitea",
         package_url: "https://github.com/burin-labs/harn-gitea-connector",
         install: "harn add github.com/burin-labs/harn-gitea-connector@v0.1.0",
-        contract_check: "harn connector check . --provider gitea",
+        package_gate: "harn connector test . --provider gitea",
     },
     FirstPartyConnectorPackage {
         provider: "Bitbucket",
         package_url: "https://github.com/burin-labs/harn-bitbucket-connector",
         install: "harn add github.com/burin-labs/harn-bitbucket-connector@v0.1.0",
-        contract_check: "harn connector check . --provider bitbucket",
+        package_gate: "harn connector test . --provider bitbucket",
     },
     FirstPartyConnectorPackage {
         provider: "SourceHut",
         package_url: "https://github.com/burin-labs/harn-sourcehut-connector",
         install: "harn add github.com/burin-labs/harn-sourcehut-connector@v0.1.0",
-        contract_check: "harn connector check . --provider sourcehut",
+        package_gate: "harn connector test . --provider sourcehut",
     },
     FirstPartyConnectorPackage {
         provider: "Subversion",
         package_url: "https://github.com/burin-labs/harn-svn-connector",
         install: "harn add github.com/burin-labs/harn-svn-connector@v0.1.0",
-        contract_check: "harn connector check . --provider svn --run-poll-tick",
+        package_gate: "harn connector test . --provider svn --run-poll-tick",
     },
 ];
 
@@ -153,12 +153,12 @@ fn generate_file() -> String {
 
     out.push_str("\n## First-party Connector Packages\n\n");
     out.push_str("Prefer pure-Harn packages for provider business logic. The Rust providers remain compatibility defaults while the pure-Harn packages soak.\n\n");
-    out.push_str("| Provider | Package | Install | Contract check |\n");
+    out.push_str("| Provider | Package | Install | Package gate |\n");
     out.push_str("|---|---|---|---|\n");
     for package in FIRST_PARTY_CONNECTOR_PACKAGES {
         out.push_str(&format!(
             "| {} | <{}> | `{}` | `{}` |\n",
-            package.provider, package.package_url, package.install, package.contract_check
+            package.provider, package.package_url, package.install, package.package_gate
         ));
     }
     out.push('\n');
@@ -185,7 +185,7 @@ fn generate_file() -> String {
     out.push_str("## Package Fixtures\n\n");
     out.push_str("Connector packages should declare deterministic fixtures in `harn.toml` and run them in CI:\n\n");
     out.push_str("```toml\n[connector_contract]\nversion = 1\n\n[[connector_contract.fixtures]]\nprovider = \"slack\"\nname = \"url verification\"\nkind = \"webhook\"\nheaders = { \"content-type\" = \"application/json\" }\nbody_json = { type = \"url_verification\", challenge = \"challenge-token\" }\nexpect_type = \"immediate_response\"\nexpect_event_count = 0\n```\n\n");
-    out.push_str("Run `harn connector check .` locally. Use `--provider <id>` for a multi-provider package, `--run-poll-tick` to execute the first poll tick, and `--json` for CI output.\n\n");
+    out.push_str("Run `harn connector test .` locally. Use `--provider <id>` for a multi-provider package, `--run-poll-tick` to execute the first poll tick, and `--json` for CI output.\n\n");
 
     out.push_str("## Example Library\n\n");
     out.push_str("Ready-to-customize pipelines live under `examples/triggers/`. Each example includes `harn.toml`, `lib.harn`, `README.md`, and `SKILL.md` so it can be copied into a project or installed as a local skill bundle. Validate examples with `make check-trigger-examples`.\n");
@@ -303,7 +303,7 @@ mod tests {
         let out = generate_file();
         assert!(out.contains("| `github` | `webhook` | `GitHubEventPayload` |"));
         assert!(out.contains("Connector Contract V1"));
-        assert!(out.contains("harn connector check ."));
+        assert!(out.contains("harn connector test ."));
         assert!(out.contains("harn-forgejo-connector"));
         assert!(out.contains("harn-svn-connector"));
     }

--- a/crates/harn-cli/src/commands/init.rs
+++ b/crates/harn-cli/src/commands/init.rs
@@ -580,8 +580,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-binstall
       - run: cargo binstall harn-cli --no-confirm
       - run: harn install --locked --offline || harn install
-      - run: harn test tests/
-      - run: harn connector check .
+      - run: harn connector test .
       - run: harn package check
       - run: harn package docs --check
       - run: harn package pack --dry-run
@@ -598,8 +597,7 @@ Pure-Harn connector package.
 ## Quickstart
 
 ```bash
-harn connector check .
-harn test tests/
+harn connector test .
 harn package check
 harn package docs
 harn package pack

--- a/docs/llm/harn-triggers-quickref.md
+++ b/docs/llm/harn-triggers-quickref.md
@@ -65,18 +65,18 @@ This table is generated from `std/triggers::list_providers()` / `ProviderCatalog
 
 Prefer pure-Harn packages for provider business logic. The Rust providers remain compatibility defaults while the pure-Harn packages soak.
 
-| Provider | Package | Install | Contract check |
+| Provider | Package | Install | Package gate |
 |---|---|---|---|
-| GitHub | <https://github.com/burin-labs/harn-github-connector> | `harn add github.com/burin-labs/harn-github-connector@v0.1.0` | `harn connector check . --provider github` |
-| Slack | <https://github.com/burin-labs/harn-slack-connector> | `harn add github.com/burin-labs/harn-slack-connector@v0.1.0` | `harn connector check . --provider slack` |
-| Linear | <https://github.com/burin-labs/harn-linear-connector> | `harn add github.com/burin-labs/harn-linear-connector@v0.1.0` | `harn connector check . --provider linear` |
-| Notion | <https://github.com/burin-labs/harn-notion-connector> | `harn add github.com/burin-labs/harn-notion-connector@v0.1.0` | `harn connector check . --provider notion --run-poll-tick` |
-| GitLab | <https://github.com/burin-labs/harn-gitlab-connector> | `harn add github.com/burin-labs/harn-gitlab-connector@v0.1.0` | `harn connector check . --provider gitlab` |
-| Forgejo | <https://github.com/burin-labs/harn-forgejo-connector> | `harn add github.com/burin-labs/harn-forgejo-connector@v0.1.0` | `harn connector check . --provider forgejo` |
-| Gitea | <https://github.com/burin-labs/harn-gitea-connector> | `harn add github.com/burin-labs/harn-gitea-connector@v0.1.0` | `harn connector check . --provider gitea` |
-| Bitbucket | <https://github.com/burin-labs/harn-bitbucket-connector> | `harn add github.com/burin-labs/harn-bitbucket-connector@v0.1.0` | `harn connector check . --provider bitbucket` |
-| SourceHut | <https://github.com/burin-labs/harn-sourcehut-connector> | `harn add github.com/burin-labs/harn-sourcehut-connector@v0.1.0` | `harn connector check . --provider sourcehut` |
-| Subversion | <https://github.com/burin-labs/harn-svn-connector> | `harn add github.com/burin-labs/harn-svn-connector@v0.1.0` | `harn connector check . --provider svn --run-poll-tick` |
+| GitHub | <https://github.com/burin-labs/harn-github-connector> | `harn add github.com/burin-labs/harn-github-connector@v0.1.0` | `harn connector test . --provider github` |
+| Slack | <https://github.com/burin-labs/harn-slack-connector> | `harn add github.com/burin-labs/harn-slack-connector@v0.1.0` | `harn connector test . --provider slack` |
+| Linear | <https://github.com/burin-labs/harn-linear-connector> | `harn add github.com/burin-labs/harn-linear-connector@v0.1.0` | `harn connector test . --provider linear` |
+| Notion | <https://github.com/burin-labs/harn-notion-connector> | `harn add github.com/burin-labs/harn-notion-connector@v0.1.0` | `harn connector test . --provider notion --run-poll-tick` |
+| GitLab | <https://github.com/burin-labs/harn-gitlab-connector> | `harn add github.com/burin-labs/harn-gitlab-connector@v0.1.0` | `harn connector test . --provider gitlab` |
+| Forgejo | <https://github.com/burin-labs/harn-forgejo-connector> | `harn add github.com/burin-labs/harn-forgejo-connector@v0.1.0` | `harn connector test . --provider forgejo` |
+| Gitea | <https://github.com/burin-labs/harn-gitea-connector> | `harn add github.com/burin-labs/harn-gitea-connector@v0.1.0` | `harn connector test . --provider gitea` |
+| Bitbucket | <https://github.com/burin-labs/harn-bitbucket-connector> | `harn add github.com/burin-labs/harn-bitbucket-connector@v0.1.0` | `harn connector test . --provider bitbucket` |
+| SourceHut | <https://github.com/burin-labs/harn-sourcehut-connector> | `harn add github.com/burin-labs/harn-sourcehut-connector@v0.1.0` | `harn connector test . --provider sourcehut` |
+| Subversion | <https://github.com/burin-labs/harn-svn-connector> | `harn add github.com/burin-labs/harn-svn-connector@v0.1.0` | `harn connector test . --provider svn --run-poll-tick` |
 
 Community connectors are Harn packages that declare `connector_contract = "v1"` and export the connector functions below. Direct GitHub refs are enough for private or pre-registry packages; registry names such as `@burin/notion-connector` are for discoverable package-index entries.
 
@@ -118,7 +118,7 @@ expect_type = "immediate_response"
 expect_event_count = 0
 ```
 
-Run `harn connector check .` locally. Use `--provider <id>` for a multi-provider package, `--run-poll-tick` to execute the first poll tick, and `--json` for CI output.
+Run `harn connector test .` locally. Use `--provider <id>` for a multi-provider package, `--run-poll-tick` to execute the first poll tick, and `--json` for CI output.
 
 ## Example Library
 

--- a/docs/src/connectors/architecture.md
+++ b/docs/src/connectors/architecture.md
@@ -46,13 +46,13 @@ Each package should declare connector contract v1 metadata, ship deterministic
 fixtures, and pass:
 
 ```sh
-harn connector check .
+harn connector test .
 ```
 
 Poll-based packages should also run:
 
 ```sh
-harn connector check . --run-poll-tick
+harn connector test . --run-poll-tick
 ```
 
 ## Rust compatibility shims
@@ -83,7 +83,7 @@ surfaces exist and are tested:
 | Durable inbox dedupe and dispatcher handoff | `crates/harn-vm/src/triggers/inbox.rs`, `triggers/dispatcher/` |
 | Rate-limit and `Retry-After` behavior | connector clients plus shared HTTP retry/backoff builtins |
 | Harn connector contract, `NormalizeResult`, `poll_tick`, and effect policy | `crates/harn-vm/src/connectors/harn_module.rs`, `crates/harn-lint/src/tests/connector_effect_policy.rs` |
-| Connector package conformance harness | `harn connector check` and connector contract fixtures |
+| Connector package conformance harness | `harn connector test`, `harn connector check`, and connector contract fixtures |
 | Catalog, examples, and migration guidance | `docs/src/connectors/catalog.md`, `examples/triggers/`, `docs/src/migrations/rust-connectors-to-harn-packages.md` |
 
 Future work should update those newer ownership surfaces, not reopen the old

--- a/docs/src/connectors/authoring.md
+++ b/docs/src/connectors/authoring.md
@@ -187,16 +187,29 @@ connectors with `HarnConnector::load_with_effect_policies` and
 run that export without the default connector policy, or `set_export_policy` to
 install a narrower host-specific `CapabilityPolicy`.
 
-## Connector contract check
+## Connector package gate
 
-Pure-Harn connector packages should run the package-level contract harness in
-CI:
+Pure-Harn connector packages should run the package-level gate in CI:
+
+```bash
+harn connector test .
+```
+
+The gate validates package metadata, runs `harn check`, `harn lint`,
+`harn fmt --check`, executes package-local `tests/*.harn` fixture programs,
+checks install/import behavior from a clean consumer package, parses standalone
+Harn doc examples, and includes the connector contract check below. Pass
+`--json` to emit a machine-readable readiness report for CI, Harn Cloud, or
+Burin Code.
+
+Use the lower-level contract harness when iterating only on the connector
+module:
 
 ```bash
 harn connector check .
 ```
 
-The command loads the package through its `harn.toml` `[[providers]]` entries,
+That command loads the package through its `harn.toml` `[[providers]]` entries,
 uses the normal Harn-backed connector adapter, and checks connector contract
 v1:
 

--- a/docs/src/connectors/catalog.md
+++ b/docs/src/connectors/catalog.md
@@ -9,7 +9,7 @@ transition plan:
 - GitHub, Slack, Linear, and Notion still have deprecated Rust compatibility
   shims, but new provider business logic belongs in pure-Harn packages.
 - Community connectors are Harn packages that export connector contract v1 and
-  pass `harn connector check`.
+  pass `harn connector test`.
 
 For the architecture and ownership split that closes the old connector-library
 epic, see [Connector architecture status](./architecture.md).
@@ -86,23 +86,23 @@ See `examples/triggers/a2a-reviewer-fanout`.
 Each first-party connector repo should publish:
 
 - repository URL and package install command
-- `harn connector check` command
+- `harn connector test` command
 - required secrets and provider scopes
 - supported trigger/event types
 - mocked fixtures so CI does not need live provider credentials
 
-| Provider | Package repo | Install | Contract check | Required secrets/scopes | Supported trigger/event types |
+| Provider | Package repo | Install | Package gate | Required secrets/scopes | Supported trigger/event types |
 |---|---|---|---|---|---|
-| GitHub | <https://github.com/burin-labs/harn-github-connector> | `harn add github.com/burin-labs/harn-github-connector@v0.1.0` | `harn connector check . --provider github` | Webhook secret; for outbound, GitHub App id, installation id, and private key. App permissions depend on methods: issues, pull requests, contents/metadata, checks, deployments. | `issues`, `pull_request`, `issue_comment`, `pull_request_review`, `push`, `workflow_run`, `deployment_status`, `check_run`; outbound REST/GraphQL escape hatches. |
-| Slack | <https://github.com/burin-labs/harn-slack-connector> | `harn add github.com/burin-labs/harn-slack-connector@v0.1.0` | `harn connector check . --provider slack` | Signing secret; for outbound, bot token. Typical scopes: `app_mentions:read`, `channels:history`, `reactions:read`, `chat:write`, `reactions:write`, `users:read`, `files:write`. | URL verification, `message`, `app_mention`, `reaction_added`, `app_home_opened`, `assistant_thread_started`; outbound Web API calls. |
-| Linear | <https://github.com/burin-labs/harn-linear-connector> | `harn add github.com/burin-labs/harn-linear-connector@v0.1.0` | `harn connector check . --provider linear` | Webhook signing secret; optional API key/access token for outbound GraphQL. | `Issue`, `Comment`, `IssueLabel`, `Project`, `Cycle`, `Customer`, `CustomerRequest`; outbound GraphQL. |
-| Notion | <https://github.com/burin-labs/harn-notion-connector> | `harn add github.com/burin-labs/harn-notion-connector@v0.1.0` | `harn connector check . --provider notion --run-poll-tick` | Webhook verification token; outbound API token. Notion integration capabilities depend on pages/databases/comments used. | Webhook events such as subscription verification, page updates, comments, data source schema updates; `poll_tick` database/page watchers; outbound Notion API via `notion-sdk-harn`. |
-| GitLab | <https://github.com/burin-labs/harn-gitlab-connector> | `harn add github.com/burin-labs/harn-gitlab-connector@v0.1.0` | `harn connector check . --provider gitlab` | Webhook signing secret (plain shared-secret `X-Gitlab-Token`, not HMAC); for outbound, an OAuth2 access token, PAT, or project/group access token with `api` scope. | `push`, `tag_push`, `merge_request`, `note`, `issue`, `pipeline`; outbound REST (notes, MR update/changes/approve, commit status, repository files), GraphQL passthrough, and OAuth2 helpers. |
-| Forgejo | <https://github.com/burin-labs/harn-forgejo-connector> | `harn add github.com/burin-labs/harn-forgejo-connector@v0.1.0` | `harn connector check . --provider forgejo` | Webhook signing secret verified as HMAC-SHA256 from `X-Gitea-Signature`; for outbound, a user, organization, or repository access token accepted by the instance API. | `push`, `pull_request`, `issues`, `issue_comment`, `release`, `repository`, `star`; outbound REST for comments, PR updates, commit statuses, repository contents, and raw API passthrough. |
-| Gitea | <https://github.com/burin-labs/harn-gitea-connector> | `harn add github.com/burin-labs/harn-gitea-connector@v0.1.0` | `harn connector check . --provider gitea` | Webhook signing secret verified as HMAC-SHA256 from `X-Gitea-Signature`; for outbound, an access token scoped to the target self-hosted instance. | `push`, `pull_request`, `issues`, `issue_comment`, `release`, `repository`, `star`; outbound REST for comments, PR updates, commit statuses, repository contents, and raw API passthrough. |
-| Bitbucket | <https://github.com/burin-labs/harn-bitbucket-connector> | `harn add github.com/burin-labs/harn-bitbucket-connector@v0.1.0` | `harn connector check . --provider bitbucket` | Optional webhook signing secret verified as HMAC-SHA256 from `X-Hub-Signature`; `X-Hook-UUID` and `X-Request-UUID` are preserved for dedupe. For outbound, app password, OAuth2 token, or Data Center PAT. | Cloud and Data Center `repo:push`, `pullrequest:*`, `issue:*`, `repo:commit_status_*`; outbound PR comments/updates, commit statuses, repository file fetches, and raw API passthrough. |
-| SourceHut | <https://github.com/burin-labs/harn-sourcehut-connector> | `harn add github.com/burin-labs/harn-sourcehut-connector@v0.1.0` | `harn connector check . --provider sourcehut` | Webhook public key verified with Ed25519 over the raw payload; outbound GraphQL/REST calls use an OAuth2 token or PAT. | Repository push/update events, todo/ticket changes, build notifications, mailing-list oriented message metadata; outbound GraphQL/REST passthrough. |
-| Subversion | <https://github.com/burin-labs/harn-svn-connector> | `harn add github.com/burin-labs/harn-svn-connector@v0.1.0` | `harn connector check . --provider svn --run-poll-tick` | Optional post-commit hook HMAC secret; polling credentials are repository URL plus username/password, SSH key, or ambient host-managed credential helper. | `commit`, `branch`, `tag`, `property_change`; webhook-style post-commit normalization plus `poll_tick` revision scanning for repositories that cannot install hooks. |
+| GitHub | <https://github.com/burin-labs/harn-github-connector> | `harn add github.com/burin-labs/harn-github-connector@v0.1.0` | `harn connector test . --provider github` | Webhook secret; for outbound, GitHub App id, installation id, and private key. App permissions depend on methods: issues, pull requests, contents/metadata, checks, deployments. | `issues`, `pull_request`, `issue_comment`, `pull_request_review`, `push`, `workflow_run`, `deployment_status`, `check_run`; outbound REST/GraphQL escape hatches. |
+| Slack | <https://github.com/burin-labs/harn-slack-connector> | `harn add github.com/burin-labs/harn-slack-connector@v0.1.0` | `harn connector test . --provider slack` | Signing secret; for outbound, bot token. Typical scopes: `app_mentions:read`, `channels:history`, `reactions:read`, `chat:write`, `reactions:write`, `users:read`, `files:write`. | URL verification, `message`, `app_mention`, `reaction_added`, `app_home_opened`, `assistant_thread_started`; outbound Web API calls. |
+| Linear | <https://github.com/burin-labs/harn-linear-connector> | `harn add github.com/burin-labs/harn-linear-connector@v0.1.0` | `harn connector test . --provider linear` | Webhook signing secret; optional API key/access token for outbound GraphQL. | `Issue`, `Comment`, `IssueLabel`, `Project`, `Cycle`, `Customer`, `CustomerRequest`; outbound GraphQL. |
+| Notion | <https://github.com/burin-labs/harn-notion-connector> | `harn add github.com/burin-labs/harn-notion-connector@v0.1.0` | `harn connector test . --provider notion --run-poll-tick` | Webhook verification token; outbound API token. Notion integration capabilities depend on pages/databases/comments used. | Webhook events such as subscription verification, page updates, comments, data source schema updates; `poll_tick` database/page watchers; outbound Notion API via `notion-sdk-harn`. |
+| GitLab | <https://github.com/burin-labs/harn-gitlab-connector> | `harn add github.com/burin-labs/harn-gitlab-connector@v0.1.0` | `harn connector test . --provider gitlab` | Webhook signing secret (plain shared-secret `X-Gitlab-Token`, not HMAC); for outbound, an OAuth2 access token, PAT, or project/group access token with `api` scope. | `push`, `tag_push`, `merge_request`, `note`, `issue`, `pipeline`; outbound REST (notes, MR update/changes/approve, commit status, repository files), GraphQL passthrough, and OAuth2 helpers. |
+| Forgejo | <https://github.com/burin-labs/harn-forgejo-connector> | `harn add github.com/burin-labs/harn-forgejo-connector@v0.1.0` | `harn connector test . --provider forgejo` | Webhook signing secret verified as HMAC-SHA256 from `X-Gitea-Signature`; for outbound, a user, organization, or repository access token accepted by the instance API. | `push`, `pull_request`, `issues`, `issue_comment`, `release`, `repository`, `star`; outbound REST for comments, PR updates, commit statuses, repository contents, and raw API passthrough. |
+| Gitea | <https://github.com/burin-labs/harn-gitea-connector> | `harn add github.com/burin-labs/harn-gitea-connector@v0.1.0` | `harn connector test . --provider gitea` | Webhook signing secret verified as HMAC-SHA256 from `X-Gitea-Signature`; for outbound, an access token scoped to the target self-hosted instance. | `push`, `pull_request`, `issues`, `issue_comment`, `release`, `repository`, `star`; outbound REST for comments, PR updates, commit statuses, repository contents, and raw API passthrough. |
+| Bitbucket | <https://github.com/burin-labs/harn-bitbucket-connector> | `harn add github.com/burin-labs/harn-bitbucket-connector@v0.1.0` | `harn connector test . --provider bitbucket` | Optional webhook signing secret verified as HMAC-SHA256 from `X-Hub-Signature`; `X-Hook-UUID` and `X-Request-UUID` are preserved for dedupe. For outbound, app password, OAuth2 token, or Data Center PAT. | Cloud and Data Center `repo:push`, `pullrequest:*`, `issue:*`, `repo:commit_status_*`; outbound PR comments/updates, commit statuses, repository file fetches, and raw API passthrough. |
+| SourceHut | <https://github.com/burin-labs/harn-sourcehut-connector> | `harn add github.com/burin-labs/harn-sourcehut-connector@v0.1.0` | `harn connector test . --provider sourcehut` | Webhook public key verified with Ed25519 over the raw payload; outbound GraphQL/REST calls use an OAuth2 token or PAT. | Repository push/update events, todo/ticket changes, build notifications, mailing-list oriented message metadata; outbound GraphQL/REST passthrough. |
+| Subversion | <https://github.com/burin-labs/harn-svn-connector> | `harn add github.com/burin-labs/harn-svn-connector@v0.1.0` | `harn connector test . --provider svn --run-poll-tick` | Optional post-commit hook HMAC secret; polling credentials are repository URL plus username/password, SSH key, or ambient host-managed credential helper. | `commit`, `branch`, `tag`, `property_change`; webhook-style post-commit normalization plus `poll_tick` revision scanning for repositories that cannot install hooks. |
 
 Direct GitHub installs are the MVP path. Registry names such as
 `@burin/notion-connector` should be used once the hosted first-party index is
@@ -196,7 +196,7 @@ A community connector is any Harn package that:
 3. Exports `provider_id`, `kinds`, `payload_schema`, and the relevant
    `normalize_inbound`, `poll_tick`, or `call` exports.
 4. Ships deterministic `[connector_contract]` fixtures and passes
-   `harn connector check .`.
+   `harn connector test .`.
 
 Minimal package shape:
 
@@ -232,9 +232,7 @@ expect_event_count = 1
 Run:
 
 ```sh
-harn connector check .
-harn package check .
-harn install --locked --offline
+harn connector test .
 ```
 
 Use live credentials only in provider-specific integration tests. Catalog
@@ -249,7 +247,7 @@ Start with [Connector authoring](./authoring.md), then add:
 - contract fixtures that cover normal event, ack-first response, reject, and
   poll cases where relevant
 - a `README.md` with install, setup, required secrets/scopes, supported events,
-  and `harn connector check` command
+  and `harn connector test` command
 - mocked tests for outbound `call(...)` methods
 - a small recipe example under `examples/triggers/` when the connector is
   first-party or broadly useful

--- a/docs/src/package-authoring.md
+++ b/docs/src/package-authoring.md
@@ -39,16 +39,16 @@ dependencies pinned to a version or rev.
 ```bash
 harn new connector echo-connector
 cd echo-connector
-harn connector check .
-harn test tests/
-harn package check
+harn connector test .
 harn package docs
 harn publish --dry-run
 ```
 
-Connector packages use the same package checks plus `harn connector check .` for
-the pure-Harn connector contract. First-party and community connectors should
-keep this CI shape so package consumers get the same authoring workflow.
+Connector packages use `harn connector test .` as the CI gate. It runs package
+metadata validation, `harn check`, `harn lint`, `harn fmt --check`, connector
+contract fixtures, package-local fixture tests, install/import smoke tests, and
+standalone Harn doc examples. Use `harn connector check .` when you only need
+the lower-level pure-Harn connector contract check.
 
 ## Manifest metadata
 


### PR DESCRIPTION
## Summary

- Add `harn connector test` as the first-class connector package gate with JSON and human reports.
- Gate connector packages through metadata validation, package-owned `harn check`/`lint`/`fmt --check`, connector contract fixtures, package-local fixture programs, clean consumer install/import smoke, and standalone Harn doc examples.
- Update connector docs, generated trigger quickref, and connector template CI/readme guidance to use the single package gate command.

Closes #812.

## Verification

- `cargo fmt --check`
- `cargo check -p harn-cli`
- `cargo test -p harn-cli commands::connector::tests -- --nocapture`
- `cargo test -p harn-cli cli::tests::test_parses_connector_test_args`
- `cargo test -p harn-cli commands::dump_trigger_quickref::tests -- --nocapture`
- `cargo clippy -p harn-cli --bin harn -- -D warnings`
- Pre-commit hook: workspace clippy and generated-doc checks passed.
- Pre-push hook: 2,855 workspace tests passed; markdown lint passed.

I also ran the new gate against the local first-party connector checkouts with `--json`:

- `/Users/ksinder/projects/harn-github-connector` with `--provider github`
- `/Users/ksinder/projects/harn-slack-connector` with `--provider slack`
- `/Users/ksinder/projects/harn-linear-connector` with `--provider linear`
- `/Users/ksinder/projects/harn-notion-connector` with `--provider notion --run-poll-tick`

Those runs produced machine-readable JSON reports and reached the expected package checks. Each currently fails only on existing `harn fmt --check` drift in that connector checkout, with the failing files named directly in the report.
