### PR TITLE
Implement agent loop compaction policy

### DIFF
--- a/conformance/tests/integration/agent_loop_compaction_policy.expected
+++ b/conformance/tests/integration/agent_loop_compaction_policy.expected
@@ -1,0 +1,6 @@
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/integration/agent_loop_compaction_policy.harn
+++ b/conformance/tests/integration/agent_loop_compaction_policy.harn
@@ -1,0 +1,33 @@
+fn noisy_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "observe",
+    "Return an observation so the loop keeps going.",
+    {handler: { _args -> "observation " + "x" * 240 }, parameters: {}, returns: {type: "string"}},
+  )
+  return tools
+}
+
+pipeline default() {
+  let result = agent_loop(
+    "Keep observing until the iteration budget is exhausted.",
+    "You are a compacting test agent.",
+    {
+      provider: "mock",
+      model: "gpt-4",
+      tools: noisy_tools(),
+      tool_format: "native",
+      max_iterations: 100,
+      compact_threshold: 1,
+      compaction: {strategy: "hybrid", keep_last_n: 10},
+    },
+  )
+  let events = transcript_events_by_kind(result?.transcript, "compaction")
+  println(result?.llm?.iterations == 100)
+  println(result?.status == "budget_exhausted")
+  println(result?.trace?.compactions > 0)
+  println(len(events) > 0)
+  println(events[0]?.metadata?.strategy == "hybrid")
+  println(events[0]?.metadata?.engine_strategy == "llm")
+}

