### PR TITLE
Add explicit generic call type arguments

### DIFF
--- a/conformance/tests/types/parametric_polymorphism.expected
+++ b/conformance/tests/types/parametric_polymorphism.expected
@@ -1,0 +1,6 @@
+6
+4
+12
+fallback
+12
+value=12

--- a/conformance/tests/types/parametric_polymorphism.harn
+++ b/conformance/tests/types/parametric_polymorphism.harn
@@ -1,0 +1,65 @@
+pipeline default() {
+  fn map<T, U>(xs: list<T>, f: fn(T) -> U) -> list<U> {
+    var out: list<U> = []
+    for x in xs {
+      out = out.push(f(x))
+    }
+    return out
+  }
+  fn filter<T>(xs: list<T>, pred: fn(T) -> bool) -> list<T> {
+    var out: list<T> = []
+    for x in xs {
+      if pred(x) {
+        out = out.push(x)
+      }
+    }
+    return out
+  }
+  fn fold<T, U>(xs: list<T>, init: U, step: fn(U, T) -> U) -> U {
+    var acc: U = init
+    for x in xs {
+      acc = step(acc, x)
+    }
+    return acc
+  }
+  fn result_map<T, U, E>(result: Result<T, E>, f: fn(T) -> U) -> Result<U, E> {
+    match result {
+      Result.Ok(value) -> { return Result.Ok(f(value)) }
+      Result.Err(error) -> { return Result.Err(error) }
+    }
+  }
+  fn result_unwrap_or<T, E>(result: Result<T, E>, fallback: T) -> T {
+    match result {
+      Result.Ok(value) -> { return value }
+      Result.Err(_) -> { return fallback }
+    }
+  }
+  struct Pair<A, B> {
+    first: A
+    second: B
+  }
+  fn double(x: int) -> int {
+    return x * 2
+  }
+  fn keep_even(x: int) -> bool {
+    return x % 2 == 0
+  }
+  fn add(acc: int, x: int) -> int {
+    return acc + x
+  }
+  fn label(x: int) -> string {
+    return "value=${x}"
+  }
+  let mapped: list<int> = map<int, int>([1, 2, 3], double)
+  let filtered: list<int> = filter<int>(mapped, keep_even)
+  let total: int = fold<int, int>(filtered, 0, add)
+  let labeled: Result<string, string> = result_map<int, string, string>(Result.Ok(total), label)
+  let fallback: string = result_unwrap_or<string, string>(Result.Err("missing"), "fallback")
+  let pair: Pair<int, string> = Pair {first: total, second: result_unwrap_or(labeled, "none")}
+  println(mapped[2])
+  println(filtered[1])
+  println(total)
+  println(fallback)
+  println(pair.first)
+  println(pair.second)
+}

--- a/crates/harn-cli/src/commands/check/bundle.rs
+++ b/crates/harn-cli/src/commands/check/bundle.rs
@@ -244,7 +244,7 @@ fn scan_node_bundle(
                 scan_program_bundle(&import_path, &import_program, config, visited, manifest);
             }
         }
