### PR TITLE
[deflake] Remove remaining wall-clock timing assertions (#1088)

### DIFF
--- a/conformance/tests/triggers/trigger_webhook_slack_events_3s_ack.harn
+++ b/conformance/tests/triggers/trigger_webhook_slack_events_3s_ack.harn
@@ -1,5 +1,5 @@
 pipeline test(task) {
   let result = trigger_test_harness("slack_events_3s_ack")
   println(result.ok)
-  println(result.details.elapsed_ms ?? 999999 < 2900)
+  println(result.details.kind == "message.channels")
 }

--- a/crates/harn-cli/tests/check_cli.rs
+++ b/crates/harn-cli/tests/check_cli.rs
@@ -2,7 +2,6 @@ mod test_util;
 
 use std::fs;
 use std::path::Path;
-use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 use test_util::process::harn_command;
@@ -67,19 +66,11 @@ fn lint_and_check_complete_on_large_cross_directory_cycle_workspace() {
     )
     .unwrap();
 
-    // Post-fix this completes in well under a second on every supported
-    // platform; pre-fix on Linux it OOM-killed around 48 s. The 60 s
-    // budget gives slow CI shapes (qemu, sandboxed builders) headroom
-    // without letting a regression sit silently.
-    let budget = Duration::from_secs(60);
-
-    let lint_started = Instant::now();
     let lint_output = harn_command()
         .current_dir(root)
         .args(["lint", pipelines.to_str().unwrap()])
         .output()
         .unwrap();
-    let lint_elapsed = lint_started.elapsed();
     assert!(
         lint_output.status.success(),
         "lint failed: status={:?} stdout={} stderr={}",
@@ -87,28 +78,18 @@ fn lint_and_check_complete_on_large_cross_directory_cycle_workspace() {
         String::from_utf8_lossy(&lint_output.stdout),
         String::from_utf8_lossy(&lint_output.stderr)
     );
-    assert!(
-        lint_elapsed < budget,
-        "lint took {lint_elapsed:?} (>{budget:?}) — likely a regression to the path-spelling explosion fixed by #93"
-    );
 
-    let check_started = Instant::now();
     let check_output = harn_command()
         .current_dir(root)
         .args(["check", "--workspace"])
         .output()
         .unwrap();
-    let check_elapsed = check_started.elapsed();
     assert!(
         check_output.status.success(),
         "check --workspace failed: status={:?} stdout={} stderr={}",
         check_output.status,
         String::from_utf8_lossy(&check_output.stdout),
         String::from_utf8_lossy(&check_output.stderr)
-    );
-    assert!(
-        check_elapsed < budget,
-        "check --workspace took {check_elapsed:?} (>{budget:?}) — likely a regression to the path-spelling explosion fixed by #93"
     );
 }
 

--- a/crates/harn-vm/src/stdlib/workflow/tests.rs
+++ b/crates/harn-vm/src/stdlib/workflow/tests.rs
@@ -278,12 +278,8 @@ async fn execute_join_policy_stops_after_first_completion() {
                     2
                 }),
             ];
-            let started = std::time::Instant::now();
             let results = execute_join_policy(tasks, "first", None, None).await;
             assert_eq!(results.len(), 1);
-            // Wall-clock elapsed stays small — virtual sleeps auto-advance
-            // tokio time without blocking the executor.
-            assert!(started.elapsed() < std::time::Duration::from_millis(500));
             assert_eq!(results[0].as_ref().ok().copied(), Some(2));
         })
         .await;

--- a/crates/harn-vm/src/triggers/test_util/mod.rs
+++ b/crates/harn-vm/src/triggers/test_util/mod.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration as StdDuration, Instant};
+use std::time::Duration as StdDuration;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -507,7 +507,6 @@ impl TriggerTestHarness {
             .await
             .map_err(|error| error.to_string())?;
 
-        let started = Instant::now();
         let event = connector
             .normalize_inbound(slack_raw_inbound())
             .await
@@ -539,18 +538,12 @@ impl TriggerTestHarness {
         )
         .await
         .map_err(|error| error.to_string())?;
-        let elapsed_ms = started.elapsed().as_millis() as u64;
 
         Ok(TriggerHarnessResult {
             fixture: "slack_events_3s_ack".to_string(),
-            // Slack's documented contract is a 3s ack window; assert against
-            // 2900ms (well under 3s, generous enough that loaded CI schedulers
-            // can't blow it). Earlier 200ms threshold tested scheduler latency,
-            // not contract compliance, and flaked on busy runners.
-            ok: elapsed_ms < 2_900,
+            ok: event.provider.as_str() == "slack" && event.kind == "message.channels",
             stub: false,
-            summary: "slack ack-first ingress path stays under the 3s contract before dispatch"
-                .to_string(),
+            summary: "slack ack-first ingress path normalizes and appends the event".to_string(),
             emitted: Vec::new(),
             attempts: Vec::new(),
             dlq: Vec::new(),
@@ -558,7 +551,8 @@ impl TriggerTestHarness {
             bindings: Vec::new(),
             notes: Vec::new(),
             details: json!({
-                "elapsed_ms": elapsed_ms,
+                "kind": event.kind,
+                "provider": event.provider.as_str(),
             }),
         })
     }


### PR DESCRIPTION
## Summary

Follow-up to #1066 (Tier 1G). Removes the three wall-clock timing assertions identified in #1088:

- **`crates/harn-cli/tests/check_cli.rs`** — Dropped `lint_elapsed < 60s` / `check_elapsed < 60s` budget assertions. The documented regression (path-spelling OOM) is fully caught by the existing `assert!(output.status.success())` — a killed process exits nonzero.
- **`crates/harn-vm/src/stdlib/workflow/tests.rs`** — Removed `assert!(started.elapsed() < 500ms)` from `execute_join_policy_stops_after_first_completion`. Correctness is carried by `results.len() == 1` and the returned value check.
- **`crates/harn-vm/src/triggers/test_util/mod.rs`** — In `slack_events_3s_ack`, replaced `ok: elapsed_ms < 200` with `ok: event.provider == "slack" && event.kind == "message.channels"`. Updated `details` to record kind/provider for observability instead of timing.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `execute_join_policy_stops_after_first_completion` passes
- [x] `every_trigger_harness_fixture_reports_success` passes
- [x] Both `check_cli` integration tests pass
- [x] Pre-commit and pre-push hooks green

Closes #1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)