### PR TITLE
Surface LLM prompt cache usage

### DIFF
--- a/conformance/tests/integration/llm_prompt_cache_usage.expected
+++ b/conformance/tests/integration/llm_prompt_cache_usage.expected
@@ -1,0 +1,8 @@
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/integration/llm_prompt_cache_usage.harn
+++ b/conformance/tests/integration/llm_prompt_cache_usage.harn
@@ -1,0 +1,17 @@
+pipeline default() {
+  var prompt = ""
+  for i in range(0, 80) {
+    prompt += "stable cacheable prefix line " + to_string(i) + ": explain prompt caching usage fields.\n"
+  }
+  let options = {provider: "mock", model: "claude-sonnet-4-20250514", cache: true}
+  let first = llm_call(prompt, nil, options)
+  let second = llm_call(prompt, nil, options)
+  println(first.usage.cache_read_tokens == 0)
+  println(first.usage.cache_write_tokens > 0)
+  println(first.usage.cache_creation_input_tokens == first.usage.cache_write_tokens)
+  println(second.usage.cache_read_tokens > 0)
+  println(second.usage.cache_write_tokens == 0)
+  println(second.usage.cache_hit_ratio == 1.0)
+  println(second.usage.cache_savings_usd > 0.0)
+  println(second.cache_read_tokens == second.usage.cache_read_tokens)
+}

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -162,7 +162,8 @@ fn parse_cli_llm_mock_value(value: &serde_json::Value) -> Result<harn_vm::llm::L
     let input_tokens = optional_i64_field(object, "input_tokens")?;
     let output_tokens = optional_i64_field(object, "output_tokens")?;
     let cache_read_tokens = optional_i64_field(object, "cache_read_tokens")?;
-    let cache_write_tokens = optional_i64_field(object, "cache_write_tokens")?;
+    let cache_write_tokens = optional_i64_field(object, "cache_write_tokens")?
+        .or(optional_i64_field(object, "cache_creation_input_tokens")?);
     let thinking = optional_string_field(object, "thinking")?;
     let stop_reason = optional_string_field(object, "stop_reason")?;
     let model = optional_string_field(object, "model")?.unwrap_or_else(|| "mock".to_string());
@@ -403,6 +404,10 @@ fn serialize_cli_llm_mock(mock: harn_vm::llm::LlmMock) -> Result<String, String>
     if let Some(cache_write_tokens) = mock.cache_write_tokens {
         object.insert(
             "cache_write_tokens".to_string(),
+            serde_json::Value::Number(cache_write_tokens.into()),
+        );
+        object.insert(
+            "cache_creation_input_tokens".to_string(),
             serde_json::Value::Number(cache_write_tokens.into()),
         );
     }

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -492,6 +492,18 @@ pub(super) fn dump_llm_response(
         ),
         "cache_read_tokens": result.cache_read_tokens,
         "cache_write_tokens": result.cache_write_tokens,
+        "cache_creation_input_tokens": result.cache_write_tokens,
+        "cache_hit_ratio": crate::llm::cost::cache_hit_ratio(
+            result.input_tokens,
+            result.cache_read_tokens,
+            result.cache_write_tokens,
+        ),
+        "cache_savings_usd": crate::llm::cost::cache_savings_usd_for_provider(
+            &result.provider,
+            &result.model,
+            result.cache_read_tokens,
+            result.cache_write_tokens,
+        ),
         // Explicit bool for easy cache-regression spotting in tailed logs.
         "cache_hit": result.cache_read_tokens > 0,
         "thinking": result.thinking,

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -146,6 +146,8 @@ async fn vm_call_llm_full_inner_request(
             request.system.as_deref(),
             request.native_tools.as_deref(),
             &request.thinking,
+            &request.model,
+            request.cache,
         )?;
         super::trigger_predicate::note_result(request, &result);
         record_cli_llm_result(&result);
