### PR TITLE
[a2a] Add input-required, auth-required, rejected to TaskStatus (#889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,24 @@ condensed series summaries instead of full per-patch history.
   scheduler routes `local_repair` and `dirty` to the worker only
   when the policy enables the matching bundle kind.
 
+- **A2A `input-required` / `auth-required` / `rejected` task states (#889).**
+  The A2A adapter's `TaskStatus` enum now covers all six A2A 0.3.0
+  non-final/final state strings. `input-required` is wired into the
+  existing HITL primitives (`ask_user`, `request_approval`,
+  `dual_control`, `escalate_to`): each pause emits a canonical
+  `AgentEvent::HitlRequested` (with a paired `HitlResolved` once the
+  waitpoint resolves), and the `A2aWorkerSink` translates those into
+  `status.state = input-required` transitions plus a structured `hitl`
+  task event so SSE subscribers see the request payload alongside the
+  pause. The ACP adapter advertises matching `hitl_request` /
+  `hitl_resolved` session-update extensions under `_meta.harn`.
+  Synchronous policy denial (`AuthPolicy.authorize` returning
+  `Rejected`) now lands the task in the terminal `rejected` state
+  instead of `failed`, and any `auth`-classified error raised mid-task
+  (HTTP 401 / `invalid_api_key` / `authentication_error`) flips the
+  task into the non-terminal `auth-required` state so clients can
+  re-authenticate and resubscribe.
+
 ## v0.7.54
 
 ### Added
@@ -99,7 +117,6 @@ condensed series summaries instead of full per-patch history.
   `modelPreferences` / `stopSequences` / `metadata` are all forwarded
   through to `llm_call`'s typed boundary so the existing ThinkingConfig
   (#849) and structured-output paths apply unchanged.
-
 - **ACP session modes (#897).** The ACP adapter now implements the
   [session-modes](https://agentclientprotocol.com/protocol/session-modes)
   spec: `session/new` and `session/load` return a `SessionModeState`

--- a/crates/harn-serve/src/adapters/a2a.rs
+++ b/crates/harn-serve/src/adapters/a2a.rs
@@ -98,9 +98,25 @@ struct HttpState {
 enum TaskStatus {
     Submitted,
     Working,
+    /// The agent has paused execution and is waiting on the client to
+    /// supply input that the script asked for via a HITL primitive
+    /// (`ask_user`, `request_approval`, `dual_control`, `escalate`).
+    /// Non-terminal: the task transitions back to `Working` once the
+    /// HITL response arrives and the waitpoint resumes.
+    InputRequired,
+    /// The agent's execution requires fresh credentials before it can
+    /// continue. Surfaced when a downstream call fails with an auth
+    /// classification mid-task. Non-terminal per A2A 0.3.0: the client
+    /// is expected to re-authenticate and resubscribe.
+    AuthRequired,
     Completed,
     Failed,
     Cancelled,
+    /// The server declined to accept the task. Surfaced synchronously
+    /// when the dispatch core's `AuthPolicy` denies the caller before
+    /// any work runs. Terminal — the client must adjust its request
+    /// (or its credentials at the policy layer) and submit a new task.
+    Rejected,
 }
 
 impl TaskStatus {
@@ -108,14 +124,20 @@ impl TaskStatus {
         match self {
             Self::Submitted => "submitted",
             Self::Working => "working",
+            Self::InputRequired => "input-required",
+            Self::AuthRequired => "auth-required",
             Self::Completed => "completed",
             Self::Failed => "failed",
             Self::Cancelled => "cancelled",
+            Self::Rejected => "rejected",
         }
     }
 
     fn is_terminal(&self) -> bool {
-        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+        matches!(
+            self,
+            Self::Completed | Self::Failed | Self::Cancelled | Self::Rejected
+        )
     }
 }
 
@@ -717,6 +739,24 @@ impl A2aServer {
 
         match result {
             Ok(response) => self.complete_task(&task.id, response),
+            // The dispatch core's `AuthPolicy.authorize` is what produces
+            // `DispatchError::Unauthorized`. It runs synchronously at the
+            // start of `core.dispatch` before any script work, so the
+            // policy denial is "the server declined this task" — A2A
+            // 0.3.0's `rejected` terminal state. Any post-policy auth
+            // failure (e.g. an LLM/HTTP 401 raised by the script itself)
+            // surfaces through `Execution(...)` with an `auth`-classified
+            // message and maps to non-terminal `auth-required` so the
+            // client can resupply credentials and resubscribe.
+            Err(DispatchError::Unauthorized(message)) => self.reject_task(&task.id, &message),
+            Err(DispatchError::Execution(message))
+                if matches!(
+                    harn_vm::value::classify_error_message(&message),
+                    harn_vm::value::ErrorCategory::Auth
+                ) =>
+            {
+                self.auth_required_task(&task.id, &message);
+            }
             Err(error) => self.fail_task(&task.id, &error.to_string()),
         }
     }
@@ -772,10 +812,27 @@ impl A2aServer {
     }
 
     fn fail_task(&self, task_id: &str, message: &str) {
+        self.terminate_task(task_id, TaskStatus::Failed, message);
+    }
+
+    /// Terminal — the dispatch core's `AuthPolicy` synchronously denied
+    /// the caller before any script work could run. The A2A spec calls
+    /// this `rejected`: the client cannot resume by re-authing or
+    /// retrying, it has to adjust its request (or the server-side
+    /// policy) and send a new task.
+    fn reject_task(&self, task_id: &str, message: &str) {
+        self.terminate_task(task_id, TaskStatus::Rejected, message);
+    }
+
+    fn terminate_task(&self, task_id: &str, status: TaskStatus, message: &str) {
+        debug_assert!(
+            status.is_terminal(),
+            "terminate_task expects a terminal status"
+        );
         let event = json!({
             "type": "status",
             "taskId": task_id,
-            "status": {"state": "failed"},
+            "status": {"state": status.as_str()},
             "error": message,
         });
         let task_for_push = {
@@ -783,7 +840,37 @@ impl A2aServer {
             let Some(task) = tasks.get_mut(task_id) else {
                 return;
             };
-            task.status = TaskStatus::Failed;
+            task.status = status;
+            task.history.push(TaskMessage {
+                id: Uuid::now_v7().to_string(),
+                role: "agent".to_string(),
+                parts: vec![json!({"type": "text", "text": message})],
+            });
+            publish_locked(task, event);
+            task.cancel_token = None;
+            task_to_json(task)
+        };
+        self.deliver_push(task_for_push);
+    }
+
+    /// Non-terminal — a downstream auth check failed mid-task (the
+    /// script itself raised an `auth`-classified error). The client is
+    /// expected to refresh its credentials and resubscribe; the task
+    /// remains in the store so a follow-up `tasks/resubscribe` finds it.
+    /// Subscribers are kept attached because the state is non-terminal.
+    fn auth_required_task(&self, task_id: &str, message: &str) {
+        let event = json!({
+            "type": "status",
+            "taskId": task_id,
+            "status": {"state": TaskStatus::AuthRequired.as_str()},
+            "error": message,
+        });
+        let task_for_push = {
+            let mut tasks = self.tasks.lock().expect("tasks poisoned");
+            let Some(task) = tasks.get_mut(task_id) else {
+                return;
+            };
+            task.status = TaskStatus::AuthRequired;
             task.history.push(TaskMessage {
                 id: Uuid::now_v7().to_string(),
                 role: "agent".to_string(),
@@ -2330,6 +2417,24 @@ impl harn_vm::agent_events::AgentEventSink for A2aWorkerSink {
                     "plan": plan,
                 })
             }
+            harn_vm::agent_events::AgentEvent::HitlRequested {
+                request_id,
+                kind,
+                payload,
+                ..
+            } => {
+                self.transition_input_required(request_id, kind, payload);
+                return;
+            }
+            harn_vm::agent_events::AgentEvent::HitlResolved {
+                request_id,
+                kind,
+                outcome,
+                ..
+            } => {
+                self.resolve_input_required(request_id, kind, outcome);
+                return;
+            }
             _ => return,
         };
         let task_for_push = {
@@ -2346,6 +2451,70 @@ impl harn_vm::agent_events::AgentEventSink for A2aWorkerSink {
         // transitions so high-volume worker traffic doesn't flood
         // outbound HTTP endpoints.
         let _ = task_for_push;
+    }
+}
+
+impl A2aWorkerSink {
+    /// Flip the task into `input-required` while a HITL primitive is
+    /// blocked waiting for a response. The script remains suspended on
+    /// a waitpoint; subscribers see two events — a structured `hitl`
+    /// extension event carrying the request payload, then the canonical
+    /// `status` transition. Idempotent for repeat HITL requests inside
+    /// the same task: only the first transitions the status.
+    ///
+    /// No push-config webhook delivery here, mirroring the
+    /// `worker_update` policy: HITL transitions stream live to active
+    /// SSE subscribers and surface on `tasks/get`, but high-frequency
+    /// status flips don't fan out to outbound webhook endpoints.
+    fn transition_input_required(&self, request_id: &str, kind: &str, payload: &JsonValue) {
+        let mut tasks = self.tasks.lock().expect("tasks poisoned");
+        let Some(task) = tasks.get_mut(&self.task_id) else {
+            return;
+        };
+        // Don't override a terminal/cancelled task: the waitpoint
+        // emit can race the cancel path. Once the task is dead it
+        // must stay dead.
+        if task.status.is_terminal() {
+            return;
+        }
+        let hitl_event = json!({
+            "type": "hitl",
+            "taskId": self.task_id,
+            "phase": "requested",
+            "requestId": request_id,
+            "kind": kind,
+            "payload": payload,
+        });
+        publish_locked(task, hitl_event);
+        if task.status != TaskStatus::InputRequired {
+            task.status = TaskStatus::InputRequired;
+            publish_locked(task, status_event(&self.task_id, TaskStatus::InputRequired));
+        }
+    }
+
+    /// Companion to `transition_input_required`. Flip back to `working`
+    /// once the waitpoint resolves so subscribers see the task resume
+    /// (or terminate naturally on the next tick if the script returned
+    /// from the HITL call). Only flips out of `input-required`; if a
+    /// later `auth-required` / cancellation snuck in, leave it.
+    fn resolve_input_required(&self, request_id: &str, kind: &str, outcome: &str) {
+        let mut tasks = self.tasks.lock().expect("tasks poisoned");
+        let Some(task) = tasks.get_mut(&self.task_id) else {
+            return;
+        };
+        let hitl_event = json!({
+            "type": "hitl",
+            "taskId": self.task_id,
+            "phase": "resolved",
+            "requestId": request_id,
+            "kind": kind,
+            "outcome": outcome,
+        });
+        publish_locked(task, hitl_event);
+        if task.status == TaskStatus::InputRequired {
+            task.status = TaskStatus::Working;
+            publish_locked(task, status_event(&self.task_id, TaskStatus::Working));
+        }
     }
 }
 
@@ -3561,5 +3730,269 @@ pub fn run(task: string) -> string {
         );
 
         harn_vm::agent_events::clear_session_sinks(&session_id);
+    }
+
+    #[test]
+    fn task_status_renders_a2a_0_3_0_state_strings() {
+        // The wire-level state names follow A2A 0.3.0's hyphenated
+        // schema. Pin them so a typo can't silently regress the public
+        // surface of the SSE / push-config payloads.
+        assert_eq!(TaskStatus::Submitted.as_str(), "submitted");
+        assert_eq!(TaskStatus::Working.as_str(), "working");
+        assert_eq!(TaskStatus::InputRequired.as_str(), "input-required");
+        assert_eq!(TaskStatus::AuthRequired.as_str(), "auth-required");
+        assert_eq!(TaskStatus::Completed.as_str(), "completed");
+        assert_eq!(TaskStatus::Failed.as_str(), "failed");
+        assert_eq!(TaskStatus::Cancelled.as_str(), "cancelled");
+        assert_eq!(TaskStatus::Rejected.as_str(), "rejected");
+
+        // Terminal states cannot be cancelled or transitioned out of.
+        // `input-required` and `auth-required` are pause states — the
+        // task is alive and the client is expected to act on it.
+        assert!(TaskStatus::Completed.is_terminal());
+        assert!(TaskStatus::Failed.is_terminal());
+        assert!(TaskStatus::Cancelled.is_terminal());
+        assert!(TaskStatus::Rejected.is_terminal());
+        assert!(!TaskStatus::Submitted.is_terminal());
+        assert!(!TaskStatus::Working.is_terminal());
+        assert!(!TaskStatus::InputRequired.is_terminal());
+        assert!(!TaskStatus::AuthRequired.is_terminal());
+    }
+
+    #[test]
+    fn hitl_requested_event_transitions_task_into_input_required() {
+        // A2A 0.3.0 `input-required` is the wire signal a client uses
+        // to know the task is paused on a HITL waitpoint. Our sink
+        // listens for the canonical `AgentEvent::HitlRequested` emitted
+        // by the HITL primitives in `harn-vm` and flips task status
+        // accordingly. `HitlResolved` flips it back to `working` so
+        // subscribers can observe the resume before the task ultimately
+        // completes / fails.
+        let task_id = "task-hitl".to_string();
+        let task = TaskState {
+            id: task_id.clone(),
+            context_id: None,
+            status: TaskStatus::Working,
+            history: Vec::new(),
+            artifacts: Vec::new(),
+            metadata: BTreeMap::new(),
+            events: Vec::new(),
+            subscribers: Vec::new(),
+            cancel_token: None,
+        };
+        let tasks: TaskStore = Arc::new(Mutex::new(HashMap::from([(task_id.clone(), task)])));
+        let sink = super::A2aWorkerSink {
+            task_id: task_id.clone(),
+            tasks: tasks.clone(),
+        };
+
+        sink.handle_event(&harn_vm::agent_events::AgentEvent::HitlRequested {
+            session_id: super::a2a_worker_session_id(&task_id),
+            request_id: "hitl_question_t1_1".into(),
+            kind: "question".into(),
+            payload: serde_json::json!({"prompt": "Approve?"}),
+        });
+
+        {
+            let tasks = tasks.lock().expect("tasks");
+            let task = tasks.get(&task_id).expect("task");
+            assert_eq!(task.status, TaskStatus::InputRequired);
+            let hitl_event = task
+                .events
+                .iter()
+                .find(|event| event.get("type").and_then(JsonValue::as_str) == Some("hitl"))
+                .expect("hitl event");
+            assert_eq!(hitl_event["phase"], "requested");
+            assert_eq!(hitl_event["kind"], "question");
+            assert_eq!(hitl_event["requestId"], "hitl_question_t1_1");
+            assert_eq!(hitl_event["payload"]["prompt"], "Approve?");
+            let status_event = task
+                .events
+                .iter()
+                .filter_map(|event| {
+                    if event.get("type").and_then(JsonValue::as_str) == Some("status") {
+                        event.pointer("/status/state").and_then(JsonValue::as_str)
+                    } else {
+                        None
+                    }
+                })
+                .next_back()
+                .expect("status event");
+            assert_eq!(status_event, "input-required");
+        }
+
+        sink.handle_event(&harn_vm::agent_events::AgentEvent::HitlResolved {
+            session_id: super::a2a_worker_session_id(&task_id),
+            request_id: "hitl_question_t1_1".into(),
+            kind: "question".into(),
+            outcome: "answered".into(),
+        });
+
+        let tasks = tasks.lock().expect("tasks");
+        let task = tasks.get(&task_id).expect("task");
+        assert_eq!(task.status, TaskStatus::Working);
+        let resolved_event = task
+            .events
+            .iter()
+            .rfind(|event| event.get("type").and_then(JsonValue::as_str) == Some("hitl"))
+            .expect("resolved hitl event");
+        assert_eq!(resolved_event["phase"], "resolved");
+        assert_eq!(resolved_event["outcome"], "answered");
+    }
+
+    #[test]
+    fn hitl_requested_event_does_not_override_terminal_task() {
+        // The waitpoint emit can race with cancellation/completion.
+        // Once a task is terminal, a stray `HitlRequested` must not
+        // reanimate it into `input-required`.
+        let task_id = "task-terminal".to_string();
+        let task = TaskState {
+            id: task_id.clone(),
+            context_id: None,
+            status: TaskStatus::Cancelled,
+            history: Vec::new(),
+            artifacts: Vec::new(),
+            metadata: BTreeMap::new(),
+            events: Vec::new(),
+            subscribers: Vec::new(),
+            cancel_token: None,
+        };
+        let tasks: TaskStore = Arc::new(Mutex::new(HashMap::from([(task_id.clone(), task)])));
+        let sink = super::A2aWorkerSink {
+            task_id: task_id.clone(),
+            tasks: tasks.clone(),
+        };
+
+        sink.handle_event(&harn_vm::agent_events::AgentEvent::HitlRequested {
+            session_id: super::a2a_worker_session_id(&task_id),
+            request_id: "late".into(),
+            kind: "question".into(),
+            payload: serde_json::json!({}),
+        });
+
+        let tasks = tasks.lock().expect("tasks");
+        let task = tasks.get(&task_id).expect("task");
+        assert_eq!(task.status, TaskStatus::Cancelled);
+        // No HITL event is published either — the late emission is
+        // dropped wholesale rather than partially recorded.
+        assert!(
+            task.events
+                .iter()
+                .all(|event| event.get("type").and_then(JsonValue::as_str) != Some("hitl")),
+            "events: {:?}",
+            task.events
+        );
+    }
+
+    #[tokio::test]
+    async fn rejected_state_surfaces_when_auth_policy_denies_dispatch() {
+        // Synchronous policy denial: `AuthPolicy.authorize` returns
+        // `Rejected` before any script work runs, so the task lands in
+        // the terminal `rejected` state per A2A 0.3.0. The client sees
+        // the `rejected` status alongside the policy's reason in the
+        // task history; subsequent `tasks/cancel` is rejected because
+        // the task is already terminal.
+        let (_dir, server) = server_with_api_key_policy(
+            r#"
+pub fn triage(task: string) -> string {
+  return task
+}
+"#,
+            "secret-key",
+        );
+        let request = harn_vm::jsonrpc::request(
+            "rej-1",
+            "message/send",
+            json!({
+                "message": {
+                    "metadata": {"target_agent": "triage"},
+                    "parts": [{"type": "text", "text": "hello"}]
+                },
+                "configuration": {"blocking": true}
+            }),
+        );
+
+        // No bearer token — the API-key policy will deny the dispatch.
+        let processed = server.process_rpc(request, AuthRequest::default()).await;
+        let RpcOutcome::Json(response) = processed.outcome else {
+            panic!(
+                "expected json response, got: {processed:?}",
+                processed = match processed.outcome {
+                    RpcOutcome::Json(_) => "json",
+                    RpcOutcome::Sse(_) => "sse",
+                }
+            );
+        };
+
+        assert_eq!(
+            response["result"]["status"]["state"], "rejected",
+            "got: {response}"
+        );
+        // The denial reason lands in the task history as the agent
+        // turn so callers can render it without cracking error fields.
+        let history = response["result"]["history"]
+            .as_array()
+            .expect("history array");
+        let agent_message = history
+            .iter()
+            .find(|message| message["role"] == "agent")
+            .expect("agent reply");
+        let text = agent_message["parts"][0]["text"]
+            .as_str()
+            .expect("text part")
+            .to_lowercase();
+        assert!(
+            text.contains("auth") || text.contains("missing") || text.contains("invalid"),
+            "expected denial reason in history, got: {agent_message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_required_state_surfaces_when_script_raises_auth_error() {
+        // Mid-task downstream auth failure: the script raises an
+        // auth-classified error (e.g. an LLM/HTTP 401 surfaces through
+        // `error_to_category`). The dispatch returns `Execution(...)`
+        // wrapping the message; the adapter classifies it via
+        // `harn_vm::value::classify_error_message` and flips the task
+        // into the non-terminal `auth-required` state so the client
+        // can refresh credentials and resubscribe.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(
+            &script,
+            r#"
+pub fn triage(task: string) -> string {
+  // The auth classifier matches "401" (HTTP status code) and well-
+  // known error identifier substrings. This message hits both so the
+  // path is exercised regardless of which heuristic fires first.
+  throw "downstream HTTP 401: invalid_api_key"
+  return task
+}
+"#,
+        )
+        .expect("write script");
+        let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+        let server = Arc::new(A2aServer::new(A2aServerConfig::new(core)));
+        let request = harn_vm::jsonrpc::request(
+            "auth-1",
+            "message/send",
+            json!({
+                "message": {
+                    "metadata": {"target_agent": "triage"},
+                    "parts": [{"type": "text", "text": "hello"}]
+                },
+                "configuration": {"blocking": true}
+            }),
+        );
+
+        let processed = server.process_rpc(request, AuthRequest::default()).await;
+        let RpcOutcome::Json(response) = processed.outcome else {
+            panic!("expected json response");
+        };
+
+        assert_eq!(
+            response["result"]["status"]["state"], "auth-required",
+            "got: {response}"
+        );
     }
 }

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -545,6 +545,53 @@ impl AgentEventSink for AcpAgentEventSink {
                     "update": update,
                 }));
             }
+            AgentEvent::HitlRequested {
+                session_id,
+                request_id,
+                kind,
+                payload,
+            } => {
+                let mut update = serde_json::json!({
+                    "sessionUpdate": "hitl_request",
+                });
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert(
+                    "requestId".to_string(),
+                    serde_json::Value::String(request_id.clone()),
+                );
+                harn_meta.insert("kind".to_string(), serde_json::Value::String(kind.clone()));
+                harn_meta.insert("payload".to_string(), payload.clone());
+                merge_harn_meta(&mut update, harn_meta);
+                self.write_notification(serde_json::json!({
+                    "sessionId": session_id,
+                    "update": update,
+                }));
+            }
+            AgentEvent::HitlResolved {
+                session_id,
+                request_id,
+                kind,
+                outcome,
+            } => {
+                let mut update = serde_json::json!({
+                    "sessionUpdate": "hitl_resolved",
+                });
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert(
+                    "requestId".to_string(),
+                    serde_json::Value::String(request_id.clone()),
+                );
+                harn_meta.insert("kind".to_string(), serde_json::Value::String(kind.clone()));
+                harn_meta.insert(
+                    "outcome".to_string(),
+                    serde_json::Value::String(outcome.clone()),
+                );
+                merge_harn_meta(&mut update, harn_meta);
+                self.write_notification(serde_json::json!({
+                    "sessionId": session_id,
+                    "update": update,
+                }));
+            }
             // Pipeline-loop milestones with no canonical ACP session/update
             // mapping; deliberately not forwarded.
             AgentEvent::TurnStart { .. }
@@ -739,6 +786,18 @@ mod tests {
                     "child_run_path": ".harn-runs/run_x",
                 }),
                 audit: Some(serde_json::json!({"run_id": "run_x"})),
+            },
+            AgentEvent::HitlRequested {
+                session_id: "session-1".into(),
+                request_id: "hitl_question_session-1_1".into(),
+                kind: "question".into(),
+                payload: serde_json::json!({"prompt": "Approve deploy?"}),
+            },
+            AgentEvent::HitlResolved {
+                session_id: "session-1".into(),
+                request_id: "hitl_question_session-1_1".into(),
+                kind: "question".into(),
+                outcome: "answered".into(),
             },
         ]
     }
