### PR TITLE
[codex] Add transcript-aware completion judge hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ condensed series summaries instead of full per-patch history.
   tool-use counts so judge logic can fork transcripts via
   `agent_session_fork_at` + `parallel settle` without any new runtime
   primitives.
+- **Built-in `verify_completion_judge` stop policy.** Hosts can now pass
+  `verify_completion_judge: true` or a policy dict to have Harn own the
+  structured completion-judge side call, transcript rendering, feedback
+  injection, optional final-response synthesis, and bounded retry loop.
+  The schema requires only `pass`; `feedback` and `final_response` are
+  optional and may be `null`, so weak local models do not need to emit
+  placeholder strings on passes.
 - **`post_turn_callback` enriched payload.** The post-turn callback now
   receives `session_id` so callbacks can address the live session, and
   the verdict shape was extended with an `injects: [{role, content}]`
@@ -69,6 +76,16 @@ condensed series summaries instead of full per-patch history.
   or value types went unnoticed. They now error
   (`'<name>' must be a closure or nil; got <type>`) so foot-guns surface
   immediately.
+- **Completion verification is conservative under judge failure.** The
+  built-in judge now treats malformed or schema-invalid structured
+  output as a veto with fallback feedback instead of confirming
+  completion. `max_verify_attempts` now defaults to 20 so product
+  integrations can safely allow long local-model recovery loops while
+  still capping infinite judge-veto cycles.
+- **Ollama native tool history replay.** Replayed assistant tool-call
+  history now uses the OpenAI-compatible string-encoded
+  `function.arguments` shape that modern Ollama validates, avoiding
+  second-iteration local Qwen failures after a native tool call.
 
 - **Merge Captain timeout ladder evals (#1014).** Added a reusable persona eval ladder runner for
   Merge Captain, exposed through `harn merge-captain ladder`, `harn eval`, `harn test package

--- a/crates/harn-vm/src/llm/agent/completion_judge.rs
+++ b/crates/harn-vm/src/llm/agent/completion_judge.rs
@@ -1,0 +1,398 @@
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use crate::value::{VmError, VmValue};
+
+use super::helpers::{append_message_to_contexts, runtime_feedback_message};
+use super::state::AgentLoopState;
+use super::{emit_agent_event, AgentEvent};
+
+const MAX_JUDGE_TRANSCRIPT_CHARS: usize = 32_000;
+const MAX_JUDGE_MESSAGE_CHARS: usize = 4_000;
+
+#[derive(Clone, Debug)]
+pub(crate) struct CompletionJudgeConfig {
+    pub system: String,
+    pub feedback_fallback: String,
+    pub max_feedback_chars: i64,
+    pub options: BTreeMap<String, VmValue>,
+}
+
+impl Default for CompletionJudgeConfig {
+    fn default() -> Self {
+        Self {
+            system: "You are a strict completion judge for an autonomous agent. Decide if the latest visible response is a safe final answer. Return only JSON.".to_string(),
+            feedback_fallback: "The completion judge was not satisfied. Continue with the smallest concrete next action before yielding.".to_string(),
+            max_feedback_chars: 600,
+            options: BTreeMap::new(),
+        }
+    }
+}
+
+pub(crate) fn parse_completion_judge_option(
+    options: &Option<BTreeMap<String, VmValue>>,
+) -> Result<Option<CompletionJudgeConfig>, VmError> {
+    let Some(value) = options
+        .as_ref()
+        .and_then(|dict| dict.get("verify_completion_judge"))
+    else {
+        return Ok(None);
+    };
+    match value {
+        VmValue::Nil => Ok(None),
+        VmValue::Bool(false) => Ok(None),
+        VmValue::Bool(true) => Ok(Some(CompletionJudgeConfig::default())),
+        VmValue::Dict(dict) => parse_completion_judge_dict(dict),
+        other => Err(VmError::Runtime(format!(
+            "verify_completion_judge must be true, false, nil, or a dict; got {}",
+            other.display()
+        ))),
+    }
+}
+
+fn parse_completion_judge_dict(
+    dict: &BTreeMap<String, VmValue>,
+) -> Result<Option<CompletionJudgeConfig>, VmError> {
+    if matches!(dict.get("enabled"), Some(VmValue::Bool(false))) {
+        return Ok(None);
+    }
+    let mut config = CompletionJudgeConfig::default();
+    if let Some(value) = dict.get("system") {
+        config.system = expect_string(value, "verify_completion_judge.system")?;
+    }
+    if let Some(value) = dict.get("feedback_fallback") {
+        config.feedback_fallback =
+            expect_string(value, "verify_completion_judge.feedback_fallback")?;
+    }
+    if let Some(value) = dict.get("max_feedback_chars") {
+        config.max_feedback_chars = value.as_int().ok_or_else(|| {
+            VmError::Runtime(
+                "verify_completion_judge.max_feedback_chars must be an integer".to_string(),
+            )
+        })?;
+    }
+    if let Some(value) = dict.get("options") {
+        let nested = value.as_dict().ok_or_else(|| {
+            VmError::Runtime("verify_completion_judge.options must be a dict".to_string())
+        })?;
+        config.options.extend(
+            nested
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone())),
+        );
+    }
+    for (key, value) in dict {
+        if matches!(
+            key.as_str(),
+            "enabled" | "system" | "feedback_fallback" | "max_feedback_chars" | "options"
+        ) {
+            continue;
+        }
+        config.options.insert(key.clone(), value.clone());
+    }
+    Ok(Some(config))
+}
+
+fn expect_string(value: &VmValue, field: &str) -> Result<String, VmError> {
+    match value {
+        VmValue::String(text) => Ok(text.to_string()),
+        _ => Err(VmError::Runtime(format!("{field} must be a string"))),
+    }
+}
+
+pub(super) async fn run_completion_judge(
+    state: &mut AgentLoopState,
+    config: &CompletionJudgeConfig,
+    main_opts: &crate::llm::api::LlmCallOptions,
+    session_id: &str,
+    iteration: usize,
+    stop_reason: &str,
+    last_text: &str,
+) -> Result<bool, VmError> {
+    let prompt = build_judge_prompt(state, session_id, iteration, stop_reason, last_text);
+    let schema = serde_json::json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["pass"],
+        "properties": {
+            "pass": {"type": "boolean"},
+            "feedback": {"type": ["string", "null"], "maxLength": config.max_feedback_chars},
+            "final_response": {"type": ["string", "null"], "maxLength": 2000},
+        },
+    });
+    let options = build_judge_options(config, main_opts);
+    let result = crate::llm::structured_envelope::llm_call_structured_result_impl(
+        vec![
+            VmValue::String(Rc::from(prompt)),
+            crate::stdlib::json_to_vm_value(&schema),
+            VmValue::Dict(Rc::new(options)),
+        ],
+        state.bridge.as_ref(),
+    )
+    .await?;
+    let Some(result_dict) = result.as_dict() else {
+        crate::events::log_warn(
+            "agent.verify_completion_judge",
+            "structured judge returned a non-dict envelope; vetoing completion with fallback feedback",
+        );
+        inject_judge_feedback(state, session_id, &config.feedback_fallback).await;
+        return Ok(true);
+    };
+    if !result_dict
+        .get("ok")
+        .is_some_and(|value| matches!(value, VmValue::Bool(true)))
+    {
+        crate::events::log_warn(
+            "agent.verify_completion_judge",
+            "structured judge failed; vetoing completion with fallback feedback",
+        );
+        inject_judge_feedback(state, session_id, &config.feedback_fallback).await;
+        return Ok(true);
+    }
+    let data = result_dict
+        .get("data")
+        .and_then(VmValue::as_dict)
+        .cloned()
+        .unwrap_or_default();
+    if data
+        .get("pass")
+        .is_some_and(|value| matches!(value, VmValue::Bool(true)))
+    {
+        if let Some(final_response) = data
+            .get("final_response")
+            .and_then(|value| match value {
+                VmValue::String(text) => Some(text.trim().to_string()),
+                _ => None,
+            })
+            .filter(|text| !text.is_empty())
+        {
+            state.last_iteration_text = final_response;
+        }
+        return Ok(false);
+    }
+    let feedback = data
+        .get("feedback")
+        .and_then(|value| match value {
+            VmValue::String(text) => Some(text.trim().to_string()),
+            _ => None,
+        })
+        .filter(|text| !text.is_empty())
+        .unwrap_or_else(|| config.feedback_fallback.clone());
+    inject_judge_feedback(state, session_id, &feedback).await;
+    Ok(true)
+}
+
+fn build_judge_prompt(
+    state: &AgentLoopState,
+    session_id: &str,
+    iteration: usize,
+    stop_reason: &str,
+    last_text: &str,
+) -> String {
+    let transcript = render_judge_transcript(state);
+    format!(
+        "Stop reason: {stop_reason}\nSession: {session_id}\nIteration: {iteration}\nSession tools used: {}\nSuccessful session tools: {}\n\nTranscript context:\n{transcript}\n\nLatest assistant text:\n{}\n\nDecide whether this agent loop may yield to the user now. Consider the original user request, recent assistant prose, tool calls, and tool result outputs together. If the latest assistant message included a tool call, do not require an extra prose-only turn when the assistant text plus tool result already form a clear final answer. Respond as JSON with keys pass (bool), optional feedback (string), and optional final_response (string). If not safe, feedback must be a concrete instruction for the next turn. If safe but the current visible answer is a pre-tool phrase, raw tool output, or otherwise not a clean final answer, provide final_response as a concise user-facing answer grounded only in the transcript.",
+        state.all_tools_used.join(", "),
+        state.successful_tools_used.join(", "),
+        last_text.trim()
+    )
+}
+
+fn render_judge_transcript(state: &AgentLoopState) -> String {
+    let messages = if state.visible_messages.is_empty() {
+        &state.recorded_messages
+    } else {
+        &state.visible_messages
+    };
+    let mut entries: Vec<(usize, String)> = messages
+        .iter()
+        .enumerate()
+        .map(|(index, message)| (index, render_judge_message(index, message)))
+        .collect();
+    if entries.is_empty() {
+        return state
+            .transcript_summary
+            .as_deref()
+            .filter(|summary| !summary.trim().is_empty())
+            .unwrap_or("<empty transcript>")
+            .to_string();
+    }
+
+    let mut selected: Vec<(usize, String)> = entries.drain(..entries.len().min(4)).collect();
+    let mut used_chars: usize = selected
+        .iter()
+        .map(|(_, entry)| entry.chars().count())
+        .sum();
+    if let Some(summary) = state
+        .transcript_summary
+        .as_deref()
+        .filter(|summary| !summary.trim().is_empty())
+    {
+        used_chars = used_chars.saturating_add(summary.chars().count());
+    }
+
+    let first_tail_index = selected
+        .last()
+        .map(|(index, _)| index.saturating_add(1))
+        .unwrap_or(0);
+    let mut tail: Vec<(usize, String)> = Vec::new();
+    for (index, entry) in entries.into_iter().rev() {
+        if index < first_tail_index {
+            continue;
+        }
+        let entry_chars = entry.chars().count();
+        if used_chars.saturating_add(entry_chars) > MAX_JUDGE_TRANSCRIPT_CHARS {
+            break;
+        }
+        used_chars = used_chars.saturating_add(entry_chars);
+        tail.push((index, entry));
+    }
+    tail.reverse();
+
+    let omitted_count = match (selected.last(), tail.first()) {
+        (Some((last_head_index, _)), Some((first_tail_index, _)))
+            if first_tail_index > last_head_index =>
+        {
+            first_tail_index.saturating_sub(last_head_index.saturating_add(1))
+        }
+        (Some((last_head_index, _)), None) => messages.len().saturating_sub(last_head_index + 1),
+        _ => 0,
+    };
+    if omitted_count > 0 {
+        selected.push((
+            first_tail_index,
+            format!("[... omitted {omitted_count} middle transcript message(s) ...]"),
+        ));
+    }
+    selected.extend(tail);
+
+    let mut output = String::new();
+    if let Some(summary) = state
+        .transcript_summary
+        .as_deref()
+        .filter(|summary| !summary.trim().is_empty())
+    {
+        output.push_str("Compacted transcript summary:\n");
+        output.push_str(summary.trim());
+        output.push_str("\n\n");
+    }
+    for (_, entry) in selected {
+        output.push_str(&entry);
+        output.push('\n');
+    }
+    output.trim_end().to_string()
+}
+
+fn render_judge_message(index: usize, message: &serde_json::Value) -> String {
+    let role = message
+        .get("role")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    let name = message
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .filter(|name| !name.trim().is_empty())
+        .map(|name| format!(" name={name}"))
+        .unwrap_or_default();
+    let tool_call_id = message
+        .get("tool_call_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|tool_call_id| !tool_call_id.trim().is_empty())
+        .map(|tool_call_id| format!(" tool_call_id={tool_call_id}"))
+        .unwrap_or_default();
+    let tool_calls = render_tool_calls_for_judge(message.get("tool_calls"));
+    let content = message
+        .get("content")
+        .map(render_message_content_for_judge)
+        .unwrap_or_default();
+    format!(
+        "[{index}] role={role}{name}{tool_call_id}{tool_calls}\n{}",
+        truncate_chars(content.trim(), MAX_JUDGE_MESSAGE_CHARS)
+    )
+}
+
+fn render_tool_calls_for_judge(tool_calls: Option<&serde_json::Value>) -> String {
+    let Some(tool_calls) = tool_calls.and_then(serde_json::Value::as_array) else {
+        return String::new();
+    };
+    if tool_calls.is_empty() {
+        return String::new();
+    }
+    let names: Vec<String> = tool_calls
+        .iter()
+        .map(|tool_call| {
+            tool_call
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .or_else(|| {
+                    tool_call
+                        .get("function")
+                        .and_then(|function| function.get("name"))
+                        .and_then(serde_json::Value::as_str)
+                })
+                .unwrap_or("unknown")
+                .to_string()
+        })
+        .collect();
+    format!(" tool_calls={}", names.join(","))
+}
+
+fn render_message_content_for_judge(content: &serde_json::Value) -> String {
+    match content {
+        serde_json::Value::String(text) => text.clone(),
+        other => serde_json::to_string(other).unwrap_or_else(|_| other.to_string()),
+    }
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let mut truncated: String = text.chars().take(max_chars).collect();
+    truncated.push_str("\n[... truncated ...]");
+    truncated
+}
+
+fn build_judge_options(
+    config: &CompletionJudgeConfig,
+    main_opts: &crate::llm::api::LlmCallOptions,
+) -> BTreeMap<String, VmValue> {
+    let mut options = config.options.clone();
+    options
+        .entry("system".to_string())
+        .or_insert_with(|| VmValue::String(Rc::from(config.system.clone())));
+    options
+        .entry("provider".to_string())
+        .or_insert_with(|| VmValue::String(Rc::from(main_opts.provider.clone())));
+    options
+        .entry("model".to_string())
+        .or_insert_with(|| VmValue::String(Rc::from(main_opts.model.clone())));
+    options
+        .entry("temperature".to_string())
+        .or_insert(VmValue::Float(0.0));
+    options
+        .entry("max_tokens".to_string())
+        .or_insert(VmValue::Int(800));
+    options
+        .entry("schema_retries".to_string())
+        .or_insert(VmValue::Int(1));
+    options
+        .entry("thinking".to_string())
+        .or_insert(VmValue::Bool(false));
+    options
+}
+
+async fn inject_judge_feedback(state: &mut AgentLoopState, session_id: &str, feedback: &str) {
+    let message = runtime_feedback_message("verify_completion", feedback);
+    append_message_to_contexts(
+        &mut state.visible_messages,
+        &mut state.recorded_messages,
+        message,
+    );
+    emit_agent_event(&AgentEvent::FeedbackInjected {
+        session_id: session_id.to_string(),
+        kind: "verify_completion_judge".to_string(),
+        content: feedback.to_string(),
+    })
+    .await;
+}

--- a/crates/harn-vm/src/llm/agent/helpers.rs
+++ b/crates/harn-vm/src/llm/agent/helpers.rs
@@ -184,31 +184,6 @@ pub(crate) fn action_turn_nudge(
     ))
 }
 
-pub(crate) fn sentinel_without_action_nudge(
-    tool_format: &str,
-    turn_policy: Option<&crate::orchestration::TurnPolicy>,
-) -> String {
-    let completion_signal = if tool_format == "native" {
-        "`##DONE##`"
-    } else {
-        "a <done> block"
-    };
-    let mut message = if turn_policy.is_some_and(|policy| !policy.allow_done_sentinel) {
-        format!(
-            "You emitted {completion_signal} in a workflow-owned action stage. The task is not complete yet. Make concrete progress with an available tool now, or switch phase if the workflow allows it. Do not output {completion_signal} in this stage."
-        )
-    } else {
-        format!(
-            "You emitted {completion_signal} without taking any tool action. The task is not complete yet. Make concrete progress with an available tool now, or switch phase if the workflow allows it. Do not emit {completion_signal} again until you have acted."
-        )
-    };
-    if let Some(nudge) = action_turn_nudge(tool_format, true, turn_policy, false) {
-        message.push(' ');
-        message.push_str(&nudge);
-    }
-    message
-}
-
 pub(crate) async fn inject_queued_user_messages(
     bridge: Option<&Rc<crate::bridge::HostBridge>>,
     messages: &mut Vec<serde_json::Value>,

--- a/crates/harn-vm/src/llm/agent/llm_call.rs
+++ b/crates/harn-vm/src/llm/agent/llm_call.rs
@@ -45,7 +45,7 @@ use super::super::helpers::{expects_structured_output, transcript_event};
 use super::super::tools::{collect_tool_schemas, parse_text_tool_calls_with_tools};
 use super::helpers::{
     append_message_to_contexts, loop_state_requests_phase_change, prose_exceeds_budget,
-    runtime_feedback_message, sentinel_without_action_nudge, trim_prose_for_history,
+    runtime_feedback_message, trim_prose_for_history,
 };
 use super::state::AgentLoopState;
 
@@ -531,13 +531,10 @@ pub(super) async fn run_llm_call(
     let sentinel_active = allow_done_sentinel && sentinel_lookup_active;
     // exit_when_verified: honor sentinel only if the last run() exit 0.
     let verified = !ctx.exit_when_verified || state.last_run_exit_code == Some(0);
-    // Guard against premature exit where the model emits done without acting.
-    let has_acted = !state.all_tools_used.is_empty() || !tool_calls.is_empty();
-    let completion_ready = has_acted || !ctx.has_tools;
     // Ledger gate: reject done while open/blocked deliverables remain.
     let ledger_blocks_done = state.task_ledger.gates_done();
-    let completion_requested =
-        sentinel_in_text || (sentinel_active && user_response.as_deref().is_some());
+    let completion_requested = tool_calls.is_empty()
+        && (sentinel_in_text || (sentinel_active && user_response.as_deref().is_some()));
     // Sentinel detection is no longer gated on `persistent`. The persistent
     // flag governs whether the loop breaks on a text-only turn (post_turn);
     // the model's explicit stop signal is honored in either mode. Persistent
@@ -546,8 +543,7 @@ pub(super) async fn run_llm_call(
     // non-persistent mode the request is "answer once" and the gates do
     // not apply.
     let sentinel_hit = if ctx.persistent {
-        (completion_requested && verified && completion_ready && !ledger_blocks_done)
-            || phase_change
+        (completion_requested && verified && !ledger_blocks_done) || phase_change
     } else {
         completion_requested || phase_change
     };
@@ -577,15 +573,6 @@ pub(super) async fn run_llm_call(
             runtime_feedback_message("verification_gate", corrective),
         );
     }
-    if completion_requested && !has_acted && ctx.persistent && ctx.has_tools {
-        let corrective = sentinel_without_action_nudge(ctx.tool_format, ctx.turn_policy);
-        append_message_to_contexts(
-            &mut state.visible_messages,
-            &mut state.recorded_messages,
-            runtime_feedback_message("sentinel_without_action", corrective),
-        );
-    }
-
     // Intercept `ledger(...)` before normal dispatch — it mutates
     // task_ledger state and has no host executor.
     let mut tool_calls: Vec<serde_json::Value> = tool_calls;

--- a/crates/harn-vm/src/llm/agent/mod.rs
+++ b/crates/harn-vm/src/llm/agent/mod.rs
@@ -8,6 +8,7 @@ use crate::value::{VmError, VmValue};
 use super::agent_config::AgentLoopConfig;
 
 mod agent_mcp;
+pub(crate) mod completion_judge;
 mod finalize;
 mod helpers;
 mod llm_call;
@@ -502,6 +503,7 @@ pub async fn run_agent_loop_internal(
     let stop_after_successful_tools = state.config.stop_after_successful_tools.clone();
     let post_turn_callback = state.config.post_turn_callback.clone();
     let verify_completion = state.config.verify_completion.clone();
+    let verify_completion_judge = state.config.verify_completion_judge.clone();
     let max_verify_attempts = state.config.max_verify_attempts;
     let bridge = state.bridge.clone();
     let max_iterations = state.max_iterations;
@@ -684,6 +686,8 @@ pub async fn run_agent_loop_internal(
                 turn_policy: turn_policy.as_ref(),
                 stop_after_successful_tools: &stop_after_successful_tools,
                 post_turn_callback: &post_turn_callback,
+                verify_completion_enabled: verify_completion.is_some()
+                    || verify_completion_judge.is_some(),
                 auto_compact: &auto_compact,
                 daemon_config: &daemon_config,
                 custom_nudge: &custom_nudge,
@@ -724,12 +728,12 @@ pub async fn run_agent_loop_internal(
         match iteration_outcome {
             post_turn::IterationOutcome::Continue => continue,
             post_turn::IterationOutcome::Break => {
-                // verify_completion stop hook: when set, runs at every
+                // verify_completion stop hooks: when set, run at every
                 // natural break and may veto with feedback so a "false
                 // done" gets one more turn instead of yielding to the
                 // caller. Bounded by max_verify_attempts to prevent a
                 // buggy judge from holding the loop open.
-                if let Some(closure_value) = verify_completion.as_ref() {
+                if verify_completion.is_some() || verify_completion_judge.is_some() {
                     if verify_attempts >= max_verify_attempts {
                         crate::events::log_warn(
                             "agent.verify_completion",
@@ -747,15 +751,32 @@ pub async fn run_agent_loop_internal(
                         "" => "natural",
                         other => other,
                     };
-                    let veto = post_turn::run_verify_completion(
-                        &mut state,
-                        closure_value,
-                        &session_id,
-                        iteration,
-                        stop_reason,
-                        &call_result.text,
-                    )
-                    .await?;
+                    let mut veto = false;
+                    if let Some(closure_value) = verify_completion.as_ref() {
+                        veto = post_turn::run_verify_completion(
+                            &mut state,
+                            closure_value,
+                            &session_id,
+                            iteration,
+                            stop_reason,
+                            &call_result.text,
+                        )
+                        .await?;
+                    }
+                    if !veto {
+                        if let Some(judge) = verify_completion_judge.as_ref() {
+                            veto = completion_judge::run_completion_judge(
+                                &mut state,
+                                judge,
+                                opts,
+                                &session_id,
+                                iteration,
+                                stop_reason,
+                                &call_result.text,
+                            )
+                            .await?;
+                        }
+                    }
                     if veto {
                         verify_attempts += 1;
                         crate::events::log_debug(

--- a/crates/harn-vm/src/llm/agent/post_turn.rs
+++ b/crates/harn-vm/src/llm/agent/post_turn.rs
@@ -58,6 +58,8 @@ use super::llm_call::LlmCallResult;
 use super::state::AgentLoopState;
 use super::tool_dispatch::ToolDispatchResult;
 
+const MAX_FINAL_TOOL_RESULT_CHARS: usize = 4_000;
+
 pub(super) enum IterationOutcome {
     Continue,
     Break,
@@ -74,6 +76,7 @@ pub(super) struct PostTurnContext<'a> {
     pub turn_policy: Option<&'a TurnPolicy>,
     pub stop_after_successful_tools: &'a Option<Vec<String>>,
     pub post_turn_callback: &'a Option<VmValue>,
+    pub verify_completion_enabled: bool,
     pub auto_compact: &'a Option<AutoCompactConfig>,
     pub daemon_config: &'a DaemonLoopConfig,
     pub custom_nudge: &'a Option<String>,
@@ -250,6 +253,34 @@ pub(super) async fn run_post_turn(
                 );
                 return Ok(IterationOutcome::Break);
             }
+        }
+
+        let tool_turn_has_failure = dispatch
+            .tool_results_this_iter
+            .iter()
+            .any(|result| result["status"].as_str() != Some("ok"))
+            || !call_result.tool_parse_errors.is_empty();
+        let tool_turn_has_success = dispatch
+            .tool_results_this_iter
+            .iter()
+            .any(|result| result["status"].as_str() == Some("ok"));
+        let tool_turn_has_visible_answer = !call_result.text.trim().is_empty();
+        if ctx.verify_completion_enabled
+            && tool_turn_has_success
+            && !tool_turn_has_failure
+            && tool_turn_has_visible_answer
+        {
+            state.last_iteration_text = verified_tool_turn_visible_text(
+                state,
+                call_result,
+                dispatch.tool_results_this_iter.len(),
+                &dispatch.observations,
+            );
+            crate::events::log_debug(
+                "agent.verify_completion",
+                &format!("iter={iteration} checking successful tool turn as an exit candidate"),
+            );
+            return Ok(IterationOutcome::Break);
         }
 
         // Include system prompt + tool defs in the estimate since they
@@ -822,6 +853,65 @@ pub(super) async fn run_post_turn(
     )
     .await?;
     Ok(IterationOutcome::Continue)
+}
+
+fn verified_tool_turn_visible_text(
+    state: &AgentLoopState,
+    call_result: &LlmCallResult,
+    tool_result_count: usize,
+    observations: &str,
+) -> String {
+    let assistant_text = call_result.text.trim();
+    let tool_results = final_tool_result_text(state, tool_result_count, observations);
+    if tool_results.trim().is_empty() {
+        return assistant_text.to_string();
+    }
+    let label = if tool_result_count == 1 {
+        "Tool result"
+    } else {
+        "Tool results"
+    };
+    if assistant_text.is_empty() {
+        return format!("{label}:\n{tool_results}");
+    }
+    format!("{assistant_text}\n\n{label}:\n{tool_results}")
+}
+
+fn final_tool_result_text(
+    state: &AgentLoopState,
+    tool_result_count: usize,
+    observations: &str,
+) -> String {
+    if !observations.trim().is_empty() {
+        return truncate_tool_result_text(observations.trim());
+    }
+    let mut tool_messages: Vec<String> = state
+        .visible_messages
+        .iter()
+        .rev()
+        .filter(|message| message["role"].as_str() == Some("tool"))
+        .take(tool_result_count)
+        .filter_map(|message| message.get("content"))
+        .map(render_tool_message_content)
+        .collect();
+    tool_messages.reverse();
+    truncate_tool_result_text(tool_messages.join("\n\n").trim())
+}
+
+fn render_tool_message_content(content: &serde_json::Value) -> String {
+    match content {
+        serde_json::Value::String(text) => text.clone(),
+        other => serde_json::to_string(other).unwrap_or_else(|_| other.to_string()),
+    }
+}
+
+fn truncate_tool_result_text(text: &str) -> String {
+    if text.chars().count() <= MAX_FINAL_TOOL_RESULT_CHARS {
+        return text.to_string();
+    }
+    let mut truncated: String = text.chars().take(MAX_FINAL_TOOL_RESULT_CHARS).collect();
+    truncated.push_str("\n[... truncated ...]");
+    truncated
 }
 
 /// Run the `verify_completion` closure once and apply its decision.

--- a/crates/harn-vm/src/llm/agent/tests/mod.rs
+++ b/crates/harn-vm/src/llm/agent/tests/mod.rs
@@ -5,8 +5,8 @@
 
 pub(super) use super::helpers::{
     action_turn_nudge, assistant_history_text, has_successful_tools,
-    loop_state_requests_phase_change, prose_exceeds_budget, sentinel_without_action_nudge,
-    should_stop_after_successful_tools, trim_prose_for_history,
+    loop_state_requests_phase_change, prose_exceeds_budget, should_stop_after_successful_tools,
+    trim_prose_for_history,
 };
 pub(super) use super::run_agent_loop_internal;
 pub(super) use crate::bridge::HostBridge;
@@ -124,7 +124,8 @@ pub(super) fn base_agent_config() -> AgentLoopConfig {
         task_ledger: Default::default(),
         post_turn_callback: None,
         verify_completion: None,
-        max_verify_attempts: 3,
+        verify_completion_judge: None,
+        max_verify_attempts: crate::llm::agent_config::DEFAULT_MAX_VERIFY_ATTEMPTS,
         llm_transcript_dir: None,
         skill_registry: None,
         skill_match: Default::default(),

--- a/crates/harn-vm/src/llm/agent/tests/prompts.rs
+++ b/crates/harn-vm/src/llm/agent/tests/prompts.rs
@@ -43,32 +43,6 @@ fn native_action_turn_nudge_mentions_bare_done_sentinel() {
 }
 
 #[test]
-fn sentinel_without_action_nudge_stays_stage_agnostic() {
-    let policy = TurnPolicy {
-        require_action_or_yield: true,
-        allow_done_sentinel: true,
-        max_prose_chars: Some(180),
-    };
-    let msg = sentinel_without_action_nudge("text", Some(&policy));
-    assert!(msg.contains("without taking any tool action"));
-    assert!(msg.contains("Make concrete progress with an available tool now, or switch phase"));
-    assert!(!msg.contains("lookup() or read()"));
-    assert!(msg.contains("Keep prose to at most 180 visible characters"));
-}
-
-#[test]
-fn native_sentinel_without_action_nudge_mentions_bare_done_sentinel() {
-    let policy = TurnPolicy {
-        require_action_or_yield: true,
-        allow_done_sentinel: true,
-        max_prose_chars: Some(180),
-    };
-    let msg = sentinel_without_action_nudge("native", Some(&policy));
-    assert!(msg.contains("`##DONE##` without taking any tool action"));
-    assert!(!msg.contains("<done>"));
-}
-
-#[test]
 fn action_turn_nudge_omits_done_sentinel_when_stage_disallows_it() {
     let policy = TurnPolicy {
         require_action_or_yield: true,
@@ -80,18 +54,6 @@ fn action_turn_nudge_omits_done_sentinel_when_stage_disallows_it() {
     assert!(msg.contains(
         "either make concrete progress with a well-formed <tool_call> block or switch phase"
     ));
-}
-
-#[test]
-fn sentinel_without_action_nudge_explains_workflow_owned_stage_rule() {
-    let policy = TurnPolicy {
-        require_action_or_yield: true,
-        allow_done_sentinel: false,
-        max_prose_chars: Some(90),
-    };
-    let msg = sentinel_without_action_nudge("text", Some(&policy));
-    assert!(msg.contains("workflow-owned action stage"));
-    assert!(msg.contains("Do not output a <done> block in this stage"));
 }
 
 #[test]

--- a/crates/harn-vm/src/llm/agent/tests/tool_dispatch_categories.rs
+++ b/crates/harn-vm/src/llm/agent/tests/tool_dispatch_categories.rs
@@ -110,8 +110,16 @@ fn done_mock() -> crate::llm::mock::LlmMock {
 }
 
 fn tool_call_mock(tool_name: &str, args: serde_json::Value) -> crate::llm::mock::LlmMock {
+    tool_call_with_text_mock(String::new(), tool_name, args)
+}
+
+fn tool_call_with_text_mock(
+    text: String,
+    tool_name: &str,
+    args: serde_json::Value,
+) -> crate::llm::mock::LlmMock {
     crate::llm::mock::LlmMock {
-        text: String::new(),
+        text,
         tool_calls: vec![json!({
             "id": format!("call_{tool_name}"),
             "type": "tool_call",
@@ -214,7 +222,7 @@ fn assert_tool_execution_with_category(
 
 #[tokio::test(flavor = "current_thread")]
 async fn schema_validation_failure_emits_categorized_event() {
-    let _guard = serialize_tests();
+    let guard = serialize_tests();
     drain_thread_local_state();
     reset_llm_mock_state();
     crate::llm::mock::push_llm_mock(tool_call_mock("read", json!({})));
@@ -232,11 +240,217 @@ async fn schema_validation_failure_emits_categorized_event() {
     assert_tool_execution_with_category(&result, "read", ToolCallErrorCategory::SchemaValidation);
 
     reset_llm_mock_state();
+    drop(guard);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn completion_judge_can_confirm_successful_tool_turn_from_transcript_context() {
+    let guard = serialize_tests();
+    drain_thread_local_state();
+    reset_llm_mock_state();
+    let temp_file = tempfile::NamedTempFile::new().expect("create temp file");
+    let path = temp_file.path().to_path_buf();
+    std::fs::write(&path, "COMPLETE-OK\n").expect("write temp file");
+
+    crate::llm::mock::push_llm_mock(tool_call_with_text_mock(
+        "The validation file contains COMPLETE-OK, so the request is satisfied.".to_string(),
+        "read_file",
+        json!({"path": path.to_string_lossy().to_string()}),
+    ));
+    crate::llm::mock::push_llm_mock(text_mock(
+        "{\"pass\": true, \"final_response\": \"Confirmed: the validation file contains COMPLETE-OK.\"}",
+    ));
+    crate::llm::mock::push_llm_mock(text_mock("unexpected extra turn"));
+
+    let mut opts = base_opts(vec![json!({
+        "role": "user",
+        "content": "Read the validation file and stop once COMPLETE-OK is observed.",
+    })]);
+    opts.native_tools = Some(vec![native_read_file_schema()]);
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 3;
+    config.max_verify_attempts = 2;
+    config.tool_format = "native".to_string();
+    config.verify_completion_judge =
+        Some(crate::llm::agent::completion_judge::CompletionJudgeConfig::default());
+    config.session_id = "test-judge-successful-tool-turn".to_string();
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    let calls = get_llm_mock_calls();
+    assert_eq!(
+        calls.len(),
+        2,
+        "successful tool turn should be verified instead of forcing another main-model turn"
+    );
+    let judge_prompt = calls[1]
+        .messages
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        judge_prompt.contains("Read the validation file"),
+        "judge prompt should include the original user request: {judge_prompt}"
+    );
+    assert!(
+        judge_prompt.contains("COMPLETE-OK"),
+        "judge prompt should include recent tool-result context: {judge_prompt}"
+    );
+    assert_eq!(result["status"], "done");
+    let visible_text = result["visible_text"]
+        .as_str()
+        .expect("verified tool turn should produce visible text");
+    assert_eq!(
+        visible_text,
+        "Confirmed: the validation file contains COMPLETE-OK."
+    );
+
+    std::fs::remove_file(path).ok();
+    reset_llm_mock_state();
+    drop(guard);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn completion_judge_treats_null_optional_fields_as_absent() {
+    let guard = serialize_tests();
+    drain_thread_local_state();
+    reset_llm_mock_state();
+    let temp_file = tempfile::NamedTempFile::new().expect("create temp file");
+    let path = temp_file.path().to_path_buf();
+    std::fs::write(&path, "NEEDS-ANSWER\n").expect("write temp file");
+
+    crate::llm::mock::push_llm_mock(tool_call_with_text_mock(
+        "I will inspect the file before answering.".to_string(),
+        "read_file",
+        json!({"path": path.to_string_lossy().to_string()}),
+    ));
+    crate::llm::mock::push_llm_mock(text_mock(
+        "{\"pass\": false, \"feedback\": null, \"final_response\": null}",
+    ));
+    crate::llm::mock::push_llm_mock(text_mock("The file contains NEEDS-ANSWER."));
+    crate::llm::mock::push_llm_mock(text_mock(
+        "{\"pass\": true, \"final_response\": \"Confirmed after judge feedback: NEEDS-ANSWER.\"}",
+    ));
+    crate::llm::mock::push_llm_mock(text_mock("unexpected extra turn"));
+
+    let mut opts = base_opts(vec![json!({
+        "role": "user",
+        "content": "Read the validation file and answer with its token.",
+    })]);
+    opts.native_tools = Some(vec![native_read_file_schema()]);
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 4;
+    config.max_verify_attempts = 3;
+    config.tool_format = "native".to_string();
+    config.verify_completion_judge =
+        Some(crate::llm::agent::completion_judge::CompletionJudgeConfig::default());
+    config.session_id = "test-judge-null-optional-fields".to_string();
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    let calls = get_llm_mock_calls();
+    assert_eq!(
+        calls.len(),
+        4,
+        "null optional judge fields should not trigger a schema retry"
+    );
+    let resumed_prompt = calls[2]
+        .messages
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        resumed_prompt.contains("The completion judge was not satisfied"),
+        "null feedback should fall back to the configured feedback instruction: {resumed_prompt}"
+    );
+    assert_eq!(result["status"], "done");
+    let visible_text = result["visible_text"]
+        .as_str()
+        .expect("verified retry should produce visible text");
+    assert_eq!(
+        visible_text,
+        "Confirmed after judge feedback: NEEDS-ANSWER."
+    );
+
+    std::fs::remove_file(path).ok();
+    reset_llm_mock_state();
+    drop(guard);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn completion_judge_schema_failure_vetoes_with_fallback() {
+    let guard = serialize_tests();
+    drain_thread_local_state();
+    reset_llm_mock_state();
+    let temp_file = tempfile::NamedTempFile::new().expect("create temp file");
+    let path = temp_file.path().to_path_buf();
+    std::fs::write(&path, "SCHEMA-RECOVERY\n").expect("write temp file");
+
+    crate::llm::mock::push_llm_mock(tool_call_with_text_mock(
+        "I will inspect the file before answering.".to_string(),
+        "read_file",
+        json!({"path": path.to_string_lossy().to_string()}),
+    ));
+    crate::llm::mock::push_llm_mock(text_mock("not json"));
+    crate::llm::mock::push_llm_mock(text_mock("The file contains SCHEMA-RECOVERY."));
+    crate::llm::mock::push_llm_mock(text_mock(
+        "{\"pass\": true, \"final_response\": \"Recovered after fallback feedback: SCHEMA-RECOVERY.\"}",
+    ));
+    crate::llm::mock::push_llm_mock(text_mock("unexpected extra turn"));
+
+    let mut opts = base_opts(vec![json!({
+        "role": "user",
+        "content": "Read the validation file and answer with its token.",
+    })]);
+    opts.native_tools = Some(vec![native_read_file_schema()]);
+    let mut judge_config = crate::llm::agent::completion_judge::CompletionJudgeConfig::default();
+    judge_config
+        .options
+        .insert("schema_retries".to_string(), VmValue::Int(0));
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 4;
+    config.max_verify_attempts = 3;
+    config.tool_format = "native".to_string();
+    config.verify_completion_judge = Some(judge_config);
+    config.session_id = "test-judge-schema-failure-fallback".to_string();
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    let calls = get_llm_mock_calls();
+    assert_eq!(
+        calls.len(),
+        4,
+        "invalid judge JSON should veto once, not confirm completion or retry schema internally"
+    );
+    let resumed_prompt = calls[2]
+        .messages
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        resumed_prompt.contains("The completion judge was not satisfied"),
+        "schema failure should inject fallback feedback into the next main-model turn: {resumed_prompt}"
+    );
+    assert_eq!(result["status"], "done");
+    let visible_text = result["visible_text"]
+        .as_str()
+        .expect("verified retry should produce visible text");
+    assert_eq!(
+        visible_text,
+        "Recovered after fallback feedback: SCHEMA-RECOVERY."
+    );
+
+    std::fs::remove_file(path).ok();
+    reset_llm_mock_state();
+    drop(guard);
 }
 
 #[tokio::test(flavor = "current_thread")]
 async fn native_persistent_answer_after_successful_tool_does_not_require_done_sentinel() {
-    let _guard = serialize_tests();
+    let guard = serialize_tests();
     drain_thread_local_state();
     reset_llm_mock_state();
     let temp_file = tempfile::NamedTempFile::new().expect("create temp file");
@@ -272,11 +486,12 @@ async fn native_persistent_answer_after_successful_tool_does_not_require_done_se
 
     let _ = std::fs::remove_file(path);
     reset_llm_mock_state();
+    drop(guard);
 }
 
 #[tokio::test(flavor = "current_thread")]
 async fn text_persistent_bare_answer_after_successful_tool_is_final_response() {
-    let _guard = serialize_tests();
+    let guard = serialize_tests();
     drain_thread_local_state();
     reset_llm_mock_state();
     let temp_file = tempfile::NamedTempFile::new().expect("create temp file");
@@ -315,6 +530,7 @@ async fn text_persistent_bare_answer_after_successful_tool_is_final_response() {
 
     let _ = std::fs::remove_file(path);
     reset_llm_mock_state();
+    drop(guard);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -323,7 +539,7 @@ async fn unknown_tool_emits_permission_denied_category() {
     // through to the "Tool '<name>' is not available" arm, which returns
     // `Err(VmError::CategorizedError { category: ToolRejected })`. The
     // wire enum collapses ToolRejected to PermissionDenied.
-    let _guard = serialize_tests();
+    let guard = serialize_tests();
     drain_thread_local_state();
     reset_llm_mock_state();
     crate::llm::mock::push_llm_mock(tool_call_mock("nonexistent_tool", json!({"arg": "value"})));
@@ -344,6 +560,7 @@ async fn unknown_tool_emits_permission_denied_category() {
     );
 
     reset_llm_mock_state();
+    drop(guard);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -353,7 +570,7 @@ async fn rejected_loop_skip_emits_rejected_loop_category() {
     // without a bridge) so the calls actually execute and the loop
     // tracker can record an identical-result repeat — repeats of
     // *rejected* tools never reach `loop_tracker.record()`.
-    let _guard = serialize_tests();
+    let guard = serialize_tests();
     drain_thread_local_state();
     reset_llm_mock_state();
     let args = json!({"path": "/nonexistent/test/path/that/never/exists"});
@@ -377,6 +594,7 @@ async fn rejected_loop_skip_emits_rejected_loop_category() {
     assert_tool_execution_with_category(&result, "read_file", ToolCallErrorCategory::RejectedLoop);
 
     reset_llm_mock_state();
+    drop(guard);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -385,7 +603,7 @@ async fn tool_returning_error_string_emits_tool_error_category() {
     // read file ...")` for an unreadable path. dispatch sees `Ok(...)`
     // — not rejected, not a denied dict — but the result_text starts
     // with "Error:". Final emission is Failed + ToolError.
-    let _guard = serialize_tests();
+    let guard = serialize_tests();
     drain_thread_local_state();
     reset_llm_mock_state();
     crate::llm::mock::push_llm_mock(tool_call_mock(
@@ -405,6 +623,7 @@ async fn tool_returning_error_string_emits_tool_error_category() {
     assert_tool_execution_with_category(&result, "read_file", ToolCallErrorCategory::ToolError);
 
     reset_llm_mock_state();
+    drop(guard);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -413,7 +632,7 @@ async fn parse_error_emits_schema_validation_category() {
     // VM normalizes that into args carrying a `__parse_error` sentinel,
     // which the dispatch loop short-circuits as a SchemaValidation
     // failure before any policy/permission/validation runs.
-    let _guard = serialize_tests();
+    let guard = serialize_tests();
     drain_thread_local_state();
     reset_llm_mock_state();
     crate::llm::mock::push_llm_mock(tool_call_mock(
@@ -434,4 +653,5 @@ async fn parse_error_emits_schema_validation_category() {
     assert_tool_execution_with_category(&result, "read", ToolCallErrorCategory::SchemaValidation);
 
     reset_llm_mock_state();
+    drop(guard);
 }

--- a/crates/harn-vm/src/llm/agent/tests/transcript.rs
+++ b/crates/harn-vm/src/llm/agent/tests/transcript.rs
@@ -516,7 +516,7 @@ async fn persisted_session_keeps_compacted_prompt_surface_on_resume() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn user_response_block_can_complete_persistent_loop_without_done_sentinel() {
+async fn user_response_block_with_tool_call_is_not_final_completion() {
     reset_llm_mock_state();
     let response_text = "<tool_call>\nledger({ action: \"note\", text: \"verified completion\" })\n</tool_call>\n<user_response>Completed cleanly.</user_response>";
     let parsed = crate::llm::tools::parse_text_tool_calls_with_tools(response_text, None);
@@ -582,10 +582,11 @@ async fn user_response_block_can_complete_persistent_loop_without_done_sentinel(
     ]))));
     let mut config = base_agent_config();
     config.persistent = true;
-    config.max_iterations = 2;
+    config.max_iterations = 1;
 
     let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
-    assert_eq!(result["status"], "done");
+    assert_eq!(result["status"], "budget_exhausted");
+    assert_eq!(result["llm"]["iterations"].as_u64(), Some(1));
     assert_eq!(result["visible_text"].as_str(), Some("Completed cleanly."));
     reset_llm_mock_state();
 }
@@ -674,6 +675,118 @@ async fn tagged_done_block_does_not_complete_persistent_loop_without_tools() {
     assert_eq!(result["status"], "budget_exhausted");
     assert_eq!(result["llm"]["iterations"].as_u64(), Some(1));
     assert_eq!(result["visible_text"].as_str(), Some("Still working."));
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn persistent_done_without_prior_tool_action_is_a_proposed_exit() {
+    reset_llm_mock_state();
+    crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
+        text: "<user_response>2 + 2 is 4.</user_response>\n<done>##DONE##</done>".to_string(),
+        tool_calls: Vec::new(),
+        match_pattern: None,
+        consume_on_match: true,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+        thinking: None,
+        thinking_summary: None,
+        stop_reason: None,
+        model: "mock".to_string(),
+        provider: None,
+        blocks: None,
+        error: None,
+    });
+
+    let mut opts = base_opts(vec![serde_json::json!({
+        "role": "user",
+        "content": "What is 2 + 2?",
+    })]);
+    let dummy_tool = VmValue::Dict(Rc::new(std::collections::BTreeMap::from([
+        ("name".to_string(), VmValue::String(Rc::from("look"))),
+        (
+            "description".to_string(),
+            VmValue::String(Rc::from("Inspect a file.")),
+        ),
+        (
+            "parameters".to_string(),
+            VmValue::Dict(Rc::new(std::collections::BTreeMap::new())),
+        ),
+        (
+            "executor".to_string(),
+            VmValue::String(Rc::from("host_bridge")),
+        ),
+        (
+            "host_capability".to_string(),
+            VmValue::String(Rc::from("workspace.read_text")),
+        ),
+    ])));
+    opts.tools = Some(VmValue::Dict(Rc::new(std::collections::BTreeMap::from([
+        (
+            "tools".to_string(),
+            VmValue::List(Rc::new(vec![dummy_tool])),
+        ),
+    ]))));
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 1;
+    config.turn_policy = Some(TurnPolicy {
+        require_action_or_yield: false,
+        allow_done_sentinel: true,
+        max_prose_chars: None,
+    });
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_eq!(result["status"], "done");
+    assert_eq!(result["visible_text"].as_str(), Some("2 + 2 is 4."));
+    assert_eq!(result["llm"]["iterations"].as_u64(), Some(1));
+    reset_llm_mock_state();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn built_in_completion_judge_can_veto_then_confirm() {
+    reset_llm_mock_state();
+    for text in [
+        "<user_response>Done.</user_response>\n<done>##DONE##</done>",
+        "{\"pass\": false, \"feedback\": \"Give the user the actual answer before yielding.\"}",
+        "<user_response>The answer is 4.</user_response>\n<done>##DONE##</done>",
+        "{\"pass\": true}",
+    ] {
+        crate::llm::mock::push_llm_mock(crate::llm::mock::LlmMock {
+            text: text.to_string(),
+            tool_calls: Vec::new(),
+            match_pattern: None,
+            consume_on_match: true,
+            input_tokens: None,
+            output_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+            thinking: None,
+            thinking_summary: None,
+            stop_reason: None,
+            model: "mock".to_string(),
+            provider: None,
+            blocks: None,
+            error: None,
+        });
+    }
+
+    let mut opts = base_opts(vec![serde_json::json!({
+        "role": "user",
+        "content": "What is 2 + 2?",
+    })]);
+    let mut config = base_agent_config();
+    config.persistent = true;
+    config.max_iterations = 2;
+    config.max_verify_attempts = 2;
+    config.verify_completion_judge =
+        Some(crate::llm::agent::completion_judge::CompletionJudgeConfig::default());
+
+    let result = run_agent_loop_internal(&mut opts, config).await.unwrap();
+    assert_eq!(result["status"], "done");
+    assert_eq!(result["llm"]["iterations"].as_u64(), Some(2));
+    assert_eq!(result["visible_text"].as_str(), Some("The answer is 4."));
     reset_llm_mock_state();
 }
 

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -19,6 +19,7 @@ use super::helpers::{
 use super::tools::build_assistant_response_message;
 
 pub(crate) const DEFAULT_AGENT_LOOP_LLM_RETRIES: usize = 2;
+pub(crate) const DEFAULT_MAX_VERIFY_ATTEMPTS: usize = 20;
 
 #[derive(Clone, Copy)]
 pub(crate) struct AgentLoopProfileDefaults {
@@ -173,6 +174,13 @@ pub struct AgentLoopConfig {
     /// Does NOT fire on budget-exhaustion paths — those represent hard
     /// resource limits, not "is the work actually done" decisions.
     pub verify_completion: Option<crate::value::VmValue>,
+    /// Built-in completion judge. When enabled, Harn runs a structured
+    /// side-call at natural exit points and interprets `{pass, feedback}`:
+    /// pass confirms, failure vetoes and injects feedback. This is the
+    /// Harn-owned version of the common "is the agent really done?"
+    /// integration hook, so hosts do not need to hand-roll side
+    /// transcript mechanics.
+    pub verify_completion_judge: Option<super::agent::completion_judge::CompletionJudgeConfig>,
     /// Cap on how many times `verify_completion` may veto a stop in a
     /// single loop. Once exceeded, the next break is forced and the
     /// loop exits with `final_status = "verify_exhausted"`. Defaults to
@@ -636,10 +644,12 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
                     task_ledger: parse_task_ledger_from_options(&options),
                     post_turn_callback: parse_closure_option(&options, "post_turn_callback")?,
                     verify_completion: parse_closure_option(&options, "verify_completion")?,
+                    verify_completion_judge:
+                        super::agent::completion_judge::parse_completion_judge_option(&options)?,
                     max_verify_attempts: opt_int(&options, "max_verify_attempts")
                         .filter(|n| *n >= 0)
                         .map(|n| n as usize)
-                        .unwrap_or(3),
+                        .unwrap_or(DEFAULT_MAX_VERIFY_ATTEMPTS),
                     llm_transcript_dir: opt_str(&options, "llm_transcript_dir"),
                     skill_registry,
                     skill_match,

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -478,6 +478,7 @@ fn join_limited_keys(keys: &[String]) -> String {
     )
 }
 
+pub(crate) use self::agent::completion_judge::parse_completion_judge_option;
 pub(crate) use self::agent::parse_skill_match_config_public as parse_skill_match_config_dict;
 pub(crate) use self::agent::SkillMatchConfig;
 pub use self::agent::{
@@ -490,7 +491,7 @@ pub(crate) use self::agent::{
 };
 pub(crate) use self::agent_config::{
     agent_loop_profile_defaults, agent_loop_result_from_llm, parse_command_policy_from_options,
-    AgentLoopConfig,
+    AgentLoopConfig, DEFAULT_MAX_VERIFY_ATTEMPTS,
 };
 pub use self::agent_config::{
     register_agent_loop_with_bridge, register_llm_call_structured_with_bridge,
@@ -1277,10 +1278,12 @@ pub fn register_llm_builtins(vm: &mut Vm) {
                     &options,
                     "verify_completion",
                 )?,
+                verify_completion_judge:
+                    agent::completion_judge::parse_completion_judge_option(&options)?,
                 max_verify_attempts: opt_int(&options, "max_verify_attempts")
                     .filter(|n| *n >= 0)
                     .map(|n| n as usize)
-                    .unwrap_or(3),
+                    .unwrap_or(agent_config::DEFAULT_MAX_VERIFY_ATTEMPTS),
                 llm_transcript_dir: opt_str(&options, "llm_transcript_dir"),
                 skill_registry,
                 skill_match,

--- a/crates/harn-vm/src/llm/tools/messages.rs
+++ b/crates/harn-vm/src/llm/tools/messages.rs
@@ -26,8 +26,10 @@ pub(crate) fn build_assistant_tool_message(
         }
         serde_json::json!({"role": "assistant", "content": content})
     } else if is_ollama {
-        // Ollama `/api/chat` expects native tool-call history with
-        // object arguments instead of OpenAI-style JSON strings.
+        // Modern Ollama chat validates replayed tool-call history using
+        // the OpenAI-compatible string-encoded `function.arguments`
+        // shape. Keeping the history shape consistent also prevents
+        // local Qwen runs from failing on the second iteration.
         let calls: Vec<serde_json::Value> = tool_calls
             .iter()
             .enumerate()
@@ -37,7 +39,7 @@ pub(crate) fn build_assistant_tool_message(
                     "function": {
                         "index": idx,
                         "name": tc["name"],
-                        "arguments": tc["arguments"],
+                        "arguments": serde_json::to_string(&tc["arguments"]).unwrap_or_default(),
                     }
                 })
             })

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -643,7 +643,7 @@ fn assistant_tool_message_includes_empty_content_for_openai_style() {
 }
 
 #[test]
-fn assistant_tool_message_uses_ollama_native_shape() {
+fn assistant_tool_message_uses_ollama_openai_compatible_arguments() {
     let message = build_assistant_tool_message(
         "",
         &[json!({
@@ -659,8 +659,8 @@ fn assistant_tool_message_uses_ollama_native_shape() {
     assert_eq!(message["tool_calls"][0]["type"], "function");
     assert_eq!(message["tool_calls"][0]["function"]["name"], "read");
     assert_eq!(
-        message["tool_calls"][0]["function"]["arguments"]["path"],
-        "main.rs"
+        message["tool_calls"][0]["function"]["arguments"],
+        "{\"path\":\"main.rs\"}"
     );
 }
 

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1524,7 +1524,24 @@ pub async fn execute_stage_node(
                         .and_then(|d| d.get("verify_completion"))
                         .filter(|v| matches!(v, crate::value::VmValue::Closure(_)))
                         .cloned(),
-                    max_verify_attempts: 3,
+                    verify_completion_judge: crate::llm::parse_completion_judge_option(
+                        &node
+                            .raw_model_policy
+                            .as_ref()
+                            .and_then(|value| value.as_dict())
+                            .cloned(),
+                    )?,
+                    max_verify_attempts: crate::llm::helpers::opt_int(
+                        &node
+                            .raw_model_policy
+                            .as_ref()
+                            .and_then(|value| value.as_dict())
+                            .cloned(),
+                        "max_verify_attempts",
+                    )
+                    .filter(|n| *n >= 0)
+                    .map(|n| n as usize)
+                    .unwrap_or(crate::llm::DEFAULT_MAX_VERIFY_ATTEMPTS),
                     llm_transcript_dir: node
                         .raw_model_policy
                         .as_ref()

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -721,10 +721,11 @@ fn sub_agent_loop_options(spec: &SubAgentRunSpec) -> Result<crate::llm::AgentLoo
             .and_then(|o| o.get("verify_completion"))
             .filter(|v| matches!(v, VmValue::Closure(_)))
             .cloned(),
+        verify_completion_judge: crate::llm::parse_completion_judge_option(&options)?,
         max_verify_attempts: crate::llm::helpers::opt_int(&options, "max_verify_attempts")
             .filter(|n| *n >= 0)
             .map(|n| n as usize)
-            .unwrap_or(3),
+            .unwrap_or(crate::llm::DEFAULT_MAX_VERIFY_ATTEMPTS),
         llm_transcript_dir: crate::llm::helpers::opt_str(&options, "llm_transcript_dir"),
         skill_registry,
         skill_match,


### PR DESCRIPTION
## Summary

- Adds Harn-owned `verify_completion_judge` as a structured completion-verification policy so hosts no longer hand-roll side transcript machinery.
- Renders bounded transcript context, tool calls, and tool results into the judge prompt; supports optional `feedback` and `final_response`, including JSON `null` as absent.
- Makes judge failures conservative: malformed/schema-invalid judge output injects fallback feedback instead of falsely confirming completion, bounded by `max_verify_attempts` now defaulting to 20.
- Lets successful native tool turns with visible assistant prose become judge-verified exit candidates, and preserves terminal tool results/final response synthesis for user-visible output.
- Fixes Ollama native tool-call history replay to use string-encoded `function.arguments` for local Qwen continuation compatibility.

## Validation

- `cargo fmt --all`
- `cargo test -p harn-vm completion_judge -- --nocapture`
- `cargo clippy -p harn-vm --tests -- -D warnings`
- `cargo build --release -p harn-cli -p harn-dap -p harn-lsp`
- Pre-commit hook: Rust fmt, workspace clippy, highlight sync, markdown lint
- Pre-push hook: 3306 nextest tests passed, markdown lint, CHANGELOG retroactive-edit check
- Downstream local-model validation through burin-code TUI using copied release binary:
  - Long ask/read-only task: 3 provider calls, 8 tools, all `ollama:qwen3.6:35b-a3b-coding-nvfp4`, correct final answer.
  - Edit/test task: 9 provider calls, 7 tools, all `ollama:qwen3.6:35b-a3b-coding-nvfp4`, independent `python3 -m unittest test_calc.py` passed.
