### PR TITLE
Convert CLI tests to in-process; gate binary-surface tests as ignored

### DIFF
--- a/crates/harn-cli/src/commands/mcp/serve.rs
+++ b/crates/harn-cli/src/commands/mcp/serve.rs
@@ -2200,6 +2200,32 @@ pub fn on_fail(event: TriggerEvent) -> any {
         serde_json::from_str(text).unwrap_or_else(|_| json!(text))
     }
 
+    // Wait for the next non-lagged notification, treating broadcast
+    // `Lagged` errors as benign (production listeners at lines 1154 /
+    // 1786 do the same). Without this, fixture-write storms during test
+    // setup can fill the 64-slot broadcast buffer faster than the
+    // subscriber drains it on a loaded CI runner, producing a spurious
+    // `Lagged(N)` panic.
+    async fn recv_next_notification(
+        notifications: &mut broadcast::Receiver<JsonValue>,
+    ) -> JsonValue {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            assert!(!remaining.is_zero(), "timed out waiting for notification");
+            match tokio::time::timeout(remaining, notifications.recv())
+                .await
+                .expect("timed out waiting for notification")
+            {
+                Ok(msg) => return msg,
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => {
+                    panic!("notification channel closed")
+                }
+            }
+        }
+    }
+
     async fn collect_notification_methods(
         notifications: &mut broadcast::Receiver<JsonValue>,
         expected: &[&str],
@@ -2209,17 +2235,8 @@ pub fn on_fail(event: TriggerEvent) -> any {
             .copied()
             .collect::<std::collections::BTreeSet<_>>();
         let mut seen = std::collections::BTreeSet::new();
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
         while !expected.iter().all(|method| seen.contains(*method)) {
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            assert!(
-                !remaining.is_zero(),
-                "timed out waiting for notifications; seen={seen:?}"
-            );
-            let notification = tokio::time::timeout(remaining, notifications.recv())
-                .await
-                .expect("timed out waiting for list_changed notification")
-                .expect("notification channel closed");
+            let notification = recv_next_notification(notifications).await;
             if let Some(method) = notification.get("method").and_then(JsonValue::as_str) {
                 seen.insert(method.to_string());
             }
@@ -2364,11 +2381,7 @@ required = true
 Updated: {{ code }}
 "#,
         );
-        let notification =
-            tokio::time::timeout(std::time::Duration::from_secs(5), notifications.recv())
-                .await
-                .expect("timed out waiting for prompt list_changed")
-                .expect("prompt notification channel closed");
+        let notification = recv_next_notification(&mut notifications).await;
         assert_eq!(
             notification["method"],
             json!("notifications/prompts/list_changed")

--- a/crates/harn-cli/tests/acp_server_cli.rs
+++ b/crates/harn-cli/tests/acp_server_cli.rs
@@ -119,6 +119,7 @@ fn latest_prompt_summary(notifications: &[JsonValue], session_id: &str) -> JsonV
         .unwrap_or_else(|| panic!("no prompt summary found for session {session_id}"))
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[test]
 fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
     let _guard = lock_acp_cli_tests();
@@ -318,6 +319,7 @@ fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
     assert!(status.success(), "status={status}");
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[test]
 fn serve_acp_stdio_runs_packaged_adapter() {
     let _guard = lock_acp_cli_tests();

--- a/crates/harn-cli/tests/burin_mini_playground.rs
+++ b/crates/harn-cli/tests/burin_mini_playground.rs
@@ -97,6 +97,7 @@ fn run_case(task: &str, fixture_name: &str) -> (TempDir, PathBuf, Output) {
     (temp, experiment_root, output)
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn burin_mini_explain_repo_fixture_run_passes() {
     let (_temp, experiment_root, output) =
@@ -120,6 +121,7 @@ fn burin_mini_explain_repo_fixture_run_passes() {
     assert_eq!(report_json["verdict"], "pass");
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn burin_mini_comment_file_fixture_run_updates_workspace_copy() {
     let (_temp, experiment_root, output) = run_case("Comment what this file does", "comment.jsonl");
@@ -175,6 +177,7 @@ fn burin_mini_comment_file_fixture_run_updates_workspace_copy() {
     );
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn burin_mini_rate_limit_fixture_run_wires_middleware() {
     let (_temp, experiment_root, output) = run_case(
@@ -291,6 +294,7 @@ fn burin_mini_rate_limit_fixture_run_wires_middleware() {
     );
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn burin_mini_rate_limit_liveish_fixture_ignores_redundant_read_actions() {
     let (_temp, experiment_root, output) = run_case(
@@ -341,6 +345,7 @@ fn burin_mini_rate_limit_liveish_fixture_ignores_redundant_read_actions() {
     );
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn burin_mini_rate_limit_weak_verify_plan_normalizes_to_single_verify_action() {
     let (_temp, experiment_root, output) = run_case(
@@ -411,6 +416,7 @@ fn burin_mini_rate_limit_weak_verify_plan_normalizes_to_single_verify_action() {
     );
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn burin_mini_rate_limit_overresearch_planner_commits_final_action_graph() {
     let (_temp, experiment_root, output) = run_case(
@@ -457,6 +463,7 @@ fn burin_mini_rate_limit_overresearch_planner_commits_final_action_graph() {
     );
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn burin_mini_semantic_evaluator_heuristic_passes_for_rate_limit_fixture() {
     let (temp, experiment_root) = setup_experiment_copy();

--- a/crates/harn-cli/tests/check_cli.rs
+++ b/crates/harn-cli/tests/check_cli.rs
@@ -1,104 +1,98 @@
+//! In-process coverage of `harn check` / `harn lint` regression behaviors.
+//!
+//! Tier 1H of the de-flake epic (#1057, #1067): subprocess CLI tests
+//! pay full cold-start cost per test and rely on stderr scraping. The
+//! regressions here live in workspace library crates (`harn_parser`
+//! type-checking and `harn_modules::build` cycle handling), so the
+//! tests can call those library APIs directly and assert on the
+//! returned values without going through the `harn` binary.
+
 mod test_util;
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use harn_parser::{check_source, DiagnosticSeverity, PipelineError, TypeDiagnostic};
 use tempfile::TempDir;
-use test_util::process::harn_command;
 
 #[test]
-fn check_reports_unknown_struct_type_in_stderr() {
+fn check_reports_unknown_struct_type_with_precise_location() {
     let temp = TempDir::new().unwrap();
     let script = temp.path().join("main.harn");
-    fs::write(&script, "let p = Point { x: 3, y: 4 }\n").unwrap();
+    let source = "let p = Point { x: 3, y: 4 }\n";
+    fs::write(&script, source).unwrap();
 
-    let output = harn_command()
-        .current_dir(temp.path())
-        .args(["check", script.to_str().unwrap()])
-        .output()
-        .unwrap();
+    let (_program, diagnostics) = match check_source(source) {
+        Ok(out) => out,
+        Err(PipelineError::TypeCheck(boxed)) => (Vec::new(), vec![*boxed]),
+        Err(other) => panic!("unexpected non-type-check pipeline error: {other:?}"),
+    };
 
+    let errors: Vec<&TypeDiagnostic> = diagnostics
+        .iter()
+        .filter(|d| d.severity == DiagnosticSeverity::Error)
+        .collect();
     assert!(
-        !output.status.success(),
-        "expected nonzero exit, stdout={}, stderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+        !errors.is_empty(),
+        "expected at least one type-check error; got diagnostics: {diagnostics:#?}"
     );
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("unknown struct type `Point`"),
-        "missing unknown-struct diagnostic: {stderr}"
-    );
-    assert!(
-        stderr.contains(&format!("{}:1:9", script.display())),
-        "missing precise location in stderr: {stderr}"
+    let unknown_struct = errors
+        .iter()
+        .find(|d| d.message.contains("unknown struct type `Point`"))
+        .unwrap_or_else(|| {
+            panic!(
+                "missing unknown-struct diagnostic; got: {:#?}",
+                errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+            )
+        });
+
+    let span = unknown_struct
+        .span
+        .as_ref()
+        .expect("unknown-struct diagnostic should carry a span");
+    let (line, column) = line_column_for_offset(source, span.start);
+    assert_eq!(
+        (line, column),
+        (1, 9),
+        "expected diagnostic at 1:9, got {line}:{column} (span={span:?})"
     );
 }
 
-/// CLI-level regression for the Linux hang on `harn lint <dir>` and
-/// `harn check --workspace` against pipeline trees with cyclic
-/// cross-sibling-directory relative imports (#748). The underlying fix
-/// (`harn_modules::build()` canonicalizing before seen-set dedupe,
-/// #93) already has a unit test in `harn-modules`. This test guards
-/// the same regression at the CLI surface so a future walker change in
-/// `lint` / `check --workspace` that re-introduces the explosion is
-/// caught here rather than in downstream pipeline trees like
-/// burin-code's. Four sibling directories × six files importing every
-/// other directory by relative path — the exact pattern that produced
-/// fresh path spellings on every round-trip and OOM-killed Linux CI
-/// runners around 48 s pre-fix.
+/// In-process regression for the Linux hang on cycles across sibling
+/// directories (#748). The fix lives in `harn_modules::build` (#93),
+/// which canonicalizes paths before the seen-set dedupe; that is the
+/// surface this test exercises directly. Four sibling directories ×
+/// six files importing every other directory by relative path — the
+/// exact pattern that produced fresh path spellings on every
+/// round-trip and OOM-killed Linux CI runners around 48 s pre-fix.
 #[test]
-fn lint_and_check_complete_on_large_cross_directory_cycle_workspace() {
+fn module_graph_terminates_on_large_cross_directory_cycle() {
     let temp = TempDir::new().unwrap();
-    let root = temp.path();
-    let pipelines = root.join("Sources/pipelines");
-    write_cross_directory_cycle_workspace(&pipelines);
+    let pipelines = temp.path().join("Sources/pipelines");
+    let files = write_cross_directory_cycle_workspace(&pipelines);
 
-    fs::write(
-        root.join("harn.toml"),
-        "[package]\n\
-         name = \"hang-regression\"\n\
-         version = \"0.0.0\"\n\
-         \n\
-         [workspace]\n\
-         pipelines = [\"Sources/pipelines\"]\n",
-    )
-    .unwrap();
-
-    let lint_output = harn_command()
-        .current_dir(root)
-        .args(["lint", pipelines.to_str().unwrap()])
-        .output()
-        .unwrap();
-    assert!(
-        lint_output.status.success(),
-        "lint failed: status={:?} stdout={} stderr={}",
-        lint_output.status,
-        String::from_utf8_lossy(&lint_output.stdout),
-        String::from_utf8_lossy(&lint_output.stderr)
-    );
-
-    let check_output = harn_command()
-        .current_dir(root)
-        .args(["check", "--workspace"])
-        .output()
-        .unwrap();
-    assert!(
-        check_output.status.success(),
-        "check --workspace failed: status={:?} stdout={} stderr={}",
-        check_output.status,
-        String::from_utf8_lossy(&check_output.stdout),
-        String::from_utf8_lossy(&check_output.stderr)
-    );
+    // The pre-fix bug appended distinct path spellings forever and
+    // never returned. The post-fix `build()` terminates and returns a
+    // graph with import edges resolvable for every seed file. Calling
+    // `imported_names_for_file` on each seed forces the build to have
+    // visited every node.
+    let graph = harn_modules::build(&files);
+    for seed in &files {
+        assert!(
+            graph.imported_names_for_file(seed).is_some(),
+            "module graph dropped seed file {seed:?}; pre-fix this loop never terminated"
+        );
+    }
 }
 
-fn write_cross_directory_cycle_workspace(pipelines: &Path) {
+fn write_cross_directory_cycle_workspace(pipelines: &Path) -> Vec<PathBuf> {
     let dirs = ["context", "runtime", "host", "tools"];
-    let files_per_dir = 6;
+    let files_per_dir: usize = 6;
     for dir in dirs {
         fs::create_dir_all(pipelines.join(dir)).unwrap();
     }
+    let mut written: Vec<PathBuf> = Vec::new();
     for (dir_idx, dir) in dirs.iter().enumerate() {
         for file_idx in 0..files_per_dir {
             let mut source = String::new();
@@ -110,11 +104,27 @@ fn write_cross_directory_cycle_workspace(pipelines: &Path) {
                 source.push_str(&format!("import \"../{other}/{target}\"\n"));
             }
             source.push_str(&format!("pub fn {dir}_m{file_idx}() {{ {file_idx} }}\n"));
-            fs::write(
-                pipelines.join(dir).join(format!("m{file_idx}.harn")),
-                source,
-            )
-            .unwrap();
+            let path = pipelines.join(dir).join(format!("m{file_idx}.harn"));
+            fs::write(&path, source).unwrap();
+            written.push(path);
         }
     }
+    written
+}
+
+fn line_column_for_offset(source: &str, offset: usize) -> (usize, usize) {
+    let mut line = 1usize;
+    let mut col = 1usize;
+    for (idx, ch) in source.char_indices() {
+        if idx >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+    (line, col)
 }

--- a/crates/harn-cli/tests/crystallize_cli.rs
+++ b/crates/harn-cli/tests/crystallize_cli.rs
@@ -172,8 +172,7 @@ fn crystallize_version_bump_emits_validatable_bundle() {
 
     // Manifest sanity check: schema marker, fixture redaction, plan-vs-candidate kind.
     let manifest_path = bundle_dir.join("candidate.json");
-    let manifest_json: Value =
-        serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
+    let manifest_json: Value = serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
     assert_eq!(
         manifest_json["schema"],
         Value::String("harn.crystallization.candidate.bundle".to_string())
@@ -243,12 +242,9 @@ fn crystallize_plan_only_bundle_keeps_plan_only_kind() {
     )
     .expect("crystallize");
 
-    let bundle = build_crystallization_bundle(
-        artifacts.clone(),
-        &normalized,
-        BundleOptions::default(),
-    )
-    .expect("build bundle");
+    let bundle =
+        build_crystallization_bundle(artifacts.clone(), &normalized, BundleOptions::default())
+            .expect("build bundle");
 
     let report = write_crystallization_artifacts(artifacts, &workflow_path, &report_path, None)
         .expect("write artifacts");

--- a/crates/harn-cli/tests/crystallize_cli.rs
+++ b/crates/harn-cli/tests/crystallize_cli.rs
@@ -1,20 +1,26 @@
+//! In-process coverage of `harn crystallize` mining + bundle behavior.
+//!
+//! Tier 1H of the de-flake epic (#1057, #1067): the CLI command is a
+//! thin wrapper around library functions in
+//! `harn_vm::orchestration::{crystallize_traces,
+//! build_crystallization_bundle, write_crystallization_artifacts,
+//! write_crystallization_bundle, validate_crystallization_bundle,
+//! shadow_replay_bundle}`. Tests call those library functions
+//! directly and assert on the returned data structures plus the
+//! manifest written to disk.
+
 mod test_util;
 
 use std::fs;
 use std::path::Path;
-use std::process::Output;
 
+use harn_vm::orchestration::{
+    build_crystallization_bundle, crystallize_traces, load_crystallization_traces_from_dir,
+    shadow_replay_bundle, validate_crystallization_bundle, write_crystallization_artifacts,
+    write_crystallization_bundle, BundleOptions, CrystallizeOptions,
+};
 use serde_json::{json, Value};
 use tempfile::TempDir;
-use test_util::process::harn_command;
-
-fn run_harn(cwd: &Path, args: &[&str]) -> Output {
-    harn_command()
-        .current_dir(cwd)
-        .args(args)
-        .output()
-        .expect("failed to spawn harn binary")
-}
 
 fn write_trace(dir: &Path, name: &str, payload: &Value) {
     let path = dir.join(name);
@@ -119,86 +125,94 @@ fn crystallize_version_bump_emits_validatable_bundle() {
     let eval_pack_path = temp.path().join("version_bump.harn.eval.toml");
     let bundle_dir = temp.path().join("bundle");
 
-    let mine = run_harn(
-        temp.path(),
-        &[
-            "crystallize",
-            "--from",
-            traces_dir.to_str().unwrap(),
-            "--out",
-            workflow_path.to_str().unwrap(),
-            "--report",
-            report_path.to_str().unwrap(),
-            "--eval-pack",
-            eval_pack_path.to_str().unwrap(),
-            "--bundle",
-            bundle_dir.to_str().unwrap(),
-            "--workflow-name",
-            "version_bump",
-            "--package-name",
-            "release-workflows",
-            "--bundle-team",
-            "platform",
-            "--bundle-repo",
-            "burin-labs/harn",
-            "--min-examples",
-            "5",
-        ],
-    );
+    let traces = load_crystallization_traces_from_dir(&traces_dir).expect("load traces");
+    let normalized = traces.clone();
+    let artifacts = crystallize_traces(
+        traces,
+        CrystallizeOptions {
+            min_examples: 5,
+            workflow_name: Some("version_bump".to_string()),
+            package_name: Some("release-workflows".to_string()),
+            author: None,
+            approver: None,
+            eval_pack_link: Some(eval_pack_path.to_string_lossy().into_owned()),
+        },
+    )
+    .expect("crystallize");
+
+    let bundle = build_crystallization_bundle(
+        artifacts.clone(),
+        &normalized,
+        BundleOptions {
+            external_key: None,
+            title: None,
+            team: Some("platform".to_string()),
+            repo: Some("burin-labs/harn".to_string()),
+            risk_level: None,
+            rollout_policy: None,
+        },
+    )
+    .expect("build bundle");
+
+    let report = write_crystallization_artifacts(
+        artifacts,
+        &workflow_path,
+        &report_path,
+        Some(eval_pack_path.as_path()),
+    )
+    .expect("write artifacts");
+
     assert!(
-        mine.status.success(),
-        "mine failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&mine.stdout),
-        String::from_utf8_lossy(&mine.stderr),
+        report.selected_candidate_id.is_some(),
+        "expected a safe candidate to be selected; report: {report:#?}"
     );
+
+    let manifest = write_crystallization_bundle(&bundle, &bundle_dir).expect("write bundle");
+    assert_eq!(manifest.fixtures.len(), 5);
 
     // Manifest sanity check: schema marker, fixture redaction, plan-vs-candidate kind.
     let manifest_path = bundle_dir.join("candidate.json");
-    let manifest: Value = serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
+    let manifest_json: Value =
+        serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
     assert_eq!(
-        manifest["schema"],
+        manifest_json["schema"],
         Value::String("harn.crystallization.candidate.bundle".to_string())
     );
-    assert_eq!(manifest["schema_version"], json!(1));
-    assert_eq!(manifest["kind"], json!("candidate"));
-    assert_eq!(manifest["external_key"], json!("version-bump"));
-    let workflow = &manifest["workflow"];
+    assert_eq!(manifest_json["schema_version"], json!(1));
+    assert_eq!(manifest_json["kind"], json!("candidate"));
+    assert_eq!(manifest_json["external_key"], json!("version-bump"));
+    let workflow = &manifest_json["workflow"];
     assert_eq!(workflow["name"], json!("version_bump"));
     assert_eq!(workflow["package_name"], json!("release-workflows"));
     assert_eq!(workflow["path"], json!("workflow.harn"));
-    assert_eq!(manifest["team"], json!("platform"));
-    let fixtures = manifest["fixtures"].as_array().unwrap();
+    assert_eq!(manifest_json["team"], json!("platform"));
+    let fixtures = manifest_json["fixtures"].as_array().unwrap();
     assert_eq!(fixtures.len(), 5);
     assert!(fixtures
         .iter()
         .all(|fixture| fixture["redacted"] == json!(true)));
 
-    // The validate subcommand exits 0 and reports OK.
-    let validate = run_harn(
-        temp.path(),
-        &["crystallize", "validate", bundle_dir.to_str().unwrap()],
-    );
+    // Bundle validation passes against itself.
+    let validation = validate_crystallization_bundle(&bundle_dir).expect("validate");
     assert!(
-        validate.status.success(),
-        "validate failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&validate.stdout),
-        String::from_utf8_lossy(&validate.stderr),
+        validation.problems.is_empty(),
+        "validation reported problems: {:#?}",
+        validation.problems
     );
-    assert!(String::from_utf8_lossy(&validate.stdout).contains("OK"));
+    assert!(validation.manifest_ok);
+    assert!(validation.workflow_ok);
+    assert!(validation.report_ok);
+    assert!(validation.fixtures_ok);
+    assert!(validation.redaction_ok);
 
     // Shadow replay also passes against the bundle's own redacted fixtures.
-    let shadow = run_harn(
-        temp.path(),
-        &["crystallize", "shadow", bundle_dir.to_str().unwrap()],
-    );
+    let (shadow_manifest, shadow) = shadow_replay_bundle(&bundle_dir).expect("shadow replay");
     assert!(
-        shadow.status.success(),
-        "shadow failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&shadow.stdout),
-        String::from_utf8_lossy(&shadow.stderr),
+        shadow.pass,
+        "shadow replay failed for candidate {}: {:#?}",
+        shadow_manifest.candidate_id, shadow.failures
     );
-    let stdout = String::from_utf8_lossy(&shadow.stdout);
-    assert!(stdout.contains("pass=true"));
+    assert!(shadow.compared_traces > 0);
 }
 
 #[test]
@@ -217,39 +231,39 @@ fn crystallize_plan_only_bundle_keeps_plan_only_kind() {
     let report_path = temp.path().join("plan.report.json");
     let bundle_dir = temp.path().join("bundle");
 
-    let mine = run_harn(
-        temp.path(),
-        &[
-            "crystallize",
-            "--from",
-            traces_dir.to_str().unwrap(),
-            "--out",
-            workflow_path.to_str().unwrap(),
-            "--report",
-            report_path.to_str().unwrap(),
-            "--bundle",
-            bundle_dir.to_str().unwrap(),
-            "--workflow-name",
-            "linear_triage_plan",
-            "--min-examples",
-            "3",
-        ],
-    );
-    assert!(mine.status.success(), "{:?}", mine);
+    let traces = load_crystallization_traces_from_dir(&traces_dir).expect("load traces");
+    let normalized = traces.clone();
+    let artifacts = crystallize_traces(
+        traces,
+        CrystallizeOptions {
+            min_examples: 3,
+            workflow_name: Some("linear_triage_plan".to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("crystallize");
 
-    let manifest: Value =
+    let bundle = build_crystallization_bundle(
+        artifacts.clone(),
+        &normalized,
+        BundleOptions::default(),
+    )
+    .expect("build bundle");
+
+    let report = write_crystallization_artifacts(artifacts, &workflow_path, &report_path, None)
+        .expect("write artifacts");
+    assert!(report.selected_candidate_id.is_some());
+
+    write_crystallization_bundle(&bundle, &bundle_dir).expect("write bundle");
+    let manifest_json: Value =
         serde_json::from_slice(&fs::read(bundle_dir.join("candidate.json")).unwrap()).unwrap();
-    assert_eq!(manifest["kind"], json!("plan_only"));
-    assert_eq!(manifest["risk_level"], json!("low"));
+    assert_eq!(manifest_json["kind"], json!("plan_only"));
+    assert_eq!(manifest_json["risk_level"], json!("low"));
 
-    let validate = run_harn(
-        temp.path(),
-        &["crystallize", "validate", bundle_dir.to_str().unwrap()],
-    );
+    let validation = validate_crystallization_bundle(&bundle_dir).expect("validate");
     assert!(
-        validate.status.success(),
-        "validate failed: stdout={} stderr={}",
-        String::from_utf8_lossy(&validate.stdout),
-        String::from_utf8_lossy(&validate.stderr),
+        validation.problems.is_empty(),
+        "validation reported problems: {:#?}",
+        validation.problems
     );
 }

--- a/crates/harn-cli/tests/flow_ship_cli.rs
+++ b/crates/harn-cli/tests/flow_ship_cli.rs
@@ -60,6 +60,7 @@ fn phase_zero_demo(slice) {
     temp
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn flow_ship_watch_injects_atoms_and_opens_mock_pr() {
     let repo = demo_repo();
@@ -168,6 +169,7 @@ fn write_invariants_with_many_predicates(dir: &std::path::Path, count: usize) {
     fs::write(dir.join("invariants.harn"), body).unwrap();
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn flow_ship_watch_surfaces_bootstrap_policy_when_present() {
     let repo = demo_repo();
@@ -231,6 +233,7 @@ fn _bootstrap_marker() {
     assert_eq!(maintainers[1]["id"], "user:alice");
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn flow_ship_watch_marks_bootstrap_policy_absent_when_missing() {
     let repo = demo_repo();
@@ -260,6 +263,7 @@ fn flow_ship_watch_marks_bootstrap_policy_absent_when_missing() {
     );
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn flow_ship_watch_blocks_when_predicate_union_explodes() {
     let temp = TempDir::new().unwrap();

--- a/crates/harn-cli/tests/harn_serve_mcp_cli.rs
+++ b/crates/harn-cli/tests/harn_serve_mcp_cli.rs
@@ -201,6 +201,7 @@ async fn collect_sse_body_after_progress(
     body
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[test]
 fn serve_mcp_stdio_lists_calls_and_cancels_exported_functions() {
     let _guard = lock_harn_serve_mcp_tests();
@@ -353,6 +354,7 @@ fn serve_mcp_stdio_lists_calls_and_cancels_exported_functions() {
     assert!(status.success(), "status={status}");
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[test]
 fn serve_mcp_stdio_exposes_script_registered_surface() {
     let _guard = lock_harn_serve_mcp_tests();
@@ -457,6 +459,7 @@ fn serve_mcp_stdio_exposes_script_registered_surface() {
     assert!(status.success(), "status={status}");
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[tokio::test(flavor = "multi_thread")]
 async fn serve_mcp_http_streams_progress_and_enforces_api_keys() {
     let _guard = lock_harn_serve_mcp_tests();
@@ -637,6 +640,7 @@ async fn serve_mcp_http_streams_progress_and_enforces_api_keys() {
     handle.join().unwrap();
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[tokio::test(flavor = "multi_thread")]
 async fn serve_mcp_http_exposes_script_registered_surface() {
     let _guard = lock_harn_serve_mcp_tests();

--- a/crates/harn-cli/tests/llm_mock_cli.rs
+++ b/crates/harn-cli/tests/llm_mock_cli.rs
@@ -34,6 +34,7 @@ fn stderr(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn llm_mock_replays_fifo_fixtures_for_non_mock_provider() {
     let temp = TempDir::new().unwrap();
@@ -70,6 +71,7 @@ pipeline default() {
     assert_eq!(stdout(&output), "first\nsecond\n");
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn llm_mock_reuses_glob_matches() {
     let temp = TempDir::new().unwrap();
@@ -105,6 +107,7 @@ pipeline default() {
     assert_eq!(stdout(&output), "matched\nmatched\n");
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn llm_mock_reports_unmatched_prompt_snippet() {
     let temp = TempDir::new().unwrap();
@@ -136,6 +139,7 @@ pipeline default() {
     assert!(stderr.contains("this prompt is intentionally unmatched"));
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn llm_mock_record_replays_identical_output() {
     let temp = TempDir::new().unwrap();
@@ -187,6 +191,7 @@ pipeline default() {
     assert_eq!(stdout(&recorded), stdout(&replayed));
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn playground_llm_mock_replays_fifo_fixtures_for_non_mock_provider() {
     let temp = TempDir::new().unwrap();
@@ -243,6 +248,7 @@ pipeline default() {
     assert_eq!(stdout(&output), "playground replay\n");
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn playground_llm_mock_record_replays_identical_output() {
     let temp = TempDir::new().unwrap();
@@ -318,6 +324,7 @@ pipeline default() {
     assert_eq!(stdout(&recorded), stdout(&replayed));
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn playground_llm_mock_sub_agent_tool_calls_mutate_host_workspace() {
     let temp = TempDir::new().unwrap();
@@ -420,6 +427,7 @@ pipeline default() {
     assert!(stdout(&output).contains("write complete"));
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn playground_llm_mock_sub_agent_handles_multiple_tool_calls_in_one_turn() {
     let temp = TempDir::new().unwrap();
@@ -528,6 +536,7 @@ pipeline default() {
     assert!(stdout(&output).contains("multi tool complete"));
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn playground_llm_mock_consume_match_advances_between_identical_patterns() {
     let temp = TempDir::new().unwrap();
@@ -621,6 +630,7 @@ pipeline default() {
     assert!(stdout(&output).contains("matched summary"));
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn eval_runs_baseline_and_structural_variant_for_pipeline_file() {
     let temp = TempDir::new().unwrap();

--- a/crates/harn-cli/tests/mcp_server_cli.rs
+++ b/crates/harn-cli/tests/mcp_server_cli.rs
@@ -114,6 +114,7 @@ fn wait_for_http_listener(child: &mut std::process::Child, rx: &Receiver<String>
     )
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[test]
 fn mcp_server_stdio_roundtrips_tools_and_resources() {
     let _guard = lock_mcp_cli_tests();
@@ -378,6 +379,7 @@ fn mcp_server_stdio_roundtrips_tools_and_resources() {
     assert!(status.success(), "status={status}");
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[tokio::test(flavor = "multi_thread")]
 async fn mcp_server_http_roundtrips_initialize_and_fire() {
     let _guard = lock_mcp_cli_tests();

--- a/crates/harn-cli/tests/merge_captain_cli.rs
+++ b/crates/harn-cli/tests/merge_captain_cli.rs
@@ -1,5 +1,21 @@
+//! In-process coverage of `harn merge-captain audit`.
+//!
+//! Tier 1H of the de-flake epic (#1057, #1067): the CLI command in
+//! `crates/harn-cli/src/commands/merge_captain.rs` is a thin wrapper
+//! around `harn_vm::orchestration::{audit_transcript,
+//! load_transcript_jsonl, load_merge_captain_golden}` plus pretty
+//! printing. These tests call the library functions directly and
+//! assert on the structured `AuditReport`, then re-derive the
+//! human/JSON projections used by the CLI to keep the contract
+//! pinned.
+
+mod test_util;
+
 use std::path::PathBuf;
-use std::process::Command;
+
+use harn_vm::orchestration::{
+    audit_transcript, load_merge_captain_golden, load_transcript_jsonl, AuditReport,
+};
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -22,156 +38,114 @@ fn fixture(scenario: &str, kind: &str) -> PathBuf {
         .join(format!("{scenario}.{ext}"))
 }
 
+fn run_audit(scenario: &str) -> AuditReport {
+    let loaded = load_transcript_jsonl(&fixture(scenario, "transcripts")).expect("load transcript");
+    let golden =
+        load_merge_captain_golden(&fixture(scenario, "goldens")).expect("load golden");
+    let mut report = audit_transcript(&loaded.events, Some(&golden));
+    report.source_path = Some(loaded.source_path.display().to_string());
+    report
+}
+
 #[test]
 fn green_pr_passes_audit() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("green_pr", "transcripts").to_str().unwrap(),
-            "--golden",
-            fixture("green_pr", "goldens").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run harn merge-captain audit");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let report = run_audit("green_pr");
     assert!(
-        output.status.success(),
-        "expected pass; stdout={}\nstderr={}",
-        stdout,
-        stderr
+        report.pass,
+        "expected pass; findings: {:#?}",
+        report.findings
     );
-    assert!(stdout.contains("PASS"));
-    assert!(stdout.contains("scenario=green_pr"));
+    assert_eq!(report.scenario.as_deref(), Some("green_pr"));
+    let rendered = format!("{report}");
+    assert!(rendered.contains("PASS"));
+    assert!(rendered.contains("scenario=green_pr"));
 }
 
 #[test]
 fn failing_ci_passes_audit_with_handoff() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("failing_ci", "transcripts").to_str().unwrap(),
-            "--golden",
-            fixture("failing_ci", "goldens").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run audit");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(output.status.success(), "stdout={}", stdout);
-    assert!(stdout.contains("handoff <- handoff"));
+    let report = run_audit("failing_ci");
+    assert!(report.pass, "findings: {:#?}", report.findings);
+    let handoff_transitions: Vec<_> = report
+        .state_transitions
+        .iter()
+        .filter(|t| t.step == "handoff" && t.triggered_by == "handoff")
+        .collect();
+    assert!(
+        !handoff_transitions.is_empty(),
+        "expected at least one handoff transition; transitions: {:#?}",
+        report.state_transitions
+    );
 }
 
 #[test]
 fn semantic_conflict_passes_audit() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("semantic_conflict", "transcripts")
-                .to_str()
-                .unwrap(),
-            "--golden",
-            fixture("semantic_conflict", "goldens").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run audit");
-    assert!(output.status.success());
+    let report = run_audit("semantic_conflict");
+    assert!(report.pass, "findings: {:#?}", report.findings);
 }
 
 #[test]
 fn merge_queue_passes_audit() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("merge_queue", "transcripts").to_str().unwrap(),
-            "--golden",
-            fixture("merge_queue", "goldens").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run audit");
-    assert!(output.status.success());
+    let report = run_audit("merge_queue");
+    assert!(report.pass, "findings: {:#?}", report.findings);
 }
 
 #[test]
 fn new_pr_arrival_passes_audit() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("new_pr_arrival", "transcripts").to_str().unwrap(),
-            "--golden",
-            fixture("new_pr_arrival", "goldens").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run audit");
-    assert!(output.status.success());
+    let report = run_audit("new_pr_arrival");
+    assert!(report.pass, "findings: {:#?}", report.findings);
 }
 
 #[test]
 fn bad_unsafe_merge_fails_audit_with_findings() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("bad_unsafe_merge", "transcripts").to_str().unwrap(),
-            "--golden",
-            fixture("bad_unsafe_merge", "goldens").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run audit");
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let report = run_audit("bad_unsafe_merge");
     assert!(
-        !output.status.success(),
-        "expected non-zero exit; stdout={}",
-        stdout
+        !report.pass,
+        "expected failure; report: {:#?}",
+        report.findings
     );
-    assert!(stdout.contains("FAIL"));
-    assert!(stdout.contains("repeated_read"));
-    assert!(stdout.contains("unsafe_attempted_action"));
-    assert!(stdout.contains("missing_state_step"));
-    assert!(stdout.contains("skipped_verification"));
+    let categories: Vec<&str> = report
+        .findings
+        .iter()
+        .map(|f| f.category.as_str())
+        .collect();
+    for expected in [
+        "repeated_read",
+        "unsafe_attempted_action",
+        "missing_state_step",
+        "skipped_verification",
+    ] {
+        assert!(
+            categories.contains(&expected),
+            "expected `{expected}` finding category; got {categories:?}"
+        );
+    }
+    let rendered = format!("{report}");
+    assert!(rendered.contains("FAIL"));
 }
 
 #[test]
 fn json_output_is_machine_readable() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("green_pr", "transcripts").to_str().unwrap(),
-            "--golden",
-            fixture("green_pr", "goldens").to_str().unwrap(),
-            "--format",
-            "json",
-        ])
-        .output()
-        .expect("run audit");
-    let stdout = String::from_utf8(output.stdout).expect("utf8");
-    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("parse json");
-    assert_eq!(parsed["pass"], serde_json::Value::Bool(true));
+    let report = run_audit("green_pr");
+    let serialized = serde_json::to_value(&report).expect("serialize");
+    assert_eq!(serialized["pass"], serde_json::Value::Bool(true));
     assert_eq!(
-        parsed["scenario"],
+        serialized["scenario"],
         serde_json::Value::String("green_pr".into())
     );
-    assert!(!parsed["state_transitions"].as_array().unwrap().is_empty());
+    assert!(!serialized["state_transitions"]
+        .as_array()
+        .unwrap()
+        .is_empty());
 }
 
 #[test]
 fn audit_without_golden_uses_defaults() {
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args([
-            "merge-captain",
-            "audit",
-            fixture("green_pr", "transcripts").to_str().unwrap(),
-        ])
-        .output()
-        .expect("run audit");
-    assert!(output.status.success());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("scenario=<none>"));
+    let loaded = load_transcript_jsonl(&fixture("green_pr", "transcripts")).expect("load");
+    let mut report = audit_transcript(&loaded.events, None);
+    report.source_path = Some(loaded.source_path.display().to_string());
+    let rendered = format!("{report}");
+    assert!(report.scenario.is_none());
+    assert!(rendered.contains("scenario=<none>"));
 }
 
 #[test]
@@ -181,9 +155,9 @@ fn directory_argument_loads_rotated_logs() {
     std::fs::create_dir_all(&session).unwrap();
     let src = std::fs::read_to_string(fixture("green_pr", "transcripts")).unwrap();
     std::fs::write(session.join("event_log.jsonl"), &src).unwrap();
-    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
-        .args(["merge-captain", "audit", session.to_str().unwrap()])
-        .output()
-        .expect("run audit");
-    assert!(output.status.success());
+    let loaded = load_transcript_jsonl(session.as_path()).expect("load directory");
+    assert!(!loaded.events.is_empty());
+    // The directory case is about loading mechanics, not pass/fail; calling
+    // audit_transcript is enough to exercise the post-load wiring.
+    let _ = audit_transcript(&loaded.events, None);
 }

--- a/crates/harn-cli/tests/merge_captain_cli.rs
+++ b/crates/harn-cli/tests/merge_captain_cli.rs
@@ -40,8 +40,7 @@ fn fixture(scenario: &str, kind: &str) -> PathBuf {
 
 fn run_audit(scenario: &str) -> AuditReport {
     let loaded = load_transcript_jsonl(&fixture(scenario, "transcripts")).expect("load transcript");
-    let golden =
-        load_merge_captain_golden(&fixture(scenario, "goldens")).expect("load golden");
+    let golden = load_merge_captain_golden(&fixture(scenario, "goldens")).expect("load golden");
     let mut report = audit_transcript(&loaded.events, Some(&golden));
     report.source_path = Some(loaded.source_path.display().to_string());
     report

--- a/crates/harn-cli/tests/orchestrator_cli.rs
+++ b/crates/harn-cli/tests/orchestrator_cli.rs
@@ -967,6 +967,7 @@ pub fn on_task(event: TriggerEvent) -> string {
 #[test]
 fn restart_surfaces_stranded_envelopes_and_recover_replays_them_explicitly() {}
 
+#[ignore = "asserts on subprocess stdout for `harn orchestrator fire`/`queue ls`/`queue drain` — moves to slow E2E/smoke job (issue #1069)"]
 #[tokio::test(flavor = "multi_thread")]
 async fn worker_queue_drain_uses_consumer_manifest_and_persists_response_records() {
     let temp = TempDir::new().unwrap();

--- a/crates/harn-cli/tests/orchestrator_http/admin.rs
+++ b/crates/harn-cli/tests/orchestrator_http/admin.rs
@@ -185,6 +185,7 @@ async fn watch_mode_reloads_manifest_changes() {
     shutdown(harness).await;
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[tokio::test(flavor = "multi_thread")]
 async fn reload_cli_uses_admin_endpoint() {
     let temp = TempDir::new().unwrap();

--- a/crates/harn-cli/tests/orchestrator_http/notion.rs
+++ b/crates/harn-cli/tests/orchestrator_http/notion.rs
@@ -1,6 +1,7 @@
 use super::support::*;
 use crate::test_util::process::harn_command;
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[tokio::test(flavor = "multi_thread")]
 async fn notion_webhook_handshake_is_captured_and_reported_by_doctor() {
     let temp = TempDir::new().unwrap();

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -50,6 +50,7 @@ receipt_policy = "required"
 "#
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn persona_list_and_inspect_emit_stable_json() {
     let temp = write_manifest(valid_manifest());
@@ -92,6 +93,7 @@ fn persona_list_and_inspect_emit_stable_json() {
     assert_eq!(persona["evals"][0], "merge_safety");
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn persona_cli_rejects_required_invalid_manifest_cases() {
     for (body, expected) in [
@@ -169,6 +171,7 @@ handoffs = ["review_captain"]
     }
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn persona_manifest_flag_loads_example_personas() {
     let output = harn_command()
@@ -196,6 +199,7 @@ fn persona_manifest_flag_loads_example_personas() {
     assert_eq!(persona["receipt_policy"], "required");
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn persona_manifest_flag_loads_fixer_persona() {
     let output = harn_command()
@@ -225,6 +229,7 @@ fn persona_manifest_flag_loads_fixer_persona() {
     assert_eq!(persona["receipt_policy"], "required");
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn persona_manifest_flag_loads_merge_captain_persona() {
     let output = harn_command()
@@ -262,6 +267,7 @@ fn persona_manifest_flag_loads_merge_captain_persona() {
     assert_eq!(persona["evals"][0], "merge_captain_smoke");
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn persona_manifest_flag_loads_ship_captain_persona() {
     let output = harn_command()
@@ -292,6 +298,7 @@ fn persona_manifest_flag_loads_ship_captain_persona() {
     assert_eq!(persona["evals"][0], "slice_quality");
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn persona_runtime_status_tick_and_budget_are_persisted() {
     let temp = write_manifest(valid_manifest());
@@ -377,6 +384,7 @@ fn persona_runtime_status_tick_and_budget_are_persisted() {
     assert_eq!(status_json["budget"]["tokens_today"], 12);
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn persona_pause_resume_disable_trigger_controls_are_durable() {
     let temp = write_manifest(valid_manifest());
@@ -482,6 +490,7 @@ fn persona_pause_resume_disable_trigger_controls_are_durable() {
     assert_eq!(receipt["status"], "dead_lettered");
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn persona_runtime_blocks_budget_exhaustion() {
     let temp = write_manifest(

--- a/crates/harn-cli/tests/run_exit_codes.rs
+++ b/crates/harn-cli/tests/run_exit_codes.rs
@@ -26,6 +26,7 @@ fn run_script(body: &str) -> std::process::Output {
         .unwrap()
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[test]
 fn pipeline_main_returning_int_sets_exit_code() {
     let out = run_script("pipeline main() {\n  return 42\n}\n");
@@ -38,6 +39,7 @@ fn pipeline_main_returning_int_sets_exit_code() {
     );
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[test]
 fn pipeline_main_returning_err_writes_stderr_and_exits_one() {
     let out = run_script("pipeline main() {\n  return Err(\"boom\")\n}\n");
@@ -49,12 +51,14 @@ fn pipeline_main_returning_err_writes_stderr_and_exits_one() {
     );
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[test]
 fn pipeline_main_returning_ok_exits_zero() {
     let out = run_script("pipeline main() {\n  return Ok(\"done\")\n}\n");
     assert_eq!(out.status.code(), Some(0));
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[test]
 fn pipeline_main_implicit_return_exits_zero() {
     let out = run_script("pipeline main() {\n  println(\"hi\")\n}\n");
@@ -62,6 +66,7 @@ fn pipeline_main_implicit_return_exits_zero() {
     assert!(String::from_utf8_lossy(&out.stdout).contains("hi"));
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[test]
 fn pipeline_main_int_clamped_to_byte_range() {
     let out = run_script("pipeline main() {\n  return 999\n}\n");
@@ -69,6 +74,7 @@ fn pipeline_main_int_clamped_to_byte_range() {
     assert_eq!(out.status.code(), Some(255));
 }
 
+#[ignore = "binary surface — moves to slow E2E/smoke job (issue #1069)"]
 #[test]
 fn explicit_exit_builtin_still_works() {
     let out = run_script("pipeline main() {\n  exit(3)\n}\n");

--- a/crates/harn-cli/tests/trigger_replay_cli.rs
+++ b/crates/harn-cli/tests/trigger_replay_cli.rs
@@ -115,6 +115,7 @@ fn seed_written_event(temp: &TempDir) -> serde_json::Value {
     serde_json::from_str(stdout(&output).trim()).unwrap()
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn trigger_replay_diff_reports_structured_drift() {
     let temp = TempDir::new().unwrap();
@@ -170,6 +171,7 @@ pub fn on_issue(event: TriggerEvent) -> dict {
     );
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn trigger_replay_as_of_uses_historical_binding_version() {
     let temp = TempDir::new().unwrap();
@@ -232,6 +234,7 @@ pub fn on_issue(event: TriggerEvent) -> dict {
     assert_eq!(report["as_of"].as_str(), Some(as_of.as_str()));
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn trigger_replay_bulk_dry_run_filters_on_event_payload() {
     let temp = TempDir::new().unwrap();
@@ -278,6 +281,7 @@ pub fn on_issue(event: TriggerEvent) -> dict {
     assert!(report["items"][0]["report"].is_null());
 }
 
+#[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
 #[test]
 fn trigger_cancel_reports_terminal_events_as_not_cancellable() {
     let temp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Tier 1H of the de-flake epic ([#1057](https://github.com/burin-labs/harn/issues/1057)), implementing [#1067](https://github.com/burin-labs/harn/issues/1067).

Every subprocess CLI test in the fast suite is either replaced with an in-process call against the underlying workspace library crates, or gated behind `#[ignore]` for the slow E2E suite ([#1069](https://github.com/burin-labs/harn/issues/1069)). The fast push-hook suite no longer pays per-test cold-start cost on the `harn` binary for these areas.

### Converted to in-process

| File | Library API used | Tests |
|------|------------------|-------|
| `check_cli` | `harn_parser::check_source`, `harn_modules::build` (the regression for [#93](https://github.com/burin-labs/harn/pull/93)/[#748](https://github.com/burin-labs/harn/issues/748) lives in `harn_modules`, so the test calls it directly) | 2 |
| `crystallize_cli` | `harn_vm::orchestration::{crystallize_traces, build_crystallization_bundle, write_*, validate_crystallization_bundle, shadow_replay_bundle}` | 2 |
| `merge_captain_cli` | `harn_vm::orchestration::{audit_transcript, load_transcript_jsonl, load_merge_captain_golden}` | 9 |

### Gated behind `#[ignore]`

**Pure binary surface** (exit-code mapping, signal handling, persistent stdio JSON-RPC servers — these can't run in-process by definition):

- `run_exit_codes` (6 tests)
- `mcp_server_cli` (2)
- `acp_server_cli` (2)
- `harn_serve_mcp_cli` (4)
- `orchestrator_cli::worker_queue_drain_uses_consumer_manifest_*` (1)
- `orchestrator_http::admin::reload_cli_uses_admin_endpoint` (1)
- `orchestrator_http::notion::notion_webhook_handshake_*` (1)

**Pending follow-up library-API extraction** (the underlying logic lives in the CLI command module rather than a workspace library; converting cleanly requires either bumping `pub(crate) fn run` to `pub` in the relevant `commands::*` module, or extracting the JSON-payload-building portions into `harn-vm`/`harn-flow`/etc. — tracked in [#1106](https://github.com/burin-labs/harn/issues/1106)):

- `flow_ship_cli` (4)
- `persona_cli` (9)
- `llm_mock_cli` (10)
- `trigger_replay_cli` (4)
- `burin_mini_playground` (7)

### Acceptance ([#1067](https://github.com/burin-labs/harn/issues/1067))

- [x] `grep -rn 'harn_command\|Command::new' crates/harn-cli/tests/` matches only `#[ignore]`d tests (verified by an AST-aware Python script that also follows test-helper indirection — the `worker_queue_drain` test transitively calls `harn_command()` via the `run_harn_with_env` helper, which the naïve grep alone would miss).
- [x] The 13 converted tests pass on the fast push-hook suite in 0.3s combined.
- [x] `cargo build --tests -p harn-cli` and `cargo clippy --tests -p harn-cli` are clean.
- [x] Manual `cargo run --bin harn -- check` / `merge-captain audit` smoke-tested via the existing CLI dispatcher (which still calls the same library functions the converted tests now exercise).

## Test plan

- [x] `cargo build --tests -p harn-cli` — clean
- [x] `cargo clippy --tests -p harn-cli` — clean
- [x] `cargo test -p harn-cli --test check_cli --test crystallize_cli --test merge_captain_cli` — 13 passed
- [ ] Full workspace `make test` and `make all` will be exercised by CI on this PR before auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)