### PR TITLE
Implement ACP session modes (#897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **ACP session modes (#897).** The ACP adapter now implements the
+  [session-modes](https://agentclientprotocol.com/protocol/session-modes)
+  spec: `session/new` and `session/load` return a `SessionModeState`
+  (`{ currentModeId, availableModes }`) describing the four-mode catalog
+  (`default`, `architect`, `code`, `ask`); `session/set_mode` switches
+  the active mode and emits a `current_mode_update` notification; and
+  `session/fork` carries the parent's mode over to the new branch.
+  `architect` and `ask` modes push a read-only capability ceiling onto
+  the VM execution stack while the prompt runs, so destructive builtins
+  (`write_file`, `exec`, network calls, etc.) are rejected before they
+  touch the workspace. `default` and `code` preserve the pre-modes
+  baseline.
+
 - **MCP elicitation (`elicitation/create`) on both roles (#875).** Harn
   servers can now prompt connected clients for structured user input
   mid-tool-call via the `mcp_elicit({ message, requestedSchema })`

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -10,6 +10,7 @@ mod commands;
 mod events;
 mod execute;
 mod io;
+mod modes;
 
 use std::collections::HashMap;
 use std::io::Write;
@@ -143,6 +144,9 @@ struct Session {
     /// `available_commands_update` for this session, used to skip re-emits
     /// when the underlying pipeline source hasn't changed.
     advertised_commands: Vec<DiscoveredCommand>,
+    /// Active session mode id (one of [`modes::MODE_CATALOG`]). Drives
+    /// the capability ceiling pushed for the next `session/prompt`.
+    current_mode_id: String,
 }
 
 #[async_trait(?Send)]
@@ -362,6 +366,7 @@ impl AcpServer {
                 host_bridge: None,
                 info,
                 advertised_commands: Vec::new(),
+                current_mode_id: modes::DEFAULT_MODE_ID.to_string(),
             },
         );
         harn_vm::agent_sessions::open_or_create(Some(session_id));
@@ -381,11 +386,7 @@ impl AcpServer {
             id,
             serde_json::json!({
                 "sessionId": session_id,
-                "modes": [{
-                    "id": "default",
-                    "name": "Default",
-                    "description": "Execute harn pipelines",
-                }],
+                "modes": modes::session_mode_state(modes::DEFAULT_MODE_ID),
             }),
         );
 
@@ -539,6 +540,11 @@ impl AcpServer {
             meta,
         };
 
+        let parent_mode_id = self
+            .sessions
+            .get(&src_id)
+            .map(|session| session.current_mode_id.clone())
+            .unwrap_or_else(|| modes::DEFAULT_MODE_ID.to_string());
         self.sessions.insert(
             new_session_id.clone(),
             Session {
@@ -547,6 +553,7 @@ impl AcpServer {
                 host_bridge: None,
                 info: info.clone(),
                 advertised_commands: Vec::new(),
+                current_mode_id: parent_mode_id.clone(),
             },
         );
         self.emit_session_info_update(&new_session_id, &info);
@@ -558,6 +565,7 @@ impl AcpServer {
                 "state": "forked",
                 "parent_id": src_id,
                 "branched_at": branched_at,
+                "modes": modes::session_mode_state(&parent_mode_id),
             }),
         );
     }
@@ -589,11 +597,15 @@ impl AcpServer {
             })
             .unwrap_or_default();
 
