### PR TITLE
Use capability matrix for native tool mode

### DIFF
--- a/conformance/tests/integration/llm_provider_catalog.harn
+++ b/conformance/tests/integration/llm_provider_catalog.harn
@@ -5,7 +5,7 @@ pipeline test(task) {
   let ollama = llm_model_info("ollama:qwen3:30b-a3b")
   assert_eq(ollama.id, "qwen3:30b-a3b")
   assert_eq(ollama.provider, "ollama")
-  assert_eq(ollama.tool_format, "text")
+  assert_eq(ollama.tool_format, "native")
   assert(ollama.auth_available, "ollama should not require API auth")
   let known = llm_known_models()
   assert(len(known.filter({ name -> name == "mid" })) == 1, "known aliases include mid")

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -864,6 +864,46 @@ pub fn reset_all_sinks() {
     }
 }
 
+/// Mirror externally-registered sinks from `source_session_id` onto
+/// `target_session_id` without moving ownership. Transports such as ACP
+/// register sinks on the outer prompt session before a script runs; scripts
+/// may then open a first-class agent transcript and route `agent_loop` events
+/// through that inner id. Mirroring keeps the transport subscribed to the
+/// in-run child transcript while preserving explicit session ids.
+pub fn mirror_session_sinks(source_session_id: &str, target_session_id: &str) {
+    if source_session_id.is_empty() || target_session_id.is_empty() {
+        return;
+    }
+    if source_session_id == target_session_id {
+        return;
+    }
+    let mut reg = external_sinks().write().expect("sink registry poisoned");
+    let Some(source_sinks) = reg.get(source_session_id).cloned() else {
+        return;
+    };
+    let target = reg.entry(target_session_id.to_string()).or_default();
+    #[cfg(test)]
+    {
+        for source in source_sinks {
+            let already_present = target
+                .iter()
+                .any(|existing| Arc::ptr_eq(&existing.sink, &source.sink));
+            if !already_present {
+                target.push(source);
+            }
+        }
+    }
+    #[cfg(not(test))]
+    {
+        for source in source_sinks {
+            let already_present = target.iter().any(|existing| Arc::ptr_eq(existing, &source));
+            if !already_present {
+                target.push(source);
+            }
+        }
+    }
+}
+
 /// Emit an event to external sinks registered for this session. Pipeline
 /// closure subscribers are NOT called by this function — the agent
 /// loop owns that path because it needs its async VM context.
@@ -977,6 +1017,24 @@ mod tests {
         clear_session_sinks("session-a");
         assert_eq!(session_external_sink_count("session-a"), 0);
         assert_eq!(session_external_sink_count("session-b"), 1);
+        reset_all_sinks();
+    }
+
+    #[test]
+    fn newly_opened_child_session_inherits_current_external_sinks() {
+        reset_all_sinks();
+        let delivered = Arc::new(AtomicUsize::new(0));
+        register_sink("outer-session", Arc::new(CountingSink(delivered.clone())));
+        {
+            let _guard = crate::agent_sessions::enter_current_session("outer-session");
+            let inner = crate::agent_sessions::open_or_create(None);
+            assert_ne!(inner, "outer-session");
+            emit_event(&AgentEvent::TurnStart {
+                session_id: inner,
+                iteration: 0,
+            });
+        }
+        assert_eq!(delivered.load(Ordering::SeqCst), 1);
         reset_all_sinks();
     }
 

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -170,6 +170,7 @@ pub fn snapshot(id: &str) -> Option<VmValue> {
 /// re-register — sinks are per-session, owned by the first opener.
 pub fn open_or_create(id: Option<String>) -> String {
     let resolved = id.unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
+    let parent_session = current_session_id();
     let mut was_new = false;
     SESSIONS.with(|s| {
         let mut map = s.borrow_mut();
@@ -191,6 +192,9 @@ pub fn open_or_create(id: Option<String>) -> String {
         map.insert(resolved.clone(), SessionState::new(resolved.clone()));
     });
     if was_new {
+        if let Some(parent) = parent_session.as_deref() {
+            crate::agent_events::mirror_session_sinks(parent, &resolved);
+        }
         try_register_event_log(&resolved);
     }
     resolved

--- a/crates/harn-vm/src/llm/agent/post_turn.rs
+++ b/crates/harn-vm/src/llm/agent/post_turn.rs
@@ -33,6 +33,7 @@
 //!     (bridge messages, watch paths, timer), inject the wake-reason
 //!     feedback message, Continue
 //!   - `AfterCurrentOperation` host messages → Continue
+//!   - native persistent answer after at least one tool action → Break
 //!   - `consecutive_text_only > max_nudges` → final_status=stuck,
 //!     Break
 //!   - action-turn nudge (or custom nudge) injection, Continue
@@ -703,6 +704,27 @@ pub(super) async fn run_post_turn(
         )
         .await?;
         return Ok(IterationOutcome::Continue);
+    }
+
+    let native_answer_after_action = ctx.tool_format == "native"
+        && ctx.persistent
+        && !ctx.daemon
+        && ctx.has_tools
+        && !state.all_tools_used.is_empty()
+        && !call_result.text.trim().is_empty();
+    if native_answer_after_action {
+        emit_post_agent_turn_hook(
+            ctx.session_id,
+            iteration,
+            serde_json::json!({
+                "iteration": iteration,
+                "failed": false,
+                "status": "answered_after_action",
+                "text": call_result.text.clone(),
+            }),
+        )
+        .await?;
+        return Ok(IterationOutcome::Break);
     }
 
     state.consecutive_text_only += 1;

--- a/crates/harn-vm/src/llm/agent/tests/tool_dispatch_categories.rs
+++ b/crates/harn-vm/src/llm/agent/tests/tool_dispatch_categories.rs
@@ -134,6 +134,43 @@ fn tool_call_mock(tool_name: &str, args: serde_json::Value) -> crate::llm::mock:
     }
 }
 
