### PR TITLE
[codex] Emit MCP tool annotations

### DIFF
--- a/crates/harn-cli/src/commands/mcp/serve.rs
+++ b/crates/harn-cli/src/commands/mcp/serve.rs
@@ -581,6 +581,7 @@ impl McpOrchestratorService {
             tool_def(
                 "harn.secret_scan",
                 "Scan content for high-signal secrets before commit or PR-open flows. The `harn::secret_scan` alias is also accepted.",
+                read_only_tool_annotations("Secret Scan"),
                 json!({
                     "type": "object",
                     "required": ["content"],
@@ -624,6 +625,7 @@ impl McpOrchestratorService {
             tool_def(
                 "harn.trigger.fire",
                 "Dispatch a trigger inline and return its event id plus terminal status.",
+                mutating_open_world_tool_annotations("Fire Trigger"),
                 json!({
                     "type": "object",
                     "required": ["trigger_id", "payload"],
@@ -646,6 +648,7 @@ impl McpOrchestratorService {
             tool_def(
                 "harn.trigger.list",
                 "List registered triggers and their kind/provider/when/handler metadata.",
+                read_only_tool_annotations("List Triggers"),
                 json!({
                     "type": "object",
                     "properties": {},
@@ -657,6 +660,7 @@ impl McpOrchestratorService {
             tool_def(
                 "harn.trigger.replay",
                 "Replay an existing trigger event, optionally resolving bindings as of a historical timestamp or recording a teaching correction.",
+                mutating_open_world_tool_annotations("Replay Trigger"),
                 json!({
                     "type": "object",
                     "required": ["event_id"],
@@ -680,6 +684,7 @@ impl McpOrchestratorService {
             tool_def(
                 "harn.orchestrator.queue",
                 "Return inbox/outbox/attempt/DLQ counts plus recent previews.",
+                read_only_tool_annotations("Inspect Orchestrator Queue"),
                 json!({
                     "type": "object",
                     "properties": {},
@@ -691,6 +696,7 @@ impl McpOrchestratorService {
             tool_def(
                 "harn.orchestrator.dlq.list",
                 "List pending dead-letter queue entries.",
+                read_only_tool_annotations("List Dead Letter Queue"),
                 json!({
                     "type": "object",
                     "properties": {},
@@ -702,6 +708,7 @@ impl McpOrchestratorService {
             tool_def(
                 "harn.orchestrator.dlq.retry",
                 "Replay a pending dead-letter queue entry.",
+                mutating_open_world_tool_annotations("Retry Dead Letter Queue Entry"),
                 json!({
                     "type": "object",
                     "required": ["entry_id"],
@@ -716,6 +723,7 @@ impl McpOrchestratorService {
             tool_def(
                 "harn.orchestrator.inspect",
                 "Snapshot dispatcher state, triggers, flow-control state, and recent dispatches.",
+                read_only_tool_annotations("Inspect Orchestrator"),
                 json!({
                     "type": "object",
                     "properties": {},
@@ -727,6 +735,7 @@ impl McpOrchestratorService {
             tool_def(
                 "harn.trust.query",
                 "Query trust-graph records with the same filters exposed by trust_query(filters).",
+                read_only_tool_annotations("Query Trust Records"),
                 json!({
                     "type": "object",
                     "properties": {
@@ -2511,6 +2520,7 @@ fn paginated_list_response(
 fn tool_def(
     name: &str,
     description: &str,
+    annotations: JsonValue,
     input_schema: JsonValue,
     output_schema: Option<JsonValue>,
     task_support: mcp_protocol::McpToolTaskSupport,
@@ -2518,13 +2528,37 @@ fn tool_def(
     let mut value = json!({
         "name": name,
         "description": description,
+        "annotations": annotations,
         "inputSchema": input_schema,
         "execution": mcp_protocol::tool_execution(task_support),
     });
+    if let Some(title) = value["annotations"].get("title").cloned() {
+        value["title"] = title;
+    }
     if let Some(output_schema) = output_schema {
         value["outputSchema"] = output_schema;
     }
     value
+}
+
+fn read_only_tool_annotations(title: &str) -> JsonValue {
+    json!({
+        "title": title,
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+    })
+}
+
+fn mutating_open_world_tool_annotations(title: &str) -> JsonValue {
+    json!({
+        "title": title,
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true,
+    })
 }
 
 fn task_support_for_tool(name: &str) -> Option<mcp_protocol::McpToolTaskSupport> {
@@ -3214,7 +3248,7 @@ version = "0.1.0"
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn tools_list_advertises_task_support_per_tool() {
+    async fn tools_list_advertises_tool_metadata_per_tool() {
         let _guard = lock_harn_state();
         let temp = TempDir::new().unwrap();
         write_fixture(&temp);
@@ -3237,7 +3271,13 @@ version = "0.1.0"
             .find(|tool| tool["name"] == "harn.trigger.list")
             .unwrap();
         assert_eq!(trigger_fire["execution"]["taskSupport"], json!("optional"));
+        assert_eq!(trigger_fire["annotations"]["readOnlyHint"], json!(false));
+        assert_eq!(trigger_fire["annotations"]["destructiveHint"], json!(true));
+        assert_eq!(trigger_fire["annotations"]["openWorldHint"], json!(true));
         assert_eq!(trigger_list["execution"]["taskSupport"], json!("forbidden"));
+        assert_eq!(trigger_list["annotations"]["readOnlyHint"], json!(true));
+        assert_eq!(trigger_list["annotations"]["idempotentHint"], json!(true));
+        assert_eq!(trigger_list["annotations"]["openWorldHint"], json!(false));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-cli/tests/harn_serve_mcp_cli.rs
+++ b/crates/harn-cli/tests/harn_serve_mcp_cli.rs
@@ -72,8 +72,10 @@ pipeline main(task) {
   var tools = tool_registry()
   tools = tool_define(tools, "echo", "Echo input", {
     parameters: {text: "string"},
+    returns: {type: "string"},
     handler: { args -> args.text },
-    annotations: {title: "Echo Tool", readOnlyHint: true}
+    annotations: {title: "Echo Tool", readOnlyHint: true, idempotentHint: true, openWorldHint: false},
+    icons: [{src: "https://example.com/echo.png", mimeType: "image/png", sizes: ["48x48"]}]
   })
   mcp_tools(tools)
 
@@ -401,6 +403,23 @@ fn serve_mcp_stdio_exposes_script_registered_surface() {
         json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
     );
     assert_eq!(tools["result"]["tools"][0]["name"], "echo");
+    assert_eq!(
+        tools["result"]["tools"][0]["outputSchema"]["type"],
+        "string"
+    );
+    assert_eq!(
+        tools["result"]["tools"][0]["annotations"],
+        json!({
+            "title": "Echo Tool",
+            "readOnlyHint": true,
+            "idempotentHint": true,
+            "openWorldHint": false,
+        })
+    );
+    assert_eq!(
+        tools["result"]["tools"][0]["icons"][0]["src"],
+        "https://example.com/echo.png"
+    );
 
     let resources = send_stdio_request(
         &mut stdin,

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -3,7 +3,7 @@
 //! (unused/undefined symbols, etc.). The large `lint_node` match lives
 //! in the [`walk`] submodule.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use harn_lexer::{FixEdit, Span};
 use harn_parser::diagnostic::find_closest_match;
@@ -93,6 +93,9 @@ pub(crate) struct Linter<'a> {
     /// Whether the current body contains a defer/finally path that cancels
     /// long-running handles.
     pub(super) long_running_cleanup_stack: Vec<bool>,
+    /// Registry variables mapped to `tool_define` calls that will need MCP
+    /// annotations if the registry is later exposed through `mcp_tools`.
+    pub(super) mcp_registry_missing_annotation_spans: HashMap<String, Vec<Span>>,
 }
 
 impl<'a> Linter<'a> {
@@ -129,6 +132,7 @@ impl<'a> Linter<'a> {
             value_block_depth: 0,
             connector_effect_export_stack: Vec::new(),
             long_running_cleanup_stack: Vec::new(),
+            mcp_registry_missing_annotation_spans: HashMap::new(),
         }
     }
 
@@ -711,6 +715,76 @@ impl<'a> Linter<'a> {
             | Node::RawStringLiteral(value) => Some(value.clone()),
             _ => None,
         }
+    }
+
+    pub(super) fn simple_binding_name(pattern: &BindingPattern) -> Option<&str> {
+        match pattern {
+            BindingPattern::Identifier(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    pub(super) fn record_mcp_registry_binding(&mut self, name: &str, value: &SNode) {
+        let missing = self.mcp_missing_annotation_spans(value);
+        if missing.is_empty() {
+            self.mcp_registry_missing_annotation_spans.remove(name);
+        } else {
+            self.mcp_registry_missing_annotation_spans
+                .insert(name.to_string(), missing);
+        }
+    }
+
+    pub(super) fn warn_mcp_tools_missing_annotations(&mut self, value: &SNode) {
+        for span in self.mcp_missing_annotation_spans(value) {
+            self.warn_missing_mcp_tool_annotations(span);
+        }
+    }
+
+    fn mcp_missing_annotation_spans(&self, node: &SNode) -> Vec<Span> {
+        match &node.node {
+            Node::Identifier(name) => self
+                .mcp_registry_missing_annotation_spans
+                .get(name)
+                .cloned()
+                .unwrap_or_default(),
+            Node::FunctionCall { name, args, .. } if name == "tool_define" => {
+                let mut spans = args
+                    .first()
+                    .map(|arg| self.mcp_missing_annotation_spans(arg))
+                    .unwrap_or_default();
+                if !Self::tool_define_has_annotations(args) {
+                    spans.push(node.span);
+                }
+                spans
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn tool_define_has_annotations(args: &[SNode]) -> bool {
+        let Some(config) = args.get(3) else {
+            return false;
+        };
+        let Node::DictLiteral(entries) = &config.node else {
+            return false;
+        };
+        entries
+            .iter()
+            .any(|entry| Self::dict_key_name(&entry.key).as_deref() == Some("annotations"))
+    }
+
+    fn warn_missing_mcp_tool_annotations(&mut self, span: Span) {
+        self.diagnostics.push(LintDiagnostic {
+            rule: "mcp-tool-annotations",
+            message: "MCP-exposed `tool_define` registration has no `annotations`".to_string(),
+            span,
+            severity: LintSeverity::Warning,
+            suggestion: Some(
+                "add MCP `annotations` such as `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` before passing the registry to `mcp_tools`"
+                    .to_string(),
+            ),
+            fix: None,
+        });
     }
 
     fn warn_missing_secret_scan(&mut self, span: Span) {

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -235,6 +235,9 @@ impl<'a> Linter<'a> {
                 type_ann,
                 value,
             } => {
+                if let Some(name) = Self::simple_binding_name(pattern) {
+                    self.record_mcp_registry_binding(name, value);
+                }
                 self.lint_node(value);
                 if let Some(ann) = type_ann {
                     self.check_eager_collection_conversion(ann, value);
@@ -247,6 +250,9 @@ impl<'a> Linter<'a> {
                 type_ann,
                 value,
             } => {
+                if let Some(name) = Self::simple_binding_name(pattern) {
+                    self.record_mcp_registry_binding(name, value);
+                }
                 self.lint_node(value);
                 if let Some(ann) = type_ann {
                     self.check_eager_collection_conversion(ann, value);
@@ -256,6 +262,7 @@ impl<'a> Linter<'a> {
 
             Node::Assignment { target, value, .. } => {
                 if let Some(name) = Self::root_var_name(target) {
+                    self.record_mcp_registry_binding(&name, value);
                     self.assignments.insert(name);
                 }
                 self.lint_node(target);
@@ -271,6 +278,11 @@ impl<'a> Linter<'a> {
                 self.references.insert(name.clone());
                 self.function_references.insert(name.clone());
                 self.function_calls.push((name.clone(), snode.span));
+                if name == "mcp_tools" {
+                    if let Some(registry) = args.first() {
+                        self.warn_mcp_tools_missing_annotations(registry);
+                    }
+                }
                 if Self::is_assert_builtin(name) && !self.in_test_pipeline() {
                     self.diagnostics.push(LintDiagnostic {
                         rule: "assert-outside-test",

--- a/crates/harn-lint/src/tests/mcp_tools.rs
+++ b/crates/harn-lint/src/tests/mcp_tools.rs
@@ -1,0 +1,95 @@
+use super::*;
+
+#[test]
+fn mcp_tools_warns_for_unannotated_tool_define() {
+    let diagnostics = lint_source(
+        r#"
+pipeline main() {
+  var tools = tool_registry()
+  tools = tool_define(tools, "echo", "Echo input", {
+    parameters: {text: "string"},
+    handler: { args -> args.text },
+  })
+  mcp_tools(tools)
+}
+"#,
+    );
+
+    assert_eq!(count_rule(&diagnostics, "mcp-tool-annotations"), 1);
+}
+
+#[test]
+fn mcp_tools_accepts_annotated_tool_define() {
+    let diagnostics = lint_source(
+        r#"
+pipeline main() {
+  var tools = tool_registry()
+  tools = tool_define(tools, "echo", "Echo input", {
+    parameters: {text: "string"},
+    handler: { args -> args.text },
+    annotations: {readOnlyHint: true, idempotentHint: true, openWorldHint: false},
+  })
+  mcp_tools(tools)
+}
+"#,
+    );
+
+    assert!(!has_rule(&diagnostics, "mcp-tool-annotations"));
+}
+
+#[test]
+fn non_mcp_tool_define_does_not_warn() {
+    let diagnostics = lint_source(
+        r#"
+pipeline main() {
+  var tools = tool_registry()
+  tools = tool_define(tools, "echo", "Echo input", {
+    parameters: {text: "string"},
+    handler: { args -> args.text },
+  })
+  tool_count(tools)
+}
+"#,
+    );
+
+    assert!(!has_rule(&diagnostics, "mcp-tool-annotations"));
+}
+
+#[test]
+fn mcp_tools_warns_for_inline_unannotated_tool_define() {
+    let diagnostics = lint_source(
+        r#"
+pipeline main() {
+  mcp_tools(tool_define(tool_registry(), "echo", "Echo input", {
+    parameters: {text: "string"},
+    handler: { args -> args.text },
+  }))
+}
+"#,
+    );
+
+    assert_eq!(count_rule(&diagnostics, "mcp-tool-annotations"), 1);
+}
+
+#[test]
+fn mcp_tools_reports_only_unannotated_entries_in_chain() {
+    let diagnostics = lint_source(
+        r#"
+pipeline main() {
+  var tools = tool_registry()
+  tools = tool_define(tools, "read", "Read input", {
+    parameters: {},
+    handler: { _args -> "ok" },
+    annotations: {readOnlyHint: true},
+  })
+  tools = tool_define(tools, "write", "Write output", {
+    parameters: {},
+    handler: { _args -> "ok" },
+  })
+  mcp_tools(tools)
+}
+"#,
+    );
+
+    assert_eq!(count_rule(&diagnostics, "mcp-tool-annotations"), 1);
+}

--- a/crates/harn-lint/src/tests/mod.rs
+++ b/crates/harn-lint/src/tests/mod.rs
@@ -87,6 +87,7 @@ mod imports;
 mod invalid_binop;
 mod llm_rules;
 mod long_running;
+mod mcp_tools;
 mod mutability;
 mod naming_types;
 mod optional_shorthand;

--- a/crates/harn-serve/src/adapters/mcp.rs
+++ b/crates/harn-serve/src/adapters/mcp.rs
@@ -1111,7 +1111,15 @@ fn parse_cursor(params: &JsonValue) -> (usize, usize) {
 fn tool_entry(function: &crate::ExportedFunction) -> JsonValue {
     let mut entry = json!({
         "name": function.name,
+        "title": function.name,
         "description": format!("Invoke exported Harn function '{}'.", function.name),
+        "annotations": {
+            "title": function.name,
+            "readOnlyHint": false,
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": true,
+        },
         "inputSchema": function.input_schema,
     });
     if let Some(output_schema) = function.output_schema.clone() {
@@ -1325,6 +1333,8 @@ pub fn greet(name: string) -> string {
         let server = McpServer::new(McpServerConfig::new(core));
         let tools = server.tools_list_result(&json!({}));
         assert_eq!(tools["tools"][0]["name"], "greet");
+        assert_eq!(tools["tools"][0]["annotations"]["readOnlyHint"], false);
+        assert_eq!(tools["tools"][0]["annotations"]["destructiveHint"], true);
         assert_eq!(tools["tools"][0]["inputSchema"]["type"], "object");
         assert_eq!(tools["tools"][0]["outputSchema"]["type"], "string");
     }

--- a/crates/harn-vm/src/mcp_server/defs.rs
+++ b/crates/harn-vm/src/mcp_server/defs.rs
@@ -8,6 +8,7 @@ pub struct McpToolDef {
     pub input_schema: serde_json::Value,
     pub output_schema: Option<serde_json::Value>,
     pub annotations: Option<serde_json::Value>,
+    pub icons: Option<serde_json::Value>,
     pub handler: VmClosure,
 }
 

--- a/crates/harn-vm/src/mcp_server/server.rs
+++ b/crates/harn-vm/src/mcp_server/server.rs
@@ -256,6 +256,9 @@ impl McpServer {
                 if let Some(ref annotations) = t.annotations {
                     entry["annotations"] = annotations.clone();
                 }
+                if let Some(ref icons) = t.icons {
+                    entry["icons"] = icons.clone();
+                }
                 entry["execution"] = crate::mcp_protocol::tool_execution(
                     crate::mcp_protocol::McpToolTaskSupport::Forbidden,
                 );

--- a/crates/harn-vm/src/mcp_server/tests.rs
+++ b/crates/harn-vm/src/mcp_server/tests.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
-use crate::value::VmValue;
+use crate::chunk::{Chunk, CompiledFunction};
+use crate::value::{VmClosure, VmEnv, VmValue};
 
 use super::convert::{annotations_to_json, prompt_value_to_messages};
 use super::defs::McpResourceDef;
@@ -65,6 +66,75 @@ fn test_tool_registry_to_mcp_tools_empty() {
     registry.insert("tools".into(), VmValue::List(Rc::new(Vec::new())));
     let result = tool_registry_to_mcp_tools(&VmValue::Dict(Rc::new(registry)));
     assert!(result.unwrap().is_empty());
+}
+
+#[test]
+fn test_tool_registry_to_mcp_tools_preserves_metadata() {
+    let handler = VmValue::Closure(Rc::new(VmClosure {
+        func: Rc::new(CompiledFunction {
+            name: "echo".to_string(),
+            params: Vec::new(),
+            default_start: None,
+            chunk: Rc::new(Chunk::new()),
+            is_generator: false,
+            is_stream: false,
+            has_rest_param: false,
+        }),
+        env: VmEnv::new(),
+        source_dir: None,
+        module_functions: None,
+        module_state: None,
+    }));
+
+    let mut annotations = BTreeMap::new();
+    annotations.insert("readOnlyHint".into(), VmValue::Bool(true));
+    annotations.insert("idempotentHint".into(), VmValue::Bool(true));
+
+    let icon = VmValue::Dict(Rc::new({
+        let mut icon = BTreeMap::new();
+        icon.insert(
+            "src".into(),
+            VmValue::String(Rc::from("https://example.com/tool.png")),
+        );
+        icon.insert("mimeType".into(), VmValue::String(Rc::from("image/png")));
+        icon
+    }));
+
+    let mut tool = BTreeMap::new();
+    tool.insert("name".into(), VmValue::String(Rc::from("echo")));
+    tool.insert("title".into(), VmValue::String(Rc::from("Echo")));
+    tool.insert(
+        "description".into(),
+        VmValue::String(Rc::from("Echo input")),
+    );
+    tool.insert("handler".into(), handler);
+    tool.insert("parameters".into(), VmValue::Dict(Rc::new(BTreeMap::new())));
+    tool.insert("annotations".into(), VmValue::Dict(Rc::new(annotations)));
+    tool.insert("icons".into(), VmValue::List(Rc::new(vec![icon])));
+    tool.insert(
+        "outputSchema".into(),
+        VmValue::Dict(Rc::new({
+            let mut schema = BTreeMap::new();
+            schema.insert("type".into(), VmValue::String(Rc::from("string")));
+            schema
+        })),
+    );
+
+    let mut registry = BTreeMap::new();
+    registry.insert("_type".into(), VmValue::String(Rc::from("tool_registry")));
+    registry.insert(
+        "tools".into(),
+        VmValue::List(Rc::new(vec![VmValue::Dict(Rc::new(tool))])),
+    );
+
+    let tools = tool_registry_to_mcp_tools(&VmValue::Dict(Rc::new(registry))).unwrap();
+    assert_eq!(tools[0].title.as_deref(), Some("Echo"));
+    assert_eq!(tools[0].annotations.as_ref().unwrap()["readOnlyHint"], true);
+    assert_eq!(
+        tools[0].icons.as_ref().unwrap()[0]["src"],
+        "https://example.com/tool.png"
+    );
+    assert_eq!(tools[0].output_schema.as_ref().unwrap()["type"], "string");
 }
 
 #[test]

--- a/crates/harn-vm/src/mcp_server/tools_schema.rs
+++ b/crates/harn-vm/src/mcp_server/tools_schema.rs
@@ -48,7 +48,7 @@ pub fn tool_registry_to_mcp_tools(registry: &VmValue) -> Result<Vec<McpToolDef>,
             };
 
             let input_schema = params_to_json_schema(entry.get("parameters"));
-            let output_schema = entry.get("output_schema").and_then(|v| {
+            let output_schema = entry.get("outputSchema").and_then(|v| {
                 if let VmValue::Dict(_) = v {
                     Some(vm_value_to_json(v))
                 } else {
@@ -56,6 +56,13 @@ pub fn tool_registry_to_mcp_tools(registry: &VmValue) -> Result<Vec<McpToolDef>,
                 }
             });
             let annotations = entry.get("annotations").and_then(annotations_to_json);
+            let icons = entry.get("icons").and_then(|v| {
+                if let VmValue::List(_) = v {
+                    Some(vm_value_to_json(v))
+                } else {
+                    None
+                }
+            });
 
             mcp_tools.push(McpToolDef {
                 name,
@@ -64,6 +71,7 @@ pub fn tool_registry_to_mcp_tools(registry: &VmValue) -> Result<Vec<McpToolDef>,
                 input_schema,
                 output_schema,
                 annotations,
+                icons,
                 handler,
             });
         }

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1936,6 +1936,30 @@ registry = tool_define(registry, "ask_user", "Ask the user", {
 })
 ```
 
+Registries exposed through `mcp_tools(registry)` should declare MCP
+tool annotations on each `tool_define` entry. The MCP server forwards
+recognized `annotations` fields (`title`, `readOnlyHint`,
+`destructiveHint`, `idempotentHint`, and `openWorldHint`) plus
+top-level `title` and `icons` metadata into the `tools/list` response.
+`harn lint` warns when a registry passed to `mcp_tools` contains a
+`tool_define` entry without annotations.
+
+```harn
+registry = tool_define(registry, "repo.status", "Read repository status", {
+  parameters: {},
+  title: "Repository Status",
+  handler: { _args -> git.status() },
+  annotations: {
+    title: "Repository Status",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  icons: [{src: "https://example.com/repo-status.png", mimeType: "image/png"}],
+})
+```
+
 #### Tool surface validation
 
 `tool_surface_validate(surface, options?)` validates a tool-calling

--- a/examples/mcp_server.harn
+++ b/examples/mcp_server.harn
@@ -24,65 +24,77 @@ pipeline main(task) {
     "greet",
     "Greet someone by name",
     {
-    params: {name: "string"},
-    handler: { args -> "Hello, " + args.name + "! Welcome to Harn." },
-    annotations: {title: "Greeting Tool", readOnlyHint: true, destructiveHint: false},
-  },
+      parameters: {name: "string"},
+      handler: { args -> "Hello, " + args.name + "! Welcome to Harn." },
+      annotations: {
+        title: "Greeting Tool",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
   )
   tools = tool_define(
     tools,
     "add",
     "Add two numbers together",
     {
-    params: {a: "number", b: "number"},
-    handler: { args -> to_string(args.a + args.b) },
-    annotations: {readOnlyHint: true},
-  },
+      parameters: {a: "number", b: "number"},
+      handler: { args -> to_string(args.a + args.b) },
+      annotations: {
+        title: "Add Numbers",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
   )
   mcp_tools(tools)
   // ---- Static Resources ----
   mcp_resource(
     {
-    uri: "docs://readme",
-    name: "README",
-    description: "Project documentation",
-    mime_type: "text/markdown",
-    text: "# Harn MCP Demo\n\nThis is a demo MCP server built with Harn.",
-  },
+      uri: "docs://readme",
+      name: "README",
+      description: "Project documentation",
+      mime_type: "text/markdown",
+      text: "# Harn MCP Demo\n\nThis is a demo MCP server built with Harn.",
+    },
   )
   // ---- Resource Templates ----
   mcp_resource_template(
     {
-    uri_template: "config://{key}",
-    name: "Configuration Values",
-    description: "Read configuration by key",
-    mime_type: "text/plain",
-    handler: { args ->
-    if args.key == "version" {
-      "0.4.23"
-    } else {
-      if args.key == "name" {
-        "harn-demo"
-      } else {
-        "unknown key: " + args.key
-      }
-    }
-  },
-  },
+      uri_template: "config://{key}",
+      name: "Configuration Values",
+      description: "Read configuration by key",
+      mime_type: "text/plain",
+      handler: { args ->
+        if args.key == "version" {
+          "0.4.23"
+        } else {
+          if args.key == "name" {
+            "harn-demo"
+          } else {
+            "unknown key: " + args.key
+          }
+        }
+      },
+    },
   )
   // ---- Prompts ----
   mcp_prompt(
     {
-    name: "code_review",
-    description: "Review code for quality and suggest improvements",
-    arguments: [
-    {name: "code", description: "The code to review", required: true},
-    {name: "language", description: "Programming language"},
-  ],
-    handler: { args ->
-    let lang = args.language ?? "unknown"
-    "Please review this " + lang + " code for quality, bugs, and improvements:\n\n" + args.code
-  },
-  },
+      name: "code_review",
+      description: "Review code for quality and suggest improvements",
+      arguments: [
+        {name: "code", description: "The code to review", required: true},
+        {name: "language", description: "Programming language"},
+      ],
+      handler: { args ->
+        let lang = args.language ?? "unknown"
+        "Please review this " + lang + " code for quality, bugs, and improvements:\n\n" + args.code
+      },
+    },
   )
 }

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1934,6 +1934,30 @@ registry = tool_define(registry, "ask_user", "Ask the user", {
 })
 ```
 
+Registries exposed through `mcp_tools(registry)` should declare MCP
+tool annotations on each `tool_define` entry. The MCP server forwards
+recognized `annotations` fields (`title`, `readOnlyHint`,
+`destructiveHint`, `idempotentHint`, and `openWorldHint`) plus
+top-level `title` and `icons` metadata into the `tools/list` response.
+`harn lint` warns when a registry passed to `mcp_tools` contains a
+`tool_define` entry without annotations.
+
+```harn
+registry = tool_define(registry, "repo.status", "Read repository status", {
+  parameters: {},
+  title: "Repository Status",
+  handler: { _args -> git.status() },
+  annotations: {
+    title: "Repository Status",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  icons: [{src: "https://example.com/repo-status.png", mimeType: "image/png"}],
+})
+```
+
 #### Tool surface validation
 
 `tool_surface_validate(surface, options?)` validates a tool-calling


### PR DESCRIPTION
Closes #880

## Summary
- Emit MCP tool annotations and titles for built-in Harn orchestrator tools.
- Preserve script-authored MCP `title`, `annotations`, `icons`, and `returns` metadata through `tool_define` and `mcp_tools`.
- Add lint coverage that warns when a registry exposed via `mcp_tools` contains unannotated `tool_define` entries.
- Document the script-facing annotation surface and update the MCP example.

## Verification
- Pre-commit hook: Rust fmt, Harn fmt/lint, clippy, generated spec mirror, markdown lint.
- Rebased on `origin/main`.
- `git diff --check`
- `CARGO_BUILD_JOBS=2 cargo test -p harn-lint mcp_tools -- --nocapture`
- `CARGO_BUILD_JOBS=2 cargo test -p harn-vm test_tool_registry_to_mcp_tools_preserves_metadata -- --nocapture`
- `CARGO_BUILD_JOBS=2 cargo test -p harn-cli tools_list_advertises_tool_metadata_per_tool -- --nocapture`
- `CARGO_BUILD_JOBS=2 cargo test -p harn-serve tools_list_exposes_public_functions -- --nocapture`
- `CARGO_BUILD_JOBS=2 cargo test -p harn-cli serve_mcp_stdio_exposes_script_registered_surface --test harn_serve_mcp_cli -- --ignored --nocapture`
- `CARGO_BUILD_JOBS=2 cargo run --quiet --bin harn -- lint examples/mcp_server.harn conformance/tests/integration/mcp_tools.harn`
- `CARGO_BUILD_JOBS=2 cargo run --quiet --bin harn -- test conformance --filter mcp_tools`
- Pre-push hook: 3255 nextest tests passed, affected Harn formatting/lint, markdown lint, generated spec mirror.
