### PR TITLE
Document Harn ACP/MCP extension fields

### DIFF
--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -81,7 +81,7 @@ fn harn_acp_extension_meta() -> serde_json::Value {
                     "shell_invocation"
                 ]
             },
-            "extensionContract": "docs/src/bridge-protocol.md#acp-compatibility-contract",
+            "extensionContract": "https://harnlang.com/spec/harn-extensions/v1",
         }
     })
 }
@@ -1717,6 +1717,10 @@ mod tests {
                     initialize["result"]["agentCapabilities"]["_meta"]["harn"]
                         ["schemaCompatibility"],
                     ACP_SCHEMA_COMPATIBILITY
+                );
+                assert_eq!(
+                    initialize["result"]["agentCapabilities"]["_meta"]["harn"]["extensionContract"],
+                    "https://harnlang.com/spec/harn-extensions/v1"
                 );
                 assert_eq!(
                     initialize["result"]["agentCapabilities"]["_meta"]["harn"]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -64,6 +64,7 @@
 - [Bridge protocol](./bridge-protocol.md)
 - [Host tools over the bridge](./bridge/host-tools.md)
 - [ACP over WebSocket](./acp/websocket.md)
+- [Harn ACP/MCP extensions v1](./spec/harn-extensions/v1.md)
 - [Agents Protocol v1](./spec/agents-protocol/v1.md)
 - [Agents Protocol Receipt Format](./spec/agents-protocol/receipt-format-v1.md)
 - [Agents Protocol Replay Contract](./spec/agents-protocol/replay-v1.md)

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -27,7 +27,9 @@ registers per session.
 
 ### ACP Compatibility Contract
 
-Harn tracks the upstream Agent Client Protocol schema and pins its
+Harn-owned ACP/MCP extension fields are specified in
+[Harn ACP/MCP extensions v1](./spec/harn-extensions/v1.md). Harn tracks the
+upstream Agent Client Protocol schema and pins its
 wire contract against `agentclientprotocol/agent-client-protocol` schema
 `v0.12.2`. The adapter treats these `session/update` values as standard
 ACP variants:
@@ -46,6 +48,8 @@ are advertised during `initialize` under
 
 - `fs_watch`
 - `handoff`
+- `hitl_request`
+- `hitl_resolved`
 - `log`
 - `progress`
 - `skill_activated`
@@ -106,6 +110,8 @@ that route on it keep working unchanged. Concretely:
 | `skill_scope_tools`    | `skillName`, `allowedTools`                                                                                                            |
 | `tool_search_query`    | `toolUseId`, `name`, `query`, `strategy`, `mode`                                                                                       |
 | `tool_search_result`   | `toolUseId`, `promoted`, `strategy`, `mode`                                                                                            |
+| `hitl_request`         | `requestId`, `kind`, `payload`                                                                                                         |
+| `hitl_resolved`        | `requestId`, `kind`, `outcome`                                                                                                         |
 
 Hosts migrating from pre-#905 builds must read these fields from
 `_meta.harn.<field>` instead of the update root. The fixture
@@ -180,8 +186,9 @@ contract):
 
 The `_meta.harn.audit` field is omitted when no mutation session is installed (read-only
 `harn run` invocations, conformance fixtures, scripts that don't enter
-a workflow). `worker_update.audit` remains top-level because
-`worker_update` itself is a Harn extension update.
+a workflow). Worker lifecycle audit data is carried as
+`worker_update._meta.harn.audit`, matching the Harn extension namespacing
+contract.
 
 ### `executor` tag
 

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -6,7 +6,8 @@ covers how to use each from both client and server perspectives.
 
 For a scan-friendly status table across all protocol entry points, see the
 [protocol support matrix](./protocol-support.md). For shared serving internals,
-see [Outbound workflow server](./harn-serve.md).
+see [Outbound workflow server](./harn-serve.md). Harn-owned ACP/MCP extension
+fields are specified in [Harn ACP/MCP extensions v1](./spec/harn-extensions/v1.md).
 
 ## MCP client (connecting to MCP servers)
 

