### PR TITLE
Add Harn-native Merge Captain persona (#1009)

### DIFF
--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -224,6 +224,43 @@ fn persona_manifest_flag_loads_fixer_persona() {
 }
 
 #[test]
+fn persona_manifest_flag_loads_merge_captain_persona() {
+    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .args([
+            "persona",
+            "--manifest",
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../personas/merge_captain/harn.toml"
+            ),
+            "inspect",
+            "merge_captain",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let persona: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(persona["name"], "merge_captain");
+    assert_eq!(persona["entry_workflow"], "manifest.harn#run");
+    assert_eq!(persona["receipt_policy"], "required");
+    assert_eq!(persona["autonomy_tier"], "act_with_approval");
+    let triggers = persona["triggers"].as_array().expect("triggers array");
+    assert!(triggers.iter().any(|t| t == "github.pr_opened"));
+    let capabilities = persona["capabilities"]
+        .as_array()
+        .expect("capabilities array");
+    assert!(capabilities.iter().any(|c| c == "process.exec"));
+    assert!(capabilities.iter().any(|c| c == "runtime.dry_run"));
+    assert_eq!(persona["evals"][0], "merge_captain_smoke");
+}
+
+#[test]
 fn persona_manifest_flag_loads_ship_captain_persona() {
     let output = Command::new(env!("CARGO_BIN_EXE_harn"))
         .args([

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -42,6 +42,7 @@
 - [Trust graph](./trust-graph.md)
 - [Skills](./skills.md)
 - [Personas](./personas.md)
+  - [Merge Captain](./personas/merge-captain.md)
 - [Skill provenance](./skill-provenance.md)
 - [Sessions](./sessions.md)
 - [Agent state](./agent-state.md)

--- a/docs/src/personas/merge-captain.md
+++ b/docs/src/personas/merge-captain.md
@@ -1,0 +1,154 @@
+# Merge Captain persona
+
+The Merge Captain persona is a Harn-native runbook for owning
+pull-request queues across multiple repositories. It is the
+recommended starting point for teams that want a deterministic,
+receipt-emitting merge workflow rather than a shell-driven sweep
+script.
+
+The full persona package lives at
+[`personas/merge_captain/`](https://github.com/burin-labs/harn/tree/main/personas/merge_captain)
+and ships with policies for `harn`, `harn-cloud`, and `burin-code`.
+
+## What it owns
+
+- A canonical 12-state machine over each tracked PR (`discovered`,
+  `draft`, `waiting_checks`, `behind`, `dirty`, `queued`,
+  `merge_group_running`, `failing_ci`, `local_repair`, `blocked`,
+  `merged`, `closed`).
+- Per-repo policy: merge method, merge-queue toggle, required checks,
+  required review count, blocking labels, optional ready label,
+  per-repo `local_verification` commands, and downstream bump/release
+  ordering.
+- Durable per-PR checkpoints written through
+  [`std/agent_state`](../agent-state.md) so the sweep loop survives
+  cancellation and process restart, and so two sweeps cannot race —
+  the second writer hits the
+  `conflict_policy: "error"` guard.
+- One signed merge receipt per (sweep, repo, PR) capturing the
+  classification, the action chosen, the evidence the classifier saw,
+  the approval state under the per-repo autopilot policy, the
+  commands actually executed, the checks observed, and the final
+  outcome. A sweep-level summary aggregates by state, action, and
+  repo.
+- A typed GitHub adapter that dispatches through
+  [`std/connectors/github`](../stdlib/connectors-github.md) in live
+  mode and through a deterministic JSON snapshot in fixture mode.
+  Tests, evals, and replay all run on fixtures — no `gh` shelling.
+
+## Running the sweep
+
+```bash
+# Default fixture sweep — useful for evals and CI.
+harn run personas/merge_captain/manifest.harn
+
+# Persona inspection.
+harn persona --manifest personas/merge_captain/harn.toml \
+  inspect merge_captain --json
+
+# Smoke eval.
+harn eval personas/merge_captain/evals/merge_captain_smoke.json
+
+# Unit tests for every layer.
+harn test personas/merge_captain/tests/states_test.harn
+harn test personas/merge_captain/tests/policy_test.harn
+harn test personas/merge_captain/tests/classifier_test.harn
+harn test personas/merge_captain/tests/receipt_test.harn
+harn test personas/merge_captain/tests/scheduler_test.harn
+```
+
+## Live mode input
+
+`manifest.harn` reads its configuration via
+[`runtime_pipeline_input()`](../stdlib/runtime.md), so the same entry
+pipeline serves both the smoke fixture and a production sweep.
+
+```json
+{
+  "mode": "live",
+  "policy_paths": [
+    "personas/merge_captain/policies/harn.json",
+    "personas/merge_captain/policies/harn-cloud.json",
+    "personas/merge_captain/policies/burin-code.json"
+  ],
+  "state_root": "/var/lib/harn/merge-captain/state",
+  "session_id": "production",
+  "writer_id": "merge_captain@host-1",
+  "dry_run": false,
+  "sweep_id": "live-2026-04-29T17:30Z"
+}
+```
+
+The `github` connector must be active for live mode. Local
+verification commands run via the host's `process.exec` capability;
+no other I/O leaves the typed connector layer.
+
+## Authoring per-repo policy
+
+Policies are JSON files under
+[`personas/merge_captain/policies/`](https://github.com/burin-labs/harn/tree/main/personas/merge_captain/policies).
+Only `repo` is required; everything else inherits from
+`policy.defaults()` in
+[`lib/policy.harn`](https://github.com/burin-labs/harn/blob/main/personas/merge_captain/lib/policy.harn).
+
+```json
+{
+  "repo": "burin-labs/harn",
+  "default_branch": "main",
+  "merge_method": "squash",
+  "merge_queue_enabled": true,
+  "required_checks": ["ci / rust", "ci / portal", "ci / conformance"],
+  "required_review_count": 1,
+  "blocking_labels": ["do-not-merge", "needs-revision", "release-block"],
+  "ready_label": null,
+  "max_in_flight": 8,
+  "local_verification": [
+    {"name": "make-test", "command": "make test"},
+    {"name": "make-conformance", "command": "make conformance"}
+  ],
+  "downstream": [{"repo": "burin-labs/burin-code", "action": "fetch_harn_bump"}],
+  "bump_after_merge": null,
+  "autopilot_states": ["queued", "waiting_checks", "behind"],
+  "require_human_for": ["blocked", "local_repair"]
+}
+```
+
+`autopilot_states` lists states whose mutating actions can fire
+without a human approval. `require_human_for` lists states that
+always escalate, even if their action is technically non-mutating.
+Both lists are evaluated against the per-PR classification, and the
+result lands in the receipt's `approval_state` field
+(`autopilot`, `dry_run`, `needs_human`, or `no_mutation`).
+
+## Receipt shape
+
+```json
+{
+  "_type": "merge_receipt",
+  "version": 1,
+  "persona": "merge_captain",
+  "sweep_id": "...",
+  "observed_at": 1761729600000,
+  "repo": "burin-labs/harn",
+  "pr_number": 1010,
+  "head_sha": "...",
+  "prior_state": "discovered",
+  "classification": {
+    "state": "queued",
+    "action": "enqueue_merge_queue",
+    "reason": "all gates passed; enqueueing on the merge queue"
+  },
+  "evidence": {
+    "classifier": {"merge_method": "squash"},
+    "snapshot": {"approvals": 1, "labels": [], "...": "..."}
+  },
+  "approval_state": "autopilot",
+  "commands_run": [{"action": "enqueue_merge_queue", "response": {...}}],
+  "checks_observed": [{"name": "ci / rust", "status": "completed", "conclusion": "success"}],
+  "final_outcome": "enqueued",
+  "policy_summary": {"merge_method": "squash", "merge_queue_enabled": true}
+}
+```
+
+`harn` always prefers the merge queue when `merge_queue_enabled` is
+true — admin-merge bypass is never an action the classifier picks.

--- a/personas/merge_captain/README.md
+++ b/personas/merge_captain/README.md
@@ -1,0 +1,136 @@
+# Merge Captain persona
+
+Merge Captain is a Harn-native runbook for owning pull-request queues
+across `harn`, `harn-cloud`, and `burin-code` (or any other repo whose
+policy you check in here). It replaces the shell-driven sweep MVP with
+a deterministic state machine, durable per-PR checkpoints, and a typed
+GitHub adapter that rides the connector contract — no raw
+`process.exec` against `gh` shell strings.
+
+## What it does
+
+- Discovers open PRs in every configured repo on every sweep.
+- Classifies each PR into one of twelve canonical states (see
+  [`lib/states.harn`](lib/states.harn)) using a pure observation
+  classifier ([`lib/classifier.harn`](lib/classifier.harn)).
+- Persists each PR's state to a session-scoped agent-state checkpoint
+  ([`lib/checkpoint_store.harn`](lib/checkpoint_store.harn)) so the
+  sweep loop survives cancellation and process restart.
+- Runs the action the classification calls for: comment, request
+  review, update branch, run local verification, enqueue on the merge
+  queue, escalate to a human, etc.
+- Emits one merge receipt per PR per sweep
+  ([`lib/receipt.harn`](lib/receipt.harn)) capturing classification,
+  action, evidence, approval state, commands run, observed checks, and
+  final outcome — plus a sweep-level summary that aggregates by state,
+  action, and repo.
+- Treats the GitHub merge queue as the first-class merge path; admin
+  bypass is never the action it picks.
+- Picks up brand new PRs on the very next sweep, and reconciles PRs
+  that disappeared from the open list with a synthetic closing
+  receipt.
+
+## Layout
+
+| Path | Role |
+|---|---|
+| [`harn.toml`](harn.toml) | Persona manifest entry. |
+| [`manifest.harn`](manifest.harn) | Entry pipeline. One run = one sweep. |
+| [`lib/states.harn`](lib/states.harn) | Canonical states, transitions, actions. |
+| [`lib/policy.harn`](lib/policy.harn) | Per-repo policy schema, defaults, validation. |
+| [`lib/observation.harn`](lib/observation.harn) | Normalized PR observation shape. |
+| [`lib/classifier.harn`](lib/classifier.harn) | Pure (observation, policy) -> (state, action). |
+| [`lib/checkpoint_store.harn`](lib/checkpoint_store.harn) | `std/agent_state`-backed per-PR persistence. |
+| [`lib/github_adapter.harn`](lib/github_adapter.harn) | Live (connector) and fixture-mode GitHub I/O. |
+| [`lib/local_verify.harn`](lib/local_verify.harn) | Runs per-repo local verification commands. |
+| [`lib/receipt.harn`](lib/receipt.harn) | Per-PR + sweep receipt builders. |
+| [`lib/scheduler.harn`](lib/scheduler.harn) | The actual sweep loop. |
+| [`policies/*.json`](policies) | Per-repo policy fixtures for harn / harn-cloud / burin-code. |
+| [`fixtures/github_snapshot.json`](fixtures/github_snapshot.json) | Deterministic GitHub state for evals. |
+| [`tests/`](tests) | Pure-Harn unit + scheduler tests. |
+| [`evals/merge_captain_smoke.json`](evals/merge_captain_smoke.json) | Smoke eval suite. |
+| [`runs/merge_captain_smoke.run.json`](runs/merge_captain_smoke.run.json) | Recorded run for the smoke eval. |
+
+## States
+
+`discovered`, `draft`, `waiting_checks`, `behind`, `dirty`, `queued`,
+`merge_group_running`, `failing_ci`, `local_repair`, `blocked`,
+`merged`, `closed`. The legal-edges table lives in
+[`lib/states.harn`](lib/states.harn) and is enforced by
+`classifier.verify(...)` after every classification — illegal jumps
+trigger an automatic `escalate_human` rather than a silent state
+update.
+
+## Running locally
+
+```bash
+# Dry-run sweep over the checked-in fixtures (default behaviour).
+harn run personas/merge_captain/manifest.harn
+
+# Persona inspection + smoke eval.
+harn persona --manifest personas/merge_captain/harn.toml inspect merge_captain --json
+harn eval personas/merge_captain/evals/merge_captain_smoke.json
+
+# Unit tests for every layer.
+harn test personas/merge_captain/tests/states_test.harn
+harn test personas/merge_captain/tests/policy_test.harn
+harn test personas/merge_captain/tests/classifier_test.harn
+harn test personas/merge_captain/tests/receipt_test.harn
+harn test personas/merge_captain/tests/scheduler_test.harn
+```
+
+## Running against live GitHub
+
+`manifest.harn` accepts a structured input via
+`runtime_pipeline_input()`:
+
+```json
+{
+  "mode": "live",
+  "policy_paths": [
+    "personas/merge_captain/policies/harn.json",
+    "personas/merge_captain/policies/harn-cloud.json",
+    "personas/merge_captain/policies/burin-code.json"
+  ],
+  "state_root": "/var/lib/harn/merge-captain/state",
+  "session_id": "production",
+  "writer_id": "merge_captain@host-1",
+  "dry_run": false,
+  "sweep_id": "live-2026-04-29T17:30Z"
+}
+```
+
+In live mode the adapter dispatches through the
+[`std/connectors/github`](../../crates/harn-modules/src/stdlib/stdlib_connectors_github.harn)
+connector. You still need a registered `github` connector client — the
+adapter never shells out to `gh`. Local verification commands are the
+one exception; they run via `process.exec` per the per-repo
+`local_verification` list.
+
+## Invariants
+
+- One writer per session. The checkpoint store opens with
+  `conflict_policy: "error"`, so two concurrent sweeps will error
+  rather than race.
+- Classifier is pure and deterministic. Tests cover every transition
+  branch.
+- Every transition is checked against the legal-edges table; failures
+  rewrite the action to `escalate_human`.
+- Mutating actions are gated by either `dry_run`, autopilot allow-list,
+  or human approval — the receipt's `approval_state` is the audit
+  trail.
+
+## Customizing for a new repo
+
+1. Copy one of the JSON files in [`policies/`](policies) and edit the
+   fields. `repo` is required; everything else has a sane default in
+   [`lib/policy.harn`](lib/policy.harn).
+2. Add the path to `policy_paths` in your runtime input.
+3. (Optional) Add a per-repo entry in
+   [`fixtures/github_snapshot.json`](fixtures/github_snapshot.json) to
+   exercise the new policy under `harn test`.
+
+## Provenance
+
+This implementation closes
+[harn#1009](https://github.com/burin-labs/harn/issues/1009).

--- a/personas/merge_captain/evals/merge_captain_smoke.json
+++ b/personas/merge_captain/evals/merge_captain_smoke.json
@@ -1,0 +1,11 @@
+{
+  "_type": "eval_suite_manifest",
+  "id": "merge_captain_smoke",
+  "name": "merge_captain smoke",
+  "cases": [
+    {
+      "label": "merge_captain_dry_run_sweep",
+      "run_path": "../runs/merge_captain_smoke.run.json"
+    }
+  ]
+}

--- a/personas/merge_captain/fixtures/github_snapshot.json
+++ b/personas/merge_captain/fixtures/github_snapshot.json
@@ -1,0 +1,252 @@
+{
+  "burin-labs/harn": {
+    "pulls": [
+      {
+        "repo": "burin-labs/harn",
+        "number": 1010,
+        "title": "Add merge captain skeleton",
+        "head_sha": "aaaaaaaa",
+        "head_ref": "ksinder/merge-captain",
+        "base_ref": "main",
+        "state": "open",
+        "draft": false,
+        "merged": false,
+        "mergeable": true,
+        "mergeable_state": "clean",
+        "behind_by": 0,
+        "labels": [],
+        "review_decision": "APPROVED",
+        "approvals": 1,
+        "in_merge_queue": false,
+        "merge_group_active": false
+      },
+      {
+        "repo": "burin-labs/harn",
+        "number": 1012,
+        "title": "Refactor lexer fast path",
+        "head_sha": "bbbbbbbb",
+        "head_ref": "ksinder/lexer-fast",
+        "base_ref": "main",
+        "state": "open",
+        "draft": true,
+        "merged": false,
+        "mergeable": null,
+        "mergeable_state": "unknown",
+        "behind_by": 0,
+        "labels": [],
+        "review_decision": "REVIEW_REQUIRED",
+        "approvals": 0,
+        "in_merge_queue": false,
+        "merge_group_active": false
+      },
+      {
+        "repo": "burin-labs/harn",
+        "number": 1013,
+        "title": "Bump tree-sitter grammar",
+        "head_sha": "cccccccc",
+        "head_ref": "ksinder/ts-bump",
+        "base_ref": "main",
+        "state": "open",
+        "draft": false,
+        "merged": false,
+        "mergeable": true,
+        "mergeable_state": "behind",
+        "behind_by": 4,
+        "labels": [],
+        "review_decision": "APPROVED",
+        "approvals": 1,
+        "in_merge_queue": false,
+        "merge_group_active": false
+      },
+      {
+        "repo": "burin-labs/harn",
+        "number": 1014,
+        "title": "Risky CI change",
+        "head_sha": "dddddddd",
+        "head_ref": "ksinder/ci-risky",
+        "base_ref": "main",
+        "state": "open",
+        "draft": false,
+        "merged": false,
+        "mergeable": true,
+        "mergeable_state": "clean",
+        "behind_by": 0,
+        "labels": [],
+        "review_decision": "APPROVED",
+        "approvals": 1,
+        "in_merge_queue": false,
+        "merge_group_active": false
+      },
+      {
+        "repo": "burin-labs/harn",
+        "number": 1015,
+        "title": "Held by review label",
+        "head_sha": "eeeeeeee",
+        "head_ref": "ksinder/blocked",
+        "base_ref": "main",
+        "state": "open",
+        "draft": false,
+        "merged": false,
+        "mergeable": true,
+        "mergeable_state": "clean",
+        "behind_by": 0,
+        "labels": ["needs-revision"],
+        "review_decision": "CHANGES_REQUESTED",
+        "approvals": 0,
+        "in_merge_queue": false,
+        "merge_group_active": false
+      }
+    ],
+    "checks": {
+      "1010": [
+        {"name": "ci / rust", "status": "completed", "conclusion": "success"},
+        {"name": "ci / portal", "status": "completed", "conclusion": "success"},
+        {"name": "ci / conformance", "status": "completed", "conclusion": "success"}
+      ],
+      "1012": [],
+      "1013": [
+        {"name": "ci / rust", "status": "completed", "conclusion": "success"},
+        {"name": "ci / portal", "status": "completed", "conclusion": "success"},
+        {"name": "ci / conformance", "status": "completed", "conclusion": "success"}
+      ],
+      "1014": [
+        {"name": "ci / rust", "status": "completed", "conclusion": "failure"},
+        {"name": "ci / portal", "status": "completed", "conclusion": "success"},
+        {"name": "ci / conformance", "status": "in_progress", "conclusion": null}
+      ],
+      "1015": [
+        {"name": "ci / rust", "status": "completed", "conclusion": "success"},
+        {"name": "ci / portal", "status": "completed", "conclusion": "success"},
+        {"name": "ci / conformance", "status": "completed", "conclusion": "success"}
+      ]
+    }
+  },
+  "burin-labs/harn-cloud": {
+    "pulls": [
+      {
+        "repo": "burin-labs/harn-cloud",
+        "number": 72,
+        "title": "Spec out managed agents API",
+        "head_sha": "11111111",
+        "head_ref": "ksinder/agents-api",
+        "base_ref": "main",
+        "state": "open",
+        "draft": false,
+        "merged": false,
+        "mergeable": true,
+        "mergeable_state": "clean",
+        "behind_by": 0,
+        "labels": ["ready-to-merge"],
+        "review_decision": "APPROVED",
+        "approvals": 1,
+        "in_merge_queue": false,
+        "merge_group_active": false
+      },
+      {
+        "repo": "burin-labs/harn-cloud",
+        "number": 73,
+        "title": "Migrations missing review",
+        "head_sha": "22222222",
+        "head_ref": "ksinder/migrations",
+        "base_ref": "main",
+        "state": "open",
+        "draft": false,
+        "merged": false,
+        "mergeable": true,
+        "mergeable_state": "clean",
+        "behind_by": 0,
+        "labels": [],
+        "review_decision": "REVIEW_REQUIRED",
+        "approvals": 0,
+        "in_merge_queue": false,
+        "merge_group_active": false
+      },
+      {
+        "repo": "burin-labs/harn-cloud",
+        "number": 74,
+        "title": "Conflict on schema",
+        "head_sha": "33333333",
+        "head_ref": "ksinder/schema",
+        "base_ref": "main",
+        "state": "open",
+        "draft": false,
+        "merged": false,
+        "mergeable": false,
+        "mergeable_state": "dirty",
+        "behind_by": 0,
+        "labels": [],
+        "review_decision": "APPROVED",
+        "approvals": 1,
+        "in_merge_queue": false,
+        "merge_group_active": false
+      }
+    ],
+    "checks": {
+      "72": [
+        {"name": "ci / build", "status": "completed", "conclusion": "success"},
+        {"name": "ci / test", "status": "completed", "conclusion": "success"},
+        {"name": "ci / migrations", "status": "completed", "conclusion": "success"}
+      ],
+      "73": [
+        {"name": "ci / build", "status": "completed", "conclusion": "success"},
+        {"name": "ci / test", "status": "completed", "conclusion": "success"},
+        {"name": "ci / migrations", "status": "completed", "conclusion": "success"}
+      ],
+      "74": []
+    }
+  },
+  "burin-labs/burin-code": {
+    "pulls": [
+      {
+        "repo": "burin-labs/burin-code",
+        "number": 4221,
+        "title": "Bridge improvements",
+        "head_sha": "AAAAAAAA",
+        "head_ref": "ksinder/bridge",
+        "base_ref": "main",
+        "state": "open",
+        "draft": false,
+        "merged": false,
+        "mergeable": true,
+        "mergeable_state": "clean",
+        "behind_by": 0,
+        "labels": [],
+        "review_decision": "APPROVED",
+        "approvals": 1,
+        "in_merge_queue": false,
+        "merge_group_active": false
+      },
+      {
+        "repo": "burin-labs/burin-code",
+        "number": 4222,
+        "title": "Held PR with do-not-merge label",
+        "head_sha": "BBBBBBBB",
+        "head_ref": "ksinder/hold",
+        "base_ref": "main",
+        "state": "open",
+        "draft": false,
+        "merged": false,
+        "mergeable": true,
+        "mergeable_state": "clean",
+        "behind_by": 0,
+        "labels": ["do-not-merge"],
+        "review_decision": "APPROVED",
+        "approvals": 1,
+        "in_merge_queue": false,
+        "merge_group_active": false
+      }
+    ],
+    "checks": {
+      "4221": [
+        {"name": "swift / build", "status": "completed", "conclusion": "success"},
+        {"name": "swift / test", "status": "completed", "conclusion": "success"},
+        {"name": "lint", "status": "completed", "conclusion": "success"}
+      ],
+      "4222": [
+        {"name": "swift / build", "status": "completed", "conclusion": "success"},
+        {"name": "swift / test", "status": "completed", "conclusion": "success"},
+        {"name": "lint", "status": "completed", "conclusion": "success"}
+      ]
+    }
+  }
+}

--- a/personas/merge_captain/harn.toml
+++ b/personas/merge_captain/harn.toml
@@ -1,0 +1,40 @@
+[package]
+name = "harn-merge-captain-persona"
+version = "0.1.0"
+
+[[personas]]
+name = "merge_captain"
+version = "0.1.0"
+description = "Harn-native merge captain. Owns multi-repo PR queue scheduling and per-PR state transitions with durable checkpoints and merge receipts."
+entry_workflow = "manifest.harn#run"
+tools = ["github", "ci"]
+capabilities = [
+  "git.get_branch",
+  "git.get_diff",
+  "process.exec",
+  "interaction.ask",
+  "runtime.approved_plan",
+  "runtime.dry_run",
+  "runtime.pipeline_input",
+  "runtime.record_run",
+  "runtime.task",
+  "workspace.read_text",
+  "workspace.list",
+]
+autonomy_tier = "act_with_approval"
+receipt_policy = "required"
+triggers = [
+  "github.pr_opened",
+  "github.pr_synchronized",
+  "github.check_failed",
+  "github.merge_group_completed",
+]
+schedules = ["*/10 * * * *"]
+handoffs = []
+context_packs = ["repo_policy", "merge_policy", "release_policy"]
+evals = ["merge_captain_smoke"]
+owner = "platform"
+budget = { daily_usd = 12.0, frontier_escalations = 2, max_tokens = 80000, max_runtime_seconds = 900 }
+model_policy = { default_model = "gpt-5.4-mini", escalation_model = "gpt-5.4", fallback_models = ["gpt-5.2"], reasoning_effort = "medium" }
+rollout_policy = { mode = "approval_only", percentage = 100, cohorts = ["merge-captain-v1"] }
+package_source = { package = "harn-merge-captain-persona", path = "personas/merge_captain" }

--- a/personas/merge_captain/lib/checkpoint_store.harn
+++ b/personas/merge_captain/lib/checkpoint_store.harn
@@ -1,0 +1,110 @@
+// Per-PR checkpoint persistence backed by std/agent_state.
+//
+// Each tracked PR has a single key whose value is a small JSON envelope
+// that captures the last observed state, the last sweep id, and the
+// last raw observation. Resuming from a crash is a no-op: open the
+// session and `read` returns the envelope.
+import {
+  agent_state_delete,
+  agent_state_init,
+  agent_state_list,
+  agent_state_read,
+  agent_state_resume,
+  agent_state_write,
+} from "std/agent_state"
+
+/** Open or resume the agent_state session used to persist checkpoints. */
+pub fn open_checkpoints(root, session_id, writer_id) {
+  let options = {writer_id: writer_id, session_id: session_id, conflict_policy: "error"}
+  return agent_state_init(root, options)
+}
+
+/** Open in resume mode (errors if the session does not exist). */
+pub fn resume_checkpoints(root, session_id, writer_id) {
+  let options = {writer_id: writer_id, conflict_policy: "error"}
+  return agent_state_resume(root, session_id, options)
+}
+
+fn _key(repo, number) {
+  let safe_repo = repo.replace("/", "__")
+  return "pr/${safe_repo}/${to_string(number)}.json"
+}
+
+/** Save the latest observation + classification for a PR. */
+pub fn save_checkpoint(handle, sweep_id, observation, classification) {
+  let envelope = {
+    _type: "merge_captain_pr_checkpoint",
+    version: 1,
+    repo: observation.repo,
+    number: observation.number,
+    head_sha: observation.head_sha,
+    last_sweep_id: sweep_id,
+    last_state: classification.state,
+    last_action: classification.action,
+    last_observed_at: now_ms(),
+    snapshot: {
+      title: observation.title,
+      base_ref: observation.base_ref,
+      head_ref: observation.head_ref,
+      labels: observation.labels,
+      approvals: observation.approvals,
+      behind_by: observation.behind_by,
+      mergeable_state: observation.mergeable_state,
+      in_merge_queue: observation.in_merge_queue,
+      merge_group_active: observation.merge_group_active,
+    },
+  }
+  agent_state_write(handle, _key(observation.repo, observation.number), json_stringify(envelope))
+  return envelope
+}
+
+/** Load the saved checkpoint for a PR, or nil. */
+pub fn load_checkpoint(handle, repo, number) {
+  let raw = agent_state_read(handle, _key(repo, number))
+  if raw == nil {
+    return nil
+  }
+  let parsed = try {
+    json_parse(raw)
+  }
+  if !is_ok(parsed) {
+    return nil
+  }
+  return unwrap(parsed)
+}
+
+/** List all checkpoints currently held by the session. */
+pub fn list_all_checkpoints(handle) {
+  let keys = agent_state_list(handle)
+  return keys.filter({ k -> k.starts_with("pr/") })
+    .map(
+    { k ->
+      let raw = agent_state_read(handle, k)
+      let parsed = try {
+        json_parse(raw)
+      }
+      if is_ok(parsed) {
+        unwrap(parsed)
+      } else {
+        nil
+      }
+    },
+  )
+    .filter(
+    { env -> env != nil },
+  )
+}
+
+/** Drop a checkpoint (e.g. for a merged or closed PR we no longer track). */
+pub fn forget_checkpoint(handle, repo, number) {
+  agent_state_delete(handle, _key(repo, number))
+}
+
+/** Snapshot the prior state for a PR, defaulting to "discovered". */
+pub fn prior_state_for(handle, repo, number) {
+  let env = load_checkpoint(handle, repo, number)
+  if env == nil {
+    return "discovered"
+  }
+  return env.last_state ?? "discovered"
+}

--- a/personas/merge_captain/lib/classifier.harn
+++ b/personas/merge_captain/lib/classifier.harn
@@ -1,0 +1,138 @@
+// PR observation -> next state + action.
+//
+// Pure: takes (observation, policy, prior_state) and returns
+// {state, action, reason, evidence}. Tests cover every branch.
+import {
+  checks_pass,
+  has_required_approvals,
+  is_behind,
+  is_blocked_by_label,
+  is_closed,
+  is_dirty,
+  is_merged,
+} from "observation"
+import { allowed_next, is_valid_transition, unknown_state } from "states"
+
+/** Result of classifying a single observation. */
+fn _result(state, action, reason, evidence) {
+  return {state: state, action: action, reason: reason, evidence: evidence}
+}
+
+/** Classify an observation under a repo policy. */
+pub fn classify(observation, policy, prior_state) {
+  let obs = observation
+  // Terminal observations override anything we previously thought.
+  if is_merged(obs) {
+    return _result("merged", "mark_merged", "PR is merged on remote", {merged: true})
+  }
+  if is_closed(obs) {
+    return _result("closed", "archive", "PR is closed without merge", {state: obs.state})
+  }
+  // Drafts wait until they are marked ready.
+  if obs.draft {
+    return _result("draft", "wait", "PR is still in draft", {draft: true})
+  }
+  // Already in the merge queue or actively running through it.
+  if obs.merge_group_active {
+    return _result("merge_group_running", "wait", "merge group is running", {})
+  }
+  if obs.in_merge_queue {
+    return _result("queued", "wait", "PR is on the merge queue", {})
+  }
+  // Hard blockers come next: explicit labels and dirty branches.
+  if is_blocked_by_label(obs, policy.blocking_labels) {
+    let hits = obs.labels.filter({ l -> policy.blocking_labels.contains(l) })
+    return _result("blocked", "escalate_human", "blocked by label", {labels: hits})
+  }
+  if is_dirty(obs) {
+    return _result(
+      "dirty",
+      "comment",
+      "PR has merge conflicts",
+      {mergeable_state: obs.mergeable_state, mergeable: obs.mergeable},
+    )
+  }
+  // Required CI: if anything failed we either escalate or repair locally.
+  if len(obs.failed_required_checks) > 0 {
+    let action = if len(policy.local_verification) > 0 {
+      "run_local_verification"
+    } else {
+      "escalate_human"
+    }
+    let next = if len(policy.local_verification) > 0 {
+      "local_repair"
+    } else {
+      "failing_ci"
+    }
+    return _result(next, action, "required CI checks failed", {failed: obs.failed_required_checks})
+  }
+  // Branch is behind base: update before requeuing.
+  if is_behind(obs) {
+    return _result(
+      "behind",
+      "update_branch",
+      "branch is behind base",
+      {behind_by: obs.behind_by, mergeable_state: obs.mergeable_state},
+    )
+  }
+  // Required CI: if anything is still pending, just wait.
+  if !checks_pass(obs) {
+    return _result(
+      "waiting_checks",
+      "wait",
+      "required checks still running",
+      {missing: obs.missing_required_checks},
+    )
+  }
+  // Approvals: ensure the human review gate is satisfied.
+  if !has_required_approvals(obs, policy.required_review_count) {
+    let needed = policy.required_review_count - obs.approvals
+    return _result(
+      "blocked",
+      "request_review",
+      "need ${to_string(needed)} more approvals",
+      {have: obs.approvals, need: policy.required_review_count},
+    )
+  }
+  // Ready label gate (optional, when policy declares one).
+  if policy.ready_label != nil && !obs.labels.contains(policy.ready_label) {
+    return _result(
+      "blocked",
+      "wait",
+      "missing required ready_label '${policy.ready_label}'",
+      {ready_label: policy.ready_label, observed_labels: obs.labels},
+    )
+  }
+  // Cleared all gates: queue or admin-merge depending on repo policy.
+  if policy.merge_queue_enabled {
+    return _result(
+      "queued",
+      "enqueue_merge_queue",
+      "all gates passed; enqueueing on the merge queue",
+      {merge_method: policy.merge_method},
+    )
+  }
+  return _result(
+    "queued",
+    "enqueue_merge_queue",
+    "all gates passed; ready to merge",
+    {merge_method: policy.merge_method},
+  )
+}
+
+/** Compute the prior state to use when starting from no checkpoint. */
+pub fn initial_prior() {
+  return unknown_state()
+}
+
+/** Sanity-check a classification against the legal-edge table. */
+pub fn verify(prior_state, classification) {
+  if !is_valid_transition(prior_state, classification.state) {
+    return {
+      ok: false,
+      error: "illegal transition: ${prior_state} -> ${classification.state}",
+      allowed: allowed_next(prior_state),
+    }
+  }
+  return {ok: true}
+}

--- a/personas/merge_captain/lib/github_adapter.harn
+++ b/personas/merge_captain/lib/github_adapter.harn
@@ -1,0 +1,140 @@
+/**
+ * Typed GitHub adapter for Merge Captain. All GitHub I/O routes through
+ * this module. In live mode it dispatches directly to the registered
+ * `github` connector via `connector_call`; in fixture mode it serves a
+ * pre-recorded snapshot. Tests and evals run entirely on fixtures, so
+ * the state machine never reaches for `process.exec` or shells out to
+ * `gh`.
+ */
+fn _gh(method, params) {
+  return connector_call("github", method, params)
+}
+
+/** Construct a live adapter that dispatches to the github connector. */
+pub fn live_adapter() {
+  return {mode: "live", snapshot: nil}
+}
+
+/** Construct a fixture adapter from an in-memory snapshot dict. */
+pub fn fixture_adapter(snapshot) {
+  return {mode: "fixture", snapshot: snapshot}
+}
+
+/** List open PRs in a repository. */
+pub fn list_open_prs(adapter, repo) {
+  if adapter.mode == "fixture" {
+    let bucket = adapter.snapshot[repo]
+    if bucket == nil {
+      return []
+    }
+    return (bucket.pulls ?? []).filter({ pr -> pr.state == "open" })
+  }
+  let parts = repo.split("/")
+  let path = "/repos/${parts[0]}/${parts[1]}/pulls?state=open&per_page=100"
+  let result = _gh("api_call", {path: path, method: "GET"})
+  return result ?? []
+}
+
+/** Fetch detailed PR + checks data. */
+pub fn get_pr_details(adapter, repo, number) {
+  if adapter.mode == "fixture" {
+    let bucket = adapter.snapshot[repo]
+    if bucket == nil {
+      return nil
+    }
+    var found = nil
+    for pr in bucket.pulls ?? [] {
+      if pr.number == number {
+        found = pr
+      }
+    }
+    if found == nil {
+      return nil
+    }
+    let checks_for = (bucket.checks ?? {})[to_string(number)] ?? []
+    return {pr: found, checks: checks_for}
+  }
+  let parts = repo.split("/")
+  let pr = _gh("api_call", {path: "/repos/${parts[0]}/${parts[1]}/pulls/${to_string(number)}", method: "GET"})
+  let checks_envelope = _gh(
+    "api_call",
+    {path: "/repos/${parts[0]}/${parts[1]}/commits/${pr.head.sha}/check-runs", method: "GET"},
+  )
+  let runs = checks_envelope?.check_runs ?? []
+  return {pr: normalize_pr(pr), checks: runs}
+}
+
+/** Normalize a raw GitHub PR API payload into our minimal shape. */
+pub fn normalize_pr(api_pr) {
+  let labels = (api_pr.labels ?? []).map({ l -> l.name })
+  return {
+    repo: api_pr.base?.repo?.full_name ?? "",
+    number: api_pr.number,
+    title: api_pr.title ?? "",
+    head_sha: api_pr.head?.sha ?? "",
+    head_ref: api_pr.head?.ref ?? "",
+    base_ref: api_pr.base?.ref ?? "main",
+    state: api_pr.state ?? "open",
+    draft: api_pr.draft ?? false,
+    merged: api_pr.merged ?? false,
+    mergeable: api_pr.mergeable,
+    mergeable_state: api_pr.mergeable_state ?? "unknown",
+    behind_by: api_pr.behind_by ?? 0,
+    labels: labels,
+    review_decision: api_pr.review_decision ?? "REVIEW_REQUIRED",
+    approvals: api_pr.approvals ?? 0,
+    in_merge_queue: api_pr.auto_merge != nil,
+    merge_group_active: api_pr.merge_group_active ?? false,
+  }
+}
+
+/** Update a PR branch (rebase/merge from base). */
+pub fn update_branch(adapter, repo, number, dry_run) {
+  if dry_run || adapter.mode == "fixture" {
+    return {ok: true, dry_run: true, mode: adapter.mode}
+  }
+  let parts = repo.split("/")
+  let path = "/repos/${parts[0]}/${parts[1]}/pulls/${to_string(number)}/update-branch"
+  let response = _gh("api_call", {path: path, method: "PUT", body: {}})
+  return {ok: true, response: response}
+}
+
+/** Enqueue a PR onto the merge queue. */
+pub fn enqueue_merge_queue(adapter, repo, number, merge_method, dry_run) {
+  if dry_run || adapter.mode == "fixture" {
+    return {ok: true, dry_run: true, mode: adapter.mode}
+  }
+  let pr_url = "https://github.com/${repo}/pull/${to_string(number)}"
+  let response = _gh("merge_pr", {pr_url: pr_url, merge_method: merge_method, queue: true})
+  return {ok: true, response: response}
+}
+
+/** Add a label to a PR. */
+pub fn add_label(adapter, repo, number, label, dry_run) {
+  if dry_run || adapter.mode == "fixture" {
+    return {ok: true, dry_run: true, mode: adapter.mode}
+  }
+  let issue_url = "https://github.com/${repo}/issues/${to_string(number)}"
+  let response = _gh("add_labels", {issue_url: issue_url, labels: [label]})
+  return {ok: true, response: response}
+}
+
+/** Comment on a PR. */
+pub fn comment(adapter, repo, number, body, dry_run) {
+  if dry_run || adapter.mode == "fixture" {
+    return {ok: true, dry_run: true, mode: adapter.mode}
+  }
+  let issue_url = "https://github.com/${repo}/issues/${to_string(number)}"
+  let response = _gh("comment", {issue_url: issue_url, body: body})
+  return {ok: true, response: response}
+}
+
+/** Request reviews on a PR. */
+pub fn request_review(adapter, repo, number, reviewers, dry_run) {
+  if dry_run || adapter.mode == "fixture" {
+    return {ok: true, dry_run: true, mode: adapter.mode}
+  }
+  let pr_url = "https://github.com/${repo}/pull/${to_string(number)}"
+  let response = _gh("request_review", {pr_url: pr_url, reviewers: reviewers})
+  return {ok: true, response: response}
+}

--- a/personas/merge_captain/lib/local_verify.harn
+++ b/personas/merge_captain/lib/local_verify.harn
@@ -1,0 +1,69 @@
+// Local verification commands.
+//
+// Runs each command listed in the per-repo policy and returns a record
+// the receipt can attach. In dry-run mode the commands are recorded but
+// not executed.
+import { process_exec_with_timeout } from "std/runtime"
+
+/** Run all local verification commands for a repo. */
+pub fn run_local_verify(commands, dry_run) {
+  let timeout_ms = 600000
+  return commands
+    .map(
+    { cmd ->
+      if dry_run {
+        {
+          name: cmd.name ?? cmd.command,
+          command: cmd.command,
+          status: "skipped_dry_run",
+          exit_code: nil,
+          stdout: "",
+          stderr: "",
+        }
+      } else {
+        let started = now_ms()
+        let result = try {
+          process_exec_with_timeout(cmd.command, cmd.timeout_ms ?? timeout_ms)
+        }
+        let finished = now_ms()
+        if !is_ok(result) {
+          {
+            name: cmd.name ?? cmd.command,
+            command: cmd.command,
+            status: "error",
+            exit_code: nil,
+            stdout: "",
+            stderr: to_string(unwrap_err(result)),
+            duration_ms: finished - started,
+          }
+        } else {
+          let v = unwrap(result)
+          let exit_code = v.exit_code ?? 0
+          {
+            name: cmd.name ?? cmd.command,
+            command: cmd.command,
+            status: if exit_code == 0 {
+              "ok"
+            } else {
+              "failed"
+            },
+            exit_code: exit_code,
+            stdout: v.stdout ?? "",
+            stderr: v.stderr ?? "",
+            duration_ms: finished - started,
+          }
+        }
+      }
+    },
+  )
+}
+
+/** True when every command in the verification result succeeded. */
+pub fn all_ok(results) {
+  for r in results {
+    if r.status != "ok" && r.status != "skipped_dry_run" {
+      return false
+    }
+  }
+  return true
+}

--- a/personas/merge_captain/lib/observation.harn
+++ b/personas/merge_captain/lib/observation.harn
@@ -1,0 +1,102 @@
+// PR observation shape.
+//
+// Observations are plain dicts produced by an adapter (live GitHub or
+// fixture). Keeping them in their own module lets the classifier and the
+// receipt builder agree on field names without depending on either I/O
+// path.
+/** Build a normalized observation from raw GitHub PR + checks data. */
+pub fn from_github(pr, checks, required_checks) {
+  let observed_checks = (checks ?? [])
+    .map(
+    { check -> {
+      name: check.name ?? check.context ?? "",
+      status: check.status ?? "unknown",
+      conclusion: check.conclusion ?? nil,
+    } },
+  )
+  let conclusion_for = { name ->
+    var found = nil
+    for c in observed_checks {
+      if c.name == name {
+        found = c
+      }
+    }
+    found
+  }
+  let missing_required = (required_checks ?? [])
+    .filter(
+    { name ->
+      let c = conclusion_for(name)
+      c == nil || c.status != "completed"
+    },
+  )
+  let failed_required = (required_checks ?? [])
+    .filter(
+    { name ->
+      let c = conclusion_for(name)
+      c != nil && c.status == "completed" && c.conclusion != "success" && c.conclusion != "neutral"
+    },
+  )
+  return {
+    repo: pr.repo,
+    number: pr.number,
+    title: pr.title ?? "",
+    head_sha: pr.head_sha ?? "",
+    base_ref: pr.base_ref ?? "main",
+    head_ref: pr.head_ref ?? "",
+    state: pr.state ?? "open",
+    draft: pr.draft ?? false,
+    merged: pr.merged ?? false,
+    mergeable: pr.mergeable,
+    mergeable_state: pr.mergeable_state ?? "unknown",
+    behind_by: pr.behind_by ?? 0,
+    labels: pr.labels ?? [],
+    review_decision: pr.review_decision ?? "REVIEW_REQUIRED",
+    approvals: pr.approvals ?? 0,
+    in_merge_queue: pr.in_merge_queue ?? false,
+    merge_group_active: pr.merge_group_active ?? false,
+    checks: observed_checks,
+    missing_required_checks: missing_required,
+    failed_required_checks: failed_required,
+  }
+}
+
+/** Quick predicate helpers used by the classifier and tests. */
+pub fn is_merged(obs) {
+  return obs.merged
+}
+
+/** True when the PR is closed without being merged. */
+pub fn is_closed(obs) {
+  return obs.state == "closed" && !is_merged(obs)
+}
+
+/** True when the PR has merge conflicts. */
+pub fn is_dirty(obs) {
+  return obs.mergeable_state == "dirty" || !obs.mergeable
+}
+
+/** True when the branch is behind the base. */
+pub fn is_behind(obs) {
+  return obs.behind_by > 0 || obs.mergeable_state == "behind"
+}
+
+/** True when any of the policy's blocking labels are on the PR. */
+pub fn is_blocked_by_label(obs, blocking_labels) {
+  for label in obs.labels {
+    if blocking_labels.contains(label) {
+      return true
+    }
+  }
+  return false
+}
+
+/** True when the PR has at least the required review count. */
+pub fn has_required_approvals(obs, required) {
+  return obs.approvals >= required
+}
+
+/** True when no required check is missing or failing. */
+pub fn checks_pass(obs) {
+  return len(obs.missing_required_checks) == 0 && len(obs.failed_required_checks) == 0
+}

--- a/personas/merge_captain/lib/policy.harn
+++ b/personas/merge_captain/lib/policy.harn
@@ -1,0 +1,92 @@
+// Per-repo Merge Captain policy.
+//
+// Policies are simple JSON documents loaded from disk. This module
+// validates the shape, applies defaults, and exposes typed accessors.
+/** Default policy values for fields the user can omit. */
+pub fn defaults() {
+  return {
+    merge_method: "squash",
+    merge_queue_enabled: false,
+    required_checks: [],
+    required_review_count: 1,
+    blocking_labels: ["do-not-merge", "needs-revision", "blocked"],
+    ready_label: nil,
+    max_in_flight: 4,
+    local_verification: [],
+    downstream: [],
+    bump_after_merge: nil,
+    autopilot_states: ["queued", "waiting_checks"],
+    require_human_for: ["blocked", "local_repair"],
+  }
+}
+
+/** Merge a parsed policy on top of the defaults. */
+pub fn with_defaults(policy) {
+  let base = defaults()
+  return {
+    repo: policy.repo,
+    default_branch: policy.default_branch ?? "main",
+    merge_method: policy.merge_method ?? base.merge_method,
+    merge_queue_enabled: policy.merge_queue_enabled ?? base.merge_queue_enabled,
+    required_checks: policy.required_checks ?? base.required_checks,
+    required_review_count: policy.required_review_count ?? base.required_review_count,
+    blocking_labels: policy.blocking_labels ?? base.blocking_labels,
+    ready_label: policy.ready_label ?? base.ready_label,
+    max_in_flight: policy.max_in_flight ?? base.max_in_flight,
+    local_verification: policy.local_verification ?? base.local_verification,
+    downstream: policy.downstream ?? base.downstream,
+    bump_after_merge: policy.bump_after_merge ?? base.bump_after_merge,
+    autopilot_states: policy.autopilot_states ?? base.autopilot_states,
+    require_human_for: policy.require_human_for ?? base.require_human_for,
+  }
+}
+
+/** Validate a policy. Returns nil on success or a string error. */
+pub fn validate(policy) {
+  if policy.repo == nil || len(to_string(policy.repo)) == 0 {
+    return "policy.repo is required"
+  }
+  let valid_methods = ["merge", "squash", "rebase"]
+  if !valid_methods.contains(policy.merge_method) {
+    return "policy.merge_method must be one of merge|squash|rebase"
+  }
+  if policy.required_review_count < 0 {
+    return "policy.required_review_count must be >= 0"
+  }
+  if policy.max_in_flight <= 0 {
+    return "policy.max_in_flight must be > 0"
+  }
+  for cmd in policy.local_verification {
+    if cmd.command == nil || len(to_string(cmd.command)) == 0 {
+      return "policy.local_verification[].command is required"
+    }
+  }
+  return nil
+}
+
+/** Parse + default + validate. Returns {ok: true, policy} or {ok: false, error}. */
+pub fn load_policy(json_text) {
+  let parsed_result = try {
+    json_parse(json_text)
+  }
+  if !is_ok(parsed_result) {
+    return {ok: false, error: "policy json parse failed: ${unwrap_err(parsed_result)}"}
+  }
+  let parsed = unwrap(parsed_result)
+  let policy = with_defaults(parsed)
+  let err = validate(policy)
+  if err != nil {
+    return {ok: false, error: err}
+  }
+  return {ok: true, policy: policy}
+}
+
+/** Returns true when a state is on the per-repo autopilot list. */
+pub fn autopilot_for(policy, state) {
+  return policy.autopilot_states.contains(state)
+}
+
+/** Returns true when a state requires a human-in-the-loop step. */
+pub fn requires_human(policy, state) {
+  return policy.require_human_for.contains(state)
+}

--- a/personas/merge_captain/lib/receipt.harn
+++ b/personas/merge_captain/lib/receipt.harn
@@ -1,0 +1,117 @@
+// Merge receipt builder.
+//
+// One receipt per (sweep, repo, pr). Captures everything an auditor needs
+// to retrace a decision: the classification, the action chosen, the
+// evidence the classifier saw, the approval state under the per-repo
+// autopilot policy, the local commands actually executed, the checks
+// observed, and the final outcome.
+import { autopilot_for, requires_human } from "policy"
+import { action_is_mutating } from "states"
+
+/** Build the per-PR merge receipt. */
+pub fn build_receipt(args) {
+  let policy = args.policy
+  let observation = args.observation
+  let classification = args.classification
+  let prior_state = args.prior_state ?? "discovered"
+  let commands = args.commands_run ?? []
+  let outcome = args.outcome ?? "wait"
+  let dry_run = args.dry_run ?? true
+  let approval = approval_state(policy, classification, dry_run)
+  let evidence = evidence_payload(observation, classification)
+  return {
+    _type: "merge_receipt",
+    version: 1,
+    persona: "merge_captain",
+    sweep_id: args.sweep_id,
+    observed_at: args.observed_at,
+    repo: observation.repo,
+    pr_number: observation.number,
+    pr_title: observation.title,
+    head_sha: observation.head_sha,
+    prior_state: prior_state,
+    classification: {state: classification.state, action: classification.action, reason: classification.reason},
+    evidence: evidence,
+    approval_state: approval,
+    commands_run: commands,
+    checks_observed: observation.checks,
+    final_outcome: outcome,
+    policy_summary: {
+      merge_method: policy.merge_method,
+      merge_queue_enabled: policy.merge_queue_enabled,
+      required_review_count: policy.required_review_count,
+      blocking_labels: policy.blocking_labels,
+      required_checks: policy.required_checks,
+    },
+  }
+}
+
+/** Decide approval state given policy and dry-run posture. */
+pub fn approval_state(policy, classification, dry_run) {
+  if requires_human(policy, classification.state) {
+    return "needs_human"
+  }
+  if !action_is_mutating(classification.action) {
+    return "no_mutation"
+  }
+  if dry_run {
+    return "dry_run"
+  }
+  if autopilot_for(policy, classification.state) {
+    return "autopilot"
+  }
+  return "needs_human"
+}
+
+/** Evidence payload mixed into the receipt. */
+pub fn evidence_payload(observation, classification) {
+  let extras = classification.evidence ?? {}
+  return {
+    classifier: extras,
+    snapshot: {
+      state: observation.state,
+      draft: observation.draft,
+      mergeable: observation.mergeable,
+      mergeable_state: observation.mergeable_state,
+      behind_by: observation.behind_by,
+      approvals: observation.approvals,
+      labels: observation.labels,
+      review_decision: observation.review_decision,
+      in_merge_queue: observation.in_merge_queue,
+      merge_group_active: observation.merge_group_active,
+      failed_required_checks: observation.failed_required_checks,
+      missing_required_checks: observation.missing_required_checks,
+    },
+  }
+}
+
+/** Roll up per-PR receipts into a sweep-level summary. */
+pub fn summarize_sweep(receipts, sweep_id, started_at, finished_at) {
+  var by_state = {}
+  var by_action = {}
+  var by_repo = {}
+  for receipt in receipts {
+    let state = receipt.classification.state
+    let action = receipt.classification.action
+    let repo = receipt.repo
+    let prior_state_count = by_state[state] ?? 0
+    let prior_action_count = by_action[action] ?? 0
+    let prior_repo_count = by_repo[repo] ?? 0
+    by_state[state] = prior_state_count + 1
+    by_action[action] = prior_action_count + 1
+    by_repo[repo] = prior_repo_count + 1
+  }
+  return {
+    _type: "merge_sweep_summary",
+    version: 1,
+    persona: "merge_captain",
+    sweep_id: sweep_id,
+    started_at: started_at,
+    finished_at: finished_at,
+    pr_count: len(receipts),
+    by_state: by_state,
+    by_action: by_action,
+    by_repo: by_repo,
+    receipts: receipts,
+  }
+}

--- a/personas/merge_captain/lib/scheduler.harn
+++ b/personas/merge_captain/lib/scheduler.harn
@@ -1,0 +1,323 @@
+// Sweep scheduler.
+//
+// One sweep iterates every configured repo, discovers open PRs (live or
+// from fixture), classifies each PR, persists the resulting checkpoint,
+// runs whatever local action the classification calls for, and records
+// the merge receipt. Newly opened PRs are picked up automatically
+// because discovery runs every sweep; PRs that disappear from the open
+// list because they were merged or closed receive a final receipt and
+// have their checkpoint dropped.
+import {
+  forget_checkpoint,
+  list_all_checkpoints,
+  prior_state_for,
+  save_checkpoint,
+} from "checkpoint_store"
+import { classify, verify } from "classifier"
+import {
+  add_label,
+  comment,
+  enqueue_merge_queue,
+  get_pr_details,
+  list_open_prs,
+  request_review,
+  update_branch,
+} from "github_adapter"
+import { run_local_verify } from "local_verify"
+import { from_github } from "observation"
+import { load_policy } from "policy"
+import { build_receipt, summarize_sweep } from "receipt"
+import { is_terminal } from "states"
+
+fn _gen_sweep_id() {
+  return "sweep-${to_string(now_ms())}"
+}
+
+/** Apply the action a classification calls for, returning an outcome string. */
+pub fn apply_action(adapter, policy, observation, classification, dry_run) {
+  let action = classification.action
+  if action == "noop" || action == "wait" {
+    return {outcome: "wait", commands: []}
+  }
+  if action == "mark_merged" {
+    return {outcome: "merged", commands: []}
+  }
+  if action == "archive" {
+    return {outcome: "closed", commands: []}
+  }
+  if action == "update_branch" {
+    let resp = update_branch(adapter, observation.repo, observation.number, dry_run)
+    return {
+      outcome: if dry_run {
+        "dry_run"
+      } else {
+        "branch_updated"
+      },
+      commands: [{action: "update_branch", response: resp}],
+    }
+  }
+  if action == "enqueue_merge_queue" {
+    let resp = enqueue_merge_queue(adapter, observation.repo, observation.number, policy.merge_method, dry_run)
+    return {
+      outcome: if dry_run {
+        "dry_run"
+      } else {
+        "enqueued"
+      },
+      commands: [{action: "enqueue_merge_queue", response: resp}],
+    }
+  }
+  if action == "request_review" {
+    let resp = request_review(adapter, observation.repo, observation.number, [], dry_run)
+    return {
+      outcome: if dry_run {
+        "dry_run"
+      } else {
+        "review_requested"
+      },
+      commands: [{action: "request_review", response: resp}],
+    }
+  }
+  if action == "comment" {
+    let body = "merge_captain: ${classification.reason}"
+    let resp = comment(adapter, observation.repo, observation.number, body, dry_run)
+    return {
+      outcome: if dry_run {
+        "dry_run"
+      } else {
+        "commented"
+      },
+      commands: [{action: "comment", body: body, response: resp}],
+    }
+  }
+  if action == "add_label" {
+    let label = "merge-captain-blocked"
+    let resp = add_label(adapter, observation.repo, observation.number, label, dry_run)
+    return {
+      outcome: if dry_run {
+        "dry_run"
+      } else {
+        "labeled"
+      },
+      commands: [{action: "add_label", label: label, response: resp}],
+    }
+  }
+  if action == "run_local_verification" {
+    let results = run_local_verify(policy.local_verification, dry_run)
+    return {
+      outcome: if dry_run {
+        "dry_run"
+      } else {
+        "verified"
+      },
+      commands: [{action: "run_local_verification", results: results}],
+    }
+  }
+  if action == "escalate_human" {
+    return {outcome: "escalated", commands: [{action: "escalate_human"}]}
+  }
+  return {outcome: "noop", commands: []}
+}
+
+/** Process a single PR: classify, persist, act, build receipt. */
+pub fn process_pr(args) {
+  let adapter = args.adapter
+  let policy = args.policy
+  let raw_pr = args.pr
+  let checkpoint_handle = args.checkpoint_handle
+  let sweep_id = args.sweep_id
+  let dry_run = args.dry_run
+  let detail = get_pr_details(adapter, policy.repo, raw_pr.number)
+  if detail == nil {
+    return nil
+  }
+  let observation = from_github(detail.pr, detail.checks, policy.required_checks)
+  let prior = prior_state_for(checkpoint_handle, observation.repo, observation.number)
+  let classification = classify(observation, policy, prior)
+  let edge = verify(prior, classification)
+  if !edge.ok {
+    let safe_class = {
+      state: classification.state,
+      action: "escalate_human",
+      reason: "${classification.reason} (illegal transition; ${edge.error})",
+      evidence: classification.evidence,
+    }
+    let action_result = apply_action(adapter, policy, observation, safe_class, dry_run)
+    save_checkpoint(checkpoint_handle, sweep_id, observation, safe_class)
+    return build_receipt(
+      {
+        sweep_id: sweep_id,
+        observed_at: now_ms(),
+        policy: policy,
+        observation: observation,
+        classification: safe_class,
+        prior_state: prior,
+        commands_run: action_result.commands,
+        outcome: action_result.outcome,
+        dry_run: dry_run,
+      },
+    )
+  }
+  let action_result = apply_action(adapter, policy, observation, classification, dry_run)
+  if is_terminal(classification.state) {
+    forget_checkpoint(checkpoint_handle, observation.repo, observation.number)
+  } else {
+    save_checkpoint(checkpoint_handle, sweep_id, observation, classification)
+  }
+  return build_receipt(
+    {
+      sweep_id: sweep_id,
+      observed_at: now_ms(),
+      policy: policy,
+      observation: observation,
+      classification: classification,
+      prior_state: prior,
+      commands_run: action_result.commands,
+      outcome: action_result.outcome,
+      dry_run: dry_run,
+    },
+  )
+}
+
+/** Reconcile PRs that disappeared from the open list (merged or closed remotely). */
+pub fn reconcile_disappeared(args) {
+  let adapter = args.adapter
+  let checkpoint_handle = args.checkpoint_handle
+  let policy = args.policy
+  let sweep_id = args.sweep_id
+  let dry_run = args.dry_run
+  let observed_numbers = args.observed_numbers
+  var receipts = []
+  let stale = list_all_checkpoints(checkpoint_handle)
+    .filter(
+    { env -> env.repo == policy.repo && !observed_numbers.contains(env.number) },
+  )
+  for env in stale {
+    let detail = get_pr_details(adapter, env.repo, env.number)
+    let final_obs = if detail != nil {
+      from_github(detail.pr, detail.checks, policy.required_checks)
+    } else {
+      {
+        repo: env.repo,
+        number: env.number,
+        title: env.snapshot?.title ?? "",
+        head_sha: env.head_sha,
+        base_ref: env.snapshot?.base_ref ?? "main",
+        head_ref: env.snapshot?.head_ref ?? "",
+        state: "closed",
+        draft: false,
+        merged: false,
+        mergeable: nil,
+        mergeable_state: "unknown",
+        behind_by: 0,
+        labels: env.snapshot?.labels ?? [],
+        review_decision: "REVIEW_REQUIRED",
+        approvals: env.snapshot?.approvals ?? 0,
+        in_merge_queue: false,
+        merge_group_active: false,
+        checks: [],
+        missing_required_checks: [],
+        failed_required_checks: [],
+      }
+    }
+    let next_state = if final_obs.merged {
+      "merged"
+    } else {
+      "closed"
+    }
+    let action = if final_obs.merged {
+      "mark_merged"
+    } else {
+      "archive"
+    }
+    let synthetic = {
+      state: next_state,
+      action: action,
+      reason: "PR no longer in open list",
+      evidence: {previously: env.last_state},
+    }
+    let action_result = apply_action(adapter, policy, final_obs, synthetic, dry_run)
+    forget_checkpoint(checkpoint_handle, env.repo, env.number)
+    let receipt = build_receipt(
+      {
+        sweep_id: sweep_id,
+        observed_at: now_ms(),
+        policy: policy,
+        observation: final_obs,
+        classification: synthetic,
+        prior_state: env.last_state,
+        commands_run: action_result.commands,
+        outcome: action_result.outcome,
+        dry_run: dry_run,
+      },
+    )
+    receipts = receipts + [receipt]
+  }
+  return receipts
+}
+
+/** Run a single sweep across all configured repos. */
+pub fn sweep(args) {
+  let adapter = args.adapter
+  let policies = args.policies
+  let checkpoint_handle = args.checkpoint_handle
+  let dry_run = args.dry_run ?? true
+  let sweep_id = args.sweep_id ?? _gen_sweep_id()
+  let started_at = now_ms()
+  var all_receipts = []
+  for policy in policies {
+    var receipts_for_repo = []
+    var observed_numbers = []
+    let open_prs = list_open_prs(adapter, policy.repo)
+    let trimmed = if len(open_prs) > policy.max_in_flight {
+      open_prs[0:policy.max_in_flight]
+    } else {
+      open_prs
+    }
+    for pr in trimmed {
+      observed_numbers = observed_numbers + [pr.number]
+      let receipt = process_pr(
+        {
+          adapter: adapter,
+          policy: policy,
+          pr: pr,
+          checkpoint_handle: checkpoint_handle,
+          sweep_id: sweep_id,
+          dry_run: dry_run,
+        },
+      )
+      if receipt != nil {
+        receipts_for_repo = receipts_for_repo + [receipt]
+      }
+    }
+    let disappeared = reconcile_disappeared(
+      {
+        adapter: adapter,
+        policy: policy,
+        checkpoint_handle: checkpoint_handle,
+        sweep_id: sweep_id,
+        dry_run: dry_run,
+        observed_numbers: observed_numbers,
+      },
+    )
+    all_receipts = all_receipts + receipts_for_repo + disappeared
+  }
+  let finished_at = now_ms()
+  return summarize_sweep(all_receipts, sweep_id, started_at, finished_at)
+}
+
+/** Helper for fixture-based runs: load a list of policy json paths. */
+pub fn load_policies(paths) {
+  var ok_policies = []
+  var errors = []
+  for path in paths {
+    let raw = read_file(path)
+    let res = load_policy(raw)
+    if res.ok {
+      ok_policies = ok_policies + [res.policy]
+    } else {
+      errors = errors + ["${path}: ${res.error}"]
+    }
+  }
+  return {policies: ok_policies, errors: errors}
+}

--- a/personas/merge_captain/lib/states.harn
+++ b/personas/merge_captain/lib/states.harn
@@ -1,0 +1,117 @@
+// Merge Captain state machine.
+//
+// Owns the canonical list of PR states and the legality of transitions
+// between them. Keep this module pure: no I/O, no time, no network.
+/** All states a tracked PR can occupy. */
+pub fn all_states() {
+  return [
+    "discovered",
+    "draft",
+    "waiting_checks",
+    "behind",
+    "dirty",
+    "queued",
+    "merge_group_running",
+    "failing_ci",
+    "local_repair",
+    "blocked",
+    "merged",
+    "closed",
+  ]
+}
+
+/** True when state is one of the canonical states. */
+pub fn is_state(state) {
+  return all_states().contains(state)
+}
+
+/** Terminal states do not transition further within a sweep. */
+pub fn is_terminal(state) {
+  return state == "merged" || state == "closed"
+}
+
+/** Active states still consume scheduler attention. */
+pub fn is_active(state) {
+  return !is_terminal(state)
+}
+
+/** Synthetic "no prior" sentinel returned for first-observation PRs. */
+pub fn unknown_state() {
+  return "discovered"
+}
+
+/** Allowed actions, ranked from least to most invasive. */
+pub fn all_actions() {
+  return [
+    "noop",
+    "wait",
+    "request_review",
+    "comment",
+    "add_label",
+    "update_branch",
+    "run_local_verification",
+    "enqueue_merge_queue",
+    "mark_merged",
+    "archive",
+    "escalate_human",
+  ]
+}
+
+/** True when the action mutates remote state. */
+pub fn action_is_mutating(action) {
+  let read_only = ["noop", "wait", "comment"]
+  return !read_only.contains(action)
+}
+
+/**
+ * Legal forward edges, expressed as a directed graph. Used by tests and
+ * the receipt validator to surface accidental skips (e.g. discovered ->
+ * merged with no observed evidence).
+ */
+fn _transitions() {
+  return {
+    discovered: [
+      "draft",
+      "waiting_checks",
+      "behind",
+      "dirty",
+      "blocked",
+      "failing_ci",
+      "local_repair",
+      "queued",
+      "merge_group_running",
+      "merged",
+      "closed",
+    ],
+    draft: ["discovered", "waiting_checks", "blocked", "closed"],
+    waiting_checks: ["queued", "failing_ci", "behind", "dirty", "blocked", "merged", "closed"],
+    behind: ["waiting_checks", "dirty", "blocked", "closed"],
+    dirty: ["local_repair", "blocked", "closed"],
+    queued: ["merge_group_running", "failing_ci", "blocked", "merged", "closed"],
+    merge_group_running: ["merged", "failing_ci", "blocked", "closed"],
+    failing_ci: ["local_repair", "blocked", "waiting_checks", "closed"],
+    local_repair: ["waiting_checks", "blocked", "closed"],
+    blocked: ["waiting_checks", "behind", "dirty", "queued", "closed", "merged"],
+    merged: [],
+    closed: [],
+  }
+}
+
+/** Returns true when prior -> next is a permitted edge. */
+pub fn is_valid_transition(prior, next) {
+  if prior == next {
+    return true
+  }
+  let table = _transitions()
+  let allowed = table[prior]
+  if allowed == nil {
+    return false
+  }
+  return allowed.contains(next)
+}
+
+/** Returns the allowed next-states from prior. */
+pub fn allowed_next(prior) {
+  let table = _transitions()
+  return table[prior] ?? []
+}

--- a/personas/merge_captain/manifest.harn
+++ b/personas/merge_captain/manifest.harn
@@ -1,0 +1,89 @@
+// Merge Captain entry pipeline.
+//
+// One invocation runs a single sweep across all configured repos. The
+// pipeline accepts arguments via runtime_pipeline_input(); when no input
+// is provided it falls back to the smoke fixture so `harn run
+// personas/merge_captain/manifest.harn` still produces a deterministic
+// receipt.
+import { runtime_pipeline_input } from "std/runtime"
+import { open_checkpoints } from "lib/checkpoint_store"
+import { fixture_adapter, live_adapter } from "lib/github_adapter"
+import { load_policies, sweep } from "lib/scheduler"
+
+fn _default_input() {
+  return {
+    mode: "fixture",
+    fixture_path: "personas/merge_captain/fixtures/github_snapshot.json",
+    policy_paths: [
+      "personas/merge_captain/policies/harn.json",
+      "personas/merge_captain/policies/harn-cloud.json",
+      "personas/merge_captain/policies/burin-code.json",
+    ],
+    state_root: ".harn/merge-captain/state",
+    session_id: "smoke",
+    writer_id: "merge_captain",
+    dry_run: true,
+    sweep_id: "merge-captain-smoke",
+  }
+}
+
+fn _resolve_input() {
+  let attempt = try {
+    runtime_pipeline_input()
+  }
+  let provided = if is_ok(attempt) {
+    unwrap(attempt) ?? {}
+  } else {
+    {}
+  }
+  let defaults = _default_input()
+  return {
+    mode: provided.mode ?? defaults.mode,
+    fixture_path: provided.fixture_path ?? defaults.fixture_path,
+    policy_paths: provided.policy_paths ?? defaults.policy_paths,
+    state_root: provided.state_root ?? defaults.state_root,
+    session_id: provided.session_id ?? defaults.session_id,
+    writer_id: provided.writer_id ?? defaults.writer_id,
+    dry_run: provided.dry_run ?? defaults.dry_run,
+    sweep_id: provided.sweep_id ?? defaults.sweep_id,
+  }
+}
+
+fn _adapter_for(input) {
+  if input.mode == "live" {
+    return live_adapter()
+  }
+  let raw = read_file(input.fixture_path)
+  let parsed = json_parse(raw)
+  return fixture_adapter(parsed)
+}
+
+pipeline run(task) {
+  let input = _resolve_input()
+  let policies_load = load_policies(input.policy_paths)
+  if len(policies_load.errors) > 0 {
+    let summary = {
+      persona: "merge_captain",
+      sweep_id: input.sweep_id,
+      status: "policy_load_failed",
+      errors: policies_load.errors,
+    }
+    println(json_stringify(summary))
+    return summary
+  }
+  let adapter = _adapter_for(input)
+  let checkpoint_handle = open_checkpoints(input.state_root, input.session_id, input.writer_id)
+  let summary = sweep(
+    {
+      adapter: adapter,
+      policies: policies_load.policies,
+      checkpoint_handle: checkpoint_handle,
+      dry_run: input.dry_run,
+      sweep_id: input.sweep_id,
+    },
+  )
+  let visible = "merge_captain swept ${to_string(summary.pr_count)} PRs across ${to_string(len(policies_load.policies))} repos (dry_run=${to_string(input.dry_run)})"
+  println(visible)
+  println(json_stringify(summary))
+  return summary
+}

--- a/personas/merge_captain/policies/burin-code.json
+++ b/personas/merge_captain/policies/burin-code.json
@@ -1,0 +1,25 @@
+{
+  "repo": "burin-labs/burin-code",
+  "default_branch": "main",
+  "merge_method": "squash",
+  "merge_queue_enabled": false,
+  "required_checks": [
+    "swift / build",
+    "swift / test",
+    "lint"
+  ],
+  "required_review_count": 1,
+  "blocking_labels": [
+    "do-not-merge",
+    "needs-revision"
+  ],
+  "ready_label": null,
+  "max_in_flight": 4,
+  "local_verification": [
+    {"name": "swift-test", "command": "swift test"}
+  ],
+  "downstream": [],
+  "bump_after_merge": "harn",
+  "autopilot_states": ["queued"],
+  "require_human_for": ["blocked", "local_repair", "dirty", "behind"]
+}

--- a/personas/merge_captain/policies/harn-cloud.json
+++ b/personas/merge_captain/policies/harn-cloud.json
@@ -1,0 +1,26 @@
+{
+  "repo": "burin-labs/harn-cloud",
+  "default_branch": "main",
+  "merge_method": "squash",
+  "merge_queue_enabled": true,
+  "required_checks": [
+    "ci / build",
+    "ci / test",
+    "ci / migrations"
+  ],
+  "required_review_count": 1,
+  "blocking_labels": [
+    "do-not-merge",
+    "needs-revision",
+    "schema-review-required"
+  ],
+  "ready_label": "ready-to-merge",
+  "max_in_flight": 4,
+  "local_verification": [
+    {"name": "cargo-test", "command": "cargo test --workspace"}
+  ],
+  "downstream": [],
+  "bump_after_merge": null,
+  "autopilot_states": ["queued", "waiting_checks"],
+  "require_human_for": ["blocked", "local_repair", "dirty"]
+}

--- a/personas/merge_captain/policies/harn.json
+++ b/personas/merge_captain/policies/harn.json
@@ -1,0 +1,29 @@
+{
+  "repo": "burin-labs/harn",
+  "default_branch": "main",
+  "merge_method": "squash",
+  "merge_queue_enabled": true,
+  "required_checks": [
+    "ci / rust",
+    "ci / portal",
+    "ci / conformance"
+  ],
+  "required_review_count": 1,
+  "blocking_labels": [
+    "do-not-merge",
+    "needs-revision",
+    "release-block"
+  ],
+  "ready_label": null,
+  "max_in_flight": 8,
+  "local_verification": [
+    {"name": "make-test", "command": "make test"},
+    {"name": "make-conformance", "command": "make conformance"}
+  ],
+  "downstream": [
+    {"repo": "burin-labs/burin-code", "action": "fetch_harn_bump"}
+  ],
+  "bump_after_merge": null,
+  "autopilot_states": ["queued", "waiting_checks", "behind"],
+  "require_human_for": ["blocked", "local_repair"]
+}

--- a/personas/merge_captain/runs/merge_captain_smoke.run.json
+++ b/personas/merge_captain/runs/merge_captain_smoke.run.json
@@ -1,0 +1,61 @@
+{
+  "_type": "run_record",
+  "id": "merge-captain-smoke",
+  "workflow_id": "run",
+  "workflow_name": "merge_captain",
+  "task": "fixture sweep",
+  "status": "completed",
+  "started_at": "2026-04-29T00:00:00Z",
+  "finished_at": "2026-04-29T00:00:01Z",
+  "stages": [
+    {
+      "id": "stage_1",
+      "node_id": "run",
+      "kind": "stage",
+      "status": "completed",
+      "outcome": "success",
+      "started_at": "2026-04-29T00:00:00Z",
+      "finished_at": "2026-04-29T00:00:01Z",
+      "visible_text": "merge_captain swept 10 PRs across 3 repos (dry_run=true)"
+    }
+  ],
+  "completed_nodes": ["run"],
+  "policy": {
+    "tools": [],
+    "capabilities": {},
+    "workspace_roots": [],
+    "side_effect_level": "read_only",
+    "recursion_limit": null,
+    "tool_arg_constraints": [],
+    "tool_annotations": {}
+  },
+  "metadata": {
+    "persona": "merge_captain",
+    "fixture": "fixtures/github_snapshot.json",
+    "dry_run": true,
+    "approval_required": true,
+    "policies": [
+      "policies/harn.json",
+      "policies/harn-cloud.json",
+      "policies/burin-code.json"
+    ]
+  },
+  "replay_fixture": {
+    "_type": "replay_fixture",
+    "id": "merge-captain-smoke-fixture",
+    "source_run_id": "merge-captain-smoke",
+    "workflow_id": "run",
+    "workflow_name": "merge_captain",
+    "created_at": "2026-04-29T00:00:01Z",
+    "expected_status": "completed",
+    "stage_assertions": [
+      {
+        "node_id": "run",
+        "expected_status": "completed",
+        "expected_outcome": "success",
+        "required_artifact_kinds": [],
+        "visible_text_contains": "merge_captain swept"
+      }
+    ]
+  }
+}

--- a/personas/merge_captain/tests/classifier_test.harn
+++ b/personas/merge_captain/tests/classifier_test.harn
@@ -1,0 +1,165 @@
+// Run: harn test personas/merge_captain/tests/classifier_test.harn
+import { classify, verify } from "../lib/classifier"
+import { from_github } from "../lib/observation"
+import { with_defaults } from "../lib/policy"
+
+fn _policy(extra) {
+  let base = {
+    repo: "x/y",
+    merge_queue_enabled: true,
+    required_checks: ["ci"],
+    required_review_count: 1,
+    blocking_labels: ["do-not-merge"],
+  }
+  let extras = extra ?? {}
+  return with_defaults(base + extras)
+}
+
+fn _pr(overrides) {
+  let base = {
+    repo: "x/y",
+    number: 1,
+    title: "T",
+    head_sha: "abc",
+    head_ref: "feat",
+    base_ref: "main",
+    state: "open",
+    draft: false,
+    merged: false,
+    mergeable: true,
+    mergeable_state: "clean",
+    behind_by: 0,
+    labels: [],
+    review_decision: "APPROVED",
+    approvals: 1,
+    in_merge_queue: false,
+    merge_group_active: false,
+  }
+  let extras = overrides ?? {}
+  return base + extras
+}
+
+fn _checks(success) {
+  if success {
+    return [{name: "ci", status: "completed", conclusion: "success"}]
+  }
+  return [{name: "ci", status: "completed", conclusion: "failure"}]
+}
+
+pipeline test_clean_pr_with_passing_checks_enqueues(task) {
+  let policy = _policy({})
+  let obs = from_github(_pr({}), _checks(true), policy.required_checks)
+  let result = classify(obs, policy, "discovered")
+  assert_eq(result.state, "queued")
+  assert_eq(result.action, "enqueue_merge_queue")
+}
+
+pipeline test_draft_waits(task) {
+  let policy = _policy({})
+  let obs = from_github(_pr({draft: true}), [], policy.required_checks)
+  let result = classify(obs, policy, "discovered")
+  assert_eq(result.state, "draft")
+  assert_eq(result.action, "wait")
+}
+
+pipeline test_dirty_pr_comments(task) {
+  let policy = _policy({})
+  let obs = from_github(
+    _pr({mergeable: false, mergeable_state: "dirty"}),
+    _checks(true),
+    policy.required_checks,
+  )
+  let result = classify(obs, policy, "discovered")
+  assert_eq(result.state, "dirty")
+  assert_eq(result.action, "comment")
+}
+
+pipeline test_behind_branch_updates(task) {
+  let policy = _policy({})
+  let obs = from_github(_pr({behind_by: 4, mergeable_state: "behind"}), _checks(true), policy.required_checks)
+  let result = classify(obs, policy, "discovered")
+  assert_eq(result.state, "behind")
+  assert_eq(result.action, "update_branch")
+}
+
+pipeline test_failing_ci_with_local_verify_repairs(task) {
+  let policy = _policy({local_verification: [{name: "t", command: "true"}]})
+  let obs = from_github(_pr({}), _checks(false), policy.required_checks)
+  let result = classify(obs, policy, "waiting_checks")
+  assert_eq(result.state, "local_repair")
+  assert_eq(result.action, "run_local_verification")
+}
+
+pipeline test_failing_ci_without_local_verify_escalates(task) {
+  let policy = _policy({local_verification: []})
+  let obs = from_github(_pr({}), _checks(false), policy.required_checks)
+  let result = classify(obs, policy, "waiting_checks")
+  assert_eq(result.state, "failing_ci")
+  assert_eq(result.action, "escalate_human")
+}
+
+pipeline test_blocked_label_escalates(task) {
+  let policy = _policy({})
+  let obs = from_github(_pr({labels: ["do-not-merge"]}), _checks(true), policy.required_checks)
+  let result = classify(obs, policy, "queued")
+  assert_eq(result.state, "blocked")
+  assert_eq(result.action, "escalate_human")
+}
+
+pipeline test_missing_approvals_requests_review(task) {
+  let policy = _policy({required_review_count: 2})
+  let obs = from_github(_pr({approvals: 1}), _checks(true), policy.required_checks)
+  let result = classify(obs, policy, "discovered")
+  assert_eq(result.state, "blocked")
+  assert_eq(result.action, "request_review")
+}
+
+pipeline test_pending_checks_wait(task) {
+  let policy = _policy({})
+  let obs = from_github(_pr({}), [], policy.required_checks)
+  let result = classify(obs, policy, "discovered")
+  assert_eq(result.state, "waiting_checks")
+  assert_eq(result.action, "wait")
+}
+
+pipeline test_merged_observation_marks_merged(task) {
+  let policy = _policy({})
+  let obs = from_github(_pr({merged: true, state: "closed"}), _checks(true), policy.required_checks)
+  let result = classify(obs, policy, "merge_group_running")
+  assert_eq(result.state, "merged")
+  assert_eq(result.action, "mark_merged")
+}
+
+pipeline test_closed_observation_archives(task) {
+  let policy = _policy({})
+  let obs = from_github(_pr({merged: false, state: "closed"}), [], policy.required_checks)
+  let result = classify(obs, policy, "queued")
+  assert_eq(result.state, "closed")
+  assert_eq(result.action, "archive")
+}
+
+pipeline test_in_merge_queue_holds_state(task) {
+  let policy = _policy({})
+  let obs = from_github(_pr({in_merge_queue: true}), _checks(true), policy.required_checks)
+  let result = classify(obs, policy, "queued")
+  assert_eq(result.state, "queued")
+  assert_eq(result.action, "wait")
+}
+
+pipeline test_active_merge_group_visible(task) {
+  let policy = _policy({})
+  let obs = from_github(_pr({merge_group_active: true}), _checks(true), policy.required_checks)
+  let result = classify(obs, policy, "queued")
+  assert_eq(result.state, "merge_group_running")
+}
+
+pipeline test_verify_rejects_illegal_edge(task) {
+  let edge = verify("merged", {state: "queued", action: "wait", reason: "x", evidence: {}})
+  assert(!edge.ok)
+  assert(edge.error.contains("illegal transition"))
+}
+
+pipeline test_verify_accepts_legal_edge(task) {
+  let edge = verify("waiting_checks", {state: "queued", action: "wait", reason: "x", evidence: {}})
+  assert(edge.ok)
+}

--- a/personas/merge_captain/tests/policy_test.harn
+++ b/personas/merge_captain/tests/policy_test.harn
@@ -1,0 +1,55 @@
+// Run: harn test personas/merge_captain/tests/policy_test.harn
+import {
+  autopilot_for,
+  defaults,
+  load_policy,
+  requires_human,
+  validate,
+  with_defaults,
+} from "../lib/policy"
+
+pipeline test_defaults_shape(task) {
+  let d = defaults()
+  assert_eq(d.merge_method, "squash")
+  assert_eq(d.merge_queue_enabled, false)
+  assert_eq(d.required_review_count, 1)
+  assert(d.blocking_labels.contains("do-not-merge"))
+}
+
+pipeline test_with_defaults_fills_missing_fields(task) {
+  let raw = {repo: "x/y", merge_queue_enabled: true}
+  let merged = with_defaults(raw)
+  assert_eq(merged.repo, "x/y")
+  assert_eq(merged.merge_queue_enabled, true)
+  assert_eq(merged.merge_method, "squash")
+  assert_eq(merged.default_branch, "main")
+}
+
+pipeline test_validation_rejects_bad_method(task) {
+  let raw = with_defaults({repo: "x/y", merge_method: "weird"})
+  let err = validate(raw)
+  assert(err != nil)
+  assert(err.contains("merge_method"))
+}
+
+pipeline test_load_round_trip(task) {
+  let json = "{\"repo\": \"burin-labs/harn\", \"merge_queue_enabled\": true, \"required_checks\": [\"a\", \"b\"]}"
+  let res = load_policy(json)
+  assert(res.ok)
+  assert_eq(res.policy.repo, "burin-labs/harn")
+  assert_eq(len(res.policy.required_checks), 2)
+}
+
+pipeline test_load_rejects_bad_json(task) {
+  let res = load_policy("{not json")
+  assert(!res.ok)
+  assert(res.error.contains("policy json parse failed"))
+}
+
+pipeline test_autopilot_helpers(task) {
+  let p = with_defaults({repo: "a/b", autopilot_states: ["queued"], require_human_for: ["blocked"]})
+  assert(autopilot_for(p, "queued"))
+  assert(!autopilot_for(p, "blocked"))
+  assert(requires_human(p, "blocked"))
+  assert(!requires_human(p, "queued"))
+}

--- a/personas/merge_captain/tests/receipt_test.harn
+++ b/personas/merge_captain/tests/receipt_test.harn
@@ -1,0 +1,114 @@
+import { from_github } from "../lib/observation"
+import { with_defaults } from "../lib/policy"
+// Run: harn test personas/merge_captain/tests/receipt_test.harn
+import { approval_state, build_receipt, summarize_sweep } from "../lib/receipt"
+
+fn _policy() {
+  return with_defaults(
+    {
+      repo: "x/y",
+      merge_queue_enabled: true,
+      autopilot_states: ["queued"],
+      require_human_for: ["blocked"],
+    },
+  )
+}
+
+fn _obs() {
+  return from_github(
+    {
+      repo: "x/y",
+      number: 1,
+      title: "T",
+      head_sha: "abc",
+      state: "open",
+      mergeable: true,
+      mergeable_state: "clean",
+      approvals: 1,
+      labels: [],
+    },
+    [{name: "ci", status: "completed", conclusion: "success"}],
+    ["ci"],
+  )
+}
+
+pipeline test_approval_state_branches(task) {
+  let policy = _policy()
+  // Non-mutating actions skip approval altogether.
+  let no_op = approval_state(policy, {state: "waiting_checks", action: "wait"}, false)
+  assert_eq(no_op, "no_mutation")
+  // Dry-run trumps autopilot.
+  let dry = approval_state(policy, {state: "queued", action: "enqueue_merge_queue"}, true)
+  assert_eq(dry, "dry_run")
+  // require_human_for forces a human review even on no-op-ish actions.
+  let blocked = approval_state(policy, {state: "blocked", action: "request_review"}, false)
+  assert_eq(blocked, "needs_human")
+  // Autopilot lets queued mutations proceed.
+  let auto = approval_state(policy, {state: "queued", action: "enqueue_merge_queue"}, false)
+  assert_eq(auto, "autopilot")
+}
+
+pipeline test_build_receipt_shape(task) {
+  let receipt = build_receipt(
+    {
+      sweep_id: "s",
+      observed_at: 1,
+      policy: _policy(),
+      observation: _obs(),
+      classification: {
+        state: "queued",
+        action: "enqueue_merge_queue",
+        reason: "ready",
+        evidence: {merge_method: "squash"},
+      },
+      prior_state: "discovered",
+      commands_run: [{action: "enqueue_merge_queue"}],
+      outcome: "dry_run",
+      dry_run: true,
+    },
+  )
+  assert_eq(receipt._type, "merge_receipt")
+  assert_eq(receipt.persona, "merge_captain")
+  assert_eq(receipt.repo, "x/y")
+  assert_eq(receipt.classification.state, "queued")
+  assert_eq(receipt.approval_state, "dry_run")
+  assert_eq(receipt.final_outcome, "dry_run")
+  assert_eq(len(receipt.commands_run), 1)
+  assert_eq(receipt.policy_summary.merge_method, "squash")
+}
+
+pipeline test_summarize_sweep_aggregates(task) {
+  let r1 = build_receipt(
+    {
+      sweep_id: "s",
+      observed_at: 1,
+      policy: _policy(),
+      observation: _obs(),
+      classification: {state: "queued", action: "enqueue_merge_queue", reason: "ok", evidence: {}},
+      prior_state: "discovered",
+      commands_run: [],
+      outcome: "dry_run",
+      dry_run: true,
+    },
+  )
+  let r2 = build_receipt(
+    {
+      sweep_id: "s",
+      observed_at: 1,
+      policy: _policy(),
+      observation: _obs(),
+      classification: {state: "blocked", action: "request_review", reason: "needs review", evidence: {}},
+      prior_state: "discovered",
+      commands_run: [],
+      outcome: "wait",
+      dry_run: true,
+    },
+  )
+  let summary = summarize_sweep([r1, r2], "s", 1, 2)
+  assert_eq(summary._type, "merge_sweep_summary")
+  assert_eq(summary.pr_count, 2)
+  assert_eq(summary.by_state.queued, 1)
+  assert_eq(summary.by_state.blocked, 1)
+  assert_eq(summary.by_action.enqueue_merge_queue, 1)
+  assert_eq(summary.by_action.request_review, 1)
+}

--- a/personas/merge_captain/tests/scheduler_test.harn
+++ b/personas/merge_captain/tests/scheduler_test.harn
@@ -1,0 +1,191 @@
+// Run: harn test personas/merge_captain/tests/scheduler_test.harn
+//
+// End-to-end exercises that the sweep loop reads from the fixture
+// adapter, classifies each PR correctly, persists checkpoints, and
+// surfaces newly arrived PRs across two sweeps.
+import { list_all_checkpoints, open_checkpoints, prior_state_for } from "../lib/checkpoint_store"
+import { fixture_adapter } from "../lib/github_adapter"
+import { with_defaults } from "../lib/policy"
+import { sweep } from "../lib/scheduler"
+
+fn _policy_for(repo, queue_enabled) {
+  return with_defaults(
+    {repo: repo, merge_queue_enabled: queue_enabled, required_checks: ["ci"], required_review_count: 1},
+  )
+}
+
+fn _snapshot(prs, checks_map) {
+  return {[_default_repo()]: {pulls: prs, checks: checks_map}}
+}
+
+fn _default_repo() {
+  return "x/y"
+}
+
+fn _pr(num, overrides) {
+  let base = {
+    repo: "x/y",
+    number: num,
+    title: "PR ${to_string(num)}",
+    head_sha: "sha${to_string(num)}",
+    head_ref: "feat-${to_string(num)}",
+    base_ref: "main",
+    state: "open",
+    draft: false,
+    merged: false,
+    mergeable: true,
+    mergeable_state: "clean",
+    behind_by: 0,
+    labels: [],
+    review_decision: "APPROVED",
+    approvals: 1,
+    in_merge_queue: false,
+    merge_group_active: false,
+  }
+  let extras = overrides ?? {}
+  return base + extras
+}
+
+fn _ok_check() {
+  return [{name: "ci", status: "completed", conclusion: "success"}]
+}
+
+fn _fail_check() {
+  return [{name: "ci", status: "completed", conclusion: "failure"}]
+}
+
+fn _open_handle(suffix) {
+  // Unique per invocation so re-running tests does not see stale state.
+  let session = "scheduler-test-${suffix}-${to_string(now_ms())}"
+  return open_checkpoints(".harn/test/merge-captain", session, "merge_captain_test")
+}
+
+pipeline test_sweep_classifies_clean_pr(task) {
+  let snapshot = _snapshot([_pr(1, {})], {["1"]: _ok_check()})
+  let adapter = fixture_adapter(snapshot)
+  let handle = _open_handle("classify-clean")
+  let summary = sweep(
+    {
+      adapter: adapter,
+      policies: [_policy_for(_default_repo(), true)],
+      checkpoint_handle: handle,
+      dry_run: true,
+      sweep_id: "test-clean",
+    },
+  )
+  assert_eq(summary.pr_count, 1)
+  assert_eq(summary.by_state.queued, 1)
+  assert_eq(summary.by_action.enqueue_merge_queue, 1)
+}
+
+pipeline test_sweep_persists_checkpoints(task) {
+  let snapshot = _snapshot([_pr(1, {behind_by: 2, mergeable_state: "behind"})], {["1"]: _ok_check()})
+  let adapter = fixture_adapter(snapshot)
+  let handle = _open_handle("persist")
+  sweep(
+    {
+      adapter: adapter,
+      policies: [_policy_for(_default_repo(), true)],
+      checkpoint_handle: handle,
+      dry_run: true,
+      sweep_id: "test-persist",
+    },
+  )
+  let prior = prior_state_for(handle, _default_repo(), 1)
+  assert_eq(prior, "behind")
+  let all = list_all_checkpoints(handle)
+  assert_eq(len(all), 1)
+}
+
+pipeline test_resume_picks_up_new_pr(task) {
+  let policy = _policy_for(_default_repo(), true)
+  let snapshot1 = _snapshot([_pr(1, {})], {["1"]: _ok_check()})
+  let snapshot2 = _snapshot([_pr(1, {}), _pr(2, {})], {["1"]: _ok_check(), ["2"]: _ok_check()})
+  let handle = _open_handle("resume-add")
+  // First sweep tracks PR 1 only.
+  sweep(
+    {
+      adapter: fixture_adapter(snapshot1),
+      policies: [policy],
+      checkpoint_handle: handle,
+      dry_run: true,
+      sweep_id: "test-resume-1",
+    },
+  )
+  assert_eq(prior_state_for(handle, _default_repo(), 1), "queued")
+  assert_eq(prior_state_for(handle, _default_repo(), 2), "discovered")
+  // Second sweep absorbs the newly opened PR 2.
+  let summary = sweep(
+    {
+      adapter: fixture_adapter(snapshot2),
+      policies: [policy],
+      checkpoint_handle: handle,
+      dry_run: true,
+      sweep_id: "test-resume-2",
+    },
+  )
+  assert_eq(summary.pr_count, 2)
+  assert_eq(prior_state_for(handle, _default_repo(), 2), "queued")
+}
+
+pipeline test_disappeared_pr_gets_terminal_receipt(task) {
+  let policy = _policy_for(_default_repo(), true)
+  let snapshot1 = _snapshot([_pr(1, {})], {["1"]: _ok_check()})
+  let snapshot2 = _snapshot([], {})
+  let handle = _open_handle("disappear")
+  sweep(
+    {
+      adapter: fixture_adapter(snapshot1),
+      policies: [policy],
+      checkpoint_handle: handle,
+      dry_run: true,
+      sweep_id: "test-disappear-1",
+    },
+  )
+  let summary = sweep(
+    {
+      adapter: fixture_adapter(snapshot2),
+      policies: [policy],
+      checkpoint_handle: handle,
+      dry_run: true,
+      sweep_id: "test-disappear-2",
+    },
+  )
+  // Reconciliation produced a closed-receipt for PR 1.
+  assert_eq(summary.pr_count, 1)
+  assert_eq(summary.by_state.closed, 1)
+  // Checkpoint was forgotten so the next sweep stays clean.
+  let all = list_all_checkpoints(handle)
+  assert_eq(len(all), 0)
+}
+
+pipeline test_failing_ci_with_local_verify_runs_dry(task) {
+  let policy_extra = with_defaults(
+    {
+      repo: _default_repo(),
+      merge_queue_enabled: true,
+      required_checks: ["ci"],
+      local_verification: [{name: "tests", command: "true"}],
+    },
+  )
+  let snapshot = _snapshot([_pr(1, {})], {["1"]: _fail_check()})
+  let handle = _open_handle("local-verify")
+  let summary = sweep(
+    {
+      adapter: fixture_adapter(snapshot),
+      policies: [policy_extra],
+      checkpoint_handle: handle,
+      dry_run: true,
+      sweep_id: "test-local-verify",
+    },
+  )
+  assert_eq(summary.by_state.local_repair, 1)
+  assert_eq(summary.by_action.run_local_verification, 1)
+  // Per-PR receipt records the (skipped) command.
+  let receipt = summary.receipts[0]
+  assert_eq(len(receipt.commands_run), 1)
+  let cmd = receipt.commands_run[0]
+  assert_eq(cmd.action, "run_local_verification")
+  let local_results = cmd.results
+  assert_eq(local_results[0].status, "skipped_dry_run")
+}

--- a/personas/merge_captain/tests/states_test.harn
+++ b/personas/merge_captain/tests/states_test.harn
@@ -1,0 +1,68 @@
+// Run: harn test personas/merge_captain/tests/states_test.harn
+import {
+  action_is_mutating,
+  all_actions,
+  all_states,
+  allowed_next,
+  is_state,
+  is_terminal,
+  is_valid_transition,
+  unknown_state,
+} from "../lib/states"
+
+pipeline test_all_states_distinct(task) {
+  let states = all_states()
+  assert_eq(len(states), 12)
+  assert(is_state("queued"))
+  assert(is_state("merge_group_running"))
+  assert(!is_state("nope"))
+}
+
+pipeline test_terminal_states(task) {
+  assert(is_terminal("merged"))
+  assert(is_terminal("closed"))
+  assert(!is_terminal("queued"))
+  assert(!is_terminal("blocked"))
+}
+
+pipeline test_unknown_state_default(task) {
+  assert_eq(unknown_state(), "discovered")
+}
+
+pipeline test_transitions_legality(task) {
+  // Discovered can fan out to nearly anything.
+  assert(is_valid_transition("discovered", "queued"))
+  assert(is_valid_transition("discovered", "draft"))
+  assert(is_valid_transition("waiting_checks", "queued"))
+  assert(is_valid_transition("queued", "merge_group_running"))
+  assert(is_valid_transition("merge_group_running", "merged"))
+  // Idempotent self-transitions are permitted (mostly for sticky waits).
+  assert(is_valid_transition("waiting_checks", "waiting_checks"))
+  // Terminal -> anywhere is illegal.
+  assert(!is_valid_transition("merged", "queued"))
+  assert(!is_valid_transition("closed", "queued"))
+  // Random nonsense is rejected.
+  assert(!is_valid_transition("queued", "draft"))
+  assert(!is_valid_transition("dirty", "queued"))
+}
+
+pipeline test_allowed_next_lists_are_subsets_of_all_states(task) {
+  let known = all_states()
+  for s in known {
+    let next = allowed_next(s)
+    for n in next {
+      assert(known.contains(n), "${s} -> ${n} references unknown state")
+    }
+  }
+}
+
+pipeline test_actions_catalogue(task) {
+  let actions = all_actions()
+  assert(actions.contains("noop"))
+  assert(actions.contains("enqueue_merge_queue"))
+  assert(actions.contains("escalate_human"))
+  assert(!action_is_mutating("noop"))
+  assert(!action_is_mutating("wait"))
+  assert(action_is_mutating("enqueue_merge_queue"))
+  assert(action_is_mutating("update_branch"))
+}


### PR DESCRIPTION
## Summary

Closes [harn#1009](https://github.com/burin-labs/harn/issues/1009). Replaces the shell-driven Merge Captain MVP with a **deterministic Harn package** that owns multi-repo PR queue scheduling, durable per-PR state, and audit-grade merge receipts.

- **12-state machine** over each tracked PR (`discovered`, `draft`, `waiting_checks`, `behind`, `dirty`, `queued`, `merge_group_running`, `failing_ci`, `local_repair`, `blocked`, `merged`, `closed`) with a legal-edge table enforced by a post-classification verifier — illegal jumps auto-rewrite to `escalate_human`.
- **Per-repo policy** loaded from JSON: merge method, merge-queue toggle, required checks, required review count, blocking labels, optional ready label, `local_verification` commands, downstream bump/release ordering, `autopilot_states`, and `require_human_for`.
- **Durable per-PR checkpoints** via `std/agent_state` (filesystem-backed, single-writer enforced via `conflict_policy: "error"`) so the sweep loop survives cancellation and process restart.
- **Typed GitHub adapter** that dispatches through the registered `github` connector via `connector_call` in live mode and through a deterministic JSON snapshot in fixture mode — no `gh` shelling, no raw `process.exec` shell strings.
- **One signed merge receipt per (sweep, repo, PR)** capturing classification, action, evidence, approval state (`autopilot` / `dry_run` / `needs_human` / `no_mutation`), commands run, observed checks, and final outcome — plus a sweep-level summary aggregating by state, action, and repo.
- **Merge queue is the first-class merge path**; admin-merge bypass is never the action the classifier picks.
- **New PRs** are absorbed automatically (every sweep re-discovers); **disappeared PRs** receive a synthetic terminal receipt and have their checkpoint dropped.
- **Per-repo policy fixtures** for `harn`, `harn-cloud`, and `burin-code`, plus a 10-PR GitHub snapshot that exercises every classifier branch.
- **35 pure-Harn unit tests** across states / policy / classifier / receipt / scheduler, a smoke eval suite (`harn eval`), a smoke run record, a docs page, and a Rust persona-validation test.

Layout: [`personas/merge_captain/`](personas/merge_captain/) (manifest + lib + policies + fixtures + tests + evals + run record + README), [`docs/src/personas/merge-captain.md`](docs/src/personas/merge-captain.md), [`crates/harn-cli/tests/persona_cli.rs`](crates/harn-cli/tests/persona_cli.rs).

## Test plan

- [x] `harn check personas/merge_captain/lib/*.harn personas/merge_captain/manifest.harn` — clean
- [x] `harn lint personas/merge_captain/...` — no issues
- [x] `harn fmt --check personas/merge_captain/...` — clean
- [x] `harn test personas/merge_captain/tests/states_test.harn` — 6/6 pass
- [x] `harn test personas/merge_captain/tests/policy_test.harn` — 6/6 pass
- [x] `harn test personas/merge_captain/tests/classifier_test.harn` — 15/15 pass
- [x] `harn test personas/merge_captain/tests/receipt_test.harn` — 3/3 pass
- [x] `harn test personas/merge_captain/tests/scheduler_test.harn` — 5/5 pass (resume + new-PR ingestion + disappeared-PR reconciliation)
- [x] `harn run personas/merge_captain/manifest.harn` — sweeps 10 PRs across 3 repos, prints summary + per-PR receipts
- [x] `harn persona --manifest personas/merge_captain/harn.toml inspect merge_captain --json` — passes
- [x] `harn persona check personas/merge_captain/harn.toml --json` — passes
- [x] `harn eval personas/merge_captain/evals/merge_captain_smoke.json` — passes
- [x] `cargo test -p harn-cli --test persona_cli` — 9/9 pass (incl. new `persona_manifest_flag_loads_merge_captain_persona`)
- [x] Pre-commit hooks clean (rustfmt, clippy, harn fmt, harn lint, markdownlint)
- [x] Pre-push hooks clean (workspace tests + markdown + portal + Harn fmt/lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)