### PR TITLE
Add llm_call transport retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ granular archaeology.
 
 ### Added
 
+- **Native `llm_call` transport retries (#853).** Raw `llm_call` and
+  structured wrappers now accept `llm_retries` and `llm_backoff_ms` for
+  transient provider failures, sharing the canonical LLM error taxonomy while
+  keeping schema retries independent. Plain `llm_call` remains fail-fast by
+  default (`llm_retries: 0`, `llm_backoff_ms: 250`).
+
 - **Canonical LLM error taxonomy (#854).** Provider transport errors now surface
   `kind` (`"transient"` / `"terminal"`) and `reason` (`"rate_limit"`,
   `"server_error"`, `"network_error"`, `"timeout"`, `"auth_failure"`,

--- a/conformance/tests/integration/llm_call_transport_retries.expected
+++ b/conformance/tests/integration/llm_call_transport_retries.expected
@@ -1,0 +1,13 @@
+ok after retry
+2
+true
+transient
+server_error
+2
+true
+1
+true
+schema_validation
+1
+fixed
+2

--- a/conformance/tests/integration/llm_call_transport_retries.harn
+++ b/conformance/tests/integration/llm_call_transport_retries.harn
@@ -1,0 +1,66 @@
+pipeline default() {
+  llm_mock_clear()
+  llm_mock({error: {category: "server_error", message: "HTTP 503 Service Unavailable"}})
+  llm_mock({text: "ok after retry"})
+  let recovered = llm_call("retry once", nil, {provider: "mock", llm_retries: 2, llm_backoff_ms: 0})
+  println(recovered.prose)
+  println(len(llm_mock_calls()))
+  llm_mock_clear()
+  llm_mock({error: {category: "server_error", message: "HTTP 503 Service Unavailable"}})
+  llm_mock({error: {category: "server_error", message: "HTTP 503 Service Unavailable again"}})
+  llm_mock({text: "unreachable"})
+  let exhausted = try {
+    llm_call("retry budget exhausted", nil, {provider: "mock", llm_retries: 1, llm_backoff_ms: 0})
+  }
+  println(is_err(exhausted))
+  println(unwrap_err(exhausted)?.kind)
+  println(unwrap_err(exhausted)?.reason)
+  println(len(llm_mock_calls()))
+  llm_mock_clear()
+  llm_mock({error: {category: "server_error", message: "HTTP 503 default fail-fast"}})
+  llm_mock({text: "unreachable without explicit retries"})
+  let default_fail_fast = try {
+    llm_call("default retry budget", nil, {provider: "mock", llm_backoff_ms: 0})
+  }
+  println(is_err(default_fail_fast))
+  println(len(llm_mock_calls()))
+  let schema = {type: "object", required: ["answer"], properties: {answer: {type: "string"}}}
+  llm_mock_clear()
+  llm_mock({text: "{\"wrong\": true}"})
+  let schema_failure = try {
+    llm_call(
+      "schema failure is not a transport retry",
+      nil,
+      {
+        provider: "mock",
+        response_format: "json",
+        output_schema: schema,
+        output_validation: "error",
+        schema_retries: 0,
+        llm_retries: 2,
+        llm_backoff_ms: 0,
+      },
+    )
+  }
+  println(is_err(schema_failure))
+  println(unwrap_err(schema_failure)?.category)
+  println(len(llm_mock_calls()))
+  llm_mock_clear()
+  llm_mock({text: "{\"wrong\": true}"})
+  llm_mock({text: "{\"answer\": \"fixed\"}"})
+  let structured = llm_call(
+    "schema retry",
+    nil,
+    {
+      provider: "mock",
+      response_format: "json",
+      output_schema: schema,
+      output_validation: "error",
+      schema_retries: 1,
+      llm_retries: 2,
+      llm_backoff_ms: 0,
+    },
+  )
+  println(structured.data.answer)
+  println(len(llm_mock_calls()))
+}

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -9,7 +9,9 @@ use crate::value::VmValue;
 use crate::vm::Vm;
 
 use super::agent::run_agent_loop_internal;
-use super::agent_observe::{observed_llm_call, LlmRetryConfig};
+use super::agent_observe::{
+    observed_llm_call, LlmRetryConfig, DEFAULT_LLM_CALL_BACKOFF_MS, DEFAULT_LLM_CALL_RETRIES,
+};
 use super::daemon::{parse_daemon_loop_config, DaemonLoopConfig};
 use super::helpers::{
     extract_llm_options, opt_bool, opt_int, opt_str, transcript_event, transcript_to_vm_with_events,
@@ -674,13 +676,15 @@ pub fn register_llm_call_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Host
             let options = args.get(2).and_then(|a| a.as_dict()).cloned();
             let user_visible = opt_bool(&options, "user_visible");
             // Match the non-bridge `llm_call` default (see
-            // `crate::llm::execute_llm_call`): transient HTTP/provider
-            // failures retry twice by default; pass `llm_retries: 0` to
-            // opt out. Schema validation errors are orthogonal and
-            // handled by `schema_retries`.
+            // `crate::llm::execute_llm_call`): fail fast unless the caller
+            // opts into transient HTTP/provider retries.
             let retry_config = LlmRetryConfig {
-                retries: opt_int(&options, "llm_retries").unwrap_or(2) as usize,
-                backoff_ms: opt_int(&options, "llm_backoff_ms").unwrap_or(2000) as u64,
+                retries: opt_int(&options, "llm_retries")
+                    .unwrap_or(DEFAULT_LLM_CALL_RETRIES as i64)
+                    .max(0) as usize,
+                backoff_ms: opt_int(&options, "llm_backoff_ms")
+                    .unwrap_or(DEFAULT_LLM_CALL_BACKOFF_MS as i64)
+                    .max(0) as u64,
             };
             let _ =
                 crate::llm::structural_experiments::apply_structural_experiment(&mut opts, None)

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -653,6 +653,9 @@ async fn run_detector_loop(
 }
 
 /// Configuration for LLM call retries.
+pub(crate) const DEFAULT_LLM_CALL_RETRIES: usize = 0;
+pub(crate) const DEFAULT_LLM_CALL_BACKOFF_MS: u64 = 250;
+
 pub(crate) struct LlmRetryConfig {
     /// Maximum number of retries for transient errors (429, 5xx, connection).
     pub retries: usize,
@@ -663,8 +666,8 @@ pub(crate) struct LlmRetryConfig {
 impl Default for LlmRetryConfig {
     fn default() -> Self {
         Self {
-            retries: 0,
-            backoff_ms: 2000,
+            retries: DEFAULT_LLM_CALL_RETRIES,
+            backoff_ms: DEFAULT_LLM_CALL_BACKOFF_MS,
         }
     }
 }
@@ -678,7 +681,8 @@ fn llm_retry_backoff_ms(
     if crate::llm::providers::MockProvider::should_intercept(provider) {
         return 0;
     }
-    extract_retry_after_ms(error).unwrap_or(retry_config.backoff_ms * (1 << attempt.min(4)) as u64)
+    extract_retry_after_ms(error)
+        .unwrap_or_else(|| retry_config.backoff_ms.saturating_mul(1 << attempt.min(4)))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -667,15 +667,13 @@ pub(crate) async fn execute_schema_retry_loop(
     bridge: Option<&Rc<crate::bridge::HostBridge>>,
 ) -> Result<SchemaLoopOutcome, VmError> {
     let _ = structural_experiments::apply_structural_experiment(&mut opts, None).await?;
-    // Default `llm_retries` to 2 for resilience against transient
-    // HTTP / provider failures on the non-bridge path; bridge callers
-    // default to 0 to match the historical bridge-aware `llm_call`
-    // behavior (the host drives retries). Pass `llm_retries: 0` to opt
-    // out explicitly.
-    let transient_default = if bridge.is_some() { 0 } else { 2 };
     let retry_config = agent_observe::LlmRetryConfig {
-        retries: helpers::opt_int(&options, "llm_retries").unwrap_or(transient_default) as usize,
-        backoff_ms: helpers::opt_int(&options, "llm_backoff_ms").unwrap_or(2000) as u64,
+        retries: helpers::opt_int(&options, "llm_retries")
+            .unwrap_or(agent_observe::DEFAULT_LLM_CALL_RETRIES as i64)
+            .max(0) as usize,
+        backoff_ms: helpers::opt_int(&options, "llm_backoff_ms")
+            .unwrap_or(agent_observe::DEFAULT_LLM_CALL_BACKOFF_MS as i64)
+            .max(0) as u64,
     };
     // Schema retry loop is orthogonal to transient retries. Each
     // schema retry gets a fresh transient budget. Small/local models

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -610,8 +610,8 @@ println(response.output_tokens)
 | `output_validation` | string | `"off"` | `"error"` throws on mismatch; `"warn"` logs. |
 | `schema_retries` | int | 1 | When validation fails, re-prompt up to N times with a corrective user turn. Each retry is a single-turn correction — the invalid response is NOT persisted; the original messages are replayed with one appended user-role correction citing the validation errors + schema. Works alongside `output_validation: "error"`. |
 | `schema_retry_nudge` | string \| bool | auto | String = verbatim corrective message (+ validation errors appended). `true` = auto nudge from schema required/properties keys. `false` = bare retry — replays the original messages unchanged, no correction appended. |
-| `llm_retries` | int | 2 | Retries on transient HTTP / provider errors. Set to 0 for fail-fast. |
-| `llm_backoff_ms` | int | 2000 | Base exponential backoff. |
+| `llm_retries` | int | 0 | Retries on transient HTTP / provider errors. Raw `llm_call` is fail-fast by default; set to N to allow N retries after the first attempt. |
+| `llm_backoff_ms` | int | 250 | Base exponential backoff in milliseconds. |
 | `stream` | bool | true | SSE streaming transport. |
 
 ### Tool executor declarations

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -175,6 +175,8 @@ only accepts base64 image data, so `url` image blocks are rejected for
 | `presence_penalty` | float | nil | Presence penalty (OpenAI only) |
 | `response_format` | string | `"text"` | `"text"` or `"json"` |
 | `schema` | dict | nil | JSON Schema, OpenAPI Schema Object, or canonical Harn schema dict for structured output |
+| `llm_retries` | int | `0` | Retries on transient HTTP / provider errors. Raw `llm_call` is fail-fast by default; set to N to allow N retries after the first attempt |
+| `llm_backoff_ms` | int | `250` | Base exponential backoff in ms between LLM retries |
 | `thinking` | bool/dict | nil | Enable typed provider reasoning. `true` and `{budget_tokens: N}` remain shorthand for `{mode: "enabled"}`; use `{mode: "enabled", budget_tokens: N}`, `{mode: "adaptive"}`, or `{mode: "effort", level: "low" \| "medium" \| "high"}`. |
 | `vision` | bool | inferred | Require image-input support. Image content blocks set this implicitly; `vision: true` fails before transport unless the selected provider/model declares `vision_supported`. |
 | `tools` | list | nil | Tool definitions |
@@ -731,7 +733,7 @@ Same as `llm_call`, plus additional options:
 | `max_iterations` | int | `50` | Maximum number of LLM round-trips |
 | `max_nudges` | int | `8` | Max consecutive text-only responses before stopping |
 | `nudge` | string | see below | Custom message to send when nudging the agent |
-| `llm_retries` | int | `2` | Retries on transient HTTP / provider errors. Set to `0` for fail-fast |
+| `llm_retries` | int | `2` | Retries on transient HTTP / provider errors. Explicit option keys override profile defaults |
 | `llm_backoff_ms` | int | `2000` | Base exponential backoff in ms between LLM retries |
 | `tool_retries` | int | `0` | Number of retry attempts for failed tool calls |
 | `tool_backoff_ms` | int | `1000` | Base backoff delay in ms for tool retries (doubles each attempt) |

--- a/docs/src/scripting-cheatsheet.md
+++ b/docs/src/scripting-cheatsheet.md
@@ -213,8 +213,8 @@ Key options:
 | Option | Default | Notes |
 |---|---|---|
 | `provider` | `"auto"` | `"auto"` infers from model prefix (`local:` / `/` / `claude-*` / `gpt-*` / `:`). |
-| `llm_retries` | `2` | Transient error retries (HTTP 5xx, timeout, rate-limit). Set `0` to fail fast. |
-| `llm_backoff_ms` | `2000` | Base exponential backoff. |
+| `llm_retries` | `0` | Transient error retries (HTTP 5xx, timeout, rate-limit). Set to N to allow N retries after the first attempt. |
+| `llm_backoff_ms` | `250` | Base exponential backoff in milliseconds. |
 | `schema_retries` | `1` | Re-prompt on `output_schema` validation failure. Requires `output_validation: "error"` to kick in. |
 | `schema_retry_nudge` | auto | String (verbatim), `true` (auto), or `false` (bare retry). |
 | `output_validation` | `"off"` | `"error"` throws on mismatch; `"warn"` logs. |


### PR DESCRIPTION
## Summary
- add explicit raw llm_call transport retry defaults (`llm_retries: 0`, `llm_backoff_ms: 250`) using the existing transient/terminal LLM taxonomy
- keep schema retries independent from transport retries and preserve agent_loop profile retry defaults
- add conformance coverage for retry success, retry exhaustion, fail-fast default, and schema-validation isolation
- update quickref/docs/changelog for the new option surface

Fixes #853

## Self-review
- checked that raw llm_call defaults do not leak into agent_loop profile defaults
- clamped negative raw retry/backoff options before unsigned conversion
- switched retry backoff multiplication to saturating math
- reviewed docs for default mismatches and corrected the agent_loop table separately from llm_call

## Tests
- `CARGO_TARGET_DIR=/tmp/harn-target-issue853 cargo run --quiet --bin harn -- test conformance --filter llm_call_transport_retries`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue853 cargo test --quiet -p harn-vm llm::agent_observe::retry_tests`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue853 cargo run --quiet --bin harn -- test conformance --filter llm_mock_error`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue853 cargo run --quiet --bin harn -- test conformance --filter llm_call_`
- pre-commit hook: Rust fmt, Harn fmt/lint, clippy, markdown lint
- pre-push hook: 2962 nextest tests, affected Harn format/lint, markdown lint
