### PR TITLE
Improve type mismatch diagnostics

### DIFF
--- a/crates/harn-cli/src/commands/bench.rs
+++ b/crates/harn-cli/src/commands/bench.rs
@@ -38,42 +38,18 @@ pub(crate) async fn run_bench(path: &str, iterations: usize) {
     if let Some(imported) = graph.imported_type_declarations_for_file(file_path) {
         checker = checker.with_imported_type_decls(imported);
     }
-    let type_diagnostics = checker.check(&program);
+    let type_diagnostics = checker.check_with_source(&program, &source);
     let mut had_type_error = false;
     for diag in &type_diagnostics {
         match diag.severity {
             DiagnosticSeverity::Error => {
                 had_type_error = true;
-                if let Some(span) = &diag.span {
-                    let rendered = harn_parser::diagnostic::render_diagnostic(
-                        &source,
-                        path,
-                        span,
-                        "error",
-                        &diag.message,
-                        None,
-                        diag.help.as_deref(),
-                    );
-                    eprint!("{rendered}");
-                } else {
-                    eprintln!("error: {}", diag.message);
-                }
+                let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, path, diag);
+                eprint!("{rendered}");
             }
             DiagnosticSeverity::Warning => {
-                if let Some(span) = &diag.span {
-                    let rendered = harn_parser::diagnostic::render_diagnostic(
-                        &source,
-                        path,
-                        span,
-                        "warning",
-                        &diag.message,
-                        None,
-                        diag.help.as_deref(),
-                    );
-                    eprint!("{rendered}");
-                } else {
-                    eprintln!("warning: {}", diag.message);
-                }
+                let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, path, diag);
+                eprint!("{rendered}");
             }
         }
     }

