### PR TITLE
Lint and document deterministic test patterns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
       - run: make check-connector-matrix
       - run: make check-trigger-examples
       - run: make check-docs-snippets
+      - run: make lint-test-patterns
       - run: python3 scripts/verify_release_metadata.py
 
   changes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,11 @@ at `.claude/skills/harn-scripting/SKILL.md`.
   `npm run portal:build`.
 - If you change the VS Code extension, run `(cd editors/vscode && npm run compile)`.
 - If you change tree-sitter grammar or queries, run `(cd tree-sitter-harn && npm test)`.
+- Do not add `std::thread::sleep`, `tokio::time::sleep`, `Instant::now()` polling loops,
+  `SystemTime::now()`, or short `recv_timeout` calls to test files. These patterns are banned
+  by `make lint-test-patterns`. Use `tokio::time::pause()`/`advance()`, `EventLog::subscribe()`,
+  or `OrchestratorHarness` instead. See `docs/dev/testing.md` for approved patterns and the
+  opt-out procedure.
 
 ## Generated Files And Sync Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,23 @@ Tests live under `conformance/tests/` (passing) and `conformance/errors/`
 runner discovers `.harn` files recursively, so just drop new tests into
 the subdirectory that best matches their area.
 
+## Writing tests
+
+Wall-clock waits are banned in test files. Do not use `std::thread::sleep`,
+`tokio::time::sleep` (outside a `start_paused = true` test), `Instant::now()`
+polling loops, `SystemTime::now()`, or short `recv_timeout` calls. The
+`make lint-test-patterns` step in CI enforces this.
+
+Use the approved alternatives instead:
+
+- `tokio::time::pause()` + `advance()` for simulating time in async tests
+- `EventLog::subscribe()` + `tokio::time::timeout` for waiting on events
+- `OrchestratorHarness` for orchestrator tests that do not need real subprocesses
+
+See [`docs/src/dev/testing.md`](docs/src/dev/testing.md) for detailed guidance,
+common pitfalls, and the opt-out procedure for cases where a wall-clock wait is
+genuinely unavoidable.
+
 ## Code style
 
 - Clippy warnings are treated as errors -- fix all warnings before committing

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-cargo test-fast conformance protocol-conformance bench-vm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec
+.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-cargo test-fast conformance protocol-conformance bench-vm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec lint-test-patterns
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test conformance protocol-conformance check-highlight check-language-spec check-trigger-quickref check-provider-matrix check-connector-matrix check-trigger-examples check-docs-snippets portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test conformance protocol-conformance check-highlight check-language-spec check-trigger-quickref check-provider-matrix check-connector-matrix check-trigger-examples check-docs-snippets lint-test-patterns portal-check
 
 check: all
 
@@ -232,3 +232,8 @@ check-trigger-examples:
 check-docs-snippets:
 	@echo "=== Checking docs snippets parse under harn check ==="
 	@./scripts/check_docs_snippets.sh
+
+# Lint test files for wall-clock polling patterns that cause flaky tests.
+# See docs/dev/testing.md for approved alternatives and the opt-out mechanism.
+lint-test-patterns:
+	@./scripts/lint_test_patterns.sh

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -117,6 +117,7 @@
 - [Deploy to Railway](./deploy/railway.md)
 - [Maintainer release workflow](./maintainer-release.md)
 - [Windows test coverage](./dev/windows-test-coverage.md)
+- [Deterministic test patterns](./dev/testing.md)
 
 # Tutorials and Guides
 

