### PR TITLE
ci: block retroactive edits to released CHANGELOG sections

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -138,4 +138,19 @@ else
   echo "=== Pre-push: skipping language spec check (no spec changes) ==="
 fi
 
+# Block retroactive edits to released CHANGELOG sections. New entries
+# belong under `## Unreleased` (or the in-progress next-version heading
+# in a release PR), not under a section that already shipped under a tag.
+if hook_paths_match "$changed" '^CHANGELOG\.md$'; then
+  echo "=== Pre-push: checking CHANGELOG for retroactive edits ==="
+  if ! python3 scripts/check_changelog_no_retroactive_edits.py; then
+    echo "" >&2
+    echo "  Bypass for genuine fix-ups (typos, broken links):" >&2
+    echo "    ALLOW_CHANGELOG_RETROACTIVE_EDIT=1 git push" >&2
+    exit 1
+  fi
+else
+  echo "=== Pre-push: skipping CHANGELOG retroactive-edit check (no CHANGELOG.md changes) ==="
+fi
+
 echo "=== Pre-push checks passed. ==="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history + tags so the changelog retroactive-edit check can
+          # traverse BASE..HEAD and inspect commit trailers.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
@@ -91,6 +95,15 @@ jobs:
       - run: make check-docs-snippets
       - run: make lint-test-patterns
       - run: python3 scripts/verify_release_metadata.py
+      - name: Check no retroactive CHANGELOG edits
+        run: |
+          # checkout already fetched full history + tags. Pass the PR base
+          # explicitly so the script doesn't have to guess.
+          base="${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || '' }}"
+          if [ -n "$base" ]; then
+            export CHANGELOG_GUARD_BASE="$base"
+          fi
+          python3 scripts/check_changelog_no_retroactive_edits.py
 
   changes:
     name: Detect code changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ condensed series summaries instead of full per-patch history.
 
 ## Unreleased
 
