### PR TITLE
[codex] Add agent_loop MCP server tools

### DIFF
--- a/conformance/helpers/mcp_http_echo_server.py
+++ b/conformance/helpers/mcp_http_echo_server.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Tiny HTTP MCP server for agent_loop conformance tests."""
+
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+
+STATE = {"list_calls": 0, "tool_calls": []}
+
+
+def jsonrpc_result(msg_id, result):
+    return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+
+def handle_rpc(payload):
+    method = payload.get("method")
+    msg_id = payload.get("id")
+    params = payload.get("params") or {}
+
+    if method == "initialize":
+        return jsonrpc_result(
+            msg_id,
+            {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "harn-http-mcp-test", "version": "1.0.0"},
+            },
+        )
+    if method == "notifications/initialized":
+        return None
+    if method == "tools/list":
+        STATE["list_calls"] += 1
+        return jsonrpc_result(
+            msg_id,
+            {
+                "tools": [
+                    {
+                        "name": "echo",
+                        "description": "Echo a message back",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "type": "string",
+                                    "description": "Message to echo",
+                                }
+                            },
+                            "required": ["message"],
+                        },
+                    }
+                ]
+            },
+        )
+    if method == "tools/call":
+        tool_name = params.get("name")
+        arguments = params.get("arguments") or {}
+        STATE["tool_calls"].append({"name": tool_name, "arguments": arguments})
+        if tool_name == "echo":
+            return jsonrpc_result(
+                msg_id,
+                {
+                    "content": [
+                        {"type": "text", "text": arguments.get("message", "")}
+                    ],
+                    "isError": False,
+                },
+            )
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"},
+        }
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {"code": -32601, "message": f"Method not found: {method}"},
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/__state":
+            self.send_json(STATE)
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        if self.path == "/__shutdown":
+            self.send_json({"ok": True})
+            raise SystemExit
+        if self.path != "/mcp":
+            self.send_response(404)
+            self.end_headers()
+            return
+        length = int(self.headers.get("content-length", "0"))
+        payload = json.loads(self.rfile.read(length) or b"{}")
+        response = handle_rpc(payload)
+        if response is None:
+            self.send_response(202)
+            self.end_headers()
+            return
+        self.send_json(response, {"MCP-Protocol-Version": "2025-11-25"})
+
+    def send_json(self, value, headers=None):
+        body = json.dumps(value).encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        for key, header_value in (headers or {}).items():
+            self.send_header(key, header_value)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format, *_args):
+        return
+
+
+def main():
+    state_dir = Path(sys.argv[1])
+    state_dir.mkdir(parents=True, exist_ok=True)
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    (state_dir / "port").write_text(str(server.server_port))
+    try:
+        server.serve_forever()
+    except SystemExit:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/conformance/tests/integration/agent_loop_mcp_servers.expected
+++ b/conformance/tests/integration/agent_loop_mcp_servers.expected
@@ -1,0 +1,7 @@
+remote__echo
+mirror__echo
+2
+echo
+hello from remote
+echo
+hello from mirror

--- a/conformance/tests/integration/agent_loop_mcp_servers.harn
+++ b/conformance/tests/integration/agent_loop_mcp_servers.harn
@@ -6,7 +6,7 @@ fn wait_for_file(path, attempts) {
     sleep(50ms)
     remaining = remaining - 1
   }
-  assert(file_exists(path), "timed out waiting for " + path)
+  require file_exists(path), "timed out waiting for " + path
 }
 
 pipeline default() {
@@ -24,7 +24,7 @@ pipeline default() {
       + pid_path
       + "\"",
   )
-  assert(start?.success, "MCP mock server started")
+  require start?.success, "MCP mock server started"
   wait_for_file(port_path, 100)
   let base = "http://127.0.0.1:" + read_file(port_path).trim()
   llm_mock_clear()
@@ -51,7 +51,8 @@ pipeline default() {
       ],
     },
   )
-  let state = json_parse(http_get(base + "/__state").body)
+  let state_response = http_get(base + "/__state")
+  let state = json_parse(state_response.body)
   let _stop = http_post(base + "/__shutdown", "")
   process_exec("kill $(cat \"" + pid_path + "\") >/dev/null 2>&1 || true")
   println(result?.tools.successful[0])

--- a/conformance/tests/integration/agent_loop_mcp_servers.harn
+++ b/conformance/tests/integration/agent_loop_mcp_servers.harn
@@ -1,0 +1,64 @@
+import { process_exec } from "std/runtime"
+
+fn wait_for_file(path, attempts) {
+  var remaining = attempts
+  while !file_exists(path) && remaining > 0 {
+    sleep(50ms)
+    remaining = remaining - 1
+  }
+  assert(file_exists(path), "timed out waiting for " + path)
+}
+
+pipeline default() {
+  let root = project_root() ?? cwd()
+  let helper_dir = path_join(root, "conformance/helpers")
+  let server_script = path_join(helper_dir, "mcp_http_echo_server.py")
+  let state_dir = path_join(temp_dir(), "harn-agent-loop-mcp-" + uuid())
+  let port_path = path_join(state_dir, "port")
+  let pid_path = path_join(state_dir, "server.pid")
+  let log_path = path_join(state_dir, "server.log")
+  mkdir(state_dir)
+  let start = process_exec(
+    "python3 \"" + server_script + "\" \"" + state_dir + "\" >\"" + log_path
+      + "\" 2>&1 & echo $! > \""
+      + pid_path
+      + "\"",
+  )
+  assert(start?.success, "MCP mock server started")
+  wait_for_file(port_path, 100)
+  let base = "http://127.0.0.1:" + read_file(port_path).trim()
+  llm_mock_clear()
+  llm_mock(
+    {
+      text: "Calling MCP tools.",
+      tool_calls: [
+        {id: "mcp1", name: "remote__echo", arguments: {message: "hello from remote"}},
+        {id: "mcp2", name: "mirror__echo", arguments: {message: "hello from mirror"}},
+      ],
+    },
+  )
+  llm_mock({text: "<done>##DONE##</done>"})
+  let result = agent_loop(
+    "Use both MCP echo tools",
+    nil,
+    {
+      provider: "mock",
+      tool_format: "native",
+      max_iterations: 3,
+      mcp_servers: [
+        {name: "remote", transport: "http", url: base + "/mcp"},
+        {name: "mirror", transport: "http", url: base + "/mcp"},
+      ],
+    },
+  )
+  let state = json_parse(http_get(base + "/__state").body)
+  let _stop = http_post(base + "/__shutdown", "")
+  process_exec("kill $(cat \"" + pid_path + "\") >/dev/null 2>&1 || true")
+  println(result?.tools.successful[0])
+  println(result?.tools.successful[1])
+  println(state.list_calls)
+  println(state.tool_calls[0].name)
+  println(state.tool_calls[0].arguments.message)
+  println(state.tool_calls[1].name)
+  println(state.tool_calls[1].arguments.message)
+}

--- a/crates/harn-vm/src/llm/agent/agent_mcp.rs
+++ b/crates/harn-vm/src/llm/agent/agent_mcp.rs
@@ -1,0 +1,366 @@
+//! Direct MCP-server integration for `agent_loop`.
+//!
+//! This is the "one option" path for MCP-backed tools: bootstrap the
+//! configured servers before the first model turn, materialize their
+//! `tools/list` results into the normal Harn tool registry, and keep the
+//! live clients available for dispatch.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
+
+use crate::llm::api::LlmCallOptions;
+use crate::value::{VmError, VmValue};
+
+pub(super) type AgentLoopMcpClients = BTreeMap<String, crate::mcp::VmMcpClientHandle>;
+
+pub(crate) fn parse_mcp_server_specs(
+    options: &Option<BTreeMap<String, VmValue>>,
+) -> Result<Vec<serde_json::Value>, VmError> {
+    let Some(value) = options.as_ref().and_then(|opts| opts.get("mcp_servers")) else {
+        return Ok(Vec::new());
+    };
+    let VmValue::List(items) = value else {
+        return Err(VmError::Runtime(
+            "agent_loop: `mcp_servers` must be a list of server config dicts".to_string(),
+        ));
+    };
+
+    let mut specs = Vec::with_capacity(items.len());
+    let mut seen = BTreeSet::new();
+    for item in items.iter() {
+        let mut spec = crate::llm::helpers::vm_value_to_json(item);
+        normalize_server_spec(&mut spec)?;
+        let name = spec
+            .get("name")
+            .and_then(|value| value.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if name.is_empty() {
+            return Err(VmError::Runtime(
+                "agent_loop: every `mcp_servers` entry requires a non-empty `name`".to_string(),
+            ));
+        }
+        if !seen.insert(name.clone()) {
+            return Err(VmError::Runtime(format!(
+                "agent_loop: duplicate MCP server name `{name}` in `mcp_servers`"
+            )));
+        }
+        specs.push(spec);
+    }
+    Ok(specs)
+}
+
+fn normalize_server_spec(spec: &mut serde_json::Value) -> Result<(), VmError> {
+    let Some(obj) = spec.as_object_mut() else {
+        return Err(VmError::Runtime(
+            "agent_loop: each `mcp_servers` entry must be a dict".to_string(),
+        ));
+    };
+
+    match obj.get("command") {
+        Some(serde_json::Value::Array(items)) => {
+            let Some(command) = items.first().and_then(|value| value.as_str()) else {
+                return Err(VmError::Runtime(
+                    "agent_loop: stdio MCP `command` arrays must start with a command string"
+                        .to_string(),
+                ));
+            };
+            let args = items
+                .iter()
+                .skip(1)
+                .map(|value| {
+                    value.as_str().map(str::to_string).ok_or_else(|| {
+                        VmError::Runtime(
+                            "agent_loop: stdio MCP `command` array args must be strings"
+                                .to_string(),
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            obj.insert(
+                "command".to_string(),
+                serde_json::Value::String(command.to_string()),
+            );
+            obj.entry("args".to_string()).or_insert_with(|| {
+                serde_json::Value::Array(args.into_iter().map(serde_json::Value::String).collect())
+            });
+        }
+        Some(serde_json::Value::String(_)) | None => {}
+        Some(_) => {
+            return Err(VmError::Runtime(
+                "agent_loop: MCP `command` must be a string or a string array".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) async fn bootstrap_agent_loop_mcp_servers(
+    opts: &mut LlmCallOptions,
+    specs: &[serde_json::Value],
+) -> Result<AgentLoopMcpClients, VmError> {
+    if specs.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let mut clients = BTreeMap::new();
+    let mut mcp_entries = Vec::new();
+
+    for spec in specs {
+        let server_name = spec
+            .get("name")
+            .and_then(|value| value.as_str())
+            .unwrap_or("")
+            .to_string();
+        let client = match crate::mcp::connect_mcp_server_from_json(spec).await {
+            Ok(client) => client,
+            Err(error) => {
+                disconnect_clients(&clients).await;
+                return Err(error);
+            }
+        };
+        let result = match client.call("tools/list", serde_json::json!({})).await {
+            Ok(result) => result,
+            Err(error) => {
+                let _ = client.disconnect().await;
+                disconnect_clients(&clients).await;
+                return Err(error);
+            }
+        };
+        let tools = result
+            .get("tools")
+            .and_then(|value| value.as_array())
+            .cloned()
+            .unwrap_or_default();
+        for tool in tools {
+            match mcp_tool_to_registry_entry(&server_name, &tool) {
+                Ok(entry) => mcp_entries.push(entry),
+                Err(error) => {
+                    let _ = client.disconnect().await;
+                    disconnect_clients(&clients).await;
+                    return Err(error);
+                }
+            }
+        }
+        clients.insert(server_name, client);
+    }
+
+    if !mcp_entries.is_empty() {
+        opts.tools = match merge_mcp_tools(opts.tools.clone(), &mcp_entries) {
+            Ok(tools) => Some(tools),
+            Err(error) => {
+                disconnect_clients(&clients).await;
+                return Err(error);
+            }
+        };
+        let mcp_tools_value = VmValue::List(Rc::new(mcp_entries));
+        let mut native_mcp_tools =
+            match crate::llm::tools::vm_tools_to_native(&mcp_tools_value, &opts.provider) {
+                Ok(tools) => tools,
+                Err(error) => {
+                    disconnect_clients(&clients).await;
+                    return Err(error);
+                }
+            };
+        match opts.native_tools.as_mut() {
+            Some(native_tools) => native_tools.append(&mut native_mcp_tools),
+            None => opts.native_tools = Some(native_mcp_tools),
+        }
+    }
+
+    Ok(clients)
+}
+
+async fn disconnect_clients(clients: &AgentLoopMcpClients) {
+    for client in clients.values() {
+        let _ = client.disconnect().await;
+    }
+}
+
+fn mcp_tool_to_registry_entry(server: &str, tool: &serde_json::Value) -> Result<VmValue, VmError> {
+    let original_name = tool
+        .get("name")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .trim();
+    if original_name.is_empty() {
+        return Err(VmError::Runtime(format!(
+            "agent_loop: MCP server `{server}` returned a tool without a name"
+        )));
+    }
+    let prefixed_name = format!("{server}__{original_name}");
+    let description = tool
+        .get("description")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+    let input_schema = tool
+        .get("inputSchema")
+        .or_else(|| tool.get("input_schema"))
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({"type": "object", "properties": {}}));
+
+    let mut entry = BTreeMap::new();
+    entry.insert("name".to_string(), VmValue::String(Rc::from(prefixed_name)));
+    entry.insert(
+        "description".to_string(),
+        VmValue::String(Rc::from(description)),
+    );
+    entry.insert(
+        "parameters".to_string(),
+        json_schema_to_harn_parameters(&input_schema),
+    );
+    entry.insert(
+        "annotations".to_string(),
+        json_schema_to_tool_annotations(&input_schema),
+    );
+    entry.insert(
+        "executor".to_string(),
+        VmValue::String(Rc::from("mcp_server")),
+    );
+    entry.insert(
+        "mcp_server".to_string(),
+        VmValue::String(Rc::from(server.to_string())),
+    );
+    entry.insert(
+        "_mcp_server".to_string(),
+        VmValue::String(Rc::from(server.to_string())),
+    );
+    entry.insert(
+        "_mcp_tool_name".to_string(),
+        VmValue::String(Rc::from(original_name.to_string())),
+    );
+    if let Some(output_schema) = tool
+        .get("outputSchema")
+        .or_else(|| tool.get("output_schema"))
+    {
+        entry.insert(
+            "outputSchema".to_string(),
+            crate::stdlib::json_to_vm_value(output_schema),
+        );
+    }
+    Ok(VmValue::Dict(Rc::new(entry)))
+}
+
+fn json_schema_to_harn_parameters(schema: &serde_json::Value) -> VmValue {
+    let required: BTreeSet<String> = schema
+        .get("required")
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    let mut params = BTreeMap::new();
+    if let Some(properties) = schema.get("properties").and_then(|value| value.as_object()) {
+        for (name, prop) in properties {
+            let mut param = crate::stdlib::json_to_vm_value(prop);
+            if let VmValue::Dict(dict) = &param {
+                let mut cloned = dict.as_ref().clone();
+                cloned.insert(
+                    "required".to_string(),
+                    VmValue::Bool(required.contains(name)),
+                );
+                param = VmValue::Dict(Rc::new(cloned));
+            }
+            params.insert(name.clone(), param);
+        }
+    }
+    VmValue::Dict(Rc::new(params))
+}
+
+fn json_schema_to_tool_annotations(schema: &serde_json::Value) -> VmValue {
+    let required: Vec<serde_json::Value> = schema
+        .get("required")
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|value| value.as_str())
+                .map(|value| serde_json::Value::String(value.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    crate::stdlib::json_to_vm_value(&serde_json::json!({
+        "kind": "fetch",
+        "side_effect_level": "network",
+        "arg_schema": {
+            "required": required,
+        },
+    }))
+}
+
+fn merge_mcp_tools(existing: Option<VmValue>, mcp_entries: &[VmValue]) -> Result<VmValue, VmError> {
+    let mut seen = BTreeSet::new();
+    let mut merged = Vec::new();
+
+    let mut root = match existing {
+        Some(VmValue::Dict(dict)) => {
+            let root = dict.as_ref().clone();
+            if let Some(VmValue::List(tools)) = root.get("tools") {
+                for tool in tools.iter() {
+                    remember_tool_name(tool, &mut seen)?;
+                    merged.push(tool.clone());
+                }
+            }
+            root
+        }
+        Some(VmValue::List(tools)) => {
+            for tool in tools.iter() {
+                remember_tool_name(tool, &mut seen)?;
+                merged.push(tool.clone());
+            }
+            let mut root = BTreeMap::new();
+            root.insert(
+                "_type".to_string(),
+                VmValue::String(Rc::from("tool_registry")),
+            );
+            root
+        }
+        Some(_) => {
+            return Err(VmError::Runtime(
+                "agent_loop: `tools` must be a tool registry or list when `mcp_servers` is used"
+                    .to_string(),
+            ));
+        }
+        None => {
+            let mut root = BTreeMap::new();
+            root.insert(
+                "_type".to_string(),
+                VmValue::String(Rc::from("tool_registry")),
+            );
+            root
+        }
+    };
+
+    for entry in mcp_entries {
+        remember_tool_name(entry, &mut seen)?;
+        merged.push(entry.clone());
+    }
+
+    root.insert("tools".to_string(), VmValue::List(Rc::new(merged)));
+    Ok(VmValue::Dict(Rc::new(root)))
+}
+
+fn remember_tool_name(tool: &VmValue, seen: &mut BTreeSet<String>) -> Result<(), VmError> {
+    let Some(dict) = tool.as_dict() else {
+        return Ok(());
+    };
+    let name = dict
+        .get("name")
+        .map(|value| value.display())
+        .unwrap_or_default();
+    if name.is_empty() {
+        return Ok(());
+    }
+    if !seen.insert(name.clone()) {
+        return Err(VmError::Runtime(format!(
+            "agent_loop: duplicate tool name `{name}` after MCP server prefixing"
+        )));
+    }
+    Ok(())
+}

--- a/crates/harn-vm/src/llm/agent/mod.rs
+++ b/crates/harn-vm/src/llm/agent/mod.rs
@@ -6,6 +6,7 @@ use crate::value::{VmError, VmValue};
 
 use super::agent_config::AgentLoopConfig;
 
+mod agent_mcp;
 mod finalize;
 mod helpers;
 mod llm_call;
@@ -16,6 +17,7 @@ mod tool_dispatch;
 mod tool_search_client;
 mod turn_preflight;
 
+pub(crate) use agent_mcp::parse_mcp_server_specs;
 pub use skill_match::{parse_skill_config, parse_skill_match_config_public};
 pub use state::SkillMatchConfig;
 #[allow(unused_imports)]
@@ -321,10 +323,41 @@ impl Drop for AgentSessionGuard {
     }
 }
 
+struct AgentLoopMcpCleanupGuard {
+    clients: agent_mcp::AgentLoopMcpClients,
+    armed: bool,
+}
+
+impl AgentLoopMcpCleanupGuard {
+    fn new(clients: agent_mcp::AgentLoopMcpClients) -> Self {
+        Self {
+            clients,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for AgentLoopMcpCleanupGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            for client in self.clients.values() {
+                client.start_disconnect();
+            }
+        }
+    }
+}
+
 pub async fn run_agent_loop_internal(
     opts: &mut super::api::LlmCallOptions,
-    config: AgentLoopConfig,
+    mut config: AgentLoopConfig,
 ) -> Result<serde_json::Value, VmError> {
+    config.mcp_clients =
+        agent_mcp::bootstrap_agent_loop_mcp_servers(opts, &config.mcp_servers).await?;
+    let mut mcp_cleanup = AgentLoopMcpCleanupGuard::new(config.mcp_clients.clone());
     let mut state = state::AgentLoopState::new(opts, config)?;
     let _session_guard = AgentSessionGuard::install(state.session_id.clone());
 
@@ -400,6 +433,7 @@ pub async fn run_agent_loop_internal(
     let daemon_config = state.daemon_config.clone();
     let custom_nudge = state.custom_nudge.clone();
     let session_id = state.session_id.clone();
+    let mcp_clients = state.config.mcp_clients.clone();
 
     // Warn on unknown `stop_after_successful_tools` names: they're
     // tolerated (forward-compat with late-declared tools) but silently
@@ -508,6 +542,7 @@ pub async fn run_agent_loop_internal(
                         bridge: &bridge,
                         tool_format: &tool_format,
                         tools_val: effective_tools_val,
+                        mcp_clients: &mcp_clients,
                         tool_retries,
                         tool_backoff_ms,
                         loop_detect_enabled,
@@ -594,6 +629,10 @@ pub async fn run_agent_loop_internal(
     // Notify external resource managers (e.g. long-running tool handles)
     // that this session has ended so they can clean up orphaned processes.
     fire_session_end_hooks(&session_id);
+    for client in mcp_clients.values() {
+        let _ = client.disconnect().await;
+    }
+    mcp_cleanup.disarm();
 
     result
 }

--- a/crates/harn-vm/src/llm/agent/tests/mod.rs
+++ b/crates/harn-vm/src/llm/agent/tests/mod.rs
@@ -118,6 +118,8 @@ pub(super) fn base_agent_config() -> AgentLoopConfig {
         skill_registry: None,
         skill_match: Default::default(),
         working_files: Vec::new(),
+        mcp_servers: Vec::new(),
+        mcp_clients: Default::default(),
     }
 }
 

--- a/crates/harn-vm/src/llm/agent/tool_dispatch.rs
+++ b/crates/harn-vm/src/llm/agent/tool_dispatch.rs
@@ -38,7 +38,7 @@ use crate::bridge::HostBridge;
 use crate::value::{ErrorCategory, VmError, VmValue};
 
 use super::super::agent_tools::{
-    classify_tool_mutation, declared_paths, denied_tool_result, dispatch_tool_execution,
+    classify_tool_mutation, declared_paths, denied_tool_result, dispatch_tool_execution_with_mcp,
     is_denied_tool_result, loop_intervention_message, render_tool_result, stable_hash,
     stable_hash_str, LoopIntervention, ToolDispatchOutcome,
 };
@@ -57,6 +57,7 @@ pub(super) struct ToolDispatchContext<'a> {
     pub bridge: &'a Option<Rc<HostBridge>>,
     pub tool_format: &'a str,
     pub tools_val: Option<&'a VmValue>,
+    pub mcp_clients: &'a std::collections::BTreeMap<String, crate::mcp::VmMcpClientHandle>,
     pub tool_retries: usize,
     pub tool_backoff_ms: u64,
     pub loop_detect_enabled: bool,
@@ -355,10 +356,11 @@ pub(super) async fn run_tool_dispatch(
             let bridge_local = ctx.bridge.clone();
             let tools_val_local = ctx.tools_val.cloned();
             async move {
-                dispatch_tool_execution(
+                dispatch_tool_execution_with_mcp(
                     &tool_name,
                     &tool_args,
                     tools_val_local.as_ref(),
+                    None,
                     bridge_local.as_ref(),
                     tool_retries_local,
                     tool_backoff_ms_local,
@@ -1158,10 +1160,11 @@ pub(super) async fn run_tool_dispatch(
                 {
                     (cached_result, cached_executor)
                 } else {
-                    let outcome = dispatch_tool_execution(
+                    let outcome = dispatch_tool_execution_with_mcp(
                         tool_name,
                         &tool_args,
                         ctx.tools_val,
+                        Some(ctx.mcp_clients),
                         ctx.bridge.as_ref(),
                         ctx.tool_retries,
                         ctx.tool_backoff_ms,

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -96,6 +96,10 @@ pub struct AgentLoopConfig {
     pub skill_match: super::agent::SkillMatchConfig,
     /// Working file set fed into `paths:` auto-trigger scoring.
     pub working_files: Vec<String>,
+    /// Declarative MCP server configs bootstrapped for this loop.
+    pub mcp_servers: Vec<serde_json::Value>,
+    /// Live MCP clients created from `mcp_servers` after bootstrap.
+    pub(crate) mcp_clients: std::collections::BTreeMap<String, crate::mcp::VmMcpClientHandle>,
 }
 
 pub(crate) fn parse_command_policy_from_options(
@@ -420,6 +424,7 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                 });
             let (skill_registry, skill_match, working_files) =
                 super::agent::parse_skill_config(&options);
+            let mcp_servers = super::agent::parse_mcp_server_specs(&options)?;
             let mut opts = extract_llm_options(&args)?;
             let result = run_agent_loop_internal(
                 &mut opts,
@@ -471,6 +476,8 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                     skill_registry,
                     skill_match,
                     working_files,
+                    mcp_servers,
+                    mcp_clients: Default::default(),
                 },
             )
             .await?;

--- a/crates/harn-vm/src/llm/agent_tools.rs
+++ b/crates/harn-vm/src/llm/agent_tools.rs
@@ -261,10 +261,32 @@ pub(super) struct ToolDispatchOutcome {
 /// bridge, not handled locally) — i.e. the categorized "tool not
 /// available" error. Retries don't change the executor: a tool that
 /// resolves via the bridge stays a `HostBridge` call across attempts.
+#[cfg(test)]
 pub(super) async fn dispatch_tool_execution(
     tool_name: &str,
     tool_args: &serde_json::Value,
     tools_val: Option<&VmValue>,
+    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    tool_retries: usize,
+    tool_backoff_ms: u64,
+) -> ToolDispatchOutcome {
+    dispatch_tool_execution_with_mcp(
+        tool_name,
+        tool_args,
+        tools_val,
+        None,
+        bridge,
+        tool_retries,
+        tool_backoff_ms,
+    )
+    .await
+}
+
+pub(super) async fn dispatch_tool_execution_with_mcp(
+    tool_name: &str,
+    tool_args: &serde_json::Value,
+    tools_val: Option<&VmValue>,
+    mcp_clients: Option<&std::collections::BTreeMap<String, crate::mcp::VmMcpClientHandle>>,
     bridge: Option<&Rc<crate::bridge::HostBridge>>,
     tool_retries: usize,
     tool_backoff_ms: u64,
@@ -338,10 +360,14 @@ pub(super) async fn dispatch_tool_execution(
             executor = Some(ToolExecutor::McpServer {
                 server_name: server_name.clone(),
             });
-            // MCP-served tools defined by the host are typically served
-            // through the host bridge today; preserve that path. A
-            // Harn-side `handler` overrides (custom MCP wrappers).
-            if let Some(handler) = find_tool_handler(tools_val, tool_name) {
+            if let Some(client) = mcp_clients.and_then(|clients| clients.get(&server_name)) {
+                let original_name = declared_mcp_tool_name_for_tool(tools_val, tool_name)
+                    .unwrap_or_else(|| tool_name.to_string());
+                crate::mcp::call_mcp_tool(client, &original_name, tool_args.clone()).await
+            } else if let Some(handler) = find_tool_handler(tools_val, tool_name) {
+                // MCP-served tools defined by the host are typically served
+                // through the host bridge today; preserve that path. A
+                // Harn-side `handler` overrides (custom MCP wrappers).
                 let Some(mut vm) = crate::vm::clone_async_builtin_child_vm() else {
                     return ToolDispatchOutcome {
                         result: Err(VmError::CategorizedError {
@@ -384,7 +410,7 @@ pub(super) async fn dispatch_tool_execution(
                 Err(VmError::CategorizedError {
                     message: format!(
                         "tool '{tool_name}' (mcp_server: \"{server_name}\") cannot be \
-                         dispatched: no bridge and no Harn handler"
+                         dispatched: no direct MCP client, bridge, or Harn handler"
                     ),
                     category: ErrorCategory::ToolRejected,
                 })
@@ -579,6 +605,28 @@ fn declared_mcp_server_for_tool(tools_val: Option<&VmValue>, tool_name: &str) ->
             continue;
         }
         if let Some(VmValue::String(s)) = entry.get("mcp_server") {
+            return Some(s.to_string());
+        }
+        return None;
+    }
+    None
+}
+
+fn declared_mcp_tool_name_for_tool(tools_val: Option<&VmValue>, tool_name: &str) -> Option<String> {
+    let dict = tools_val?.as_dict()?;
+    let tools_list = match dict.get("tools") {
+        Some(VmValue::List(l)) => l,
+        _ => return None,
+    };
+    for tool in tools_list.iter() {
+        let entry: &std::collections::BTreeMap<String, VmValue> = match tool {
+            VmValue::Dict(d) => d,
+            _ => continue,
+        };
+        if entry.get("name").map(|v| v.display()).as_deref() != Some(tool_name) {
+            continue;
+        }
+        if let Some(VmValue::String(s)) = entry.get("_mcp_tool_name") {
             return Some(s.to_string());
         }
         return None;

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -472,8 +472,8 @@ pub use self::agent::{
     register_session_end_hook,
 };
 pub(crate) use self::agent::{
-    current_host_bridge, emit_agent_event as emit_live_agent_event, parse_skill_config,
-    run_agent_loop_internal,
+    current_host_bridge, emit_agent_event as emit_live_agent_event, parse_mcp_server_specs,
+    parse_skill_config, run_agent_loop_internal,
 };
 pub(crate) use self::agent_config::{
     agent_loop_result_from_llm, parse_command_policy_from_options, AgentLoopConfig,
@@ -1154,6 +1154,7 @@ pub fn register_llm_builtins(vm: &mut Vm) {
         let daemon_config = parse_daemon_loop_config(options.as_ref());
         let (skill_registry, skill_match, working_files) =
             crate::llm::agent::parse_skill_config(&options);
+        let mcp_servers = crate::llm::agent::parse_mcp_server_specs(&options)?;
         let mut opts = extract_llm_options(&args)?;
         let result = run_agent_loop_internal(
             &mut opts,
@@ -1198,6 +1199,8 @@ pub fn register_llm_builtins(vm: &mut Vm) {
                 skill_registry,
                 skill_match,
                 working_files,
+                mcp_servers,
+                mcp_clients: Default::default(),
             },
         )
         .await?;

--- a/crates/harn-vm/src/mcp.rs
+++ b/crates/harn-vm/src/mcp.rs
@@ -90,7 +90,7 @@ impl std::fmt::Debug for VmMcpClientHandle {
 }
 
 impl VmMcpClientHandle {
-    async fn call(
+    pub(crate) async fn call(
         &self,
         method: &str,
         params: serde_json::Value,
@@ -115,6 +115,33 @@ impl VmMcpClientHandle {
         match inner {
             McpClientInner::Stdio(inner) => stdio_notify(inner, method, params).await,
             McpClientInner::Http(inner) => http_notify(inner, method, params).await,
+        }
+    }
+
+    pub(crate) async fn disconnect(&self) -> Result<(), VmError> {
+        let mut guard = self.inner.lock().await;
+        if let Some(inner) = guard.take() {
+            match inner {
+                McpClientInner::Stdio(mut inner) => {
+                    let _ = inner.child.kill().await;
+                }
+                McpClientInner::Http(_) => {}
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn start_disconnect(&self) {
+        let Ok(mut guard) = self.inner.try_lock() else {
+            return;
+        };
+        if let Some(inner) = guard.take() {
+            match inner {
+                McpClientInner::Stdio(mut inner) => {
+                    let _ = inner.child.start_kill();
+                }
+                McpClientInner::Http(_) => {}
+            }
         }
     }
 }
@@ -655,6 +682,45 @@ fn extract_content_text(result: &serde_json::Value) -> String {
     }
 }
 
+pub(crate) async fn call_mcp_tool(
+    client: &VmMcpClientHandle,
+    tool_name: &str,
+    arguments: serde_json::Value,
+) -> Result<serde_json::Value, VmError> {
+    let result = client
+        .call(
+            "tools/call",
+            serde_json::json!({
+                "name": tool_name,
+                "arguments": arguments,
+            }),
+        )
+        .await?;
+
+    if result.get("isError").and_then(|v| v.as_bool()) == Some(true) {
+        let error_text = extract_content_text(&result);
+        return Err(VmError::Thrown(VmValue::String(Rc::from(error_text))));
+    }
+
+    let content = result
+        .get("content")
+        .and_then(|c| c.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    if content.len() == 1 && content[0].get("type").and_then(|t| t.as_str()) == Some("text") {
+        if let Some(text) = content[0].get("text").and_then(|t| t.as_str()) {
+            return Ok(serde_json::Value::String(text.to_string()));
+        }
+    }
+
+    if content.is_empty() {
+        Ok(serde_json::Value::Null)
+    } else {
+        Ok(serde_json::Value::Array(content))
+    }
+}
+
 pub async fn connect_mcp_server(
     name: &str,
     command: &str,
@@ -879,40 +945,9 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
             _ => serde_json::json!({}),
         };
 
-        let result = client
-            .call(
-                "tools/call",
-                serde_json::json!({
-                    "name": tool_name,
-                    "arguments": arguments,
-                }),
-            )
-            .await?;
-
-        if result.get("isError").and_then(|v| v.as_bool()) == Some(true) {
-            let error_text = extract_content_text(&result);
-            return Err(VmError::Thrown(VmValue::String(Rc::from(error_text))));
-        }
-
-        let content = result
-            .get("content")
-            .and_then(|c| c.as_array())
-            .cloned()
-            .unwrap_or_default();
-
-        if content.len() == 1 && content[0].get("type").and_then(|t| t.as_str()) == Some("text") {
-            if let Some(text) = content[0].get("text").and_then(|t| t.as_str()) {
-                return Ok(VmValue::String(Rc::from(text)));
-            }
-        }
-
-        if content.is_empty() {
-            Ok(VmValue::Nil)
-        } else {
-            Ok(VmValue::List(Rc::new(
-                content.iter().map(json_to_vm_value).collect(),
-            )))
-        }
+        Ok(json_to_vm_value(
+            &call_mcp_tool(&client, &tool_name, arguments).await?,
+        ))
     });
 
     vm.register_async_builtin("mcp_server_info", |args| async move {
@@ -950,15 +985,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
             }
         };
 
-        let mut guard = client.inner.lock().await;
-        if let Some(inner) = guard.take() {
-            match inner {
-                McpClientInner::Stdio(mut inner) => {
-                    let _ = inner.child.kill().await;
-                }
-                McpClientInner::Http(_) => {}
-            }
-        }
+        client.disconnect().await?;
         Ok(VmValue::Nil)
     });
 

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1516,6 +1516,8 @@ pub async fn execute_stage_node(
                     skill_registry: resolve_stage_skill_registry(node),
                     skill_match: resolve_stage_skill_match(node),
                     working_files: Vec::new(),
+                    mcp_servers: Vec::new(),
+                    mcp_clients: Default::default(),
                 },
             )
             .await?

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -653,6 +653,7 @@ fn sub_agent_loop_options(spec: &SubAgentRunSpec) -> Result<crate::llm::AgentLoo
         .transpose()?
         .unwrap_or_default();
     let (skill_registry, skill_match, working_files) = crate::llm::parse_skill_config(&options);
+    let mcp_servers = crate::llm::parse_mcp_server_specs(&options)?;
     Ok(crate::llm::AgentLoopConfig {
         persistent: crate::llm::helpers::opt_bool(&options, "persistent"),
         max_iterations: max_iterations as usize,
@@ -705,6 +706,8 @@ fn sub_agent_loop_options(spec: &SubAgentRunSpec) -> Result<crate::llm::AgentLoo
         skill_registry,
         skill_match,
         working_files,
+        mcp_servers,
+        mcp_clients: Default::default(),
     })
 }
 

--- a/crates/harn-vm/src/tool_surface.rs
+++ b/crates/harn-vm/src/tool_surface.rs
@@ -290,7 +290,14 @@ fn collect_entries(input: &ToolSurfaceInput) -> Vec<ToolEntry> {
         collect_vm_entries(tools, input.policy.as_ref(), &mut entries);
     }
     if let Some(native) = input.native_tools.as_ref() {
-        collect_native_entries(native, input.policy.as_ref(), &mut entries);
+        let vm_names: BTreeSet<String> = entries.iter().map(|entry| entry.name.clone()).collect();
+        let mut native_entries = Vec::new();
+        collect_native_entries(native, input.policy.as_ref(), &mut native_entries);
+        entries.extend(
+            native_entries
+                .into_iter()
+                .filter(|entry| !vm_names.contains(&entry.name)),
+        );
     }
     entries
 }

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -692,11 +692,39 @@ Same as `llm_call`, plus additional options:
 | `skills` | skill_registry or list | nil | Skill registry exposed to the match-and-activate lifecycle phase. See [Skills lifecycle](#skills-lifecycle) |
 | `skill_match` | dict | `{strategy: "metadata", top_n: 1, sticky: true}` | Match configuration — `strategy` (`"metadata"` \| `"host"` \| `"embedding"`), `top_n`, `sticky` |
 | `working_files` | list\|string | `[]` | Paths that feed `paths:` glob auto-trigger in the metadata matcher and ride along as a hint to host-delegated matchers |
+| `mcp_servers` | list | nil | MCP servers to connect for this loop. Harn calls `tools/list` once per server, adds discovered tools as `<server>__<tool>`, and dispatches matching tool calls through `tools/call` |
 
 When `daemon: true`, the loop transitions `active -> idle -> active` instead of
 terminating on a text-only turn. Idle daemons can be woken by queued human
 messages, `agent/resume` bridge notifications, `wake_interval_ms`, or watched
 file changes from `watch_paths`.
+
+#### MCP server tools
+
+Use `mcp_servers` when an agent should use an MCP server's tool catalog without
+manually calling `mcp_connect`, `mcp_list_tools`, and `mcp_call`.
+
+```harn
+let result = agent_loop(
+  "Summarize the latest open issue and draft a reply.",
+  "You are a concise triage assistant.",
+  {
+    provider: "openai",
+    model: "gpt-5.4",
+    mcp_servers: [
+      {name: "github", transport: "http", url: "http://localhost:3030/mcp"},
+      {name: "local_fs", transport: "stdio", command: ["mcp-filesystem", "/tmp/project"]},
+    ],
+    max_iterations: 8,
+  },
+)
+```
+
+Discovered tools are always prefixed with the server name, for example
+`github__search_issues` or `local_fs__read_file`. The prefix makes collisions
+deterministic when two servers both export a tool named `search` or when a
+server tool would otherwise overlap a local Harn tool. The actual MCP
+`tools/call` request still uses the original unprefixed MCP tool name.
 
 Native-tool stages also expose structured fallback / retry metadata in the
 result `trace` summary. Look for `native_text_tool_fallbacks`,


### PR DESCRIPTION
Closes #860.

## Summary
- Adds `agent_loop({ mcp_servers: [...] })` support that bootstraps configured HTTP/stdio MCP servers, lists tools once, prefixes tool names as `<server>__<tool>`, and merges them into the normal Harn tool registry/native tool surface.
- Routes prefixed MCP tool calls back through the live client using the original unprefixed MCP tool name, while preserving existing handler and host-bridge fallback paths.
- Adds lifecycle cleanup for MCP clients, docs for the new option, and conformance coverage with a mocked HTTP MCP server and collision-prefixing assertions.

## Verification
- `cargo fmt`
- `cargo check -p harn-vm`
- `cargo check -p harn-cli`
- `cargo run --quiet --bin harn -- test conformance --filter agent_loop_mcp_servers`
- `cargo run --quiet --bin harn -- test conformance --filter mcp_basic`
- `cargo test -p harn-vm agent_tools::tests::dispatch`
- `cargo test -p harn-vm tool_surface`
- `git diff --check origin/main...HEAD`
- pre-commit hook
- pre-push hook: 2908/2908 tests passed plus affected Harn format/lint checks

## Self-review
- Rechecked MCP bootstrap failure cleanup, normal-exit disconnects, direct dispatch fallback behavior, duplicate post-prefix tool-name rejection, native/VM tool surface deduping, and conformance assertions that direct MCP calls use the original unprefixed tool names.