--- a/crates/harn-cli/src/commands/check/check_cmd.rs
+++ b/crates/harn-cli/src/commands/check/check_cmd.rs
@@ -30,33 +30,15 @@ pub(crate) fn check_file_inner(
     if let Some(imported) = module_graph.imported_type_declarations_for_file(path) {
         checker = checker.with_imported_type_decls(imported);
     }
-    let type_diagnostics = checker.check(&program);
+    let type_diagnostics = checker.check_with_source(&program, &source);
     for diag in &type_diagnostics {
-        let severity = match diag.severity {
-            DiagnosticSeverity::Error => {
-                has_error = true;
-                "error"
-            }
-            DiagnosticSeverity::Warning => {
-                has_warning = true;
-                "warning"
-            }
-        };
-        diagnostic_count += 1;
-        if let Some(span) = &diag.span {
-            let rendered = harn_parser::diagnostic::render_diagnostic(
-                &source,
-                &path_str,
-                span,
-                severity,
-                &diag.message,
-                None,
-                diag.help.as_deref(),
-            );
-            eprint!("{rendered}");
-        } else {
-            eprintln!("{severity}: {}", diag.message);
+        match diag.severity {
+            DiagnosticSeverity::Error => has_error = true,
+            DiagnosticSeverity::Warning => has_warning = true,
         }
+        diagnostic_count += 1;
+        let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, &path_str, diag);
+        eprint!("{rendered}");
     }
 
     let lint_diagnostics = harn_lint::lint_with_module_graph(

--- a/crates/harn-cli/src/commands/playground.rs
+++ b/crates/harn-cli/src/commands/playground.rs
@@ -283,26 +283,14 @@ fn typecheck_program(
     let mut rendered = String::new();
     let mut had_error = false;
     for diagnostic in &diagnostics {
-        let severity = match diagnostic.severity {
-            DiagnosticSeverity::Error => {
-                had_error = true;
-                "error"
-            }
-            DiagnosticSeverity::Warning => "warning",
-        };
-        if let Some(span) = &diagnostic.span {
-            rendered.push_str(&harn_parser::diagnostic::render_diagnostic(
-                source,
-                &path.to_string_lossy(),
-                span,
-                severity,
-                &diagnostic.message,
-                None,
-                diagnostic.help.as_deref(),
-            ));
-        } else {
-            rendered.push_str(&format!("{severity}: {}\n", diagnostic.message));
+        if diagnostic.severity == DiagnosticSeverity::Error {
+            had_error = true;
         }
+        rendered.push_str(&harn_parser::diagnostic::render_type_diagnostic(
+            source,
+            &path.to_string_lossy(),
+            diagnostic,
+        ));
     }
 
     if had_error {

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -93,6 +93,7 @@ pub(crate) fn build_denied_builtins(
 fn typecheck_with_imports(
     program: &[harn_parser::SNode],
     path: &Path,
+    source: &str,
 ) -> Vec<harn_parser::TypeDiagnostic> {
     if let Err(error) = package::ensure_dependencies_materialized(path) {
         eprintln!("error: {error}");
@@ -106,7 +107,7 @@ fn typecheck_with_imports(
     if let Some(imported) = graph.imported_type_declarations_for_file(path) {
         checker = checker.with_imported_type_decls(imported);
     }
-    checker.check(program)
+    checker.check_with_source(program, source)
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -481,41 +482,17 @@ pub(crate) async fn run_file_with_skill_dirs(
     let (source, program) = parse_source_file(path);
 
     let mut had_type_error = false;
-    let type_diagnostics = typecheck_with_imports(&program, Path::new(path));
+    let type_diagnostics = typecheck_with_imports(&program, Path::new(path), &source);
     for diag in &type_diagnostics {
         match diag.severity {
             DiagnosticSeverity::Error => {
                 had_type_error = true;
-                if let Some(span) = &diag.span {
-                    let rendered = harn_parser::diagnostic::render_diagnostic(
-                        &source,
-                        path,
-                        span,
-                        "error",
-                        &diag.message,
-                        None,
-                        diag.help.as_deref(),
-                    );
-                    eprint!("{rendered}");
-                } else {
-                    eprintln!("error: {}", diag.message);
-                }
+                let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, path, diag);
+                eprint!("{rendered}");
             }
             DiagnosticSeverity::Warning => {
-                if let Some(span) = &diag.span {
-                    let rendered = harn_parser::diagnostic::render_diagnostic(
-                        &source,
-                        path,
-                        span,
-                        "warning",
-                        &diag.message,
-                        None,
-                        diag.help.as_deref(),
-                    );
-                    eprint!("{rendered}");
-                } else {
-                    eprintln!("warning: {}", diag.message);
-                }
+                let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, path, diag);
+                eprint!("{rendered}");
             }
         }
     }
@@ -994,19 +971,17 @@ pub(crate) async fn run_file_mcp_serve(
 ) {
     let (source, program) = crate::parse_source_file(path);
 
-    let type_diagnostics = typecheck_with_imports(&program, Path::new(path));
+    let type_diagnostics = typecheck_with_imports(&program, Path::new(path), &source);
     for diag in &type_diagnostics {
         match diag.severity {
             DiagnosticSeverity::Error => {
-                eprintln!("error: {}", diag.message);
+                let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, path, diag);
+                eprint!("{rendered}");
                 process::exit(1);
             }
             DiagnosticSeverity::Warning => {
-                if let Some(span) = &diag.span {
-                    eprintln!("warning: {} (line {})", diag.message, span.line);
-                } else {
-                    eprintln!("warning: {}", diag.message);
-                }
+                let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, path, diag);
+                eprint!("{rendered}");
             }
         }
     }

--- a/crates/harn-parser/src/diagnostic.rs
+++ b/crates/harn-parser/src/diagnostic.rs
@@ -5,6 +5,11 @@ use yansi::{Color, Paint};
 
 use crate::ParserError;
 
+pub struct RelatedSpanLabel<'a> {
+    pub span: &'a Span,
+    pub label: &'a str,
+}
+
 /// Compute the Levenshtein edit distance between two strings.
 pub fn edit_distance(a: &str, b: &str) -> usize {
     let a_chars: Vec<char> = a.chars().collect();
@@ -53,6 +58,19 @@ pub fn render_diagnostic(
     message: &str,
     label: Option<&str>,
     help: Option<&str>,
+) -> String {
+    render_diagnostic_with_related(source, filename, span, severity, message, label, help, &[])
+}
+
+pub fn render_diagnostic_with_related(
+    source: &str,
+    filename: &str,
+    span: &Span,
+    severity: &str,
+    message: &str,
+    label: Option<&str>,
+    help: Option<&str>,
+    related: &[RelatedSpanLabel<'_>],
 ) -> String {
     let mut out = String::new();
     let severity_color = severity_color(severity);
@@ -118,6 +136,23 @@ pub fn render_diagnostic(
         ));
     }
 
+    for item in related {
+        out.push_str(&format!(
+            "{:>width$} = {note_prefix}: {}\n",
+            " ",
+            item.label,
+            width = gutter_width + 1,
+        ));
+        render_related_span(
+            &mut out,
+            source,
+            filename,
+            item.span,
+            item.label,
+            gutter_width,
+        );
+    }
+
     if let Some(note_text) = fun_note(severity) {
         out.push_str(&format!(
             "{:>width$} = {note_prefix}: {note_text}\n",
@@ -127,6 +162,100 @@ pub fn render_diagnostic(
     }
 
     out
+}
+
+pub fn render_type_diagnostic(
+    source: &str,
+    filename: &str,
+    diag: &crate::typechecker::TypeDiagnostic,
+) -> String {
+    let severity = match diag.severity {
+        crate::typechecker::DiagnosticSeverity::Error => "error",
+        crate::typechecker::DiagnosticSeverity::Warning => "warning",
+    };
+    let related = diag
+        .related
+        .iter()
+        .map(|related| RelatedSpanLabel {
+            span: &related.span,
+            label: &related.message,
+        })
+        .collect::<Vec<_>>();
+    match &diag.span {
+        Some(span) => render_diagnostic_with_related(
+            source,
+            filename,
+            span,
+            severity,
+            &diag.message,
+            type_diagnostic_primary_label(diag),
+            diag.help.as_deref(),
+            &related,
+        ),
+        None => format!("{severity}: {}\n", diag.message),
+    }
+}
+
+fn type_diagnostic_primary_label(
+    diag: &crate::typechecker::TypeDiagnostic,
+) -> Option<&'static str> {
+    if diag.message.contains("expected ") && diag.message.contains("found ") {
+        Some("found this type")
+    } else {
+        None
+    }
+}
+
+fn render_related_span(
+    out: &mut String,
+    source: &str,
+    filename: &str,
+    span: &Span,
+    label: &str,
+    primary_gutter_width: usize,
+) {
+    let severity_color = Color::Magenta;
+    let gutter = style_fragment("|", Color::Blue, false);
+    let arrow = style_fragment("-->", Color::Blue, true);
+    let line_num = span.line;
+    let col_num = span.column;
+    let gutter_width = primary_gutter_width.max(line_num.to_string().len());
+
+    out.push_str(&format!(
+        "{:>width$}{arrow} {filename}:{line_num}:{col_num}\n",
+        " ",
+        width = gutter_width + 1,
+    ));
+    out.push_str(&format!(
+        "{:>width$} {gutter}\n",
+        " ",
+        width = gutter_width + 1,
+    ));
+
+    if let Some(source_line) = source
+        .lines()
+        .nth(line_num.wrapping_sub(1))
+        .filter(|_| line_num > 0)
+    {
+        out.push_str(&format!(
+            "{:>width$} {gutter} {source_line}\n",
+            line_num,
+            width = gutter_width + 1,
+        ));
+        let span_len = if span.end > span.start && span.start <= source.len() {
+            let span_text = &source[span.start.min(source.len())..span.end.min(source.len())];
+            span_text.chars().count().max(1)
+        } else {
+            1
+        };
+        let padding = " ".repeat(col_num.max(1) - 1);
+        let carets = style_fragment(&"^".repeat(span_len), severity_color, true);
+        out.push_str(&format!(
+            "{:>width$} {gutter} {padding}{carets} {label}\n",
+            " ",
+            width = gutter_width + 1,
+        ));
+    }
 }
 
 fn severity_color(severity: &str) -> Color {

--- a/crates/harn-parser/src/lib.rs
+++ b/crates/harn-parser/src/lib.rs
@@ -91,7 +91,7 @@ pub fn parse_source(source: &str) -> Result<Vec<SNode>, PipelineError> {
 /// diagnostics (which may include warnings even on success).
 pub fn check_source(source: &str) -> Result<(Vec<SNode>, Vec<TypeDiagnostic>), PipelineError> {
     let program = parse_source(source)?;
-    let diagnostics = TypeChecker::new().check(&program);
+    let diagnostics = TypeChecker::new().check_with_source(&program, source);
     Ok((program, diagnostics))
 }
 

--- a/crates/harn-parser/src/typechecker/inference/calls.rs
+++ b/crates/harn-parser/src/typechecker/inference/calls.rs
@@ -827,15 +827,16 @@ impl TypeChecker {
                     if let Some(actual) = &actual {
                         let expected = Self::apply_type_bindings(expected, &type_bindings);
                         if !self.types_compatible(&expected, actual, &call_scope) {
-                            self.error_at(
-                                format!(
-                                    "Argument {} ('{}'): expected {}, got {}",
-                                    i + 1,
-                                    param_name,
-                                    format_type(&expected),
-                                    format_type(actual)
-                                ),
+                            self.type_mismatch_at(
+                                format!("argument {} `{}`", i + 1, param_name),
+                                &expected,
+                                actual,
                                 arg.span,
+                                sig.definition_span.map(|span| {
+                                    (span, format!("parameter `{param_name}` declared here"))
+                                }),
+                                Some(arg.span),
+                                &call_scope,
                             );
                         }
                     }

--- a/crates/harn-parser/src/typechecker/inference/decls.rs
+++ b/crates/harn-parser/src/typechecker/inference/decls.rs
@@ -94,6 +94,7 @@ impl TypeChecker {
         body: &[SNode],
         where_clauses: &[WhereClause],
         is_stream: bool,
+        expected_span: Span,
     ) {
         self.fn_depth += 1;
         let saved_stream_depth = self.stream_fn_depth;
@@ -113,6 +114,7 @@ impl TypeChecker {
             body,
             where_clauses,
             is_stream,
+            expected_span,
         );
         if is_stream {
             self.stream_emit_types.pop();
@@ -137,6 +139,7 @@ impl TypeChecker {
         body: &[SNode],
         where_clauses: &[WhereClause],
         is_stream: bool,
+        expected_span: Span,
     ) {
         let mut fn_scope = self.scope.child();
         // Register generic type parameters so they are treated as compatible
@@ -171,7 +174,7 @@ impl TypeChecker {
             if let Some(actual) = return_type {
                 self.error_at(
                     format!(
-                        "`gen fn` must return Stream<T>, got {}",
+                        "`gen fn` must return Stream<T>, found {}",
                         format_type(actual)
                     ),
                     Span::dummy(),
@@ -183,7 +186,7 @@ impl TypeChecker {
         if let Some(ret_type) = return_type {
             let mut ret_scope = ret_scope_base.unwrap();
             for stmt in body {
-                self.check_return_type(stmt, ret_type, &mut ret_scope);
+                self.check_return_type(stmt, ret_type, expected_span, &mut ret_scope);
             }
         }
     }
@@ -192,21 +195,22 @@ impl TypeChecker {
         &mut self,
         snode: &SNode,
         expected: &TypeExpr,
+        expected_span: Span,
         scope: &mut TypeScope,
     ) {
-        let span = snode.span;
         match &snode.node {
             Node::ReturnStmt { value: Some(val) } => {
                 let inferred = self.infer_type(val, scope);
                 if let Some(actual) = &inferred {
                     if !self.types_compatible(expected, actual, scope) {
-                        self.error_at(
-                            format!(
-                                "return type doesn't match: expected {}, got {}",
-                                format_type(expected),
-                                format_type(actual)
-                            ),
-                            span,
+                        self.type_mismatch_at(
+                            "return value",
+                            expected,
+                            actual,
+                            val.span,
+                            Some((expected_span, "return type declared here".to_string())),
+                            Some(val.span),
+                            scope,
                         );
                     }
                 }
@@ -220,13 +224,13 @@ impl TypeChecker {
                 let mut then_scope = scope.child();
                 refs.apply_truthy(&mut then_scope);
                 for stmt in then_body {
-                    self.check_return_type(stmt, expected, &mut then_scope);
+                    self.check_return_type(stmt, expected, expected_span, &mut then_scope);
                 }
                 if let Some(else_body) = else_body {
                     let mut else_scope = scope.child();
                     refs.apply_falsy(&mut else_scope);
                     for stmt in else_body {
-                        self.check_return_type(stmt, expected, &mut else_scope);
+                        self.check_return_type(stmt, expected, expected_span, &mut else_scope);
                     }
                     // Post-branch narrowing for return type checking
                     if Self::block_definitely_exits(then_body)

--- a/crates/harn-parser/src/typechecker/inference/entry.rs
+++ b/crates/harn-parser/src/typechecker/inference/entry.rs
@@ -93,7 +93,7 @@ impl TypeChecker {
                         (return_type.as_ref(), ret_scope_base)
                     {
                         for stmt in body {
-                            self.check_return_type(stmt, ret_type, &mut ret_scope);
+                            self.check_return_type(stmt, ret_type, inner_node.span, &mut ret_scope);
                         }
                     }
                     self.fn_depth -= 1;
@@ -117,6 +117,7 @@ impl TypeChecker {
                             .map(|p| (p.name.clone(), p.type_expr.clone()))
                             .collect(),
                         return_type: return_type.clone(),
+                        definition_span: Some(snode.span),
                         type_param_names: type_params.iter().map(|tp| tp.name.clone()).collect(),
                         required_params,
                         where_clauses: where_clauses
@@ -133,6 +134,7 @@ impl TypeChecker {
                         body,
                         where_clauses,
                         *is_stream,
+                        snode.span,
                     );
                 }
                 _ => {
@@ -190,6 +192,7 @@ impl TypeChecker {
                             .map(|p| (p.name.clone(), p.type_expr.clone()))
                             .collect(),
                         return_type,
+                        definition_span: Some(inner.span),
                         type_param_names: type_params.iter().map(|tp| tp.name.clone()).collect(),
                         required_params: params
                             .iter()
@@ -208,6 +211,7 @@ impl TypeChecker {
                     let sig = FnSignature {
                         params: Vec::new(),
                         return_type: None,
+                        definition_span: Some(inner.span),
                         type_param_names: Vec::new(),
                         required_params: 0,
                         where_clauses: Vec::new(),
@@ -220,6 +224,7 @@ impl TypeChecker {
                     let sig = FnSignature {
                         params: Vec::new(),
                         return_type: None,
+                        definition_span: Some(inner.span),
                         type_param_names: Vec::new(),
                         required_params: 0,
                         where_clauses: Vec::new(),

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -18,7 +18,7 @@ use crate::builtin_signatures;
 
 use super::super::binary_ops::infer_binary_op_type;
 use super::super::exits::stmt_definitely_exits;
-use super::super::format::{format_type, is_obvious_type, shape_mismatch_detail};
+use super::super::format::{format_type, is_obvious_type};
 use super::super::schema_inference::schema_type_expr_from_node;
 use super::super::scope::{
     EnumDeclInfo, FnSignature, ImplMethodSig, InterfaceDeclInfo, StructDeclInfo, TypeAliasInfo,
@@ -137,16 +137,15 @@ impl TypeChecker {
                     if let Some(expected) = type_ann {
                         if let Some(actual) = &inferred {
                             if !self.types_compatible(expected, actual, scope) {
-                                let mut msg = format!(
-                                    "'{}' declared as {}, but assigned {}",
-                                    name,
-                                    format_type(expected),
-                                    format_type(actual)
+                                self.type_mismatch_at(
+                                    format!("let binding `{name}`"),
+                                    expected,
+                                    actual,
+                                    value.span,
+                                    Some((span, "expected type declared here".to_string())),
+                                    Some(value.span),
+                                    scope,
                                 );
-                                if let Some(detail) = shape_mismatch_detail(expected, actual) {
-                                    msg.push_str(&format!(" ({})", detail));
-                                }
-                                self.error_at(msg, span);
                             }
                         }
                     }
@@ -193,16 +192,15 @@ impl TypeChecker {
                     if let Some(expected) = type_ann {
                         if let Some(actual) = &inferred {
                             if !self.types_compatible(expected, actual, scope) {
-                                let mut msg = format!(
-                                    "'{}' declared as {}, but assigned {}",
-                                    name,
-                                    format_type(expected),
-                                    format_type(actual)
+                                self.type_mismatch_at(
+                                    format!("var binding `{name}`"),
+                                    expected,
+                                    actual,
+                                    value.span,
+                                    Some((span, "expected type declared here".to_string())),
+                                    Some(value.span),
+                                    scope,
                                 );
-                                if let Some(detail) = shape_mismatch_detail(expected, actual) {
-                                    msg.push_str(&format!(" ({})", detail));
-                                }
-                                self.error_at(msg, span);
                             }
                         }
                     }
@@ -262,6 +260,7 @@ impl TypeChecker {
                         .map(|p| (p.name.clone(), p.type_expr.clone()))
                         .collect(),
                     return_type: callable_return_type,
+                    definition_span: Some(span),
                     type_param_names: type_params.iter().map(|tp| tp.name.clone()).collect(),
                     required_params,
                     where_clauses: where_clauses
@@ -281,6 +280,7 @@ impl TypeChecker {
                     body,
                     where_clauses,
                     *is_stream,
+                    span,
                 );
             }
 
@@ -299,6 +299,7 @@ impl TypeChecker {
                         .map(|p| (p.name.clone(), p.type_expr.clone()))
                         .collect(),
                     return_type: return_type.clone(),
+                    definition_span: Some(span),
                     type_param_names: Vec::new(),
                     required_params,
                     where_clauses: Vec::new(),
@@ -307,7 +308,7 @@ impl TypeChecker {
                 scope.define_fn(name, sig);
                 scope.define_var(name, None);
                 scope.clear_nil_widenable(name);
-                self.check_fn_body(&[], params, return_type, body, &[], false);
+                self.check_fn_body(&[], params, return_type, body, &[], false, span);
             }
 
             Node::SkillDecl { name, fields, .. } => {
@@ -589,14 +590,17 @@ impl TypeChecker {
                                 {
                                     widened_slot_type = Some(Self::union_with_nil(actual));
                                 } else {
-                                    self.error_at(
-                                        format!(
-                                            "can't assign {} to '{}' (declared as {})",
-                                            format_type(actual),
-                                            name,
-                                            format_type(check_type)
-                                        ),
-                                        span,
+                                    self.type_mismatch_at(
+                                        format!("assignment to `{name}`"),
+                                        check_type,
+                                        actual,
+                                        value.span,
+                                        Some((
+                                            target.span,
+                                            format!("`{name}` has this expected type"),
+                                        )),
+                                        Some(value.span),
+                                        scope,
                                     );
                                 }
                             }
@@ -1256,16 +1260,17 @@ impl TypeChecker {
                         "`emit` can only be used inside a `gen fn`".to_string(),
                         span,
                     );
-                } else if let Some(Some(expected)) = self.stream_emit_types.last() {
+                } else if let Some(Some(expected)) = self.stream_emit_types.last().cloned() {
                     if let Some(actual) = self.infer_type(value, scope) {
-                        if !self.types_compatible(expected, &actual, scope) {
-                            self.error_at(
-                                format!(
-                                    "emit type doesn't match: expected {}, got {}",
-                                    format_type(expected),
-                                    format_type(&actual)
-                                ),
+                        if !self.types_compatible(&expected, &actual, scope) {
+                            self.type_mismatch_at(
+                                "`emit` value",
+                                &expected,
+                                &actual,
                                 span,
+                                Some((span, "stream emit type expected here".to_string())),
+                                Some(value.span),
+                                scope,
                             );
                         }
                     }
@@ -1326,15 +1331,14 @@ impl TypeChecker {
                         };
                         let expected = Self::apply_type_bindings(expected_type, &type_bindings);
                         if !self.types_compatible(&expected, &actual_type, scope) {
-                            self.error_at(
-                                format!(
-                                    "Field '{}' in struct '{}' expects {}, got {}",
-                                    field.name,
-                                    struct_name,
-                                    format_type(&expected),
-                                    format_type(&actual_type)
-                                ),
+                            self.type_mismatch_at(
+                                format!("field `{}` in struct `{struct_name}`", field.name),
+                                &expected,
+                                &actual_type,
                                 entry.value.span,
+                                Some((span, format!("struct `{struct_name}` expected here"))),
+                                Some(entry.value.span),
+                                scope,
                             );
                         }
                     }
@@ -1431,16 +1435,17 @@ impl TypeChecker {
                         };
                         let expected = Self::apply_type_bindings(expected_type, &type_bindings);
                         if !self.types_compatible(&expected, &actual_type, scope) {
-                            self.error_at(
-                                format!(
-                                    "{}.{} expects {}: {}, got {}",
-                                    enum_name,
-                                    variant,
-                                    field.name,
-                                    format_type(&expected),
-                                    format_type(&actual_type)
-                                ),
+                            self.type_mismatch_at(
+                                format!("{}.{} argument `{}`", enum_name, variant, field.name),
+                                &expected,
+                                &actual_type,
                                 arg.span,
+                                Some((
+                                    span,
+                                    format!("enum variant `{enum_name}.{variant}` expected here"),
+                                )),
+                                Some(arg.span),
+                                scope,
                             );
                         }
                     }

--- a/crates/harn-parser/src/typechecker/mod.rs
+++ b/crates/harn-parser/src/typechecker/mod.rs
@@ -35,6 +35,7 @@ pub struct TypeDiagnostic {
     pub severity: DiagnosticSeverity,
     pub span: Option<Span>,
     pub help: Option<String>,
+    pub related: Vec<RelatedDiagnostic>,
     /// Machine-applicable fix edits.
     pub fix: Option<Vec<FixEdit>>,
     /// Optional structured payload that higher-level tooling (e.g. the
@@ -42,6 +43,12 @@ pub struct TypeDiagnostic {
     /// need more than a static `FixEdit`. Out-of-band from `fix` so the
     /// string-based rendering pipeline doesn't have to care.
     pub details: Option<DiagnosticDetails>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RelatedDiagnostic {
+    pub span: Span,
+    pub message: String,
 }
 
 /// Optional structured companion data on a `TypeDiagnostic`. The
@@ -277,6 +284,7 @@ impl TypeChecker {
             severity: DiagnosticSeverity::Error,
             span: Some(span),
             help: None,
+            related: Vec::new(),
             fix: None,
             details: None,
         });
@@ -294,6 +302,49 @@ impl TypeChecker {
             severity: DiagnosticSeverity::Error,
             span: Some(span),
             help: Some(help),
+            related: Vec::new(),
+            fix: None,
+            details: None,
+        });
+    }
+
+    pub(in crate::typechecker) fn type_mismatch_at(
+        &mut self,
+        context: impl Into<String>,
+        expected: &TypeExpr,
+        actual: &TypeExpr,
+        span: Span,
+        expected_origin: Option<(Span, String)>,
+        value_span: Option<Span>,
+        scope: &TypeScope,
+    ) {
+        let mut message = format!(
+            "{}: expected {}, found {}",
+            context.into(),
+            format_type(expected),
+            format_type(actual)
+        );
+        if let Some(detail) = type_mismatch_detail(expected, actual, scope) {
+            message.push_str(&format!(" ({detail})"));
+        }
+
+        let mut related = Vec::new();
+        if let Some((span, message)) = expected_origin {
+            related.push(RelatedDiagnostic { span, message });
+        }
+        for note in type_mismatch_notes(expected, actual, scope) {
+            related.push(RelatedDiagnostic {
+                span,
+                message: note,
+            });
+        }
+
+        self.diagnostics.push(TypeDiagnostic {
+            message,
+            severity: DiagnosticSeverity::Error,
+            span: Some(span),
+            help: coercion_suggestion(expected, actual, value_span, self.source.as_deref()),
+            related,
             fix: None,
             details: None,
         });
@@ -310,6 +361,7 @@ impl TypeChecker {
             severity: DiagnosticSeverity::Error,
             span: Some(span),
             help: None,
+            related: Vec::new(),
             fix: Some(fix),
             details: None,
         });
@@ -327,6 +379,7 @@ impl TypeChecker {
             severity: DiagnosticSeverity::Error,
             span: Some(span),
             help: None,
+            related: Vec::new(),
             fix: None,
             details: None,
         });
@@ -347,6 +400,7 @@ impl TypeChecker {
             severity: DiagnosticSeverity::Error,
             span: Some(span),
             help: None,
+            related: Vec::new(),
             fix: None,
             details: Some(DiagnosticDetails::NonExhaustiveMatch { missing }),
         });
@@ -358,6 +412,7 @@ impl TypeChecker {
             severity: DiagnosticSeverity::Warning,
             span: Some(span),
             help: None,
+            related: Vec::new(),
             fix: None,
             details: None,
         });
@@ -375,10 +430,263 @@ impl TypeChecker {
             severity: DiagnosticSeverity::Warning,
             span: Some(span),
             help: Some(help),
+            related: Vec::new(),
             fix: None,
             details: None,
         });
     }
+}
+
+fn type_mismatch_detail(
+    expected: &TypeExpr,
+    actual: &TypeExpr,
+    scope: &TypeScope,
+) -> Option<String> {
+    shape_mismatch_detail(expected, actual)
+        .or_else(|| first_nested_mismatch(expected, actual, scope).map(|note| note.message))
+}
+
+#[derive(Debug)]
+struct MismatchNote {
+    message: String,
+}
+
+fn type_mismatch_notes(expected: &TypeExpr, actual: &TypeExpr, scope: &TypeScope) -> Vec<String> {
+    first_nested_mismatch(expected, actual, scope)
+        .map(|note| vec![format!("nested mismatch: {}", note.message)])
+        .unwrap_or_default()
+}
+
+fn first_nested_mismatch(
+    expected: &TypeExpr,
+    actual: &TypeExpr,
+    scope: &TypeScope,
+) -> Option<MismatchNote> {
+    let expected = resolve_type_for_diagnostic(expected, scope);
+    let actual = resolve_type_for_diagnostic(actual, scope);
+    match (&expected, &actual) {
+        (TypeExpr::Shape(expected_fields), TypeExpr::Shape(actual_fields)) => {
+            for expected_field in expected_fields {
+                if expected_field.optional {
+                    continue;
+                }
+                let Some(actual_field) = actual_fields
+                    .iter()
+                    .find(|actual_field| actual_field.name == expected_field.name)
+                else {
+                    return Some(MismatchNote {
+                        message: format!(
+                            "field `{}` is missing; expected {}",
+                            expected_field.name,
+                            format_type(&expected_field.type_expr)
+                        ),
+                    });
+                };
+                if !types_compatible_for_diagnostic(
+                    &expected_field.type_expr,
+                    &actual_field.type_expr,
+                    scope,
+                ) {
+                    return Some(MismatchNote {
+                        message: format!(
+                            "field `{}` expected {}, found {}",
+                            expected_field.name,
+                            format_type(&expected_field.type_expr),
+                            format_type(&actual_field.type_expr)
+                        ),
+                    });
+                }
+            }
+            None
+        }
+        (TypeExpr::List(expected_inner), TypeExpr::List(actual_inner)) => {
+            if !types_compatible_for_diagnostic(expected_inner, actual_inner, scope)
+                || !types_compatible_for_diagnostic(actual_inner, expected_inner, scope)
+            {
+                Some(MismatchNote {
+                    message: format!(
+                        "list element expected {}, found {}",
+                        format_type(expected_inner),
+                        format_type(actual_inner)
+                    ),
+                })
+            } else {
+                None
+            }
+        }
+        (
+            TypeExpr::DictType(expected_key, expected_value),
+            TypeExpr::DictType(actual_key, actual_value),
+        ) => {
+            if !types_compatible_for_diagnostic(expected_key, actual_key, scope)
+                || !types_compatible_for_diagnostic(actual_key, expected_key, scope)
+            {
+                Some(MismatchNote {
+                    message: format!(
+                        "dict key expected {}, found {}",
+                        format_type(expected_key),
+                        format_type(actual_key)
+                    ),
+                })
+            } else if !types_compatible_for_diagnostic(expected_value, actual_value, scope)
+                || !types_compatible_for_diagnostic(actual_value, expected_value, scope)
+            {
+                Some(MismatchNote {
+                    message: format!(
+                        "dict value expected {}, found {}",
+                        format_type(expected_value),
+                        format_type(actual_value)
+                    ),
+                })
+            } else {
+                None
+            }
+        }
+        (
+            TypeExpr::Applied {
+                name: expected_name,
+                args: expected_args,
+            },
+            TypeExpr::Applied {
+                name: actual_name,
+                args: actual_args,
+            },
+        ) if expected_name == actual_name => expected_args
+            .iter()
+            .zip(actual_args.iter())
+            .enumerate()
+            .find_map(|(idx, (expected_arg, actual_arg))| {
+                if types_compatible_for_diagnostic(expected_arg, actual_arg, scope)
+                    && types_compatible_for_diagnostic(actual_arg, expected_arg, scope)
+                {
+                    None
+                } else {
+                    Some(MismatchNote {
+                        message: format!(
+                            "{} type argument {} expected {}, found {}",
+                            expected_name,
+                            idx + 1,
+                            format_type(expected_arg),
+                            format_type(actual_arg)
+                        ),
+                    })
+                }
+            }),
+        (
+            TypeExpr::FnType {
+                params: expected_params,
+                return_type: expected_return,
+            },
+            TypeExpr::FnType {
+                params: actual_params,
+                return_type: actual_return,
+            },
+        ) => {
+            for (idx, (expected_param, actual_param)) in
+                expected_params.iter().zip(actual_params.iter()).enumerate()
+            {
+                if !types_compatible_for_diagnostic(actual_param, expected_param, scope) {
+                    return Some(MismatchNote {
+                        message: format!(
+                            "function parameter {} expected {}, found {}",
+                            idx + 1,
+                            format_type(expected_param),
+                            format_type(actual_param)
+                        ),
+                    });
+                }
+            }
+            if !types_compatible_for_diagnostic(expected_return, actual_return, scope) {
+                Some(MismatchNote {
+                    message: format!(
+                        "function return expected {}, found {}",
+                        format_type(expected_return),
+                        format_type(actual_return)
+                    ),
+                })
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn types_compatible_for_diagnostic(
+    expected: &TypeExpr,
+    actual: &TypeExpr,
+    scope: &TypeScope,
+) -> bool {
+    TypeChecker::new().types_compatible(expected, actual, scope)
+}
+
+fn resolve_type_for_diagnostic(ty: &TypeExpr, scope: &TypeScope) -> TypeExpr {
+    TypeChecker::new().resolve_alias(ty, scope)
+}
+
+fn coercion_suggestion(
+    expected: &TypeExpr,
+    actual: &TypeExpr,
+    value_span: Option<Span>,
+    source: Option<&str>,
+) -> Option<String> {
+    let expr = value_span
+        .and_then(|span| source.and_then(|source| source.get(span.start..span.end)))
+        .map(str::trim)
+        .filter(|expr| !expr.is_empty());
+    if is_nilable(actual) {
+        return Some("handle `nil` first or provide a default with `??`".to_string());
+    }
+    let expected_ty = expected;
+    let expected = simple_type_name(expected)?;
+    let actual_name = simple_type_name(actual)?;
+    let with_expr = |template: &str| {
+        expr.map(|expr| template.replace("{}", expr))
+            .unwrap_or_else(|| template.replace("{}", "value"))
+    };
+
+    match (expected, actual_name) {
+        ("string", "int" | "float" | "bool" | "nil" | "duration") => {
+            Some(format!("did you mean `{}`?", with_expr("to_string({})")))
+        }
+        ("int", "string") => Some(format!("did you mean `{}`?", with_expr("to_int({})"))),
+        ("float", "string" | "int") => {
+            Some(format!("did you mean `{}`?", with_expr("to_float({})")))
+        }
+        (_, "nil") => Some("handle `nil` first or provide a default with `??`".to_string()),
+        _ if actual_is_result_of(expected_ty, actual) => Some(format!(
+            "did you mean `{}` or `{}`?",
+            with_expr("{}?"),
+            with_expr("unwrap_or({}, default)")
+        )),
+        _ => None,
+    }
+}
+
+fn simple_type_name(ty: &TypeExpr) -> Option<&str> {
+    match ty {
+        TypeExpr::Named(name) => Some(name.as_str()),
+        TypeExpr::LitString(_) => Some("string"),
+        TypeExpr::LitInt(_) => Some("int"),
+        _ => None,
+    }
+}
+
+fn is_nilable(ty: &TypeExpr) -> bool {
+    match ty {
+        TypeExpr::Union(members) if members.len() == 2 => members
+            .iter()
+            .any(|member| matches!(member, TypeExpr::Named(name) if name == "nil")),
+        _ => false,
+    }
+}
+
+fn actual_is_result_of(expected: &TypeExpr, actual: &TypeExpr) -> bool {
+    matches!(
+        actual,
+        TypeExpr::Applied { name, args }
+            if name == "Result" && args.first().is_some_and(|ok| ok == expected)
+    )
 }
 
 impl Default for TypeChecker {

--- a/crates/harn-parser/src/typechecker/mod.rs
+++ b/crates/harn-parser/src/typechecker/mod.rs
@@ -318,13 +318,16 @@ impl TypeChecker {
         value_span: Option<Span>,
         scope: &TypeScope,
     ) {
+        let nested_mismatch = first_nested_mismatch(expected, actual, scope);
         let mut message = format!(
             "{}: expected {}, found {}",
             context.into(),
             format_type(expected),
             format_type(actual)
         );
-        if let Some(detail) = type_mismatch_detail(expected, actual, scope) {
+        if let Some(detail) = shape_mismatch_detail(expected, actual)
+            .or_else(|| nested_mismatch.as_ref().map(|note| note.message.clone()))
+        {
             message.push_str(&format!(" ({detail})"));
         }
 
@@ -332,10 +335,10 @@ impl TypeChecker {
         if let Some((span, message)) = expected_origin {
             related.push(RelatedDiagnostic { span, message });
         }
-        for note in type_mismatch_notes(expected, actual, scope) {
+        if let Some(note) = nested_mismatch {
             related.push(RelatedDiagnostic {
                 span,
-                message: note,
+                message: format!("nested mismatch: {}", note.message),
             });
         }
 
@@ -437,24 +440,9 @@ impl TypeChecker {
     }
 }
 
-fn type_mismatch_detail(
-    expected: &TypeExpr,
-    actual: &TypeExpr,
-    scope: &TypeScope,
-) -> Option<String> {
-    shape_mismatch_detail(expected, actual)
-        .or_else(|| first_nested_mismatch(expected, actual, scope).map(|note| note.message))
-}
-
 #[derive(Debug)]
 struct MismatchNote {
     message: String,
-}
-
-fn type_mismatch_notes(expected: &TypeExpr, actual: &TypeExpr, scope: &TypeScope) -> Vec<String> {
-    first_nested_mismatch(expected, actual, scope)
-        .map(|note| vec![format!("nested mismatch: {}", note.message)])
-        .unwrap_or_default()
 }
 
 fn first_nested_mismatch(

--- a/crates/harn-parser/src/typechecker/scope.rs
+++ b/crates/harn-parser/src/typechecker/scope.rs
@@ -133,6 +133,7 @@ pub(super) struct ImplMethodSig {
 pub(super) struct FnSignature {
     pub(super) params: Vec<(String, InferredType)>,
     pub(super) return_type: InferredType,
+    pub(super) definition_span: Option<harn_lexer::Span>,
     /// Generic type parameter names declared on the function.
     pub(super) type_param_names: Vec<String>,
     /// Number of required parameters (those without defaults).

--- a/crates/harn-parser/src/typechecker/tests/narrowing.rs
+++ b/crates/harn-parser/src/typechecker/tests/narrowing.rs
@@ -260,7 +260,7 @@ if y != nil {
     // s2 should fail because y was reassigned, invalidating the narrowing
     assert_eq!(errs.len(), 1, "expected 1 error, got: {:?}", errs);
     assert!(
-        errs[0].contains("declared as"),
+        errs[0].contains("expected string"),
         "expected type mismatch, got: {}",
         errs[0]
     );
@@ -493,7 +493,7 @@ pipeline t(task) {
 }"#,
     );
     assert!(
-        errs.iter().any(|e| e.contains("'wrong' declared as")),
+        errs.iter().any(|e| e.contains("let binding `wrong`")),
         "expected residual-narrowing assignment to fail, got: {:?}",
         errs
     );

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -18,8 +18,8 @@ fn test_correct_typed_let() {
 fn test_type_mismatch_let() {
     let errs = errors(r#"pipeline t(task) { let x: int = "hello" }"#);
     assert_eq!(errs.len(), 1);
-    assert!(errs[0].contains("declared as int"));
-    assert!(errs[0].contains("assigned string"));
+    assert!(errs[0].contains("expected int"));
+    assert!(errs[0].contains("found string"));
 }
 
 #[test]
@@ -302,7 +302,7 @@ fn test_fn_arg_type_mismatch() {
 add("hello", 2) }"#,
     );
     assert_eq!(errs.len(), 1);
-    assert!(errs[0].contains("Argument 1"));
+    assert!(errs[0].contains("argument 1 `a`"));
     assert!(errs[0].contains("expected int"));
 }
 
@@ -310,7 +310,7 @@ add("hello", 2) }"#,
 fn test_return_type_mismatch() {
     let errs = errors(r#"pipeline t(task) { fn get() -> int { return "hello" } }"#);
     assert_eq!(errs.len(), 1);
-    assert!(errs[0].contains("return type doesn't match"));
+    assert!(errs[0].contains("return value: expected int, found string"));
 }
 
 #[test]
@@ -323,7 +323,8 @@ fn test_union_type_compatible() {
 fn test_union_type_mismatch() {
     let errs = errors(r#"pipeline t(task) { let x: string | nil = 42 }"#);
     assert_eq!(errs.len(), 1);
-    assert!(errs[0].contains("declared as"));
+    assert!(errs[0].contains("expected string | nil"));
+    assert!(errs[0].contains("found int"));
 }
 
 #[test]
@@ -373,7 +374,7 @@ fn test_explicit_nil_var_does_not_widen() {
 }"#,
     );
     assert_eq!(errs.len(), 1, "expected 1 error, got: {errs:?}");
-    assert!(errs[0].contains("declared as nil"), "got: {}", errs[0]);
+    assert!(errs[0].contains("expected nil"), "got: {}", errs[0]);
 }
 
 #[test]
@@ -385,7 +386,8 @@ fn test_type_inference_propagation() {
 }"#,
     );
     assert_eq!(errs.len(), 1);
-    assert!(errs[0].contains("declared as"));
+    assert!(errs[0].contains("expected string"));
+    assert!(errs[0].contains("found int"));
     assert!(errs[0].contains("string"));
     assert!(errs[0].contains("int"));
 }
@@ -431,7 +433,7 @@ fn test_explicit_generic_call_type_args_must_match_arguments() {
     );
     assert!(
         errs.iter()
-            .any(|err| err.contains("expected int, got string")),
+            .any(|err| err.contains("expected int, found string")),
         "missing explicit type-arg mismatch error: {errs:?}"
     );
 }
@@ -453,7 +455,7 @@ fn test_generic_type_param_must_bind_consistently() {
     );
     assert!(
         errs.iter()
-            .any(|err| err.contains("Argument 2 ('b'): expected int, got string")),
+            .any(|err| err.contains("argument 2 `b`: expected int, found string")),
         "missing instantiated argument mismatch error: {:?}",
         errs
     );
@@ -468,7 +470,7 @@ fn test_generic_list_binding_propagates_element_type() {
 }"#,
     );
     assert_eq!(errs.len(), 1, "expected 1 error, got: {:?}", errs);
-    assert!(errs[0].contains("declared as string, but assigned int"));
+    assert!(errs[0].contains("expected string, found int"));
 }
 
 #[test]
@@ -705,7 +707,61 @@ fn test_assignment_type_check() {
 }"#,
     );
     assert_eq!(errs.len(), 1);
-    assert!(errs[0].contains("can't assign string"));
+    assert!(errs[0].contains("expected int, found string"));
+}
+
+#[test]
+fn test_type_mismatch_render_snapshot_with_coercion_help() {
+    std::env::set_var("NO_COLOR", "1");
+    let source = r#"pipeline t(task) {
+  let label: string = 42
+}"#;
+    let diags = check_source_with_source(source);
+    let rendered = crate::diagnostic::render_type_diagnostic(source, "test.harn", &diags[0]);
+    assert_eq!(
+        rendered,
+        r#"error: let binding `label`: expected string, found int
+  --> test.harn:2:23
+   |
+ 2 |   let label: string = 42
+   |                       ^^ found this type
+   = help: did you mean `to_string(42)`?
+   = note: expected type declared here
+  --> test.harn:2:3
+   |
+ 2 |   let label: string = 42
+   |   ^^^^^^^^^^^^^^^^^^^^^^ expected type declared here
+"#
+    );
+}
+
+#[test]
+fn test_type_mismatch_render_snapshot_with_nested_note() {
+    std::env::set_var("NO_COLOR", "1");
+    let source = r#"pipeline t(task) {
+  let item: {name: string, count: int} = {name: 1, count: 2}
+}"#;
+    let diags = check_source_with_source(source);
+    let rendered = crate::diagnostic::render_type_diagnostic(source, "test.harn", &diags[0]);
+    assert_eq!(
+        rendered,
+        r#"error: let binding `item`: expected {name: string, count: int}, found {name: int, count: int} (field 'name' has type int, expected string)
+  --> test.harn:2:42
+   |
+ 2 |   let item: {name: string, count: int} = {name: 1, count: 2}
+   |                                          ^^^^^^^^^^^^^^^^^^^ found this type
+   = note: expected type declared here
+  --> test.harn:2:3
+   |
+ 2 |   let item: {name: string, count: int} = {name: 1, count: 2}
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type declared here
+   = note: nested mismatch: field `name` expected string, found int
+  --> test.harn:2:42
+   |
+ 2 |   let item: {name: string, count: int} = {name: 1, count: 2}
+   |                                          ^^^^^^^^^^^^^^^^^^^ nested mismatch: field `name` expected string, found int
+"#
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds centralized type mismatch diagnostics with `expected …, found …` wording, related spans for expectation origins, nested mismatch notes, and coercion help for common conversions / nilable / `Result` cases.
- Routes CLI typecheck rendering through the richer diagnostic renderer for `check`, `run`, playground, bench, and MCP serve paths.
- Adds rendered diagnostic snapshot-style tests and updates existing typechecker assertions.
- Fixes pre-existing branch health issues found during verification: stale generated highlight keywords and missing `Command` import in `persona_cli` tests.

Closes #916

## Verification
- `cargo fmt --check`
- `cargo test -p harn-parser typechecker::tests::typing --no-fail-fast`
- `cargo test -p harn-parser --no-fail-fast`
- `cargo check -p harn-cli`
- `cargo test -p harn-cli commands::check --no-fail-fast`
- `cargo test -p harn-cli commands::dump_highlight_keywords::tests::committed_keyword_file_matches_generator -- --nocapture`
- CLI smoke: `harn check` reports source-labelled type mismatch with coercion help
- Pre-commit hook: workspace clippy with `-D warnings`
- Pre-push hook: 3,079 tests passed
