### PR TITLE
Audit cfg(unix) test gates and add nightly Windows nextest matrix

### DIFF
--- a/.github/workflows/windows-nightly.yml
+++ b/.github/workflows/windows-nightly.yml
@@ -1,0 +1,63 @@
+name: Windows nightly
+
+# Runs the full workspace nextest surface on Windows once per night, plus
+# on-demand from the Actions tab. Complements the per-PR `windows` job in
+# `ci.yml`, which builds the workspace test graph but only runs a curated
+# subset of unit tests to keep the PR pipeline fast. The nightly fan-out
+# is the cross-platform safety net: every test that is *not* gated to
+# `#![cfg(unix)]` is expected to pass here.
+#
+# Failure is informational, not blocking — the nightly does not gate the
+# `check-status` job. When something regresses, file an issue and either
+# fix the underlying portability bug or add a per-test `#[cfg(unix)]`
+# annotation with rationale, then update
+# `docs/src/dev/windows-test-coverage.md` to reflect the disposition.
+#
+# Tracking issue: harn#946.
+
+on:
+  schedule:
+    # 07:00 UTC ≈ 23:00 Pacific the previous evening, ≈ 02:00 Eastern.
+    # Picked to land outside US business hours so the nightly result is
+    # waiting when contributors start their day.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  nextest:
+    name: Workspace nextest (windows-latest)
+    runs-on: windows-latest
+    # Don't run forks of the repo on a fork's own schedule.
+    if: github.repository == 'burin-labs/harn'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        continue-on-error: true
+        with:
+          # Reuse the same cache key as the per-PR Windows smoke job to
+          # piggy-back on whatever artifacts already landed today.
+          shared-key: workspace-windows
+          cache-on-failure: true
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
+        with:
+          tool: nextest@0.9.133
+      - name: Run workspace nextest
+        shell: bash
+        # No package filter — the whole workspace runs. Tests gated to
+        # `#![cfg(unix)]` are excluded at compile time, so the nightly
+        # surface is exactly what is portable.
+        run: cargo nextest run --workspace --profile ci
+      - name: Smoke test harn run
+        shell: bash
+        run: |
+          echo 'pipeline main() { println("ok") }' > smoke.harn
+          ./target/debug/harn.exe run smoke.harn

--- a/crates/harn-cli/tests/acp_server_cli.rs
+++ b/crates/harn-cli/tests/acp_server_cli.rs
@@ -1,4 +1,6 @@
-#![cfg(unix)]
+// Portable across Unix and Windows: this suite drives `harn serve acp` over
+// piped stdio and shuts the child down by closing stdin (EOF), so it does not
+// rely on POSIX signals or platform-specific tooling.
 
 use std::fs;
 use std::io::{BufRead, BufReader, Write};

--- a/crates/harn-cli/tests/harn_serve_mcp_cli.rs
+++ b/crates/harn-cli/tests/harn_serve_mcp_cli.rs
@@ -1,8 +1,7 @@
-#![cfg(unix)]
-// These integration tests serialize CLI child processes with a cross-process
-// file lock. Nextest runs each test in a separate process, so a static mutex
-// would not prevent several heavyweight `harn` servers from cold-starting at
-// once and racing the protocol-level readiness assertions.
+// Portable across Unix and Windows: this suite drives `harn serve mcp` over
+// piped stdio and tears each child down by closing stdin or calling
+// `std::process::Child::kill` (TerminateProcess on Windows / SIGKILL on Unix),
+// so it does not rely on POSIX signals or platform-specific shellouts.
 #![allow(clippy::await_holding_lock)]
 
 #[path = "support/mcp.rs"]

--- a/crates/harn-cli/tests/mcp_server_cli.rs
+++ b/crates/harn-cli/tests/mcp_server_cli.rs
@@ -1,7 +1,7 @@
-#![cfg(unix)]
-// Serialized with the shared process-test file lock. Nextest runs individual
-// tests in separate processes, so a static mutex would not prevent multiple
-// heavyweight `harn` child servers from cold-starting at once.
+// Portable across Unix and Windows: this suite drives `harn mcp serve` over
+// piped stdio and tears the child down with `std::process::Child::kill`
+// (TerminateProcess on Windows / SIGKILL on Unix), so it does not rely on
+// POSIX signals or platform-specific shellouts.
 #![allow(clippy::await_holding_lock)]
 
 #[path = "support/mcp.rs"]

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -1,3 +1,12 @@
+// POSIX-bound: every test in this file asserts on graceful-shutdown behaviour
+// (drain progress, `graceful shutdown complete` log line, successful exit
+// code) after sending SIGTERM to the orchestrator child. Windows lacks a
+// portable signal delivery mechanism for console children, so the orchestrator
+// cannot be drained the same way under test. The Windows nightly nextest
+// matrix in `.github/workflows/windows-nightly.yml` runs every other test.
+//
+// See `docs/dev/windows-test-coverage.md` for the full inventory and
+// disposition tracker (issue #946).
 #![cfg(unix)]
 
 mod support;

