### PR TITLE
Implement DAP source retrieval

### DIFF
--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -2242,11 +2242,10 @@ async fn json_log_format_writes_structured_rotating_file_with_trace_ids() {
 //
 // The orchestrator subprocess runs with the simple span processor
 // (`HARN_OTEL_SPAN_PROCESSOR=simple`). That replaces the production batch
-// pipeline with a synchronous "export each span on close" pipeline, so the
-// dispatch span — which closes inside graceful drain — is guaranteed to be on
-// the wire before the orchestrator exits. The test then has only one
-// synchronization point: process exit. No polling, no wall-clock cadence, no
-// dependence on `force_flush`-during-shutdown reliability.
+// pipeline with a synchronous "export each span on close" pipeline. The test
+// waits for the existing pump lifecycle event before shutdown, so it asserts
+// trace propagation after the dispatch span has actually closed instead of
+// racing the ack-first inbox pump.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
     let _lock = lock_orchestrator_tests();
@@ -2282,6 +2281,12 @@ async fn otel_exports_ingest_and_dispatch_spans_with_shared_trace_id() {
         .unwrap();
     let response = client.execute(request).await.unwrap();
     assert_status(response, StatusCode::OK).await;
+
+    wait_for_topic_event(&temp, "orchestrator.lifecycle", |event| {
+        event.kind == "pump_dispatch_completed"
+            && event.payload["status"] == serde_json::json!("completed")
+    })
+    .await;
 
     send_sigterm(&mut process.child);
     let status = wait_for_exit_async(&mut process.child).await;

--- a/crates/harn-dap/src/debugger/breakpoints.rs
+++ b/crates/harn-dap/src/debugger/breakpoints.rs
@@ -61,6 +61,7 @@ impl Debugger {
                             source: request_path.clone().map(|p| Source {
                                 name: None,
                                 path: Some(p),
+                                source_reference: None,
                             }),
                             condition,
                             hit_condition,

--- a/crates/harn-dap/src/debugger/mod.rs
+++ b/crates/harn-dap/src/debugger/mod.rs
@@ -1,5 +1,6 @@
 mod breakpoints;
 mod events;
+mod sources;
 pub(crate) mod state;
 mod stepping;
 mod variables;
@@ -61,6 +62,7 @@ impl Debugger {
             "pause" => self.handle_pause(&msg),
             "threads" => self.handle_threads(&msg),
             "stackTrace" => self.handle_stack_trace(&msg),
+            "source" => self.handle_source(&msg),
             "scopes" => self.handle_scopes(&msg),
             "variables" => self.handle_variables(&msg),
             "evaluate" => self.handle_evaluate(&msg),
@@ -159,21 +161,27 @@ impl Debugger {
     }
 
     fn handle_stack_trace(&mut self, msg: &DapMessage) -> Vec<DapResponse> {
-        let frames: Vec<StackFrame> = if let Some(vm) = &self.vm {
-            vm.debug_stack_frames()
+        let frames: Vec<StackFrame> = if self.vm.is_some() {
+            let vm_frames = self
+                .vm
+                .as_ref()
+                .expect("checked above")
+                .debug_stack_frames_with_sources();
+            let fallback_source_path = self.source_path.clone();
+            vm_frames
                 .into_iter()
                 .enumerate()
-                .map(|(i, (name, line))| StackFrame {
-                    id: (i + 1) as i64,
-                    name,
-                    line: line.max(1) as i64,
-                    column: 1,
-                    source: self.source_path.as_ref().map(|p| Source {
-                        name: std::path::Path::new(p)
-                            .file_name()
-                            .map(|f| f.to_string_lossy().into_owned()),
-                        path: Some(p.clone()),
-                    }),
+                .map(|(i, (name, line, source_path))| {
+                    let frame_source_path = source_path.or_else(|| fallback_source_path.clone());
+                    StackFrame {
+                        id: (i + 1) as i64,
+                        name,
+                        line: line.max(1) as i64,
+                        column: 1,
+                        source: frame_source_path
+                            .as_deref()
+                            .map(|p| self.source_for_path(p)),
+                    }
                 })
                 .collect()
         } else {
@@ -182,12 +190,7 @@ impl Debugger {
                 name: "pipeline".to_string(),
                 line: self.current_line.max(1),
                 column: 1,
-                source: self.source_path.as_ref().map(|p| Source {
-                    name: std::path::Path::new(p)
-                        .file_name()
-                        .map(|f| f.to_string_lossy().into_owned()),
-                    path: Some(p.clone()),
-                }),
+                source: self.source_path.clone().map(|p| self.source_for_path(&p)),
             }]
         };
 

--- a/crates/harn-dap/src/debugger/sources.rs
+++ b/crates/harn-dap/src/debugger/sources.rs
@@ -1,0 +1,120 @@
+use serde_json::json;
+
+use super::state::Debugger;
+use crate::protocol::{DapMessage, DapResponse, Source};
+
+impl Debugger {
+    pub(crate) fn handle_source(&mut self, msg: &DapMessage) -> Vec<DapResponse> {
+        let args = msg.arguments.as_ref();
+        let source_reference = args
+            .and_then(|a| a.get("sourceReference"))
+            .and_then(|v| v.as_i64())
+            .filter(|v| *v > 0);
+        let source_path = args
+            .and_then(|a| a.get("source"))
+            .and_then(|s| s.get("path"))
+            .and_then(|p| p.as_str())
+            .map(str::to_string);
+
+        let ref_path = source_reference.and_then(|id| self.source_refs.get(&id).cloned());
+        let Some(path) = ref_path.or(source_path) else {
+            return vec![self.dap_error(
+                msg,
+                "source",
+                "source request requires source.path or sourceReference",
+            )];
+        };
+
+        match self.source_content_for_path(&path) {
+            Some(content) => {
+                let seq = self.next_seq();
+                vec![DapResponse::success(
+                    seq,
+                    msg.seq,
+                    "source",
+                    Some(json!({
+                        "content": content,
+                        "mimeType": source_mime_type(&path),
+                    })),
+                )]
+            }
+            None => {
+                vec![self.dap_error(msg, "source", &format!("source not available for '{path}'"))]
+            }
+        }
+    }
+
+    pub(crate) fn source_for_path(&mut self, path: &str) -> Source {
+        let has_cached_source = (self.source_path.as_deref() == Some(path)
+            && self.source_content.is_some())
+            || self
+                .vm
+                .as_ref()
+                .and_then(|vm| vm.debug_source_for_path(path))
+                .is_some()
+            || stdlib_source(path).is_some();
+        let source_reference = if has_cached_source {
+            Some(self.source_reference_for_path(path))
+        } else {
+            None
+        };
+
+        Source {
+            name: std::path::Path::new(path)
+                .file_name()
+                .map(|f| f.to_string_lossy().into_owned())
+                .or_else(|| Some(path.to_string())),
+            path: Some(path.to_string()),
+            source_reference,
+        }
+    }
+
+    fn source_reference_for_path(&mut self, path: &str) -> i64 {
+        if let Some(id) = self.source_ref_by_path.get(path) {
+            return *id;
+        }
+        let id = self.next_source_ref;
+        self.next_source_ref += 1;
+        self.source_ref_by_path.insert(path.to_string(), id);
+        self.source_refs.insert(id, path.to_string());
+        id
+    }
+
+    fn source_content_for_path(&self, path: &str) -> Option<String> {
+        if self.source_path.as_deref() == Some(path) {
+            if let Some(source) = &self.source_content {
+                return Some(source.clone());
+            }
+        }
+
+        if let Some(vm) = &self.vm {
+            if let Some(source) = vm.debug_source_for_path(path) {
+                return Some(source);
+            }
+        }
+
+        if let Some(source) = stdlib_source(path) {
+            return Some(source.to_string());
+        }
+
+        let fs_path = path.strip_prefix("file://").unwrap_or(path);
+        std::fs::read_to_string(fs_path).ok()
+    }
+}
+
+fn stdlib_source(path: &str) -> Option<&'static str> {
+    let module = path
+        .strip_prefix("<stdlib>/")
+        .and_then(|s| s.strip_suffix(".harn"))?;
+    harn_vm::stdlib_modules::get_stdlib_source(module)
+}
+
+fn source_mime_type(path: &str) -> &'static str {
+    if path.ends_with(".harn") {
+        "text/x-harn"
+    } else if path.ends_with(".harn.prompt") {
+        "text/x-harn-prompt"
+    } else {
+        "text/plain"
+    }
+}

--- a/crates/harn-dap/src/debugger/state.rs
+++ b/crates/harn-dap/src/debugger/state.rs
@@ -43,6 +43,12 @@ pub struct Debugger {
     pub(crate) seq: i64,
     pub(crate) source_path: Option<String>,
     pub(crate) source_content: Option<String>,
+    /// DAP sourceReference -> source key.
+    pub(crate) source_refs: BTreeMap<i64, String>,
+    /// Source key -> DAP sourceReference for stable stack frame/source requests.
+    pub(crate) source_ref_by_path: BTreeMap<String, i64>,
+    /// Next source reference ID. Starts above variable refs to keep logs readable.
+    pub(crate) next_source_ref: i64,
     pub(crate) breakpoints: Vec<crate::protocol::Breakpoint>,
     pub(crate) next_bp_id: i64,
     pub(crate) vm: Option<Vm>,
@@ -148,6 +154,9 @@ impl Debugger {
             seq: 1,
             source_path: None,
             source_content: None,
+            source_refs: BTreeMap::new(),
+            source_ref_by_path: BTreeMap::new(),
+            next_source_ref: 1000,
             breakpoints: Vec::new(),
             next_bp_id: 1,
             vm: None,

--- a/crates/harn-dap/src/debugger/stepping.rs
+++ b/crates/harn-dap/src/debugger/stepping.rs
@@ -38,6 +38,9 @@ impl Debugger {
         }
 
         let mut vm = Vm::new();
+        if let Some(ref path) = self.source_path {
+            vm.set_source_info(path, source);
+        }
         register_vm_stdlib(&mut vm);
         register_http_builtins(&mut vm);
         register_llm_builtins(&mut vm);

--- a/crates/harn-dap/src/debugger/tests.rs
+++ b/crates/harn-dap/src/debugger/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use harn_vm::VmValue;
+use harn_vm::{Vm, VmValue};
 use serde_json::json;
 use tempfile::TempDir;
 
@@ -318,6 +318,81 @@ fn test_evaluate_with_context() {
         let body = responses[0].body.as_ref().unwrap();
         assert_eq!(body["result"], "7");
     }
+}
+
+#[test]
+fn test_source_returns_launch_source_content() {
+    let mut dbg = Debugger::new();
+    dbg.source_path = Some("/tmp/main.harn".to_string());
+    dbg.source_content = Some("let x = 1\n".to_string());
+
+    let responses = dbg.handle_message(make_request(
+        1,
+        "source",
+        Some(json!({"source": {"path": "/tmp/main.harn"}})),
+    ));
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].success, Some(true));
+    let body = responses[0].body.as_ref().unwrap();
+    assert_eq!(body["content"], "let x = 1\n");
+    assert_eq!(body["mimeType"], "text/x-harn");
+}
+
+#[test]
+fn test_source_reads_prompt_template_from_disk() {
+    let (_dir, file) = write_temp_program("sample.harn.prompt", "Hello {{ name }}\n");
+    let responses = Debugger::new().handle_message(make_request(
+        1,
+        "source",
+        Some(json!({"source": {"path": file.to_string_lossy()}})),
+    ));
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].success, Some(true));
+    let body = responses[0].body.as_ref().unwrap();
+    assert_eq!(body["content"], "Hello {{ name }}\n");
+    assert_eq!(body["mimeType"], "text/x-harn-prompt");
+}
+
+#[test]
+fn test_source_reads_stdlib_synthetic_source() {
+    let responses = Debugger::new().handle_message(make_request(
+        1,
+        "source",
+        Some(json!({"source": {"path": "<stdlib>/text.harn"}})),
+    ));
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].success, Some(true));
+    let body = responses[0].body.as_ref().unwrap();
+    assert!(body["content"].as_str().unwrap().contains("pub fn"));
+}
+
+#[test]
+fn test_source_reference_reads_vm_generated_source() {
+    let source = "pub fn generated_answer() {\n  return 42\n}\n";
+    let mut vm = Vm::new();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("runtime");
+    runtime
+        .block_on(vm.load_module_exports_from_source("<generated>/wrapper.harn", source))
+        .expect("load generated module");
+
+    let mut dbg = Debugger::new();
+    dbg.vm = Some(vm);
+    let source_ref = dbg
+        .source_for_path("<generated>/wrapper.harn")
+        .source_reference
+        .expect("generated source gets a sourceReference");
+
+    let responses = dbg.handle_message(make_request(
+        1,
+        "source",
+        Some(json!({"sourceReference": source_ref})),
+    ));
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].success, Some(true));
+    let body = responses[0].body.as_ref().unwrap();
+    assert_eq!(body["content"], source);
 }
 
 #[test]

