### PR TITLE
Add schema_recover stdlib helper for malformed-JSON repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,17 @@ granular archaeology.
 
 ### Added
 
+- **`schema_recover` malformed-JSON repair helper (#906).** New stdlib
+  `schema_recover(text, schema, opts?)` runs a three-tier deterministic
+  recovery cascade — direct JSON parse → extract from prose / code
+  fences → regex scrape of top-level `key: value` lines — followed by
+  an optional one-shot `llm_call` repair pass. Returns the same
+  `{ok, data, raw_text, error, error_category, attempts, stage,
+  repaired}` envelope shape as `llm_call_structured_result`, with
+  `stage` reporting which tier succeeded. Designed to replace
+  hand-rolled `normalize_*()` chains downstream of LLM calls; set
+  `{llm_repair: false}` for a fully deterministic recovery pass.
+
 - **Enterprise LLM providers (#870/#976).** First-class shims for Bedrock
   Runtime (Converse API with hand-rolled AWS SigV4 signing and
   env/profile/container/instance credential resolution), Azure OpenAI

--- a/conformance/tests/integration/schema_recover_extracted.expected
+++ b/conformance/tests/integration/schema_recover_extracted.expected
@@ -1,0 +1,6 @@
+true
+extracted
+pass
+clean
+2
+false

--- a/conformance/tests/integration/schema_recover_extracted.harn
+++ b/conformance/tests/integration/schema_recover_extracted.harn
@@ -1,0 +1,20 @@
+/**
+ * `schema_recover` lifts JSON out of a markdown code fence
+ * (stage="extracted", attempts=2 — direct parse fails, then the
+ * extractor finds the fenced block).
+ */
+pipeline default() {
+  let schema = {
+    type: "object",
+    required: ["verdict"],
+    properties: {verdict: {type: "string"}, note: {type: "string"}},
+  }
+  let raw = "Sure, here's the answer:\n```json\n{\"verdict\": \"pass\", \"note\": \"clean\"}\n```\nLet me know if you need more."
+  let r = schema_recover(raw, schema, {llm_repair: false})
+  println(r.ok)
+  println(r.stage)
+  println(r.data.verdict)
+  println(r.data.note)
+  println(r.attempts)
+  println(r.repaired)
+}

--- a/conformance/tests/integration/schema_recover_failed.expected
+++ b/conformance/tests/integration/schema_recover_failed.expected
@@ -1,0 +1,4 @@
+false
+failed
+schema_validation
+true

--- a/conformance/tests/integration/schema_recover_failed.harn
+++ b/conformance/tests/integration/schema_recover_failed.harn
@@ -1,0 +1,14 @@
+/**
+ * `schema_recover` reports stage="failed" / ok=false /
+ * error_category="schema_validation" when no deterministic stage
+ * recovers and the LLM repair pass is disabled. Verifies the
+ * `{llm_repair: false}` knob keeps recovery fully deterministic.
+ */
+pipeline default() {
+  let schema = {type: "object", required: ["verdict"], properties: {verdict: {type: "string"}}}
+  let r = schema_recover("nothing useful here at all", schema, {llm_repair: false})
+  println(r.ok)
+  println(r.stage)
+  println(r.error_category)
+  println(r.data == nil)
+}

--- a/conformance/tests/integration/schema_recover_llm_repair.expected
+++ b/conformance/tests/integration/schema_recover_llm_repair.expected
@@ -1,0 +1,4 @@
+true
+llm_repair
+pass
+true

--- a/conformance/tests/integration/schema_recover_llm_repair.harn
+++ b/conformance/tests/integration/schema_recover_llm_repair.harn
@@ -1,0 +1,16 @@
+/**
+ * `schema_recover` falls through to the LLM repair stage when the
+ * three deterministic stages can't recover the value, and the mock
+ * provider returns valid JSON. Stage="llm_repair", repaired=true,
+ * attempts=4 (parsed → regex → llm_repair; the extracted stage is
+ * skipped when extract_json_from_text doesn't change the input).
+ */
+pipeline default() {
+  let schema = {type: "object", required: ["verdict"], properties: {verdict: {type: "string"}}}
+  llm_mock({text: "{\"verdict\": \"pass\"}"})
+  let r = schema_recover("model said pass but failed to format it", schema, {provider: "mock"})
+  println(r.ok)
+  println(r.stage)
+  println(r.data.verdict)
+  println(r.repaired)
+}

--- a/conformance/tests/integration/schema_recover_parsed.expected
+++ b/conformance/tests/integration/schema_recover_parsed.expected
@@ -1,0 +1,7 @@
+true
+Ada
+36
+parsed
+1
+false
+true

--- a/conformance/tests/integration/schema_recover_parsed.harn
+++ b/conformance/tests/integration/schema_recover_parsed.harn
@@ -1,0 +1,19 @@
+/**
+ * `schema_recover` happy path: clean JSON parses on the first stage
+ * with attempts=1 and stage="parsed".
+ */
+pipeline default() {
+  let schema = {
+    type: "object",
+    required: ["name", "age"],
+    properties: {name: {type: "string"}, age: {type: "integer"}},
+  }
+  let r = schema_recover("{\"name\": \"Ada\", \"age\": 36}", schema)
+  println(r.ok)
+  println(r.data.name)
+  println(r.data.age)
+  println(r.stage)
+  println(r.attempts)
+  println(r.repaired)
+  println(r.error_category == nil)
+}

--- a/conformance/tests/integration/schema_recover_regex.expected
+++ b/conformance/tests/integration/schema_recover_regex.expected
@@ -1,0 +1,6 @@
+true
+regex
+Grace Hopper
+85
+true
+false

--- a/conformance/tests/integration/schema_recover_regex.harn
+++ b/conformance/tests/integration/schema_recover_regex.harn
@@ -1,0 +1,21 @@
+/**
+ * `schema_recover` regex-scrapes top-level `key: value` lines when
+ * the model produced YAML-ish output instead of JSON. Stage="regex",
+ * attempts=3 (parsed fails, no fenced block to extract, regex
+ * succeeds). Booleans accept "yes"/"no" tokens.
+ */
+pipeline default() {
+  let schema = {
+    type: "object",
+    required: ["name", "age", "active"],
+    properties: {name: {type: "string"}, age: {type: "integer"}, active: {type: "boolean"}},
+  }
+  let raw = "name: \"Grace Hopper\", age: 85, active: yes"
+  let r = schema_recover(raw, schema, {llm_repair: false})
+  println(r.ok)
+  println(r.stage)
+  println(r.data.name)
+  println(r.data.age)
+  println(r.data.active)
+  println(r.repaired)
+}

--- a/crates/harn-parser/src/builtin_signatures/generics.rs
+++ b/crates/harn-parser/src/builtin_signatures/generics.rs
@@ -17,6 +17,7 @@ pub(crate) fn lookup_generic_builtin_sig(name: &str) -> Option<BuiltinGenericSig
         "request_approval" => Some(request_approval_builtin_sig()),
         "schema_parse" | "schema_check" => Some(schema_parse_generic_sig()),
         "schema_expect" => Some(schema_expect_generic_sig()),
+        "schema_recover" => Some(schema_recover_generic_sig()),
         "handler_context" => Some(handler_context_builtin_sig()),
         "trust_graph_policy_for" => Some(trust_graph_policy_for_builtin_sig()),
         "trust_graph_query" => Some(trust_graph_query_builtin_sig()),
@@ -288,6 +289,74 @@ fn schema_expect_generic_sig() -> BuiltinGenericSig {
         type_params: vec!["T".into()],
         params: vec![TypeExpr::Named("unknown".into()), schema_of_t()],
         return_type: TypeExpr::Named("T".into()),
+    }
+}
+
+fn schema_recover_generic_sig() -> BuiltinGenericSig {
+    // `schema_recover(text, schema, options?)` returns a diagnostic
+    // envelope. When `schema: Schema<T>`, the envelope's `data`
+    // narrows to `T | nil` (nil on failure). The other envelope
+    // fields (`stage`, `repaired`, etc.) are stably-typed regardless
+    // of T. See harn#906.
+    let envelope_shape = TypeExpr::Shape(vec![
+        ShapeField {
+            name: "ok".into(),
+            type_expr: TypeExpr::Named("bool".into()),
+            optional: false,
+        },
+        ShapeField {
+            name: "data".into(),
+            type_expr: TypeExpr::Union(vec![
+                TypeExpr::Named("T".into()),
+                TypeExpr::Named("nil".into()),
+            ]),
+            optional: false,
+        },
+        ShapeField {
+            name: "raw_text".into(),
+            type_expr: TypeExpr::Named("string".into()),
+            optional: false,
+        },
+        ShapeField {
+            name: "error".into(),
+            type_expr: TypeExpr::Named("string".into()),
+            optional: false,
+        },
+        ShapeField {
+            name: "error_category".into(),
+            type_expr: TypeExpr::Union(vec![
+                TypeExpr::Named("string".into()),
+                TypeExpr::Named("nil".into()),
+            ]),
+            optional: false,
+        },
+        ShapeField {
+            name: "attempts".into(),
+            type_expr: TypeExpr::Named("int".into()),
+            optional: false,
+        },
+        ShapeField {
+            name: "stage".into(),
+            type_expr: TypeExpr::Named("string".into()),
+            optional: false,
+        },
+        ShapeField {
+            name: "repaired".into(),
+            type_expr: TypeExpr::Named("bool".into()),
+            optional: false,
+        },
+    ]);
+    BuiltinGenericSig {
+        type_params: vec!["T".into()],
+        params: vec![
+            TypeExpr::Named("string".into()),
+            schema_of_t(),
+            TypeExpr::Union(vec![
+                TypeExpr::Named("dict".into()),
+                TypeExpr::Named("nil".into()),
+            ]),
+        ],
+        return_type: envelope_shape,
     }
 }
 

--- a/crates/harn-parser/src/builtin_signatures/signatures/schema.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/schema.rs
@@ -52,6 +52,16 @@ pub(crate) const SIGNATURES: &[BuiltinSig] = &[
         return_type: Some(BuiltinReturn::Named("dict")),
     },
     BuiltinSig {
+        name: "schema_recover",
+        // Returns a diagnostic envelope dict whose `data` field
+        // narrows to `T | nil` when called with `Schema<T>` —
+        // resolved by `lookup_generic_builtin_sig`. Fall-through
+        // `None` keeps the parser from defaulting to a concrete
+        // dict type when the schema isn't a typed alias. See
+        // harn#906.
+        return_type: None,
+    },
+    BuiltinSig {
         name: "schema_to_json_schema",
         return_type: Some(BuiltinReturn::Named("dict")),
     },

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod mock;
 pub(crate) mod permissions;
 pub mod plan;
 pub mod readiness;
+pub(crate) mod schema_recover;
 pub(crate) mod structural_experiments;
 pub(crate) mod structured_envelope;
 pub(crate) mod tool_search;
@@ -1022,6 +1023,18 @@ pub fn register_llm_builtins(vm: &mut Vm) {
     // dispatches branch on the failure mode. See harn#744.
     vm.register_async_builtin("llm_call_structured_result", |args| async move {
         structured_envelope::llm_call_structured_result_impl(args, None).await
+    });
+
+    // `schema_recover(text, schema, opts?)` — three-tier malformed-JSON
+    // repair: direct parse → extract-from-prose → regex field scrape →
+    // optional one-shot LLM repair pass. Returns a diagnostic envelope
+    // dict `{ok, data, raw_text, error, error_category, attempts,
+    // stage, repaired}` so callers dispatch on `ok` / `stage` instead
+    // of hand-rolling normalize_*() chains. Disabled-LLM-repair mode
+    // (`{llm_repair: false}`) keeps it fully deterministic. See
+    // harn#906.
+    vm.register_async_builtin("schema_recover", |args| async move {
+        schema_recover::schema_recover_impl(args, None).await
     });
 
     // `with_rate_limit(provider, fn() -> T, opts?) -> T` — acquires a

--- a/crates/harn-vm/src/llm/schema_recover.rs
+++ b/crates/harn-vm/src/llm/schema_recover.rs
@@ -1,0 +1,1039 @@
+//! `schema_recover(text, schema, opts?)` — best-effort recovery of
+//! malformed LLM output against a target schema. Implements the
+//! three-tier fallback that scripts (notably `burin-code`'s
+//! `grade-lora-corpus.harn` `normalize_grader_output()`) used to
+//! hand-roll: parse → extract → regex → optional LLM repair.
+//!
+//! Pipeline (each stage runs only if the previous failed):
+//!
+//! 1. **Direct parse** (`stage: "parsed"`) — `serde_json::from_str` on
+//!    the raw text, then validate against the schema.
+//! 2. **Extracted** (`stage: "extracted"`) — `extract_json_from_text`
+//!    lifts JSON from code fences or balanced braces, then parses +
+//!    validates. Recovers responses where the model wrapped JSON in
+//!    prose or markdown.
+//! 3. **Regex** (`stage: "regex"`) — For each top-level scalar field
+//!    in `schema.properties`, scan for `"key": value` / `key: value` /
+//!    YAML-shaped patterns and assemble a partial dict. Useful when
+//!    the model dropped quotes or produced YAML-ish output. Only top-
+//!    level scalars (string / integer / number / boolean) are
+//!    recovered this way — nested objects are too unreliable.
+//! 4. **LLM repair** (`stage: "llm_repair"`, optional) — Single-shot
+//!    `llm_call` with the malformed text and schema in the prompt,
+//!    asking for valid JSON. Disabled with `{llm_repair: false}` or
+//!    when no LLM provider is configured. Repair runs with
+//!    `schema_retries: 0` to fail fast; cost amplification is the
+//!    caller's problem if they want more.
+//!
+//! Returns a diagnostic envelope dict so callers can dispatch on
+//! `ok` / `error_category` / `stage` without try/catch:
+//!
+//! ```harn
+//! let r = schema_recover(raw_text, schema)
+//! if r.ok {
+//!   process(r.data)
+//! } else {
+//!   log("recovery failed:", r.error_category, "stage:", r.stage)
+//! }
+//! ```
+//!
+//! Unlike `llm_call_structured_result`, this helper takes already-
+//! produced text rather than running a fresh structured call. The
+//! intended use is downstream of an `llm_call(...)` that returned
+//! prose or that used `output_validation: "off"`, when the caller
+//! wants to recover the schema-shaped payload after the fact.
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use serde_json::Value as JsonValue;
+
+use crate::stdlib::{json_to_vm_value, schema_result_value};
+use crate::value::{VmError, VmValue};
+
+use super::helpers::extract_llm_options;
+use super::{execute_schema_retry_loop, structured_output_errors};
+
+const STAGE_PARSED: &str = "parsed";
+const STAGE_EXTRACTED: &str = "extracted";
+const STAGE_REGEX: &str = "regex";
+const STAGE_LLM_REPAIR: &str = "llm_repair";
+const STAGE_FAILED: &str = "failed";
+
+const ERR_SCHEMA_VALIDATION: &str = "schema_validation";
+const ERR_REPAIR_FAILED: &str = "repair_failed";
+const ERR_TRANSPORT: &str = "transport";
+
+/// Public entry point used by `register_llm_builtins`. The bridge
+/// argument is forwarded to the optional LLM repair pass so worker /
+/// agent contexts get the same provider routing as the surrounding
+/// agent loop. Pass `None` from non-bridge call sites.
+pub(crate) async fn schema_recover_impl(
+    args: Vec<VmValue>,
+    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+) -> Result<VmValue, VmError> {
+    if args.len() < 2 {
+        return Err(VmError::Runtime(
+            "schema_recover: expected (text: string, schema: dict, opts?: dict)".to_string(),
+        ));
+    }
+    let text = args[0].display();
+    let schema_value = match &args[1] {
+        VmValue::Dict(_) => args[1].clone(),
+        other => {
+            return Err(VmError::Runtime(format!(
+                "schema_recover: schema must be a dict, got {}",
+                other.type_name(),
+            )));
+        }
+    };
+    let opts = args.get(2).and_then(|a| a.as_dict()).cloned();
+    let apply_defaults = opt_bool_field(&opts, "apply_defaults");
+
+    let mut last_errors: Vec<String>;
+    let mut attempts: usize = 0;
+
+    // Stage 1: direct parse.
+    attempts += 1;
+    match try_parse_and_validate(&text, &schema_value, apply_defaults) {
+        Ok(data) => {
+            return Ok(envelope_success(data, &text, STAGE_PARSED, attempts, false));
+        }
+        Err(errs) => {
+            last_errors = errs;
+        }
+    }
+
+    // Stage 2: extract JSON from prose / fences and try again.
+    let extracted = crate::stdlib::json::extract_json_from_text(&text);
+    if extracted.trim() != text.trim() {
+        attempts += 1;
+        match try_parse_and_validate(&extracted, &schema_value, apply_defaults) {
+            Ok(data) => {
+                return Ok(envelope_success(
+                    data,
+                    &text,
+                    STAGE_EXTRACTED,
+                    attempts,
+                    false,
+                ));
+            }
+            Err(errs) => {
+                last_errors = errs;
+            }
+        }
+    }
+
+    // Stage 3: regex-based field extraction for top-level scalars.
+    attempts += 1;
+    match try_regex_recover(&text, &schema_value, apply_defaults) {
+        Ok(Some(data)) => {
+            return Ok(envelope_success(data, &text, STAGE_REGEX, attempts, false));
+        }
+        Ok(None) => {
+            // No fields recoverable via regex — keep last_errors.
+        }
+        Err(errs) => {
+            last_errors = errs;
+        }
+    }
+
+    // Stage 4: LLM repair pass (optional, opt-out).
+    let repair = parse_llm_repair_config(&opts);
+    if repair.enabled {
+        attempts += 1;
+        match run_llm_repair(&text, &schema_value, &repair, &opts, bridge).await {
+            Ok(Some(data)) => {
+                return Ok(envelope_success(
+                    data,
+                    &text,
+                    STAGE_LLM_REPAIR,
+                    attempts,
+                    true,
+                ));
+            }
+            Ok(None) => {
+                return Ok(envelope_failure(
+                    &text,
+                    STAGE_LLM_REPAIR,
+                    ERR_REPAIR_FAILED,
+                    "LLM repair pass returned invalid JSON",
+                    attempts,
+                ));
+            }
+            Err(message) => {
+                return Ok(envelope_failure(
+                    &text,
+                    STAGE_LLM_REPAIR,
+                    ERR_TRANSPORT,
+                    &message,
+                    attempts,
+                ));
+            }
+        }
+    }
+
+    let message = if last_errors.is_empty() {
+        "schema_recover: no recoverable JSON found".to_string()
+    } else {
+        last_errors.join("; ")
+    };
+    Ok(envelope_failure(
+        &text,
+        STAGE_FAILED,
+        ERR_SCHEMA_VALIDATION,
+        &message,
+        attempts,
+    ))
+}
+
+/// Try `serde_json` parse + schema validation. Returns the validated
+/// (and possibly default-applied) value on success, or the list of
+/// validation / parse errors on failure.
+fn try_parse_and_validate(
+    text: &str,
+    schema: &VmValue,
+    apply_defaults: bool,
+) -> Result<VmValue, Vec<String>> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Err(vec!["empty input".to_string()]);
+    }
+    let parsed = match serde_json::from_str::<JsonValue>(trimmed) {
+        Ok(v) => v,
+        Err(e) => return Err(vec![format!("JSON parse error: {e}")]),
+    };
+    let vm_value = json_to_vm_value(&parsed);
+    let result = schema_result_value(&vm_value, schema, apply_defaults);
+    extract_validation_outcome(&result)
+}
+
+/// Pull the validated payload out of a `Result.Ok(value)` or surface
+/// the error list from `Result.Err({errors, ...})`.
+fn extract_validation_outcome(result: &VmValue) -> Result<VmValue, Vec<String>> {
+    match result {
+        VmValue::EnumVariant {
+            enum_name,
+            variant,
+            fields,
+        } if enum_name.as_ref() == "Result" => match variant.as_ref() {
+            "Ok" => Ok(fields.first().cloned().unwrap_or(VmValue::Nil)),
+            "Err" => {
+                let errors = fields
+                    .first()
+                    .and_then(|payload| payload.as_dict())
+                    .and_then(|payload| payload.get("errors"))
+                    .and_then(|errors| match errors {
+                        VmValue::List(items) => {
+                            Some(items.iter().map(|err| err.display()).collect())
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| vec!["schema validation failed".to_string()]);
+                Err(errors)
+            }
+            other => Err(vec![format!(
+                "unexpected Result variant from schema validation: {other}"
+            )]),
+        },
+        _ => Err(vec!["schema validation did not return a Result".to_string()]),
+    }
+}
+
+/// Walk the schema's top-level scalar properties and try to scrape
+/// `"key": value` / `key: value` / `key = value` patterns out of free-
+/// form text. Returns:
+///
+/// - `Ok(Some(dict))` — at least one field was scraped AND the
+///   resulting dict (filled in with defaults from the schema where
+///   possible) validates.
+/// - `Ok(None)` — nothing was scraped or what was scraped didn't
+///   form a valid object (the caller falls through to the next
+///   stage without treating this as a validation error).
+/// - `Err(errors)` — the schema is unusable (e.g. not an object
+///   schema).
+fn try_regex_recover(
+    text: &str,
+    schema: &VmValue,
+    apply_defaults: bool,
+) -> Result<Option<VmValue>, Vec<String>> {
+    let schema_dict = match schema.as_dict() {
+        Some(d) => d,
+        None => return Ok(None),
+    };
+    // We only attempt regex recovery on object-shaped schemas — this
+    // matches the canonical grade-lora-corpus.harn pattern where the
+    // schema is `{type: "object", properties: {...}}`. Non-object
+    // schemas (e.g. raw arrays / scalars) skip this stage cleanly.
+    let is_object = matches!(
+        schema_dict.get("type"),
+        Some(VmValue::String(s)) if s.as_ref() == "object"
+    ) || schema_dict.contains_key("properties");
+    if !is_object {
+        return Ok(None);
+    }
+    let properties = match schema_dict.get("properties") {
+        Some(VmValue::Dict(p)) => p.clone(),
+        _ => return Ok(None),
+    };
+
+    let mut recovered: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut any = false;
+    for (field, field_schema) in properties.iter() {
+        let field_type = field_type_name(field_schema);
+        if field_type.is_none() {
+            continue;
+        }
+        let ty = field_type.unwrap();
+        if let Some(value) = scrape_field(text, field, ty, field_schema) {
+            recovered.insert(field.clone(), value);
+            any = true;
+        }
+    }
+    if !any {
+        return Ok(None);
+    }
+    let candidate = VmValue::Dict(Rc::new(recovered));
+    let result = schema_result_value(&candidate, schema, apply_defaults);
+    match extract_validation_outcome(&result) {
+        Ok(data) => Ok(Some(data)),
+        Err(_) => Ok(None),
+    }
+}
+
+/// Return the JSON-Schema-style type name for a field schema, treating
+/// nested object / array / null / unknown shapes as "skip" — only
+/// scalars (string / integer / number / boolean) participate in regex
+/// recovery.
+fn field_type_name(field_schema: &VmValue) -> Option<&'static str> {
+    let dict = field_schema.as_dict()?;
+    let ty = dict.get("type")?;
+    match ty {
+        VmValue::String(s) => match s.as_ref() {
+            "string" => Some("string"),
+            "integer" => Some("integer"),
+            "number" => Some("number"),
+            "boolean" => Some("boolean"),
+            _ => None,
+        },
+        // Union types like ["string", "null"] — pick the first scalar.
+        VmValue::List(items) => items.iter().find_map(|item| {
+            if let VmValue::String(s) = item {
+                match s.as_ref() {
+                    "string" => Some("string"),
+                    "integer" => Some("integer"),
+                    "number" => Some("number"),
+                    "boolean" => Some("boolean"),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        }),
+        _ => None,
+    }
+}
+
+/// Try a sequence of progressively-loose patterns to extract a single
+/// scalar value for `field` from `text`. Patterns mirror the shapes
+/// LLMs commonly produce when they fail JSON validity:
+///
+/// 1. `"field": "value"`   (quoted JSON-ish)
+/// 2. `"field": value`     (quoted key, bare value)
+/// 3. `field: "value"`     (YAML-ish quoted value)
+/// 4. `field: value`       (bare YAML)
+/// 5. `field = value`      (env/ini-ish)
+fn scrape_field(
+    text: &str,
+    field: &str,
+    field_type: &'static str,
+    field_schema: &VmValue,
+) -> Option<VmValue> {
+    let escaped = regex::escape(field);
+    let patterns = [
+        // Quoted key, quoted value.
+        format!(r#""{esc}"\s*:\s*"((?:[^"\\]|\\.)*)""#, esc = escaped),
+        // Quoted key, bare value (until comma / brace / newline).
+        format!(r#""{esc}"\s*:\s*([^,\n\r}}]+)"#, esc = escaped),
+        // Bare key with quoted value (YAML-ish).
+        format!(r#"\b{esc}\s*[:=]\s*"((?:[^"\\]|\\.)*)""#, esc = escaped),
+        // Bare key with bare value (terminated by newline / comma /
+        // brace). This is the most permissive pattern and goes last.
+        format!(r#"\b{esc}\s*[:=]\s*([^,\n\r}}]+)"#, esc = escaped),
+    ];
+    for pat in &patterns {
+        let re = match regex::Regex::new(pat) {
+            Ok(re) => re,
+            Err(_) => continue,
+        };
+        if let Some(caps) = re.captures(text) {
+            if let Some(m) = caps.get(1) {
+                let raw = m.as_str().trim();
+                if let Some(value) = coerce_scalar(raw, field_type, field_schema) {
+                    return Some(value);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Convert a raw scraped string to the schema-declared scalar type.
+/// Unquoted strings get cleaned of trailing punctuation; numerics
+/// are parsed; booleans accept the common spellings (true/yes/y/1).
+fn coerce_scalar(raw: &str, field_type: &str, field_schema: &VmValue) -> Option<VmValue> {
+    let cleaned = raw
+        .trim_end_matches([',', ';', '}', ']'])
+        .trim()
+        .to_string();
+    if cleaned.is_empty() {
+        return None;
+    }
+    match field_type {
+        "string" => {
+            let unquoted = strip_surrounding_quotes(&cleaned);
+            let unescaped = unescape_json_string(&unquoted);
+            // Reject obvious null tokens for non-nullable string fields.
+            if unescaped.eq_ignore_ascii_case("null") && !field_allows_null(field_schema) {
+                return None;
+            }
+            Some(VmValue::String(Rc::from(unescaped.as_str())))
+        }
+        "integer" => {
+            let n: i64 = cleaned.parse().ok()?;
+            Some(VmValue::Int(n))
+        }
+        "number" => {
+            // Try integer first to preserve numeric precision; fall
+            // back to float for fractional values.
+            if let Ok(n) = cleaned.parse::<i64>() {
+                Some(VmValue::Int(n))
+            } else {
+                let n: f64 = cleaned.parse().ok()?;
+                Some(VmValue::Float(n))
+            }
+        }
+        "boolean" => parse_bool_token(&cleaned).map(VmValue::Bool),
+        _ => None,
+    }
+}
+
+fn parse_bool_token(s: &str) -> Option<bool> {
+    match s.to_ascii_lowercase().as_str() {
+        "true" | "yes" | "y" | "on" | "1" => Some(true),
+        "false" | "no" | "n" | "off" | "0" => Some(false),
+        _ => None,
+    }
+}
+
+fn strip_surrounding_quotes(s: &str) -> String {
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return s[1..s.len() - 1].to_string();
+        }
+    }
+    s.to_string()
+}
+
+/// Best-effort JSON string escape decode: handles the common escapes
+/// (`\"`, `\\`, `\n`, `\t`, `\r`). Unknown escapes pass through.
+fn unescape_json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('"') => out.push('"'),
+            Some('\\') => out.push('\\'),
+            Some('/') => out.push('/'),
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
+}
+
+fn field_allows_null(field_schema: &VmValue) -> bool {
+    let dict = match field_schema.as_dict() {
+        Some(d) => d,
+        None => return false,
+    };
+    match dict.get("type") {
+        Some(VmValue::String(s)) => s.as_ref() == "null",
+        Some(VmValue::List(items)) => items
+            .iter()
+            .any(|item| matches!(item, VmValue::String(s) if s.as_ref() == "null")),
+        _ => false,
+    }
+}
+
+#[derive(Clone)]
+struct LlmRepairConfig {
+    enabled: bool,
+    overrides: BTreeMap<String, VmValue>,
+}
+
+fn parse_llm_repair_config(opts: &Option<BTreeMap<String, VmValue>>) -> LlmRepairConfig {
+    let Some(opts) = opts.as_ref() else {
+        return LlmRepairConfig {
+            enabled: true,
+            overrides: BTreeMap::new(),
+        };
+    };
+    let raw = opts.get("llm_repair");
+    match raw {
+        None => LlmRepairConfig {
+            enabled: true,
+            overrides: BTreeMap::new(),
+        },
+        Some(VmValue::Nil) => LlmRepairConfig {
+            enabled: true,
+            overrides: BTreeMap::new(),
+        },
+        Some(VmValue::Bool(b)) => LlmRepairConfig {
+            enabled: *b,
+            overrides: BTreeMap::new(),
+        },
+        Some(VmValue::Dict(d)) => {
+            let enabled = match d.get("enabled") {
+                None => true,
+                Some(VmValue::Bool(false)) => false,
+                Some(VmValue::Nil) => true,
+                Some(_) => true,
+            };
+            let mut overrides: BTreeMap<String, VmValue> = (**d).clone();
+            overrides.remove("enabled");
+            LlmRepairConfig { enabled, overrides }
+        }
+        // Tolerant: any other shape disables the repair pass cleanly
+        // rather than throwing — recovery is best-effort.
+        Some(_) => LlmRepairConfig {
+            enabled: false,
+            overrides: BTreeMap::new(),
+        },
+    }
+}
+
+fn opt_bool_field(opts: &Option<BTreeMap<String, VmValue>>, key: &str) -> bool {
+    matches!(
+        opts.as_ref().and_then(|o| o.get(key)),
+        Some(VmValue::Bool(true))
+    )
+}
+
+/// Run the LLM repair pass: build a corrective prompt and call into
+/// the schema-retry loop with `schema_retries: 0` (single shot). The
+/// schema is installed on the call so the provider can use native
+/// JSON-mode where available.
+///
+/// Returns:
+/// - `Ok(Some(data))` — repair produced valid JSON that schema-validates.
+/// - `Ok(None)` — repair completed but the result still failed validation.
+/// - `Err(message)` — the LLM transport itself failed (no provider, network, etc).
+async fn run_llm_repair(
+    text: &str,
+    schema: &VmValue,
+    repair: &LlmRepairConfig,
+    base_opts: &Option<BTreeMap<String, VmValue>>,
+    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+) -> Result<Option<VmValue>, String> {
+    let prompt = build_repair_prompt(text, schema);
+    let merged_options = merge_repair_options(base_opts.as_ref(), &repair.overrides, schema);
+    let merged_dict = Some(merged_options.clone());
+    let args = vec![
+        VmValue::String(Rc::from(prompt.as_str())),
+        // System slot — the prompt carries instructions inline so the
+        // repair pass works regardless of any caller-set system text.
+        VmValue::Nil,
+        VmValue::Dict(Rc::new(merged_options)),
+    ];
+    let opts = extract_llm_options(&args).map_err(|e| e.to_string())?;
+    let outcome = execute_schema_retry_loop(opts.clone(), merged_dict, bridge)
+        .await
+        .map_err(|e| e.to_string())?;
+    if !outcome.errors.is_empty() {
+        return Ok(None);
+    }
+    // Re-validate against the schema using the same path the rest of
+    // schema_recover uses so the success criterion is identical (and
+    // we get back the validated, default-applied value).
+    let errors = structured_output_errors(&outcome.vm_result, &opts);
+    if !errors.is_empty() {
+        return Ok(None);
+    }
+    let data = outcome
+        .vm_result
+        .as_dict()
+        .and_then(|d| d.get("data").cloned())
+        .unwrap_or(VmValue::Nil);
+    Ok(Some(data))
+}
+
+fn build_repair_prompt(raw_text: &str, schema: &VmValue) -> String {
+    let schema_text = schema_to_compact_json(schema);
+    let mut s = String::from(
+        "The following text was supposed to be JSON conforming to the schema below, but it failed validation. \
+Repair it and respond with ONLY the corrected JSON — no prose, no markdown fences, no commentary.\n\n",
+    );
+    s.push_str("Target schema:\n");
+    s.push_str(&schema_text);
+    s.push_str("\n\nOriginal text:\n");
+    s.push_str(raw_text);
+    s.push_str("\n\nReply with valid JSON only.");
+    s
+}
+
+fn schema_to_compact_json(schema: &VmValue) -> String {
+    let json = super::helpers::vm_value_to_json(schema);
+    serde_json::to_string(&json).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn merge_repair_options(
+    base: Option<&BTreeMap<String, VmValue>>,
+    overrides: &BTreeMap<String, VmValue>,
+    schema: &VmValue,
+) -> BTreeMap<String, VmValue> {
+    let mut merged: BTreeMap<String, VmValue> = base.cloned().unwrap_or_default();
+    // The repair pass is always single-shot inside schema_recover —
+    // burning the caller's `schema_retries` budget here would amplify
+    // cost and the outer recovery cascade has already done what it
+    // can. Set explicitly rather than relying on defaults.
+    merged.insert("schema_retries".to_string(), VmValue::Int(0));
+    // Strip schema_recover-specific keys so they don't leak into
+    // `extract_llm_options` as unknown provider params.
+    merged.remove("llm_repair");
+    merged.remove("apply_defaults");
+    // Install the schema on the call so providers can use their
+    // native JSON-mode and so the schema-retry loop's validation runs.
+    merged.insert("output_schema".to_string(), schema.clone());
+    merged.insert("json_schema".to_string(), schema.clone());
+    merged
+        .entry("output_format".to_string())
+        .or_insert_with(|| {
+            let mut fmt = BTreeMap::new();
+            fmt.insert("kind".to_string(), VmValue::String(Rc::from("json_schema")));
+            fmt.insert("schema".to_string(), schema.clone());
+            fmt.insert("strict".to_string(), VmValue::Bool(true));
+            VmValue::Dict(Rc::new(fmt))
+        });
+    merged
+        .entry("output_validation".to_string())
+        .or_insert(VmValue::String(Rc::from("error")));
+    merged
+        .entry("response_format".to_string())
+        .or_insert(VmValue::String(Rc::from("json")));
+    for (k, v) in overrides {
+        merged.insert(k.clone(), v.clone());
+    }
+    merged
+}
+
+fn envelope_success(
+    data: VmValue,
+    raw_text: &str,
+    stage: &str,
+    attempts: usize,
+    repaired: bool,
+) -> VmValue {
+    let mut env = BTreeMap::new();
+    env.insert("ok".to_string(), VmValue::Bool(true));
+    env.insert("data".to_string(), data);
+    env.insert("raw_text".to_string(), VmValue::String(Rc::from(raw_text)));
+    env.insert("error".to_string(), VmValue::String(Rc::from("")));
+    env.insert("error_category".to_string(), VmValue::Nil);
+    env.insert("attempts".to_string(), VmValue::Int(attempts as i64));
+    env.insert("stage".to_string(), VmValue::String(Rc::from(stage)));
+    env.insert("repaired".to_string(), VmValue::Bool(repaired));
+    VmValue::Dict(Rc::new(env))
+}
+
+fn envelope_failure(
+    raw_text: &str,
+    stage: &str,
+    error_category: &str,
+    error_message: &str,
+    attempts: usize,
+) -> VmValue {
+    let mut env = BTreeMap::new();
+    env.insert("ok".to_string(), VmValue::Bool(false));
+    env.insert("data".to_string(), VmValue::Nil);
+    env.insert("raw_text".to_string(), VmValue::String(Rc::from(raw_text)));
+    env.insert(
+        "error".to_string(),
+        VmValue::String(Rc::from(error_message)),
+    );
+    env.insert(
+        "error_category".to_string(),
+        VmValue::String(Rc::from(error_category)),
+    );
+    env.insert("attempts".to_string(), VmValue::Int(attempts as i64));
+    env.insert("stage".to_string(), VmValue::String(Rc::from(stage)));
+    env.insert("repaired".to_string(), VmValue::Bool(false));
+    VmValue::Dict(Rc::new(env))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn person_schema() -> VmValue {
+        let mut name = BTreeMap::new();
+        name.insert("type".to_string(), VmValue::String(Rc::from("string")));
+        let mut age = BTreeMap::new();
+        age.insert("type".to_string(), VmValue::String(Rc::from("integer")));
+        let mut active = BTreeMap::new();
+        active.insert("type".to_string(), VmValue::String(Rc::from("boolean")));
+        let mut props = BTreeMap::new();
+        props.insert("name".to_string(), VmValue::Dict(Rc::new(name)));
+        props.insert("age".to_string(), VmValue::Dict(Rc::new(age)));
+        props.insert("active".to_string(), VmValue::Dict(Rc::new(active)));
+        let required = VmValue::List(Rc::new(vec![
+            VmValue::String(Rc::from("name")),
+            VmValue::String(Rc::from("age")),
+        ]));
+        let mut schema = BTreeMap::new();
+        schema.insert("type".to_string(), VmValue::String(Rc::from("object")));
+        schema.insert("properties".to_string(), VmValue::Dict(Rc::new(props)));
+        schema.insert("required".to_string(), required);
+        VmValue::Dict(Rc::new(schema))
+    }
+
+    #[test]
+    fn parses_clean_json_directly() {
+        let schema = person_schema();
+        let result = try_parse_and_validate(
+            r#"{"name": "Ada", "age": 36, "active": true}"#,
+            &schema,
+            false,
+        )
+        .unwrap();
+        let dict = result.as_dict().unwrap();
+        assert_eq!(dict.get("name").unwrap().display(), "Ada");
+        assert_eq!(dict.get("age").unwrap().as_int(), Some(36));
+        assert!(matches!(dict.get("active"), Some(VmValue::Bool(true))));
+    }
+
+    #[test]
+    fn rejects_validation_failure() {
+        let schema = person_schema();
+        let err = try_parse_and_validate(r#"{"name": 42}"#, &schema, false).unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn extracts_field_with_quoted_key_and_value() {
+        let schema = person_schema();
+        let scraped = scrape_field(
+            r#"the result is "name": "Ada Lovelace", others omitted"#,
+            "name",
+            "string",
+            schema
+                .as_dict()
+                .unwrap()
+                .get("properties")
+                .unwrap()
+                .as_dict()
+                .unwrap()
+                .get("name")
+                .unwrap(),
+        );
+        assert_eq!(scraped.unwrap().display(), "Ada Lovelace");
+    }
+
+    #[test]
+    fn extracts_field_with_yaml_shape() {
+        let schema = person_schema();
+        let scraped = scrape_field(
+            "name: Ada\nage: 36\nactive: yes\n",
+            "age",
+            "integer",
+            schema
+                .as_dict()
+                .unwrap()
+                .get("properties")
+                .unwrap()
+                .as_dict()
+                .unwrap()
+                .get("age")
+                .unwrap(),
+        );
+        assert_eq!(scraped.unwrap().as_int(), Some(36));
+    }
+
+    #[test]
+    fn extracts_boolean_via_yes_token() {
+        let schema = person_schema();
+        let scraped = scrape_field(
+            "name: Ada\nage: 36\nactive: yes\n",
+            "active",
+            "boolean",
+            schema
+                .as_dict()
+                .unwrap()
+                .get("properties")
+                .unwrap()
+                .as_dict()
+                .unwrap()
+                .get("active")
+                .unwrap(),
+        );
+        assert!(matches!(scraped, Some(VmValue::Bool(true))));
+    }
+
+    #[test]
+    fn regex_recover_assembles_partial_dict() {
+        let schema = person_schema();
+        let raw = "Here is the answer: name: \"Grace Hopper\", age: 85, active: false";
+        let result = try_regex_recover(raw, &schema, false).unwrap().unwrap();
+        let dict = result.as_dict().unwrap();
+        assert_eq!(dict.get("name").unwrap().display(), "Grace Hopper");
+        assert_eq!(dict.get("age").unwrap().as_int(), Some(85));
+        assert!(matches!(dict.get("active"), Some(VmValue::Bool(false))));
+    }
+
+    #[test]
+    fn regex_recover_returns_none_when_required_field_missing() {
+        let schema = person_schema();
+        // Only `active` (non-required) is present — required `name`
+        // and `age` are missing, so validation fails and the helper
+        // returns None to let the next stage run.
+        let raw = "active: true";
+        let outcome = try_regex_recover(raw, &schema, false).unwrap();
+        assert!(outcome.is_none());
+    }
+
+    #[test]
+    fn regex_recover_skips_when_schema_is_not_object() {
+        let mut scalar = BTreeMap::new();
+        scalar.insert("type".to_string(), VmValue::String(Rc::from("string")));
+        let schema = VmValue::Dict(Rc::new(scalar));
+        let outcome = try_regex_recover("hello", &schema, false).unwrap();
+        assert!(outcome.is_none());
+    }
+
+    #[test]
+    fn coerce_handles_unquoted_string_with_trailing_punct() {
+        let mut field = BTreeMap::new();
+        field.insert("type".to_string(), VmValue::String(Rc::from("string")));
+        let v = coerce_scalar("Ada,", "string", &VmValue::Dict(Rc::new(field))).unwrap();
+        assert_eq!(v.display(), "Ada");
+    }
+
+    #[test]
+    fn coerce_handles_escaped_quotes_in_string() {
+        let mut field = BTreeMap::new();
+        field.insert("type".to_string(), VmValue::String(Rc::from("string")));
+        let v = coerce_scalar(
+            "he said \\\"hi\\\"",
+            "string",
+            &VmValue::Dict(Rc::new(field)),
+        )
+        .unwrap();
+        assert_eq!(v.display(), "he said \"hi\"");
+    }
+
+    #[test]
+    fn coerce_rejects_null_for_non_nullable_string() {
+        let mut field = BTreeMap::new();
+        field.insert("type".to_string(), VmValue::String(Rc::from("string")));
+        let v = coerce_scalar("null", "string", &VmValue::Dict(Rc::new(field)));
+        assert!(v.is_none());
+    }
+
+    #[test]
+    fn parse_repair_config_disable_via_bool() {
+        let mut opts = BTreeMap::new();
+        opts.insert("llm_repair".to_string(), VmValue::Bool(false));
+        let cfg = parse_llm_repair_config(&Some(opts));
+        assert!(!cfg.enabled);
+    }
+
+    #[test]
+    fn parse_repair_config_enabled_when_unspecified() {
+        let cfg = parse_llm_repair_config(&None);
+        assert!(cfg.enabled);
+    }
+
+    #[test]
+    fn parse_repair_config_dict_extracts_overrides() {
+        let mut repair = BTreeMap::new();
+        repair.insert("model".to_string(), VmValue::String(Rc::from("local:fix")));
+        repair.insert("max_tokens".to_string(), VmValue::Int(400));
+        let mut opts = BTreeMap::new();
+        opts.insert("llm_repair".to_string(), VmValue::Dict(Rc::new(repair)));
+        let cfg = parse_llm_repair_config(&Some(opts));
+        assert!(cfg.enabled);
+        assert_eq!(
+            cfg.overrides.get("model").map(VmValue::display).as_deref(),
+            Some("local:fix")
+        );
+        assert_eq!(
+            cfg.overrides.get("max_tokens").and_then(VmValue::as_int),
+            Some(400)
+        );
+    }
+
+    #[test]
+    fn merge_repair_caps_schema_retries_and_installs_schema() {
+        let schema = person_schema();
+        let mut base = BTreeMap::new();
+        base.insert("schema_retries".to_string(), VmValue::Int(7));
+        base.insert("llm_repair".to_string(), VmValue::Bool(true));
+        base.insert("apply_defaults".to_string(), VmValue::Bool(true));
+        let merged = merge_repair_options(Some(&base), &BTreeMap::new(), &schema);
+        assert_eq!(
+            merged.get("schema_retries").and_then(VmValue::as_int),
+            Some(0)
+        );
+        assert!(merged.contains_key("output_schema"));
+        assert!(!merged.contains_key("llm_repair"));
+        assert!(!merged.contains_key("apply_defaults"));
+        assert_eq!(
+            merged
+                .get("output_validation")
+                .map(VmValue::display)
+                .as_deref(),
+            Some("error")
+        );
+    }
+
+    #[test]
+    fn merge_repair_overrides_win_over_base() {
+        let schema = person_schema();
+        let mut base = BTreeMap::new();
+        base.insert("model".to_string(), VmValue::String(Rc::from("base:big")));
+        let mut overrides = BTreeMap::new();
+        overrides.insert(
+            "model".to_string(),
+            VmValue::String(Rc::from("override:small")),
+        );
+        let merged = merge_repair_options(Some(&base), &overrides, &schema);
+        assert_eq!(
+            merged.get("model").map(VmValue::display).as_deref(),
+            Some("override:small")
+        );
+    }
+
+    #[test]
+    fn build_repair_prompt_includes_schema_and_text() {
+        let schema = person_schema();
+        let prompt = build_repair_prompt(r#"{"name": 42}"#, &schema);
+        assert!(prompt.contains("Target schema"));
+        assert!(prompt.contains("Original text"));
+        assert!(prompt.contains(r#"{"name": 42}"#));
+        assert!(prompt.contains("Reply with valid JSON only"));
+    }
+
+    #[tokio::test]
+    async fn schema_recover_stage_parsed_for_clean_json() {
+        let schema = person_schema();
+        let args = vec![
+            VmValue::String(Rc::from(r#"{"name": "Ada", "age": 36}"#)),
+            schema,
+        ];
+        let env = schema_recover_impl(args, None).await.unwrap();
+        let dict = env.as_dict().unwrap();
+        assert!(matches!(dict.get("ok"), Some(VmValue::Bool(true))));
+        assert_eq!(
+            dict.get("stage").map(VmValue::display).as_deref(),
+            Some("parsed"),
+        );
+        assert_eq!(dict.get("attempts").and_then(VmValue::as_int), Some(1));
+        assert!(matches!(dict.get("repaired"), Some(VmValue::Bool(false))));
+    }
+
+    #[tokio::test]
+    async fn schema_recover_stage_extracted_for_fenced_json() {
+        let schema = person_schema();
+        let args = vec![
+            VmValue::String(Rc::from(
+                "Sure, here you go:\n```json\n{\"name\": \"Ada\", \"age\": 36}\n```\nDone.",
+            )),
+            schema,
+        ];
+        let env = schema_recover_impl(args, None).await.unwrap();
+        let dict = env.as_dict().unwrap();
+        assert!(matches!(dict.get("ok"), Some(VmValue::Bool(true))));
+        assert_eq!(
+            dict.get("stage").map(VmValue::display).as_deref(),
+            Some("extracted"),
+        );
+    }
+
+    #[tokio::test]
+    async fn schema_recover_stage_regex_for_yaml_shape() {
+        let schema = person_schema();
+        let args = vec![
+            VmValue::String(Rc::from("name: Ada\nage: 36\nactive: true\n")),
+            schema,
+        ];
+        let env = schema_recover_impl(args, None).await.unwrap();
+        let dict = env.as_dict().unwrap();
+        assert!(
+            matches!(dict.get("ok"), Some(VmValue::Bool(true))),
+            "envelope: {:?}",
+            env
+        );
+        assert_eq!(
+            dict.get("stage").map(VmValue::display).as_deref(),
+            Some("regex"),
+        );
+        let data = dict.get("data").unwrap().as_dict().unwrap();
+        assert_eq!(data.get("name").unwrap().display(), "Ada");
+        assert_eq!(data.get("age").unwrap().as_int(), Some(36));
+    }
+
+    #[tokio::test]
+    async fn schema_recover_failure_when_repair_disabled_and_unrecoverable() {
+        let schema = person_schema();
+        let mut opts = BTreeMap::new();
+        opts.insert("llm_repair".to_string(), VmValue::Bool(false));
+        let args = vec![
+            VmValue::String(Rc::from("nothing useful here at all")),
+            schema,
+            VmValue::Dict(Rc::new(opts)),
+        ];
+        let env = schema_recover_impl(args, None).await.unwrap();
+        let dict = env.as_dict().unwrap();
+        assert!(matches!(dict.get("ok"), Some(VmValue::Bool(false))));
+        assert_eq!(
+            dict.get("stage").map(VmValue::display).as_deref(),
+            Some("failed"),
+        );
+        assert_eq!(
+            dict.get("error_category").map(VmValue::display).as_deref(),
+            Some("schema_validation"),
+        );
+    }
+
+    #[tokio::test]
+    async fn schema_recover_rejects_non_dict_schema() {
+        let args = vec![
+            VmValue::String(Rc::from("anything")),
+            VmValue::String(Rc::from("not a schema")),
+        ];
+        let err = schema_recover_impl(args, None).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("schema must be a dict"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn schema_recover_rejects_missing_schema_arg() {
+        let args = vec![VmValue::String(Rc::from("anything"))];
+        let err = schema_recover_impl(args, None).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("expected"), "got: {msg}");
+    }
+}

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1007,6 +1007,53 @@ Options: everything `llm_call` accepts flows through, plus
 through unchanged. The `repair` block is recognized only by
 `llm_call_structured_result`.
 
+After-the-fact recovery — `schema_recover(text, schema, opts?)`
+turns malformed output that's already in your hand into a validated
+payload. Three deterministic stages followed by an optional one-shot
+LLM repair, returning the same `{ok, data, raw_text, error,
+error_category, attempts, stage, repaired}` envelope shape:
+
+| Stage | When | Notes |
+|---|---|---|
+| `parsed` | Raw text is valid JSON that schema-validates. | Cheapest path; always tried first. |
+| `extracted` | JSON is wrapped in markdown fences or surrounded by prose. | Uses the same balanced-brace lifter as `json_extract`. |
+| `regex` | Model produced YAML-ish / unquoted `key: value` lines. | Only top-level scalar fields (string/int/number/boolean) are recovered — nested objects fall through. |
+| `llm_repair` | Earlier stages failed and `llm_repair` is enabled (default). | Single shot, `schema_retries: 0`. Set `{llm_repair: false}` for fully deterministic recovery. |
+
+```harn
+let raw = llm_call(prompt, sys, {provider: "auto"}).text
+let r = schema_recover(raw, schema)
+if r.ok {
+  process(r.data)                  // narrowed-shape dict
+} else {
+  log("recovery failed:", r.stage, r.error_category, r.error)
+}
+```
+
+Use it as a drop-in replacement for hand-rolled `normalize_*()`
+chains downstream of `llm_call(...)` / Ollama prose responses, or
+when you want a deterministic local recovery pass before paying for
+a structured re-call. The `llm_repair` block accepts the same
+overrides as `llm_call_structured_result`'s `repair`:
+
+```harn
+let r = schema_recover(raw, schema, {
+  apply_defaults: true,            // schema defaults during validation
+  llm_repair: {
+    enabled: true,
+    model: "cheapest_over_quality(low)",
+    max_tokens: 600,
+  },
+})
+```
+
+Stages report via `r.stage` ∈ `"parsed" | "extracted" | "regex" |
+"llm_repair" | "failed"`; `r.attempts` counts how many stages ran
+(1 = clean parse, 4 = ran every stage including the LLM repair).
+On failure, `r.error_category` is `"schema_validation"` (no stage
+recovered) or `"repair_failed"` / `"transport"` (LLM repair was
+attempted and failed).
+
 If you need the raw response (token counts, transcript, thinking
 trace) alongside the parsed data, call `llm_call` directly:
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -3135,6 +3135,21 @@ wrappers pick up the same narrowing.
 - `schema_parse<T>(value: unknown, schema: Schema<T>) -> Result<T, string>`
 - `schema_check<T>(value: unknown, schema: Schema<T>) -> Result<T, string>`
 - `schema_expect<T>(value: unknown, schema: Schema<T>) -> T`
+- `schema_recover<T>(text: string, schema: Schema<T>, options?:
+  {llm_repair?: bool | dict, apply_defaults?: bool,
+  ...llm_call_overrides}) -> {ok: bool, data: T | nil, raw_text:
+  string, error: string, error_category: string | nil, attempts: int,
+  stage: string, repaired: bool}`. Best-effort recovery of malformed
+  LLM output against a target schema. Three deterministic stages
+  followed by an optional one-shot LLM repair: `parsed` (direct
+  `serde_json` parse) → `extracted` (lift JSON from prose / code
+  fences) → `regex` (scrape top-level `key: value` lines for scalar
+  fields) → `llm_repair` (single-shot `llm_call` with `schema_retries:
+  0`). `stage` reports which stage produced the result; `failed` means
+  every stage exhausted. Set `{llm_repair: false}` for a fully
+  deterministic recovery pass with no LLM calls. The LLM repair stage
+  accepts the same overrides as `llm_call_structured_result`'s
+  `repair`.
 
 `Schema<T>` denotes a runtime schema value whose static shape is `T`.
 In a parameter position, matching a `Schema<T>` against an argument


### PR DESCRIPTION
## Summary

- Adds `schema_recover(text, schema, opts?)` — a four-stage recovery cascade for malformed LLM output (parse → extract → regex → optional LLM repair)
- Returns the same `{ok, data, raw_text, error, error_category, attempts, stage, repaired}` envelope as `llm_call_structured_result`, with a new `stage` field reporting which tier produced the result
- Designed to replace hand-rolled `normalize_*()` chains downstream of `llm_call(...)` (e.g. burin-code's `normalize_grader_output()`)

Closes #906.

## Stages

| Stage | When |
|---|---|
| `parsed` | Raw text is valid JSON that schema-validates |
| `extracted` | JSON wrapped in markdown fences or surrounded by prose (uses the same balanced-brace lifter as `json_extract`) |
| `regex` | Top-level `key: value` / `key: "value"` / YAML-shape lines for scalar fields (string/int/number/boolean) |
| `llm_repair` | Single-shot `llm_call` with `schema_retries: 0`. Disabled with `{llm_repair: false}` for fully deterministic recovery |
| `failed` | Every stage exhausted |

## Files

- `crates/harn-vm/src/llm/schema_recover.rs` — new module, 23 unit tests
- `crates/harn-vm/src/llm/mod.rs` — module declaration + builtin registration
- `crates/harn-parser/src/builtin_signatures/signatures/schema.rs` — parser signature (return type resolved by generic lookup)
- `crates/harn-parser/src/builtin_signatures/generics.rs` — `Schema<T> -> {data: T | nil, ...}` generic so callers get `data` narrowing
- `conformance/tests/integration/schema_recover_*.{harn,expected}` — 5 end-to-end tests covering each stage including the mock LLM repair path
- `docs/llm/harn-quickref.md` — quickref entry with stage table and usage examples
- `spec/HARN_SPEC.md` + `docs/src/language-spec.md` — spec entry alongside `schema_parse`/`schema_check`/`schema_expect`
- `CHANGELOG.md` — v0.7.50 entry
- `docs/theme/harn-keywords.js` — regenerated highlight keywords (auto-synced via pre-commit)

## Cross-repo follow-up

After this ships in a Harn release, file an issue in `burin-labs/burin-code` to delete `normalize_grader_output()` from `scripts/grade-lora-corpus.harn` and replace with a direct `schema_recover(...)` call.

## Test plan

- [x] `cargo build -p harn-vm` — clean (no warnings)
- [x] `cargo test -p harn-vm schema_recover` — 23/23 pass
- [x] `cargo test -p harn-vm --test builtin_registry_alignment` — 2/2 pass (parser↔runtime drift)
- [x] `cargo run --bin harn -- test conformance --filter schema_recover` — 5/5 pass
- [x] `cargo run --bin harn -- test conformance` — 754/754 pass after retrying flaky supervisor tests (unrelated)
- [x] `cargo clippy -p harn-vm -p harn-parser` — clean
- [x] `cargo fmt --check` — clean
- [x] `npx markdownlint-cli2 docs/llm/harn-quickref.md spec/HARN_SPEC.md CHANGELOG.md docs/src/language-spec.md` — clean
- [x] `cargo run --bin harn -- lint conformance/tests/integration/schema_recover_*.harn` — no issues
- [x] `cargo run --bin harn -- fmt --check conformance/tests/integration/schema_recover_*.harn` — clean
- [x] Pre-commit + pre-push hooks pass (clippy, markdown lint, highlight regen, language spec sync, workspace tests, conformance fmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)