### PR TITLE
Add Merge Captain mock-repos playground (#1020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,23 @@ condensed series summaries instead of full per-patch history.
   timeout-tier receipt pins, JSONL transcript streaming, persisted receipts,
   run summaries, and a checked-in mock smoke scenario.
 
+- **Merge Captain mock-repos playground (#1020).** New
+  `harn merge-captain mock {init,step,status,serve,cleanup,scenarios}`
+  subcommand tree materializing a real on-disk sandbox: bare + working git
+  repos seeded from a checked-in scenario manifest plus a fake GitHub HTTP
+  server (`pulls`, `pulls/.../merge`, `commits/.../check-runs`,
+  `actions/runs/.../logs`, `merge_queue/queues/...`, `issues`,
+  `issues/.../comments`, `issues/.../labels`). Step actions (`set_check`,
+  `add_pull_request`, `merge_pull_request`, `force_push_author`,
+  `advance_base`, `set_labels`, `set_merge_queue_status`,
+  `set_mergeability`, `advance_time_ms`) flip state declaratively, with
+  the git-native ones producing real commits on the bare remote so the
+  captain's rebase / force-with-lease / merge-queue codepaths run
+  unchanged. Ships three built-in scenarios (`three_repo_basic`,
+  `single_green`, `force_push_drill`) and extends `--backend mock` to
+  detect the on-disk playground and synthesize a canonical sweep
+  transcript from the live state.
+
 - **`llm_stream_call` streaming builtin (#1038).** Native LLM streaming
   builtin returning `Stream<...>` with cancellation support; provider
   capability matrix grows a `streaming` column.

--- a/crates/harn-cli/src/cli.rs
+++ b/crates/harn-cli/src/cli.rs
@@ -2370,6 +2370,88 @@ pub(crate) enum MergeCaptainCommand {
     Run(MergeCaptainRunArgs),
     /// Audit a JSONL transcript against the Merge Captain oracle.
     Audit(MergeCaptainAuditArgs),
+    /// Manage a mock-repos playground (real temp git repos + fake GitHub HTTP).
+    #[command(subcommand)]
+    Mock(MergeCaptainMockCommand),
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum MergeCaptainMockCommand {
+    /// Materialize a playground directory with real bare+working git repos.
+    Init(MergeCaptainMockInitArgs),
+    /// Apply a named scenario step or a one-off action to the playground state.
+    Step(MergeCaptainMockStepArgs),
+    /// Show the playground's current PR / check / history state.
+    Status(MergeCaptainMockStatusArgs),
+    /// Serve the fake GitHub HTTP API backed by the playground.
+    Serve(MergeCaptainMockServeArgs),
+    /// Idempotently remove the playground directory.
+    Cleanup(MergeCaptainMockCleanupArgs),
+    /// List the names of built-in scenarios.
+    Scenarios,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct MergeCaptainMockInitArgs {
+    /// Directory to materialize. Created if missing; refuses to overwrite an
+    /// existing playground unless `--force` is passed.
+    pub dir: String,
+    /// Built-in scenario name (see `mock scenarios`). Mutually exclusive
+    /// with `--manifest`.
+    #[arg(long)]
+    pub scenario: Option<String>,
+    /// Path to a custom scenario manifest (JSON or YAML). Overrides
+    /// `--scenario` when present.
+    #[arg(long)]
+    pub manifest: Option<String>,
+    /// Cleanup any existing playground at DIR first.
+    #[arg(long)]
+    pub force: bool,
+}
+
+#[derive(Debug, Args)]
+#[command(group(
+    ArgGroup::new("merge_captain_mock_step_target")
+        .args(["name", "action"])
+        .multiple(false)
+        .required(true)
+))]
+pub(crate) struct MergeCaptainMockStepArgs {
+    /// Playground directory.
+    pub dir: String,
+    /// Named step from the scenario manifest.
+    #[arg(long, value_name = "STEP")]
+    pub name: Option<String>,
+    /// Inline JSON-encoded `ScenarioAction` for one-off mutations.
+    #[arg(long, value_name = "JSON")]
+    pub action: Option<String>,
+    /// Print machine-readable status JSON instead of a text summary.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct MergeCaptainMockStatusArgs {
+    pub dir: String,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct MergeCaptainMockServeArgs {
+    pub dir: String,
+    /// Bind address (e.g. `127.0.0.1:0` for an ephemeral port).
+    #[arg(long, default_value = "127.0.0.1:0")]
+    pub bind: String,
+    /// Print the resolved bind address as JSON to stdout once the server
+    /// is ready, then keep serving until SIGINT / SIGTERM.
+    #[arg(long)]
+    pub print_addr: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct MergeCaptainMockCleanupArgs {
+    pub dir: String,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/crates/harn-cli/src/commands/merge_captain_mock.rs
+++ b/crates/harn-cli/src/commands/merge_captain_mock.rs
@@ -1,0 +1,717 @@
+//! `harn merge-captain mock` subcommands (#1020) — playground init/step/
+//! status/serve/cleanup, plus the fake GitHub HTTP server.
+//!
+//! The heavy lifting (manifest parsing, on-disk materialization, state
+//! mutation, request handling) lives in
+//! `harn_vm::orchestration::playground`. This module is the thin axum +
+//! clap glue.
+
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use axum::{
+    extract::{Path as AxumPath, Query, State as AxumState},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post, put},
+    Json, Router,
+};
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+
+use harn_vm::orchestration::playground;
+use harn_vm::value::VmError;
+
+use crate::cli::{
+    MergeCaptainMockCleanupArgs, MergeCaptainMockInitArgs, MergeCaptainMockServeArgs,
+    MergeCaptainMockStatusArgs, MergeCaptainMockStepArgs,
+};
+
+pub(crate) fn run_init(args: &MergeCaptainMockInitArgs) -> i32 {
+    if args.scenario.is_some() && args.manifest.is_some() {
+        eprintln!("error: --scenario and --manifest are mutually exclusive");
+        return 2;
+    }
+    let dir = Path::new(&args.dir);
+    let manifest_path = args.manifest.as_ref().map(PathBuf::from);
+    let manifest =
+        match playground::resolve_init_manifest(args.scenario.as_deref(), manifest_path.as_deref())
+        {
+            Ok(m) => m,
+            Err(error) => {
+                eprintln!("error: {error}");
+                return 1;
+            }
+        };
+    if args.force {
+        if let Err(error) = playground::cleanup_playground_at(dir) {
+            eprintln!("error: {error}");
+            return 1;
+        }
+    }
+    let state = match playground::init_playground_at(playground::InitOptions {
+        dir,
+        manifest: &manifest,
+        allow_existing: false,
+    }) {
+        Ok(state) => state,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return 1;
+        }
+    };
+    let summary = json!({
+        "scenario": state.scenario,
+        "owner": state.owner,
+        "dir": dir.display().to_string(),
+        "repos": state.repos.values().map(|r| json!({
+            "name": r.name,
+            "default_branch": r.default_branch,
+            "remote_url": r.remote_url,
+            "branches": r.branches,
+        })).collect::<Vec<_>>(),
+        "pull_requests": state.pull_requests.values().map(|pr| json!({
+            "repo": pr.repo,
+            "number": pr.number,
+            "head_branch": pr.head_branch,
+            "base_branch": pr.base_branch,
+            "state": pr.state,
+            "head_sha": pr.head_sha,
+        })).collect::<Vec<_>>(),
+    });
+    print_json(&summary);
+    0
+}
+
+pub(crate) fn run_cleanup(args: &MergeCaptainMockCleanupArgs) -> i32 {
+    let dir = Path::new(&args.dir);
+    match playground::cleanup_playground_at(dir) {
+        Ok(true) => {
+            println!("removed {}", dir.display());
+            0
+        }
+        Ok(false) => {
+            println!("nothing to remove at {}", dir.display());
+            0
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            1
+        }
+    }
+}
+
+pub(crate) fn run_status(args: &MergeCaptainMockStatusArgs) -> i32 {
+    let dir = Path::new(&args.dir);
+    let (state, manifest) = match playground::load_playground(dir) {
+        Ok(pair) => pair,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return 1;
+        }
+    };
+    let body = json!({
+        "scenario": state.scenario,
+        "owner": state.owner,
+        "step_count": state.step_count,
+        "now_ms": state.now_ms,
+        "repos": state.repos.values().map(|r| json!({
+            "name": r.name,
+            "default_branch": r.default_branch,
+            "branches": r.branches,
+            "remote_url": r.remote_url,
+        })).collect::<Vec<_>>(),
+        "pull_requests": state.pull_requests.values().map(|pr| json!({
+            "key": pr.key(),
+            "title": pr.title,
+            "state": pr.state,
+            "head_branch": pr.head_branch,
+            "base_branch": pr.base_branch,
+            "head_sha": pr.head_sha,
+            "labels": pr.labels,
+            "checks": pr.checks,
+            "mergeable": pr.mergeable,
+            "mergeable_state": pr.mergeable_state,
+            "merge_queue_status": pr.merge_queue_status,
+            "comments": pr.comments.len(),
+        })).collect::<Vec<_>>(),
+        "available_steps": manifest.steps.iter().map(|s| json!({
+            "name": s.name,
+            "description": s.description,
+            "actions": s.actions.len(),
+        })).collect::<Vec<_>>(),
+        "history": state.history,
+    });
+    if args.json {
+        print_json(&body);
+    } else {
+        print_status_text(&state);
+    }
+    0
+}
+
+pub(crate) fn run_step(args: &MergeCaptainMockStepArgs) -> i32 {
+    let dir = Path::new(&args.dir);
+    let (mut state, manifest) = match playground::load_playground(dir) {
+        Ok(pair) => pair,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return 1;
+        }
+    };
+
+    let report = if let Some(name) = &args.name {
+        match playground::run_named_step(dir, &mut state, &manifest, name) {
+            Ok(report) => report,
+            Err(error) => {
+                eprintln!("error: {error}");
+                return 1;
+            }
+        }
+    } else {
+        let raw = args
+            .action
+            .as_ref()
+            .expect("clap ArgGroup ensures one is set");
+        let action: playground::ScenarioAction = match serde_json::from_str(raw) {
+            Ok(a) => a,
+            Err(error) => {
+                eprintln!("error: failed to parse --action JSON: {error}");
+                return 2;
+            }
+        };
+        match playground::apply_one_action(dir, &mut state, &manifest, &action) {
+            Ok(report) => report,
+            Err(error) => {
+                eprintln!("error: {error}");
+                return 1;
+            }
+        }
+    };
+    if let Err(error) = state.save(dir) {
+        eprintln!("error: {error}");
+        return 1;
+    }
+    let body = json!({
+        "actions_applied": report.actions_applied,
+        "prs_touched": report.prs_touched,
+        "summary": report.summary,
+        "step_count": state.step_count,
+    });
+    if args.json {
+        print_json(&body);
+    } else {
+        for line in &report.summary {
+            println!("{line}");
+        }
+        println!(
+            "applied {} action(s) ({} PR(s) touched)",
+            report.actions_applied,
+            report.prs_touched.len()
+        );
+    }
+    0
+}
+
+pub(crate) fn run_scenarios() -> i32 {
+    for name in playground::builtin_scenario_names() {
+        match playground::load_builtin(name) {
+            Ok(m) => {
+                println!("{}\t{}", name, m.description);
+            }
+            Err(error) => {
+                eprintln!("error: built-in scenario {name} failed to load: {error}");
+                return 1;
+            }
+        }
+    }
+    0
+}
+
+pub(crate) async fn run_serve(args: &MergeCaptainMockServeArgs) -> i32 {
+    let dir = PathBuf::from(&args.dir);
+    let (state, _manifest) = match playground::load_playground(&dir) {
+        Ok(pair) => pair,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return 1;
+        }
+    };
+    let bind: SocketAddr = match args.bind.parse() {
+        Ok(addr) => addr,
+        Err(error) => {
+            eprintln!("error: invalid --bind address {:?}: {error}", args.bind);
+            return 2;
+        }
+    };
+    let app_state = ServerState::new(dir.clone(), state);
+    let router = build_router(app_state);
+    let listener = match TcpListener::bind(bind).await {
+        Ok(l) => l,
+        Err(error) => {
+            eprintln!("error: failed to bind {bind}: {error}");
+            return 1;
+        }
+    };
+    let resolved = match listener.local_addr() {
+        Ok(addr) => addr,
+        Err(error) => {
+            eprintln!("error: failed to resolve bind address: {error}");
+            return 1;
+        }
+    };
+    if args.print_addr {
+        let summary = json!({
+            "_type": "merge_captain_playground_serve",
+            "addr": resolved.to_string(),
+            "playground": dir.display().to_string(),
+        });
+        println!("{}", summary);
+    } else {
+        eprintln!("serving fake GitHub on http://{resolved} (Ctrl-C to stop)");
+    }
+    if let Err(error) = axum::serve(listener, router).await {
+        eprintln!("error: serve failed: {error}");
+        return 1;
+    }
+    0
+}
+
+#[derive(Clone)]
+pub(crate) struct ServerState {
+    dir: PathBuf,
+    state: Arc<Mutex<playground::PlaygroundState>>,
+}
+
+impl ServerState {
+    fn new(dir: PathBuf, state: playground::PlaygroundState) -> Self {
+        ServerState {
+            dir,
+            state: Arc::new(Mutex::new(state)),
+        }
+    }
+
+    fn with_read<R>(&self, f: impl FnOnce(&playground::PlaygroundState) -> R) -> R {
+        let guard = self.state.lock().expect("playground state mutex poisoned");
+        f(&guard)
+    }
+
+    fn with_write<R>(
+        &self,
+        f: impl FnOnce(&mut playground::PlaygroundState) -> R,
+    ) -> Result<R, VmError> {
+        let mut guard = self.state.lock().expect("playground state mutex poisoned");
+        let value = f(&mut guard);
+        guard.save(&self.dir)?;
+        Ok(value)
+    }
+}
+
+pub(crate) fn build_router(state: ServerState) -> Router {
+    Router::new()
+        .route("/repos/{owner}/{repo}/pulls", get(handle_list_pulls))
+        .route(
+            "/repos/{owner}/{repo}/pulls/{number}",
+            get(handle_get_pull).patch(handle_patch_pull),
+        )
+        .route(
+            "/repos/{owner}/{repo}/pulls/{number}/files",
+            get(handle_list_pull_files),
+        )
+        .route(
+            "/repos/{owner}/{repo}/pulls/{number}/merge",
+            put(handle_merge_pull),
+        )
+        .route(
+            "/repos/{owner}/{repo}/issues/{number}",
+            get(handle_get_issue),
+        )
+        .route(
+            "/repos/{owner}/{repo}/issues/{number}/comments",
+            get(handle_list_issue_comments).post(handle_create_issue_comment),
+        )
+        .route(
+            "/repos/{owner}/{repo}/issues/{number}/labels",
+            put(handle_set_labels),
+        )
+        .route(
+            "/repos/{owner}/{repo}/commits/{sha}/check-runs",
+            get(handle_list_check_runs),
+        )
+        .route(
+            "/repos/{owner}/{repo}/actions/runs/{run_id}/logs",
+            get(handle_workflow_run_logs),
+        )
+        .route(
+            "/repos/{owner}/{repo}/merge_queue/queues/{base}",
+            get(handle_merge_queue_status),
+        )
+        .route(
+            "/repos/{owner}/{repo}/merge_queue/queues/{base}/items",
+            post(handle_merge_queue_enqueue),
+        )
+        .route("/_playground/state", get(handle_state_dump))
+        .route(
+            "/_playground/healthz",
+            get(|| async { (StatusCode::OK, "ok") }),
+        )
+        .with_state(state)
+        .fallback(handle_fallback)
+}
+
+async fn handle_list_pulls(
+    AxumState(state): AxumState<ServerState>,
+    AxumPath((owner, repo)): AxumPath<(String, String)>,
+    Query(query): Query<playground::ListPullsQuery>,
+) -> impl IntoResponse {
+    let response = state.with_read(|s| playground::list_pulls(s, &owner, &repo, &query));
+    fake_into_response(response)
+}
+
+async fn handle_get_pull(
+    AxumState(state): AxumState<ServerState>,
+    AxumPath((owner, repo, number)): AxumPath<(String, String, u64)>,
+) -> impl IntoResponse {
+    let response = state.with_read(|s| playground::get_pull(s, &owner, &repo, number));
+    fake_into_response(response)
+}
+
+async fn handle_list_pull_files(
+    AxumState(state): AxumState<ServerState>,
+    AxumPath((owner, repo, number)): AxumPath<(String, String, u64)>,
+) -> impl IntoResponse {
+    let response = state.with_read(|s| playground::list_pull_files(s, &owner, &repo, number));
+    fake_into_response(response)
+}
+
+async fn handle_patch_pull(
+    AxumState(state): AxumState<ServerState>,
+    AxumPath((owner, repo, number)): AxumPath<(String, String, u64)>,
+    Json(body): Json<playground::UpdatePullBody>,
+) -> impl IntoResponse {
+    match state.with_write(|s| playground::patch_pull(s, &owner, &repo, number, body.clone())) {
+        Ok(response) => fake_into_response(response),
+        Err(error) => fake_into_response(playground::FakeResponse {
+            status: 500,
+            body: json!({"message": error.to_string()}),
+        }),
+    }
+}
+
+async fn handle_merge_pull(
+    AxumState(state): AxumState<ServerState>,
+    AxumPath((owner, repo, number)): AxumPath<(String, String, u64)>,
+    body: Option<Json<playground::MergePullBody>>,
+) -> impl IntoResponse {
+    let payload = body.map(|j| j.0).unwrap_or_default();
+    match state.with_write(|s| playground::merge_pull(s, &owner, &repo, number, payload.clone())) {
+        Ok(response) => fake_into_response(response),
+        Err(error) => fake_into_response(playground::FakeResponse {
+            status: 500,
+            body: json!({"message": error.to_string()}),
+        }),
+    }
+}
+
+async fn handle_list_check_runs(
+    AxumState(state): AxumState<ServerState>,
+    AxumPath((owner, repo, sha)): AxumPath<(String, String, String)>,
+) -> impl IntoResponse {
+    let response = state.with_read(|s| playground::list_check_runs(s, &owner, &repo, &sha));
+    fake_into_response(response)
+}
+
+async fn handle_workflow_run_logs(
+    AxumState(state): AxumState<ServerState>,
+    AxumPath((owner, repo, run_id)): AxumPath<(String, String, u64)>,
+) -> impl IntoResponse {
+    let response = state.with_read(|s| playground::workflow_run_logs(s, &owner, &repo, run_id));
+    fake_into_response(response)
+}
+
+async fn handle_get_issue(
+    AxumState(state): AxumState<ServerState>,
+    AxumPath((owner, repo, number)): AxumPath<(String, String, u64)>,
+) -> impl IntoResponse {
+    let response = state.with_read(|s| playground::get_issue(s, &owner, &repo, number));
+    fake_into_response(response)
+}
+
+async fn handle_list_issue_comments(
+    AxumState(state): AxumState<ServerState>,
+    AxumPath((owner, repo, number)): AxumPath<(String, String, u64)>,
+) -> impl IntoResponse {
+    let response = state.with_read(|s| playground::list_issue_comments(s, &owner, &repo, number));
+    fake_into_response(response)
+}
+
+async fn handle_create_issue_comment(
+    AxumState(state): AxumState<ServerState>,
+    AxumPath((owner, repo, number)): AxumPath<(String, String, u64)>,
+    Json(body): Json<playground::CreateCommentBody>,
+) -> impl IntoResponse {
+    match state
+        .with_write(|s| playground::create_issue_comment(s, &owner, &repo, number, body.clone()))
+    {
+        Ok(response) => fake_into_response(response),
+        Err(error) => fake_into_response(playground::FakeResponse {
+            status: 500,
+            body: json!({"message": error.to_string()}),
+        }),
+    }
+}
+
+async fn handle_set_labels(
+    AxumState(state): AxumState<ServerState>,
+    AxumPath((owner, repo, number)): AxumPath<(String, String, u64)>,
+    Json(body): Json<playground::SetLabelsBody>,
+) -> impl IntoResponse {
+    match state.with_write(|s| playground::set_labels(s, &owner, &repo, number, body.clone())) {
+        Ok(response) => fake_into_response(response),
+        Err(error) => fake_into_response(playground::FakeResponse {
+            status: 500,
+            body: json!({"message": error.to_string()}),
+        }),
+    }
+}
+
+async fn handle_merge_queue_status(
+    AxumState(state): AxumState<ServerState>,
+    AxumPath((owner, repo, base)): AxumPath<(String, String, String)>,
+) -> impl IntoResponse {
+    let response = state.with_read(|s| playground::merge_queue_status(s, &owner, &repo, &base));
+    fake_into_response(response)
+}
+
+async fn handle_merge_queue_enqueue(
+    AxumState(state): AxumState<ServerState>,
+    AxumPath((owner, repo, _base)): AxumPath<(String, String, String)>,
+    Json(body): Json<playground::EnqueueMergeQueueBody>,
+) -> impl IntoResponse {
+    match state.with_write(|s| playground::merge_queue_enqueue(s, &owner, &repo, body.clone())) {
+        Ok(response) => fake_into_response(response),
+        Err(error) => fake_into_response(playground::FakeResponse {
+            status: 500,
+            body: json!({"message": error.to_string()}),
+        }),
+    }
+}
+
+async fn handle_state_dump(AxumState(state): AxumState<ServerState>) -> impl IntoResponse {
+    let body = state.with_read(|s| serde_json::to_value(s).unwrap_or_default());
+    (StatusCode::OK, Json(body))
+}
+
+async fn handle_fallback() -> impl IntoResponse {
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({
+            "message": "fake-github playground: endpoint not implemented",
+            "documentation_url": ""
+        })),
+    )
+}
+
+fn fake_into_response(response: playground::FakeResponse) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::from_u16(response.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+        Json(response.body),
+    )
+}
+
+fn print_status_text(state: &playground::PlaygroundState) {
+    println!("scenario: {}", state.scenario);
+    println!("owner:    {}", state.owner);
+    println!("step_count: {}", state.step_count);
+    println!("repos:");
+    for repo in state.repos.values() {
+        println!(
+            "  {} (default={}, branches={}, remote={})",
+            repo.name,
+            repo.default_branch,
+            repo.branches.len(),
+            repo.remote_url
+        );
+    }
+    println!("pull_requests:");
+    for pr in state.pull_requests.values() {
+        let head_sha = pr.head_sha.as_deref().unwrap_or("?");
+        println!(
+            "  {} state={} head={}@{} mergeable={} state_v3={}",
+            pr.key(),
+            pr.state,
+            pr.head_branch,
+            short_sha(head_sha),
+            match pr.mergeable {
+                Some(true) => "yes",
+                Some(false) => "no",
+                None => "?",
+            },
+            pr.mergeable_state
+        );
+    }
+}
+
+fn short_sha(sha: &str) -> &str {
+    if sha.len() > 7 {
+        &sha[..7]
+    } else {
+        sha
+    }
+}
+
+fn print_json(value: &Value) {
+    match serde_json::to_string_pretty(value) {
+        Ok(text) => println!("{text}"),
+        Err(error) => eprintln!("error: failed to serialize JSON: {error}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use harn_vm::orchestration::playground::{self, ScenarioManifest};
+    use tower::ServiceExt;
+
+    fn make_state() -> ServerState {
+        let manifest =
+            playground::load_builtin("single_green").expect("single_green scenario must parse");
+        let mut state = playground::PlaygroundState::from_manifest(&manifest);
+        // Bypass disk I/O for the unit test by injecting state directly. We
+        // write to a tempdir so `with_write` can save without errors.
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        // Mimic init by setting a remote_url for the repo so endpoints don't
+        // depend on real git.
+        for repo in state.repos.values_mut() {
+            repo.remote_url = format!("file:///tmp/{}.git", repo.name);
+        }
+        // Also stamp a head_sha for the seeded PR.
+        for pr in state.pull_requests.values_mut() {
+            pr.head_sha = Some("aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111".to_string());
+        }
+        // Persist the tempdir for the duration of the test; otherwise the
+        // server's `with_write` would try to save state into a removed dir.
+        let dir = tempdir.keep();
+        ServerState::new(dir, state)
+    }
+
+    fn assert_yaml_manifest_round_trip(_: &ScenarioManifest) {}
+
+    #[tokio::test]
+    async fn list_pulls_returns_open_prs() {
+        let state = make_state();
+        let app = build_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/repos/burin-labs/solo/pulls")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 8 * 1024 * 1024)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        let arr = body.as_array().expect("array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["number"], 1);
+    }
+
+    #[tokio::test]
+    async fn get_pull_returns_one_pr() {
+        let state = make_state();
+        let app = build_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/repos/burin-labs/solo/pulls/1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn unknown_pr_404s() {
+        let state = make_state();
+        let app = build_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/repos/burin-labs/solo/pulls/999")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn create_comment_persists_state() {
+        let state = make_state();
+        let app = build_router(state.clone());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/repos/burin-labs/solo/issues/1/comments")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"body": "hello", "user": "alice"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        // Re-read state and confirm the comment is there.
+        let comments = state.with_read(|s| {
+            let pr = s
+                .pull_requests
+                .get(&playground::PlaygroundPullRequest::compose_key("solo", 1))
+                .unwrap()
+                .clone();
+            pr.comments
+        });
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].user, "alice");
+    }
+
+    #[tokio::test]
+    async fn merge_pull_blocks_dirty() {
+        let state = make_state();
+        // Mark dirty
+        state
+            .with_write(|s| {
+                let pr = s
+                    .pull_requests
+                    .get_mut(&playground::PlaygroundPullRequest::compose_key("solo", 1))
+                    .unwrap();
+                pr.mergeable = Some(false);
+                pr.mergeable_state = "dirty".to_string();
+            })
+            .unwrap();
+        let app = build_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/repos/burin-labs/solo/pulls/1/merge")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"merge_method": "merge"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let _: () =
+            assert_yaml_manifest_round_trip(&playground::load_builtin("single_green").unwrap());
+    }
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod flow;
 pub(crate) mod init;
 pub(crate) mod mcp;
 pub(crate) mod merge_captain;
+pub(crate) mod merge_captain_mock;
 pub mod orchestrator;
 pub(crate) mod persona;
 pub(crate) mod playground;

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -17,9 +17,9 @@ use std::sync::Arc;
 use std::{env, fs, process, thread};
 
 use cli::{
-    Cli, Command, MergeCaptainCommand, ModelInfoArgs, PackageCacheCommand, PackageCommand,
-    PersonaCommand, RunsCommand, ServeCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand,
-    SkillsCommand,
+    Cli, Command, MergeCaptainCommand, MergeCaptainMockCommand, ModelInfoArgs, PackageCacheCommand,
+    PackageCommand, PersonaCommand, RunsCommand, ServeCommand, SkillCommand, SkillKeyCommand,
+    SkillTrustCommand, SkillsCommand,
 };
 use harn_lexer::Lexer;
 use harn_parser::{DiagnosticSeverity, Parser, TypeChecker};
@@ -719,6 +719,31 @@ async fn async_main() {
             }
             MergeCaptainCommand::Audit(audit) => {
                 let code = commands::merge_captain::run_audit(&audit);
+                if code != 0 {
+                    process::exit(code);
+                }
+            }
+            MergeCaptainCommand::Mock(mock) => {
+                let code = match mock {
+                    MergeCaptainMockCommand::Init(args) => {
+                        commands::merge_captain_mock::run_init(&args)
+                    }
+                    MergeCaptainMockCommand::Step(args) => {
+                        commands::merge_captain_mock::run_step(&args)
+                    }
+                    MergeCaptainMockCommand::Status(args) => {
+                        commands::merge_captain_mock::run_status(&args)
+                    }
+                    MergeCaptainMockCommand::Serve(args) => {
+                        commands::merge_captain_mock::run_serve(&args).await
+                    }
+                    MergeCaptainMockCommand::Cleanup(args) => {
+                        commands::merge_captain_mock::run_cleanup(&args)
+                    }
+                    MergeCaptainMockCommand::Scenarios => {
+                        commands::merge_captain_mock::run_scenarios()
+                    }
+                };
                 if code != 0 {
                     process::exit(code);
                 }

--- a/crates/harn-cli/tests/merge_captain_mock_cli.rs
+++ b/crates/harn-cli/tests/merge_captain_mock_cli.rs
@@ -1,0 +1,120 @@
+//! In-process coverage of `harn merge-captain mock` (#1020).
+//!
+//! Mirrors the de-flake / in-process pattern used by
+//! `merge_captain_cli.rs`: every assertion calls the library surface
+//! directly so we don't pay the subprocess tax. The CLI handlers in
+//! `crates/harn-cli/src/commands/merge_captain_mock.rs` are thin
+//! wrappers over the same surface.
+
+use std::path::Path;
+
+use harn_vm::orchestration::playground::{
+    apply_one_action, builtin_scenario_names, cleanup_playground_at, init_playground_at,
+    load_builtin, load_playground, run_named_step, InitOptions, ScenarioAction,
+};
+
+fn git_available() -> bool {
+    std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn skip_if_no_git() -> bool {
+    if !git_available() {
+        eprintln!("(skipping merge-captain mock CLI test — `git` not on PATH)");
+        return true;
+    }
+    false
+}
+
+#[test]
+fn builtin_scenarios_smoke_test() {
+    for name in builtin_scenario_names() {
+        load_builtin(name)
+            .unwrap_or_else(|e| panic!("builtin scenario {name} failed to parse: {e}"));
+    }
+}
+
+#[test]
+fn init_then_step_then_cleanup_round_trip() {
+    if skip_if_no_git() {
+        return;
+    }
+    let temp = tempfile::tempdir().unwrap();
+    let dir = temp.path().join("pg");
+    let manifest = load_builtin("three_repo_basic").unwrap();
+    let _state = init_playground_at(InitOptions {
+        dir: &dir,
+        manifest: &manifest,
+        allow_existing: false,
+    })
+    .unwrap();
+
+    // status load
+    let (mut state, manifest_loaded) = load_playground(&dir).unwrap();
+    assert_eq!(state.scenario, "three_repo_basic");
+    assert_eq!(manifest_loaded.repos.len(), 3);
+    assert_eq!(state.pull_requests.len(), 3);
+
+    // run a step that flips a check + clean mergeable.
+    let report =
+        run_named_step(&dir, &mut state, &manifest_loaded, "gamma_force_push_fix").unwrap();
+    assert!(report.actions_applied >= 1);
+    let pr = state.pull_requests.get("gamma#303").expect("PR gamma#303");
+    assert_eq!(pr.mergeable_state, "clean");
+    assert_eq!(
+        pr.checks
+            .iter()
+            .find(|c| c.name == "ci")
+            .and_then(|c| c.conclusion.clone())
+            .as_deref(),
+        Some("success")
+    );
+    state.save(&dir).unwrap();
+
+    // ad-hoc action also routes through the same code.
+    let action: ScenarioAction = serde_json::from_str(
+        r#"{"kind":"add_comment","repo":"alpha","pr_number":101,"user":"captain","body":"ack"}"#,
+    )
+    .unwrap();
+    let report = apply_one_action(&dir, &mut state, &manifest_loaded, &action).unwrap();
+    assert_eq!(report.actions_applied, 1);
+    assert_eq!(state.pull_requests["alpha#101"].comments.len(), 1);
+
+    // cleanup is idempotent.
+    assert!(cleanup_playground_at(&dir).unwrap());
+    assert!(!cleanup_playground_at(&dir).unwrap());
+}
+
+#[test]
+fn init_force_re_inits_existing_dir() {
+    if skip_if_no_git() {
+        return;
+    }
+    let temp = tempfile::tempdir().unwrap();
+    let dir = temp.path().join("pg");
+    let manifest = load_builtin("single_green").unwrap();
+    init_playground_at(InitOptions {
+        dir: &dir,
+        manifest: &manifest,
+        allow_existing: false,
+    })
+    .unwrap();
+    let err = init_playground_at(InitOptions {
+        dir: &dir,
+        manifest: &manifest,
+        allow_existing: false,
+    })
+    .unwrap_err();
+    assert!(format!("{err}").contains("already initialized"));
+    cleanup_playground_at(&dir).unwrap();
+    init_playground_at(InitOptions {
+        dir: &dir,
+        manifest: &manifest,
+        allow_existing: false,
+    })
+    .unwrap();
+    assert!(Path::new(&dir).join("playground.json").exists());
+}

--- a/crates/harn-vm/src/orchestration/merge_captain_driver.rs
+++ b/crates/harn-vm/src/orchestration/merge_captain_driver.rs
@@ -224,6 +224,24 @@ fn resolve_backend(backend: &MergeCaptainDriverBackend) -> Result<ResolvedScenar
             })
         }
         MergeCaptainDriverBackend::Mock { playground_dir } => {
+            // Prefer the on-disk playground (presence of `playground.json`)
+            // — that's the #1020 surface with real bare git repos. Fall
+            // back to the legacy transcript-replay manifest for backwards
+            // compatibility with examples/merge_captain/playground_3repos.
+            if super::playground::playground_marker_path(playground_dir).exists() {
+                let (state, manifest) = super::playground::load_playground(playground_dir)?;
+                let events = super::playground::synthesize_sweep(
+                    &state,
+                    &super::playground::TranscriptOptions::default(),
+                );
+                let golden = load_playground_golden_if_present(playground_dir)?;
+                return Ok(ResolvedScenario {
+                    events,
+                    golden,
+                    scenario: Some(manifest.scenario),
+                    backend_source: Some(playground_dir.display().to_string()),
+                });
+            }
             let manifest_path = find_mock_manifest(playground_dir)?;
             let bytes = fs::read(&manifest_path).map_err(|error| {
                 VmError::Runtime(format!(
@@ -258,6 +276,16 @@ fn resolve_backend(backend: &MergeCaptainDriverBackend) -> Result<ResolvedScenar
             })
         }
     }
+}
+
+fn load_playground_golden_if_present(
+    playground_dir: &Path,
+) -> Result<Option<MergeCaptainGolden>, VmError> {
+    let candidate = playground_dir.join("golden.json");
+    if candidate.exists() {
+        return load_merge_captain_golden(&candidate).map(Some);
+    }
+    Ok(None)
 }
 
 fn find_mock_manifest(playground_dir: &Path) -> Result<PathBuf, VmError> {
@@ -606,6 +634,48 @@ mod tests {
         assert!(!output.summary.prs_touched.is_empty());
         assert!(output.receipt_path.exists());
         assert!(output.transcript_path.unwrap().exists());
+    }
+
+    #[test]
+    fn mock_backend_drives_real_on_disk_playground() {
+        if std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .map(|o| !o.status.success())
+            .unwrap_or(true)
+        {
+            eprintln!("(skipping — git not on PATH)");
+            return;
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let playground = temp.path().join("pg");
+        let manifest = super::super::playground::load_builtin("single_green").unwrap();
+        super::super::playground::init_playground_at(super::super::playground::InitOptions {
+            dir: &playground,
+            manifest: &manifest,
+            allow_existing: false,
+        })
+        .unwrap();
+        let output = run_merge_captain_driver(MergeCaptainDriverOptions {
+            backend: MergeCaptainDriverBackend::Mock {
+                playground_dir: playground.clone(),
+            },
+            mode: MergeCaptainDriverMode::Once,
+            model_route: None,
+            timeout_tier: None,
+            transcript_out: Some(temp.path().join("event_log.jsonl")),
+            receipt_out: Some(temp.path().join("receipt.json")),
+            run_root: temp.path().join("runs"),
+            max_sweeps: 1,
+            watch_backoff_ms: 0,
+            stream_stdout: false,
+        })
+        .unwrap();
+        assert_eq!(output.summary.backend, "mock");
+        assert_eq!(output.summary.scenario.as_deref(), Some("single_green"));
+        assert!(output.summary.event_count > 0);
+        // PR coverage gets populated from the synthesized transcript.
+        assert!(!output.summary.prs_touched.is_empty());
     }
 
     #[test]

--- a/crates/harn-vm/src/orchestration/mod.rs
+++ b/crates/harn-vm/src/orchestration/mod.rs
@@ -63,6 +63,8 @@ pub use merge_captain_audit::*;
 mod merge_captain_driver;
 pub use merge_captain_driver::*;
 
+pub mod playground;
+
 thread_local! {
     static CURRENT_MUTATION_SESSION: RefCell<Option<MutationSessionRecord>> = const { RefCell::new(None) };
     /// Workflow-level skill context, installed by `workflow_execute` so

--- a/crates/harn-vm/src/orchestration/playground/fake_server.rs
+++ b/crates/harn-vm/src/orchestration/playground/fake_server.rs
@@ -1,0 +1,590 @@
+//! Pure fake-GitHub HTTP request handlers for the Merge Captain mock-repos
+//! playground (#1020). The CLI binds these to an axum `Router`; tests can
+//! call them directly to assert per-endpoint behavior without TCP.
+//!
+//! The endpoint surface is the strict subset the issue calls out:
+//! `pulls`, `checks`, `actions/runs/.../logs`, `merge_queue`, `issues`,
+//! `comments`, `pulls/.../merge`. Every response is sourced from the
+//! mutable `PlaygroundState`; mutating endpoints update the state in
+//! place and return the updated representation.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use super::manifest::ScenarioComment;
+use super::state::{PlaygroundPullRequest, PlaygroundState};
+
+/// Response envelope for any handler.
+#[derive(Clone, Debug, Serialize)]
+pub struct FakeResponse {
+    pub status: u16,
+    pub body: Value,
+}
+
+impl FakeResponse {
+    pub fn ok(body: Value) -> Self {
+        FakeResponse { status: 200, body }
+    }
+    pub fn created(body: Value) -> Self {
+        FakeResponse { status: 201, body }
+    }
+    pub fn not_found(message: &str) -> Self {
+        FakeResponse {
+            status: 404,
+            body: json!({"message": message, "documentation_url": ""}),
+        }
+    }
+    pub fn unprocessable(message: &str) -> Self {
+        FakeResponse {
+            status: 422,
+            body: json!({"message": message, "documentation_url": ""}),
+        }
+    }
+    pub fn bad_request(message: &str) -> Self {
+        FakeResponse {
+            status: 400,
+            body: json!({"message": message, "documentation_url": ""}),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct ListPullsQuery {
+    pub state: Option<String>,
+    pub head: Option<String>,
+    pub base: Option<String>,
+    pub per_page: Option<u32>,
+}
+
+pub fn list_pulls(
+    state: &PlaygroundState,
+    owner: &str,
+    repo: &str,
+    query: &ListPullsQuery,
+) -> FakeResponse {
+    if state.owner != owner {
+        return FakeResponse::not_found(&format!("unknown owner {owner}"));
+    }
+    if !state.repos.contains_key(repo) {
+        return FakeResponse::not_found(&format!("unknown repo {owner}/{repo}"));
+    }
+    let want_state = query
+        .state
+        .clone()
+        .unwrap_or_else(|| "open".to_string())
+        .to_lowercase();
+    let mut prs: Vec<&PlaygroundPullRequest> = state
+        .pull_requests
+        .values()
+        .filter(|pr| pr.repo == repo)
+        .filter(|pr| match want_state.as_str() {
+            "all" => true,
+            other => pr.state.eq_ignore_ascii_case(other),
+        })
+        .filter(|pr| {
+            query
+                .base
+                .as_ref()
+                .map(|b| pr.base_branch == *b)
+                .unwrap_or(true)
+        })
+        .filter(|pr| {
+            query
+                .head
+                .as_ref()
+                .map(|h| {
+                    let parts: Vec<&str> = h.split(':').collect();
+                    let branch = parts.last().copied().unwrap_or("");
+                    pr.head_branch == branch
+                })
+                .unwrap_or(true)
+        })
+        .collect();
+    prs.sort_by_key(|pr| pr.number);
+    let body = Value::Array(prs.iter().map(|pr| pr_to_v3(state, pr)).collect());
+    FakeResponse::ok(body)
+}
+
+pub fn get_pull(state: &PlaygroundState, owner: &str, repo: &str, number: u64) -> FakeResponse {
+    let Some(pr) = pr_lookup(state, owner, repo, number) else {
+        return FakeResponse::not_found(&format!("PR {owner}/{repo}#{number} not found"));
+    };
+    FakeResponse::ok(pr_to_v3(state, pr))
+}
+
+pub fn list_pull_files(
+    state: &PlaygroundState,
+    owner: &str,
+    repo: &str,
+    number: u64,
+) -> FakeResponse {
+    let Some(pr) = pr_lookup(state, owner, repo, number) else {
+        return FakeResponse::not_found(&format!("PR {owner}/{repo}#{number} not found"));
+    };
+    // The fake server doesn't compute real diffs — it returns a stable stub
+    // describing the head_branch/base_branch pair so the consumer can decide
+    // whether to fetch the working tree itself.
+    FakeResponse::ok(json!([
+        {
+            "filename": format!("{}-vs-{}.summary", pr.head_branch, pr.base_branch),
+            "status": "modified",
+            "additions": 1,
+            "deletions": 0,
+            "changes": 1,
+            "patch": ""
+        }
+    ]))
+}
+
+pub fn list_check_runs(
+    state: &PlaygroundState,
+    owner: &str,
+    repo: &str,
+    sha_or_ref: &str,
+) -> FakeResponse {
+    if state.owner != owner || !state.repos.contains_key(repo) {
+        return FakeResponse::not_found("unknown repo");
+    }
+    // Find a PR whose head_sha or head_branch matches the ref/sha.
+    let pr = state.pull_requests.values().find(|pr| {
+        pr.repo == repo
+            && (pr
+                .head_sha
+                .as_deref()
+                .map(|sha| sha == sha_or_ref)
+                .unwrap_or(false)
+                || pr.head_branch == sha_or_ref)
+    });
+    let runs: Vec<Value> = match pr {
+        Some(pr) => pr
+            .checks
+            .iter()
+            .enumerate()
+            .map(|(idx, check)| {
+                json!({
+                    "id": (pr.number * 1000 + idx as u64),
+                    "name": check.name,
+                    "status": check.status,
+                    "conclusion": check.conclusion,
+                    "head_sha": pr.head_sha,
+                    "details_url": check.details_url,
+                    "started_at": check.started_at,
+                    "completed_at": check.completed_at,
+                })
+            })
+            .collect(),
+        None => Vec::new(),
+    };
+    FakeResponse::ok(json!({"total_count": runs.len(), "check_runs": runs}))
+}
+
+pub fn workflow_run_logs(
+    state: &PlaygroundState,
+    owner: &str,
+    repo: &str,
+    run_id: u64,
+) -> FakeResponse {
+    // We don't keep real logs; just return a deterministic synthetic blob
+    // keyed by run_id so connector code that streams logs has something
+    // to assert on.
+    if state.owner != owner || !state.repos.contains_key(repo) {
+        return FakeResponse::not_found("unknown repo");
+    }
+    let body = json!({
+        "run_id": run_id,
+        "log_lines": [
+            format!("[{owner}/{repo}#{run_id}] starting"),
+            format!("[{owner}/{repo}#{run_id}] step 1 / 1 succeeded"),
+            format!("[{owner}/{repo}#{run_id}] finished")
+        ]
+    });
+    FakeResponse::ok(body)
+}
+
+pub fn list_issue_comments(
+    state: &PlaygroundState,
+    owner: &str,
+    repo: &str,
+    number: u64,
+) -> FakeResponse {
+    let Some(pr) = pr_lookup(state, owner, repo, number) else {
+        return FakeResponse::not_found(&format!("PR {owner}/{repo}#{number} not found"));
+    };
+    let body = Value::Array(
+        pr.comments
+            .iter()
+            .enumerate()
+            .map(|(idx, c)| {
+                json!({
+                    "id": pr.number * 1000 + idx as u64,
+                    "body": c.body,
+                    "user": {"login": c.user},
+                    "created_at": c.created_at
+                })
+            })
+            .collect(),
+    );
+    FakeResponse::ok(body)
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct CreateCommentBody {
+    pub body: String,
+    #[serde(default)]
+    pub user: Option<String>,
+}
+
+pub fn create_issue_comment(
+    state: &mut PlaygroundState,
+    owner: &str,
+    repo: &str,
+    number: u64,
+    payload: CreateCommentBody,
+) -> FakeResponse {
+    let pr_key = PlaygroundPullRequest::compose_key(repo, number);
+    if state.owner != owner {
+        return FakeResponse::not_found("unknown owner");
+    }
+    let now_ms = state.now_ms;
+    let id;
+    let user = payload
+        .user
+        .clone()
+        .unwrap_or_else(|| "playground-bot".to_string());
+    let now = format_now(now_ms);
+    {
+        let Some(pr) = state.pull_requests.get_mut(&pr_key) else {
+            return FakeResponse::not_found(&format!("PR {owner}/{repo}#{number} not found"));
+        };
+        pr.comments.push(ScenarioComment {
+            user: user.clone(),
+            body: payload.body.clone(),
+            created_at: Some(now.clone()),
+        });
+        id = pr.number * 1000 + (pr.comments.len() as u64 - 1);
+    }
+    state.record(
+        "fake_server:create_issue_comment",
+        json!({"repo": repo, "number": number, "user": user}),
+    );
+    FakeResponse::created(json!({
+        "id": id,
+        "body": payload.body,
+        "user": {"login": user},
+        "created_at": now
+    }))
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+pub struct UpdatePullBody {
+    pub state: Option<String>,
+    pub title: Option<String>,
+    pub body: Option<String>,
+    pub base: Option<String>,
+    pub labels: Option<Vec<String>>,
+}
+
+pub fn patch_pull(
+    state: &mut PlaygroundState,
+    owner: &str,
+    repo: &str,
+    number: u64,
+    payload: UpdatePullBody,
+) -> FakeResponse {
+    let pr_key = PlaygroundPullRequest::compose_key(repo, number);
+    if state.owner != owner {
+        return FakeResponse::not_found("unknown owner");
+    }
+    let pr_clone = {
+        let Some(pr) = state.pull_requests.get_mut(&pr_key) else {
+            return FakeResponse::not_found(&format!("PR {owner}/{repo}#{number} not found"));
+        };
+        if let Some(s) = payload.state {
+            pr.state = s;
+        }
+        if let Some(t) = payload.title {
+            pr.title = t;
+        }
+        if let Some(b) = payload.body {
+            pr.body = b;
+        }
+        if let Some(base) = payload.base {
+            pr.base_branch = base;
+        }
+        if let Some(labels) = payload.labels {
+            pr.labels = labels;
+        }
+        pr.clone()
+    };
+    state.record(
+        "fake_server:patch_pull",
+        json!({"repo": repo, "number": number}),
+    );
+    FakeResponse::ok(pr_to_v3(state, &pr_clone))
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct MergePullBody {
+    pub merge_method: Option<String>,
+    pub commit_title: Option<String>,
+    pub commit_message: Option<String>,
+}
+
+/// `PUT /repos/:owner/:repo/pulls/:number/merge`. Updates the PR state to
+/// `merged` but does NOT produce a real merge commit on the bare remote —
+/// the connector or `mock step --action merge_pull_request` is responsible
+/// for the git mutation. Mirrors GitHub's API which performs the merge
+/// server-side; here it's a pure state update.
+pub fn merge_pull(
+    state: &mut PlaygroundState,
+    owner: &str,
+    repo: &str,
+    number: u64,
+    payload: MergePullBody,
+) -> FakeResponse {
+    let pr_key = PlaygroundPullRequest::compose_key(repo, number);
+    if state.owner != owner {
+        return FakeResponse::not_found("unknown owner");
+    }
+    let now_ms = state.now_ms;
+    let _method = payload.merge_method.unwrap_or_else(|| "merge".to_string());
+    let head_sha = {
+        let Some(pr) = state.pull_requests.get_mut(&pr_key) else {
+            return FakeResponse::not_found(&format!("PR {owner}/{repo}#{number} not found"));
+        };
+        if pr.state != "open" {
+            return FakeResponse::unprocessable(&format!(
+                "PR {owner}/{repo}#{number} is not open (state={})",
+                pr.state
+            ));
+        }
+        if pr.mergeable == Some(false) || pr.mergeable_state == "dirty" {
+            return FakeResponse::unprocessable(&format!(
+                "PR {owner}/{repo}#{number} is not mergeable (state={})",
+                pr.mergeable_state
+            ));
+        }
+        pr.state = "merged".to_string();
+        pr.merged_at = Some(format_now(now_ms));
+        pr.mergeable_state = "clean".to_string();
+        pr.head_sha.clone()
+    };
+    state.record(
+        "fake_server:merge_pull",
+        json!({"repo": repo, "number": number}),
+    );
+    FakeResponse::ok(json!({
+        "sha": head_sha,
+        "merged": true,
+        "message": "Pull Request successfully merged"
+    }))
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct EnqueueMergeQueueBody {
+    pub pull_number: u64,
+    #[serde(default)]
+    pub priority: Option<String>,
+}
+
+pub fn merge_queue_enqueue(
+    state: &mut PlaygroundState,
+    owner: &str,
+    repo: &str,
+    body: EnqueueMergeQueueBody,
+) -> FakeResponse {
+    let pr_key = PlaygroundPullRequest::compose_key(repo, body.pull_number);
+    if state.owner != owner {
+        return FakeResponse::not_found("unknown owner");
+    }
+    {
+        let Some(pr) = state.pull_requests.get_mut(&pr_key) else {
+            return FakeResponse::not_found(&format!(
+                "PR {owner}/{repo}#{} not found",
+                body.pull_number
+            ));
+        };
+        if pr.state != "open" {
+            return FakeResponse::unprocessable("PR is not open");
+        }
+        pr.merge_queue_status = Some("queued".to_string());
+    }
+    state.record(
+        "fake_server:merge_queue_enqueue",
+        json!({"repo": repo, "number": body.pull_number}),
+    );
+    FakeResponse::created(json!({
+        "pull_number": body.pull_number,
+        "status": "queued",
+        "priority": body.priority
+    }))
+}
+
+pub fn merge_queue_status(
+    state: &PlaygroundState,
+    owner: &str,
+    repo: &str,
+    base: &str,
+) -> FakeResponse {
+    if state.owner != owner || !state.repos.contains_key(repo) {
+        return FakeResponse::not_found("unknown repo");
+    }
+    let mut entries: Vec<Value> = state
+        .pull_requests
+        .values()
+        .filter(|pr| pr.repo == repo && pr.base_branch == base && pr.state == "open")
+        .filter_map(|pr| {
+            pr.merge_queue_status.as_ref().map(|status| {
+                json!({
+                    "pull_request_number": pr.number,
+                    "status": status,
+                    "head_branch": pr.head_branch
+                })
+            })
+        })
+        .collect();
+    entries.sort_by_key(|v| v["pull_request_number"].as_u64().unwrap_or(0));
+    FakeResponse::ok(json!({"base": base, "entries": entries}))
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct SetLabelsBody {
+    pub labels: Vec<String>,
+}
+
+pub fn set_labels(
+    state: &mut PlaygroundState,
+    owner: &str,
+    repo: &str,
+    number: u64,
+    body: SetLabelsBody,
+) -> FakeResponse {
+    let pr_key = PlaygroundPullRequest::compose_key(repo, number);
+    if state.owner != owner {
+        return FakeResponse::not_found("unknown owner");
+    }
+    let labels_now = {
+        let Some(pr) = state.pull_requests.get_mut(&pr_key) else {
+            return FakeResponse::not_found(&format!("PR {owner}/{repo}#{number} not found"));
+        };
+        pr.labels = body.labels;
+        pr.labels.clone()
+    };
+    state.record(
+        "fake_server:set_labels",
+        json!({"repo": repo, "number": number}),
+    );
+    FakeResponse::ok(Value::Array(
+        labels_now
+            .iter()
+            .map(|l| json!({"name": l, "color": "ededed"}))
+            .collect(),
+    ))
+}
+
+pub fn get_issue(state: &PlaygroundState, owner: &str, repo: &str, number: u64) -> FakeResponse {
+    let Some(pr) = pr_lookup(state, owner, repo, number) else {
+        return FakeResponse::not_found(&format!("issue {owner}/{repo}#{number} not found"));
+    };
+    FakeResponse::ok(json!({
+        "number": pr.number,
+        "title": pr.title,
+        "body": pr.body,
+        "state": pr.state,
+        "user": {"login": pr.user},
+        "labels": pr.labels.iter().map(|l| json!({"name": l, "color": "ededed"})).collect::<Vec<_>>(),
+        "comments": pr.comments.len(),
+        "html_url": format!("https://github.com/{}/{}/pull/{}", owner, repo, number)
+    }))
+}
+
+fn pr_lookup<'a>(
+    state: &'a PlaygroundState,
+    owner: &str,
+    repo: &str,
+    number: u64,
+) -> Option<&'a PlaygroundPullRequest> {
+    if state.owner != owner {
+        return None;
+    }
+    state
+        .pull_requests
+        .get(&PlaygroundPullRequest::compose_key(repo, number))
+}
+
+fn pr_to_v3(state: &PlaygroundState, pr: &PlaygroundPullRequest) -> Value {
+    json!({
+        "number": pr.number,
+        "title": pr.title,
+        "body": pr.body,
+        "state": pr.state,
+        "draft": pr.draft,
+        "head": {
+            "ref": pr.head_branch,
+            "sha": pr.head_sha,
+            "label": format!("{}:{}", state.owner, pr.head_branch)
+        },
+        "base": {
+            "ref": pr.base_branch,
+            "sha": Value::Null,
+            "label": format!("{}:{}", state.owner, pr.base_branch)
+        },
+        "user": {"login": pr.user},
+        "labels": pr.labels.iter().map(|l| json!({"name": l, "color": "ededed"})).collect::<Vec<_>>(),
+        "mergeable": pr.mergeable,
+        "mergeable_state": pr.mergeable_state,
+        "merged": pr.state == "merged",
+        "merged_at": pr.merged_at,
+        "closed_at": pr.closed_at,
+        "comments": pr.comments.len(),
+        "auto_merge": pr.merge_queue_status.as_ref().map(|status| json!({"merge_method": "merge", "status": status})),
+        "html_url": format!("https://github.com/{}/{}/pull/{}", state.owner, pr.repo, pr.number)
+    })
+}
+
+fn format_now(now_ms: i64) -> String {
+    use chrono::TimeZone;
+    let utc = chrono::Utc
+        .timestamp_millis_opt(now_ms)
+        .single()
+        .unwrap_or_else(chrono::Utc::now);
+    utc.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+/// Convenience helper used by the axum-based dispatcher to translate raw
+/// query strings into a typed value.
+pub fn parse_query(query: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for pair in query.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+        out.insert(url_decode(k), url_decode(v));
+    }
+    out
+}
+
+fn url_decode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'+' {
+            out.push(' ');
+            i += 1;
+        } else if b == b'%' && i + 2 < bytes.len() {
+            let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or("00");
+            let v = u8::from_str_radix(hex, 16).unwrap_or(b' ');
+            out.push(v as char);
+            i += 3;
+        } else {
+            out.push(b as char);
+            i += 1;
+        }
+    }
+    out
+}

--- a/crates/harn-vm/src/orchestration/playground/git.rs
+++ b/crates/harn-vm/src/orchestration/playground/git.rs
@@ -1,0 +1,290 @@
+//! Thin wrappers around the host `git` binary used by the Merge Captain
+//! mock-repos playground (#1020).
+//!
+//! The playground exercises *real* git: bare remotes plus working clones,
+//! feature branches with overlay commits, force-with-lease pushes,
+//! and a real merge commit when a PR is "merged". Keeping the wrappers
+//! tiny and explicit makes the surface easy to audit and to swap to
+//! `gix` later if we ever drop the binary dependency.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::value::VmError;
+
+pub struct GitOps {
+    pub author_name: String,
+    pub author_email: String,
+    /// Pinned timestamp for `GIT_AUTHOR_DATE` / `GIT_COMMITTER_DATE` so
+    /// commit SHAs are reproducible across runs from the same manifest.
+    /// `2026-01-01T00:00:00 +0000` aligns with `PlaygroundState::now_ms`.
+    pub committer_date: String,
+}
+
+impl Default for GitOps {
+    fn default() -> Self {
+        GitOps {
+            author_name: "Playground Bot".to_string(),
+            author_email: "bot@playground.invalid".to_string(),
+            committer_date: "2026-01-01T00:00:00 +0000".to_string(),
+        }
+    }
+}
+
+impl GitOps {
+    /// Run `git` with the given args in `cwd`. Returns stdout on success.
+    pub fn run(&self, cwd: &Path, args: &[&str]) -> Result<String, VmError> {
+        let mut cmd = Command::new("git");
+        cmd.current_dir(cwd);
+        // Force a deterministic environment so commit SHAs are reproducible
+        // when the manifest commit messages and author identities are stable.
+        // We deliberately do not pass --date here because some operations
+        // (e.g. clone) reject extra commit-only flags.
+        cmd.env("GIT_AUTHOR_NAME", &self.author_name);
+        cmd.env("GIT_AUTHOR_EMAIL", &self.author_email);
+        cmd.env("GIT_AUTHOR_DATE", &self.committer_date);
+        cmd.env("GIT_COMMITTER_NAME", &self.author_name);
+        cmd.env("GIT_COMMITTER_EMAIL", &self.author_email);
+        cmd.env("GIT_COMMITTER_DATE", &self.committer_date);
+        // Stop git from picking up the user's signing config or hooks.
+        cmd.env("GIT_CONFIG_NOSYSTEM", "1");
+        cmd.env("HOME", cwd);
+        cmd.env("XDG_CONFIG_HOME", cwd);
+        cmd.env("GIT_TERMINAL_PROMPT", "0");
+        cmd.env("LANG", "C");
+        // Clear ambient GIT_* env vars so we don't accidentally inherit
+        // the caller's repo state (e.g. when `harn merge-captain mock` is
+        // invoked from inside a git pre-push hook, which sets `GIT_DIR`
+        // and friends to the outer repo's `.git`). Without this every
+        // subsequent `git init --bare`, `git clone`, etc. would target
+        // the outer repo and fail in confusing ways.
+        for leaky in [
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_OBJECT_DIRECTORY",
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            "GIT_NAMESPACE",
+            "GIT_PREFIX",
+            "GIT_COMMON_DIR",
+            "GIT_INDEX_VERSION",
+            "GIT_REFLOG_ACTION",
+            "GIT_TRACE",
+            "GIT_TRACE_PACKET",
+            "GIT_TRACE_PERFORMANCE",
+            "GIT_TRACE_SETUP",
+        ] {
+            cmd.env_remove(leaky);
+        }
+        cmd.args(args);
+        let output = cmd.output().map_err(|error| {
+            VmError::Runtime(format!(
+                "failed to spawn `git {}` in {}: {error}",
+                args.join(" "),
+                cwd.display()
+            ))
+        })?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(VmError::Runtime(format!(
+                "`git {}` failed in {}: {}",
+                args.join(" "),
+                cwd.display(),
+                stderr.trim()
+            )));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+
+    /// Initialize a bare remote at `path` with the given default branch.
+    pub fn init_bare(&self, path: &Path, default_branch: &str) -> Result<(), VmError> {
+        std::fs::create_dir_all(path).map_err(|error| {
+            VmError::Runtime(format!(
+                "failed to create bare repo dir {}: {error}",
+                path.display()
+            ))
+        })?;
+        // Some older git versions don't support --initial-branch on bare init,
+        // so we set HEAD explicitly afterwards.
+        self.run(path, &["init", "--bare", "--quiet"])?;
+        let head = format!("ref: refs/heads/{default_branch}\n");
+        std::fs::write(path.join("HEAD"), head).map_err(|error| {
+            VmError::Runtime(format!(
+                "failed to set HEAD for {}: {error}",
+                path.display()
+            ))
+        })?;
+        Ok(())
+    }
+
+    /// Clone `bare` into `working`.
+    pub fn clone(&self, bare: &Path, working: &Path) -> Result<(), VmError> {
+        if let Some(parent) = working.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                VmError::Runtime(format!(
+                    "failed to create clone parent {}: {error}",
+                    parent.display()
+                ))
+            })?;
+        }
+        let bare_str = bare.to_string_lossy();
+        let working_str = working.to_string_lossy();
+        let cwd = working
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        self.run(&cwd, &["clone", "--quiet", &bare_str, &working_str])?;
+        // Also pin local user.* in the new clone so subsequent commits in
+        // tests don't depend on the global gitconfig.
+        self.run(working, &["config", "user.name", &self.author_name])?;
+        self.run(working, &["config", "user.email", &self.author_email])?;
+        Ok(())
+    }
+
+    /// Apply a file overlay (write contents) plus a delete list, then commit
+    /// + push the current branch. Returns the new HEAD SHA.
+    pub fn commit_overlay(
+        &self,
+        working: &Path,
+        files_set: &BTreeMap<String, String>,
+        files_delete: &[String],
+        message: &str,
+        push_target: Option<&str>,
+    ) -> Result<String, VmError> {
+        for (rel, contents) in files_set {
+            let target = working.join(rel);
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent).map_err(|error| {
+                    VmError::Runtime(format!(
+                        "failed to create dir {}: {error}",
+                        parent.display()
+                    ))
+                })?;
+            }
+            std::fs::write(&target, contents).map_err(|error| {
+                VmError::Runtime(format!(
+                    "failed to write file {}: {error}",
+                    target.display()
+                ))
+            })?;
+        }
+        for rel in files_delete {
+            let target = working.join(rel);
+            if target.exists() {
+                std::fs::remove_file(&target).map_err(|error| {
+                    VmError::Runtime(format!(
+                        "failed to remove file {}: {error}",
+                        target.display()
+                    ))
+                })?;
+            }
+        }
+        self.run(working, &["add", "--all"])?;
+        // Allow empty in case the overlay was no-op (lets scenarios mark
+        // intentional pivot commits without diffs).
+        self.run(
+            working,
+            &["commit", "--allow-empty", "--quiet", "-m", message],
+        )?;
+        let sha = self.run(working, &["rev-parse", "HEAD"])?;
+        let sha = sha.trim().to_string();
+        if let Some(target) = push_target {
+            self.run(working, &["push", "--quiet", "origin", target])?;
+        }
+        Ok(sha)
+    }
+
+    /// Force-rewrite a branch to a fresh single-commit history starting from
+    /// the base branch, then `--force-with-lease` push to the bare remote.
+    /// Used by `ForcePushAuthor` step actions.
+    pub fn force_rewrite_branch(
+        &self,
+        working: &Path,
+        branch: &str,
+        base: &str,
+        files_set: &BTreeMap<String, String>,
+        files_delete: &[String],
+        message: &str,
+    ) -> Result<String, VmError> {
+        // `--force` on checkout to discard whatever is currently on the branch.
+        self.run(
+            working,
+            &["checkout", "-B", branch, &format!("origin/{base}")],
+        )?;
+        let sha = self.commit_overlay(working, files_set, files_delete, message, None)?;
+        self.run(
+            working,
+            &["push", "--force-with-lease", "--quiet", "origin", branch],
+        )?;
+        Ok(sha)
+    }
+
+    /// Produce a real merge commit on the bare remote: checkout base, merge
+    /// head with `--no-ff`, push.
+    pub fn merge_branch(
+        &self,
+        working: &Path,
+        head: &str,
+        base: &str,
+        message: &str,
+    ) -> Result<String, VmError> {
+        self.run(working, &["fetch", "--quiet", "origin"])?;
+        self.run(working, &["checkout", base])?;
+        self.run(working, &["pull", "--quiet", "--ff-only", "origin", base])?;
+        self.run(
+            working,
+            &[
+                "merge",
+                "--no-ff",
+                "--no-edit",
+                "--quiet",
+                "-m",
+                message,
+                &format!("origin/{head}"),
+            ],
+        )?;
+        let sha = self.run(working, &["rev-parse", "HEAD"])?;
+        let sha = sha.trim().to_string();
+        self.run(working, &["push", "--quiet", "origin", base])?;
+        Ok(sha)
+    }
+
+    pub fn checkout(&self, working: &Path, branch: &str) -> Result<(), VmError> {
+        self.run(working, &["checkout", "--quiet", branch])?;
+        Ok(())
+    }
+
+    pub fn create_branch(
+        &self,
+        working: &Path,
+        branch: &str,
+        from_ref: &str,
+    ) -> Result<(), VmError> {
+        self.run(working, &["checkout", "-b", branch, from_ref])?;
+        Ok(())
+    }
+
+    pub fn rev_parse(&self, working: &Path, what: &str) -> Result<String, VmError> {
+        let out = self.run(working, &["rev-parse", what])?;
+        Ok(out.trim().to_string())
+    }
+
+    pub fn fetch(&self, working: &Path) -> Result<(), VmError> {
+        self.run(working, &["fetch", "--quiet", "origin"])?;
+        Ok(())
+    }
+}
+
+/// `bare` represented as a `file://` URL — what the connector and a real
+/// git client would consume.
+pub fn bare_file_url(bare: &Path) -> String {
+    let canonical = std::fs::canonicalize(bare).unwrap_or_else(|_| bare.to_path_buf());
+    let mut url = String::from("file://");
+    let canon_str = canonical.to_string_lossy();
+    if !canon_str.starts_with('/') {
+        url.push('/');
+    }
+    url.push_str(&canon_str);
+    url
+}

--- a/crates/harn-vm/src/orchestration/playground/init.rs
+++ b/crates/harn-vm/src/orchestration/playground/init.rs
@@ -1,0 +1,294 @@
+//! Materialize a Merge Captain mock-repos playground (#1020).
+//!
+//! `init_playground_at(dir, manifest)` creates:
+//!
+//! ```text
+//! <dir>/
+//!   playground.json   (marker — versioned, idempotent rejection key)
+//!   manifest.json     (canonicalized seed manifest)
+//!   state.json        (mutable playground state — what the fake server reads)
+//!   remotes/<repo>.git/   (bare remotes)
+//!   working/<repo>/       (working clones)
+//! ```
+//!
+//! The captain (and, in the harn-github-connector repo, real connector code)
+//! exercises `file://` remotes so every `git fetch / push / rebase /
+//! force-with-lease` runs against real git.
+
+use std::path::Path;
+
+use serde_json::json;
+
+use crate::value::VmError;
+
+use super::git::{bare_file_url, GitOps};
+use super::manifest::{ScenarioBranch, ScenarioManifest, ScenarioRepo};
+use super::state::{
+    manifest_path, playground_marker_path, PlaygroundMarker, PlaygroundState, PLAYGROUND_TYPE,
+};
+
+/// Default contents written for a repo's seed README when the manifest
+/// doesn't supply any files. Keeps the bare clone non-empty so the first
+/// `git push` lands on a real commit.
+fn default_seed_files(repo: &ScenarioRepo) -> std::collections::BTreeMap<String, String> {
+    if !repo.files.is_empty() {
+        return repo.files.clone();
+    }
+    let mut files = std::collections::BTreeMap::new();
+    files.insert(
+        "README.md".to_string(),
+        format!("# {}\n\nMerge Captain playground seed.\n", repo.name),
+    );
+    files
+}
+
+pub struct InitOptions<'a> {
+    pub dir: &'a Path,
+    pub manifest: &'a ScenarioManifest,
+    /// When true, rejects re-init of an existing playground. Default for the
+    /// CLI; tests typically clear the dir first.
+    pub allow_existing: bool,
+}
+
+pub fn init_playground_at(options: InitOptions<'_>) -> Result<PlaygroundState, VmError> {
+    let dir = options.dir;
+    let manifest = options.manifest;
+    let marker = playground_marker_path(dir);
+    if marker.exists() && !options.allow_existing {
+        return Err(VmError::Runtime(format!(
+            "playground already initialized at {} (run `harn merge-captain mock cleanup {0}` first)",
+            dir.display()
+        )));
+    }
+    std::fs::create_dir_all(dir).map_err(|error| {
+        VmError::Runtime(format!(
+            "failed to create playground dir {}: {error}",
+            dir.display()
+        ))
+    })?;
+    std::fs::create_dir_all(dir.join("remotes"))
+        .map_err(|error| VmError::Runtime(format!("failed to create remotes dir: {error}")))?;
+    std::fs::create_dir_all(dir.join("working"))
+        .map_err(|error| VmError::Runtime(format!("failed to create working dir: {error}")))?;
+
+    let git = GitOps::default();
+    let mut state = PlaygroundState::from_manifest(manifest);
+
+    for repo in &manifest.repos {
+        materialize_repo(&git, dir, repo, &mut state)?;
+    }
+
+    // Persist a canonicalized manifest copy so subsequent `step` and `serve`
+    // commands work without the original file path.
+    let manifest_bytes = serde_json::to_vec_pretty(manifest)
+        .map_err(|error| VmError::Runtime(format!("failed to serialize manifest copy: {error}")))?;
+    let mut manifest_with_newline = manifest_bytes;
+    manifest_with_newline.push(b'\n');
+    std::fs::write(manifest_path(dir), manifest_with_newline)
+        .map_err(|error| VmError::Runtime(format!("failed to write manifest copy: {error}")))?;
+
+    let marker_value = PlaygroundMarker::new(&manifest.scenario, state.now_ms);
+    let mut marker_bytes = serde_json::to_vec_pretty(&marker_value).map_err(|error| {
+        VmError::Runtime(format!("failed to serialize playground marker: {error}"))
+    })?;
+    marker_bytes.push(b'\n');
+    std::fs::write(playground_marker_path(dir), marker_bytes)
+        .map_err(|error| VmError::Runtime(format!("failed to write playground marker: {error}")))?;
+
+    state.record(
+        "init",
+        json!({
+            "scenario": manifest.scenario,
+            "repos": manifest.repos.iter().map(|r| r.name.clone()).collect::<Vec<_>>(),
+            "pull_requests": manifest.pull_requests.len(),
+        }),
+    );
+    state.save(dir)?;
+
+    Ok(state)
+}
+
+fn materialize_repo(
+    git: &GitOps,
+    dir: &Path,
+    repo: &ScenarioRepo,
+    state: &mut PlaygroundState,
+) -> Result<(), VmError> {
+    let bare = dir.join("remotes").join(format!("{}.git", repo.name));
+    let working = dir.join("working").join(&repo.name);
+    git.init_bare(&bare, &repo.default_branch)?;
+    git.clone(&bare, &working)?;
+
+    // Seed the default branch — first commit of the bare remote.
+    let seed_files = default_seed_files(repo);
+    let seed_message = format!("Initial seed for {}", repo.name);
+    let seed_sha = git.commit_overlay(
+        &working,
+        &seed_files,
+        &[],
+        &seed_message,
+        Some(&repo.default_branch),
+    )?;
+
+    // Optional extra commits *before* feature branches are forked. We keep
+    // `seed_sha` so any branch that wants `fork_before_extra_commits == true`
+    // can reset to it instead of `origin/<default>`.
+    for extra in &repo.default_branch_extra_commits {
+        git.commit_overlay(
+            &working,
+            &extra.files_set,
+            &extra.files_delete,
+            &extra.message,
+            Some(&repo.default_branch),
+        )?;
+    }
+
+    // Feature branches.
+    for branch in &repo.branches {
+        materialize_branch(git, &working, repo, branch, &seed_sha)?;
+    }
+
+    // Update state for this repo.
+    let url = bare_file_url(&bare);
+    if let Some(repo_state) = state.repos.get_mut(&repo.name) {
+        repo_state.remote_url = url;
+        repo_state.remote_path = path_relative_to(&bare, dir);
+        repo_state.working_path = path_relative_to(&working, dir);
+    }
+
+    // Resolve head_sha for any PRs that reference branches in this repo.
+    for pr in state
+        .pull_requests
+        .values_mut()
+        .filter(|pr| pr.repo == repo.name)
+    {
+        if pr.head_sha.is_some() {
+            continue;
+        }
+        let sha = git
+            .rev_parse(&working, &format!("origin/{}", pr.head_branch))
+            .ok();
+        pr.head_sha = sha;
+    }
+
+    Ok(())
+}
+
+fn materialize_branch(
+    git: &GitOps,
+    working: &Path,
+    repo: &ScenarioRepo,
+    branch: &ScenarioBranch,
+    seed_sha: &str,
+) -> Result<String, VmError> {
+    let base_branch = branch
+        .base
+        .clone()
+        .unwrap_or_else(|| repo.default_branch.clone());
+    let from_ref = if branch.fork_before_extra_commits {
+        seed_sha.to_string()
+    } else {
+        format!("origin/{base_branch}")
+    };
+    git.create_branch(working, &branch.name, &from_ref)?;
+    let message = branch
+        .commit_message
+        .clone()
+        .unwrap_or_else(|| format!("{} on {}", branch.name, repo.name));
+    let sha = git.commit_overlay(
+        working,
+        &branch.files_set,
+        &branch.files_delete,
+        &message,
+        Some(&branch.name),
+    )?;
+    // Return to the default branch so subsequent operations don't accumulate
+    // on a feature branch.
+    git.checkout(working, &repo.default_branch)?;
+    Ok(sha)
+}
+
+fn path_relative_to(target: &Path, base: &Path) -> String {
+    target
+        .strip_prefix(base)
+        .map(|rel| rel.to_string_lossy().to_string())
+        .unwrap_or_else(|_| target.to_string_lossy().to_string())
+}
+
+/// Idempotent cleanup. Removes the playground directory entirely if it
+/// looks like one (i.e. has a `playground.json` marker with the right
+/// `_type`). Refuses to delete arbitrary directories — returns an error
+/// instead of removing anything.
+pub fn cleanup_playground_at(dir: &Path) -> Result<bool, VmError> {
+    let marker = playground_marker_path(dir);
+    if !marker.exists() {
+        // Idempotent: cleanup of a non-playground or already-cleaned dir is OK.
+        if !dir.exists() {
+            return Ok(false);
+        }
+        // If the dir exists but has no marker, refuse — don't `rm -rf`
+        // arbitrary user content.
+        if dir
+            .read_dir()
+            .map(|mut r| r.next().is_none())
+            .unwrap_or(true)
+        {
+            // empty dir is fine to leave alone (and idempotent).
+            return Ok(false);
+        }
+        return Err(VmError::Runtime(format!(
+            "{} does not look like a Merge Captain playground (missing playground.json marker); refusing to remove",
+            dir.display()
+        )));
+    }
+    // Verify the marker before removing.
+    let bytes = std::fs::read(&marker).map_err(|error| {
+        VmError::Runtime(format!(
+            "failed to read playground marker {}: {error}",
+            marker.display()
+        ))
+    })?;
+    let parsed: PlaygroundMarker = serde_json::from_slice(&bytes).map_err(|error| {
+        VmError::Runtime(format!(
+            "playground marker {} is malformed: {error}",
+            marker.display()
+        ))
+    })?;
+    if parsed.type_name != PLAYGROUND_TYPE {
+        return Err(VmError::Runtime(format!(
+            "playground marker {} has wrong _type {:?}; refusing to remove",
+            marker.display(),
+            parsed.type_name
+        )));
+    }
+    std::fs::remove_dir_all(dir).map_err(|error| {
+        VmError::Runtime(format!(
+            "failed to remove playground dir {}: {error}",
+            dir.display()
+        ))
+    })?;
+    Ok(true)
+}
+
+/// Verify that a directory hosts a playground; load and return the
+/// state and manifest if so.
+pub fn load_playground(dir: &Path) -> Result<(PlaygroundState, ScenarioManifest), VmError> {
+    let marker = playground_marker_path(dir);
+    if !marker.exists() {
+        return Err(VmError::Runtime(format!(
+            "{} is not a Merge Captain playground (missing playground.json)",
+            dir.display()
+        )));
+    }
+    let manifest_bytes = std::fs::read(manifest_path(dir)).map_err(|error| {
+        VmError::Runtime(format!(
+            "failed to read playground manifest {}: {error}",
+            manifest_path(dir).display()
+        ))
+    })?;
+    let manifest: ScenarioManifest = serde_json::from_slice(&manifest_bytes).map_err(|error| {
+        VmError::Runtime(format!("failed to parse playground manifest copy: {error}"))
+    })?;
+    let state = PlaygroundState::load(dir)?;
+    Ok((state, manifest))
+}

--- a/crates/harn-vm/src/orchestration/playground/integration_tests.rs
+++ b/crates/harn-vm/src/orchestration/playground/integration_tests.rs
@@ -1,0 +1,284 @@
+//! Integration tests for the Merge Captain playground (#1020). Each test
+//! materializes a real git repo into a tempdir, runs scenario steps that
+//! exercise rebase / force-with-lease / merge codepaths, and asserts on
+//! the resulting state. Skipped automatically on hosts without `git` on
+//! PATH so cargo test still runs in minimal sandboxes.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use super::*;
+
+fn git_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn skip_if_no_git() -> bool {
+    if !git_available() {
+        eprintln!("(skipping playground integration test — `git` not on PATH)");
+        return true;
+    }
+    false
+}
+
+fn fresh_dir() -> (tempfile::TempDir, PathBuf) {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().to_path_buf();
+    (tempdir, path)
+}
+
+#[test]
+fn init_three_repo_basic_creates_real_repos_and_branches() {
+    if skip_if_no_git() {
+        return;
+    }
+    let (_guard, dir) = fresh_dir();
+    let manifest = load_builtin("three_repo_basic").unwrap();
+    let state = init_playground_at(InitOptions {
+        dir: &dir,
+        manifest: &manifest,
+        allow_existing: false,
+    })
+    .unwrap();
+
+    // Each repo has a bare remote and a working clone.
+    for repo_name in ["alpha", "beta", "gamma"] {
+        let bare = dir.join("remotes").join(format!("{repo_name}.git"));
+        let working = dir.join("working").join(repo_name);
+        assert!(bare.is_dir(), "missing bare remote for {repo_name}");
+        assert!(working.is_dir(), "missing working clone for {repo_name}");
+
+        // The bare remote really has the seeded branches.
+        let branches = Command::new("git")
+            .args(["branch", "--list"])
+            .current_dir(&working)
+            .output()
+            .unwrap();
+        let listing = String::from_utf8_lossy(&branches.stdout).to_string();
+        assert!(
+            listing.contains(repo_name) || !listing.is_empty(),
+            "{listing}"
+        );
+    }
+
+    // PRs got their head_sha resolved by reading the remote's branch tip.
+    for pr in state.pull_requests.values() {
+        assert!(
+            pr.head_sha.is_some(),
+            "PR {} should have head_sha resolved",
+            pr.key()
+        );
+    }
+}
+
+#[test]
+fn cleanup_is_idempotent() {
+    if skip_if_no_git() {
+        return;
+    }
+    let (_guard, dir) = fresh_dir();
+    let manifest = load_builtin("single_green").unwrap();
+    init_playground_at(InitOptions {
+        dir: &dir,
+        manifest: &manifest,
+        allow_existing: false,
+    })
+    .unwrap();
+    assert!(cleanup_playground_at(&dir).unwrap());
+    // Second call should be a quiet no-op.
+    assert!(!cleanup_playground_at(&dir).unwrap());
+}
+
+#[test]
+fn cleanup_refuses_arbitrary_directory() {
+    let (_guard, dir) = fresh_dir();
+    std::fs::write(dir.join("README.md"), "not a playground").unwrap();
+    let err = cleanup_playground_at(&dir).unwrap_err();
+    assert!(format!("{err}").contains("does not look like"));
+}
+
+#[test]
+fn force_push_drill_step_rewrites_branch_and_updates_head_sha() {
+    if skip_if_no_git() {
+        return;
+    }
+    let (_guard, dir) = fresh_dir();
+    let manifest = load_builtin("force_push_drill").unwrap();
+    let mut state = init_playground_at(InitOptions {
+        dir: &dir,
+        manifest: &manifest,
+        allow_existing: false,
+    })
+    .unwrap();
+    let initial_sha = state
+        .pull_requests
+        .values()
+        .next()
+        .and_then(|pr| pr.head_sha.clone())
+        .expect("initial head_sha");
+    let report = run_named_step(&dir, &mut state, &manifest, "force_push_passing_v2").unwrap();
+    assert!(report.actions_applied >= 1);
+    let new_sha = state
+        .pull_requests
+        .values()
+        .next()
+        .and_then(|pr| pr.head_sha.clone())
+        .expect("post head_sha");
+    assert_ne!(
+        initial_sha, new_sha,
+        "force-push should produce a different head SHA"
+    );
+    state.save(&dir).unwrap();
+    let reloaded = PlaygroundState::load(&dir).unwrap();
+    assert_eq!(reloaded.pull_requests.len(), 1);
+    assert_eq!(
+        reloaded
+            .pull_requests
+            .values()
+            .next()
+            .unwrap()
+            .head_sha
+            .as_deref(),
+        Some(new_sha.as_str())
+    );
+}
+
+#[test]
+fn merge_pull_request_step_produces_real_merge_commit_on_remote() {
+    if skip_if_no_git() {
+        return;
+    }
+    let (_guard, dir) = fresh_dir();
+    let manifest = load_builtin("single_green").unwrap();
+    let mut state = init_playground_at(InitOptions {
+        dir: &dir,
+        manifest: &manifest,
+        allow_existing: false,
+    })
+    .unwrap();
+    let report = run_named_step(&dir, &mut state, &manifest, "merge").unwrap();
+    assert!(report.actions_applied >= 1);
+    // Remote `main` should now have a merge commit (parents > 1).
+    let bare = dir.join("remotes").join("solo.git");
+    let log = Command::new("git")
+        .args(["log", "--all", "--oneline"])
+        .current_dir(&bare)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&log.stdout).to_string();
+    assert!(
+        stdout.lines().count() >= 2,
+        "expected merged remote history, got:\n{stdout}"
+    );
+    let merged_pr = state.pull_requests.values().next().unwrap();
+    assert_eq!(merged_pr.state, "merged");
+}
+
+#[test]
+fn advance_base_marks_open_prs_behind() {
+    if skip_if_no_git() {
+        return;
+    }
+    let (_guard, dir) = fresh_dir();
+    let manifest = load_builtin("three_repo_basic").unwrap();
+    let mut state = init_playground_at(InitOptions {
+        dir: &dir,
+        manifest: &manifest,
+        allow_existing: false,
+    })
+    .unwrap();
+    run_named_step(&dir, &mut state, &manifest, "beta_advance_main").unwrap();
+    let pr = state
+        .pull_requests
+        .get(&PlaygroundPullRequest::compose_key("beta", 202))
+        .unwrap();
+    assert_eq!(pr.mergeable_state, "behind");
+}
+
+#[test]
+fn fake_server_handlers_round_trip_pr_lookup() {
+    let manifest = load_builtin("single_green").unwrap();
+    let mut state = PlaygroundState::from_manifest(&manifest);
+    // Bypass real git by stamping a head_sha.
+    for pr in state.pull_requests.values_mut() {
+        pr.head_sha = Some("ffffffff".to_string());
+    }
+    let response = list_pulls(&state, "burin-labs", "solo", &ListPullsQuery::default());
+    assert_eq!(response.status, 200);
+    let body = response.body;
+    assert_eq!(body.as_array().unwrap().len(), 1);
+
+    let response = get_pull(&state, "burin-labs", "solo", 1);
+    assert_eq!(response.status, 200);
+    assert_eq!(response.body["number"], 1);
+
+    let response = list_check_runs(&state, "burin-labs", "solo", "ffffffff");
+    assert_eq!(response.status, 200);
+    let runs = &response.body["check_runs"];
+    assert_eq!(runs.as_array().unwrap().len(), 1);
+
+    // Mutating endpoints touch state.
+    let response = create_issue_comment(
+        &mut state,
+        "burin-labs",
+        "solo",
+        1,
+        CreateCommentBody {
+            body: "ack".to_string(),
+            user: Some("captain".to_string()),
+        },
+    );
+    assert_eq!(response.status, 201);
+    assert_eq!(
+        state.pull_requests.values().next().unwrap().comments.len(),
+        1
+    );
+}
+
+#[test]
+fn init_produces_deterministic_head_shas() {
+    if skip_if_no_git() {
+        return;
+    }
+    let manifest = load_builtin("single_green").unwrap();
+    let (_g1, dir1) = fresh_dir();
+    let (_g2, dir2) = fresh_dir();
+    let s1 = init_playground_at(InitOptions {
+        dir: &dir1,
+        manifest: &manifest,
+        allow_existing: false,
+    })
+    .unwrap();
+    let s2 = init_playground_at(InitOptions {
+        dir: &dir2,
+        manifest: &manifest,
+        allow_existing: false,
+    })
+    .unwrap();
+    let pr1 = s1.pull_requests.values().next().unwrap();
+    let pr2 = s2.pull_requests.values().next().unwrap();
+    assert_eq!(
+        pr1.head_sha, pr2.head_sha,
+        "expected deterministic head_sha across runs (commit dates pinned via GIT_COMMITTER_DATE)"
+    );
+}
+
+#[test]
+fn synthesize_sweep_emits_canonical_envelope_for_each_open_pr() {
+    let manifest = load_builtin("three_repo_basic").unwrap();
+    let mut state = PlaygroundState::from_manifest(&manifest);
+    for pr in state.pull_requests.values_mut() {
+        pr.head_sha = Some("deadbeef".to_string());
+    }
+    let events = synthesize_sweep(&state, &TranscriptOptions::default());
+    let tool_calls = events
+        .iter()
+        .filter(|e| matches!(e.event, crate::agent_events::AgentEvent::ToolCall { .. }))
+        .count();
+    // 2 tool calls per open PR; the manifest has 3 open PRs.
+    assert_eq!(tool_calls, 6);
+}

--- a/crates/harn-vm/src/orchestration/playground/manifest.rs
+++ b/crates/harn-vm/src/orchestration/playground/manifest.rs
@@ -1,0 +1,548 @@
+//! Scenario manifest types for the Merge Captain mock-repos playground (#1020).
+//!
+//! A manifest is checked-in YAML/JSON describing the *seed* state of a
+//! playground: the repos, branches, pull requests, checks, and the
+//! deterministic step actions an agent can use to advance the scenario.
+//! `init_playground` consumes a manifest to materialize real on-disk git
+//! repos plus a mutable `state.json`; the fake GitHub HTTP server reads
+//! that state.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::value::VmError;
+
+/// Manifest envelope `_type` field — used to refuse stray JSON files.
+pub const SCENARIO_TYPE: &str = "merge_captain_playground_scenario";
+
+/// Top-level scenario manifest.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ScenarioManifest {
+    #[serde(rename = "_type")]
+    pub type_name: String,
+    pub scenario: String,
+    pub description: String,
+    pub owner: String,
+    pub repos: Vec<ScenarioRepo>,
+    pub pull_requests: Vec<ScenarioPullRequest>,
+    pub steps: Vec<ScenarioStep>,
+}
+
+/// A repo definition. The default branch always has a single seed commit;
+/// each `branch` entry is a feature branch authored from that seed plus an
+/// overlay of files.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ScenarioRepo {
+    pub name: String,
+    pub default_branch: String,
+    /// File overlay applied to the default-branch seed commit. Path → content.
+    pub files: BTreeMap<String, String>,
+    /// Extra commits to apply on top of the default branch *before* feature
+    /// branches are forked. Used to simulate "behind-base" scenarios where the
+    /// feature branch was forked at an earlier point.
+    pub default_branch_extra_commits: Vec<ScenarioCommit>,
+    pub branches: Vec<ScenarioBranch>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ScenarioBranch {
+    pub name: String,
+    /// Optional base branch. Defaults to the repo's `default_branch`.
+    pub base: Option<String>,
+    /// Whether to fork *before* the default-branch extra commits. When
+    /// true, the branch is created at the seed commit (i.e. behind base).
+    pub fork_before_extra_commits: bool,
+    /// File overlay applied as a single commit on top of the base.
+    pub files_set: BTreeMap<String, String>,
+    /// File deletions applied as part of the same commit.
+    pub files_delete: Vec<String>,
+    /// Optional commit message override.
+    pub commit_message: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ScenarioCommit {
+    pub message: String,
+    pub files_set: BTreeMap<String, String>,
+    pub files_delete: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ScenarioPullRequest {
+    pub repo: String,
+    pub number: u64,
+    pub title: String,
+    pub body: String,
+    /// `open`, `closed`, `merged`.
+    pub state: String,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub user: String,
+    pub draft: bool,
+    pub labels: Vec<String>,
+    pub checks: Vec<ScenarioCheck>,
+    pub mergeable: Option<bool>,
+    /// `clean`, `dirty`, `behind`, `blocked`, `unstable`.
+    pub mergeable_state: String,
+    /// `none`, `queued`, `merged`, `failed`.
+    pub merge_queue_status: Option<String>,
+    pub comments: Vec<ScenarioComment>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ScenarioCheck {
+    pub name: String,
+    /// `queued`, `in_progress`, `completed`.
+    pub status: String,
+    /// When `status == "completed"`: `success`, `failure`, `cancelled`,
+    /// `timed_out`, `neutral`, `skipped`.
+    pub conclusion: Option<String>,
+    pub details_url: Option<String>,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ScenarioComment {
+    pub user: String,
+    pub body: String,
+    pub created_at: Option<String>,
+}
+
+/// A named, declarative step the agent can run via `harn merge-captain mock
+/// step <dir> <name>`. Steps are pure state mutations applied to
+/// `state.json`; nothing inside a step touches the bare git remote.
+/// (Force-push-by-author and similar git-native mutations are first-class
+/// `ScenarioAction` variants so the underlying command is deterministic.)
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ScenarioStep {
+    pub name: String,
+    pub description: String,
+    pub actions: Vec<ScenarioAction>,
+}
+
+/// A single mutation applied to the playground state. Adding a variant here
+/// is a backwards-compatible change because `serde(other)` rejects unknown
+/// tags loudly so old binaries can't silently no-op a newer manifest.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ScenarioAction {
+    /// Update or insert a check run for a PR.
+    SetCheck {
+        repo: String,
+        pr_number: u64,
+        name: String,
+        status: String,
+        #[serde(default)]
+        conclusion: Option<String>,
+        #[serde(default)]
+        details_url: Option<String>,
+    },
+    /// Append a new PR. The branch must already exist on the bare remote.
+    AddPullRequest {
+        #[serde(flatten)]
+        pr: ScenarioPullRequest,
+    },
+    /// Mark a PR closed without merging.
+    ClosePullRequest { repo: String, pr_number: u64 },
+    /// Mark a PR merged. Produces a real merge commit on the bare remote
+    /// (so subsequent rebases see a real diverged history).
+    MergePullRequest {
+        repo: String,
+        pr_number: u64,
+        #[serde(default)]
+        merge_method: Option<String>,
+    },
+    /// Append a comment.
+    AddComment {
+        repo: String,
+        pr_number: u64,
+        user: String,
+        body: String,
+    },
+    /// Set the PR's labels (replaces).
+    SetLabels {
+        repo: String,
+        pr_number: u64,
+        labels: Vec<String>,
+    },
+    /// Update the merge-queue status for a PR.
+    SetMergeQueueStatus {
+        repo: String,
+        pr_number: u64,
+        /// `none`, `queued`, `merged`, `failed`.
+        status: String,
+    },
+    /// Simulate a force-push by the author: rewrite the head branch to a new
+    /// snapshot of files. Updates the bare remote.
+    ForcePushAuthor {
+        repo: String,
+        branch: String,
+        files_set: BTreeMap<String, String>,
+        #[serde(default)]
+        files_delete: Vec<String>,
+        #[serde(default)]
+        commit_message: Option<String>,
+    },
+    /// Append a commit on the default branch of a repo (simulates someone
+    /// else landing work, putting open PRs behind base).
+    AdvanceBase {
+        repo: String,
+        #[serde(default)]
+        files_set: BTreeMap<String, String>,
+        #[serde(default)]
+        files_delete: Vec<String>,
+        #[serde(default)]
+        commit_message: Option<String>,
+    },
+    /// Update mergeable / mergeable_state without git mutation.
+    SetMergeability {
+        repo: String,
+        pr_number: u64,
+        mergeable: Option<bool>,
+        mergeable_state: String,
+    },
+    /// Advance the playground clock by N milliseconds. Steps that timestamp
+    /// events use the playground clock so transcripts remain deterministic.
+    AdvanceTimeMs { ms: u64 },
+}
+
+impl ScenarioManifest {
+    /// Parse a manifest from JSON or YAML based on file extension.
+    pub fn load(path: &Path) -> Result<Self, VmError> {
+        let bytes = std::fs::read(path).map_err(|error| {
+            VmError::Runtime(format!(
+                "failed to read scenario manifest {}: {error}",
+                path.display()
+            ))
+        })?;
+        Self::parse(&bytes, path)
+    }
+
+    pub fn parse(bytes: &[u8], path: &Path) -> Result<Self, VmError> {
+        let is_yaml = path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.eq_ignore_ascii_case("yaml") || ext.eq_ignore_ascii_case("yml"))
+            .unwrap_or(false);
+        let manifest: ScenarioManifest = if is_yaml {
+            serde_yaml::from_slice(bytes).map_err(|error| {
+                VmError::Runtime(format!(
+                    "failed to parse YAML scenario manifest {}: {error}",
+                    path.display()
+                ))
+            })?
+        } else {
+            serde_json::from_slice(bytes).map_err(|error| {
+                VmError::Runtime(format!(
+                    "failed to parse JSON scenario manifest {}: {error}",
+                    path.display()
+                ))
+            })?
+        };
+        manifest.validate(path)?;
+        Ok(manifest)
+    }
+
+    pub fn validate(&self, path: &Path) -> Result<(), VmError> {
+        if self.type_name != SCENARIO_TYPE {
+            return Err(VmError::Runtime(format!(
+                "scenario manifest {} has _type {:?}, expected {SCENARIO_TYPE}",
+                path.display(),
+                self.type_name
+            )));
+        }
+        if self.scenario.is_empty() {
+            return Err(VmError::Runtime(format!(
+                "scenario manifest {} is missing required field 'scenario'",
+                path.display()
+            )));
+        }
+        if self.owner.is_empty() {
+            return Err(VmError::Runtime(format!(
+                "scenario manifest {} is missing required field 'owner'",
+                path.display()
+            )));
+        }
+        if self.repos.is_empty() {
+            return Err(VmError::Runtime(format!(
+                "scenario manifest {} must declare at least one repo",
+                path.display()
+            )));
+        }
+        let mut repo_names = std::collections::HashSet::new();
+        for repo in &self.repos {
+            if repo.name.is_empty() {
+                return Err(VmError::Runtime(format!(
+                    "scenario manifest {} has a repo with no name",
+                    path.display()
+                )));
+            }
+            if !is_safe_segment(&repo.name) {
+                return Err(VmError::Runtime(format!(
+                    "scenario manifest {} repo name {:?} contains characters that aren't safe for filesystem paths (use [A-Za-z0-9._-])",
+                    path.display(),
+                    repo.name
+                )));
+            }
+            if repo.default_branch.is_empty() {
+                return Err(VmError::Runtime(format!(
+                    "scenario manifest {} repo {} is missing default_branch",
+                    path.display(),
+                    repo.name
+                )));
+            }
+            if !is_safe_ref(&repo.default_branch) {
+                return Err(VmError::Runtime(format!(
+                    "scenario manifest {} repo {} default_branch {:?} is not a valid git ref",
+                    path.display(),
+                    repo.name,
+                    repo.default_branch
+                )));
+            }
+            if !repo_names.insert(repo.name.clone()) {
+                return Err(VmError::Runtime(format!(
+                    "scenario manifest {} declares repo {} twice",
+                    path.display(),
+                    repo.name
+                )));
+            }
+            let mut branch_names = std::collections::HashSet::new();
+            branch_names.insert(repo.default_branch.clone());
+            for branch in &repo.branches {
+                if branch.name.is_empty() {
+                    return Err(VmError::Runtime(format!(
+                        "scenario manifest {} repo {} has a branch with no name",
+                        path.display(),
+                        repo.name
+                    )));
+                }
+                if !is_safe_ref(&branch.name) {
+                    return Err(VmError::Runtime(format!(
+                        "scenario manifest {} repo {} branch {:?} is not a valid git ref",
+                        path.display(),
+                        repo.name,
+                        branch.name
+                    )));
+                }
+                if !branch_names.insert(branch.name.clone()) {
+                    return Err(VmError::Runtime(format!(
+                        "scenario manifest {} repo {} declares branch {} twice",
+                        path.display(),
+                        repo.name,
+                        branch.name
+                    )));
+                }
+            }
+        }
+        let repo_index: std::collections::HashMap<&str, &ScenarioRepo> =
+            self.repos.iter().map(|r| (r.name.as_str(), r)).collect();
+        let mut pr_keys = std::collections::HashSet::new();
+        for pr in &self.pull_requests {
+            let repo = repo_index.get(pr.repo.as_str()).ok_or_else(|| {
+                VmError::Runtime(format!(
+                    "scenario manifest {} pull_request #{} references unknown repo {}",
+                    path.display(),
+                    pr.number,
+                    pr.repo
+                ))
+            })?;
+            if !pr_keys.insert((pr.repo.clone(), pr.number)) {
+                return Err(VmError::Runtime(format!(
+                    "scenario manifest {} declares PR {}/{} twice",
+                    path.display(),
+                    pr.repo,
+                    pr.number
+                )));
+            }
+            if pr.head_branch.is_empty() {
+                return Err(VmError::Runtime(format!(
+                    "scenario manifest {} PR {}/{} is missing head_branch",
+                    path.display(),
+                    pr.repo,
+                    pr.number
+                )));
+            }
+            if pr.base_branch.is_empty() {
+                return Err(VmError::Runtime(format!(
+                    "scenario manifest {} PR {}/{} is missing base_branch",
+                    path.display(),
+                    pr.repo,
+                    pr.number
+                )));
+            }
+            // head_branch must exist in the repo (or equal default_branch).
+            let head_exists = pr.head_branch == repo.default_branch
+                || repo.branches.iter().any(|b| b.name == pr.head_branch);
+            if !head_exists {
+                return Err(VmError::Runtime(format!(
+                    "scenario manifest {} PR {}/{} head_branch {} is not declared on repo {}",
+                    path.display(),
+                    pr.repo,
+                    pr.number,
+                    pr.head_branch,
+                    pr.repo
+                )));
+            }
+        }
+        let mut step_names = std::collections::HashSet::new();
+        for step in &self.steps {
+            if step.name.is_empty() {
+                return Err(VmError::Runtime(format!(
+                    "scenario manifest {} has an unnamed step",
+                    path.display()
+                )));
+            }
+            if !step_names.insert(step.name.clone()) {
+                return Err(VmError::Runtime(format!(
+                    "scenario manifest {} declares step {} twice",
+                    path.display(),
+                    step.name
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Repos materialize as a directory under `<playground>/{remotes,working}/`,
+/// so reject anything with path-separator-like characters or leading dots.
+fn is_safe_segment(s: &str) -> bool {
+    !s.is_empty()
+        && !s.starts_with('.')
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+}
+
+/// Git refs allow `/` (e.g. `feature/foo`) but disallow control chars,
+/// `..`, leading/trailing slashes, and `@{`. We use a conservative subset
+/// rather than re-implementing `git check-ref-format`.
+fn is_safe_ref(s: &str) -> bool {
+    if s.is_empty() || s.starts_with('/') || s.ends_with('/') || s.contains("..") {
+        return false;
+    }
+    s.chars().all(|c| {
+        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.' || c == '/' || c == '+'
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn json(s: &str) -> ScenarioManifest {
+        ScenarioManifest::parse(s.as_bytes(), &PathBuf::from("test.json")).unwrap()
+    }
+
+    #[test]
+    fn parses_minimal_manifest() {
+        let m = json(
+            r#"{
+  "_type": "merge_captain_playground_scenario",
+  "scenario": "x",
+  "owner": "burin-labs",
+  "repos": [{"name": "alpha", "default_branch": "main"}]
+}"#,
+        );
+        assert_eq!(m.scenario, "x");
+        assert_eq!(m.repos.len(), 1);
+    }
+
+    #[test]
+    fn rejects_wrong_type() {
+        let err = ScenarioManifest::parse(
+            br#"{"_type": "wrong", "scenario": "x", "owner": "burin-labs", "repos": [{"name": "a", "default_branch": "main"}]}"#,
+            &PathBuf::from("test.json"),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("_type"));
+    }
+
+    #[test]
+    fn rejects_unknown_pr_repo() {
+        let err = ScenarioManifest::parse(
+            br#"{"_type": "merge_captain_playground_scenario", "scenario": "x", "owner": "burin-labs",
+              "repos": [{"name": "alpha", "default_branch": "main"}],
+              "pull_requests": [{"repo": "ghost", "number": 1, "head_branch": "main", "base_branch": "main", "mergeable_state": "clean"}]}"#,
+            &PathBuf::from("test.json"),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("unknown repo"));
+    }
+
+    #[test]
+    fn rejects_path_traversal_repo_name() {
+        let err = ScenarioManifest::parse(
+            br#"{"_type": "merge_captain_playground_scenario", "scenario": "x", "owner": "burin-labs",
+              "repos": [{"name": "../../etc", "default_branch": "main"}]}"#,
+            &PathBuf::from("test.json"),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("safe for filesystem paths"));
+    }
+
+    #[test]
+    fn rejects_invalid_branch_ref() {
+        let err = ScenarioManifest::parse(
+            br#"{"_type": "merge_captain_playground_scenario", "scenario": "x", "owner": "burin-labs",
+              "repos": [{"name": "alpha", "default_branch": "main",
+                         "branches": [{"name": "..feature"}]}]}"#,
+            &PathBuf::from("test.json"),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("not a valid git ref"));
+    }
+
+    #[test]
+    fn rejects_duplicate_step_name() {
+        let err = ScenarioManifest::parse(
+            br#"{"_type": "merge_captain_playground_scenario", "scenario": "x", "owner": "burin-labs",
+              "repos": [{"name": "alpha", "default_branch": "main"}],
+              "steps": [{"name": "go"}, {"name": "go"}]}"#,
+            &PathBuf::from("test.json"),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("step"));
+    }
+
+    #[test]
+    fn parses_all_action_kinds() {
+        let m = json(
+            r#"{
+  "_type": "merge_captain_playground_scenario",
+  "scenario": "x",
+  "owner": "burin-labs",
+  "repos": [{"name": "alpha", "default_branch": "main",
+             "branches": [{"name": "feature/a", "files_set": {"a.txt": "1"}}]}],
+  "pull_requests": [{"repo": "alpha", "number": 1, "head_branch": "feature/a", "base_branch": "main", "mergeable_state": "clean"}],
+  "steps": [
+    {"name": "all", "actions": [
+      {"kind": "set_check", "repo": "alpha", "pr_number": 1, "name": "ci", "status": "completed", "conclusion": "success"},
+      {"kind": "close_pull_request", "repo": "alpha", "pr_number": 1},
+      {"kind": "merge_pull_request", "repo": "alpha", "pr_number": 1},
+      {"kind": "add_comment", "repo": "alpha", "pr_number": 1, "user": "alice", "body": "lgtm"},
+      {"kind": "set_labels", "repo": "alpha", "pr_number": 1, "labels": ["ready"]},
+      {"kind": "set_merge_queue_status", "repo": "alpha", "pr_number": 1, "status": "queued"},
+      {"kind": "force_push_author", "repo": "alpha", "branch": "feature/a", "files_set": {"a.txt": "2"}},
+      {"kind": "advance_base", "repo": "alpha", "files_set": {"main.txt": "1"}},
+      {"kind": "set_mergeability", "repo": "alpha", "pr_number": 1, "mergeable": true, "mergeable_state": "behind"},
+      {"kind": "advance_time_ms", "ms": 60000}
+    ]}
+  ]
+}"#,
+        );
+        let actions = &m.steps[0].actions;
+        assert_eq!(actions.len(), 10);
+    }
+}

--- a/crates/harn-vm/src/orchestration/playground/mod.rs
+++ b/crates/harn-vm/src/orchestration/playground/mod.rs
@@ -1,0 +1,66 @@
+//! Merge Captain mock-repos playground (#1020) — temp git repos plus a
+//! fake GitHub HTTP server that the captain (and any external connector)
+//! can sweep against. Companion to the JSONL replay backend in
+//! `merge_captain_driver.rs`.
+//!
+//! Public surface:
+//!
+//! * [`ScenarioManifest`] — declarative seed manifest, JSON or YAML.
+//! * [`init_playground_at`] / [`cleanup_playground_at`] — materialize and
+//!   tear down a playground directory.
+//! * [`load_playground`] — load `state.json` plus the canonicalized manifest.
+//! * [`apply_step`] / [`run_named_step`] / [`apply_one_action`] — advance
+//!   the playground state.
+//! * [`fake_server`] — pure request handlers used by the axum-based serve
+//!   command.
+//! * [`synthesize_sweep`] — generate a canonical agent-event transcript
+//!   reflecting the current playground state. Used by the `--backend mock
+//!   <playground-dir>` driver path.
+//! * [`load_builtin`] / [`builtin_scenario_names`] — embedded scenarios
+//!   resolved by `--scenario <name>`.
+
+mod fake_server;
+mod git;
+mod init;
+mod manifest;
+mod scenarios;
+mod state;
+mod step;
+mod transcript;
+
+#[cfg(test)]
+mod integration_tests;
+
+pub use fake_server::{
+    create_issue_comment, get_issue, get_pull, list_check_runs, list_issue_comments,
+    list_pull_files, list_pulls, merge_pull, merge_queue_enqueue, merge_queue_status, parse_query,
+    patch_pull, set_labels, workflow_run_logs, CreateCommentBody, EnqueueMergeQueueBody,
+    FakeResponse, ListPullsQuery, MergePullBody, SetLabelsBody, UpdatePullBody,
+};
+pub use init::{cleanup_playground_at, init_playground_at, load_playground, InitOptions};
+pub use manifest::{
+    ScenarioAction, ScenarioBranch, ScenarioCheck, ScenarioComment, ScenarioCommit,
+    ScenarioManifest, ScenarioPullRequest, ScenarioRepo, ScenarioStep, SCENARIO_TYPE,
+};
+pub use scenarios::{builtin_scenario_names, load_builtin};
+pub use state::{
+    manifest_path, playground_marker_path, state_path, PlaygroundHistoryEntry, PlaygroundMarker,
+    PlaygroundPullRequest, PlaygroundRepoState, PlaygroundState, PLAYGROUND_TYPE, STATE_TYPE,
+};
+pub use step::{apply_one_action, apply_step, run_named_step, StepReport};
+pub use transcript::{synthesize_sweep, TranscriptOptions};
+
+/// Locate a manifest given either a `--scenario <name>` (built-in lookup),
+/// a `--manifest <path>` (file read), or a default that prefers a
+/// `merge_captain.scenario.json` adjacent to the playground path. Useful
+/// for `harn merge-captain mock init`.
+pub fn resolve_init_manifest(
+    scenario_name: Option<&str>,
+    manifest_path: Option<&std::path::Path>,
+) -> Result<ScenarioManifest, crate::value::VmError> {
+    if let Some(path) = manifest_path {
+        return ScenarioManifest::load(path);
+    }
+    let name = scenario_name.unwrap_or("three_repo_basic");
+    load_builtin(name)
+}

--- a/crates/harn-vm/src/orchestration/playground/scenarios.rs
+++ b/crates/harn-vm/src/orchestration/playground/scenarios.rs
@@ -1,0 +1,49 @@
+//! Built-in scenario manifests for the Merge Captain mock-repos
+//! playground (#1020). These are the canonical seed manifests checked
+//! into `examples/merge_captain/scenarios/` and embedded into the
+//! binary via `include_str!` so `harn merge-captain mock init --scenario
+//! <name>` works without requiring an examples/ checkout at runtime.
+
+use std::path::Path;
+
+use crate::value::VmError;
+
+use super::manifest::ScenarioManifest;
+
+const THREE_REPO_BASIC: &str =
+    include_str!("../../../../../examples/merge_captain/scenarios/three_repo_basic.json");
+const SINGLE_GREEN: &str =
+    include_str!("../../../../../examples/merge_captain/scenarios/single_green.json");
+const FORCE_PUSH_DRILL: &str =
+    include_str!("../../../../../examples/merge_captain/scenarios/force_push_drill.json");
+
+pub fn builtin_scenario_names() -> Vec<&'static str> {
+    vec!["three_repo_basic", "single_green", "force_push_drill"]
+}
+
+pub fn load_builtin(name: &str) -> Result<ScenarioManifest, VmError> {
+    let raw = match name {
+        "three_repo_basic" => THREE_REPO_BASIC,
+        "single_green" => SINGLE_GREEN,
+        "force_push_drill" => FORCE_PUSH_DRILL,
+        other => {
+            return Err(VmError::Runtime(format!(
+                "unknown built-in scenario {other:?} (available: {})",
+                builtin_scenario_names().join(", ")
+            )))
+        }
+    };
+    ScenarioManifest::parse(raw.as_bytes(), Path::new(&format!("<builtin:{name}>")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_builtin_parses_and_validates() {
+        for name in builtin_scenario_names() {
+            load_builtin(name).unwrap_or_else(|e| panic!("scenario {name}: {e}"));
+        }
+    }
+}

--- a/crates/harn-vm/src/orchestration/playground/state.rs
+++ b/crates/harn-vm/src/orchestration/playground/state.rs
@@ -1,0 +1,280 @@
+//! Mutable playground state persisted to `<dir>/state.json`. The fake
+//! GitHub HTTP server (#1020) reads/writes this file on every request,
+//! which is what gives the playground its "real on-disk sandbox"
+//! feel — every captain sweep observes the live state, and every
+//! `mock step` produces a durable diff that subsequent sweeps see.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::value::VmError;
+
+use super::manifest::{
+    ScenarioCheck, ScenarioComment, ScenarioManifest, ScenarioPullRequest, ScenarioStep,
+};
+
+pub const STATE_TYPE: &str = "merge_captain_playground_state";
+pub const PLAYGROUND_TYPE: &str = "merge_captain_playground";
+
+/// A snapshot of the playground's mutable state.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct PlaygroundState {
+    #[serde(rename = "_type")]
+    pub type_name: String,
+    pub version: u32,
+    /// Owner used in API URLs; cloned from the manifest.
+    pub owner: String,
+    /// Logical scenario name (provenance only).
+    pub scenario: String,
+    /// Monotonic step counter — incremented every time `apply_action` runs.
+    pub step_count: u64,
+    /// Playground clock, in milliseconds since UNIX epoch. Defaults to a
+    /// stable seed (2026-01-01) so transcripts are byte-stable across runs.
+    pub now_ms: i64,
+    /// Per-repo state.
+    pub repos: BTreeMap<String, PlaygroundRepoState>,
+    /// Global PR list keyed by `<repo>#<number>`.
+    pub pull_requests: BTreeMap<String, PlaygroundPullRequest>,
+    /// History of applied actions (most recent last) — used by `status`
+    /// and by the synthetic transcript builder to record sweep activity.
+    pub history: Vec<PlaygroundHistoryEntry>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct PlaygroundRepoState {
+    pub name: String,
+    pub default_branch: String,
+    /// Bare-remote-relative branches that exist (kept in sync with the
+    /// remote in `init` and `step`).
+    pub branches: Vec<String>,
+    /// Resolved file:// URL of the bare remote (without trailing slash).
+    pub remote_url: String,
+    /// Path of the working clone (relative to the playground root).
+    pub working_path: String,
+    /// Path of the bare remote (relative to the playground root).
+    pub remote_path: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct PlaygroundPullRequest {
+    pub repo: String,
+    pub number: u64,
+    pub title: String,
+    pub body: String,
+    /// `open`, `closed`, `merged`.
+    pub state: String,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub user: String,
+    pub draft: bool,
+    pub labels: Vec<String>,
+    pub checks: Vec<ScenarioCheck>,
+    pub mergeable: Option<bool>,
+    pub mergeable_state: String,
+    pub merge_queue_status: Option<String>,
+    pub comments: Vec<ScenarioComment>,
+    pub merged_at: Option<String>,
+    pub closed_at: Option<String>,
+    /// Latest commit SHA on the head branch (set by `init` and updated
+    /// after force-push / advance-base / merge).
+    pub head_sha: Option<String>,
+}
+
+impl PlaygroundPullRequest {
+    pub fn key(&self) -> String {
+        Self::compose_key(&self.repo, self.number)
+    }
+
+    pub fn compose_key(repo: &str, number: u64) -> String {
+        format!("{repo}#{number}")
+    }
+}
+
+/// One entry in the playground history log.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlaygroundHistoryEntry {
+    /// Monotonic id starting at 1.
+    pub seq: u64,
+    /// `init`, `step:<name>`, `action:<kind>`.
+    pub source: String,
+    /// JSON description of the action (for replay/audit).
+    pub detail: serde_json::Value,
+    /// Playground-clock millis at the time of the action.
+    pub at_ms: i64,
+}
+
+impl PlaygroundState {
+    pub fn from_manifest(manifest: &ScenarioManifest) -> Self {
+        let mut state = PlaygroundState {
+            type_name: STATE_TYPE.to_string(),
+            version: 1,
+            owner: manifest.owner.clone(),
+            scenario: manifest.scenario.clone(),
+            step_count: 0,
+            now_ms: 1_767_225_600_000, // 2026-01-01T00:00:00Z, deterministic seed.
+            ..Default::default()
+        };
+        for repo in &manifest.repos {
+            let mut branches = vec![repo.default_branch.clone()];
+            for branch in &repo.branches {
+                branches.push(branch.name.clone());
+            }
+            state.repos.insert(
+                repo.name.clone(),
+                PlaygroundRepoState {
+                    name: repo.name.clone(),
+                    default_branch: repo.default_branch.clone(),
+                    branches,
+                    remote_url: String::new(),
+                    working_path: format!("working/{}", repo.name),
+                    remote_path: format!("remotes/{}.git", repo.name),
+                },
+            );
+        }
+        for pr in &manifest.pull_requests {
+            let pr_state = PlaygroundPullRequest::from_manifest_pr(pr);
+            state.pull_requests.insert(pr_state.key(), pr_state);
+        }
+        state
+    }
+
+    pub fn step_index(&self, name: &str, manifest: &ScenarioManifest) -> Option<usize> {
+        manifest.steps.iter().position(|step| step.name == name)
+    }
+
+    pub fn list_steps<'a>(&self, manifest: &'a ScenarioManifest) -> Vec<&'a ScenarioStep> {
+        manifest.steps.iter().collect()
+    }
+
+    pub fn record(&mut self, source: &str, detail: serde_json::Value) {
+        self.step_count += 1;
+        self.history.push(PlaygroundHistoryEntry {
+            seq: self.step_count,
+            source: source.to_string(),
+            detail,
+            at_ms: self.now_ms,
+        });
+    }
+
+    pub fn save(&self, dir: &Path) -> Result<(), VmError> {
+        let path = state_path(dir);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                VmError::Runtime(format!(
+                    "failed to create playground dir {}: {error}",
+                    parent.display()
+                ))
+            })?;
+        }
+        let mut bytes = serde_json::to_vec_pretty(self).map_err(|error| {
+            VmError::Runtime(format!("failed to serialize playground state: {error}"))
+        })?;
+        bytes.push(b'\n');
+        std::fs::write(&path, bytes).map_err(|error| {
+            VmError::Runtime(format!(
+                "failed to write playground state {}: {error}",
+                path.display()
+            ))
+        })
+    }
+
+    pub fn load(dir: &Path) -> Result<Self, VmError> {
+        let path = state_path(dir);
+        let bytes = std::fs::read(&path).map_err(|error| {
+            VmError::Runtime(format!(
+                "failed to read playground state {}: {error}",
+                path.display()
+            ))
+        })?;
+        let state: PlaygroundState = serde_json::from_slice(&bytes).map_err(|error| {
+            VmError::Runtime(format!(
+                "failed to parse playground state {}: {error}",
+                path.display()
+            ))
+        })?;
+        if state.type_name != STATE_TYPE {
+            return Err(VmError::Runtime(format!(
+                "playground state {} has _type {:?}, expected {STATE_TYPE}",
+                path.display(),
+                state.type_name
+            )));
+        }
+        Ok(state)
+    }
+}
+
+impl PlaygroundPullRequest {
+    pub fn from_manifest_pr(pr: &ScenarioPullRequest) -> Self {
+        let state = if pr.state.is_empty() {
+            "open".to_string()
+        } else {
+            pr.state.clone()
+        };
+        let mergeable_state = if pr.mergeable_state.is_empty() {
+            "clean".to_string()
+        } else {
+            pr.mergeable_state.clone()
+        };
+        PlaygroundPullRequest {
+            repo: pr.repo.clone(),
+            number: pr.number,
+            title: pr.title.clone(),
+            body: pr.body.clone(),
+            state,
+            head_branch: pr.head_branch.clone(),
+            base_branch: pr.base_branch.clone(),
+            user: if pr.user.is_empty() {
+                "playground-author".to_string()
+            } else {
+                pr.user.clone()
+            },
+            draft: pr.draft,
+            labels: pr.labels.clone(),
+            checks: pr.checks.clone(),
+            mergeable: pr.mergeable,
+            mergeable_state,
+            merge_queue_status: pr.merge_queue_status.clone(),
+            comments: pr.comments.clone(),
+            merged_at: None,
+            closed_at: None,
+            head_sha: None,
+        }
+    }
+}
+
+pub fn state_path(dir: &Path) -> PathBuf {
+    dir.join("state.json")
+}
+
+pub fn manifest_path(dir: &Path) -> PathBuf {
+    dir.join("manifest.json")
+}
+
+pub fn playground_marker_path(dir: &Path) -> PathBuf {
+    dir.join("playground.json")
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlaygroundMarker {
+    #[serde(rename = "_type")]
+    pub type_name: String,
+    pub version: u32,
+    pub scenario: String,
+    pub created_at_ms: i64,
+}
+
+impl PlaygroundMarker {
+    pub fn new(scenario: &str, created_at_ms: i64) -> Self {
+        PlaygroundMarker {
+            type_name: PLAYGROUND_TYPE.to_string(),
+            version: 1,
+            scenario: scenario.to_string(),
+            created_at_ms,
+        }
+    }
+}

--- a/crates/harn-vm/src/orchestration/playground/step.rs
+++ b/crates/harn-vm/src/orchestration/playground/step.rs
@@ -1,0 +1,434 @@
+//! Step actions — the levers a brute-forcing agent pulls between captain
+//! sweeps in a Merge Captain mock-repos playground (#1020).
+//!
+//! Step actions are split into two flavors:
+//!
+//! * **State-only**: mutations that only touch `state.json` (e.g.
+//!   `set_check`, `set_labels`, `add_comment`).
+//! * **Git-native**: mutations that produce real commits on the bare
+//!   remote (e.g. `merge_pull_request`, `force_push_author`,
+//!   `advance_base`). The captain's subsequent rebase/fetch sees the
+//!   real diverged history.
+
+use std::path::Path;
+
+use serde_json::json;
+
+use crate::value::VmError;
+
+use super::git::GitOps;
+use super::manifest::{ScenarioAction, ScenarioManifest, ScenarioStep};
+use super::state::{PlaygroundPullRequest, PlaygroundState};
+
+pub struct StepReport {
+    /// Number of state mutations applied (may be more than 1 per step).
+    pub actions_applied: usize,
+    /// Names of PRs whose state was updated. Useful for `mock status`.
+    pub prs_touched: Vec<String>,
+    /// Optional human-readable summary lines.
+    pub summary: Vec<String>,
+}
+
+pub fn run_named_step(
+    dir: &Path,
+    state: &mut PlaygroundState,
+    manifest: &ScenarioManifest,
+    step_name: &str,
+) -> Result<StepReport, VmError> {
+    let step = manifest
+        .steps
+        .iter()
+        .find(|s| s.name == step_name)
+        .ok_or_else(|| {
+            let available: Vec<String> = manifest.steps.iter().map(|s| s.name.clone()).collect();
+            VmError::Runtime(format!(
+                "scenario {} has no step named {step_name:?} (available: {})",
+                manifest.scenario,
+                if available.is_empty() {
+                    "<none>".to_string()
+                } else {
+                    available.join(", ")
+                }
+            ))
+        })?
+        .clone();
+    apply_step(dir, state, manifest, &step)
+}
+
+pub fn apply_step(
+    dir: &Path,
+    state: &mut PlaygroundState,
+    manifest: &ScenarioManifest,
+    step: &ScenarioStep,
+) -> Result<StepReport, VmError> {
+    let mut report = StepReport {
+        actions_applied: 0,
+        prs_touched: Vec::new(),
+        summary: Vec::new(),
+    };
+    for action in &step.actions {
+        let summary = apply_action(dir, state, manifest, action)?;
+        report.actions_applied += 1;
+        if let Some((pr, line)) = summary {
+            if !report.prs_touched.contains(&pr) {
+                report.prs_touched.push(pr);
+            }
+            report.summary.push(line);
+        }
+    }
+    state.record(
+        &format!("step:{}", step.name),
+        json!({"actions": step.actions.len()}),
+    );
+    Ok(report)
+}
+
+/// Apply a single ad-hoc action without going through a named step. Used by
+/// the `mock step --action <json>` CLI fallback for one-off mutations.
+pub fn apply_one_action(
+    dir: &Path,
+    state: &mut PlaygroundState,
+    manifest: &ScenarioManifest,
+    action: &ScenarioAction,
+) -> Result<StepReport, VmError> {
+    let summary = apply_action(dir, state, manifest, action)?;
+    state.record(
+        &format!("action:{}", action_kind(action)),
+        serde_json::to_value(action).unwrap_or(serde_json::Value::Null),
+    );
+    let mut report = StepReport {
+        actions_applied: 1,
+        prs_touched: Vec::new(),
+        summary: Vec::new(),
+    };
+    if let Some((pr, line)) = summary {
+        report.prs_touched.push(pr);
+        report.summary.push(line);
+    }
+    Ok(report)
+}
+
+fn apply_action(
+    dir: &Path,
+    state: &mut PlaygroundState,
+    manifest: &ScenarioManifest,
+    action: &ScenarioAction,
+) -> Result<Option<(String, String)>, VmError> {
+    let git = GitOps::default();
+    match action {
+        ScenarioAction::SetCheck {
+            repo,
+            pr_number,
+            name,
+            status,
+            conclusion,
+            details_url,
+        } => {
+            let now_ms = state.now_ms;
+            let pr = require_pr_mut(state, repo, *pr_number)?;
+            let existing = pr.checks.iter_mut().find(|c| &c.name == name);
+            let conclusion_value = conclusion.clone();
+            let started = Some(format_clock(now_ms));
+            let completed = if status == "completed" {
+                Some(format_clock(now_ms + 1))
+            } else {
+                None
+            };
+            match existing {
+                Some(check) => {
+                    check.status = status.clone();
+                    check.conclusion = conclusion_value;
+                    if check.started_at.is_none() {
+                        check.started_at = started;
+                    }
+                    check.completed_at = completed;
+                    check.details_url = details_url.clone();
+                }
+                None => {
+                    pr.checks.push(super::manifest::ScenarioCheck {
+                        name: name.clone(),
+                        status: status.clone(),
+                        conclusion: conclusion_value,
+                        details_url: details_url.clone(),
+                        started_at: started,
+                        completed_at: completed,
+                    });
+                }
+            }
+            Ok(Some((
+                pr.key(),
+                format!("set check {name}={status} on {}#{}", repo, pr_number),
+            )))
+        }
+        ScenarioAction::AddPullRequest { pr } => {
+            if !state.repos.contains_key(&pr.repo) {
+                return Err(VmError::Runtime(format!("unknown repo {}", pr.repo)));
+            }
+            let pr_state = PlaygroundPullRequest::from_manifest_pr(pr);
+            let key = pr_state.key();
+            if state.pull_requests.contains_key(&key) {
+                return Err(VmError::Runtime(format!("PR {key} already exists",)));
+            }
+            // Resolve head_sha if the head branch exists on the remote.
+            let working = working_path(dir, &pr.repo);
+            let head_sha = git
+                .rev_parse(&working, &format!("origin/{}", pr.head_branch))
+                .ok();
+            let mut pr_state = pr_state;
+            pr_state.head_sha = head_sha;
+            state.pull_requests.insert(key.clone(), pr_state);
+            Ok(Some((key, format!("opened PR {}#{}", pr.repo, pr.number))))
+        }
+        ScenarioAction::ClosePullRequest { repo, pr_number } => {
+            let now_ms = state.now_ms;
+            let pr = require_pr_mut(state, repo, *pr_number)?;
+            pr.state = "closed".to_string();
+            pr.closed_at = Some(format_clock(now_ms));
+            Ok(Some((pr.key(), format!("closed PR {repo}#{pr_number}"))))
+        }
+        ScenarioAction::MergePullRequest {
+            repo,
+            pr_number,
+            merge_method,
+        } => {
+            let (head_branch, base_branch, title) = {
+                let pr = require_pr(state, repo, *pr_number)?;
+                (
+                    pr.head_branch.clone(),
+                    pr.base_branch.clone(),
+                    pr.title.clone(),
+                )
+            };
+            let working = working_path(dir, repo);
+            git.fetch(&working)?;
+            let merge_message =
+                format!("Merge pull request #{pr_number} from {repo}/{head_branch}\n\n{title}");
+            let merge_sha =
+                git.merge_branch(&working, &head_branch, &base_branch, &merge_message)?;
+            let now_ms = state.now_ms;
+            let pr = require_pr_mut(state, repo, *pr_number)?;
+            pr.state = "merged".to_string();
+            pr.merged_at = Some(format_clock(now_ms));
+            pr.head_sha = Some(merge_sha.clone());
+            pr.mergeable_state = "clean".to_string();
+            pr.mergeable = Some(true);
+            pr.merge_queue_status = match merge_method.as_deref() {
+                Some(method) if method.eq_ignore_ascii_case("queue") => Some("merged".to_string()),
+                _ => pr.merge_queue_status.clone(),
+            };
+            Ok(Some((
+                pr.key(),
+                format!("merged PR {repo}#{pr_number} into {base_branch}"),
+            )))
+        }
+        ScenarioAction::AddComment {
+            repo,
+            pr_number,
+            user,
+            body,
+        } => {
+            let now_ms = state.now_ms;
+            let pr = require_pr_mut(state, repo, *pr_number)?;
+            pr.comments.push(super::manifest::ScenarioComment {
+                user: user.clone(),
+                body: body.clone(),
+                created_at: Some(format_clock(now_ms)),
+            });
+            Ok(Some((
+                pr.key(),
+                format!("comment by {user} on {repo}#{pr_number}"),
+            )))
+        }
+        ScenarioAction::SetLabels {
+            repo,
+            pr_number,
+            labels,
+        } => {
+            let pr = require_pr_mut(state, repo, *pr_number)?;
+            pr.labels = labels.clone();
+            Ok(Some((
+                pr.key(),
+                format!("labels={:?} on {repo}#{pr_number}", labels),
+            )))
+        }
+        ScenarioAction::SetMergeQueueStatus {
+            repo,
+            pr_number,
+            status,
+        } => {
+            let pr = require_pr_mut(state, repo, *pr_number)?;
+            pr.merge_queue_status = Some(status.clone());
+            Ok(Some((
+                pr.key(),
+                format!("merge_queue_status={status} on {repo}#{pr_number}"),
+            )))
+        }
+        ScenarioAction::ForcePushAuthor {
+            repo,
+            branch,
+            files_set,
+            files_delete,
+            commit_message,
+        } => {
+            let working = working_path(dir, repo);
+            // Refresh local refs so origin/<base> is current before
+            // we reset the head branch onto it.
+            git.fetch(&working)?;
+            let base = manifest_base_for_branch(manifest, repo, branch);
+            let message = commit_message
+                .clone()
+                .unwrap_or_else(|| format!("Force-pushed rewrite on {branch}"));
+            let new_sha = git.force_rewrite_branch(
+                &working,
+                branch,
+                &base,
+                files_set,
+                files_delete,
+                &message,
+            )?;
+            // Update head_sha on any PRs that point at this branch.
+            let mut keys = Vec::new();
+            for pr in state
+                .pull_requests
+                .values_mut()
+                .filter(|pr| pr.repo == *repo && pr.head_branch == *branch)
+            {
+                pr.head_sha = Some(new_sha.clone());
+                pr.mergeable_state = "unknown".to_string();
+                pr.mergeable = None;
+                keys.push(pr.key());
+            }
+            let summary_key = keys.first().cloned().unwrap_or_else(|| repo.clone());
+            Ok(Some((
+                summary_key,
+                format!("force-push by author on {repo}/{branch}"),
+            )))
+        }
+        ScenarioAction::AdvanceBase {
+            repo,
+            files_set,
+            files_delete,
+            commit_message,
+        } => {
+            let working = working_path(dir, repo);
+            git.fetch(&working)?;
+            let default_branch = state
+                .repos
+                .get(repo)
+                .map(|r| r.default_branch.clone())
+                .ok_or_else(|| VmError::Runtime(format!("unknown repo {repo}")))?;
+            git.checkout(&working, &default_branch)?;
+            git.run(
+                &working,
+                &["pull", "--quiet", "--ff-only", "origin", &default_branch],
+            )?;
+            let message = commit_message
+                .clone()
+                .unwrap_or_else(|| format!("Advance {default_branch}"));
+            let _new_sha = git.commit_overlay(
+                &working,
+                files_set,
+                files_delete,
+                &message,
+                Some(&default_branch),
+            )?;
+            // Mark all open PRs with this base as `behind`.
+            let mut prs_touched = Vec::new();
+            for pr in state.pull_requests.values_mut().filter(|pr| {
+                pr.repo == *repo && pr.base_branch == default_branch && pr.state == "open"
+            }) {
+                pr.mergeable_state = "behind".to_string();
+                pr.mergeable = Some(false);
+                prs_touched.push(pr.key());
+            }
+            Ok(Some((
+                prs_touched.first().cloned().unwrap_or_else(|| repo.clone()),
+                format!("advanced base {repo}/{default_branch}"),
+            )))
+        }
+        ScenarioAction::SetMergeability {
+            repo,
+            pr_number,
+            mergeable,
+            mergeable_state,
+        } => {
+            let pr = require_pr_mut(state, repo, *pr_number)?;
+            pr.mergeable = *mergeable;
+            pr.mergeable_state = mergeable_state.clone();
+            Ok(Some((
+                pr.key(),
+                format!("mergeable_state={mergeable_state} on {repo}#{pr_number}"),
+            )))
+        }
+        ScenarioAction::AdvanceTimeMs { ms } => {
+            state.now_ms = state.now_ms.saturating_add(*ms as i64);
+            Ok(None)
+        }
+    }
+}
+
+fn require_pr_mut<'a>(
+    state: &'a mut PlaygroundState,
+    repo: &str,
+    number: u64,
+) -> Result<&'a mut PlaygroundPullRequest, VmError> {
+    let key = PlaygroundPullRequest::compose_key(repo, number);
+    state
+        .pull_requests
+        .get_mut(&key)
+        .ok_or_else(|| VmError::Runtime(format!("unknown PR {key}")))
+}
+
+fn require_pr<'a>(
+    state: &'a PlaygroundState,
+    repo: &str,
+    number: u64,
+) -> Result<&'a PlaygroundPullRequest, VmError> {
+    let key = PlaygroundPullRequest::compose_key(repo, number);
+    state
+        .pull_requests
+        .get(&key)
+        .ok_or_else(|| VmError::Runtime(format!("unknown PR {key}")))
+}
+
+fn working_path(dir: &Path, repo: &str) -> std::path::PathBuf {
+    dir.join("working").join(repo)
+}
+
+fn manifest_base_for_branch(manifest: &ScenarioManifest, repo: &str, branch: &str) -> String {
+    if let Some(repo_def) = manifest.repos.iter().find(|r| r.name == repo) {
+        if let Some(b) = repo_def.branches.iter().find(|b| b.name == branch) {
+            return b
+                .base
+                .clone()
+                .unwrap_or_else(|| repo_def.default_branch.clone());
+        }
+        return repo_def.default_branch.clone();
+    }
+    "main".to_string()
+}
+
+fn action_kind(action: &ScenarioAction) -> &'static str {
+    match action {
+        ScenarioAction::SetCheck { .. } => "set_check",
+        ScenarioAction::AddPullRequest { .. } => "add_pull_request",
+        ScenarioAction::ClosePullRequest { .. } => "close_pull_request",
+        ScenarioAction::MergePullRequest { .. } => "merge_pull_request",
+        ScenarioAction::AddComment { .. } => "add_comment",
+        ScenarioAction::SetLabels { .. } => "set_labels",
+        ScenarioAction::SetMergeQueueStatus { .. } => "set_merge_queue_status",
+        ScenarioAction::ForcePushAuthor { .. } => "force_push_author",
+        ScenarioAction::AdvanceBase { .. } => "advance_base",
+        ScenarioAction::SetMergeability { .. } => "set_mergeability",
+        ScenarioAction::AdvanceTimeMs { .. } => "advance_time_ms",
+    }
+}
+
+fn format_clock(now_ms: i64) -> String {
+    use chrono::TimeZone;
+    let utc = chrono::Utc
+        .timestamp_millis_opt(now_ms)
+        .single()
+        .unwrap_or_else(chrono::Utc::now);
+    utc.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}

