### PR TITLE
[codex] Expose project prompt templates over MCP

### DIFF
--- a/crates/harn-cli/src/commands/mcp/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/mod.rs
@@ -12,6 +12,7 @@ use url::Url;
 use crate::cli::{McpCommand, McpLoginArgs, McpServerRefArgs};
 use crate::package::{self, McpServerConfig};
 
+mod prompts;
 pub(crate) mod serve;
 
 const DEFAULT_REDIRECT_URI: &str = "http://127.0.0.1:9783/oauth/callback";

--- a/crates/harn-cli/src/commands/mcp/prompts.rs
+++ b/crates/harn-cli/src/commands/mcp/prompts.rs
@@ -1,0 +1,633 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use base64::Engine;
+use serde::Deserialize;
+use serde_json::{json, Value as JsonValue};
+
+use crate::package::Manifest;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct FilePromptCatalog {
+    prompts: Vec<FilePrompt>,
+}
+
+#[derive(Clone, Debug)]
+struct FilePrompt {
+    name: String,
+    title: Option<String>,
+    description: Option<String>,
+    arguments: Vec<FilePromptArgument>,
+    path: PathBuf,
+    body: String,
+    images: Vec<PromptImage>,
+}
+
+#[derive(Clone, Debug)]
+struct FilePromptArgument {
+    name: String,
+    description: Option<String>,
+    required: bool,
+}
+
+#[derive(Clone, Debug)]
+struct PromptImage {
+    path: Option<PathBuf>,
+    data: Option<String>,
+    mime_type: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PromptFrontMatter {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    arguments: Vec<PromptArgumentFrontMatter>,
+    #[serde(default)]
+    images: Vec<PromptImageFrontMatter>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PromptArgumentFrontMatter {
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default = "default_required")]
+    required: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum PromptImageFrontMatter {
+    Path(String),
+    Config {
+        #[serde(default)]
+        path: Option<String>,
+        #[serde(default)]
+        data: Option<String>,
+        #[serde(default, alias = "mimeType")]
+        mime_type: Option<String>,
+    },
+}
+
+#[derive(Clone, Debug)]
+struct PromptCandidate {
+    prompt: FilePrompt,
+    fallback_name: String,
+}
+
+fn default_required() -> bool {
+    true
+}
+
+impl FilePromptCatalog {
+    pub(crate) fn discover(project_root: &Path, manifest_source: &str) -> Self {
+        let mut candidates = Vec::new();
+        collect_prompt_files(project_root, project_root, None, &mut candidates);
+
+        for alias in dependency_aliases(manifest_source) {
+            let package_root = project_root.join(".harn/packages").join(&alias);
+            if package_root.is_dir() {
+                collect_prompt_files(&package_root, &package_root, Some(&alias), &mut candidates);
+            }
+        }
+
+        Self {
+            prompts: resolve_prompt_name_collisions(candidates),
+        }
+    }
+
+    pub(crate) fn list(&self) -> Vec<JsonValue> {
+        self.prompts
+            .iter()
+            .map(|prompt| {
+                let mut entry = json!({
+                    "name": prompt.name,
+                    "arguments": prompt
+                        .arguments
+                        .iter()
+                        .map(|argument| {
+                            let mut value = json!({
+                                "name": argument.name,
+                                "required": argument.required,
+                            });
+                            if let Some(description) = &argument.description {
+                                value["description"] = json!(description);
+                            }
+                            value
+                        })
+                        .collect::<Vec<_>>(),
+                });
+                if let Some(title) = &prompt.title {
+                    entry["title"] = json!(title);
+                }
+                if let Some(description) = &prompt.description {
+                    entry["description"] = json!(description);
+                }
+                entry
+            })
+            .collect()
+    }
+
+    pub(crate) fn get(&self, name: &str, arguments: &JsonValue) -> Result<JsonValue, String> {
+        let prompt = self
+            .prompts
+            .iter()
+            .find(|prompt| prompt.name == name)
+            .ok_or_else(|| format!("Unknown prompt: {name}"))?;
+        prompt.render(arguments)
+    }
+}
+
+impl FilePrompt {
+    fn render(&self, arguments: &JsonValue) -> Result<JsonValue, String> {
+        let object = arguments
+            .as_object()
+            .ok_or_else(|| "prompt arguments must be an object".to_string())?;
+        for argument in &self.arguments {
+            if argument.required && object.get(&argument.name).is_none_or(JsonValue::is_null) {
+                return Err(format!("Missing required argument: {}", argument.name));
+            }
+        }
+
+        let mut bindings = BTreeMap::new();
+        for (key, value) in object {
+            bindings.insert(key.clone(), harn_vm::json_to_vm_value(value));
+        }
+
+        let rendered = harn_vm::stdlib::template::render_template_to_string(
+            &self.body,
+            Some(&bindings),
+            self.path.parent(),
+            Some(&self.path),
+        )?;
+
+        let mut messages = vec![json!({
+            "role": "user",
+            "content": {
+                "type": "text",
+                "text": rendered,
+            },
+        })];
+
+        for image in &self.images {
+            messages.push(json!({
+                "role": "user",
+                "content": {
+                    "type": "image",
+                    "data": image_data(image, &self.path)?,
+                    "mimeType": image_mime_type(image, &self.path),
+                },
+            }));
+        }
+
+        let mut result = json!({ "messages": messages });
+        if let Some(description) = &self.description {
+            result["description"] = json!(description);
+        }
+        Ok(result)
+    }
+}
+
+fn collect_prompt_files(
+    root: &Path,
+    cursor: &Path,
+    package_alias: Option<&str>,
+    out: &mut Vec<PromptCandidate>,
+) {
+    let Ok(entries) = fs::read_dir(cursor) else {
+        return;
+    };
+    let mut entries = entries.flatten().collect::<Vec<_>>();
+    entries.sort_by_key(|entry| entry.path());
+    for entry in entries {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            if should_skip_dir(root, &path, package_alias.is_some()) {
+                continue;
+            }
+            collect_prompt_files(root, &path, package_alias, out);
+        } else if file_type.is_file()
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(".harn.prompt"))
+        {
+            if let Some(candidate) = load_prompt_file(root, &path, package_alias) {
+                out.push(candidate);
+            }
+        }
+    }
+}
+
+fn should_skip_dir(root: &Path, path: &Path, in_package: bool) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    if matches!(
+        name,
+        ".git" | "target" | "node_modules" | "dist" | "portal-dist"
+    ) {
+        return true;
+    }
+    if !in_package && name == ".harn" {
+        return true;
+    }
+    path != root && name.starts_with('.') && name != ".harn"
+}
+
+fn load_prompt_file(
+    root: &Path,
+    path: &Path,
+    package_alias: Option<&str>,
+) -> Option<PromptCandidate> {
+    let text = fs::read_to_string(path).ok()?;
+    let (front_matter, body) = split_front_matter(&text);
+    let meta = front_matter
+        .as_deref()
+        .and_then(|source| toml::from_str::<PromptFrontMatter>(source).ok())
+        .unwrap_or_default();
+    let relative_stem = relative_prompt_stem(root, path);
+    let fallback_name = match package_alias {
+        Some(alias) => format!("{alias}/{relative_stem}"),
+        None => relative_stem.clone(),
+    };
+    let preferred = meta
+        .name
+        .as_ref()
+        .or(meta.id.as_ref())
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| match package_alias {
+            Some(alias) => format!("{alias}/{value}"),
+            None => value.to_string(),
+        })
+        .unwrap_or_else(|| fallback_name.clone());
+
+    let arguments = if meta.arguments.is_empty() {
+        infer_arguments(body)
+    } else {
+        meta.arguments
+            .into_iter()
+            .map(|argument| FilePromptArgument {
+                name: argument.name,
+                description: argument.description,
+                required: argument.required,
+            })
+            .collect()
+    };
+
+    let images = meta
+        .images
+        .into_iter()
+        .map(|image| match image {
+            PromptImageFrontMatter::Path(path) => PromptImage {
+                path: Some(PathBuf::from(path)),
+                data: None,
+                mime_type: None,
+            },
+            PromptImageFrontMatter::Config {
+                path,
+                data,
+                mime_type,
+            } => PromptImage {
+                path: path.map(PathBuf::from),
+                data,
+                mime_type,
+            },
+        })
+        .collect();
+
+    Some(PromptCandidate {
+        prompt: FilePrompt {
+            name: preferred,
+            title: meta.title,
+            description: meta.description,
+            arguments,
+            path: path.to_path_buf(),
+            body: body.to_string(),
+            images,
+        },
+        fallback_name,
+    })
+}
+
+fn resolve_prompt_name_collisions(candidates: Vec<PromptCandidate>) -> Vec<FilePrompt> {
+    let mut counts = HashMap::<String, usize>::new();
+    for candidate in &candidates {
+        *counts.entry(candidate.prompt.name.clone()).or_default() += 1;
+    }
+
+    let mut used = BTreeSet::new();
+    candidates
+        .into_iter()
+        .map(|mut candidate| {
+            if counts
+                .get(&candidate.prompt.name)
+                .copied()
+                .unwrap_or_default()
+                > 1
+            {
+                candidate.prompt.name = candidate.fallback_name;
+            }
+            if !used.insert(candidate.prompt.name.clone()) {
+                let mut index = 2;
+                let base = candidate.prompt.name.clone();
+                while !used.insert(format!("{base}-{index}")) {
+                    index += 1;
+                }
+                candidate.prompt.name = format!("{base}-{index}");
+            }
+            candidate.prompt
+        })
+        .collect()
+}
+
+fn split_front_matter(text: &str) -> (Option<String>, &str) {
+    let Some(rest) = text.strip_prefix("---\n") else {
+        return (None, text);
+    };
+    let Some(index) = rest.find("\n---\n") else {
+        return (None, text);
+    };
+    let meta = rest[..index].to_string();
+    let body = &rest[index + "\n---\n".len()..];
+    (Some(meta), body)
+}
+
+fn relative_prompt_stem(root: &Path, path: &Path) -> String {
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    let mut rendered = relative.to_string_lossy().replace('\\', "/");
+    if let Some(stem) = rendered.strip_suffix(".harn.prompt") {
+        rendered = stem.to_string();
+    }
+    rendered
+}
+
+fn infer_arguments(body: &str) -> Vec<FilePromptArgument> {
+    let mut names = BTreeSet::new();
+    for raw in body
+        .split("{{")
+        .skip(1)
+        .filter_map(|part| part.split("}}").next())
+    {
+        let expr = raw.trim().trim_matches('-').trim();
+        if expr.is_empty() || expr.starts_with('#') {
+            continue;
+        }
+        if let Some(condition) = expr
+            .strip_prefix("if ")
+            .or_else(|| expr.strip_prefix("elif "))
+        {
+            names.extend(identifiers_in_expr(condition));
+            continue;
+        }
+        if let Some(iterable) = expr
+            .strip_prefix("for ")
+            .and_then(|for_expr| for_expr.split_once(" in ").map(|(_, iterable)| iterable))
+        {
+            names.extend(identifiers_in_expr(iterable));
+            continue;
+        }
+        if expr.starts_with("else")
+            || expr.starts_with("end")
+            || expr.starts_with("include ")
+            || expr.starts_with("raw")
+        {
+            continue;
+        }
+        if let Some(name) = first_identifier(expr) {
+            names.insert(name);
+        }
+    }
+    names
+        .into_iter()
+        .map(|name| FilePromptArgument {
+            name,
+            description: None,
+            required: true,
+        })
+        .collect()
+}
+
+fn first_identifier(expr: &str) -> Option<String> {
+    let name = expr
+        .split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '.'))
+        .next()
+        .unwrap_or_default()
+        .split('.')
+        .next()
+        .unwrap_or_default();
+    is_prompt_argument_identifier(name).then(|| name.to_string())
+}
+
+fn identifiers_in_expr(expr: &str) -> Vec<String> {
+    expr.split(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '.'))
+        .filter_map(|token| token.split('.').next())
+        .filter(|token| is_prompt_argument_identifier(token))
+        .map(str::to_string)
+        .collect()
+}
+
+fn is_prompt_argument_identifier(value: &str) -> bool {
+    is_identifier(value)
+        && !matches!(
+            value,
+            "true" | "false" | "nil" | "and" | "or" | "not" | "in" | "loop"
+        )
+}
+
+fn is_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    chars
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn dependency_aliases(manifest_source: &str) -> Vec<String> {
+    let Ok(manifest) = toml::from_str::<Manifest>(manifest_source) else {
+        return Vec::new();
+    };
+    let mut aliases = manifest.dependencies.keys().cloned().collect::<Vec<_>>();
+    aliases.sort();
+    aliases
+}
+
+fn image_data(image: &PromptImage, prompt_path: &Path) -> Result<String, String> {
+    if let Some(data) = &image.data {
+        return Ok(data.clone());
+    }
+    let path = image
+        .path
+        .as_ref()
+        .ok_or_else(|| "prompt image requires path or data".to_string())?;
+    let resolved = resolve_prompt_relative_path(prompt_path, path)?;
+    let bytes = fs::read(&resolved).map_err(|error| {
+        format!(
+            "failed to read prompt image {}: {error}",
+            resolved.display()
+        )
+    })?;
+    Ok(base64::engine::general_purpose::STANDARD.encode(bytes))
+}
+
+fn image_mime_type(image: &PromptImage, prompt_path: &Path) -> String {
+    image.mime_type.clone().unwrap_or_else(|| {
+        image
+            .path
+            .as_ref()
+            .and_then(|path| {
+                resolve_prompt_relative_path(prompt_path, path)
+                    .ok()
+                    .and_then(|resolved| mime_type_for_path(&resolved).map(str::to_string))
+            })
+            .unwrap_or_else(|| "application/octet-stream".to_string())
+    })
+}
+
+fn resolve_prompt_relative_path(prompt_path: &Path, path: &Path) -> Result<PathBuf, String> {
+    if path.is_absolute() {
+        return Err("prompt image path must be relative to the prompt file".to_string());
+    }
+    let mut safe = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => safe.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(format!(
+                    "prompt image path {} escapes the prompt directory",
+                    path.display()
+                ));
+            }
+        }
+    }
+    let base = prompt_path
+        .parent()
+        .ok_or_else(|| format!("prompt path {} has no parent", prompt_path.display()))?;
+    Ok(base.join(safe))
+}
+
+fn mime_type_for_path(path: &Path) -> Option<&'static str> {
+    match path.extension().and_then(|extension| extension.to_str()) {
+        Some("png") => Some("image/png"),
+        Some("jpg") | Some("jpeg") => Some("image/jpeg"),
+        Some("gif") => Some("image/gif"),
+        Some("webp") => Some("image/webp"),
+        Some("svg") => Some("image/svg+xml"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, text: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, text).unwrap();
+    }
+
+    #[test]
+    fn discovers_and_renders_front_matter_prompt() {
+        let temp = TempDir::new().unwrap();
+        write(
+            temp.path().join("harn.toml").as_path(),
+            "[package]\nname = \"x\"\n",
+        );
+        write(
+            temp.path().join("prompts/review.harn.prompt").as_path(),
+            r#"---
+id = "review"
+description = "Review code"
+[[arguments]]
+name = "code"
+description = "Code to review"
+required = true
+---
+Review this: {{ code }}
+"#,
+        );
+
+        let catalog = FilePromptCatalog::discover(temp.path(), "[package]\nname = \"x\"\n");
+        assert_eq!(catalog.list()[0]["name"], "review");
+        assert_eq!(
+            catalog.list()[0]["arguments"][0]["description"],
+            "Code to review"
+        );
+
+        let rendered = catalog
+            .get("review", &json!({ "code": "fn main() {}" }))
+            .unwrap();
+        assert!(rendered["messages"][0]["content"]["text"]
+            .as_str()
+            .unwrap()
+            .contains("fn main"));
+    }
+
+    #[test]
+    fn prefixes_dependency_package_prompts() {
+        let temp = TempDir::new().unwrap();
+        let manifest = r#"[package]
+name = "root"
+[dependencies]
+pack = { path = "../pack" }
+"#;
+        write(temp.path().join("harn.toml").as_path(), manifest);
+        write(
+            temp.path()
+                .join(".harn/packages/pack/prompts/helper.harn.prompt")
+                .as_path(),
+            "Use {{ topic }}",
+        );
+
+        let catalog = FilePromptCatalog::discover(temp.path(), manifest);
+        assert_eq!(catalog.list()[0]["name"], "pack/prompts/helper");
+    }
+
+    #[test]
+    fn infers_arguments_from_template_expressions() {
+        let args =
+            infer_arguments("{{ if enabled }}{{ user.name }}{{ for item in items }}x{{ end }}");
+        let names = args
+            .into_iter()
+            .map(|argument| argument.name)
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["enabled", "items", "user"]);
+    }
+
+    #[test]
+    fn prompt_images_cannot_escape_prompt_directory() {
+        let temp = TempDir::new().unwrap();
+        write(
+            temp.path().join("harn.toml").as_path(),
+            "[package]\nname = \"x\"\n",
+        );
+        write(
+            temp.path().join("prompts/review.harn.prompt").as_path(),
+            r#"---
+id = "review"
+images = [{ path = "../secret.png", mime_type = "image/png" }]
+---
+hello
+"#,
+        );
+
+        let catalog = FilePromptCatalog::discover(temp.path(), "[package]\nname = \"x\"\n");
+        let error = catalog.get("review", &json!({})).unwrap_err();
+        assert!(error.contains("escapes the prompt directory"));
+    }
+}

