### PR TITLE
Add multimodal image content support

### DIFF
--- a/conformance/tests/integration/llm_call_image_content.expected
+++ b/conformance/tests/integration/llm_call_image_content.expected
@@ -1,0 +1,1 @@
+[harn] llm_call_image_content tests passed

--- a/conformance/tests/integration/llm_call_image_content.harn
+++ b/conformance/tests/integration/llm_call_image_content.harn
@@ -1,0 +1,49 @@
+pipeline test(task) {
+  llm_mock_clear()
+  let png_path = "vision_fixture.png"
+  write_file_bytes(
+    png_path,
+    bytes_from_hex(
+      "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c63000100000500010d0a2db40000000049454e44ae426082",
+    ),
+  )
+  let png = read_file_bytes(png_path)
+  let image_base64 = bytes_to_base64(png)
+  delete_file(png_path)
+  llm_mock({text: "seen"})
+  let result = llm_call(
+    "",
+    nil,
+    {
+      provider: "mock",
+      model: "gpt-4o",
+      vision: true,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {type: "text", text: "Caption the image."},
+            {type: "image", base64: image_base64, media_type: "image/png", detail: "low"},
+          ],
+        },
+      ],
+    },
+  )
+  assert_eq(result.text, "seen")
+  let calls = llm_mock_calls()
+  assert_eq(len(calls), 1)
+  let blocks = calls[0].messages[0].content
+  assert_eq(blocks[0].type, "text")
+  assert_eq(blocks[1].type, "image")
+  assert_eq(blocks[1].media_type, "image/png")
+  assert_eq(blocks[1].base64, image_base64)
+  assert_eq(blocks[1].detail, "low")
+  let gate_error = try {
+    llm_call("plain", nil, {provider: "mock", model: "gpt-3.5-turbo", vision: true})
+    "unreachable"
+  } catch (e) {
+    e
+  }
+  assert(contains(gate_error, "vision_supported"), "vision gate should reject non-vision models")
+  log("llm_call_image_content tests passed")
+}