@@ -1575,6 +1634,8 @@ mod tests {
                     "audit",
                 ],
             ),
+            ("hitl_request", &["requestId", "kind", "payload"]),
+            ("hitl_resolved", &["requestId", "kind", "outcome"]),
         ];
 
         assert_eq!(

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -39,6 +39,8 @@ pub(super) const ACP_SCHEMA_COMPATIBILITY: &str =
 pub(super) const HARN_SESSION_UPDATE_EXTENSIONS: &[&str] = &[
     "fs_watch",
     "handoff",
+    "hitl_request",
+    "hitl_resolved",
     "log",
     "progress",
     "skill_activated",

--- a/crates/harn-serve/tests/fixtures/acp/session_update_extensions.json
+++ b/crates/harn-serve/tests/fixtures/acp/session_update_extensions.json
@@ -207,5 +207,41 @@
         "sessionUpdate": "worker_update"
       }
     }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "_meta": {
+          "harn": {
+            "kind": "question",
+            "payload": {
+              "prompt": "Approve deploy?"
+            },
+            "requestId": "hitl_question_session-1_1"
+          }
+        },
+        "sessionUpdate": "hitl_request"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": {
+      "sessionId": "session-1",
+      "update": {
+        "_meta": {
+          "harn": {
+            "kind": "question",
+            "outcome": "answered",
+            "requestId": "hitl_question_session-1_1"
+          }
+        },
+        "sessionUpdate": "hitl_resolved"
+      }
+    }
   }
 ]

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -473,6 +473,30 @@ pub enum AgentEvent {
         metadata: serde_json::Value,
         audit: Option<serde_json::Value>,
     },
