### PR TITLE
Fix audit findings across runtime surfaces

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,6 +10,14 @@
 # Any test that runs longer than 15s is considered "slow"; if it exceeds
 # the 60s hard cap three times it is terminated so the suite keeps moving.
 slow-timeout = { period = "15s", terminate-after = 4, grace-period = "5s" }
+# Nextest's upstream default FD-leak grace period is 200ms. Under full
+# workspace fan-out, fast Rust tests in the largest binaries can take a
+# little longer than that to close captured stdout/stderr after libtest
+# reports success, which creates noisy "passed (leaky)" results attributed
+# to whichever fast test happened to finish at the wrong moment. Keep this
+# short enough to catch real leaked subprocesses, but make leaks fail so
+# they are fixed instead of silently accepted.
+leak-timeout = { period = "1s", result = "fail" }
 # Terminate runaway tests after 60 seconds by default. Tests that legitimately
 # need more time must opt in via an override below.
 fail-fast = false
@@ -17,6 +25,7 @@ fail-fast = false
 # CI profile is stricter: one warning at 30s, hard kill at 120s.
 [profile.ci]
 slow-timeout = { period = "30s", terminate-after = 4, grace-period = "10s" }
+leak-timeout = { period = "1s", result = "fail" }
 fail-fast = false
 failure-output = "immediate-final"
 success-output = "never"
@@ -39,6 +48,7 @@ success-output = "never"
 # vs. the old serial behavior.
 [test-groups]
 harn-subprocess = { max-threads = 4 }
+harn-cli-bin = { max-threads = 4 }
 
 # Transport-layer LLM tests do real localhost TCP with a 3s accept deadline.
 # They're bounded internally but give them a bit more room than the default
@@ -58,6 +68,14 @@ slow-timeout = { period = "60s", terminate-after = 3, grace-period = "10s" }
 filter = "package(harn-cli) and kind(test)"
 test-group = "harn-subprocess"
 
+[[profile.default.overrides]]
+filter = "package(harn-cli) and binary(harn)"
+test-group = "harn-cli-bin"
+
 [[profile.ci.overrides]]
 filter = "package(harn-cli) and kind(test)"
 test-group = "harn-subprocess"
+
+[[profile.ci.overrides]]
+filter = "package(harn-cli) and binary(harn)"
+test-group = "harn-cli-bin"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,7 @@ dependencies = [
  "rustls",
  "serde_json",
  "sha2 0.11.0",
+ "subtle",
  "tempfile",
  "time",
  "tokio",

--- a/crates/harn-cli/src/commands/portal/assets.rs
+++ b/crates/harn-cli/src/commands/portal/assets.rs
@@ -15,11 +15,23 @@ pub(super) async fn index() -> Response {
 }
 
 pub(super) async fn asset(axum::extract::Path(path): axum::extract::Path<String>) -> Response {
+    if !is_safe_asset_path(&path) {
+        return not_found_error(format!("asset not found: {path}")).into_response();
+    }
     let asset_path = format!("assets/{path}");
     match PORTAL_DIST.get_file(&asset_path) {
         Some(file) => asset_response(file.contents(), content_type_for_path(&asset_path)),
         None => not_found_error(format!("asset not found: {path}")).into_response(),
     }
+}
+
+fn is_safe_asset_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.starts_with('/')
+        && !path.contains('\\')
+        && path
+            .split('/')
+            .all(|segment| !segment.is_empty() && segment != "." && segment != "..")
 }
 
 pub(super) fn asset_response(body: &'static [u8], content_type: &'static str) -> Response {

--- a/crates/harn-cli/src/commands/portal/tests.rs
+++ b/crates/harn-cli/src/commands/portal/tests.rs
@@ -637,6 +637,24 @@ async fn portal_index_and_assets_are_served() {
 }
 
 #[tokio::test]
+async fn portal_assets_reject_traversal_segments() {
+    let temp = tempfile::tempdir().unwrap();
+    let app = build_router(test_portal_state(temp.path()));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/assets/../index.html")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn api_run_rejects_escaping_paths() {
     let temp = tempfile::tempdir().unwrap();
     let app = build_router(test_portal_state(temp.path()));

--- a/crates/harn-hostlib/src/tools/proc.rs
+++ b/crates/harn-hostlib/src/tools/proc.rs
@@ -16,21 +16,23 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{mpsc, LazyLock, Mutex};
+use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
 use harn_vm::process_sandbox;
 use harn_vm::VmValue;
-use sha2::{Digest, Sha256};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use crate::error::HostlibError;
 use crate::tools::response::ResponseBuilder;
 
+mod artifacts;
+
+use self::artifacts::planned_artifact_paths;
+pub(crate) use self::artifacts::{persist_artifacts, resolve_output_path};
+
 static COMMAND_COUNTER: AtomicU64 = AtomicU64::new(1);
-static ARTIFACTS: LazyLock<Mutex<BTreeMap<String, CommandArtifacts>>> =
-    LazyLock::new(|| Mutex::new(BTreeMap::new()));
 
 const DEFAULT_MAX_INLINE_BYTES: usize = 50_000;
 
@@ -114,16 +116,6 @@ impl CommandStatus {
             CommandStatus::Killed => "killed",
         }
     }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct CommandArtifacts {
-    pub(crate) output_path: PathBuf,
-    pub(crate) stdout_path: PathBuf,
-    pub(crate) stderr_path: PathBuf,
-    pub(crate) line_count: u64,
-    pub(crate) byte_count: u64,
-    pub(crate) output_sha256: String,
 }
 
 /// Spawn the configured command, capture stdout + stderr in full, and
@@ -362,55 +354,6 @@ pub(crate) fn running_response(
         .build()
 }
 
-pub(crate) fn persist_artifacts(
-    command_id: &str,
-    stdout: &[u8],
-    stderr: &[u8],
-    handle_id: Option<&str>,
-) -> Result<CommandArtifacts, HostlibError> {
-    let artifacts = planned_artifact_paths(command_id);
-    std::fs::create_dir_all(artifacts.output_path.parent().unwrap()).map_err(|e| {
-        HostlibError::Backend {
-            builtin: "hostlib_tools_run_command",
-            message: format!("failed to create command artifact dir: {e}"),
-        }
-    })?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(
-            artifacts.output_path.parent().unwrap(),
-            std::fs::Permissions::from_mode(0o700),
-        );
-    }
-    std::fs::write(&artifacts.stdout_path, stdout).map_err(|e| HostlibError::Backend {
-        builtin: "hostlib_tools_run_command",
-        message: format!("failed to write stdout artifact: {e}"),
-    })?;
-    std::fs::write(&artifacts.stderr_path, stderr).map_err(|e| HostlibError::Backend {
-        builtin: "hostlib_tools_run_command",
-        message: format!("failed to write stderr artifact: {e}"),
-    })?;
-    let mut combined = Vec::with_capacity(stdout.len() + stderr.len());
-    combined.extend_from_slice(stdout);
-    combined.extend_from_slice(stderr);
-    std::fs::write(&artifacts.output_path, &combined).map_err(|e| HostlibError::Backend {
-        builtin: "hostlib_tools_run_command",
-        message: format!("failed to write combined output artifact: {e}"),
-    })?;
-    let output_sha256 = format!("sha256:{}", hex::encode(Sha256::digest(&combined)));
-    let artifacts = CommandArtifacts {
-        output_path: artifacts.output_path,
-        stdout_path: artifacts.stdout_path,
-        stderr_path: artifacts.stderr_path,
-        line_count: line_count(&combined),
-        byte_count: combined.len() as u64,
-        output_sha256,
-    };
-    register_artifacts(command_id, handle_id, &artifacts);
-    Ok(artifacts)
-}
-
 pub(crate) fn next_command_id() -> String {
     let id = COMMAND_COUNTER.fetch_add(1, Ordering::SeqCst);
     let now_nanos = SystemTime::now()
@@ -459,21 +402,6 @@ pub(crate) fn inline_output(
             String::new()
         },
     )
-}
-
-pub(crate) fn resolve_output_path(
-    command_id: Option<&str>,
-    handle_id: Option<&str>,
-    path: Option<&str>,
-) -> Option<PathBuf> {
-    if let Some(path) = path {
-        return Some(PathBuf::from(path));
-    }
-    let artifacts = ARTIFACTS.lock().expect("command artifact store poisoned");
-    command_id
-        .and_then(|id| artifacts.get(id))
-        .or_else(|| handle_id.and_then(|id| artifacts.get(id)))
-        .map(|a| a.output_path.clone())
 }
 
 pub(crate) fn child_process_group_id(pid: u32) -> Option<u32> {
@@ -541,40 +469,11 @@ fn wait_with_timeout(
     }
 }
 
-fn planned_artifact_paths(command_id: &str) -> CommandArtifacts {
-    let dir = std::env::temp_dir().join(format!("harn-command-{command_id}"));
-    CommandArtifacts {
-        output_path: dir.join("combined.txt"),
-        stdout_path: dir.join("stdout.txt"),
-        stderr_path: dir.join("stderr.txt"),
-        line_count: 0,
-        byte_count: 0,
-        output_sha256: String::new(),
-    }
-}
-
-fn register_artifacts(command_id: &str, handle_id: Option<&str>, artifacts: &CommandArtifacts) {
-    let mut store = ARTIFACTS.lock().expect("command artifact store poisoned");
-    store.insert(command_id.to_string(), artifacts.clone());
-    if let Some(handle_id) = handle_id {
-        store.insert(handle_id.to_string(), artifacts.clone());
-    }
-}
-
 fn lossy_prefix(bytes: &[u8], max_inline_bytes: usize) -> String {
     let cap = bytes.len().min(max_inline_bytes);
-    String::from_utf8_lossy(&bytes[..cap]).into_owned()
-}
-
-fn line_count(bytes: &[u8]) -> u64 {
-    if bytes.is_empty() {
-        return 0;
-    }
-    let newlines = bytes.iter().filter(|b| **b == b'\n').count() as u64;
-    if bytes.ends_with(b"\n") {
-        newlines
-    } else {
-        newlines + 1
+    match std::str::from_utf8(&bytes[..cap]) {
+        Ok(text) => text.to_string(),
+        Err(error) => String::from_utf8_lossy(&bytes[..error.valid_up_to()]).into_owned(),
     }
 }
 
@@ -648,5 +547,44 @@ pub(crate) fn parse_cwd(
             message: format!("not an existing directory: {raw}"),
         });
     }
-    Ok(Some(path.to_path_buf()))
+    let canonical = path
+        .canonicalize()
+        .map_err(|error| HostlibError::InvalidParameter {
+            builtin,
+            param: "cwd",
+            message: format!("failed to canonicalize cwd `{raw}`: {error}"),
+        })?;
+    Ok(Some(canonical))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inline_output_does_not_split_utf8_codepoint() {
+        let (stdout, stderr) = inline_output(
+            "alpha 🚀 beta".as_bytes(),
+            &[],
+            CaptureConfig {
+                max_inline_bytes: b"alpha \xF0\x9F".len(),
+                ..CaptureConfig::default()
+            },
+        );
+
+        assert_eq!(stdout, "alpha ");
+        assert_eq!(stderr, "");
+    }
+
+    #[test]
+    fn parse_cwd_returns_canonical_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let nested = temp.path().join("a").join("..");
+        std::fs::create_dir_all(temp.path().join("a")).unwrap();
+        let parsed = parse_cwd("test", Some(nested.to_str().unwrap()))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(parsed, temp.path().canonicalize().unwrap());
+    }
 }