--- a/conformance/tests/integration/provider_capabilities_basic.harn
+++ b/conformance/tests/integration/provider_capabilities_basic.harn
@@ -17,6 +17,7 @@ pipeline test(task) {
   assert(opus.prompt_caching, "Opus 4.7 supports prompt caching")
   assert(opus.thinking, "Opus 4.7 exposes adaptive thinking")
   assert(opus.thinking_modes[0] == "adaptive", "Opus 4.7 exposes adaptive thinking mode")
+  assert(opus.vision_supported, "Opus 4.7 accepts image content")
   assert(opus.max_tools == 10000, "Opus 4.7 max_tools cap is 10000")
   // Older Claude — no tool search, still cache + thinking.
   let old = provider_capabilities("anthropic", "claude-opus-3-5")
@@ -39,12 +40,16 @@ pipeline test(task) {
   // Legacy GPT — native tools only.
   let gpt4o = provider_capabilities("openai", "gpt-4o")
   assert(gpt4o.native_tools, "gpt-4o has native tools")
+  assert(gpt4o.vision_supported, "gpt-4o accepts image content")
   assert(!gpt4o.defer_loading, "gpt-4o has no defer_loading")
   let o3 = provider_capabilities("openai", "o3")
   assert(o3.thinking_modes[0] == "effort", "o3 exposes effort thinking mode")
   // Ollama Qwen 3.5 advertises native tools on the official model page.
   let qwen35 = provider_capabilities("ollama", "qwen3.5:35b-a3b-coding-nvfp4")
   assert(qwen35.native_tools, "qwen3.5 on ollama has native tools")
+  assert(!qwen35.vision_supported, "qwen3.5 is not a vision route")
+  let gemini = provider_capabilities("gemini", "gemini-2.5-flash")
+  assert(gemini.vision_supported, "gemini native route accepts image content")
   // OpenRouter inherits the openai family.
   let routed = provider_capabilities("openrouter", "gpt-5.4")
   assert(routed.defer_loading, "openrouter inherits openai defer_loading")

--- a/crates/harn-vm/src/llm/agent/tests/mod.rs
+++ b/crates/harn-vm/src/llm/agent/tests/mod.rs
@@ -66,6 +66,7 @@ pub(super) fn base_opts(messages: Vec<serde_json::Value>) -> LlmCallOptions {
         output_schema: None,
         output_validation: None,
         thinking: crate::llm::api::ThinkingConfig::Disabled,
+        vision: false,
         tools: None,
         native_tools: None,
         tool_choice: None,

--- a/crates/harn-vm/src/llm/api/options.rs
+++ b/crates/harn-vm/src/llm/api/options.rs
@@ -315,6 +315,8 @@ pub(crate) struct LlmCallOptions {
 
     // --- Thinking ---
     pub thinking: ThinkingConfig,
+    /// True when the call explicitly asks for vision or contains image blocks.
+    pub vision: bool,
 
     // --- Tools ---
     pub tools: Option<VmValue>,
@@ -400,6 +402,7 @@ pub(crate) struct LlmRequestPayload {
     pub response_format: Option<String>,
     pub json_schema: Option<serde_json::Value>,
     pub thinking: ThinkingConfig,
+    pub vision: bool,
     pub native_tools: Option<Vec<serde_json::Value>>,
     pub tool_choice: Option<serde_json::Value>,
     pub cache: bool,
@@ -440,6 +443,7 @@ impl From<&LlmCallOptions> for LlmRequestPayload {
             response_format: opts.response_format.clone(),
             json_schema: opts.json_schema.clone(),
             thinking: opts.thinking.clone(),
+            vision: opts.vision,
             native_tools: opts.native_tools.clone(),
             tool_choice: opts.tool_choice.clone(),
             cache: opts.cache,
@@ -479,6 +483,7 @@ pub(super) fn base_opts(provider: &str) -> LlmCallOptions {
         output_schema: Some(serde_json::json!({"type": "object"})),
         output_validation: Some("error".to_string()),
         thinking: ThinkingConfig::Disabled,
+        vision: false,
         tools: Some(VmValue::String(Rc::from("vm-local-tools"))),
         native_tools: Some(vec![
             serde_json::json!({"type": "function", "function": {"name": "tool"}}),

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -194,6 +194,11 @@ async fn dispatch_to_registered_provider(
         return ollama.chat_impl(opts, delta_tx).await;
     }
 
+    if provider == "gemini" {
+        let gemini = crate::llm::providers::GeminiProvider;
+        return gemini.chat_impl(opts, delta_tx).await;
+    }
+
     if resolved.is_anthropic_style {
         let anthropic = crate::llm::providers::AnthropicProvider;
         return anthropic.chat_impl(opts, delta_tx).await;

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -74,6 +74,9 @@ pub struct ProviderRule {
     /// `thinking_modes` so the capability matrix preserves mode detail.
     #[serde(default)]
     pub thinking: Option<bool>,
+    /// Whether the model accepts image inputs in chat content.
+    #[serde(default)]
+    pub vision_supported: Option<bool>,
     /// Carry `<think>...</think>` blocks in assistant history across turns.
     /// Qwen3.6 exposes this as `chat_template_kwargs.preserve_thinking`;
     /// Alibaba recommends enabling it for long-horizon agent loops so the
@@ -113,6 +116,7 @@ pub struct Capabilities {
     pub max_tools: Option<u32>,
     pub prompt_caching: bool,
     pub thinking_modes: Vec<String>,
+    pub vision_supported: bool,
     pub preserve_thinking: bool,
     pub server_parser: String,
     pub honors_chat_template_kwargs: bool,
@@ -129,6 +133,7 @@ impl Default for Capabilities {
             max_tools: None,
             prompt_caching: false,
             thinking_modes: Vec::new(),
+            vision_supported: false,
             preserve_thinking: false,
             server_parser: "none".to_string(),
             honors_chat_template_kwargs: false,
@@ -296,6 +301,7 @@ fn rule_to_caps(rule: &ProviderRule) -> Capabilities {
         max_tools: rule.max_tools,
         prompt_caching: rule.prompt_caching.unwrap_or(false),
         thinking_modes,
+        vision_supported: rule.vision_supported.unwrap_or(false),
         preserve_thinking: rule.preserve_thinking.unwrap_or(false),
         server_parser: rule
             .server_parser
@@ -380,6 +386,7 @@ mod tests {
         assert_eq!(caps.tool_search, vec!["bm25", "regex"]);
         assert!(caps.prompt_caching);
         assert_eq!(caps.thinking_modes, vec!["adaptive"]);
+        assert!(caps.vision_supported);
         assert_eq!(caps.max_tools, Some(10000));
     }
 
@@ -433,6 +440,7 @@ mod tests {
         let caps = lookup("openai", "gpt-5.3");
         assert!(caps.native_tools);
         assert!(!caps.defer_loading);
+        assert!(!caps.vision_supported);
         assert!(caps.tool_search.is_empty());
     }
 
@@ -441,6 +449,19 @@ mod tests {
         reset();
         let caps = lookup("openai", "o3");
         assert_eq!(caps.thinking_modes, vec!["effort"]);
+    }
+
+    #[test]
+    fn vision_capability_gates_known_multimodal_models() {
+        reset();
+        assert!(lookup("openai", "gpt-4o").vision_supported);
+        assert!(lookup("openai", "gpt-5.4-preview").vision_supported);
+        assert!(lookup("anthropic", "claude-sonnet-4-6").vision_supported);
+        assert!(lookup("openrouter", "google/gemini-2.5-flash").vision_supported);
+        assert!(lookup("gemini", "gemini-2.5-flash").vision_supported);
+        assert!(lookup("ollama", "llava:latest").vision_supported);
+        assert!(!lookup("openai", "gpt-3.5-turbo").vision_supported);
+        assert!(!lookup("ollama", "qwen3.5:35b-a3b-coding-nvfp4").vision_supported);
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -30,6 +30,7 @@
 #                     Used by harn-lint to warn about oversized registries.
 #   prompt_caching  : whether the provider honors cache_control blocks.
 #   thinking_modes  : supported script-facing modes: enabled, adaptive, effort.
+#   vision_supported: whether image content blocks are accepted.
 #   preserve_thinking: whether prior <think> blocks should be carried forward.
 #   server_parser   : server-side response parser that transforms model output.
 #   honors_chat_template_kwargs: whether chat_template_kwargs are honored.
@@ -48,6 +49,7 @@ tool_search = ["bm25", "regex"]
 max_tools = 10000
 prompt_caching = true
 thinking_modes = ["adaptive"]
+vision_supported = true
 
 [[provider.anthropic]]
 model_match = "claude-opus-*"
@@ -58,6 +60,7 @@ tool_search = ["bm25", "regex"]
 max_tools = 10000
 prompt_caching = true
 thinking_modes = ["adaptive"]
+vision_supported = true
 
 [[provider.anthropic]]
 model_match = "claude-sonnet-*"
@@ -68,6 +71,7 @@ tool_search = ["bm25", "regex"]
 max_tools = 10000
 prompt_caching = true
 thinking_modes = ["adaptive"]
+vision_supported = true
 
 # Haiku 4.5+ supports server-side tool search.
 [[provider.anthropic]]
@@ -79,6 +83,7 @@ tool_search = ["bm25", "regex"]
 max_tools = 10000
 prompt_caching = true
 thinking_modes = ["enabled"]
+vision_supported = true
 
 # Opus 4.0+ supports tool search.
 [[provider.anthropic]]
@@ -90,6 +95,7 @@ tool_search = ["bm25", "regex"]
 max_tools = 10000
 prompt_caching = true
 thinking_modes = ["enabled"]
+vision_supported = true
 
 # Sonnet 4.0+ supports tool search.
 [[provider.anthropic]]
@@ -101,6 +107,7 @@ tool_search = ["bm25", "regex"]
 max_tools = 10000
 prompt_caching = true
 thinking_modes = ["enabled"]
+vision_supported = true
 
 # OpenRouter-style `anthropic/claude-...` prefixes.
 [[provider.anthropic]]
@@ -112,6 +119,7 @@ tool_search = ["bm25", "regex"]
 max_tools = 10000
 prompt_caching = true
 thinking_modes = ["adaptive"]
+vision_supported = true
 
 [[provider.anthropic]]
 model_match = "anthropic/claude-opus-*"
@@ -122,6 +130,7 @@ tool_search = ["bm25", "regex"]
 max_tools = 10000
 prompt_caching = true
 thinking_modes = ["adaptive"]
+vision_supported = true
 
 [[provider.anthropic]]
 model_match = "anthropic/claude-sonnet-*"
@@ -132,6 +141,7 @@ tool_search = ["bm25", "regex"]
 max_tools = 10000
 prompt_caching = true
 thinking_modes = ["adaptive"]
+vision_supported = true
 
 [[provider.anthropic]]
 model_match = "anthropic/claude-haiku-*"
@@ -142,6 +152,7 @@ tool_search = ["bm25", "regex"]
 max_tools = 10000
 prompt_caching = true
 thinking_modes = ["enabled"]
+vision_supported = true
 
 [[provider.anthropic]]
 model_match = "anthropic/claude-opus-*"
@@ -152,6 +163,7 @@ tool_search = ["bm25", "regex"]
 max_tools = 10000
 prompt_caching = true
 thinking_modes = ["enabled"]
+vision_supported = true
 
 [[provider.anthropic]]
 model_match = "anthropic/claude-sonnet-*"
@@ -162,6 +174,7 @@ tool_search = ["bm25", "regex"]
 max_tools = 10000
 prompt_caching = true
 thinking_modes = ["enabled"]
+vision_supported = true
 
 # Catch-all for older Claude models — native tools + prompt caching +
 # thinking, but no progressive tool disclosure.
@@ -170,6 +183,7 @@ model_match = "claude-*"
 native_tools = true
 prompt_caching = true
 thinking_modes = ["enabled"]
+vision_supported = true
 
 # ---------- OpenAI family -----------------------------------------------------
 #
@@ -185,6 +199,17 @@ version_min = [5, 4]
 native_tools = true
 defer_loading = true
 tool_search = ["hosted", "client"]
+vision_supported = true
+
+[[provider.openai]]
+model_match = "gpt-4o*"
+native_tools = true
+vision_supported = true
+
+[[provider.openai]]
+model_match = "gpt-4.1*"
+native_tools = true
+vision_supported = true
 
 # Legacy GPT: native tool calls only.
 [[provider.openai]]
@@ -206,6 +231,7 @@ thinking_modes = ["effort"]
 model_match = "o4*"
 native_tools = true
 thinking_modes = ["effort"]
+vision_supported = true
 
 # OpenRouter-style provider-prefixed IDs.
 [[provider.openai]]
@@ -214,6 +240,17 @@ version_min = [5, 4]
 native_tools = true
 defer_loading = true
 tool_search = ["hosted", "client"]
+vision_supported = true
+
+[[provider.openai]]
+model_match = "openai/gpt-4o*"
+native_tools = true
+vision_supported = true
+
+[[provider.openai]]
+model_match = "openai/gpt-4.1*"
+native_tools = true
+vision_supported = true
 
 [[provider.openai]]
 model_match = "openai/gpt-*"
@@ -227,6 +264,22 @@ native_tools = true
 # official docs + model pages. Qwen 3.6 adds `preserve_thinking` which
 # Alibaba recommends for multi-turn agentic / coding workflows (the
 # flagship use case we're building for) — keep it on by default.
+
+[[provider.ollama]]
+model_match = "llava*"
+vision_supported = true
+
+[[provider.ollama]]
+model_match = "bakllava*"
+vision_supported = true
+
+[[provider.ollama]]
+model_match = "llama3.2-vision*"
+vision_supported = true
+
+[[provider.ollama]]
+model_match = "gemma3*"
+vision_supported = true
 
 [[provider.ollama]]
 model_match = "qwen3.6*"
@@ -478,6 +531,15 @@ model_match = "google/gemini-2.5*"
 native_tools = true
 thinking_modes = ["enabled", "effort"]
 prompt_caching = true
+vision_supported = true
+
+[[provider.gemini]]
+model_match = "gemini-*"
+vision_supported = true
+
+[[provider.gemini]]
+model_match = "models/gemini-*"
+vision_supported = true
 
 [[provider.openrouter]]
 model_match = "google/gemma-4*"

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -544,6 +544,10 @@ fn capabilities_to_vm_value(
         string_list_to_vm_value(caps.thinking_modes.clone()),
     );
     dict.insert(
+        "vision_supported".to_string(),
+        VmValue::Bool(caps.vision_supported),
+    );
+    dict.insert(
         "preserve_thinking".to_string(),
         VmValue::Bool(caps.preserve_thinking),
     );

--- a/crates/harn-vm/src/llm/content.rs
+++ b/crates/harn-vm/src/llm/content.rs
@@ -1,0 +1,330 @@
+//! Provider-neutral multimodal content helpers.
+//!
+//! Harn scripts represent image inputs as content blocks:
+//! `{type: "image", url?: string, base64?: string, media_type: string, detail?: "low"|"high"|"auto"}`.
+//! Provider serializers translate that one shape into their native wire format.
+
+use std::rc::Rc;
+
+use crate::value::{VmError, VmValue};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ImageContent {
+    pub url: Option<String>,
+    pub base64: Option<String>,
+    pub media_type: String,
+    pub detail: Option<String>,
+}
+
+impl ImageContent {
+    fn from_block(block: &serde_json::Value) -> Result<Option<Self>, VmError> {
+        if block.get("type").and_then(|value| value.as_str()) != Some("image") {
+            return Ok(None);
+        }
+        let url = block
+            .get("url")
+            .or_else(|| block.get("file_uri"))
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let base64 = block
+            .get("base64")
+            .or_else(|| block.get("data"))
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        if url.is_some() == base64.is_some() {
+            return Err(VmError::Thrown(VmValue::String(Rc::from(
+                "llm_call image content requires exactly one of url or base64",
+            ))));
+        }
+        let media_type = block
+            .get("media_type")
+            .or_else(|| block.get("mime_type"))
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                VmError::Thrown(VmValue::String(Rc::from(
+                    "llm_call image content requires media_type",
+                )))
+            })?
+            .to_string();
+        let detail = block
+            .get("detail")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        if let Some(detail) = detail.as_deref() {
+            if !matches!(detail, "low" | "high" | "auto") {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(
+                    "llm_call image detail must be \"low\", \"high\", or \"auto\"",
+                ))));
+            }
+        }
+        Ok(Some(Self {
+            url,
+            base64,
+            media_type,
+            detail,
+        }))
+    }
+
+    pub(crate) fn openai_url(&self) -> String {
+        self.url.clone().unwrap_or_else(|| {
+            format!(
+                "data:{};base64,{}",
+                self.media_type,
+                self.base64.as_deref().unwrap_or_default()
+            )
+        })
+    }
+}
+
+pub(crate) fn parse_image_block(
+    block: &serde_json::Value,
+) -> Result<Option<ImageContent>, VmError> {
+    ImageContent::from_block(block)
+}
+
+pub(crate) fn messages_contain_images(messages: &[serde_json::Value]) -> Result<bool, VmError> {
+    for message in messages {
+        if message
+            .get("images")
+            .and_then(|value| value.as_array())
+            .is_some_and(|images| !images.is_empty())
+        {
+            return Ok(true);
+        }
+        match message.get("content") {
+            Some(serde_json::Value::Array(blocks)) => {
+                for block in blocks {
+                    if parse_image_block(block)?.is_some() {
+                        return Ok(true);
+                    }
+                }
+            }
+            Some(content @ serde_json::Value::Object(_)) => {
+                let contains_image = parse_image_block(content)?.is_some();
+                if contains_image {
+                    return Ok(true);
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(false)
+}
+
+pub(crate) fn messages_contain_url_images(messages: &[serde_json::Value]) -> Result<bool, VmError> {
+    for message in messages {
+        match message.get("content") {
+            Some(serde_json::Value::Array(blocks)) => {
+                for block in blocks {
+                    if parse_image_block(block)?.is_some_and(|image| image.url.is_some()) {
+                        return Ok(true);
+                    }
+                }
+            }
+            Some(content @ serde_json::Value::Object(_)) => {
+                let contains_url_image =
+                    parse_image_block(content)?.is_some_and(|image| image.url.is_some());
+                if contains_url_image {
+                    return Ok(true);
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(false)
+}
+
+fn normalized_text_block(block: &serde_json::Value) -> Option<serde_json::Value> {
+    let block_type = block.get("type").and_then(|value| value.as_str());
+    match block_type {
+        Some("text") | Some("output_text") => Some(serde_json::json!({
+            "type": "text",
+            "text": block.get("text").and_then(|value| value.as_str()).unwrap_or_default(),
+        })),
+        _ => None,
+    }
+}
+
+pub(crate) fn anthropic_content(content: &serde_json::Value) -> serde_json::Value {
+    match content {
+        serde_json::Value::Array(blocks) => {
+            let mut out = Vec::new();
+            for block in blocks {
+                if let Ok(Some(image)) = parse_image_block(block) {
+                    let source = match (image.base64, image.url) {
+                        (Some(data), None) => serde_json::json!({
+                            "type": "base64",
+                            "media_type": image.media_type,
+                            "data": data,
+                        }),
+                        (None, Some(url)) => serde_json::json!({
+                            "type": "url",
+                            "url": url,
+                        }),
+                        _ => continue,
+                    };
+                    out.push(serde_json::json!({"type": "image", "source": source}));
+                } else if let Some(text) = normalized_text_block(block) {
+                    out.push(text);
+                } else {
+                    out.push(block.clone());
+                }
+            }
+            serde_json::Value::Array(out)
+        }
+        serde_json::Value::Object(_) => {
+            if let Ok(Some(image)) = parse_image_block(content) {
+                anthropic_content(&serde_json::Value::Array(vec![serde_json::json!(
+                    image_to_neutral_json(&image)
+                )]))
+            } else {
+                content.clone()
+            }
+        }
+        _ => content.clone(),
+    }
+}
+
+pub(crate) fn openai_content(content: &serde_json::Value) -> serde_json::Value {
+    match content {
+        serde_json::Value::Array(blocks) => {
+            let mut out = Vec::new();
+            for block in blocks {
+                if let Ok(Some(image)) = parse_image_block(block) {
+                    let mut image_url = serde_json::json!({"url": image.openai_url()});
+                    if let Some(detail) = image.detail {
+                        image_url["detail"] = serde_json::json!(detail);
+                    }
+                    out.push(serde_json::json!({
+                        "type": "image_url",
+                        "image_url": image_url,
+                    }));
+                } else if let Some(text) = normalized_text_block(block) {
+                    out.push(text);
+                } else {
+                    out.push(block.clone());
+                }
+            }
+            serde_json::Value::Array(out)
+        }
+        serde_json::Value::Object(_) => {
+            if let Ok(Some(image)) = parse_image_block(content) {
+                let mut image_url = serde_json::json!({"url": image.openai_url()});
+                if let Some(detail) = image.detail {
+                    image_url["detail"] = serde_json::json!(detail);
+                }
+                serde_json::Value::Array(vec![serde_json::json!({
+                    "type": "image_url",
+                    "image_url": image_url,
+                })])
+            } else {
+                content.clone()
+            }
+        }
+        _ => content.clone(),
+    }
+}
+
+pub(crate) fn ollama_message(mut message: serde_json::Value) -> serde_json::Value {
+    let Some(object) = message.as_object_mut() else {
+        return message;
+    };
+    let Some(content) = object.get("content").cloned() else {
+        return message;
+    };
+    let serde_json::Value::Array(blocks) = content else {
+        return message;
+    };
+    let mut text_parts = Vec::new();
+    let mut images = Vec::new();
+    let mut passthrough = Vec::new();
+    for block in blocks {
+        if let Ok(Some(image)) = parse_image_block(&block) {
+            if let Some(base64) = image.base64 {
+                images.push(serde_json::Value::String(base64));
+            }
+            continue;
+        }
+        if let Some(text) = normalized_text_block(&block) {
+            if let Some(value) = text.get("text").and_then(|value| value.as_str()) {
+                if !value.is_empty() {
+                    text_parts.push(value.to_string());
+                }
+            }
+        } else {
+            passthrough.push(block);
+        }
+    }
+    if !text_parts.is_empty() {
+        object.insert(
+            "content".to_string(),
+            serde_json::Value::String(text_parts.join("\n\n")),
+        );
+    }
+    if !images.is_empty() {
+        object.insert("images".to_string(), serde_json::Value::Array(images));
+    }
+    if text_parts.is_empty() && !passthrough.is_empty() {
+        object.insert("content".to_string(), serde_json::Value::Array(passthrough));
+    }
+    message
+}
+
+pub(crate) fn gemini_parts(content: &serde_json::Value) -> Vec<serde_json::Value> {
+    match content {
+        serde_json::Value::String(text) => vec![serde_json::json!({"text": text})],
+        serde_json::Value::Array(blocks) => blocks
+            .iter()
+            .filter_map(|block| {
+                if let Ok(Some(image)) = parse_image_block(block) {
+                    if let Some(data) = image.base64 {
+                        return Some(serde_json::json!({
+                            "inline_data": {
+                                "mime_type": image.media_type,
+                                "data": data,
+                            }
+                        }));
+                    }
+                    if let Some(file_uri) = image.url {
+                        return Some(serde_json::json!({
+                            "file_data": {
+                                "mime_type": image.media_type,
+                                "file_uri": file_uri,
+                            }
+                        }));
+                    }
+                }
+                if let Some(text) = normalized_text_block(block) {
+                    return Some(serde_json::json!({
+                        "text": text.get("text").and_then(|value| value.as_str()).unwrap_or_default(),
+                    }));
+                }
+                block.get("text")
+                    .and_then(|value| value.as_str())
+                    .map(|text| serde_json::json!({"text": text}))
+            })
+            .collect(),
+        other => vec![serde_json::json!({"text": other.to_string()})],
+    }
+}
+
+fn image_to_neutral_json(image: &ImageContent) -> serde_json::Value {
+    let mut value = serde_json::json!({
+        "type": "image",
+        "media_type": image.media_type,
+    });
+    if let Some(url) = image.url.as_ref() {
+        value["url"] = serde_json::json!(url);
+    }
+    if let Some(base64) = image.base64.as_ref() {
+        value["base64"] = serde_json::json!(base64);
+    }
+    if let Some(detail) = image.detail.as_ref() {
+        value["detail"] = serde_json::json!(detail);
+    }
+    value
+}

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -409,6 +409,21 @@ pub(crate) fn extract_llm_options(
     } else {
         vec![serde_json::json!({"role": "user", "content": prompt})]
     };
+    let vision =
+        opt_bool(&options, "vision") || crate::llm::content::messages_contain_images(&messages)?;
+    if vision && !crate::llm::capabilities::lookup(&provider, &model).vision_supported {
+        return Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(format!(
+            "llm_call: provider \"{provider}\" model \"{model}\" does not declare vision_supported=true"
+        )))));
+    }
+    if vision
+        && provider == "ollama"
+        && crate::llm::content::messages_contain_url_images(&messages)?
+    {
+        return Err(VmError::Thrown(VmValue::String(std::rc::Rc::from(
+            "llm_call: provider \"ollama\" requires image base64; url image content is not supported",
+        ))));
+    }
 
     let tools_val = options.as_ref().and_then(|o| o.get("tools")).cloned();
     let mut native_tools = if let Some(tools) = &tools_val {
@@ -663,6 +678,7 @@ pub(crate) fn extract_llm_options(
         output_schema,
         output_validation,
         thinking,
+        vision,
         tools: tools_val,
         native_tools,
         tool_choice,
@@ -1285,5 +1301,89 @@ mod routing_tests {
                 level: crate::llm::api::ReasoningEffort::High
             }
         );
+    }
+
+    #[test]
+    fn image_content_sets_vision_and_requires_capability() {
+        let image_block = VmValue::Dict(Rc::new(BTreeMap::from([
+            ("type".to_string(), VmValue::String(Rc::from("image"))),
+            (
+                "base64".to_string(),
+                VmValue::String(Rc::from("iVBORw0KGgo=")),
+            ),
+            (
+                "media_type".to_string(),
+                VmValue::String(Rc::from("image/png")),
+            ),
+        ])));
+        let message = VmValue::Dict(Rc::new(BTreeMap::from([
+            ("role".to_string(), VmValue::String(Rc::from("user"))),
+            (
+                "content".to_string(),
+                VmValue::List(Rc::new(vec![image_block.clone()])),
+            ),
+        ])));
+        let options = VmValue::Dict(Rc::new(BTreeMap::from([
+            ("provider".to_string(), VmValue::String(Rc::from("mock"))),
+            ("model".to_string(), VmValue::String(Rc::from("gpt-4o"))),
+            (
+                "messages".to_string(),
+                VmValue::List(Rc::new(vec![message.clone()])),
+            ),
+        ])));
+        let opts =
+            extract_llm_options(&[VmValue::String(Rc::from("")), VmValue::Nil, options]).unwrap();
+        assert!(opts.vision);
+
+        let bad_options = VmValue::Dict(Rc::new(BTreeMap::from([
+            ("provider".to_string(), VmValue::String(Rc::from("mock"))),
+            (
+                "model".to_string(),
+                VmValue::String(Rc::from("gpt-3.5-turbo")),
+            ),
+            (
+                "messages".to_string(),
+                VmValue::List(Rc::new(vec![message])),
+            ),
+        ])));
+        let err = extract_llm_options(&[VmValue::String(Rc::from("")), VmValue::Nil, bad_options])
+            .err()
+            .expect("non-vision model should reject image content");
+        assert!(err.to_string().contains("vision_supported"));
+
+        let url_image = VmValue::Dict(Rc::new(BTreeMap::from([
+            ("type".to_string(), VmValue::String(Rc::from("image"))),
+            (
+                "url".to_string(),
+                VmValue::String(Rc::from("https://example.com/image.png")),
+            ),
+            (
+                "media_type".to_string(),
+                VmValue::String(Rc::from("image/png")),
+            ),
+        ])));
+        let url_message = VmValue::Dict(Rc::new(BTreeMap::from([
+            ("role".to_string(), VmValue::String(Rc::from("user"))),
+            (
+                "content".to_string(),
+                VmValue::List(Rc::new(vec![url_image])),
+            ),
+        ])));
+        let ollama_options = VmValue::Dict(Rc::new(BTreeMap::from([
+            ("provider".to_string(), VmValue::String(Rc::from("ollama"))),
+            (
+                "model".to_string(),
+                VmValue::String(Rc::from("llava:latest")),
+            ),
+            (
+                "messages".to_string(),
+                VmValue::List(Rc::new(vec![url_message])),
+            ),
+        ])));
+        let err =
+            extract_llm_options(&[VmValue::String(Rc::from("")), VmValue::Nil, ollama_options])
+                .err()
+                .expect("ollama should reject url image content");
+        assert!(err.to_string().contains("requires image base64"));
     }
 }

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -18,6 +18,7 @@ mod agent_tools;
 pub(crate) mod api;
 pub mod capabilities;
 mod config_builtins;
+pub(crate) mod content;
 mod conversation;
 pub(crate) mod cost;
 pub(crate) mod daemon;
@@ -1557,6 +1558,7 @@ mod tests {
             })),
             output_validation: Some("error".to_string()),
             thinking: crate::llm::api::ThinkingConfig::Disabled,
+            vision: false,
             tools: None,
             native_tools: None,
             tool_choice: None,

--- a/crates/harn-vm/src/llm/provider.rs
+++ b/crates/harn-vm/src/llm/provider.rs
@@ -113,6 +113,7 @@ pub(crate) fn register_default_providers() {
         }
         names.insert("mock".to_string());
         names.insert("anthropic".to_string());
+        names.insert("gemini".to_string());
         names.insert("ollama".to_string());
         for name in [
             "openai",

--- a/crates/harn-vm/src/llm/providers/anthropic.rs
+++ b/crates/harn-vm/src/llm/providers/anthropic.rs
@@ -216,7 +216,22 @@ impl AnthropicProvider {
         } else {
             8192
         };
-        let mut messages = opts.messages.clone();
+        let mut messages: Vec<serde_json::Value> = opts
+            .messages
+            .iter()
+            .cloned()
+            .map(|mut message| {
+                if let Some(object) = message.as_object_mut() {
+                    if let Some(content) = object.get("content").cloned() {
+                        object.insert(
+                            "content".to_string(),
+                            crate::llm::content::anthropic_content(&content),
+                        );
+                    }
+                }
+                message
+            })
+            .collect();
         if let Some(ref prefill) = opts.prefill {
             // Claude 4.6+ deprecated the assistant-prefill feature and
             // returns HTTP 400 when the final message is role=assistant.
@@ -362,6 +377,7 @@ mod tests {
             response_format: None,
             json_schema: None,
             thinking: ThinkingConfig::Disabled,
+            vision: false,
             native_tools: Some(vec![serde_json::json!({
                 "name": "read_file",
                 "description": "Read a file",
@@ -457,6 +473,55 @@ mod tests {
         );
         assert_eq!(info.kind, LlmErrorKind::Terminal);
         assert_eq!(info.reason, LlmErrorReason::AuthFailure);
+    }
+
+    #[test]
+    fn image_content_maps_to_anthropic_source_block() {
+        let mut payload = base_payload();
+        payload.messages = vec![serde_json::json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "caption"},
+                {"type": "image", "base64": "iVBORw0KGgo=", "media_type": "image/png"}
+            ],
+        })];
+
+        let body = AnthropicProvider::build_request_body(&payload);
+        assert_eq!(body["messages"][0]["content"][0]["text"], "caption");
+        assert_eq!(
+            body["messages"][0]["content"][1],
+            serde_json::json!({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "iVBORw0KGgo=",
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn image_url_content_maps_to_anthropic_url_source() {
+        let mut payload = base_payload();
+        payload.messages = vec![serde_json::json!({
+            "role": "user",
+            "content": [
+                {"type": "image", "url": "https://example.com/image.png", "media_type": "image/png"}
+            ],
+        })];
+
+        let body = AnthropicProvider::build_request_body(&payload);
+        assert_eq!(
+            body["messages"][0]["content"][0],
+            serde_json::json!({
+                "type": "image",
+                "source": {
+                    "type": "url",
+                    "url": "https://example.com/image.png",
+                }
+            })
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/providers/gemini.rs
+++ b/crates/harn-vm/src/llm/providers/gemini.rs
@@ -1,0 +1,282 @@
+//! Google Gemini provider.
+
+use std::rc::Rc;
+
+use crate::llm::api::{DeltaSender, LlmRequestPayload, LlmResult};
+use crate::llm::provider::{LlmProvider, LlmProviderChat};
+use crate::value::{VmError, VmValue};
+
+pub(crate) struct GeminiProvider;
+
+impl LlmProvider for GeminiProvider {
+    fn name(&self) -> &str {
+        "gemini"
+    }
+}
+
+impl LlmProviderChat for GeminiProvider {
+    fn chat<'a>(
+        &'a self,
+        request: &'a LlmRequestPayload,
+        delta_tx: Option<DeltaSender>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<LlmResult, VmError>> + 'a>> {
+        Box::pin(self.chat_impl(request, delta_tx))
+    }
+}
+
+impl GeminiProvider {
+    pub(crate) fn build_request_body(opts: &LlmRequestPayload) -> serde_json::Value {
+        let mut contents = Vec::new();
+        for message in &opts.messages {
+            let role = match message.get("role").and_then(|value| value.as_str()) {
+                Some("assistant" | "model") => "model",
+                _ => "user",
+            };
+            let content = message.get("content").unwrap_or(&serde_json::Value::Null);
+            let parts = crate::llm::content::gemini_parts(content);
+            if !parts.is_empty() {
+                contents.push(serde_json::json!({
+                    "role": role,
+                    "parts": parts,
+                }));
+            }
+        }
+
+        let mut body = serde_json::json!({ "contents": contents });
+        if let Some(system) = opts.system.as_deref().filter(|value| !value.is_empty()) {
+            body["system_instruction"] = serde_json::json!({
+                "parts": [{"text": system}],
+            });
+        }
+        let mut generation_config = serde_json::Map::new();
+        if opts.max_tokens > 0 {
+            generation_config.insert(
+                "maxOutputTokens".to_string(),
+                serde_json::json!(opts.max_tokens),
+            );
+        }
+        if let Some(temp) = opts.temperature {
+            generation_config.insert("temperature".to_string(), serde_json::json!(temp));
+        }
+        if let Some(top_p) = opts.top_p {
+            generation_config.insert("topP".to_string(), serde_json::json!(top_p));
+        }
+        if let Some(top_k) = opts.top_k {
+            generation_config.insert("topK".to_string(), serde_json::json!(top_k));
+        }
+        if let Some(stop) = &opts.stop {
+            generation_config.insert("stopSequences".to_string(), serde_json::json!(stop));
+        }
+        if !generation_config.is_empty() {
+            body["generationConfig"] = serde_json::Value::Object(generation_config);
+        }
+        if let Some(overrides) = opts
+            .provider_overrides
+            .as_ref()
+            .and_then(|value| value.as_object())
+        {
+            for (key, value) in overrides {
+                body[key] = value.clone();
+            }
+        }
+        body
+    }
+
+    pub(crate) async fn chat_impl(
+        &self,
+        request: &LlmRequestPayload,
+        delta_tx: Option<DeltaSender>,
+    ) -> Result<LlmResult, VmError> {
+        let body = Self::build_request_body(request);
+        let pdef = crate::llm_config::provider_config(&request.provider);
+        let base_url = pdef
+            .as_ref()
+            .map(crate::llm_config::resolve_base_url)
+            .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string());
+        let model = request
+            .model
+            .strip_prefix("models/")
+            .unwrap_or(&request.model);
+        let url = format!("{base_url}/v1beta/models/{model}:generateContent");
+        let client = crate::llm::shared_blocking_client().clone();
+        let req = client
+            .post(url)
+            .header("Content-Type", "application/json")
+            .timeout(std::time::Duration::from_secs(request.resolve_timeout()))
+            .json(&body);
+        let req = crate::llm::api::apply_auth_headers(req, &request.api_key, pdef.as_ref());
+        let response = req.send().await.map_err(|error| {
+            VmError::Thrown(VmValue::String(Rc::from(format!(
+                "gemini API error: {error}"
+            ))))
+        })?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                "gemini API error HTTP {status}: {body}"
+            )))));
+        }
+        let json: serde_json::Value = response.json().await.map_err(|error| {
+            VmError::Thrown(VmValue::String(Rc::from(format!(
+                "gemini response parse error: {error}"
+            ))))
+        })?;
+        let result = parse_response(&json, request)?;
+        if let Some(tx) = delta_tx {
+            if !result.text.is_empty() {
+                let _ = tx.send(result.text.clone());
+            }
+        }
+        Ok(result)
+    }
+}
+
+fn parse_response(
+    json: &serde_json::Value,
+    request: &LlmRequestPayload,
+) -> Result<LlmResult, VmError> {
+    if let Some(message) = json
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(|value| value.as_str())
+    {
+        return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+            "gemini API error: {message}"
+        )))));
+    }
+    let mut text = String::new();
+    let mut blocks = Vec::new();
+    if let Some(parts) = json["candidates"][0]["content"]["parts"].as_array() {
+        for part in parts {
+            if let Some(fragment) = part.get("text").and_then(|value| value.as_str()) {
+                text.push_str(fragment);
+                blocks.push(serde_json::json!({
+                    "type": "output_text",
+                    "text": fragment,
+                    "visibility": "public",
+                }));
+            }
+        }
+    }
+    let input_tokens = json["usageMetadata"]["promptTokenCount"]
+        .as_i64()
+        .unwrap_or(0);
+    let output_tokens = json["usageMetadata"]["candidatesTokenCount"]
+        .as_i64()
+        .unwrap_or(0);
+    let stop_reason = json["candidates"][0]["finishReason"]
+        .as_str()
+        .map(str::to_string);
+    Ok(LlmResult {
+        text,
+        tool_calls: Vec::new(),
+        input_tokens,
+        output_tokens,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        model: request.model.clone(),
+        provider: request.provider.clone(),
+        thinking: None,
+        stop_reason,
+        blocks,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::api::ThinkingConfig;
+
+    #[test]
+    fn gemini_image_content_maps_to_inline_data() {
+        let payload = LlmRequestPayload {
+            provider: "gemini".to_string(),
+            model: "gemini-2.5-flash".to_string(),
+            api_key: String::new(),
+            fallback_chain: Vec::new(),
+            messages: vec![serde_json::json!({
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "caption"},
+                    {"type": "image", "base64": "iVBORw0KGgo=", "media_type": "image/png"}
+                ],
+            })],
+            system: None,
+            max_tokens: 64,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop: None,
+            seed: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            response_format: None,
+            json_schema: None,
+            thinking: ThinkingConfig::Disabled,
+            vision: true,
+            native_tools: None,
+            tool_choice: None,
+            cache: false,
+            timeout: None,
+            stream: false,
+            provider_overrides: None,
+            prefill: None,
+            session_id: None,
+        };
+        let body = GeminiProvider::build_request_body(&payload);
+        assert_eq!(body["contents"][0]["parts"][0]["text"], "caption");
+        assert_eq!(
+            body["contents"][0]["parts"][1]["inline_data"],
+            serde_json::json!({"mime_type": "image/png", "data": "iVBORw0KGgo="})
+        );
+    }
+
+    #[test]
+    fn gemini_image_url_content_maps_to_file_data() {
+        let mut payload = LlmRequestPayload {
+            provider: "gemini".to_string(),
+            model: "gemini-2.5-flash".to_string(),
+            api_key: String::new(),
+            fallback_chain: Vec::new(),
+            messages: vec![serde_json::json!({
+                "role": "user",
+                "content": [
+                    {"type": "image", "url": "https://example.com/image.png", "media_type": "image/png"}
+                ],
+            })],
+            system: None,
+            max_tokens: 64,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop: None,
+            seed: None,
+            frequency_penalty: None,
+            presence_penalty: None,
+            response_format: None,
+            json_schema: None,
+            thinking: ThinkingConfig::Disabled,
+            vision: true,
+            native_tools: None,
+            tool_choice: None,
+            cache: false,
+            timeout: None,
+            stream: false,
+            provider_overrides: None,
+            prefill: None,
+            session_id: None,
+        };
+        payload.system = Some("system".to_string());
+
+        let body = GeminiProvider::build_request_body(&payload);
+        assert_eq!(
+            body["contents"][0]["parts"][0]["file_data"],
+            serde_json::json!({
+                "mime_type": "image/png",
+                "file_uri": "https://example.com/image.png",
+            })
+        );
+        assert_eq!(body["system_instruction"]["parts"][0]["text"], "system");
+    }
+}

--- a/crates/harn-vm/src/llm/providers/mod.rs
+++ b/crates/harn-vm/src/llm/providers/mod.rs
@@ -10,11 +10,13 @@
 //! - **Mock** — deterministic test responses without any network I/O
 
 pub(crate) mod anthropic;
+mod gemini;
 mod mock;
 mod ollama;
 pub(crate) mod openai_compat;
 
 pub(crate) use anthropic::AnthropicProvider;
+pub(crate) use gemini::GeminiProvider;
 pub(crate) use mock::MockProvider;
 pub(crate) use ollama::OllamaProvider;
 pub(crate) use openai_compat::OpenAiCompatibleProvider;

--- a/crates/harn-vm/src/llm/providers/ollama.rs
+++ b/crates/harn-vm/src/llm/providers/ollama.rs
@@ -40,8 +40,57 @@ impl OllamaProvider {
     /// Build the Ollama-specific request body. Ollama uses OpenAI-style messages
     /// but with additional options and NDJSON streaming.
     pub(crate) fn build_request_body(opts: &LlmRequestPayload) -> serde_json::Value {
-        let mut body =
-            crate::llm::providers::OpenAiCompatibleProvider::build_request_body(opts, true);
+        let mut msgs = Vec::new();
+        if let Some(ref sys) = opts.system {
+            msgs.push(serde_json::json!({"role": "system", "content": sys}));
+        }
+        msgs.extend(
+            opts.messages
+                .iter()
+                .cloned()
+                .map(crate::llm::content::ollama_message),
+        );
+        if let Some(ref prefill) = opts.prefill {
+            msgs.push(serde_json::json!({
+                "role": "assistant",
+                "content": prefill,
+            }));
+        }
+        let msgs = crate::llm::api::normalize_openai_style_messages(msgs, true);
+
+        let mut body = serde_json::json!({
+            "model": opts.model,
+            "messages": msgs,
+        });
+        if opts.max_tokens > 0 {
+            body["max_tokens"] = serde_json::json!(opts.max_tokens);
+        }
+        if let Some(temp) = opts.temperature {
+            body["temperature"] = serde_json::json!(temp);
+        }
+        if let Some(top_p) = opts.top_p {
+            body["top_p"] = serde_json::json!(top_p);
+        }
+        if let Some(ref stop) = opts.stop {
+            body["stop"] = serde_json::json!(stop);
+        }
+        if let Some(seed) = opts.seed {
+            body["seed"] = serde_json::json!(seed);
+        }
+        if let Some(fp) = opts.frequency_penalty {
+            body["frequency_penalty"] = serde_json::json!(fp);
+        }
+        if let Some(pp) = opts.presence_penalty {
+            body["presence_penalty"] = serde_json::json!(pp);
+        }
+        if let Some(ref tools) = opts.native_tools {
+            if !tools.is_empty() {
+                body["tools"] = serde_json::json!(tools);
+            }
+        }
+        if let Some(ref tc) = opts.tool_choice {
+            body["tool_choice"] = tc.clone();
+        }
 
         if opts.response_format.as_deref() == Some("json") {
             body.as_object_mut()
@@ -513,6 +562,7 @@ mod tests {
             response_format: Some("json".to_string()),
             json_schema: Some(serde_json::json!({"type": "object"})),
             thinking: ThinkingConfig::Disabled,
+            vision: false,
             native_tools: None,
             tool_choice: None,
             cache: false,
@@ -537,6 +587,28 @@ mod tests {
         payload.json_schema = None;
         let body = OllamaProvider::build_request_body(&payload);
         assert!(body.get("format").is_none());
+    }
+
+    #[test]
+    fn image_content_maps_to_ollama_images_array() {
+        let mut payload = base_payload();
+        payload.model = "llava:latest".to_string();
+        payload.response_format = None;
+        payload.json_schema = None;
+        payload.messages = vec![serde_json::json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "caption"},
+                {"type": "image", "base64": "iVBORw0KGgo=", "media_type": "image/png"}
+            ],
+        })];
+
+        let body = OllamaProvider::build_request_body(&payload);
+        assert_eq!(body["messages"][0]["content"], "caption");
+        assert_eq!(
+            body["messages"][0]["images"],
+            serde_json::json!(["iVBORw0KGgo="])
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -134,7 +134,17 @@ impl OpenAiCompatibleProvider {
         if let Some(ref sys) = opts.system {
             msgs.push(serde_json::json!({"role": "system", "content": sys}));
         }
-        msgs.extend(opts.messages.iter().cloned());
+        msgs.extend(opts.messages.iter().cloned().map(|mut message| {
+            if let Some(object) = message.as_object_mut() {
+                if let Some(content) = object.get("content").cloned() {
+                    object.insert(
+                        "content".to_string(),
+                        crate::llm::content::openai_content(&content),
+                    );
+                }
+            }
+            message
+        }));
         if let Some(ref prefill) = opts.prefill {
             msgs.push(serde_json::json!({
                 "role": "assistant",
@@ -456,6 +466,58 @@ mod tests {
         assert!(body.get("reasoning_effort").is_none());
     }
 
+    #[test]
+    fn image_content_maps_to_openai_image_url_block() {
+        let mut payload = base_request_payload();
+        payload.provider = "openai".to_string();
+        payload.model = "gpt-4o".to_string();
+        payload.messages = vec![json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "caption"},
+                {"type": "image", "base64": "iVBORw0KGgo=", "media_type": "image/png", "detail": "low"}
+            ],
+        })];
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert_eq!(body["messages"][0]["content"][0]["text"], "caption");
+        assert_eq!(
+            body["messages"][0]["content"][1],
+            json!({
+                "type": "image_url",
+                "image_url": {
+                    "url": "data:image/png;base64,iVBORw0KGgo=",
+                    "detail": "low",
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn image_url_content_maps_to_openai_image_url_block() {
+        let mut payload = base_request_payload();
+        payload.provider = "openai".to_string();
+        payload.model = "gpt-4o".to_string();
+        payload.messages = vec![json!({
+            "role": "user",
+            "content": [
+                {"type": "image", "url": "https://example.com/image.png", "media_type": "image/png", "detail": "high"}
+            ],
+        })];
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert_eq!(
+            body["messages"][0]["content"][0],
+            json!({
+                "type": "image_url",
+                "image_url": {
+                    "url": "https://example.com/image.png",
+                    "detail": "high",
+                }
+            })
+        );
+    }
+
     fn base_request_payload() -> LlmRequestPayload {
         LlmRequestPayload {
             provider: "openrouter".to_string(),
@@ -476,6 +538,7 @@ mod tests {
             response_format: None,
             json_schema: None,
             thinking: ThinkingConfig::Disabled,
+            vision: false,
             native_tools: None,
             tool_choice: None,
             cache: false,

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -435,6 +435,9 @@ fn infer_provider_with_config(config: &ProvidersConfig, model_id: &str) -> Strin
     if model_id.starts_with("gpt-") || model_id.starts_with("o1") || model_id.starts_with("o3") {
         return "openai".to_string();
     }
+    if model_id.starts_with("gemini-") || model_id.starts_with("models/gemini-") {
+        return "gemini".to_string();
+    }
     if model_id.contains('/') {
         return "openrouter".to_string();
     }
@@ -890,6 +893,32 @@ fn default_config() -> ProvidersConfig {
             cost_per_1k_in: Some(0.0),
             cost_per_1k_out: Some(0.0),
             latency_p50_ms: Some(1200),
+            ..Default::default()
+        },
+    );
+
+    // Google Gemini native API.
+    config.providers.insert(
+        "gemini".to_string(),
+        ProviderDef {
+            base_url: "https://generativelanguage.googleapis.com".to_string(),
+            base_url_env: Some("GEMINI_BASE_URL".to_string()),
+            auth_style: "header".to_string(),
+            auth_header: Some("x-goog-api-key".to_string()),
+            auth_env: AuthEnv::Multiple(vec![
+                "GEMINI_API_KEY".to_string(),
+                "GOOGLE_API_KEY".to_string(),
+            ]),
+            chat_endpoint: "/v1beta/models".to_string(),
+            healthcheck: Some(HealthcheckDef {
+                method: "GET".to_string(),
+                path: Some("/v1beta/models".to_string()),
+                url: None,
+                body: None,
+            }),
+            cost_per_1k_in: Some(0.00125),
+            cost_per_1k_out: Some(0.005),
+            latency_p50_ms: Some(1800),
             ..Default::default()
         },
     );

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -70,6 +70,32 @@ let result = llm_call(
 println(result.text)
 ```
 
+With image content:
+
+```harn
+let image = bytes_to_base64(read_file_bytes("diagram.png"))
+let result = llm_call("", nil, {
+  provider: "openai",
+  model: "gpt-4o",
+  messages: [{
+    role: "user",
+    content: [
+      {type: "text", text: "Summarize this diagram."},
+      {type: "image", base64: image, media_type: "image/png", detail: "auto"},
+    ],
+  }],
+})
+println(result.text)
+```
+
+Image blocks use the provider-neutral shape
+`{type: "image", url?: string, base64?: string, media_type: string, detail?: "low"|"high"|"auto"}`.
+Exactly one of `url` or `base64` is required. Harn translates it to
+Anthropic `source`, OpenAI `image_url`, Gemini `inline_data`/`file_data`,
+or Ollama `images` fields at the provider boundary. Ollama's REST API
+only accepts base64 image data, so `url` image blocks are rejected for
+`provider: "ollama"`.
+
 ### Parameters
 
 | Parameter | Type | Required | Description |
@@ -104,7 +130,7 @@ println(result.text)
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `provider` | string | `"anthropic"` | Any configured provider. Built-in names include `"anthropic"`, `"openai"`, `"openrouter"`, `"huggingface"`, `"ollama"`, and `"local"` |
+| `provider` | string | `"anthropic"` | Any configured provider. Built-in names include `"anthropic"`, `"openai"`, `"openrouter"`, `"huggingface"`, `"ollama"`, `"gemini"`, and `"local"` |
 | `model` | string | varies by provider | Model identifier |
 | `max_tokens` | int | `16384` | Maximum tokens in the response |
 | `temperature` | float | provider default | Sampling temperature (0.0-2.0) |
@@ -117,6 +143,7 @@ println(result.text)
 | `response_format` | string | `"text"` | `"text"` or `"json"` |
 | `schema` | dict | nil | JSON Schema, OpenAPI Schema Object, or canonical Harn schema dict for structured output |
 | `thinking` | bool/dict | nil | Enable typed provider reasoning. `true` and `{budget_tokens: N}` remain shorthand for `{mode: "enabled"}`; use `{mode: "enabled", budget_tokens: N}`, `{mode: "adaptive"}`, or `{mode: "effort", level: "low" \| "medium" \| "high"}`. |
+| `vision` | bool | inferred | Require image-input support. Image content blocks set this implicitly; `vision: true` fails before transport unless the selected provider/model declares `vision_supported`. |
 | `tools` | list | nil | Tool definitions |
 | `tool_choice` | string/dict | `"auto"` | `"auto"`, `"none"`, `"required"`, or `{name: "tool"}` |
 | `tool_search` | bool/string/dict | nil | Progressive tool disclosure. See [Tool Vault](#tool-vault) |
@@ -417,7 +444,7 @@ let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 // {
 //   native_tools: true, defer_loading: true,
 //   tool_search: ["bm25", "regex"], max_tools: 10000,
-//   prompt_caching: true, thinking: true,
+//   prompt_caching: true, thinking: true, vision_supported: true,
 // }
 
 if "bm25" in caps.tool_search {
@@ -466,6 +493,7 @@ Each `[[capabilities.provider.<name>]]` entry accepts these fields:
 | `max_tools` | int | Cap on tool count. `harn lint` will warn if a registry exceeds the smallest cap any active provider advertises. |
 | `prompt_caching` | bool | `cache_control` blocks honored. |
 | `thinking_modes` | list of strings | Supported script-facing thinking modes. Values are `enabled`, `adaptive`, or `effort`. |
+| `vision_supported` | bool | Image content accepted by the provider/model route. |
 
 First match wins. User rules for a given provider are consulted
 before the shipped rules — so the order inside the TOML file matters


### PR DESCRIPTION
## Summary
- Add provider-neutral image content blocks for `llm_call` with base64/URL validation and implicit `vision` gating.
- Translate image blocks at provider boundaries for Anthropic, OpenAI-compatible, Gemini, and Ollama, including native Gemini provider registration/config.
- Expose `vision_supported` capabilities, update docs, and add conformance/unit coverage for image content and capability rejection.

Closes #863

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-863 cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-863 cargo clippy -p harn-vm --lib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-863 cargo test -p harn-vm --lib llm:: -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-863 cargo test -p harn-vm --lib llm_config::`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-863 cargo run --quiet --bin harn -- test conformance --filter llm_call_image_content`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-863 cargo run --quiet --bin harn -- test conformance --filter provider_capabilities_basic`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`, markdown lint
- pre-push hook: 2917 nextest tests passed, affected Harn format/lint, markdown lint

## Self-review
- Rechecked provider wire shapes against official Anthropic/OpenAI/Gemini/Ollama docs and added URL/base64 serializer tests.
- Confirmed Ollama URL images fail before transport because Ollama only accepts base64 image arrays.
- Confirmed the conformance PNG fixture is deleted during the test and does not dirty the worktree.