### PR TITLE
Release v0.7.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,113 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
+## v0.7.50
+
+### Added
+
+- **Enterprise LLM providers (#870/#976).** First-class shims for Bedrock
+  Runtime (Converse API with hand-rolled AWS SigV4 signing and
+  env/profile/container/instance credential resolution), Azure OpenAI
+  (deployment-name routing with API-key and Entra bearer-token auth), and
+  Vertex AI Gemini (`generateContent` routing with bearer-token and
+  service-account JWT exchange). Provider registry, default config, inference
+  rules, capability matrix, and conformance coverage updated; existing
+  `provider_overrides` apply uniformly to the new providers.
+
+- **Provider capability matrix (#871/#979).** New `harn check
+  --provider-matrix` with text/JSON output and feature filtering, backed by
+  vision/audio/JSON-schema fields on the live capability schema. Generated
+  `docs/src/provider-matrix.md` is gated by a CI drift check.
+
+- **Multimodal image content (#863/#977).** Provider-neutral image content
+  blocks for `llm_call` with base64/URL validation and implicit `vision`
+  capability gating. Translation at provider boundaries for Anthropic,
+  OpenAI-compatible, Gemini (now natively registered), and Ollama, plus
+  `vision_supported` capability and conformance coverage.
+
+- **First-class stream generators (#963/#978).** Contextual `gen fn`
+  declarations and `emit` statements with `Stream<T>` runtime support
+  alongside existing `yield`/`Generator<T>`. Parser/AST/formatter/linter/LSP,
+  tree-sitter grammar, docs, and spec coverage. Streams support `for`,
+  `.next()`, `.iter()`, nesting, early break, and body-error propagation;
+  `gen` stays contextual so existing identifiers keep parsing.
+
+- **LLM prompt cache usage (#862/#980).** New `usage` dict on `llm_call`
+  results with cache read/write tokens, Anthropic
+  `cache_creation_input_tokens`, `cache_hit_ratio`, and
+  `cache_savings_usd`. Parsed across Anthropic and OpenAI-compatible response
+  shapes and surfaced through structured-result envelopes; mock provider
+  simulates cache warm/read behavior.
+
+- **Unified LLM thinking config (#849/#971).** Typed `ThinkingConfig`
+  boundary with disabled, enabled-budget, adaptive, and effort modes. The
+  capability matrix replaces the `thinking` boolean with `thinking_modes`
+  (legacy boolean preserved for queries). Mapped through Anthropic,
+  OpenAI-compatible/OpenRouter, and Ollama providers, including OpenAI
+  `reasoning_effort`.
+
+- **LLM budget envelopes (#868/#961).** First-class `budget` envelopes on
+  `llm_call` with pre-flight `max_cost_usd`, `max_input_tokens`,
+  `max_output_tokens`, and `total_budget_usd` checks. Structured terminal
+  `budget_exceeded` errors flow through `try { ... }`. Same envelope threads
+  through `agent_loop`, workflow stages, and `sub_agent_run`, with aggregate
+  loop `total_budget_usd` stopping before an over-budget turn starts.
+
+- **Agent loop profiles (#861/#960).** New `tool_using`, `researcher`,
+  `verifier`, and `completer` profiles with sensible defaults and explicit
+  per-call overrides. Profile parsing applies across direct, bridge-backed,
+  `sub_agent_run`, and workflow agent-loop config paths. Adds
+  `agent_loop` schema-retry handling so verifier/schema profiles retry
+  invalid structured output before accepting a turn.
+
+- **`agent_loop` MCP server tools (#860/#962).** `agent_loop({ mcp_servers:
+  [...] })` bootstraps configured HTTP/stdio MCP servers, lists tools once,
+  prefixes them as `<server>__<tool>`, and merges them into the tool
+  registry/native tool surface. Prefixed calls route back through the live
+  client using the unprefixed MCP name; lifecycle cleanup, docs, and
+  conformance with a mocked HTTP MCP server included.
+
+- **MCP Streamable HTTP transport (#872/#972).** Canonical Streamable HTTP
+  GET/DELETE on the `/mcp` endpoint with `Mcp-Session-Id` continuity, plus
+  event-stream-only POST responses negotiated as SSE `message` events while
+  JSON clients keep `application/json`. Legacy SSE `/sse` and `/messages`
+  routes carry `Deprecation: true`; protocol/origin validation hardened.
+
+- **Project prompt templates over MCP (#879/#974).** `harn mcp serve` now
+  exposes project and prompt-library `.harn.prompt` files via `prompts/list`
+  and `prompts/get`, rendering with supplied arguments, validating required
+  args, and returning text plus structured image content. Advertises
+  `prompts.listChanged` and emits `notifications/prompts/list_changed` on
+  prompt/manifest hot reloads for stdio and legacy SSE clients.
+
+### Changed
+
+- **Canonical LLM error taxonomy enforced in retry (#854/#958).** Retry
+  decisions now consult the structured `kind` (`transient`/`terminal`) and
+  `reason` first; OpenAI-compatible, Anthropic, and Ollama HTTP/provider
+  shapes are mapped (context overflow, content policy, auth, invalid
+  request, model unavailable, rate limit, timeout, network, server). Legacy
+  `category` field and `[rate_limited]` / `[http_error]` message tags
+  preserved for compatibility.
+
+- **Audit hardening across runtime surfaces (#848).** Auth, egress, portal
+  asset serving, skill substitution, tenant registry writes, and namespaced
+  skill lookup tightened. Schema validation composition fixed so
+  `all_of`/union still apply sibling constraints. Host command handling now
+  uses canonical cwd, UTF-8-safe inline output, Gradle wrapper portability,
+  and a split artifact module. Tests isolate global egress policies and
+  agent event sinks to remove parallel-suite contamination.
+
+- **Module splits for maintainability.** `crates/harn-cli/src/package.rs`
+  split into focused submodules (`manifest`, `validation`, `registry`,
+  `lockfile`, `extensions`, `package_ops`, `skills`, with shared
+  `test_support`); every new file under 2,000 LOC (#938/#975). The trigger
+  dispatcher gains `predicate_eval.rs` (predicate evaluation, cache replay,
+  budget accounting, action-graph metadata) and `circuits.rs` (destination
+  circuit state/probing, budget/circuit DLQ helpers), reducing
+  `triggers/dispatcher/mod.rs` from 4633 to 3827 LOC with no behavior change
+  (#940/#973).
+
 ## v0.7.49
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.49"
+version = "0.7.50"
 dependencies = [
  "async-trait",
  "axum",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.49"
+version = "0.7.50"
 dependencies = [
  "harn-vm",
  "serde",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.49"
+version = "0.7.50"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.49"
+version = "0.7.50"
 dependencies = [
  "anyhow",
  "base64",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.49"
+version = "0.7.50"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1812,11 +1812,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.49"
+version = "0.7.50"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.49"
+version = "0.7.50"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.49"
+version = "0.7.50"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.49"
+version = "0.7.50"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.49"
+version = "0.7.50"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.49"
+version = "0.7.50"
 dependencies = [
  "async-trait",
  "axum",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "harn-vm"
-version = "0.7.49"
+version = "0.7.50"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.49"
+version = "0.7.50"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -2341,6 +2341,14 @@ async fn json_log_format_writes_structured_rotating_file_with_trace_ids() {
 // Regression coverage for harn#327 and harn#479: ingest should inject W3C
 // trace-context headers, queue append should preserve the trace, and dispatch
 // should adopt the queue append span as its remote parent.
+//
+// The orchestrator subprocess runs with the simple span processor
+// (`HARN_OTEL_SPAN_PROCESSOR=simple`). That replaces the production batch
+// pipeline with a synchronous "export each span on close" pipeline, so the
+// dispatch span — which closes inside graceful drain — is guaranteed to be on
+// the wire before the orchestrator exits. The test then has only one
+// synchronization point: process exit. No polling, no wall-clock cadence, no
+// dependence on `force_flush`-during-shutdown reliability.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
     let _lock = lock_orchestrator_tests();
@@ -2359,6 +2367,8 @@ async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
             "HARN_OTEL_HEADERS",
             "authorization=Bearer otel-token,x-tenant-id=tenant-abc",
         ),
+        // Synchronous export per span close. See doc comment above this fn.
+        ("HARN_OTEL_SPAN_PROCESSOR", "simple"),
         ("RUST_LOG", "info"),
     ];
     let mut process = spawn_orchestrator(&temp, &[], &envs);
@@ -2381,27 +2391,20 @@ async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
     assert!(status.success(), "status={status} stderr={stderr}");
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
 
-    let deadline = Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
-    let spans = loop {
-        let spans = collector.collected_spans();
-        let has_ingest = spans.iter().any(|span| span.name == "ingest");
-        let has_queue_append = spans.iter().any(|span| span.name == "queue_append");
-        let has_dispatch = spans.iter().any(|span| span.name == "dispatch");
-        if has_ingest && has_queue_append && has_dispatch {
-            break spans;
-        }
-        if Instant::now() >= deadline {
-            let requests = collector.requests.lock().unwrap().clone();
-            panic!(
-                "timed out waiting for OTel spans\ncollector_headers={:#?}",
-                requests
-                    .iter()
-                    .map(|request| request.headers.clone())
-                    .collect::<Vec<_>>()
-            );
-        }
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    };
+    let spans = collector.collected_spans();
+    let span_names: Vec<&str> = spans.iter().map(|span| span.name.as_str()).collect();
+    assert!(
+        span_names.contains(&"ingest"),
+        "ingest span missing; observed={span_names:?}"
+    );
+    assert!(
+        span_names.contains(&"queue_append"),
+        "queue_append span missing; observed={span_names:?}"
+    );
+    assert!(
+        span_names.contains(&"dispatch"),
+        "dispatch span missing; observed={span_names:?}"
+    );
 
     let ingest = spans.iter().find(|span| span.name == "ingest").unwrap();
     let queue_append = spans

--- a/crates/harn-vm/src/observability/otel.rs
+++ b/crates/harn-vm/src/observability/otel.rs
@@ -483,6 +483,7 @@ fn build_tracer_provider_from_env(
     use opentelemetry_otlp::{Protocol, WithExportConfig as _, WithHttpConfig as _};
     use opentelemetry_sdk::runtime;
     use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
+    use opentelemetry_sdk::trace::SimpleSpanProcessor;
     use opentelemetry_sdk::Resource;
 
     let Some(raw_endpoint) = std::env::var("HARN_OTEL_ENDPOINT")
@@ -500,6 +501,13 @@ fn build_tracer_provider_from_env(
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| "harn-orchestrator".to_string());
     let headers = parse_headers(&std::env::var("HARN_OTEL_HEADERS").unwrap_or_default());
+    let processor_kind = parse_span_processor_kind(
+        std::env::var("HARN_OTEL_SPAN_PROCESSOR")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty()),
+    )?;
 
     let exporter = opentelemetry_otlp::SpanExporter::builder()
         .with_http()
@@ -514,13 +522,43 @@ fn build_tracer_provider_from_env(
         .build()
         .map_err(|error| format!("failed to build OTel span exporter: {error}"))?;
 
-    let batch = BatchSpanProcessor::builder(exporter, runtime::Tokio).build();
-    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
-        .with_resource(Resource::builder().with_service_name(service_name).build())
-        .with_span_processor(batch)
-        .build();
+    let mut builder = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_resource(Resource::builder().with_service_name(service_name).build());
+    builder = match processor_kind {
+        SpanProcessorKind::Batch => builder
+            .with_span_processor(BatchSpanProcessor::builder(exporter, runtime::Tokio).build()),
+        // Simple processor exports each span synchronously when it ends. This
+        // gives test harnesses a deterministic "process exit ⇒ all spans
+        // exported" guarantee without a force_flush race or scheduled-delay
+        // wall-clock dependency. Production paths must keep using batch.
+        SpanProcessorKind::Simple => {
+            builder.with_span_processor(SimpleSpanProcessor::new(exporter))
+        }
+    };
+    let provider = builder.build();
     global::set_tracer_provider(provider.clone());
     Ok(Some(provider))
+}
+
+#[cfg(feature = "otel")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SpanProcessorKind {
+    Batch,
+    Simple,
+}
+
+#[cfg(feature = "otel")]
+fn parse_span_processor_kind(value: Option<&str>) -> Result<SpanProcessorKind, String> {
+    match value {
+        None => Ok(SpanProcessorKind::Batch),
+        Some(value) => match value.to_ascii_lowercase().as_str() {
+            "batch" => Ok(SpanProcessorKind::Batch),
+            "simple" => Ok(SpanProcessorKind::Simple),
+            other => Err(format!(
+                "unsupported HARN_OTEL_SPAN_PROCESSOR value {other:?}; expected 'batch' or 'simple'"
+            )),
+        },
+    }
 }
 
 #[cfg(feature = "otel")]
@@ -635,5 +673,41 @@ mod tests {
         );
         assert_eq!(headers.get("x-tenant-id"), Some(&"tenant-123".to_string()));
         assert_eq!(headers.get("trace"), Some(&"true".to_string()));
+    }
+
+    #[test]
+    fn parses_span_processor_kind_defaults_to_batch() {
+        assert_eq!(
+            parse_span_processor_kind(None).unwrap(),
+            SpanProcessorKind::Batch
+        );
+    }
+
+    #[test]
+    fn parses_span_processor_kind_accepts_known_values() {
+        assert_eq!(
+            parse_span_processor_kind(Some("batch")).unwrap(),
+            SpanProcessorKind::Batch
+        );
+        assert_eq!(
+            parse_span_processor_kind(Some("Batch")).unwrap(),
+            SpanProcessorKind::Batch
+        );
+        assert_eq!(
+            parse_span_processor_kind(Some("simple")).unwrap(),
+            SpanProcessorKind::Simple
+        );
+        assert_eq!(
+            parse_span_processor_kind(Some("SIMPLE")).unwrap(),
+            SpanProcessorKind::Simple
+        );
+    }
+
+    #[test]
+    fn parses_span_processor_kind_rejects_unknown_values() {
+        let error = parse_span_processor_kind(Some("forwarder")).unwrap_err();
+        assert!(error.contains("forwarder"), "{error}");
+        assert!(error.contains("batch"), "{error}");
+        assert!(error.contains("simple"), "{error}");
     }
 }


### PR DESCRIPTION
## Summary

Consolidated release PR for v0.7.50. Bumps `Cargo.toml` / `Cargo.lock` /
per-crate manifests from 0.7.49 → 0.7.50 and ships the changelog + derived
files in one commit. Once this lands, the Publish release workflow auto-fires
on tag drift to push `v0.7.50`, run `cargo publish`, and trigger the binary +
container build.

## Highlights

- **Enterprise LLM providers (#976)** — Bedrock (SigV4), Azure OpenAI, Vertex AI Gemini.
- **Provider capability matrix (#979)** — `harn check --provider-matrix` + generated docs.
- **Multimodal images (#977)** — provider-neutral image content for `llm_call`.
- **First-class stream generators (#978)** — contextual `gen fn` / `emit` / `Stream<T>`.
- **LLM prompt cache usage (#980)** — `usage` dict with cache tokens, hit ratio, and savings.
- **Unified thinking config (#971)** — typed `ThinkingConfig` with disabled / budget / adaptive / effort modes.
- **LLM budget envelopes (#961)** — pre-flight `max_cost_usd` / `max_input_tokens` / `max_output_tokens` / aggregate `total_budget_usd`.
- **Agent loop profiles (#960)** — `tool_using` / `researcher` / `verifier` / `completer` with schema-retry handling.
- **`agent_loop` MCP server tools (#962)** — bootstrap HTTP/stdio MCP servers and merge their tools.
- **MCP Streamable HTTP transport (#972)** — canonical GET/DELETE on `/mcp` + SSE message events; legacy SSE deprecated.
- **Project prompt templates over MCP (#974)** — `prompts/list`, `prompts/get`, hot-reload notifications.
- **Audit hardening (#848)** — auth, egress, portal asset serving, skill substitution, schema composition fixes.
- **LLM error taxonomy applied to retries (#958)** — structured `kind` + `reason` drives retry decisions.
- **Module splits** — `harn-cli/package` and trigger dispatcher refactors with no behavior change (#975, #973).

See `CHANGELOG.md` for the full v0.7.50 entry.

## Test plan

- [x] `./scripts/release_ship.sh --prepare --bump patch` (audit + dry-run publish + bump + regen)
- [x] Pre-commit hook (rustfmt, clippy, markdownlint)
- [x] Pre-push hook (workspace nextest 2962/2962, markdownlint)
- [ ] Merge-queue CI gate (full lint/test/conformance/spec/highlight/docs/portal/Windows)
- [ ] Publish release workflow auto-fires on tag drift after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)