### PR TITLE
Remove wall-clock timing assertions from tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,6 +1759,7 @@ version = "0.7.52"
 dependencies = [
  "anyhow",
  "base64",
+ "criterion",
  "filetime",
  "globset",
  "grep-matcher",

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -297,11 +297,13 @@ fn seed_legacy_inbox_records(temp: &TempDir) {
     let log = harn_vm::event_log::open_event_log(&config).unwrap();
 
     let legacy_topic = Topic::new(harn_vm::TRIGGER_INBOX_LEGACY_TOPIC).unwrap();
-    let future_expiry_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as i64
-        + 60_000;
+    // Use `i64::MAX` so the dedupe claim is treated as still-active for the
+    // duration of the test regardless of wall-clock skew on shared CI.
+    // `InboxIndex` checks `claim.expires_at_ms > now_ms` (see
+    // `crates/harn-vm/src/triggers/inbox.rs`); a never-expiring fixture lets
+    // us assert the legacy record is honored without scheduling a real
+    // expiry deadline against `SystemTime::now()`.
+    let future_expiry_ms = i64::MAX;
     futures::executor::block_on(log.append(
         &legacy_topic,
         LogEvent::new(

--- a/crates/harn-hostlib/Cargo.toml
+++ b/crates/harn-hostlib/Cargo.toml
@@ -78,5 +78,10 @@ tree-sitter-r = "1.2"
 tempfile = "3"
 serde_json = "1"
 filetime = "0.2"
+criterion = "0.7"
 harn-lexer = { path = "../harn-lexer", version = "0.7" }
 harn-parser = { path = "../harn-parser", version = "0.7" }
+
+[[bench]]
+name = "ast_parse"
+harness = false

--- a/crates/harn-hostlib/benches/ast_parse.rs
+++ b/crates/harn-hostlib/benches/ast_parse.rs
@@ -1,0 +1,64 @@
+//! Benchmark for the `hostlib_ast_parse_file` builtin warm-path latency.
+//!
+//! Replaces the `parse_file_meets_perf_budget_on_a_known_input` integration
+//! test (issue #564's 20ms target). Wall-clock budgets in unit tests flake on
+//! shared CI runners under contention; Criterion's statistical sampling tracks
+//! the same regression signal without that flake.
+//!
+//! Run with: `cargo bench --bench ast_parse`.
+
+use std::collections::BTreeMap;
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::slice;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use harn_hostlib::{ast::AstCapability, BuiltinRegistry, HostlibCapability};
+use harn_vm::VmValue;
+
+fn fixture_path(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/ast")
+        .join(rel)
+}
+
+fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in pairs {
+        map.insert((*k).into(), v.clone());
+    }
+    VmValue::Dict(Rc::new(map))
+}
+
+fn ast_registry() -> BuiltinRegistry {
+    let mut registry = BuiltinRegistry::new();
+    AstCapability.register_builtins(&mut registry);
+    registry
+}
+
+fn parse_file_warm(c: &mut Criterion) {
+    let registry = ast_registry();
+    let path = fixture_path("rust/source.rs");
+    let payload = dict(&[(
+        "path",
+        VmValue::String(Rc::from(path.to_string_lossy().as_ref())),
+    )]);
+    let entry = registry
+        .find("hostlib_ast_parse_file")
+        .expect("parse_file builtin registered");
+
+    // Warm up: first call pays a one-time grammar load.
+    let _ = (entry.handler)(slice::from_ref(&payload)).expect("warmup parse");
+
+    c.bench_function("ast_parse_file_warm_rust_source", |b| {
+        b.iter(|| {
+            let result = (entry.handler)(black_box(slice::from_ref(&payload)))
+                .expect("parse_file should succeed");
+            black_box(result);
+        });
+    });
+}
+
+criterion_group!(benches, parse_file_warm);
+criterion_main!(benches);

--- a/crates/harn-hostlib/tests/ast_builtins.rs
+++ b/crates/harn-hostlib/tests/ast_builtins.rs
@@ -6,10 +6,8 @@
 //! includes a perf smoke check against a known input.
 
 use std::collections::BTreeMap;
-use std::fs;
 use std::path::PathBuf;
 use std::rc::Rc;
-use std::time::Instant;
 
 use harn_hostlib::{ast::AstCapability, BuiltinRegistry, HostlibCapability};
 use harn_vm::VmValue;
@@ -165,35 +163,10 @@ fn outline_caps_depth_when_max_depth_supplied() {
     }
 }
 
-/// Perf smoke test from issue #564: parse a known file within a budget.
-/// We don't pin the exact cutoff because tree-sitter performance varies
-/// across CI machines, but a 20ms budget is comfortable on local dev
-/// hardware and gives ample headroom on CI.
-#[test]
-fn parse_file_meets_perf_budget_on_a_known_input() {
-    let registry = ast_registry();
-    // Use the largest fixture we ship (Rust). Running against an in-tree
-    // fixture keeps the test hermetic and CI-friendly.
-    let path = fixture_path("rust/source.rs");
-    let payload = dict(&[(
-        "path",
-        VmValue::String(Rc::from(path.to_string_lossy().as_ref())),
-    )]);
-
-    // Warm up: first call sometimes pays a one-time grammar load.
-    let _ = invoke(&registry, "hostlib_ast_parse_file", payload.clone());
-
-    let start = Instant::now();
-    let _ = invoke(&registry, "hostlib_ast_parse_file", payload);
-    let elapsed = start.elapsed();
-
-    // 20ms target from the issue. Doubled to 40ms here so the test is
-    // immune to noisy CI; the realistic warm-call latency is sub-1ms.
-    assert!(
-        elapsed.as_millis() < 40,
-        "parse_file took {elapsed:?} (>40ms ceiling)",
-    );
-}
+// Issue #564's 20ms parse-time target moved to a Criterion benchmark
+// (`benches/ast_parse.rs`). Wall-clock perf budgets in tests flake on
+// shared CI runners; Criterion's statistical sampling tracks the same
+// signal without that flake.
 
 // ---------------------------------------------------------------------------
 // Mutation + bracket-balance builtins (issue #775)
@@ -527,33 +500,8 @@ fn undefined_names_marks_unsupported_languages() {
     assert!(diagnostics.is_empty());
 }
 
-#[test]
-fn perf_smoke_against_external_file_when_available() {
-    // Optional maintainer smoke test for a larger real-world file. CI
-    // leaves this unset, so the test remains hermetic by default.
-    let target = std::env::var("HARN_AST_PERF_SMOKE_PATH")
-        .ok()
-        .map(PathBuf::from);
-    let Some(path) = target.filter(|p| p.exists()) else {
-        return;
-    };
-
-    let registry = ast_registry();
-    let payload = dict(&[(
-        "path",
-        VmValue::String(Rc::from(path.to_string_lossy().as_ref())),
-    )]);
-    let _warmup = invoke(&registry, "hostlib_ast_parse_file", payload.clone());
-    let start = Instant::now();
-    let _ = invoke(&registry, "hostlib_ast_parse_file", payload);
-    let elapsed = start.elapsed();
-    let bytes = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
-    eprintln!(
-        "external parse_file perf smoke: {elapsed:?} ({} bytes)",
-        bytes
-    );
-    assert!(
-        elapsed.as_millis() < 50,
-        "Package.swift parse took {elapsed:?} (>50ms)"
-    );
-}
+// `perf_smoke_against_external_file_when_available` (env-gated maintainer
+// perf check, never run in CI) was removed alongside the in-tree perf
+// budget assertion. Use `cargo bench --bench ast_parse` for parse latency
+// characterization; it runs against the in-tree fixture without depending
+// on a maintainer-local file.

--- a/crates/harn-hostlib/tests/code_index_scenario.rs
+++ b/crates/harn-hostlib/tests/code_index_scenario.rs
@@ -176,13 +176,8 @@ fn live_code_index_smoke() {
     let mut registry = BuiltinRegistry::new();
     cap.register_builtins(&mut registry);
 
-    let started = std::time::Instant::now();
     let files_indexed = rebuild(&registry, &path);
-    let elapsed = started.elapsed();
-    eprintln!(
-        "live code-index scenario rebuild: {files_indexed} files in {:.2}s",
-        elapsed.as_secs_f64()
-    );
+    eprintln!("live code-index scenario rebuild: {files_indexed} files");
     assert!(files_indexed > 0);
 
     assert_substring_query_finds(&registry, "TrigramIndex", &["TrigramIndex.swift"]);

--- a/crates/harn-hostlib/tests/scanner_e2e.rs
+++ b/crates/harn-hostlib/tests/scanner_e2e.rs
@@ -14,7 +14,7 @@
 
 use std::fs;
 use std::path::Path;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use harn_hostlib::scanner::{
     scan_incremental, scan_project, FileRecord, ScanProjectOptions, SymbolKind,
@@ -359,23 +359,12 @@ fn scan_project_self_smoke_test() {
         ..ScanProjectOptions::default()
     };
 
-    let start = std::time::Instant::now();
     let result = scan_project(workspace_root, opts);
-    let elapsed = start.elapsed();
 
     assert!(!result.files.is_empty(), "harn workspace should have files");
     assert!(
         !result.symbols.is_empty(),
         "harn workspace should have symbols"
-    );
-    const SOFT_BUDGET: Duration = Duration::from_secs(30);
-    const HARD_BUDGET: Duration = Duration::from_secs(120);
-    if elapsed > SOFT_BUDGET {
-        eprintln!("scan_project_self_smoke_test took {elapsed:?}, exceeded advisory budget");
-    }
-    assert!(
-        elapsed < HARD_BUDGET,
-        "scan took {elapsed:?}, exceeded {HARD_BUDGET:?} hard budget"
     );
 
     // Sanity: well-known top-level files show up.

--- a/crates/harn-vm/src/triggers/dispatcher/tests/dispatch.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests/dispatch.rs
@@ -211,11 +211,10 @@ async fn worker_handler_enqueues_job_and_returns_receipt() {
 
     let queue = crate::WorkerQueue::new(log.clone());
     let state = queue.queue_state("triage").await.expect("load queue state");
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock")
-        .as_millis() as i64;
-    assert_eq!(state.summary(now_ms).ready, 1);
+    // Use `i64::MAX` as the "now" reference so every enqueued job is past its
+    // scheduled `not_before` and counted as ready, independent of wall-clock
+    // drift between fixture setup and assertion.
+    assert_eq!(state.summary(i64::MAX).ready, 1);
     assert_eq!(state.jobs.len(), 1);
     assert_eq!(state.jobs[0].job.trigger_id, "github-worker-review");
     assert_eq!(state.jobs[0].job.priority, crate::WorkerQueuePriority::High);


### PR DESCRIPTION
## Summary

Closes #1066 (Tier 1G de-flake). Wall-clock budgets in unit/integration tests flake on shared CI runners under contention; performance claims belong in benchmarks.

- `crates/harn-hostlib/tests/scanner_e2e.rs` — drop the 30s soft / 120s hard budget on `scan_project_self_smoke_test`. Existing file-count and symbol invariants already cover the regression signal.
- `crates/harn-hostlib/tests/code_index_scenario.rs` — drop the elapsed-time `eprintln` from `live_code_index_smoke`.
- `crates/harn-hostlib/tests/ast_builtins.rs` — drop the 40ms ceiling on `parse_file_meets_perf_budget_on_a_known_input` (issue #564's 20ms target). Delete the env-gated maintainer-only `perf_smoke_against_external_file_when_available`.
- `crates/harn-cli/tests/orchestrator_cli.rs` — replace the `SystemTime::now() + 60_000` legacy-inbox dedupe-claim expiry fixture with `i64::MAX`.
- Discovered + fixed in the final grep pass: `crates/harn-vm/src/triggers/dispatcher/tests/dispatch.rs:214` — pass `i64::MAX` to `state.summary` so every enqueued job is past its `not_before`.

Adds `criterion` as a `harn-hostlib` dev-dep and registers `benches/ast_parse.rs` so `cargo bench --bench ast_parse` characterizes the warm parse path with statistical sampling instead of a noisy CI ceiling. Local run: ~106µs/iter on the in-tree Rust fixture (vs. the old 40ms wall-clock ceiling).

## Stacking

Stacked on top of #1081 (`ksinder/orchestrator-harness`). Base must merge first; the orchestrator_cli.rs edits live on top of that branch's split.

## Test plan

- [x] Targeted tests run clean: scanner_e2e, code_index_scenario, ast_builtins, orchestrator_queue_soft_migrates_legacy_inbox_topics, dispatch::worker_handler_enqueues_job_and_returns_receipt
- [x] 50× rerun passes for each touched test (50/50 pass on each — even with wide latency variation under load, demonstrating exactly why the wall-clock assertion was flaky)
- [x] `cargo bench --bench ast_parse` runs and reports a warm parse latency distribution
- [x] Final grep on the four issue-listed files: `Instant::now()` returns zero, `SystemTime::now()` returns zero (the only remaining match is in an explanatory comment, not code)
- [x] Out-of-scope timing assertions filed as #1088 (`check_cli.rs` 60s hang-regression budget, `workflow/tests.rs` virtual-time leak detector, slack ack-first harness elapsed-ms predicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)