### PR TITLE
Add lint hygiene rules

### DIFF
--- a/crates/harn-lint/src/fixes.rs
+++ b/crates/harn-lint/src/fixes.rs
@@ -78,6 +78,22 @@ pub(crate) fn unnecessary_cast_fix(
     }])
 }
 
+/// Replace an outer method call expression with its receiver text. Used for
+/// syntactic wrappers like `value.clone()` where removing the method call is
+/// the whole fix.
+pub(crate) fn remove_method_call_wrapper_fix(
+    source: Option<&str>,
+    call_span: Span,
+    receiver_span: Span,
+) -> Option<Vec<FixEdit>> {
+    let src = source?;
+    let receiver_text = src.get(receiver_span.start..receiver_span.end)?;
+    Some(vec![FixEdit {
+        span: call_span,
+        replacement: receiver_text.to_string(),
+    }])
+}
+
 /// Append a sink call (`.to_list()` / `.to_set()` / `.to_dict()`) to the
 /// end of an expression span.
 pub(crate) fn append_sink_fix(expr_span: Span, sink: &str) -> Vec<FixEdit> {

--- a/crates/harn-lint/src/lib.rs
+++ b/crates/harn-lint/src/lib.rs
@@ -152,9 +152,17 @@ fn lint_full(
         linter
             .diagnostics
             .into_iter()
-            .filter(|d| !disabled_rules.iter().any(|r| r == d.rule))
+            .filter(|d| {
+                !disabled_rules
+                    .iter()
+                    .any(|r| rule_matches_disabled(d.rule, r))
+            })
             .collect()
     }
+}
+
+fn rule_matches_disabled(rule: &str, disabled: &str) -> bool {
+    rule == disabled || (rule == "dead-code-after-return" && disabled == "unreachable-code")
 }
 
 /// Extract all function names that appear in selective import statements

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -12,7 +12,7 @@ use harn_parser::{BindingPattern, Node, SNode, TypeExpr, TypedParam};
 use crate::complexity::cyclomatic_complexity;
 use crate::decls::{Declaration, FnDeclaration, ImportInfo, ParamDeclaration, TypeDeclaration};
 use crate::diagnostic::{LintDiagnostic, LintSeverity, DEFAULT_COMPLEXITY_THRESHOLD};
-use crate::fixes::{append_sink_fix, simple_ident_rename_fix};
+use crate::fixes::{append_sink_fix, remove_method_call_wrapper_fix, simple_ident_rename_fix};
 use crate::harndoc::check_legacy_doc_comments;
 use crate::naming::{is_pascal_case, is_snake_case, to_pascal_case, to_snake_case};
 use crate::rules::blank_lines::check_blank_line_between_items;
@@ -338,6 +338,46 @@ impl<'a> Linter<'a> {
             suggestion: Some(format!("append `.{sink}()` to materialize the iterator")),
             fix: Some(fix),
         });
