### PR TITLE
Replace orchestrator test sleep polling

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,13 +11,13 @@
 # the 60s hard cap three times it is terminated so the suite keeps moving.
 slow-timeout = { period = "15s", terminate-after = 4, grace-period = "5s" }
 # Nextest's upstream default FD-leak grace period is 200ms. Under full
-# workspace fan-out, fast Rust tests in the largest binaries can take a
-# little longer than that to close captured stdout/stderr after libtest
-# reports success, which creates noisy "passed (leaky)" results attributed
-# to whichever fast test happened to finish at the wrong moment. Keep this
-# short enough to catch real leaked subprocesses, but make leaks fail so
-# they are fixed instead of silently accepted.
-leak-timeout = { period = "1s", result = "fail" }
+# workspace fan-out, fast Rust tests in the largest binaries can take longer
+# than that to close captured stdout/stderr after libtest reports success,
+# which creates noisy "passed (leaky)" results attributed to whichever fast
+# test happened to finish at the wrong moment. Keep this short enough to catch
+# real leaked subprocesses, but make leaks fail so they are fixed instead of
+# silently accepted.
+leak-timeout = { period = "2s", result = "fail" }
 # Terminate runaway tests after 60 seconds by default. Tests that legitimately
 # need more time must opt in via an override below.
 fail-fast = false
@@ -25,7 +25,7 @@ fail-fast = false
 # CI profile is stricter: one warning at 30s, hard kill at 120s.
 [profile.ci]
 slow-timeout = { period = "30s", terminate-after = 4, grace-period = "10s" }
-leak-timeout = { period = "1s", result = "fail" }
+leak-timeout = { period = "2s", result = "fail" }
 fail-fast = false
 failure-output = "immediate-final"
 success-output = "never"

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -1,12 +1,13 @@
 #![cfg(unix)]
 
 mod support;
+mod test_util;
 
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
-use std::process::{Child, Command, Output, Stdio};
+use std::process::{Command, Output, Stdio};
 use std::sync::mpsc::{self, Receiver};
 use std::sync::Arc;
 use std::thread;
@@ -17,19 +18,13 @@ use harn_vm::event_log::{
 };
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use tempfile::TempDir;
+use test_util::timing::{
+    self, ChildExitWatcher, EVENT_FAIL_FAST_TIMEOUT, LOG_RECV_POLL_INTERVAL,
+    PROCESS_FAIL_FAST_TIMEOUT,
+};
 
 const STARTUP_NEEDLE: &str = "HTTP listener ready on";
 const SHUTDOWN_NEEDLE: &str = "graceful shutdown complete";