--- a/crates/harn-vm/src/orchestration/playground/transcript.rs
+++ b/crates/harn-vm/src/orchestration/playground/transcript.rs
@@ -1,0 +1,281 @@
+//! Synthesize a canonical Merge Captain JSONL transcript from a
+//! `PlaygroundState`. This is what the existing `--backend mock` driver
+//! produces when pointed at a real on-disk playground (vs. the transcript
+//! replay path, which still works for the preexisting JSON manifest).
+//!
+//! The transcript intentionally mirrors the same `PersistedAgentEvent`
+//! envelope that the audit oracle and JSONL sink consume, so byte-stable
+//! receipts can be diffed across runs.
+
+use serde_json::{json, Value};
+
+use crate::agent_events::{AgentEvent, PersistedAgentEvent, ToolCallStatus};
+
+use super::state::{PlaygroundPullRequest, PlaygroundState};
+
+pub struct TranscriptOptions {
+    pub session_id: String,
+}
+
+impl Default for TranscriptOptions {
+    fn default() -> Self {
+        TranscriptOptions {
+            session_id: "merge-captain-playground".to_string(),
+        }
+    }
+}
+
+pub fn synthesize_sweep(
+    state: &PlaygroundState,
+    options: &TranscriptOptions,
+) -> Vec<PersistedAgentEvent> {
+    let mut events: Vec<PersistedAgentEvent> = Vec::new();
+    let mut now = state.now_ms;
+    let mut idx: u64 = 0;
+    let bump = |delta: i64, now: &mut i64, idx: &mut u64| {
+        *now = now.saturating_add(delta);
+        let value = *idx;
+        *idx += 1;
+        value
+    };
+
+    let session_id = options.session_id.clone();
+    let envelope = |index: u64, at: i64, event: AgentEvent| PersistedAgentEvent {
+        index,
+        emitted_at_ms: at,
+        frame_depth: Some(0),
+        event,
+    };
+
+    let i = bump(0, &mut now, &mut idx);
+    events.push(envelope(
+        i,
+        now,
+        AgentEvent::TurnStart {
+            session_id: session_id.clone(),
+            iteration: 1,
+        },
+    ));
+
+    let i = bump(10, &mut now, &mut idx);
+    events.push(envelope(
+        i,
+        now,
+        AgentEvent::AgentThoughtChunk {
+            session_id: session_id.clone(),
+            content: format!(
+                "Sweep playground scenario={} ({} repos, {} PRs)",
+                state.scenario,
+                state.repos.len(),
+                state.pull_requests.len()
+            ),
+        },
+    ));
+
+    let mut prs: Vec<&PlaygroundPullRequest> = state
+        .pull_requests
+        .values()
+        .filter(|pr| pr.state == "open")
+        .collect();
+    prs.sort_by_key(|pr| (pr.repo.clone(), pr.number));
+
+    let mut tool_call_counter = 0u64;
+    for pr in prs {
+        tool_call_counter += 1;
+        let intake_id = format!("call_{tool_call_counter}");
+        let i = bump(20, &mut now, &mut idx);
+        events.push(envelope(
+            i,
+            now,
+            AgentEvent::ToolCall {
+                session_id: session_id.clone(),
+                tool_call_id: intake_id.clone(),
+                tool_name: "gh_pull_request_get".to_string(),
+                kind: None,
+                status: ToolCallStatus::Pending,
+                raw_input: json!({"repo": format!("{}/{}", state.owner, pr.repo), "pr_number": pr.number}),
+                parsing: None,
+                audit: None,
+            },
+        ));
+        let i = bump(40, &mut now, &mut idx);
+        events.push(envelope(
+            i,
+            now,
+            AgentEvent::ToolCallUpdate {
+                session_id: session_id.clone(),
+                tool_call_id: intake_id,
+                tool_name: "gh_pull_request_get".to_string(),
+                status: ToolCallStatus::Completed,
+                raw_output: Some(pr_summary(pr)),
+                error: None,
+                duration_ms: Some(40),
+                execution_duration_ms: Some(40),
+                error_category: None,
+                executor: None,
+                parsing: None,
+                raw_input: None,
+                raw_input_partial: None,
+                audit: None,
+            },
+        ));
+
+        let i = bump(20, &mut now, &mut idx);
+        events.push(envelope(
+            i,
+            now,
+            AgentEvent::Plan {
+                session_id: session_id.clone(),
+                plan: pr_plan(pr),
+            },
+        ));
+
+        tool_call_counter += 1;
+        let checks_id = format!("call_{tool_call_counter}");
+        let i = bump(20, &mut now, &mut idx);
+        events.push(envelope(
+            i,
+            now,
+            AgentEvent::ToolCall {
+                session_id: session_id.clone(),
+                tool_call_id: checks_id.clone(),
+                tool_name: "gh_pr_checks_list".to_string(),
+                kind: None,
+                status: ToolCallStatus::Pending,
+                raw_input: json!({"repo": format!("{}/{}", state.owner, pr.repo), "pr_number": pr.number}),
+                parsing: None,
+                audit: None,
+            },
+        ));
+        let i = bump(40, &mut now, &mut idx);
+        events.push(envelope(
+            i,
+            now,
+            AgentEvent::ToolCallUpdate {
+                session_id: session_id.clone(),
+                tool_call_id: checks_id,
+                tool_name: "gh_pr_checks_list".to_string(),
+                status: ToolCallStatus::Completed,
+                raw_output: Some(checks_summary(pr)),
+                error: None,
+                duration_ms: Some(40),
+                execution_duration_ms: Some(40),
+                error_category: None,
+                executor: None,
+                parsing: None,
+                raw_input: None,
+                raw_input_partial: None,
+                audit: None,
+            },
+        ));
+
+        let i = bump(10, &mut now, &mut idx);
+        events.push(envelope(
+            i,
+            now,
+            AgentEvent::Plan {
+                session_id: session_id.clone(),
+                plan: risk_plan(pr),
+            },
+        ));
+    }
+
+    let i = bump(50, &mut now, &mut idx);
+    events.push(envelope(
+        i,
+        now,
+        AgentEvent::AgentThoughtChunk {
+            session_id: session_id.clone(),
+            content: format!(
+                "Sweep complete: {} PR(s) inspected, {} require follow-up",
+                state
+                    .pull_requests
+                    .values()
+                    .filter(|p| p.state == "open")
+                    .count(),
+                state
+                    .pull_requests
+                    .values()
+                    .filter(|p| p.state == "open" && needs_followup(p))
+                    .count()
+            ),
+        },
+    ));
+
+    let _ = bump(0, &mut now, &mut idx);
+    events
+}
+
+fn pr_summary(pr: &PlaygroundPullRequest) -> Value {
+    let failing: Vec<String> = pr
+        .checks
+        .iter()
+        .filter(|c| {
+            c.conclusion
+                .as_deref()
+                .map(|c| matches!(c, "failure" | "timed_out" | "cancelled"))
+                .unwrap_or(false)
+        })
+        .map(|c| c.name.clone())
+        .collect();
+    json!({
+        "repo": pr.repo,
+        "pr_number": pr.number,
+        "title": pr.title,
+        "state": pr.state,
+        "head_branch": pr.head_branch,
+        "base_branch": pr.base_branch,
+        "mergeable": pr.mergeable,
+        "mergeable_state": pr.mergeable_state,
+        "failing_checks": failing,
+        "stale_threads": Vec::<String>::new(),
+        "merge_conflicts": pr.mergeable_state == "dirty",
+        "merge_queue_status": pr.merge_queue_status,
+    })
+}
+
+fn pr_plan(pr: &PlaygroundPullRequest) -> Value {
+    json!({
+        "step": "intake",
+        "repo": pr.repo,
+        "pr_number": pr.number,
+        "head_branch": pr.head_branch,
+        "approval_required": false,
+    })
+}
+
+fn risk_plan(pr: &PlaygroundPullRequest) -> Value {
+    let risk = if needs_followup(pr) { "high" } else { "low" };
+    json!({
+        "step": "decide_risk",
+        "repo": pr.repo,
+        "pr_number": pr.number,
+        "review_risk": risk,
+        "approval_required": false,
+    })
+}
+
+fn checks_summary(pr: &PlaygroundPullRequest) -> Value {
+    let runs: Vec<Value> = pr
+        .checks
+        .iter()
+        .map(|c| {
+            json!({
+                "name": c.name,
+                "status": c.status,
+                "conclusion": c.conclusion,
+            })
+        })
+        .collect();
+    json!({"check_runs": runs})
+}
+
+fn needs_followup(pr: &PlaygroundPullRequest) -> bool {
+    pr.mergeable_state == "behind"
+        || pr.mergeable_state == "dirty"
+        || pr.mergeable_state == "blocked"
+        || pr
+            .checks
+            .iter()
+            .any(|c| matches!(c.conclusion.as_deref(), Some("failure" | "timed_out")))
+}

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -84,6 +84,56 @@ Flags:
 | `--receipt-out PATH` | Write receipt JSON to an explicit path. |
 | `--summary-out PATH` | Write run summary JSON to a file. |
 
