### PR TITLE
Subscribe instead of poll in Notion/Linear connector tests

### DIFF
--- a/crates/harn-vm/src/connectors/linear/tests.rs
+++ b/crates/harn-vm/src/connectors/linear/tests.rs
@@ -490,7 +490,8 @@ async fn linear_client_supports_typed_methods_and_escape_hatch() {
 #[tokio::test]
 async fn linear_connector_monitor_reenables_webhook_after_probe_streak() {
     let requests = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
-    let server = spawn_monitor_server(requests.clone(), 3);
+    let probes_done = Arc::new(tokio::sync::Notify::new());
+    let server = spawn_monitor_server(requests.clone(), 3, probes_done.clone());
     let base_url = server.base_url().to_string();
     let mut binding = binding();
     binding.config = json!({
@@ -510,14 +511,9 @@ async fn linear_connector_monitor_reenables_webhook_after_probe_streak() {
     });
     let (connector, _) = connector_with_binding(binding).await;
 
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
-    while requests.lock().expect("requests lock").len() < 3 {
-        assert!(
-            std::time::Instant::now() < deadline,
-            "timed out waiting for monitor probes"
-        );
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
+    tokio::time::timeout(std::time::Duration::from_secs(1), probes_done.notified())
+        .await
+        .expect("timed out waiting for monitor probes");
     connector
         .shutdown(std::time::Duration::from_secs(1))
         .await
@@ -668,11 +664,12 @@ fn write_response_status(
 fn spawn_monitor_server(
     requests: Arc<Mutex<Vec<CapturedRequest>>>,
     expected_requests: usize,
+    probes_done: Arc<tokio::sync::Notify>,
 ) -> MockHttpServer {
     spawn_mock_http_server(
         expected_requests,
         "linear monitor server",
-        move |_index, _addr, raw, stream| {
+        move |index, _addr, raw, stream| {
             let request = capture_request(&requests, raw);
             match (request.method.as_str(), request.path.as_str()) {
                 ("GET", "/health") => {
@@ -704,6 +701,9 @@ fn spawn_monitor_server(
                     );
                 }
                 other => panic!("unexpected request {other:?}"),
+            }
+            if index + 1 == expected_requests {
+                probes_done.notify_one();
             }
         },
     )

--- a/crates/harn-vm/src/connectors/notion/tests.rs
+++ b/crates/harn-vm/src/connectors/notion/tests.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration as StdDuration;
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use serde_json::{json, Value as JsonValue};
 use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
@@ -515,18 +516,17 @@ async fn notion_poll_binding_emits_targeted_inbox_event_and_persists_high_water(
         }
     });
 
+    let inbox_topic = crate::event_log::Topic::new(TRIGGER_INBOX_ENVELOPES_TOPIC).unwrap();
+    let mut inbox_stream = log.clone().subscribe(&inbox_topic, None).await.unwrap();
+
     std::env::set_var("HARN_TEST_NOTION_API_BASE_URL", &base_url);
     connector.activate(&[binding]).await.unwrap();
 
-    for _ in 0..40 {
-        if !read_topic(&log, TRIGGER_INBOX_ENVELOPES_TOPIC)
-            .await
-            .is_empty()
-        {
-            break;
-        }
-        tokio::time::sleep(StdDuration::from_millis(25)).await;
-    }
+    tokio::time::timeout(StdDuration::from_secs(1), inbox_stream.next())
+        .await
+        .expect("timed out waiting for inbox envelope")
+        .expect("inbox stream closed before envelope arrived")
+        .expect("inbox subscribe yielded error");
 
     let inbox = read_topic(&log, TRIGGER_INBOX_ENVELOPES_TOPIC).await;
     assert_eq!(inbox.len(), 1);


### PR DESCRIPTION
## Summary

- **Notion poll test**: replaces the 40-iteration `tokio::time::sleep` loop on `read_topic` with `EventLog::subscribe()` on `TRIGGER_INBOX_ENVELOPES_TOPIC`, gated by `tokio::time::timeout` as the hard ceiling.
- **Linear monitor test**: replaces the `Instant::now()` deadline + 10ms sleep loop with a `tokio::sync::Notify` that the mock HTTP server signals after the expected probe count is reached, gated by `tokio::time::timeout`.

Both polling sites are entirely in-process — no cross-process barrier, just legacy polling code. Event-driven wakeups remove the polling latency and remove the dependence on a wall-clock deadline.

Originally stacked on top of #1081 (OrchestratorHarness). Now that #1081 has merged to main, this PR retargets to `main` directly. The earlier #1084 squash-merged into the orphaned head branch of #1081 and never reached `main`; that's why this is reopened here.

Closes #1065

## Acceptance criteria

- ✅ `grep -rn "tokio::time::sleep\|Instant::now()" crates/harn-vm/src/connectors/notion/tests.rs crates/harn-vm/src/connectors/linear/tests.rs` returns zero matches.
- ✅ 50× rerun: 50/50 passes (`for i in $(seq 50); do cargo nextest run -p harn-vm connectors::notion connectors::linear --no-fail-fast; done`).
- ✅ Wall-clock improvement: linear monitor case now completes in ~90ms (vs. the old 1s deadline ceiling); notion poll case completes in ~25ms (vs. up to 1s of polling).
- ✅ No follow-ups identified — the other connector test files (`webhook`, `github`, `slack`, `cron`) had no polling patterns.

## Test plan

- [x] `cargo nextest run -p harn-vm` (1648 tests pass)
- [x] `cargo clippy -p harn-vm --tests --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Pre-push hook ran full 3132-test workspace suite — all pass (twice — once on the original push, once after rebase onto main)
- [x] 50× targeted rerun — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)