+    /// A human-in-the-loop primitive (`ask_user`, `request_approval`,
+    /// `dual_control`, `escalate`) has just suspended the script and is
+    /// waiting on a response. Hosts that bridge the VM onto a remote
+    /// transport (ACP, A2A) translate this into a "paused / awaiting
+    /// input" wire signal so the client knows the task isn't stuck —
+    /// it's blocked on the human side. Pair-emitted with `HitlResolved`
+    /// when the waitpoint completes/cancels/times out.
+    HitlRequested {
+        session_id: String,
+        request_id: String,
+        kind: String,
+        payload: serde_json::Value,
+    },
+    /// Companion to `HitlRequested`: the waitpoint has resolved (either
+    /// a response arrived, the deadline elapsed, or the request was
+    /// cancelled). `outcome` is one of `"answered"`, `"timeout"`,
+    /// `"cancelled"`. Hosts use this to flip task state back to
+    /// `working` after an `input-required` pause.
+    HitlResolved {
+        session_id: String,
+        request_id: String,
+        kind: String,
+        outcome: String,
+    },
 }
 
 impl AgentEvent {
@@ -497,7 +521,9 @@ impl AgentEvent {
             | Self::TranscriptCompacted { session_id, .. }
             | Self::Handoff { session_id, .. }
             | Self::FsWatch { session_id, .. }
-            | Self::WorkerUpdate { session_id, .. } => session_id,
+            | Self::WorkerUpdate { session_id, .. }
+            | Self::HitlRequested { session_id, .. }
+            | Self::HitlResolved { session_id, .. } => session_id,
         }
     }
 }

