### PR TITLE
Refine ACP session mode config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
+## Unreleased
+
+### Added
+
+- **ACP mode config options follow the current protocol (#897).** The ACP adapter now exposes
+  session modes through preferred
+  [session config options](https://agentclientprotocol.com/protocol/session-config-options) while
+  keeping legacy [session-modes](https://agentclientprotocol.com/protocol/session-modes) in sync.
+  Sessions default to conservative `ask`, advertise `ask`, `architect`, `code`, and `shadow`, and
+  accept both `session/set_config_option` and `session/set_mode`. Mode changes emit both
+  `current_mode_update` and `config_option_update`, and non-`code` modes derive their prompt-time
+  capability ceiling from Harn's `AutonomyTier` policy.
+
 ## v0.7.55
 
 ### Added

--- a/conformance/protocols/fixtures/acp/session_update_standard.valid.json
+++ b/conformance/protocols/fixtures/acp/session_update_standard.valid.json
@@ -58,6 +58,59 @@
           ]
         }
       }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "sessionUpdate": "current_mode_update",
+          "modeId": "architect"
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "session/update",
+      "params": {
+        "sessionId": "session-1",
+        "update": {
+          "sessionUpdate": "config_option_update",
+          "configOptions": [
+            {
+              "id": "mode",
+              "name": "Session Mode",
+              "description": "Controls Harn autonomy and side-effect policy.",
+              "category": "mode",
+              "type": "select",
+              "currentValue": "architect",
+              "options": [
+                {
+                  "value": "ask",
+                  "name": "Ask",
+                  "description": "Request permission before making changes."
+                },
+                {
+                  "value": "architect",
+                  "name": "Architect",
+                  "description": "Design and plan without modifying the workspace."
+                },
+                {
+                  "value": "code",
+                  "name": "Code",
+                  "description": "Read, write, execute processes, and call external services."
+                },
+                {
+                  "value": "shadow",
+                  "name": "Shadow",
+                  "description": "Evaluate the request and emit proposals without side effects."
+                }
+              ]
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/conformance/protocols/schemas/acp-session-update.schema.json
+++ b/conformance/protocols/schemas/acp-session-update.schema.json
@@ -29,6 +29,8 @@
         { "$ref": "#/$defs/ToolCall" },
         { "$ref": "#/$defs/ToolCallUpdate" },
         { "$ref": "#/$defs/Plan" },
+        { "$ref": "#/$defs/CurrentModeUpdate" },
+        { "$ref": "#/$defs/ConfigOptionUpdate" },
         { "$ref": "#/$defs/SessionInfoUpdate" },
         { "$ref": "#/$defs/SkillActivated" },
         { "$ref": "#/$defs/SkillDeactivated" },
@@ -148,6 +150,54 @@
       "properties": {
         "sessionUpdate": { "const": "plan" },
         "entries": { "type": "array" }
+      }
+    },
+    "CurrentModeUpdate": {
+      "type": "object",
+      "required": ["sessionUpdate", "modeId"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "current_mode_update" },
+        "modeId": { "type": "string", "minLength": 1 }
+      }
+    },
+    "ConfigOptionUpdate": {
+      "type": "object",
+      "required": ["sessionUpdate", "configOptions"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "config_option_update" },
+        "configOptions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ConfigOption" }
+        }
+      }
+    },
+    "ConfigOption": {
+      "type": "object",
+      "required": ["id", "name", "type", "currentValue", "options"],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "category": { "type": "string" },
+        "type": { "const": "select" },
+        "currentValue": { "type": "string", "minLength": 1 },
+        "options": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ConfigOptionValue" }
+        }
+      }
+    },
+    "ConfigOptionValue": {
+      "type": "object",
+      "required": ["value", "name"],
+      "additionalProperties": true,
+      "properties": {
+        "value": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" }
       }
     },
     "SessionInfoUpdate": {

--- a/crates/harn-cli/tests/acp_server_cli.rs
+++ b/crates/harn-cli/tests/acp_server_cli.rs
@@ -154,6 +154,14 @@ fn acp_session_fork_branches_runtime_state_and_dispatches_independently() {
         init["result"]["agentCapabilities"]["sessionCapabilities"]["fork"],
         json!({})
     );
+    assert_eq!(
+        init["result"]["agentCapabilities"]["sessionCapabilities"]["setMode"],
+        json!({})
+    );
+    assert_eq!(
+        init["result"]["agentCapabilities"]["sessionCapabilities"]["setConfigOption"],
+        json!({})
+    );
 
     let (_, created) = send_request(
         &mut stdin,

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -354,6 +354,8 @@ impl AcpServer {
                     "sessionCapabilities": {
                         "fork": {},
                         "load": {},
+                        "setConfigOption": {},
+                        "setMode": {},
                     },
                 },
                 "agentInfo": {
@@ -398,6 +400,7 @@ impl AcpServer {
             serde_json::json!({
                 "sessionId": session_id,
                 "modes": modes::session_mode_state(modes::DEFAULT_MODE_ID),
+                "configOptions": modes::config_options_state(modes::DEFAULT_MODE_ID),
             }),
         );
 
@@ -577,6 +580,7 @@ impl AcpServer {
                 "parent_id": src_id,
                 "branched_at": branched_at,
                 "modes": modes::session_mode_state(&parent_mode_id),
+                "configOptions": modes::config_options_state(&parent_mode_id),
             }),
         );
     }
