### PR TITLE
[codex] Normalize diagnostic paths

### DIFF
--- a/crates/harn-parser/src/diagnostic.rs
+++ b/crates/harn-parser/src/diagnostic.rs
@@ -10,6 +10,58 @@ pub struct RelatedSpanLabel<'a> {
     pub label: &'a str,
 }
 
+/// Normalize diagnostic filenames lexically for display.
+///
+/// This deliberately does not touch the filesystem: diagnostics should cancel
+/// `.` and `..` path components even when the path points at a file that no
+/// longer exists, without resolving symlinks.
+pub fn normalize_diagnostic_path(path: &str) -> String {
+    let posix = path.replace('\\', "/");
+    if posix.is_empty() {
+        return String::new();
+    }
+
+    let bytes = posix.as_bytes();
+    let mut drive = "";
+    let mut rest = posix.as_str();
+    if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        drive = &posix[..2];
+        rest = &posix[2..];
+    }
+
+    let absolute = rest.starts_with('/');
+    let mut stack: Vec<&str> = Vec::new();
+    for segment in rest.split('/').filter(|segment| !segment.is_empty()) {
+        match segment {
+            "." => {}
+            ".." => {
+                if let Some(top) = stack.last() {
+                    if *top != ".." {
+                        stack.pop();
+                        continue;
+                    }
+                }
+                if !absolute {
+                    stack.push("..");
+                }
+            }
+            _ => stack.push(segment),
+        }
+    }
+
+    let mut normalized = String::new();
+    normalized.push_str(drive);
+    if absolute {
+        normalized.push('/');
+    }
+    normalized.push_str(&stack.join("/"));
+    if normalized.is_empty() {
+        ".".to_string()
+    } else {
+        normalized
+    }
+}
+
 /// Compute the Levenshtein edit distance between two strings.
 pub fn edit_distance(a: &str, b: &str) -> usize {
     let a_chars: Vec<char> = a.chars().collect();
@@ -73,6 +125,7 @@ pub fn render_diagnostic_with_related(
     related: &[RelatedSpanLabel<'_>],
 ) -> String {
     let mut out = String::new();
+    let filename = normalize_diagnostic_path(filename);
     let severity_color = severity_color(severity);
     let gutter = style_fragment("|", Color::Blue, false);
     let arrow = style_fragment("-->", Color::Blue, true);
@@ -146,7 +199,7 @@ pub fn render_diagnostic_with_related(
         render_related_span(
             &mut out,
             source,
-            filename,
+            &filename,
             item.span,
             item.label,
             gutter_width,
@@ -214,6 +267,7 @@ fn render_related_span(
     label: &str,
     primary_gutter_width: usize,
 ) {
+    let filename = normalize_diagnostic_path(filename);
     let severity_color = Color::Magenta;
     let gutter = style_fragment("|", Color::Blue, false);
     let arrow = style_fragment("-->", Color::Blue, true);
@@ -364,6 +418,30 @@ mod tests {
         assert!(output.contains("--> example.harn:2:13"));
         assert!(output.contains("let y = x + 1"));
         assert!(output.contains("^ not found in this scope"));
+    }
+
+    #[test]
+    fn test_diagnostic_normalizes_filename() {
+        disable_colors();
+        let source = "let value = thing";
+        let span = Span {
+            start: 12,
+            end: 17,
+            line: 1,
+            column: 13,
+            end_line: 1,
+        };
+        let output = render_diagnostic(
+            source,
+            "/workspace/pipelines/mode/../lib/runtime/loop.harn",
+            &span,
+            "error",
+            "bad value",
+            Some("here"),
+            None,
+        );
+        assert!(output.contains("--> /workspace/pipelines/lib/runtime/loop.harn:1:13"));
+        assert!(!output.contains("/../"));
     }
 
     #[test]

--- a/crates/harn-vm/src/vm/format.rs
+++ b/crates/harn-vm/src/vm/format.rs
@@ -33,6 +33,7 @@ impl super::Vm {
             let line = *line;
             let col = *col;
             let filename = frame_file.as_deref().unwrap_or(entry_file);
+            let display_filename = harn_parser::diagnostic::normalize_diagnostic_path(filename);
             // Read the frame's own source so the caret line is meaningful;
             // fall back to entry-point source (e.g. for stdlib modules).
             let owned_source: Option<String> = frame_file
@@ -48,7 +49,7 @@ impl super::Vm {
                 let display_col = if col > 0 { col } else { 1 };
                 let gutter_width = line.to_string().len();
                 out.push_str(&format!(
-                    "{:>width$}--> {filename}:{line}:{display_col}\n",
+                    "{:>width$}--> {display_filename}:{line}:{display_col}\n",
                     " ",
                     width = gutter_width + 1,
                 ));
@@ -92,8 +93,10 @@ impl super::Vm {
                 let display_name = if name.is_empty() { "pipeline" } else { name };
                 if *line > 0 {
                     let filename = frame_file.as_deref().unwrap_or(entry_file);
+                    let display_filename =
+                        harn_parser::diagnostic::normalize_diagnostic_path(filename);
                     out.push_str(&format!(
-                        "  = note: called from {display_name} at {filename}:{line}\n"
+                        "  = note: called from {display_name} at {display_filename}:{line}\n"
                     ));
                 }
             }

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -115,6 +115,37 @@ fn run_harn_result(source: &str) -> Result<(String, VmValue), VmError> {
     })
 }
 
+#[test]
+fn runtime_error_renderer_normalizes_frame_paths() {
+    let mut vm = Vm::new();
+    vm.set_source_info(
+        "/workspace/pipelines/mode/../mode/auto.harn",
+        "let run = agent_loop(message, system_prompt, opts)\n",
+    );
+    vm.error_stack_trace = vec![
+        (
+            "pipeline".to_string(),
+            39,
+            1,
+            Some("/workspace/pipelines/mode/../mode/auto.harn".to_string()),
+        ),
+        (
+            "agent_loop".to_string(),
+            205,
+            48,
+            Some("/workspace/pipelines/mode/../lib/runtime/loop.harn".to_string()),
+        ),
+    ];
+
+    let rendered = vm.format_runtime_error(&VmError::Runtime(
+        "option `cache` is not supported".to_string(),
+    ));
+
+    assert!(rendered.contains("--> /workspace/pipelines/lib/runtime/loop.harn:205:48"));
+    assert!(rendered.contains("called from pipeline at /workspace/pipelines/mode/auto.harn:39"));
+    assert!(!rendered.contains("/../"));
+}
+
 async fn run_harn_result_async(source: &str) -> Result<(String, VmValue), VmError> {
     let mut lexer = Lexer::new(source);
     let tokens = lexer.tokenize().unwrap();


### PR DESCRIPTION
## Summary

Normalize diagnostic file paths at render time so user-facing parser and runtime error output cancels lexical `.` and `..` path components without canonicalizing through the filesystem.

The runtime formatter now uses the same diagnostic path normalizer for the primary `-->` location and call-stack notes, so pipeline errors like `mode/../lib/runtime/loop.harn` render as `lib/runtime/loop.harn` while preserving existing source metadata for file reads and debugging.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-be07-normalize-paths-target cargo test -p harn-parser -p harn-vm normalizes -- --nocapture`
- Pre-commit hook: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`
- Pre-push hook: nextest workspace run, 3176 passed
