### PR TITLE
Tier the test suite: fast push-hook suite + slow E2E job

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,6 +7,10 @@
 # bound a `TcpListener` in blocking mode have hung CI for many minutes).
 
 [profile.default]
+# Fast suite only — subprocess-spawning integration tests run via `make test-e2e`
+# (nextest profile "e2e"). This keeps the pre-push hook and PR suite under 2 min
+# on a warm cache. See CONTRIBUTING.md for the two-tier test model.
+default-filter = "not (package(harn-cli) and kind(test))"
 # Any test that runs longer than 15s is considered "slow"; if it exceeds
 # the 60s hard cap three times it is terminated so the suite keeps moving.
 slow-timeout = { period = "15s", terminate-after = 4, grace-period = "5s" }
@@ -24,9 +28,23 @@ leak-timeout = { period = "5s", result = "fail" }
 fail-fast = false
 
 # CI profile is stricter: one warning at 30s, hard kill at 120s.
+# Inherits the same default-filter as the default profile (fast suite only).
 [profile.ci]
+default-filter = "not (package(harn-cli) and kind(test))"
 slow-timeout = { period = "30s", terminate-after = 4, grace-period = "10s" }
 leak-timeout = { period = "5s", result = "fail" }
+fail-fast = false
+failure-output = "immediate-final"
+success-output = "never"
+
+# E2E profile: subprocess-spawning integration tests — CLI invocation, signal
+# handling, MCP server launch, real ProcessHandle, real process tools.
+# Run with `make test-e2e` or `cargo nextest run --profile e2e`.
+# Triggered nightly, on the `e2e` PR label, and on merge-queue.
+[profile.e2e]
+default-filter = "package(harn-cli) and kind(test)"
+slow-timeout = { period = "60s", terminate-after = 3, grace-period = "15s" }
+leak-timeout = { period = "15s", result = "pass" }
 fail-fast = false
 failure-output = "immediate-final"
 success-output = "never"
@@ -156,3 +174,10 @@ leak-timeout = { period = "10s", result = "pass" }
 [[profile.flake-detection.overrides]]
 filter = "package(harn-dap)"
 test-group = "harn-dap"
+
+# E2E profile overrides: throttle subprocess concurrency the same way the
+# default/ci profiles do so nightly runs stay deterministic.
+[[profile.e2e.overrides]]
+filter = "package(harn-cli) and kind(test)"
+test-group = "harn-subprocess"
+leak-timeout = { period = "15s", result = "pass" }

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -51,7 +51,16 @@ fi
 
 echo "=== Pre-push: running fast release-quality checks ==="
 if hook_paths_match "$changed" "$HOOK_TEST_PATTERN"; then
-  make test
+  test_start=$(date +%s)
+  make test || exit 1
+  test_elapsed=$(( $(date +%s) - test_start ))
+  if [ "$test_elapsed" -gt 120 ]; then
+    echo ""
+    echo "error: pre-push 'make test' exceeded 120s budget (took ${test_elapsed}s)" >&2
+    echo "hint: Move slow tests to the e2e suite (cargo nextest profile 'e2e')." >&2
+    echo "      See CONTRIBUTING.md for the two-tier test model." >&2
+    exit 2
+  fi
 else
   echo "=== Pre-push: skipping Rust/Harn tests (no code changes) ==="
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,11 +183,33 @@ jobs:
       - run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
       - run: make lint-actions
 
+  e2e:
+    name: Slow E2E suite
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e'))
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        continue-on-error: true
+        with:
+          shared-key: e2e
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
+        with:
+          tool: nextest@0.9.133
+      - run: make test-e2e
+        env:
+          NEXTEST_PROFILE: e2e
+
   check-status:
     name: Check status
     runs-on: ubuntu-latest
     if: always()
-    needs: [fmt, lint-md, rust, windows, portal, actions]
+    needs: [fmt, lint-md, rust, windows, portal, actions, e2e]
     steps:
       - name: Verify required CI jobs
         run: |
@@ -206,6 +228,15 @@ jobs:
           echo "Rust on Windows (build + smoke test): $windows_result"
           if [ "$windows_result" != "success" ] && [ "$windows_result" != "skipped" ]; then
             echo "::error::Windows job failed."
+            exit 1
+          fi
+
+          # The E2E job only runs on merge_group and PRs with the `e2e` label.
+          # Treat `skipped` as passing so regular PRs are not blocked.
+          e2e_result="${{ needs.e2e.result }}"
+          echo "Slow E2E suite: $e2e_result"
+          if [ "$e2e_result" != "success" ] && [ "$e2e_result" != "skipped" ]; then
+            echo "::error::E2E job failed."
             exit 1
           fi
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,46 @@
+name: E2E
+
+# Slow E2E / smoke suite — subprocess-spawning binary surface tests.
+# Runs:
+#   - nightly (3 AM UTC)
+#   - when the `e2e` label is added to a pull request
+#   - manually via workflow_dispatch
+#
+# The merge-queue E2E run lives in ci.yml (needs the same check-status gate).
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  e2e:
+    name: Slow E2E suite
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e'))
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        continue-on-error: true
+        with:
+          shared-key: e2e
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
+        with:
+          tool: nextest@0.9.133
+      - run: make test-e2e
+        env:
+          NEXTEST_PROFILE: e2e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,29 @@ What triggers a cold rebuild:
 On macOS, Spotlight may index freshly-linked test binaries on first run,
 adding ~30–60 s of stat traffic unrelated to cargo.
 
