### PR TITLE
test: stop pre-existing MCP/long-running test flakes

### DIFF
--- a/crates/harn-cli/src/commands/mcp/serve.rs
+++ b/crates/harn-cli/src/commands/mcp/serve.rs
@@ -3686,6 +3686,11 @@ version = "0.1.0"
     #[tokio::test(flavor = "current_thread")]
     async fn oauth_metadata_and_challenge_are_served_when_configured() {
         let _env_lock = lock_env().lock().await;
+        // Acquire the harn-state lock BEFORE setting env vars. Rust drops
+        // bindings in reverse declaration order, so env vars must be
+        // declared *after* the lock to be cleared before another test
+        // can acquire `lock_harn_state()` and read leaked OAuth config.
+        let _guard = lock_harn_state();
         let _auth_servers = ScopedEnvVar::set(
             "HARN_MCP_OAUTH_AUTHORIZATION_SERVERS",
             "https://auth.example.test",
@@ -3699,8 +3704,6 @@ version = "0.1.0"
         let _audience =
             ScopedEnvVar::set("HARN_MCP_OAUTH_AUDIENCE", "https://mcp.example.test/mcp");
         let _scopes = ScopedEnvVar::set("HARN_MCP_OAUTH_SCOPES", "harn:mcp");
-
-        let _guard = lock_harn_state();
         let temp = TempDir::new().unwrap();
         write_fixture(&temp);
         let args = fixture_args(&temp);
@@ -3810,6 +3813,11 @@ version = "0.1.0"
         });
 
         let _env_lock = lock_env().lock().await;
+        // Acquire the harn-state lock BEFORE setting env vars so they
+        // are dropped (cleared) before another test can re-enter the
+        // lock — see the matching comment in
+        // `oauth_metadata_and_challenge_are_served_when_configured`.
+        let _guard = lock_harn_state();
         let auth_server_url = format!("http://{auth_addr}");
         let introspection_url = format!("{auth_server_url}/introspect");
         let _auth_servers =
@@ -3819,8 +3827,6 @@ version = "0.1.0"
         let _audience = ScopedEnvVar::set("HARN_MCP_OAUTH_AUDIENCE", "mcp://harn-test");
         let _scopes = ScopedEnvVar::set("HARN_MCP_OAUTH_SCOPES", "harn:mcp");
         let _resource = ScopedEnvVar::set("HARN_MCP_OAUTH_RESOURCE", "mcp://harn-test");
-
-        let _guard = lock_harn_state();
         let temp = TempDir::new().unwrap();
         write_fixture(&temp);
         let args = fixture_args(&temp);

--- a/crates/harn-cli/src/tests/common/harn_state_lock.rs
+++ b/crates/harn-cli/src/tests/common/harn_state_lock.rs
@@ -2,12 +2,17 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 
 static HARN_STATE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
