### PR TITLE
Support match expressions in typed value positions

### DIFF
--- a/conformance/tests/control_flow/match_as_expression.expected
+++ b/conformance/tests/control_flow/match_as_expression.expected
@@ -1,0 +1,3 @@
+bravo
+large:7
+20

--- a/conformance/tests/control_flow/match_as_expression.harn
+++ b/conformance/tests/control_flow/match_as_expression.harn
@@ -1,0 +1,25 @@
+pipeline default() {
+  let input = "b"
+  let label = match input {
+    "a" -> { "alpha" }
+    "b" -> { "bravo" }
+    _ -> { "other" }
+  }
+  println(label)
+  let n = 7
+  let size = match n {
+    0 -> { "zero" }
+    x if x > 5 -> {
+      let prefix = "large"
+      prefix + ":" + to_string(x)
+    }
+    _ -> { "small" }
+  }
+  println(size)
+  let pair = [10, 20]
+  let second = match pair {
+    [_, value] -> { value }
+    _ -> { 0 }
+  }
+  println(second)
+}

--- a/crates/harn-fmt/src/formatter/decls.rs
+++ b/crates/harn-fmt/src/formatter/decls.rs
@@ -565,11 +565,16 @@ impl Formatter<'_> {
 
     fn format_match_arm(&mut self, arm: &harn_parser::MatchArm) {
         let pattern = self.format_expr(&arm.pattern, self.indent);
+        let guard = if let Some(ref guard) = arm.guard {
+            format!(" if {}", self.format_expr(guard, self.indent))
+        } else {
+            String::new()
+        };
         if arm.body.len() == 1 && crate::helpers::is_simple_expr(&arm.body[0]) {
             let expr = self.format_expr(&arm.body[0], self.indent);
-            self.writeln(&format!("{pattern} -> {{ {expr} }}"));
+            self.writeln(&format!("{pattern}{guard} -> {{ {expr} }}"));
         } else {
-            self.writeln(&format!("{pattern} -> {{"));
+            self.writeln(&format!("{pattern}{guard} -> {{"));
             self.indent();
             self.format_body(&arm.body, arm.pattern.span.line);
             self.dedent();

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -78,6 +78,15 @@ fn test_roundtrip_match() {
 }
 
 #[test]
+fn test_format_match_expression_in_let_binding() {
+    let source = r#"pipeline default(task) { let label = match x { "a" -> { "alpha" } "b" if keep -> { "bravo" } _ -> { "other" } } }"#;
+    let result = format_source(source).unwrap();
+    assert!(result.contains("let label = match x {\n"));
+    assert!(result.contains(r#""b" if keep -> { "bravo" }"#));
+    assert_roundtrip(source);
+}
+
+#[test]
 fn test_roundtrip_computed_dict_key() {
     assert_roundtrip(
         r#"pipeline default(task) { let k = "x"

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -108,6 +108,126 @@ impl TypeChecker {
             .unwrap_or_else(|| TypeExpr::Named("list".into()))
     }
 
+    fn infer_match_expr_type(
+        &self,
+        value: &SNode,
+        arms: &[MatchArm],
+        scope: &TypeScope,
+    ) -> InferredType {
+        let value_type = self.infer_type(value, scope);
+        let mut arm_types = Vec::new();
+        for arm in arms {
+            let mut arm_scope = scope.child();
+            self.define_match_pattern_bindings(&arm.pattern, value_type.as_ref(), &mut arm_scope);
+            if let Some(arm_type) = self.infer_block_type(&arm.body, &arm_scope) {
+                arm_types.push(arm_type);
+            }
+        }
+        match (arms.is_empty(), arm_types.len()) {
+            (true, _) => Some(TypeExpr::Never),
+            (false, 0) => None,
+            (false, 1) => arm_types.pop(),
+            (false, _) => Some(simplify_union(arm_types)),
+        }
+    }
+
+    fn define_match_pattern_bindings(
+        &self,
+        pattern: &SNode,
+        value_type: Option<&TypeExpr>,
+        scope: &mut TypeScope,
+    ) {
+        match &pattern.node {
+            Node::Identifier(name) if name != "_" => {
+                scope.define_var(name, value_type.cloned());
+            }
+            Node::ListLiteral(elements) => {
+                let item_type = value_type.and_then(|ty| match self.resolve_alias(ty, scope) {
+                    TypeExpr::List(inner) => Some(*inner),
+                    _ => None,
+                });
+                for element in elements {
+                    if let Node::Identifier(name) = &element.node {
+                        if name != "_" {
+                            scope.define_var(name, item_type.clone());
+                        }
+                    }
+                }
+            }
+            Node::DictLiteral(entries) => {
+                for entry in entries {
+                    let Some(key) = (match &entry.key.node {
+                        Node::StringLiteral(key) | Node::Identifier(key) => Some(key.as_str()),
+                        _ => None,
+                    }) else {
+                        continue;
+                    };
+                    let Node::Identifier(name) = &entry.value.node else {
+                        continue;
+                    };
+                    if name == "_" {
+                        continue;
+                    }
+                    let binding_type =
+                        value_type.and_then(|ty| match self.resolve_alias(ty, scope) {
+                            TypeExpr::Shape(fields) => fields
+                                .into_iter()
+                                .find(|field| field.name == key)
+                                .map(|field| field.type_expr),
+                            TypeExpr::DictType(_, value) => Some(*value),
+                            _ => None,
+                        });
+                    scope.define_var(name, binding_type);
+                }
+            }
+            Node::EnumConstruct {
+                enum_name,
+                variant,
+                args,
+            } => {
+                self.define_enum_pattern_bindings(enum_name, variant, args, scope);
+            }
+            Node::MethodCall {
+                object,
+                method,
+                args,
+            } => {
+                if let Node::Identifier(enum_name) = &object.node {
+                    self.define_enum_pattern_bindings(enum_name, method, args, scope);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn define_enum_pattern_bindings(
+        &self,
+        enum_name: &str,
+        variant: &str,
+        args: &[SNode],
+        scope: &mut TypeScope,
+    ) {
+        let Some(enum_info) = scope.get_enum(enum_name) else {
+            return;
+        };
+        let Some(variant_info) = enum_info.variants.iter().find(|v| v.name == variant) else {
+            return;
+        };
+        let bindings: Vec<(String, InferredType)> = args
+            .iter()
+            .zip(&variant_info.fields)
+            .filter_map(|(arg, field)| match &arg.node {
+                Node::Identifier(name) if name != "_" => {
+                    Some((name.clone(), field.type_expr.clone()))
+                }
+                _ => None,
+            })
+            .collect();
+        for (name, ty) in bindings {
+            scope.define_var(&name, ty);
+        }
+    }
+
     /// Infer the type of an expression.
     pub(in crate::typechecker) fn infer_type(
         &self,
@@ -676,6 +796,8 @@ impl TypeChecker {
                     args: vec![ok_type, err_type],
                 })
             }
+
+            Node::MatchExpr { value, arms } => self.infer_match_expr_type(value, arms, scope),
 
             Node::Parallel { mode, body, .. } => {
                 let item_type = self

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -23,6 +23,70 @@ fn test_type_mismatch_let() {
 }
 
 #[test]
+fn test_match_expression_infers_common_arm_type() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  let input = "b"
+  let value: string = match input {
+    "a" -> { "alpha" }
+    "b" -> {
+      let suffix = "ravo"
+      "b" + suffix
+    }
+    _ -> { "other" }
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "unexpected errors: {errs:?}");
+}
+
+#[test]
+fn test_match_expression_assignment_uses_arm_value_type() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  let input = "a"
+  let value: int = match input {
+    "a" -> { "alpha" }
+    _ -> { "other" }
+  }
+}"#,
+    );
+    assert_eq!(errs.len(), 1);
+    assert!(errs[0].contains("declared as int"));
+    assert!(errs[0].contains("assigned string"));
+}
+
+#[test]
+fn test_match_expression_mixed_arms_infer_union() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  let input = "a"
+  let value: string | int = match input {
+    "a" -> { "alpha" }
+    _ -> { 42 }
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "unexpected errors: {errs:?}");
+}
+
+#[test]
+fn test_match_expression_infers_list_pattern_binding_type() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  let pair = [10, 20]
+  let value: string = match pair {
+    [_, item] -> { item }
+    _ -> { 0 }
+  }
+}"#,
+    );
+    assert_eq!(errs.len(), 1);
+    assert!(errs[0].contains("declared as string"));
+    assert!(errs[0].contains("assigned int"));
+}
+
+#[test]
 fn test_correct_typed_fn() {
     let errs =
         errors("pipeline t(task) { fn add(a: int, b: int) -> int { return a + b }\nadd(1, 2) }");

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -256,6 +256,7 @@ let doc = """
 | `%` | `.percent` | Modulo |
 | `?` | `.question` | Ternary / Result propagation |
 | `\|` | `.bar` | Union types |
+| `&` | `.amp` | Intersection types |
 
 #### Keyword operators
 
@@ -1128,6 +1129,10 @@ Maximum 10,000 iterations (safety limit). Condition is re-evaluated each iterati
 
 ### match
 
+`match` is an expression. It can be used as a standalone statement or in
+expression position; the selected arm evaluates to the value of its block's
+last expression.
+
 ```harn
 match value {
   pattern1 -> { body1 }
@@ -1140,17 +1145,17 @@ using `valuesEqual`. An arm may include an `if` guard after the pattern; when
 present, the arm only matches if the pattern matches **and** the guard expression
 evaluates to a truthy value. The first matching arm executes.
 
-If no arm matches, a runtime error is thrown (`no matching arm in match expression`).
+If no arm matches, a runtime error is thrown (`No match arm matched the value`).
 This makes non-exhaustive matches a hard failure rather than a silent `nil`.
 
 ```harn
 let x = 5
-match x {
+let label = match x {
   1 -> { "one" }
   n if n > 3 -> { "big: ${n}" }
   _ -> { "other" }
 }
-// -> "big: 5"
+// label == "big: 5"
 ```
 
 ### retry
@@ -2960,6 +2965,31 @@ type ActionContainer<T> = {action: T, process_action: fn(T) -> nil}
 ActionContainer<"edit">`, and a literal-tagged shape on the right flows
 into the matching branch.
 
+### Intersection types
+
+```harn
+type BaseCtx = {request_id: string}
+type AuthCtx = {user_id: string}
+
+fn use_ctx(ctx: BaseCtx & AuthCtx) -> string {
+  return ctx.request_id + "/" + ctx.user_id
+}
+```
+
+`A & B` requires the value to satisfy *every* component. The intersection
+of two shape types behaves like a dict that has every field from each
+component, so `ctx.request_id` and `ctx.user_id` are both accessible
+above. Shape components may be inline or named aliases; the operator
+nests freely (`A & B & C`).
+
+`&` binds tighter than `|`, so `A & B | C` parses as `(A & B) | C`. Use
+parentheses to write the union-of-intersections form.
+
+At runtime, an intersection annotation lowers to a JSON-Schema `allOf`
+guard. A value that is missing a field required by *any* component is
+rejected by the parameter-annotation runtime check just like a single
+shape mismatch is.
+
 ### Parameterized types
 
 ```harn
@@ -3137,6 +3167,21 @@ wrappers pick up the same narrowing.
 - `schema_parse<T>(value: unknown, schema: Schema<T>) -> Result<T, string>`
 - `schema_check<T>(value: unknown, schema: Schema<T>) -> Result<T, string>`
 - `schema_expect<T>(value: unknown, schema: Schema<T>) -> T`
+- `schema_recover<T>(text: string, schema: Schema<T>, options?:
+  {llm_repair?: bool | dict, apply_defaults?: bool,
+  ...llm_call_overrides}) -> {ok: bool, data: T | nil, raw_text:
+  string, error: string, error_category: string | nil, attempts: int,
+  stage: string, repaired: bool}`. Best-effort recovery of malformed
+  LLM output against a target schema. Three deterministic stages
+  followed by an optional one-shot LLM repair: `parsed` (direct
+  `serde_json` parse) → `extracted` (lift JSON from prose / code
+  fences) → `regex` (scrape top-level `key: value` lines for scalar
+  fields) → `llm_repair` (single-shot `llm_call` with `schema_retries:
+  0`). `stage` reports which stage produced the result; `failed` means
+  every stage exhausted. Set `{llm_repair: false}` for a fully
+  deterministic recovery pass with no LLM calls. The LLM repair stage
+  accepts the same overrides as `llm_call_structured_result`'s
+  `repair`.
 
 `Schema<T>` denotes a runtime schema value whose static shape is `T`.
 In a parameter position, matching a `Schema<T>` against an argument
@@ -3164,10 +3209,26 @@ typechecker support.
 runtime `schema_of(T)` builtin returns an idiomatic schema dict
 whose static type is `Schema<T>`.
 
-### Human-in-the-loop stdlib
+### Human-in-the-loop primitives
 
-Human-in-the-loop is modeled as typed stdlib primitives rather than special
-syntax. The runtime owns blocking semantics, timeout behavior, event-log
+Human-in-the-loop is modeled as **first-class typed expression syntax**.
+`ask_user`, `request_approval`, `dual_control`, and `escalate_to` are
+reserved keywords with VM-enforced semantics: their names cannot be
+shadowed or rebound, the result envelopes are produced (and signed) by
+the runtime, and quorum approval requires distinct principals. Each
+primitive accepts either named arguments or the legacy positional form;
+both lower to the same runtime.
+
+```harn,ignore
+let answer = ask_user(prompt: "deploy now?", schema: schema_of(Choice))
+let record = request_approval(action: "merge_pr", quorum: 2,
+                              reviewers: ["alice", "bob", "carol"])
+let merged = dual_control(n: 2, m: 3, action: destructive_step,
+                          approvers: ["alice", "bob", "carol"])
+let handle = escalate_to(role: "oncall", reason: "deploy failed")
+```
+
+The runtime owns blocking semantics, timeout behavior, event-log
 records, and replay.
 
 - `ask_user<T>(prompt: string, options?: {schema?: Schema<T>, timeout?: duration, default?: T}) -> T`
@@ -4674,7 +4735,7 @@ Permission denied: builtin 'read_file' is not allowed in sandbox mode
 ### --allow
 
 ```bash
-harn run --allow llm,llm_stream script.harn
+harn run --allow llm,llm_stream,llm_stream_call script.harn
 ```
 
 Allows only the listed builtins plus the core builtins (see below). All
@@ -4769,7 +4830,7 @@ they are intended for test pipelines and the linter warns on non-test use:
 During `harn test`, the `HARN_LLM_PROVIDER` environment variable is
 automatically set to `"mock"` unless explicitly overridden. The mock
 provider returns deterministic placeholder responses, allowing tests
-that call `llm` or `llm_stream` to run without API keys.
+that call `llm`, `llm_stream`, or `llm_stream_call` to run without API keys.
 
 ### CLI options
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1127,6 +1127,10 @@ Maximum 10,000 iterations (safety limit). Condition is re-evaluated each iterati
 
 ### match
 
+`match` is an expression. It can be used as a standalone statement or in
+expression position; the selected arm evaluates to the value of its block's
+last expression.
+
 ```harn
 match value {
   pattern1 -> { body1 }
@@ -1139,17 +1143,17 @@ using `valuesEqual`. An arm may include an `if` guard after the pattern; when
 present, the arm only matches if the pattern matches **and** the guard expression
 evaluates to a truthy value. The first matching arm executes.
 
-If no arm matches, a runtime error is thrown (`no matching arm in match expression`).
+If no arm matches, a runtime error is thrown (`No match arm matched the value`).
 This makes non-exhaustive matches a hard failure rather than a silent `nil`.
 
 ```harn
 let x = 5
-match x {
+let label = match x {
   1 -> { "one" }
   n if n > 3 -> { "big: ${n}" }
   _ -> { "other" }
 }
-// -> "big: 5"
+// label == "big: 5"
 ```
 
 ### retry


### PR DESCRIPTION
## Summary

- infer `match` expression value types from arm block values, including common pattern bindings for list/dict/enum/bare identifier arms
- preserve guarded match arms in statement-position formatting and add formatter coverage for `let x = match ...`
- add conformance coverage for 3 `let = match` scenarios and update the language spec/generated docs
- sync generated language spec drift from latest `origin/main`

Closes #920.

## Validation

- `cargo test -p harn-parser typechecker::tests::typing::test_match_expression -- --nocapture`
- `cargo test -p harn-fmt match -- --nocapture`
- `cargo run --quiet --bin harn -- test conformance --filter match_as_expression`
- `cargo run --quiet --bin harn -- test conformance --filter match`
- `cargo check -p harn-cli --test persona_cli`
- `make check-docs-snippets`
- pre-commit hook: Rust fmt, Harn fmt/lint, workspace clippy, language spec sync, markdown lint
- pre-push hook: 3106 nextest tests passed; affected Harn format/lint; markdown lint

## Self-review notes

- Kept parser/runtime paths unchanged because latest code already parses and executes `match` as an expression.
- Adjusted inference so empty `match` is `never`, while non-empty matches with only gradual/unknown arm values stay unknown rather than falsely inferring `never`.
- Removed a transient `persona_cli` import fix after latest `origin/main` qualified that call independently.
