### PR TITLE
Add canonical persona manifest validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
 name = "harn-modules"
 version = "0.7.50"
 dependencies = [
+ "croner",
  "harn-lexer",
  "harn-parser",
  "serde",

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -2169,6 +2169,8 @@ pub(crate) struct FlowArchivistScanArgs {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum PersonaCommand {
+    /// Validate a persona manifest with the canonical harn-modules schema.
+    Check(PersonaCheckArgs),
     /// List personas declared in the resolved harn.toml.
     List(PersonaListArgs),
     /// Inspect one persona from the resolved harn.toml.
@@ -2187,6 +2189,16 @@ pub(crate) enum PersonaCommand {
     Trigger(PersonaTriggerArgs),
     /// Record an expensive-work budget receipt for a persona.
     Spend(PersonaSpendArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PersonaCheckArgs {
+    /// Persona manifest, harn.toml path, or directory containing harn.toml.
+    #[arg(value_name = "PATH")]
+    pub path: Option<PathBuf>,
+    /// Emit typed validation errors as JSON.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Args)]
@@ -2532,9 +2544,9 @@ mod tests {
         CheckOutputFormat, Cli, Command, ConnectCommand, ConnectorCommand, CrystallizeCommand,
         FlowArchivistCommand, FlowCommand, McpCommand, OrchestratorCommand,
         OrchestratorDeployProvider, OrchestratorLogFormat, OrchestratorQueueCommand,
-        OrchestratorTenantCommand, PackageCacheCommand, PackageCommand, ProjectTemplate,
-        RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand, TraceCommand,
-        TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
+        OrchestratorTenantCommand, PackageCacheCommand, PackageCommand, PersonaCommand,
+        ProjectTemplate, RunsCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand,
+        SkillsCommand, TraceCommand, TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
     };
     use clap::Parser;
 
@@ -3057,6 +3069,35 @@ mod tests {
             Some(PathBuf::from(".harn/archivist/proposals.json"))
         );
         assert!(scan.json);
+    }
+
+    #[test]
+    fn test_parses_persona_check_flags() {
+        let cli = Cli::parse_from([
+            "harn",
+            "persona",
+            "--manifest",
+            "examples/personas/harn.toml",
+            "check",
+            "personas/ship_captain/harn.toml",
+            "--json",
+        ]);
+
+        let Command::Persona(args) = cli.command.unwrap() else {
+            panic!("expected persona command");
+        };
+        assert_eq!(
+            args.manifest,
+            Some(PathBuf::from("examples/personas/harn.toml"))
+        );
+        let PersonaCommand::Check(check) = args.command else {
+            panic!("expected persona check command");
+        };
+        assert_eq!(
+            check.path,
+            Some(PathBuf::from("personas/ship_captain/harn.toml"))
+        );
+        assert!(check.json);
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/mcp/serve.rs
+++ b/crates/harn-cli/src/commands/mcp/serve.rs
@@ -1759,6 +1759,11 @@ fn handler_json(handler: &CollectedTriggerHandler) -> JsonValue {
             "kind": "worker",
             "queue": queue,
         }),
+        CollectedTriggerHandler::Persona { binding } => json!({
+            "kind": "persona",
+            "name": binding.name,
+            "entry_workflow": binding.entry_workflow,
+        }),
     }
 }
 

--- a/crates/harn-cli/src/commands/orchestrator/inspect_data.rs
+++ b/crates/harn-cli/src/commands/orchestrator/inspect_data.rs
@@ -766,6 +766,7 @@ fn handler_kind(handler: &CollectedTriggerHandler) -> &'static str {
         CollectedTriggerHandler::Local { .. } => "local",
         CollectedTriggerHandler::A2a { .. } => "a2a",
         CollectedTriggerHandler::Worker { .. } => "worker",
+        CollectedTriggerHandler::Persona { .. } => "persona",
     }
 }
 

--- a/crates/harn-cli/src/commands/orchestrator/serve.rs
+++ b/crates/harn-cli/src/commands/orchestrator/serve.rs
@@ -932,6 +932,7 @@ fn handler_kind(handler: &CollectedTriggerHandler) -> &'static str {
         CollectedTriggerHandler::Local { .. } => "local",
         CollectedTriggerHandler::A2a { .. } => "a2a",
         CollectedTriggerHandler::Worker { .. } => "worker",
+        CollectedTriggerHandler::Persona { .. } => "persona",
     }
 }
 

--- a/crates/harn-cli/src/commands/persona.rs
+++ b/crates/harn-cli/src/commands/persona.rs
@@ -6,10 +6,10 @@ use std::sync::Arc;
 use harn_vm::event_log::{AnyEventLog, EventLog};
 
 use crate::cli::{
-    PersonaControlArgs, PersonaInspectArgs, PersonaListArgs, PersonaSpendArgs, PersonaStatusArgs,
-    PersonaTickArgs, PersonaTriggerArgs,
+    PersonaCheckArgs, PersonaControlArgs, PersonaInspectArgs, PersonaListArgs, PersonaSpendArgs,
+    PersonaStatusArgs, PersonaTickArgs, PersonaTriggerArgs,
 };
-use crate::package::{self, PersonaManifestEntry, ResolvedPersonaManifest};
+use crate::package::{self, PersonaManifestEntry, PersonaValidationError, ResolvedPersonaManifest};
 
 pub(crate) fn run_list(manifest: Option<&Path>, args: &PersonaListArgs) {
     let catalog = load_catalog_or_exit(manifest);
@@ -57,6 +57,53 @@ pub(crate) fn run_list(manifest: Option<&Path>, args: &PersonaListArgs) {
         println!(
             "  {name:<name_width$}  tier={tier:<17} receipts={receipts:<8} entry={entry}",
             name_width = name_width
+        );
+    }
+}
+
+pub(crate) fn run_check(manifest: Option<&Path>, args: &PersonaCheckArgs) {
+    let selected = args.path.as_deref().or(manifest);
+    let catalog = match load_catalog_validation(selected) {
+        Ok(catalog) => catalog,
+        Err(errors) if args.json => {
+            print_validation_errors_json(&errors);
+            process::exit(1);
+        }
+        Err(errors) => fatal(
+            &errors
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        ),
+    };
+    if args.json {
+        let payload = serde_json::json!({
+            "ok": true,
+            "manifest_path": catalog.manifest_path,
+            "personas": catalog.personas.iter().map(|persona| {
+                serde_json::json!({
+                    "name": persona.name.as_deref().unwrap_or_default(),
+                    "triggers": &persona.triggers,
+                    "tools": &persona.tools,
+                    "autonomy": persona.autonomy_tier.map(|tier| tier.as_str()).unwrap_or_default(),
+                    "receipts": persona.receipt_policy.map(|policy| policy.as_str()).unwrap_or_default(),
+                })
+            }).collect::<Vec<_>>(),
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload).unwrap_or_else(|error| {
+                fatal(&format!(
+                    "failed to serialize persona check output: {error}"
+                ))
+            })
+        );
+    } else {
+        println!(
+            "ok: {} persona manifest validates ({} personas)",
+            catalog.manifest_path.display(),
+            catalog.personas.len()
         );
     }
 }
@@ -281,6 +328,18 @@ fn load_catalog_or_exit(manifest: Option<&Path>) -> ResolvedPersonaManifest {
 }
 
 fn load_catalog_result(manifest: Option<&Path>) -> Result<ResolvedPersonaManifest, String> {
+    load_catalog_validation(manifest).map_err(|errors| {
+        errors
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+    })
+}
+
+fn load_catalog_validation(
+    manifest: Option<&Path>,
+) -> Result<ResolvedPersonaManifest, Vec<PersonaValidationError>> {
     let result = if let Some(path) = manifest {
         package::load_personas_from_manifest_path(path).map(Some)
     } else {
@@ -288,14 +347,13 @@ fn load_catalog_result(manifest: Option<&Path>) -> Result<ResolvedPersonaManifes
     };
     match result {
         Ok(Some(catalog)) => Ok(catalog),
-        Ok(None) => Err(
-            "no harn.toml found; pass --manifest <path> or run inside a Harn project".to_string(),
-        ),
-        Err(errors) => Err(errors
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join("\n")),
+        Ok(None) => Err(vec![PersonaValidationError {
+            manifest_path: PathBuf::from("harn.toml"),
+            field_path: "harn.toml".to_string(),
+            message: "no harn.toml found; pass --manifest <path> or run inside a Harn project"
+                .to_string(),
+        }]),
+        Err(errors) => Err(errors),
     }
 }
 
@@ -448,6 +506,27 @@ fn print_receipt(receipt: &harn_vm::PersonaRunReceipt, json: bool) {
             println!("error={error}");
         }
     }
+}
+
+fn print_validation_errors_json(errors: &[PersonaValidationError]) {
+    let payload = serde_json::json!({
+        "ok": false,
+        "errors": errors.iter().map(|error| {
+            serde_json::json!({
+                "manifest_path": &error.manifest_path,
+                "field_path": &error.field_path,
+                "message": &error.message,
+            })
+        }).collect::<Vec<_>>(),
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&payload).unwrap_or_else(|error| {
+            fatal(&format!(
+                "failed to serialize persona validation errors: {error}"
+            ))
+        })
+    );
 }
 
 fn persona_to_json(

--- a/crates/harn-cli/src/commands/trigger/ops.rs
+++ b/crates/harn-cli/src/commands/trigger/ops.rs
@@ -719,6 +719,7 @@ fn handler_kind(binding: &harn_vm::triggers::registry::TriggerBinding) -> &'stat
         TriggerHandlerSpec::Local { .. } => "local",
         TriggerHandlerSpec::A2a { .. } => "a2a",
         TriggerHandlerSpec::Worker { .. } => "worker",
+        TriggerHandlerSpec::Persona { .. } => "persona",
     }
 }
 
