### PR TITLE
Auto-size formatter section headers

### DIFF
--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -354,7 +354,8 @@ pub(crate) struct FmtArgs {
     /// Maximum line width before wrapping. Overrides `[fmt] line_width` in harn.toml.
     #[arg(long = "line-width")]
     pub line_width: Option<usize>,
-    /// Total width of `// ----` separator bars. Overrides `[fmt] separator_width`.
+    /// Total width of `// ----` separator bars. Defaults to line width minus indent.
+    /// Overrides `[fmt] separator_width`.
     #[arg(long = "separator-width")]
     pub separator_width: Option<usize>,
     /// One or more .harn files or directories.

--- a/crates/harn-cli/src/config.rs
+++ b/crates/harn-cli/src/config.rs
@@ -11,7 +11,8 @@
 //! ```toml
 //! [fmt]
 //! line_width = 100
-//! separator_width = 80
+//! # By default, section-header separators follow line_width.
+//! # Set separator_width to force a fixed width.
 //!
 //! [lint]
 //! disabled = ["unused-import"]

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -1,6 +1,6 @@
 mod test_util;
 
-use std::fs;
+use std::{fs, process::Command};
 
 use tempfile::TempDir;
 use test_util::process::harn_command;

--- a/crates/harn-fmt/src/formatter/comments.rs
+++ b/crates/harn-fmt/src/formatter/comments.rs
@@ -251,17 +251,26 @@ impl Formatter<'_> {
     }
 
     fn emit_separator_bar(&mut self) {
-        let dashes = self.separator_width.saturating_sub(3);
+        let dashes = self.section_separator_width().saturating_sub(3);
         let bar: String = "-".repeat(dashes);
         self.writeln(&format!("// {bar}"));
     }
 
     fn emit_section_header(&mut self, title: &str) {
-        let dashes = self.separator_width.saturating_sub(3);
+        let title = title.trim_end();
+        let dashes = self.section_separator_width().saturating_sub(3);
         let bar: String = "-".repeat(dashes);
         self.writeln(&format!("// {bar}"));
         self.writeln(&format!("// {title}"));
         self.writeln(&format!("// {bar}"));
+    }
+
+    fn section_separator_width(&self) -> usize {
+        if self.separator_width == crate::AUTO_SEPARATOR_WIDTH {
+            self.line_width.saturating_sub(self.indent * 2)
+        } else {
+            self.separator_width
+        }
     }
 }
 

--- a/crates/harn-fmt/src/helpers.rs
+++ b/crates/harn-fmt/src/helpers.rs
@@ -5,11 +5,11 @@ use harn_parser::{
     Variance, WhereClause,
 };
 
-use crate::Formatter;
+use crate::{Formatter, AUTO_SEPARATOR_WIDTH};
 
 /// Format a default-value expression in a destructuring pattern.
 fn format_default_expr(node: &SNode) -> String {
-    let fmt = Formatter::new("", BTreeMap::new(), 100, 80);
+    let fmt = Formatter::new("", BTreeMap::new(), 100, AUTO_SEPARATOR_WIDTH);
     fmt.format_expr(node, 0)
 }
 
