### PR TITLE
[codex] Add agent loop profiles

### DIFF
--- a/conformance/tests/integration/agent_loop_llm_retries_default.expected
+++ b/conformance/tests/integration/agent_loop_llm_retries_default.expected
@@ -1,3 +1,3 @@
 done
 Recovered after default retries. ##DONE##
-5
+3

--- a/conformance/tests/integration/agent_loop_llm_retries_default.harn
+++ b/conformance/tests/integration/agent_loop_llm_retries_default.harn
@@ -1,11 +1,10 @@
 pipeline default() {
   llm_mock_clear()
-  // The default agent_loop retry budget is four retries after the
-  // first attempt. This succeeds only if the fifth mock response is reached.
+  // The default tool_using profile gives agent_loop two transient retries
+  // after the first attempt. This succeeds only if the third mock response
+  // is reached.
   llm_mock({error: {category: "rate_limit", message: "429 transient 1"}})
   llm_mock({error: {category: "rate_limit", message: "429 transient 2"}})
-  llm_mock({error: {category: "rate_limit", message: "429 transient 3"}})
-  llm_mock({error: {category: "rate_limit", message: "429 transient 4"}})
   llm_mock({text: "Recovered after default retries. ##DONE##"})
   let result = agent_loop("finish", nil, {provider: "mock", llm_backoff_ms: 0})
   println(result.status)

--- a/conformance/tests/integration/agent_loop_profile_invalid.error
+++ b/conformance/tests/integration/agent_loop_profile_invalid.error
@@ -1,0 +1,1 @@
+profile must be one of tool_using, researcher, verifier, completer

--- a/conformance/tests/integration/agent_loop_profile_invalid.harn
+++ b/conformance/tests/integration/agent_loop_profile_invalid.harn
@@ -1,0 +1,3 @@
+pipeline default() {
+  agent_loop("finish", nil, {provider: "mock", profile: "planner"})
+}

--- a/conformance/tests/integration/agent_loop_profiles.expected
+++ b/conformance/tests/integration/agent_loop_profiles.expected
@@ -1,0 +1,6 @@
+{"verdict": "pass"}
+2
+stuck
+1
+done
+2

--- a/conformance/tests/integration/agent_loop_profiles.harn
+++ b/conformance/tests/integration/agent_loop_profiles.harn
@@ -1,0 +1,36 @@
+pipeline default() {
+  let schema = {type: "object", required: ["verdict"], properties: {verdict: {type: "string"}}}
+  llm_mock_clear()
+  llm_mock({text: "{\"note\": \"missing verdict\"}"})
+  llm_mock({text: "{\"verdict\": \"pass\"}"})
+  let structured = agent_loop(
+    "grade this",
+    nil,
+    {provider: "mock", profile: "verifier", output_schema: schema, output_validation: "error"},
+  )
+  println(structured.visible_text)
+  println(len(llm_mock_calls()))
+  assert(len(llm_mock_calls()) == 2, "verifier profile should retry schema-invalid output")
+  llm_mock_clear()
+  llm_mock({text: "Needs another pass."})
+  let verifier = agent_loop("verify this", nil, {provider: "mock", profile: "verifier", persistent: true})
+  println(verifier.status)
+  println(verifier.llm.iterations)
+  assert(verifier.status == "stuck", "verifier max_nudges default should stop immediately")
+  assert(verifier.llm.iterations == 1, "verifier profile should run one text-only turn before stuck")
+  llm_mock_clear()
+  llm_mock({text: "Still working."})
+  llm_mock({text: "Finished. ##DONE##"})
+  let overridden = agent_loop(
+    "finish in two",
+    nil,
+    {provider: "mock", profile: "completer", persistent: true, max_iterations: 2, max_nudges: 2},
+  )
+  println(overridden.status)
+  println(overridden.llm.iterations)
+  assert(overridden.status == "done", "explicit max_iterations/max_nudges should override profile")
+  assert(
+    overridden.llm.iterations == 2,
+    "explicit max_iterations override should allow a second turn",
+  )
+}

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -41,7 +41,7 @@ use crate::orchestration::TurnPolicy;
 use super::super::agent_observe::{
     dump_llm_interpreted_response, observed_llm_call, LlmRetryConfig, StreamingDetectorContext,
 };
-use super::super::helpers::transcript_event;
+use super::super::helpers::{expects_structured_output, transcript_event};
 use super::super::tools::{collect_tool_schemas, parse_text_tool_calls_with_tools};
 use super::helpers::{
     append_message_to_contexts, loop_state_requests_phase_change, prose_exceeds_budget,
@@ -62,6 +62,8 @@ pub(super) struct LlmCallContext<'a> {
     pub turn_policy: Option<&'a TurnPolicy>,
     pub llm_retries: usize,
     pub llm_backoff_ms: u64,
+    pub schema_retries: usize,
+    pub schema_retry_nudge: &'a super::super::SchemaNudge,
     pub tools_val: Option<&'a crate::value::VmValue>,
 }
 
@@ -90,7 +92,7 @@ pub(super) async fn run_llm_call(
     // detector for them would surface false-positive candidates from
     // any tool-shaped narration the model emits before its native
     // tool block.
-    let streaming_detector = if ctx.has_tools && ctx.tool_format != "native" {
+    let mut streaming_detector = if ctx.has_tools && ctx.tool_format != "native" {
         let mut known: std::collections::BTreeSet<String> =
             collect_tool_schemas(ctx.tools_val, None)
                 .into_iter()
@@ -112,20 +114,60 @@ pub(super) async fn run_llm_call(
     // transport has no session to attribute streaming partial-arg events
     // to and falls back to the dispatch-time lifecycle only.
     opts.session_id = Some(state.session_id.clone());
-    let result = observed_llm_call(
-        opts,
-        Some(ctx.tool_format),
-        ctx.bridge.as_ref(),
-        &LlmRetryConfig {
-            retries: ctx.llm_retries,
-            backoff_ms: ctx.llm_backoff_ms,
-        },
-        Some(iteration),
-        true,
-        false, // agent_loop runs on the local set, not offthread
-        streaming_detector,
-    )
-    .await?;
+    let retry_config = LlmRetryConfig {
+        retries: ctx.llm_retries,
+        backoff_ms: ctx.llm_backoff_ms,
+    };
+    let mut schema_attempt = 0usize;
+    let result = loop {
+        let detector = if schema_attempt == 0 {
+            streaming_detector.take()
+        } else {
+            None
+        };
+        let result = observed_llm_call(
+            opts,
+            Some(ctx.tool_format),
+            ctx.bridge.as_ref(),
+            &retry_config,
+            Some(iteration),
+            true,
+            false, // agent_loop runs on the local set, not offthread
+            detector,
+        )
+        .await?;
+
+        if schema_attempt >= ctx.schema_retries || !expects_structured_output(opts) {
+            break result;
+        }
+
+        let vm_result = super::super::agent_config::build_llm_call_result(&result, opts);
+        let errors = super::super::structured_output_errors(&vm_result, opts);
+        if errors.is_empty() {
+            break result;
+        }
+
+        schema_attempt += 1;
+        let nudge = super::super::build_schema_nudge(
+            &errors,
+            opts.output_schema.as_ref(),
+            ctx.schema_retry_nudge,
+        );
+        super::super::trace::emit_agent_event(super::super::trace::AgentTraceEvent::SchemaRetry {
+            attempt: schema_attempt,
+            errors: errors.clone(),
+            nudge_used: !nudge.is_empty(),
+            correction_prompt: nudge.clone(),
+        });
+        if !nudge.is_empty() {
+            append_message_to_contexts(
+                &mut state.visible_messages,
+                &mut state.recorded_messages,
+                runtime_feedback_message("schema_retry", nudge),
+            );
+        }
+        opts.messages = state.visible_messages.clone();
+    };
 
     // Consume the prefill after the call. The provider appended it to
     // the outgoing request as a final `role: "assistant"` message; the

--- a/crates/harn-vm/src/llm/agent/mod.rs
+++ b/crates/harn-vm/src/llm/agent/mod.rs
@@ -373,6 +373,8 @@ pub async fn run_agent_loop_internal(
     // them without fighting the `&mut state` borrow in the loop body.
     let llm_retries = state.config.llm_retries;
     let llm_backoff_ms = state.config.llm_backoff_ms;
+    let schema_retries = state.config.schema_retries;
+    let schema_retry_nudge = state.config.schema_retry_nudge.clone();
     let token_budget = state.config.token_budget;
     let turn_policy = state.config.turn_policy.clone();
     let stop_after_successful_tools = state.config.stop_after_successful_tools.clone();
@@ -493,6 +495,8 @@ pub async fn run_agent_loop_internal(
                 turn_policy: turn_policy.as_ref(),
                 llm_retries,
                 llm_backoff_ms,
+                schema_retries,
+                schema_retry_nudge: &schema_retry_nudge,
                 tools_val: effective_tools_val,
             },
             iteration,

--- a/crates/harn-vm/src/llm/agent/tests/mod.rs
+++ b/crates/harn-vm/src/llm/agent/tests/mod.rs
@@ -91,6 +91,8 @@ pub(super) fn base_agent_config() -> AgentLoopConfig {
         break_unless_phase: None,
         tool_retries: 0,
         tool_backoff_ms: 1,
+        schema_retries: 0,
+        schema_retry_nudge: crate::llm::parse_schema_nudge(&None),
         tool_format: "text".to_string(),
         native_tool_fallback: crate::orchestration::NativeToolFallbackPolicy::Allow,
         auto_compact: None,

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -16,7 +16,64 @@ use super::helpers::{
 };
 use super::tools::build_assistant_response_message;
 
-pub(crate) const DEFAULT_AGENT_LOOP_LLM_RETRIES: usize = 4;
+pub(crate) const DEFAULT_AGENT_LOOP_LLM_RETRIES: usize = 2;
+
+#[derive(Clone, Copy)]
+pub(crate) struct AgentLoopProfileDefaults {
+    pub max_iterations: i64,
+    pub max_nudges: i64,
+    pub tool_retries: i64,
+    pub llm_retries: i64,
+    pub schema_retries: i64,
+}
+
+impl AgentLoopProfileDefaults {
+    fn for_name(name: &str) -> Option<Self> {
+        match name {
+            "tool_using" => Some(Self {
+                max_iterations: 50,
+                max_nudges: 8,
+                tool_retries: 0,
+                llm_retries: DEFAULT_AGENT_LOOP_LLM_RETRIES as i64,
+                schema_retries: 0,
+            }),
+            "researcher" => Some(Self {
+                max_iterations: 30,
+                max_nudges: 4,
+                tool_retries: 0,
+                llm_retries: 2,
+                schema_retries: 0,
+            }),
+            "verifier" => Some(Self {
+                max_iterations: 5,
+                max_nudges: 0,
+                tool_retries: 0,
+                llm_retries: 2,
+                schema_retries: 3,
+            }),
+            "completer" => Some(Self {
+                max_iterations: 1,
+                max_nudges: 0,
+                tool_retries: 0,
+                llm_retries: 2,
+                schema_retries: 0,
+            }),
+            _ => None,
+        }
+    }
+}
+
+pub(crate) fn agent_loop_profile_defaults(
+    options: &Option<std::collections::BTreeMap<String, VmValue>>,
+    label: &str,
+) -> Result<AgentLoopProfileDefaults, crate::value::VmError> {
+    let profile = opt_str(options, "profile").unwrap_or_else(|| "tool_using".to_string());
+    AgentLoopProfileDefaults::for_name(&profile).ok_or_else(|| {
+        crate::value::VmError::Runtime(format!(
+            "{label}: profile must be one of tool_using, researcher, verifier, completer; got `{profile}`"
+        ))
+    })
+}
 
 #[derive(Clone)]
 pub struct AgentLoopConfig {
@@ -28,6 +85,8 @@ pub struct AgentLoopConfig {
     pub break_unless_phase: Option<String>,
     pub tool_retries: usize,
     pub tool_backoff_ms: u64,
+    pub schema_retries: usize,
+    pub schema_retry_nudge: super::SchemaNudge,
     pub tool_format: String,
     pub native_tool_fallback: crate::orchestration::NativeToolFallbackPolicy,
     /// Auto-compaction config.
@@ -305,11 +364,20 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
         async move {
             std::mem::drop(captured_bridge);
             let options = args.get(2).and_then(|a| a.as_dict()).cloned();
-            let max_iterations = opt_int(&options, "max_iterations").unwrap_or(50) as usize;
+            let profile_defaults = agent_loop_profile_defaults(&options, "agent_loop")?;
+            let max_iterations =
+                opt_int(&options, "max_iterations").unwrap_or(profile_defaults.max_iterations)
+                    as usize;
             let persistent = opt_bool(&options, "persistent");
-            let max_nudges = opt_int(&options, "max_nudges").unwrap_or(8) as usize;
+            let max_nudges =
+                opt_int(&options, "max_nudges").unwrap_or(profile_defaults.max_nudges) as usize;
             let custom_nudge = opt_str(&options, "nudge");
-            let tool_retries = opt_int(&options, "tool_retries").unwrap_or(0) as usize;
+            let tool_retries =
+                opt_int(&options, "tool_retries").unwrap_or(profile_defaults.tool_retries)
+                    as usize;
+            let schema_retries =
+                opt_int(&options, "schema_retries").unwrap_or(profile_defaults.schema_retries)
+                    as usize;
             let tool_backoff_ms = opt_int(&options, "tool_backoff_ms").unwrap_or(1000) as u64;
             let tool_format = opt_str(&options, "tool_format").unwrap_or_else(|| {
                 let opts = extract_llm_options(&args).ok();
@@ -432,6 +500,8 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                     break_unless_phase,
                     tool_retries,
                     tool_backoff_ms,
+                    schema_retries,
+                    schema_retry_nudge: super::parse_schema_nudge(&options),
                     tool_format,
                     native_tool_fallback,
                     auto_compact,
@@ -442,8 +512,7 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                     daemon,
                     daemon_config,
                     llm_retries: opt_int(&options, "llm_retries")
-                        .unwrap_or(DEFAULT_AGENT_LOOP_LLM_RETRIES as i64)
-                        as usize,
+                        .unwrap_or(profile_defaults.llm_retries) as usize,
                     llm_backoff_ms: opt_int(&options, "llm_backoff_ms").unwrap_or(2000) as u64,
                     token_budget: opt_int(&options, "token_budget"),
                     exit_when_verified: opt_bool(&options, "exit_when_verified"),

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -251,7 +251,10 @@ fn compute_validation_errors(data: &VmValue, opts: &api::LlmCallOptions) -> Vec<
     schema_validation_errors(&validation)
 }
 
-fn structured_output_errors(result: &VmValue, opts: &api::LlmCallOptions) -> Vec<String> {
+pub(crate) fn structured_output_errors(
+    result: &VmValue,
+    opts: &api::LlmCallOptions,
+) -> Vec<String> {
     let Some(dict) = result.as_dict() else {
         return vec!["structured output result was not a dict".to_string()];
     };
@@ -281,7 +284,7 @@ fn structured_output_errors(result: &VmValue, opts: &api::LlmCallOptions) -> Vec
 /// How `llm_call` should nudge the model when `output_schema` validation
 /// fails and `schema_retries > 0`.
 #[derive(Debug, Clone)]
-enum SchemaNudge {
+pub(crate) enum SchemaNudge {
     /// Build a default corrective user message from the schema's top-level
     /// `required` / `properties` keys plus the validation errors. This is
     /// the default when `schema_retry_nudge` is unset or `true`.
@@ -294,7 +297,7 @@ enum SchemaNudge {
     Disabled,
 }
 
-fn parse_schema_nudge(
+pub(crate) fn parse_schema_nudge(
     options: &Option<std::collections::BTreeMap<String, VmValue>>,
 ) -> SchemaNudge {
     let Some(opts) = options.as_ref() else {
@@ -315,7 +318,7 @@ fn parse_schema_nudge(
 /// so small / local models can fix nested object mistakes without seeing
 /// the whole JSON Schema again (see `docs/llm/harn-quickref.md` "Schema
 /// retries").
-fn build_schema_nudge(
+pub(crate) fn build_schema_nudge(
     errors: &[String],
     schema: Option<&serde_json::Value>,
     mode: &SchemaNudge,
@@ -476,8 +479,8 @@ pub(crate) use self::agent::{
     run_agent_loop_internal,
 };
 pub(crate) use self::agent_config::{
-    agent_loop_result_from_llm, parse_command_policy_from_options, AgentLoopConfig,
-    DEFAULT_AGENT_LOOP_LLM_RETRIES,
+    agent_loop_profile_defaults, agent_loop_result_from_llm, parse_command_policy_from_options,
+    AgentLoopConfig,
 };
 pub use self::agent_config::{
     register_agent_loop_with_bridge, register_llm_call_structured_with_bridge,
@@ -1070,11 +1073,19 @@ pub fn register_llm_builtins(vm: &mut Vm) {
 
     vm.register_async_builtin("agent_loop", |args| async move {
         let options = args.get(2).and_then(|a| a.as_dict()).cloned();
-        let max_iterations = opt_int(&options, "max_iterations").unwrap_or(50) as usize;
+        let profile_defaults = agent_config::agent_loop_profile_defaults(&options, "agent_loop")?;
+        let max_iterations =
+            opt_int(&options, "max_iterations").unwrap_or(profile_defaults.max_iterations)
+                as usize;
         let persistent = opt_bool(&options, "persistent");
-        let max_nudges = opt_int(&options, "max_nudges").unwrap_or(3) as usize;
+        let max_nudges =
+            opt_int(&options, "max_nudges").unwrap_or(profile_defaults.max_nudges) as usize;
         let custom_nudge = opt_str(&options, "nudge");
-        let tool_retries = opt_int(&options, "tool_retries").unwrap_or(0) as usize;
+        let tool_retries =
+            opt_int(&options, "tool_retries").unwrap_or(profile_defaults.tool_retries) as usize;
+        let schema_retries =
+            opt_int(&options, "schema_retries").unwrap_or(profile_defaults.schema_retries)
+                as usize;
         let tool_backoff_ms = opt_int(&options, "tool_backoff_ms").unwrap_or(1000) as u64;
         let tool_format = opt_str(&options, "tool_format").unwrap_or_else(|| "text".to_string());
         let native_tool_fallback = opt_str(&options, "native_tool_fallback")
@@ -1166,6 +1177,8 @@ pub fn register_llm_builtins(vm: &mut Vm) {
                 break_unless_phase,
                 tool_retries,
                 tool_backoff_ms,
+                schema_retries,
+                schema_retry_nudge: parse_schema_nudge(&options),
                 tool_format,
                 native_tool_fallback,
                 auto_compact,
@@ -1176,7 +1189,7 @@ pub fn register_llm_builtins(vm: &mut Vm) {
                 daemon,
                 daemon_config,
                 llm_retries: opt_int(&options, "llm_retries")
-                    .unwrap_or(DEFAULT_AGENT_LOOP_LLM_RETRIES as i64) as usize,
+                    .unwrap_or(profile_defaults.llm_retries) as usize,
                 llm_backoff_ms: opt_int(&options, "llm_backoff_ms").unwrap_or(2000) as u64,
                 token_budget: opt_int(&options, "token_budget"),
                 exit_when_verified,

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1447,6 +1447,14 @@ pub async fn execute_stage_node(
                     break_unless_phase: None,
                     tool_retries: 0,
                     tool_backoff_ms: 1000,
+                    schema_retries: 0,
+                    schema_retry_nudge: crate::llm::parse_schema_nudge(
+                        &node
+                            .raw_model_policy
+                            .as_ref()
+                            .and_then(|value| value.as_dict())
+                            .cloned(),
+                    ),
                     tool_format: tool_format.clone(),
                     native_tool_fallback: node.model_policy.native_tool_fallback,
                     auto_compact,

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -609,9 +609,15 @@ fn parse_structured_sub_agent_data(
 
 fn sub_agent_loop_options(spec: &SubAgentRunSpec) -> Result<crate::llm::AgentLoopConfig, VmError> {
     let options = Some(spec.options.clone());
-    let max_iterations = crate::llm::helpers::opt_int(&options, "max_iterations").unwrap_or(50);
-    let max_nudges = crate::llm::helpers::opt_int(&options, "max_nudges").unwrap_or(3);
-    let tool_retries = crate::llm::helpers::opt_int(&options, "tool_retries").unwrap_or(0);
+    let profile_defaults = crate::llm::agent_loop_profile_defaults(&options, "sub_agent_run")?;
+    let max_iterations = crate::llm::helpers::opt_int(&options, "max_iterations")
+        .unwrap_or(profile_defaults.max_iterations);
+    let max_nudges =
+        crate::llm::helpers::opt_int(&options, "max_nudges").unwrap_or(profile_defaults.max_nudges);
+    let tool_retries = crate::llm::helpers::opt_int(&options, "tool_retries")
+        .unwrap_or(profile_defaults.tool_retries);
+    let schema_retries = crate::llm::helpers::opt_int(&options, "schema_retries")
+        .unwrap_or(profile_defaults.schema_retries) as usize;
     let tool_backoff_ms = crate::llm::helpers::opt_int(&options, "tool_backoff_ms").unwrap_or(1000);
     let tool_format = crate::llm::helpers::opt_str(&options, "tool_format");
     let done_sentinel = crate::llm::helpers::opt_str(&options, "done_sentinel");
@@ -662,6 +668,8 @@ fn sub_agent_loop_options(spec: &SubAgentRunSpec) -> Result<crate::llm::AgentLoo
         break_unless_phase,
         tool_retries: tool_retries as usize,
         tool_backoff_ms: tool_backoff_ms as u64,
+        schema_retries,
+        schema_retry_nudge: crate::llm::parse_schema_nudge(&options),
         tool_format: tool_format.unwrap_or_default(),
         native_tool_fallback,
         auto_compact: None,
@@ -672,8 +680,7 @@ fn sub_agent_loop_options(spec: &SubAgentRunSpec) -> Result<crate::llm::AgentLoo
         daemon: false,
         daemon_config: Default::default(),
         llm_retries: crate::llm::helpers::opt_int(&options, "llm_retries")
-            .unwrap_or(crate::llm::DEFAULT_AGENT_LOOP_LLM_RETRIES as i64)
-            as usize,
+            .unwrap_or(profile_defaults.llm_retries) as usize,
         llm_backoff_ms: crate::llm::helpers::opt_int(&options, "llm_backoff_ms").unwrap_or(2000)
             as u64,
         token_budget: crate::llm::helpers::opt_int(&options, "token_budget"),

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1010,11 +1010,20 @@ Returns a namespaced dict: top-level `status`, `text`, `visible_text`
 (`iterations`, `duration_ms`, `input_tokens`, `output_tokens`); tool
 invocation data nested under `tools` (`calls`, `successful`, `rejected`,
 `mode`). Respects the same `llm_retries` / `llm_backoff_ms` options
-as `llm_call`, with `agent_loop` defaulting `llm_retries` to 4, plus
-its own `tool_retries`, `max_iterations`, `max_nudges`, and
-`native_tool_fallback` (`"allow"`, `"allow_once"`, or `"reject"` for
-native-tool stages that receive text-mode `<tool_call>` fallback
-output).
+as `llm_call`, plus its own `profile`, `tool_retries`,
+`max_iterations`, `max_nudges`, and `native_tool_fallback`
+(`"allow"`, `"allow_once"`, or `"reject"` for native-tool stages that
+receive text-mode `<tool_call>` fallback output).
+
+Profiles preload common loop budgets and retry counts. Explicit keys
+override the profile:
+
+| Profile | `max_iterations` | `max_nudges` | `tool_retries` | `llm_retries` | `schema_retries` |
+|---|---:|---:|---:|---:|---:|
+| `tool_using` (default) | 50 | 8 | 0 | 2 | 0 |
+| `researcher` | 30 | 4 | 0 | 2 | 0 |
+| `verifier` | 5 | 0 | 0 | 2 | 3 |
+| `completer` | 1 | 0 | 0 | 2 | 0 |
 
 Pass `stop_after_successful_tools: ["name", ...]` to terminate the loop
 the moment any of those tools is dispatched successfully. Same shape as

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -663,11 +663,12 @@ Same as `llm_call`, plus additional options:
 
 | Key | Type | Default | Description |
 |---|---|---|---|
+| `profile` | string | `"tool_using"` | Named preset for common loop shapes. One of `"tool_using"`, `"researcher"`, `"verifier"`, or `"completer"`; explicit option keys override profile defaults |
 | `persistent` | bool | `false` | Keep looping until the completion sentinel is emitted (`##DONE##`, or `<done>##DONE##</done>` in tagged text-tool stages) |
 | `max_iterations` | int | `50` | Maximum number of LLM round-trips |
-| `max_nudges` | int | `3` | Max consecutive text-only responses before stopping |
+| `max_nudges` | int | `8` | Max consecutive text-only responses before stopping |
 | `nudge` | string | see below | Custom message to send when nudging the agent |
-| `llm_retries` | int | `4` | Retries on transient HTTP / provider errors. Set to `0` for fail-fast |
+| `llm_retries` | int | `2` | Retries on transient HTTP / provider errors. Set to `0` for fail-fast |
 | `llm_backoff_ms` | int | `2000` | Base exponential backoff in ms between LLM retries |
 | `tool_retries` | int | `0` | Number of retry attempts for failed tool calls |
 | `tool_backoff_ms` | int | `1000` | Base backoff delay in ms for tool retries (doubles each attempt) |
@@ -692,6 +693,16 @@ Same as `llm_call`, plus additional options:
 | `skills` | skill_registry or list | nil | Skill registry exposed to the match-and-activate lifecycle phase. See [Skills lifecycle](#skills-lifecycle) |
 | `skill_match` | dict | `{strategy: "metadata", top_n: 1, sticky: true}` | Match configuration — `strategy` (`"metadata"` \| `"host"` \| `"embedding"`), `top_n`, `sticky` |
 | `working_files` | list\|string | `[]` | Paths that feed `paths:` glob auto-trigger in the metadata matcher and ride along as a hint to host-delegated matchers |
+
+Profiles preload the common loop-budget and retry keys below. Pass any
+key explicitly to override the profile's value for that call.
+
+| Profile | `max_iterations` | `max_nudges` | `tool_retries` | `llm_retries` | `schema_retries` |
+|---|---:|---:|---:|---:|---:|
+| `tool_using` | 50 | 8 | 0 | 2 | 0 |
+| `researcher` | 30 | 4 | 0 | 2 | 0 |
+| `verifier` | 5 | 0 | 0 | 2 | 3 |
+| `completer` | 1 | 0 | 0 | 2 | 0 |
 
 When `daemon: true`, the loop transitions `active -> idle -> active` instead of
 terminating on a text-only turn. Idle daemons can be woken by queued human


### PR DESCRIPTION
## Summary
- Add agent_loop profiles (tool_using, researcher, verifier, completer) with profile defaults and explicit option overrides.
- Apply profile parsing across direct, bridge-backed, sub_agent_run, and workflow-backed agent loop config paths.
- Add agent_loop schema retry handling so verifier/schema profiles actually retry invalid structured output before accepting a turn.
- Document the profile defaults table in llm-and-agents and the LLM quickref.

Closes #861

## Validation
- cargo fmt --all
- CARGO_TARGET_DIR=/tmp/harn-target-8af6 cargo check -p harn-vm
- CARGO_TARGET_DIR=/tmp/harn-target-8af6 cargo run --quiet --bin harn -- test conformance --filter agent_loop_profiles
- CARGO_TARGET_DIR=/tmp/harn-target-8af6 cargo run --quiet --bin harn -- test conformance --filter agent_loop_llm_retries_default
- CARGO_TARGET_DIR=/tmp/harn-target-8af6 cargo run --quiet --bin harn -- test conformance --filter agent_loop_profile_invalid
- CARGO_TARGET_DIR=/tmp/harn-target-8af6 cargo test -p harn-vm llm::agent::tests
- pre-commit hook: Rust/Harn format, Harn lint, workspace clippy, highlight sync, markdownlint
- pre-push hook attempted full make test: 2907/2908 passed; one unrelated nextest leak failure in harn-vm stdlib::regex::tests::cache_eviction_still_works; exact rerun passed with cargo nextest run -p harn-vm stdlib::regex::tests::cache_eviction_still_works