### PR TITLE
Namespace ACP vendor-extension session-update fields under _meta.harn (#905)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,29 @@ condensed series summaries instead of full per-patch history.
 
 ### Fixed
 
+- **ACP vendor-extension session-update payloads follow `_meta.harn`
+  (#905).** Harn-specific session-update variants now ride their vendor
+  fields under `update._meta.harn` rather than the update root,
+  completing the namespacing pass started in #904. Affected variants:
+  `progress` (`phase`, `message`, `progress`, `total`, `data`), `log`
+  (`level`, `message`, `fields`), `fs_watch` (`subscriptionId`,
+  `events`), `worker_update` (`workerId`, `workerName`, `workerTask`,
+  `workerMode`, `event`, `status`, `terminal`, `metadata`, `audit`),
+  `transcript_compacted` (`mode`, `strategy`, `archivedMessages`,
+  `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId`),
+  `handoff` (`handoffId`, `artifactId`, `handoff`), `skill_activated` /
+  `skill_deactivated` / `skill_scope_tools` (`skillName`, `iteration`,
+  `reason`, `allowedTools`), and `tool_search_query` /
+  `tool_search_result` (`toolUseId`, `name`, `query`, `promoted`,
+  `strategy`, `mode`). Content extensions `visible_text` /
+  `visible_delta` on `agent_message_chunk` move under
+  `content._meta.harn`. The canonical `sessionUpdate` discriminator and
+  the ACP `content` block stay at their top-level locations. Burin Code
+  and other ACP hosts must migrate to the new field locations before
+  consuming this release; pre-#905 fixtures will fail to render. Burin
+  Code consumer migration is tracked in
+  [burin-code#511](https://github.com/burin-labs/burin-code/issues/511).
+
 - **ACP tool-call extension metadata follows `_meta.harn` (#904).**
   Harn-specific `tool_call` / `tool_call_update` fields (`audit`,
   `durationMs`, `executionDurationMs`, `error`, `errorCategory`,

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -61,18 +61,38 @@ impl AcpAgentEventSink {
         update: &mut serde_json::Value,
         harn_meta: serde_json::Map<String, serde_json::Value>,
     ) {
-        if harn_meta.is_empty() {
-            return;
-        }
-        let Some(update) = update.as_object_mut() else {
-            return;
-        };
-        update.insert(
-            "_meta".to_string(),
-            serde_json::json!({
-                "harn": harn_meta,
-            }),
-        );
+        merge_harn_meta(update, harn_meta);
+    }
+}
+
+/// Merge `harn_meta` keys into `value._meta.harn`, creating intermediate
+/// objects as needed. Existing `_meta.harn` keys are preserved (unless
+/// overwritten by `harn_meta`). No-op when `harn_meta` is empty or
+/// `value` is not a JSON object.
+pub(super) fn merge_harn_meta(
+    value: &mut serde_json::Value,
+    harn_meta: serde_json::Map<String, serde_json::Value>,
+) {
+    if harn_meta.is_empty() {
+        return;
+    }
+    let Some(obj) = value.as_object_mut() else {
+        return;
+    };
+    let meta = obj
+        .entry("_meta".to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    let Some(meta_obj) = meta.as_object_mut() else {
+        return;
+    };
+    let harn = meta_obj
+        .entry("harn".to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+    let Some(harn_obj) = harn.as_object_mut() else {
+        return;
+    };
+    for (k, v) in harn_meta {
+        harn_obj.insert(k, v);
     }
 }
 
@@ -84,16 +104,25 @@ impl AgentEventSink for AcpAgentEventSink {
                 content,
             } => {
                 let visible = sanitize_visible_assistant_text(content, true);
+                let mut content_block = serde_json::json!({
+                    "type": "text",
+                    "text": content,
+                });
+                let mut content_meta = serde_json::Map::new();
+                content_meta.insert(
+                    "visible_text".to_string(),
+                    serde_json::Value::String(visible.clone()),
+                );
+                content_meta.insert(
+                    "visible_delta".to_string(),
+                    serde_json::Value::String(visible),
+                );
+                merge_harn_meta(&mut content_block, content_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
                     "update": {
                         "sessionUpdate": "agent_message_chunk",
-                        "content": {
-                            "type": "text",
-                            "text": content,
-                            "visible_text": visible.clone(),
-                            "visible_delta": visible,
-                        },
+                        "content": content_block,
                     },
                 }));
             }
@@ -249,14 +278,23 @@ impl AgentEventSink for AcpAgentEventSink {
                 iteration,
                 reason,
             } => {
+                let mut update = serde_json::json!({
+                    "sessionUpdate": "skill_activated",
+                });
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert(
+                    "skillName".to_string(),
+                    serde_json::Value::String(skill_name.clone()),
+                );
+                harn_meta.insert("iteration".to_string(), serde_json::Value::from(*iteration));
+                harn_meta.insert(
+                    "reason".to_string(),
+                    serde_json::Value::String(reason.clone()),
+                );
+                merge_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
-                    "update": {
-                        "sessionUpdate": "skill_activated",
-                        "skillName": skill_name,
-                        "iteration": iteration,
-                        "reason": reason,
-                    },
+                    "update": update,
                 }));
             }
             AgentEvent::SkillDeactivated {
@@ -264,13 +302,19 @@ impl AgentEventSink for AcpAgentEventSink {
                 skill_name,
                 iteration,
             } => {
+                let mut update = serde_json::json!({
+                    "sessionUpdate": "skill_deactivated",
+                });
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert(
+                    "skillName".to_string(),
+                    serde_json::Value::String(skill_name.clone()),
+                );
+                harn_meta.insert("iteration".to_string(), serde_json::Value::from(*iteration));
+                merge_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
-                    "update": {
-                        "sessionUpdate": "skill_deactivated",
-                        "skillName": skill_name,
-                        "iteration": iteration,
-                    },
+                    "update": update,
                 }));
             }
             AgentEvent::SkillScopeTools {
@@ -278,13 +322,22 @@ impl AgentEventSink for AcpAgentEventSink {
                 skill_name,
                 allowed_tools,
             } => {
+                let mut update = serde_json::json!({
+                    "sessionUpdate": "skill_scope_tools",
+                });
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert(
+                    "skillName".to_string(),
+                    serde_json::Value::String(skill_name.clone()),
+                );
+                harn_meta.insert(
+                    "allowedTools".to_string(),
+                    serde_json::to_value(allowed_tools).unwrap_or_default(),
+                );
+                merge_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
-                    "update": {
-                        "sessionUpdate": "skill_scope_tools",
-                        "skillName": skill_name,
-                        "allowedTools": allowed_tools,
-                    },
+                    "update": update,
                 }));
             }
             AgentEvent::ToolSearchQuery {
@@ -295,16 +348,25 @@ impl AgentEventSink for AcpAgentEventSink {
                 strategy,
                 mode,
             } => {
+                let mut update = serde_json::json!({
+                    "sessionUpdate": "tool_search_query",
+                });
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert(
+                    "toolUseId".to_string(),
+                    serde_json::Value::String(tool_use_id.clone()),
+                );
+                harn_meta.insert("name".to_string(), serde_json::Value::String(name.clone()));
+                harn_meta.insert("query".to_string(), query.clone());
+                harn_meta.insert(
+                    "strategy".to_string(),
+                    serde_json::Value::String(strategy.clone()),
+                );
+                harn_meta.insert("mode".to_string(), serde_json::Value::String(mode.clone()));
+                merge_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
-                    "update": {
-                        "sessionUpdate": "tool_search_query",
-                        "toolUseId": tool_use_id,
-                        "name": name,
-                        "query": query,
-                        "strategy": strategy,
-                        "mode": mode,
-                    },
+                    "update": update,
                 }));
             }
             AgentEvent::ToolSearchResult {
@@ -314,15 +376,27 @@ impl AgentEventSink for AcpAgentEventSink {
                 strategy,
                 mode,
             } => {
+                let mut update = serde_json::json!({
+                    "sessionUpdate": "tool_search_result",
+                });
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert(
+                    "toolUseId".to_string(),
+                    serde_json::Value::String(tool_use_id.clone()),
+                );
+                harn_meta.insert(
+                    "promoted".to_string(),
+                    serde_json::to_value(promoted).unwrap_or_default(),
+                );
+                harn_meta.insert(
+                    "strategy".to_string(),
+                    serde_json::Value::String(strategy.clone()),
+                );
+                harn_meta.insert("mode".to_string(), serde_json::Value::String(mode.clone()));
+                merge_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
-                    "update": {
-                        "sessionUpdate": "tool_search_result",
-                        "toolUseId": tool_use_id,
-                        "promoted": promoted,
-                        "strategy": strategy,
-                        "mode": mode,
-                    },
+                    "update": update,
                 }));
             }
             AgentEvent::TranscriptCompacted {
@@ -334,17 +408,38 @@ impl AgentEventSink for AcpAgentEventSink {
                 estimated_tokens_after,
                 snapshot_asset_id,
             } => {
+                let mut update = serde_json::json!({
+                    "sessionUpdate": "transcript_compacted",
+                });
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert("mode".to_string(), serde_json::Value::String(mode.clone()));
+                harn_meta.insert(
+                    "strategy".to_string(),
+                    serde_json::Value::String(strategy.clone()),
+                );
+                harn_meta.insert(
+                    "archivedMessages".to_string(),
+                    serde_json::Value::from(*archived_messages),
+                );
+                harn_meta.insert(
+                    "estimatedTokensBefore".to_string(),
+                    serde_json::Value::from(*estimated_tokens_before),
+                );
+                harn_meta.insert(
+                    "estimatedTokensAfter".to_string(),
+                    serde_json::Value::from(*estimated_tokens_after),
+                );
+                harn_meta.insert(
+                    "snapshotAssetId".to_string(),
+                    match snapshot_asset_id {
+                        Some(id) => serde_json::Value::String(id.clone()),
+                        None => serde_json::Value::Null,
+                    },
+                );
+                merge_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
-                    "update": {
-                        "sessionUpdate": "transcript_compacted",
-                        "mode": mode,
-                        "strategy": strategy,
-                        "archivedMessages": archived_messages,
-                        "estimatedTokensBefore": estimated_tokens_before,
-                        "estimatedTokensAfter": estimated_tokens_after,
-                        "snapshotAssetId": snapshot_asset_id,
-                    },
+                    "update": update,
                 }));
             }
             AgentEvent::Handoff {
@@ -352,14 +447,26 @@ impl AgentEventSink for AcpAgentEventSink {
                 artifact_id,
                 handoff,
             } => {
+                let mut update = serde_json::json!({
+                    "sessionUpdate": "handoff",
+                });
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert(
+                    "handoffId".to_string(),
+                    serde_json::Value::String(handoff.id.clone()),
+                );
+                harn_meta.insert(
+                    "artifactId".to_string(),
+                    serde_json::Value::String(artifact_id.clone()),
+                );
+                harn_meta.insert(
+                    "handoff".to_string(),
+                    serde_json::to_value(handoff).unwrap_or_default(),
+                );
+                merge_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
-                    "update": {
-                        "sessionUpdate": "handoff",
-                        "handoffId": handoff.id,
-                        "artifactId": artifact_id,
-                        "handoff": handoff,
-                    },
+                    "update": update,
                 }));
             }
             AgentEvent::FsWatch {
@@ -367,13 +474,22 @@ impl AgentEventSink for AcpAgentEventSink {
                 subscription_id,
                 events,
             } => {
+                let mut update = serde_json::json!({
+                    "sessionUpdate": "fs_watch",
+                });
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert(
+                    "subscriptionId".to_string(),
+                    serde_json::Value::String(subscription_id.clone()),
+                );
+                harn_meta.insert(
+                    "events".to_string(),
+                    serde_json::to_value(events).unwrap_or_default(),
+                );
+                merge_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
-                    "update": {
-                        "sessionUpdate": "fs_watch",
-                        "subscriptionId": subscription_id,
-                        "events": events,
-                    },
+                    "update": update,
                 }));
             }
             AgentEvent::WorkerUpdate {
@@ -389,18 +505,41 @@ impl AgentEventSink for AcpAgentEventSink {
             } => {
                 let mut update = serde_json::json!({
                     "sessionUpdate": "worker_update",
-                    "workerId": worker_id,
-                    "workerName": worker_name,
-                    "workerTask": worker_task,
-                    "workerMode": worker_mode,
-                    "event": event.as_str(),
-                    "status": status,
-                    "terminal": event.is_terminal(),
-                    "metadata": metadata,
                 });
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert(
+                    "workerId".to_string(),
+                    serde_json::Value::String(worker_id.clone()),
+                );
+                harn_meta.insert(
+                    "workerName".to_string(),
+                    serde_json::Value::String(worker_name.clone()),
+                );
+                harn_meta.insert(
+                    "workerTask".to_string(),
+                    serde_json::Value::String(worker_task.clone()),
+                );
+                harn_meta.insert(
+                    "workerMode".to_string(),
+                    serde_json::Value::String(worker_mode.clone()),
+                );
+                harn_meta.insert(
+                    "event".to_string(),
+                    serde_json::Value::String(event.as_str().to_string()),
+                );
+                harn_meta.insert(
+                    "status".to_string(),
+                    serde_json::Value::String(status.clone()),
+                );
+                harn_meta.insert(
+                    "terminal".to_string(),
+                    serde_json::Value::Bool(event.is_terminal()),
+                );
+                harn_meta.insert("metadata".to_string(), metadata.clone());
                 if let Some(audit) = audit {
-                    update["audit"] = audit.clone();
+                    harn_meta.insert("audit".to_string(), audit.clone());
                 }
+                merge_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,
                     "update": update,
@@ -737,15 +876,19 @@ mod tests {
             assert_eq!(payload["params"]["sessionId"], "session-1");
             let update = &payload["params"]["update"];
             assert_eq!(update["sessionUpdate"], "worker_update");
-            assert_eq!(update["workerId"], "worker-1");
-            assert_eq!(update["workerName"], "review");
-            assert_eq!(update["workerTask"], "review pr");
-            assert_eq!(update["workerMode"], "delegated_stage");
-            assert_eq!(update["event"], worker_event.as_str());
-            assert_eq!(update["status"], status);
-            assert_eq!(update["terminal"], terminal);
-            assert_eq!(update["metadata"]["child_run_id"], "run_x");
-            assert_eq!(update["audit"]["run_id"], "run_x");
+            // Vendor-extension fields ride under `_meta.harn` per harn#905.
+            let harn_meta = update_harn_meta(&payload);
+            assert_eq!(harn_meta["workerId"], "worker-1");
+            assert_eq!(harn_meta["workerName"], "review");
+            assert_eq!(harn_meta["workerTask"], "review pr");
+            assert_eq!(harn_meta["workerMode"], "delegated_stage");
+            assert_eq!(harn_meta["event"], worker_event.as_str());
+            assert_eq!(harn_meta["status"], status);
+            assert_eq!(harn_meta["terminal"], terminal);
+            assert_eq!(harn_meta["metadata"]["child_run_id"], "run_x");
+            assert_eq!(harn_meta["audit"]["run_id"], "run_x");
+            assert!(update.get("workerId").is_none());
+            assert!(update.get("audit").is_none());
         }
     }
 
@@ -766,6 +909,8 @@ mod tests {
         });
         let line = rx.recv().await.expect("acp worker_update notification");
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        let harn_meta = update_harn_meta(&payload);
+        assert!(harn_meta.get("audit").is_none());
         assert!(payload["params"]["update"].get("audit").is_none());
     }
 
