### PR TITLE
Add CI determinism gates (flake-detection + thread-parity)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -123,3 +123,36 @@ leak-timeout = { period = "10s", result = "pass" }
 [[profile.ci.overrides]]
 filter = "package(harn-dap)"
 test-group = "harn-dap"
+
+# Flake-detection profile: zero retries, no fail-fast, tighter slow-test
+# threshold.  Used by the flake-detection CI workflow which runs touched
+# test binaries 50× at --test-threads=8.
+#
+# Profile overrides do NOT inherit from [[profile.default.overrides]], so
+# the subprocess-group caps and leak-timeout exemptions must be duplicated
+# here to avoid false "leaky" failures and DAP teardown races.
+[profile.flake-detection]
+retries = 0
+slow-timeout = { period = "15s", terminate-after = 4, grace-period = "5s" }
+leak-timeout = { period = "5s", result = "fail" }
+fail-fast = false
+failure-output = "immediate-final"
+success-output = "never"
+
+[[profile.flake-detection.overrides]]
+filter = 'package(harn-vm) and test(/llm::api::tests/)'
+slow-timeout = { period = "30s", terminate-after = 3, grace-period = "5s" }
+
+[[profile.flake-detection.overrides]]
+filter = "package(harn-cli) and kind(test)"
+test-group = "harn-subprocess"
+leak-timeout = { period = "10s", result = "pass" }
+
+[[profile.flake-detection.overrides]]
+filter = "package(harn-cli) and binary(harn)"
+test-group = "harn-cli-bin"
+leak-timeout = { period = "10s", result = "pass" }
+
+[[profile.flake-detection.overrides]]
+filter = "package(harn-dap)"
+test-group = "harn-dap"