--- a/docs/src/spec/harn-extensions/v1.md
+++ b/docs/src/spec/harn-extensions/v1.md
@@ -1,0 +1,207 @@
+# Harn ACP/MCP extensions v1
+
+Canonical URL: <https://harnlang.com/spec/harn-extensions/v1>
+
+This page defines Harn-owned protocol extension fields for clients that consume
+Harn over Agent Client Protocol (ACP) or Model Context Protocol (MCP). Harn uses
+`_meta.harn` for fields that extend an upstream protocol object. Standard ACP
+and MCP fields stay at their standard locations.
+
+## Compatibility
+
+The ACP adapter advertises this contract during `initialize`:
+
+```json
+{
+  "agentCapabilities": {
+    "_meta": {
+      "harn": {
+        "schemaCompatibility": "agentclientprotocol/agent-client-protocol schema v0.12.2",
+        "extensionContract": "https://harnlang.com/spec/harn-extensions/v1",
+        "sessionUpdateExtensions": [
+          "fs_watch",
+          "handoff",
+          "hitl_request",
+          "hitl_resolved",
+          "log",
+          "progress",
+          "skill_activated",
+          "skill_deactivated",
+          "skill_scope_tools",
+          "tool_search_query",
+          "tool_search_result",
+          "transcript_compacted",
+          "worker_update"
+        ],
+        "toolLifecycleExtensionFields": [
+          "audit",
+          "durationMs",
+          "error",
+          "errorCategory",
+          "executionDurationMs",
+          "executor",
+          "parsing",
+          "rawInputPartial"
+        ],
+        "contentExtensionFields": ["visible_delta", "visible_text"],
+        "hostCapabilityOperations": {
+          "process": [
+            "exec",
+            "list_shells",
+            "get_default_shell",
+            "set_default_shell",
+            "shell_invocation"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+Field stability means the field name and location are part of this v1 contract.
+Consumers must still ignore unknown sibling fields and tolerate missing optional
+fields.
+
+| Field | Location | Stability | Meaning |
+| --- | --- | --- | --- |
+| `schemaCompatibility` | `agentCapabilities._meta.harn` | Stable v1 | Upstream ACP schema version Harn pins its ACP wire shape against. |
+| `extensionContract` | `agentCapabilities._meta.harn` | Stable v1 | Public spec URL for Harn-owned extension fields. |
+| `sessionUpdateExtensions` | `agentCapabilities._meta.harn` | Stable v1 | Harn `session/update` discriminators a client may receive in addition to upstream ACP values. |
+| `toolLifecycleExtensionFields` | `agentCapabilities._meta.harn` | Stable v1 | Harn fields that can appear below `tool_call._meta.harn` or `tool_call_update._meta.harn`. |
+| `contentExtensionFields` | `agentCapabilities._meta.harn` | Stable v1 | Harn fields that can appear below ACP content-block `_meta.harn`. |
+| `hostCapabilityOperations` | `agentCapabilities._meta.harn` | Experimental | Host bridge operation names Harn may request through ACP host calls. |
+
+## ACP session updates
+
+Harn extension session updates keep the `sessionUpdate` discriminator at
+`params.update.sessionUpdate`; all Harn-owned payload fields are under
+`params.update._meta.harn`.
+
+```json
+{
+  "method": "session/update",
+  "params": {
+    "sessionId": "session_123",
+    "update": {
+      "sessionUpdate": "progress",
+      "_meta": {
+        "harn": {
+          "phase": "ingest",
+          "message": "loading",
+          "progress": 3,
+          "total": 10
+        }
+      }
+    }
+  }
+}
+```
+
+| `sessionUpdate` value | `_meta.harn` fields | Stability |
+| --- | --- | --- |
+| `progress` | `phase`, `message`, `progress`, `total`, `data` | Stable v1 |
+| `log` | `level`, `message`, `fields` | Stable v1 |
+| `fs_watch` | `subscriptionId`, `events` | Stable v1 |
+| `worker_update` | `workerId`, `workerName`, `workerTask`, `workerMode`, `event`, `status`, `terminal`, `metadata`, `audit` | Stable v1 |
+| `transcript_compacted` | `mode`, `strategy`, `archivedMessages`, `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId` | Stable v1 |
+| `handoff` | `handoffId`, `artifactId`, `handoff` | Stable v1 |
+| `skill_activated` | `skillName`, `iteration`, `reason` | Stable v1 |
+| `skill_deactivated` | `skillName`, `iteration` | Stable v1 |
+| `skill_scope_tools` | `skillName`, `allowedTools` | Stable v1 |
+| `tool_search_query` | `toolUseId`, `name`, `query`, `strategy`, `mode` | Stable v1 |
+| `tool_search_result` | `toolUseId`, `promoted`, `strategy`, `mode` | Stable v1 |
+| `hitl_request` | `requestId`, `kind`, `payload` | Experimental |
+| `hitl_resolved` | `requestId`, `kind`, `outcome` | Experimental |
+
+The `audit` field on `worker_update` is the same mutation-session record shape
+used by tool lifecycle `audit`.
+
+Standard ACP updates such as `agent_message_chunk`, `tool_call`,
+`tool_call_update`, and `plan` keep their standard payload fields at the root
+of `params.update`.
+
+## ACP tool lifecycle
+
+`tool_call` and `tool_call_update` use canonical ACP root fields for
+`toolCallId`, `title`, `kind`, `status`, `rawInput`, `rawOutput`, and `content`.
+Harn-owned lifecycle fields appear under `params.update._meta.harn`.
+
+```json
+{
+  "sessionUpdate": "tool_call_update",
+  "toolCallId": "call_123",
+  "title": "edit_file",
+  "status": "completed",
+  "rawOutput": "ok",
+  "_meta": {
+    "harn": {
+      "executor": "host_bridge",
+      "durationMs": 25,
+      "executionDurationMs": 18,
+      "audit": {
+        "session_id": "session_123",
+        "run_id": "run_123",
+        "mutation_scope": "apply_workspace"
+      }
+    }
+  }
+}
+```
+
+| Field | Applies to | Stability | Meaning |
+| --- | --- | --- | --- |
+| `audit` | `tool_call`, `tool_call_update` | Stable v1 | Mutation-session record for grouping writes, approvals, undo/redo, and audit logs. |
+| `executor` | `tool_call_update` | Stable v1 | Execution backend: `"harn_builtin"`, `"host_bridge"`, `"provider_native"`, or `{"kind":"mcp_server","serverName":"..."}`. |
+| `durationMs` | `tool_call_update` | Stable v1 | End-to-end duration from Harn's lifecycle observation. |
+| `executionDurationMs` | `tool_call_update` | Stable v1 | Backend execution duration when Harn can separate it from parsing or routing overhead. |
+| `error` | `tool_call_update` | Stable v1 | Human-readable execution or validation error. |
+| `errorCategory` | `tool_call_update` | Stable v1 | Machine-readable error category such as `schema_validation` or `parse_aborted`. |
+| `parsing` | `tool_call`, `tool_call_update` | Experimental | Whether the event represents an in-progress structured input parsing state. |
+| `rawInputPartial` | `tool_call_update` | Experimental | Unparseable partial tool input bytes captured during streaming tool-call parsing. |
+
+`audit` is omitted when no mutation session is installed.
+
+## ACP content extensions
+
+Harn can add visibility metadata to ACP text content blocks. These fields live
+under the content block's `_meta.harn`, not under the surrounding update.
+
+```json
+{
+  "sessionUpdate": "agent_message_chunk",
+  "content": {
+    "type": "text",
+    "text": "hello",
+    "_meta": {
+      "harn": {
+        "visible_text": "hello",
+        "visible_delta": "hello"
+      }
+    }
+  }
+}
+```
+
+| Field | Location | Stability | Meaning |
+| --- | --- | --- | --- |
+| `visible_text` | `content._meta.harn` | Experimental | Assistant-visible text after Harn visibility filtering. |
+| `visible_delta` | `content._meta.harn` | Experimental | Newly visible text in this content chunk. |
+
+## MCP extension boundary
+
+Harn does not currently emit Harn-owned `_meta.harn` fields on MCP tool
+annotations, capabilities, or notifications. MCP consumers should treat the
+following as standard MCP fields, not Harn namespace extensions:
+
+| MCP surface | Fields Harn emits or consumes | Namespace |
+| --- | --- | --- |
+| Tool list entries | `annotations.title`, `annotations.readOnlyHint`, `annotations.destructiveHint`, `annotations.idempotentHint`, `annotations.openWorldHint` | MCP standard |
+| Tool list entries | `execution.taskSupport` | MCP task execution extension |
+| Server capabilities | `tools.listChanged`, `resources.listChanged`, `prompts.listChanged`, `logging`, `tasks`, `elicitation` | MCP standard or latest-spec MCP extension |
+| Tool-call requests | `_meta.progressToken` | MCP standard |
+| Notifications | `notifications/progress` with `progressToken`, `progress`, `message` | MCP standard |
+| Task correlation metadata | `_meta["io.modelcontextprotocol/related-task"].taskId` | MCP namespace |
+
+If Harn introduces MCP-specific Harn metadata in a future revision, those fields
+will be added below `_meta.harn` and advertised by a new version of this page.


### PR DESCRIPTION
## Summary
- Add the public Harn ACP/MCP extensions v1 spec page covering ACP `_meta.harn` capability metadata, session update payloads, tool lifecycle metadata, content metadata, and the current MCP namespace boundary.
- Link the spec from the MCP/ACP guide, docs navigation, and bridge protocol docs.
- Advertise the new canonical extension contract URL from ACP `initialize`.

Closes #957

## Verification
- `npx markdownlint-cli2 docs/src/spec/harn-extensions/v1.md docs/src/mcp-and-acp.md docs/src/bridge-protocol.md`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-957 cargo test -p harn-serve acp_server_handles_session_flow_and_prompt_updates --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-957 make check-docs-snippets`
- `CARGO_TARGET_DIR=/tmp/harn-target-issue-957 cargo fmt --check`
- `mdbook build docs`
- Pre-commit hook: rustfmt, workspace clippy, markdown lint
- Pre-push hook: full `make test` / nextest, markdown lint