### PR TITLE
Fix flaky file_backed_prompts_list_render_and_notify_changes test

### DIFF
--- a/crates/harn-cli/src/commands/mcp/serve.rs
+++ b/crates/harn-cli/src/commands/mcp/serve.rs
@@ -2495,11 +2495,15 @@ required = true
 Updated: {{ code }}
 "#,
         );
-        let notification = recv_next_notification(&mut notifications).await;
-        assert_eq!(
-            notification["method"],
-            json!("notifications/prompts/list_changed")
-        );
+        // Writing a `.harn.prompt` file can also trigger the tools/resources
+        // watchers, so the order of incoming notifications is not deterministic.
+        // Drain until we observe `prompts/list_changed`; ignore any others.
+        let seen = collect_notification_methods(
+            &mut notifications,
+            &["notifications/prompts/list_changed"],
+        )
+        .await;
+        assert!(seen.contains("notifications/prompts/list_changed"));
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary

The test in \`crates/harn-cli/src/commands/mcp/serve.rs\` writes a
\`.harn.prompt\` file and then expects the next received notification
to be \`prompts/list_changed\`. In practice the file write also triggers
the tools/resources watchers, so broadcast ordering isn't deterministic
and the test sometimes panics with:

\`\`\`
left:  \"notifications/tools/list_changed\"
right: \"notifications/prompts/list_changed\"
\`\`\`

The 50x flake-rerun caught it on iteration 8 of #1122 (run 25216991629).

## Fix

Switch to the existing \`collect_notification_methods\` helper (already
used by the sibling \`package_metadata_changes_*\` test) which drains
until the expected method is observed and ignores any unrelated
notifications.

## Test plan

- [x] CI on this PR