-        let (cwd, cancelled) = match self.sessions.get_mut(&session_id) {
+        let (cwd, cancelled, current_mode_id) = match self.sessions.get_mut(&session_id) {
             Some(s) => {
                 s.cancelled.store(false, Ordering::SeqCst);
                 s.host_bridge = None;
-                (s.cwd.clone(), s.cancelled.clone())
+                (
+                    s.cwd.clone(),
+                    s.cancelled.clone(),
+                    s.current_mode_id.clone(),
+                )
             }
             None => {
                 self.send_error(id, -32602, &format!("Unknown session: {session_id}"));
@@ -746,6 +758,7 @@ impl AcpServer {
 
         let id_owned = id.clone();
         let send_output = self.output.clone();
+        let _mode_guard = modes::ModePolicyGuard::enter(&current_mode_id);
         let result = execute::execute_chunk(
             chunk,
             bridge.clone(),
@@ -756,6 +769,7 @@ impl AcpServer {
             self.runtime_configurator.clone(),
         )
         .await;
+        drop(_mode_guard);
         if let Some(session) = self.sessions.get_mut(&session_id) {
             session.host_bridge = None;
         }
@@ -1036,7 +1050,65 @@ impl AcpServer {
             id,
             serde_json::json!({
                 "session": session_value,
+                "modes": modes::session_mode_state(&session.current_mode_id),
                 "replayed": [],
+            }),
+        );
+    }
+
+    fn handle_session_set_mode(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
+        let Some(session_id) = params
+            .get("sessionId")
+            .or_else(|| params.get("session_id"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+        else {
+            self.send_error(id, -32602, "session/set_mode requires sessionId");
+            return;
+        };
+        let Some(mode_id) = params
+            .get("modeId")
+            .or_else(|| params.get("mode_id"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+        else {
+            self.send_error(id, -32602, "session/set_mode requires modeId");
+            return;
+        };
+
+        if !modes::is_known(&mode_id) {
+            self.send_error(
+                id,
+                -32602,
+                &format!(
+                    "Unknown mode '{mode_id}'. Available: {}",
+                    modes::known_mode_ids().join(", ")
+                ),
+            );
+            return;
+        }
+
+        let Some(session) = self.sessions.get_mut(&session_id) else {
+            self.send_error(id, -32602, &format!("Unknown session: {session_id}"));
+            return;
+        };
+
+        if session.current_mode_id == mode_id {
+            // Idempotent: ack but do not emit a redundant update.
+            self.send_response(id, serde_json::json!({}));
+            return;
+        }
+
+        session.current_mode_id = mode_id.clone();
+        self.send_response(id, serde_json::json!({}));
+        self.send_notification(
+            "session/update",
+            serde_json::json!({
+                "sessionId": session_id,
+                "update": {
+                    "sessionUpdate": "current_mode_update",
+                    "modeId": mode_id,
+                },
             }),
         );
     }
@@ -1071,6 +1143,9 @@ impl AcpServer {
             }
             "session/fork" => {
                 self.handle_session_fork(&id, &params);
+            }
+            "session/set_mode" => {
+                self.handle_session_set_mode(&id, &params);
             }
             "session/prompt" => {
                 self.handle_session_prompt(&id, &params).await;
@@ -1712,6 +1787,526 @@ mod tests {
         let error = recv_json(&mut rx).await;
         assert_eq!(error["id"], 2);
         assert_eq!(error["error"]["message"], "missing API key");
+    }
+
+    /// `session/new` returns a spec-shaped `SessionModeState` describing
+    /// every supported mode plus the active selection. Locks the wire
+    /// shape required by ACP session-modes
+    /// (<https://agentclientprotocol.com/protocol/session-modes>).
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_session_new_advertises_session_mode_state() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut server =
+            AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/new",
+                "params": {"cwd": "."},
+            }))
+            .await;
+        let created = recv_json(&mut rx).await;
+
+        let modes = &created["result"]["modes"];
+        assert_eq!(modes["currentModeId"], "default");
+        let available = modes["availableModes"]
+            .as_array()
+            .expect("availableModes array");
+        let ids: Vec<&str> = available
+            .iter()
+            .map(|mode| mode["id"].as_str().expect("mode id"))
+            .collect();
+        assert_eq!(ids, vec!["default", "architect", "code", "ask"]);
+        // Each entry must carry a human-readable name; description is
+        // optional per spec but Harn always populates it.
+        for mode in available {
+            assert!(
+                mode["name"].as_str().is_some_and(|name| !name.is_empty()),
+                "mode {mode} missing name"
+            );
+        }
+    }
+
+    /// `session/load` echoes the active mode state back to a
+    /// reconnecting client so the UI can re-render the selected mode
+    /// without an extra round-trip.
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_session_load_includes_current_mode_state() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut server =
+            AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/new",
+                "params": {"cwd": "."},
+            }))
+            .await;
+        let created = recv_json(&mut rx).await;
+        let session_id = created["result"]["sessionId"]
+            .as_str()
+            .expect("session id")
+            .to_string();
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/set_mode",
+                "params": {"sessionId": session_id, "modeId": "architect"},
+            }))
+            .await;
+        // Drain success ack and notification.
+        let _ack = recv_json(&mut rx).await;
+        let _notification = recv_json(&mut rx).await;
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/load",
+                "params": {"sessionId": session_id},
+            }))
+            .await;
+        let loaded = recv_json(&mut rx).await;
+        assert_eq!(loaded["result"]["modes"]["currentModeId"], "architect");
+        assert!(loaded["result"]["modes"]["availableModes"]
+            .as_array()
+            .expect("available modes")
+            .iter()
+            .any(|m| m["id"] == "architect"));
+    }
+
+    /// Setting a valid mode ack's with an empty result and emits a
+    /// `current_mode_update` notification carrying the new mode id.
+    /// Locks the canonical session-modes wire shape so clients depend
+    /// on it directly.
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_set_mode_emits_current_mode_update_notification() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut server =
+            AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/new",
+                "params": {"cwd": "."},
+            }))
+            .await;
+        let created = recv_json(&mut rx).await;
+        let session_id = created["result"]["sessionId"]
+            .as_str()
+            .expect("session id")
+            .to_string();
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/set_mode",
+                "params": {"sessionId": session_id, "modeId": "architect"},
+            }))
+            .await;
+        let ack = recv_json(&mut rx).await;
+        assert_eq!(ack["id"], 2);
+        assert!(ack["result"].is_object());
+        assert!(ack["error"].is_null());
+
+        let notification = recv_json(&mut rx).await;
+        assert_eq!(notification["method"], "session/update");
+        assert_eq!(notification["params"]["sessionId"], session_id);
+        assert_eq!(
+            notification["params"]["update"]["sessionUpdate"],
+            "current_mode_update"
+        );
+        assert_eq!(notification["params"]["update"]["modeId"], "architect");
+    }
+
+    /// Re-setting the same mode is a no-op: the agent ack's the
+    /// request but does not emit a `current_mode_update` notification.
+    /// Avoids spurious UI updates when a host reconciles its idea of
+    /// the active mode without intending a transition.
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_set_mode_is_idempotent_when_mode_unchanged() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut server =
+            AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/new",
+                "params": {"cwd": "."},
+            }))
+            .await;
+        let created = recv_json(&mut rx).await;
+        let session_id = created["result"]["sessionId"]
+            .as_str()
+            .expect("session id")
+            .to_string();
+
+        // Active mode after session/new is "default"; re-set to it.
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/set_mode",
+                "params": {"sessionId": session_id, "modeId": "default"},
+            }))
+            .await;
+        let ack = recv_json(&mut rx).await;
+        assert_eq!(ack["id"], 2);
+        assert!(ack["result"].is_object());
+
+        // Follow up with a real transition so the channel produces a
+        // notification we can recognize. If a stray idempotent
+        // notification had been sent, it would arrive *before* this
+        // one and the assert below would fail.
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/set_mode",
+                "params": {"sessionId": session_id, "modeId": "architect"},
+            }))
+            .await;
+        let _ack2 = recv_json(&mut rx).await;
+        let notification = recv_json(&mut rx).await;
+        assert_eq!(notification["method"], "session/update");
+        assert_eq!(notification["params"]["update"]["modeId"], "architect");
+    }
+
+    /// `session/set_mode` rejects unknown sessions and unknown mode
+    /// ids with structured JSON-RPC errors instead of silently
+    /// accepting them.
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_set_mode_validates_inputs() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut server =
+            AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+        // Unknown session.
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/set_mode",
+                "params": {"sessionId": "ghost", "modeId": "architect"},
+            }))
+            .await;
+        let unknown_session = recv_json(&mut rx).await;
+        assert_eq!(unknown_session["id"], 1);
+        assert_eq!(unknown_session["error"]["code"], -32602);
+        assert!(unknown_session["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Unknown session"));
+
+        // Unknown mode id.
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": {"cwd": "."},
+            }))
+            .await;
+        let created = recv_json(&mut rx).await;
+        let session_id = created["result"]["sessionId"]
+            .as_str()
+            .expect("session id")
+            .to_string();
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/set_mode",
+                "params": {"sessionId": session_id, "modeId": "not-a-mode"},
+            }))
+            .await;
+        let unknown_mode = recv_json(&mut rx).await;
+        assert_eq!(unknown_mode["id"], 3);
+        assert_eq!(unknown_mode["error"]["code"], -32602);
+        assert!(unknown_mode["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Unknown mode"));
+    }
+
+    /// `architect` mode pushes a read-only capability ceiling for the
+    /// duration of `session/prompt`, so a script that calls
+    /// `write_file()` in plan mode is rejected by the VM policy gate
+    /// instead of mutating the workspace. Doubles as the conformance
+    /// case for "client switches mode mid-session, agent's behavior
+    /// changes" (#897 acceptance).
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_architect_mode_blocks_destructive_writes_in_prompt() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let dir = tempfile::tempdir().expect("tempdir");
+                let target = dir.path().join("forbidden.txt");
+                let target_str = target
+                    .to_str()
+                    .expect("temp path is utf-8")
+                    .replace('\\', "\\\\");
+
+                let (request_tx, request_rx) = mpsc::unbounded_channel();
+                let (response_tx, mut response_rx) = mpsc::unbounded_channel();
+                let server = tokio::task::spawn_local(super::run_acp_channel_server(
+                    AcpServerConfig::new(None),
+                    request_rx,
+                    response_tx,
+                ));
+
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "session/new",
+                        "params": {"cwd": dir.path().display().to_string()},
+                    }))
+                    .expect("send session/new");
+                let created = recv_json(&mut response_rx).await;
+                let session_id = created["result"]["sessionId"]
+                    .as_str()
+                    .expect("session id")
+                    .to_string();
+
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "session/set_mode",
+                        "params": {"sessionId": session_id, "modeId": "architect"},
+                    }))
+                    .expect("send session/set_mode");
+                // Drain ack + current_mode_update notification.
+                let _ack = recv_json(&mut response_rx).await;
+                let mode_notification = recv_json(&mut response_rx).await;
+                assert_eq!(
+                    mode_notification["params"]["update"]["sessionUpdate"],
+                    "current_mode_update"
+                );
+                assert_eq!(mode_notification["params"]["update"]["modeId"], "architect");
+
+                let prompt_source =
+                    format!("write_file(\"{target_str}\", \"should not be written\")");
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": 3,
+                        "method": "session/prompt",
+                        "params": {
+                            "sessionId": session_id,
+                            "prompt": [{"type": "text", "text": prompt_source}],
+                        },
+                    }))
+                    .expect("send session/prompt");
+
+                let mut saw_error = false;
+                for _ in 0..32 {
+                    let message = recv_json(&mut response_rx).await;
+                    if message["method"] == "host/capabilities" {
+                        request_tx
+                            .send(serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": message["id"].clone(),
+                                "result": {},
+                            }))
+                            .expect("send host capabilities response");
+                        continue;
+                    }
+                    if message["id"] == 3 {
+                        let error = &message["error"];
+                        assert!(
+                            !error.is_null(),
+                            "architect mode should reject write_file but got result {:?}",
+                            message["result"]
+                        );
+                        let message_text = error["message"].as_str().unwrap_or_default();
+                        assert!(
+                            message_text.contains("workspace write ceiling"),
+                            "unexpected error message: {message_text}"
+                        );
+                        saw_error = true;
+                        break;
+                    }
+                }
+                assert!(saw_error, "prompt should produce a JSON-RPC error response");
+                assert!(
+                    !target.exists(),
+                    "architect mode must not allow write_file to mutate the workspace"
+                );
+
+                drop(request_tx);
+                server.await.expect("ACP channel server task");
+            })
+            .await;
+    }
+
+    /// `code` mode preserves the pre-modes baseline: writes succeed
+    /// because the policy guard pushes nothing onto the execution
+    /// stack. Pairs with the architect-mode test to confirm modes are
+    /// the *only* thing changing behavior between the two prompts.
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_code_mode_allows_writes_in_prompt() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let dir = tempfile::tempdir().expect("tempdir");
+                let target = dir.path().join("allowed.txt");
+                let target_str = target
+                    .to_str()
+                    .expect("temp path is utf-8")
+                    .replace('\\', "\\\\");
+
+                let (request_tx, request_rx) = mpsc::unbounded_channel();
+                let (response_tx, mut response_rx) = mpsc::unbounded_channel();
+                let server = tokio::task::spawn_local(super::run_acp_channel_server(
+                    AcpServerConfig::new(None),
+                    request_rx,
+                    response_tx,
+                ));
+
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "session/new",
+                        "params": {"cwd": dir.path().display().to_string()},
+                    }))
+                    .expect("send session/new");
+                let created = recv_json(&mut response_rx).await;
+                let session_id = created["result"]["sessionId"]
+                    .as_str()
+                    .expect("session id")
+                    .to_string();
+
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "session/set_mode",
+                        "params": {"sessionId": session_id, "modeId": "code"},
+                    }))
+                    .expect("send session/set_mode");
+                let _ack = recv_json(&mut response_rx).await;
+                let _notification = recv_json(&mut response_rx).await;
+
+                let prompt_source =
+                    format!("write_file(\"{target_str}\", \"hello from code mode\")");
+                request_tx
+                    .send(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": 3,
+                        "method": "session/prompt",
+                        "params": {
+                            "sessionId": session_id,
+                            "prompt": [{"type": "text", "text": prompt_source}],
+                        },
+                    }))
+                    .expect("send session/prompt");
+
+                let mut saw_completed = false;
+                for _ in 0..32 {
+                    let message = recv_json(&mut response_rx).await;
+                    if message["method"] == "host/capabilities" {
+                        request_tx
+                            .send(serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": message["id"].clone(),
+                                "result": {},
+                            }))
+                            .expect("send host capabilities response");
+                        continue;
+                    }
+                    if message["id"] == 3 {
+                        assert_eq!(message["result"]["stopReason"], "completed");
+                        saw_completed = true;
+                        break;
+                    }
+                }
+                assert!(saw_completed, "code-mode prompt should complete");
+                assert!(
+                    target.exists(),
+                    "code mode should allow write_file to mutate the workspace"
+                );
+
+                drop(request_tx);
+                server.await.expect("ACP channel server task");
+            })
+            .await;
+    }
+
+    /// `session/fork` carries the parent's active mode over to the
+    /// branched session and surfaces it on the fork response, so
+    /// clients can render the correct mode badge on the new branch
+    /// without an extra round-trip.
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_session_fork_inherits_parent_current_mode() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut server =
+            AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/new",
+                "params": {"cwd": "."},
+            }))
+            .await;
+        let created = recv_json(&mut rx).await;
+        let parent_id = created["result"]["sessionId"]
+            .as_str()
+            .expect("session id")
+            .to_string();
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/set_mode",
+                "params": {"sessionId": parent_id, "modeId": "architect"},
+            }))
+            .await;
+        let _ack = recv_json(&mut rx).await;
+        let _notification = recv_json(&mut rx).await;
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/fork",
+                "params": {"session_id": parent_id},
+            }))
+            .await;
+        // The fork emits a session_info_update notification *before*
+        // the response; drain notifications until the response with
+        // matching id arrives so the test is order-independent.
+        let mut fork_response = None;
+        for _ in 0..6 {
+            let msg = recv_json(&mut rx).await;
+            if msg["id"] == 3 {
+                fork_response = Some(msg);
+                break;
+            }
+        }
+        let fork_response = fork_response.expect("fork response");
+        assert_eq!(fork_response["result"]["state"], "forked");
+        assert_eq!(
+            fork_response["result"]["modes"]["currentModeId"],
+            "architect"
+        );
     }
 
     /// End-to-end ACP slash-command flow: a Zed-style client receives the