--- a/crates/harn-hostlib/src/tools/proc/artifacts.rs
+++ b/crates/harn-hostlib/src/tools/proc/artifacts.rs
@@ -1,0 +1,116 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::{LazyLock, Mutex};
+
+use sha2::{Digest, Sha256};
+
+use crate::error::HostlibError;
+
+static ARTIFACTS: LazyLock<Mutex<BTreeMap<String, CommandArtifacts>>> =
+    LazyLock::new(|| Mutex::new(BTreeMap::new()));
+
+#[derive(Clone, Debug)]
+pub(crate) struct CommandArtifacts {
+    pub(crate) output_path: PathBuf,
+    pub(crate) stdout_path: PathBuf,
+    pub(crate) stderr_path: PathBuf,
+    pub(crate) line_count: u64,
+    pub(crate) byte_count: u64,
+    pub(crate) output_sha256: String,
+}
+
+pub(crate) fn persist_artifacts(
+    command_id: &str,
+    stdout: &[u8],
+    stderr: &[u8],
+    handle_id: Option<&str>,
+) -> Result<CommandArtifacts, HostlibError> {
+    let artifacts = planned_artifact_paths(command_id);
+    std::fs::create_dir_all(artifacts.output_path.parent().unwrap()).map_err(|e| {
+        HostlibError::Backend {
+            builtin: "hostlib_tools_run_command",
+            message: format!("failed to create command artifact dir: {e}"),
+        }
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(
+            artifacts.output_path.parent().unwrap(),
+            std::fs::Permissions::from_mode(0o700),
+        );
+    }
+    std::fs::write(&artifacts.stdout_path, stdout).map_err(|e| HostlibError::Backend {
+        builtin: "hostlib_tools_run_command",
+        message: format!("failed to write stdout artifact: {e}"),
+    })?;
+    std::fs::write(&artifacts.stderr_path, stderr).map_err(|e| HostlibError::Backend {
+        builtin: "hostlib_tools_run_command",
+        message: format!("failed to write stderr artifact: {e}"),
+    })?;
+    let mut combined = Vec::with_capacity(stdout.len() + stderr.len());
+    combined.extend_from_slice(stdout);
+    combined.extend_from_slice(stderr);
+    std::fs::write(&artifacts.output_path, &combined).map_err(|e| HostlibError::Backend {
+        builtin: "hostlib_tools_run_command",
+        message: format!("failed to write combined output artifact: {e}"),
+    })?;
+    let output_sha256 = format!("sha256:{}", hex::encode(Sha256::digest(&combined)));
+    let artifacts = CommandArtifacts {
+        output_path: artifacts.output_path,
+        stdout_path: artifacts.stdout_path,
+        stderr_path: artifacts.stderr_path,
+        line_count: line_count(&combined),
+        byte_count: combined.len() as u64,
+        output_sha256,
+    };
+    register_artifacts(command_id, handle_id, &artifacts);
+    Ok(artifacts)
+}
+
+pub(crate) fn planned_artifact_paths(command_id: &str) -> CommandArtifacts {
+    let dir = std::env::temp_dir().join(format!("harn-command-{command_id}"));
+    CommandArtifacts {
+        output_path: dir.join("combined.txt"),
+        stdout_path: dir.join("stdout.txt"),
+        stderr_path: dir.join("stderr.txt"),
+        line_count: 0,
+        byte_count: 0,
+        output_sha256: String::new(),
+    }
+}
+
+pub(crate) fn resolve_output_path(
+    command_id: Option<&str>,
+    handle_id: Option<&str>,
+    path: Option<&str>,
+) -> Option<PathBuf> {
+    if let Some(path) = path {
+        return Some(PathBuf::from(path));
+    }
+    let artifacts = ARTIFACTS.lock().expect("command artifact store poisoned");
+    command_id
+        .and_then(|id| artifacts.get(id))
+        .or_else(|| handle_id.and_then(|id| artifacts.get(id)))
+        .map(|a| a.output_path.clone())
+}
+
+fn register_artifacts(command_id: &str, handle_id: Option<&str>, artifacts: &CommandArtifacts) {
+    let mut store = ARTIFACTS.lock().expect("command artifact store poisoned");
+    store.insert(command_id.to_string(), artifacts.clone());
+    if let Some(handle_id) = handle_id {
+        store.insert(handle_id.to_string(), artifacts.clone());
+    }
+}
+
+fn line_count(bytes: &[u8]) -> u64 {
+    if bytes.is_empty() {
+        return 0;
+    }
+    let newlines = bytes.iter().filter(|b| **b == b'\n').count() as u64;
+    if bytes.ends_with(b"\n") {
+        newlines
+    } else {
+        newlines + 1
+    }
+}

--- a/crates/harn-hostlib/src/tools/run_build_command.rs
+++ b/crates/harn-hostlib/src/tools/run_build_command.rs
@@ -177,7 +177,7 @@ fn build_default_argv(
             DiagnosticSource::Generic,
         ),
         Ecosystem::Gradle => (
-            vec!["./gradlew".into(), "build".into()],
+            vec![gradle_wrapper_program().into(), "build".into()],
             DiagnosticSource::Generic,
         ),
         Ecosystem::Maven => (
@@ -217,6 +217,14 @@ fn build_default_argv(
     }
 }
 
+fn gradle_wrapper_program() -> &'static str {
+    if cfg!(windows) {
+        "gradlew.bat"
+    } else {
+        "./gradlew"
+    }
+}
+
 fn infer_diagnostic_source(argv: &[String]) -> DiagnosticSource {
     let joined = argv.join(" ");
     if joined.contains("cargo") && joined.contains("--message-format=json") {
@@ -225,5 +233,20 @@ fn infer_diagnostic_source(argv: &[String]) -> DiagnosticSource {
         DiagnosticSource::GoBuild
     } else {
         DiagnosticSource::Generic
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gradle_default_uses_platform_wrapper() {
+        let (argv, _) = build_default_argv(Ecosystem::Gradle, None, false);
+        if cfg!(windows) {
+            assert_eq!(argv[0], "gradlew.bat");
+        } else {
+            assert_eq!(argv[0], "./gradlew");
+        }
     }
 }

--- a/crates/harn-serve/Cargo.toml
+++ b/crates/harn-serve/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 serde_json = "1"
 sha2 = "0.11"
+subtle = "2"
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "sync", "time"] }
 time = "0.3"
 tracing = "0.1"

--- a/crates/harn-serve/src/auth.rs
+++ b/crates/harn-serve/src/auth.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use harn_vm::connectors::ConnectorError;
 use harn_vm::event_log::MemoryEventLog;
 use harn_vm::ProviderId;
+use subtle::ConstantTimeEq;
 use time::{Duration, OffsetDateTime};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -30,8 +31,7 @@ pub struct AuthRequest {
 
 impl AuthRequest {
     pub fn bearer_token(&self) -> Option<&str> {
-        self.headers
-            .get("authorization")
+        header_value(&self.headers, "authorization")
             .and_then(|value| value.split_once(' '))
             .filter(|(scheme, _)| scheme.eq_ignore_ascii_case("bearer"))
             .map(|(_, token)| token.trim())
@@ -39,12 +39,23 @@ impl AuthRequest {
     }
 
     pub fn api_key(&self) -> Option<&str> {
-        self.headers
-            .get("x-api-key")
-            .map(String::as_str)
+        header_value(&self.headers, "x-api-key")
             .filter(|value| !value.is_empty())
             .or_else(|| self.bearer_token())
     }
+}
+
+fn header_value<'a>(headers: &'a BTreeMap<String, String>, name: &str) -> Option<&'a str> {
+    headers
+        .get(name)
+        .map(String::as_str)
+        .or_else(|| {
+            headers
+                .iter()
+                .find(|(key, _)| key.eq_ignore_ascii_case(name))
+                .map(|(_, value)| value.as_str())
+        })
+        .map(str::trim)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -118,7 +129,7 @@ async fn authorize_method(
             let Some(api_key) = request.api_key() else {
                 return Err("missing API key".to_string());
             };
-            if config.keys.contains(api_key) {
+            if api_key_matches(&config.keys, api_key) {
                 Ok(AuthenticatedPrincipal {
                     subject: "api-key".to_string(),
                     scheme: "api_key".to_string(),
@@ -157,13 +168,11 @@ async fn authorize_method(
                     config.issuer, claims.issuer
                 ));
             }
-            if config
-                .audience
-                .as_ref()
-                .zip(claims.audience.as_ref())
-                .is_some_and(|(expected, actual)| expected != actual)
-            {
-                return Err("oauth audience mismatch".to_string());
+            if let Some(expected) = config.audience.as_ref() {
+                match claims.audience.as_ref() {
+                    Some(actual) if actual == expected => {}
+                    _ => return Err("oauth audience mismatch".to_string()),
+                }
             }
             if !config.required_scopes.is_subset(&claims.scopes) {
                 return Err("oauth scope requirement not satisfied".to_string());
@@ -174,6 +183,11 @@ async fn authorize_method(
             })
         }
     }
+}
+
+fn api_key_matches(keys: &BTreeSet<String>, candidate: &str) -> bool {
+    keys.iter()
+        .any(|key| key.as_bytes().ct_eq(candidate.as_bytes()).into())
 }
 
 fn connector_error_message(error: ConnectorError) -> String {
@@ -197,6 +211,21 @@ mod tests {
         };
         let request = AuthRequest {
             headers: BTreeMap::from([("authorization".to_string(), "Bearer secret".to_string())]),
+            ..AuthRequest::default()
+        };
+        let decision = policy.authorize(&request).await;
+        assert!(matches!(decision, AuthorizationDecision::Authorized(_)));
+    }
+
+    #[tokio::test]
+    async fn api_key_policy_accepts_case_insensitive_header_names() {
+        let policy = AuthPolicy {
+            methods: vec![AuthMethodConfig::ApiKey(ApiKeyAuthConfig {
+                keys: BTreeSet::from(["secret".to_string()]),
+            })],
+        };
+        let request = AuthRequest {
+            headers: BTreeMap::from([("X-API-Key".to_string(), " secret ".to_string())]),
             ..AuthRequest::default()
         };
         let decision = policy.authorize(&request).await;
@@ -261,6 +290,32 @@ mod tests {
                 subject: "alice".to_string(),
                 scheme: "oauth21".to_string(),
             })
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_policy_rejects_missing_required_audience() {
+        let policy = AuthPolicy {
+            methods: vec![AuthMethodConfig::OAuth21(OAuth21AuthConfig {
+                issuer: "https://issuer.example".to_string(),
+                audience: Some("harn-serve".to_string()),
+                required_scopes: BTreeSet::new(),
+            })],
+        };
+        let request = AuthRequest {
+            validated_oauth: Some(OAuthClaims {
+                subject: "alice".to_string(),
+                issuer: "https://issuer.example".to_string(),
+                audience: None,
+                scopes: BTreeSet::new(),
+            }),
+            ..AuthRequest::default()
+        };
+
+        let decision = policy.authorize(&request).await;
+        assert_eq!(
+            decision,
+            AuthorizationDecision::Rejected("oauth audience mismatch".to_string())
         );
     }
 }

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -764,7 +764,17 @@ impl AgentEventSink for MultiSink {
     }
 }
 
-type ExternalSinkRegistry = RwLock<HashMap<String, Vec<Arc<dyn AgentEventSink>>>>;
+#[cfg(test)]
+#[derive(Clone)]
+struct RegisteredSink {
+    owner: std::thread::ThreadId,
+    sink: Arc<dyn AgentEventSink>,
+}
+
+#[cfg(not(test))]
+type RegisteredSink = Arc<dyn AgentEventSink>;
+
+type ExternalSinkRegistry = RwLock<HashMap<String, Vec<RegisteredSink>>>;
 
 fn external_sinks() -> &'static ExternalSinkRegistry {
     static REGISTRY: OnceLock<ExternalSinkRegistry> = OnceLock::new();
@@ -774,6 +784,11 @@ fn external_sinks() -> &'static ExternalSinkRegistry {
 pub fn register_sink(session_id: impl Into<String>, sink: Arc<dyn AgentEventSink>) {
     let session_id = session_id.into();
     let mut reg = external_sinks().write().expect("sink registry poisoned");
+    #[cfg(test)]
+    let sink = RegisteredSink {
+        owner: std::thread::current().id(),
+        sink,
+    };
     reg.entry(session_id).or_default().push(sink);
 }
 