-/// Process-global env vars that point harn_vm at a specific state dir.
-/// Any test that leaves these set leaks its (now-deleted) `TempDir`
-/// path into subsequent tests' `install_default_for_base_dir(base_dir)`
-/// calls because `state_root()` / `event_log_*` resolvers honor an
-/// absolute env-var value over the supplied `base_dir`, silently
-/// pointing every test at the same stale SQLite file.
+/// Process-global env vars that point harn_vm at a specific state dir
+/// or flip the MCP serve auth posture. Any test that leaves these set
+/// leaks state into subsequent tests:
+/// - State-dir vars leak the previous test's (now-deleted) `TempDir`
+///   path into `install_default_for_base_dir(base_dir)` because
+///   `state_root()` / `event_log_*` resolvers honor an absolute env-var
+///   value over the supplied `base_dir`.
+/// - `HARN_MCP_OAUTH_*` vars flip `McpOrchestratorService::new_local`
+///   into OAuth-required mode, so a test that constructs a service
+///   while a previous OAuth test's env is still live receives 401 on
+///   every unauthenticated request.
 const LEAKY_STATE_ENV_VARS: &[&str] = &[
     harn_vm::runtime_paths::HARN_STATE_DIR_ENV,
     harn_vm::runtime_paths::HARN_RUN_DIR_ENV,
@@ -16,6 +21,11 @@ const LEAKY_STATE_ENV_VARS: &[&str] = &[
     harn_vm::event_log::HARN_EVENT_LOG_DIR_ENV,
     harn_vm::event_log::HARN_EVENT_LOG_SQLITE_PATH_ENV,
     harn_vm::event_log::HARN_EVENT_LOG_QUEUE_DEPTH_ENV,
+    "HARN_MCP_OAUTH_AUTHORIZATION_SERVERS",
+    "HARN_MCP_OAUTH_INTROSPECTION_URL",
+    "HARN_MCP_OAUTH_RESOURCE",
+    "HARN_MCP_OAUTH_AUDIENCE",
+    "HARN_MCP_OAUTH_SCOPES",
 ];
 
 /// Serialize tests that mutate harn_vm process-global state.

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -87,7 +87,7 @@ pub use llm::register_llm_builtins;
 pub use llm::trigger_predicate::TriggerPredicateBudget;
 pub use llm::{
     current_agent_session_id, drain_global_pending_feedback, push_pending_feedback_global,
-    register_session_end_hook,
+    register_session_end_hook, wait_for_global_pending_feedback,
 };
 pub use mcp::{
     connect_mcp_server, connect_mcp_server_from_json, connect_mcp_server_from_spec,

--- a/crates/harn-vm/src/llm/agent/mod.rs
+++ b/crates/harn-vm/src/llm/agent/mod.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, Condvar, LazyLock, Mutex};
+use std::time::Duration;
 
 use crate::agent_events::{self, AgentEvent, AgentEventSink};
 use crate::value::{VmError, VmValue};
@@ -56,6 +57,12 @@ type SessionEndHook = Arc<dyn Fn(&str) + Send + Sync>;
 /// and the thread-local `PENDING_FEEDBACK` at each preflight boundary.
 static GLOBAL_PENDING_FEEDBACK: LazyLock<Mutex<Vec<(String, String, String)>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
+/// Paired notifier so test helpers can wait for new entries without
+/// polling `Instant::now()` + `thread::sleep`. `push_pending_feedback_global`
+/// notifies after pushing; `wait_for_global_pending_feedback` parks on
+/// this condvar with a timeout. Production drain paths don't observe it
+/// because the turn-loop already runs at every preflight boundary.
+static GLOBAL_PENDING_FEEDBACK_CV: LazyLock<Condvar> = LazyLock::new(Condvar::new);
 
 /// Registry of hooks called when an agent-loop session ends (normally or via
 /// budget exhaustion). Each hook receives the session_id so it can release
@@ -188,6 +195,46 @@ pub fn push_pending_feedback_global(session_id: &str, kind: &str, content: &str)
             kind.to_string(),
             content.to_string(),
         ));