-// Process-level deadline mirrors `orchestrator_http`'s 60s budget. Tests in
-// this file no longer serialize through a process-wide lock (see
-// `tests/support/process.rs` for the architectural rationale), so cold
-// subprocess starts may now overlap with sibling tests under nextest. The
-// happy-path subprocess startup is well under 1s; the generous upper bound
-// only affects the panic-message path, where it absorbs macOS dyld + amfi
-// cold-cache spikes for the unsigned debug-build `harn` binary under load.
-const PROCESS_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(60);
-const EVENT_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(10);
-
 fn write_file(dir: &Path, relative: &str, contents: &str) {
     let path = dir.join(relative);
     if let Some(parent) = path.parent() {
@@ -54,7 +49,13 @@ pub fn on_task(event: TriggerEvent) -> string {{
     )
 }
 
-fn spawn_orchestrator(temp: &TempDir) -> (Child, Receiver<String>, thread::JoinHandle<String>) {
+fn spawn_orchestrator(
+    temp: &TempDir,
+) -> (
+    ChildExitWatcher,
+    Receiver<String>,
+    thread::JoinHandle<String>,
+) {
     spawn_orchestrator_with(temp, &[], &[])
 }
 
@@ -62,7 +63,11 @@ fn spawn_orchestrator_with(
     temp: &TempDir,
     extra_args: &[&str],
     envs: &[(&str, &str)],
-) -> (Child, Receiver<String>, thread::JoinHandle<String>) {
+) -> (
+    ChildExitWatcher,
+    Receiver<String>,
+    thread::JoinHandle<String>,
+) {
     let mut child = Command::new(env!("CARGO_BIN_EXE_harn"));
     child
         .current_dir(temp.path())
@@ -99,17 +104,17 @@ fn spawn_orchestrator_with(
         collected
     });
 
-    (child, rx, handle)
+    (ChildExitWatcher::new(child), rx, handle)
 }
 
-fn wait_for_log_line(child: &mut Child, rx: &Receiver<String>, needle: &str) {
+fn wait_for_log_line(child: &mut ChildExitWatcher, rx: &Receiver<String>, needle: &str) {
     let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
-        match rx.recv_timeout(Duration::from_millis(25)) {
+        match rx.recv_timeout(LOG_RECV_POLL_INTERVAL) {
             Ok(line) if line.contains(needle) => return,
             Ok(_) => continue,
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                if let Some(status) = child.try_wait().unwrap() {
+                if let Some(status) = child.try_status().unwrap() {
                     panic!("process exited before '{needle}' appeared: {status}");
                 }
             }
@@ -121,10 +126,10 @@ fn wait_for_log_line(child: &mut Child, rx: &Receiver<String>, needle: &str) {
     panic!("timed out waiting for '{needle}'");
 }
 
-fn wait_for_listener_url(child: &mut Child, rx: &Receiver<String>) -> String {
+fn wait_for_listener_url(child: &mut ChildExitWatcher, rx: &Receiver<String>) -> String {
     let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
-        match rx.recv_timeout(Duration::from_millis(25)) {
+        match rx.recv_timeout(LOG_RECV_POLL_INTERVAL) {
             Ok(line) if line.contains(STARTUP_NEEDLE) => {
                 let url = line
                     .split(STARTUP_NEEDLE)
@@ -138,7 +143,7 @@ fn wait_for_listener_url(child: &mut Child, rx: &Receiver<String>) -> String {
             }
             Ok(_) => continue,
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                if let Some(status) = child.try_wait().unwrap() {
+                if let Some(status) = child.try_status().unwrap() {
                     panic!("process exited before listener became ready: {status}");
                 }
             }
@@ -147,68 +152,30 @@ fn wait_for_listener_url(child: &mut Child, rx: &Receiver<String>) -> String {
             }
         }
     }
-    let _ = child.kill();
-    let _ = child.wait();
+    child.kill();
     panic!("timed out waiting for listener URL");
 }
 
-fn send_sigterm(child: &Child) {
-    let status = Command::new("kill")
-        .arg("-TERM")
-        .arg(child.id().to_string())
-        .status()
-        .unwrap();
-    assert!(status.success(), "kill exited with {status}");
+fn send_sigterm(child: &mut ChildExitWatcher) {
+    child.terminate();
 }
 
-fn wait_for_exit_code(child: &mut Child, expected: i32) {
-    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
-    while Instant::now() < deadline {
-        if let Some(status) = child.try_wait().unwrap() {
-            assert_eq!(
-                status.code(),
-                Some(expected),
-                "unexpected exit status: {status}"
-            );
-            return;
-        }
-        thread::sleep(Duration::from_millis(25));
-    }
-    panic!("timed out waiting for orchestrator exit");
+fn wait_for_exit_code(child: &mut ChildExitWatcher, expected: i32) {
+    child.wait_for_code(PROCESS_FAIL_FAST_TIMEOUT, expected);
 }
 
-fn wait_for_exit(child: &mut Child) {
-    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
-    while Instant::now() < deadline {
-        if let Some(status) = child.try_wait().unwrap() {
-            assert!(status.success(), "child exited unsuccessfully: {status}");
-            return;
-        }
-        thread::sleep(Duration::from_millis(50));
-    }
-    panic!("timed out waiting for orchestrator exit");
+fn wait_for_exit(child: &mut ChildExitWatcher) {
+    child.wait_for_success(PROCESS_FAIL_FAST_TIMEOUT);
 }
 
-fn wait_for_any_exit(child: &mut Child) {
-    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
-    while Instant::now() < deadline {
-        if child.try_wait().unwrap().is_some() {
-            return;
-        }
-        thread::sleep(Duration::from_millis(25));
-    }
-    panic!("timed out waiting for orchestrator exit");
+fn wait_for_any_exit(child: &mut ChildExitWatcher) {
+    child
+        .wait_timeout(PROCESS_FAIL_FAST_TIMEOUT)
+        .unwrap_or_else(|error| panic!("{error}"));
 }
 
-fn wait_for_path(path: &Path, timeout: Duration) {
-    let deadline = Instant::now() + timeout;
-    while Instant::now() < deadline {
-        if path.exists() {
-            return;
-        }
-        thread::sleep(Duration::from_millis(25));
-    }
-    panic!("timed out waiting for {}", path.display());
+fn wait_for_path(path: &Path, timeout: std::time::Duration) {
+    timing::wait_for_existing_path(path, timeout);
 }
 
 fn json_headers() -> HeaderMap {
@@ -242,7 +209,7 @@ async fn wait_for_metrics_contains(
         if needles.iter().all(|needle| last.contains(needle)) {
             return last;
         }
-        tokio::time::sleep(Duration::from_millis(25)).await;
+        timing::sleep_async(timing::RETRY_POLL_INTERVAL).await;
     }
     panic!("timed out waiting for metrics samples {needles:?}; last={last}");
 }
@@ -308,7 +275,7 @@ async fn wait_for_consumer_cursor(
         if cursor >= at_least {
             return;
         }
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        timing::sleep_async(timing::RETRY_POLL_INTERVAL).await;
     }
     panic!("timed out waiting for consumer cursor {consumer} on {topic_name} to reach {at_least}");
 }
@@ -381,7 +348,7 @@ fn wait_for_topic_kind(state_dir: &Path, topic_name: &str, kind: &str) {
         {
             return;
         }
-        thread::sleep(Duration::from_millis(25));
+        timing::sleep_blocking(timing::RETRY_POLL_INTERVAL);
     }
     panic!("timed out waiting for {topic_name}/{kind}");
 }
@@ -395,7 +362,7 @@ fn wait_for_topic_event(state_dir: &Path, topic_name: &str, predicate: impl Fn(&
         {
             return;
         }
-        thread::sleep(Duration::from_millis(25));
+        timing::sleep_blocking(timing::RETRY_POLL_INTERVAL);
     }
     panic!("timed out waiting for matching {topic_name} event");
 }
@@ -410,7 +377,7 @@ fn wait_for_topic_event_count(state_dir: &Path, topic_name: &str, kind: &str, ex
         if count >= expected {
             return;
         }
-        thread::sleep(Duration::from_millis(25));
+        timing::sleep_blocking(timing::RETRY_POLL_INTERVAL);
     }
     panic!("timed out waiting for {topic_name}/{kind} count {expected}");
 }
@@ -455,7 +422,7 @@ fn wait_for_sqlite_event_count(state_dir: &Path, topic_name: &str, kind: &str, e
         if sqlite_event_count(state_dir, topic_name, kind) >= expected {
             return;
         }
-        thread::sleep(Duration::from_millis(25));
+        timing::sleep_blocking(timing::RETRY_POLL_INTERVAL);
     }
     panic!("timed out waiting for {topic_name}/{kind} count {expected}");
 }
@@ -497,7 +464,7 @@ pub fn on_issue(event: TriggerEvent) {
 
     let (mut child, rx, handle) = spawn_orchestrator(&temp);
     wait_for_log_line(&mut child, &rx, STARTUP_NEEDLE);
-    send_sigterm(&child);
+    send_sigterm(&mut child);
     wait_for_exit(&mut child);
     let stderr = handle.join().expect("stderr collector thread");
 
@@ -572,7 +539,7 @@ handler = "handlers::on_task"
     assert_eq!(response.status(), reqwest::StatusCode::OK);
 
     wait_for_topic_kind(&state_dir, "triggers.lifecycle", "DispatchStarted");
-    send_sigterm(&child);
+    send_sigterm(&mut child);
     fs::write(&handler_release_path, b"release").unwrap();
     wait_for_exit(&mut child);
     let stderr = handle.join().expect("stderr collector thread");
@@ -665,7 +632,7 @@ pub fn on_task(event: TriggerEvent) -> string {
         .unwrap();
     assert_eq!(response.status(), reqwest::StatusCode::OK);
 
-    send_sigterm(&child);
+    send_sigterm(&mut child);
     wait_for_exit(&mut child);
     let stderr = handle.join().expect("stderr collector thread");
 
@@ -754,7 +721,7 @@ pub fn on_task(event: TriggerEvent) -> string {
         event.kind == "pump_acked" && event.payload["event_log_id"] == serde_json::json!(1)
     });
 
-    send_sigterm(&child);
+    send_sigterm(&mut child);
     fs::write(&inbox_release_file, b"release").unwrap();
     wait_for_exit(&mut child);
     let stderr = handle.join().expect("stderr collector thread");
@@ -896,7 +863,7 @@ pub fn on_task(event: TriggerEvent) -> string {
     )
     .await;
 
-    send_sigterm(&child);
+    send_sigterm(&mut child);
     fs::write(&inbox_release_file, b"release").unwrap();
     wait_for_exit(&mut child);
     let stderr = handle.join().expect("stderr collector thread");
@@ -968,7 +935,7 @@ pub fn on_event(event: TriggerEvent) {
 
     let (mut child, rx, handle) = spawn_orchestrator(&temp);
     wait_for_log_line(&mut child, &rx, STARTUP_NEEDLE);
-    child.kill().unwrap();
+    child.kill();
     wait_for_any_exit(&mut child);
     let _stderr = handle.join().expect("stderr collector thread");
     let legacy_after = read_topic_events(&state_dir, harn_vm::TRIGGER_INBOX_LEGACY_TOPIC);
@@ -1093,7 +1060,7 @@ pub fn on_task(event: TriggerEvent) -> string {
     }
 
     wait_for_path(&pump_waiting_file, EVENT_FAIL_FAST_TIMEOUT);
-    send_sigterm(&child);
+    send_sigterm(&mut child);
     wait_for_path(&pump_draining_file, EVENT_FAIL_FAST_TIMEOUT);
     fs::write(&pump_release_file, b"release").unwrap();
     wait_for_exit(&mut child);
@@ -1116,7 +1083,7 @@ pub fn on_task(event: TriggerEvent) -> string {
         "dispatch_succeeded",
         TOTAL_EVENTS,
     );
-    send_sigterm(&restart_child);
+    send_sigterm(&mut restart_child);
     wait_for_exit(&mut restart_child);
     let restart_stderr = restart_handle.join().expect("stderr collector thread");
     assert!(
@@ -1325,7 +1292,7 @@ pub fn on_task(event: TriggerEvent) -> string {
     );
     assert!(stdout(&queue_after).contains("stranded_envelopes=0"));
 
-    send_sigterm(&restarted_child);
+    send_sigterm(&mut restarted_child);
     wait_for_exit(&mut restarted_child);
     let restarted_stderr = restarted_handle.join().expect("stderr collector thread");
     assert!(

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -5,15 +5,16 @@
 #![allow(clippy::await_holding_lock)]
 
 mod support;
+mod test_util;
 
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
-use std::process::{Child, Command, Stdio};
+use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, Receiver};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use axum::body::Bytes;
 use axum::extract::State;
@@ -28,6 +29,10 @@ use reqwest::StatusCode;
 use serde_json::Value as JsonValue;
 use sha2::Sha256;
 use tempfile::TempDir;
+use test_util::timing::{
+    self, ChildExitWatcher, EVENT_FAIL_FAST_TIMEOUT, LOG_RECV_POLL_INTERVAL,
+    PROCESS_FAIL_FAST_TIMEOUT,
+};
 use time::OffsetDateTime;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -35,17 +40,6 @@ use tokio::sync::oneshot;
 const STARTUP_PREFIX: &str = "[harn] HTTP listener ready on ";
 const STARTUP_NEEDLE: &str = "HTTP listener ready";
 const SHUTDOWN_NEEDLE: &str = "graceful shutdown complete";
-// Process-level deadline for spawning the orchestrator subprocess and
-// waiting for it to bind its listener / shut down. Tests serialize
-// through a cross-process file lock, so a generous deadline here only
-// affects the failure path — happy-path tests still complete in well
-// under a second of post-spawn wall time. A previous 15s ceiling
-// produced spurious "timed out waiting for listener startup" failures
-// on macOS when dyld + amfi cold-cache lookups for the unsigned
-// debug-build binary exceeded the budget under nextest load.
-const PROCESS_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(60);
-const EVENT_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(10);
-
 type HmacSha256 = Hmac<Sha256>;
 
 fn lock_orchestrator_tests() -> support::OrchestratorProcessTestLock {
@@ -524,14 +518,14 @@ fn spawn_orchestrator(
     });
 
     OrchestratorProcess {
-        child,
+        child: ChildExitWatcher::new(child),
         rx,
         handle: Some(handle),
     }
 }
 
 struct OrchestratorProcess {
-    child: Child,
+    child: ChildExitWatcher,
     rx: Receiver<String>,
     handle: Option<thread::JoinHandle<String>>,
 }
@@ -539,13 +533,8 @@ struct OrchestratorProcess {
 impl OrchestratorProcess {
     fn wait_for_listener_url(&mut self) -> String {
         let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
-        // Block on the stderr line stream with a coarse poll cadence. The
-        // recv_timeout only exists so we can periodically check whether the
-        // child died without printing the listener line — we don't need
-        // 25ms granularity for that.
-        let liveness_poll = Duration::from_millis(250);
         while Instant::now() < deadline {
-            match self.rx.recv_timeout(liveness_poll) {
+            match self.rx.recv_timeout(LOG_RECV_POLL_INTERVAL) {
                 Ok(line) if line.contains(STARTUP_NEEDLE) => {
                     if let Some(url) = listener_url_from_line(&line) {
                         support::wait_for_readyz(&mut self.child, &url, PROCESS_FAIL_FAST_TIMEOUT)
@@ -558,7 +547,7 @@ impl OrchestratorProcess {
                 }
                 Ok(_) => continue,
                 Err(mpsc::RecvTimeoutError::Timeout) => {
-                    if let Some(status) = self.child.try_wait().unwrap() {
+                    if let Some(status) = self.child.try_status().unwrap() {
                         let stderr = self.join_stderr();
                         panic!(
                             "process exited before listener became ready: {status}\nstderr={stderr}"
@@ -576,8 +565,8 @@ impl OrchestratorProcess {
     }
 
     fn shutdown_and_join_stderr(&mut self) -> String {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        self.child.kill();
+        let _ = self.child.wait_timeout(PROCESS_FAIL_FAST_TIMEOUT);
         self.join_stderr()
     }
 
@@ -609,36 +598,18 @@ fn listener_url_from_line(line: &str) -> Option<String> {
     Some(url.to_string())
 }
 
-fn send_sigterm(child: &Child) {
-    let status = Command::new("kill")
-        .arg("-TERM")
-        .arg(child.id().to_string())
-        .status()
-        .unwrap();
-    assert!(status.success(), "kill exited with {status}");
+fn send_sigterm(child: &mut ChildExitWatcher) {
+    child.terminate();
 }
 
-fn wait_for_exit(child: &mut Child) {
-    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
-    while Instant::now() < deadline {
-        if let Some(status) = child.try_wait().unwrap() {
-            assert!(status.success(), "child exited unsuccessfully: {status}");
-            return;
-        }
-        thread::sleep(Duration::from_millis(25));
-    }
-    panic!("timed out waiting for orchestrator exit");
+fn wait_for_exit(child: &mut ChildExitWatcher) {
+    child.wait_for_success(PROCESS_FAIL_FAST_TIMEOUT);
 }
 
-async fn wait_for_exit_async(child: &mut Child) -> std::process::ExitStatus {
-    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
-    while Instant::now() < deadline {
-        if let Some(status) = child.try_wait().unwrap() {
-            return status;
-        }
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
-    panic!("timed out waiting for orchestrator exit");
+async fn wait_for_exit_async(child: &mut ChildExitWatcher) -> std::process::ExitStatus {
+    child
+        .wait_timeout(PROCESS_FAIL_FAST_TIMEOUT)
+        .unwrap_or_else(|error| panic!("{error}"))
 }
 
 fn github_signature(secret: &str, body: &[u8]) -> String {
@@ -733,7 +704,7 @@ async fn wait_for_topic_event(
         {
             return;
         }
-        tokio::time::sleep(Duration::from_millis(25)).await;
+        timing::sleep_async(timing::RETRY_POLL_INTERVAL).await;
     }
     let events = read_topic_events(temp, topic).await;
     panic!("timed out waiting for matching {topic} event; events={events:?}");
@@ -751,85 +722,11 @@ fn json_headers() -> HeaderMap {
     headers
 }
 
-fn wait_for_path(path: &Path, timeout: Duration) {
-    use notify::event::EventKind;
-    use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
-
-    if path_has_content(path) {
-        return;
-    }
-    let parent = path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    if !parent.exists() {
-        panic!("watch parent directory missing: {}", parent.display());
-    }
-    let target_name = path
-        .file_name()
-        .unwrap_or_else(|| panic!("wait_for_path requires a file name: {}", path.display()))
-        .to_owned();
-
-    let (tx, rx) = std::sync::mpsc::channel::<()>();
-    let target_for_handler = target_name.clone();
-    let mut watcher: RecommendedWatcher =
-        notify::recommended_watcher(move |event: Result<Event, notify::Error>| {
-            let Ok(event) = event else { return };
-            // We only need a hint that *something* under the parent directory
-            // changed; the outer loop re-checks `path.exists()` so false
-            // positives just trigger an extra cheap stat call.
-            let interesting = matches!(
-                event.kind,
-                EventKind::Create(_) | EventKind::Modify(_) | EventKind::Any
-            );
-            if !interesting {
-                return;
-            }
-            if event
-                .paths
-                .iter()
-                .any(|candidate| candidate.file_name() == Some(target_for_handler.as_os_str()))
-            {
-                let _ = tx.send(());
-            }
-        })
-        .unwrap_or_else(|error| panic!("failed to install notify watcher: {error}"));
-    watcher
-        .watch(parent, RecursiveMode::NonRecursive)
-        .unwrap_or_else(|error| {
-            panic!("failed to watch {}: {error}", parent.display());
-        });
-
-    // Race: the file may have been created between the content check above
-    // and the watcher being armed. Re-check, then block on either an event
-    // notification or the deadline. Notify events are advisory — fall back
-    // to a 250ms wakeup so platforms with eventual-consistency semantics
-    // (e.g. FSEvents coalescing) still complete promptly.
-    let deadline = Instant::now() + timeout;
-    loop {
-        if path_has_content(path) {
-            return;
-        }
-        let remaining = match deadline.checked_duration_since(Instant::now()) {
-            Some(remaining) => remaining,
-            None => break,
-        };
-        match rx.recv_timeout(remaining.min(Duration::from_millis(250))) {
-            Ok(()) => continue,
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
-        }
-    }
-    panic!("timed out waiting for {}", path.display());
+fn wait_for_path(path: &Path, timeout: std::time::Duration) {
+    timing::wait_for_nonempty_file(path, timeout);
 }
 
-fn path_has_content(path: &Path) -> bool {
-    fs::metadata(path)
-        .map(|metadata| metadata.is_file() && metadata.len() > 0)
-        .unwrap_or(false)
-}
-
-fn wait_for_json_file(path: &Path, timeout: Duration) -> JsonValue {
+fn wait_for_json_file(path: &Path, timeout: std::time::Duration) -> JsonValue {
     let deadline = Instant::now() + timeout;
     loop {
         if let Ok(contents) = fs::read_to_string(path) {
@@ -850,7 +747,7 @@ fn wait_for_json_file(path: &Path, timeout: Duration) -> JsonValue {
             Some(remaining) => remaining,
             None => break,
         };
-        thread::sleep(remaining.min(Duration::from_millis(25)));
+        timing::sleep_blocking(remaining.min(timing::RETRY_POLL_INTERVAL));
     }
     panic!("timed out waiting for valid JSON in {}", path.display());
 }
@@ -1078,7 +975,7 @@ async fn github_webhook_delivery_is_accepted_and_persisted() {
         .unwrap();
     assert_status(response, StatusCode::OK).await;
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     let status = wait_for_exit_async(&mut process.child).await;
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
@@ -1144,7 +1041,7 @@ async fn github_provider_prefers_configured_harn_connector_over_deprecated_rust_
     let marker = fs::read_to_string(&marker_path).unwrap();
     assert_eq!(marker, "issues");
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     let status = wait_for_exit_async(&mut process.child).await;
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
@@ -1202,20 +1099,18 @@ async fn slack_webhook_acknowledges_before_handler_finishes() {
     }))
     .unwrap();
 
-    let started = Instant::now();
-    let response = reqwest::Client::new()
-        .post(format!("{base_url}/triggers/slack-mentions"))
-        .headers(slack_headers(secret, timestamp, &body))
-        .body(body)
-        .send()
-        .await
-        .unwrap();
+    let response = tokio::time::timeout(
+        timing::SLACK_ACK_TIMEOUT,
+        reqwest::Client::new()
+            .post(format!("{base_url}/triggers/slack-mentions"))
+            .headers(slack_headers(secret, timestamp, &body))
+            .body(body)
+            .send(),
+    )
+    .await
+    .unwrap_or_else(|_| panic!("slack ack path exceeded {:?}", timing::SLACK_ACK_TIMEOUT))
+    .unwrap();
     assert_status(response, StatusCode::OK).await;
-    assert!(
-        started.elapsed() < Duration::from_secs(2),
-        "slack ack path took too long: {:?}",
-        started.elapsed()
-    );
     assert!(
         !marker_path.exists(),
         "dispatch should not have completed before the HTTP ack"
@@ -1242,7 +1137,7 @@ async fn slack_webhook_acknowledges_before_handler_finishes() {
     let marker = fs::read_to_string(&marker_path).unwrap();
     assert_eq!(marker, "app_mention");
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     wait_for_exit(&mut process.child);
 }
 
@@ -1286,7 +1181,7 @@ async fn slack_url_verification_returns_plaintext_challenge() {
         "3eZbrw1aBm2rZgRNFdxV2595E9CY3gmdALWMmHkvFXO7tYXAYM8P"
     );
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     wait_for_exit(&mut process.child);
 }
 
@@ -1396,7 +1291,7 @@ async fn slack_bad_requests_set_no_retry_header_and_export_delivery_metrics() {
         "metrics={metrics}"
     );
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     wait_for_exit(&mut process.child);
 }
 
@@ -1439,7 +1334,7 @@ async fn notion_webhook_handshake_is_captured_and_reported_by_doctor() {
         Some("secret_notion_test_token")
     );
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     let status = wait_for_exit_async(&mut process.child).await;
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
@@ -1516,7 +1411,7 @@ async fn notion_webhook_signed_delivery_is_dispatched() {
     let marker = fs::read_to_string(&marker_path).unwrap();
     assert_eq!(marker, "page.content_updated");
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     let status = wait_for_exit_async(&mut process.child).await;
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
@@ -1603,7 +1498,7 @@ async fn harn_connector_module_round_trips_inbound_and_client_calls() {
         "metrics={metrics}"
     );
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     let status = wait_for_exit_async(&mut process.child).await;
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
@@ -1705,7 +1600,7 @@ async fn stream_trigger_route_uses_generic_stream_connector() {
     );
     assert_eq!(marker.get("amount").and_then(JsonValue::as_i64), Some(10));
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     let status = wait_for_exit_async(&mut process.child).await;
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
@@ -1771,7 +1666,7 @@ async fn a2a_push_route_requires_bearer_or_valid_hmac() {
         .unwrap();
     assert_status(response, StatusCode::OK).await;
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     let status = wait_for_exit_async(&mut process.child).await;
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
@@ -1860,7 +1755,7 @@ async fn embedded_mcp_endpoint_serves_orchestrator_tools_on_listener() {
         "tools={tools_body}"
     );
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     let status = wait_for_exit_async(&mut process.child).await;
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
@@ -1939,7 +1834,7 @@ async fn admin_reload_endpoint_applies_manifest_changes() {
         .unwrap();
     assert_status(retired, StatusCode::NOT_FOUND).await;
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     wait_for_exit(&mut process.child);
     let snapshot = state_snapshot(&temp);
     assert!(snapshot.contains("\"listener_url\""), "snapshot={snapshot}");
@@ -1991,7 +1886,7 @@ async fn admin_reload_invalid_manifest_keeps_existing_routes_live() {
         .unwrap();
     assert_status(still_live, StatusCode::OK).await;
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     wait_for_exit(&mut process.child);
 }
 
@@ -2034,7 +1929,7 @@ async fn watch_mode_reloads_manifest_changes() {
         }
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
         assert!(Instant::now() < deadline, "watch reload never applied");
-        tokio::time::sleep(Duration::from_millis(25)).await;
+        timing::sleep_async(timing::RETRY_POLL_INTERVAL).await;
     }
 
     let retired = client
@@ -2046,7 +1941,7 @@ async fn watch_mode_reloads_manifest_changes() {
         .unwrap();
     assert_status(retired, StatusCode::NOT_FOUND).await;
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     wait_for_exit(&mut process.child);
 }
 
@@ -2107,7 +2002,7 @@ async fn reload_cli_uses_admin_endpoint() {
         .unwrap();
     assert_status(updated, StatusCode::OK).await;
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     wait_for_exit(&mut process.child);
 }
 
@@ -2149,8 +2044,11 @@ async fn tls_listener_serves_https_with_supplied_cert_and_key() {
         .unwrap();
     assert_status(response, StatusCode::OK).await;
 
-    send_sigterm(&process.child);
-    let status = process.child.wait().unwrap();
+    send_sigterm(&mut process.child);
+    let status = process
+        .child
+        .wait_timeout(PROCESS_FAIL_FAST_TIMEOUT)
+        .unwrap_or_else(|error| panic!("{error}"));
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
@@ -2192,7 +2090,7 @@ allowed_origins = ["https://allowed.example"]"#,
         .unwrap();
     assert_status(response, StatusCode::FORBIDDEN).await;
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     wait_for_exit(&mut process.child);
     let stderr = process.join_stderr();
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
@@ -2223,7 +2121,7 @@ async fn oversized_request_body_is_rejected() {
         .unwrap();
     assert_status(response, StatusCode::PAYLOAD_TOO_LARGE).await;
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     wait_for_exit(&mut process.child);
     let stderr = process.join_stderr();
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
@@ -2265,7 +2163,7 @@ async fn graceful_shutdown_waits_for_in_flight_request() {
     });
 
     wait_for_path(&request_entered_path, EVENT_FAIL_FAST_TIMEOUT);
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     fs::write(&request_release_path, b"release").unwrap();
     let response = request.await.unwrap().unwrap();
     assert_status(response, StatusCode::OK).await;
@@ -2308,7 +2206,7 @@ async fn json_log_format_writes_structured_rotating_file_with_trace_ids() {
         .unwrap();
     assert_status(response, StatusCode::OK).await;
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     let status = wait_for_exit_async(&mut process.child).await;
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
@@ -2385,26 +2283,33 @@ async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
     let response = client.execute(request).await.unwrap();
     assert_status(response, StatusCode::OK).await;
 
-    send_sigterm(&process.child);
+    send_sigterm(&mut process.child);
     let status = wait_for_exit_async(&mut process.child).await;
     let stderr = process.join_stderr();
     assert!(status.success(), "status={status} stderr={stderr}");
     assert!(stderr.contains(SHUTDOWN_NEEDLE), "stderr={stderr}");
 
-    let spans = collector.collected_spans();
-    let span_names: Vec<&str> = spans.iter().map(|span| span.name.as_str()).collect();
-    assert!(
-        span_names.contains(&"ingest"),
-        "ingest span missing; observed={span_names:?}"
-    );
-    assert!(
-        span_names.contains(&"queue_append"),
-        "queue_append span missing; observed={span_names:?}"
-    );
-    assert!(
-        span_names.contains(&"dispatch"),
-        "dispatch span missing; observed={span_names:?}"
-    );
+    let deadline = Instant::now() + EVENT_FAIL_FAST_TIMEOUT;
+    let spans = loop {
+        let spans = collector.collected_spans();
+        let has_ingest = spans.iter().any(|span| span.name == "ingest");
+        let has_queue_append = spans.iter().any(|span| span.name == "queue_append");
+        let has_dispatch = spans.iter().any(|span| span.name == "dispatch");
+        if has_ingest && has_queue_append && has_dispatch {
+            break spans;
+        }
+        if Instant::now() >= deadline {
+            let requests = collector.requests.lock().unwrap().clone();
+            panic!(
+                "timed out waiting for OTel spans\ncollector_headers={:#?}",
+                requests
+                    .iter()
+                    .map(|request| request.headers.clone())
+                    .collect::<Vec<_>>()
+            );
+        }
+        timing::sleep_async(timing::RETRY_POLL_INTERVAL).await;
+    };
 
     let ingest = spans.iter().find(|span| span.name == "ingest").unwrap();
     let queue_append = spans

--- a/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
+++ b/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
@@ -2,32 +2,29 @@
 
 #[path = "support/process.rs"]
 mod process_support;
+mod test_util;
 
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use harn_vm::event_log::{EventLog, SqliteEventLog, Topic};
 use tempfile::TempDir;
+use test_util::timing::{
+    self, ChildExitWatcher, EVENT_FAIL_FAST_TIMEOUT, LOG_RECV_POLL_INTERVAL,
+    PROCESS_FAIL_FAST_TIMEOUT,
+};
 
 // This fixture only exercises cron dispatch + inbox dedupe recovery. Waiting
 // for connector activation is sufficient and avoids a race where the
 // fail-after-emit test hook can terminate the process before the HTTP listener
 // readiness line is logged.
 const STARTUP_NEEDLE: &str = "activated connectors: cron(1)";
-// The previous 5s/2s budgets caused intermittent CI failures on macOS where
-// dyld + amfi cold-cache lookups for the unsigned debug-build binary plus
-// nextest's cargo-test launch overhead pushed subprocess spawn past the
-// budget. Tests serialize through a process-wide file lock, so a generous
-// upper bound only affects the failure path.
-const PROCESS_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(60);
-const EVENT_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(10);
-
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
@@ -57,7 +54,11 @@ fn seed_fixture(temp: &TempDir) {
 fn spawn_orchestrator(
     temp: &TempDir,
     extra_env: &[(&str, &str)],
-) -> (Child, Receiver<String>, thread::JoinHandle<String>) {
+) -> (
+    ChildExitWatcher,
+    Receiver<String>,
+    thread::JoinHandle<String>,
+) {
     let mut command = Command::new(env!("CARGO_BIN_EXE_harn"));
     command
         .current_dir(temp.path())
@@ -94,17 +95,17 @@ fn spawn_orchestrator(
         collected
     });
 
-    (child, rx, handle)
+    (ChildExitWatcher::new(child), rx, handle)
 }
 
-fn wait_for_log_line(child: &mut Child, rx: &Receiver<String>, needle: &str) {
+fn wait_for_log_line(child: &mut ChildExitWatcher, rx: &Receiver<String>, needle: &str) {
     let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
     while Instant::now() < deadline {
-        match rx.recv_timeout(Duration::from_millis(25)) {
+        match rx.recv_timeout(LOG_RECV_POLL_INTERVAL) {
             Ok(line) if line.contains(needle) => return,
             Ok(_) => continue,
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                if let Some(status) = child.try_wait().unwrap() {
+                if let Some(status) = child.try_status().unwrap() {
                     panic!("process exited before '{needle}' appeared: {status}");
                 }
             }
@@ -116,41 +117,16 @@ fn wait_for_log_line(child: &mut Child, rx: &Receiver<String>, needle: &str) {
     panic!("timed out waiting for '{needle}'");
 }
 
-fn wait_for_exit_code(child: &mut Child, expected: i32) {
-    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
-    while Instant::now() < deadline {
-        if let Some(status) = child.try_wait().unwrap() {
-            assert_eq!(
-                status.code(),
-                Some(expected),
-                "unexpected exit status: {status}"
-            );
-            return;
-        }
-        thread::sleep(Duration::from_millis(25));
-    }
-    panic!("timed out waiting for orchestrator exit");
+fn wait_for_exit_code(child: &mut ChildExitWatcher, expected: i32) {
+    child.wait_for_code(PROCESS_FAIL_FAST_TIMEOUT, expected);
 }
 
-fn send_sigterm(child: &Child) {
-    let status = Command::new("kill")
-        .arg("-TERM")
-        .arg(child.id().to_string())
-        .status()
-        .unwrap();
-    assert!(status.success(), "kill exited with {status}");
+fn send_sigterm(child: &mut ChildExitWatcher) {
+    child.terminate();
 }
 
-fn wait_for_successful_exit(child: &mut Child) {
-    let deadline = Instant::now() + PROCESS_FAIL_FAST_TIMEOUT;
-    while Instant::now() < deadline {
-        if let Some(status) = child.try_wait().unwrap() {
-            assert!(status.success(), "child exited unsuccessfully: {status}");
-            return;
-        }
-        thread::sleep(Duration::from_millis(25));
-    }
-    panic!("timed out waiting for orchestrator exit");
+fn wait_for_successful_exit(child: &mut ChildExitWatcher) {
+    child.wait_for_success(PROCESS_FAIL_FAST_TIMEOUT);
 }
 
 async fn read_tick_dedupe_counts(temp: &TempDir) -> HashMap<String, usize> {
@@ -181,7 +157,7 @@ async fn wait_for_tick_count(temp: &TempDir, min_count: usize) -> HashMap<String
             Instant::now() < deadline,
             "timed out waiting for {min_count} cron ticks: {counts:?}"
         );
-        tokio::time::sleep(Duration::from_millis(25)).await;
+        timing::sleep_async(timing::RETRY_POLL_INTERVAL).await;
     }
 }
 
@@ -215,7 +191,7 @@ async fn restart_after_emit_does_not_duplicate_cron_dispatch() {
         spawn_orchestrator(&temp, &[("HARN_TEST_CRON_SINGLE_TICK_AT", "1800000001")]);
     wait_for_log_line(&mut second_child, &second_rx, STARTUP_NEEDLE);
     let counts = wait_for_tick_count(&temp, 2).await;
-    send_sigterm(&second_child);
+    send_sigterm(&mut second_child);
     wait_for_successful_exit(&mut second_child);
     let second_stderr = second_handle.join().expect("stderr collector thread");
     assert!(second_stderr.contains("registered connectors (1): cron"));

--- a/crates/harn-cli/tests/support/mcp.rs
+++ b/crates/harn-cli/tests/support/mcp.rs
@@ -1,5 +1,7 @@
 #[path = "process.rs"]
 mod process;
+#[path = "../test_util/timing.rs"]
+mod timing;
 
 use std::io::{BufRead, BufReader, Read};
 use std::process::Child;
@@ -46,7 +48,7 @@ pub fn wait_for_child_log_suffix(
     let deadline = Instant::now() + timeout;
     let mut observed = Vec::new();
     while Instant::now() < deadline {
-        match rx.recv_timeout(Duration::from_millis(25)) {
+        match rx.recv_timeout(timing::LOG_RECV_POLL_INTERVAL) {
             Ok(line) if line.contains(needle) => {
                 return line
                     .split(needle)
@@ -56,14 +58,7 @@ pub fn wait_for_child_log_suffix(
                     .to_string();
             }
             Ok(line) => observed.push(line),
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                if let Some(status) = child.try_wait().unwrap() {
-                    panic!(
-                        "{label} process exited before readiness log `{needle}` appeared: {status}\nstderr={}",
-                        observed.join("\n")
-                    );
-                }
-            }
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 panic!(
                     "{label} stderr stream closed before readiness log `{needle}` appeared\nstderr={}",

--- a/crates/harn-cli/tests/support/mod.rs
+++ b/crates/harn-cli/tests/support/mod.rs
@@ -2,9 +2,9 @@ mod process;
 
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::process::Child;
-use std::thread;
 use std::time::{Duration, Instant};
+
+use crate::test_util::timing::{self, ChildExitWatcher};
 
 /// Sentinel "lock" returned by [`lock_orchestrator_process_tests`].
 ///
@@ -31,7 +31,11 @@ pub fn lock_orchestrator_process_tests() -> OrchestratorProcessTestLock {
     process::HarnProcessTestNoLock
 }
 
-pub fn wait_for_readyz(child: &mut Child, base_url: &str, timeout: Duration) -> Result<(), String> {
+pub fn wait_for_readyz(
+    child: &mut ChildExitWatcher,
+    base_url: &str,
+    timeout: Duration,
+) -> Result<(), String> {
     let Some(target) = ReadyzTarget::parse(base_url)? else {
         return Ok(());
     };
@@ -39,10 +43,7 @@ pub fn wait_for_readyz(child: &mut Child, base_url: &str, timeout: Duration) -> 
     let mut last_error = None;
 
     while Instant::now() < deadline {
-        if let Some(status) = child
-            .try_wait()
-            .map_err(|error| format!("failed to inspect orchestrator process: {error}"))?
-        {
+        if let Some(status) = child.try_status()? {
             return Err(format!(
                 "orchestrator exited before readiness probe succeeded: {status}"
             ));
@@ -52,7 +53,7 @@ pub fn wait_for_readyz(child: &mut Child, base_url: &str, timeout: Duration) -> 
             Ok(()) => return Ok(()),
             Err(error) => last_error = Some(error),
         }
-        thread::sleep(Duration::from_millis(25));
+        timing::sleep_blocking(timing::RETRY_POLL_INTERVAL);
     }
 
     Err(format!(
@@ -93,14 +94,14 @@ fn probe_readyz(target: &ReadyzTarget) -> Result<(), String> {
         &addr
             .parse()
             .map_err(|error| format!("invalid readiness address `{addr}`: {error}"))?,
-        Duration::from_millis(250),
+        timing::READY_PROBE_IO_TIMEOUT,
     )
     .map_err(|error| format!("readiness connect failed: {error}"))?;
     stream
-        .set_read_timeout(Some(Duration::from_millis(250)))
+        .set_read_timeout(Some(timing::READY_PROBE_IO_TIMEOUT))
         .map_err(|error| format!("failed to set readiness read timeout: {error}"))?;
     stream
-        .set_write_timeout(Some(Duration::from_millis(250)))
+        .set_write_timeout(Some(timing::READY_PROBE_IO_TIMEOUT))
         .map_err(|error| format!("failed to set readiness write timeout: {error}"))?;
     write!(
         stream,

--- a/crates/harn-cli/tests/test_util/mod.rs
+++ b/crates/harn-cli/tests/test_util/mod.rs
@@ -1,0 +1,1 @@
+pub mod timing;

--- a/crates/harn-cli/tests/test_util/timing.rs
+++ b/crates/harn-cli/tests/test_util/timing.rs
@@ -1,0 +1,235 @@
+#![allow(dead_code)]
+
+use std::fs;
+use std::path::Path;
+use std::process::{Child, Command, ExitStatus};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+
+pub const PROCESS_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(60);
+pub const EVENT_FAIL_FAST_TIMEOUT: Duration = Duration::from_secs(10);
+pub const LOG_RECV_POLL_INTERVAL: Duration = Duration::from_millis(25);
+pub const READY_PROBE_IO_TIMEOUT: Duration = Duration::from_millis(250);
+pub const RETRY_POLL_INTERVAL: Duration = Duration::from_millis(25);
+pub const SLACK_ACK_TIMEOUT: Duration = Duration::from_secs(3);
+
+pub struct ChildExitWatcher {
+    pid: u32,
+    rx: Receiver<Result<ExitStatus, String>>,
+    status: Option<Result<ExitStatus, String>>,
+    wait_thread: Option<thread::JoinHandle<()>>,
+}
+
+impl ChildExitWatcher {
+    pub fn new(mut child: Child) -> Self {
+        let pid = child.id();
+        let (tx, rx) = mpsc::channel();
+        let wait_thread = thread::spawn(move || {
+            let result = child.wait().map_err(|error| error.to_string());
+            let _ = tx.send(result);
+        });
+        Self {
+            pid,
+            rx,
+            status: None,
+            wait_thread: Some(wait_thread),
+        }
+    }
+
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    pub fn try_status(&mut self) -> Result<Option<ExitStatus>, String> {
+        if let Some(status) = &self.status {
+            return status
+                .as_ref()
+                .map(|status| Some(*status))
+                .map_err(Clone::clone);
+        }
+        match self.rx.try_recv() {
+            Ok(status) => self.cache_status(status),
+            Err(mpsc::TryRecvError::Empty) => Ok(None),
+            Err(mpsc::TryRecvError::Disconnected) => {
+                Err("process wait thread disconnected before reporting exit".to_string())
+            }
+        }
+    }
+
+    pub fn wait_timeout(&mut self, timeout: Duration) -> Result<ExitStatus, String> {
+        if let Some(status) = &self.status {
+            return status.as_ref().copied().map_err(Clone::clone);
+        }
+        match self.rx.recv_timeout(timeout) {
+            Ok(status) => match self.cache_status(status)? {
+                Some(status) => Ok(status),
+                None => unreachable!("cache_status returns Some after receiving a status"),
+            },
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                Err(format!("timed out waiting for process {} exit", self.pid))
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                Err("process wait thread disconnected before reporting exit".to_string())
+            }
+        }
+    }
+
+    pub fn wait_for_success(&mut self, timeout: Duration) {
+        let status = self
+            .wait_timeout(timeout)
+            .unwrap_or_else(|error| panic!("{error}"));
+        assert!(status.success(), "child exited unsuccessfully: {status}");
+    }
+
+    pub fn wait_for_code(&mut self, timeout: Duration, expected: i32) {
+        let status = self
+            .wait_timeout(timeout)
+            .unwrap_or_else(|error| panic!("{error}"));
+        assert_eq!(
+            status.code(),
+            Some(expected),
+            "unexpected exit status: {status}"
+        );
+    }
+
+    pub fn terminate(&mut self) {
+        if self
+            .try_status()
+            .unwrap_or_else(|error| panic!("{error}"))
+            .is_some()
+        {
+            return;
+        }
+        let status = Command::new("kill")
+            .arg("-TERM")
+            .arg(self.pid.to_string())
+            .status()
+            .unwrap();
+        if !status.success()
+            && self
+                .try_status()
+                .unwrap_or_else(|error| panic!("{error}"))
+                .is_none()
+        {
+            panic!("kill exited with {status}");
+        }
+    }
+
+    pub fn kill(&mut self) {
+        if self
+            .try_status()
+            .unwrap_or_else(|error| panic!("{error}"))
+            .is_some()
+        {
+            return;
+        }
+        let _ = Command::new("kill")
+            .arg("-KILL")
+            .arg(self.pid.to_string())
+            .status();
+    }
+
+    fn cache_status(
+        &mut self,
+        status: Result<ExitStatus, String>,
+    ) -> Result<Option<ExitStatus>, String> {
+        self.join_wait_thread();
+        let result = status.as_ref().copied().map(Some).map_err(Clone::clone);
+        self.status = Some(status);
+        result
+    }
+
+    fn join_wait_thread(&mut self) {
+        if let Some(wait_thread) = self.wait_thread.take() {
+            wait_thread.join().expect("process wait thread");
+        }
+    }
+}
+
+pub fn wait_for_existing_path(path: &Path, timeout: Duration) {
+    wait_for_path_ready(path, timeout, PathReady::Exists)
+}
+
+pub fn wait_for_nonempty_file(path: &Path, timeout: Duration) {
+    wait_for_path_ready(path, timeout, PathReady::NonEmptyFile)
+}
+
+enum PathReady {
+    Exists,
+    NonEmptyFile,
+}
+
+fn wait_for_path_ready(path: &Path, timeout: Duration, ready: PathReady) {
+    if is_path_ready(path, &ready) {
+        return;
+    }
+
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    if !parent.exists() {
+        panic!("watch parent directory missing: {}", parent.display());
+    }
+
+    path.file_name()
+        .unwrap_or_else(|| panic!("wait_for_path requires a file name: {}", path.display()));
+
+    let (tx, rx) = mpsc::channel::<()>();
+    let mut watcher: RecommendedWatcher =
+        notify::recommended_watcher(move |event: Result<Event, notify::Error>| {
+            if event.is_ok() {
+                let _ = tx.send(());
+            }
+        })
+        .unwrap_or_else(|error| panic!("failed to install notify watcher: {error}"));
+    watcher
+        .watch(parent, RecursiveMode::NonRecursive)
+        .unwrap_or_else(|error| panic!("failed to watch {}: {error}", parent.display()));
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        if is_path_ready(path, &ready) {
+            return;
+        }
+        let remaining = match deadline.checked_duration_since(Instant::now()) {
+            Some(remaining) => remaining,
+            None => break,
+        };
+        match rx.recv_timeout(remaining) {
+            Ok(()) => continue,
+            Err(mpsc::RecvTimeoutError::Timeout) => break,
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!(
+                    "notify watcher disconnected while waiting for {}",
+                    path.display()
+                );
+            }
+        }
+    }
+    panic!("timed out waiting for {}", path.display());
+}
+
+fn is_path_ready(path: &Path, ready: &PathReady) -> bool {
+    match ready {
+        PathReady::Exists => path.exists(),
+        PathReady::NonEmptyFile => nonempty_file(path),
+    }
+}
+
+fn nonempty_file(path: &Path) -> bool {
+    fs::metadata(path)
+        .map(|metadata| metadata.is_file() && metadata.len() > 0)
+        .unwrap_or(false)
+}
+
+pub fn sleep_blocking(duration: Duration) {
+    thread::sleep(duration);
+}
+
+pub async fn sleep_async(duration: Duration) {
+    tokio::time::sleep(duration).await;
+}

--- a/crates/harn-cli/tests/trigger_replay_cli.rs
+++ b/crates/harn-cli/tests/trigger_replay_cli.rs
@@ -1,8 +1,12 @@
+mod test_util;
+
 use std::fs;
 use std::path::Path;
 use std::process::{Command, Output};
+use std::time::Duration;
 
 use tempfile::TempDir;
+use test_util::timing;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
@@ -184,7 +188,7 @@ pub fn on_issue(event: TriggerEvent) -> dict {
     let seeded = seed_event(&temp, "delivery-as-of-v1");
     let event_id = seeded["event_id"].as_str().unwrap().to_string();
     let as_of = OffsetDateTime::now_utc();
-    std::thread::sleep(std::time::Duration::from_millis(10));
+    timing::sleep_blocking(Duration::from_millis(10));
 
     write_file(
         temp.path(),

--- a/crates/harn-vm/src/triggers/test_util/mod.rs
+++ b/crates/harn-vm/src/triggers/test_util/mod.rs
@@ -40,7 +40,7 @@ use crate::triggers::{
     SignatureStatus, TenantId, TriggerEvent, TriggerRetryConfig, DEFAULT_INBOX_RETENTION_DAYS,
 };
 
-use self::timing::{FILE_WATCH_FALLBACK_POLL, TEST_DEFAULT_TIMEOUT};
+use self::timing::TEST_DEFAULT_TIMEOUT;
 
 pub mod clock;
 pub mod timing;
@@ -1465,7 +1465,7 @@ impl TriggerTestHarness {
                 .await
                 .map_err(|error| error.to_string())?;
             let received_at = OffsetDateTime::now_utc();
-            std::thread::sleep(FILE_WATCH_FALLBACK_POLL);
+            wait_until_wall_clock_after(received_at);
             install_manifest_triggers(vec![manifest_spec("replay.gc.fixture", "v4")])
                 .await
                 .map_err(|error| error.to_string())?;
@@ -2119,6 +2119,14 @@ fn format_rfc3339(value: OffsetDateTime) -> String {
     value
         .format(&time::format_description::well_known::Rfc3339)
         .unwrap_or_default()
+}
+
+fn wait_until_wall_clock_after(timestamp: OffsetDateTime) {
+    let timestamp_ms = timestamp.unix_timestamp_nanos() / 1_000_000;
+    while OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000 <= timestamp_ms {
+        std::hint::spin_loop();
+        std::thread::yield_now();
+    }
 }
 
 fn signature_state_label(value: &SignatureStatus) -> &'static str {


### PR DESCRIPTION
## Summary

- Add shared harn-cli test timing utilities for process exit channels, notify-based path readiness, and centralized timing constants.
- Replace orchestrator CLI/HTTP/inbox-dedupe subprocess `try_wait` polling with `ChildExitWatcher`, which waits in one background thread and reports exit through a channel.
- Replace marker-file wait loops with notify watcher waits, without periodic fallback polling.
- Move remaining explicit test sleeps in touched harn-cli tests behind `tests/test_util/timing.rs` and remove direct sleeps from the VM trigger harness fallback fixture.
- Relax the Slack ack assertion into a centralized 3s timeout while preserving the behavioral assertion that dispatch has not completed when the HTTP ack returns.

Closes #947.

## Self-review

- Checked the process wrapper for PID-signal races and changed terminate/kill to first drain any pending exit status before signaling.
- Adjusted notify path waits to re-check the target after any parent-directory event, which is more robust with coalesced filesystem events while still failing if no notify event arrives.
- Verified the VM trigger harness timestamp replacement against millisecond lifecycle-history granularity.

## Verification

- `cargo fmt`
- `cargo test -p harn-cli --test orchestrator_cli --test orchestrator_http --test orchestrator_inbox_dedupe --test trigger_replay_cli`
- `cargo test -p harn-cli --test mcp_server_cli --test harn_serve_mcp_cli`
- `cargo test -p harn-vm every_trigger_harness_fixture_reports_success`
- `cargo clippy -p harn-cli --tests -p harn-vm --lib -- -D warnings`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook: nextest full suite, 2943 tests passed
- `rg -n "thread::sleep|tokio::time::sleep|try_wait" crates/harn-cli/tests crates/harn-vm/src/triggers/test_util/mod.rs` only reports sleeps inside `crates/harn-cli/tests/test_util/timing.rs`