--- a/crates/harn-cli/tests/orchestrator_http.rs
+++ b/crates/harn-cli/tests/orchestrator_http.rs
@@ -1,7 +1,18 @@
+// POSIX-bound: every test asserts on graceful-shutdown behaviour after sending
+// SIGTERM to the orchestrator child (drain semantics, `graceful shutdown
+// complete` log line, successful exit code, in-flight HTTP request drain).
+// Windows lacks a portable signal delivery mechanism for console children, so
+// the orchestrator cannot be drained the same way under test. The Windows
+// nightly nextest matrix in `.github/workflows/windows-nightly.yml` runs
+// every other test.
+//
+// See `docs/dev/windows-test-coverage.md` for the full inventory and
+// disposition tracker (issue #946).
 #![cfg(unix)]
-// Orchestrator HTTP tests serialize CLI child processes with the shared
-// cross-process file lock. Each test holds the guard across .await boundaries
-// while the child server is alive.
+// Orchestrator HTTP tests previously serialized CLI child processes with a
+// cross-process file lock; the `.await` boundaries were held by the lock
+// guard. The lock has since been retired (see `support::process`), but the
+// `#[allow]` is left in place for incremental migrations.
 #![allow(clippy::await_holding_lock)]
 
 mod support;

--- a/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
+++ b/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
@@ -1,3 +1,10 @@
+// POSIX-bound: this test asserts on graceful-shutdown behaviour after sending
+// SIGTERM to the orchestrator child (clean exit code, drained inbox dedupe
+// state). Windows lacks a portable signal delivery mechanism for console
+// children, so the orchestrator cannot be drained the same way under test.
+//
+// See `docs/dev/windows-test-coverage.md` for the full inventory and
+// disposition tracker (issue #946).
 #![cfg(unix)]
 
 #[path = "support/process.rs"]

--- a/crates/harn-cli/tests/test_util/timing.rs
+++ b/crates/harn-cli/tests/test_util/timing.rs
@@ -95,6 +95,14 @@ impl ChildExitWatcher {
         );
     }
 