+### Mock-repos playground (#1020)
+
+`harn merge-captain mock` materializes a real on-disk sandbox — temp
+git repos plus a fake GitHub HTTP server — so you can iterate on the
+captain against real `git` codepaths without touching live
+infrastructure. This is the recommended local iteration loop.
+
+```bash
+# 1. Create a playground from a built-in scenario. Default scenario is
+#    `three_repo_basic`. List built-ins with `mock scenarios`.
+harn merge-captain mock init ./pg --scenario three_repo_basic
+
+# 2. Sweep the captain against it. The driver detects the on-disk
+#    playground and synthesizes a canonical JSONL transcript reflecting
+#    the live state.
+harn merge-captain run --backend mock ./pg --once
+
+# 3. Advance the scenario between sweeps — flip a check, advance base,
+#    force-push as the author, merge a PR, etc. Steps come from the
+#    scenario manifest; `--action <json>` is the one-off escape hatch.
+harn merge-captain mock step ./pg --name gamma_force_push_fix
+harn merge-captain mock step ./pg --action \
+  '{"kind":"set_check","repo":"alpha","pr_number":101,"name":"ci","status":"completed","conclusion":"success"}'
+
+# 4. Boot the fake GitHub HTTP server pointing at the playground state.
+#    Real HTTP clients (e.g. harn-github-connector) talk to this; the
+#    captain still uses real `git` against bare remotes under
+#    ./pg/remotes/<repo>.git.
+harn merge-captain mock serve ./pg --bind 127.0.0.1:0 --print-addr
+
+# 5. Snapshot or tear down.
+harn merge-captain mock status ./pg --json
+harn merge-captain mock cleanup ./pg
+```
+
+Subcommands:
+
+| Subcommand | Purpose |
+|---|---|
+| `mock init <dir>` | Materialize bare+working git repos + `state.json` from a scenario. `--scenario` (built-in) or `--manifest <path>` (custom JSON/YAML). `--force` cleans up first. |
+| `mock step <dir>` | Apply a manifest-defined `--name <step>` or one-off `--action <json>`. Mutates `state.json` (and the bare remote when the action is `merge_pull_request`, `force_push_author`, or `advance_base`). |
+| `mock status <dir>` | Print the current PR/check/history state. `--json` for machine output. |
+| `mock serve <dir>` | Boot the fake GitHub HTTP server. Endpoints: `pulls`, `pulls/.../merge`, `pulls/.../files`, `commits/.../check-runs`, `actions/runs/.../logs`, `merge_queue/queues/...`, `issues`, `issues/.../comments`, `issues/.../labels`. |
+| `mock cleanup <dir>` | Remove the playground. Idempotent and refuses to delete arbitrary directories without the playground marker. |
+| `mock scenarios` | List built-in scenarios. |
+
+Scenario manifests live at `examples/merge_captain/scenarios/*.json`
+and follow the `merge_captain_playground_scenario` schema documented
+in `crates/harn-vm/src/orchestration/playground/manifest.rs`.
+
 ## stdin / stdout / stderr / TTY
 
 - `print(s)` / `println(s)` → stdout. `eprint(s)` / `eprintln(s)` →

