### PR TITLE
[codex] Classify LLM provider errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ granular archaeology.
 
 ### Added
 
+- **Canonical LLM error taxonomy (#854).** Provider transport errors now surface
+  `kind` (`"transient"` / `"terminal"`) and `reason` (`"rate_limit"`,
+  `"server_error"`, `"network_error"`, `"timeout"`, `"auth_failure"`,
+  `"context_overflow"`, `"content_policy"`, `"invalid_request"`,
+  `"model_unavailable"`, `"unknown"`) alongside the existing `category`
+  compatibility field. `llm_call` / `agent_loop` retry only transient kinds,
+  and provider-specific HTTP mappings cover OpenAI-compatible, Anthropic, and
+  Ollama error shapes.
+
 - **Command policy hooks (#824/#846).** First-class `command_policy` builtins
   with policy stack management, deterministic command/result risk scanning,
   and a safe `command_llm_risk_scan` fallback shape. `host_call("process.exec",

--- a/conformance/tests/integration/llm_mock_error.expected
+++ b/conformance/tests/integration/llm_mock_error.expected
@@ -1,8 +1,12 @@
 rate_limit
 true
+transient
+rate_limit
 rate_limit
 2500
 mock
 mock-model
 overloaded
+transient
+server_error
 true

--- a/conformance/tests/integration/llm_mock_error.harn
+++ b/conformance/tests/integration/llm_mock_error.harn
@@ -1,9 +1,9 @@
 /**
- * `llm_call`'s catch value is a dict `{category, message,
- * retry_after_ms?, provider, model}` — the same shape `llm_call_safe`
- * returns inside its `error` envelope. `error_category(e)` and
- * `is_rate_limited(e)` still work (they accept dict or string); scripts
- * can also dispatch directly on `e.category`.
+ * `llm_call`'s catch value is a dict `{kind, reason, category,
+ * message, retry_after_ms?, provider, model}` — the same shape
+ * `llm_call_safe` returns inside its `error` envelope.
+ * `error_category(e)` and `is_rate_limited(e)` still work (they accept
+ * dict or string); scripts can dispatch directly on `e.kind`/`e.reason`.
  */
 pipeline default(task) {
   // `llm_retries: 0` disables the llm_call-internal transient retry so
@@ -14,6 +14,8 @@ pipeline default(task) {
   } catch (e) {
     println(error_category(e))
     println(is_rate_limited(e))
+    println(e.kind)
+    println(e.reason)
     println(e.category)
     println(e.retry_after_ms)
     println(e.provider)
@@ -24,6 +26,8 @@ pipeline default(task) {
     llm_call("hello again", nil, {provider: "mock", llm_retries: 0})
   } catch (e2) {
     println(error_category(e2))
+    println(e2.kind)
+    println(e2.reason)
     // retry_after_ms is omitted when the provider didn't surface one.
     println(e2.retry_after_ms == nil)
   }

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -104,11 +104,35 @@ fn current_iteration() -> Option<usize> {
 pub(super) fn is_retryable_llm_error(err: &VmError) -> bool {
     use crate::value::{classify_error_message, ErrorCategory};
     let msg = match err {
-        VmError::CategorizedError { category, .. } => return category.is_transient(),
+        VmError::CategorizedError { category, message } => {
+            let llm_info = crate::llm::api::classify_llm_error(category.clone(), message);
+            return if llm_info.reason == crate::llm::api::LlmErrorReason::Unknown {
+                category.is_transient()
+            } else {
+                llm_info.kind == crate::llm::api::LlmErrorKind::Transient
+            };
+        }
+        VmError::Thrown(crate::value::VmValue::Dict(d)) => {
+            if let Some(kind) = d.get("kind").map(|v| v.display()) {
+                return kind == "transient";
+            }
+            if let Some(category) = d.get("category").map(|v| v.display()) {
+                return ErrorCategory::parse(&category).is_transient();
+            }
+            return false;
+        }
         VmError::Thrown(crate::value::VmValue::String(s)) => s.as_ref(),
         VmError::Runtime(s) => s.as_str(),
         _ => return false,
     };
+    let category = classify_error_message(msg);
+    let llm_info = crate::llm::api::classify_llm_error(category.clone(), msg);
+    if llm_info.kind == crate::llm::api::LlmErrorKind::Transient {
+        return true;
+    }
+    if llm_info.reason != crate::llm::api::LlmErrorReason::Unknown {
+        return false;
+    }
     let derived = classify_error_message(msg);
     if derived != ErrorCategory::Generic {
         return derived.is_transient();
@@ -152,6 +176,12 @@ fn is_empty_completion_retry_error(err: &VmError) -> bool {
 pub(super) fn extract_retry_after_ms(err: &VmError) -> Option<u64> {
     let msg = match err {
         VmError::Thrown(crate::value::VmValue::String(s)) => s.as_ref(),
+        VmError::Thrown(crate::value::VmValue::Dict(d)) => {
+            return d.get("retry_after_ms").and_then(|v| match v {
+                crate::value::VmValue::Int(ms) if *ms >= 0 => Some(*ms as u64),
+                _ => None,
+            });
+        }
         VmError::CategorizedError { message, .. } => message.as_str(),
         VmError::Runtime(s) => s.as_str(),
         _ => return None,
@@ -957,6 +987,35 @@ mod retry_tests {
         assert!(!is_retryable_llm_error(&categorized(
             "invalid key",
             ErrorCategory::Auth
+        )));
+    }
+
+    #[test]
+    fn llm_error_kind_dict_gates_retry() {
+        let transient =
+            VmError::Thrown(VmValue::Dict(Rc::new(std::collections::BTreeMap::from([
+                ("kind".to_string(), VmValue::String(Rc::from("transient"))),
+                (
+                    "reason".to_string(),
+                    VmValue::String(Rc::from("network_error")),
+                ),
+            ]))));
+        assert!(is_retryable_llm_error(&transient));
+
+        let terminal = VmError::Thrown(VmValue::Dict(Rc::new(std::collections::BTreeMap::from([
+            ("kind".to_string(), VmValue::String(Rc::from("terminal"))),
+            (
+                "reason".to_string(),
+                VmValue::String(Rc::from("context_overflow")),
+            ),
+        ]))));
+        assert!(!is_retryable_llm_error(&terminal));
+    }
+
+    #[test]
+    fn context_overflow_message_is_not_retryable() {
+        assert!(!is_retryable_llm_error(&thrown(
+            "local HTTP 400 Bad Request [context_overflow]: prompt is too long"
         )));
     }
 

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -33,6 +33,9 @@ pub(crate) use auth::apply_auth_headers;
 pub(crate) use completion::vm_call_completion_full;
 pub(crate) use context_window::adapt_auto_compact_to_provider;
 pub use context_window::fetch_provider_max_context;
+pub(crate) use errors::{
+    classify_llm_error, classify_provider_http_error, LlmErrorInfo, LlmErrorKind, LlmErrorReason,
+};
 pub(crate) use ollama::apply_ollama_runtime_settings;
 pub use ollama::{
     normalize_ollama_keep_alive, ollama_readiness, ollama_runtime_settings_from_env,

--- a/crates/harn-vm/src/llm/api/errors.rs
+++ b/crates/harn-vm/src/llm/api/errors.rs
@@ -2,52 +2,286 @@
 //! streaming and non-streaming transports so the classification never
 //! drifts between them.
 
+use crate::value::ErrorCategory;
+
+/// Coarse retry semantics for provider failures.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LlmErrorKind {
+    Transient,
+    Terminal,
+}
+
+impl LlmErrorKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Transient => "transient",
+            Self::Terminal => "terminal",
+        }
+    }
+}
+
+/// Canonical reason within the LLM error taxonomy.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LlmErrorReason {
+    RateLimit,
+    ServerError,
+    NetworkError,
+    Timeout,
+    AuthFailure,
+    ContextOverflow,
+    ContentPolicy,
+    InvalidRequest,
+    ModelUnavailable,
+    Unknown,
+}
+
+impl LlmErrorReason {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::RateLimit => "rate_limit",
+            Self::ServerError => "server_error",
+            Self::NetworkError => "network_error",
+            Self::Timeout => "timeout",
+            Self::AuthFailure => "auth_failure",
+            Self::ContextOverflow => "context_overflow",
+            Self::ContentPolicy => "content_policy",
+            Self::InvalidRequest => "invalid_request",
+            Self::ModelUnavailable => "model_unavailable",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    fn legacy_tag(self) -> &'static str {
+        match self {
+            Self::RateLimit => "rate_limited",
+            Self::ServerError => "http_error",
+            other => other.as_str(),
+        }
+    }
+}
+
+/// Fully classified provider failure.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LlmErrorInfo {
+    pub(crate) kind: LlmErrorKind,
+    pub(crate) reason: LlmErrorReason,
+    pub(crate) message: String,
+}
+
 /// Build a tagged, provider-prefixed error message from a non-2xx HTTP
 /// response so downstream agent loops can react (e.g. trigger compaction on
 /// `context_overflow`, back off on `rate_limited`, surface everything else as
 /// `http_error`).
-pub(crate) fn classify_http_error(
+pub(crate) fn classify_provider_http_error(
     provider: &str,
     status: reqwest::StatusCode,
     retry_after: Option<&str>,
     body: &str,
-) -> String {
-    // Patterns cover vLLM, OpenAI, Anthropic, and most OpenAI-compatibles.
-    let body_lower = body.to_lowercase();
-    let is_context_overflow = body_lower.contains("maximum context length")
-        || body_lower.contains("context length")
-        || body_lower.contains("context_length_exceeded")
-        || body_lower.contains("prompt is too long")
-        || body_lower.contains("prompt_tokens_exceeded")
-        || body_lower.contains("this model's maximum context")
-        || body_lower.contains("exceeds the maximum")
-        || (body_lower.contains("max_tokens") && body_lower.contains("exceed"));
-    let tag = if is_context_overflow {
-        "context_overflow"
-    } else if status.as_u16() == 429 {
-        "rate_limited"
-    } else {
-        "http_error"
-    };
-    let mut msg = format!("{provider} HTTP {status} [{tag}]: {body}");
+) -> LlmErrorInfo {
+    let (kind, reason) = classify_http_status_and_body(status, body);
+    let mut msg = format!("{provider} HTTP {status} [{}]: {body}", reason.legacy_tag());
     if let Some(ra) = retry_after {
         msg.push_str(&format!(" (retry-after: {ra})"));
     }
-    msg
+    LlmErrorInfo {
+        kind,
+        reason,
+        message: msg,
+    }
+}
+
+pub(crate) fn classify_llm_error(category: ErrorCategory, message: &str) -> LlmErrorInfo {
+    if let Some((kind, reason)) = classify_error_message_taxonomy(message) {
+        return LlmErrorInfo {
+            kind,
+            reason,
+            message: message.to_string(),
+        };
+    }
+
+    let (kind, reason) = match category {
+        ErrorCategory::RateLimit => (LlmErrorKind::Transient, LlmErrorReason::RateLimit),
+        ErrorCategory::Timeout => (LlmErrorKind::Transient, LlmErrorReason::Timeout),
+        ErrorCategory::Overloaded | ErrorCategory::ServerError => {
+            (LlmErrorKind::Transient, LlmErrorReason::ServerError)
+        }
+        ErrorCategory::TransientNetwork => (LlmErrorKind::Transient, LlmErrorReason::NetworkError),
+        ErrorCategory::Auth => (LlmErrorKind::Terminal, LlmErrorReason::AuthFailure),
+        ErrorCategory::NotFound => (LlmErrorKind::Terminal, LlmErrorReason::ModelUnavailable),
+        _ => (LlmErrorKind::Terminal, LlmErrorReason::Unknown),
+    };
+
+    LlmErrorInfo {
+        kind,
+        reason,
+        message: message.to_string(),
+    }
+}
+
+fn classify_http_status_and_body(
+    status: reqwest::StatusCode,
+    body: &str,
+) -> (LlmErrorKind, LlmErrorReason) {
+    // Patterns cover vLLM, OpenAI, Anthropic, and most OpenAI-compatibles.
+    let body_lower = body.to_lowercase();
+
+    if is_context_overflow(&body_lower) {
+        return (LlmErrorKind::Terminal, LlmErrorReason::ContextOverflow);
+    }
+    if is_content_policy(&body_lower) {
+        return (LlmErrorKind::Terminal, LlmErrorReason::ContentPolicy);
+    }
+    if is_auth_failure(&body_lower) || matches!(status.as_u16(), 401 | 403) {
+        return (LlmErrorKind::Terminal, LlmErrorReason::AuthFailure);
+    }
+    if status.as_u16() == 429
+        || body_lower.contains("rate_limit")
+        || body_lower.contains("insufficient_quota")
+        || body_lower.contains("billing_hard_limit_reached")
+    {
+        return (LlmErrorKind::Transient, LlmErrorReason::RateLimit);
+    }
+    if matches!(status.as_u16(), 408 | 504 | 522 | 524) || body_lower.contains("timeout") {
+        return (LlmErrorKind::Transient, LlmErrorReason::Timeout);
+    }
+    if is_model_unavailable(&body_lower) || matches!(status.as_u16(), 404 | 410) {
+        return (LlmErrorKind::Terminal, LlmErrorReason::ModelUnavailable);
+    }
+    if matches!(status.as_u16(), 500 | 502 | 503 | 529)
+        || body_lower.contains("overloaded_error")
+        || body_lower.contains("service unavailable")
+        || body_lower.contains("bad gateway")
+        || body_lower.contains("api_error")
+    {
+        return (LlmErrorKind::Transient, LlmErrorReason::ServerError);
+    }
+    if status.as_u16() == 400
+        || body_lower.contains("invalid_request")
+        || body_lower.contains("bad request")
+    {
+        return (LlmErrorKind::Terminal, LlmErrorReason::InvalidRequest);
+    }
+
+    (LlmErrorKind::Terminal, LlmErrorReason::Unknown)
+}
+
+fn classify_error_message_taxonomy(msg: &str) -> Option<(LlmErrorKind, LlmErrorReason)> {
+    let lower = msg.to_lowercase();
+    if lower.contains("kind") && lower.contains("transient") {
+        if lower.contains("rate_limit") || lower.contains("rate_limited") {
+            return Some((LlmErrorKind::Transient, LlmErrorReason::RateLimit));
+        }
+        if lower.contains("timeout") {
+            return Some((LlmErrorKind::Transient, LlmErrorReason::Timeout));
+        }
+        if lower.contains("network_error") || lower.contains("transient_network") {
+            return Some((LlmErrorKind::Transient, LlmErrorReason::NetworkError));
+        }
+        if lower.contains("server_error") || lower.contains("overloaded") {
+            return Some((LlmErrorKind::Transient, LlmErrorReason::ServerError));
+        }
+    }
+    if is_context_overflow(&lower) {
+        return Some((LlmErrorKind::Terminal, LlmErrorReason::ContextOverflow));
+    }
+    if is_content_policy(&lower) {
+        return Some((LlmErrorKind::Terminal, LlmErrorReason::ContentPolicy));
+    }
+    if is_auth_failure(&lower) {
+        return Some((LlmErrorKind::Terminal, LlmErrorReason::AuthFailure));
+    }
+    if is_model_unavailable(&lower) {
+        return Some((LlmErrorKind::Terminal, LlmErrorReason::ModelUnavailable));
+    }
+    if lower.contains("[rate_limited]")
+        || lower.contains("too many requests")
+        || lower.contains("insufficient_quota")
+        || lower.contains("billing_hard_limit_reached")
+    {
+        return Some((LlmErrorKind::Transient, LlmErrorReason::RateLimit));
+    }
+    if lower.contains("[http_error]")
+        || lower.contains("bad gateway")
+        || lower.contains("service unavailable")
+        || lower.contains("overloaded")
+        || lower.contains("api_error")
+    {
+        return Some((LlmErrorKind::Transient, LlmErrorReason::ServerError));
+    }
+    if lower.contains("timed out") || lower.contains("timeout") {
+        return Some((LlmErrorKind::Transient, LlmErrorReason::Timeout));
+    }
+    if lower.contains("connection reset")
+        || lower.contains("connection refused")
+        || lower.contains("connection closed")
+        || lower.contains("broken pipe")
+        || lower.contains("dns error")
+        || lower.contains("stream error")
+        || lower.contains("unexpected eof")
+        || lower.contains("eof")
+    {
+        return Some((LlmErrorKind::Transient, LlmErrorReason::NetworkError));
+    }
+    if lower.contains("invalid_request")
+        || lower.contains("bad request")
+        || lower.contains("[invalid_request]")
+    {
+        return Some((LlmErrorKind::Terminal, LlmErrorReason::InvalidRequest));
+    }
+    None
+}
+
+fn is_context_overflow(lower: &str) -> bool {
+    lower.contains("maximum context length")
+        || lower.contains("context length")
+        || lower.contains("context_length_exceeded")
+        || lower.contains("context_overflow")
+        || lower.contains("prompt is too long")
+        || lower.contains("prompt_tokens_exceeded")
+        || lower.contains("this model's maximum context")
+        || lower.contains("exceeds the maximum")
+        || (lower.contains("max_tokens") && lower.contains("exceed"))
+}
+
+fn is_content_policy(lower: &str) -> bool {
+    lower.contains("content_policy")
+        || lower.contains("content policy")
+        || lower.contains("safety policy")
+        || lower.contains("moderation")
+        || lower.contains("responsible_ai_policy")
+        || lower.contains("blocked by policy")
+}
+
+fn is_auth_failure(lower: &str) -> bool {
+    lower.contains("invalid_api_key")
+        || lower.contains("authentication_error")
+        || lower.contains("auth_failure")
+        || lower.contains("unauthorized")
+        || lower.contains("forbidden")
+}
+
+fn is_model_unavailable(lower: &str) -> bool {
+    lower.contains("model_not_found")
+        || lower.contains("not_found_error")
+        || lower.contains("model unavailable")
+        || lower.contains("model is unavailable")
+        || lower.contains("model not found")
 }
 
 #[cfg(test)]
 mod tests {
-    use super::classify_http_error;
+    use super::{classify_llm_error, classify_provider_http_error, LlmErrorKind, LlmErrorReason};
+    use crate::value::ErrorCategory;
 
     #[test]
     fn classify_tags_vllm_prompt_too_long_as_context_overflow() {
-        let msg = classify_http_error(
+        let msg = classify_provider_http_error(
             "local",
             reqwest::StatusCode::BAD_REQUEST,
             None,
             r#"{"object":"error","message":"This model's maximum context length is 8192 tokens. However, your prompt is too long (10234 tokens)."}"#,
-        );
+        )
+        .message;
         assert!(msg.contains("[context_overflow]"), "msg was: {msg}");
         assert!(msg.starts_with("local HTTP 400 Bad Request"));
         assert!(!msg.contains("(retry-after"));
@@ -55,35 +289,40 @@ mod tests {
 
     #[test]
     fn classify_tags_openai_context_length_exceeded_as_context_overflow() {
-        let msg = classify_http_error(
+        let info = classify_provider_http_error(
             "openai",
             reqwest::StatusCode::BAD_REQUEST,
             None,
             r#"{"error":{"code":"context_length_exceeded","message":"maximum context length"}}"#,
         );
+        let msg = info.message;
+        assert_eq!(info.kind, LlmErrorKind::Terminal);
+        assert_eq!(info.reason, LlmErrorReason::ContextOverflow);
         assert!(msg.contains("[context_overflow]"), "msg was: {msg}");
     }
 
     #[test]
     fn classify_tags_429_with_retry_after_as_rate_limited() {
-        let msg = classify_http_error(
+        let msg = classify_provider_http_error(
             "anthropic",
             reqwest::StatusCode::TOO_MANY_REQUESTS,
             Some("12"),
             r#"{"error":{"type":"rate_limit_error","message":"quota exceeded"}}"#,
-        );
+        )
+        .message;
         assert!(msg.contains("[rate_limited]"), "msg was: {msg}");
         assert!(msg.ends_with("(retry-after: 12)"), "msg was: {msg}");
     }
 
     #[test]
     fn classify_tags_opaque_500_as_http_error() {
-        let msg = classify_http_error(
+        let msg = classify_provider_http_error(
             "local",
             reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             None,
             "upstream exploded",
-        );
+        )
+        .message;
         assert!(msg.contains("[http_error]"), "msg was: {msg}");
         assert!(msg.contains("upstream exploded"));
     }
@@ -92,12 +331,34 @@ mod tests {
     fn classify_429_with_context_body_still_prefers_context_overflow() {
         // Some OpenAI-compat servers return 429 for context overflow;
         // classify by body because caller reaction differs (compact vs back off).
-        let msg = classify_http_error(
+        let info = classify_provider_http_error(
             "local",
             reqwest::StatusCode::TOO_MANY_REQUESTS,
             Some("1"),
             "prompt is too long",
         );
+        let msg = info.message;
+        assert_eq!(info.kind, LlmErrorKind::Terminal);
+        assert_eq!(info.reason, LlmErrorReason::ContextOverflow);
         assert!(msg.contains("[context_overflow]"), "msg was: {msg}");
+    }
+
+    #[test]
+    fn classify_content_policy_as_terminal() {
+        let info = classify_provider_http_error(
+            "openai",
+            reqwest::StatusCode::BAD_REQUEST,
+            None,
+            r#"{"error":{"code":"content_policy_violation","message":"blocked"}}"#,
+        );
+        assert_eq!(info.kind, LlmErrorKind::Terminal);
+        assert_eq!(info.reason, LlmErrorReason::ContentPolicy);
+    }
+
+    #[test]
+    fn category_mapping_preserves_transient_semantics() {
+        let info = classify_llm_error(ErrorCategory::TransientNetwork, "connection reset");
+        assert_eq!(info.kind, LlmErrorKind::Transient);
+        assert_eq!(info.reason, LlmErrorReason::NetworkError);
     }
 }

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -9,7 +9,6 @@ use std::time::Instant;
 use crate::agent_events::{AgentEvent, ToolCallStatus};
 use crate::value::{VmError, VmValue};
 
-use super::errors::classify_http_error;
 use super::openai_normalize::{
     append_paragraph, debug_log_message_shapes, extract_openai_delta_field_str,
 };
@@ -96,6 +95,39 @@ fn should_request_stream_usage(is_anthropic_style: bool, is_ollama: bool, endpoi
     // this field, but its `/v1/chat/completions` compatibility endpoint
     // does.
     !is_ollama || endpoint.contains("/v1/")
+}
+
+fn classify_transport_http_error(
+    provider: &str,
+    status: reqwest::StatusCode,
+    retry_after: Option<&str>,
+    body: &str,
+    is_anthropic_style: bool,
+    is_ollama: bool,
+) -> String {
+    if is_anthropic_style {
+        return crate::llm::providers::AnthropicProvider::classify_http_error(
+            status,
+            retry_after,
+            body,
+        )
+        .message;
+    }
+    if is_ollama {
+        return crate::llm::providers::OllamaProvider::classify_http_error(
+            status,
+            retry_after,
+            body,
+        )
+        .message;
+    }
+    crate::llm::providers::OpenAiCompatibleProvider::classify_http_error(
+        provider,
+        status,
+        retry_after,
+        body,
+    )
+    .message
 }
 
 /// Dispatch an LLM API call to the appropriate provider. This is the main
@@ -276,7 +308,14 @@ pub(crate) async fn vm_call_llm_api_with_body(
                 .and_then(|v| v.to_str().ok())
                 .map(|s| s.to_string());
             let body = response.text().await.unwrap_or_default();
-            let msg = classify_http_error(provider, status, retry_after.as_deref(), &body);
+            let msg = classify_transport_http_error(
+                provider,
+                status,
+                retry_after.as_deref(),
+                &body,
+                is_anthropic_style,
+                is_ollama,
+            );
             return Err(VmError::Thrown(VmValue::String(Rc::from(msg))));
         }
         let ct = response
@@ -315,7 +354,14 @@ pub(crate) async fn vm_call_llm_api_with_body(
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
         let body = response.text().await.unwrap_or_default();
-        let msg = classify_http_error(provider, status, retry_after.as_deref(), &body);
+        let msg = classify_transport_http_error(
+            provider,
+            status,
+            retry_after.as_deref(),
+            &body,
+            is_anthropic_style,
+            is_ollama,
+        );
         return Err(VmError::Thrown(VmValue::String(Rc::from(msg))));
     }
 

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -520,8 +520,9 @@ pub fn reset_llm_state() {
 /// Shared implementation of `llm_call` / `llm_call_safe`. Runs the
 /// full schema-retry loop; on success returns the LLM result dict, on
 /// failure returns the underlying `VmError`. `llm_call` propagates the
-/// error (re-wrapped as a thrown `{category, message, retry_after_ms?,
-/// provider, model}` dict so catch blocks can dispatch on category);
+/// error (re-wrapped as a thrown `{kind, reason, category, message,
+/// retry_after_ms?, provider, model}` dict so catch blocks can dispatch
+/// on the LLM error taxonomy);
 /// `llm_call_safe` wraps it in a `{ok: false, error: …}` envelope with
 /// the same fields.
 async fn llm_call_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
@@ -537,33 +538,34 @@ async fn llm_call_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     }
 }
 
-/// Build the `{category, message, retry_after_ms?, provider, model}`
+/// Build the `{kind, reason, category, message, retry_after_ms?, provider, model}`
 /// dict that `llm_call` throws on failure. `retry_after_ms` is only
 /// set when the underlying error carries a parseable `retry-after:`
 /// hint, so callers can pattern-match on its presence:
 ///
 /// ```harn
 /// try { llm_call(prompt, nil, opts) } catch (e) {
-///   if e.category == "rate_limit" {
+///   if e.kind == "transient" && e.reason == "rate_limit" {
 ///     sleep(e.retry_after_ms ?? 1000)
 ///   }
 /// }
 /// ```
 pub(crate) fn build_llm_error_dict(err: &VmError, provider: &str, model: &str) -> VmValue {
     let category = crate::value::error_to_category(err);
-    let message = match err {
-        VmError::CategorizedError { message, .. } => message.clone(),
-        VmError::Thrown(VmValue::String(s)) => s.to_string(),
-        VmError::Thrown(VmValue::Dict(d)) => d
-            .get("message")
-            .map(|v| v.display())
-            .unwrap_or_else(|| err.to_string()),
-        _ => err.to_string(),
-    };
+    let message = llm_error_message(err);
+    let llm_error = api::classify_llm_error(category.clone(), &message);
     let mut dict = std::collections::BTreeMap::new();
     dict.insert(
         "category".to_string(),
         VmValue::String(Rc::from(category.as_str())),
+    );
+    dict.insert(
+        "kind".to_string(),
+        VmValue::String(Rc::from(llm_error.kind.as_str())),
+    );
+    dict.insert(
+        "reason".to_string(),
+        VmValue::String(Rc::from(llm_error.reason.as_str())),
     );
     dict.insert("message".to_string(), VmValue::String(Rc::from(message)));
     if let Some(ms) = agent_observe::extract_retry_after_ms(err) {
@@ -572,6 +574,18 @@ pub(crate) fn build_llm_error_dict(err: &VmError, provider: &str, model: &str) -
     dict.insert("provider".to_string(), VmValue::String(Rc::from(provider)));
     dict.insert("model".to_string(), VmValue::String(Rc::from(model)));
     VmValue::Dict(Rc::new(dict))
+}
+
+fn llm_error_message(err: &VmError) -> String {
+    match err {
+        VmError::CategorizedError { message, .. } => message.clone(),
+        VmError::Thrown(VmValue::String(s)) => s.to_string(),
+        VmError::Thrown(VmValue::Dict(d)) => d
+            .get("message")
+            .map(|v| v.display())
+            .unwrap_or_else(|| err.to_string()),
+        _ => err.to_string(),
+    }
 }
 
 pub(crate) async fn execute_llm_call(
@@ -755,8 +769,8 @@ fn llm_safe_envelope_ok(response: VmValue) -> VmValue {
 
 fn llm_safe_envelope_err(err: &VmError) -> VmValue {
     // `llm_call_impl` pre-wraps its errors into a
-    // `VmError::Thrown(VmValue::Dict{category, message, retry_after_ms?,
-    // provider, model})`. Pass that dict through verbatim so
+    // `VmError::Thrown(VmValue::Dict{kind, reason, category, message,
+    // retry_after_ms?, provider, model})`. Pass that dict through verbatim so
     // `llm_call_safe` callers see the same fields as `try/catch`
     // users — with `category` / `message` always populated.
     if let VmError::Thrown(VmValue::Dict(d)) = err {
@@ -767,15 +781,20 @@ fn llm_safe_envelope_err(err: &VmError) -> VmValue {
         return VmValue::Dict(Rc::new(dict));
     }
     let category = crate::value::error_to_category(err);
-    let message = match err {
-        VmError::CategorizedError { message, .. } => message.clone(),
-        VmError::Thrown(VmValue::String(s)) => s.to_string(),
-        _ => err.to_string(),
-    };
+    let message = llm_error_message(err);
+    let llm_error = api::classify_llm_error(category.clone(), &message);
     let mut err_dict = std::collections::BTreeMap::new();
     err_dict.insert(
         "category".to_string(),
         VmValue::String(Rc::from(category.as_str())),
+    );
+    err_dict.insert(
+        "kind".to_string(),
+        VmValue::String(Rc::from(llm_error.kind.as_str())),
+    );
+    err_dict.insert(
+        "reason".to_string(),
+        VmValue::String(Rc::from(llm_error.reason.as_str())),
     );
     err_dict.insert("message".to_string(), VmValue::String(Rc::from(message)));
     let mut dict = std::collections::BTreeMap::new();
@@ -881,20 +900,28 @@ pub(crate) fn structured_safe_envelope_ok(data: VmValue) -> VmValue {
 }
 
 pub(crate) fn structured_safe_envelope_err(err: &VmError) -> VmValue {
+    if let VmError::Thrown(VmValue::Dict(d)) = err {
+        let mut dict = std::collections::BTreeMap::new();
+        dict.insert("ok".to_string(), VmValue::Bool(false));
+        dict.insert("data".to_string(), VmValue::Nil);
+        dict.insert("error".to_string(), VmValue::Dict(d.clone()));
+        return VmValue::Dict(Rc::new(dict));
+    }
     let category = crate::value::error_to_category(err);
-    let message = match err {
-        VmError::CategorizedError { message, .. } => message.clone(),
-        VmError::Thrown(VmValue::String(s)) => s.to_string(),
-        VmError::Thrown(VmValue::Dict(d)) => d
-            .get("message")
-            .map(|v| v.display())
-            .unwrap_or_else(|| err.to_string()),
-        _ => err.to_string(),
-    };
+    let message = llm_error_message(err);
+    let llm_error = api::classify_llm_error(category.clone(), &message);
     let mut err_dict = std::collections::BTreeMap::new();
     err_dict.insert(
         "category".to_string(),
         VmValue::String(Rc::from(category.as_str())),
+    );
+    err_dict.insert(
+        "kind".to_string(),
+        VmValue::String(Rc::from(llm_error.kind.as_str())),
+    );
+    err_dict.insert(
+        "reason".to_string(),
+        VmValue::String(Rc::from(llm_error.reason.as_str())),
     );
     err_dict.insert("message".to_string(), VmValue::String(Rc::from(message)));
     let mut dict = std::collections::BTreeMap::new();

--- a/crates/harn-vm/src/llm/providers/anthropic.rs
+++ b/crates/harn-vm/src/llm/providers/anthropic.rs
@@ -199,6 +199,14 @@ impl LlmProviderChat for AnthropicProvider {
 }
 
 impl AnthropicProvider {
+    pub(crate) fn classify_http_error(
+        status: reqwest::StatusCode,
+        retry_after: Option<&str>,
+        body: &str,
+    ) -> crate::llm::api::LlmErrorInfo {
+        crate::llm::api::classify_provider_http_error("anthropic", status, retry_after, body)
+    }
+
     /// Build the Anthropic-style request body.
     pub(crate) fn build_request_body(opts: &LlmRequestPayload) -> serde_json::Value {
         let anthropic_max = if opts.max_tokens > 0 {
@@ -324,6 +332,7 @@ impl AnthropicProvider {
 mod tests {
     use super::*;
     use crate::llm::api::LlmRequestPayload;
+    use crate::llm::api::{LlmErrorKind, LlmErrorReason};
 
     fn base_payload() -> LlmRequestPayload {
         LlmRequestPayload {
@@ -418,6 +427,28 @@ mod tests {
         let provider = AnthropicProvider;
         assert!(provider.supports_defer_loading("claude-opus-4-7"));
         assert!(!provider.supports_defer_loading("claude-opus-3-5"));
+    }
+
+    #[test]
+    fn classifies_anthropic_overloaded_error_as_transient_server_error() {
+        let info = AnthropicProvider::classify_http_error(
+            reqwest::StatusCode::from_u16(529).unwrap(),
+            None,
+            r#"{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"#,
+        );
+        assert_eq!(info.kind, LlmErrorKind::Transient);
+        assert_eq!(info.reason, LlmErrorReason::ServerError);
+    }
+
+    #[test]
+    fn classifies_anthropic_auth_error_as_terminal_auth_failure() {
+        let info = AnthropicProvider::classify_http_error(
+            reqwest::StatusCode::UNAUTHORIZED,
+            None,
+            r#"{"type":"error","error":{"type":"authentication_error","message":"bad key"}}"#,
+        );
+        assert_eq!(info.kind, LlmErrorKind::Terminal);
+        assert_eq!(info.reason, LlmErrorReason::AuthFailure);
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/providers/ollama.rs
+++ b/crates/harn-vm/src/llm/providers/ollama.rs
@@ -29,6 +29,14 @@ impl LlmProviderChat for OllamaProvider {
 }
 
 impl OllamaProvider {
+    pub(crate) fn classify_http_error(
+        status: reqwest::StatusCode,
+        retry_after: Option<&str>,
+        body: &str,
+    ) -> crate::llm::api::LlmErrorInfo {
+        crate::llm::api::classify_provider_http_error("ollama", status, retry_after, body)
+    }
+
     /// Build the Ollama-specific request body. Ollama uses OpenAI-style messages
     /// but with additional options and NDJSON streaming.
     pub(crate) fn build_request_body(opts: &LlmRequestPayload) -> serde_json::Value {
@@ -172,10 +180,14 @@ impl OllamaProvider {
         })?;
         if !response.status().is_success() {
             let status = response.status();
+            let retry_after = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
             let body = response.text().await.unwrap_or_default();
-            return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
-                "ollama raw generate API error HTTP {status}: {body}"
-            )))));
+            let msg = Self::classify_http_error(status, retry_after.as_deref(), &body).message;
+            return Err(VmError::Thrown(VmValue::String(Rc::from(msg))));
         }
         if request.stream {
             let tx = delta_tx.unwrap_or_else(|| {
@@ -460,6 +472,7 @@ fn blocks_from_text_and_thinking(text: &str, thinking: &str) -> Vec<serde_json::
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::llm::api::{LlmErrorKind, LlmErrorReason};
 
     struct ScopedEnvVar {
         key: &'static str,
@@ -597,6 +610,28 @@ mod tests {
         })]);
 
         assert!(!OllamaProvider::should_route_via_raw_generate(&payload));
+    }
+
+    #[test]
+    fn classifies_ollama_missing_model_as_terminal_model_unavailable() {
+        let info = OllamaProvider::classify_http_error(
+            reqwest::StatusCode::NOT_FOUND,
+            None,
+            r#"{"error":"model not found"}"#,
+        );
+        assert_eq!(info.kind, LlmErrorKind::Terminal);
+        assert_eq!(info.reason, LlmErrorReason::ModelUnavailable);
+    }
+
+    #[test]
+    fn classifies_ollama_timeout_as_transient_timeout() {
+        let info = OllamaProvider::classify_http_error(
+            reqwest::StatusCode::GATEWAY_TIMEOUT,
+            None,
+            r#"{"error":"upstream timeout"}"#,
+        );
+        assert_eq!(info.kind, LlmErrorKind::Transient);
+        assert_eq!(info.reason, LlmErrorReason::Timeout);
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -80,6 +80,15 @@ impl OpenAiCompatibleProvider {
             provider_name: name,
         }
     }
+
+    pub(crate) fn classify_http_error(
+        provider: &str,
+        status: reqwest::StatusCode,
+        retry_after: Option<&str>,
+        body: &str,
+    ) -> crate::llm::api::LlmErrorInfo {
+        crate::llm::api::classify_provider_http_error(provider, status, retry_after, body)
+    }
 }
 
 impl LlmProvider for OpenAiCompatibleProvider {
@@ -243,8 +252,7 @@ fn openrouter_reasoning_config(thinking: Option<&ThinkingConfig>) -> Option<serd
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::llm::api::LlmRequestPayload;
-    use crate::llm::api::ThinkingConfig;
+    use crate::llm::api::{LlmErrorKind, LlmErrorReason, LlmRequestPayload, ThinkingConfig};
     use serde_json::json;
 
     #[test]
@@ -303,6 +311,31 @@ mod tests {
     fn native_tool_search_variants_empty_for_old_model() {
         let provider = OpenAiCompatibleProvider::new("openai".to_string());
         assert!(provider.native_tool_search_variants("gpt-4o").is_empty());
+    }
+
+    #[test]
+    fn classifies_openai_context_length_as_terminal_context_overflow() {
+        let info = OpenAiCompatibleProvider::classify_http_error(
+            "openai",
+            reqwest::StatusCode::BAD_REQUEST,
+            None,
+            r#"{"error":{"code":"context_length_exceeded","message":"maximum context length"}}"#,
+        );
+        assert_eq!(info.kind, LlmErrorKind::Terminal);
+        assert_eq!(info.reason, LlmErrorReason::ContextOverflow);
+    }
+
+    #[test]
+    fn classifies_openai_rate_limit_as_transient_rate_limit() {
+        let info = OpenAiCompatibleProvider::classify_http_error(
+            "openai",
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            Some("5"),
+            r#"{"error":{"type":"rate_limit_error","message":"slow down"}}"#,
+        );
+        assert_eq!(info.kind, LlmErrorKind::Transient);
+        assert_eq!(info.reason, LlmErrorReason::RateLimit);
+        assert!(info.message.contains("retry-after: 5"));
     }
 
     #[test]

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1323,14 +1323,15 @@ removed — call the lifecycle verbs explicitly.
 
 `llm_call` throws on transport / schema / budget failures. The thrown
 value is a dict with the same fields `llm_call_safe` exposes under
-`r.error`, so scripts can dispatch on category without string-sniffing:
+`r.error`, so scripts can dispatch on a canonical LLM error taxonomy
+without string-sniffing:
 
 ```harn
 try {
   let r = llm_call(user_prompt, nil, opts)
 } catch (e) {
-  // e is {category, message, retry_after_ms?, provider, model}
-  if e.category == "rate_limit" {
+  // e is {kind, reason, category, message, retry_after_ms?, provider, model}
+  if e.kind == "transient" && e.reason == "rate_limit" {
     sleep(e.retry_after_ms ?? 1000)
     continue
   }
@@ -1371,12 +1372,21 @@ let r = with_rate_limit("openai", fn() {
 ```
 
 `error.category` (both on the thrown dict and on
-`r.error.category`) is one of the canonical `ErrorCategory` strings:
+`r.error.category`) remains for compatibility and is one of the
+canonical `ErrorCategory` strings:
 `"rate_limit"`, `"timeout"`, `"overloaded"`, `"server_error"`,
 `"transient_network"`, `"schema_validation"`, `"auth"`, `"not_found"`,
 `"circuit_open"`, `"tool_error"`, `"tool_rejected"`, `"cancelled"`,
 `"generic"`. `retry_after_ms` is set when the provider surfaced a
 `Retry-After` hint (or `llm_mock` was told to); otherwise omitted.
+
+LLM provider failures also include `error.kind` and `error.reason`.
+`kind` is `"transient"` or `"terminal"`. Transient reasons are
+`"rate_limit"`, `"server_error"`, `"network_error"`, and `"timeout"`;
+terminal reasons are `"auth_failure"`, `"context_overflow"`,
+`"content_policy"`, `"invalid_request"`, `"model_unavailable"`, and
+`"unknown"`. `llm_call` and `agent_loop` spend their retry budget only
+when `kind == "transient"`.
 
 Pair with `llm_mock({error: {category, message, retry_after_ms?}})` to
 write deterministic tests for either helper's error path:
@@ -1386,6 +1396,8 @@ llm_mock({error: {category: "rate_limit", message: "429", retry_after_ms: 2500}}
 try {
   llm_call("hi", nil, {provider: "mock", llm_retries: 0})
 } catch (e) {
+  assert(e.kind == "transient")
+  assert(e.reason == "rate_limit")
   assert(e.category == "rate_limit")
   assert(e.retry_after_ms == 2500)
 }


### PR DESCRIPTION
## Summary

- Adds a canonical LLM error taxonomy with `kind` (`transient` / `terminal`) and `reason` values alongside the existing `category` compatibility field.
- Maps OpenAI-compatible, Anthropic, and Ollama HTTP/provider error shapes into the taxonomy, including context overflow, content policy, auth failures, invalid requests, model unavailable, rate limit, timeout, network, and server errors.
- Makes `llm_call` / `agent_loop` retry decisions consult the structured LLM kind first, while preserving legacy category and message fallbacks.
- Updates conformance and the LLM quickref docs for the new envelope.

Closes #854.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-issue854 cargo test -p harn-vm retry_tests`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue854 cargo test -p harn-vm classifies`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue854 cargo run --quiet --bin harn -- test conformance --filter llm_mock_error`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue854 cargo clippy -p harn-vm --lib -- -D warnings`
- pre-commit hook: Rust fmt, staged Harn fmt/lint, workspace clippy, markdown lint
- pre-push hook: workspace nextest (`2918 passed`), affected Harn fmt/lint, markdown lint

## Self-review notes

- Kept `category` in every public error dict for compatibility with existing scripts and `error_category` / `is_rate_limited` helpers.
- Preserved legacy provider message tags such as `[rate_limited]` and `[http_error]` so existing string consumers keep working while new callers use `kind` / `reason`.
- Tightened retry gating so clear terminal LLM reasons, especially context overflow, do not burn retry budget even when older category/message heuristics would otherwise be ambiguous.
