### PR TITLE
[codex] Support per-call agent transcript dirs

### DIFF
--- a/crates/harn-vm/src/llm/agent/mod.rs
+++ b/crates/harn-vm/src/llm/agent/mod.rs
@@ -396,6 +396,8 @@ pub async fn run_agent_loop_internal(
 
     config.mcp_clients =
         agent_mcp::bootstrap_agent_loop_mcp_servers(opts, &config.mcp_servers).await?;
+    let _llm_transcript_dir_guard =
+        crate::llm::agent_observe::push_llm_transcript_dir(config.llm_transcript_dir.clone());
     let mut mcp_cleanup = AgentLoopMcpCleanupGuard::new(config.mcp_clients.clone());
     let mut state = state::AgentLoopState::new(opts, config)?;
     let _session_guard = AgentSessionGuard::install(state.session_id.clone());

--- a/crates/harn-vm/src/llm/agent/tests/mod.rs
+++ b/crates/harn-vm/src/llm/agent/tests/mod.rs
@@ -123,6 +123,7 @@ pub(super) fn base_agent_config() -> AgentLoopConfig {
         event_sink: None,
         task_ledger: Default::default(),
         post_turn_callback: None,
+        llm_transcript_dir: None,
         skill_registry: None,
         skill_match: Default::default(),
         working_files: Vec::new(),

--- a/crates/harn-vm/src/llm/agent/tests/transcript.rs
+++ b/crates/harn-vm/src/llm/agent/tests/transcript.rs
@@ -294,6 +294,39 @@ async fn observed_llm_call_bridge_events_include_non_user_visible() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn agent_loop_option_writes_llm_transcript_jsonl() {
+    reset_llm_mock_state();
+    let dir = std::env::temp_dir().join(format!(
+        "harn-agent-loop-option-transcript-{}",
+        uuid::Uuid::now_v7()
+    ));
+    let mut opts = base_opts(vec![serde_json::json!({
+        "role": "user",
+        "content": "write a transcript sidecar",
+    })]);
+    let mut config = base_agent_config();
+    config.llm_transcript_dir = Some(dir.to_string_lossy().into_owned());
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_eq!(result["status"], "done");
+
+    let transcript_path = dir.join("llm_transcript.jsonl");
+    let transcript = std::fs::read_to_string(&transcript_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", transcript_path.display()));
+    assert!(
+        transcript.contains("\"provider_call_request\""),
+        "provider call request missing from transcript:\n{transcript}"
+    );
+    assert!(
+        transcript.contains("\"provider_call_response\""),
+        "provider call response missing from transcript:\n{transcript}"
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn daemon_timer_wake_persists_snapshot_and_compacts_on_idle() {
     let dir = std::env::temp_dir().join(format!("harn-agent-daemon-{}", uuid::Uuid::now_v7()));
     std::fs::create_dir_all(&dir).unwrap();

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -153,6 +153,10 @@ pub struct AgentLoopConfig {
     /// - `true`: stop the stage immediately
     /// - `{message, stop}` dict: both (optional `message`, optional `stop`)
     pub post_turn_callback: Option<crate::value::VmValue>,
+    /// Optional per-call directory for the existing Harn
+    /// `llm_transcript.jsonl` sidecar. When unset, the process-level
+    /// `HARN_LLM_TRANSCRIPT_DIR` environment variable is still honored.
+    pub llm_transcript_dir: Option<String>,
     /// Skill registry (from `skill_registry()` / `skill { }` decls)
     /// exposed to the skill-matching phase. `None` disables skills for
     /// this loop.
@@ -540,6 +544,7 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                         .and_then(|o| o.get("post_turn_callback"))
                         .filter(|v| matches!(v, crate::value::VmValue::Closure(_)))
                         .cloned(),
+                    llm_transcript_dir: opt_str(&options, "llm_transcript_dir"),
                     skill_registry,
                     skill_match,
                     working_files,

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -56,6 +56,42 @@ thread_local! {
     /// call, tool results between iterations). Set at the top of each
     /// iteration and cleared on loop exit.
     static CURRENT_ITERATION: RefCell<Option<usize>> = const { RefCell::new(None) };
+    static TRANSCRIPT_DIR_STACK: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+}
+
+pub(crate) struct LlmTranscriptDirGuard {
+    pushed: bool,
+}
+
+impl Drop for LlmTranscriptDirGuard {
+    fn drop(&mut self) {
+        if self.pushed {
+            TRANSCRIPT_DIR_STACK.with(|stack| {
+                let _ = stack.borrow_mut().pop();
+            });
+        }
+    }
+}
+
+pub(crate) fn push_llm_transcript_dir(dir: Option<String>) -> LlmTranscriptDirGuard {
+    let Some(dir) = dir else {
+        return LlmTranscriptDirGuard { pushed: false };
+    };
+    if dir.trim().is_empty() {
+        return LlmTranscriptDirGuard { pushed: false };
+    }
+    TRANSCRIPT_DIR_STACK.with(|stack| stack.borrow_mut().push(dir));
+    LlmTranscriptDirGuard { pushed: true }
+}
+
+fn current_transcript_dir() -> Option<String> {
+    TRANSCRIPT_DIR_STACK
+        .with(|stack| stack.borrow().last().cloned())
+        .or_else(|| {
+            std::env::var("HARN_LLM_TRANSCRIPT_DIR")
+                .ok()
+                .filter(|d| !d.is_empty())
+        })
 }
 
 fn hash_str(value: &str) -> u64 {
@@ -227,9 +263,8 @@ pub(crate) fn parse_retry_after(msg: &str) -> Option<u64> {
 /// Write the full LLM request payload to a JSONL transcript file.
 pub(super) fn append_llm_transcript_entry(entry: &serde_json::Value) {
     append_llm_transcript_event_log(entry);
-    let dir = match std::env::var("HARN_LLM_TRANSCRIPT_DIR") {
-        Ok(d) if !d.is_empty() => d,
-        _ => return,
+    let Some(dir) = current_transcript_dir() else {
+        return;
     };
     let _ = std::fs::create_dir_all(&dir);
     let path = format!("{dir}/llm_transcript.jsonl");

--- a/crates/harn-vm/src/llm/helpers/opt_get.rs
+++ b/crates/harn-vm/src/llm/helpers/opt_get.rs
@@ -3,7 +3,10 @@ use std::collections::BTreeMap;
 use crate::value::VmValue;
 
 pub(crate) fn opt_str(options: &Option<BTreeMap<String, VmValue>>, key: &str) -> Option<String> {
-    options.as_ref()?.get(key).map(|v| v.display())
+    match options.as_ref()?.get(key)? {
+        VmValue::Nil => None,
+        value => Some(value.display()),
+    }
 }
 
 pub(crate) fn opt_int(options: &Option<BTreeMap<String, VmValue>>, key: &str) -> Option<i64> {
@@ -24,4 +27,32 @@ pub(crate) fn opt_bool(options: &Option<BTreeMap<String, VmValue>>, key: &str) -
         .and_then(|o| o.get(key))
         .map(|v| v.is_truthy())
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, rc::Rc};
+
+    use crate::value::VmValue;
+
+    use super::opt_str;
+
+    #[test]
+    fn opt_str_treats_nil_as_unset() {
+        let mut options = BTreeMap::new();
+        options.insert("path".to_string(), VmValue::Nil);
+
+        assert_eq!(opt_str(&Some(options), "path"), None);
+    }
+
+    #[test]
+    fn opt_str_preserves_string_values() {
+        let mut options = BTreeMap::new();
+        options.insert("path".to_string(), VmValue::String(Rc::from("transcripts")));
+
+        assert_eq!(
+            opt_str(&Some(options), "path"),
+            Some("transcripts".to_string())
+        );
+    }
 }

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -1270,6 +1270,7 @@ pub fn register_llm_builtins(vm: &mut Vm) {
                     .and_then(|o| o.get("post_turn_callback"))
                     .filter(|v| matches!(v, crate::value::VmValue::Closure(_)))
                     .cloned(),
+                llm_transcript_dir: opt_str(&options, "llm_transcript_dir"),
                 skill_registry,
                 skill_match,
                 working_files,

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1517,6 +1517,15 @@ pub async fn execute_stage_node(
                         .and_then(|d| d.get("post_turn_callback"))
                         .filter(|v| matches!(v, crate::value::VmValue::Closure(_)))
                         .cloned(),
+                    llm_transcript_dir: node
+                        .raw_model_policy
+                        .as_ref()
+                        .and_then(|v| v.as_dict())
+                        .and_then(|d| d.get("llm_transcript_dir"))
+                        .and_then(|v| match v {
+                            crate::value::VmValue::String(s) => Some(s.to_string()),
+                            _ => None,
+                        }),
                     // Inherit the workflow-level skill wiring installed
                     // by `workflow_execute`. Per-node `model_policy.skills`
                     // (optional) overrides, letting authors scope a skill

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -712,6 +712,7 @@ fn sub_agent_loop_options(spec: &SubAgentRunSpec) -> Result<crate::llm::AgentLoo
             .and_then(|o| o.get("post_turn_callback"))
             .filter(|v| matches!(v, VmValue::Closure(_)))
             .cloned(),
+        llm_transcript_dir: crate::llm::helpers::opt_str(&options, "llm_transcript_dir"),
         skill_registry,
         skill_match,
         working_files,

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -103,6 +103,7 @@ Same as `llm_call`, plus additional options:
 | `context_callback` | closure | nil | Per-turn hook that can rewrite prompt-visible `messages` and/or the effective `system` prompt before the next LLM call |
 | `context_filter` | closure | nil | Alias for `context_callback` |
 | `post_turn_callback` | closure | nil | Hook called after each tool turn. Receives turn metadata and may inject a message, request an immediate stage stop, or both |
+| `llm_transcript_dir` | string | nil | Per-loop directory for Harn's existing `llm_transcript.jsonl` sidecar. This is equivalent to scoping `HARN_LLM_TRANSCRIPT_DIR` to one agent loop and is preferred when a script needs run-specific auditable model-turn JSONL |
 | `turn_policy` | dict | nil | Turn-shape policy for action stages. Supports `require_action_or_yield: bool`, `allow_done_sentinel: bool` (default `true`; set to `false` in workflow-owned action stages so nudges stop advertising the done sentinel), and `max_prose_chars: int` |
 | `native_tool_fallback` | string | `"allow"` | Native-tool-stage policy when the provider emits text-mode `<tool_call>` content instead of native tool calls. `"allow"` preserves the current recovery path, `"allow_once"` accepts the first fallback turn then rejects later repeats with corrective feedback, and `"reject"` fails closed on the first text fallback |
 | `stop_after_successful_tools` | `list<string>` | nil | Stop after a tool-calling turn whose successful results include one of these tool names. Useful for workflow-owned verify loops such as `["edit", "scaffold"]` |


### PR DESCRIPTION
## Summary

- add an `llm_transcript_dir` option to agent_loop/sub-agent/workflow model policy paths so individual Harn workflows can write auditable LLM JSONL transcripts without relying on global env only
- thread the transcript directory through the existing agent observation layer using the standard JSONL writer
- treat `nil` optional string values as unset so absent transcript dirs do not create a literal `nil/` output directory
- document the new agent_loop option and add focused regression coverage

## Validation

- `cargo fmt --check`
- `cargo test -p harn-vm opt_str_`
- `cargo test -p harn-vm agent_loop_option_writes_llm_transcript_jsonl`
- `git diff --check`
- pre-commit hook: workspace clippy, highlight keyword sync check, markdownlint
- pre-push hook: nextest suite, 3187 tests passed, markdownlint
