### PR TITLE
[codex] Fix four agent_loop bugs that broke Codex-style workflows

### DIFF
--- a/.experiments/README.md
+++ b/.experiments/README.md
@@ -1,0 +1,43 @@
+# Codex-loop manual evals
+
+Hand-run agent_loop scenarios against a local `llama-server` instance.
+Used to empirically validate the four bug fixes in commit
+`1439dd88` ("[codex] Fix four agent_loop bugs that broke Codex-style
+workflows"). Not CI-gated — they require a local llama.cpp server and a
+provider config.
+
+## Setup
+
+1. Start `llama-server` on `127.0.0.1:8080` with a model alias of
+   `qwen3.6` (see `providers.toml`).
+2. Build the harn binary: `cargo build --bin harn`.
+3. Point harn at the experimental provider config and run an eval, e.g.:
+
+   ```sh
+   HARN_PROVIDERS_CONFIG=$(pwd)/.experiments/providers.toml \
+     ./target/debug/harn run .experiments/exp2_sentinel_matrix.harn
+   ```
+
+   To capture the full request/response transcript for debugging, also
+   set `HARN_LLM_TRANSCRIPT_DIR=/tmp/some-dir` — the run will write
+   `llm_transcript.jsonl` there.
+
+## What each script tests
+
+| File | What it proves |
+|---|---|
+| `exp0_smoke.harn` | Single-tool calc loop terminates cleanly. Baseline sanity check. |
+| `exp2_sentinel_matrix.harn` | Multi-step investigation (3 mock tools) terminates with `status=done` across all four `tool_format × done_sentinel` cells. The canonical regression for the bug bundle. |
+| `exp2b_persistent.harn` | Same as exp2 but with `persistent: true`, to verify the `persistent` flag still controls only the text-only-turn break path (its actual semantic) and doesn't double-gate sentinel injection. |
+| `exp5_single_variant.harn` | Single-variant run with a `post_turn_callback` that logs per-iteration tool calls. Combine with `HARN_LLM_TRANSCRIPT_DIR` to inspect what messages the model actually receives. |
+| `exp6_optout_check.harn` | Sanity check on the three sentinel modes — default (`##DONE##`), opt-out (`""`), custom (`"STOP"`) — against the same minimal task. |
+
+## Why these matter
+
+The pre-fix runs of exp2 budget-exhausted at `max_iterations` in all
+four variants because the loop was reading the *real* harn workspace
+(custom `read_file` handler silently shadowed by the vm-stdlib
+short-circuit) instead of the tiny mock data the script intended to
+provide. Once user handler precedence was fixed, all four variants
+terminate naturally in 4-6 iterations with a correct answer
+(`compute(n) returns 2n+1, called as compute(5) in main → 11`).

--- a/.experiments/exp0_smoke.harn
+++ b/.experiments/exp0_smoke.harn
@@ -1,0 +1,25 @@
+/** Smoke test: minimal agent_loop call against local llama.cpp. */
+pipeline main(task) {
+  var registry = tool_registry()
+  registry = tool_define(
+    registry,
+    "calc",
+    "Evaluate a math expression",
+    {parameters: {expr: {type: "string"}}, handler: { _args -> "396" }},
+  )
+  log("Smoke test: calling agent_loop against llamacpp provider")
+  let result = agent_loop(
+    "What is 17 * 23 + 5? Use the calc tool.",
+    "/no_think You are a math assistant. Always use the calc tool for arithmetic.",
+    {
+      provider: "llamacpp",
+      model: "qwen3.6",
+      tool_format: "native",
+      done_sentinel: "",
+      persistent: false,
+      max_iterations: 5,
+      tools: registry,
+    },
+  )
+  log("status=${result.status} iters=${result.llm.iterations} text=${result.text}")
+}

--- a/.experiments/exp2_sentinel_matrix.harn
+++ b/.experiments/exp2_sentinel_matrix.harn
@@ -1,0 +1,129 @@
+/**
+ * EXP2: Sentinel on/off matrix with per-iteration logging.
+ *
+ * Goal: figure out empirically what `done_sentinel` does for non-persistent
+ * agent_loop on local Qwen3.6 in both native and text tool_format modes.
+ *
+ * post_turn_callback fires once per tool-call turn. We log the tool_count
+ * and tool_names so we can see exactly when (if ever) the model stops
+ * calling tools.
+ *
+ * Variants:
+ *   A: native + default sentinel (##DONE##)
+ *   B: native + done_sentinel: ""
+ *   C: text   + default sentinel
+ *   D: text   + done_sentinel: ""
+ *
+ * max_iterations is small (8) to bound cost.
+ */
+fn build_tools() -> dict {
+  var registry = tool_registry()
+  registry = tool_define(
+    registry,
+    "list_dir",
+    "List files in a directory",
+    {
+      parameters: {path: {type: "string"}},
+      handler: { args ->
+        if args.path == "." {
+          return "src/\nCargo.toml\nREADME.md"
+        }
+        if args.path == "src" {
+          return "main.rs\nlib.rs\nutils.rs"
+        }
+        return "(empty)"
+      },
+    },
+  )
+  registry = tool_define(
+    registry,
+    "read_file",
+    "Read the contents of a file",
+    {
+      parameters: {path: {type: "string"}},
+      handler: { args ->
+        if args.path == "src/main.rs" {
+          return "fn main() {\n    let x = compute(5);\n    println!(\"{}\", x);\n}"
+        }
+        if args.path == "src/utils.rs" {
+          return "pub fn compute(n: i32) -> i32 { n * 2 + 1 }"
+        }
+        if args.path == "src/lib.rs" {
+          return "pub mod utils;\npub use utils::*;"
+        }
+        if args.path == "Cargo.toml" {
+          return "[package]\nname = \"demo\"\nversion = \"0.1.0\""
+        }
+        return "(file not found: ${args.path})"
+      },
+    },
+  )
+  registry = tool_define(
+    registry,
+    "grep",
+    "Grep a pattern in files",
+    {
+      parameters: {pattern: {type: "string"}, path: {type: "string"}},
+      handler: { args ->
+        if args.pattern == "compute" {
+          return "src/main.rs:2:    let x = compute(5);\nsrc/utils.rs:1:pub fn compute(n: i32) -> i32 {"
+        }
+        return "(no matches)"
+      },
+    },
+  )
+  return registry
+}
+
+fn run_variant(label: string, mode: string, sentinel: string, registry: dict) -> dict {
+  log("\n--- ${label} (mode=${mode}, sentinel=\"${sentinel}\") ---")
+  let task = "Investigate this small repo and tell me what the compute function does and how it is used in main."
+  let system_prompt = "/no_think You are a coding agent. Use the available tools to investigate the repo step by step, then return a concise final answer to the user."
+  let cb = { info ->
+    let names = info?.tool_names ?? []
+    let count = info?.tool_count ?? 0
+    let iter = info?.iteration ?? 0
+    log("  [${label}] iter=${iter} tools=${count} names=${names}")
+    nil
+  }
+  var opts = {
+    provider: "llamacpp",
+    model: "qwen3.6",
+    tool_format: mode,
+    persistent: false,
+    max_iterations: 8,
+    tools: registry,
+    post_turn_callback: cb,
+  }
+  if sentinel != "(default)" {
+    opts = opts + {done_sentinel: sentinel}
+  }
+  let result = agent_loop(task, system_prompt, opts)
+  log("  [${label}] DONE status=${result.status} iters=${result.llm.iterations}")
+  let visible = result?.visible_text ?? ""
+  let visible_len = len(visible)
+  log("  [${label}] visible_len=${visible_len}")
+  if visible_len > 0 {
+    let head_len = if visible_len < 200 {
+      visible_len
+    } else {
+      200
+    }
+    log("  [${label}] visible[0..${head_len}]=${visible[:head_len]}")
+  }
+  return {label: label, status: result.status, iters: result.llm.iterations, visible_len: visible_len}
+}
+
+pipeline main(task) {
+  let registry = build_tools()
+  let results = [
+    run_variant("A:native+default", "native", "(default)", registry),
+    run_variant("B:native+empty", "native", "", registry),
+    run_variant("C:text+default", "text", "(default)", registry),
+    run_variant("D:text+empty", "text", "", registry),
+  ]
+  log("\n========== EXP2 SUMMARY ==========")
+  for r in results {
+    log("${r.label}: status=${r.status} iters=${r.iters} visible_len=${r.visible_len}")
+  }
+}

--- a/.experiments/exp2b_persistent.harn
+++ b/.experiments/exp2b_persistent.harn
@@ -1,0 +1,122 @@
+/**
+ * EXP2b: Confirm the hypothesis that `persistent: true` is what actually
+ * activates the sentinel instruction in the system prompt.
+ *
+ * Variants:
+ *   E: persistent + native + default sentinel
+ *   F: persistent + text   + default sentinel
+ *   G: persistent + native + done_sentinel: ""  (control: should NOT stop via sentinel)
+ *
+ * Same task and tools as exp2 so results are directly comparable.
+ */
+fn build_tools() -> dict {
+  var registry = tool_registry()
+  registry = tool_define(
+    registry,
+    "list_dir",
+    "List files in a directory",
+    {
+      parameters: {path: {type: "string"}},
+      handler: { args ->
+        if args.path == "." {
+          return "src/\nCargo.toml\nREADME.md"
+        }
+        if args.path == "src" {
+          return "main.rs\nlib.rs\nutils.rs"
+        }
+        return "(empty)"
+      },
+    },
+  )
+  registry = tool_define(
+    registry,
+    "read_file",
+    "Read the contents of a file",
+    {
+      parameters: {path: {type: "string"}},
+      handler: { args ->
+        if args.path == "src/main.rs" {
+          return "fn main() {\n    let x = compute(5);\n    println!(\"{}\", x);\n}"
+        }
+        if args.path == "src/utils.rs" {
+          return "pub fn compute(n: i32) -> i32 { n * 2 + 1 }"
+        }
+        if args.path == "src/lib.rs" {
+          return "pub mod utils;\npub use utils::*;"
+        }
+        if args.path == "Cargo.toml" {
+          return "[package]\nname = \"demo\"\nversion = \"0.1.0\""
+        }
+        return "(file not found: ${args.path})"
+      },
+    },
+  )
+  registry = tool_define(
+    registry,
+    "grep",
+    "Grep a pattern in files",
+    {
+      parameters: {pattern: {type: "string"}, path: {type: "string"}},
+      handler: { args ->
+        if args.pattern == "compute" {
+          return "src/main.rs:2:    let x = compute(5);\nsrc/utils.rs:1:pub fn compute(n: i32) -> i32 {"
+        }
+        return "(no matches)"
+      },
+    },
+  )
+  return registry
+}
+
+fn run_variant(label: string, mode: string, sentinel: string, registry: dict) -> dict {
+  log("\n--- ${label} (mode=${mode}, sentinel=\"${sentinel}\") ---")
+  let task = "Investigate this small repo and tell me what the compute function does and how it is used in main."
+  let system_prompt = "/no_think You are a coding agent. Use the available tools to investigate the repo step by step, then return a concise final answer to the user."
+  let cb = { info ->
+    let names = info?.tool_names ?? []
+    let count = info?.tool_count ?? 0
+    let iter = info?.iteration ?? 0
+    log("  [${label}] iter=${iter} tools=${count} names=${names}")
+    nil
+  }
+  var opts = {
+    provider: "llamacpp",
+    model: "qwen3.6",
+    tool_format: mode,
+    persistent: true,
+    max_iterations: 10,
+    tools: registry,
+    post_turn_callback: cb,
+  }
+  if sentinel != "(default)" {
+    opts = opts + {done_sentinel: sentinel}
+  }
+  let result = agent_loop(task, system_prompt, opts)
+  let visible = result?.visible_text ?? ""
+  let visible_len = len(visible)
+  log(
+    "  [${label}] DONE status=${result.status} iters=${result.llm.iterations} visible_len=${visible_len}",
+  )
+  if visible_len > 0 {
+    let head_len = if visible_len < 400 {
+      visible_len
+    } else {
+      400
+    }
+    log("  [${label}] visible=${visible[:head_len]}")
+  }
+  return {label: label, status: result.status, iters: result.llm.iterations, visible_len: visible_len}
+}
+
+pipeline main(task) {
+  let registry = build_tools()
+  let results = [
+    run_variant("E:persistent+native+default", "native", "(default)", registry),
+    run_variant("F:persistent+text+default", "text", "(default)", registry),
+    run_variant("G:persistent+native+empty", "native", "", registry),
+  ]
+  log("\n========== EXP2b SUMMARY ==========")
+  for r in results {
+    log("${r.label}: status=${r.status} iters=${r.iters} visible_len=${r.visible_len}")
+  }
+}

--- a/.experiments/exp5_single_variant.harn
+++ b/.experiments/exp5_single_variant.harn
@@ -1,0 +1,90 @@
+/**
+ * EXP5: Single variant of the multi-step investigation, run once with
+ * HARN_LLM_TRANSCRIPT_DIR set so we can inspect the full conversation
+ * the model sees iteration-by-iteration.
+ */
+fn build_tools() -> dict {
+  var registry = tool_registry()
+  registry = tool_define(
+    registry,
+    "list_dir",
+    "List files in a directory",
+    {
+      parameters: {path: {type: "string"}},
+      handler: { args ->
+        if args.path == "." {
+          return "src/\nCargo.toml\nREADME.md"
+        }
+        if args.path == "src" {
+          return "main.rs\nlib.rs\nutils.rs"
+        }
+        return "(empty)"
+      },
+    },
+  )
+  registry = tool_define(
+    registry,
+    "read_file",
+    "Read the contents of a file",
+    {
+      parameters: {path: {type: "string"}},
+      handler: { args ->
+        if args.path == "src/main.rs" {
+          return "fn main() {\n    let x = compute(5);\n    println!(\"{}\", x);\n}"
+        }
+        if args.path == "src/utils.rs" {
+          return "pub fn compute(n: i32) -> i32 { n * 2 + 1 }"
+        }
+        if args.path == "src/lib.rs" {
+          return "pub mod utils;\npub use utils::*;"
+        }
+        if args.path == "Cargo.toml" {
+          return "[package]\nname = \"demo\"\nversion = \"0.1.0\""
+        }
+        return "(file not found: ${args.path})"
+      },
+    },
+  )
+  registry = tool_define(
+    registry,
+    "grep",
+    "Grep a pattern in files",
+    {
+      parameters: {pattern: {type: "string"}, path: {type: "string"}},
+      handler: { args ->
+        if args.pattern == "compute" {
+          return "src/main.rs:2:    let x = compute(5);\nsrc/utils.rs:1:pub fn compute(n: i32) -> i32 {"
+        }
+        return "(no matches)"
+      },
+    },
+  )
+  return registry
+}
+
+pipeline main(task) {
+  let registry = build_tools()
+  let task_text = "Investigate this small repo and tell me what the compute function does and how it is used in main."
+  let system_prompt = "/no_think You are a coding agent. Use the available tools to investigate the repo step by step, then return a concise final answer to the user."
+  let cb = { info ->
+    let names = info?.tool_names ?? []
+    let count = info?.tool_count ?? 0
+    let iter = info?.iteration ?? 0
+    log("[exp5] iter=${iter} tools=${count} names=${names}")
+    nil
+  }
+  let result = agent_loop(
+    task_text,
+    system_prompt,
+    {
+      provider: "llamacpp",
+      model: "qwen3.6",
+      tool_format: "native",
+      persistent: false,
+      max_iterations: 6,
+      tools: registry,
+      post_turn_callback: cb,
+    },
+  )
+  log("[exp5] DONE status=${result.status} iters=${result.llm.iterations}")
+}

--- a/.experiments/exp6_optout_check.harn
+++ b/.experiments/exp6_optout_check.harn
@@ -1,0 +1,59 @@
+/** EXP6: Verify `done_sentinel: ""` opt-out cleanly omits sentinel guidance. */
+fn build_tools() -> dict {
+  var registry = tool_registry()
+  registry = tool_define(
+    registry,
+    "calc",
+    "Evaluate a math expression",
+    {parameters: {expr: {type: "string"}}, handler: { _args -> "396" }},
+  )
+  return registry
+}
+
+pipeline main(task) {
+  let registry = build_tools()
+  log("--- with default sentinel ---")
+  let r1 = agent_loop(
+    "What is 17 * 23 + 5?",
+    "/no_think You are a math assistant.",
+    {
+      provider: "llamacpp",
+      model: "qwen3.6",
+      tool_format: "native",
+      persistent: false,
+      max_iterations: 4,
+      tools: registry,
+    },
+  )
+  log("default: status=${r1.status} iters=${r1.llm.iterations}")
+  log("\n--- with done_sentinel: \"\" (opt out) ---")
+  let r2 = agent_loop(
+    "What is 17 * 23 + 5?",
+    "/no_think You are a math assistant.",
+    {
+      provider: "llamacpp",
+      model: "qwen3.6",
+      tool_format: "native",
+      persistent: false,
+      max_iterations: 4,
+      tools: registry,
+      done_sentinel: "",
+    },
+  )
+  log("opt-out: status=${r2.status} iters=${r2.llm.iterations}")
+  log("\n--- with done_sentinel: \"STOP\" (custom) ---")
+  let r3 = agent_loop(
+    "What is 17 * 23 + 5?",
+    "/no_think You are a math assistant.",
+    {
+      provider: "llamacpp",
+      model: "qwen3.6",
+      tool_format: "native",
+      persistent: false,
+      max_iterations: 4,
+      tools: registry,
+      done_sentinel: "STOP",
+    },
+  )
+  log("custom: status=${r3.status} iters=${r3.llm.iterations}")
+}

--- a/.experiments/providers.toml
+++ b/.experiments/providers.toml
@@ -1,0 +1,35 @@
+# Experimental providers config for the codex-style loop spike.
+# Set HARN_PROVIDERS_CONFIG=/Users/ksinder/projects/harn/.worktrees/codex-loop/.experiments/providers.toml
+# before invoking harn so it picks this up.
+
+[providers.llamacpp]
+display_name = "llama.cpp local"
+base_url = "http://127.0.0.1:8080/v1"
+auth_style = "none"
+chat_endpoint = "/chat/completions"
+
+[providers.anthropic]
+display_name = "Anthropic"
+base_url = "https://api.anthropic.com"
+auth_style = "header"
+auth_header = "x-api-key"
+auth_env = "ANTHROPIC_API_KEY"
+chat_endpoint = "/v1/messages"
+extra_headers = { "anthropic-version" = "2023-06-01" }
+
+[providers.openai]
+display_name = "OpenAI"
+base_url = "https://api.openai.com/v1"
+auth_style = "bearer"
+auth_env = "OPENAI_API_KEY"
+chat_endpoint = "/chat/completions"
+
+[aliases."qwen3.6"]
+id = "qwen3.6"
+provider = "llamacpp"
+tool_format = "native"
+
+[aliases."local"]
+id = "qwen3.6"
+provider = "llamacpp"
+tool_format = "native"

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -455,18 +455,22 @@ pub(super) async fn run_llm_call(
         );
     }
     if should_inject_protocol_feedback {
+        let done_line = if ctx.done_sentinel.is_empty() {
+            String::new()
+        } else {
+            format!("<done>{}</done>\n", ctx.done_sentinel)
+        };
         let feedback = format!(
             "Your response violated the tagged response protocol. Each issue:\n- {}\n\n\
              Re-emit using only these top-level tags, separated by whitespace:\n\n\
              <assistant_prose>short narration (optional)</assistant_prose>\n\
              <user_response>final user-facing answer (optional)</user_response>\n\
              <tool_call>\nname({{ key: value }})\n</tool_call>\n\
-             <done>{done_sentinel}</done>\n\n\
+             {done_line}\n\
              Nothing outside these tags is accepted. Do not paste source code, \
              diffs, JSON, or command output as prose — wrap each action in its \
              own <tool_call> block.",
             protocol_violations.join("\n- "),
-            done_sentinel = ctx.done_sentinel,
         );
         append_message_to_contexts(
             &mut state.visible_messages,
@@ -476,11 +480,18 @@ pub(super) async fn run_llm_call(
     }
 
     // Check sentinel on every response; when it coexists with tool calls
-    // we still process the tools, then exit.
-    let tagged_done_hit = tagged_done_marker
-        .as_deref()
-        .is_some_and(|body| body == ctx.done_sentinel);
-    let plain_done_hit = if ctx.tool_format == "native" {
+    // we still process the tools, then exit. An empty `done_sentinel` means
+    // the user has opted out of sentinel detection entirely — short-circuit
+    // before doing any string-contains checks (since `text.contains("")` is
+    // always true and would falsely signal completion every turn).
+    let sentinel_lookup_active = !ctx.done_sentinel.is_empty();
+    let tagged_done_hit = sentinel_lookup_active
+        && tagged_done_marker
+            .as_deref()
+            .is_some_and(|body| body == ctx.done_sentinel);
+    let plain_done_hit = if !sentinel_lookup_active {
+        false
+    } else if ctx.tool_format == "native" {
         // Native-mode providers may surface the sentinel in visible prose
         // while tool calls travel separately via the provider channel.
         text.contains(ctx.done_sentinel)
@@ -517,6 +528,7 @@ pub(super) async fn run_llm_call(
         .turn_policy
         .map(|policy| policy.allow_done_sentinel)
         .unwrap_or(true);
+    let sentinel_active = allow_done_sentinel && sentinel_lookup_active;
     // exit_when_verified: honor sentinel only if the last run() exit 0.
     let verified = !ctx.exit_when_verified || state.last_run_exit_code == Some(0);
     // Guard against premature exit where the model emits done without acting.
@@ -525,10 +537,20 @@ pub(super) async fn run_llm_call(
     // Ledger gate: reject done while open/blocked deliverables remain.
     let ledger_blocks_done = state.task_ledger.gates_done();
     let completion_requested =
-        sentinel_in_text || (allow_done_sentinel && user_response.as_deref().is_some());
-    let sentinel_hit = ctx.persistent
-        && ((completion_requested && verified && completion_ready && !ledger_blocks_done)
-            || phase_change);
+        sentinel_in_text || (sentinel_active && user_response.as_deref().is_some());
+    // Sentinel detection is no longer gated on `persistent`. The persistent
+    // flag governs whether the loop breaks on a text-only turn (post_turn);
+    // the model's explicit stop signal is honored in either mode. Persistent
+    // loops still apply the verification/ledger gates because those guard
+    // against premature completion in long-running multi-turn work; in
+    // non-persistent mode the request is "answer once" and the gates do
+    // not apply.
+    let sentinel_hit = if ctx.persistent {
+        (completion_requested && verified && completion_ready && !ledger_blocks_done)
+            || phase_change
+    } else {
+        completion_requested || phase_change
+    };
 
     if completion_requested && ledger_blocks_done && ctx.persistent {
         let corrective = state.task_ledger.done_gate_feedback();

--- a/crates/harn-vm/src/llm/agent/post_turn.rs
+++ b/crates/harn-vm/src/llm/agent/post_turn.rs
@@ -201,6 +201,8 @@ pub(super) async fn run_post_turn(
             })?;
             let info_vm = crate::stdlib::json_to_vm_value(&turn_info);
             let cb_result = cb_vm.call_closure_pub(closure, &[info_vm]).await?;
+            let cb_output = cb_vm.take_output();
+            crate::vm::forward_child_output_to_parent(&cb_output);
             let (message, stop) = interpret_post_turn_callback_result(&cb_result);
             if let Some(msg) = message {
                 if !msg.trim().is_empty() {

--- a/crates/harn-vm/src/llm/agent/state.rs
+++ b/crates/harn-vm/src/llm/agent/state.rs
@@ -790,6 +790,7 @@ impl AgentLoopState {
                 .is_some_and(|policy| policy.require_action_or_yield),
             self.config.tool_examples.as_deref(),
             !self.config.task_ledger.is_empty(),
+            &self.done_sentinel,
         );
         if let Some(client_cfg) = opts.tool_search.as_ref().filter(|c| c.include_stub_listing) {
             let mut stub_lines = Vec::new();
@@ -910,10 +911,19 @@ impl AgentLoopState {
         let config_skill_match = config.skill_match.clone();
         let config_working_files = config.working_files.clone();
         let custom_nudge = config.nudge.clone();
-        let done_sentinel = config
-            .done_sentinel
-            .clone()
-            .unwrap_or_else(|| "##DONE##".to_string());
+        // `done_sentinel` is the explicit "I'm done" stop signal the model
+        // can emit to terminate the loop:
+        //   - `None` (option omitted)  → default `##DONE##`
+        //   - `Some("")` (explicit empty) → opt out: no instruction injected
+        //     into the system prompt and no detection at all
+        //   - `Some(s)`                → custom sentinel `s`
+        // Detection sites guard with `!done_sentinel.is_empty()` so the empty
+        // case is a true no-op rather than relying on a sentinel literal that
+        // cannot appear in real text.
+        let done_sentinel = match config.done_sentinel.as_deref() {
+            None => "##DONE##".to_string(),
+            Some(s) => s.to_string(),
+        };
         let break_unless_phase = config.break_unless_phase.clone();
         let tool_retries = config.tool_retries;
         let tool_backoff_ms = config.tool_backoff_ms;
@@ -1109,6 +1119,7 @@ impl AgentLoopState {
                     .is_some_and(|policy| policy.require_action_or_yield),
                 tool_examples.as_deref(),
                 !config.task_ledger.is_empty(),
+                &done_sentinel,
             );
             // Client-mode tool_search: when the user opted into stub
             // listings, append a short "also available via search"
@@ -1165,23 +1176,30 @@ impl AgentLoopState {
             .as_ref()
             .map(|policy| policy.allow_done_sentinel)
             .unwrap_or(true);
+        // Sentinel injection is now driven by the sentinel value itself, not
+        // by `persistent`. The `persistent` flag controls only the loop's
+        // text-only-turn break behavior (see post_turn.rs); whether the
+        // model is *told* about the sentinel is orthogonal — a non-persistent
+        // tool-eager model still needs the explicit stop convention or it
+        // will exhaust the iteration budget.
+        let sentinel_active = allow_done_sentinel && !done_sentinel.is_empty();
         let done_instruction = if tool_format == "native" || !has_tools {
             format!("include `{done_sentinel}` exactly once in assistant text")
         } else {
             format!("emit `<done>{done_sentinel}</done>` as its own top-level block")
         };
-        let persistent_system_prompt = if persistent {
-            let progress_instruction = if has_tools {
-                if tool_format == "native" {
-                    "Use the provider tool channel until the request is complete; after tool evidence is sufficient, give the final user-facing answer in concise assistant text."
-                } else {
-                    "Use <tool_call> blocks until the request is complete; after tool evidence is sufficient, emit the final user-facing answer in a <user_response> block."
-                }
+        let progress_instruction = if has_tools {
+            if tool_format == "native" {
+                "Use the provider tool channel until the request is complete; after tool evidence is sufficient, give the final user-facing answer in concise assistant text."
             } else {
-                "Solve the request directly in assistant text — do not stop early to explain or summarize."
-            };
+                "Use <tool_call> blocks until the request is complete; after tool evidence is sufficient, emit the final user-facing answer in a <user_response> block."
+            }
+        } else {
+            "Solve the request directly in assistant text — do not stop early to explain or summarize."
+        };
+        let persistent_system_prompt = if persistent {
             if exit_when_verified {
-                if allow_done_sentinel {
+                if sentinel_active {
                     Some(format!(
                         "\n\nKeep working until the current request is complete. {progress_instruction} {} only after the current request passes verification.",
                         done_instruction,
@@ -1191,7 +1209,7 @@ impl AgentLoopState {
                         "\n\nKeep working until the current request is complete. {progress_instruction}"
                     ))
                 }
-            } else if allow_done_sentinel {
+            } else if sentinel_active {
                 Some(format!(
                     "\n\nIMPORTANT: You MUST keep working until the current request is complete. \
                      {progress_instruction} \
@@ -1204,6 +1222,15 @@ impl AgentLoopState {
                      {progress_instruction}"
                 ))
             }
+        } else if sentinel_active && has_tools {
+            // Non-persistent, tool-using loops: even though the loop will
+            // also break on a text-only turn, tool-eager models often never
+            // emit one. Tell the model the explicit stop convention so it
+            // can short-circuit when it's satisfied.
+            Some(format!(
+                "\n\nWhen you have produced the final answer for the user, {}.",
+                done_instruction
+            ))
         } else {
             None
         };

--- a/crates/harn-vm/src/llm/agent/turn_preflight.rs
+++ b/crates/harn-vm/src/llm/agent/turn_preflight.rs
@@ -109,6 +109,7 @@ pub(super) async fn run_turn_preflight(
                     .is_some_and(|policy| policy.require_action_or_yield),
                 state.config.tool_examples.as_deref(),
                 !state.config.task_ledger.is_empty(),
+                &state.done_sentinel,
             )
         });
     let tool_prompt_slot = dynamic_contract_prompt

--- a/crates/harn-vm/src/llm/agent_tools.rs
+++ b/crates/harn-vm/src/llm/agent_tools.rs
@@ -381,7 +381,10 @@ pub(super) async fn dispatch_tool_execution_with_mcp(
                 };
                 let args_vm = crate::stdlib::json_to_vm_value(tool_args);
                 let _trusted_bridge_guard = crate::orchestration::allow_trusted_bridge_calls();
-                match vm.call_closure_pub(&handler, &[args_vm]).await {
+                let outcome = vm.call_closure_pub(&handler, &[args_vm]).await;
+                let captured = vm.take_output();
+                crate::vm::forward_child_output_to_parent(&captured);
+                match outcome {
                     Ok(val) => Ok(serde_json::Value::String(val.display())),
                     Err(VmError::CategorizedError {
                         message,
@@ -415,18 +418,20 @@ pub(super) async fn dispatch_tool_execution_with_mcp(
                     category: ErrorCategory::ToolRejected,
                 })
             }
-        } else if let Some(local_result) = handle_tool_locally(tool_name, tool_args) {
-            // VM-stdlib short-circuit (read_file / list_directory). Any
-            // other tool falls through to the script-handler / bridge
-            // path below.
-            executor = Some(ToolExecutor::HarnBuiltin);
-            Ok(serde_json::Value::String(local_result))
         } else if let Some(handler) = find_tool_handler(tools_val, tool_name) {
-            // A Harn-side handler closure exists — but if the tool was
-            // sourced from `mcp_list_tools`, the dict carries the
-            // originating server name as `_mcp_server`, and the call is
-            // semantically "served by MCP" even though dispatch goes
-            // through a Harn closure that ultimately invokes mcp_call.
+            // User-registered Harn handler. Runs BEFORE the vm-stdlib
+            // short-circuit so user-defined tool semantics always win
+            // over the runtime's built-in `read_file`/`list_directory`
+            // shortcuts; otherwise a script that registers `read_file`
+            // with a custom handler (mock data, sandboxed paths, audit
+            // wrappers) would silently get the built-in real-filesystem
+            // read instead of the user's intent.
+            //
+            // If the tool was sourced from `mcp_list_tools`, the dict
+            // carries the originating server name as `_mcp_server`, and
+            // the call is semantically "served by MCP" even though
+            // dispatch goes through a Harn closure that ultimately
+            // invokes mcp_call.
             executor = Some(match mcp_server_for_tool(tools_val, tool_name) {
                 Some(server_name) => ToolExecutor::McpServer { server_name },
                 None => ToolExecutor::HarnBuiltin,
@@ -444,7 +449,10 @@ pub(super) async fn dispatch_tool_execution_with_mcp(
             };
             let args_vm = crate::stdlib::json_to_vm_value(tool_args);
             let _trusted_bridge_guard = crate::orchestration::allow_trusted_bridge_calls();
-            match vm.call_closure_pub(&handler, &[args_vm]).await {
+            let outcome = vm.call_closure_pub(&handler, &[args_vm]).await;
+            let captured = vm.take_output();
+            crate::vm::forward_child_output_to_parent(&captured);
+            match outcome {
                 Ok(val) => Ok(serde_json::Value::String(val.display())),
                 Err(VmError::CategorizedError {
                     message,
@@ -452,6 +460,13 @@ pub(super) async fn dispatch_tool_execution_with_mcp(
                 }) => Ok(denied_tool_result(tool_name, message)),
                 Err(e) => Ok(serde_json::Value::String(format!("Error: {e}"))),
             }
+        } else if let Some(local_result) = handle_tool_locally(tool_name, tool_args) {
+            // VM-stdlib short-circuit (read_file / list_directory) used
+            // when no user handler is registered for a tool name harn
+            // can service from its own stdlib. Provides the implicit
+            // "free" tools without forcing every script to wire them.
+            executor = Some(ToolExecutor::HarnBuiltin);
+            Ok(serde_json::Value::String(local_result))
         } else if let Some(bridge) = bridge {
             // Same `_mcp_server` discriminator: a host that surfaces an
             // MCP server's tools without a Harn-side closure (e.g. the

--- a/crates/harn-vm/src/llm/tools/contract_prompt.rs
+++ b/crates/harn-vm/src/llm/tools/contract_prompt.rs
@@ -27,6 +27,7 @@ pub(crate) fn build_tool_calling_contract_prompt(
     require_action: bool,
     tool_examples: Option<&str>,
     include_task_ledger_help: bool,
+    done_sentinel: &str,
 ) -> String {
     let mut prompt = String::from("\n\n## Tool Calling Contract\n");
     prompt.push_str(&format!(
@@ -34,27 +35,19 @@ pub(crate) fn build_tool_calling_contract_prompt(
     ));
 
     if mode == "native" {
-        prompt.push_str(NATIVE_CALL_CONTRACT_HELP);
+        prompt.push_str(&native_call_contract_help(done_sentinel));
         if require_action {
-            prompt.push_str(
-                "\nThis turn is action-gated. If tools are available, open your response \
-                 with a native tool call, not prose. Do not emit raw source code, diffs, \
-                 JSON, or `##DONE##` before the first successful tool action.\n",
-            );
+            prompt.push_str(&native_action_gated_clause(done_sentinel));
         }
         if include_task_ledger_help {
-            prompt.push_str(TASK_LEDGER_HELP);
+            prompt.push_str(&task_ledger_help(done_sentinel));
         }
     } else {
         // Front-load format + examples before schemas so weaker models
         // see the calling convention while attention is strongest.
-        prompt.push_str(TEXT_RESPONSE_PROTOCOL_HELP);
+        prompt.push_str(&text_response_protocol_help(done_sentinel));
         if require_action {
-            prompt.push_str(
-                "\nThis turn is action-gated. If tools are available, open your response \
-                 with a tool call (`<tool_call>...</tool_call>`), not prose. Do not emit \
-                 raw source code, diffs, JSON, or a <done> block before the first tool call.\n",
-            );
+            prompt.push_str(&text_action_gated_clause(done_sentinel));
         }
         if let Some(examples) = tool_examples {
             let trimmed = examples.trim();
@@ -65,7 +58,7 @@ pub(crate) fn build_tool_calling_contract_prompt(
             }
         }
         if include_task_ledger_help {
-            prompt.push_str(TASK_LEDGER_HELP);
+            prompt.push_str(&task_ledger_help(done_sentinel));
         }
 
         let (schemas, registry) = collect_tool_schemas_with_registry(tools_val, native_tools);
@@ -157,22 +150,41 @@ fn build_tool_args_type(params: &[ToolParamSchema]) -> TypeExpr {
     TypeExpr::Object(fields)
 }
 
-/// Help text for the fenceless TS call syntax. Declared as a constant so tests
-/// can assert on its content without duplicating the string.
-///
-/// The text is written to minimise backtick-counting demands on weaker models:
-/// prose references to single-character syntax use quoted descriptions
-/// ('backtick', 'double quote') and the ONE code example is embedded in the
-/// paragraph without any wrapping fence. Wrapping the example in a Markdown
-/// fenced code block caused confusion because models had to balance several
-/// levels of backticks at once.
-pub(crate) const TEXT_RESPONSE_PROTOCOL_HELP: &str = "
+/// Build the text-mode response protocol help block, substituting the
+/// configured sentinel value (or omitting the sentinel guidance entirely
+/// when the sentinel is opted out).
+pub(crate) fn text_response_protocol_help(done_sentinel: &str) -> String {
+    let (done_block_line, done_rule_line, completion_clause) = if done_sentinel.is_empty() {
+        (
+            String::new(),
+            String::new(),
+            "Once the request is satisfied and no more tool calls are needed, emit \
+             `<user_response>...</user_response>` with the final answer and do not \
+             include any `<tool_call>` block — that signals completion."
+                .to_string(),
+        )
+    } else {
+        (
+            format!("<done>{done_sentinel}</done>\n\n"),
+            format!(
+                "- `<done>{done_sentinel}</done>` signals task completion. Emit it only \
+                 after a successful verifying tool call; the runtime rejects it otherwise.\n"
+            ),
+            format!(
+                "Prefer `<tool_call>` over `<assistant_prose>` while work remains. Once no \
+                 more tool calls are needed, emit `<user_response>...</user_response>` and \
+                 then `<done>{done_sentinel}</done>`."
+            ),
+        )
+    };
+    format!(
+        "
 ## Response protocol
 
 Every response must be a sequence of these tags, with only whitespace between them:
 
 <tool_call>
-name({ key: value })
+name({{ key: value }})
 </tool_call>
 
 <assistant_prose>
@@ -183,52 +195,109 @@ Short narration. Optional.
 Final user-facing answer. Required when no more tool calls are needed.
 </user_response>
 
-<done>##DONE##</done>
-
-Rules the runtime enforces:
+{done_block_line}Rules the runtime enforces:
 
 - No text, code, diffs, JSON, or reasoning outside these tags. Any stray content is rejected with structured feedback.
-- `<tool_call>` wraps exactly one bare call `name({ key: value })`. Do not quote or JSON-encode the call. Use heredoc `<<TAG` ... `TAG` for multiline string fields — raw content, no escaping. Place TAG at the start of the closing line; closing punctuation like `},` may follow on that same line.
+- `<tool_call>` wraps exactly one bare call `name({{ key: value }})`. Do not quote or JSON-encode the call. Use heredoc `<<TAG` ... `TAG` for multiline string fields — raw content, no escaping. Place TAG at the start of the closing line; closing punctuation like `}},` may follow on that same line.
 - `<assistant_prose>` is optional and must be brief. Never paste source code, file contents, command transcripts, or long plans here — wrap those in the relevant tool call instead.
 - `<user_response>` is reserved for the final user-facing answer that hosts should surface. Emit it when the user should see a wrap-up or answer, and keep it concise and grounded.
-- `<done>##DONE##</done>` signals task completion. Emit it only after a successful verifying tool call; the runtime rejects it otherwise.
-- Do not prefix calls with labels like `tool_code:`, `python:`, `shell:`, or any language tag, and do not wrap tool calls in Markdown fences.
-- Prefer `<tool_call>` over `<assistant_prose>` while work remains. Once no more tool calls are needed, emit `<user_response>...</user_response>`.
+{done_rule_line}- Do not prefix calls with labels like `tool_code:`, `python:`, `shell:`, or any language tag, and do not wrap tool calls in Markdown fences.
+- {completion_clause}
 
 Example of a well-formed response:
 
 <assistant_prose>Creating the test file.</assistant_prose>
 <user_response>Created the test file.</user_response>
 <tool_call>
-edit({ action: \"create\", path: \"tests/test_foo.py\", content: <<EOF
+edit({{ action: \"create\", path: \"tests/test_foo.py\", content: <<EOF
 def test_foo():
     assert foo() == 42
 EOF
-})
+}})
 </tool_call>
-";
+"
+    )
+}
 
-pub(crate) const NATIVE_CALL_CONTRACT_HELP: &str = "
+/// Build the native-tool-protocol help block, substituting the sentinel.
+pub(crate) fn native_call_contract_help(done_sentinel: &str) -> String {
+    let completion_clause = if done_sentinel.is_empty() {
+        "When the task is complete and no more tool calls are needed, emit your \
+         final user-facing answer in `<user_response>...</user_response>` (or just \
+         plain assistant text) and stop calling tools — that signals completion."
+            .to_string()
+    } else {
+        format!(
+            "When the task is complete and no more tool calls are needed, include \
+             `{done_sentinel}` exactly once in assistant text."
+        )
+    };
+    format!(
+        "
 ## Native tool protocol
 
 The provider exposes tool definitions outside this prompt.
 
 - Invoke tools only through the provider's native tool-calling channel.
 - The current workflow/system prompt may mention only the tool names available for this stage; do not assume tools from earlier stages remain available.
-- Do not write text-mode tool tags, bare `name({ ... })` calls, Markdown code fences, or JSON tool-call envelopes in assistant text.
-- Keep assistant prose short and operational. If you emit a final user-facing answer, wrap it in `<user_response>...</user_response>`. When the task is complete and no more tool calls are needed, include `##DONE##` exactly once in assistant text.
-";
+- Do not write text-mode tool tags, bare `name({{ ... }})` calls, Markdown code fences, or JSON tool-call envelopes in assistant text.
+- Keep assistant prose short and operational. If you emit a final user-facing answer, wrap it in `<user_response>...</user_response>`. {completion_clause}
+"
+    )
+}
 
-pub(crate) const TASK_LEDGER_HELP: &str = "
+/// Action-gated guard injected when `turn_policy.require_action_or_yield` is true.
+pub(crate) fn native_action_gated_clause(done_sentinel: &str) -> String {
+    let sentinel_clause = if done_sentinel.is_empty() {
+        String::new()
+    } else {
+        format!(", or `{done_sentinel}`")
+    };
+    format!(
+        "\nThis turn is action-gated. If tools are available, open your response \
+         with a native tool call, not prose. Do not emit raw source code, diffs, \
+         JSON{sentinel_clause} before the first successful tool action.\n"
+    )
+}
+
+/// Action-gated guard for text mode.
+pub(crate) fn text_action_gated_clause(done_sentinel: &str) -> String {
+    let sentinel_clause = if done_sentinel.is_empty() {
+        String::new()
+    } else {
+        ", or a <done> block".to_string()
+    };
+    format!(
+        "\nThis turn is action-gated. If tools are available, open your response \
+         with a tool call (`<tool_call>...</tool_call>`), not prose. Do not emit \
+         raw source code, diffs, JSON{sentinel_clause} before the first tool call.\n"
+    )
+}
+
+/// Task-ledger help block. The "{done_sentinel} is rejected while any
+/// deliverable is open" clause only appears when a sentinel is configured.
+pub(crate) fn task_ledger_help(done_sentinel: &str) -> String {
+    let sentinel_block = if done_sentinel.is_empty() {
+        String::new()
+    } else {
+        format!(
+            " When a task ledger is present, the `{done_sentinel}` sentinel is rejected \
+             while any deliverable is `open` or `blocked`."
+        )
+    };
+    format!(
+        "
 ## Task ledger
 
-The runtime may inject a durable `<task_ledger>` of the user's deliverables above this prompt. Only use the `ledger` tool if that `<task_ledger>` block is actually present in the current turn. If no `<task_ledger>` block is present, ignore this section entirely and do not call `ledger(...)`. When a task ledger is present, the `##DONE##` sentinel is rejected while any deliverable is `open` or `blocked`. Use the ledger ids shown in that block; do not invent ids such as `deliverable-N`.
+The runtime may inject a durable `<task_ledger>` of the user's deliverables above this prompt. Only use the `ledger` tool if that `<task_ledger>` block is actually present in the current turn. If no `<task_ledger>` block is present, ignore this section entirely and do not call `ledger(...)`.{sentinel_block} Use the ledger ids shown in that block; do not invent ids such as `deliverable-N`.
 
-- `ledger({ action: \"add\", text: \"what needs to happen\" })` — declare a new sub-deliverable.
-- `ledger({ action: \"mark\", id: \"deliverable-id-from-task-ledger\", status: \"done\" })` — mark a deliverable complete after a real tool call satisfied it.
-- `ledger({ action: \"mark\", id: \"deliverable-id-from-task-ledger\", status: \"dropped\", note: \"why\" })` — escape hatch when scope truly changed; the note is required.
-- `ledger({ action: \"rationale\", text: \"one-sentence answer to why the user will call this done\" })` — commit to an interpretation of the success criterion.
-- `ledger({ action: \"note\", text: \"observation worth remembering across turns\" })` — durable cross-stage memory.
+- `ledger({{ action: \"add\", text: \"what needs to happen\" }})` — declare a new sub-deliverable.
+- `ledger({{ action: \"mark\", id: \"deliverable-id-from-task-ledger\", status: \"done\" }})` — mark a deliverable complete after a real tool call satisfied it.
+- `ledger({{ action: \"mark\", id: \"deliverable-id-from-task-ledger\", status: \"dropped\", note: \"why\" }})` — escape hatch when scope truly changed; the note is required.
+- `ledger({{ action: \"rationale\", text: \"one-sentence answer to why the user will call this done\" }})` — commit to an interpretation of the success criterion.
+- `ledger({{ action: \"note\", text: \"observation worth remembering across turns\" }})` — durable cross-stage memory.
 
 Prefer marking deliverables done only AFTER a concrete tool call demonstrates completion (an edit landed, a run() returned exit 0, a read confirmed an invariant). Don't mark done on prose alone.
-";
+"
+    )
+}

--- a/crates/harn-vm/src/llm/tools/mod.rs
+++ b/crates/harn-vm/src/llm/tools/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use collect::{collect_tool_schemas, validate_tool_args, ToolSchema};
 pub(crate) use components::ComponentRegistry;
 pub(crate) use contract_prompt::build_tool_calling_contract_prompt;
 #[cfg(test)]
-pub(crate) use contract_prompt::TEXT_RESPONSE_PROTOCOL_HELP;
+pub(crate) use contract_prompt::text_response_protocol_help;
 pub(crate) use handle_local::{handle_tool_locally, is_vm_stdlib_short_circuit};
 #[cfg(test)]
 pub(crate) use json_schema::json_schema_to_type_expr;

--- a/crates/harn-vm/src/llm/tools/tests/contract_prompt.rs
+++ b/crates/harn-vm/src/llm/tools/tests/contract_prompt.rs
@@ -1,12 +1,20 @@
 use super::{
     build_tool_calling_contract_prompt, collect_tool_schemas_with_registry, json,
-    normalize_tool_args, sample_tool_registry, ComponentRegistry, TEXT_RESPONSE_PROTOCOL_HELP,
+    normalize_tool_args, sample_tool_registry, text_response_protocol_help, ComponentRegistry,
 };
 
 #[test]
 fn contract_prompt_renders_edit_signature_with_enum_and_required_markers() {
     let tools = sample_tool_registry();
-    let prompt = build_tool_calling_contract_prompt(Some(&tools), None, "text", true, None, false);
+    let prompt = build_tool_calling_contract_prompt(
+        Some(&tools),
+        None,
+        "text",
+        true,
+        None,
+        false,
+        "##DONE##",
+    );
     // TypeScript declaration header.
     assert!(
         prompt.contains("declare function edit(args:"),
@@ -41,19 +49,36 @@ fn contract_prompt_renders_edit_signature_with_enum_and_required_markers() {
 
 #[test]
 fn contract_prompt_help_block_documents_tagged_protocol() {
-    // The help constant teaches the top-level tags, the call shape
+    // With the default sentinel: teaches the top-level tags, call shape
     // inside <tool_call>, and the done-block grammar.
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("Response protocol"));
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("<tool_call>"));
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("</tool_call>"));
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("<assistant_prose>"));
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("<user_response>"));
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("<done>##DONE##</done>"));
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("name({ key: value })"));
-    assert!(TEXT_RESPONSE_PROTOCOL_HELP.contains("heredoc"));
+    let help = text_response_protocol_help("##DONE##");
+    assert!(help.contains("Response protocol"));
+    assert!(help.contains("<tool_call>"));
+    assert!(help.contains("</tool_call>"));
+    assert!(help.contains("<assistant_prose>"));
+    assert!(help.contains("<user_response>"));
+    assert!(help.contains("<done>##DONE##</done>"));
+    assert!(help.contains("name({ key: value })"));
+    assert!(help.contains("heredoc"));
     // Legacy bare-call phrasing must not regress.
-    assert!(!TEXT_RESPONSE_PROTOCOL_HELP.contains("contains no tool calls"));
-    assert!(!TEXT_RESPONSE_PROTOCOL_HELP.contains("```call"));
+    assert!(!help.contains("contains no tool calls"));
+    assert!(!help.contains("```call"));
+
+    // With sentinel opt-out: the done block, the done rule, and the
+    // sentinel-named completion clause all disappear; the protocol still
+    // teaches the rest of the tag grammar.
+    let opt_out = text_response_protocol_help("");
+    assert!(opt_out.contains("Response protocol"));
+    assert!(opt_out.contains("<user_response>"));
+    assert!(!opt_out.contains("<done>"));
+    assert!(!opt_out.contains("##DONE##"));
+    assert!(opt_out.contains("no more tool calls are needed"));
+
+    // Custom sentinel: substitutes consistently in done block, rule, and
+    // completion clause.
+    let custom = text_response_protocol_help("STOP");
+    assert!(custom.contains("<done>STOP</done>"));
+    assert!(!custom.contains("##DONE##"));
 }
 
 #[test]
@@ -63,8 +88,15 @@ fn contract_prompt_native_mode_prefers_provider_channel_without_text_fallback() 
     // the text-mode response grammar or duplicate `declare function`
     // schemas that can confuse native-tool parsers.
     let tools = sample_tool_registry();
-    let prompt =
-        build_tool_calling_contract_prompt(Some(&tools), None, "native", true, None, false);
+    let prompt = build_tool_calling_contract_prompt(
+        Some(&tools),
+        None,
+        "native",
+        true,
+        None,
+        false,
+        "##DONE##",
+    );
     assert!(
         prompt.contains("native tool-calling channel"),
         "native preamble missing: {prompt}"
@@ -83,7 +115,15 @@ fn contract_prompt_native_mode_prefers_provider_channel_without_text_fallback() 
 #[test]
 fn contract_prompt_ledger_help_requires_visible_task_ledger_ids() {
     let tools = sample_tool_registry();
-    let prompt = build_tool_calling_contract_prompt(Some(&tools), None, "native", true, None, true);
+    let prompt = build_tool_calling_contract_prompt(
+        Some(&tools),
+        None,
+        "native",
+        true,
+        None,
+        true,
+        "##DONE##",
+    );
     assert!(
         prompt.contains(
             "Only use the `ledger` tool if that `<task_ledger>` block is actually present"
@@ -103,7 +143,15 @@ fn contract_prompt_ledger_help_requires_visible_task_ledger_ids() {
 #[test]
 fn contract_prompt_text_mode_mentions_action_gate_before_examples() {
     let tools = sample_tool_registry();
-    let prompt = build_tool_calling_contract_prompt(Some(&tools), None, "text", true, None, false);
+    let prompt = build_tool_calling_contract_prompt(
+        Some(&tools),
+        None,
+        "text",
+        true,
+        None,
+        false,
+        "##DONE##",
+    );
     assert!(prompt.contains("This turn is action-gated."));
     assert!(prompt.contains("`<tool_call>...</tool_call>`"));
     assert!(prompt.contains("Do not emit raw source code"));
@@ -113,8 +161,15 @@ fn contract_prompt_text_mode_mentions_action_gate_before_examples() {
 fn contract_prompt_includes_tool_examples_before_schemas() {
     let tools = sample_tool_registry();
     let examples = "read({ path: \"src/main.rs\" })\n\nedit({ action: \"create\", path: \"test.rs\", content: <<EOF\nfn main() {}\nEOF\n})";
-    let prompt =
-        build_tool_calling_contract_prompt(Some(&tools), None, "text", true, Some(examples), false);
+    let prompt = build_tool_calling_contract_prompt(
+        Some(&tools),
+        None,
+        "text",
+        true,
+        Some(examples),
+        false,
+        "##DONE##",
+    );
     // Examples section is present.
     assert!(
         prompt.contains("## Tool call examples"),
@@ -136,7 +191,15 @@ fn contract_prompt_includes_tool_examples_before_schemas() {
 #[test]
 fn contract_prompt_omits_examples_section_when_none() {
     let tools = sample_tool_registry();
-    let prompt = build_tool_calling_contract_prompt(Some(&tools), None, "text", true, None, false);
+    let prompt = build_tool_calling_contract_prompt(
+        Some(&tools),
+        None,
+        "text",
+        true,
+        None,
+        false,
+        "##DONE##",
+    );
     assert!(
         !prompt.contains("Tool call examples"),
         "should not have examples section when None"
@@ -175,8 +238,15 @@ fn native_schema_ref_resolves_to_component_alias() {
         "expected type alias for FilePath: {aliases}"
     );
     // The signature for `touch` should reference `FilePath` by name.
-    let prompt =
-        build_tool_calling_contract_prompt(None, Some(&native_tools), "text", false, None, false);
+    let prompt = build_tool_calling_contract_prompt(
+        None,
+        Some(&native_tools),
+        "text",
+        false,
+        None,
+        false,
+        "##DONE##",
+    );
     assert!(
         prompt.contains("type FilePath = string;"),
         "prompt missing alias: {prompt}"

--- a/crates/harn-vm/src/llm/tools/tests/mod.rs
+++ b/crates/harn-vm/src/llm/tools/tests/mod.rs
@@ -13,8 +13,8 @@ pub(super) use super::{
     build_assistant_tool_message, build_tool_calling_contract_prompt, build_tool_result_message,
     collect_tool_schemas, collect_tool_schemas_with_registry, extract_deferred_tool_names,
     normalize_tool_args, parse_bare_calls_in_body, parse_native_json_tool_calls,
-    parse_text_tool_calls_with_tools, validate_tool_args, vm_tools_to_native, ComponentRegistry,
-    TEXT_RESPONSE_PROTOCOL_HELP,
+    parse_text_tool_calls_with_tools, text_response_protocol_help, validate_tool_args,
+    vm_tools_to_native, ComponentRegistry,
 };
 pub(super) use crate::value::VmValue;
 pub(super) use serde_json::json;

--- a/crates/harn-vm/src/vm/async_builtin.rs
+++ b/crates/harn-vm/src/vm/async_builtin.rs
@@ -18,6 +18,26 @@ pub fn clone_async_builtin_child_vm() -> Option<Vm> {
     CURRENT_ASYNC_BUILTIN_CHILD_VM.with(|slot| slot.borrow().last().map(|vm| vm.child_vm()))
 }
 
+/// Forward captured output from a transient child VM (typically created via
+/// `clone_async_builtin_child_vm` and used to invoke a closure) back into the
+/// async-builtin's host stack entry. The dispatch loop drains that entry's
+/// output back to the original parent VM after the async builtin returns.
+///
+/// Without this hook, `log()`/`print()` calls inside `post_turn_callback`
+/// closures, tool handlers, and other VM-side closures invoked from async
+/// builtins would silently disappear because the transient cb_vm.output
+/// buffer is dropped on scope exit.
+pub fn forward_child_output_to_parent(text: &str) {
+    if text.is_empty() {
+        return;
+    }
+    CURRENT_ASYNC_BUILTIN_CHILD_VM.with(|slot| {
+        if let Some(top) = slot.borrow_mut().last_mut() {
+            top.append_output(text);
+        }
+    });
+}
+
 pub struct AsyncBuiltinChildVmGuard;
 
 pub fn install_async_builtin_child_vm(vm: Vm) -> AsyncBuiltinChildVmGuard {

--- a/crates/harn-vm/src/vm/dispatch.rs
+++ b/crates/harn-vm/src/vm/dispatch.rs
@@ -316,9 +316,14 @@ impl Vm {
                     slot.borrow_mut().push(self.child_vm());
                 });
                 let result = async_builtin(args).await;
-                CURRENT_ASYNC_BUILTIN_CHILD_VM.with(|slot| {
-                    slot.borrow_mut().pop();
+                let captured = CURRENT_ASYNC_BUILTIN_CHILD_VM.with(|slot| {
+                    let mut stack = slot.borrow_mut();
+                    let mut top = stack.pop();
+                    top.as_mut().map(|vm| vm.take_output()).unwrap_or_default()
                 });
+                if !captured.is_empty() {
+                    self.output.push_str(&captured);
+                }
                 result
             }
         }

--- a/crates/harn-vm/src/vm/mod.rs
+++ b/crates/harn-vm/src/vm/mod.rs
@@ -17,8 +17,8 @@ mod tests_runtime;
 
 #[allow(deprecated)]
 pub use async_builtin::{
-    clone_async_builtin_child_vm, install_async_builtin_child_vm, restore_async_builtin_child_vm,
-    take_async_builtin_child_vm, AsyncBuiltinChildVmGuard,
+    clone_async_builtin_child_vm, forward_child_output_to_parent, install_async_builtin_child_vm,
+    restore_async_builtin_child_vm, take_async_builtin_child_vm, AsyncBuiltinChildVmGuard,
 };
 pub use debug::{DebugAction, DebugState};
 pub use modules::resolve_module_import_path;

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -576,6 +576,20 @@ impl Vm {
         &self.output
     }
 
+    /// Drain and return the captured output, leaving the buffer empty.
+    /// Used by the async-builtin dispatch path to forward closure output
+    /// from a child VM back to its parent.
+    pub fn take_output(&mut self) -> String {
+        std::mem::take(&mut self.output)
+    }
+
+    /// Append text to this VM's captured output. Used to forward output
+    /// from child VMs (e.g. closures invoked via `call_closure_pub`)
+    /// back into the parent stream.
+    pub fn append_output(&mut self, text: &str) {
+        self.output.push_str(text);
+    }
+
     pub(crate) fn pop(&mut self) -> Result<VmValue, VmError> {
         self.stack.pop().ok_or(VmError::StackUnderflow)
     }


### PR DESCRIPTION
## Summary

Fixes four bugs that collectively prevented `agent_loop` from reliably terminating on multi-step coding tasks. Discovered while empirically validating a Codex-style loop against local Qwen3.6-35B-A3B + the harn worktree itself; the surface symptom was \"the loop never stops calling tools,\" but the root cause was a tool-handler precedence inversion that silently fed the model the wrong context.

All 1762 harn-vm unit tests pass after each fix. The model was never the problem — the harness was.

### The bugs (all in `crates/harn-vm/`)

1. **`agent_tools.rs` — vm-stdlib short-circuits shadow user handlers.** `read_file` / `list_directory` ran via `handle_tool_locally` *before* user-registered handlers. A script wiring `read_file` to mock data, sandboxed paths, or audit wrappers silently got the runtime's real-filesystem read instead. **Smoking gun for the symptom**: my exp scripts intended to feed tiny mock data (\"fn main() { let x = compute(5); ... }\") but the model was actually reading the entire harn workspace, and dutifully explored it forever. Swap the branch order so user handlers always win; the stdlib short-circuit is the implicit fallback for tool names with no registered handler.

2. **`vm/dispatch.rs` + `vm/async_builtin.rs` + `vm/state.rs` — closure output silently dropped.** `post_turn_callback` and tool-handler closures run on a child VM (`clone_async_builtin_child_vm()`), and that VM's `output` buffer was never drained. `log()` / `print()` inside callbacks went nowhere, making the loop opaque to anyone trying to instrument it. Adds `Vm::take_output` / `append_output`, a `forward_child_output_to_parent` helper that pushes captured output to the topmost async-builtin stack entry, and a drain step in the dispatch loop that copies that entry's output back to the parent VM's stream after the async builtin returns.

3. **`agent/state.rs` + `agent/llm_call.rs` — sentinel injection + detection gated on `persistent`.** `persistent_system_prompt` only built the sentinel-completion instruction when `persistent: true`, so a non-persistent loop with the default `done_sentinel: \"##DONE##\"` never told the model how to signal completion. Companion gate at `llm_call.rs:529` made `sentinel_hit = ctx.persistent && ...`, silently disabling sentinel detection in non-persistent mode. Decoupled both: `sentinel_active = allow_done_sentinel && !done_sentinel.is_empty()` drives both injection and detection regardless of `persistent`. The `persistent` flag now governs only its actual semantic — whether to break on a text-only turn vs continue. Also guards `text.contains(ctx.done_sentinel)` so the empty-sentinel opt-out case doesn't always match (`text.contains(\"\")` is `true`).

4. **`tools/contract_prompt.rs` — hardcoded `##DONE##`.** `NATIVE_CALL_CONTRACT_HELP`, `TEXT_RESPONSE_PROTOCOL_HELP`, and `TASK_LEDGER_HELP` were `&'static str` constants with `##DONE##` baked in. A user setting `done_sentinel: \"STOP\"` got a prompt telling the model to emit `##DONE##` instead. A user opting out via `done_sentinel: \"\"` got a prompt insisting they emit `##DONE##` even though detection was off. Convert to builder functions taking the configured sentinel; omit the sentinel-related lines entirely when the sentinel is empty.

### Empirical proof

`exp2_sentinel_matrix.harn` runs the same multi-step investigation task across `{native, text} × {default sentinel, opt-out}`:

| variant | before fixes | after fixes |
|---|---|---|
| native + default | budget_exhausted @ 8 | **status=done @ 5** |
| native + empty | budget_exhausted @ 8 | **status=done @ 5** |
| text + default | budget_exhausted @ 8 | **status=done @ 5** |
| text + empty | budget_exhausted @ 8 | **status=done @ 6** |

Sample answer Qwen3.6 produces post-fix: *\"The compute function is defined in src/utils.rs: pub fn compute(n: i32) -> i32 { n * 2 + 1 }. It computes 2n+1. In src/main.rs, compute(5) is called, which evaluates to 11, and the result is printed.\"*

### Manual evals included

`.experiments/` carries the five hand-runnable scripts that drove the diagnosis, plus a `providers.toml` for the local llama-server and a README. Not CI-gated — they require a running `llama-server`. Useful as regression baselines if anyone touches `agent_loop` prompt construction or tool dispatch in the future.

## Test plan

- [x] `cargo test -p harn-vm --lib` — 1762 / 1762 pass
- [x] `exp0_smoke.harn` — single-tool loop terminates cleanly
- [x] `exp2_sentinel_matrix.harn` — all four variants now `status=done` (matrix above)
- [x] `exp5_single_variant.harn` with `HARN_LLM_TRANSCRIPT_DIR` set — confirmed model receives mock data, not real harn workspace, and produces correct answer in iter 3
- [x] `exp6_optout_check.harn` — default + opt-out + custom sentinel all produce sensible behavior
- [ ] CI on this PR (rustfmt + clippy + workspace tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)