+    /// Request graceful shutdown of the child.
+    ///
+    /// On Unix this delivers SIGTERM and the child runs its drain. Windows
+    /// has no portable equivalent that reaches an arbitrary console child
+    /// without taking over the parent's console group, so the Windows path
+    /// falls back to a forceful `taskkill /F` — no graceful drain, no
+    /// shutdown-needle log line. Tests that assert on graceful-shutdown
+    /// semantics must therefore stay `#![cfg(unix)]`.
     pub fn terminate(&mut self) {
         if self
             .try_status()
@@ -103,11 +111,7 @@ impl ChildExitWatcher {
         {
             return;
         }
-        let status = Command::new("kill")
-            .arg("-TERM")
-            .arg(self.pid.to_string())
-            .status()
-            .unwrap();
+        let status = posix_kill_or_taskkill(self.pid, KillKind::Term);
         if !status.success()
             && self
                 .try_status()
@@ -118,6 +122,11 @@ impl ChildExitWatcher {
         }
     }
 
+    /// Forcefully terminate the child.
+    ///
+    /// Maps to SIGKILL on Unix and `taskkill /F` on Windows (which calls
+    /// `TerminateProcess` underneath). Both paths are immediate and skip
+    /// any drain logic.
     pub fn kill(&mut self) {
         if self
             .try_status()
@@ -126,10 +135,7 @@ impl ChildExitWatcher {
         {
             return;
         }
-        let _ = Command::new("kill")
-            .arg("-KILL")
-            .arg(self.pid.to_string())
-            .status();
+        let _ = posix_kill_or_taskkill(self.pid, KillKind::Kill);
     }
 
     fn cache_status(
@@ -232,4 +238,38 @@ pub fn sleep_blocking(duration: Duration) {
 
 pub async fn sleep_async(duration: Duration) {
     tokio::time::sleep(duration).await;
+}
+
+#[derive(Copy, Clone)]
+enum KillKind {
+    Term,
+    Kill,
+}
+
+#[cfg(unix)]
+fn posix_kill_or_taskkill(pid: u32, kind: KillKind) -> ExitStatus {
+    let signal = match kind {
+        KillKind::Term => "-TERM",
+        KillKind::Kill => "-KILL",
+    };
+    Command::new("kill")
+        .arg(signal)
+        .arg(pid.to_string())
+        .status()
+        .unwrap()
+}
+
+#[cfg(windows)]
+fn posix_kill_or_taskkill(pid: u32, _kind: KillKind) -> ExitStatus {
+    // Windows has no portable signal-delivery mechanism for arbitrary console
+    // children, so both Term and Kill collapse to a forceful TerminateProcess
+    // via `taskkill /F`. The orchestrator's drain logic is therefore not
+    // exercised on this platform; tests that depend on it must remain gated
+    // to `#![cfg(unix)]`.
+    Command::new("taskkill")
+        .arg("/F")
+        .arg("/PID")
+        .arg(pid.to_string())
+        .status()
+        .unwrap()
 }

--- a/crates/harn-hostlib/tests/process_tools.rs
+++ b/crates/harn-hostlib/tests/process_tools.rs
@@ -2,19 +2,16 @@
 //! (`run_command`, `run_test`, `run_build_command`,
 //! `inspect_test_results`, `manage_packages`, `cancel_handle`).
 //!
-//! These spawn real subprocesses, so they're gated to Unix and rely only
-//! on coreutils / shell that ship with both macOS and standard Linux
-//! distros. The tests assert on:
+//! POSIX-bound: every fixture spawns `bash -c "<script>"` to exercise argv,
+//! cwd, env, stdin plumbing, timeouts, and the long-running-handle drain.
+//! Bash and the shell-script vocabulary used here (`echo`, `pwd`, `1>&2`,
+//! `for i in $(seq 1 N); do printf x; done`, `printenv`, `$$`, etc.) are
+//! POSIX-only; porting the suite to Windows would require rewriting every
+//! fixture against `cmd.exe` / PowerShell, with subtle quoting and exit-code
+//! semantics that no longer test the same plumbing on both sides.
 //!
-//! - argv / cwd / env / stdin plumbing matches the request schema
-//! - timeout enforcement kills the child and reports `timed_out: true`
-//! - error variants (missing argv, bad cwd, malformed types) round-trip
-//!   through `HostlibError` rather than panicking
-//! - language detection picks the right runner from manifest files
-//! - inspect_test_results parses JUnit XML written by `run_test`
-//! - long_running: true returns a handle synchronously; result lands in the
-//!   global pending-feedback queue after the process exits
-//! - cancel_handle kills the spawned process
+//! See `docs/dev/windows-test-coverage.md` for the full inventory and
+//! disposition tracker (issue #946).
 
 #![cfg(unix)]
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -113,6 +113,7 @@
 - [Deploy to Fly.io](./deploy/fly.md)
 - [Deploy to Railway](./deploy/railway.md)
 - [Maintainer release workflow](./maintainer-release.md)
+- [Windows test coverage](./dev/windows-test-coverage.md)
 
 # Tutorials and Guides
 

--- a/docs/src/dev/windows-test-coverage.md
+++ b/docs/src/dev/windows-test-coverage.md
@@ -1,0 +1,61 @@
+# Windows test coverage
+
+This page tracks the disposition of every workspace test module that opts
+out of Windows via `#![cfg(unix)]` (or per-test `#[cfg(unix)]`). It exists
+so that a new contributor can tell at a glance whether a gate is
+load-bearing (POSIX semantics under test) or simply lazy (the test does
+not exercise anything OS-specific and could run on Windows with minor
+care).
+
+The Windows nightly nextest matrix in
+`.github/workflows/windows-nightly.yml` runs the workspace test surface on
+`windows-latest`, so any test that is *not* gated below is expected to
+pass on Windows.
+
+## Inventory
+
+| Test module | Disposition | Rationale |
+|-------------|-------------|-----------|
+| [`crates/harn-hostlib/tests/process_tools.rs`](https://github.com/burin-labs/harn/blob/main/crates/harn-hostlib/tests/process_tools.rs) | **Keep `#![cfg(unix)]`** — POSIX-bound | Every fixture spawns `bash -c "<script>"` to exercise argv / cwd / env / stdin / timeout plumbing. Bash and the shell-script vocabulary used here (`echo`, `pwd`, `1>&2`, `for i in $(seq 1 N)`, `printenv`, `$$`, etc.) are POSIX-only. Porting to Windows would require rewriting every fixture against `cmd.exe` / PowerShell, with subtle quoting and exit-code semantics that would no longer test the same plumbing on both sides. |
+| [`crates/harn-cli/tests/orchestrator_cli.rs`](https://github.com/burin-labs/harn/blob/main/crates/harn-cli/tests/orchestrator_cli.rs) | **Keep `#![cfg(unix)]`** — POSIX-bound | Every test sends `SIGTERM` to the orchestrator child and asserts on the resulting drain (`graceful shutdown complete` log line, successful exit code, lifecycle event ordering). Windows has no portable signal-delivery mechanism for an arbitrary console child without taking over the parent's console group, so the orchestrator cannot be drained the same way under test. |
+| [`crates/harn-cli/tests/orchestrator_http.rs`](https://github.com/burin-labs/harn/blob/main/crates/harn-cli/tests/orchestrator_http.rs) | **Keep `#![cfg(unix)]`** — POSIX-bound | Same as `orchestrator_cli.rs`: every test asserts on graceful shutdown after `SIGTERM`. Some tests additionally assert on in-flight HTTP request drain, which is also a POSIX-signal-driven flow today. |
+| [`crates/harn-cli/tests/orchestrator_inbox_dedupe.rs`](https://github.com/burin-labs/harn/blob/main/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs) | **Keep `#![cfg(unix)]`** — POSIX-bound | Same as above: `SIGTERM` + clean drain are part of the assertion. |
+| [`crates/harn-cli/tests/acp_server_cli.rs`](https://github.com/burin-labs/harn/blob/main/crates/harn-cli/tests/acp_server_cli.rs) | **Ungate** — fully portable | Drives `harn serve acp` over piped stdio; child shutdown is via stdin EOF, not signals. Runs on Unix and Windows. |
+| [`crates/harn-cli/tests/mcp_server_cli.rs`](https://github.com/burin-labs/harn/blob/main/crates/harn-cli/tests/mcp_server_cli.rs) | **Ungate** — fully portable | Drives `harn mcp serve` over piped stdio; child shutdown is via `std::process::Child::kill` (TerminateProcess on Windows, SIGKILL on Unix). |
+| [`crates/harn-cli/tests/harn_serve_mcp_cli.rs`](https://github.com/burin-labs/harn/blob/main/crates/harn-cli/tests/harn_serve_mcp_cli.rs) | **Ungate** — fully portable | Drives `harn serve mcp`; child shutdown is via stdin EOF or `Child::kill`. No POSIX signals, no shellouts to `kill`. |
+
+The rest of the workspace either has no module-level `#![cfg(unix)]`
+(individual `#[cfg(unix)]` items remain — typically for skill paths,
+symlink helpers, or tokio signal streams that already have a
+`#[cfg(not(unix))]` Windows fallback nearby) or is a Unix-only
+implementation file (`crates/harn-vm/src/stdlib/sandbox.rs`,
+`crates/harn-cli/src/package/registry.rs::symlink_path_dependency`, etc.)
+that genuinely cannot be implemented on Windows the same way.
+
+## Adding new POSIX-bound tests
+
+If a new test module needs POSIX semantics (signals, fork, real shell),
+gate it `#![cfg(unix)]` and add a row to the table above so the gate
+remains discoverable. The header comment in the test file should explain
+*why* the gate exists; this page is for cross-cutting visibility.
+
+## Adding new portable tests
+
+Default to *not* gating. The Windows nightly matrix will catch hidden
+Unix assumptions (`/`-only paths, `\n`-only line endings, missing `.exe`
+suffix, etc.) and you can either fix them in place or add a per-test
+`#[cfg(unix)]` annotation if a single case turns out to be POSIX-bound.
+
+## Cross-platform child shutdown helpers
+
+`crates/harn-cli/tests/test_util/timing.rs::ChildExitWatcher` exposes
+`terminate()` and `kill()` that work on both platforms:
+
+- **Unix**: shells out to `kill -TERM` / `kill -KILL`.
+- **Windows**: shells out to `taskkill /F` (which calls `TerminateProcess`
+  underneath). Both `terminate()` and `kill()` collapse to the same
+  forceful path; there is no graceful-shutdown drain on Windows.
+
+Tests that depend on the orchestrator running its drain logic must
+therefore stay `#![cfg(unix)]` regardless of which helper they call. This
+is documented in the doc-comment on `ChildExitWatcher::terminate`.

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -415,3 +415,13 @@ the expected and actual values.
 Use `require` for runtime invariants in normal pipelines. The linter warns if
 you use `assert*` outside test pipelines, and it suggests `assert*` instead of
 `require` inside test pipelines.
+
+## Cross-platform test coverage
+
+Most workspace tests run on both Unix and Windows. A small set of test
+modules opts out of Windows via `#![cfg(unix)]` because they exercise
+POSIX-only semantics (`bash`-fixture process spawning, SIGTERM-driven
+graceful shutdown). The full inventory and disposition lives at
+[Windows test coverage](./dev/windows-test-coverage.md), and the nightly
+`Windows nightly` GitHub Actions workflow runs the portable surface on
+`windows-latest` so cross-platform regressions surface within 24 hours.


### PR DESCRIPTION
## Summary

Audit every `#![cfg(unix)]` test module in the workspace, drop the gate where it is unjustified, document the rest, and stand up a nightly Windows nextest matrix so cross-platform regressions surface within 24 hours.

Closes #946.

## What's in the box

- **Drop the gate on three portable suites** — `crates/harn-cli/tests/acp_server_cli.rs`, `mcp_server_cli.rs`, `harn_serve_mcp_cli.rs`. None of them use POSIX signals or shellouts; they tear down their child via stdin EOF or `std::process::Child::kill` (TerminateProcess on Windows / SIGKILL on Unix). Replaces the `#![cfg(unix)]` line with a one-liner explaining why the suite is portable.
- **Keep the gate on four POSIX-bound suites** — `process_tools.rs` (every fixture spawns `bash -c "<script>"`), `orchestrator_cli.rs` / `orchestrator_http.rs` / `orchestrator_inbox_dedupe.rs` (every test sends `SIGTERM` and asserts on the resulting drain). Each file now carries a header comment that names the POSIX semantics under test and points at the inventory page.
- **Make `ChildExitWatcher::terminate` / `kill` cross-platform.** A small `posix_kill_or_taskkill` helper shells out to `kill -TERM` / `kill -KILL` on Unix and `taskkill /F` on Windows. The Windows path is a forceful `TerminateProcess` (no graceful drain), and the doc-comment on `terminate` is explicit that tests asserting on graceful-shutdown semantics must stay `#![cfg(unix)]`.
- **`.github/workflows/windows-nightly.yml`** runs `cargo nextest run --workspace --profile ci` on `windows-latest` at 07:00 UTC daily, plus `workflow_dispatch` for manual smoke. Failure is informational — the nightly does not gate `check-status`, so a regression files an issue without blocking unrelated PRs. The per-PR `windows` job in `ci.yml` is unchanged.
- **`docs/src/dev/windows-test-coverage.md`** — single-page disposition tracker with one row per gated module, the rationale for each, guidance on adding new gated/portable tests, and a section on the cross-platform shutdown helpers. Linked from `docs/src/SUMMARY.md` and `docs/src/testing.md`.

## Out of scope (deferred)

The issue mentions standardising on `assert_cmd` / `predicates`. The codebase has zero usages of either today, and a wholesale conversion would touch every test that spawns the `harn` binary. Keeping that as a follow-up so this PR can land the disposition + nightly matrix without a much larger refactor in the same review.

The orchestrator's Windows graceful-shutdown story (Ctrl+Break delivery via `CREATE_NEW_PROCESS_GROUP`, listening on `tokio::signal::windows::ctrl_break`) would let the `orchestrator_*` suites run on Windows too. Also a follow-up — it would need coordinated changes in `crates/harn-cli/src/commands/orchestrator/serve.rs` and the test helpers, plus per-test verification.

## Test plan

- [x] `cargo check -p harn-cli --tests` passes locally (clean).
- [x] `cargo fmt --check` passes.
- [x] `make lint-md` passes.
- [x] `make lint-actions` passes.
- [ ] CI: per-PR `windows` job still green (compiles workspace + runs the existing curated test slice on `windows-latest`).
- [ ] CI: full Linux `make all` green via the standard `rust` job.
- [ ] After merge: trigger `Windows nightly` once via `workflow_dispatch` to confirm the new matrix bootstraps cleanly. Subsequent runs are scheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)