--- a/crates/harn-vm/src/stdlib/hitl.rs
+++ b/crates/harn-vm/src/stdlib/hitl.rs
@@ -411,9 +411,16 @@ async fn ask_user_impl(args: &[VmValue]) -> Result<VmValue, VmError> {
     create_request_waitpoint(&log, &request).await?;
     append_request(&log, &request).await?;
     maybe_notify_host(&request);
+    emit_hitl_requested(&request);
     maybe_apply_mock_response(HitlRequestKind::Question, &request_id, &request.payload).await?;
 
-    match wait_for_request_waitpoint(&request_id, options.timeout).await? {
+    match wait_for_request_waitpoint_with_events(
+        &request_id,
+        HitlRequestKind::Question,
+        options.timeout,
+    )
+    .await?
+    {
         WaitpointOutcome::Completed(record) => {
             let answer = record
                 .value
@@ -521,9 +528,16 @@ async fn request_approval_impl(args: &[VmValue]) -> Result<VmValue, VmError> {
     create_request_waitpoint(&log, &request).await?;
     append_request(&log, &request).await?;
     maybe_notify_host(&request);
+    emit_hitl_requested(&request);
     maybe_apply_mock_response(HitlRequestKind::Approval, &request_id, &request.payload).await?;
 
-    match wait_for_request_waitpoint(&request_id, Some(options.deadline)).await? {
+    match wait_for_request_waitpoint_with_events(
+        &request_id,
+        HitlRequestKind::Approval,
+        Some(options.deadline),
+    )
+    .await?
+    {
         WaitpointOutcome::Completed(record) => {
             approval_record_from_waitpoint(&record, "request_approval")
         }
@@ -627,10 +641,12 @@ async fn dual_control_impl(args: &[VmValue]) -> Result<VmValue, VmError> {
     create_request_waitpoint(&log, &request).await?;
     append_request(&log, &request).await?;
     maybe_notify_host(&request);
+    emit_hitl_requested(&request);
     maybe_apply_mock_response(HitlRequestKind::DualControl, &request_id, &request.payload).await?;
 
-    match wait_for_request_waitpoint(
+    match wait_for_request_waitpoint_with_events(
         &request_id,
+        HitlRequestKind::DualControl,
         Some(StdDuration::from_millis(HITL_APPROVAL_TIMEOUT_MS)),
     )
     .await?
@@ -696,9 +712,12 @@ async fn escalate_to_impl(args: &[VmValue]) -> Result<VmValue, VmError> {
     create_request_waitpoint(&log, &request).await?;
     append_request(&log, &request).await?;
     maybe_notify_host(&request);
+    emit_hitl_requested(&request);
     maybe_apply_mock_response(HitlRequestKind::Escalation, &request_id, &request.payload).await?;
 
-    match wait_for_request_waitpoint(&request_id, None).await? {
+    match wait_for_request_waitpoint_with_events(&request_id, HitlRequestKind::Escalation, None)
+        .await?
+    {
         WaitpointOutcome::Completed(record) => {
             let accepted_at = record.completed_at.clone();
             let reviewer = record.completed_by.clone();
@@ -1333,6 +1352,62 @@ fn maybe_notify_host(request: &HitlRequestEnvelope) {
     );
 }
 
+/// Emit a `HitlRequested` `AgentEvent` so transport adapters
+/// (currently the A2A `A2aWorkerSink`) can flip a task into
+/// `input-required` while the script is suspended on the waitpoint.
+/// No-op when there is no current agent session — the bridge-level
+/// `harn.hitl.requested` notification still fires for hosts that drive
+/// HITL UX through the bridge.
+fn emit_hitl_requested(request: &HitlRequestEnvelope) {
+    let Some(session_id) = crate::agent_sessions::current_session_id() else {
+        return;
+    };
+    crate::agent_events::emit_event(&crate::agent_events::AgentEvent::HitlRequested {
+        session_id,
+        request_id: request.request_id.clone(),
+        kind: request.kind.as_str().to_string(),
+        payload: request.payload.clone(),
+    });
+}
+
+/// Companion to `emit_hitl_requested`: notifies sinks that the
+/// suspended waitpoint has resolved so a paused task can flip back
+/// out of `input-required`. `outcome` is one of `"answered"`,
+/// `"timeout"`, `"cancelled"`, or `"error"`.
+fn emit_hitl_resolved(request_id: &str, kind: HitlRequestKind, outcome: &str) {
+    let Some(session_id) = crate::agent_sessions::current_session_id() else {
+        return;
+    };
+    crate::agent_events::emit_event(&crate::agent_events::AgentEvent::HitlResolved {
+        session_id,
+        request_id: request_id.to_string(),
+        kind: kind.as_str().to_string(),
+        outcome: outcome.to_string(),
+    });
+}
+
+/// Wrapper around `wait_for_request_waitpoint` that emits the
+/// canonical `HitlResolved` `AgentEvent` regardless of which terminal
+/// branch the waitpoint takes (response / timeout / cancellation /
+/// error). Pair-emitted with `emit_hitl_requested` so transport
+/// adapters can bracket the `input-required` pause cleanly without
+/// each `*_impl` having to duplicate the emission at every match arm.
+async fn wait_for_request_waitpoint_with_events(
+    request_id: &str,
+    kind: HitlRequestKind,
+    timeout: Option<StdDuration>,
+) -> Result<WaitpointOutcome, VmError> {
+    let outcome = wait_for_request_waitpoint(request_id, timeout).await;
+    let label = match &outcome {
+        Ok(WaitpointOutcome::Completed(_)) => "answered",
+        Ok(WaitpointOutcome::Timeout) => "timeout",
+        Ok(WaitpointOutcome::Cancelled { .. }) => "cancelled",
+        Err(_) => "error",
+    };
+    emit_hitl_resolved(request_id, kind, label);
+    outcome
+}
+
 fn parse_ask_user_options(value: Option<&VmValue>) -> Result<AskUserOptions, VmError> {
     let Some(value) = value else {
         return Ok(AskUserOptions {
@@ -1963,6 +2038,104 @@ pipeline test(task) {
                         "hitl.escalation_accepted".to_string(),
                     ]
                 );
+            })
+            .await;
+    }
+
+    /// `harn-serve` adapters (A2A `input-required`, ACP `hitl_request`)
+    /// rely on the canonical `AgentEvent::HitlRequested` /
+    /// `AgentEvent::HitlResolved` pair to bracket every HITL pause.
+    /// Pin the contract here so future HITL primitives keep emitting
+    /// the event around their waitpoint blocks.
+    #[tokio::test(flavor = "current_thread")]
+    async fn ask_user_emits_hitl_request_and_resolution_to_agent_event_sinks() {
+        use std::sync::Mutex as StdMutex;
+
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                let dir = tempfile::tempdir().expect("tempdir");
+                let session_id = "hitl-session".to_string();
+                let captured: std::sync::Arc<StdMutex<Vec<crate::agent_events::AgentEvent>>> =
+                    std::sync::Arc::new(StdMutex::new(Vec::new()));
+
+                struct CaptureSink(std::sync::Arc<StdMutex<Vec<crate::agent_events::AgentEvent>>>);
+                impl crate::agent_events::AgentEventSink for CaptureSink {
+                    fn handle_event(&self, event: &crate::agent_events::AgentEvent) {
+                        self.0.lock().expect("captured").push(event.clone());
+                    }
+                }
+
+                // Inline the script setup rather than using the
+                // `execute_hitl_script` helper: that helper calls
+                // `reset_thread_local_state` (which wipes the session
+                // store), so any session pushed before it would be
+                // gone by the time `ask_user` runs.
+                crate::reset_thread_local_state();
+                crate::event_log::install_default_for_base_dir(dir.path())
+                    .expect("install event log");
+
+                crate::agent_events::reset_all_sinks();
+                let sink: std::sync::Arc<dyn crate::agent_events::AgentEventSink> =
+                    std::sync::Arc::new(CaptureSink(captured.clone()));
+                crate::agent_events::register_sink(session_id.clone(), sink);
+                crate::agent_sessions::open_or_create(Some(session_id.clone()));
+                let _guard = crate::agent_sessions::enter_current_session(session_id.clone());
+
+                let source = r#"
+pipeline test(task) {
+  host_mock("hitl", "question", {answer: "ok"})
+  let answer: string = ask_user("Are you sure?", {default: "no"})
+  println(answer)
+}
+"#;
+                let chunk = crate::compile_source(source).expect("compile source");
+                let mut vm = Vm::new();
+                register_vm_stdlib(&mut vm);
+                vm.set_source_dir(dir.path());
+                vm.execute(&chunk).await.expect("script runs");
+                assert_eq!(vm.output().trim_end(), "ok");
+
+                let events = captured.lock().expect("captured");
+                let mut iter = events.iter().filter(|event| {
+                    matches!(
+                        event,
+                        crate::agent_events::AgentEvent::HitlRequested { .. }
+                            | crate::agent_events::AgentEvent::HitlResolved { .. }
+                    )
+                });
+                let requested = iter.next().expect("HitlRequested emitted");
+                let resolved = iter.next().expect("HitlResolved emitted");
+                assert!(iter.next().is_none(), "exactly one pair: {events:?}");
+
+                let crate::agent_events::AgentEvent::HitlRequested {
+                    session_id: req_session,
+                    request_id: req_id,
+                    kind: req_kind,
+                    payload,
+                } = requested
+                else {
+                    panic!("expected HitlRequested, got: {requested:?}");
+                };
+                assert_eq!(req_session, &session_id);
+                assert_eq!(req_kind, "question");
+                assert!(req_id.starts_with("hitl_question_"));
+                assert_eq!(payload["prompt"], "Are you sure?");
+
+                let crate::agent_events::AgentEvent::HitlResolved {
+                    request_id: res_id,
+                    kind: res_kind,
+                    outcome,
+                    ..
+                } = resolved
+                else {
+                    panic!("expected HitlResolved, got: {resolved:?}");
+                };
+                assert_eq!(res_id, req_id);
+                assert_eq!(res_kind, "question");
+                assert_eq!(outcome, "answered");
+
+                drop(_guard);
+                crate::agent_events::reset_all_sinks();
             })
             .await;
     }

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -752,8 +752,22 @@ Content-Type: application/json
 {"jsonrpc":"2.0","id":"get-1","method":"tasks/get","params":{"id":"<task-id>"}}
 ```
 
-Task states follow the A2A protocol lifecycle: `submitted`, `working`,
-`completed`, `failed`, `cancelled`.
+Task states follow the A2A 0.3.0 lifecycle:
+
+- **Active**: `submitted`, `working`.
+- **Pause states (non-terminal)**: `input-required` is set while a HITL
+  primitive (`ask_user`, `request_approval`, `dual_control`,
+  `escalate_to`) is suspended on a waitpoint; the SSE stream carries a
+  paired `hitl` event with the request payload, then flips back to
+  `working` when the response arrives. `auth-required` is set when a
+  downstream call inside the script raises an auth-classified error
+  (e.g. an HTTP 401 from an LLM provider); the client is expected to
+  re-authenticate and resubscribe.
+- **Terminal**: `completed`, `failed`, `cancelled`, `rejected`.
+  `rejected` is returned synchronously when the dispatch core's
+  `AuthPolicy` denies the caller before any script work runs (the
+  caller cannot recover by retrying with the same credentials —
+  policy/credentials must change).
 
 Completed task payloads also include `metadata.handoff_ids` and
 `metadata.handoffs` when the served function returned typed handoff artifacts,


### PR DESCRIPTION
## Summary

Closes [#889](https://github.com/burin-labs/harn/issues/889).

The A2A adapter previously only modeled five of A2A 0.3.0's eight canonical task states. This PR extends `TaskStatus` with the missing three (`input-required`, `auth-required`, `rejected`) and wires each one into the runtime behavior the spec calls for.

- **`input-required`** — every HITL primitive (`ask_user`, `request_approval`, `dual_control`, `escalate_to`) now emits a canonical `AgentEvent::HitlRequested` / `HitlResolved` pair around its waitpoint. The A2A `A2aWorkerSink` translates these into a structured `hitl` task event plus the `input-required` ↔ `working` status transition so SSE subscribers see both the request payload and the pause state. The ACP adapter advertises matching `hitl_request` / `hitl_resolved` session-update extensions under `_meta.harn`.
- **`auth-required`** — when a downstream call fails with an `auth`-classified error mid-task (HTTP 401, `invalid_api_key`, `authentication_error`, …), the adapter classifies the dispatch error via `harn_vm::value::classify_error_message` and flips the task into the non-terminal `auth-required` state. The client is expected to refresh credentials and resubscribe.
- **`rejected`** — synchronous policy denial (`AuthPolicy.authorize` returning `Rejected`) now lands the task in the terminal `rejected` state instead of `failed`, distinguishing "we declined this work" from runtime failure.

`is_terminal()` is updated so `rejected` joins `completed` / `failed` / `cancelled`; `input-required` and `auth-required` stay non-terminal so subscribers and `tasks/cancel` keep working against paused tasks.

## Files

- `crates/harn-serve/src/adapters/a2a.rs` — `TaskStatus` extension, `reject_task` / `auth_required_task` / `transition_input_required` / `resolve_input_required`, error→state mapping in `run_task_to_completion`, four new tests.
- `crates/harn-vm/src/agent_events.rs` — new `HitlRequested` / `HitlResolved` `AgentEvent` variants.
- `crates/harn-vm/src/stdlib/hitl.rs` — emission helpers and a `wait_for_request_waitpoint_with_events` wrapper that pair-emits `HitlResolved` regardless of which terminal branch the waitpoint takes; new test pinning the contract end-to-end.
- `crates/harn-serve/src/adapters/acp/{events.rs,mod.rs}` + `tests/fixtures/acp/session_update_extensions.json` — ACP-side `hitl_request` / `hitl_resolved` session-update extensions plus pinned fixture.
- `CHANGELOG.md`, `docs/src/mcp-and-acp.md` — release note + lifecycle docs update.

## Test plan

- [x] `cargo test -p harn-serve --lib` (108 passed)
- [x] `cargo test -p harn-vm --lib` (1700 passed)
- [x] `cargo clippy -p harn-serve -p harn-vm --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Fixture-pinned ACP session-update test still matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)