### PR TITLE
Add persona step attribute metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,6 +1739,8 @@ dependencies = [
 name = "harn-dap"
 version = "0.7.52"
 dependencies = [
+ "harn-modules",
+ "harn-parser",
  "harn-vm",
  "serde",
  "serde_json",

--- a/conformance/tests/integration/attributes_step.expected
+++ b/conformance/tests/integration/attributes_step.expected
@@ -1,0 +1,1 @@
+[harn] attributes_step ok

--- a/conformance/tests/integration/attributes_step.harn
+++ b/conformance/tests/integration/attributes_step.harn
@@ -1,0 +1,28 @@
+// `@step` declares statically discoverable persona step metadata.
+@persona(name: "merge_captain", tools: [github], autonomy: suggest, receipts: optional)
+fn merge_captain(ctx) -> string {
+  let planned = plan_step(ctx)
+  let implemented = implement_step(planned)
+  return verify_step(implemented)
+}
+
+@step(name: "plan", model: "gpt-5.4-mini", approval: optional, receipt: audit, error_boundary: fail, retry: {max_attempts: 2})
+fn plan_step(ctx) -> string {
+  return "plan:${ctx}"
+}
+
+@step(name: "implement", approval: required, receipt: audit, error_boundary: continue)
+fn implement_step(ctx) -> string {
+  return "implement:${ctx}"
+}
+
+@step(name: "verify", model: "gpt-5.4", approval: optional, receipt: none, error_boundary: escalate)
+fn verify_step(ctx) -> string {
+  return "verify:${ctx}"
+}
+
+@test
+pipeline test_step_attributes(task) {
+  assert_eq(merge_captain("issue"), "verify:implement:plan:issue")
+  log("attributes_step ok")
+}

--- a/crates/harn-cli/src/commands/check/check_cmd.rs
+++ b/crates/harn-cli/src/commands/check/check_cmd.rs
@@ -52,6 +52,7 @@ pub(crate) fn check_file_inner(
             file_path: Some(path),
             require_file_header: false,
             complexity_threshold: None,
+            persona_step_allowlist: &[],
         },
     );
     diagnostic_count += lint_diagnostics.len();

--- a/crates/harn-cli/src/commands/check/config.rs
+++ b/crates/harn-cli/src/commands/check/config.rs
@@ -48,6 +48,17 @@ pub(crate) fn harn_lint_complexity_threshold(path: &Path) -> Option<usize> {
     }
 }
 
