### PR TITLE
Rename CI rollup gate: Check status → CI status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,8 +205,8 @@ jobs:
         env:
           NEXTEST_PROFILE: e2e
 
-  check-status:
-    name: Check status
+  ci-status:
+    name: CI status
     runs-on: ubuntu-latest
     if: always()
     needs: [fmt, lint-md, rust, windows, portal, actions, e2e]
@@ -255,7 +255,7 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    needs: [check-status]
+    needs: [ci-status]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ name: E2E
 #   - when the `e2e` label is added to a pull request
 #   - manually via workflow_dispatch
 #
-# The merge-queue E2E run lives in ci.yml (needs the same check-status gate).
+# The merge-queue E2E run lives in ci.yml (needs the same ci-status gate).
 
 on:
   schedule:

--- a/.github/workflows/windows-nightly.yml
+++ b/.github/workflows/windows-nightly.yml
@@ -8,7 +8,7 @@ name: Windows nightly
 # `#![cfg(unix)]` is expected to pass here.
 #
 # Failure is informational, not blocking — the nightly does not gate the
-# `check-status` job. When something regresses, file an issue and either
+# `ci-status` job. When something regresses, file an issue and either
 # fix the underlying portability bug or add a per-test `#[cfg(unix)]`
 # annotation with rationale, then update
 # `docs/src/dev/windows-test-coverage.md` to reflect the disposition.


### PR DESCRIPTION
The org-level "main protection" ruleset (`burin-labs/15807155`) requires
a status check named `CI status`. This repo's CI rollup gate was named
`Check status`, which is why PRs have been getting stuck in the merge
queue (queue test passes, then GitHub refuses to merge because the
required context is missing).

Other burin-labs repos (`harn-cloud`, `burin-code`) already use the
`CI status` name. This brings `harn` into line.

## Changes

- `.github/workflows/ci.yml`: rename job id `check-status` → `ci-status`,
  display name `Check status` → `CI status`. Update `deploy-docs.needs`.
- `.github/workflows/windows-nightly.yml`, `.github/workflows/e2e.yml`:
  update comment references.

## Follow-up

After this lands:

1. Rebase #1119, #1115, #1117 onto new main so they emit `CI status`,
   then re-queue.
2. Add `CI status` rollup gates to the rest of the burin-labs repos
   (connectors, examples, SDKs) that currently lack one.