### PR TITLE
Make dispatcher tests deterministic with tokio::time::pause

### DIFF
--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -64,6 +64,8 @@ thread_local! {
     static ACTIVE_DISPATCH_WAIT_LEASE: RefCell<Option<DispatchWaitLease>> = const { RefCell::new(None) };
     #[cfg(test)]
     static TEST_INBOX_DEQUEUED_SIGNAL: RefCell<Option<tokio::sync::oneshot::Sender<()>>> = const { RefCell::new(None) };
+    #[cfg(test)]
+    static TEST_INBOX_SUBSCRIBED_SIGNAL: RefCell<Option<tokio::sync::oneshot::Sender<()>>> = const { RefCell::new(None) };
 }
 
 tokio::task_local! {
@@ -642,6 +644,7 @@ impl Dispatcher {
             .expect("static trigger inbox envelopes topic is valid");
         let start_from = self.event_log.latest(&topic).await?;
         let stream = self.event_log.clone().subscribe(&topic, start_from).await?;
+        notify_test_inbox_subscribed();
         pin_mut!(stream);
         let mut cancel_rx = self.cancel_tx.subscribe();
 
@@ -3411,6 +3414,25 @@ fn notify_test_inbox_dequeued() {}
 #[cfg(test)]
 fn notify_test_inbox_dequeued() {
     TEST_INBOX_DEQUEUED_SIGNAL.with(|slot| {
+        if let Some(tx) = slot.borrow_mut().take() {
+            let _ = tx.send(());
+        }
+    });
+}
+
+#[cfg(test)]
+fn install_test_inbox_subscribed_signal(tx: tokio::sync::oneshot::Sender<()>) {
+    TEST_INBOX_SUBSCRIBED_SIGNAL.with(|slot| {
+        *slot.borrow_mut() = Some(tx);
+    });
+}
+
+#[cfg(not(test))]
+fn notify_test_inbox_subscribed() {}
+
+#[cfg(test)]
+fn notify_test_inbox_subscribed() {
+    TEST_INBOX_SUBSCRIBED_SIGNAL.with(|slot| {
         if let Some(tx) = slot.borrow_mut().take() {
             let _ = tx.send(());
         }

--- a/crates/harn-vm/src/triggers/dispatcher/tests/dispatch.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests/dispatch.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn local_handler_round_trip_logs_outbox_lifecycle_and_action_graph() {
     let local = tokio::task::LocalSet::new();
     local
@@ -71,7 +71,7 @@ pub fn should_handle(event: TriggerEvent) -> bool {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn local_handler_receives_raw_body_as_bytes() {
     let local = tokio::task::LocalSet::new();
     local
@@ -180,7 +180,7 @@ async fn a2a_handler_returns_inline_result_and_emits_a2a_action_graph() {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn worker_handler_enqueues_job_and_returns_receipt() {
     let (_dir, log, dispatcher) = worker_dispatcher_fixture(
         "triage".to_string(),

--- a/crates/harn-vm/src/triggers/dispatcher/tests/flow_control.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests/flow_control.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn flow_control_rate_limit_skips_excess_dispatches() {
     let local = tokio::task::LocalSet::new();
     local
@@ -76,7 +76,7 @@ pub fn local_fn(event: TriggerEvent) -> string {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn flow_control_throttle_waits_for_window() {
     let local = tokio::task::LocalSet::new();
     local
@@ -215,7 +215,7 @@ pub fn slow_handler(event: TriggerEvent) -> string {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn waitpoint_wait_releases_singleton_flow_control_while_waiting() {
     crate::reset_thread_local_state();
     let dir = tempfile::tempdir().expect("tempdir");
@@ -293,7 +293,7 @@ async fn waitpoint_wait_releases_singleton_flow_control_while_waiting() {
     );
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn monitor_wait_releases_singleton_flow_control_while_waiting() {
     let local = tokio::task::LocalSet::new();
     local
@@ -395,7 +395,7 @@ pub fn coordinated_handler(event: TriggerEvent) -> string {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn flow_control_debounce_keeps_latest_event() {
     let local = tokio::task::LocalSet::new();
     local
@@ -515,7 +515,7 @@ pub fn local_fn(event: TriggerEvent) -> string {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn flow_control_batch_coalesces_multiple_events() {
     let local = tokio::task::LocalSet::new();
     local

--- a/crates/harn-vm/src/triggers/dispatcher/tests/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests/mod.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc::{self, Receiver};
 use std::sync::Arc;
 use std::sync::Once;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use futures::StreamExt;
 use rcgen::generate_simple_self_signed;
@@ -25,7 +25,7 @@ use crate::triggers::registry::{
     TriggerBindingSpec, TriggerHandlerSpec, TriggerPredicateSpec,
 };
 use crate::triggers::test_util::timing::{
-    FILE_WATCH_FALLBACK_POLL, NETWORK_PROBE_INITIAL, PROCESS_EXIT_GRACE, TEST_DEFAULT_TIMEOUT,
+    FILE_WATCH_FALLBACK_POLL, PROCESS_EXIT_GRACE, TEST_DEFAULT_TIMEOUT,
 };
 use crate::triggers::{ProviderId, ProviderPayload, SignatureStatus, TraceId, TriggerEvent};
 use crate::TriggerPredicateBudget;
@@ -34,9 +34,10 @@ use crate::Vm;
 use super::retry::TriggerRetryConfig;
 use super::uri::{DispatchUri, DispatchUriError};
 use super::{
-    append_dispatch_cancel_request, install_test_inbox_dequeued_signal, AcquiredFlowControl,
-    DispatchCancelRequest, DispatchStatus, DispatchWaitLease, Dispatcher, DispatcherRuntimeState,
-    RetryPolicy, SingletonLease, DEFAULT_AUTONOMY_BUDGET_REVIEWER,
+    append_dispatch_cancel_request, install_test_inbox_dequeued_signal,
+    install_test_inbox_subscribed_signal, AcquiredFlowControl, DispatchCancelRequest,
+    DispatchStatus, DispatchWaitLease, Dispatcher, DispatcherRuntimeState, RetryPolicy,
+    SingletonLease, DEFAULT_AUTONOMY_BUDGET_REVIEWER,
 };
 
 mod fixtures;

--- a/crates/harn-vm/src/triggers/dispatcher/tests/predicate.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests/predicate.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn predicate_budget_exceeded_short_circuits_and_emits_lifecycle() {
     let local = tokio::task::LocalSet::new();
     local
@@ -88,7 +88,7 @@ pub fn should_handle(event: TriggerEvent) -> bool {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn predicate_daily_budget_exceeded_short_circuits_subsequent_events() {
     let local = tokio::task::LocalSet::new();
     local
@@ -187,7 +187,7 @@ pub fn should_handle(event: TriggerEvent) -> bool {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn predicate_budget_warn_strategy_proceeds_without_llm_spend() {
     let local = tokio::task::LocalSet::new();
     local
@@ -245,7 +245,7 @@ pub fn should_handle(event: TriggerEvent) -> bool {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn predicate_budget_fail_strategy_moves_to_dlq() {
     let local = tokio::task::LocalSet::new();
     local
@@ -294,7 +294,7 @@ pub fn should_handle(event: TriggerEvent) -> bool {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn predicate_budget_retry_later_strategy_defers_event() {
     let local = tokio::task::LocalSet::new();
     local
@@ -343,7 +343,7 @@ pub fn should_handle(event: TriggerEvent) -> bool {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn predicate_replay_uses_event_cache_without_hitting_provider() {
     let local = tokio::task::LocalSet::new();
     local
@@ -424,7 +424,7 @@ pub fn should_handle(event: TriggerEvent) -> bool {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn predicate_circuit_breaker_opens_after_three_failures() {
     let local = tokio::task::LocalSet::new();
     local
@@ -503,7 +503,7 @@ pub fn should_handle(event: TriggerEvent) -> bool {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn autonomy_budget_routes_act_auto_to_approval() {
     crate::reset_thread_local_state();
     let dir = tempfile::tempdir().expect("tempdir");
@@ -610,7 +610,7 @@ pub fn local_fn(event: TriggerEvent) -> dict {
     );
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn handler_tier_is_enforced_through_capability_policy() {
     crate::reset_thread_local_state();
     let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/harn-vm/src/triggers/dispatcher/tests/retry.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests/retry.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn retry_exhaustion_moves_failed_dispatch_to_dlq() {
     let local = tokio::task::LocalSet::new();
     local
@@ -70,7 +70,7 @@ pub fn local_fn(event: TriggerEvent) -> string {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn destination_circuit_opens_and_dlqs_subsequent_dispatches() {
     let local = tokio::task::LocalSet::new();
     local
@@ -130,7 +130,7 @@ pub fn local_fn(event: TriggerEvent) -> string {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn replay_dispatch_emits_replay_chain_edge_and_headers() {
     let local = tokio::task::LocalSet::new();
     local
@@ -187,7 +187,7 @@ pub fn local_fn(event: TriggerEvent) -> dict {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn replay_dispatch_scopes_harn_replay_per_dispatch_and_child_process() {
     let local = tokio::task::LocalSet::new();
     local
@@ -273,7 +273,7 @@ pub fn local_fn(event: TriggerEvent) -> dict {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn shutdown_propagates_cancel_to_all_in_flight_local_handlers() {
     let local = tokio::task::LocalSet::new();
     local
@@ -325,7 +325,7 @@ pub fn wait_for_cancel(event: TriggerEvent) -> string {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn external_cancel_request_cancels_in_flight_local_handler() {
     let local = tokio::task::LocalSet::new();
     local
@@ -399,7 +399,7 @@ pub fn wait_for_cancel(event: TriggerEvent) -> string {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn external_cancel_request_interrupts_waitpoint_waiting_handler() {
     let local = tokio::task::LocalSet::new();
     local
@@ -476,7 +476,7 @@ pub fn wait_for_signal(event: TriggerEvent) -> string {
         .await;
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn run_skips_historical_inbox_entries_on_startup() {
     let local = tokio::task::LocalSet::new();
     local
@@ -505,6 +505,27 @@ pub fn local_fn(event: TriggerEvent) -> string {
                 .await
                 .expect("enqueue historical inbox entry");
 
+            // Subscribe to the outbox before starting the run task. The
+            // subscription's history-replay step backfills any events that
+            // arrive before live forwarding takes over, so this captures every
+            // dispatch the run task emits without a polling loop.
+            let outbox_topic = Topic::new("trigger.outbox").expect("outbox topic");
+            let mut outbox_stream = log
+                .clone()
+                .subscribe(&outbox_topic, None)
+                .await
+                .expect("subscribe to trigger.outbox");
+
+            // Install a one-shot signal that fires once the run loop has
+            // captured the inbox `latest()` cursor and registered its
+            // subscribe. This is the deterministic replacement for the legacy
+            // 20ms wall-clock probe: without it we'd race between the run
+            // loop's `latest()` call and the test's enqueue of `live`, and a
+            // late subscribe would advance `start_from` past `live` and skip
+            // it entirely.
+            let (subscribed_tx, subscribed_rx) = oneshot::channel();
+            super::install_test_inbox_subscribed_signal(subscribed_tx);
+
             let dispatcher_for_task = dispatcher.clone();
             let run_task = tokio::task::spawn_local(async move {
                 dispatcher_for_task
@@ -513,40 +534,50 @@ pub fn local_fn(event: TriggerEvent) -> string {
                     .expect("dispatcher run exits");
             });
 
-            tokio::time::sleep(NETWORK_PROBE_INITIAL).await;
-            let outbox_before = read_topic(log.clone(), "trigger.outbox").await;
-            assert!(
-                outbox_before.is_empty(),
-                "startup should not auto-dispatch historical inbox entries: {outbox_before:?}"
-            );
+            subscribed_rx
+                .await
+                .expect("dispatcher run loop reaches inbox subscribe");
 
+            // Now that run() is committed to start_from = historical.id, the
+            // live event - which has a strictly greater id - is guaranteed to
+            // be delivered through the inbox subscription.
             let live = trigger_event("issues.opened", "delivery-live");
+            let live_id = live.id.0.clone();
             dispatcher
-                .enqueue_targeted(Some("github-new-issue".to_string()), Some(1), live.clone())
+                .enqueue_targeted(Some("github-new-issue".to_string()), Some(1), live)
                 .await
                 .expect("enqueue live inbox entry");
 
-            let deadline = Instant::now() + TEST_DEFAULT_TIMEOUT;
-            while Instant::now() < deadline {
-                let outbox = read_topic(log.clone(), "trigger.outbox").await;
-                if outbox.iter().any(|(_, event)| {
-                    event.headers.get("event_id").map(String::as_str) == Some(live.id.0.as_str())
-                        && event.kind == "dispatch_succeeded"
-                }) {
+            loop {
+                let item = outbox_stream
+                    .next()
+                    .await
+                    .expect("outbox stream closed before live dispatch")
+                    .expect("outbox event");
+                let (_, event) = item;
+                if event.kind == "dispatch_succeeded"
+                    && event.headers.get("event_id").map(String::as_str) == Some(live_id.as_str())
+                {
                     break;
                 }
-                tokio::time::sleep(NETWORK_PROBE_INITIAL).await;
             }
 
             dispatcher.shutdown();
             run_task.await.expect("join dispatcher run task");
 
+            // Final state: live dispatched, historical never dispatched.
+            // Dispatching is append-only so this end-of-test assertion is
+            // equivalent to checking at every intermediate step.
             let outbox = read_topic(log.clone(), "trigger.outbox").await;
-            assert!(!outbox.iter().any(|(_, event)| {
-                event.headers.get("event_id").map(String::as_str) == Some(historical.id.0.as_str())
-            }));
+            assert!(
+                !outbox.iter().any(|(_, event)| {
+                    event.headers.get("event_id").map(String::as_str)
+                        == Some(historical.id.0.as_str())
+                }),
+                "historical inbox entry must not appear in outbox: {outbox:?}"
+            );
             assert!(outbox.iter().any(|(_, event)| {
-                event.headers.get("event_id").map(String::as_str) == Some(live.id.0.as_str())
+                event.headers.get("event_id").map(String::as_str) == Some(live_id.as_str())
                     && event.kind == "dispatch_succeeded"
             }));
         })
@@ -601,7 +632,7 @@ pub fn slow_handler(event: TriggerEvent) -> string {
 // Regression coverage for harn#324: dispatcher shutdown must wake handlers
 // that are blocked in `sleep()` so a cooperative `is_cancelled()` loop can
 // exit without silently dropping an already-dequeued inbox event.
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn run_shutdown_does_not_silently_drop_dequeued_inbox_events() {
     let local = tokio::task::LocalSet::new();
     local

--- a/crates/harn-vm/src/triggers/test_util/timing.rs
+++ b/crates/harn-vm/src/triggers/test_util/timing.rs
@@ -1,16 +1,20 @@
 use std::time::Duration;
 
-/// Poll cadence for short test-only fallback loops.
+/// Poll cadence for short test-only fallback loops on real OS resources
+/// (e.g. polling a non-blocking `TcpListener` for shutdown). Not for
+/// dispatcher logic waits — those must be event-driven and run under
+/// `tokio::test(start_paused = true)`.
 pub const FILE_WATCH_FALLBACK_POLL: Duration = Duration::from_millis(10);
-/// Grace period for negative assertions after shutdown or process cancellation.
+/// Grace period for negative assertions after shutdown or process cancellation
+/// against real network mocks (TCP). Inside `start_paused` tests, prefer
+/// `tokio::time::advance` instead.
 pub const PROCESS_EXIT_GRACE: Duration = Duration::from_millis(100);
-/// Initial wait/poll cadence for tests that probe asynchronous network dispatch.
-pub const NETWORK_PROBE_INITIAL: Duration = Duration::from_millis(20);
-/// Default upper bound for trigger test harness waits.
+/// Hard fail-fast ceiling for trigger test harness waits.
 ///
-/// Set generously enough to absorb CPU starvation when the workspace
-/// test suite runs the trigger dispatcher tests concurrently with
-/// hundreds of other tokio tasks (the original 5-second budget
-/// produced occasional spurious "timed out waiting for ..." failures
-/// in CI under load).
+/// Used as the upper bound on `tokio::time::timeout` calls and `Dispatcher::drain`
+/// — a deterministic test should never come close to this. Under
+/// `tokio::test(start_paused = true)`, paused-time auto-advance ensures the
+/// ceiling fires immediately when no work remains, instead of burning real
+/// wall-clock seconds. The 30-second value remains generous enough for
+/// real-network A2A fixture tests.
 pub const TEST_DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);


### PR DESCRIPTION
## Summary

Closes [#1061](https://github.com/burin-labs/harn/issues/1061). Stacked on top of [#1081](https://github.com/burin-labs/harn/pull/1081).

Direct cutover of the dispatcher logic tests in `crates/harn-vm/src/triggers/dispatcher/tests/` to `#[tokio::test(start_paused = true, flavor = "current_thread")]` with deterministic, event-driven waits. Eliminates the only remaining wall-clock polling pattern (`run_skips_historical_inbox_entries_on_startup` was using a 20ms `tokio::time::sleep` plus an `Instant::now()` deadline + 20ms-poll loop).

The five A2A tests in `dispatch.rs` that go through real TCP+TLS via `MockA2aServer` are intentionally left out of scope — paused time does not honor real I/O. Those are tracked in [#1089](https://github.com/burin-labs/harn/issues/1089) under Tier 3B.

## Key changes

- New `#[cfg(test)]` hook `notify_test_inbox_subscribed()` in `Dispatcher::run()` so the historical-skip test can deterministically wait for the run loop's inbox `latest()` cursor before enqueueing the live event. Without this, there is a race between `run()`'s `latest()` call and the test's enqueue: a late subscribe would advance `start_from` past the live event and skip it entirely. The legacy 20ms wall-clock probe was hiding that race; the new signal is the deterministic equivalent.
- All in-scope tests now use `start_paused = true` (matching the existing 3 paused tests already in the suite).
- Drop `NETWORK_PROBE_INITIAL` from `crates/harn-vm/src/triggers/test_util/timing.rs` (no longer used). Tighten doc comments on `FILE_WATCH_FALLBACK_POLL`, `PROCESS_EXIT_GRACE`, and `TEST_DEFAULT_TIMEOUT` so future readers know which constants are appropriate under paused time.

## Acceptance criteria

- `grep -rn "tokio::time::sleep\|std::thread::sleep" crates/harn-vm/src/triggers/` returns zero matches in test code. The four remaining hits are all production: `registry.rs:1787,1828` (file-watch fallback polling — pre-existing), `dispatcher/mod.rs:3320` (retry backoff), `dispatcher/flow_control.rs:445` (throttle wait, only used when no `MockClock` is installed).
- `grep -rn "Instant::now()" crates/harn-vm/src/triggers/dispatcher/tests/` returns zero matches.
- 50× rerun: 50 of 50 dispatcher test runs pass.
- Thread-count parity: identical outcomes at `--test-threads=1` (1.679s) and `--test-threads=16` (0.427s).
- `cargo nextest run -p harn-vm` — 1648/1648 tests pass.

The headline test `run_skips_historical_inbox_entries_on_startup` dropped from 0.123s wall-clock to 0.050s (~60% reduction). Total dispatcher-module wall-clock is now bounded by the out-of-scope A2A network tests; once those move to a dispatcher-boundary mock under [#1089](https://github.com/burin-labs/harn/issues/1089), the remaining 50% module reduction goal will follow.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo nextest run -p harn-vm` — 1648/1648 pass
- [x] `cargo nextest run -p harn-vm 'triggers::dispatcher'` 50× — 50/50 pass
- [x] `--test-threads=1` and `--test-threads=16` produce identical outcomes

🤖 Generated with [Claude Code](https://claude.com/claude-code)