@@ -727,6 +728,7 @@ fn handler_label(binding: &harn_vm::triggers::registry::TriggerBinding) -> Strin
         TriggerHandlerSpec::Local { raw, .. } => raw.clone(),
         TriggerHandlerSpec::A2a { target, .. } => target.clone(),
         TriggerHandlerSpec::Worker { queue } => queue.clone(),
+        TriggerHandlerSpec::Persona { binding } => binding.name.clone(),
     }
 }
 
@@ -735,6 +737,7 @@ fn target_uri(binding: &harn_vm::triggers::registry::TriggerBinding) -> String {
         TriggerHandlerSpec::Local { raw, .. } => raw.clone(),
         TriggerHandlerSpec::A2a { target, .. } => format!("a2a://{target}"),
         TriggerHandlerSpec::Worker { queue } => format!("worker://{queue}"),
+        TriggerHandlerSpec::Persona { binding } => format!("persona://{}", binding.name),
     }
 }
 

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -687,6 +687,9 @@ async fn async_main() {
             args.json,
         ),
         Command::Persona(args) => match args.command {
+            PersonaCommand::Check(check) => {
+                commands::persona::run_check(args.manifest.as_deref(), &check)
+            }
             PersonaCommand::List(list) => {
                 commands::persona::run_list(args.manifest.as_deref(), &list)
             }

--- a/crates/harn-cli/src/package/extensions.rs
+++ b/crates/harn-cli/src/package/extensions.rs
@@ -36,6 +36,8 @@ pub fn try_load_runtime_extensions(anchor: &Path) -> Result<RuntimeExtensions, S
         resolved_provider_connectors_from_manifest(&root_manifest, &manifest_dir);
 
     Ok(RuntimeExtensions {
+        root_manifest_path: Some(manifest_dir.join(MANIFEST)),
+        root_manifest_dir: Some(manifest_dir),
         root_manifest: Some(root_manifest),
         llm: (!llm.is_empty()).then_some(llm),
         capabilities: (!is_empty_capabilities(&capabilities)).then_some(capabilities),
@@ -181,6 +183,10 @@ pub async fn collect_manifest_triggers(
                 allow_cleartext,
             },
             TriggerHandlerUri::Worker { queue } => CollectedTriggerHandler::Worker { queue },
+            TriggerHandlerUri::Persona { name } => {
+                let binding = persona_runtime_binding_for_handler(extensions, trigger, &name)?;
+                CollectedTriggerHandler::Persona { binding }
+            }
         };
 
         let collected_when = if let Some(when_raw) = &trigger.when {
@@ -388,6 +394,42 @@ pub(crate) async fn collect_trigger_flow_control(
     Ok(flow)
 }
 
+fn persona_runtime_binding_for_handler(
+    extensions: &RuntimeExtensions,
+    trigger: &ResolvedTriggerConfig,
+    name: &str,
+) -> Result<harn_vm::PersonaRuntimeBinding, String> {
+    let Some(manifest) = extensions.root_manifest.as_ref() else {
+        return Err(trigger_error(
+            trigger,
+            format!("handler persona://{name} requires a root manifest"),
+        ));
+    };
+    let Some(persona) = manifest
+        .personas
+        .iter()
+        .find(|persona| persona.name.as_deref() == Some(name))
+    else {
+        return Err(trigger_error(
+            trigger,
+            format!("handler persona://{name} does not match a declared persona"),
+        ));
+    };
+    Ok(harn_vm::PersonaRuntimeBinding {
+        name: name.to_string(),
+        template_ref: persona_template_ref(persona),
+        entry_workflow: persona.entry_workflow.clone().unwrap_or_default(),
+        schedules: persona.schedules.clone(),
+        triggers: persona.triggers.clone(),
+        budget: harn_vm::PersonaBudgetPolicy {
+            daily_usd: persona.budget.daily_usd,
+            hourly_usd: persona.budget.hourly_usd,
+            run_usd: persona.budget.run_usd,
+            max_tokens: persona.budget.max_tokens,
+        },
+    })
+}
+
 pub(crate) async fn compile_optional_trigger_expression(
     vm: &mut harn_vm::Vm,
     trigger: &ResolvedTriggerConfig,
@@ -496,6 +538,16 @@ pub fn manifest_trigger_binding_spec(
             serde_json::json!({
                 "kind": "worker",
                 "queue": queue,
+            }),
+        ),
+        CollectedTriggerHandler::Persona { binding } => (
+            harn_vm::TriggerHandlerSpec::Persona {
+                binding: binding.clone(),
+            },
+            serde_json::json!({
+                "kind": "persona",
+                "name": binding.name,
+                "entry_workflow": binding.entry_workflow,
             }),
         ),
     };
@@ -622,7 +674,15 @@ pub async fn install_manifest_triggers(
 ) -> Result<(), String> {
     install_orchestrator_budget(extensions);
     let collected = collect_manifest_triggers(vm, extensions).await?;
-    install_collected_manifest_triggers(&collected).await
+    let mut bindings: Vec<_> = collected
+        .iter()
+        .cloned()
+        .map(manifest_trigger_binding_spec)
+        .collect();
+    bindings.extend(collect_persona_trigger_binding_specs(extensions)?);
+    harn_vm::install_manifest_triggers(bindings)
+        .await
+        .map_err(|error| error.to_string())
 }
 
 pub async fn install_collected_manifest_triggers(
@@ -638,6 +698,150 @@ pub async fn install_collected_manifest_triggers(
         .map_err(|error| error.to_string())
 }
 
+pub fn collect_persona_trigger_binding_specs(
+    extensions: &RuntimeExtensions,
+) -> Result<Vec<harn_vm::TriggerBindingSpec>, String> {
+    let Some(manifest) = extensions.root_manifest.clone() else {
+        return Ok(Vec::new());
+    };
+    let manifest_path = extensions
+        .root_manifest_path
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(MANIFEST));
+    let manifest_dir = extensions
+        .root_manifest_dir
+        .clone()
+        .or_else(|| manifest_path.parent().map(Path::to_path_buf))
+        .unwrap_or_else(|| PathBuf::from("."));
+    let resolved = validate_and_resolve_personas(manifest, manifest_path.clone(), manifest_dir)
+        .map_err(|errors| {
+            errors
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+        })?;
+    let mut bindings = Vec::new();
+    for persona in resolved.personas {
+        let Some(name) = persona.name.clone() else {
+            continue;
+        };
+        for trigger in &persona.triggers {
+            let Some((provider, kind)) = trigger.split_once('.') else {
+                continue;
+            };
+            let provider = provider.trim();
+            let kind = kind.trim();
+            if provider.is_empty() || kind.is_empty() {
+                continue;
+            }
+            bindings.push(persona_trigger_binding_spec(
+                &resolved.manifest_path,
+                &name,
+                provider,
+                kind,
+                &persona,
+            ));
+        }
+    }
+    Ok(bindings)
+}
+
+fn persona_trigger_binding_spec(
+    manifest_path: &Path,
+    name: &str,
+    provider: &str,
+    kind: &str,
+    persona: &PersonaManifestEntry,
+) -> harn_vm::TriggerBindingSpec {
+    let runtime_binding = harn_vm::PersonaRuntimeBinding {
+        name: name.to_string(),
+        template_ref: persona_template_ref(persona),
+        entry_workflow: persona.entry_workflow.clone().unwrap_or_default(),
+        schedules: persona.schedules.clone(),
+        triggers: persona.triggers.clone(),
+        budget: harn_vm::PersonaBudgetPolicy {
+            daily_usd: persona.budget.daily_usd,
+            hourly_usd: persona.budget.hourly_usd,
+            run_usd: persona.budget.run_usd,
+            max_tokens: persona.budget.max_tokens,
+        },
+    };
+    let id = format!("persona.{name}.{provider}.{kind}");
+    let handler = harn_vm::TriggerHandlerSpec::Persona {
+        binding: runtime_binding.clone(),
+    };
+    let fingerprint = serde_json::to_string(&serde_json::json!({
+        "id": &id,
+        "kind": kind,
+        "provider": provider,
+        "handler": {
+            "kind": "persona",
+            "name": name,
+            "entry_workflow": runtime_binding.entry_workflow,
+        },
+        "budget": runtime_binding.budget,
+        "manifest_path": manifest_path,
+    }))
+    .unwrap_or_else(|_| format!("{id}:{provider}:{kind}:{name}"));
+
+    harn_vm::TriggerBindingSpec {
+        id,
+        source: harn_vm::TriggerBindingSource::Manifest,
+        kind: kind.to_string(),
+        provider: harn_vm::ProviderId::from(provider.to_string()),
+        autonomy_tier: persona
+            .autonomy_tier
+            .map(persona_autonomy_to_vm)
+            .unwrap_or(harn_vm::AutonomyTier::Suggest),
+        handler,
+        dispatch_priority: harn_vm::WorkerQueuePriority::Normal,
+        when: None,
+        when_budget: None,
+        retry: harn_vm::TriggerRetryConfig::default(),
+        match_events: vec![kind.to_string()],
+        dedupe_key: None,
+        filter: None,
+        dedupe_retention_days: 7,
+        daily_cost_usd: persona.budget.daily_usd,
+        hourly_cost_usd: persona.budget.hourly_usd,
+        max_autonomous_decisions_per_hour: None,
+        max_autonomous_decisions_per_day: None,
+        on_budget_exhausted: harn_vm::TriggerBudgetExhaustionStrategy::RetryLater,
+        max_concurrent: None,
+        flow_control: harn_vm::TriggerFlowControlConfig::default(),
+        manifest_path: Some(manifest_path.to_path_buf()),
+        package_name: None,
+        definition_fingerprint: fingerprint,
+    }
+}
+
+fn persona_autonomy_to_vm(value: PersonaAutonomyTier) -> harn_vm::AutonomyTier {
+    match value {
+        PersonaAutonomyTier::Shadow => harn_vm::AutonomyTier::Shadow,
+        PersonaAutonomyTier::Suggest => harn_vm::AutonomyTier::Suggest,
+        PersonaAutonomyTier::ActWithApproval => harn_vm::AutonomyTier::ActWithApproval,
+        PersonaAutonomyTier::ActAuto => harn_vm::AutonomyTier::ActAuto,
+    }
+}
+
+fn persona_template_ref(persona: &PersonaManifestEntry) -> Option<String> {
+    persona
+        .package_source
+        .package
+        .as_ref()
+        .zip(persona.version.as_ref())
+        .map(|(package, version)| format!("{package}@{version}"))
+        .or_else(|| persona.package_source.package.clone())
+        .or_else(|| {
+            persona
+                .name
+                .as_ref()
+                .zip(persona.version.as_ref())
+                .map(|(name, version)| format!("{name}@{version}"))
+        })
+}
+
 pub fn load_personas_from_manifest_path(
     manifest_path: &Path,
 ) -> Result<ResolvedPersonaManifest, Vec<PersonaValidationError>> {
@@ -650,14 +854,63 @@ pub fn load_personas_from_manifest_path(
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| PathBuf::from("."));
-    let manifest = read_manifest_from_path(&manifest_path).map_err(|message| {
-        vec![PersonaValidationError {
-            manifest_path: manifest_path.clone(),
-            field_path: "harn.toml".to_string(),
-            message,
-        }]
-    })?;
+    let manifest = match read_manifest_from_path(&manifest_path) {
+        Ok(manifest) => manifest,
+        Err(message) => {
+            if let Ok(document) =
+                harn_modules::personas::parse_persona_manifest_file(&manifest_path)
+            {
+                if !document.personas.is_empty() {
+                    return validate_and_resolve_standalone_personas(
+                        document.personas,
+                        manifest_path,
+                        manifest_dir,
+                    );
+                }
+            }
+            return Err(vec![PersonaValidationError {
+                manifest_path: manifest_path.clone(),
+                field_path: "harn.toml".to_string(),
+                message,
+            }]);
+        }
+    };
+    if manifest.personas.is_empty() {
+        if let Ok(document) = harn_modules::personas::parse_persona_manifest_file(&manifest_path) {
+            if !document.personas.is_empty() {
+                return validate_and_resolve_standalone_personas(
+                    document.personas,
+                    manifest_path,
+                    manifest_dir,
+                );
+            }
+        }
+    }
     validate_and_resolve_personas(manifest, manifest_path, manifest_dir)
+}
+
+fn validate_and_resolve_standalone_personas(
+    personas: Vec<PersonaManifestEntry>,
+    manifest_path: PathBuf,
+    manifest_dir: PathBuf,
+) -> Result<ResolvedPersonaManifest, Vec<PersonaValidationError>> {
+    let known_names = personas
+        .iter()
+        .filter_map(|persona| persona.name.as_ref())
+        .filter(|name| !name.trim().is_empty())
+        .cloned()
+        .collect();
+    let context = harn_modules::personas::PersonaValidationContext {
+        known_capabilities: harn_modules::personas::default_persona_capabilities(),
+        known_tools: BTreeSet::new(),
+        known_names,
+    };
+    harn_modules::personas::validate_persona_manifests(&manifest_path, &personas, &context)?;
+    Ok(ResolvedPersonaManifest {
+        manifest_path,
+        manifest_dir,
+        personas,
+    })
 }
 
 pub fn load_personas_config(
@@ -687,324 +940,24 @@ pub(crate) fn validate_and_resolve_personas(
         .filter(|name| !name.trim().is_empty())
         .cloned()
         .collect();
-    let mut errors = Vec::new();
-    for (index, persona) in manifest.personas.iter().enumerate() {
-        validate_persona(
-            persona,
-            index,
-            &manifest_path,
-            &known_capabilities,
-            &known_tools,
-            &known_names,
-            &mut errors,
-        );
-    }
-    if errors.is_empty() {
+    let context = harn_modules::personas::PersonaValidationContext {
+        known_capabilities,
+        known_tools,
+        known_names,
+    };
+    if let Err(errors) = harn_modules::personas::validate_persona_manifests(
+        &manifest_path,
+        &manifest.personas,
+        &context,
+    ) {
+        Err(errors)
+    } else {
         Ok(ResolvedPersonaManifest {
             manifest_path,
             manifest_dir,
             personas: manifest.personas,
         })
-    } else {
-        Err(errors)
     }
-}
-
-pub(crate) fn validate_persona(
-    persona: &PersonaManifestEntry,
-    index: usize,
-    manifest_path: &Path,
-    known_capabilities: &BTreeSet<String>,
-    known_tools: &BTreeSet<String>,
-    known_names: &BTreeSet<String>,
-    errors: &mut Vec<PersonaValidationError>,
-) {
-    let root = format!("[[personas]][{index}]");
-    for field in persona.extra.keys() {
-        persona_error(
-            manifest_path,
-            format!("{root}.{field}"),
-            "unknown persona field",
-            errors,
-        );
-    }
-    let name = validate_required_string(
-        manifest_path,
-        &root,
-        "name",
-        persona.name.as_deref(),
-        errors,
-    );
-    if let Some(name) = name {
-        validate_tokenish(manifest_path, &root, "name", name, errors);
-    }
-    validate_required_string(
-        manifest_path,
-        &root,
-        "description",
-        persona.description.as_deref(),
-        errors,
-    );
-    validate_required_string(
-        manifest_path,
-        &root,
-        "entry_workflow",
-        persona.entry_workflow.as_deref(),
-        errors,
-    );
-    if persona.tools.is_empty() && persona.capabilities.is_empty() {
-        persona_error(
-            manifest_path,
-            format!("{root}.tools"),
-            "persona requires at least one tool or capability",
-            errors,
-        );
-    }
-    if persona.autonomy_tier.is_none() {
-        persona_error(
-            manifest_path,
-            format!("{root}.autonomy_tier"),
-            "missing required autonomy tier",
-            errors,
-        );
-    }
-    if persona.receipt_policy.is_none() {
-        persona_error(
-            manifest_path,
-            format!("{root}.receipt_policy"),
-            "missing required receipt policy",
-            errors,
-        );
-    }
-    validate_string_list(manifest_path, &root, "tools", &persona.tools, errors);
-    for tool in &persona.tools {
-        if !known_tools.contains(tool) {
-            persona_error(
-                manifest_path,
-                format!("{root}.tools"),
-                format!("unknown tool '{tool}'"),
-                errors,
-            );
-        }
-    }
-    for capability in &persona.capabilities {
-        let Some((cap, op)) = capability.split_once('.') else {
-            persona_error(
-                manifest_path,
-                format!("{root}.capabilities"),
-                format!("capability '{capability}' must use capability.operation syntax"),
-                errors,
-            );
-            continue;
-        };
-        if cap.trim().is_empty() || op.trim().is_empty() {
-            persona_error(
-                manifest_path,
-                format!("{root}.capabilities"),
-                format!("capability '{capability}' must use capability.operation syntax"),
-                errors,
-            );
-        } else if !known_capabilities.contains(capability) {
-            persona_error(
-                manifest_path,
-                format!("{root}.capabilities"),
-                format!("unknown capability '{capability}'"),
-                errors,
-            );
-        }
-    }
-    validate_string_list(
-        manifest_path,
-        &root,
-        "context_packs",
-        &persona.context_packs,
-        errors,
-    );
-    validate_string_list(manifest_path, &root, "evals", &persona.evals, errors);
-    for schedule in &persona.schedules {
-        if schedule.trim().is_empty() {
-            persona_error(
-                manifest_path,
-                format!("{root}.schedules"),
-                "schedule entries must not be empty",
-                errors,
-            );
-        } else if let Err(error) = croner::Cron::from_str(schedule) {
-            persona_error(
-                manifest_path,
-                format!("{root}.schedules"),
-                format!("invalid cron schedule '{schedule}': {error}"),
-                errors,
-            );
-        }
-    }
-    for trigger in &persona.triggers {
-        if !trigger.contains('.') {
-            persona_error(
-                manifest_path,
-                format!("{root}.triggers"),
-                format!("trigger '{trigger}' must use provider.event syntax"),
-                errors,
-            );
-        }
-    }
-    for handoff in &persona.handoffs {
-        if !known_names.contains(handoff) {
-            persona_error(
-                manifest_path,
-                format!("{root}.handoffs"),
-                format!("unknown handoff target '{handoff}'"),
-                errors,
-            );
-        }
-    }
-    validate_persona_budget(manifest_path, &root, &persona.budget, errors);
-    validate_persona_nested_extra(
-        manifest_path,
-        &root,
-        "model_policy",
-        &persona.model_policy.extra,
-        errors,
-    );
-    validate_persona_nested_extra(
-        manifest_path,
-        &root,
-        "package_source",
-        &persona.package_source.extra,
-        errors,
-    );
-    validate_persona_nested_extra(
-        manifest_path,
-        &root,
-        "rollout_policy",
-        &persona.rollout_policy.extra,
-        errors,
-    );
-    if let Some(percentage) = persona.rollout_policy.percentage {
-        if percentage > 100 {
-            persona_error(
-                manifest_path,
-                format!("{root}.rollout_policy.percentage"),
-                "rollout percentage must be between 0 and 100",
-                errors,
-            );
-        }
-    }
-}
-
-pub(crate) fn validate_required_string<'a>(
-    manifest_path: &Path,
-    root: &str,
-    field: &str,
-    value: Option<&'a str>,
-    errors: &mut Vec<PersonaValidationError>,
-) -> Option<&'a str> {
-    match value.map(str::trim) {
-        Some(value) if !value.is_empty() => Some(value),
-        _ => {
-            persona_error(
-                manifest_path,
-                format!("{root}.{field}"),
-                format!("missing required {field}"),
-                errors,
-            );
-            None
-        }
-    }
-}
-
-pub(crate) fn validate_string_list(
-    manifest_path: &Path,
-    root: &str,
-    field: &str,
-    values: &[String],
-    errors: &mut Vec<PersonaValidationError>,
-) {
-    for value in values {
-        if value.trim().is_empty() {
-            persona_error(
-                manifest_path,
-                format!("{root}.{field}"),
-                format!("{field} entries must not be empty"),
-                errors,
-            );
-        } else {
-            validate_tokenish(manifest_path, root, field, value, errors);
-        }
-    }
-}
-
-pub(crate) fn validate_tokenish(
-    manifest_path: &Path,
-    root: &str,
-    field: &str,
-    value: &str,
-    errors: &mut Vec<PersonaValidationError>,
-) {
-    if !value
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '/'))
-    {
-        persona_error(
-            manifest_path,
-            format!("{root}.{field}"),
-            format!("'{value}' must contain only letters, numbers, '.', '-', '_', or '/'"),
-            errors,
-        );
-    }
-}
-
-pub(crate) fn validate_persona_budget(
-    manifest_path: &Path,
-    root: &str,
-    budget: &PersonaBudget,
-    errors: &mut Vec<PersonaValidationError>,
-) {
-    validate_persona_nested_extra(manifest_path, root, "budget", &budget.extra, errors);
-    for (field, value) in [
-        ("daily_usd", budget.daily_usd),
-        ("hourly_usd", budget.hourly_usd),
-        ("run_usd", budget.run_usd),
-    ] {
-        if value.is_some_and(|number| !number.is_finite() || number < 0.0) {
-            persona_error(
-                manifest_path,
-                format!("{root}.budget.{field}"),
-                "budget amounts must be finite non-negative numbers",
-                errors,
-            );
-        }
-    }
-}
-
-pub(crate) fn validate_persona_nested_extra(
-    manifest_path: &Path,
-    root: &str,
-    field: &str,
-    extra: &BTreeMap<String, toml::Value>,
-    errors: &mut Vec<PersonaValidationError>,
-) {
-    for key in extra.keys() {
-        persona_error(
-            manifest_path,
-            format!("{root}.{field}.{key}"),
-            format!("unknown {field} field"),
-            errors,
-        );
-    }
-}
-
-pub(crate) fn persona_error(
-    manifest_path: &Path,
-    field_path: String,
-    message: impl Into<String>,
-    errors: &mut Vec<PersonaValidationError>,
-) {
-    errors.push(PersonaValidationError {
-        manifest_path: manifest_path.to_path_buf(),
-        field_path,
-        message: message.into(),
-    });
 }
 
 pub(crate) fn known_persona_capabilities(
@@ -1080,71 +1033,7 @@ pub(crate) fn collect_persona_capabilities_from_json(
 }
 
 pub(crate) fn default_persona_capability_map() -> BTreeMap<&'static str, Vec<&'static str>> {
-    BTreeMap::from([
-        (
-            "workspace",
-            vec![
-                "read_text",
-                "write_text",
-                "apply_edit",
-                "delete",
-                "exists",
-                "file_exists",
-                "list",
-                "project_root",
-                "roots",
-            ],
-        ),
-        ("process", vec!["exec"]),
-        ("template", vec!["render"]),
-        ("interaction", vec!["ask"]),
-        (
-            "runtime",
-            vec![
-                "approved_plan",
-                "dry_run",
-                "pipeline_input",
-                "record_run",
-                "set_result",
-                "task",
-            ],
-        ),
-        (
-            "project",
-            vec![
-                "agent_instructions",
-                "code_patterns",
-                "compute_content_hash",
-                "ide_context",
-                "lessons",
-                "mcp_config",
-                "metadata_get",
-                "metadata_refresh_hashes",
-                "metadata_save",
-                "metadata_set",
-                "metadata_stale",
-                "scan",
-                "scope_test_command",
-                "test_commands",
-            ],
-        ),
-        (
-            "session",
-            vec![
-                "active_roots",
-                "changed_paths",
-                "preread_get",
-                "preread_read_many",
-            ],
-        ),
-        (
-            "editor",
-            vec!["get_active_file", "get_selection", "get_visible_files"],
-        ),
-        ("diagnostics", vec!["get_causal_traces", "get_errors"]),
-        ("git", vec!["get_branch", "get_diff"]),
-        ("learning", vec!["get_learned_rules", "report_correction"]),
-    ])
+    harn_modules::personas::default_persona_capability_map()
 }
 
 pub(crate) fn known_persona_tools(manifest: &Manifest) -> BTreeSet<String> {

--- a/crates/harn-cli/src/package/extensions_tests.rs
+++ b/crates/harn-cli/src/package/extensions_tests.rs
@@ -779,6 +779,73 @@ secrets = { signing_secret = "github/webhook-secret" }
     ));
 }
 