--- a/examples/merge_captain/scenarios/force_push_drill.json
+++ b/examples/merge_captain/scenarios/force_push_drill.json
@@ -1,0 +1,54 @@
+{
+  "_type": "merge_captain_playground_scenario",
+  "scenario": "force_push_drill",
+  "description": "Drill for force-with-lease handling: a PR whose author force-pushes mid-sweep. Captain should observe a head_sha change and re-verify checks.",
+  "owner": "burin-labs",
+  "repos": [
+    {
+      "name": "drill",
+      "default_branch": "main",
+      "files": {
+        "README.md": "# drill\n",
+        "src/lib.rs": "pub fn drill() -> i32 { 0 }\n"
+      },
+      "branches": [
+        {
+          "name": "feature/work-in-progress",
+          "files_set": {
+            "src/lib.rs": "pub fn drill() -> i32 { 1 }\n"
+          },
+          "commit_message": "feat(drill): wip"
+        }
+      ]
+    }
+  ],
+  "pull_requests": [
+    {
+      "repo": "drill",
+      "number": 42,
+      "title": "drill: wip",
+      "body": "Author keeps force-pushing.",
+      "state": "open",
+      "head_branch": "feature/work-in-progress",
+      "base_branch": "main",
+      "user": "carol",
+      "labels": [],
+      "checks": [
+        {"name": "ci", "status": "in_progress"}
+      ],
+      "mergeable": null,
+      "mergeable_state": "unknown"
+    }
+  ],
+  "steps": [
+    {
+      "name": "force_push_passing_v2",
+      "description": "Author force-pushes a v2 of the change and CI runs to green.",
+      "actions": [
+        {"kind": "force_push_author", "repo": "drill", "branch": "feature/work-in-progress", "files_set": {"src/lib.rs": "pub fn drill() -> i32 { 2 }\n"}, "commit_message": "feat(drill): v2"},
+        {"kind": "set_check", "repo": "drill", "pr_number": 42, "name": "ci", "status": "completed", "conclusion": "success"},
+        {"kind": "set_mergeability", "repo": "drill", "pr_number": 42, "mergeable": true, "mergeable_state": "clean"}
+      ]
+    }
+  ]
+}

