### PR TITLE
Expose shell discovery host capability

### DIFF
--- a/conformance/tests/runtime/host_capabilities.harn
+++ b/conformance/tests/runtime/host_capabilities.harn
@@ -1,8 +1,10 @@
 pipeline default() {
   let caps = host_capabilities()
   println(host_has("process", "exec"))
+  println(host_has("process", "list_shells"))
   println(caps?.process?.description != nil)
-  let result = host_call("process.exec", {command: "printf hi"})
+  let default_shell = host_call("process.get_default_shell", {})
+  let result = host_call("process.exec", {mode: "shell", command: "printf hi", shell_id: default_shell?.id})
   println(result?.success)
   println(result?.combined)
 }

--- a/conformance/tests/runtime/shell_discovery.expected
+++ b/conformance/tests/runtime/shell_discovery.expected
@@ -2,4 +2,4 @@ true
 true
 true
 true
-hi
+shell-contract

--- a/conformance/tests/runtime/shell_discovery.harn
+++ b/conformance/tests/runtime/shell_discovery.harn
@@ -1,0 +1,17 @@
+pipeline default() {
+  let catalog = host_call("process.list_shells", {})
+  let default_shell = host_call("process.get_default_shell", {})
+  let invocation = host_call(
+    "process.shell_invocation",
+    {shell_id: default_shell?.id, command: "printf shell-contract"},
+  )
+  println(len(catalog?.shells) > 0)
+  println(catalog?.default_shell_id == default_shell?.id)
+  println(invocation?.program == default_shell?.path)
+  println(invocation?.args != nil)
+  let result = host_call(
+    "process.exec",
+    {mode: "shell", shell_id: default_shell?.id, command: "printf shell-contract"},
+  )
+  println(result?.stdout)
+}

--- a/crates/harn-cli/src/commands/check/host_capabilities.rs
+++ b/crates/harn-cli/src/commands/check/host_capabilities.rs
@@ -18,7 +18,16 @@ fn default_host_capabilities() -> HashMap<String, HashSet<String>> {
                 "roots".to_string(),
             ]),
         ),
-        ("process".to_string(), HashSet::from(["exec".to_string()])),
+        (
+            "process".to_string(),
+            HashSet::from([
+                "exec".to_string(),
+                "get_default_shell".to_string(),
+                "list_shells".to_string(),
+                "set_default_shell".to_string(),
+                "shell_invocation".to_string(),
+            ]),
+        ),
         (
             "template".to_string(),
             HashSet::from(["render".to_string()]),

--- a/crates/harn-hostlib/README.md
+++ b/crates/harn-hostlib/README.md
@@ -100,9 +100,11 @@ workspace roots the embedder configured.
 
 - `tools/run_command` is the canonical command runner. It accepts
   `mode: "argv"` with `argv: [string]` as the recommended path, or
-  `mode: "shell"` with an explicit `shell` object when shell evaluation is
-  required. It captures stdout/stderr, enforces `timeout_ms`, forwards
-  optional `cwd`, `env`, `env_mode`, and `stdin`, and returns a command
+  `mode: "shell"` with an explicit `shell` object or `shell_id` from the
+  shared `process.list_shells` / `process.get_default_shell` host
+  capability when shell evaluation is required. It captures stdout/stderr,
+  enforces `timeout_ms`, forwards optional `cwd`, `env`, `env_mode`, and
+  `stdin`, and returns a command
   envelope with `command_id`, `status`, pid/process-group metadata, inline
   output capped by `capture.max_inline_bytes`, full output artifact paths,
   byte/line counts, `output_sha256`, sandbox metadata, and `audit_id`.

--- a/crates/harn-hostlib/schemas/tools/run_command.request.json
+++ b/crates/harn-hostlib/schemas/tools/run_command.request.json
@@ -11,16 +11,34 @@
       "items": { "type": "string" }
     },
     "command": { "type": "string" },
+    "shell_id": {
+      "type": "string",
+      "description": "Stable id from process.list_shells / process.get_default_shell."
+    },
     "shell": {
       "type": "object",
       "properties": {
         "id": { "type": "string" },
+        "label": { "type": "string" },
         "path": { "type": "string" },
-        "login": { "type": "boolean", "default": false },
-        "interactive": { "type": "boolean", "default": false }
+        "platform": { "type": "string" },
+        "available": { "type": "boolean" },
+        "supports_login": { "type": "boolean" },
+        "supports_interactive": { "type": "boolean" },
+        "default_args": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "login_args": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "source": { "type": "string" }
       },
       "additionalProperties": false
     },
+    "login": { "type": "boolean", "default": false },
+    "interactive": { "type": "boolean", "default": false },
     "cwd": { "type": "string" },
     "env": {
       "type": "object",
@@ -73,7 +91,11 @@
     },
     {
       "properties": { "mode": { "const": "shell" } },
-      "required": ["command", "shell"]
+      "required": ["command"],
+      "anyOf": [
+        { "required": ["shell"] },
+        { "required": ["shell_id"] }
+      ]
     }
   ],
   "additionalProperties": false

--- a/crates/harn-hostlib/src/tools/run_command.rs
+++ b/crates/harn-hostlib/src/tools/run_command.rs
@@ -17,6 +17,7 @@
 //!   process exits. See `tools/long_running.rs`.
 
 use harn_vm::VmValue;
+use std::collections::BTreeMap;
 
 use crate::error::HostlibError;
 use crate::tools::payload::{
@@ -103,31 +104,45 @@ fn parse_command(
                     builtin: NAME,
                     param: "command",
                 })?;
