### PR TITLE
Per-step model routing + token / cost budgets (#1074)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,23 @@ condensed series summaries instead of full per-patch history.
   task into the non-terminal `auth-required` state so clients can
   re-authenticate and resubscribe.
 
+- **Per-step model routing + token / cost budgets (#1074).** `@step`
+  now accepts `model: "..."` and `budget: { max_tokens: N, max_usd:
+  N.NN }` so a single persona can mix cheap classification (Haiku),
+  semantic judgment (Sonnet), and frontier escalation (Opus) without
+  hand-rolled routing inside the persona body. While a step's frame is
+  on the call stack `llm_call` defaults to the step's model when the
+  call site doesn't override it, and per-step token / cost spend is
+  tracked separately and short-circuits calls that would exceed the
+  step's ceiling. The thrown error honors the step's `error_boundary`:
+  `fail` (default) propagates as-is, `continue` swallows the throw and
+  returns nil from the step, and `escalate` re-tags the error with
+  `category: "handoff_escalation"` and `escalated: true` so the persona
+  body / handoff receiver can route on it. `harn persona inspect --json`
+  surfaces each step's `model` + `budget`, and the canonical receipt
+  envelope's `model_calls[]` carries the per-step token / cost
+  breakdown via `Receipt::push_step_breakdown`.
+
 ## v0.7.54
 
 ### Added

--- a/conformance/tests/integration/per_step_model_policy.expected
+++ b/conformance/tests/integration/per_step_model_policy.expected
@@ -1,0 +1,5 @@
+classify:low_priority|judge:balanced|decide:merge|nil
+3
+handoff_escalation
+true
+expensive_escalate

--- a/conformance/tests/integration/per_step_model_policy.harn
+++ b/conformance/tests/integration/per_step_model_policy.harn
@@ -1,0 +1,118 @@
+// `@step(model: ..., budget: ..., error_boundary: ...)` is consumed by
+// the runtime: each step's `llm_call` defaults to the configured model
+// when the call site doesn't override it; per-step token / cost
+// budgets short-circuit calls that would exceed the ceiling; and the
+// step's `error_boundary` decides whether the budget-exhausted error
+// propagates (`fail`), gets skipped (`continue`), or is bubbled to a
+// handoff (`escalate`).
+@persona(name: "triage_captain", tools: [github], autonomy: suggest, receipts: optional)
+fn triage_captain(ctx) -> string {
+  let cheap = classify_step(ctx)
+  let mid = judge_step(cheap)
+  let expensive = decide_step(mid)
+  let skipped = budget_exhausted_continue_step(expensive)
+  return "${cheap}|${mid}|${expensive}|${skipped}"
+}
+
+@step(name: "classify", model: "claude-haiku-4-5", receipt: audit, error_boundary: fail)
+fn classify_step(ctx) -> string {
+  let r = llm_call("classify ${ctx}", nil, {provider: "mock"})
+  return "classify:${r.text}"
+}
+
+@step(name: "judge", model: "claude-sonnet-4-6", receipt: audit, error_boundary: fail)
+fn judge_step(ctx) -> string {
+  let r = llm_call("judge ${ctx}", nil, {provider: "mock"})
+  return "judge:${r.text}"
+}
+
+@step(name: "decide", model: "claude-opus-4-7", receipt: audit, error_boundary: fail)
+fn decide_step(ctx) -> string {
+  let r = llm_call("decide ${ctx}", nil, {provider: "mock"})
+  return "decide:${r.text}"
+}
+
+@step(name: "expensive_skipped", model: "claude-opus-4-7", budget: {max_tokens: 5}, error_boundary: continue)
+fn budget_exhausted_continue_step(ctx) -> string {
+  let r = llm_call("explode ${ctx}", nil, {provider: "mock"})
+  return "should_not_reach:${r.text}"
+}
+
+@step(name: "expensive_escalate", model: "claude-opus-4-7", budget: {max_tokens: 5}, error_boundary: escalate)
+fn budget_exhausted_escalate_step(ctx) -> string {
+  let r = llm_call("escalate ${ctx}", nil, {provider: "mock"})
+  return "should_not_reach:${r.text}"
+}
+
+pipeline default() {
+  llm_mock_clear()
+  llm_mock(
+    {
+      match: "classify*",
+      consume_match: false,
+      text: "low_priority",
+      input_tokens: 5,
+      output_tokens: 5,
+      model: "claude-haiku-4-5",
+    },
+  )
+  llm_mock(
+    {
+      match: "judge*",
+      consume_match: false,
+      text: "balanced",
+      input_tokens: 12,
+      output_tokens: 18,
+      model: "claude-sonnet-4-6",
+    },
+  )
+  llm_mock(
+    {
+      match: "decide*",
+      consume_match: false,
+      text: "merge",
+      input_tokens: 30,
+      output_tokens: 40,
+      model: "claude-opus-4-7",
+    },
+  )
+  llm_mock(
+    {
+      match: "explode*",
+      consume_match: false,
+      text: "boom",
+      input_tokens: 50,
+      output_tokens: 100,
+      model: "claude-opus-4-7",
+    },
+  )
+  llm_mock(
+    {
+      match: "escalate*",
+      consume_match: false,
+      text: "esc",
+      input_tokens: 50,
+      output_tokens: 100,
+      model: "claude-opus-4-7",
+    },
+  )
+  // Routing: each `@step`'s configured model defaults onto its
+  // `llm_call`, the prompt-glob mocks return per-model fixtures, and
+  // the over-budget step is skipped (continue → nil).
+  let result = triage_captain("PR-42")
+  println(result)
+  // 3 calls succeeded; the 4th was rejected pre-flight by the step's
+  // own max_tokens=5 budget.
+  println(len(llm_mock_calls()))
+  // `escalate` re-tags the budget-exhausted error with category
+  // "handoff_escalation" and `escalated: true`, which the persona body
+  // can route on. The step's frame is unwound, so the throw exits the
+  // step function as a typed handoff escalation.
+  let escalation_caught = try {
+    budget_exhausted_escalate_step("PR-42")
+  }
+  let err = unwrap_err(escalation_caught)
+  println(err.category)
+  println(err.escalated)
+  println(err.step)
+}

--- a/crates/harn-cli/src/commands/persona.rs
+++ b/crates/harn-cli/src/commands/persona.rs
@@ -203,15 +203,25 @@ pub(crate) fn run_inspect(manifest: Option<&Path>, args: &PersonaInspectArgs) {
     println!("context_packs:  {}", comma_or_dash(&persona.context_packs));
     println!("evals:          {}", comma_or_dash(&persona.evals));
     if !persona.steps.is_empty() {
-        println!(
-            "steps:          {}",
-            persona
-                .steps
-                .iter()
-                .map(|step| format!("{} ({})", step.name, step.function))
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
+        println!("steps:");
+        for step in &persona.steps {
+            let mut detail = format!("  - {} ({})", step.name, step.function);
+            if let Some(model) = step.model.as_deref() {
+                detail.push_str(&format!(" model={model}"));
+            }
+            if let Some(budget) = step.budget.as_ref() {
+                if let Some(max_tokens) = budget.max_tokens {
+                    detail.push_str(&format!(" max_tokens={max_tokens}"));
+                }
+                if let Some(max_usd) = budget.max_usd {
+                    detail.push_str(&format!(" max_usd={max_usd}"));
+                }
+            }
+            if let Some(boundary) = step.error_boundary.as_deref() {
+                detail.push_str(&format!(" error_boundary={boundary}"));
+            }
+            println!("{detail}");
+        }
     }
     if let Some(owner) = &persona.owner {
         println!("owner:          {owner}");

--- a/crates/harn-modules/src/personas.rs
+++ b/crates/harn-modules/src/personas.rs
@@ -71,12 +71,26 @@ pub struct PersonaStepMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retry: Option<PersonaStepRetry>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget: Option<PersonaStepBudget>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line: Option<usize>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct PersonaStepRetry {
     pub max_attempts: u64,
+}
+
+/// Per-step token / cost ceiling. Either field is optional; whichever is
+/// set governs that dimension. Surfaced statically by `harn persona
+/// inspect --json` and consumed at runtime by `crates/harn-vm/src/step_runtime.rs`
+/// to short-circuit `llm_call` invocations before they exceed the limit.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PersonaStepBudget {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_usd: Option<f64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -361,6 +375,7 @@ fn collect_step_declarations(program: &[SNode]) -> BTreeMap<String, PersonaStepM
                 receipt: attr_string(step_attr, "receipt"),
                 error_boundary: attr_string(step_attr, "error_boundary"),
                 retry: attr_retry(step_attr),
+                budget: attr_step_budget(step_attr),
                 line: Some(inner.span.line),
             },
         );
@@ -408,6 +423,40 @@ fn attr_retry(attr: &Attribute) -> Option<PersonaStepRetry> {
         }
     }
     None
+}
+
+fn attr_step_budget(attr: &Attribute) -> Option<PersonaStepBudget> {
+    let budget = attr.named_arg("budget")?;
+    let Node::DictLiteral(entries) = &budget.node else {
+        return None;
+    };
+    let mut out = PersonaStepBudget::default();
+    let mut any = false;
+    for entry in entries {
+        match entry_key(&entry.key) {
+            Some("max_tokens") => {
+                if let Node::IntLiteral(value) = entry.value.node {
+                    if value >= 1 {
+                        out.max_tokens = Some(value as u64);
+                        any = true;
+                    }
+                }
+            }
+            Some("max_usd") => match entry.value.node {
+                Node::FloatLiteral(value) if value.is_finite() && value >= 0.0 => {
+                    out.max_usd = Some(value);
+                    any = true;
+                }
+                Node::IntLiteral(value) if value >= 0 => {
+                    out.max_usd = Some(value as f64);
+                    any = true;
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    any.then_some(out)
 }
 
 fn entry_key(node: &SNode) -> Option<&str> {

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -1718,6 +1718,7 @@ impl TypeChecker {
             "receipt",
             "error_boundary",
             "retry",
+            "budget",
         ];
         let mut has_name = false;
         for arg in &attr.args {
@@ -1755,6 +1756,7 @@ impl TypeChecker {
                     &["fail", "continue", "escalate"],
                 ),
                 "retry" => self.expect_step_retry_dict(&arg.value, arg.span),
+                "budget" => self.expect_step_budget_dict(&arg.value, arg.span),
                 _ => {}
             }
         }
@@ -1764,6 +1766,50 @@ impl TypeChecker {
                     .to_string(),
                 attr.span,
             );
+        }
+    }
+
+    fn expect_step_budget_dict(&mut self, value: &SNode, span: Span) {
+        const NUMBER_KEYS: &[&str] = &["max_tokens", "max_usd"];
+        let Node::DictLiteral(entries) = &value.node else {
+            self.warning_at(
+                "`@step(budget: ...)` must be a dict such as `{ max_tokens: 1000, max_usd: 0.05 }`"
+                    .to_string(),
+                span,
+            );
+            return;
+        };
+        for entry in entries {
+            let Some(field_name) = attr_key_name(&entry.key.node) else {
+                self.warning_at(
+                    "`@step(budget: ...)` field names must be strings or identifiers".to_string(),
+                    entry.key.span,
+                );
+                continue;
+            };
+            if !NUMBER_KEYS.contains(&field_name) {
+                self.warning_at(
+                    format!(
+                        "unknown `@step(budget: ...)` field `{field_name}`; expected one of {NUMBER_KEYS:?}"
+                    ),
+                    entry.key.span,
+                );
+                continue;
+            }
+            match (field_name, &entry.value.node) {
+                ("max_tokens", Node::IntLiteral(value)) if *value >= 1 => {}
+                ("max_tokens", _) => self.warning_at(
+                    "`@step(budget: { max_tokens: ... })` must be a positive integer".to_string(),
+                    entry.value.span,
+                ),
+                ("max_usd", Node::IntLiteral(value)) if *value >= 0 => {}
+                ("max_usd", Node::FloatLiteral(value)) if value.is_finite() && *value >= 0.0 => {}
+                ("max_usd", _) => self.warning_at(
+                    "`@step(budget: { max_usd: ... })` must be a non-negative number".to_string(),
+                    entry.value.span,
+                ),
+                _ => {}
+            }
         }
     }
 

--- a/crates/harn-vm/src/compiler/decls.rs
+++ b/crates/harn-vm/src/compiler/decls.rs
@@ -222,8 +222,72 @@ impl Compiler {
                 if let Node::FnDecl { name, .. } = &inner.node {
                     self.emit_acp_skill_registration(attr, name)?;
                 }
+            } else if attr.name == "step" {
+                if let Node::FnDecl { name, .. } = &inner.node {
+                    self.emit_step_registration(attr, name)?;
+                }
             }
         }
+        Ok(())
+    }
+
+    /// Emit bytecode equivalent to:
+    ///   __register_step("plan_step", { name: "plan", model: "...",
+    ///                                  error_boundary: "continue",
+    ///                                  budget: { max_tokens: 200, max_usd: 0.05 } })
+    /// Runs at module load so the per-step metadata is in
+    /// `crates/harn-vm/src/step_runtime.rs`'s registry by the time
+    /// any persona body invokes the step's function.
+    pub(super) fn emit_step_registration(
+        &mut self,
+        attr: &harn_parser::Attribute,
+        fn_name: &str,
+    ) -> Result<(), CompileError> {
+        // Push the builtin name.
+        let define_idx = self
+            .chunk
+            .add_constant(Constant::String("__register_step".into()));
+        self.chunk.emit_u16(Op::Constant, define_idx, self.line);
+
+        // Arg 0: function name (the registry key).
+        let fn_const = self.chunk.add_constant(Constant::String(fn_name.into()));
+        self.chunk.emit_u16(Op::Constant, fn_const, self.line);
+
+        // Arg 1: metadata dict — emit only the fields the step
+        // declared, matching the parser's KNOWN_KEYS for @step.
+        const META_KEYS: &[&str] = &["name", "model", "approval", "receipt", "error_boundary"];
+        let mut entries: u16 = 0;
+        for arg in &attr.args {
+            let Some(ref key) = arg.name else {
+                continue;
+            };
+            if !META_KEYS.contains(&key.as_str()) {
+                continue;
+            }
+            let key_idx = self.chunk.add_constant(Constant::String(key.clone()));
+            self.chunk.emit_u16(Op::Constant, key_idx, self.line);
+            self.compile_attribute_value(&arg.value)?;
+            entries += 1;
+        }
+        // Budget is forwarded as a nested dict so the runtime can
+        // distinguish "no budget set" from "budget set with no
+        // fields". The parser already enforces shape; we just plumb
+        // the dict literal through verbatim.
+        if let Some(budget) = attr.named_arg("budget") {
+            if matches!(budget.node, Node::DictLiteral(_)) {
+                let key_idx = self.chunk.add_constant(Constant::String("budget".into()));
+                self.chunk.emit_u16(Op::Constant, key_idx, self.line);
+                self.compile_attribute_value(budget)?;
+                entries += 1;
+            }
+        }
+        self.chunk.emit_u16(Op::BuildDict, entries, self.line);
+
+        // Call __register_step(fn_name, meta_dict). The builtin
+        // returns nil; pop it so we don't leave dead values on the
+        // stack at module top-level.
+        self.chunk.emit_u8(Op::Call, 2, self.line);
+        self.chunk.emit(Op::Pop, self.line);
         Ok(())
     }
 

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -42,6 +42,7 @@ pub mod shells;
 pub mod skills;
 pub mod stdlib;
 pub mod stdlib_modules;
+pub mod step_runtime;
 pub mod store;
 pub(crate) mod synchronization;
 pub mod tenant;

--- a/crates/harn-vm/src/llm/agent/tests/mod.rs
+++ b/crates/harn-vm/src/llm/agent/tests/mod.rs
@@ -133,12 +133,8 @@ pub(super) fn base_agent_config() -> AgentLoopConfig {
     }
 }
 
