### PR TITLE
Add generic webhook intake substrate (#1011)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,18 @@ granular archaeology.
   `stage` reporting which tier succeeded. Designed to replace
   hand-rolled `normalize_*()` chains downstream of LLM calls; set
   `{llm_repair: false}` for a fully deterministic recovery pass.
+- **Generic webhook intake substrate (#1011).** Forge-agnostic intake layer
+  any connector can wire into. Connectors declare a path scope, signature
+  header + algorithm (`sha256` or legacy `sha1`), delivery-id header, and
+  topic; the substrate handles HMAC verification, durable delivery-id
+  deduplication via the trigger inbox, and republishes accepted deliveries
+  onto the connector's chosen topic. Exposed as `webhook_intake_register`,
+  `webhook_intake_feed`, `webhook_intake_recent`, `webhook_intake_list`,
+  and `webhook_intake_deregister` builtins. Per-forge event normalization
+  remains in each connector repo. Includes `hmac_sha1` builtin for legacy
+  signature schemes. New `triggers/webhook-intake.md` doc and conformance
+  coverage for happy path, signature rejection, replay dedupe, and
+  multi-path isolation.
 
 - **Enterprise LLM providers (#870/#976).** First-class shims for Bedrock
   Runtime (Converse API with hand-rolled AWS SigV4 signing and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,6 +1932,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_yaml",
+ "sha1",
  "sha2 0.11.0",
  "sha3",
  "sqlx-core",

--- a/conformance/tests/triggers/webhook_intake_multi_path_isolation.expected
+++ b/conformance/tests/triggers/webhook_intake_multi_path_isolation.expected
@@ -1,0 +1,6 @@
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/triggers/webhook_intake_multi_path_isolation.harn
+++ b/conformance/tests/triggers/webhook_intake_multi_path_isolation.harn
@@ -1,0 +1,66 @@
+pipeline test(task) {
+  let intake_a = webhook_intake_register(
+    {
+      id: "intake-a",
+      path: "/hooks/a",
+      secret: "secret-a",
+      signature_header: "x-a-signature",
+      delivery_id_header: "x-a-delivery",
+      topic: "tests.intake.path_a",
+    },
+  )
+  let intake_b = webhook_intake_register(
+    {
+      id: "intake-b",
+      path: "/hooks/b",
+      secret: "secret-b",
+      signature_header: "x-b-signature",
+      delivery_id_header: "x-b-delivery",
+      topic: "tests.intake.path_b",
+    },
+  )
+  println(intake_a.id == "intake-a")
+  println(intake_b.id == "intake-b")
+  let body = "shared-body"
+  // Same delivery id on two intakes must NOT collide.
+  let sig_a = "sha256=" + hmac_sha256("secret-a", body)
+  let sig_b = "sha256=" + hmac_sha256("secret-b", body)
+  let outcome_a = webhook_intake_feed(
+    "intake-a",
+    {
+      headers: {["x-a-signature"]: sig_a, ["x-a-delivery"]: "shared-delivery"},
+      body: body,
+      path: "/hooks/a",
+    },
+  )
+  let outcome_b = webhook_intake_feed(
+    "intake-b",
+    {
+      headers: {["x-b-signature"]: sig_b, ["x-b-delivery"]: "shared-delivery"},
+      body: body,
+      path: "/hooks/b",
+    },
+  )
+  println(outcome_a.status == "accepted")
+  println(outcome_b.status == "accepted")
+  // Path mismatch is rejected even with a valid signature.
+  let mismatched = webhook_intake_feed(
+    "intake-a",
+    {
+      headers: {["x-a-signature"]: sig_a, ["x-a-delivery"]: "delivery-other"},
+      body: body,
+      path: "/hooks/wrong",
+    },
+  )
+  println(mismatched.status == "rejected")
+  // Wrong-secret signature is rejected (cross-intake leakage).
+  let cross = webhook_intake_feed(
+    "intake-a",
+    {
+      headers: {["x-a-signature"]: sig_b, ["x-a-delivery"]: "delivery-cross"},
+      body: body,
+      path: "/hooks/a",
+    },
+  )
+  println(cross.status == "rejected")
+}

--- a/conformance/tests/triggers/webhook_intake_round_trip.expected
+++ b/conformance/tests/triggers/webhook_intake_round_trip.expected
@@ -1,0 +1,8 @@
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/triggers/webhook_intake_round_trip.harn
+++ b/conformance/tests/triggers/webhook_intake_round_trip.harn
@@ -1,0 +1,51 @@
+pipeline test(task) {
+  let intake = webhook_intake_register(
+    {
+      id: "round-trip",
+      path: "/hooks/foo",
+      secret: "super-secret",
+      signature_header: "x-hub-signature-256",
+      delivery_id_header: "x-github-delivery",
+      topic: "tests.intake.round_trip",
+    },
+  )
+  println(intake.id == "round-trip")
+  println(intake.topic == "tests.intake.round_trip")
+  let body = "{\"hello\":\"world\"}"
+  let signature = "sha256=" + hmac_sha256("super-secret", body)
+  // Acceptance: a valid signature is accepted and republished onto the topic.
+  let accepted = webhook_intake_feed(
+    "round-trip",
+    {
+      headers: {["x-hub-signature-256"]: signature, ["x-github-delivery"]: "delivery-1"},
+      body: body,
+      path: "/hooks/foo",
+    },
+  )
+  println(accepted.status == "accepted")
+  println(accepted.delivery_id == "delivery-1")
+  // Acceptance: replay with the same delivery id is deduped.
+  let dup = webhook_intake_feed(
+    "round-trip",
+    {
+      headers: {["x-hub-signature-256"]: signature, ["x-github-delivery"]: "delivery-1"},
+      body: body,
+      path: "/hooks/foo",
+    },
+  )
+  println(dup.status == "duplicate")
+  // Acceptance: a tampered signature is rejected.
+  let bad = webhook_intake_feed(
+    "round-trip",
+    {
+      headers: {["x-hub-signature-256"]: "sha256=deadbeef", ["x-github-delivery"]: "delivery-2"},
+      body: body,
+      path: "/hooks/foo",
+    },
+  )
+  println(bad.status == "rejected")
+  // Bounded replay buffer: the topic holds the accepted delivery.
+  let recent = webhook_intake_recent("round-trip", 8)
+  println(len(recent) == 1)
+  println(recent[0].delivery_id == "delivery-1")
+}

--- a/conformance/tests/triggers/webhook_intake_sha1_legacy.expected
+++ b/conformance/tests/triggers/webhook_intake_sha1_legacy.expected
@@ -1,0 +1,2 @@
+true
+true

--- a/conformance/tests/triggers/webhook_intake_sha1_legacy.harn
+++ b/conformance/tests/triggers/webhook_intake_sha1_legacy.harn
@@ -1,0 +1,34 @@
+pipeline test(task) {
+  // Legacy webhook providers (older Bitbucket, pre-2018 GitHub) sign with
+  // SHA-1. The substrate must let connectors opt in.
+  let _intake = webhook_intake_register(
+    {
+      id: "legacy-sha1",
+      secret: "legacy-secret",
+      algorithm: "sha1",
+      signature_header: "x-hub-signature",
+      signature_prefix: "sha1=",
+      delivery_id_header: "x-legacy-delivery",
+      topic: "tests.intake.legacy",
+    },
+  )
+  let body = "legacy-payload"
+  let signature = "sha1=" + hmac_sha1("legacy-secret", body)
+  let outcome = webhook_intake_feed(
+    "legacy-sha1",
+    {headers: {["x-hub-signature"]: signature, ["x-legacy-delivery"]: "legacy-1"}, body: body},
+  )
+  println(outcome.status == "accepted")
+  // SHA-256 signature against a SHA-1 intake is rejected (mismatch).
+  let wrong = webhook_intake_feed(
+    "legacy-sha1",
+    {
+      headers: {
+        ["x-hub-signature"]: "sha1=" + hmac_sha256("legacy-secret", body),
+        ["x-legacy-delivery"]: "legacy-2",
+      },
+      body: body,
+    },
+  )
+  println(wrong.status == "rejected")
+}

--- a/crates/harn-cli/src/commands/dump_trigger_quickref.rs
+++ b/crates/harn-cli/src/commands/dump_trigger_quickref.rs
@@ -189,7 +189,64 @@ fn generate_file() -> String {
     out.push_str("Run `harn connector test .` locally. Use `--provider <id>` for a multi-provider package, `--run-poll-tick` to execute the first poll tick, and `--json` for CI output.\n\n");
 
     out.push_str("## Example Library\n\n");
-    out.push_str("Ready-to-customize pipelines live under `examples/triggers/`. Each example includes `harn.toml`, `lib.harn`, `README.md`, and `SKILL.md` so it can be copied into a project or installed as a local skill bundle. Validate examples with `make check-trigger-examples`.\n");
+    out.push_str("Ready-to-customize pipelines live under `examples/triggers/`. Each example includes `harn.toml`, `lib.harn`, `README.md`, and `SKILL.md` so it can be copied into a project or installed as a local skill bundle. Validate examples with `make check-trigger-examples`.\n\n");
+
+    out.push_str("## Generic Webhook Intake Substrate\n\n");
+    out.push_str(
+        "Below the per-provider connectors lives a forge-agnostic intake substrate\n\
+that any connector can wire into. It is the lowest-level entry point: a\n\
+connector declares a path scope, a signature header + algorithm, a\n\
+delivery-id header, and a topic; the substrate handles HMAC verification,\n\
+delivery-id deduplication (durable across process restarts), and\n\
+republishing onto the chosen topic. Per-forge event normalization lives in\n\
+the connector that consumes the topic.\n\n",
+    );
+    out.push_str("Builtins:\n\n");
+    out.push_str(
+        "- `webhook_intake_register(config) -> dict` — register an intake. Returns\n  \
+`{ id, path, topic, signature_header, signature_prefix,\n  signature_encoding, algorithm, delivery_id_header,\n  dedupe_ttl_seconds }`. Config keys:\n  \
+- `id` (optional) — pin the intake id; one is generated if omitted.\n  \
+- `path` (optional) — HTTP path scope. When set, `webhook_intake_feed`\n    rejects deliveries on a different path.\n  \
+- `secret` (string or bytes, required) — HMAC key.\n  \
+- `signature_header` (required) — e.g. `\"x-hub-signature-256\"`.\n  \
+- `signature_prefix` — defaults to `\"<algorithm>=\"`. Pass `\"\"` to opt out.\n  \
+- `signature_encoding` — `\"hex\"` (default) or `\"base64\"`.\n  \
+- `algorithm` — `\"sha256\"` (default) or `\"sha1\"` (legacy).\n  \
+- `delivery_id_header` (required) — e.g. `\"x-github-delivery\"`.\n  \
+- `topic` (required) — event-log topic accepted deliveries are appended to.\n  \
+- `dedupe_ttl_seconds` — defaults to 24h.\n\
+- `webhook_intake_feed(intake_id, request) -> dict` — feed a delivery.\n  \
+Request keys: `headers` (dict), `body` (string or bytes), optional `path`\n  \
+and `received_at` (RFC3339). Returns `{ status, intake_id, topic,\n  \
+delivery_id, topic_event_id, reason, received_at }`. `status` is\n  \
+`\"accepted\"`, `\"duplicate\"`, or `\"rejected\"`.\n\
+- `webhook_intake_recent(intake_id, limit?) -> list` — bounded replay\n  \
+buffer. Reads the last `limit` accepted deliveries from the topic.\n\
+- `webhook_intake_list() -> list` — all currently-registered intakes.\n\
+- `webhook_intake_deregister(intake_id) -> bool` — remove an intake.\n\n",
+    );
+    out.push_str("A connector wires this in well under 30 lines:\n\n");
+    out.push_str(
+        "```harn\n\
+import \"std/triggers\"\n\n\
+let intake = webhook_intake_register({\n  \
+id: \"github\",\n  \
+path: \"/hooks/github\",\n  \
+secret: secret_get(\"github/webhook-secret\"),\n  \
+signature_header: \"x-hub-signature-256\",\n  \
+delivery_id_header: \"x-github-delivery\",\n  \
+topic: \"github.events\",\n\
+})\n\n\
+// In your inbound HTTP handler:\n\
+let outcome = webhook_intake_feed(intake.id, {\n  \
+headers: request.headers,\n  \
+body: request.body,\n  \
+path: request.path,\n\
+})\n\
+return { status: outcome.status == \"rejected\" ? 401 : 202 }\n\
+```\n\n",
+    );
+    out.push_str("Rejections are appended to `triggers.webhook_intake.rejections` with the\nintake id and reason for audit. The substrate is agnostic to per-forge\nevent shape — connectors normalize the opaque payload after consuming the\ntopic.\n");
     out
 }
 

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -408,6 +408,26 @@ pub(crate) const SIGNATURES: &[BuiltinSig] = &[
         return_type: Some(BuiltinReturn::Named("dict")),
     },
     BuiltinSig {
+        name: "webhook_intake_register",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "webhook_intake_feed",
+        return_type: Some(BuiltinReturn::Named("dict")),
+    },
+    BuiltinSig {
+        name: "webhook_intake_deregister",
+        return_type: Some(BuiltinReturn::Named("bool")),
+    },
+    BuiltinSig {
+        name: "webhook_intake_list",
+        return_type: Some(BuiltinReturn::Named("list")),
+    },
+    BuiltinSig {
+        name: "webhook_intake_recent",
+        return_type: Some(BuiltinReturn::Named("list")),
+    },
+    BuiltinSig {
         name: "date_add",
         return_type: None,
     },
@@ -605,6 +625,10 @@ pub(crate) const SIGNATURES: &[BuiltinSig] = &[
     },
     BuiltinSig {
         name: "hex_encode",
+        return_type: Some(BuiltinReturn::Named("string")),
+    },
+    BuiltinSig {
+        name: "hmac_sha1",
         return_type: Some(BuiltinReturn::Named("string")),
     },
     BuiltinSig {

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -41,6 +41,7 @@ data-encoding = "2"
 ed25519-dalek = { version = "2", features = ["pem", "pkcs8", "rand_core"] }
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 hex = "0.4"
+sha1 = "0.10"
 sha2 = "0.11"
 sha3 = "0.11"
 blake3 = "1"

--- a/crates/harn-vm/src/connectors/hmac.rs
+++ b/crates/harn-vm/src/connectors/hmac.rs
@@ -1185,6 +1185,37 @@ pub(crate) fn hmac_sha256(secret: &[u8], data: &[u8]) -> Vec<u8> {
     outer.finalize().to_vec()
 }
 
+pub(crate) fn hmac_sha1(secret: &[u8], data: &[u8]) -> Vec<u8> {
+    use sha1::{Digest, Sha1};
+    const BLOCK_SIZE: usize = 64;
+
+    let mut key = if secret.len() > BLOCK_SIZE {
+        Sha1::digest(secret).to_vec()
+    } else {
+        secret.to_vec()
+    };
+    key.resize(BLOCK_SIZE, 0);
+
+    let mut inner_pad = vec![0x36; BLOCK_SIZE];
+    let mut outer_pad = vec![0x5c; BLOCK_SIZE];
+    for (slot, key_byte) in inner_pad.iter_mut().zip(&key) {
+        *slot ^= key_byte;
+    }
+    for (slot, key_byte) in outer_pad.iter_mut().zip(&key) {
+        *slot ^= key_byte;
+    }
+
+    let mut inner = Sha1::new();
+    inner.update(&inner_pad);
+    inner.update(data);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha1::new();
+    outer.update(&outer_pad);
+    outer.update(inner_digest);
+    outer.finalize().to_vec()
+}
+
 pub(crate) fn secure_eq(expected: &[u8], provided: &[u8]) -> bool {
     expected.ct_eq(provided).into()
 }

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -208,4 +208,5 @@ pub fn reset_stdlib_state() {
     vision::reset_vision_state();
     crate::skills::clear_current_skill_registry();
     template::reset_prompt_registry();
+    crate::triggers::clear_webhook_intake_state();
 }

--- a/crates/harn-vm/src/stdlib/crypto.rs
+++ b/crates/harn-vm/src/stdlib/crypto.rs
@@ -725,6 +725,17 @@ pub(crate) fn register_crypto_builtins(vm: &mut Vm) {
         )))
     });
 
+    // HMAC-SHA1 (hex). Provided for legacy webhook signatures (e.g. older
+    // Bitbucket / GitHub `x-hub-signature: sha1=<hex>`); SHA-256 should be
+    // preferred for any new integration.
+    vm.register_builtin("hmac_sha1", |args, _out| {
+        let key = args.first().map(|a| a.display()).unwrap_or_default();
+        let msg = args.get(1).map(|a| a.display()).unwrap_or_default();
+        let mac = crate::connectors::hmac::hmac_sha1(key.as_bytes(), msg.as_bytes());
+        let hex: String = mac.iter().map(|b| format!("{b:02x}")).collect();
+        Ok(VmValue::String(Rc::from(hex)))
+    });
+
     vm.register_builtin("jwt_sign", |args, _out| jwt_sign_builtin(args));
 
     vm.register_builtin("signed_url", |args, _out| signed_url_builtin(args));

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -12,11 +12,13 @@ use crate::triggers::dispatcher::current_dispatch_context;
 use crate::triggers::dispatcher::DEFAULT_MAX_ATTEMPTS;
 use crate::triggers::test_util::{clock, run_trigger_harness_fixture};
 use crate::triggers::{
-    dynamic_register, registered_provider_metadata, resolve_live_or_as_of,
-    resolve_live_trigger_binding, snapshot_trigger_bindings, RecordedTriggerBinding, RetryPolicy,
-    TriggerBindingSnapshot, TriggerBindingSource, TriggerBindingSpec, TriggerEvent, TriggerEventId,
-    TriggerHandlerSpec, TriggerPredicateSpec, TriggerRegistryError, TriggerRetryConfig,
-    TRIGGERS_LIFECYCLE_TOPIC, TRIGGER_DLQ_TOPIC,
+    deregister_webhook_intake, dynamic_register, feed_webhook_intake, recent_webhook_deliveries,
+    register_webhook_intake, registered_provider_metadata, resolve_live_or_as_of,
+    resolve_live_trigger_binding, snapshot_trigger_bindings, snapshot_webhook_intakes,
+    HmacAlgorithm, RecordedTriggerBinding, RetryPolicy, SignatureEncoding, TriggerBindingSnapshot,
+    TriggerBindingSource, TriggerBindingSpec, TriggerEvent, TriggerEventId, TriggerHandlerSpec,
+    TriggerPredicateSpec, TriggerRegistryError, TriggerRetryConfig, WebhookIntakeConfig,
+    WebhookIntakeError, WebhookIntakeRequest, TRIGGERS_LIFECYCLE_TOPIC, TRIGGER_DLQ_TOPIC,
 };
 use crate::trust_graph::{
     group_trust_records_by_trace, policy_for_agent, query_trust_records, trust_score_for,
@@ -258,6 +260,60 @@ pub(crate) fn register_trigger_builtins(vm: &mut Vm) {
             .await
             .map_err(|error| VmError::Runtime(format!("trust_graph_verify_chain: {error}")))?;
         Ok(value_from_serde(&report))
+    });
+
+    vm.register_async_builtin("webhook_intake_register", |args| async move {
+        let config = require_dict_arg(&args, 0, "webhook_intake_register")?;
+        let parsed = parse_webhook_intake_config(config)?;
+        let snapshot = register_webhook_intake(parsed).map_err(webhook_intake_error)?;
+        Ok(value_from_serde(&snapshot))
+    });
+
+    vm.register_async_builtin("webhook_intake_feed", |args| async move {
+        let intake_id = required_string_arg(&args, 0, "webhook_intake_feed", "intake_id")?;
+        let request_dict = require_dict_arg(&args, 1, "webhook_intake_feed")?;
+        let request = parse_webhook_intake_request(request_dict)?;
+        let outcome = feed_webhook_intake(&intake_id, request)
+            .await
+            .map_err(webhook_intake_error)?;
+        Ok(value_from_serde(&outcome))
+    });
+
+    vm.register_async_builtin("webhook_intake_deregister", |args| async move {
+        let intake_id = required_string_arg(&args, 0, "webhook_intake_deregister", "intake_id")?;
+        Ok(VmValue::Bool(deregister_webhook_intake(&intake_id)))
+    });
+
+    vm.register_builtin("webhook_intake_list", |_args, _out| {
+        Ok(VmValue::List(Rc::new(
+            snapshot_webhook_intakes()
+                .into_iter()
+                .map(|snapshot| value_from_serde(&snapshot))
+                .collect(),
+        )))
+    });
+
+    vm.register_async_builtin("webhook_intake_recent", |args| async move {
+        let intake_id = required_string_arg(&args, 0, "webhook_intake_recent", "intake_id")?;
+        let limit = match args.get(1) {
+            Some(VmValue::Int(value)) if *value >= 0 => *value as usize,
+            Some(VmValue::Nil) | None => 32,
+            Some(other) => {
+                return Err(VmError::Runtime(format!(
+                    "webhook_intake_recent: limit must be a non-negative int, got {}",
+                    other.type_name()
+                )))
+            }
+        };
+        let entries = recent_webhook_deliveries(&intake_id, limit)
+            .await
+            .map_err(webhook_intake_error)?;
+        Ok(VmValue::List(Rc::new(
+            entries
+                .iter()
+                .map(crate::stdlib::json_to_vm_value)
+                .collect(),
+        )))
     });
 
     vm.register_async_builtin("trigger_test_harness", |args| async move {
@@ -1445,6 +1501,153 @@ fn number_value(value: &VmValue) -> Option<f64> {
 
 fn trigger_registry_error(error: impl std::fmt::Display) -> VmError {
     VmError::Runtime(format!("trigger stdlib: {error}"))
+}
+
+fn webhook_intake_error(error: WebhookIntakeError) -> VmError {
+    VmError::Runtime(format!("webhook_intake: {error}"))
+}
+
+fn parse_webhook_intake_config(
+    config: &BTreeMap<String, VmValue>,
+) -> Result<WebhookIntakeConfig, VmError> {
+    let signature_header = required_string(config, "signature_header", "webhook_intake_register")?;
+    let delivery_id_header =
+        required_string(config, "delivery_id_header", "webhook_intake_register")?;
+    let topic = required_string(config, "topic", "webhook_intake_register")?;
+
+    let algorithm = match optional_string(config, "algorithm").as_deref() {
+        Some(raw) => HmacAlgorithm::parse(raw).ok_or_else(|| {
+            VmError::Runtime(format!(
+                "webhook_intake_register: unsupported algorithm `{raw}`, expected sha256 or sha1"
+            ))
+        })?,
+        None => HmacAlgorithm::default(),
+    };
+    let signature_encoding = match optional_string(config, "signature_encoding").as_deref() {
+        Some(raw) => SignatureEncoding::parse(raw).ok_or_else(|| {
+            VmError::Runtime(format!(
+                "webhook_intake_register: unsupported signature_encoding `{raw}`, expected hex or base64"
+            ))
+        })?,
+        None => SignatureEncoding::default(),
+    };
+    // `signature_prefix` defaults to "<algorithm>=" (matches GitHub, GitLab,
+    // Bitbucket conventions). Pass an empty string explicitly to opt out.
+    let signature_prefix = match config.get("signature_prefix") {
+        Some(VmValue::String(text)) => Some(text.to_string()),
+        Some(VmValue::Nil) | None => Some(format!("{}=", algorithm.as_str())),
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "webhook_intake_register: signature_prefix must be a string or nil, got {}",
+                other.type_name()
+            )))
+        }
+    }
+    .filter(|prefix| !prefix.is_empty());
+
+    let secret = parse_intake_secret(config)?;
+    let dedupe_ttl_secs = match config.get("dedupe_ttl_seconds") {
+        Some(VmValue::Int(value)) if *value > 0 => *value as u64,
+        Some(VmValue::Nil) | None => crate::triggers::webhook_intake::DEFAULT_DEDUPE_TTL_SECS,
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "webhook_intake_register: dedupe_ttl_seconds must be a positive int, got {}",
+                other.type_name()
+            )))
+        }
+    };
+
+    Ok(WebhookIntakeConfig {
+        id: optional_string(config, "id"),
+        path: optional_string(config, "path"),
+        signature_header,
+        signature_prefix,
+        signature_encoding,
+        algorithm,
+        secret,
+        delivery_id_header,
+        topic,
+        dedupe_ttl: std::time::Duration::from_secs(dedupe_ttl_secs),
+    })
+}
+
+fn parse_intake_secret(config: &BTreeMap<String, VmValue>) -> Result<Vec<u8>, VmError> {
+    match config.get("secret") {
+        Some(VmValue::String(text)) => Ok(text.as_bytes().to_vec()),
+        Some(VmValue::Bytes(bytes)) => Ok((**bytes).clone()),
+        Some(other) => Err(VmError::Runtime(format!(
+            "webhook_intake_register: `secret` must be a string or bytes, got {}",
+            other.type_name()
+        ))),
+        None => Err(VmError::Runtime(
+            "webhook_intake_register: missing `secret` (string or bytes)".to_string(),
+        )),
+    }
+}
+
+fn parse_webhook_intake_request(
+    request: &BTreeMap<String, VmValue>,
+) -> Result<WebhookIntakeRequest, VmError> {
+    let headers = match request.get("headers") {
+        Some(VmValue::Dict(dict)) => dict
+            .iter()
+            .map(|(key, value)| match value {
+                VmValue::String(text) => Ok((key.clone(), text.to_string())),
+                VmValue::Int(value) => Ok((key.clone(), value.to_string())),
+                VmValue::Float(value) => Ok((key.clone(), value.to_string())),
+                VmValue::Bool(value) => Ok((key.clone(), value.to_string())),
+                other => Err(VmError::Runtime(format!(
+                    "webhook_intake_feed: headers.{key} must be a string, got {}",
+                    other.type_name()
+                ))),
+            })
+            .collect::<Result<BTreeMap<_, _>, _>>()?,
+        Some(VmValue::Nil) | None => BTreeMap::new(),
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "webhook_intake_feed: headers must be a dict, got {}",
+                other.type_name()
+            )))
+        }
+    };
+    let body = match request.get("body") {
+        Some(VmValue::Bytes(bytes)) => (**bytes).clone(),
+        Some(VmValue::String(text)) => text.as_bytes().to_vec(),
+        Some(VmValue::Nil) | None => Vec::new(),
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "webhook_intake_feed: body must be string or bytes, got {}",
+                other.type_name()
+            )))
+        }
+    };
+    let path = optional_string(request, "path");
+    let received_at = match request.get("received_at") {
+        Some(VmValue::String(text)) => Some(
+            OffsetDateTime::parse(
+                text.as_ref(),
+                &time::format_description::well_known::Rfc3339,
+            )
+            .map_err(|error| {
+                VmError::Runtime(format!(
+                    "webhook_intake_feed: received_at must be RFC3339, got `{text}`: {error}"
+                ))
+            })?,
+        ),
+        Some(VmValue::Nil) | None => None,
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "webhook_intake_feed: received_at must be a string, got {}",
+                other.type_name()
+            )))
+        }
+    };
+    Ok(WebhookIntakeRequest {
+        headers,
+        body,
+        path,
+        received_at,
+    })
 }
 
 fn value_from_serde<T: Serialize>(value: &T) -> VmValue {

--- a/crates/harn-vm/src/triggers/mod.rs
+++ b/crates/harn-vm/src/triggers/mod.rs
@@ -6,6 +6,7 @@ pub mod registry;
 pub mod scheduler;
 pub mod test_util;
 pub mod topics;
+pub mod webhook_intake;
 pub mod worker_queue;
 
 pub use dispatcher::{
@@ -57,6 +58,13 @@ pub use topics::{
     TRIGGER_CANCEL_REQUESTS_TOPIC, TRIGGER_DLQ_TOPIC, TRIGGER_INBOX_CLAIMS_TOPIC,
     TRIGGER_INBOX_ENVELOPES_TOPIC, TRIGGER_INBOX_LEGACY_TOPIC, TRIGGER_OPERATION_AUDIT_TOPIC,
     TRIGGER_OUTBOX_TOPIC,
+};
+pub use webhook_intake::{
+    build_request as build_webhook_intake_request, clear_webhook_intake_state,
+    deregister_webhook_intake, feed_webhook_intake, intake_for_path, recent_webhook_deliveries,
+    register_webhook_intake, snapshot_webhook_intakes, HmacAlgorithm, SignatureEncoding,
+    WebhookIntakeConfig, WebhookIntakeError, WebhookIntakeId, WebhookIntakeOutcome,
+    WebhookIntakeRequest, WebhookIntakeSnapshot, WebhookIntakeStatus,
 };
 pub use worker_queue::{
     claims_topic_name as worker_claims_topic_name, job_topic_name as worker_job_topic_name,

--- a/crates/harn-vm/src/triggers/webhook_intake.rs
+++ b/crates/harn-vm/src/triggers/webhook_intake.rs
@@ -1,0 +1,910 @@
+//! Forge-agnostic webhook intake substrate.
+//!
+//! This is the lowest-level layer connectors can wire into to absorb webhook
+//! deliveries. It is deliberately ignorant of any specific provider (GitHub,
+//! GitLab, Linear, Slack, Stripe, ...). A connector declares:
+//!
+//! * a path scope (e.g. `/hooks/github`)
+//! * a signature header + algorithm + format the substrate should verify
+//! * a delivery-id header the substrate should dedupe on
+//! * a topic to republish accepted deliveries onto
+//!
+//! and the substrate handles the rest: HMAC verification, delivery-id
+//! deduplication (durable across process restarts via the trigger inbox), and
+//! republishing to the chosen event-log topic. Per-forge event normalization
+//! lives in the connector that consumes the topic.
+//!
+//! The substrate is process-global, mirroring the rest of the trigger runtime.
+//! It is exposed to Harn scripts through the `webhook_intake_*` builtins.
+//
+// Design notes:
+// - A connector should be able to wire intake in <30 lines of Harn (issue
+//   #1011). The Harn-facing surface is therefore a single `register` call that
+//   takes a config dict, plus `feed` for hand-driving the substrate from a
+//   handler or a test fixture.
+// - Dedupe survives process restart because we delegate to the existing
+//   `InboxIndex`, which rehydrates from the durable claim topic on construction.
+// - Multiple connectors on different paths must not collide — each intake gets
+//   its own intake id, and the inbox dedupe is namespaced by intake id.
+
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use std::time::Duration as StdDuration;
+
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use subtle::ConstantTimeEq;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::connectors::MetricsRegistry;
+use crate::event_log::{
+    active_event_log, install_memory_for_current_thread, EventLog, LogEvent, Topic,
+};
+use crate::triggers::inbox::InboxIndex;
+
+/// Default delivery-id retention used when callers omit the field. Matches the
+/// 24-hour window most providers retry within.
+pub const DEFAULT_DEDUPE_TTL_SECS: u64 = 24 * 60 * 60;
+/// Topic the substrate appends `webhook_intake_rejected` audit events on.
+pub const REJECTION_TOPIC: &str = "triggers.webhook_intake.rejections";
+const INTAKE_EVENT_LOG_QUEUE_DEPTH: usize = 128;
+
+/// Identifier of a registered intake. Stable for the lifetime of the process,
+/// or until `webhook_intake_deregister` is called.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct WebhookIntakeId(pub String);
+
+impl WebhookIntakeId {
+    pub fn new() -> Self {
+        Self(format!("intake_{}", Uuid::now_v7()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for WebhookIntakeId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Hash algorithm used to recompute the HMAC over the request body.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HmacAlgorithm {
+    #[default]
+    Sha256,
+    Sha1,
+}
+
+impl HmacAlgorithm {
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "" | "sha256" | "hmac-sha256" => Some(Self::Sha256),
+            "sha1" | "hmac-sha1" => Some(Self::Sha1),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Sha256 => "sha256",
+            Self::Sha1 => "sha1",
+        }
+    }
+}
+
+/// Encoding the wire signature is presented in.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignatureEncoding {
+    #[default]
+    Hex,
+    Base64,
+}
+
+impl SignatureEncoding {
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "" | "hex" | "base16" => Some(Self::Hex),
+            "base64" | "b64" => Some(Self::Base64),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Hex => "hex",
+            Self::Base64 => "base64",
+        }
+    }
+}
+
+/// Configuration for a single registered intake.
+#[derive(Clone, Debug)]
+pub struct WebhookIntakeConfig {
+    pub id: Option<String>,
+    pub path: Option<String>,
+    pub signature_header: String,
+    pub signature_prefix: Option<String>,
+    pub signature_encoding: SignatureEncoding,
+    pub algorithm: HmacAlgorithm,
+    pub secret: Vec<u8>,
+    pub delivery_id_header: String,
+    pub topic: String,
+    pub dedupe_ttl: StdDuration,
+}
+
+impl WebhookIntakeConfig {
+    /// Common forges (GitHub, GitLab, Bitbucket) prefix the digest with the
+    /// algorithm name. Helper for callers that want the same default the
+    /// stdlib parser applies when `signature_prefix` is omitted.
+    pub fn default_prefix(algorithm: HmacAlgorithm) -> Option<String> {
+        Some(format!("{}=", algorithm.as_str()))
+    }
+}
+
+/// What the substrate did with a delivery.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WebhookIntakeStatus {
+    Accepted,
+    Duplicate,
+    Rejected,
+}
+
+impl WebhookIntakeStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Accepted => "accepted",
+            Self::Duplicate => "duplicate",
+            Self::Rejected => "rejected",
+        }
+    }
+}
+
+/// Result of feeding a delivery through the substrate.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WebhookIntakeOutcome {
+    pub status: String,
+    pub intake_id: String,
+    pub topic: String,
+    pub delivery_id: Option<String>,
+    pub topic_event_id: Option<u64>,
+    pub reason: Option<String>,
+    pub received_at: String,
+}
+
+/// Snapshot of an intake registration. Returned by `register` and `list`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WebhookIntakeSnapshot {
+    pub id: String,
+    pub path: Option<String>,
+    pub topic: String,
+    pub signature_header: String,
+    pub signature_prefix: Option<String>,
+    pub signature_encoding: String,
+    pub algorithm: String,
+    pub delivery_id_header: String,
+    pub dedupe_ttl_seconds: u64,
+}
+
+/// Raw inbound delivery as fed to the substrate.
+#[derive(Clone, Debug, Default)]
+pub struct WebhookIntakeRequest {
+    pub headers: BTreeMap<String, String>,
+    pub body: Vec<u8>,
+    pub path: Option<String>,
+    pub received_at: Option<OffsetDateTime>,
+}
+
+#[derive(Debug)]
+pub enum WebhookIntakeError {
+    Config(String),
+    UnknownIntake(String),
+    Internal(String),
+}
+
+impl std::fmt::Display for WebhookIntakeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Config(detail) => write!(f, "intake config: {detail}"),
+            Self::UnknownIntake(id) => write!(f, "intake `{id}` is not registered"),
+            Self::Internal(detail) => write!(f, "intake substrate: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for WebhookIntakeError {}
+
+#[derive(Clone)]
+struct RegisteredIntake {
+    snapshot: WebhookIntakeSnapshot,
+    config: WebhookIntakeConfig,
+}
+
+#[derive(Default)]
+struct WebhookIntakeRegistry {
+    by_id: HashMap<String, RegisteredIntake>,
+    by_path: HashMap<String, String>,
+}
+
+thread_local! {
+    static REGISTRY: RefCell<WebhookIntakeRegistry> =
+        RefCell::new(WebhookIntakeRegistry::default());
+}
+
+fn with_registry<R>(f: impl FnOnce(&WebhookIntakeRegistry) -> R) -> R {
+    REGISTRY.with(|slot| f(&slot.borrow()))
+}
+
+fn with_registry_mut<R>(f: impl FnOnce(&mut WebhookIntakeRegistry) -> R) -> R {
+    REGISTRY.with(|slot| f(&mut slot.borrow_mut()))
+}
+
+/// Reset all in-process intake state. Called between conformance tests.
+pub fn clear_webhook_intake_state() {
+    with_registry_mut(|state| {
+        state.by_id.clear();
+        state.by_path.clear();
+    });
+    reset_cached_inbox();
+}
+
+/// Snapshot of all currently-registered intakes.
+pub fn snapshot_webhook_intakes() -> Vec<WebhookIntakeSnapshot> {
+    with_registry(|state| {
+        let mut out: Vec<_> = state
+            .by_id
+            .values()
+            .map(|entry| entry.snapshot.clone())
+            .collect();
+        out.sort_by(|left, right| left.id.cmp(&right.id));
+        out
+    })
+}
+
+/// Resolve the intake registered against `path`, if any.
+pub fn intake_for_path(path: &str) -> Option<String> {
+    with_registry(|state| state.by_path.get(path).cloned())
+}
+
+/// Register a new intake. Returns its assigned id.
+pub fn register_webhook_intake(
+    config: WebhookIntakeConfig,
+) -> Result<WebhookIntakeSnapshot, WebhookIntakeError> {
+    if config.signature_header.trim().is_empty() {
+        return Err(WebhookIntakeError::Config(
+            "signature_header cannot be empty".to_string(),
+        ));
+    }
+    if config.delivery_id_header.trim().is_empty() {
+        return Err(WebhookIntakeError::Config(
+            "delivery_id_header cannot be empty".to_string(),
+        ));
+    }
+    if config.topic.trim().is_empty() {
+        return Err(WebhookIntakeError::Config(
+            "topic cannot be empty".to_string(),
+        ));
+    }
+    if config.secret.is_empty() {
+        return Err(WebhookIntakeError::Config(
+            "secret cannot be empty".to_string(),
+        ));
+    }
+    Topic::new(config.topic.clone())
+        .map_err(|error| WebhookIntakeError::Config(format!("invalid topic: {error}")))?;
+
+    let id = config
+        .id
+        .clone()
+        .filter(|raw| !raw.trim().is_empty())
+        .unwrap_or_else(|| WebhookIntakeId::new().0);
+
+    with_registry_mut(|state| {
+        if state.by_id.contains_key(&id) {
+            return Err(WebhookIntakeError::Config(format!(
+                "intake `{id}` is already registered"
+            )));
+        }
+        if let Some(path) = config.path.as_ref() {
+            if state.by_path.contains_key(path) {
+                return Err(WebhookIntakeError::Config(format!(
+                    "path `{path}` is already bound to intake `{}`",
+                    state.by_path[path]
+                )));
+            }
+        }
+
+        let snapshot = WebhookIntakeSnapshot {
+            id: id.clone(),
+            path: config.path.clone(),
+            topic: config.topic.clone(),
+            signature_header: normalize_header(&config.signature_header),
+            signature_prefix: config.signature_prefix.clone(),
+            signature_encoding: config.signature_encoding.as_str().to_string(),
+            algorithm: config.algorithm.as_str().to_string(),
+            delivery_id_header: normalize_header(&config.delivery_id_header),
+            dedupe_ttl_seconds: config.dedupe_ttl.as_secs(),
+        };
+
+        let mut stored = config;
+        stored.id = Some(id.clone());
+        stored.signature_header = normalize_header(&stored.signature_header);
+        stored.delivery_id_header = normalize_header(&stored.delivery_id_header);
+
+        if let Some(path) = stored.path.as_ref() {
+            state.by_path.insert(path.clone(), id.clone());
+        }
+        state.by_id.insert(
+            id,
+            RegisteredIntake {
+                snapshot: snapshot.clone(),
+                config: stored,
+            },
+        );
+        Ok(snapshot)
+    })
+}
+
+/// Remove an intake. Returns `true` if it existed.
+pub fn deregister_webhook_intake(intake_id: &str) -> bool {
+    with_registry_mut(|state| {
+        let Some(entry) = state.by_id.remove(intake_id) else {
+            return false;
+        };
+        if let Some(path) = entry.snapshot.path {
+            state.by_path.remove(&path);
+        }
+        true
+    })
+}
+
+/// Feed a delivery through the substrate.
+///
+/// On `Accepted`, the substrate has appended a `webhook_delivery` event to the
+/// configured topic and claimed the delivery id in the inbox. Subsequent calls
+/// with the same delivery id within the dedupe TTL return `Duplicate`. Any
+/// signature failure (missing/invalid header, bad HMAC) returns `Rejected`.
+pub async fn feed_webhook_intake(
+    intake_id: &str,
+    request: WebhookIntakeRequest,
+) -> Result<WebhookIntakeOutcome, WebhookIntakeError> {
+    let entry = with_registry(|state| state.by_id.get(intake_id).cloned())
+        .ok_or_else(|| WebhookIntakeError::UnknownIntake(intake_id.to_string()))?;
+    let received_at = request.received_at.unwrap_or_else(OffsetDateTime::now_utc);
+    let received_at_str = format_rfc3339(received_at);
+    let log = ensure_event_log();
+    let topic = Topic::new(entry.snapshot.topic.clone())
+        .map_err(|error| WebhookIntakeError::Internal(format!("invalid topic: {error}")))?;
+
+    if let Some(expected_path) = entry.config.path.as_deref() {
+        if let Some(actual_path) = request.path.as_deref() {
+            if actual_path != expected_path {
+                let reason =
+                    format!("path mismatch: expected `{expected_path}`, got `{actual_path}`");
+                emit_rejection(&log, &entry.snapshot, &reason, &received_at_str).await;
+                return Ok(WebhookIntakeOutcome {
+                    status: WebhookIntakeStatus::Rejected.as_str().to_string(),
+                    intake_id: entry.snapshot.id.clone(),
+                    topic: entry.snapshot.topic.clone(),
+                    delivery_id: None,
+                    topic_event_id: None,
+                    reason: Some(reason),
+                    received_at: received_at_str,
+                });
+            }
+        }
+    }
+
+    let signature = match find_header(&request.headers, &entry.config.signature_header) {
+        Some(value) => value,
+        None => {
+            let reason = format!(
+                "missing signature header `{}`",
+                entry.config.signature_header
+            );
+            emit_rejection(&log, &entry.snapshot, &reason, &received_at_str).await;
+            return Ok(WebhookIntakeOutcome {
+                status: WebhookIntakeStatus::Rejected.as_str().to_string(),
+                intake_id: entry.snapshot.id.clone(),
+                topic: entry.snapshot.topic.clone(),
+                delivery_id: None,
+                topic_event_id: None,
+                reason: Some(reason),
+                received_at: received_at_str,
+            });
+        }
+    };
+
+    if let Err(reason) = verify_signature(&entry.config, signature.as_str(), &request.body) {
+        emit_rejection(&log, &entry.snapshot, &reason, &received_at_str).await;
+        return Ok(WebhookIntakeOutcome {
+            status: WebhookIntakeStatus::Rejected.as_str().to_string(),
+            intake_id: entry.snapshot.id.clone(),
+            topic: entry.snapshot.topic.clone(),
+            delivery_id: None,
+            topic_event_id: None,
+            reason: Some(reason),
+            received_at: received_at_str,
+        });
+    }
+
+    let delivery_id = match find_header(&request.headers, &entry.config.delivery_id_header) {
+        Some(value) if !value.trim().is_empty() => value,
+        _ => {
+            let reason = format!(
+                "missing delivery id header `{}`",
+                entry.config.delivery_id_header
+            );
+            emit_rejection(&log, &entry.snapshot, &reason, &received_at_str).await;
+            return Ok(WebhookIntakeOutcome {
+                status: WebhookIntakeStatus::Rejected.as_str().to_string(),
+                intake_id: entry.snapshot.id.clone(),
+                topic: entry.snapshot.topic.clone(),
+                delivery_id: None,
+                topic_event_id: None,
+                reason: Some(reason),
+                received_at: received_at_str,
+            });
+        }
+    };
+
+    let inbox = ensure_inbox().await?;
+    let claim_key = format!("intake:{}", entry.snapshot.id);
+    let claimed = inbox
+        .insert_if_new(&claim_key, &delivery_id, entry.config.dedupe_ttl)
+        .await
+        .map_err(|error| WebhookIntakeError::Internal(format!("inbox claim: {error}")))?;
+    if !claimed {
+        return Ok(WebhookIntakeOutcome {
+            status: WebhookIntakeStatus::Duplicate.as_str().to_string(),
+            intake_id: entry.snapshot.id.clone(),
+            topic: entry.snapshot.topic.clone(),
+            delivery_id: Some(delivery_id),
+            topic_event_id: None,
+            reason: None,
+            received_at: received_at_str,
+        });
+    }
+
+    let payload = serde_json::json!({
+        "intake_id": entry.snapshot.id,
+        "delivery_id": delivery_id,
+        "received_at": received_at_str,
+        "headers": request.headers,
+        "body_b64": BASE64_STANDARD.encode(&request.body),
+        "body_text": std::str::from_utf8(&request.body).ok().map(str::to_string),
+        "path": entry.config.path,
+        "signature_header": entry.config.signature_header,
+        "delivery_id_header": entry.config.delivery_id_header,
+        "algorithm": entry.config.algorithm.as_str(),
+    });
+    let mut headers_meta = BTreeMap::new();
+    headers_meta.insert("intake_id".to_string(), entry.snapshot.id.clone());
+    headers_meta.insert("delivery_id".to_string(), delivery_id.clone());
+    let event_id = log
+        .append(
+            &topic,
+            LogEvent::new("webhook_delivery", payload).with_headers(headers_meta),
+        )
+        .await
+        .map_err(|error| WebhookIntakeError::Internal(format!("topic append: {error}")))?;
+
+    Ok(WebhookIntakeOutcome {
+        status: WebhookIntakeStatus::Accepted.as_str().to_string(),
+        intake_id: entry.snapshot.id.clone(),
+        topic: entry.snapshot.topic.clone(),
+        delivery_id: Some(delivery_id),
+        topic_event_id: Some(event_id),
+        reason: None,
+        received_at: received_at_str,
+    })
+}
+
+/// Read the most recent `limit` accepted deliveries on an intake's topic.
+/// Provides the bounded replay buffer surface called out in #1011.
+pub async fn recent_webhook_deliveries(
+    intake_id: &str,
+    limit: usize,
+) -> Result<Vec<serde_json::Value>, WebhookIntakeError> {
+    let topic_name = with_registry(|state| {
+        state
+            .by_id
+            .get(intake_id)
+            .map(|entry| entry.snapshot.topic.clone())
+    })
+    .ok_or_else(|| WebhookIntakeError::UnknownIntake(intake_id.to_string()))?;
+    let log = ensure_event_log();
+    let topic = Topic::new(topic_name)
+        .map_err(|error| WebhookIntakeError::Internal(format!("invalid topic: {error}")))?;
+    let events = log
+        .read_range(&topic, None, usize::MAX)
+        .await
+        .map_err(|error| WebhookIntakeError::Internal(format!("topic read: {error}")))?;
+    let mut payloads: Vec<serde_json::Value> = events
+        .into_iter()
+        .filter(|(_, event)| {
+            event.kind == "webhook_delivery"
+                && event
+                    .headers
+                    .get("intake_id")
+                    .map(|value| value == intake_id)
+                    .unwrap_or(true)
+        })
+        .map(|(_, event)| event.payload)
+        .collect();
+    if payloads.len() > limit {
+        let drop = payloads.len() - limit;
+        payloads.drain(0..drop);
+    }
+    Ok(payloads)
+}
+
+fn verify_signature(
+    config: &WebhookIntakeConfig,
+    raw_signature: &str,
+    body: &[u8],
+) -> Result<(), String> {
+    let stripped = strip_prefix(raw_signature, config.signature_prefix.as_deref())?;
+    let provided = decode_signature(stripped, config.signature_encoding)?;
+    let expected = compute_hmac(config.algorithm, &config.secret, body);
+    if provided.len() != expected.len() {
+        return Err(format!(
+            "signature length mismatch (expected {} bytes, got {})",
+            expected.len(),
+            provided.len()
+        ));
+    }
+    if expected.ct_eq(&provided).into() {
+        Ok(())
+    } else {
+        Err("signature mismatch".to_string())
+    }
+}
+
+fn strip_prefix<'a>(raw: &'a str, prefix: Option<&str>) -> Result<&'a str, String> {
+    let trimmed = raw.trim();
+    match prefix {
+        Some(expected) if !expected.is_empty() => trimmed
+            .strip_prefix(expected)
+            .ok_or_else(|| format!("signature missing expected prefix `{expected}`")),
+        _ => Ok(trimmed),
+    }
+}
+
+fn decode_signature(raw: &str, encoding: SignatureEncoding) -> Result<Vec<u8>, String> {
+    match encoding {
+        SignatureEncoding::Hex => hex::decode(raw).map_err(|error| format!("invalid hex: {error}")),
+        SignatureEncoding::Base64 => BASE64_STANDARD
+            .decode(raw)
+            .map_err(|error| format!("invalid base64: {error}")),
+    }
+}
+
+fn compute_hmac(algorithm: HmacAlgorithm, secret: &[u8], data: &[u8]) -> Vec<u8> {
+    match algorithm {
+        HmacAlgorithm::Sha256 => crate::connectors::hmac::hmac_sha256(secret, data),
+        HmacAlgorithm::Sha1 => crate::connectors::hmac::hmac_sha1(secret, data),
+    }
+}
+
+fn find_header(headers: &BTreeMap<String, String>, name: &str) -> Option<String> {
+    let lower = name.to_ascii_lowercase();
+    headers
+        .iter()
+        .find(|(key, _)| key.to_ascii_lowercase() == lower)
+        .map(|(_, value)| value.clone())
+}
+
+fn normalize_header(name: &str) -> String {
+    name.trim().to_ascii_lowercase()
+}
+
+fn format_rfc3339(value: OffsetDateTime) -> String {
+    value.format(&Rfc3339).unwrap_or_default()
+}
+
+fn ensure_event_log() -> Arc<crate::event_log::AnyEventLog> {
+    active_event_log()
+        .unwrap_or_else(|| install_memory_for_current_thread(INTAKE_EVENT_LOG_QUEUE_DEPTH))
+}
+
+thread_local! {
+    static CACHED_INBOX: RefCell<Option<(Arc<crate::event_log::AnyEventLog>, Arc<InboxIndex>)>> =
+        const { RefCell::new(None) };
+}
+
+async fn ensure_inbox() -> Result<Arc<InboxIndex>, WebhookIntakeError> {
+    let log = ensure_event_log();
+    if let Some(existing) = CACHED_INBOX.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .filter(|(cached_log, _)| Arc::ptr_eq(cached_log, &log))
+            .map(|(_, inbox)| inbox.clone())
+    }) {
+        return Ok(existing);
+    }
+    let metrics = Arc::new(MetricsRegistry::default());
+    let inbox = Arc::new(
+        InboxIndex::new(log.clone(), metrics)
+            .await
+            .map_err(|error| WebhookIntakeError::Internal(format!("inbox init: {error}")))?,
+    );
+    CACHED_INBOX.with(|slot| {
+        *slot.borrow_mut() = Some((log, inbox.clone()));
+    });
+    Ok(inbox)
+}
+
+fn reset_cached_inbox() {
+    CACHED_INBOX.with(|slot| *slot.borrow_mut() = None);
+}
+
+async fn emit_rejection(
+    log: &Arc<crate::event_log::AnyEventLog>,
+    snapshot: &WebhookIntakeSnapshot,
+    reason: &str,
+    received_at: &str,
+) {
+    let topic = match Topic::new(REJECTION_TOPIC) {
+        Ok(topic) => topic,
+        Err(_) => return,
+    };
+    let mut headers = BTreeMap::new();
+    headers.insert("intake_id".to_string(), snapshot.id.clone());
+    let payload = serde_json::json!({
+        "intake_id": snapshot.id,
+        "topic": snapshot.topic,
+        "path": snapshot.path,
+        "reason": reason,
+        "received_at": received_at,
+    });
+    let _ = log
+        .append(
+            &topic,
+            LogEvent::new("webhook_intake_rejected", payload).with_headers(headers),
+        )
+        .await;
+}
+
+/// Helper: build a `WebhookIntakeRequest` from a `headers` dict, body, and
+/// optional fields. Used by the stdlib bindings to keep the parsing logic out
+/// of the substrate proper.
+pub fn build_request(
+    headers: BTreeMap<String, String>,
+    body: Vec<u8>,
+    path: Option<String>,
+    received_at: Option<OffsetDateTime>,
+) -> WebhookIntakeRequest {
+    WebhookIntakeRequest {
+        headers,
+        body,
+        path,
+        received_at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event_log::{install_default_for_base_dir, AnyEventLog, FileEventLog};
+
+    fn make_config(secret: &[u8]) -> WebhookIntakeConfig {
+        WebhookIntakeConfig {
+            id: None,
+            path: None,
+            signature_header: "x-test-signature".to_string(),
+            signature_prefix: Some("sha256=".to_string()),
+            signature_encoding: SignatureEncoding::Hex,
+            algorithm: HmacAlgorithm::Sha256,
+            secret: secret.to_vec(),
+            delivery_id_header: "x-test-delivery".to_string(),
+            topic: "tests.webhook_intake".to_string(),
+            dedupe_ttl: StdDuration::from_secs(60),
+        }
+    }
+
+    fn signed_headers(
+        config: &WebhookIntakeConfig,
+        body: &[u8],
+        delivery_id: &str,
+    ) -> BTreeMap<String, String> {
+        let digest = compute_hmac(config.algorithm, &config.secret, body);
+        let signature = match config.signature_encoding {
+            SignatureEncoding::Hex => hex::encode(&digest),
+            SignatureEncoding::Base64 => BASE64_STANDARD.encode(&digest),
+        };
+        let prefix = config.signature_prefix.clone().unwrap_or_default();
+        let mut headers = BTreeMap::new();
+        headers.insert(
+            config.signature_header.clone(),
+            format!("{prefix}{signature}"),
+        );
+        headers.insert(config.delivery_id_header.clone(), delivery_id.to_string());
+        headers
+    }
+
+    async fn reset() {
+        clear_webhook_intake_state();
+        crate::event_log::reset_active_event_log();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn round_trip_accepts_then_dedupes() {
+        reset().await;
+        let body = br#"{"hello":"world"}"#.to_vec();
+        let config = make_config(b"super-secret");
+        let snapshot = register_webhook_intake(config.clone()).expect("register");
+
+        let headers = signed_headers(&config, &body, "delivery-1");
+        let outcome = feed_webhook_intake(
+            snapshot.id.as_str(),
+            build_request(headers.clone(), body.clone(), None, None),
+        )
+        .await
+        .expect("feed");
+        assert_eq!(outcome.status, "accepted");
+        assert_eq!(outcome.delivery_id.as_deref(), Some("delivery-1"));
+        assert!(outcome.topic_event_id.is_some());
+
+        let dup = feed_webhook_intake(
+            snapshot.id.as_str(),
+            build_request(headers, body, None, None),
+        )
+        .await
+        .expect("feed dup");
+        assert_eq!(dup.status, "duplicate");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rejects_bad_signature() {
+        reset().await;
+        let body = b"payload".to_vec();
+        let config = make_config(b"correct-secret");
+        let snapshot = register_webhook_intake(config.clone()).expect("register");
+
+        let mut headers = signed_headers(&config, &body, "delivery-1");
+        headers.insert(
+            config.signature_header.clone(),
+            "sha256=deadbeef".to_string(),
+        );
+        let outcome = feed_webhook_intake(
+            snapshot.id.as_str(),
+            build_request(headers, body, None, None),
+        )
+        .await
+        .expect("feed");
+        assert_eq!(outcome.status, "rejected");
+        assert!(outcome
+            .reason
+            .as_deref()
+            .unwrap_or("")
+            .contains("signature"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn isolates_two_intakes_on_different_paths() {
+        reset().await;
+        let body = b"shared-body".to_vec();
+        let mut config_a = make_config(b"secret-a");
+        config_a.path = Some("/hooks/a".to_string());
+        config_a.topic = "tests.intake_a".to_string();
+        config_a.delivery_id_header = "x-a-delivery".to_string();
+
+        let mut config_b = make_config(b"secret-b");
+        config_b.path = Some("/hooks/b".to_string());
+        config_b.topic = "tests.intake_b".to_string();
+        config_b.delivery_id_header = "x-b-delivery".to_string();
+
+        let snap_a = register_webhook_intake(config_a.clone()).expect("register a");
+        let snap_b = register_webhook_intake(config_b.clone()).expect("register b");
+
+        // Same delivery id on both intakes must NOT collide.
+        let headers_a = signed_headers(&config_a, &body, "shared-delivery");
+        let outcome_a = feed_webhook_intake(
+            snap_a.id.as_str(),
+            build_request(headers_a, body.clone(), Some("/hooks/a".to_string()), None),
+        )
+        .await
+        .expect("feed a");
+        assert_eq!(outcome_a.status, "accepted");
+
+        let headers_b = signed_headers(&config_b, &body, "shared-delivery");
+        let outcome_b = feed_webhook_intake(
+            snap_b.id.as_str(),
+            build_request(headers_b, body, Some("/hooks/b".to_string()), None),
+        )
+        .await
+        .expect("feed b");
+        assert_eq!(outcome_b.status, "accepted");
+
+        // And path mismatch is rejected.
+        let body = b"more".to_vec();
+        let headers = signed_headers(&config_a, &body, "another-delivery");
+        let outcome = feed_webhook_intake(
+            snap_a.id.as_str(),
+            build_request(headers, body, Some("/hooks/wrong".to_string()), None),
+        )
+        .await
+        .expect("feed mismatch");
+        assert_eq!(outcome.status, "rejected");
+        assert!(outcome.reason.unwrap().contains("path mismatch"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn supports_sha1_legacy() {
+        reset().await;
+        let body = b"legacy".to_vec();
+        let mut config = make_config(b"legacy-secret");
+        config.algorithm = HmacAlgorithm::Sha1;
+        config.signature_prefix = Some("sha1=".to_string());
+        let snapshot = register_webhook_intake(config.clone()).expect("register");
+
+        let headers = signed_headers(&config, &body, "legacy-delivery");
+        let outcome = feed_webhook_intake(
+            snapshot.id.as_str(),
+            build_request(headers, body, None, None),
+        )
+        .await
+        .expect("feed");
+        assert_eq!(outcome.status, "accepted");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dedupe_survives_process_restart() {
+        clear_webhook_intake_state();
+        crate::event_log::reset_active_event_log();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Install a file-backed event log so the inbox can rehydrate from disk.
+        let log = Arc::new(AnyEventLog::File(
+            FileEventLog::open(tmp.path().to_path_buf(), 32).expect("file log"),
+        ));
+        crate::event_log::install_active_event_log(log.clone());
+
+        let body = br#"{"hello":"durable"}"#.to_vec();
+        let mut config = make_config(b"durable-secret");
+        // Pin the id so the post-restart re-register uses the same dedupe
+        // namespace; without this each register call would mint a fresh id.
+        config.id = Some("durable-intake".to_string());
+        let snapshot = register_webhook_intake(config.clone()).expect("register");
+        let headers = signed_headers(&config, &body, "durable-1");
+
+        let first = feed_webhook_intake(
+            snapshot.id.as_str(),
+            build_request(headers.clone(), body.clone(), None, None),
+        )
+        .await
+        .expect("first feed");
+        assert_eq!(first.status, "accepted");
+
+        // Simulate a process restart by clearing in-memory intake state and the
+        // active event log handle, then reinstalling a fresh file-backed log on
+        // the same directory.
+        clear_webhook_intake_state();
+        crate::event_log::reset_active_event_log();
+        let log = Arc::new(AnyEventLog::File(
+            FileEventLog::open(tmp.path().to_path_buf(), 32).expect("file log"),
+        ));
+        crate::event_log::install_active_event_log(log);
+        let snapshot = register_webhook_intake(config.clone()).expect("re-register");
+
+        let second = feed_webhook_intake(
+            snapshot.id.as_str(),
+            build_request(headers, body, None, None),
+        )
+        .await
+        .expect("second feed");
+        assert_eq!(second.status, "duplicate");
+
+        // Use install_default_for_base_dir to keep parity with stdlib path
+        // (no assertion — just ensures the helper still works).
+        let _log = install_default_for_base_dir(tmp.path()).expect("install default");
+    }
+}

--- a/docs/llm/harn-triggers-quickref.md
+++ b/docs/llm/harn-triggers-quickref.md
@@ -125,3 +125,68 @@ Run `harn connector test .` locally. Use `--provider <id>` for a multi-provider 
 ## Example Library
 
 Ready-to-customize pipelines live under `examples/triggers/`. Each example includes `harn.toml`, `lib.harn`, `README.md`, and `SKILL.md` so it can be copied into a project or installed as a local skill bundle. Validate examples with `make check-trigger-examples`.
+
+## Generic Webhook Intake Substrate
+
+Below the per-provider connectors lives a forge-agnostic intake substrate
+that any connector can wire into. It is the lowest-level entry point: a
+connector declares a path scope, a signature header + algorithm, a
+delivery-id header, and a topic; the substrate handles HMAC verification,
+delivery-id deduplication (durable across process restarts), and
+republishing onto the chosen topic. Per-forge event normalization lives in
+the connector that consumes the topic.
+
+Builtins:
+
+- `webhook_intake_register(config) -> dict` — register an intake. Returns
+  `{ id, path, topic, signature_header, signature_prefix,
+  signature_encoding, algorithm, delivery_id_header,
+  dedupe_ttl_seconds }`. Config keys:
+  - `id` (optional) — pin the intake id; one is generated if omitted.
+  - `path` (optional) — HTTP path scope. When set, `webhook_intake_feed`
+    rejects deliveries on a different path.
+  - `secret` (string or bytes, required) — HMAC key.
+  - `signature_header` (required) — e.g. `"x-hub-signature-256"`.
+  - `signature_prefix` — defaults to `"<algorithm>="`. Pass `""` to opt out.
+  - `signature_encoding` — `"hex"` (default) or `"base64"`.
+  - `algorithm` — `"sha256"` (default) or `"sha1"` (legacy).
+  - `delivery_id_header` (required) — e.g. `"x-github-delivery"`.
+  - `topic` (required) — event-log topic accepted deliveries are appended to.
+  - `dedupe_ttl_seconds` — defaults to 24h.
+- `webhook_intake_feed(intake_id, request) -> dict` — feed a delivery.
+  Request keys: `headers` (dict), `body` (string or bytes), optional `path`
+  and `received_at` (RFC3339). Returns `{ status, intake_id, topic,
+  delivery_id, topic_event_id, reason, received_at }`. `status` is
+  `"accepted"`, `"duplicate"`, or `"rejected"`.
+- `webhook_intake_recent(intake_id, limit?) -> list` — bounded replay
+  buffer. Reads the last `limit` accepted deliveries from the topic.
+- `webhook_intake_list() -> list` — all currently-registered intakes.
+- `webhook_intake_deregister(intake_id) -> bool` — remove an intake.
+
+A connector wires this in well under 30 lines:
+
+```harn
+import "std/triggers"
+
+let intake = webhook_intake_register({
+  id: "github",
+  path: "/hooks/github",
+  secret: secret_get("github/webhook-secret"),
+  signature_header: "x-hub-signature-256",
+  delivery_id_header: "x-github-delivery",
+  topic: "github.events",
+})
+
+// In your inbound HTTP handler:
+let outcome = webhook_intake_feed(intake.id, {
+  headers: request.headers,
+  body: request.body,
+  path: request.path,
+})
+return { status: outcome.status == "rejected" ? 401 : 202 }
+```
+
+Rejections are appended to `triggers.webhook_intake.rejections` with the
+intake id and reason for audit. The substrate is agnostic to per-forge
+event shape — connectors normalize the opaque payload after consuming the
+topic.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -74,6 +74,7 @@
 - [Trigger event schema](./triggers/event-schema.md)
 - [Trigger dispatcher](./triggers/dispatcher.md)
 - [Trigger registry](./triggers/registry.md)
+- [Webhook intake substrate](./triggers/webhook-intake.md)
 - [Orchestrator](./orchestrator.md)
 - [Hot reload](./orchestrator/hot-reload.md)
 - [Orchestrator DLQ management](./orchestrator/dlq.md)

--- a/docs/src/triggers/webhook-intake.md
+++ b/docs/src/triggers/webhook-intake.md
@@ -1,0 +1,168 @@
+# Generic webhook intake substrate
+
+The webhook intake substrate is the lowest-level layer connectors compose
+with to absorb webhook deliveries. It is deliberately ignorant of any
+specific provider (GitHub, GitLab, Linear, Slack, Stripe, ...). A
+connector declares:
+
+- a path scope (e.g. `/hooks/github`)
+- a signature header + algorithm + format the substrate verifies
+- a delivery-id header the substrate dedupes on
+- a topic to republish accepted deliveries onto
+
+and the substrate handles the rest: HMAC verification, delivery-id
+deduplication (durable across process restarts via the trigger inbox),
+and republishing onto the chosen event-log topic. Per-forge event
+normalization lives in the connector that consumes the topic.
+
+The intake substrate sits **below** the higher-level `GenericWebhookConnector`
+(see [Generic webhook connector](../connectors/webhook.md)). The connector
+normalizes payloads into `TriggerEvent` shapes; the substrate just gets
+opaque bytes onto a topic safely. New per-forge connectors are encouraged
+to compose the substrate directly rather than copy-paste signature /
+dedupe logic.
+
+## Surface
+
+The substrate is exposed as five Harn builtins.
+
+### `webhook_intake_register(config) -> dict`
+
+Register an intake. Returns a snapshot dict
+(`{ id, path, topic, signature_header, signature_prefix,
+signature_encoding, algorithm, delivery_id_header,
+dedupe_ttl_seconds }`). Config keys:
+
+| Key | Required | Default | Description |
+|---|:---:|---|---|
+| `id` | no | generated `intake_<uuid>` | Pin the intake id; needed for dedupe to survive process restart. |
+| `path` | no | none | HTTP path scope. When set, `webhook_intake_feed` rejects deliveries on a different path. |
+| `secret` | yes | — | HMAC key. Accepts a string or a `bytes` value (e.g. from `secret_get`). |
+| `signature_header` | yes | — | Header name carrying the signature, e.g. `"x-hub-signature-256"`. |
+| `signature_prefix` | no | `"<algorithm>="` (e.g. `"sha256="`) | Prefix to strip before decoding. Pass `""` to opt out. |
+| `signature_encoding` | no | `"hex"` | `"hex"` or `"base64"`. |
+| `algorithm` | no | `"sha256"` | `"sha256"` or `"sha1"` (legacy). |
+| `delivery_id_header` | yes | — | Header name carrying the delivery id, e.g. `"x-github-delivery"`. |
+| `topic` | yes | — | Event-log topic to append accepted deliveries onto. |
+| `dedupe_ttl_seconds` | no | 86400 (24h) | How long delivery ids stay claimed in the inbox. |
+
+### `webhook_intake_feed(intake_id, request) -> dict`
+
+Feed a delivery through the substrate. `request` keys:
+
+| Key | Required | Description |
+|---|:---:|---|
+| `headers` | yes | Header dict (case-insensitive lookup). |
+| `body` | yes | String or bytes; HMAC is computed over this verbatim. |
+| `path` | no | If the intake declared a `path`, deliveries with a different path are rejected. |
+| `received_at` | no | Override the timestamp recorded on the published event. RFC3339. |
+
+Returns:
+
+```json
+{
+  "status": "accepted" | "duplicate" | "rejected",
+  "intake_id": "...",
+  "topic": "...",
+  "delivery_id": "...",
+  "topic_event_id": 123,
+  "reason": "...",
+  "received_at": "..."
+}
+```
+
+On `accepted`, the substrate appends a `webhook_delivery` event to the
+configured topic with payload:
+
+```json
+{
+  "intake_id": "...",
+  "delivery_id": "...",
+  "received_at": "...",
+  "headers": { "...": "..." },
+  "body_b64": "<base64>",
+  "body_text": "<utf-8 if valid, else null>",
+  "path": "...",
+  "signature_header": "...",
+  "delivery_id_header": "...",
+  "algorithm": "sha256"
+}
+```
+
+The published payload is **opaque** at this layer — connectors decode it
+into provider-specific shapes downstream.
+
+### `webhook_intake_recent(intake_id, limit?) -> list`
+
+Bounded replay buffer. Reads up to `limit` (default 32) accepted
+deliveries from the intake's topic. Useful for connector-side replay or
+debugging.
+
+### `webhook_intake_list() -> list`
+
+Snapshot of every currently-registered intake.
+
+### `webhook_intake_deregister(intake_id) -> bool`
+
+Remove an intake. The published deliveries on the topic remain.
+
+## A connector wires intake in <30 lines
+
+```harn,ignore
+import "std/triggers"
+
+let intake = webhook_intake_register({
+  id: "github",
+  path: "/hooks/github",
+  secret: secret_get("github/webhook-secret"),
+  signature_header: "x-hub-signature-256",
+  delivery_id_header: "x-github-delivery",
+  topic: "github.events",
+})
+
+// In your inbound HTTP handler:
+let outcome = webhook_intake_feed(intake.id, {
+  headers: request.headers,
+  body: request.body,
+  path: request.path,
+})
+
+if outcome.status == "rejected" {
+  return { status: 401, body: outcome.reason }
+}
+return { status: 202 }
+```
+
+## Audit and observability
+
+- Accepted deliveries land on the topic the connector chose.
+- Rejections are appended to `triggers.webhook_intake.rejections` with
+  the intake id, the configured topic, the path, and the reason. This is
+  the audit trail when a forge sends a bad signature, a missing delivery
+  id, or hits the wrong path.
+- Delivery-id claims are written to the existing trigger inbox topic, so
+  dedupe survives process restart for the configured TTL.
+
+## Replay fixtures
+
+`webhook_intake_feed` does not require a live HTTP listener. To drive
+the substrate from a recorded delivery in a test or replay job, build the
+request dict directly:
+
+```harn,ignore
+let outcome = webhook_intake_feed("github", {
+  headers: load_json("fixtures/github_pr_opened_headers.json"),
+  body: read_file("fixtures/github_pr_opened.body"),
+})
+```
+
+The connector contract `[[fixtures]]` blocks (see
+[connector authoring](../connectors/authoring.md)) compose the same way:
+each fixture is just a `(headers, body)` pair the harness feeds in.
+
+## Boundary
+
+This substrate intentionally does **not** know about GitHub, GitLab,
+Linear, Slack, etc. It is the shared cross-forge plumbing used by every
+connector. Per-forge event mapping lives in each connector repo (e.g.
+[harn-github-connector](https://github.com/burin-labs/harn-github-connector)).


### PR DESCRIPTION
## Summary

Closes #1011. Adds a forge-agnostic webhook intake substrate that any
connector can compose with to absorb webhook deliveries safely.

A connector wires intake in well under 30 lines by declaring a path
scope, a signature header + algorithm (`sha256` or legacy `sha1`), a
delivery-id header, and a topic. The substrate handles HMAC verification,
durable delivery-id deduplication via the existing trigger inbox, and
republishes accepted deliveries onto the connector's chosen event-log
topic. Per-forge event normalization stays in each connector repo (e.g.
[harn-github-connector#18](https://github.com/burin-labs/harn-github-connector/issues/18)
will consume the GitHub topic).

- New module: [`crates/harn-vm/src/triggers/webhook_intake.rs`](crates/harn-vm/src/triggers/webhook_intake.rs)
- New Harn builtins: `webhook_intake_register`, `webhook_intake_feed`,
  `webhook_intake_recent`, `webhook_intake_list`,
  `webhook_intake_deregister`. Plus `hmac_sha1` for legacy schemes.
- New doc page: [`docs/src/triggers/webhook-intake.md`](docs/src/triggers/webhook-intake.md),
  with the LLM trigger quickref regenerated to include the same surface.
- Three new conformance fixtures cover the acceptance criteria from the
  ticket: signed-delivery accept + bounded replay buffer
  (`webhook_intake_round_trip`), bad signature rejection + replay dedupe
  (same fixture), multi-connector isolation on different paths
  (`webhook_intake_multi_path_isolation`), and SHA-1 legacy support
  (`webhook_intake_sha1_legacy`).
- Substrate-level Rust unit test covers durable dedupe survival across a
  simulated process restart by reopening a `FileEventLog` on the same
  directory and re-registering the intake with the same id — the second
  feed of the same delivery id returns `duplicate`.

## Acceptance criteria from #1011

- [x] **<30 lines of Harn to wire intake**: register one dict + one feed
  call. See [`docs/src/triggers/webhook-intake.md`](docs/src/triggers/webhook-intake.md).
- [x] **Dedupe survives process restart**: delegated to the existing
  `InboxIndex`, which rehydrates from the durable claim topic on
  startup. Covered by the `dedupe_survives_process_restart` Rust unit
  test.
- [x] **Hosted (Harn Cloud) and local CLI/IDE share the substrate**:
  exposed as stdlib builtins on the same VM, available wherever harn
  scripts run.
- [x] **Conformance covers bad-signature reject, replay dedupe,
  multi-connector path isolation**: see the three new fixtures.

## Boundary kept clean

- Substrate has no knowledge of GitHub/GitLab/Linear/Slack/etc.
- Payloads are opaque at this layer (forwarded as base64 + utf-8 best
  effort) — connectors decode them downstream.
- Rejections audit to `triggers.webhook_intake.rejections` with the
  intake id, topic, path, and reason for triage.

## Test plan

- [x] `cargo test -p harn-vm --lib triggers::webhook_intake` (5/5 pass)
- [x] `cargo test -p harn-vm --lib triggers::` (84/84 pass)
- [x] `cargo run --bin harn -- test conformance --filter webhook_intake` (3/3 pass)
- [x] `cargo run --bin harn -- test conformance --filter triggers` (30/30 pass; existing trigger fixtures still pass)
- [x] `cargo run --bin harn -- test conformance --filter hmac` (existing hmac_sha256 conformance still passes)
- [x] `cargo clippy -p harn-vm --no-deps` (clean)
- [x] `make check-trigger-quickref` (regenerated quickref matches the dump-trigger-quickref output)
- [x] `make check-docs-snippets` (469/469 docs snippets parse)
- [x] `make fmt-harn` and Harn lint clean on all new fixtures
- [x] Pre-push hook: full workspace `make test` passes (3037/3037)

🤖 Generated with [Claude Code](https://claude.com/claude-code)