+    }
+
+    pub(super) fn clone_call_receiver(node: &SNode) -> Option<&SNode> {
+        match &node.node {
+            Node::MethodCall {
+                object,
+                method,
+                args,
+            } if method == "clone" && args.is_empty() => Some(object),
+            _ => None,
+        }
+    }
+
+    pub(super) fn check_redundant_clone_args(&mut self, callee: &str, args: &[SNode]) {
+        for arg in args {
+            let Some(receiver) = Self::clone_call_receiver(arg) else {
+                continue;
+            };
+            let is_drop = callee == "drop";
+            let message = if is_drop {
+                "cloned value is immediately dropped".to_string()
+            } else {
+                "cloned value is immediately passed by value".to_string()
+            };
+            let suggestion = if is_drop {
+                "drop the original value directly".to_string()
+            } else {
+                "pass the original value directly unless a distinct snapshot is required"
+                    .to_string()
+            };
+            let fix = remove_method_call_wrapper_fix(self.source, arg.span, receiver.span);
+            self.diagnostics.push(LintDiagnostic {
+                rule: "redundant-clone",
+                message,
+                span: arg.span,
+                severity: LintSeverity::Warning,
+                suggestion: Some(suggestion),
+                fix,
+            });
+        }
     }
 
     pub(super) fn record_param_type_references(&mut self, params: &[TypedParam]) {
@@ -784,8 +824,8 @@ impl<'a> Linter<'a> {
         for (idx, node) in nodes.iter().enumerate() {
             if found_terminator {
                 self.diagnostics.push(LintDiagnostic {
-                    rule: "unreachable-code",
-                    message: "unreachable code after return or throw".to_string(),
+                    rule: "dead-code-after-return",
+                    message: "unreachable code after a terminating statement".to_string(),
                     span: node.span,
                     severity: LintSeverity::Warning,
                     suggestion: Some("remove the unreachable code".to_string()),
@@ -800,12 +840,67 @@ impl<'a> Linter<'a> {
                 self.check_discarded_approval_result(node);
             }
 
+            if let Some(next) = nodes.get(idx + 1) {
+                self.check_let_then_return(node, next);
+            }
+
             self.lint_node(node);
 
             if stmt_definitely_exits(node) {
                 found_terminator = true;
             }
         }
+    }
+
+    fn check_let_then_return(&mut self, node: &SNode, next: &SNode) {
+        let Node::LetBinding {
+            pattern: BindingPattern::Identifier(name),
+            type_ann: None,
+            value,
+        } = &node.node
+        else {
+            return;
+        };
+        let Node::ReturnStmt {
+            value: Some(returned),
+        } = &next.node
+        else {
+            return;
+        };
+        let Node::Identifier(returned_name) = &returned.node else {
+            return;
+        };
+        if returned_name != name {
+            return;
+        }
+
+        let fix = self.source.and_then(|src| {
+            let value_text = src.get(value.span.start..value.span.end)?;
+            Some(vec![FixEdit {
+                span: Span::with_offsets(
+                    node.span.start,
+                    next.span.end,
+                    node.span.line,
+                    node.span.column,
+                ),
+                replacement: format!("return {value_text}"),
+            }])
+        });
+        self.diagnostics.push(LintDiagnostic {
+            rule: "let-then-return",
+            message: format!("binding `{name}` is immediately returned"),
+            span: Span::with_offsets(
+                node.span.start,
+                next.span.end,
+                node.span.line,
+                node.span.column,
+            ),
+            severity: LintSeverity::Warning,
+            suggestion: Some(format!(
+                "return the expression assigned to `{name}` directly"
+            )),
+            fix,
+        });
     }
 
     fn check_discarded_approval_result(&mut self, node: &SNode) {
@@ -835,17 +930,28 @@ impl<'a> Linter<'a> {
                 continue;
             }
             if !self.references.contains(&decl.name) {
-                let fix = if decl.is_simple_ident {
-                    simple_ident_rename_fix(self.source, decl.span, &decl.name)
+                let (rule, message, suggestion, fix) = if decl.is_simple_ident {
+                    (
+                        "unused-variable",
+                        format!("variable `{}` is declared but never used", decl.name),
+                        format!("prefix with underscore: `_{}`", decl.name),
+                        simple_ident_rename_fix(self.source, decl.span, &decl.name),
+                    )
                 } else {
-                    None
+                    (
+                        "unused-pattern-binding",
+                        format!("pattern binding `{}` is never used", decl.name),
+                        "rename the binding with an underscore prefix or remove it from the pattern"
+                            .to_string(),
+                        None,
+                    )
                 };
                 self.diagnostics.push(LintDiagnostic {
-                    rule: "unused-variable",
-                    message: format!("variable `{}` is declared but never used", decl.name),
+                    rule,
+                    message,
                     span: decl.span,
                     severity: LintSeverity::Warning,
-                    suggestion: Some(format!("prefix with underscore: `_{}`", decl.name)),
+                    suggestion: Some(suggestion),
                     fix,
                 });
             }

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -3,7 +3,7 @@
 //! state-tracking plumbing.
 
 use harn_lexer::{FixEdit, Span, StringSegment};
-use harn_parser::{Node, SNode};
+use harn_parser::{BindingPattern, Node, SNode};
 
 use super::Linter;
 use crate::decls::{FnDeclaration, ImportInfo, TypeDeclaration};
@@ -279,6 +279,7 @@ impl<'a> Linter<'a> {
                         });
                     }
                 }
+                self.check_redundant_clone_args(name, args);
                 if let Some(target) = unnecessary_cast_target(name, args) {
                     let inner = &args[0];
                     let fix = unnecessary_cast_fix(self.source, snode.span, inner.span);
@@ -299,8 +300,17 @@ impl<'a> Linter<'a> {
                 }
             }
 
-            Node::MethodCall { object, args, .. }
-            | Node::OptionalMethodCall { object, args, .. } => {
+            Node::MethodCall {
+                object,
+                method,
+                args,
+            }
+            | Node::OptionalMethodCall {
+                object,
+                method,
+                args,
+            } => {
+                self.check_redundant_clone_args(method, args);
                 self.lint_node(object);
                 for arg in args {
                     self.lint_node(arg);
@@ -364,7 +374,24 @@ impl<'a> Linter<'a> {
             }
 
             Node::BinaryOp { op, left, right } => {
-                if op == "==" || op == "!=" {
+                let is_pointless_self_comparison = (op == "==" || op == "!=")
+                    && left.node == right.node
+                    && is_pure_expression(&left.node);
+                if is_pointless_self_comparison {
+                    let replacement = if op == "==" { "true" } else { "false" };
+                    self.diagnostics.push(LintDiagnostic {
+                        rule: "pointless-comparison",
+                        message: format!("expression is compared to itself with `{op}`"),
+                        span: snode.span,
+                        severity: LintSeverity::Warning,
+                        suggestion: Some(format!("replace this comparison with `{replacement}`")),
+                        fix: Some(vec![FixEdit {
+                            span: snode.span,
+                            replacement: replacement.to_string(),
+                        }]),
+                    });
+                }
+                if (op == "==" || op == "!=") && !is_pointless_self_comparison {
                     let is_bool_left = matches!(left.node, Node::BoolLiteral(_));
                     let is_bool_right = matches!(right.node, Node::BoolLiteral(_));
                     if is_bool_left || is_bool_right {
@@ -509,6 +536,19 @@ impl<'a> Linter<'a> {
                 else_body,
             } => {
                 self.lint_node(condition);
+                if let Node::BoolLiteral(value) = &condition.node {
+                    self.diagnostics.push(LintDiagnostic {
+                        rule: "pointless-comparison",
+                        message: format!("if condition is always `{value}`"),
+                        span: condition.span,
+                        severity: LintSeverity::Warning,
+                        suggestion: Some(
+                            "remove the constant condition or replace it with real branching"
+                                .to_string(),
+                        ),
+                        fix: None,
+                    });
+                }
                 if then_body.is_empty() {
                     // Skip autofix when an `else` branch exists (dropping the
                     // whole if-else would silently drop the else body) or when
@@ -607,11 +647,14 @@ impl<'a> Linter<'a> {
                     });
                 }
                 self.push_scope();
-                for name in Self::pattern_names(pattern) {
-                    if let Some(scope) = self.scopes.last_mut() {
-                        scope.insert(name.clone());
+                match pattern {
+                    BindingPattern::Identifier(name) => {
+                        if let Some(scope) = self.scopes.last_mut() {
+                            scope.insert(name.clone());
+                        }
+                        self.references.insert(name.clone());
                     }
-                    self.references.insert(name);
+                    _ => self.declare_pattern_variables(pattern, snode.span, false),
                 }
                 self.loop_depth += 1;
                 self.lint_block(body);

--- a/crates/harn-lint/src/tests/hygiene.rs
+++ b/crates/harn-lint/src/tests/hygiene.rs
@@ -1,0 +1,175 @@
+//! Clippy-tier hygiene rules: redundant clones, constant/self comparisons,
+//! destructuring-only unused bindings, and let-then-return.
+
+use super::*;
+
+#[test]
+fn test_redundant_clone_passed_by_value_autofix() {
+    let source = "pipeline default(task) {\n  let data = [1, 2]\n  log(data.clone())\n}";
+    let diags = lint_source(source);
+    assert!(
+        has_rule(&diags, "redundant-clone"),
+        "expected redundant-clone, got: {diags:?}"
+    );
+    let fixed = apply_fixes(source, &diags);
+    assert!(
+        fixed.contains("log(data)"),
+        "expected clone wrapper to be removed, got: {fixed}"
+    );
+}
+
+#[test]
+fn test_redundant_clone_dropped_autofix() {
+    let source = "pipeline default(task) {\n  let data = [1, 2]\n  drop(data.clone())\n}";
+    let diags = lint_source(source);
+    assert!(
+        has_rule(&diags, "redundant-clone"),
+        "expected redundant-clone for dropped clone, got: {diags:?}"
+    );
+    let fixed = apply_fixes(source, &diags);
+    assert!(
+        fixed.contains("drop(data)"),
+        "expected dropped clone wrapper to be removed, got: {fixed}"
+    );
+}
+
+#[test]
+fn test_redundant_clone_ignores_named_clone_binding() {
+    let diags = lint_source(
+        r#"
+pipeline default(task) {
+  let data = [1, 2]
+  let copied = data.clone()
+  log(copied)
+  log(data)
+}
+"#,
+    );
+    assert!(
+        !has_rule(&diags, "redundant-clone"),
+        "binding a clone for later use should not trigger redundant-clone: {diags:?}"
+    );
+}
+
+#[test]
+fn test_pointless_self_comparison_autofix() {
+    let source = "pipeline default(task) {\n  let always = task == task\n  log(always)\n}";
+    let diags = lint_source(source);
+    assert!(
+        has_rule(&diags, "pointless-comparison"),
+        "expected pointless-comparison, got: {diags:?}"
+    );
+    let fixed = apply_fixes(source, &diags);
+    assert!(
+        fixed.contains("let always = true"),
+        "expected self-comparison to become true, got: {fixed}"
+    );
+}
+
+#[test]
+fn test_pointless_if_constant_condition() {
+    let diags = lint_source(
+        r#"
+pipeline default(task) {
+  if false {
+    log(task)
+  }
+}
+"#,
+    );
+    assert!(
+        has_rule(&diags, "pointless-comparison"),
+        "expected constant if condition warning, got: {diags:?}"
+    );
+}
+
+#[test]
+fn test_pointless_comparison_ignores_different_expressions() {
+    let diags = lint_source(
+        r#"
+pipeline default(task) {
+  let other = "x"
+  let same = task == other
+  log(same)
+}
+"#,
+    );
+    assert!(
+        !has_rule(&diags, "pointless-comparison"),
+        "different operands should not trigger pointless-comparison: {diags:?}"
+    );
+}
+
+#[test]
+fn test_unused_pattern_binding_for_destructuring() {
+    let diags = lint_source(
+        r#"
+pipeline default(task) {
+  let { a, b } = { a: 1, b: 2 }
+  log(a)
+}
+"#,
+    );
+    assert!(
+        has_rule(&diags, "unused-pattern-binding"),
+        "expected unused-pattern-binding, got: {diags:?}"
+    );
+    assert!(
+        !has_rule(&diags, "unused-variable"),
+        "destructuring names should use unused-pattern-binding, got: {diags:?}"
+    );
+}
+
+#[test]
+fn test_unused_pattern_binding_underscore_ignored() {
+    let diags = lint_source(
+        r#"
+pipeline default(task) {
+  let { a, b: _b } = { a: 1, b: 2 }
+  log(a)
+}
+"#,
+    );
+    assert!(
+        !has_rule(&diags, "unused-pattern-binding"),
+        "underscore-prefixed pattern binding should be ignored: {diags:?}"
+    );
+}
+
+#[test]
+fn test_let_then_return_autofix() {
+    let source = "pipeline default(task) {\n  fn answer() {\n    let value = 1 + 2\n    return value\n  }\n  log(answer())\n}";
+    let diags = lint_source(source);
+    assert!(
+        has_rule(&diags, "let-then-return"),
+        "expected let-then-return, got: {diags:?}"
+    );
+    let fixed = apply_fixes(source, &diags);
+    assert!(
+        fixed.contains("return 1 + 2"),
+        "expected direct return fix, got: {fixed}"
+    );
+    assert!(
+        !fixed.contains("let value = 1 + 2"),
+        "expected temporary binding to be removed, got: {fixed}"
+    );
+}
+
+#[test]
+fn test_let_then_return_ignores_typed_binding() {
+    let diags = lint_source(
+        r#"
+pipeline default(task) {
+  fn answer() {
+    let value: int = 1 + 2
+    return value
+  }
+  log(answer())
+}
+"#,
+    );
+    assert!(
+        !has_rule(&diags, "let-then-return"),
+        "typed temporary should preserve its annotation: {diags:?}"
+    );
+}

--- a/crates/harn-lint/src/tests/mod.rs
+++ b/crates/harn-lint/src/tests/mod.rs
@@ -81,6 +81,7 @@ mod file_header;
 mod formatting;
 mod harndoc;
 mod hitl;
+mod hygiene;
 mod imports;
 mod invalid_binop;
 mod llm_rules;

--- a/crates/harn-lint/src/tests/unreachable.rs
+++ b/crates/harn-lint/src/tests/unreachable.rs
@@ -1,4 +1,4 @@
-//! `unreachable-code` coverage — return/throw/break/composite-exit.
+//! `dead-code-after-return` coverage — return/throw/break/composite-exit.
 
 use super::*;
 
@@ -13,8 +13,8 @@ log("never reached")
 "#,
     );
     assert!(
-        has_rule(&diags, "unreachable-code"),
-        "expected unreachable-code warning, got: {diags:?}"
+        has_rule(&diags, "dead-code-after-return"),
+        "expected dead-code-after-return warning, got: {diags:?}"
     );
 }
 
@@ -29,8 +29,8 @@ return 1
 "#,
     );
     assert!(
-        !has_rule(&diags, "unreachable-code"),
-        "return at end should not trigger unreachable-code: {diags:?}"
+        !has_rule(&diags, "dead-code-after-return"),
+        "return at end should not trigger dead-code-after-return: {diags:?}"
     );
 }
 
@@ -38,8 +38,8 @@ return 1
 fn test_unreachable_after_throw() {
     let diags = lint_source("pipeline t(task) { throw \"err\"\nlog(\"unreachable\") }");
     assert!(
-        diags.iter().any(|d| d.rule == "unreachable-code"),
-        "expected unreachable-code after throw, got: {diags:?}"
+        diags.iter().any(|d| d.rule == "dead-code-after-return"),
+        "expected dead-code-after-return after throw, got: {diags:?}"
     );
 }
 
@@ -56,8 +56,8 @@ while true {
 "#,
     );
     assert!(
-        has_rule(&diags, "unreachable-code"),
-        "expected unreachable-code after break, got: {diags:?}"
+        has_rule(&diags, "dead-code-after-return"),
+        "expected dead-code-after-return after break, got: {diags:?}"
     );
 }
 
@@ -75,8 +75,8 @@ foo(true)
 "#,
     );
     assert!(
-        has_rule(&diags, "unreachable-code"),
-        "expected unreachable-code after composite exit, got: {diags:?}"
+        has_rule(&diags, "dead-code-after-return"),
+        "expected dead-code-after-return after composite exit, got: {diags:?}"
     );
 }
 
@@ -94,7 +94,22 @@ foo(true)
 "#,
     );
     assert!(
-        !has_rule(&diags, "unreachable-code"),
+        !has_rule(&diags, "dead-code-after-return"),
         "should not flag reachable code: {diags:?}"
+    );
+}
+
+#[test]
+fn test_legacy_unreachable_code_disabled_rule_alias() {
+    let source = "pipeline default(task) {\n  return 1\n  log(\"never reached\")\n}";
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let program = parser.parse().unwrap();
+    let diags =
+        lint_with_config_and_source(&program, &["unreachable-code".to_string()], Some(source));
+    assert!(
+        !has_rule(&diags, "dead-code-after-return"),
+        "legacy disabled rule should suppress renamed diagnostic: {diags:?}"
     );
 }

--- a/crates/harn-lint/src/tests/unused.rs
+++ b/crates/harn-lint/src/tests/unused.rs
@@ -124,8 +124,8 @@ log("dead")
     );
     assert!(has_rule(&diags, "unused-variable"));
     assert!(has_rule(&diags, "mutable-never-reassigned"));
-    assert!(has_rule(&diags, "unreachable-code"));
-    assert_eq!(count_rule(&diags, "unreachable-code"), 1);
+    assert!(has_rule(&diags, "dead-code-after-return"));
+    assert_eq!(count_rule(&diags, "dead-code-after-return"), 1);
 }
 
 #[test]
@@ -184,22 +184,22 @@ fn test_no_fix_for_unused_variable_in_dict_destructuring() {
     let diags = lint_source(source);
     let unused: Vec<_> = diags
         .iter()
-        .filter(|d| d.rule == "unused-variable")
+        .filter(|d| d.rule == "unused-pattern-binding")
         .collect();
     assert!(
         unused.iter().any(|d| d.message.contains("`b`")),
-        "expected unused-variable for `b`, got: {diags:?}"
+        "expected unused-pattern-binding for `b`, got: {diags:?}"
     );
     for diag in &unused {
         if diag.message.contains("`b`") {
             assert!(
                 diag.fix.is_none(),
-                "destructuring unused-variable must not autofix, got: {:?}",
+                "destructuring unused-pattern-binding must not autofix, got: {:?}",
                 diag.fix
             );
             assert!(
                 diag.suggestion.is_some(),
-                "destructuring unused-variable must keep its suggestion"
+                "destructuring unused-pattern-binding must keep its suggestion"
             );
         }
     }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -242,8 +242,9 @@ contexts, but they are not preserved in formatter output.
 ## harn lint
 
 Lint one or more `.harn` files or directories for common issues (unused
-variables, unused functions, unreachable code, empty blocks, missing
-`/** */` HarnDoc on public functions, etc.).
+variables, unused functions, dead code after terminating statements,
+pointless comparisons, redundant clones, empty blocks, missing `/** */`
+HarnDoc on public functions, etc.).
 
 ```bash
 harn lint main.harn
@@ -252,8 +253,9 @@ harn lint src/ tests/
 
 Pass `--fix` to automatically apply safe fixes (e.g., `var` → `let` for
 never-reassigned bindings, boolean comparison simplification, unused import
-removal, string interpolation conversion, and removing redundant
-`to_string(...)`/`to_int(...)`/`to_list(...)` casts):
+removal, string interpolation conversion, `let`-then-`return` simplification,
+and removing redundant `clone()`/`to_string(...)`/`to_int(...)`/`to_list(...)`
+wrappers):
 
 ```bash
 harn lint --fix main.harn

--- a/docs/src/editor-integration.md
+++ b/docs/src/editor-integration.md
@@ -132,13 +132,15 @@ harn lint file.harn
 harn lint --fix file.harn   # automatically apply safe fixes
 ```
 
-The linter checks for: shadow variables, unused variables, unused types,
-undefined functions, unreachable code, missing harndoc comments, naming
-convention drift, branch-heavy functions, prompt-injection risks such as
+The linter checks for: shadow variables, unused variables, unused pattern
+bindings, unused types, undefined functions, dead code after terminating
+statements, pointless comparisons, redundant clones, missing harndoc comments,
+naming convention drift, branch-heavy functions, prompt-injection risks such as
 interpolated `llm_call` system prompts, and unnecessary conversion calls
 (`to_string("hi")`, `to_int(42)`, etc.). With `--fix`, the linter
 automatically rewrites fixable issues (e.g., `var` → `let`, boolean
-comparison simplification, unused import removal, unnecessary-cast
-removal). The same fixes are surfaced through the LSP as both
+comparison simplification, `let`-then-`return` simplification, redundant
+clone removal, unused import removal, unnecessary-cast removal). The same fixes
+are surfaced through the LSP as both
 per-diagnostic quick-fixes and a bulk `source.fixAll.harn` code action
 suitable for `editor.codeActionsOnSave`.


### PR DESCRIPTION
## Summary
- add hygiene lint rules for redundant clones, dead code after terminating statements, pointless comparisons, unused pattern bindings, and let-then-return
- add safe autofixes for redundant clone wrappers, pure self-comparisons, and let-then-return
- update lint docs and keep the legacy `unreachable-code` disabled-rule alias working for the renamed dead-code diagnostic

Closes #917

## Self-review
- checked for duplicate diagnostics against existing boolean-comparison and unused-variable rules
- kept destructuring fixes manual because dict shorthand needs key/alias awareness
- preserved backwards compatibility for existing `unreachable-code` suppressions

## Verification
- `cargo test -p harn-lint`
- `cargo check -p harn-cli -p harn-lsp`
- pre-commit hook: cargo fmt, workspace clippy, markdownlint
- pre-push hook: 2,988 nextest tests, markdownlint
