### PR TITLE
Replace wall-clock deadlines in TCP test stubs with shutdown guards

### DIFF
--- a/crates/harn-vm/src/connectors/linear/tests.rs
+++ b/crates/harn-vm/src/connectors/linear/tests.rs
@@ -490,7 +490,7 @@ async fn linear_client_supports_typed_methods_and_escape_hatch() {
 #[tokio::test]
 async fn linear_connector_monitor_reenables_webhook_after_probe_streak() {
     let requests = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
-    let server = spawn_monitor_server(requests.clone(), 3);
+    let mut server = spawn_monitor_server(requests.clone(), 3);
     let base_url = server.base_url().to_string();
     let mut binding = binding();
     binding.config = json!({
@@ -510,19 +510,19 @@ async fn linear_connector_monitor_reenables_webhook_after_probe_streak() {
     });
     let (connector, _) = connector_with_binding(binding).await;
 
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
-    while requests.lock().expect("requests lock").len() < 3 {
-        assert!(
-            std::time::Instant::now() < deadline,
-            "timed out waiting for monitor probes"
-        );
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
+    // Block until the mock server has served all three expected probes and
+    // its worker thread exits, instead of polling a shared counter against
+    // a wall-clock deadline. nextest's per-test timeout will surface a
+    // genuine deadlock; we no longer pretend to bound it ourselves.
+    tokio::task::spawn_blocking(move || {
+        server.wait_until_handled();
+    })
+    .await
+    .expect("await monitor server completion");
     connector
         .shutdown(std::time::Duration::from_secs(1))
         .await
         .expect("shutdown connector");
-    drop(server);
 
     let requests = requests.lock().expect("requests lock").clone();
     assert_eq!(requests.len(), 3);

--- a/crates/harn-vm/src/connectors/test_util.rs
+++ b/crates/harn-vm/src/connectors/test_util.rs
@@ -122,6 +122,23 @@ impl MockHttpServer {
     pub(crate) fn addr(&self) -> SocketAddr {
         self.addr
     }
+
+    /// Block until the server thread finishes serving its expected request
+    /// count and exits naturally. After this returns, the bound port is
+    /// released and the captured-request collection is fully populated, so
+    /// tests can assert deterministically without polling.
+    ///
+    /// Subsequent `Drop` is a no-op for the join, but the shutdown flag is
+    /// still flipped (harmlessly) for symmetry. If the expected requests
+    /// never arrive, this blocks indefinitely — relying on nextest's
+    /// per-test timeout to surface the bug rather than letting a
+    /// wall-clock deadline mask it.
+    #[allow(dead_code)]
+    pub(crate) fn wait_until_handled(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
 }
 
 impl Drop for MockHttpServer {

--- a/crates/harn-vm/src/http.rs
+++ b/crates/harn-vm/src/http.rs
@@ -4965,6 +4965,7 @@ mod tests {
         vm_sse_server_response, vm_sse_server_send, HttpMockResponse,
     };
     use crate::connectors::test_util::{spawn_mock_http_server, write_http_response};
+    use crate::test_stub::spawn_stub;
     use crate::value::VmValue;
     use base64::Engine;
     use rcgen::generate_simple_self_signed;
@@ -4973,7 +4974,6 @@ mod tests {
     use sha2::{Digest, Sha256};
     use std::collections::BTreeMap;
     use std::io::{Read, Write};
-    use std::net::TcpListener;
     use std::rc::Rc;
     use std::sync::{Arc, Once};
     use std::time::{Duration, SystemTime};
@@ -5307,8 +5307,6 @@ mod tests {
         std::fs::write(&cert_path, cert_pem.as_bytes()).expect("write cert");
         let pin = spki_pin_base64(cert.cert.der().as_ref());
 
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind tls listener");
-        let port = listener.local_addr().expect("tls addr").port();
         let server_config = Arc::new(
             ServerConfig::builder()
                 .with_no_client_auth()
@@ -5318,8 +5316,7 @@ mod tests {
                 )
                 .expect("build tls config"),
         );
-        let thread = std::thread::spawn(move || {
-            let (tcp, _) = listener.accept().expect("accept tls client");
+        let stub = spawn_stub("tls pin allow", move |tcp| {
             let conn = ServerConnection::new(server_config).expect("server connection");
             let mut stream = StreamOwned::new(conn, tcp);
             let request = read_http_request_generic(&mut stream);
@@ -5331,6 +5328,7 @@ mod tests {
                 "secure",
             );
         });
+        let port = stub.addr().port();
 
         let options = BTreeMap::from([(
             "tls".to_string(),
@@ -5351,7 +5349,7 @@ mod tests {
                 .expect("tls request should succeed");
         let response = response.as_dict().expect("response dict");
         assert_eq!(response["body"].display(), "secure");
-        thread.join().expect("tls thread");
+        drop(stub);
         reset_http_state();
     }
 
@@ -5367,8 +5365,6 @@ mod tests {
         let cert_path = temp.path().join("cert.pem");
         std::fs::write(&cert_path, cert_pem.as_bytes()).expect("write cert");
 
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind tls listener");
-        let port = listener.local_addr().expect("tls addr").port();
         let server_config = Arc::new(
             ServerConfig::builder()
                 .with_no_client_auth()
@@ -5378,8 +5374,7 @@ mod tests {
                 )
                 .expect("build tls config"),
         );
-        let thread = std::thread::spawn(move || {
-            let (tcp, _) = listener.accept().expect("accept tls client");
+        let stub = spawn_stub("tls pin reject", move |tcp| {
             let conn = ServerConnection::new(server_config).expect("server connection");
             let mut stream = StreamOwned::new(conn, tcp);
             let _ = read_http_request_generic(&mut stream);
@@ -5390,6 +5385,7 @@ mod tests {
                 "secure",
             );
         });
+        let port = stub.addr().port();
 
         let options = BTreeMap::from([(
             "tls".to_string(),
@@ -5410,7 +5406,7 @@ mod tests {
                 .expect_err("pin mismatch should fail");
         let message = error.to_string();
         assert!(message.contains("TLS SPKI pin mismatch"), "{message}");
-        thread.join().expect("tls thread");
+        drop(stub);
         reset_http_state();
     }
 

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -40,6 +40,8 @@ pub mod stdlib_modules;
 pub mod store;
 pub(crate) mod synchronization;
 pub mod tenant;
+#[cfg(test)]
+pub(crate) mod test_stub;
 pub mod tool_annotations;
 pub mod tool_surface;
 pub mod tracing;

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -545,96 +545,10 @@ mod tests {
         assert_eq!(messages[0]["role"].as_str(), Some("user"));
     }
 
-    /// Cooperative accept loop: blocks until a client connects or the
-    /// shared `shutdown` flag is set. The shutdown flag is owned by the
-    /// returned [`LlmStub`] guard and flipped on Drop, so the stub thread
-    /// can never outlive the test (replaces the older fixed-deadline loop
-    /// that flaked under heavy CI fan-out).
-    fn accept_with_shutdown(
-        listener: &std::net::TcpListener,
-        label: &str,
-        shutdown: &std::sync::atomic::AtomicBool,
-    ) -> Option<std::net::TcpStream> {
-        listener
-            .set_nonblocking(true)
-            .expect("set listener nonblocking");
-        loop {
-            if shutdown.load(std::sync::atomic::Ordering::Acquire) {
-                return None;
-            }
-            match listener.accept() {
-                Ok((stream, _)) => {
-                    stream
-                        .set_nonblocking(false)
-                        .expect("restore blocking mode");
-                    stream
-                        .set_read_timeout(Some(std::time::Duration::from_secs(30)))
-                        .ok();
-                    stream
-                        .set_write_timeout(Some(std::time::Duration::from_secs(30)))
-                        .ok();
-                    return Some(stream);
-                }
-                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                    std::thread::sleep(std::time::Duration::from_millis(5));
-                }
-                Err(e) => panic!("{label}: accept failed: {e}"),
-            }
-        }
-    }
+    use crate::test_stub::{spawn_stub, StubServer};
 
-    /// RAII guard for an in-process LLM stub. Dropping signals the stub
-    /// thread to exit and joins it so no FDs leak past the test, even on
-    /// panic.
-    struct LlmStub {
-        addr: std::net::SocketAddr,
-        shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
-        handle: Option<std::thread::JoinHandle<()>>,
-    }
-
-    impl LlmStub {
-        fn addr(&self) -> std::net::SocketAddr {
-            self.addr
-        }
-    }
-
-    impl Drop for LlmStub {
-        fn drop(&mut self) {
-            self.shutdown
-                .store(true, std::sync::atomic::Ordering::Release);
-            if let Some(handle) = self.handle.take() {
-                let _ = handle.join();
-            }
-        }
-    }
-
-    /// Bind a localhost listener and run `body` on a background thread once
-    /// a client connects. Wraps the listener in an [`LlmStub`] guard whose
-    /// lifetime bounds the stub thread.
-    fn spawn_llm_stub<F>(label: &'static str, body: F) -> LlmStub
-    where
-        F: FnOnce(&mut std::net::TcpStream) + Send + 'static,
-    {
-        use std::net::TcpListener;
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind llm stub");
-        let addr = listener.local_addr().expect("stub addr");
-        let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let shutdown_thread = shutdown.clone();
-        let handle = std::thread::spawn(move || {
-            let Some(mut stream) = accept_with_shutdown(&listener, label, &shutdown_thread) else {
-                return;
-            };
-            body(&mut stream);
-        });
-        LlmStub {
-            addr,
-            shutdown,
-            handle: Some(handle),
-        }
-    }
-
-    fn spawn_ollama_stub() -> LlmStub {
-        spawn_llm_stub("ollama stub", |stream| {
+    fn spawn_ollama_stub() -> StubServer {
+        spawn_stub("ollama stub", |mut stream| {
             use std::io::{Read, Write};
             let mut buf = vec![0u8; 8192];
             let n = stream.read(&mut buf).expect("read request");
@@ -659,8 +573,8 @@ mod tests {
 
     fn spawn_ollama_stub_with_body_capture(
         captured: std::sync::Arc<std::sync::Mutex<Option<String>>>,
-    ) -> LlmStub {
-        spawn_llm_stub("ollama stub (capture)", move |stream| {
+    ) -> StubServer {
+        spawn_stub("ollama stub (capture)", move |mut stream| {
             use std::io::{Read, Write};
             let mut buf = vec![0u8; 16384];
             let n = stream.read(&mut buf).expect("read request");
@@ -689,8 +603,8 @@ mod tests {
 
     fn spawn_ollama_raw_generate_stub(
         captured: std::sync::Arc<std::sync::Mutex<Option<String>>>,
-    ) -> LlmStub {
-        spawn_llm_stub("ollama raw stub", move |stream| {
+    ) -> StubServer {
+        spawn_stub("ollama raw stub", move |mut stream| {
             use std::io::{Read, Write};
             let mut buf = vec![0u8; 16384];
             let n = stream.read(&mut buf).expect("read request");
@@ -943,15 +857,15 @@ mod tests {
     }
 
     /// Bind a stub listener that serves one canned HTTP error response.
-    /// The returned [`LlmStub`] guard owns the listener and the worker
+    /// The returned [`StubServer`] guard owns the listener and the worker
     /// thread, so dropping it (test exit, panic) signals shutdown and
     /// joins — a stuck or misrouted client can never wedge the suite.
     fn spawn_openai_error_stub(
         status_line: &'static str,
         extra_headers: &'static str,
         body: &'static str,
-    ) -> LlmStub {
-        spawn_llm_stub("openai error stub", move |stream| {
+    ) -> StubServer {
+        spawn_stub("openai error stub", move |mut stream| {
             use std::io::{Read, Write};
             let mut buf = vec![0u8; 16384];
             let _ = stream.read(&mut buf);

--- a/crates/harn-vm/src/llm/api/ollama.rs
+++ b/crates/harn-vm/src/llm/api/ollama.rs
@@ -609,8 +609,9 @@ async fn ollama_warmup(
 mod tests {
     use super::*;
     use crate::llm::env_lock;
-    use std::io::{Read, Write};
-    use std::net::TcpListener;
+    use crate::test_stub::{
+        read_http_request_bytes, spawn_stub_n, write_http_response, StubServer,
+    };
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -766,7 +767,7 @@ mod tests {
                 warmup_timeout: Duration::from_secs(2),
             }));
 
-        server.join().expect("stub server");
+        drop(server);
         assert!(result.valid, "result was: {result:?}");
         assert_eq!(result.status, "ok");
         assert_eq!(result.matched_model.as_deref(), Some("qwen3:latest"));
@@ -802,7 +803,7 @@ mod tests {
                 warmup_timeout: Duration::from_secs(2),
             }));
 
-        server.join().expect("stub server");
+        drop(server);
         assert!(!result.valid);
         assert_eq!(result.status, "model_missing");
         assert_eq!(result.available_models, vec!["llama3.2:latest"]);
@@ -812,56 +813,16 @@ mod tests {
     fn spawn_stub(
         responses: Vec<(u16, &'static str)>,
         captured: Arc<Mutex<Vec<String>>>,
-    ) -> (std::net::SocketAddr, std::thread::JoinHandle<()>) {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ollama stub");
-        let addr = listener.local_addr().expect("stub addr");
-        let handle = std::thread::spawn(move || {
-            for (status, body) in responses {
-                let (mut stream, _) = listener.accept().expect("accept request");
-                stream
-                    .set_read_timeout(Some(Duration::from_secs(2)))
-                    .expect("read timeout");
-                let request = read_http_request(&mut stream);
-                captured.lock().expect("captured").push(request);
-                let reason = if status == 200 { "OK" } else { "ERROR" };
-                let response = format!(
-                    "HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
-                    body.len()
-                );
-                stream
-                    .write_all(response.as_bytes())
-                    .expect("write response");
-            }
+    ) -> (std::net::SocketAddr, StubServer) {
+        let expected = responses.len();
+        let server = spawn_stub_n(expected, "ollama stub", move |index, mut stream| {
+            let bytes = read_http_request_bytes(&mut stream);
+            let request = String::from_utf8(bytes).expect("utf8 request");
+            captured.lock().expect("captured").push(request);
+            let (status, body) = responses[index];
+            write_http_response(&mut stream, status, &[], body);
         });
-        (addr, handle)
-    }
-
-    fn read_http_request(stream: &mut std::net::TcpStream) -> String {
-        let mut data = Vec::new();
-        let mut buf = [0_u8; 512];
-        loop {
-            let n = stream.read(&mut buf).expect("read request");
-            if n == 0 {
-                break;
-            }
-            data.extend_from_slice(&buf[..n]);
-            let text = String::from_utf8_lossy(&data);
-            if let Some(header_end) = text.find("\r\n\r\n") {
-                let headers = &text[..header_end];
-                let content_length = headers
-                    .lines()
-                    .find_map(|line| {
-                        let (name, value) = line.split_once(':')?;
-                        name.eq_ignore_ascii_case("content-length")
-                            .then(|| value.trim().parse::<usize>().ok())
-                            .flatten()
-                    })
-                    .unwrap_or(0);
-                if data.len() >= header_end + 4 + content_length {
-                    break;
-                }
-            }
-        }
-        String::from_utf8(data).expect("utf8 request")
+        let addr = server.addr();
+        (addr, server)
     }
 }

--- a/crates/harn-vm/src/llm/healthcheck.rs
+++ b/crates/harn-vm/src/llm/healthcheck.rs
@@ -263,11 +263,10 @@ fn body_snippet(body: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Read, Write};
-    use std::net::TcpListener;
     use std::sync::{Arc, Mutex};
 
     use super::*;
+    use crate::test_stub::{read_http_request_bytes, spawn_stub, write_http_response, StubServer};
 
     fn provider_with_healthcheck(base_url: String, healthcheck: HealthcheckDef) -> ProviderDef {
         ProviderDef {
@@ -291,85 +290,15 @@ mod tests {
         status: u16,
         body: &'static str,
         captured: Arc<Mutex<Option<String>>>,
-    ) -> (String, std::thread::JoinHandle<()>) {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind healthcheck stub");
-        let addr = listener.local_addr().expect("stub addr");
-        listener
-            .set_nonblocking(true)
-            .expect("set listener nonblocking");
-
-        // Use a generous deadline so the stub doesn't trip when nextest fans
-        // out across the workspace and starves this thread of CPU. The
-        // healthcheck client itself completes in milliseconds against the
-        // loopback stub once it gets scheduled — the deadline is just an
-        // upper bound to keep a stuck test from hanging forever.
-        let handle = std::thread::spawn(move || {
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-            let (mut stream, _) = loop {
-                match listener.accept() {
-                    Ok(pair) => break pair,
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        if std::time::Instant::now() >= deadline {
-                            panic!("healthcheck stub: no client within 30s");
-                        }
-                        std::thread::sleep(std::time::Duration::from_millis(10));
-                    }
-                    Err(error) => panic!("healthcheck stub accept failed: {error}"),
-                }
-            };
-            stream
-                .set_nonblocking(false)
-                .expect("set accepted stream blocking");
-            stream
-                .set_read_timeout(Some(std::time::Duration::from_secs(30)))
-                .ok();
-            stream
-                .set_write_timeout(Some(std::time::Duration::from_secs(30)))
-                .ok();
-
-            let mut bytes = Vec::new();
-            let mut buf = [0u8; 4096];
-            loop {
-                let n = stream.read(&mut buf).expect("read request");
-                if n == 0 {
-                    break;
-                }
-                bytes.extend_from_slice(&buf[..n]);
-                let request = String::from_utf8_lossy(&bytes);
-                if request_complete(&request) {
-                    break;
-                }
-            }
+    ) -> (String, StubServer) {
+        let server = spawn_stub("healthcheck stub", move |mut stream| {
+            let bytes = read_http_request_bytes(&mut stream);
             *captured.lock().expect("capture request") =
                 Some(String::from_utf8_lossy(&bytes).to_string());
-
-            let response = format!(
-                "HTTP/1.1 {status} OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
-                body.len()
-            );
-            stream
-                .write_all(response.as_bytes())
-                .expect("write response");
+            write_http_response(&mut stream, status, &[], body);
         });
-
-        (format!("http://{addr}"), handle)
-    }
-
-    fn request_complete(request: &str) -> bool {
-        let Some((headers, body)) = request.split_once("\r\n\r\n") else {
-            return false;
-        };
-        let content_length = headers
-            .lines()
-            .find_map(|line| line.strip_prefix("content-length: "))
-            .or_else(|| {
-                headers
-                    .lines()
-                    .find_map(|line| line.strip_prefix("Content-Length: "))
-            })
-            .and_then(|value| value.trim().parse::<usize>().ok())
-            .unwrap_or(0);
-        body.len() >= content_length
+        let base_url = format!("http://{}", server.addr());
+        (base_url, server)
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -399,7 +328,7 @@ mod tests {
             },
         )
         .await;
-        server.join().expect("stub server");
+        drop(server);
         llm_config::clear_user_overrides();
 
         assert!(result.valid);
@@ -478,7 +407,7 @@ mod tests {
             },
         )
         .await;
-        server.join().expect("stub server");
+        drop(server);
         llm_config::clear_user_overrides();
 
         assert!(!result.valid);

--- a/crates/harn-vm/src/llm/readiness.rs
+++ b/crates/harn-vm/src/llm/readiness.rs
@@ -322,9 +322,10 @@ fn models_url(def: &ProviderDef, base_url: &str) -> Result<String, String> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Read;
+
     use super::*;
-    use std::io::{Read, Write};
-    use std::net::TcpListener;
+    use crate::test_stub::{spawn_stub, write_http_response, StubServer};
 
     #[test]
     fn parse_model_ids_reads_openai_compatible_data() {
@@ -344,12 +345,12 @@ mod tests {
 
     #[tokio::test]
     async fn probe_provider_readiness_verifies_served_model() {
-        let (base_url, handle) = spawn_models_stub(
+        let (base_url, server) = spawn_models_stub(
             200,
             r#"{"data":[{"id":"unsloth/Qwen3.6-27B-UD-MLX-4bit"}]}"#,
         );
         let result = probe_provider_readiness("mlx", Some("mlx-qwen36-27b"), Some(&base_url)).await;
-        handle.join().expect("stub joins");
+        drop(server);
         assert!(result.ok);
         assert_eq!(result.status, ReadinessStatus::Ok);
         assert_eq!(
@@ -360,48 +361,23 @@ mod tests {
 
     #[tokio::test]
     async fn probe_provider_readiness_reports_missing_model() {
-        let (base_url, handle) = spawn_models_stub(200, r#"{"data":[{"id":"other-model"}]}"#);
+        let (base_url, server) = spawn_models_stub(200, r#"{"data":[{"id":"other-model"}]}"#);
         let result = probe_provider_readiness("mlx", Some("mlx-qwen36-27b"), Some(&base_url)).await;
-        handle.join().expect("stub joins");
+        drop(server);
         assert!(!result.ok);
         assert_eq!(result.status, ReadinessStatus::ModelMissing);
         assert!(result.message.contains("Currently served: other-model"));
     }
 
-    fn spawn_models_stub(status: u16, body: &'static str) -> (String, std::thread::JoinHandle<()>) {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind models stub");
-        let addr = listener.local_addr().expect("stub addr");
-        let handle = std::thread::spawn(move || {
-            listener
-                .set_nonblocking(true)
-                .expect("set listener nonblocking");
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
-            let mut stream = loop {
-                match listener.accept() {
-                    Ok((stream, _)) => break stream,
-                    Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        if std::time::Instant::now() >= deadline {
-                            panic!("models stub: no client within 3s");
-                        }
-                        std::thread::sleep(std::time::Duration::from_millis(20));
-                    }
-                    Err(error) => panic!("models stub: accept failed: {error}"),
-                }
-            };
-            stream.set_nonblocking(false).expect("set stream blocking");
+    fn spawn_models_stub(status: u16, body: &'static str) -> (String, StubServer) {
+        let server = spawn_stub("models stub", move |mut stream| {
             let mut buf = vec![0u8; 4096];
             let n = stream.read(&mut buf).expect("read request");
             let request = String::from_utf8_lossy(&buf[..n]);
             assert!(request.starts_with("GET /v1/models HTTP/1.1\r\n"));
-            let response = format!(
-                "HTTP/1.1 {status} OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
-                body.len(),
-                body
-            );
-            stream
-                .write_all(response.as_bytes())
-                .expect("write response");
+            write_http_response(&mut stream, status, &[], body);
         });
-        (format!("http://{addr}"), handle)
+        let base_url = format!("http://{}", server.addr());
+        (base_url, server)
     }
 }

--- a/crates/harn-vm/src/test_stub.rs
+++ b/crates/harn-vm/src/test_stub.rs
@@ -1,0 +1,198 @@
+//! Shared building blocks for in-process TCP stubs used by VM tests.
+//!
+//! The pattern here replaces wall-clock-deadline accept loops (which flake
+//! under heavy nextest fan-out on CI) with a cooperative shutdown flag owned
+//! by an RAII guard. The guard joins the stub thread on Drop, so the stub's
+//! lifetime is bounded by the test's local scope rather than by a deadline,
+//! and threads can never leak past the leak-timeout window even on panic.
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+/// Cooperative blocking accept: returns the next client connection, or
+/// `None` once `shutdown` flips. Sets the listener nonblocking and polls
+/// every 5ms. The returned stream is restored to blocking mode and given
+/// 30-second read/write timeouts so a misbehaving handler can't wedge the
+/// stub thread forever.
+pub(crate) fn accept_until(
+    listener: &TcpListener,
+    label: &str,
+    shutdown: &AtomicBool,
+) -> Option<TcpStream> {
+    listener
+        .set_nonblocking(true)
+        .expect("set listener nonblocking");
+    loop {
+        if shutdown.load(Ordering::Acquire) {
+            return None;
+        }
+        match listener.accept() {
+            Ok((stream, _)) => {
+                stream
+                    .set_nonblocking(false)
+                    .expect("restore blocking mode");
+                stream.set_read_timeout(Some(Duration::from_secs(30))).ok();
+                stream.set_write_timeout(Some(Duration::from_secs(30))).ok();
+                return Some(stream);
+            }
+            Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Err(error) => panic!("{label}: accept failed: {error}"),
+        }
+    }
+}
+
+/// RAII guard for an in-process stub. Dropping flips the shutdown flag and
+/// joins the worker thread.
+pub(crate) struct StubServer {
+    addr: SocketAddr,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl StubServer {
+    pub(crate) fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn base_url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+}
+
+impl Drop for StubServer {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Bind a localhost listener and run `body` on a worker thread once a
+/// client connects. The closure receives the accepted [`TcpStream`] by
+/// value so it can wrap it in TLS or otherwise consume it. The returned
+/// [`StubServer`] guard binds the worker's lifetime to the test scope.
+pub(crate) fn spawn_stub<F>(label: &'static str, body: F) -> StubServer
+where
+    F: FnOnce(TcpStream) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind stub listener");
+    let addr = listener.local_addr().expect("stub addr");
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_thread = shutdown.clone();
+    let handle = std::thread::spawn(move || {
+        let Some(stream) = accept_until(&listener, label, &shutdown_thread) else {
+            return;
+        };
+        body(stream);
+    });
+    StubServer {
+        addr,
+        shutdown,
+        handle: Some(handle),
+    }
+}
+
+/// Like [`spawn_stub`] but for stubs that must accept multiple connections
+/// in sequence. The handler is invoked per accepted stream with the request
+/// index. The worker exits naturally after `expected` accepts or when the
+/// guard is dropped, whichever comes first.
+pub(crate) fn spawn_stub_n<F>(expected: usize, label: &'static str, mut body: F) -> StubServer
+where
+    F: FnMut(usize, TcpStream) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind stub listener");
+    let addr = listener.local_addr().expect("stub addr");
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_thread = shutdown.clone();
+    let handle = std::thread::spawn(move || {
+        for index in 0..expected {
+            let Some(stream) = accept_until(&listener, label, &shutdown_thread) else {
+                return;
+            };
+            body(index, stream);
+        }
+    });
+    StubServer {
+        addr,
+        shutdown,
+        handle: Some(handle),
+    }
+}
+
+/// Read an HTTP/1.1 request from `stream`, returning the raw byte buffer
+/// (headers + body). Reads until a `\r\n\r\n` separator is found, then
+/// continues reading until the body matches `Content-Length` (if present).
+/// Useful for stubs that want to inspect or capture the full request bytes
+/// without parsing structure.
+pub(crate) fn read_http_request_bytes(stream: &mut TcpStream) -> Vec<u8> {
+    let mut data = Vec::new();
+    let mut buf = [0u8; 4096];
+    let header_end = loop {
+        let n = stream.read(&mut buf).expect("read request");
+        assert!(n > 0, "request ended before headers");
+        data.extend_from_slice(&buf[..n]);
+        if let Some(idx) = data.windows(4).position(|window| window == b"\r\n\r\n") {
+            break idx + 4;
+        }
+    };
+    let header_text = String::from_utf8_lossy(&data[..header_end]);
+    let content_length = header_text
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())
+                .flatten()
+        })
+        .unwrap_or(0);
+    while data.len() < header_end + content_length {
+        let n = stream.read(&mut buf).expect("read request body");
+        assert!(n > 0, "request ended before body");
+        data.extend_from_slice(&buf[..n]);
+    }
+    data
+}
+
+/// Write a complete HTTP/1.1 response. `extra_headers` are inserted between
+/// `content-length` and the blank line. Status text is filled in for common
+/// codes; unknown codes default to "OK" (callers should pass strings via
+/// the response body or rely on test clients that only inspect status).
+pub(crate) fn write_http_response(
+    stream: &mut TcpStream,
+    status: u16,
+    extra_headers: &[(&str, &str)],
+    body: &str,
+) {
+    let status_text = match status {
+        200 => "OK",
+        201 => "Created",
+        401 => "Unauthorized",
+        429 => "Too Many Requests",
+        _ => "OK",
+    };
+    let mut response = format!(
+        "HTTP/1.1 {} {}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n",
+        status,
+        status_text,
+        body.len()
+    );
+    for (name, value) in extra_headers {
+        response.push_str(name);
+        response.push_str(": ");
+        response.push_str(value);
+        response.push_str("\r\n");
+    }
+    response.push_str("\r\n");
+    response.push_str(body);
+    stream
+        .write_all(response.as_bytes())
+        .expect("write response");
+}


### PR DESCRIPTION
## Summary

This follow-up audit replaces the remaining clear wall-clock-deadline TCP test stubs with cooperative shutdown guards and RAII cleanup.

- Adds a vm-level `crate::test_stub` helper with `accept_until`, `StubServer`, one-shot and N-shot stub spawners, and shared HTTP request/response helpers.
- Migrates LLM API, healthcheck, readiness, Ollama, and HTTP TLS pin tests away from manual deadline or blocking accept loops.
- Adds `MockHttpServer::wait_until_handled` and uses it in the Linear webhook monitor test to wait deterministically for the expected probe requests.

## Scope Notes

Deliberately left orchestrator integration polling loops out of scope: those tests observe real subprocess/runtime state and still need wall-clock bounds unless the orchestrator grows dedicated runtime hooks. The dispatcher A2A mock is also left alone because it already has cooperative `Arc<AtomicBool>` shutdown behavior; the remaining differences are cosmetic and tangled with TLS-specific handling.

## Validation

- `cargo nextest run -p harn-dap --bin harn-dap` repeated 5x: passed; the previously failing `test_evaluate_dot_access` stayed well below the 1s leak threshold.
- `make test` repeated 2x after the failed push: passed all 2908 tests both times.
- `git push -u origin ksinder/test-stub-shutdown-cleanup`: pre-push hook passed all 2908 tests; no hook bypass.