@@ -1062,56 +1066,30 @@ impl AcpServer {
             serde_json::json!({
                 "session": session_value,
                 "modes": modes::session_mode_state(&session.current_mode_id),
+                "configOptions": modes::config_options_state(&session.current_mode_id),
                 "replayed": [],
             }),
         );
     }
 
-    fn handle_session_set_mode(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
-        let Some(session_id) = params
-            .get("sessionId")
-            .or_else(|| params.get("session_id"))
-            .and_then(serde_json::Value::as_str)
-            .map(str::to_string)
-        else {
-            self.send_error(id, -32602, "session/set_mode requires sessionId");
-            return;
-        };
-        let Some(mode_id) = params
-            .get("modeId")
-            .or_else(|| params.get("mode_id"))
-            .and_then(serde_json::Value::as_str)
-            .map(str::to_string)
-        else {
-            self.send_error(id, -32602, "session/set_mode requires modeId");
-            return;
-        };
-
-        if !modes::is_known(&mode_id) {
-            self.send_error(
-                id,
-                -32602,
-                &format!(
-                    "Unknown mode '{mode_id}'. Available: {}",
-                    modes::known_mode_ids().join(", ")
-                ),
-            );
-            return;
+    fn set_session_mode(&mut self, session_id: &str, mode_id: &str) -> Result<bool, String> {
+        if !modes::is_known(mode_id) {
+            return Err(format!(
+                "Unknown mode '{mode_id}'. Available: {}",
+                modes::known_mode_ids().join(", ")
+            ));
         }
-
-        let Some(session) = self.sessions.get_mut(&session_id) else {
-            self.send_error(id, -32602, &format!("Unknown session: {session_id}"));
-            return;
+        let Some(session) = self.sessions.get_mut(session_id) else {
+            return Err(format!("Unknown session: {session_id}"));
         };
-
         if session.current_mode_id == mode_id {
-            // Idempotent: ack but do not emit a redundant update.
-            self.send_response(id, serde_json::json!({}));
-            return;
+            return Ok(false);
         }
+        session.current_mode_id = mode_id.to_string();
+        Ok(true)
+    }
 
-        session.current_mode_id = mode_id.clone();
-        self.send_response(id, serde_json::json!({}));
+    fn emit_current_mode_update(&self, session_id: &str, mode_id: &str) {
         self.send_notification(
             "session/update",
             serde_json::json!({
@@ -1122,6 +1100,92 @@ impl AcpServer {
                 },
             }),
         );
+    }
+
+    fn emit_config_option_update(&self, session_id: &str, mode_id: &str) {
+        self.send_notification(
+            "session/update",
+            serde_json::json!({
+                "sessionId": session_id,
+                "update": {
+                    "sessionUpdate": "config_option_update",
+                    "configOptions": modes::config_options_state(mode_id),
+                },
+            }),
+        );
+    }
+
+    fn handle_session_set_mode(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
+        let Some(session_id) = params
+            .get("sessionId")
+            .or_else(|| params.get("session_id"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            self.send_error(id, -32602, "session/set_mode requires sessionId");
+            return;
+        };
+        let Some(mode_id) = params
+            .get("modeId")
+            .or_else(|| params.get("mode_id"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            self.send_error(id, -32602, "session/set_mode requires modeId");
+            return;
+        };
+
+        match self.set_session_mode(session_id, mode_id) {
+            Ok(changed) => {
+                self.send_response(id, serde_json::json!({}));
+                if changed {
+                    self.emit_current_mode_update(session_id, mode_id);
+                    self.emit_config_option_update(session_id, mode_id);
+                }
+            }
+            Err(message) => self.send_error(id, -32602, &message),
+        }
+    }
+
+    fn handle_session_set_config_option(
+        &mut self,
+        id: &serde_json::Value,
+        params: &serde_json::Value,
+    ) {
+        let Some(session_id) = params.get("sessionId").and_then(serde_json::Value::as_str) else {
+            self.send_error(id, -32602, "session/set_config_option requires sessionId");
+            return;
+        };
+        let Some(config_id) = params.get("configId").and_then(serde_json::Value::as_str) else {
+            self.send_error(id, -32602, "session/set_config_option requires configId");
+            return;
+        };
+        if config_id != "mode" {
+            self.send_error(
+                id,
+                -32602,
+                &format!("Unknown config option '{config_id}'. Available: mode"),
+            );
+            return;
+        }
+        let Some(mode_id) = params.get("value").and_then(serde_json::Value::as_str) else {
+            self.send_error(id, -32602, "session/set_config_option requires value");
+            return;
+        };
+
+        match self.set_session_mode(session_id, mode_id) {
+            Ok(changed) => {
+                self.send_response(
+                    id,
+                    serde_json::json!({
+                        "configOptions": modes::config_options_state(mode_id),
+                    }),
+                );
+                if changed {
+                    self.emit_current_mode_update(session_id, mode_id);
+                    self.emit_config_option_update(session_id, mode_id);
+                }
+            }
+            Err(message) => self.send_error(id, -32602, &message),
+        }
     }
 
     async fn handle_incoming_message(&mut self, msg: serde_json::Value) {
@@ -1157,6 +1221,9 @@ impl AcpServer {
             }
             "session/set_mode" => {
                 self.handle_session_set_mode(&id, &params);
+            }
+            "session/set_config_option" => {
+                self.handle_session_set_config_option(&id, &params);
             }
             "session/prompt" => {
                 self.handle_session_prompt(&id, &params).await;
@@ -1834,12 +1901,10 @@ mod tests {
         assert_eq!(error["error"]["message"], "missing API key");
     }
 
-    /// `session/new` returns a spec-shaped `SessionModeState` describing
-    /// every supported mode plus the active selection. Locks the wire
-    /// shape required by ACP session-modes
-    /// (<https://agentclientprotocol.com/protocol/session-modes>).
+    /// `session/new` returns the legacy `SessionModeState` and the
+    /// preferred `configOptions` selector from the same catalog.
     #[tokio::test(flavor = "current_thread")]
-    async fn acp_session_new_advertises_session_mode_state() {
+    async fn acp_session_new_advertises_session_mode_state_and_config_options() {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let mut server =
             AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
@@ -1855,7 +1920,7 @@ mod tests {
         let created = recv_json(&mut rx).await;
 
         let modes = &created["result"]["modes"];
-        assert_eq!(modes["currentModeId"], "default");
+        assert_eq!(modes["currentModeId"], "ask");
         let available = modes["availableModes"]
             .as_array()
             .expect("availableModes array");
@@ -1863,7 +1928,7 @@ mod tests {
             .iter()
             .map(|mode| mode["id"].as_str().expect("mode id"))
             .collect();
-        assert_eq!(ids, vec!["default", "architect", "code", "ask"]);
+        assert_eq!(ids, vec!["ask", "architect", "code", "shadow"]);
         // Each entry must carry a human-readable name; description is
         // optional per spec but Harn always populates it.
         for mode in available {
@@ -1872,6 +1937,22 @@ mod tests {
                 "mode {mode} missing name"
             );
         }
+
+        let config_options = created["result"]["configOptions"]
+            .as_array()
+            .expect("configOptions array");
+        assert_eq!(config_options.len(), 1);
+        assert_eq!(config_options[0]["id"], "mode");
+        assert_eq!(config_options[0]["category"], "mode");
+        assert_eq!(config_options[0]["type"], "select");
+        assert_eq!(config_options[0]["currentValue"], "ask");
+        let option_ids: Vec<&str> = config_options[0]["options"]
+            .as_array()
+            .expect("mode options")
+            .iter()
+            .map(|mode| mode["value"].as_str().expect("mode value"))
+            .collect();
+        assert_eq!(option_ids, vec!["ask", "architect", "code", "shadow"]);
     }
 
     /// `session/load` echoes the active mode state back to a
@@ -1905,9 +1986,10 @@ mod tests {
                 "params": {"sessionId": session_id, "modeId": "architect"},
             }))
             .await;
-        // Drain success ack and notification.
+        // Drain success ack plus mode/config notifications.
         let _ack = recv_json(&mut rx).await;
-        let _notification = recv_json(&mut rx).await;
+        let _mode_notification = recv_json(&mut rx).await;
+        let _config_notification = recv_json(&mut rx).await;
 
         server
             .handle_incoming_message(serde_json::json!({
@@ -1919,6 +2001,10 @@ mod tests {
             .await;
         let loaded = recv_json(&mut rx).await;
         assert_eq!(loaded["result"]["modes"]["currentModeId"], "architect");
+        assert_eq!(
+            loaded["result"]["configOptions"][0]["currentValue"],
+            "architect"
+        );
         assert!(loaded["result"]["modes"]["availableModes"]
             .as_array()
             .expect("available modes")
@@ -1971,12 +2057,21 @@ mod tests {
             "current_mode_update"
         );
         assert_eq!(notification["params"]["update"]["modeId"], "architect");
+
+        let config_notification = recv_json(&mut rx).await;
+        assert_eq!(config_notification["method"], "session/update");
+        assert_eq!(
+            config_notification["params"]["update"]["sessionUpdate"],
+            "config_option_update"
+        );
+        assert_eq!(
+            config_notification["params"]["update"]["configOptions"][0]["currentValue"],
+            "architect"
+        );
     }
 
-    /// Re-setting the same mode is a no-op: the agent ack's the
-    /// request but does not emit a `current_mode_update` notification.
-    /// Avoids spurious UI updates when a host reconciles its idea of
-    /// the active mode without intending a transition.
+    /// Re-setting the same mode is a no-op: the agent ack's the request but
+    /// does not emit redundant mode/config notifications.
     #[tokio::test(flavor = "current_thread")]
     async fn acp_set_mode_is_idempotent_when_mode_unchanged() {
         let (tx, mut rx) = mpsc::unbounded_channel();
@@ -1997,13 +2092,13 @@ mod tests {
             .expect("session id")
             .to_string();
 
-        // Active mode after session/new is "default"; re-set to it.
+        // Active mode after session/new is "ask"; re-set to it.
         server
             .handle_incoming_message(serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 2,
                 "method": "session/set_mode",
-                "params": {"sessionId": session_id, "modeId": "default"},
+                "params": {"sessionId": session_id, "modeId": "ask"},
             }))
             .await;
         let ack = recv_json(&mut rx).await;
@@ -2026,6 +2121,63 @@ mod tests {
         let notification = recv_json(&mut rx).await;
         assert_eq!(notification["method"], "session/update");
         assert_eq!(notification["params"]["update"]["modeId"], "architect");
+    }
+
+    /// `configOptions` is ACP's preferred mode selector. Harn keeps it
+    /// synchronized with the legacy `modes` surface while the protocol
+    /// transitions away from dedicated mode methods.
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_set_config_option_updates_mode() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut server =
+            AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/new",
+                "params": {"cwd": "."},
+            }))
+            .await;
+        let created = recv_json(&mut rx).await;
+        let session_id = created["result"]["sessionId"]
+            .as_str()
+            .expect("session id")
+            .to_string();
+
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/set_config_option",
+                "params": {
+                    "sessionId": session_id,
+                    "configId": "mode",
+                    "value": "shadow",
+                },
+            }))
+            .await;
+        let ack = recv_json(&mut rx).await;
+        assert_eq!(ack["id"], 2);
+        assert_eq!(ack["result"]["configOptions"][0]["currentValue"], "shadow");
+
+        let mode_notification = recv_json(&mut rx).await;
+        assert_eq!(
+            mode_notification["params"]["update"]["sessionUpdate"],
+            "current_mode_update"
+        );
+        assert_eq!(mode_notification["params"]["update"]["modeId"], "shadow");
+
+        let config_notification = recv_json(&mut rx).await;
+        assert_eq!(
+            config_notification["params"]["update"]["sessionUpdate"],
+            "config_option_update"
+        );
+        assert_eq!(
+            config_notification["params"]["update"]["configOptions"][0]["currentValue"],
+            "shadow"
+        );
     }
 
     /// `session/set_mode` rejects unknown sessions and unknown mode
@@ -2198,10 +2350,10 @@ mod tests {
             .await;
     }
 
-    /// `code` mode preserves the pre-modes baseline: writes succeed
-    /// because the policy guard pushes nothing onto the execution
-    /// stack. Pairs with the architect-mode test to confirm modes are
-    /// the *only* thing changing behavior between the two prompts.
+    /// `code` mode is full-access mode: writes succeed because Harn leaves
+    /// host and runtime capability resolution authoritative instead of
+    /// installing an ACP mode ceiling. Pairs with the architect-mode test to
+    /// confirm mode policy is the only behavior difference between prompts.
     #[tokio::test(flavor = "current_thread")]
     async fn acp_code_mode_allows_writes_in_prompt() {
         let local = tokio::task::LocalSet::new();

--- a/crates/harn-serve/src/adapters/acp/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/modes.rs
@@ -1,121 +1,122 @@
 //! ACP session modes (<https://agentclientprotocol.com/protocol/session-modes>).
 //!
-//! A session mode caps the agent's tool access and side-effect ceiling.
-//! The catalog is fixed: `default`, `architect`, `code`, `ask`. The
-//! adapter advertises this catalog in `session/new` and `session/load`
-//! results, accepts `session/set_mode` requests to switch the active
-//! mode, and emits `current_mode_update` notifications when the mode
-//! changes. While a prompt runs, the active mode's policy is pushed
-//! onto the VM execution policy stack so destructive builtins are
-//! rejected from `architect` mode and gated through approval flows from
-//! `ask` mode.
+//! A session mode is the ACP-facing name for Harn's runtime autonomy tier.
+//! The catalog is fixed and is rendered both as legacy ACP `modes` and as
+//! the newer `configOptions` mode selector.
 
-use std::collections::BTreeMap;
+use harn_vm::{orchestration::CapabilityPolicy, AutonomyTier};
 
-use harn_vm::orchestration::CapabilityPolicy;
-
-/// Default mode id assigned to newly created sessions. `default` is
-/// chosen over `code` so existing clients that never call
-/// `session/set_mode` observe the same unbounded behavior they had
-/// before modes were introduced (no policy override pushed on the
-/// execution stack).
-pub(super) const DEFAULT_MODE_ID: &str = "default";
+/// Default mode id assigned to newly created sessions. `ask` is the
+/// conservative ACP default: the agent can inspect context, but side effects
+/// are held behind the approval-oriented autonomy tier until a client or user
+/// explicitly switches to `code`.
+pub(super) const DEFAULT_MODE_ID: &str = "ask";
 
 pub(super) struct ModeDefinition {
     pub(super) id: &'static str,
     pub(super) name: &'static str,
     pub(super) description: &'static str,
+    autonomy_tier: AutonomyTier,
 }
 
-/// The static catalog of modes Harn advertises over ACP. Order is
-/// preserved on the wire so clients render a stable list. `default`
-/// stays first so it remains the obvious initial selection.
+/// The static catalog of modes Harn advertises over ACP. Order is preserved on
+/// the wire so clients render a stable selector.
 pub(super) const MODE_CATALOG: &[ModeDefinition] = &[
     ModeDefinition {
-        id: "default",
-        name: "Default",
-        description: "Execute Harn pipelines with no extra restrictions.",
+        id: "ask",
+        name: "Ask",
+        description: "Request permission before making changes.",
+        autonomy_tier: AutonomyTier::ActWithApproval,
     },
     ModeDefinition {
         id: "architect",
         name: "Architect",
-        description: "Read-only planning. Workspace writes, process execution, and \
-                      network requests are rejected; only reads, listings, and analysis \
-                      are permitted.",
+        description: "Design and plan without modifying the workspace.",
+        autonomy_tier: AutonomyTier::Suggest,
     },
     ModeDefinition {
         id: "code",
         name: "Code",
-        description: "Full tool access for reading, writing, executing processes, and \
-                      calling out to LLMs and connectors.",
+        description: "Read, write, execute processes, and call external services.",
+        autonomy_tier: AutonomyTier::ActAuto,
     },
     ModeDefinition {
-        id: "ask",
-        name: "Ask",
-        description: "Read-only by default. Destructive operations require host \
-                      approval through the ACP permission flow before they run.",
+        id: "shadow",
+        name: "Shadow",
+        description: "Evaluate the request and emit proposals without side effects.",
+        autonomy_tier: AutonomyTier::Shadow,
     },
 ];
 
 pub(super) fn is_known(mode_id: &str) -> bool {
-    MODE_CATALOG.iter().any(|m| m.id == mode_id)
+    definition(mode_id).is_some()
 }
 
 pub(super) fn known_mode_ids() -> Vec<&'static str> {
     MODE_CATALOG.iter().map(|m| m.id).collect()
 }
 
+fn definition(mode_id: &str) -> Option<&'static ModeDefinition> {
+    MODE_CATALOG.iter().find(|m| m.id == mode_id)
+}
+
 /// Render the spec-shaped `SessionModeState`:
 /// `{ currentModeId, availableModes: [{ id, name, description }] }`.
 pub(super) fn session_mode_state(current_mode_id: &str) -> serde_json::Value {
-    let available: Vec<serde_json::Value> = MODE_CATALOG
-        .iter()
-        .map(|mode| {
-            serde_json::json!({
-                "id": mode.id,
-                "name": mode.name,
-                "description": mode.description,
-            })
-        })
-        .collect();
     serde_json::json!({
         "currentModeId": current_mode_id,
-        "availableModes": available,
+        "availableModes": mode_entries("id"),
     })
 }
 
-/// Capability ceiling enforced while a prompt runs in this mode.
-///
-/// The returned policy is pushed onto the VM execution stack via
-/// `harn_vm::orchestration::push_execution_policy` for the duration of
-/// the prompt. `default` and `code` return `None` to preserve the
-/// pre-modes behavior (no override). `architect` clamps the
-/// side-effect ceiling to read-only. `ask` mirrors `architect`'s
-/// ceiling for now: writes/exec/network are rejected by the same
-/// builtin gate, which surfaces as an error the host can use to drive
-/// an approval prompt. We deliberately do *not* layer
-/// `ToolApprovalPolicy` here — the ACP `session/request_permission`
-/// flow is the host-driven path, and the VM gate is the safety net for
-/// scripts that bypass tool approval.
-pub(super) fn policy_for_mode(mode_id: &str) -> Option<CapabilityPolicy> {
-    match mode_id {
-        "default" | "code" => None,
-        "architect" | "ask" => Some(CapabilityPolicy {
-            tools: Vec::new(),
-            capabilities: BTreeMap::new(),
-            workspace_roots: Vec::new(),
-            side_effect_level: Some("read_only".to_string()),
-            recursion_limit: None,
-            tool_arg_constraints: Vec::new(),
-            tool_annotations: BTreeMap::new(),
-        }),
-        _ => None,
-    }
+/// Render the preferred ACP `configOptions` representation for the same mode
+/// catalog. ACP clients that understand this field should prefer it over
+/// `modes`; Harn keeps both in sync while the protocol transitions.
+pub(super) fn config_options_state(current_mode_id: &str) -> serde_json::Value {
+    serde_json::json!([
+        {
+            "id": "mode",
+            "name": "Session Mode",
+            "description": "Controls Harn autonomy and side-effect policy.",
+            "category": "mode",
+            "type": "select",
+            "currentValue": current_mode_id,
+            "options": mode_entries("value"),
+        }
+    ])
 }
 
-/// RAII guard that pushes a CapabilityPolicy on construction and pops
-/// it on drop. For modes without an override, the guard does nothing
-/// on enter and on drop, preserving the pre-modes baseline.
+fn mode_entries(id_key: &str) -> Vec<serde_json::Value> {
+    MODE_CATALOG
+        .iter()
+        .map(|mode| {
+            let mut entry = serde_json::Map::new();
+            entry.insert(id_key.to_string(), serde_json::json!(mode.id));
+            entry.insert("name".to_string(), serde_json::json!(mode.name));
+            entry.insert(
+                "description".to_string(),
+                serde_json::json!(mode.description),
+            );
+            serde_json::Value::Object(entry)
+        })
+        .collect()
+}
+
+/// Capability ceiling enforced while a prompt runs in this mode. Harn's
+/// autonomy-tier policy remains authoritative; ACP modes only select the tier.
+pub(super) fn policy_for_mode(mode_id: &str) -> Option<CapabilityPolicy> {
+    let mode = definition(mode_id)?;
+    if mode.autonomy_tier == AutonomyTier::ActAuto {
+        // Full-access mode leaves the ambient host/runtime policy as the
+        // authority. Installing a no-op ceiling would still make legacy bridge
+        // fallbacks look policy-governed and block them.
+        return None;
+    }
+    Some(harn_vm::policy_for_autonomy_tier(mode.autonomy_tier))
+}
+
+/// RAII guard that pushes a CapabilityPolicy on construction and pops it on
+/// drop. Full-access `code` mode has no extra policy to push.
 pub(super) struct ModePolicyGuard {
     pushed: bool,
 }
@@ -147,14 +148,14 @@ mod tests {
     #[test]
     fn catalog_contains_expected_modes() {
         let ids = known_mode_ids();
-        assert!(ids.contains(&"default"));
+        assert!(ids.contains(&"ask"));
         assert!(ids.contains(&"architect"));
         assert!(ids.contains(&"code"));
-        assert!(ids.contains(&"ask"));
+        assert!(ids.contains(&"shadow"));
     }
 
     #[test]
-    fn default_mode_is_first_in_catalog() {
+    fn default_mode_matches_first_catalog_entry() {
         assert_eq!(MODE_CATALOG.first().map(|m| m.id), Some(DEFAULT_MODE_ID));
     }
 
@@ -170,8 +171,21 @@ mod tests {
     }
 
     #[test]
-    fn policy_for_default_and_code_is_none() {
-        assert!(policy_for_mode("default").is_none());
+    fn config_options_state_contains_mode_selector() {
+        let state = config_options_state("code");
+        let options = state.as_array().expect("config options array");
+        assert_eq!(options.len(), 1);
+        assert_eq!(options[0]["id"], "mode");
+        assert_eq!(options[0]["currentValue"], "code");
+        assert!(options[0]["options"]
+            .as_array()
+            .expect("mode options")
+            .iter()
+            .any(|m| m["value"] == "ask"));
+    }
+
+    #[test]
+    fn policy_for_code_is_none() {
         assert!(policy_for_mode("code").is_none());
     }
 
@@ -188,13 +202,20 @@ mod tests {
     }
 
     #[test]
+    fn policy_for_shadow_blocks_side_effects() {
+        let policy = policy_for_mode("shadow").expect("shadow has policy");
+        assert_eq!(policy.side_effect_level.as_deref(), Some("none"));
+        assert_eq!(policy.recursion_limit, Some(0));
+    }
+
+    #[test]
     fn policy_for_unknown_mode_is_none() {
         assert!(policy_for_mode("not-a-real-mode").is_none());
     }
 
     #[test]
     fn is_known_rejects_unknown_mode() {
-        assert!(is_known("default"));
+        assert!(is_known("ask"));
         assert!(!is_known(""));
         assert!(!is_known("plan"));
     }

--- a/docs/src/acp/websocket.md
+++ b/docs/src/acp/websocket.md
@@ -97,6 +97,7 @@ surface as stdio ACP:
 - `session/input`
 - `session/fork`
 - `session/set_mode`
+- `session/set_config_option`
 - `agent/resume`
 - `workflow/*`
 - `harn.hitl.respond`

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -449,6 +449,7 @@ The ACP server supports these JSON-RPC methods:
 | `session/prompt` | Send a prompt to the agent for execution |
 | `session/cancel` | Cancel the currently running prompt |
 | `session/set_mode` | Switch the active session mode |
+| `session/set_config_option` | Switch a preferred ACP session config option such as `mode` |
 | `workflow/signal` | Enqueue a workflow signal message in the current session workspace |
 | `workflow/query` | Read a named workflow query value from the current session workspace |
 | `workflow/update` | Send a workflow update request and wait for a response |
@@ -507,20 +508,38 @@ are not copied from the parent.
 
 ### Session Modes
 
-Harn implements ACP
-[session-modes](https://agentclientprotocol.com/protocol/session-modes) so a
-host can clamp the agent's tool ceiling at runtime. The `session/new` and
-`session/load` results carry a spec-shaped `modes` field:
+Harn exposes ACP
+[session config options](https://agentclientprotocol.com/protocol/session-config-options)
+and the legacy
+[session-modes](https://agentclientprotocol.com/protocol/session-modes) field
+from the same mode catalog. Clients that understand `configOptions` should use
+it; Harn keeps `modes` available for clients still on `session/set_mode`.
+`session/new` and `session/load` return both shapes:
 
 ```json
 {
+  "configOptions": [
+    {
+      "id": "mode",
+      "name": "Session Mode",
+      "category": "mode",
+      "type": "select",
+      "currentValue": "ask",
+      "options": [
+        { "value": "ask",       "name": "Ask",       "description": "..." },
+        { "value": "architect", "name": "Architect", "description": "..." },
+        { "value": "code",      "name": "Code",      "description": "..." },
+        { "value": "shadow",    "name": "Shadow",    "description": "..." }
+      ]
+    }
+  ],
   "modes": {
-    "currentModeId": "default",
+    "currentModeId": "ask",
     "availableModes": [
-      { "id": "default",   "name": "Default",   "description": "..." },
+      { "id": "ask",       "name": "Ask",       "description": "..." },
       { "id": "architect", "name": "Architect", "description": "..." },
       { "id": "code",      "name": "Code",      "description": "..." },
-      { "id": "ask",       "name": "Ask",       "description": "..." }
+      { "id": "shadow",    "name": "Shadow",    "description": "..." }
     ]
   }
 }
@@ -528,17 +547,28 @@ host can clamp the agent's tool ceiling at runtime. The `session/new` and
 
 Mode semantics:
 
-- `default` — preserves the pre-modes baseline (no extra capability ceiling).
+- `ask` — conservative default, mapped to Harn's `act_with_approval`
+  autonomy tier.
 - `architect` — read-only planning mode. Builtins that mutate the workspace,
   execute processes, or hit the network are rejected by the VM policy gate
-  before they run. Reads, listings, and analysis stay available.
-- `code` — full tool access; equivalent to `default` for the purposes of the
-  capability ceiling. Surfaces a distinct id so hosts can render the mode
-  the user explicitly opted into.
-- `ask` — read-only by default; destructive operations are gated through the
-  ACP `session/request_permission` flow on the host before executing.
+  before they run. Maps to Harn's `suggest` autonomy tier.
+- `code` — full tool access. Harn leaves host/runtime capability resolution
+  authoritative instead of installing an extra ceiling. Maps to `act_auto`.
+- `shadow` — proposal-only mode mapped to Harn's `shadow` autonomy tier.
+  Side effects are blocked before they touch the workspace.
 
-Switching modes:
+Preferred mode switching:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 17,
+  "method": "session/set_config_option",
+  "params": { "sessionId": "sess_abc", "configId": "mode", "value": "architect" }
+}
+```
+
+Legacy mode switching:
 
 ```json
 {
@@ -549,17 +579,21 @@ Switching modes:
 }
 ```
 
-The agent ack's with an empty result and emits a `session/update`
-notification with `sessionUpdate: "current_mode_update"` carrying the new
-`modeId`. Re-setting the same mode is a no-op (ack only, no notification).
+`session/set_config_option` responds with the complete `configOptions` state.
+Both switching methods emit `session/update` notifications with
+`sessionUpdate: "current_mode_update"` and
+`sessionUpdate: "config_option_update"` when the selected mode changes.
+Re-setting the same mode is a no-op (ack only, no notification).
 `session/fork` carries the parent's active mode over to the new branch and
 echoes it back on the fork response.
 
 The selected mode is enforced for the next `session/prompt`: while the
 prompt runs, the matching capability policy is pushed onto the VM
-execution stack and popped when the prompt completes. The conformance
-case `acp_architect_mode_blocks_destructive_writes_in_prompt` locks this
-behavior end-to-end.
+execution stack and popped when the prompt completes. Harn derives that
+policy from the same `AutonomyTier` machinery used by trigger dispatch, so
+ACP sessions and runtime autonomy stay aligned. The conformance case
+`acp_architect_mode_blocks_destructive_writes_in_prompt` locks this behavior
+end-to-end.
 
 ### Queued user messages during agent execution
 


### PR DESCRIPTION
## Summary
- Replace the legacy ACP default-mode catalog with `ask`, `architect`, `code`, and `shadow` backed by Harn `AutonomyTier` policy.
- Return ACP `configOptions` alongside legacy `modes`, implement `session/set_config_option`, and keep mode/config notifications synchronized.
- Pin `current_mode_update` and `config_option_update` in protocol conformance, docs, and CLI capability coverage.

Fixes #897

## Test plan
- `CARGO_TARGET_DIR=/tmp/harn-target-897 cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-897 cargo test -p harn-serve --lib adapters::acp`
- `CARGO_TARGET_DIR=/tmp/harn-target-897 HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test protocols`
- `CARGO_TARGET_DIR=/tmp/harn-target-897 cargo clippy -p harn-serve --tests --no-deps -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-897 cargo test -p harn-cli --test acp_server_cli`
- pre-commit hook: workspace clippy + markdownlint
- pre-push hook: `make test` / nextest, 3239 passed; markdownlint; changelog retroactive-edit guard
