### PR TITLE
Add build/build-release targets with macOS ad-hoc codesign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install-hooks configure-merge-drivers check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-cargo test-fast conformance protocol-conformance bench-vm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec
+.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-cargo test-fast conformance protocol-conformance bench-vm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
@@ -17,6 +17,16 @@ install-hooks:
 
 configure-merge-drivers:
 	./scripts/configure_merge_drivers.sh
+
+# Build the harn binary. On macOS, ad-hoc signs it so Gatekeeper skips
+# the "Verifying harn..." dialog on first run.
+build:
+	cargo build
+	@if [ "$$(uname -s)" = "Darwin" ]; then codesign -s - -f target/debug/harn 2>/dev/null || true; fi
+
+build-release:
+	cargo build --release
+	@if [ "$$(uname -s)" = "Darwin" ]; then codesign -s - -f target/release/harn 2>/dev/null || true; fi
 
 # Format all code
 fmt:


### PR DESCRIPTION
## Summary

- Adds `make build` and `make build-release` targets to the Makefile
- On macOS, each target runs `codesign -s - -f` on the resulting binary after `cargo build`, suppressing the \"Verifying harn...\" Gatekeeper dialog that appears on first run after each compile
- The codesign step is a no-op on non-macOS platforms (guarded by `uname -s`) and silently skips if `codesign` is unavailable

## Test plan

- [ ] Run `make build` on macOS — confirm `target/debug/harn` runs without the Gatekeeper verification dialog
- [ ] Run `make build-release` on macOS — same check for `target/release/harn`
- [ ] Run `make build` on Linux — confirm it skips codesign cleanly and just produces the binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)