### PR TITLE
Promote long-running stdlib handle pattern

### DIFF
--- a/crates/harn-hostlib/schemas/tools/run_command.response.json
+++ b/crates/harn-hostlib/schemas/tools/run_command.response.json
@@ -40,7 +40,8 @@
       "type": "object",
       "additionalProperties": true
     },
-    "command": { "type": "string" }
+    "command": { "type": "string" },
+    "command_or_op_descriptor": { "type": "string" }
   },
   "required": [
     "command_id",

--- a/crates/harn-hostlib/src/tools/cancel_handle.rs
+++ b/crates/harn-hostlib/src/tools/cancel_handle.rs
@@ -22,7 +22,8 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let map = require_dict_arg(NAME, args)?;
     let handle_id = require_string(NAME, &map, "handle_id")?;
 
-    let cancelled = super::long_running::cancel_handle(&handle_id);
+    let cancelled = super::long_running::cancel_handle(&handle_id)
+        || harn_vm::cancel_long_running_handle(&handle_id);
 
     Ok(ResponseBuilder::new()
         .str("handle_id", handle_id)

--- a/crates/harn-hostlib/src/tools/long_running.rs
+++ b/crates/harn-hostlib/src/tools/long_running.rs
@@ -5,7 +5,11 @@
 //! registers it here, and returns a handle dict immediately:
 //!
 //! ```json
-//! { "handle_id": "hto-<pid-hex>-<n>", "started_at": <unix_ms>, "command": "..." }
+//! {
+//!   "handle_id": "hto-<pid-hex>-<n>",
+//!   "started_at": "...",
+//!   "command_or_op_descriptor": "..."
+//! }
 //! ```
 //!
 //! A background thread waits for the child and, when it exits, calls
@@ -220,6 +224,7 @@ pub(crate) fn spawn_long_running_with_options(
     let waiter_handle_id = handle_id.clone();
     let waiter_session_id = session_id;
     let waiter_started_at = started_at.clone();
+    let waiter_command_display = command_display.clone();
     std::thread::Builder::new()
         .name(format!("hto-waiter-{waiter_handle_id}"))
         .spawn(move || {
@@ -231,6 +236,7 @@ pub(crate) fn spawn_long_running_with_options(
                 capture,
                 waiter_started_at,
                 process_group_id,
+                waiter_command_display,
             );
         })
         .map_err(|e| HostlibError::Backend {
@@ -257,6 +263,7 @@ fn waiter_thread(
     capture: CaptureConfig,
     started_at: String,
     process_group_id: Option<u32>,
+    command_display: String,
 ) {
     let waiter_start = std::time::Instant::now();
 
@@ -341,6 +348,10 @@ fn waiter_thread(
         serde_json::Value::String(CommandStatus::Completed.as_str().to_string()),
     );
     payload.insert("handle_id".into(), serde_json::Value::String(handle_id));
+    payload.insert(
+        "command_or_op_descriptor".into(),
+        serde_json::Value::String(command_display),
+    );
     payload.insert("started_at".into(), serde_json::Value::String(started_at));
     payload.insert(
         "ended_at".into(),

--- a/crates/harn-hostlib/src/tools/proc.rs
+++ b/crates/harn-hostlib/src/tools/proc.rs
@@ -350,7 +350,8 @@ pub(crate) fn running_response(
         .str("output_sha256", "")
         .dict("sandbox", sandbox)
         .str("audit_id", format!("audit_{command_id}"))
-        .str("command", command_display)
+        .str("command", command_display.clone())
+        .str("command_or_op_descriptor", command_display)
         .build()
 }
 

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -81,6 +81,9 @@ pub(crate) struct Linter<'a> {
     /// Stack of connector exports whose default effect policy restricts
     /// direct builtin calls.
     pub(super) connector_effect_export_stack: Vec<String>,
+    /// Whether the current body contains a defer/finally path that cancels
+    /// long-running handles.
+    pub(super) long_running_cleanup_stack: Vec<bool>,
 }
 
 impl<'a> Linter<'a> {
@@ -112,6 +115,7 @@ impl<'a> Linter<'a> {
             complexity_threshold: DEFAULT_COMPLEXITY_THRESHOLD,
             value_block_depth: 0,
             connector_effect_export_stack: Vec::new(),
+            long_running_cleanup_stack: Vec::new(),
         }
     }
 
@@ -430,6 +434,226 @@ impl<'a> Linter<'a> {
     fn string_literal_value(node: &SNode) -> Option<&str> {
         match &node.node {
             Node::StringLiteral(value) | Node::RawStringLiteral(value) => Some(value.as_str()),
+            _ => None,
+        }
+    }
+
+    pub(super) fn enter_long_running_body(&mut self, body: &[SNode]) {
+        self.long_running_cleanup_stack
+            .push(Self::body_has_long_running_cleanup(body));
+    }
+
+    pub(super) fn exit_long_running_body(&mut self) {
+        self.long_running_cleanup_stack.pop();
+    }
+
+    pub(super) fn current_body_has_long_running_cleanup(&self) -> bool {
+        self.long_running_cleanup_stack
+            .last()
+            .copied()
+            .unwrap_or(false)
+    }
+
+    pub(super) fn warn_unmanaged_long_running_call(&mut self, name: &str, span: Span) {
+        if self.current_body_has_long_running_cleanup() {
+            return;
+        }
+        self.diagnostics.push(LintDiagnostic {
+            rule: "long-running-without-cleanup",
+            message: format!(
+                "`{name}` starts long-running work without a defer/finally cleanup path"
+            ),
+            span,
+            severity: LintSeverity::Warning,
+            suggestion: Some(
+                "store the returned handle and cancel it from a defer or finally block with `tools.cancel_handle`"
+                    .to_string(),
+            ),
+            fix: None,
+        });
+    }
+
+    pub(super) fn call_uses_long_running_flag(name: &str, args: &[SNode]) -> bool {
+        if !Self::long_running_capable_call(name, args) {
+            return false;
+        }
+        args.iter().any(Self::expr_has_long_running_flag)
+    }
+
+    fn long_running_capable_call(name: &str, args: &[SNode]) -> bool {
+        matches!(
+            name,
+            "walk_dir"
+                | "glob"
+                | "http_get"
+                | "http_request"
+                | "http_download"
+                | "run_command"
+                | "run_test"
+                | "run_build_command"
+        ) || matches!(
+            (name, args.first().and_then(Self::string_literal_value)),
+            (
+                "host_tool_call",
+                Some(
+                    "run_command"
+                        | "run_test"
+                        | "run_build_command"
+                        | "tools.run_command"
+                        | "tools.run_test"
+                        | "tools.run_build_command"
+                )
+            )
+        )
+    }
+
+    fn expr_has_long_running_flag(node: &SNode) -> bool {
+        match &node.node {
+            Node::DictLiteral(entries) => entries.iter().any(|entry| {
+                matches!(
+                    Self::dict_key_name(&entry.key).as_deref(),
+                    Some("long_running" | "background")
+                ) && matches!(entry.value.node, Node::BoolLiteral(true))
+            }),
+            _ => false,
+        }
+    }
+
+    fn body_has_long_running_cleanup(body: &[SNode]) -> bool {
+        body.iter().any(Self::node_has_long_running_cleanup)
+    }
+
+    fn node_has_long_running_cleanup(node: &SNode) -> bool {
+        match &node.node {
+            Node::DeferStmt { body } => Self::block_calls_cancel_handle(body),
+            Node::TryCatch {
+                body,
+                catch_body,
+                finally_body,
+                ..
+            } => {
+                finally_body
+                    .as_ref()
+                    .is_some_and(|body| Self::block_calls_cancel_handle(body))
+                    || Self::body_has_long_running_cleanup(body)
+                    || Self::body_has_long_running_cleanup(catch_body)
+            }
+            Node::IfElse {
+                then_body,
+                else_body,
+                ..
+            } => {
+                Self::body_has_long_running_cleanup(then_body)
+                    || else_body
+                        .as_ref()
+                        .is_some_and(|body| Self::body_has_long_running_cleanup(body))
+            }
+            Node::ForIn { body, .. }
+            | Node::WhileLoop { body, .. }
+            | Node::Retry { body, .. }
+            | Node::Block(body)
+            | Node::SpawnExpr { body }
+            | Node::Closure { body, .. } => Self::body_has_long_running_cleanup(body),
+            _ => false,
+        }
+    }
+
+    fn block_calls_cancel_handle(body: &[SNode]) -> bool {
+        body.iter().any(Self::node_calls_cancel_handle)
+    }
+
+    fn node_calls_cancel_handle(node: &SNode) -> bool {
+        match &node.node {
+            Node::FunctionCall { name, args } => {
+                name == "cancel_handle"
+                    || matches!(
+                        (
+                            name.as_str(),
+                            args.first().and_then(Self::string_literal_value)
+                        ),
+                        (
+                            "host_tool_call",
+                            Some("cancel_handle" | "tools.cancel_handle")
+                        )
+                    )
+                    || args.iter().any(Self::node_calls_cancel_handle)
+            }
+            Node::DictLiteral(entries) => entries.iter().any(|entry| {
+                Self::node_calls_cancel_handle(&entry.key)
+                    || Self::node_calls_cancel_handle(&entry.value)
+            }),
+            Node::ListLiteral(items) => items.iter().any(Self::node_calls_cancel_handle),
+            Node::IfElse {
+                condition,
+                then_body,
+                else_body,
+            } => {
+                Self::node_calls_cancel_handle(condition)
+                    || Self::block_calls_cancel_handle(then_body)
+                    || else_body
+                        .as_ref()
+                        .is_some_and(|body| Self::block_calls_cancel_handle(body))
+            }
+            Node::TryCatch {
+                body,
+                catch_body,
+                finally_body,
+                ..
+            } => {
+                Self::block_calls_cancel_handle(body)
+                    || Self::block_calls_cancel_handle(catch_body)
+                    || finally_body
+                        .as_ref()
+                        .is_some_and(|body| Self::block_calls_cancel_handle(body))
+            }
+            Node::DeferStmt { body }
+            | Node::ForIn { body, .. }
+            | Node::WhileLoop { body, .. }
+            | Node::Retry { body, .. }
+            | Node::Block(body)
+            | Node::SpawnExpr { body }
+            | Node::Closure { body, .. } => Self::block_calls_cancel_handle(body),
+            Node::MethodCall { object, args, .. }
+            | Node::OptionalMethodCall { object, args, .. } => {
+                Self::node_calls_cancel_handle(object)
+                    || args.iter().any(Self::node_calls_cancel_handle)
+            }
+            Node::PropertyAccess { object, .. }
+            | Node::OptionalPropertyAccess { object, .. }
+            | Node::SubscriptAccess { object, .. }
+            | Node::OptionalSubscriptAccess { object, .. }
+            | Node::SliceAccess { object, .. } => Self::node_calls_cancel_handle(object),
+            Node::BinaryOp { left, right, .. } => {
+                Self::node_calls_cancel_handle(left) || Self::node_calls_cancel_handle(right)
+            }
+            Node::UnaryOp { operand, .. }
+            | Node::TryOperator { operand }
+            | Node::TryStar { operand } => Self::node_calls_cancel_handle(operand),
+            Node::Ternary {
+                condition,
+                true_expr,
+                false_expr,
+            } => {
+                Self::node_calls_cancel_handle(condition)
+                    || Self::node_calls_cancel_handle(true_expr)
+                    || Self::node_calls_cancel_handle(false_expr)
+            }
+            Node::ReturnStmt { value } | Node::YieldExpr { value } => value
+                .as_ref()
+                .is_some_and(|value| Self::node_calls_cancel_handle(value)),
+            Node::ThrowStmt { value } | Node::EmitExpr { value } => {
+                Self::node_calls_cancel_handle(value)
+            }
+            Node::AttributedDecl { inner, .. } => Self::node_calls_cancel_handle(inner),
+            _ => false,
+        }
+    }
+
+    fn dict_key_name(node: &SNode) -> Option<String> {
+        match &node.node {
+            Node::Identifier(value)
+            | Node::StringLiteral(value)
+            | Node::RawStringLiteral(value) => Some(value.clone()),
             _ => None,
         }
     }

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -58,7 +58,9 @@ impl<'a> Linter<'a> {
                     self.test_pipeline_depth += 1;
                 }
                 let _ = self.analyze_secret_scan_block(body, false);
+                self.enter_long_running_body(body);
                 self.lint_block(body);
+                self.exit_long_running_body();
                 if Self::is_test_pipeline_name(name) {
                     self.test_pipeline_depth -= 1;
                 }
@@ -120,7 +122,9 @@ impl<'a> Linter<'a> {
                     self.connector_effect_export_stack.push(name.clone());
                 }
                 let _ = self.analyze_secret_scan_block(body, false);
+                self.enter_long_running_body(body);
                 self.lint_block(body);
+                self.exit_long_running_body();
                 if harn_vm::connector_export_effect_class(name).is_some() {
                     self.connector_effect_export_stack.pop();
                 }
@@ -158,7 +162,9 @@ impl<'a> Linter<'a> {
                 }
                 self.return_type_stack.push(return_type.clone());
                 let _ = self.analyze_secret_scan_block(body, false);
+                self.enter_long_running_body(body);
                 self.lint_block(body);
+                self.exit_long_running_body();
                 self.return_type_stack.pop();
                 self.loop_depth = saved_loop_depth;
                 self.pop_scope();
@@ -293,6 +299,9 @@ impl<'a> Linter<'a> {
                         suggestion: Some(format!("remove the redundant `{name}(...)` wrapper")),
                         fix,
                     });
+                }
+                if Self::call_uses_long_running_flag(name, args) {
+                    self.warn_unmanaged_long_running_call(name, snode.span);
                 }
                 for arg in args {
                     self.lint_node(arg);
@@ -741,7 +750,9 @@ impl<'a> Linter<'a> {
                 for p in params {
                     self.declare_parameter(&p.name, snode.span);
                 }
+                self.enter_long_running_body(body);
                 self.lint_block(body);
+                self.exit_long_running_body();
                 self.loop_depth = saved_loop_depth;
                 self.pop_scope();
             }

--- a/crates/harn-lint/src/tests/long_running.rs
+++ b/crates/harn-lint/src/tests/long_running.rs
@@ -1,0 +1,53 @@
+use super::*;
+
+#[test]
+fn long_running_flag_without_cleanup_warns() {
+    let diags = lint_source(
+        r#"
+pipeline main() {
+  let handle = walk_dir(".", {long_running: true})
+  println(handle.handle_id)
+}
+"#,
+    );
+
+    assert!(
+        has_rule(&diags, "long-running-without-cleanup"),
+        "expected long-running cleanup warning, got: {diags:?}"
+    );
+}
+
+#[test]
+fn long_running_flag_with_defer_cleanup_is_ok() {
+    let diags = lint_source(
+        r#"
+pipeline main() {
+  let handle = walk_dir(".", {long_running: true})
+  defer {
+    host_tool_call("cancel_handle", {handle_id: handle.handle_id})
+  }
+}
+"#,
+    );
+
+    assert!(
+        !has_rule(&diags, "long-running-without-cleanup"),
+        "did not expect long-running cleanup warning, got: {diags:?}"
+    );
+}
+
+#[test]
+fn host_tool_long_running_flag_without_cleanup_warns() {
+    let diags = lint_source(
+        r#"
+pipeline main() {
+  host_tool_call("run_command", {argv: ["sleep", "10"], long_running: true})
+}
+"#,
+    );
+
+    assert!(
+        has_rule(&diags, "long-running-without-cleanup"),
+        "expected host tool cleanup warning, got: {diags:?}"
+    );
+}

--- a/crates/harn-lint/src/tests/mod.rs
+++ b/crates/harn-lint/src/tests/mod.rs
@@ -84,6 +84,7 @@ mod hitl;
 mod imports;
 mod invalid_binop;
 mod llm_rules;
+mod long_running;
 mod mutability;
 mod naming_types;
 mod redundant_nil_ternary;

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -117,6 +117,7 @@ pub use stdlib::hitl::{
 };
 pub use stdlib::host::{clear_host_call_bridge, set_host_call_bridge, HostCallBridge};
 pub use stdlib::io::take_stderr_buffer;
+pub use stdlib::long_running::cancel_handle as cancel_long_running_handle;
 pub use stdlib::secret_scan::{
     append_secret_scan_audit, audit_secret_scan_active, scan_content as secret_scan_content,
     SecretFinding, SECRET_SCAN_AUDIT_TOPIC,

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -28,6 +28,7 @@ pub(crate) mod json;
 mod json_query;
 mod junit;
 mod logging;
+pub mod long_running;
 mod math;
 mod memory;
 mod monitors;
@@ -187,6 +188,7 @@ pub fn reset_stdlib_state() {
     io::reset_io_state();
     sandbox::reset_sandbox_state();
     fs::reset_fs_state();
+    long_running::reset_state();
     json::reset_json_state();
     host::reset_host_state();
     crate::egress::reset_egress_policy_for_host();

--- a/crates/harn-vm/src/stdlib/fs.rs
+++ b/crates/harn-vm/src/stdlib/fs.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::SystemTime;
 use std::{cell::RefCell, thread_local};
 
@@ -24,6 +25,27 @@ pub(crate) fn reset_fs_state() {
     FILE_TEXT_CACHE.with(|cache| cache.borrow_mut().clear());
 }
 
+#[derive(Clone, Copy)]
+struct WalkDirOptions {
+    max_depth: Option<usize>,
+    follow_symlinks: bool,
+    long_running: bool,
+}
+
+#[derive(Clone)]
+struct WalkDirEntry {
+    path: String,
+    is_dir: bool,
+    is_file: bool,
+    depth: i64,
+}
+
+#[derive(Clone)]
+struct GlobOptions {
+    base: String,
+    long_running: bool,
+}
+
 fn resolve_fs_path(path: &str) -> PathBuf {
     crate::stdlib::process::resolve_source_relative_path(path)
 }
@@ -34,6 +56,154 @@ fn result_ok(value: VmValue) -> VmValue {
 
 fn result_err(value: VmValue) -> VmValue {
     VmValue::enum_variant("Result", "Err", vec![value])
+}
+
+fn bool_option(opts: &BTreeMap<String, VmValue>, key: &str) -> Option<bool> {
+    match opts.get(key) {
+        Some(VmValue::Bool(value)) => Some(*value),
+        _ => None,
+    }
+}
+
+fn string_option(opts: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+    match opts.get(key) {
+        Some(VmValue::String(value)) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn parse_walk_dir_options(args: &[VmValue]) -> WalkDirOptions {
+    let mut options = WalkDirOptions {
+        max_depth: None,
+        follow_symlinks: false,
+        long_running: false,
+    };
+    if let Some(VmValue::Dict(opts)) = args.get(1) {
+        if let Some(v) = opts.get("max_depth").and_then(|v| v.as_int()) {
+            if v >= 0 {
+                options.max_depth = Some(v as usize);
+            }
+        }
+        options.follow_symlinks = bool_option(opts, "follow_symlinks").unwrap_or(false);
+        options.long_running = bool_option(opts, "long_running")
+            .or_else(|| bool_option(opts, "background"))
+            .unwrap_or(false);
+    }
+    options
+}
+
+fn walk_dir_entries(
+    resolved: &PathBuf,
+    options: WalkDirOptions,
+    cancel: Option<&AtomicBool>,
+) -> Vec<WalkDirEntry> {
+    let mut walker = walkdir::WalkDir::new(resolved).follow_links(options.follow_symlinks);
+    if let Some(d) = options.max_depth {
+        walker = walker.max_depth(d);
+    }
+    let mut entries = Vec::new();
+    for entry in walker.into_iter().filter_map(|e| e.ok()) {
+        if cancel.is_some_and(|flag| flag.load(Ordering::Acquire)) {
+            break;
+        }
+        let path = entry.path();
+        entries.push(WalkDirEntry {
+            path: path.to_string_lossy().replace('\\', "/"),
+            is_dir: entry.file_type().is_dir(),
+            is_file: entry.file_type().is_file(),
+            depth: entry.depth() as i64,
+        });
+    }
+    entries
+}
+
+fn walk_entry_to_vm(entry: WalkDirEntry) -> VmValue {
+    let mut dict = BTreeMap::new();
+    dict.insert("path".to_string(), VmValue::String(Rc::from(entry.path)));
+    dict.insert("is_dir".to_string(), VmValue::Bool(entry.is_dir));
+    dict.insert("is_file".to_string(), VmValue::Bool(entry.is_file));
+    dict.insert("depth".to_string(), VmValue::Int(entry.depth));
+    VmValue::Dict(Rc::new(dict))
+}
+
+fn walk_entries_to_json(entries: Vec<WalkDirEntry>) -> serde_json::Value {
+    serde_json::Value::Array(
+        entries
+            .into_iter()
+            .map(|entry| {
+                serde_json::json!({
+                    "path": entry.path,
+                    "is_dir": entry.is_dir,
+                    "is_file": entry.is_file,
+                    "depth": entry.depth,
+                })
+            })
+            .collect(),
+    )
+}
+
+fn parse_glob_options(args: &[VmValue]) -> GlobOptions {
+    let mut options = GlobOptions {
+        base: ".".to_string(),
+        long_running: false,
+    };
+    match args.get(1) {
+        Some(VmValue::Dict(opts)) => {
+            options.base = string_option(opts, "base").unwrap_or_else(|| ".".to_string());
+            options.long_running = bool_option(opts, "long_running")
+                .or_else(|| bool_option(opts, "background"))
+                .unwrap_or(false);
+        }
+        Some(value) => {
+            let base = value.display();
+            if !base.is_empty() {
+                options.base = base;
+            }
+            if let Some(VmValue::Dict(opts)) = args.get(2) {
+                options.long_running = bool_option(opts, "long_running")
+                    .or_else(|| bool_option(opts, "background"))
+                    .unwrap_or(false);
+            }
+        }
+        None => {}
+    }
+    options
+}
+
+fn glob_matches(
+    pattern: &str,
+    base: &PathBuf,
+    cancel: Option<&AtomicBool>,
+) -> Result<Vec<String>, VmError> {
+    let mut builder = globset::GlobSetBuilder::new();
+    let glob = globset::Glob::new(pattern)
+        .map_err(|e| VmError::Thrown(VmValue::String(Rc::from(format!("glob: {e}")))))?;
+    builder.add(glob);
+    let set = builder
+        .build()
+        .map_err(|e| VmError::Thrown(VmValue::String(Rc::from(format!("glob: {e}")))))?;
+    let mut matches = Vec::new();
+    for entry in walkdir::WalkDir::new(base)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if cancel.is_some_and(|flag| flag.load(Ordering::Acquire)) {
+            break;
+        }
+        let rel = match entry.path().strip_prefix(base) {
+            Ok(p) => p.to_path_buf(),
+            Err(_) => continue,
+        };
+        let rel_str = rel.to_string_lossy().replace('\\', "/");
+        if rel_str.is_empty() {
+            continue;
+        }
+        if set.is_match(&rel_str) {
+            matches.push(entry.path().to_string_lossy().replace('\\', "/"));
+        }
+    }
+    matches.sort();
+    Ok(matches)
 }
 
 fn metadata_signature(path: &PathBuf) -> Option<(u64, Option<SystemTime>)> {
@@ -476,40 +646,29 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
             &resolved,
             crate::stdlib::sandbox::FsAccess::Read,
         )?;
-        let mut max_depth: Option<usize> = None;
-        let mut follow_symlinks = false;
-        if let Some(VmValue::Dict(opts)) = args.get(1) {
-            if let Some(v) = opts.get("max_depth").and_then(|v| v.as_int()) {
-                if v >= 0 {
-                    max_depth = Some(v as usize);
-                }
-            }
-            if let Some(VmValue::Bool(b)) = opts.get("follow_symlinks") {
-                follow_symlinks = *b;
-            }
+        let options = parse_walk_dir_options(args);
+        if options.long_running {
+            let session_id = crate::llm::current_agent_session_id().unwrap_or_default();
+            let descriptor = format!("walk_dir {}", resolved.display());
+            let handle = crate::stdlib::long_running::spawn_json_operation(
+                "walk_dir",
+                descriptor,
+                session_id,
+                move |cancel| {
+                    Ok(walk_entries_to_json(walk_dir_entries(
+                        &resolved,
+                        options,
+                        Some(&cancel),
+                    )))
+                },
+            )
+            .map_err(VmError::Runtime)?;
+            return Ok(handle.into_vm_value());
         }
-        let mut walker = walkdir::WalkDir::new(&resolved).follow_links(follow_symlinks);
-        if let Some(d) = max_depth {
-            walker = walker.max_depth(d);
-        }
-        let mut entries: Vec<VmValue> = Vec::new();
-        for entry in walker.into_iter().filter_map(|e| e.ok()) {
-            let path = entry.path();
-            let depth = entry.depth() as i64;
-            let is_dir = entry.file_type().is_dir();
-            let mut dict = BTreeMap::new();
-            dict.insert(
-                "path".to_string(),
-                VmValue::String(Rc::from(path.to_string_lossy().replace('\\', "/"))),
-            );
-            dict.insert("is_dir".to_string(), VmValue::Bool(is_dir));
-            dict.insert(
-                "is_file".to_string(),
-                VmValue::Bool(entry.file_type().is_file()),
-            );
-            dict.insert("depth".to_string(), VmValue::Int(depth));
-            entries.push(VmValue::Dict(Rc::new(dict)));
-        }
+        let entries = walk_dir_entries(&resolved, options, None)
+            .into_iter()
+            .map(walk_entry_to_vm)
+            .collect::<Vec<_>>();
         Ok(VmValue::List(Rc::new(entries)))
     });
 
@@ -520,48 +679,37 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
                 "glob: pattern is required",
             ))));
         }
-        // The pattern is matched against paths relative to the configured
-        // base. Default base is the script source directory; an explicit
-        // second argument overrides.
-        let base_str = args
-            .get(1)
-            .map(|a| a.display())
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| ".".to_string());
-        let base = resolve_fs_path(&base_str);
+        let options = parse_glob_options(args);
+        let base = resolve_fs_path(&options.base);
         crate::stdlib::sandbox::enforce_fs_path(
             "glob",
             &base,
             crate::stdlib::sandbox::FsAccess::Read,
         )?;
-        let mut builder = globset::GlobSetBuilder::new();
-        let glob = globset::Glob::new(&pattern)
-            .map_err(|e| VmError::Thrown(VmValue::String(Rc::from(format!("glob: {e}")))))?;
-        builder.add(glob);
-        let set = builder
-            .build()
-            .map_err(|e| VmError::Thrown(VmValue::String(Rc::from(format!("glob: {e}")))))?;
-        let mut matches: Vec<VmValue> = Vec::new();
-        for entry in walkdir::WalkDir::new(&base)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
-            // Match against path relative to base, using forward slashes.
-            let rel = match entry.path().strip_prefix(&base) {
-                Ok(p) => p.to_path_buf(),
-                Err(_) => continue,
-            };
-            let rel_str = rel.to_string_lossy().replace('\\', "/");
-            if rel_str.is_empty() {
-                continue;
-            }
-            if set.is_match(&rel_str) {
-                matches.push(VmValue::String(Rc::from(
-                    entry.path().to_string_lossy().replace('\\', "/"),
-                )));
-            }
+        if options.long_running {
+            let session_id = crate::llm::current_agent_session_id().unwrap_or_default();
+            let descriptor = format!("glob {} in {}", pattern, base.display());
+            let handle = crate::stdlib::long_running::spawn_json_operation(
+                "glob",
+                descriptor,
+                session_id,
+                move |cancel| {
+                    glob_matches(&pattern, &base, Some(&cancel))
+                        .map(|items| {
+                            serde_json::Value::Array(
+                                items.into_iter().map(serde_json::Value::String).collect(),
+                            )
+                        })
+                        .map_err(|error| error.to_string())
+                },
+            )
+            .map_err(VmError::Runtime)?;
+            return Ok(handle.into_vm_value());
         }
-        matches.sort_by_key(|a| a.display());
+        let matches = glob_matches(&pattern, &base, None)?
+            .into_iter()
+            .map(|path| VmValue::String(Rc::from(path)))
+            .collect::<Vec<_>>();
         Ok(VmValue::List(Rc::new(matches)))
     });
 }
