### PR TITLE
Move ACP tool metadata under _meta.harn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,15 @@ condensed series summaries instead of full per-patch history.
 
 ### Fixed
 
+- **ACP tool-call extension metadata follows `_meta.harn` (#904).**
+  Harn-specific `tool_call` / `tool_call_update` fields (`audit`,
+  `durationMs`, `executionDurationMs`, `error`, `errorCategory`,
+  `executor`, `parsing`, and `rawInputPartial`) now live under
+  `_meta.harn` instead of the ACP update root. Canonical fields such as
+  `toolCallId`, `title`, `kind`, `status`, `rawInput`, and `rawOutput`
+  remain top-level. Burin Code consumers should migrate to the new
+  location before consuming this release.
+
 - **Protocol retry spiral after recovered tool calls (#1039).** Tool-call
   recovery no longer triggers an infinite protocol-retry loop.
 

--- a/conformance/protocols/fixtures/acp/session_update_standard.valid.json
+++ b/conformance/protocols/fixtures/acp/session_update_standard.valid.json
@@ -30,9 +30,13 @@
           "toolCallId": "tool-1",
           "title": "read_file",
           "status": "completed",
-          "durationMs": 8,
-          "executionDurationMs": 6,
-          "executor": "harn_builtin",
+          "_meta": {
+            "harn": {
+              "durationMs": 8,
+              "executionDurationMs": 6,
+              "executor": "harn_builtin"
+            }
+          },
           "rawOutput": {
             "ok": true
           }

--- a/conformance/protocols/fixtures/acp/session_update_tool_call_harn_meta.valid.json
+++ b/conformance/protocols/fixtures/acp/session_update_tool_call_harn_meta.valid.json
@@ -1,0 +1,61 @@
+{
+  "name": "acp.session_update.tool_call_harn_meta",
+  "protocol": "acp",
+  "schema": "schemas/acp-session-update.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tool-1",
+          "title": "edit_file",
+          "status": "pending",
+          "rawInput": {
+            "path": "src/main.rs"
+          },
+          "_meta": {
+            "harn": {
+              "audit": {
+                "session_id": "session_42",
+                "mutation_scope": "apply_workspace"
+              },
+              "parsing": true
+            }
+          }
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tool-1",
+          "title": "edit_file",
+          "status": "failed",
+          "_meta": {
+            "harn": {
+              "audit": {
+                "session_id": "session_42",
+                "mutation_scope": "apply_workspace"
+              },
+              "durationMs": 11,
+              "error": "malformed args",
+              "errorCategory": "parse_aborted",
+              "executionDurationMs": 7,
+              "executor": "host_bridge",
+              "parsing": false,
+              "rawInputPartial": "{\"path\":\"src"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/conformance/protocols/fixtures/acp/session_update_tool_call_legacy_top_level_harn_fields.invalid.json
+++ b/conformance/protocols/fixtures/acp/session_update_tool_call_legacy_top_level_harn_fields.invalid.json
@@ -1,0 +1,27 @@
+{
+  "name": "acp.session_update.tool_call_legacy_top_level_harn_fields",
+  "protocol": "acp",
+  "schema": "schemas/acp-session-update.schema.json",
+  "expect": "invalid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tool-1",
+          "title": "read_file",
+          "status": "completed",
+          "durationMs": 8,
+          "executionDurationMs": 6,
+          "executor": "harn_builtin",
+          "rawOutput": {
+            "ok": true
+          }
+        }
+      }
+    }
+  ]
+}

--- a/conformance/protocols/schemas/acp-session-update.schema.json
+++ b/conformance/protocols/schemas/acp-session-update.schema.json
@@ -80,25 +80,56 @@
     "ToolCall": {
       "type": "object",
       "required": ["sessionUpdate", "toolCallId", "title"],
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "sessionUpdate": { "const": "tool_call" },
         "toolCallId": { "type": "string", "minLength": 1 },
         "title": { "type": "string" },
-        "status": { "$ref": "#/$defs/ToolCallStatus" }
+        "kind": { "type": "string" },
+        "status": { "$ref": "#/$defs/ToolCallStatus" },
+        "content": { "type": "array" },
+        "locations": { "type": "array" },
+        "rawInput": {},
+        "rawOutput": {},
+        "_meta": { "$ref": "#/$defs/ExtensionMeta" }
       }
     },
     "ToolCallUpdate": {
       "type": "object",
       "required": ["sessionUpdate", "toolCallId"],
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "sessionUpdate": { "const": "tool_call_update" },
         "toolCallId": { "type": "string", "minLength": 1 },
         "title": { "type": ["string", "null"] },
         "status": { "$ref": "#/$defs/NullableToolCallStatus" },
+        "kind": { "type": "string" },
+        "content": { "type": "array" },
+        "locations": { "type": "array" },
+        "rawInput": {},
+        "rawOutput": {},
+        "_meta": { "$ref": "#/$defs/ExtensionMeta" }
+      }
+    },
+    "ExtensionMeta": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "harn": { "$ref": "#/$defs/HarnToolLifecycleMeta" }
+      }
+    },
+    "HarnToolLifecycleMeta": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "audit": {},
         "durationMs": { "type": "number", "minimum": 0 },
