### PR TITLE
Ensure final prose after text tool actions

### DIFF
--- a/crates/harn-vm/src/llm/agent/helpers.rs
+++ b/crates/harn-vm/src/llm/agent/helpers.rs
@@ -166,7 +166,7 @@ pub(crate) fn action_turn_nudge(
     let completion_clause = if has_tools && policy.allow_done_sentinel && tool_format == "native" {
         "either make concrete progress with the provider tool channel, switch phase, or include `##DONE##` exactly once if the task is genuinely complete."
     } else if has_tools && policy.allow_done_sentinel {
-        "either make concrete progress with a well-formed <tool_call> block, switch phase, or emit a <done> block if the task is genuinely complete."
+        "either make concrete progress with a well-formed <tool_call> block, switch phase, or emit <user_response>final answer</user_response> plus a <done> block if the task is genuinely complete."
     } else if has_tools {
         "either make concrete progress with a well-formed <tool_call> block or switch phase if the workflow allows it."
     } else if policy.allow_done_sentinel {

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -74,6 +74,7 @@ pub(super) struct LlmCallResult {
     pub tool_parse_errors: Vec<String>,
     pub canonical_history: Option<String>,
     pub prose_too_long: bool,
+    pub recoverable_bare_final_response: bool,
     pub sentinel_hit: bool,
     pub input_tokens: i64,
     pub output_tokens: i64,
@@ -401,6 +402,16 @@ pub(super) async fn run_llm_call(
     };
     let prose_too_long = prose_exceeds_budget(&text_prose, ctx.turn_policy);
     let shaped_text_prose = trim_prose_for_history(&text_prose, ctx.turn_policy);
+    let recoverable_bare_final_response = is_recoverable_bare_final_response(
+        &text,
+        ctx.has_tools,
+        ctx.tool_format,
+        &tool_calls,
+        &tool_parse_errors,
+        &protocol_violations,
+        tagged_done_marker.as_deref(),
+        user_response.as_deref(),
+    );
     let interpreted_call_id = format!("iteration-{iteration}");
     dump_llm_interpreted_response(
         iteration,
@@ -427,6 +438,7 @@ pub(super) async fn run_llm_call(
         ctx.has_tools,
         ctx.tool_format,
         tool_calls.len(),
+        recoverable_bare_final_response,
     );
     if !protocol_violations.is_empty()
         && ctx.has_tools
@@ -609,10 +621,38 @@ pub(super) async fn run_llm_call(
         tool_parse_errors,
         canonical_history,
         prose_too_long,
+        recoverable_bare_final_response,
         sentinel_hit,
         input_tokens: result.input_tokens,
         output_tokens: result.output_tokens,
     })
+}
+
+fn is_recoverable_bare_final_response(
+    text: &str,
+    has_tools: bool,
+    tool_format: &str,
+    tool_calls: &[serde_json::Value],
+    tool_parse_errors: &[String],
+    protocol_violations: &[String],
+    tagged_done_marker: Option<&str>,
+    user_response: Option<&str>,
+) -> bool {
+    if !has_tools
+        || tool_format == "native"
+        || !tool_calls.is_empty()
+        || !tool_parse_errors.is_empty()
+        || tagged_done_marker.is_some()
+        || user_response.is_some()
+    {
+        return false;
+    }
+    let trimmed = text.trim();
+    !trimmed.is_empty()
+        && !trimmed.contains('<')
+        && !trimmed.contains('>')
+        && protocol_violations.len() == 1
+        && protocol_violations[0].starts_with("Stray text outside response tags:")
 }
 
 fn should_inject_protocol_feedback(
@@ -620,11 +660,13 @@ fn should_inject_protocol_feedback(
     has_tools: bool,
     tool_format: &str,
     parsed_tool_call_count: usize,
+    recoverable_bare_final_response: bool,
 ) -> bool {
     !protocol_violations.is_empty()
         && has_tools
         && tool_format != "native"
         && parsed_tool_call_count == 0
+        && !recoverable_bare_final_response
 }
 
 /// Per-block translation of provider-native `tool_search_*` content into
@@ -793,13 +835,22 @@ mod tests {
             &violations,
             true,
             "text",
-            1
+            1,
+            false
         ));
         assert!(should_inject_protocol_feedback(
             &violations,
             true,
             "text",
-            0
+            0,
+            false
+        ));
+        assert!(!should_inject_protocol_feedback(
+            &violations,
+            true,
+            "text",
+            0,
+            true
         ));
     }
 
@@ -811,13 +862,15 @@ mod tests {
             &violations,
             false,
             "text",
-            0
+            0,
+            false
         ));
         assert!(!should_inject_protocol_feedback(
             &violations,
             true,
             "native",
-            0
+            0,
+            false
         ));
     }
 

