### PR TITLE
Accept compact text-tool protocol tags

### DIFF
--- a/crates/harn-vm/src/llm/tools/parse/streaming.rs
+++ b/crates/harn-vm/src/llm/tools/parse/streaming.rs
@@ -41,6 +41,8 @@ use super::syntax::{ident_length, parse_ts_call_from};
 
 const TAGGED_OPEN: &str = "<tool_call>";
 const TAGGED_CLOSE: &str = "</tool_call>";
+const TAGGED_OPEN_COMPACT: &str = "<toolcall>";
+const TAGGED_CLOSE_COMPACT: &str = "</toolcall>";
 
 /// Streaming candidate detector for text-mode tool calls.
 ///
@@ -75,6 +77,7 @@ enum DetectorState {
     /// Inside a `<tool_call>...` block. Buffering until `</tool_call>`.
     InTaggedBlock {
         body_start: usize,
+        close_tag: &'static str,
         tool_call_id: String,
     },
     /// Inside a bare `name(` call. Buffering until the TS-call parser
@@ -237,8 +240,8 @@ impl StreamingToolCallDetector {
 
                 // Tagged opener.
                 let rest = &self.buffer[j..];
-                if rest.starts_with(TAGGED_OPEN) {
-                    let body_start = j + TAGGED_OPEN.len();
+                if let Some((open_tag, close_tag)) = tagged_open_at(rest) {
+                    let body_start = j + open_tag.len();
                     let id = self.next_candidate_id();
                     events.push(AgentEvent::ToolCall {
                         session_id: self.session_id.clone(),
@@ -252,12 +255,13 @@ impl StreamingToolCallDetector {
                     });
                     self.state = DetectorState::InTaggedBlock {
                         body_start,
+                        close_tag,
                         tool_call_id: id,
                     };
                     self.cursor = body_start;
                     return true;
                 }
-                if TAGGED_OPEN.starts_with(rest) {
+                if is_partial_tagged_open(rest) {
                     // Partial `<tool_call>` prefix — wait for the rest.
                     self.cursor = i;
                     return false;
@@ -320,18 +324,19 @@ impl StreamingToolCallDetector {
     }
 
     fn scan_tagged(&mut self, events: &mut Vec<AgentEvent>) -> bool {
-        let (body_start, tool_call_id) = match &self.state {
+        let (body_start, close_tag, tool_call_id) = match &self.state {
             DetectorState::InTaggedBlock {
                 body_start,
+                close_tag,
                 tool_call_id,
-            } => (*body_start, tool_call_id.clone()),
+            } => (*body_start, *close_tag, tool_call_id.clone()),
             _ => return false,
         };
-        let Some(close_rel) = self.buffer[body_start..].find(TAGGED_CLOSE) else {
+        let Some(close_rel) = self.buffer[body_start..].find(close_tag) else {
             return false;
         };
         let body_end = body_start + close_rel;
-        let after = body_end + TAGGED_CLOSE.len();
+        let after = body_end + close_tag.len();
         let body = self.buffer[body_start..body_end].trim().to_string();
         let parse_attempt = if body.is_empty() {
             Err("<tool_call> body was empty.".to_string())
@@ -400,6 +405,20 @@ impl StreamingToolCallDetector {
             }
         }
     }
+}
+
+fn tagged_open_at(rest: &str) -> Option<(&'static str, &'static str)> {
+    if rest.starts_with(TAGGED_OPEN) {
+        Some((TAGGED_OPEN, TAGGED_CLOSE))
+    } else if rest.starts_with(TAGGED_OPEN_COMPACT) {
+        Some((TAGGED_OPEN_COMPACT, TAGGED_CLOSE_COMPACT))
+    } else {
+        None
+    }
+}
+
+fn is_partial_tagged_open(rest: &str) -> bool {
+    TAGGED_OPEN.starts_with(rest) || TAGGED_OPEN_COMPACT.starts_with(rest)
 }
 
 fn promote_event(
@@ -559,6 +578,29 @@ mod tests {
                 "<tool_call>\n",
                 "run({ command: \"ls\" })\n",
                 "</tool_call>",
+            ],
+            &mut det,
+        );
+        assert_eq!(events.len(), 2, "events={events:#?}");
+        let (start_id, start_name, parsing) = unwrap_call(&events[0]);
+        assert_eq!(start_name, "");
+        assert_eq!(parsing, Some(true));
+        let (terminal_id, terminal_name, status, parsing, cat) = unwrap_update(&events[1]);
+        assert_eq!(start_id, terminal_id, "ids match across promote");
+        assert_eq!(terminal_name, "run");
+        assert_eq!(status, ToolCallStatus::Pending);
+        assert_eq!(parsing, Some(false));
+        assert!(cat.is_none());
+    }
+
+    #[test]
+    fn compact_tagged_candidate_promotes_when_block_closes() {
+        let mut det = detector(&["run"]);
+        let events = run(
+            &[
+                "<toolcall>\n",
+                "run({ command: \"git status\" })\n",
+                "</toolcall>",
             ],
             &mut det,
         );

--- a/crates/harn-vm/src/llm/tools/parse/tagged.rs
+++ b/crates/harn-vm/src/llm/tools/parse/tagged.rs
@@ -83,7 +83,9 @@ pub(crate) fn parse_text_tool_calls_with_tools(
             continue;
         }
 
-        if let Some((body, after)) = match_block(src, cursor, "tool_call") {
+        if let Some((body, after)) =
+            match_block(src, cursor, "tool_call").or_else(|| match_block(src, cursor, "toolcall"))
+        {
             match parse_single_tool_call(body, tools_val) {
                 Ok(call) => {
                     let name = call
@@ -104,14 +106,18 @@ pub(crate) fn parse_text_tool_calls_with_tools(
                 Err(msg) => errors.push(msg),
             }
             cursor = after;
-        } else if let Some((body, after)) = match_block(src, cursor, "assistant_prose") {
+        } else if let Some((body, after)) = match_block(src, cursor, "assistant_prose")
+            .or_else(|| match_block(src, cursor, "assistantprose"))
+        {
             let trimmed = body.trim();
             if !trimmed.is_empty() {
                 assistant_prose_parts.push(trimmed.to_string());
                 canonical_parts.push(format!("<assistant_prose>\n{trimmed}\n</assistant_prose>"));
             }
             cursor = after;
-        } else if let Some((body, after)) = match_block(src, cursor, "user_response") {
+        } else if let Some((body, after)) = match_block(src, cursor, "user_response")
+            .or_else(|| match_block(src, cursor, "userresponse"))
+        {
             let trimmed = body.trim();
             if !trimmed.is_empty() {
                 user_response_parts.push(trimmed.to_string());

--- a/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
+++ b/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
@@ -112,6 +112,30 @@ fn tagged_parser_accepts_well_formed_response() {
 }
 
 #[test]
+fn tagged_parser_accepts_compact_protocol_tag_aliases() {
+    let tools = sample_tool_registry();
+    let text = "<assistantprose>Checking status.</assistantprose>\n\
+                <userresponse>Done.</userresponse>\n\
+                <toolcall>\n\
+                run({ command: \"git status\" })\n\
+                </toolcall>\n\
+                <done>##DONE##</done>";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert!(
+        result.violations.is_empty(),
+        "compact tag aliases should parse without violations: {:?}",
+        result.violations,
+    );
+    assert!(result.errors.is_empty(), "no errors: {:?}", result.errors);
+    assert_eq!(result.calls.len(), 1);
+    assert_eq!(result.calls[0]["name"], json!("run"));
+    assert_eq!(result.prose, "Done.");
+    assert_eq!(result.user_response.as_deref(), Some("Done."));
+    assert!(result.canonical.contains("<tool_call>"));
+    assert!(result.canonical.contains("<user_response>"));
+}
+
+#[test]
 fn tagged_parser_flags_stray_prose_outside_tags() {
     let tools = sample_tool_registry();
     let text = "def foo():\n    pass\n\n<tool_call>\nedit({ action: \"create\", path: \"a.rs\", content: \"x\" })\n</tool_call>";

--- a/crates/harn-vm/src/visible_text.rs
+++ b/crates/harn-vm/src/visible_text.rs
@@ -37,7 +37,7 @@ fn internal_block_patterns() -> &'static [Regex] {
             // Tagged response protocol: hide tool-call bodies (executed as
             // structured data, never surfaced as narration) and done
             // blocks (runtime signal, not user-facing).
-            r"(?s)<tool_call>.*?</tool_call>",
+            r"(?s)<tool_?call>.*?</tool_?call>",
             r"(?s)<done>.*?</done>",
             r"(?s)<tool_result[^>]*>.*?</tool_result>",
             r"(?s)\[result of [^\]]+\].*?\[end of [^\]]+\]",
@@ -52,7 +52,7 @@ fn internal_block_patterns() -> &'static [Regex] {
 fn assistant_prose_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r"(?s)<assistant_prose>\s*(.*?)\s*</assistant_prose>")
+        Regex::new(r"(?s)<assistant_?prose>\s*(.*?)\s*</assistant_?prose>")
             .expect("valid assistant_prose regex")
     })
 }
@@ -60,7 +60,7 @@ fn assistant_prose_regex() -> &'static Regex {
 fn user_response_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r"(?s)<user_response>\s*(.*?)\s*</user_response>")
+        Regex::new(r"(?s)<user_?response>\s*(.*?)\s*</user_?response>")
             .expect("valid user_response regex")
     })
 }
@@ -203,6 +203,13 @@ fn strip_unclosed_internal_blocks(text: &str) -> String {
         }
     }
 
+    if let Some(open_idx) = text.rfind("<toolcall>") {
+        let close_idx = text.rfind("</toolcall>");
+        if close_idx.is_none_or(|idx| idx < open_idx) {
+            return text[..open_idx].to_string();
+        }
+    }
+
     if let Some(open_idx) = text.rfind("<done>") {
         let close_idx = text.rfind("</done>");
         if close_idx.is_none_or(|idx| idx < open_idx) {
@@ -212,6 +219,13 @@ fn strip_unclosed_internal_blocks(text: &str) -> String {
 
     if let Some(open_idx) = text.rfind("<user_response>") {
         let close_idx = text.rfind("</user_response>");
+        if close_idx.is_none_or(|idx| idx < open_idx) {
+            return text[..open_idx].to_string();
+        }
+    }
+
+    if let Some(open_idx) = text.rfind("<userresponse>") {
+        let close_idx = text.rfind("</userresponse>");
         if close_idx.is_none_or(|idx| idx < open_idx) {
             return text[..open_idx].to_string();
         }
@@ -247,11 +261,14 @@ fn strip_inline_internal_planning_json(text: &str, partial: bool) -> String {
 }
 
 fn strip_partial_marker_suffix(text: &str) -> String {
-    const MARKERS: [&str; 10] = [
+    const MARKERS: [&str; 13] = [
         "<|tool_call|>",
         "<tool_call>",
+        "<toolcall>",
         "<assistant_prose>",
+        "<assistantprose>",
         "<user_response>",
+        "<userresponse>",
         "<done>",
         "<tool_result",
         "[result of ",
@@ -371,6 +388,20 @@ mod tests {
         assert_eq!(
             sanitize_visible_assistant_text(raw, false),
             "Visible answer."
+        );
+    }
+
+    #[test]
+    fn sanitize_accepts_compact_protocol_tag_aliases_without_hiding_plain_words() {
+        let raw = "The phrase tool call is normal prose.\n<assistantprose>hidden</assistantprose>\n<toolcall>\nrun({ command: \"git status\" })\n</toolcall>\n<userresponse>Visible answer.</userresponse>\n<done>##DONE##</done>";
+        assert_eq!(
+            sanitize_visible_assistant_text(raw, false),
+            "Visible answer."
+        );
+
+        assert_eq!(
+            sanitize_visible_assistant_text("A tool call summary is fine.", false),
+            "A tool call summary is fine."
         );
     }
 }


### PR DESCRIPTION
## Summary
- Accept compact text-tool aliases like `<toolcall>`, `<assistantprose>`, and `<userresponse>`.
- Canonicalize compact aliases back to underscore protocol tags for stored history.
- Update streaming detection so compact `<toolcall>` blocks emit normal tool-call lifecycle events.

## Root Cause
Local llama.cpp/Qwen-style output can emit compact protocol tags without underscores. Harn previously treated those as unknown top-level tags, so visible-text sanitization could expose protocol text and clients could miss tool-call events/counts.

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-target-tui-leak cargo test -p harn-vm compact --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-tui-leak cargo build -p harn-cli --bin harn`
- Direct binary validation with compact tag output: `/tmp/harn-target-tui-leak/debug/harn run -e ...` rendered only `Visible done.`
- Pre-commit clippy hook passed
- Pre-push hook passed, including 3184 nextest tests