+### Test tiers
+
+The workspace splits tests into two tiers to keep the pre-push hook fast:
+
+**Fast suite** — `make test`
+
+In-process, deterministic, zero subprocess-per-test. Wall-clock budget: <2 min
+on a warm cache. Runs automatically on pre-push and on every PR. The nextest
+`default` and `ci` profiles exclude the `harn-cli` integration test binaries
+(those live in `crates/harn-cli/tests/` and spawn the compiled `harn` binary as
+a subprocess).
+
+**Slow E2E suite** — `make test-e2e`
+
+Subprocess-spawning binary surface tests: CLI invocation, signal handling, MCP
+server launch, real `ProcessHandle` smoke, orchestrator drain/replay, etc. Uses
+the nextest `e2e` profile, which targets `package(harn-cli) and kind(test)`.
+Runs on:
+
+- Schedule — nightly at 3 AM UTC (`.github/workflows/e2e.yml`)
+- `e2e` PR label — add the label to opt in before merge
+- Merge-queue — the `e2e` job in `ci.yml` runs before a PR lands
+
 ### Preferred Rust test path
 
 `make test` is the default Rust workspace test entry point. When
@@ -63,12 +86,13 @@ manually:
 
 ```bash
 cargo install cargo-nextest --locked
-make test
+make test       # fast suite
+make test-e2e   # slow E2E suite (requires nextest)
 ```
 
 The workspace `.config/nextest.toml` applies a 15 s slow-test threshold by
 default and a 60 s hard termination cap. Tests that legitimately need more
-time (the LLM transport tests) have targeted overrides.
+time (the LLM transport tests, E2E subprocess tests) have targeted overrides.
 
 If you need the baseline Cargo behavior explicitly, use:
 
@@ -84,6 +108,7 @@ make bench-vm    # opt-in interpreter microbenchmark suite
 make portal      # launch the local Harn observability portal
 make setup       # rerun repo bootstrap
 make test-cargo  # force plain cargo test --workspace
+make test-e2e    # run slow E2E / smoke suite
 ```
 
 This runs:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-cargo test-fast conformance protocol-conformance bench-vm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec lint-test-patterns
+.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast conformance protocol-conformance bench-vm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec lint-test-patterns
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
@@ -36,9 +36,11 @@ fmt:
 lint:
 	cargo clippy --workspace --all-targets -- -D warnings
 
-# Run Rust unit tests via cargo-nextest when available for better whole-workspace
-# parallelism and bounded timeouts (see .config/nextest.toml). Falls back to
-# `cargo test --workspace` when nextest is not installed.
+# Run the fast (in-process, deterministic) test suite via cargo-nextest.
+# Subprocess-spawning integration tests are excluded by the nextest "default"
+# profile's default-filter. Run `make test-e2e` for the slow E2E suite.
+# Falls back to `cargo test --workspace` when nextest is not installed
+# (cargo test has no profile support, so it will run all tests).
 test:
 	@if command -v cargo-nextest >/dev/null 2>&1; then \
 		HARN_LLM_CALLS_DISABLED=1 cargo nextest run --workspace; \
@@ -47,6 +49,13 @@ test:
 		echo "hint: run 'make setup' or 'cargo install cargo-nextest --locked'"; \
 		HARN_LLM_CALLS_DISABLED=1 cargo test --workspace; \
 	fi
+
+# Run the slow E2E / smoke suite: subprocess-spawning CLI surface tests,
+# signal handling, MCP server launch, real ProcessHandle smoke tests, etc.
+# Runs on schedule (nightly), on the `e2e` PR label, and on merge-queue.
+# Requires cargo-nextest (no plain `cargo test` fallback for profile support).
+test-e2e:
+	HARN_LLM_CALLS_DISABLED=1 cargo nextest run --workspace --profile e2e
 
 # Run the baseline Cargo workspace test command explicitly.
 test-cargo:


### PR DESCRIPTION
## Summary

Closes #1069.

- **Fast suite** (`make test`, nextest `default`/`ci` profiles): adds `default-filter = "not (package(harn-cli) and kind(test))"` so the 15 subprocess-spawning integration test binaries are excluded. Pre-push hook now enforces a 120-second wall-clock budget with an error exit and actionable hint if exceeded. Verified: **3041 tests across 33 binaries, 15 binaries skipped** on the push run.
- **Slow E2E suite** (`make test-e2e`, nextest `e2e` profile): `default-filter = "package(harn-cli) and kind(test)"` — exactly those 15 integration test binaries. Inherits the `harn-subprocess` group (max-threads=8) for deterministic nightly runs. No file renames needed; the existing `kind(test)` filterset is sufficient.
- **`ci.yml`**: new `e2e` job runs `make test-e2e` on `merge_group` and the `e2e` PR label. `check-status` treats `e2e` as optional (skipped = passing) on plain PRs.
- **`.github/workflows/e2e.yml`**: new nightly workflow (03:00 UTC) + label-triggered + `workflow_dispatch`.
- **`CONTRIBUTING.md`**: documents the two-tier model, trigger conditions, and `make test-e2e`.

## Test plan

- [x] `cargo nextest list --workspace --profile e2e` shows exactly the 15 `harn-cli` integration test binaries (all of `crates/harn-cli/tests/*.rs`)
- [x] `cargo nextest list --workspace` (default profile) shows zero `harn-cli` integration test binaries
- [x] Pre-push hook ran the fast suite: 3041 tests, 15 binaries skipped — push succeeded
- [x] `actionlint` clean on both `ci.yml` and `e2e.yml`
- [x] Pre-commit (clippy + markdownlint) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)