--- a/.github/workflows/flake-detection.yml
+++ b/.github/workflows/flake-detection.yml
@@ -1,0 +1,80 @@
+name: Flake detection
+
+on:
+  pull_request:
+  merge_group:
+
+env:
+  CARGO_TERM_COLOR: always
+  # Incremental compilation fights sccache; disable on CI.
+  CARGO_INCREMENTAL: "0"
+  HARN_LLM_CALLS_DISABLED: "1"
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  flake-rerun:
+    name: 50x flake rerun (touched tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect touched test files
+        id: touched
+        run: |
+          git fetch origin main --depth=1
+          TOUCHED=$(git diff --name-only origin/main...HEAD -- \
+            'crates/**/tests/**' \
+            'crates/**/src/**/tests*.rs' | tr '\n' ' ')
+          FILTER=""
+          if [[ -n "${TOUCHED// }" ]]; then
+            read -ra PATHS <<< "$TOUCHED"
+            FILTER=$(./scripts/nextest_filters_from_paths.sh "${PATHS[@]}" 2>/dev/null || true)
+          fi
+          if [[ -n "$FILTER" ]]; then
+            echo "has_tests=true" >> "$GITHUB_OUTPUT"
+            echo "filter=$FILTER" >> "$GITHUB_OUTPUT"
+            echo "Touched test filter: $FILTER"
+          else
+            echo "has_tests=false" >> "$GITHUB_OUTPUT"
+            echo "No touched Rust test files detected; skipping flake rerun."
+          fi
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        if: steps.touched.outputs.has_tests == 'true'
+
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        if: steps.touched.outputs.has_tests == 'true'
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        if: steps.touched.outputs.has_tests == 'true'
+        continue-on-error: true
+        with:
+          shared-key: workspace
+
+      - name: Install cargo-nextest
+        if: steps.touched.outputs.has_tests == 'true'
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
+        continue-on-error: true
+        with:
+          tool: nextest@0.9.133
+
+      - name: Build test binaries
+        if: steps.touched.outputs.has_tests == 'true'
+        run: cargo test --no-run --workspace
+
+      - name: 50x flake rerun
+        if: steps.touched.outputs.has_tests == 'true'
+        env:
+          NEXTEST_FILTER: ${{ steps.touched.outputs.filter }}
+        run: |
+          for i in $(seq 50); do
+            printf '--- Iteration %d/50 ---\n' "$i"
+            cargo nextest run \
+              --profile flake-detection \
+              --test-threads 8 \
+              -E "$NEXTEST_FILTER" \
+              || { echo "::error::Flake detected on iteration $i"; exit 1; }
+          done

--- a/.github/workflows/thread-parity.yml
+++ b/.github/workflows/thread-parity.yml
@@ -1,0 +1,45 @@
+name: Thread-count parity
+
+on:
+  pull_request:
+  merge_group:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  HARN_LLM_CALLS_DISABLED: "1"
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  thread-parity:
+    name: Full suite at ${{ matrix.threads }} threads
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      # Run all thread counts even if one fails so we see the full picture.
+      fail-fast: false
+      matrix:
+        threads: [1, 8, 16]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        continue-on-error: true
+        with:
+          shared-key: workspace
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
+        continue-on-error: true
+        with:
+          tool: nextest@0.9.133
+
+      - name: Run full suite at ${{ matrix.threads }} threads
+        run: cargo nextest run --workspace --test-threads=${{ matrix.threads }}
+        env:
+          NEXTEST_PROFILE: ci

--- a/scripts/nextest_filters_from_paths.sh
+++ b/scripts/nextest_filters_from_paths.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# nextest_filters_from_paths.sh — translate touched file paths into a
+# cargo-nextest filterset expression.
+#
+# Usage:
+#   ./scripts/nextest_filters_from_paths.sh [file1 file2 ...]
+#
+# Outputs a nextest -E filter expression on stdout (e.g.
+# "binary(orchestrator_http) or package(harn-vm)"), or nothing if no
+# Rust test-relevant paths are given.  Exit code is always 0.
+#
+# Mapping rules (first match wins):
+#
+#   crates/<pkg>/tests/<name>.rs          → binary(<name>)
+#     Top-level integration test file = its own nextest binary.
+#
+#   crates/<pkg>/tests/<dir>/<file>.rs    → binary(<dir>)   (when <dir>.rs exists)
+#                                         → package(<pkg>)  (shared support dir)
+#     Subdirectory files are either modules of the same-named binary
+#     (e.g. orchestrator_http/a2a.rs lives under orchestrator_http.rs)
+#     or shared helpers (e.g. support/, test_util/) — check for the
+#     sibling .rs entry to tell them apart.
+#
+#   crates/<pkg>/...                      → package(<pkg>)
+#     Unit tests in src/ or any other crate-local change.
+#
+# Designed to be called from the flake-detection CI workflow.
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    exit 0
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+declare -A seen
+filters=()
+
+add_filter() {
+    local f="$1"
+    if [[ -z "${seen[$f]+_}" ]]; then
+        seen["$f"]=1
+        filters+=("$f")
+    fi
+}
+
+for path in "$@"; do
+    # Strip leading ./ and skip blank entries.
+    path="${path#./}"
+    [[ -z "$path" ]] && continue
+
+    # crates/<pkg>/tests/<name>.rs — top-level integration test binary.
+    if [[ "$path" =~ ^crates/([^/]+)/tests/([^/]+)\.rs$ ]]; then
+        add_filter "binary(${BASH_REMATCH[2]})"
+        continue
+    fi
+
+    # crates/<pkg>/tests/<dir>/... — module file or shared support directory.
+    if [[ "$path" =~ ^crates/([^/]+)/tests/([^/]+)/ ]]; then
+        pkg="${BASH_REMATCH[1]}"
+        dir="${BASH_REMATCH[2]}"
+        if [[ -f "${repo_root}/crates/${pkg}/tests/${dir}.rs" ]]; then
+            add_filter "binary(${dir})"
+        else
+            add_filter "package(${pkg})"
+        fi
+        continue
+    fi
+
+    # crates/<pkg>/... — unit tests in src/ or any other package file.
+    if [[ "$path" =~ ^crates/([^/]+)/ ]]; then
+        add_filter "package(${BASH_REMATCH[1]})"
+        continue
+    fi
+done
+
+if [[ ${#filters[@]} -eq 0 ]]; then
+    exit 0
+fi
+
+result=""
+for f in "${filters[@]}"; do
+    if [[ -n "$result" ]]; then
+        result="$result or $f"
+    else
+        result="$f"
+    fi
+done
+
+printf '%s\n' "$result"


### PR DESCRIPTION
## Summary

Closes #1070. Implements Tier 2B of the de-flake epic (#1057).

- **`scripts/nextest_filters_from_paths.sh`** — translates touched file paths from `git diff` into a cargo-nextest filterset expression (`binary(X)` for integration test binaries, `package(X)` for source/unit-test changes and shared helper dirs).

- **`.config/nextest.toml`** — new `flake-detection` profile with `retries = 0`, `fail-fast = false`, and the same subprocess/leak-timeout overrides as the default profile to avoid false positives during the 50× loop.

- **`.github/workflows/flake-detection.yml`** — on every PR, computes touched test files via `git diff --name-only origin/main...HEAD`, generates the nextest filterset, then runs those tests **50× at `--test-threads=8`**. Skips the expensive steps cleanly when no test files are touched. Fails the check on the first flaky iteration.

- **`.github/workflows/thread-parity.yml`** — matrix job (`threads: [1, 8, 16]`, `fail-fast: false`) that runs the full workspace test suite under each thread count using the `ci` profile.

## Test plan

- [x] `actionlint` passes on both new workflow files (pre-commit hook + manual run)
- [x] TOML validated via `tomllib`; all three profiles (`default`, `ci`, `flake-detection`) parse cleanly
- [x] Filter script smoke-tested: no-args, top-level test file, subdir module, support/test_util dir (→ package fallback), source file, mixed dedup, non-crate paths ignored
- [x] Pre-push: 3133/3133 tests passed
- [ ] Verify both workflows appear as PR checks once this PR is open
- [ ] (Acceptance) Introduce a `rand::random::<f32>() < 0.05 { panic!() }` in a test on a draft PR and confirm the flake-detection gate fails

🤖 Generated with [Claude Code](https://claude.ai/claude-code)