@@ -208,6 +210,8 @@ async fn vm_call_llm_full_inner_offthread(
             request.system.as_deref(),
             request.native_tools.as_deref(),
             &request.thinking,
+            &request.model,
+            request.cache,
         )
         .map_err(|e| e.to_string())?;
         super::trigger_predicate::note_result(request, &result);

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -295,6 +295,13 @@ pub(super) fn extract_cache_read_tokens(usage: &serde_json::Value) -> i64 {
     {
         return n;
     }
+    if let Some(n) = usage
+        .get("input_tokens_details")
+        .and_then(|d| d.get("cached_tokens"))
+        .and_then(|v| v.as_i64())
+    {
+        return n;
+    }
     // OpenRouter variants: cache_read_tokens / cached_prompt_tokens.
     if let Some(n) = usage.get("cache_read_tokens").and_then(|v| v.as_i64()) {
         return n;
@@ -319,12 +326,30 @@ pub(super) fn extract_cache_write_tokens(usage: &serde_json::Value) -> i64 {
         .get("prompt_tokens_details")
         .and_then(|d| d.get("cache_write_tokens"))
         .and_then(|v| v.as_i64())
+        .or_else(|| {
+            usage
+                .get("prompt_tokens_details")
+                .and_then(|d| d.get("cache_creation_input_tokens"))
+                .and_then(|v| v.as_i64())
+        })
+        .or_else(|| {
+            usage
+                .get("input_tokens_details")
+                .and_then(|d| d.get("cache_write_tokens"))
+                .and_then(|v| v.as_i64())
+        })
+        .or_else(|| {
+            usage
+                .get("input_tokens_details")
+                .and_then(|d| d.get("cache_creation_input_tokens"))
+                .and_then(|v| v.as_i64())
+        })
         .unwrap_or(0)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_cache_write_tokens, parse_llm_response};
+    use super::{extract_cache_read_tokens, extract_cache_write_tokens, parse_llm_response};
 
     // Build a ResolvedProvider for the Anthropic path without going through
     // the thread-local provider registry — these parser tests only need the
@@ -345,6 +370,21 @@ mod tests {
         });
 
         assert_eq!(extract_cache_write_tokens(&usage), 100);
+    }
+
+    #[test]
+    fn cache_tokens_support_openai_responses_details_shape() {
+        let usage = serde_json::json!({
+            "input_tokens": 194,
+            "output_tokens": 2,
+            "input_tokens_details": {
+                "cached_tokens": 120,
+                "cache_creation_input_tokens": 40
+            }
+        });
+
+        assert_eq!(extract_cache_read_tokens(&usage), 120);
+        assert_eq!(extract_cache_write_tokens(&usage), 40);
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/api/result.rs
+++ b/crates/harn-vm/src/llm/api/result.rs
@@ -29,6 +29,51 @@ pub(crate) struct LlmResult {
     pub blocks: Vec<serde_json::Value>,
 }
 
+fn build_usage_dict(result: &LlmResult) -> BTreeMap<String, VmValue> {
+    let cache_hit_ratio = crate::llm::cost::cache_hit_ratio(
+        result.input_tokens,
+        result.cache_read_tokens,
+        result.cache_write_tokens,
+    );
+    let cache_savings_usd = crate::llm::cost::cache_savings_usd_for_provider(
+        &result.provider,
+        &result.model,
+        result.cache_read_tokens,
+        result.cache_write_tokens,
+    );
+
+    let mut usage = BTreeMap::new();
+    usage.insert(
+        "input_tokens".to_string(),
+        VmValue::Int(result.input_tokens),
+    );
+    usage.insert(
+        "output_tokens".to_string(),
+        VmValue::Int(result.output_tokens),
+    );
+    usage.insert(
+        "cache_read_tokens".to_string(),
+        VmValue::Int(result.cache_read_tokens),
+    );
+    usage.insert(
+        "cache_write_tokens".to_string(),
+        VmValue::Int(result.cache_write_tokens),
+    );
+    usage.insert(
+        "cache_creation_input_tokens".to_string(),
+        VmValue::Int(result.cache_write_tokens),
+    );
+    usage.insert(
+        "cache_hit_ratio".to_string(),
+        VmValue::Float(cache_hit_ratio),
+    );
+    usage.insert(
+        "cache_savings_usd".to_string(),
+        VmValue::Float(cache_savings_usd),
+    );
+    usage
+}
+
 pub(crate) fn vm_build_llm_result(
     result: &LlmResult,
     parsed_json: Option<VmValue>,
@@ -67,6 +112,18 @@ pub(crate) fn vm_build_llm_result(
         "cache_write_tokens".to_string(),
         VmValue::Int(result.cache_write_tokens),
     );
+    dict.insert(
+        "cache_creation_input_tokens".to_string(),
+        VmValue::Int(result.cache_write_tokens),
+    );
+    let usage = build_usage_dict(result);
+    if let Some(value) = usage.get("cache_hit_ratio") {
+        dict.insert("cache_hit_ratio".to_string(), value.clone());
+    }
+    if let Some(value) = usage.get("cache_savings_usd") {
+        dict.insert("cache_savings_usd".to_string(), value.clone());
+    }
+    dict.insert("usage".to_string(), VmValue::Dict(Rc::new(usage)));
 
     if let Some(json_val) = parsed_json {
         dict.insert("data".to_string(), json_val);

--- a/crates/harn-vm/src/llm/cost.rs
+++ b/crates/harn-vm/src/llm/cost.rs
@@ -380,6 +380,26 @@ pub(crate) fn pricing_per_1k_for(provider: &str, model: &str) -> Option<(f64, f6
     model_pricing_per_1k(model).or_else(|| crate::llm_config::pricing_per_1k_for(provider, model))
 }
 
+fn model_cache_pricing_per_1k(model: &str) -> Option<(f64, Option<f64>, Option<f64>)> {
+    crate::llm_config::model_pricing_per_mtok(model).map(|pricing| {
+        (
+            pricing.input_per_mtok / 1000.0,
+            pricing.cache_read_per_mtok.map(|rate| rate / 1000.0),
+            pricing.cache_write_per_mtok.map(|rate| rate / 1000.0),
+        )
+    })
+}
+
+fn cache_pricing_per_1k_for(
+    provider: &str,
+    model: &str,
+) -> Option<(f64, Option<f64>, Option<f64>)> {
+    model_cache_pricing_per_1k(model).or_else(|| {
+        crate::llm_config::pricing_per_1k_for(provider, model)
+            .map(|(input_rate, _output_rate)| (input_rate, None, None))
+    })
+}
+
 pub(crate) fn latency_p50_ms_for(provider: &str) -> Option<u64> {
     let (_, _, latency) = crate::llm_config::provider_economics(provider);
     latency
@@ -409,6 +429,47 @@ pub fn calculate_cost_for_provider(
         }
         None => 0.0,
     }
+}
+
+pub(crate) fn cache_hit_ratio(
+    input_tokens: i64,
+    cache_read_tokens: i64,
+    cache_write_tokens: i64,
+) -> f64 {
+    let input_tokens = input_tokens.max(0);
+    let cache_read_tokens = cache_read_tokens.max(0);
+    let cache_write_tokens = cache_write_tokens.max(0);
+    let reported_cache_tokens = cache_read_tokens.saturating_add(cache_write_tokens);
+    let total_prompt_tokens = if reported_cache_tokens <= input_tokens {
+        input_tokens
+    } else {
+        input_tokens.saturating_add(reported_cache_tokens)
+    };
+    if total_prompt_tokens == 0 {
+        0.0
+    } else {
+        cache_read_tokens as f64 / total_prompt_tokens as f64
+    }
+}
+
+pub(crate) fn cache_savings_usd_for_provider(
+    provider: &str,
+    model: &str,
+    cache_read_tokens: i64,
+    cache_write_tokens: i64,
+) -> f64 {
+    let Some((input_rate, cache_read_rate, cache_write_rate)) =
+        cache_pricing_per_1k_for(provider, model)
+    else {
+        return 0.0;
+    };
+    let cache_read_savings = cache_read_tokens.max(0) as f64
+        * (input_rate - cache_read_rate.unwrap_or(input_rate))
+        / 1000.0;
+    let cache_write_savings = cache_write_tokens.max(0) as f64
+        * (input_rate - cache_write_rate.unwrap_or(input_rate))
+        / 1000.0;
+    cache_read_savings + cache_write_savings
 }
 
 pub(crate) fn accumulate_cost_for_provider(
@@ -527,5 +588,28 @@ mod tests {
         assert!((cost - 0.03).abs() < f64::EPSILON);
 
         crate::llm_config::clear_user_overrides();
+    }
+
+    #[test]
+    fn cache_savings_uses_catalog_cache_pricing() {
+        let _guard = crate::llm::env_lock().lock().unwrap();
+        crate::llm_config::clear_user_overrides();
+
+        let savings =
+            cache_savings_usd_for_provider("anthropic", "claude-sonnet-4-20250514", 1000, 0);
+        assert!((savings - 0.0027).abs() < 0.0000001);
+
+        let write_delta =
+            cache_savings_usd_for_provider("anthropic", "claude-sonnet-4-20250514", 0, 1000);
+        assert!((write_delta + 0.00075).abs() < 0.0000001);
+
+        crate::llm_config::clear_user_overrides();
+    }
+
+    #[test]
+    fn cache_hit_ratio_handles_subset_and_separate_anthropic_counts() {
+        assert!((cache_hit_ratio(1000, 250, 0) - 0.25).abs() < f64::EPSILON);
+        assert!((cache_hit_ratio(100, 900, 0) - 0.9).abs() < f64::EPSILON);
+        assert_eq!(cache_hit_ratio(0, 0, 0), 0.0);
     }
 }

--- a/crates/harn-vm/src/llm/mock.rs
+++ b/crates/harn-vm/src/llm/mock.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::collections::BTreeSet;
 
 use super::api::LlmResult;
 use crate::orchestration::ToolCallRecord;
@@ -71,6 +72,8 @@ pub(crate) struct LlmMockCall {
     pub thinking: serde_json::Value,
 }
 
+type LlmMockScope = (Vec<LlmMock>, Vec<LlmMockCall>, BTreeSet<String>);
+
 thread_local! {
     static LLM_REPLAY_MODE: RefCell<LlmReplayMode> = const { RefCell::new(LlmReplayMode::Off) };
     static LLM_FIXTURE_DIR: RefCell<String> = const { RefCell::new(String::new()) };
@@ -82,8 +85,8 @@ thread_local! {
     static CLI_LLM_MOCKS: RefCell<Vec<LlmMock>> = const { RefCell::new(Vec::new()) };
     static CLI_LLM_RECORDINGS: RefCell<Vec<LlmMock>> = const { RefCell::new(Vec::new()) };
     static LLM_MOCK_CALLS: RefCell<Vec<LlmMockCall>> = const { RefCell::new(Vec::new()) };
-    static LLM_MOCK_SCOPES: RefCell<Vec<(Vec<LlmMock>, Vec<LlmMockCall>)>> =
-        const { RefCell::new(Vec::new()) };
+    static LLM_PROMPT_CACHE: RefCell<BTreeSet<String>> = const { RefCell::new(BTreeSet::new()) };
+    static LLM_MOCK_SCOPES: RefCell<Vec<LlmMockScope>> = const { RefCell::new(Vec::new()) };
 }
 
 pub(crate) fn push_llm_mock(mock: LlmMock) {
@@ -100,6 +103,7 @@ pub(crate) fn reset_llm_mock_state() {
     CLI_LLM_MOCKS.with(|v| v.borrow_mut().clear());
     CLI_LLM_RECORDINGS.with(|v| v.borrow_mut().clear());
     LLM_MOCK_CALLS.with(|v| v.borrow_mut().clear());
+    LLM_PROMPT_CACHE.with(|v| v.borrow_mut().clear());
     LLM_MOCK_SCOPES.with(|v| v.borrow_mut().clear());
 }
 
@@ -110,7 +114,8 @@ pub(crate) fn reset_llm_mock_state() {
 pub(crate) fn push_llm_mock_scope() {
     let mocks = LLM_MOCKS.with(|v| std::mem::take(&mut *v.borrow_mut()));
     let calls = LLM_MOCK_CALLS.with(|v| std::mem::take(&mut *v.borrow_mut()));
-    LLM_MOCK_SCOPES.with(|v| v.borrow_mut().push((mocks, calls)));
+    let cache = LLM_PROMPT_CACHE.with(|v| std::mem::take(&mut *v.borrow_mut()));
+    LLM_MOCK_SCOPES.with(|v| v.borrow_mut().push((mocks, calls, cache)));
 }
 
 /// Restore the most recently pushed builtin LLM mock scope. Returns
@@ -121,9 +126,10 @@ pub(crate) fn push_llm_mock_scope() {
 pub(crate) fn pop_llm_mock_scope() -> bool {
     let entry = LLM_MOCK_SCOPES.with(|v| v.borrow_mut().pop());
     match entry {
-        Some((mocks, calls)) => {
+        Some((mocks, calls, cache)) => {
             LLM_MOCKS.with(|v| *v.borrow_mut() = mocks);
             LLM_MOCK_CALLS.with(|v| *v.borrow_mut() = calls);
+            LLM_PROMPT_CACHE.with(|v| *v.borrow_mut() = cache);
             true
         }
         None => false,
@@ -308,6 +314,43 @@ fn mock_last_prompt_text(messages: &[serde_json::Value]) -> String {
     String::new()
 }
 
+fn mock_prompt_cache_key(
+    model: &str,
+    messages: &[serde_json::Value],
+    system: Option<&str>,
+) -> String {
+    serde_json::to_string(&serde_json::json!({
+        "model": model,
+        "system": system,
+        "messages": messages,
+    }))
+    .unwrap_or_default()
+}
+
+fn apply_mock_prompt_cache(result: &mut LlmResult, cache_key: &str) {
+    if result.cache_read_tokens > 0 || result.cache_write_tokens > 0 {
+        return;
+    }
+    let cache_tokens = result.input_tokens.max(0);
+    if cache_tokens == 0 {
+        return;
+    }
+    let cache_hit = LLM_PROMPT_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if cache.contains(cache_key) {
+            true
+        } else {
+            cache.insert(cache_key.to_string());
+            false
+        }
+    });
+    if cache_hit {
+        result.cache_read_tokens = cache_tokens;
+    } else {
+        result.cache_write_tokens = cache_tokens;
+    }
+}
+
 /// Convert a mock's `error` payload into the `VmError` that the
 /// provider path would have raised, so classification, retry, and
 /// `error_category` all behave identically to a real failure.
@@ -455,8 +498,13 @@ pub(crate) fn save_fixture(hash: &str, result: &LlmResult) {
         "tool_calls": result.tool_calls,
         "input_tokens": result.input_tokens,
         "output_tokens": result.output_tokens,
+        "cache_read_tokens": result.cache_read_tokens,
+        "cache_write_tokens": result.cache_write_tokens,
+        "cache_creation_input_tokens": result.cache_write_tokens,
         "model": result.model,
         "provider": result.provider,
+        "thinking": result.thinking,
+        "stop_reason": result.stop_reason,
         "blocks": result.blocks,
     });
     let _ = std::fs::write(
@@ -479,7 +527,10 @@ pub(crate) fn load_fixture(hash: &str) -> Option<LlmResult> {
         input_tokens: json["input_tokens"].as_i64().unwrap_or(0),
         output_tokens: json["output_tokens"].as_i64().unwrap_or(0),
         cache_read_tokens: json["cache_read_tokens"].as_i64().unwrap_or(0),
-        cache_write_tokens: json["cache_write_tokens"].as_i64().unwrap_or(0),
+        cache_write_tokens: json["cache_write_tokens"]
+            .as_i64()
+            .or_else(|| json["cache_creation_input_tokens"].as_i64())
+            .unwrap_or(0),
         model: json["model"].as_str().unwrap_or("").to_string(),
         provider: json["provider"].as_str().unwrap_or("mock").to_string(),
         thinking: json["thinking"].as_str().map(|s| s.to_string()),
@@ -549,18 +600,31 @@ pub(crate) fn mock_llm_response(
     system: Option<&str>,
     native_tools: Option<&[serde_json::Value]>,
     thinking: &super::api::ThinkingConfig,
+    model: &str,
+    cache: bool,
 ) -> Result<LlmResult, VmError> {
     record_llm_mock_call(messages, system, native_tools, thinking);
 
     let match_text = mock_match_text(messages);
     let prompt_text = mock_last_prompt_text(messages);
+    let cache_key = mock_prompt_cache_key(model, messages, system);
 
     if let Some(matched) = try_match_cli_mock(&match_text) {
-        return matched;
+        return matched.map(|mut result| {
+            if cache {
+                apply_mock_prompt_cache(&mut result, &cache_key);
+            }
+            result
+        });
     }
 
     if let Some(matched) = try_match_builtin_mock(&match_text) {
-        return matched;
+        return matched.map(|mut result| {
+            if cache {
+                apply_mock_prompt_cache(&mut result, &cache_key);
+            }
+            result
+        });
     }
 
     if cli_llm_mock_replay_active() {
@@ -577,7 +641,7 @@ pub(crate) fn mock_llm_response(
                 .and_then(|n| n.as_str())
                 .unwrap_or("unknown");
             let mock_args = mock_required_args(first_tool);
-            return Ok(LlmResult {
+            let mut result = LlmResult {
                 text: String::new(),
                 tool_calls: vec![serde_json::json!({
                         "id": "mock_call_1",
@@ -589,7 +653,7 @@ pub(crate) fn mock_llm_response(
                 output_tokens: 20,
                 cache_read_tokens: 0,
                 cache_write_tokens: 0,
-                model: "mock".to_string(),
+                model: model.to_string(),
                 provider: "mock".to_string(),
                 thinking: None,
                 stop_reason: None,
@@ -600,7 +664,11 @@ pub(crate) fn mock_llm_response(
                     "arguments": mock_args,
                     "visibility": "internal",
                 })],
-            });
+            };
+            if cache {
+                apply_mock_prompt_cache(&mut result, &cache_key);
+            }
+            return Ok(result);
         }
     }
 
@@ -625,14 +693,14 @@ pub(crate) fn mock_llm_response(
         prose_body
     };
 
-    Ok(LlmResult {
+    let mut result = LlmResult {
         text: response.clone(),
         tool_calls: vec![],
         input_tokens: prompt_text.len() as i64,
         output_tokens: 30,
         cache_read_tokens: 0,
         cache_write_tokens: 0,
-        model: "mock".to_string(),
+        model: model.to_string(),
         provider: "mock".to_string(),
         thinking: None,
         stop_reason: None,
@@ -641,7 +709,11 @@ pub(crate) fn mock_llm_response(
             "text": response,
             "visibility": "public",
         })],
-    })
+    };
+    if cache {
+        apply_mock_prompt_cache(&mut result, &cache_key);
+    }
+    Ok(result)
 }
 
 pub fn set_tool_recording_mode(mode: ToolRecordingMode) {

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -1321,6 +1321,15 @@ fn register_llm_mock_builtins(vm: &mut Vm) {
 
         let input_tokens = config.get("input_tokens").and_then(|v| v.as_int());
         let output_tokens = config.get("output_tokens").and_then(|v| v.as_int());
+        let cache_read_tokens = config.get("cache_read_tokens").and_then(|v| v.as_int());
+        let cache_write_tokens = config
+            .get("cache_write_tokens")
+            .and_then(|v| v.as_int())
+            .or_else(|| {
+                config
+                    .get("cache_creation_input_tokens")
+                    .and_then(|v| v.as_int())
+            });
         let thinking = config.get("thinking").and_then(|v| {
             if matches!(v, VmValue::Nil) {
                 None
@@ -1403,8 +1412,8 @@ fn register_llm_mock_builtins(vm: &mut Vm) {
             consume_on_match,
             input_tokens,
             output_tokens,
-            cache_read_tokens: None,
-            cache_write_tokens: None,
+            cache_read_tokens,
+            cache_write_tokens,
             thinking,
             stop_reason,
             model,

--- a/crates/harn-vm/src/llm/providers/mock.rs
+++ b/crates/harn-vm/src/llm/providers/mock.rs
@@ -47,6 +47,8 @@ impl MockProvider {
             request.system.as_deref(),
             request.native_tools.as_deref(),
             &request.thinking,
+            &request.model,
+            request.cache,
         )
     }
 }

--- a/crates/harn-vm/src/llm/structured_envelope.rs
+++ b/crates/harn-vm/src/llm/structured_envelope.rs
@@ -374,6 +374,9 @@ fn empty_usage_dict() -> BTreeMap<String, VmValue> {
     usage.insert("output_tokens".to_string(), VmValue::Int(0));
     usage.insert("cache_read_tokens".to_string(), VmValue::Int(0));
     usage.insert("cache_write_tokens".to_string(), VmValue::Int(0));
+    usage.insert("cache_creation_input_tokens".to_string(), VmValue::Int(0));
+    usage.insert("cache_hit_ratio".to_string(), VmValue::Float(0.0));
+    usage.insert("cache_savings_usd".to_string(), VmValue::Float(0.0));
     usage
 }
 
@@ -382,12 +385,18 @@ fn build_usage_dict(outcome: &SchemaLoopOutcome) -> VmValue {
         Some(d) => d,
         None => return VmValue::Dict(Rc::new(empty_usage_dict())),
     };
+    if let Some(VmValue::Dict(usage)) = dict.get("usage") {
+        return VmValue::Dict(usage.clone());
+    }
     let mut usage = empty_usage_dict();
     for key in [
         "input_tokens",
         "output_tokens",
         "cache_read_tokens",
         "cache_write_tokens",
+        "cache_creation_input_tokens",
+        "cache_hit_ratio",
+        "cache_savings_usd",
     ] {
         if let Some(v) = dict.get(key) {
             usage.insert(key.to_string(), v.clone());

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -2993,8 +2993,10 @@ wrappers pick up the same narrowing.
   {ok: bool, data: T | nil, raw_text: string, error: string,
   error_category: string | nil, attempts: int, repaired: bool,
   extracted_json: bool, usage: {input_tokens: int, output_tokens: int,
-  cache_read_tokens: int, cache_write_tokens: int}, model: string,
-  provider: string}`. Never throws on transport / schema failures —
+  cache_read_tokens: int, cache_write_tokens: int,
+  cache_creation_input_tokens: int, cache_hit_ratio: float,
+  cache_savings_usd: float}, model: string, provider: string}`.
+  Never throws on transport / schema failures —
   callers dispatch on `ok` / `error_category`. Recognized
   `error_category` values: `transport`-class categories pass through
   the underlying enum (`rate_limit`, `timeout`, `auth`,

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -92,6 +92,10 @@ println(result.text)
 | `output_tokens` | int | Output/completion token count |
 | `cache_read_tokens` | int | Prompt tokens served from provider-side cache when supported |
 | `cache_write_tokens` | int | Prompt tokens written into provider-side cache when supported |
+| `cache_creation_input_tokens` | int | Anthropic-compatible alias for `cache_write_tokens` |
+| `cache_hit_ratio` | float | Fraction of prompt tokens served from provider-side cache |
+| `cache_savings_usd` | float | Estimated prompt-cache savings versus full input-token price; cache writes can be negative when writes cost more than normal input |
+| `usage` | dict | Token and prompt-cache accounting fields, including the cache fields above |
 | `data` | any | Parsed JSON (when `response_format: "json"`) |
 | `tool_calls` | list | Tool calls (when model uses tools) |
 | `thinking` | string | Reasoning trace (when `thinking` is enabled) |
@@ -256,7 +260,7 @@ Envelope fields:
 | `attempts` | int | Number of model calls made. `1` = no retries; `2+` = schema retries kicked in. `0` only when arg parsing failed before any call. |
 | `repaired` | bool | `true` when the repair pass produced valid JSON. |
 | `extracted_json` | bool | `true` when JSON had to be lifted from prose / markdown fences. |
-| `usage` | `{input_tokens, output_tokens, cache_read_tokens, cache_write_tokens}` | Token counts from the final attempt. |
+| `usage` | `{input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, cache_creation_input_tokens, cache_hit_ratio, cache_savings_usd}` | Token and prompt-cache accounting from the final attempt. |
 | `model` | string | Model that produced the final attempt. |
 | `provider` | string | Provider that produced the final attempt. |
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -2991,8 +2991,10 @@ wrappers pick up the same narrowing.
   {ok: bool, data: T | nil, raw_text: string, error: string,
   error_category: string | nil, attempts: int, repaired: bool,
   extracted_json: bool, usage: {input_tokens: int, output_tokens: int,
-  cache_read_tokens: int, cache_write_tokens: int}, model: string,
-  provider: string}`. Never throws on transport / schema failures —
+  cache_read_tokens: int, cache_write_tokens: int,
+  cache_creation_input_tokens: int, cache_hit_ratio: float,
+  cache_savings_usd: float}, model: string, provider: string}`.
+  Never throws on transport / schema failures —
   callers dispatch on `ok` / `error_category`. Recognized
   `error_category` values: `transport`-class categories pass through
   the underlying enum (`rate_limit`, `timeout`, `auth`,


### PR DESCRIPTION
## Summary
- add a `usage` dict to `llm_call` results with cache read/write, Anthropic `cache_creation_input_tokens`, `cache_hit_ratio`, and `cache_savings_usd`
- parse cache usage across Anthropic/OpenAI-compatible response shapes and expose the same fields through structured-result envelopes
- simulate prompt cache warm/read behavior in the mock provider and add conformance coverage for two repeated `cache: true` calls
- document the new fields in the LLM docs and generated language spec

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-862 cargo test -p harn-vm cache_`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-862 cargo run --quiet --bin harn -- test conformance --filter llm_prompt_cache_usage`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-862 cargo test -p harn-cli`
- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-862 cargo clippy -p harn-vm --all-targets -- -D warnings`
- LLM-related conformance cases passed: `--filter llm` passed through all integration LLM cases and the remaining trigger/type LLM cases were rerun individually after the broad run stopped producing output
- Pre-commit hook passed, including workspace clippy, markdown lint, and language spec sync
- Pre-push hook ran 2927 tests: 2926 passed, 1 unrelated DAP test was reported as leaky; rerunning `harn-dap::bin/harn-dap debugger::tests::test_cancel_handler_responds_success_even_without_match` passed cleanly

## Self-review
- cache savings uses catalog cache pricing and returns zero when no cache-specific rate is known
- cache writes can be negative savings when write pricing is higher than normal input, which is documented
- mock cache state is scoped/reset with the existing mock queues so tests do not leak cache warmth across mock scopes

Closes #862