### PR TITLE
Harden Ollama streaming failures

### DIFF
--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -37,6 +37,7 @@ pub(crate) use errors::{
     classify_llm_error, classify_provider_http_error, LlmErrorInfo, LlmErrorKind, LlmErrorReason,
 };
 pub(crate) use ollama::apply_ollama_runtime_settings;
+pub(crate) use ollama::ollama_unload_grace_duration_from_env;
 pub use ollama::{
     normalize_ollama_keep_alive, ollama_readiness, ollama_runtime_settings_from_env,
     warm_ollama_model, warm_ollama_model_with_settings, OllamaReadinessOptions,
@@ -658,6 +659,31 @@ mod tests {
         }
     }
 
+    fn spawn_llm_stub_many<F>(label: &'static str, connections: usize, mut body: F) -> LlmStub
+    where
+        F: FnMut(usize, &mut std::net::TcpStream) + Send + 'static,
+    {
+        use std::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind llm stub");
+        let addr = listener.local_addr().expect("stub addr");
+        let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let shutdown_thread = shutdown.clone();
+        let handle = std::thread::spawn(move || {
+            for attempt in 0..connections {
+                let Some(mut stream) = accept_with_shutdown(&listener, label, &shutdown_thread)
+                else {
+                    return;
+                };
+                body(attempt, &mut stream);
+            }
+        });
+        LlmStub {
+            addr,
+            shutdown,
+            handle: Some(handle),
+        }
+    }
+
     fn spawn_ollama_stub() -> LlmStub {
         spawn_llm_stub("ollama stub", |stream| {
             use std::io::{Read, Write};
@@ -671,6 +697,36 @@ mod tests {
                 "{\"message\":{\"role\":\"assistant\",\"content\":\"world\"},\"done\":false}\n",
                 "{\"done\":true,\"prompt_eval_count\":3,\"eval_count\":2,\"model\":\"stub-model\"}\n"
             );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/x-ndjson\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+        })
+    }
+
+    fn spawn_ollama_empty_then_success_stub(
+        request_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    ) -> LlmStub {
+        spawn_llm_stub_many("ollama retry stub", 2, move |attempt, stream| {
+            use std::io::{Read, Write};
+            request_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let mut buf = vec![0u8; 8192];
+            let n = stream.read(&mut buf).expect("read request");
+            let request = String::from_utf8_lossy(&buf[..n]);
+            assert!(request.starts_with("POST /api/chat HTTP/1.1\r\n"));
+
+            let body = if attempt == 0 {
+                "{\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":true,\"prompt_eval_count\":5,\"eval_count\":3}\n"
+            } else {
+                concat!(
+                    "{\"message\":{\"role\":\"assistant\",\"content\":\"retried\"},\"done\":false,\"model\":\"stub-model\"}\n",
+                    "{\"done\":true,\"prompt_eval_count\":5,\"eval_count\":1,\"model\":\"stub-model\"}\n"
+                )
+            };
             let response = format!(
                 "HTTP/1.1 200 OK\r\ncontent-type: application/x-ndjson\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
                 body.len(),
@@ -883,6 +939,60 @@ mod tests {
             assert_eq!(result.input_tokens, 3);
             assert_eq!(result.output_tokens, 2);
             assert_eq!(deltas.join(""), "hello world");
+        });
+    }
+
+    #[test]
+    fn ollama_empty_content_done_frame_retries_once() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _allow_llm_transport = allow_stubbed_llm_transport();
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(2)
+            .build()
+            .expect("runtime");
+
+        runtime.block_on(async {
+            let request_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let server = spawn_ollama_empty_then_success_stub(request_count.clone());
+            let addr = server.addr();
+            let prev_ollama_host = std::env::var("OLLAMA_HOST").ok();
+            unsafe {
+                std::env::set_var("OLLAMA_HOST", format!("http://{addr}"));
+            }
+
+            let local = tokio::task::LocalSet::new();
+            let result = local
+                .run_until(async {
+                    let opts = base_opts("ollama");
+                    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+                    let result = tokio::time::timeout(
+                        std::time::Duration::from_secs(5),
+                        vm_call_llm_full_streaming_offthread(&opts, tx),
+                    )
+                    .await
+                    .expect("llm call timed out")
+                    .expect("retry should recover from empty done frame");
+
+                    let mut deltas = Vec::new();
+                    while let Ok(delta) = rx.try_recv() {
+                        deltas.push(delta);
+                    }
+                    (result, deltas)
+                })
+                .await;
+
+            match prev_ollama_host {
+                Some(value) => unsafe { std::env::set_var("OLLAMA_HOST", value) },
+                None => unsafe { std::env::remove_var("OLLAMA_HOST") },
+            }
+
+            drop(server);
+
+            let (result, deltas) = result;
+            assert_eq!(request_count.load(std::sync::atomic::Ordering::SeqCst), 2);
+            assert_eq!(result.text, "retried");
+            assert_eq!(deltas.join(""), "retried");
         });
     }
 

--- a/crates/harn-vm/src/llm/api/errors.rs
+++ b/crates/harn-vm/src/llm/api/errors.rs
@@ -80,6 +80,11 @@ pub(crate) fn classify_provider_http_error(
 ) -> LlmErrorInfo {
     let (kind, reason) = classify_http_status_and_body(status, body);
     let mut msg = format!("{provider} HTTP {status} [{}]: {body}", reason.legacy_tag());
+    if reason == LlmErrorReason::ContextOverflow {
+        if let Some(tokens) = extract_token_count_hint(body) {
+            msg.push_str(&format!(" (offending_tokens: {tokens})"));
+        }
+    }
     if let Some(ra) = retry_after {
         msg.push_str(&format!(" (retry-after: {ra})"));
     }
@@ -234,13 +239,39 @@ fn classify_error_message_taxonomy(msg: &str) -> Option<(LlmErrorKind, LlmErrorR
 fn is_context_overflow(lower: &str) -> bool {
     lower.contains("maximum context length")
         || lower.contains("context length")
+        || lower.contains("model context exceeded")
+        || lower.contains("context exceeded")
         || lower.contains("context_length_exceeded")
         || lower.contains("context_overflow")
         || lower.contains("prompt is too long")
         || lower.contains("prompt_tokens_exceeded")
         || lower.contains("this model's maximum context")
         || lower.contains("exceeds the maximum")
+        || (lower.contains("context") && lower.contains("exceed"))
         || (lower.contains("max_tokens") && lower.contains("exceed"))
+}
+
+fn extract_token_count_hint(body: &str) -> Option<u64> {
+    let mut max_number = None;
+    let mut current = String::new();
+    for ch in body.chars() {
+        if ch.is_ascii_digit() {
+            current.push(ch);
+            continue;
+        }
+        if !current.is_empty() {
+            if let Ok(parsed) = current.parse::<u64>() {
+                max_number = Some(max_number.map_or(parsed, |n: u64| n.max(parsed)));
+            }
+            current.clear();
+        }
+    }
+    if !current.is_empty() {
+        if let Ok(parsed) = current.parse::<u64>() {
+            max_number = Some(max_number.map_or(parsed, |n: u64| n.max(parsed)));
+        }
+    }
+    max_number
 }
 
 fn is_content_policy(lower: &str) -> bool {
@@ -341,6 +372,20 @@ mod tests {
         assert_eq!(info.kind, LlmErrorKind::Terminal);
         assert_eq!(info.reason, LlmErrorReason::ContextOverflow);
         assert!(msg.contains("[context_overflow]"), "msg was: {msg}");
+    }
+
+    #[test]
+    fn classify_ollama_model_context_exceeded_as_context_overflow() {
+        let info = classify_provider_http_error(
+            "ollama",
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            None,
+            r#"{"error":"model context exceeded: requested 49152 tokens"}"#,
+        );
+        assert_eq!(info.kind, LlmErrorKind::Terminal);
+        assert_eq!(info.reason, LlmErrorReason::ContextOverflow);
+        assert!(info.message.contains("[context_overflow]"));
+        assert!(info.message.contains("offending_tokens: 49152"));
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/api/ollama.rs
+++ b/crates/harn-vm/src/llm/api/ollama.rs
@@ -74,8 +74,11 @@ pub fn ollama_keep_alive_override() -> Option<serde_json::Value> {
 
 pub const OLLAMA_DEFAULT_NUM_CTX: u64 = 32_768;
 pub const OLLAMA_DEFAULT_KEEP_ALIVE: &str = "30m";
+pub const OLLAMA_DEFAULT_UNLOAD_GRACE_MS: u64 = 10_000;
 pub const HARN_OLLAMA_NUM_CTX_ENV: &str = "HARN_OLLAMA_NUM_CTX";
 pub const HARN_OLLAMA_KEEP_ALIVE_ENV: &str = "HARN_OLLAMA_KEEP_ALIVE";
+pub const HARN_OLLAMA_UNLOAD_GRACE_MS_ENV: &str = "HARN_OLLAMA_UNLOAD_GRACE_MS";
+pub const OLLAMA_UNLOAD_GRACE_MS_ENV: &str = "OLLAMA_UNLOAD_GRACE_MS";
 pub const OLLAMA_HOST_ENV: &str = "OLLAMA_HOST";
 
 const OLLAMA_NUM_CTX_ENV_KEYS: [&str; 3] = [
@@ -84,6 +87,8 @@ const OLLAMA_NUM_CTX_ENV_KEYS: [&str; 3] = [
     "OLLAMA_NUM_CTX",
 ];
 const OLLAMA_KEEP_ALIVE_ENV_KEYS: [&str; 2] = [HARN_OLLAMA_KEEP_ALIVE_ENV, "OLLAMA_KEEP_ALIVE"];
+const OLLAMA_UNLOAD_GRACE_MS_ENV_KEYS: [&str; 2] =
+    [HARN_OLLAMA_UNLOAD_GRACE_MS_ENV, OLLAMA_UNLOAD_GRACE_MS_ENV];
 const OLLAMA_DEFAULT_BASE_URL: &str = "http://localhost:11434";
 
 #[derive(Clone, Debug, PartialEq)]
@@ -123,6 +128,15 @@ impl OllamaRuntimeSettings {
 
 pub fn ollama_runtime_settings_from_env() -> OllamaRuntimeSettings {
     OllamaRuntimeSettings::from_env()
+}
+
+pub(crate) fn ollama_unload_grace_duration_from_env() -> Duration {
+    Duration::from_millis(
+        OLLAMA_UNLOAD_GRACE_MS_ENV_KEYS
+            .iter()
+            .find_map(|key| std::env::var(key).ok().and_then(|raw| parse_grace_ms(&raw)))
+            .unwrap_or(OLLAMA_DEFAULT_UNLOAD_GRACE_MS),
+    )
 }
 
 pub async fn warm_ollama_model(model: &str, base_url: Option<&str>) -> Result<(), String> {
@@ -222,6 +236,10 @@ fn keep_alive_from_overrides(overrides: Option<&Value>) -> Option<Value> {
 
 fn parse_num_ctx(raw: &str) -> Option<u64> {
     raw.trim().parse::<u64>().ok().filter(|parsed| *parsed > 0)
+}
+
+fn parse_grace_ms(raw: &str) -> Option<u64> {
+    raw.trim().parse::<u64>().ok()
 }
 
 fn parse_num_ctx_value(value: &Value) -> Option<u64> {

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -4,7 +4,7 @@
 //! the wire-format layer below that.
 
 use std::rc::Rc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::agent_events::{AgentEvent, ToolCallStatus};
 use crate::value::{VmError, VmValue};
@@ -306,61 +306,94 @@ pub(crate) async fn vm_call_llm_api_with_body(
             let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<String>();
             tx
         };
-        let response = req.send().await.map_err(|e| {
-            let kind = if e.is_timeout() {
-                "timeout"
-            } else if e.is_connect() {
-                "connect"
-            } else if e.is_request() {
-                "request_build"
-            } else if e.is_body() {
-                "body"
-            } else {
-                "unknown"
-            };
-            // "unknown" uses Debug repr to surface the inner cause.
-            let detail = if kind == "unknown" {
-                format!("{provider} stream error ({kind}): {e:?}")
-            } else {
-                format!("{provider} stream error ({kind}): {e}")
-            };
-            VmError::Thrown(VmValue::String(Rc::from(detail)))
-        })?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let retry_after = response
-                .headers()
-                .get("retry-after")
-                .and_then(|v| v.to_str().ok())
-                .map(|s| s.to_string());
-            let body = response.text().await.unwrap_or_default();
-            let msg = classify_transport_http_error(
+        let max_attempts = if is_ollama { 2 } else { 1 };
+        let unload_grace = if is_ollama {
+            crate::llm::api::ollama_unload_grace_duration_from_env()
+        } else {
+            Duration::ZERO
+        };
+        let mut ollama_warmup_gate = false;
+        for attempt in 0..max_attempts {
+            let req = client
+                .post(resolved.url())
+                .header("Content-Type", "application/json")
+                .timeout(std::time::Duration::from_secs(opts.resolve_timeout()))
+                .json(&body);
+            let mut req = resolved.apply_headers(req, &opts.api_key);
+            if is_anthropic_style && !opts.anthropic_beta_features.is_empty() {
+                req = req.header("anthropic-beta", opts.anthropic_beta_features.join(","));
+            }
+            let response = send_stream_request_with_ollama_warmup(
+                req,
                 provider,
-                status,
-                retry_after.as_deref(),
-                &body,
-                is_anthropic_style,
+                model,
                 is_ollama,
-            );
-            return Err(VmError::Thrown(VmValue::String(Rc::from(msg))));
-        }
-        let ct = response
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-        if ct.contains("text/event-stream") {
-            return vm_call_llm_api_sse_from_response(
+                unload_grace,
+                &mut ollama_warmup_gate,
+            )
+            .await?;
+            if !response.status().is_success() {
+                let status = response.status();
+                let retry_after = response
+                    .headers()
+                    .get("retry-after")
+                    .and_then(|v| v.to_str().ok())
+                    .map(|s| s.to_string());
+                let body = response.text().await.unwrap_or_default();
+                let msg = classify_transport_http_error(
+                    provider,
+                    status,
+                    retry_after.as_deref(),
+                    &body,
+                    is_anthropic_style,
+                    is_ollama,
+                );
+                return Err(VmError::Thrown(VmValue::String(Rc::from(msg))));
+            }
+            let is_sse = response
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .is_some_and(|ct| ct.contains("text/event-stream"));
+            if is_sse {
+                return vm_call_llm_api_sse_from_response(
+                    response,
+                    provider,
+                    model,
+                    &resolved,
+                    tx,
+                    opts.session_id.as_deref(),
+                )
+                .await;
+            }
+            match vm_call_llm_api_ndjson_from_response(
                 response,
                 provider,
                 model,
-                &resolved,
-                tx,
-                opts.session_id.as_deref(),
+                tx.clone(),
+                unload_grace,
+                &mut ollama_warmup_gate,
             )
-            .await;
+            .await
+            {
+                Ok(result) => return Ok(result),
+                Err(err)
+                    if is_ollama
+                        && attempt + 1 < max_attempts
+                        && is_ollama_empty_content_parser_bug(&err) =>
+                {
+                    crate::events::log_warn(
+                        "llm",
+                        &format!(
+                            "ollama model {model} returned empty content with eval_count; retrying once"
+                        ),
+                    );
+                    continue;
+                }
+                Err(err) => return Err(err),
+            }
         }
-        return vm_call_llm_api_ndjson_from_response(response, provider, model, tx).await;
+        unreachable!("streaming LLM attempt loop exhausted without returning");
     }
 
     let response = req.send().await.map_err(|e| {
@@ -469,6 +502,53 @@ fn try_emit_partial_tool_args(
         parsing: None,
     };
     crate::llm::agent::emit_agent_event_sync(&event);
+}
+
+async fn send_stream_request_with_ollama_warmup(
+    req: reqwest::RequestBuilder,
+    provider: &str,
+    model: &str,
+    is_ollama: bool,
+    unload_grace: Duration,
+    warmup_gate: &mut bool,
+) -> Result<reqwest::Response, VmError> {
+    let send = req.send();
+    if !is_ollama || *warmup_gate || unload_grace.is_zero() {
+        return send
+            .await
+            .map_err(|error| stream_send_error(provider, error));
+    }
+
+    tokio::pin!(send);
+    tokio::select! {
+        response = &mut send => response.map_err(|error| stream_send_error(provider, error)),
+        _ = tokio::time::sleep(unload_grace) => {
+            *warmup_gate = true;
+            emit_ollama_warmup_progress(model);
+            send.await.map_err(|error| stream_send_error(provider, error))
+        }
+    }
+}
+
+fn stream_send_error(provider: &str, error: reqwest::Error) -> VmError {
+    let kind = if error.is_timeout() {
+        "timeout"
+    } else if error.is_connect() {
+        "connect"
+    } else if error.is_request() {
+        "request_build"
+    } else if error.is_body() {
+        "body"
+    } else {
+        "unknown"
+    };
+    // "unknown" uses Debug repr to surface the inner cause.
+    let detail = if kind == "unknown" {
+        format!("{provider} stream error ({kind}): {error:?}")
+    } else {
+        format!("{provider} stream error ({kind}): {error}")
+    };
+    VmError::Thrown(VmValue::String(Rc::from(detail)))
 }
 
 /// Map an Anthropic `tool_use` block id (or, as a fallback, an
@@ -1007,14 +1087,31 @@ async fn vm_call_llm_api_ndjson_from_response(
     provider: &str,
     model: &str,
     delta_tx: DeltaSender,
+    unload_grace: Duration,
+    warmup_gate: &mut bool,
 ) -> Result<LlmResult, VmError> {
-    use tokio::io::AsyncBufReadExt;
     use tokio_stream::StreamExt;
 
     let stream = response.bytes_stream();
     let reader = tokio::io::BufReader::new(tokio_util::io::StreamReader::new(
         stream.map(|r| r.map_err(std::io::Error::other)),
     ));
+    consume_ollama_ndjson_lines(reader, provider, model, delta_tx, unload_grace, warmup_gate).await
+}
+
+async fn consume_ollama_ndjson_lines<R>(
+    reader: R,
+    provider: &str,
+    model: &str,
+    delta_tx: DeltaSender,
+    unload_grace: Duration,
+    warmup_gate: &mut bool,
+) -> Result<LlmResult, VmError>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+{
+    use tokio::io::AsyncBufReadExt;
+
     let mut lines = reader.lines();
 
     let mut text = String::new();
@@ -1025,15 +1122,35 @@ async fn vm_call_llm_api_ndjson_from_response(
     let mut thinking_text = String::new();
     let mut tool_calls = Vec::new();
     let mut blocks = Vec::new();
+    let mut saw_done = false;
+    let mut saw_chunk = false;
 
-    while let Ok(Some(line)) = lines.next_line().await {
+    loop {
+        let line = next_ollama_ndjson_line(&mut lines, model, unload_grace, warmup_gate)
+            .await
+            .map_err(|error| {
+                VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "ollama stream error: unexpected EOF or read failure before done=true: {error}"
+                ))))
+            })?;
+        let Some(line) = line else {
+            break;
+        };
+        *warmup_gate = true;
         if line.is_empty() {
             continue;
         }
-        let json: serde_json::Value = match serde_json::from_str(&line) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
+        let data = line.strip_prefix("data: ").unwrap_or(&line);
+        if data == "[DONE]" {
+            break;
+        }
+        let json: serde_json::Value = serde_json::from_str(data).map_err(|error| {
+            VmError::Thrown(VmValue::String(Rc::from(format!(
+                "ollama stream parse error: partial or invalid NDJSON frame before done=true: {error}; line={}",
+                &data[..data.len().min(200)]
+            ))))
+        })?;
+        saw_chunk = true;
 
         // Ollama streams content and thinking as separate channels for
         // reasoning-capable models (gemma3/4, qwen3, etc.); we always set
@@ -1066,8 +1183,20 @@ async fn vm_call_llm_api_ndjson_from_response(
             if let Some(n) = json["eval_count"].as_i64() {
                 output_tokens = n;
             }
+            saw_done = true;
             break;
         }
+    }
+
+    if !saw_done {
+        let suffix = if saw_chunk {
+            " after partial content"
+        } else {
+            " before any chunks"
+        };
+        return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+            "ollama stream error: unexpected EOF before done=true{suffix}"
+        )))));
     }
 
     let thinking = if thinking_text.is_empty() {
@@ -1087,7 +1216,7 @@ async fn vm_call_llm_api_ndjson_from_response(
     // iterations on a no-op.
     if text.is_empty() && tool_calls.is_empty() && output_tokens > 0 {
         return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
-            "ollama model {model} reported eval_count={output_tokens} but delivered no content or thinking — likely a server-side parser bug; try a different model"
+            "ollama model {model} reported eval_count={output_tokens} but delivered no content or thinking [ollama_empty_content_parser_bug]"
         )))));
     }
 
@@ -1112,11 +1241,64 @@ async fn vm_call_llm_api_ndjson_from_response(
     })
 }
 
+async fn next_ollama_ndjson_line<R>(
+    lines: &mut tokio::io::Lines<R>,
+    model: &str,
+    unload_grace: Duration,
+    warmup_progress_sent: &mut bool,
+) -> std::io::Result<Option<String>>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+{
+    if *warmup_progress_sent || unload_grace.is_zero() {
+        return lines.next_line().await;
+    }
+
+    tokio::select! {
+        line = lines.next_line() => line,
+        _ = tokio::time::sleep(unload_grace) => {
+            *warmup_progress_sent = true;
+            emit_ollama_warmup_progress(model);
+            lines.next_line().await
+        }
+    }
+}
+
+fn emit_ollama_warmup_progress(model: &str) {
+    let message = format!("warming up Ollama model {model}");
+    if let Some(bridge) = crate::llm::current_host_bridge() {
+        bridge.send_progress(
+            "llm",
+            &message,
+            None,
+            None,
+            Some(serde_json::json!({
+                "provider": "ollama",
+                "model": model,
+                "reason": "model_unload",
+            })),
+        );
+    }
+    crate::events::log_info("llm", &message);
+}
+
+fn is_ollama_empty_content_parser_bug(err: &VmError) -> bool {
+    match err {
+        VmError::Thrown(VmValue::String(message)) => {
+            message.contains("[ollama_empty_content_parser_bug]")
+        }
+        VmError::Runtime(message) => message.contains("[ollama_empty_content_parser_bug]"),
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        append_ollama_tool_calls, parse_ollama_tool_arguments, should_request_stream_usage,
+        append_ollama_tool_calls, consume_ollama_ndjson_lines, parse_ollama_tool_arguments,
+        should_request_stream_usage,
     };
+    use std::time::Duration;
 
     #[test]
     fn stream_usage_requested_for_openai_compatible_endpoints() {
@@ -1169,6 +1351,47 @@ mod tests {
         assert_eq!(tool_calls[0]["arguments"]["path"], "README.md");
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0]["type"], "tool_call");
+    }
+
+    #[tokio::test]
+    async fn ollama_ndjson_empty_content_eval_count_is_marked_for_retry() {
+        let body = b"{\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":true,\"prompt_eval_count\":10,\"eval_count\":4}\n";
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut warmup_gate = false;
+        let err = consume_ollama_ndjson_lines(
+            &body[..],
+            "ollama",
+            "stub-model",
+            tx,
+            Duration::ZERO,
+            &mut warmup_gate,
+        )
+        .await
+        .expect_err("empty Ollama parser-bug response should fail");
+        assert!(
+            err.to_string()
+                .contains("[ollama_empty_content_parser_bug]"),
+            "err was: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ollama_ndjson_requires_done_frame() {
+        let body =
+            b"{\"message\":{\"role\":\"assistant\",\"content\":\"partial\"},\"done\":false}\n";
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut warmup_gate = false;
+        let err = consume_ollama_ndjson_lines(
+            &body[..],
+            "ollama",
+            "stub-model",
+            tx,
+            Duration::ZERO,
+            &mut warmup_gate,
+        )
+        .await
+        .expect_err("truncated Ollama stream should fail");
+        assert!(err.to_string().contains("unexpected EOF before done=true"));
     }
 }
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -4696,6 +4696,7 @@ The following environment variables configure runtime behavior:
 | `OLLAMA_HOST` | Override the Ollama host. Default `http://localhost:11434`. |
 | `HARN_OLLAMA_NUM_CTX` | Preferred Ollama context window for Harn-owned Ollama chat, completion, context-window fallback, and warmup requests. Must be a positive integer. Takes precedence over `OLLAMA_CONTEXT_LENGTH` and `OLLAMA_NUM_CTX`; default `32768`. Hosts that persist IDE preferences should pass the raw stored value here and let Harn validate/default it. |
 | `HARN_OLLAMA_KEEP_ALIVE` | Preferred Ollama keep-alive for Harn-owned Ollama chat, completion, and warmup requests. Takes precedence over `OLLAMA_KEEP_ALIVE`; default `30m`. `forever`, `infinite`, and `-1` normalize to Ollama's numeric `-1`; `default` normalizes to `30m`. |
+| `HARN_OLLAMA_UNLOAD_GRACE_MS` | Preferred Ollama unload/warmup grace in milliseconds before Harn emits a one-time progress notification for an Ollama stream that has produced no chunks yet. Takes precedence over `OLLAMA_UNLOAD_GRACE_MS`; default `10000`. Set `0` to disable the notification. |
 | `LOCAL_LLM_BASE_URL` | Base URL for a local OpenAI-compatible server. Default `http://localhost:8000`. |
 | `LOCAL_LLM_MODEL` | Default model ID for the local OpenAI-compatible provider. |
 | `MLX_BASE_URL` | Base URL for the MLX OpenAI-compatible provider. Default `http://127.0.0.1:8002`. |

--- a/docs/src/llm-and-agents.md
+++ b/docs/src/llm-and-agents.md
@@ -22,7 +22,8 @@ servers. Most scripts choose a provider with the `provider` option, the
 `HARN_LLM_PROVIDER` environment variable, or a model name that Harn can infer.
 
 See [LLM providers](./llm/providers.md) for API keys, local model setup,
-enterprise provider notes, and the capability matrix.
+enterprise provider notes, Ollama runtime environment variables, and the
+capability matrix.
 
 ## Capability matrix + `harn.toml` overrides
 

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -219,7 +219,10 @@ and model aliases without editing Rust-side registration code.
   `30m`; `forever`, `infinite`, and `-1` normalize to numeric `-1`, while
   `default` normalizes to `30m`. Hosts that persist IDE preferences should pass
   the raw stored values via `HARN_OLLAMA_*` and let Harn own validation and
-  defaults.
+  defaults. `HARN_OLLAMA_UNLOAD_GRACE_MS` wins over `OLLAMA_UNLOAD_GRACE_MS`
+  and defaults to `10000`; when an Ollama stream produces no chunks for longer
+  than this after the request starts, Harn emits one progress notification that
+  the model is warming up.
 
 ### Local OpenAI-compatible server
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -4694,6 +4694,7 @@ The following environment variables configure runtime behavior:
 | `OLLAMA_HOST` | Override the Ollama host. Default `http://localhost:11434`. |
 | `HARN_OLLAMA_NUM_CTX` | Preferred Ollama context window for Harn-owned Ollama chat, completion, context-window fallback, and warmup requests. Must be a positive integer. Takes precedence over `OLLAMA_CONTEXT_LENGTH` and `OLLAMA_NUM_CTX`; default `32768`. Hosts that persist IDE preferences should pass the raw stored value here and let Harn validate/default it. |
 | `HARN_OLLAMA_KEEP_ALIVE` | Preferred Ollama keep-alive for Harn-owned Ollama chat, completion, and warmup requests. Takes precedence over `OLLAMA_KEEP_ALIVE`; default `30m`. `forever`, `infinite`, and `-1` normalize to Ollama's numeric `-1`; `default` normalizes to `30m`. |
+| `HARN_OLLAMA_UNLOAD_GRACE_MS` | Preferred Ollama unload/warmup grace in milliseconds before Harn emits a one-time progress notification for an Ollama stream that has produced no chunks yet. Takes precedence over `OLLAMA_UNLOAD_GRACE_MS`; default `10000`. Set `0` to disable the notification. |
 | `LOCAL_LLM_BASE_URL` | Base URL for a local OpenAI-compatible server. Default `http://localhost:8000`. |
 | `LOCAL_LLM_MODEL` | Default model ID for the local OpenAI-compatible provider. |
 | `MLX_BASE_URL` | Base URL for the MLX OpenAI-compatible provider. Default `http://127.0.0.1:8002`. |


### PR DESCRIPTION
## Summary
- classify Ollama `model context exceeded` responses as terminal context overflow and include an offending token hint when present
- emit one one-time Ollama warmup progress notification when no stream data arrives within `HARN_OLLAMA_UNLOAD_GRACE_MS` / `OLLAMA_UNLOAD_GRACE_MS`
- retry once for Ollama empty-content `done: true` frames with nonzero `eval_count`, and fail truncated NDJSON streams explicitly
- document the new unload grace env var in provider docs and the generated language spec

Closes #865

## Self-review
- Re-read the transport retry path after implementation to make sure the retry is limited to Ollama empty-content parser-bug responses and does not replay after partial deltas.
- Checked that warmup progress is gated across both delayed `send()` and delayed first NDJSON line, and disabled for non-Ollama NDJSON.
- Checked context-overflow classification remains terminal/non-retryable.

## Verification
- `cargo fmt`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-865 cargo test -p harn-vm llm::api::`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-865 cargo test -p harn-vm context_overflow_message_is_not_retryable`
- Pre-commit hook: Rust formatting OK, clippy OK, language spec OK; markdownlint failed on existing untouched `docs/src/scripting-cheatsheet.md:169` duplicate `Streams` heading.
- Pre-push hook: failed in `cargo test --no-run --workspace` because the hook temp target ran out of disk space (`No space left on device`).