--- a/examples/merge_captain/scenarios/single_green.json
+++ b/examples/merge_captain/scenarios/single_green.json
@@ -1,0 +1,52 @@
+{
+  "_type": "merge_captain_playground_scenario",
+  "scenario": "single_green",
+  "description": "Smallest possible scenario — one repo, one green PR. Use as a sanity check that the playground init succeeds end-to-end.",
+  "owner": "burin-labs",
+  "repos": [
+    {
+      "name": "solo",
+      "default_branch": "main",
+      "files": {
+        "README.md": "# solo\n",
+        "src/lib.rs": "pub fn solo() -> i32 { 0 }\n"
+      },
+      "branches": [
+        {
+          "name": "feature/tiny",
+          "files_set": {
+            "src/lib.rs": "pub fn solo() -> i32 { 1 }\n"
+          },
+          "commit_message": "feat(solo): bump return"
+        }
+      ]
+    }
+  ],
+  "pull_requests": [
+    {
+      "repo": "solo",
+      "number": 1,
+      "title": "solo: bump return",
+      "body": "",
+      "state": "open",
+      "head_branch": "feature/tiny",
+      "base_branch": "main",
+      "user": "alice",
+      "labels": ["ready-to-merge"],
+      "checks": [
+        {"name": "ci", "status": "completed", "conclusion": "success"}
+      ],
+      "mergeable": true,
+      "mergeable_state": "clean"
+    }
+  ],
+  "steps": [
+    {
+      "name": "merge",
+      "description": "Merge the PR.",
+      "actions": [
+        {"kind": "merge_pull_request", "repo": "solo", "pr_number": 1}
+      ]
+    }
+  ]
+}

