### PR TITLE
Release v0.7.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ external users before 0.6.0, so we intentionally do not preserve the full
 per-patch history of the 0.5.x and 0.4.x lines here — consult `git log` for
 granular archaeology.
 
-## v0.7.50
+## v0.7.51
 
 ### Added
 
@@ -32,6 +32,30 @@ granular archaeology.
   default baselines. Formatter, linter, LSP, tree-sitter, docs, generated
   keywords, and conformance coverage updated; per-case `compare_to`
   overrides manifest-level `baseline`.
+
+- **Provider-capability LLM option gating (#869/#1024).** `llm_call` options
+  are now gated against the provider capability matrix with consistent
+  provider/model error messages and a `harn check --provider-matrix` hint.
+  PDF capability metadata flows through provider rows, `model-info`,
+  `provider_capabilities`, docs, and matrix filters. CLI replay / mock-replay
+  paths bypass gates to keep fixture-backed tests unblocked.
+
+- **Signed provenance receipts (#931/#1018).** Adds Merkle-chained EventLog
+  provenance headers with per-topic prev/record hashes and Ed25519-signed
+  receipts. New `harn run --attest` / `--receipt-out` / `--attest-agent`
+  flags plus a top-level `harn verify` command for receipt verification with
+  tamper detection. Parser/unit coverage and CLI docs updated.
+
+- **Guarded stdlib tool synthesis (#966/#1017).** New `tool_synthesize`
+  builtin produces deterministic, cached callable tools from natural-language
+  specs. Default executor stays in dry-run; explicit `host_bridge` and
+  `mcp_server` dispatch paths are gated by existing `host_tool_call` /
+  `mcp_call` policy checks. Conformance coverage and highlight metadata
+  refreshed.
+
+## v0.7.50
+
+### Added
 
 - **Enterprise LLM providers (#870/#976).** First-class shims for Bedrock
   Runtime (Converse API with hand-rolled AWS SigV4 signing and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.50"
+version = "0.7.51"
 dependencies = [
  "async-trait",
  "axum",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.50"
+version = "0.7.51"
 dependencies = [
  "harn-vm",
  "serde",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.50"
+version = "0.7.51"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.50"
+version = "0.7.51"
 dependencies = [
  "anyhow",
  "base64",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.50"
+version = "0.7.51"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1812,11 +1812,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.50"
+version = "0.7.51"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.50"
+version = "0.7.51"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.50"
+version = "0.7.51"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.50"
+version = "0.7.51"
 dependencies = [
  "croner",
  "harn-lexer",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.50"
+version = "0.7.51"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.50"
+version = "0.7.51"
 dependencies = [
  "async-trait",
  "axum",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "harn-vm"
-version = "0.7.50"
+version = "0.7.51"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.50"
+version = "0.7.51"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1221,7 +1221,7 @@ Returns a list of results in the original order.
 
 ```harn
 let results = parallel each list with { max_concurrent: 4 } { item ->
-  work(item)
+  // body for each item
 } as stream
 
 for result in results {

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -91,6 +91,7 @@ The following identifiers are reserved:
 | `while` | `.whileKw` |
 | `type` | `.typeKw` |
 | `enum` | `.enum` |
+| `eval_pack` | `.evalPack` |
 | `struct` | `.struct` |
 | `interface` | `.interface` |
 | `pub` | `.pub` |
@@ -1181,8 +1182,8 @@ The stable fields are always present, with unavailable values represented as
 `provider`, `trace_id`, `span_id`, `scheduler_key`, `runner`,
 `capacity_class`, `context_values`, `cancelled`, and `debug`.
 
-`spawn`, `parallel`, `parallel each`, and `parallel settle` create child
-logical tasks. A child task receives a deterministic `task_id`, its
+`spawn`, `parallel`, `parallel each`, `parallel each ... as stream`, and
+`parallel settle` create child logical tasks. A child task receives a deterministic `task_id`, its
 `parent_task_id` is the creating task, and its `root_task_id` is inherited from
 the root task. `parallel` siblings share a `task_group_id`.
 
@@ -1215,6 +1216,30 @@ parallel each list { item ->
 Maps over a list concurrently. Each task gets an isolated interpreter.
 The variable is bound to the current list element.
 Returns a list of results in the original order.
+
+### parallel each as stream
+
+```harn
+let results = parallel each list with { max_concurrent: 4 } { item ->
+  work(item)
+} as stream
+
+for result in results {
+  println(result)
+}
+```
+
+Maps over a list concurrently and returns `Stream<T>` instead of
+materializing a result list. The stream emits each task result as soon as
+that task completes, so output order is completion order rather than
+source order. `with { max_concurrent: N }` is honored the same way as
+eager `parallel each`. If a task throws, the error is raised when the
+consumer pulls that stream item and remaining tasks are cancelled.
+
+`parallel_race(items, callable, options?)` is the first-success helper
+for this pattern. It returns the first plain value or `Result.Ok`
+payload produced by `callable`, cancels remaining tasks, and throws an
+aggregate error if every task throws or returns `Result.Err`.
 
 ### parallel settle
 
@@ -3041,6 +3066,31 @@ let r = llm_call(prompt, nil, {
 })
 ```
 
+For call sites that want routing policy to be visibly scoped around the work,
+`cost_route` installs an inherited LLM routing context for the dynamic extent
+of its block. Nested `llm_call` invocations inherit the block's routing and
+budget options; an explicit option on the call wins for the same key.
+
+```harn
+let r = cost_route {
+  budget_usd: 0.05
+  prefer: ["anthropic:claude-haiku-4-5", "openai:gpt-5.4-mini"]
+  fallback_strategy: cheapest_first
+
+  llm_call(prompt, nil, {max_tokens: 800})
+}
+```
+
+`budget_usd` is a shorthand for `budget.max_cost_usd`. `prefer` is an ordered
+list of model aliases, model ids, or `provider:model` selectors. The
+`fallback_strategy` value may be `prefer_order`, `cheapest_first`, or
+`fastest_first`; failures on the selected route are retried against the
+remaining preferred routes before provider-level fallbacks are considered.
+Without `prefer`, `fallback_strategy: cheapest_first` and
+`fallback_strategy: fastest_first` lower to the corresponding
+`cheapest_over_quality(quality)` / `fastest_over_quality(quality)` policy,
+using `quality` or `min_quality` when present and `mid` otherwise.
+
 The emitted schema follows canonical JSON-Schema conventions (objects
 with `properties`/`required`, arrays with `items`, literal unions as
 `{type, enum}`) so it is compatible with structured-output validators
@@ -4391,6 +4441,36 @@ Threshold severity controls deployment-gate behavior:
 
 Run a pack directly with `harn eval harn.eval.toml`, or run package-declared
 packs with `harn test package --evals`.
+
+Harn source may also declare an eval pack directly:
+
+```harn
+eval_pack regression "slack-connector" {
+  baseline: "fixtures/baseline.run.json"
+  fixtures: [{id: "candidate", kind: "run-record", path: "fixtures/candidate.run.json"}]
+  rubrics: [{id: "status", kind: "deterministic", assertions: [{kind: "run-status", expected: "completed"}]}]
+  cases: [{id: "url-verification", run: "candidate", rubrics: ["status"]}]
+}
+```
+
+`eval_pack NAME { ... }` binds `NAME` to `eval_pack_manifest({ ... })`. If a
+string id is supplied after the name, that string becomes the manifest id; if
+the declaration starts with a string id, Harn derives a valid binding name from
+the id. Missing `version` defaults to `1`, and missing `id` defaults to the
+header id.
+
+Field entries use `field: expression` and are normalized through the same
+eval-pack runtime data model as TOML packs. A top-level `baseline` field acts
+as a default `compare_to` path for cases that do not specify their own
+baseline.
+
+An `eval_pack` block may include ordinary Harn statements and one
+`summarize { ... }` block. These statements run when the declaration is
+executed in script or block position, with the binding name, `id`, `version`,
+and all declared field names in scope. When a file has pipelines, top-level
+`eval_pack` declarations are preloaded as manifest values without running
+their executable body, so importing or running an unrelated pipeline does not
+trigger eval side effects.
 
 ### Package registry index
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1219,7 +1219,7 @@ Returns a list of results in the original order.
 
 ```harn
 let results = parallel each list with { max_concurrent: 4 } { item ->
-  work(item)
+  // body for each item
 } as stream
 
 for result in results {


### PR DESCRIPTION
## Summary

Cuts v0.7.51 with the post-v0.7.50 backlog landed today:

- **`cost_route` language block** (#967/#1025)
- **Streaming `parallel each` and event-log subscriptions** (#970/#1023)
- **First-class `eval_pack` declarations** (#965/#1022)
- **Provider-capability LLM option gating** (#869/#1024)
- **Signed provenance receipts** (#931/#1018)
- **Guarded stdlib tool synthesis** (#966/#1017)

CHANGELOG was sliced to add a new \`## v0.7.51\` heading above these
entries; v0.7.50's published content is unchanged below.

## Test plan

- [x] \`cargo check --workspace --tests\` on the release branch
- [x] release_gate.sh prepare audit + publish dry-run
- [ ] CI (Rust, Windows, conformance, format, markdown lint)
- [ ] Merge queue lands, Finalize Release workflow auto-fires on tag drift, ships v0.7.51 to crates.io and GH Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)