--- a/crates/harn-cli/src/commands/mcp/serve.rs
+++ b/crates/harn-cli/src/commands/mcp/serve.rs
@@ -12,11 +12,12 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use futures::channel::mpsc::{unbounded, UnboundedSender};
 use futures::{stream, StreamExt};
+use notify::Watcher;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use time::OffsetDateTime;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot};
 use uuid::Uuid;
 
 use harn_vm::event_log::{EventLog, LogEvent, Topic};
@@ -36,6 +37,8 @@ use crate::commands::orchestrator::inspect_data::{
 use crate::commands::orchestrator::listener::ListenerAuth;
 use crate::package::CollectedTriggerHandler;
 
+use super::prompts::FilePromptCatalog;
+
 const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
 const MCP_SESSION_HEADER: &str = "mcp-session-id";
 const MCP_PROTOCOL_HEADER: &str = "mcp-protocol-version";
@@ -49,6 +52,9 @@ pub(crate) struct McpOrchestratorService {
     state_dir: PathBuf,
     manifest_source: Arc<String>,
     auth: ListenerAuth,
+    prompt_catalog: Arc<Mutex<FilePromptCatalog>>,
+    prompt_notify_tx: broadcast::Sender<JsonValue>,
+    _prompt_watcher: Arc<Mutex<Option<notify::RecommendedWatcher>>>,
 }
 
 #[derive(Clone, Debug)]
@@ -220,11 +226,30 @@ impl McpOrchestratorService {
             )
         })?;
         let auth = ListenerAuth::from_env(false)?;
