### PR TITLE
Add ProcessHandle trait and MockProcess for deterministic process-tool tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,25 @@ condensed series summaries instead of full per-patch history.
   return their typed `OrchestratorError` / `PackageError::Registry`
   variants.
 
+### Tests
+
+- **`ProcessHandle` trait + `MockProcess` for deterministic
+  process-tool tests (#1062).** `crates/harn-hostlib/src/process/`
+  introduces a `ProcessHandle` / `ProcessSpawner` abstraction with a
+  real implementation that wraps `harn_vm::process_sandbox` and a
+  `MockSpawner` test double that returns scripted `MockProcess`
+  handles. `tools/proc.rs` and `tools/long_running.rs` consume the
+  trait instead of `std::process::Child` directly. The 33 integration
+  tests in `crates/harn-hostlib/tests/process_tools.rs` are rewritten
+  to install `MockSpawner` per test — zero `std::thread::sleep`, zero
+  `Instant::now()` polling, zero real subprocess spawning. Long-running
+  waiter completion is awaited deterministically via a new
+  `register_completion_notifier` API. The full file finishes in 0.01 s
+  and 50× rerun under `cargo nextest` is flake-free. Two real-process
+  smoke tests live in `crates/harn-hostlib/tests/process_tools_e2e.rs`
+  for end-to-end coverage; they keep the `_e2e.rs` suffix so issue
+  #1069's slow-job tagging can pick them up.
+
 ## v0.7.51
 
 ### Added

--- a/crates/harn-hostlib/src/lib.rs
+++ b/crates/harn-hostlib/src/lib.rs
@@ -31,6 +31,7 @@ pub mod ast;
 pub mod code_index;
 pub mod error;
 pub mod fs_watch;
+pub mod process;
 pub mod scanner;
 pub mod schemas;
 pub mod tools;

--- a/crates/harn-hostlib/src/process/handle.rs
+++ b/crates/harn-hostlib/src/process/handle.rs
@@ -1,0 +1,210 @@
+//! Process abstraction trait used by `tools/proc` and
+//! `tools/long_running`.
+//!
+//! Tier 1C of the de-flake epic (#1057). Production code spawns through
+//! the [`ProcessSpawner`] trait — the default implementation in
+//! `process::real` wraps `std::process::Child` and goes through
+//! `harn_vm::process_sandbox`. Tests install a `MockSpawner` (see
+//! `process::mock`) that returns deterministic [`MockProcess`] handles,
+//! so process-tool tests no longer depend on real subprocess scheduling
+//! or wall-clock timing.
+
+use std::collections::BTreeMap;
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Resolved exit information for a finished process. Mirrors the subset of
+/// `std::process::ExitStatus` that the process-tool builtins surface.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExitStatus {
+    /// Exit code from `exit(2)` / `_exit(2)`. `None` means the process did not
+    /// exit normally (it was terminated by a signal).
+    pub code: Option<i32>,
+    /// Unix signal that terminated the process, when applicable. `None` on
+    /// non-Unix targets or when the process exited normally.
+    pub signal: Option<i32>,
+}
+
+impl ExitStatus {
+    /// Construct a normal exit with the given code.
+    pub fn from_code(code: i32) -> Self {
+        Self {
+            code: Some(code),
+            signal: None,
+        }
+    }
+
+    /// Construct a signal-terminated exit.
+    pub fn from_signal(signal: i32) -> Self {
+        Self {
+            code: None,
+            signal: Some(signal),
+        }
+    }
+}
+
+/// How a spawn should treat the parent's environment. Mirrors the legacy
+/// `EnvMode` from `tools/proc.rs`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EnvMode {
+    /// Inherit the parent's environment, then apply `env` overrides.
+    InheritClean,
+    /// Clear the environment, then apply `env`.
+    Replace,
+    /// Inherit the parent's environment and apply `env` (default behaviour).
+    Patch,
+}
+
+/// Parameters describing a single spawn. The spawner is responsible for any
+/// sandbox setup (Linux seccomp/landlock, macOS sandbox-exec, etc.) and for
+/// configuring the child's process group when requested.
+#[derive(Clone, Debug)]
+pub struct SpawnSpec {
+    /// Builtin name surfaced in error messages (e.g. `"hostlib_tools_run_command"`).
+    pub builtin: &'static str,
+    /// Program to execute. Must be non-empty (validated by the spawner).
+    pub program: String,
+    /// Arguments to pass to the program.
+    pub args: Vec<String>,
+    /// Working directory for the child. `None` inherits the parent's cwd.
+    pub cwd: Option<PathBuf>,
+    /// Environment overrides to apply (interpretation depends on `env_mode`).
+    pub env: BTreeMap<String, String>,
+    /// How to treat the parent's environment.
+    pub env_mode: EnvMode,
+    /// Whether stdin will be written to (`true`) or piped to /dev/null (`false`).
+    pub use_stdin: bool,
+    /// Set the child's process group to its own pid (`setpgid(0, 0)`). Used
+    /// for long-running handles so the kill-by-pgid path works.
+    pub configure_process_group: bool,
+}
+
+/// Handle to a running (or finished) process. Used by both the synchronous
+/// `proc::run` path and the long-running waiter thread.
+///
+/// The trait is intentionally small: the legacy code already managed
+/// stdout/stderr drain on dedicated threads, and stdin is written once after
+/// spawn — wrapping those reads/writes via boxed trait objects keeps the
+/// real and mock paths uniform without forcing async into the rest of the
+/// hostlib.
+pub trait ProcessHandle: Send {
+    /// OS process id, when available.
+    fn pid(&self) -> Option<u32>;
+
+    /// OS process group id, when available. Falls back to [`Self::pid`] on
+    /// platforms that don't expose process groups.
+    fn process_group_id(&self) -> Option<u32>;
+
+    /// Returns a killer that can terminate the process even after the
+    /// stdout/stderr/wait halves have been moved into the waiter thread.
+    fn killer(&self) -> Arc<dyn ProcessKiller>;
+
+    /// Take ownership of the stdin pipe, if the spawn requested one.
+    fn take_stdin(&mut self) -> Option<Box<dyn Write + Send>>;
+
+    /// Take ownership of the stdout reader.
+    fn take_stdout(&mut self) -> Option<Box<dyn Read + Send>>;
+
+    /// Take ownership of the stderr reader.
+    fn take_stderr(&mut self) -> Option<Box<dyn Read + Send>>;
+
+    /// Wait for the process to exit, optionally with a timeout. Returns
+    /// `(Some(status), false)` when the process exited cleanly,
+    /// `(None, true)` when the timeout elapsed (and the spawner killed the
+    /// child), or `(None, false)` when the wait failed for a reason other
+    /// than the timeout.
+    fn wait_with_timeout(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> io::Result<(Option<ExitStatus>, bool)>;
+
+    /// Block until the process exits, no timeout.
+    fn wait(&mut self) -> io::Result<ExitStatus>;
+}
+
+/// Kill side of a [`ProcessHandle`]. Cloneable via `Arc` so cancellation
+/// works after the waiter thread has taken ownership of the handle itself.
+pub trait ProcessKiller: Send + Sync {
+    /// Send SIGKILL to the process (and its process group, when applicable).
+    fn kill(&self);
+}
+
+/// Spawner abstraction: produces [`ProcessHandle`] instances.
+pub trait ProcessSpawner: Send + Sync {
+    /// Spawn the configured process.
+    fn spawn(&self, spec: SpawnSpec) -> Result<Box<dyn ProcessHandle>, ProcessError>;
+}
+
+/// Errors raised by a spawner. These map onto `HostlibError::Backend` /
+/// `HostlibError::InvalidParameter` at the call site so the script-side
+/// surface stays unchanged.
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum ProcessError {
+    /// `argv` was empty or otherwise malformed.
+    #[error("invalid argv: {0}")]
+    InvalidArgv(String),
+    /// Sandbox setup (e.g. landlock policy assembly) failed.
+    #[error("sandbox setup failed: {0}")]
+    SandboxSetup(String),
+    /// Sandbox rejected the supplied cwd.
+    #[error("sandbox cwd rejected: {0}")]
+    SandboxCwd(String),
+    /// Sandbox rejected the spawn at execve time.
+    #[error("sandbox rejected spawn: {0}")]
+    SandboxSpawn(String),
+    /// Generic spawn failure (typically io::Error from `Command::spawn`).
+    #[error("spawn failed: {0}")]
+    Spawn(String),
+}
+
+use std::cell::RefCell;
+
+thread_local! {
+    static THREAD_SPAWNER: RefCell<Option<Arc<dyn ProcessSpawner>>> = const { RefCell::new(None) };
+}
+
+/// Install a per-thread spawner used by `spawn_process` from this thread.
+/// Returns a guard that restores the previous spawner on drop. Tests use
+/// this to install a [`super::mock::MockSpawner`]; production never calls
+/// it (the default real spawner runs whenever no per-thread spawner is
+/// installed).
+///
+/// Thread-local rather than global so parallel test execution is safe.
+/// Process-tool spawns happen on the test's thread; the long-running
+/// waiter threads operate on the handle that was already returned, so
+/// they don't perform spawner lookups themselves.
+pub fn install_spawner(spawner: Arc<dyn ProcessSpawner>) -> SpawnerGuard {
+    let prev = THREAD_SPAWNER.with(|slot| slot.replace(Some(spawner)));
+    SpawnerGuard { prev: Some(prev) }
+}
+
+/// Guard returned by [`install_spawner`]. Restores the previous spawner on
+/// drop so installs nest correctly across tests.
+pub struct SpawnerGuard {
+    prev: Option<Option<Arc<dyn ProcessSpawner>>>,
+}
+
+impl Drop for SpawnerGuard {
+    fn drop(&mut self) {
+        if let Some(prev) = self.prev.take() {
+            THREAD_SPAWNER.with(|slot| {
+                *slot.borrow_mut() = prev;
+            });
+        }
+    }
+}
+
+/// Return the currently installed spawner for this thread, falling back
+/// to the default real spawner.
+pub fn current_spawner() -> Arc<dyn ProcessSpawner> {
+    THREAD_SPAWNER
+        .with(|slot| slot.borrow().clone())
+        .unwrap_or_else(super::real::default_spawner)
+}
+
+/// Spawn a process via the currently installed spawner.
+pub fn spawn_process(spec: SpawnSpec) -> Result<Box<dyn ProcessHandle>, ProcessError> {
+    current_spawner().spawn(spec)
+}

--- a/crates/harn-hostlib/src/process/mock.rs
+++ b/crates/harn-hostlib/src/process/mock.rs
@@ -1,0 +1,484 @@
+//! Test-only [`ProcessSpawner`] / [`ProcessHandle`] implementations.
+//!
+//! Tests install a [`MockSpawner`] via
+//! [`super::handle::install_spawner`], enqueue per-spawn responses, and
+//! drive the resulting [`MockProcess`] state explicitly via the controller
+//! returned at enqueue time. There are zero real subprocesses, no
+//! `thread::sleep`, no `Instant::now` polling.
+
+use std::collections::VecDeque;
+use std::io::{self, Read, Write};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
+
+use super::handle::{
+    ExitStatus, ProcessError, ProcessHandle, ProcessKiller, ProcessSpawner, SpawnSpec,
+};
+
+/// Behaviour to script for a single mocked spawn.
+#[derive(Clone, Debug)]
+pub struct MockProcessConfig {
+    /// PID returned by [`ProcessHandle::pid`] for this spawn. Must be > 0
+    /// because `process_tools` test assertions check `> 0`.
+    pub pid: u32,
+    /// Process-group id returned by [`ProcessHandle::process_group_id`].
+    pub pgid: Option<u32>,
+    /// Initial stdout bytes available before any test-side appends.
+    pub stdout: Vec<u8>,
+    /// Initial stderr bytes available before any test-side appends.
+    pub stderr: Vec<u8>,
+    /// If `Some`, the process is already complete and `wait*` returns this
+    /// immediately. If `None`, the process stays "running" until the test
+    /// signals exit via the controller.
+    pub exit_status: Option<ExitStatus>,
+    /// If `true`, [`ProcessHandle::wait_with_timeout`] reports a timeout
+    /// regardless of `exit_status`. Used to test the timeout path without
+    /// real subprocess scheduling.
+    pub force_timeout: bool,
+    /// If non-`None`, force [`ProcessSpawner::spawn`] to fail with this
+    /// error instead of returning a handle. Used to exercise sandbox /
+    /// invalid-argv error paths.
+    pub spawn_error: Option<ProcessError>,
+}
+
+impl Default for MockProcessConfig {
+    fn default() -> Self {
+        Self {
+            pid: 99_999,
+            pgid: Some(99_999),
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            exit_status: Some(ExitStatus::from_code(0)),
+            force_timeout: false,
+            spawn_error: None,
+        }
+    }
+}
+
+impl MockProcessConfig {
+    /// Convenience: build a successful spawn with the given exit code, no
+    /// stdout/stderr.
+    pub fn completed(exit_code: i32) -> Self {
+        Self {
+            exit_status: Some(ExitStatus::from_code(exit_code)),
+            ..Self::default()
+        }
+    }
+
+    /// Convenience: build a successful spawn with the given exit code and
+    /// inline stdout payload.
+    pub fn with_stdout(exit_code: i32, stdout: impl Into<Vec<u8>>) -> Self {
+        Self {
+            stdout: stdout.into(),
+            exit_status: Some(ExitStatus::from_code(exit_code)),
+            ..Self::default()
+        }
+    }
+
+    /// Convenience: build a config that stays "running" until the test
+    /// signals exit via the controller. Used for long-running and
+    /// timeout tests.
+    pub fn running() -> Self {
+        Self {
+            exit_status: None,
+            ..Self::default()
+        }
+    }
+}
+
+#[derive(Default)]
+struct MockSpawnerInner {
+    queue: VecDeque<(MockProcessConfig, Arc<MockState>)>,
+    captured: Vec<SpawnSpec>,
+    last_controller: Option<MockHandleController>,
+}
+
+/// Test [`ProcessSpawner`] that returns scripted [`MockProcess`] handles
+/// and captures the [`SpawnSpec`] passed to each spawn.
+pub struct MockSpawner {
+    inner: Mutex<MockSpawnerInner>,
+}
+
+impl Default for MockSpawner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MockSpawner {
+    /// Build an empty spawner. Call [`Self::enqueue`] to script behaviour
+    /// for each anticipated spawn.
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(MockSpawnerInner::default()),
+        }
+    }
+
+    /// Enqueue a configuration for the next spawn. Returns a controller
+    /// that lets the test drive the resulting [`MockProcess`] state
+    /// (append stdout, complete with status, etc.). For one-shot
+    /// foreground tests, the controller may simply be dropped.
+    pub fn enqueue(&self, config: MockProcessConfig) -> MockHandleController {
+        let state = Arc::new(MockState::new(&config));
+        let controller = MockHandleController {
+            state: Arc::clone(&state),
+        };
+        let mut inner = self.inner.lock().expect("MockSpawner mutex poisoned");
+        inner.queue.push_back((config, state));
+        inner.last_controller = Some(controller.clone());
+        controller
+    }
+
+    /// Returns the [`SpawnSpec`] objects captured so far, in order.
+    pub fn captured(&self) -> Vec<SpawnSpec> {
+        self.inner
+            .lock()
+            .expect("MockSpawner mutex poisoned")
+            .captured
+            .clone()
+    }
+
+    /// Returns the latest controller installed via [`Self::enqueue`].
+    /// Convenience for tests that only enqueue one config.
+    pub fn last_controller(&self) -> Option<MockHandleController> {
+        self.inner
+            .lock()
+            .expect("MockSpawner mutex poisoned")
+            .last_controller
+            .clone()
+    }
+}
+
+impl ProcessSpawner for MockSpawner {
+    fn spawn(&self, spec: SpawnSpec) -> Result<Box<dyn ProcessHandle>, ProcessError> {
+        let (config, state) = {
+            let mut inner = self.inner.lock().expect("MockSpawner mutex poisoned");
+            inner.captured.push(spec);
+            inner.queue.pop_front().expect(
+                "MockSpawner: spawn() called with no enqueued configuration. Call \
+                 MockSpawner::enqueue(...) before each expected spawn.",
+            )
+        };
+
+        if let Some(err) = config.spawn_error {
+            return Err(err);
+        }
+
+        let killer: Arc<dyn ProcessKiller> = Arc::new(MockKiller {
+            state: Arc::clone(&state),
+        });
+
+        Ok(Box::new(MockProcess {
+            pid: config.pid,
+            pgid: config.pgid,
+            killer,
+            state,
+            stdin_taken: false,
+            stdout_taken: false,
+            stderr_taken: false,
+        }))
+    }
+}
+
+/// Test-side controller for a [`MockProcess`]. Cloneable; all clones
+/// reference the same underlying state.
+#[derive(Clone)]
+pub struct MockHandleController {
+    state: Arc<MockState>,
+}
+
+impl MockHandleController {
+    /// Append bytes to the mock's stdout buffer. Subsequent reads on the
+    /// stdout reader will see them.
+    pub fn append_stdout(&self, bytes: &[u8]) {
+        let mut data = self.state.stdout.lock().unwrap();
+        data.extend_from_slice(bytes);
+        self.state.stdout_cv.notify_all();
+    }
+
+    /// Append bytes to the mock's stderr buffer.
+    pub fn append_stderr(&self, bytes: &[u8]) {
+        let mut data = self.state.stderr.lock().unwrap();
+        data.extend_from_slice(bytes);
+        self.state.stderr_cv.notify_all();
+    }
+
+    /// Mark the process as having exited with the given status. Drains
+    /// any blocked `wait()` callers and closes the stdout/stderr readers.
+    pub fn complete_with(&self, status: ExitStatus) {
+        let mut exit = self.state.exit.lock().unwrap();
+        if exit.is_none() {
+            *exit = Some(ExitOutcome {
+                status,
+                killed: false,
+            });
+        }
+        drop(exit);
+        self.state.exit_cv.notify_all();
+        self.state.stdout_cv.notify_all();
+        self.state.stderr_cv.notify_all();
+    }
+
+    /// Returns true if [`MockKiller::kill`] has been invoked since spawn.
+    pub fn was_killed(&self) -> bool {
+        self.state
+            .exit
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|o| o.killed)
+            .unwrap_or(false)
+    }
+
+    /// Returns the bytes the test-tool side wrote to the mock's stdin
+    /// reader (after the process-tool path closed stdin).
+    pub fn stdin_written(&self) -> Vec<u8> {
+        self.state.stdin_written.lock().unwrap().clone()
+    }
+}
+
+struct MockState {
+    /// Bytes available to the stdout reader. Drained as the reader pulls.
+    stdout: Mutex<Vec<u8>>,
+    /// Bytes available to the stderr reader.
+    stderr: Mutex<Vec<u8>>,
+    /// Captured stdin bytes the spawn-side wrote.
+    stdin_written: Mutex<Vec<u8>>,
+    /// Final status, set by `complete_with` or by the killer.
+    exit: Mutex<Option<ExitOutcome>>,
+    exit_cv: Condvar,
+    stdout_cv: Condvar,
+    stderr_cv: Condvar,
+    /// Force-timeout config copied from MockProcessConfig.
+    force_timeout: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ExitOutcome {
+    status: ExitStatus,
+    killed: bool,
+}
+
+impl MockState {
+    fn new(config: &MockProcessConfig) -> Self {
+        let exit = config.exit_status.map(|status| ExitOutcome {
+            status,
+            killed: false,
+        });
+        Self {
+            stdout: Mutex::new(config.stdout.clone()),
+            stderr: Mutex::new(config.stderr.clone()),
+            stdin_written: Mutex::new(Vec::new()),
+            exit: Mutex::new(exit),
+            exit_cv: Condvar::new(),
+            stdout_cv: Condvar::new(),
+            stderr_cv: Condvar::new(),
+            force_timeout: config.force_timeout,
+        }
+    }
+
+    fn is_exited(&self) -> bool {
+        self.exit.lock().unwrap().is_some()
+    }
+
+    fn wait_for_exit(&self, timeout: Option<Duration>) -> Option<ExitOutcome> {
+        let mut exit = self.exit.lock().unwrap();
+        if let Some(timeout) = timeout {
+            if exit.is_none() {
+                let (next, result) = self.exit_cv.wait_timeout(exit, timeout).unwrap();
+                exit = next;
+                if result.timed_out() && exit.is_none() {
+                    return None;
+                }
+            }
+        } else {
+            while exit.is_none() {
+                exit = self.exit_cv.wait(exit).unwrap();
+            }
+        }
+        *exit
+    }
+
+    fn record_kill(&self) {
+        let mut exit = self.exit.lock().unwrap();
+        if exit.is_none() {
+            *exit = Some(ExitOutcome {
+                status: ExitStatus::from_signal(9),
+                killed: true,
+            });
+        } else if let Some(outcome) = exit.as_mut() {
+            outcome.killed = true;
+        }
+        drop(exit);
+        self.exit_cv.notify_all();
+        self.stdout_cv.notify_all();
+        self.stderr_cv.notify_all();
+    }
+}
+
+/// Mock process backed by a shared `MockState`.
+pub struct MockProcess {
+    pid: u32,
+    pgid: Option<u32>,
+    killer: Arc<dyn ProcessKiller>,
+    state: Arc<MockState>,
+    stdin_taken: bool,
+    stdout_taken: bool,
+    stderr_taken: bool,
+}
+
+impl ProcessHandle for MockProcess {
+    fn pid(&self) -> Option<u32> {
+        Some(self.pid)
+    }
+
+    fn process_group_id(&self) -> Option<u32> {
+        self.pgid
+    }
+
+    fn killer(&self) -> Arc<dyn ProcessKiller> {
+        Arc::clone(&self.killer)
+    }
+
+    fn take_stdin(&mut self) -> Option<Box<dyn Write + Send>> {
+        if self.stdin_taken {
+            return None;
+        }
+        self.stdin_taken = true;
+        Some(Box::new(MockStdin {
+            state: Arc::clone(&self.state),
+        }))
+    }
+
+    fn take_stdout(&mut self) -> Option<Box<dyn Read + Send>> {
+        if self.stdout_taken {
+            return None;
+        }
+        self.stdout_taken = true;
+        Some(Box::new(MockStdoutReader {
+            state: Arc::clone(&self.state),
+            kind: PipeKind::Stdout,
+        }))
+    }
+
+    fn take_stderr(&mut self) -> Option<Box<dyn Read + Send>> {
+        if self.stderr_taken {
+            return None;
+        }
+        self.stderr_taken = true;
+        Some(Box::new(MockStdoutReader {
+            state: Arc::clone(&self.state),
+            kind: PipeKind::Stderr,
+        }))
+    }
+
+    fn wait_with_timeout(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> io::Result<(Option<ExitStatus>, bool)> {
+        if self.state.force_timeout {
+            self.state.record_kill();
+            return Ok((None, true));
+        }
+        let Some(timeout) = timeout else {
+            let outcome = self
+                .state
+                .wait_for_exit(None)
+                .expect("wait without timeout returned None");
+            return Ok((Some(outcome.status), false));
+        };
+        match self.state.wait_for_exit(Some(timeout)) {
+            Some(outcome) => Ok((Some(outcome.status), false)),
+            None => {
+                self.state.record_kill();
+                Ok((None, true))
+            }
+        }
+    }
+
+    fn wait(&mut self) -> io::Result<ExitStatus> {
+        let outcome = self
+            .state
+            .wait_for_exit(None)
+            .expect("wait without timeout returned None");
+        Ok(outcome.status)
+    }
+}
+
+struct MockStdin {
+    state: Arc<MockState>,
+}
+
+impl Write for MockStdin {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.state
+            .stdin_written
+            .lock()
+            .unwrap()
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+enum PipeKind {
+    Stdout,
+    Stderr,
+}
+
+struct MockStdoutReader {
+    state: Arc<MockState>,
+    kind: PipeKind,
+}
+
+impl MockStdoutReader {
+    fn pipe_lock(&self) -> &Mutex<Vec<u8>> {
+        match self.kind {
+            PipeKind::Stdout => &self.state.stdout,
+            PipeKind::Stderr => &self.state.stderr,
+        }
+    }
+
+    fn pipe_cv(&self) -> &Condvar {
+        match self.kind {
+            PipeKind::Stdout => &self.state.stdout_cv,
+            PipeKind::Stderr => &self.state.stderr_cv,
+        }
+    }
+}
+
+impl Read for MockStdoutReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let lock = self.pipe_lock();
+        let cv = self.pipe_cv();
+        let mut data = lock.lock().unwrap();
+        loop {
+            if !data.is_empty() {
+                let n = data.len().min(buf.len());
+                buf[..n].copy_from_slice(&data[..n]);
+                data.drain(..n);
+                return Ok(n);
+            }
+            // Empty buffer: if the process is exited, signal EOF;
+            // otherwise wait for either more bytes or exit.
+            if self.state.is_exited() {
+                return Ok(0);
+            }
+            data = cv.wait(data).unwrap();
+        }
+    }
+}
+
+struct MockKiller {
+    state: Arc<MockState>,
+}
+
+impl ProcessKiller for MockKiller {
+    fn kill(&self) {
+        self.state.record_kill();
+    }
+}

--- a/crates/harn-hostlib/src/process/mod.rs
+++ b/crates/harn-hostlib/src/process/mod.rs
@@ -1,0 +1,18 @@
+//! Process abstraction used by the deterministic process tools.
+//!
+//! Production code spawns through [`spawn_process`], which dispatches to
+//! the [`ProcessSpawner`] currently installed via
+//! [`install_spawner`]. The default spawner ([`real::default_spawner`])
+//! goes through `harn_vm::process_sandbox`. Tests install
+//! [`mock::MockSpawner`] to drive process behaviour deterministically.
+
+pub mod handle;
+pub mod mock;
+pub mod real;
+
+pub use handle::{
+    current_spawner, install_spawner, spawn_process, EnvMode, ExitStatus, ProcessError,
+    ProcessHandle, ProcessKiller, ProcessSpawner, SpawnSpec, SpawnerGuard,
+};
+pub use mock::{MockHandleController, MockProcess, MockProcessConfig, MockSpawner};
+pub use real::default_spawner;

--- a/crates/harn-hostlib/src/process/real.rs
+++ b/crates/harn-hostlib/src/process/real.rs
@@ -1,0 +1,283 @@
+//! Production [`ProcessSpawner`] implementation backed by
+//! `std::process::Command` + `harn_vm::process_sandbox`.
+
+use std::io::{self, Read, Write};
+use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Stdio};
+use std::sync::{Arc, LazyLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use harn_vm::process_sandbox;
+
+use super::handle::{
+    EnvMode, ExitStatus, ProcessError, ProcessHandle, ProcessKiller, ProcessSpawner, SpawnSpec,
+};
+
+/// Spawner that produces real OS processes via `std::process::Command`.
+pub struct RealSpawner;
+
+static REAL_SPAWNER: LazyLock<Arc<dyn ProcessSpawner>> =
+    LazyLock::new(|| Arc::new(RealSpawner) as Arc<dyn ProcessSpawner>);
+
+/// Returns the singleton real spawner used as the default.
+pub fn default_spawner() -> Arc<dyn ProcessSpawner> {
+    Arc::clone(&REAL_SPAWNER)
+}
+
+impl ProcessSpawner for RealSpawner {
+    fn spawn(&self, spec: SpawnSpec) -> Result<Box<dyn ProcessHandle>, ProcessError> {
+        if spec.program.is_empty() {
+            return Err(ProcessError::InvalidArgv(
+                "first element of argv must be a non-empty program name".to_string(),
+            ));
+        }
+
+        let mut command = process_sandbox::std_command_for(&spec.program, &spec.args)
+            .map_err(|e| ProcessError::SandboxSetup(format!("{e:?}")))?;
+
+        if let Some(cwd) = spec.cwd.as_ref() {
+            process_sandbox::enforce_process_cwd(cwd)
+                .map_err(|e| ProcessError::SandboxCwd(format!("{e:?}")))?;
+            command.current_dir(cwd);
+        }
+
+        if matches!(spec.env_mode, EnvMode::Replace) {
+            command.env_clear();
+        }
+        for (key, value) in &spec.env {
+            command.env(key, value);
+        }
+
+        if spec.configure_process_group {
+            configure_background_process_group(&mut command);
+        }
+
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+        command.stdin(if spec.use_stdin {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        });
+
+        let child = command.spawn().map_err(|e| {
+            if let Some(violation) = process_sandbox::process_spawn_error(&e) {
+                return ProcessError::SandboxSpawn(format!("{violation:?}"));
+            }
+            ProcessError::Spawn(format!("{e}"))
+        })?;
+
+        let pid = child.id();
+        let pgid = child_process_group_id(pid);
+        let killer: Arc<dyn ProcessKiller> = Arc::new(RealKiller { pid });
+
+        Ok(Box::new(RealProcess {
+            pid,
+            pgid,
+            killer,
+            child: Some(child),
+            stdin: None,
+            stdout: None,
+            stderr: None,
+            stdin_taken: false,
+            stdout_taken: false,
+            stderr_taken: false,
+        }))
+    }
+}
+
+struct RealProcess {
+    pid: u32,
+    pgid: Option<u32>,
+    killer: Arc<dyn ProcessKiller>,
+    child: Option<Child>,
+    stdin: Option<ChildStdin>,
+    stdout: Option<ChildStdout>,
+    stderr: Option<ChildStderr>,
+    stdin_taken: bool,
+    stdout_taken: bool,
+    stderr_taken: bool,
+}
+
+impl RealProcess {
+    fn ensure_pipes_taken(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            if self.stdin.is_none() && !self.stdin_taken {
+                self.stdin = child.stdin.take();
+            }
+            if self.stdout.is_none() && !self.stdout_taken {
+                self.stdout = child.stdout.take();
+            }
+            if self.stderr.is_none() && !self.stderr_taken {
+                self.stderr = child.stderr.take();
+            }
+        }
+    }
+}
+
+impl ProcessHandle for RealProcess {
+    fn pid(&self) -> Option<u32> {
+        Some(self.pid)
+    }
+
+    fn process_group_id(&self) -> Option<u32> {
+        self.pgid
+    }
+
+    fn killer(&self) -> Arc<dyn ProcessKiller> {
+        Arc::clone(&self.killer)
+    }
+
+    fn take_stdin(&mut self) -> Option<Box<dyn Write + Send>> {
+        self.ensure_pipes_taken();
+        self.stdin_taken = true;
+        self.stdin
+            .take()
+            .map(|s| Box::new(s) as Box<dyn Write + Send>)
+    }
+
+    fn take_stdout(&mut self) -> Option<Box<dyn Read + Send>> {
+        self.ensure_pipes_taken();
+        self.stdout_taken = true;
+        self.stdout
+            .take()
+            .map(|s| Box::new(s) as Box<dyn Read + Send>)
+    }
+
+    fn take_stderr(&mut self) -> Option<Box<dyn Read + Send>> {
+        self.ensure_pipes_taken();
+        self.stderr_taken = true;
+        self.stderr
+            .take()
+            .map(|s| Box::new(s) as Box<dyn Read + Send>)
+    }
+
+    fn wait_with_timeout(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> io::Result<(Option<ExitStatus>, bool)> {
+        let Some(child) = self.child.as_mut() else {
+            return Ok((None, false));
+        };
+        let Some(timeout) = timeout else {
+            let status = child.wait()?;
+            return Ok((Some(decode_status(status)), false));
+        };
+        let deadline = Instant::now() + timeout;
+        loop {
+            match child.try_wait()? {
+                Some(status) => return Ok((Some(decode_status(status)), false)),
+                None => {
+                    if Instant::now() >= deadline {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return Ok((None, true));
+                    }
+                    // Cheap poll. Real workloads are dominated by spawn cost
+                    // and pipe drain, not this sleep.
+                    thread::sleep(Duration::from_millis(20));
+                }
+            }
+        }
+    }
+
+    fn wait(&mut self) -> io::Result<ExitStatus> {
+        let child = self
+            .child
+            .as_mut()
+            .ok_or_else(|| io::Error::other("child already reaped"))?;
+        let status = child.wait()?;
+        Ok(decode_status(status))
+    }
+}
+
+struct RealKiller {
+    pid: u32,
+}
+
+impl ProcessKiller for RealKiller {
+    fn kill(&self) {
+        kill_pid_or_group(self.pid);
+    }
+}
+
+#[cfg(unix)]
+fn decode_status(status: std::process::ExitStatus) -> ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    if let Some(code) = status.code() {
+        ExitStatus::from_code(code)
+    } else if let Some(sig) = status.signal() {
+        ExitStatus::from_signal(sig)
+    } else {
+        ExitStatus {
+            code: None,
+            signal: None,
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn decode_status(status: std::process::ExitStatus) -> ExitStatus {
+    ExitStatus::from_code(status.code().unwrap_or(-1))
+}
+
+pub(crate) fn child_process_group_id(pid: u32) -> Option<u32> {
+    #[cfg(unix)]
+    {
+        extern "C" {
+            fn getpgid(pid: i32) -> i32;
+        }
+        let pgid = unsafe { getpgid(pid as i32) };
+        if pgid > 0 {
+            Some(pgid as u32)
+        } else {
+            None
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        Some(pid)
+    }
+}
+
+pub(crate) fn configure_background_process_group(command: &mut std::process::Command) {
+    #[cfg(unix)]
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        command.pre_exec(|| {
+            extern "C" {
+                fn setpgid(pid: i32, pgid: i32) -> i32;
+            }
+            if setpgid(0, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = command;
+    }
+}
+
+/// Send SIGKILL to a pid (and its process group). Public so existing
+/// non-trait paths (e.g. session-end cleanup) can keep using it during
+/// the transition.
+pub(crate) fn kill_pid_or_group(pid: u32) {
+    #[cfg(unix)]
+    {
+        // SAFETY: kill(2) takes a pid_t (i32 on all Unix targets) and a
+        // signal number. Calling it with SIGKILL (9) is well-defined.
+        extern "C" {
+            fn kill(pid: i32, sig: i32) -> i32;
+        }
+        unsafe {
+            kill(-(pid as i32), 9);
+            kill(pid as i32, 9);
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+    }
+}

--- a/crates/harn-hostlib/src/tools/long_running.rs
+++ b/crates/harn-hostlib/src/tools/long_running.rs
@@ -34,16 +34,14 @@
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::process::{Child, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 use std::time::Duration;
 
 use harn_vm::VmValue;
 
-use harn_vm::process_sandbox;
-
 use crate::error::HostlibError;
+use crate::process::{self as process_handle, ProcessHandle, ProcessKiller, SpawnSpec};
 use crate::tools::proc::{self, CaptureConfig, CommandStatus, EnvMode};
 
 /// Atomic counter for generating unique handle IDs within this process.
@@ -58,13 +56,17 @@ struct CancelState {
 
 /// Shared state for a single in-flight child process.
 struct HandleEntry {
-    /// The child process. `None` after the waiter thread takes ownership.
-    child: Option<Child>,
-    /// Raw OS process ID — available even after the waiter took `child`.
-    pid: u32,
+    /// The process handle. `None` after the waiter thread takes ownership.
+    handle: Option<Box<dyn ProcessHandle>>,
+    /// Killer that works even after the waiter took `handle`.
+    killer: Arc<dyn ProcessKiller>,
     session_id: String,
     /// Shared with the waiter thread.
     cancel_state: Arc<CancelState>,
+    /// Sender used by the waiter thread to signal that the post-exit
+    /// feedback push is complete. `None` if the test-side hasn't asked
+    /// to be notified.
+    completion_tx: Option<std::sync::mpsc::SyncSender<()>>,
 }
 
 #[derive(Default)]
@@ -140,58 +142,22 @@ pub(crate) fn spawn_long_running_with_options(
     capture: CaptureConfig,
     session_id: String,
 ) -> Result<LongRunningHandleInfo, HostlibError> {
-    if program.is_empty() {
-        return Err(HostlibError::InvalidParameter {
-            builtin,
-            param: "argv",
-            message: "first element of argv must be a non-empty program name".to_string(),
-        });
-    }
+    let spec = SpawnSpec {
+        builtin,
+        program: program.clone(),
+        args: args.clone(),
+        cwd,
+        env,
+        env_mode,
+        use_stdin: false,
+        configure_process_group: true,
+    };
+    let handle = process_handle::spawn_process(spec)
+        .map_err(|e| proc::process_error_to_hostlib(builtin, e))?;
 
-    let mut command =
-        process_sandbox::std_command_for(&program, &args).map_err(|e| HostlibError::Backend {
-            builtin,
-            message: format!("sandbox setup failed: {e:?}"),
-        })?;
-
-    if let Some(cwd_path) = cwd.as_ref() {
-        process_sandbox::enforce_process_cwd(cwd_path).map_err(|e| HostlibError::Backend {
-            builtin,
-            message: format!("sandbox cwd rejected: {e:?}"),
-        })?;
-        command.current_dir(cwd_path);
-    }
-
-    proc::configure_background_process_group(&mut command);
-
-    if matches!(env_mode, EnvMode::Replace) {
-        command.env_clear();
-    }
-    if !env.is_empty() {
-        for (key, value) in &env {
-            command.env(key, value);
-        }
-    }
-
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::piped());
-    command.stdin(Stdio::null());
-
-    let child = command.spawn().map_err(|e| {
-        if let Some(violation) = process_sandbox::process_spawn_error(&e) {
-            return HostlibError::Backend {
-                builtin,
-                message: format!("sandbox rejected spawn: {violation:?}"),
-            };
-        }
-        HostlibError::Backend {
-            builtin,
-            message: format!("spawn failed: {e}"),
-        }
-    })?;
-
-    let pid = child.id();
-    let process_group_id = proc::child_process_group_id(pid);
+    let pid = handle.pid().unwrap_or(0);
+    let process_group_id = handle.process_group_id();
+    let killer = handle.killer();
     let id = HANDLE_COUNTER.fetch_add(1, Ordering::SeqCst);
     let handle_id = format!("hto-{:x}-{id}", std::process::id());
     let command_id = proc::next_command_id();
@@ -212,10 +178,11 @@ pub(crate) fn spawn_long_running_with_options(
         store.entries.insert(
             handle_id.clone(),
             HandleEntry {
-                child: Some(child),
-                pid,
+                handle: Some(handle),
+                killer,
                 session_id: session_id.clone(),
                 cancel_state: cancel_state.clone(),
+                completion_tx: None,
             },
         );
     }
@@ -267,15 +234,15 @@ fn waiter_thread(
 ) {
     let waiter_start = std::time::Instant::now();
 
-    // Take the child out of the store. If the entry is already gone (i.e.
+    // Take the handle out of the store. If the entry is already gone (i.e.
     // cancel_handle ran and removed it before us), exit without action.
-    let mut child = {
+    let mut handle = {
         let mut store = HANDLE_STORE
             .lock()
             .expect("long-running handle store poisoned");
         match store.entries.get_mut(&handle_id) {
-            Some(entry) => match entry.child.take() {
-                Some(c) => c,
+            Some(entry) => match entry.handle.take() {
+                Some(h) => h,
                 None => return, // already cancelled before we ran
             },
             None => return, // entry removed (cancelled before store insert — shouldn't happen)
@@ -289,20 +256,20 @@ fn waiter_thread(
     let (out_tx, out_rx) = std::sync::mpsc::channel::<Vec<u8>>();
     let (err_tx, err_rx) = std::sync::mpsc::channel::<Vec<u8>>();
 
-    if let Some(mut out) = child.stdout.take() {
+    if let Some(mut out) = handle.take_stdout() {
         std::thread::spawn(move || {
             let _ = out.read_to_end(&mut stdout_bytes);
             let _ = out_tx.send(stdout_bytes);
         });
     }
-    if let Some(mut err) = child.stderr.take() {
+    if let Some(mut err) = handle.take_stderr() {
         std::thread::spawn(move || {
             let _ = err.read_to_end(&mut stderr_bytes);
             let _ = err_tx.send(stderr_bytes);
         });
     }
 
-    let status = child.wait().ok();
+    let status = handle.wait().ok();
 
     let stdout = out_rx
         .recv_timeout(Duration::from_secs(5))
@@ -311,17 +278,28 @@ fn waiter_thread(
         .recv_timeout(Duration::from_secs(5))
         .unwrap_or_default();
 
-    // Remove our entry from the store.
-    {
+    // Remove our entry from the store, taking the completion notifier on
+    // the way out so we can signal it after the feedback push completes.
+    let completion_tx = {
         let mut store = HANDLE_STORE
             .lock()
             .expect("long-running handle store poisoned");
-        store.entries.remove(&handle_id);
-    }
+        store
+            .entries
+            .remove(&handle_id)
+            .and_then(|mut e| e.completion_tx.take())
+    };
+
+    let signal_done = move || {
+        if let Some(tx) = completion_tx {
+            let _ = tx.try_send(());
+        }
+    };
 
     // If cancellation was requested, don't push feedback — the caller
     // that cancelled doesn't want to receive a spurious tool_result.
     if cancel_state.cancelled.load(Ordering::Acquire) {
+        signal_done();
         return;
     }
 
@@ -405,28 +383,49 @@ fn waiter_thread(
 
     let content = serde_json::to_string(&payload).unwrap_or_default();
     harn_vm::push_pending_feedback_global(&session_id, "tool_result", &content);
+    signal_done();
 }
 
 /// Cancel a specific in-flight long-running handle. Kills the process and
 /// removes the entry. Returns `true` if the handle was found and cancelled.
 pub fn cancel_handle(handle_id: &str) -> bool {
-    let (pid, child, cancel_state) = {
+    let (handle_owned, killer, cancel_state, completion_tx) = {
         let mut store = HANDLE_STORE
             .lock()
             .expect("long-running handle store poisoned");
         match store.entries.remove(handle_id) {
             None => return false,
-            Some(mut entry) => (entry.pid, entry.child.take(), entry.cancel_state.clone()),
+            Some(mut entry) => (
+                entry.handle.take(),
+                entry.killer.clone(),
+                entry.cancel_state.clone(),
+                entry.completion_tx.take(),
+            ),
         }
     };
-    do_kill(pid, child, cancel_state);
+    do_kill(handle_owned, killer, cancel_state);
+    // If a test registered a completion notifier, signal it now — the
+    // waiter won't be able to (entry already removed) and we know the
+    // waiter will skip feedback because cancellation is set.
+    if let Some(tx) = completion_tx {
+        let _ = tx.try_send(());
+    }
     true
 }
+
+/// Tuple shape used by `cancel_session_handles` to drain entries while
+/// holding the store lock for as little as possible. Boxed-trait fields
+/// make it noisy to inline as an unnamed type.
+type SessionKillEntry = (
+    Option<Box<dyn ProcessHandle>>,
+    Arc<dyn ProcessKiller>,
+    Arc<CancelState>,
+);
 
 /// Cancel all in-flight handles for a given session. Called by the
 /// session-end hook to avoid orphaned processes.
 pub fn cancel_session_handles(session_id: &str) {
-    let to_kill: Vec<(u32, Option<Child>, Arc<CancelState>)> = {
+    let to_kill: Vec<SessionKillEntry> = {
         let mut store = HANDLE_STORE
             .lock()
             .expect("long-running handle store poisoned");
@@ -440,29 +439,31 @@ pub fn cancel_session_handles(session_id: &str) {
             .into_iter()
             .filter_map(|id| {
                 store.entries.remove(&id).map(|mut e| {
-                    let child = e.child.take();
-                    (e.pid, child, e.cancel_state.clone())
+                    let handle = e.handle.take();
+                    (handle, e.killer.clone(), e.cancel_state.clone())
                 })
             })
             .collect()
     };
-    for (pid, child, cancel_state) in to_kill {
-        do_kill(pid, child, cancel_state);
+    for (handle, killer, cancel_state) in to_kill {
+        do_kill(handle, killer, cancel_state);
     }
 }
 
 /// Set the cancellation flag and kill the process. Used by both `cancel_handle`
 /// and `cancel_session_handles`.
-fn do_kill(pid: u32, child: Option<Child>, cancel_state: Arc<CancelState>) {
+fn do_kill(
+    handle: Option<Box<dyn ProcessHandle>>,
+    killer: Arc<dyn ProcessKiller>,
+    cancel_state: Arc<CancelState>,
+) {
     // Signal cancellation so the waiter (if still running) skips feedback.
     cancel_state.cancelled.store(true, Ordering::Release);
-    if let Some(mut c) = child {
-        // Waiter hasn't taken the child yet — kill it directly.
-        kill_child(&mut c);
-    } else {
-        // Waiter already took the child; signal by PID.
-        kill_pid_or_group(pid);
-    }
+    // Kill via the handle's killer (works whether or not we still own
+    // the handle). If we still hold the handle, drop it after kill so the
+    // OS reaps the child.
+    killer.kill();
+    drop(handle);
 }
 
 /// Register the session-cleanup hook with harn-vm. Uses a `OnceLock` so the
@@ -478,45 +479,27 @@ pub(crate) fn register_cleanup_hook() {
     });
 }
 
-fn kill_child(child: &mut Child) {
-    kill_pid_or_group(child.id());
-    let _ = child.kill();
-    let _ = child.wait();
+fn decode_exit_status(status: process_handle::ExitStatus) -> (i32, Option<String>) {
+    if let Some(code) = status.code {
+        return (code, None);
+    }
+    if let Some(sig) = status.signal {
+        return (-1, Some(format!("SIG{sig}")));
+    }
+    (-1, None)
 }
 
-/// Kill a process by its PID. Used when the waiter thread has already taken
-/// ownership of the `Child` object but the process must still be terminated.
-fn kill_pid_or_group(pid: u32) {
-    #[cfg(unix)]
-    {
-        // SAFETY: We call kill(2) with a valid PID and SIGKILL (9). On all
-        // Unix targets pid_t and int are i32. No libc crate needed.
-        extern "C" {
-            fn kill(pid: i32, sig: i32) -> i32;
-        }
-        unsafe {
-            kill(-(pid as i32), 9); // SIGKILL process group first.
-            kill(pid as i32, 9);
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = pid; // No-op on non-Unix; TerminateProcess would require winapi.
-    }
-}
-
-fn decode_exit_status(status: std::process::ExitStatus) -> (i32, Option<String>) {
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::ExitStatusExt;
-        if let Some(code) = status.code() {
-            return (code, None);
-        }
-        if let Some(sig) = status.signal() {
-            return (-1, Some(format!("SIG{sig}")));
-        }
-        (-1, None)
-    }
-    #[cfg(not(unix))]
-    (status.code().unwrap_or(-1), None)
+/// Register a completion notifier for `handle_id`. The waiter thread sends
+/// `()` on the returned receiver after it pushes the feedback item to the
+/// global queue. Returns `None` if the handle is no longer in the store
+/// (e.g. already cancelled or completed). Used by tests to await waiter
+/// completion deterministically — no polling, no `thread::sleep`.
+pub fn register_completion_notifier(handle_id: &str) -> Option<std::sync::mpsc::Receiver<()>> {
+    let (tx, rx) = std::sync::mpsc::sync_channel::<()>(1);
+    let mut store = HANDLE_STORE
+        .lock()
+        .expect("long-running handle store poisoned");
+    let entry = store.entries.get_mut(handle_id)?;
+    entry.completion_tx = Some(tx);
+    Some(rx)
 }

--- a/crates/harn-hostlib/src/tools/proc.rs
+++ b/crates/harn-hostlib/src/tools/proc.rs
@@ -2,9 +2,13 @@
 //! `tools/run_*` and `tools/manage_packages` builtin.
 //!
 //! All process tools funnel through here so:
-//! 1. Each spawn goes through [`harn_vm::process_sandbox`], so the active
-//!    orchestration capability policy applies (Linux seccomp/landlock,
-//!    macOS `sandbox-exec`, workspace-root cwd enforcement).
+//! 1. Each spawn goes through the [`crate::process::ProcessSpawner`]
+//!    currently installed (default: real spawner backed by
+//!    `harn_vm::process_sandbox`), so the active orchestration capability
+//!    policy applies (Linux seccomp/landlock, macOS `sandbox-exec`,
+//!    workspace-root cwd enforcement). Tests install a mock spawner so
+//!    every test in `tests/process_tools.rs` is deterministic and
+//!    free of wall-clock dependence.
 //! 2. Pipe drains run on background threads so >64 KB output never
 //!    deadlocks `wait()`.
 //! 3. Timeout enforcement is uniform: when a deadline elapses, the child
@@ -13,18 +17,17 @@
 use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::thread;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
 
-use harn_vm::process_sandbox;
 use harn_vm::VmValue;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use crate::error::HostlibError;
+use crate::process::{self as process_handle, ProcessError, SpawnSpec};
 use crate::tools::response::ResponseBuilder;
 
 mod artifacts;
@@ -73,12 +76,7 @@ pub(crate) struct SpawnOutcome {
     pub(crate) timed_out: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum EnvMode {
-    InheritClean,
-    Replace,
-    Patch,
-}
+pub(crate) use crate::process::EnvMode;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CaptureConfig {
@@ -123,66 +121,28 @@ impl CommandStatus {
 /// `HostlibError::Backend` so the surrounding builtin gets a uniform
 /// `Thrown` dict on the script side.
 pub(crate) fn run(req: SpawnRequest) -> Result<SpawnOutcome, HostlibError> {
-    if req.program.is_empty() {
-        return Err(HostlibError::InvalidParameter {
-            builtin: req.builtin,
-            param: "argv",
-            message: "first element of argv must be a non-empty program name".to_string(),
-        });
-    }
-
-    let mut command = process_sandbox::std_command_for(&req.program, &req.args).map_err(|e| {
-        HostlibError::Backend {
-            builtin: req.builtin,
-            message: format!("sandbox setup failed: {e:?}"),
-        }
-    })?;
-
-    if let Some(cwd) = req.cwd.as_ref() {
-        process_sandbox::enforce_process_cwd(cwd).map_err(|e| HostlibError::Backend {
-            builtin: req.builtin,
-            message: format!("sandbox cwd rejected: {e:?}"),
-        })?;
-        command.current_dir(cwd);
-    }
-
-    if matches!(req.env_mode, EnvMode::Replace) {
-        command.env_clear();
-    }
-    if !req.env.is_empty() {
-        for (key, value) in &req.env {
-            command.env(key, value);
-        }
-    }
-
-    command.stdout(Stdio::piped());
-    command.stderr(Stdio::piped());
-    command.stdin(if req.stdin.is_some() {
-        Stdio::piped()
-    } else {
-        Stdio::null()
-    });
-
-    let command_id = next_command_id();
-    let started = Instant::now();
+    let started = std::time::Instant::now();
     let started_at = now_rfc3339();
-    let mut child = command.spawn().map_err(|e| {
-        if let Some(violation) = process_sandbox::process_spawn_error(&e) {
-            return HostlibError::Backend {
-                builtin: req.builtin,
-                message: format!("sandbox rejected spawn: {violation:?}"),
-            };
-        }
-        HostlibError::Backend {
-            builtin: req.builtin,
-            message: format!("spawn failed: {e}"),
-        }
-    })?;
-    let pid = Some(child.id());
-    let process_group_id = child_process_group_id(child.id());
+    let command_id = next_command_id();
+
+    let spec = SpawnSpec {
+        builtin: req.builtin,
+        program: req.program.clone(),
+        args: req.args.clone(),
+        cwd: req.cwd.clone(),
+        env: req.env.clone(),
+        env_mode: req.env_mode,
+        use_stdin: req.stdin.is_some(),
+        configure_process_group: false,
+    };
+    let mut handle = process_handle::spawn_process(spec)
+        .map_err(|e| process_error_to_hostlib(req.builtin, e))?;
+
+    let pid = handle.pid();
+    let process_group_id = handle.process_group_id();
 
     if let Some(stdin_data) = req.stdin.as_ref() {
-        if let Some(mut stdin) = child.stdin.take() {
+        if let Some(mut stdin) = handle.take_stdin() {
             use std::io::Write;
             // A failed write is non-fatal — the child may have closed stdin
             // immediately. We surface the eventual exit code regardless.
@@ -190,28 +150,29 @@ pub(crate) fn run(req: SpawnRequest) -> Result<SpawnOutcome, HostlibError> {
         }
     }
 
-    let stdout_handle = child.stdout.take();
-    let stderr_handle = child.stderr.take();
+    let stdout_reader = handle.take_stdout();
+    let stderr_reader = handle.take_stderr();
 
     let (out_tx, out_rx) = mpsc::channel::<Vec<u8>>();
     let (err_tx, err_rx) = mpsc::channel::<Vec<u8>>();
 
-    let stdout_thread = stdout_handle.map(|mut handle| {
+    let stdout_thread = stdout_reader.map(|mut reader| {
         thread::spawn(move || {
             let mut buf = Vec::new();
-            let _ = handle.read_to_end(&mut buf);
+            let _ = reader.read_to_end(&mut buf);
             let _ = out_tx.send(buf);
         })
     });
-    let stderr_thread = stderr_handle.map(|mut handle| {
+    let stderr_thread = stderr_reader.map(|mut reader| {
         thread::spawn(move || {
             let mut buf = Vec::new();
-            let _ = handle.read_to_end(&mut buf);
+            let _ = reader.read_to_end(&mut buf);
             let _ = err_tx.send(buf);
         })
     });
 
-    let (status, timed_out) = wait_with_timeout(&mut child, req.timeout);
+    let (status, timed_out): (Option<process_handle::ExitStatus>, bool) =
+        handle.wait_with_timeout(req.timeout).unwrap_or_default();
 
     if let Some(t) = stdout_thread {
         let _ = t.join();
@@ -227,7 +188,7 @@ pub(crate) fn run(req: SpawnRequest) -> Result<SpawnOutcome, HostlibError> {
 
     let exited = status.is_some();
     let (exit_code, signal) = match status {
-        Some(status) => decode_status(status),
+        Some(s) => decode_status(s),
         None => (-1, Some("SIGKILL".to_string())),
     };
     let command_status = if timed_out {
@@ -260,6 +221,32 @@ pub(crate) fn run(req: SpawnRequest) -> Result<SpawnOutcome, HostlibError> {
         duration: started.elapsed(),
         timed_out,
     })
+}
+
+pub(crate) fn process_error_to_hostlib(builtin: &'static str, err: ProcessError) -> HostlibError {
+    match err {
+        ProcessError::InvalidArgv(message) => HostlibError::InvalidParameter {
+            builtin,
+            param: "argv",
+            message,
+        },
+        ProcessError::SandboxSetup(message) => HostlibError::Backend {
+            builtin,
+            message: format!("sandbox setup failed: {message}"),
+        },
+        ProcessError::SandboxCwd(message) => HostlibError::Backend {
+            builtin,
+            message: format!("sandbox cwd rejected: {message}"),
+        },
+        ProcessError::SandboxSpawn(message) => HostlibError::Backend {
+            builtin,
+            message: format!("sandbox rejected spawn: {message}"),
+        },
+        ProcessError::Spawn(message) => HostlibError::Backend {
+            builtin,
+            message: format!("spawn failed: {message}"),
+        },
+    }
 }
 
 pub(crate) fn build_response(
@@ -405,71 +392,6 @@ pub(crate) fn inline_output(
     )
 }
 
-pub(crate) fn child_process_group_id(pid: u32) -> Option<u32> {
-    #[cfg(unix)]
-    {
-        extern "C" {
-            fn getpgid(pid: i32) -> i32;
-        }
-        let pgid = unsafe { getpgid(pid as i32) };
-        if pgid > 0 {
-            Some(pgid as u32)
-        } else {
-            None
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        Some(pid)
-    }
-}
-
-pub(crate) fn configure_background_process_group(command: &mut std::process::Command) {
-    #[cfg(unix)]
-    unsafe {
-        use std::os::unix::process::CommandExt;
-        command.pre_exec(|| {
-            extern "C" {
-                fn setpgid(pid: i32, pgid: i32) -> i32;
-            }
-            if setpgid(0, 0) == -1 {
-                return Err(std::io::Error::last_os_error());
-            }
-            Ok(())
-        });
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = command;
-    }
-}
-
-fn wait_with_timeout(
-    child: &mut std::process::Child,
-    timeout: Option<Duration>,
-) -> (Option<std::process::ExitStatus>, bool) {
-    let Some(timeout) = timeout else {
-        return (child.wait().ok(), false);
-    };
-    let deadline = Instant::now() + timeout;
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => return (Some(status), false),
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return (None, true);
-                }
-                // Cheap poll. Real workloads are dominated by spawn cost
-                // and pipe drain, not this sleep.
-                thread::sleep(Duration::from_millis(20));
-            }
-            Err(_) => return (child.wait().ok(), false),
-        }
-    }
-}
-
 fn lossy_prefix(bytes: &[u8], max_inline_bytes: usize) -> String {
     let cap = bytes.len().min(max_inline_bytes);
     match std::str::from_utf8(&bytes[..cap]) {
@@ -494,24 +416,16 @@ fn sandbox_enforced() -> bool {
     harn_vm::orchestration::current_execution_policy().is_some()
 }
 
-#[cfg(unix)]
-fn decode_status(status: std::process::ExitStatus) -> (i32, Option<String>) {
-    use std::os::unix::process::ExitStatusExt;
-    if let Some(code) = status.code() {
+fn decode_status(status: process_handle::ExitStatus) -> (i32, Option<String>) {
+    if let Some(code) = status.code {
         (code, None)
-    } else if let Some(sig) = status.signal() {
+    } else if let Some(sig) = status.signal {
         (-1, Some(format_signal(sig)))
     } else {
         (-1, None)
     }
 }
 
-#[cfg(not(unix))]
-fn decode_status(status: std::process::ExitStatus) -> (i32, Option<String>) {
-    (status.code().unwrap_or(-1), None)
-}
-
-#[cfg(unix)]
 fn format_signal(sig: i32) -> String {
     // Stay minimal: expose the conventional signal names hosts render.
     match sig {

--- a/crates/harn-hostlib/tests/process_tools.rs
+++ b/crates/harn-hostlib/tests/process_tools.rs
@@ -2,27 +2,38 @@
 //! (`run_command`, `run_test`, `run_build_command`,
 //! `inspect_test_results`, `manage_packages`, `cancel_handle`).
 //!
-//! POSIX-bound: every fixture spawns `bash -c "<script>"` to exercise argv,
-//! cwd, env, stdin plumbing, timeouts, and the long-running-handle drain.
-//! Bash and the shell-script vocabulary used here (`echo`, `pwd`, `1>&2`,
-//! `for i in $(seq 1 N); do printf x; done`, `printenv`, `$$`, etc.) are
-//! POSIX-only; porting the suite to Windows would require rewriting every
-//! fixture against `cmd.exe` / PowerShell, with subtle quoting and exit-code
-//! semantics that no longer test the same plumbing on both sides.
+//! These tests are **deterministic and mock-based**. Every spawn goes
+//! through a `MockSpawner` installed via
+//! `harn_hostlib::process::install_spawner`, so:
 //!
-//! See `docs/dev/windows-test-coverage.md` for the full inventory and
-//! disposition tracker (issue #946).
+//! - No real subprocess is spawned.
+//! - There is zero `std::thread::sleep` and zero `std::time::Instant::now()`
+//!   polling — we use [`harn_hostlib::tools::long_running::register_completion_notifier`]
+//!   to deterministically await the long-running waiter thread.
+//! - Tests run in well under 50 ms each.
+//!
+//! End-to-end coverage of the real-process spawn path is provided by
+//! `tests/process_tools_e2e.rs`. That suite is allowed to spawn real
+//! subprocesses; if it grows, it should move into the slow E2E job
+//! tracked by Tier 2A of the deflake epic (issue #1069).
 
 #![cfg(unix)]
 
 use std::collections::BTreeMap;
 use std::rc::Rc;
+use std::sync::Arc;
 
+use harn_hostlib::process::{
+    install_spawner, ExitStatus, MockHandleController, MockProcessConfig, MockSpawner, SpawnerGuard,
+};
+use harn_hostlib::tools::long_running::register_completion_notifier;
 use harn_hostlib::tools::ToolsCapability;
 use harn_hostlib::{BuiltinRegistry, HostlibCapability, HostlibError};
 use harn_vm::VmValue;
 use sha2::{Digest, Sha256};
 use tempfile::tempdir;
+
+// -------- harness --------
 
 fn registry() -> BuiltinRegistry {
     let mut registry = BuiltinRegistry::new();
@@ -80,10 +91,33 @@ fn require_bool(map: &BTreeMap<String, VmValue>, key: &str) -> bool {
     }
 }
 
+/// Install a fresh `MockSpawner` for the calling thread and return both the
+/// spawner (for inspection / additional enqueues) and the `SpawnerGuard`
+/// that restores the previous spawner on drop. The guard must be kept
+/// alive for the duration of the test.
+fn install_mock() -> (Arc<MockSpawner>, SpawnerGuard) {
+    let spawner = Arc::new(MockSpawner::new());
+    let guard = install_spawner(spawner.clone());
+    (spawner, guard)
+}
+
+/// Convenience: install a mock and immediately enqueue a single config.
+/// Returns the controller for the configured spawn plus the guard.
+fn install_mock_with(
+    config: MockProcessConfig,
+) -> (Arc<MockSpawner>, MockHandleController, SpawnerGuard) {
+    let (spawner, guard) = install_mock();
+    let controller = spawner.enqueue(config);
+    (spawner, controller, guard)
+}
+
 // -------- run_command --------
 
 #[test]
 fn run_command_echoes_stdout_and_reports_exit_zero() {
+    let (_spawner, _controller, _guard) =
+        install_mock_with(MockProcessConfig::with_stdout(0, "hello\n"));
+
     let mut req = dict();
     req.insert("argv".into(), vlist_str(&["bash", "-c", "echo hello"]));
     let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
@@ -101,6 +135,7 @@ fn run_command_echoes_stdout_and_reports_exit_zero() {
     assert!(require_str(&resp, "audit_id").starts_with("audit_cmd_"));
     assert!(matches!(resp.get("signal"), Some(VmValue::Nil)));
     assert!(require_int(&resp, "duration_ms") >= 0);
+
     let output_path = require_str(&resp, "output_path");
     assert_eq!(
         std::fs::read_to_string(&output_path).unwrap().trim(),
@@ -117,6 +152,8 @@ fn run_command_echoes_stdout_and_reports_exit_zero() {
 
 #[test]
 fn run_command_propagates_nonzero_exit_code() {
+    let (_spawner, _controller, _guard) = install_mock_with(MockProcessConfig::completed(7));
+
     let mut req = dict();
     req.insert("argv".into(), vlist_str(&["bash", "-c", "exit 7"]));
     let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
@@ -126,29 +163,53 @@ fn run_command_propagates_nonzero_exit_code() {
 
 #[test]
 fn run_command_pipes_stdin_into_child() {
+    // Mock `cat`: emit nothing on stdout from the spawn-side, but capture
+    // the bytes the spawn-side wrote to stdin and assert in two ways:
+    //   1. The captured bytes hit the controller's stdin buffer.
+    //   2. The SpawnSpec recorded `use_stdin = true`.
+    let (spawner, controller, _guard) = install_mock_with(MockProcessConfig::completed(0));
+
     let mut req = dict();
     req.insert("argv".into(), vlist_str(&["cat"]));
     req.insert("stdin".into(), vstr("from-stdin"));
     let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
-    assert_eq!(require_str(&resp, "stdout"), "from-stdin");
+
+    assert_eq!(require_int(&resp, "exit_code"), 0);
+
+    let captured = spawner.captured();
+    assert_eq!(captured.len(), 1);
+    assert!(captured[0].use_stdin, "stdin should be wired up in spec");
+
+    assert_eq!(controller.stdin_written(), b"from-stdin");
 }
 
 #[test]
 fn run_command_runs_in_supplied_cwd() {
+    let (spawner, _controller, _guard) = install_mock_with(MockProcessConfig::completed(0));
+
     let dir = tempdir().unwrap();
     let mut req = dict();
     req.insert("argv".into(), vlist_str(&["bash", "-c", "pwd"]));
     req.insert("cwd".into(), vstr(dir.path().to_str().unwrap()));
     let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
 
-    let stdout = require_str(&resp, "stdout");
+    assert_eq!(require_int(&resp, "exit_code"), 0);
+    let captured = spawner.captured();
+    assert_eq!(captured.len(), 1);
     let canon_cwd = std::fs::canonicalize(dir.path()).unwrap();
-    let canon_stdout = std::fs::canonicalize(stdout.trim()).unwrap();
-    assert_eq!(canon_stdout, canon_cwd);
+    assert_eq!(captured[0].cwd.as_ref().unwrap(), &canon_cwd);
 }
 
 #[test]
 fn run_command_kills_child_when_timeout_elapses() {
+    // No exit set + force_timeout = `wait_with_timeout` reports timeout
+    // immediately, no wall-clock dependence.
+    let config = MockProcessConfig {
+        force_timeout: true,
+        ..MockProcessConfig::running()
+    };
+    let (_spawner, _controller, _guard) = install_mock_with(config);
+
     let mut req = dict();
     req.insert("argv".into(), vlist_str(&["sleep", "30"]));
     req.insert("timeout_ms".into(), VmValue::Int(150));
@@ -161,6 +222,13 @@ fn run_command_kills_child_when_timeout_elapses() {
 
 #[test]
 fn run_command_capture_stderr_false_merges_into_stdout() {
+    let config = MockProcessConfig {
+        stdout: b"out\n".to_vec(),
+        stderr: b"err\n".to_vec(),
+        ..MockProcessConfig::default()
+    };
+    let (_spawner, _controller, _guard) = install_mock_with(config);
+
     let mut req = dict();
     req.insert(
         "argv".into(),
@@ -176,6 +244,9 @@ fn run_command_capture_stderr_false_merges_into_stdout() {
 
 #[test]
 fn run_command_supports_explicit_shell_mode() {
+    let (spawner, _controller, _guard) =
+        install_mock_with(MockProcessConfig::with_stdout(0, "shell-ok\n"));
+
     let mut shell: BTreeMap<String, VmValue> = BTreeMap::new();
     shell.insert("id".into(), vstr("sh"));
 
@@ -185,10 +256,23 @@ fn run_command_supports_explicit_shell_mode() {
     req.insert("shell".into(), VmValue::Dict(Rc::new(shell)));
     let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
     assert_eq!(require_str(&resp, "stdout").trim(), "shell-ok");
+
+    // Shell mode resolves to a real shell argv on the spec — verify the
+    // command flows through (echo shell-ok) somewhere in the args.
+    let captured = spawner.captured();
+    let argv_blob = format!("{} {}", captured[0].program, captured[0].args.join(" "));
+    assert!(
+        argv_blob.contains("echo shell-ok"),
+        "unexpected resolved argv: {argv_blob:?}"
+    );
 }
 
 #[test]
 fn run_command_caps_inline_output_and_read_command_output_reads_artifact() {
+    let payload = vec![b'x'; 2000];
+    let (_spawner, _controller, _guard) =
+        install_mock_with(MockProcessConfig::with_stdout(0, payload));
+
     let mut capture: BTreeMap<String, VmValue> = BTreeMap::new();
     capture.insert("max_inline_bytes".into(), VmValue::Int(8));
 
@@ -222,8 +306,11 @@ fn read_command_output_rejects_arbitrary_path_reads() {
 
 #[test]
 fn run_command_passes_env_when_supplied() {
+    let (spawner, _controller, _guard) =
+        install_mock_with(MockProcessConfig::with_stdout(0, "value-42\n"));
+
     let mut env_dict: BTreeMap<String, VmValue> = BTreeMap::new();
-    env_dict.insert("PATH".into(), vstr(env!("PATH")));
+    env_dict.insert("PATH".into(), vstr("/bin:/usr/bin"));
     env_dict.insert("HOSTLIB_TEST_VAR".into(), vstr("value-42"));
 
     let mut req = dict();
@@ -234,10 +321,17 @@ fn run_command_passes_env_when_supplied() {
     req.insert("env".into(), VmValue::Dict(Rc::new(env_dict)));
     let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
     assert_eq!(require_str(&resp, "stdout").trim(), "value-42");
+
+    let captured = spawner.captured();
+    assert_eq!(
+        captured[0].env.get("HOSTLIB_TEST_VAR"),
+        Some(&"value-42".to_string())
+    );
 }
 
 #[test]
 fn run_command_missing_argv_returns_missing_parameter() {
+    // No mock needed — fails before reaching the spawner.
     let err = call("hostlib_tools_run_command", dict()).unwrap_err();
     match err {
         HostlibError::MissingParameter { param, .. } => assert_eq!(param, "argv"),
@@ -274,6 +368,8 @@ fn run_command_argv_must_be_strings() {
 
 #[test]
 fn run_test_explicit_argv_runs_and_returns_handle() {
+    let (_spawner, _controller, _guard) = install_mock_with(MockProcessConfig::completed(0));
+
     let mut req = dict();
     req.insert("argv".into(), vlist_str(&["true"]));
     let resp = require_dict(call("hostlib_tools_run_test", req).unwrap());
@@ -292,36 +388,19 @@ fn run_test_without_argv_or_manifest_errors() {
 
 #[test]
 fn run_test_inspect_returns_parsed_records_for_explicit_junit() {
-    // Stage a JUnit XML that the bundled handler would have written, then
-    // ask `run_test` to drive a no-op runner and point at it via argv.
-    let dir = tempdir().unwrap();
-    let junit = dir.path().join("junit.xml");
-    std::fs::write(
-        &junit,
-        r#"<?xml version="1.0"?>
-<testsuites>
-  <testsuite name="suite">
-    <testcase classname="C" name="passes" time="0.001"/>
-    <testcase classname="C" name="fails" time="0.005">
-      <failure message="boom">trace</failure>
-    </testcase>
-  </testsuite>
-</testsuites>"#,
-    )
-    .unwrap();
+    // Mock a cargo libtest-style stdout that the parser auto-detects.
+    let stdout = "running 2 tests\n\
+                  test a::passes ... ok\n\
+                  test a::fails ... FAILED\n\
+                  \n\
+                  test result: FAILED. 1 passed; 1 failed; 0 ignored\n";
+    let (_spawner, _controller, _guard) =
+        install_mock_with(MockProcessConfig::with_stdout(1, stdout));
 
-    // Mock pytest by passing argv that just `cat`s the JUnit and exits 0,
-    // but since explicit-argv `run_test` won't know to look for the file,
-    // we test via inspect_test_results stable behavior: shape it like
-    // the cargo libtest text path which the parser auto-detects.
     let mut req = dict();
     req.insert(
         "argv".into(),
-        vlist_str(&[
-            "bash",
-            "-c",
-            "echo 'running 2 tests'; echo 'test a::passes ... ok'; echo 'test a::fails ... FAILED'; printf '\\n'; echo 'test result: FAILED. 1 passed; 1 failed; 0 ignored'; exit 1",
-        ]),
+        vlist_str(&["bash", "-c", "echo cargo libtest output"]),
     );
     let resp = require_dict(call("hostlib_tools_run_test", req).unwrap());
     assert_eq!(require_int(&resp, "exit_code"), 1);
@@ -341,6 +420,9 @@ fn run_test_inspect_returns_parsed_records_for_explicit_junit() {
 
 #[test]
 fn run_test_summary_omitted_when_no_records_parsed() {
+    let (_spawner, _controller, _guard) =
+        install_mock_with(MockProcessConfig::with_stdout(0, "nothing\n"));
+
     let mut req = dict();
     req.insert("argv".into(), vlist_str(&["bash", "-c", "echo nothing"]));
     let resp = require_dict(call("hostlib_tools_run_test", req).unwrap());
@@ -374,6 +456,12 @@ fn inspect_test_results_missing_handle_errors() {
 
 #[test]
 fn run_build_command_explicit_argv_runs_and_parses_diagnostics() {
+    let config = MockProcessConfig {
+        stderr: b"src/foo.rs:3:7: error: parse error here\n".to_vec(),
+        ..MockProcessConfig::completed(2)
+    };
+    let (_spawner, _controller, _guard) = install_mock_with(config);
+
     let mut req = dict();
     req.insert(
         "argv".into(),
@@ -430,7 +518,6 @@ fn manage_packages_no_ecosystem_no_manifest_errors() {
 
 #[test]
 fn manage_packages_unsupported_pair_for_ecosystem_errors() {
-    // Gradle does not have a portable CLI mapping for adding dependencies.
     let mut req = dict();
     req.insert("operation".into(), vstr("add"));
     req.insert("ecosystem".into(), vstr("gradle"));
@@ -440,48 +527,34 @@ fn manage_packages_unsupported_pair_for_ecosystem_errors() {
 }
 
 #[test]
-fn manage_packages_runs_for_detected_npm_workspace_when_manifest_present() {
-    // We can't actually invoke `npm install` in a sandboxed tmp directory
-    // without network access, so use an `ecosystem` that maps to a tiny
-    // synthetic command via the executable-on-PATH machinery. We re-run
-    // the real plumbing by overriding the ecosystem to something whose
-    // first argv element is a no-op shell builtin.
-    //
-    // This test asserts that *given* an explicit ecosystem + a real cwd,
-    // the builtin assembles + spawns + collects an outcome. It uses the
-    // `bundler` ecosystem with `update` (no packages) → `bundle update`,
-    // then accepts whatever exit code the missing binary yields. The
-    // important part: no panic, structured response, lockfile_changed
-    // reported as a bool.
+fn manage_packages_runs_for_detected_ecosystem_with_explicit_cwd() {
+    let (spawner, _controller, _guard) = install_mock_with(MockProcessConfig::completed(0));
+
     let dir = tempdir().unwrap();
     let mut req = dict();
     req.insert("operation".into(), vstr("update"));
     req.insert("ecosystem".into(), vstr("bundler"));
     req.insert("cwd".into(), vstr(dir.path().to_str().unwrap()));
-    let result = call("hostlib_tools_manage_packages", req);
-    match result {
-        Ok(value) => {
-            let resp = require_dict(value);
-            assert_eq!(require_str(&resp, "ecosystem"), "bundler");
-            assert_eq!(require_str(&resp, "operation"), "update");
-            assert!(matches!(
-                resp.get("lockfile_changed"),
-                Some(VmValue::Bool(_))
-            ));
-        }
-        Err(HostlibError::Backend { .. }) => {
-            // Spawn failed because `bundle` isn't installed in CI — that's
-            // a valid sandbox-aware backend error, not a contract bug.
-        }
-        Err(other) => panic!("unexpected error variant: {other:?}"),
-    }
+    let resp = require_dict(call("hostlib_tools_manage_packages", req).unwrap());
+    assert_eq!(require_str(&resp, "ecosystem"), "bundler");
+    assert_eq!(require_str(&resp, "operation"), "update");
+    assert!(matches!(
+        resp.get("lockfile_changed"),
+        Some(VmValue::Bool(_))
+    ));
+    // Spec captured `bundle update`.
+    let captured = spawner.captured();
+    assert_eq!(captured[0].program, "bundle");
+    assert_eq!(captured[0].args, vec!["update".to_string()]);
 }
 
 // -------- long_running handles --------
 
 #[test]
 fn run_command_long_running_returns_handle_immediately() {
-    // A 10-second sleep: the handle must arrive before the process exits.
+    // Stay running until the test cancels.
+    let (_spawner, _controller, _guard) = install_mock_with(MockProcessConfig::running());
+
     let mut req = dict();
     req.insert("argv".into(), vlist_str(&["sleep", "10"]));
     req.insert("long_running".into(), VmValue::Bool(true));
@@ -504,17 +577,23 @@ fn run_command_long_running_returns_handle_immediately() {
         "command should contain 'sleep', got {cmd}"
     );
 
-    // Clean up: cancel so sleep doesn't outlive the test.
+    // Block on waiter completion before returning so the test stays
+    // deterministic — cancel signals the notifier itself.
+    let completion_rx = register_completion_notifier(&handle_id);
+
+    // Clean up: cancel so the waiter unblocks.
     let mut cancel_req = dict();
     cancel_req.insert("handle_id".into(), vstr(&handle_id));
     let cancel_resp = require_dict(call("hostlib_tools_cancel_handle", cancel_req).unwrap());
     assert!(require_bool(&cancel_resp, "cancelled"));
+
+    if let Some(rx) = completion_rx {
+        let _ = rx.recv();
+    }
 }
 
 #[test]
 fn run_command_long_running_feedback_fires_after_exit() {
-    use std::time::Duration;
-
     // Use a process-unique session id so parallel tests don't interfere.
     let session_id = format!(
         "test-lr-feedback-{}-{:?}",
@@ -522,7 +601,9 @@ fn run_command_long_running_feedback_fires_after_exit() {
         std::thread::current().id()
     );
 
-    // Spawn a short-lived process: echoes stdout, stderr, then exits 0.
+    // Stay running until the controller signals exit.
+    let (_spawner, controller, _guard) = install_mock_with(MockProcessConfig::running());
+
     let info = harn_hostlib::tools::long_running::spawn_long_running(
         "test_builtin",
         "bash".into(),
@@ -535,61 +616,61 @@ fn run_command_long_running_feedback_fires_after_exit() {
         session_id.clone(),
     )
     .expect("spawn_long_running failed");
-
     assert!(!info.handle_id.is_empty());
 
-    // Poll the global feedback queue until the item arrives (max 5 s).
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    loop {
-        let items = harn_vm::drain_global_pending_feedback(&session_id);
-        if !items.is_empty() {
-            let (kind, content) = &items[0];
-            assert_eq!(kind, "tool_result", "unexpected feedback kind: {kind}");
-            let payload: serde_json::Value =
-                serde_json::from_str(content).expect("feedback content not valid JSON");
-            assert_eq!(
-                payload["handle_id"].as_str().unwrap(),
-                info.handle_id,
-                "handle_id mismatch in feedback"
-            );
-            assert_eq!(payload["exit_code"], 0);
-            assert_eq!(payload["status"], "completed");
-            assert!(payload["output_path"]
-                .as_str()
-                .unwrap()
-                .contains("combined.txt"));
-            assert!(
-                payload["stdout"].as_str().unwrap().contains("hello stdout"),
-                "stdout missing: {}",
-                payload["stdout"]
-            );
-            assert!(
-                payload["stderr"].as_str().unwrap().contains("hello stderr"),
-                "stderr missing: {}",
-                payload["stderr"]
-            );
-            assert!(
-                payload["duration_ms"].as_i64().unwrap() >= 0,
-                "duration_ms must be non-negative"
-            );
-            return;
-        }
-        if std::time::Instant::now() >= deadline {
-            panic!("feedback never arrived in 5 s");
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
+    // Register a completion notifier BEFORE pushing the exit so we can
+    // recv on it once the waiter publishes the feedback item.
+    let completion_rx =
+        register_completion_notifier(&info.handle_id).expect("handle should still be live");
+
+    controller.append_stdout(b"hello stdout\n");
+    controller.append_stderr(b"hello stderr\n");
+    controller.complete_with(ExitStatus::from_code(0));
+
+    completion_rx.recv().expect("waiter completion never fired");
+
+    let items = harn_vm::drain_global_pending_feedback(&session_id);
+    assert_eq!(items.len(), 1, "expected exactly one feedback item");
+    let (kind, content) = &items[0];
+    assert_eq!(kind, "tool_result", "unexpected feedback kind: {kind}");
+    let payload: serde_json::Value =
+        serde_json::from_str(content).expect("feedback content not valid JSON");
+    assert_eq!(
+        payload["handle_id"].as_str().unwrap(),
+        info.handle_id,
+        "handle_id mismatch in feedback"
+    );
+    assert_eq!(payload["exit_code"], 0);
+    assert_eq!(payload["status"], "completed");
+    assert!(payload["output_path"]
+        .as_str()
+        .unwrap()
+        .contains("combined.txt"));
+    assert!(
+        payload["stdout"].as_str().unwrap().contains("hello stdout"),
+        "stdout missing: {}",
+        payload["stdout"]
+    );
+    assert!(
+        payload["stderr"].as_str().unwrap().contains("hello stderr"),
+        "stderr missing: {}",
+        payload["stderr"]
+    );
+    assert!(
+        payload["duration_ms"].as_i64().unwrap() >= 0,
+        "duration_ms must be non-negative"
+    );
 }
 
 #[test]
 fn cancel_handle_kills_long_running_process() {
-    use std::time::Duration;
-
     let session_id = format!(
         "test-lr-cancel-{}-{:?}",
         std::process::id(),
         std::thread::current().id()
     );
+
+    let (_spawner, _controller, _guard) = install_mock_with(MockProcessConfig::running());
 
     let info = harn_hostlib::tools::long_running::spawn_long_running(
         "test_builtin",
@@ -600,6 +681,9 @@ fn cancel_handle_kills_long_running_process() {
         session_id.clone(),
     )
     .expect("spawn_long_running failed");
+
+    // Register so cancel signals it.
+    let completion_rx = register_completion_notifier(&info.handle_id);
 
     // Cancel via the builtin — should return cancelled: true.
     let mut req = dict();
@@ -617,11 +701,16 @@ fn cancel_handle_kills_long_running_process() {
         "second cancel should return false"
     );
 
-    // A feedback item for the killed process may or may not arrive depending
-    // on whether the waiter thread observed the exit before we removed the
-    // entry. Drain and discard so we don't pollute other tests.
-    std::thread::sleep(Duration::from_millis(200));
-    harn_vm::drain_global_pending_feedback(&session_id);
+    if let Some(rx) = completion_rx {
+        let _ = rx.recv();
+    }
+
+    // Cancelled handles never push feedback — drain returns empty.
+    let items = harn_vm::drain_global_pending_feedback(&session_id);
+    assert!(
+        items.is_empty(),
+        "cancelled handle should not push feedback, got {items:?}"
+    );
 }
 
 #[test]
@@ -634,6 +723,8 @@ fn cancel_handle_unknown_handle_returns_false() {
 
 #[test]
 fn run_test_long_running_returns_handle() {
+    let (_spawner, _controller, _guard) = install_mock_with(MockProcessConfig::running());
+
     let mut req = dict();
     req.insert("argv".into(), vlist_str(&["sleep", "10"]));
     req.insert("long_running".into(), VmValue::Bool(true));
@@ -644,14 +735,19 @@ fn run_test_long_running_returns_handle() {
         "unexpected handle_id: {handle_id}"
     );
 
-    // Clean up.
+    let completion_rx = register_completion_notifier(&handle_id);
     let mut cancel_req = dict();
     cancel_req.insert("handle_id".into(), vstr(&handle_id));
     call("hostlib_tools_cancel_handle", cancel_req).unwrap();
+    if let Some(rx) = completion_rx {
+        let _ = rx.recv();
+    }
 }
 
 #[test]
 fn run_build_command_long_running_returns_handle() {
+    let (_spawner, _controller, _guard) = install_mock_with(MockProcessConfig::running());
+
     let mut req = dict();
     req.insert("argv".into(), vlist_str(&["sleep", "10"]));
     req.insert("long_running".into(), VmValue::Bool(true));
@@ -662,8 +758,11 @@ fn run_build_command_long_running_returns_handle() {
         "unexpected handle_id: {handle_id}"
     );
 
-    // Clean up.
+    let completion_rx = register_completion_notifier(&handle_id);
     let mut cancel_req = dict();
     cancel_req.insert("handle_id".into(), vstr(&handle_id));
     call("hostlib_tools_cancel_handle", cancel_req).unwrap();
+    if let Some(rx) = completion_rx {
+        let _ = rx.recv();
+    }
 }

--- a/crates/harn-hostlib/tests/process_tools_e2e.rs
+++ b/crates/harn-hostlib/tests/process_tools_e2e.rs
@@ -1,0 +1,103 @@
+//! End-to-end smoke coverage for the real-process spawn path.
+//!
+//! `tests/process_tools.rs` exercises the process-tool builtins against
+//! a [`MockSpawner`](harn_hostlib::process::MockSpawner) and is the
+//! deterministic default. This file keeps a small smoke suite that
+//! actually spawns real subprocesses through
+//! [`harn_hostlib::process::default_spawner`] so the trait wiring isn't
+//! drifting away from real semantics.
+//!
+//! These tests are wall-clock-dependent (they spawn `bash`, `sleep`,
+//! etc.) and therefore live in their own integration target. When the
+//! test-suite tiering work in issue #1069 lands, the goal is to tag
+//! this target into the slow E2E job so it runs on schedule rather
+//! than every push.
+
+#![cfg(unix)]
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use harn_hostlib::tools::ToolsCapability;
+use harn_hostlib::{BuiltinRegistry, HostlibCapability, HostlibError};
+use harn_vm::VmValue;
+
+fn registry() -> BuiltinRegistry {
+    let mut registry = BuiltinRegistry::new();
+    ToolsCapability.register_builtins(&mut registry);
+    registry
+}
+
+fn call(builtin: &str, request: BTreeMap<String, VmValue>) -> Result<VmValue, HostlibError> {
+    harn_hostlib::tools::permissions::enable_for_test();
+    let registry = registry();
+    let entry = registry
+        .find(builtin)
+        .unwrap_or_else(|| panic!("builtin {builtin} not registered"));
+    let arg = VmValue::Dict(Rc::new(request));
+    (entry.handler)(&[arg])
+}
+
+fn dict() -> BTreeMap<String, VmValue> {
+    BTreeMap::new()
+}
+
+fn vstr(value: &str) -> VmValue {
+    VmValue::String(Rc::from(value))
+}
+
+fn vlist_str(values: &[&str]) -> VmValue {
+    VmValue::List(Rc::new(values.iter().map(|s| vstr(s)).collect()))
+}
+
+fn require_dict(value: VmValue) -> BTreeMap<String, VmValue> {
+    match value {
+        VmValue::Dict(map) => (*map).clone(),
+        other => panic!("expected dict response, got {other:?}"),
+    }
+}
+
+fn require_int(map: &BTreeMap<String, VmValue>, key: &str) -> i64 {
+    match map.get(key) {
+        Some(VmValue::Int(i)) => *i,
+        other => panic!("expected int at {key}, got {other:?}"),
+    }
+}
+
+fn require_str(map: &BTreeMap<String, VmValue>, key: &str) -> String {
+    match map.get(key) {
+        Some(VmValue::String(s)) => s.to_string(),
+        other => panic!("expected string at {key}, got {other:?}"),
+    }
+}
+
+fn require_bool(map: &BTreeMap<String, VmValue>, key: &str) -> bool {
+    match map.get(key) {
+        Some(VmValue::Bool(b)) => *b,
+        other => panic!("expected bool at {key}, got {other:?}"),
+    }
+}
+
+#[test]
+fn real_run_command_echoes_stdout_and_reports_exit_zero() {
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["bash", "-c", "echo hello"]));
+    let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
+    assert_eq!(require_int(&resp, "exit_code"), 0);
+    assert_eq!(require_str(&resp, "stdout").trim(), "hello");
+    assert_eq!(require_str(&resp, "status"), "completed");
+    assert!(!require_bool(&resp, "timed_out"));
+}
+
+#[test]
+fn real_run_command_kills_child_when_timeout_elapses() {
+    // Smoke: the real `wait_with_timeout` should fire SIGKILL when the
+    // child blocks past the deadline. Use a very short sleep so the test
+    // doesn't bloat the slow suite — under 250 ms wall-clock total.
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["sleep", "5"]));
+    req.insert("timeout_ms".into(), VmValue::Int(150));
+    let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
+    assert!(require_bool(&resp, "timed_out"));
+    assert_eq!(require_str(&resp, "status"), "timed_out");
+}


### PR DESCRIPTION
## Summary

- Adds `ProcessHandle` / `ProcessSpawner` traits + `MockSpawner` test double in a new `crates/harn-hostlib/src/process/` module so `tools/proc.rs` and `tools/long_running.rs` no longer touch `std::process::Child` directly.
- Rewrites all 33 integration tests in `tests/process_tools.rs` to install a per-thread `MockSpawner` — zero `std::thread::sleep`, zero `Instant::now()` polling, zero real subprocesses. The full file finishes in 0.01 s and is flake-free across 50× nextest reruns.
- Long-running waiter completion is awaited deterministically via a new `register_completion_notifier(handle_id)` API (mpsc sync_channel that fires after the waiter publishes feedback or after `cancel_handle` runs).
- Two real-process smoke tests live in `tests/process_tools_e2e.rs` so the trait wiring stays honest end-to-end. The `_e2e.rs` suffix is so issue [#1069](https://github.com/burin-labs/harn/issues/1069) can pick them up for slow-job tagging.

Closes [#1062](https://github.com/burin-labs/harn/issues/1062). Tier 1C of the de-flake epic [#1057](https://github.com/burin-labs/harn/issues/1057). Stacked on [#1081](https://github.com/burin-labs/harn/pull/1081).

## Test plan

- [x] `grep -rn 'std::thread::sleep\|Instant::now()' crates/harn-hostlib/tests/process_tools.rs` returns zero matches.
- [x] All 33 mock tests + 2 e2e smoke tests pass.
- [x] 50× rerun under `cargo nextest run -p harn-hostlib --test process_tools` is flake-free.
- [x] `--test-threads=1` parity verified.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes.
- [x] `make test` green (3134 tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)