### PR TITLE
Implement provider auto-resolution from model IDs

### DIFF
--- a/conformance/tests/integration/llm_provider_catalog.harn
+++ b/conformance/tests/integration/llm_provider_catalog.harn
@@ -1,7 +1,7 @@
 pipeline test(task) {
   let local = llm_resolve_model("local:gemma-4-e4b-it")
   assert_eq(local.id, "gemma-4-e4b-it")
-  assert_eq(local.provider, "local")
+  assert_eq(local.provider, "ollama")
   let ollama = llm_model_info("ollama:qwen3:30b-a3b")
   assert_eq(ollama.id, "qwen3:30b-a3b")
   assert_eq(ollama.provider, "ollama")

--- a/crates/harn-vm/src/llm/helpers/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/mod.rs
@@ -286,10 +286,10 @@ mod tests {
     }
 
     #[test]
-    fn provider_auto_with_local_prefix_model_routes_to_local() {
+    fn provider_auto_with_local_prefix_model_routes_to_ollama() {
         // `provider: "auto"` must fall through to inference. With a `local:`
-        // model prefix that inference should resolve to the local provider
-        // rather than anthropic/ollama.
+        // model prefix that inference should resolve to Ollama rather than
+        // the local OpenAI-compatible provider or Anthropic.
         let _guard = crate::llm::env_lock().lock().expect("env lock");
         let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
         let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
@@ -307,7 +307,7 @@ mod tests {
             "model".to_string(),
             VmValue::String(Rc::from("local:gemma-4-e4b-it")),
         );
-        assert_eq!(vm_resolve_provider(&Some(opts)), "local");
+        assert_eq!(vm_resolve_provider(&Some(opts)), "ollama");
 
         // Case-insensitive: "AUTO" should behave the same.
         let mut opts2: BTreeMap<String, VmValue> = BTreeMap::new();
@@ -316,7 +316,7 @@ mod tests {
             "model".to_string(),
             VmValue::String(Rc::from("local:foo/bar")),
         );
-        assert_eq!(vm_resolve_provider(&Some(opts2)), "local");
+        assert_eq!(vm_resolve_provider(&Some(opts2)), "ollama");
 
         // Explicit non-auto provider still wins.
         let mut opts3: BTreeMap<String, VmValue> = BTreeMap::new();
@@ -335,6 +335,65 @@ mod tests {
             match prev_harn_model {
                 Some(v) => std::env::set_var("HARN_LLM_MODEL", v),
                 None => std::env::remove_var("HARN_LLM_MODEL"),
+            }
+            match prev_base {
+                Some(v) => std::env::set_var("LOCAL_LLM_BASE_URL", v),
+                None => std::env::remove_var("LOCAL_LLM_BASE_URL"),
+            }
+        }
+        reset_provider_key_cache();
+    }
+
+    #[test]
+    fn provider_auto_unknown_model_warns_and_uses_default_provider() {
+        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
+        let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
+        let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
+        let prev_base = std::env::var("LOCAL_LLM_BASE_URL").ok();
+        unsafe {
+            std::env::remove_var("HARN_LLM_PROVIDER");
+            std::env::remove_var("HARN_LLM_MODEL");
+            std::env::remove_var("LOCAL_LLM_BASE_URL");
+            std::env::set_var("HARN_DEFAULT_PROVIDER", "mock");
+        }
+        reset_provider_key_cache();
+
+        crate::events::clear_event_sinks();
+        let sink = Rc::new(crate::events::CollectorSink::new());
+        crate::events::add_event_sink(sink.clone());
+
+        let opts = BTreeMap::from([
+            ("provider".to_string(), VmValue::String(Rc::from("auto"))),
+            (
+                "model".to_string(),
+                VmValue::String(Rc::from("unclassified-provider-model-for-test")),
+            ),
+        ]);
+
+        assert_eq!(vm_resolve_provider(&Some(opts)), "mock");
+        let logs = sink.logs.borrow();
+        assert!(logs.iter().any(|event| {
+            event.level == crate::events::EventLevel::Warn
+                && event.category == "llm.provider"
+                && event
+                    .message
+                    .contains("falling back to default provider 'mock'")
+        }));
+
+        crate::events::reset_event_sinks();
+        unsafe {
+            match prev_harn_provider {
+                Some(v) => std::env::set_var("HARN_LLM_PROVIDER", v),
+                None => std::env::remove_var("HARN_LLM_PROVIDER"),
+            }
+            match prev_harn_model {
+                Some(v) => std::env::set_var("HARN_LLM_MODEL", v),
+                None => std::env::remove_var("HARN_LLM_MODEL"),
+            }
+            match prev_default_provider {
+                Some(v) => std::env::set_var("HARN_DEFAULT_PROVIDER", v),
+                None => std::env::remove_var("HARN_DEFAULT_PROVIDER"),
             }
             match prev_base {
                 Some(v) => std::env::set_var("LOCAL_LLM_BASE_URL", v),

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -46,9 +46,8 @@ fn route_target_from_short(target: &str) -> Result<(String, String), crate::valu
             return Ok((resolved_model, provider.trim().to_string()));
         }
     }
-    let (model, provider) = crate::llm_config::resolve_model(target);
-    let provider = provider.unwrap_or_else(|| crate::llm_config::infer_provider(&model));
-    Ok((model, provider))
+    let resolved = crate::llm_config::resolve_model_info(target);
+    Ok((resolved.id, resolved.provider))
 }
 
 fn parse_route_policy_text(text: &str) -> Result<crate::llm::api::LlmRoutePolicy, VmError> {

--- a/crates/harn-vm/src/llm/helpers/provider.rs
+++ b/crates/harn-vm/src/llm/helpers/provider.rs
@@ -9,6 +9,7 @@ use crate::value::{VmError, VmValue};
 /// Cached for process lifetime since env vars don't change mid-run.
 static PROVIDER_KEY_CACHE: OnceLock<Mutex<HashMap<String, bool>>> = OnceLock::new();
 static MODEL_TIER_WARNING_CACHE: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+static PROVIDER_INFERENCE_WARNING_CACHE: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
 /// Check whether `provider` has a usable API key (or needs none). Cached.
 pub(crate) fn provider_key_available(provider: &str) -> bool {
@@ -63,6 +64,53 @@ fn warn_model_tier_fallback(target: &str, requested_provider: Option<&str>, chos
         ),
         BTreeMap::new(),
     );
+}
+
+fn warn_provider_default_fallback(model_id: &str, provider: &str) {
+    let key = format!("{model_id}|{provider}");
+    let cache = PROVIDER_INFERENCE_WARNING_CACHE.get_or_init(|| Mutex::new(HashSet::new()));
+    let mut guard = cache.lock().unwrap();
+    if !guard.insert(key) {
+        return;
+    }
+    drop(guard);
+
+    crate::events::log_warn_meta(
+        "llm.provider",
+        &format!(
+            "could not infer provider from model id '{model_id}'; falling back to default provider '{provider}'"
+        ),
+        BTreeMap::from([
+            (
+                "model".to_string(),
+                serde_json::Value::String(model_id.to_string()),
+            ),
+            (
+                "provider".to_string(),
+                serde_json::Value::String(provider.to_string()),
+            ),
+            (
+                "reason".to_string(),
+                serde_json::Value::String("default_provider_fallback".to_string()),
+            ),
+        ]),
+    );
+}
+
+fn infer_provider_from_model_selector(raw_model: &str, warn_on_default: bool) -> String {
+    use crate::llm::provider::ProviderInferenceSource;
+    use crate::llm_config;
+
+    let (_resolved_model, resolved_provider) = llm_config::resolve_model(raw_model);
+    if let Some(provider) = resolved_provider {
+        return provider;
+    }
+
+    let inference = llm_config::infer_provider_detail(raw_model);
+    if warn_on_default && inference.source == ProviderInferenceSource::DefaultFallback {
+        warn_provider_default_fallback(raw_model, &inference.provider);
+    }
+    inference.provider
 }
 
 fn env_selected_model_for_tier() -> Option<(String, String)> {
@@ -201,6 +249,13 @@ pub(crate) fn vm_resolve_provider(options: &Option<BTreeMap<String, VmValue>>) -
         if !p.eq_ignore_ascii_case("auto") {
             return p;
         }
+        if let Some(m) = options
+            .as_ref()
+            .and_then(|o| o.get("model"))
+            .map(|v| v.display())
+        {
+            return infer_provider_from_model_selector(&m, true);
+        }
     }
     if let Ok(p) = std::env::var("HARN_LLM_PROVIDER") {
         return p;
@@ -218,7 +273,7 @@ pub(crate) fn vm_resolve_provider(options: &Option<BTreeMap<String, VmValue>>) -
         .and_then(|o| o.get("model"))
         .map(|v| v.display())
     {
-        return llm_config::infer_provider(&m);
+        return infer_provider_from_model_selector(&m, true);
     }
     if let Some(tier) = options
         .as_ref()
@@ -230,14 +285,14 @@ pub(crate) fn vm_resolve_provider(options: &Option<BTreeMap<String, VmValue>>) -
         }
     }
     if let Ok(m) = std::env::var("HARN_LLM_MODEL") {
-        return llm_config::infer_provider(&m);
+        return infer_provider_from_model_selector(&m, true);
     }
     // Default to anthropic, but fall back to keyless providers when its
     // key is missing - avoids noisy errors when a sub-pipeline (e.g.
     // enrichment) didn't inherit the provider env.
-    let default = "anthropic";
-    if provider_key_available(default) {
-        return default.to_string();
+    let default = llm_config::default_provider();
+    if provider_key_available(&default) {
+        return default;
     }
     for fallback in ["ollama", "local"] {
         if provider_key_available(fallback) {
@@ -245,7 +300,7 @@ pub(crate) fn vm_resolve_provider(options: &Option<BTreeMap<String, VmValue>>) -
         }
     }
     // Let resolve_api_key surface its descriptive error.
-    default.to_string()
+    default
 }
 
 pub(crate) fn vm_resolve_model(

--- a/crates/harn-vm/src/llm/provider.rs
+++ b/crates/harn-vm/src/llm/provider.rs
@@ -10,6 +10,76 @@ use std::collections::HashSet;
 use super::api::{DeltaSender, LlmRequestPayload, LlmResult};
 use crate::value::VmError;
 
+/// Source of an automatic provider inference decision.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProviderInferenceSource {
+    /// The model id matched a transport/model prefix that Harn knows natively.
+    BuiltinRule,
+    /// No rule matched and the configured default provider was used.
+    DefaultFallback,
+}
+
+/// Result of resolving `provider: "auto"` from a model id.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ProviderInference {
+    pub provider: String,
+    pub source: ProviderInferenceSource,
+}
+
+impl ProviderInference {
+    pub(crate) fn builtin(provider: impl Into<String>) -> Self {
+        Self {
+            provider: provider.into(),
+            source: ProviderInferenceSource::BuiltinRule,
+        }
+    }
+
+    pub(crate) fn default(provider: impl Into<String>) -> Self {
+        Self {
+            provider: provider.into(),
+            source: ProviderInferenceSource::DefaultFallback,
+        }
+    }
+}
+
+/// Infer a provider from well-known provider/model id shapes.
+///
+/// This is the built-in rule set used after user-configured inference rules.
+/// It deliberately matches only one `/` for OpenRouter so provider-native paths
+/// with deeper resource hierarchies can fall through to explicit config rules
+/// or the default provider instead of being swallowed by OpenRouter.
+pub(crate) fn infer_provider_from_model_id(
+    model_id: &str,
+    default_provider: &str,
+) -> ProviderInference {
+    if model_id.starts_with("local:") || model_id.starts_with("ollama:") {
+        return ProviderInference::builtin("ollama");
+    }
+    if model_id.starts_with("huggingface:") || model_id.starts_with("hf:") {
+        return ProviderInference::builtin("huggingface");
+    }
+    if model_id.matches('/').count() == 1 {
+        return ProviderInference::builtin("openrouter");
+    }
+    if model_id.starts_with("claude-") {
+        return ProviderInference::builtin("anthropic");
+    }
+    if model_id.starts_with("gpt-")
+        || model_id.starts_with("o1")
+        || model_id.starts_with("o3")
+        || model_id.starts_with("o4")
+    {
+        return ProviderInference::builtin("openai");
+    }
+    if model_id.starts_with("gemini-") {
+        return ProviderInference::builtin("gemini");
+    }
+    if model_id.contains(':') {
+        return ProviderInference::builtin("ollama");
+    }
+    ProviderInference::default(default_provider)
+}
+
 /// Trait that all LLM providers implement.
 ///
 /// Dispatch currently goes through concrete types in

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -17,6 +17,8 @@ thread_local! {
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct ProvidersConfig {
     #[serde(default)]
+    pub default_provider: Option<String>,
+    #[serde(default)]
     pub providers: BTreeMap<String, ProviderDef>,
     #[serde(default)]
     pub aliases: BTreeMap<String, AliasDef>,
@@ -36,7 +38,8 @@ pub struct ProvidersConfig {
 
 impl ProvidersConfig {
     pub fn is_empty(&self) -> bool {
-        self.providers.is_empty()
+        self.default_provider.is_none()
+            && self.providers.is_empty()
             && self.aliases.is_empty()
             && self.models.is_empty()
             && self.qc_defaults.is_empty()
@@ -51,6 +54,10 @@ impl ProvidersConfig {
         self.aliases.extend(overlay.aliases.clone());
         self.models.extend(overlay.models.clone());
         self.qc_defaults.extend(overlay.qc_defaults.clone());
+
+        if overlay.default_provider.is_some() {
+            self.default_provider = overlay.default_provider.clone();
+        }
 
         if !overlay.inference_rules.is_empty() {
             let mut merged = overlay.inference_rules.clone();
@@ -376,7 +383,7 @@ pub fn resolve_model_info(selector: &str) -> ResolvedModel {
         };
     }
 
-    let provider = infer_provider_with_config(&config, selector);
+    let provider = infer_provider_with_config(&config, selector).provider;
     let id = normalize_model_id(selector);
     let tool_format = default_tool_format_with_config(&config, &id, &provider);
     let tier = model_tier_with_config(&config, &id);
@@ -391,60 +398,67 @@ pub fn resolve_model_info(selector: &str) -> ResolvedModel {
 
 /// Infer provider from a model ID using inference rules.
 pub fn infer_provider(model_id: &str) -> String {
+    infer_provider_detail(model_id).provider
+}
+
+/// Infer provider from a model ID and retain whether the configured default was used.
+pub(crate) fn infer_provider_detail(model_id: &str) -> crate::llm::provider::ProviderInference {
     let config = effective_config();
     infer_provider_with_config(&config, model_id)
 }
 
-fn infer_provider_with_config(config: &ProvidersConfig, model_id: &str) -> String {
-    if model_id.starts_with("local:") {
-        return "local".to_string();
-    }
-    if model_id.starts_with("ollama:") {
-        return "ollama".to_string();
+fn infer_provider_with_config(
+    config: &ProvidersConfig,
+    model_id: &str,
+) -> crate::llm::provider::ProviderInference {
+    if model_id.starts_with("local:") || model_id.starts_with("ollama:") {
+        return crate::llm::provider::ProviderInference::builtin("ollama");
     }
     if model_id.starts_with("huggingface:") || model_id.starts_with("hf:") {
-        return "huggingface".to_string();
+        return crate::llm::provider::ProviderInference::builtin("huggingface");
     }
     for rule in &config.inference_rules {
         if let Some(exact) = &rule.exact {
             if model_id == exact {
-                return rule.provider.clone();
+                return crate::llm::provider::ProviderInference::builtin(rule.provider.clone());
             }
         }
         if let Some(pattern) = &rule.pattern {
             if glob_match(pattern, model_id) {
-                return rule.provider.clone();
+                return crate::llm::provider::ProviderInference::builtin(rule.provider.clone());
             }
         }
         if let Some(substr) = &rule.contains {
             if model_id.contains(substr.as_str()) {
-                return rule.provider.clone();
+                return crate::llm::provider::ProviderInference::builtin(rule.provider.clone());
             }
         }
     }
-    // Fallback to hardcoded inference.
-    // Order matters: `local:` must beat the generic `:` → ollama rule, and
-    // any prefix-based rule must beat the generic `/` → openrouter rule for
-    // ids like `local:owner/model`.
-    if model_id.starts_with("claude-") {
-        return "anthropic".to_string();
-    }
-    if model_id.to_lowercase().starts_with("or-") {
-        return "openrouter".to_string();
-    }
-    if model_id.starts_with("gpt-") || model_id.starts_with("o1") || model_id.starts_with("o3") {
-        return "openai".to_string();
-    }
-    if model_id.starts_with("gemini-") || model_id.starts_with("models/gemini-") {
-        return "gemini".to_string();
-    }
-    if model_id.contains('/') {
-        return "openrouter".to_string();
-    }
-    if model_id.contains(':') {
-        return "ollama".to_string();
-    }
-    "anthropic".to_string()
+    crate::llm::provider::infer_provider_from_model_id(
+        model_id,
+        &default_provider_with_config(config),
+    )
+}
+
+pub fn default_provider() -> String {
+    let config = effective_config();
+    default_provider_with_config(&config)
+}
+
+fn default_provider_with_config(config: &ProvidersConfig) -> String {
+    std::env::var("HARN_DEFAULT_PROVIDER")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case("auto"))
+        .or_else(|| {
+            config
+                .default_provider
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case("auto"))
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "anthropic".to_string())
 }
 
 /// Get model tier ("small", "mid", "frontier").
@@ -767,7 +781,10 @@ pub fn resolve_base_url(pdef: &ProviderDef) -> String {
 }
 
 fn default_config() -> ProvidersConfig {
-    let mut config = ProvidersConfig::default();
+    let mut config = ProvidersConfig {
+        default_provider: Some("anthropic".to_string()),
+        ..Default::default()
+    };
 
     config.providers.insert(
         "anthropic".to_string(),
@@ -1220,10 +1237,10 @@ fn default_config() -> ProvidersConfig {
             provider: "openai".to_string(),
         },
         InferenceRule {
-            pattern: Some("local:*".to_string()),
+            pattern: Some("o4*".to_string()),
             contains: None,
             exact: None,
-            provider: "local".to_string(),
+            provider: "openai".to_string(),
         },
         InferenceRule {
             pattern: Some("anthropic.claude-*".to_string()),
@@ -1259,19 +1276,7 @@ fn default_config() -> ProvidersConfig {
             pattern: Some("gemini-*".to_string()),
             contains: None,
             exact: None,
-            provider: "vertex".to_string(),
-        },
-        InferenceRule {
-            pattern: None,
-            contains: Some("/".to_string()),
-            exact: None,
-            provider: "openrouter".to_string(),
-        },
-        InferenceRule {
-            pattern: None,
-            contains: Some(":".to_string()),
-            exact: None,
-            provider: "ollama".to_string(),
+            provider: "gemini".to_string(),
         },
     ];
 
@@ -1554,30 +1559,63 @@ mod tests {
 
     #[test]
     fn test_infer_provider_from_defaults() {
+        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
+        unsafe {
+            std::env::remove_var("HARN_DEFAULT_PROVIDER");
+        }
+
         assert_eq!(infer_provider("claude-sonnet-4-20250514"), "anthropic");
         assert_eq!(infer_provider("gpt-4o"), "openai");
         assert_eq!(infer_provider("o1-preview"), "openai");
         assert_eq!(infer_provider("o3-mini"), "openai");
+        assert_eq!(infer_provider("o4-mini"), "openai");
+        assert_eq!(infer_provider("gemini-2.5-pro"), "gemini");
         assert_eq!(infer_provider("qwen/qwen3-coder"), "openrouter");
         assert_eq!(infer_provider("llama3.2:latest"), "ollama");
         assert_eq!(infer_provider("unknown-model"), "anthropic");
+
+        unsafe {
+            match prev_default_provider {
+                Some(value) => std::env::set_var("HARN_DEFAULT_PROVIDER", value),
+                None => std::env::remove_var("HARN_DEFAULT_PROVIDER"),
+            }
+        }
     }
 
     #[test]
-    fn test_infer_provider_local_prefix() {
-        // `local:` must route to the local OpenAI-compatible provider, not
-        // ollama (which would otherwise swallow everything containing `:`).
-        assert_eq!(infer_provider("local:gemma-4-e4b-it"), "local");
-        assert_eq!(infer_provider("local:qwen2.5"), "local");
-        // Even when the id also contains `/`, the `local:` prefix wins.
-        assert_eq!(infer_provider("local:owner/model"), "local");
+    fn test_infer_provider_prefix_rules() {
+        assert_eq!(infer_provider("local:gemma-4-e4b-it"), "ollama");
+        assert_eq!(infer_provider("ollama:qwen3:30b-a3b"), "ollama");
+        // Even when the id also contains `/`, the local transport prefix wins.
+        assert_eq!(infer_provider("local:owner/model"), "ollama");
+        assert_eq!(infer_provider("hf:Qwen/Qwen3.6-35B-A3B"), "huggingface");
+    }
+
+    #[test]
+    fn test_openrouter_inference_requires_one_slash() {
+        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
+        unsafe {
+            std::env::remove_var("HARN_DEFAULT_PROVIDER");
+        }
+
+        assert_eq!(infer_provider("org/model"), "openrouter");
+        assert_eq!(infer_provider("org/team/model"), "anthropic");
+
+        unsafe {
+            match prev_default_provider {
+                Some(value) => std::env::set_var("HARN_DEFAULT_PROVIDER", value),
+                None => std::env::remove_var("HARN_DEFAULT_PROVIDER"),
+            }
+        }
     }
 
     #[test]
     fn test_resolve_model_info_normalizes_provider_prefixes() {
         let local = resolve_model_info("local:gemma-4-e4b-it");
         assert_eq!(local.id, "gemma-4-e4b-it");
-        assert_eq!(local.provider, "local");
+        assert_eq!(local.provider, "ollama");
 
         let ollama = resolve_model_info("ollama:qwen3:30b-a3b");
         assert_eq!(ollama.id, "qwen3:30b-a3b");
@@ -1682,7 +1720,31 @@ mod tests {
 
         let vertex = provider_config("vertex").unwrap();
         assert_eq!(vertex.base_url, "https://aiplatform.googleapis.com/v1");
-        assert_eq!(infer_provider("gemini-1.5-pro-002"), "vertex");
+        assert_eq!(infer_provider("gemini-1.5-pro-002"), "gemini");
+    }
+
+    #[test]
+    fn test_default_provider_env_override_for_unknown_model() {
+        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
+        unsafe {
+            std::env::set_var("HARN_DEFAULT_PROVIDER", "openai");
+        }
+
+        let inference = infer_provider_detail("unknown-model");
+
+        unsafe {
+            match prev_default_provider {
+                Some(value) => std::env::set_var("HARN_DEFAULT_PROVIDER", value),
+                None => std::env::remove_var("HARN_DEFAULT_PROVIDER"),
+            }
+        }
+
+        assert_eq!(inference.provider, "openai");
+        assert_eq!(
+            inference.source,
+            crate::llm::provider::ProviderInferenceSource::DefaultFallback
+        );
     }
 
     #[test]

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -599,8 +599,8 @@ println(response.output_tokens)
 
 | Option | Type | Default | Notes |
 |---|---|---|---|
-| `provider` | string | `"auto"` | `"auto"` infers from `model` (`local:*` → local, `/` → openrouter, `claude-*` → anthropic, `gpt-*` → openai, `llm:` → ollama). Explicit wins. |
-| `model` | string | (inferred) | `local:gemma-4-e4b-it` routes through local. |
+| `provider` | string | `"auto"` | Explicit provider wins. `"auto"` infers from `model`; see the resolution table below. |
+| `model` | string | (inferred) | `local:gemma-4-e4b-it` strips the `local:` transport prefix and routes through Ollama. |
 | `max_tokens` | int | 4096 | |
 | `temperature` | float | provider default | |
 | `tools` | list | nil | Registered tool schemas. |
@@ -613,6 +613,26 @@ println(response.output_tokens)
 | `llm_retries` | int | 0 | Retries on transient HTTP / provider errors. Raw `llm_call` is fail-fast by default; set to N to allow N retries after the first attempt. |
 | `llm_backoff_ms` | int | 250 | Base exponential backoff in milliseconds. |
 | `stream` | bool | true | SSE streaming transport. |
+
+Provider auto-resolution precedence:
+
+1. Explicit `provider` option other than `"auto"` wins.
+2. `provider: "auto"` with a `model` infers from the model selector.
+3. If `provider` is omitted, `HARN_LLM_PROVIDER` wins when set; otherwise a `model` infers the provider.
+4. Unknown model IDs fall back to `HARN_DEFAULT_PROVIDER`, then the
+   configured default provider (`anthropic` in the built-in catalog),
+   and emit a warning.
+
+| Model selector | Provider | Model sent to provider |
+|---|---|---|
+| `local:<model>` | `ollama` | `<model>` |
+| `ollama:<model>` | `ollama` | `<model>` |
+| `<org>/<model>` (one slash) | `openrouter` | unchanged |
+| `claude-*` | `anthropic` | unchanged |
+| `gpt-*`, `o1*`, `o3*`, `o4*` | `openai` | unchanged |
+| `gemini-*` | `gemini` | unchanged |
+| `<model>:<tag>` | `ollama` | unchanged |
+| anything else | `HARN_DEFAULT_PROVIDER` / configured default | unchanged |
 
 ### Tool executor declarations
 
@@ -1491,8 +1511,9 @@ in-flight work. Use both when batching LLM calls at scale.
   `improvement`. Small models often leave them blank, and validation
   will fail every time. Use the system prompt to demand non-empty
   strings instead.
-- On `llm_call`, `provider: "auto"` with `model: "local:foo"` routes
-  to the local provider. Without `"auto"`, explicit `"local"` wins.
+- On `llm_call`, `provider: "auto"` with `model: "local:foo"` strips
+  the `local:` prefix and routes to Ollama. Without `"auto"`, an
+  explicit provider such as `"local"` still wins.
 - `schema_retries` retries schema-validation failures with a
   corrective nudge. `llm_retries` retries transient provider errors.
   They compose orthogonally — each schema retry starts a fresh


### PR DESCRIPTION
## Summary
- add built-in provider inference metadata for `provider: "auto"` model selectors, including `local:`/`ollama:` -> Ollama, one-slash OpenRouter IDs, Claude/OpenAI/Gemini prefixes, and default fallback tracking
- add `HARN_DEFAULT_PROVIDER` / configured `default_provider` fallback handling with a one-time runtime warning for unclassified model IDs
- document provider auto-resolution precedence and the model selector table in the LLM quickref

Fixes #852.

## Verification
- `cargo fmt --all --check`
- `cargo clippy -p harn-vm --lib -- -D warnings`
- `cargo test -p harn-vm llm_config::tests -- --nocapture`
- `cargo test -p harn-vm llm::helpers::tests -- --nocapture`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`, markdownlint
- pre-push hook: workspace nextest suite, markdownlint

## Self-review
- Re-read the final diff for precedence, alias handling, warning deduplication, and docs drift. Tightened default-provider normalization so blank/`auto` configured values fall back to the built-in default instead of becoming literal provider IDs.