--- a/crates/harn-vm/src/llm/agent/helpers.rs
+++ b/crates/harn-vm/src/llm/agent/helpers.rs
@@ -331,10 +331,7 @@ pub(crate) async fn maybe_auto_compact_agent_messages(
                         &crate::agent_events::AgentEvent::TranscriptCompacted {
                             session_id,
                             mode: "auto".to_string(),
-                            strategy: crate::orchestration::compact_strategy_name(
-                                &ac.compact_strategy,
-                            )
-                            .to_string(),
+                            strategy: ac.policy_strategy.clone(),
                             archived_messages,
                             estimated_tokens_before: approx_tokens,
                             estimated_tokens_after,

--- a/crates/harn-vm/src/llm/agent/mod.rs
+++ b/crates/harn-vm/src/llm/agent/mod.rs
@@ -510,6 +510,7 @@ pub async fn run_agent_loop_internal(
                 base_system: base_system.as_deref(),
                 tool_contract_prompt: tool_contract_prompt.as_deref(),
                 persistent_system_prompt: persistent_system_prompt.as_deref(),
+                auto_compact: &auto_compact,
                 scoped_tools_val: scoped_tools.as_ref(),
             },
         )

--- a/crates/harn-vm/src/llm/agent/post_turn.rs
+++ b/crates/harn-vm/src/llm/agent/post_turn.rs
@@ -257,20 +257,20 @@ pub(super) async fn run_post_turn(
                         "Transcript compacted during agent loop",
                         Some(serde_json::json!({
                             "mode": "auto",
-                            "strategy": crate::orchestration::compact_strategy_name(&ac.compact_strategy),
+                            "strategy": ac.policy_strategy.clone(),
+                            "engine_strategy": crate::orchestration::compact_strategy_name(&ac.compact_strategy),
                             "archived_messages": archived_messages,
                             "estimated_tokens_before": est,
                             "estimated_tokens_after": estimated_tokens_after,
+                            "keep_first": ac.keep_first,
+                            "keep_last": ac.keep_last,
                         })),
                     ));
                     super::emit_agent_event(
                         &crate::agent_events::AgentEvent::TranscriptCompacted {
                             session_id: ctx.session_id.to_string(),
                             mode: "auto".to_string(),
-                            strategy: crate::orchestration::compact_strategy_name(
-                                &ac.compact_strategy,
-                            )
-                            .to_string(),
+                            strategy: ac.policy_strategy.clone(),
                             archived_messages,
                             estimated_tokens_before: est,
                             estimated_tokens_after,

--- a/crates/harn-vm/src/llm/agent/turn_preflight.rs
+++ b/crates/harn-vm/src/llm/agent/turn_preflight.rs
@@ -43,6 +43,7 @@ pub(super) struct PreflightContext<'a> {
     pub base_system: Option<&'a str>,
     pub tool_contract_prompt: Option<&'a str>,
     pub persistent_system_prompt: Option<&'a str>,
+    pub auto_compact: &'a Option<crate::orchestration::AutoCompactConfig>,
     /// Skill-scoped tool registry for this turn, when skill activation
     /// narrowed `tools_val`. `None` when the full registry is in
     /// effect — the preflight then uses the baked-in `tool_contract_prompt`.
@@ -125,6 +126,75 @@ pub(super) async fn run_turn_preflight(
     );
     let mut call_messages = state.visible_messages.clone();
     let call_system = default_system;
+
+    if let Some(ac) = ctx.auto_compact {
+        let system_tokens = call_system.as_deref().map(|s| s.len() / 4).unwrap_or(0);
+        let estimated_tokens_before =
+            crate::orchestration::estimate_message_tokens(&state.visible_messages) + system_tokens;
+        if estimated_tokens_before >= ac.token_threshold {
+            let mut compact_opts = opts.clone();
+            compact_opts.messages = state.visible_messages.clone();
+            compact_opts.system = call_system.clone();
+            let original_message_count = state.visible_messages.len();
+            if let Some(summary) = crate::orchestration::auto_compact_messages(
+                &mut state.visible_messages,
+                ac,
+                Some(&compact_opts),
+            )
+            .await?
+            {
+                let estimated_tokens_after =
+                    crate::orchestration::estimate_message_tokens(&state.visible_messages)
+                        + system_tokens;
+                let archived_messages = original_message_count
+                    .saturating_sub(state.visible_messages.len())
+                    .saturating_add(1);
+                super::super::trace::emit_agent_event(
+                    super::super::trace::AgentTraceEvent::ContextCompaction {
+                        archived_messages,
+                        new_summary_len: summary.len(),
+                        iteration: ctx.iteration,
+                    },
+                );
+                state.transcript_events.push(transcript_event(
+                    "compaction",
+                    "system",
+                    "internal",
+                    "Transcript compacted before agent LLM call",
+                    Some(serde_json::json!({
+                        "mode": "preflight",
+                        "strategy": ac.policy_strategy.clone(),
+                        "engine_strategy": crate::orchestration::compact_strategy_name(&ac.compact_strategy),
+                        "archived_messages": archived_messages,
+                        "estimated_tokens_before": estimated_tokens_before,
+                        "estimated_tokens_after": estimated_tokens_after,
+                        "keep_first": ac.keep_first,
+                        "keep_last": ac.keep_last,
+                    })),
+                ));
+                super::emit_agent_event(&AgentEvent::TranscriptCompacted {
+                    session_id: ctx.session_id.to_string(),
+                    mode: "preflight".to_string(),
+                    strategy: ac.policy_strategy.clone(),
+                    archived_messages,
+                    estimated_tokens_before,
+                    estimated_tokens_after,
+                    snapshot_asset_id: None,
+                })
+                .await;
+                let merged = match state.transcript_summary.take() {
+                    Some(existing)
+                        if !existing.trim().is_empty() && existing.trim() != summary.trim() =>
+                    {
+                        format!("{existing}\n\n{summary}")
+                    }
+                    Some(_) | None => summary,
+                };
+                state.transcript_summary = Some(merged);
+                call_messages = state.visible_messages.clone();
+            }
+        }
+    }
 
     crate::orchestration::run_lifecycle_hooks(
         crate::orchestration::HookEvent::PreAgentTurn,

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -438,61 +438,7 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                 .or_else(crate::agent_sessions::current_session_id)
                 .unwrap_or_else(|| format!("agent_session_{}", uuid::Uuid::now_v7()));
             let daemon = opt_bool(&options, "daemon");
-            let auto_compact = if opt_bool(&options, "auto_compact") {
-                let mut ac = crate::orchestration::AutoCompactConfig::default();
-                let user_specified_threshold = opt_int(&options, "compact_threshold").is_some();
-                if let Some(v) = opt_int(&options, "compact_threshold") {
-                    ac.token_threshold = v as usize;
-                }
-                if let Some(v) = opt_int(&options, "tool_output_max_chars") {
-                    ac.tool_output_max_chars = v as usize;
-                }
-                if let Some(v) = opt_int(&options, "compact_keep_last") {
-                    ac.keep_last = v as usize;
-                }
-                if let Some(strategy) = opt_str(&options, "compact_strategy") {
-                    ac.compact_strategy = crate::orchestration::parse_compact_strategy(&strategy)?;
-                }
-                if let Some(v) = opt_int(&options, "hard_limit_tokens") {
-                    ac.hard_limit_tokens = Some(v as usize);
-                }
-                if let Some(strategy) = opt_str(&options, "hard_limit_strategy") {
-                    ac.hard_limit_strategy =
-                        crate::orchestration::parse_compact_strategy(&strategy)?;
-                }
-                if let Some(callback) = options.as_ref().and_then(|o| o.get("mask_callback")) {
-                    ac.mask_callback = Some(callback.clone());
-                }
-                if let Some(callback) = options.as_ref().and_then(|o| o.get("compact_callback")) {
-                    ac.custom_compactor = Some(callback.clone());
-                    if !options
-                        .as_ref()
-                        .is_some_and(|o| o.contains_key("compact_strategy"))
-                    {
-                        ac.compact_strategy = crate::orchestration::CompactStrategy::Custom;
-                    }
-                }
-                if let Some(callback) = options.as_ref().and_then(|o| o.get("compress_callback")) {
-                    ac.compress_callback = Some(callback.clone());
-                }
-                {
-                    let probe_opts = extract_llm_options(&args)?;
-                    let user_specified_hard_limit =
-                        opt_int(&options, "hard_limit_tokens").is_some();
-                    crate::llm::api::adapt_auto_compact_to_provider(
-                        &mut ac,
-                        user_specified_threshold,
-                        user_specified_hard_limit,
-                        &probe_opts.provider,
-                        &probe_opts.model,
-                        &probe_opts.api_key,
-                    )
-                    .await;
-                }
-                Some(ac)
-            } else {
-                None
-            };
+            let auto_compact = crate::llm::resolve_agent_loop_auto_compact(&args, &options).await?;
             let policy = options.as_ref().and_then(|o| o.get("policy")).map(|v| {
                 let json = crate::llm::helpers::vm_value_to_json(v);
                 serde_json::from_value::<crate::orchestration::CapabilityPolicy>(json)

--- a/crates/harn-vm/src/llm/compaction.rs
+++ b/crates/harn-vm/src/llm/compaction.rs
@@ -1,0 +1,298 @@
+//! Agent-loop transcript compaction policy.
+//!
+//! The orchestration module owns the low-level compaction engine. This
+//! module owns the user-facing agent-loop policy shape and lowers it to that
+//! engine so every `agent_loop` caller gets the same defaults.
+
+use crate::llm::helpers::{opt_bool, opt_int, opt_str};
+use crate::value::{VmError, VmValue};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CompactionStrategy {
+    None,
+    Truncate {
+        keep_first_n: usize,
+        keep_last_n: usize,
+    },
+    SummarizeMiddle {
+        keep_first_n: usize,
+        keep_last_n: usize,
+    },
+    SummarizeAll {
+        keep_first_n: usize,
+    },
+    Hybrid {
+        keep_first_n: usize,
+        keep_last_n: usize,
+    },
+}
+
+impl Default for CompactionStrategy {
+    fn default() -> Self {
+        Self::Hybrid {
+            keep_first_n: 0,
+            keep_last_n: 10,
+        }
+    }
+}
+
+impl CompactionStrategy {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Truncate { .. } => "truncate",
+            Self::SummarizeMiddle { .. } => "summarize_middle",
+            Self::SummarizeAll { .. } => "summarize_all",
+            Self::Hybrid { .. } => "hybrid",
+        }
+    }
+}
+
+pub(crate) async fn resolve_agent_loop_auto_compact(
+    args: &[VmValue],
+    options: &Option<std::collections::BTreeMap<String, VmValue>>,
+) -> Result<Option<crate::orchestration::AutoCompactConfig>, VmError> {
+    let has_auto_compact_key = options
+        .as_ref()
+        .is_some_and(|opts| opts.contains_key("auto_compact"));
+    let has_compaction_key = options
+        .as_ref()
+        .is_some_and(|opts| opts.contains_key("compaction"));
+
+    let mut ac = crate::orchestration::AutoCompactConfig::default();
+    let user_specified_threshold = opt_int(options, "compact_threshold").is_some();
+    let user_specified_hard_limit = opt_int(options, "hard_limit_tokens").is_some();
+
+    if has_compaction_key {
+        let value = options.as_ref().and_then(|opts| opts.get("compaction"));
+        let strategy = parse_compaction_strategy(value, options)?;
+        if matches!(strategy, CompactionStrategy::None) {
+            return Ok(None);
+        }
+        apply_strategy(&mut ac, strategy);
+    } else if has_auto_compact_key {
+        if !opt_bool(options, "auto_compact") {
+            return Ok(None);
+        }
+        apply_legacy_options(&mut ac, options)?;
+    } else {
+        apply_strategy(&mut ac, CompactionStrategy::default());
+    }
+
+    apply_common_options(&mut ac, options)?;
+    if !has_compaction_key && has_auto_compact_key {
+        apply_legacy_options(&mut ac, options)?;
+    }
+
+    let probe_opts = crate::llm::helpers::extract_llm_options(args)?;
+    crate::llm::api::adapt_auto_compact_to_provider(
+        &mut ac,
+        user_specified_threshold,
+        user_specified_hard_limit,
+        &probe_opts.provider,
+        &probe_opts.model,
+        &probe_opts.api_key,
+    )
+    .await;
+
+    Ok(Some(ac))
+}
+
+fn parse_compaction_strategy(
+    value: Option<&VmValue>,
+    options: &Option<std::collections::BTreeMap<String, VmValue>>,
+) -> Result<CompactionStrategy, VmError> {
+    let Some(value) = value else {
+        return Ok(CompactionStrategy::default());
+    };
+    match value {
+        VmValue::Nil => Ok(CompactionStrategy::default()),
+        VmValue::Bool(false) => Ok(CompactionStrategy::None),
+        VmValue::Bool(true) => Ok(CompactionStrategy::default()),
+        VmValue::String(label) => strategy_from_label(label, 0, 10),
+        VmValue::Dict(dict) => {
+            let label = dict
+                .get("type")
+                .or_else(|| dict.get("kind"))
+                .or_else(|| dict.get("strategy"))
+                .and_then(|value| match value {
+                    VmValue::String(s) => Some(s.to_string()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| "hybrid".to_string());
+            let keep_first_n = dict
+                .get("keep_first_n")
+                .or_else(|| dict.get("keep_first"))
+                .and_then(VmValue::as_int)
+                .or_else(|| opt_int(options, "compact_keep_first"))
+                .unwrap_or(0);
+            let keep_last_n = dict
+                .get("keep_last_n")
+                .or_else(|| dict.get("keep_last"))
+                .and_then(VmValue::as_int)
+                .or_else(|| opt_int(options, "compact_keep_last"))
+                .unwrap_or(10);
+            if keep_first_n < 0 || keep_last_n < 0 {
+                return Err(VmError::Runtime(
+                    "agent_loop: compaction keep counts must be >= 0".to_string(),
+                ));
+            }
+            strategy_from_label(&label, keep_first_n as usize, keep_last_n as usize)
+        }
+        _ => Err(VmError::Runtime(
+            "agent_loop: compaction must be a string, dict, bool, or nil".to_string(),
+        )),
+    }
+}
+
+fn strategy_from_label(
+    label: &str,
+    keep_first_n: usize,
+    keep_last_n: usize,
+) -> Result<CompactionStrategy, VmError> {
+    match label {
+        "none" => Ok(CompactionStrategy::None),
+        "truncate" => Ok(CompactionStrategy::Truncate {
+            keep_first_n,
+            keep_last_n,
+        }),
+        "summarize_middle" | "summarize" | "llm" => Ok(CompactionStrategy::SummarizeMiddle {
+            keep_first_n,
+            keep_last_n,
+        }),
+        "summarize_all" => Ok(CompactionStrategy::SummarizeAll { keep_first_n }),
+        "hybrid" => Ok(CompactionStrategy::Hybrid {
+            keep_first_n,
+            keep_last_n,
+        }),
+        other => Err(VmError::Runtime(format!(
+            "agent_loop: unknown compaction strategy '{other}' (expected none, truncate, summarize_middle, summarize_all, or hybrid)"
+        ))),
+    }
+}
+
+fn apply_strategy(ac: &mut crate::orchestration::AutoCompactConfig, strategy: CompactionStrategy) {
+    ac.policy_strategy = strategy.label().to_string();
+    match strategy {
+        CompactionStrategy::None => {}
+        CompactionStrategy::Truncate {
+            keep_first_n,
+            keep_last_n,
+        } => {
+            ac.keep_first = keep_first_n;
+            ac.keep_last = keep_last_n;
+            ac.compact_strategy = crate::orchestration::CompactStrategy::Truncate;
+            ac.hard_limit_strategy = crate::orchestration::CompactStrategy::Truncate;
+        }
+        CompactionStrategy::SummarizeMiddle {
+            keep_first_n,
+            keep_last_n,
+        } => {
+            ac.keep_first = keep_first_n;
+            ac.keep_last = keep_last_n;
+            ac.compact_strategy = crate::orchestration::CompactStrategy::Llm;
+            ac.hard_limit_strategy = crate::orchestration::CompactStrategy::Llm;
+        }
+        CompactionStrategy::SummarizeAll { keep_first_n } => {
+            ac.keep_first = keep_first_n;
+            ac.keep_last = 0;
+            ac.compact_strategy = crate::orchestration::CompactStrategy::Llm;
+            ac.hard_limit_strategy = crate::orchestration::CompactStrategy::Llm;
+        }
+        CompactionStrategy::Hybrid {
+            keep_first_n,
+            keep_last_n,
+        } => {
+            ac.keep_first = keep_first_n;
+            ac.keep_last = keep_last_n;
+            ac.compact_strategy = crate::orchestration::CompactStrategy::Llm;
+            ac.hard_limit_strategy = crate::orchestration::CompactStrategy::Truncate;
+        }
+    }
+}
+
+fn apply_common_options(
+    ac: &mut crate::orchestration::AutoCompactConfig,
+    options: &Option<std::collections::BTreeMap<String, VmValue>>,
+) -> Result<(), VmError> {
+    if let Some(v) = opt_int(options, "compact_threshold") {
+        if v < 0 {
+            return Err(VmError::Runtime(
+                "agent_loop: compact_threshold must be >= 0".to_string(),
+            ));
+        }
+        ac.token_threshold = v as usize;
+    }
+    if let Some(v) = opt_int(options, "tool_output_max_chars") {
+        if v < 0 {
+            return Err(VmError::Runtime(
+                "agent_loop: tool_output_max_chars must be >= 0".to_string(),
+            ));
+        }
+        ac.tool_output_max_chars = v as usize;
+    }
+    if let Some(v) = opt_int(options, "compact_keep_first") {
+        if v < 0 {
+            return Err(VmError::Runtime(
+                "agent_loop: compact_keep_first must be >= 0".to_string(),
+            ));
+        }
+        ac.keep_first = v as usize;
+    }
+    if let Some(v) = opt_int(options, "compact_keep_last") {
+        if v < 0 {
+            return Err(VmError::Runtime(
+                "agent_loop: compact_keep_last must be >= 0".to_string(),
+            ));
+        }
+        ac.keep_last = v as usize;
+    }
+    if let Some(v) = opt_int(options, "hard_limit_tokens") {
+        if v < 0 {
+            return Err(VmError::Runtime(
+                "agent_loop: hard_limit_tokens must be >= 0".to_string(),
+            ));
+        }
+        ac.hard_limit_tokens = Some(v as usize);
+    }
+    if let Some(prompt) = opt_str(options, "summarize_prompt") {
+        ac.summarize_prompt = Some(prompt);
+    }
+    if let Some(callback) = options.as_ref().and_then(|opts| opts.get("mask_callback")) {
+        ac.mask_callback = Some(callback.clone());
+    }
+    if let Some(callback) = options
+        .as_ref()
+        .and_then(|opts| opts.get("compress_callback"))
+    {
+        ac.compress_callback = Some(callback.clone());
+    }
+    Ok(())
+}
+
+fn apply_legacy_options(
+    ac: &mut crate::orchestration::AutoCompactConfig,
+    options: &Option<std::collections::BTreeMap<String, VmValue>>,
+) -> Result<(), VmError> {
+    if let Some(strategy) = opt_str(options, "compact_strategy") {
+        ac.policy_strategy = strategy.clone();
+        ac.compact_strategy = crate::orchestration::parse_compact_strategy(&strategy)?;
+    }
+    if let Some(strategy) = opt_str(options, "hard_limit_strategy") {
+        ac.hard_limit_strategy = crate::orchestration::parse_compact_strategy(&strategy)?;
+    }
+    if let Some(callback) = options
+        .as_ref()
+        .and_then(|opts| opts.get("compact_callback"))
+    {
+        ac.custom_compactor = Some(callback.clone());
+        if !options
+            .as_ref()
+            .is_some_and(|opts| opts.contains_key("compact_strategy"))
+        {
+            ac.compact_strategy = crate::orchestration::CompactStrategy::Custom;
+            ac.policy_strategy = "custom".to_string();
+        }
+    }
+    Ok(())
+}

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -17,6 +17,7 @@ mod agent_observe;
 mod agent_tools;
 pub(crate) mod api;
 pub mod capabilities;
+mod compaction;
 mod config_builtins;
 pub(crate) mod content;
 mod conversation;
@@ -492,6 +493,7 @@ pub use self::api::{
     fetch_provider_max_context, probe_openai_compatible_model, selected_model_for_provider,
     supports_model_readiness_probe, ModelReadiness,
 };
+pub(crate) use self::compaction::resolve_agent_loop_auto_compact;
 pub use self::cost::{calculate_cost_for_provider, peek_total_cost};
 pub use self::healthcheck::{
     build_healthcheck_url, run_provider_healthcheck, run_provider_healthcheck_with_options,
@@ -1143,36 +1145,7 @@ pub fn register_llm_builtins(vm: &mut Vm) {
         // this path and does not persist). A caller-provided id flows
         // through as the session's persistent identity.
         let session_id = opt_str(&options, "session_id").unwrap_or_default();
-        let auto_compact = if opt_bool(&options, "auto_compact") {
-            let mut ac = crate::orchestration::AutoCompactConfig::default();
-            if let Some(v) = opt_int(&options, "compact_threshold") {
-                ac.token_threshold = v as usize;
-            }
-            if let Some(v) = opt_int(&options, "tool_output_max_chars") {
-                ac.tool_output_max_chars = v as usize;
-            }
-            if let Some(v) = opt_int(&options, "compact_keep_last") {
-                ac.keep_last = v as usize;
-            }
-            if let Some(strategy) = opt_str(&options, "compact_strategy") {
-                ac.compact_strategy = crate::orchestration::parse_compact_strategy(&strategy)?;
-            }
-            if let Some(callback) = options.as_ref().and_then(|o| o.get("compact_callback")) {
-                ac.custom_compactor = Some(callback.clone());
-                if !options
-                    .as_ref()
-                    .is_some_and(|o| o.contains_key("compact_strategy"))
-                {
-                    ac.compact_strategy = crate::orchestration::CompactStrategy::Custom;
-                }
-            }
-            if let Some(callback) = options.as_ref().and_then(|o| o.get("compress_callback")) {
-                ac.compress_callback = Some(callback.clone());
-            }
-            Some(ac)
-        } else {
-            None
-        };
+        let auto_compact = resolve_agent_loop_auto_compact(&args, &options).await?;
         let policy = options.as_ref().and_then(|o| o.get("policy")).map(|v| {
             let json = crate::llm::helpers::vm_value_to_json(v);
             serde_json::from_value::<crate::orchestration::CapabilityPolicy>(json)

--- a/crates/harn-vm/src/orchestration/compaction.rs
+++ b/crates/harn-vm/src/orchestration/compaction.rs
@@ -46,6 +46,10 @@ pub fn compact_strategy_name(strategy: &CompactStrategy) -> &'static str {
 ///     transcript approaches the model's actual context window.
 #[derive(Clone, Debug)]
 pub struct AutoCompactConfig {
+    /// Number of earliest messages to keep verbatim before the compacted
+    /// summary. The system prompt is not part of this list and is always
+    /// preserved separately by the caller.
+    pub keep_first: usize,
     /// Tier-1 threshold: estimated tokens before lightweight compaction.
     pub token_threshold: usize,
     /// Maximum character length for a single tool result before microcompaction.
@@ -79,11 +83,16 @@ pub struct AutoCompactConfig {
     /// selected. The rendered template becomes the user message sent to
     /// the summarizer.
     pub summarize_prompt: Option<String>,
+    /// User-facing policy label for replay and observability. This can be
+    /// broader than the engine strategy, e.g. `hybrid` lowers to LLM
+    /// summarization plus truncate fallback.
+    pub policy_strategy: String,
 }
 
 impl Default for AutoCompactConfig {
     fn default() -> Self {
         Self {
+            keep_first: 0,
             token_threshold: 48_000,
             tool_output_max_chars: 16_000,
             keep_last: 12,
@@ -94,6 +103,7 @@ impl Default for AutoCompactConfig {
             mask_callback: None,
             compress_callback: None,
             summarize_prompt: None,
+            policy_strategy: compact_strategy_name(&CompactStrategy::ObservationMask).to_string(),
         }
     }
 }
@@ -615,15 +625,17 @@ pub(crate) async fn auto_compact_messages(
     config: &AutoCompactConfig,
     llm_opts: Option<&crate::llm::api::LlmCallOptions>,
 ) -> Result<Option<String>, VmError> {
-    if messages.len() <= config.keep_last {
+    if messages.len() <= config.keep_first.saturating_add(config.keep_last) {
         return Ok(None);
     }
+    let compact_start = config.keep_first.min(messages.len());
     let original_split = messages.len().saturating_sub(config.keep_last);
     let mut split_at = original_split;
     // Snap back to a user-role boundary so the kept suffix begins at a clean
     // turn. OpenAI-compatible APIs reject tool results orphaned from their
     // assistant request, so splitting mid-turn corrupts the transcript.
-    while split_at > 0
+    while split_at > compact_start
+        && split_at < messages.len()
         && messages[split_at]
             .get("role")
             .and_then(|r| r.as_str())
@@ -633,7 +645,7 @@ pub(crate) async fn auto_compact_messages(
     }
     // Fall back to the naive split (e.g. tool-heavy transcripts with the sole
     // user message at index 0) rather than skipping compaction entirely.
-    if split_at == 0 {
+    if split_at == compact_start {
         split_at = original_split;
     }
     if let Some(volatile_start) = messages[split_at..]
@@ -644,15 +656,15 @@ pub(crate) async fn auto_compact_messages(
         if let Some(boundary) = volatile_start
             .checked_sub(1)
             .and_then(|idx| find_prev_user_boundary(messages, idx))
-            .filter(|boundary| *boundary > 0)
+            .filter(|boundary| *boundary > compact_start)
         {
             split_at = boundary;
         }
     }
-    if split_at == 0 {
+    if split_at <= compact_start {
         return Ok(None);
     }
-    let old_messages: Vec<_> = messages.drain(..split_at).collect();
+    let old_messages: Vec<_> = messages.drain(compact_start..split_at).collect();
     let archived_count = old_messages.len();
 
     let mut summary = apply_compaction_strategy(
@@ -690,7 +702,7 @@ pub(crate) async fn auto_compact_messages(
     }
 
     messages.insert(
-        0,
+        compact_start,
         serde_json::json!({
             "role": "user",
             "content": summary,

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -95,6 +95,10 @@ Same as `llm_call`, plus additional options:
 | `wake_interval_ms` | int | nil | Fixed timer wake interval for daemon loops |
 | `watch_paths` | list/string | nil | Files to poll for mtime changes while idle |
 | `consolidate_on_idle` | bool | `false` | Run transcript auto-compaction before persisting an idle daemon snapshot |
+| `compaction` | string/dict/bool | `{strategy: "hybrid", keep_last_n: 10}` | Agent-loop context-window policy. Use `"none"` or `false` to disable; `"truncate"`, `"summarize_middle"`, `"summarize_all"`, or `"hybrid"` to choose policy |
+| `compact_threshold` | int | model-aware | Estimated input-token threshold for compaction. Harn lowers this from the provider/model context window when known |
+| `compact_keep_first` | int | `0` | Prompt-visible messages to keep verbatim before the compaction summary. The system prompt is always kept separately |
+| `compact_keep_last` | int | strategy default | Prompt-visible messages to keep verbatim after the compaction summary |
 | `idle_watchdog_attempts` | int | nil (disabled) | Max consecutive idle-wait ticks that may return no wake reason before the daemon terminates with `status = "watchdog"`. Guards against a misconfigured daemon (e.g. bridge never signals, no timer, no watch paths) hanging the session silently |
 | `context_callback` | closure | nil | Per-turn hook that can rewrite prompt-visible `messages` and/or the effective `system` prompt before the next LLM call |
 | `context_filter` | closure | nil | Alias for `context_callback` |
@@ -113,6 +117,37 @@ Same as `llm_call`, plus additional options:
 
 Profiles preload the common loop-budget and retry keys below. Pass any
 key explicitly to override the profile's value for that call.
+
+### Agent-loop compaction
+
+`agent_loop` compacts prompt-visible transcript messages before an LLM call
+would exceed the configured or discovered context budget. The default policy is
+`hybrid`: keep the system prompt and the last 10 prompt-visible messages
+verbatim, summarize older messages, and fall back to truncation if the summary
+still exceeds the hard limit.
+
+```harn
+let result = agent_loop(task, system, {
+  provider: "openai",
+  model: "gpt-4o",
+  compaction: {strategy: "hybrid", keep_last_n: 10}
+})
+```
+
+Available strategies:
+
+| Strategy | Behavior |
+|---|---|
+| `"none"` / `false` | Disable automatic agent-loop transcript compaction |
+| `"truncate"` | Replace older messages with a deterministic abbreviated summary |
+| `"summarize_middle"` | Summarize older messages and keep the latest suffix verbatim |
+| `"summarize_all"` | Summarize all compactable prompt-visible messages |
+| `"hybrid"` | Summarize older messages, keep the latest suffix, and use truncate as the hard-limit fallback |
+
+Compaction emits `TranscriptCompacted` live events and transcript
+`compaction` events with `strategy`, `engine_strategy`,
+`estimated_tokens_before`, and `estimated_tokens_after`, so replay tools can
+verify which policy ran.
 
 | Profile | `max_iterations` | `max_nudges` | `tool_retries` | `llm_retries` | `schema_retries` |
 |---|---:|---:|---:|---:|---:|


### PR DESCRIPTION
## Summary
- add a high-level agent_loop `compaction` policy surface with default hybrid behavior
- run compaction before oversized LLM calls and preserve replay/live observability metadata
- add 100-iteration conformance coverage for compaction continuing through a small-budget loop

Closes #910.

## Self-review
- checked legacy `auto_compact` compatibility, explicit disable behavior, replay metadata, and preflight/post-turn event paths
- cleaned up the resolver after reviewing the staged diff

## Verification
- cargo check -p harn-vm
- cargo test -p harn-vm compaction
- cargo run --quiet --bin harn -- test conformance --filter agent_loop_compaction_policy
- cargo run --quiet --bin harn -- test conformance --filter agent_runtime_features
- cargo run --quiet --bin harn -- fmt --check conformance/tests/integration/agent_loop_compaction_policy.harn
- pre-commit hook: rustfmt, Harn fmt/lint, clippy --workspace --all-targets -D warnings, markdownlint
- pre-push hook: 2975 nextest tests, affected Harn fmt/lint, markdownlint