### PR TITLE
Release v0.7.56

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -19,6 +19,7 @@
     "**/node_modules",
     "target",
     "docs/dist",
+    ".worktrees",
     ".burin",
     ".claude",
     "docs/src/SUMMARY.md",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Pre-0.6 highlights live in [CHANGELOG-pre-0.6.md](CHANGELOG-pre-0.6.md).
 Harn had no external users before 0.6.0, so that archive intentionally keeps
 condensed series summaries instead of full per-patch history.
 
-## Unreleased
+## v0.7.56
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "harn-cli"
-version = "0.7.55"
+version = "0.7.56"
 dependencies = [
  "async-trait",
  "axum",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "harn-dap"
-version = "0.7.55"
+version = "0.7.56"
 dependencies = [
  "harn-modules",
  "harn-parser",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "harn-fmt"
-version = "0.7.55"
+version = "0.7.56"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "harn-hostlib"
-version = "0.7.55"
+version = "0.7.56"
 dependencies = [
  "anyhow",
  "base64",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "harn-ir"
-version = "0.7.55"
+version = "0.7.56"
 dependencies = [
  "harn-lexer",
  "harn-parser",
@@ -1817,11 +1817,11 @@ dependencies = [
 
 [[package]]
 name = "harn-lexer"
-version = "0.7.55"
+version = "0.7.56"
 
 [[package]]
 name = "harn-lint"
-version = "0.7.55"
+version = "0.7.56"
 dependencies = [
  "harn-lexer",
  "harn-modules",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "harn-lsp"
-version = "0.7.55"
+version = "0.7.56"
 dependencies = [
  "harn-fmt",
  "harn-ir",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "harn-modules"
-version = "0.7.55"
+version = "0.7.56"
 dependencies = [
  "croner",
  "harn-lexer",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "harn-parser"
-version = "0.7.55"
+version = "0.7.56"
 dependencies = [
  "harn-lexer",
  "yansi",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "harn-serve"
-version = "0.7.55"
+version = "0.7.56"
 dependencies = [
  "async-trait",
  "axum",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "harn-vm"
-version = "0.7.55"
+version = "0.7.56"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["crates/harn-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.55"
+version = "0.7.56"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn"


### PR DESCRIPTION
## Summary\n- Release Harn v0.7.56, including the merged transcript-aware completion judge and agent-loop polish.\n- Add markdownlint ignore coverage for repo-local .worktrees used by release/cross-repo workflows.\n\n## Validation\n- ./scripts/release_ship.sh --prepare --bump patch (audit lanes covered across retries; first run docs-only failed due local .worktrees lint scope, second run harn-audit hit known orchestrator timeout after first harn-audit had passed)\n- ./scripts/release_ship.sh --prepare --bump patch --skip-audit\n- pre-commit: cargo fmt, clippy, markdownlint\n- pre-push retry: 3306 tests passed, markdownlint, changelog guard\n