### PR TITLE
Replace mock HTTP server with deterministic FakeHttpServer

### DIFF
--- a/crates/harn-vm/src/connectors/github/tests.rs
+++ b/crates/harn-vm/src/connectors/github/tests.rs
@@ -8,10 +8,7 @@ use time::OffsetDateTime;
 
 use super::*;
 use crate::connectors::{
-    test_util::{
-        spawn_mock_http_server, write_http_response, CapturedHttpRequest as CapturedRequest,
-        MockHttpServer,
-    },
+    test_util::{FakeHttpRequest as CapturedRequest, FakeHttpResponse, FakeHttpServer},
     Connector, ConnectorCtx, InboxIndex, MetricsRegistry, RateLimiterFactory, RawInbound,
     TriggerBinding,
 };
@@ -132,93 +129,59 @@ fn client_args(api_base_url: &str) -> JsonValue {
     })
 }
 
-fn spawn_mock_server(
+async fn spawn_mock_server(
     expected_requests: usize,
     scenario: Arc<Mutex<MockScenario>>,
-) -> MockHttpServer {
-    spawn_mock_http_server(
-        expected_requests,
+) -> FakeHttpServer {
+    FakeHttpServer::start_with_capacity(
         "github mock server",
-        move |_index, _addr, request, stream| {
-            let response = {
-                let mut state = scenario.lock().expect("scenario lock");
-                if request.path == "/app/installations/77/access_tokens" {
-                    state.token_requests += 1;
-                    let token = format!("token-{}", state.token_requests);
-                    (
-                        201,
-                        vec![("content-type", "application/json".to_string())],
-                        json!({
-                            "token": token,
-                            "expires_at": "2030-01-01T00:00:00Z",
-                        })
-                        .to_string(),
+        expected_requests,
+        move |_index, _addr, request| {
+            let mut state = scenario.lock().expect("scenario lock");
+            if request.path == "/app/installations/77/access_tokens" {
+                state.token_requests += 1;
+                let token = format!("token-{}", state.token_requests);
+                FakeHttpResponse::status_json(
+                    201,
+                    &json!({
+                        "token": token,
+                        "expires_at": "2030-01-01T00:00:00Z",
+                    }),
+                )
+            } else if state.unauthorized_once.remove(&request.path) {
+                FakeHttpResponse::status_json(401, &json!({"message": "expired token"}))
+            } else if state.rate_limit_once.remove(&request.path) {
+                FakeHttpResponse::status_json(429, &json!({"message": "slow down"}))
+                    .with_header("retry-after", "0")
+            } else {
+                state.api_requests.push(request.clone());
+                let accept = request.headers.get("accept").cloned().unwrap_or_default();
+                let response = if request.path.ends_with("/comments") {
+                    FakeHttpResponse::status_json(201, &json!({"id": 1, "body": "commented"}))
+                } else if request.path.ends_with("/labels") {
+                    FakeHttpResponse::ok_json(&json!([{"name": "bug"}, {"name": "triage"}]))
+                } else if request.path.ends_with("/requested_reviewers") {
+                    FakeHttpResponse::status_json(201, &json!({"requested_reviewers": ["alice"]}))
+                } else if request.path.ends_with("/merge") {
+                    FakeHttpResponse::ok_json(&json!({"merged": true, "message": "merged"}))
+                } else if request.path.starts_with("/search/issues") {
+                    FakeHttpResponse::ok_json(
+                        &json!({"total_count": 1, "items": [{"number": 7, "title": "stale"}]}),
                     )
-                } else if state.unauthorized_once.remove(&request.path) {
-                    (
-                        401,
-                        vec![("content-type", "application/json".to_string())],
-                        json!({"message": "expired token"}).to_string(),
-                    )
-                } else if state.rate_limit_once.remove(&request.path) {
-                    (
-                        429,
-                        vec![
-                            ("content-type", "application/json".to_string()),
-                            ("retry-after", "0".to_string()),
-                        ],
-                        json!({"message": "slow down"}).to_string(),
-                    )
+                } else if request.path.ends_with("/pulls/123")
+                    && accept.contains("application/vnd.github.diff")
+                {
+                    FakeHttpResponse::text(200, "diff --git a/file b/file\n")
+                } else if request.path.ends_with("/issues") {
+                    FakeHttpResponse::status_json(201, &json!({"number": 88, "title": "created"}))
                 } else {
-                    state.api_requests.push(request.clone());
-                    let accept = request.headers.get("accept").cloned().unwrap_or_default();
-                    let (status, body) = if request.path.ends_with("/comments") {
-                        (201, json!({"id": 1, "body": "commented"}).to_string())
-                    } else if request.path.ends_with("/labels") {
-                        (
-                            200,
-                            json!([{"name": "bug"}, {"name": "triage"}]).to_string(),
-                        )
-                    } else if request.path.ends_with("/requested_reviewers") {
-                        (201, json!({"requested_reviewers": ["alice"]}).to_string())
-                    } else if request.path.ends_with("/merge") {
-                        (
-                            200,
-                            json!({"merged": true, "message": "merged"}).to_string(),
-                        )
-                    } else if request.path.starts_with("/search/issues") {
-                        (
-                            200,
-                            json!({"total_count": 1, "items": [{"number": 7, "title": "stale"}]})
-                                .to_string(),
-                        )
-                    } else if request.path.ends_with("/pulls/123")
-                        && accept.contains("application/vnd.github.diff")
-                    {
-                        (200, "diff --git a/file b/file\n".to_string())
-                    } else if request.path.ends_with("/issues") {
-                        (201, json!({"number": 88, "title": "created"}).to_string())
-                    } else {
-                        (200, json!({"ok": true}).to_string())
-                    };
-                    let content_type = if accept.contains("application/vnd.github.diff") {
-                        "text/plain".to_string()
-                    } else {
-                        "application/json".to_string()
-                    };
-                    (
-                        status,
-                        vec![
-                            ("content-type", content_type),
-                            ("x-ratelimit-remaining", "4999".to_string()),
-                        ],
-                        body,
-                    )
-                }
-            };
-            write_http_response(stream, response.0, &response.1, &response.2);
+                    FakeHttpResponse::ok_json(&json!({"ok": true}))
+                };
+                response.with_header("x-ratelimit-remaining", "4999")
+            }
         },
     )
+    .await
 }
 
 fn github_signature(secret: &str, body: &[u8]) -> String {
@@ -494,7 +457,7 @@ async fn normalizes_monitor_github_webhook_events() {
 #[tokio::test]
 async fn outbound_methods_share_cached_installation_token() {
     let scenario = Arc::new(Mutex::new(MockScenario::default()));
-    let server = spawn_mock_server(8, scenario.clone());
+    let server = spawn_mock_server(8, scenario.clone()).await;
     let base_url = server.base_url().to_string();
     let client = initialized_client(Arc::new(StaticSecretProvider {
         namespace: "github".to_string(),
@@ -579,7 +542,7 @@ async fn outbound_methods_share_cached_installation_token() {
 #[tokio::test]
 async fn api_call_uses_authenticated_github_rest_request() {
     let scenario = Arc::new(Mutex::new(MockScenario::default()));
-    let server = spawn_mock_server(2, scenario.clone());
+    let server = spawn_mock_server(2, scenario.clone()).await;
     let base_url = server.base_url().to_string();
     let client = initialized_client(Arc::new(StaticSecretProvider {
         namespace: "github".to_string(),
@@ -632,7 +595,7 @@ async fn unauthorized_response_invalidates_token_and_remints() {
         unauthorized_once: HashSet::from(["/repos/octo/demo/issues/123/comments".to_string()]),
         ..MockScenario::default()
     }));
-    let server = spawn_mock_server(4, scenario.clone());
+    let server = spawn_mock_server(4, scenario.clone()).await;
     let base_url = server.base_url().to_string();
     let client = initialized_client(Arc::new(StaticSecretProvider {
         namespace: "github".to_string(),
@@ -667,7 +630,7 @@ async fn rate_limited_response_retries_once() {
         rate_limit_once: HashSet::from(["/repos/octo/demo/issues/123/comments".to_string()]),
         ..MockScenario::default()
     }));
-    let server = spawn_mock_server(3, scenario.clone());
+    let server = spawn_mock_server(3, scenario.clone()).await;
     let base_url = server.base_url().to_string();
     let client = initialized_client(Arc::new(StaticSecretProvider {
         namespace: "github".to_string(),

--- a/crates/harn-vm/src/connectors/linear/tests.rs
+++ b/crates/harn-vm/src/connectors/linear/tests.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::io::Write;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -9,7 +8,7 @@ use time::OffsetDateTime;
 
 use super::*;
 use crate::connectors::{
-    test_util::{spawn_mock_http_server, MockHttpServer},
+    test_util::{FakeHttpRequest, FakeHttpResponse, FakeHttpServer},
     Connector, ConnectorClient, ConnectorCtx, InboxIndex, MetricsRegistry, RateLimiterFactory,
     RawInbound, TriggerBinding,
 };
@@ -384,7 +383,7 @@ async fn linear_connector_rejects_stale_timestamps_and_records_metric() {
 #[tokio::test]
 async fn linear_client_supports_typed_methods_and_escape_hatch() {
     let requests = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
-    let server = spawn_mock_server(requests.clone(), 5);
+    let server = spawn_mock_server(requests.clone(), 5).await;
     let base_url = server.base_url().to_string();
     let client = initialized_client(&base_url).await;
 
@@ -491,7 +490,7 @@ async fn linear_client_supports_typed_methods_and_escape_hatch() {
 async fn linear_connector_monitor_reenables_webhook_after_probe_streak() {
     let requests = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
     let probes_done = Arc::new(tokio::sync::Notify::new());
-    let server = spawn_monitor_server(requests.clone(), 3, probes_done.clone());
+    let server = spawn_monitor_server(requests.clone(), 3, probes_done.clone()).await;
     let base_url = server.base_url().to_string();
     let mut binding = binding();
     binding.config = json!({
@@ -548,7 +547,7 @@ async fn linear_connector_monitor_reenables_webhook_after_probe_streak() {
 
 fn capture_request(
     requests: &Arc<Mutex<Vec<CapturedRequest>>>,
-    raw: &crate::connectors::test_util::CapturedHttpRequest,
+    raw: &FakeHttpRequest,
 ) -> CapturedRequest {
     let body = if raw.body.is_empty() {
         None
@@ -568,14 +567,14 @@ fn capture_request(
     captured
 }
 
-fn spawn_mock_server(
+async fn spawn_mock_server(
     requests: Arc<Mutex<Vec<CapturedRequest>>>,
     expected_requests: usize,
-) -> MockHttpServer {
-    spawn_mock_http_server(
-        expected_requests,
+) -> FakeHttpServer {
+    FakeHttpServer::start_with_capacity(
         "linear mock server",
-        move |_index, _addr, raw, stream| {
+        expected_requests,
+        move |_index, _addr, raw| {
             let request = capture_request(&requests, raw);
             let query = request
                 .body
@@ -625,56 +624,24 @@ fn spawn_mock_server(
                     }
                 })
             };
-            write_response(
-                stream,
-                &body.to_string(),
-                &[("x-complexity", "12"), ("content-type", "application/json")],
-            );
+            FakeHttpResponse::ok_json(&body).with_header("x-complexity", "12")
         },
     )
+    .await
 }
 
-fn write_response(stream: &mut std::net::TcpStream, body: &str, headers: &[(&str, &str)]) {
-    write_response_status(stream, "200 OK", body, headers);
-}
-
-fn write_response_status(
-    stream: &mut std::net::TcpStream,
-    status: &str,
-    body: &str,
-    headers: &[(&str, &str)],
-) {
-    let mut response = format!(
-        "HTTP/1.1 {status}\r\ncontent-length: {}\r\nconnection: close\r\n",
-        body.len()
-    );
-    for (name, value) in headers {
-        response.push_str(name);
-        response.push_str(": ");
-        response.push_str(value);
-        response.push_str("\r\n");
-    }
-    response.push_str("\r\n");
-    response.push_str(body);
-    stream
-        .write_all(response.as_bytes())
-        .expect("write response");
-}
-
-fn spawn_monitor_server(
+async fn spawn_monitor_server(
     requests: Arc<Mutex<Vec<CapturedRequest>>>,
     expected_requests: usize,
     probes_done: Arc<tokio::sync::Notify>,
-) -> MockHttpServer {
-    spawn_mock_http_server(
-        expected_requests,
+) -> FakeHttpServer {
+    FakeHttpServer::start_with_capacity(
         "linear monitor server",
-        move |index, _addr, raw, stream| {
+        expected_requests,
+        move |index, _addr, raw| {
             let request = capture_request(&requests, raw);
-            match (request.method.as_str(), request.path.as_str()) {
-                ("GET", "/health") => {
-                    write_response_status(stream, "200 OK", "", &[("content-type", "text/plain")]);
-                }
+            let response = match (request.method.as_str(), request.path.as_str()) {
+                ("GET", "/health") => FakeHttpResponse::text(200, ""),
                 ("POST", "/") => {
                     let query = request
                         .body
@@ -686,25 +653,22 @@ fn spawn_monitor_server(
                         query.contains("webhookUpdate"),
                         "unexpected GraphQL query: {query}"
                     );
-                    write_response(
-                        stream,
-                        &json!({
-                            "data": {
-                                "webhookUpdate": {
-                                    "success": true,
-                                    "webhook": { "id": "wh-123", "enabled": true }
-                                }
+                    FakeHttpResponse::ok_json(&json!({
+                        "data": {
+                            "webhookUpdate": {
+                                "success": true,
+                                "webhook": { "id": "wh-123", "enabled": true }
                             }
-                        })
-                        .to_string(),
-                        &[("content-type", "application/json")],
-                    );
+                        }
+                    }))
                 }
                 other => panic!("unexpected request {other:?}"),
-            }
+            };
             if index + 1 == expected_requests {
                 probes_done.notify_one();
             }
+            response
         },
     )
+    .await
 }

--- a/crates/harn-vm/src/connectors/notion/tests.rs
+++ b/crates/harn-vm/src/connectors/notion/tests.rs
@@ -10,10 +10,7 @@ use time::OffsetDateTime;
 
 use super::*;
 use crate::connectors::{
-    test_util::{
-        spawn_mock_http_server, write_http_response, CapturedHttpRequest as CapturedRequest,
-        MockHttpServer,
-    },
+    test_util::{FakeHttpRequest as CapturedRequest, FakeHttpResponse, FakeHttpServer},
     Connector, ConnectorCtx, InboxIndex, MetricsRegistry, RateLimiterFactory, RawInbound,
     TriggerBinding,
 };
@@ -284,35 +281,35 @@ async fn notion_webhook_signed_event_normalizes_to_typed_payload() {
     assert_eq!(payload.subscription_id.as_deref(), Some("sub_1"));
 }
 
-fn write_response(stream: &mut std::net::TcpStream, status: u16, body: &str) {
-    let headers = if status == 429 {
-        vec![
-            ("content-type", "application/json".to_string()),
-            ("retry-after", "0".to_string()),
-        ]
+fn build_response(status: u16, body: String) -> FakeHttpResponse {
+    let response = FakeHttpResponse::empty(status)
+        .with_header("content-type", "application/json")
+        .with_body(body.into_bytes());
+    if status == 429 {
+        response.with_header("retry-after", "0")
     } else {
-        vec![("content-type", "application/json".to_string())]
-    };
-    write_http_response(stream, status, &headers, body);
+        response
+    }
 }
 
-fn spawn_mock_server(
+async fn spawn_mock_server(
     expected_requests: usize,
     responder: impl Fn(usize, &CapturedRequest) -> (u16, String) + Send + 'static,
     captured: Arc<Mutex<Vec<CapturedRequest>>>,
-) -> MockHttpServer {
-    spawn_mock_http_server(
-        expected_requests,
+) -> FakeHttpServer {
+    FakeHttpServer::start_with_capacity(
         "notion mock server",
-        move |index, _addr, request, stream| {
+        expected_requests,
+        move |index, _addr, request| {
             captured
                 .lock()
                 .expect("captured requests poisoned")
                 .push(request.clone());
             let (status, body) = responder(index, request);
-            write_response(stream, status, &body);
+            build_response(status, body)
         },
     )
+    .await
 }
 
 #[tokio::test]
@@ -329,7 +326,8 @@ async fn notion_client_methods_use_current_api_headers_and_paths() {
             (200, body)
         },
         captured.clone(),
-    );
+    )
+    .await;
     let base_url = server.base_url().to_string();
 
     let secrets = Arc::new(StaticSecretProvider::new("notion", HashMap::new()));
@@ -433,7 +431,8 @@ async fn notion_client_retries_once_after_rate_limit() {
             }
         },
         captured.clone(),
-    );
+    )
+    .await;
     let base_url = server.base_url().to_string();
 
     let secrets = Arc::new(StaticSecretProvider::new("notion", HashMap::new()));
@@ -492,7 +491,8 @@ async fn notion_poll_binding_emits_targeted_inbox_event_and_persists_high_water(
             )
         },
         captured,
-    );
+    )
+    .await;
     let base_url = server.base_url().to_string();
 
     let secrets = Arc::new(StaticSecretProvider::new(

--- a/crates/harn-vm/src/connectors/slack/tests.rs
+++ b/crates/harn-vm/src/connectors/slack/tests.rs
@@ -8,10 +8,7 @@ use time::OffsetDateTime;
 
 use super::*;
 use crate::connectors::{
-    test_util::{
-        spawn_mock_http_server, write_http_response, CapturedHttpRequest as CapturedRequest,
-        MockHttpServer,
-    },
+    test_util::{FakeHttpRequest as CapturedRequest, FakeHttpResponse, FakeHttpServer},
     Connector, ConnectorClient, ConnectorCtx, InboxIndex, MetricsRegistry, RateLimiterFactory,
     RawInbound, TriggerBinding,
 };
@@ -414,83 +411,62 @@ struct MockScenario {
     requests: Vec<CapturedRequest>,
 }
 
-fn spawn_mock_server(
+fn json_body(body: &str) -> FakeHttpResponse {
+    FakeHttpResponse::empty(200)
+        .with_header("content-type", "application/json")
+        .with_body(body.as_bytes().to_vec())
+}
+
+async fn spawn_mock_server(
     expected_requests: usize,
     scenario: Arc<Mutex<MockScenario>>,
-) -> MockHttpServer {
-    spawn_mock_http_server(
-        expected_requests,
+) -> FakeHttpServer {
+    FakeHttpServer::start_with_capacity(
         "slack mock server",
-        move |_index, addr, request, stream| {
+        expected_requests,
+        move |_index, addr, request| {
             scenario
                 .lock()
                 .expect("scenario lock")
                 .requests
                 .push(request.clone());
             match request.path.as_str() {
-                "/chat.postMessage" => write_http_response(
-                    stream,
-                    200,
-                    &[("content-type", "application/json".to_string())],
+                "/chat.postMessage" => json_body(
                     r#"{"ok":true,"channel":"C123ABC456","ts":"1715.000100","message":{"text":"hello from harn"}}"#,
                 ),
-                "/chat.update" => write_http_response(
-                    stream,
-                    200,
-                    &[("content-type", "application/json".to_string())],
+                "/chat.update" => json_body(
                     r#"{"ok":true,"channel":"C123ABC456","ts":"1715.000100","text":"updated"}"#,
                 ),
-                "/reactions.add" => write_http_response(
-                    stream,
-                    200,
-                    &[("content-type", "application/json".to_string())],
-                    r#"{"ok":true}"#,
-                ),
-                "/views.open" => write_http_response(
-                    stream,
-                    200,
-                    &[("content-type", "application/json".to_string())],
-                    r#"{"ok":true,"view":{"id":"V123ABC456","type":"modal"}}"#,
-                ),
-                path if path.starts_with("/users.info") => write_http_response(
-                    stream,
-                    200,
-                    &[("content-type", "application/json".to_string())],
-                    r#"{"ok":true,"user":{"id":"U123ABC456","name":"roadrunner"}}"#,
-                ),
-                "/auth.test" => write_http_response(
-                    stream,
-                    200,
-                    &[("content-type", "application/json".to_string())],
+                "/reactions.add" => json_body(r#"{"ok":true}"#),
+                "/views.open" => {
+                    json_body(r#"{"ok":true,"view":{"id":"V123ABC456","type":"modal"}}"#)
+                }
+                path if path.starts_with("/users.info") => {
+                    json_body(r#"{"ok":true,"user":{"id":"U123ABC456","name":"roadrunner"}}"#)
+                }
+                "/auth.test" => json_body(
                     r#"{"ok":true,"url":"https://example.slack.com/","team":"Example","user":"bot"}"#,
                 ),
-                "/files.getUploadURLExternal" => write_http_response(
-                    stream,
-                    200,
-                    &[("content-type", "application/json".to_string())],
-                    &format!(
-                        "{{\"ok\":true,\"upload_url\":\"http://{}/upload/F123\",\"file_id\":\"F123\"}}",
-                        addr
-                    ),
-                ),
-                "/upload/F123" => write_http_response(stream, 200, &[], ""),
-                "/files.completeUploadExternal" => write_http_response(
-                    stream,
-                    200,
-                    &[("content-type", "application/json".to_string())],
-                    r#"{"ok":true,"files":[{"id":"F123","title":"notes.txt"}]}"#,
-                ),
+                "/files.getUploadURLExternal" => json_body(&format!(
+                    "{{\"ok\":true,\"upload_url\":\"http://{}/upload/F123\",\"file_id\":\"F123\"}}",
+                    addr
+                )),
+                "/upload/F123" => FakeHttpResponse::empty(200),
+                "/files.completeUploadExternal" => {
+                    json_body(r#"{"ok":true,"files":[{"id":"F123","title":"notes.txt"}]}"#)
+                }
                 other => panic!("unexpected path {other}"),
             }
         },
     )
+    .await
 }
 
 #[tokio::test]
 async fn slack_outbound_helpers_hit_expected_api_methods() {
     let client = initialized_client().await;
     let scenario = Arc::new(Mutex::new(MockScenario::default()));
-    let server = spawn_mock_server(9, scenario.clone());
+    let server = spawn_mock_server(9, scenario.clone()).await;
     let base_url = server.base_url().to_string();
 
     let posted = client

--- a/crates/harn-vm/src/connectors/test_util.rs
+++ b/crates/harn-vm/src/connectors/test_util.rs
@@ -1,76 +1,304 @@
-use std::collections::BTreeMap;
-use std::io::{Read, Write};
-use std::net::{SocketAddr, TcpListener, TcpStream};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::thread::JoinHandle;
-use std::time::Duration;
+//! Deterministic fake HTTP server for connector tests.
+//!
+//! `FakeHttpServer` binds `127.0.0.1:0`, drives an `accept().await` loop on
+//! a tokio task, and serves each connection sequentially. The server has no
+//! internal busy-wait, no spin-retry, and no wall-clock deadline — shutdown
+//! is signalled via `tokio::sync::Notify` and the listener is bound to the
+//! task lifetime, so dropping the server cancels the accept future without
+//! leaking threads.
+//!
+//! Tests author one closure that turns a `FakeHttpRequest` into a
+//! `FakeHttpResponse`. Captured requests are stored in-memory and accessible
+//! via `requests()` / `assert_received(...)`. For pre-scripted scenarios use
+//! `FakeHttpServer::scripted(label, vec![...])`.
 
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value as JsonValue;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+
+#[allow(unused_imports)]
 pub(crate) use crate::triggers::test_util::clock::MockClock;
 
+/// HTTP request captured by [`FakeHttpServer`].
+///
+/// Headers are normalised to lowercase. The body is the raw bytes between
+/// header end and `content-length`.
 #[derive(Clone, Debug)]
-pub(crate) struct CapturedHttpRequest {
+pub(crate) struct FakeHttpRequest {
     pub(crate) method: String,
     pub(crate) path: String,
     pub(crate) headers: BTreeMap<String, String>,
     pub(crate) body: String,
 }
 
-/// Cooperative accept loop: blocks until either a client connects or
-/// `shutdown` flips, whichever comes first. Returns `None` on shutdown.
-/// Mock servers built on top of [`spawn_mock_http_server`] use this so the
-/// stub thread's lifetime is bounded by a test-owned guard rather than a
-/// wall-clock deadline — the deadline approach flaked under heavy workspace
-/// fan-out on CI.
-fn accept_http_connection_until(
-    listener: &TcpListener,
-    label: &str,
-    shutdown: &AtomicBool,
-) -> Option<TcpStream> {
-    listener
-        .set_nonblocking(true)
-        .expect("set listener nonblocking");
-    loop {
-        if shutdown.load(Ordering::Acquire) {
-            return None;
-        }
-        match listener.accept() {
-            Ok((stream, _)) => {
-                stream
-                    .set_nonblocking(false)
-                    .expect("restore blocking mode");
-                stream.set_read_timeout(Some(Duration::from_secs(30))).ok();
-                stream.set_write_timeout(Some(Duration::from_secs(30))).ok();
-                return Some(stream);
-            }
-            Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                std::thread::sleep(Duration::from_millis(5));
-            }
-            Err(error) => panic!("{label}: accept failed: {error}"),
+impl FakeHttpRequest {
+    /// Parse the body as JSON, returning `None` if the body is empty or
+    /// not valid JSON.
+    #[allow(dead_code)]
+    pub(crate) fn body_json(&self) -> Option<JsonValue> {
+        if self.body.is_empty() {
+            None
+        } else {
+            serde_json::from_str(&self.body).ok()
         }
     }
 }
 
-pub(crate) fn read_http_request(stream: &mut TcpStream) -> CapturedHttpRequest {
-    let mut buffer = Vec::new();
-    let mut temp = [0u8; 4096];
-    let header_end;
-    loop {
-        let n = stream.read(&mut temp).expect("read request");
-        assert!(n > 0, "request ended before headers");
-        buffer.extend_from_slice(&temp[..n]);
-        if let Some(idx) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
-            header_end = idx + 4;
-            break;
+/// Response written back from the fake server's handler.
+#[derive(Clone, Debug)]
+pub(crate) struct FakeHttpResponse {
+    pub(crate) status: u16,
+    pub(crate) headers: Vec<(String, String)>,
+    pub(crate) body: Vec<u8>,
+    /// Drop the connection without writing any bytes — simulates a
+    /// network-level failure observed by the client.
+    pub(crate) disconnect: bool,
+}
+
+impl FakeHttpResponse {
+    /// 200 OK with `application/json` body.
+    pub(crate) fn ok_json(body: &JsonValue) -> Self {
+        Self::status_json(200, body)
+    }
+
+    /// JSON body with the given status.
+    pub(crate) fn status_json(status: u16, body: &JsonValue) -> Self {
+        Self {
+            status,
+            headers: vec![("content-type".into(), "application/json".into())],
+            body: body.to_string().into_bytes(),
+            disconnect: false,
         }
     }
 
+    /// Raw text body with the given status. Defaults `content-type` to
+    /// `text/plain`.
+    pub(crate) fn text(status: u16, body: impl Into<String>) -> Self {
+        Self {
+            status,
+            headers: vec![("content-type".into(), "text/plain".into())],
+            body: body.into().into_bytes(),
+            disconnect: false,
+        }
+    }
+
+    /// Empty body with no headers (callers add their own).
+    pub(crate) fn empty(status: u16) -> Self {
+        Self {
+            status,
+            headers: Vec::new(),
+            body: Vec::new(),
+            disconnect: false,
+        }
+    }
+
+    /// Append a header.
+    pub(crate) fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.push((name.into(), value.into()));
+        self
+    }
+
+    /// Replace the entire header list.
+    #[allow(dead_code)]
+    pub(crate) fn with_headers<I, K, V>(mut self, headers: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.headers = headers
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect();
+        self
+    }
+
+    /// Override the body with raw bytes.
+    #[allow(dead_code)]
+    pub(crate) fn with_body(mut self, body: impl Into<Vec<u8>>) -> Self {
+        self.body = body.into();
+        self
+    }
+
+    /// Drop the connection without sending any bytes.
+    #[allow(dead_code)]
+    pub(crate) fn disconnect() -> Self {
+        Self {
+            status: 0,
+            headers: Vec::new(),
+            body: Vec::new(),
+            disconnect: true,
+        }
+    }
+}
+
+/// Async fake HTTP server bound to `127.0.0.1:0`.
+///
+/// One closure handles every request. Captured requests are stored in
+/// insertion order regardless of whether the response was written. The
+/// server task accepts up to `expected_requests` connections, runs the
+/// handler against each, and exits naturally — there is no wall-clock
+/// deadline. Dropping the server signals shutdown and aborts the task.
+pub(crate) struct FakeHttpServer {
+    addr: SocketAddr,
+    base_url: String,
+    requests: Arc<Mutex<Vec<FakeHttpRequest>>>,
+    shutdown: Arc<Notify>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl FakeHttpServer {
+    /// Default cap when callers don't care about the precise request count.
+    const DEFAULT_CAPACITY: usize = 1024;
+
+    /// Start a fake server with `handler` invoked per accepted request. The
+    /// server accepts up to [`Self::DEFAULT_CAPACITY`] requests before
+    /// exiting; use [`Self::start_with_capacity`] for a precise cap.
+    #[allow(dead_code)]
+    pub(crate) async fn start<F>(label: &'static str, handler: F) -> Self
+    where
+        F: FnMut(usize, SocketAddr, &FakeHttpRequest) -> FakeHttpResponse + Send + 'static,
+    {
+        Self::start_with_capacity(label, Self::DEFAULT_CAPACITY, handler).await
+    }
+
+    /// Start a fake server that accepts up to `expected_requests` and exits.
+    pub(crate) async fn start_with_capacity<F>(
+        label: &'static str,
+        expected_requests: usize,
+        mut handler: F,
+    ) -> Self
+    where
+        F: FnMut(usize, SocketAddr, &FakeHttpRequest) -> FakeHttpResponse + Send + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fake http server");
+        let addr = listener.local_addr().expect("fake http server addr");
+        let base_url = format!("http://{addr}");
+        let requests: Arc<Mutex<Vec<FakeHttpRequest>>> = Arc::new(Mutex::new(Vec::new()));
+        let shutdown = Arc::new(Notify::new());
+        let requests_task = requests.clone();
+        let shutdown_task = shutdown.clone();
+        let handle = tokio::spawn(async move {
+            for index in 0..expected_requests {
+                let mut stream = tokio::select! {
+                    _ = shutdown_task.notified() => return,
+                    accept = listener.accept() => match accept {
+                        Ok((stream, _)) => stream,
+                        Err(error) => panic!("{label}: accept failed: {error}"),
+                    },
+                };
+                let request = match read_request(&mut stream).await {
+                    Some(request) => request,
+                    None => continue,
+                };
+                requests_task
+                    .lock()
+                    .expect("fake http requests poisoned")
+                    .push(request.clone());
+                let response = handler(index, addr, &request);
+                if let Err(error) = write_response(&mut stream, response).await {
+                    // Client closed early or test panicked — record once and
+                    // keep accepting so other in-flight tests aren't masked.
+                    eprintln!("{label}: write failed: {error}");
+                }
+            }
+        });
+        Self {
+            addr,
+            base_url,
+            requests,
+            shutdown,
+            handle: Some(handle),
+        }
+    }
+
+    /// Pre-scripted responses; each accepted request consumes one entry in
+    /// order. Panics if the script is exhausted.
+    #[allow(dead_code)]
+    pub(crate) async fn scripted(label: &'static str, script: Vec<FakeHttpResponse>) -> Self {
+        let capacity = script.len();
+        let mut iter = script.into_iter();
+        Self::start_with_capacity(label, capacity, move |_, _, _| {
+            iter.next()
+                .expect("fake http: pre-scripted responses exhausted")
+        })
+        .await
+    }
+
+    pub(crate) fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Snapshot of every captured request, in receive order.
+    #[allow(dead_code)]
+    pub(crate) fn requests(&self) -> Vec<FakeHttpRequest> {
+        self.requests
+            .lock()
+            .expect("fake http requests poisoned")
+            .clone()
+    }
+
+    /// Find the first captured request matching `predicate`, panicking if
+    /// none match. Useful for `let req = server.assert_received(|r| r.path
+    /// == "/foo")` style assertions.
+    #[allow(dead_code)]
+    pub(crate) fn assert_received(
+        &self,
+        predicate: impl Fn(&FakeHttpRequest) -> bool,
+    ) -> FakeHttpRequest {
+        let snapshot = self.requests();
+        snapshot
+            .into_iter()
+            .find(predicate)
+            .expect("fake http: no captured request matched the predicate")
+    }
+}
+
+impl Drop for FakeHttpServer {
+    fn drop(&mut self) {
+        self.shutdown.notify_waiters();
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+async fn read_request(stream: &mut TcpStream) -> Option<FakeHttpRequest> {
+    let mut buffer: Vec<u8> = Vec::new();
+    let mut temp = [0u8; 4096];
+    let header_end = loop {
+        let n = match stream.read(&mut temp).await {
+            Ok(n) => n,
+            Err(_) => return None,
+        };
+        if n == 0 {
+            return None;
+        }
+        buffer.extend_from_slice(&temp[..n]);
+        if let Some(idx) = find_double_crlf(&buffer) {
+            break idx + 4;
+        }
+    };
+
     let header_text = String::from_utf8_lossy(&buffer[..header_end]).to_string();
     let mut lines = header_text.split("\r\n").filter(|line| !line.is_empty());
-    let request_line = lines.next().expect("request line");
+    let request_line = lines.next()?;
     let mut request_parts = request_line.split_whitespace();
-    let method = request_parts.next().unwrap_or_default().to_string();
-    let path = request_parts.next().unwrap_or_default().to_string();
+    let method = request_parts.next()?.to_string();
+    let path = request_parts.next()?.to_string();
     let mut headers = BTreeMap::new();
     for line in lines {
         if let Some((name, value)) = line.split_once(':') {
@@ -83,120 +311,142 @@ pub(crate) fn read_http_request(stream: &mut TcpStream) -> CapturedHttpRequest {
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(0);
     while buffer.len() < header_end + content_length {
-        let n = stream.read(&mut temp).expect("read body");
-        assert!(n > 0, "request ended before body");
+        let n = match stream.read(&mut temp).await {
+            Ok(n) => n,
+            Err(_) => return None,
+        };
+        if n == 0 {
+            return None;
+        }
         buffer.extend_from_slice(&temp[..n]);
     }
     let body =
         String::from_utf8_lossy(&buffer[header_end..header_end + content_length]).to_string();
 
-    CapturedHttpRequest {
+    Some(FakeHttpRequest {
         method,
         path,
         headers,
         body,
-    }
+    })
 }
 
-/// Mock HTTP server whose lifetime is tied to a test-owned guard.
-///
-/// The server thread serves up to `expected_requests` requests and then
-/// exits naturally. If the guard drops first (e.g. test panicked), the
-/// shutdown flag flips and the server thread exits within one poll
-/// iteration. There is no wall-clock deadline so the test cannot flake
-/// under heavy CI fan-out, and there is no thread leak on test failure
-/// because Drop signals shutdown and joins.
-pub(crate) struct MockHttpServer {
-    addr: SocketAddr,
-    base_url: String,
-    shutdown: Arc<AtomicBool>,
-    handle: Option<JoinHandle<()>>,
+fn find_double_crlf(buffer: &[u8]) -> Option<usize> {
+    buffer.windows(4).position(|window| window == b"\r\n\r\n")
 }
 
-impl MockHttpServer {
-    pub(crate) fn base_url(&self) -> &str {
-        &self.base_url
+async fn write_response(stream: &mut TcpStream, response: FakeHttpResponse) -> std::io::Result<()> {
+    if response.disconnect {
+        return Ok(());
     }
-
-    #[allow(dead_code)]
-    pub(crate) fn addr(&self) -> SocketAddr {
-        self.addr
+    let status_text = status_reason(response.status);
+    let mut header_block = format!(
+        "HTTP/1.1 {} {}\r\ncontent-length: {}\r\nconnection: close\r\n",
+        response.status,
+        status_text,
+        response.body.len(),
+    );
+    for (name, value) in &response.headers {
+        header_block.push_str(name);
+        header_block.push_str(": ");
+        header_block.push_str(value);
+        header_block.push_str("\r\n");
     }
+    header_block.push_str("\r\n");
+    stream.write_all(header_block.as_bytes()).await?;
+    stream.write_all(&response.body).await?;
+    stream.flush().await?;
+    Ok(())
 }
 
-impl Drop for MockHttpServer {
-    fn drop(&mut self) {
-        self.shutdown.store(true, Ordering::Release);
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
-    }
-}
-
-/// Spawn a mock HTTP server bound to `127.0.0.1:0`. The supplied handler is
-/// invoked per accepted request with the request index, the bound listening
-/// address (so handlers can build self-referential URLs), the parsed
-/// request, and the live stream so it can decide how to respond. The server
-/// stops after `expected_requests` accepted requests, after the handler
-/// panics, or when the returned [`MockHttpServer`] is dropped.
-pub(crate) fn spawn_mock_http_server<F>(
-    expected_requests: usize,
-    label: &'static str,
-    mut handler: F,
-) -> MockHttpServer
-where
-    F: FnMut(usize, SocketAddr, &CapturedHttpRequest, &mut TcpStream) + Send + 'static,
-{
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock http server");
-    let addr = listener.local_addr().expect("mock http server addr");
-    let shutdown = Arc::new(AtomicBool::new(false));
-    let shutdown_thread = shutdown.clone();
-    let handle = std::thread::spawn(move || {
-        for index in 0..expected_requests {
-            let Some(mut stream) = accept_http_connection_until(&listener, label, &shutdown_thread)
-            else {
-                return;
-            };
-            let request = read_http_request(&mut stream);
-            handler(index, addr, &request, &mut stream);
-        }
-    });
-    MockHttpServer {
-        addr,
-        base_url: format!("http://{}", addr),
-        shutdown,
-        handle: Some(handle),
-    }
-}
-
-pub(crate) fn write_http_response(
-    stream: &mut TcpStream,
-    status: u16,
-    headers: &[(&str, String)],
-    body: &str,
-) {
-    let status_text = match status {
+fn status_reason(status: u16) -> &'static str {
+    match status {
         200 => "OK",
         201 => "Created",
+        202 => "Accepted",
+        204 => "No Content",
+        301 => "Moved Permanently",
+        302 => "Found",
+        304 => "Not Modified",
+        400 => "Bad Request",
         401 => "Unauthorized",
+        403 => "Forbidden",
+        404 => "Not Found",
+        409 => "Conflict",
+        422 => "Unprocessable Entity",
         429 => "Too Many Requests",
+        500 => "Internal Server Error",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
         _ => "OK",
-    };
-    let mut response = format!(
-        "HTTP/1.1 {} {}\r\ncontent-length: {}\r\nconnection: close\r\n",
-        status,
-        status_text,
-        body.len()
-    );
-    for (name, value) in headers {
-        response.push_str(name);
-        response.push_str(": ");
-        response.push_str(value);
-        response.push_str("\r\n");
     }
-    response.push_str("\r\n");
-    response.push_str(body);
-    stream
-        .write_all(response.as_bytes())
-        .expect("write response");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    async fn http_get(url: &str) -> (u16, String) {
+        let response = reqwest::get(url).await.expect("get");
+        let status = response.status().as_u16();
+        let body = response.text().await.expect("body");
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn handler_serves_one_request_and_captures_it() {
+        let server =
+            FakeHttpServer::start_with_capacity("fake-test", 1, |_index, _addr, request| {
+                assert_eq!(request.method, "GET");
+                FakeHttpResponse::ok_json(&json!({"ok": true, "path": request.path}))
+            })
+            .await;
+        let url = format!("{}/probe", server.base_url());
+        let (status, body) = http_get(&url).await;
+        assert_eq!(status, 200);
+        assert!(body.contains("\"path\":\"/probe\""));
+        assert_eq!(server.requests().len(), 1);
+        let captured = server.assert_received(|req| req.path == "/probe");
+        assert_eq!(captured.method, "GET");
+    }
+
+    #[tokio::test]
+    async fn scripted_responses_replay_in_order() {
+        let server = FakeHttpServer::scripted(
+            "scripted",
+            vec![
+                FakeHttpResponse::ok_json(&json!({"index": 0})),
+                FakeHttpResponse::status_json(429, &json!({"index": 1})),
+            ],
+        )
+        .await;
+        let url = format!("{}/", server.base_url());
+        let (status_a, body_a) = http_get(&url).await;
+        let (status_b, body_b) = http_get(&url).await;
+        assert_eq!(status_a, 200);
+        assert!(body_a.contains("\"index\":0"));
+        assert_eq!(status_b, 429);
+        assert!(body_b.contains("\"index\":1"));
+    }
+
+    #[tokio::test]
+    async fn body_json_decodes_request_payload() {
+        let server = FakeHttpServer::start_with_capacity("body-json", 1, |_, _, request| {
+            let payload = request.body_json().expect("json body");
+            assert_eq!(payload["query"], json!("ping"));
+            FakeHttpResponse::ok_json(&json!({"echo": payload}))
+        })
+        .await;
+        let url = format!("{}/echo", server.base_url());
+        let response = reqwest::Client::new()
+            .post(&url)
+            .json(&json!({"query": "ping"}))
+            .send()
+            .await
+            .expect("post");
+        assert_eq!(response.status().as_u16(), 200);
+        let body = response.text().await.expect("text");
+        assert!(body.contains("\"echo\":{\"query\":\"ping\"}"));
+    }
 }

--- a/crates/harn-vm/src/http/tests.rs
+++ b/crates/harn-vm/src/http/tests.rs
@@ -11,7 +11,7 @@ use super::{
     handle_from_value, http_mock_calls_snapshot, mock_call_headers_value, push_http_mock,
     redact_mock_call_url, reset_http_state, HttpMockResponse,
 };
-use crate::connectors::test_util::{spawn_mock_http_server, write_http_response};
+use crate::connectors::test_util::{FakeHttpResponse, FakeHttpServer};
 use crate::value::VmValue;
 use base64::Engine;
 use rcgen::generate_simple_self_signed;
@@ -296,23 +296,20 @@ async fn http_download_mock_writes_file() {
 #[tokio::test]
 async fn http_proxy_routes_requests_through_configured_proxy() {
     reset_http_state();
-    let proxy = spawn_mock_http_server(1, "proxy listener", |_index, _addr, request, stream| {
-        assert_eq!(request.method, "GET");
-        assert_eq!(request.path, "http://example.invalid/proxy-check");
-        assert_eq!(
-            request
-                .headers
-                .get("proxy-authorization")
-                .map(String::as_str),
-            Some("Basic dXNlcjpwYXNz")
-        );
-        write_http_response(
-            stream,
-            200,
-            &[("content-type", "text/plain".to_string())],
-            "proxied",
-        );
-    });
+    let proxy =
+        FakeHttpServer::start_with_capacity("proxy listener", 1, |_index, _addr, request| {
+            assert_eq!(request.method, "GET");
+            assert_eq!(request.path, "http://example.invalid/proxy-check");
+            assert_eq!(
+                request
+                    .headers
+                    .get("proxy-authorization")
+                    .map(String::as_str),
+                Some("Basic dXNlcjpwYXNz")
+            );
+            FakeHttpResponse::text(200, "proxied")
+        })
+        .await;
 
     let options = BTreeMap::from([
         (


### PR DESCRIPTION
## Summary

- Rebuilds `crates/harn-vm/src/connectors/test_util.rs` on `tokio::net::TcpListener` with an explicit `accept().await` loop, dropping the `std::thread::sleep(5ms)` accept-retry spin and the wall-clock-bounded join.
- Adds a `FakeHttpServer` / `FakeHttpResponse` / `FakeHttpRequest` API with `assert_received`, scripted-replay (`FakeHttpServer::scripted`), and a `disconnect()` failure mode.
- Migrates every existing caller (linear, notion, github, slack, plus the `http_proxy_routes_requests_through_configured_proxy` test in `http/tests.rs`) to the new API and deletes the legacy `MockHttpServer` / `spawn_mock_http_server` / `write_http_response`.

Closes [#1073](https://github.com/burin-labs/harn/issues/1073).

## Acceptance criteria

- `grep -rn "thread::sleep\|tokio::time::sleep" crates/harn-vm/src/connectors/test_util.rs` → 0 matches.
- `grep -rn "thread::sleep" crates/harn-vm/src/connectors/` → 0 matches.
- Connector tests (77) compile and pass on `FakeHttpServer`.
- 50× rerun of `cargo test -p harn-vm --lib connectors:: -- --test-threads=8` is clean.
- `make lint`, `make lint-test-patterns`, `make fmt-harn`, and the full workspace `make test` (3053 tests) are green.

## Test plan

- [x] `cargo test -p harn-vm --lib connectors::`
- [x] `cargo test -p harn-vm --lib http::tests`
- [x] `cargo test -p harn-vm --lib connectors::test_util`
- [x] 50× rerun at `--test-threads=8`
- [x] `make test` (full workspace)
- [x] `make lint` / `make lint-test-patterns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)