+/// Read `[lint] persona_step_allowlist` from the nearest harn.toml.
+pub(crate) fn harn_lint_persona_step_allowlist(path: &Path) -> Vec<String> {
+    match harn_config::load_for_path(path) {
+        Ok(cfg) => cfg.lint.persona_step_allowlist,
+        Err(e) => {
+            eprintln!("warning: {e}");
+            Vec::new()
+        }
+    }
+}
+
 pub(crate) fn collect_harn_targets(targets: &[&str]) -> Vec<PathBuf> {
     let mut files = Vec::new();
     for target in targets {

--- a/crates/harn-cli/src/commands/check/lint.rs
+++ b/crates/harn-cli/src/commands/check/lint.rs
@@ -17,6 +17,7 @@ pub(crate) fn lint_file_inner(
     module_graph: &harn_modules::ModuleGraph,
     require_file_header: bool,
     complexity_threshold: Option<usize>,
+    persona_step_allowlist: &[String],
 ) -> CommandOutcome {
     let path_str = path.to_string_lossy().into_owned();
     let (source, program) = parse_source_file(&path_str);
@@ -25,6 +26,7 @@ pub(crate) fn lint_file_inner(
         file_path: Some(path),
         require_file_header,
         complexity_threshold,
+        persona_step_allowlist,
     };
     let diagnostics = harn_lint::lint_with_module_graph(
         &program,
@@ -61,6 +63,7 @@ pub(crate) fn lint_fix_file(
     module_graph: &harn_modules::ModuleGraph,
     require_file_header: bool,
     complexity_threshold: Option<usize>,
+    persona_step_allowlist: &[String],
 ) -> usize {
     let path_str = path.to_string_lossy().into_owned();
     let (source, program) = parse_source_file(&path_str);
@@ -69,6 +72,7 @@ pub(crate) fn lint_fix_file(
         file_path: Some(path),
         require_file_header,
         complexity_threshold,
+        persona_step_allowlist,
     };
     let lint_diags = harn_lint::lint_with_module_graph(
         &program,

--- a/crates/harn-cli/src/commands/check/mod.rs
+++ b/crates/harn-cli/src/commands/check/mod.rs
@@ -18,7 +18,8 @@ pub(crate) use bundle::build_bundle_manifest;
 pub(crate) use check_cmd::check_file_inner;
 pub(crate) use config::{
     apply_harn_lint_config, build_module_graph, collect_cross_file_imports, collect_harn_targets,
-    harn_lint_complexity_threshold, harn_lint_require_file_header,
+    harn_lint_complexity_threshold, harn_lint_persona_step_allowlist,
+    harn_lint_require_file_header,
 };
 pub(crate) use fmt::{fmt_targets, FmtMode};
 pub(crate) use host_capabilities::load_host_capabilities;

--- a/crates/harn-cli/src/commands/persona.rs
+++ b/crates/harn-cli/src/commands/persona.rs
@@ -168,6 +168,17 @@ pub(crate) fn run_inspect(manifest: Option<&Path>, args: &PersonaInspectArgs) {
     println!("handoffs:       {}", comma_or_dash(&persona.handoffs));
     println!("context_packs:  {}", comma_or_dash(&persona.context_packs));
     println!("evals:          {}", comma_or_dash(&persona.evals));
+    if !persona.steps.is_empty() {
+        println!(
+            "steps:          {}",
+            persona
+                .steps
+                .iter()
+                .map(|step| format!("{} ({})", step.name, step.function))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
     if let Some(owner) = &persona.owner {
         println!("owner:          {owner}");
     }
@@ -561,6 +572,7 @@ fn persona_to_json(
         "handoffs": &persona.handoffs,
         "context_packs": &persona.context_packs,
         "evals": &persona.evals,
+        "steps": &persona.steps,
         "owner": persona.owner.as_deref(),
         "package_source": {
             "package": persona.package_source.package.as_deref(),

--- a/crates/harn-cli/src/config.rs
+++ b/crates/harn-cli/src/config.rs
@@ -18,6 +18,7 @@
 //! disabled = ["unused-import"]
 //! require_file_header = false
 //! complexity_threshold = 25
+//! persona_step_allowlist = ["legacy_helper"]
 //! ```
 
 use std::fmt;
@@ -67,6 +68,10 @@ pub struct LintConfig {
     /// snake_case and kebab-case for consistency with the other keys.
     #[serde(default, alias = "complexity-threshold")]
     pub complexity_threshold: Option<usize>,
+    /// Non-stdlib functions that may be called directly from `@persona`
+    /// bodies without being declared as `@step`.
+    #[serde(default, alias = "persona-step-allowlist")]
+    pub persona_step_allowlist: Vec<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -270,6 +270,8 @@ async fn async_main() {
                         || commands::check::harn_lint_require_file_header(file);
                     let complexity_threshold =
                         commands::check::harn_lint_complexity_threshold(file);
+                    let persona_step_allowlist =
+                        commands::check::harn_lint_persona_step_allowlist(file);
                     commands::check::lint_fix_file(
                         file,
                         &config,
@@ -277,6 +279,7 @@ async fn async_main() {
                         &module_graph,
                         require_header,
                         complexity_threshold,
+                        &persona_step_allowlist,
                     );
                 }
             } else {
@@ -288,6 +291,8 @@ async fn async_main() {
                         || commands::check::harn_lint_require_file_header(file);
                     let complexity_threshold =
                         commands::check::harn_lint_complexity_threshold(file);
+                    let persona_step_allowlist =
+                        commands::check::harn_lint_persona_step_allowlist(file);
                     let outcome = commands::check::lint_file_inner(
                         file,
                         &config,
@@ -295,6 +300,7 @@ async fn async_main() {
                         &module_graph,
                         require_header,
                         complexity_threshold,
+                        &persona_step_allowlist,
                     );
                     should_fail |= outcome.should_fail(config.strict);
                 }

--- a/crates/harn-cli/src/package/extensions.rs
+++ b/crates/harn-cli/src/package/extensions.rs
@@ -857,6 +857,27 @@ pub fn load_personas_from_manifest_path(
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| PathBuf::from("."));
+    if manifest_path.extension().and_then(|ext| ext.to_str()) == Some("harn") {
+        return match harn_modules::personas::parse_persona_source_file(&manifest_path) {
+            Ok(document) if !document.personas.is_empty() => {
+                validate_and_resolve_standalone_personas(
+                    document.personas,
+                    manifest_path,
+                    manifest_dir,
+                )
+            }
+            Ok(_) => Err(vec![PersonaValidationError {
+                manifest_path: manifest_path.clone(),
+                field_path: "persona".to_string(),
+                message: "no @persona declarations found".to_string(),
+            }]),
+            Err(message) => Err(vec![PersonaValidationError {
+                manifest_path: manifest_path.clone(),
+                field_path: "persona".to_string(),
+                message,
+            }]),
+        };
+    }
     let manifest = match read_manifest_from_path(&manifest_path) {
         Ok(manifest) => manifest,
         Err(message) => {
@@ -955,11 +976,41 @@ pub(crate) fn validate_and_resolve_personas(
     ) {
         Err(errors)
     } else {
+        let mut personas = manifest.personas;
+        attach_entry_workflow_steps(&mut personas, &manifest_dir);
         Ok(ResolvedPersonaManifest {
             manifest_path,
             manifest_dir,
-            personas: manifest.personas,
+            personas,
         })
+    }
+}
+
+fn attach_entry_workflow_steps(personas: &mut [PersonaManifestEntry], manifest_dir: &Path) {
+    for persona in personas {
+        if !persona.steps.is_empty() {
+            continue;
+        }
+        let Some(entry_workflow) = persona.entry_workflow.as_deref() else {
+            continue;
+        };
+        let Some((path, entry_name)) = entry_workflow.split_once('#') else {
+            continue;
+        };
+        if !path.ends_with(".harn") {
+            continue;
+        }
+        let source_path = manifest_dir.join(path);
+        let Ok(document) = harn_modules::personas::parse_persona_source_file(&source_path) else {
+            continue;
+        };
+        let entry_name = entry_name.trim();
+        if let Some(source_persona) = document.personas.iter().find(|candidate| {
+            candidate.entry_workflow.as_deref() == Some(entry_name)
+                || candidate.name.as_deref() == persona.name.as_deref()
+        }) {
+            persona.steps.clone_from(&source_persona.steps);
+        }
     }
 }
 

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -12,6 +12,14 @@ fn write_manifest(body: &str) -> TempDir {
     temp
 }
 
+fn write_persona_source(body: &str) -> (TempDir, std::path::PathBuf) {
+    let temp = TempDir::new().unwrap();
+    fs::create_dir_all(temp.path().join(".git")).unwrap();
+    let path = temp.path().join("persona.harn");
+    fs::write(&path, body).unwrap();
+    (temp, path)
+}
+
 fn valid_manifest() -> &'static str {
     r#"
 [[personas]]
@@ -200,6 +208,86 @@ fn persona_manifest_flag_loads_example_personas() {
 }
 
 #[ignore = "subprocess CLI test pending in-process conversion (issue #1106 follow-up to #1067)"]
+#[test]
+fn persona_inspect_reports_source_declared_steps() {
+    let (_temp, path) = write_persona_source(
+        r#"
+@persona(name: "merge_captain")
+fn merge_captain(ctx) {
+  plan_step(ctx)
+  verify_step(ctx)
+}
+
+@step(name: "plan", model: "gpt-5.4-mini", approval: optional, receipt: audit, error_boundary: fail, retry: {max_attempts: 2})
+fn plan_step(ctx) {
+  return ctx
+}
+
+@step(name: "verify", approval: required, receipt: none, error_boundary: escalate)
+fn verify_step(ctx) {
+  return ctx
+}
+"#,
+    );
+    let output = harn_command()
+        .args([
+            "persona",
+            "--manifest",
+            path.to_string_lossy().as_ref(),
+            "inspect",
+            "merge_captain",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let persona: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(persona["steps"].as_array().unwrap().len(), 2);
+    assert_eq!(persona["steps"][0]["name"], "plan");
+    assert_eq!(persona["steps"][0]["model"], "gpt-5.4-mini");
+    assert_eq!(persona["steps"][0]["retry"]["max_attempts"], 2);
+    assert_eq!(persona["steps"][1]["error_boundary"], "escalate");
+}
+
+#[test]
+fn lint_fails_strict_when_persona_body_calls_non_step_helper() {
+    let (temp, path) = write_persona_source(
+        r#"
+@persona(name: "merge_captain")
+fn merge_captain(ctx) {
+  helper(ctx)
+}
+
+fn helper(ctx) {
+  return ctx
+}
+"#,
+    );
+    fs::write(temp.path().join("harn.toml"), "[check]\nstrict = true\n").unwrap();
+    let output = harn_command()
+        .current_dir(temp.path())
+        .args(["lint", path.to_string_lossy().as_ref()])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "expected strict lint failure, stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(combined.contains("persona-body-must-call-steps"));
+}
+
 #[test]
 fn persona_manifest_flag_loads_fixer_persona() {
     let output = harn_e2e_command()

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -229,7 +229,7 @@ fn verify_step(ctx) {
 }
 "#,
     );
-    let output = harn_command()
+    let output = harn_e2e_command()
         .args([
             "persona",
             "--manifest",
@@ -269,7 +269,7 @@ fn helper(ctx) {
 "#,
     );
     fs::write(temp.path().join("harn.toml"), "[check]\nstrict = true\n").unwrap();
-    let output = harn_command()
+    let output = harn_e2e_command()
         .current_dir(temp.path())
         .args(["lint", path.to_string_lossy().as_ref()])
         .output()

--- a/crates/harn-dap/Cargo.toml
+++ b/crates/harn-dap/Cargo.toml
@@ -12,6 +12,8 @@ name = "harn-dap"
 path = "src/main.rs"
 
 [dependencies]
+harn-modules = { path = "../harn-modules", version = "0.7" }
+harn-parser = { path = "../harn-parser", version = "0.7" }
 harn-vm = { path = "../harn-vm", version = "0.7" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/harn-dap/src/debugger/breakpoints.rs
+++ b/crates/harn-dap/src/debugger/breakpoints.rs
@@ -142,13 +142,9 @@ impl Debugger {
         }
         // Mirror onto the VM so Vm::push_closure_frame latches the hit
         // on entry to any matching function.
+        let names = self.effective_function_breakpoint_names();
         if let Some(vm) = &mut self.vm {
-            vm.set_function_breakpoints(
-                self.function_breakpoints
-                    .iter()
-                    .map(|fb| fb.name.clone())
-                    .collect(),
-            );
+            vm.set_function_breakpoints(names);
         }
         // Hit counts from the prior set belong to now-stale ids; drop
         // them so a fresh edit starts counting over.
@@ -257,6 +253,27 @@ impl Debugger {
                 }
             }
         }
+    }
+
+    pub(crate) fn refresh_vm_function_breakpoints(&mut self) {
+        let names = self.effective_function_breakpoint_names();
+        if let Some(vm) = &mut self.vm {
+            vm.set_function_breakpoints(names);
+        }
+    }
+
+    fn effective_function_breakpoint_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .function_breakpoints
+            .iter()
+            .map(|fb| fb.name.clone())
+            .collect();
+        for name in &self.pending_step_boundary_functions {
+            if !names.iter().any(|existing| existing == name) {
+                names.push(name.clone());
+            }
+        }
+        names
     }
 
     /// Transition idle -> running. Snapshots breakpoint conditions and

--- a/crates/harn-dap/src/debugger/mod.rs
+++ b/crates/harn-dap/src/debugger/mod.rs
@@ -57,6 +57,7 @@ impl Debugger {
             "configurationDone" => self.handle_configuration_done(&msg),
             "continue" => self.handle_continue(&msg),
             "next" => self.handle_next(&msg),
+            "harnStepOverStep" | "harn/stepOverStep" => self.handle_step_over_step(&msg, command),
             "stepIn" => self.handle_step_in(&msg),
             "stepOut" => self.handle_step_out(&msg),
             "pause" => self.handle_pause(&msg),

--- a/crates/harn-dap/src/debugger/state.rs
+++ b/crates/harn-dap/src/debugger/state.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -106,6 +106,10 @@ pub struct Debugger {
     /// the full list here; it's mirrored onto the VM on each launch /
     /// edit so `Vm::function_breakpoints` stays in lockstep.
     pub(crate) function_breakpoints: Vec<crate::protocol::FunctionBreakpoint>,
+    /// Function names declared with `@step` in the launched source.
+    pub(crate) step_functions: BTreeSet<String>,
+    /// Temporary function names used by "step over to next @step".
+    pub(crate) pending_step_boundary_functions: BTreeSet<String>,
     /// Armed state for triggered breakpoints (#102). A BP with
     /// `triggered_by: [A, B]` stays disarmed until A or B fires at
     /// least once; then flips to armed for the rest of the run.
@@ -177,6 +181,8 @@ impl Debugger {
             bp_conditions: Vec::new(),
             bp_hit_counts: BTreeMap::new(),
             function_breakpoints: Vec::new(),
+            step_functions: BTreeSet::new(),
+            pending_step_boundary_functions: BTreeSet::new(),
             armed_breakpoints: BTreeMap::new(),
             pending_pause: false,
             active_progress_id: None,

--- a/crates/harn-dap/src/debugger/stepping.rs
+++ b/crates/harn-dap/src/debugger/stepping.rs
@@ -27,6 +27,16 @@ fn extract_exception_kind(msg: &str) -> Option<String> {
 impl Debugger {
     pub(crate) fn compile_program(&mut self, source: &str) -> Result<(), String> {
         let mut chunk = harn_vm::compile_source(source)?;
+        self.step_functions = harn_parser::parse_source(source)
+            .ok()
+            .map(|program| {
+                harn_modules::personas::extract_step_metadata_from_program(&program)
+                    .into_iter()
+                    .map(|step| step.function)
+                    .collect()
+            })
+            .unwrap_or_default();
+        self.pending_step_boundary_functions.clear();
         // Tag the main program's chunk with its source path so
         // `Vm::breakpoint_matches` can match DAP breakpoints keyed by the
         // absolute path the client sent (otherwise `current_source_file()`
@@ -161,12 +171,39 @@ impl Debugger {
     }
 
     pub(crate) fn handle_next(&mut self, msg: &DapMessage) -> Vec<DapResponse> {
+        if msg
+            .arguments
+            .as_ref()
+            .and_then(|args| args.get("granularity"))
+            .and_then(|value| value.as_str())
+            == Some("step")
+        {
+            return self.handle_step_over_step(msg, "next");
+        }
         self.step_mode = StepMode::StepOver;
         if let Some(vm) = &mut self.vm {
             vm.set_step_over();
         }
         let seq = self.next_seq();
         let response = DapResponse::success(seq, msg.seq, "next", None);
+        self.enter_running();
+        vec![response]
+    }
+
+    pub(crate) fn handle_step_over_step(
+        &mut self,
+        msg: &DapMessage,
+        command: &str,
+    ) -> Vec<DapResponse> {
+        if self.step_functions.is_empty() {
+            return vec![self.dap_error(msg, command, "no @step declarations in launched source")];
+        }
+        self.pending_step_boundary_functions = self.step_functions.clone();
+        self.refresh_vm_function_breakpoints();
+        self.step_mode = StepMode::Continue;
+        self.stopped = false;
+        let seq = self.next_seq();
+        let response = DapResponse::success(seq, msg.seq, command, None);
         self.enter_running();
         vec![response]
     }
@@ -362,6 +399,11 @@ impl Debugger {
                     .as_mut()
                     .and_then(|vm| vm.take_pending_function_bp());
                 if let Some(fn_name) = function_bp_name {
+                    let step_boundary_hit = self.pending_step_boundary_functions.contains(&fn_name);
+                    if step_boundary_hit {
+                        self.pending_step_boundary_functions.clear();
+                        self.refresh_vm_function_breakpoints();
+                    }
                     // Honor condition / hitCondition the same way
                     // classify_breakpoint_hit does for line BPs.
                     let fb_idx = self
@@ -369,30 +411,34 @@ impl Debugger {
                         .iter()
                         .position(|fb| fb.name == fn_name);
                     let mut should_stop = true;
-                    if let Some(idx) = fb_idx {
-                        let fb = self.function_breakpoints[idx].clone();
-                        let counter = self.bp_hit_counts.entry(fb.id).or_insert(0);
-                        *counter += 1;
-                        let hits = *counter;
-                        if let Some(ref hc) = fb.hit_condition {
-                            if super::breakpoints::hit_condition_matches(hc, hits) == Some(false) {
-                                should_stop = false;
+                    if !step_boundary_hit {
+                        if let Some(idx) = fb_idx {
+                            let fb = self.function_breakpoints[idx].clone();
+                            let counter = self.bp_hit_counts.entry(fb.id).or_insert(0);
+                            *counter += 1;
+                            let hits = *counter;
+                            if let Some(ref hc) = fb.hit_condition {
+                                if super::breakpoints::hit_condition_matches(hc, hits)
+                                    == Some(false)
+                                {
+                                    should_stop = false;
+                                }
                             }
-                        }
-                        if should_stop {
-                            if let Some(ref cond) = fb.condition {
-                                self.ensure_runtime();
-                                if let Some(vm) = self.vm.as_mut() {
-                                    let runtime = self.runtime.as_ref().unwrap();
-                                    let truthy = runtime
-                                        .block_on(async {
-                                            let local = tokio::task::LocalSet::new();
-                                            local.run_until(vm.evaluate_in_frame(cond, 0)).await
-                                        })
-                                        .map(|v| v.is_truthy())
-                                        .unwrap_or(true);
-                                    if !truthy {
-                                        should_stop = false;
+                            if should_stop {
+                                if let Some(ref cond) = fb.condition {
+                                    self.ensure_runtime();
+                                    if let Some(vm) = self.vm.as_mut() {
+                                        let runtime = self.runtime.as_ref().unwrap();
+                                        let truthy = runtime
+                                            .block_on(async {
+                                                let local = tokio::task::LocalSet::new();
+                                                local.run_until(vm.evaluate_in_frame(cond, 0)).await
+                                            })
+                                            .map(|v| v.is_truthy())
+                                            .unwrap_or(true);
+                                        if !truthy {
+                                            should_stop = false;
+                                        }
                                     }
                                 }
                             }
@@ -410,12 +456,22 @@ impl Debugger {
                     self.flush_output_into(&mut responses);
                     self.end_progress(&mut responses);
                     let seq = self.next_seq();
+                    let reason = if step_boundary_hit {
+                        "step"
+                    } else {
+                        "function breakpoint"
+                    };
+                    let description = if step_boundary_hit {
+                        format!("@step {fn_name}")
+                    } else {
+                        fn_name
+                    };
                     responses.push(DapResponse::event(
                         seq,
                         "stopped",
                         Some(json!({
-                            "reason": "function breakpoint",
-                            "description": fn_name,
+                            "reason": reason,
+                            "description": description,
                             "threadId": self.current_thread_id as i64,
                             "allThreadsStopped": true,
                         })),

--- a/crates/harn-dap/src/debugger/tests.rs
+++ b/crates/harn-dap/src/debugger/tests.rs
@@ -864,6 +864,62 @@ fn test_function_breakpoint_fires_on_matching_call() {
 }
 
 #[test]
+fn test_step_over_step_stops_on_next_step_boundary() {
+    let mut dbg = Debugger::new();
+
+    let (_dir, file) = write_temp_program(
+        "step_boundary.harn",
+        r#"
+@persona(name: "merge_captain")
+fn merge_captain(ctx) {
+  first_step(ctx)
+  second_step(ctx)
+}
+
+@step(name: "first")
+fn first_step(ctx) {
+  log(ctx)
+}
+
+@step(name: "second")
+fn second_step(ctx) {
+  log(ctx)
+}
+
+pipeline test(task) {
+  merge_captain("issue")
+}
+"#,
+    );
+
+    dbg.handle_message(make_request(1, "initialize", None));
+    dbg.handle_message(make_request(
+        2,
+        "launch",
+        Some(json!({"program": file.to_string_lossy()})),
+    ));
+    let mut responses = dbg.handle_message(make_request(3, "harnStepOverStep", None));
+    while dbg.is_running() && responses.len() < 50 {
+        responses.extend(dbg.step_running_vm());
+    }
+
+    let stopped_on_step = responses.iter().any(|r| {
+        r.event.as_deref() == Some("stopped")
+            && r.body.as_ref().is_some_and(|body| {
+                body["reason"] == "step"
+                    && body["description"]
+                        .as_str()
+                        .is_some_and(|description| description.contains("@step first_step"))
+            })
+    });
+    assert!(
+        stopped_on_step,
+        "harnStepOverStep must stop at the next @step function"
+    );
+    drop(dbg);
+}
+
+#[test]
 fn test_set_breakpoints_accepts_hit_condition_and_log_message() {
     let mut dbg = Debugger::new();
     let responses = dbg.handle_message(make_request(

--- a/crates/harn-lint/src/diagnostic.rs
+++ b/crates/harn-lint/src/diagnostic.rs
@@ -44,4 +44,7 @@ pub struct LintOptions<'a> {
     /// Override the cyclomatic-complexity threshold. `None` uses
     /// [`DEFAULT_COMPLEXITY_THRESHOLD`].
     pub complexity_threshold: Option<usize>,
+    /// Extra non-stdlib function names that persona bodies may call
+    /// without requiring a `@step` declaration.
+    pub persona_step_allowlist: &'a [String],
 }

--- a/crates/harn-lint/src/lib.rs
+++ b/crates/harn-lint/src/lib.rs
@@ -139,6 +139,9 @@ fn lint_full(
     if let Some(threshold) = options.complexity_threshold {
         linter.complexity_threshold = threshold;
     }
+    linter
+        .persona_step_allowlist
+        .extend(options.persona_step_allowlist.iter().cloned());
     linter.lint_program(program);
     if let Some(src) = source {
         if options.require_file_header {

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -34,8 +34,16 @@ pub(crate) struct Linter<'a> {
     pub(super) loop_depth: usize,
     /// Track all declared/known function names for undefined-function detection.
     pub(super) known_functions: HashSet<String>,
+    /// Builtin function names derived from the live VM stdlib.
+    pub(super) builtin_functions: HashSet<String>,
     /// Track function call sites for undefined-function checking.
     pub(super) function_calls: Vec<(String, Span)>,
+    /// Function names declared with `@step`.
+    pub(super) step_functions: HashSet<String>,
+    /// Function calls made from `@persona` bodies.
+    pub(super) persona_body_calls: Vec<(String, Span, String)>,
+    /// Opt-in function names allowed directly inside `@persona` bodies.
+    pub(super) persona_step_allowlist: HashSet<String>,
     /// Whether the file has wildcard imports (import "module").
     /// If true, skip undefined-function checks since we can't know what was imported.
     pub(super) has_wildcard_import: bool,
@@ -98,7 +106,11 @@ impl<'a> Linter<'a> {
             imports: Vec::new(),
             loop_depth: 0,
             known_functions: Self::builtin_names(),
+            builtin_functions: Self::builtin_names(),
             function_calls: Vec::new(),
+            step_functions: HashSet::new(),
+            persona_body_calls: Vec::new(),
+            persona_step_allowlist: HashSet::new(),
             has_wildcard_import: false,
             use_module_graph_for_wildcards: false,
             module_graph_wildcard_exports: None,
@@ -1037,6 +1049,7 @@ impl<'a> Linter<'a> {
     }
 
     pub(crate) fn lint_program(&mut self, nodes: &[SNode]) {
+        self.collect_persona_step_metadata(nodes);
         if let Some(src) = self.source {
             check_legacy_doc_comments(src, nodes, &mut self.diagnostics);
             check_blank_line_between_items(src, nodes, &mut self.diagnostics);
@@ -1045,6 +1058,220 @@ impl<'a> Linter<'a> {
         }
         for node in nodes {
             self.lint_node(node);
+        }
+    }
+
+    fn collect_persona_step_metadata(&mut self, nodes: &[SNode]) {
+        for node in nodes {
+            let Node::AttributedDecl { attributes, inner } = &node.node else {
+                continue;
+            };
+            let is_step = attributes.iter().any(|attr| attr.name == "step");
+            let is_persona = attributes.iter().any(|attr| attr.name == "persona");
+            if is_step {
+                if let Node::FnDecl { name, .. } = &inner.node {
+                    self.step_functions.insert(name.clone());
+                }
+            }
+            if is_persona {
+                if let Node::FnDecl { name, body, .. } = &inner.node {
+                    self.collect_persona_calls(name, body);
+                }
+            }
+        }
+    }
+
+    fn collect_persona_calls(&mut self, persona_name: &str, body: &[SNode]) {
+        for node in body {
+            self.collect_persona_calls_node(persona_name, node);
+        }
+    }
+
+    fn collect_persona_calls_node(&mut self, persona_name: &str, node: &SNode) {
+        match &node.node {
+            Node::FunctionCall { name, args, .. } => {
+                self.persona_body_calls
+                    .push((name.clone(), node.span, persona_name.to_string()));
+                for arg in args {
+                    self.collect_persona_calls_node(persona_name, arg);
+                }
+            }
+            Node::LetBinding { value, .. }
+            | Node::VarBinding { value, .. }
+            | Node::ReturnStmt { value: Some(value) }
+            | Node::YieldExpr { value: Some(value) }
+            | Node::EmitExpr { value }
+            | Node::ThrowStmt { value }
+            | Node::Spread(value)
+            | Node::TryOperator { operand: value }
+            | Node::TryStar { operand: value }
+            | Node::UnaryOp { operand: value, .. } => {
+                self.collect_persona_calls_node(persona_name, value);
+            }
+            Node::IfElse {
+                condition,
+                then_body,
+                else_body,
+            } => {
+                self.collect_persona_calls_node(persona_name, condition);
+                self.collect_persona_calls(persona_name, then_body);
+                if let Some(else_body) = else_body {
+                    self.collect_persona_calls(persona_name, else_body);
+                }
+            }
+            Node::ForIn { iterable, body, .. } => {
+                self.collect_persona_calls_node(persona_name, iterable);
+                self.collect_persona_calls(persona_name, body);
+            }
+            Node::WhileLoop { condition, body } => {
+                self.collect_persona_calls_node(persona_name, condition);
+                self.collect_persona_calls(persona_name, body);
+            }
+            Node::Retry { count, body } => {
+                self.collect_persona_calls_node(persona_name, count);
+                self.collect_persona_calls(persona_name, body);
+            }
+            Node::CostRoute { options, body } => {
+                for (_, value) in options {
+                    self.collect_persona_calls_node(persona_name, value);
+                }
+                self.collect_persona_calls(persona_name, body);
+            }
+            Node::TryCatch {
+                body,
+                catch_body,
+                finally_body,
+                ..
+            } => {
+                self.collect_persona_calls(persona_name, body);
+                self.collect_persona_calls(persona_name, catch_body);
+                if let Some(finally_body) = finally_body {
+                    self.collect_persona_calls(persona_name, finally_body);
+                }
+            }
+            Node::TryExpr { body }
+            | Node::SpawnExpr { body }
+            | Node::DeferStmt { body }
+            | Node::MutexBlock { body }
+            | Node::Block(body)
+            | Node::Closure { body, .. } => self.collect_persona_calls(persona_name, body),
+            Node::DeadlineBlock { duration, body } => {
+                self.collect_persona_calls_node(persona_name, duration);
+                self.collect_persona_calls(persona_name, body);
+            }
+            Node::GuardStmt {
+                condition,
+                else_body,
+            } => {
+                self.collect_persona_calls_node(persona_name, condition);
+                self.collect_persona_calls(persona_name, else_body);
+            }
+            Node::RequireStmt { condition, message } => {
+                self.collect_persona_calls_node(persona_name, condition);
+                if let Some(message) = message {
+                    self.collect_persona_calls_node(persona_name, message);
+                }
+            }
+            Node::Parallel {
+                expr,
+                body,
+                options,
+                ..
+            } => {
+                self.collect_persona_calls_node(persona_name, expr);
+                for (_, value) in options {
+                    self.collect_persona_calls_node(persona_name, value);
+                }
+                self.collect_persona_calls(persona_name, body);
+            }
+            Node::SelectExpr {
+                cases,
+                timeout,
+                default_body,
+            } => {
+                for case in cases {
+                    self.collect_persona_calls_node(persona_name, &case.channel);
+                    self.collect_persona_calls(persona_name, &case.body);
+                }
+                if let Some((duration, body)) = timeout {
+                    self.collect_persona_calls_node(persona_name, duration);
+                    self.collect_persona_calls(persona_name, body);
+                }
+                if let Some(body) = default_body {
+                    self.collect_persona_calls(persona_name, body);
+                }
+            }
+            Node::MatchExpr { value, arms } => {
+                self.collect_persona_calls_node(persona_name, value);
+                for arm in arms {
+                    self.collect_persona_calls_node(persona_name, &arm.pattern);
+                    if let Some(guard) = &arm.guard {
+                        self.collect_persona_calls_node(persona_name, guard);
+                    }
+                    self.collect_persona_calls(persona_name, &arm.body);
+                }
+            }
+            Node::MethodCall { object, args, .. }
+            | Node::OptionalMethodCall { object, args, .. } => {
+                self.collect_persona_calls_node(persona_name, object);
+                for arg in args {
+                    self.collect_persona_calls_node(persona_name, arg);
+                }
+            }
+            Node::PropertyAccess { object, .. } | Node::OptionalPropertyAccess { object, .. } => {
+                self.collect_persona_calls_node(persona_name, object);
+            }
+            Node::SubscriptAccess { object, index }
+            | Node::OptionalSubscriptAccess { object, index } => {
+                self.collect_persona_calls_node(persona_name, object);
+                self.collect_persona_calls_node(persona_name, index);
+            }
+            Node::SliceAccess { object, start, end } => {
+                self.collect_persona_calls_node(persona_name, object);
+                if let Some(start) = start {
+                    self.collect_persona_calls_node(persona_name, start);
+                }
+                if let Some(end) = end {
+                    self.collect_persona_calls_node(persona_name, end);
+                }
+            }
+            Node::BinaryOp { left, right, .. } => {
+                self.collect_persona_calls_node(persona_name, left);
+                self.collect_persona_calls_node(persona_name, right);
+            }
+            Node::Ternary {
+                condition,
+                true_expr,
+                false_expr,
+            } => {
+                self.collect_persona_calls_node(persona_name, condition);
+                self.collect_persona_calls_node(persona_name, true_expr);
+                self.collect_persona_calls_node(persona_name, false_expr);
+            }
+            Node::Assignment { target, value, .. } => {
+                self.collect_persona_calls_node(persona_name, target);
+                self.collect_persona_calls_node(persona_name, value);
+            }
+            Node::EnumConstruct { args, .. } | Node::ListLiteral(args) | Node::OrPattern(args) => {
+                for arg in args {
+                    self.collect_persona_calls_node(persona_name, arg);
+                }
+            }
+            Node::StructConstruct { fields, .. } | Node::DictLiteral(fields) => {
+                for entry in fields {
+                    self.collect_persona_calls_node(persona_name, &entry.key);
+                    self.collect_persona_calls_node(persona_name, &entry.value);
+                }
+            }
+            Node::HitlExpr { args, .. } => {
+                for arg in args {
+                    self.collect_persona_calls_node(persona_name, &arg.value);
+                }
+            }
+            Node::AttributedDecl { inner, .. } => {
+                self.collect_persona_calls_node(persona_name, inner)
+            }
+            _ => {}
         }
     }
 
@@ -1361,6 +1588,33 @@ impl<'a> Linter<'a> {
                     fix: None,
                 });
             }
+        }
+
+        for (name, span, persona_name) in &self.persona_body_calls {
+            if self.builtin_functions.contains(name) {
+                continue;
+            }
+            if self.step_functions.contains(name) {
+                continue;
+            }
+            if self.persona_step_allowlist.contains(name) {
+                continue;
+            }
+            if name.starts_with("__") || name.starts_with("hostlib_") {
+                continue;
+            }
+            self.diagnostics.push(LintDiagnostic {
+                rule: "persona-body-must-call-steps",
+                message: format!(
+                    "`@persona` function `{persona_name}` calls `{name}`, which is not declared `@step`"
+                ),
+                span: *span,
+                severity: LintSeverity::Warning,
+                suggestion: Some(format!(
+                    "add `@step(name: \"{name}\", ...)` to `{name}` or list it in `[lint].persona_step_allowlist`"
+                )),
+                fix: None,
+            });
         }
 
         // Variables and parameters may hold closures, so treat them as

--- a/crates/harn-lint/src/tests/complexity.rs
+++ b/crates/harn-lint/src/tests/complexity.rs
@@ -110,6 +110,7 @@ pipeline default(task) {
         file_path: None,
         require_file_header: false,
         complexity_threshold: Some(5),
+        persona_step_allowlist: &[],
     };
     let diags = lint_with_options(&program, &[], Some(source), &externally_imported, &options);
     let complexity_warnings: Vec<_> = diags
@@ -175,6 +176,7 @@ pipeline default(task) {
         file_path: None,
         require_file_header: false,
         complexity_threshold: Some(100),
+        persona_step_allowlist: &[],
     };
     let diags = lint_with_options(&program, &[], Some(source), &externally_imported, &options);
     assert!(

--- a/crates/harn-lint/src/tests/mod.rs
+++ b/crates/harn-lint/src/tests/mod.rs
@@ -66,6 +66,7 @@ pub(super) fn lint_with_require_header(
         file_path: path,
         require_file_header: true,
         complexity_threshold: None,
+        persona_step_allowlist: &[],
     };
     lint_with_options(&program, &[], Some(source), &HashSet::new(), &options)
 }
@@ -88,6 +89,7 @@ mod llm_rules;
 mod long_running;
 mod mutability;
 mod naming_types;
+mod persona_steps;
 mod redundant_nil_ternary;
 mod secret_scan_rules;
 mod shadowing;

--- a/crates/harn-lint/src/tests/persona_steps.rs
+++ b/crates/harn-lint/src/tests/persona_steps.rs
@@ -1,0 +1,57 @@
+use super::*;
+
+#[test]
+fn persona_body_must_call_step_functions() {
+    let source = r#"
+@persona(name: "merge_captain")
+fn merge_captain(ctx) {
+  plan(ctx)
+  helper(ctx)
+  println("done")
+}
+
+@step(name: "plan")
+fn plan(ctx) {
+  return ctx
+}
+
+fn helper(ctx) {
+  return ctx
+}
+"#;
+
+    let diagnostics = lint_source(source);
+    let persona_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|diag| diag.rule == "persona-body-must-call-steps")
+        .collect();
+    assert_eq!(persona_diags.len(), 1);
+    assert!(persona_diags[0].message.contains("helper"));
+}
+
+#[test]
+fn persona_body_allowlist_suppresses_step_requirement() {
+    let source = r#"
+@persona(name: "merge_captain")
+fn merge_captain(ctx) {
+  helper(ctx)
+}
+
+fn helper(ctx) {
+  return ctx
+}
+"#;
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let program = parser.parse().unwrap();
+    let allow = vec!["helper".to_string()];
+    let options = LintOptions {
+        file_path: None,
+        require_file_header: false,
+        complexity_threshold: None,
+        persona_step_allowlist: &allow,
+    };
+    let diagnostics = lint_with_options(&program, &[], Some(source), &HashSet::new(), &options);
+    assert!(!has_rule(&diagnostics, "persona-body-must-call-steps"));
+}

--- a/crates/harn-lsp/src/handlers/symbols.rs
+++ b/crates/harn-lsp/src/handlers/symbols.rs
@@ -1,6 +1,9 @@
 //! Document symbols, workspace symbol search, and semantic tokens.
 
+use std::collections::{BTreeMap, BTreeSet};
+
 use harn_lexer::Lexer;
+use harn_parser::Node;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 
@@ -25,8 +28,23 @@ impl HarnLsp {
         let symbols = state.symbols.clone();
         drop(docs);
 
+        let step_symbols: Vec<_> = symbols
+            .iter()
+            .filter(|sym| {
+                sym.scope_span.is_none()
+                    && sym.kind == HarnSymbolKind::Function
+                    && sym.attributes.iter().any(|attr| attr.name == "step")
+            })
+            .collect();
+        let persona_steps = persona_step_map(&source);
         let mut doc_symbols = Vec::new();
         for sym in &symbols {
+            let is_step = sym.scope_span.is_none()
+                && sym.kind == HarnSymbolKind::Function
+                && sym.attributes.iter().any(|attr| attr.name == "step");
+            if is_step {
+                continue;
+            }
             let kind = match sym.kind {
                 HarnSymbolKind::Pipeline => SymbolKind::FUNCTION,
                 HarnSymbolKind::Function => SymbolKind::FUNCTION,
@@ -55,6 +73,38 @@ impl HarnLsp {
                 HarnSymbolKind::Interface => "interface",
                 HarnSymbolKind::Parameter => "parameter",
             };
+            let children = if sym.scope_span.is_none()
+                && sym.kind == HarnSymbolKind::Function
+                && sym.attributes.iter().any(|attr| attr.name == "persona")
+            {
+                let persona_name = persona_outline_name(sym);
+                let called_steps = persona_steps.get(&persona_name);
+                Some(
+                    step_symbols
+                        .iter()
+                        .filter(|step| {
+                            called_steps
+                                .map(|called| called.contains(step.name.as_str()))
+                                .unwrap_or(true)
+                        })
+                        .map(|step| {
+                            let range = span_to_full_range(&step.def_span, &source);
+                            DocumentSymbol {
+                                name: step_outline_name(step),
+                                detail: Some(format!("step: {}", step.name)),
+                                kind: SymbolKind::FUNCTION,
+                                range,
+                                selection_range: range,
+                                tags: None,
+                                deprecated: None,
+                                children: None,
+                            }
+                        })
+                        .collect(),
+                )
+            } else {
+                None
+            };
             doc_symbols.push(DocumentSymbol {
                 name: sym.name.clone(),
                 detail: Some(detail.to_string()),
@@ -63,7 +113,7 @@ impl HarnLsp {
                 selection_range: range,
                 tags: None,
                 deprecated: None,
-                children: None,
+                children,
             });
         }
 
@@ -142,5 +192,54 @@ impl HarnLsp {
             result_id: None,
             data: semantic_tokens,
         })))
+    }
+}
+
+fn persona_step_map(source: &str) -> BTreeMap<String, BTreeSet<String>> {
+    let Ok(document) = harn_modules::personas::parse_persona_source_str(source) else {
+        return BTreeMap::new();
+    };
+    document
+        .personas
+        .into_iter()
+        .filter_map(|persona| {
+            let name = persona.name?;
+            let steps = persona
+                .steps
+                .into_iter()
+                .map(|step| step.function)
+                .collect::<BTreeSet<_>>();
+            Some((name, steps))
+        })
+        .collect()
+}
+
+fn persona_outline_name(sym: &crate::symbols::SymbolInfo) -> String {
+    let Some(attr) = sym.attributes.iter().find(|attr| attr.name == "persona") else {
+        return sym.name.clone();
+    };
+    let Some(value) = attr.named_arg("name") else {
+        return sym.name.clone();
+    };
+    match &value.node {
+        Node::StringLiteral(name) | Node::RawStringLiteral(name) | Node::Identifier(name) => {
+            name.clone()
+        }
+        _ => sym.name.clone(),
+    }
+}
+
+fn step_outline_name(sym: &crate::symbols::SymbolInfo) -> String {
+    let Some(attr) = sym.attributes.iter().find(|attr| attr.name == "step") else {
+        return sym.name.clone();
+    };
+    let Some(value) = attr.named_arg("name") else {
+        return sym.name.clone();
+    };
+    match &value.node {
+        Node::StringLiteral(name) | Node::RawStringLiteral(name) | Node::Identifier(name) => {
+            name.clone()
+        }
+        _ => sym.name.clone(),
     }
 }

--- a/crates/harn-modules/src/personas.rs
+++ b/crates/harn-modules/src/personas.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use harn_parser::{Attribute, DictEntry, Node, SNode};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -49,8 +50,33 @@ pub struct PersonaManifestEntry {
     pub package_source: PersonaPackageSource,
     #[serde(default)]
     pub rollout_policy: PersonaRolloutPolicy,
+    #[serde(default)]
+    pub steps: Vec<PersonaStepMetadata>,
     #[serde(flatten, default)]
     pub extra: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaStepMetadata {
+    pub name: String,
+    pub function: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receipt: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_boundary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry: Option<PersonaStepRetry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaStepRetry {
+    pub max_attempts: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,6 +99,20 @@ impl PersonaAutonomyTier {
     }
 }
 
+impl FromStr for PersonaAutonomyTier {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "shadow" => Ok(Self::Shadow),
+            "suggest" => Ok(Self::Suggest),
+            "act_with_approval" => Ok(Self::ActWithApproval),
+            "act_auto" => Ok(Self::ActAuto),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PersonaReceiptPolicy {
@@ -88,6 +128,20 @@ impl PersonaReceiptPolicy {
             Self::Optional => "optional",
             Self::Required => "required",
             Self::Disabled => "disabled",
+        }
+    }
+}
+
+impl FromStr for PersonaReceiptPolicy {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "optional" => Ok(Self::Optional),
+            "required" => Ok(Self::Required),
+            "disabled" => Ok(Self::Disabled),
+            "none" => Ok(Self::Disabled),
+            _ => Err(()),
         }
     }
 }
@@ -212,6 +266,359 @@ pub fn parse_persona_manifest_file(path: &Path) -> Result<PersonaManifestDocumen
         .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
     parse_persona_manifest_str(&content)
         .map_err(|error| format!("failed to parse {}: {error}", path.display()))
+}
+
+pub fn parse_persona_source_file(path: &Path) -> Result<PersonaManifestDocument, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    parse_persona_source_str(&content)
+        .map_err(|error| format!("failed to parse {}: {error}", path.display()))
+}
+
+pub fn parse_persona_source_str(source: &str) -> Result<PersonaManifestDocument, String> {
+    let program = harn_parser::parse_source(source).map_err(|error| error.to_string())?;
+    Ok(extract_personas_from_program(&program))
+}
+
+pub fn extract_personas_from_program(program: &[SNode]) -> PersonaManifestDocument {
+    let step_decls = collect_step_declarations(program);
+    let mut personas = Vec::new();
+    for snode in program {
+        let Node::AttributedDecl { attributes, inner } = &snode.node else {
+            continue;
+        };
+        let Some(persona_attr) = attributes.iter().find(|attr| attr.name == "persona") else {
+            continue;
+        };
+        let Node::FnDecl { name, body, .. } = &inner.node else {
+            continue;
+        };
+        let persona_name = attr_string(persona_attr, "name").unwrap_or_else(|| name.clone());
+        let mut seen = BTreeSet::new();
+        let mut steps = Vec::new();
+        for call_name in collect_called_functions(body) {
+            if !seen.insert(call_name.clone()) {
+                continue;
+            }
+            if let Some(step) = step_decls.get(&call_name) {
+                steps.push(step.clone());
+            }
+        }
+        personas.push(PersonaManifestEntry {
+            name: Some(persona_name),
+            description: Some(
+                attr_string(persona_attr, "description")
+                    .unwrap_or_else(|| "Source-declared persona".to_string()),
+            ),
+            entry_workflow: Some(name.clone()),
+            tools: attr_string_list(persona_attr, "tools"),
+            capabilities: {
+                let capabilities = attr_string_list(persona_attr, "capabilities");
+                if capabilities.is_empty() {
+                    vec!["project.test_commands".to_string()]
+                } else {
+                    capabilities
+                }
+            },
+            autonomy_tier: attr_string(persona_attr, "autonomy")
+                .as_deref()
+                .and_then(|value| PersonaAutonomyTier::from_str(value).ok())
+                .or(Some(PersonaAutonomyTier::Suggest)),
+            receipt_policy: attr_string(persona_attr, "receipts")
+                .as_deref()
+                .and_then(|value| PersonaReceiptPolicy::from_str(value).ok())
+                .or(Some(PersonaReceiptPolicy::Optional)),
+            steps,
+            ..PersonaManifestEntry::default()
+        });
+    }
+    PersonaManifestDocument { personas }
+}
+
+pub fn extract_step_metadata_from_program(program: &[SNode]) -> Vec<PersonaStepMetadata> {
+    collect_step_declarations(program).into_values().collect()
+}
+
+fn collect_step_declarations(program: &[SNode]) -> BTreeMap<String, PersonaStepMetadata> {
+    let mut steps = BTreeMap::new();
+    for snode in program {
+        let Node::AttributedDecl { attributes, inner } = &snode.node else {
+            continue;
+        };
+        let Some(step_attr) = attributes.iter().find(|attr| attr.name == "step") else {
+            continue;
+        };
+        let Node::FnDecl { name, .. } = &inner.node else {
+            continue;
+        };
+        steps.insert(
+            name.clone(),
+            PersonaStepMetadata {
+                name: attr_string(step_attr, "name").unwrap_or_else(|| name.clone()),
+                function: name.clone(),
+                model: attr_string(step_attr, "model"),
+                approval: attr_string(step_attr, "approval"),
+                receipt: attr_string(step_attr, "receipt"),
+                error_boundary: attr_string(step_attr, "error_boundary"),
+                retry: attr_retry(step_attr),
+                line: Some(inner.span.line),
+            },
+        );
+    }
+    steps
+}
+
+fn attr_string(attr: &Attribute, key: &str) -> Option<String> {
+    attr.named_arg(key).and_then(node_string)
+}
+
+fn attr_string_list(attr: &Attribute, key: &str) -> Vec<String> {
+    let Some(value) = attr.named_arg(key) else {
+        return Vec::new();
+    };
+    let Node::ListLiteral(items) = &value.node else {
+        return Vec::new();
+    };
+    items.iter().filter_map(node_string).collect()
+}
+
+fn node_string(node: &SNode) -> Option<String> {
+    match &node.node {
+        Node::StringLiteral(value) | Node::RawStringLiteral(value) | Node::Identifier(value) => {
+            Some(value.clone())
+        }
+        _ => None,
+    }
+}
+
+fn attr_retry(attr: &Attribute) -> Option<PersonaStepRetry> {
+    let retry = attr.named_arg("retry")?;
+    let Node::DictLiteral(entries) = &retry.node else {
+        return None;
+    };
+    for entry in entries {
+        if entry_key(&entry.key) == Some("max_attempts") {
+            if let Node::IntLiteral(value) = entry.value.node {
+                if value >= 1 {
+                    return Some(PersonaStepRetry {
+                        max_attempts: value as u64,
+                    });
+                }
+            }
+        }
+    }
+    None
+}
+
+fn entry_key(node: &SNode) -> Option<&str> {
+    match &node.node {
+        Node::Identifier(value) | Node::StringLiteral(value) | Node::RawStringLiteral(value) => {
+            Some(value.as_str())
+        }
+        _ => None,
+    }
+}
+
+fn collect_called_functions(body: &[SNode]) -> Vec<String> {
+    let mut calls = Vec::new();
+    for node in body {
+        collect_called_functions_node(node, &mut calls);
+    }
+    calls
+}
+
+fn collect_called_functions_node(node: &SNode, calls: &mut Vec<String>) {
+    match &node.node {
+        Node::FunctionCall { name, args, .. } => {
+            calls.push(name.clone());
+            collect_many(args, calls);
+        }
+        Node::LetBinding { value, .. }
+        | Node::VarBinding { value, .. }
+        | Node::ReturnStmt { value: Some(value) }
+        | Node::YieldExpr { value: Some(value) }
+        | Node::EmitExpr { value }
+        | Node::ThrowStmt { value }
+        | Node::Spread(value)
+        | Node::TryOperator { operand: value }
+        | Node::TryStar { operand: value }
+        | Node::UnaryOp { operand: value, .. } => collect_called_functions_node(value, calls),
+        Node::IfElse {
+            condition,
+            then_body,
+            else_body,
+        } => {
+            collect_called_functions_node(condition, calls);
+            collect_many(then_body, calls);
+            if let Some(else_body) = else_body {
+                collect_many(else_body, calls);
+            }
+        }
+        Node::ForIn { iterable, body, .. } => {
+            collect_called_functions_node(iterable, calls);
+            collect_many(body, calls);
+        }
+        Node::MatchExpr { value, arms } => {
+            collect_called_functions_node(value, calls);
+            for arm in arms {
+                collect_called_functions_node(&arm.pattern, calls);
+                if let Some(guard) = &arm.guard {
+                    collect_called_functions_node(guard, calls);
+                }
+                collect_many(&arm.body, calls);
+            }
+        }
+        Node::WhileLoop { condition, body } => {
+            collect_called_functions_node(condition, calls);
+            collect_many(body, calls);
+        }
+        Node::Retry { count, body } => {
+            collect_called_functions_node(count, calls);
+            collect_many(body, calls);
+        }
+        Node::CostRoute { options, body } => {
+            for (_, value) in options {
+                collect_called_functions_node(value, calls);
+            }
+            collect_many(body, calls);
+        }
+        Node::TryCatch {
+            body,
+            catch_body,
+            finally_body,
+            ..
+        } => {
+            collect_many(body, calls);
+            collect_many(catch_body, calls);
+            if let Some(finally_body) = finally_body {
+                collect_many(finally_body, calls);
+            }
+        }
+        Node::TryExpr { body }
+        | Node::SpawnExpr { body }
+        | Node::DeferStmt { body }
+        | Node::MutexBlock { body }
+        | Node::Block(body)
+        | Node::Closure { body, .. } => collect_many(body, calls),
+        Node::DeadlineBlock { duration, body } => {
+            collect_called_functions_node(duration, calls);
+            collect_many(body, calls);
+        }
+        Node::GuardStmt {
+            condition,
+            else_body,
+        } => {
+            collect_called_functions_node(condition, calls);
+            collect_many(else_body, calls);
+        }
+        Node::RequireStmt { condition, message } => {
+            collect_called_functions_node(condition, calls);
+            if let Some(message) = message {
+                collect_called_functions_node(message, calls);
+            }
+        }
+        Node::Parallel {
+            expr,
+            body,
+            options,
+            ..
+        } => {
+            collect_called_functions_node(expr, calls);
+            for (_, value) in options {
+                collect_called_functions_node(value, calls);
+            }
+            collect_many(body, calls);
+        }
+        Node::SelectExpr {
+            cases,
+            timeout,
+            default_body,
+        } => {
+            for case in cases {
+                collect_called_functions_node(&case.channel, calls);
+                collect_many(&case.body, calls);
+            }
+            if let Some((duration, body)) = timeout {
+                collect_called_functions_node(duration, calls);
+                collect_many(body, calls);
+            }
+            if let Some(body) = default_body {
+                collect_many(body, calls);
+            }
+        }
+        Node::MethodCall { object, args, .. } | Node::OptionalMethodCall { object, args, .. } => {
+            collect_called_functions_node(object, calls);
+            collect_many(args, calls);
+        }
+        Node::PropertyAccess { object, .. } | Node::OptionalPropertyAccess { object, .. } => {
+            collect_called_functions_node(object, calls);
+        }
+        Node::SubscriptAccess { object, index }
+        | Node::OptionalSubscriptAccess { object, index } => {
+            collect_called_functions_node(object, calls);
+            collect_called_functions_node(index, calls);
+        }
+        Node::SliceAccess { object, start, end } => {
+            collect_called_functions_node(object, calls);
+            if let Some(start) = start {
+                collect_called_functions_node(start, calls);
+            }
+            if let Some(end) = end {
+                collect_called_functions_node(end, calls);
+            }
+        }
+        Node::BinaryOp { left, right, .. } => {
+            collect_called_functions_node(left, calls);
+            collect_called_functions_node(right, calls);
+        }
+        Node::Ternary {
+            condition,
+            true_expr,
+            false_expr,
+        } => {
+            collect_called_functions_node(condition, calls);
+            collect_called_functions_node(true_expr, calls);
+            collect_called_functions_node(false_expr, calls);
+        }
+        Node::Assignment { target, value, .. } => {
+            collect_called_functions_node(target, calls);
+            collect_called_functions_node(value, calls);
+        }
+        Node::EnumConstruct { args, .. } => collect_many(args, calls),
+        Node::StructConstruct { fields, .. } | Node::DictLiteral(fields) => {
+            collect_dict_calls(fields, calls);
+        }
+        Node::ListLiteral(items) | Node::OrPattern(items) => collect_many(items, calls),
+        Node::HitlExpr { args, .. } => {
+            for arg in args {
+                collect_called_functions_node(&arg.value, calls);
+            }
+        }
+        Node::AttributedDecl { inner, .. } => collect_called_functions_node(inner, calls),
+        Node::Pipeline { body, .. }
+        | Node::OverrideDecl { body, .. }
+        | Node::FnDecl { body, .. }
+        | Node::ToolDecl { body, .. } => collect_many(body, calls),
+        Node::SkillDecl { fields, .. } | Node::EvalPackDecl { fields, .. } => {
+            for (_, value) in fields {
+                collect_called_functions_node(value, calls);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_many(nodes: &[SNode], calls: &mut Vec<String>) {
+    for node in nodes {
+        collect_called_functions_node(node, calls);
+    }
+}
+
+fn collect_dict_calls(entries: &[DictEntry], calls: &mut Vec<String>) {
+    for entry in entries {
+        collect_called_functions_node(&entry.key, calls);
+        collect_called_functions_node(&entry.value, calls);
+    }
 }
 
 pub fn validate_persona_manifests(
@@ -697,5 +1104,37 @@ surprise = true
         assert!(fields.contains("[[personas]][0].budget.daily_usd"));
         assert!(fields.contains("[[personas]][0].budget.surprise"));
         assert!(fields.contains("[[personas]][0].surprise"));
+    }
+
+    #[test]
+    fn source_persona_extracts_called_steps_in_order() {
+        let parsed = parse_persona_source_str(
+            r#"
+@persona(name: "merge_captain")
+fn merge_captain(ctx) {
+  plan(ctx)
+  verify(ctx)
+}
+
+@step(name: "plan", model: "gpt-5.4-mini", retry: {max_attempts: 2})
+fn plan(ctx) {
+  return ctx
+}
+
+@step(name: "verify", error_boundary: continue)
+fn verify(ctx) {
+  return ctx
+}
+"#,
+        )
+        .expect("source persona parses");
+        assert_eq!(parsed.personas.len(), 1);
+        let persona = &parsed.personas[0];
+        assert_eq!(persona.name.as_deref(), Some("merge_captain"));
+        assert_eq!(persona.steps.len(), 2);
+        assert_eq!(persona.steps[0].name, "plan");
+        assert_eq!(persona.steps[0].model.as_deref(), Some("gpt-5.4-mini"));
+        assert_eq!(persona.steps[0].retry.as_ref().unwrap().max_attempts, 2);
+        assert_eq!(persona.steps[1].error_boundary.as_deref(), Some("continue"));
     }
 }

--- a/crates/harn-parser/src/parser/decls.rs
+++ b/crates/harn-parser/src/parser/decls.rs
@@ -32,6 +32,10 @@ fn sanitize_eval_pack_binding(id: &str) -> String {
     }
 }
 
+fn is_attribute_key_token(token: &TokenKind) -> bool {
+    matches!(token, TokenKind::Identifier(_) | TokenKind::Retry)
+}
+
 impl Parser {
     pub(super) fn parse_pipeline_with_pub(&mut self, is_pub: bool) -> Result<SNode, ParserError> {
         let start = self.current_span();
@@ -213,8 +217,8 @@ impl Parser {
         let start = self.current_span();
         // Detect `key: value` form by looking ahead.
         if let (Some(t1), Some(t2)) = (self.peek_kind_at(0), self.peek_kind_at(1)) {
-            if matches!(t1, TokenKind::Identifier(_)) && matches!(t2, TokenKind::Colon) {
-                let key = self.consume_identifier("argument name")?;
+            if is_attribute_key_token(t1) && matches!(t2, TokenKind::Colon) {
+                let key = self.consume_attribute_key("argument name")?;
                 self.consume(&TokenKind::Colon, ":")?;
                 let value = self.parse_attribute_value()?;
                 return Ok(AttributeArg {
@@ -250,6 +254,7 @@ impl Parser {
             TokenKind::True => Node::BoolLiteral(true),
             TokenKind::False => Node::BoolLiteral(false),
             TokenKind::Nil => Node::NilLiteral,
+            TokenKind::Continue => Node::Identifier("continue".to_string()),
             TokenKind::Identifier(name) => {
                 let mut name = name.clone();
                 self.advance();
@@ -319,6 +324,10 @@ impl Parser {
                             self.advance();
                             spanned(Node::Identifier(name), key_span)
                         }
+                        Some(TokenKind::Retry) => {
+                            self.advance();
+                            spanned(Node::Identifier("retry".to_string()), key_span)
+                        }
                         Some(TokenKind::StringLiteral(name)) => {
                             self.advance();
                             spanned(Node::StringLiteral(name), key_span)
@@ -367,6 +376,20 @@ impl Parser {
         };
         self.advance();
         Ok(spanned(node, span))
+    }
+
+    fn consume_attribute_key(&mut self, expected: &str) -> Result<String, ParserError> {
+        match self.current_kind().cloned() {
+            Some(TokenKind::Identifier(name)) => {
+                self.advance();
+                Ok(name)
+            }
+            Some(TokenKind::Retry) => {
+                self.advance();
+                Ok("retry".to_string())
+            }
+            _ => Err(self.error(expected)),
+        }
     }
 
     pub(super) fn parse_fn_decl_with_pub(&mut self, is_pub: bool) -> Result<SNode, ParserError> {

--- a/crates/harn-parser/src/parser/mod.rs
+++ b/crates/harn-parser/src/parser/mod.rs
@@ -200,6 +200,28 @@ fn merge_captain(ctx) {
     }
 
     #[test]
+    fn parses_step_annotation_values() {
+        let source = r#"
+@step(name: "plan", model: "gpt-5.4-mini", approval: required, receipt: audit, error_boundary: escalate, retry: {max_attempts: 2})
+fn plan_step(ctx) {
+  return ctx
+}
+"#;
+
+        let program = parse_source(source).expect("should parse step annotations");
+        let Node::AttributedDecl { attributes, inner } = &program[0].node else {
+            panic!("expected attributed decl");
+        };
+        assert_eq!(attributes[0].name, "step");
+        assert!(matches!(inner.node, Node::FnDecl { .. }));
+        let retry = attributes[0].named_arg("retry").expect("retry arg");
+        let Node::DictLiteral(entries) = &retry.node else {
+            panic!("expected retry dict");
+        };
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
     fn parses_generic_structs_and_enums() {
         let source = r#"
 struct Pair<A, B> {

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -1539,7 +1539,7 @@ impl TypeChecker {
             match attr.name.as_str() {
                 "deprecated" | "test" | "complexity" | "acp_tool" | "acp_skill" | "invariant"
                 | "deterministic" | "semantic" | "archivist" | "retroactive" | "persona"
-                | "trigger" | "handoff" | "budget" | "command" => {}
+                | "step" | "trigger" | "handoff" | "budget" | "command" => {}
                 other => {
                     self.warning_at(format!("unknown attribute `@{}`", other), attr.span);
                 }
@@ -1582,6 +1582,12 @@ impl TypeChecker {
             if attr.name == "command" && !matches!(inner.node, Node::Pipeline { .. }) {
                 self.warning_at(
                     "`@command` only applies to pipeline declarations".to_string(),
+                    attr.span,
+                );
+            }
+            if attr.name == "step" && !matches!(inner.node, Node::FnDecl { .. }) {
+                self.warning_at(
+                    "`@step` only applies to function declarations".to_string(),
                     attr.span,
                 );
             }
@@ -1674,6 +1680,7 @@ impl TypeChecker {
     pub(in crate::typechecker) fn validate_standard_attribute_args(&mut self, attr: &Attribute) {
         match attr.name.as_str() {
             "persona" => self.validate_persona_args(attr),
+            "step" => self.validate_step_args(attr),
             "trigger" => self.validate_trigger_args(attr),
             "handoff" => self.validate_handoff_args(attr),
             "budget" => self.validate_budget_args(attr),
@@ -1700,6 +1707,63 @@ impl TypeChecker {
                 continue;
             }
             self.expect_symbol_like("@command", name, &arg.value, arg.span);
+        }
+    }
+
+    fn validate_step_args(&mut self, attr: &Attribute) {
+        const KNOWN_KEYS: &[&str] = &[
+            "name",
+            "model",
+            "approval",
+            "receipt",
+            "error_boundary",
+            "retry",
+        ];
+        let mut has_name = false;
+        for arg in &attr.args {
+            let Some(name) = self.require_named_arg("@step", arg) else {
+                continue;
+            };
+            if !KNOWN_KEYS.contains(&name) {
+                self.warning_at(
+                    format!("unknown `@step` argument `{name}`; expected one of {KNOWN_KEYS:?}"),
+                    arg.span,
+                );
+                continue;
+            }
+            match name {
+                "name" => {
+                    has_name = true;
+                    self.expect_symbol_like("@step", name, &arg.value, arg.span);
+                }
+                "model" => self.expect_symbol_like("@step", name, &arg.value, arg.span),
+                "approval" => self.expect_one_of(
+                    "@step",
+                    name,
+                    &arg.value,
+                    arg.span,
+                    &["required", "optional"],
+                ),
+                "receipt" => {
+                    self.expect_one_of("@step", name, &arg.value, arg.span, &["audit", "none"])
+                }
+                "error_boundary" => self.expect_one_of(
+                    "@step",
+                    name,
+                    &arg.value,
+                    arg.span,
+                    &["fail", "continue", "escalate"],
+                ),
+                "retry" => self.expect_step_retry_dict(&arg.value, arg.span),
+                _ => {}
+            }
+        }
+        if !has_name {
+            self.warning_at(
+                "`@step(...)` should declare `name: \"...\"` for stable supervision metadata"
+                    .to_string(),
+                attr.span,
+            );
         }
     }
 
@@ -1867,6 +1931,29 @@ impl TypeChecker {
         }
     }
 
+    fn expect_one_of(
+        &mut self,
+        attr_name: &str,
+        key: &str,
+        value: &SNode,
+        span: Span,
+        allowed: &[&str],
+    ) {
+        let Some(value) = symbol_like_value(&value.node) else {
+            self.warning_at(
+                format!("`{attr_name}({key}: ...)` must be one of {allowed:?}"),
+                span,
+            );
+            return;
+        };
+        if !allowed.contains(&value) {
+            self.warning_at(
+                format!("`{attr_name}({key}: ...)` must be one of {allowed:?}"),
+                span,
+            );
+        }
+    }
+
     fn expect_list_of_symbols(&mut self, attr_name: &str, key: &str, value: &SNode, span: Span) {
         let Node::ListLiteral(items) = &value.node else {
             self.warning_at(
@@ -1926,6 +2013,44 @@ impl TypeChecker {
                 continue;
             };
             self.expect_budget_value(attr_name, field_name, &entry.value, entry.value.span);
+        }
+    }
+
+    fn expect_step_retry_dict(&mut self, value: &SNode, span: Span) {
+        let Node::DictLiteral(entries) = &value.node else {
+            self.warning_at(
+                "`@step(retry: ...)` must be a dict such as `{ max_attempts: 3 }`".to_string(),
+                span,
+            );
+            return;
+        };
+        for entry in entries {
+            let Some(field_name) = attr_key_name(&entry.key.node) else {
+                self.warning_at(
+                    "`@step(retry: ...)` field names must be strings or identifiers".to_string(),
+                    entry.key.span,
+                );
+                continue;
+            };
+            match field_name {
+                "max_attempts" => {
+                    if !matches!(entry.value.node, Node::IntLiteral(i) if i >= 1) {
+                        self.warning_at(
+                            "`@step(retry: { max_attempts: ... })` must be a positive integer"
+                                .to_string(),
+                            entry.value.span,
+                        );
+                    }
+                }
+                other => {
+                    self.warning_at(
+                        format!(
+                            "unknown `@step(retry: ...)` field `{other}`; expected `max_attempts`"
+                        ),
+                        entry.key.span,
+                    );
+                }
+            }
         }
     }
 
@@ -2039,6 +2164,15 @@ fn is_symbol_like(node: &Node) -> bool {
         node,
         Node::Identifier(_) | Node::StringLiteral(_) | Node::RawStringLiteral(_)
     )
+}
+
+fn symbol_like_value(node: &Node) -> Option<&str> {
+    match node {
+        Node::Identifier(value) | Node::StringLiteral(value) | Node::RawStringLiteral(value) => {
+            Some(value.as_str())
+        }
+        _ => None,
+    }
 }
 
 fn is_trigger_spec(node: &Node) -> bool {

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -2696,7 +2696,7 @@ runner discovers attributed pipelines in addition to the legacy
 #### Durable persona annotations
 
 Durable persona metadata can be declared directly on a function, tool, or
-pipeline with `@persona`, `@trigger`, `@handoff`, and `@budget`:
+pipeline with `@persona`, `@step`, `@trigger`, `@handoff`, and `@budget`:
 
 ```harn,ignore
 @persona(
@@ -2711,6 +2711,16 @@ pipeline with `@persona`, `@trigger`, `@handoff`, and `@budget`:
 @handoff(target: review_captain, reason: "risky diff")
 @budget(daily_usd: 20, max_tokens: 100000)
 fn merge_captain(ctx: HandlerCtx) { ... }
+
+@step(
+  name: "plan",
+  model: "gpt-5.4-mini",
+  approval: optional,
+  receipt: audit,
+  error_boundary: fail,
+  retry: {max_attempts: 2},
+)
+fn plan_step(ctx: HandlerCtx) { ... }
 ```
 
 The annotations are first-class parser and type-checker metadata. The
@@ -2722,9 +2732,15 @@ not rewritten by this syntax.
 | Attribute | Arguments |
 |---|---|
 | `@persona` | Named metadata: `triggers`, `schedules`, `tools`, `autonomy`, `budget`, `handoffs`, `context_packs`, `evals`, `receipts`, `model`, `owner`, `name`, `description` |
+| `@step` | Named metadata: `name`, `model`, `approval` (`required`/`optional`), `receipt` (`audit`/`none`), `error_boundary` (`fail`/`continue`/`escalate`), `retry` (`{max_attempts: N}`) |
 | `@trigger` | Positional trigger specs (`github.pr_opened`, `"github.pr_opened"`, `schedule("cron")`) or named `id`, `provider`, `kind`, `event`, `when`, `schedule`, `budget` |
 | `@handoff` | Named `target`/`to`, `reason`, `schema`, `artifact` |
 | `@budget` | Named numeric fields: `daily_usd`, `hourly_usd`, `run_usd`, `max_tokens`, `frontier_escalations`, `max_autonomous_decisions_per_hour`, `max_autonomous_decisions_per_day`; string/symbol exhaustion policy via `on_exhausted` or `on_budget_exhausted` |
+
+For `@persona` functions, `harn lint` reports
+`persona-body-must-call-steps` when the body directly calls a non-stdlib
+function that is not declared with `@step`. Projects may allow specific
+legacy helpers with `[lint].persona_step_allowlist`.
 
 #### `@command(name?, description?, hint?)`
 
@@ -4771,6 +4787,7 @@ root-manifest-owned by default.
 disabled = ["unused-import"]
 require_file_header = false
 complexity_threshold = 25
+persona_step_allowlist = ["legacy_helper"]
 ```
 
 - `disabled` silences the listed rules for the whole project.
@@ -4781,6 +4798,9 @@ complexity_threshold = 25
   warning threshold (default **25**, chosen to match Clippy's
   `cognitive_complexity` default). Set lower to tighten, higher to
   loosen. Per-function escapes still go through `@complexity(allow)`.
+- `persona_step_allowlist` lists non-stdlib helper functions that
+  `@persona` bodies may call directly without a matching `@step`
+  declaration.
 
 ## Sandbox mode
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -2694,7 +2694,7 @@ runner discovers attributed pipelines in addition to the legacy
 #### Durable persona annotations
 
 Durable persona metadata can be declared directly on a function, tool, or
-pipeline with `@persona`, `@trigger`, `@handoff`, and `@budget`:
+pipeline with `@persona`, `@step`, `@trigger`, `@handoff`, and `@budget`:
 
 ```harn,ignore
 @persona(
@@ -2709,6 +2709,16 @@ pipeline with `@persona`, `@trigger`, `@handoff`, and `@budget`:
 @handoff(target: review_captain, reason: "risky diff")
 @budget(daily_usd: 20, max_tokens: 100000)
 fn merge_captain(ctx: HandlerCtx) { ... }
+
+@step(
+  name: "plan",
+  model: "gpt-5.4-mini",
+  approval: optional,
+  receipt: audit,
+  error_boundary: fail,
+  retry: {max_attempts: 2},
+)
+fn plan_step(ctx: HandlerCtx) { ... }
 ```
 
 The annotations are first-class parser and type-checker metadata. The
@@ -2720,9 +2730,15 @@ not rewritten by this syntax.
 | Attribute | Arguments |
 |---|---|
 | `@persona` | Named metadata: `triggers`, `schedules`, `tools`, `autonomy`, `budget`, `handoffs`, `context_packs`, `evals`, `receipts`, `model`, `owner`, `name`, `description` |
+| `@step` | Named metadata: `name`, `model`, `approval` (`required`/`optional`), `receipt` (`audit`/`none`), `error_boundary` (`fail`/`continue`/`escalate`), `retry` (`{max_attempts: N}`) |
 | `@trigger` | Positional trigger specs (`github.pr_opened`, `"github.pr_opened"`, `schedule("cron")`) or named `id`, `provider`, `kind`, `event`, `when`, `schedule`, `budget` |
 | `@handoff` | Named `target`/`to`, `reason`, `schema`, `artifact` |
 | `@budget` | Named numeric fields: `daily_usd`, `hourly_usd`, `run_usd`, `max_tokens`, `frontier_escalations`, `max_autonomous_decisions_per_hour`, `max_autonomous_decisions_per_day`; string/symbol exhaustion policy via `on_exhausted` or `on_budget_exhausted` |
+
+For `@persona` functions, `harn lint` reports
+`persona-body-must-call-steps` when the body directly calls a non-stdlib
+function that is not declared with `@step`. Projects may allow specific
+legacy helpers with `[lint].persona_step_allowlist`.
 
 #### `@command(name?, description?, hint?)`
 
@@ -4769,6 +4785,7 @@ root-manifest-owned by default.
 disabled = ["unused-import"]
 require_file_header = false
 complexity_threshold = 25
+persona_step_allowlist = ["legacy_helper"]
 ```
 
 - `disabled` silences the listed rules for the whole project.
@@ -4779,6 +4796,9 @@ complexity_threshold = 25
   warning threshold (default **25**, chosen to match Clippy's
   `cognitive_complexity` default). Set lower to tighten, higher to
   loosen. Per-function escapes still go through `@complexity(allow)`.
+- `persona_step_allowlist` lists non-stdlib helper functions that
+  `@persona` bodies may call directly without a matching `@step`
+  declaration.
 
 ## Sandbox mode
 


### PR DESCRIPTION
## Summary
- Adds `@step(...)` attribute parsing/type-check validation with step metadata fields: name, model, approval, receipt, error boundary, and retry max attempts.
- Extracts persona step graphs from source-declared `@persona` functions and surfaces them through `harn persona inspect <name> --json`, including manifest entry-workflow augmentation.
- Adds `persona-body-must-call-steps` lint coverage with `[lint].persona_step_allowlist`, plus LSP persona -> steps outline and DAP `@step` boundary stepping.

## Validation
- `cargo check -p harn-parser -p harn-modules -p harn-lint -p harn-lsp -p harn-dap -p harn-cli`
- `cargo test -p harn-parser parses_step_annotation_values`
- `cargo test -p harn-modules source_persona_extracts_called_steps_in_order`
- `cargo test -p harn-lint persona_steps`
- `cargo test -p harn-dap test_step_over_step_stops_on_next_step_boundary`
- `cargo test -p harn-cli persona_inspect_reports_source_declared_steps`
- `cargo test -p harn-cli lint_fails_strict_when_persona_body_calls_non_step_helper -- --nocapture`
- `cargo run --quiet --bin harn -- test conformance --filter attributes_step`
- `git diff --check`

Fixes #1056
