### PR TITLE
release-harn skill: rebase + auto-merge before walking away

### DIFF
--- a/.claude/commands/release-harn.md
+++ b/.claude/commands/release-harn.md
@@ -73,12 +73,21 @@ Steps 1-9 are the only steps that need judgment. After step 9 you are done
    merge-queue CI when iterating fast; use `--skip-dry-run` for the same
    reason on the publish dry-run.
 
-9. Commit, push, open the PR titled **`Release vX.Y.Z`**:
+9. Commit, rebase onto latest `origin/main`, push, open the PR titled
+   **`Release vX.Y.Z`**, and enable auto-merge:
 
    ```bash
    git commit -m "Release vX.Y.Z"
+   git fetch origin main && git rebase origin/main
+   # Resolve any CHANGELOG.md conflicts: bullets that landed on main while
+   # --prepare was running may need to move from v0.7.52 → v0.7.53, or a
+   # Merge Captain-style bullet may end up duplicated across both
+   # sections. Verify v(X.Y.Z-1) section still matches the previous tag:
+   #   diff <(git show v(X.Y.Z-1):CHANGELOG.md | awk '/^## v(X.Y.Z-1)/,/^## /') \
+   #        <(awk '/^## v(X.Y.Z-1)/,/^## /' CHANGELOG.md)
    git push -u origin release/vX.Y.Z
    gh pr create --title "Release vX.Y.Z" --body "..."
+   gh pr merge --auto         # merge-queue picks the strategy
    ```
 
    Then walk away. The merge queue runs the full CI gate (`make lint`,
@@ -86,7 +95,19 @@ Steps 1-9 are the only steps that need judgment. After step 9 you are done
    `make check-highlight`, `make check-language-spec`,
    `make check-trigger-quickref`, `make check-trigger-examples`,
    `make check-docs-snippets`, `verify_release_metadata.py`, portal
-   lint+build, Windows smoke). Once it lands, Publish release fires.
+   lint+build, Windows smoke). Auto-merge fires it as soon as CI is
+   green; once it lands, Publish release fires on tag drift.
+
+   **Why rebase before push:** `--prepare` takes ~1-15 min depending on
+   cache state; main may have moved while it ran. Rebasing now (instead
+   of waiting for the merge queue to push back) catches CHANGELOG drift
+   while the context is fresh and avoids a stale PR sitting in queue.
+
+   **Why `--auto`:** the merge queue gates a substantial CI suite, so
+   the release sits in queue for ~10-15 min cold-cache. Auto-merge means
+   you don't have to babysit it; it lands when CI goes green. Don't pass
+   `--squash`/`--merge`/`--rebase` — the merge queue's branch protection
+   rules pick the strategy and `gh` will reject explicit overrides.
 
 ## New-crate first-release pre-flight (harn#609)
 

--- a/.codex/commands/harn-release.md
+++ b/.codex/commands/harn-release.md
@@ -59,13 +59,30 @@ The work is in the one release PR. After that, hands off.
    `--skip-audit` / `--skip-dry-run` to trust the merge-queue CI when
    iterating.
 
-9. Commit, push, open the PR titled **`Release vX.Y.Z`**:
+9. Commit, rebase onto latest `origin/main`, push, open the PR titled
+   **`Release vX.Y.Z`**, and enable auto-merge:
 
    ```bash
    git commit -m "Release vX.Y.Z"
+   git fetch origin main && git rebase origin/main
+   # Resolve any CHANGELOG.md conflicts: bullets that landed on main while
+   # --prepare was running may need to move from v(X.Y.Z-1) → vX.Y.Z, or a
+   # bullet may end up duplicated across both sections. Sanity-check with:
+   #   diff <(git show v(X.Y.Z-1):CHANGELOG.md | awk '/^## v(X.Y.Z-1)/,/^## /') \
+   #        <(awk '/^## v(X.Y.Z-1)/,/^## /' CHANGELOG.md)
    git push -u origin release/vX.Y.Z
    gh pr create --title "Release vX.Y.Z" --body "..."
+   gh pr merge --auto         # let the merge queue pick the strategy
    ```
+
+   Rebase right before push because `--prepare` takes 1-15 min depending
+   on cache state, and main may have moved while it ran. Catching drift
+   now (instead of letting the merge queue push back) keeps the PR fresh.
+
+   `gh pr merge --auto` (no `--squash`/`--merge`/`--rebase` flag — branch
+   protection picks the strategy and rejects explicit overrides) lands
+   the PR as soon as CI is green so you don't have to babysit a queue
+   that takes ~10-15 min cold-cache.
 
 That's it. Stop here. The bot takes over once the PR lands.
 