--- a/crates/harn-vm/src/llm/agent/post_turn.rs
+++ b/crates/harn-vm/src/llm/agent/post_turn.rs
@@ -706,13 +706,13 @@ pub(super) async fn run_post_turn(
         return Ok(IterationOutcome::Continue);
     }
 
-    let native_answer_after_action = ctx.tool_format == "native"
-        && ctx.persistent
+    let can_answer_after_action = ctx.persistent
         && !ctx.daemon
         && ctx.has_tools
         && !state.all_tools_used.is_empty()
-        && !call_result.text.trim().is_empty();
-    if native_answer_after_action {
+        && !call_result.text.trim().is_empty()
+        && (ctx.tool_format == "native" || call_result.recoverable_bare_final_response);
+    if can_answer_after_action {
         emit_post_agent_turn_hook(
             ctx.session_id,
             iteration,

--- a/crates/harn-vm/src/llm/agent/state.rs
+++ b/crates/harn-vm/src/llm/agent/state.rs
@@ -1172,7 +1172,11 @@ impl AgentLoopState {
         };
         let persistent_system_prompt = if persistent {
             let progress_instruction = if has_tools {
-                "Take action with tool calls — do not stop to explain."
+                if tool_format == "native" {
+                    "Use the provider tool channel until the request is complete; after tool evidence is sufficient, give the final user-facing answer in concise assistant text."
+                } else {
+                    "Use <tool_call> blocks until the request is complete; after tool evidence is sufficient, emit the final user-facing answer in a <user_response> block."
+                }
             } else {
                 "Solve the request directly in assistant text — do not stop early to explain or summarize."
             };

--- a/crates/harn-vm/src/llm/agent/tests/prompts.rs
+++ b/crates/harn-vm/src/llm/agent/tests/prompts.rs
@@ -24,7 +24,7 @@ fn action_turn_nudge_mentions_action_or_yield() {
     };
     let msg = action_turn_nudge("text", true, Some(&policy), true).expect("nudge");
     assert!(
-        msg.contains("either make concrete progress with a well-formed <tool_call> block, switch phase, or emit a <done> block")
+        msg.contains("either make concrete progress with a well-formed <tool_call> block, switch phase, or emit <user_response>final answer</user_response> plus a <done> block")
     );
     assert!(msg.contains("120"));
     assert!(msg.contains("too much budget on prose"));

--- a/crates/harn-vm/src/llm/agent/tests/tool_dispatch_categories.rs
+++ b/crates/harn-vm/src/llm/agent/tests/tool_dispatch_categories.rs
@@ -171,6 +171,26 @@ fn native_read_file_schema() -> serde_json::Value {
     })
 }
 
+fn text_read_file_registry() -> VmValue {
+    let mut path_param = BTreeMap::new();
+    path_param.insert("type".to_string(), VmValue::String(Rc::from("string")));
+    let mut params = BTreeMap::new();
+    params.insert("path".to_string(), VmValue::Dict(Rc::new(path_param)));
+    let tool = VmValue::Dict(Rc::new(BTreeMap::from([
+        ("name".to_string(), VmValue::String(Rc::from("read_file"))),
+        (
+            "description".to_string(),
+            VmValue::String(Rc::from("Read a file.")),
+        ),
+        ("parameters".to_string(), VmValue::Dict(Rc::new(params))),
+        ("executor".to_string(), VmValue::String(Rc::from("harn"))),
+    ])));
+    VmValue::Dict(Rc::new(BTreeMap::from([(
+        "tools".to_string(),
+        VmValue::List(Rc::new(vec![tool])),
+    )])))
+}
+
 fn assert_tool_execution_with_category(
     result: &serde_json::Value,
     expected_tool: &str,
@@ -249,6 +269,49 @@ async fn native_persistent_answer_after_successful_tool_does_not_require_done_se
     let calls = get_llm_mock_calls();
     assert_eq!(calls.len(), 2, "native final answer should stop the loop");
     assert_eq!(result["text"].as_str(), Some("@burin/tui"));
+
+    let _ = std::fs::remove_file(path);
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn text_persistent_bare_answer_after_successful_tool_is_final_response() {
+    let _guard = serialize_tests();
+    drain_thread_local_state();
+    reset_llm_mock_state();
+    let temp_file = tempfile::NamedTempFile::new().expect("create temp file");
+    let path = temp_file.path().to_path_buf();
+    std::fs::write(&path, "@burin/tui\n").expect("write temp file");
+    let escaped_path = path
+        .to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+
+    crate::llm::mock::push_llm_mock(text_mock(&format!(
+        "<tool_call>\nread_file({{ path: \"{escaped_path}\" }})\n</tool_call>"
+    )));
+    crate::llm::mock::push_llm_mock(text_mock("@burin/tui"));
+    crate::llm::mock::push_llm_mock(text_mock("unexpected extra turn"));
+
+    let mut opts = base_opts(vec![
+        json!({"role": "user", "content": "read package name"}),
+    ]);
+    opts.tools = Some(text_read_file_registry());
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 3;
+    config.tool_format = "text".to_string();
+    config.turn_policy = Some(TurnPolicy {
+        require_action_or_yield: true,
+        allow_done_sentinel: true,
+        max_prose_chars: None,
+    });
+    config.session_id = "test-text-final-after-tool".to_string();
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    let calls = get_llm_mock_calls();
+    assert_eq!(calls.len(), 2, "text final answer should stop the loop");
+    assert_eq!(result["visible_text"].as_str(), Some("@burin/tui"));
 
     let _ = std::fs::remove_file(path);
     reset_llm_mock_state();

--- a/crates/harn-vm/src/llm/tools/contract_prompt.rs
+++ b/crates/harn-vm/src/llm/tools/contract_prompt.rs
@@ -180,7 +180,7 @@ Short narration. Optional.
 </assistant_prose>
 
 <user_response>
-Final user-facing answer. Optional.
+Final user-facing answer. Required when no more tool calls are needed.
 </user_response>
 
 <done>##DONE##</done>
@@ -190,10 +190,10 @@ Rules the runtime enforces:
 - No text, code, diffs, JSON, or reasoning outside these tags. Any stray content is rejected with structured feedback.
 - `<tool_call>` wraps exactly one bare call `name({ key: value })`. Do not quote or JSON-encode the call. Use heredoc `<<TAG` ... `TAG` for multiline string fields — raw content, no escaping. Place TAG at the start of the closing line; closing punctuation like `},` may follow on that same line.
 - `<assistant_prose>` is optional and must be brief. Never paste source code, file contents, command transcripts, or long plans here — wrap those in the relevant tool call instead.
-- `<user_response>` is optional and reserved for the final user-facing answer that hosts should surface. When present, keep it concise and grounded.
+- `<user_response>` is reserved for the final user-facing answer that hosts should surface. Emit it when the user should see a wrap-up or answer, and keep it concise and grounded.
 - `<done>##DONE##</done>` signals task completion. Emit it only after a successful verifying tool call; the runtime rejects it otherwise.
 - Do not prefix calls with labels like `tool_code:`, `python:`, `shell:`, or any language tag, and do not wrap tool calls in Markdown fences.
-- Prefer `<tool_call>` over `<assistant_prose>`. If you have nothing concrete to say, omit prose entirely.
+- Prefer `<tool_call>` over `<assistant_prose>` while work remains. Once no more tool calls are needed, emit `<user_response>...</user_response>`.
 
 Example of a well-formed response:
 


### PR DESCRIPTION
## Summary
- make final user prose explicit in the text tool-calling contract and persistent agent prompt
- accept plain final answers after a successful text-tool action while still rejecting protocol-looking fragments
- add regression coverage for native and text persistent final-answer behavior

## Verification
- cargo test -p harn-vm llm::agent::tests::tool_dispatch_categories -- --nocapture
- cargo test -p harn-vm llm::agent::tests::prompts::action_turn_nudge_mentions_action_or_yield -- --nocapture
- make lint-test-patterns
- make conformance
- pre-push fast release-quality checks: 3229 passed
- Burin TUI native and forced text-tool multi-turn edit smokes passed against llamacpp-qwen3.6-q4