-            let shell = match map.get("shell") {
-                Some(VmValue::Dict(shell)) => shell,
-                Some(other) => {
-                    return Err(HostlibError::InvalidParameter {
-                        builtin: NAME,
-                        param: "shell",
-                        message: format!("expected dict, got {}", other.type_name()),
-                    });
+            let mut invocation = BTreeMap::new();
+            invocation.insert(
+                "command".to_string(),
+                VmValue::String(std::rc::Rc::from(command)),
+            );
+            if let Some(shell_id) = optional_string(NAME, map, "shell_id")? {
+                invocation.insert(
+                    "shell_id".to_string(),
+                    VmValue::String(std::rc::Rc::from(shell_id)),
+                );
+            }
+            if let Some(shell) = map.get("shell") {
+                match shell {
+                    VmValue::Dict(_) => {
+                        invocation.insert("shell".to_string(), shell.clone());
+                    }
+                    VmValue::Nil => {}
+                    other => {
+                        return Err(HostlibError::InvalidParameter {
+                            builtin: NAME,
+                            param: "shell",
+                            message: format!("expected dict, got {}", other.type_name()),
+                        });
+                    }
                 }
-                None => {
-                    return Err(HostlibError::MissingParameter {
-                        builtin: NAME,
-                        param: "shell",
-                    });
-                }
-            };
-            let path = shell_string(shell, "path")?
-                .or_else(|| shell_string(shell, "id").ok().flatten())
-                .ok_or(HostlibError::MissingParameter {
+            }
+            if let Some(login) = optional_bool(NAME, map, "login")? {
+                invocation.insert("login".to_string(), VmValue::Bool(login));
+            }
+            if let Some(interactive) = optional_bool(NAME, map, "interactive")? {
+                invocation.insert("interactive".to_string(), VmValue::Bool(interactive));
+            }
+            let resolved = harn_vm::shells::resolve_invocation_from_vm_params(&invocation)
+                .map_err(|message| HostlibError::InvalidParameter {
                     builtin: NAME,
-                    param: "shell.path",
+                    param: "shell",
+                    message,
                 })?;
-            let login = shell_bool(shell, "login")?.unwrap_or(false);
-            let interactive = shell_bool(shell, "interactive")?.unwrap_or(false);
-            Ok(shell_argv(path, command, login, interactive))
+            Ok((resolved.program, resolved.args))
         }
         other => Err(HostlibError::InvalidParameter {
             builtin: NAME,
@@ -189,55 +204,6 @@ fn parse_capture(
         capture.max_inline_bytes = usize::try_from(max).unwrap_or(usize::MAX);
     }
     Ok(capture)
-}
-
-fn shell_argv(
-    shell_path_or_id: String,
-    command: String,
-    login: bool,
-    interactive: bool,
-) -> (String, Vec<String>) {
-    let program = match shell_path_or_id.as_str() {
-        "sh" if cfg!(windows) => "cmd".to_string(),
-        "sh" => "/bin/sh".to_string(),
-        "bash" => "/bin/bash".to_string(),
-        "zsh" => "/bin/zsh".to_string(),
-        "cmd" => "cmd".to_string(),
-        "powershell" => "powershell".to_string(),
-        other => other.to_string(),
-    };
-    if cfg!(windows) && program.eq_ignore_ascii_case("cmd") {
-        return (program, vec!["/C".to_string(), command]);
-    }
-    let mut args = Vec::new();
-    if interactive {
-        args.push("-i".to_string());
-    }
-    args.push(if login { "-lc" } else { "-c" }.to_string());
-    args.push(command);
-    (program, args)
-}
-
-fn shell_string(
-    dict: &std::rc::Rc<std::collections::BTreeMap<String, VmValue>>,
-    key: &'static str,
-) -> Result<Option<String>, HostlibError> {
-    match dict.get(key) {
-        None | Some(VmValue::Nil) => Ok(None),
-        Some(VmValue::String(s)) => Ok(Some(s.to_string())),
-        Some(other) => Err(HostlibError::InvalidParameter {
-            builtin: NAME,
-            param: key,
-            message: format!("expected string, got {}", other.type_name()),
-        }),
-    }
-}
-
-fn shell_bool(
-    dict: &std::rc::Rc<std::collections::BTreeMap<String, VmValue>>,
-    key: &'static str,
-) -> Result<Option<bool>, HostlibError> {
-    dict_bool(dict, key)
 }
 
 fn dict_bool(

--- a/crates/harn-modules/src/stdlib/stdlib_agents.harn
+++ b/crates/harn-modules/src/stdlib/stdlib_agents.harn
@@ -95,7 +95,8 @@ pub fn verify_command(config) {
   if config?.command == nil || config?.command == "" {
     return nil
   }
-  let output = host_call("process.exec", {command: config?.command})
+  let shell = host_call("process.get_default_shell", {})
+  let output = host_call("process.exec", {mode: "shell", command: config?.command, shell_id: shell?.id})
   var ok = output?.success
   if config?.expect_status != nil {
     ok = output?.exit_code ?? output?.legacy_status ?? output?.status == config?.expect_status

--- a/crates/harn-modules/src/stdlib/stdlib_runtime.harn
+++ b/crates/harn-modules/src/stdlib/stdlib_runtime.harn
@@ -20,12 +20,17 @@ pub fn runtime_approved_plan() -> string {
 
 /** process_exec. */
 pub fn process_exec(command) {
-  return host_call("process.exec", {command: command})
+  let shell = host_call("process.get_default_shell", {})
+  return host_call("process.exec", {mode: "shell", command: command, shell_id: shell?.id})
 }
 
 /** process_exec_with_timeout. */
 pub fn process_exec_with_timeout(command, timeout_ms) {
-  return host_call("process.exec", {command: command, timeout: timeout_ms})
+  let shell = host_call("process.get_default_shell", {})
+  return host_call(
+    "process.exec",
+    {mode: "shell", command: command, timeout: timeout_ms, shell_id: shell?.id},
+  )
 }
 
 /** interaction_ask. */
@@ -44,18 +49,18 @@ pub fn record_run_metadata(run, workflow_name) {
     host_call(
       "runtime.record_run",
       {
-      workflow: workflow_name,
-      path: run?.path,
-      status: run?.status ?? "",
-      fixture_type: run?.run?.replay_fixture?._type,
-      usage: run?.usage,
-      persisted_path: run?.persisted_path,
-      summary: transcript_summary(run?.transcript),
-      transcript_state: run?.transcript?.state ?? "",
-      message_count: len(transcript_messages(run?.transcript)),
-      event_count: len(transcript_events(run?.transcript)),
-      asset_count: len(transcript_assets(run?.transcript)),
-    },
+        workflow: workflow_name,
+        path: run?.path,
+        status: run?.status ?? "",
+        fixture_type: run?.run?.replay_fixture?._type,
+        usage: run?.usage,
+        persisted_path: run?.persisted_path,
+        summary: transcript_summary(run?.transcript),
+        transcript_state: run?.transcript?.state ?? "",
+        message_count: len(transcript_messages(run?.transcript)),
+        event_count: len(transcript_events(run?.transcript)),
+        asset_count: len(transcript_assets(run?.transcript)),
+      },
     )
   }
 }

--- a/crates/harn-serve/src/adapters/acp/builtins.rs
+++ b/crates/harn-serve/src/adapters/acp/builtins.rs
@@ -22,6 +22,23 @@ pub(super) async fn register_acp_builtins(vm: &mut harn_vm::Vm, bridge: Rc<AcpBr
             normalize_host_capability_manifest(harn_vm::bridge::json_result_to_vm_value(&result))
         })
         .unwrap_or_else(|_| harn_vm::VmValue::Dict(Rc::new(std::collections::BTreeMap::new())));
+    let selected_shell =
+        if manifest_has_operation(&host_capability_manifest, "process", "get_default_shell") {
+            bridge
+                .call_client(
+                    "host/call",
+                    serde_json::json!({
+                        "sessionId": bridge.session_id,
+                        "name": "process.get_default_shell",
+                        "args": {},
+                    }),
+                )
+                .await
+                .map(|result| harn_vm::bridge::json_result_to_vm_value(&result))
+                .unwrap_or_else(|_| harn_vm::shells::default_shell_vm_value())
+        } else {
+            harn_vm::shells::default_shell_vm_value()
+        };
 
     let b = bridge.clone();
     vm.register_builtin("log", move |args, _out| {
@@ -102,9 +119,11 @@ pub(super) async fn register_acp_builtins(vm: &mut harn_vm::Vm, bridge: Rc<AcpBr
     });
 
     let b = bridge.clone();
+    let shell = selected_shell.clone();
     vm.register_async_builtin("run_command", move |args| {
         let bridge = b.clone();
-        async move { acp_terminal_exec(&bridge, &args).await }
+        let shell = shell.clone();
+        async move { acp_terminal_exec(&bridge, &args, &shell).await }
     });
 
     for level in ["log_debug", "log_info", "log_warn", "log_error"] {
@@ -175,15 +194,19 @@ pub(super) async fn register_acp_builtins(vm: &mut harn_vm::Vm, bridge: Rc<AcpBr
     }
 
     let b = bridge.clone();
+    let shell = selected_shell.clone();
     vm.register_async_builtin("exec", move |args| {
         let bridge = b.clone();
-        async move { acp_terminal_exec(&bridge, &args).await }
+        let shell = shell.clone();
+        async move { acp_terminal_exec(&bridge, &args, &shell).await }
     });
 
     let b = bridge;
+    let shell = selected_shell;
     vm.register_async_builtin("shell", move |args| {
         let bridge = b.clone();
-        async move { acp_terminal_exec(&bridge, &args).await }
+        let shell = shell.clone();
+        async move { acp_terminal_exec(&bridge, &args, &shell).await }
     });
 }
 
@@ -191,6 +214,7 @@ pub(super) async fn register_acp_builtins(vm: &mut harn_vm::Vm, bridge: Rc<AcpBr
 pub(super) async fn acp_terminal_exec(
     bridge: &AcpBridge,
     args: &[harn_vm::VmValue],
+    shell: &harn_vm::VmValue,
 ) -> Result<harn_vm::VmValue, harn_vm::VmError> {
     let cmd = args.first().map(|a| a.display()).unwrap_or_default();
     if cmd.is_empty() {
@@ -205,6 +229,7 @@ pub(super) async fn acp_terminal_exec(
             serde_json::json!({
                 "sessionId": bridge.session_id,
                 "command": cmd,
+                "shell": harn_vm::llm::vm_value_to_json(shell),
             }),
         )
         .await?;
@@ -217,7 +242,7 @@ pub(super) async fn acp_terminal_exec(
 
     if terminal_id.is_empty() {
         // Client doesn't support terminal — fall back to local exec.
-        let output = local_shell_exec(&cmd).map_err(|e| {
+        let output = local_shell_exec(&cmd, shell).map_err(|e| {
             harn_vm::VmError::Thrown(harn_vm::VmValue::String(Rc::from(format!(
                 "exec failed: {e}"
             ))))
@@ -333,8 +358,19 @@ pub(super) fn normalize_host_capability_manifest(value: harn_vm::VmValue) -> har
     let mut normalized = BTreeMap::new();
     for (capability, entry) in root.iter() {
         match entry {
-            harn_vm::VmValue::Dict(_) => {
-                normalized.insert(capability.clone(), entry.clone());
+            harn_vm::VmValue::Dict(dict) => {
+                let mut normalized_entry = (**dict).clone();
+                if !normalized_entry.contains_key("ops") {
+                    if let Some(ops) =
+                        operation_names_from_value(normalized_entry.get("operations"))
+                    {
+                        normalized_entry.insert("ops".to_string(), harn_vm::VmValue::List(ops));
+                    }
+                }
+                normalized.insert(
+                    capability.clone(),
+                    harn_vm::VmValue::Dict(Rc::new(normalized_entry)),
+                );
             }
             harn_vm::VmValue::List(list) => {
                 let mut dict = BTreeMap::new();
@@ -348,27 +384,52 @@ pub(super) fn normalize_host_capability_manifest(value: harn_vm::VmValue) -> har
     harn_vm::VmValue::Dict(Rc::new(normalized))
 }
 
+fn operation_names_from_value(
+    value: Option<&harn_vm::VmValue>,
+) -> Option<Rc<Vec<harn_vm::VmValue>>> {
+    let value = value?;
+    match value {
+        harn_vm::VmValue::List(list) => Some(list.clone()),
+        harn_vm::VmValue::Dict(dict) => Some(Rc::new(
+            dict.keys()
+                .map(|name| harn_vm::VmValue::String(Rc::from(name.clone())))
+                .collect(),
+        )),
+        _ => None,
+    }
+}
+
+fn manifest_has_operation(manifest: &harn_vm::VmValue, capability: &str, op: &str) -> bool {
+    manifest
+        .as_dict()
+        .and_then(|root| root.get(capability))
+        .and_then(|value| value.as_dict())
+        .and_then(|capability| capability.get("ops"))
+        .and_then(|ops| match ops {
+            harn_vm::VmValue::List(list) => Some(list.iter().any(|item| item.display() == op)),
+            _ => None,
+        })
+        .unwrap_or(false)
+}
+
 /// Cross-platform fallback shell exec used when the ACP client doesn't
-/// expose a terminal capability. Picks `sh -c` on Unix and `cmd /C` on
-/// Windows; returns an explanatory error on other platforms.
-#[cfg(unix)]
-fn local_shell_exec(cmd: &str) -> std::io::Result<std::process::Output> {
-    std::process::Command::new("sh").arg("-c").arg(cmd).output()
-}
-
-#[cfg(windows)]
-fn local_shell_exec(cmd: &str) -> std::io::Result<std::process::Output> {
-    std::process::Command::new("cmd")
-        .arg("/C")
-        .arg(cmd)
+/// expose a terminal capability. Uses the same selected-shell descriptor
+/// carried on `terminal/create`.
+fn local_shell_exec(cmd: &str, shell: &harn_vm::VmValue) -> std::io::Result<std::process::Output> {
+    let mut params = BTreeMap::new();
+    params.insert(
+        "command".to_string(),
+        harn_vm::VmValue::String(Rc::from(cmd.to_string())),
+    );
+    params.insert("shell".to_string(), shell.clone());
+    let invocation =
+        harn_vm::shells::resolve_invocation_from_vm_params(&params).map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid shell invocation: {error}"),
+            )
+        })?;
+    std::process::Command::new(invocation.program)
+        .args(invocation.args)
         .output()
-}
-
-#[cfg(not(any(unix, windows)))]
-fn local_shell_exec(_cmd: &str) -> std::io::Result<std::process::Output> {
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "local shell exec fallback is not supported on this platform; \
-         the ACP client must advertise the terminal capability",
-    ))
 }

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -65,6 +65,15 @@ fn harn_acp_extension_meta() -> serde_json::Value {
             "sessionUpdateExtensions": HARN_SESSION_UPDATE_EXTENSIONS,
             "toolLifecycleExtensionFields": HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS,
             "contentExtensionFields": HARN_CONTENT_EXTENSION_FIELDS,
+            "hostCapabilityOperations": {
+                "process": [
+                    "exec",
+                    "list_shells",
+                    "get_default_shell",
+                    "set_default_shell",
+                    "shell_invocation"
+                ]
+            },
             "extensionContract": "docs/src/bridge-protocol.md#acp-compatibility-contract",
         }
     })
@@ -1317,6 +1326,37 @@ mod tests {
         assert!(ops
             .iter()
             .any(|value| value.display() == "scope_test_command"));
+    }
+
+    #[test]
+    fn normalize_host_capabilities_derives_ops_from_operation_metadata() {
+        let mut operations = BTreeMap::new();
+        operations.insert(
+            "get_default_shell".to_string(),
+            VmValue::Dict(Rc::new(BTreeMap::new())),
+        );
+        let mut process = BTreeMap::new();
+        process.insert("operations".to_string(), VmValue::Dict(Rc::new(operations)));
+        let mut root = BTreeMap::new();
+        root.insert("process".to_string(), VmValue::Dict(Rc::new(process)));
+
+        let normalized = normalize_host_capability_manifest(VmValue::Dict(Rc::new(root)));
+        let manifest = normalized.as_dict().expect("dict manifest");
+        let process = manifest
+            .get("process")
+            .and_then(|value| value.as_dict())
+            .expect("process capability dict");
+        let ops = process
+            .get("ops")
+            .and_then(|value| match value {
+                VmValue::List(list) => Some(list),
+                _ => None,
+            })
+            .expect("ops list");
+
+        assert!(ops
+            .iter()
+            .any(|value| value.display() == "get_default_shell"));
     }
 
     #[test]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -33,6 +33,7 @@ pub mod runtime_paths;
 pub mod schema;
 pub mod secrets;
 pub(crate) mod shared_state;
+pub mod shells;
 pub mod skills;
 pub mod stdlib;
 pub mod stdlib_modules;

--- a/crates/harn-vm/src/shells.rs
+++ b/crates/harn-vm/src/shells.rs
@@ -1,5 +1,7 @@
 use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
+#[cfg(not(windows))]
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 

--- a/crates/harn-vm/src/shells.rs
+++ b/crates/harn-vm/src/shells.rs
@@ -1,0 +1,611 @@
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use crate::value::{VmError, VmValue};
+
+thread_local! {
+    static SELECTED_DEFAULT_SHELL_ID: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ShellDescriptor {
+    pub id: String,
+    pub label: String,
+    pub path: String,
+    pub platform: String,
+    pub available: bool,
+    pub supports_login: bool,
+    pub supports_interactive: bool,
+    pub default_args: Vec<String>,
+    pub login_args: Vec<String>,
+    pub source: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ShellCatalog {
+    pub shells: Vec<ShellDescriptor>,
+    pub default_shell_id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ShellInvocation {
+    pub program: String,
+    pub args: Vec<String>,
+    pub command_arg_index: usize,
+    pub shell: ShellDescriptor,
+}
+
+pub fn clear_selected_default_shell_for_test() {
+    SELECTED_DEFAULT_SHELL_ID.with(|selected| *selected.borrow_mut() = None);
+}
+
+pub fn discover_shells() -> ShellCatalog {
+    let shells = platform_shells();
+    let selected = SELECTED_DEFAULT_SHELL_ID.with(|selected| selected.borrow().clone());
+    let default_shell_id = selected
+        .filter(|id| {
+            shells
+                .iter()
+                .any(|shell| shell.id == *id && shell.available)
+        })
+        .or_else(|| {
+            shells
+                .iter()
+                .find(|shell| shell.available)
+                .map(|shell| shell.id.clone())
+        })
+        .or_else(|| shells.first().map(|shell| shell.id.clone()));
+    ShellCatalog {
+        shells,
+        default_shell_id,
+    }
+}
+
+pub fn get_default_shell() -> Option<ShellDescriptor> {
+    let catalog = discover_shells();
+    catalog
+        .default_shell_id
+        .as_deref()
+        .and_then(|id| catalog.shells.iter().find(|shell| shell.id == id))
+        .cloned()
+        .or_else(|| catalog.shells.first().cloned())
+}
+
+pub fn set_default_shell(shell_id: &str) -> Result<ShellDescriptor, String> {
+    let catalog = discover_shells();
+    let Some(shell) = catalog
+        .shells
+        .iter()
+        .find(|shell| shell.id == shell_id && shell.available)
+        .cloned()
+    else {
+        return Err(format!("unknown or unavailable shell id {shell_id:?}"));
+    };
+    SELECTED_DEFAULT_SHELL_ID.with(|selected| *selected.borrow_mut() = Some(shell.id.clone()));
+    Ok(shell)
+}
+
+pub fn list_shells_vm_value() -> VmValue {
+    shell_catalog_to_vm_value(&discover_shells())
+}
+
+pub fn default_shell_vm_value() -> VmValue {
+    get_default_shell()
+        .map(|shell| shell_descriptor_to_vm_value(&shell))
+        .unwrap_or(VmValue::Nil)
+}
+
+pub fn set_default_shell_vm_value(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
+    let shell_id = params
+        .get("shell_id")
+        .or_else(|| params.get("id"))
+        .and_then(vm_string)
+        .ok_or_else(|| {
+            VmError::Runtime("process.set_default_shell missing shell_id".to_string())
+        })?;
+    set_default_shell(shell_id)
+        .map(|shell| shell_descriptor_to_vm_value(&shell))
+        .map_err(|err| VmError::Runtime(format!("process.set_default_shell: {err}")))
+}
+
+pub fn shell_invocation_vm_value(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
+    resolve_invocation_from_vm_params(params)
+        .map(|invocation| shell_invocation_to_vm_value(&invocation))
+        .map_err(|err| VmError::Runtime(format!("process.shell_invocation: {err}")))
+}
+
+pub fn default_shell_invocation(command: &str) -> Result<ShellInvocation, String> {
+    let shell = get_default_shell().ok_or_else(|| "no shell candidates available".to_string())?;
+    Ok(invocation_for_shell(
+        shell,
+        command.to_string(),
+        false,
+        false,
+    ))
+}
+
+pub fn resolve_invocation_from_vm_params(
+    params: &BTreeMap<String, VmValue>,
+) -> Result<ShellInvocation, String> {
+    let command = params
+        .get("command")
+        .and_then(vm_string)
+        .unwrap_or("{command}")
+        .to_string();
+    let login = optional_bool(params, "login").unwrap_or(false);
+    let interactive = optional_bool(params, "interactive").unwrap_or(false);
+    let shell = resolve_shell_from_vm_params(params)?;
+    Ok(invocation_for_shell(shell, command, login, interactive))
+}
+
+pub fn resolve_shell_from_vm_params(
+    params: &BTreeMap<String, VmValue>,
+) -> Result<ShellDescriptor, String> {
+    if let Some(shell) = params.get("shell").and_then(|value| value.as_dict()) {
+        return shell_descriptor_from_vm_dict(shell);
+    }
+    if let Some(shell_id) = params.get("shell_id").and_then(vm_string) {
+        return shell_by_id(shell_id);
+    }
+    Err("shell mode requires `shell` or `shell_id`".to_string())
+}
+
+pub fn shell_descriptor_to_vm_value(shell: &ShellDescriptor) -> VmValue {
+    let mut map = BTreeMap::new();
+    map.insert("id".to_string(), string(&shell.id));
+    map.insert("label".to_string(), string(&shell.label));
+    map.insert("path".to_string(), string(&shell.path));
+    map.insert("platform".to_string(), string(&shell.platform));
+    map.insert("available".to_string(), VmValue::Bool(shell.available));
+    map.insert(
+        "supports_login".to_string(),
+        VmValue::Bool(shell.supports_login),
+    );
+    map.insert(
+        "supports_interactive".to_string(),
+        VmValue::Bool(shell.supports_interactive),
+    );
+    map.insert("default_args".to_string(), string_list(&shell.default_args));
+    map.insert("login_args".to_string(), string_list(&shell.login_args));
+    map.insert("source".to_string(), string(&shell.source));
+    VmValue::Dict(Rc::new(map))
+}
+
+pub fn shell_invocation_to_vm_value(invocation: &ShellInvocation) -> VmValue {
+    let mut map = BTreeMap::new();
+    map.insert("program".to_string(), string(&invocation.program));
+    map.insert("args".to_string(), string_list(&invocation.args));
+    map.insert(
+        "command_arg_index".to_string(),
+        VmValue::Int(invocation.command_arg_index as i64),
+    );
+    map.insert(
+        "shell".to_string(),
+        shell_descriptor_to_vm_value(&invocation.shell),
+    );
+    VmValue::Dict(Rc::new(map))
+}
+
+fn shell_catalog_to_vm_value(catalog: &ShellCatalog) -> VmValue {
+    let mut map = BTreeMap::new();
+    map.insert(
+        "shells".to_string(),
+        VmValue::List(Rc::new(
+            catalog
+                .shells
+                .iter()
+                .map(shell_descriptor_to_vm_value)
+                .collect(),
+        )),
+    );
+    map.insert(
+        "default_shell_id".to_string(),
+        catalog
+            .default_shell_id
+            .as_ref()
+            .map(|id| string(id))
+            .unwrap_or(VmValue::Nil),
+    );
+    VmValue::Dict(Rc::new(map))
+}
+
+fn shell_descriptor_from_vm_dict(
+    dict: &BTreeMap<String, VmValue>,
+) -> Result<ShellDescriptor, String> {
+    if let Some(path) = dict.get("path").and_then(vm_string) {
+        let id = dict
+            .get("id")
+            .and_then(vm_string)
+            .map(ToString::to_string)
+            .unwrap_or_else(|| shell_id_from_path(path));
+        let platform = dict
+            .get("platform")
+            .and_then(vm_string)
+            .unwrap_or(platform_name())
+            .to_string();
+        let label = dict
+            .get("label")
+            .and_then(vm_string)
+            .map(ToString::to_string)
+            .unwrap_or_else(|| id.clone());
+        let default_args = dict
+            .get("default_args")
+            .and_then(vm_string_list)
+            .unwrap_or_else(|| default_args_for_id(&id));
+        let login_args = dict
+            .get("login_args")
+            .and_then(vm_string_list)
+            .unwrap_or_else(|| login_args_for_id(&id));
+        let available = dict
+            .get("available")
+            .and_then(|value| match value {
+                VmValue::Bool(value) => Some(*value),
+                _ => None,
+            })
+            .unwrap_or_else(|| executable_available(path));
+        let supports_login = dict
+            .get("supports_login")
+            .and_then(|value| match value {
+                VmValue::Bool(value) => Some(*value),
+                _ => None,
+            })
+            .unwrap_or_else(|| supports_login_for_id(&id));
+        let supports_interactive = dict
+            .get("supports_interactive")
+            .and_then(|value| match value {
+                VmValue::Bool(value) => Some(*value),
+                _ => None,
+            })
+            .unwrap_or_else(|| supports_interactive_for_id(&id));
+        return Ok(ShellDescriptor {
+            id,
+            label,
+            path: path.to_string(),
+            platform,
+            available,
+            supports_login,
+            supports_interactive,
+            default_args,
+            login_args,
+            source: dict
+                .get("source")
+                .and_then(vm_string)
+                .unwrap_or("host")
+                .to_string(),
+        });
+    }
+    if let Some(id) = dict.get("id").and_then(vm_string) {
+        return shell_by_id(id);
+    }
+    Err("shell object requires `path` or `id`".to_string())
+}
+
+fn shell_by_id(shell_id: &str) -> Result<ShellDescriptor, String> {
+    discover_shells()
+        .shells
+        .into_iter()
+        .find(|shell| shell.id == shell_id)
+        .ok_or_else(|| format!("unknown shell id {shell_id:?}"))
+}
+
+fn invocation_for_shell(
+    shell: ShellDescriptor,
+    command: String,
+    login: bool,
+    interactive: bool,
+) -> ShellInvocation {
+    let mut args = if login && shell.supports_login && !shell.login_args.is_empty() {
+        shell.login_args.clone()
+    } else {
+        shell.default_args.clone()
+    };
+    if interactive && shell.supports_interactive && !args.iter().any(|arg| arg == "-i") {
+        args.insert(0, "-i".to_string());
+    }
+    let command_arg_index = args.len();
+    args.push(command);
+    ShellInvocation {
+        program: shell.path.clone(),
+        args,
+        command_arg_index,
+        shell,
+    }
+}
+
+#[cfg(windows)]
+fn platform_shells() -> Vec<ShellDescriptor> {
+    let mut shells = Vec::new();
+    if let Ok(value) = std::env::var("HARN_DEFAULT_SHELL") {
+        push_shell(&mut shells, descriptor_for_path(&value, "configured"));
+    }
+    if let Ok(value) = std::env::var("COMSPEC") {
+        push_shell(&mut shells, descriptor_for_path(&value, "env"));
+    }
+    for (id, label, executable) in [
+        ("pwsh", "PowerShell 7", "pwsh.exe"),
+        ("powershell", "Windows PowerShell", "powershell.exe"),
+        ("cmd", "cmd", "cmd.exe"),
+    ] {
+        let path = find_on_path(executable).unwrap_or_else(|| executable.to_string());
+        let mut shell = descriptor_for_path(&path, "fallback");
+        shell.id = id.to_string();
+        shell.label = label.to_string();
+        push_shell(&mut shells, shell);
+    }
+    shells
+}
+
+#[cfg(not(windows))]
+fn platform_shells() -> Vec<ShellDescriptor> {
+    let mut shells = Vec::new();
+    if let Ok(value) = std::env::var("HARN_DEFAULT_SHELL") {
+        push_shell(&mut shells, descriptor_for_path(&value, "configured"));
+    }
+    if let Ok(value) = std::env::var("SHELL") {
+        push_shell(&mut shells, descriptor_for_path(&value, "env"));
+    }
+    if let Some(value) = login_shell_from_passwd() {
+        push_shell(&mut shells, descriptor_for_path(&value, "login"));
+    }
+    for value in shells_from_etc_shells() {
+        push_shell(&mut shells, descriptor_for_path(&value, "etc_shells"));
+    }
+    for value in [
+        "/bin/zsh",
+        "/bin/bash",
+        "/bin/sh",
+        "/usr/bin/zsh",
+        "/usr/bin/bash",
+        "/usr/bin/sh",
+    ] {
+        push_shell(&mut shells, descriptor_for_path(value, "fallback"));
+    }
+    shells
+}
+
+fn push_shell(shells: &mut Vec<ShellDescriptor>, shell: ShellDescriptor) {
+    if shells.iter().any(|existing| existing.id == shell.id) {
+        return;
+    }
+    shells.push(shell);
+}
+
+fn descriptor_for_path(path: &str, source: &str) -> ShellDescriptor {
+    let id = shell_id_from_path(path);
+    ShellDescriptor {
+        id: id.clone(),
+        label: label_for_id(&id),
+        path: path.to_string(),
+        platform: platform_name().to_string(),
+        available: executable_available(path),
+        supports_login: supports_login_for_id(&id),
+        supports_interactive: supports_interactive_for_id(&id),
+        default_args: default_args_for_id(&id),
+        login_args: login_args_for_id(&id),
+        source: source.to_string(),
+    }
+}
+
+fn shell_id_from_path(path: &str) -> String {
+    let raw = Path::new(path)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(path)
+        .to_ascii_lowercase();
+    let file_name = raw.strip_suffix(".exe").unwrap_or(&raw);
+    match file_name {
+        "powershell" | "windowspowershell" => "powershell".to_string(),
+        "pwsh" => "pwsh".to_string(),
+        "cmd" => "cmd".to_string(),
+        "bash" => "bash".to_string(),
+        "zsh" => "zsh".to_string(),
+        "fish" => "fish".to_string(),
+        _ if file_name.is_empty() => "shell".to_string(),
+        _ => file_name.to_string(),
+    }
+}
+
+fn label_for_id(id: &str) -> String {
+    match id {
+        "pwsh" => "PowerShell 7",
+        "powershell" => "Windows PowerShell",
+        "cmd" => "cmd",
+        "bash" => "bash",
+        "zsh" => "zsh",
+        "fish" => "fish",
+        "sh" => "sh",
+        other => other,
+    }
+    .to_string()
+}
+
+fn default_args_for_id(id: &str) -> Vec<String> {
+    match id {
+        "cmd" => vec!["/C".to_string()],
+        "pwsh" | "powershell" => vec!["-NoProfile".to_string(), "-Command".to_string()],
+        _ => vec!["-c".to_string()],
+    }
+}
+
+fn login_args_for_id(id: &str) -> Vec<String> {
+    match id {
+        "cmd" | "pwsh" | "powershell" => default_args_for_id(id),
+        _ => vec!["-l".to_string(), "-c".to_string()],
+    }
+}
+
+fn supports_login_for_id(id: &str) -> bool {
+    !matches!(id, "cmd" | "pwsh" | "powershell")
+}
+
+fn supports_interactive_for_id(id: &str) -> bool {
+    !matches!(id, "cmd" | "pwsh" | "powershell")
+}
+
+fn platform_name() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "darwin"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else if cfg!(target_os = "linux") {
+        "linux"
+    } else {
+        std::env::consts::OS
+    }
+}
+
+fn executable_available(path: &str) -> bool {
+    let path_obj = Path::new(path);
+    if path_obj.components().count() > 1 || path_obj.is_absolute() {
+        return path_obj.is_file();
+    }
+    find_on_path(path).is_some()
+}
+
+fn find_on_path(program: &str) -> Option<String> {
+    let path = std::env::var_os("PATH")?;
+    let candidates = path_candidates(program);
+    for dir in std::env::split_paths(&path) {
+        for candidate in &candidates {
+            let full = dir.join(candidate);
+            if full.is_file() {
+                return Some(full.display().to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(windows)]
+fn path_candidates(program: &str) -> Vec<PathBuf> {
+    let mut candidates = vec![PathBuf::from(program)];
+    if Path::new(program).extension().is_none() {
+        for ext in [".exe", ".cmd", ".bat"] {
+            candidates.push(PathBuf::from(format!("{program}{ext}")));
+        }
+    }
+    candidates
+}
+
+#[cfg(not(windows))]
+fn path_candidates(program: &str) -> Vec<PathBuf> {
+    vec![PathBuf::from(program)]
+}
+
+#[cfg(not(windows))]
+fn login_shell_from_passwd() -> Option<String> {
+    let username = std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .ok()?;
+    let passwd = std::fs::read_to_string("/etc/passwd").ok()?;
+    passwd.lines().find_map(|line| {
+        let mut parts = line.split(':');
+        let name = parts.next()?;
+        if name != username {
+            return None;
+        }
+        parts
+            .nth(5)
+            .map(str::trim)
+            .filter(|shell| {
+                !shell.is_empty() && !shell.ends_with("/false") && !shell.ends_with("/nologin")
+            })
+            .map(ToString::to_string)
+    })
+}
+
+#[cfg(not(windows))]
+fn shells_from_etc_shells() -> Vec<String> {
+    let Ok(content) = std::fs::read_to_string("/etc/shells") else {
+        return Vec::new();
+    };
+    let mut seen = BTreeSet::new();
+    content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#') && line.starts_with('/'))
+        .filter(|line| seen.insert((*line).to_string()))
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn optional_bool(params: &BTreeMap<String, VmValue>, key: &str) -> Option<bool> {
+    match params.get(key) {
+        Some(VmValue::Bool(value)) => Some(*value),
+        _ => None,
+    }
+}
+
+fn vm_string(value: &VmValue) -> Option<&str> {
+    match value {
+        VmValue::String(value) => Some(value.as_ref()),
+        _ => None,
+    }
+}
+
+fn vm_string_list(value: &VmValue) -> Option<Vec<String>> {
+    let VmValue::List(values) = value else {
+        return None;
+    };
+    values
+        .iter()
+        .map(|value| vm_string(value).map(ToString::to_string))
+        .collect()
+}
+
+fn string(value: &str) -> VmValue {
+    VmValue::String(Rc::from(value.to_string()))
+}
+
+fn string_list(values: &[String]) -> VmValue {
+    VmValue::List(Rc::new(values.iter().map(|value| string(value)).collect()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unix_shell_descriptor_uses_split_login_args() {
+        let shell = descriptor_for_path("/bin/zsh", "fallback");
+        assert_eq!(shell.id, "zsh");
+        assert_eq!(shell.default_args, vec!["-c"]);
+        assert_eq!(shell.login_args, vec!["-l", "-c"]);
+        assert!(shell.supports_login);
+        assert!(shell.supports_interactive);
+    }
+
+    #[test]
+    fn windows_shell_descriptor_distinguishes_cmd_and_pwsh() {
+        let cmd = descriptor_for_path("cmd.exe", "fallback");
+        assert_eq!(cmd.id, "cmd");
+        assert_eq!(cmd.default_args, vec!["/C"]);
+        assert!(!cmd.supports_login);
+
+        let pwsh = descriptor_for_path("pwsh.exe", "fallback");
+        assert_eq!(pwsh.id, "pwsh");
+        assert_eq!(pwsh.default_args, vec!["-NoProfile", "-Command"]);
+    }
+
+    #[test]
+    fn invocation_appends_command_after_shell_args() {
+        let shell = ShellDescriptor {
+            id: "zsh".to_string(),
+            label: "zsh".to_string(),
+            path: "/bin/zsh".to_string(),
+            platform: "darwin".to_string(),
+            available: true,
+            supports_login: true,
+            supports_interactive: true,
+            default_args: vec!["-c".to_string()],
+            login_args: vec!["-l".to_string(), "-c".to_string()],
+            source: "test".to_string(),
+        };
+        let invocation = invocation_for_shell(shell, "echo ok".to_string(), true, true);
+        assert_eq!(invocation.program, "/bin/zsh");
+        assert_eq!(invocation.args, vec!["-i", "-l", "-c", "echo ok"]);
+        assert_eq!(invocation.command_arg_index, 3);
+    }
+}

--- a/crates/harn-vm/src/stdlib/host.rs
+++ b/crates/harn-vm/src/stdlib/host.rs
@@ -70,7 +70,22 @@ fn capability_manifest_map() -> BTreeMap<String, VmValue> {
         "process".to_string(),
         capability(
             "Process execution.",
-            &[op("exec", "Execute a shell command.")],
+            &[
+                op("exec", "Execute a process in argv or explicit shell mode."),
+                op("list_shells", "List shells discovered by the host/session."),
+                op(
+                    "get_default_shell",
+                    "Return the selected default shell for this host/session.",
+                ),
+                op(
+                    "set_default_shell",
+                    "Select the default shell for this host/session.",
+                ),
+                op(
+                    "shell_invocation",
+                    "Resolve a shell id/object plus login/interactive flags into argv.",
+                ),
+            ],
         ),
     );
     root.insert(
@@ -525,6 +540,10 @@ async fn dispatch_host_operation(
                 timed_out,
             }))
         }
+        ("process", "list_shells") => Ok(crate::shells::list_shells_vm_value()),
+        ("process", "get_default_shell") => Ok(crate::shells::default_shell_vm_value()),
+        ("process", "set_default_shell") => crate::shells::set_default_shell_vm_value(params),
+        ("process", "shell_invocation") => crate::shells::shell_invocation_vm_value(params),
         ("template", "render") => {
             let path = require_param(params, "path")?;
             let bindings = params.get("bindings").and_then(|v| v.as_dict());
@@ -671,18 +690,12 @@ fn process_exec_argv(params: &BTreeMap<String, VmValue>) -> Result<(String, Vec<
         }
         "shell" => {
             let command = require_param(params, "command")?;
-            if cfg!(windows) {
-                Ok(("cmd".to_string(), vec!["/C".to_string(), command]))
-            } else {
-                let shell = params
-                    .get("shell")
-                    .and_then(|value| value.as_dict())
-                    .and_then(|dict| dict.get("path").or_else(|| dict.get("id")))
-                    .and_then(vm_string)
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "/bin/sh".to_string());
-                Ok((shell, vec!["-lc".to_string(), command]))
-            }
+            let mut invocation_params = params.clone();
+            invocation_params.insert("command".to_string(), VmValue::String(Rc::from(command)));
+            let invocation =
+                crate::shells::resolve_invocation_from_vm_params(&invocation_params)
+                    .map_err(|err| VmError::Runtime(format!("host_call process.exec: {err}")))?;
+            Ok((invocation.program, invocation.args))
         }
         other => Err(VmError::Runtime(format!(
             "host_call process.exec unsupported mode {other:?}"

--- a/crates/harn-vm/src/stdlib/process.rs
+++ b/crates/harn-vm/src/stdlib/process.rs
@@ -142,17 +142,9 @@ pub(crate) fn register_process_builtins(vm: &mut Vm) {
                 "shell: command string is required",
             ))));
         }
-        let shell = if cfg!(target_os = "windows") {
-            "cmd"
-        } else {
-            "sh"
-        };
-        let flag = if cfg!(target_os = "windows") {
-            "/C"
-        } else {
-            "-c"
-        };
-        let output = exec_shell(None, shell, flag, &cmd)?;
+        let invocation = crate::shells::default_shell_invocation(&cmd)
+            .map_err(|error| VmError::Runtime(format!("shell: {error}")))?;
+        let output = exec_shell_args(None, &invocation.program, &invocation.args)?;
         Ok(vm_output_to_value(output))
     });
 
@@ -182,17 +174,9 @@ pub(crate) fn register_process_builtins(vm: &mut Vm) {
                 "shell_at: command string is required",
             ))));
         }
-        let shell = if cfg!(target_os = "windows") {
-            "cmd"
-        } else {
-            "sh"
-        };
-        let flag = if cfg!(target_os = "windows") {
-            "/C"
-        } else {
-            "-c"
-        };
-        let output = exec_shell(Some(dir.as_str()), shell, flag, &cmd)?;
+        let invocation = crate::shells::default_shell_invocation(&cmd)
+            .map_err(|error| VmError::Runtime(format!("shell_at: {error}")))?;
+        let output = exec_shell_args(Some(dir.as_str()), &invocation.program, &invocation.args)?;
         Ok(vm_output_to_value(output))
     });
 
@@ -396,6 +380,7 @@ fn exec_command(
         .map_err(|error| prefix_process_error(error, "exec"))
 }
 
+#[cfg(test)]
 fn exec_shell(
     dir: Option<&str>,
     shell: &str,
@@ -403,8 +388,16 @@ fn exec_shell(
     script: &str,
 ) -> Result<std::process::Output, VmError> {
     let args = vec![flag.to_string(), script.to_string()];
+    exec_shell_args(dir, shell, &args)
+}
+
+fn exec_shell_args(
+    dir: Option<&str>,
+    shell: &str,
+    args: &[String],
+) -> Result<std::process::Output, VmError> {
     let config = process_command_config(dir)?;
-    crate::stdlib::sandbox::command_output(shell, &args, &config)
+    crate::stdlib::sandbox::command_output(shell, args, &config)
         .map_err(|error| prefix_process_error(error, "shell"))
 }
 

--- a/crates/harn-vm/src/stdlib_agents.harn
+++ b/crates/harn-vm/src/stdlib_agents.harn
@@ -95,7 +95,8 @@ pub fn verify_command(config) {
   if config?.command == nil || config?.command == "" {
     return nil
   }
-  let output = host_call("process.exec", {command: config?.command})
+  let shell = host_call("process.get_default_shell", {})
+  let output = host_call("process.exec", {mode: "shell", command: config?.command, shell_id: shell?.id})
   var ok = output?.success
   if config?.expect_status != nil {
     ok = output?.exit_code ?? output?.legacy_status ?? output?.status == config?.expect_status

--- a/crates/harn-vm/src/stdlib_runtime.harn
+++ b/crates/harn-vm/src/stdlib_runtime.harn
@@ -20,12 +20,17 @@ pub fn runtime_approved_plan() -> string {
 
 /** process_exec. */
 pub fn process_exec(command) {
-  return host_call("process.exec", {command: command})
+  let shell = host_call("process.get_default_shell", {})
+  return host_call("process.exec", {mode: "shell", command: command, shell_id: shell?.id})
 }
 
 /** process_exec_with_timeout. */
 pub fn process_exec_with_timeout(command, timeout_ms) {
-  return host_call("process.exec", {command: command, timeout: timeout_ms})
+  let shell = host_call("process.get_default_shell", {})
+  return host_call(
+    "process.exec",
+    {mode: "shell", command: command, timeout: timeout_ms, shell_id: shell?.id},
+  )
 }
 
 /** interaction_ask. */
@@ -44,18 +49,18 @@ pub fn record_run_metadata(run, workflow_name) {
     host_call(
       "runtime.record_run",
       {
-      workflow: workflow_name,
-      path: run?.path,
-      status: run?.status ?? "",
-      fixture_type: run?.run?.replay_fixture?._type,
-      usage: run?.usage,
-      persisted_path: run?.persisted_path,
-      summary: transcript_summary(run?.transcript),
-      transcript_state: run?.transcript?.state ?? "",
-      message_count: len(transcript_messages(run?.transcript)),
-      event_count: len(transcript_events(run?.transcript)),
-      asset_count: len(transcript_assets(run?.transcript)),
-    },
+        workflow: workflow_name,
+        path: run?.path,
+        status: run?.status ?? "",
+        fixture_type: run?.run?.replay_fixture?._type,
+        usage: run?.usage,
+        persisted_path: run?.persisted_path,
+        summary: transcript_summary(run?.transcript),
+        transcript_state: run?.transcript?.state ?? "",
+        message_count: len(transcript_messages(run?.transcript)),
+        event_count: len(transcript_events(run?.transcript)),
+        asset_count: len(transcript_assets(run?.transcript)),
+      },
     )
   }
 }

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -419,6 +419,80 @@ Invocation:
   existing `builtin_call` bridge request using `name` as the builtin
   name and `args` as the single argument payload.
 
+## Shell discovery host capability
+
+Shell discovery is a typed `process` host capability so IDEs, TUIs,
+headless CLI runs, and cloud workers can share one shell-selection
+contract. Harn's standalone fallback exposes the same operations when no
+bridge host is attached.
+
+### `process.list_shells`
+
+Called through `host_call("process.list_shells", {})`. The response is:
+
+```json
+{
+  "shells": [
+    {
+      "id": "zsh",
+      "label": "zsh",
+      "path": "/bin/zsh",
+      "platform": "darwin",
+      "available": true,
+      "supports_login": true,
+      "supports_interactive": true,
+      "default_args": ["-c"],
+      "login_args": ["-l", "-c"],
+      "source": "env"
+    }
+  ],
+  "default_shell_id": "zsh"
+}
+```
+
+Windows hosts should distinguish `pwsh`, `powershell`, and `cmd`.
+`cmd` uses `["/C"]`; PowerShell variants use
+`["-NoProfile", "-Command"]`.
+
+### `process.get_default_shell` / `process.set_default_shell`
+
+`process.get_default_shell` returns the selected shell object for the
+session. Stateful hosts may implement `process.set_default_shell` with
+`{ "shell_id": "zsh" }`; hosts that keep persistence in editor settings
+can omit persistence and still pass the selected shell on command
+requests.
+
+### `process.shell_invocation`
+
+`process.shell_invocation` resolves a discovered shell ID or shell object
+into executable argv:
+
+```json
+{
+  "shell_id": "zsh",
+  "command": "printf ok",
+  "login": false,
+  "interactive": false
+}
+```
+
+Response:
+
+```json
+{
+  "program": "/bin/zsh",
+  "args": ["-c", "printf ok"],
+  "command_arg_index": 1,
+  "shell": {"id": "zsh"}
+}
+```
+
+Shell-mode command runners must pass a shell object or a shell ID
+resolved through this capability. `argv` mode remains preferred for
+programmatic execution; shell mode is for user-authored commands and
+interactive shell semantics. The normative JSON Schema lives at
+`spec/schemas/host-shell-discovery.schema.json`.
+
 ## Skill registry
 
 Hosts expose their own managed skill store to the VM through three RPCs.

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1269,6 +1269,21 @@ host bridge. The local runtime exposes generic `process`, `template`, and
 `interaction` capabilities. Product hosts can add capabilities such as
 `workspace`, `project`, `runtime`, `editor`, `git`, or `diagnostics`.
 
+The `process` capability includes the shell discovery contract used by
+shell-mode command runners:
+
+- `process.list_shells` returns `{shells, default_shell_id}` with stable shell
+  IDs, paths, platform, availability, invocation args, and source.
+- `process.get_default_shell` returns the selected shell object for the
+  current host/session.
+- `process.set_default_shell` selects a shell by `shell_id` for stateful hosts.
+- `process.shell_invocation` resolves `{shell_id | shell, command?, login?,
+  interactive?}` to `{program, args, command_arg_index, shell}`.
+
+Programmatic execution should prefer argv mode (`process.exec` with
+`mode: "argv"`). Shell mode is for user-authored commands and must pass a
+shell object or a shell ID discovered through this capability.
+
 Prefer `host_call("capability.operation", args)` in shared wrappers and
 host-owned `.harn` modules so capability names stay consistent across the
 runtime, host manifest, and preflight validation.

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -3978,6 +3978,29 @@ applied with transaction-local `set_config(name, value, true)` for RLS
 policies. Schema migrations are host-owned; Harn does not maintain a migration
 ledger.
 
+## Host shell discovery
+
+The `process` host capability owns shell discovery and shell-mode invocation.
+This keeps IDEs, TUIs, headless CLI runs, and cloud workers on the same
+contract instead of hardcoding `/bin/sh`, `cmd`, or host-specific settings in
+each integration.
+
+- `process.list_shells` returns `{shells, default_shell_id}`. Each shell entry
+  has `id`, `label`, `path`, `platform`, `available`, `supports_login`,
+  `supports_interactive`, `default_args`, `login_args`, and `source`.
+- `process.get_default_shell` returns the selected shell object for the
+  current host/session.
+- `process.set_default_shell` may be implemented by stateful hosts. Harn's
+  standalone fallback stores the selection for the current thread/session.
+- `process.shell_invocation` resolves `{shell_id | shell, command?, login?,
+  interactive?}` into `{program, args, command_arg_index, shell}`.
+
+Shell-mode command runners must pass a shell object or a shell ID resolved
+through this capability. `argv` mode remains preferred for programmatic
+execution; shell mode is for user-authored commands and interactive shell
+semantics. The normative schema is
+`spec/schemas/host-shell-discovery.schema.json`.
+
 ## Workspace manifest (`harn.toml`)
 
 Harn projects declare a workspace manifest at the project root named

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -3976,6 +3976,29 @@ applied with transaction-local `set_config(name, value, true)` for RLS
 policies. Schema migrations are host-owned; Harn does not maintain a migration
 ledger.
 
+## Host shell discovery
+
+The `process` host capability owns shell discovery and shell-mode invocation.
+This keeps IDEs, TUIs, headless CLI runs, and cloud workers on the same
+contract instead of hardcoding `/bin/sh`, `cmd`, or host-specific settings in
+each integration.
+
+- `process.list_shells` returns `{shells, default_shell_id}`. Each shell entry
+  has `id`, `label`, `path`, `platform`, `available`, `supports_login`,
+  `supports_interactive`, `default_args`, `login_args`, and `source`.
+- `process.get_default_shell` returns the selected shell object for the
+  current host/session.
+- `process.set_default_shell` may be implemented by stateful hosts. Harn's
+  standalone fallback stores the selection for the current thread/session.
+- `process.shell_invocation` resolves `{shell_id | shell, command?, login?,
+  interactive?}` into `{program, args, command_arg_index, shell}`.
+
+Shell-mode command runners must pass a shell object or a shell ID resolved
+through this capability. `argv` mode remains preferred for programmatic
+execution; shell mode is for user-authored commands and interactive shell
+semantics. The normative schema is
+`spec/schemas/host-shell-discovery.schema.json`.
+
 ## Workspace manifest (`harn.toml`)
 
 Harn projects declare a workspace manifest at the project root named

--- a/spec/schemas/host-shell-discovery.schema.json
+++ b/spec/schemas/host-shell-discovery.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/host-shell-discovery.schema.json",
+  "title": "Harn host shell discovery contract",
+  "$defs": {
+    "shell": {
+      "type": "object",
+      "required": [
+        "id",
+        "label",
+        "path",
+        "platform",
+        "available",
+        "supports_login",
+        "supports_interactive",
+        "default_args",
+        "login_args",
+        "source"
+      ],
+      "properties": {
+        "id": { "type": "string" },
+        "label": { "type": "string" },
+        "path": { "type": "string" },
+        "platform": {
+          "type": "string",
+          "description": "Runtime platform such as darwin, linux, or windows."
+        },
+        "available": { "type": "boolean" },
+        "supports_login": { "type": "boolean" },
+        "supports_interactive": { "type": "boolean" },
+        "default_args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Arguments before the command string for normal shell execution."
+        },
+        "login_args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Arguments before the command string for login shell execution."
+        },
+        "source": {
+          "type": "string",
+          "enum": ["configured", "env", "login", "etc_shells", "fallback", "host"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "list_shells_response": {
+      "type": "object",
+      "required": ["shells", "default_shell_id"],
+      "properties": {
+        "shells": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/shell" }
+        },
+        "default_shell_id": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "shell_invocation_request": {
+      "type": "object",
+      "properties": {
+        "shell_id": { "type": "string" },
+        "shell": { "$ref": "#/$defs/shell" },
+        "command": { "type": "string" },
+        "login": { "type": "boolean", "default": false },
+        "interactive": { "type": "boolean", "default": false }
+      },
+      "anyOf": [{ "required": ["shell_id"] }, { "required": ["shell"] }],
+      "additionalProperties": false
+    },
+    "shell_invocation_response": {
+      "type": "object",
+      "required": ["program", "args", "command_arg_index", "shell"],
+      "properties": {
+        "program": { "type": "string" },
+        "args": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "command_arg_index": { "type": "integer", "minimum": 0 },
+        "shell": { "$ref": "#/$defs/shell" }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a shared Harn shell discovery contract for process.list_shells, process.get_default_shell, process.set_default_shell, and process.shell_invocation.
- Route VM shell builtins, process.exec shell mode, hostlib run_command shell mode, ACP terminal/create, and stdlib wrappers through selected shell metadata instead of hardcoded sh/cmd assumptions.
- Add JSON schema/docs and conformance coverage for shell discovery and selected-shell execution.

Closes #826

## Validation
- Pre-commit hook: cargo fmt, staged Harn fmt/lint, cargo clippy --workspace --all-targets -- -D warnings, markdownlint, generated language spec/highlight checks
- Pre-push hook: 2891 nextest tests passed (4 leaky reported by nextest), affected Harn fmt/lint, markdownlint
- cargo test -p harn-vm shells --lib
- cargo test -p harn-hostlib --test process_tools
- cargo test -p harn-serve adapters::acp::tests
- cargo run --quiet --bin harn -- test conformance --filter host_capabilities
- cargo run --quiet --bin harn -- test conformance --filter shell_discovery
- cargo run --quiet --bin harn -- test conformance --filter command_runner_v2