@@ -781,18 +796,45 @@ pub fn register_sink(session_id: impl Into<String>, sink: Arc<dyn AgentEventSink
 /// close the session itself — subscribers and transcript survive, so a
 /// later `agent_loop` call with the same id continues the conversation.
 pub fn clear_session_sinks(session_id: &str) {
-    external_sinks()
-        .write()
-        .expect("sink registry poisoned")
-        .remove(session_id);
+    #[cfg(test)]
+    {
+        let owner = std::thread::current().id();
+        let mut reg = external_sinks().write().expect("sink registry poisoned");
+        if let Some(sinks) = reg.get_mut(session_id) {
+            sinks.retain(|sink| sink.owner != owner);
+            if sinks.is_empty() {
+                reg.remove(session_id);
+            }
+        }
+    }
+    #[cfg(not(test))]
+    {
+        external_sinks()
+            .write()
+            .expect("sink registry poisoned")
+            .remove(session_id);
+    }
 }
 
 pub fn reset_all_sinks() {
-    external_sinks()
-        .write()
-        .expect("sink registry poisoned")
-        .clear();
-    crate::agent_sessions::reset_session_store();
+    #[cfg(test)]
+    {
+        let owner = std::thread::current().id();
+        let mut reg = external_sinks().write().expect("sink registry poisoned");
+        reg.retain(|_, sinks| {
+            sinks.retain(|sink| sink.owner != owner);
+            !sinks.is_empty()
+        });
+        crate::agent_sessions::reset_session_store();
+    }
+    #[cfg(not(test))]
+    {
+        external_sinks()
+            .write()
+            .expect("sink registry poisoned")
+            .clear();
+        crate::agent_sessions::reset_session_store();
+    }
 }
 
 /// Emit an event to external sinks registered for this session. Pipeline
@@ -801,7 +843,23 @@ pub fn reset_all_sinks() {
 pub fn emit_event(event: &AgentEvent) {
     let sinks: Vec<Arc<dyn AgentEventSink>> = {
         let reg = external_sinks().read().expect("sink registry poisoned");
-        reg.get(event.session_id()).cloned().unwrap_or_default()
+        #[cfg(test)]
+        {
+            let owner = std::thread::current().id();
+            reg.get(event.session_id())
+                .map(|sinks| {
+                    sinks
+                        .iter()
+                        .filter(|sink| sink.owner == owner)
+                        .map(|sink| sink.sink.clone())
+                        .collect()
+                })
+                .unwrap_or_default()
+        }
+        #[cfg(not(test))]
+        {
+            reg.get(event.session_id()).cloned().unwrap_or_default()
+        }
     };
     for sink in sinks {
         sink.handle_event(event);
@@ -816,12 +874,25 @@ fn now_ms() -> i64 {
 }
 
 pub fn session_external_sink_count(session_id: &str) -> usize {
-    external_sinks()
-        .read()
-        .expect("sink registry poisoned")
-        .get(session_id)
-        .map(|v| v.len())
-        .unwrap_or(0)
+    #[cfg(test)]
+    {
+        let owner = std::thread::current().id();
+        return external_sinks()
+            .read()
+            .expect("sink registry poisoned")
+            .get(session_id)
+            .map(|sinks| sinks.iter().filter(|sink| sink.owner == owner).count())
+            .unwrap_or(0);
+    }
+    #[cfg(not(test))]
+    {
+        external_sinks()
+            .read()
+            .expect("sink registry poisoned")
+            .get(session_id)
+            .map(|v| v.len())
+            .unwrap_or(0)
+    }
 }
 
 pub fn session_closure_subscriber_count(session_id: &str) -> usize {

--- a/crates/harn-vm/src/connectors/github/tests.rs
+++ b/crates/harn-vm/src/connectors/github/tests.rs
@@ -1,7 +1,5 @@
 use std::collections::{BTreeMap, HashSet};
-use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
-use std::thread::JoinHandle;
 
 use async_trait::async_trait;
 use serde_json::json;
@@ -11,8 +9,8 @@ use time::OffsetDateTime;
 use super::*;
 use crate::connectors::{
     test_util::{
-        accept_http_connection, read_http_request, write_http_response,
-        CapturedHttpRequest as CapturedRequest,
+        spawn_mock_http_server, write_http_response, CapturedHttpRequest as CapturedRequest,
+        MockHttpServer,
     },
     Connector, ConnectorCtx, InboxIndex, MetricsRegistry, RateLimiterFactory, RawInbound,
     TriggerBinding,
@@ -137,13 +135,11 @@ fn client_args(api_base_url: &str) -> JsonValue {
 fn spawn_mock_server(
     expected_requests: usize,
     scenario: Arc<Mutex<MockScenario>>,
-) -> (String, JoinHandle<()>) {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
-    let addr = listener.local_addr().expect("mock addr");
-    let handle = std::thread::spawn(move || {
-        for _ in 0..expected_requests {
-            let mut stream = accept_http_connection(&listener, "github mock server");
-            let request = read_http_request(&mut stream);
+) -> MockHttpServer {
+    spawn_mock_http_server(
+        expected_requests,
+        "github mock server",
+        move |_index, _addr, request, stream| {
             let response = {
                 let mut state = scenario.lock().expect("scenario lock");
                 if request.path == "/app/installations/77/access_tokens" {
@@ -220,10 +216,9 @@ fn spawn_mock_server(
                     )
                 }
             };
-            write_http_response(&mut stream, response.0, &response.1, &response.2);
-        }
-    });
-    (format!("http://{}", addr), handle)
+            write_http_response(stream, response.0, &response.1, &response.2);
+        },
+    )
 }
 
 fn github_signature(secret: &str, body: &[u8]) -> String {
@@ -499,7 +494,8 @@ async fn normalizes_monitor_github_webhook_events() {
 #[tokio::test]
 async fn outbound_methods_share_cached_installation_token() {
     let scenario = Arc::new(Mutex::new(MockScenario::default()));
-    let (base_url, server) = spawn_mock_server(8, scenario.clone());
+    let server = spawn_mock_server(8, scenario.clone());
+    let base_url = server.base_url().to_string();
     let client = initialized_client(Arc::new(StaticSecretProvider {
         namespace: "github".to_string(),
         secrets: BTreeMap::new(),
@@ -567,7 +563,7 @@ async fn outbound_methods_share_cached_installation_token() {
         .insert("labels".to_string(), json!(["bug"]));
     client.call("create_issue", args).await.unwrap();
 
-    server.join().unwrap();
+    drop(server);
     let state = scenario.lock().unwrap();
     assert_eq!(state.token_requests, 1);
     assert_eq!(state.api_requests.len(), 7);
@@ -583,7 +579,8 @@ async fn outbound_methods_share_cached_installation_token() {
 #[tokio::test]
 async fn api_call_uses_authenticated_github_rest_request() {
     let scenario = Arc::new(Mutex::new(MockScenario::default()));
-    let (base_url, server) = spawn_mock_server(2, scenario.clone());
+    let server = spawn_mock_server(2, scenario.clone());
+    let base_url = server.base_url().to_string();
     let client = initialized_client(Arc::new(StaticSecretProvider {
         namespace: "github".to_string(),
         secrets: BTreeMap::new(),
@@ -607,7 +604,7 @@ async fn api_call_uses_authenticated_github_rest_request() {
         .await
         .unwrap();
 
-    server.join().unwrap();
+    drop(server);
     let state = scenario.lock().unwrap();
     assert_eq!(state.token_requests, 1);
     assert_eq!(state.api_requests.len(), 1);
@@ -635,7 +632,8 @@ async fn unauthorized_response_invalidates_token_and_remints() {
         unauthorized_once: HashSet::from(["/repos/octo/demo/issues/123/comments".to_string()]),
         ..MockScenario::default()
     }));
-    let (base_url, server) = spawn_mock_server(4, scenario.clone());
+    let server = spawn_mock_server(4, scenario.clone());
+    let base_url = server.base_url().to_string();
     let client = initialized_client(Arc::new(StaticSecretProvider {
         namespace: "github".to_string(),
         secrets: BTreeMap::new(),
@@ -651,7 +649,7 @@ async fn unauthorized_response_invalidates_token_and_remints() {
     object.insert("body".to_string(), JsonValue::String("hello".to_string()));
     client.call("comment", args).await.unwrap();
 
-    server.join().unwrap();
+    drop(server);
     let state = scenario.lock().unwrap();
     assert_eq!(state.token_requests, 2);
     assert_eq!(state.api_requests.len(), 1);
@@ -669,7 +667,8 @@ async fn rate_limited_response_retries_once() {
         rate_limit_once: HashSet::from(["/repos/octo/demo/issues/123/comments".to_string()]),
         ..MockScenario::default()
     }));
-    let (base_url, server) = spawn_mock_server(3, scenario.clone());
+    let server = spawn_mock_server(3, scenario.clone());
+    let base_url = server.base_url().to_string();
     let client = initialized_client(Arc::new(StaticSecretProvider {
         namespace: "github".to_string(),
         secrets: BTreeMap::new(),
@@ -685,7 +684,7 @@ async fn rate_limited_response_retries_once() {
     object.insert("body".to_string(), JsonValue::String("hello".to_string()));
     client.call("comment", args).await.unwrap();
 
-    server.join().unwrap();
+    drop(server);
     let state = scenario.lock().unwrap();
     assert_eq!(state.token_requests, 1);
     assert_eq!(state.api_requests.len(), 1);

--- a/crates/harn-vm/src/connectors/linear/tests.rs
+++ b/crates/harn-vm/src/connectors/linear/tests.rs
@@ -1,8 +1,6 @@
 use std::collections::BTreeMap;
-use std::io::{Read, Write};
-use std::net::TcpListener;
+use std::io::Write;
 use std::sync::{Arc, Mutex};
-use std::thread::JoinHandle;
 
 use async_trait::async_trait;
 use serde_json::{json, Value as JsonValue};
@@ -11,6 +9,7 @@ use time::OffsetDateTime;
 
 use super::*;
 use crate::connectors::{
+    test_util::{spawn_mock_http_server, MockHttpServer},
     Connector, ConnectorClient, ConnectorCtx, InboxIndex, MetricsRegistry, RateLimiterFactory,
     RawInbound, TriggerBinding,
 };
@@ -385,7 +384,8 @@ async fn linear_connector_rejects_stale_timestamps_and_records_metric() {
 #[tokio::test]
 async fn linear_client_supports_typed_methods_and_escape_hatch() {
     let requests = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
-    let (base_url, handle) = spawn_mock_server(requests.clone(), 5);
+    let server = spawn_mock_server(requests.clone(), 5);
+    let base_url = server.base_url().to_string();
     let client = initialized_client(&base_url).await;
 
     let list = client
@@ -449,7 +449,7 @@ async fn linear_client_supports_typed_methods_and_escape_hatch() {
         .await
         .expect("graphql");
 
-    handle.join().expect("join mock server");
+    drop(server);
     let requests = requests.lock().expect("requests lock").clone();
     assert_eq!(requests.len(), 5);
     assert!(requests.iter().all(|request| {
@@ -490,7 +490,8 @@ async fn linear_client_supports_typed_methods_and_escape_hatch() {
 #[tokio::test]
 async fn linear_connector_monitor_reenables_webhook_after_probe_streak() {
     let requests = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
-    let (base_url, handle) = spawn_monitor_server(requests.clone(), 3);
+    let server = spawn_monitor_server(requests.clone(), 3);
+    let base_url = server.base_url().to_string();
     let mut binding = binding();
     binding.config = json!({
         "match": { "path": "/hooks/linear" },
@@ -521,7 +522,7 @@ async fn linear_connector_monitor_reenables_webhook_after_probe_streak() {
         .shutdown(std::time::Duration::from_secs(1))
         .await
         .expect("shutdown connector");
-    handle.join().expect("join monitor server");
+    drop(server);
 
     let requests = requests.lock().expect("requests lock").clone();
     assert_eq!(requests.len(), 3);
@@ -549,20 +550,37 @@ async fn linear_connector_monitor_reenables_webhook_after_probe_streak() {
     );
 }
 
+fn capture_request(
+    requests: &Arc<Mutex<Vec<CapturedRequest>>>,
+    raw: &crate::connectors::test_util::CapturedHttpRequest,
+) -> CapturedRequest {
+    let body = if raw.body.is_empty() {
+        None
+    } else {
+        Some(serde_json::from_str(&raw.body).expect("decode request body"))
+    };
+    let captured = CapturedRequest {
+        method: raw.method.clone(),
+        path: raw.path.clone(),
+        headers: raw.headers.clone(),
+        body,
+    };
+    requests
+        .lock()
+        .expect("requests lock")
+        .push(captured.clone());
+    captured
+}
+
 fn spawn_mock_server(
     requests: Arc<Mutex<Vec<CapturedRequest>>>,
     expected_requests: usize,
-) -> (String, JoinHandle<()>) {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
-    let addr = listener.local_addr().expect("mock addr");
-    let handle = std::thread::spawn(move || {
-        for _ in 0..expected_requests {
-            let (mut stream, _) = listener.accept().expect("accept request");
-            let request = read_request(&mut stream);
-            requests
-                .lock()
-                .expect("requests lock")
-                .push(request.clone());
+) -> MockHttpServer {
+    spawn_mock_http_server(
+        expected_requests,
+        "linear mock server",
+        move |_index, _addr, raw, stream| {
+            let request = capture_request(&requests, raw);
             let query = request
                 .body
                 .as_ref()
@@ -612,66 +630,12 @@ fn spawn_mock_server(
                 })
             };
             write_response(
-                &mut stream,
+                stream,
                 &body.to_string(),
                 &[("x-complexity", "12"), ("content-type", "application/json")],
             );
-        }
-    });
-    (format!("http://{}", addr), handle)
-}
-
-fn read_request(stream: &mut std::net::TcpStream) -> CapturedRequest {
-    let mut buffer = Vec::new();
-    let mut temp = [0u8; 4096];
-    let header_end;
-    loop {
-        let n = stream.read(&mut temp).expect("read request");
-        assert!(n > 0, "request ended before headers");
-        buffer.extend_from_slice(&temp[..n]);
-        if let Some(idx) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
-            header_end = idx + 4;
-            break;
-        }
-    }
-    let header_text = String::from_utf8_lossy(&buffer[..header_end]).to_string();
-    let mut lines = header_text.split("\r\n").filter(|line| !line.is_empty());
-    let request_line = lines.next().expect("request line");
-    let mut request_line_parts = request_line.split_whitespace();
-    let method = request_line_parts
-        .next()
-        .expect("request method")
-        .to_string();
-    let path = request_line_parts.next().expect("request path").to_string();
-    let mut headers = BTreeMap::new();
-    for line in lines {
-        if let Some((name, value)) = line.split_once(':') {
-            headers.insert(name.to_ascii_lowercase(), value.trim().to_string());
-        }
-    }
-    let content_length = headers
-        .get("content-length")
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(0);
-    while buffer.len() < header_end + content_length {
-        let n = stream.read(&mut temp).expect("read body");
-        assert!(n > 0, "request ended before body");
-        buffer.extend_from_slice(&temp[..n]);
-    }
-    let body = if content_length == 0 {
-        None
-    } else {
-        Some(
-            serde_json::from_slice(&buffer[header_end..header_end + content_length])
-                .expect("decode request body"),
-        )
-    };
-    CapturedRequest {
-        method,
-        path,
-        headers,
-        body,
-    }
+        },
+    )
 }
 
 fn write_response(stream: &mut std::net::TcpStream, body: &str, headers: &[(&str, &str)]) {
@@ -704,25 +668,15 @@ fn write_response_status(
 fn spawn_monitor_server(
     requests: Arc<Mutex<Vec<CapturedRequest>>>,
     expected_requests: usize,
-) -> (String, JoinHandle<()>) {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind monitor server");
-    let addr = listener.local_addr().expect("monitor addr");
-    let handle = std::thread::spawn(move || {
-        for _ in 0..expected_requests {
-            let (mut stream, _) = listener.accept().expect("accept request");
-            let request = read_request(&mut stream);
-            requests
-                .lock()
-                .expect("requests lock")
-                .push(request.clone());
+) -> MockHttpServer {
+    spawn_mock_http_server(
+        expected_requests,
+        "linear monitor server",
+        move |_index, _addr, raw, stream| {
+            let request = capture_request(&requests, raw);
             match (request.method.as_str(), request.path.as_str()) {
                 ("GET", "/health") => {
-                    write_response_status(
-                        &mut stream,
-                        "200 OK",
-                        "",
-                        &[("content-type", "text/plain")],
-                    );
+                    write_response_status(stream, "200 OK", "", &[("content-type", "text/plain")]);
                 }
                 ("POST", "/") => {
                     let query = request
@@ -736,7 +690,7 @@ fn spawn_monitor_server(
                         "unexpected GraphQL query: {query}"
                     );
                     write_response(
-                        &mut stream,
+                        stream,
                         &json!({
                             "data": {
                                 "webhookUpdate": {
@@ -751,7 +705,6 @@ fn spawn_monitor_server(
                 }
                 other => panic!("unexpected request {other:?}"),
             }
-        }
-    });
-    (format!("http://{}", addr), handle)
+        },
+    )
 }

--- a/crates/harn-vm/src/connectors/notion/tests.rs
+++ b/crates/harn-vm/src/connectors/notion/tests.rs
@@ -1,7 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
-use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
-use std::thread::JoinHandle;
 use std::time::Duration as StdDuration;
 
 use async_trait::async_trait;
@@ -12,8 +10,8 @@ use time::OffsetDateTime;
 use super::*;
 use crate::connectors::{
     test_util::{
-        accept_http_connection, read_http_request, write_http_response,
-        CapturedHttpRequest as CapturedRequest,
+        spawn_mock_http_server, write_http_response, CapturedHttpRequest as CapturedRequest,
+        MockHttpServer,
     },
     Connector, ConnectorCtx, InboxIndex, MetricsRegistry, RateLimiterFactory, RawInbound,
     TriggerBinding,
@@ -301,25 +299,25 @@ fn spawn_mock_server(
     expected_requests: usize,
     responder: impl Fn(usize, &CapturedRequest) -> (u16, String) + Send + 'static,
     captured: Arc<Mutex<Vec<CapturedRequest>>>,
-) -> (String, JoinHandle<()>) {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap();
-    let handle = std::thread::spawn(move || {
-        for index in 0..expected_requests {
-            let mut stream = accept_http_connection(&listener, "notion mock server");
-            let request = read_http_request(&mut stream);
-            captured.lock().unwrap().push(request.clone());
-            let (status, body) = responder(index, &request);
-            write_response(&mut stream, status, &body);
-        }
-    });
-    (format!("http://{}", addr), handle)
+) -> MockHttpServer {
+    spawn_mock_http_server(
+        expected_requests,
+        "notion mock server",
+        move |index, _addr, request, stream| {
+            captured
+                .lock()
+                .expect("captured requests poisoned")
+                .push(request.clone());
+            let (status, body) = responder(index, request);
+            write_response(stream, status, &body);
+        },
+    )
 }
 
 #[tokio::test]
 async fn notion_client_methods_use_current_api_headers_and_paths() {
     let captured = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
-    let (base_url, handle) = spawn_mock_server(
+    let server = spawn_mock_server(
         7,
         |_index, request| {
             let body = if request.path.starts_with("/data_sources/") {
@@ -331,6 +329,7 @@ async fn notion_client_methods_use_current_api_headers_and_paths() {
         },
         captured.clone(),
     );
+    let base_url = server.base_url().to_string();
 
     let secrets = Arc::new(StaticSecretProvider::new("notion", HashMap::new()));
     let mut connector = NotionConnector::new();
@@ -393,7 +392,7 @@ async fn notion_client_methods_use_current_api_headers_and_paths() {
         .await
         .unwrap();
 
-    handle.join().unwrap();
+    drop(server);
     let requests = captured.lock().unwrap().clone();
     assert_eq!(requests.len(), 7);
     assert_eq!(requests[0].method, "GET");
@@ -420,7 +419,7 @@ async fn notion_client_methods_use_current_api_headers_and_paths() {
 #[tokio::test]
 async fn notion_client_retries_once_after_rate_limit() {
     let captured = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
-    let (base_url, handle) = spawn_mock_server(
+    let server = spawn_mock_server(
         2,
         |index, _request| {
             if index == 0 {
@@ -434,6 +433,7 @@ async fn notion_client_retries_once_after_rate_limit() {
         },
         captured.clone(),
     );
+    let base_url = server.base_url().to_string();
 
     let secrets = Arc::new(StaticSecretProvider::new("notion", HashMap::new()));
     let ctx = test_ctx(secrets).await;
@@ -447,7 +447,7 @@ async fn notion_client_retries_once_after_rate_limit() {
         .await
         .unwrap();
 
-    handle.join().unwrap();
+    drop(server);
     let requests = captured.lock().unwrap().clone();
     assert_eq!(requests.len(), 2);
     assert_eq!(result.get("id").and_then(JsonValue::as_str), Some("page_1"));
@@ -477,7 +477,7 @@ async fn notion_poll_binding_emits_targeted_inbox_event_and_persists_high_water(
             }
         }
     });
-    let (base_url, handle) = spawn_mock_server(
+    let server = spawn_mock_server(
         1,
         move |_index, _request| {
             (
@@ -492,6 +492,7 @@ async fn notion_poll_binding_emits_targeted_inbox_event_and_persists_high_water(
         },
         captured,
     );
+    let base_url = server.base_url().to_string();
 
     let secrets = Arc::new(StaticSecretProvider::new(
         "notion",
@@ -548,5 +549,5 @@ async fn notion_poll_binding_emits_targeted_inbox_event_and_persists_high_water(
 
     connector.shutdown(StdDuration::from_secs(1)).await.unwrap();
     std::env::remove_var("HARN_TEST_NOTION_API_BASE_URL");
-    handle.join().unwrap();
+    drop(server);
 }

--- a/crates/harn-vm/src/connectors/slack/tests.rs
+++ b/crates/harn-vm/src/connectors/slack/tests.rs
@@ -1,7 +1,5 @@
 use std::collections::BTreeMap;
-use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
-use std::thread::JoinHandle;
 
 use async_trait::async_trait;
 use serde_json::{json, Value as JsonValue};
@@ -11,8 +9,8 @@ use time::OffsetDateTime;
 use super::*;
 use crate::connectors::{
     test_util::{
-        accept_http_connection, read_http_request, write_http_response,
-        CapturedHttpRequest as CapturedRequest,
+        spawn_mock_http_server, write_http_response, CapturedHttpRequest as CapturedRequest,
+        MockHttpServer,
     },
     Connector, ConnectorClient, ConnectorCtx, InboxIndex, MetricsRegistry, RateLimiterFactory,
     RawInbound, TriggerBinding,
@@ -419,13 +417,11 @@ struct MockScenario {
 fn spawn_mock_server(
     expected_requests: usize,
     scenario: Arc<Mutex<MockScenario>>,
-) -> (String, JoinHandle<()>) {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
-    let addr = listener.local_addr().expect("mock addr");
-    let handle = std::thread::spawn(move || {
-        for _ in 0..expected_requests {
-            let mut stream = accept_http_connection(&listener, "slack mock server");
-            let request = read_http_request(&mut stream);
+) -> MockHttpServer {
+    spawn_mock_http_server(
+        expected_requests,
+        "slack mock server",
+        move |_index, addr, request, stream| {
             scenario
                 .lock()
                 .expect("scenario lock")
@@ -433,43 +429,43 @@ fn spawn_mock_server(
                 .push(request.clone());
             match request.path.as_str() {
                 "/chat.postMessage" => write_http_response(
-                    &mut stream,
+                    stream,
                     200,
                     &[("content-type", "application/json".to_string())],
                     r#"{"ok":true,"channel":"C123ABC456","ts":"1715.000100","message":{"text":"hello from harn"}}"#,
                 ),
                 "/chat.update" => write_http_response(
-                    &mut stream,
+                    stream,
                     200,
                     &[("content-type", "application/json".to_string())],
                     r#"{"ok":true,"channel":"C123ABC456","ts":"1715.000100","text":"updated"}"#,
                 ),
                 "/reactions.add" => write_http_response(
-                    &mut stream,
+                    stream,
                     200,
                     &[("content-type", "application/json".to_string())],
                     r#"{"ok":true}"#,
                 ),
                 "/views.open" => write_http_response(
-                    &mut stream,
+                    stream,
                     200,
                     &[("content-type", "application/json".to_string())],
                     r#"{"ok":true,"view":{"id":"V123ABC456","type":"modal"}}"#,
                 ),
                 path if path.starts_with("/users.info") => write_http_response(
-                    &mut stream,
+                    stream,
                     200,
                     &[("content-type", "application/json".to_string())],
                     r#"{"ok":true,"user":{"id":"U123ABC456","name":"roadrunner"}}"#,
                 ),
                 "/auth.test" => write_http_response(
-                    &mut stream,
+                    stream,
                     200,
                     &[("content-type", "application/json".to_string())],
                     r#"{"ok":true,"url":"https://example.slack.com/","team":"Example","user":"bot"}"#,
                 ),
                 "/files.getUploadURLExternal" => write_http_response(
-                    &mut stream,
+                    stream,
                     200,
                     &[("content-type", "application/json".to_string())],
                     &format!(
@@ -477,25 +473,25 @@ fn spawn_mock_server(
                         addr
                     ),
                 ),
-                "/upload/F123" => write_http_response(&mut stream, 200, &[], ""),
+                "/upload/F123" => write_http_response(stream, 200, &[], ""),
                 "/files.completeUploadExternal" => write_http_response(
-                    &mut stream,
+                    stream,
                     200,
                     &[("content-type", "application/json".to_string())],
                     r#"{"ok":true,"files":[{"id":"F123","title":"notes.txt"}]}"#,
                 ),
                 other => panic!("unexpected path {other}"),
             }
-        }
-    });
-    (format!("http://{addr}"), handle)
+        },
+    )
 }
 
 #[tokio::test]
 async fn slack_outbound_helpers_hit_expected_api_methods() {
     let client = initialized_client().await;
     let scenario = Arc::new(Mutex::new(MockScenario::default()));
-    let (base_url, handle) = spawn_mock_server(9, scenario.clone());
+    let server = spawn_mock_server(9, scenario.clone());
+    let base_url = server.base_url().to_string();
 
     let posted = client
         .call(
@@ -591,7 +587,7 @@ async fn slack_outbound_helpers_hit_expected_api_methods() {
         .await
         .unwrap();
 
-    handle.join().expect("server thread");
+    drop(server);
     let requests = scenario.lock().expect("scenario lock").requests.clone();
     assert_eq!(requests.len(), 9);
     assert_eq!(requests[0].path, "/chat.postMessage");

--- a/crates/harn-vm/src/connectors/test_util.rs
+++ b/crates/harn-vm/src/connectors/test_util.rs
@@ -1,7 +1,10 @@
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream};
-use std::time::{Duration, Instant};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Duration;
 
 pub(crate) use crate::triggers::test_util::clock::MockClock;
 
@@ -13,23 +16,34 @@ pub(crate) struct CapturedHttpRequest {
     pub(crate) body: String,
 }
 
-pub(crate) fn accept_http_connection(listener: &TcpListener, label: &str) -> TcpStream {
+/// Cooperative accept loop: blocks until either a client connects or
+/// `shutdown` flips, whichever comes first. Returns `None` on shutdown.
+/// Mock servers built on top of [`spawn_mock_http_server`] use this so the
+/// stub thread's lifetime is bounded by a test-owned guard rather than a
+/// wall-clock deadline — the deadline approach flaked under heavy workspace
+/// fan-out on CI.
+fn accept_http_connection_until(
+    listener: &TcpListener,
+    label: &str,
+    shutdown: &AtomicBool,
+) -> Option<TcpStream> {
     listener
         .set_nonblocking(true)
         .expect("set listener nonblocking");
-    let deadline = Instant::now() + Duration::from_secs(2);
     loop {
+        if shutdown.load(Ordering::Acquire) {
+            return None;
+        }
         match listener.accept() {
             Ok((stream, _)) => {
                 stream
                     .set_nonblocking(false)
                     .expect("restore blocking mode");
-                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
-                stream.set_write_timeout(Some(Duration::from_secs(2))).ok();
-                return stream;
+                stream.set_read_timeout(Some(Duration::from_secs(30))).ok();
+                stream.set_write_timeout(Some(Duration::from_secs(30))).ok();
+                return Some(stream);
             }
             Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                assert!(Instant::now() < deadline, "{label}: no client within 2s");
                 std::thread::sleep(Duration::from_millis(5));
             }
             Err(error) => panic!("{label}: accept failed: {error}"),
@@ -81,6 +95,77 @@ pub(crate) fn read_http_request(stream: &mut TcpStream) -> CapturedHttpRequest {
         path,
         headers,
         body,
+    }
+}
+
+/// Mock HTTP server whose lifetime is tied to a test-owned guard.
+///
+/// The server thread serves up to `expected_requests` requests and then
+/// exits naturally. If the guard drops first (e.g. test panicked), the
+/// shutdown flag flips and the server thread exits within one poll
+/// iteration. There is no wall-clock deadline so the test cannot flake
+/// under heavy CI fan-out, and there is no thread leak on test failure
+/// because Drop signals shutdown and joins.
+pub(crate) struct MockHttpServer {
+    addr: SocketAddr,
+    base_url: String,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl MockHttpServer {
+    pub(crate) fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+}
+
+impl Drop for MockHttpServer {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Spawn a mock HTTP server bound to `127.0.0.1:0`. The supplied handler is
+/// invoked per accepted request with the request index, the bound listening
+/// address (so handlers can build self-referential URLs), the parsed
+/// request, and the live stream so it can decide how to respond. The server
+/// stops after `expected_requests` accepted requests, after the handler
+/// panics, or when the returned [`MockHttpServer`] is dropped.
+pub(crate) fn spawn_mock_http_server<F>(
+    expected_requests: usize,
+    label: &'static str,
+    mut handler: F,
+) -> MockHttpServer
+where
+    F: FnMut(usize, SocketAddr, &CapturedHttpRequest, &mut TcpStream) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock http server");
+    let addr = listener.local_addr().expect("mock http server addr");
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_thread = shutdown.clone();
+    let handle = std::thread::spawn(move || {
+        for index in 0..expected_requests {
+            let Some(mut stream) = accept_http_connection_until(&listener, label, &shutdown_thread)
+            else {
+                return;
+            };
+            let request = read_http_request(&mut stream);
+            handler(index, addr, &request, &mut stream);
+        }
+    });
+    MockHttpServer {
+        addr,
+        base_url: format!("http://{}", addr),
+        shutdown,
+        handle: Some(handle),
     }
 }
 

--- a/crates/harn-vm/src/egress.rs
+++ b/crates/harn-vm/src/egress.rs
@@ -1,4 +1,6 @@
 use std::collections::BTreeMap;
+#[cfg(test)]
+use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::rc::Rc;
 use std::str::FromStr;
@@ -47,8 +49,14 @@ enum EgressMatcher {
 
 #[derive(Clone, Debug)]
 struct EgressState {
+    #[cfg(not(test))]
     env_checked: bool,
+    #[cfg(not(test))]
     policy: Option<ConfiguredPolicy>,
+    #[cfg(test)]
+    test_env_checked: HashSet<std::thread::ThreadId>,
+    #[cfg(test)]
+    test_policies: HashMap<std::thread::ThreadId, ConfiguredPolicy>,
 }
 
 #[derive(Clone, Debug)]
@@ -71,8 +79,14 @@ static EGRESS_STATE: OnceLock<RwLock<EgressState>> = OnceLock::new();
 fn state() -> &'static RwLock<EgressState> {
     EGRESS_STATE.get_or_init(|| {
         RwLock::new(EgressState {
+            #[cfg(not(test))]
             env_checked: false,
+            #[cfg(not(test))]
             policy: None,
+            #[cfg(test)]
+            test_env_checked: HashSet::new(),
+            #[cfg(test)]
+            test_policies: HashMap::new(),
         })
     })
 }
@@ -140,8 +154,17 @@ pub fn connector_error_for_url(
 
 pub fn reset_egress_policy_for_host() {
     let mut guard = state().write().expect("egress policy state poisoned");
-    guard.env_checked = false;
-    guard.policy = None;
+    #[cfg(test)]
+    {
+        let thread_id = std::thread::current().id();
+        guard.test_env_checked.remove(&thread_id);
+        guard.test_policies.remove(&thread_id);
+    }
+    #[cfg(not(test))]
+    {
+        guard.env_checked = false;
+        guard.policy = None;
+    }
 }
 
 #[cfg(test)]
@@ -153,7 +176,17 @@ fn check_url(surface: &str, raw_url: &str) -> Result<Option<EgressBlocked>, VmEr
     ensure_env_seeded()?;
     let configured = {
         let guard = state().read().expect("egress policy state poisoned");
-        guard.policy.clone()
+        #[cfg(test)]
+        {
+            guard
+                .test_policies
+                .get(&std::thread::current().id())
+                .cloned()
+        }
+        #[cfg(not(test))]
+        {
+            guard.policy.clone()
+        }
     };
     let Some(configured) = configured else {
         return Ok(None);
@@ -194,7 +227,7 @@ fn check_url(surface: &str, raw_url: &str) -> Result<Option<EgressBlocked>, VmEr
 fn blocked(surface: &str, url: &str, target: &EgressTarget, reason: String) -> EgressBlocked {
     EgressBlocked {
         surface: surface.to_string(),
-        url: url.to_string(),
+        url: redact_sensitive_url(url),
         host: target.host.clone(),
         port: target.port,
         reason,
@@ -248,21 +281,50 @@ fn audit_blocked_background(blocked: EgressBlocked) {
 fn install_policy(policy: EgressPolicy, source: &'static str) -> Result<(), VmError> {
     ensure_env_seeded()?;
     let mut guard = state().write().expect("egress policy state poisoned");
-    if let Some(existing) = &guard.policy {
-        return Err(vm_error(format!(
-            "egress_policy: policy already configured from {}",
-            existing.source
-        )));
+    #[cfg(test)]
+    {
+        let thread_id = std::thread::current().id();
+        if let Some(existing) = guard.test_policies.get(&thread_id) {
+            return Err(vm_error(format!(
+                "egress_policy: policy already configured from {}",
+                existing.source
+            )));
+        }
+        guard
+            .test_policies
+            .insert(thread_id, ConfiguredPolicy { source, policy });
+        Ok(())
     }
-    guard.policy = Some(ConfiguredPolicy { source, policy });
-    Ok(())
+    #[cfg(not(test))]
+    {
+        if let Some(existing) = &guard.policy {
+            return Err(vm_error(format!(
+                "egress_policy: policy already configured from {}",
+                existing.source
+            )));
+        }
+        guard.policy = Some(ConfiguredPolicy { source, policy });
+        Ok(())
+    }
 }
 
 fn ensure_env_seeded() -> Result<(), VmError> {
     {
         let guard = state().read().expect("egress policy state poisoned");
-        if guard.env_checked {
-            return Ok(());
+        #[cfg(test)]
+        {
+            if guard
+                .test_env_checked
+                .contains(&std::thread::current().id())
+            {
+                return Ok(());
+            }
+        }
+        #[cfg(not(test))]
+        {
+            if guard.env_checked {
+                return Ok(());
+            }
         }
     }
 
@@ -270,23 +332,50 @@ fn ensure_env_seeded() -> Result<(), VmError> {
     let deny = std::env::var(HARN_EGRESS_DENY_ENV).ok();
     let default = std::env::var(HARN_EGRESS_DEFAULT_ENV).ok();
     let mut guard = state().write().expect("egress policy state poisoned");
-    if guard.env_checked {
-        return Ok(());
+    #[cfg(test)]
+    {
+        let thread_id = std::thread::current().id();
+        if guard.test_env_checked.contains(&thread_id) {
+            return Ok(());
+        }
+        guard.test_env_checked.insert(thread_id);
+        if allow.is_none() && deny.is_none() && default.is_none() {
+            return Ok(());
+        }
+        let policy = EgressPolicy {
+            allow: parse_rule_list(allow.as_deref().unwrap_or(""))?,
+            deny: parse_rule_list(deny.as_deref().unwrap_or(""))?,
+            default: parse_default_action(default.as_deref().unwrap_or("allow"))?,
+        };
+        guard.test_policies.insert(
+            thread_id,
+            ConfiguredPolicy {
+                source: "environment",
+                policy,
+            },
+        );
+        Ok(())
     }
-    guard.env_checked = true;
-    if allow.is_none() && deny.is_none() && default.is_none() {
-        return Ok(());
+    #[cfg(not(test))]
+    {
+        if guard.env_checked {
+            return Ok(());
+        }
+        guard.env_checked = true;
+        if allow.is_none() && deny.is_none() && default.is_none() {
+            return Ok(());
+        }
+        let policy = EgressPolicy {
+            allow: parse_rule_list(allow.as_deref().unwrap_or(""))?,
+            deny: parse_rule_list(deny.as_deref().unwrap_or(""))?,
+            default: parse_default_action(default.as_deref().unwrap_or("allow"))?,
+        };
+        guard.policy = Some(ConfiguredPolicy {
+            source: "environment",
+            policy,
+        });
+        Ok(())
     }
-    let policy = EgressPolicy {
-        allow: parse_rule_list(allow.as_deref().unwrap_or(""))?,
-        deny: parse_rule_list(deny.as_deref().unwrap_or(""))?,
-        default: parse_default_action(default.as_deref().unwrap_or("allow"))?,
-    };
-    guard.policy = Some(ConfiguredPolicy {
-        source: "environment",
-        policy,
-    });
-    Ok(())
 }
 
 fn policy_from_config(config: &BTreeMap<String, VmValue>) -> Result<EgressPolicy, VmError> {
@@ -342,7 +431,17 @@ fn parse_default_action(raw: &str) -> Result<DefaultAction, VmError> {
 fn policy_summary() -> VmValue {
     let configured = {
         let guard = state().read().expect("egress policy state poisoned");
-        guard.policy.clone()
+        #[cfg(test)]
+        {
+            guard
+                .test_policies
+                .get(&std::thread::current().id())
+                .cloned()
+        }
+        #[cfg(not(test))]
+        {
+            guard.policy.clone()
+        }
     };
     let mut dict = BTreeMap::new();
     if let Some(configured) = configured {
@@ -515,6 +614,51 @@ fn normalize_host(host: &str) -> String {
         .to_ascii_lowercase()
 }
 
+fn is_sensitive_url_param(name: &str) -> bool {
+    let normalized = name.to_ascii_lowercase();
+    normalized == "api_key"
+        || normalized == "apikey"
+        || normalized == "access_token"
+        || normalized == "refresh_token"
+        || normalized == "id_token"
+        || normalized == "client_secret"
+        || normalized == "password"
+        || normalized == "secret"
+        || normalized == "token"
+        || normalized.ends_with("_token")
+        || normalized.ends_with("_secret")
+}
+
+fn redact_sensitive_url(url: &str) -> String {
+    let Ok(mut parsed) = Url::parse(url) else {
+        return url.to_string();
+    };
+    let mut redacted_any = false;
+    let pairs: Vec<(String, String)> = parsed
+        .query_pairs()
+        .map(|(key, value)| {
+            let value = if is_sensitive_url_param(&key) {
+                redacted_any = true;
+                "[redacted]".to_string()
+            } else {
+                value.into_owned()
+            };
+            (key.into_owned(), value)
+        })
+        .collect();
+    if !redacted_any {
+        return url.to_string();
+    }
+    parsed.set_query(None);
+    {
+        let mut query = parsed.query_pairs_mut();
+        for (key, value) in pairs {
+            query.append_pair(&key, &value);
+        }
+    }
+    parsed.to_string()
+}
+
 fn vm_error(message: impl Into<String>) -> VmError {
     VmError::Thrown(VmValue::String(Rc::from(message.into())))
 }
@@ -663,16 +807,33 @@ mod tests {
     }
 
     #[test]
+    fn blocked_urls_redact_sensitive_query_values() {
+        let _guard = install(&[("default", VmValue::String(Rc::from("deny")))]);
+        let blocked = check_url(
+            "http_get",
+            "https://api.example.com/resource?access_token=secret-token&ok=1",
+        )
+        .unwrap()
+        .expect("default deny blocks");
+
+        assert_eq!(
+            blocked.url,
+            "https://api.example.com/resource?access_token=%5Bredacted%5D&ok=1"
+        );
+        assert!(!blocked.to_string().contains("secret-token"));
+    }
+
+    #[test]
     fn env_seeding_is_honored() {
         let _guard = ENV_LOCK.lock().unwrap();
         reset_egress_policy_for_tests();
-        std::env::set_var(HARN_EGRESS_ALLOW_ENV, "env.example.com");
-        std::env::set_var(HARN_EGRESS_DENY_ENV, "");
-        std::env::set_var(HARN_EGRESS_DEFAULT_ENV, "deny");
+        std::env::set_var(HARN_EGRESS_ALLOW_ENV, "");
+        std::env::set_var(HARN_EGRESS_DENY_ENV, "blocked-env.example.com");
+        std::env::set_var(HARN_EGRESS_DEFAULT_ENV, "allow");
         assert!(check_url("http_get", "https://env.example.com")
             .unwrap()
             .is_none());
-        assert!(check_url("http_get", "https://other.example.com")
+        assert!(check_url("http_get", "https://blocked-env.example.com")
             .unwrap()
             .is_some());
         std::env::remove_var(HARN_EGRESS_ALLOW_ENV);

--- a/crates/harn-vm/src/http.rs
+++ b/crates/harn-vm/src/http.rs
@@ -4964,9 +4964,7 @@ mod tests {
         vm_sse_server_mock_disconnect, vm_sse_server_mock_receive, vm_sse_server_observed_bool,
         vm_sse_server_response, vm_sse_server_send, HttpMockResponse,
     };
-    use crate::connectors::test_util::{
-        accept_http_connection, read_http_request, write_http_response,
-    };
+    use crate::connectors::test_util::{spawn_mock_http_server, write_http_response};
     use crate::value::VmValue;
     use base64::Engine;
     use rcgen::generate_simple_self_signed;
@@ -5251,32 +5249,29 @@ mod tests {
     #[tokio::test]
     async fn http_proxy_routes_requests_through_configured_proxy() {
         reset_http_state();
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind proxy listener");
-        let proxy_addr = listener.local_addr().expect("proxy addr");
-        let proxy_thread = std::thread::spawn(move || {
-            let mut stream = accept_http_connection(&listener, "proxy listener");
-            let request = read_http_request(&mut stream);
-            assert_eq!(request.method, "GET");
-            assert_eq!(request.path, "http://example.invalid/proxy-check");
-            assert_eq!(
-                request
-                    .headers
-                    .get("proxy-authorization")
-                    .map(String::as_str),
-                Some("Basic dXNlcjpwYXNz")
-            );
-            write_http_response(
-                &mut stream,
-                200,
-                &[("content-type", "text/plain".to_string())],
-                "proxied",
-            );
-        });
+        let proxy =
+            spawn_mock_http_server(1, "proxy listener", |_index, _addr, request, stream| {
+                assert_eq!(request.method, "GET");
+                assert_eq!(request.path, "http://example.invalid/proxy-check");
+                assert_eq!(
+                    request
+                        .headers
+                        .get("proxy-authorization")
+                        .map(String::as_str),
+                    Some("Basic dXNlcjpwYXNz")
+                );
+                write_http_response(
+                    stream,
+                    200,
+                    &[("content-type", "text/plain".to_string())],
+                    "proxied",
+                );
+            });
 
         let options = BTreeMap::from([
             (
                 "proxy".to_string(),
-                VmValue::String(Rc::from(format!("http://{proxy_addr}"))),
+                VmValue::String(Rc::from(proxy.base_url().to_string())),
             ),
             (
                 "proxy_auth".to_string(),
@@ -5295,7 +5290,7 @@ mod tests {
         let response = response.as_dict().expect("response dict");
         assert_eq!(response["status"].as_int(), Some(200));
         assert_eq!(response["body"].display(), "proxied");
-        proxy_thread.join().expect("proxy thread");
+        drop(proxy);
         reset_http_state();
     }
 

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -545,48 +545,97 @@ mod tests {
         assert_eq!(messages[0]["role"].as_str(), Some("user"));
     }
 
-    /// Accept a single connection with a bounded deadline so a buggy client
-    /// can't wedge the test runner. Used by all localhost stubs in this
-    /// module. Historical note: blocking `listener.accept()` has taken down
-    /// the test suite at least twice.
-    fn accept_with_deadline(listener: &std::net::TcpListener, label: &str) -> std::net::TcpStream {
+    /// Cooperative accept loop: blocks until a client connects or the
+    /// shared `shutdown` flag is set. The shutdown flag is owned by the
+    /// returned [`LlmStub`] guard and flipped on Drop, so the stub thread
+    /// can never outlive the test (replaces the older fixed-deadline loop
+    /// that flaked under heavy CI fan-out).
+    fn accept_with_shutdown(
+        listener: &std::net::TcpListener,
+        label: &str,
+        shutdown: &std::sync::atomic::AtomicBool,
+    ) -> Option<std::net::TcpStream> {
         listener
             .set_nonblocking(true)
             .expect("set listener nonblocking");
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
         loop {
+            if shutdown.load(std::sync::atomic::Ordering::Acquire) {
+                return None;
+            }
             match listener.accept() {
                 Ok((stream, _)) => {
                     stream
                         .set_nonblocking(false)
                         .expect("restore blocking mode");
                     stream
-                        .set_read_timeout(Some(std::time::Duration::from_secs(3)))
+                        .set_read_timeout(Some(std::time::Duration::from_secs(30)))
                         .ok();
                     stream
-                        .set_write_timeout(Some(std::time::Duration::from_secs(3)))
+                        .set_write_timeout(Some(std::time::Duration::from_secs(30)))
                         .ok();
-                    return stream;
+                    return Some(stream);
                 }
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                    if std::time::Instant::now() >= deadline {
-                        panic!("{label}: no client within 3s");
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(20));
+                    std::thread::sleep(std::time::Duration::from_millis(5));
                 }
                 Err(e) => panic!("{label}: accept failed: {e}"),
             }
         }
     }
 
-    fn spawn_ollama_stub() -> (std::net::SocketAddr, std::thread::JoinHandle<()>) {
-        use std::io::{Read, Write};
-        use std::net::TcpListener;
+    /// RAII guard for an in-process LLM stub. Dropping signals the stub
+    /// thread to exit and joins it so no FDs leak past the test, even on
+    /// panic.
+    struct LlmStub {
+        addr: std::net::SocketAddr,
+        shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        handle: Option<std::thread::JoinHandle<()>>,
+    }
 
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ollama stub");
+    impl LlmStub {
+        fn addr(&self) -> std::net::SocketAddr {
+            self.addr
+        }
+    }
+
+    impl Drop for LlmStub {
+        fn drop(&mut self) {
+            self.shutdown
+                .store(true, std::sync::atomic::Ordering::Release);
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    /// Bind a localhost listener and run `body` on a background thread once
+    /// a client connects. Wraps the listener in an [`LlmStub`] guard whose
+    /// lifetime bounds the stub thread.
+    fn spawn_llm_stub<F>(label: &'static str, body: F) -> LlmStub
+    where
+        F: FnOnce(&mut std::net::TcpStream) + Send + 'static,
+    {
+        use std::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind llm stub");
         let addr = listener.local_addr().expect("stub addr");
+        let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let shutdown_thread = shutdown.clone();
         let handle = std::thread::spawn(move || {
-            let mut stream = accept_with_deadline(&listener, "ollama stub");
+            let Some(mut stream) = accept_with_shutdown(&listener, label, &shutdown_thread) else {
+                return;
+            };
+            body(&mut stream);
+        });
+        LlmStub {
+            addr,
+            shutdown,
+            handle: Some(handle),
+        }
+    }
+
+    fn spawn_ollama_stub() -> LlmStub {
+        spawn_llm_stub("ollama stub", |stream| {
+            use std::io::{Read, Write};
             let mut buf = vec![0u8; 8192];
             let n = stream.read(&mut buf).expect("read request");
             let request = String::from_utf8_lossy(&buf[..n]);
@@ -605,20 +654,14 @@ mod tests {
             stream
                 .write_all(response.as_bytes())
                 .expect("write response");
-        });
-        (addr, handle)
+        })
     }
 
     fn spawn_ollama_stub_with_body_capture(
         captured: std::sync::Arc<std::sync::Mutex<Option<String>>>,
-    ) -> (std::net::SocketAddr, std::thread::JoinHandle<()>) {
-        use std::io::{Read, Write};
-        use std::net::TcpListener;
-
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ollama stub");
-        let addr = listener.local_addr().expect("stub addr");
-        let handle = std::thread::spawn(move || {
-            let mut stream = accept_with_deadline(&listener, "ollama stub (capture)");
+    ) -> LlmStub {
+        spawn_llm_stub("ollama stub (capture)", move |stream| {
+            use std::io::{Read, Write};
             let mut buf = vec![0u8; 16384];
             let n = stream.read(&mut buf).expect("read request");
             let request = String::from_utf8_lossy(&buf[..n]).to_string();
@@ -641,20 +684,14 @@ mod tests {
             stream
                 .write_all(response.as_bytes())
                 .expect("write response");
-        });
-        (addr, handle)
+        })
     }
 
     fn spawn_ollama_raw_generate_stub(
         captured: std::sync::Arc<std::sync::Mutex<Option<String>>>,
-    ) -> (std::net::SocketAddr, std::thread::JoinHandle<()>) {
-        use std::io::{Read, Write};
-        use std::net::TcpListener;
-
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ollama raw stub");
-        let addr = listener.local_addr().expect("stub addr");
-        let handle = std::thread::spawn(move || {
-            let mut stream = accept_with_deadline(&listener, "ollama raw stub");
+    ) -> LlmStub {
+        spawn_llm_stub("ollama raw stub", move |stream| {
+            use std::io::{Read, Write};
             let mut buf = vec![0u8; 16384];
             let n = stream.read(&mut buf).expect("read request");
             let request = String::from_utf8_lossy(&buf[..n]).to_string();
@@ -678,8 +715,7 @@ mod tests {
             stream
                 .write_all(response.as_bytes())
                 .expect("write response");
-        });
-        (addr, handle)
+        })
     }
 
     #[test]
@@ -693,7 +729,8 @@ mod tests {
             .expect("runtime");
 
         runtime.block_on(async {
-            let (addr, server) = spawn_ollama_stub();
+            let server = spawn_ollama_stub();
+            let addr = server.addr();
             let prev_ollama_host = std::env::var("OLLAMA_HOST").ok();
             unsafe {
                 std::env::set_var("OLLAMA_HOST", format!("http://{addr}"));
@@ -729,7 +766,7 @@ mod tests {
                 },
             }
 
-            server.join().expect("stub server");
+            drop(server);
 
             let (result, deltas) = result;
             assert_eq!(result.text, "hello world");
@@ -752,7 +789,8 @@ mod tests {
 
         runtime.block_on(async {
             let captured = std::sync::Arc::new(std::sync::Mutex::new(None));
-            let (addr, server) = spawn_ollama_stub_with_body_capture(captured.clone());
+            let server = spawn_ollama_stub_with_body_capture(captured.clone());
+            let addr = server.addr();
             let prev_ollama_host = std::env::var("OLLAMA_HOST").ok();
             let prev_num_ctx = std::env::var("HARN_OLLAMA_NUM_CTX").ok();
             let prev_keep_alive = std::env::var("HARN_OLLAMA_KEEP_ALIVE").ok();
@@ -786,7 +824,7 @@ mod tests {
                 None => unsafe { std::env::remove_var("HARN_OLLAMA_KEEP_ALIVE") },
             }
 
-            server.join().expect("stub server");
+            drop(server);
             assert_eq!(result.text, "ok");
             let body = captured
                 .lock()
@@ -811,7 +849,8 @@ mod tests {
 
         runtime.block_on(async {
             let captured = std::sync::Arc::new(std::sync::Mutex::new(None));
-            let (addr, server) = spawn_ollama_raw_generate_stub(captured.clone());
+            let server = spawn_ollama_raw_generate_stub(captured.clone());
+            let addr = server.addr();
             let prev_ollama_host = std::env::var("OLLAMA_HOST").ok();
             unsafe {
                 std::env::set_var("OLLAMA_HOST", format!("http://{addr}"));
@@ -842,7 +881,7 @@ mod tests {
                 None => unsafe { std::env::remove_var("OLLAMA_HOST") },
             }
 
-            server.join().expect("stub server");
+            drop(server);
             let (result, deltas) = result;
             assert_eq!(
                 result.text,
@@ -881,7 +920,8 @@ mod tests {
 
         runtime.block_on(async {
             let captured = std::sync::Arc::new(std::sync::Mutex::new(None));
-            let (addr, server) = spawn_ollama_stub_with_body_capture(captured.clone());
+            let server = spawn_ollama_stub_with_body_capture(captured.clone());
+            let addr = server.addr();
             let _num_ctx = ScopedEnvVar::set("HARN_OLLAMA_NUM_CTX", "65536");
             let _keep_alive = ScopedEnvVar::set("HARN_OLLAMA_KEEP_ALIVE", "forever");
 
@@ -889,7 +929,7 @@ mod tests {
                 .await
                 .expect("warmup should succeed");
 
-            server.join().expect("stub server");
+            drop(server);
             let body = captured
                 .lock()
                 .expect("captured body")
@@ -902,49 +942,17 @@ mod tests {
         });
     }
 
-    /// Bind a stub listener + spawn a responder that serves a single canned
-    /// HTTP error response, then returns its join handle. The listener uses
-    /// a bounded accept so a misrouted client can never hang the test
-    /// process — any failure to connect within 3s causes the thread to
-    /// exit, unblocking `join()`.
+    /// Bind a stub listener that serves one canned HTTP error response.
+    /// The returned [`LlmStub`] guard owns the listener and the worker
+    /// thread, so dropping it (test exit, panic) signals shutdown and
+    /// joins — a stuck or misrouted client can never wedge the suite.
     fn spawn_openai_error_stub(
         status_line: &'static str,
         extra_headers: &'static str,
         body: &'static str,
-    ) -> (std::net::SocketAddr, std::thread::JoinHandle<()>) {
-        use std::io::{Read, Write};
-        use std::net::TcpListener;
-
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind openai stub");
-        let addr = listener.local_addr().expect("stub addr");
-        listener
-            .set_nonblocking(true)
-            .expect("set listener nonblocking");
-        let handle = std::thread::spawn(move || {
-            // Fail fast if the client never reaches the stub listener.
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-            let (mut stream, _) = loop {
-                match listener.accept() {
-                    Ok(pair) => break pair,
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        if std::time::Instant::now() >= deadline {
-                            return;
-                        }
-                        std::thread::sleep(std::time::Duration::from_millis(5));
-                    }
-                    Err(_) => return,
-                }
-            };
-            // Bounded read/write so a stuck client can't wedge the suite.
-            stream
-                .set_nonblocking(false)
-                .expect("restore blocking mode on accepted stream");
-            stream
-                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
-                .ok();
-            stream
-                .set_write_timeout(Some(std::time::Duration::from_secs(5)))
-                .ok();
+    ) -> LlmStub {
+        spawn_llm_stub("openai error stub", move |stream| {
+            use std::io::{Read, Write};
             let mut buf = vec![0u8; 16384];
             let _ = stream.read(&mut buf);
             let response = format!(
@@ -953,8 +961,7 @@ mod tests {
             );
             let _ = stream.write_all(response.as_bytes());
             let _ = stream.flush();
-        });
-        (addr, handle)
+        })
     }
 
     /// Single-entrypoint helper that serializes env-var mutation and the
@@ -968,7 +975,8 @@ mod tests {
     ) -> String {
         let _guard = env_lock().lock().expect("env lock");
         let _allow_llm_transport = allow_stubbed_llm_transport();
-        let (addr, server) = spawn_openai_error_stub(status_line, extra_headers, body);
+        let server = spawn_openai_error_stub(status_line, extra_headers, body);
+        let addr = server.addr();
         let prev = std::env::var("LOCAL_LLM_BASE_URL").ok();
         unsafe {
             std::env::set_var("LOCAL_LLM_BASE_URL", format!("http://{addr}"));
@@ -991,8 +999,8 @@ mod tests {
                     opts.output_schema = None;
                     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
                     let call = tokio::time::timeout(
-                        // Must stay inside the stub's fail-fast accept window.
-                        std::time::Duration::from_secs(2),
+                        // Must stay inside the stub's accept window.
+                        std::time::Duration::from_secs(30),
                         vm_call_llm_full_streaming_offthread(&opts, tx),
                     )
                     .await;
@@ -1008,7 +1016,7 @@ mod tests {
             Some(v) => unsafe { std::env::set_var("LOCAL_LLM_BASE_URL", v) },
             None => unsafe { std::env::remove_var("LOCAL_LLM_BASE_URL") },
         }
-        let _ = server.join();
+        drop(server);
         err
     }
 

--- a/crates/harn-vm/src/schema/tests.rs
+++ b/crates/harn-vm/src/schema/tests.rs
@@ -79,6 +79,38 @@ fn validate_union_type_array_input() {
 }
 
 #[test]
+fn all_of_still_applies_sibling_constraints() {
+    let schema = make_vm_dict(vec![
+        (
+            "all_of",
+            make_list(vec![make_vm_dict(vec![("type", s("string"))])]),
+        ),
+        ("min_length", VmValue::Int(3)),
+    ]);
+
+    assert!(schema_is_value(&s("abc"), &schema).unwrap());
+    assert!(!schema_is_value(&s("ab"), &schema).unwrap());
+}
+
+#[test]
+fn union_still_applies_sibling_constraints() {
+    let schema = make_vm_dict(vec![
+        (
+            "union",
+            make_list(vec![
+                make_vm_dict(vec![("type", s("string"))]),
+                make_vm_dict(vec![("type", s("int"))]),
+            ]),
+        ),
+        ("enum", make_list(vec![s("allowed"), VmValue::Int(7)])),
+    ]);
+
+    assert!(schema_is_value(&s("allowed"), &schema).unwrap());
+    assert!(schema_is_value(&VmValue::Int(7), &schema).unwrap());
+    assert!(!schema_is_value(&s("blocked"), &schema).unwrap());
+}
+
+#[test]
 fn export_openapi_nullable() {
     let schema = make_vm_dict(vec![
         ("type", s("string")),

--- a/crates/harn-vm/src/schema/validate.rs
+++ b/crates/harn-vm/src/schema/validate.rs
@@ -113,9 +113,10 @@ fn validate_against_schema(
         }
     }
 
+    let mut errors = Vec::new();
+    let mut normalized = value.clone();
+
     if let Some(VmValue::List(branches)) = schema.get("all_of") {
-        let mut normalized = value.clone();
-        let mut errors = Vec::new();
         for branch in branches.iter() {
             let Some(branch_dict) = branch.as_dict() else {
                 continue;
@@ -125,49 +126,46 @@ fn validate_against_schema(
             normalized = branch_result.value;
             errors.extend(branch_result.errors);
         }
-        return ValidationResult {
-            value: normalized,
-            errors,
-        };
     }
 
     if let Some(VmValue::List(union_schemas)) = schema.get("union") {
+        let mut matched = None;
         for branch in union_schemas.iter() {
             if let Some(dict) = branch.as_dict() {
                 let branch_result =
                     validate_against_schema(value, dict, root_schema, path, options);
                 if branch_result.errors.is_empty() {
-                    return branch_result;
+                    matched = Some(branch_result.value);
+                    break;
                 }
             }
         }
-        return ValidationResult {
-            value: value.clone(),
-            errors: vec![format!(
+        if let Some(value) = matched {
+            normalized = value;
+        } else {
+            errors.push(format!(
                 "at {}: value did not match any union branch",
                 location_label(path)
-            )],
-        };
+            ));
+        }
     }
 
     if let Some(expected_type) = schema_type_name(schema) {
         if !value_matches_type(value, expected_type, options.numeric_compat) {
+            errors.push(format!(
+                "at {}: expected type '{}', got '{}'",
+                location_label(path),
+                expected_type,
+                actual_value_type(value)
+            ));
             return ValidationResult {
-                value: value.clone(),
-                errors: vec![format!(
-                    "at {}: expected type '{}', got '{}'",
-                    location_label(path),
-                    expected_type,
-                    actual_value_type(value)
-                )],
+                value: normalized,
+                errors,
             };
         }
     }
 
-    let mut errors = Vec::new();
-    let mut normalized = value.clone();
-
-    match value {
+    match &normalized {
         VmValue::Dict(map) => {
             let (next_value, next_errors) =
                 validate_object_fields(map, None, schema, root_schema, path, options);
@@ -175,7 +173,7 @@ fn validate_against_schema(
             errors.extend(next_errors);
         }
         VmValue::StructInstance { layout, .. } => {
-            let fields = value.struct_fields_map().unwrap_or_default();
+            let fields = normalized.struct_fields_map().unwrap_or_default();
             let (next_value, next_errors) =
                 validate_object_fields(&fields, Some(layout), schema, root_schema, path, options);
             normalized = next_value;
@@ -218,7 +216,7 @@ fn validate_against_schema(
                         errors.extend(child.errors);
                     }
                 }
-                normalized = match value {
+                normalized = match &normalized {
                     VmValue::Set(_) => VmValue::Set(Rc::new(normalized_items)),
                     _ => VmValue::List(Rc::new(normalized_items)),
                 };
@@ -268,7 +266,7 @@ fn validate_against_schema(
             if let Some(VmValue::List(enum_values)) = schema.get("enum") {
                 if !enum_values
                     .iter()
-                    .any(|candidate| values_equal(candidate, value))
+                    .any(|candidate| values_equal(candidate, &normalized))
                 {
                     errors.push(format!(
                         "at {}: value must be one of [{}]",
@@ -284,14 +282,14 @@ fn validate_against_schema(
         }
         VmValue::Int(number) => {
             validate_numeric_constraints(*number as f64, schema, path, &mut errors);
-            validate_enum_membership(value, schema, path, &mut errors);
+            validate_enum_membership(&normalized, schema, path, &mut errors);
         }
         VmValue::Float(number) => {
             validate_numeric_constraints(*number, schema, path, &mut errors);
-            validate_enum_membership(value, schema, path, &mut errors);
+            validate_enum_membership(&normalized, schema, path, &mut errors);
         }
         VmValue::Bool(_) | VmValue::Nil => {
-            validate_enum_membership(value, schema, path, &mut errors);
+            validate_enum_membership(&normalized, schema, path, &mut errors);
         }
         _ => {}
     }

--- a/crates/harn-vm/src/skills/source.rs
+++ b/crates/harn-vm/src/skills/source.rs
@@ -283,13 +283,9 @@ impl SkillSource for FsSkillSource {
     }
 
     fn fetch(&self, id: &str) -> Result<Skill, String> {
-        let target_name = match id.rsplit_once('/') {
-            Some((_, n)) => n,
-            None => id,
-        };
         for dir in self.iter_skill_dirs() {
             let skill = self.load_from_dir(&dir)?;
-            if skill.id() == id || skill.manifest.name == target_name {
+            if skill.id() == id || (self.namespace.is_none() && skill.manifest.name == id) {
                 return Ok(skill);
             }
         }
@@ -702,6 +698,24 @@ mod tests {
         assert_eq!(listed[0].id, "acme/ops/deploy");
         let skill = src.fetch("acme/ops/deploy").unwrap();
         assert_eq!(skill.id(), "acme/ops/deploy");
+    }
+
+    #[test]
+    fn fs_source_namespaced_fetch_requires_qualified_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(
+            tmp.path(),
+            "deploy/SKILL.md",
+            "---\nname: deploy\nshort: deploy the service\n---\nbody",
+        );
+        let src = FsSkillSource::new(tmp.path(), Layer::Manifest).with_namespace("acme/ops");
+
+        assert!(src.fetch("deploy").is_err());
+        assert!(src.fetch("other/deploy").is_err());
+        assert_eq!(
+            src.fetch("acme/ops/deploy").unwrap().id(),
+            "acme/ops/deploy"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/skills/substitute.rs
+++ b/crates/harn-vm/src/skills/substitute.rs
@@ -34,9 +34,11 @@ pub struct SubstitutionContext {
 /// - `$ARGUMENTS` expands to `arguments.join(" ")`.
 /// - `$1`..`$9` expands to the N-th argument (1-based). `$0` passes
 ///   through unchanged — reserved.
-/// - `${HARN_SKILL_DIR}` / `${HARN_SESSION_ID}` / any other
-///   `${NAME}` looks up `extra_env` and falls back to `std::env::var`
-///   so hosts can scope through the process environment.
+/// - `${HARN_SKILL_DIR}` / `${HARN_SESSION_ID}` / any other `${HARN_*}`
+///   looks up `extra_env` and falls back to `std::env::var` so hosts can
+///   scope safe Harn-specific values through the process environment.
+///   Non-Harn placeholders only use `extra_env`; this keeps arbitrary
+///   process secrets from being exposed by a skill body.
 /// - A literal `$$` escapes to `$`. Everything else is untouched.
 pub fn substitute_skill_body(body: &str, ctx: &SubstitutionContext) -> String {
     let bytes = body.as_bytes();
@@ -113,12 +115,13 @@ fn resolve_named(name: &str, ctx: &SubstitutionContext, original: &str) -> Strin
             .session_id
             .clone()
             .unwrap_or_else(|| original.to_string()),
-        other => ctx
-            .extra_env
-            .get(other)
-            .cloned()
-            .or_else(|| std::env::var(other).ok())
-            .unwrap_or_else(|| original.to_string()),
+        other => ctx.extra_env.get(other).cloned().unwrap_or_else(|| {
+            if other.starts_with("HARN_") {
+                std::env::var(other).unwrap_or_else(|_| original.to_string())
+            } else {
+                original.to_string()
+            }
+        }),
     }
 }
 
@@ -206,6 +209,17 @@ mod tests {
     }
 
     #[test]
+    fn harn_named_placeholder_falls_back_to_process_env() {
+        std::env::set_var("HARN_CI_SUBSTITUTE_TEST_VALUE", "from-env");
+        let ctx = SubstitutionContext::default();
+        assert_eq!(
+            substitute_skill_body("${HARN_CI_SUBSTITUTE_TEST_VALUE}", &ctx),
+            "from-env"
+        );
+        std::env::remove_var("HARN_CI_SUBSTITUTE_TEST_VALUE");
+    }
+
+    #[test]
     fn unknown_named_placeholder_passes_through_when_unset() {
         let ctx = SubstitutionContext::default();
         // Only true when the env var is also unset. This test relies on
@@ -213,6 +227,17 @@ mod tests {
         std::env::remove_var("HARN_CI_UNLIKELY_VAR_NAME_XYZ");
         let body = "value=${HARN_CI_UNLIKELY_VAR_NAME_XYZ}";
         assert_eq!(substitute_skill_body(body, &ctx), body);
+    }
+
+    #[test]
+    fn non_harn_placeholder_does_not_read_process_env() {
+        std::env::set_var("CI_SUBSTITUTE_TEST_SECRET", "secret-value");
+        let ctx = SubstitutionContext::default();
+        assert_eq!(
+            substitute_skill_body("key=${CI_SUBSTITUTE_TEST_SECRET}", &ctx),
+            "key=${CI_SUBSTITUTE_TEST_SECRET}"
+        );
+        std::env::remove_var("CI_SUBSTITUTE_TEST_SECRET");
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/workflow_messages.rs
+++ b/crates/harn-vm/src/stdlib/workflow_messages.rs
@@ -150,13 +150,21 @@ fn load_state(target: &WorkflowTarget) -> Result<WorkflowMailboxState, String> {
 
 fn save_state(target: &WorkflowTarget, state: &WorkflowMailboxState) -> Result<(), String> {
     let path = workflow_state_path(target);
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|error| format!("workflow state mkdir error: {error}"))?;
-    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| "workflow state path has no parent".to_string())?;
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("workflow state mkdir error: {error}"))?;
     let json = serde_json::to_string_pretty(state)
         .map_err(|error| format!("workflow state encode error: {error}"))?;
-    std::fs::write(&path, json).map_err(|error| format!("workflow state write error: {error}"))
+    let tmp_path = parent.join(format!(".state.json.{}.tmp", uuid::Uuid::now_v7()));
+    std::fs::write(&tmp_path, &json)
+        .map_err(|error| format!("workflow state write error: {error}"))?;
+    if let Err(error) = std::fs::rename(&tmp_path, &path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("workflow state rename error: {error}"));
+    }
+    Ok(())
 }
 
 fn parse_target_json(
@@ -391,9 +399,10 @@ pub async fn workflow_update_for_base(
     enqueue_message(&target, "update", name, payload, Some(request_id.clone()))?;
     let started = std::time::Instant::now();
     while started.elapsed() <= timeout {
-        let state = load_state(&target)?;
-        if let Some(response) = state.responses.get(&request_id) {
-            return Ok(response.value.clone());
+        if let Ok(state) = load_state(&target) {
+            if let Some(response) = state.responses.get(&request_id) {
+                return Ok(response.value.clone());
+            }
         }
         tokio::time::sleep(StdDuration::from_millis(UPDATE_POLL_INTERVAL_MS)).await;
     }

--- a/crates/harn-vm/src/tenant.rs
+++ b/crates/harn-vm/src/tenant.rs
@@ -159,7 +159,7 @@ impl TenantStore {
         };
         let encoded = serde_json::to_string_pretty(&snapshot).map_err(|error| error.to_string())?;
         let path = registry_path(&self.state_dir);
-        std::fs::write(&path, encoded)
+        write_file_replace(&path, encoded.as_bytes())
             .map_err(|error| format!("failed to write {}: {error}", path.display()))
     }
 
@@ -458,6 +458,26 @@ fn registry_path(state_dir: &Path) -> PathBuf {
         .join(TENANT_REGISTRY_FILE)
 }
 
+fn write_file_replace(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let tmp_path = dir.join(format!(
+        ".{}.{}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("registry"),
+        uuid::Uuid::now_v7()
+    ));
+    std::fs::write(&tmp_path, contents)?;
+    #[cfg(windows)]
+    if path.exists() {
+        std::fs::remove_file(path)?;
+    }
+    std::fs::rename(&tmp_path, path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp_path);
+    })?;
+    Ok(())
+}
+
 fn generate_api_key(id: &str) -> String {
     let random: [u8; 32] = rand::random();
     format!("harn_tenant_{id}_{}", hex::encode(random))
@@ -580,5 +600,22 @@ mod tests {
 
         let cross = SecretId::new("harn.tenant.tenant-b", "webhook");
         assert!(provider.get(&cross).await.is_err());
+    }
+
+    #[test]
+    fn tenant_store_save_replaces_registry_without_temp_leak() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut store = TenantStore::load(temp.path()).unwrap();
+        store
+            .create_tenant("tenant-a", TenantBudget::default())
+            .unwrap();
+
+        let registry = registry_path(temp.path());
+        assert!(registry.is_file());
+        let leaked_temp = std::fs::read_dir(registry.parent().unwrap())
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|entry| entry.file_name().to_string_lossy().ends_with(".tmp"));
+        assert!(!leaked_temp);
     }
 }


### PR DESCRIPTION
## Summary
- harden auth, egress, portal asset serving, skill substitution, tenant registry writes, and namespaced skill lookup
- fix schema validation composition so all_of/union still apply sibling constraints
- improve host command handling for canonical cwd, UTF-8-safe inline output, Gradle wrapper portability, and artifact module split
- isolate global egress policies and agent event sinks in tests to remove parallel-suite contamination

## Verification
- cargo fmt --all
- CARGO_TARGET_DIR=/tmp/harn-target/audit cargo clippy --workspace --all-targets -- -D warnings
- CARGO_TARGET_DIR=/tmp/harn-target/audit cargo test -p harn-vm -p harn-hostlib -p harn-serve --lib
- CARGO_TARGET_DIR=/tmp/harn-target/audit cargo test -p harn-cli portal
- CARGO_TARGET_DIR=/tmp/harn-target/audit cargo test -p harn-vm --lib skills::substitute::tests
- pre-commit hook: clippy passed
- pre-push hook: nextest 2908 passed, 1 existing leaky test reported