-/// Mutex protecting the HARN_LLM_TRANSCRIPT_DIR env var so transcript
-/// tests in this module don't race each other and end up writing to a
-/// neighbour's temp dir.
-pub(super) fn transcript_env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-    LOCK.get_or_init(|| std::sync::Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-}
+// `transcript_env_lock` was removed once the
+// `observed_llm_call_transcript_*` tests stopped mutating
+// `HARN_LLM_TRANSCRIPT_DIR` and switched to per-thread
+// `push_llm_transcript_dir` guards. The new pattern is in
+// `transcript.rs::TestTranscriptDir`.

--- a/crates/harn-vm/src/llm/agent/tests/transcript.rs
+++ b/crates/harn-vm/src/llm/agent/tests/transcript.rs
@@ -1,28 +1,58 @@
 use super::*;
 
+/// Per-test transcript dir: pushes onto the per-thread
+/// `TRANSCRIPT_DIR_STACK` (race-free) instead of mutating the
+/// process-global `HARN_LLM_TRANSCRIPT_DIR` env var.
+///
+/// The previous env-var-based pattern was racy under cargo test's
+/// parallel scheduler: tests A, B, C running on different libtest
+/// threads each `set_var` to their own temp dir, but the env var is
+/// process-global, so whichever `set_var` ran most recently won. All
+/// three tests' `append_llm_transcript_entry` calls then funneled
+/// into the SAME file, and (a) the JSON lines from neighboring
+/// tests polluted each other's reads while (b) concurrent
+/// `writeln!` calls > PIPE_BUF (512 bytes on macOS) interleaved
+/// mid-line, producing torn JSON that the `serde_json::from_str`
+/// filter silently dropped. The thread-local stack is per-thread,
+/// so each test reads only its own transcript.
+struct TestTranscriptDir {
+    dir: std::path::PathBuf,
+    _guard: crate::llm::agent_observe::LlmTranscriptDirGuard,
+}
+
+impl TestTranscriptDir {
+    fn new(prefix: &str) -> Self {
+        let dir = std::env::temp_dir().join(format!("{prefix}-{}", uuid::Uuid::now_v7()));
+        std::fs::create_dir_all(&dir).expect("create transcript temp dir");
+        let guard = crate::llm::agent_observe::push_llm_transcript_dir(Some(
+            dir.to_string_lossy().into_owned(),
+        ));
+        Self { dir, _guard: guard }
+    }
+
+    fn path(&self) -> std::path::PathBuf {
+        self.dir.join("llm_transcript.jsonl")
+    }
+}
+
+impl Drop for TestTranscriptDir {
+    fn drop(&mut self) {
+        // The transcript dir guard pops first (Rust drops fields in
+        // reverse declaration order). After pop, no new writes from
+        // this thread go to `dir`, so it's safe to remove.
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
 #[tokio::test(flavor = "current_thread")]
-#[allow(clippy::await_holding_lock)]
 async fn observed_llm_call_transcript_deduplicates_system_and_tool_schemas() {
     // Two back-to-back calls with identical system prompt and tool schema
     // list should emit `system_prompt` and `tool_schemas` events exactly
     // once each, while `provider_call_request` fires on every call. The
     // dedup state is per-agent-loop; for standalone `observed_llm_call`
     // tests we rely on the thread-local seeded in the first dump.
-    //
-    // Guard against parallel tests racing on the shared HARN_LLM_TRANSCRIPT_DIR
-    // env var — other tests in this module set/unset the same variable.
-    let _guard = transcript_env_lock();
     reset_llm_mock_state();
-    let dir = std::env::temp_dir().join(format!(
-        "harn-llm-transcript-dedup-{}",
-        uuid::Uuid::now_v7()
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    let old_dir = std::env::var("HARN_LLM_TRANSCRIPT_DIR").ok();
-    std::env::set_var(
-        "HARN_LLM_TRANSCRIPT_DIR",
-        dir.to_string_lossy().into_owned(),
-    );
+    let scratch = TestTranscriptDir::new("harn-llm-transcript-dedup");
     crate::llm::agent_observe::reset_transcript_dedup();
 
     let mut opts = base_opts(vec![serde_json::json!({"role": "user", "content": "ping"})]);
@@ -43,12 +73,7 @@ async fn observed_llm_call_transcript_deduplicates_system_and_tool_schemas() {
         .unwrap();
     }
 
-    // Other parallel tests in this binary may briefly point
-    // HARN_LLM_TRANSCRIPT_DIR at the same temp dir via the shared env var,
-    // so our file can pick up stray events. Filter on our marker system
-    // prompt before asserting counts.
-    let transcript =
-        std::fs::read_to_string(dir.join("llm_transcript.jsonl")).expect("transcript file");
+    let transcript = std::fs::read_to_string(scratch.path()).expect("transcript file");
     let system_events_for_us = transcript
         .lines()
         .filter(|l| {
@@ -80,27 +105,13 @@ async fn observed_llm_call_transcript_deduplicates_system_and_tool_schemas() {
         "provider_call_request must not embed the message list; messages are emitted as their own events: {transcript}",
     );
 
-    if let Some(previous) = old_dir {
-        std::env::set_var("HARN_LLM_TRANSCRIPT_DIR", previous);
-    } else {
-        std::env::remove_var("HARN_LLM_TRANSCRIPT_DIR");
-    }
-    let _ = std::fs::remove_dir_all(dir);
     reset_llm_mock_state();
 }
 
 #[tokio::test(flavor = "current_thread")]
-#[allow(clippy::await_holding_lock)]
 async fn observed_llm_call_transcript_uses_explicit_tool_format() {
-    let _guard = transcript_env_lock();
     reset_llm_mock_state();
-    let dir = std::env::temp_dir().join(format!("harn-llm-transcript-{}", uuid::Uuid::now_v7()));
-    std::fs::create_dir_all(&dir).unwrap();
-    let old_dir = std::env::var("HARN_LLM_TRANSCRIPT_DIR").ok();
-    std::env::set_var(
-        "HARN_LLM_TRANSCRIPT_DIR",
-        dir.to_string_lossy().into_owned(),
-    );
+    let scratch = TestTranscriptDir::new("harn-llm-transcript");
 
     let opts = base_opts(vec![serde_json::json!({
         "role": "user",
@@ -119,34 +130,16 @@ async fn observed_llm_call_transcript_uses_explicit_tool_format() {
     .await
     .unwrap();
 
-    let transcript =
-        std::fs::read_to_string(dir.join("llm_transcript.jsonl")).expect("transcript file");
+    let transcript = std::fs::read_to_string(scratch.path()).expect("transcript file");
     assert!(transcript.contains("\"tool_format\":\"native\""));
 
-    if let Some(previous) = old_dir {
-        std::env::set_var("HARN_LLM_TRANSCRIPT_DIR", previous);
-    } else {
-        std::env::remove_var("HARN_LLM_TRANSCRIPT_DIR");
-    }
-    let _ = std::fs::remove_dir_all(dir);
     reset_llm_mock_state();
 }
 
 #[tokio::test(flavor = "current_thread")]
-#[allow(clippy::await_holding_lock)]
 async fn observed_llm_call_transcript_records_thinking_settings() {
-    let _guard = transcript_env_lock();
     reset_llm_mock_state();
-    let dir = std::env::temp_dir().join(format!(
-        "harn-llm-transcript-thinking-{}",
-        uuid::Uuid::now_v7()
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    let old_dir = std::env::var("HARN_LLM_TRANSCRIPT_DIR").ok();
-    std::env::set_var(
-        "HARN_LLM_TRANSCRIPT_DIR",
-        dir.to_string_lossy().into_owned(),
-    );
+    let scratch = TestTranscriptDir::new("harn-llm-transcript-thinking");
 
     let mut opts = base_opts(vec![serde_json::json!({
         "role": "user",
@@ -171,27 +164,27 @@ async fn observed_llm_call_transcript_records_thinking_settings() {
     .await
     .unwrap();
 
-    let transcript =
-        std::fs::read_to_string(dir.join("llm_transcript.jsonl")).expect("transcript file");
+    let transcript = std::fs::read_to_string(scratch.path()).expect("transcript file");
     let request = transcript
         .lines()
         .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
         .find(|line| {
             line["type"] == "provider_call_request" && line["model"] == model_marker.as_str()
         })
-        .expect("provider_call_request event");
+        .unwrap_or_else(|| {
+            panic!(
+                "provider_call_request event for model `{model_marker}` not found.\n\
+                 transcript dir: {}\n\
+                 transcript contents:\n{transcript}",
+                scratch.dir.display(),
+            )
+        });
     assert_eq!(request["thinking"]["enabled"], serde_json::json!(true));
     assert_eq!(
         request["thinking"]["budget_tokens"],
         serde_json::json!(2048)
     );
 
-    if let Some(previous) = old_dir {
-        std::env::set_var("HARN_LLM_TRANSCRIPT_DIR", previous);
-    } else {
-        std::env::remove_var("HARN_LLM_TRANSCRIPT_DIR");
-    }
-    let _ = std::fs::remove_dir_all(dir);
     reset_llm_mock_state();
 }
 

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -261,6 +261,16 @@ pub(crate) fn parse_retry_after(msg: &str) -> Option<u64> {
 }
 
 /// Write the full LLM request payload to a JSONL transcript file.
+///
+/// Holds a process-wide mutex around the open + write so concurrent
+/// transcript emitters (parallel tests, multi-tenant agent loops on the
+/// same VM) never produce a torn line. POSIX `O_APPEND` only guarantees
+/// atomicity for writes ≤ `PIPE_BUF` (512 bytes on macOS), and
+/// `provider_call_request` events comfortably exceed that — without
+/// this lock, two simultaneous `writeln!` calls on different `File`
+/// handles for the same path can interleave their bytes mid-line and
+/// produce invalid JSON that downstream readers (and tests) silently
+/// drop.
 pub(super) fn append_llm_transcript_entry(entry: &serde_json::Value) {
     append_llm_transcript_event_log(entry);
     let Some(dir) = current_transcript_dir() else {
@@ -268,15 +278,21 @@ pub(super) fn append_llm_transcript_entry(entry: &serde_json::Value) {
     };
     let _ = std::fs::create_dir_all(&dir);
     let path = format!("{dir}/llm_transcript.jsonl");
-    if let Ok(line) = serde_json::to_string(&entry) {
+    let Ok(line) = serde_json::to_string(&entry) else {
+        return;
+    };
+    static WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
         use std::io::Write;
-        if let Ok(mut f) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-        {
-            let _ = writeln!(f, "{line}");
-        }
+        let _ = f.write_all(line.as_bytes());
+        let _ = f.write_all(b"\n");
     }
 }
 

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -650,42 +650,50 @@ mod tests {
         assert_eq!(messages[0]["role"].as_str(), Some("user"));
     }
 
-    /// Cooperative accept loop: blocks until a client connects or the
-    /// shared `shutdown` flag is set. The shutdown flag is owned by the
-    /// returned [`LlmStub`] guard and flipped on Drop, so the stub thread
-    /// can never outlive the test (replaces the older fixed-deadline loop
-    /// that flaked under heavy CI fan-out).
+    /// Cooperative accept: blocks the stub thread on a real
+    /// `accept()` call until a client connects, then returns the
+    /// stream. Shutdown wakes the thread by self-connecting to the
+    /// listener (see [`LlmStub::drop`]) — when the resulting `accept`
+    /// returns, the shutdown flag is checked and the synthetic stream
+    /// is discarded.
+    ///
+    /// This replaces a previous nonblocking polling loop with a 5ms
+    /// sleep tick. Polling introduced two flake modes under nextest's
+    /// 50× concurrent flake-detection profile: (1) a real client
+    /// connection could land between two polls and reqwest could time
+    /// out on the SYN-ACK before the stub thread woke; (2) under
+    /// heavy CPU contention the 5ms tick could stretch to tens of
+    /// milliseconds, compounding (1). Blocking accept removes the
+    /// scheduling-latency variable entirely.
     fn accept_with_shutdown(
         listener: &std::net::TcpListener,
         label: &str,
         shutdown: &std::sync::atomic::AtomicBool,
     ) -> Option<std::net::TcpStream> {
-        listener
-            .set_nonblocking(true)
-            .expect("set listener nonblocking");
-        loop {
-            if shutdown.load(std::sync::atomic::Ordering::Acquire) {
-                return None;
-            }
-            match listener.accept() {
-                Ok((stream, _)) => {
-                    stream
-                        .set_nonblocking(false)
-                        .expect("restore blocking mode");
-                    stream
-                        .set_read_timeout(Some(std::time::Duration::from_secs(30)))
-                        .ok();
-                    stream
-                        .set_write_timeout(Some(std::time::Duration::from_secs(30)))
-                        .ok();
-                    return Some(stream);
-                }
-                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                    std::thread::sleep(std::time::Duration::from_millis(5));
-                }
-                Err(e) => panic!("{label}: accept failed: {e}"),
-            }
+        let (stream, _peer) = listener
+            .accept()
+            .unwrap_or_else(|e| panic!("{label}: accept failed: {e}"));
+        if shutdown.load(std::sync::atomic::Ordering::Acquire) {
+            drop(stream);
+            return None;
         }
+        stream
+            .set_read_timeout(Some(std::time::Duration::from_secs(30)))
+            .ok();
+        stream
+            .set_write_timeout(Some(std::time::Duration::from_secs(30)))
+            .ok();
+        Some(stream)
+    }
+
+    /// Wake a stub thread blocked in [`accept_with_shutdown`] by
+    /// opening a one-shot self-connection to its listener. The thread
+    /// then observes the shutdown flag and exits without serving the
+    /// connection. The connect uses a short timeout so a deferred
+    /// shutdown (e.g. drop during panic unwind on a saturated CI
+    /// worker) cannot wedge the test process.
+    fn wake_accept_for_shutdown(addr: std::net::SocketAddr) {
+        let _ = std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(500));
     }
 
     /// RAII guard for an in-process LLM stub. Dropping signals the stub
@@ -695,6 +703,11 @@ mod tests {
         addr: std::net::SocketAddr,
         shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
         handle: Option<std::thread::JoinHandle<()>>,
+        /// Maximum number of `accept()` calls the stub thread can be
+        /// parked on. Single-shot stubs use 1; `spawn_llm_stub_many`
+        /// uses its connection count. Drop fires that many self-
+        /// connections so every parked accept observes shutdown.
+        pending_accepts: usize,
     }
 
     impl LlmStub {
@@ -707,6 +720,13 @@ mod tests {
         fn drop(&mut self) {
             self.shutdown
                 .store(true, std::sync::atomic::Ordering::Release);
+            // Self-connect to unblock any thread parked inside
+            // `accept_with_shutdown`. Multiple stubs in
+            // `spawn_llm_stub_many` may need waking, so issue one
+            // wake per outstanding accept slot.
+            for _ in 0..self.pending_accepts.max(1) {
+                wake_accept_for_shutdown(self.addr);
+            }
             if let Some(handle) = self.handle.take() {
                 let _ = handle.join();
             }
@@ -735,6 +755,7 @@ mod tests {
             addr,
             shutdown,
             handle: Some(handle),
+            pending_accepts: 1,
         }
     }
 
@@ -760,6 +781,7 @@ mod tests {
             addr,
             shutdown,
             handle: Some(handle),
+            pending_accepts: connections,
         }
     }
 

--- a/crates/harn-vm/src/llm/api/readiness.rs
+++ b/crates/harn-vm/src/llm/api/readiness.rs
@@ -470,13 +470,16 @@ mod tests {
 
     #[tokio::test]
     async fn probe_distinguishes_unreachable() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind");
-        let addr = listener.local_addr().expect("addr");
-        drop(listener);
+        // The earlier "bind ephemeral, drop, probe the same port"
+        // pattern was racy under nextest fan-out: another concurrent
+        // test using `bind 127.0.0.1:0` could be assigned the freed
+        // port between the drop and the probe, making the connection
+        // succeed and the test report a different category. Port 1
+        // (IANA-reserved tcpmux) is always unprivileged-bind-blocked,
+        // so connecting to it yields a deterministic ECONNREFUSED →
+        // "unreachable", with no listener-handoff race.
         let def = ProviderDef {
-            base_url: format!("http://{addr}"),
+            base_url: "http://127.0.0.1:1".to_string(),
             chat_endpoint: "/v1/chat/completions".to_string(),
             healthcheck: Some(HealthcheckDef {
                 method: "GET".to_string(),

--- a/crates/harn-vm/src/llm/cost.rs
+++ b/crates/harn-vm/src/llm/cost.rs
@@ -479,6 +479,10 @@ pub(crate) fn accumulate_cost_for_provider(
     output_tokens: i64,
 ) -> Result<(), VmError> {
     let cost = calculate_cost_for_provider(provider, model, input_tokens, output_tokens);
+    // Always attribute usage to the active `@step` (if any), even when
+    // the per-call cost is zero — token-only step budgets need the
+    // count regardless of pricing.
+    crate::step_runtime::record_step_llm_usage(model, input_tokens, output_tokens, cost)?;
     if cost == 0.0 {
         return Ok(());
     }

--- a/crates/harn-vm/src/llm/healthcheck.rs
+++ b/crates/harn-vm/src/llm/healthcheck.rs
@@ -294,32 +294,22 @@ mod tests {
     ) -> (String, std::thread::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind healthcheck stub");
         let addr = listener.local_addr().expect("stub addr");
-        listener
-            .set_nonblocking(true)
-            .expect("set listener nonblocking");
 
-        // Use a generous deadline so the stub doesn't trip when nextest fans
-        // out across the workspace and starves this thread of CPU. The
-        // healthcheck client itself completes in milliseconds against the
-        // loopback stub once it gets scheduled — the deadline is just an
-        // upper bound to keep a stuck test from hanging forever.
+        // Block on `accept()` directly. The earlier nonblocking poll +
+        // 30s wall-clock deadline introduced two failure modes under
+        // CI fan-out: (1) a 10ms tick stretched under load, delaying
+        // accept past the client's connect timeout; (2) the deadline
+        // wall-clock could elapse before the polling thread woke,
+        // panicking even though the client was already connected.
+        // Blocking accept is deterministic and cannot starve. The
+        // test always sends a request, so the accept always returns;
+        // if a test panics before sending, the leaked thread is
+        // captured by nextest's `leak-timeout = "fail"` rather than
+        // hidden behind a synthetic panic.
         let handle = std::thread::spawn(move || {
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-            let (mut stream, _) = loop {
-                match listener.accept() {
-                    Ok(pair) => break pair,
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        if std::time::Instant::now() >= deadline {
-                            panic!("healthcheck stub: no client within 30s");
-                        }
-                        std::thread::sleep(std::time::Duration::from_millis(10));
-                    }
-                    Err(error) => panic!("healthcheck stub accept failed: {error}"),
-                }
-            };
-            stream
-                .set_nonblocking(false)
-                .expect("set accepted stream blocking");
+            let (mut stream, _) = listener
+                .accept()
+                .unwrap_or_else(|e| panic!("healthcheck stub accept failed: {e}"));
             stream
                 .set_read_timeout(Some(std::time::Duration::from_secs(30)))
                 .ok();

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -567,6 +567,61 @@ fn validate_output_format_supported(
     }
 }
 
+/// Layer the active step's defaults onto the call options dict before
+/// model/provider resolution and budget parsing run. The model override
+/// is a no-op when the user explicitly passed `model:`. The budget
+/// merge is non-destructive: only fields the call site didn't already
+/// set are filled in, so a tighter explicit ceiling always wins.
+fn apply_active_step_defaults(options: &mut Option<BTreeMap<String, VmValue>>) {
+    let user_supplied_model = options
+        .as_ref()
+        .map(|o| o.contains_key("model"))
+        .unwrap_or(false);
+    let step_default = if user_supplied_model {
+        None
+    } else {
+        crate::step_runtime::active_step_model_default()
+    };
+    let step_budget = crate::step_runtime::with_active_step(|step| step.definition.clone())
+        .map(|definition| (definition.max_tokens, definition.max_usd));
+    if step_default.is_none() && step_budget.is_none() {
+        return;
+    }
+    let opts = options.get_or_insert_with(BTreeMap::new);
+    if let Some(model_name) = step_default {
+        opts.insert(
+            "model".to_string(),
+            VmValue::String(std::rc::Rc::from(model_name)),
+        );
+    }
+    if let Some((max_tokens, max_usd)) = step_budget {
+        if max_tokens.is_some() || max_usd.is_some() {
+            // Project the step budget onto `llm_call`'s preflight
+            // budget envelope so the existing accumulator + projection
+            // machinery short-circuits a call that would obviously
+            // exceed the step's ceiling.
+            let mut step_budget_dict: BTreeMap<String, VmValue> = match opts.get("budget") {
+                Some(VmValue::Dict(existing)) => (**existing).clone(),
+                _ => BTreeMap::new(),
+            };
+            if let Some(max_tokens) = max_tokens {
+                step_budget_dict
+                    .entry("max_output_tokens".to_string())
+                    .or_insert_with(|| VmValue::Int(max_tokens as i64));
+            }
+            if let Some(max_usd) = max_usd {
+                step_budget_dict
+                    .entry("max_cost_usd".to_string())
+                    .or_insert_with(|| VmValue::Float(max_usd));
+            }
+            opts.insert(
+                "budget".to_string(),
+                VmValue::Dict(std::rc::Rc::new(step_budget_dict)),
+            );
+        }
+    }
+}
+
 /// Extract all LLM call options from the standard (prompt, system, options) args.
 pub(crate) fn extract_llm_options(
     args: &[VmValue],
@@ -585,6 +640,13 @@ pub(crate) fn extract_llm_options(
     });
     let explicit_options = args.get(2).and_then(|a| a.as_dict()).cloned();
     let options = crate::llm::cost_route::merge_context_options(explicit_options);
+
+    // If we're inside an `@step`-annotated persona function and the
+    // call site didn't pin a model, inherit the step's declared model
+    // and budget. The persona body stays free of "if step == X use
+    // cheap model" branching.
+    let mut options = options;
+    apply_active_step_defaults(&mut options);
 
     let route_policy = parse_route_policy_option(options.as_ref())?;
     let mut provider = vm_resolve_provider(&options);

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -530,6 +530,10 @@ pub fn reset_llm_state() {
     trigger_predicate::reset_trigger_predicate_state();
     capabilities::clear_user_overrides();
     autonomy_budget::reset_autonomy_budget_state();
+    // Per-`@step` registry, active stack, and completed-step log are
+    // thread-local; clear them between runs to prevent stale step
+    // metadata from one program leaking into the next.
+    crate::step_runtime::reset_thread_local_state();
 }
 
 /// Shared implementation of `llm_call` / `llm_call_safe`. Runs the

--- a/crates/harn-vm/src/llm/readiness.rs
+++ b/crates/harn-vm/src/llm/readiness.rs
@@ -371,24 +371,18 @@ mod tests {
     fn spawn_models_stub(status: u16, body: &'static str) -> (String, std::thread::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind models stub");
         let addr = listener.local_addr().expect("stub addr");
+        // Block on `accept()` directly rather than polling. The
+        // earlier 3s wall-clock deadline + 20ms polling sleep was
+        // brittle under nextest's flake-detection profile: another
+        // concurrent test could starve this thread of CPU long
+        // enough for the deadline to elapse before the kernel even
+        // delivered the SYN that the client had already sent.
+        // Blocking accept is deterministic; the test invariably
+        // sends a request, so it returns promptly.
         let handle = std::thread::spawn(move || {
-            listener
-                .set_nonblocking(true)
-                .expect("set listener nonblocking");
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
-            let mut stream = loop {
-                match listener.accept() {
-                    Ok((stream, _)) => break stream,
-                    Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        if std::time::Instant::now() >= deadline {
-                            panic!("models stub: no client within 3s");
-                        }
-                        std::thread::sleep(std::time::Duration::from_millis(20));
-                    }
-                    Err(error) => panic!("models stub: accept failed: {error}"),
-                }
-            };
-            stream.set_nonblocking(false).expect("set stream blocking");
+            let (mut stream, _) = listener
+                .accept()
+                .unwrap_or_else(|e| panic!("models stub: accept failed: {e}"));
             let mut buf = vec![0u8; 4096];
             let n = stream.read(&mut buf).expect("read request");
             let request = String::from_utf8_lossy(&buf[..n]);

--- a/crates/harn-vm/src/receipts/mod.rs
+++ b/crates/harn-vm/src/receipts/mod.rs
@@ -110,6 +110,58 @@ impl Receipt {
     pub fn schema_json() -> Result<JsonValue, serde_json::Error> {
         serde_json::from_str(RECEIPT_SCHEMA_JSON)
     }
+
+    /// Append a `model_calls[]` entry that records the per-step model
+    /// + token + cost breakdown produced by `crates/harn-vm/src/step_runtime.rs`.
+    ///   Used by run-receipt builders (harn-cloud-store, burin-code) so a
+    ///   single canonical envelope carries per-step economics without
+    ///   each consumer reinventing the field layout.
+    pub fn push_step_breakdown(&mut self, summary: &crate::step_runtime::CompletedStep) {
+        let mut entry: BTreeMap<String, JsonValue> = BTreeMap::new();
+        entry.insert("step".to_string(), JsonValue::String(summary.name.clone()));
+        entry.insert(
+            "function".to_string(),
+            JsonValue::String(summary.function.clone()),
+        );
+        if let Some(model) = summary.model.as_deref() {
+            entry.insert("model".to_string(), JsonValue::String(model.to_string()));
+        }
+        entry.insert(
+            "input_tokens".to_string(),
+            JsonValue::Number(summary.input_tokens.into()),
+        );
+        entry.insert(
+            "output_tokens".to_string(),
+            JsonValue::Number(summary.output_tokens.into()),
+        );
+        entry.insert(
+            "llm_calls".to_string(),
+            JsonValue::Number(summary.llm_calls.into()),
+        );
+        entry.insert(
+            "status".to_string(),
+            JsonValue::String(summary.status.clone()),
+        );
+        if let Some(error) = summary.error.as_deref() {
+            entry.insert("error".to_string(), JsonValue::String(error.to_string()));
+        }
+        if summary.cost_usd.is_finite() {
+            if let Some(num) = serde_json::Number::from_f64(summary.cost_usd) {
+                entry.insert("cost_usd".to_string(), JsonValue::Number(num));
+            }
+            self.cost_usd += summary.cost_usd;
+        }
+        self.model_calls.push(entry);
+    }
+
+    /// Drain the per-thread step log into this receipt's `model_calls[]`
+    /// in declaration order. Idempotent: a second call after the
+    /// thread-local has been drained appends nothing.
+    pub fn attach_completed_steps(&mut self) {
+        for summary in crate::step_runtime::drain_completed_steps() {
+            self.push_step_breakdown(&summary);
+        }
+    }
 }
 
 #[async_trait]
@@ -242,6 +294,33 @@ mod tests {
             .as_array()
             .unwrap()
             .contains(&json!("receipt_only")));
+    }
+
+    #[test]
+    fn receipt_attaches_per_step_breakdown_with_aggregated_cost() {
+        let summary = crate::step_runtime::CompletedStep {
+            name: "classify".to_string(),
+            function: "classify_step".to_string(),
+            model: Some("claude-haiku-4-5".to_string()),
+            input_tokens: 5,
+            output_tokens: 5,
+            cost_usd: 0.000_05,
+            llm_calls: 1,
+            status: "completed".to_string(),
+            error: None,
+        };
+        let mut receipt = fixture_receipt();
+        let starting_cost = receipt.cost_usd;
+        receipt.push_step_breakdown(&summary);
+        assert_eq!(receipt.model_calls.len(), 1);
+        let entry = &receipt.model_calls[0];
+        assert_eq!(entry["step"], json!("classify"));
+        assert_eq!(entry["function"], json!("classify_step"));
+        assert_eq!(entry["model"], json!("claude-haiku-4-5"));
+        assert_eq!(entry["input_tokens"], json!(5));
+        assert_eq!(entry["output_tokens"], json!(5));
+        assert_eq!(entry["llm_calls"], json!(1));
+        assert!((receipt.cost_usd - starting_cost - 0.000_05).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -149,6 +149,7 @@ pub fn register_agent_stdlib(vm: &mut Vm) {
     register_llm_builtins(vm);
     register_mcp_builtins(vm);
     register_mcp_server_builtins(vm);
+    crate::step_runtime::register_step_builtins(vm);
 }
 
 /// Register all standard builtins on a VM (core + io + agent).

--- a/crates/harn-vm/src/step_runtime.rs
+++ b/crates/harn-vm/src/step_runtime.rs
@@ -1,0 +1,569 @@
+//! Per-step runtime state for `@step`-annotated persona functions.
+//!
+//! The compiler emits a call to the `__register_step` builtin after each
+//! `@step` declaration so the runtime can dispatch on the step's metadata
+//! when its function is invoked. While a step's frame is on the call
+//! stack, an [`ActiveStep`] entry tracks per-step LLM usage, defaults
+//! `llm_call`'s model when the call site doesn't override it, and bounds
+//! cumulative token and cost spend against the step's budget.
+//!
+//! This module owns three thread-locals (a per-program registry, a stack
+//! of currently-active steps, and a log of completed step summaries) but
+//! exposes only narrow helpers — `current_active_step_*` /
+//! `record_step_llm_usage` / etc. — so the call sites in
+//! `crates/harn-vm/src/llm/`, `crates/harn-vm/src/vm/`, and the compiler
+//! stay focused.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+
+use crate::value::{VmError, VmValue};
+
+fn vm_str(value: &VmValue) -> Option<&str> {
+    match value {
+        VmValue::String(s) => Some(s.as_ref()),
+        _ => None,
+    }
+}
+
+/// Static metadata captured from a `@step(...)` attribute.
+///
+/// Populated by the `__register_step` builtin (see [`register_step_from_dict`])
+/// when the program first runs, then consulted by `llm_call` and the
+/// frame-pop hooks while the step is active.
+#[derive(Debug, Default, Clone)]
+pub struct StepDefinition {
+    pub name: String,
+    pub function: String,
+    pub model: Option<String>,
+    pub max_tokens: Option<u64>,
+    pub max_usd: Option<f64>,
+    /// One of "fail" (default), "continue", "escalate". Drives how a
+    /// `budget_exceeded` error propagating out of the step is handled —
+    /// see `crates/harn-vm/src/vm/execution.rs`.
+    pub error_boundary: Option<String>,
+}
+
+impl StepDefinition {
+    pub fn boundary(&self) -> StepErrorBoundary {
+        match self.error_boundary.as_deref() {
+            Some("continue") => StepErrorBoundary::Continue,
+            Some("escalate") => StepErrorBoundary::Escalate,
+            _ => StepErrorBoundary::Fail,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepErrorBoundary {
+    Fail,
+    Continue,
+    Escalate,
+}
+
+/// Tracks one in-flight step. The `frame_depth` is `Vm::frames.len()`
+/// captured immediately after `push_closure_frame` returns, so an
+/// `ActiveStep` is "alive" while `Vm::frames.len() >= frame_depth`.
+#[derive(Debug, Clone)]
+pub struct ActiveStep {
+    pub frame_depth: usize,
+    pub definition: Rc<StepDefinition>,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cost_usd: f64,
+    pub llm_calls: u32,
+    pub last_model: Option<String>,
+}
+
+impl ActiveStep {
+    fn new(frame_depth: usize, definition: Rc<StepDefinition>) -> Self {
+        Self {
+            frame_depth,
+            definition,
+            input_tokens: 0,
+            output_tokens: 0,
+            cost_usd: 0.0,
+            llm_calls: 0,
+            last_model: None,
+        }
+    }
+
+    fn total_tokens(&self) -> u64 {
+        self.input_tokens.saturating_add(self.output_tokens)
+    }
+}
+
+/// Snapshot persisted into [`COMPLETED_STEPS`] when the step's frame
+/// unwinds. Receipts and `harn persona inspect`-style downstream consumers
+/// read it back via [`drain_completed_steps`].
+#[derive(Debug, Clone, Serialize)]
+pub struct CompletedStep {
+    pub name: String,
+    pub function: String,
+    pub model: Option<String>,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cost_usd: f64,
+    pub llm_calls: u32,
+    pub status: String,
+    pub error: Option<String>,
+}
+
+thread_local! {
+    static STEP_REGISTRY: RefCell<BTreeMap<String, Rc<StepDefinition>>> =
+        const { RefCell::new(BTreeMap::new()) };
+    static STEP_STACK: RefCell<Vec<ActiveStep>> = const { RefCell::new(Vec::new()) };
+    static COMPLETED_STEPS: RefCell<Vec<CompletedStep>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Reset every thread-local owned by this module. Called between test
+/// runs and at the start of each top-level program execution so leftover
+/// registrations don't leak across runs.
+pub fn reset_thread_local_state() {
+    STEP_REGISTRY.with(|r| r.borrow_mut().clear());
+    STEP_STACK.with(|s| s.borrow_mut().clear());
+    COMPLETED_STEPS.with(|c| c.borrow_mut().clear());
+}
+
+/// Bind a `@step` function name to its declared metadata. Idempotent: a
+/// second call replaces the prior definition (matches re-evaluation
+/// semantics of `harn run` and the conformance harness).
+pub fn register_step(function: &str, definition: StepDefinition) {
+    STEP_REGISTRY.with(|registry| {
+        registry
+            .borrow_mut()
+            .insert(function.to_string(), Rc::new(definition));
+    });
+}
+
+/// Builtin entry point invoked by compiler-emitted bytecode after every
+/// `@step` function declaration. Accepts a dict mirroring
+/// `harn_modules::PersonaStepMetadata`.
+pub fn register_step_from_dict(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let function = args
+        .first()
+        .and_then(vm_str)
+        .map(|s| s.to_string())
+        .ok_or_else(|| {
+            VmError::Thrown(VmValue::String(Rc::from(
+                "__register_step: expected (function_name, metadata_dict)",
+            )))
+        })?;
+    let meta = args
+        .get(1)
+        .and_then(VmValue::as_dict)
+        .cloned()
+        .ok_or_else(|| {
+            VmError::Thrown(VmValue::String(Rc::from(
+                "__register_step: metadata argument must be a dict",
+            )))
+        })?;
+
+    let mut definition = StepDefinition {
+        function: function.clone(),
+        ..StepDefinition::default()
+    };
+    definition.name = meta
+        .get("name")
+        .and_then(vm_str)
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| function.clone());
+    definition.model = meta
+        .get("model")
+        .and_then(vm_str)
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty());
+    definition.error_boundary = meta
+        .get("error_boundary")
+        .and_then(vm_str)
+        .map(|s| s.to_string());
+
+    if let Some(VmValue::Dict(budget)) = meta.get("budget") {
+        if let Some(value) = budget.get("max_tokens") {
+            definition.max_tokens = match value {
+                VmValue::Int(n) if *n > 0 => Some(*n as u64),
+                VmValue::Float(f) if f.is_finite() && *f > 0.0 => Some(*f as u64),
+                _ => None,
+            };
+        }
+        if let Some(value) = budget.get("max_usd") {
+            definition.max_usd = match value {
+                VmValue::Float(f) if f.is_finite() && *f >= 0.0 => Some(*f),
+                VmValue::Int(n) if *n >= 0 => Some(*n as f64),
+                _ => None,
+            };
+        }
+    }
+
+    register_step(&function, definition);
+    Ok(VmValue::Nil)
+}
+
+/// Push an active step onto the stack iff `function_name` has metadata
+/// registered. Returns `true` when a frame was pushed so the call site
+/// can record that fact. Called from `Vm::push_closure_frame` after the
+/// new frame has been added.
+pub fn maybe_push_active_step(function_name: &str, frame_depth: usize) -> bool {
+    let definition = STEP_REGISTRY.with(|registry| registry.borrow().get(function_name).cloned());
+    let Some(definition) = definition else {
+        return false;
+    };
+    STEP_STACK.with(|stack| {
+        stack
+            .borrow_mut()
+            .push(ActiveStep::new(frame_depth, definition));
+    });
+    true
+}
+
+/// Drop any step entries whose owning frame has already been unwound,
+/// recording a `CompletedStep` summary for each. The `current_frame_depth`
+/// is `Vm::frames.len()` at the call site — entries with
+/// `frame_depth > current_frame_depth` are stale.
+pub fn prune_below_frame(current_frame_depth: usize) {
+    let mut popped: Vec<ActiveStep> = Vec::new();
+    STEP_STACK.with(|stack| {
+        let mut stack = stack.borrow_mut();
+        while let Some(top) = stack.last() {
+            if top.frame_depth > current_frame_depth {
+                popped.push(stack.pop().unwrap());
+            } else {
+                break;
+            }
+        }
+    });
+    for step in popped {
+        finish_step(step, "completed", None);
+    }
+}
+
+/// Pop the topmost active step (if its frame is the current one) and
+/// record an explicit completion status. Used when an error boundary
+/// rewrites or absorbs an in-flight error so the receipt log reflects the
+/// outcome the persona actually saw.
+pub fn pop_and_record(current_frame_depth: usize, status: &str, error: Option<String>) -> bool {
+    let popped = STEP_STACK.with(|stack| {
+        let mut stack = stack.borrow_mut();
+        if stack
+            .last()
+            .map(|step| step.frame_depth == current_frame_depth)
+            .unwrap_or(false)
+        {
+            stack.pop()
+        } else {
+            None
+        }
+    });
+    let Some(step) = popped else {
+        return false;
+    };
+    finish_step(step, status, error);
+    true
+}
+
+fn finish_step(step: ActiveStep, status: &str, error: Option<String>) {
+    let summary = CompletedStep {
+        name: step.definition.name.clone(),
+        function: step.definition.function.clone(),
+        model: step
+            .last_model
+            .clone()
+            .or_else(|| step.definition.model.clone()),
+        input_tokens: step.input_tokens,
+        output_tokens: step.output_tokens,
+        cost_usd: step.cost_usd,
+        llm_calls: step.llm_calls,
+        status: status.to_string(),
+        error,
+    };
+    COMPLETED_STEPS.with(|completed| completed.borrow_mut().push(summary));
+}
+
+/// Get a snapshot of the topmost active step, if any. Used by the
+/// llm_call path to fill in defaults — never for mutation.
+pub fn with_active_step<R>(f: impl FnOnce(&ActiveStep) -> R) -> Option<R> {
+    STEP_STACK.with(|stack| stack.borrow().last().map(f))
+}
+
+/// Mutate the topmost active step (typically to attribute LLM usage).
+pub fn with_active_step_mut<R>(f: impl FnOnce(&mut ActiveStep) -> R) -> Option<R> {
+    STEP_STACK.with(|stack| stack.borrow_mut().last_mut().map(f))
+}
+
+/// Frame depth of the topmost active step, or `None` when no step is
+/// active. Used by `handle_error` to detect "this throw is exiting a
+/// step's frame".
+pub fn active_step_frame_depth() -> Option<usize> {
+    STEP_STACK.with(|stack| stack.borrow().last().map(|s| s.frame_depth))
+}
+
+/// Default model the topmost active step should impose on `llm_call`
+/// invocations whose options dict didn't pin a model.
+pub fn active_step_model_default() -> Option<String> {
+    STEP_STACK.with(|stack| {
+        stack
+            .borrow()
+            .last()
+            .and_then(|step| step.definition.model.clone())
+    })
+}
+
+/// Record that `llm_call` consumed `input_tokens` / `output_tokens` for
+/// `cost_usd`. Updates the active step's running totals and returns a
+/// budget-exhaustion error if the step's ceiling is now breached.
+///
+/// The check is performed AFTER the call so the test fixture's first
+/// call (which fits under budget) succeeds and subsequent calls trip the
+/// limit. This matches the existing `accumulate_cost_for_provider`
+/// pattern where global budget is also checked post-hoc.
+pub fn record_step_llm_usage(
+    model: &str,
+    input_tokens: i64,
+    output_tokens: i64,
+    cost_usd: f64,
+) -> Result<(), VmError> {
+    let exhausted = STEP_STACK.with(|stack| -> Option<VmError> {
+        let mut stack = stack.borrow_mut();
+        let step = stack.last_mut()?;
+        step.input_tokens = step.input_tokens.saturating_add(input_tokens.max(0) as u64);
+        step.output_tokens = step
+            .output_tokens
+            .saturating_add(output_tokens.max(0) as u64);
+        step.cost_usd += cost_usd;
+        step.llm_calls = step.llm_calls.saturating_add(1);
+        if !model.is_empty() {
+            step.last_model = Some(model.to_string());
+        }
+
+        if let Some(max_tokens) = step.definition.max_tokens {
+            if step.total_tokens() > max_tokens {
+                return Some(budget_exhausted_error(
+                    &step.definition,
+                    "max_tokens",
+                    max_tokens as f64,
+                    step.total_tokens() as f64,
+                    step.cost_usd,
+                ));
+            }
+        }
+        if let Some(max_usd) = step.definition.max_usd {
+            if step.cost_usd > max_usd {
+                return Some(budget_exhausted_error(
+                    &step.definition,
+                    "max_usd",
+                    max_usd,
+                    step.total_tokens() as f64,
+                    step.cost_usd,
+                ));
+            }
+        }
+        None
+    });
+    if let Some(err) = exhausted {
+        return Err(err);
+    }
+    Ok(())
+}
+
+fn budget_exhausted_error(
+    definition: &StepDefinition,
+    limit: &str,
+    limit_value: f64,
+    consumed_tokens: f64,
+    consumed_cost_usd: f64,
+) -> VmError {
+    let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+    dict.insert(
+        "category".to_string(),
+        VmValue::String(Rc::from("budget_exceeded")),
+    );
+    dict.insert(
+        "kind".to_string(),
+        VmValue::String(Rc::from("budget_exhausted")),
+    );
+    dict.insert(
+        "reason".to_string(),
+        VmValue::String(Rc::from("step_budget_exhausted")),
+    );
+    dict.insert(
+        "step".to_string(),
+        VmValue::String(Rc::from(definition.name.clone())),
+    );
+    dict.insert(
+        "function".to_string(),
+        VmValue::String(Rc::from(definition.function.clone())),
+    );
+    dict.insert(
+        "limit".to_string(),
+        VmValue::String(Rc::from(limit.to_string())),
+    );
+    dict.insert("limit_value".to_string(), VmValue::Float(limit_value));
+    dict.insert(
+        "consumed_tokens".to_string(),
+        VmValue::Float(consumed_tokens),
+    );
+    dict.insert(
+        "consumed_cost_usd".to_string(),
+        VmValue::Float(consumed_cost_usd),
+    );
+    dict.insert(
+        "error_boundary".to_string(),
+        VmValue::String(Rc::from(
+            definition
+                .error_boundary
+                .clone()
+                .unwrap_or_else(|| "fail".to_string()),
+        )),
+    );
+    dict.insert(
+        "message".to_string(),
+        VmValue::String(Rc::from(format!(
+            "step `{}` exceeded {} budget ({} > {})",
+            definition.name, limit, consumed_tokens as i64, limit_value as i64
+        ))),
+    );
+    VmError::Thrown(VmValue::Dict(Rc::new(dict)))
+}
+
+/// Returns true if the thrown value looks like a budget-exhausted
+/// error — either our typed step-budget dict or the existing
+/// `crates/harn-vm/src/llm/cost.rs::budget_exceeded_error` shape.
+/// Either form is treated identically by `error_boundary` because the
+/// per-step budget machinery layers onto the existing envelope; a step
+/// whose budget the preflight projection rejects is still a budget
+/// exhaustion the step authored.
+pub fn is_step_budget_exhausted(err: &VmError) -> bool {
+    let VmError::Thrown(VmValue::Dict(dict)) = err else {
+        return false;
+    };
+    let category = dict.get("category").and_then(vm_str);
+    let kind = dict.get("kind").and_then(vm_str);
+    let reason = dict.get("reason").and_then(vm_str);
+    if matches!(kind, Some("budget_exhausted")) && matches!(reason, Some("step_budget_exhausted")) {
+        return true;
+    }
+    matches!(category, Some("budget_exceeded"))
+}
+
+/// Annotate an existing budget-exhausted error with `escalated: true`
+/// and the step's identity so the persona body / handoff receiver can
+/// route on it. Returns the original error if it isn't a thrown dict.
+/// Ensures `step` and `function` keys reflect the just-finished step
+/// even when the underlying error was raised by the preflight budget
+/// machinery (which doesn't know which step it's running under).
+pub fn mark_escalated(err: VmError, step_name: Option<&str>, function: Option<&str>) -> VmError {
+    let VmError::Thrown(VmValue::Dict(dict)) = err else {
+        return err;
+    };
+    let mut next = (*dict).clone();
+    next.insert("escalated".to_string(), VmValue::Bool(true));
+    next.insert(
+        "category".to_string(),
+        VmValue::String(Rc::from("handoff_escalation")),
+    );
+    if let Some(step) = step_name {
+        next.entry("step".to_string())
+            .or_insert_with(|| VmValue::String(Rc::from(step.to_string())));
+    }
+    if let Some(function) = function {
+        next.entry("function".to_string())
+            .or_insert_with(|| VmValue::String(Rc::from(function.to_string())));
+    }
+    VmError::Thrown(VmValue::Dict(Rc::new(next)))
+}
+
+/// Drain the completed-step log. Used by receipt builders that want a
+/// per-step model + token + cost breakdown for the just-finished run.
+pub fn drain_completed_steps() -> Vec<CompletedStep> {
+    COMPLETED_STEPS.with(|completed| std::mem::take(&mut *completed.borrow_mut()))
+}
+
+/// Read the completed-step log without clearing it. Use when callers
+/// want a peek without disturbing the global record stream.
+pub fn peek_completed_steps() -> Vec<CompletedStep> {
+    COMPLETED_STEPS.with(|completed| completed.borrow().clone())
+}
+
+/// Lower a [`CompletedStep`] into JSON for embedding in receipts /
+/// inspect output.
+pub fn completed_step_to_json(step: &CompletedStep) -> JsonValue {
+    serde_json::to_value(step).unwrap_or(JsonValue::Null)
+}
+
+/// Register the `__register_step` host builtin. Compiler-emitted
+/// bytecode after every `@step` declaration calls it with
+/// `(function_name, metadata_dict)` so the runtime can later dispatch on
+/// the step's metadata when its function is invoked.
+pub fn register_step_builtins(vm: &mut crate::vm::Vm) {
+    vm.register_builtin("__register_step", |args, _out| {
+        register_step_from_dict(args.to_vec())
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_state() {
+        reset_thread_local_state();
+    }
+
+    #[test]
+    fn registers_and_pops_step_from_dict() {
+        fresh_state();
+        let mut budget: BTreeMap<String, VmValue> = BTreeMap::new();
+        budget.insert("max_tokens".to_string(), VmValue::Int(100));
+        budget.insert("max_usd".to_string(), VmValue::Float(0.05));
+        let mut meta: BTreeMap<String, VmValue> = BTreeMap::new();
+        meta.insert("name".to_string(), VmValue::String(Rc::from("plan")));
+        meta.insert(
+            "model".to_string(),
+            VmValue::String(Rc::from("claude-haiku-4-5")),
+        );
+        meta.insert(
+            "error_boundary".to_string(),
+            VmValue::String(Rc::from("continue")),
+        );
+        meta.insert("budget".to_string(), VmValue::Dict(Rc::new(budget)));
+
+        register_step_from_dict(vec![
+            VmValue::String(Rc::from("plan_step")),
+            VmValue::Dict(Rc::new(meta)),
+        ])
+        .expect("registration succeeds");
+
+        assert!(maybe_push_active_step("plan_step", 3));
+        assert_eq!(active_step_frame_depth(), Some(3));
+        assert_eq!(
+            active_step_model_default().as_deref(),
+            Some("claude-haiku-4-5")
+        );
+
+        record_step_llm_usage("claude-haiku-4-5", 10, 20, 0.001).expect("under budget");
+        with_active_step(|step| {
+            assert_eq!(step.input_tokens, 10);
+            assert_eq!(step.output_tokens, 20);
+            assert!((step.cost_usd - 0.001).abs() < 1e-9);
+        });
+
+        let err =
+            record_step_llm_usage("claude-haiku-4-5", 50, 50, 0.0).expect_err("should exhaust");
+        assert!(is_step_budget_exhausted(&err));
+
+        prune_below_frame(2);
+        let completed = drain_completed_steps();
+        assert_eq!(completed.len(), 1);
+        assert_eq!(completed[0].llm_calls, 2);
+    }
+
+    #[test]
+    fn unregistered_function_does_not_push() {
+        fresh_state();
+        assert!(!maybe_push_active_step("not_a_step", 1));
+        assert!(active_step_frame_depth().is_none());
+    }
+}

--- a/crates/harn-vm/src/vm/execution.rs
+++ b/crates/harn-vm/src/vm/execution.rs
@@ -50,6 +50,7 @@ impl Vm {
                     self.env = frame.saved_env;
                 }
             }
+            crate::step_runtime::prune_below_frame(self.frames.len());
 
             // Drop deadlines that belonged to unwound frames.
             while self
@@ -150,6 +151,7 @@ impl Vm {
                 if let Some(ref dir) = popped_frame.saved_source_dir {
                     crate::stdlib::set_thread_source_dir(dir);
                 }
+                crate::step_runtime::prune_below_frame(self.frames.len());
 
                 if self.frames.is_empty() {
                     return Ok(val);
@@ -177,6 +179,7 @@ impl Vm {
                         let current_depth = self.frames.len();
                         self.exception_handlers
                             .retain(|h| h.frame_depth <= current_depth);
+                        crate::step_runtime::prune_below_frame(current_depth);
 
                         if self.frames.is_empty() {
                             return Ok(val);
@@ -194,6 +197,20 @@ impl Vm {
                     if self.error_stack_trace.is_empty() {
                         self.error_stack_trace = self.capture_stack_trace();
                     }
+                    // Honor `@step(error_boundary: ...)` if a step-budget
+                    // exhaustion error is propagating out of the step's
+                    // own frame. `continue` swaps the throw for a Nil
+                    // return; `escalate` re-tags the error as a handoff
+                    // escalation and lets the existing exception
+                    // handlers route it.
+                    let e = match self.apply_step_error_boundary(e) {
+                        StepBoundaryOutcome::Returned(val) => {
+                            self.error_stack_trace.clear();
+                            self.stack.push(val);
+                            continue;
+                        }
+                        StepBoundaryOutcome::Throw(err) => err,
+                    };
                     match self.handle_error(e) {
                         Ok(None) => {
                             self.error_stack_trace.clear();
@@ -207,6 +224,102 @@ impl Vm {
         }
     }
 
+    /// Inspect a thrown error against the topmost active step's
+    /// `error_boundary`. Called from the main step loop before
+    /// `handle_error` so that a step's own budget-exhaustion error can be
+    /// short-circuited (`continue`) or annotated (`escalate`) before the
+    /// generic try/catch machinery sees it.
+    pub(crate) fn apply_step_error_boundary(&mut self, error: VmError) -> StepBoundaryOutcome {
+        use crate::step_runtime;
+        if !step_runtime::is_step_budget_exhausted(&error) {
+            return StepBoundaryOutcome::Throw(error);
+        }
+        let Some(step_depth) = step_runtime::active_step_frame_depth() else {
+            return StepBoundaryOutcome::Throw(error);
+        };
+        // The step's frame is the topmost on the call stack iff its
+        // recorded frame_depth equals `frames.len()`. If the throw is
+        // coming from a deeper frame we let it bubble up — the boundary
+        // still applies later when the step's own frame is reached.
+        if step_depth != self.frames.len() {
+            return StepBoundaryOutcome::Throw(error);
+        }
+        let boundary = step_runtime::with_active_step(|step| step.definition.boundary())
+            .unwrap_or(step_runtime::StepErrorBoundary::Fail);
+        match boundary {
+            step_runtime::StepErrorBoundary::Continue => {
+                // Mimic VmError::Return(Nil) for the step's frame: pop
+                // the frame, restore its env/iterators/stack, and feed a
+                // Nil return value back to the caller.
+                if let Some(popped) = self.frames.pop() {
+                    self.release_sync_guards_for_frame(self.frames.len() + 1);
+                    if let Some(ref dir) = popped.saved_source_dir {
+                        crate::stdlib::set_thread_source_dir(dir);
+                    }
+                    let current_depth = self.frames.len();
+                    self.exception_handlers
+                        .retain(|h| h.frame_depth <= current_depth);
+                    step_runtime::pop_and_record(
+                        current_depth + 1,
+                        "skipped",
+                        Some(step_runtime_error_message(&error)),
+                    );
+                    if self.frames.is_empty() {
+                        return StepBoundaryOutcome::Returned(VmValue::Nil);
+                    }
+                    self.iterators.truncate(popped.saved_iterator_depth);
+                    self.env = popped.saved_env;
+                    self.stack.truncate(popped.stack_base);
+                }
+                StepBoundaryOutcome::Returned(VmValue::Nil)
+            }
+            step_runtime::StepErrorBoundary::Escalate => {
+                let identity = step_runtime::with_active_step(|step| {
+                    (
+                        step.definition.name.clone(),
+                        step.definition.function.clone(),
+                    )
+                });
+                step_runtime::pop_and_record(
+                    step_depth,
+                    "escalated",
+                    Some(step_runtime_error_message(&error)),
+                );
+                let (step_name, function) = identity.unzip();
+                StepBoundaryOutcome::Throw(step_runtime::mark_escalated(
+                    error,
+                    step_name.as_deref(),
+                    function.as_deref(),
+                ))
+            }
+            step_runtime::StepErrorBoundary::Fail => {
+                step_runtime::pop_and_record(
+                    step_depth,
+                    "failed",
+                    Some(step_runtime_error_message(&error)),
+                );
+                StepBoundaryOutcome::Throw(error)
+            }
+        }
+    }
+}
+
+fn step_runtime_error_message(error: &VmError) -> String {
+    match error {
+        VmError::Thrown(VmValue::Dict(dict)) => dict
+            .get("message")
+            .map(|v| v.display())
+            .unwrap_or_else(|| error.to_string()),
+        _ => error.to_string(),
+    }
+}
+
+pub(crate) enum StepBoundaryOutcome {
+    Returned(VmValue),
+    Throw(VmError),
+}
+
+impl crate::vm::Vm {
     pub(crate) async fn execute_one_cycle(&mut self) -> Result<Option<(VmValue, bool)>, VmError> {
         if let Some(err) = self.pending_scope_interrupt() {
             match self.handle_error(err) {

--- a/crates/harn-vm/src/vm/scope.rs
+++ b/crates/harn-vm/src/vm/scope.rs
@@ -124,6 +124,13 @@ impl Vm {
             local_scope_depth: 0,
         });
 
+        // If this fn is `@step`-decorated, push an active-step entry so
+        // `llm_call` and the error-boundary unwind path can attribute
+        // tokens, cost, and budget exhaustion to it. The push is keyed
+        // off the function name registered by compiler-emitted
+        // `__register_step` calls.
+        crate::step_runtime::maybe_push_active_step(&closure.func.name, self.frames.len());
+
         Ok(())
     }
 

--- a/crates/harn-vm/tests/builtin_registry_alignment.rs
+++ b/crates/harn-vm/tests/builtin_registry_alignment.rs
@@ -77,6 +77,7 @@ const RUNTIME_ONLY_EXCEPTIONS: &[&str] = &[
     "__memory_summarize",
     "__make_struct",
     "__range__",
+    "__register_step",
     "__select_list",
     "__select_timeout",
     "__select_try",


### PR DESCRIPTION
Closes #1074.

## Summary

`@step` now accepts `model: \"...\"` and `budget: { max_tokens: N, max_usd: N.NN }`. While a step's frame is on the call stack, `llm_call` defaults to the step's model when the call site doesn't pin one, per-step token + cost spend is tracked separately, and the step's `error_boundary` decides what happens when the budget is exhausted (`fail` propagates, `continue` returns nil from the step, `escalate` re-tags the error as a handoff escalation).

A single persona can now mix cheap classification (Haiku), semantic judgment (Sonnet), and frontier escalation (Opus) without hand-rolled routing inside the persona body.

## Implementation

- **Parser** ([statements.rs](crates/harn-parser/src/typechecker/inference/statements.rs)): adds `budget` to `@step`'s known keys + shape validation.
- **harn-modules** ([personas.rs](crates/harn-modules/src/personas.rs)): adds `PersonaStepBudget` to `PersonaStepMetadata` and the AST extractor.
- **Runtime** ([step_runtime.rs](crates/harn-vm/src/step_runtime.rs), new module): three thread-locals — a per-program registry, a stack of currently-active steps keyed by frame depth, and a completed-step log. `Vm::push_closure_frame` pushes an active step when the called function's name has metadata; `run_chunk_ref`'s frame-pop sites prune entries whose owning frame has been unwound.
- **llm_call routing** ([options.rs](crates/harn-vm/src/llm/helpers/options.rs)): `apply_active_step_defaults` layers the step's model + budget onto the options dict before `vm_resolve_*` and the preflight envelope run. Tighter explicit limits always win.
- **Cost accumulator** ([cost.rs](crates/harn-vm/src/llm/cost.rs)): `accumulate_cost_for_provider` also attributes to the active step and raises a typed `budget_exhausted` dict when the step ceiling is breached.
- **Error boundary** ([execution.rs](crates/harn-vm/src/vm/execution.rs)): `apply_step_error_boundary` runs in the main run loop *before* `handle_error`, so a step's own `error_boundary` short-circuits before the generic try/catch machinery sees it. `continue` mirrors the `Op::Return(Nil)` semantics; `escalate` annotates the dict with `category: \"handoff_escalation\"`, `escalated: true`, and the step's identity.
- **Compiler** ([decls.rs](crates/harn-vm/src/compiler/decls.rs)): emits `__register_step(fn_name, meta_dict)` after every `@step` FnDecl so the registry is populated at module-load time.
- **CLI** ([persona.rs](crates/harn-cli/src/commands/persona.rs)): `harn persona inspect` shows the per-step `model`, `budget`, and `error_boundary` in both the human-readable and `--json` outputs (the JSON path serializes the new `budget` field automatically via serde).
- **Receipts** ([receipts/mod.rs](crates/harn-vm/src/receipts/mod.rs)): `Receipt::push_step_breakdown` / `Receipt::attach_completed_steps` lower a `CompletedStep` into a `model_calls[]` entry, so the canonical envelope (#1058) carries the per-step token + cost story without each downstream consumer (harn-cloud, burin-code) reinventing the field layout.

## Test plan

- [x] Conformance: new fixture [conformance/tests/integration/per_step_model_policy.harn](conformance/tests/integration/per_step_model_policy.harn) — three steps with three different models routed via prompt-glob mocks, plus `continue` and `escalate` boundaries on over-budget steps.
- [x] All 790 conformance tests pass (`harn test conformance`).
- [x] All 1702 harn-vm unit tests pass (`cargo test -p harn-vm --lib`); receipts test verifies `push_step_breakdown` aggregates cost; step_runtime tests verify register / push / record / prune.
- [x] `make lint-harn`, `make fmt-harn`, `cargo fmt --check`, `cargo clippy -p harn-vm` all clean.
- [x] Manually verified `harn persona inspect <name> --json` surfaces the new `budget` field on each step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)