### PR TITLE
Fix flake-detection: --workspace + broaden src/ diff glob

### DIFF
--- a/.github/workflows/flake-detection.yml
+++ b/.github/workflows/flake-detection.yml
@@ -70,9 +70,17 @@ jobs:
         env:
           NEXTEST_FILTER: ${{ steps.touched.outputs.filter }}
         run: |
+          # `--workspace` is required: without it, `cargo nextest run`
+          # only discovers tests in the cwd's package, so `-E
+          # "package(harn-vm)"` (or any other package() filter) matches
+          # nothing at workspace root and reports "0 tests across 0
+          # binaries". `binary(...)` filters happened to work because
+          # they scan built artifacts in target/debug/deps directly, but
+          # package() filters need cargo metadata.
           for i in $(seq 50); do
             printf -- '--- Iteration %d/50 ---\n' "$i"
             cargo nextest run \
+              --workspace \
               --profile flake-detection \
               --test-threads 8 \
               -E "$NEXTEST_FILTER" \

--- a/.github/workflows/flake-detection.yml
+++ b/.github/workflows/flake-detection.yml
@@ -25,9 +25,17 @@ jobs:
         id: touched
         run: |
           git fetch origin main --depth=1
+          # Match every Rust source file under any workspace crate.
+          # The narrower `crates/**/src/**/tests*.rs` glob this replaces
+          # silently skipped src/ files containing inline `#[cfg(test)]`
+          # modules (e.g. `src/foo.rs` with `mod tests { ... }`, or
+          # `src/triggers/test_util/mod.rs` from #1104). The filter
+          # script below maps any non-`tests/` path to
+          # `package(<pkg>)`, which now reruns the whole package's
+          # tests 50× — the safe default when behavior changes
+          # anywhere in a crate could introduce a flake.
           TOUCHED=$(git diff --name-only origin/main...HEAD -- \
-            'crates/**/tests/**' \
-            'crates/**/src/**/tests*.rs' | tr '\n' ' ')
+            'crates/**/*.rs' | tr '\n' ' ')
           FILTER=""
           if [[ -n "${TOUCHED// }" ]]; then
             read -ra PATHS <<< "$TOUCHED"


### PR DESCRIPTION
## Summary

Two coupled fixes to the flake-detection gate, both pre-existing latent bugs that silently skipped coverage:

### 1. Add \`--workspace\` to \`cargo nextest run\`

Without \`--workspace\`, nextest only discovers tests in the cwd's package. At workspace root that's nothing, so any \`-E "package(...)"\` filter resolves to \`0 tests across 0 binaries\` and the job exits with \`Flake detected on iteration 1\`.

\`binary(...)\` filters happened to work (they scan \`target/debug/deps\` directly), which masked the bug while only binary-targeted PRs landed (#1098). The first PRs to exercise \`package(...)\` filters tripped the latent failure:
- #1097 (\`binary(check_cli) or package(harn-vm)\`) — failed flake-detection, landed anyway because the check is non-required.
- #1105 (\`package(harn-vm)\`, just merged) — same phantom failure.

### 2. Broaden the diff glob to catch inline \`#[cfg(test)]\` modules

The prior \`crates/**/src/**/tests*.rs\` glob only caught files literally named \`tests.rs\` or \`tests_*.rs\`. **294 src/ files** in the repo contain inline \`#[cfg(test)] mod tests { ... }\` blocks (\`src/config.rs\`, \`src/triggers/test_util/mod.rs\`, etc.) and were invisible to flake-detection. A PR touching tests inside one of those files would skip the gate silently with \`has_tests=false\`.

Same class of bug that let #1104 silently bypass flake-detection (its \`src/triggers/test_util/mod.rs\` edit didn't match \`tests*.rs\`).

Replaced with single \`crates/**/*.rs\` glob. The filter script already maps any non-\`tests/\` path under \`crates/<pkg>/\` to \`package(<pkg>)\`, so the worst case is "rerun the whole package's tests 50×" — the safe default when behavior changes anywhere in a crate could introduce a flake.

## Verification (local)

\`\`\`sh
$ cargo nextest run --workspace --profile flake-detection --test-threads 8 \\
    -E 'package(harn-vm) and test(/stdlib::agents::workflow::/)'
Summary [0.193s] 25 tests run: 25 passed, 1635 skipped
\`\`\`

(Without \`--workspace\`: \`0 tests run: 0 passed, 0 skipped\`, exit 1.)

\`\`\`sh
$ ./scripts/nextest_filters_from_paths.sh \\
    crates/harn-vm/src/triggers/test_util/mod.rs
package(harn-vm)

$ ./scripts/nextest_filters_from_paths.sh \\
    crates/harn-vm/src/foo.rs crates/harn-cli/tests/orchestrator_cli.rs
package(harn-vm) or binary(orchestrator_cli)
\`\`\`

## Test plan

- [ ] CI: this PR's diff is workflow-YAML-only, so the new glob still produces empty TOUCHED → \`has_tests=false\` → flake-rerun job skipped. Confirms the no-tests path still works.
- [ ] Future PR touching \`crates/<pkg>/src/<file>.rs\`: flake-detection now generates \`package(<pkg>)\` and reruns the package's tests 50× rather than silently passing.