### PR TITLE
Convert CLI tests to in-process; gate binary-surface tests as ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,19 @@ condensed series summaries instead of full per-patch history.
   harn-cli subprocess tests and raises the nextest concurrency cap to
   cut local + CI test wall-clock.
 
+- **In-process CLI tests (#1067).** `merge_captain_cli`,
+  `crystallize_cli`, and `check_cli` now exercise the underlying
+  workspace library crates (`harn_vm::orchestration::*`,
+  `harn_parser::TypeChecker`, `harn_modules::build`) directly instead of
+  spawning the `harn` debug binary per case. Subprocess-driven CLI
+  tests that genuinely cover binary surface (signal handling, exit-code
+  mapping, stdio JSON-RPC) — `run_exit_codes`, `mcp_server_cli`,
+  `acp_server_cli`, `harn_serve_mcp_cli`, `orchestrator_cli`,
+  `orchestrator_inbox_dedupe`, plus `flow_ship_cli`, `persona_cli`,
+  `llm_mock_cli`, `trigger_replay_cli`, `burin_mini_playground` pending
+  follow-up library-API extraction — are gated behind `#[ignore]` for
+  the slow E2E suite (#1069) and skipped on the push hook.
+
 - **Windows-only typed error returns** (fix-forward). The #1032
   migration left two `cfg(not(unix))`/`cfg(windows)` paths returning
   `Result<(), String>` against typed signatures (Ctrl-C loop in

--- a/crates/harn-cli/tests/acp_server_cli.rs
+++ b/crates/harn-cli/tests/acp_server_cli.rs
@@ -120,6 +120,7 @@ fn latest_prompt_summary(notifications: &[JsonValue], session_id: &str) -> JsonV
 }
 
 #[test]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
     let _guard = lock_acp_cli_tests();
     let temp = TempDir::new().unwrap();
@@ -319,6 +320,7 @@ fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
 }
 
 #[test]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 fn serve_acp_stdio_runs_packaged_adapter() {
     let _guard = lock_acp_cli_tests();
     let temp = TempDir::new().unwrap();

--- a/crates/harn-cli/tests/burin_mini_playground.rs
+++ b/crates/harn-cli/tests/burin_mini_playground.rs
@@ -98,6 +98,7 @@ fn run_case(task: &str, fixture_name: &str) -> (TempDir, PathBuf, Output) {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn burin_mini_explain_repo_fixture_run_passes() {
     let (_temp, experiment_root, output) =
         run_case("Explain this repo to me in simple terms", "explain.jsonl");
@@ -121,6 +122,7 @@ fn burin_mini_explain_repo_fixture_run_passes() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn burin_mini_comment_file_fixture_run_updates_workspace_copy() {
     let (_temp, experiment_root, output) = run_case("Comment what this file does", "comment.jsonl");
 
@@ -176,6 +178,7 @@ fn burin_mini_comment_file_fixture_run_updates_workspace_copy() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn burin_mini_rate_limit_fixture_run_wires_middleware() {
     let (_temp, experiment_root, output) = run_case(
         "Add rate limiting middleware to the auth module",
@@ -292,6 +295,7 @@ fn burin_mini_rate_limit_fixture_run_wires_middleware() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn burin_mini_rate_limit_liveish_fixture_ignores_redundant_read_actions() {
     let (_temp, experiment_root, output) = run_case(
         "Add rate limiting middleware to the auth module",
@@ -342,6 +346,7 @@ fn burin_mini_rate_limit_liveish_fixture_ignores_redundant_read_actions() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn burin_mini_rate_limit_weak_verify_plan_normalizes_to_single_verify_action() {
     let (_temp, experiment_root, output) = run_case(
         "Add rate limiting middleware to the auth module",
@@ -412,6 +417,7 @@ fn burin_mini_rate_limit_weak_verify_plan_normalizes_to_single_verify_action() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn burin_mini_rate_limit_overresearch_planner_commits_final_action_graph() {
     let (_temp, experiment_root, output) = run_case(
         "Add rate limiting middleware to the auth module",
@@ -458,6 +464,7 @@ fn burin_mini_rate_limit_overresearch_planner_commits_final_action_graph() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn burin_mini_semantic_evaluator_heuristic_passes_for_rate_limit_fixture() {
     let (temp, experiment_root) = setup_experiment_copy();
     let evaluator = experiment_root.join("evaluator.harn");

--- a/crates/harn-cli/tests/check_cli.rs
+++ b/crates/harn-cli/tests/check_cli.rs
@@ -1,120 +1,95 @@
-mod test_util;
+//! In-process tests for `harn check` / `harn lint` semantics.
+//!
+//! Replaces the prior subprocess-spawning version (#1067). The two
+//! regressions guarded here both live in workspace library crates
+//! (`harn_parser` for the type-diagnostic case, `harn_modules` for the
+//! cross-directory cycle case), so the tests call those crates directly
+//! without paying the cold-start cost of spawning the `harn` binary.
 
 use std::fs;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+use harn_lexer::Lexer;
+use harn_parser::{diagnostic::render_type_diagnostic, DiagnosticSeverity, Parser, TypeChecker};
 use tempfile::TempDir;
-use test_util::process::harn_command;
 
 #[test]
 fn check_reports_unknown_struct_type_in_stderr() {
     let temp = TempDir::new().unwrap();
     let script = temp.path().join("main.harn");
-    fs::write(&script, "let p = Point { x: 3, y: 4 }\n").unwrap();
+    let source = "let p = Point { x: 3, y: 4 }\n";
+    fs::write(&script, source).unwrap();
 
-    let output = harn_command()
-        .current_dir(temp.path())
-        .args(["check", script.to_str().unwrap()])
-        .output()
-        .unwrap();
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().expect("lex");
+    let program = Parser::new(tokens).parse().expect("parse");
+    let diagnostics = TypeChecker::new().check_with_source(&program, source);
+
+    let path_str = script.to_string_lossy().into_owned();
+    let mut rendered_messages = String::new();
+    let mut had_error = false;
+    for diag in &diagnostics {
+        if matches!(diag.severity, DiagnosticSeverity::Error) {
+            had_error = true;
+        }
+        rendered_messages.push_str(&render_type_diagnostic(source, &path_str, diag));
+    }
 
     assert!(
-        !output.status.success(),
-        "expected nonzero exit, stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+        had_error,
+        "expected a type-checker error; got diagnostics={:#?}",
+        diagnostics
     );
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("unknown struct type `Point`"),
-        "missing unknown-struct diagnostic: {stderr}"
+        rendered_messages.contains("unknown struct type `Point`"),
+        "missing unknown-struct diagnostic in:\n{rendered_messages}"
     );
     assert!(
-        stderr.contains(&format!("{}:1:9", script.display())),
-        "missing precise location in stderr: {stderr}"
+        rendered_messages.contains(&format!("{}:1:9", path_str)),
+        "missing precise location in:\n{rendered_messages}"
     );
 }
 
-/// CLI-level regression for the Linux hang on `harn lint <dir>` and
+/// Regression for the Linux hang on `harn lint <dir>` and
 /// `harn check --workspace` against pipeline trees with cyclic
 /// cross-sibling-directory relative imports (#748). The underlying fix
-/// (`harn_modules::build()` canonicalizing before seen-set dedupe,
-/// #93) already has a unit test in `harn-modules`. This test guards
-/// the same regression at the CLI surface so a future walker change in
-/// `lint` / `check --workspace` that re-introduces the explosion is
-/// caught here rather than in downstream pipeline trees like
-/// burin-code's. Four sibling directories × six files importing every
-/// other directory by relative path — the exact pattern that produced
-/// fresh path spellings on every round-trip and OOM-killed Linux CI
-/// runners around 48 s pre-fix.
+/// (`harn_modules::build()` canonicalizing before seen-set dedupe, #93)
+/// already has a unit test in `harn-modules`; this test guards the same
+/// regression at the API the CLI walkers actually call. Pre-fix the
+/// `build` call OOM-killed Linux CI runners around 48s; post-fix every
+/// supported platform completes in well under a second.
 #[test]
-fn lint_and_check_complete_on_large_cross_directory_cycle_workspace() {
+fn module_graph_build_completes_on_large_cross_directory_cycle_workspace() {
     let temp = TempDir::new().unwrap();
-    let root = temp.path();
-    let pipelines = root.join("Sources/pipelines");
-    write_cross_directory_cycle_workspace(&pipelines);
+    let pipelines = temp.path().join("Sources/pipelines");
+    let files = write_cross_directory_cycle_workspace(&pipelines);
 
-    fs::write(
-        root.join("harn.toml"),
-        "[package]\n\
-         name = \"hang-regression\"\n\
-         version = \"0.0.0\"\n\
-         \n\
-         [workspace]\n\
-         pipelines = [\"Sources/pipelines\"]\n",
-    )
-    .unwrap();
-
-    // Post-fix this completes in well under a second on every supported
-    // platform; pre-fix on Linux it OOM-killed around 48 s. The 60 s
-    // budget gives slow CI shapes (qemu, sandboxed builders) headroom
-    // without letting a regression sit silently.
     let budget = Duration::from_secs(60);
-
-    let lint_started = Instant::now();
-    let lint_output = harn_command()
-        .current_dir(root)
-        .args(["lint", pipelines.to_str().unwrap()])
-        .output()
-        .unwrap();
-    let lint_elapsed = lint_started.elapsed();
+    let started = Instant::now();
+    let graph = harn_modules::build(&files);
+    let elapsed = started.elapsed();
     assert!(
-        lint_output.status.success(),
-        "lint failed: status={:?} stdout={} stderr={}",
-        lint_output.status,
-        String::from_utf8_lossy(&lint_output.stdout),
-        String::from_utf8_lossy(&lint_output.stderr)
+        elapsed < budget,
+        "harn_modules::build took {elapsed:?} (>{budget:?}) — likely a regression to the path-spelling explosion fixed by #93"
     );
-    assert!(
-        lint_elapsed < budget,
-        "lint took {lint_elapsed:?} (>{budget:?}) — likely a regression to the path-spelling explosion fixed by #93"
-    );
-
-    let check_started = Instant::now();
-    let check_output = harn_command()
-        .current_dir(root)
-        .args(["check", "--workspace"])
-        .output()
-        .unwrap();
-    let check_elapsed = check_started.elapsed();
-    assert!(
-        check_output.status.success(),
-        "check --workspace failed: status={:?} stdout={} stderr={}",
-        check_output.status,
-        String::from_utf8_lossy(&check_output.stdout),
-        String::from_utf8_lossy(&check_output.stderr)
-    );
-    assert!(
-        check_elapsed < budget,
-        "check --workspace took {check_elapsed:?} (>{budget:?}) — likely a regression to the path-spelling explosion fixed by #93"
-    );
+    // Every file participated in the graph (no silent drops). The walker
+    // must reach every entry point at least once even with cyclic edges.
+    for file in &files {
+        // A file that the walker actually visited will have at least one
+        // imported-name set (every file imports from three siblings).
+        assert!(
+            graph.imported_names_for_file(file).is_some(),
+            "module graph missing entry for {}",
+            file.display()
+        );
+    }
 }
 
-fn write_cross_directory_cycle_workspace(pipelines: &Path) {
+fn write_cross_directory_cycle_workspace(pipelines: &Path) -> Vec<std::path::PathBuf> {
     let dirs = ["context", "runtime", "host", "tools"];
     let files_per_dir = 6;
+    let mut files = Vec::new();
     for dir in dirs {
         fs::create_dir_all(pipelines.join(dir)).unwrap();
     }
@@ -129,11 +104,10 @@ fn write_cross_directory_cycle_workspace(pipelines: &Path) {
                 source.push_str(&format!("import \"../{other}/{target}\"\n"));
             }
             source.push_str(&format!("pub fn {dir}_m{file_idx}() {{ {file_idx} }}\n"));
-            fs::write(
-                pipelines.join(dir).join(format!("m{file_idx}.harn")),
-                source,
-            )
-            .unwrap();
+            let path = pipelines.join(dir).join(format!("m{file_idx}.harn"));
+            fs::write(&path, source).unwrap();
+            files.push(path);
         }
     }
+    files
 }

--- a/crates/harn-cli/tests/crystallize_cli.rs
+++ b/crates/harn-cli/tests/crystallize_cli.rs
@@ -1,20 +1,17 @@
-mod test_util;
+//! In-process tests for the `harn crystallize` library API
+//! (`harn_vm::orchestration::*`). Replaces the prior subprocess-spawning
+//! version that ran the `harn` binary per case (#1067).
 
 use std::fs;
 use std::path::Path;
-use std::process::Output;
 
+use harn_vm::orchestration::{
+    build_crystallization_bundle, crystallize_traces, load_crystallization_traces_from_dir,
+    shadow_replay_bundle, validate_crystallization_bundle, write_crystallization_artifacts,
+    write_crystallization_bundle, BundleOptions, CrystallizationArtifacts, CrystallizeOptions,
+};
 use serde_json::{json, Value};
 use tempfile::TempDir;
-use test_util::process::harn_command;
-
-fn run_harn(cwd: &Path, args: &[&str]) -> Output {
-    harn_command()
-        .current_dir(cwd)
-        .args(args)
-        .output()
-        .expect("failed to spawn harn binary")
-}
 
 fn write_trace(dir: &Path, name: &str, payload: &Value) {
     let path = dir.join(name);
@@ -102,6 +99,84 @@ fn plan_only_trace(idx: usize) -> Value {
     })
 }
 
+/// Run the same pipeline as `harn crystallize <flags>` (the `mine`
+/// path). Returns `(report_path, bundle_dir)` so callers can inspect
+/// on-disk artifacts.
+struct MineOutcome {
+    artifacts: CrystallizationArtifacts,
+    workflow_path: std::path::PathBuf,
+    report_path: std::path::PathBuf,
+    eval_pack_path: Option<std::path::PathBuf>,
+    bundle_dir: std::path::PathBuf,
+}
+
+fn mine(
+    temp: &TempDir,
+    traces_dir: &Path,
+    workflow_name: &str,
+    package_name: Option<&str>,
+    bundle_team: Option<&str>,
+    bundle_repo: Option<&str>,
+    eval_pack: bool,
+    min_examples: usize,
+) -> MineOutcome {
+    let traces = load_crystallization_traces_from_dir(traces_dir).unwrap();
+    let normalized = traces.clone();
+    let eval_pack_path = if eval_pack {
+        Some(temp.path().join(format!("{workflow_name}.harn.eval.toml")))
+    } else {
+        None
+    };
+    let artifacts = crystallize_traces(
+        traces,
+        CrystallizeOptions {
+            min_examples,
+            workflow_name: Some(workflow_name.to_string()),
+            package_name: package_name.map(str::to_string),
+            author: None,
+            approver: None,
+            eval_pack_link: eval_pack_path
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned()),
+        },
+    )
+    .unwrap();
+
+    let bundle_dir = temp.path().join("bundle");
+    let bundle = build_crystallization_bundle(
+        artifacts.clone(),
+        &normalized,
+        BundleOptions {
+            external_key: None,
+            title: None,
+            team: bundle_team.map(str::to_string),
+            repo: bundle_repo.map(str::to_string),
+            risk_level: None,
+            rollout_policy: None,
+        },
+    )
+    .unwrap();
+
+    let workflow_path = temp.path().join(format!("{workflow_name}.harn"));
+    let report_path = temp.path().join("report.json");
+    write_crystallization_artifacts(
+        artifacts.clone(),
+        &workflow_path,
+        &report_path,
+        eval_pack_path.as_deref(),
+    )
+    .unwrap();
+    write_crystallization_bundle(&bundle, &bundle_dir).unwrap();
+
+    MineOutcome {
+        artifacts,
+        workflow_path,
+        report_path,
+        eval_pack_path,
+        bundle_dir,
+    }
+}
+
 #[test]
 fn crystallize_version_bump_emits_validatable_bundle() {
     let temp = TempDir::new().unwrap();
@@ -114,46 +189,27 @@ fn crystallize_version_bump_emits_validatable_bundle() {
             &version_bump_trace(idx),
         );
     }
-    let workflow_path = temp.path().join("version_bump.harn");
-    let report_path = temp.path().join("report.json");
-    let eval_pack_path = temp.path().join("version_bump.harn.eval.toml");
-    let bundle_dir = temp.path().join("bundle");
 
-    let mine = run_harn(
-        temp.path(),
-        &[
-            "crystallize",
-            "--from",
-            traces_dir.to_str().unwrap(),
-            "--out",
-            workflow_path.to_str().unwrap(),
-            "--report",
-            report_path.to_str().unwrap(),
-            "--eval-pack",
-            eval_pack_path.to_str().unwrap(),
-            "--bundle",
-            bundle_dir.to_str().unwrap(),
-            "--workflow-name",
-            "version_bump",
-            "--package-name",
-            "release-workflows",
-            "--bundle-team",
-            "platform",
-            "--bundle-repo",
-            "burin-labs/harn",
-            "--min-examples",
-            "5",
-        ],
+    let outcome = mine(
+        &temp,
+        &traces_dir,
+        "version_bump",
+        Some("release-workflows"),
+        Some("platform"),
+        Some("burin-labs/harn"),
+        true,
+        5,
     );
     assert!(
-        mine.status.success(),
-        "mine failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&mine.stdout),
-        String::from_utf8_lossy(&mine.stderr),
+        outcome.workflow_path.exists(),
+        "workflow file missing at {}",
+        outcome.workflow_path.display()
     );
+    assert!(outcome.report_path.exists());
+    assert!(outcome.eval_pack_path.as_ref().unwrap().exists());
 
     // Manifest sanity check: schema marker, fixture redaction, plan-vs-candidate kind.
-    let manifest_path = bundle_dir.join("candidate.json");
+    let manifest_path = outcome.bundle_dir.join("candidate.json");
     let manifest: Value = serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
     assert_eq!(
         manifest["schema"],
@@ -173,32 +229,22 @@ fn crystallize_version_bump_emits_validatable_bundle() {
         .iter()
         .all(|fixture| fixture["redacted"] == json!(true)));
 
-    // The validate subcommand exits 0 and reports OK.
-    let validate = run_harn(
-        temp.path(),
-        &["crystallize", "validate", bundle_dir.to_str().unwrap()],
-    );
+    // The validate library API succeeds with zero problems.
+    let validation = validate_crystallization_bundle(&outcome.bundle_dir).unwrap();
     assert!(
-        validate.status.success(),
-        "validate failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&validate.stdout),
-        String::from_utf8_lossy(&validate.stderr),
+        validation.is_ok(),
+        "validation problems: {:#?}",
+        validation.problems
     );
-    assert!(String::from_utf8_lossy(&validate.stdout).contains("OK"));
 
     // Shadow replay also passes against the bundle's own redacted fixtures.
-    let shadow = run_harn(
-        temp.path(),
-        &["crystallize", "shadow", bundle_dir.to_str().unwrap()],
+    let (shadow_manifest, shadow) = shadow_replay_bundle(&outcome.bundle_dir).unwrap();
+    assert!(shadow.pass, "shadow failures: {:#?}", shadow.failures);
+    assert_eq!(
+        serde_json::to_value(&shadow_manifest.kind).unwrap(),
+        manifest["kind"]
     );
-    assert!(
-        shadow.status.success(),
-        "shadow failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&shadow.stdout),
-        String::from_utf8_lossy(&shadow.stderr),
-    );
-    let stdout = String::from_utf8_lossy(&shadow.stdout);
-    assert!(stdout.contains("pass=true"));
+    let _ = outcome.artifacts;
 }
 
 #[test]
@@ -213,43 +259,28 @@ fn crystallize_plan_only_bundle_keeps_plan_only_kind() {
             &plan_only_trace(idx),
         );
     }
-    let workflow_path = temp.path().join("plan.harn");
-    let report_path = temp.path().join("plan.report.json");
-    let bundle_dir = temp.path().join("bundle");
 
-    let mine = run_harn(
-        temp.path(),
-        &[
-            "crystallize",
-            "--from",
-            traces_dir.to_str().unwrap(),
-            "--out",
-            workflow_path.to_str().unwrap(),
-            "--report",
-            report_path.to_str().unwrap(),
-            "--bundle",
-            bundle_dir.to_str().unwrap(),
-            "--workflow-name",
-            "linear_triage_plan",
-            "--min-examples",
-            "3",
-        ],
+    let outcome = mine(
+        &temp,
+        &traces_dir,
+        "linear_triage_plan",
+        None,
+        None,
+        None,
+        false,
+        3,
     );
-    assert!(mine.status.success(), "{:?}", mine);
 
     let manifest: Value =
-        serde_json::from_slice(&fs::read(bundle_dir.join("candidate.json")).unwrap()).unwrap();
+        serde_json::from_slice(&fs::read(outcome.bundle_dir.join("candidate.json")).unwrap())
+            .unwrap();
     assert_eq!(manifest["kind"], json!("plan_only"));
     assert_eq!(manifest["risk_level"], json!("low"));
 
-    let validate = run_harn(
-        temp.path(),
-        &["crystallize", "validate", bundle_dir.to_str().unwrap()],
-    );
+    let validation = validate_crystallization_bundle(&outcome.bundle_dir).unwrap();
     assert!(
-        validate.status.success(),
-        "validate failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&validate.stdout),
-        String::from_utf8_lossy(&validate.stderr),
+        validation.is_ok(),
+        "validation problems: {:#?}",
+        validation.problems
     );
 }

--- a/crates/harn-cli/tests/flow_ship_cli.rs
+++ b/crates/harn-cli/tests/flow_ship_cli.rs
@@ -61,6 +61,7 @@ fn phase_zero_demo(slice) {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn flow_ship_watch_injects_atoms_and_opens_mock_pr() {
     let repo = demo_repo();
     let store_path = repo.path().join(".harn/flow.sqlite");
@@ -169,6 +170,7 @@ fn write_invariants_with_many_predicates(dir: &std::path::Path, count: usize) {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn flow_ship_watch_surfaces_bootstrap_policy_when_present() {
     let repo = demo_repo();
     fs::write(
@@ -232,6 +234,7 @@ fn _bootstrap_marker() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn flow_ship_watch_marks_bootstrap_policy_absent_when_missing() {
     let repo = demo_repo();
     let store_path = repo.path().join(".harn/flow.sqlite");
@@ -261,6 +264,7 @@ fn flow_ship_watch_marks_bootstrap_policy_absent_when_missing() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn flow_ship_watch_blocks_when_predicate_union_explodes() {
     let temp = TempDir::new().unwrap();
     let repo = temp.path();

--- a/crates/harn-cli/tests/harn_serve_mcp_cli.rs
+++ b/crates/harn-cli/tests/harn_serve_mcp_cli.rs
@@ -202,6 +202,7 @@ async fn collect_sse_body_after_progress(
 }
 
 #[test]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 fn serve_mcp_stdio_lists_calls_and_cancels_exported_functions() {
     let _guard = lock_harn_serve_mcp_tests();
     let temp = TempDir::new().unwrap();
@@ -354,6 +355,7 @@ fn serve_mcp_stdio_lists_calls_and_cancels_exported_functions() {
 }
 
 #[test]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 fn serve_mcp_stdio_exposes_script_registered_surface() {
     let _guard = lock_harn_serve_mcp_tests();
     let temp = TempDir::new().unwrap();
@@ -458,6 +460,7 @@ fn serve_mcp_stdio_exposes_script_registered_surface() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 async fn serve_mcp_http_streams_progress_and_enforces_api_keys() {
     let _guard = lock_harn_serve_mcp_tests();
     let temp = TempDir::new().unwrap();
@@ -638,6 +641,7 @@ async fn serve_mcp_http_streams_progress_and_enforces_api_keys() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 async fn serve_mcp_http_exposes_script_registered_surface() {
     let _guard = lock_harn_serve_mcp_tests();
     let temp = TempDir::new().unwrap();

--- a/crates/harn-cli/tests/llm_mock_cli.rs
+++ b/crates/harn-cli/tests/llm_mock_cli.rs
@@ -35,6 +35,7 @@ fn stderr(output: &Output) -> String {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn llm_mock_replays_fifo_fixtures_for_non_mock_provider() {
     let temp = TempDir::new().unwrap();
     let script = write_file(
@@ -71,6 +72,7 @@ pipeline default() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn llm_mock_reuses_glob_matches() {
     let temp = TempDir::new().unwrap();
     let script = write_file(
@@ -106,6 +108,7 @@ pipeline default() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn llm_mock_reports_unmatched_prompt_snippet() {
     let temp = TempDir::new().unwrap();
     let script = write_file(
@@ -137,6 +140,7 @@ pipeline default() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn llm_mock_record_replays_identical_output() {
     let temp = TempDir::new().unwrap();
     let script = write_file(
@@ -188,6 +192,7 @@ pipeline default() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn playground_llm_mock_replays_fifo_fixtures_for_non_mock_provider() {
     let temp = TempDir::new().unwrap();
     let host = write_file(
@@ -244,6 +249,7 @@ pipeline default() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn playground_llm_mock_record_replays_identical_output() {
     let temp = TempDir::new().unwrap();
     let host = write_file(
@@ -319,6 +325,7 @@ pipeline default() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn playground_llm_mock_sub_agent_tool_calls_mutate_host_workspace() {
     let temp = TempDir::new().unwrap();
     let host = write_file(
@@ -421,6 +428,7 @@ pipeline default() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn playground_llm_mock_sub_agent_handles_multiple_tool_calls_in_one_turn() {
     let temp = TempDir::new().unwrap();
     fs::write(temp.path().join("seed.txt"), "seed contents").unwrap();
@@ -529,6 +537,7 @@ pipeline default() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn playground_llm_mock_consume_match_advances_between_identical_patterns() {
     let temp = TempDir::new().unwrap();
     let host = write_file(
@@ -622,6 +631,7 @@ pipeline default() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn eval_runs_baseline_and_structural_variant_for_pipeline_file() {
     let temp = TempDir::new().unwrap();
     let script = write_file(

--- a/crates/harn-cli/tests/mcp_server_cli.rs
+++ b/crates/harn-cli/tests/mcp_server_cli.rs
@@ -115,6 +115,7 @@ fn wait_for_http_listener(child: &mut std::process::Child, rx: &Receiver<String>
 }
 
 #[test]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 fn mcp_server_stdio_roundtrips_tools_and_resources() {
     let _guard = lock_mcp_cli_tests();
     let temp = TempDir::new().unwrap();
@@ -379,6 +380,7 @@ fn mcp_server_stdio_roundtrips_tools_and_resources() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 async fn mcp_server_http_roundtrips_initialize_and_fire() {
     let _guard = lock_mcp_cli_tests();
     let temp = TempDir::new().unwrap();

--- a/crates/harn-cli/tests/merge_captain_cli.rs
+++ b/crates/harn-cli/tests/merge_captain_cli.rs
@@ -1,5 +1,14 @@
-use std::path::PathBuf;
-use std::process::Command;
+//! In-process tests for the `harn merge-captain audit` library API
+//! (`harn_vm::orchestration::audit_transcript`). Replaces the prior
+//! subprocess-spawning version that ran the `harn` binary per case
+//! (#1067).
+
+use std::path::{Path, PathBuf};
+
+use harn_vm::orchestration::{
+    audit_transcript, load_merge_captain_golden, load_transcript_jsonl, AuditReport,
+    MergeCaptainGolden,
+};
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -22,135 +31,89 @@ fn fixture(scenario: &str, kind: &str) -> PathBuf {
         .join(format!("{scenario}.{ext}"))
 }
 
+/// Mirror of `harn-cli`'s `run_audit` inner work: load transcript, load
+/// optional golden, audit, attach `source_path`. Tests use the report
+/// directly instead of inspecting CLI stdout/stderr.
+fn audit(scenario: &str, with_golden: bool) -> AuditReport {
+    let transcript = fixture(scenario, "transcripts");
+    let loaded = load_transcript_jsonl(&transcript).expect("load transcript");
+    let golden: Option<MergeCaptainGolden> = if with_golden {
+        Some(load_merge_captain_golden(&fixture(scenario, "goldens")).expect("load golden"))
+    } else {
+        None
+    };
+    let mut report = audit_transcript(&loaded.events, golden.as_ref());
+    report.source_path = Some(loaded.source_path.display().to_string());
+    report
+}
+
 #[test]
 fn green_pr_passes_audit() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("green_pr", "transcripts").to_str().unwrap(),
-            "--golden",
-            fixture("green_pr", "goldens").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run harn merge-captain audit");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        output.status.success(),
-        "expected pass; stdout={}\nstderr={}",
-        stdout,
-        stderr
-    );
-    assert!(stdout.contains("PASS"));
-    assert!(stdout.contains("scenario=green_pr"));
+    let report = audit("green_pr", true);
+    assert!(report.pass, "report={:#?}", report);
+    assert_eq!(report.scenario.as_deref(), Some("green_pr"));
+    let rendered = format!("{report}");
+    assert!(rendered.contains("PASS"));
+    assert!(rendered.contains("scenario=green_pr"));
 }
 
 #[test]
 fn failing_ci_passes_audit_with_handoff() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("failing_ci", "transcripts").to_str().unwrap(),
-            "--golden",
-            fixture("failing_ci", "goldens").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run audit");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(output.status.success(), "stdout={}", stdout);
-    assert!(stdout.contains("handoff <- handoff"));
+    let report = audit("failing_ci", true);
+    assert!(report.pass, "report={:#?}", report);
+    let rendered = format!("{report}");
+    assert!(
+        rendered.contains("handoff <- handoff"),
+        "missing handoff transition in:\n{rendered}"
+    );
 }
 
 #[test]
 fn semantic_conflict_passes_audit() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("semantic_conflict", "transcripts")
-                .to_str()
-                .unwrap(),
-            "--golden",
-            fixture("semantic_conflict", "goldens").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run audit");
-    assert!(output.status.success());
+    let report = audit("semantic_conflict", true);
+    assert!(report.pass, "report={:#?}", report);
 }
 
 #[test]
 fn merge_queue_passes_audit() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("merge_queue", "transcripts").to_str().unwrap(),
-            "--golden",
-            fixture("merge_queue", "goldens").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run audit");
-    assert!(output.status.success());
+    let report = audit("merge_queue", true);
+    assert!(report.pass, "report={:#?}", report);
 }
 
 #[test]
 fn new_pr_arrival_passes_audit() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("new_pr_arrival", "transcripts").to_str().unwrap(),
-            "--golden",
-            fixture("new_pr_arrival", "goldens").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run audit");
-    assert!(output.status.success());
+    let report = audit("new_pr_arrival", true);
+    assert!(report.pass, "report={:#?}", report);
 }
 
 #[test]
 fn bad_unsafe_merge_fails_audit_with_findings() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("bad_unsafe_merge", "transcripts").to_str().unwrap(),
-            "--golden",
-            fixture("bad_unsafe_merge", "goldens").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run audit");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        !output.status.success(),
-        "expected non-zero exit; stdout={}",
-        stdout
-    );
-    assert!(stdout.contains("FAIL"));
-    assert!(stdout.contains("repeated_read"));
-    assert!(stdout.contains("unsafe_attempted_action"));
-    assert!(stdout.contains("missing_state_step"));
-    assert!(stdout.contains("skipped_verification"));
+    let report = audit("bad_unsafe_merge", true);
+    assert!(!report.pass, "report={:#?}", report);
+    assert!(report.error_findings() > 0);
+    let categories: Vec<_> = report
+        .findings
+        .iter()
+        .map(|f| f.category.as_str().to_string())
+        .collect();
+    for expected in [
+        "repeated_read",
+        "unsafe_attempted_action",
+        "missing_state_step",
+        "skipped_verification",
+    ] {
+        assert!(
+            categories.iter().any(|c| c == expected),
+            "missing finding category {expected}; got {categories:?}"
+        );
+    }
 }
 
 #[test]
 fn json_output_is_machine_readable() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("green_pr", "transcripts").to_str().unwrap(),
-            "--golden",
-            fixture("green_pr", "goldens").to_str().unwrap(),
-            "--format",
-            "json",
-        ])
-        .output()
-        .expect("run audit");
-    let stdout = String::from_utf8(output.stdout).expect("utf8");
-    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("parse json");
+    let report = audit("green_pr", true);
+    let json = serde_json::to_string(&report).expect("serialize");
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse json");
     assert_eq!(parsed["pass"], serde_json::Value::Bool(true));
     assert_eq!(
         parsed["scenario"],
@@ -161,17 +124,14 @@ fn json_output_is_machine_readable() {
 
 #[test]
 fn audit_without_golden_uses_defaults() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("green_pr", "transcripts").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run audit");
-    assert!(output.status.success());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("scenario=<none>"));
+    let report = audit("green_pr", false);
+    assert!(report.pass, "report={:#?}", report);
+    assert!(report.scenario.is_none());
+    let rendered = format!("{report}");
+    assert!(
+        rendered.contains("scenario=<none>"),
+        "expected scenario=<none> placeholder in:\n{rendered}"
+    );
 }
 
 #[test]
@@ -181,9 +141,7 @@ fn directory_argument_loads_rotated_logs() {
     std::fs::create_dir_all(&session).unwrap();
     let src = std::fs::read_to_string(fixture("green_pr", "transcripts")).unwrap();
     std::fs::write(session.join("event_log.jsonl"), &src).unwrap();
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args(["merge-captain", "audit", session.to_str().unwrap()])
-        .output()
-        .expect("run audit");
-    assert!(output.status.success());
+    let loaded = load_transcript_jsonl(Path::new(&session)).expect("load directory transcript");
+    let report = audit_transcript(&loaded.events, None);
+    assert!(report.pass, "report={:#?}", report);
 }

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -438,6 +438,7 @@ fn wait_for_sqlite_event_count(state_dir: &Path, topic_name: &str, kind: &str, e
 }
 
 #[test]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 fn orchestrator_serve_starts_and_shuts_down_cleanly() {
     let _lock = support::lock_orchestrator_process_tests();
     let temp = TempDir::new().unwrap();
@@ -499,6 +500,7 @@ pub fn on_issue(event: TriggerEvent) {
 // a2a-push dispatch finish within the configured shutdown window and emit the
 // terminal `dispatch_succeeded` lifecycle event instead of a shutdown failure.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 async fn graceful_shutdown_drains_in_flight_dispatch_and_emits_lifecycle_events() {
     let _lock = support::lock_orchestrator_process_tests();
     let temp = TempDir::new().unwrap();
@@ -587,6 +589,7 @@ handler = "handlers::on_task"
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 async fn graceful_shutdown_continues_after_pump_error_and_persists_stopped_state() {
     let _lock = support::lock_orchestrator_process_tests();
     let temp = TempDir::new().unwrap();
@@ -664,6 +667,7 @@ pub fn on_task(event: TriggerEvent) -> string {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 async fn graceful_shutdown_waits_for_spawned_inbox_dispatch_tasks() {
     let _lock = support::lock_orchestrator_process_tests();
     let temp = TempDir::new().unwrap();
@@ -763,6 +767,7 @@ pub fn on_task(event: TriggerEvent) -> string {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 async fn inbox_pump_backpressures_before_ack_when_outstanding_limit_is_full() {
     let _lock = support::lock_orchestrator_process_tests();
     let temp = TempDir::new().unwrap();
@@ -905,6 +910,7 @@ pub fn on_task(event: TriggerEvent) -> string {
 }
 
 #[test]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 fn orchestrator_queue_soft_migrates_legacy_inbox_topics() {
     let _lock = support::lock_orchestrator_process_tests();
     let temp = TempDir::new().unwrap();
@@ -982,6 +988,7 @@ pub fn on_event(event: TriggerEvent) {
 // shutdown, persist each pump's consumer cursor in the event log, and let the
 // next orchestrator run replay the remaining backlog to completion.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 async fn bounded_pump_drain_truncates_and_replays_remaining_backlog_after_restart() {
     let _lock = support::lock_orchestrator_process_tests();
     const TOTAL_EVENTS: usize = 60;
@@ -1108,6 +1115,7 @@ pub fn on_task(event: TriggerEvent) -> string {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 async fn restart_surfaces_stranded_envelopes_and_recover_replays_them_explicitly() {
     let _lock = support::lock_orchestrator_process_tests();
     let temp = TempDir::new().unwrap();
@@ -1312,6 +1320,7 @@ pub fn on_task(event: TriggerEvent) -> string {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 async fn worker_queue_drain_uses_consumer_manifest_and_persists_response_records() {
     let temp = TempDir::new().unwrap();
     write_file(

--- a/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
+++ b/crates/harn-cli/tests/orchestrator_inbox_dedupe.rs
@@ -170,6 +170,7 @@ async fn wait_for_tick_count(temp: &TempDir, min_count: usize) -> HashMap<String
 }
 
 #[tokio::test(flavor = "current_thread")]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 async fn restart_after_emit_does_not_duplicate_cron_dispatch() {
     let _lock = process_support::lock_harn_process_tests();
     let temp = TempDir::new().unwrap();

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -51,6 +51,7 @@ receipt_policy = "required"
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn persona_list_and_inspect_emit_stable_json() {
     let temp = write_manifest(valid_manifest());
 
@@ -93,6 +94,7 @@ fn persona_list_and_inspect_emit_stable_json() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn persona_cli_rejects_required_invalid_manifest_cases() {
     for (body, expected) in [
         (
@@ -170,6 +172,7 @@ handoffs = ["review_captain"]
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn persona_manifest_flag_loads_example_personas() {
     let output = harn_command()
         .args([
@@ -197,6 +200,7 @@ fn persona_manifest_flag_loads_example_personas() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn persona_manifest_flag_loads_fixer_persona() {
     let output = harn_command()
         .args([
@@ -226,6 +230,7 @@ fn persona_manifest_flag_loads_fixer_persona() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn persona_manifest_flag_loads_merge_captain_persona() {
     let output = harn_command()
         .args([
@@ -263,6 +268,7 @@ fn persona_manifest_flag_loads_merge_captain_persona() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn persona_manifest_flag_loads_ship_captain_persona() {
     let output = harn_command()
         .args([
@@ -293,6 +299,7 @@ fn persona_manifest_flag_loads_ship_captain_persona() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn persona_runtime_status_tick_and_budget_are_persisted() {
     let temp = write_manifest(valid_manifest());
     let state_dir = temp.path().join(".harn-personas-test");
@@ -378,6 +385,7 @@ fn persona_runtime_status_tick_and_budget_are_persisted() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn persona_pause_resume_disable_trigger_controls_are_durable() {
     let temp = write_manifest(valid_manifest());
     let state_dir = temp.path().join(".harn-personas-test");
@@ -483,6 +491,7 @@ fn persona_pause_resume_disable_trigger_controls_are_durable() {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn persona_runtime_blocks_budget_exhaustion() {
     let temp = write_manifest(
         r#"

--- a/crates/harn-cli/tests/run_exit_codes.rs
+++ b/crates/harn-cli/tests/run_exit_codes.rs
@@ -27,6 +27,7 @@ fn run_script(body: &str) -> std::process::Output {
 }
 
 #[test]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 fn pipeline_main_returning_int_sets_exit_code() {
     let out = run_script("pipeline main() {\n  return 42\n}\n");
     assert_eq!(
@@ -39,6 +40,7 @@ fn pipeline_main_returning_int_sets_exit_code() {
 }
 
 #[test]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 fn pipeline_main_returning_err_writes_stderr_and_exits_one() {
     let out = run_script("pipeline main() {\n  return Err(\"boom\")\n}\n");
     assert_eq!(out.status.code(), Some(1));
@@ -50,12 +52,14 @@ fn pipeline_main_returning_err_writes_stderr_and_exits_one() {
 }
 
 #[test]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 fn pipeline_main_returning_ok_exits_zero() {
     let out = run_script("pipeline main() {\n  return Ok(\"done\")\n}\n");
     assert_eq!(out.status.code(), Some(0));
 }
 
 #[test]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 fn pipeline_main_implicit_return_exits_zero() {
     let out = run_script("pipeline main() {\n  println(\"hi\")\n}\n");
     assert_eq!(out.status.code(), Some(0));
@@ -63,6 +67,7 @@ fn pipeline_main_implicit_return_exits_zero() {
 }
 
 #[test]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 fn pipeline_main_int_clamped_to_byte_range() {
     let out = run_script("pipeline main() {\n  return 999\n}\n");
     // Linux limits child exit codes to a byte; we clamp to 0..=255 explicitly.
@@ -70,6 +75,7 @@ fn pipeline_main_int_clamped_to_byte_range() {
 }
 
 #[test]
+#[ignore = "binary-surface CLI test moved to slow E2E suite (#1069); see harn#1067 for the in-process conversion follow-up"]
 fn explicit_exit_builtin_still_works() {
     let out = run_script("pipeline main() {\n  exit(3)\n}\n");
     assert_eq!(out.status.code(), Some(3));

--- a/crates/harn-cli/tests/test_util/process.rs
+++ b/crates/harn-cli/tests/test_util/process.rs
@@ -1,6 +1,11 @@
 #![allow(dead_code)]
 
-//! Subprocess harness shared by every harn-cli integration test binary.
+//! Subprocess harness shared by harn-cli integration tests that still
+//! cover binary surface (signal handling, exit-code mapping, stdio
+//! JSON-RPC). As of harn#1067 every fast-suite caller has either moved
+//! to in-process invocation against the underlying library crates or is
+//! gated behind `#[ignore]` pending follow-up extraction. The helper is
+//! preserved for the slow E2E suite (see harn#1069).
 //!
 //! ## Why this module exists
 //!

--- a/crates/harn-cli/tests/trigger_replay_cli.rs
+++ b/crates/harn-cli/tests/trigger_replay_cli.rs
@@ -116,6 +116,7 @@ fn seed_written_event(temp: &TempDir) -> serde_json::Value {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn trigger_replay_diff_reports_structured_drift() {
     let temp = TempDir::new().unwrap();
     write_manifest(temp.path());
@@ -171,6 +172,7 @@ pub fn on_issue(event: TriggerEvent) -> dict {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn trigger_replay_as_of_uses_historical_binding_version() {
     let temp = TempDir::new().unwrap();
     write_manifest(temp.path());
@@ -233,6 +235,7 @@ pub fn on_issue(event: TriggerEvent) -> dict {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn trigger_replay_bulk_dry_run_filters_on_event_payload() {
     let temp = TempDir::new().unwrap();
     write_manifest(temp.path());
@@ -279,6 +282,7 @@ pub fn on_issue(event: TriggerEvent) -> dict {
 }
 
 #[test]
+#[ignore = "subprocess CLI test deferred to slow E2E suite (#1069); see harn#1067 for the planned in-process conversion via library-API extraction"]
 fn trigger_cancel_reports_terminal_events_as_not_cancellable() {
     let temp = TempDir::new().unwrap();
     write_manifest(temp.path());


### PR DESCRIPTION
## Summary

Tier 1H of the de-flake epic ([#1057](https://github.com/burin-labs/harn/issues/1057)), implementing [#1067](https://github.com/burin-labs/harn/issues/1067). Stacked on [#1081](https://github.com/burin-labs/harn/pull/1081) (OrchestratorHarness extraction).

Every subprocess CLI test in the fast suite is either replaced with an in-process call against the underlying workspace library crates, or gated behind `#[ignore]` for the slow E2E suite ([#1069](https://github.com/burin-labs/harn/issues/1069)).

### Converted to in-process

| File | Library API used | Tests | Wall-clock |
|------|------------------|-------|-----------|
| `merge_captain_cli` | `harn_vm::orchestration::{audit_transcript, load_transcript_jsonl, load_merge_captain_golden}` | 9 | 0.00s |
| `crystallize_cli` | `harn_vm::orchestration::{crystallize_traces, build_crystallization_bundle, write_*, validate_crystallization_bundle, shadow_replay_bundle}` | 2 | 0.22s |
| `check_cli` | `harn_parser::TypeChecker`, `harn_modules::build` (the regression for [#93](https://github.com/burin-labs/harn/pull/93)/[#748](https://github.com/burin-labs/harn/issues/748) lives in `harn_modules`, so the test calls it directly instead of going through the CLI walker) | 2 | 0.01s |

### Gated behind `#[ignore]`

**Pure binary surface** (exit-code mapping, signal handling, stdio JSON-RPC — these can't run in-process by definition):
- `run_exit_codes`, `mcp_server_cli`, `acp_server_cli`, `harn_serve_mcp_cli`
- `orchestrator_cli`, `orchestrator_inbox_dedupe`

**Pending follow-up library-API extraction** (the underlying logic is in the CLI command module rather than a workspace library; converting cleanly requires either (a) adding `crates/harn-cli/src/lib.rs` so external tests can call `harn_cli::commands::*::run(args)` or (b) extracting the JSON-payload-building portions into `harn-vm`/`harn-flow`/etc. Both are larger refactors that deserve their own PRs):
- `flow_ship_cli`, `persona_cli`, `llm_mock_cli`, `trigger_replay_cli`, `burin_mini_playground`

### Acceptance ([#1067](https://github.com/burin-labs/harn/issues/1067))

- [x] `grep -rn "harn_command\|Command::new" crates/harn-cli/tests/` matches only `#[ignore]`d tests, doc comments, and the legacy helper.
- [x] 50× rerun of converted tests at default thread count: zero flakes.
- [x] Wall-clock for the converted files is <0.25s (was multi-second per spawn × N spawns previously). The fast suite drops 58 ignored tests entirely; pre-push runs 3074 tests in 24.7s.
- [x] `cargo run --bin harn -- check`/`merge-captain audit` smoke-tested manually.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` (pre-commit verified)
- [x] `cargo nextest run --workspace` (pre-push: 3074 passed, 58 skipped, 24.7s)
- [x] 50× rerun of `check_cli` + `crystallize_cli` + `merge_captain_cli` with no flakes
- [x] Manual smoke of `harn --version`, `harn check`, `harn merge-captain audit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)