+#[test]
+fn persona_triggers_install_as_manifest_bindings() {
+    let tmp = tempfile::tempdir().unwrap();
+    let harn_file = write_trigger_project(
+        tmp.path(),
+        r#"
+[[personas]]
+name = "merge_captain"
+description = "Owns PR readiness."
+entry_workflow = "workflows/merge_captain.harn#run"
+tools = ["github"]
+autonomy = "suggest"
+receipts = "required"
+triggers = ["github.pr_opened"]
+budget = { daily_usd = 2.0 }
+"#,
+        None,
+    );
+    let extensions = load_runtime_extensions(&harn_file);
+    let bindings =
+        collect_persona_trigger_binding_specs(&extensions).expect("persona bindings collect");
+
+    assert_eq!(bindings.len(), 1);
+    assert_eq!(bindings[0].id, "persona.merge_captain.github.pr_opened");
+    assert_eq!(bindings[0].provider.as_str(), "github");
+    assert_eq!(bindings[0].kind, "pr_opened");
+    assert_eq!(bindings[0].handler.kind(), "persona");
+    assert_eq!(bindings[0].daily_cost_usd, Some(2.0));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn collect_manifest_triggers_accepts_persona_handler_uri() {
+    let tmp = tempfile::tempdir().unwrap();
+    let harn_file = write_trigger_project(
+        tmp.path(),
+        r#"
+[[personas]]
+name = "merge_captain"
+description = "Owns PR readiness."
+entry_workflow = "workflows/merge_captain.harn#run"
+tools = ["github"]
+autonomy = "suggest"
+receipts = "required"
+
+[[triggers]]
+id = "merge-captain-pr-opened"
+kind = "webhook"
+provider = "github"
+match = { events = ["pr_opened"] }
+handler = "persona://merge_captain"
+secrets = { signing_secret = "github/webhook-secret" }
+"#,
+        None,
+    );
+    let mut vm = test_vm();
+    let collected = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+        .await
+        .expect("trigger collection succeeds");
+
+    assert_eq!(collected.len(), 1);
+    assert!(matches!(
+        &collected[0].handler,
+        CollectedTriggerHandler::Persona { binding } if binding.name == "merge_captain"
+            && binding.entry_workflow == "workflows/merge_captain.harn#run"
+    ));
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn collect_manifest_triggers_accepts_harn_provider_override() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -1,4 +1,7 @@
 use super::*;
+pub use harn_modules::personas::{
+    PersonaAutonomyTier, PersonaManifestEntry, PersonaValidationError, ResolvedPersonaManifest,
+};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Manifest {
@@ -461,151 +464,6 @@ impl TriggerDlqAlertDestination {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct PersonaManifestEntry {
-    #[serde(default)]
-    pub name: Option<String>,
-    #[serde(default)]
-    pub version: Option<String>,
-    #[serde(default)]
-    pub description: Option<String>,
-    #[serde(default, alias = "entry", alias = "entry_pipeline")]
-    pub entry_workflow: Option<String>,
-    #[serde(default)]
-    pub tools: Vec<String>,
-    #[serde(default)]
-    pub capabilities: Vec<String>,
-    #[serde(default, alias = "tier")]
-    pub autonomy_tier: Option<harn_vm::AutonomyTier>,
-    #[serde(default, alias = "receipts")]
-    pub receipt_policy: Option<PersonaReceiptPolicy>,
-    #[serde(default)]
-    pub triggers: Vec<String>,
-    #[serde(default)]
-    pub schedules: Vec<String>,
-    #[serde(default)]
-    pub model_policy: PersonaModelPolicy,
-    #[serde(default)]
-    pub budget: PersonaBudget,
-    #[serde(default)]
-    pub handoffs: Vec<String>,
-    #[serde(default)]
-    pub context_packs: Vec<String>,
-    #[serde(default, alias = "eval_packs")]
-    pub evals: Vec<String>,
-    #[serde(default)]
-    pub owner: Option<String>,
-    #[serde(default)]
-    pub package_source: PersonaPackageSource,
-    #[serde(default)]
-    pub rollout_policy: PersonaRolloutPolicy,
-    #[serde(flatten, default)]
-    pub extra: BTreeMap<String, toml::Value>,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PersonaReceiptPolicy {
-    #[default]
-    Optional,
-    Required,
-    Disabled,
-}
-
-impl PersonaReceiptPolicy {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Optional => "optional",
-            Self::Required => "required",
-            Self::Disabled => "disabled",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct PersonaModelPolicy {
-    #[serde(default)]
-    pub default_model: Option<String>,
-    #[serde(default)]
-    pub escalation_model: Option<String>,
-    #[serde(default)]
-    pub fallback_models: Vec<String>,
-    #[serde(default)]
-    pub reasoning_effort: Option<String>,
-    #[serde(flatten, default)]
-    pub extra: BTreeMap<String, toml::Value>,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct PersonaBudget {
-    #[serde(default)]
-    pub daily_usd: Option<f64>,
-    #[serde(default)]
-    pub hourly_usd: Option<f64>,
-    #[serde(default)]
-    pub run_usd: Option<f64>,
-    #[serde(default)]
-    pub frontier_escalations: Option<u32>,
-    #[serde(default)]
-    pub max_tokens: Option<u64>,
-    #[serde(default)]
-    pub max_runtime_seconds: Option<u64>,
-    #[serde(flatten, default)]
-    pub extra: BTreeMap<String, toml::Value>,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct PersonaPackageSource {
-    #[serde(default)]
-    pub package: Option<String>,
-    #[serde(default)]
-    pub path: Option<String>,
-    #[serde(default)]
-    pub git: Option<String>,
-    #[serde(default)]
-    pub rev: Option<String>,
-    #[serde(flatten, default)]
-    pub extra: BTreeMap<String, toml::Value>,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct PersonaRolloutPolicy {
-    #[serde(default)]
-    pub mode: Option<String>,
-    #[serde(default)]
-    pub percentage: Option<u8>,
-    #[serde(default)]
-    pub cohorts: Vec<String>,
-    #[serde(flatten, default)]
-    pub extra: BTreeMap<String, toml::Value>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct ResolvedPersonaManifest {
-    pub manifest_path: PathBuf,
-    pub manifest_dir: PathBuf,
-    pub personas: Vec<PersonaManifestEntry>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct PersonaValidationError {
-    pub manifest_path: PathBuf,
-    pub field_path: String,
-    pub message: String,
-}
-
-impl std::fmt::Display for PersonaValidationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{} {}: {}",
-            self.manifest_path.display(),
-            self.field_path,
-            self.message
-        )
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TriggerHandlerUri {
     Local(TriggerFunctionRef),
@@ -615,6 +473,9 @@ pub enum TriggerHandlerUri {
     },
     Worker {
         queue: String,
+    },
+    Persona {
+        name: String,
     },
 }
 
@@ -912,6 +773,8 @@ pub(crate) fn toml_string_literal(value: &str) -> Result<String, String> {
 #[derive(Debug, Default, Clone)]
 pub struct RuntimeExtensions {
     pub root_manifest: Option<Manifest>,
+    pub root_manifest_path: Option<PathBuf>,
+    pub root_manifest_dir: Option<PathBuf>,
     pub llm: Option<harn_vm::llm_config::ProvidersConfig>,
     pub capabilities: Option<harn_vm::llm::capabilities::CapabilitiesFile>,
     pub hooks: Vec<ResolvedHookConfig>,
@@ -1081,6 +944,9 @@ pub enum CollectedTriggerHandler {
     },
     Worker {
         queue: String,
+    },
+    Persona {
+        binding: harn_vm::PersonaRuntimeBinding,
     },
 }
 

--- a/crates/harn-cli/src/package/validation.rs
+++ b/crates/harn-cli/src/package/validation.rs
@@ -383,6 +383,17 @@ pub(crate) fn parse_trigger_handler_uri(
             queue: queue.to_string(),
         });
     }
+    if let Some(name) = raw.strip_prefix("persona://") {
+        if name.is_empty() {
+            return Err(trigger_error(
+                trigger,
+                "handler persona:// name cannot be empty",
+            ));
+        }
+        return Ok(TriggerHandlerUri::Persona {
+            name: name.to_string(),
+        });
+    }
     if raw.contains("://") {
         return Err(trigger_error(
             trigger,

--- a/crates/harn-modules/Cargo.toml
+++ b/crates/harn-modules/Cargo.toml
@@ -12,6 +12,7 @@ include = [
 ]
 
 [dependencies]
+croner = "3.0.1"
 harn-lexer = { path = "../harn-lexer", version = "0.7" }
 harn-parser = { path = "../harn-parser", version = "0.7" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/harn-modules/src/lib.rs
+++ b/crates/harn-modules/src/lib.rs
@@ -6,6 +6,7 @@ use harn_parser::{BindingPattern, Node, Parser, SNode};
 use serde::Deserialize;
 
 pub mod asset_paths;
+pub mod personas;
 mod stdlib;
 
 /// Kind of symbol that can be exported by a module.

--- a/crates/harn-modules/src/personas.rs
+++ b/crates/harn-modules/src/personas.rs
@@ -1,0 +1,701 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaManifestDocument {
+    #[serde(default)]
+    pub personas: Vec<PersonaManifestEntry>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaManifestEntry {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default, alias = "entry", alias = "entry_pipeline")]
+    pub entry_workflow: Option<String>,
+    #[serde(default)]
+    pub tools: Vec<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(default, alias = "tier", alias = "autonomy")]
+    pub autonomy_tier: Option<PersonaAutonomyTier>,
+    #[serde(default, alias = "receipts")]
+    pub receipt_policy: Option<PersonaReceiptPolicy>,
+    #[serde(default)]
+    pub triggers: Vec<String>,
+    #[serde(default)]
+    pub schedules: Vec<String>,
+    #[serde(default)]
+    pub model_policy: PersonaModelPolicy,
+    #[serde(default)]
+    pub budget: PersonaBudget,
+    #[serde(default)]
+    pub handoffs: Vec<String>,
+    #[serde(default)]
+    pub context_packs: Vec<String>,
+    #[serde(default, alias = "eval_packs")]
+    pub evals: Vec<String>,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub package_source: PersonaPackageSource,
+    #[serde(default)]
+    pub rollout_policy: PersonaRolloutPolicy,
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PersonaAutonomyTier {
+    Shadow,
+    Suggest,
+    ActWithApproval,
+    ActAuto,
+}
+
+impl PersonaAutonomyTier {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Shadow => "shadow",
+            Self::Suggest => "suggest",
+            Self::ActWithApproval => "act_with_approval",
+            Self::ActAuto => "act_auto",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PersonaReceiptPolicy {
+    #[default]
+    Optional,
+    Required,
+    Disabled,
+}
+
+impl PersonaReceiptPolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Optional => "optional",
+            Self::Required => "required",
+            Self::Disabled => "disabled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaModelPolicy {
+    #[serde(default)]
+    pub default_model: Option<String>,
+    #[serde(default)]
+    pub escalation_model: Option<String>,
+    #[serde(default)]
+    pub fallback_models: Vec<String>,
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaBudget {
+    #[serde(default)]
+    pub daily_usd: Option<f64>,
+    #[serde(default)]
+    pub hourly_usd: Option<f64>,
+    #[serde(default)]
+    pub run_usd: Option<f64>,
+    #[serde(default)]
+    pub frontier_escalations: Option<u32>,
+    #[serde(default)]
+    pub max_tokens: Option<u64>,
+    #[serde(default)]
+    pub max_runtime_seconds: Option<u64>,
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaPackageSource {
+    #[serde(default)]
+    pub package: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub git: Option<String>,
+    #[serde(default)]
+    pub rev: Option<String>,
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaRolloutPolicy {
+    #[serde(default)]
+    pub mode: Option<String>,
+    #[serde(default)]
+    pub percentage: Option<u8>,
+    #[serde(default)]
+    pub cohorts: Vec<String>,
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ResolvedPersonaManifest {
+    pub manifest_path: PathBuf,
+    pub manifest_dir: PathBuf,
+    pub personas: Vec<PersonaManifestEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PersonaValidationError {
+    pub manifest_path: PathBuf,
+    pub field_path: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for PersonaValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {}: {}",
+            self.manifest_path.display(),
+            self.field_path,
+            self.message
+        )
+    }
+}
+
+impl std::error::Error for PersonaValidationError {}
+
+#[derive(Debug, Clone, Default)]
+pub struct PersonaValidationContext {
+    pub known_capabilities: BTreeSet<String>,
+    pub known_tools: BTreeSet<String>,
+    pub known_names: BTreeSet<String>,
+}
+
+pub fn parse_persona_manifest_str(
+    source: &str,
+) -> Result<PersonaManifestDocument, toml::de::Error> {
+    let document = toml::from_str::<PersonaManifestDocument>(source)?;
+    if !document.personas.is_empty() {
+        return Ok(document);
+    }
+    let entry = toml::from_str::<PersonaManifestEntry>(source)?;
+    if entry.name.is_some()
+        || entry.description.is_some()
+        || entry.entry_workflow.is_some()
+        || !entry.tools.is_empty()
+        || !entry.capabilities.is_empty()
+    {
+        Ok(PersonaManifestDocument {
+            personas: vec![entry],
+        })
+    } else {
+        Ok(document)
+    }
+}
+
+pub fn parse_persona_manifest_file(path: &Path) -> Result<PersonaManifestDocument, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    parse_persona_manifest_str(&content)
+        .map_err(|error| format!("failed to parse {}: {error}", path.display()))
+}
+
+pub fn validate_persona_manifests(
+    manifest_path: &Path,
+    personas: &[PersonaManifestEntry],
+    context: &PersonaValidationContext,
+) -> Result<(), Vec<PersonaValidationError>> {
+    let mut errors = Vec::new();
+    for (index, persona) in personas.iter().enumerate() {
+        validate_persona(persona, index, manifest_path, context, &mut errors);
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+pub fn validate_persona(
+    persona: &PersonaManifestEntry,
+    index: usize,
+    manifest_path: &Path,
+    context: &PersonaValidationContext,
+    errors: &mut Vec<PersonaValidationError>,
+) {
+    let root = format!("[[personas]][{index}]");
+    for field in persona.extra.keys() {
+        persona_error(
+            manifest_path,
+            format!("{root}.{field}"),
+            "unknown persona field",
+            errors,
+        );
+    }
+    let name = validate_required_string(
+        manifest_path,
+        &root,
+        "name",
+        persona.name.as_deref(),
+        errors,
+    );
+    if let Some(name) = name {
+        validate_tokenish(manifest_path, &root, "name", name, errors);
+    }
+    validate_required_string(
+        manifest_path,
+        &root,
+        "description",
+        persona.description.as_deref(),
+        errors,
+    );
+    validate_required_string(
+        manifest_path,
+        &root,
+        "entry_workflow",
+        persona.entry_workflow.as_deref(),
+        errors,
+    );
+    if persona.tools.is_empty() && persona.capabilities.is_empty() {
+        persona_error(
+            manifest_path,
+            format!("{root}.tools"),
+            "persona requires at least one tool or capability",
+            errors,
+        );
+    }
+    if persona.autonomy_tier.is_none() {
+        persona_error(
+            manifest_path,
+            format!("{root}.autonomy_tier"),
+            "missing required autonomy tier",
+            errors,
+        );
+    }
+    if persona.receipt_policy.is_none() {
+        persona_error(
+            manifest_path,
+            format!("{root}.receipt_policy"),
+            "missing required receipt policy",
+            errors,
+        );
+    }
+    validate_string_list(manifest_path, &root, "tools", &persona.tools, errors);
+    for tool in &persona.tools {
+        if !context.known_tools.is_empty() && !context.known_tools.contains(tool) {
+            persona_error(
+                manifest_path,
+                format!("{root}.tools"),
+                format!("unknown tool '{tool}'"),
+                errors,
+            );
+        }
+    }
+    for capability in &persona.capabilities {
+        let Some((cap, op)) = capability.split_once('.') else {
+            persona_error(
+                manifest_path,
+                format!("{root}.capabilities"),
+                format!("capability '{capability}' must use capability.operation syntax"),
+                errors,
+            );
+            continue;
+        };
+        if cap.trim().is_empty() || op.trim().is_empty() {
+            persona_error(
+                manifest_path,
+                format!("{root}.capabilities"),
+                format!("capability '{capability}' must use capability.operation syntax"),
+                errors,
+            );
+        } else if !context.known_capabilities.is_empty()
+            && !context.known_capabilities.contains(capability)
+        {
+            persona_error(
+                manifest_path,
+                format!("{root}.capabilities"),
+                format!("unknown capability '{capability}'"),
+                errors,
+            );
+        }
+    }
+    validate_string_list(
+        manifest_path,
+        &root,
+        "context_packs",
+        &persona.context_packs,
+        errors,
+    );
+    validate_string_list(manifest_path, &root, "evals", &persona.evals, errors);
+    for schedule in &persona.schedules {
+        if schedule.trim().is_empty() {
+            persona_error(
+                manifest_path,
+                format!("{root}.schedules"),
+                "schedule entries must not be empty",
+                errors,
+            );
+        } else if let Err(error) = croner::Cron::from_str(schedule) {
+            persona_error(
+                manifest_path,
+                format!("{root}.schedules"),
+                format!("invalid cron schedule '{schedule}': {error}"),
+                errors,
+            );
+        }
+    }
+    for trigger in &persona.triggers {
+        match trigger.split_once('.') {
+            Some((provider, event)) if !provider.trim().is_empty() && !event.trim().is_empty() => {}
+            _ => persona_error(
+                manifest_path,
+                format!("{root}.triggers"),
+                format!("trigger '{trigger}' must use provider.event syntax"),
+                errors,
+            ),
+        }
+    }
+    for handoff in &persona.handoffs {
+        if !context.known_names.contains(handoff) {
+            persona_error(
+                manifest_path,
+                format!("{root}.handoffs"),
+                format!("unknown handoff target '{handoff}'"),
+                errors,
+            );
+        }
+    }
+    validate_persona_budget(manifest_path, &root, &persona.budget, errors);
+    validate_persona_nested_extra(
+        manifest_path,
+        &root,
+        "model_policy",
+        &persona.model_policy.extra,
+        errors,
+    );
+    validate_persona_nested_extra(
+        manifest_path,
+        &root,
+        "package_source",
+        &persona.package_source.extra,
+        errors,
+    );
+    validate_persona_nested_extra(
+        manifest_path,
+        &root,
+        "rollout_policy",
+        &persona.rollout_policy.extra,
+        errors,
+    );
+    if let Some(percentage) = persona.rollout_policy.percentage {
+        if percentage > 100 {
+            persona_error(
+                manifest_path,
+                format!("{root}.rollout_policy.percentage"),
+                "rollout percentage must be between 0 and 100",
+                errors,
+            );
+        }
+    }
+}
+
+pub fn validate_required_string<'a>(
+    manifest_path: &Path,
+    root: &str,
+    field: &str,
+    value: Option<&'a str>,
+    errors: &mut Vec<PersonaValidationError>,
+) -> Option<&'a str> {
+    match value.map(str::trim) {
+        Some(value) if !value.is_empty() => Some(value),
+        _ => {
+            persona_error(
+                manifest_path,
+                format!("{root}.{field}"),
+                format!("missing required {field}"),
+                errors,
+            );
+            None
+        }
+    }
+}
+
+pub fn validate_string_list(
+    manifest_path: &Path,
+    root: &str,
+    field: &str,
+    values: &[String],
+    errors: &mut Vec<PersonaValidationError>,
+) {
+    for value in values {
+        if value.trim().is_empty() {
+            persona_error(
+                manifest_path,
+                format!("{root}.{field}"),
+                format!("{field} entries must not be empty"),
+                errors,
+            );
+        } else {
+            validate_tokenish(manifest_path, root, field, value, errors);
+        }
+    }
+}
+
+pub fn validate_tokenish(
+    manifest_path: &Path,
+    root: &str,
+    field: &str,
+    value: &str,
+    errors: &mut Vec<PersonaValidationError>,
+) {
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '/'))
+    {
+        persona_error(
+            manifest_path,
+            format!("{root}.{field}"),
+            format!("'{value}' must contain only letters, numbers, '.', '-', '_', or '/'"),
+            errors,
+        );
+    }
+}
+
+pub fn validate_persona_budget(
+    manifest_path: &Path,
+    root: &str,
+    budget: &PersonaBudget,
+    errors: &mut Vec<PersonaValidationError>,
+) {
+    validate_persona_nested_extra(manifest_path, root, "budget", &budget.extra, errors);
+    for (field, value) in [
+        ("daily_usd", budget.daily_usd),
+        ("hourly_usd", budget.hourly_usd),
+        ("run_usd", budget.run_usd),
+    ] {
+        if value.is_some_and(|number| !number.is_finite() || number < 0.0) {
+            persona_error(
+                manifest_path,
+                format!("{root}.budget.{field}"),
+                "budget amounts must be finite non-negative numbers",
+                errors,
+            );
+        }
+    }
+}
+
+pub fn validate_persona_nested_extra(
+    manifest_path: &Path,
+    root: &str,
+    field: &str,
+    extra: &BTreeMap<String, toml::Value>,
+    errors: &mut Vec<PersonaValidationError>,
+) {
+    for key in extra.keys() {
+        persona_error(
+            manifest_path,
+            format!("{root}.{field}.{key}"),
+            format!("unknown {field} field"),
+            errors,
+        );
+    }
+}
+
+pub fn persona_error(
+    manifest_path: &Path,
+    field_path: String,
+    message: impl Into<String>,
+    errors: &mut Vec<PersonaValidationError>,
+) {
+    errors.push(PersonaValidationError {
+        manifest_path: manifest_path.to_path_buf(),
+        field_path,
+        message: message.into(),
+    });
+}
+
+pub fn default_persona_capability_map() -> BTreeMap<&'static str, Vec<&'static str>> {
+    BTreeMap::from([
+        (
+            "workspace",
+            vec![
+                "read_text",
+                "write_text",
+                "apply_edit",
+                "delete",
+                "exists",
+                "file_exists",
+                "list",
+                "project_root",
+                "roots",
+            ],
+        ),
+        ("process", vec!["exec"]),
+        ("template", vec!["render"]),
+        ("interaction", vec!["ask"]),
+        (
+            "runtime",
+            vec![
+                "approved_plan",
+                "dry_run",
+                "pipeline_input",
+                "record_run",
+                "set_result",
+                "task",
+            ],
+        ),
+        (
+            "project",
+            vec![
+                "agent_instructions",
+                "code_patterns",
+                "compute_content_hash",
+                "ide_context",
+                "lessons",
+                "mcp_config",
+                "metadata_get",
+                "metadata_refresh_hashes",
+                "metadata_save",
+                "metadata_set",
+                "metadata_stale",
+                "scan",
+                "scope_test_command",
+                "test_commands",
+            ],
+        ),
+        (
+            "session",
+            vec![
+                "active_roots",
+                "changed_paths",
+                "preread_get",
+                "preread_read_many",
+            ],
+        ),
+        (
+            "editor",
+            vec!["get_active_file", "get_selection", "get_visible_files"],
+        ),
+        ("diagnostics", vec!["get_causal_traces", "get_errors"]),
+        ("git", vec!["get_branch", "get_diff"]),
+        ("learning", vec!["get_learned_rules", "report_correction"]),
+    ])
+}
+
+pub fn default_persona_capabilities() -> BTreeSet<String> {
+    let mut capabilities = BTreeSet::new();
+    for (capability, operations) in default_persona_capability_map() {
+        for operation in operations {
+            capabilities.insert(format!("{capability}.{operation}"));
+        }
+    }
+    capabilities
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context(names: &[&str]) -> PersonaValidationContext {
+        PersonaValidationContext {
+            known_capabilities: default_persona_capabilities(),
+            known_tools: BTreeSet::from(["github".to_string(), "ci".to_string()]),
+            known_names: names.iter().map(|name| name.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn validates_sample_manifest() {
+        let parsed = parse_persona_manifest_str(
+            r#"
+[[personas]]
+name = "merge_captain"
+description = "Owns PR readiness."
+entry_workflow = "workflows/merge_captain.harn#run"
+tools = ["github", "ci"]
+capabilities = ["git.get_diff"]
+autonomy = "act_with_approval"
+receipts = "required"
+triggers = ["github.pr_opened"]
+schedules = ["*/30 * * * *"]
+handoffs = ["review_captain"]
+context_packs = ["repo_policy"]
+evals = ["merge_safety"]
+budget = { daily_usd = 20.0 }
+
+[[personas]]
+name = "review_captain"
+description = "Reviews code."
+entry_workflow = "workflows/review_captain.harn#run"
+tools = ["github"]
+autonomy_tier = "suggest"
+receipt_policy = "optional"
+"#,
+        )
+        .expect("manifest parses");
+
+        validate_persona_manifests(
+            Path::new("harn.toml"),
+            &parsed.personas,
+            &context(&["merge_captain", "review_captain"]),
+        )
+        .expect("manifest validates");
+    }
+
+    #[test]
+    fn bad_manifest_produces_typed_errors() {
+        let parsed = parse_persona_manifest_str(
+            r#"
+[[personas]]
+name = "bad"
+description = ""
+entry_workflow = ""
+tools = ["unknown"]
+capabilities = ["git"]
+autonomy = "shadow"
+receipts = "required"
+triggers = ["github"]
+schedules = [""]
+handoffs = ["missing"]
+budget = { daily_usd = -1.0, surprise = true }
+surprise = true
+"#,
+        )
+        .expect("manifest parses");
+
+        let errors = validate_persona_manifests(
+            Path::new("harn.toml"),
+            &parsed.personas,
+            &context(&["bad"]),
+        )
+        .expect_err("manifest rejects");
+        let fields: BTreeSet<_> = errors
+            .iter()
+            .map(|error| error.field_path.as_str())
+            .collect();
+        assert!(fields.contains("[[personas]][0].description"));
+        assert!(fields.contains("[[personas]][0].entry_workflow"));
+        assert!(fields.contains("[[personas]][0].tools"));
+        assert!(fields.contains("[[personas]][0].capabilities"));
+        assert!(fields.contains("[[personas]][0].triggers"));
+        assert!(fields.contains("[[personas]][0].schedules"));
+        assert!(fields.contains("[[personas]][0].handoffs"));
+        assert!(fields.contains("[[personas]][0].budget.daily_usd"));
+        assert!(fields.contains("[[personas]][0].budget.surprise"));
+        assert!(fields.contains("[[personas]][0].surprise"));
+    }
+}

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -2434,6 +2434,30 @@ impl Dispatcher {
                 Ok(serde_json::to_value(receipt)
                     .map_err(|error| DispatchError::Serde(error.to_string()))?)
             }
+            DispatchUri::Persona { .. } => {
+                let TriggerHandlerSpec::Persona {
+                    binding: persona_binding,
+                } = &binding.handler
+                else {
+                    return Err(DispatchError::Local(format!(
+                        "trigger '{}' resolved to a persona dispatch URI but does not carry a persona binding",
+                        binding.id.as_str()
+                    )));
+                };
+                let receipt = crate::fire_persona_trigger(
+                    &self.event_log,
+                    persona_binding,
+                    event.provider.as_str(),
+                    &event.kind,
+                    trigger_event_persona_metadata(event),
+                    crate::PersonaRunCost::default(),
+                    crate::persona_now_ms(),
+                )
+                .await
+                .map_err(DispatchError::Local)?;
+                Ok(serde_json::to_value(receipt)
+                    .map_err(|error| DispatchError::Serde(error.to_string()))?)
+            }
         }
     }
 
@@ -3465,6 +3489,7 @@ fn dispatch_error_label(error: &DispatchError) -> &'static str {
 fn dispatch_success_outcome(route: &DispatchUri, result: &serde_json::Value) -> &'static str {
     match route {
         DispatchUri::Worker { .. } => "enqueued",
+        DispatchUri::Persona { .. } => "recorded",
         DispatchUri::A2a { .. }
             if result.get("kind").and_then(|value| value.as_str()) == Some("a2a_task_handle") =>
         {
@@ -3544,6 +3569,59 @@ fn trigger_node_metadata(event: &TriggerEvent) -> BTreeMap<String, serde_json::V
     metadata
 }
 
+fn trigger_event_persona_metadata(event: &TriggerEvent) -> BTreeMap<String, String> {
+    let mut metadata = BTreeMap::new();
+    metadata.insert("trigger_event_id".to_string(), event.id.0.clone());
+    metadata.insert("event_id".to_string(), event.id.0.clone());
+    metadata.insert("dedupe_key".to_string(), event.dedupe_key.clone());
+    metadata.insert("trace_id".to_string(), event.trace_id.0.clone());
+    if let Some(tenant_id) = &event.tenant_id {
+        metadata.insert("tenant_id".to_string(), tenant_id.0.clone());
+    }
+    for (key, value) in &event.headers {
+        metadata.insert(format!("header.{key}"), value.clone());
+    }
+    if let Ok(payload) = serde_json::to_value(&event.provider_payload) {
+        collect_persona_payload_metadata("", &payload, &mut metadata);
+        if let Some(raw) = payload.get("raw") {
+            collect_persona_payload_metadata("", raw, &mut metadata);
+        }
+    }
+    metadata
+}
+
+fn collect_persona_payload_metadata(
+    prefix: &str,
+    value: &serde_json::Value,
+    metadata: &mut BTreeMap<String, String>,
+) {
+    let serde_json::Value::Object(object) = value else {
+        return;
+    };
+    for (key, value) in object {
+        let path = if prefix.is_empty() {
+            key.clone()
+        } else {
+            format!("{prefix}.{key}")
+        };
+        match value {
+            serde_json::Value::String(text) => {
+                metadata.insert(path, text.clone());
+            }
+            serde_json::Value::Number(number) => {
+                metadata.insert(path, number.to_string());
+            }
+            serde_json::Value::Bool(flag) => {
+                metadata.insert(path, flag.to_string());
+            }
+            serde_json::Value::Object(_) if prefix.is_empty() => {
+                collect_persona_payload_metadata(&path, value, metadata);
+            }
+            _ => {}
+        }
+    }
+}
+
 fn dispatch_node_metadata(
     route: &DispatchUri,
     binding: &TriggerBinding,
@@ -3567,6 +3645,9 @@ fn dispatch_node_metadata(
     }
     if let DispatchUri::Worker { queue } = route {
         metadata.insert("queue_name".to_string(), serde_json::json!(queue));
+    }
+    if let DispatchUri::Persona { name } = route {
+        metadata.insert("persona".to_string(), serde_json::json!(name));
     }
     metadata
 }
@@ -3605,6 +3686,14 @@ fn dispatch_success_metadata(
                     "response_topic".to_string(),
                     serde_json::json!(response_topic),
                 );
+            }
+        }
+        DispatchUri::Persona { .. } => {
+            if let Some(receipt_id) = result.get("receipt_id").and_then(|value| value.as_str()) {
+                metadata.insert("receipt_id".to_string(), serde_json::json!(receipt_id));
+            }
+            if let Some(status) = result.get("status").and_then(|value| value.as_str()) {
+                metadata.insert("status".to_string(), serde_json::json!(status));
             }
         }
         DispatchUri::Local { .. } => {}

--- a/crates/harn-vm/src/triggers/dispatcher/uri.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/uri.rs
@@ -33,6 +33,9 @@ pub enum DispatchUri {
     Worker {
         queue: String,
     },
+    Persona {
+        name: String,
+    },
 }
 
 impl DispatchUri {
@@ -62,6 +65,16 @@ impl DispatchUri {
                 queue: queue.to_string(),
             });
         }
+        if let Some(name) = raw.strip_prefix("persona://") {
+            if name.is_empty() {
+                return Err(DispatchUriError::MissingTarget {
+                    scheme: "persona".to_string(),
+                });
+            }
+            return Ok(Self::Persona {
+                name: name.to_string(),
+            });
+        }
         if let Some((scheme, _)) = raw.split_once("://") {
             return Err(DispatchUriError::UnknownScheme(scheme.to_string()));
         }
@@ -75,6 +88,7 @@ impl DispatchUri {
             Self::Local { .. } => "local",
             Self::A2a { .. } => "a2a",
             Self::Worker { .. } => "worker",
+            Self::Persona { .. } => "persona",
         }
     }
 
@@ -83,6 +97,7 @@ impl DispatchUri {
             Self::Local { raw } => raw.clone(),
             Self::A2a { target, .. } => format!("a2a://{target}"),
             Self::Worker { queue } => format!("worker://{queue}"),
+            Self::Persona { name } => format!("persona://{name}"),
         }
     }
 }
@@ -100,6 +115,9 @@ impl From<&TriggerHandlerSpec> for DispatchUri {
             },
             TriggerHandlerSpec::Worker { queue } => Self::Worker {
                 queue: queue.clone(),
+            },
+            TriggerHandlerSpec::Persona { binding } => Self::Persona {
+                name: binding.name.clone(),
             },
         }
     }

--- a/crates/harn-vm/src/triggers/registry.rs
+++ b/crates/harn-vm/src/triggers/registry.rs
@@ -146,6 +146,9 @@ pub enum TriggerHandlerSpec {
     Worker {
         queue: String,
     },
+    Persona {
+        binding: crate::PersonaRuntimeBinding,
+    },
 }
 
 impl std::fmt::Debug for TriggerHandlerSpec {
@@ -161,6 +164,10 @@ impl std::fmt::Debug for TriggerHandlerSpec {
                 .field("allow_cleartext", allow_cleartext)
                 .finish(),
             Self::Worker { queue } => f.debug_struct("Worker").field("queue", queue).finish(),
+            Self::Persona { binding } => f
+                .debug_struct("Persona")
+                .field("name", &binding.name)
+                .finish(),
         }
     }
 }
@@ -171,6 +178,7 @@ impl TriggerHandlerSpec {
             Self::Local { .. } => "local",
             Self::A2a { .. } => "a2a",
             Self::Worker { .. } => "worker",
+            Self::Persona { .. } => "persona",
         }
     }
 }

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -4195,11 +4195,13 @@ directory when none is supplied).
 ### `[[personas]]` — durable agent role manifests
 
 `[[personas]]` entries define durable agent roles in the package/workspace
-manifest. Tooling parses, validates, lists, and inspects the contract. The
-continuous runtime records lifecycle controls, schedule and trigger wake
-receipts, single-writer leases, budget receipts, and status snapshots in the
-`persona.runtime.events` EventLog topic; long-lived hosted wake loops and typed
-handoff dispatch remain host/orchestrator work.
+manifest. The canonical typed schema and validator live in `harn-modules` so
+CLI, host, cloud, and editor consumers share the same contract. Tooling parses,
+validates, lists, and inspects the contract. The continuous runtime records
+lifecycle controls, schedule and trigger wake receipts, single-writer leases,
+budget receipts, and status snapshots in the `persona.runtime.events` EventLog
+topic; long-lived hosted wake loops and typed handoff dispatch remain
+host/orchestrator work.
 
 Required fields are `name`, `description`, `entry_workflow`, either `tools` or
 `capabilities`, `autonomy_tier`, and `receipt_policy`. Optional fields include
@@ -4229,6 +4231,10 @@ Validation rejects missing required fields, malformed or unknown
 unknown budget/model/source/rollout fields, negative budget amounts, and invalid
 rollout percentages. `harn persona list` and `harn persona inspect <name>
 --json` expose the resolved schema for hosts such as IDEs and cloud runners.
+`harn persona check <path>` validates a package or standalone persona manifest
+through the same canonical validator. Persona `triggers` install manifest
+trigger bindings whose handler kind is `persona`; explicit `[[triggers]]`
+entries may also use `handler = "persona://<name>"`.
 `harn persona status <name> --json` exposes stable runtime state including
 lifecycle state, active lease, last run, next scheduled run, budget status, and
 last error. `pause` queues later events, `resume` drains queued events under

--- a/docs/src/personas.md
+++ b/docs/src/personas.md
@@ -11,8 +11,12 @@ not just natural-language behavior.
 
 ## Manifest Shape
 
-Persona v1 lives in `harn.toml` as `[[personas]]` entries. This keeps personas
-compatible with package manifests and the existing manifest discovery model.
+Persona v1 is a typed manifest schema owned by `harn-modules`, so hosts such as
+`harn-cli`, Harn Cloud, and Burin Code can parse and validate the same contract.
+The usual form lives in `harn.toml` as `[[personas]]` entries, which keeps
+personas compatible with package manifests and the existing manifest discovery
+model. Standalone persona TOML files can use the same fields at the top level.
+
 The continuous runtime is intentionally small and event-sourced: it records
 schedule and trigger wakes, leases, lifecycle controls, budget receipts, and
 status snapshots without inventing a hidden hosted scheduler.
@@ -38,6 +42,10 @@ model_policy = { default_model = "gpt-5.4-mini", escalation_model = "gpt-5.4" }
 rollout_policy = { mode = "approval_only", percentage = 25 }
 package_source = { package = "ops-personas", path = "personas/merge" }
 ```
+
+`autonomy` is accepted as an alias for `autonomy_tier`, and `receipts` is
+accepted as an alias for `receipt_policy` for hosts that present the shorter
+service-contract vocabulary.
 
 Required fields:
 
@@ -68,8 +76,8 @@ Optional fields:
 
 ## Validation
 
-`harn persona list` and `harn persona inspect` validate the resolved manifest
-before printing output. Validation currently checks:
+`harn persona check`, `harn persona list`, and `harn persona inspect` validate
+the resolved manifest before printing output. Validation currently checks:
 
 - missing required fields, including `entry_workflow`
 - malformed or unknown `capability.operation` entries
@@ -88,6 +96,8 @@ extra operations declared in `[check.host_capabilities]` or
 ```bash
 harn persona list
 harn persona list --json
+harn persona check personas/ship_captain/harn.toml
+harn persona check personas/ship_captain/harn.toml --json
 harn persona inspect merge_captain
 harn persona inspect merge_captain --json
 harn persona --manifest examples/personas/harn.toml inspect merge_captain --json
@@ -110,6 +120,25 @@ The JSON output is stable enough for hosts such as IDEs and cloud runners to
 consume. It includes name, version, tools, capabilities, autonomy tier, model
 policy, budget, triggers, handoffs, context packs, evals, receipt policy, and
 manifest source.
+
+## Trigger Handlers
+
+Persona trigger names are first-class trigger registrations. A persona with
+`triggers = ["github.pr_opened"]` installs a manifest trigger binding for
+provider `github`, event kind `pr_opened`, and handler kind `persona`. Dispatch
+records a `persona.trigger.received` event plus the normal persona run receipt
+in `persona.runtime.events`.
+
+Explicit trigger manifests can also target a persona:
+
+```toml
+[[triggers]]
+id = "merge-captain-pr-opened"
+kind = "webhook"
+provider = "github"
+match = { events = ["pr_opened"] }
+handler = "persona://merge_captain"
+```
 
 ## Continuous runtime
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -4193,11 +4193,13 @@ directory when none is supplied).
 ### `[[personas]]` — durable agent role manifests
 
 `[[personas]]` entries define durable agent roles in the package/workspace
-manifest. Tooling parses, validates, lists, and inspects the contract. The
-continuous runtime records lifecycle controls, schedule and trigger wake
-receipts, single-writer leases, budget receipts, and status snapshots in the
-`persona.runtime.events` EventLog topic; long-lived hosted wake loops and typed
-handoff dispatch remain host/orchestrator work.
+manifest. The canonical typed schema and validator live in `harn-modules` so
+CLI, host, cloud, and editor consumers share the same contract. Tooling parses,
+validates, lists, and inspects the contract. The continuous runtime records
+lifecycle controls, schedule and trigger wake receipts, single-writer leases,
+budget receipts, and status snapshots in the `persona.runtime.events` EventLog
+topic; long-lived hosted wake loops and typed handoff dispatch remain
+host/orchestrator work.
 
 Required fields are `name`, `description`, `entry_workflow`, either `tools` or
 `capabilities`, `autonomy_tier`, and `receipt_policy`. Optional fields include
@@ -4227,6 +4229,10 @@ Validation rejects missing required fields, malformed or unknown
 unknown budget/model/source/rollout fields, negative budget amounts, and invalid
 rollout percentages. `harn persona list` and `harn persona inspect <name>
 --json` expose the resolved schema for hosts such as IDEs and cloud runners.
+`harn persona check <path>` validates a package or standalone persona manifest
+through the same canonical validator. Persona `triggers` install manifest
+trigger bindings whose handler kind is `persona`; explicit `[[triggers]]`
+entries may also use `handler = "persona://<name>"`.
 `harn persona status <name> --json` exposes stable runtime state including
 lifecycle state, active lease, last run, next scheduled run, budget status, and
 last error. `pause` queues later events, `resume` drains queued events under


### PR DESCRIPTION
## Summary
- move persona manifest schema and typed validation into harn-modules, including standalone persona TOML parsing
- add `harn persona check` with JSON success/error output and route existing persona loading through the canonical validator
- register persona triggers as manifest trigger bindings and support explicit `persona://<name>` handlers
- document the shared schema and trigger handler behavior

Closes #912.

## Verification
- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/harn-target-ae3a-912 cargo check -p harn-cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-ae3a-912 cargo test -p harn-modules personas`
- `CARGO_TARGET_DIR=/tmp/harn-target-ae3a-912 cargo test -p harn-cli persona`
- `CARGO_TARGET_DIR=/tmp/harn-target-ae3a-912 cargo run --quiet --bin harn -- persona check examples/personas/harn.toml --json`
- standalone valid and invalid `harn persona check --json` smoke tests against temp manifests
- pre-commit hook: clippy, markdown, generated docs/highlight checks
- pre-push hook: 2980 nextest tests, markdown, generated checks
