### PR TITLE
Avoid protocol retry spiral after recovered tool calls

### DIFF
--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -353,12 +353,13 @@ pub(super) async fn run_llm_call(
                     .cloned()
                     .collect::<Vec<_>>()
                     .join("; ");
+                let error_preview: String = error_summary.chars().take(200).collect();
                 crate::events::log_warn(
                     "llm.tool",
                     &format!(
                         "{} tool-call parse error(s): {} (parsed_calls={})",
                         tool_parse_errors.len(),
-                        &error_summary[..error_summary.len().min(200)],
+                        error_preview,
                         calls.len(),
                     ),
                 );
@@ -421,7 +422,27 @@ pub(super) async fn run_llm_call(
 
     // Teach the model to fix grammar violations. Done before tool-call
     // dispatch so protocol errors surface even in mixed turns.
-    if !protocol_violations.is_empty() && ctx.has_tools && ctx.tool_format != "native" {
+    let should_inject_protocol_feedback = should_inject_protocol_feedback(
+        &protocol_violations,
+        ctx.has_tools,
+        ctx.tool_format,
+        tool_calls.len(),
+    );
+    if !protocol_violations.is_empty()
+        && ctx.has_tools
+        && ctx.tool_format != "native"
+        && !tool_calls.is_empty()
+    {
+        crate::events::log_info(
+            "llm.tool",
+            &format!(
+                "suppressed protocol feedback for {} violation(s) because {} tool call(s) parsed",
+                protocol_violations.len(),
+                tool_calls.len()
+            ),
+        );
+    }
+    if should_inject_protocol_feedback {
         let feedback = format!(
             "Your response violated the tagged response protocol. Each issue:\n- {}\n\n\
              Re-emit using only these top-level tags, separated by whitespace:\n\n\
@@ -594,6 +615,18 @@ pub(super) async fn run_llm_call(
     })
 }
 
+fn should_inject_protocol_feedback(
+    protocol_violations: &[String],
+    has_tools: bool,
+    tool_format: &str,
+    parsed_tool_call_count: usize,
+) -> bool {
+    !protocol_violations.is_empty()
+        && has_tools
+        && tool_format != "native"
+        && parsed_tool_call_count == 0
+}
+
 /// Per-block translation of provider-native `tool_search_*` content into
 /// transcript + agent events. Pure: no global state, no I/O — the
 /// caller dispatches the produced events. Pulled out so harn#691 can
@@ -751,6 +784,42 @@ mod tests {
     //! result blocks (currently `tool_search_result`).
 
     use super::*;
+
+    #[test]
+    fn protocol_feedback_is_suppressed_when_tool_calls_recovered() {
+        let violations = vec!["stray text outside response tags".to_string()];
+
+        assert!(!should_inject_protocol_feedback(
+            &violations,
+            true,
+            "text",
+            1
+        ));
+        assert!(should_inject_protocol_feedback(
+            &violations,
+            true,
+            "text",
+            0
+        ));
+    }
+
+    #[test]
+    fn protocol_feedback_is_not_injected_without_text_tools() {
+        let violations = vec!["stray text outside response tags".to_string()];
+
+        assert!(!should_inject_protocol_feedback(
+            &violations,
+            false,
+            "text",
+            0
+        ));
+        assert!(!should_inject_protocol_feedback(
+            &violations,
+            true,
+            "native",
+            0
+        ));
+    }
 
     #[test]
     fn tool_search_result_block_emits_provider_native_tool_call_update() {


### PR DESCRIPTION
## Summary

- suppress tagged protocol feedback when the parser already recovered one or more text tool calls
- keep malformed/no-call responses on the existing feedback path
- avoid UTF-8 slicing in the parse-error preview log

## Why

Burin eval JSONL showed a local-model response with stray prose plus valid tagged tool calls. Harn recovered and dispatched the calls, but still injected `protocol_violation` feedback into the next model turn. That turned a recoverable mixed response into a long retry/no-call spiral. If Harn has canonicalized tool calls to execute, the harness should proceed with them instead of teaching the model to retry the same turn.

## Verification

- `cargo fmt -p harn-vm --check`
- `cargo test -p harn-vm protocol_feedback`
- pre-push release-quality suite: 3040 tests passed

## Remaining harness notes

- Burin eval setup can still spend too long on optional enrichment before runtime preflight; that is separate from this recovered-tool-call feedback issue.
- Burin-side version bump/pin update is intentionally left for the consuming repo after the next Harn release.