@@ -796,11 +941,15 @@ mod tests {
         let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
         assert_eq!(payload["method"], "session/update");
         assert_eq!(payload["params"]["update"]["sessionUpdate"], "handoff");
-        assert_eq!(payload["params"]["update"]["handoffId"], "handoff-1");
+        // Vendor-extension fields ride under `_meta.harn` per harn#905.
+        let harn_meta = update_harn_meta(&payload);
+        assert_eq!(harn_meta["handoffId"], "handoff-1");
         assert_eq!(
-            payload["params"]["update"]["handoff"]["target_persona_or_human"]["label"],
+            harn_meta["handoff"]["target_persona_or_human"]["label"],
             "review_captain"
         );
+        assert!(payload["params"]["update"].get("handoffId").is_none());
+        assert!(payload["params"]["update"].get("handoff").is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1374,6 +1523,209 @@ mod tests {
             payload["params"]["update"].get("_meta").is_none(),
             "got: {payload}"
         );
+    }
+
+    /// harn#905 conformance: vendor-extension session-update fields
+    /// must travel under `update._meta.harn` and **must not** appear at
+    /// the update root. Canonical ACP fields (`sessionUpdate`, `content`,
+    /// etc.) stay at their canonical locations. This test pins the
+    /// contract field-by-field for every `HARN_SESSION_UPDATE_EXTENSIONS`
+    /// variant the adapter emits so a regression in any one variant
+    /// fails this single test.
+    #[tokio::test(flavor = "current_thread")]
+    async fn vendor_extension_session_update_fields_live_under_meta_harn() {
+        let actual = collect_notifications(extension_fixture_events()).await;
+
+        let expectations: &[(&str, &[&str])] = &[
+            ("skill_activated", &["skillName", "iteration", "reason"]),
+            ("skill_deactivated", &["skillName", "iteration"]),
+            ("skill_scope_tools", &["skillName", "allowedTools"]),
+            (
+                "tool_search_query",
+                &["toolUseId", "name", "query", "strategy", "mode"],
+            ),
+            (
+                "tool_search_result",
+                &["toolUseId", "promoted", "strategy", "mode"],
+            ),
+            (
+                "transcript_compacted",
+                &[
+                    "mode",
+                    "strategy",
+                    "archivedMessages",
+                    "estimatedTokensBefore",
+                    "estimatedTokensAfter",
+                    "snapshotAssetId",
+                ],
+            ),
+            ("handoff", &["handoffId", "artifactId", "handoff"]),
+            ("fs_watch", &["subscriptionId", "events"]),
+            (
+                "worker_update",
+                &[
+                    "workerId",
+                    "workerName",
+                    "workerTask",
+                    "workerMode",
+                    "event",
+                    "status",
+                    "terminal",
+                    "metadata",
+                    "audit",
+                ],
+            ),
+        ];
+
+        assert_eq!(
+            actual.len(),
+            expectations.len(),
+            "fixture event count must match expectations table"
+        );
+
+        for (notification, (variant, vendor_fields)) in actual.iter().zip(expectations.iter()) {
+            let update = &notification["params"]["update"];
+            assert_eq!(
+                update["sessionUpdate"], *variant,
+                "update[{variant}] must keep canonical sessionUpdate at the root"
+            );
+            let harn_meta = &update["_meta"]["harn"];
+            assert!(
+                harn_meta.is_object(),
+                "update[{variant}] must carry _meta.harn object, got: {update}"
+            );
+            for field in *vendor_fields {
+                assert!(
+                    harn_meta.get(field).is_some(),
+                    "update[{variant}]._meta.harn must contain `{field}`, got: {harn_meta}"
+                );
+                assert!(
+                    update.get(field).is_none(),
+                    "update[{variant}].`{field}` must not be emitted at the root, got: {update}"
+                );
+            }
+            // No vendor field other than `_meta` and `sessionUpdate`
+            // should be present at the update root.
+            let update_obj = update.as_object().expect("update is object");
+            for key in update_obj.keys() {
+                assert!(
+                    matches!(key.as_str(), "sessionUpdate" | "_meta"),
+                    "update[{variant}] must not carry root key `{key}` (vendor extension); got: {update}"
+                );
+            }
+        }
+    }
+
+    /// harn#905 conformance: `progress` and `log` are emitted by
+    /// `AcpBridge` (not `AcpAgentEventSink`), so cover them with a
+    /// dedicated bridge-side test. Both variants are entirely
+    /// vendor — every field other than `sessionUpdate` itself must
+    /// land under `_meta.harn`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn bridge_progress_and_log_session_updates_namespace_vendor_fields() {
+        use std::collections::HashMap;
+        use std::rc::Rc;
+        use std::sync::atomic::{AtomicBool, AtomicU64};
+        use std::sync::Arc;
+        use tokio::sync::Mutex as TokioMutex;
+
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let (tx, mut rx) = mpsc::unbounded_channel();
+                let bridge = Rc::new(super::super::AcpBridge {
+                    session_id: "session-1".to_string(),
+                    output: AcpOutput::Channel(tx),
+                    pending: Arc::new(TokioMutex::new(HashMap::new())),
+                    next_id_counter: AtomicU64::new(1),
+                    cancelled: Arc::new(AtomicBool::new(false)),
+                    script_name: std::sync::Mutex::new(String::new()),
+                    assistant_state: std::sync::Mutex::new(
+                        harn_vm::visible_text::VisibleTextState::default(),
+                    ),
+                });
+
+                bridge.send_progress(
+                    "ingest",
+                    "loading",
+                    Some(3),
+                    Some(10),
+                    Some(serde_json::json!({"item": "row-7"})),
+                );
+                let line = rx.recv().await.expect("progress notification");
+                let payload: serde_json::Value =
+                    serde_json::from_str(&line).expect("progress json");
+                let update = &payload["params"]["update"];
+                assert_eq!(update["sessionUpdate"], "progress");
+                let harn_meta = &update["_meta"]["harn"];
+                assert_eq!(harn_meta["phase"], "ingest");
+                assert_eq!(harn_meta["message"], "loading");
+                assert_eq!(harn_meta["progress"], 3);
+                assert_eq!(harn_meta["total"], 10);
+                assert_eq!(harn_meta["data"]["item"], "row-7");
+                for forbidden in ["phase", "message", "progress", "total", "data"] {
+                    assert!(
+                        update.get(forbidden).is_none(),
+                        "progress.{forbidden} must live under _meta.harn, got: {update}"
+                    );
+                }
+
+                bridge.send_log(
+                    "warn",
+                    "deprecated builtin: foo",
+                    Some(serde_json::json!({"builtin": "foo"})),
+                );
+                let line = rx.recv().await.expect("log notification");
+                let payload: serde_json::Value = serde_json::from_str(&line).expect("log json");
+                let update = &payload["params"]["update"];
+                assert_eq!(update["sessionUpdate"], "log");
+                let harn_meta = &update["_meta"]["harn"];
+                assert_eq!(harn_meta["level"], "warn");
+                assert_eq!(harn_meta["message"], "deprecated builtin: foo");
+                assert_eq!(harn_meta["fields"]["builtin"], "foo");
+                for forbidden in ["level", "message", "fields"] {
+                    assert!(
+                        update.get(forbidden).is_none(),
+                        "log.{forbidden} must live under _meta.harn, got: {update}"
+                    );
+                }
+
+                // Optional fields are simply absent under `_meta.harn`,
+                // not promoted back to the root.
+                bridge.send_progress("ingest", "starting", None, None, None);
+                let line = rx.recv().await.expect("minimal progress notification");
+                let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+                let update = &payload["params"]["update"];
+                let harn_meta = &update["_meta"]["harn"];
+                assert!(harn_meta.get("progress").is_none());
+                assert!(harn_meta.get("total").is_none());
+                assert!(harn_meta.get("data").is_none());
+                assert!(update.get("progress").is_none());
+            })
+            .await;
+    }
+
+    /// harn#905 conformance: `agent_message_chunk` is canonical, so the
+    /// content block and its `text` field stay at the canonical
+    /// location; only the harn-specific `visible_text` /
+    /// `visible_delta` content extensions move under `content._meta.harn`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn agent_message_chunk_visible_text_lives_under_content_meta_harn() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+        sink.handle_event(&AgentEvent::AgentMessageChunk {
+            session_id: "session-1".to_string(),
+            content: "hello".to_string(),
+        });
+        let line = rx.recv().await.expect("agent_message_chunk notification");
+        let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+        let content = &payload["params"]["update"]["content"];
+        assert_eq!(content["type"], "text");
+        assert_eq!(content["text"], "hello");
+        assert_eq!(content["_meta"]["harn"]["visible_text"], "hello");
+        assert_eq!(content["_meta"]["harn"]["visible_delta"], "hello");
+        assert!(content.get("visible_text").is_none());
+        assert!(content.get("visible_delta").is_none());
     }
 
     #[test]

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -300,18 +300,27 @@ impl AcpServer {
     #[allow(dead_code)]
     fn send_update(&self, session_id: &str, text: &str) {
         let visible_text = sanitize_visible_assistant_text(text, true);
+        let mut content = serde_json::json!({
+            "type": "text",
+            "text": text,
+        });
+        let mut content_meta = serde_json::Map::new();
+        content_meta.insert(
+            "visible_text".to_string(),
+            serde_json::Value::String(visible_text.clone()),
+        );
+        content_meta.insert(
+            "visible_delta".to_string(),
+            serde_json::Value::String(visible_text),
+        );
+        events::merge_harn_meta(&mut content, content_meta);
         self.send_notification(
             "session/update",
             serde_json::json!({
                 "sessionId": session_id,
                 "update": {
                     "sessionUpdate": "agent_message_chunk",
-                    "content": {
-                        "type": "text",
-                        "text": text,
-                        "visible_text": visible_text.clone(),
-                        "visible_delta": visible_text,
-                    },
+                    "content": content,
                 },
             }),
         );
@@ -1187,18 +1196,27 @@ impl AcpBridge {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .push(text, true);
+        let mut content = serde_json::json!({
+            "type": "text",
+            "text": text,
+        });
+        let mut content_meta = serde_json::Map::new();
+        content_meta.insert(
+            "visible_text".to_string(),
+            serde_json::Value::String(visible_text),
+        );
+        content_meta.insert(
+            "visible_delta".to_string(),
+            serde_json::Value::String(visible_delta),
+        );
+        events::merge_harn_meta(&mut content, content_meta);
         self.send_notification(
             "session/update",
             serde_json::json!({
                 "sessionId": self.session_id,
                 "update": {
                     "sessionUpdate": "agent_message_chunk",
-                    "content": {
-                        "type": "text",
-                        "text": text,
-                        "visible_text": visible_text,
-                        "visible_delta": visible_delta,
-                    },
+                    "content": content,
                 },
             }),
         );
@@ -1206,7 +1224,8 @@ impl AcpBridge {
 
     /// Send a structured `session/update` with progress phase, message,
     /// and data. `progress` is a harn vendor-extension session-update
-    /// variant; canonical ACP has no progress-phase concept.
+    /// variant; canonical ACP has no progress-phase concept, so all
+    /// vendor fields ride under `update._meta.harn`.
     pub(super) fn send_progress(
         &self,
         phase: &str,
@@ -1217,18 +1236,26 @@ impl AcpBridge {
     ) {
         let mut update = serde_json::json!({
             "sessionUpdate": "progress",
-            "phase": phase,
-            "message": message,
         });
+        let mut harn_meta = serde_json::Map::new();
+        harn_meta.insert(
+            "phase".to_string(),
+            serde_json::Value::String(phase.to_string()),
+        );
+        harn_meta.insert(
+            "message".to_string(),
+            serde_json::Value::String(message.to_string()),
+        );
         if let Some(p) = progress {
-            update["progress"] = serde_json::json!(p);
+            harn_meta.insert("progress".to_string(), serde_json::Value::from(p));
         }
         if let Some(t) = total {
-            update["total"] = serde_json::json!(t);
+            harn_meta.insert("total".to_string(), serde_json::Value::from(t));
         }
         if let Some(d) = data {
-            update["data"] = d;
+            harn_meta.insert("data".to_string(), d);
         }
+        events::merge_harn_meta(&mut update, harn_meta);
         self.send_notification(
             "session/update",
             serde_json::json!({
@@ -1240,19 +1267,28 @@ impl AcpBridge {
 
     /// Send a structured `session/update` with log level, message, and
     /// fields. `log` is a harn vendor-extension; canonical ACP has no
-    /// log channel on the session-update stream.
+    /// log channel on the session-update stream, so all vendor fields
+    /// ride under `update._meta.harn`.
     pub(super) fn send_log(&self, level: &str, message: &str, fields: Option<serde_json::Value>) {
         if level == "info" && suppress_default_info_log(message) {
             return;
         }
         let mut update = serde_json::json!({
             "sessionUpdate": "log",
-            "level": level,
-            "message": message,
         });
+        let mut harn_meta = serde_json::Map::new();
+        harn_meta.insert(
+            "level".to_string(),
+            serde_json::Value::String(level.to_string()),
+        );
+        harn_meta.insert(
+            "message".to_string(),
+            serde_json::Value::String(message.to_string()),
+        );
         if let Some(f) = fields {
-            update["fields"] = f;
+            harn_meta.insert("fields".to_string(), f);
         }
+        events::merge_harn_meta(&mut update, harn_meta);
         self.send_notification(
             "session/update",
             serde_json::json!({
@@ -1603,9 +1639,13 @@ mod tests {
                         && message["params"]["update"]["sessionUpdate"] == "agent_message_chunk"
                     {
                         assert_eq!(
-                            message["params"]["update"]["content"]["visible_delta"],
+                            message["params"]["update"]["content"]["_meta"]["harn"]
+                                ["visible_delta"],
                             "hello from acp"
                         );
+                        assert!(message["params"]["update"]["content"]
+                            .get("visible_delta")
+                            .is_none());
                         saw_update = true;
                     }
                     if message["id"] == 4 {
@@ -1706,9 +1746,12 @@ mod tests {
         let update = recv_json(&mut rx).await;
         assert_eq!(update["method"], "session/update");
         assert_eq!(
-            update["params"]["update"]["content"]["visible_delta"],
+            update["params"]["update"]["content"]["_meta"]["harn"]["visible_delta"],
             "Error: missing API key"
         );
+        assert!(update["params"]["update"]["content"]
+            .get("visible_delta")
+            .is_none());
         let error = recv_json(&mut rx).await;
         assert_eq!(error["id"], 2);
         assert_eq!(error["error"]["message"], "missing API key");
@@ -1962,7 +2005,7 @@ mod tests {
         let update = recv_json(&mut rx).await;
         assert_eq!(update["method"], "session/update");
         assert!(
-            update["params"]["update"]["content"]["visible_delta"]
+            update["params"]["update"]["content"]["_meta"]["harn"]["visible_delta"]
                 .as_str()
                 .unwrap_or_default()
                 .contains("Slash commands require `--pipeline"),

--- a/crates/harn-serve/tests/fixtures/acp/session_update_extensions.json
+++ b/crates/harn-serve/tests/fixtures/acp/session_update_extensions.json
@@ -5,53 +5,14 @@
     "params": {
       "sessionId": "session-1",
       "update": {
-        "iteration": 1,
-        "reason": "matched",
-        "sessionUpdate": "skill_activated",
-        "skillName": "rust"
-      }
-    }
-  },
-  {
-    "jsonrpc": "2.0",
-    "method": "session/update",
-    "params": {
-      "sessionId": "session-1",
-      "update": {
-        "iteration": 2,
-        "sessionUpdate": "skill_deactivated",
-        "skillName": "rust"
-      }
-    }
-  },
-  {
-    "jsonrpc": "2.0",
-    "method": "session/update",
-    "params": {
-      "sessionId": "session-1",
-      "update": {
-        "allowedTools": [
-          "read"
-        ],
-        "sessionUpdate": "skill_scope_tools",
-        "skillName": "rust"
-      }
-    }
-  },
-  {
-    "jsonrpc": "2.0",
-    "method": "session/update",
-    "params": {
-      "sessionId": "session-1",
-      "update": {
-        "mode": "client",
-        "name": "tool_search",
-        "query": {
-          "q": "read"
+        "_meta": {
+          "harn": {
+            "iteration": 1,
+            "reason": "matched",
+            "skillName": "rust"
+          }
         },
-        "sessionUpdate": "tool_search_query",
-        "strategy": "semantic",
-        "toolUseId": "search-1"
+        "sessionUpdate": "skill_activated"
       }
     }
   },
@@ -61,65 +22,132 @@
     "params": {
       "sessionId": "session-1",
       "update": {
-        "mode": "client",
-        "promoted": [
-          "read"
-        ],
-        "sessionUpdate": "tool_search_result",
-        "strategy": "semantic",
-        "toolUseId": "search-1"
-      }
-    }
-  },
-  {
-    "jsonrpc": "2.0",
-    "method": "session/update",
-    "params": {
-      "sessionId": "session-1",
-      "update": {
-        "archivedMessages": 3,
-        "estimatedTokensAfter": 40,
-        "estimatedTokensBefore": 100,
-        "mode": "auto",
-        "sessionUpdate": "transcript_compacted",
-        "snapshotAssetId": "asset-1",
-        "strategy": "summary"
-      }
-    }
-  },
-  {
-    "jsonrpc": "2.0",
-    "method": "session/update",
-    "params": {
-      "sessionId": "session-1",
-      "update": {
-        "artifactId": "artifact-1",
-        "handoff": {
-          "_type": "handoff_artifact",
-          "allowed_side_effects": [],
-          "blocked_on": [],
-          "budget_remaining": null,
-          "confidence": null,
-          "created_at": "2026-04-28T00:00:00Z",
-          "deadline_checkback": null,
-          "evidence_refs": [],
-          "files_or_entities_touched": [],
-          "id": "handoff-1",
-          "metadata": {},
-          "open_questions": [],
-          "parent_run_id": null,
-          "reason": "Merge queue requires review",
-          "receipt_links": [],
-          "requested_capabilities": [],
-          "source_persona": "merge_captain",
-          "target_persona_or_human": {
-            "id": "review_captain",
-            "kind": "persona",
-            "label": "review_captain"
-          },
-          "task": "Review the patch"
+        "_meta": {
+          "harn": {
+            "iteration": 2,
+            "skillName": "rust"
+          }
         },
-        "handoffId": "handoff-1",
+        "sessionUpdate": "skill_deactivated"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "_meta": {
+          "harn": {
+            "allowedTools": [
+              "read"
+            ],
+            "skillName": "rust"
+          }
+        },
+        "sessionUpdate": "skill_scope_tools"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "_meta": {
+          "harn": {
+            "mode": "client",
+            "name": "tool_search",
+            "query": {
+              "q": "read"
+            },
+            "strategy": "semantic",
+            "toolUseId": "search-1"
+          }
+        },
+        "sessionUpdate": "tool_search_query"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "_meta": {
+          "harn": {
+            "mode": "client",
+            "promoted": [
+              "read"
+            ],
+            "strategy": "semantic",
+            "toolUseId": "search-1"
+          }
+        },
+        "sessionUpdate": "tool_search_result"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "_meta": {
+          "harn": {
+            "archivedMessages": 3,
+            "estimatedTokensAfter": 40,
+            "estimatedTokensBefore": 100,
+            "mode": "auto",
+            "snapshotAssetId": "asset-1",
+            "strategy": "summary"
+          }
+        },
+        "sessionUpdate": "transcript_compacted"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "_meta": {
+          "harn": {
+            "artifactId": "artifact-1",
+            "handoff": {
+              "_type": "handoff_artifact",
+              "allowed_side_effects": [],
+              "blocked_on": [],
+              "budget_remaining": null,
+              "confidence": null,
+              "created_at": "2026-04-28T00:00:00Z",
+              "deadline_checkback": null,
+              "evidence_refs": [],
+              "files_or_entities_touched": [],
+              "id": "handoff-1",
+              "metadata": {},
+              "open_questions": [],
+              "parent_run_id": null,
+              "reason": "Merge queue requires review",
+              "receipt_links": [],
+              "requested_capabilities": [],
+              "source_persona": "merge_captain",
+              "target_persona_or_human": {
+                "id": "review_captain",
+                "kind": "persona",
+                "label": "review_captain"
+              },
+              "task": "Review the patch"
+            },
+            "handoffId": "handoff-1"
+          }
+        },
         "sessionUpdate": "handoff"
       }
     }
@@ -130,21 +158,25 @@
     "params": {
       "sessionId": "session-1",
       "update": {
-        "events": [
-          {
-            "error": null,
-            "kind": "modify",
-            "paths": [
-              "/tmp/project/src/lib.rs"
+        "_meta": {
+          "harn": {
+            "events": [
+              {
+                "error": null,
+                "kind": "modify",
+                "paths": [
+                  "/tmp/project/src/lib.rs"
+                ],
+                "raw_kind": "Modify(Any)",
+                "relative_paths": [
+                  "src/lib.rs"
+                ]
+              }
             ],
-            "raw_kind": "Modify(Any)",
-            "relative_paths": [
-              "src/lib.rs"
-            ]
+            "subscriptionId": "fsw-1"
           }
-        ],
-        "sessionUpdate": "fs_watch",
-        "subscriptionId": "fsw-1"
+        },
+        "sessionUpdate": "fs_watch"
       }
     }
   },
@@ -154,21 +186,25 @@
     "params": {
       "sessionId": "session-1",
       "update": {
-        "audit": {
-          "run_id": "run_x"
+        "_meta": {
+          "harn": {
+            "audit": {
+              "run_id": "run_x"
+            },
+            "event": "WorkerWaitingForInput",
+            "metadata": {
+              "child_run_id": "run_x",
+              "child_run_path": ".harn-runs/run_x"
+            },
+            "status": "awaiting_input",
+            "terminal": false,
+            "workerId": "worker-1",
+            "workerMode": "delegated_stage",
+            "workerName": "review",
+            "workerTask": "review pr"
+          }
         },
-        "event": "WorkerWaitingForInput",
-        "metadata": {
-          "child_run_id": "run_x",
-          "child_run_path": ".harn-runs/run_x"
-        },
-        "sessionUpdate": "worker_update",
-        "status": "awaiting_input",
-        "terminal": false,
-        "workerId": "worker-1",
-        "workerMode": "delegated_stage",
-        "workerName": "review",
-        "workerTask": "review pr"
+        "sessionUpdate": "worker_update"
       }
     }
   }

--- a/crates/harn-serve/tests/fixtures/acp/session_update_standard.json
+++ b/crates/harn-serve/tests/fixtures/acp/session_update_standard.json
@@ -6,10 +6,14 @@
       "sessionId": "session-1",
       "update": {
         "content": {
+          "_meta": {
+            "harn": {
+              "visible_delta": "hello",
+              "visible_text": "hello"
+            }
+          },
           "text": "hello",
-          "type": "text",
-          "visible_delta": "hello",
-          "visible_text": "hello"
+          "type": "text"
         },
         "sessionUpdate": "agent_message_chunk"
       }

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -84,6 +84,56 @@ Harn's pinned fixtures under `crates/harn-serve/tests/fixtures/acp/` pin
 both the standard and extension shapes so host integrations can reference
 stable examples.
 
+#### Vendor-extension session-update payload namespacing (#905)
+
+Following the
+[ACP extensibility convention](https://agentclientprotocol.com/protocol/extensibility),
+**every vendor field on a Harn extension session-update is emitted under
+`update._meta.harn`** — never as a bare top-level field. The `sessionUpdate`
+discriminator stays at the canonical location so existing dispatchers
+that route on it keep working unchanged. Concretely:
+
+| Update variant         | Vendor fields under `_meta.harn`                                                                                                       |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `progress`             | `phase`, `message`, `progress`, `total`, `data`                                                                                        |
+| `log`                  | `level`, `message`, `fields`                                                                                                           |
+| `fs_watch`             | `subscriptionId`, `events`                                                                                                             |
+| `worker_update`        | `workerId`, `workerName`, `workerTask`, `workerMode`, `event`, `status`, `terminal`, `metadata`, `audit`                               |
+| `transcript_compacted` | `mode`, `strategy`, `archivedMessages`, `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId`                             |
+| `handoff`              | `handoffId`, `artifactId`, `handoff`                                                                                                   |
+| `skill_activated`      | `skillName`, `iteration`, `reason`                                                                                                     |
+| `skill_deactivated`    | `skillName`, `iteration`                                                                                                               |
+| `skill_scope_tools`    | `skillName`, `allowedTools`                                                                                                            |
+| `tool_search_query`    | `toolUseId`, `name`, `query`, `strategy`, `mode`                                                                                       |
+| `tool_search_result`   | `toolUseId`, `promoted`, `strategy`, `mode`                                                                                            |
+
+Hosts migrating from pre-#905 builds must read these fields from
+`_meta.harn.<field>` instead of the update root. The fixture
+`crates/harn-serve/tests/fixtures/acp/session_update_extensions.json`
+pins the new wire shape verbatim.
+
+Content extensions (`visible_text` and `visible_delta` on the
+`agent_message_chunk` content block, advertised via
+`agentCapabilities._meta.harn.contentExtensionFields`) follow the same
+convention but ride under `content._meta.harn` because they extend the
+canonical ACP content block, not the session-update envelope. Example:
+
+```json
+{
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+    "type": "text",
+    "text": "hello",
+    "_meta": {
+      "harn": {
+        "visible_text": "hello",
+        "visible_delta": "hello"
+      }
+    }
+  }
+}
+```
+
 ### `audit` tag
 
 Both `tool_call` and `tool_call_update` carry an optional `_meta.harn.audit`
@@ -267,7 +317,9 @@ expect more events on the same `worker_id` after they fire.
 ACP and A2A adapters subscribe to the canonical `AgentEvent::WorkerUpdate`
 variant and translate it into their respective wire formats from one
 typed source. ACP emits a `session/update` with `sessionUpdate:
-"worker_update"`:
+"worker_update"`. Per the [vendor-extension namespacing
+rule](#vendor-extension-session-update-payload-namespacing-905), all
+worker fields ride under `update._meta.harn`:
 
 ```json
 {
@@ -277,26 +329,30 @@ typed source. ACP emits a `session/update` with `sessionUpdate:
     "sessionId": "session_123",
     "update": {
       "sessionUpdate": "worker_update",
-      "workerId": "worker_abc",
-      "workerName": "review_captain",
-      "workerTask": "Review PR #42",
-      "workerMode": "delegated_stage",
-      "event": "WorkerWaitingForInput",
-      "status": "awaiting_input",
-      "terminal": false,
-      "metadata": {
-        "task": "Review PR #42",
-        "mode": "delegated_stage",
-        "started_at": "0193...",
-        "finished_at": null,
-        "awaiting_started_at": "0193...",
-        "child_run_id": "run_xyz",
-        "child_run_path": ".harn-runs/run_xyz",
-        "snapshot_path": ".harn/workers/worker_abc.json",
-        "audit": { "...": "MutationSessionRecord" },
-        "error": null
-      },
-      "audit": { "...": "MutationSessionRecord" }
+      "_meta": {
+        "harn": {
+          "workerId": "worker_abc",
+          "workerName": "review_captain",
+          "workerTask": "Review PR #42",
+          "workerMode": "delegated_stage",
+          "event": "WorkerWaitingForInput",
+          "status": "awaiting_input",
+          "terminal": false,
+          "metadata": {
+            "task": "Review PR #42",
+            "mode": "delegated_stage",
+            "started_at": "0193...",
+            "finished_at": null,
+            "awaiting_started_at": "0193...",
+            "child_run_id": "run_xyz",
+            "child_run_path": ".harn-runs/run_xyz",
+            "snapshot_path": ".harn/workers/worker_abc.json",
+            "audit": { "...": "MutationSessionRecord" },
+            "error": null
+          },
+          "audit": { "...": "MutationSessionRecord" }
+        }
+      }
     }
   }
 }
@@ -310,10 +366,9 @@ name.
 
 A2A surfaces the same event as a task-stream entry of type
 `worker_update`, scoped to the task whose dispatch spawned the worker.
-The payload mirrors the ACP shape (worker fields under camelCase keys
-plus `metadata`/`audit`). Subscribers receive these alongside the
-existing `status`/`message` events on the SSE / push-notification
-streams.
+A2A is a separate protocol surface and keeps the worker fields at the
+task-stream entry root (it has its own envelope conventions). ACP hosts
+should always read worker fields from `update._meta.harn.<field>`.
 
 Structured Harn plan emissions use the same task stream. When an agent calls
 `emit_plan` or `update_plan`, A2A subscribers receive a `harn_plan` entry with


### PR DESCRIPTION
## Summary

Closes #905. Per the [ACP extensibility convention](https://agentclientprotocol.com/protocol/extensibility), every vendor-extension field on a Harn `session/update` must travel under `_meta.harn` rather than as a bare top-level field. #904 already covered `tool_call` / `tool_call_update`; this PR finishes the namespacing pass for the remaining harn-extension session-update variants and the `agent_message_chunk` content extensions.

The canonical `sessionUpdate` discriminator and the ACP `content` block stay at top level, so existing dispatchers that route on `sessionUpdate` keep working unchanged. Vendor fields for these variants now live under `update._meta.harn`:

- `progress` (`phase`, `message`, `progress`, `total`, `data`)
- `log` (`level`, `message`, `fields`)
- `fs_watch` (`subscriptionId`, `events`)
- `worker_update` (`workerId`, `workerName`, `workerTask`, `workerMode`, `event`, `status`, `terminal`, `metadata`, `audit`)
- `transcript_compacted` (`mode`, `strategy`, `archivedMessages`, `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId`)
- `handoff` (`handoffId`, `artifactId`, `handoff`)
- `skill_activated` / `skill_deactivated` / `skill_scope_tools` (`skillName`, `iteration`, `reason`, `allowedTools`)
- `tool_search_query` / `tool_search_result` (`toolUseId`, `name`, `query`, `promoted`, `strategy`, `mode`)

`agent_message_chunk`'s `visible_text` / `visible_delta` content extensions move under `content._meta.harn` (extending the canonical ACP content block, not the session-update envelope).

A single `merge_harn_meta` helper in `acp/events.rs` deep-merges into `_meta.harn`. It's reused by `AcpAgentEventSink` per-variant handlers and by the in-process `AcpBridge` emitters (`send_progress`, `send_log`, `send_update`).

## Wire-shape conformance

- `crates/harn-serve/tests/fixtures/acp/session_update_extensions.json` and `session_update_standard.json` are pinned to the new shape.
- New tests assert the contract field-by-field for every affected variant:
  - `vendor_extension_session_update_fields_live_under_meta_harn` — covers `AcpAgentEventSink` extensions; asserts each vendor field is present under `_meta.harn` and absent from the update root, and that no non-canonical key leaks to the root.
  - `bridge_progress_and_log_session_updates_namespace_vendor_fields` — covers the `AcpBridge` `progress` / `log` paths.
  - `agent_message_chunk_visible_text_lives_under_content_meta_harn` — covers the content-extension placement.

## Burin Code follow-up

Tracked in [burin-code#511](https://github.com/burin-labs/burin-code/issues/511) — the Swift host needs to migrate its session-update consumers from the old top-level locations to `_meta.harn` before pulling the next harn release.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (via pre-commit)
- [x] `cargo test -p harn-serve --lib` (80 passed)
- [x] `cargo test -p harn-vm --lib agent_events` (19 passed)
- [x] `make check-docs-snippets` (479 checked, 0 failed)
- [x] `make lint-md`
- [ ] CI gate: `make all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)