### PR TITLE
[codex] Add Bedrock, Azure OpenAI, and Vertex providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,6 +1740,7 @@ dependencies = [
  "harn-vm",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/conformance/tests/integration/provider_capabilities_basic.harn
+++ b/conformance/tests/integration/provider_capabilities_basic.harn
@@ -59,6 +59,15 @@ pipeline test(task) {
     let caps = provider_capabilities(family, "gpt-5.4")
     assert(caps.defer_loading, family + " inherits openai defer_loading")
   }
+  // Enterprise providers expose native tool schemas without claiming
+  // provider-specific tool_search semantics.
+  let azure = provider_capabilities("azure_openai", "gpt-4o-prod")
+  assert(azure.native_tools, "Azure OpenAI supports native tools")
+  assert(!azure.defer_loading, "Azure chat completions has no Harn tool_search gate")
+  let bedrock = provider_capabilities("bedrock", "meta.llama3-70b-instruct-v1:0")
+  assert(bedrock.native_tools, "Bedrock Converse supports native tools")
+  let vertex = provider_capabilities("vertex", "gemini-1.5-pro-002")
+  assert(vertex.native_tools, "Vertex Gemini supports native tools")
   // Unknown provider + unknown model: all-default dict.
   let unknown = provider_capabilities("my-custom-proxy", "mystery-7b")
   assert(!unknown.native_tools, "unknown provider has no native_tools")

--- a/crates/harn-dap/Cargo.toml
+++ b/crates/harn-dap/Cargo.toml
@@ -16,3 +16,6 @@ harn-vm = { path = "../harn-vm", version = "0.7" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/harn-dap/src/debugger/breakpoints.rs
+++ b/crates/harn-dap/src/debugger/breakpoints.rs
@@ -241,8 +241,10 @@ impl Debugger {
         match cond {
             None => true,
             Some(expr) => {
+                self.ensure_runtime();
                 if let Some(vm) = self.vm.as_mut() {
-                    self.runtime
+                    let runtime = self.runtime.as_ref().unwrap();
+                    runtime
                         .block_on(async {
                             let local = tokio::task::LocalSet::new();
                             local.run_until(vm.evaluate_in_frame(&expr, 0)).await

--- a/crates/harn-dap/src/debugger/state.rs
+++ b/crates/harn-dap/src/debugger/state.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::rc::Rc;
+use std::time::Duration;
 
 use harn_vm::{DebugState, Vm, VmValue};
 
@@ -60,7 +61,10 @@ pub struct Debugger {
     /// Structured variable references: reference_id -> children
     pub(crate) var_refs: BTreeMap<i64, Vec<(String, VmValue)>>,
     /// Tokio runtime for async VM execution.
-    pub(crate) runtime: tokio::runtime::Runtime,
+    ///
+    /// Built lazily so protocol-only debugger sessions and unit tests do
+    /// not open runtime I/O/timer descriptors they never use.
+    pub(crate) runtime: Option<tokio::runtime::Runtime>,
     /// Next variable reference ID (start at 100 to avoid conflict with scope refs).
     pub(crate) next_var_ref: i64,
     /// Whether to break on thrown exceptions.
@@ -155,10 +159,7 @@ impl Debugger {
             program_state: ProgramState::NotStarted,
             var_refs: BTreeMap::new(),
             next_var_ref: 100,
-            runtime: tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap(),
+            runtime: None,
             break_on_exceptions: false,
             exception_filters: BTreeMap::new(),
             latest_debug_state: Rc::new(RefCell::new(None)),
@@ -258,6 +259,17 @@ impl Debugger {
         s
     }
 
+    pub(crate) fn ensure_runtime(&mut self) {
+        if self.runtime.is_none() {
+            self.runtime = Some(
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap(),
+            );
+        }
+    }
+
     /// True when the main loop should keep stepping this debugger's VM.
     /// Drives the message-interleave loop in `main.rs` -- when false, the
     /// loop blocks on `request_rx.recv()` instead of busy-stepping.
@@ -282,5 +294,18 @@ impl Debugger {
                 frame_name: "pipeline".to_string(),
                 frame_depth: 0,
             })
+    }
+}
+
+impl Drop for Debugger {
+    fn drop(&mut self) {
+        self.running = false;
+        if let Some(vm) = self.vm.as_mut() {
+            vm.signal_cancel();
+        }
+        self.vm = None;
+        if let Some(runtime) = self.runtime.take() {
+            runtime.shutdown_timeout(Duration::ZERO);
+        }
     }
 }

--- a/crates/harn-dap/src/debugger/stepping.rs
+++ b/crates/harn-dap/src/debugger/stepping.rs
@@ -331,9 +331,11 @@ impl Debugger {
         }
 
         let mut responses = Vec::new();
+        self.ensure_runtime();
         let step_result = {
+            let runtime = self.runtime.as_ref().unwrap();
             let vm = self.vm.as_mut().unwrap();
-            self.runtime.block_on(async { vm.step_execute().await })
+            runtime.block_on(async { vm.step_execute().await })
         };
 
         for tele in self.drain_telemetry_events() {
@@ -376,9 +378,10 @@ impl Debugger {
                         }
                         if should_stop {
                             if let Some(ref cond) = fb.condition {
+                                self.ensure_runtime();
                                 if let Some(vm) = self.vm.as_mut() {
-                                    let truthy = self
-                                        .runtime
+                                    let runtime = self.runtime.as_ref().unwrap();
+                                    let truthy = runtime
                                         .block_on(async {
                                             let local = tokio::task::LocalSet::new();
                                             local.run_until(vm.evaluate_in_frame(cond, 0)).await

--- a/crates/harn-dap/src/debugger/tests.rs
+++ b/crates/harn-dap/src/debugger/tests.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 use harn_vm::VmValue;
 use serde_json::json;
+use tempfile::TempDir;
 
 use super::state::{Debugger, StepMode};
 use crate::protocol::DapMessage;
@@ -17,6 +19,13 @@ fn make_request(seq: i64, command: &str, args: Option<serde_json::Value>) -> Dap
         message: None,
         body: None,
     }
+}
+
+fn write_temp_program(file_name: &str, source: &str) -> (TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("create temp debugger workspace");
+    let file = dir.path().join(file_name);
+    std::fs::write(&file, source).expect("write temp Harn program");
+    (dir, file)
 }
 
 #[test]
@@ -140,10 +149,7 @@ fn test_set_breakpoints() {
 fn test_launch_and_run() {
     let mut dbg = Debugger::new();
 
-    let dir = std::env::temp_dir().join("harn_dap_test");
-    std::fs::create_dir_all(&dir).ok();
-    let file = dir.join("test.harn");
-    std::fs::write(&file, "pipeline test(task) { log(42) }").unwrap();
+    let (_dir, file) = write_temp_program("test.harn", "pipeline test(task) { log(42) }");
 
     dbg.handle_message(make_request(1, "initialize", None));
     dbg.handle_message(make_request(
@@ -179,9 +185,7 @@ fn test_launch_and_run() {
         .iter()
         .find(|r| r.event.as_deref() == Some("terminated"));
     assert!(terminated.is_some());
-
-    std::fs::remove_file(&file).ok();
-    std::fs::remove_dir(&dir).ok();
+    drop(dbg);
 }
 
 #[test]
@@ -416,14 +420,10 @@ fn test_stack_trace() {
 fn test_breakpoint_stop() {
     let mut dbg = Debugger::new();
 
-    let dir = std::env::temp_dir().join("harn_dap_bp_test");
-    std::fs::create_dir_all(&dir).ok();
-    let file = dir.join("test_bp.harn");
-    std::fs::write(
-        &file,
+    let (_dir, file) = write_temp_program(
+        "test_bp.harn",
         "pipeline test(task) {\n  let x = 1\n  let y = 2\n  log(x + y)\n}",
-    )
-    .unwrap();
+    );
 
     dbg.handle_message(make_request(1, "initialize", None));
     dbg.handle_message(make_request(
@@ -462,23 +462,17 @@ fn test_breakpoint_stop() {
         stopped_on_breakpoint,
         "expected a stopped event with reason=breakpoint for the entry script"
     );
-
-    std::fs::remove_file(&file).ok();
-    std::fs::remove_dir(&dir).ok();
+    drop(dbg);
 }
 
 #[test]
 fn test_pause_interrupts_running_vm() {
     let mut dbg = Debugger::new();
 
-    let dir = std::env::temp_dir().join("harn_dap_pause_test");
-    std::fs::create_dir_all(&dir).ok();
-    let file = dir.join("test_pause.harn");
-    std::fs::write(
-        &file,
+    let (_dir, file) = write_temp_program(
+        "test_pause.harn",
         "pipeline test(task) {\n  let x = 1\n  let y = 2\n  let z = 3\n}",
-    )
-    .unwrap();
+    );
 
     dbg.handle_message(make_request(1, "initialize", None));
     dbg.handle_message(make_request(
@@ -502,9 +496,7 @@ fn test_pause_interrupts_running_vm() {
     });
     assert!(paused, "expected a stopped event with reason=pause");
     assert!(!dbg.is_running());
-
-    std::fs::remove_file(&file).ok();
-    std::fs::remove_dir(&dir).ok();
+    drop(dbg);
 }
 
 #[test]
@@ -522,14 +514,10 @@ fn test_harn_ping_reports_state() {
 fn test_completions_returns_frame_scope_and_builtins() {
     let mut dbg = Debugger::new();
 
-    let dir = std::env::temp_dir().join("harn_dap_completions_test");
-    std::fs::create_dir_all(&dir).ok();
-    let file = dir.join("completions.harn");
-    std::fs::write(
-        &file,
+    let (_dir, file) = write_temp_program(
+        "completions.harn",
         "pipeline t(task) { let local_name = 1\nlog(local_name) }",
-    )
-    .unwrap();
+    );
     dbg.handle_message(make_request(1, "initialize", None));
     dbg.handle_message(make_request(
         2,
@@ -552,8 +540,7 @@ fn test_completions_returns_frame_scope_and_builtins() {
     // regardless of user code.
     let labels: Vec<_> = targets.iter().filter_map(|t| t["label"].as_str()).collect();
     assert!(labels.contains(&"log"), "builtin log must appear");
-    std::fs::remove_file(&file).ok();
-    std::fs::remove_dir(&dir).ok();
+    drop(dbg);
 }
 
 #[test]
@@ -765,14 +752,10 @@ fn test_set_function_breakpoints_replaces_prior_list_and_clears_hit_counts() {
 fn test_function_breakpoint_fires_on_matching_call() {
     let mut dbg = Debugger::new();
 
-    let dir = std::env::temp_dir().join("harn_dap_fn_bp_test");
-    std::fs::create_dir_all(&dir).ok();
-    let file = dir.join("fn_bp.harn");
-    std::fs::write(
-        &file,
+    let (_dir, file) = write_temp_program(
+        "fn_bp.harn",
         "fn helper() -> int { return 42 }\npipeline t(task) { let x = helper()\n log(x) }",
-    )
-    .unwrap();
+    );
 
     dbg.handle_message(make_request(1, "initialize", None));
     dbg.handle_message(make_request(
@@ -802,9 +785,7 @@ fn test_function_breakpoint_fires_on_matching_call() {
         stopped_on_fn,
         "function breakpoint on helper() must produce a stopped event"
     );
-
-    std::fs::remove_file(&file).ok();
-    std::fs::remove_dir(&dir).ok();
+    drop(dbg);
 }
 
 #[test]

--- a/crates/harn-dap/src/debugger/variables.rs
+++ b/crates/harn-dap/src/debugger/variables.rs
@@ -312,12 +312,15 @@ impl Debugger {
     }
 
     fn store_variable(&mut self, name: &str, value_expr: &str) -> Result<VmValue, String> {
+        self.ensure_runtime();
         let Some(vm) = self.vm.as_mut() else {
             return Err("Cannot setVariable: no active VM session".into());
         };
         let name = name.to_string();
         let value_expr = value_expr.to_string();
         self.runtime
+            .as_ref()
+            .unwrap()
             .block_on(async { vm.set_variable_in_frame(&name, &value_expr, 0).await })
             .map_err(|e| format!("setVariable: {e}"))
     }
@@ -344,6 +347,7 @@ impl Debugger {
         &mut self,
         expression: &str,
     ) -> Result<VmValue, String> {
+        self.ensure_runtime();
         let Some(vm) = self.vm.as_mut() else {
             return Err(format!(
                 "Cannot evaluate '{expression}': no active VM session"
@@ -351,6 +355,8 @@ impl Debugger {
         };
         let expression_owned = expression.to_string();
         self.runtime
+            .as_ref()
+            .unwrap()
             .block_on(async { vm.evaluate_in_frame(&expression_owned, 0).await })
             .map_err(|e| format!("Cannot evaluate '{expression}': {e}"))
     }

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -53,6 +53,7 @@ pub use readiness::{
     probe_openai_compatible_model, selected_model_for_provider, supports_model_readiness_probe,
     ModelReadiness,
 };
+pub(crate) use response::parse_llm_response as parse_llm_response_for_provider;
 pub(crate) use result::{vm_build_llm_result, LlmResult};
 pub(crate) use thinking::{split_openai_thinking_blocks, ThinkingStreamSplitter};
 pub(crate) use transport::vm_call_llm_api_with_body;

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -10,7 +10,7 @@ use super::openai_normalize::normalize_openai_message_text;
 use super::result::LlmResult;
 
 /// Parse a complete (non-streaming) LLM JSON response into an `LlmResult`.
-pub(super) fn parse_llm_response(
+pub(crate) fn parse_llm_response(
     json: &serde_json::Value,
     provider: &str,
     model: &str,

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -199,6 +199,24 @@ async fn dispatch_to_registered_provider(
         return gemini.chat_impl(opts, delta_tx).await;
     }
 
+    if provider == "bedrock" {
+        return crate::llm::providers::BedrockProvider
+            .chat_impl(opts, delta_tx)
+            .await;
+    }
+
+    if provider == "azure_openai" {
+        return crate::llm::providers::AzureOpenAiProvider
+            .chat_impl(opts, delta_tx)
+            .await;
+    }
+
+    if provider == "vertex" {
+        return crate::llm::providers::VertexProvider
+            .chat_impl(opts, delta_tx)
+            .await;
+    }
+
     if resolved.is_anthropic_style {
         let anthropic = crate::llm::providers::AnthropicProvider;
         return anthropic.chat_impl(opts, delta_tx).await;

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -553,6 +553,54 @@ native_tools = true
 model_match = "moonshotai/*"
 native_tools = true
 
+# ---------- Enterprise cloud providers ---------------------------------------
+
+# Bedrock Converse normalizes native tool calling across Anthropic, Meta,
+# Amazon, Mistral, and other Bedrock-hosted model families. Tool-search and
+# prompt-cache semantics remain provider/model-specific, so don't advertise
+# those through the generic Bedrock route yet.
+[[provider.bedrock]]
+model_match = "*"
+native_tools = true
+recommended_endpoint = "/model/{model}/converse"
+text_tool_wire_format_supported = true
+
+# Azure OpenAI uses deployment-name routing but keeps the OpenAI chat
+# completions tool-call body. Do not inherit OpenAI Responses API
+# tool_search flags: this shim targets Azure's chat-completions endpoint.
+[[provider.azure_openai]]
+model_match = "gpt-*"
+native_tools = true
+recommended_endpoint = "/openai/deployments/{deployment}/chat/completions"
+text_tool_wire_format_supported = true
+
+[[provider.azure_openai]]
+model_match = "o1*"
+native_tools = true
+recommended_endpoint = "/openai/deployments/{deployment}/chat/completions"
+text_tool_wire_format_supported = true
+
+[[provider.azure_openai]]
+model_match = "o3*"
+native_tools = true
+recommended_endpoint = "/openai/deployments/{deployment}/chat/completions"
+text_tool_wire_format_supported = true
+
+[[provider.azure_openai]]
+model_match = "o4*"
+native_tools = true
+recommended_endpoint = "/openai/deployments/{deployment}/chat/completions"
+text_tool_wire_format_supported = true
+
+# Vertex Gemini exposes function declarations in generateContent. Harn maps
+# native tool schemas to that shape, but leaves provider-specific cached
+# content / thinking flags off until they are wired as first-class options.
+[[provider.vertex]]
+model_match = "gemini-*"
+native_tools = true
+recommended_endpoint = "/projects/{project}/locations/{location}/publishers/google/models/{model}:generateContent"
+text_tool_wire_format_supported = true
+
 # ---------- Mock --------------------------------------------------------------
 #
 # Mock spoofs either Anthropic or OpenAI shape depending on the model ID.

--- a/crates/harn-vm/src/llm/helpers/provider.rs
+++ b/crates/harn-vm/src/llm/helpers/provider.rs
@@ -306,6 +306,15 @@ pub fn resolve_api_key(provider: &str) -> Result<String, VmError> {
         return Ok(String::new());
     }
 
+    // These providers use multi-step platform auth that is resolved inside
+    // their provider shims: Bedrock walks the AWS credential chain and Vertex
+    // accepts bearer tokens or service-account JSON. Returning an empty string
+    // here keeps generic option extraction from rejecting valid profile /
+    // instance-role / ADC setups before the provider can inspect them.
+    if matches!(provider, "bedrock" | "vertex") {
+        return Ok(String::new());
+    }
+
     // Explain provenance (env vs llm.toml vs default) and how to opt into mock.
     let selection_hint = {
         let config_path = llm_config::loaded_config_path()

--- a/crates/harn-vm/src/llm/provider.rs
+++ b/crates/harn-vm/src/llm/provider.rs
@@ -114,7 +114,10 @@ pub(crate) fn register_default_providers() {
         names.insert("mock".to_string());
         names.insert("anthropic".to_string());
         names.insert("gemini".to_string());
+        names.insert("azure_openai".to_string());
+        names.insert("bedrock".to_string());
         names.insert("ollama".to_string());
+        names.insert("vertex".to_string());
         for name in [
             "openai",
             "openrouter",

--- a/crates/harn-vm/src/llm/providers/azure_openai.rs
+++ b/crates/harn-vm/src/llm/providers/azure_openai.rs
@@ -1,0 +1,251 @@
+//! Azure OpenAI provider.
+//!
+//! Azure uses the OpenAI chat-completions request body, but routes by
+//! deployment name in the URL and authenticates with either `api-key` or
+//! Microsoft Entra bearer tokens.
+
+use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult};
+use crate::llm::provider::{LlmProvider, LlmProviderChat};
+use crate::llm::providers::common::{
+    apply_provider_overrides, maybe_emit_delta, percent_encode_path_segment, vm_err,
+};
+use crate::value::VmError;
+
+use super::openai_compat::OpenAiCompatibleProvider;
+
+pub(crate) const DEFAULT_API_VERSION: &str = "2024-10-21";
+
+pub(crate) struct AzureOpenAiProvider;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AzureAuth {
+    ApiKey(String),
+    Bearer(String),
+}
+
+impl AzureOpenAiProvider {
+    pub(crate) fn build_request_body(request: &LlmRequestPayload) -> serde_json::Value {
+        let mut body = OpenAiCompatibleProvider::build_request_body(request, false);
+        if let Some(obj) = body.as_object_mut() {
+            // Azure deployment routing supplies the model identity in the path.
+            obj.remove("model");
+        }
+        body
+    }
+
+    pub(crate) fn endpoint_url(request: &LlmRequestPayload) -> Result<String, VmError> {
+        let pdef = crate::llm_config::provider_config("azure_openai");
+        let base_url = pdef
+            .as_ref()
+            .map(crate::llm_config::resolve_base_url)
+            .unwrap_or_default();
+        let base_url = base_url.trim_end_matches('/');
+        if base_url.is_empty() || base_url.contains('{') {
+            return Err(vm_err(
+                "Azure OpenAI endpoint is not configured; set AZURE_OPENAI_ENDPOINT",
+            ));
+        }
+        let deployment = std::env::var("AZURE_OPENAI_DEPLOYMENT")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| request.model.clone());
+        if deployment.trim().is_empty() {
+            return Err(vm_err(
+                "Azure OpenAI deployment is not configured; set model or AZURE_OPENAI_DEPLOYMENT",
+            ));
+        }
+        let api_version = std::env::var("AZURE_OPENAI_API_VERSION")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_API_VERSION.to_string());
+        Ok(format!(
+            "{base_url}/openai/deployments/{}/chat/completions?api-version={api_version}",
+            percent_encode_path_segment(deployment.trim())
+        ))
+    }
+
+    pub(crate) fn resolve_auth(api_key: &str) -> Result<AzureAuth, VmError> {
+        if let Ok(key) = std::env::var("AZURE_OPENAI_API_KEY") {
+            if !key.trim().is_empty() {
+                return Ok(AzureAuth::ApiKey(key));
+            }
+        }
+        for env_name in ["AZURE_OPENAI_AD_TOKEN", "AZURE_OPENAI_BEARER_TOKEN"] {
+            if let Ok(token) = std::env::var(env_name) {
+                if !token.trim().is_empty() {
+                    return Ok(AzureAuth::Bearer(token));
+                }
+            }
+        }
+        if !api_key.trim().is_empty() {
+            return Ok(AzureAuth::ApiKey(api_key.to_string()));
+        }
+        Err(vm_err(
+            "Missing Azure OpenAI credentials: set AZURE_OPENAI_API_KEY or AZURE_OPENAI_AD_TOKEN",
+        ))
+    }
+
+    pub(crate) async fn chat_impl(
+        &self,
+        request: &LlmRequestPayload,
+        delta_tx: Option<DeltaSender>,
+    ) -> Result<LlmResult, VmError> {
+        let url = Self::endpoint_url(request)?;
+        let auth = Self::resolve_auth(&request.api_key)?;
+        let mut body = Self::build_request_body(request);
+        apply_provider_overrides(&mut body, request.provider_overrides.as_ref());
+        let mut req = crate::llm::shared_blocking_client()
+            .post(url)
+            .header("Content-Type", "application/json")
+            .timeout(std::time::Duration::from_secs(request.resolve_timeout()))
+            .json(&body);
+        req = match auth {
+            AzureAuth::ApiKey(key) => req.header("api-key", key),
+            AzureAuth::Bearer(token) => req.header("Authorization", format!("Bearer {token}")),
+        };
+        let response = req
+            .send()
+            .await
+            .map_err(|error| vm_err(format!("azure_openai API error: {error}")))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(vm_err(format!("azure_openai HTTP {status}: {body}")));
+        }
+        let json: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|error| vm_err(format!("azure_openai response parse error: {error}")))?;
+        let resolved = crate::llm::helpers::ResolvedProvider::resolve("openai");
+        let result = crate::llm::api::parse_llm_response_for_provider(
+            &json,
+            "azure_openai",
+            &request.model,
+            &resolved,
+        )?;
+        maybe_emit_delta(delta_tx, &result.text);
+        Ok(result)
+    }
+}
+
+impl LlmProvider for AzureOpenAiProvider {
+    fn name(&self) -> &str {
+        "azure_openai"
+    }
+}
+
+impl LlmProviderChat for AzureOpenAiProvider {
+    fn chat<'a>(
+        &'a self,
+        request: &'a LlmRequestPayload,
+        delta_tx: Option<DeltaSender>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<LlmResult, VmError>> + 'a>> {
+        Box::pin(self.chat_impl(request, delta_tx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::api::{LlmRequestPayload, ThinkingConfig};
+    use crate::llm::env_lock;
+    use serde_json::json;
+
+    struct ScopedEnv {
+        key: &'static str,
+        prev: Option<String>,
+    }
+
+    impl ScopedEnv {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+        fn remove(key: &'static str) -> Self {
+            let prev = std::env::var(key).ok();
+            unsafe { std::env::remove_var(key) };
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for ScopedEnv {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    #[test]
+    fn deployment_url_uses_model_and_api_version() {
+        let _guard = env_lock().lock().unwrap();
+        let _endpoint = ScopedEnv::set("AZURE_OPENAI_ENDPOINT", "https://acct.openai.azure.com/");
+        let _api_version = ScopedEnv::set("AZURE_OPENAI_API_VERSION", "2025-01-01-preview");
+        let _deployment = ScopedEnv::remove("AZURE_OPENAI_DEPLOYMENT");
+        let request = base_request();
+        let url = AzureOpenAiProvider::endpoint_url(&request).expect("url");
+        assert_eq!(
+            url,
+            "https://acct.openai.azure.com/openai/deployments/gpt-4o-prod/chat/completions?api-version=2025-01-01-preview"
+        );
+    }
+
+    #[test]
+    fn auth_prefers_api_key_then_bearer_token() {
+        let _guard = env_lock().lock().unwrap();
+        let _key = ScopedEnv::set("AZURE_OPENAI_API_KEY", "key");
+        let _token = ScopedEnv::set("AZURE_OPENAI_AD_TOKEN", "token");
+        assert_eq!(
+            AzureOpenAiProvider::resolve_auth("").expect("auth"),
+            AzureAuth::ApiKey("key".to_string())
+        );
+        drop(_key);
+        assert_eq!(
+            AzureOpenAiProvider::resolve_auth("").expect("auth"),
+            AzureAuth::Bearer("token".to_string())
+        );
+    }
+
+    #[test]
+    fn request_body_removes_model_because_deployment_routes() {
+        let body = AzureOpenAiProvider::build_request_body(&base_request());
+        assert!(body.get("model").is_none());
+        assert_eq!(
+            body["messages"][0],
+            json!({"role": "user", "content": "hello"})
+        );
+    }
+
+    fn base_request() -> LlmRequestPayload {
+        LlmRequestPayload {
+            provider: "azure_openai".to_string(),
+            model: "gpt-4o-prod".to_string(),
+            api_key: String::new(),
+            fallback_chain: Vec::new(),
+            messages: vec![json!({"role": "user", "content": "hello"})],
+            system: None,
+            max_tokens: 32,
+            temperature: Some(0.0),
+            top_p: None,
+            top_k: None,
+            stop: None,
+            seed: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            response_format: None,
+            json_schema: None,
+            thinking: ThinkingConfig::Disabled,
+            vision: false,
+            native_tools: None,
+            tool_choice: None,
+            cache: false,
+            timeout: None,
+            stream: false,
+            provider_overrides: None,
+            prefill: None,
+            session_id: None,
+        }
+    }
+}

--- a/crates/harn-vm/src/llm/providers/bedrock.rs
+++ b/crates/harn-vm/src/llm/providers/bedrock.rs
@@ -1,0 +1,635 @@
+//! Amazon Bedrock Runtime provider.
+//!
+//! Uses Bedrock's Converse API so Claude, Llama, Titan, Mistral, and other
+//! Bedrock model IDs share one request shape. Auth is hand-rolled AWS SigV4
+//! to avoid pulling the full AWS SDK into the VM crate.
+
+use std::collections::BTreeMap;
+
+use chrono::Utc;
+use sha2::{Digest, Sha256};
+
+use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult};
+use crate::llm::provider::{LlmProvider, LlmProviderChat};
+use crate::llm::providers::common::{
+    apply_provider_overrides, maybe_emit_delta, percent_encode_path_segment, request_text_content,
+    vm_err,
+};
+use crate::value::VmError;
+
+pub(crate) struct BedrockProvider;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AwsCredentials {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    pub session_token: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SigV4Headers {
+    pub authorization: String,
+    pub amz_date: String,
+    pub content_sha256: String,
+    pub security_token: Option<String>,
+}
+
+impl BedrockProvider {
+    pub(crate) fn build_request_body(request: &LlmRequestPayload) -> serde_json::Value {
+        let mut messages = Vec::new();
+        let mut system = Vec::new();
+        if let Some(text) = request.system.as_deref() {
+            if !text.is_empty() {
+                system.push(serde_json::json!({ "text": text }));
+            }
+        }
+        for message in &request.messages {
+            let role = match message.get("role").and_then(|value| value.as_str()) {
+                Some("assistant") => "assistant",
+                Some("system") => {
+                    let text = request_text_content(message);
+                    if !text.is_empty() {
+                        system.push(serde_json::json!({ "text": text }));
+                    }
+                    continue;
+                }
+                _ => "user",
+            };
+            let text = request_text_content(message);
+            if text.is_empty() {
+                continue;
+            }
+            messages.push(serde_json::json!({
+                "role": role,
+                "content": [{ "text": text }],
+            }));
+        }
+        if let Some(prefill) = request.prefill.as_deref() {
+            if !prefill.is_empty() {
+                messages.push(serde_json::json!({
+                    "role": "assistant",
+                    "content": [{ "text": prefill }],
+                }));
+            }
+        }
+        let mut body = serde_json::json!({ "messages": messages });
+        if !system.is_empty() {
+            body["system"] = serde_json::json!(system);
+        }
+        let mut inference = serde_json::Map::new();
+        if request.max_tokens > 0 {
+            inference.insert(
+                "maxTokens".to_string(),
+                serde_json::json!(request.max_tokens),
+            );
+        }
+        if let Some(temp) = request.temperature {
+            inference.insert("temperature".to_string(), serde_json::json!(temp));
+        }
+        if let Some(top_p) = request.top_p {
+            inference.insert("topP".to_string(), serde_json::json!(top_p));
+        }
+        if let Some(stop) = request.stop.as_ref() {
+            inference.insert("stopSequences".to_string(), serde_json::json!(stop));
+        }
+        if !inference.is_empty() {
+            body["inferenceConfig"] = serde_json::Value::Object(inference);
+        }
+        if let Some(tool_config) = bedrock_tool_config(request.native_tools.as_deref()) {
+            body["toolConfig"] = tool_config;
+        }
+        body
+    }
+
+    pub(crate) async fn chat_impl(
+        &self,
+        request: &LlmRequestPayload,
+        delta_tx: Option<DeltaSender>,
+    ) -> Result<LlmResult, VmError> {
+        let region = resolve_region()?;
+        let credentials = resolve_aws_credentials().await?;
+        let mut body = Self::build_request_body(request);
+        apply_provider_overrides(&mut body, request.provider_overrides.as_ref());
+        let body_bytes = serde_json::to_vec(&body)
+            .map_err(|error| vm_err(format!("bedrock request serialization failed: {error}")))?;
+        let path = format!(
+            "/model/{}/converse",
+            percent_encode_path_segment(&request.model)
+        );
+        let base_url = bedrock_base_url(&region);
+        let url = format!("{}{}", base_url.trim_end_matches('/'), path);
+        let host = host_for_url(&url)?;
+        let signed = sign_request(
+            &credentials,
+            &region,
+            "POST",
+            &host,
+            &path,
+            &body_bytes,
+            None,
+        )?;
+        let mut req = crate::llm::shared_blocking_client()
+            .post(url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header("X-Amz-Date", signed.amz_date)
+            .header("X-Amz-Content-Sha256", signed.content_sha256)
+            .header("Authorization", signed.authorization)
+            .timeout(std::time::Duration::from_secs(request.resolve_timeout()))
+            .body(body_bytes);
+        if let Some(token) = signed.security_token {
+            req = req.header("X-Amz-Security-Token", token);
+        }
+        let response = req
+            .send()
+            .await
+            .map_err(|error| vm_err(format!("bedrock API error: {error}")))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(vm_err(format!("bedrock HTTP {status}: {body}")));
+        }
+        let json: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|error| vm_err(format!("bedrock response parse error: {error}")))?;
+        let result = parse_bedrock_converse_response(&json, &request.model)?;
+        maybe_emit_delta(delta_tx, &result.text);
+        Ok(result)
+    }
+}
+
+impl LlmProvider for BedrockProvider {
+    fn name(&self) -> &str {
+        "bedrock"
+    }
+}
+
+impl LlmProviderChat for BedrockProvider {
+    fn chat<'a>(
+        &'a self,
+        request: &'a LlmRequestPayload,
+        delta_tx: Option<DeltaSender>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<LlmResult, VmError>> + 'a>> {
+        Box::pin(self.chat_impl(request, delta_tx))
+    }
+}
+
+fn bedrock_tool_config(tools: Option<&[serde_json::Value]>) -> Option<serde_json::Value> {
+    let mut specs = Vec::new();
+    for tool in tools.unwrap_or_default() {
+        let function = tool.get("function").unwrap_or(tool);
+        let Some(name) = function.get("name").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        let mut spec = serde_json::json!({ "name": name });
+        if let Some(description) = function.get("description") {
+            spec["description"] = description.clone();
+        }
+        if let Some(schema) = function
+            .get("parameters")
+            .or_else(|| function.get("input_schema"))
+        {
+            spec["inputSchema"] = serde_json::json!({ "json": schema });
+        }
+        specs.push(serde_json::json!({ "toolSpec": spec }));
+    }
+    (!specs.is_empty()).then(|| serde_json::json!({ "tools": specs }))
+}
+
+fn parse_bedrock_converse_response(
+    json: &serde_json::Value,
+    model: &str,
+) -> Result<LlmResult, VmError> {
+    if let Some(message) = json["message"].as_str() {
+        return Err(vm_err(format!("bedrock API error: {message}")));
+    }
+    if let Some(message) = json["error"]["message"].as_str() {
+        return Err(vm_err(format!("bedrock API error: {message}")));
+    }
+    let mut result = crate::llm::providers::common::empty_result("bedrock", model);
+    if let Some(content) = json["output"]["message"]["content"].as_array() {
+        for block in content {
+            if let Some(text) = block.get("text").and_then(|value| value.as_str()) {
+                result.text.push_str(text);
+                result.blocks.push(serde_json::json!({
+                    "type": "output_text",
+                    "text": text,
+                    "visibility": "public",
+                }));
+            }
+            if let Some(tool_use) = block.get("toolUse") {
+                let id = tool_use
+                    .get("toolUseId")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let name = tool_use
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let input = tool_use
+                    .get("input")
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!({}));
+                result.tool_calls.push(serde_json::json!({
+                    "id": id,
+                    "name": name,
+                    "arguments": input,
+                }));
+                result.blocks.push(serde_json::json!({
+                    "type": "tool_call",
+                    "id": id,
+                    "name": name,
+                    "arguments": input,
+                    "visibility": "internal",
+                }));
+            }
+        }
+    }
+    result.input_tokens = json["usage"]["inputTokens"].as_i64().unwrap_or(0);
+    result.output_tokens = json["usage"]["outputTokens"].as_i64().unwrap_or(0);
+    result.stop_reason = json["stopReason"].as_str().map(str::to_string);
+    Ok(result)
+}
+
+fn bedrock_base_url(region: &str) -> String {
+    std::env::var("BEDROCK_BASE_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| format!("https://bedrock-runtime.{region}.amazonaws.com"))
+}
+
+fn host_for_url(url: &str) -> Result<String, VmError> {
+    let parsed =
+        url::Url::parse(url).map_err(|error| vm_err(format!("invalid Bedrock URL: {error}")))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| vm_err("Bedrock URL does not contain a host"))?;
+    Ok(match parsed.port() {
+        Some(port) => format!("{host}:{port}"),
+        None => host.to_string(),
+    })
+}
+
+fn resolve_region() -> Result<String, VmError> {
+    for env_name in ["AWS_REGION", "AWS_DEFAULT_REGION", "BEDROCK_REGION"] {
+        if let Ok(region) = std::env::var(env_name) {
+            if !region.trim().is_empty() {
+                return Ok(region);
+            }
+        }
+    }
+    let profile = std::env::var("AWS_PROFILE").unwrap_or_else(|_| "default".to_string());
+    if let Some(region) = read_aws_profile_value("config", &profile, "region") {
+        return Ok(region);
+    }
+    Err(vm_err(
+        "AWS region is not configured; set AWS_REGION, AWS_DEFAULT_REGION, or BEDROCK_REGION",
+    ))
+}
+
+async fn resolve_aws_credentials() -> Result<AwsCredentials, VmError> {
+    if let (Ok(access_key_id), Ok(secret_access_key)) = (
+        std::env::var("AWS_ACCESS_KEY_ID"),
+        std::env::var("AWS_SECRET_ACCESS_KEY"),
+    ) {
+        if !access_key_id.trim().is_empty() && !secret_access_key.trim().is_empty() {
+            return Ok(AwsCredentials {
+                access_key_id,
+                secret_access_key,
+                session_token: std::env::var("AWS_SESSION_TOKEN").ok(),
+            });
+        }
+    }
+    let profile = std::env::var("AWS_PROFILE").unwrap_or_else(|_| "default".to_string());
+    if let (Some(access_key_id), Some(secret_access_key)) = (
+        read_aws_profile_value("credentials", &profile, "aws_access_key_id"),
+        read_aws_profile_value("credentials", &profile, "aws_secret_access_key"),
+    ) {
+        return Ok(AwsCredentials {
+            access_key_id,
+            secret_access_key,
+            session_token: read_aws_profile_value("credentials", &profile, "aws_session_token"),
+        });
+    }
+    if let Some(credentials) = resolve_container_credentials().await? {
+        return Ok(credentials);
+    }
+    if let Some(credentials) = resolve_instance_profile_credentials().await? {
+        return Ok(credentials);
+    }
+    Err(vm_err(
+        "AWS credentials not found: set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, configure an AWS profile, or run on an instance/container role",
+    ))
+}
+
+fn read_aws_profile_value(file_kind: &str, profile: &str, key: &str) -> Option<String> {
+    let home = std::env::var("HOME").ok()?;
+    let path = match file_kind {
+        "credentials" => format!("{home}/.aws/credentials"),
+        "config" => format!("{home}/.aws/config"),
+        _ => return None,
+    };
+    let text = std::fs::read_to_string(path).ok()?;
+    let profile_section = if file_kind == "config" && profile != "default" {
+        format!("profile {profile}")
+    } else {
+        profile.to_string()
+    };
+    parse_ini_value(&text, &profile_section, key)
+}
+
+fn parse_ini_value(text: &str, section: &str, key: &str) -> Option<String> {
+    let mut in_section = false;
+    for raw_line in text.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            in_section = &line[1..line.len() - 1] == section;
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        let Some((candidate, value)) = line.split_once('=') else {
+            continue;
+        };
+        if candidate.trim() == key {
+            return Some(value.trim().to_string());
+        }
+    }
+    None
+}
+
+async fn resolve_container_credentials() -> Result<Option<AwsCredentials>, VmError> {
+    let url = if let Ok(full) = std::env::var("AWS_CONTAINER_CREDENTIALS_FULL_URI") {
+        full
+    } else if let Ok(relative) = std::env::var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") {
+        format!("http://169.254.170.2{relative}")
+    } else {
+        return Ok(None);
+    };
+    let mut req = crate::llm::shared_utility_client()
+        .get(url)
+        .timeout(std::time::Duration::from_secs(2));
+    if let Ok(token) = std::env::var("AWS_CONTAINER_AUTHORIZATION_TOKEN") {
+        req = req.header("Authorization", token);
+    }
+    let response = match req.send().await {
+        Ok(response) => response,
+        Err(_) => return Ok(None),
+    };
+    if !response.status().is_success() {
+        return Ok(None);
+    }
+    let json: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|error| vm_err(format!("container credential parse error: {error}")))?;
+    Ok(credentials_from_metadata_json(&json))
+}
+
+async fn resolve_instance_profile_credentials() -> Result<Option<AwsCredentials>, VmError> {
+    let client = crate::llm::shared_utility_client();
+    let token = match client
+        .put("http://169.254.169.254/latest/api/token")
+        .header("X-aws-ec2-metadata-token-ttl-seconds", "21600")
+        .timeout(std::time::Duration::from_secs(2))
+        .send()
+        .await
+    {
+        Ok(response) if response.status().is_success() => response.text().await.ok(),
+        _ => None,
+    };
+    let mut role_req = client
+        .get("http://169.254.169.254/latest/meta-data/iam/security-credentials/")
+        .timeout(std::time::Duration::from_secs(2));
+    if let Some(token) = token.as_deref() {
+        role_req = role_req.header("X-aws-ec2-metadata-token", token);
+    }
+    let role = match role_req.send().await {
+        Ok(response) if response.status().is_success() => response.text().await.ok(),
+        _ => None,
+    };
+    let Some(role) = role
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+    let mut cred_req = client
+        .get(format!(
+            "http://169.254.169.254/latest/meta-data/iam/security-credentials/{role}"
+        ))
+        .timeout(std::time::Duration::from_secs(2));
+    if let Some(token) = token.as_deref() {
+        cred_req = cred_req.header("X-aws-ec2-metadata-token", token);
+    }
+    let response = match cred_req.send().await {
+        Ok(response) if response.status().is_success() => response,
+        _ => return Ok(None),
+    };
+    let json: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|error| vm_err(format!("instance profile credential parse error: {error}")))?;
+    Ok(credentials_from_metadata_json(&json))
+}
+
+fn credentials_from_metadata_json(json: &serde_json::Value) -> Option<AwsCredentials> {
+    Some(AwsCredentials {
+        access_key_id: json
+            .get("AccessKeyId")
+            .or_else(|| json.get("AccessKeyID"))?
+            .as_str()?
+            .to_string(),
+        secret_access_key: json.get("SecretAccessKey")?.as_str()?.to_string(),
+        session_token: json
+            .get("Token")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+    })
+}
+
+fn sign_request(
+    credentials: &AwsCredentials,
+    region: &str,
+    method: &str,
+    host: &str,
+    path: &str,
+    body: &[u8],
+    now_override: Option<chrono::DateTime<Utc>>,
+) -> Result<SigV4Headers, VmError> {
+    let now = now_override.unwrap_or_else(Utc::now);
+    let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+    let date = now.format("%Y%m%d").to_string();
+    let content_sha256 = sha256_hex(body);
+    let mut headers = BTreeMap::from([
+        ("content-type".to_string(), "application/json".to_string()),
+        ("host".to_string(), host.to_string()),
+        ("x-amz-content-sha256".to_string(), content_sha256.clone()),
+        ("x-amz-date".to_string(), amz_date.clone()),
+    ]);
+    if let Some(token) = credentials.session_token.as_ref() {
+        headers.insert("x-amz-security-token".to_string(), token.clone());
+    }
+    let signed_headers = headers.keys().cloned().collect::<Vec<_>>().join(";");
+    let canonical_headers = headers
+        .iter()
+        .map(|(key, value)| format!("{key}:{}\n", value.trim()))
+        .collect::<String>();
+    let canonical_request =
+        format!("{method}\n{path}\n\n{canonical_headers}\n{signed_headers}\n{content_sha256}");
+    let credential_scope = format!("{date}/{region}/bedrock/aws4_request");
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{amz_date}\n{credential_scope}\n{}",
+        sha256_hex(canonical_request.as_bytes())
+    );
+    let date_key = crate::connectors::hmac::hmac_sha256(
+        format!("AWS4{}", credentials.secret_access_key).as_bytes(),
+        date.as_bytes(),
+    );
+    let region_key = crate::connectors::hmac::hmac_sha256(&date_key, region.as_bytes());
+    let service_key = crate::connectors::hmac::hmac_sha256(&region_key, b"bedrock");
+    let signing_key = crate::connectors::hmac::hmac_sha256(&service_key, b"aws4_request");
+    let signature = hex::encode(crate::connectors::hmac::hmac_sha256(
+        &signing_key,
+        string_to_sign.as_bytes(),
+    ));
+    Ok(SigV4Headers {
+        authorization: format!(
+            "AWS4-HMAC-SHA256 Credential={}/{credential_scope}, SignedHeaders={signed_headers}, Signature={signature}",
+            credentials.access_key_id
+        ),
+        amz_date,
+        content_sha256,
+        security_token: credentials.session_token.clone(),
+    })
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    hex::encode(Sha256::digest(data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::api::{LlmRequestPayload, ThinkingConfig};
+    use chrono::TimeZone;
+    use serde_json::json;
+
+    #[test]
+    fn converse_body_maps_messages_system_inference_and_tools() {
+        let body = BedrockProvider::build_request_body(&base_request());
+        assert_eq!(body["system"][0]["text"], "be brief");
+        assert_eq!(body["messages"][0]["role"], "user");
+        assert_eq!(body["messages"][0]["content"][0]["text"], "hello");
+        assert_eq!(body["inferenceConfig"]["maxTokens"], 32);
+        assert_eq!(
+            body["toolConfig"]["tools"][0]["toolSpec"]["inputSchema"]["json"]["type"],
+            "object"
+        );
+    }
+
+    #[test]
+    fn sigv4_signs_bedrock_request_with_session_token() {
+        let credentials = AwsCredentials {
+            access_key_id: "AKIDEXAMPLE".to_string(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+            session_token: Some("session".to_string()),
+        };
+        let signed = sign_request(
+            &credentials,
+            "us-east-1",
+            "POST",
+            "bedrock-runtime.us-east-1.amazonaws.com",
+            "/model/anthropic.claude-3-5-sonnet-20240620-v1%3A0/converse",
+            br#"{"messages":[]}"#,
+            Some(Utc.with_ymd_and_hms(2026, 4, 29, 12, 0, 0).unwrap()),
+        )
+        .expect("signature");
+        assert_eq!(signed.amz_date, "20260429T120000Z");
+        assert_eq!(signed.security_token.as_deref(), Some("session"));
+        assert!(signed
+            .authorization
+            .contains("Credential=AKIDEXAMPLE/20260429/us-east-1/bedrock/aws4_request"));
+        assert!(signed.authorization.contains(
+            "SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token"
+        ));
+    }
+
+    #[test]
+    fn parse_converse_response_extracts_text_tools_and_usage() {
+        let json = json!({
+            "output": {"message": {"content": [
+                {"text": "hello"},
+                {"toolUse": {"toolUseId": "t1", "name": "lookup", "input": {"q": "x"}}}
+            ]}},
+            "usage": {"inputTokens": 2, "outputTokens": 3},
+            "stopReason": "tool_use"
+        });
+        let result = parse_bedrock_converse_response(&json, "meta.llama3-70b-instruct-v1:0")
+            .expect("result");
+        assert_eq!(result.text, "hello");
+        assert_eq!(result.input_tokens, 2);
+        assert_eq!(result.output_tokens, 3);
+        assert_eq!(result.tool_calls[0]["name"], "lookup");
+    }
+
+    #[test]
+    fn ini_parser_reads_profile_values() {
+        let text = r#"
+[default]
+aws_access_key_id = default-key
+
+[dev]
+aws_secret_access_key = dev-secret
+"#;
+        assert_eq!(
+            parse_ini_value(text, "dev", "aws_secret_access_key").as_deref(),
+            Some("dev-secret")
+        );
+    }
+
+    fn base_request() -> LlmRequestPayload {
+        LlmRequestPayload {
+            provider: "bedrock".to_string(),
+            model: "anthropic.claude-3-5-sonnet-20240620-v1:0".to_string(),
+            api_key: String::new(),
+            fallback_chain: Vec::new(),
+            messages: vec![json!({"role": "user", "content": "hello"})],
+            system: Some("be brief".to_string()),
+            max_tokens: 32,
+            temperature: Some(0.1),
+            top_p: Some(0.9),
+            top_k: None,
+            stop: None,
+            seed: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            response_format: None,
+            json_schema: None,
+            thinking: ThinkingConfig::Disabled,
+            vision: false,
+            native_tools: Some(vec![json!({
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "Lookup",
+                    "parameters": {"type": "object"}
+                }
+            })]),
+            tool_choice: None,
+            cache: false,
+            timeout: None,
+            stream: false,
+            provider_overrides: None,
+            prefill: None,
+            session_id: None,
+        }
+    }
+}

--- a/crates/harn-vm/src/llm/providers/common.rs
+++ b/crates/harn-vm/src/llm/providers/common.rs
@@ -1,0 +1,78 @@
+use std::rc::Rc;
+
+use crate::llm::api::{DeltaSender, LlmResult};
+use crate::value::{VmError, VmValue};
+
+pub(super) fn vm_err(message: impl Into<String>) -> VmError {
+    VmError::Thrown(VmValue::String(Rc::from(message.into())))
+}
+
+pub(super) fn maybe_emit_delta(delta_tx: Option<DeltaSender>, text: &str) {
+    if let Some(tx) = delta_tx {
+        if !text.is_empty() {
+            let _ = tx.send(text.to_string());
+        }
+    }
+}
+
+pub(super) fn request_text_content(message: &serde_json::Value) -> String {
+    let content = &message["content"];
+    if let Some(text) = content.as_str() {
+        return text.to_string();
+    }
+    let Some(parts) = content.as_array() else {
+        return String::new();
+    };
+    let mut text = String::new();
+    for part in parts {
+        if let Some(value) = part.get("text").and_then(|value| value.as_str()) {
+            text.push_str(value);
+        } else if part.get("type").and_then(|value| value.as_str()) == Some("text") {
+            if let Some(value) = part.get("text").and_then(|value| value.as_str()) {
+                text.push_str(value);
+            }
+        }
+    }
+    text
+}
+
+pub(super) fn percent_encode_path_segment(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+pub(super) fn empty_result(provider: &str, model: &str) -> LlmResult {
+    LlmResult {
+        text: String::new(),
+        tool_calls: Vec::new(),
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        model: model.to_string(),
+        provider: provider.to_string(),
+        thinking: None,
+        stop_reason: None,
+        blocks: Vec::new(),
+    }
+}
+
+pub(super) fn apply_provider_overrides(
+    body: &mut serde_json::Value,
+    overrides: Option<&serde_json::Value>,
+) {
+    let Some(obj) = overrides.and_then(|value| value.as_object()) else {
+        return;
+    };
+    for (key, value) in obj {
+        body[key] = value.clone();
+    }
+}

--- a/crates/harn-vm/src/llm/providers/mod.rs
+++ b/crates/harn-vm/src/llm/providers/mod.rs
@@ -7,16 +7,24 @@
 //! - **OpenAI-compatible** — OpenAI, OpenRouter, Together, Groq, DeepSeek,
 //!   Fireworks, HuggingFace, local vLLM/SGLang servers, etc.
 //! - **Ollama** — local Ollama server with NDJSON streaming
+//! - **Bedrock / Azure OpenAI / Vertex AI** — enterprise cloud shims
 //! - **Mock** — deterministic test responses without any network I/O
 
 pub(crate) mod anthropic;
+pub(crate) mod azure_openai;
+pub(crate) mod bedrock;
+mod common;
 mod gemini;
 mod mock;
 mod ollama;
 pub(crate) mod openai_compat;
+pub(crate) mod vertex;
 
 pub(crate) use anthropic::AnthropicProvider;
+pub(crate) use azure_openai::AzureOpenAiProvider;
+pub(crate) use bedrock::BedrockProvider;
 pub(crate) use gemini::GeminiProvider;
 pub(crate) use mock::MockProvider;
 pub(crate) use ollama::OllamaProvider;
 pub(crate) use openai_compat::OpenAiCompatibleProvider;
+pub(crate) use vertex::VertexProvider;

--- a/crates/harn-vm/src/llm/providers/vertex.rs
+++ b/crates/harn-vm/src/llm/providers/vertex.rs
@@ -1,0 +1,428 @@
+//! Google Vertex AI Gemini provider.
+//!
+//! Vertex exposes Gemini through `projects/{project}/locations/{location}/...`
+//! routes and Google OAuth bearer tokens. The request mapper keeps Harn's
+//! canonical OpenAI-like message list at the boundary and emits Vertex
+//! `generateContent` JSON.
+
+use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult};
+use crate::llm::provider::{LlmProvider, LlmProviderChat};
+use crate::llm::providers::common::{
+    apply_provider_overrides, maybe_emit_delta, percent_encode_path_segment, request_text_content,
+    vm_err,
+};
+use crate::value::VmError;
+
+pub(crate) struct VertexProvider;
+
+#[derive(Debug, serde::Deserialize)]
+struct ServiceAccountKey {
+    client_email: String,
+    private_key: String,
+    #[serde(default)]
+    token_uri: Option<String>,
+    #[serde(default)]
+    project_id: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct ServiceAccountClaims<'a> {
+    iss: &'a str,
+    scope: &'a str,
+    aud: &'a str,
+    exp: usize,
+    iat: usize,
+}
+
+impl VertexProvider {
+    pub(crate) fn build_request_body(request: &LlmRequestPayload) -> serde_json::Value {
+        let mut contents = Vec::new();
+        let mut system_parts = Vec::new();
+        if let Some(system) = request.system.as_deref() {
+            if !system.is_empty() {
+                system_parts.push(serde_json::json!({"text": system}));
+            }
+        }
+        for message in &request.messages {
+            let role = match message.get("role").and_then(|value| value.as_str()) {
+                Some("assistant") => "model",
+                Some("system") => {
+                    let text = request_text_content(message);
+                    if !text.is_empty() {
+                        system_parts.push(serde_json::json!({"text": text}));
+                    }
+                    continue;
+                }
+                _ => "user",
+            };
+            let text = request_text_content(message);
+            if text.is_empty() {
+                continue;
+            }
+            contents.push(serde_json::json!({
+                "role": role,
+                "parts": [{"text": text}],
+            }));
+        }
+        if let Some(prefill) = request.prefill.as_deref() {
+            if !prefill.is_empty() {
+                contents.push(serde_json::json!({
+                    "role": "model",
+                    "parts": [{"text": prefill}],
+                }));
+            }
+        }
+
+        let mut body = serde_json::json!({ "contents": contents });
+        if !system_parts.is_empty() {
+            body["systemInstruction"] = serde_json::json!({ "parts": system_parts });
+        }
+        let mut generation = serde_json::Map::new();
+        if request.max_tokens > 0 {
+            generation.insert(
+                "maxOutputTokens".to_string(),
+                serde_json::json!(request.max_tokens),
+            );
+        }
+        if let Some(temp) = request.temperature {
+            generation.insert("temperature".to_string(), serde_json::json!(temp));
+        }
+        if let Some(top_p) = request.top_p {
+            generation.insert("topP".to_string(), serde_json::json!(top_p));
+        }
+        if let Some(stop) = request.stop.as_ref() {
+            generation.insert("stopSequences".to_string(), serde_json::json!(stop));
+        }
+        if request.response_format.as_deref() == Some("json") {
+            generation.insert(
+                "responseMimeType".to_string(),
+                serde_json::json!("application/json"),
+            );
+            if let Some(schema) = request.json_schema.as_ref() {
+                generation.insert("responseSchema".to_string(), schema.clone());
+            }
+        }
+        if !generation.is_empty() {
+            body["generationConfig"] = serde_json::Value::Object(generation);
+        }
+        if let Some(tools) = vertex_tools(request.native_tools.as_deref()) {
+            body["tools"] = tools;
+        }
+        body
+    }
+
+    pub(crate) fn endpoint_url(request: &LlmRequestPayload) -> Result<String, VmError> {
+        let project = std::env::var("VERTEX_AI_PROJECT")
+            .or_else(|_| std::env::var("GOOGLE_CLOUD_PROJECT"))
+            .or_else(|_| service_account_project())
+            .map_err(|_| vm_err("Vertex AI project is not configured; set VERTEX_AI_PROJECT"))?;
+        let location = std::env::var("VERTEX_AI_LOCATION")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "us-central1".to_string());
+        let pdef = crate::llm_config::provider_config("vertex");
+        let base_url = pdef
+            .as_ref()
+            .map(crate::llm_config::resolve_base_url)
+            .unwrap_or_else(|| "https://aiplatform.googleapis.com/v1".to_string());
+        let base_url = base_url.trim_end_matches('/');
+        let model = if request.model.starts_with("projects/") {
+            request.model.clone()
+        } else {
+            format!(
+                "projects/{}/locations/{}/publishers/google/models/{}",
+                percent_encode_path_segment(&project),
+                percent_encode_path_segment(&location),
+                percent_encode_path_segment(&request.model)
+            )
+        };
+        Ok(format!("{base_url}/{model}:generateContent"))
+    }
+
+    async fn bearer_token(api_key: &str) -> Result<String, VmError> {
+        for env_name in ["VERTEX_AI_ACCESS_TOKEN", "GOOGLE_OAUTH_ACCESS_TOKEN"] {
+            if let Ok(token) = std::env::var(env_name) {
+                if !token.trim().is_empty() {
+                    return Ok(token);
+                }
+            }
+        }
+        if !api_key.trim().is_empty() && !api_key.trim().starts_with('/') {
+            return Ok(api_key.to_string());
+        }
+        let key_path = std::env::var("GOOGLE_APPLICATION_CREDENTIALS")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| (!api_key.trim().is_empty()).then(|| api_key.to_string()))
+            .ok_or_else(|| {
+                vm_err(
+                    "Missing Vertex AI credentials: set VERTEX_AI_ACCESS_TOKEN or GOOGLE_APPLICATION_CREDENTIALS",
+                )
+            })?;
+        exchange_service_account_token(&key_path).await
+    }
+
+    pub(crate) async fn chat_impl(
+        &self,
+        request: &LlmRequestPayload,
+        delta_tx: Option<DeltaSender>,
+    ) -> Result<LlmResult, VmError> {
+        let url = Self::endpoint_url(request)?;
+        let token = Self::bearer_token(&request.api_key).await?;
+        let mut body = Self::build_request_body(request);
+        apply_provider_overrides(&mut body, request.provider_overrides.as_ref());
+        let response = crate::llm::shared_blocking_client()
+            .post(url)
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {token}"))
+            .timeout(std::time::Duration::from_secs(request.resolve_timeout()))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| vm_err(format!("vertex API error: {error}")))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(vm_err(format!("vertex HTTP {status}: {body}")));
+        }
+        let json: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|error| vm_err(format!("vertex response parse error: {error}")))?;
+        let result = parse_vertex_response(&json, &request.model)?;
+        maybe_emit_delta(delta_tx, &result.text);
+        Ok(result)
+    }
+}
+
+impl LlmProvider for VertexProvider {
+    fn name(&self) -> &str {
+        "vertex"
+    }
+}
+
+impl LlmProviderChat for VertexProvider {
+    fn chat<'a>(
+        &'a self,
+        request: &'a LlmRequestPayload,
+        delta_tx: Option<DeltaSender>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<LlmResult, VmError>> + 'a>> {
+        Box::pin(self.chat_impl(request, delta_tx))
+    }
+}
+
+fn vertex_tools(tools: Option<&[serde_json::Value]>) -> Option<serde_json::Value> {
+    let mut declarations = Vec::new();
+    for tool in tools.unwrap_or_default() {
+        let function = tool.get("function").unwrap_or(tool);
+        let Some(name) = function.get("name").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        let mut declaration = serde_json::json!({ "name": name });
+        if let Some(description) = function.get("description") {
+            declaration["description"] = description.clone();
+        }
+        if let Some(parameters) = function
+            .get("parameters")
+            .or_else(|| function.get("input_schema"))
+        {
+            declaration["parameters"] = parameters.clone();
+        }
+        declarations.push(declaration);
+    }
+    (!declarations.is_empty())
+        .then(|| serde_json::json!([{ "functionDeclarations": declarations }]))
+}
+
+fn parse_vertex_response(json: &serde_json::Value, model: &str) -> Result<LlmResult, VmError> {
+    if let Some(error) = json["error"]["message"].as_str() {
+        return Err(vm_err(format!("vertex API error: {error}")));
+    }
+    let mut result = crate::llm::providers::common::empty_result("vertex", model);
+    if let Some(parts) = json["candidates"][0]["content"]["parts"].as_array() {
+        for part in parts {
+            if let Some(text) = part.get("text").and_then(|value| value.as_str()) {
+                result.text.push_str(text);
+                result.blocks.push(serde_json::json!({
+                    "type": "output_text",
+                    "text": text,
+                    "visibility": "public",
+                }));
+            }
+            if let Some(call) = part.get("functionCall") {
+                let name = call
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let args = call
+                    .get("args")
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!({}));
+                let id = format!("vertex_tool_{}", result.tool_calls.len());
+                result.tool_calls.push(serde_json::json!({
+                    "id": id,
+                    "name": name,
+                    "arguments": args,
+                }));
+                result.blocks.push(serde_json::json!({
+                    "type": "tool_call",
+                    "id": id,
+                    "name": name,
+                    "arguments": args,
+                    "visibility": "internal",
+                }));
+            }
+        }
+    }
+    result.input_tokens = json["usageMetadata"]["promptTokenCount"]
+        .as_i64()
+        .unwrap_or(0);
+    result.output_tokens = json["usageMetadata"]["candidatesTokenCount"]
+        .as_i64()
+        .unwrap_or(0);
+    result.stop_reason = json["candidates"][0]["finishReason"]
+        .as_str()
+        .map(str::to_string);
+    Ok(result)
+}
+
+fn service_account_project() -> Result<String, VmError> {
+    let path = std::env::var("GOOGLE_APPLICATION_CREDENTIALS")
+        .map_err(|_| vm_err("GOOGLE_APPLICATION_CREDENTIALS is not set"))?;
+    let key = read_service_account_key(&path)?;
+    key.project_id
+        .filter(|project| !project.trim().is_empty())
+        .ok_or_else(|| vm_err("service account JSON does not contain project_id"))
+}
+
+fn read_service_account_key(path: &str) -> Result<ServiceAccountKey, VmError> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|error| vm_err(format!("failed to read service account JSON: {error}")))?;
+    serde_json::from_str(&text)
+        .map_err(|error| vm_err(format!("failed to parse service account JSON: {error}")))
+}
+
+async fn exchange_service_account_token(path: &str) -> Result<String, VmError> {
+    let key = read_service_account_key(path)?;
+    let token_uri = key
+        .token_uri
+        .as_deref()
+        .unwrap_or("https://oauth2.googleapis.com/token");
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| vm_err(format!("system clock error: {error}")))?
+        .as_secs() as usize;
+    let claims = ServiceAccountClaims {
+        iss: &key.client_email,
+        scope: "https://www.googleapis.com/auth/cloud-platform",
+        aud: token_uri,
+        iat: now,
+        exp: now + 3600,
+    };
+    let jwt = jsonwebtoken::encode(
+        &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
+        &claims,
+        &jsonwebtoken::EncodingKey::from_rsa_pem(key.private_key.as_bytes())
+            .map_err(|error| vm_err(format!("invalid service account private key: {error}")))?,
+    )
+    .map_err(|error| vm_err(format!("failed to sign service account JWT: {error}")))?;
+    let response = crate::llm::shared_utility_client()
+        .post(token_uri)
+        .form(&[
+            ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+            ("assertion", jwt.as_str()),
+        ])
+        .send()
+        .await
+        .map_err(|error| vm_err(format!("service account token exchange failed: {error}")))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(vm_err(format!(
+            "service account token exchange HTTP {status}: {body}"
+        )));
+    }
+    let json: serde_json::Value = response.json().await.map_err(|error| {
+        vm_err(format!(
+            "service account token response parse error: {error}"
+        ))
+    })?;
+    json["access_token"]
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| vm_err("service account token response did not include access_token"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::api::{LlmRequestPayload, ThinkingConfig};
+    use serde_json::json;
+
+    #[test]
+    fn build_request_maps_messages_to_generate_content() {
+        let body = VertexProvider::build_request_body(&base_request());
+        assert_eq!(body["systemInstruction"]["parts"][0]["text"], "be brief");
+        assert_eq!(body["contents"][0]["role"], "user");
+        assert_eq!(body["contents"][0]["parts"][0]["text"], "hello");
+        assert_eq!(body["generationConfig"]["maxOutputTokens"], 32);
+    }
+
+    #[test]
+    fn parse_response_extracts_text_usage_and_function_calls() {
+        let response = json!({
+            "candidates": [{
+                "content": {"parts": [
+                    {"text": "hi"},
+                    {"functionCall": {"name": "lookup", "args": {"q": "x"}}}
+                ]},
+                "finishReason": "STOP"
+            }],
+            "usageMetadata": {"promptTokenCount": 3, "candidatesTokenCount": 4}
+        });
+        let result = parse_vertex_response(&response, "gemini-1.5-pro-002").expect("result");
+        assert_eq!(result.text, "hi");
+        assert_eq!(result.input_tokens, 3);
+        assert_eq!(result.output_tokens, 4);
+        assert_eq!(result.tool_calls[0]["name"], "lookup");
+    }
+
+    fn base_request() -> LlmRequestPayload {
+        LlmRequestPayload {
+            provider: "vertex".to_string(),
+            model: "gemini-1.5-pro-002".to_string(),
+            api_key: String::new(),
+            fallback_chain: Vec::new(),
+            messages: vec![json!({"role": "user", "content": "hello"})],
+            system: Some("be brief".to_string()),
+            max_tokens: 32,
+            temperature: Some(0.2),
+            top_p: None,
+            top_k: None,
+            stop: None,
+            seed: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            response_format: None,
+            json_schema: None,
+            thinking: ThinkingConfig::Disabled,
+            vision: false,
+            native_tools: Some(vec![json!({
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "Lookup",
+                    "parameters": {"type": "object"}
+                }
+            })]),
+            tool_choice: None,
+            cache: false,
+            timeout: None,
+            stream: false,
+            provider_overrides: None,
+            prefill: None,
+            session_id: None,
+        }
+    }
+}

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -1038,6 +1038,71 @@ fn default_config() -> ProvidersConfig {
         },
     );
 
+    // AWS Bedrock Runtime. The provider shim resolves AWS credentials through
+    // env vars, the selected/default profile, container credentials, or EC2
+    // instance profile credentials, then signs Converse API calls with SigV4.
+    config.providers.insert(
+        "bedrock".to_string(),
+        ProviderDef {
+            base_url: String::new(),
+            base_url_env: Some("BEDROCK_BASE_URL".to_string()),
+            auth_style: "aws_sigv4".to_string(),
+            auth_env: AuthEnv::None,
+            chat_endpoint: "/model/{model}/converse".to_string(),
+            features: vec!["native_tools".to_string()],
+            latency_p50_ms: Some(2600),
+            ..Default::default()
+        },
+    );
+
+    // Azure OpenAI. The deployment name is routed in the URL; callers can
+    // use the Harn model field as the deployment name or set
+    // AZURE_OPENAI_DEPLOYMENT.
+    config.providers.insert(
+        "azure_openai".to_string(),
+        ProviderDef {
+            base_url: "https://{resource}.openai.azure.com".to_string(),
+            base_url_env: Some("AZURE_OPENAI_ENDPOINT".to_string()),
+            auth_style: "azure_openai".to_string(),
+            auth_env: AuthEnv::Multiple(vec![
+                "AZURE_OPENAI_API_KEY".to_string(),
+                "AZURE_OPENAI_AD_TOKEN".to_string(),
+                "AZURE_OPENAI_BEARER_TOKEN".to_string(),
+            ]),
+            chat_endpoint:
+                "/openai/deployments/{deployment}/chat/completions?api-version={api_version}"
+                    .to_string(),
+            features: vec!["native_tools".to_string()],
+            cost_per_1k_in: Some(0.0025),
+            cost_per_1k_out: Some(0.010),
+            latency_p50_ms: Some(1900),
+            ..Default::default()
+        },
+    );
+
+    // Google Vertex AI Gemini.
+    config.providers.insert(
+        "vertex".to_string(),
+        ProviderDef {
+            base_url: "https://aiplatform.googleapis.com/v1".to_string(),
+            base_url_env: Some("VERTEX_AI_BASE_URL".to_string()),
+            auth_style: "bearer".to_string(),
+            auth_env: AuthEnv::Multiple(vec![
+                "VERTEX_AI_ACCESS_TOKEN".to_string(),
+                "GOOGLE_OAUTH_ACCESS_TOKEN".to_string(),
+                "GOOGLE_APPLICATION_CREDENTIALS".to_string(),
+            ]),
+            chat_endpoint:
+                "/projects/{project}/locations/{location}/publishers/google/models/{model}:generateContent"
+                    .to_string(),
+            features: vec!["native_tools".to_string()],
+            cost_per_1k_in: Some(0.00125),
+            cost_per_1k_out: Some(0.005),
+            latency_p50_ms: Some(2100),
+            ..Default::default()
+        },
+    );
+
     // Local OpenAI-compatible server
     config.providers.insert(
         "local".to_string(),
@@ -1159,6 +1224,42 @@ fn default_config() -> ProvidersConfig {
             contains: None,
             exact: None,
             provider: "local".to_string(),
+        },
+        InferenceRule {
+            pattern: Some("anthropic.claude-*".to_string()),
+            contains: None,
+            exact: None,
+            provider: "bedrock".to_string(),
+        },
+        InferenceRule {
+            pattern: Some("meta.llama*".to_string()),
+            contains: None,
+            exact: None,
+            provider: "bedrock".to_string(),
+        },
+        InferenceRule {
+            pattern: Some("amazon.*".to_string()),
+            contains: None,
+            exact: None,
+            provider: "bedrock".to_string(),
+        },
+        InferenceRule {
+            pattern: Some("mistral.*".to_string()),
+            contains: None,
+            exact: None,
+            provider: "bedrock".to_string(),
+        },
+        InferenceRule {
+            pattern: Some("cohere.*".to_string()),
+            contains: None,
+            exact: None,
+            provider: "bedrock".to_string(),
+        },
+        InferenceRule {
+            pattern: Some("gemini-*".to_string()),
+            contains: None,
+            exact: None,
+            provider: "vertex".to_string(),
         },
         InferenceRule {
             pattern: None,
@@ -1512,6 +1613,9 @@ mod tests {
         assert!(names.contains(&"mlx".to_string()));
         assert!(names.contains(&"openai".to_string()));
         assert!(names.contains(&"ollama".to_string()));
+        assert!(names.contains(&"bedrock".to_string()));
+        assert!(names.contains(&"azure_openai".to_string()));
+        assert!(names.contains(&"vertex".to_string()));
     }
 
     #[test]
@@ -1552,6 +1656,33 @@ mod tests {
         let (model, provider) = resolve_model("mlx-qwen36-27b");
         assert_eq!(model, "unsloth/Qwen3.6-27B-UD-MLX-4bit");
         assert_eq!(provider.as_deref(), Some("mlx"));
+    }
+
+    #[test]
+    fn test_enterprise_provider_defaults_and_inference() {
+        let bedrock = provider_config("bedrock").unwrap();
+        assert_eq!(bedrock.auth_style, "aws_sigv4");
+        assert_eq!(bedrock.base_url_env.as_deref(), Some("BEDROCK_BASE_URL"));
+        assert_eq!(
+            infer_provider("anthropic.claude-3-5-sonnet-20240620-v1:0"),
+            "bedrock"
+        );
+        assert_eq!(infer_provider("meta.llama3-70b-instruct-v1:0"), "bedrock");
+
+        let azure = provider_config("azure_openai").unwrap();
+        assert_eq!(azure.base_url_env.as_deref(), Some("AZURE_OPENAI_ENDPOINT"));
+        assert_eq!(
+            auth_env_names(&azure.auth_env),
+            vec![
+                "AZURE_OPENAI_API_KEY".to_string(),
+                "AZURE_OPENAI_AD_TOKEN".to_string(),
+                "AZURE_OPENAI_BEARER_TOKEN".to_string(),
+            ]
+        );
+
+        let vertex = provider_config("vertex").unwrap();
+        assert_eq!(vertex.base_url, "https://aiplatform.googleapis.com/v1");
+        assert_eq!(infer_provider("gemini-1.5-pro-002"), "vertex");
     }
 
     #[test]

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -5,8 +5,9 @@ Harn has built-in support for calling language models and running persistent age
 ## Providers
 
 Harn ships with built-in configs for Anthropic, OpenAI, OpenRouter, Ollama,
-HuggingFace, and a local OpenAI-compatible server. Set the appropriate
-environment variable to authenticate or point Harn at a local endpoint:
+HuggingFace, Bedrock, Azure OpenAI, Vertex AI, and local OpenAI-compatible
+servers. Set the appropriate environment variable to authenticate or point
+Harn at an endpoint:
 
 | Provider | Environment variable | Default model |
 |---|---|---|
@@ -14,6 +15,9 @@ environment variable to authenticate or point Harn at a local endpoint:
 | OpenAI | `OPENAI_API_KEY` | `gpt-4o` |
 | OpenRouter | `OPENROUTER_API_KEY` | `anthropic/claude-sonnet-4.6` |
 | HuggingFace | `HF_TOKEN` or `HUGGINGFACE_API_KEY` | explicit `model` |
+| Bedrock | AWS env/profile/instance role | explicit Bedrock `model` |
+| Azure OpenAI | `AZURE_OPENAI_API_KEY` or `AZURE_OPENAI_AD_TOKEN` | deployment name in `model` |
+| Vertex AI | `VERTEX_AI_ACCESS_TOKEN` or `GOOGLE_APPLICATION_CREDENTIALS` | Gemini model ID |
 | Ollama | `OLLAMA_HOST` (optional) | `llama3.2` |
 | Local server | `LOCAL_LLM_BASE_URL` | `LOCAL_LLM_MODEL` or explicit `model` |
 | MLX OpenAI-compatible server | `MLX_BASE_URL` | `MLX_MODEL_ID` or `mlx-qwen36-27b` |
@@ -33,6 +37,31 @@ and verify that the configured model or alias is currently served. Harn
 does not launch MLX scripts itself; hosts that support auto-start should
 run their launcher, report launcher failures, then call the Harn readiness
 probe again.
+
+### Enterprise providers
+
+Bedrock uses the AWS credential chain. Harn checks `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN` first, then the
+selected `AWS_PROFILE` or default profile under `~/.aws/credentials`, then
+container credentials, then EC2 instance profile credentials. Set
+`AWS_REGION`, `AWS_DEFAULT_REGION`, or `BEDROCK_REGION`. The model is a
+Bedrock model ID such as `anthropic.claude-3-5-sonnet-20240620-v1:0` or
+`meta.llama3-70b-instruct-v1:0`.
+
+Azure OpenAI requires `AZURE_OPENAI_ENDPOINT`, for example
+`https://my-resource.openai.azure.com`. Harn routes the request to
+`/openai/deployments/{deployment}/chat/completions` and uses the Harn
+`model` value as the deployment name unless `AZURE_OPENAI_DEPLOYMENT` is
+set. `AZURE_OPENAI_API_VERSION` defaults to `2024-10-21`. Authentication
+uses `AZURE_OPENAI_API_KEY` via the `api-key` header, or
+`AZURE_OPENAI_AD_TOKEN` / `AZURE_OPENAI_BEARER_TOKEN` as a bearer token.
+
+Vertex AI requires a project and location. Set `VERTEX_AI_PROJECT` or
+`GOOGLE_CLOUD_PROJECT`; set `VERTEX_AI_LOCATION` when the default
+`us-central1` is not correct. Authentication uses
+`VERTEX_AI_ACCESS_TOKEN` / `GOOGLE_OAUTH_ACCESS_TOKEN`, or a service-account
+JSON file through `GOOGLE_APPLICATION_CREDENTIALS`. Harn exchanges service
+account keys for a short-lived OAuth token with the cloud-platform scope.
 
 ## llm_call
 

--- a/docs/src/providers.md
+++ b/docs/src/providers.md
@@ -24,6 +24,9 @@ Each provider defines an `auth_style` and one or more environment variables:
 | OpenAI | `OPENAI_API_KEY` | bearer |
 | OpenRouter | `OPENROUTER_API_KEY` | bearer |
 | HuggingFace | `HF_TOKEN`, `HUGGINGFACE_API_KEY` | bearer |
+| Bedrock | AWS credential chain | SigV4 |
+| Azure OpenAI | `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_AD_TOKEN` | api-key or bearer |
+| Vertex AI | `VERTEX_AI_ACCESS_TOKEN`, `GOOGLE_APPLICATION_CREDENTIALS` | bearer |
 | Ollama | (none) | none |
 | Local | (none) | none |
 
@@ -82,6 +85,49 @@ The readiness probe checks `/v1/models` and reports distinct failures for
 an unreachable server, a bad HTTP status, an unparsable model listing, or
 a missing model. Harn does not run optional host launcher scripts; hosts
 should surface launcher failures separately and then re-run the probe.
+
+## Enterprise cloud providers
+
+### Bedrock
+
+Set `HARN_LLM_PROVIDER=bedrock`, a Bedrock model ID, and an AWS region:
+
+```bash
+export HARN_LLM_PROVIDER=bedrock
+export HARN_LLM_MODEL=anthropic.claude-3-5-sonnet-20240620-v1:0
+export AWS_REGION=us-east-1
+```
+
+Credential resolution follows AWS conventions: environment credentials,
+the selected/default profile, container credentials, then instance profile
+credentials. `BEDROCK_BASE_URL` can point tests at a local mock.
+
+### Azure OpenAI
+
+```bash
+export HARN_LLM_PROVIDER=azure_openai
+export AZURE_OPENAI_ENDPOINT=https://my-resource.openai.azure.com
+export AZURE_OPENAI_API_KEY=...
+export HARN_LLM_MODEL=my-gpt4o-deployment
+```
+
+Use `AZURE_OPENAI_DEPLOYMENT` when the deployment name should differ from
+the Harn model value. Set `AZURE_OPENAI_API_VERSION` to override the default
+API version. For Microsoft Entra auth, set `AZURE_OPENAI_AD_TOKEN` or
+`AZURE_OPENAI_BEARER_TOKEN` instead of an API key.
+
+### Vertex AI
+
+```bash
+export HARN_LLM_PROVIDER=vertex
+export HARN_LLM_MODEL=gemini-1.5-pro-002
+export VERTEX_AI_PROJECT=my-project
+export VERTEX_AI_LOCATION=us-central1
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+```
+
+Direct bearer tokens are also accepted through `VERTEX_AI_ACCESS_TOKEN` or
+`GOOGLE_OAUTH_ACCESS_TOKEN`.
 
 Harn will automatically fall back to a local provider if no cloud API key
 is configured. This makes it easy to develop and test without incurring


### PR DESCRIPTION
## Summary

Adds first-class enterprise LLM provider shims for issue #870:

- Bedrock Runtime via Converse API with hand-rolled AWS SigV4 signing and AWS env/profile/container/instance credential resolution.
- Azure OpenAI deployment-name routing with API-key and Entra bearer-token auth.
- Vertex AI Gemini generateContent routing with bearer-token and service-account JWT exchange support.

Also updates the provider registry, default provider config, capability matrix, provider inference rules, conformance coverage, and provider setup docs.

Closes #870.

## Validation

- `cargo test -p harn-vm llm::providers --lib`
- `cargo test -p harn-vm llm_config --lib`
- `cargo run --quiet --bin harn -- test conformance --filter provider_capabilities_basic`
- `cargo check -p harn-vm`
- pre-commit: Rust fmt, Harn fmt/lint, workspace clippy, markdownlint
- pre-push: 2918 nextest tests, affected Harn formatting/lint, markdownlint

## Self-review notes

Reviewed the new auth and request-shape paths for credential leakage, URL construction, provider overrides, non-Send off-thread dispatch, and response/tool-call normalization. The review found and fixed one gap: Bedrock/Azure/Vertex now apply existing `provider_overrides` before sending requests.
