### PR TITLE
[codex] Add canonical receipt envelope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast conformance protocol-conformance bench-vm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec lint-test-patterns
+.PHONY: setup install-hooks configure-merge-drivers build build-release check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast conformance protocol-conformance bench-vm all release-gate portal portal-check portal-demo gen-highlight check-highlight gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets sync-language-spec check-language-spec lint-test-patterns check-receipt-structs
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test conformance protocol-conformance check-highlight check-language-spec check-trigger-quickref check-provider-matrix check-connector-matrix check-trigger-examples check-docs-snippets lint-test-patterns portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test conformance protocol-conformance check-highlight check-language-spec check-trigger-quickref check-provider-matrix check-connector-matrix check-trigger-examples check-docs-snippets lint-test-patterns check-receipt-structs portal-check
 
 check: all
 
@@ -246,3 +246,6 @@ check-docs-snippets:
 # See docs/dev/testing.md for approved alternatives and the opt-out mechanism.
 lint-test-patterns:
 	@./scripts/lint_test_patterns.sh
+
+check-receipt-structs:
+	@./scripts/check_receipt_struct_duplication.py

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -29,6 +29,7 @@ pub mod orchestration;
 pub mod personas;
 pub mod process_sandbox;
 pub mod provenance;
+pub mod receipts;
 pub mod record_filter;
 pub mod runtime_context;
 pub mod runtime_paths;