@@ -569,6 +717,9 @@ pub(crate) fn register_fs_builtins(vm: &mut Vm) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{LazyLock, Mutex};
+
+    static LONG_RUNNING_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     fn vm() -> Vm {
         let mut vm = Vm::new();
@@ -584,6 +735,33 @@ mod tests {
 
     fn s(v: &str) -> VmValue {
         VmValue::String(Rc::from(v))
+    }
+
+    fn b(v: bool) -> VmValue {
+        VmValue::Bool(v)
+    }
+
+    fn dict(entries: Vec<(&str, VmValue)>) -> VmValue {
+        VmValue::Dict(Rc::new(
+            entries
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value))
+                .collect(),
+        ))
+    }
+
+    fn drain_feedback(handle_id: &str) -> serde_json::Value {
+        for _ in 0..50 {
+            for (kind, content) in crate::llm::drain_global_pending_feedback("") {
+                assert_eq!(kind, "tool_result");
+                let payload: serde_json::Value = serde_json::from_str(&content).unwrap();
+                if payload["handle_id"] == handle_id {
+                    return payload;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        panic!("timed out waiting for feedback for {handle_id}");
     }
 
     #[test]
@@ -608,5 +786,75 @@ mod tests {
                 .display(),
             "two updated"
         );
+    }
+
+    #[test]
+    fn walk_dir_long_running_returns_handle_and_feedback() {
+        let _guard = LONG_RUNNING_TEST_LOCK.lock().unwrap();
+        crate::stdlib::long_running::reset_state();
+        let _ = crate::llm::drain_global_pending_feedback("");
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/lib.harn"), "fn main() {}\n").unwrap();
+        let mut vm = vm();
+
+        let response = call(
+            &mut vm,
+            "walk_dir",
+            vec![
+                s(&dir.path().to_string_lossy()),
+                dict(vec![("long_running", b(true))]),
+            ],
+        )
+        .unwrap();
+        let response = response.as_dict().expect("handle dict");
+        assert_eq!(response["status"].display(), "running");
+        assert_eq!(response["operation"].display(), "walk_dir");
+        assert!(response["command_or_op_descriptor"]
+            .display()
+            .contains("walk_dir"));
+        let handle_id = response["handle_id"].display();
+        let payload = drain_feedback(&handle_id);
+
+        assert_eq!(payload["status"], "completed");
+        assert_eq!(payload["operation"], "walk_dir");
+        assert!(payload["result"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["path"].as_str().unwrap().ends_with("src/lib.harn")));
+    }
+
+    #[test]
+    fn glob_long_running_returns_handle_and_feedback() {
+        let _guard = LONG_RUNNING_TEST_LOCK.lock().unwrap();
+        crate::stdlib::long_running::reset_state();
+        let _ = crate::llm::drain_global_pending_feedback("");
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/lib.harn"), "fn main() {}\n").unwrap();
+        std::fs::write(dir.path().join("README.md"), "# test\n").unwrap();
+        let mut vm = vm();
+
+        let response = call(
+            &mut vm,
+            "glob",
+            vec![
+                s("**/*.harn"),
+                s(&dir.path().to_string_lossy()),
+                dict(vec![("background", b(true))]),
+            ],
+        )
+        .unwrap();
+        let response = response.as_dict().expect("handle dict");
+        assert_eq!(response["status"].display(), "running");
+        assert_eq!(response["operation"].display(), "glob");
+        let handle_id = response["handle_id"].display();
+        let payload = drain_feedback(&handle_id);
+
+        assert_eq!(payload["status"], "completed");
+        let result = payload["result"].as_array().unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result[0].as_str().unwrap().ends_with("src/lib.harn"));
     }
 }