+### Changed
+
+- **CHANGELOG retroactive-edit guard.** Added
+  `scripts/check_changelog_no_retroactive_edits.py`, wired into the
+  `Rust (lint + test + conformance)` CI job and the pre-push hook. The
+  check fails the PR when a `## vX.Y.Z` section whose tag already exists
+  is modified, comparing the section body against the PR base (or the
+  push upstream locally). New entries belong under `## Unreleased` (or
+  the in-progress next-version heading on a release PR). Bypass with
+  `ALLOW_CHANGELOG_RETROACTIVE_EDIT=1` for genuine fix-ups.
+
 ### Added
 
 - **Merge Captain repair-worker checkpoint contract (#1010).**
@@ -67,6 +78,26 @@ condensed series summaries instead of full per-patch history.
   surfaces each step's `model` + `budget`, and the canonical receipt
   envelope's `model_calls[]` carries the per-step token / cost
   breakdown via `Receipt::push_step_breakdown`.
+
+- **MCP `sampling/createMessage` server-to-client bridge (#874).** When
+  Harn acts as an MCP client (stdio or Streamable HTTP), it now declares
+  the `sampling` capability on `initialize` and accepts inbound
+  `sampling/createMessage` requests from connected servers. Each request
+  is dispatched through the host-call bridge as
+  `("mcp", "sample", {server, params})` so embedders can run their own
+  approval UX, rate-limit by server, or inject `llm_call` overrides
+  (e.g. force `provider`/`model`). On approval the request flows through
+  Harn's regular `extract_llm_options` + `execute_llm_call` boundary —
+  picking up routing, capability gates, mock interception, and budget
+  plumbing — and the response is returned to the originating server as
+  `{role: "assistant", content: {type: "text", text}, model, stopReason}`.
+  Without an installed bridge, sampling requests are declined with a
+  structured `mcp.samplingDeclined` error (code `-32603`) so servers can
+  fall back to a sensible default rather than driving unattended LLM
+  spend. Sampling-side `tools` / `toolChoice` / `thinking` /
+  `modelPreferences` / `stopSequences` / `metadata` are all forwarded
+  through to `llm_call`'s typed boundary so the existing ThinkingConfig
+  (#849) and structured-output paths apply unchanged.
 
 ## v0.7.54
 

--- a/scripts/check_changelog_no_retroactive_edits.py
+++ b/scripts/check_changelog_no_retroactive_edits.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Fail when this commit edits a CHANGELOG.md section for a published version.
+
+A `## vX.Y.Z` heading whose git tag `vX.Y.Z` already exists is "published"
+and must not change. New entries belong under `## Unreleased` (or the next
+unreleased `## vX.Y.Z` heading being prepared in a release PR).
+
+We only flag drift that this PR introduces — pre-existing drift in main is
+left alone. Compares the CHANGELOG body between a base ref (default:
+`merge-base HEAD origin/main`) and HEAD, per `## vX.Y.Z` section.
+
+Bypass for genuine fix-ups (typos, broken links, cleaning up an
+already-merged retroactive entry): either set
+`ALLOW_CHANGELOG_RETROACTIVE_EDIT=1` in the environment, or include a
+`Allow-Retroactive-Changelog: <reason>` trailer in any commit between
+the base and HEAD. The trailer makes the bypass visible in PR review.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG_REL = "CHANGELOG.md"
+
+VERSION_HEADING = re.compile(r"^## v([0-9]+\.[0-9]+\.[0-9]+)$", re.MULTILINE)
+
+
+def section_body(text: str, version: str) -> str | None:
+    match = re.search(
+        rf"(?ms)^## v{re.escape(version)}\n(.*?)(?=^## |\Z)",
+        text,
+    )
+    return match.group(1) if match else None
+
+
+def git_show(ref: str, path: str = CHANGELOG_REL) -> str | None:
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def tag_exists(tag: str) -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}"],
+        cwd=ROOT,
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def commit_messages_since(base: str) -> str:
+    result = subprocess.run(
+        ["git", "log", "--format=%B%x00", f"{base}..HEAD"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout
+    # Shallow-checkout fallback: history between BASE and HEAD isn't
+    # connected (depth-1 clone). Scan a generous window of recent
+    # commits — covers any reasonable PR length without needing the
+    # connecting history.
+    fallback = subprocess.run(
+        ["git", "log", "-50", "--format=%B%x00", "HEAD"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return fallback.stdout if fallback.returncode == 0 else ""
+
+
+def has_bypass_trailer(base: str) -> bool:
+    messages = commit_messages_since(base)
+    return bool(re.search(r"^Allow-Retroactive-Changelog:\s*\S", messages, re.MULTILINE))
+
+
+def resolve_base(base: str | None) -> str:
+    if base:
+        return base
+    env_base = os.environ.get("CHANGELOG_GUARD_BASE")
+    if env_base:
+        return env_base
+    # Default: merge-base with origin/main. Falls back to origin/main if a
+    # merge-base can't be computed (e.g., shallow clone with no shared history).
+    for candidate in ("origin/main", "main"):
+        result = subprocess.run(
+            ["git", "merge-base", "HEAD", candidate],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    return "HEAD~1"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        help="Git ref to compare against (defaults to merge-base with origin/main).",
+    )
+    args = parser.parse_args()
+
+    if os.environ.get("ALLOW_CHANGELOG_RETROACTIVE_EDIT") == "1":
+        print("check_changelog_no_retroactive_edits: bypassed via env var")
+        return 0
+
+    head_text = (ROOT / CHANGELOG_REL).read_text(encoding="utf-8")
+    base = resolve_base(args.base)
+    base_text = git_show(base)
+    if base_text is None:
+        # No base to compare against — nothing to enforce.
+        return 0
+
+    if has_bypass_trailer(base):
+        print(
+            "check_changelog_no_retroactive_edits: bypassed via "
+            "Allow-Retroactive-Changelog trailer"
+        )
+        return 0
+
+    versions = VERSION_HEADING.findall(head_text)
+    drift: list[str] = []
+    for version in versions:
+        tag = f"v{version}"
+        if not tag_exists(tag):
+            continue
+        head_body = section_body(head_text, version)
+        base_body = section_body(base_text, version)
+        if head_body is None or base_body is None:
+            continue
+        if head_body != base_body:
+            drift.append(version)
+
+    if not drift:
+        return 0
+
+    print(
+        "error: CHANGELOG.md sections for already-published versions were modified",
+        f"in this change (compared against {base}):",
+        file=sys.stderr,
+    )
+    for version in drift:
+        print(f"  - v{version}", file=sys.stderr)
+    print(
+        "\nNew entries belong under '## Unreleased' (or the next unreleased '## vX.Y.Z'\n"
+        "heading being prepared in a release PR), not under a section that has\n"
+        "already shipped. Move the entry, or — if this is a deliberate fix-up\n"
+        "(typo / broken link / cleaning up a previously-merged retroactive entry)\n"
+        "— bypass by adding a commit trailer:\n"
+        "    Allow-Retroactive-Changelog: <reason>\n"
+        "or set ALLOW_CHANGELOG_RETROACTIVE_EDIT=1 in the environment.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `scripts/check_changelog_no_retroactive_edits.py` and wires it into the `Rust (lint + test + conformance)` CI job + the pre-push hook. Fails the PR when a `## vX.Y.Z` section whose tag already exists is modified, comparing the section body against the PR base.
- **Drive-by:** moves the #874 MCP `sampling/createMessage` entry that landed retroactively under `## v0.7.53` (in #1151) back to `## Unreleased` — it merged after the v0.7.53 tag and belongs under the next release. This is the exact mistake the guard is designed to prevent.

## Why

Two recently merged PRs (#1151, and #1152/#1154 which I rebased today) added new entries under the most recent already-shipped section instead of under `## Unreleased`. CI never caught it because nothing gated changelog drift relative to the published tag. After the bump, those bullets show up in v0.7.53's notes even though they shipped on main *after* v0.7.53 was tagged.

## Bypass for genuine fix-ups

Two options, both visible:

- **Commit trailer (preferred — visible in PR review):**
  ```
  Allow-Retroactive-Changelog: short reason here
  ```
- **Env var (for local one-offs):**
  ```
  ALLOW_CHANGELOG_RETROACTIVE_EDIT=1 git push
  ```

## Test plan

- [x] `python3 scripts/check_changelog_no_retroactive_edits.py` fails locally with no trailer (caught the v0.7.53 fix-up in this very PR).
- [x] Same script passes once the `Allow-Retroactive-Changelog:` trailer is added.
- [x] Pre-push hook fires only when CHANGELOG.md is in the diff, and otherwise skips cleanly.
- [x] `make lint-actions` clean.
- [ ] CI confirms the new step runs in the `Rust (lint + test + conformance)` job (will see this on the green).