--- a/docs/src/dev/testing.md
+++ b/docs/src/dev/testing.md
@@ -1,0 +1,185 @@
+# Deterministic test patterns
+
+This page documents how to write fast, deterministic tests in the Harn
+workspace. It explains the approved patterns, the patterns that are banned by
+`make lint-test-patterns`, how to opt out when a ban is unavoidable, and how to
+write tests that need real subprocesses.
+
+## Background
+
+A multi-tier deflake effort ([#1057]) removed wall-clock polling from the fast
+test suite. Before that work, many unit and integration tests used patterns like
+`tokio::time::sleep(Duration::from_millis(50))` or polling loops driven by
+`Instant::now()`. These patterns caused the suite to be sensitive to scheduler
+jitter and system load, and were the primary source of intermittent failures on
+CI and slow developer machines.
+
+The lint at `scripts/lint_test_patterns.sh` (run by `make lint-test-patterns`)
+enforces that new test code does not reintroduce these patterns.
+
+[#1057]: https://github.com/burin-labs/harn/issues/1057
+
+## Approved patterns
+
+### `tokio::time::pause()` and `advance()`
+
+For tests that need to simulate time passing, use Tokio's paused-time runtime.
+A test annotated with `start_paused = true` starts with the clock frozen at an
+arbitrary epoch and advances only when you call `tokio::time::advance()`.
+
+```rust
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn timeout_fires_after_deadline() {
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = tx.send(());
+    });
+
+    // Advance 6 seconds in zero wall-clock time.
+    tokio::time::advance(Duration::from_secs(6)).await;
+    assert!(rx.await.is_ok());
+}
+```
+
+**Caveats:**
+
+- `start_paused = true` only works with `flavor = "current_thread"`. The
+  multi-thread runtime shares a real monotonic clock and cannot be paused.
+- `tokio::time::advance()` only drives Tokio timers (`sleep`, `timeout`,
+  `interval`). It does not advance `SystemTime::now()`, `Instant::now()`, or
+  any file-descriptor-backed timer. If your code mixes Tokio timers with
+  wall-clock reads, both need injection.
+- Do not mix `start_paused = true` tests with code that touches real I/O
+  (network, file system). The paused runtime will not drive completion events
+  from the OS while time is frozen; a real TCP write behind a `tokio::time::sleep`
+  may never complete.
+
+### `EventLog::subscribe()`
+
+For tests that wait for something to happen inside a running component,
+subscribe to its `EventLog` and block on the channel with a `tokio::time::timeout`
+ceiling.
+
+```rust
+let (log, handle) = EventLog::new();
+let mut sub = log.subscribe("trigger.outbox").await;
+
+// Trigger the action under test.
+component.do_thing().await;
+
+// Wait for the expected event — hard fail-fast after 5 s.
+let event = tokio::time::timeout(Duration::from_secs(5), sub.recv())
+    .await
+    .expect("timed out waiting for trigger.outbox event")
+    .expect("channel closed");
+
+assert_eq!(event.kind, "dispatch");
+```
+
+The `tokio::time::timeout` here is the right pattern: it is a hard ceiling that
+turns a hang into a fast failure. Pair it with a meaningful error message so the
+failure is obvious.
+
+### `OrchestratorHarness`
+
+For tests that need the orchestrator running but do not need real subprocesses,
+use `OrchestratorHarness` from the test-util crate. It boots the orchestrator
+in-process with an injectable clock and exposes event subscriptions so tests can
+wait deterministically.
+
+### `MockProcess`
+
+For subprocess tests that do not need real shell behavior, use `MockProcess`.
+It exposes a synchronous control channel so the test drives process state
+(exit code, stdout lines, signal receipt) without polling.
+
+## Forbidden patterns
+
+The following patterns are banned in test files by `make lint-test-patterns`.
+The script searches files under `crates/**/tests/**/*.rs`,
+`crates/**/src/**/tests.rs`, and `crates/**/src/**/tests_*.rs`.
+
+| Pattern | Why it is banned | Approved alternative |
+|---|---|---|
+| `std::thread::sleep(` | Blocks the thread, races against scheduler | `tokio::time::pause()` + `advance()` |
+| `tokio::time::sleep(` (outside `start_paused`) | Non-deterministic; races against system load | `start_paused = true` + `advance()` |
+| `while … Instant::now()` | Wall-clock polling loop; flaky under load | `EventLog::subscribe()` + `timeout` |
+| `SystemTime::now()` in tests | Real wall-clock timestamp; non-reproducible | `MockClock` or injected timestamp |
+| `recv_timeout(Duration::from_millis(…))` | Busy-wait with a short literal timeout | `tokio::time::timeout` with event channel |
+
+## Opting out
+
+If you are writing a test that genuinely cannot use any of the approved
+patterns — typically because it exercises real subprocess I/O or a syscall that
+has no deterministic equivalent — you have two options:
+
+1. **Move the test to the slow E2E suite** (see below). Subprocess tests belong
+   in files named `*_e2e.rs` or under `tests/` directories that are not part
+   of the fast nextest run.
+
+2. **Add the file to the per-pattern allowlist in `scripts/lint_test_patterns.sh`.**
+   Open a PR that adds your file to the appropriate array (`THREAD_SLEEP_ALLOWLIST`,
+   `TOKIO_SLEEP_ALLOWLIST`, etc.), includes a one-line comment in the array entry
+   explaining why the opt-out is justified, and gets a second reviewer sign-off.
+   The allowlist is public and tracked as technical debt; entries are expected to
+   shrink, not grow, as the codebase matures.
+
+## Writing subprocess tests in the slow E2E suite
+
+Real subprocess tests — those that spawn `harn` as a child process, send signals,
+or read real file output — belong in files ending `_e2e.rs` or under the
+`crates/harn-cli/tests/` tree that is excluded from the sub-second nextest profile.
+
+These tests are subject to different rules:
+
+- Wall-clock timeouts (`Instant::now()` deadlines, `recv_timeout`) are acceptable
+  because there is no deterministic alternative for real process I/O.
+- Use named constants (`EVENT_FAIL_FAST_TIMEOUT`, `PROCESS_FAIL_FAST_TIMEOUT`)
+  rather than inline `Duration::from_millis(…)` literals so timeout values are
+  easy to audit and tune centrally.
+- Always provide a human-readable timeout message so a failure says _what_ timed
+  out, not just that an assertion failed.
+- Prefer `tokio::time::timeout` over `recv_timeout` even in E2E tests; it
+  composes better with async code and gives cleaner error messages.
+
+## Using `tokio::time::pause()` — common mistakes
+
+### Multi-thread flavor
+
+```rust
+// WRONG — start_paused only works with current_thread.
+#[tokio::test(flavor = "multi_thread", start_paused = true)]
+async fn broken() { … }
+```
+
+Use `flavor = "current_thread"` for paused-time tests.
+
+### Real I/O behind a Tokio timer
+
+```rust
+// WRONG — the TCP read will never complete while time is paused.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn broken() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    tokio::time::sleep(Duration::from_millis(10)).await; // pause doesn't drive I/O
+    let _ = listener.accept().await; // hangs
+}
+```
+
+If your test needs both time control and real I/O, use the multi-thread runtime
+and a `tokio::time::timeout` ceiling instead of `start_paused`.
+
+### `advance()` semantics
+
+`tokio::time::advance(d)` adds `d` to the Tokio clock and polls all pending
+timers that would fire within that window. It does not yield to other tasks
+automatically; if the task that sets a timer has not yet been polled to
+register it, `advance()` may appear to do nothing.
+
+The fix is to yield once before advancing:
+
+```rust
+tokio::task::yield_now().await;
+tokio::time::advance(Duration::from_secs(1)).await;
+```

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# Lint script that fails if wall-clock polling patterns appear in test files
+# outside an explicit per-pattern allowlist. Part of the deflake epic (#1057).
+#
+# These patterns cause flaky tests because they race against scheduler
+# behavior and system load. The approved replacements use injected time
+# (tokio::time::pause/advance), event subscriptions, or deterministic
+# harnesses.
+#
+# Usage: ./scripts/lint_test_patterns.sh
+#   Exits 0 if no violations found, 1 otherwise.
+#
+# To suppress a false-positive, add the file to the appropriate per-pattern
+# allowlist below with a brief comment explaining why. All suppressions are
+# pre-existing technical debt tracked under the deflake epic; new entries
+# require explicit reviewer justification.
+#
+# Pending Tier 1A (#1057): spawn_orchestrator / harn_command checks are
+# commented-out below. Enable them once Tier 1A renames those helpers.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# ---------------------------------------------------------------------------
+# Per-pattern allowlists — pre-existing violations from before the deflake
+# epic. Remove entries as each tier of #1057 completes.
+# ---------------------------------------------------------------------------
+
+# std::thread::sleep in test files
+# Legitimate uses: waiting on real subprocess I/O that cannot be time-paused.
+THREAD_SLEEP_ALLOWLIST=(
+  "crates/harn-hostlib/tests/process_tools.rs"
+  "crates/harn-cli/tests/test_util/process.rs"
+)
+
+# tokio::time::sleep in test files (outside start_paused = true tests)
+# Legitimate uses: connector integration tests polling real async state.
+TOKIO_SLEEP_ALLOWLIST=(
+  "crates/harn-vm/src/connectors/notion/tests.rs"
+  "crates/harn-vm/src/connectors/linear/tests.rs"
+  "crates/harn-vm/src/triggers/dispatcher/tests/retry.rs"
+  "crates/harn-vm/src/orchestration/tests.rs"
+  "crates/harn-vm/src/stdlib/workflow/tests.rs"
+  "crates/harn-cli/tests/test_util/timing.rs"
+)
+
+# Instant::now() in a while-loop condition — wall-clock polling.
+# All entries below are subprocess/orchestrator integration tests that poll
+# real process output; they will be refactored by Tier 1A/1B of #1057.
+INSTANT_NOW_WHILE_ALLOWLIST=(
+  "crates/harn-vm/src/triggers/dispatcher/tests/retry.rs"
+  "crates/harn-cli/tests/orchestrator_cli.rs"
+  "crates/harn-cli/tests/orchestrator_inbox_dedupe.rs"
+  "crates/harn-cli/tests/orchestrator_http/support.rs"
+  "crates/harn-cli/tests/orchestrator_http/admin.rs"
+  "crates/harn-cli/tests/orchestrator_http/observability.rs"
+  "crates/harn-cli/tests/harn_serve_mcp_cli.rs"
+  "crates/harn-cli/tests/support/mcp.rs"
+  "crates/harn-cli/tests/support/mod.rs"
+  "crates/harn-cli/tests/test_util/process.rs"
+)
+
+# SystemTime::now() in test files — use injected clock / MockClock instead.
+SYSTEM_TIME_ALLOWLIST=(
+  "crates/harn-vm/src/triggers/dispatcher/tests/dispatch.rs"
+  "crates/harn-vm/src/http/tests.rs"
+  "crates/harn-vm/src/stdlib/template/tests.rs"
+  "crates/harn-hostlib/tests/scanner_e2e.rs"
+  "crates/harn-cli/tests/orchestrator_cli.rs"
+  "crates/harn-cli/src/commands/check/tests.rs"
+)
+
+# recv_timeout with an explicit sub-second Duration literal.
+# Named-constant variants (LOG_RECV_POLL_INTERVAL etc.) are not caught here
+# because the constant value cannot be resolved by a static text search.
+RECV_TIMEOUT_MILLIS_ALLOWLIST=(
+  "crates/harn-cli/tests/harn_serve_mcp_cli.rs"
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+violations=0
+
+# Check if a path is in a given allowlist (bash array passed by name).
+in_allowlist() {
+  local path="$1"
+  local -n _list="$2"
+  # Normalize to a path relative to the repo root for comparison.
+  local rel="${path#"$ROOT_DIR/"}"
+  for entry in "${_list[@]}"; do
+    if [[ "$rel" == "$entry" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Collect test file paths into a temp file so we can reuse the list.
+TEST_FILES_TMP="$(mktemp)"
+trap 'rm -f "$TEST_FILES_TMP"' EXIT
+
+{
+  # crates/**/tests/**/*.rs — any depth under a tests/ directory
+  find crates -type f -name "*.rs" -path "*/tests/*"
+  # crates/**/src/**/tests.rs and tests_*.rs — inline test modules
+  find crates -type f \( -name "tests.rs" -o -name "tests_*.rs" \) -path "*/src/*"
+} | sort -u > "$TEST_FILES_TMP"
+
+# check_pattern PATTERN ALLOWLIST_VAR SUGGESTION
+#   Greps PATTERN across test files, skipping allowlisted files.
+#   Prints file:line for each violation and increments $violations.
+check_pattern() {
+  local pattern="$1"
+  local allowlist_var="$2"
+  local suggestion="$3"
+
+  while IFS= read -r file; do
+    in_allowlist "$file" "$allowlist_var" && continue
+    while IFS= read -r hit; do
+      [[ -z "$hit" ]] && continue
+      echo "  $hit"
+      echo "    hint: $suggestion"
+      violations=$((violations + 1))
+    done < <(grep -n -- "$pattern" "$file" 2>/dev/null || true)
+  done < "$TEST_FILES_TMP"
+}
+
+# ---------------------------------------------------------------------------
+# Pattern checks
+# ---------------------------------------------------------------------------
+
+echo "=== Checking test files for wall-clock patterns ==="
+
+echo "--- std::thread::sleep ---"
+check_pattern \
+  "std::thread::sleep\|thread::sleep(Duration\|thread::sleep(std::time" \
+  THREAD_SLEEP_ALLOWLIST \
+  "Use tokio::time::pause() + advance(), or wait on an event/channel instead."
+
+echo "--- tokio::time::sleep ---"
+check_pattern \
+  "tokio::time::sleep(" \
+  TOKIO_SLEEP_ALLOWLIST \
+  "Use tokio::time::pause() + advance() in a #[tokio::test(start_paused = true)] context."
+
+echo "--- Instant::now() in while-loop (wall-clock poll) ---"
+check_pattern \
+  "while.*Instant::now\|while.*std::time::Instant::now" \
+  INSTANT_NOW_WHILE_ALLOWLIST \
+  "Subscribe to an EventLog channel or use a deterministic OrchestratorHarness instead."
+
+echo "--- SystemTime::now() in tests ---"
+check_pattern \
+  "SystemTime::now()\|std::time::SystemTime::now()" \
+  SYSTEM_TIME_ALLOWLIST \
+  "Inject a MockClock or use the stdlib clock() builtin via a test harness."
+
+echo "--- recv_timeout with explicit sub-second Duration ---"
+check_pattern \
+  "recv_timeout(Duration::from_millis\|recv_timeout(Duration::from_nanos\|recv_timeout(Duration::from_micros" \
+  RECV_TIMEOUT_MILLIS_ALLOWLIST \
+  "Use an event-driven wait (channel recv with tokio::time::timeout) instead of busy-polling."
+
+# ---------------------------------------------------------------------------
+# Tier 1A gate — enable once Tier 1A of #1057 renames these helpers.
+# Uncomment both blocks below after that cleanup lands.
+# ---------------------------------------------------------------------------
+#
+# echo "--- spawn_orchestrator outside *_e2e.rs ---"
+# while IFS= read -r file; do
+#   [[ "$file" == *_e2e.rs ]] && continue
+#   while IFS= read -r hit; do
+#     [[ -z "$hit" ]] && continue
+#     echo "  $hit"
+#     echo "    hint: spawn_orchestrator is E2E-only; use OrchestratorHarness in fast tests."
+#     violations=$((violations + 1))
+#   done < <(grep -n "spawn_orchestrator(" "$file" 2>/dev/null || true)
+# done < "$TEST_FILES_TMP"
+#
+# echo "--- harn_command outside *_e2e.rs ---"
+# while IFS= read -r file; do
+#   [[ "$file" == *_e2e.rs ]] && continue
+#   while IFS= read -r hit; do
+#     [[ -z "$hit" ]] && continue
+#     echo "  $hit"
+#     echo "    hint: harn_command is E2E-only; use OrchestratorHarness in fast tests."
+#     violations=$((violations + 1))
+#   done < <(grep -n "harn_command(" "$file" 2>/dev/null || true)
+# done < "$TEST_FILES_TMP"
+
+# ---------------------------------------------------------------------------
+echo
+if (( violations > 0 )); then
+  echo "FAIL: $violations wall-clock pattern violation(s) found in test files."
+  echo
+  echo "Forbidden patterns cause flaky tests. See docs/dev/testing.md for"
+  echo "approved alternatives and how to opt out with reviewer justification."
+  exit 1
+else
+  echo "OK: no wall-clock pattern violations found."
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/lint_test_patterns.sh` (`make lint-test-patterns`) — bans wall-clock polling in test files: `std::thread::sleep`, `tokio::time::sleep` outside `start_paused` tests, `while … Instant::now()` polling loops, `SystemTime::now()`, and short `recv_timeout(Duration::from_millis(…))` calls
- Wires `make lint-test-patterns` into the `rust` CI job as a required check; existing violations are tracked in per-pattern allowlists inside the script and will shrink as each tier of [#1057] completes
- Adds `docs/src/dev/testing.md` — covers approved alternatives (`tokio::time::pause`/`advance`, `EventLog::subscribe`, `OrchestratorHarness`), opt-out procedure, E2E guidance, and common `start_paused` pitfalls
- Updates `CLAUDE.md` and `CONTRIBUTING.md` to point at the new doc and remind contributors that wall-clock waits are banned in fast tests

Closes #1071

## Test plan

- [x] `make lint-test-patterns` exits 0 on current main (all existing violations are allowlisted)
- [x] Adding `tokio::time::sleep(Duration::from_millis(100))` to a new test file fails `make lint-test-patterns` with a clear error and hint
- [x] Markdown lint passes on `docs/src/dev/testing.md`
- [x] Pre-push hook passes (format, md-lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)