### PR TITLE
Repair-worker checkpoint contract for Merge Captain (#1010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Added
+
+- **Merge Captain repair-worker checkpoint contract (#1010).**
+  Added a typed contract for the bounded `agent_loop` worker that
+  Merge Captain (and the release-harness consumer in
+  [#1146](https://github.com/burin-labs/harn/issues/1146)) calls at
+  explicit repair checkpoints. New modules under
+  `personas/merge_captain/lib/` cover bundle preparation
+  (`repair_bundle.harn`), per-action approval gates
+  (`approval.harn`), the dispatcher itself (`repair_worker.harn`),
+  and deterministic output validators (`repair_validator.harn`). The
+  bundle pins repo + PR + base/head SHAs, allowed write-scope globs,
+  required verification commands, push target, and the action kinds
+  that need human approval (`semantic_repair`, `force_push`,
+  `admin_merge`, `release_tag`, `branch_delete`). Workers must
+  produce a `merge_captain.repair_output` v1 JSON document; the
+  harness rejects missing tests, unexpected write scope, malformed
+  output, unpushed commits, and (when opted in) dirty worktrees.
+  Every run yields a versioned `merge_captain.repair_run` record
+  that the merge receipt links back to via a compact
+  `merge_captain.repair_run_link` summary. The worker is opt-in per
+  repo via `policy.repair_worker.{enabled, handles_kinds, ...}`; the
+  scheduler routes `local_repair` and `dirty` to the worker only
+  when the policy enables the matching bundle kind.
+
 ## v0.7.54
 
 ### Added

--- a/personas/merge_captain/README.md
+++ b/personas/merge_captain/README.md
@@ -43,8 +43,12 @@ GitHub adapter that rides the connector contract — no raw
 | [`lib/checkpoint_store.harn`](lib/checkpoint_store.harn) | `std/agent_state`-backed per-PR persistence. |
 | [`lib/github_adapter.harn`](lib/github_adapter.harn) | Live (connector) and fixture-mode GitHub I/O. |
 | [`lib/local_verify.harn`](lib/local_verify.harn) | Runs per-repo local verification commands. |
-| [`lib/receipt.harn`](lib/receipt.harn) | Per-PR + sweep receipt builders. |
-| [`lib/scheduler.harn`](lib/scheduler.harn) | The actual sweep loop. |
+| [`lib/repair_bundle.harn`](lib/repair_bundle.harn) | Pure builders + JSON schema for the repair-worker checkpoint contract. |
+| [`lib/repair_validator.harn`](lib/repair_validator.harn) | Deterministic validators for repair-worker output (missing tests, dirty worktrees, unexpected write scope, malformed output, unpushed commits). |
+| [`lib/approval.harn`](lib/approval.harn) | Approval gate for repair-worker action kinds (semantic_repair / force_push / admin_merge / release_tag / branch_delete). |
+| [`lib/repair_worker.harn`](lib/repair_worker.harn) | The only `agent_loop` caller. Builds the bundle, runs the gate, dispatches the worker, runs the validators, and returns a `merge_captain.repair_run` record. |
+| [`lib/receipt.harn`](lib/receipt.harn) | Per-PR + sweep receipt builders, including the `merge_captain.repair_run_link` summary. |
+| [`lib/scheduler.harn`](lib/scheduler.harn) | The actual sweep loop. Routes `local_repair` / `dirty` to the repair worker when policy enables it. |
 | [`policies/*.json`](policies) | Per-repo policy fixtures for harn / harn-cloud / burin-code. |
 | [`fixtures/github_snapshot.json`](fixtures/github_snapshot.json) | Deterministic GitHub state for evals. |
 | [`tests/`](tests) | Pure-Harn unit + scheduler tests. |
@@ -107,6 +111,95 @@ adapter never shells out to `gh`. Local verification commands are the
 one exception; they run via `process.exec` per the per-repo
 `local_verification` list.
 
+## Repair-worker checkpoint contract
+
+Most Merge Captain steps are deterministic, but a few require coding
+judgment: semantic merge conflicts, CI failure diagnosis, flaky-test
+hardening, release-note audits. Those run through a bounded
+`agent_loop` worker called at explicit repair checkpoints. The
+contract has four pieces:
+
+1. **Typed bundle** (`lib/repair_bundle.harn`). The deterministic
+   harness packages a `merge_captain.repair_bundle` v1 record
+   covering: repo, PR, base/head SHAs, changed files, conflict paths
+   or failing checks, relevant logs, allowed write scope (path
+   globs), required verification commands, push target with
+   `force_with_lease`, and the action kinds that require approval.
+   Bundle kinds are `ci_failure`, `merge_conflict`, `release_audit`,
+   `flaky_test`. The release-audit kind carries the typed
+   `release_facts` and `release_outputs` shape used by
+   [harn#1146](https://github.com/burin-labs/harn/issues/1146).
+2. **Approval gate** (`lib/approval.harn`). Per-repo
+   `policy.repair_worker.{require_human_for, autopilot_action_kinds,
+   pre_approved}` decides whether the worker can proceed without a
+   human for each of `semantic_repair`, `force_push`, `admin_merge`,
+   `release_tag`, `branch_delete`. The default is "human required for
+   everything" — autopilot is opt-in per action kind.
+3. **Worker dispatch** (`lib/repair_worker.harn`). The only
+   `agent_loop` caller in the persona. It validates the bundle, runs
+   the gate, calls `agent_loop` with the prompt + the
+   `repair_bundle.output_schema()` JSON schema, runs every
+   deterministic validator, and returns a versioned
+   `merge_captain.repair_run` record.
+4. **Deterministic validators** (`lib/repair_validator.harn`). Every
+   worker output is checked against five guards:
+   - **missing tests** — `tests_run` is empty or fails to cover every
+     `required_verification` entry, or any test reports `status !=
+     "ok"`.
+   - **unexpected write scope** — any path in `files_changed` falls
+     outside the bundle's `allowed_write_scope` glob list.
+   - **malformed output** — any required key on the `repair_output`
+     schema is missing or has the wrong type.
+   - **unpushed commits** — `commits_created` is non-empty but the
+     `push_result.pushed` flag is not true, the ref is missing, or
+     the ref does not match the bundle's push target.
+   - **dirty worktree** — opt-in `harness_validate(...)` runs `git
+     status --porcelain` after the worker returns and fails closed if
+     the tree is not clean.
+
+The receipt links back to the parent merge-captain PR state through
+the `repair_run` field on `merge_receipt`, which carries a compact
+`merge_captain.repair_run_link` summary (bundle kind, status,
+approval state, output counts, agent_loop telemetry). The full
+`repair_run` record is the audit trail.
+
+## Enabling the repair worker
+
+The repair worker is opt-in per repo. Add a `repair_worker` block to
+the policy JSON:
+
+```json
+{
+  "repair_worker": {
+    "enabled": true,
+    "handles_kinds": ["ci_failure"],
+    "require_human_for": [
+      "semantic_repair",
+      "force_push",
+      "admin_merge",
+      "release_tag",
+      "branch_delete"
+    ],
+    "autopilot_action_kinds": [],
+    "model": "claude-sonnet-4-6",
+    "max_iterations": 24,
+    "profile": "tool_using"
+  }
+}
+```
+
+When the scheduler classifies a PR as `local_repair` (CI failure with
+local verification configured), and the policy enables the worker for
+`ci_failure`, the dispatcher builds a CI-failure bundle and routes
+through `repair_worker.invoke(...)` instead of running
+`run_local_verification` inline. Same for `merge_conflict` when
+`handles_kinds` includes it.
+
+For non-Merge-Captain consumers (release-harness in
+[harn#1146](https://github.com/burin-labs/harn/issues/1146)), call
+`repair_worker.invoke_for_release_audit(...)` directly with the
+typed git/changelog facts.
+
 ## Invariants
 
 - One writer per session. The checkpoint store opens with
@@ -119,6 +212,9 @@ one exception; they run via `process.exec` per the per-repo
 - Mutating actions are gated by either `dry_run`, autopilot allow-list,
   or human approval — the receipt's `approval_state` is the audit
   trail.
+- `agent_loop` is invoked **only** at explicit repair checkpoints
+  inside `lib/repair_worker.harn`. The classifier and scheduler stay
+  pure; no other Merge Captain module calls into the LLM.
 
 ## Customizing for a new repo
 
@@ -133,4 +229,8 @@ one exception; they run via `process.exec` per the per-repo
 ## Provenance
 
 This implementation closes
-[harn#1009](https://github.com/burin-labs/harn/issues/1009).
+[harn#1009](https://github.com/burin-labs/harn/issues/1009). The
+repair-worker checkpoint contract closes
+[harn#1010](https://github.com/burin-labs/harn/issues/1010) and
+shares the typed bundle/output shapes with
+[harn#1146](https://github.com/burin-labs/harn/issues/1146).

--- a/personas/merge_captain/lib/approval.harn
+++ b/personas/merge_captain/lib/approval.harn
@@ -1,0 +1,121 @@
+// Approval policy gate for repair-worker actions.
+//
+// Repair workers can take a small set of high-blast-radius actions
+// (`semantic_repair`, `force_push`, `admin_merge`, `release_tag`,
+// `branch_delete`). Per-repo policy declares which of those a sweep is
+// allowed to take without first asking a human. This module is pure:
+// it answers `requires_human_for(policy, action_kind, ...)` and
+// surfaces a single `gate(...)` decision the worker dispatcher consumes.
+import { all_action_kinds, is_action_kind } from "repair_bundle"
+
+/** Default approval requirements when policy.repair_worker is missing. */
+pub fn defaults() {
+  return {
+    enabled: false,
+    require_human_for: all_action_kinds(),
+    autopilot_action_kinds: [],
+    pre_approved: false,
+  }
+}
+
+/** Merge per-repo policy.repair_worker on top of the defaults. */
+pub fn with_defaults(repair_policy) {
+  let d = defaults()
+  if repair_policy == nil {
+    return d
+  }
+  return {
+    enabled: repair_policy.enabled ?? d.enabled,
+    require_human_for: repair_policy.require_human_for ?? d.require_human_for,
+    autopilot_action_kinds: repair_policy.autopilot_action_kinds ?? d.autopilot_action_kinds,
+    pre_approved: repair_policy.pre_approved ?? d.pre_approved,
+    model: repair_policy.model,
+    max_iterations: repair_policy.max_iterations,
+    profile: repair_policy.profile,
+    handles_kinds: repair_policy.handles_kinds ?? ["ci_failure"],
+  }
+}
+
+/** True when the per-repo policy allows the worker to handle this kind at all. */
+pub fn handles_kind(repair_policy, kind) {
+  let policy = with_defaults(repair_policy)
+  if !policy.enabled {
+    return false
+  }
+  return policy.handles_kinds.contains(kind)
+}
+
+/** True when human approval is required for the given action_kind. */
+pub fn requires_human_for(repair_policy, action_kind) {
+  if !is_action_kind(action_kind) {
+    return true
+  }
+  let policy = with_defaults(repair_policy)
+  if policy.pre_approved {
+    return false
+  }
+  if policy.autopilot_action_kinds.contains(action_kind) {
+    return false
+  }
+  return policy.require_human_for.contains(action_kind)
+}
+
+/**
+ * Compute the gate decision for a repair bundle. The bundle's
+ * `approval_required_for` lists the actions the bundle expects to
+ * perform (filled in by the dispatcher based on the bundle kind);
+ * we cross-reference that against the repo policy and return:
+ *
+ *   {
+ *     allowed: bool,
+ *     blocking_actions: [string],
+ *     approval_state: "needs_human" | "autopilot" | "pre_approved",
+ *   }
+ */
+pub fn gate(repair_policy, bundle, dry_run) {
+  let policy = with_defaults(repair_policy)
+  if dry_run {
+    return {allowed: true, blocking_actions: [], approval_state: "dry_run"}
+  }
+  if !policy.enabled {
+    return {allowed: false, blocking_actions: bundle.approval_required_for, approval_state: "needs_human"}
+  }
+  if policy.pre_approved {
+    return {allowed: true, blocking_actions: [], approval_state: "pre_approved"}
+  }
+  var blockers = []
+  for action_kind in bundle.approval_required_for {
+    if requires_human_for(repair_policy, action_kind) {
+      blockers = blockers + [action_kind]
+    }
+  }
+  if len(blockers) == 0 {
+    return {allowed: true, blocking_actions: [], approval_state: "autopilot"}
+  }
+  return {allowed: false, blocking_actions: blockers, approval_state: "needs_human"}
+}
+
+/** Validate a repair_worker policy block. Returns nil on success or a string error. */
+pub fn validate_repair_policy(repair_policy) {
+  if repair_policy == nil {
+    return nil
+  }
+  let policy = with_defaults(repair_policy)
+  for kind in policy.require_human_for {
+    if !is_action_kind(kind) {
+      return "repair_worker.require_human_for contains unknown action '${kind}'"
+    }
+  }
+  for kind in policy.autopilot_action_kinds {
+    if !is_action_kind(kind) {
+      return "repair_worker.autopilot_action_kinds contains unknown action '${kind}'"
+    }
+  }
+  for kind in policy.handles_kinds {
+    let canonical = ["ci_failure", "merge_conflict", "release_audit", "flaky_test"]
+    if !canonical.contains(kind) {
+      return "repair_worker.handles_kinds contains unknown bundle kind '${kind}'"
+    }
+  }
+  return nil
+}

--- a/personas/merge_captain/lib/policy.harn
+++ b/personas/merge_captain/lib/policy.harn
@@ -2,6 +2,8 @@
 //
 // Policies are simple JSON documents loaded from disk. This module
 // validates the shape, applies defaults, and exposes typed accessors.
+import { validate_repair_policy } from "approval"
+
 /** Default policy values for fields the user can omit. */
 pub fn defaults() {
   return {
@@ -17,6 +19,7 @@ pub fn defaults() {
     bump_after_merge: nil,
     autopilot_states: ["queued", "waiting_checks"],
     require_human_for: ["blocked", "local_repair"],
+    repair_worker: nil,
   }
 }
 
@@ -38,6 +41,7 @@ pub fn with_defaults(policy) {
     bump_after_merge: policy.bump_after_merge ?? base.bump_after_merge,
     autopilot_states: policy.autopilot_states ?? base.autopilot_states,
     require_human_for: policy.require_human_for ?? base.require_human_for,
+    repair_worker: policy.repair_worker ?? base.repair_worker,
   }
 }
 
@@ -60,6 +64,10 @@ pub fn validate(policy) {
     if cmd.command == nil || len(to_string(cmd.command)) == 0 {
       return "policy.local_verification[].command is required"
     }
+  }
+  let repair_err = validate_repair_policy(policy.repair_worker)
+  if repair_err != nil {
+    return "policy.${repair_err}"
   }
   return nil
 }

--- a/personas/merge_captain/lib/receipt.harn
+++ b/personas/merge_captain/lib/receipt.harn
@@ -19,6 +19,11 @@ pub fn build_receipt(args) {
   let dry_run = args.dry_run ?? true
   let approval = approval_state(policy, classification, dry_run)
   let evidence = evidence_payload(observation, classification)
+  let repair_run_summary = if args.repair_run != nil {
+    summarize_repair_run(args.repair_run)
+  } else {
+    nil
+  }
   return {
     _type: "merge_receipt",
     version: 1,
@@ -36,6 +41,7 @@ pub fn build_receipt(args) {
     commands_run: commands,
     checks_observed: observation.checks,
     final_outcome: outcome,
+    repair_run: repair_run_summary,
     policy_summary: {
       merge_method: policy.merge_method,
       merge_queue_enabled: policy.merge_queue_enabled,
@@ -43,6 +49,46 @@ pub fn build_receipt(args) {
       blocking_labels: policy.blocking_labels,
       required_checks: policy.required_checks,
     },
+  }
+}
+
+/**
+ * Compress a `merge_captain.repair_run` record into the linkage shape
+ * carried inside a merge receipt. We keep the bundle metadata, the
+ * agent_loop summary, and the validation outcome — enough for an
+ * auditor to retrace the checkpoint without dumping the whole prompt.
+ */
+pub fn summarize_repair_run(run) {
+  if run == nil {
+    return nil
+  }
+  let output = run.output
+  return {
+    _type: "merge_captain.repair_run_link",
+    version: 1,
+    parent_receipt_ref: run.parent_receipt_ref,
+    bundle_kind: run.bundle?.kind,
+    bundle_repo: run.bundle?.repo,
+    bundle_pr_number: run.bundle?.pr_number,
+    approval_state: run.approval_state,
+    blocking_actions: run.blocking_actions ?? [],
+    status: run.status,
+    validation_errors: run.validation_errors ?? [],
+    agent_loop: run.agent_loop,
+    output_summary: if output != nil {
+      {
+        diagnosis: output.diagnosis,
+        files_changed_count: len(output.files_changed ?? []),
+        tests_run_count: len(output.tests_run ?? []),
+        commits_created_count: len(output.commits_created ?? []),
+        pushed: output.push_result?.pushed ?? false,
+        residual_risk: output.residual_risk,
+      }
+    } else {
+      nil
+    },
+    started_at: run.started_at,
+    finished_at: run.finished_at,
   }
 }
 

--- a/personas/merge_captain/lib/repair_bundle.harn
+++ b/personas/merge_captain/lib/repair_bundle.harn
@@ -1,0 +1,224 @@
+// Repair-worker checkpoint bundle.
+//
+// Pure builders for the typed input the deterministic harness hands to
+// an `agent_loop` repair worker. Every checkpoint passes through this
+// module so the contract stays uniform across CI-failure repairs,
+// merge-conflict repairs, release audits, and flaky-test hardening.
+//
+// No I/O, no time, no network. The scheduler (or a release driver)
+// gathers the raw inputs and asks this module to assemble them.
+/** Canonical kinds of repair checkpoint. */
+pub fn all_kinds() {
+  return ["ci_failure", "merge_conflict", "release_audit", "flaky_test"]
+}
+
+/** True when the kind is one of the canonical kinds. */
+pub fn is_kind(kind) {
+  return all_kinds().contains(kind)
+}
+
+/** Canonical mutating actions a repair worker may take. */
+pub fn all_action_kinds() {
+  return ["semantic_repair", "force_push", "admin_merge", "release_tag", "branch_delete"]
+}
+
+/** True when action_kind is in the canonical action-kinds set. */
+pub fn is_action_kind(action_kind) {
+  return all_action_kinds().contains(action_kind)
+}
+
+/** Bundle defaults for keys the caller is allowed to omit. */
+pub fn defaults() {
+  return {
+    changed_files: [],
+    conflict_paths: [],
+    failing_checks: [],
+    failing_check_logs: [],
+    allowed_write_scope: [],
+    required_verification: [],
+    push_target: {remote: "origin", branch: "", force_with_lease: true},
+    approval_required_for: ["semantic_repair", "force_push", "admin_merge", "release_tag", "branch_delete"],
+    release_facts: nil,
+    extra_context: {},
+  }
+}
+
+/**
+ * Build a repair bundle. `args` is a dict carrying the same keys as the
+ * returned bundle plus optional `prompt`. Missing keys take values from
+ * `defaults()` so the caller only has to fill in what it knows.
+ */
+pub fn build(args) {
+  let d = defaults()
+  let kind = args.kind ?? "ci_failure"
+  let parent = {
+    sweep_id: args.parent?.sweep_id ?? "",
+    repo: args.parent?.repo ?? args.repo ?? "",
+    pr_number: args.parent?.pr_number ?? args.pr_number ?? 0,
+    prior_state: args.parent?.prior_state ?? "discovered",
+    classification_reason: args.parent?.classification_reason ?? "",
+  }
+  let push_target = {
+    remote: args.push_target?.remote ?? d.push_target.remote,
+    branch: args.push_target?.branch ?? args.head_ref ?? d.push_target.branch,
+    force_with_lease: args.push_target?.force_with_lease ?? d.push_target.force_with_lease,
+  }
+  return {
+    _type: "merge_captain.repair_bundle",
+    version: 1,
+    kind: kind,
+    parent: parent,
+    repo: args.repo ?? "",
+    pr_number: args.pr_number ?? 0,
+    base_sha: args.base_sha ?? "",
+    head_sha: args.head_sha ?? "",
+    base_ref: args.base_ref ?? "main",
+    head_ref: args.head_ref ?? "",
+    changed_files: args.changed_files ?? d.changed_files,
+    conflict_paths: args.conflict_paths ?? d.conflict_paths,
+    failing_checks: args.failing_checks ?? d.failing_checks,
+    failing_check_logs: args.failing_check_logs ?? d.failing_check_logs,
+    allowed_write_scope: args.allowed_write_scope ?? d.allowed_write_scope,
+    required_verification: args.required_verification ?? d.required_verification,
+    push_target: push_target,
+    approval_required_for: args.approval_required_for ?? d.approval_required_for,
+    release_facts: args.release_facts ?? d.release_facts,
+    extra_context: args.extra_context ?? d.extra_context,
+    prompt: args.prompt ?? default_prompt(kind),
+  }
+}
+
+/** Validate a bundle. Returns nil on success or a string describing the first problem. */
+pub fn validate_bundle(bundle) {
+  if bundle._type != "merge_captain.repair_bundle" {
+    return "bundle._type must be 'merge_captain.repair_bundle'"
+  }
+  if bundle.version != 1 {
+    return "bundle.version must be 1"
+  }
+  if !is_kind(bundle.kind) {
+    return "bundle.kind must be one of ${json_stringify(all_kinds())}"
+  }
+  if bundle.repo == nil || len(to_string(bundle.repo)) == 0 {
+    return "bundle.repo is required"
+  }
+  if bundle.kind == "ci_failure" && len(bundle.failing_checks) == 0 {
+    return "ci_failure bundles must list at least one failing_check"
+  }
+  if bundle.kind == "merge_conflict" && len(bundle.conflict_paths) == 0 {
+    return "merge_conflict bundles must list at least one conflict_path"
+  }
+  if bundle.kind == "release_audit" && bundle.release_facts == nil {
+    return "release_audit bundles require release_facts"
+  }
+  if len(bundle.allowed_write_scope) == 0 {
+    return "bundle.allowed_write_scope must list at least one path glob (an empty list disables all writes)"
+  }
+  for action_kind in bundle.approval_required_for {
+    if !is_action_kind(action_kind) {
+      return "bundle.approval_required_for contains unknown action '${action_kind}'"
+    }
+  }
+  for cmd in bundle.required_verification {
+    if cmd.command == nil || len(to_string(cmd.command)) == 0 {
+      return "bundle.required_verification[].command is required"
+    }
+  }
+  return nil
+}
+
+/** Default prompt for each kind. Kept short so it's easy to override. */
+pub fn default_prompt(kind) {
+  if kind == "ci_failure" {
+    return "Diagnose and repair the failing CI checks listed in this bundle. Modify only the files inside allowed_write_scope. After your edits, run every command in required_verification, commit the result, and push to push_target. Respond once with a single JSON document that conforms to the merge_captain.repair_output v1 schema. Do not emit any text outside the JSON."
+  }
+  if kind == "merge_conflict" {
+    return "Resolve the merge conflict on the listed paths. Preserve the intent of both branches. Modify only files in allowed_write_scope. After your edits, run every command in required_verification, commit the resolution, and push to push_target. Respond with a single repair_output JSON document. No prose outside the JSON."
+  }
+  if kind == "release_audit" {
+    return "Audit the changelog and release notes against the commits in release_facts. Identify gaps, propose user-facing release-note rewrites, and surface remaining blockers. Modify only files in allowed_write_scope. Respond with a single repair_output JSON document populated with release_outputs."
+  }
+  if kind == "flaky_test" {
+    return "Stabilize the listed flaky test. Diagnose the source of nondeterminism, modify only files in allowed_write_scope, run required_verification, commit the fix, and push to push_target. Respond with a single repair_output JSON document."
+  }
+  return "Address the issue described in this bundle. Modify only files in allowed_write_scope. Run required_verification before pushing. Respond with a single repair_output JSON document."
+}
+
+/**
+ * The JSON schema the worker is held to. Returned as a Harn dict so it
+ * can be passed straight into `llm_call(... output_schema: ...)` or
+ * `agent_loop(... output_schema: ...)`.
+ */
+pub fn output_schema() {
+  return {
+    type: "object",
+    additionalProperties: false,
+    required: ["diagnosis", "files_changed", "tests_run", "commits_created", "push_result", "residual_risk"],
+    properties: {
+      diagnosis: {type: "string"},
+      files_changed: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["path", "action"],
+          additionalProperties: false,
+          properties: {path: {type: "string"}, action: {type: "string", enum: ["modified", "created", "deleted"]}},
+        },
+      },
+      tests_run: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["name", "command", "status"],
+          additionalProperties: false,
+          properties: {
+            name: {type: "string"},
+            command: {type: "string"},
+            status: {type: "string", enum: ["ok", "failed", "skipped"]},
+            exit_code: {type: ["integer", "null"]},
+          },
+        },
+      },
+      commits_created: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["sha", "subject"],
+          additionalProperties: false,
+          properties: {sha: {type: "string"}, subject: {type: "string"}},
+        },
+      },
+      push_result: {
+        type: "object",
+        required: ["pushed", "ref"],
+        additionalProperties: false,
+        properties: {
+          pushed: {type: "boolean"},
+          ref: {type: "string"},
+          sha: {type: ["string", "null"]},
+          force_with_lease: {type: ["boolean", "null"]},
+        },
+      },
+      residual_risk: {type: "string"},
+      release_outputs: {
+        type: ["object", "null"],
+        additionalProperties: false,
+        required: ["changelog_gaps", "release_note_edits", "blockers"],
+        properties: {
+          changelog_gaps: {type: "array", items: {type: "string"}},
+          release_note_edits: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["section", "before", "after"],
+              additionalProperties: false,
+              properties: {section: {type: "string"}, before: {type: "string"}, after: {type: "string"}},
+            },
+          },
+          blockers: {type: "array", items: {type: "string"}},
+        },
+      },
+      notes: {type: ["array", "null"], items: {type: "string"}},
+    },
+  }
+}

--- a/personas/merge_captain/lib/repair_validator.harn
+++ b/personas/merge_captain/lib/repair_validator.harn
@@ -1,0 +1,304 @@
+// Deterministic validators for repair_worker output.
+//
+// Every validator is pure: it takes a (bundle, output) pair and returns
+// a structured `{ok, errors}` record. The dispatcher composes them so
+// that a worker run only counts as a successful repair when *every*
+// validator passes. The acceptance criteria for harn#1010 calls these
+// out explicitly:
+//
+//   - missing tests
+//   - dirty worktrees
+//   - unexpected write scope
+//   - malformed output
+//   - unpushed commits
+//
+// A separate `harness_validate(...)` runs the post-condition check
+// against the actual local repo state via `process_exec_with_timeout`
+// (e.g. `git status --porcelain`). It is the only validator that does
+// I/O and is opt-in via `enabled = true`.
+import { process_exec_with_timeout } from "std/runtime"
+
+/** Required top-level keys on a repair_output document. */
+pub fn required_keys() {
+  return ["diagnosis", "files_changed", "tests_run", "commits_created", "push_result", "residual_risk"]
+}
+
+fn _err(messages) {
+  return {ok: len(messages) == 0, errors: messages}
+}
+
+/**
+ * Schema-shape validator. Doesn't replace the LLM-side `output_schema`
+ * check — that one runs while the model still has room to retry. This
+ * is the harness-side belt-and-braces pass.
+ */
+pub fn validate_shape(output) {
+  if output == nil {
+    return _err(["output is nil"])
+  }
+  if type_of(output) != "dict" {
+    return _err(["output must be a dict, got ${type_of(output)}"])
+  }
+  var missing = []
+  for key in required_keys() {
+    if output[key] == nil {
+      missing = missing + [key]
+    }
+  }
+  if len(missing) > 0 {
+    return _err(["malformed output: missing required keys ${json_stringify(missing)}"])
+  }
+  if type_of(output.files_changed) != "list" {
+    return _err(["malformed output: files_changed must be a list"])
+  }
+  if type_of(output.tests_run) != "list" {
+    return _err(["malformed output: tests_run must be a list"])
+  }
+  if type_of(output.commits_created) != "list" {
+    return _err(["malformed output: commits_created must be a list"])
+  }
+  if type_of(output.push_result) != "dict" {
+    return _err(["malformed output: push_result must be a dict"])
+  }
+  return _err([])
+}
+
+/**
+ * `tests_run` must be non-empty and every test must report a status.
+ * Any test with status != "ok" counts as a missing/failed test for the
+ * purposes of the harness — we will not push semantic edits if the
+ * worker did not prove they pass locally.
+ */
+pub fn validate_tests(bundle, output) {
+  let tests = output.tests_run ?? []
+  if len(tests) == 0 {
+    return _err(
+      [
+        "missing tests: tests_run is empty (expected ${to_string(len(bundle.required_verification))} verifications)",
+      ],
+    )
+  }
+  if len(bundle.required_verification) > 0 {
+    var missing = []
+    for cmd in bundle.required_verification {
+      let saw = tests.filter({ t -> t.command == cmd.command || t.name == cmd.name })
+      if len(saw) == 0 {
+        missing = missing + [cmd.name ?? cmd.command]
+      }
+    }
+    if len(missing) > 0 {
+      return _err(["missing tests: required_verification entries not run: ${json_stringify(missing)}"])
+    }
+  }
+  var failed = []
+  for t in tests {
+    if t.status != "ok" {
+      failed = failed + [t.name ?? t.command ?? "unnamed"]
+    }
+  }
+  if len(failed) > 0 {
+    return _err(["failing tests: ${json_stringify(failed)}"])
+  }
+  return _err([])
+}
+
+/**
+ * True when `path` matches `glob`. We support a tiny subset that is
+ * adequate for write-scope policies: a plain path prefix; a single-segment
+ * wildcard at the end (one slash followed by a single asterisk, matching
+ * one path component); or a recursive wildcard at the end (one slash
+ * followed by two asterisks, matching any number of components). No
+ * character classes, no negation. Path comparison is exact-prefix with
+ * forward-slash boundaries.
+ */
+pub fn path_matches_glob(path, glob) {
+  if glob == nil || len(to_string(glob)) == 0 {
+    return false
+  }
+  if glob == path {
+    return true
+  }
+  if glob == "**" {
+    return true
+  }
+  if glob.ends_with("/**") {
+    let prefix = glob[0:len(glob) - 3]
+    return path == prefix || path.starts_with(prefix + "/")
+  }
+  if glob.ends_with("/*") {
+    let prefix = glob[0:len(glob) - 2]
+    if !path.starts_with(prefix + "/") {
+      return false
+    }
+    let tail = path[len(prefix) + 1:len(path)]
+    return !tail.contains("/")
+  }
+  if glob.contains("**") {
+    return false
+  }
+  if glob.contains("*") {
+    return false
+  }
+  return path == glob || path.starts_with(glob + "/")
+}
+
+/** True when path matches any glob in the list. */
+pub fn path_matches_any(path, globs) {
+  for g in globs {
+    if path_matches_glob(path, g) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Every entry in `output.files_changed` must fall under at least one
+ * glob in `bundle.allowed_write_scope`. The harness rejects writes
+ * outside that scope even when they are syntactically valid.
+ */
+pub fn validate_write_scope(bundle, output) {
+  let scope = bundle.allowed_write_scope ?? []
+  if len(scope) == 0 {
+    if len(output.files_changed ?? []) > 0 {
+      return _err(
+        [
+          "unexpected write scope: bundle has no allowed_write_scope but worker reports ${to_string(len(output.files_changed))} file change(s)",
+        ],
+      )
+    }
+    return _err([])
+  }
+  var violations = []
+  for entry in output.files_changed ?? [] {
+    let path = entry.path ?? ""
+    if !path_matches_any(path, scope) {
+      violations = violations + [path]
+    }
+  }
+  if len(violations) > 0 {
+    return _err(
+      [
+        "unexpected write scope: ${json_stringify(violations)} not covered by allowed_write_scope ${json_stringify(scope)}",
+      ],
+    )
+  }
+  return _err([])
+}
+
+/**
+ * If commits were created, the push must have succeeded. This is the
+ * "unpushed commits" guard: a worker that committed but did not push
+ * leaves the repo in a state Merge Captain cannot reason about.
+ */
+pub fn validate_pushed(bundle, output) {
+  let commits = output.commits_created ?? []
+  let push = output.push_result ?? {}
+  if len(commits) == 0 {
+    if push.pushed ?? false {
+      return _err(["push without commits: push_result.pushed=true but commits_created is empty"])
+    }
+    return _err([])
+  }
+  if !(push.pushed ?? false) {
+    return _err(
+      [
+        "unpushed commits: ${to_string(len(commits))} commit(s) created but push_result.pushed is not true",
+      ],
+    )
+  }
+  if push.ref == nil || len(to_string(push.ref)) == 0 {
+    return _err(["unpushed commits: push_result.ref is missing"])
+  }
+  let target = bundle.push_target?.branch ?? ""
+  if len(target) > 0 && push.ref != target && !push.ref.ends_with("/" + target) {
+    return _err(
+      [
+        "push target mismatch: pushed ref '${push.ref}' does not match bundle.push_target.branch '${target}'",
+      ],
+    )
+  }
+  return _err([])
+}
+
+/**
+ * Run every pure validator against (bundle, output) and return a
+ * combined record. Validators short-circuit on shape failure since the
+ * downstream checks all assume a well-formed dict.
+ */
+pub fn validate_all(bundle, output) {
+  let shape = validate_shape(output)
+  if !shape.ok {
+    return shape
+  }
+  var errors = []
+  let v_tests = validate_tests(bundle, output)
+  errors = errors + v_tests.errors
+  let v_scope = validate_write_scope(bundle, output)
+  errors = errors + v_scope.errors
+  let v_push = validate_pushed(bundle, output)
+  errors = errors + v_push.errors
+  return _err(errors)
+}
+
+/**
+ * True when `cwd` is safe to splice into a shell command line. We are
+ * conservative: forbid the metacharacters that would let an attacker
+ * pivot from a path string into arbitrary shell. Callers always set
+ * cwd from trusted state, but this is a cheap defence-in-depth.
+ */
+pub fn _cwd_is_shell_safe(cwd) {
+  let banned = ["`", "$", ";", "|", "&", "\n", "\\r", "\"", "'", "<", ">", "(", ")"]
+  for ch in banned {
+    if cwd.contains(ch) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Optional post-run harness check. After `agent_loop` returns we ask
+ * git for the working-tree state. If `git status --porcelain` produces
+ * any output, the worker left the tree dirty — fail closed. Skipped
+ * when `enabled` is false (tests, dry-run sweeps).
+ *
+ * `cwd` defaults to `.` and must pass `_cwd_is_shell_safe` — we splice
+ * it into the command line for `git -C`, so a path with shell
+ * metacharacters would be a command-injection risk.
+ */
+pub fn harness_validate(bundle, output, options) {
+  if !(options.enabled ?? false) {
+    return _err([])
+  }
+  let cwd = options.cwd ?? "."
+  if !_cwd_is_shell_safe(cwd) {
+    return _err(["harness check rejected: cwd contains shell metacharacters: ${cwd}"])
+  }
+  let cmd = "git -C ${cwd} status --porcelain"
+  let result = try {
+    process_exec_with_timeout(cmd, options.timeout_ms ?? 30000)
+  }
+  if !is_ok(result) {
+    return _err(["harness check failed: ${to_string(unwrap_err(result))}"])
+  }
+  let value = unwrap(result)
+  let stdout = to_string(value.stdout ?? "")
+  let exit_code = value.exit_code ?? 0
+  if exit_code != 0 {
+    return _err(
+      [
+        "dirty worktree probe failed: exit ${to_string(exit_code)}; stderr=${to_string(value.stderr ?? "")}",
+      ],
+    )
+  }
+  let trimmed = stdout.trim()
+  if len(trimmed) > 0 {
+    return _err(
+      [
+        "dirty worktree: 'git status --porcelain' reports uncommitted changes (${to_string(len(trimmed.split("\n")))} entry/entries)",
+      ],
+    )
+  }
+  return _err([])
+}

--- a/personas/merge_captain/lib/repair_worker.harn
+++ b/personas/merge_captain/lib/repair_worker.harn
@@ -1,0 +1,371 @@
+// Repair-worker checkpoint dispatcher.
+//
+// This module is the only place in Merge Captain that calls
+// `agent_loop`. The deterministic harness builds a typed
+// `repair_bundle`, the approval gate decides whether the run can
+// proceed without a human, and the post-run validators reject any
+// output that does not satisfy the contract (missing tests, dirty
+// worktree, unexpected write scope, malformed output, unpushed
+// commits). The result is a `repair_run` record that the merge
+// receipt links back to.
+//
+// The dispatcher accepts an optional `executor` closure so tests can
+// stub out the LLM call without touching agent_loop. Callers in
+// production omit it and the default executor uses agent_loop with
+// the bundle prompt + repair_bundle.output_schema().
+import { gate, validate_repair_policy } from "approval"
+import { build, output_schema, validate_bundle } from "repair_bundle"
+import { harness_validate, validate_all } from "repair_validator"
+
+/** Default agent_loop options for a repair worker turn. */
+pub fn default_agent_options() {
+  return {
+    profile: "tool_using",
+    max_iterations: 24,
+    max_nudges: 3,
+    output_validation: "error",
+    schema_retries: 2,
+    output_format: {kind: "json_schema", strict: true},
+  }
+}
+
+/**
+ * Default executor: invoke `agent_loop` with the bundle prompt + a
+ * strict json_schema output format, then parse the JSON. Returns a
+ * record with `{ok, output, raw, agent_loop}` where `output` is the
+ * parsed JSON dict.
+ */
+pub fn default_executor(bundle, options) {
+  let merged = default_agent_options() + options ?? {}
+  let schema = output_schema()
+  let agent_options = merged
+    + {output_schema: schema, output_format: {kind: "json_schema", schema: schema, strict: true}}
+  let result = agent_loop(bundle.prompt, options?.system, agent_options)
+  let raw = result?.text ?? ""
+  let parsed = try {
+    json_parse(raw)
+  }
+  let agent_meta = {
+    status: result?.status,
+    iterations: result?.llm?.iterations,
+    input_tokens: result?.llm?.input_tokens,
+    output_tokens: result?.llm?.output_tokens,
+    transcript_session_id: options?.session_id,
+  }
+  if !is_ok(parsed) {
+    return {
+      ok: false,
+      output: nil,
+      raw: raw,
+      agent_loop: agent_meta,
+      error: "json parse failed: ${to_string(unwrap_err(parsed))}",
+    }
+  }
+  return {ok: true, output: unwrap(parsed), raw: raw, agent_loop: agent_meta}
+}
+
+fn _started() {
+  return now_ms()
+}
+
+fn _empty_output_run(args) {
+  return {
+    _type: "merge_captain.repair_run",
+    version: 1,
+    parent_receipt_ref: args.parent_receipt_ref,
+    bundle: args.bundle,
+    status: args.status,
+    approval_state: args.approval_state,
+    blocking_actions: args.blocking_actions ?? [],
+    agent_loop: args.agent_loop ?? nil,
+    output: nil,
+    validation_errors: args.errors ?? [],
+    raw_text: args.raw_text ?? "",
+    started_at: args.started_at,
+    finished_at: args.finished_at ?? now_ms(),
+  }
+}
+
+/**
+ * Single-checkpoint dispatch. `args` carries:
+ *
+ *   bundle               — the repair bundle (pre-built)
+ *   policy.repair_worker — repo policy block (already with_defaults'd)
+ *   parent_receipt_ref   — link back to the merge receipt
+ *   dry_run              — bool; when true, no LLM call, no validators ran
+ *   executor             — optional closure(bundle, options) -> {ok, output, raw, agent_loop}
+ *   agent_options        — passthrough to executor (model, profile, etc.)
+ *   harness              — optional {enabled, cwd, timeout_ms} for git status check
+ */
+pub fn invoke(args) {
+  let bundle = args.bundle
+  let parent_receipt_ref = args.parent_receipt_ref
+    ?? {sweep_id: "", repo: bundle.repo, pr_number: bundle.pr_number, prior_state: "discovered"}
+  let started_at = _started()
+  let bundle_err = validate_bundle(bundle)
+  if bundle_err != nil {
+    return _empty_output_run(
+      {
+        parent_receipt_ref: parent_receipt_ref,
+        bundle: bundle,
+        status: "bundle_invalid",
+        approval_state: "no_run",
+        errors: [bundle_err],
+        started_at: started_at,
+      },
+    )
+  }
+  let dry_run = args.dry_run ?? true
+  let repair_policy = args.policy?.repair_worker
+  let policy_err = validate_repair_policy(repair_policy)
+  if policy_err != nil {
+    return _empty_output_run(
+      {
+        parent_receipt_ref: parent_receipt_ref,
+        bundle: bundle,
+        status: "policy_invalid",
+        approval_state: "no_run",
+        errors: [policy_err],
+        started_at: started_at,
+      },
+    )
+  }
+  let decision = gate(repair_policy, bundle, dry_run)
+  if !decision.allowed && !dry_run {
+    return _empty_output_run(
+      {
+        parent_receipt_ref: parent_receipt_ref,
+        bundle: bundle,
+        status: "blocked_pending_approval",
+        approval_state: decision.approval_state,
+        blocking_actions: decision.blocking_actions,
+        errors: ["repair worker requires human approval for: ${json_stringify(decision.blocking_actions)}"],
+        started_at: started_at,
+      },
+    )
+  }
+  if dry_run {
+    return _empty_output_run(
+      {
+        parent_receipt_ref: parent_receipt_ref,
+        bundle: bundle,
+        status: "skipped_dry_run",
+        approval_state: "dry_run",
+        started_at: started_at,
+      },
+    )
+  }
+  let executor = args.executor ?? default_executor
+  let exec_result = executor(bundle, args.agent_options ?? {})
+  if !exec_result.ok {
+    return _empty_output_run(
+      {
+        parent_receipt_ref: parent_receipt_ref,
+        bundle: bundle,
+        status: "schema_invalid",
+        approval_state: decision.approval_state,
+        agent_loop: exec_result?.agent_loop,
+        errors: [exec_result?.error ?? "executor returned ok=false"],
+        raw_text: exec_result?.raw ?? "",
+        started_at: started_at,
+      },
+    )
+  }
+  let output = exec_result.output
+  let v = validate_all(bundle, output)
+  if !v.ok {
+    return {
+      _type: "merge_captain.repair_run",
+      version: 1,
+      parent_receipt_ref: parent_receipt_ref,
+      bundle: bundle,
+      status: "validators_failed",
+      approval_state: decision.approval_state,
+      blocking_actions: decision.blocking_actions,
+      agent_loop: exec_result.agent_loop,
+      output: output,
+      validation_errors: v.errors,
+      raw_text: exec_result.raw,
+      started_at: started_at,
+      finished_at: now_ms(),
+    }
+  }
+  let harness_options = args.harness ?? {enabled: false}
+  let h = harness_validate(bundle, output, harness_options)
+  if !h.ok {
+    return {
+      _type: "merge_captain.repair_run",
+      version: 1,
+      parent_receipt_ref: parent_receipt_ref,
+      bundle: bundle,
+      status: "harness_failed",
+      approval_state: decision.approval_state,
+      blocking_actions: decision.blocking_actions,
+      agent_loop: exec_result.agent_loop,
+      output: output,
+      validation_errors: h.errors,
+      raw_text: exec_result.raw,
+      started_at: started_at,
+      finished_at: now_ms(),
+    }
+  }
+  return {
+    _type: "merge_captain.repair_run",
+    version: 1,
+    parent_receipt_ref: parent_receipt_ref,
+    bundle: bundle,
+    status: "completed",
+    approval_state: decision.approval_state,
+    blocking_actions: [],
+    agent_loop: exec_result.agent_loop,
+    output: output,
+    validation_errors: [],
+    raw_text: exec_result.raw,
+    started_at: started_at,
+    finished_at: now_ms(),
+  }
+}
+
+/**
+ * Convenience: build a CI-failure bundle from the merge-captain
+ * observation + policy and dispatch the worker. Used by the
+ * scheduler when it lands on `local_repair`. The bundle's
+ * `approval_required_for` defaults to `["semantic_repair"]` because
+ * the worker's deliverable here is a code change + commit + push
+ * (not a force push, admin merge, release tag, or branch delete).
+ */
+pub fn invoke_for_ci_failure(args) {
+  let observation = args.observation
+  let policy = args.policy
+  let parent = args.parent_receipt_ref
+    ?? {
+    sweep_id: args.sweep_id ?? "",
+    repo: observation.repo,
+    pr_number: observation.number,
+    prior_state: args.prior_state ?? "discovered",
+    classification_reason: args.classification_reason ?? "",
+  }
+  let failing = (observation.failed_required_checks ?? [])
+    .map({ name -> {name: name, conclusion: "failure"} })
+  let bundle = build(
+    {
+      kind: "ci_failure",
+      parent: parent,
+      repo: observation.repo,
+      pr_number: observation.number,
+      base_sha: observation.base_sha ?? "",
+      head_sha: observation.head_sha,
+      base_ref: observation.base_ref,
+      head_ref: observation.head_ref,
+      changed_files: args.changed_files ?? [],
+      failing_checks: failing,
+      failing_check_logs: args.failing_check_logs ?? [],
+      allowed_write_scope: policy?.repair_worker?.allowed_write_scope ?? args.allowed_write_scope ?? [],
+      required_verification: policy.local_verification ?? [],
+      push_target: {remote: "origin", branch: observation.head_ref, force_with_lease: true},
+      approval_required_for: ["semantic_repair"],
+    },
+  )
+  return invoke(
+    {
+      bundle: bundle,
+      policy: policy,
+      parent_receipt_ref: parent,
+      dry_run: args.dry_run ?? true,
+      executor: args.executor,
+      agent_options: args.agent_options,
+      harness: args.harness,
+    },
+  )
+}
+
+/**
+ * Convenience: build a merge-conflict bundle from the merge-captain
+ * observation + policy. The worker's deliverable is a semantic
+ * resolution + commit + push, so `approval_required_for` is
+ * `["semantic_repair", "force_push"]` (force-with-lease is the typical
+ * push for a rewritten conflict).
+ */
+pub fn invoke_for_merge_conflict(args) {
+  let observation = args.observation
+  let policy = args.policy
+  let parent = args.parent_receipt_ref
+    ?? {
+    sweep_id: args.sweep_id ?? "",
+    repo: observation.repo,
+    pr_number: observation.number,
+    prior_state: args.prior_state ?? "discovered",
+    classification_reason: args.classification_reason ?? "",
+  }
+  let bundle = build(
+    {
+      kind: "merge_conflict",
+      parent: parent,
+      repo: observation.repo,
+      pr_number: observation.number,
+      base_sha: observation.base_sha ?? "",
+      head_sha: observation.head_sha,
+      base_ref: observation.base_ref,
+      head_ref: observation.head_ref,
+      changed_files: args.changed_files ?? [],
+      conflict_paths: args.conflict_paths ?? [],
+      allowed_write_scope: policy?.repair_worker?.allowed_write_scope ?? args.allowed_write_scope ?? [],
+      required_verification: policy.local_verification ?? [],
+      push_target: {remote: "origin", branch: observation.head_ref, force_with_lease: true},
+      approval_required_for: ["semantic_repair", "force_push"],
+    },
+  )
+  return invoke(
+    {
+      bundle: bundle,
+      policy: policy,
+      parent_receipt_ref: parent,
+      dry_run: args.dry_run ?? true,
+      executor: args.executor,
+      agent_options: args.agent_options,
+      harness: args.harness,
+    },
+  )
+}
+
+/**
+ * Convenience: build a release-audit bundle (consumer for harn#1146).
+ * The release-harness driver prepares git/changelog facts and asks
+ * for a typed audit. The bundle never pushes (`pushed: false` is
+ * acceptable); approvals default to release_tag + semantic_repair
+ * because the audit can both edit release notes and request a tag.
+ */
+pub fn invoke_for_release_audit(args) {
+  let release_facts = args.release_facts
+  let policy = args.policy
+  let bundle = build(
+    {
+      kind: "release_audit",
+      parent: args.parent_receipt_ref
+        ?? {sweep_id: "", repo: args.repo, pr_number: 0, prior_state: "discovered"},
+      repo: args.repo,
+      pr_number: args.pr_number ?? 0,
+      base_sha: args.base_sha ?? "",
+      head_sha: args.head_sha ?? "",
+      base_ref: args.base_ref ?? "main",
+      head_ref: args.head_ref ?? "",
+      changed_files: args.changed_files ?? [],
+      release_facts: release_facts,
+      allowed_write_scope: policy?.repair_worker?.allowed_write_scope ?? args.allowed_write_scope ?? [],
+      required_verification: policy?.local_verification ?? [],
+      push_target: args.push_target ?? {remote: "origin", branch: args.head_ref ?? "", force_with_lease: false},
+      approval_required_for: args.approval_required_for ?? ["semantic_repair", "release_tag"],
+    },
+  )
+  return invoke(
+    {
+      bundle: bundle,
+      policy: policy,
+      parent_receipt_ref: bundle.parent,
+      dry_run: args.dry_run ?? true,
+      executor: args.executor,
+      agent_options: args.agent_options,
+      harness: args.harness,
+    },
+  )
+}

--- a/personas/merge_captain/lib/scheduler.harn
+++ b/personas/merge_captain/lib/scheduler.harn
@@ -7,6 +7,7 @@
 // because discovery runs every sweep; PRs that disappear from the open
 // list because they were merged or closed receive a final receipt and
 // have their checkpoint dropped.
+import { handles_kind } from "approval"
 import {
   forget_checkpoint,
   list_all_checkpoints,
@@ -27,10 +28,63 @@ import { run_local_verify } from "local_verify"
 import { from_github } from "observation"
 import { load_policy } from "policy"
 import { build_receipt, summarize_sweep } from "receipt"
+import { invoke_for_ci_failure, invoke_for_merge_conflict } from "repair_worker"
 import { is_terminal } from "states"
 
 fn _gen_sweep_id() {
   return "sweep-${to_string(now_ms())}"
+}
+
+/**
+ * Decide whether the deterministic harness should hand this
+ * classification off to the repair worker checkpoint instead of
+ * running the inline action. Returns the bundle kind to dispatch
+ * (`"ci_failure"` / `"merge_conflict"`) or nil to keep the existing
+ * apply_action path.
+ *
+ * Repair worker dispatch is opt-in per repo via
+ * `policy.repair_worker = { enabled: true, handles_kinds: [...] }`.
+ * The classifier stays pure: it never mentions the worker.
+ */
+pub fn repair_worker_kind_for(policy, classification) {
+  if classification.action == "run_local_verification"
+    && handles_kind(policy.repair_worker, "ci_failure") {
+    return "ci_failure"
+  }
+  if classification.state == "dirty" && classification.action == "comment"
+    && handles_kind(policy.repair_worker, "merge_conflict") {
+    return "merge_conflict"
+  }
+  return nil
+}
+
+fn _outcome_from_repair_run(run, dry_run) {
+  if dry_run {
+    return "repair_worker_dry_run"
+  }
+  return "repair_worker_${run.status}"
+}
+
+fn _command_for_repair_run(run) {
+  return {
+    action: "run_repair_worker",
+    bundle_kind: run.bundle?.kind,
+    status: run.status,
+    approval_state: run.approval_state,
+    blocking_actions: run.blocking_actions ?? [],
+    validation_errors: run.validation_errors ?? [],
+    output_summary: if run.output != nil {
+      {
+        diagnosis: run.output.diagnosis,
+        files_changed_count: len(run.output.files_changed ?? []),
+        tests_run_count: len(run.output.tests_run ?? []),
+        commits_created_count: len(run.output.commits_created ?? []),
+        pushed: run.output.push_result?.pushed ?? false,
+      }
+    } else {
+      nil
+    },
+  }
 }
 
 /** Apply the action a classification calls for, returning an outcome string. */
@@ -119,6 +173,35 @@ pub fn apply_action(adapter, policy, observation, classification, dry_run) {
   return {outcome: "noop", commands: []}
 }
 
+fn _dispatch_repair_worker(kind, args) {
+  let observation = args.observation
+  let policy = args.policy
+  let parent_receipt_ref = {
+    sweep_id: args.sweep_id,
+    repo: observation.repo,
+    pr_number: observation.number,
+    prior_state: args.prior,
+    classification_reason: args.classification.reason,
+  }
+  let common = {
+    observation: observation,
+    policy: policy,
+    sweep_id: args.sweep_id,
+    parent_receipt_ref: parent_receipt_ref,
+    prior_state: args.prior,
+    classification_reason: args.classification.reason,
+    dry_run: args.dry_run,
+    executor: args.repair_executor,
+    agent_options: args.repair_agent_options,
+    harness: args.repair_harness,
+    allowed_write_scope: args.allowed_write_scope,
+  }
+  if kind == "merge_conflict" {
+    return invoke_for_merge_conflict(common + {conflict_paths: args.conflict_paths ?? []})
+  }
+  return invoke_for_ci_failure(common + {failing_check_logs: args.failing_check_logs ?? []})
+}
+
 /** Process a single PR: classify, persist, act, build receipt. */
 pub fn process_pr(args) {
   let adapter = args.adapter
@@ -155,6 +238,46 @@ pub fn process_pr(args) {
         commands_run: action_result.commands,
         outcome: action_result.outcome,
         dry_run: dry_run,
+      },
+    )
+  }
+  let repair_kind = repair_worker_kind_for(policy, classification)
+  if repair_kind != nil {
+    let extras = if args.repair_extras_for != nil {
+      args.repair_extras_for(observation) ?? {}
+    } else {
+      {}
+    }
+    let run = _dispatch_repair_worker(
+      repair_kind,
+      {
+        observation: observation,
+        policy: policy,
+        sweep_id: sweep_id,
+        prior: prior,
+        classification: classification,
+        dry_run: dry_run,
+        repair_executor: args.repair_executor,
+        repair_agent_options: args.repair_agent_options,
+        repair_harness: args.repair_harness,
+        conflict_paths: extras.conflict_paths ?? [],
+        failing_check_logs: extras.failing_check_logs ?? [],
+        allowed_write_scope: extras.allowed_write_scope ?? args.allowed_write_scope,
+      },
+    )
+    save_checkpoint(checkpoint_handle, sweep_id, observation, classification)
+    return build_receipt(
+      {
+        sweep_id: sweep_id,
+        observed_at: now_ms(),
+        policy: policy,
+        observation: observation,
+        classification: classification,
+        prior_state: prior,
+        commands_run: [_command_for_repair_run(run)],
+        outcome: _outcome_from_repair_run(run, dry_run),
+        dry_run: dry_run,
+        repair_run: run,
       },
     )
   }
@@ -284,6 +407,10 @@ pub fn sweep(args) {
           checkpoint_handle: checkpoint_handle,
           sweep_id: sweep_id,
           dry_run: dry_run,
+          repair_executor: args.repair_executor,
+          repair_agent_options: args.repair_agent_options,
+          repair_harness: args.repair_harness,
+          repair_extras_for: args.repair_extras_for,
         },
       )
       if receipt != nil {

--- a/personas/merge_captain/policies/harn.json
+++ b/personas/merge_captain/policies/harn.json
@@ -25,5 +25,20 @@
   ],
   "bump_after_merge": null,
   "autopilot_states": ["queued", "waiting_checks", "behind"],
-  "require_human_for": ["blocked", "local_repair"]
+  "require_human_for": ["blocked", "local_repair"],
+  "repair_worker": {
+    "enabled": false,
+    "handles_kinds": ["ci_failure"],
+    "require_human_for": [
+      "semantic_repair",
+      "force_push",
+      "admin_merge",
+      "release_tag",
+      "branch_delete"
+    ],
+    "autopilot_action_kinds": [],
+    "model": "claude-sonnet-4-6",
+    "max_iterations": 24,
+    "profile": "tool_using"
+  }
 }

--- a/personas/merge_captain/tests/approval_test.harn
+++ b/personas/merge_captain/tests/approval_test.harn
@@ -1,0 +1,130 @@
+// Run: harn test personas/merge_captain/tests/approval_test.harn
+import {
+  defaults,
+  gate,
+  handles_kind,
+  requires_human_for,
+  validate_repair_policy,
+  with_defaults,
+} from "../lib/approval"
+
+fn _bundle(approval_required) {
+  return {
+    _type: "merge_captain.repair_bundle",
+    version: 1,
+    kind: "ci_failure",
+    approval_required_for: approval_required,
+  }
+}
+
+pipeline test_defaults_disabled(task) {
+  let d = defaults()
+  assert_eq(d.enabled, false)
+  // require_human_for is the full action-kinds list by default.
+  assert_eq(len(d.require_human_for), 5)
+  assert_eq(len(d.autopilot_action_kinds), 0)
+  assert_eq(d.pre_approved, false)
+}
+
+pipeline test_handles_kind_respects_enabled(task) {
+  assert(!handles_kind(nil, "ci_failure"))
+  assert(!handles_kind({enabled: false, handles_kinds: ["ci_failure"]}, "ci_failure"))
+  assert(handles_kind({enabled: true, handles_kinds: ["ci_failure"]}, "ci_failure"))
+  assert(!handles_kind({enabled: true, handles_kinds: ["merge_conflict"]}, "ci_failure"))
+}
+
+pipeline test_requires_human_pre_approved_short_circuits(task) {
+  let policy = {enabled: true, pre_approved: true}
+  assert(!requires_human_for(policy, "semantic_repair"))
+  assert(!requires_human_for(policy, "force_push"))
+}
+
+pipeline test_requires_human_autopilot_overrides_human_list(task) {
+  let policy = {
+    enabled: true,
+    require_human_for: ["semantic_repair", "force_push"],
+    autopilot_action_kinds: ["semantic_repair"],
+  }
+  // semantic_repair is overridden into autopilot.
+  assert(!requires_human_for(policy, "semantic_repair"))
+  // force_push remains gated.
+  assert(requires_human_for(policy, "force_push"))
+}
+
+pipeline test_requires_human_unknown_action_fails_closed(task) {
+  let policy = {enabled: true}
+  assert(requires_human_for(policy, "drop_table"))
+}
+
+pipeline test_gate_dry_run_short_circuits(task) {
+  let policy = {enabled: false}
+  let bundle = _bundle(["semantic_repair"])
+  let decision = gate(policy, bundle, true)
+  assert(decision.allowed)
+  assert_eq(decision.approval_state, "dry_run")
+}
+
+pipeline test_gate_disabled_blocks_with_human(task) {
+  let bundle = _bundle(["semantic_repair", "force_push"])
+  let decision = gate(nil, bundle, false)
+  assert(!decision.allowed)
+  assert_eq(decision.approval_state, "needs_human")
+  assert_eq(len(decision.blocking_actions), 2)
+}
+
+pipeline test_gate_pre_approved_allows(task) {
+  let policy = {enabled: true, pre_approved: true}
+  let bundle = _bundle(["semantic_repair", "force_push"])
+  let decision = gate(policy, bundle, false)
+  assert(decision.allowed)
+  assert_eq(decision.approval_state, "pre_approved")
+  assert_eq(len(decision.blocking_actions), 0)
+}
+
+pipeline test_gate_autopilot_partial_blocks(task) {
+  let policy = {
+    enabled: true,
+    require_human_for: ["semantic_repair", "force_push"],
+    autopilot_action_kinds: ["semantic_repair"],
+  }
+  let bundle = _bundle(["semantic_repair", "force_push"])
+  let decision = gate(policy, bundle, false)
+  // semantic_repair is autopilot but force_push still blocks.
+  assert(!decision.allowed)
+  assert_eq(decision.approval_state, "needs_human")
+  assert(decision.blocking_actions.contains("force_push"))
+  assert(!decision.blocking_actions.contains("semantic_repair"))
+}
+
+pipeline test_gate_autopilot_full_passes(task) {
+  let policy = {enabled: true, require_human_for: ["force_push"], autopilot_action_kinds: ["semantic_repair"]}
+  let bundle = _bundle(["semantic_repair"])
+  let decision = gate(policy, bundle, false)
+  assert(decision.allowed)
+  assert_eq(decision.approval_state, "autopilot")
+}
+
+pipeline test_validate_rejects_unknown_action_kind(task) {
+  let err = validate_repair_policy({enabled: true, require_human_for: ["force_push", "drop_db"]})
+  assert(err != nil)
+  assert(err.contains("require_human_for"))
+}
+
+pipeline test_validate_rejects_unknown_handles_kind(task) {
+  let err = validate_repair_policy({enabled: true, handles_kinds: ["wat"]})
+  assert(err != nil)
+  assert(err.contains("handles_kinds"))
+}
+
+pipeline test_validate_accepts_nil(task) {
+  assert_eq(validate_repair_policy(nil), nil)
+}
+
+pipeline test_with_defaults_preserves_fields(task) {
+  let merged = with_defaults({enabled: true, pre_approved: true, model: "gpt-4o"})
+  assert_eq(merged.enabled, true)
+  assert_eq(merged.pre_approved, true)
+  assert_eq(merged.model, "gpt-4o")
+  // handles_kinds defaults to ci_failure when omitted.
+  assert(merged.handles_kinds.contains("ci_failure"))
+}

--- a/personas/merge_captain/tests/repair_bundle_test.harn
+++ b/personas/merge_captain/tests/repair_bundle_test.harn
@@ -1,0 +1,155 @@
+// Run: harn test personas/merge_captain/tests/repair_bundle_test.harn
+import {
+  all_action_kinds,
+  all_kinds,
+  build,
+  defaults,
+  is_action_kind,
+  is_kind,
+  output_schema,
+  validate_bundle,
+} from "../lib/repair_bundle"
+
+fn _ci_failure_args() {
+  return {
+    kind: "ci_failure",
+    parent: {sweep_id: "s1", repo: "x/y", pr_number: 7, prior_state: "waiting_checks"},
+    repo: "x/y",
+    pr_number: 7,
+    base_sha: "base",
+    head_sha: "head",
+    base_ref: "main",
+    head_ref: "feat",
+    failing_checks: [{name: "ci", conclusion: "failure"}],
+    allowed_write_scope: ["src/**"],
+    required_verification: [{name: "tests", command: "make test"}],
+  }
+}
+
+pipeline test_canonical_kind_set(task) {
+  let kinds = all_kinds()
+  assert_eq(len(kinds), 4)
+  assert(kinds.contains("ci_failure"))
+  assert(kinds.contains("merge_conflict"))
+  assert(kinds.contains("release_audit"))
+  assert(kinds.contains("flaky_test"))
+  assert(is_kind("ci_failure"))
+  assert(!is_kind("not_a_real_kind"))
+}
+
+pipeline test_canonical_action_kinds(task) {
+  let actions = all_action_kinds()
+  assert_eq(len(actions), 5)
+  assert(actions.contains("semantic_repair"))
+  assert(actions.contains("force_push"))
+  assert(actions.contains("admin_merge"))
+  assert(actions.contains("release_tag"))
+  assert(actions.contains("branch_delete"))
+  assert(is_action_kind("force_push"))
+  assert(!is_action_kind("hard_reset"))
+}
+
+pipeline test_defaults_lock_in_safe_values(task) {
+  let d = defaults()
+  // Empty lists are intentional: we make the caller declare intent.
+  assert_eq(len(d.changed_files), 0)
+  assert_eq(len(d.allowed_write_scope), 0)
+  // Default approvals require a human for every mutating action.
+  assert_eq(len(d.approval_required_for), 5)
+  // Push target defaults to force-with-lease — repair workers rewrite history.
+  assert(d.push_target.force_with_lease)
+}
+
+pipeline test_build_assembles_full_shape(task) {
+  let bundle = build(_ci_failure_args())
+  assert_eq(bundle._type, "merge_captain.repair_bundle")
+  assert_eq(bundle.version, 1)
+  assert_eq(bundle.kind, "ci_failure")
+  assert_eq(bundle.repo, "x/y")
+  assert_eq(bundle.pr_number, 7)
+  assert_eq(bundle.parent.sweep_id, "s1")
+  assert_eq(bundle.parent.prior_state, "waiting_checks")
+  assert_eq(bundle.head_sha, "head")
+  assert_eq(bundle.push_target.branch, "feat")
+  assert_eq(bundle.push_target.force_with_lease, true)
+  assert(len(bundle.prompt) > 0)
+  assert(bundle.prompt.contains("repair_output"))
+}
+
+pipeline test_validate_accepts_well_formed(task) {
+  let bundle = build(_ci_failure_args())
+  assert_eq(validate_bundle(bundle), nil)
+}
+
+pipeline test_validate_requires_repo(task) {
+  let bundle = build(_ci_failure_args() + {repo: ""})
+  let err = validate_bundle(bundle)
+  assert(err != nil)
+  assert(err.contains("repo"))
+}
+
+pipeline test_validate_requires_failing_checks_for_ci(task) {
+  let bundle = build(_ci_failure_args() + {failing_checks: []})
+  let err = validate_bundle(bundle)
+  assert(err != nil)
+  assert(err.contains("failing_check"))
+}
+
+pipeline test_validate_requires_conflict_paths_for_merge(task) {
+  let bundle = build(
+    {
+      kind: "merge_conflict",
+      repo: "x/y",
+      pr_number: 1,
+      head_sha: "h",
+      head_ref: "feat",
+      allowed_write_scope: ["src/**"],
+    },
+  )
+  let err = validate_bundle(bundle)
+  assert(err != nil)
+  assert(err.contains("conflict_path"))
+}
+
+pipeline test_validate_requires_release_facts_for_release_audit(task) {
+  let bundle = build(
+    {
+      kind: "release_audit",
+      repo: "x/y",
+      pr_number: 1,
+      head_ref: "main",
+      allowed_write_scope: ["CHANGELOG.md"],
+    },
+  )
+  let err = validate_bundle(bundle)
+  assert(err != nil)
+  assert(err.contains("release_facts"))
+}
+
+pipeline test_validate_requires_write_scope(task) {
+  let bundle = build(_ci_failure_args() + {allowed_write_scope: []})
+  let err = validate_bundle(bundle)
+  assert(err != nil)
+  assert(err.contains("allowed_write_scope"))
+}
+
+pipeline test_validate_rejects_unknown_action(task) {
+  let bundle = build(_ci_failure_args() + {approval_required_for: ["semantic_repair", "drop_db"]})
+  let err = validate_bundle(bundle)
+  assert(err != nil)
+  assert(err.contains("approval_required_for"))
+}
+
+pipeline test_output_schema_advertises_required_fields(task) {
+  let s = output_schema()
+  assert_eq(s.type, "object")
+  assert(s.required.contains("diagnosis"))
+  assert(s.required.contains("files_changed"))
+  assert(s.required.contains("tests_run"))
+  assert(s.required.contains("commits_created"))
+  assert(s.required.contains("push_result"))
+  assert(s.required.contains("residual_risk"))
+  // The release-audit consumer surfaces release_outputs as an optional
+  // alongside the universal repair fields.
+  assert(s.properties.release_outputs != nil)
+}

--- a/personas/merge_captain/tests/repair_validator_test.harn
+++ b/personas/merge_captain/tests/repair_validator_test.harn
@@ -1,0 +1,208 @@
+// Run: harn test personas/merge_captain/tests/repair_validator_test.harn
+import { build } from "../lib/repair_bundle"
+import {
+  harness_validate,
+  path_matches_any,
+  path_matches_glob,
+  validate_all,
+  validate_pushed,
+  validate_shape,
+  validate_tests,
+  validate_write_scope,
+} from "../lib/repair_validator"
+
+fn _bundle(overrides) {
+  let base = {
+    kind: "ci_failure",
+    repo: "x/y",
+    pr_number: 1,
+    head_sha: "h",
+    head_ref: "feat",
+    failing_checks: [{name: "ci", conclusion: "failure"}],
+    allowed_write_scope: ["src/**", "tests/**"],
+    required_verification: [{name: "tests", command: "make test"}],
+  }
+  return build(base + overrides ?? {})
+}
+
+fn _good_output() {
+  return {
+    diagnosis: "x",
+    files_changed: [{path: "src/foo.rs", action: "modified"}],
+    tests_run: [{name: "tests", command: "make test", status: "ok", exit_code: 0}],
+    commits_created: [{sha: "abc", subject: "fix"}],
+    push_result: {pushed: true, ref: "feat", sha: "abc", force_with_lease: true},
+    residual_risk: "none",
+  }
+}
+
+pipeline test_path_matches_glob_plain_prefix(task) {
+  assert(path_matches_glob("src/foo.rs", "src"))
+  assert(path_matches_glob("src/foo/bar.rs", "src/foo"))
+  assert(!path_matches_glob("srcs/foo.rs", "src"))
+  assert(!path_matches_glob("other/foo.rs", "src"))
+}
+
+pipeline test_path_matches_glob_recursive(task) {
+  assert(path_matches_glob("src/foo.rs", "src/**"))
+  assert(path_matches_glob("src/foo/bar/baz.rs", "src/**"))
+  assert(path_matches_glob("src", "src/**"))
+  assert(!path_matches_glob("other/foo.rs", "src/**"))
+}
+
+pipeline test_path_matches_glob_single_segment(task) {
+  assert(path_matches_glob("src/foo.rs", "src/*"))
+  assert(!path_matches_glob("src/foo/bar.rs", "src/*"))
+  assert(!path_matches_glob("src", "src/*"))
+}
+
+pipeline test_path_matches_any_short_circuits(task) {
+  let globs = ["src/**", "tests/**"]
+  assert(path_matches_any("src/foo.rs", globs))
+  assert(path_matches_any("tests/foo_test.rs", globs))
+  assert(!path_matches_any("docs/foo.md", globs))
+}
+
+pipeline test_validate_shape_catches_missing_keys(task) {
+  let bare = {diagnosis: "x"}
+  let v = validate_shape(bare)
+  assert(!v.ok)
+  assert_eq(len(v.errors), 1)
+  let err = v.errors[0]
+  assert(err.contains("malformed output"))
+  assert(err.contains("files_changed"))
+}
+
+pipeline test_validate_shape_passes_full(task) {
+  let v = validate_shape(_good_output())
+  assert(v.ok)
+  assert_eq(len(v.errors), 0)
+}
+
+pipeline test_validate_tests_rejects_empty_when_required(task) {
+  let bundle = _bundle({})
+  let bad = _good_output() + {tests_run: []}
+  let v = validate_tests(bundle, bad)
+  assert(!v.ok)
+  assert(v.errors[0].contains("missing tests"))
+}
+
+pipeline test_validate_tests_rejects_missing_required_command(task) {
+  let bundle = _bundle({required_verification: [{name: "lint", command: "make lint"}]})
+  let bad = _good_output() + {tests_run: [{name: "tests", command: "make test", status: "ok", exit_code: 0}]}
+  let v = validate_tests(bundle, bad)
+  assert(!v.ok)
+  assert(v.errors[0].contains("missing tests"))
+  assert(v.errors[0].contains("lint"))
+}
+
+pipeline test_validate_tests_rejects_failing(task) {
+  let bundle = _bundle({})
+  let bad = _good_output()
+    + {tests_run: [{name: "tests", command: "make test", status: "failed", exit_code: 1}]}
+  let v = validate_tests(bundle, bad)
+  assert(!v.ok)
+  assert(v.errors[0].contains("failing tests"))
+}
+
+pipeline test_validate_write_scope_blocks_outside(task) {
+  let bundle = _bundle({})
+  let bad = _good_output()
+    + {
+    files_changed: [{path: "src/foo.rs", action: "modified"}, {path: "secrets/key.pem", action: "created"}],
+  }
+  let v = validate_write_scope(bundle, bad)
+  assert(!v.ok)
+  assert(v.errors[0].contains("unexpected write scope"))
+  assert(v.errors[0].contains("secrets/key.pem"))
+}
+
+pipeline test_validate_write_scope_allows_inside(task) {
+  let bundle = _bundle({})
+  let v = validate_write_scope(bundle, _good_output())
+  assert(v.ok)
+}
+
+pipeline test_validate_write_scope_empty_scope_blocks_writes(task) {
+  // build() requires at least one entry, so we forge a raw bundle.
+  let bundle = {_type: "merge_captain.repair_bundle", version: 1, kind: "ci_failure", allowed_write_scope: []}
+  let v = validate_write_scope(bundle, _good_output())
+  assert(!v.ok)
+  assert(v.errors[0].contains("unexpected write scope"))
+}
+
+pipeline test_validate_pushed_requires_push_when_committed(task) {
+  let bundle = _bundle({})
+  let bad = _good_output() + {push_result: {pushed: false, ref: "feat"}}
+  let v = validate_pushed(bundle, bad)
+  assert(!v.ok)
+  assert(v.errors[0].contains("unpushed commits"))
+}
+
+pipeline test_validate_pushed_rejects_push_without_commits(task) {
+  let bundle = _bundle({})
+  let bad = _good_output() + {commits_created: [], push_result: {pushed: true, ref: "feat"}}
+  let v = validate_pushed(bundle, bad)
+  assert(!v.ok)
+  assert(v.errors[0].contains("push without commits"))
+}
+
+pipeline test_validate_pushed_rejects_target_mismatch(task) {
+  let bundle = _bundle({})
+  let bad = _good_output() + {push_result: {pushed: true, ref: "wrong-branch", sha: "abc"}}
+  let v = validate_pushed(bundle, bad)
+  assert(!v.ok)
+  assert(v.errors[0].contains("push target mismatch"))
+}
+
+pipeline test_validate_pushed_accepts_qualified_ref(task) {
+  let bundle = _bundle({})
+  let good = _good_output() + {push_result: {pushed: true, ref: "refs/heads/feat", sha: "abc"}}
+  let v = validate_pushed(bundle, good)
+  assert(v.ok)
+}
+
+pipeline test_validate_all_short_circuits_on_shape_failure(task) {
+  let bundle = _bundle({})
+  let bad = {diagnosis: "x"}
+  let v = validate_all(bundle, bad)
+  assert(!v.ok)
+  // Only the shape error surfaces because downstream checks need a full dict.
+  assert_eq(len(v.errors), 1)
+  assert(v.errors[0].contains("malformed output"))
+}
+
+pipeline test_validate_all_aggregates_errors(task) {
+  let bundle = _bundle({})
+  let bad = _good_output()
+    + {
+    files_changed: [{path: "secrets/key.pem", action: "created"}],
+    tests_run: [{name: "tests", command: "make test", status: "failed", exit_code: 1}],
+    push_result: {pushed: false, ref: "feat"},
+  }
+  let v = validate_all(bundle, bad)
+  assert(!v.ok)
+  // tests + write scope + push together produce 3 distinct errors.
+  assert_eq(len(v.errors), 3)
+}
+
+pipeline test_validate_all_passes_clean(task) {
+  let bundle = _bundle({})
+  let v = validate_all(bundle, _good_output())
+  assert(v.ok)
+  assert_eq(len(v.errors), 0)
+}
+
+pipeline test_harness_validate_skipped_when_disabled(task) {
+  let bundle = _bundle({})
+  let v = harness_validate(bundle, _good_output(), {enabled: false})
+  assert(v.ok)
+  assert_eq(len(v.errors), 0)
+}
+
+pipeline test_harness_validate_rejects_unsafe_cwd(task) {
+  let bundle = _bundle({})
+  let v = harness_validate(bundle, _good_output(), {enabled: true, cwd: "/tmp; rm -rf /"})
+  assert(!v.ok)
+  assert(v.errors[0].contains("shell metacharacters"))
+}

--- a/personas/merge_captain/tests/repair_worker_test.harn
+++ b/personas/merge_captain/tests/repair_worker_test.harn
@@ -1,0 +1,282 @@
+// Run: harn test personas/merge_captain/tests/repair_worker_test.harn
+//
+// Exercises the dispatcher's branches without ever calling agent_loop:
+// every test passes a stub `executor` closure so the worker contract is
+// validated end-to-end (build bundle → gate → executor → validators →
+// run record) on pure Harn.
+import { build } from "../lib/repair_bundle"
+import {
+  invoke,
+  invoke_for_ci_failure,
+  invoke_for_merge_conflict,
+  invoke_for_release_audit,
+} from "../lib/repair_worker"
+
+fn _ok_output() {
+  return {
+    diagnosis: "fixed",
+    files_changed: [{path: "src/foo.rs", action: "modified"}],
+    tests_run: [{name: "tests", command: "make test", status: "ok", exit_code: 0}],
+    commits_created: [{sha: "abc", subject: "fix"}],
+    push_result: {pushed: true, ref: "feat", sha: "abc", force_with_lease: true},
+    residual_risk: "none",
+  }
+}
+
+fn _stub_executor(output) {
+  return { _bundle, _options -> {
+    ok: true,
+    output: output,
+    raw: "stub",
+    agent_loop: {status: "completed", iterations: 1, input_tokens: 100, output_tokens: 50},
+  } }
+}
+
+fn _failing_executor(error) {
+  return { _bundle, _options -> {ok: false, output: nil, raw: "garbage", error: error, agent_loop: {status: "error"}} }
+}
+
+fn _ci_bundle() {
+  return build(
+    {
+      kind: "ci_failure",
+      repo: "x/y",
+      pr_number: 7,
+      head_sha: "head",
+      head_ref: "feat",
+      failing_checks: [{name: "ci", conclusion: "failure"}],
+      allowed_write_scope: ["src/**"],
+      required_verification: [{name: "tests", command: "make test"}],
+      approval_required_for: ["semantic_repair"],
+    },
+  )
+}
+
+fn _autopilot_policy() {
+  return {
+    repair_worker: {
+      enabled: true,
+      handles_kinds: ["ci_failure", "merge_conflict"],
+      autopilot_action_kinds: ["semantic_repair", "force_push"],
+      require_human_for: [],
+    },
+  }
+}
+
+fn _human_required_policy() {
+  return {
+    repair_worker: {enabled: true, handles_kinds: ["ci_failure"], require_human_for: ["semantic_repair"]},
+  }
+}
+
+pipeline test_dry_run_skips_executor(task) {
+  var calls = 0
+  let executor = { _b, _o ->
+    calls = calls + 1
+    {ok: true, output: _ok_output(), raw: "should_not_run"}
+  }
+  let run = invoke(
+    {
+      bundle: _ci_bundle(),
+      policy: _autopilot_policy(),
+      parent_receipt_ref: {sweep_id: "s", repo: "x/y", pr_number: 7, prior_state: "discovered"},
+      dry_run: true,
+      executor: executor,
+    },
+  )
+  assert_eq(run.status, "skipped_dry_run")
+  assert_eq(run.approval_state, "dry_run")
+  assert_eq(run.output, nil)
+  assert_eq(calls, 0)
+}
+
+pipeline test_blocked_when_human_approval_required(task) {
+  let run = invoke(
+    {
+      bundle: _ci_bundle(),
+      policy: _human_required_policy(),
+      parent_receipt_ref: {sweep_id: "s", repo: "x/y", pr_number: 7, prior_state: "discovered"},
+      dry_run: false,
+      executor: _stub_executor(_ok_output()),
+    },
+  )
+  assert_eq(run.status, "blocked_pending_approval")
+  assert_eq(run.approval_state, "needs_human")
+  assert(run.blocking_actions.contains("semantic_repair"))
+  // Executor never ran, so output is nil.
+  assert_eq(run.output, nil)
+}
+
+pipeline test_completed_run_attaches_output(task) {
+  let run = invoke(
+    {
+      bundle: _ci_bundle(),
+      policy: _autopilot_policy(),
+      parent_receipt_ref: {sweep_id: "s", repo: "x/y", pr_number: 7, prior_state: "discovered"},
+      dry_run: false,
+      executor: _stub_executor(_ok_output()),
+    },
+  )
+  assert_eq(run.status, "completed")
+  assert_eq(run.approval_state, "autopilot")
+  assert_eq(len(run.validation_errors), 0)
+  assert_eq(run.output.diagnosis, "fixed")
+  assert_eq(run.agent_loop.status, "completed")
+  assert_eq(run.agent_loop.iterations, 1)
+}
+
+pipeline test_schema_invalid_when_executor_fails(task) {
+  let run = invoke(
+    {
+      bundle: _ci_bundle(),
+      policy: _autopilot_policy(),
+      parent_receipt_ref: {sweep_id: "s", repo: "x/y", pr_number: 7, prior_state: "discovered"},
+      dry_run: false,
+      executor: _failing_executor("syntax error"),
+    },
+  )
+  assert_eq(run.status, "schema_invalid")
+  assert_eq(run.output, nil)
+  assert(run.validation_errors[0].contains("syntax error"))
+  assert_eq(run.raw_text, "garbage")
+}
+
+pipeline test_validators_failed_when_output_violates_contract(task) {
+  let bad_output = _ok_output() + {files_changed: [{path: "secrets/key.pem", action: "created"}]}
+  let run = invoke(
+    {
+      bundle: _ci_bundle(),
+      policy: _autopilot_policy(),
+      parent_receipt_ref: {sweep_id: "s", repo: "x/y", pr_number: 7, prior_state: "discovered"},
+      dry_run: false,
+      executor: _stub_executor(bad_output),
+    },
+  )
+  assert_eq(run.status, "validators_failed")
+  assert(run.validation_errors[0].contains("unexpected write scope"))
+  // Output is preserved so a reviewer can inspect what the worker tried.
+  assert_eq(run.output.diagnosis, "fixed")
+}
+
+pipeline test_bundle_invalid_short_circuits(task) {
+  let bad_bundle = build(
+    {
+      kind: "ci_failure",
+      repo: "",
+      failing_checks: [{name: "ci", conclusion: "failure"}],
+      allowed_write_scope: ["src/**"],
+    },
+  )
+  let run = invoke(
+    {
+      bundle: bad_bundle,
+      policy: _autopilot_policy(),
+      dry_run: false,
+      executor: _stub_executor(_ok_output()),
+    },
+  )
+  assert_eq(run.status, "bundle_invalid")
+  assert(run.validation_errors[0].contains("repo"))
+}
+
+pipeline test_invoke_for_ci_failure_builds_correct_bundle(task) {
+  let observation = {
+    repo: "x/y",
+    number: 7,
+    head_sha: "head",
+    head_ref: "feat",
+    base_ref: "main",
+    failed_required_checks: ["ci / rust", "ci / portal"],
+  }
+  let policy = _autopilot_policy() + {local_verification: [{name: "tests", command: "make test"}]}
+  let run = invoke_for_ci_failure(
+    {
+      observation: observation,
+      policy: policy,
+      sweep_id: "s",
+      dry_run: true,
+      allowed_write_scope: ["src/**", "tests/**"],
+    },
+  )
+  assert_eq(run.status, "skipped_dry_run")
+  let b = run.bundle
+  assert_eq(b.kind, "ci_failure")
+  assert_eq(b.repo, "x/y")
+  assert_eq(b.pr_number, 7)
+  assert_eq(len(b.failing_checks), 2)
+  assert_eq(b.required_verification[0].command, "make test")
+  assert(b.approval_required_for.contains("semantic_repair"))
+  assert(!b.approval_required_for.contains("force_push"))
+  assert_eq(b.push_target.branch, "feat")
+}
+
+pipeline test_invoke_for_merge_conflict_marks_force_push(task) {
+  let observation = {
+    repo: "x/y",
+    number: 8,
+    head_sha: "h",
+    head_ref: "feat",
+    base_ref: "main",
+    failed_required_checks: [],
+  }
+  let policy = _autopilot_policy() + {local_verification: [{name: "tests", command: "make test"}]}
+  let run = invoke_for_merge_conflict(
+    {
+      observation: observation,
+      policy: policy,
+      sweep_id: "s",
+      dry_run: true,
+      conflict_paths: ["src/lib.rs"],
+      allowed_write_scope: ["src/**"],
+    },
+  )
+  assert_eq(run.status, "skipped_dry_run")
+  let b = run.bundle
+  assert_eq(b.kind, "merge_conflict")
+  assert(b.conflict_paths.contains("src/lib.rs"))
+  assert(b.approval_required_for.contains("semantic_repair"))
+  assert(b.approval_required_for.contains("force_push"))
+}
+
+pipeline test_invoke_for_release_audit_builds_bundle(task) {
+  let release_facts = {
+    tag: "v0.7.54",
+    commits_in_range: [{sha: "abc", subject: "feat: foo", author: "x"}],
+    changelog_path: "CHANGELOG.md",
+    changelog_excerpt: "## Unreleased",
+  }
+  let run = invoke_for_release_audit(
+    {
+      repo: "burin-labs/harn",
+      head_ref: "main",
+      release_facts: release_facts,
+      policy: _autopilot_policy() + {local_verification: []},
+      dry_run: true,
+      allowed_write_scope: ["CHANGELOG.md"],
+    },
+  )
+  assert_eq(run.status, "skipped_dry_run")
+  let b = run.bundle
+  assert_eq(b.kind, "release_audit")
+  assert_eq(b.release_facts.tag, "v0.7.54")
+  assert(b.approval_required_for.contains("release_tag"))
+  // Release audits do not force-push by default.
+  assert_eq(b.push_target.force_with_lease, false)
+}
+
+pipeline test_run_record_is_versioned(task) {
+  let run = invoke(
+    {
+      bundle: _ci_bundle(),
+      policy: _autopilot_policy(),
+      parent_receipt_ref: {sweep_id: "s", repo: "x/y", pr_number: 7, prior_state: "discovered"},
+      dry_run: false,
+      executor: _stub_executor(_ok_output()),
+    },
+  )
+  assert_eq(run._type, "merge_captain.repair_run")
+  assert_eq(run.version, 1)
+  assert(run.started_at <= run.finished_at)
+  assert_eq(run.parent_receipt_ref.sweep_id, "s")
+  assert_eq(run.parent_receipt_ref.repo, "x/y")
+}

--- a/personas/merge_captain/tests/scheduler_test.harn
+++ b/personas/merge_captain/tests/scheduler_test.harn
@@ -189,3 +189,174 @@ pipeline test_failing_ci_with_local_verify_runs_dry(task) {
   let local_results = cmd.results
   assert_eq(local_results[0].status, "skipped_dry_run")
 }
+
+fn _stub_repair_executor(output) {
+  return { _bundle, _options -> {
+    ok: true,
+    output: output,
+    raw: "stub",
+    agent_loop: {status: "completed", iterations: 1, input_tokens: 50, output_tokens: 25},
+  } }
+}
+
+fn _ok_repair_output() {
+  return {
+    diagnosis: "ci flake repaired",
+    files_changed: [{path: "src/foo.rs", action: "modified"}],
+    tests_run: [{name: "tests", command: "true", status: "ok", exit_code: 0}],
+    commits_created: [{sha: "abc", subject: "fix flake"}],
+    push_result: {pushed: true, ref: "feat-1", sha: "abc", force_with_lease: true},
+    residual_risk: "none",
+  }
+}
+
+pipeline test_repair_worker_dispatch_attaches_run_to_receipt(task) {
+  let policy_with_worker = with_defaults(
+    {
+      repo: _default_repo(),
+      merge_queue_enabled: true,
+      required_checks: ["ci"],
+      local_verification: [{name: "tests", command: "true"}],
+      repair_worker: {
+        enabled: true,
+        handles_kinds: ["ci_failure"],
+        autopilot_action_kinds: ["semantic_repair"],
+        require_human_for: [],
+      },
+    },
+  )
+  let snapshot = _snapshot([_pr(1, {head_ref: "feat-1"})], {["1"]: _fail_check()})
+  let handle = _open_handle("repair-worker-attach")
+  let summary = sweep(
+    {
+      adapter: fixture_adapter(snapshot),
+      policies: [policy_with_worker],
+      checkpoint_handle: handle,
+      dry_run: false,
+      sweep_id: "test-repair-attach",
+      repair_executor: _stub_repair_executor(_ok_repair_output()),
+      repair_extras_for: { _obs -> {allowed_write_scope: ["src/**"]} },
+    },
+  )
+  assert_eq(summary.pr_count, 1)
+  let receipt = summary.receipts[0]
+  // The classifier still says local_repair / run_local_verification —
+  // the scheduler upgrades the action transparently and records it as
+  // run_repair_worker in the commands list.
+  assert_eq(receipt.classification.state, "local_repair")
+  assert_eq(receipt.classification.action, "run_local_verification")
+  assert_eq(len(receipt.commands_run), 1)
+  let cmd = receipt.commands_run[0]
+  assert_eq(cmd.action, "run_repair_worker")
+  assert_eq(cmd.bundle_kind, "ci_failure")
+  assert_eq(cmd.status, "completed")
+  assert_eq(cmd.approval_state, "autopilot")
+  assert_eq(cmd.output_summary.pushed, true)
+  // The repair_run linkage is on the receipt itself for auditability.
+  assert(receipt.repair_run != nil)
+  assert_eq(receipt.repair_run._type, "merge_captain.repair_run_link")
+  assert_eq(receipt.repair_run.bundle_kind, "ci_failure")
+  assert_eq(receipt.repair_run.bundle_pr_number, 1)
+  assert_eq(receipt.repair_run.status, "completed")
+  assert_eq(receipt.final_outcome, "repair_worker_completed")
+}
+
+pipeline test_repair_worker_blocked_when_human_required(task) {
+  let policy = with_defaults(
+    {
+      repo: _default_repo(),
+      merge_queue_enabled: true,
+      required_checks: ["ci"],
+      local_verification: [{name: "tests", command: "true"}],
+      repair_worker: {enabled: true, handles_kinds: ["ci_failure"], require_human_for: ["semantic_repair"]},
+    },
+  )
+  let snapshot = _snapshot([_pr(1, {head_ref: "feat-1"})], {["1"]: _fail_check()})
+  let handle = _open_handle("repair-worker-blocked")
+  var executor_calls = 0
+  let executor = { _bundle, _options ->
+    executor_calls = executor_calls + 1
+    {ok: true, output: _ok_repair_output(), raw: "should_not_run"}
+  }
+  let summary = sweep(
+    {
+      adapter: fixture_adapter(snapshot),
+      policies: [policy],
+      checkpoint_handle: handle,
+      dry_run: false,
+      sweep_id: "test-repair-blocked",
+      repair_executor: executor,
+      repair_extras_for: { _obs -> {allowed_write_scope: ["src/**"]} },
+    },
+  )
+  let receipt = summary.receipts[0]
+  let cmd = receipt.commands_run[0]
+  assert_eq(cmd.status, "blocked_pending_approval")
+  assert(cmd.blocking_actions.contains("semantic_repair"))
+  assert_eq(executor_calls, 0)
+  assert_eq(receipt.repair_run.status, "blocked_pending_approval")
+}
+
+pipeline test_repair_worker_disabled_falls_back_to_local_verify(task) {
+  // Policy without repair_worker block keeps the existing path working.
+  let policy = with_defaults(
+    {
+      repo: _default_repo(),
+      merge_queue_enabled: true,
+      required_checks: ["ci"],
+      local_verification: [{name: "tests", command: "true"}],
+    },
+  )
+  let snapshot = _snapshot([_pr(1, {head_ref: "feat-1"})], {["1"]: _fail_check()})
+  let handle = _open_handle("repair-worker-disabled")
+  let summary = sweep(
+    {
+      adapter: fixture_adapter(snapshot),
+      policies: [policy],
+      checkpoint_handle: handle,
+      dry_run: true,
+      sweep_id: "test-repair-disabled",
+    },
+  )
+  let receipt = summary.receipts[0]
+  let cmd = receipt.commands_run[0]
+  assert_eq(cmd.action, "run_local_verification")
+  assert_eq(receipt.repair_run, nil)
+}
+
+pipeline test_repair_worker_validators_fail_writes_outside_scope(task) {
+  let policy = with_defaults(
+    {
+      repo: _default_repo(),
+      merge_queue_enabled: true,
+      required_checks: ["ci"],
+      local_verification: [{name: "tests", command: "true"}],
+      repair_worker: {
+        enabled: true,
+        handles_kinds: ["ci_failure"],
+        autopilot_action_kinds: ["semantic_repair"],
+        require_human_for: [],
+      },
+    },
+  )
+  let snapshot = _snapshot([_pr(1, {head_ref: "feat-1"})], {["1"]: _fail_check()})
+  let handle = _open_handle("repair-worker-violations")
+  let bad_output = _ok_repair_output() + {files_changed: [{path: "secrets/key.pem", action: "created"}]}
+  let summary = sweep(
+    {
+      adapter: fixture_adapter(snapshot),
+      policies: [policy],
+      checkpoint_handle: handle,
+      dry_run: false,
+      sweep_id: "test-repair-violations",
+      repair_executor: _stub_repair_executor(bad_output),
+      repair_extras_for: { _obs -> {allowed_write_scope: ["src/**"]} },
+    },
+  )
+  let receipt = summary.receipts[0]
+  let cmd = receipt.commands_run[0]
+  assert_eq(cmd.status, "validators_failed")
+  assert_eq(receipt.repair_run.status, "validators_failed")
+  assert(receipt.repair_run.validation_errors[0].contains("unexpected write scope"))
+  assert_eq(receipt.final_outcome, "repair_worker_validators_failed")
+}


### PR DESCRIPTION
## Summary

- Adds the typed `agent_loop` contract that lets Merge Captain (and the release-harness consumer in [#1146](https://github.com/burin-labs/harn/issues/1146)) call into a bounded coding-worker at explicit repair checkpoints — CI failure repairs, semantic merge conflicts, flaky-test hardening, release-note audits — without leaking the LLM into the rest of the persona.
- Five new pure-Harn modules: `repair_bundle.harn` (typed input + JSON output schema), `approval.harn` (per-action approval gates), `repair_worker.harn` (the only `agent_loop` caller in the persona), `repair_validator.harn` (deterministic post-run guards), plus integration in scheduler/policy/receipt.
- Unit-tested end-to-end via stub executors so the contract is validated without touching `agent_loop` in tests; opt-in per repo via `policy.repair_worker`.

## What's in the bundle

The deterministic harness hands the worker a `merge_captain.repair_bundle` v1 record covering: repo, PR, base/head SHAs, changed files, conflict paths or failing checks + logs, allowed write-scope globs, required verification commands, push target with `force_with_lease`, the action kinds that need approval, and (for release audits) typed `release_facts`.

The worker must respond with a `merge_captain.repair_output` v1 JSON document. The harness then runs five deterministic validators that fail closed on:

- **missing tests** — `tests_run` is empty, doesn't cover every `required_verification` entry, or any test reports `status != "ok"`
- **dirty worktrees** — opt-in `harness_validate(...)` runs `git -C <cwd> status --porcelain` and rejects uncommitted changes
- **unexpected write scope** — any `files_changed` path falls outside the allowed glob list
- **malformed output** — required schema fields missing or wrong type
- **unpushed commits** — commits created but `push_result.pushed != true` or the ref doesn't match the bundle target

Approval gates over `semantic_repair`, `force_push`, `admin_merge`, `release_tag`, `branch_delete`. Default is "human required for everything"; autopilot is opt-in per action kind.

## Receipt linkage

Every repair run is summarized into a `merge_captain.repair_run_link` field on the merge receipt (bundle kind, status, approval state, output counts, agent_loop telemetry). The full `merge_captain.repair_run` record is the audit trail.

## Wiring

The classifier stays pure. The scheduler routes `local_repair` (CI failure) and `dirty` (merge conflict) to the worker only when `policy.repair_worker.{enabled, handles_kinds}` opts in for the matching kind. Otherwise the existing `run_local_verification` / `comment` paths are unchanged.

## Test plan

- [x] `cargo run --bin harn -- check personas/` — every new module type-checks
- [x] `cargo run --bin harn -- lint personas/merge_captain/` — clean
- [x] `make fmt-harn` — clean
- [x] `cargo run --bin harn -- test personas/merge_captain/` — 96 passed (61 new)
- [x] `cargo run --bin harn -- run personas/merge_captain/manifest.harn` — smoke sweep produces receipts with `repair_run: null` (back-compat)
- [x] `cargo run --bin harn -- eval personas/merge_captain/evals/merge_captain_smoke.json` — pass
- [x] `make test` (cargo-nextest) — 3187 passed
- [x] `make conformance` — 789 passed
- [x] `make all` — green (after `npm install` in `crates/harn-cli/portal/` for `portal-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1010