-        Node::FunctionCall { name, args } if name == "render" || name == "render_prompt" => {
+        Node::FunctionCall { name, args, .. } if name == "render" || name == "render_prompt" => {
             if let Some(template_path) = args.first().and_then(literal_string) {
                 let candidates = resolve_preflight_target(file_path, &template_path, config);
                 manifest.add_asset(
@@ -258,7 +258,7 @@ fn scan_node_bundle(
             let children = args.iter().collect::<Vec<_>>();
             scan_children_bundle(&children, file_path, config, visited, manifest);
         }
-        Node::FunctionCall { name, args } if name == "host_call" => {
+        Node::FunctionCall { name, args, .. } if name == "host_call" => {
             if let Some((cap, op, params_arg)) = parse_host_call_args(args) {
                 manifest.add_host_capability(&cap, &op);
                 if cap == "template" && op == "render" {
@@ -278,7 +278,7 @@ fn scan_node_bundle(
             let children = args.iter().collect::<Vec<_>>();
             scan_children_bundle(&children, file_path, config, visited, manifest);
         }
-        Node::FunctionCall { name, args } if name == "exec_at" || name == "shell_at" => {
+        Node::FunctionCall { name, args, .. } if name == "exec_at" || name == "shell_at" => {
             if let Some(dir) = args.first().and_then(literal_string) {
                 manifest.execution_dirs.insert(
                     resolve_source_relative(file_path, &dir)
@@ -289,7 +289,7 @@ fn scan_node_bundle(
             let children = args.iter().collect::<Vec<_>>();
             scan_children_bundle(&children, file_path, config, visited, manifest);
         }
-        Node::FunctionCall { name, args } if name == "spawn_agent" => {
+        Node::FunctionCall { name, args, .. } if name == "spawn_agent" => {
             if let Some(config_node) = args.first() {
                 collect_spawn_agent_bundle(config_node, file_path, manifest);
             }

--- a/crates/harn-cli/src/commands/check/mock_host.rs
+++ b/crates/harn-cli/src/commands/check/mock_host.rs
@@ -348,7 +348,7 @@ fn collect_mock_host_capabilities_from_node(
                 }
             }
         }
-        Node::FunctionCall { name, args } => {
+        Node::FunctionCall { name, args, .. } => {
             if name == "host_mock" {
                 if let (Some(Node::StringLiteral(cap)), Some(Node::StringLiteral(op))) = (
                     args.first().map(|arg| &arg.node),

--- a/crates/harn-cli/src/commands/check/preflight.rs
+++ b/crates/harn-cli/src/commands/check/preflight.rs
@@ -164,7 +164,7 @@ fn collect_static_tool_surface_from_node(
     tool_search_active: &mut bool,
 ) {
     match &node.node {
-        Node::FunctionCall { name, args } if name == "tool_define" => {
+        Node::FunctionCall { name, args, .. } if name == "tool_define" => {
             if let Some(tool_name) = args.get(1).and_then(literal_string) {
                 let defer_loading = args
                     .get(3)
@@ -184,7 +184,7 @@ fn collect_static_tool_surface_from_node(
                 );
             }
         }
-        Node::FunctionCall { name, args } if name == "render_prompt" => {
+        Node::FunctionCall { name, args, .. } if name == "render_prompt" => {
             if let Some(target) = args.first().and_then(literal_template_path) {
                 prompt_targets.push(target);
             }
@@ -197,7 +197,7 @@ fn collect_static_tool_surface_from_node(
                 );
             }
         }
-        Node::FunctionCall { name, args } if name == "agent_loop" || name == "llm_call" => {
+        Node::FunctionCall { name, args, .. } if name == "agent_loop" || name == "llm_call" => {
             if args
                 .get(2)
                 .and_then(|options| dict_literal_field(options, "tool_search"))
@@ -704,7 +704,7 @@ fn scan_node_preflight(
                 }),
             }
         }
-        Node::FunctionCall { name, args } if name == "render" || name == "render_prompt" => {
+        Node::FunctionCall { name, args, .. } if name == "render" || name == "render_prompt" => {
             if let Some(template_path) = args.first().and_then(literal_template_path) {
                 if let Some(asset_ref) = harn_modules::asset_paths::parse(&template_path) {
                     let anchor = file_path.parent().unwrap_or(Path::new("."));
@@ -763,7 +763,7 @@ fn scan_node_preflight(
                 }
             }
         }
-        Node::FunctionCall { name, args } if name == "exec_at" || name == "shell_at" => {
+        Node::FunctionCall { name, args, .. } if name == "exec_at" || name == "shell_at" => {
             if let Some(dir) = args.first().and_then(literal_string) {
                 let resolved = resolve_source_relative(file_path, &dir);
                 if !resolved.is_dir() {
@@ -785,7 +785,7 @@ fn scan_node_preflight(
                 }
             }
         }
-        Node::FunctionCall { name, args } if name == "spawn_agent" => {
+        Node::FunctionCall { name, args, .. } if name == "spawn_agent" => {
             if let Some(agent_config) = args.first() {
                 scan_spawn_agent_preflight(agent_config, file_path, source, diagnostics);
             }
@@ -799,7 +799,7 @@ fn scan_node_preflight(
                 diagnostics,
             );
         }
-        Node::FunctionCall { name, args } if name == "host_invoke" => {
+        Node::FunctionCall { name, args, .. } if name == "host_invoke" => {
             diagnostics.push(PreflightDiagnostic {
                 path: file_path.display().to_string(),
                 source: source.to_string(),
@@ -821,7 +821,7 @@ fn scan_node_preflight(
                 diagnostics,
             );
         }
-        Node::FunctionCall { name, args } if name == "tool_define" => {
+        Node::FunctionCall { name, args, .. } if name == "tool_define" => {
             // harn#743: when a tool declares `executor: "host_bridge"`,
             // its `host_capability` must point at a real host operation
             // — otherwise the model gets a tool whose dispatch will
@@ -846,7 +846,7 @@ fn scan_node_preflight(
                 diagnostics,
             );
         }
-        Node::FunctionCall { name, args } if name == "host_call" => {
+        Node::FunctionCall { name, args, .. } if name == "host_call" => {
             if let Some((cap, op, params_arg)) = parse_host_call_args(args) {
                 if !is_known_host_operation(host_capabilities, &cap, &op) {
                     diagnostics.push(PreflightDiagnostic {

--- a/crates/harn-fmt/src/formatter/expressions.rs
+++ b/crates/harn-fmt/src/formatter/expressions.rs
@@ -100,9 +100,26 @@ impl Formatter<'_> {
                     format!("try* {expr}")
                 }
             }
-            Node::FunctionCall { name, args } => {
-                let args_str = self.format_call_args(args, name.len() + 1, indent);
-                format!("{name}({args_str})")
+            Node::FunctionCall {
+                name,
+                type_args,
+                args,
+            } => {
+                let type_args_str = if type_args.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        "<{}>",
+                        type_args
+                            .iter()
+                            .map(format_type_expr)
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                };
+                let args_str =
+                    self.format_call_args(args, name.len() + type_args_str.len() + 1, indent);
+                format!("{name}{type_args_str}({args_str})")
             }
             Node::MethodCall {
                 object,
@@ -478,6 +495,7 @@ impl Formatter<'_> {
                     let escaped = escape_string(desc);
                     effective_body.push(harn_parser::Spanned::dummy(Node::FunctionCall {
                         name: "description".to_string(),
+                        type_args: Vec::new(),
                         args: vec![harn_parser::Spanned::dummy(Node::StringLiteral(escaped))],
                     }));
                 }

--- a/crates/harn-fmt/src/formatter/statements.rs
+++ b/crates/harn-fmt/src/formatter/statements.rs
@@ -94,6 +94,7 @@ impl Formatter<'_> {
                     let escaped = escape_string(desc);
                     effective_body.push(harn_parser::Spanned::dummy(Node::FunctionCall {
                         name: "description".to_string(),
+                        type_args: Vec::new(),
                         args: vec![harn_parser::Spanned::dummy(Node::StringLiteral(escaped))],
                     }));
                 }

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -29,6 +29,13 @@ fn test_roundtrip_fn_decl() {
 }
 
 #[test]
+fn test_roundtrip_explicit_generic_call_type_args() {
+    assert_roundtrip(
+        "pipeline default(task) { fn id<T>(x: T) -> T { return x }\nlet x = id<int>(1) }",
+    );
+}
+
+#[test]
 fn test_roundtrip_closure() {
     assert_roundtrip("pipeline default(task) { let f = { x -> x * 2 }\nlog(f(3)) }");
 }

--- a/crates/harn-ir/src/lib.rs
+++ b/crates/harn-ir/src/lib.rs
@@ -1032,7 +1032,7 @@ impl<'a> HandlerIrBuilder<'a> {
 
     fn build_expr(&mut self, node: &SNode, incoming: Vec<NodeId>) -> Vec<NodeId> {
         match &node.node {
-            Node::FunctionCall { name, args } => {
+            Node::FunctionCall { name, args, .. } => {
                 self.build_function_call(node, name, args, incoming)
             }
             Node::MethodCall { object, args, .. }

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -604,7 +604,7 @@ impl<'a> Linter<'a> {
 
     fn node_calls_cancel_handle(node: &SNode) -> bool {
         match &node.node {
-            Node::FunctionCall { name, args } => {
+            Node::FunctionCall { name, args, .. } => {
                 name == "cancel_handle"
                     || matches!(
                         (
@@ -714,7 +714,7 @@ impl<'a> Linter<'a> {
 
     fn analyze_secret_scan_expr(&mut self, node: &SNode, scanned: bool) -> bool {
         match &node.node {
-            Node::FunctionCall { name, args } => {
+            Node::FunctionCall { name, args, .. } => {
                 let mut state = scanned;
                 for arg in args {
                     state = self.analyze_secret_scan_expr(arg, state);

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -234,7 +234,7 @@ impl<'a> Linter<'a> {
                 self.function_references.insert(name.clone());
             }
 
-            Node::FunctionCall { name, args } => {
+            Node::FunctionCall { name, args, .. } => {
                 self.references.insert(name.clone());
                 self.function_references.insert(name.clone());
                 self.function_calls.push((name.clone(), snode.span));
@@ -1144,6 +1144,7 @@ fn expr_has_known_type(node: &Node, cast: &str) -> bool {
     if let Node::FunctionCall {
         name: inner_name,
         args: inner_args,
+        ..
     } = node
     {
         if inner_name == cast && inner_args.len() == 1 {

--- a/crates/harn-lsp/src/handlers/definition.rs
+++ b/crates/harn-lsp/src/handlers/definition.rs
@@ -262,7 +262,7 @@ fn find_render_string_at_offset(program: &[SNode], offset: usize) -> Option<(Str
 }
 
 fn find_render_string_in_node(node: &SNode, offset: usize) -> Option<(String, Span)> {
-    if let Node::FunctionCall { name, args } = &node.node {
+    if let Node::FunctionCall { name, args, .. } = &node.node {
         if (name == "render" || name == "render_prompt") && !args.is_empty() {
             if let Node::StringLiteral(value) = &args[0].node {
                 let span = args[0].span;

--- a/crates/harn-lsp/src/references.rs
+++ b/crates/harn-lsp/src/references.rs
@@ -17,7 +17,7 @@ fn collect_references(snode: &SNode, target_name: &str, refs: &mut Vec<Span>) {
         Node::Identifier(name) if name == target_name => {
             refs.push(snode.span);
         }
-        Node::FunctionCall { name, args } => {
+        Node::FunctionCall { name, args, .. } => {
             if name == target_name {
                 refs.push(snode.span);
             }

--- a/crates/harn-parser/src/ast.rs
+++ b/crates/harn-parser/src/ast.rs
@@ -295,6 +295,7 @@ pub enum Node {
 
     FunctionCall {
         name: String,
+        type_args: Vec<TypeExpr>,
         args: Vec<SNode>,
     },
     MethodCall {

--- a/crates/harn-parser/src/parser/expressions.rs
+++ b/crates/harn-parser/src/parser/expressions.rs
@@ -457,6 +457,34 @@ impl Parser {
                     },
                     dict.span,
                 );
+            } else if self.check(&TokenKind::Lt) && matches!(expr.node, Node::Identifier(_)) {
+                let saved_pos = self.pos;
+                let start = expr.span;
+                self.advance();
+                let parsed_type_args = self.parse_type_arg_list();
+                if let Ok(type_args) = parsed_type_args {
+                    if self.check(&TokenKind::LParen) {
+                        self.advance();
+                        let args = self.parse_arg_list()?;
+                        self.consume(&TokenKind::RParen, ")")?;
+                        if let Node::Identifier(name) = expr.node {
+                            expr = spanned(
+                                Node::FunctionCall {
+                                    name,
+                                    type_args,
+                                    args,
+                                },
+                                Span::merge(start, self.prev_span()),
+                            );
+                        }
+                    } else {
+                        self.pos = saved_pos;
+                        break;
+                    }
+                } else {
+                    self.pos = saved_pos;
+                    break;
+                }
             } else if self.check(&TokenKind::LParen) && matches!(expr.node, Node::Identifier(_)) {
                 let start = expr.span;
                 self.advance();
@@ -464,7 +492,11 @@ impl Parser {
                 self.consume(&TokenKind::RParen, ")")?;
                 if let Node::Identifier(name) = expr.node {
                     expr = spanned(
-                        Node::FunctionCall { name, args },
+                        Node::FunctionCall {
+                            name,
+                            type_args: Vec::new(),
+                            args,
+                        },
                         Span::merge(start, self.prev_span()),
                     );
                 }

--- a/crates/harn-parser/src/parser/mod.rs
+++ b/crates/harn-parser/src/parser/mod.rs
@@ -193,6 +193,56 @@ enum Option<T> {
     }
 
     #[test]
+    fn parses_explicit_generic_call_type_args() {
+        let source = r#"
+pipeline test(task) {
+  let n = identity<int>(42)
+  let words = identity<[string]>(["a"])
+}
+"#;
+
+        let program = parse_source(source).expect("should parse");
+        let pipeline = program
+            .iter()
+            .find(|node| matches!(node.node, Node::Pipeline { .. }))
+            .expect("pipeline node");
+        let body = match &pipeline.node {
+            Node::Pipeline { body, .. } => body,
+            _ => unreachable!(),
+        };
+        assert!(matches!(
+            &body[0].node,
+            Node::LetBinding { value, .. }
+                if matches!(
+                    &value.node,
+                    Node::FunctionCall { name, type_args, .. }
+                        if name == "identity" && type_args == &vec![TypeExpr::Named("int".into())]
+                )
+        ));
+        assert!(matches!(
+            &body[1].node,
+            Node::LetBinding { value, .. }
+                if matches!(
+                    &value.node,
+                    Node::FunctionCall { name, type_args, .. }
+                        if name == "identity"
+                            && type_args == &vec![TypeExpr::List(Box::new(TypeExpr::Named("string".into())))]
+                )
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_generic_call_type_args() {
+        let source = r#"
+pipeline test(task) {
+  let n = identity<>(42)
+}
+"#;
+
+        assert!(parse_source(source).is_err());
+    }
+
+    #[test]
     fn parses_struct_literal_syntax_for_known_structs() {
         let source = r#"
 struct Point {

--- a/crates/harn-parser/src/parser/types.rs
+++ b/crates/harn-parser/src/parser/types.rs
@@ -26,6 +26,27 @@ impl Parser {
         Ok(params)
     }
 
+    /// Parse a comma-separated type argument list after the opening `<`.
+    pub(super) fn parse_type_arg_list(&mut self) -> Result<Vec<TypeExpr>, ParserError> {
+        let mut args = Vec::new();
+        self.skip_newlines();
+        if self.check(&TokenKind::Gt) {
+            return Err(self.error("type argument"));
+        }
+        while !self.is_at_end() && !self.check(&TokenKind::Gt) {
+            args.push(self.parse_type_expr()?);
+            self.skip_newlines();
+            if self.check(&TokenKind::Comma) {
+                self.advance();
+                self.skip_newlines();
+            } else {
+                break;
+            }
+        }
+        self.consume(&TokenKind::Gt, ">")?;
+        Ok(args)
+    }
+
     /// Consume an optional `in` / `out` variance marker at the start
     /// of a type parameter. `in` is a reserved keyword and so is
     /// always a marker when it appears here. `out` is a contextual
@@ -108,6 +129,12 @@ impl Parser {
         if self.check(&TokenKind::LBrace) {
             return self.parse_shape_type();
         }
+        if self.check(&TokenKind::LBracket) {
+            self.advance();
+            let inner = self.parse_type_expr()?;
+            self.consume(&TokenKind::RBracket, "]")?;
+            return Ok(TypeExpr::List(Box::new(inner)));
+        }
         if let Some(tok) = self.current() {
             match &tok.kind {
                 TokenKind::Nil => {
@@ -167,12 +194,7 @@ impl Parser {
         }
         if self.check(&TokenKind::Lt) {
             self.advance();
-            let mut type_args = vec![self.parse_type_expr()?];
-            while self.check(&TokenKind::Comma) {
-                self.advance();
-                type_args.push(self.parse_type_expr()?);
-            }
-            self.consume(&TokenKind::Gt, ">")?;
+            let mut type_args = self.parse_type_arg_list()?;
             if name == "list" && type_args.len() == 1 {
                 return Ok(TypeExpr::List(Box::new(type_args.remove(0))));
             } else if name == "dict" && type_args.len() == 2 {

--- a/crates/harn-parser/src/typechecker/inference/calls.rs
+++ b/crates/harn-parser/src/typechecker/inference/calls.rs
@@ -29,7 +29,14 @@ impl TypeChecker {
         concrete: &TypeExpr,
         bindings: &mut BTreeMap<String, TypeExpr>,
     ) -> Result<(), String> {
+        if Self::is_wildcard_type(concrete) {
+            return Ok(());
+        }
         if let Some(existing) = bindings.get(param_name) {
+            if Self::is_wildcard_type(existing) {
+                bindings.insert(param_name.to_string(), concrete.clone());
+                return Ok(());
+            }
             if existing != concrete {
                 return Err(format!(
                     "type parameter '{}' was inferred as both {} and {}",
@@ -362,7 +369,7 @@ impl TypeChecker {
     /// positions where `check_node` only triggers `infer_type`.
     pub(in crate::typechecker) fn visit_for_deprecation(&mut self, node: &SNode) {
         match &node.node {
-            Node::FunctionCall { name, args } => {
+            Node::FunctionCall { name, args, .. } => {
                 if let Some((since, use_hint)) = self.deprecated_fns.get(name).cloned() {
                     let mut msg = format!("`{name}` is deprecated");
                     if let Some(s) = since {
@@ -584,6 +591,7 @@ impl TypeChecker {
     pub(in crate::typechecker) fn check_call(
         &mut self,
         name: &str,
+        type_args: &[TypeExpr],
         args: &[SNode],
         scope: &mut TypeScope,
         span: Span,
@@ -704,6 +712,24 @@ impl TypeChecker {
         // Check against known function signatures
         let has_spread = args.iter().any(|a| matches!(&a.node, Node::Spread(_)));
         if let Some(sig) = scope.get_fn(name).cloned() {
+            if !type_args.is_empty() {
+                if sig.type_param_names.is_empty() {
+                    self.error_at(
+                        format!("Function '{}' does not declare type parameters", name),
+                        span,
+                    );
+                } else if type_args.len() != sig.type_param_names.len() {
+                    self.error_at(
+                        format!(
+                            "Function '{}' expects {} type arguments, got {}",
+                            name,
+                            sig.type_param_names.len(),
+                            type_args.len()
+                        ),
+                        span,
+                    );
+                }
+            }
             if !has_spread
                 && !is_builtin(name)
                 && !sig.has_rest
@@ -738,6 +764,11 @@ impl TypeChecker {
             let mut type_bindings: BTreeMap<String, TypeExpr> = BTreeMap::new();
             let type_param_set: std::collections::BTreeSet<String> =
                 sig.type_param_names.iter().cloned().collect();
+            if type_args.len() == sig.type_param_names.len() {
+                for (param_name, type_arg) in sig.type_param_names.iter().zip(type_args.iter()) {
+                    type_bindings.insert(param_name.clone(), type_arg.clone());
+                }
+            }
             for (arg, (_param_name, param_type)) in args.iter().zip(sig.params.iter()) {
                 if let Some(param_ty) = param_type {
                     if let Err(message) = self.bind_from_arg_node(
@@ -804,6 +835,28 @@ impl TypeChecker {
                         }
                     }
                 }
+            }
+        } else if !type_args.is_empty() && is_builtin(name) {
+            if let Some(sig) = builtin_signatures::lookup_generic_builtin_sig(name) {
+                if type_args.len() != sig.type_params.len() {
+                    self.error_at(
+                        format!(
+                            "Builtin function '{}' expects {} type arguments, got {}",
+                            name,
+                            sig.type_params.len(),
+                            type_args.len()
+                        ),
+                        span,
+                    );
+                }
+            } else {
+                self.error_at(
+                    format!(
+                        "Builtin function '{}' does not declare type parameters",
+                        name
+                    ),
+                    span,
+                );
             }
         }
         // Check args recursively

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -191,7 +191,11 @@ impl TypeChecker {
                 None
             }
 
-            Node::FunctionCall { name, args } => {
+            Node::FunctionCall {
+                name,
+                type_args,
+                args,
+            } => {
                 if name == "schema_of" && args.len() == 1 {
                     if let Node::Identifier(alias) = &args[0].node {
                         if let Some(resolved) = scope.resolve_type(alias) {
@@ -243,6 +247,12 @@ impl TypeChecker {
                         let mut bindings = BTreeMap::new();
                         let type_param_set: std::collections::BTreeSet<String> =
                             sig.type_param_names.iter().cloned().collect();
+                        if type_args.len() == sig.type_param_names.len() {
+                            for (param_name, type_arg) in sig.type_param_names.iter().zip(type_args)
+                            {
+                                bindings.insert(param_name.clone(), type_arg.clone());
+                            }
+                        }
                         for (arg, (_param_name, param_type)) in args.iter().zip(sig.params.iter()) {
                             if let Some(param_ty) = param_type {
                                 let _ = self.bind_from_arg_node(
@@ -268,6 +278,11 @@ impl TypeChecker {
                     let type_param_set: std::collections::BTreeSet<String> =
                         sig.type_params.iter().cloned().collect();
                     let mut bindings: BTreeMap<String, TypeExpr> = BTreeMap::new();
+                    if type_args.len() == sig.type_params.len() {
+                        for (param_name, type_arg) in sig.type_params.iter().zip(type_args) {
+                            bindings.insert(param_name.clone(), type_arg.clone());
+                        }
+                    }
                     for (arg, param_ty) in args.iter().zip(sig.params.iter()) {
                         let _ = self.bind_from_arg_node(
                             param_ty,

--- a/crates/harn-parser/src/typechecker/inference/flow.rs
+++ b/crates/harn-parser/src/typechecker/inference/flow.rs
@@ -196,7 +196,7 @@ impl TypeChecker {
                 Self::extract_has_refinements(object, args, scope)
             }
 
-            Node::FunctionCall { name, args }
+            Node::FunctionCall { name, args, .. }
                 if (name == "schema_is" || name == "is_type") && args.len() == 2 =>
             {
                 Self::extract_schema_refinements(args, scope)

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -322,8 +322,12 @@ impl TypeChecker {
                 scope.clear_nil_widenable(name);
             }
 
-            Node::FunctionCall { name, args } => {
-                self.check_call(name, args, scope, span);
+            Node::FunctionCall {
+                name,
+                type_args,
+                args,
+            } => {
+                self.check_call(name, type_args, args, scope, span);
                 // Strict types: schema_expect clears untyped source status
                 if self.strict_types && name == "schema_expect" && args.len() >= 2 {
                     if let Node::Identifier(var_name) = &args[0].node {
@@ -348,7 +352,7 @@ impl TypeChecker {
                 // Strict types: schema_is/is_type in condition clears
                 // untyped source in then-branch
                 if self.strict_types {
-                    if let Node::FunctionCall { name, args } = &condition.node {
+                    if let Node::FunctionCall { name, args, .. } = &condition.node {
                         if (name == "schema_is" || name == "is_type") && args.len() == 2 {
                             if let Node::Identifier(var_name) = &args[0].node {
                                 then_scope.clear_untyped_source(var_name);
@@ -932,7 +936,7 @@ impl TypeChecker {
             Node::PropertyAccess { object, .. } | Node::OptionalPropertyAccess { object, .. } => {
                 if self.strict_types {
                     // Direct property access on boundary function result
-                    if let Node::FunctionCall { name, args } = &object.node {
+                    if let Node::FunctionCall { name, args, .. } = &object.node {
                         if builtin_signatures::is_untyped_boundary_source(name) {
                             let has_schema = (name == "llm_call" || name == "llm_completion")
                                 && Self::llm_call_has_typed_schema_option(args, scope);
@@ -967,7 +971,7 @@ impl TypeChecker {
             Node::SubscriptAccess { object, index }
             | Node::OptionalSubscriptAccess { object, index } => {
                 if self.strict_types {
-                    if let Node::FunctionCall { name, args } = &object.node {
+                    if let Node::FunctionCall { name, args, .. } = &object.node {
                         if builtin_signatures::is_untyped_boundary_source(name) {
                             let has_schema = (name == "llm_call" || name == "llm_completion")
                                 && Self::llm_call_has_typed_schema_option(args, scope);

--- a/crates/harn-parser/src/typechecker/mod.rs
+++ b/crates/harn-parser/src/typechecker/mod.rs
@@ -203,7 +203,7 @@ impl TypeChecker {
         scope: &TypeScope,
     ) -> Option<String> {
         match &value.node {
-            Node::FunctionCall { name, args } => {
+            Node::FunctionCall { name, args, .. } => {
                 if !builtin_signatures::is_untyped_boundary_source(name) {
                     return None;
                 }

--- a/crates/harn-parser/src/typechecker/schema_inference.rs
+++ b/crates/harn-parser/src/typechecker/schema_inference.rs
@@ -32,7 +32,7 @@ pub(super) fn schema_type_expr_from_node(node: &SNode, scope: &TypeScope) -> Opt
         // dict for a type alias. When its result is passed into a position
         // typed `Schema<T>`, we resolve the underlying alias to its
         // TypeExpr so the generic binding can extract `T`.
-        Node::FunctionCall { name, args } if name == "schema_of" && args.len() == 1 => {
+        Node::FunctionCall { name, args, .. } if name == "schema_of" && args.len() == 1 => {
             if let Node::Identifier(alias) = &args[0].node {
                 return scope.resolve_type(alias).cloned();
             }

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -340,6 +340,39 @@ fn test_generic_return_type_instantiates_from_callsite() {
 }
 
 #[test]
+fn test_explicit_generic_call_type_args_are_checked() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  fn identity<T>(x: T) -> T { return x }
+  let n: int = identity<int>(42)
+  let words: [string] = identity<[string]>(["a", "b"])
+}"#,
+    );
+    assert!(errs.is_empty(), "unexpected type errors: {errs:?}");
+}
+
+#[test]
+fn test_explicit_generic_call_type_args_must_match_arguments() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  fn identity<T>(x: T) -> T { return x }
+  let n: int = identity<int>("oops")
+}"#,
+    );
+    assert_eq!(errs.len(), 2, "expected 2 errors, got: {errs:?}");
+    assert!(
+        errs.iter()
+            .any(|err| err.contains("type parameter 'T' was inferred as both int and string")),
+        "missing explicit type binding conflict error: {errs:?}"
+    );
+    assert!(
+        errs.iter()
+            .any(|err| err.contains("expected int, got string")),
+        "missing explicit type-arg mismatch error: {errs:?}"
+    );
+}
+
+#[test]
 fn test_generic_type_param_must_bind_consistently() {
     let errs = errors(
         r#"pipeline t(task) {

--- a/crates/harn-parser/src/typechecker/union.rs
+++ b/crates/harn-parser/src/typechecker/union.rs
@@ -54,7 +54,7 @@ pub(super) fn narrow_to_single(members: &[TypeExpr], target: &str) -> InferredTy
 
 /// Extract the variable name from a `type_of(x)` call.
 pub(super) fn extract_type_of_var(node: &SNode) -> Option<String> {
-    if let Node::FunctionCall { name, args } = &node.node {
+    if let Node::FunctionCall { name, args, .. } = &node.node {
         if name == "type_of" && args.len() == 1 {
             if let Node::Identifier(var) = &args[0].node {
                 return Some(var.clone());

--- a/crates/harn-vm/src/compiler/mod.rs
+++ b/crates/harn-vm/src/compiler/mod.rs
@@ -200,7 +200,7 @@ impl Compiler {
                 self.compile_node(false_expr)?;
                 self.chunk.patch_jump(end_jump);
             }
-            Node::FunctionCall { name, args } => {
+            Node::FunctionCall { name, args, .. } => {
                 self.compile_function_call(name, args)?;
             }
             Node::MethodCall {

--- a/crates/harn-vm/src/compiler/pipe.rs
+++ b/crates/harn-vm/src/compiler/pipe.rs
@@ -25,8 +25,13 @@ pub(super) fn contains_pipe_placeholder(node: &SNode) -> bool {
 pub(super) fn replace_pipe_placeholder(node: &SNode) -> SNode {
     let new_node = match &node.node {
         Node::Identifier(name) if name == "_" => Node::Identifier("__pipe".into()),
-        Node::FunctionCall { name, args } => Node::FunctionCall {
+        Node::FunctionCall {
+            name,
+            type_args,
+            args,
+        } => Node::FunctionCall {
             name: name.clone(),
+            type_args: type_args.clone(),
             args: args.iter().map(replace_pipe_placeholder).collect(),
         },
         Node::MethodCall {

--- a/crates/harn-vm/src/compiler/statements.rs
+++ b/crates/harn-vm/src/compiler/statements.rs
@@ -208,7 +208,7 @@ impl Compiler {
         } else {
             // No pending finally — use tail-call optimization when possible.
             if let Some(val) = value {
-                if let Node::FunctionCall { name, args } = &val.node {
+                if let Node::FunctionCall { name, args, .. } = &val.node {
                     let name_idx = self.chunk.add_constant(Constant::String(name.clone()));
                     self.chunk.emit_u16(Op::Constant, name_idx, self.line);
                     for arg in args {

--- a/crates/harn-wasm/src/lib.rs
+++ b/crates/harn-wasm/src/lib.rs
@@ -436,7 +436,7 @@ impl SyncInterpreter {
                 self.env.define(name, closure, false);
                 Ok(Val::Nil)
             }
-            Node::FunctionCall { name, args } => {
+            Node::FunctionCall { name, args, .. } => {
                 if let Some(Val::Closure(params, body, cenv)) = self.env.get(name) {
                     let arg_vals: Result<Vec<_>, _> = args.iter().map(|a| self.eval(a)).collect();
                     return self.invoke_closure(&params, &body, &cenv, &arg_vals?);

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -436,7 +436,8 @@ select_expr        ::= 'select' '{'
 break_stmt         ::= 'break'
 continue_stmt      ::= 'continue'
 
-generic_params     ::= '<' IDENTIFIER (',' IDENTIFIER)* '>'
+generic_params     ::= '<' generic_param (',' generic_param)* '>'
+generic_param      ::= ['in' | 'out'] IDENTIFIER
 where_clause       ::= 'where' IDENTIFIER ':' IDENTIFIER
                        (',' IDENTIFIER ':' IDENTIFIER)*
 
@@ -444,6 +445,14 @@ fn_param_list      ::= (fn_param (',' fn_param)*)? [',' rest_param]
                      | rest_param
 fn_param           ::= IDENTIFIER [':' type_expr] ['=' expression]
 rest_param         ::= '...' IDENTIFIER
+type_expr          ::= IDENTIFIER
+                     | IDENTIFIER '<' type_expr (',' type_expr)* '>'
+                     | '[' type_expr ']'
+                     | 'fn' '(' [type_expr (',' type_expr)*] ')' '->' type_expr
+                     | '{' shape_field (',' shape_field)* '}'
+                     | type_expr '|' type_expr
+                     | STRING_LITERAL
+                     | INT_LITERAL
 
 A rest parameter (`...name`) must be the last parameter in the list. At call
 time, any arguments beyond the positional parameters are collected into a list
@@ -523,7 +532,9 @@ subscript_access   ::= '[' expression ']'
 optional_subscript_access
                     ::= '?[' expression ']'
 slice_access       ::= '[' [expression] ':' [expression] ']'
-call               ::= '(' arg_list ')'    (* only when postfix base is an identifier *)
+call               ::= [type_args] '(' arg_list ')'
+                       (* only when postfix base is an identifier *)
+type_args          ::= '<' type_expr (',' type_expr)* '>'
 try_unwrap         ::= '?'                 (* expr? on Result *)
 ```
 
@@ -2928,8 +2939,24 @@ into the matching branch.
 
 ```harn
 let numbers: list<int> = [1, 2, 3]
+let also_numbers: [int] = [1, 2, 3]
 let headers: dict<string, string> = {content_type: "json"}
 ```
+
+`[T]` is shorthand for `list<T>` in type positions. User-defined functions,
+structs, enums, interfaces, and type aliases may declare type parameters with
+`<T, U>`. Function calls normally infer those parameters from arguments, but
+callers may pass them explicitly when inference needs help or when the desired
+instantiation should be documented at the call site:
+
+```harn,ignore
+fn map<T, U>(xs: [T], f: fn(T) -> U) -> [U] { ... }
+let labels: [string] = map<int, string>([1, 2, 3], label)
+```
+
+Explicit type arguments are erased at runtime. They are checked statically:
+the number of supplied type arguments must match the function declaration, and
+each explicit binding must remain consistent with the concrete argument types.
 
 ### Structural types (shapes)
 

--- a/docs/src/scripting-cheatsheet.md
+++ b/docs/src/scripting-cheatsheet.md
@@ -76,7 +76,7 @@ let body = if len(content) > 2400 {
 }
 ```
 
-## Streams
+## Stream Operators
 
 `stream.*` accepts lists, ranges, channels, generators, and lazy
 `iter(...)` values. Operators stay lazy until a sink such as
@@ -166,7 +166,7 @@ let results = parallel settle paths with { max_concurrent: 4 } { p ->
 `concurrency.md` for the RPM rate limiter, channels, `select`,
 `deadline`, and `defer`.
 
-## Streams
+## Stream Generators
 
 Use `gen fn` plus `emit` for lazy script-level streams:
 

--- a/spec/AST.md
+++ b/spec/AST.md
@@ -445,13 +445,16 @@ Yields control to the host, optionally with a value.
 ### `FunctionCall`
 
 ```rust
-FunctionCall { name: String, args: Vec<SNode> }
+FunctionCall { name: String, type_args: Vec<TypeExpr>, args: Vec<SNode> }
 ```
 
-Calls a function or builtin by name. Arguments may include `Spread` nodes.
+Calls a function or builtin by name. `type_args` stores explicit generic
+instantiations such as `identity<int>(value)` and is empty for inferred calls.
+Arguments may include `Spread` nodes.
 
 ```harn
 read_file("config.json")
+identity<int>(42)
 add(...args)
 ```
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -434,7 +434,8 @@ select_expr        ::= 'select' '{'
 break_stmt         ::= 'break'
 continue_stmt      ::= 'continue'
 
-generic_params     ::= '<' IDENTIFIER (',' IDENTIFIER)* '>'
+generic_params     ::= '<' generic_param (',' generic_param)* '>'
+generic_param      ::= ['in' | 'out'] IDENTIFIER
 where_clause       ::= 'where' IDENTIFIER ':' IDENTIFIER
                        (',' IDENTIFIER ':' IDENTIFIER)*
 
@@ -442,6 +443,14 @@ fn_param_list      ::= (fn_param (',' fn_param)*)? [',' rest_param]
                      | rest_param
 fn_param           ::= IDENTIFIER [':' type_expr] ['=' expression]
 rest_param         ::= '...' IDENTIFIER
+type_expr          ::= IDENTIFIER
+                     | IDENTIFIER '<' type_expr (',' type_expr)* '>'
+                     | '[' type_expr ']'
+                     | 'fn' '(' [type_expr (',' type_expr)*] ')' '->' type_expr
+                     | '{' shape_field (',' shape_field)* '}'
+                     | type_expr '|' type_expr
+                     | STRING_LITERAL
+                     | INT_LITERAL
 
 A rest parameter (`...name`) must be the last parameter in the list. At call
 time, any arguments beyond the positional parameters are collected into a list
@@ -521,7 +530,9 @@ subscript_access   ::= '[' expression ']'
 optional_subscript_access
                     ::= '?[' expression ']'
 slice_access       ::= '[' [expression] ':' [expression] ']'
-call               ::= '(' arg_list ')'    (* only when postfix base is an identifier *)
+call               ::= [type_args] '(' arg_list ')'
+                       (* only when postfix base is an identifier *)
+type_args          ::= '<' type_expr (',' type_expr)* '>'
 try_unwrap         ::= '?'                 (* expr? on Result *)
 ```
 
@@ -2926,8 +2937,24 @@ into the matching branch.
 
 ```harn
 let numbers: list<int> = [1, 2, 3]
+let also_numbers: [int] = [1, 2, 3]
 let headers: dict<string, string> = {content_type: "json"}
 ```
+
+`[T]` is shorthand for `list<T>` in type positions. User-defined functions,
+structs, enums, interfaces, and type aliases may declare type parameters with
+`<T, U>`. Function calls normally infer those parameters from arguments, but
+callers may pass them explicitly when inference needs help or when the desired
+instantiation should be documented at the call site:
+
+```harn,ignore
+fn map<T, U>(xs: [T], f: fn(T) -> U) -> [U] { ... }
+let labels: [string] = map<int, string>([1, 2, 3], label)
+```
+
+Explicit type arguments are erased at runtime. They are checked statically:
+the number of supplied type arguments must match the function declaration, and
+each explicit binding must remain consistent with the concrete argument types.
 
 ### Structural types (shapes)
 

--- a/tree-sitter-harn/grammar.js
+++ b/tree-sitter-harn/grammar.js
@@ -17,6 +17,7 @@ module.exports = grammar({
     [$.typed_parameter, $.shape_field],
     [$.parallel_expression],
     [$.typed_parameter, $.type_annotation],
+    [$.type_arguments, $.type_annotation],
     [$.block],
     [$.closure],
     [$.select_block],
@@ -490,6 +491,9 @@ module.exports = grammar({
         $.identifier
       ),
 
+    type_arguments: ($) =>
+      seq("<", commaSep1($.type_annotation), ">"),
+
     where_clause: ($) =>
       seq(
         "where",
@@ -614,6 +618,7 @@ module.exports = grammar({
             $.subscript_expression,
             $.parenthesized_expression
           )),
+          optional(field("type_arguments", $.type_arguments)),
           "(",
           repeat(lineBreak($)),
           optional($.argument_list),
@@ -957,6 +962,7 @@ module.exports = grammar({
     type_annotation: ($) =>
       choice(
         $.fn_type,
+        seq("[", $.type_annotation, "]"),
         seq($.identifier, "<", $.type_annotation, ",", $.type_annotation, ">"),
         seq($.identifier, "<", $.type_annotation, ">"),
         prec.left(1, seq($.type_annotation, "|", $.type_annotation)),

--- a/tree-sitter-harn/src/grammar.json
+++ b/tree-sitter-harn/src/grammar.json
@@ -3351,6 +3351,44 @@
         }
       ]
     },
+    "type_arguments": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_annotation"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "type_annotation"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        }
+      ]
+    },
     "where_clause": {
       "type": "SEQ",
       "members": [
@@ -4460,6 +4498,22 @@
                 }
               ]
             }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "type_arguments",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "type_arguments"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           },
           {
             "type": "STRING",
@@ -7294,6 +7348,23 @@
           "type": "SEQ",
           "members": [
             {
+              "type": "STRING",
+              "value": "["
+            },
+            {
+              "type": "SYMBOL",
+              "name": "type_annotation"
+            },
+            {
+              "type": "STRING",
+              "value": "]"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
               "type": "SYMBOL",
               "name": "identifier"
             },
@@ -7607,6 +7678,10 @@
     ],
     [
       "typed_parameter",
+      "type_annotation"
+    ],
+    [
+      "type_arguments",
       "type_annotation"
     ],
     [

--- a/tree-sitter-harn/src/node-types.json
+++ b/tree-sitter-harn/src/node-types.json
@@ -895,6 +895,16 @@
             "named": true
           }
         ]
+      },
+      "type_arguments": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_arguments",
+            "named": true
+          }
+        ]
       }
     },
     "children": {
@@ -10334,6 +10344,21 @@
           "type": "string_literal",
           "named": true
         },
+        {
+          "type": "type_annotation",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "type_arguments",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
         {
           "type": "type_annotation",
           "named": true

--- a/tree-sitter-harn/test/corpus/expressions.txt
+++ b/tree-sitter-harn/test/corpus/expressions.txt
@@ -1,4 +1,38 @@
 ==================
+Generic Call Type Arguments
+==================
+
+pipeline test(task) {
+  let mapped: [int] = map<int, string>([1], label)
+}
+
+---
+
+(source_file
+  (pipeline_declaration
+    name: (identifier)
+    (parameter_list
+      (typed_parameter
+        name: (identifier)))
+    (block
+      (let_binding
+        name: (identifier)
+        type: (type_annotation
+          (type_annotation
+            (identifier)))
+        value: (call_expression
+          function: (identifier)
+          type_arguments: (type_arguments
+            (type_annotation
+              (identifier))
+            (type_annotation
+              (identifier)))
+          (argument_list
+            (list_literal
+              (integer_literal))
+            (identifier)))))))
+
+==================
 Exponentiation Precedence
 ==================
 


### PR DESCRIPTION
## Summary
- add explicit generic call type arguments to the AST/parser/typechecker/formatter/compiler pipeline
- add `[T]` list shorthand in type positions and tree-sitter support for generic call syntax
- add end-to-end conformance for generic map/filter/fold, Result combinators, and a generic struct
- update the language spec mirror and AST docs

Closes #913.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-913 cargo check --workspace`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-913 cargo test -p harn-parser -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-913 cargo test -p harn-fmt test_roundtrip_explicit_generic_call_type_args -- --nocapture`
- `(cd tree-sitter-harn && npm test)`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-913 HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test conformance --filter types`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-913 make fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-913 make lint-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-913 make check-docs-snippets`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-913 make check-language-spec`
- pre-commit hook: rustfmt, Harn fmt/lint, clippy, language spec sync, markdown lint
- pre-push hook: nextest workspace suite (`2982 passed`), affected Harn fmt/lint, markdown lint

## Self-review
- tightened the shared type-argument parser to reject empty `<>` and added parser coverage for that edge case
- checked the erased-runtime path so explicit type arguments affect static checking/formatting/tree-sitter only, while compiler and pipe rewriting preserve/ignore them correctly
- reviewed generated docs/tree-sitter artifacts for sync with source grammar/spec changes