+    }
+    GLOBAL_PENDING_FEEDBACK_CV.notify_all();
+}
+
+/// Test/integration helper: block (with timeout) until at least one
+/// item with `session_id` is queued in the global pending-feedback
+/// queue, then return without draining. Designed to replace
+/// `Instant::now()` + `thread::sleep` polling loops in tests that
+/// observe background-thread feedback. Returns `true` if an item with
+/// the matching session_id appeared before the timeout, `false` on
+/// timeout. Spurious wake-ups are absorbed by re-checking the queue
+/// inside the wait loop.
+pub fn wait_for_global_pending_feedback(session_id: &str, timeout: Duration) -> bool {
+    let Ok(mut guard) = GLOBAL_PENDING_FEEDBACK.lock() else {
+        return false;
+    };
+    if guard.iter().any(|(sid, _, _)| sid == session_id) {
+        return true;
+    }
+    let start = std::time::Instant::now();
+    loop {
+        let remaining = match timeout.checked_sub(start.elapsed()) {
+            Some(remaining) if !remaining.is_zero() => remaining,
+            _ => return guard.iter().any(|(sid, _, _)| sid == session_id),
+        };
+        let (next_guard, wait_result) =
+            match GLOBAL_PENDING_FEEDBACK_CV.wait_timeout(guard, remaining) {
+                Ok(pair) => pair,
+                Err(poison) => {
+                    let pair = poison.into_inner();
+                    (pair.0, pair.1)
+                }
+            };
+        guard = next_guard;
+        if guard.iter().any(|(sid, _, _)| sid == session_id) {
+            return true;
+        }
+        if wait_result.timed_out() {
+            return false;
+        }
     }
 }
 

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -482,7 +482,7 @@ pub(crate) use self::agent::parse_skill_match_config_public as parse_skill_match
 pub(crate) use self::agent::SkillMatchConfig;
 pub use self::agent::{
     current_agent_session_id, drain_global_pending_feedback, push_pending_feedback_global,
-    register_session_end_hook,
+    register_session_end_hook, wait_for_global_pending_feedback,
 };
 pub(crate) use self::agent::{
     current_host_bridge, emit_agent_event as emit_live_agent_event, parse_mcp_server_specs,

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -188,6 +188,17 @@ pub fn stdlib_builtin_names() -> Vec<String> {
 }
 
 /// Reset thread-local stdlib state. Call between test runs.
+///
+/// Note: `long_running::reset_state()` is intentionally NOT called here
+/// because that store is process-global, not thread-local. Wiping it
+/// from a per-test reset hook lets one test cancel another test's
+/// in-flight worker thread (and lose its `push_pending_feedback_global`
+/// notification), which surfaces as `walk_dir_long_running` /
+/// `glob_long_running` timing out under parallel test load. The two
+/// call sites that genuinely need a clean handle store —
+/// `stdlib::fs::tests::{walk_dir_long_running,glob_long_running}` — call
+/// `long_running::reset_state()` explicitly while holding
+/// `LONG_RUNNING_TEST_LOCK`.
 pub fn reset_stdlib_state() {
     logging::reset_logging_state();
     process::reset_process_state();
@@ -195,7 +206,6 @@ pub fn reset_stdlib_state() {
     io::reset_io_state();
     sandbox::reset_sandbox_state();
     fs::reset_fs_state();
-    long_running::reset_state();
     json::reset_json_state();
     host::reset_host_state();
     crate::egress::reset_egress_policy_for_host();

--- a/crates/harn-vm/src/stdlib/fs.rs
+++ b/crates/harn-vm/src/stdlib/fs.rs
@@ -751,9 +751,15 @@ mod tests {
     }
 
     fn drain_feedback(handle_id: &str) -> serde_json::Value {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        // Cap total wait at 10s; each iteration parks on the
+        // condvar paired with `GLOBAL_PENDING_FEEDBACK` so we wake the
+        // moment a background thread pushes, instead of polling
+        // `Instant::now()` + sleeping. The outer loop accounts for items
+        // that arrive for *other* handles (we requeue them via the
+        // `seen_handles` log; long-running ops use session_id="" today).
+        let overall_deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
         let mut seen_handles = Vec::new();
-        while std::time::Instant::now() < deadline {
+        loop {
             for (kind, content) in crate::llm::drain_global_pending_feedback("") {
                 assert_eq!(kind, "tool_result");
                 let payload: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -764,9 +770,34 @@ mod tests {
                     seen_handles.push(seen.to_string());
                 }
             }
-            std::thread::sleep(std::time::Duration::from_millis(20));
+            let remaining = overall_deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                panic!(
+                    "timed out waiting for feedback for {handle_id}; saw handles {seen_handles:?}"
+                );
+            }
+            // Block until a producer notifies a push, or we hit the
+            // remaining deadline. `wait_for_global_pending_feedback`
+            // returns `false` only when nothing matched within the
+            // window; we still loop once more to drain any stragglers
+            // that arrived just before the timeout.
+            if !crate::llm::wait_for_global_pending_feedback("", remaining) {
+                let leftover = crate::llm::drain_global_pending_feedback("");
+                for (kind, content) in leftover {
+                    assert_eq!(kind, "tool_result");
+                    let payload: serde_json::Value = serde_json::from_str(&content).unwrap();
+                    if payload["handle_id"] == handle_id {
+                        return payload;
+                    }
+                    if let Some(seen) = payload["handle_id"].as_str() {
+                        seen_handles.push(seen.to_string());
+                    }
+                }
+                panic!(
+                    "timed out waiting for feedback for {handle_id}; saw handles {seen_handles:?}"
+                );
+            }
         }
-        panic!("timed out waiting for feedback for {handle_id}; saw handles {seen_handles:?}");
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/long_running.rs
+++ b/crates/harn-vm/src/stdlib/long_running.rs
@@ -210,6 +210,14 @@ pub(crate) fn register_cleanup_hook() {
     });
 }
 
+/// Cancel every in-flight long-running handle and clear the registry.
+///
+/// Used only by the long-running fs/glob tests to start each test from
+/// a clean store. Production callers must NOT use this — it wipes
+/// process-global state shared across threads. Removed from
+/// `reset_stdlib_state` so other tests can't accidentally cancel a
+/// concurrent fs/glob worker thread mid-flight.
+#[cfg(test)]
 pub(crate) fn reset_state() {
     let entries = {
         let mut store = HANDLE_STORE


### PR DESCRIPTION
## Summary

Three pre-existing parallel-test races in the harn-cli/harn-vm test suite caused intermittent failures that surfaced while running the full suite. None of them depend on this PR — they all reproduce on `main` — but they made `cargo test --workspace` unreliable.

## What's wrong, and how each is fixed

### 1. OAuth env vars leaked between MCP serve tests

`oauth_metadata_and_challenge_are_served_when_configured` and `oauth_introspection_accepts_valid_token_and_rejects_wrong_audience` declared `let _auth_servers = ScopedEnvVar::set(...)` *before* `let _guard = lock_harn_state()`. Rust drops bindings in reverse declaration order, so `lock_harn_state()` was released *before* the env vars were cleared. A test waiting on `lock_harn_state()` would then acquire it, build an `McpOrchestratorService` while the OAuth env vars were still live, and fail with `401` instead of `200` — exactly the `streamable_http_endpoint_supports_sse_get_delete_and_session_headers` and `legacy_sse_routes_are_marked_deprecated` failures.

**Fix:** reorder the bindings so `lock_harn_state()` is acquired first (and released last). Also extend `LEAKY_STATE_ENV_VARS` to clear the five `HARN_MCP_OAUTH_*` env vars on lock entry, so any future leak self-recovers.

### 2. `Instant::now()` + `thread::sleep` polling in long-running fs tests

`stdlib::fs::tests::{walk_dir,glob}_long_running_returns_handle_and_feedback` used a 10-second deadline + 20ms sleep loop to poll the global `GLOBAL_PENDING_FEEDBACK` queue. CLAUDE.md explicitly bans this pattern; `make lint-test-patterns` doesn't catch it because the inline tests live in `crates/harn-vm/src/stdlib/fs.rs`, not under a `tests/` directory.

**Fix:** pair `GLOBAL_PENDING_FEEDBACK` with a `Condvar`, notify on every `push_pending_feedback_global`, and expose a public `wait_for_global_pending_feedback(session_id, timeout)` helper so the tests park on the condvar instead of polling. The drain helper now wakes the moment a producer notifies, with no measurable wall-clock dependency.

### 3. `long_running::reset_state()` cancelled cross-test workers

`reset_stdlib_state()` (called by `reset_thread_local_state()`, itself called by ~50 tests) wiped the process-global `HANDLE_STORE` and set every entry's `cancel` flag. When test A spawned a long-running fs/glob worker and test B (on a different runner thread) ran any cleanup in parallel, B's `reset_thread_local_state` cancelled A's worker. A then returned without pushing feedback and timed out with `saw handles []`.

**Fix:** remove `long_running::reset_state()` from `reset_stdlib_state()`. Only the two long-running fs tests genuinely need a clean handle store, and they already call `reset_state()` explicitly while holding `LONG_RUNNING_TEST_LOCK`. Gate the function with `#[cfg(test)]` so production code can't accidentally re-introduce the cross-thread wipe.

## What's NOT fixed here

A separate `commands::mcp::serve::tests::dlq_tools_roundtrip_and_resource_read` flake remains (~1/15 runs). Symptom: `event log was not installed during VM initialization`. That's an event-log VM-install race rooted in MCP serve's per-test event-log construction path, unrelated to env-var leakage or long-running handle cancellation. Tracking it here would balloon scope.

## Test plan

- [x] OAuth tests: `cargo test -p harn-cli --lib commands::mcp::serve::tests` — 19/19 pass, repeatedly. Previously failed reproducibly under parallel run.
- [x] Long-running fs tests: 15 back-to-back `cargo test --workspace --lib --bins` runs — `walk_dir`/`glob` long-running tests pass in 15/15 runs (previously failed in 3/6 due to cross-test handle cancellation).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `make lint-test-patterns` clean.