### PR TITLE
[deflake] Make Slack 3s-ack conformance test deterministic

### DIFF
--- a/conformance/tests/triggers/trigger_webhook_slack_events_3s_ack.harn
+++ b/conformance/tests/triggers/trigger_webhook_slack_events_3s_ack.harn
@@ -1,5 +1,5 @@
 pipeline test(task) {
   let result = trigger_test_harness("slack_events_3s_ack")
   println(result.ok)
-  println(result.details.elapsed_ms ?? 999999 < 200)
+  println(result.details.elapsed_ms ?? 999999 < 2900)
 }

--- a/crates/harn-vm/src/triggers/test_util/mod.rs
+++ b/crates/harn-vm/src/triggers/test_util/mod.rs
@@ -543,9 +543,14 @@ impl TriggerTestHarness {
 
         Ok(TriggerHarnessResult {
             fixture: "slack_events_3s_ack".to_string(),
-            ok: elapsed_ms < 200,
+            // Slack's documented contract is a 3s ack window; assert against
+            // 2900ms (well under 3s, generous enough that loaded CI schedulers
+            // can't blow it). Earlier 200ms threshold tested scheduler latency,
+            // not contract compliance, and flaked on busy runners.
+            ok: elapsed_ms < 2_900,
             stub: false,
-            summary: "slack ack-first ingress path stays below 200ms before dispatch".to_string(),
+            summary: "slack ack-first ingress path stays under the 3s contract before dispatch"
+                .to_string(),
             emitted: Vec::new(),
             attempts: Vec::new(),
             dlq: Vec::new(),


### PR DESCRIPTION
## Summary

Fixes a wall-clock-dependent flake in
`conformance/tests/triggers/trigger_webhook_slack_events_3s_ack.harn`.

The `slack_events_3s_ack` trigger harness was asserting that the Slack
URL-verification handshake completed in under **200ms**, both via its
`ok` flag (`elapsed_ms < 200` in `crates/harn-vm/src/triggers/test_util/mod.rs`)
and via a redundant `< 200` check in the conformance fixture. That
threshold tested scheduler latency, not contract compliance, and flaked
intermittently on loaded CI runners (observed on PR #1097's `Rust (lint
+ test + conformance)` job at
https://github.com/burin-labs/harn/actions/runs/25200658760).

### What changed

- **Harness** (`crates/harn-vm/src/triggers/test_util/mod.rs`):
  loosened `ok: elapsed_ms < 200` to `ok: elapsed_ms < 2_900`, and
  updated the summary string accordingly. Added a comment explaining
  the rationale.
- **Conformance fixture**: changed `< 200` to `< 2900` to match.
- **Expected output** unchanged (`true\ntrue`) since both bounds still
  hold in practice.

### Why Option A (loosen) over Option B (delete the assertion)

The issue laid out two options and preferred Option B *if* the harness
already enforced the 3s contract internally. It does not — the harness
was enforcing the same flaky 200ms threshold via `result.ok`. So
deleting only the second `println` would have left the first one
(`println(result.ok)`) flaky for the same reason. The right surgical
fix is to relax the threshold to the actual Slack 3-second ack contract
in both places.

2900ms is well under Slack's documented 3s deliverability SLA (so the
test still meaningfully exercises the contract) and far above any
realistic CI scheduler hiccup.

### Other `elapsed_ms` patterns in conformance/

Grepped: `grep -rn "elapsed_ms" conformance/` — only one match, the
file we're fixing here. No other conformance fixtures have the same
wall-clock pattern.

## Test plan

- [x] `cargo run --quiet --bin harn -- test conformance --filter trigger_webhook_slack_events_3s_ack` passes
- [x] 20x determinism loop locally: **20/20 OK**
  ```
  for i in $(seq 20); do
    cargo run --quiet --bin harn -- test conformance --filter trigger_webhook_slack_events_3s_ack >/dev/null \
      || { echo "failed on iter $i"; exit 1; };
  done && echo "20/20 OK"
  ```
- [x] No regression in broader trigger conformance suite: 24/24 pass
  (`cargo run --quiet --bin harn -- test conformance --filter trigger_`)
- [ ] CI green

Closes #1101.