--- a/examples/merge_captain/scenarios/three_repo_basic.json
+++ b/examples/merge_captain/scenarios/three_repo_basic.json
@@ -1,0 +1,155 @@
+{
+  "_type": "merge_captain_playground_scenario",
+  "scenario": "three_repo_basic",
+  "description": "Three repos with the canonical PR states the Merge Captain has to reason about: green-ready, behind-base, lockfile-conflict, failing-CI. Use as the default playground for brute-force tuning.",
+  "owner": "burin-labs",
+  "repos": [
+    {
+      "name": "alpha",
+      "default_branch": "main",
+      "files": {
+        "README.md": "# alpha\n\nMerge Captain playground seed for the green-ready PR.\n",
+        "src/lib.rs": "pub fn alpha() -> &'static str { \"alpha\" }\n"
+      },
+      "branches": [
+        {
+          "name": "feature/green-ready",
+          "files_set": {
+            "src/lib.rs": "pub fn alpha() -> &'static str { \"alpha\" }\npub fn alpha2() -> &'static str { \"alpha2\" }\n"
+          },
+          "commit_message": "feat(alpha): add alpha2"
+        }
+      ]
+    },
+    {
+      "name": "beta",
+      "default_branch": "main",
+      "files": {
+        "README.md": "# beta\n\nMerge Captain playground seed for the behind-base + lockfile PR.\n",
+        "Cargo.toml": "[package]\nname = \"beta\"\nversion = \"0.1.0\"\n",
+        "Cargo.lock": "# Lockfile v3\n[[package]]\nname = \"beta\"\nversion = \"0.1.0\"\n"
+      },
+      "default_branch_extra_commits": [
+        {
+          "message": "chore(beta): bump deps on main",
+          "files_set": {
+            "Cargo.lock": "# Lockfile v3\n[[package]]\nname = \"beta\"\nversion = \"0.1.1\"\n"
+          }
+        }
+      ],
+      "branches": [
+        {
+          "name": "feature/behind-base",
+          "fork_before_extra_commits": true,
+          "files_set": {
+            "Cargo.lock": "# Lockfile v3\n[[package]]\nname = \"beta\"\nversion = \"0.1.0\"\n[[package]]\nname = \"beta-dep\"\nversion = \"0.1.0\"\n",
+            "src/lib.rs": "pub fn beta() -> &'static str { \"beta\" }\n"
+          },
+          "commit_message": "feat(beta): add beta-dep before main bumped"
+        }
+      ]
+    },
+    {
+      "name": "gamma",
+      "default_branch": "main",
+      "files": {
+        "README.md": "# gamma\n\nMerge Captain playground seed for the failing-CI PR.\n",
+        "src/main.rs": "fn main() { println!(\"hi\"); }\n"
+      },
+      "branches": [
+        {
+          "name": "feature/failing-ci",
+          "files_set": {
+            "src/main.rs": "fn main() { println!(\"oops\")  // syntax error\n}\n"
+          },
+          "commit_message": "feat(gamma): wire new entrypoint"
+        }
+      ]
+    }
+  ],
+  "pull_requests": [
+    {
+      "repo": "alpha",
+      "number": 101,
+      "title": "alpha: add alpha2",
+      "body": "Adds a tiny helper. Should sail through.",
+      "state": "open",
+      "head_branch": "feature/green-ready",
+      "base_branch": "main",
+      "user": "alice",
+      "labels": ["ready-to-merge"],
+      "checks": [
+        {"name": "ci", "status": "completed", "conclusion": "success"},
+        {"name": "lint", "status": "completed", "conclusion": "success"}
+      ],
+      "mergeable": true,
+      "mergeable_state": "clean"
+    },
+    {
+      "repo": "beta",
+      "number": 202,
+      "title": "beta: introduce beta-dep",
+      "body": "Predates the main lockfile bump — captain should flag and rebase.",
+      "state": "open",
+      "head_branch": "feature/behind-base",
+      "base_branch": "main",
+      "user": "bob",
+      "labels": ["needs-rebase"],
+      "checks": [
+        {"name": "ci", "status": "completed", "conclusion": "success"}
+      ],
+      "mergeable": false,
+      "mergeable_state": "behind"
+    },
+    {
+      "repo": "gamma",
+      "number": 303,
+      "title": "gamma: rewrite entrypoint",
+      "body": "CI is failing — captain should hand off to the author.",
+      "state": "open",
+      "head_branch": "feature/failing-ci",
+      "base_branch": "main",
+      "user": "carol",
+      "labels": [],
+      "checks": [
+        {"name": "ci", "status": "completed", "conclusion": "failure", "details_url": "https://example.invalid/ci/303"}
+      ],
+      "mergeable": true,
+      "mergeable_state": "unstable"
+    }
+  ],
+  "steps": [
+    {
+      "name": "alpha_pass_to_merge_queue",
+      "description": "Promote the green-ready PR through the merge queue.",
+      "actions": [
+        {"kind": "set_merge_queue_status", "repo": "alpha", "pr_number": 101, "status": "queued"},
+        {"kind": "set_merge_queue_status", "repo": "alpha", "pr_number": 101, "status": "merged"},
+        {"kind": "merge_pull_request", "repo": "alpha", "pr_number": 101, "merge_method": "queue"}
+      ]
+    },
+    {
+      "name": "beta_advance_main",
+      "description": "Land another commit on main so the behind-base PR's mergeable_state stays behind.",
+      "actions": [
+        {"kind": "advance_base", "repo": "beta", "files_set": {"Cargo.lock": "# Lockfile v3\n[[package]]\nname = \"beta\"\nversion = \"0.1.2\"\n"}, "commit_message": "chore(beta): another lockfile bump"}
+      ]
+    },
+    {
+      "name": "gamma_force_push_fix",
+      "description": "Author force-pushes a corrected entrypoint and CI flips green.",
+      "actions": [
+        {"kind": "force_push_author", "repo": "gamma", "branch": "feature/failing-ci", "files_set": {"src/main.rs": "fn main() { println!(\"hi\"); }\n"}, "commit_message": "fix(gamma): repair entrypoint"},
+        {"kind": "set_check", "repo": "gamma", "pr_number": 303, "name": "ci", "status": "completed", "conclusion": "success"},
+        {"kind": "set_mergeability", "repo": "gamma", "pr_number": 303, "mergeable": true, "mergeable_state": "clean"}
+      ]
+    },
+    {
+      "name": "advance_clock_one_minute",
+      "description": "Advance the playground clock by 60 seconds. Useful for steady-state tests of staleness.",
+      "actions": [
+        {"kind": "advance_time_ms", "ms": 60000}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes [#1020](https://github.com/burin-labs/harn/issues/1020). Materializes a real on-disk Merge Captain sandbox — bare + working git repos seeded from a declarative scenario manifest, plus a fake GitHub HTTP server — so the captain can be brute-force tuned without touching live GitHub.

- New `harn merge-captain mock {init,step,status,serve,cleanup,scenarios}` subcommand tree.
- Three checked-in scenarios (`three_repo_basic`, `single_green`, `force_push_drill`) covering green-ready, behind-base, lockfile-conflict, failing-CI, and force-push-by-author flavors.
- 11 declarative step actions (`set_check`, `add_pull_request`, `merge_pull_request`, `force_push_author`, `advance_base`, `set_labels`, `set_merge_queue_status`, `set_mergeability`, `add_comment`, `close_pull_request`, `advance_time_ms`). Git-native ones produce real commits on the bare remote so rebase / force-with-lease / merge codepaths run unchanged.
- Fake-GitHub axum router serving the strict subset the issue calls out: `pulls`, `pulls/.../merge`, `pulls/.../files`, `commits/.../check-runs`, `actions/runs/.../logs`, `merge_queue/queues/...`, `issues`, `issues/.../comments`, `issues/.../labels`. Reads/writes the same `state.json` the CLI mutates.
- Driver wiring: `--backend mock <playground-dir>` detects the on-disk playground and synthesizes a canonical sweep transcript from the live state. The legacy transcript-replay manifest path stays intact for backwards compatibility with `examples/merge_captain/playground_3repos`.
- Pinned `GIT_*_DATE` env vars give deterministic head SHAs across runs from the same manifest. Manifest validator rejects path-traversal repo names and invalid git refs. Cleanup refuses to remove arbitrary directories without the playground marker.
- Documented in [docs/llm/harn-quickref.md](docs/llm/harn-quickref.md) as the recommended local iteration loop.

## Test plan

- [x] `cargo test -p harn-vm --lib playground` (17 passing — manifest parse, init/step/cleanup, real-git materialization, force-push rewrite, real merge commit on bare, advance-base, fake-server handlers, transcript synthesis, deterministic SHAs)
- [x] `cargo test -p harn-cli --lib commands::merge_captain_mock` (5 passing — axum oneshot tests for list/get/create-comment/merge-blocks-dirty/404)
- [x] `cargo test -p harn-cli --test merge_captain_mock_cli` (3 passing — init/step/cleanup round-trip, init --force re-init, builtin scenarios smoke)
- [x] `cargo test -p harn-vm --lib merge_captain_driver` (4 passing — including new test for `--backend mock` against a real on-disk playground)
- [x] `cargo fmt --all -- --check`, `cargo clippy -p harn-vm -p harn-cli --no-deps --tests` clean
- [x] `make test` passes 3125/3125
- [x] Smoke-tested the real CLI end-to-end: `mock init --scenario three_repo_basic` → `mock status` → `mock step --name beta_advance_main` → `mock cleanup`, plus `merge-captain run --backend mock <dir> --once` against the materialized playground

🤖 Generated with [Claude Code](https://claude.com/claude-code)