### PR TITLE
Strip GIT_* env from stdlib.git subprocess calls

### DIFF
--- a/crates/harn-vm/src/stdlib/git.rs
+++ b/crates/harn-vm/src/stdlib/git.rs
@@ -490,6 +490,25 @@ async fn planned_receipt(command: GitCommand) -> Result<VmValue, VmError> {
     Ok(crate::stdlib::json_to_vm_value(&receipt))
 }
 
+/// Environment variables that, when set on the calling process, would
+/// override the `cwd`/`argv`-based repo selection that the Harn git
+/// stdlib relies on. Strip them from every subprocess invocation so
+/// behavior is identical whether Harn is launched from a clean shell
+/// or from inside a git hook (which sets `GIT_DIR` etc. for the hook
+/// process and any of its descendants).
+///
+/// Reference: <https://git-scm.com/docs/git#_environment_variables>.
+const GIT_ENV_OVERRIDES: &[&str] = &[
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_WORK_TREE",
+    "GIT_NAMESPACE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_PREFIX",
+];
+
 async fn exec_argv(command: &GitCommand) -> Result<VmValue, VmError> {
     let mut params = BTreeMap::new();
     params.insert("mode".to_string(), VmValue::String(Rc::from("argv")));
@@ -508,6 +527,15 @@ async fn exec_argv(command: &GitCommand) -> Result<VmValue, VmError> {
         VmValue::String(Rc::from(display_path(&command.cwd))),
     );
     params.insert("timeout_ms".to_string(), VmValue::Int(120_000));
+    params.insert(
+        "env_remove".to_string(),
+        VmValue::List(Rc::new(
+            GIT_ENV_OVERRIDES
+                .iter()
+                .map(|name| VmValue::String(Rc::from(*name)))
+                .collect(),
+        )),
+    );
     let caller = json!({
         "surface": "stdlib.git",
         "operation": command.operation,
@@ -1133,11 +1161,17 @@ mod tests {
     }
 
     fn git(cwd: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .args(args)
-            .current_dir(cwd)
-            .output()
-            .expect("run git");
+        let mut command = Command::new("git");
+        command.args(args).current_dir(cwd);
+        // Mirror the production `exec_argv` env scrub so these tests
+        // also pass when invoked from inside a git hook (which sets
+        // `GIT_DIR=.git` for the hook process and its descendants —
+        // without this, a child `git init` in a temp dir reuses the
+        // outer repo's index and fails).
+        for name in super::GIT_ENV_OVERRIDES {
+            command.env_remove(name);
+        }
+        let output = command.output().expect("run git");
         assert!(
             output.status.success(),
             "git {:?} failed\nstdout:\n{}\nstderr:\n{}",

--- a/crates/harn-vm/src/stdlib/host.rs
+++ b/crates/harn-vm/src/stdlib/host.rs
@@ -592,6 +592,16 @@ pub(crate) async fn dispatch_process_exec(
             cmd.env(key, value);
         }
     }
+    // env_remove: list of environment variable names to strip before
+    // spawning. Applied after `env` so callers can both inherit and
+    // selectively unset (e.g. the git stdlib strips `GIT_*` so its
+    // operations are self-contained even when Harn is invoked from
+    // inside a git hook that sets `GIT_DIR`).
+    if let Some(env_remove) = optional_string_list(&params, "env_remove") {
+        for key in env_remove {
+            cmd.env_remove(key);
+        }
+    }
     cmd.stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())


### PR DESCRIPTION
## Summary

- `make test` (and the pre-push hook that wraps it) flakes on two `harn-vm stdlib::git::tests::*` tests when invoked from inside a git-driven context — git itself sets `GIT_DIR=.git` for hooks, which leaks down into the tests' `Command::new(\"git\")` subprocesses and overrides their `cwd`/`argv`-based repo selection.
- Fix at the stdlib.git boundary: `exec_argv` now passes an `env_remove` list of canonical "override repo selection" knobs to `dispatch_process_exec`, which learns to honor it. The test helper `git()` mirrors the same scrub for its direct `Command` calls.
- Discovered while pushing #1118 (mcp elicitation, #875) — pre-push hook flaked on these unrelated git tests, surfacing the bug.

## Why this is correct (not just a band-aid)

The Harn git stdlib already specifies its target repo via the `cwd` + `argv` it builds explicitly. Inheriting `GIT_DIR` / `GIT_INDEX_FILE` / `GIT_WORK_TREE` / etc. from the parent process can only ever override that — never augment it — so stripping them is the right semantics regardless of test context. Anyone running `harn` from inside a git hook today silently gets misrouted git operations; this fixes that too.

## Test plan

- [x] Reproduced the failure: `GIT_DIR=foo cargo nextest run --package harn-vm stdlib::git::tests::{force_with_lease_detects_advanced_remote_before_push,git_status_returns_receipt_and_trust_record}` → both fail on main, both pass with this branch
- [x] Full `cargo nextest run --package harn-vm` — all 1687 pass
- [x] Pre-push hook itself runs `make test` cleanly on this branch (this is what I was working around in #1118)
- [x] `cargo fmt --check` + `cargo clippy --package harn-vm` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)