+fn text_mock(text: &str) -> crate::llm::mock::LlmMock {
+    crate::llm::mock::LlmMock {
+        text: text.to_string(),
+        tool_calls: Vec::new(),
+        match_pattern: None,
+        consume_on_match: true,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: None,
+        thinking_summary: None,
+        stop_reason: None,
+        model: "mock".to_string(),
+        provider: None,
+        blocks: None,
+        error: None,
+    }
+}
+
+fn native_read_file_schema() -> serde_json::Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read a file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"}
+                },
+                "required": ["path"]
+            }
+        }
+    })
+}
+
 fn assert_tool_execution_with_category(
     result: &serde_json::Value,
     expected_tool: &str,
@@ -174,6 +211,52 @@ async fn schema_validation_failure_emits_categorized_event() {
     let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
     assert_tool_execution_with_category(&result, "read", ToolCallErrorCategory::SchemaValidation);
 
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn native_persistent_answer_after_successful_tool_does_not_require_done_sentinel() {
+    let _guard = serialize_tests();
+    drain_thread_local_state();
+    reset_llm_mock_state();
+    let path = std::env::temp_dir().join(format!(
+        "harn-native-final-answer-{}-{}.txt",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    std::fs::write(&path, "@burin/tui\n").expect("write temp file");
+
+    crate::llm::mock::push_llm_mock(tool_call_mock(
+        "read_file",
+        json!({"path": path.to_string_lossy().to_string()}),
+    ));
+    crate::llm::mock::push_llm_mock(text_mock("@burin/tui"));
+    crate::llm::mock::push_llm_mock(text_mock("unexpected extra turn"));
+
+    let mut opts = base_opts(vec![
+        json!({"role": "user", "content": "read package name"}),
+    ]);
+    opts.native_tools = Some(vec![native_read_file_schema()]);
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 3;
+    config.tool_format = "native".to_string();
+    config.turn_policy = Some(TurnPolicy {
+        require_action_or_yield: true,
+        allow_done_sentinel: true,
+        max_prose_chars: None,
+    });
+    config.session_id = "test-native-final-after-tool".to_string();
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    let calls = get_llm_mock_calls();
+    assert_eq!(calls.len(), 2, "native final answer should stop the loop");
+    assert_eq!(result["text"].as_str(), Some("@burin/tui"));
+
+    let _ = std::fs::remove_file(path);
     reset_llm_mock_state();
 }
 

--- a/crates/harn-vm/src/llm/agent/tests/tool_dispatch_categories.rs
+++ b/crates/harn-vm/src/llm/agent/tests/tool_dispatch_categories.rs
@@ -219,14 +219,8 @@ async fn native_persistent_answer_after_successful_tool_does_not_require_done_se
     let _guard = serialize_tests();
     drain_thread_local_state();
     reset_llm_mock_state();
-    let path = std::env::temp_dir().join(format!(
-        "harn-native-final-answer-{}-{}.txt",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos()
-    ));
+    let temp_file = tempfile::NamedTempFile::new().expect("create temp file");
+    let path = temp_file.path().to_path_buf();
     std::fs::write(&path, "@burin/tui\n").expect("write temp file");
 
     crate::llm::mock::push_llm_mock(tool_call_mock(

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -531,7 +531,17 @@ pub fn alias_entries() -> Vec<(String, AliasDef)> {
 
 /// Return every configured model-catalog entry, sorted by provider then id.
 pub fn model_catalog_entries() -> Vec<(String, ModelDef)> {
-    let mut entries: Vec<_> = effective_config().models.into_iter().collect();
+    let mut entries: Vec<_> = effective_config()
+        .models
+        .into_iter()
+        .map(|(id, model)| {
+            let provider = model.provider.clone();
+            (
+                id.clone(),
+                with_effective_capability_tags(id, provider, model),
+            )
+        })
+        .collect();
     entries.sort_by(|(id_a, model_a), (id_b, model_b)| {
         model_a
             .provider
@@ -542,7 +552,14 @@ pub fn model_catalog_entries() -> Vec<(String, ModelDef)> {
 }
 
 pub fn model_catalog_entry(model_id: &str) -> Option<ModelDef> {
-    effective_config().models.get(model_id).cloned()
+    effective_config()
+        .models
+        .get(model_id)
+        .cloned()
+        .map(|model| {
+            let provider = model.provider.clone();
+            with_effective_capability_tags(model_id.to_string(), provider, model)
+        })
 }
 
 pub fn qc_default_model(provider: &str) -> Option<String> {
@@ -614,7 +631,7 @@ pub fn available_provider_names() -> Vec<String> {
         .collect()
 }
 
-/// Check if a provider advertises a feature (e.g., "native_tools").
+/// Check if a provider advertises a legacy provider-level feature.
 pub fn provider_has_feature(provider: &str, feature: &str) -> bool {
     provider_config(provider)
         .map(|p| p.features.iter().any(|f| f == feature))
@@ -631,7 +648,8 @@ pub fn provider_economics(provider: &str) -> (Option<f64>, Option<f64>, Option<u
 }
 
 /// Resolve the default tool format for a model+provider combination.
-/// Priority: alias `tool_format` (matched by model ID) > provider feature > "text".
+/// Priority: alias `tool_format` (matched by model ID) > provider/model
+/// capability matrix > legacy provider feature > "text".
 pub fn default_tool_format(model: &str, provider: &str) -> String {
     let config = effective_config();
     default_tool_format_with_config(&config, model, provider)
@@ -651,16 +669,73 @@ fn default_tool_format_with_config(
             }
         }
     }
-    if config
+    let capability_matrix_native = crate::llm::capabilities::lookup(provider, model).native_tools;
+    let legacy_provider_native = config
         .providers
         .get(provider)
         .map(|p| p.features.iter().any(|f| f == "native_tools"))
-        .unwrap_or(false)
-    {
+        .unwrap_or(false);
+    if capability_matrix_native || legacy_provider_native {
         "native".to_string()
     } else {
         "text".to_string()
     }
+}
+
+fn with_effective_capability_tags(
+    model_id: String,
+    provider: String,
+    mut model: ModelDef,
+) -> ModelDef {
+    model.capabilities = effective_model_capability_tags(&provider, &model_id);
+    model
+}
+
+/// Legacy display tags derived from the canonical provider/model capability
+/// matrix. The matrix is the source of truth; `models.*.capabilities` in
+/// providers.toml is accepted only for backwards-compatible parsing.
+pub fn effective_model_capability_tags(provider: &str, model_id: &str) -> Vec<String> {
+    let caps = crate::llm::capabilities::lookup(provider, model_id);
+    let mut tags = Vec::new();
+    // Today all Harn chat providers expose streaming. Keep this as a
+    // transport baseline rather than a duplicated per-model declaration.
+    tags.push("streaming".to_string());
+    if caps.native_tools {
+        tags.push("tools".to_string());
+    }
+    if !caps.tool_search.is_empty() {
+        tags.push("tool_search".to_string());
+    }
+    if caps.vision || caps.vision_supported {
+        tags.push("vision".to_string());
+    }
+    if caps.audio {
+        tags.push("audio".to_string());
+    }
+    if caps.pdf {
+        tags.push("pdf".to_string());
+    }
+    if caps.files_api_supported {
+        tags.push("files".to_string());
+    }
+    if caps.prompt_caching {
+        tags.push("prompt_caching".to_string());
+    }
+    if !caps.thinking_modes.is_empty() {
+        tags.push("thinking".to_string());
+    }
+    if caps.interleaved_thinking_supported
+        || caps
+            .thinking_modes
+            .iter()
+            .any(|mode| mode == "adaptive" || mode == "effort")
+    {
+        tags.push("extended_thinking".to_string());
+    }
+    if caps.json_schema.is_some() {
+        tags.push("structured_output".to_string());
+    }
+    tags
 }
 
 /// Resolve a tier or alias into a concrete model/provider pair.
@@ -1806,6 +1881,17 @@ mod tests {
     }
 
     #[test]
+    fn test_default_tool_format_uses_capability_matrix() {
+        reset_overrides();
+
+        assert_eq!(
+            default_tool_format("qwen3.6-35b-a3b-ud-q4-k-xl", "llamacpp"),
+            "native"
+        );
+        assert_eq!(default_tool_format("gemma-4-26b-a4b-it", "local"), "text");
+    }
+
+    #[test]
     fn test_user_overrides_add_model_catalog_pricing_and_qc_defaults() {
         reset_overrides();
         let mut overlay = ProvidersConfig::default();
@@ -1832,6 +1918,7 @@ mod tests {
 
         let entry = model_catalog_entry("acme/model-fast").expect("catalog entry");
         assert_eq!(entry.context_window, 65_536);
+        assert_eq!(entry.capabilities, vec!["streaming".to_string()]);
         assert_eq!(
             entry.pricing.as_ref().map(|pricing| pricing.input_per_mtok),
             Some(1.25)

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -89,6 +89,15 @@ if "bm25" in caps.tool_search {
 }
 ```
 
+The same matrix is the source of truth for Harn's default tool-calling
+mode. Alias-level `tool_format` still wins when set explicitly, but
+otherwise a matrix row with `native_tools = true` makes
+`agent_loop()` and `model-info` choose native provider tools for that
+provider/model route. Model-catalog display tags are derived from this
+matrix too; legacy `models.*.capabilities` entries are parsed for
+backwards compatibility but do not override runtime capability
+resolution.
+
 Projects override or extend the shipped table in `harn.toml` — useful
 for flagging a proxied OpenAI-compat endpoint as supporting
 `tool_search` ahead of a Harn release that knows about it natively:


### PR DESCRIPTION
## Summary
- Make the provider/model capability matrix the source of truth for default native/text tool mode and model catalog capability tags.
- Stop native persistent agent loops after a plain final answer once at least one tool action has run, so native tool transcripts do not require a DONE sentinel after successful action.
- Mirror external AgentEvent sinks from an outer transport session to newly opened child agent sessions so ACP clients receive canonical tool_call/tool_call_update lifecycle events.
- Document the capability matrix ownership and add regression coverage for native final-answer and sink mirroring behavior.

## Verification
- cargo test -p harn-vm llm_config::tests -- --nocapture
- cargo test -p harn-vm llm::capabilities::tests -- --nocapture
- cargo test -p harn-vm llm::agent::tests::tool_dispatch_categories -- --nocapture
- cargo test -p harn-vm agent_events::tests -- --nocapture
- cargo test -p harn-vm --test agent_sessions -- --nocapture
- cargo build -p harn-cli
- pre-commit hook: cargo clippy --workspace --all-targets -- -D warnings; markdownlint
- pre-push hook: nextest 3225 tests passed; markdownlint
- Live Burin TUI native smoke against local llamacpp-qwen3.6-q4: final stdout @burin/tui; Harn resolved tool_format native and emitted canonical tool lifecycle into the TUI