-        "executionDurationMs": { "type": "number", "minimum": 0 }
+        "error": { "type": "string" },
+        "errorCategory": { "type": "string" },
+        "executionDurationMs": { "type": "number", "minimum": 0 },
+        "executor": {},
+        "parsing": { "type": "boolean" },
+        "rawInputPartial": { "type": "string" }
       }
     },
     "ToolCallStatus": {

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -56,6 +56,24 @@ impl AcpAgentEventSink {
             }
         }
     }
+
+    fn attach_harn_meta(
+        update: &mut serde_json::Value,
+        harn_meta: serde_json::Map<String, serde_json::Value>,
+    ) {
+        if harn_meta.is_empty() {
+            return;
+        }
+        let Some(update) = update.as_object_mut() else {
+            return;
+        };
+        update.insert(
+            "_meta".to_string(),
+            serde_json::json!({
+                "harn": harn_meta,
+            }),
+        );
+    }
 }
 
 impl AgentEventSink for AcpAgentEventSink {
@@ -114,14 +132,16 @@ impl AgentEventSink for AcpAgentEventSink {
                 if let Some(k) = kind {
                     update["kind"] = serde_json::to_value(k).unwrap_or_default();
                 }
+                let mut harn_meta = serde_json::Map::new();
                 if let Some(p) = parsing {
-                    update["parsing"] = serde_json::Value::Bool(*p);
+                    harn_meta.insert("parsing".to_string(), serde_json::Value::Bool(*p));
                 }
                 if let Some(record) = audit {
                     if let Ok(value) = serde_json::to_value(record) {
-                        update["audit"] = value;
+                        harn_meta.insert("audit".to_string(), value);
                     }
                 }
+                Self::attach_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
                     "update": update,
@@ -149,38 +169,49 @@ impl AgentEventSink for AcpAgentEventSink {
                     "title": tool_name,
                     "status": Self::status_str(*status),
                 });
+                let mut harn_meta = serde_json::Map::new();
                 if let Some(out) = raw_output {
                     update["rawOutput"] = out.clone();
                 }
                 if let Some(err) = error {
-                    update["error"] = serde_json::Value::String(err.clone());
+                    harn_meta.insert("error".to_string(), serde_json::Value::String(err.clone()));
                 }
                 if let Some(d) = duration_ms {
-                    update["durationMs"] = serde_json::Value::from(*d);
+                    harn_meta.insert("durationMs".to_string(), serde_json::Value::from(*d));
                 }
                 if let Some(d) = execution_duration_ms {
-                    update["executionDurationMs"] = serde_json::Value::from(*d);
+                    harn_meta.insert(
+                        "executionDurationMs".to_string(),
+                        serde_json::Value::from(*d),
+                    );
                 }
                 if let Some(cat) = error_category {
-                    update["errorCategory"] = serde_json::Value::String(cat.as_str().to_string());
+                    harn_meta.insert(
+                        "errorCategory".to_string(),
+                        serde_json::Value::String(cat.as_str().to_string()),
+                    );
                 }
                 if let Some(exec) = executor {
-                    update["executor"] = Self::executor_to_json(exec);
+                    harn_meta.insert("executor".to_string(), Self::executor_to_json(exec));
                 }
                 if let Some(p) = parsing {
-                    update["parsing"] = serde_json::Value::Bool(*p);
+                    harn_meta.insert("parsing".to_string(), serde_json::Value::Bool(*p));
                 }
                 if let Some(record) = audit {
                     if let Ok(value) = serde_json::to_value(record) {
-                        update["audit"] = value;
+                        harn_meta.insert("audit".to_string(), value);
                     }
                 }
                 if let Some(input) = raw_input {
                     update["rawInput"] = input.clone();
                 }
                 if let Some(partial) = raw_input_partial {
-                    update["rawInputPartial"] = serde_json::Value::String(partial.clone());
+                    harn_meta.insert(
+                        "rawInputPartial".to_string(),
+                        serde_json::Value::String(partial.clone()),
+                    );
                 }
+                Self::attach_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
                     "update": update,
@@ -429,6 +460,10 @@ mod tests {
             notifications.push(serde_json::from_str(&line).expect("json"));
         }
         notifications
+    }
+
+    fn update_harn_meta(payload: &serde_json::Value) -> &serde_json::Value {
+        &payload["params"]["update"]["_meta"]["harn"]
     }
 
     fn fixture_handoff() -> HandoffArtifact {
@@ -940,14 +975,11 @@ mod tests {
             "tool_call_update"
         );
         assert_eq!(payload["params"]["update"]["status"], "failed");
-        assert_eq!(
-            payload["params"]["update"]["errorCategory"],
-            "schema_validation"
-        );
-        assert_eq!(
-            payload["params"]["update"]["error"],
-            "missing required arg `path`"
-        );
+        let harn_meta = update_harn_meta(&payload);
+        assert_eq!(harn_meta["errorCategory"], "schema_validation");
+        assert_eq!(harn_meta["error"], "missing required arg `path`");
+        assert!(payload["params"]["update"].get("errorCategory").is_none());
+        assert!(payload["params"]["update"].get("error").is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -973,17 +1005,14 @@ mod tests {
         });
         let line = rx.recv().await.expect("acp tool_call_update");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
-        assert!(payload["params"]["update"].get("errorCategory").is_none());
-        assert!(payload["params"]["update"].get("error").is_none());
+        assert!(payload["params"]["update"].get("_meta").is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn tool_call_carries_parsing_flag_through_to_acp_wire() {
-        // Harn#692: when the streaming candidate detector emits a
-        // tool_call with `parsing: Some(true)`, the ACP wire must carry
-        // a literal `"parsing": true` so clients can render the
-        // in-flight chip. The terminal `tool_call_update` likewise
-        // carries `"parsing": false` to retract it.
+        // Harn#692/#904: candidate parser state is Harn metadata on
+        // the ACP wire so clients can render the in-flight chip without
+        // extending the root ACP tool-call shape.
         let (tx, mut rx) = mpsc::unbounded_channel();
         let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
 
@@ -1000,7 +1029,8 @@ mod tests {
         let line = rx.recv().await.expect("acp tool_call notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
         assert_eq!(payload["params"]["update"]["sessionUpdate"], "tool_call");
-        assert_eq!(payload["params"]["update"]["parsing"], true);
+        assert_eq!(update_harn_meta(&payload)["parsing"], true);
+        assert!(payload["params"]["update"].get("parsing").is_none());
 
         sink.handle_event(&AgentEvent::ToolCallUpdate {
             session_id: "session-1".to_string(),
@@ -1026,15 +1056,13 @@ mod tests {
             payload["params"]["update"]["sessionUpdate"],
             "tool_call_update"
         );
-        assert_eq!(payload["params"]["update"]["parsing"], false);
-        assert_eq!(
-            payload["params"]["update"]["errorCategory"],
-            "parse_aborted"
-        );
+        let harn_meta = update_harn_meta(&payload);
+        assert_eq!(harn_meta["parsing"], false);
+        assert_eq!(harn_meta["errorCategory"], "parse_aborted");
+        assert!(payload["params"]["update"].get("parsing").is_none());
+        assert!(payload["params"]["update"].get("errorCategory").is_none());
 
-        // Default `parsing: None` must not surface a `parsing` field
-        // at all, so existing ACP clients that don't know about the
-        // candidate phase don't see a misleading `null`.
+        // Default `parsing: None` must not surface Harn metadata at all.
         sink.handle_event(&AgentEvent::ToolCall {
             session_id: "session-1".to_string(),
             tool_call_id: "tool-1".to_string(),
@@ -1047,15 +1075,12 @@ mod tests {
         });
         let line = rx.recv().await.expect("acp tool_call notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
-        assert!(
-            payload["params"]["update"].get("parsing").is_none(),
-            "got: {payload}"
-        );
+        assert!(payload["params"]["update"].get("_meta").is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn tool_call_update_serializes_executor_per_acp_wire_format() {
-        // Harn#691: clients render badges off the ACP `executor` field.
+        // Harn#691/#904: clients render badges off Harn executor metadata.
         // The wire shape must distinguish bare-string variants from the
         // McpServer object-with-serverName form so a UI can branch on
         // `typeof executor === "string"`.
@@ -1101,11 +1126,11 @@ mod tests {
                 payload["params"]["update"]["sessionUpdate"],
                 "tool_call_update"
             );
-            assert_eq!(payload["params"]["update"]["executor"], expected);
+            assert_eq!(update_harn_meta(&payload)["executor"], expected);
+            assert!(payload["params"]["update"].get("executor").is_none());
         }
 
-        // `executor: None` must not surface on the wire so existing
-        // clients that don't know about the field aren't surprised.
+        // `executor: None` must not surface Harn metadata.
         sink.handle_event(&AgentEvent::ToolCallUpdate {
             session_id: "session-1".to_string(),
             tool_call_id: "tool-2".to_string(),
@@ -1125,18 +1150,13 @@ mod tests {
         });
         let line = rx.recv().await.expect("acp tool_call_update notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
-        assert!(
-            payload["params"]["update"].get("executor").is_none(),
-            "got: {payload}"
-        );
+        assert!(payload["params"]["update"].get("_meta").is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn tool_call_update_streams_raw_input_and_raw_input_partial_per_acp_wire_format() {
-        // #693: ACP wire format must mirror raw_input as `rawInput` and
-        // raw_input_partial as `rawInputPartial`. Both fields skip
-        // serialization when None so older clients see no surprise
-        // keys.
+        // #693/#904: parsed raw input remains canonical `rawInput`;
+        // unparseable raw bytes are Harn metadata under `_meta.harn`.
         let (tx, mut rx) = mpsc::unbounded_channel();
         let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
 
@@ -1161,7 +1181,7 @@ mod tests {
         let line = rx.recv().await.expect("acp tool_call_update notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
         assert_eq!(payload["params"]["update"]["rawInput"]["q"], "hello");
-        assert!(payload["params"]["update"].get("rawInputPartial").is_none());
+        assert!(payload["params"]["update"].get("_meta").is_none());
 
         // Unparseable partial bytes → `rawInputPartial` populated, `rawInput` absent.
         sink.handle_event(&AgentEvent::ToolCallUpdate {
@@ -1184,9 +1204,10 @@ mod tests {
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
         assert!(payload["params"]["update"].get("rawInput").is_none());
         assert_eq!(
-            payload["params"]["update"]["rawInputPartial"],
+            update_harn_meta(&payload)["rawInputPartial"],
             r#"{"q":"hel"#
         );
+        assert!(payload["params"]["update"].get("rawInputPartial").is_none());
 
         // Terminal updates (None / None) must not introduce these keys.
         sink.handle_event(&AgentEvent::ToolCallUpdate {
@@ -1208,7 +1229,7 @@ mod tests {
         let line = rx.recv().await.expect("acp tool_call_update notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
         assert!(payload["params"]["update"].get("rawInput").is_none());
-        assert!(payload["params"]["update"].get("rawInputPartial").is_none());
+        assert!(update_harn_meta(&payload).get("rawInputPartial").is_none());
         assert_eq!(payload["params"]["update"]["status"], "completed");
     }
 
@@ -1242,7 +1263,7 @@ mod tests {
         });
         let line = rx.recv().await.expect("acp tool_call notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
-        let audit_value = &payload["params"]["update"]["audit"];
+        let audit_value = &update_harn_meta(&payload)["audit"];
         assert_eq!(audit_value["session_id"], "session_42");
         assert_eq!(audit_value["parent_session_id"], "session_root");
         assert_eq!(audit_value["run_id"], "run_42");
@@ -1257,6 +1278,7 @@ mod tests {
             audit_value["approval_policy"]["write_path_allowlist"][0],
             "src/**"
         );
+        assert!(payload["params"]["update"].get("audit").is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1276,7 +1298,7 @@ mod tests {
         let line = rx.recv().await.expect("acp tool_call notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
         assert!(
-            payload["params"]["update"].get("audit").is_none(),
+            payload["params"]["update"].get("_meta").is_none(),
             "got: {payload}"
         );
     }
@@ -1312,12 +1334,18 @@ mod tests {
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
         let update = &payload["params"]["update"];
         assert_eq!(update["sessionUpdate"], "tool_call_update");
-        assert_eq!(update["audit"]["session_id"], "session_42");
-        assert_eq!(update["audit"]["run_id"], "run_42");
-        assert_eq!(update["audit"]["mutation_scope"], "apply_workspace");
-        assert_eq!(update["audit"]["execution_kind"], "workflow");
-        assert_eq!(update["executor"], "host_bridge");
-        assert_eq!(update["durationMs"], 11);
+        let harn_meta = update_harn_meta(&payload);
+        assert_eq!(harn_meta["audit"]["session_id"], "session_42");
+        assert_eq!(harn_meta["audit"]["run_id"], "run_42");
+        assert_eq!(harn_meta["audit"]["mutation_scope"], "apply_workspace");
+        assert_eq!(harn_meta["audit"]["execution_kind"], "workflow");
+        assert_eq!(harn_meta["executor"], "host_bridge");
+        assert_eq!(harn_meta["durationMs"], 11);
+        assert_eq!(harn_meta["executionDurationMs"], 7);
+        assert!(update.get("audit").is_none());
+        assert!(update.get("executor").is_none());
+        assert!(update.get("durationMs").is_none());
+        assert!(update.get("executionDurationMs").is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1343,7 +1371,7 @@ mod tests {
         let line = rx.recv().await.expect("acp tool_call_update notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
         assert!(
-            payload["params"]["update"].get("audit").is_none(),
+            payload["params"]["update"].get("_meta").is_none(),
             "got: {payload}"
         );
     }

--- a/crates/harn-serve/tests/fixtures/acp/session_update_standard.json
+++ b/crates/harn-serve/tests/fixtures/acp/session_update_standard.json
@@ -52,9 +52,13 @@
     "params": {
       "sessionId": "session-1",
       "update": {
-        "durationMs": 7,
-        "executionDurationMs": 5,
-        "executor": "harn_builtin",
+        "_meta": {
+          "harn": {
+            "durationMs": 7,
+            "executionDurationMs": 5,
+            "executor": "harn_builtin"
+          }
+        },
         "rawOutput": {
           "ok": true
         },

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -61,10 +61,10 @@ normal ACP forward-compatibility behavior. Hosts that render Harn
 extensions should key off the explicit extension list from `initialize`
 instead of discovering behavior from a local allow-list.
 
-Harn keeps several high-value tool-rendering fields at the top level of
-`tool_call` / `tool_call_update` rather than moving them under `_meta`,
-because downstream UIs already consume them directly. These field
-extensions are also advertised during `initialize` under
+Harn keeps its tool-rendering extensions under `tool_call._meta.harn` and
+`tool_call_update._meta.harn`, following ACP's extension convention while
+leaving canonical ACP fields at their standard locations. These Harn
+metadata keys are advertised during `initialize` under
 `agentCapabilities._meta.harn.toolLifecycleExtensionFields`:
 
 - `audit`
@@ -78,13 +78,15 @@ extensions are also advertised during `initialize` under
 
 The standard ACP fields (`toolCallId`, `title`, `kind`, `status`,
 `content`, `locations`, `rawInput`, and `rawOutput`) remain available in
-their ACP locations. Harn's pinned fixtures under
-`crates/harn-serve/tests/fixtures/acp/` pin both the standard and
-extension shapes so host integrations can reference stable examples.
+their ACP locations. Hosts migrating from pre-#904 builds should read the
+listed Harn fields from `_meta.harn` instead of the tool-call update root.
+Harn's pinned fixtures under `crates/harn-serve/tests/fixtures/acp/` pin
+both the standard and extension shapes so host integrations can reference
+stable examples.
 
 ### `audit` tag
 
-Both `tool_call` and `tool_call_update` carry an optional `audit`
+Both `tool_call` and `tool_call_update` carry an optional `_meta.harn.audit`
 field that mirrors the active mutation session for the dispatch (see
 [Trust boundary](../../spec/opentrustgraph.md)). Hosts use it to:
 
@@ -105,31 +107,35 @@ contract):
 
 ```json
 {
-  "audit": {
-    "session_id": "session_42",
-    "parent_session_id": "session_root",
-    "run_id": "run_42",
-    "worker_id": "worker_3",
-    "execution_kind": "worker",
-    "mutation_scope": "apply_workspace",
-    "approval_policy": {
-      "auto_approve": [],
-      "auto_deny": [],
-      "require_approval": ["edit_*"],
-      "write_path_allowlist": ["src/**"]
+  "_meta": {
+    "harn": {
+      "audit": {
+        "session_id": "session_42",
+        "parent_session_id": "session_root",
+        "run_id": "run_42",
+        "worker_id": "worker_3",
+        "execution_kind": "worker",
+        "mutation_scope": "apply_workspace",
+        "approval_policy": {
+          "auto_approve": [],
+          "auto_deny": [],
+          "require_approval": ["edit_*"],
+          "write_path_allowlist": ["src/**"]
+        }
+      }
     }
   }
 }
 ```
 
-The field is omitted when no mutation session is installed (read-only
+The `_meta.harn.audit` field is omitted when no mutation session is installed (read-only
 `harn run` invocations, conformance fixtures, scripts that don't enter
-a workflow). Existing clients that don't know about `audit` see the
-same wire shape they always did.
+a workflow). `worker_update.audit` remains top-level because
+`worker_update` itself is a Harn extension update.
 
 ### `executor` tag
 
-`tool_call_update` carries an optional `executor` field that names the
+`tool_call_update` carries an optional `_meta.harn.executor` field that names the
 backend that ran the tool, so clients can render "via mcp:linear" /
 "via host bridge" badges, attribute latency by transport, and route
 errors correctly. Variants:


### PR DESCRIPTION
## Summary

- Move Harn-specific ACP `tool_call` / `tool_call_update` lifecycle fields under `_meta.harn`, leaving canonical ACP fields at the update root.
- Tighten the ACP protocol conformance profile for tool-call updates and add valid/invalid fixtures for the new metadata location and legacy top-level fields.
- Document the migration in `docs/src/bridge-protocol.md` and `CHANGELOG.md`, including the Burin Code consumer follow-up.

Closes #904.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-issue904 cargo test -p harn-serve acp::events -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue904 HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test protocols --filter acp.session_update`
- `cargo fmt --all`
- `git diff --cached --check`