--- a/crates/harn-dap/src/protocol.rs
+++ b/crates/harn-dap/src/protocol.rs
@@ -230,6 +230,12 @@ pub struct Source {
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "sourceReference"
+    )]
+    pub source_reference: Option<i64>,
 }
 
 /// DAP StackFrame.

--- a/crates/harn-vm/src/vm/debug.rs
+++ b/crates/harn-vm/src/vm/debug.rs
@@ -271,6 +271,15 @@ impl Vm {
 
     /// Get all stack frames for the debugger.
     pub fn debug_stack_frames(&self) -> Vec<(String, usize)> {
+        self.debug_stack_frames_with_sources()
+            .into_iter()
+            .map(|(name, line, _source)| (name, line))
+            .collect()
+    }
+
+    /// Get all stack frames plus their source keys for debugger clients that
+    /// can retrieve synthetic sources through DAP `source`.
+    pub fn debug_stack_frames_with_sources(&self) -> Vec<(String, usize, Option<String>)> {
         let mut frames = Vec::new();
         for (i, frame) in self.frames.iter().enumerate() {
             let line = if frame.ip > 0 && frame.ip - 1 < frame.chunk.lines.len() {
@@ -287,9 +296,34 @@ impl Vm {
             } else {
                 frame.fn_name.clone()
             };
-            frames.push((name, line));
+            frames.push((name, line, frame.chunk.source_file.clone()));
         }
         frames
+    }
+
+    /// Return cached source text by debugger source key. This covers entry
+    /// programs, real imports that have already been read, and synthetic
+    /// sources such as stdlib modules or generated in-memory modules.
+    pub fn debug_source_for_path(&self, path: &str) -> Option<String> {
+        if self.source_file.as_deref() == Some(path) {
+            if let Some(source) = &self.source_text {
+                return Some(source.clone());
+            }
+        }
+
+        let key = std::path::PathBuf::from(path);
+        if let Some(source) = self.source_cache.get(&key) {
+            return Some(source.clone());
+        }
+
+        if let Some(module) = path
+            .strip_prefix("<stdlib>/")
+            .and_then(|s| s.strip_suffix(".harn"))
+        {
+            return crate::stdlib_modules::get_stdlib_source(module).map(str::to_string);
+        }
+
+        None
     }
 
     /// Get the current source line.

--- a/crates/harn-vm/src/vm/modules.rs
+++ b/crates/harn-vm/src/vm/modules.rs
@@ -39,6 +39,8 @@ impl Vm {
         if let Some(loaded) = self.module_cache.get(&synthetic).cloned() {
             return Ok(loaded);
         }
+        self.source_cache
+            .insert(synthetic.clone(), source.to_string());
 
         let mut lexer = harn_lexer::Lexer::new(source);
         let tokens = lexer.tokenize().map_err(|e| {
@@ -53,7 +55,9 @@ impl Vm {
         })?;
 
         self.imported_paths.push(synthetic.clone());
-        let loaded = self.import_declarations(&program, None).await?;
+        let loaded = self
+            .import_declarations(&program, None, Some(&synthetic))
+            .await?;
         self.imported_paths.pop();
         self.module_cache.insert(synthetic, loaded.clone());
         Ok(loaded)
@@ -141,6 +145,8 @@ impl Vm {
                     file_path.display()
                 ))
             })?;
+            self.source_cache.insert(canonical.clone(), source.clone());
+            self.source_cache.insert(file_path.clone(), source.clone());
 
             let mut lexer = harn_lexer::Lexer::new(&source);
             let tokens = lexer
@@ -151,7 +157,9 @@ impl Vm {
                 .parse()
                 .map_err(|e| VmError::Runtime(format!("Import parse error: {e}")))?;
 
-            let loaded = self.import_declarations(&program, Some(&file_path)).await?;
+            let loaded = self
+                .import_declarations(&program, Some(&file_path), Some(&file_path))
+                .await?;
             self.imported_paths.pop();
             self.module_cache.insert(canonical.clone(), loaded.clone());
             self.export_loaded_module(&canonical, &loaded, selected_names)?;
@@ -165,6 +173,7 @@ impl Vm {
         &'a mut self,
         program: &'a [harn_parser::SNode],
         file_path: Option<&'a Path>,
+        debug_source_file: Option<&'a Path>,
     ) -> Pin<Box<dyn Future<Output = Result<LoadedModule, VmError>> + 'a>> {
         Box::pin(async move {
             let caller_env = self.env.clone();
@@ -259,7 +268,7 @@ impl Vm {
                 };
 
                 let mut compiler = crate::Compiler::new();
-                let module_source_file = file_path.map(|p| p.display().to_string());
+                let module_source_file = debug_source_file.map(|p| p.display().to_string());
                 let func_chunk = compiler
                     .compile_fn_body(params, body, module_source_file)
                     .map_err(|e| VmError::Runtime(format!("Import compile error: {e}")))?;

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -194,6 +194,8 @@ pub struct Vm {
     pub(crate) imported_paths: Vec<std::path::PathBuf>,
     /// Loaded module cache keyed by canonical or synthetic module path.
     pub(crate) module_cache: BTreeMap<std::path::PathBuf, LoadedModule>,
+    /// Source text keyed by canonical or synthetic module path for debugger retrieval.
+    pub(crate) source_cache: BTreeMap<std::path::PathBuf, String>,
     /// Source file path for error reporting.
     pub(crate) source_file: Option<String>,
     /// Source text for error reporting.
@@ -409,6 +411,7 @@ impl Vm {
             source_dir: None,
             imported_paths: Vec::new(),
             module_cache: BTreeMap::new(),
+            source_cache: BTreeMap::new(),
             source_file: None,
             source_text: None,
             bridge: None,
@@ -438,6 +441,8 @@ impl Vm {
     pub fn set_source_info(&mut self, file: &str, text: &str) {
         self.source_file = Some(file.to_string());
         self.source_text = Some(text.to_string());
+        self.source_cache
+            .insert(std::path::PathBuf::from(file), text.to_string());
     }
 
     /// Initialize execution (push the initial frame).
@@ -498,6 +503,7 @@ impl Vm {
             source_dir: self.source_dir.clone(),
             imported_paths: Vec::new(),
             module_cache: self.module_cache.clone(),
+            source_cache: self.source_cache.clone(),
             source_file: self.source_file.clone(),
             source_text: self.source_text.clone(),
             bridge: self.bridge.clone(),

--- a/crates/harn-vm/src/vm/tests_debug.rs
+++ b/crates/harn-vm/src/vm/tests_debug.rs
@@ -313,6 +313,31 @@ fn test_function_breakpoint_stops_on_entry() {
 }
 
 #[test]
+fn test_generated_module_source_is_cached_and_tagged_for_debugger() {
+    let source = "pub fn generated_answer() {\n  return 42\n}\n";
+    let mut vm = Vm::new();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+    let exports = rt
+        .block_on(vm.load_module_exports_from_source("<generated>/wrapper.harn", source))
+        .expect("generated module loads");
+
+    assert_eq!(
+        vm.debug_source_for_path("<generated>/wrapper.harn")
+            .as_deref(),
+        Some(source)
+    );
+    let closure = exports
+        .get("generated_answer")
+        .expect("exported generated function");
+    assert_eq!(
+        closure.func.chunk.source_file.as_deref(),
+        Some("<generated>/wrapper.harn")
+    );
+}
+
+#[test]
 fn test_function_breakpoint_unknown_name_does_not_fire() {
     let mut vm = Vm::new();
     register_vm_stdlib(&mut vm);


### PR DESCRIPTION
## Summary
- add DAP `source` request handling for launch files, prompt templates, stdlib synthetic sources, and VM-generated in-memory modules
- cache VM source text for entry/imported/generated modules and expose stack frame source keys/sourceReferences
- keep existing `evaluate` and `setVariable` coverage intact while adding source retrieval tests

Fixes #919.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-8234 cargo test -p harn-dap`
- `CARGO_TARGET_DIR=/tmp/harn-target-8234 cargo test -p harn-vm vm::tests_debug`
- pre-commit hook: `cargo clippy --workspace --all-targets -- -D warnings`
- pre-push hook: nextest run, 2982 tests passed