### PR TITLE
Fix printf option-parsing in flake-rerun loop

### DIFF
--- a/.github/workflows/flake-detection.yml
+++ b/.github/workflows/flake-detection.yml
@@ -71,7 +71,7 @@ jobs:
           NEXTEST_FILTER: ${{ steps.touched.outputs.filter }}
         run: |
           for i in $(seq 50); do
-            printf '--- Iteration %d/50 ---\n' "$i"
+            printf -- '--- Iteration %d/50 ---\n' "$i"
             cargo nextest run \
               --profile flake-detection \
               --test-threads 8 \


### PR DESCRIPTION
## Summary

The flake-detection workflow added in #1085 fails immediately on every PR
that touches test files because bash's `printf` builtin sees the `--`
prefix in `printf '--- Iteration %d/50 ---\n' "$i"` as the end-of-options
marker. The format string is rejected with `printf: --: invalid option`
and the workflow exits 2 on iteration 1 — so no actual flake-detection
runs are happening; the gate is just blocking blindly.

Add an explicit `printf --` end-of-options marker so the leading `--` in
the format string is treated as literal.

Currently breaking: #1096, #1097, #1098, #1087, and any future PR that
touches a test file.

## Repro

\`\`\`text
$ printf '--- Iteration %d/50 ---\n' 1
bash: printf: --: invalid option
bash: printf: usage: printf [-v var] format [arguments]

$ printf -- '--- Iteration %d/50 ---\n' 1
--- Iteration 1/50 ---
\`\`\`

## Test plan

- [x] Local repro of broken form fails as documented above
- [x] Local repro of fixed form prints expected output
- [ ] CI flake-detection job advances past iteration 1 on this PR