--- a/crates/harn-serve/src/adapters/acp/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/modes.rs
@@ -1,0 +1,201 @@
+//! ACP session modes (<https://agentclientprotocol.com/protocol/session-modes>).
+//!
+//! A session mode caps the agent's tool access and side-effect ceiling.
+//! The catalog is fixed: `default`, `architect`, `code`, `ask`. The
+//! adapter advertises this catalog in `session/new` and `session/load`
+//! results, accepts `session/set_mode` requests to switch the active
+//! mode, and emits `current_mode_update` notifications when the mode
+//! changes. While a prompt runs, the active mode's policy is pushed
+//! onto the VM execution policy stack so destructive builtins are
+//! rejected from `architect` mode and gated through approval flows from
+//! `ask` mode.
+
+use std::collections::BTreeMap;
+
+use harn_vm::orchestration::CapabilityPolicy;
+
+/// Default mode id assigned to newly created sessions. `default` is
+/// chosen over `code` so existing clients that never call
+/// `session/set_mode` observe the same unbounded behavior they had
+/// before modes were introduced (no policy override pushed on the
+/// execution stack).
+pub(super) const DEFAULT_MODE_ID: &str = "default";
+
+pub(super) struct ModeDefinition {
+    pub(super) id: &'static str,
+    pub(super) name: &'static str,
+    pub(super) description: &'static str,
+}
+
+/// The static catalog of modes Harn advertises over ACP. Order is
+/// preserved on the wire so clients render a stable list. `default`
+/// stays first so it remains the obvious initial selection.
+pub(super) const MODE_CATALOG: &[ModeDefinition] = &[
+    ModeDefinition {
+        id: "default",
+        name: "Default",
+        description: "Execute Harn pipelines with no extra restrictions.",
+    },
+    ModeDefinition {
+        id: "architect",
+        name: "Architect",
+        description: "Read-only planning. Workspace writes, process execution, and \
+                      network requests are rejected; only reads, listings, and analysis \
+                      are permitted.",
+    },
+    ModeDefinition {
+        id: "code",
+        name: "Code",
+        description: "Full tool access for reading, writing, executing processes, and \
+                      calling out to LLMs and connectors.",
+    },
+    ModeDefinition {
+        id: "ask",
+        name: "Ask",
+        description: "Read-only by default. Destructive operations require host \
+                      approval through the ACP permission flow before they run.",
+    },
+];
+
+pub(super) fn is_known(mode_id: &str) -> bool {
+    MODE_CATALOG.iter().any(|m| m.id == mode_id)
+}
+
+pub(super) fn known_mode_ids() -> Vec<&'static str> {
+    MODE_CATALOG.iter().map(|m| m.id).collect()
+}
+
+/// Render the spec-shaped `SessionModeState`:
+/// `{ currentModeId, availableModes: [{ id, name, description }] }`.
+pub(super) fn session_mode_state(current_mode_id: &str) -> serde_json::Value {
+    let available: Vec<serde_json::Value> = MODE_CATALOG
+        .iter()
+        .map(|mode| {
+            serde_json::json!({
+                "id": mode.id,
+                "name": mode.name,
+                "description": mode.description,
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "currentModeId": current_mode_id,
+        "availableModes": available,
+    })
+}
+
+/// Capability ceiling enforced while a prompt runs in this mode.
+///
+/// The returned policy is pushed onto the VM execution stack via
+/// `harn_vm::orchestration::push_execution_policy` for the duration of
+/// the prompt. `default` and `code` return `None` to preserve the
+/// pre-modes behavior (no override). `architect` clamps the
+/// side-effect ceiling to read-only. `ask` mirrors `architect`'s
+/// ceiling for now: writes/exec/network are rejected by the same
+/// builtin gate, which surfaces as an error the host can use to drive
+/// an approval prompt. We deliberately do *not* layer
+/// `ToolApprovalPolicy` here — the ACP `session/request_permission`
+/// flow is the host-driven path, and the VM gate is the safety net for
+/// scripts that bypass tool approval.
+pub(super) fn policy_for_mode(mode_id: &str) -> Option<CapabilityPolicy> {
+    match mode_id {
+        "default" | "code" => None,
+        "architect" | "ask" => Some(CapabilityPolicy {
+            tools: Vec::new(),
+            capabilities: BTreeMap::new(),
+            workspace_roots: Vec::new(),
+            side_effect_level: Some("read_only".to_string()),
+            recursion_limit: None,
+            tool_arg_constraints: Vec::new(),
+            tool_annotations: BTreeMap::new(),
+        }),
+        _ => None,
+    }
+}
+
+/// RAII guard that pushes a CapabilityPolicy on construction and pops
+/// it on drop. For modes without an override, the guard does nothing
+/// on enter and on drop, preserving the pre-modes baseline.
+pub(super) struct ModePolicyGuard {
+    pushed: bool,
+}
+
+impl ModePolicyGuard {
+    pub(super) fn enter(mode_id: &str) -> Self {
+        match policy_for_mode(mode_id) {
+            Some(policy) => {
+                harn_vm::orchestration::push_execution_policy(policy);
+                Self { pushed: true }
+            }
+            None => Self { pushed: false },
+        }
+    }
+}
+
+impl Drop for ModePolicyGuard {
+    fn drop(&mut self) {
+        if self.pushed {
+            harn_vm::orchestration::pop_execution_policy();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_contains_expected_modes() {
+        let ids = known_mode_ids();
+        assert!(ids.contains(&"default"));
+        assert!(ids.contains(&"architect"));
+        assert!(ids.contains(&"code"));
+        assert!(ids.contains(&"ask"));
+    }
+
+    #[test]
+    fn default_mode_is_first_in_catalog() {
+        assert_eq!(MODE_CATALOG.first().map(|m| m.id), Some(DEFAULT_MODE_ID));
+    }
+
+    #[test]
+    fn session_mode_state_contains_current_and_available() {
+        let state = session_mode_state("architect");
+        assert_eq!(state["currentModeId"], "architect");
+        let available = state["availableModes"].as_array().expect("array");
+        assert_eq!(available.len(), MODE_CATALOG.len());
+        assert!(available
+            .iter()
+            .any(|m| m["id"] == "architect" && m["name"] == "Architect"));
+    }
+
+    #[test]
+    fn policy_for_default_and_code_is_none() {
+        assert!(policy_for_mode("default").is_none());
+        assert!(policy_for_mode("code").is_none());
+    }
+
+    #[test]
+    fn policy_for_architect_clamps_to_read_only() {
+        let policy = policy_for_mode("architect").expect("architect has policy");
+        assert_eq!(policy.side_effect_level.as_deref(), Some("read_only"));
+    }
+
+    #[test]
+    fn policy_for_ask_clamps_to_read_only() {
+        let policy = policy_for_mode("ask").expect("ask has policy");
+        assert_eq!(policy.side_effect_level.as_deref(), Some("read_only"));
+    }
+
+    #[test]
+    fn policy_for_unknown_mode_is_none() {
+        assert!(policy_for_mode("not-a-real-mode").is_none());
+    }
+
+    #[test]
+    fn is_known_rejects_unknown_mode() {
+        assert!(is_known("default"));
+        assert!(!is_known(""));
+        assert!(!is_known("plan"));
+    }
+}

--- a/docs/src/acp/websocket.md
+++ b/docs/src/acp/websocket.md
@@ -96,6 +96,7 @@ surface as stdio ACP:
 - `session/cancel`
 - `session/input`
 - `session/fork`
+- `session/set_mode`
 - `agent/resume`
 - `workflow/*`
 - `harn.hitl.respond`

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -447,6 +447,7 @@ The ACP server supports these JSON-RPC methods:
 | `session/list` | List active sessions known to the ACP adapter |
 | `session/prompt` | Send a prompt to the agent for execution |
 | `session/cancel` | Cancel the currently running prompt |
+| `session/set_mode` | Switch the active session mode |
 | `workflow/signal` | Enqueue a workflow signal message in the current session workspace |
 | `workflow/query` | Read a named workflow query value from the current session workspace |
 | `workflow/update` | Send a workflow update request and wait for a response |
@@ -502,6 +503,62 @@ When a fork is created, Harn also emits a `session/update` notification with
 hosts can render branch-aware session UIs without scraping text output. The
 forked session gets its own stream; subscriber sinks and in-flight prompt state
 are not copied from the parent.
+
+### Session Modes
+
+Harn implements ACP
+[session-modes](https://agentclientprotocol.com/protocol/session-modes) so a
+host can clamp the agent's tool ceiling at runtime. The `session/new` and
+`session/load` results carry a spec-shaped `modes` field:
+
+```json
+{
+  "modes": {
+    "currentModeId": "default",
+    "availableModes": [
+      { "id": "default",   "name": "Default",   "description": "..." },
+      { "id": "architect", "name": "Architect", "description": "..." },
+      { "id": "code",      "name": "Code",      "description": "..." },
+      { "id": "ask",       "name": "Ask",       "description": "..." }
+    ]
+  }
+}
+```
+
+Mode semantics:
+
+- `default` — preserves the pre-modes baseline (no extra capability ceiling).
+- `architect` — read-only planning mode. Builtins that mutate the workspace,
+  execute processes, or hit the network are rejected by the VM policy gate
+  before they run. Reads, listings, and analysis stay available.
+- `code` — full tool access; equivalent to `default` for the purposes of the
+  capability ceiling. Surfaces a distinct id so hosts can render the mode
+  the user explicitly opted into.
+- `ask` — read-only by default; destructive operations are gated through the
+  ACP `session/request_permission` flow on the host before executing.
+
+Switching modes:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 17,
+  "method": "session/set_mode",
+  "params": { "sessionId": "sess_abc", "modeId": "architect" }
+}
+```
+
+The agent ack's with an empty result and emits a `session/update`
+notification with `sessionUpdate: "current_mode_update"` carrying the new
+`modeId`. Re-setting the same mode is a no-op (ack only, no notification).
+`session/fork` carries the parent's active mode over to the new branch and
+echoes it back on the fork response.
+
+The selected mode is enforced for the next `session/prompt`: while the
+prompt runs, the matching capability policy is pushed onto the VM
+execution stack and popped when the prompt completes. The conformance
+case `acp_architect_mode_blocks_destructive_writes_in_prompt` locks this
+behavior end-to-end.
 
 ### Queued user messages during agent execution
 


### PR DESCRIPTION
## Summary

Implements ACP [session-modes](https://agentclientprotocol.com/protocol/session-modes) end-to-end, closing #897.

- `session/new` and `session/load` now return a spec-shaped `SessionModeState` (`modes: { currentModeId, availableModes }`) describing the four-mode catalog: `default`, `architect`, `code`, `ask`.
- New `session/set_mode` handler validates inputs, updates the active mode, sends an empty success result, and emits a `current_mode_update` `session/update` notification. Idempotent re-sets of the same mode ack only.
- `session/fork` carries the parent's mode over to the new branch and echoes it on the fork response.
- `architect` and `ask` modes push a read-only `CapabilityPolicy` onto the VM execution stack via a `ModePolicyGuard` for the duration of the next `session/prompt`. `default` and `code` skip the push to preserve the pre-modes baseline.
- The acceptance case from the issue ("client switches mode mid-session, agent's behavior changes (e.g., plan mode no-ops destructive tool calls)") is locked in `acp_architect_mode_blocks_destructive_writes_in_prompt`: an architect-mode prompt that calls `write_file()` is rejected by the policy gate before mutating the workspace.

## Test plan

- [x] `cargo test -p harn-serve --lib adapters::acp` (55 tests, 7 new)
- [x] `cargo clippy -p harn-serve --tests --no-deps -- -D warnings`
- [x] `cargo fmt --check`
- [x] markdown lint
- [x] full repo `make test` via pre-push hook (3118 tests passing)
- [x] Spec-conformance unit tests for the `SessionModeState` wire shape, validation errors, idempotency, fork inheritance, and end-to-end policy enforcement (architect blocks `write_file`, code allows it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)