--- a/.codex/skills/harn-release/SKILL.md
+++ b/.codex/skills/harn-release/SKILL.md
@@ -111,7 +111,27 @@ default step.
 
    This audits, dry-run-publishes, bumps `Cargo.toml`/`Cargo.lock`/per-crate
    manifests, regenerates derived files, and `git add`s everything.
-9. Commit + push + open the PR titled `Release vX.Y.Z`. Walk away.
+9. Commit, rebase onto latest `origin/main`, push, open the PR titled
+   `Release vX.Y.Z`, then `gh pr merge --auto`. Walk away.
+
+   ```bash
+   git commit -m "Release vX.Y.Z"
+   git fetch origin main && git rebase origin/main
+   # Resolve any CHANGELOG.md conflicts: bullets that landed on main
+   # while --prepare was running may need to move from v(X.Y.Z-1) → vX.Y.Z,
+   # or a bullet may end up duplicated across both sections. Verify with:
+   #   diff <(git show v(X.Y.Z-1):CHANGELOG.md | awk '/^## v(X.Y.Z-1)/,/^## /') \
+   #        <(awk '/^## v(X.Y.Z-1)/,/^## /' CHANGELOG.md)
+   git push -u origin release/vX.Y.Z
+   gh pr create --title "Release vX.Y.Z" --body "..."
+   gh pr merge --auto         # branch protection picks the strategy; do
+                              # NOT pass --squash/--merge/--rebase
+   ```
+
+   Rebase right before push because `--prepare` takes 1-15 min depending
+   on cache state, and main may have moved while it ran. Auto-merge means
+   the PR lands as soon as CI is green so you don't have to babysit the
+   ~10-15 min cold-cache merge-queue CI.
 
 ## Expectations
 

--- a/.codex/skills/release-harn/SKILL.md
+++ b/.codex/skills/release-harn/SKILL.md
@@ -45,8 +45,10 @@ Commit pattern for a real release:
 
 1. **`Release vX.Y.Z`** — code + docs + `CHANGELOG.md` + Cargo.toml /
    Cargo.lock + per-crate manifest bumps + regenerated mirrors. Authored
-   by you via `release_ship.sh --prepare --bump <type>`, landed through
-   PR/merge queue.
+   by you via `release_ship.sh --prepare --bump <type>`, then **rebased
+   onto latest `origin/main` before push** (because `--prepare` takes
+   1-15 min and main may have moved), landed through PR/merge queue
+   with `gh pr merge --auto` enabled so it lands as soon as CI is green.
 
 That's it. The bot takes over once it lands.
 


### PR DESCRIPTION
## Summary

Refines step 9 of the release-harn workflow in both Claude (`/release-harn`) and Codex (`harn-release`, `release-harn`) skill variants:

1. **Rebase onto `origin/main` after the release commit, before push.**
   `--prepare` takes 1-15 min depending on cache state and main may have moved while it ran. Catching CHANGELOG drift now (vs. letting the merge queue push back) keeps the PR fresh and avoids stale-PR thrash.

2. **Run `gh pr merge --auto` after opening the PR.** Branch protection picks the strategy and rejects explicit `--squash`/`--merge`/`--rebase` overrides; the PR lands as soon as CI is green so we don't have to babysit a ~10-15 min cold-cache merge-queue CI.

CHANGELOG conflict-resolution guidance is now called out explicitly: bullets that landed on main during prep often need to move from `v(X.Y.Z-1)` → `vX.Y.Z`, or end up duplicated across both sections. The skill includes a sanity-check diff snippet against the previous tag.

This came out of the v0.7.53 release (#1139), where 3 PRs landed on main while `--prepare` was running and the resulting rebase quietly duplicated the "Harn-native Merge Captain persona" bullet across `v0.7.52` and `v0.7.53` until I caught it manually. The skill now points the next agent at the canonical fix.

## Files

- `.claude/commands/release-harn.md` (Claude Code skill)
- `.codex/commands/harn-release.md` (Codex command)
- `.codex/skills/harn-release/SKILL.md` (Codex skill)
- `.codex/skills/release-harn/SKILL.md` (Codex skill alias)

## Test plan

- [ ] Skill changes are documentation-only (no executable behavior change to verify in CI).
- [ ] Markdownlint passes (already verified locally via pre-commit).
- [ ] Next release uses the updated workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)