@@ -114,6 +115,10 @@ pub use personas::{
 pub use provenance::{
     build_signed_receipt, load_or_generate_agent_signing_key, verify_receipt, ProvenanceReceipt,
     ReceiptBuildOptions, ReceiptVerificationReport,
+};
+pub use receipts::{
+    Receipt, ReceiptSink, ReceiptStatus, ReceiptValidationError, RedactionClass, RECEIPT_SCHEMA_ID,
+    RECEIPT_SCHEMA_JSON, RECEIPT_SCHEMA_VERSION,
 };
 pub use record_filter::{normalize_record_filter_expression, CompiledRecordFilter};
 pub use schema::json_to_vm_value;

--- a/crates/harn-vm/src/receipts/mod.rs
+++ b/crates/harn-vm/src/receipts/mod.rs
@@ -1,0 +1,265 @@
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use time::OffsetDateTime;
+
+pub const RECEIPT_SCHEMA_ID: &str = "https://harnlang.com/schemas/receipt.v1.json";
+pub const RECEIPT_SCHEMA_VERSION: &str = "harn.receipt.v1";
+pub const RECEIPT_SCHEMA_JSON: &str = include_str!("../../../../docs/schemas/receipt.v1.json");
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Receipt {
+    pub schema: String,
+    pub id: String,
+    pub parent_run_id: Option<String>,
+    pub persona: String,
+    pub step: Option<String>,
+    pub trace_id: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub started_at: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub completed_at: Option<OffsetDateTime>,
+    pub status: ReceiptStatus,
+    pub inputs_digest: Option<String>,
+    pub outputs_digest: Option<String>,
+    pub model_calls: Vec<BTreeMap<String, JsonValue>>,
+    pub tool_calls: Vec<BTreeMap<String, JsonValue>>,
+    pub cost_usd: f64,
+    pub approvals: Vec<BTreeMap<String, JsonValue>>,
+    pub handoffs: Vec<BTreeMap<String, JsonValue>>,
+    pub side_effects: Vec<BTreeMap<String, JsonValue>>,
+    pub error: Option<BTreeMap<String, JsonValue>>,
+    pub redaction_class: RedactionClass,
+    pub metadata: BTreeMap<String, JsonValue>,
+}
+
+impl Default for Receipt {
+    fn default() -> Self {
+        Self {
+            schema: RECEIPT_SCHEMA_VERSION.to_string(),
+            id: String::new(),
+            parent_run_id: None,
+            persona: String::new(),
+            step: None,
+            trace_id: String::new(),
+            started_at: OffsetDateTime::from_unix_timestamp(0).unwrap(),
+            completed_at: None,
+            status: ReceiptStatus::default(),
+            inputs_digest: None,
+            outputs_digest: None,
+            model_calls: Vec::new(),
+            tool_calls: Vec::new(),
+            cost_usd: 0.0,
+            approvals: Vec::new(),
+            handoffs: Vec::new(),
+            side_effects: Vec::new(),
+            error: None,
+            redaction_class: RedactionClass::default(),
+            metadata: BTreeMap::new(),
+        }
+    }
+}
+
+impl Receipt {
+    pub fn new(
+        id: impl Into<String>,
+        persona: impl Into<String>,
+        trace_id: impl Into<String>,
+        started_at: OffsetDateTime,
+    ) -> Self {
+        Self {
+            schema: RECEIPT_SCHEMA_VERSION.to_string(),
+            id: id.into(),
+            persona: persona.into(),
+            trace_id: trace_id.into(),
+            started_at,
+            status: ReceiptStatus::Running,
+            redaction_class: RedactionClass::Internal,
+            ..Self::default()
+        }
+    }
+
+    pub fn completed(mut self, completed_at: OffsetDateTime, status: ReceiptStatus) -> Self {
+        self.completed_at = Some(completed_at);
+        self.status = status;
+        self
+    }
+
+    pub fn validate_required_shape(&self) -> Result<(), ReceiptValidationError> {
+        if self.schema != RECEIPT_SCHEMA_VERSION {
+            return Err(ReceiptValidationError::InvalidSchema(self.schema.clone()));
+        }
+        if self.id.trim().is_empty() {
+            return Err(ReceiptValidationError::MissingField("id"));
+        }
+        if self.persona.trim().is_empty() {
+            return Err(ReceiptValidationError::MissingField("persona"));
+        }
+        if self.trace_id.trim().is_empty() {
+            return Err(ReceiptValidationError::MissingField("trace_id"));
+        }
+        if !self.cost_usd.is_finite() || self.cost_usd < 0.0 {
+            return Err(ReceiptValidationError::InvalidCost(self.cost_usd));
+        }
+        Ok(())
+    }
+
+    pub fn schema_json() -> Result<JsonValue, serde_json::Error> {
+        serde_json::from_str(RECEIPT_SCHEMA_JSON)
+    }
+}
+
+#[async_trait]
+pub trait ReceiptSink {
+    type Error;
+
+    async fn persist_receipt(&self, receipt: &Receipt) -> Result<(), Self::Error>;
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReceiptStatus {
+    Accepted,
+    #[default]
+    Running,
+    Success,
+    Noop,
+    Failure,
+    Denied,
+    Duplicate,
+    Cancelled,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RedactionClass {
+    Public,
+    #[default]
+    Internal,
+    ReceiptOnly,
+    Secret,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ReceiptValidationError {
+    InvalidSchema(String),
+    MissingField(&'static str),
+    InvalidCost(f64),
+}
+
+impl std::fmt::Display for ReceiptValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReceiptValidationError::InvalidSchema(schema) => {
+                write!(f, "unsupported receipt schema `{schema}`")
+            }
+            ReceiptValidationError::MissingField(field) => {
+                write!(f, "receipt is missing required field `{field}`")
+            }
+            ReceiptValidationError::InvalidCost(cost) => {
+                write!(
+                    f,
+                    "receipt cost_usd must be finite and non-negative, got {cost}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ReceiptValidationError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn fixture_receipt() -> Receipt {
+        Receipt::new(
+            "receipt_01JZCANONICAL",
+            "merge_captain",
+            "trace_01JZCANONICAL",
+            OffsetDateTime::from_unix_timestamp(1_777_000_000).unwrap(),
+        )
+        .completed(
+            OffsetDateTime::from_unix_timestamp(1_777_000_030).unwrap(),
+            ReceiptStatus::Success,
+        )
+    }
+
+    #[test]
+    fn receipt_new_serializes_with_canonical_defaults() {
+        let value = serde_json::to_value(Receipt::new(
+            "receipt_1",
+            "persona",
+            "trace_1",
+            OffsetDateTime::from_unix_timestamp(1_777_000_000).unwrap(),
+        ))
+        .unwrap();
+
+        assert_eq!(value["schema"], RECEIPT_SCHEMA_VERSION);
+        assert_eq!(value["status"], "running");
+        assert_eq!(value["redaction_class"], "internal");
+        assert!(value["model_calls"].as_array().unwrap().is_empty());
+        assert!(value["tool_calls"].as_array().unwrap().is_empty());
+        assert!(value["approvals"].as_array().unwrap().is_empty());
+        assert!(value["handoffs"].as_array().unwrap().is_empty());
+        assert!(value["side_effects"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn receipt_to_value_matches_published_schema_surface() {
+        let receipt_value = serde_json::to_value(fixture_receipt()).unwrap();
+        let receipt_object = receipt_value.as_object().unwrap();
+        let schema = Receipt::schema_json().unwrap();
+        let schema_object = schema.as_object().unwrap();
+        let properties = schema_object["properties"].as_object().unwrap();
+
+        for required in schema_object["required"].as_array().unwrap() {
+            let key = required.as_str().unwrap();
+            assert!(
+                receipt_object.contains_key(key),
+                "serialized receipt is missing schema-required key `{key}`"
+            );
+        }
+
+        for key in receipt_object.keys() {
+            assert!(
+                properties.contains_key(key),
+                "serialized receipt has key `{key}` not published in docs/schemas/receipt.v1.json"
+            );
+        }
+
+        assert_eq!(schema_object["$id"], RECEIPT_SCHEMA_ID);
+        assert_eq!(properties["schema"]["const"], json!(RECEIPT_SCHEMA_VERSION));
+        assert!(properties["status"]["enum"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("success")));
+        assert!(properties["redaction_class"]["enum"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("receipt_only")));
+    }
+
+    #[test]
+    fn receipt_shape_validation_rejects_bad_core_fields() {
+        let mut receipt = fixture_receipt();
+        assert!(receipt.validate_required_shape().is_ok());
+
+        receipt.trace_id.clear();
+        assert_eq!(
+            receipt.validate_required_shape(),
+            Err(ReceiptValidationError::MissingField("trace_id"))
+        );
+
+        receipt.trace_id = "trace_ok".to_string();
+        receipt.cost_usd = -0.01;
+        assert_eq!(
+            receipt.validate_required_shape(),
+            Err(ReceiptValidationError::InvalidCost(-0.01))
+        );
+    }
+}

--- a/docs/schemas/receipt.v1.json
+++ b/docs/schemas/receipt.v1.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/receipt.v1.json",
+  "title": "Harn Receipt Envelope v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "id",
+    "parent_run_id",
+    "persona",
+    "step",
+    "trace_id",
+    "started_at",
+    "completed_at",
+    "status",
+    "inputs_digest",
+    "outputs_digest",
+    "model_calls",
+    "tool_calls",
+    "cost_usd",
+    "approvals",
+    "handoffs",
+    "side_effects",
+    "error",
+    "redaction_class",
+    "metadata"
+  ],
+  "properties": {
+    "schema": {
+      "const": "harn.receipt.v1",
+      "description": "Stable discriminator for the canonical Harn receipt envelope."
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "parent_run_id": {
+      "type": ["string", "null"]
+    },
+    "persona": {
+      "type": "string",
+      "minLength": 1
+    },
+    "step": {
+      "type": ["string", "null"]
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "completed_at": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "accepted",
+        "running",
+        "success",
+        "noop",
+        "failure",
+        "denied",
+        "duplicate",
+        "cancelled"
+      ]
+    },
+    "inputs_digest": {
+      "$ref": "#/$defs/nullable_digest"
+    },
+    "outputs_digest": {
+      "$ref": "#/$defs/nullable_digest"
+    },
+    "model_calls": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/payload_object"
+      }
+    },
+    "tool_calls": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/payload_object"
+      }
+    },
+    "cost_usd": {
+      "type": "number",
+      "minimum": 0
+    },
+    "approvals": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/payload_object"
+      }
+    },
+    "handoffs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/payload_object"
+      }
+    },
+    "side_effects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/payload_object"
+      }
+    },
+    "error": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/payload_object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "redaction_class": {
+      "type": "string",
+      "enum": ["public", "internal", "receipt_only", "secret"]
+    },
+    "metadata": {
+      "$ref": "#/$defs/metadata"
+    }
+  },
+  "$defs": {
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "nullable_digest": {
+      "type": ["string", "null"],
+      "description": "Digest of the corresponding payload, formatted as algorithm:value such as sha256:abc123."
+    },
+    "payload_object": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -41,6 +41,7 @@
 - [Prompt library stdlib](./stdlib/prompt-library.md)
 - [Human in the loop](./hitl.md)
 - [Trust graph](./trust-graph.md)
+- [Audit receipts](./audit-receipts.md)
 - [Skills](./skills.md)
 - [Personas](./personas.md)
   - [Merge Captain](./personas/merge-captain.md)

--- a/docs/src/audit-receipts.md
+++ b/docs/src/audit-receipts.md
@@ -1,0 +1,93 @@
+# Audit Receipts
+
+Harn owns one canonical audit receipt envelope for run, persona, tool, model,
+approval, handoff, and side-effect summaries:
+
+- Rust type: `harn_vm::receipts::Receipt`
+- Rust sink trait: `harn_vm::receipts::ReceiptSink`
+- JSON Schema: `docs/schemas/receipt.v1.json`
+- Schema discriminator: `harn.receipt.v1`
+
+Any new receipt-emitting code MUST serialize this envelope directly or derive
+from it. Downstream crates and applications MUST NOT define parallel receipt
+structs with their own `parent_run_id`, `trace_id`, and `cost_usd` field set.
+If a surface needs a smaller public view, build a projection from
+`Receipt` instead of inventing another source shape.
+
+## Envelope
+
+The v1 envelope includes:
+
+- `id`, `parent_run_id`, `persona`, optional `step`, and `trace_id`
+- `started_at`, optional `completed_at`, and `status`
+- optional `inputs_digest` and `outputs_digest`
+- `model_calls[]`, `tool_calls[]`, `approvals[]`, `handoffs[]`, and
+  `side_effects[]`
+- `cost_usd`, optional `error`, `redaction_class`, and extensible `metadata`
+
+Digest fields are content-addressed references, not raw payload storage. Keep
+secret-bearing inputs, outputs, and tool arguments out of the receipt body; put
+their hash in the digest field and store restricted material behind the
+appropriate host-controlled artifact path.
+
+## Rust Usage
+
+```rust
+use harn_vm::receipts::{Receipt, ReceiptSink, ReceiptStatus};
+
+let receipt = Receipt::new("receipt_01", "merge_captain", "trace_01", started_at)
+    .completed(completed_at, ReceiptStatus::Success);
+
+receipt.validate_required_shape()?;
+sink.persist_receipt(&receipt).await?;
+```
+
+Implement `ReceiptSink` at persistence boundaries. The trait keeps storage
+backends such as harn-cloud-store, local run-record writers, and future host
+surfaces accepting the same envelope even when their physical storage differs.
+
+## harn-cloud Migration
+
+`run_receipts.payload` remains JSONB. The migration should enforce the canonical
+envelope at the JSON boundary:
+
+```sql
+ALTER TABLE run_receipts
+  ADD COLUMN payload JSONB;
+
+ALTER TABLE run_receipts
+  ADD CONSTRAINT run_receipts_payload_receipt_v1
+  CHECK (
+    payload IS NULL OR (
+      jsonb_typeof(payload) = 'object'
+      AND payload->>'schema' = 'harn.receipt.v1'
+      AND payload ? 'parent_run_id'
+      AND payload ? 'trace_id'
+      AND payload ? 'cost_usd'
+      AND jsonb_typeof(payload->'model_calls') = 'array'
+      AND jsonb_typeof(payload->'tool_calls') = 'array'
+      AND jsonb_typeof(payload->'approvals') = 'array'
+      AND jsonb_typeof(payload->'handoffs') = 'array'
+      AND jsonb_typeof(payload->'side_effects') = 'array'
+    )
+  );
+```
+
+The existing typed harn-cloud receipt views can stay as projections for public
+or operator display, but writes to `payload` should come from
+`harn_vm::receipts::Receipt` and the schema in `docs/schemas/receipt.v1.json`.
+
+## burin-code Migration
+
+`RunRecord` readers in burin-code should be generated from
+`docs/schemas/receipt.v1.json` or decode the canonical envelope directly. Swift
+view models may keep local projection types, but they should map from the
+schema-generated receipt type and not carry independent field definitions for
+`parent_run_id`, `trace_id`, and `cost_usd`.
+
+## Duplication Guard
+
+`make check-receipt-structs` fails if a Rust `pub struct` outside
+`crates/harn-vm/src/receipts/` contains the duplicate receipt field trio
+`parent_run_id`, `trace_id`, and `cost_usd`. `make check` runs the guard through
+the `all` target.

--- a/scripts/check_receipt_struct_duplication.py
+++ b/scripts/check_receipt_struct_duplication.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Reject duplicated receipt envelope structs outside harn-vm receipts."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CANONICAL_DIR = ROOT / "crates" / "harn-vm" / "src" / "receipts"
+FIELD_NAMES = {"parent_run_id", "trace_id", "cost_usd"}
+SKIP_PARTS = {
+    ".git",
+    "target",
+    "node_modules",
+    "portal-dist",
+    "docs",
+}
+
+
+def iter_rust_files() -> list[Path]:
+    files: list[Path] = []
+    for path in ROOT.rglob("*.rs"):
+        if any(part in SKIP_PARTS for part in path.relative_to(ROOT).parts):
+            continue
+        if path.is_relative_to(CANONICAL_DIR):
+            continue
+        files.append(path)
+    return files
+
+
+def strip_comments(text: str) -> str:
+    text = re.sub(r"//.*", "", text)
+    return re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+
+
+def find_public_structs(text: str) -> list[tuple[str, int, str]]:
+    structs: list[tuple[str, int, str]] = []
+    for match in re.finditer(r"\bpub\s+struct\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{", text):
+        name = match.group(1)
+        open_brace = text.find("{", match.end() - 1)
+        depth = 0
+        for index in range(open_brace, len(text)):
+            char = text[index]
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    line = text.count("\n", 0, match.start()) + 1
+                    structs.append((name, line, text[open_brace:index]))
+                    break
+    return structs
+
+
+def main() -> int:
+    violations: list[str] = []
+    for path in iter_rust_files():
+        text = strip_comments(path.read_text())
+        for name, line, body in find_public_structs(text):
+            fields = {
+                field
+                for field in FIELD_NAMES
+                if re.search(rf"\bpub\s+{field}\s*:", body)
+            }
+            if fields == FIELD_NAMES:
+                rel = path.relative_to(ROOT)
+                violations.append(f"{rel}:{line}: pub struct {name}")
+
+    if not violations:
+        return 0
+
+    print(
+        "Receipt envelope duplication detected. Use "
+        "`harn_vm::receipts::Receipt` or a projection derived from it instead.",
+        file=sys.stderr,
+    )
+    for violation in violations:
+        print(f"  {violation}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add `harn_vm::receipts::Receipt` as the canonical audit-receipt envelope, with serde JSON support, schema constants, a constructor, shape validation, and `ReceiptSink`
- publish `docs/schemas/receipt.v1.json` and document downstream harn-cloud/burin-code migration expectations
- add `make check-receipt-structs` to fail on duplicate Rust receipt-like structs outside the canonical module

Closes #1058

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p harn-vm receipts --lib`
- `cargo clippy -p harn-vm --lib -- -D warnings`
- `./scripts/check_receipt_struct_duplication.py`
- `python3 -m json.tool docs/schemas/receipt.v1.json >/dev/null`
- `git diff --check`