+        let project_root = local
+            .config
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        let prompt_catalog = Arc::new(Mutex::new(FilePromptCatalog::discover(
+            &project_root,
+            &manifest_source,
+        )));
+        let (prompt_notify_tx, _) = broadcast::channel(32);
+        let prompt_watcher = start_prompt_watcher(
+            project_root,
+            local.config.clone(),
+            prompt_catalog.clone(),
+            prompt_notify_tx.clone(),
+        );
         Ok(Self {
             config_path: local.config,
             state_dir: local.state_dir,
             manifest_source: Arc::new(manifest_source),
             auth,
+            prompt_catalog,
+            prompt_notify_tx,
+            _prompt_watcher: Arc::new(Mutex::new(prompt_watcher)),
         })
     }
 
@@ -233,6 +258,10 @@ impl McpOrchestratorService {
             config: self.config_path.clone(),
             state_dir: self.state_dir.clone(),
         }
+    }
+
+    fn subscribe_prompt_notifications(&self) -> broadcast::Receiver<JsonValue> {
+        self.prompt_notify_tx.subscribe()
     }
 
     async fn handle_request(&self, session: &mut ConnectionState, request: JsonValue) -> JsonValue {
@@ -266,8 +295,8 @@ impl McpOrchestratorService {
             "resources/templates/list" => {
                 harn_vm::jsonrpc::response(id, json!({"resourceTemplates": []}))
             }
-            "prompts/list" => harn_vm::jsonrpc::response(id, json!({"prompts": []})),
-            "prompts/get" => harn_vm::jsonrpc::error_response(id, -32602, "Unknown prompt"),
+            "prompts/list" => self.handle_prompts_list(id),
+            "prompts/get" => self.handle_prompts_get(id, &params),
             _ if mcp_protocol::unsupported_latest_spec_method(method).is_some() => {
                 mcp_protocol::unsupported_latest_spec_method_response(id, method)
                     .expect("checked unsupported MCP method")
@@ -317,6 +346,7 @@ impl McpOrchestratorService {
                 "capabilities": {
                     "tools": { "listChanged": false },
                     "resources": { "listChanged": false },
+                    "prompts": { "listChanged": true },
                     "logging": {},
                 },
                 "serverInfo": {
@@ -327,6 +357,42 @@ impl McpOrchestratorService {
                 "instructions": "Expose Harn trigger and orchestrator controls over MCP."
             }),
         )
+    }
+
+    fn handle_prompts_list(&self, id: JsonValue) -> JsonValue {
+        let prompts = self
+            .prompt_catalog
+            .lock()
+            .expect("prompt catalog poisoned")
+            .list();
+        harn_vm::jsonrpc::response(id, json!({ "prompts": prompts }))
+    }
+
+    fn handle_prompts_get(&self, id: JsonValue, params: &JsonValue) -> JsonValue {
+        let name = params
+            .get("name")
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default();
+        let arguments = params
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        let result = self
+            .prompt_catalog
+            .lock()
+            .expect("prompt catalog poisoned")
+            .get(name, &arguments);
+        match result {
+            Ok(value) => harn_vm::jsonrpc::response(id, value),
+            Err(error)
+                if error.starts_with("Unknown prompt")
+                    || error.starts_with("Missing required argument")
+                    || error.starts_with("prompt arguments") =>
+            {
+                harn_vm::jsonrpc::error_response(id, -32602, &error)
+            }
+            Err(error) => harn_vm::jsonrpc::error_response(id, -32603, &error),
+        }
     }
 
     fn handle_tools_list(&self, id: JsonValue) -> JsonValue {
@@ -990,36 +1056,54 @@ async fn run_stdio(service: Arc<McpOrchestratorService>) -> Result<(), String> {
     let mut stdout = tokio::io::stdout();
     let mut lines = stdin.lines();
     let mut session = ConnectionState::default();
+    let mut prompt_notifications = service.subscribe_prompt_notifications();
 
     eprintln!("[harn] MCP stdio server ready");
 
-    while let Ok(Some(line)) = lines.next_line().await {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
+    loop {
+        tokio::select! {
+            line = lines.next_line() => {
+                let Some(line) = line.map_err(|error| format!("stdin read failed: {error}"))? else {
+                    break;
+                };
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let request: JsonValue = match serde_json::from_str(trimmed) {
+                    Ok(value) => value,
+                    Err(_) => continue,
+                };
+                let response = service.handle_request(&mut session, request).await;
+                if !response.is_null() {
+                    write_stdio_json(&mut stdout, &response).await?;
+                }
+            }
+            notification = prompt_notifications.recv() => {
+                match notification {
+                    Ok(notification) => write_stdio_json(&mut stdout, &notification).await?,
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
         }
-        let request: JsonValue = match serde_json::from_str(trimmed) {
-            Ok(value) => value,
-            Err(_) => continue,
-        };
-        let response = service.handle_request(&mut session, request).await;
-        if response.is_null() {
-            continue;
-        }
-        let mut encoded = serde_json::to_string(&response)
-            .map_err(|error| format!("serialize error: {error}"))?;
-        encoded.push('\n');
-        stdout
-            .write_all(encoded.as_bytes())
-            .await
-            .map_err(|error| format!("stdout write failed: {error}"))?;
-        stdout
-            .flush()
-            .await
-            .map_err(|error| format!("stdout flush failed: {error}"))?;
     }
 
     Ok(())
+}
+
+async fn write_stdio_json(stdout: &mut tokio::io::Stdout, value: &JsonValue) -> Result<(), String> {
+    let mut encoded =
+        serde_json::to_string(value).map_err(|error| format!("serialize error: {error}"))?;
+    encoded.push('\n');
+    stdout
+        .write_all(encoded.as_bytes())
+        .await
+        .map_err(|error| format!("stdout write failed: {error}"))?;
+    stdout
+        .flush()
+        .await
+        .map_err(|error| format!("stdout flush failed: {error}"))
 }
 
 async fn run_http(service: Arc<McpOrchestratorService>, args: &McpServeArgs) -> Result<(), String> {
@@ -1030,6 +1114,45 @@ async fn run_http(service: Arc<McpOrchestratorService>, args: &McpServeArgs) -> 
         args.messages_path.clone(),
     );
     serve_http_router(router, args.bind, &args.path).await
+}
+
+fn start_prompt_watcher(
+    project_root: PathBuf,
+    config_path: PathBuf,
+    prompt_catalog: Arc<Mutex<FilePromptCatalog>>,
+    prompt_notify_tx: broadcast::Sender<JsonValue>,
+) -> Option<notify::RecommendedWatcher> {
+    let project_root_for_callback = project_root.clone();
+    let mut watcher = notify::recommended_watcher(move |result: notify::Result<notify::Event>| {
+        let Ok(event) = result else {
+            return;
+        };
+        if !event
+            .paths
+            .iter()
+            .any(|path| is_prompt_reload_path(path.as_path()))
+        {
+            return;
+        }
+        let manifest_source = std::fs::read_to_string(&config_path).unwrap_or_default();
+        let updated = FilePromptCatalog::discover(&project_root_for_callback, &manifest_source);
+        *prompt_catalog.lock().expect("prompt catalog poisoned") = updated;
+        let _ = prompt_notify_tx.send(json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/prompts/list_changed",
+        }));
+    })
+    .ok()?;
+    watcher
+        .watch(&project_root, notify::RecursiveMode::Recursive)
+        .ok()?;
+    Some(watcher)
+}
+
+fn is_prompt_reload_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "harn.toml" || name.ends_with(".harn.prompt"))
 }
 
 pub(crate) fn http_router_for_local(
@@ -1206,6 +1329,28 @@ async fn legacy_sse_stream(State(state): State<HttpState>, headers: HeaderMap) -
     let session = Arc::new(HttpSession::default());
     let (tx, rx) = unbounded::<JsonValue>();
     *session.sse_tx.lock().expect("SSE sender poisoned") = Some(tx);
+    let mut prompt_notifications = state.service.subscribe_prompt_notifications();
+    let prompt_tx = session
+        .sse_tx
+        .lock()
+        .expect("SSE sender poisoned")
+        .as_ref()
+        .cloned();
+    if let Some(prompt_tx) = prompt_tx {
+        tokio::spawn(async move {
+            loop {
+                match prompt_notifications.recv().await {
+                    Ok(message) => {
+                        if prompt_tx.unbounded_send(message).is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+    }
     state
         .sessions
         .lock()
@@ -1610,6 +1755,10 @@ pub fn on_fail(event: TriggerEvent) -> any {
             )
             .await;
         assert_eq!(response["result"]["protocolVersion"], MCP_PROTOCOL_VERSION);
+        assert_eq!(
+            response["result"]["capabilities"]["prompts"]["listChanged"],
+            json!(true)
+        );
         session
     }
 
@@ -1714,6 +1863,97 @@ pub fn on_fail(event: TriggerEvent) -> any {
             )
             .await;
         assert_eq!(prompt["error"]["code"], json!(-32602));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn file_backed_prompts_list_render_and_notify_changes() {
+        let _guard = lock_harn_state();
+        let temp = TempDir::new().unwrap();
+        write_fixture(&temp);
+        write_file(temp.path(), "pixel.png", "fake");
+        write_file(
+            temp.path(),
+            "review.harn.prompt",
+            r#"---
+id = "review"
+description = "Review code"
+images = [{ path = "pixel.png", mime_type = "image/png" }]
+[[arguments]]
+name = "code"
+description = "Code to review"
+required = true
+---
+Review this: {{ code }}
+"#,
+        );
+        let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
+        let mut session = init_session(&service).await;
+        let mut notifications = service.subscribe_prompt_notifications();
+
+        let prompts = service
+            .handle_request(
+                &mut session,
+                harn_vm::jsonrpc::request(20, "prompts/list", json!({})),
+            )
+            .await;
+        assert_eq!(prompts["result"]["prompts"][0]["name"], json!("review"));
+        assert_eq!(
+            prompts["result"]["prompts"][0]["arguments"][0]["description"],
+            json!("Code to review")
+        );
+
+        let missing = service
+            .handle_request(
+                &mut session,
+                harn_vm::jsonrpc::request(21, "prompts/get", json!({"name": "review"})),
+            )
+            .await;
+        assert_eq!(missing["error"]["code"], json!(-32602));
+
+        let prompt = service
+            .handle_request(
+                &mut session,
+                harn_vm::jsonrpc::request(
+                    22,
+                    "prompts/get",
+                    json!({"name": "review", "arguments": {"code": "fn main() {}"}}),
+                ),
+            )
+            .await;
+        assert!(prompt["result"]["messages"][0]["content"]["text"]
+            .as_str()
+            .unwrap()
+            .contains("fn main"));
+        assert_eq!(
+            prompt["result"]["messages"][1]["content"]["type"],
+            json!("image")
+        );
+        assert_eq!(
+            prompt["result"]["messages"][1]["content"]["data"],
+            json!("ZmFrZQ==")
+        );
+
+        write_file(
+            temp.path(),
+            "review.harn.prompt",
+            r#"---
+id = "review"
+[[arguments]]
+name = "code"
+required = true
+---
+Updated: {{ code }}
+"#,
+        );
+        let notification =
+            tokio::time::timeout(std::time::Duration::from_secs(5), notifications.recv())
+                .await
+                .expect("timed out waiting for prompt list_changed")
+                .expect("prompt notification channel closed");
+        assert_eq!(
+            notification["method"],
+            json!("notifications/prompts/list_changed")
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-cli/tests/mcp_server_cli.rs
+++ b/crates/harn-cli/tests/mcp_server_cli.rs
@@ -86,11 +86,20 @@ fn send_request(
     stdout: &mut BufReader<impl std::io::Read>,
     request: JsonValue,
 ) -> JsonValue {
+    let request_id = request.get("id").cloned();
     writeln!(stdin, "{}", serde_json::to_string(&request).unwrap()).unwrap();
     stdin.flush().unwrap();
-    let mut line = String::new();
-    stdout.read_line(&mut line).unwrap();
-    serde_json::from_str(line.trim()).unwrap()
+    loop {
+        let mut line = String::new();
+        stdout.read_line(&mut line).unwrap();
+        let response: JsonValue = serde_json::from_str(line.trim()).unwrap();
+        if request_id
+            .as_ref()
+            .is_none_or(|id| response.get("id") == Some(id))
+        {
+            return response;
+        }
+    }
 }
 
 fn wait_for_http_listener(child: &mut std::process::Child, rx: &Receiver<String>) -> String {

--- a/crates/harn-vm/src/mcp_server/convert.rs
+++ b/crates/harn-vm/src/mcp_server/convert.rs
@@ -11,22 +11,18 @@ pub(super) fn prompt_value_to_messages(value: &VmValue) -> Vec<serde_json::Value
         }
         VmValue::List(items) => items
             .iter()
-            .map(|item| {
+            .flat_map(|item| {
                 if let VmValue::Dict(d) = item {
                     let role = d
                         .get("role")
                         .map(|v| v.display())
                         .unwrap_or_else(|| "user".into());
-                    let content = d.get("content").map(|v| v.display()).unwrap_or_default();
-                    serde_json::json!({
-                        "role": role,
-                        "content": { "type": "text", "text": content }
-                    })
+                    prompt_content_messages(&role, d.get("content"))
                 } else {
-                    serde_json::json!({
+                    vec![serde_json::json!({
                         "role": "user",
                         "content": { "type": "text", "text": item.display() }
-                    })
+                    })]
                 }
             })
             .collect(),
@@ -36,6 +32,81 @@ pub(super) fn prompt_value_to_messages(value: &VmValue) -> Vec<serde_json::Value
                 "content": { "type": "text", "text": value.display() }
             })]
         }
+    }
+}
+
+fn prompt_content_messages(role: &str, content: Option<&VmValue>) -> Vec<serde_json::Value> {
+    match content {
+        Some(value @ VmValue::Dict(_)) => vec![serde_json::json!({
+            "role": role,
+            "content": normalize_prompt_content(value),
+        })],
+        Some(VmValue::List(items)) => items
+            .iter()
+            .map(|item| {
+                serde_json::json!({
+                    "role": role,
+                    "content": normalize_prompt_content(item),
+                })
+            })
+            .collect(),
+        Some(value) => vec![serde_json::json!({
+            "role": role,
+            "content": { "type": "text", "text": value.display() },
+        })],
+        None => vec![serde_json::json!({
+            "role": role,
+            "content": { "type": "text", "text": "" },
+        })],
+    }
+}
+
+fn normalize_prompt_content(value: &VmValue) -> serde_json::Value {
+    if let VmValue::Dict(d) = value {
+        let content_type = d.get("type").map(|v| v.display()).unwrap_or_default();
+        match content_type.as_str() {
+            "text" => serde_json::json!({
+                "type": "text",
+                "text": d.get("text").map(|v| v.display()).unwrap_or_default(),
+            }),
+            "image" => {
+                let mut content = serde_json::json!({
+                    "type": "image",
+                    "data": d.get("data").map(|v| v.display()).unwrap_or_default(),
+                    "mimeType": d
+                        .get("mimeType")
+                        .or_else(|| d.get("mime_type"))
+                        .map(|v| v.display())
+                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                });
+                if let Some(annotations) = d.get("annotations") {
+                    content["annotations"] = vm_value_to_json(annotations);
+                }
+                content
+            }
+            "audio" => serde_json::json!({
+                "type": "audio",
+                "data": d.get("data").map(|v| v.display()).unwrap_or_default(),
+                "mimeType": d
+                    .get("mimeType")
+                    .or_else(|| d.get("mime_type"))
+                    .map(|v| v.display())
+                    .unwrap_or_else(|| "application/octet-stream".to_string()),
+            }),
+            "resource" => {
+                let mut content = serde_json::json!({ "type": "resource" });
+                if let Some(resource) = d.get("resource") {
+                    content["resource"] = vm_value_to_json(resource);
+                }
+                content
+            }
+            _ => serde_json::json!({
+                "type": "text",
+                "text": d.get("text").map(|v| v.display()).unwrap_or_else(|| value.display()),
+            }),
+        }
+    } else {
+        serde_json::json!({ "type": "text", "text": value.display() })
     }
 }
 

--- a/crates/harn-vm/src/mcp_server/server.rs
+++ b/crates/harn-vm/src/mcp_server/server.rs
@@ -142,7 +142,10 @@ impl McpServer {
             capabilities.insert("resources".into(), serde_json::json!({}));
         }
         if !self.prompts.is_empty() {
-            capabilities.insert("prompts".into(), serde_json::json!({}));
+            capabilities.insert(
+                "prompts".into(),
+                serde_json::json!({ "listChanged": false }),
+            );
         }
         capabilities.insert("logging".into(), serde_json::json!({}));
 

--- a/crates/harn-vm/src/mcp_server/tests.rs
+++ b/crates/harn-vm/src/mcp_server/tests.rs
@@ -96,6 +96,26 @@ fn test_prompt_value_to_messages_list() {
 }
 
 #[test]
+fn test_prompt_value_to_messages_preserves_image_content() {
+    let items = vec![VmValue::Dict(Rc::new({
+        let mut image = BTreeMap::new();
+        image.insert("type".into(), VmValue::String(Rc::from("image")));
+        image.insert("data".into(), VmValue::String(Rc::from("ZmFrZQ==")));
+        image.insert("mimeType".into(), VmValue::String(Rc::from("image/png")));
+
+        let mut message = BTreeMap::new();
+        message.insert("role".into(), VmValue::String(Rc::from("user")));
+        message.insert("content".into(), VmValue::Dict(Rc::new(image)));
+        message
+    }))];
+    let msgs = prompt_value_to_messages(&VmValue::List(Rc::new(items)));
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0]["content"]["type"], "image");
+    assert_eq!(msgs[0]["content"]["data"], "ZmFrZQ==");
+    assert_eq!(msgs[0]["content"]["mimeType"], "image/png");
+}
+
+#[test]
 fn test_match_uri_template_simple() {
     let vars = match_uri_template("file:///{path}", "file:///foo/bar.rs").unwrap();
     assert_eq!(vars["path"], "foo/bar.rs");

--- a/crates/harn-vm/src/stdlib/template/mod.rs
+++ b/crates/harn-vm/src/stdlib/template/mod.rs
@@ -236,6 +236,17 @@ pub(crate) fn render_template_result(
     Ok(rendered)
 }
 
+/// Render a template for callers outside the VM crate that need the same
+/// prompt-template semantics as `render(...)` / `render_prompt(...)`.
+pub fn render_template_to_string(
+    template: &str,
+    bindings: Option<&BTreeMap<String, VmValue>>,
+    base: Option<&Path>,
+    source_path: Option<&Path>,
+) -> Result<String, String> {
+    render_template_result(template, bindings, base, source_path).map_err(|error| error.message())
+}
+
 /// One byte-range in a rendered prompt mapped back to its source
 /// template. Foundation for the prompt-provenance UX (burin-code #93):
 /// hover a chunk of the live prompt in the debugger and jump to the

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -215,13 +215,37 @@ The server exposes these MCP resources:
 `harn://event/<event_id>` includes the recorded trigger event plus related
 outbox/attempt/DLQ/action-graph trace entries.
 
+## Prompts
+
+The server exposes `.harn.prompt` files from the project root and from
+installed prompt-library packages under `.harn/packages/<alias>`.
+TOML front matter can define display metadata and MCP arguments:
+
+```harn,ignore
+---
+id = "review"
+description = "Review code"
+[[arguments]]
+name = "code"
+description = "Code to review"
+required = true
+---
+Review this:
+{{ code }}
+```
+
+`prompts/get` renders the template with the supplied `arguments` object.
+The server advertises `prompts.listChanged = true` and emits
+`notifications/prompts/list_changed` when watched `.harn.prompt` files or
+package metadata changes.
+
 ## Protocol Support
 
 `harn mcp serve` negotiates MCP protocol version `2025-11-25`. It is a
 control-plane server for Harn orchestration state, so it supports tools,
-resources, logging, cancellation, progress, and streamable HTTP sessions. It
-does not expose prompts, completions, resource subscriptions, roots, sampling,
-elicitation, or MCP tasks.
+resources, prompts, logging, cancellation, progress, and streamable HTTP
+sessions. It does not expose completions, resource subscriptions, roots,
+sampling, elicitation, or MCP tasks.
 
 | Method or feature | Status |
 |---|---|
@@ -231,8 +255,8 @@ elicitation, or MCP tasks.
 | `notifications/progress`, `notifications/cancelled` | Supported for cancellable work |
 | `resources/list`, `resources/read` | Supported for manifest, event, and DLQ resources |
 | `resources/templates/list` | Supported; returns an empty list |
-| `prompts/list` | Supported; returns an empty list |
-| `prompts/get` | Supported error for unknown prompts; the orchestrator server exposes no prompts |
+| `prompts/list` | Supported for `.harn.prompt` files in the project and prompt-library packages |
+| `prompts/get` | Supported; renders prompt templates with supplied arguments |
 | `completion/complete` | Explicitly unsupported |
 | `resources/subscribe`, `resources/unsubscribe` | Explicitly unsupported |
 | `roots/list` | Explicitly unsupported |


### PR DESCRIPTION
## Summary
- Exposes project and prompt-library `.harn.prompt` files through `harn mcp serve` via `prompts/list` and `prompts/get`.
- Renders prompt templates with supplied arguments, validates required args, and returns text plus structured image content blocks.
- Advertises `prompts.listChanged` and emits `notifications/prompts/list_changed` on prompt/manifest hot reloads for stdio and legacy SSE clients.
- Preserves structured prompt content in the VM MCP server conversion path and documents the new file-backed prompt behavior.

Fixes #879.

## Validation
- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/harn-target-422e-879 cargo test -p harn-cli commands::mcp::serve::tests::file_backed_prompts_list_render_and_notify_changes`
- `CARGO_TARGET_DIR=/tmp/harn-target-422e-879 cargo test -p harn-cli commands::mcp::prompts::tests`
- `CARGO_TARGET_DIR=/tmp/harn-target-422e-879 cargo test -p harn-cli commands::mcp::serve::tests`
- `CARGO_TARGET_DIR=/tmp/harn-target-422e-879 cargo test -p harn-vm mcp_server::tests`
- `npm run lint:md -- docs/src/mcp-server.md`
- `git diff --check`
- Pre-commit hook passed, including `cargo clippy --workspace --all-targets -- -D warnings`.
- Pre-push hook ran the full workspace test suite: 2913/2914 passed, with one unrelated nextest leak failure in `harn-cli::bin/harn-container-probe tests::parses_http_url_with_default_path`; rerunning that single test passed with `CARGO_TARGET_DIR=/tmp/harn-target-422e-879 cargo nextest run -p harn-cli --bin harn-container-probe parses_http_url_with_default_path`.

## Self-review
- Tightened image-path handling so prompt images must stay under the prompt directory.
- Kept hot-reload narrowly scoped to prompt and manifest changes to avoid excessive list-change notifications.
- Reused the VM template renderer rather than adding a separate interpolation path.