--- a/crates/harn-vm/src/stdlib/long_running.rs
+++ b/crates/harn-vm/src/stdlib/long_running.rs
@@ -1,0 +1,223 @@
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
+use std::time::Instant;
+
+use crate::value::VmValue;
+
+static HANDLE_COUNTER: AtomicU64 = AtomicU64::new(1);
+static HANDLE_STORE: LazyLock<Mutex<BTreeMap<String, HandleEntry>>> =
+    LazyLock::new(|| Mutex::new(BTreeMap::new()));
+
+struct HandleEntry {
+    session_id: String,
+    cancel: Arc<AtomicBool>,
+}
+
+pub(crate) struct OperationHandleInfo {
+    pub handle_id: String,
+    pub started_at: String,
+    pub operation: String,
+    pub descriptor: String,
+}
+
+impl OperationHandleInfo {
+    pub(crate) fn into_vm_value(self) -> VmValue {
+        let mut dict = BTreeMap::new();
+        dict.insert(
+            "handle_id".to_string(),
+            VmValue::String(Rc::from(self.handle_id)),
+        );
+        dict.insert(
+            "started_at".to_string(),
+            VmValue::String(Rc::from(self.started_at)),
+        );
+        dict.insert("ended_at".to_string(), VmValue::Nil);
+        dict.insert("duration_ms".to_string(), VmValue::Int(0));
+        dict.insert("status".to_string(), VmValue::String(Rc::from("running")));
+        dict.insert(
+            "operation".to_string(),
+            VmValue::String(Rc::from(self.operation)),
+        );
+        dict.insert(
+            "command_or_op_descriptor".to_string(),
+            VmValue::String(Rc::from(self.descriptor)),
+        );
+        VmValue::Dict(Rc::new(dict))
+    }
+}
+
+pub(crate) fn spawn_json_operation<F>(
+    operation: impl Into<String>,
+    descriptor: impl Into<String>,
+    session_id: String,
+    run: F,
+) -> Result<OperationHandleInfo, String>
+where
+    F: FnOnce(Arc<AtomicBool>) -> Result<serde_json::Value, String> + Send + 'static,
+{
+    register_cleanup_hook();
+    let handle_id = format!(
+        "hso-{:x}-{}",
+        std::process::id(),
+        HANDLE_COUNTER.fetch_add(1, Ordering::SeqCst)
+    );
+    let started_at = chrono::Utc::now().to_rfc3339();
+    let operation = operation.into();
+    let descriptor = descriptor.into();
+    let cancel = Arc::new(AtomicBool::new(false));
+    {
+        let mut store = HANDLE_STORE
+            .lock()
+            .expect("stdlib long-running handle store poisoned");
+        store.insert(
+            handle_id.clone(),
+            HandleEntry {
+                session_id: session_id.clone(),
+                cancel: cancel.clone(),
+            },
+        );
+    }
+
+    let worker_handle_id = handle_id.clone();
+    let worker_started_at = started_at.clone();
+    let worker_operation = operation.clone();
+    let worker_descriptor = descriptor.clone();
+    std::thread::Builder::new()
+        .name(format!("hso-worker-{worker_handle_id}"))
+        .spawn(move || {
+            let started = Instant::now();
+            let result = run(cancel.clone());
+            let entry = {
+                let mut store = HANDLE_STORE
+                    .lock()
+                    .expect("stdlib long-running handle store poisoned");
+                store.remove(&worker_handle_id)
+            };
+            if cancel.load(Ordering::Acquire) {
+                return;
+            }
+            let Some(entry) = entry else {
+                return;
+            };
+            let mut payload = serde_json::Map::new();
+            payload.insert(
+                "handle_id".to_string(),
+                serde_json::Value::String(worker_handle_id),
+            );
+            payload.insert(
+                "operation".to_string(),
+                serde_json::Value::String(worker_operation),
+            );
+            payload.insert(
+                "command_or_op_descriptor".to_string(),
+                serde_json::Value::String(worker_descriptor),
+            );
+            payload.insert(
+                "started_at".to_string(),
+                serde_json::Value::String(worker_started_at),
+            );
+            payload.insert(
+                "ended_at".to_string(),
+                serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+            );
+            payload.insert(
+                "duration_ms".to_string(),
+                serde_json::Value::Number((started.elapsed().as_millis() as u64).into()),
+            );
+            match result {
+                Ok(value) => {
+                    payload.insert(
+                        "status".to_string(),
+                        serde_json::Value::String("completed".to_string()),
+                    );
+                    payload.insert("result".to_string(), value);
+                }
+                Err(error) => {
+                    payload.insert(
+                        "status".to_string(),
+                        serde_json::Value::String("failed".to_string()),
+                    );
+                    payload.insert("error".to_string(), serde_json::Value::String(error));
+                }
+            }
+            let content = serde_json::to_string(&payload).unwrap_or_default();
+            crate::llm::push_pending_feedback_global(&entry.session_id, "tool_result", &content);
+        })
+        .map_err(|error| {
+            let entry = {
+                let mut store = HANDLE_STORE
+                    .lock()
+                    .expect("stdlib long-running handle store poisoned");
+                store.remove(&handle_id)
+            };
+            if let Some(entry) = entry {
+                entry.cancel.store(true, Ordering::Release);
+            }
+            format!("failed to spawn stdlib long-running worker: {error}")
+        })?;
+
+    Ok(OperationHandleInfo {
+        handle_id,
+        started_at,
+        operation,
+        descriptor,
+    })
+}
+
+pub fn cancel_handle(handle_id: &str) -> bool {
+    let entry = {
+        let mut store = HANDLE_STORE
+            .lock()
+            .expect("stdlib long-running handle store poisoned");
+        store.remove(handle_id)
+    };
+    match entry {
+        Some(entry) => {
+            entry.cancel.store(true, Ordering::Release);
+            true
+        }
+        None => false,
+    }
+}
+
+pub(crate) fn cancel_session_handles(session_id: &str) {
+    let entries = {
+        let mut store = HANDLE_STORE
+            .lock()
+            .expect("stdlib long-running handle store poisoned");
+        let matching = store
+            .iter()
+            .filter(|(_, entry)| entry.session_id == session_id)
+            .map(|(handle_id, _)| handle_id.clone())
+            .collect::<Vec<_>>();
+        matching
+            .into_iter()
+            .filter_map(|handle_id| store.remove(&handle_id))
+            .collect::<Vec<_>>()
+    };
+    for entry in entries {
+        entry.cancel.store(true, Ordering::Release);
+    }
+}
+
+pub(crate) fn register_cleanup_hook() {
+    static REGISTERED: OnceLock<()> = OnceLock::new();
+    REGISTERED.get_or_init(|| {
+        let hook: Arc<dyn Fn(&str) + Send + Sync> = Arc::new(cancel_session_handles);
+        crate::llm::register_session_end_hook(hook);
+    });
+}
+
+pub(crate) fn reset_state() {
+    let entries = {
+        let mut store = HANDLE_STORE
+            .lock()
+            .expect("stdlib long-running handle store poisoned");
+        std::mem::take(&mut *store)
+    };
+    for (_, entry) in entries {
+        entry.cancel.store(true, Ordering::Release);
+    }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -29,6 +29,8 @@
   - [Streaming and transcripts](./llm/streaming.md)
   - [LLM providers](./llm/providers.md)
   - [Provider capability matrix](./provider-matrix.md)
+- [Typed tools for agent loops](./typed-tools.md)
+- [Long-running tools](./long-running-tools.md)
 - [Tool surface validation](./tool-surface-validation.md)
 - [Daemon stdlib](./stdlib/daemon.md)
 - [Current session builtin](./stdlib/agent_session_current_id.md)

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -545,6 +545,8 @@ does **not** drain the iterator.
 | `delete_file(path)` | path: string | nil | Delete a file or directory (recursive). Throws on failure |
 | `file_exists(path)` | path: string | bool | Check if a file or directory exists |
 | `list_dir(path?)` | path: string (default `"."`) | list | List directory contents as sorted list of file names. Throws on failure |
+| `walk_dir(path, options?)` | path: string, options: dict | list or handle dict | Recursively list files/directories. Options: `max_depth`, `follow_symlinks`, `long_running`/`background` |
+| `glob(pattern, base_or_options?, options?)` | pattern: string, base: string or options: dict | list or handle dict | Match files under a base directory. Set `long_running`/`background` in options to return a handle |
 | `mkdir(path)` | path: string | nil | Create directory and all parent directories. Throws on failure |
 | `stat(path)` | path: string | dict | File metadata: `{size, is_file, is_dir, readonly, modified}`. Throws on failure |
 | `temp_dir()` | none | string | System temporary directory path |

--- a/docs/src/long-running-tools.md
+++ b/docs/src/long-running-tools.md
@@ -1,0 +1,107 @@
+# Long-running tools
+
+Long-running tool handles let a script start slow work, continue the agent
+loop, and receive the final result through the pending feedback queue on a
+later turn. The idiom is the same for host command tools and stdlib operations
+that support `long_running: true` or `background: true`.
+
+Supported stdlib operations:
+
+- `walk_dir(path, {long_running: true, ...})`
+- `glob(pattern, base?, {long_running: true})`
+- `glob(pattern, {base: "...", long_running: true})`
+
+Supported host tools:
+
+- `tools.run_command`
+- `tools.run_test`
+- `tools.run_build_command`
+
+## Handle envelope
+
+A long-running call returns immediately with a handle envelope:
+
+```harn
+let handle = walk_dir(".", {long_running: true})
+```
+
+The returned dict includes:
+
+```text
+{
+  handle_id: string,
+  started_at: string,
+  status: "running",
+  command_or_op_descriptor: string
+}
+```
+
+Command tools also include command-specific fields such as `command_id`, `pid`,
+planned output paths, and sandbox metadata.
+
+## Lifecycle
+
+1. Spawn the operation with `long_running: true` or `background: true`.
+2. Save `handle_id`.
+3. Let the agent loop poll normally. Background workers push a `tool_result`
+   item to the pending feedback queue when they complete.
+4. Cancel abandoned work with `tools.cancel_handle`.
+5. Rely on session-end cleanup only as a backstop. When an agent-loop session
+   ends, registered resource managers cancel remaining handles for that
+   session.
+
+## Correct cleanup
+
+Use `defer` or `finally` so early returns and thrown errors still release the
+handle when the script no longer needs the result.
+
+```harn
+pipeline main() {
+  let handle = walk_dir(".", {long_running: true})
+  defer {
+    host_tool_call("cancel_handle", {handle_id: handle.handle_id})
+  }
+
+  agent_loop({
+    system: "Summarize the repository while the file walk runs.",
+    tools: ["read_file"]
+  })
+}
+```
+
+When the operation finishes before the cleanup path runs, cancellation returns
+`cancelled: false`; that is expected because the handle has already left the
+in-flight store and its result has been queued.
+
+## Incorrect lifecycle
+
+This starts background work but has no cleanup path if the pipeline exits early:
+
+```harn
+pipeline main() {
+  let handle = walk_dir(".", {long_running: true})
+  println(handle.handle_id)
+}
+```
+
+`harn lint` warns for this shape with `long-running-without-cleanup`. Add a
+`defer` or `finally` block that calls `tools.cancel_handle`.
+
+## Feedback shape
+
+Completed stdlib operations enqueue a `tool_result` payload like:
+
+```json
+{
+  "handle_id": "hso-...",
+  "status": "completed",
+  "operation": "walk_dir",
+  "command_or_op_descriptor": "walk_dir /repo",
+  "started_at": "2026-04-30T12:00:00Z",
+  "ended_at": "2026-04-30T12:00:01Z",
+  "duration_ms": 1000,
+  "result": []
+}
+```
+
+Failed operations use `status: "failed"` and include `error`.


### PR DESCRIPTION
## Summary

- add a VM stdlib long-running handle registry with feedback-queue completion and session-end cleanup
- migrate `walk_dir` and `glob` to support `long_running`/`background` handles
- wire `tools.cancel_handle` to cancel VM stdlib handles as well as process handles
- add the `long-running-without-cleanup` lint and docs for correct/incorrect lifecycle handling

Closes #909

## Verification

- `cargo test -p harn-vm long_running_returns_handle`
- `cargo test -p harn-lint long_running`
- `cargo test -p harn-hostlib long_running`
- `cargo check -p harn-vm -p harn-hostlib -p harn-lint`
- `cargo run --quiet --bin harn -- test conformance --filter fs_extras`
- pre-commit hook passed: rustfmt, clippy, highlight sync, markdownlint
- pre-push hook ran full nextest: 2,979 passed, 1 transient leaky failure in `harn-cli::bin/harn-container-probe tests::parses_http_url_with_default_path`; exact rerun passed with `cargo nextest run -p harn-cli --bin harn-container-probe tests::parses_http_url_with_default_path`

## Self-review

- checked for cancellation races, feedback delivery shape, session cleanup registration side effects, and foreground `walk_dir`/`glob` compatibility
- tightened cleanup hook registration to happen lazily when a stdlib handle is spawned, avoiding side effects during builtin-name introspection