@@ -368,7 +368,7 @@ pub(crate) fn format_where_clauses(clauses: &[WhereClause]) -> String {
 
 /// Format an expression inline for use in parameter defaults.
 pub(crate) fn format_inline_expr(node: &SNode) -> String {
-    let fmt = Formatter::new("", BTreeMap::new(), 100, 80);
+    let fmt = Formatter::new("", BTreeMap::new(), 100, AUTO_SEPARATOR_WIDTH);
     fmt.format_expr(node, 0)
 }
 

--- a/crates/harn-fmt/src/lib.rs
+++ b/crates/harn-fmt/src/lib.rs
@@ -10,13 +10,19 @@ use harn_parser::Parser;
 
 pub(crate) use formatter::{Comment, Formatter};
 
+/// `FmtOptions::separator_width` value that resolves section-header bars from
+/// `line_width` minus the current indent.
+pub const AUTO_SEPARATOR_WIDTH: usize = 0;
+
 /// Options controlling formatter behavior.
 #[derive(Debug, Clone)]
 pub struct FmtOptions {
     /// Maximum line width before wrapping (default: 100).
     pub line_width: usize,
     /// Total width of `// ----` separator bars rendered by the formatter
-    /// when it normalizes section-header comment blocks (default: 80).
+    /// when it normalizes section-header comment blocks. Use
+    /// `AUTO_SEPARATOR_WIDTH` to resolve from `line_width` minus the current
+    /// indent.
     pub separator_width: usize,
 }
 
@@ -24,7 +30,7 @@ impl Default for FmtOptions {
     fn default() -> Self {
         Self {
             line_width: 100,
-            separator_width: 80,
+            separator_width: AUTO_SEPARATOR_WIDTH,
         }
     }
 }

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -2,7 +2,7 @@ use harn_lexer::Lexer;
 use harn_parser::Parser;
 
 use crate::helpers::format_duration;
-use crate::{format_source, format_source_opts, FmtOptions};
+use crate::{format_source, format_source_opts, FmtOptions, AUTO_SEPARATOR_WIDTH};
 
 fn assert_roundtrip(source: &str) {
     let formatted = format_source(source).unwrap();
@@ -744,7 +744,7 @@ fn test_backslash_continuation_roundtrip() {
 fn fmt_opts(source: &str, line_width: usize) -> String {
     let opts = FmtOptions {
         line_width,
-        separator_width: 80,
+        separator_width: AUTO_SEPARATOR_WIDTH,
     };
     format_source_opts(source, &opts).unwrap()
 }
@@ -836,7 +836,7 @@ fn test_custom_line_width_idempotent() {
 }"#;
     let opts = FmtOptions {
         line_width: 40,
-        separator_width: 80,
+        separator_width: AUTO_SEPARATOR_WIDTH,
     };
     let first = format_source_opts(source, &opts).unwrap();
     let second = format_source_opts(&first, &opts).unwrap();
@@ -1260,8 +1260,11 @@ fn test_doc_comment_glued_to_item_blank_line_above() {
 }
 
 fn canonical_bar() -> String {
-    // Default separator_width is 80 → 77 dashes after `// `.
-    let dashes: String = "-".repeat(77);
+    separator_bar(100)
+}
+
+fn separator_bar(width: usize) -> String {
+    let dashes: String = "-".repeat(width.saturating_sub(3));
     format!("// {dashes}")
 }
 
@@ -1347,6 +1350,37 @@ fn test_section_header_respects_custom_separator_width() {
         result.contains(&bar),
         "separator should match separator_width=40, got:\n{result}"
     );
+}
+
+#[test]
+fn test_section_header_auto_width_snapshots_across_line_widths() {
+    let source =
+        "fn a() -> int { return 1 }\n// ----\n// Helpers  \t\n// ----   \nfn b() -> int { return 2 }\n";
+    for line_width in [60, 80, 120] {
+        let opts = FmtOptions {
+            line_width,
+            separator_width: AUTO_SEPARATOR_WIDTH,
+        };
+        let bar = separator_bar(line_width);
+        let expected = format!(
+            "fn a() -> int {{\n  return 1\n}}\n\n{bar}\n// Helpers\n{bar}\n\nfn b() -> int {{\n  return 2\n}}\n"
+        );
+        let result = format_source_opts(source, &opts).unwrap();
+        assert_eq!(
+            result, expected,
+            "line_width={line_width} section-header snapshot drifted"
+        );
+        assert_eq!(
+            result,
+            format_source_opts(&result, &opts).unwrap(),
+            "line_width={line_width} section-header formatting is not idempotent"
+        );
+        assert_eq!(
+            bar.len(),
+            line_width,
+            "bar should span the configured line width"
+        );
+    }
 }
 
 #[test]

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -234,12 +234,14 @@ harn fmt main.harn
 harn fmt src/
 harn fmt --check main.harn            # check mode (no changes, exit 1 if unformatted)
 harn fmt --line-width 80 main.harn    # custom line width
+harn fmt --separator-width 60 main.harn # fixed section-header separator width
 ```
 
 | Flag | Description |
 |---|---|
 | `--check` | Check mode: exit 1 if any file would be reformatted, make no changes |
 | `--line-width <N>` | Maximum line width before wrapping (default: 100) |
+| `--separator-width <N>` | Fixed total width for normalized `// ----` section-header separators (default: `line-width` minus indent) |
 
 The formatter enforces a **100-character line width** by default (overridable with `--line-width`). When a line exceeds
 this limit the formatter wraps it automatically:


### PR DESCRIPTION
## Summary
- Make formatter section-header separators auto-size from `line_width` minus the current indent by default while keeping explicit `separator_width` overrides.
- Normalize section-header titles with trailing whitespace stripped and add exact-output coverage for 60/80/120 line widths.
- Update fmt CLI/docs wording, fix the existing persona CLI test compile import, and refresh generated highlight keywords required by the rebased gate.

Closes #923

## Verification
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-923 cargo test -p harn-fmt`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-923 cargo test -p harn-cli --test persona_cli --no-run`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-923 cargo test -p harn-cli --bin harn commands::dump_highlight_keywords::tests::committed_keyword_file_matches_generator -- --nocapture`
- Pre-commit hook: passed
- Pre-push hook: passed (3102/3102 nextest tests, Markdown lint)
